### PR TITLE
Add definitions for new settable zone function

### DIFF
--- a/moment/moment.d.ts
+++ b/moment/moment.d.ts
@@ -121,6 +121,8 @@ interface Moment {
 
     isLeapYear(): boolean;
     zone(): number;
+    zone(b: number) Moment;
+    zone(b: string): Moment;
     daysInMonth(): number;
     isDST(): boolean;
 


### PR DESCRIPTION
Moment.js version 2.1 added a new zone function which takes either a number or string and returns a Moment, see here: http://momentjs.com/docs/#/manipulating/timezone-offset/ . So the definitions for that function should be added to this file.
