### PR TITLE
Knockout.es5, Added Array methods + minor refactor

### DIFF
--- a/knockout.es5/knockout.es5-tests.ts
+++ b/knockout.es5/knockout.es5-tests.ts
@@ -73,6 +73,10 @@ anOrder.lines.push(someOrderLine);
 anOrder.lines.push(someOrderLine);
 anOrder.lines.shift();
 
+console.log(someOrderLine.subtotal == someOrderLine.getSubtotal());     // true
+console.log(anOrder.lines.length);                                      // 1
+
+//Array methods
 anOrder.lines.remove(someOrderLine);
 anOrder.lines.removeAll([someOrderLine]);
 anOrder.lines.removeAll();
@@ -80,6 +84,3 @@ anOrder.lines.removeAll();
 anOrder.lines.destroy(someOrderLine);
 anOrder.lines.destroyAll([someOrderLine]);
 anOrder.lines.destroyAll();
-
-console.log(someOrderLine.subtotal == someOrderLine.getSubtotal());     // true
-console.log(anOrder.lines.length);                                      // 1

--- a/knockout.es5/knockout.es5-tests.ts
+++ b/knockout.es5/knockout.es5-tests.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="knockout.es5.d.ts" />
+/// <reference path="knockout.es5.d.ts" />
 
 var empty = {},
     obj = { a: 'string', b: 123, c: true, d: empty },
@@ -72,6 +72,14 @@ someOrderLine.quantity += 1;
 anOrder.lines.push(someOrderLine);
 anOrder.lines.push(someOrderLine);
 anOrder.lines.shift();
+
+anOrder.lines.remove(someOrderLine);
+anOrder.lines.removeAll([someOrderLine]);
+anOrder.lines.removeAll();
+
+anOrder.lines.destroy(someOrderLine);
+anOrder.lines.destroyAll([someOrderLine]);
+anOrder.lines.destroyAll();
 
 console.log(someOrderLine.subtotal == someOrderLine.getSubtotal());     // true
 console.log(anOrder.lines.length);                                      // 1

--- a/knockout.es5/knockout.es5.d.ts
+++ b/knockout.es5/knockout.es5.d.ts
@@ -8,7 +8,22 @@
 interface KnockoutStatic {
     track(obj: any, propertyNames?: Array<string>): any;
     defineProperty(obj: any, propertyName: string, evaluator: Function): any;
-    defineProperty(obj: any, propertyName: string, options: { get: () => any; set?: (value: any) => void; }): any;
+    defineProperty(obj: any, propertyName: string, options: KnockoutDefinePropertyOptions): any;
     getObservable(obj: any, propertyName: string): KnockoutObservable<any>;
     valueHasMutated(obj: any, propertyName: string): void;
+}
+
+interface KnockoutDefinePropertyOptions {
+	get(): any;
+	set?(value: any): void;
+}
+
+interface Array<T> {
+	remove(item): T[];
+	removeAll(items: T[]): T[];
+	removeAll(): T[];
+
+	destroy(item: T): void;
+	destroyAll(items: T[]): void;
+	destroyAll(): void;
 }


### PR DESCRIPTION
The knockout ES5 plugin augments the Array prototype to add remove, removeAll, destroy and destroyAll methods.  I've added definitions for these.  I also extracted the defineProperty method's options parameter type into its own interface.
