### PR TITLE
If eventName is an instance of an event map e.g '{change:action}' then 

### DIFF
--- a/backbone/backbone.d.ts
+++ b/backbone/backbone.d.ts
@@ -67,7 +67,7 @@ declare module Backbone {
     }
 
     class Events {
-        on(eventName: any, callback: (...args: any[]) => void , context?: any): any;
+        on(eventName: any, callback?: (...args: any[]) => void , context?: any): any;
         off(eventName?: string, callback?: (...args: any[]) => void , context?: any): any;
         trigger(eventName: string, ...args: any[]): any;
         bind(eventName: string, callback: (...args: any[]) => void , context?: any): any;


### PR DESCRIPTION
If eventName is an instance of an event map e.g '{change:action}' then Callback is not required. So callback should be marked as optional. Related to earlier commit (cb1b62852708536407d535aae31af77fef68cdd4)
