### PR TITLE
Change type of angularjs module config fuction to any

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -54,7 +54,7 @@ declare module ng {
             name: string,
             /** name of modules yours depends on */
             requires?: string[],
-            configFunction?: Function): IModule;
+            configFunction?: any): IModule;
         noop(...args: any[]): void;
         toJson(obj: any, pretty?: bool): string;
         uppercase(str: string): string;


### PR DESCRIPTION
It can be subject to dependency injection, eg.

angular.module('myModule', [], [$rootScope, function($rootScope){}]);
