### PR TITLE
Added more missing typings

### DIFF
--- a/node-azure/azure.d.ts
+++ b/node-azure/azure.d.ts
@@ -332,6 +332,10 @@ declare module "azure" {
 
     export interface QueryEntitiesResultContinuation extends QueryResultContinuation {
         tableQuery: TableQuery;
+        nextPartitionKey: string;
+        nextRowKey: string;
+        getNextPage(callback?: QueryEntitiesCallback): void;
+        hasNextPage(): boolean;
     }
 
     export interface ModifyEntityCallback {
@@ -370,4 +374,5 @@ declare module "azure" {
     //#endregion
 
     export function isEmulated(): boolean;
+
 }

--- a/node-azure/azure.d.ts
+++ b/node-azure/azure.d.ts
@@ -216,11 +216,17 @@ declare module "azure" {
     }
 
     export class LinearRetryPolicyFilter {
-
+        constructor(retryCount?: number, retryInterval?: number);
+        retryCount: number;
+        retryInterval: number;
     }
 
     export class ExponentialRetryPolicyFilter {
-
+        constructor(retryCount?: number, retryInterval?: number, minRetryInterval?: number, maxRetryInterval?: number);
+        retryCount: number;
+        retryInterval: number;
+        minRetryInterval: number;
+        maxRetryInterval: number;
     }
 
     export class SharedAccessSignature {


### PR DESCRIPTION
- QueryEntitiesResultContinunation - used when Table query returns more than 1000 (or smaller amount specified with TableQuery.top()) rows, this class is then needed to retrieve next page(s)
- LinearRetryPolicyFilter, ExponentialRetryPolicyFilter - used by Queue-, Blob-, TableService to define retry policy in case HTTP request fails.
