### PR TITLE
D3's Selection.node() returns an HTMLElement

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -740,7 +740,7 @@ declare module D3 {
         */
         sort<T>(comparator?: (a: T, b: T) => number): Selection;
         order: () => Selection;
-        node: () => SVGLocatable;
+        node: () => HTMLElement;
     }
 
     export interface EnterSelection {
@@ -748,7 +748,7 @@ declare module D3 {
         insert: (name: string, before: string) => Selection;
         select: (selector: string) => Selection;
         empty: () => boolean;
-        node: () => SVGLocatable;
+        node: () => HTMLElement;
     }
 
     export interface UpdateSelection extends Selection {


### PR DESCRIPTION
d3_documentElement = document.documentElement and d3_select is
initialized from a querySelection so node() will only ever return
HTMLElement or null. We mistook it for SVGLocatable because of the
following in d3-test.js:

var box = label.node().getBBox();

But that's a different node() function altogether.

Contacted Utkarsh Upadhyay and confirmed =)
