### PR TITLE
Suggestion: jQuery overloads for jQuery UI's method overrides

### DIFF
--- a/jqueryui/jqueryui.d.ts
+++ b/jqueryui/jqueryui.d.ts
@@ -919,17 +919,23 @@ interface JQuery {
     effect(effect: string, options?: any, duration?: number, complete?: Function): JQuery;
     effect(effect: string, options?: any, duration?: string, complete?: Function): JQuery;
 
+    hide(duration?: any, callback?: any): JQuery;
     hide(options: any): JQuery;
     hide(effect: string, options?: any, duration?: number, complete?: Function): JQuery;
     hide(effect: string, options?: any, duration?: string, complete?: Function): JQuery;
 
+    show(duration?: any, callback?: any): JQuery;
     show(options: any): JQuery;
     show(effect: string, options?: any, duration?: number, complete?: Function): JQuery;
     show(effect: string, options?: any, duration?: string, complete?: Function): JQuery;
 
+    toggle(duration?: any, callback?: any): JQuery;
     toggle(options: any): JQuery;
     toggle(effect: string, options?: any, duration?: number, complete?: Function): JQuery;
     toggle(effect: string, options?: any, duration?: string, complete?: Function): JQuery;
+
+    position(): { top: number; left: number; };
+    position(options: JQueryPositionOptions): JQuery;
 
     enableSelection(): JQuery;
     disableSelection(): JQuery;
@@ -939,7 +945,6 @@ interface JQuery {
     scrollParent(): JQuery;
     zIndex(): JQuery;
     zIndex(zIndex: number): JQuery;
-    position(options: JQueryPositionOptions): JQuery;
 
     widget: Widget;
 


### PR DESCRIPTION
I have only tested this issue in IntelliJ IDEA so it would nice if anyone can confirm if this is a real issue or not.

jQueryUI overrides some of jQuery's methods

http://api.jqueryui.com/category/overrides/

Some IDE's does not recognise jQuery's methods when jqueryui.d.ts is present and displays an "Arguments does not match" error.
