### PR TITLE
angular.mock.inject() returns any type, not void

### DIFF
--- a/angularjs/angular-mocks.d.ts
+++ b/angularjs/angular-mocks.d.ts
@@ -24,7 +24,7 @@ module ng {
         debug(obj: any): string;
                 
         // see http://docs.angularjs.org/api/angular.mock.inject
-        inject(...fns: Function[]): void;
+        inject(...fns: Function[]): any;
         
         // see http://docs.angularjs.org/api/angular.mock.module
         module(...modules: any[]): any;


### PR DESCRIPTION
Have a look at this: https://github.com/angular/angular.js/blob/master/src/ngMock/angular-mocks.js#L1770. Function inject() returns void or Function type, so type declaration in https://github.com/borisyankov/DefinitelyTyped/blob/master/angularjs/angular-mocks.d.ts#L27 should return any type.
