### PR TITLE
Add definitions for Greasemonkey API

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ List of Definitions
 * [Giraffe](https://github.com/barc/backbone.giraffe) (by [Matt McCray](https://github.com/darthapo))
 * [glDatePicker](http://glad.github.com/glDatePicker/) (by [Dániel Tar](https://github.com/qcz))
 * [GoJS](http://gojs.net/) (by [Barbara Duckworth](https://github.com/barbara42))
+* [Greasemonkey](http://www.greasespot.net/) (by [Kota Saito](https://github.com/kotas))
 * [GreenSock Animation Platform (GSAP)](http://www.greensock.com/get-started-js/) (by [Robert S.](https://github.com/codeBelt))
 * [Grunt JS](http://gruntjs.com/) (by [Basarat Ali Syed](https://github.com/basarat))
 * [Google API Client](https://code.google.com/p/google-api-javascript-client/) (by [Frank M](https://github.com/sgtfrankieboy))

--- a/greasemonkey/greasemonkey-tests.ts
+++ b/greasemonkey/greasemonkey-tests.ts
@@ -1,0 +1,220 @@
+/// <reference path="greasemonkey.d.ts" />
+
+////////////////
+// Global variable
+////////////////
+
+var title: string = unsafeWindow.document.title;
+
+var scriptDescription: string = GM_info.script.description;
+var scriptExcludes: string[]  = GM_info.script.excludes;
+var scriptIncludes: string[]  = GM_info.script.includes;
+var scriptMatches: string[]   = GM_info.script.matches;
+var scriptName: string        = GM_info.script.name;
+var scriptNamespace: string   = GM_info.script.namespace;
+var scriptResouces: Object    = GM_info.script.resources;
+var scriptRunAt: string       = GM_info.script['run-at'];
+var scriptUnwrap: boolean     = GM_info.script.unwrap;
+var scriptVersion: string     = GM_info.script.version;
+var scriptMetsStr: string     = GM_info.scriptMetaStr;
+var scriptWillUpdate: boolean = GM_info.scriptWillUpdate;
+var gmVersion: string         = GM_info.version;
+
+////////////////
+// Values
+////////////////
+
+GM_setValue('a', 'foobar');
+GM_setValue('b', 123);
+GM_setValue('c', true);
+GM_setValue('d', null);
+// NG: GM_setValue('x', new Date());
+
+var a: string  = GM_getValue('a', 'foobar');
+var b: number  = GM_getValue('b', 123);
+var c: boolean = GM_getValue('c', true);
+var d: any     = GM_getValue('d', null);
+var e: string  = GM_getValue('e');
+var f: number  = GM_getValue('f');
+var g: boolean = GM_getValue('g');
+// NG: var x: string  = GM_getValue('x', 123);
+
+GM_deleteValue('d');
+
+GM_listValues().forEach((name: string) => {
+    console.log(name + ":", GM_getValue(name));
+});
+
+////////////////
+// Resources
+////////////////
+
+var prototypeSource: string = GM_getResourceText('prototype');
+var prototypeURL: string    = GM_getResourceURL('prototype');
+
+////////////////
+// Utilities
+////////////////
+
+GM_addStyle("body { color: white; background-color: black; } img { border: 0; }");
+
+GM_log("Hello, World!");
+
+GM_openInTab("http://www.example.com/");
+
+GM_registerMenuCommand("Hello, world (simple)", helloSimple);
+GM_registerMenuCommand("Hello, world!", hello, "h");
+// NG (Old Style): GM_registerMenuCommand("Hello, world! (again)", hello2, "e", "shift alt", "w");
+function helloSimple() {}
+function hello() {}
+
+GM_setClipboard('http://www.example.com/short-url-code');
+
+////////////////
+// XMLHttpRequest
+////////////////
+
+//// Examples from Greasemonkey Wiki
+
+// Bare Minimum
+
+GM_xmlhttpRequest({
+    method: "GET",
+    url: "http://www.example.com/",
+    onload: function(response) {
+        alert(response.responseText);
+    }
+});
+
+// GET request
+
+GM_xmlhttpRequest({
+    method: "GET",
+    url: "http://www.example.net/",
+    headers: {
+        "User-Agent": "Mozilla/5.0",    // If not specified, navigator.userAgent will be used.
+        "Accept": "text/xml"            // If not specified, browser defaults will be used.
+    },
+    onload: function(response) {
+        var responseXML = response.responseXML;
+        // Inject responseXML into existing Object (only appropriate for XML content).
+        if (!response.responseXML) {
+            responseXML = new DOMParser()
+                .parseFromString(response.responseText, "text/xml");
+        }
+
+        GM_log([
+            response.status,
+            response.statusText,
+            response.readyState,
+            response.responseHeaders,
+            response.responseText,
+            response.finalUrl,
+            responseXML
+        ].join("\n"));
+    }
+});
+
+// POST request
+
+GM_xmlhttpRequest({
+    method: "POST",
+    url: "http://www.example.net/login",
+    data: "username=johndoe&password=xyz123",
+    headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+    },
+    onload: function(response) {
+        if (response.responseText.indexOf("Logged in as") > -1) {
+            location.href = "http://www.example.net/dashboard";
+        }
+    }
+});
+
+// HEAD request
+
+GM_xmlhttpRequest({
+    url: "http://www.example.com",
+    method: "HEAD",
+    onload: function(response) {
+        GM_log(response.responseHeaders);
+    }
+});
+
+//// Checkk all options
+
+var result = GM_xmlhttpRequest({
+    binary: false,
+    context: {},
+    data: 'foo=1&bar=2',
+    headers: { 'User-Agent': 'greasemonkey' },
+    method: 'POST',
+    onabort: (response: GMXMLHttpRequestResponse) => { },
+    onerror: (response: GMXMLHttpRequestResponse) => { },
+    onload: (response: GMXMLHttpRequestResponse) => { },
+    onprogress: (response: GMXMLHttpRequestProgressResponse) => { },
+    onreadystatechange: (response: GMXMLHttpRequestResponse) => { },
+    ontimeout: (response: GMXMLHttpRequestResponse) => { },
+    overrideMimeType: 'text/plain',
+    password: 'abc123',
+    synchronous: false,
+    timeout: 10,
+    upload: {
+        onabort: (response: GMXMLHttpRequestResponse) => { },
+        onerror: (response: GMXMLHttpRequestResponse) => { },
+        onload: (response: GMXMLHttpRequestResponse) => { },
+        onprogress: (response: GMXMLHttpRequestProgressResponse) => { }
+    },
+    url: 'http://example.com/',
+    user: 'guest'
+});
+
+//// Check responses
+
+GM_xmlhttpRequest({
+    method: 'GET',
+    url: 'http://example.com/',
+    onload: (response: GMXMLHttpRequestResponse) => {
+        var readyState: number      = response.readyState;
+        var responseHeaders: string = response.responseHeaders;
+        var responseText: string    = response.responseText;
+        var status: number          = response.status;
+        var statusText: string      = response.statusText;
+        var context: any            = response.context;
+        var finalUrl: string        = response.finalUrl;
+        // NG: var loaded: number   = response.loaded;
+    },
+    onprogress: (response: GMXMLHttpRequestProgressResponse) => {
+        var status: number = response.status;
+        var lengthComputable: boolean = response.lengthComputable;
+        var loaded: number = response.loaded;
+        var total: number = response.total;
+    }
+});
+
+//// Synchronous
+
+var syncResult: GMXMLHttpRequestSyncResult = GM_xmlhttpRequest({
+    method: 'GET',
+    url: 'http://example.com/',
+    synchronous: true
+});
+
+syncResult.abort();
+var finalUrl: string        = syncResult.finalUrl;
+var readyState: number      = syncResult.readyState;
+var responseHeaders: string = syncResult.responseHeaders;
+var responseText: string    = syncResult.responseText;
+var status: number          = syncResult.status;
+var statusText: string      = syncResult.statusText;
+
+//// Asynchronous
+
+var asyncResult: GMXMLHttpRequestAsyncResult = GM_xmlhttpRequest({
+    method: 'GET',
+    url: 'http://example.com/',
+    synchronous: false
+});
+
+asyncResult.abort();
+// NG: var status: number = asyncResult.status;

--- a/greasemonkey/greasemonkey.d.ts
+++ b/greasemonkey/greasemonkey.d.ts
@@ -1,0 +1,235 @@
+// Type definitions for Greasemonkey
+// Project: http://www.greasespot.net/
+// Definitions by: Kota Saito <https://github.com/kotas>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+// This definition is based on the API reference of Greasemonkey.
+// http://wiki.greasespot.net/Greasemonkey_Manual:API
+
+////////////////
+// Global variable
+////////////////
+
+/**
+ * Window object of the content page where the user script is running on.
+ * @see {@link http://wiki.greasespot.net/UnsafeWindow}
+ */
+declare var unsafeWindow: Window;
+
+/**
+ * Meta data about the running user script.
+ * @see {@link http://wiki.greasespot.net/GM_info}
+ */
+declare var GM_info: {
+    script: {
+        description: string;
+        excludes: string[];
+        includes: string[];
+        matches: string[];
+        name: string;
+        namespace: string;
+        resources: Object;
+        "run-at": string;
+        unwrap: boolean;
+        version: string;
+    };
+    scriptMetaStr: string;
+    scriptWillUpdate: boolean;
+    version: string;
+};
+
+////////////////
+// Values
+////////////////
+
+/**
+ * Deletes an existing name / value pair from the script storage.
+ * @param  name  a name of the pair to delete.
+ * @see    {@link http://wiki.greasespot.net/GM_deleteValue}
+ */
+declare function GM_deleteValue(name: string): void;
+
+/**
+ * Retrieves a value from the script storage.
+ * @param    name          a name to retrieve.
+ * @param    defaultValue  a value to be returned when the name does not exist.
+ * @returns  a retrieved value, or passed default value, or undefined.
+ * @see      {@link http://wiki.greasespot.net/GM_getValue}
+ */
+declare function GM_getValue(name: string, defaultValue?: any): any;
+declare function GM_getValue(name: string, defaultValue?: string): string;
+declare function GM_getValue(name: string, defaultValue?: number): number;
+declare function GM_getValue(name: string, defaultValue?: boolean): boolean;
+
+/**
+ * Retrieves an array of names stored in the script storage.
+ * @returns  an array of names in the storage.
+ * @see      {@link http://wiki.greasespot.net/GM_listValues}
+ */
+declare function GM_listValues(): string[];
+
+/**
+ * Stores a name / value pair to the script storage.
+ * @param  name   a name of the pair.
+ * @param  value  a value to be stored.
+ * @see    {@link http://wiki.greasespot.net/GM_setValue}
+ */
+declare function GM_setValue(name: string, value: string): void;
+declare function GM_setValue(name: string, value: boolean): void;
+declare function GM_setValue(name: string, value: number): void;
+
+////////////////
+// Resources
+////////////////
+
+/**
+ * Gets a content of a resouce defined by {@link http://wiki.greasespot.net/Metadata_Block#.40resource|@resource}.
+ * @param    resourceName  a name of the resource to get.
+ * @returns  the content of the resource.
+ * @see      {@link http://wiki.greasespot.net/GM_getResourceText}
+ */
+declare function GM_getResourceText(resourceName: string): string;
+
+/**
+ * Gets a URL of a resource defined by {@link http://wiki.greasespot.net/Metadata_Block#.40resource|@resource}.
+ * @param    resourceName  a name of the resource.
+ * @returns  a URL that returns the content of the resource.
+ * @see      {@link http://wiki.greasespot.net/GM_getResourceURL}
+ */
+declare function GM_getResourceURL(resourceName: string): string;
+
+////////////////
+// Utilities
+////////////////
+
+/**
+ * Adds CSS to the content page.
+ * @param  css  a CSS string. It can have multiple style definitions.
+ * @see    {@link http://wiki.greasespot.net/GM_addStyle}
+ */
+declare function GM_addStyle(css: string): void;
+
+/**
+ * Writes a message as a log to the console with the script identifier.
+ * @param  message  a message to be written.
+ * @see    {@link http://wiki.greasespot.net/GM_log}
+ */
+declare function GM_log(message: any): void;
+
+/**
+ * Opens a URL in a new tab.
+ * @param    url  a URL to open.
+ * @returns  window object of the opened tab.
+ * @see      {@link http://wiki.greasespot.net/GM_openInTab}
+ */
+declare function GM_openInTab(url: string): Window;
+
+/**
+ * Registers an item as a submenu of User Script Commands.
+ * @param  caption      a caption of the menu item.
+ * @param  commandFunc  a function to be invoked when the item has been selected.
+ * @param  accessKey    a single character that can be used to select the item by keyboard.
+ *                      It should be a letter in the caption.
+ * @see    {@link http://wiki.greasespot.net/GM_registerMenuCommand}
+ */
+declare function GM_registerMenuCommand(caption: string, commandFunc: Function, accessKey?: string): void;
+
+/**
+ * Sets a text to the clipboard of the opeating system.
+ * @param  text  a text to be set to the clipboard.
+ * @see    {@link http://wiki.greasespot.net/GM_setClipboard}
+ */
+declare function GM_setClipboard(text: string): void;
+
+////////////////
+// XMLHttpRequest
+////////////////
+
+/**
+ * Request options for {@link GM_xmlhttpRequest}.
+ * @see {@link http://wiki.greasespot.net/GM_xmlhttpRequest#Arguments}
+ */
+interface GMXMLHttpRequestOptions {
+    binary?: boolean;
+    context?: any;
+    data?: string;
+    headers?: Object;
+    method: string;
+    onabort?: (response: GMXMLHttpRequestResponse) => any;
+    onerror?: (response: GMXMLHttpRequestResponse) => any;
+    onload?: (response: GMXMLHttpRequestResponse) => any;
+    onprogress?: (response: GMXMLHttpRequestProgressResponse) => any;
+    onreadystatechange?: (response: GMXMLHttpRequestResponse) => any;
+    ontimeout?: (response: GMXMLHttpRequestResponse) => any;
+    overrideMimeType?: string;
+    password?: string;
+    synchronous?: boolean;
+    timeout?: number;
+    upload?: {
+        onabort?: (response: GMXMLHttpRequestResponse) => any;
+        onerror?: (response: GMXMLHttpRequestResponse) => any;
+        onload?: (response: GMXMLHttpRequestResponse) => any;
+        onprogress?: (response: GMXMLHttpRequestProgressResponse) => any;
+    };
+    url: string;
+    user?: string;
+}
+
+/**
+ * Response object for general events of {@link GM_xmlhttpRequest}.
+ * @see {@link http://wiki.greasespot.net/GM_xmlhttpRequest#Response_Object}
+ */
+interface GMXMLHttpRequestResponse {
+    readyState: number;
+    responseHeaders: string;
+    responseText: string;
+    status: number;
+    statusText: string;
+    context: any;
+    finalUrl: string;
+}
+
+/**
+ * Response object for onprogress event of {@link GM_xmlhttpRequest}.
+ */
+interface GMXMLHttpRequestProgressResponse extends GMXMLHttpRequestResponse {
+    lengthComputable: boolean;
+    loaded: number;
+    total: number;
+}
+
+/**
+ * Returned object by {@link GM_xmlhttpRequest} in asynchronous mode.
+ */
+interface GMXMLHttpRequestAsyncResult {
+    abort(): void;
+}
+
+/**
+ * Returned object by {@link GM_xmlhttpRequest} in synchronouse mode.
+ */
+interface GMXMLHttpRequestSyncResult {
+    abort(): void;
+    finalUrl: string;
+    readyState: number;
+    responseHeaders: string;
+    responseText: string;
+    status: number;
+    statusText: string;
+}
+
+/**
+ * Returned object by {@link GM_xmlhttpRequest}.
+ * @see  {@link http://wiki.greasespot.net/GM_xmlhttpRequest#Returns}
+ */
+interface GMXMLHttpRequestResult extends GMXMLHttpRequestAsyncResult, GMXMLHttpRequestSyncResult {
+}
+
+/**
+ * Sends a HTTP request to a URL.
+ * @param    options  options and callbacks for HTTP request.
+ * @returns  an object which can abort the request.
+ *           If the request is sent in the synchronous mode, it also contains the response information.
+ * @see      {@link http://wiki.greasespot.net/GM_setClipboard}
+ */
+declare function GM_xmlhttpRequest(options: GMXMLHttpRequestOptions): GMXMLHttpRequestResult;


### PR DESCRIPTION
This pull request adds `greasemonkey/greasemonkey.d.ts` which defines global functions and global variables provided to user scripts running on Greasemonkey.

Greasemonkey API document is here: http://wiki.greasespot.net/Greasemonkey_Manual:API

Because Greasemonkey became popular first, this kind of extensions such as Tampermonkey for Google Chrome or Ninjakit for Safari, they all have compatible API as Greasemonkey.
