### PR TITLE
iScroll constructor with HTMLElement

### DIFF
--- a/iscroll/iscroll-lite.d.ts
+++ b/iscroll/iscroll-lite.d.ts
@@ -34,8 +34,8 @@ interface iScrollOptions {
 
 declare class iScroll {
 
-    constructor (element: string);
-    constructor (element: string, options: iScrollOptions);
+    constructor (element: string, options?: iScrollOptions);
+	constructor (element: HTMLElement, options?: iScrollOptions);
 
     destroy(): void;
     refresh(): void;

--- a/iscroll/iscroll-tests.ts
+++ b/iscroll/iscroll-tests.ts
@@ -19,5 +19,5 @@ var myScroll6 = new iScroll('wrapper', { scrollbarClass: 'myScrollbar' });
 myScroll1.refresh();
 
 
-var myScroll6 = new iScroll(document.getElementById('wrapper'));
-var myScroll7 = new iScroll(document.getElementById('wrapper'), { scrollbarClass: 'myScrollbar' });
+var myScroll7 = new iScroll(document.getElementById('wrapper'));
+var myScroll8 = new iScroll(document.getElementById('wrapper'), { scrollbarClass: 'myScrollbar' });

--- a/iscroll/iscroll-tests.ts
+++ b/iscroll/iscroll-tests.ts
@@ -17,3 +17,7 @@ var myScroll4 = new iScroll('wrapper', {
 var myScroll6 = new iScroll('wrapper', { scrollbarClass: 'myScrollbar' });
 
 myScroll1.refresh();
+
+
+var myScroll6 = new iScroll(document.getElementById('wrapper'));
+var myScroll7 = new iScroll(document.getElementById('wrapper'), { scrollbarClass: 'myScrollbar' });

--- a/iscroll/iscroll.d.ts
+++ b/iscroll/iscroll.d.ts
@@ -59,8 +59,8 @@ interface iScrollOptions {
 
 declare class iScroll {
 
-    constructor (element: string);
-    constructor (element: string, options: iScrollOptions);
+    constructor (element: string, options?: iScrollOptions);
+	constructor (element: HTMLElement, options?: iScrollOptions);
 
     destroy(): void;
     refresh(): void;


### PR DESCRIPTION
An iScroll object can be constructed using either a string with the id of an HTMLElement, or the HTMLElement itself.
I added this second constructor and updated the test to match.
