### PR TITLE
various TS 0.9.1 fixes

### DIFF
--- a/globalize/globalize.d.ts
+++ b/globalize/globalize.d.ts
@@ -88,7 +88,7 @@ interface GlobalizeCulture {
     name: string;
     englishName: string;
     nativeName: string;
-    isRTL: bool;
+    isRTL: boolean;
     language: string;
     numberFormat: GlobalizeNumberFormat;
     calendars: GlobalizeCalendars;

--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -21,7 +21,7 @@ declare function expect(actual: any): jasmine.Matchers;
 declare function spyOn(object: any, method: string): jasmine.Spy;
 
 declare function runs(asyncMethod: Function): void;
-declare function waitsFor(latchMethod: () => bool, failureMessage: string, timeout?: number): void;
+declare function waitsFor(latchMethod: () => boolean, failureMessage: string, timeout?: number): void;
 declare function waits(timeout?: number): void;
 
 declare module jasmine {
@@ -59,7 +59,7 @@ declare module jasmine {
         uninstallMock(): void;
         real;
         assertInstalled(): void;
-        isInstalled(): bool;
+        isInstalled(): boolean;
         installed: any;
     }
 
@@ -86,7 +86,7 @@ declare module jasmine {
         equals_(a, b, mismatchKeys, mismatchValues);
         contains_(haystack, needle);
         addEqualityTester(equalityTester);
-        specFilter(spec): bool;
+        specFilter(spec): boolean;
     }
 
     interface FakeTimer {
@@ -143,37 +143,37 @@ declare module jasmine {
 
     interface Matchers {
 
-        new (env: Env, actual, spec: Env, isNot?: bool);
+        new (env: Env, actual, spec: Env, isNot?: boolean);
 
         env: Env;
         actual: any;
         spec: Env;
-        isNot?: bool;
+        isNot?: boolean;
         message(): any;
 
-        toBe(expected): bool;
-        toNotBe(expected): bool;
-        toEqual(expected): bool;
-        toNotEqual(expected): bool;
-        toMatch(expected): bool;
-        toNotMatch(expected): bool;
-        toBeDefined(): bool;
-        toBeUndefined(): bool;
-        toBeNull(): bool;
-        toBeNaN(): bool;
-        toBeTruthy(): bool;
-        toBeFalsy(): bool;
-        toHaveBeenCalled(): bool;
-        wasNotCalled(): bool;
-        toHaveBeenCalledWith(...params: any[]): bool;
-        toContain(expected): bool;
-        toNotContain(expected): bool;
-        toBeLessThan(expected): bool;
-        toBeGreaterThan(expected): bool;
-        toBeCloseTo(expected, precision): bool;
-        toContainHtml(expected: string): bool;
-        toContainText(expected: string): bool;
-        toThrow(expected? ): bool;
+        toBe(expected): boolean;
+        toNotBe(expected): boolean;
+        toEqual(expected): boolean;
+        toNotEqual(expected): boolean;
+        toMatch(expected): boolean;
+        toNotMatch(expected): boolean;
+        toBeDefined(): boolean;
+        toBeUndefined(): boolean;
+        toBeNull(): boolean;
+        toBeNaN(): boolean;
+        toBeTruthy(): boolean;
+        toBeFalsy(): boolean;
+        toHaveBeenCalled(): boolean;
+        wasNotCalled(): boolean;
+        toHaveBeenCalledWith(...params: any[]): boolean;
+        toContain(expected): boolean;
+        toNotContain(expected): boolean;
+        toBeLessThan(expected): boolean;
+        toBeGreaterThan(expected): boolean;
+        toBeCloseTo(expected, precision): boolean;
+        toContainHtml(expected: string): boolean;
+        toContainText(expected: string): boolean;
+        toThrow(expected? ): boolean;
         not: Matchers;
 
         Any: Any;
@@ -244,7 +244,7 @@ declare module jasmine {
         calls: any[];
         mostRecentCall: { args: any[]; };
         argsForCall: any[];
-        wasCalled: bool;
+        wasCalled: boolean;
         callCount: number;
 
         andReturn(value): Spy;

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -298,8 +298,6 @@ interface KnockoutUtils {
 
     setElementName(element: any, name: string): void;
 
-    ensureSelectElementIsRenderedCorrectly(selectElement);
-
     forceRefresh(node: any): void;
 
     ensureSelectElementIsRenderedCorrectly(selectElement: any): void;


### PR DESCRIPTION
For Knockout: Removed extra overload of ensureSelectElementIsRenderedCorrectly to prevent compiler error with TS 0.9.1 "error TS2175: Overloads cannot differ only by return type."

For Globalize: switched bool to boolean

For Jasmine: switched bool to boolean (so KO tests pass)
