### PR TITLE
Jasmine: removed constructor definition in Reporter interface

### DIFF
--- a/jasmine-jquery/jasmine-jquery.d.ts
+++ b/jasmine-jquery/jasmine-jquery.d.ts
@@ -1,0 +1,122 @@
+﻿// Type definitions for Jasmine-JQuery 1.5.8
+// Project: https://github.com/velesin/jasmine-jquery
+// Definitions by: Gregor Stamac <https://github.com/gstamac/>
+// DefinitelyTyped: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../jquery/jquery.d.ts"/>
+
+declare function readFixtures(...uls: string[]): string;
+declare function preloadFixtures(...uls: string[]);
+declare function loadFixtures(...uls: string[]);
+declare function appendLoadFixtures(...uls: string[]);
+declare function setFixtures(html: string): string;
+declare function appendSetFixtures();
+declare function sandbox(attributes): JQuery;
+declare function spyOnEvent(selector: JQuery, eventName: string): any;
+declare function preloadStyleFixtures();
+declare function loadStyleFixtures();
+declare function appendLoadStyleFixtures();
+declare function setStyleFixtures(html: string);
+declare function appendSetStyleFixtures(html: string);
+declare function loadJSONFixtures(): jasmine.JSONFixtures;
+declare function getJSONFixture(url: string): any;
+
+declare module jasmine {
+    function spiedEventsKey(selector: JQuery, eventName: string): string;
+
+    function getFixtures(): Fixtures;
+    function getStyleFixtures(): StyleFixtures;
+    function getJSONFixtures(): JSONFixtures;
+
+    interface Fixtures {
+        fixturesPath: string;
+        set(html: string): string;
+        appendSet(html: string);
+        preload(...uls: string[]);
+        load(...uls: string[]);
+        appendLoad(...uls: string[]);
+        read(...uls: string[]): string;
+        clearCache();
+        cleanUp();
+        sandbox(attributes): JQuery;
+        createContainer_(html: string);
+        addToContainer_(html: string);
+        getFixtureHtml_(url: string): string;
+        loadFixtureIntoCache_(relativeUrl: string);
+        makeFixtureUrl_(relativeUrl: string): string;
+        proxyCallTo_(methodName, passedArguments): any;
+    }
+
+    interface StyleFixtures {
+        set(html: string): string;
+        appendSet(html: string);
+        preload(...uls: string[]);
+        load(...uls: string[]);
+        appendLoad(...uls: string[]);
+        read_(...uls: string[]): string;
+        clearCache();
+        cleanUp();
+        createStyle_(html: string);
+        getFixtureHtml_(url: string): string;
+        loadFixtureIntoCache_(relativeUrl: string);
+        makeFixtureUrl_(relativeUrl: string): string;
+        proxyCallTo_(methodName, passedArguments): any;
+    }
+
+    interface JSONFixtures {
+        load(...uls: string[]);
+        read(...uls: string[]): string;
+        clearCache();
+        getFixtureData_(url: string): any;
+        loadFixtureIntoCache_(relativeUrl: string);
+        proxyCallTo_(methodName, passedArguments): any;
+    }
+
+    var Fixtures: Fixtures;
+    var StyleFixtures: StyleFixtures;
+    var JSONFixtures: JSONFixtures;
+
+    interface Matchers {
+        toHaveClass(className: string): boolean;
+        toHaveCss(css): boolean;
+        toBeVisible(): boolean;
+        toBeHidden(): boolean;
+        toBeSelected(): boolean;
+        toBeChecked(): boolean;
+        toBeEmpty(): boolean;
+        toExist(): boolean;
+        toHaveLength(length: number): boolean;
+        toHaveAttr(attributeName: string, expectedAttributeValue): boolean;
+        toHaveProp(propertyName: string, expectedPropertyValue): boolean;
+        toHaveId(id: string): boolean;
+        toHaveHtml(html: string): boolean;
+        //toContainHtml(html: string): boolean;
+        toHaveText(text: string): boolean;
+        //toContainText(text: string): boolean;
+        toHaveValue(value): boolean;
+        toHaveData(key, expectedValue): boolean;
+        toBe(selector: JQuery): boolean;
+        toContain(selector: JQuery): boolean;
+        toBeMatchedBy(selector: JQuery): boolean;
+        toBeDisabled(selector: JQuery): boolean;
+        toBeFocused(selector: JQuery): boolean;
+        toHandle(event): boolean;
+        toHandleWith(eventName: string, eventHandler): boolean;
+
+        toHaveBeenTriggeredOn(selector: JQuery): boolean;
+        toHaveBeenTriggered(): boolean;
+        toHaveBeenTriggeredOnAndWith(...args: any[]): boolean;
+        toHaveBeenPreventedOn(selector: JQuery): boolean;
+        toHaveBeenPrevented(): boolean;
+        toHaveBeenStoppedOn(selector: JQuery): boolean;
+        toHaveBeenStopped(): boolean;
+    }
+
+    interface JasmineJQuery {
+        browserTagCaseIndependentHtml(html: string): string;
+        elementToString(element: JQuery): string;
+        matchersClass: any;
+    }
+
+    var JQuery: JasmineJQuery;
+}

--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -30,7 +30,7 @@ declare module jasmine {
 
     function any(aclass: any):any;
     function objectContaining(sample: any): ObjectContaining;
-    function createSpy(name: string, originalFn: Function): Spy;
+    function createSpy(name: string, originalFn?: Function): Spy;
     function createSpyObj(baseName: string, methodNames: any[]): any;
     function pp(value: any): string;
     function getEnv(): Env;

--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -187,7 +187,6 @@ declare module jasmine {
     }
 
     interface Reporter {
-        new ():any;
         reportRunnerStarting(runner:any):any;
         reportRunnerResults(runner:any):any;
         reportSuiteResults(suite:any):any;

--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -29,6 +29,7 @@ declare module jasmine {
     var Clock: Clock;
 
     function any(aclass: any):any;
+    function objectContaining(sample: any): ObjectContaining;
     function createSpy(name: string, originalFn: Function): Spy;
     function createSpyObj(baseName: string, methodNames: any[]): any;
     function pp(value: any): string;
@@ -40,6 +41,13 @@ declare module jasmine {
 
         jasmineMatches(other:any):any;
         jasmineToString():any;
+    }
+
+    interface ObjectContaining {
+        new (sample: any): any;
+
+        jasmineMatches(other: any, mismatchKeys: any[], mismatchValues: any[]): any;
+        jasmineToString(): any;
     }
 
     interface Block {
@@ -214,6 +222,18 @@ declare module jasmine {
     interface Spec {
 
         new (env: Env, suite: Suite, description: string):any;
+
+        id: number;
+        env: Env;
+        suite: Suite;
+        description: string;
+        queue: Queue;
+
+        afterCallbacks: any;
+        spies_: any;
+
+        results_: NestedResults;
+        matchersClass: any;
 
         getFullName(): string;
         results():any;

--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -78,6 +78,8 @@ declare module jasmine {
         clearInterval:any;
         updateInterval:any;
 
+        currentSpec: Spec;
+
         version():any;
         versionString(): string;
         nextSpecId(): number;

--- a/signalr/signalr.d.ts
+++ b/signalr/signalr.d.ts
@@ -58,7 +58,8 @@ interface SignalR {
     disconnected(handler: () => void ): SignalR;
     connectionSlow(handler: () => void ): SignalR;
     sending(handler: () => void ): SignalR;
-    reconnected(handler: () => void ): SignalR;
+    reconnecting(handler: () => void): SignalR;
+    reconnected(handler: () => void): SignalR;
 }
 
 interface HubProxy {


### PR DESCRIPTION
There is no need to define a constructor for Reporter interface. Usually the implementation of Reporter is actually a proxy to your system so you would need your system as the parameter in the constructor. Of course you could use an Initialization function but there is no need to enforce this.
