### PR TITLE
Add windowId property to removeInfo object

### DIFF
--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -1718,6 +1718,7 @@ declare module chrome.tabs {
     }
 
     interface TabRemoveInfo {
+        windowId: number;
         isWindowClosing: boolean;
     }
 


### PR DESCRIPTION
The removeInfo object passed to listeners for chrome.tabs.onRemove should have a "windowId" property. ([chrome.tabs API](http://developer.chrome.com/extensions/tabs.html#event-onRemoved-addListener))
