### PR TITLE
Updated map return type on static map method

### DIFF
--- a/jquery/jquery-1.8.d.ts
+++ b/jquery/jquery-1.8.d.ts
@@ -292,7 +292,7 @@ interface JQueryStatic {
 
     makeArray(obj: any): any[];
 
-    map(array: any[], callback: (elementOfArray: any, indexInArray: any) =>any): JQuery;
+    map(array: any[], callback: (elementOfArray: any, indexInArray: any) =>any): any[];
 
     merge(first: any[], second: any[]): any[];
 


### PR DESCRIPTION
Here is map definition for jQuery, it returns array: http://api.jquery.com/jQuery.map/
