### PR TITLE
Fix future bug in slickgrid.d.ts

### DIFF
--- a/slickgrid/SlickGrid.d.ts
+++ b/slickgrid/SlickGrid.d.ts
@@ -87,7 +87,7 @@ declare module Slick {
 		* @method subscribe
 		* @param fn {Function} Event handler.
 		*/
-		public subscribe<T>(fn: (eventData: EventData, data: T) => any ): void;
+		public subscribe(fn: (eventData: EventData, data: T) => any ): void;
 
 		/***
 		* Removes an event handler added with <code>subscribe(fn)</code>.


### PR DESCRIPTION
Really subtle bug: the function should be using the class generic parameter - not a new one just for the method.
