### PR TITLE
Fix future bugs in leaflet.d.ts

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -1581,7 +1581,7 @@ declare module L {
           * used in GeoJSON for points. If reverse is set to true, the numbers will be interpreted
           * as (longitude, latitude).
           */
-        static coordsToLatlng(coords: Array, reverse?: boolean): LatLng;
+        static coordsToLatlng(coords: number[], reverse?: boolean): LatLng;
 
         /**
           * Creates a multidimensional array of LatLng objects from a GeoJSON coordinates
@@ -1589,7 +1589,7 @@ declare module L {
           * 1 for an array of arrays of points, etc., 0 by default). If reverse is set to
           * true, the numbers will be interpreted as (longitude, latitude).
           */
-        static coordsToLatlngs(coords: Array, levelsDeep?: number, reverse?: boolean): Array;
+        static coordsToLatlngs(coords: number[], levelsDeep?: number, reverse?: boolean): LatLng[];
 
     }
 


### PR DESCRIPTION
The 'develop' TypeScript compiler is pickier about generics being fully specified.  In this case, 3 arrays could be more specific about the type of elements.
