### PR TITLE
state-machine updates

### DIFF
--- a/state-machine/state-machine-tests.ts
+++ b/state-machine/state-machine-tests.ts
@@ -1,6 +1,13 @@
 /// <reference path="state-machine.d.ts" />
 
-var fsm = StateMachine.create({
+interface StateMachineTest extends StateMachine {
+	warn?: StateMachineEvent;
+	panic?: StateMachineEvent;
+	calm?: StateMachineEvent;
+	clear?: StateMachineEvent;
+}
+
+var fsm: StateMachineTest = StateMachine.create({
     initial: 'green',
     events: [
       { name: 'warn', from: 'green', to: 'yellow' },
@@ -16,3 +23,8 @@ var fsm = StateMachine.create({
         onred: function (event, from, to) { document.body.className = 'red'; },
     }
 });
+
+//fsm.warn();					// transition from green to yellow
+//fsm.panic("ERROR ALERT");	// transition from yellow to red
+//fsm.calm();					// transition from red to yellow
+//fsm.clear("All clear");		// transition from yellow to green

--- a/state-machine/state-machine.d.ts
+++ b/state-machine/state-machine.d.ts
@@ -3,26 +3,30 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 // Updated: 2013/01/22 by Maarten Docter <https://github.com/mdocter>
+// Updated: 2013/01/25 by William Sears <https://github.com/MrBigDog2U>
 
-
-interface ErrorCallback {
+interface StateMachineErrorCallback {
     (eventName?: string, from?: string, to?: string, args?: any[], errorCode?: number, errorMessage?: string, ex?: Error): void; // NB. errorCode? See: StateMachine.Error
 }
 
-interface StateMachineEvent {
+interface StateMachineEventDef {
     name: string;
     from: string;
     to: string;
 }
 
+interface StateMachineEvent {
+	(...args: any[]): void;
+}
+
 interface StateMachineConfig {
     initial?: any; // string or { state: 'foo', event: 'setup', defer: true|false }
-    events?: StateMachineEvent[];
+    events?: StateMachineEventDef[];
     callbacks?: {
         [s: string]: (event?: string, from?: string, to?: string, ...args: any[]) => any;
     };
-    target?: any;
-    error?: ErrorCallback;
+    target?: StateMachine;
+    error?: StateMachineErrorCallback;
 }
 
 interface StateMachineStatic {
@@ -44,24 +48,34 @@ interface StateMachineStatic {
         INVALID_CALLBACK: number;	// = 300, caller provided callback function threw an exception
     };
 
-    create(config: StateMachineConfig, target?: any): StateMachine;
+    create(config: StateMachineConfig, target?: StateMachine): StateMachine;
+}
+
+interface StateMachineTransition {
+	(): void;
+	cancel(): void;
+}
+
+interface StateMachineIs {
+	(state: string): bool;
+}
+
+interface StateMachineCan {
+	(evt: string): bool;
 }
 
 interface StateMachine {
     current: string;
-    is(state: string): bool;
-    can(event: StateMachineEvent): bool;
-    cannot(event: StateMachineEvent): bool;
-    error: ErrorCallback;
+    is: StateMachineIs;
+    can: StateMachineCan;
+    cannot: StateMachineCan;
+    error: StateMachineErrorCallback;
 
     /*  transition - only available when performing async state transitions; otherwise null. Can be a: 
-        [1] function without arguments (see: https://github.com/jakesgordon/javascript-state-machine#asynchronous-state-transitions) 
-        [2] property with a cancel function to cancel the ASYNC event. Example usages:
-    
-        [1] fsm.transition(); // called form async callback
+        [1] fsm.transition(); // called from async callback
         [2] fsm.transition.cancel(); 
     */
-    transition?: any;
+    transition: StateMachineTransition;
 }
 
 declare var StateMachine: StateMachineStatic;


### PR DESCRIPTION
I had created my own version of state-machine.d.ts before you created yours. I have applied some of my implementation to yours.

These changes show the developer how to extend the StateMachine API that gets generated by the state-machine code automatically to include the events that are registered. It also puts some type-safety around the transition call to use during async events.

Also the is(), can() and cannot() methods take a string event name, not an event.

I preferred calling the configuration objects a StateMachineEventDef in order to save the StateMachineEvent name for the extension API calls. That's just a naming thing so could be done either way.

Have a look and see if you want to apply some or all of these. 
