### PR TITLE
Removed uncompilable function definition

### DIFF
--- a/raphael/raphael.d.ts
+++ b/raphael/raphael.d.ts
@@ -245,7 +245,6 @@ interface RaphaelStatic {
     format(token: string, ...parameters: any[]): string;
     fullfill(token: string, json: JSON): string;
     getColor(value?: number): string;
-    getColor: { reset(); };
     getPointAtLength(path: string, length: number): { x: number; y: number; alpha: number; };
     getRGB(colour: string): { r: number; g: number; b: number; hex: string; error: bool; };
     getSubpath(path: string, from: number, to: number): string;


### PR DESCRIPTION
This change removes one line from raphael.d.ts, because it doesn't compile under 0.9.
