### PR TITLE
Add missing on() handler

### DIFF
--- a/bootstrap.datepicker/bootstrap.datepicker.d.ts
+++ b/bootstrap.datepicker/bootstrap.datepicker.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for bootstrap.datepicker
+// Type definitions for bootstrap.datepicker
 // Project: https://github.com/eternicode/bootstrap-datepicker
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -24,4 +24,10 @@ interface JQuery {
     datepicker(methodName: string): JQuery;
     datepicker(methodName: string, params: any): JQuery;
     datepicker(options: DatepickerOptions): JQuery;
+
+    off(events?: "changeDate", selector?: any, handler?: (eventObject: any) => any): JQuery;
+
+    on(events: "changeDate", selector?: string, data?: any, handler?: (eventObject: any) => any): JQuery;
+    on(events: "changeDate", selector?: string, handler?: (eventObject: any) => any): JQuery;
+    on(events: "changeDate", handler?: (eventObject: any) => any): JQuery;
 }

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -616,6 +616,7 @@ interface JQuery {
 
     on(events: string, selector?: string, data?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
     on(events: string, selector?: string, handler?: (eventObject: JQueryEventObject) => any): JQuery;
+    on(events: string, handler?: (eventObject: JQueryEventObject) => any): JQuery;
     on(eventsMap: { [key: string]: any; }, selector?: any, data?: any): JQuery;
 
     one(events: string, selector?: any, data?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;

--- a/select2/select2.d.ts
+++ b/select2/select2.d.ts
@@ -71,7 +71,19 @@ interface Select2Options {
     escapeMarkup?: (markup: string) => string;
 }
 
+interface Select2JQueryEventObject extends JQueryEventObject {
+    val: any;
+    added: any;
+    removed: any;
+}
+
 interface JQuery {
+    off(events?: "change", selector?: any, handler?: (eventObject: Select2JQueryEventObject) => any): JQuery;
+
+    on(events: "change", selector?: string, data?: any, handler?: (eventObject: Select2JQueryEventObject) => any): JQuery;
+    on(events: "change", selector?: string, handler?: (eventObject: Select2JQueryEventObject) => any): JQuery;
+    on(events: "change", handler?: (eventObject: Select2JQueryEventObject) => any): JQuery;
+
     select2(): JQuery;
     select2(it: IdTextPair): JQuery;
     select2(options: Select2Options): JQuery;


### PR DESCRIPTION
This was was exposed by a recent update to jquery that tightened up the
typing for on().

Documentation for on(): http://api.jquery.com/on/

I'm not a user of select2 or bootstrap.datepicker so I relied upon their documentation to figure out how to fix their definitions.  They both use enhanced jquery event objects but didn't account for that in their definitions so when the new on() handler was added it actually flushed out the missing definitions.
