### PR TITLE
Update winjs.d.ts to include proper signature for createGrouped function

### DIFF
--- a/winjs/winjs.d.ts
+++ b/winjs/winjs.d.ts
@@ -25,7 +25,7 @@ declare module WinJS {
             public splice(index: number, count: number): any[];
             public splice(index: number): any[];
             public createFiltered(predicate: (x: any) => boolean): List;
-            public createGrouped(keySelector: (x: any) => any, dataSelector: (x:any) => any): List;
+            public createGrouped(keySelector: (x: any) => any, dataSelector: (x:any) => any, groupSorter: (left:any, right:any) => number): List;
             public groups: any;
             public dataSource: any;
             public getAt: any;


### PR DESCRIPTION
`createGrouped` was missing a required parameter, as documented here: http://msdn.microsoft.com/en-us/library/windows/apps/hh700742.aspx
