### PR TITLE
Fixed the KnockoutExtenders interface definition

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -188,7 +188,7 @@ interface KnockoutVirtualElements {
 }
 
 interface KnockoutExtenders {
-    throttle(target: any, timeout: number): KnockoutComputed;
+    throttle(target: any, timeout: number): KnockoutComputed<any>;
     notify(target: any, notifyWhen: string): any;
 }
 


### PR DESCRIPTION
The TS 0.9.1.1 compiler was complaining that the throttle property was
missing a generic type argument.
