### PR TITLE
angular.d.ts — make 'scope' be any, not bool

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -646,7 +646,7 @@ declare module ng {
         replace?: bool;
         transclude?: bool;
         restrict?: string;
-        scope?: bool;
+        scope?: any;
         link?: Function;
         compile?: Function;
     }


### PR DESCRIPTION
See http://docs.angularjs.org/guide/directive: `scope` can be either `true`, or object hash which defines a set of local scope properties derived from the parent scope.
