### PR TITLE
Correction of the promise object

### DIFF
--- a/Definitions/jquery-1.8.d.ts
+++ b/Definitions/jquery-1.8.d.ts
@@ -84,6 +84,8 @@ interface JQueryPromise {
     always(...alwaysCallbacks: any[]): JQueryDeferred;
     done(...doneCallbacks: any[]): JQueryDeferred;
     fail(...failCallbacks: any[]): JQueryDeferred;
+    progress(...progressCallbacks: any[]): JQueryDeferred;
+    state(): string;
     pipe(doneFilter?: (x: any) => any, failFilter?: (x: any) => any, progressFilter?: (x: any) => any): JQueryPromise;
     then(doneCallbacks: any, failCallbacks: any, progressCallbacks?: any): JQueryDeferred;
 }


### PR DESCRIPTION
http://api.jquery.com/deferred.promise/

The Promise exposes only the Deferred methods needed to attach additional handlers or determine the state (then, done, fail, always, pipe, progress, and state), but not ones that change the state (resolve, reject, notify, resolveWith, rejectWith, and notifyWith).
