### PR TITLE
Update bind method for underscore.d.ts

### DIFF
--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -861,7 +861,7 @@ declare module _ {
 	* @return `fn` with `this` bound to `object`.
 	**/
 	export function bind(
-		func: (...as: any[]) => any,
+		func: Function,
 		context: any,
 		...arguments: any[]): () => any;
 


### PR DESCRIPTION
Bind on a <Function> parameter. This fixes typing errors caused by binding functions returned by other underscore methods such as partial/memoize/throttle/debounce etc.
