### PR TITLE
IRoute.templateUrl also now accepts a function instead of a string.

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -622,7 +622,7 @@ declare module ng {
     interface IRoute {
         controller?: any;
         template?: string;
-        templateUrl?: string;
+        templateUrl?: any;
         resolve?: any;
         redirectTo?: any;
         reloadOnSearch?: boolean;


### PR DESCRIPTION
Adjusted templateUrl of IRoute because $routeProvider now allows function templateUrls to be defined such as;

```
    .when("/:controller/:action", { 
        templateUrl: function ($routeParams) {
            console.log("Default rule");
            return '/ng/app/views/partials/' + $routeParams.action.toLowerCase() + '.htm';
        }
    })
```
