### PR TITLE
Fixed the definitions for local and sync storage.

### DIFF
--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -1534,11 +1534,11 @@ declare module chrome.storage {
         oldValue?: any;
     }
 
-    interface Local {
+    interface Local extends StorageArea {
         QUOTA_BYTES: number;
     }
 
-    interface Sync {
+    interface Sync extends StorageArea {
         MAX_SUSTAINED_WRITE_OPERATIONS_PER_MINUTE: number;
         QUOTA_BYTES: number;
         QUOTA_BYTES_PER_ITEM: number;


### PR DESCRIPTION
reference: [Chrome StorageArea Documentation](http://developer.chrome.com/extensions/storage.html#type-StorageArea)
`Local` and `Sync` are both types of `StorageArea`. You could think of `StorageArea` as an abstract class of sorts - they use it as reference in their docs, but really you're supposed to replace `StorageArea` with `local` or `sync`. I reflected this in the definition file by having `Local` and `Sync` extend `StorageArea`. 
