### PR TITLE
Select2: make optional parameters optional

### DIFF
--- a/select2/select2.d.ts
+++ b/select2/select2.d.ts
@@ -10,7 +10,7 @@ interface Select2QueryOptions {
     term?: string;
     page?: number;
     context?: any;
-    callback?: (result: { results: any; more: boolean; context: any; }) => void;
+    callback?: (result: { results: any; more?: boolean; context?: any; }) => void;
 }
 
 interface AjaxFunction {


### PR DESCRIPTION
Both `more` and `context` arguments are optional for the object passed to `callback` in `Select2QueryOptions`.

See docs example for clarification: http://ivaynberg.github.io/select2/#data
