### PR TITLE
Updated jquery.pickadate to support v3.3.0 of the library

### DIFF
--- a/jquery.pickadate/jquery.pickadate-tests.ts
+++ b/jquery.pickadate/jquery.pickadate-tests.ts
@@ -39,7 +39,8 @@ $('.datepicker').pickadate({
     // Escape any "rule" characters with an exclamation mark (!).
     format: 'You selecte!d: dddd, dd mmm, yyyy',
     formatSubmit: 'yyyy/mm/dd',
-    hiddenSuffix: '--submit'
+    hiddenPrefix: 'prefix__',
+    hiddenSuffix: '__suffix'
 });
 
 $('.datepicker').pickadate({
@@ -85,6 +86,13 @@ $('.datepicker').pickadate({
 $('.datepicker').pickadate({
     disable: [
         1, 4, 7
+    ]
+});
+
+$('.datepicker').pickadate({
+    disable: [
+        new Date(2013, 3, 13),
+        new Date(2013, 3, 29)
     ]
 });
 
@@ -140,7 +148,8 @@ $('.timepicker').pickatime({
     format: 'T!ime selected: h:i a',
     formatLabel: '<b>h</b>:i <!i>a</!i>',
     formatSubmit: 'HH:i',
-    hiddenSuffix: '--submit'
+    hiddenPrefix: 'prefix__',
+    hiddenSuffix: '__suffix'
 });
 
 $('.timepicker').pickatime({
@@ -265,6 +274,9 @@ picker.get('id');
 picker.get('disable');
 
 picker.set('clear');
+
+// reset disabled dates
+picker.set('disable', undefined);
 
 // Using arrays formatted as [YEAR,MONTH,DATE].
 picker.set('select', [2013, 3, 20]);

--- a/jquery.pickadate/jquery.pickadate.d.ts
+++ b/jquery.pickadate/jquery.pickadate.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for pickadate.js 3.2.0
+﻿// Type definitions for pickadate.js 3.3.0
 // Project: https://github.com/amsul/pickadate.js
 // Definitions by: Theodore Brown <https://github.com/theodorejb/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -37,6 +37,7 @@ interface pickadateOptions extends pickerOptions {
     // Formats
     format?: string; // default 'd mmmm, yyyy'
     formatSubmit?: string; // e.g. 'yyyy/mm/dd'
+    hiddenPrefix?: string; // default undefined
     hiddenSuffix?: string; // default '_submit'
 
     // Dropdown selectors
@@ -51,7 +52,7 @@ interface pickadateOptions extends pickerOptions {
     max?: any;
 
     // Disable dates
-    disable?: any[]; // arrays formatted as [YEAR,MONTH,DATE] or integers representing days of the week (from 1 to 7). Switch to whitelist by setting first item in collection to `true`.
+    disable?: any[]; // Date objects, arrays formatted as [YEAR,MONTH,DATE], or integers representing days of the week (from 1 to 7). Switch to whitelist by setting first item in collection to `true`.
 
     // Classes
     klass?: {
@@ -119,6 +120,7 @@ interface pickatimeOptions extends pickerOptions {
     format?: string; // default 'h:i A'
     formatLabel?: any;
     formatSubmit?: string;
+    hiddenPrefix?: string; // default undefined
     hiddenSuffix?: string; // default '_submit'
 
     // Time intervals


### PR DESCRIPTION
- Added support for `hiddenPrefix` option
- Dates can be disabled using Date objects
- Updated tests
