### PR TITLE
Update winjs.d.ts to include the class ErrorFromName

### DIFF
--- a/winjs/winjs.d.ts
+++ b/winjs/winjs.d.ts
@@ -62,6 +62,9 @@ declare module WinJS {
         function start(): void;
         function stop(): void;
     }
+    class ErrorFromName {
+        constructor(name: string, message?: string);
+    }    
     class Promise<T> {
     	constructor(init: (c: any, e: any, p: any) => void);
         then<U>(success?: (value: T) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void ): Promise<U>;


### PR DESCRIPTION
From http://msdn.microsoft.com/en-us/library/windows/apps/br211689.aspx#methods, the class ErrorFromName was missing. I've added it. (It's just a simple class with only a constructor).
