### PR TITLE
Corrected Type Heirarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ List of Definitions
 * [JWPlayer](http://developer.longtailvideo.com/trac/) (by [Martin Duparc](https://github.com/martinduparc/))
 * [KeyboardJS](https://github.com/RobertWHurst/KeyboardJS) (by [Vincent Bortone](https://github.com/vbortone/))
 * [Knockback](http://kmalakoff.github.com/knockback/) (by [Marcel Binot](https://github.com/docgit))
-* [Knockout.js](http://knockoutjs.com/) (by [Boris Yankov](https://github.com/borisyankov))
+* [Knockout.js](http://knockoutjs.com/) (by [Thomas Butler](https://github.com/butlersoftware))
 * [Knockout.Mapping](https://github.com/SteveSanderson/knockout.mapping) (by [Boris Yankov](https://github.com/borisyankov))
 * [Knockout.Postbox](https://github.com/rniemeyer/knockout-postbox) (by [Judah Gabriel](https://github.com/JudahGabriel))
 * [Knockout.Validation](https://github.com/ericmbarnard/Knockout-Validation) (by [Dan Ludwig](https://github.com/danludwig))

--- a/knockout/all-tests.ts
+++ b/knockout/all-tests.ts
@@ -1,2 +1,3 @@
 /// <reference path="tests/knockout-tests.ts" />
 /// <reference path="tests/knockout-templatingBehaviors-tests.ts" />
+/// <reference path="tests/knockout-generics-tests.ts" />

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -24,7 +24,7 @@ interface KnockoutSubscribableStatic {
 
 
 
-interface KnockoutObservableFunctions<T> extends KnockoutSubscribableFunctions<T> {
+interface KnockoutObservableFunctions<T> {
     equalityComparer(a:T, b:T): boolean;
 }
 interface KnockoutObservable<T> extends KnockoutSubscribable<T>, KnockoutObservableFunctions<T> {
@@ -43,12 +43,12 @@ interface KnockoutObservableStatic {
 
 
 
-interface KnockoutObservableArrayFunctions<T> extends KnockoutObservableFunctions {
+interface KnockoutObservableArrayFunctions<T> {
     destroy(predicate: (value: T) => boolean);
     destroyAll(values: Array<T>);
     indexOf(searchElement: T, fromIndex?: number): number;
     pop():T;
-    push(...items: T[]): void;
+    push(...values: T[]): void;
     remove(value: T);
     remove(predicate: (value: T) => boolean);
     removeAll(values?: T[]): T[];
@@ -57,15 +57,10 @@ interface KnockoutObservableArrayFunctions<T> extends KnockoutObservableFunction
     shift():T;
     slice(start: number, end?: number): T[];
     sort(compareFunction?: (a: T, b: T) => number): T[];
-    splice(start: number, deleteCount?: number, ...items: T[]): T[];
-    unshift(...items: T[]): number;
+    splice(start: number, deleteCount?: number, ...values: T[]): T[];
+    unshift(...values: T[]): number;
 }
-interface KnockoutObservableArray<T> extends KnockoutObservableArrayFunctions<T> {
-    (): T[];
-    (value: T[]): void;
-
-    subscribe(callback: (newValue: T[]) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite: T[], topic?: string);
+interface KnockoutObservableArray<T> extends KnockoutObservable<Array<T>>, KnockoutObservableArrayFunctions<T> {
 }
 interface KnockoutObservableArrayStatic {
     fn: KnockoutObservableArrayFunctions<any>;

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -61,6 +61,31 @@ interface KnockoutObservableArrayFunctions<T> {
     unshift(...values: T[]): number;
 }
 interface KnockoutObservableArray<T> extends KnockoutObservable<Array<T>>, KnockoutObservableArrayFunctions<T> {
+    //#region I SHOULDN'T HAVE TO DO THIS -- LINGERING BUG IN TYPESCRIPT?
+
+    /*****************************************************************************/
+    /**************************    HACK    ***************************************/
+    //these members should be inheriting from KnockoutObservableArrayFunctions
+    destroy(predicate: (value: T) => boolean);
+    destroy(value: T);
+    destroyAll(values?: Array<T>);
+    indexOf(searchElement: T, fromIndex?: number): number;
+    pop(): T;
+    push(...values: T[]): void;
+    remove(value: T);
+    remove(predicate: (value: T) => boolean);
+    removeAll(values?: T[]): T[];
+    replace(oldItem: T, newItem: T): void;
+    reverse(): T[];
+    shift(): T;
+    slice(start: number, end?: number): T[];
+    sort(compareFunction?: (a: T, b: T) => number): T[];
+    splice(start: number, deleteCount?: number, ...values: T[]): T[];
+    unshift(...values: T[]): number;
+    /*******************************************************************************/
+    /*******************************************************************************/
+
+    //#endregion
 }
 interface KnockoutObservableArrayStatic {
     fn: KnockoutObservableArrayFunctions<any>;

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -13,7 +13,7 @@ interface KnockoutSubscribableFunctions {
 }
 interface KnockoutSubscribable<T> extends KnockoutSubscribableFunctions {
     subscribe(callback: (newValue: T) => void , callbackTarget?: any, event?: string): KnockoutSubscription;
-    notifySubscribers(valueToNotify: T, event: string): void;
+    notifySubscribers(valueToNotify: T, event?: string): void;
     getSubscriptionsCount(): number;
     extend(requestedExtenders): any;
 }

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -176,14 +176,14 @@ interface KnockoutMemoization {
 interface KnockoutVirtualElement {}
 
 interface KnockoutVirtualElements {
-	allowedBindings: { [bindingName: string]: boolean; };
-	emptyNode( e: KnockoutVirtualElement );
-	firstChild( e: KnockoutVirtualElement );
-	insertAfter( container: KnockoutVirtualElement, nodeToInsert: HTMLElement, insertAfter: HTMLElement );
-	nextSibling( e: KnockoutVirtualElement );
-	prepend( e: KnockoutVirtualElement, toInsert: HTMLElement );
-	setDomNodeChildren( e: KnockoutVirtualElement, newChildren: { length: number;[index: number]: HTMLElement; } );
-	childNodes( e: KnockoutVirtualElement ): HTMLElement[];
+    allowedBindings: { [bindingName: string]: boolean; };
+    emptyNode( e: KnockoutVirtualElement );
+    firstChild( e: KnockoutVirtualElement );
+    insertAfter( container: KnockoutVirtualElement, nodeToInsert: HTMLElement, insertAfter: HTMLElement );
+    nextSibling( e: KnockoutVirtualElement );
+    prepend( e: KnockoutVirtualElement, toInsert: HTMLElement );
+    setDomNodeChildren( e: KnockoutVirtualElement, newChildren: { length: number;[index: number]: HTMLElement; } );
+    childNodes( e: KnockoutVirtualElement ): HTMLElement[];
 }
 
 interface KnockoutExtenders {

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -70,29 +70,24 @@ interface KnockoutObservableArrayStatic {
 
 
 
-interface KnockoutComputedDefine<T> {
-    read(): T;
-    write(T);
-}
 
-interface KnockoutComputedFunctions extends KnockoutSubscribableFunctions {
+interface KnockoutComputedFunctions<T> {
+}
+interface KnockoutComputed<T> extends KnockoutObservable<T>, KnockoutComputedFunctions<T> {
     getDependenciesCount(): number;
-    hasWriteFunction(): boolean;
-}
-interface KnockoutComputed<T> extends KnockoutComputedFunctions {
-    (): T;
-    (value: T): void;
-
-    subscribe(callback: (newValue: T) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite: T, topic?: string);
+    isActive(): boolean;
 }
 interface KnockoutComputedStatic {
-    fn: KnockoutComputedFunctions;
+    fn: KnockoutComputedFunctions<any>;
 
     <T>(): KnockoutComputed<T>;
     <T>(func: () => T, context?: any, options?: any): KnockoutComputed<T>;
     <T>(def: KnockoutComputedDefine<T>): KnockoutComputed<T>;
     (options?: any): KnockoutComputed<any>;
+}
+interface KnockoutComputedDefine<T> {
+    read(): T;
+    write(T);
 }
 
 

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -7,11 +7,11 @@
 interface KnockoutSubscription {
     dispose(): void;
 }
-interface KnockoutSubscribableFn {
+interface KnockoutSubscribableFunctions {
     extend(source);
     notifySubscribers<T>(valueToNotify:T, event: string): void;
 }
-interface KnockoutSubscribable<T> extends KnockoutSubscribableFn{
+interface KnockoutSubscribable<T> extends KnockoutSubscribableFunctions {
     subscribe(callback: (newValue: T) => void , callbackTarget?: any, event?: string): KnockoutSubscription;
     notifySubscribers(valueToNotify: T, event: string): void;
     getSubscriptionsCount(): number;
@@ -23,13 +23,30 @@ interface KnockoutSubscribableStatic {
 }
 
 
-interface KnockoutComputedFunctions extends KnockoutSubscribableFunctions {
-    getDependenciesCount(): number;
-    hasWriteFunction(): boolean;
-}
+
 
 interface KnockoutObservableFunctions extends KnockoutSubscribableFunctions {
 }
+/** use as method to get/set the value */
+interface KnockoutObservableBase extends KnockoutObservableFunctions {
+    getSubscriptionsCount(): number;
+}
+interface KnockoutObservable<T> extends KnockoutObservableBase {
+    (): T;
+    (value: T): void;
+
+    subscribe(callback: (newValue: T) => void , target?: any, topic?: string): KnockoutSubscription;
+    notifySubscribers(valueToWrite: T, topic?: string);
+}
+interface KnockoutObservableStatic {
+    fn: KnockoutObservableFunctions;
+
+    <T>(value?: T): KnockoutObservable<T>;
+}
+
+
+
+
 
 interface KnockoutObservableArrayFunctions<T> extends KnockoutObservableFunctions {
     // General Array functions
@@ -56,9 +73,37 @@ interface KnockoutObservableArrayFunctions<T> extends KnockoutObservableFunction
     destroyAll(items: T[]): void;
     destroyAll(): void;
 }
+interface KnockoutObservableArray<T> extends KnockoutObservableArrayFunctions<T> {
+    (): T[];
+    (value: T[]): void;
+
+    subscribe(callback: (newValue: T[]) => void, target?:any, topic?: string): KnockoutSubscription;
+    notifySubscribers(valueToWrite: T[], topic?: string);
+}
+interface KnockoutObservableArrayStatic {
+    fn: KnockoutObservableArrayFunctions<any>;
+    <T>(value?: T[]): KnockoutObservableArray<T>;
+}
 
 
 
+
+interface KnockoutComputedDefine<T> {
+    read(): T;
+    write(T);
+}
+
+interface KnockoutComputedFunctions extends KnockoutSubscribableFunctions {
+    getDependenciesCount(): number;
+    hasWriteFunction(): boolean;
+}
+interface KnockoutComputed<T> extends KnockoutComputedFunctions {
+    (): T;
+    (value: T): void;
+
+    subscribe(callback: (newValue: T) => void, target?:any, topic?: string): KnockoutSubscription;
+    notifySubscribers(valueToWrite: T, topic?: string);
+}
 interface KnockoutComputedStatic {
     fn: KnockoutComputedFunctions;
 
@@ -68,129 +113,15 @@ interface KnockoutComputedStatic {
     (options?: any): KnockoutComputed<any>;
 }
 
-interface KnockoutComputed<T> extends KnockoutComputedFunctions {
-    (): T;
-    (value: T): void;
 
-    subscribe(callback: (newValue: T) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite: T, topic?: string);
-}
 
-interface KnockoutObservableArrayStatic {
-
-    fn: KnockoutObservableArrayFunctions<any>;
-
-    <T>(value?: T[]): KnockoutObservableArray<T>;
-}
-
-interface KnockoutObservableArray<T> extends KnockoutObservableArrayFunctions<T> {
-    (): T[];
-    (value: T[]): void;
-
-    subscribe(callback: (newValue: T[]) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite: T[], topic?: string);
-}
-
-interface KnockoutObservableStatic {
-    fn: KnockoutObservableFunctions;
-
-    <T>(value?: T): KnockoutObservable<T>;
-}
-
-/** use as method to get/set the value */
-interface KnockoutObservableBase extends KnockoutObservableFunctions {
-    getSubscriptionsCount(): number;
-}
-
-interface KnockoutObservable<T> extends KnockoutObservableBase {
-    (): T;
-    (value: T): void;
-
-    subscribe(callback: (newValue: T) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite: T, topic?: string);
-}
-
-interface KnockoutComputedDefine<T> {
-    read(): T;
-    write(T);
-}
-
-interface KnockoutBindingContext {
-    $parent: any;
-    $parents: any[];
-    $root: any;
-    $data: any;
-    $index?: number;
-    $parentContext?: KnockoutBindingContext;
-
-    extend(any): any;
-    createChildContext(any): any;
-}
-
-interface KnockoutBindingHandler {
-    init?(element: any, valueAccessor: () => any, allBindingsAccessor: () => any, viewModel: any, bindingContext: KnockoutBindingContext): void;
-    update?(element: any, valueAccessor: () => any, allBindingsAccessor: () => any, viewModel: any, bindingContext: KnockoutBindingContext): void;
-    options?: any;
-}
-
-interface KnockoutBindingHandlers {
-    [bindingHandler: string]: KnockoutBindingHandler;
-
-    // Controlling text and appearance
-    visible: KnockoutBindingHandler;
-    text: KnockoutBindingHandler;
-    html: KnockoutBindingHandler;
-    css: KnockoutBindingHandler;
-    style: KnockoutBindingHandler;
-    attr: KnockoutBindingHandler;
-
-    // Control Flow
-    foreach: KnockoutBindingHandler;
-    if: KnockoutBindingHandler;
-    ifnot: KnockoutBindingHandler;
-    with: KnockoutBindingHandler;
-
-    // Working with form fields
-    click: KnockoutBindingHandler;
-    event: KnockoutBindingHandler;
-    submit: KnockoutBindingHandler;
-    enable: KnockoutBindingHandler;
-    disable: KnockoutBindingHandler;
-    value: KnockoutBindingHandler;
-    hasfocus: KnockoutBindingHandler;
-    checked: KnockoutBindingHandler;
-    options: KnockoutBindingHandler;
-    selectedOptions: KnockoutBindingHandler;
-    uniqueName: KnockoutBindingHandler;
-
-    // Rendering templates
-    template: KnockoutBindingHandler;
-}
-
-interface KnockoutMemoization {
-    memoize(callback);
-    unmemoize(memoId, callbackParams);
-    unmemoizeDomNodeAndDescendants(domNode, extraCallbackParamsArray);
-    parseMemoText(memoText);
-}
-
-interface KnockoutVirtualElement {}
-
-interface KnockoutVirtualElements {
-    allowedBindings: { [bindingName: string]: boolean; };
-    emptyNode( e: KnockoutVirtualElement );
-    firstChild( e: KnockoutVirtualElement );
-    insertAfter( container: KnockoutVirtualElement, nodeToInsert: HTMLElement, insertAfter: HTMLElement );
-    nextSibling( e: KnockoutVirtualElement );
-    prepend( e: KnockoutVirtualElement, toInsert: HTMLElement );
-    setDomNodeChildren( e: KnockoutVirtualElement, newChildren: { length: number;[index: number]: HTMLElement; } );
-    childNodes( e: KnockoutVirtualElement ): HTMLElement[];
-}
 
 interface KnockoutExtenders {
     throttle(target: any, timeout: number): KnockoutComputed;
     notify(target: any, notifyWhen: string): any;
 }
+
+
 
 interface KnockoutUtils {
 
@@ -213,9 +144,9 @@ interface KnockoutUtils {
     //////////////////////////////////
 
     domData: {
-        get (node: Element, key: string);
+        get(node: Element, key: string);
 
-        set (node: Element, key: string, value: any);
+        set(node: Element, key: string, value: any);
 
         getAll(node: Element, createIfNotFound: boolean);
 
@@ -320,6 +251,80 @@ interface KnockoutUtils {
 
     isIe7: boolean;
 }
+
+
+
+
+interface KnockoutBindingContext {
+    $parent: any;
+    $parents: any[];
+    $root: any;
+    $data: any;
+    $index?: number;
+    $parentContext?: KnockoutBindingContext;
+
+    extend(any): any;
+    createChildContext(any): any;
+}
+interface KnockoutBindingHandler {
+    init?(element: any, valueAccessor: () => any, allBindingsAccessor: () => any, viewModel: any, bindingContext: KnockoutBindingContext): void;
+    update?(element: any, valueAccessor: () => any, allBindingsAccessor: () => any, viewModel: any, bindingContext: KnockoutBindingContext): void;
+    options?: any;
+}
+interface KnockoutBindingHandlers {
+    [bindingHandler: string]: KnockoutBindingHandler;
+
+    // Controlling text and appearance
+    visible: KnockoutBindingHandler;
+    text: KnockoutBindingHandler;
+    html: KnockoutBindingHandler;
+    css: KnockoutBindingHandler;
+    style: KnockoutBindingHandler;
+    attr: KnockoutBindingHandler;
+
+    // Control Flow
+    foreach: KnockoutBindingHandler;
+    if: KnockoutBindingHandler;
+    ifnot: KnockoutBindingHandler;
+    with: KnockoutBindingHandler;
+
+    // Working with form fields
+    click: KnockoutBindingHandler;
+    event: KnockoutBindingHandler;
+    submit: KnockoutBindingHandler;
+    enable: KnockoutBindingHandler;
+    disable: KnockoutBindingHandler;
+    value: KnockoutBindingHandler;
+    hasfocus: KnockoutBindingHandler;
+    checked: KnockoutBindingHandler;
+    options: KnockoutBindingHandler;
+    selectedOptions: KnockoutBindingHandler;
+    uniqueName: KnockoutBindingHandler;
+
+    // Rendering templates
+    template: KnockoutBindingHandler;
+}
+
+interface KnockoutMemoization {
+    memoize(callback);
+    unmemoize(memoId, callbackParams);
+    unmemoizeDomNodeAndDescendants(domNode, extraCallbackParamsArray);
+    parseMemoText(memoText);
+}
+
+interface KnockoutVirtualElement {}
+
+interface KnockoutVirtualElements {
+    allowedBindings: { [bindingName: string]: boolean; };
+    emptyNode( e: KnockoutVirtualElement );
+    firstChild( e: KnockoutVirtualElement );
+    insertAfter( container: KnockoutVirtualElement, nodeToInsert: HTMLElement, insertAfter: HTMLElement );
+    nextSibling( e: KnockoutVirtualElement );
+    prepend( e: KnockoutVirtualElement, toInsert: HTMLElement );
+    setDomNodeChildren( e: KnockoutVirtualElement, newChildren: { length: number;[index: number]: HTMLElement; } );
+    childNodes( e: KnockoutVirtualElement ): HTMLElement[];
+}
+
 
 //////////////////////////////////
 // templateSources.js

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -4,9 +4,24 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 
-interface KnockoutSubscribableFunctions {
-    extend(source);
+interface KnockoutSubscription {
+    dispose(): void;
 }
+interface KnockoutSubscribableFn {
+    extend(source);
+    notifySubscribers<T>(valueToNotify:T, event: string): void;
+}
+interface KnockoutSubscribable<T> extends KnockoutSubscribableFn{
+    subscribe(callback: (newValue: T) => void , callbackTarget?: any, event?: string): KnockoutSubscription;
+    notifySubscribers(valueToNotify: T, event: string): void;
+    getSubscriptionsCount(): number;
+    extend(requestedExtenders): any;
+}
+interface KnockoutSubscribableStatic {
+    fn: KnockoutSubscribableFunctions;
+    new <T>(): KnockoutSubscribable<T>;
+}
+
 
 interface KnockoutComputedFunctions extends KnockoutSubscribableFunctions {
     getDependenciesCount(): number;
@@ -42,16 +57,7 @@ interface KnockoutObservableArrayFunctions<T> extends KnockoutObservableFunction
     destroyAll(): void;
 }
 
-interface KnockoutSubscribableStatic {
-    fn: KnockoutSubscribableFunctions;
 
-    new (): KnockoutSubscription;
-}
-
-interface KnockoutSubscription extends KnockoutSubscribableFunctions {
-    subscribe(callback: (newValue: any) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite, topic?: string);
-}
 
 interface KnockoutComputedStatic {
     fn: KnockoutComputedFunctions;

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -79,15 +79,16 @@ interface KnockoutComputed<T> extends KnockoutObservable<T>, KnockoutComputedFun
 }
 interface KnockoutComputedStatic {
     fn: KnockoutComputedFunctions<any>;
-
-    <T>(): KnockoutComputed<T>;
-    <T>(func: () => T, context?: any, options?: any): KnockoutComputed<T>;
+    <T>(evaluator: () => T, context?: any, options?: KnockoutComputedDefine<T>): KnockoutComputed<T>;
     <T>(def: KnockoutComputedDefine<T>): KnockoutComputed<T>;
-    (options?: any): KnockoutComputed<any>;
 }
 interface KnockoutComputedDefine<T> {
-    read(): T;
-    write(T);
+    read: () => T;
+    write?: (value: T) => void;
+    deferEvaluation?: boolean;
+    disposeWhenNodeIsRemoved?;
+    disposeWhen?: () => boolean;
+    owner?: any;
 }
 
 

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for Knockout 2.2
+// Generic Type definitions for Knockout 2.2.1
 // Project: http://knockoutjs.com
-// Definitions by: Boris Yankov <https://github.com/borisyankov/>
+// Definitions by: Thomas Butler <https://github.com/butlersoftware/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 
@@ -61,10 +61,10 @@ interface KnockoutObservableArrayFunctions<T> {
     unshift(...values: T[]): number;
 }
 interface KnockoutObservableArray<T> extends KnockoutObservable<Array<T>>, KnockoutObservableArrayFunctions<T> {
-    //#region I SHOULDN'T HAVE TO DO THIS -- LINGERING BUG IN TYPESCRIPT?
+    //#region I SHOULDN'T HAVE TO DO THIS -- POSSIBLE BUG IN TYPESCRIPT v0.9.1?
 
-    /*****************************************************************************/
-    /**************************    HACK    ***************************************/
+    /****************************************************************************/
+    /******************************    REDUNDANT   ******************************/
     //these members should be inheriting from KnockoutObservableArrayFunctions
     destroy(predicate: (value: T) => boolean);
     destroy(value: T);
@@ -82,8 +82,8 @@ interface KnockoutObservableArray<T> extends KnockoutObservable<Array<T>>, Knock
     sort(compareFunction?: (a: T, b: T) => number): T[];
     splice(start: number, deleteCount?: number, ...values: T[]): T[];
     unshift(...values: T[]): number;
-    /*******************************************************************************/
-    /*******************************************************************************/
+    /****************************************************************************/
+    /****************************************************************************/
 
     //#endregion
 }
@@ -175,22 +175,19 @@ interface KnockoutUtils {
     //////////////////////////////////
 
     fieldsIncludedWithJsonPost: any[];
-
-    arrayForEach(array: any[], action: (any) => void ): void;
-
-    arrayIndexOf(array: any[], item: any): number;
-
-    arrayFirst(array: any[], predicate: (item) => boolean, predicateOwner?: any): any;
-
-    arrayRemoveItem(array: any[], itemToRemove: any): void;
-
-    arrayGetDistinctValues(array: any[]): any[];
-
-    arrayMap(array: any[], mapping: (item) => any): any[];
-
-    arrayFilter(array: any[], predicate: (item) => boolean): any[];
-
-    arrayPushAll(array: any[], valuesToPush: any[]): any[];
+    
+    arrayForEach<T>(array: Array<T>, action: (item: T) => void ): void;
+    arrayIndexOf<T>(array: Array<T>, item: T): number;
+    arrayFirst<T>(array: Array<T>, predicate: (item: T) => bool, predicateOwner?: any): T;
+    arrayRemoveItem<T>(array: Array<T>, itemToRemove: T): void;
+    arrayGetDistinctValues<T>(array: Array<T>): Array<T>;
+    arrayMap<T>(array: Array<T>, mapping: (item: T) => any): any[];
+    arrayFilter<T>(array: Array<T>, predicate: (item: T) => bool): Array<T>;
+    arrayPushAll<T>(array: Array<T>, valuesToPush: Array<T>): Array<T>;
+    cloneNodes<T>(nodesArray: Array<T>, shouldCleanNodes: bool): Array<T>;
+    unwrapObservable<T>(value: KnockoutObservable<T>): T;
+    unwrapObservable<T>(value: T): T;
+    makeArray<T>(arrayLikeObject: any): Array<T>;
 
     extend(target, source);
 
@@ -198,7 +195,6 @@ interface KnockoutUtils {
 
     moveCleanedNodesToContainerElement(nodes: any[]): HTMLElement;
 
-    cloneNodes(nodesArray: any[], shouldCleanNodes: boolean): any[];
 
     setDomNodeChildren(domNode: any, childNodes: any[]): void;
 
@@ -222,7 +218,6 @@ interface KnockoutUtils {
 
     triggerEvent(element: any, eventType: any): void;
 
-    unwrapObservable(value: any): any;
 
     toggleDomNodeCssClass(node: any, className: string, shouldHaveClass: boolean): void;
 
@@ -236,13 +231,12 @@ interface KnockoutUtils {
 
     ensureSelectElementIsRenderedCorrectly(selectElement: any): void;
 
-    range(min: any, max: any): any;
+    range(min: number, max: number): number[];
 
-    makeArray(arrayLikeObject: any): any[];
 
     getFormFields(form: any, fieldName: string): any[];
 
-    parseJson(jsonString: string): any;
+    parseJson<T>(jsonString: string): T;
 
     stringifyJson(data: any, replacer: Function, space: string): string;
 
@@ -269,43 +263,46 @@ interface KnockoutBindingContext {
     extend(any): any;
     createChildContext(any): any;
 }
-interface KnockoutBindingHandler {
-    init?(element: any, valueAccessor: () => any, allBindingsAccessor: () => any, viewModel: any, bindingContext: KnockoutBindingContext): void;
-    update?(element: any, valueAccessor: () => any, allBindingsAccessor: () => any, viewModel: any, bindingContext: KnockoutBindingContext): void;
+interface KnockoutTypedBindingHandler<T> {
+    init?(element: HTMLElement, valueAccessor: () => T, allBindingsAccessor: () => any, viewModel: any, bindingContext: KnockoutBindingContext): void;
+    update? (element: HTMLElement, valueAccessor: () => T, allBindingsAccessor: () => any, viewModel: any, bindingContext: KnockoutBindingContext): void;
     options?: any;
+}
+interface KnockoutBindingHandler extends KnockoutTypedBindingHandler<any> {
+    
 }
 interface KnockoutBindingHandlers {
     [bindingHandler: string]: KnockoutBindingHandler;
 
     // Controlling text and appearance
-    visible: KnockoutBindingHandler;
-    text: KnockoutBindingHandler;
-    html: KnockoutBindingHandler;
-    css: KnockoutBindingHandler;
-    style: KnockoutBindingHandler;
-    attr: KnockoutBindingHandler;
+    visible: KnockoutTypedBindingHandler<any>;
+    text: KnockoutTypedBindingHandler<any>;
+    html: KnockoutTypedBindingHandler<any>;
+    css: KnockoutTypedBindingHandler<any>;
+    style: KnockoutTypedBindingHandler<any>;
+    attr: KnockoutTypedBindingHandler<any>;
 
     // Control Flow
-    foreach: KnockoutBindingHandler;
-    if: KnockoutBindingHandler;
-    ifnot: KnockoutBindingHandler;
-    with: KnockoutBindingHandler;
+    foreach: KnockoutTypedBindingHandler<any>;
+    if: KnockoutTypedBindingHandler<any>;
+    ifnot: KnockoutTypedBindingHandler<any>;
+    with: KnockoutTypedBindingHandler<any>;
 
     // Working with form fields
-    click: KnockoutBindingHandler;
-    event: KnockoutBindingHandler;
-    submit: KnockoutBindingHandler;
-    enable: KnockoutBindingHandler;
-    disable: KnockoutBindingHandler;
-    value: KnockoutBindingHandler;
-    hasfocus: KnockoutBindingHandler;
-    checked: KnockoutBindingHandler;
-    options: KnockoutBindingHandler;
-    selectedOptions: KnockoutBindingHandler;
-    uniqueName: KnockoutBindingHandler;
+    click: KnockoutTypedBindingHandler<any>;
+    event: KnockoutTypedBindingHandler<any>;
+    submit: KnockoutTypedBindingHandler<any>;
+    enable: KnockoutTypedBindingHandler<any>;
+    disable: KnockoutTypedBindingHandler<any>;
+    value: KnockoutTypedBindingHandler<any>;
+    hasfocus: KnockoutTypedBindingHandler<any>;
+    checked: KnockoutTypedBindingHandler<any>;
+    options: KnockoutTypedBindingHandler<any>;
+    selectedOptions: KnockoutTypedBindingHandler<any>;
+    uniqueName: KnockoutTypedBindingHandler<any>;
 
     // Rendering templates
-    template: KnockoutBindingHandler;
+    template: KnockoutTypedBindingHandler<any>;
 }
 
 interface KnockoutMemoization {

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -6,11 +6,6 @@
 
 interface KnockoutSubscribableFunctions {
     extend(source);
-    dispose(): void;
-    peek(): any;
-    valueHasMutated(): void;
-
-    valueWillMutate(): void;
 }
 
 interface KnockoutComputedFunctions extends KnockoutSubscribableFunctions {

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -7,40 +7,35 @@
 interface KnockoutSubscription {
     dispose(): void;
 }
-interface KnockoutSubscribableFunctions {
+interface KnockoutSubscribableFunctions<T> {
     extend(source);
-    notifySubscribers<T>(valueToNotify:T, event: string): void;
+    notifySubscribers<T>(valueToNotify:T, event?: string): void;
 }
-interface KnockoutSubscribable<T> extends KnockoutSubscribableFunctions {
+interface KnockoutSubscribable<T> extends KnockoutSubscribableFunctions<T> {
     subscribe(callback: (newValue: T) => void , callbackTarget?: any, event?: string): KnockoutSubscription;
-    notifySubscribers(valueToNotify: T, event?: string): void;
     getSubscriptionsCount(): number;
     extend(requestedExtenders): any;
 }
 interface KnockoutSubscribableStatic {
-    fn: KnockoutSubscribableFunctions;
+    fn: KnockoutSubscribableFunctions<any>;
     new <T>(): KnockoutSubscribable<T>;
 }
 
 
 
 
-interface KnockoutObservableFunctions extends KnockoutSubscribableFunctions {
+interface KnockoutObservableFunctions<T> extends KnockoutSubscribableFunctions<T> {
+    equalityComparer(a:T, b:T): boolean;
 }
-/** use as method to get/set the value */
-interface KnockoutObservableBase extends KnockoutObservableFunctions {
-    getSubscriptionsCount(): number;
-}
-interface KnockoutObservable<T> extends KnockoutObservableBase {
+interface KnockoutObservable<T> extends KnockoutSubscribable<T>, KnockoutObservableFunctions<T> {
     (): T;
     (value: T): void;
-
-    subscribe(callback: (newValue: T) => void , target?: any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite: T, topic?: string);
+    peek(): T;
+    valueHasMutated(): void;
+    valueWillMutate(): void;
 }
 interface KnockoutObservableStatic {
-    fn: KnockoutObservableFunctions;
-
+    fn: KnockoutObservableFunctions<any>;
     <T>(value?: T): KnockoutObservable<T>;
 }
 

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -44,29 +44,21 @@ interface KnockoutObservableStatic {
 
 
 interface KnockoutObservableArrayFunctions<T> extends KnockoutObservableFunctions {
-    // General Array functions
+    destroy(predicate: (value: T) => boolean);
+    destroyAll(values: Array<T>);
     indexOf(searchElement: T, fromIndex?: number): number;
-    slice(start: number, end?: number): T[];
-    splice(start: number): T[];
-    splice(start: number, deleteCount: number, ...items: T[]): T[];
-    pop();
+    pop():T;
     push(...items: T[]): void;
-    shift();
-    unshift(...items: T[]): number;
-    reverse(): T[];
-    sort(): void;
-    sort(compareFunction): void;
-
-    // Ko specific
+    remove(value: T);
+    remove(predicate: (value: T) => boolean);
+    removeAll(values?: T[]): T[];
     replace(oldItem: T, newItem: T): void;
-
-    remove(item): T[];
-    removeAll(items: T[]): T[];
-    removeAll(): T[];
-
-    destroy(item: T): void;
-    destroyAll(items: T[]): void;
-    destroyAll(): void;
+    reverse(): T[];
+    shift():T;
+    slice(start: number, end?: number): T[];
+    sort(compareFunction?: (a: T, b: T) => number): T[];
+    splice(start: number, deleteCount?: number, ...items: T[]): T[];
+    unshift(...items: T[]): number;
 }
 interface KnockoutObservableArray<T> extends KnockoutObservableArrayFunctions<T> {
     (): T[];

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -1,4 +1,4 @@
-// Generic Type definitions for Knockout 2.2.1
+// Type definitions for Knockout 2.2.1
 // Project: http://knockoutjs.com
 // Definitions by: Thomas Butler <https://github.com/butlersoftware/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/knockout/tests/knockout-generics-tests.ts
+++ b/knockout/tests/knockout-generics-tests.ts
@@ -27,9 +27,10 @@ function test_KnockoutObservable() {
 
     //type inference works
     var obs: KnockoutObservable<MyType> = ko.observable(myData);
+    obs(myData);
+    var result: MyType = obs();
 
     //all the members are present
-    obs(myData);
     obs.valueWillMutate();
     obs.valueHasMutated();
     obs.peek();
@@ -37,9 +38,6 @@ function test_KnockoutObservable() {
 
     //inherits properly
     var sub: KnockoutSubscribable<MyType> = obs;
-
-    //returns correct type
-    var result: MyType = obs();
 
 }
 
@@ -67,13 +65,20 @@ function test_KnockoutObservableArray() {
 function test_KnockoutComputed() {
 
     //type inference works
-    var computed: KnockoutComputed<MyType> = ko.computed(()=>myData);
+    var computed: KnockoutComputed<MyType> = ko.computed(() => myData);
+    computed(myData);
+    var result: MyType = computed();
+
+    //all the members are present
+    var count: number = computed.getDependenciesCount();
+    var active: boolean = computed.isActive();
+    computed.valueWillMutate();
+    computed.valueHasMutated();
+    computed.peek();
+    computed.notifySubscribers(myData);
 
     //inherits properly
     var obs: KnockoutObservable<MyType> = computed;
     var sub: KnockoutSubscribable<MyType> = computed;
-
-    //returns correct type
-    var result: MyType = computed();
 
 }

--- a/knockout/tests/knockout-generics-tests.ts
+++ b/knockout/tests/knockout-generics-tests.ts
@@ -2,7 +2,7 @@
 
 
 interface MyType { }
-var data: MyType;
+var myData: MyType;
 
 function test_KnockoutSubscribable() {
 
@@ -12,9 +12,56 @@ function test_KnockoutSubscribable() {
     
     var subscription: KnockoutSubscription = subscribable.subscribe((val: MyType) => { });
     
-    subscribable.notifySubscribers(data);
-    subscribable.notifySubscribers(data, 'someevent');
+    subscribable.notifySubscribers(myData);
+    subscribable.notifySubscribers(myData, 'someevent');
 
     subscription.dispose();
     
+}
+
+function test_KnockoutObservable() {
+    
+    //works when unexplicit
+    var obsAny: KnockoutObservable<any> = ko.observable();
+
+    //type inference works
+    var obs: KnockoutObservable<MyType> = ko.observable(myData);
+
+    //inherits properly
+    var sub: KnockoutSubscribable<MyType> = obs;
+
+    //returns correct type
+    var result:MyType = obs();
+
+}
+
+function test_KnockoutObservableArray() {
+
+    //works when unexplicit
+    var obsArrayAny: KnockoutObservableArray<any> = ko.observableArray();
+
+    //type inference works
+    var obsArray: KnockoutObservableArray<MyType> = ko.observableArray([myData]);
+
+    //inherits properly
+    var obs: KnockoutObservable<MyType[]> = obsArray;
+    var sub: KnockoutSubscribable<MyType[]> = obsArray;
+
+    //returns correct type
+    var result:MyType[] = obsArray();
+
+}
+
+function test_KnockoutComputed() {
+
+    //type inference works
+    var computed: KnockoutComputed<MyType> = ko.computed(()=>myData);
+
+    //inherits properly
+    var obs: KnockoutObservable<MyType> = computed;
+    var sub: KnockoutSubscribable<MyType> = computed;
+
+    //returns correct type
+    var result: MyType = computed();
+
 }

--- a/knockout/tests/knockout-generics-tests.ts
+++ b/knockout/tests/knockout-generics-tests.ts
@@ -33,6 +33,7 @@ function test_KnockoutObservable() {
     obs.valueWillMutate();
     obs.valueHasMutated();
     obs.peek();
+    obs.notifySubscribers(myData);
 
     //inherits properly
     var sub: KnockoutSubscribable<MyType> = obs;
@@ -49,6 +50,10 @@ function test_KnockoutObservableArray() {
 
     //type inference works
     var obsArray: KnockoutObservableArray<MyType> = ko.observableArray([myData]);
+    
+    //all the members are present
+    obsArray([myData]);
+    
 
     //inherits properly
     var obs: KnockoutObservable<MyType[]> = obsArray;

--- a/knockout/tests/knockout-generics-tests.ts
+++ b/knockout/tests/knockout-generics-tests.ts
@@ -48,17 +48,14 @@ function test_KnockoutObservableArray() {
 
     //type inference works
     var obsArray: KnockoutObservableArray<MyType> = ko.observableArray([myData]);
-    
-    //all the members are present
     obsArray([myData]);
+    var result: MyType[] = obsArray();
     
 
     //inherits properly
     var obs: KnockoutObservable<MyType[]> = obsArray;
     var sub: KnockoutSubscribable<MyType[]> = obsArray;
 
-    //returns correct type
-    var result:MyType[] = obsArray();
 
 }
 

--- a/knockout/tests/knockout-generics-tests.ts
+++ b/knockout/tests/knockout-generics-tests.ts
@@ -33,7 +33,7 @@ function test_KnockoutObservable() {
     //all the members are present
     obs.valueWillMutate();
     obs.valueHasMutated();
-    obs.peek();
+    result = obs.peek();
     obs.notifySubscribers(myData);
 
     //inherits properly
@@ -61,6 +61,13 @@ function test_KnockoutObservableArray() {
 
 function test_KnockoutComputed() {
 
+    //constructor options
+    var c = ko.computed({
+        read: () => myData,
+        write: (newVal: MyType) => {},
+        deferEvaluation: true,
+    });
+
     //type inference works
     var computed: KnockoutComputed<MyType> = ko.computed(() => myData);
     computed(myData);
@@ -71,7 +78,7 @@ function test_KnockoutComputed() {
     var active: boolean = computed.isActive();
     computed.valueWillMutate();
     computed.valueHasMutated();
-    computed.peek();
+    var result: MyType = computed.peek();
     computed.notifySubscribers(myData);
 
     //inherits properly

--- a/knockout/tests/knockout-generics-tests.ts
+++ b/knockout/tests/knockout-generics-tests.ts
@@ -1,0 +1,20 @@
+/// <reference path="../knockout.d.ts" />
+
+
+interface MyType { }
+var data: MyType;
+
+function test_KnockoutSubscribable() {
+
+    var subscribableAny: KnockoutSubscribable<any> = new ko.subscribable();
+
+    var subscribable: KnockoutSubscribable<MyType> = new ko.subscribable<MyType>();
+    
+    var subscription: KnockoutSubscription = subscribable.subscribe((val: MyType) => { });
+    
+    subscribable.notifySubscribers(data);
+    subscribable.notifySubscribers(data, 'someevent');
+
+    subscription.dispose();
+    
+}

--- a/knockout/tests/knockout-generics-tests.ts
+++ b/knockout/tests/knockout-generics-tests.ts
@@ -11,10 +11,11 @@ function test_KnockoutSubscribable() {
     var subscribable: KnockoutSubscribable<MyType> = new ko.subscribable<MyType>();
     
     var subscription: KnockoutSubscription = subscribable.subscribe((val: MyType) => { });
-    
-    subscribable.notifySubscribers(myData);
-    subscribable.notifySubscribers(myData, 'someevent');
 
+    //all the members are present
+    subscribable.notifySubscribers(myData);
+    subscribable.notifySubscribers(myData, 'topic');
+    var count: number = subscribable.getSubscriptionsCount();
     subscription.dispose();
     
 }
@@ -27,11 +28,17 @@ function test_KnockoutObservable() {
     //type inference works
     var obs: KnockoutObservable<MyType> = ko.observable(myData);
 
+    //all the members are present
+    obs(myData);
+    obs.valueWillMutate();
+    obs.valueHasMutated();
+    obs.peek();
+
     //inherits properly
     var sub: KnockoutSubscribable<MyType> = obs;
 
     //returns correct type
-    var result:MyType = obs();
+    var result: MyType = obs();
 
 }
 


### PR DESCRIPTION
Alright so this is a big one, but it needed to happen.
### Primary concerns addressed:
- Type hierarchy not properly represented -- polymorphism not possible.
- Core type member definitions deviating from reality
- No test suite for generic features
### Solutions:
#### 1.  Inheritance

Core types have been rewritten with proper inheritance. Previously it was difficult to do polymorphic hotness such as...

``` javascript
function getSomething(): KnockoutSubscribable<T> {
    if (something) {
        return ko.computed(...);
    } else {
        return ko.observable(...);
    }
}
```

...which is valid at runtime.

Also, a bunch of redundant code was eliminated like in the case of `KnockoutObservableArray<T> extends KnockoutObservable<T[]>`.
#### 2.  KnockoutSubscribable?

This guy was missing out-rite, the obvious restructuring ensued.

During these rewrites, member inclusion was judged by referencing the runtime output of the current knockout.js release (so it should be darn near perfect!).
#### 4. New tests for generics, old tests unmodified.

All of this new stuff compiles cleanly against the old tests with absolutely no changes.
#### \* Other notes
- This pull only includes major updates to the core types. I've written the whole thing out, however there isn't much of test suite against the other stuff. I'm holding it out for now to make sure I don't mess anybody up.
- There's some weird stuff happening in `KnockoutObservableArray`. For some reason that single interface will only inherit from one type at a time, so all of the `.fn` members are duplicated. Maybe this is an outstanding bug in TypeScript, or maybe I've been awake too long to see what's happening :-O.
