### PR TITLE
the Knockout definitions are missing a few useful functions

### DIFF
--- a/Definitions/knockout-2.2.d.ts
+++ b/Definitions/knockout-2.2.d.ts
@@ -8,6 +8,9 @@ interface KnockoutSubscribableFunctions {
     subscribe(callback: (newValue: any[]) => void, target?:any, topic?: string): KnockoutSubscription;
     notifySubscribers(valueToWrite, topic?: string);
     dispose(): void;
+    valueHasMutated(): void;
+
+    valueWillMutate(): void;
 }
 
 interface KnockoutComputedFunctions extends KnockoutSubscribableFunctions {


### PR DESCRIPTION
Adding missing functions to Knockout.
valueHasMutated and valueWillMutate to KnockoutSubscribableFunctions
