### PR TITLE
Improvements to the underscore definition.

### DIFF
--- a/underscore/underscore-tests.ts
+++ b/underscore/underscore-tests.ts
@@ -215,7 +215,6 @@ _.mixin({
         return string.charAt(0).toUpperCase() + string.substring(1).toLowerCase();
     }
 });
-_("fabio").capitalize();
 
 _.uniqueId('contact_');
 

--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -3,14 +3,10 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare function _(value): any;
+declare function _<T>(value: Array<T>): _<T>;
+declare function _<T>(value: T): _<T>;
 
 declare module _ {
-
-    interface UnderscoreWrappedObject {
-        value(): any;
-        filter(arg?): any;
-    }
 
     interface TemplateSettings {
         evaluate?: RegExp;
@@ -81,7 +77,6 @@ declare module _ {
     export function pluck<T>(list: Collection<T>, propertyName: string): any[];
 
     export function max<T>(list: Collection<T>, iterator?: (x: T) => any, context?: any): T;
-
     export function min<T>(list: Collection<T>, iterator?: (x: T) => any, context?: any): T;
 
     export function sortBy<T>(list: List<T>, iterator?: (x: T) => any, context?: any): T[];
@@ -116,18 +111,18 @@ declare module _ {
     export function take<T>(array: List<T>, n: number): T[];
 
     export function initial<T>(array: List<T>, n?: number): T[];
-    
+
     export function last<T>(array: List<T>): T;
     export function last<T>(array: List<T>, n: number): T[];
-    
+
     export function rest<T>(array: List<T>, n?: number): T[];
     export function tail<T>(array: List<T>, n?: number): T[];
     export function drop<T>(array: List<T>, n?: number): T[];
-    
+
     export function compact<T>(array: List<T>): T[];
 
     export function flatten(array: any[], shallow?: boolean): any[];
-    
+
     export function without<T>(array: List<T>, ...values: T[]): T[];
 
     export function union<T>(...arrays: List<T>[]): T[];
@@ -138,18 +133,18 @@ declare module _ {
 
     export function uniq<T>(array: List<T>, isSorted?: boolean, iterator?: (x: T) => any): T[];
     export function unique<T>(array: List<T>, isSorted?: boolean, iterator?: (x: T) => any): T[];
-    
+
     export function zip(...arrays: any[]): any[];
 
     export function object(list: any[], values?: any): any;
-    
+
     export function indexOf<T>(array: List<T>, value: T, isSorted?: boolean): number;
     export function indexOf<T>(array: List<T>, value: T, startFrom: number): number;
 
     export function lastIndexOf<T>(array: List<T>, value: T, fromIndex?: number): number;
-    
+
     export function sortedIndex<T>(list: List<T>, value: T, iterator?: (x: T) => any, context?: any): number;
-    
+
     export function range(stop: number): any[];
     export function range(start: number, stop: number, step?: number): any[];
 
@@ -168,7 +163,7 @@ declare module _ {
     export function after(count: number, func: any): any;
     export function wrap(func: (...as: any[]) => any, wrapper: any): () => any;
     export function compose(...functions: any[]): any;
-    
+
     /****
         Objects
     *****/
@@ -179,10 +174,12 @@ declare module _ {
     export function functions(object: any): string[];
     export function methods(object: any): string[];
     export function extend(destination: any, ...sources: any[]): any;
+    export function pick(object: any, keys: string[]): any;
     export function pick(object: any, ...keys: string[]): any;
+    export function omit(object: any, keys: string[]): any;
     export function omit(object: any, ...keys: string[]): any;
     export function defaults(object: any, ...defaults: any[]): any;
-    export function clone(object: any): any;
+    export function clone<T>(object: T): T;
     export function tap(object: any, interceptor: (...as: any[]) => any): any;
     export function has(object: any, key: string): boolean;
     export function isEqual(object: any, other: any): boolean;
@@ -220,7 +217,169 @@ declare module _ {
     /****
         Chaining
     *****/
-    export function chain(object: any): UnderscoreWrappedObject;
+    export function chain(object): any;
+}
+
+declare class _<T> {
+
+    each(iterator: _.ListIterator<T, void >, context?: any): void;
+    forEach(iterator: _.ListIterator<T, void >, context?: any): void;
+
+    map<TResult>(iterator: _.ListIterator<T, TResult>, context?: any): TResult[];
+    collect<TResult>(iterator: _.ListIterator<T, TResult>, context?: any): TResult[];
+
+    reduce<T, TResult>(iterator: (prev: TResult, curr: T) => TResult, memo: TResult, context?: any): TResult;
+    inject<T, TResult>(iterator: (prev: TResult, curr: T) => TResult, memo: TResult, context?: any): TResult;
+
+    reduceRight<T, TResult>(iterator: (prev: TResult, curr: T) => TResult, memo: TResult, context?: any): TResult;
+    foldr<T, TResult>(iterator: (prev: TResult, curr: T) => TResult, memo: TResult, context?: any): TResult;
+
+    find<T>(iterator: (x: T) => boolean, context?: any): T;
+    detect<T>(iterator: (x: T) => boolean, context?: any): T;
+
+    filter<T>(iterator: (x: T) => boolean, context?: any): T[];
+    select<T>(iterator: (x: T) => boolean, context?: any): T[];
+
+    where<T>(properties: any): T[];
+
+    reject<T>(iterator: (x: T) => boolean, context?: any): T[];
+
+    all<T>(iterator: (x: T) => boolean, context?: any): boolean;
+    every<T>(iterator: (x: T) => boolean, context?: any): boolean;
+
+    any<T>(iterator?: (x: T) => boolean, context?: any): boolean;
+    some<T>(iterator?: (x: T) => boolean, context?: any): boolean;
+
+    contains<T>(value: T): boolean;
+    include<T>(value: T): boolean;
+
+    invoke<T>(methodName: string, ...arguments: any[]): any;
+
+    pluck<T>(propertyName: string): any[];
+
+    max<T>(iterator?: (x: T) => any, context?: any): T;
+    min<T>(iterator?: (x: T) => any, context?: any): T;
+
+    sortBy<T>(iterator?: (x: T) => any, context?: any): T[];
+    sortBy<T>(iterator: string, context?: any): T[];
+
+    groupBy<T>(iterator?: (x: T) => any, context?: any): _.Dictionary<_.List<T>>;
+    groupBy<T>(iterator: string, context?: any): _.Dictionary<_.List<T>>;
+
+    countBy<T>(iterator?: (x: T) => any, context?: any): _.Dictionary<_.List<number>>;
+    countBy<T>(iterator: string, context?: any): _.Dictionary<_.List<number>>;
+
+    shuffle<T>(): T[];
+
+    toArray<T>(): T[];
+
+    size<T>(): number;
+
+    /****
+        Arrays
+    *****/
+    first<T>(n?: number): T[];
+    head<T>(n?: number): T[];
+    take<T>(n?: number): T[];
+    initial<T>(n?: number): T[];
+    last<T>(n?: number): T[];
+    rest<T>(n?: number): T[];
+    tail<T>(n?: number): T[];
+    drop<T>(n?: number): T[];
+
+    compact<T>(): T[];
+
+    flatten(shallow?: boolean): any[];
+
+    without<T>(...values: T[]): T[];
+
+    union<T>(...arrays: _.List<T>[]): T[];
+
+    intersection<T>(...arrays: _.List<T>[]): T[];
+
+    difference<T>(...others: _.List<T>[]): T[];
+
+    uniq<T>(isSorted?: boolean, iterator?: (x: T) => any): T[];
+    unique<T>(isSorted?: boolean, iterator?: (x: T) => any): T[];
+
+    zip(...arrays: any[]): any[];
+
+    object(values?: any): any;
+
+    indexOf<T>(value: T, isSorted?: boolean): number;
+    indexOf<T>(value: T, startFrom: number): number;
+
+    lastIndexOf<T>(value: T, fromIndex?: number): number;
+
+    sortedIndex<T>(value: T, iterator?: (x: T) => any, context?: any): number;
+
+    /****
+        Functions
+    *****/
+    bind(func: (...as: any[]) => any, context: any, ...arguments: any[]): () => any;
+    bindAll(...methodNames: string[]): any;
+    memoize(hashFunction?: any): any;
+    defer();
+    delay(wait: number, ...arguments: any[]): any;
+    delay(...arguments: any[]): any;
+    throttle(wait: number): any;
+    debounce(wait: number, immediate?: boolean): any;
+    once(): any;
+    after(func: any): any;
+    wrap(wrapper: any): () => any;
+    compose(...functions: any[]): any;
+
+    /****
+        Objects
+    *****/
+    keys(): string[];
+    values<T>(): T[];
+    pairs(): any[];
+    invert(): any;
+    functions(): string[];
+    methods(): string[];
+    extend(...sources: any[]): any;
+    pick(keys: string[]): any;
+    pick(...keys: string[]): any;
+    omit(keys: string[]): any;
+    omit(...keys: string[]): any;
+    defaults(...defaults: any[]): any;
+    clone(): T;
+    tap(interceptor: (...as: any[]) => any): any;
+    has(key: string): boolean;
+    isEqual(other: any): boolean;
+    isEmpty(): boolean;
+    isElement(): boolean;
+    isArray(): boolean;
+    isObject(): boolean;
+    isArguments(): boolean;
+    isFunction(): boolean;
+    isString(): boolean;
+    isNumber(): boolean;
+    isFinite(): boolean;
+    isBoolean(): boolean;
+    isDate(): boolean;
+    isRegExp(): boolean;
+    isNaN(): boolean;
+    isNull(): boolean;
+    isUndefined(): boolean;
+
+    /****
+        Utility
+    *****/
+    identity(): any;
+    times(iterator: (index: number) => void , context?: any): void;
+    random(max: number): number;
+    mixin(): void;
+    uniqueId(): string;
+    escape(): string;
+    result(property: string): any;
+    template(data?: any, settings?: any): (...data: any[]) => string;
+
+    /****
+        Chaining
+    *****/
+    chain(): any;
 }
 
 declare module "underscore" {


### PR DESCRIPTION
- Added the OOP version of underscore _(value).
- Pick/Omit accept arrays as well as list of arguments.
- Clone of T now returns T instead of any.
- Removed UnderscoreWrappedObject. It was just a hack to make the test work. Now chain() returns any.
- Test can't test the result of mixin, as new there is the function _() returning the underscore object.
