### PR TITLE
Update documentation for angularjs $httpBackend expect methods.

### DIFF
--- a/angularjs/angular-mocks.d.ts
+++ b/angularjs/angular-mocks.d.ts
@@ -82,14 +82,10 @@ declare module ng {
         verifyNoOutstandingExpectation(): void;
         verifyNoOutstandingRequest(): void;
 
-        expect(method: string, url: string, data?: string, headers?: any): mock.IRequestHandler;
-        expect(method: string, url: RegExp, data?: string, headers?: any): mock.IRequestHandler;
-        expect(method: string, url: string, data?: RegExp, headers?: any): mock.IRequestHandler;
-        expect(method: string, url: RegExp, data?: RegExp, headers?: any): mock.IRequestHandler;
-        expect(method: RegExp, url: string, data?: string, headers?: any): mock.IRequestHandler;
-        expect(method: RegExp, url: RegExp, data?: string, headers?: any): mock.IRequestHandler;
-        expect(method: RegExp, url: string, data?: RegExp, headers?: any): mock.IRequestHandler;
-        expect(method: RegExp, url: RegExp, data?: RegExp, headers?: any): mock.IRequestHandler;        
+        expect(method: string, url: string, data?: any, headers?: any): mock.IRequestHandler;
+        expect(method: string, url: RegExp, data?: any, headers?: any): mock.IRequestHandler;
+        expect(method: RegExp, url: string, data?: any, headers?: any): mock.IRequestHandler;
+        expect(method: RegExp, url: RegExp, data?: any, headers?: any): mock.IRequestHandler;      
         
         when(method: string, url: string, data?: string, headers?: any): mock.IRequestHandler;
         when(method: string, url: RegExp, data?: string, headers?: any): mock.IRequestHandler;
@@ -108,18 +104,12 @@ declare module ng {
         expectHEAD(url: RegExp, headers?: any): mock.IRequestHandler;
         expectJSONP(url: string): mock.IRequestHandler;
         expectJSONP(url: RegExp): mock.IRequestHandler;
-        expectPATCH(url: string, data?: string, headers?: any): mock.IRequestHandler;
-        expectPATCH(url: RegExp, data?: string, headers?: any): mock.IRequestHandler;
-        expectPATCH(url: string, data?: RegExp, headers?: any): mock.IRequestHandler;
-        expectPATCH(url: RegExp, data?: RegExp, headers?: any): mock.IRequestHandler;
-        expectPOST(url: string, data?: string, headers?: any): mock.IRequestHandler;
-        expectPOST(url: RegExp, data?: string, headers?: any): mock.IRequestHandler;
-        expectPOST(url: string, data?: RegExp, headers?: any): mock.IRequestHandler;
-        expectPOST(url: RegExp, data?: RegExp, headers?: any): mock.IRequestHandler;
-        expectPUT(url: string, data?: string, headers?: any): mock.IRequestHandler;
-        expectPUT(url: RegExp, data?: string, headers?: any): mock.IRequestHandler;
-        expectPUT(url: string, data?: RegExp, headers?: any): mock.IRequestHandler;
-        expectPUT(url: RegExp, data?: RegExp, headers?: any): mock.IRequestHandler;
+        expectPATCH(url: string, data?: any, headers?: any): mock.IRequestHandler;
+        expectPATCH(url: RegExp, data?: any, headers?: any): mock.IRequestHandler;
+        expectPOST(url: string, data?: any, headers?: any): mock.IRequestHandler;
+        expectPOST(url: RegExp, data?: any, headers?: any): mock.IRequestHandler;
+        expectPUT(url: string, data?: any, headers?: any): mock.IRequestHandler;
+        expectPUT(url: RegExp, data?: any, headers?: any): mock.IRequestHandler;
 
         whenDELETE(url: string, headers?: any): mock.IRequestHandler;
         whenDELETE(url: RegExp, headers?: any): mock.IRequestHandler;


### PR DESCRIPTION
Both `expect`, `expectPOST`, `expectPUT` and `expectPATCH` accept the following types for `data`:
- string
- RegExp
- function(string)
- Object

This can be seen in https://github.com/angular/angular.js/blob/master/src/ngMock/angular-mocks.js#L1500-L1506

Definition will be simpler if we just allow `data` to have type `any`.
