### PR TITLE
Correction to Q.resolve

### DIFF
--- a/q/Q.d.ts
+++ b/q/Q.d.ts
@@ -42,7 +42,7 @@ interface QStatic {
     fcall(method: Function, ...args: any[]): Qpromise;
     all(promises: Qpromise[]): Qpromise;
     allResolved(promises: Qpromise[]): Qpromise;
-    resolve(object?:Qpromise);
+    resolve(object:any):Qpromise;
     spread(onFulfilled: Function, onRejected: Function): Qpromise;
     timeout(ms: number): Qpromise;
     delay(ms: number): Qpromise;


### PR DESCRIPTION
Q.resolve signature is not defined according to the current implementation. It should accept any value and return a QPromise instead of accepting an optional QPromise parameter.
