### PR TITLE
Knockout Validation Error Fix

### DIFF
--- a/knockout.validation/knockout.validation.d.ts
+++ b/knockout.validation/knockout.validation.d.ts
@@ -107,7 +107,7 @@ interface KnockoutValidationStatic {
     configure(options: KnockoutValidationConfiguration): void;
     reset(): void;
 
-    group(obj: any, options?: any): () => string[];
+    group(obj: any, options?: any): KnockoutValidationErrors;
 
     formatMessage(message: string, params: string): string;
 


### PR DESCRIPTION
I fixed a definition error for the knockout validation d.ts file.  This change allows the .showAllMessages to work in Typescript.  Can you please merge this into master.
