### PR TITLE
jQuery Promise Typings

### DIFF
--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -940,8 +940,7 @@ function test_deferred() {
     filtered.done(function (data) { });
 
     function asyncEvent() {
-        var newDeferred = new jQuery.Deferred();
-        var dfd: JQueryDeferred;
+        var dfd: JQueryDeferred<string> = $.Deferred<string>();
         setTimeout(function () {
             dfd.resolve("hurray");
         }, Math.floor(400 + Math.random() * 2000));

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -98,7 +98,7 @@ interface JQueryPromise<T> {
     progress(...progressCallbacks: any[]): JQueryPromise<T>;
 
     // Deprecated - given no typings
-    pipe(doneFilter?: (x: any) => any, failFilter?: (x: any) => any, progressFilter?: (x: any) => any): JQueryPromise;
+    pipe(doneFilter?: (x: any) => any, failFilter?: (x: any) => any, progressFilter?: (x: any) => any): JQueryPromise<any>;
 
     then<U>(onFulfill: (value: T) => U, onReject?: (...reasons) => U, onProgress?: (...progression) => any): JQueryPromise<U>;
     then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (...reasons) => U, onProgress?: (...progression) => any): JQueryPromise<U>;

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -57,7 +57,7 @@ interface JQueryAjaxSettings {
 /*
     Interface for the jqXHR object
 */
-interface JQueryXHR extends XMLHttpRequest, JQueryPromise {
+interface JQueryXHR extends XMLHttpRequest, JQueryPromise<any> {
     overrideMimeType(mimeType: string);
     abort(statusText?: string): void;
 }
@@ -79,32 +79,60 @@ interface JQueryCallback {
 }
 
 /*
+    Allows jQuery Promises to interop with non-jQuery promises
+*/
+interface JQueryGenericPromise<T> {
+    then<U>(onFulfill: (value: T) => U, onReject?: (reason) => U): JQueryGenericPromise<U>;
+    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (reason) => U): JQueryGenericPromise<U>;
+    then<U>(onFulfill: (value: T) => U, onReject?: (reason) => JQueryGenericPromise<U>): JQueryGenericPromise<U>;
+    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (reason) => JQueryGenericPromise<U>): JQueryGenericPromise<U>;
+}
+
+/*
     Interface for the JQuery promise, part of callbacks
 */
-interface JQueryPromise {
-    always(...alwaysCallbacks: any[]): JQueryDeferred;
-    done(...doneCallbacks: any[]): JQueryDeferred;
-    fail(...failCallbacks: any[]): JQueryDeferred;
+interface JQueryPromise<T> {
+    always(...alwaysCallbacks: any[]): JQueryPromise<T>;
+    done(...doneCallbacks: any[]): JQueryPromise<T>;
+    fail(...failCallbacks: any[]): JQueryPromise<T>;
+    progress(...progressCallbacks: any[]): JQueryPromise<T>;
+
+    // Deprecated - given no typings
     pipe(doneFilter?: (x: any) => any, failFilter?: (x: any) => any, progressFilter?: (x: any) => any): JQueryPromise;
-    then(doneCallbacks: any, failCallbacks?: any, progressCallbacks?: any): JQueryDeferred;
+
+    then<U>(onFulfill: (value: T) => U, onReject?: (...reasons) => U, onProgress?: (...progression) => any): JQueryPromise<U>;
+    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (...reasons) => U, onProgress?: (...progression) => any): JQueryPromise<U>;
+    then<U>(onFulfill: (value: T) => U, onReject?: (...reasons) => JQueryGenericPromise<U>, onProgress?: (...progression) => any): JQueryPromise<U>;
+    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (...reasons) => JQueryGenericPromise<U>, onProgress?: (...progression) => any): JQueryPromise<U>;
+
+    /* Because JQuery Promises Suck */
+    then<U>(onFulfill: (...args) => U, onReject?: (...reasons) => U, onProgress?: (...progression) => any): JQueryPromise<U>;
+    then<U>(onFulfill: (...args) => JQueryGenericPromise<U>, onReject?: (...reasons) => U, onProgress?: (...progression) => any): JQueryPromise<U>;
+    then<U>(onFulfill: (...args) => U, onReject?: (...reasons) => JQueryGenericPromise<U>, onProgress?: (...progression) => any): JQueryPromise<U>;
+    then<U>(onFulfill: (...args) => JQueryGenericPromise<U>, onReject?: (...reasons) => JQueryGenericPromise<U>, onProgress?: (...progression) => any): JQueryPromise<U>;
 }
 
 /*
     Interface for the JQuery deferred, part of callbacks
 */
-interface JQueryDeferred extends JQueryPromise {
-    notify(...args: any[]): JQueryDeferred;
-    notifyWith(context: any, ...args: any[]): JQueryDeferred;
+interface JQueryDeferred<T> extends JQueryPromise<T> {
+    always(...alwaysCallbacks: any[]): JQueryDeferred<T>;
+    done(...doneCallbacks: any[]): JQueryDeferred<T>;
+    fail(...failCallbacks: any[]): JQueryDeferred<T>;
+    progress(...progressCallbacks: any[]): JQueryDeferred<T>;
 
-    pipe(doneFilter?: any, failFilter?: any, progressFilter?: any): JQueryPromise;
-    progress(...progressCallbacks: any[]): JQueryDeferred;
-    reject(...args: any[]): JQueryDeferred;
-    rejectWith(context: any, ...args: any[]): JQueryDeferred;
-    resolve(...args: any[]): JQueryDeferred;
-    resolveWith(context: any, ...args: any[]): JQueryDeferred;
+    notify(...args: any[]): JQueryDeferred<T>;
+    notifyWith(context: any, ...args: any[]): JQueryDeferred<T>;
+
+    reject(...args: any[]): JQueryDeferred<T>;
+    rejectWith(context: any, ...args: any[]): JQueryDeferred<T>;
+
+    resolve(val: T): JQueryDeferred<T>;
+    resolve(...args: any[]): JQueryDeferred<T>;
+    resolveWith(context: any, ...args: any[]): JQueryDeferred<T>;
     state(): string;
-    then(doneCallbacks: any, failCallbacks?: any, progressCallbacks?: any): JQueryDeferred;
-    promise(target?: any): JQueryPromise;
+
+    promise(target?: any): JQueryPromise<T>;
 }
 
 /*
@@ -260,10 +288,7 @@ interface JQueryStatic {
     removeData(element: Element, name?: string): JQuery;
 
     // Deferred
-    Deferred: {
-        (beforeStart?: (deferred: JQueryDeferred) => any): JQueryDeferred;
-        new (beforeStart?: (deferred: JQueryDeferred) => any): JQueryDeferred;
-    };
+    Deferred<T>(beforeStart?: (deferred: JQueryDeferred<T>) => any): JQueryDeferred<T>;
 
     // Effects
     fx: { tick: () => void; interval: number; stop: () => void; speeds: { slow: number; fast: number; }; off: boolean; step: any; };

--- a/q/Q-tests.ts
+++ b/q/Q-tests.ts
@@ -76,7 +76,8 @@ Q<number[]>(arrayPromise) // type specification required
 declare var jPromise: JQueryPromise<string>;
 
 // if jQuery promises definition supported generics, this could be more interesting example
-Q<any>(jPromise).then((val) => val.toExponential());
+Q<string>(jPromise).then(str => str.split(','));
+jPromise.then<number>(returnsNumPromise);
 
 declare var promiseArray: Q.IPromise<number>[];
 var qPromiseArray = promiseArray.map(p => Q<number>(p));

--- a/q/Q-tests.ts
+++ b/q/Q-tests.ts
@@ -73,7 +73,7 @@ Q<number[]>(arrayPromise) // type specification required
     .then<number>(returnsNumPromise) // requires specification
     .then(num => num.toFixed());
 
-declare var jPromise: JQueryPromise;
+declare var jPromise: JQueryPromise<string>;
 
 // if jQuery promises definition supported generics, this could be more interesting example
 Q<any>(jPromise).then((val) => val.toExponential());


### PR DESCRIPTION
Added typing to jQuery Deferreds and Promises. They should be interoperable with other promises that support .then . This resolves issue #726 .
