### PR TITLE
Angular JS: adding debug() to the log service

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -305,6 +305,7 @@ declare module ng {
     // see http://docs.angularjs.org/api/ng.$log
     ///////////////////////////////////////////////////////////////////////////
     interface ILogService {
+        debug: ILogCall;
         error: ILogCall;
         info: ILogCall;
         log: ILogCall;


### PR DESCRIPTION
I'm not sure what version of angular is being targeted but this logging method was added in v1.1.2 though it only exists in the 1.1.\* branch.

http://code.angularjs.org/1.1.5/docs/api/ng.$log
