### PR TITLE
googlemaps: Added missing optional operator in PolylineOptions interface def

### DIFF
--- a/googlemaps/google.maps.d.ts
+++ b/googlemaps/google.maps.d.ts
@@ -321,7 +321,7 @@ declare module google.maps {
 
     export interface PolylineOptions {
         clickable?: bool;
-        draggable: bool;
+        draggable?: bool;
         editable?: bool;
         geodesic?: bool;
         icons?: IconSequence[];


### PR DESCRIPTION
I'm new to contributing to opensource so please let me know if I'm missing a step.

The googlemaps defs were recently updated and the PolylineOptions interface is defined but is missing an optional '?' operator for the draggable property which introduces a regression to otherwise working code.

I fixed this in this commit.
