### PR TITLE
Extending EventEmitter interface on FSWatcher interface

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -716,7 +716,7 @@ declare module "fs" {
         ctime: Date;
     }
 
-    interface FSWatcher {
+    interface FSWatcher extends EventEmitter {
         close(): void;
     }
 


### PR DESCRIPTION
As of http://nodejs.org/api/fs.html#fs_class_fs_fswatcher , the interface FSWatcher should extend the EventEmitter interface.
