### PR TITLE
Restangular also accepts strings as id for the method "one"

### DIFF
--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -8,6 +8,7 @@
 
 interface Restangular extends RestangularCustom {
     one(route: string, id?: number): RestangularElement;
+    one(route: string, id?: string): RestangularElement;
     all(route: string): RestangularCollection;
     copy(fromElement: any): RestangularElement;
     withConfig(configurer: any): Restangular;


### PR DESCRIPTION
This could be avoided using a custom method, but since it actually works it would be nice to have support for it.
