### PR TITLE
Async with external module support.

### DIFF
--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -76,3 +76,7 @@ interface Async {
 }
 
 declare var async: Async;
+
+declare module "async" {
+	export = async;
+}

--- a/async/asyncamd-tests.ts
+++ b/async/asyncamd-tests.ts
@@ -1,0 +1,3 @@
+import async = require("async");
+
+async.map(["a", "b", "c"], (item, cb) => cb(null, [item.toUpperCase()]), (err, results) => { });


### PR DESCRIPTION
There are other problems with this definition file, e.g. map should except two type arguments, one for input and one for output. But those will have to be fixed later. This is just to enable external module support.
