### PR TITLE
setuid and setgid accept string as a parameter.

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -118,9 +118,9 @@ interface NodeProcess extends EventEmitter {
     env: any;
     exit(code?: number): void;
     getgid(): number;
-    setgid(id: number): void;
+    setgid(id: any): void;
     getuid(): number;
-    setuid(id: number): void;
+    setuid(id: any): void;
     version: string;
     versions: { http_parser: string; node: string; v8: string; ares: string; uv: string; zlib: string; openssl: string; };
     config: {

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -118,9 +118,11 @@ interface NodeProcess extends EventEmitter {
     env: any;
     exit(code?: number): void;
     getgid(): number;
-    setgid(id: any): void;
+    setgid(id: number): void;
+    setgid(id: string): void;
     getuid(): number;
-    setuid(id: any): void;
+    setuid(id: number): void;
+    setuid(id: string): void;
     version: string;
     versions: { http_parser: string; node: string; v8: string; ares: string; uv: string; zlib: string; openssl: string; };
     config: {


### PR DESCRIPTION
Both process.setuid and process.setgid can accept either a numerical ID or a username\groupname string.
