### PR TITLE
Remove ko.utils.setTextContent from public knockout utils API surface.

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -337,7 +337,7 @@ interface KnockoutUtils {
 
     toggleDomNodeCssClass(node: any, className: string, shouldHaveClass: bool): void;
 
-    setTextContent(element: any, textContent: string): void;
+    //setTextContent(element: any, textContent: string): void; // NOT PART OF THE MINIFIED API SURFACE (ONLY IN knockout-{version}.debug.js) https://github.com/SteveSanderson/knockout/issues/670
 
     setElementName(element: any, name: string): void;
 


### PR DESCRIPTION
Although this function is available via knockout-{version}.debug.js, it is
not part of the minified knockout-{version}.js file. Invoking this function
will cause a runtime javascript error when invoked against the minified js.

See this for more info: https://github.com/SteveSanderson/knockout/issues/670
