### PR TITLE
IHttpBackendService#flush count parameter optional

### DIFF
--- a/angularjs/angular-mocks.d.ts
+++ b/angularjs/angular-mocks.d.ts
@@ -71,7 +71,7 @@ module ng {
     // see http://docs.angularjs.org/api/ngMock.$httpBackend
     ///////////////////////////////////////////////////////////////////////////
     interface IHttpBackendService {
-        flush(count: number): void;
+        flush(count?: number): void;
         resetExpectations(): void;
         verifyNoOutstandingExpectation(): void;
         verifyNoOutstandingRequest(): void;


### PR DESCRIPTION
The `count` parameter of `IHttpBackendService#flush` is optional.
