### PR TITLE
Node: Adding missing fs methods + fixing a few method signatures

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -725,10 +725,12 @@ declare module "fs" {
 
     export function rename(oldPath: string, newPath: string, callback?: Function): void;
     export function renameSync(oldPath: string, newPath: string): void;
+    export function truncate(path: string, callback?: Function): void;
     export function truncate(path: string, len: number, callback?: Function): void;
-    export function truncateSync(path: string, len: number): void;
+    export function truncateSync(path: string, len?: number): void;
+    export function ftruncate(fd: string, callback?: Function): void;
     export function ftruncate(fd: string, len: number, callback?: Function): void;
-    export function ftruncateSync(fd: string, len: number): void;
+    export function ftruncateSync(fd: string, len?: number): void;
     export function chown(path: string, uid: number, gid: number, callback?: Function): void;
     export function chownSync(path: string, uid: number, gid: number): void;
     export function fchown(fd: string, uid: number, gid: number, callback?: Function): void;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -727,8 +727,8 @@ declare module "fs" {
     export function renameSync(oldPath: string, newPath: string): void;
     export function truncate(path: string, len: number, callback?: Function): void;
     export function truncateSync(path: string, len: number): void;
-    export function ftruncate(fd: number, len: number, callback?: Function): void;
-    export function ftruncateSync(fd: number, len: number): void;
+    export function ftruncate(fd: string, len: number, callback?: Function): void;
+    export function ftruncateSync(fd: string, len: number): void;
     export function chown(path: string, uid: number, gid: number, callback?: Function): void;
     export function chownSync(path: string, uid: number, gid: number): void;
     export function fchown(fd: string, uid: number, gid: number, callback?: Function): void;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -106,7 +106,7 @@ interface NodeProcess extends EventEmitter {
     execPath: string;
     abort(): void;
     chdir(directory: string): void;
-    cwd(): void;
+    cwd(): string;
     env: any;
     exit(code?: number): void;
     getgid(): number;
@@ -725,8 +725,10 @@ declare module "fs" {
 
     export function rename(oldPath: string, newPath: string, callback?: Function): void;
     export function renameSync(oldPath: string, newPath: string): void;
-    export function truncate(fd: string, len: number, callback?: Function): void;
-    export function truncateSync(fd: string, len: number): void;
+    export function truncate(path: string, len: number, callback?: Function): void;
+    export function truncateSync(path: string, len: number): void;
+    export function ftruncate(fd: number, len: number, callback?: Function): void;
+    export function ftruncateSync(fd: number, len: number): void;
     export function chown(path: string, uid: number, gid: number, callback?: Function): void;
     export function chownSync(path: string, uid: number, gid: number): void;
     export function fchown(fd: string, uid: number, gid: number, callback?: Function): void;
@@ -750,6 +752,7 @@ declare module "fs" {
     export function symlink(srcpath: string, dstpath: string, type?: string, callback?: Function): void;
     export function symlinkSync(srcpath: string, dstpath: string, type?: string): void;
     export function readlink(path: string, callback?: (err: Error, linkString: string) =>any): void;
+    export function readlinkSync(path: string): string;
     export function realpath(path: string, callback?: (err: Error, resolvedPath: string) =>any): void;
     export function realpath(path: string, cache: string, callback: (err: Error, resolvedPath: string) =>any): void;
     export function realpathSync(path: string, cache?: string): void;
@@ -808,12 +811,7 @@ declare module "fs" {
 declare module "path" {
     export function normalize(p: string): string;
     export function join(...paths: any[]): string;
-    export function resolve(to: string): string;
-    export function resolve(from: string, to: string): string;
-    export function resolve(from: string, from2: string, to: string): string;
-    export function resolve(from: string, from2: string, from3: string, to: string): string;
-    export function resolve(from: string, from2: string, from3: string, from4: string, to: string): string;
-    export function resolve(from: string, from2: string, from3: string, from4: string, from5: string, to: string): string;
+    export function resolve(...pathSegments: any[]): string;
     export function relative(from: string, to: string): string;
     export function dirname(p: string): string;
     export function basename(p: string, ext?: string): string;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -737,11 +737,17 @@ declare module "fs" {
     export function fchownSync(fd: string, uid: number, gid: number): void;
     export function lchown(path: string, uid: number, gid: number, callback?: Function): void;
     export function lchownSync(path: string, uid: number, gid: number): void;
+    export function chmod(path: string, mode: number, callback?: Function): void;
     export function chmod(path: string, mode: string, callback?: Function): void;
+    export function chmodSync(path: string, mode: number): void;
     export function chmodSync(path: string, mode: string): void;
+    export function fchmod(fd: string, mode: number, callback?: Function): void;
     export function fchmod(fd: string, mode: string, callback?: Function): void;
+    export function fchmodSync(fd: string, mode: number): void;
     export function fchmodSync(fd: string, mode: string): void;
+    export function lchmod(path: string, mode: number, callback?: Function): void;
     export function lchmod(path: string, mode: string, callback?: Function): void;
+    export function lchmodSync(path: string, mode: number): void;
     export function lchmodSync(path: string, mode: string): void;
     export function stat(path: string, callback?: (err: Error, stats: Stats) =>any): Stats;
     export function lstat(path: string, callback?: (err: Error, stats: Stats) =>any): Stats;
@@ -763,14 +769,18 @@ declare module "fs" {
     export function rmdir(path: string, callback?: Function): void;
     export function rmdirSync(path: string): void;
     export function mkdir(path: string, callback?: Function): void;
+    export function mkdir(path: string, mode: number, callback?: Function): void;
     export function mkdir(path: string, mode: string, callback?: Function): void;
+    export function mkdirSync(path: string, mode?: number): void;
     export function mkdirSync(path: string, mode?: string): void;
     export function readdir(path: string, callback?: (err: Error, files: string[]) => void): void;
     export function readdirSync(path: string): string[];
     export function close(fd: string, callback?: Function): void;
     export function closeSync(fd: string): void;
     export function open(path: string, flags: string, callback?: (err: Error, fd: string) => any): void;
+    export function open(path: string, flags: string, mode: number, callback?: (err: Error, fd: string) => any): void;
     export function open(path: string, flags: string, mode: string, callback?: (err: Error, fd: string) => any): void;
+    export function openSync(path: string, flags: string, mode?: number): void;
     export function openSync(path: string, flags: string, mode?: string): void;
     export function utimes(path: string, atime: number, mtime: number, callback?: Function): void;
     export function utimesSync(path: string, atime: number, mtime: number): void;
@@ -788,10 +798,14 @@ declare module "fs" {
     export function readFileSync(filename: string, options: { encoding?: string; flag?: string; }): any;
     export function writeFile(filename: string, data: any, callback?: (err: Error) => void): void;
     export function writeFile(filename: string, data: any, options: { encoding?: string; mode?: number; flag?: string; }, callback?: (err: Error) => void): void;
+    export function writeFile(filename: string, data: any, options: { encoding?: string; mode?: string; flag?: string; }, callback?: (err: Error) => void): void;
     export function writeFileSync(filename: string, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): void;
+    export function writeFileSync(filename: string, data: any, options?: { encoding?: string; mode?: string; flag?: string; }): void;
     export function appendFile(filename: string, data: any, options: { encoding?: string; mode?: number; flag?: string; }, callback?: (err: Error) => void): void;
+    export function appendFile(filename: string, data: any, options: { encoding?: string; mode?: string; flag?: string; }, callback?: (err: Error) => void): void;
     export function appendFile(filename: string, data: any, callback?: (err: Error) => void): void;
     export function appendFileSync(filename: string, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): void;
+    export function appendFileSync(filename: string, data: any, options?: { encoding?: string; mode?: string; flag?: string; }): void;
     export function watchFile(filename: string, listener: { curr: Stats; prev: Stats; }): void;
     export function watchFile(filename: string, options: { persistent?: boolean; interval?: number; }, listener: { curr: Stats; prev: Stats; }): void;
     export function unwatchFile(filename: string, listener?: Stats): void;
@@ -803,6 +817,13 @@ declare module "fs" {
         encoding?: string;
         fd?: string;
         mode?: number;
+        bufferSize?: number;
+    }): ReadStream;
+    export function createReadStream(path: string, options?: {
+        flags?: string;
+        encoding?: string;
+        fd?: string;
+        mode?: string;
         bufferSize?: number;
     }): ReadStream;
     export function createWriteStream(path: string, options?: {

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -754,8 +754,8 @@ declare module "fs" {
     export function readlink(path: string, callback?: (err: Error, linkString: string) =>any): void;
     export function readlinkSync(path: string): string;
     export function realpath(path: string, callback?: (err: Error, resolvedPath: string) =>any): void;
-    export function realpath(path: string, cache: string, callback: (err: Error, resolvedPath: string) =>any): void;
-    export function realpathSync(path: string, cache?: string): void;
+    export function realpath(path: string, cache: {[path: string]: string}, callback: (err: Error, resolvedPath: string) =>any): void;
+    export function realpathSync(path: string, cache?: {[path: string]: string}): void;
     export function unlink(path: string, callback?: Function): void;
     export function unlinkSync(path: string): void;
     export function rmdir(path: string, callback?: Function): void;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -762,13 +762,15 @@ declare module "fs" {
     export function unlinkSync(path: string): void;
     export function rmdir(path: string, callback?: Function): void;
     export function rmdirSync(path: string): void;
-    export function mkdir(path: string, mode?: string, callback?: Function): void;
+    export function mkdir(path: string, callback?: Function): void;
+    export function mkdir(path: string, mode: string, callback?: Function): void;
     export function mkdirSync(path: string, mode?: string): void;
     export function readdir(path: string, callback?: (err: Error, files: string[]) => void): void;
     export function readdirSync(path: string): string[];
     export function close(fd: string, callback?: Function): void;
     export function closeSync(fd: string): void;
-    export function open(path: string, flags: string, mode?: string, callback?: (err: Error, fd: string) =>any): void;
+    export function open(path: string, flags: string, callback?: (err: Error, fd: string) => any): void;
+    export function open(path: string, flags: string, mode: string, callback?: (err: Error, fd: string) => any): void;
     export function openSync(path: string, flags: string, mode?: string): void;
     export function utimes(path: string, atime: number, mtime: number, callback?: Function): void;
     export function utimesSync(path: string, atime: number, mtime: number): void;


### PR DESCRIPTION
Added:
- `fs.readlinkSync`
- `fs.ftruncate`
- `fs.ftruncateSync`

Fixed:
- `process.cwd`
- `path.resolve`
- `fs.realpath`
- `fs.realpathSync`
- `fs.truncate`
- `fs.truncateSync`
