### PR TITLE
NG directives: fixes

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -668,15 +668,15 @@ declare module ng {
 
     interface IDirective{
         priority?: number;
-        template?: string;
-        templateUrl?: string;
+        template?: any;
+        templateUrl?: any;
         replace?: boolean;
         transclude?: any;
         restrict?: string;
         scope?: any;
         link?: Function;
         compile?: Function;
-        controller?: Function;
+        controller?: any;
     }
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Allow functions to be defined for template/templateUrl and array notation in controller

There's not a more elegant solution that I know of until we get structs in TS anyway.
