### PR TITLE
Fix the typing of L.Icon.Default

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -1903,20 +1903,17 @@ declare module L {
           * Creates an icon instance with the given options.
           */
         constructor(options: IconOptions);
-
-        /**
-          * Default properties for newly constructed icons.
-          */
-        public static Default : IconDefault;
     }
 
-    export class IconDefault extends Icon {
-        /**
-          * Creates an icon instance with default options.
-          */
-        constructor();
+    export module Icon {
+        export class Default extends Icon {
+            /**
+              * Creates an icon instance with default options.
+              */
+            constructor();
 
-        imagePath: string;
+            static imagePath: string;
+        }
     }
 
     export interface DivIconOptions {


### PR DESCRIPTION
This wasn't quite right and the 'develop' branch of the TypeScript compiler no longer accepted the hacky typing.  This should be the correct typing according to information from the TS team here:
https://typescript.codeplex.com/workitem/132
