### PR TITLE
Knockout:Removed non-generic overloads from utils / Globalize: reduced implicit anys

### DIFF
--- a/globalize/globalize-tests.ts
+++ b/globalize/globalize-tests.ts
@@ -22,10 +22,14 @@ Globalize.addCultureInfo("fr", { messages: { "translate": "traduire" } });
 console.log(Globalize.localize("translate", "fr"));
 
 Globalize.parseInt("1,234.56"); 
-Globalize.parseInt("1.234,56");
+Globalize.parseInt("1.234,56", 10);
+Globalize.parseInt("1.234,56", 10, "de");
 Globalize.parseFloat("1,234.56"); 
-Globalize.parseFloat("1.234,56");
+Globalize.parseFloat("1.234,56", 10);
+Globalize.parseFloat("1.234,56", 10, "de");
 Globalize.parseDate("1/2/2003");
+Globalize.parseDate("15 Jun 2012", "dd MMM yyyy");
+Globalize.parseDate("15 Jun 2012", ["dd MMM yyyy"]);
 Globalize.culture("fr");
 Globalize.parseDate("1/2/2003"); 
 

--- a/globalize/globalize.d.ts
+++ b/globalize/globalize.d.ts
@@ -107,14 +107,16 @@ interface GlobalizeStatic {
     culture(cultureSelector: string): GlobalizeCulture;
     culture(cultureSelector: string[]): GlobalizeCulture;
 
-    addCultureInfo(cultureName, baseCultureName, info? );
+    addCultureInfo(cultureName: string, baseCultureName, info?);
     findClosestCulture(cultureSelector: string);
-    format(value, format, cultureSelector? );
-    localize(key, cultureSelector?);
+    format(value: number, format: string, cultureSelector?: string);
+    format(value: Date, format: string, cultureSelector?: string);
+    localize(key: string, cultureSelector?: string);
 
-    parseDate(value: string, formats? , cultureSelector?: string): Date;
-    parseInt(value: string, radix? , cultureSelector?: string): number;
-    parseFloat(value: string, radix? , cultureSelector?: string): number;
+    parseDate(value: string, format?: string, cultureSelector?: string): Date;
+    parseDate(value: string, formats?: string[], cultureSelector?: string): Date;
+    parseInt(value: string, radix?: number, cultureSelector?: string): number;
+    parseFloat(value: string, radix?: number, cultureSelector?: string): number;
 }
 
 declare var Globalize: GlobalizeStatic;

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -235,35 +235,21 @@ interface KnockoutUtils {
 
     arrayForEach<T>(array: T[], action: (item: T) => void): void;
 
-    arrayForEach(array: any[], action: (any) => void ): void;
-
     arrayIndexOf(array: any[], item: any): number;
 
     arrayFirst<T>(array: T[], predicate: (item: T) => boolean, predicateOwner?: any): T;
-
-    arrayFirst(array: any[], predicate: (item) => boolean, predicateOwner?: any): any;
 
     arrayRemoveItem(array: any[], itemToRemove: any): void;
 
     arrayGetDistinctValues<T>(array: T[]): T[];
 
-    arrayGetDistinctValues(array: any[]): any[];
-
     arrayMap<T, U>(array: T[], mapping: (item: T) => U): U[];
-
-    arrayMap(array: any[], mapping: (item) => any): any[];
 
     arrayFilter<T>(array: T[], predicate: (item: T) => boolean): T[];
 
-    arrayFilter(array: any[], predicate: (item) => boolean): any[];
-
     arrayPushAll<T>(array: T[], valuesToPush: T[]): T[];
 
-    arrayPushAll(array: any[], valuesToPush: any[]): any[];
-
     arrayPushAll<T>(array: KnockoutObservableArray<T>, valuesToPush: T[]): T[];
-
-    arrayPushAll(array: KnockoutObservableArray<any>, valuesToPush: any[]): any[];
 
     extend(target, source);
 


### PR DESCRIPTION
As far as I can tell these overloads no longer fulfil a purpose (I imagine they were created back before TypeScript got generics) and aren't needed for backward compatibility.  

As an aside they appear to currently confuse the TypeScript compiler as well (see https://typescript.codeplex.com/workitem/1865 )

Globalize typings now have reduced implicit any's. Where appropriate (`format` and `parseDate` I've added separate overloads with distinct types)
