### PR TITLE
select2: set option parameter in matcher to any (small fix)

### DIFF
--- a/select2/select2.d.ts
+++ b/select2/select2.d.ts
@@ -47,7 +47,7 @@ interface Select2Options {
     closeOnSelect?: boolean;
     openOnEnter?: boolean;
     id?: (object: any) => string;
-    matcher?: (term: string, text: string, option: JQuery) => boolean;
+    matcher?: (term: string, text: string, option: any) => boolean;
     formatSelection?: (object: any, container: JQuery) => string;
     formatResult?: (object: any, container: JQuery, query: any) => string;
     formatResultCssClass?: (object: any) => string;


### PR DESCRIPTION
When providing the select2 elements through the `data` field the `option` parameter in matcher will be the object provided, not a JQuery object.
