### PR TITLE
Added missing method 'replace' to KnockoutObservableArrayFunctions

### DIFF
--- a/knockout/knockout-2.2.d.ts
+++ b/knockout/knockout-2.2.d.ts
@@ -36,6 +36,8 @@ interface KnockoutObservableArrayFunctions extends KnockoutObservableFunctions {
     sort(compareFunction): void;
 
     // Ko specific
+    replace(oldItem: any, newItem: any): void;
+
     remove(item): any[];
     removeAll(items: any[]): any[];
     removeAll(): any[];


### PR DESCRIPTION
Noted in issue : https://github.com/borisyankov/DefinitelyTyped/issues/130
