### PR TITLE
JQuery: fixed error about metaKey not matching

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -156,7 +156,7 @@ interface BaseJQueryEventObject extends Event {
     pageX: number;
     pageY: number;
     which: number;
-    metaKey: any;
+    metaKey: boolean;
 }
 
 interface JQueryInputEventObject extends BaseJQueryEventObject {


### PR DESCRIPTION
Here is the error I was getting. I'm not sure this is the appropriate way to fix it, but it at least shuts up the error :)

```
DefinitelyTyped/jquery/jquery.d.ts
  Line 192: Interface 'JQueryEventObject' cannot simultaneously extend types 'BaseJQueryEventObject' and  'JQueryInputEventObject':
Types of property 'metaKey' of types 'BaseJQueryEventObject' and 'JQueryInputEventObject' are not identical.
```
