### PR TITLE
jquery: allow html(JQuery)

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -402,6 +402,7 @@ interface JQuery {
     html(): string;
     html(htmlString: string): JQuery;
     html(htmlContent: (index: number, oldhtml: string) => string): JQuery;
+    html(JQuery): JQuery;
 
     prop(propertyName: string): any;
     prop(propertyName: string, value: any): JQuery;


### PR DESCRIPTION
Change the declaration so that `html()` function can accept a JQuery object as input too.
