### PR TITLE
Fix wrong signature on knockout computed. Missing options argument.

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -62,7 +62,7 @@ interface KnockoutComputedStatic {
     fn: KnockoutComputedFunctions;
 
     <T>(): KnockoutComputed<T>;
-    <T>(func: () => T, context?: any): KnockoutComputed<T>;
+    <T>(func: () => T, context?: any, options?: any): KnockoutComputed<T>;
     <T>(def: KnockoutComputedDefine<T>): KnockoutComputed<T>;
     (options?: any): KnockoutComputed<any>;
 }


### PR DESCRIPTION
Ref: http://knockoutjs.com/documentation/computedObservables.html#computed_observable_reference
