### PR TITLE
Fix for 0.9 compatibility and bugfix for 'on' callback.

### DIFF
--- a/signalr/signalr.d.ts
+++ b/signalr/signalr.d.ts
@@ -65,7 +65,7 @@ interface HubProxy {
     (connection: HubConnection, hubName: string): HubProxy;
     init(connection: HubConnection, hubName: string): void;
     hasSubscriptions(): bool;
-    on(eventName: string, callback: (msg) => void ): HubProxy;
+    on(eventName: string, callback: (...msg) => void ): HubProxy;
     off(eventName: string, callback: (msg) => void ): HubProxy;
     invoke(methodName: string, ...args: any[]): JQueryDeferred;
 }
@@ -79,7 +79,7 @@ interface HubConnectionSettings {
 interface HubConnection extends SignalR {
     //(url?: string, queryString?: any, logging?: bool): HubConnection;
     proxies;
-    received(callback: (data: { Id; Method; Hub; State; Args; }) => void ): void;
+    received(callback: (data: { Id; Method; Hub; State; Args; }) => void ): HubConnection;
     createHubProxy(hubName: string): HubProxy;
 }
 


### PR DESCRIPTION
Changed the return type of HubConnection.received to match SignalR.received
The 'on' callback can take a variable number of arguments
