### PR TITLE
Added missing properties to Knockout

### DIFF
--- a/knockout/knockout-2.2.d.ts
+++ b/knockout/knockout-2.2.d.ts
@@ -264,6 +264,10 @@ interface KnockoutUtils {
     stringifyJson(data: any, replacer: Function, space: string): string;
     postJson(urlOrForm: any, data: any, options: any): void;
 
+    ieVersion: number;
+    isIe6: bool;
+    isIe7: bool;
+
     domNodeDisposal;
 }
 


### PR DESCRIPTION
Added 'ieVersion' , 'isIe6' and 'isIe7' properties to Knockout utils class.
