### PR TITLE
Added generic overload method declarations for the ko.utils.arrayX funct...

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -242,21 +242,35 @@ interface KnockoutUtils {
 
     fieldsIncludedWithJsonPost: any[];
 
+    arrayForEach<T>(array: T[], action: (item: T) => void): void;
+
     arrayForEach(array: any[], action: (any) => void ): void;
 
     arrayIndexOf(array: any[], item: any): number;
+
+    arrayFirst<T>(array: T[], predicate: (item: T) => boolean, predicateOwner?: any): T;
 
     arrayFirst(array: any[], predicate: (item) => boolean, predicateOwner?: any): any;
 
     arrayRemoveItem(array: any[], itemToRemove: any): void;
 
+    arrayGetDistinctValues<T>(array: T[]): T[];
+
     arrayGetDistinctValues(array: any[]): any[];
+
+    arrayMap<T, U>(array: T[], mapping: (item: T) => U): U[];
 
     arrayMap(array: any[], mapping: (item) => any): any[];
 
+    arrayFilter<T>(array: T[], predicate: (item: T) => boolean): T[];
+
     arrayFilter(array: any[], predicate: (item) => boolean): any[];
 
+    arrayPushAll<T>(array: T[], valuesToPush: T[]): T[];
+
     arrayPushAll(array: any[], valuesToPush: any[]): any[];
+
+    arrayPushAll<T>(array: KnockoutObservableArray<T>, valuesToPush: T[]): T[];
 
     arrayPushAll(array: KnockoutObservableArray<any>, valuesToPush: any[]): any[];
 


### PR DESCRIPTION
I was missing some generic overloads for the ko.utils.arrayX functions. I had to explicitly type the arguments like so:

ko.utils.arrayForEach(this.bikes, (bike: Bike) => { bike.broken = true });

With this commit the type is implicit and typescript still knows the type:

ko.utils.arrayForEach(this.bikes, (bike) => { bike.broken = true });
