### PR TITLE
Nodemailer: type definitions for the SMPT-specific options

### DIFF
--- a/nodemailer/nodemailer-tests.ts
+++ b/nodemailer/nodemailer-tests.ts
@@ -81,3 +81,25 @@ transport.sendMail(message, function (error) {
     }
     console.log('Message sent successfully!');
 });
+
+
+// From the SMTP section of https://npmjs.org/package/nodemailer README
+
+var smptTransport1: Transport = nodemailer.createTransport("SMTP", {
+    service: "Gmail", // sets automatically host, port and connection security settings
+    auth: {
+        user: "gmail.user@gmail.com",
+        pass: "userpass"
+    }
+});
+
+var smtpTransport2: Transport = nodemailer.createTransport("SMTP", {
+    host: "smtp.gmail.com", // hostname
+    secureConnection: true, // use SSL
+    port: 465, // port for secure SMTP
+    auth: {
+        user: "gmail.user@gmail.com",
+        pass: "userpass"
+    }
+});
+

--- a/nodemailer/nodemailer.d.ts
+++ b/nodemailer/nodemailer.d.ts
@@ -69,21 +69,37 @@ interface XOAuth2Options {
 
 interface NodemailerTransportOptions {
 	service?: string;
-	auth?: {
-		user?: string;
-		pass?: string;
-		XOAuthToken?: XOAuthGenerator;
-		XOAuth2?: XOAuth2Options;
-	};
+	auth?: NodemailerAuthInterface;
 	debug?: bool;
 	AWSAccessKeyID?: string;
 	AWSSecretKey: string;
 	ServiceUrl: string;
 }
 
+interface NodemailerAuthInterface {
+	user?: string;
+	pass?: string;
+	XOAuthToken?: XOAuthGenerator;
+	XOAuth2?: XOAuth2Options;
+}
+
+interface NodemailerSMTPTransportOptions {
+	service?:          string;
+	host?:             string;
+	port?:             number;
+	secureConnection?: bool;
+	name?:             string;
+	auth:              NodemailerAuthInterface;
+	ignoreTLS?:        bool;
+	debug?:            bool;
+	maxConnections?:   number;
+}
+
+
 interface Nodemailer {
 	createTransport(type: string): Transport;
 	createTransport(type: string, options: NodemailerTransportOptions): Transport;
+	createTransport(type: string, options: NodemailerSMTPTransportOptions): Transport;
 	createTransport(type: string, path: string): Transport;
 	createXOAuthGenerator(options: XOAuthGeneratorOptions): XOAuthGenerator;
 }


### PR DESCRIPTION
Greetings!

I didn't polish anything about these definitions to completion, but did get some examples from the nodemailer readme properly typechecking. Let me know if that's not good enough for a PR, and I'll try to go through and do a more complete sweep.

Thanks!

-a
# 

As documented here:
https://github.com/andris9/nodemailer#setting-up-smtp

Added examples from the above source as tests.

The original definition of NodemailerTransportOptions looks questionable
with its AWS-specific fields, but leaving it alone for now since I'm
new to nodemailer.

Once typescript 0.9 is rolled out with its string parameter matcher,
that should be used for specifying the type of options of the second
parameter when the first one has value "SMTP".
