### PR TITLE
Router.routes, View.events, and Model.defaults -> method form

### DIFF
--- a/backbone/backbone.d.ts
+++ b/backbone/backbone.d.ts
@@ -86,14 +86,17 @@ declare module Backbone {
         sync(...arg: any[]): JQueryXHR;
     }
 
-    class Model extends ModelBase {
+    interface OptionalDefaults {
+        defaults?(): any;
+    }
+
+    class Model extends ModelBase extends OptionalDefaults {
 
         static extend(properties: any, classProperties?: any): any; // do not use, prefer TypeScript's extend functionality
 
         attributes: any;
         changed: any[];
         cid: string;
-        defaults: any;
         id: any;
         idAttribute: string;
         validationError: any;
@@ -235,11 +238,13 @@ declare module Backbone {
         zip(...model: Model[]): Model[];
     }
 
-    class Router extends Events {
+    interface OptionalRoutes {
+        routes?(): any;
+    }
+
+    class Router extends Events implements OptionalRoutes {
 
         static extend(properties: any, classProperties?: any): any; // do not use, prefer TypeScript's extend functionality
-
-        routes: any;
 
         constructor(options?: RouterOptions);
         initialize(options?: RouterOptions);
@@ -283,7 +288,11 @@ declare module Backbone {
         attributes?: any[];
     }
 
-    class View extends Events {
+    interface OptionalEvents {
+        events?(): any;
+    }
+
+    class View extends Events implements OptionalEvents {
 
         static extend(properties: any, classProperties?: any): any;  // do not use, prefer TypeScript's extend functionality
 
@@ -299,7 +308,7 @@ declare module Backbone {
         cid: string;
         className: string;
         tagName: string;
-        events: any;
+        options: any;
 
         el: any;
         $el: JQuery;


### PR DESCRIPTION
As of typescript 0.9.1, fields are set after calling the super
constructor, so if events, defaults, or routes are set to object
literals, they will not be seen by backbone, and will not be bound.
The cleanest way to fix this is to define them as methods which return
an object hash, as the methods are already on the prototype chain when
backbone looks for events/defaults/routes, and backbone supports either
objects or functions that when called return objects.
