### PR TITLE
To resolve issue #453

### DIFF
--- a/durandal/durandal.d.ts
+++ b/durandal/durandal.d.ts
@@ -377,6 +377,10 @@ declare module "durandal/plugins/router" {
       */
     export var afterCompose: () => void;
     /**
+      * Returns the activatable instance from the supplied module.
+      */
+    export var getActivatableInstance: (routeInfo: routeInfo, params: any, module: any) => any;
+    /**
       * Causes the router to move backwards in page history.
       */
     export var navigateBack: () => void;


### PR DESCRIPTION
This adds the `router.getActivatableInstance` function as explained in https://github.com/borisyankov/DefinitelyTyped/issues/453. This is necessary for TypeScript integration where you want to use TypeScript classes for viewmodels.
