### PR TITLE
Override find functions in IAugmentedJQuery interface

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -694,6 +694,10 @@ declare module ng {
         // TODO: events, how to define?
         //$destroy
 
+        find(selector: string): IAugmentedJQuery;
+        find(element: any): IAugmentedJQuery;
+        find(obj: JQuery): IAugmentedJQuery;
+
         controller(name: string): any;
         injector(): any;
         scope(): IScope;


### PR DESCRIPTION
Calling IAugmentedJQuery.find() returns variable of IAugmentedJQuery
type, instead of JQuery.
