### PR TITLE
Fixed a small typo in node defs

### DIFF
--- a/node/node-0.8.d.ts
+++ b/node/node-0.8.d.ts
@@ -633,7 +633,7 @@ declare module "net" {
         destroy(): void;
         pause(): void;
         resume(): void;
-        setTimeout(timeout: number, callback?: Function); void;
+        setTimeout(timeout: number, callback?: Function): void;
         setNoDelay(noDelay?: bool): void;
         setKeepAlive(enable?: bool, initialDelay?: number): void;
         address(): { port: number; family: string; address: string; };


### PR DESCRIPTION
Replaced ";" by ":". Discovered when writing a parser for TypeScript def files. 
