### PR TITLE
Generic Knockout typings

### DIFF
--- a/knockout/knockout-2.2.d.ts
+++ b/knockout/knockout-2.2.d.ts
@@ -21,29 +21,29 @@ interface KnockoutComputedFunctions extends KnockoutSubscribableFunctions {
 interface KnockoutObservableFunctions extends KnockoutSubscribableFunctions {
 }
 
-interface KnockoutObservableArrayFunctions extends KnockoutObservableFunctions {
+interface KnockoutObservableArrayFunctions<T> extends KnockoutObservableFunctions {
     // General Array functions
-    indexOf(searchElement, fromIndex?: number): number;
-    slice(start: number, end?: number): any[];
-    splice(start: number): any[];
-    splice(start: number, deleteCount: number, ...items: any[]): any[];
+    indexOf(searchElement: T, fromIndex?: number): number;
+    slice(start: number, end?: number): T[];
+    splice(start: number): T[];
+    splice(start: number, deleteCount: number, ...items: T[]): T[];
     pop();
-    push(...items: any[]): void;
+    push(...items: T[]): void;
     shift();
-    unshift(...items: any[]): number;
-    reverse(): any[];
+    unshift(...items: T[]): number;
+    reverse(): T[];
     sort(): void;
     sort(compareFunction): void;
 
     // Ko specific
-    replace(oldItem: any, newItem: any): void;
+    replace(oldItem: T, newItem: T): void;
 
-    remove(item): any[];
-    removeAll(items: any[]): any[];
-    removeAll(): any[];
+    remove(item): T[];
+    removeAll(items: T[]): T[];
+    removeAll(): T[];
 
-    destroy(item): void;
-    destroyAll(items: any[]): void;
+    destroy(item: T): void;
+    destroyAll(items: T[]): void;
     destroyAll(): void;
 }
 
@@ -61,94 +61,56 @@ interface KnockoutSubscription extends KnockoutSubscribableFunctions {
 interface KnockoutComputedStatic {
     fn: KnockoutComputedFunctions;
 
-    (): KnockoutComputed;
-    (func: Function, context?: any): KnockoutComputed;
-    (def: KnockoutComputedDefine): KnockoutComputed;
-    (options?: any): KnockoutComputed;
+    <T>(): KnockoutComputed<T>;
+    <T>(func: () => T, context?: any): KnockoutComputed<T>;
+    <T>(def: KnockoutComputedDefine<T>): KnockoutComputed<T>;
+    (options?: any): KnockoutComputed<any>;
 }
 
-interface KnockoutComputed extends KnockoutComputedFunctions {
-    (): any;
-    (value: any): void;
+interface KnockoutComputed<T> extends KnockoutComputedFunctions {
+    (): T;
+    (value: T): void;
 
-    subscribe(callback: (newValue: any) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite, topic?: string);
+    subscribe(callback: (newValue: T) => void, target?:any, topic?: string): KnockoutSubscription;
+    notifySubscribers(valueToWrite: T, topic?: string);
 }
 
 interface KnockoutObservableArrayStatic {
 
-    fn: KnockoutObservableArrayFunctions;
+    fn: KnockoutObservableArrayFunctions<any>;
 
-    (): KnockoutObservableArray;
-    (value: any[]): KnockoutObservableArray;
+    <T>(): KnockoutObservableArray<T>;
+    <T>(value: T[]): KnockoutObservableArray<T>;
 }
 
-interface KnockoutObservableArray extends KnockoutObservableArrayFunctions {
-    (): any[];
-    (value: any[]): void;
+interface KnockoutObservableArray<T> extends KnockoutObservableArrayFunctions<T> {
+    (): T[];
+    (value: T[]): void;
 
-    subscribe(callback: (newValue: any[]) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite: any[], topic?: string);
+    subscribe(callback: (newValue: T[]) => void, target?:any, topic?: string): KnockoutSubscription;
+    notifySubscribers(valueToWrite: T[], topic?: string);
 }
 
 interface KnockoutObservableStatic {
     fn: KnockoutObservableFunctions;
 
-    (value: string): KnockoutObservableString;
-    (value: Date): KnockoutObservableDate;
-    (value: number): KnockoutObservableNumber;
-    (value: bool): KnockoutObservableBool;
-    (value?: any): KnockoutObservableAny;
+    <T>(value: T): KnockoutObservable<T>;
 }
 
 interface KnockoutObservableBase extends KnockoutObservableFunctions {
 }
 
-interface KnockoutObservableAny extends KnockoutObservableBase {
+interface KnockoutObservable<T> extends KnockoutObservableBase {
+    (): T;
+    (value: T): void;
 
-    (): any;
-    (value): void;
-
-    subscribe(callback: (newValue: any) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite, topic?: string);
+    subscribe(callback: (newValue: T) => void, target?:any, topic?: string): KnockoutSubscription;
+    notifySubscribers(valueToWrite: T, topic?: string);
 }
 
-interface KnockoutObservableString extends KnockoutObservableBase {
-    (): string;
-    (value: string): void;
-
-    subscribe(callback: (newValue: string) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite: string, topic?: string);
-}
-
-
-interface KnockoutObservableNumber extends KnockoutObservableBase {
-    (): number;
-    (value: number): void;
-
-    subscribe(callback: (newValue: number) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite: number, topic?: string);
-}
-
-interface KnockoutObservableBool extends KnockoutObservableBase {
-    (): bool;
-    (value: bool): void;
-
-    subscribe(callback: (newValue: bool) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite: bool, topic?: string);
-}
-
-interface KnockoutObservableDate extends KnockoutObservableBase {
-    (): Date;
-    (value: Date): void;
-
-    subscribe(callback: (newValue: Date) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite: Date, topic?: string);
-}
-
-interface KnockoutComputedDefine {
-    read(): any;
-    write(any);
+interface KnockoutComputedDefine<T> {
+    read(): T;
+    write(T);
 }
 
 interface KnockoutBindingContext {


### PR DESCRIPTION
Now that TypeScript 0.9 is officially released, here are the KnockoutJS typings using the new TS generics.
