### PR TITLE
Added generics to IHttpPromise and some missing properties/overloads

### DIFF
--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -9,148 +9,144 @@ https://github.com/witoldsz/angular-http-auth/blob/master/src/angular-http-auth.
  */
 angular.module('http-auth-interceptor', [])
 
-  .provider('authService', function () {
-      /**
-       * Holds all the requests which failed due to 401 response,
-       * so they can be re-requested in future, once login is completed.
-       */
-      var buffer = [];
+    .provider('authService', function () {
+        /**
+         * Holds all the requests which failed due to 401 response,
+         * so they can be re-requested in future, once login is completed.
+         */
+        var buffer = [];
 
-      /**
-       * Required by HTTP interceptor.
-       * Function is attached to provider to be invisible for regular users of this service.
-       */
-      this.pushToBuffer = function (config: ng.IRequestConfig, deferred: ng.IDeferred) {
-          buffer.push({
-              config: config,
-              deferred: deferred
-          });
-      }
+        /**
+         * Required by HTTP interceptor.
+         * Function is attached to provider to be invisible for regular users of this service.
+         */
+        this.pushToBuffer = function (config: ng.IRequestConfig, deferred: ng.IDeferred) {
+            buffer.push({
+                config: config,
+                deferred: deferred
+            });
+        }
 
       this.$get = ['$rootScope', '$injector', <any>function ($rootScope: ng.IScope, $injector: ng.auto.IInjectorService) {
-          var $http: ng.IHttpService; //initialized later because of circular dependency problem
-          function retry(config: ng.IRequestConfig, deferred: ng.IDeferred) {
-              $http = $http || $injector.get('$http');
-              $http(config).then(function (response) {
-                  deferred.resolve(response);
-              });
-          }
-          function retryAll() {
-              for (var i = 0; i < buffer.length; ++i) {
-                  retry(buffer[i].config, buffer[i].deferred);
-              }
-              buffer = [];
-          }
+            var $http: ng.IHttpService; //initialized later because of circular dependency problem
+            function retry(config: ng.IRequestConfig, deferred: ng.IDeferred) {
+                $http = $http || $injector.get('$http');
+                $http(config).then(function (response) {
+                    deferred.resolve(response);
+                });
+            }
+            function retryAll() {
+                for (var i = 0; i < buffer.length; ++i) {
+                    retry(buffer[i].config, buffer[i].deferred);
+                }
+                buffer = [];
+            }
 
           return {
-              loginConfirmed: function () {
-                  $rootScope.$broadcast('event:auth-loginConfirmed');
-                  retryAll();
-              }
-          }
+                loginConfirmed: function () {
+                    $rootScope.$broadcast('event:auth-loginConfirmed');
+                    retryAll();
+                }
+            }
       }]
   })
 
-  /**
-   * $http interceptor.
-   * On 401 response - it stores the request and broadcasts 'event:angular-auth-loginRequired'.
-   */
-  .config(['$httpProvider', 'authServiceProvider', <any>function ($httpProvider: ng.IHttpProvider, authServiceProvider) {
+/**
+ * $http interceptor.
+ * On 401 response - it stores the request and broadcasts 'event:angular-auth-loginRequired'.
+ */
+    .config(['$httpProvider', 'authServiceProvider', <any>function ($httpProvider: ng.IHttpProvider, authServiceProvider) {
 
-      var interceptor = ['$rootScope', '$q', <any>function ($rootScope: ng.IScope, $q: ng.IQService) {
-          function success(response: ng.IHttpPromiseCallbackArg) {
-              return response;
-          }
+        var interceptor = ['$rootScope', '$q', <any>function ($rootScope: ng.IScope, $q: ng.IQService) {
+            function success(response: ng.IHttpPromiseCallbackArg<any>) {
+                return response;
+            }
 
-          function error(response: ng.IHttpPromiseCallbackArg) {
-              if (response.status === 401) {
-                  var deferred = $q.defer();
-                  authServiceProvider.pushToBuffer(response.config, deferred);
-                  $rootScope.$broadcast('event:auth-loginRequired');
-                  return deferred.promise;
-              }
-              // otherwise
-              return $q.reject(response);
-          }
+            function error(response: ng.IHttpPromiseCallbackArg<any>) {
+                if (response.status === 401) {
+                    var deferred = $q.defer();
+                    authServiceProvider.pushToBuffer(response.config, deferred);
+                    $rootScope.$broadcast('event:auth-loginRequired');
+                    return deferred.promise;
+                }
+                // otherwise
+                return $q.reject(response);
+            }
 
-          return function (promise: ng.IHttpPromise) {
-              return promise.then(success, error);
-          }
+          return function (promise: ng.IHttpPromise<any>) {
+                return promise.then(success, error);
+            }
 
       }];
-      $httpProvider.responseInterceptors.push(interceptor);
-  }]);
+        $httpProvider.responseInterceptors.push(interceptor);
+    }]);
 
 
 module HttpAndRegularPromiseTests {
-  interface Person {
-    firstName: string;
-    lastName:  string;
-  }
+    interface Person {
+        firstName: string;
+        lastName: string;
+    }
 
-  interface ExpectedResponse extends Person {}
+    interface ExpectedResponse extends Person { }
 
-  interface SomeControllerScope extends ng.IScope {
-    person:    Person;
-    theAnswer: number;
-    letters:   string[];
-  }
+    interface SomeControllerScope extends ng.IScope {
+        person: Person;
+        theAnswer: number;
+        letters: string[];
+    }
 
-  interface OurApiPromiseCallbackArg extends ng.IHttpPromiseCallbackArg {
-    data?: ExpectedResponse;
-  }
+    var someController: Function = ($scope: SomeControllerScope, $http: ng.IHttpService, $q: ng.IQService) => {
+        $http.get("http://somewhere/some/resource")
+            .success((data: ExpectedResponse) => {
+                $scope.person = data;
+            });
 
-  var someController: Function = ($scope: SomeControllerScope, $http: ng.IHttpService, $q: ng.IQService) => {
-    $http.get("http://somewhere/some/resource")
-    .success((data: ExpectedResponse) => {
-      $scope.person = data;
-    });
+        $http.get("http://somewhere/some/resource")
+            .then((response: ng.IHttpPromiseCallbackArg<ExpectedResponse>) => {
+                // typing lost, so something like
+                // var i: number = response.data
+                // would type check
+                $scope.person = response.data;
+            });
 
-    $http.get("http://somewhere/some/resource")
-    .then((response: ng.IHttpPromiseCallbackArg) => {
-      // typing lost, so something like
-      // var i: number = response.data
-      // would type check
-      $scope.person = response.data;
-    });
+        $http.get("http://somewhere/some/resource")
+            .then((response: ng.IHttpPromiseCallbackArg<ExpectedResponse>) => {
+                // typing lost, so something like
+                // var i: number = response.data
+                // would NOT type check
+                $scope.person = response.data;
+            });
 
-    $http.get("http://somewhere/some/resource")
-    .then((response: OurApiPromiseCallbackArg) => {
-      // typing lost, so something like
-      // var i: number = response.data
-      // would NOT type check
-      $scope.person = response.data;
-    });
+        var aPromise: ng.IPromise = $q.when({ firstName: "Jack", lastName: "Sparrow" });
+        aPromise.then((person: Person) => {
+            $scope.person = person;
+        });
 
-    var aPromise: ng.IPromise = $q.when({firstName: "Jack", lastName: "Sparrow"});
-    aPromise.then((person: Person) => {
-      $scope.person = person;
-    });
+        var bPromise: ng.IPromise = $q.when(42);
+        bPromise.then((answer: number) => {
+            $scope.theAnswer = answer;
+        });
 
-    var bPromise: ng.IPromise = $q.when(42);
-    bPromise.then((answer: number) => {
-      $scope.theAnswer = answer;
-    });
-
-    var cPromise: ng.IPromise = $q.when(["a", "b", "c"]);
-    cPromise.then((letters: string[]) => {
-      $scope.letters = letters;
-    });
-  }
+        var cPromise: ng.IPromise = $q.when(["a", "b", "c"]);
+        cPromise.then((letters: string[]) => {
+            $scope.letters = letters;
+        });
+    }
 
   // Test that we can pass around a type-checked success/error Promise Callback
   var anotherController: Function = ($scope: SomeControllerScope, $http:
-      ng.IHttpService, $q: ng.IQService) => {
+        ng.IHttpService, $q: ng.IQService) => {
 
-    var buildFooData: Function = () => 42;
+        var buildFooData: Function = () => 42;
 
-    var doFoo: Function = (callback: ng.IHttpPromiseCallback) => {
-      $http.get('/foo', buildFooData())
-        .success(callback);
-    }
+        var doFoo: Function = (callback: ng.IHttpPromiseCallback<ExpectedResponse>) => {
+            $http.get('/foo', buildFooData())
+                .success(callback);
+        }
 
     doFoo((data) => console.log(data));
-  }
+    }
 }
 
 // Test for AngularJS Syntac
@@ -160,24 +156,24 @@ module My.Namespace {
 }
 
 // IModule Registering Test
-var mod = angular.module('tests',[]);
-mod.controller('name', function($scope : ng.IScope) {})
-mod.controller('name', ['$scope', <any>function($scope : ng.IScope) {}])
+var mod = angular.module('tests', []);
+mod.controller('name', function ($scope: ng.IScope) { })
+mod.controller('name', ['$scope', <any>function ($scope: ng.IScope) { }])
 mod.controller(My.Namespace);
-mod.directive('name', <any>function ($scope: ng.IScope) {})
-mod.directive('name', ['$scope', <any>function($scope : ng.IScope) {}])
+mod.directive('name', <any>function ($scope: ng.IScope) { })
+mod.directive('name', ['$scope', <any>function ($scope: ng.IScope) { }])
 mod.directive(My.Namespace);
-mod.factory('name', function($scope : ng.IScope) {})
-mod.factory('name', ['$scope', <any>function($scope : ng.IScope) {}])
+mod.factory('name', function ($scope: ng.IScope) { })
+mod.factory('name', ['$scope', <any>function ($scope: ng.IScope) { }])
 mod.factory(My.Namespace);
-mod.filter('name', function($scope : ng.IScope) {})
-mod.filter('name', ['$scope', <any>function($scope : ng.IScope) {}])
+mod.filter('name', function ($scope: ng.IScope) { })
+mod.filter('name', ['$scope', <any>function ($scope: ng.IScope) { }])
 mod.filter(My.Namespace);
-mod.provider('name', function($scope : ng.IScope) {})
-mod.provider('name', ['$scope', <any>function($scope : ng.IScope) {}])
+mod.provider('name', function ($scope: ng.IScope) { })
+mod.provider('name', ['$scope', <any>function ($scope: ng.IScope) { }])
 mod.provider(My.Namespace);
-mod.service('name', function($scope : ng.IScope) {})
-mod.service('name', ['$scope', <any>function($scope : ng.IScope) {}])
+mod.service('name', function ($scope: ng.IScope) { })
+mod.service('name', ['$scope', <any>function ($scope: ng.IScope) { }])
 mod.service(My.Namespace);
 mod.constant('name', 23);
 mod.constant('name', "23");

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -537,21 +537,21 @@ declare module ng {
         transformResponse?: any;
     }
 
-    interface IHttpPromiseCallback {
-        (data: any, status: number, headers: (headerName: string) => string, config: IRequestConfig): any;
+    interface IHttpPromiseCallback<T> {
+        (data: T, status: number, headers: (headerName: string) => string, config: IRequestConfig): any;
     }
 
-    interface IHttpPromiseCallbackArg {
-        data?: any;
+    interface IHttpPromiseCallbackArg<T> {
+        data?: T;
         status?: number;
         headers?: (headerName: string) => string;
         config?: IRequestConfig;
     }
 
-    interface IHttpPromise extends IPromise {
-        success(callback: IHttpPromiseCallback): IHttpPromise;
-        error(callback: IHttpPromiseCallback): IHttpPromise;
-        then(successCallback: (response: IHttpPromiseCallbackArg) => any, errorCallback?: (response: IHttpPromiseCallbackArg) => any): IPromise;
+    interface IHttpPromise<T> extends IPromise {
+        success(callback: IHttpPromiseCallback<T>): IHttpPromise;
+        error(callback: IHttpPromiseCallback<T>): IHttpPromise;
+        then(successCallback: (response: IHttpPromiseCallbackArg<T>) => any, errorCallback?: (response: IHttpPromiseCallbackArg<T>) => any): IPromise;
     }
 
     interface IHttpProvider extends IServiceProvider {
@@ -639,6 +639,8 @@ declare module ng {
             $scope: IScope;
             $template: string;
         };
+
+        params: any;
     }
 
     interface IRouteProvider extends IServiceProvider {
@@ -693,6 +695,7 @@ declare module ng {
             constant(name: string, value: any): void;
 
             decorator(name: string, decorator: Function): void;
+            decorator(name: string, decoratorInline: any[]): void;
             factory(name: string, serviceFactoryFunction: Function): ng.IServiceProvider;
             provider(name: string, provider: ng.IServiceProvider): ng.IServiceProvider;
             provider(name: string, serviceProviderConstructor: Function): ng.IServiceProvider;


### PR DESCRIPTION
I know you haven't used generics so far so I hope this is a welcome
change - the only nuisance is that it will "break" current compilation
but will increase type safety by far.

Also added params to ICurrentRoute and inline injection notation to
$provide.decorator as per
https://github.com/borisyankov/DefinitelyTyped/issues/799
