### PR TITLE
jQuery and Google Maps fixes

### DIFF
--- a/googlemaps/google.maps.d.ts
+++ b/googlemaps/google.maps.d.ts
@@ -1123,7 +1123,7 @@ declare module google.maps {
         worldSize?: Size;
     }
 
-    export interface StreetViewService {
+    export class StreetViewService {
         getPanoramaById(pano: string, callback: (streetViewPanoramaData: StreetViewPanoramaData, streetViewStatus: StreetViewStatus) => void );
         getPanoramaByLocation(latlng: LatLng, radius: number, callback: (streetViewPanoramaData: StreetViewPanoramaData, streetViewStatus: StreetViewStatus) => void );
     }

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -714,7 +714,7 @@ interface JQuery {
     ***********/
     length: number;
     selector: string;
-    [x: string]: HTMLElement;
+    [x: string]: any;
     [x: number]: HTMLElement;
 
     /**********


### PR DESCRIPTION
1) Indexing a `JQuery` object with string not always returns an `HTMLElement` object.
For example `$('BODY')['hide']` returns the reference to the `hide` function.

2) `StreetViewService` in Google Maps definition file is defined as an interface. Changed to class (it is a class in JS API v3 documentation).
