### PR TITLE
Update restify definition

### DIFF
--- a/restify/restify-test.ts
+++ b/restify/restify-test.ts
@@ -49,9 +49,9 @@ function send(req, res, next) {
 
     req.contentLength === 50;
     req.contentType === 'test';
-    req.href === 'test';
+    req.href() === 'test';
     req.id === 'test';
-    req.path === 'test';
+    req.path() === 'test';
     req.query === 'test';
     req.secure === true;
     req.time === 50;

--- a/restify/restify.d.ts
+++ b/restify/restify.d.ts
@@ -11,10 +11,10 @@ interface Request {
     getLogger: (component: string) => any;
     contentLength: number;
     contentType: string;
-    href: string;
+    href: () => string;
     log: Object;
     id: string;
-    path: string;
+    path: () => string;
     query: string;
     secure: bool;
     time: number;


### PR DESCRIPTION
The restify documentation incorrectly states that two attributes of the request object are string properties rather than functions. This request correctly defines them.
