### PR TITLE
Update signatures for EventEmitter.

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -68,14 +68,14 @@ declare var Buffer: {
 ************************************************/
 
 interface EventEmitter {
-    addListener(event: string, listener: Function): void;
-    on(event: string, listener: Function): void;
-    once(event: string, listener: Function): void;
-    removeListener(event: string, listener: Function): void;
-    removeAllListeners(event?: string): void;
+    addListener(event: string, listener: Function): EventEmitter;
+    on(event: string, listener: Function): EventEmitter;
+    once(event: string, listener: Function): EventEmitter;
+    removeListener(event: string, listener: Function): EventEmitter;
+    removeAllListeners(event?: string): EventEmitter;
     setMaxListeners(n: number): void;
     listeners(event: string): Function[];
-    emit(event: string, arg1?: any, arg2?: any): void;
+    emit(event: string, arg1?: any, arg2?: any): boolean;
 }
 
 interface WritableStream extends EventEmitter {
@@ -209,25 +209,25 @@ declare module "querystring" {
 
 declare module "events" {
     export interface NodeEventEmitter {
-        addListener(event: string, listener: Function): void;
-        on(event: string, listener: Function): any;
-        once(event: string, listener: Function): void;
-        removeListener(event: string, listener: Function): void;
-        removeAllListeners(event?: string): void;
+        addListener(event: string, listener: Function): NodeEventEmitter;
+        on(event: string, listener: Function): NodeEventEmitter;
+        once(event: string, listener: Function): NodeEventEmitter;
+        removeListener(event: string, listener: Function): NodeEventEmitter;
+        removeAllListeners(event?: string): NodeEventEmitter;
         setMaxListeners(n: number): void;
         listeners(event: string): Function[];
-        emit(event: string, arg1?: any, arg2?: any): void;
+        emit(event: string, arg1?: any, arg2?: any): boolean;
     }
 
     export class EventEmitter implements NodeEventEmitter {
-        addListener(event: string, listener: Function): void;
-        on(event: string, listener: Function): any;
-        once(event: string, listener: Function): void;
-        removeListener(event: string, listener: Function): void;
-        removeAllListeners(event?: string): void;
+        addListener(event: string, listener: Function): EventEmitter;
+        on(event: string, listener: Function): EventEmitter;
+        once(event: string, listener: Function): EventEmitter;
+        removeListener(event: string, listener: Function): EventEmitter;
+        removeAllListeners(event?: string): EventEmitter;
         setMaxListeners(n: number): void;
         listeners(event: string): Function[];
-        emit(event: string, arg1?: any, arg2?: any): void;
+        emit(event: string, arg1?: any, arg2?: any): boolean;
     }
 }
 


### PR DESCRIPTION
- Allow for method chaining in addListener/removeListener, on/once,
  and removeAllListeners.
- Fix return type for 'emit'.

This patch mirrors the changes made to the API docs in this commit:
https://github.com/joyent/node/commit/41cbdc5e64d090e0708dd2a63d4cd63000019bb1
