### PR TITLE
Prototype for createSpyObj to allow for typed spies

### DIFF
--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -32,6 +32,7 @@ declare module jasmine {
     function objectContaining(sample: any): ObjectContaining;
     function createSpy(name: string, originalFn?: Function): Spy;
     function createSpyObj(baseName: string, methodNames: any[]): any;
+    function createSpyObj<T>(baseName: string, methodNames: any[]): T;
     function pp(value: any): string;
     function getEnv(): Env;
 


### PR DESCRIPTION
Added an overload to the prototype for createSpyObj to allow it to return a strongly typed spy object via use of generics
