### PR TITLE
(Phonegap) Notification.confirm with buttonLabels array

### DIFF
--- a/phonegap/phonegap-tests.ts
+++ b/phonegap/phonegap-tests.ts
@@ -656,6 +656,12 @@ function test_notification() {
         'Game Over',
         'Restart,Exit'
     );
+	navigator.notification.confirm(
+        'You are the winner!',
+        onConfirm,
+        'Game Over',
+        ['Restart','Exit']
+    );
     navigator.notification.beep(2);
     navigator.notification.vibrate(2500);
 }

--- a/phonegap/phonegap.d.ts
+++ b/phonegap/phonegap.d.ts
@@ -478,6 +478,7 @@ declare var Media: {
 interface Notification {
     alert(message: string, alertCallback: Function, title?: string, buttonName?: string): void;
     confirm(message: string, confirmCallback: Function, title?: string, buttonLabels?: string): void;
+	confirm(message: string, confirmCallback: Function, title?: string, buttonLabels?: Array<string>): void;
     beep(times: number): void;
     vibrate(milliseconds: number): void;
 }

--- a/phonegap/phonegap.d.ts
+++ b/phonegap/phonegap.d.ts
@@ -478,7 +478,7 @@ declare var Media: {
 interface Notification {
     alert(message: string, alertCallback: Function, title?: string, buttonName?: string): void;
     confirm(message: string, confirmCallback: Function, title?: string, buttonLabels?: string): void;
-	confirm(message: string, confirmCallback: Function, title?: string, buttonLabels?: Array<string>): void;
+	confirm(message: string, confirmCallback: Function, title?: string, buttonLabels?: string[]): void;
     beep(times: number): void;
     vibrate(milliseconds: number): void;
 }


### PR DESCRIPTION
In the new version the comma separated buttonLabels parameter is marked as deprecated. Passing in an array of strings is the new preferred way.
