### PR TITLE
D3 is missing some methods on the Transition interface

### DIFF
--- a/d3/d3-tests.ts
+++ b/d3/d3-tests.ts
@@ -699,3 +699,33 @@ function panAndZoom {
         svg.select(".y.axis").call(yAxis);
     }
 }
+
+//Example from http://bl.ocks.org/mbostock/1125997
+function chainedTransitions() {
+    var w = 960,
+    h = 500,
+    y = d3.scale.ordinal().domain(d3.range(50)).rangePoints([20, h - 20]),
+    t = Date.now();
+
+    var svg = d3.select("body").append("svg:svg")
+        .attr("width", w)
+        .attr("height", h);
+
+    var circle = svg.selectAll("circle")
+        .data(y.domain())
+      .enter().append("svg:circle")
+        .attr("r", 16)
+        .attr("cx", 20)
+        .attr("cy", y)
+        .each(slide(20, w - 20));
+
+    function slide(x0, x1) {
+      t += 50;
+      return function() {
+        d3.select(this).transition()
+            .duration(t - Date.now())
+            .attr("cx", x1)
+            .each("end", slide(x1, x0));
+      };
+    }
+}

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -811,6 +811,10 @@ module D3 {
 
         select: (selector: string) => Transition;
         selectAll: (selector: string) => Transition;
+
+        each: (type?: string, eachFunction?: (data: any, index: number) => any) => Transition;
+        transition: () => Transition;
+        ease: (value: string, ...arrs: any[]) => Transition;
     }
 
     interface Nest {


### PR DESCRIPTION
This commit adds 3 of the missing methods - each(), transition() and ease().

It also updates the test with the Chained Transitions example from http://bl.ocks.org/mbostock/1125997

I've run the test with:
node ../_infrastructure/tests/typescript_0.8.3/tsc.js d3-tests.ts --out d3-tests.js

Hope that's the correct way to do it?
