### PR TITLE
eventName should be an object to support multiple event names:  see code...

### DIFF
--- a/backbone/backbone.d.ts
+++ b/backbone/backbone.d.ts
@@ -67,7 +67,7 @@ declare module Backbone {
     }
 
     class Events {
-        on(eventName: string, callback: (...args: any[]) => void , context?: any): any;
+        on(eventName: any, callback: (...args: any[]) => void , context?: any): any;
         off(eventName?: string, callback?: (...args: any[]) => void , context?: any): any;
         trigger(eventName: string, ...args: any[]): any;
         bind(eventName: string, callback: (...args: any[]) => void , context?: any): any;

--- a/jointjs/jointjs.d.ts
+++ b/jointjs/jointjs.d.ts
@@ -77,7 +77,7 @@ declare module joint {
             snapToGrid(p): { x: number; y: number; };
         }
 
-        class ElementView {
+        class ElementView extends CellView  {
             scale(sx: number, sy: number);
         }
         class CellView extends Backbone.View {
@@ -110,6 +110,6 @@ declare module joint {
         function mixin(objects: any[]): any;
         function supplement(objects: any[]): any;
         function deepMixin(objects: any[]): any;
-        function deepSupplement(objects: any[]): any;
+        function deepSupplement(objects: any[], defaultIndicator?: any): any;
     }
 }


### PR DESCRIPTION
... below taken from Backbone code base

```
 // Bind an event to a `callback` function. Passing `"all"` will bind
// the callback to all events fired.
on: function(name, callback, context) {
  if (!eventsApi(this, 'on', name, [callback, context]) || !callback) return this;
```
# 

  // Implement fancy features of the Events API such as multiple event
  // names `"change blur"` and jQuery-style event maps `{change: action}`
  // in terms of the existing API.
  var eventsApi = function(obj, action, name, rest) {
    if (!name) return true;

```
// Handle event maps.
if (typeof name === 'object') {
  for (var key in name) {
    obj[action].apply(obj, [key, name[key]].concat(rest));
  }
  return false;
}
```

Signed-off-by: areel aidanreel@gmail.com
