### PR TITLE
AngularJS: give an interface to $http callback functions

### DIFF
--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -137,6 +137,20 @@ module HttpAndRegularPromiseTests {
       $scope.letters = letters;
     });
   }
+
+  // Test that we can pass around a type-checked success/error Promise Callback
+  var anotherController: Function = ($scope: SomeControllerScope, $http:
+      ng.IHttpService, $q: ng.IQService) => {
+
+    var buildFooData: Function = () => 42;
+
+    var doFoo: Function = (callback: ng.IHttpPromiseCallback) => {
+      $http.get('/foo', buildFooData())
+        .success(callback);
+    }
+
+    doFoo((data) => console.log(data));
+  }
 }
 
 // Test for AngularJS Syntac

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -531,6 +531,10 @@ declare module ng {
         transformResponse?: any;
     }
 
+    interface IHttpPromiseCallback {
+        (data: any, status: number, headers: (headerName: string) => string, config: IRequestConfig): any;
+    }
+
     interface IHttpPromiseCallbackArg {
         data?: any;
         status?: number;
@@ -539,8 +543,8 @@ declare module ng {
     }
 
     interface IHttpPromise extends IPromise {
-        success(callback: (data: any, status: number, headers: (headerName: string) => string, config: IRequestConfig) => any): IHttpPromise;
-        error(callback: (data: any, status: number, headers: (headerName: string) => string, config: IRequestConfig) => any): IHttpPromise;
+        success(callback: IHttpPromiseCallback): IHttpPromise;
+        error(callback: IHttpPromiseCallback): IHttpPromise;
         then(successCallback: (response: IHttpPromiseCallbackArg) => any, errorCallback?: (response: IHttpPromiseCallbackArg) => any): IPromise;
     }
 


### PR DESCRIPTION
- add IHttpPromiseCallback for both `error` and `success` promise calls

use case is if we're passing around the callback, we don't want to be
repeating that entire function declaration every time, and we cannot use
`Function` as that doesn't satisfy the compiler. (see test case)
