### PR TITLE
Extend method returns same interface

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -74,6 +74,7 @@ interface KnockoutComputed<T> extends KnockoutSubscribable<T>, KnockoutComputedF
 	dispose(): void;
 	isActive(): boolean;
 	getDependenciesCount(): number;
+	extend(requestedExtenders: { [key: string]: any; }): KnockoutComputed<T>;
 }
 
 interface KnockoutObservableArrayStatic {
@@ -83,6 +84,7 @@ interface KnockoutObservableArrayStatic {
 }
 
 interface KnockoutObservableArray<T> extends KnockoutObservable<T[]>, KnockoutObservableArrayFunctions<T> {
+	extend(requestedExtenders: { [key: string]: any; }): KnockoutObservableArray<T>;
 }
 
 interface KnockoutObservableStatic {
@@ -95,6 +97,7 @@ interface KnockoutObservable<T> extends KnockoutSubscribable<T>, KnockoutObserva
 	peek(): T;
 	valueHasMutated(): void;
 	valueWillMutate(): void;
+	extend(requestedExtenders: { [key: string]: any; }): KnockoutObservable<T>;
 }
 
 interface KnockoutComputedDefine<T> {


### PR DESCRIPTION
This fixes an issue I reported on Thursday
