### PR TITLE
Generic Knockout update

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -15,7 +15,7 @@ interface KnockoutSubscribableFunctions {
 
 interface KnockoutComputedFunctions extends KnockoutSubscribableFunctions {
     getDependenciesCount(): number;
-    hasWriteFunction(): bool;
+    hasWriteFunction(): boolean;
 }
 
 interface KnockoutObservableFunctions extends KnockoutSubscribableFunctions {
@@ -175,7 +175,7 @@ interface KnockoutMemoization {
 interface KnockoutVirtualElement {}
 
 interface KnockoutVirtualElements {
-	allowedBindings: { [bindingName: string]: bool; };
+	allowedBindings: { [bindingName: string]: boolean; };
 	emptyNode( e: KnockoutVirtualElement );
 	firstChild( e: KnockoutVirtualElement );
 	insertAfter( container: KnockoutVirtualElement, nodeToInsert: HTMLElement, insertAfter: HTMLElement );
@@ -215,7 +215,7 @@ interface KnockoutUtils {
 
         set (node: Element, key: string, value: any);
 
-        getAll(node: Element, createIfNotFound: bool);
+        getAll(node: Element, createIfNotFound: boolean);
 
         clear(node: Element);
     };
@@ -244,7 +244,7 @@ interface KnockoutUtils {
 
     arrayIndexOf(array: any[], item: any): number;
 
-    arrayFirst(array: any[], predicate: (item) => bool, predicateOwner?: any): any;
+    arrayFirst(array: any[], predicate: (item) => boolean, predicateOwner?: any): any;
 
     arrayRemoveItem(array: any[], itemToRemove: any): void;
 
@@ -252,7 +252,7 @@ interface KnockoutUtils {
 
     arrayMap(array: any[], mapping: (item) => any): any[];
 
-    arrayFilter(array: any[], predicate: (item) => bool): any[];
+    arrayFilter(array: any[], predicate: (item) => boolean): any[];
 
     arrayPushAll(array: any[], valuesToPush: any[]): any[];
 
@@ -262,13 +262,13 @@ interface KnockoutUtils {
 
     moveCleanedNodesToContainerElement(nodes: any[]): HTMLElement;
 
-    cloneNodes(nodesArray: any[], shouldCleanNodes: bool): any[];
+    cloneNodes(nodesArray: any[], shouldCleanNodes: boolean): any[];
 
     setDomNodeChildren(domNode: any, childNodes: any[]): void;
 
     replaceDomNodes(nodeToReplaceOrNodeArray: any, newNodesArray: any[]): void;
 
-    setOptionNodeSelectionState(optionNode: any, isSelected: bool): void;
+    setOptionNodeSelectionState(optionNode: any, isSelected: boolean): void;
 
     stringTrim(str: string): string;
 
@@ -276,9 +276,9 @@ interface KnockoutUtils {
 
     stringStartsWith(str: string, startsWith: string): string;
 
-    domNodeIsContainedBy(node: any, containedByNode: any): bool;
+    domNodeIsContainedBy(node: any, containedByNode: any): boolean;
 
-    domNodeIsAttachedToDocument(node: any): bool;
+    domNodeIsAttachedToDocument(node: any): boolean;
 
     tagNameLower(element: any): string;
 
@@ -288,7 +288,7 @@ interface KnockoutUtils {
 
     unwrapObservable(value: any): any;
 
-    toggleDomNodeCssClass(node: any, className: string, shouldHaveClass: bool): void;
+    toggleDomNodeCssClass(node: any, className: string, shouldHaveClass: boolean): void;
 
     //setTextContent(element: any, textContent: string): void; // NOT PART OF THE MINIFIED API SURFACE (ONLY IN knockout-{version}.debug.js) https://github.com/SteveSanderson/knockout/issues/670
 
@@ -314,9 +314,9 @@ interface KnockoutUtils {
 
     ieVersion: number;
 
-    isIe6: bool;
+    isIe6: boolean;
 
-    isIe7: bool;
+    isIe7: boolean;
 }
 
 //////////////////////////////////
@@ -364,7 +364,7 @@ interface KnockoutTemplateEngine extends KnockoutNativeTemplateEngine {
 
     renderTemplate(template, bindingContext, options, templateDocument);
 
-    isTemplateRewritten(template, templateDocument): bool;
+    isTemplateRewritten(template, templateDocument): boolean;
 
     rewriteTemplate(template, rewriterCallback, templateDocument);
 }
@@ -388,11 +388,11 @@ interface KnockoutStatic {
     observableArray: KnockoutObservableArrayStatic;
 
     contextFor(node: any): any;
-    isSubscribable(instance: any): bool;
+    isSubscribable(instance: any): boolean;
     toJSON(viewModel: any, replacer?: Function, space?: any): string;
     toJS(viewModel: any): any;
-    isObservable(instance: any): bool;
-    isComputed(instance: any): bool;
+    isObservable(instance: any): boolean;
+    isComputed(instance: any): boolean;
     dataFor(node: any): any;
     removeNode(node: Element);
     cleanNode(node: Element);

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -94,7 +94,7 @@ interface KnockoutObservableArray<T> extends KnockoutObservableArrayFunctions<T>
 interface KnockoutObservableStatic {
     fn: KnockoutObservableFunctions;
 
-    <T>(value: T): KnockoutObservable<T>;
+    <T>(value?: T): KnockoutObservable<T>;
 }
 
 /** use as method to get/set the value */


### PR DESCRIPTION
Updated to have optional value for ko.observable. Used boolean in place of deprecated bool keyword.
