### PR TITLE
Update jquery.d.ts

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -343,7 +343,7 @@ interface JQueryStatic {
 
     now(): number;
 
-    parseJSON(json: string): Object;
+    parseJSON(json: string): any;
 
     //FIXME: This should return an XMLDocument
     parseXML(data: string): any;


### PR DESCRIPTION
parseJSON should return any. If it returns Object the properties cannot be accessed without typecasting.
