### PR TITLE
Update jquery/jquery.d.ts

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -88,7 +88,7 @@ interface JQueryPromise {
     progress(...progressCallbacks: any[]): JQueryPromise;
     state(): string;
     pipe(doneFilter?: (x: any) => any, failFilter?: (x: any) => any, progressFilter?: (x: any) => any): JQueryPromise;
-    then(doneCallbacks: any, failCallbacks: any, progressCallbacks?: any): JQueryPromise;
+    then(doneCallbacks: any, failCallbacks?: any, progressCallbacks?: any): JQueryPromise;
 }
 
 /*


### PR DESCRIPTION
In jQuery's then call, the failure callback is optional. Only the success callback is mandatory.
