### PR TITLE
Include the settings field on ColorboxStatic

### DIFF
--- a/jquery.colorbox/jquery.colorbox.d.ts
+++ b/jquery.colorbox/jquery.colorbox.d.ts
@@ -277,6 +277,10 @@ interface ColorboxStatic {
     * Removes all traces of Colorbox from the document.
     */
     remove(): void;
+    /**
+    * Default settings used for Colorbox calls
+    */
+    settings: ColorboxSettings;
 
 }
 


### PR DESCRIPTION
Included settings field ColorboxStatic. This is used for setting site-wide defaults for colorbox
