### PR TITLE
Set options in ajaxSetup(options: any) optional, to allow use it as a get function

### DIFF
--- a/jquery/jquery-1.8.d.ts
+++ b/jquery/jquery-1.8.d.ts
@@ -179,7 +179,7 @@ interface JQueryStatic {
 
     ajaxSettings: JQueryAjaxSettings;
 
-    ajaxSetup(options: any);
+    ajaxSetup(options?: any);
 
     get(url: string, data?: any, success?: any, dataType?: any): JQueryXHR;
     getJSON(url: string, data?: any, success?: any): JQueryXHR;


### PR DESCRIPTION
Sometimes its useful or necessary to remember old ajaxSetup object, for instance to restore its values later. But the missing ? in options disallow using ajaxSetup without parameter.

I changed it, because i had the same problem as this guy [here](http://stackoverflow.com/questions/11860354/how-to-get-a-current-value-from-jquerys-ajaxsetup).
