### PR TITLE
Update jQuery UI DialogOptions.width property type from number to any.

### DIFF
--- a/jqueryui/jqueryui-1.9.d.ts
+++ b/jqueryui/jqueryui-1.9.d.ts
@@ -182,7 +182,7 @@ interface DialogOptions {
     show?: any; // number, string or object
     stack?: bool;
     title?: string;
-    width?: number;
+    width?: any; // number or string
     zIndex?: number;
 }
 


### PR DESCRIPTION
Example usage: $('#el').dialog({width: 'auto'});
