### PR TITLE
Add Event method to jQueryStatic

### DIFF
--- a/jquery/jquery-1.8.d.ts
+++ b/jquery/jquery-1.8.d.ts
@@ -248,6 +248,7 @@ interface JQueryStatic {
     *******/
     proxy(context: any, name: any): any;
     Deferred(): JQueryDeferred;
+    Event(name:string, eventProperties?:any): JQueryEventObject;
 
     /*********
      INTERNALS


### PR DESCRIPTION
As it is describe [here](http://api.jquery.com/category/events/event-object/) you are able to create your own jQuery Event object. But the current jQuery type definition does not allow that :)

Example:

```
var e = jQuery.Event("onClick");
```
