### PR TITLE
Update jquery.d.ts

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -488,7 +488,7 @@ interface JQuery {
     removeData(nameOrList?: any): JQuery;
 
     // Deferred
-    promise(type?: any, target?: any): JQueryPromise;
+    promise(type?: any, target?: any): JQueryPromise<any>;
 
     // Effects
     animate(properties: any, duration?: any, complete?: Function): JQuery;


### PR DESCRIPTION
Fix error "Generic type references must include all type arguments."
that gets thrown in typescript 0.9.1.1
