### PR TITLE
Leaflet DivIcon should extend Icon

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -1932,7 +1932,7 @@ declare module L {
     
     }
 
-    export class DivIcon {
+    export class DivIcon extends Icon{
         /**
           * Creates a div icon instance with the given options.
           */


### PR DESCRIPTION
With this change Marker's constructor can accept DivIcon as well as Icon. 

NOTE: Compiler warning "Missed superclass's constructor invocation" now shows up for DivIcon constructor in the definition file. I see no way around that at the moment, and it's already present other places in the definitions.
