### PR TITLE
Added placeholder to SortableUIParams

### DIFF
--- a/jqueryui/jqueryui.d.ts
+++ b/jqueryui/jqueryui.d.ts
@@ -494,6 +494,7 @@ interface SortableUIParams {
     position: any;
     originalPosition: any;
     sender: JQuery;
+	placeholder: JQuery;
 }
 
 interface SortableEvent {


### PR DESCRIPTION
Even if the jQuery UI docs says nothing about the placeholder property in the ui argument, it   really exists in all sortable event callbacks.

``` javascript
$('element').sortable({
  start: function (event, ui) {
    console.log(ui.placeholder);
  }
});
```
