### PR TITLE
Added "cleanNode" to Knockout

### DIFF
--- a/knockout/knockout-2.2.d.ts
+++ b/knockout/knockout-2.2.d.ts
@@ -290,6 +290,7 @@ interface KnockoutStatic {
     isObservable(instance: any): bool;
     dataFor(node: any): any;
     removeNode(node: Element);
+    cleanNode(node: Element);
 }
 
 declare var ko: KnockoutStatic;


### PR DESCRIPTION
I was using a binding for a dialog box and because I'm reusing and rebinding it I was worried about creating a memory leak.
After some googling I found this link : https://groups.google.com/forum/#!topic/knockoutjs/T9g-VrWxxdA/discussion and it made me realise the "cleanNode" method was missing from the Knockout definition file, so I added it :)
