### PR TITLE
Added "amd" property definition to RequireDefine interface

### DIFF
--- a/requirejs/require.d.ts
+++ b/requirejs/require.d.ts
@@ -199,6 +199,13 @@ interface RequireDefine {
 	*	@return module definition
 	**/
 	(name: string, deps: string[], ready: (...deps: any[]) => any): void;
+	
+	/**
+	* Defines whether require js supports multiple versions of jQuery being loaded
+	**/
+	amd: {
+		jQuery: bool;
+	};
 }
 
 // Ambient declarations for 'require' and 'define'


### PR DESCRIPTION
This property is used a lot to determine the existence of the define method.

Ex: 
if (typeof define === 'function' && define.amd) {...
