### PR TITLE
Fix withConfig return type in restangular

### DIFF
--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -10,7 +10,7 @@ interface Restangular extends RestangularCustom {
     one(route: string, id?: number): RestangularElement;
     all(route: string): RestangularCollection;
     copy(fromElement: any): RestangularElement;
-    withConfig(configurer: any): RestangularElement;
+    withConfig(configurer: any): Restangular;
 }
 
 interface RestangularElement extends Restangular {


### PR DESCRIPTION
`withConfig` method returns a new Restangular service, not a RestangularElement.
https://github.com/mgonto/restangular#properties
