### PR TITLE
Update async to 0.9

### DIFF
--- a/async/async-tests.ts
+++ b/async/async-tests.ts
@@ -18,10 +18,10 @@ async.series([
     function () { }
 ]);
 
-var data;
-function asyncProcess() { }
+var data = [];
+function asyncProcess(item, callback) { }
 async.map(data, asyncProcess, function (err, results) {
-    alert(results);
+    console.log(results);
 });
 
 var openFiles = ['file1', 'file2'];

--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -5,6 +5,7 @@
 
 interface AsyncMultipleResultsCallback<T> { (err: string, results: T[]): any; }
 interface AsyncSingleResultCallback<T> { (err: string, result: T): any; }
+interface AsyncTimesCallback<T> { (n: number, callback: AsyncMultipleResultsCallback<T>): void; }
 interface AsyncIterator<T> { (item: T, callback: AsyncMultipleResultsCallback<T>): void; }
 interface AsyncMemoIterator<T> { (memo: T, item: T, callback: AsyncSingleResultCallback<T>): void; }
 interface AsyncWorker<T> { (task: T, callback: Function): void; }
@@ -57,11 +58,14 @@ interface Async {
     waterfall<T>(tasks: T[], callback?: AsyncMultipleResultsCallback<T>): void;
     waterfall<T>(tasks: T, callback?: AsyncMultipleResultsCallback<T>): void;
     queue<T>(worker: AsyncWorker<T>, concurrency: number): AsyncQueue<T>;
-    //auto(tasks: any[], callback?: AsyncMultipleResultsCallback<T>): void;
-    auto<T>(tasks: T, callback?: AsyncMultipleResultsCallback<T>): void;
-    iterator(tasks): Function;
+    // auto(tasks: any[], callback?: AsyncMultipleResultsCallback<T>): void;
+    auto(tasks: any, callback?: AsyncMultipleResultsCallback<any>): void;
+    iterator(tasks: Function[]): Function;
     apply(fn: Function, ...arguments: any[]): void;
-    nextTick<T>(callback: AsyncMultipleResultsCallback<T>): void;
+    nextTick<T>(callback: Function): void;
+
+    times<T> (n: number, callback: AsyncTimesCallback<T>): void;
+    timesSeries<T> (n: number, callback: AsyncTimesCallback<T>): void;
 
     // Utils
     memoize(fn: Function, hasher?: Function): Function;

--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -3,65 +3,65 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-
-interface AsyncCallback<T> { (err: string, results: T[]): any; }
-interface AsyncIterator<T> { (item: T, callback: AsyncCallback<T>): void; }
-interface AsyncMemoIterator<T> { (memo: T, item: T, callback: AsyncCallback<T>): void; }
+interface AsyncMultipleResultsCallback<T> { (err: string, results: T[]): any; }
+interface AsyncSingleResultCallback<T> { (err: string, result: T): any; }
+interface AsyncIterator<T> { (item: T, callback: AsyncMultipleResultsCallback<T>): void; }
+interface AsyncMemoIterator<T> { (memo: T, item: T, callback: AsyncSingleResultCallback<T>): void; }
 interface AsyncWorker<T> { (task: T, callback: Function): void; }
 
 interface AsyncQueue<T> {
     length(): number;
     concurrency: number;
-    push(task: T, callback: AsyncCallback<T>): void;
-    saturated: AsyncCallback<T>;
-    empty: AsyncCallback<T>;
-    drain: AsyncCallback<T>;
+    push(task: T, callback: AsyncMultipleResultsCallback<T>): void;
+    saturated: AsyncMultipleResultsCallback<T>;
+    empty: AsyncMultipleResultsCallback<T>;
+    drain: AsyncMultipleResultsCallback<T>;
 }
 
 interface Async {
 
     // Collections
-    forEach<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>): void;
-    forEachSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>): void;
-    forEachLimit<T>(arr: T[], limit: number, iterator: AsyncIterator<T>, callback: AsyncCallback<T>): void;
-    map<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
-    mapSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
-    filter<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
-    select<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
-    filterSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
-    selectSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
-    reject<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
-    rejectSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
-    reduce<T>(arr: T[], memo: T, iterator: AsyncMemoIterator<T>, callback: AsyncCallback<T>);
-    inject<T>(arr: T[], memo: T, iterator: AsyncMemoIterator<T>, callback: AsyncCallback<T>);
-    foldl<T>(arr: T[], memo: T, iterator: AsyncMemoIterator<T>, callback: AsyncCallback<T>);
-    reduceRight<T>(arr: T[], memo: T, iterator: AsyncMemoIterator<T>, callback: AsyncCallback<T>);
-    foldr<T>(arr: T[], memo: T, iterator: AsyncMemoIterator<T>, callback: AsyncCallback<T>);
-    detect<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
-    detectSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
-    sortBy<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
-    some<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
-    any<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
-    every<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
-    all<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
-    concat<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
-    concatSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    forEach<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>): void;
+    forEachSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>): void;
+    forEachLimit<T>(arr: T[], limit: number, iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>): void;
+    map<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>);
+    mapSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>);
+    filter<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>);
+    select<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>);
+    filterSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>);
+    selectSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>);
+    reject<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>);
+    rejectSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>);
+    reduce<T>(arr: T[], memo: T, iterator: AsyncMemoIterator<T>, callback: AsyncSingleResultCallback<T>);
+    inject<T>(arr: T[], memo: T, iterator: AsyncMemoIterator<T>, callback: AsyncSingleResultCallback<T>);
+    foldl<T>(arr: T[], memo: T, iterator: AsyncMemoIterator<T>, callback: AsyncSingleResultCallback<T>);
+    reduceRight<T>(arr: T[], memo: T, iterator: AsyncMemoIterator<T>, callback: AsyncSingleResultCallback<T>);
+    foldr<T, U>(arr: T[], memo: T, iterator: AsyncMemoIterator<T>, callback: AsyncSingleResultCallback<T>);
+    detect<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>);
+    detectSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>);
+    sortBy<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>);
+    some<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>);
+    any<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>);
+    every<T>(arr: T[], iterator: AsyncIterator<T>, callback: (result: boolean) => any);
+    all<T>(arr: T[], iterator: AsyncIterator<T>, callback: (result: boolean) => any);
+    concat<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>);
+    concatSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncMultipleResultsCallback<T>);
 
     // Control Flow
-    series<T>(tasks: T[], callback?: AsyncCallback<T>): void;
-    series<T>(tasks: T, callback?: AsyncCallback<T>): void;
-    parallel<T>(tasks: T[], callback?: AsyncCallback<T>): void;
-    parallel<T>(tasks: T, callback?: AsyncCallback<T>): void;
-    whilst(test: Function, fn: Function, callback: AsyncCallback): void; // TODO: generify
-    until(test: Function, fn: Function, callback: AsyncCallback): void; // TODO: generify
-    waterfall<T>(tasks: T[], callback?: AsyncCallback<T>): void;
-    waterfall<T>(tasks: T, callback?: AsyncCallback<T>): void;
+    series<T>(tasks: T[], callback?: AsyncMultipleResultsCallback<T>): void;
+    series<T>(tasks: T, callback?: AsyncMultipleResultsCallback<T>): void;
+    parallel<T>(tasks: T[], callback?: AsyncMultipleResultsCallback<T>): void;
+    parallel<T>(tasks: T, callback?: AsyncMultipleResultsCallback<T>): void;
+    whilst(test: Function, fn: Function, callback: Function): void;
+    until(test: Function, fn: Function, callback: Function): void;
+    waterfall<T>(tasks: T[], callback?: AsyncMultipleResultsCallback<T>): void;
+    waterfall<T>(tasks: T, callback?: AsyncMultipleResultsCallback<T>): void;
     queue<T>(worker: AsyncWorker<T>, concurrency: number): AsyncQueue<T>;
-    //auto(tasks: any[], callback?: AsyncCallback<T>): void;
-    auto<T>(tasks: T, callback?: AsyncCallback<T>): void;
+    //auto(tasks: any[], callback?: AsyncMultipleResultsCallback<T>): void;
+    auto<T>(tasks: T, callback?: AsyncMultipleResultsCallback<T>): void;
     iterator(tasks): Function;
     apply(fn: Function, ...arguments: any[]): void;
-    nextTick<T>(callback: AsyncCallback<T>): void;
+    nextTick<T>(callback: AsyncMultipleResultsCallback<T>): void;
 
     // Utils
     memoize(fn: Function, hasher?: Function): Function;

--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -1,67 +1,67 @@
-// Type definitions for Async 0.1
+// Type definitions for Async 0.1.23
 // Project: https://github.com/caolan/async
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 
-interface AsyncCallback { (err: string, results: any): any; }
-interface AsyncIterator { (item, callback: AsyncCallback): void; }
-interface AsyncMemoIterator { (memo: any, item: any, callback: AsyncCallback): void; }
-interface AsyncWorker { (task: any, callback: Function): void; }
+interface AsyncCallback<T> { (err: string, results: T[]): any; }
+interface AsyncIterator<T> { (item: T, callback: AsyncCallback<T>): void; }
+interface AsyncMemoIterator<T> { (memo: T, item: T, callback: AsyncCallback<T>): void; }
+interface AsyncWorker<T> { (task: T, callback: Function): void; }
 
-interface AsyncQueue {
+interface AsyncQueue<T> {
     length(): number;
     concurrency: number;
-    push(task: any, callback: AsyncCallback): void;
-    saturated: AsyncCallback;
-    empty: AsyncCallback;
-    drain: AsyncCallback;
+    push(task: T, callback: AsyncCallback<T>): void;
+    saturated: AsyncCallback<T>;
+    empty: AsyncCallback<T>;
+    drain: AsyncCallback<T>;
 }
 
 interface Async {
 
     // Collections
-    forEach(arr: any[], iterator: AsyncIterator, callback: AsyncCallback): void;
-    forEachSeries(arr: any[], iterator: AsyncIterator, callback: AsyncCallback): void;
-    forEachLimit(arr: any[], limit: number, iterator: AsyncIterator, callback: AsyncCallback): void;
-    map(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
-    mapSeries(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
-    filter(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
-    select(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
-    filterSeries(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
-    selectSeries(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
-    reject(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
-    rejectSeries(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
-    reduce(arr: any[], memo: any, iterator: AsyncMemoIterator, callback: AsyncCallback);
-    inject(arr: any[], memo: any, iterator: AsyncMemoIterator, callback: AsyncCallback);
-    foldl(arr: any[], memo: any, iterator: AsyncMemoIterator, callback: AsyncCallback);
-    reduceRight(arr: any[], memo: any, iterator: AsyncMemoIterator, callback: AsyncCallback);
-    foldr(arr: any[], memo: any, iterator: AsyncMemoIterator, callback: AsyncCallback);
-    detect(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
-    detectSeries(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
-    sortBy(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
-    some(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
-    any(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
-    every(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
-    all(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
-    concat(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
-    concatSeries(arr: any[], iterator: AsyncIterator, callback: AsyncCallback);
+    forEach<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>): void;
+    forEachSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>): void;
+    forEachLimit<T>(arr: T[], limit: number, iterator: AsyncIterator<T>, callback: AsyncCallback<T>): void;
+    map<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    mapSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    filter<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    select<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    filterSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    selectSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    reject<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    rejectSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    reduce<T>(arr: T[], memo: T, iterator: AsyncMemoIterator<T>, callback: AsyncCallback<T>);
+    inject<T>(arr: T[], memo: T, iterator: AsyncMemoIterator<T>, callback: AsyncCallback<T>);
+    foldl<T>(arr: T[], memo: T, iterator: AsyncMemoIterator<T>, callback: AsyncCallback<T>);
+    reduceRight<T>(arr: T[], memo: T, iterator: AsyncMemoIterator<T>, callback: AsyncCallback<T>);
+    foldr<T>(arr: T[], memo: T, iterator: AsyncMemoIterator<T>, callback: AsyncCallback<T>);
+    detect<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    detectSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    sortBy<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    some<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    any<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    every<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    all<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    concat<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
+    concatSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: AsyncCallback<T>);
 
     // Control Flow
-    series(tasks: any[], callback?: AsyncCallback): void;
-    series(tasks: any, callback?: AsyncCallback): void;
-    parallel(tasks: any[], callback?: AsyncCallback): void;
-    parallel(tasks: any, callback?: AsyncCallback): void;
-    whilst(test: Function, fn: Function, callback: AsyncCallback): void;
-    until(test: Function, fn: Function, callback: AsyncCallback): void;
-    waterfall(tasks: any[], callback?: AsyncCallback): void;
-    waterfall(tasks: any, callback?: AsyncCallback): void;
-    queue(worker: AsyncWorker, concurrency: number): AsyncQueue;
-    //auto(tasks: any[], callback?: AsyncCallback): void;
-    auto(tasks: any, callback?: AsyncCallback): void;
+    series<T>(tasks: T[], callback?: AsyncCallback<T>): void;
+    series<T>(tasks: T, callback?: AsyncCallback<T>): void;
+    parallel<T>(tasks: T[], callback?: AsyncCallback<T>): void;
+    parallel<T>(tasks: T, callback?: AsyncCallback<T>): void;
+    whilst(test: Function, fn: Function, callback: AsyncCallback): void; // TODO: generify
+    until(test: Function, fn: Function, callback: AsyncCallback): void; // TODO: generify
+    waterfall<T>(tasks: T[], callback?: AsyncCallback<T>): void;
+    waterfall<T>(tasks: T, callback?: AsyncCallback<T>): void;
+    queue<T>(worker: AsyncWorker<T>, concurrency: number): AsyncQueue<T>;
+    //auto(tasks: any[], callback?: AsyncCallback<T>): void;
+    auto<T>(tasks: T, callback?: AsyncCallback<T>): void;
     iterator(tasks): Function;
     apply(fn: Function, ...arguments: any[]): void;
-    nextTick(callback: AsyncCallback): void;
+    nextTick<T>(callback: AsyncCallback<T>): void;
 
     // Utils
     memoize(fn: Function, hasher?: Function): Function;


### PR DESCRIPTION
Adds generic parameters to async.js typings.

TODO - The code in async-tests.ts is a bit funny. I'm going to port the test suite from async.js to typescript 0.9 and submit a separate pull request to add better tests.

TODO - Also, I'm gonna audit the current async.js API to make sure we've supplied typings all exported methods.
