### PR TITLE
Fix #261 - adjusted jquery event interfaces

### DIFF
--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -1865,8 +1865,10 @@ function test_jQuery() {
     $foo.triggerHandler('eventName');
     $("div > p").css("border", "1px solid gray");
     $("input:radio", document.forms[0]);
+	var xml: any;
     $("div", xml.responseXML);
     $(document.body).css("background", "black");
+	var myForm: any;
     $(myForm.elements).hide();
     $('<p id="test">My <em>new</em> text</p>').appendTo('body');
     $('<img />');
@@ -1893,7 +1895,7 @@ function test_jQuery() {
 }
 
 function test_jquery() {
-    var a = { what: "A regular JS object" },
+    var a = <any>{ what: "A regular JS object" },
     b = $('body');
     if (a.jquery) {
         alert(' a is a jQuery object! ');
@@ -2226,3 +2228,8 @@ function test_text() {
     });
     $("p").text("<b>Some</b> new text.");
 }
+
+$('#item').click(function(e) {
+	if (e.ctrlKey) { console.log('control pressed'); }
+	if (e.altKey) { console.log('alt pressed'); }
+});

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -108,7 +108,8 @@ interface JQueryDeferred extends JQueryPromise {
 /*
     Interface of the JQuery extension of the W3C event object
 */
-interface JQueryEventObject extends Event {
+
+interface BaseJQueryEventObject extends Event {
     data: any;
     delegateTarget: Element;
     isDefaultPrevented(): bool;
@@ -126,7 +127,7 @@ interface JQueryEventObject extends Event {
     metaKey: any;
 }
 
-interface JQueryInputEventObject extends JQueryEventObject
+interface JQueryInputEventObject extends BaseJQueryEventObject
 {
     altKey: bool;
     ctrlKey: bool;
@@ -153,6 +154,9 @@ interface JQueryKeyEventObject extends JQueryInputEventObject
     charCode: number;
     key: any;
     keyCode: number;
+}
+
+interface JQueryEventObject extends BaseJQueryEventObject, JQueryInputEventObject, JQueryMouseEventObject, JQueryKeyEventObject {
 }
 
 /*
@@ -313,6 +317,7 @@ interface JQueryStatic {
     makeArray(obj: any): any[];
 
     map(array: any[], callback: (elementOfArray: any, indexInArray: any) =>any): any[];
+	map(array: any, callback: (elementOfArray: any, indexInArray: any) =>any): any;
 
     merge(first: any[], second: any[]): any[];
 
@@ -775,6 +780,10 @@ interface JQuery {
     queue(queueName?: string): any[];
     queue(queueName: string, newQueueOrCallback: any): JQuery;
     queue(newQueueOrCallback: any): JQuery;
+}
+
+interface EventTarget {
+	nodeName: string;
 }
 
 declare var jQuery: JQueryStatic;


### PR DESCRIPTION
Issue #261:

These `altKey` and `ctrlKey` properties are in class `JQueryInputEventObject`:

```
interface JQueryInputEventObject extends JQueryEventObject
{
    altKey: bool;
    ctrlKey: bool;
    metaKey: bool;
    shiftKey: bool;
}
```

I fixed the event interface orders to solve this problem.
