### PR TITLE
Make require.js variable declartions ambient 

### DIFF
--- a/requirejs/require.d.ts
+++ b/requirejs/require.d.ts
@@ -202,5 +202,5 @@ interface RequireDefine {
 }
 
 // Ambient declarations for 'require' and 'define'
-var require: Require;
-var define: RequireDefine;
+declare var require: Require;
+declare var define: RequireDefine;


### PR DESCRIPTION
My project statically imports definition files. Since the 'require' and 'define' variables are in global scope, the non-ambient nature was causing typescript to generate "var require; var define;" at the top of the file, making the global values inaccessible. This commit fixes this issue, ensuring that the variables are defined only for typechecking purposes.
