### PR TITLE
fix for combined matchers in sinon

### DIFF
--- a/sinon/sinon-1.5.d.ts
+++ b/sinon/sinon-1.5.d.ts
@@ -302,8 +302,8 @@ interface SinonStatic {
 }
 
 interface SinonMatcher {
-	and(expr: SinonMatch): SinonMatcher;
-	or(expr: SinonMatch): SinonMatcher;
+	and(expr: SinonMatcher): SinonMatcher;
+	or(expr: SinonMatcher): SinonMatcher;
 }
 
 interface SinonMatch {

--- a/sinon/sinon-tests.ts
+++ b/sinon/sinon-tests.ts
@@ -76,6 +76,10 @@ function testSeven() {
 	mockObj.expects('functionToTest').once();
 }
 
+function testEight() {
+    var combinedMatcher = sinon.match.typeOf("object").and(sinon.match.has("pages"));
+}
+
 testOne();
 testTwo();
 testThree();
@@ -83,3 +87,4 @@ testFour();
 testFive();
 testSix();
 testSeven();
+testEight();


### PR DESCRIPTION
It wasn't possible to combine matchers since "And" and "Or" required a SinonMatch.

Resulting in the following error "Type 'SinonMatcher' is missing property 'same' from type 'SinonMatch'"

Changed the requiredtype from SinonMatch to SinonMatcher.
