### PR TITLE
Added $f variable to Vimeos froogaloop.d.ts

### DIFF
--- a/vimeo/froogaloop.d.ts
+++ b/vimeo/froogaloop.d.ts
@@ -24,3 +24,5 @@ interface VimeoPlayer {
     removeCallback(eventName: string, target_id: string);
     getDomainFromUrl(url: string): string;
 }
+
+declare var $f: VimeoPlayerAPI;


### PR DESCRIPTION
froogaloop declares a jquery like variable called $f which  makes it easy to get a reference to the VimeoPlayer like this:

``` javascript
var player = $f($('.some-container-with-player'));
```
