### PR TITLE
Fix leaflet.d.ts, TileLayerOptions.subdomains is flexibly typed

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -808,7 +808,7 @@ declare module L {
           * Subdomains of the tile service. Can be passed in the form of one string (where
           * each letter is a subdomain name) or an array of strings.
           */
-        subdomains?: string;
+        subdomains?: any;
 
         /**
           * URL to the tile image to show in place of the tile that failed to load.


### PR DESCRIPTION
From the comments, subdomains can be a string or an array of strings. We
can't make any strong type inference from the interface.

Quote:
"Subdomains of the tile service. Can be passed in the form of one string (where
each letter is a subdomain name) or an array of strings."
