### PR TITLE
Removal of logChange method and explanation

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -242,7 +242,6 @@ interface KnockoutVirtualElements {
 interface KnockoutExtenders {
     throttle(target: any, timeout: number): KnockoutComputed;
     notify(target: any, notifyWhen: string): any;
-    logChange(target: KnockoutObservableAny, option: string): KnockoutObservableAny;
 }
 
 interface KnockoutUtils {


### PR DESCRIPTION
logChange is an example of an extension, not part of the standard library. To add extensions, simply extend the interface outside of the definition file:

interface KnockoutExtenders {
    logChange(target: KnockoutObservableAny, option: string): KnockoutObservableAny;
}
