### PR TITLE
Got rid of implicit any errors in d3, jquery, angularjs, moment

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -36,7 +36,7 @@ declare module ng {
         element: JQueryStatic;
         equals(value1: any, value2: any): boolean;
         extend(destination: any, ...sources: any[]): any;
-        forEach(obj: any, iterator: (value, key) => any, context?: any): any;
+        forEach(obj: any, iterator: (value: any, key: any) => any, context?: any): any;
         fromJson(json: string): any;
         identity(arg?: any): any;
         injector(modules?: any[]): auto.IInjectorService;

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1126,41 +1126,41 @@ declare module D3 {
             };
             linkDistance: {
                 (): number;
-                (number): ForceLayout;
+                (number:number): ForceLayout;
                 (accessor: (d: any, index: number) => number): ForceLayout;
             };
             linkStrength:
             {
                 (): number;
-                (number): ForceLayout;
+                (number:number): ForceLayout;
                 (accessor: (d: any, index: number) => number): ForceLayout;
             };
             friction:
             {
                 (): number;
-                (number): ForceLayout;
+                (number:number): ForceLayout;
                 (accessor: (d: any, index: number) => number): ForceLayout;
             };
             alpha: {
                 (): number;
-                (number): ForceLayout;
+                (number:number): ForceLayout;
                 (accessor: (d: any, index: number) => number): ForceLayout;
             };
             charge: {
                 (): number;
-                (number): ForceLayout;
+                (number:number): ForceLayout;
                 (accessor: (d: any, index: number) => number): ForceLayout;
             };
 
             theta: {
                 (): number;
-                (number): ForceLayout;
+                (number:number): ForceLayout;
                 (accessor: (d: any, index: number) => number): ForceLayout;
             };
 
             gravity: {
                 (): number;
-                (number): ForceLayout;
+                (number:number): ForceLayout;
                 (accessor: (d: any, index: number) => number): ForceLayout;
             };
 
@@ -1465,8 +1465,8 @@ declare module D3 {
         }
 
         export interface Symbol {
-            type: (string) => Symbol;
-            size: (number) => Symbol;
+            type: (string:string) => Symbol;
+            size: (number:number) => Symbol;
         }
 
         export interface Brush {
@@ -2917,15 +2917,15 @@ declare module D3 {
             /**
             * Computes the projected area
             */
-            area(feature: any);
+            area(feature: any): any;
             /**
             * Computes the projected centroid
             */
-            centroid(feature: any);
+            centroid(feature: any): any;
             /**
             * Computes the projected bounding box
             */
-            bounds(feature: any);
+            bounds(feature: any): any;
             /**
             * get or set the radius to display point features.
             */

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -21,9 +21,9 @@ and limitations under the License.
 interface JQueryAjaxSettings {
     accepts?: any;
     async?: boolean;
-    beforeSend? (jqXHR: JQueryXHR, settings: JQueryAjaxSettings);
+    beforeSend? (jqXHR: JQueryXHR, settings: JQueryAjaxSettings): any;
     cache?: boolean;
-    complete? (jqXHR: JQueryXHR, textStatus: string);
+    complete? (jqXHR: JQueryXHR, textStatus: string): any;
     contents?: { [key: string]: any; };
     //According to jQuery.ajax source code, ajax's option actually allows contentType to set to "false"
     // https://github.com/borisyankov/DefinitelyTyped/issues/742
@@ -46,7 +46,7 @@ interface JQueryAjaxSettings {
     processData?: boolean;
     scriptCharset?: string;
     statusCode?: { [key: string]: any; };
-    success? (data: any, textStatus: string, jqXHR: JQueryXHR);
+    success? (data: any, textStatus: string, jqXHR: JQueryXHR): any;
     timeout?: number;
     traditional?: boolean;
     type?: string;
@@ -60,7 +60,7 @@ interface JQueryAjaxSettings {
     Interface for the jqXHR object
 */
 interface JQueryXHR extends XMLHttpRequest, JQueryPromise<any> {
-    overrideMimeType(mimeType: string);
+    overrideMimeType(mimeType: string): any;
     abort(statusText?: string): void;
 }
 
@@ -84,10 +84,10 @@ interface JQueryCallback {
     Allows jQuery Promises to interop with non-jQuery promises
 */
 interface JQueryGenericPromise<T> {
-    then<U>(onFulfill: (value: T) => U, onReject?: (reason) => U): JQueryGenericPromise<U>;
-    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (reason) => U): JQueryGenericPromise<U>;
-    then<U>(onFulfill: (value: T) => U, onReject?: (reason) => JQueryGenericPromise<U>): JQueryGenericPromise<U>;
-    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (reason) => JQueryGenericPromise<U>): JQueryGenericPromise<U>;
+    then<U>(onFulfill: (value: T) => U, onReject?: (reason: any) => U): JQueryGenericPromise<U>;
+    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (reason: any) => U): JQueryGenericPromise<U>;
+    then<U>(onFulfill: (value: T) => U, onReject?: (reason: any) => JQueryGenericPromise<U>): JQueryGenericPromise<U>;
+    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (reason: any) => JQueryGenericPromise<U>): JQueryGenericPromise<U>;
 }
 
 /*
@@ -102,16 +102,16 @@ interface JQueryPromise<T> {
     // Deprecated - given no typings
     pipe(doneFilter?: (x: any) => any, failFilter?: (x: any) => any, progressFilter?: (x: any) => any): JQueryPromise<any>;
 
-    then<U>(onFulfill: (value: T) => U, onReject?: (...reasons) => U, onProgress?: (...progression) => any): JQueryPromise<U>;
-    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (...reasons) => U, onProgress?: (...progression) => any): JQueryPromise<U>;
-    then<U>(onFulfill: (value: T) => U, onReject?: (...reasons) => JQueryGenericPromise<U>, onProgress?: (...progression) => any): JQueryPromise<U>;
-    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (...reasons) => JQueryGenericPromise<U>, onProgress?: (...progression) => any): JQueryPromise<U>;
+    then<U>(onFulfill: (value: T) => U, onReject?: (...reasons: any[]) => U, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
+    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (...reasons: any[]) => U, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
+    then<U>(onFulfill: (value: T) => U, onReject?: (...reasons: any[]) => JQueryGenericPromise<U>, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
+    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (...reasons: any[]) => JQueryGenericPromise<U>, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
 
     // Because JQuery Promises Suck
-    then<U>(onFulfill: (...values) => U, onReject?: (...reasons) => U, onProgress?: (...progression) => any): JQueryPromise<U>;
-	then<U>(onFulfill: (...values) => JQueryGenericPromise<U>, onReject?: (...reasons) => U, onProgress?: (...progression) => any): JQueryPromise<U>;
-	then<U>(onFulfill: (...values) => U, onReject?: (...reasons) => JQueryGenericPromise<U>, onProgress?: (...progression) => any): JQueryPromise<U>;
-	then<U>(onFulfill: (...values) => JQueryGenericPromise<U>, onReject?: (...reasons) => JQueryGenericPromise<U>, onProgress?: (...progression) => any): JQueryPromise<U>;
+    then<U>(onFulfill: (...values: any[]) => U, onReject?: (...reasons: any[]) => U, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
+	then<U>(onFulfill: (...values: any[]) => JQueryGenericPromise<U>, onReject?: (...reasons: any[]) => U, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
+	then<U>(onFulfill: (...values: any[]) => U, onReject?: (...reasons: any[]) => JQueryGenericPromise<U>, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
+	then<U>(onFulfill: (...values: any[]) => JQueryGenericPromise<U>, onReject?: (...reasons: any[]) => JQueryGenericPromise<U>, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
 }
 
 /*
@@ -151,8 +151,8 @@ interface BaseJQueryEventObject extends Event {
     preventDefault(): any;
     relatedTarget: Element;
     result: any;
-    stopImmediatePropagation();
-    stopPropagation();
+    stopImmediatePropagation(): void;
+    stopPropagation(): void;
     pageX: number;
     pageY: number;
     which: number;
@@ -239,8 +239,8 @@ interface JQueryStatic {
 
     ajaxSettings: JQueryAjaxSettings;
 
-    ajaxSetup();
-    ajaxSetup(options: JQueryAjaxSettings);
+    ajaxSetup(): void;
+    ajaxSetup(options: JQueryAjaxSettings): void;
 
     get(url: string, data?: any, success?: any, dataType?: any): JQueryXHR;
     getJSON(url: string, data?: any, success?: any): JQueryXHR;
@@ -272,8 +272,8 @@ interface JQueryStatic {
 	when<T>(...deferreds: any[]): JQueryPromise<T>;
 
     // CSS
-    css(e: any, propertyName: string, value?: any);
-    css(e: any, propertyName: any, value?: any);
+    css(e: any, propertyName: string, value?: any): any;
+    css(e: any, propertyName: any, value?: any): any;
     cssHooks: { [key: string]: any; };
     cssNumber: any;
 
@@ -307,7 +307,7 @@ interface JQueryStatic {
     };
 
     // Internals
-    error(message: any);
+    error(message: any): JQuery;
 
     // Miscellaneous
     expr: any;
@@ -493,7 +493,7 @@ interface JQuery {
     // Effects
     animate(properties: any, duration?: any, complete?: Function): JQuery;
     animate(properties: any, duration?: any, easing?: string, complete?: Function): JQuery;
-    animate(properties: any, options: { duration?: any; easing?: string; complete?: Function; step?: Function; queue?: boolean; specialEasing?: any; });
+    animate(properties: any, options: { duration?: any; easing?: string; complete?: Function; step?: Function; queue?: boolean; specialEasing?: any; }): JQuery;
 
     delay(duration: number, queueName?: string): JQuery;
 
@@ -537,7 +537,7 @@ interface JQuery {
     bind(eventType: string, eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
     bind(eventType: string, eventData: any, preventBubble: boolean): JQuery;
     bind(eventType: string, preventBubble: boolean): JQuery;
-    bind(...events: any[]);
+    bind(...events: any[]): JQuery;
 
     blur(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
     blur(handler: (eventObject: JQueryEventObject) => any): JQuery;
@@ -661,15 +661,15 @@ interface JQuery {
 
     // Manipulation
     after(...content: any[]): JQuery;
-    after(func: (index: any) => any);
+    after(func: (index: any) => any): JQuery;
 
     append(...content: any[]): JQuery;
-    append(func: (index: any, html: any) => any);
+    append(func: (index: any, html: any) => any): JQuery;
 
     appendTo(target: any): JQuery;
 
     before(...content: any[]): JQuery;
-    before(func: (index: any) => any);
+    before(func: (index: any) => any): JQuery;
 
     clone(withDataAndEvents?: boolean, deepWithDataAndEvents?: boolean): JQuery;
 

--- a/moment/moment.d.ts
+++ b/moment/moment.d.ts
@@ -157,8 +157,8 @@ interface Moment {
     isSame(b: Date, granularity: string): boolean;
     isSame(b: Array, granularity: string): boolean;
 
-    lang(language: string);
-    lang(reset: boolean);
+    lang(language: string): void;
+    lang(reset: boolean): void;
     lang(): string;
 
 }
@@ -243,8 +243,8 @@ interface MomentStatic {
 
     isMoment(): boolean;
     isMoment(m: any): boolean;
-    lang(language: string);
-    lang(language: string, definition: MomentLanguage);
+    lang(language: string): any;
+    lang(language: string, definition: MomentLanguage): any;
     months: string[];
     monthsShort: string[];
     weekdays: string[];


### PR DESCRIPTION
When compiling with tsc --noImplicitAny d3 was emitting a few errors relating to not having implicit any, I went through and fixed them up

Signed-off-by: Ben Jackman ben@jackman.biz
