### PR TITLE
Fixed return type of shift() and pop() on KnockoutObservableArrayFunctions<T>

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -27,9 +27,9 @@ interface KnockoutObservableArrayFunctions<T> extends KnockoutObservableFunction
     slice(start: number, end?: number): T[];
     splice(start: number): T[];
     splice(start: number, deleteCount: number, ...items: T[]): T[];
-    pop();
+    pop(): T;
     push(...items: T[]): void;
-    shift();
+    shift(): T;
     unshift(...items: T[]): number;
     reverse(): T[];
     sort(): void;


### PR DESCRIPTION
Added type T as return type for shift() and pop()
