### PR TITLE
Fix jquery.d.ts break with TypeScript 'develop' branch

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -156,7 +156,7 @@ interface BaseJQueryEventObject extends Event {
     pageX: number;
     pageY: number;
     which: number;
-    metaKey: any;
+    metaKey: boolean;
 }
 
 interface JQueryInputEventObject extends BaseJQueryEventObject {


### PR DESCRIPTION
The beta compiler is smarter about detecting inconsistencies:
jquery.d.ts(192,11): error TS2189: Interface 'JQueryEventObject' cannot simultaneously extend types 'BaseJQueryEventObject' and 'JQueryInputEventObject':
Types of property 'metaKey' of types 'BaseJQueryEventObject' and 'JQueryInputEventObject' are not identical.

Documentation seems to indicate 'boolean' is correct: http://api.jquery.com/event.metaKey/
