### PR TITLE
Updated IDeferred.reject per Angular docs

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -391,7 +391,7 @@ module ng {
 
     interface IDeferred {
         resolve(value?: any): void;
-        reject(reason?: string): void;
+        reject(reason?: any): void;
         promise: IPromise;
     }
 


### PR DESCRIPTION
According to the [Angular docs](http://docs.angularjs.org/api/ng.$q), there is no restriction on type for the reason parameter on reject.

> **Parameters**
> reason – {*} – Constant, message, exception or an object representing the rejection reason.
