### PR TITLE
Requirejs should also accepts an array for path values.

### DIFF
--- a/requirejs/require.d.ts
+++ b/requirejs/require.d.ts
@@ -72,7 +72,7 @@ interface RequireConfig {
 
 	// Path mappings for module names not found directly under 
 	// baseUrl.
-	paths?: { [key: string]: string; };
+	paths?: { [key: string]: any; };
 
 	// Dictionary of Shim's.
 	// does not cover case of key->string[]


### PR DESCRIPTION
According to https://github.com/jrburke/requirejs/wiki/Upgrading-to-RequireJS-2.0#wiki-pathsfallbacks requirejs also accepts arrays as path values. Therefore, the type of path values should be `any` instead of `string`.
