### PR TITLE
Migrated a breaking change between Typescript 0.8 and 0.9.

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -1,8 +1,8 @@
 ﻿/// <reference path="node.d.ts" />
 
-import assert = module("assert");
-import fs = module("fs");
-import events = module("events");
+import assert = require("assert");
+import fs = require("fs");
+import events = require("events");
 
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -232,9 +232,9 @@ declare module "events" {
 }
 
 declare module "http" {
-    import events = module("events");
-    import net = module("net");
-    import stream = module("stream");
+    import events = require("events");
+    import net = require("net");
+    import stream = require("stream");
 
     export interface Server extends events.NodeEventEmitter {
         listen(port: number, hostname?: string, backlog?: number, callback?: Function): void;
@@ -303,7 +303,7 @@ declare module "http" {
 }
 
 declare module "cluster" {
-    import child_process = module("child_process");
+    import child_process = require("child_process");
 
     export interface ClusterSettings {
         exec: string;
@@ -340,7 +340,7 @@ declare module "cluster" {
 }
 
 declare module "zlib" {
-    import stream = module("stream");
+    import stream = require("stream");
     export interface ZlibOptions { chunkSize?: number; windowBits?: number; level?: number; memLevel?: number; strategy?: number; dictionary?: any; }
 
     export interface Gzip extends stream.ReadWriteStream { }
@@ -418,9 +418,9 @@ declare module "os" {
 }
 
 declare module "https" {
-    import tls = module("tls");
-    import events = module("events");
-    import http = module("http");
+    import tls = require("tls");
+    import events = require("events");
+    import http = require("http");
 
     export interface ServerOptions {
         pfx?: any;
@@ -484,8 +484,8 @@ declare module "punycode" {
 }
 
 declare module "repl" {
-    import stream = module("stream");
-    import events = module("events");
+    import stream = require("stream");
+    import events = require("events");
 
     export interface ReplOptions {
         prompt?: string;
@@ -502,8 +502,8 @@ declare module "repl" {
 }
 
 declare module "readline" {
-    import events = module("events");
-    import stream = module("stream");
+    import events = require("events");
+    import stream = require("stream");
 
     export interface ReadLine extends events.NodeEventEmitter {
         setPrompt(prompt: string, length: number): void;
@@ -537,8 +537,8 @@ declare module "vm" {
 }
 
 declare module "child_process" {
-    import events = module("events");
-    import stream = module("stream");
+    import events = require("events");
+    import stream = require("stream");
 
     export interface ChildProcess extends events.NodeEventEmitter {
         stdin: stream.WritableStream;
@@ -620,7 +620,7 @@ declare module "dns" {
 }
 
 declare module "net" {
-    import stream = module("stream");
+    import stream = require("stream");
 
     export interface NodeSocket extends stream.ReadWriteStream {
         // Extended base methods
@@ -673,7 +673,7 @@ declare module "net" {
 }
 
 declare module "dgram" {
-    import events = module("events");
+    import events = require("events");
 
     export function createSocket(type: string, callback?: Function): Socket;
 
@@ -691,7 +691,7 @@ declare module "dgram" {
 }
 
 declare module "fs" {
-    import stream = module("stream");
+    import stream = require("stream");
 
     interface Stats {
         isFile(): boolean;
@@ -832,9 +832,9 @@ declare module "string_decoder" {
 }
 
 declare module "tls" {
-    import crypto = module("crypto");
-    import net = module("net");
-    import stream = module("stream");
+    import crypto = require("crypto");
+    import net = require("net");
+    import stream = require("stream");
 
     var CLIENT_RENEG_LIMIT: number;
     var CLIENT_RENEG_WINDOW: number;
@@ -979,7 +979,7 @@ declare module "crypto" {
 }
 
 declare module "stream" {
-    import events = module("events");
+    import events = require("events");
 
     export interface WritableStream extends events.NodeEventEmitter {
         writable: boolean;
@@ -1040,7 +1040,7 @@ declare module "assert" {
 }
 
 declare module "tty" {
-    import net = module("net");
+    import net = require("net");
 
     export function isatty(fd: string): boolean;
     export interface ReadStream extends net.NodeSocket {
@@ -1054,7 +1054,7 @@ declare module "tty" {
 }
 
 declare module "domain" {
-    import events = module("events");
+    import events = require("events");
 
     export interface Domain extends events.NodeEventEmitter { }
 


### PR DESCRIPTION
Syntax of external module imports now uses 'require'.
