### PR TITLE
Backbone Router now extends Events class in definition file.

### DIFF
--- a/backbone/backbone-0.9.d.ts
+++ b/backbone/backbone-0.9.d.ts
@@ -180,7 +180,7 @@ declare module Backbone {
         zip(...model: Model[]): Model[];
     }
 
-    export class Router {
+    export class Router extends Events {
 
         static extend(properties: any, classProperties?: any): any; // do not use, prefer TypeScript's extend functionality
 


### PR DESCRIPTION
The Backbone.Router class did not previously extend Events in the
definition file. This caused the TypeScript compiler to raise an
error when calling one of the Events methods (such as on()) on an
instance of a router.

This change allows instances of classes derived from Backbone.Router
to call methods on the Events class that are inherited by the router.
