### PR TITLE
Ember.run.{debounce,throttle,later} have variable arguments

### DIFF
--- a/ember/ember.d.ts
+++ b/ember/ember.d.ts
@@ -2728,13 +2728,13 @@ declare module Ember {
         (target: any, method: Function): void;
         begin(): void;
         cancel(timer: any): void;
-        debounce(target: any, method: Function, wait: number, immediate: boolean): void;
-        debounce(target: any, method: string, wait: number, immediate: boolean): void;
+        debounce(target: any, method: Function, ...any): void;
+        debounce(target: any, method: string, ...any): void;
         end(): void;
         join(target: any, method: Function, ...any): any;
         join(target: any, method: string, ...any): any;
-        later(target: any, method: Function, wait: boolean): string;
-        later(target: any, method: string, wait: boolean): string;
+        later(target: any, method: Function, ...any): string;
+        later(target: any, method: string, ...any): string;
         next(target: any, method: Function, ...any): number;
         next(target: any, method: string, ...any): number;
         once(target: any, method: Function, ...any): number;
@@ -2744,8 +2744,8 @@ declare module Ember {
         scheduleOnce(queue: string, target: any, method: Function, ...any): void;
         scheduleOnce(queue: string, target: any, method: string, ...any): void;
         sync(): void;
-        throttle(target: any, method: Function, spacing: number): void;
-        throttle(target: any, method: string, spacing: number): void;
+        throttle(target: any, method: Function, ...any): void;
+        throttle(target: any, method: string, ...any): void;
         queues: any[];
     };
     function runLoadHooks(name: string, object: any): void;


### PR DESCRIPTION
Straight from the docs (http://emberjs.com/api/classes/Ember.run.html),
see the method debounce is defined thusly:

debounce (target, method, args*, wait, immediate): void

Even though the last two arguments are guaranteed, the variable
arguments in the middle means we can only ever type everything after
method as "...any".
