### PR TITLE
Added non-specialized signature for slider(methodName, values)

### DIFF
--- a/jqueryui/jqueryui.d.ts
+++ b/jqueryui/jqueryui.d.ts
@@ -955,6 +955,7 @@ interface JQuery {
     slider(methodName: 'values', index: number): number;
     slider(methodName: string, index: number, value: number): void;
     slider(methodName: 'values', index: number, value: number): void;
+    slider(methodName: string, values: Array<number>): void;    
     slider(methodName: 'values', values: Array<number>): void;
     slider(methodName: 'widget'): JQuery;
     slider(options: JQueryUI.SliderOptions): JQuery;


### PR DESCRIPTION
Compiling the current version with the new TS 0.9.1.1, the compiler stopped with "error TS2154: Specialized overload signature is not subtype of any non-specialized signature."
As a matter of fact the non-specialized signature for the slider(methodName, values) overload was missing.
I added it and everything compiles smoothly. 
Try it yourself
Have a nice day!
