### PR TITLE
Add missing on() handler

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -616,6 +616,7 @@ interface JQuery {
 
     on(events: string, selector?: string, data?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
     on(events: string, selector?: string, handler?: (eventObject: JQueryEventObject) => any): JQuery;
+    on(events: string, handler?: (eventObject: JQueryEventObject) => any): JQuery;
     on(eventsMap: { [key: string]: any; }, selector?: any, data?: any): JQuery;
 
     one(events: string, selector?: any, data?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;


### PR DESCRIPTION
This was exposed by a recent update to jquery that tightened up the typing for on().

Documentation for on(): http://api.jquery.com/on/
