### PR TITLE
Fixed issue when using $.extend to merge defaultOptions and options

### DIFF
--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -1239,7 +1239,7 @@ function test_extend() {
 
     var defaults = { validate: false, limit: 5, name: "foo" };
     var options = { validate: true, name: "bar" };
-    var settings = $.extend({}, defaults, options);
+    var settings: typeof defaults = $.extend({}, defaults, options);
 }
 
 function test_fadeIn() {

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -324,8 +324,8 @@ interface JQueryStatic {
     each(collection: JQuery, callback: (indexInArray: number, valueOfElement: HTMLElement) => any): any;
     each<T>(collection: T[], callback: (indexInArray: number, valueOfElement: T) => any): any;
 
-    extend(target: any, ...objs: any[]): Object;
-    extend(deep: boolean, target: any, ...objs: any[]): Object;
+    extend(target: any, ...objs: any[]): any;
+    extend(deep: boolean, target: any, ...objs: any[]): any;
 
     globalEval(code: string): any;
 


### PR DESCRIPTION
Hi.

For the moment the return of  `jQuery.extend` is `Object`. This is an issue when you want to merge some default options and options into a new empty object (you can see an example at http://api.jquery.com/jQuery.extend/#example-2).

I updated the test to reproduce the issue and fixed it by changing the return type of `$.extend` to `any`

Olivier
