### PR TITLE
Added getSubscriptionsCount function to KnockoutComputedFunctions

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -15,6 +15,7 @@ interface KnockoutSubscribableFunctions {
 
 interface KnockoutComputedFunctions extends KnockoutSubscribableFunctions {
     getDependenciesCount(): number;
+    getSubscriptionsCount(): number;
     hasWriteFunction(): boolean;
 }
 


### PR DESCRIPTION
The function "getSubscriptionsCount" was missing and is expected to be available to all KnockoutComputed<T> objects, as stated in the docs:
http://knockoutjs.com/documentation/computedObservables.html#computed_observable_reference
