### PR TITLE
TS 0.9 compatability

### DIFF
--- a/chai/chai-assert.d.ts
+++ b/chai/chai-assert.d.ts
@@ -107,7 +107,7 @@ declare module chai
 		ifError(val:any, msg?:string);
 	}
 	//node module
-	declare var assert:Assert;
+	var assert:Assert;
 }
 //browser global
 declare var assert:chai.Assert;


### PR DESCRIPTION
Fixed error in TS0.9 error : 'declare' modifier not allowed for code already in an ambient context.
