### PR TITLE
Fixed inheritance and function definitions in Kockout

### DIFF
--- a/knockout.deferred.updates/knockout.deferred.updates.d.ts
+++ b/knockout.deferred.updates/knockout.deferred.updates.d.ts
@@ -30,7 +30,7 @@ interface KnockoutComputedStatic {
     deferUpdates: boolean;
 }
 
-interface KnockoutComputedFunctions {
+interface KnockoutSubscription {
     deferUpdates: boolean;
 }
 

--- a/knockout.validation/knockout.validation.d.ts
+++ b/knockout.validation/knockout.validation.d.ts
@@ -117,10 +117,10 @@ interface KnockoutValidationStatic {
 
     addRule<T>(observable: KnockoutObservable<T>, rule: KnockoutValidationRule): KnockoutObservable<T>;
 
-    addAnonymousRule(observable: KnockoutObservableBase, ruleObj: KnockoutValidationAnonymousRuleDefinition): void;
+    addAnonymousRule(observable: KnockoutObservable<any>, ruleObj: KnockoutValidationAnonymousRuleDefinition): void;
 
     insertValidationMessage(element: Element): Element;
-    parseInputValidationAttributes(element: Element, valueAccessor: () => KnockoutObservableBase): void;
+    parseInputValidationAttributes(element: Element, valueAccessor: () => KnockoutObservable<any>): void;
 
     rules: KnockoutValidationRuleDefinitions;
 
@@ -129,12 +129,12 @@ interface KnockoutValidationStatic {
     utils: KnockoutValidationUtils;
 
     localize(msgTranslations: any): void;
-    validateObservable(observable: KnockoutObservableBase): boolean;
+    validateObservable(observable: KnockoutObservable<any>): boolean;
 }
 
 interface KnockoutStatic {
     validation: KnockoutValidationStatic;
-    validatedObservable(initialValue: any): KnockoutObservableBase;
+    validatedObservable(initialValue: any): KnockoutObservable<any>;
     applyBindingsWithValidation(viewModel: any, rootNode?: any, options?: KnockoutValidationConfiguration): void;
 }
 

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -4,25 +4,18 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 
-interface KnockoutSubscribableFunctions {
-    extend(source);
-    dispose(): void;
-    peek(): any;
-    valueHasMutated(): void;
-
-    valueWillMutate(): void;
+interface KnockoutSubscribableFunctions<T> {
+	notifySubscribers(valueToWrite: T, event?: string);
 }
 
-interface KnockoutComputedFunctions extends KnockoutSubscribableFunctions {
-    getDependenciesCount(): number;
-    getSubscriptionsCount(): number;
-    hasWriteFunction(): boolean;
+interface KnockoutComputedFunctions<T> {
 }
 
-interface KnockoutObservableFunctions extends KnockoutSubscribableFunctions {
+interface KnockoutObservableFunctions<T> {
+	equalityComparer(a: any, b: any): boolean;
 }
 
-interface KnockoutObservableArrayFunctions<T> extends KnockoutObservableFunctions {
+interface KnockoutObservableArrayFunctions<T> {
     // General Array functions
     indexOf(searchElement: T, fromIndex?: number): number;
     slice(start: number, end?: number): T[];
@@ -49,18 +42,26 @@ interface KnockoutObservableArrayFunctions<T> extends KnockoutObservableFunction
 }
 
 interface KnockoutSubscribableStatic {
-    fn: KnockoutSubscribableFunctions;
+    fn: KnockoutSubscribableFunctions<any>;
 
-    new (): KnockoutSubscription;
+    new <T>(): KnockoutSubscribable<T>;
 }
 
-interface KnockoutSubscription extends KnockoutSubscribableFunctions {
-    subscribe(callback: (newValue: any) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite, topic?: string);
+interface KnockoutSubscription {
+	dispose(): void;
+}
+
+interface KnockoutSubscribable<T> extends KnockoutSubscribableFunctions<T> {
+	(): T;
+	(value: T): void;
+
+	subscribe(callback: (newValue: T) => void, target?: any, event?: string): KnockoutSubscription;
+	extend(requestedExtenders: { [key: string]: any; }): KnockoutSubscribable<T>;
+	getSubscriptionsCount(): number;
 }
 
 interface KnockoutComputedStatic {
-    fn: KnockoutComputedFunctions;
+    fn: KnockoutComputedFunctions<any>;
 
     <T>(): KnockoutComputed<T>;
     <T>(func: () => T, context?: any, options?: any): KnockoutComputed<T>;
@@ -68,51 +69,41 @@ interface KnockoutComputedStatic {
     (options?: any): KnockoutComputed<any>;
 }
 
-interface KnockoutComputed<T> extends KnockoutComputedFunctions {
-    (): T;
-    (value: T): void;
-
-    subscribe(callback: (newValue: T) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite: T, topic?: string);
+interface KnockoutComputed<T> extends KnockoutSubscribable<T>, KnockoutComputedFunctions<T> {
+	peek(): T;
+	dispose(): void;
+	isActive(): boolean;
+	getDependenciesCount(): number;
 }
 
 interface KnockoutObservableArrayStatic {
-
     fn: KnockoutObservableArrayFunctions<any>;
 
     <T>(value?: T[]): KnockoutObservableArray<T>;
 }
 
-interface KnockoutObservableArray<T> extends KnockoutObservableArrayFunctions<T> {
-    (): T[];
-    (value: T[]): void;
-
-    subscribe(callback: (newValue: T[]) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite: T[], topic?: string);
+interface KnockoutObservableArray<T> extends KnockoutObservable<T[]>, KnockoutObservableArrayFunctions<T> {
 }
 
 interface KnockoutObservableStatic {
-    fn: KnockoutObservableFunctions;
+    fn: KnockoutObservableFunctions<any>;
 
     <T>(value?: T): KnockoutObservable<T>;
 }
 
-/** use as method to get/set the value */
-interface KnockoutObservableBase extends KnockoutObservableFunctions {
-    getSubscriptionsCount(): number;
-}
-
-interface KnockoutObservable<T> extends KnockoutObservableBase {
-    (): T;
-    (value: T): void;
-
-    subscribe(callback: (newValue: T) => void, target?:any, topic?: string): KnockoutSubscription;
-    notifySubscribers(valueToWrite: T, topic?: string);
+interface KnockoutObservable<T> extends KnockoutSubscribable<T>, KnockoutObservableFunctions<T> {
+	peek(): T;
+	valueHasMutated(): void;
+	valueWillMutate(): void;
 }
 
 interface KnockoutComputedDefine<T> {
-    read(): T;
-    write(T);
+	read(): T;
+	write? (value: T): void;
+	disposeWhenNodeIsRemoved?: Node;
+	disposeWhen? (): boolean;
+	owner?: any;
+	deferEvaluation?: boolean;
 }
 
 interface KnockoutBindingContext {


### PR DESCRIPTION
- fixed inheritance
- fixed fn definitions
- *Functions interfaces made generic to allow generic extensions
- added more options in KnockoutComputedDefintion

More info:
*Functions interfaces shouldn't inherit, they should only define functions for exact class
Some functions defined in fn, but not exported. This means it can't be accessable from fn via minification, only from object instance. So, I moved it from fn.
Something wrong was in Subscription. Subscription only allow to dispose.
