### PR TITLE
Added ko.unwrap shortcut

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -402,6 +402,7 @@ interface KnockoutStatic {
     cleanNode(node: Element);
     renderTemplate(template: Function, viewModel: any, options?: any, target?: any, renderMode?: any);
     renderTemplate(template: string, viewModel: any, options?: any, target?: any, renderMode?: any);
+    unwrap(value: any): any;
 
     //////////////////////////////////
     // templateSources.js


### PR DESCRIPTION
Detailed in release notes for 2.3.0 https://github.com/knockout/knockout/releases/tag/v2.3.0

There is a shortcut for ko.utils.unwrapObservable, now a much nicer cleaner ko.unwrap
