### PR TITLE
Q: support nested promises

### DIFF
--- a/q/Q.d.ts
+++ b/q/Q.d.ts
@@ -8,10 +8,10 @@ declare function Q<T>(promise: Q.IPromise<T>): Q.Promise<T>;
 
 declare module Q {
     interface IPromise<T> {
-        then<U>(onFulfill: (value: T) => U, onReject?: (reason) => U): IPromise<U>;
+        then<U>(onFulfill: (value: T) => IPromise<U>, onReject?: (reason) => IPromise<U>): IPromise<U>;
         then<U>(onFulfill: (value: T) => IPromise<U>, onReject?: (reason) => U): IPromise<U>;
         then<U>(onFulfill: (value: T) => U, onReject?: (reason) => IPromise<U>): IPromise<U>;
-        then<U>(onFulfill: (value: T) => IPromise<U>, onReject?: (reason) => IPromise<U>): IPromise<U>;
+        then<U>(onFulfill: (value: T) => U, onReject?: (reason) => U): IPromise<U>;
     }
 
     interface Deferred<T> {
@@ -26,10 +26,10 @@ declare module Q {
         fin(finallyCallback: () => any): Promise<T>;
         finally(finallyCallback: () => any): Promise<T>;
 
-        then<U>(onFulfill: (value: T) => U, onReject?: (reason) => U, onProgress?: Function): Promise<U>;
+        then<U>(onFulfill: (value: T) => IPromise<U>, onReject?: (reason) => IPromise<U>, onProgress?: Function): Promise<U>;
         then<U>(onFulfill: (value: T) => IPromise<U>, onReject?: (reason) => U, onProgress?: Function): Promise<U>;
         then<U>(onFulfill: (value: T) => U, onReject?: (reason) => IPromise<U>, onProgress?: Function): Promise<U>;
-        then<U>(onFulfill: (value: T) => IPromise<U>, onReject?: (reason) => IPromise<U>, onProgress?: Function): Promise<U>;
+        then<U>(onFulfill: (value: T) => U, onReject?: (reason) => U, onProgress?: Function): Promise<U>;
 
         spread<U>(onFulfilled: Function, onRejected?: Function): Promise<U>;
 
@@ -71,22 +71,22 @@ declare module Q {
     }
 
     // if no fulfill, reject, or progress provided, returned promise will be of same type
-    export function when<T>(value: T): Promise<T>;
     export function when<T>(value: IPromise<T>): Promise<T>;
+    export function when<T>(value: T): Promise<T>;
 
     // If a non-promise value is provided, it will not reject or progress
-    export function when<T, U>(value: T, onFulfilled: (val: T) => U): Promise<U>;
     export function when<T, U>(value: T, onFulfilled: (val: T) => IPromise<U>): Promise<U>;
+    export function when<T, U>(value: T, onFulfilled: (val: T) => U): Promise<U>;
 
-    export function when<T, U>(value: IPromise<T>, onFulfilled: (val: T) => U, onRejected?: (reason) => U, onProgress?: (progress) => any): Promise<U>;
+    export function when<T, U>(value: IPromise<T>, onFulfilled: (val: T) => IPromise<U>, onRejected?: (reason) => IPromise<U>, onProgress?: (progress) => any): Promise<U>;
     export function when<T, U>(value: IPromise<T>, onFulfilled: (val: T) => IPromise<U>, onRejected?: (reason) => U, onProgress?: (progress) => any): Promise<U>;
     export function when<T, U>(value: IPromise<T>, onFulfilled: (val: T) => U, onRejected?: (reason) => IPromise<U>, onProgress?: (progress) => any): Promise<U>;
-    export function when<T, U>(value: IPromise<T>, onFulfilled: (val: T) => IPromise<U>, onRejected?: (reason) => IPromise<U>, onProgress?: (progress) => any): Promise<U>;
+    export function when<T, U>(value: IPromise<T>, onFulfilled: (val: T) => U, onRejected?: (reason) => U, onProgress?: (progress) => any): Promise<U>;    
     
     //export function try(method: Function, ...args: any[]): Promise<any>; // <- This is broken currently - not sure how to fix.
 
-    export function fbind<T>(method: (...args: any[]) => T, ...args: any[]): (...args: any[]) => Promise<T>;
     export function fbind<T>(method: (...args: any[]) => IPromise<T>, ...args: any[]): (...args: any[]) => Promise<T>;
+    export function fbind<T>(method: (...args: any[]) => T, ...args: any[]): (...args: any[]) => Promise<T>;
 
     export function fcall<T>(method: (...args) => T, ...args: any[]): Promise<T>;
 
@@ -110,14 +110,15 @@ declare module Q {
     export function allResolved<T>(promises: any[]): Promise<Promise<T>[]>;
     export function allResolved<T>(promises: IPromise<T>[]): Promise<Promise<T>[]>;
 
-    export function spread<U>(promises: any[], onFulfilled: (...args: any[]) => U, onRejected: (reason) => U): Promise<U>;
+    export function spread<U>(promises: any[], onFulfilled: (...args: any[]) => IPromise<U>, onRejected: (reason) => IPromise<U>): Promise<U>;
     export function spread<U>(promises: any[], onFulfilled: (...args: any[]) => IPromise<U>, onRejected: (reason) => U): Promise<U>;
     export function spread<U>(promises: any[], onFulfilled: (...args: any[]) => U, onRejected: (reason) => IPromise<U>): Promise<U>;
-    export function spread<U>(promises: any[], onFulfilled: (...args: any[]) => IPromise<U>, onRejected: (reason) => IPromise<U>): Promise<U>;
-    export function spread<T, U>(promises: IPromise<T>[], onFulfilled: (...args: T[]) => U, onRejected: (reason) => U): Promise<U>;
+    export function spread<U>(promises: any[], onFulfilled: (...args: any[]) => U, onRejected: (reason) => U): Promise<U>;
+    
+    export function spread<T, U>(promises: IPromise<T>[], onFulfilled: (...args: T[]) => IPromise<U>, onRejected: (reason) => IPromise<U>): Promise<U>;
     export function spread<T, U>(promises: IPromise<T>[], onFulfilled: (...args: T[]) => IPromise<U>, onRejected: (reason) => U): Promise<U>;
     export function spread<T, U>(promises: IPromise<T>[], onFulfilled: (...args: T[]) => U, onRejected: (reason) => IPromise<U>): Promise<U>;
-    export function spread<T, U>(promises: IPromise<T>[], onFulfilled: (...args: T[]) => IPromise<U>, onRejected: (reason) => IPromise<U>): Promise<U>;
+    export function spread<T, U>(promises: IPromise<T>[], onFulfilled: (...args: T[]) => U, onRejected: (reason) => U): Promise<U>;
     
     export function timeout<T>(promise: Promise<T>, ms: number, message?: string): Promise<T>;
 
@@ -132,8 +133,8 @@ declare module Q {
 
     export function reject(reason?): Promise<any>;
 
-    export function promise<T>(resolver: (resolve: (val: T) => void , reject: (reason) => void , notify: (progress) => void ) => void ): Promise<T>;
     export function promise<T>(resolver: (resolve: (val: IPromise<T>) => void , reject: (reason) => void , notify: (progress) => void ) => void ): Promise<T>;
+    export function promise<T>(resolver: (resolve: (val: T) => void , reject: (reason) => void , notify: (progress) => void ) => void ): Promise<T>;
 
     export function promised<T>(callback: (...any) => T): (...any) => Promise<T>;
 
@@ -147,8 +148,8 @@ declare module Q {
     export var oneerror: () => void;
     export var longStackSupport: boolean;
 
-    export function resolve<T>(object: T): Promise<T>;
     export function resolve<T>(object: IPromise<T>): Promise<T>;
+    export function resolve<T>(object: T): Promise<T>;
 }
 
 declare module "q" {


### PR DESCRIPTION
On my system, the following would throw an error, because it was matching the value-based function definition before the promise-based one. 

```
function():Q.IPromise<string> {
    return doSomething().then(function (stuff) {
        return anotherPromise(stuff);
    })
}
```

I reversed the order of the function overloads so it matches the ones that return promises first, instead of the values. 
