### PR TITLE
Fixes for underscore.d.ts

### DIFF
--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -382,7 +382,7 @@ declare module _ {
 	**/
 	export function pluck<T extends {}>(
 		list: Collection<T>,
-		propertyName: string): T[];
+		propertyName: string): any[];
 
 	/**
 	* Returns the maximum value in list.
@@ -839,7 +839,7 @@ declare module _ {
 		start: number,
 		stop: number,
 		step?: number): number[];
-	
+
 	/**
 	* @see _.range
 	* @param stop Stop here.
@@ -861,7 +861,7 @@ declare module _ {
 	* @return `fn` with `this` bound to `object`.
 	**/
 	export function bind(
-		func: (...as: any[]) => any,
+		func: Function,
 		context: any,
 		...arguments: any[]): () => any;
 
@@ -900,7 +900,7 @@ declare module _ {
 	**/
 	export function memoize(
 		fn: Function,
-		hashFn?: (n: any) => string): Function;
+		hashFn?: (...args: any[]) => string): Function;
 
 	/**
 	* Much like setTimeout, invokes function after wait milliseconds. If you pass the optional arguments,
@@ -1624,7 +1624,7 @@ declare class _<T> {
 	* @see _.shuffle
 	**/
 	shuffle(): T[];
-	
+
 	/**
 	* Wrapped type `any[]`.
 	* @see _.sample


### PR DESCRIPTION
- the type of elements in the array returned by pluck have no correlation to the type of elements in the source array - they actually relate to the values of the provided property name
- bind wasn't working for a function typed as "Function".  In our use case, we call _.throttle() then use the result in _.bind().
- the hash function passed into memoize may take multiple arguments
