### PR TITLE
Changed data type on "expires" option on jquery.cookie plugin.

### DIFF
--- a/jquery.cookie/jquery.cookie.d.ts
+++ b/jquery.cookie/jquery.cookie.d.ts
@@ -5,8 +5,9 @@
 
 ///<reference path="../jquery/jquery-1.8.d.ts" />
 
+
 interface JQueryCookieOptions {
-    expires?: number;
+    expires?: any;
     path?: string;
     domain?: string;
     secure?: bool;


### PR DESCRIPTION
Hi,

After updating the definitions and switching the jquery.cookie plugin definition from my own one my code didn't compile anymore.
The expires option for jquery.cookie can be either a 'number' or a 'Date' object and it was only defined as type 'number' in the definition file ( https://github.com/carhartl/jquery-cookie#expires ).
Since there is no option to define 2 data types for a property it should be defined as 'any'.
