### PR TITLE
Update Mocha with additional methods and members

### DIFF
--- a/mocha/mocha-tests.ts
+++ b/mocha/mocha-tests.ts
@@ -1,5 +1,7 @@
 /// <reference path="mocha.d.ts" />
 
+var mocha: Mocha;
+
 function test_describe() {
     describe('something', () => { });
 
@@ -49,4 +51,85 @@ function test_afterEach() {
     afterEach(() => { });
 
     afterEach((done) => { done(); });
+}
+
+function test_reporter_string(){
+    mocha.reporter('html');
+}
+
+function test_reporter_function(){
+    mocha.reporter(function(){});
+}
+
+function test_setup_slow_option(){
+    mocha.setup({slow: 25});
+}
+
+function test_setup_timeout_option(){
+    mocha.setup({timeout: 25});
+}
+
+function test_setup_globals_option(){
+    mocha.setup({globals: ['mocha']});
+}
+
+function test_setup_ui_option(){
+    mocha.setup({ui: 'bdd'});
+}
+
+function test_setup_reporter_string_option(){
+    mocha.setup({reporter: 'html'});
+}
+
+function test_setup_reporter_function_option(){
+    mocha.setup({reporter: function(){}});
+}
+
+function test_setup_bail_option(){
+    mocha.setup({bail: false});
+}
+
+function test_setup_ignore_leaks_option(){
+    mocha.setup({ignoreLeaks: false});
+}
+
+function test_setup_grep_string_option(){
+    mocha.setup({grep: "describe"});
+}
+
+function test_setup_grep_regex_option(){
+    mocha.setup({grep: new RegExp('describe')});
+}
+
+function test_setup_grep_regex_literal_option(){
+    mocha.setup({grep: /(expect|should)/i });
+}
+
+function test_setup_all_options(){
+    mocha.setup({
+        slow: 25,
+        timeout: 25,
+        ui: 'bdd',
+        globals: ['mocha'],
+        reporter: 'html',
+        bail: true,
+        ignoreLeaks: true,
+        grep: 'test'
+    });
+}
+
+function test_run(){
+    mocha.run(function(){})
+}
+
+function test_growl(){
+    mocha.growl();
+}
+
+function test_chaining(){
+    mocha
+        .setup({slow:25})
+        .growl()
+        .reporter('html')
+        .reporter(function(){});
 }

--- a/mocha/mocha.d.ts
+++ b/mocha/mocha.d.ts
@@ -46,6 +46,10 @@ interface MochaSetupOptions {
     grep?: any;
 }
 
+interface Done {
+    (error?: Error): void;
+}
+
 declare var describe : {
     (description: string, spec: () => void): void;
     only(description: string, spec: () => void): void;
@@ -55,27 +59,27 @@ declare var describe : {
 
 declare var it: {
     (expectation: string, assertion?: () => void): void;
-    (expectation: string, assertion?: (done: (error?: Error) => void) => void): void;
+    (expectation: string, assertion?: (done: Done) => void): void;
     only(expectation: string, assertion?: () => void): void;
-    only(expectation: string, assertion?: (done: (error?: Error) => void) => void): void;
+    only(expectation: string, assertion?: (done: Done) => void): void;
     skip(expectation: string, assertion?: () => void): void;
-    skip(expectation: string, assertion?: (done: (error?: Error) => void) => void): void;
+    skip(expectation: string, assertion?: (done: Done) => void): void;
     timeout(ms: number): void;
 };
 
 declare function before(action: () => void): void;
 
-declare function before(action: (done: (error?: Error) => void) => void): void;
+declare function before(action: (done: Done) => void): void;
 
 declare function after(action: () => void): void;
 
-declare function after(action: (done: (error?: Error) => void) => void): void;
+declare function after(action: (done: Done) => void): void;
 
 declare function beforeEach(action: () => void): void;
 
-declare function beforeEach(action: (done: (error?: Error) => void) => void): void;
+declare function beforeEach(action: (done: Done) => void): void;
 
 declare function afterEach(action: () => void): void;
 
-declare function afterEach(action: (done: (error?: Error) => void) => void): void;
+declare function afterEach(action: (done: Done) => void): void;
 

--- a/mocha/mocha.d.ts
+++ b/mocha/mocha.d.ts
@@ -4,14 +4,46 @@
 // DefinitelyTyped: https://github.com/borisyankov/DefinitelyTyped
 
 interface Mocha {
-    setup(options: MochaSetupOptions): void;
+    // Setup mocha with the given setting options.
+    setup(options: MochaSetupOptions): Mocha;
+
+    //Run tests and invoke `fn()` when complete.
     run(callback: () => void): void;
+
+    // Set reporter as function
+    reporter(reporter: () => void): Mocha;
+
+    // Set reporter, defaults to "dot"
+    reporter(reporter: string): Mocha;
+
+    // Enable growl support.
+    growl(): Mocha
 }
 
 interface MochaSetupOptions {
-    slow: number;
-    timeout: number;
-    ui: string;
+    //milliseconds to wait before considering a test slow
+    slow?: number;
+
+    // timeout in milliseconds
+    timeout?: number;
+
+    // ui name "bdd", "tdd", "exports" etc
+    ui?: string;
+
+    //array of accepted globals
+    globals?: Array;
+
+    // reporter instance (function or string), defaults to `mocha.reporters.Dot`
+    reporter?: any;
+
+    // bail on the first test failure
+    bail?: Boolean;
+
+    // ignore global leaks
+    ignoreLeaks?: Boolean;
+
+    // grep string or regexp to filter tests with
+    grep?: any;
 }
 
 declare var describe : {

--- a/mocha/mocha.d.ts
+++ b/mocha/mocha.d.ts
@@ -46,8 +46,10 @@ interface MochaSetupOptions {
     grep?: any;
 }
 
-interface Done {
-    (error?: Error): void;
+declare module mocha {
+    interface Done {
+        (error?: Error): void;
+    }
 }
 
 declare var describe : {
@@ -59,27 +61,27 @@ declare var describe : {
 
 declare var it: {
     (expectation: string, assertion?: () => void): void;
-    (expectation: string, assertion?: (done: Done) => void): void;
+    (expectation: string, assertion?: (done: mocha.Done) => void): void;
     only(expectation: string, assertion?: () => void): void;
-    only(expectation: string, assertion?: (done: Done) => void): void;
+    only(expectation: string, assertion?: (done: mocha.Done) => void): void;
     skip(expectation: string, assertion?: () => void): void;
-    skip(expectation: string, assertion?: (done: Done) => void): void;
+    skip(expectation: string, assertion?: (done: mocha.Done) => void): void;
     timeout(ms: number): void;
 };
 
 declare function before(action: () => void): void;
 
-declare function before(action: (done: Done) => void): void;
+declare function before(action: (done: mocha.Done) => void): void;
 
 declare function after(action: () => void): void;
 
-declare function after(action: (done: Done) => void): void;
+declare function after(action: (done: mocha.Done) => void): void;
 
 declare function beforeEach(action: () => void): void;
 
-declare function beforeEach(action: (done: Done) => void): void;
+declare function beforeEach(action: (done: mocha.Done) => void): void;
 
 declare function afterEach(action: () => void): void;
 
-declare function afterEach(action: (done: Done) => void): void;
+declare function afterEach(action: (done: mocha.Done) => void): void;
 


### PR DESCRIPTION
Update Mocha with additional methods and members
- Add Mocha methods (growl and reporter w/ overload)
- Change return type of Mocha.setup to be Mocha
- Add tests that were missing and to support new members.
- Add MochaSetupOptions to match Mocha's comments 
- Add comments to existing and new methods and members.
- Make MochaSetupOptions optional
