### PR TITLE
Updates to JQuery and Mustache Definitions

### DIFF
--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -2220,6 +2220,13 @@ function test_prop() {
     var title: string = $('option:selected', this).prop('title');
 }
 
+
+function test_selector() {
+  var $main = $('#main');
+  var $mainDivs = $('div', $main);
+  return $mainDivs.selector == '#main div';
+}
+
 function test_text() {
     var str = $("p:first").text();
     $("p:last").html(str);

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -700,6 +700,7 @@ interface JQuery {
      PROPERTIES
     ***********/
     length: number;
+    selector: string;
     [x: string]: HTMLElement;
     [x: number]: HTMLElement;
 

--- a/mustache/mustache-tests.ts
+++ b/mustache/mustache-tests.ts
@@ -6,3 +6,6 @@ var output = Mustache.render("{{title}} spends {{calc}}", view);
 var person;
 var template = "<h1>{{firstName}} {{lastName}}</h1>Blog: {{blogURL}}";
 var html = Mustache.to_html(template, person);
+
+var writer = Mustache.compile(template);
+var writerOutput = writer(view);

--- a/mustache/mustache.d.ts
+++ b/mustache/mustache.d.ts
@@ -24,6 +24,7 @@ interface MustacheContext {
 }
 
 interface MustacheWriter {
+    (view: any): string;
     clearCache();
     compile(template: string, tags);
     compilePartial(name, template, tags);
@@ -42,6 +43,7 @@ interface MustacheStatic {
 
     parse(template: string, tags);
     clearCache(): MustacheWriter;
+    compile(template: string): MustacheWriter;
     compile(template: string, tags): MustacheWriter;
     compilePartial(name: string, template: string, tags): MustacheWriter;
     compileTokens(tokens, template: string): MustacheWriter;


### PR DESCRIPTION
JQuery:

Add selector property to return the selector used for a JQuery object.

Mustache:

Modify the MustacheWriter interface to allow it to be called as a function, with the view data as a parameter.  Also, add definition for MustacheStatic#compile for just one parameter, the template.
