### PR TITLE
Need to 'declare' the Spinner class

### DIFF
--- a/spin/spin-1.2.d.ts
+++ b/spin/spin-1.2.d.ts
@@ -23,7 +23,7 @@ interface SpinnerOptions {
 }
 
 
-class Spinner {
+declare class Spinner {
     constructor (options?: SpinnerOptions);
     spin(target?: any);
     stop();


### PR DESCRIPTION
In TypeScript 0.8.1.1, a 'declare' is needed in front of the 'class Spinner', since without it the compiler attempts to compile it as an actual class definition, and fails with:

Message: Overload declaration lacks definition
Line number: 27
Column number: 5
Source error: 
Line 26: class Spinner {
Line 27:     constructor (options?: SpinnerOptions);
-------------^
Line 28:     spin(target?: any);

The test in the typescript codebase that confirms this is intentional behavior is in tests/compiler/class.ts

http://typescript.codeplex.com/SourceControl/changeset/view/2bee84410e02#tests/compiler/class.ts

---

describe('Testing function signatures inside classes', function () {
   it('Regression test - was previously giving runtime error', function () {
       var code = "class A { a(completed: () => any): void; }";
       Harness.Compiler.compileString(code, 'fnsig-inside-classes', function (result) {
           assert.compilerWarning(result, 1, 10, 'Overload declaration lacks definition');
           assert.equal(result.errors.length, 1);
       });
   });
});

---

The compiler code that implements the check is in src/compiler/signatures.ts

http://typescript.codeplex.com/SourceControl/changeset/view/2bee84410e02#src/compiler/signatures.ts

---

if (!hasConstruct && !this.definitionSignature && this.signatures[i].declAST && this.signatures[i].declAST.isOverload && !hasFlag(this.signatures[i].declAST.fncFlags, FncFlags.Ambient)) {
    checker.errorReporter.simpleError(this.signatures[i].declAST, "Overload declaration lacks definition");
}

---

By adding the 'declare', we tell the TypeScript compiler that this is just intending to expose the API of the class, not the actual implementation.
