### PR TITLE
Upgrade knockback definition to 0.9.

### DIFF
--- a/knockback/knockback.d.ts
+++ b/knockback/knockback.d.ts
@@ -2,37 +2,37 @@
 /// <reference path="../knockout/knockout.d.ts" />
 
 declare module Knockback {
-    export interface EventWatcherOptions {
+    interface EventWatcherOptions {
         emitter: (newEmitter) => void;
         update: (newValue) => void;
         event_selector: string;
         key?: string;
     }
 
-    export interface FactoryOptions {
+    interface FactoryOptions {
         factories: any;
     }
 
-    export interface StoreOptions {
+    interface StoreOptions {
         creator: any;
         path: string;
         store: Store;
         factory: Factory;
     }
 
-    export class Destroyable {
+    class Destroyable {
         destroy();
     }
 
-    export class ViewModel extends Destroyable {
+    class ViewModel extends Destroyable {
         constructor (model?: Backbone.Model, options?: ViewModelOptions, viewModel?: ViewModel);
         shareOptions(): ViewModelOptions;
         extend(source: any);
         model(): Backbone.Model;
     }
 
-    export class EventWatcher extends Destroyable {
-        static useOptionsOrCreate(options, emitter: KnockoutObservableAny, obj: Backbone.Model, callback_options: any);
+    class EventWatcher extends Destroyable {
+        static useOptionsOrCreate(options, emitter: KnockoutObservable<any>, obj: Backbone.Model, callback_options: any);
         
         emitter(): Backbone.Model;
         emitter(newEmitter: Backbone.Model);
@@ -40,7 +40,7 @@ declare module Knockback {
         releaseCallbacks(obj: any);
     }
 
-    export class Factory {
+    class Factory {
         static useOptionsOrCreate(options: FactoryOptions, obj: any, owner_path: string);
 
         constructor (parent_factory: any);
@@ -51,39 +51,39 @@ declare module Knockback {
         creatorForPath(obj: any, path: string);
     }
 
-    export class Store extends Destroyable {
-        static useOptionsOrCreate(options: StoreOptions, obj: any, observable: KnockoutObservableAny);
+    class Store extends Destroyable {
+        static useOptionsOrCreate(options: StoreOptions, obj: any, observable: KnockoutObservable<any>);
         
         constructor (model:Backbone.Model, options: StoreOptions);
         clear();
-        register(obj: Backbone.Model, observable: KnockoutObservableAny, options: StoreOptions);
+        register(obj: Backbone.Model, observable: KnockoutObservable<any>, options: StoreOptions);
         findOrCreate(obj: Backbone.Model, options: StoreOptions);
     }
 
-    export class DefaultObservable extends Destroyable {
-        constructor (targetObservable: KnockoutObservableAny, defaultValue: any);
+    class DefaultObservable extends Destroyable {
+        constructor (targetObservable: KnockoutObservable<any>, defaultValue: any);
         setToDefault();
     }
 
-    export class FormattedObservable extends Destroyable {
+    class FormattedObservable extends Destroyable {
         constructor (format: string, args: any[]);
-        constructor (format: KnockoutObservableAny, args: any[]);
+        constructor (format: KnockoutObservable<any>, args: any[]);
     }
 
-    export interface LocalizedObservable {
+    interface LocalizedObservable {
         constructor (value: any, options: any, vm: any);
         destroy();
         resetToCurrent();
         observedValue(value: any);
     }
 
-    export class TriggeredObservable extends Destroyable {
+    class TriggeredObservable extends Destroyable {
         constructor (emitter: Backbone.ModelBase, event: string);
         emitter(): Backbone.ModelBase;
         emitter(newEmitter: Backbone.ModelBase);
     }
 
-    export class Statistics {
+    class Statistics {
         constructor ();
         clear();
         addModelEvent(event: string);
@@ -94,14 +94,14 @@ declare module Knockback {
         registeredStatsString(success_message: string): string;
     }
 
-    export interface OptionsBase {
+    interface OptionsBase {
         path?: string;               // the path to the value (used to create related observables from the factory).
         store?: Store;               // a store used to cache and share view models.
         factory?: Factory;           // a factory used to create view models.
         options?: any;               // a set of options merge into these options using _.defaults. Useful for extending options when deriving classes rather than merging them by hand.
     }
 
-    export interface ViewModelOptions extends OptionsBase {
+    interface ViewModelOptions extends OptionsBase {
         internals?: string[];       // an array of atttributes that should be scoped with an underscore, eg. name -> _name
         requires?: string[];        // an array of atttributes that will have kb.Observables created even if they do not exist on the Backbone.Model. Useful for binding Views that require specific observables to exist
         keys?: string[];            // restricts the keys used on a model. Useful for reducing the number of kb.Observables created from a limited set of Backbone.Model attributes
@@ -110,7 +110,7 @@ declare module Knockback {
         factories?: any;            // a map of dot-deliminated paths; for example {'models.name': kb.ViewModel} to either constructors or create functions. Signature: {'some.path': function(object, options)}
     }
 
-    export interface CollectionOptions extends OptionsBase {
+    interface CollectionOptions extends OptionsBase {
         models_only?: bool;         // flag for skipping the creation of view models. The collection observable will be populated with (possibly sorted) models.
         view_model?: any;           // (Constructor) — the view model constructor used for models in the collection. Signature: constructor(model, options)
         create?: any;               // a function used to create a view model for models in the collection. Signature: create(model, options)
@@ -120,7 +120,7 @@ declare module Knockback {
         filters?: any;              // filters can be individual ids (observable or simple) or arrays of ids, functions, or arrays of functions.
     }
 
-    export interface CollectionObservable extends KnockoutObservableArray {
+    interface CollectionObservable extends KnockoutObservableArray<any> {
         collection(colleciton: Backbone.Collection);
         collection(): Backbone.Collection;
         destroy();
@@ -134,7 +134,7 @@ declare module Knockback {
         hasViewModels(): bool;
     }
 
-    export interface Utils {
+    interface Utils {
         wrappedObservable(obj: any): any;
         wrappedObservable(obj: any, value: any);
         wrappedObject(obj: any): any;
@@ -148,7 +148,7 @@ declare module Knockback {
         wrappedEventWatcher(obj: any): any;
         wrappedEventWatcher(obj: any, value: any);
         wrappedDestroy(obj: any);
-        valueType(observable: KnockoutObservableAny): any;
+        valueType(observable: KnockoutObservable<any>): any;
         pathJoin(path1: string, path2: string): string;
         optionsPathJoin(options: any, path: string): any;
         inferCreator(value: any, factory: Factory, path: string, owner: any, key: string);
@@ -157,7 +157,7 @@ declare module Knockback {
         hasCollectionSignature(obj: any): bool;
     }
 
-    export interface Static extends Utils {
+    interface Static extends Utils {
     	collectionObservable(model?: Backbone.Collection, options?: CollectionOptions): CollectionObservable;
     	/** Base class for observing model attributes. */
     	observable(
@@ -166,19 +166,19 @@ declare module Knockback {
 			/** the create options. String is a single attribute name, Array is an array of attribute names. */
 				options: IObservableOptions,
 			/** the viewModel */
-			vm?: ViewModel): KnockoutObservableAny;
+			vm?: ViewModel): KnockoutObservable<any>;
         observable(
 			/** the model to observe (can be null) */
         	model: Backbone.Model,
     		/** the create options. String is a single attribute name, Array is an array of attribute names. */
         	options_attributeName: string,
 			/** the viewModel */
-			vm?: ViewModel): KnockoutObservableAny;
-        viewModel(model?: Backbone.Model, options?: any): KnockoutObservableAny;
-        defaultObservable(targetObservable: KnockoutObservableAny, defaultValue: any): KnockoutObservableAny;
-        formattedObservable(format: string, args: any[]): KnockoutObservableAny;
-        formattedObservable(format: KnockoutObservableAny, args: any[]): KnockoutObservableAny;
-        localizedObservable(data: any, options: any): KnockoutObservableAny;
+			vm?: ViewModel): KnockoutObservable<any>;
+        viewModel(model?: Backbone.Model, options?: any): KnockoutObservable<any>;
+        defaultObservable(targetObservable: KnockoutObservable<any>, defaultValue: any): KnockoutObservable<any>;
+        formattedObservable(format: string, args: any[]): KnockoutObservable<any>;
+        formattedObservable(format: KnockoutObservable<any>, args: any[]): KnockoutObservable<any>;
+        localizedObservable(data: any, options: any): KnockoutObservable<any>;
         release(object: any, pre_release?: () => void );
         releaseKeys(object: any);
         releaseOnNodeRemove(viewmodel: ViewModel, node: Element);
@@ -204,7 +204,7 @@ declare module Knockback {
     	key: string;
     	read?: () => any;
     	write?: (value: any) => void;
-    	args?: KnockoutObservableAny[];
+    	args?: KnockoutObservable<any>[];
     	localizer?: LocalizedObservable;
     	default?: any;
     	path?: string;
@@ -213,6 +213,6 @@ declare module Knockback {
     	options?: any;
     }
 
-};
+}
 
 declare var kb: Knockback.Static;


### PR DESCRIPTION
- Remove unnecessary exports.
- Remove semicolon at the end of module.
- Basic migration to new Knockout's generics implementation.
