### PR TITLE
Update google.maps.d.ts

### DIFF
--- a/googlemaps/google.maps.d.ts
+++ b/googlemaps/google.maps.d.ts
@@ -34,7 +34,6 @@ declare module google.maps {
         notify(key: string): void;
         set(key: string, value: any): void;
         setValues(values: any): void;
-        setValues(values: undefined);
         unbind(key: string): void;
         unbindAll(): void;
     }


### PR DESCRIPTION
Removing redundant specification of the MVCObject.setValues method. 'undefined' is incompatible with TypeScript 0.9.
