### PR TITLE
Append global var requirejs

### DIFF
--- a/requirejs/require.d.ts
+++ b/requirejs/require.d.ts
@@ -307,5 +307,6 @@ interface RequireDefine {
 }
 
 // Ambient declarations for 'require' and 'define'
+declare var requirejs: Require;
 declare var require: Require;
 declare var define: RequireDefine;


### PR DESCRIPTION
Append missing global var **requirejs**.

In order to avoid conflicts with typescript keyword **require**, it's recommended to use the global var **requirejs** to specifically use RequireJS method or config.

This version of definition do not contain this variable. This pull request fix that.
