### PR TITLE
Fix 'every' and 'all' definitions for underscore

### DIFF
--- a/underscore/underscore-tests.ts
+++ b/underscore/underscore-tests.ts
@@ -23,6 +23,7 @@ _.where(listOfPlays, { author: "Shakespeare", year: 1611 });
 var odds = _.reject([1, 2, 3, 4, 5, 6], (num) => num % 2 == 0);
 
 _.all([true, 1, null, 'yes'], _.identity);
+_.all([true, 1, null, 'yes']);
 
 _.any([null, 0, 'yes', false]);
 

--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -295,13 +295,13 @@ declare module _ {
 	* Returns true if all of the values in the list pass the iterator truth test. Delegates to the
 	* native method every, if present.
 	* @param list Truth test against all elements within this list.
-	* @param iterator Trust test iterator function for each element in `list`.
+	* @param iterator Trust test iterator function for each element in `list`, optional.
 	* @param context `this` object in `iterator`, optional.
 	* @return True if all elements passed the truth test, otherwise false.
 	**/
 	export function all<T>(
 		list: Collection<T>,
-		iterator: ListIterator<T, boolean>,
+		iterator?: ListIterator<T, boolean>,
 		context?: any): boolean;
 
 	/**
@@ -309,7 +309,7 @@ declare module _ {
 	**/
 	export function every<T>(
 		list: Collection<T>,
-		iterator: ListIterator<T, boolean>,
+		iterator?: ListIterator<T, boolean>,
 		context?: any): boolean;
 
 	/**
@@ -799,7 +799,7 @@ declare module _ {
 		start: number,
 		stop: number,
 		step?: number): number[];
-	
+
 	/**
 	* @see _.range
 	* @param stop Stop here.


### PR DESCRIPTION
The underscore documentation shows that the iterator parameter is
optional and is implemented that way as well.
