### PR TITLE
describe stream.Readable class

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1001,6 +1001,24 @@ declare module "stream" {
         pipe(destination: WritableStream, options?: { end?: boolean; }): void;
     }
 
+    export interface ReadableOptions {
+        highWaterMark?: number;
+        encoding?: string;
+        objectMode?: boolean;
+    }
+
+    export class Readable extends events.EventEmitter implements ReadableStream {
+        readable: boolean;
+        constructor(opts?: ReadableOptions);
+        setEncoding(encoding: string): void;
+        pause(): void;
+        resume(): void;
+        destroy(): void;
+        pipe(destination: WritableStream, options?: { end?: boolean; }): void;
+        _read(): void;
+        push(chunk: any, encoding?: string): boolean;
+    }
+
     export interface ReadWriteStream extends ReadableStream, WritableStream { }
 }
 


### PR DESCRIPTION
Describe node Stream.Readable class, this allows implementing of Readable streams as described in http://nodejs.org/api/stream.html#stream_class_stream_readable_1

Specifically the Counting Stream example can now be implemented in TypeScript like this:

``` javascript
import stream = require('stream');
export class Counter extends stream.Readable {

    private _max = 100;
    private _index = 1;

    constructor(opts?: stream.ReadableOptions) {
        super(opts);
    }

    _read() {
        var i = this._index++;
        if (i > this._max) {
            this.push(null);
        } else {
            var str = '' + i;
            var buf = new Buffer(str, 'ascii');
            this.push(buf);
        }
    }
}

var c = new Counter();
c.on('data', function (item) {
    console.log(item);
});
```
