### PR TITLE
restangular: Fix type signatures for methods that return an IPromise

### DIFF
--- a/restangular/restangular-tests.ts
+++ b/restangular/restangular-tests.ts
@@ -5,7 +5,7 @@ function test_basic() {
     Restangular.all('accounts');
     Restangular.one('accounts', 1234);
 
-    Restangular.one('users').getList().then(function (users) {
+    Restangular.all('users').getList().then(function (users) {
         $scope.user = users[0];
     })
     $scope.cars = $scope.user.getList('cars');

--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -15,18 +15,10 @@ interface Restangular extends RestangularCustom {
 }
 
 interface RestangularElement extends Restangular {
-    get (): ng.IPromise<any>;
-    get (params: any): ng.IPromise<any>;
-    get (params: any, headers: any): ng.IPromise<any>;
-
-    getList(): ng.IPromise<any>;
-    getList(subElement: any): ng.IPromise<any>;
-    getList(subElement: any, queryParams: string, headers: any): ng.IPromise<any>;
-
-    put(queryParams?: string, headers?: any): ng.IPromise<any>;
-
+    get (queryParams?: any, headers?: any): ng.IPromise<any>;
+    getList(subElement: any, queryParams?: any, headers?: any): ng.IPromise<any>;
+    put(queryParams?: any, headers?: any): ng.IPromise<any>;
     post(subElement, elementToPost, queryParams?, headers?): ng.IPromise<any>;
-
     remove(queryParams?, headers?): ng.IPromise<any>;
     head(queryParams?, headers?): ng.IPromise<any>;
     trace(queryParams?, headers?): ng.IPromise<any>;

--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -15,45 +15,45 @@ interface Restangular extends RestangularCustom {
 }
 
 interface RestangularElement extends Restangular {
-    get (): ng.IPromise;
-    get (params: any): ng.IPromise;
-    get (params: any, headers: any): ng.IPromise;
+    get (): ng.IPromise<any>;
+    get (params: any): ng.IPromise<any>;
+    get (params: any, headers: any): ng.IPromise<any>;
 
-    getList(): ng.IPromise;
-    getList(subElement: any): ng.IPromise;
-    getList(subElement: any, queryParams: string, headers: any): ng.IPromise;
+    getList(): ng.IPromise<any>;
+    getList(subElement: any): ng.IPromise<any>;
+    getList(subElement: any, queryParams: string, headers: any): ng.IPromise<any>;
 
-    put(queryParams?: string, headers?: any): ng.IPromise;
+    put(queryParams?: string, headers?: any): ng.IPromise<any>;
 
-    post(subElement, elementToPost, queryParams?, headers?): ng.IPromise;
+    post(subElement, elementToPost, queryParams?, headers?): ng.IPromise<any>;
 
-    remove(queryParams?, headers?): ng.IPromise;
-    head(queryParams?, headers?): ng.IPromise;
-    trace(queryParams?, headers?): ng.IPromise;
-    options(queryParams?, headers?): ng.IPromise;
-    patch(queryParams?, headers?): ng.IPromise;
+    remove(queryParams?, headers?): ng.IPromise<any>;
+    head(queryParams?, headers?): ng.IPromise<any>;
+    trace(queryParams?, headers?): ng.IPromise<any>;
+    options(queryParams?, headers?): ng.IPromise<any>;
+    patch(queryParams?, headers?): ng.IPromise<any>;
     getRestangularUrl(): string;
 }
 
 interface RestangularCollection extends Restangular {
-    getList(queryParams?, headers?): ng.IPromise;
-    post(elementToPost, queryParams?, headers?): ng.IPromise;
-    head(queryParams?, headers?): ng.IPromise;
-    trace(queryParams?, headers?): ng.IPromise;
-    options(queryParams?, headers?): ng.IPromise;
-    patch(queryParams?, headers?): ng.IPromise;
-    putElement(idx, params, headers): ng.IPromise;
+    getList(queryParams?, headers?): ng.IPromise<any>;
+    post(elementToPost, queryParams?, headers?): ng.IPromise<any>;
+    head(queryParams?, headers?): ng.IPromise<any>;
+    trace(queryParams?, headers?): ng.IPromise<any>;
+    options(queryParams?, headers?): ng.IPromise<any>;
+    patch(queryParams?, headers?): ng.IPromise<any>;
+    putElement(idx, params, headers): ng.IPromise<any>;
     getRestangularUrl(): string;
 }
 
 interface RestangularCustom {
-    customGET(path, params?, headers?): ng.IPromise;
-    customGETLIST(path, params?, headers?): ng.IPromise;
-    customDELETE(path, params?, headers?): ng.IPromise;
-    customPOST(path, params?, headers?, elem?): ng.IPromise;
-    customPUT(path, params?, headers?, elem?): ng.IPromise;
-    customOperation(operation, path, params?, headers?, elem?): ng.IPromise;
-    addRestangularMethod(name, operation, path?, params?, headers?, elem?): ng.IPromise;
+    customGET(path, params?, headers?): ng.IPromise<any>;
+    customGETLIST(path, params?, headers?): ng.IPromise<any>;
+    customDELETE(path, params?, headers?): ng.IPromise<any>;
+    customPOST(path, params?, headers?, elem?): ng.IPromise<any>;
+    customPUT(path, params?, headers?, elem?): ng.IPromise<any>;
+    customOperation(operation, path, params?, headers?, elem?): ng.IPromise<any>;
+    addRestangularMethod(name, operation, path?, params?, headers?, elem?): ng.IPromise<any>;
 }
 
 interface RestangularProvider {


### PR DESCRIPTION
Last merged pull request on AngularJS type definition (#851) made ng.IPromises generic. This broke the current type definition for restangular.

I decided to use `IPromise<any>` as a return type although I considered making both `RestangularElement` and `RestangularCollection` generic and return and `IPromise<T>`. The reason why I didn't decided to go that way is because methods that return promises add extra useful methods to the element returned by the promise (see https://github.com/mgonto/restangular/blob/master/src/restangular.js#L586-L625) and thus, it would not be right for it to have type T. If there is a better approach to solve this problem, please tell me and I will do my best to correct it.
