### PR TITLE
Added 'applyBindindsToNode' in Knockout

### DIFF
--- a/knockout/knockout-2.2.d.ts
+++ b/knockout/knockout-2.2.d.ts
@@ -277,6 +277,7 @@ interface KnockoutStatic {
 
     applyBindings(viewModel: any, rootNode?: any): void;
     applyBindingsToDescendants(viewModel: any, rootNode: any): void;
+    applyBindingsToNode(node: Element, options: any, viewModel: any): void;
 
     subscribable: KnockoutSubscribableStatic;
     observable: KnockoutObservableStatic;


### PR DESCRIPTION
I was looking for a way to define the bindings when applying and found out there is a method 'ko.applyBindingsToNode' , I could not find it discussed on the knockout website but found a lot of google results for it.
I looked it up in the source and it seems to be a public method, so I added it to the definition file :

![ko.applyBindingsToNode.jpg](https://f.cloud.github.com/assets/2676195/3267/0dbb6e90-42b7-11e2-9109-8c1bce00d2e3.jpg)
