### PR TITLE
Update phonegap/phonegap.d.ts

### DIFF
--- a/phonegap/phonegap.d.ts
+++ b/phonegap/phonegap.d.ts
@@ -288,12 +288,6 @@ interface GeolocationOptions {
     maximumAge?: number;
 }
 
-interface Geolocation {
-    getCurrentPosition(geolocationSuccess: (position: Position) => void , geolocationError?: PositionErrorCallback, geolocationOptions?: GeolocationOptions): void;
-    watchPosition(geolocationSuccess: (position: Position) => void , geolocationError?: PositionErrorCallback, geolocationOptions?: GeolocationOptions): void;
-    clearWatch(watchID: number): void;
-}
-
 interface GlobalizationError {
     code: number;
     message: string;


### PR DESCRIPTION
Geolocation is now part of lib.d.ts and the duplicate declaration causes an error.
