### PR TITLE
Added two function declarations for Backbone.History

### DIFF
--- a/backbone/backbone.d.ts
+++ b/backbone/backbone.d.ts
@@ -196,6 +196,8 @@ declare module Backbone {
         start(options?: HistoryOptions);
         navigate(fragment: string, options: any);
         pushSate();
+        getFragment(fragment?: string, forcePushState?: bool): string;
+        getHash(window?: Window): string;
     }
 
     export interface ViewOptions {


### PR DESCRIPTION
Backbone.History.getFragment
Backbone.History.getHash

I spent half a day today trying to get this commit without messing line endings. I don't know what line ending is used in this repository but I tried saving my modified file in Windows system, Unix system and Mac system with all combinations of git eol settings to no avail! I suppose you are using a non-Windows OS but if you add a .gitattributes file with text=auto setting and normalize all line endings in the repo that would make life much easier for people like me who are using Windows and want to contribute to this project.

See: https://help.github.com/articles/dealing-with-line-endings

Thanks.
