### PR TITLE
declare module Backbone instead declare module "Backbone"

### DIFF
--- a/Definitions/backbone-0.9.d.ts
+++ b/Definitions/backbone-0.9.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for Backbone 0.9
 // https://github.com/borisyankov/DefinitelyTyped
 
-declare module "Backbone" {
+declare module Backbone {
 
     export class Events {
         on(events: string, callback: (event) => any, context?: any): any;


### PR DESCRIPTION
can't transpile to javascript if `declare module "Backbone"` and then it's ok with `declare module Backbone`
