### PR TITLE
Typos in Sinon and Jasmine

### DIFF
--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -29,7 +29,7 @@ declare module jasmine {
     var Clock: Clock;
 
     function any(aclass: any);
-    function createSpy(name: string): any;
+    function createSpy(name: string): Spy;
     function createSpyObj(baseName: string, methodNames: any[]): any;
 
     function getEnv(): Env;
@@ -239,9 +239,9 @@ declare module jasmine {
         wasCalled: bool;
         callCount: number;
 
-        andReturn(value): void;
-        andCallThrough(): void;
-        andCallFake(fakeFunc: Function): void;
+        andReturn(value): Spy;
+        andCallThrough(): Spy;
+        andCallFake(fakeFunc: Function): Spy;
     }
 
     interface Suite {

--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -29,7 +29,7 @@ declare module jasmine {
     var Clock: Clock;
 
     function any(aclass: any);
-    function createSpy(name: string): Spy;
+    function createSpy(name: string): any;
     function createSpyObj(baseName: string, methodNames: any[]): any;
 
     function getEnv(): Env;
@@ -239,9 +239,9 @@ declare module jasmine {
         wasCalled: bool;
         callCount: number;
 
-        andReturn(value): Spy;
-        andCallThrough(): Spy;
-        andCallFake(fakeFunc: Function): Spy;
+        andReturn(value): void;
+        andCallThrough(): void;
+        andCallFake(fakeFunc: Function): void;
     }
 
     interface Suite {

--- a/sinon/sinon-1.5.d.ts
+++ b/sinon/sinon-1.5.d.ts
@@ -233,19 +233,19 @@ interface SinonFakeServer {
 	// Methods
 	respondWith(body: string): void;
 	respondWith(response: any[]): void;
-	respondWith(fn: (SinonFakeXMLHttpRequest) => void ): void;
+	respondWith(fn: (xhr: SinonFakeXMLHttpRequest) => void ): void;
 	respondWith(url: string, body: string): void;
 	respondWith(url: string, response: any[]): void;
-	respondWith(url: string, fn: (SinonFakeXMLHttpRequest) => void ): void;
+	respondWith(url: string, fn: (xhr: SinonFakeXMLHttpRequest) => void ): void;
 	respondWith(method: string, url: string, body: string): void;
 	respondWith(method: string, url: string, response: any[]): void;
-	respondWith(method: string, url: string, fn: (SinonFakeXMLHttpRequest) => void ): void;
+	respondWith(method: string, url: string, fn: (xhr: SinonFakeXMLHttpRequest) => void ): void;
 	respondWith(url: RegExp, body: string): void;
 	respondWith(url: RegExp, response: any[]): void;
-	respondWith(url: RegExp, fn: (SinonFakeXMLHttpRequest) => void ): void;
+	respondWith(url: RegExp, fn: (xhr: SinonFakeXMLHttpRequest) => void ): void;
 	respondWith(method: string, url: RegExp, body: string): void;
 	respondWith(method: string, url: RegExp, response: any[]): void;
-	respondWith(method: string, url: RegExp, fn: (SinonFakeXMLHttpRequest) => void ): void;
+	respondWith(method: string, url: RegExp, fn: (xhr: SinonFakeXMLHttpRequest) => void ): void;
 	respond(): void;
 	restore(): void;
 }


### PR DESCRIPTION
1) Fixed a typo in Sinon: no parameter name for the "xhr" parameter in fakeServer.respondWith
2) Added missing return types for Spy chaining methods and for the jasmine.createSpy
