### PR TITLE
Add id to Socket interface

### DIFF
--- a/socket.io/socket.io.d.ts
+++ b/socket.io/socket.io.d.ts
@@ -15,6 +15,7 @@ declare module "socket.io" {
 }
 
 interface Socket {
+	id: string;
 	json:any;
 	log: any;
 	volatile: any;


### PR DESCRIPTION
Although not clearly documented, the Socket object has a string 'id' attribute (see https://github.com/LearnBoost/socket.io/blob/master/lib/socket.js)
