### PR TITLE
Feat d3 improv

### DIFF
--- a/d3/d3-tests.ts
+++ b/d3/d3-tests.ts
@@ -2057,3 +2057,370 @@ function healthAndWealth() {
         }
     } );
 }
+
+// Test for d3.functor
+function functorTest () {
+    var f = d3.functor(10);
+    var g = d3.functor(function (v) { return v; });
+
+    return f(10) === g(10);
+}
+
+// Test for d3.Nest
+// Most test adopted from: https://github.com/mbostock/d3/blob/master/test/arrays/nest-test.js
+function nestTest () {
+    var data = [
+        {
+            a: 10,
+            b: [ 1, 2 ]
+        },
+        {
+            a: 20,
+            b: [ 2, 3 ]
+        },
+        {
+            a: 30,
+            b: [ 1, 2 ]
+        }
+    ];
+
+    var n1 = d3.nest()
+                .key(function (d) { return d.a; })
+                .sortKeys(d3.descending)
+                .rollup(function (vals) {
+                    return d3.sum(vals);
+                });
+    n1.map(data);
+    n1.entries(data);
+
+    var n2 = d3.nest()
+                .key(function (d) { return d.a; })
+                .sortValues(function (x1, x2) {
+                        return x1[0] < x1[1] ? -1 : (x1[0] > x1[0] ? 1 : 0); });
+    n2.map(data);
+    n2.entries(data);
+
+    // Tests adopted from d3's tests.
+    var keys = d3.nest()
+      .key(function(d) { return d.foo; })
+      .entries([{foo: 1}, {foo: 1}, {foo: 2}])
+      .map(function(d) { return d.key; })
+      .sort(d3.ascending);
+
+    var entries = d3.nest()
+      .key(function(d) { return d.foo; })
+      .entries([{foo: 1, bar: 0}, {foo: 2}, {foo: 1, bar: 1}]);
+
+    keys = d3.nest()
+        .key(function(d) { return d.foo; }).sortKeys(d3.descending)
+        .entries([{foo: 1}, {foo: 1}, {foo: 2}])
+        .map(function(d) { return d.key; });
+
+    entries = d3.nest()
+        .key(function(d) { return d.foo; })
+        .sortValues(function(a, b) { return a.bar - b.bar; })
+        .entries([{foo: 1, bar: 2}, {foo: 1, bar: 0}, {foo: 1, bar: 1}, {foo: 2}]);
+
+    entries = d3.nest()
+        .key(function(d) { return d.foo; })
+        .rollup(function(values) { return d3.sum(values, function(d) { return d.bar; }); })
+        .entries([{foo: 1, bar: 2}, {foo: 1, bar: 0}, {foo: 1, bar: 1}, {foo: 2}]);
+
+    entries = d3.nest()
+        .key(function(d) { return d[0]; }).sortKeys(d3.ascending)
+        .key(function(d) { return d[1]; }).sortKeys(d3.ascending)
+        .entries([[0, 1], [0, 2], [1, 1], [1, 2], [0, 2]]);
+
+    entries = d3.nest()
+        .key(function(d) { return d[0]; }).sortKeys(d3.ascending)
+        .key(function(d) { return d[1]; }).sortKeys(d3.ascending)
+        .rollup(function(values) { return values.length; })
+        .entries([[0, 1], [0, 2], [1, 1], [1, 2], [0, 2]]);
+
+    entries = d3.nest()
+        .key(function(d) { return d[0]; }).sortKeys(d3.ascending)
+        .key(function(d) { return d[1]; }).sortKeys(d3.ascending)
+        .sortValues(function(a, b) { return a[2] - b[2]; })
+        .entries([[0, 1], [0, 2, 1], [1, 1], [1, 2], [0, 2, 0]]);
+
+    var map = d3.nest()
+        .key(function(d) { return d[0]; }).sortKeys(d3.ascending)
+        .key(function(d) { return d[1]; }).sortKeys(d3.ascending)
+        .sortValues(function(a, b) { return a[2] - b[2]; })
+        .map([[0, 1], [0, 2, 1], [1, 1], [1, 2], [0, 2, 0]]);
+}
+
+// Test for setting attributes as an object
+// From https://github.com/mbostock/d3/blob/master/test/selection/attr-test.js
+function attrObjTest () {
+    d3.select('body')
+        .data(["orange"])
+        .attr({"xlink:href": function(d, i) { return d + "-" + i + ".png"; }});
+}
+
+// Test for brushes
+// This triggers a bug (shown below) in the 0.9.0 compiler, but works with
+// 0.9.1 compiler.
+
+// Stack trace:
+// /usr/local/share/npm/lib/node_modules/typescript/bin/tsc.js:38215
+//      return (type === this.semanticInfoChain.anyTypeSymbol) || type.isError();
+//                                                                     ^
+// TypeError: Cannot call method 'isError' of null
+//     at PullTypeResolver.isAnyOrEquivalent (/usr/local/share/npm/lib/node_modules/typescript/bin/tsc.js:38215:76)
+//     at PullTypeResolver.resolveNameExpression (/usr/local/share/npm/lib/node_modules/typescript/bin/tsc.js:39953:39)
+//     at PullTypeResolver.resolveAST (/usr/local/share/npm/lib/node_modules/typescript/bin/tsc.js:39758:37)
+//     at PullTypeResolver.computeIndexExpressionSymbol (/usr/local/share/npm/lib/node_modules/typescript/bin/tsc.js:40933:37)
+//     at PullTypeResolver.resolveIndexExpression (/usr/local/share/npm/lib/node_modules/typescript/bin/tsc.js:40925:45)
+//     at PullTypeResolver.resolveAST (/usr/local/share/npm/lib/node_modules/typescript/bin/tsc.js:39870:33)
+//     at PullTypeResolver.resolveOverloads (/usr/local/share/npm/lib/node_modules/typescript/bin/tsc.js:42917:43)
+//     at PullTypeResolver.computeCallExpressionSymbol (/usr/local/share/npm/lib/node_modules/typescript/bin/tsc.js:41373:34)
+//     at PullTypeResolver.resolveCallExpression (/usr/local/share/npm/lib/node_modules/typescript/bin/tsc.js:41175:29)
+//     at PullTypeChecker.typeCheckCallExpression (/usr/local/share/npm/lib/node_modules/typescript/bin/tsc.js:45111:58)
+//     at PullTypeChecker.typeCheckAST (/usr/local/share/npm/lib/node_modules/typescript/bin/tsc.js:43786:33)
+
+// function brushTest() {
+//     var xScale = d3.scale.linear(),
+//         yScale = d3.scale.linear();
+//
+//     var xMin = 0, xMax = 1,
+//         yMin = 0, yMax = 1;
+//
+//     // Setting only x scale.
+//     var brush1 = d3.svg.brush()
+//                     .x(xScale)
+//                     .on('brush', function () {
+//                         var extent = brush1.extent();
+//                         xMin = Math.max(extent[0], 0);
+//                         xMax = Math.min(extent[1], 1);
+//                         brush1.extent([xMin, xMax]);
+//                     });
+//
+//     // Setting both the x and y scale
+//     var brush2 = d3.svg.brush()
+//                     .x(xScale)
+//                     .y(yScale)
+//                     .on('brush', function () {
+//                         var extent = brush2.extent();
+//                         var xExtent = extent[0],
+//                             yExtent = extent[1];
+//
+//                         xMin = Math.max(xExtent[0], 0);
+//                         xMax = Math.min(xExtent[1], 1);
+//
+//                         yMin = Math.max(yExtent[0], 0);
+//                         yMax = Math.min(yExtent[1], 1);
+//
+//                         brush1.extent([[xMin, xMax], [yMin, yMax]]);
+//                     });
+// }
+
+
+// Tests for area
+// Adopted from: https://github.com/mbostock/d3/blob/master/test/svg/area-test.js
+function svgAreaTest () {
+    var a = d3.svg.area();
+
+    a.x()([0, 1]);
+    a.x()([0, 1], 1);
+    a.x(0);
+    a.x(function (d) { return d.x * 10; });
+    a.x(function (d, i) { return i * 10; });
+
+    a.x0()([0, 1]);
+    a.x0()([0, 1], 1);
+    a.x0(0);
+    a.x0(function (d) { return d.x * 10; });
+    a.x0(function (d, i) { return i * 10; });
+
+    a.x1()([0, 1]);
+    a.x1()([0, 1], 1);
+    a.x1(0);
+    a.x1(function (d) { return d.x * 10; });
+    a.x1(function (d, i) { return i * 10; });
+
+    a.y()([0, 1]);
+    a.y()([0, 1], 1);
+    a.y(0);
+    a.y(function (d) { return d.x * 10; });
+    a.y(function (d, i) { return i * 10; });
+
+    a.y0()([0, 1]);
+    a.y0()([0, 1], 1);
+    a.y0(0);
+    a.y0(function (d) { return d.x * 10; });
+    a.y0(function (d, i) { return i * 10; });
+
+    a.y1()([0, 1]);
+    a.y1()([0, 1], 1);
+    a.y1(0);
+    a.y1(function (d) { return d.x * 10; });
+    a.y1(function (d, i) { return i * 10; });
+}
+
+// Tests for areaRadial
+// Adopted from: https://github.com/mbostock/d3/blob/master/test/svg/area-radial-test.js
+function svgAreaRadialTest () {
+    var a = d3.svg.area.radial();
+
+    a.x()([0, 1]);
+    a.x()([0, 1], 1);
+    a.x(0);
+    a.x(function (d) { return d.x * 10; });
+    a.x(function (d, i) { return i * 10; });
+
+    a.x0()([0, 1]);
+    a.x0()([0, 1], 1);
+    a.x0(0);
+    a.x0(function (d) { return d.x * 10; });
+    a.x0(function (d, i) { return i * 10; });
+
+    a.x1()([0, 1]);
+    a.x1()([0, 1], 1);
+    a.x1(0);
+    a.x1(function (d) { return d.x * 10; });
+    a.x1(function (d, i) { return i * 10; });
+
+    a.y()([0, 1]);
+    a.y()([0, 1], 1);
+    a.y(0);
+    a.y(function (d) { return d.x * 10; });
+    a.y(function (d, i) { return i * 10; });
+
+    a.y0()([0, 1]);
+    a.y0()([0, 1], 1);
+    a.y0(0);
+    a.y0(function (d) { return d.x * 10; });
+    a.y0(function (d, i) { return i * 10; });
+
+    a.y1()([0, 1]);
+    a.y1()([0, 1], 1);
+    a.y1(0);
+    a.y1(function (d) { return d.x * 10; });
+    a.y1(function (d, i) { return i * 10; });
+
+    a.radius(function () { return 10; });
+    a.radius(function (d) { return d.x * 10; });
+    a.radius(function (d, i) { return i * 10; });
+
+    a.innerRadius(function () { return 10; });
+    a.innerRadius(function (d) { return d.x * 10; });
+    a.innerRadius(function (d, i) { return i * 10; });
+
+    a.outerRadius(function () { return 10; });
+    a.outerRadius(function (d) { return d.x * 10; });
+    a.outerRadius(function (d, i) { return i * 10; });
+
+    a.angle(function () { return 10; });
+    a.angle(function (d) { return d.x * 10; });
+    a.angle(function (d, i) { return i * 10; });
+
+    a.startAngle(function () { return 10; });
+    a.startAngle(function (d) { return d.x * 10; });
+    a.startAngle(function (d, i) { return i * 10; });
+
+    a.endAngle(function () { return 10; });
+    a.endAngle(function (d) { return d.x * 10; });
+    a.endAngle(function (d, i) { return i * 10; });
+}
+
+// Tests for d3.svg.line
+// Adopted from: https://github.com/mbostock/d3/blob/master/test/svg/line-test.js
+function svgLineTest () {
+    var l = d3.svg.line();
+
+    l.x()([0, 1]);
+    l.x()([0, 1], 0);
+    l.x(0);
+    l.x(function (d) { return d.x; });
+    l.x(function (d, i) { return i; });
+
+    l.y()([0, 1]);
+    l.y()([0, 1], 0);
+    l.y(0);
+    l.y(function (d) { return d.y; });
+    l.y(function (d, i) { return i; });
+}
+
+// Tests for d3.svg.line.radial
+// Adopted from: https://github.com/mbostock/d3/blob/master/test/svg/line-radial-test.js
+function svgLineRadialTest () {
+    var l = d3.svg.line.radial();
+
+    l.x()([0, 1]);
+    l.x()([0, 1], 0);
+    l.x(0);
+    l.x(function (d) { return d.x; });
+    l.x(function (d, i) { return i; });
+
+    l.y()([0, 1]);
+    l.y()([0, 1], 0);
+    l.y(0);
+    l.y(function (d) { return d.y; });
+    l.y(function (d, i) { return i; });
+
+    l.radius()([0, 1]);
+    l.radius()([0, 1], 0);
+    l.radius(0);
+    l.radius(function (d) { return d.x; });
+    l.radius(function (d, i) { return i; });
+
+    l.angle()([0, 1]);
+    l.angle()([0, 1], 0);
+    l.angle(0);
+    l.angle(function (d) { return d.y; });
+    l.angle(function (d, i) { return i; });
+}
+
+// Tests for d3.svg.arc
+// Adopted from: https://github.com/mbostock/d3/blob/master/test/svg/arc-test.js
+function svgArcTest () {
+    var l = d3.svg.arc();
+
+    l.innerRadius()([0, 1]);
+    l.innerRadius()([0, 1], 0);
+    l.innerRadius(0);
+    l.innerRadius(function (d) { return d.x; });
+    l.innerRadius(function (d, i) { return i; });
+
+    l.outerRadius()([0, 1]);
+    l.outerRadius()([0, 1], 0);
+    l.outerRadius(0);
+    l.outerRadius(function (d) { return d.x; });
+    l.outerRadius(function (d, i) { return i; });
+
+    l.startAngle()([0, 1]);
+    l.startAngle()([0, 1], 0);
+    l.startAngle(0);
+    l.startAngle(function (d) { return d.x; });
+    l.startAngle(function (d, i) { return i; });
+
+    l.endAngle()([0, 1]);
+    l.endAngle()([0, 1], 0);
+    l.endAngle(0);
+    l.endAngle(function (d) { return d.x; });
+    l.endAngle(function (d, i) { return i; });
+}
+
+// Tests for d3.svg.diagonal
+// Adopted from: https://github.com/mbostock/d3/blob/master/test/svg/diagonal-test.js
+function svgDiagonalTest () {
+    var d = d3.svg.diagonal();
+
+    d.projection()({ x: 0, y: 1});
+    d.projection()({ x: 0, y: 1}, 0);
+    d.projection(function (d) { return [d.x, d.y]; });
+    d.projection(function (d, i) { return [i, i + 1]; });
+
+    d.source()({x: 0, y: 1});
+    d.source()({x: 0, y: 1}, 0);
+    d.source({x: 0, y: 1});
+    d.source(function (d) { return {x: d.x, y: d.y}; });
+    d.source(function (d, i) { return {x: d.x * i, y: d.y * i}; });
+
+    d.target()({x: 0, y: 1});
+    d.target()({x: 0, y: 1}, 0);
+    d.target({x: 0, y: 1});
+    d.target(function (d) { return {x: d.x, y: d.y}; });
+    d.target(function (d, i) { return {x: d.x * i, y: d.y * i}; });
+}

--- a/d3/d3-tests.ts
+++ b/d3/d3-tests.ts
@@ -788,7 +788,7 @@ function populationPyramid() {
         // Produce a map from year and birthyear to [male, female].
         data = d3.nest()
             .key(function (d) { return d.year; } )
-            .key(function (d) { return d.year - d.age; } )
+            .key(function (d) { return '' + (d.year - d.age); } )
             .rollup(function (v) { return v.map(function (d) { return d.people; } ); } )
             .map(data);
 

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -740,7 +740,7 @@ declare module D3 {
         insert: (name: string, before: string) => Selection;
         select: (selector: string) => Selection;
         empty: () => boolean;
-        node: () => HTMLElementSVGLocatable;
+        node: () => SVGLocatable;
     }
 
     export interface UpdateSelection extends Selection {

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -424,7 +424,7 @@ declare module D3 {
         /**
         * Returns a built-in easing function of the specified type
         */
-        ease: (type: string, ...arrs: any[]) => Transition;
+        ease: (type: string, ...arrs: any[]) => D3.Transition.Transition;
         /**
         * Constructs a new RGB color.
         */
@@ -487,8 +487,14 @@ declare module D3 {
         * gets the touch positions relative to a specified container.
         */
         touches(container: any): Array<number>;
-        functor<T>(value: T): T;
-        functor<T>(value: () => T): T;
+
+        /**
+        * If the specified value is a function, returns the specified value.
+        * Otherwise, returns a function that returns the specified value.
+        */
+        functor<R,T>(value: (p : R) => T): (p : R) => T;
+        functor<T>(value: T): (p : any) => T;
+
         map(object?: any): Map;
         set(array?: Array<any>): Set;
         dispatch(...types: Array<string>): Dispatch;
@@ -659,6 +665,7 @@ declare module D3 {
             (name: string): string;
             (name: string, value: any): Selection;
             (name: string, valueFunction: (data: any, index: number) => any): Selection;
+            (attrValueMap : any): Selection;
         };
 
         classed: {
@@ -696,8 +703,8 @@ declare module D3 {
         remove: () => Selection;
 
         data: {
-            (values: (data: any, index: number) => any): UpdateSelection;
-            (values: any[], key?: (data: any, index: number) => any): UpdateSelection;
+            (values: (data: any, index?: number) => any[], key?: (data: any, index?: number) => string): UpdateSelection;
+            (values: any[], key?: (data: any, index?: number) => string): UpdateSelection;
         };
 
         datum: {
@@ -732,7 +739,7 @@ declare module D3 {
         append: (name: string) => Selection;
         insert: (name: string, before: string) => Selection;
         select: (selector: string) => Selection;
-        empty: () => bool;
+        empty: () => boolean;
         node: () => HTMLElementSVGLocatable;
     }
 
@@ -742,13 +749,21 @@ declare module D3 {
         exit: () => Selection;
     }
 
-    export interface Nest {
-        key(keyFunction: (data: any, index: number) => any): Nest;
-        rollup(rollupFunction: (data: any, index: number) => any): Nest;
-        map(values: any[]): Nest;
+    export interface NestKeyValue {
+        key: string;
+        values: any;
     }
 
-    export interface Map{
+    export interface Nest {
+        key(keyFunction: (data: any, index: number) => any): Nest;
+        sortKeys(comparator: (d1: any, d2: any) => number): Nest;
+        sortValues(comparator: (d1: any, d2: any) => number): Nest;
+        rollup(rollupFunction: (data: any, index: number) => any): Nest;
+        map(values: any[]): any;
+        entries(values: any[]): NestKeyValue[];
+    }
+
+    export interface Map {
         has(key: string): boolean;
         get(key: string): any;
         set<T>(key: string, value: T): T;
@@ -805,6 +820,7 @@ declare module D3 {
                 (name: string): string;
                 (name: string, value: any): Transition;
                 (name: string, valueFunction: (data: any, index: number) => any): Transition;
+                (attrValueMap : any): Transition;
             };
             style: {
                 (name: string): string;
@@ -944,19 +960,19 @@ declare module D3 {
     export module Layout {
         export interface Layout {
             /**
-            * Creates a new Stack layout 
+            * Creates a new Stack layout
             */
             stack(): StackLayout;
             /**
-            * Creates a new pie layout 
+            * Creates a new pie layout
             */
             pie(): PieLayout;
             /**
-            * Creates a new force layout 
+            * Creates a new force layout
             */
             force(): ForceLayout;
             /**
-            * Creates a new tree layout 
+            * Creates a new tree layout
             */
             tree(): TreeLayout;
             bundle(): BundleLayout;
@@ -1052,11 +1068,15 @@ declare module D3 {
                 (): number;
                 (angle: number): D3.Svg.Arc;
                 (angle: () => number): D3.Svg.Arc;
+                (angle: (d : any) => number): D3.Svg.Arc;
+                (angle: (d : any, i: number) => number): D3.Svg.Arc;
             };
             endAngle: {
                 (): number;
                 (angle: number): D3.Svg.Arc;
                 (angle: () => number): D3.Svg.Arc;
+                (angle: (d : any) => number): D3.Svg.Arc;
+                (angle: (d : any, i: number) => number): D3.Svg.Arc;
             };
         }
 
@@ -1082,7 +1102,7 @@ declare module D3 {
             startAngle: number;
             endAngle: number;
             value: number;
-            fixed: bool;
+            fixed: boolean;
             children: GraphNode[];
             _children: GraphNode[];
             parent: GraphNode;
@@ -1489,11 +1509,11 @@ declare module D3 {
                 /**
                 * Gets the current brush extent
                 */
-                (): Array<Array<number>>;
+                (): any[];
                 /**
                 * Sets the current brush extent
                 */
-                (values: Array<Array<number>>): Brush;
+                (values: any[]): Brush;
             };
             /**
             * Clears the extent, making the brush extent empty.
@@ -1541,41 +1561,48 @@ declare module D3 {
         }
 
         export interface Arc {
-            (options?: ArcOptions): string;
-            innerRadius: {
-                (): number;
+           /**
+           * Returns the path data string
+           *
+           * @param data Array of data elements
+           * @param index Optional index
+           */
+           (data: any, index?: number): string;
+           innerRadius: {
+                (): (data: any, index?: number) => number;
                 (radius: number): Arc;
                 (radius: () => number): Arc;
+                (radius: (data: any) => number): Arc;
+                (radius: (data: any, index: number) => number): Arc;
             };
             outerRadius: {
-                (): number;
+                (): (data: any, index?: number) => number;
                 (radius: number): Arc;
                 (radius: () => number): Arc;
+                (radius: (data: any) => number): Arc;
+                (radius: (data: any, index: number) => number): Arc;
             };
             startAngle: {
-                (): number;
+                (): (data: any, index?: number) => number;
                 (angle: number): Arc;
                 (angle: () => number): Arc;
+                (angle: (data: any) => number): Arc;
+                (angle: (data: any, index: number) => number): Arc;
             };
             endAngle: {
-                (): number;
+                (): (data: any, index?: number) => number;
                 (angle: number): Arc;
                 (angle: () => number): Arc;
+                (angle: (data: any) => number): Arc;
+                (angle: (data: any, index: number) => number): Arc;
             };
-            centroid(options?: ArcOptions): number[];
-        }
-
-        export interface ArcOptions {
-            innerRadius?: number;
-            outerRadius?: number;
-            startAngle?: number;
-            endAngle?: number;
+            centroid(data: any, index?: number): number[];
         }
 
         export interface Line {
             /**
             * Returns the path data string
-            * 
+            *
             * @param data Array of data elements
             * @param index Optional index
             */
@@ -1587,13 +1614,20 @@ declare module D3 {
                 /**
                 * Get the x-coordinate accessor.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => number;
                 /**
                 * Set the x-coordinate accessor.
                 *
                 * @param accessor The new accessor function
                 */
-                (accessor: (data: any) => any): Line;
+                (accessor: (data: any) => number): Line;
+                (accessor: (data: any, index: number) => number): Line;
+                /**
+                * Set the  x-coordinate to a constant.
+                *
+                * @param cnst The new constant value.
+                */
+                (cnst: number): Line;
             };
             /**
             * Get or set the y-coordinate accessor.
@@ -1602,13 +1636,20 @@ declare module D3 {
                 /**
                 * Get the y-coordinate accessor.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => number;
                 /**
                 * Set the y-coordinate accessor.
                 *
                 * @param accessor The new accessor function
                 */
-                (accessor: (data: any) => any): Line;
+                (accessor: (data: any) => number): Line;
+                (accessor: (data: any, index: number) => number): Line;
+                /**
+                * Set the  y-coordinate to a constant.
+                *
+                * @param cnst The new constant value.
+                */
+                (cnst: number): Line;
             };
             /**
             * Get or set the interpolation mode.
@@ -1647,20 +1688,20 @@ declare module D3 {
                 /**
                 * Get the accessor function that controls where the line is defined.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => boolean;
                 /**
                 * Set the accessor function that controls where the area is defined.
                 *
                 * @param defined The new accessor function
                 */
-                (defined: (data: any) => any): Line;
+                (defined: (data: any) => boolean): Line;
             };
         }
 
         export interface LineRadial {
             /**
             * Returns the path data string
-            * 
+            *
             * @param data Array of data elements
             * @param index Optional index
             */
@@ -1672,13 +1713,21 @@ declare module D3 {
                 /**
                 * Get the x-coordinate accessor.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => number;
                 /**
                 * Set the x-coordinate accessor.
                 *
                 * @param accessor The new accessor function
                 */
-                (accessor: (data: any) => any): LineRadial;
+                (accessor: (data: any) => number): LineRadial;
+                (accessor: (data: any, index: number) => number): LineRadial;
+
+                /**
+                * Set the  x-coordinate to a constant.
+                *
+                * @param cnst The new constant value.
+                */
+                (cnst: number): LineRadial;
             };
             /**
             * Get or set the y-coordinate accessor.
@@ -1687,13 +1736,20 @@ declare module D3 {
                 /**
                 * Get the y-coordinate accessor.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => number;
                 /**
                 * Set the y-coordinate accessor.
                 *
                 * @param accessor The new accessor function
                 */
-                (accessor: (data: any) => any): LineRadial;
+                (accessor: (data: any) => number): LineRadial;
+                (accessor: (data: any, index: number) => number): LineRadial;
+                /**
+                * Set the  y-coordinate to a constant.
+                *
+                * @param cnst The new constant value.
+                */
+                (cnst: number): LineRadial;
             };
             /**
             * Get or set the interpolation mode.
@@ -1741,13 +1797,15 @@ declare module D3 {
                 (defined: (data: any) => any): LineRadial;
             };
             radius: {
-                (): (d: any, i: any) => number;
+                (): (d: any, i?: number) => number;
                 (radius: number): LineRadial;
-                (radius: (d: any, i: any) => number): LineRadial;
+                (radius: (d: any) => number): LineRadial;
+                (radius: (d: any, i: number) => number): LineRadial;
             }
             angle: {
-                (): (d: any, i: any) => number;
+                (): (d: any, i?: any) => number;
                 (angle: number): LineRadial;
+                (angle: (d: any) => number): LineRadial;
                 (angle: (d: any, i: any) => number): LineRadial;
             }
         }
@@ -1764,13 +1822,20 @@ declare module D3 {
                 /**
                 * Get the x-coordinate accessor.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => number;
                 /**
                 * Set the x-coordinate accessor.
                 *
                 * @param accessor The new accessor function
                 */
-                (accessor: (data: any) => any): Area;
+                (accessor: (data: any) => number): Area;
+                (accessor: (data: any, index: number) => number): Area;
+                /**
+                * Set the  x-coordinate to a constant.
+                *
+                * @param cnst The new constant value.
+                */
+                (cnst: number): Area;
             };
             /**
             * Get or set the x0-coordinate (baseline) accessor.
@@ -1779,13 +1844,20 @@ declare module D3 {
                 /**
                 * Get the  x0-coordinate (baseline) accessor.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => number;
                 /**
                 * Set the  x0-coordinate (baseline) accessor.
                 *
                 * @param accessor The new accessor function
                 */
-                (accessor: (data: any) => any): Area;
+                (accessor: (data: any) => number): Area;
+                (accessor: (data: any, index: number) => number): Area;
+                /**
+                * Set the  x0-coordinate (baseline) to a constant.
+                *
+                * @param cnst The new constant value.
+                */
+                (cnst: number): Area;
             };
             /**
             * Get or set the x1-coordinate (topline) accessor.
@@ -1794,13 +1866,20 @@ declare module D3 {
                 /**
                 * Get the  x1-coordinate (topline) accessor.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => number;
                 /**
                 * Set the  x1-coordinate (topline) accessor.
                 *
                 * @param accessor The new accessor function
                 */
-                (accessor: (data: any) => any): Area;
+                (accessor: (data: any) => number): Area;
+                (accessor: (data: any, index: number) => number): Area;
+                /**
+                * Set the  x1-coordinate (topline) to a constant.
+                *
+                * @param cnst The new constant value.
+                */
+                (cnst: number): Area;
             };
             /**
             * Get or set the y-coordinate accessor.
@@ -1809,13 +1888,20 @@ declare module D3 {
                 /**
                 * Get the y-coordinate accessor.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => number;
                 /**
                 * Set the y-coordinate accessor.
                 *
                 * @param accessor The new accessor function
                 */
-                (accessor: (data: any) => any): Area;
+                (accessor: (data: any) => number): Area;
+                (accessor: (data: any, index: number) => number): Area;
+                /**
+                * Set the y-coordinate to a constant.
+                *
+                * @param cnst The constant value
+                */
+                (cnst: number): Area;
             };
             /**
             * Get or set the y0-coordinate (baseline) accessor.
@@ -1824,13 +1910,20 @@ declare module D3 {
                 /**
                 * Get the y0-coordinate (baseline) accessor.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => number;
                 /**
                 * Set the y0-coordinate (baseline) accessor.
                 *
                 * @param accessor The new accessor function
                 */
-                (accessor: (data: any) => any): Area;
+                (accessor: (data: any) => number): Area;
+                (accessor: (data: any, index: number) => number): Area;
+                /**
+                * Set the y0-coordinate (baseline) to a constant.
+                *
+                * @param cnst The constant value
+                */
+                (cnst: number): Area;
             };
             /**
             * Get or set the y1-coordinate (topline) accessor.
@@ -1839,13 +1932,20 @@ declare module D3 {
                 /**
                 * Get the y1-coordinate (topline) accessor.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => number;
                 /**
                 * Set the y1-coordinate (topline) accessor.
                 *
                 * @param accessor The new accessor function
                 */
-                (accessor: (data: any) => any): Area;
+                (accessor: (data: any) => number): Area;
+                (accessor: (data: any, index: number) => number): Area;
+                /**
+                * Set the y1-coordinate (baseline) to a constant.
+                *
+                * @param cnst The constant value
+                */
+                (cnst: number): Area;
             };
             /**
             * Get or set the interpolation mode.
@@ -1906,13 +2006,20 @@ declare module D3 {
                 /**
                 * Get the x-coordinate accessor.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => number;
                 /**
                 * Set the x-coordinate accessor.
                 *
                 * @param accessor The new accessor function
                 */
-                (accessor: (data: any) => any): AreaRadial;
+                (accessor: (data: any) => number): AreaRadial;
+                (accessor: (data: any, index: number) => number): AreaRadial;
+                /**
+                * Set the  x-coordinate to a constant.
+                *
+                * @param cnst The new constant value.
+                */
+                (cnst: number): AreaRadial;
             };
             /**
             * Get or set the x0-coordinate (baseline) accessor.
@@ -1921,13 +2028,20 @@ declare module D3 {
                 /**
                 * Get the  x0-coordinate (baseline) accessor.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => number;
                 /**
                 * Set the  x0-coordinate (baseline) accessor.
                 *
                 * @param accessor The new accessor function
                 */
-                (accessor: (data: any) => any): AreaRadial;
+                (accessor: (data: any) => number): AreaRadial;
+                (accessor: (data: any, index: number) => number): AreaRadial;
+                /**
+                * Set the  x0-coordinate to a constant.
+                *
+                * @param cnst The new constant value.
+                */
+                (cnst: number): AreaRadial;
             };
             /**
             * Get or set the x1-coordinate (topline) accessor.
@@ -1936,13 +2050,20 @@ declare module D3 {
                 /**
                 * Get the  x1-coordinate (topline) accessor.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => number;
                 /**
                 * Set the  x1-coordinate (topline) accessor.
                 *
                 * @param accessor The new accessor function
                 */
-                (accessor: (data: any) => any): AreaRadial;
+                (accessor: (data: any) => number): AreaRadial;
+                (accessor: (data: any, index: number) => number): AreaRadial;
+                /**
+                * Set the  x1-coordinate to a constant.
+                *
+                * @param cnst The new constant value.
+                */
+                (cnst: number): AreaRadial;
             };
             /**
             * Get or set the y-coordinate accessor.
@@ -1951,13 +2072,20 @@ declare module D3 {
                 /**
                 * Get the y-coordinate accessor.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => number;
                 /**
                 * Set the y-coordinate accessor.
                 *
                 * @param accessor The new accessor function
                 */
-                (accessor: (data: any) => any): AreaRadial;
+                (accessor: (data: any) => number): AreaRadial;
+                (accessor: (data: any, index: number) => number): AreaRadial;
+                /**
+                * Set the y-coordinate to a constant.
+                *
+                * @param cnst The new constant value.
+                */
+                (cnst: number): AreaRadial;
             };
             /**
             * Get or set the y0-coordinate (baseline) accessor.
@@ -1966,13 +2094,20 @@ declare module D3 {
                 /**
                 * Get the y0-coordinate (baseline) accessor.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => number;
                 /**
                 * Set the y0-coordinate (baseline) accessor.
                 *
                 * @param accessor The new accessor function
                 */
-                (accessor: (data: any) => any): AreaRadial;
+                (accessor: (data: any) => number): AreaRadial;
+                (accessor: (data: any, index: number) => number): AreaRadial;
+                /**
+                * Set the  y0-coordinate to a constant.
+                *
+                * @param cnst The new constant value.
+                */
+                (cnst: number): AreaRadial;
             };
             /**
             * Get or set the y1-coordinate (topline) accessor.
@@ -1981,13 +2116,20 @@ declare module D3 {
                 /**
                 * Get the y1-coordinate (topline) accessor.
                 */
-                (): (data: any) => any;
+                (): (data: any, index ?: number) => number;
                 /**
                 * Set the y1-coordinate (topline) accessor.
                 *
                 * @param accessor The new accessor function
                 */
-                (accessor: (data: any) => any): AreaRadial;
+                (accessor: (data: any) => number): AreaRadial;
+                (accessor: (data: any, index: number) => number): AreaRadial;
+                /**
+                * Set the  y1-coordinate to a constant.
+                *
+                * @param cnst The new constant value.
+                */
+                (cnst: number): AreaRadial;
             };
             /**
             * Get or set the interpolation mode.
@@ -2038,31 +2180,43 @@ declare module D3 {
                 (): number;
                 (radius: number): AreaRadial;
                 (radius: () => number): AreaRadial;
+                (radius: (data: any) => number): AreaRadial;
+                (radius: (data: any, index: number) => number): AreaRadial;
             };
             innerRadius: {
                 (): number;
                 (radius: number): AreaRadial;
                 (radius: () => number): AreaRadial;
+                (radius: (data: any) => number): AreaRadial;
+                (radius: (data: any, index: number) => number): AreaRadial;
             };
             outerRadius: {
                 (): number;
                 (radius: number): AreaRadial;
                 (radius: () => number): AreaRadial;
+                (radius: (data: any) => number): AreaRadial;
+                (radius: (data: any, index: number) => number): AreaRadial;
             };
             angle: {
                 (): number;
                 (angle: number): AreaRadial;
                 (angle: () => number): AreaRadial;
+                (angle: (data: any) => number): AreaRadial;
+                (angle: (data: any, index: number) => number): AreaRadial;
             };
             startAngle: {
                 (): number;
                 (angle: number): AreaRadial;
                 (angle: () => number): AreaRadial;
+                (angle: (data: any) => number): AreaRadial;
+                (angle: (data: any, index: number) => number): AreaRadial;
             };
             endAngle: {
                 (): number;
                 (angle: number): AreaRadial;
                 (angle: () => number): AreaRadial;
+                (angle: (data: any) => number): AreaRadial;
+                (angle: (data: any, index: number) => number): AreaRadial;
             };
         }
 
@@ -2098,18 +2252,21 @@ declare module D3 {
         export interface Diagonal {
             (datum: any, index?: number): string;
             projection: {
-                (): Array<number>;
-                (radius: (d: any, i?: number) => Array<number>): Diagonal;
+                (): (datum: any, index?: number) => Array<number>;
+                (proj: (datum: any) => Array<number>): Diagonal;
+                (proj: (datum: any, index: number) => Array<number>): Diagonal;
             };
             source: {
-                (): any;
-                (angle: any): Diagonal;
-                (angle: (d: any, i?: number) => any): Diagonal;
+                (): (datum: any, index?: number) => any;
+                (src: (datum: any) => any): Diagonal;
+                (src: (datum: any, index: number) => any): Diagonal;
+                (src: any): Diagonal;
             };
             target: {
-                (): any;
-                (angle: any): Diagonal;
-                (angle: (d: any, i?: number) => any): Diagonal;
+                (): (datum: any, index?: number) => any;
+                (target: (d: any) => any): Diagonal;
+                (target: (d: any, i: number) => any): Diagonal;
+                (target: any): Diagonal;
             };
         }
     }
@@ -2980,7 +3137,7 @@ declare module D3 {
                 (accesor: (d: any) => any): Quadtree;
 
             }
-                y: {
+            y: {
                 (): (d: any) => any;
                 (accesor: (d: any) => any): Quadtree;
 

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -755,7 +755,7 @@ declare module D3 {
     }
 
     export interface Nest {
-        key(keyFunction: (data: any, index: number) => any): Nest;
+        key(keyFunction: (data: any, index: number) => string): Nest;
         sortKeys(comparator: (d1: any, d2: any) => number): Nest;
         sortValues(comparator: (d1: any, d2: any) => number): Nest;
         rollup(rollupFunction: (data: any, index: number) => any): Nest;


### PR DESCRIPTION
In this pull-request:
1. Added tests for various calls, adopted from D3's tests.
2. Fixed type problems with some of the setters and getters of accessors.
3. Added some missing functions (in Nest) and fixed some incorrect ones (Arc, centroid)
4. Made the a little more `v0.9.1` friendly (renamed `bool` to `boolean`, avoided overloading functions by return type, fixed names of types/modules)

I ran into a compiler issue with one of the tests. The issue does not happen with the `devel` version of the compiler. I have included the test in the body nevertheless.
