### PR TITLE
Added missing definitions required to use the ASYNC features + bugfixes

### DIFF
--- a/state-machine/state-machine-2.2.d.ts
+++ b/state-machine/state-machine-2.2.d.ts
@@ -2,17 +2,11 @@
 // Project: https://github.com/jakesgordon/javascript-state-machine
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
+// Updated: 2013/01/22 by Maarten Docter <https://github.com/mdocter>
 
 
 interface ErrorCallback {
-    (name: string, from: string, to: string, args: any[]): void;
-}
-
-interface EventCallback {
-    event: string;
-    from: string;
-    to: string;
-    msg?: string;
+    (eventName?: string, from?: string, to?: string, args?: any[], errorCode?: number, errorMessage?: string, ex?: Error): void; // NB. errorCode? See: StateMachine.Error
 }
 
 interface StateMachineEvent {
@@ -24,26 +18,50 @@ interface StateMachineEvent {
 interface StateMachineConfig {
     initial?: any; // string or { state: 'foo', event: 'setup', defer: true|false }
     events?: StateMachineEvent[];
-    callbacks?: any;
+    callbacks?: {
+        [s: string]: (event?: string, from?: string, to?: string, ...args: any[]) => any;
+    };
     target?: any;
     error?: ErrorCallback;
 }
 
 interface StateMachineStatic {
+
+    VERSION: string; 		        // = "2.2.0"
+    WILDCARD: string;		        // = '*'
+    ASYNC: string;			        // = 'async'   
+
+    Result: {
+        SUCCEEDED: number;	        // = 1, the event transitioned successfully from one state to another
+        NOTRANSITION: number;	    // = 2, the event was successfull but no state transition was necessary
+        CANCELLED: number;	        // = 3, the event was cancelled by the caller in a beforeEvent callback
+        ASYNC: number;		        // = 4, the event is asynchronous and the caller is in control of when the transition occurs
+    };
+
+    Error: {
+        INVALID_TRANSITION: number;	// = 100, caller tried to fire an event that was innapropriate in the current state
+        PENDING_TRANSITION: number;	// = 200, caller tried to fire an event while an async transition was still pending
+        INVALID_CALLBACK: number;	// = 300, caller provided callback function threw an exception
+    };
+
     create(config: StateMachineConfig, target?: any): StateMachine;
 }
 
 interface StateMachine {
     current: string;
-    is(sstate: string): bool;
+    is(state: string): bool;
     can(event: StateMachineEvent): bool;
     cannot(event: StateMachineEvent): bool;
     error: ErrorCallback;
 
-    onbeforeevent: EventCallback;
-    onleaveevent: EventCallback;
-    onenterevent: EventCallback;
-    onafterevent: EventCallback;
+    /*  transition - only available when performing async state transitions; otherwise null. Can be a: 
+        [1] function without arguments (see: https://github.com/jakesgordon/javascript-state-machine#asynchronous-state-transitions) 
+        [2] property with a cancel function to cancel the ASYNC event. Example usages:
+    
+        [1] fsm.transition(); // called form async callback
+        [2] fsm.transition.cancel(); 
+    */
+    transition?: any;
 }
 
 declare var StateMachine: StateMachineStatic;


### PR DESCRIPTION
Added all stuff required to use the ASYNC features of StateMachine and
refined some other modelled functions / properties.

Also removed:
-    onbeforeevent: EventCallback;
-    onleaveevent: EventCallback;
-    onenterevent: EventCallback;
-    onafterevent: EventCallback;

and the EventCallback interface.

StateMachine dynamically adds event functions depending on the config
being used. These can't be modelled in this file. The four event
callbacks from above could wrongly suggest that these event callbacks
are present on the returned StateMachine instance.

Also noticed a bug in the StateMachine code. The StateMachine is wrongly
using the StateMachine.Result constants. The author forgot to add the
Result property to the code, so he's now returning
StateMachine.SUCCEEDED instead of StateMachine.Result.SUCCEEDED. I will
create a pull-request to fix this issue.
