### PR TITLE
iScroll library typo's.

### DIFF
--- a/iscroll/iscroll-lite.d.ts
+++ b/iscroll/iscroll-lite.d.ts
@@ -42,6 +42,6 @@ declare class iScroll {
     scrollTo(x: number, y: number, time: number, relative: boolean): void;
     scrollToElement(element: string, time: number): void;
     disable(): void;
-    enalbe(): void;
+    enable(): void;
     stop(): void;
 }

--- a/iscroll/iscroll.d.ts
+++ b/iscroll/iscroll.d.ts
@@ -68,7 +68,7 @@ declare class iScroll {
     scrollToElement(element: string, time: number): void;
     scrollToPage(pageX: number, pageY: number, time: number): void;
     disable(): void;
-    enalbe(): void;
+    enable(): void;
     stop(): void;
     zoom(x: number, y: number, scale: number, time: number): void;
     isReady(): boolean;


### PR DESCRIPTION
Fixed typo's in the iScroll definition files.
