### PR TITLE
Fix modernizr tests

### DIFF
--- a/modernizr/modernizr-tests.ts
+++ b/modernizr/modernizr-tests.ts
@@ -2,10 +2,6 @@
 
 declare var $: any;
 
-function alert(thing: any) {
-    $('#content').append('<div>' + thing + '</div>');
-}
-
 $(function () {
     var audio = new Audio();
     audio.src = Modernizr.audio.ogg ? 'background.ogg' :

--- a/modernizr/modernizr-tests.ts
+++ b/modernizr/modernizr-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path="modernizr.d.ts" />
+ï»¿/// <reference path="modernizr.d.ts" />
 
 declare var $: any;
 
@@ -15,7 +15,7 @@ $(function () {
     if (Modernizr.webgl) {
         // loadAllWebGLScripts();
     } else {
-        var msg = 'With a different browser you’ll get to see the WebGL experience here: get.webgl.org.';
+        var msg = "With a different browser you'll get to see the WebGL experience here: get.webgl.org.";
         document.getElementById('#notice').innerHTML = msg;
     }
 


### PR DESCRIPTION
Modernizr tests were failing due to incorrect encoding and invalid alert function overload
