### PR TITLE
Add missing 'get' from Selection.datum

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -719,6 +719,7 @@ declare module D3 {
         datum: {
             (values: (data: any, index: number) => any): UpdateSelection;
             (values: any): UpdateSelection;
+            () : any;
         };
 
         filter: {


### PR DESCRIPTION
From D3's doc [*] "If value is not specified, [datum] returns the bound datum for the first non-null element in the selection. This is generally useful only if you know the selection contains exactly one element."

[*] https://github.com/mbostock/d3/wiki/Selections#wiki-datum
