### PR TITLE
sammyjs: Resolve syntax issue with route overloads, Add line to README for docCookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-DefinitelyTyped [![Build Status](https://travis-ci.org/borisyankov/DefinitelyTyped.png?branch=master)](https://travis-ci.org/borisyankov/DefinitelyTyped)
+﻿DefinitelyTyped [![Build Status](https://travis-ci.org/borisyankov/DefinitelyTyped.png?branch=master)](https://travis-ci.org/borisyankov/DefinitelyTyped)
 ===============
 
 The repository for *high quality* TypeScript type definitions.
@@ -47,6 +47,7 @@ List of Definitions
 * [CodeMirror](http://codemirror.net) (by [François de Campredon](https://github.com/fdecampredon))
 * [Commander](http://github.com/visionmedia/commander.js) (by [Marcelo Dezem](https://github.com/mdezem))
 * [d3.js](http://d3js.org/) (from TypeScript samples)
+* [docCookies](https://developer.mozilla.org/en-US/docs/Web/API/document.cookie) (by [Jon Egerton](https://github.com/jonegerton))
 * [domo](http://domo-js.com/) (by [Steve Fenton](https://github.com/Steve-Fenton))
 * [dust](http://linkedin.github.com/dustjs) (by [Marcelo Dezem](https://github.com/mdezem))
 * [EaselJS](http://www.createjs.com/#!/EaselJS) (by [Pedro Ferreira](https://bitbucket.org/drk4))

--- a/sammyjs/sammyjs.d.ts
+++ b/sammyjs/sammyjs.d.ts
@@ -81,7 +81,6 @@ declare module Sammy {
         $element(selector?: string): JQuery;
         after(callback: Function): Application;
         any(verb: string, path: string, callback: Function): void;
-        route(verb: string, path: string, callback: Function): void;
         around(callback: Function): Application;
         before(options: any, callback: Function): Application;
         bind(name: string, callback: Function): Application;


### PR DESCRIPTION
Resolve issue with route overloads by removing the route overload that
returns void in favour of those that return Application (this matches
the library code)

Add a line to README.mb for added docCookies type definition
