### PR TITLE
Knockout:Dealt with implicit any in knockout.d.ts and knockout.amd.ts

### DIFF
--- a/knockout/knockout.amd.d.ts
+++ b/knockout/knockout.amd.d.ts
@@ -24,10 +24,10 @@ declare module 'knockout' {
     export function isObservable(instance: any): boolean;
     export function isComputed(instance: any): boolean;
     export function dataFor(node: any): any;
-    export function removeNode(node: Element);
-    export function cleanNode(node: Element);
-    export function renderTemplate(template: Function, viewModel: any, options?: any, target?: any, renderMode?: any);
-    export function renderTemplate(template: string, viewModel: any, options?: any, target?: any, renderMode?: any);
+    export function removeNode(node: Element): void;
+    export function cleanNode(node: Element): Element;
+    export function renderTemplate(template: Function, viewModel: any, options?: any, target?: any, renderMode?: any): any;
+    export function renderTemplate(template: string, viewModel: any, options?: any, target?: any, renderMode?: any): any;
 
     //////////////////////////////////
     //// templateSources.js
@@ -44,9 +44,10 @@ declare module 'knockout' {
     //// templateRewriting.js
     ////////////////////////////////////
     export var templateRewriting: {
-        ensureTemplateIsRewritten(template, templateEngine, templateDocument);
-        memoizeBindingAttributeSyntax(htmlString: string, templateEngine: KnockoutTemplateEngine);
-        applyMemoizedBindingsToNextSibling(bindings);
+        ensureTemplateIsRewritten(template: Node, templateEngine: KnockoutTemplateEngine, templateDocument: Document): any;
+        ensureTemplateIsRewritten(template: string, templateEngine: KnockoutTemplateEngine, templateDocument: Document): any;
+        memoizeBindingAttributeSyntax(htmlString: string, templateEngine: KnockoutTemplateEngine): any;
+        applyMemoizedBindingsToNextSibling(bindings: any, nodeName: string): string;
     };
     ////////////////////////////////////
     //// nativeTemplateEngine.js
@@ -61,16 +62,25 @@ declare module 'knockout' {
     ////////////////////////////////////
     export var jqueryTmplTemplateEngine: {
         prototype: KnockoutTemplateEngine;
-        renderTemplateSource(templateSource, bindingContext, options);
+        renderTemplateSource(templateSource: Object, bindingContext: KnockoutBindingContext, options: Object): Node[];
         createJavaScriptEvaluatorBlock(script: string): string;
-        addTemplate(templateName, templateMarkup);
+        addTemplate(templateName: string, templateMarkup: string): void;
     };
     ////////////////////////////////////
     //// templating.js
     ////////////////////////////////////
-    export function setTemplateEngine(templateEngine: KnockoutNativeTemplateEngine);
-    export function renderTemplate(template, dataOrBindingContext, options, targetNodeOrNodeArray, renderMode);
-    export function renderTemplateForEach(template, arrayOrObservableArray, options, targetNode, parentBindingContext);
+    export function renderTemplate(template: Function, dataOrBindingContext: KnockoutBindingContext, options: Object, targetNodeOrNodeArray: Node, renderMode: string): any;
+    export function renderTemplate(template: any, dataOrBindingContext: KnockoutBindingContext, options: Object, targetNodeOrNodeArray: Node, renderMode: string): any;
+    export function renderTemplate(template: Function, dataOrBindingContext: any, options: Object, targetNodeOrNodeArray: Node, renderMode: string): any;
+    export function renderTemplate(template: any, dataOrBindingContext: any, options: Object, targetNodeOrNodeArray: Node, renderMode: string): any;
+    export function renderTemplate(template: Function, dataOrBindingContext: KnockoutBindingContext, options: Object, targetNodeOrNodeArray: Node[], renderMode: string): any;
+    export function renderTemplate(template: any, dataOrBindingContext: KnockoutBindingContext, options: Object, targetNodeOrNodeArray: Node[], renderMode: string): any;
+    export function renderTemplate(template: Function, dataOrBindingContext: any, options: Object, targetNodeOrNodeArray: Node[], renderMode: string): any;
+    export function renderTemplate(template: any, dataOrBindingContext: any, options: Object, targetNodeOrNodeArray: Node[], renderMode: string): any;
+    export function renderTemplateForEach(template: Function, arrayOrObservableArray: Array, options: Object, targetNode: Node, parentBindingContext: KnockoutBindingContext): any;
+    export function renderTemplateForEach(template: any, arrayOrObservableArray: Array, options: Object, targetNode: Node, parentBindingContext: KnockoutBindingContext): any;
+    export function renderTemplateForEach(template: Function, arrayOrObservableArray: KnockoutObservable<Array>, options: Object, targetNode: Node, parentBindingContext: KnockoutBindingContext): any;
+    export function renderTemplateForEach(template: any, arrayOrObservableArray: KnockoutObservable < Array>, options: Object, targetNode: Node, parentBindingContext: KnockoutBindingContext): any;
     export var expressionRewriting: {
         bindingRewriteValidators: any;
     };

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -5,7 +5,7 @@
 
 
 interface KnockoutSubscribableFunctions<T> {
-	notifySubscribers(valueToWrite: T, event?: string);
+	notifySubscribers(valueToWrite: T, event?: string): void;
 }
 
 interface KnockoutComputedFunctions<T> {
@@ -27,12 +27,13 @@ interface KnockoutObservableArrayFunctions<T> {
     unshift(...items: T[]): number;
     reverse(): T[];
     sort(): void;
-    sort(compareFunction): void;
+    sort(compareFunction: (left: any, right: any) => number): void;
 
     // Ko specific
     replace(oldItem: T, newItem: T): void;
 
-    remove(item): T[];
+    remove(item: T): T[];
+    remove(removeFunction: (item: T) => boolean): T[];
     removeAll(items: T[]): T[];
     removeAll(): T[];
 
@@ -121,9 +122,8 @@ interface KnockoutBindingContext {
     $index?: number;
     $parentContext?: KnockoutBindingContext;
 
-    extend(any): any;
-    createChildContext(any): any;
-    createChildContext(a: any, b: any, c: Function): any;
+    extend(properties: any): any;
+    createChildContext(dataItemOrAccessor: any, dataItemAlias: any, extendCallback?: Function): any;
 }
 
 interface KnockoutBindingHandler {
@@ -167,23 +167,23 @@ interface KnockoutBindingHandlers {
 }
 
 interface KnockoutMemoization {
-    memoize(callback);
-    unmemoize(memoId, callbackParams);
-    unmemoizeDomNodeAndDescendants(domNode, extraCallbackParamsArray);
-    parseMemoText(memoText);
+    memoize(callback: () => string): string;
+    unmemoize(memoId: string, callbackParams: Array): boolean;
+    unmemoizeDomNodeAndDescendants(domNode: any, extraCallbackParamsArray: Array): boolean;
+    parseMemoText(memoText: string): string;
 }
 
 interface KnockoutVirtualElement {}
 
 interface KnockoutVirtualElements {
 	allowedBindings: { [bindingName: string]: boolean; };
-	emptyNode( e: KnockoutVirtualElement );
-	firstChild( e: KnockoutVirtualElement );
-	insertAfter( container: KnockoutVirtualElement, nodeToInsert: HTMLElement, insertAfter: HTMLElement );
-	nextSibling( e: KnockoutVirtualElement );
-	prepend( e: KnockoutVirtualElement, toInsert: HTMLElement );
-	setDomNodeChildren( e: KnockoutVirtualElement, newChildren: { length: number;[index: number]: HTMLElement; } );
-	childNodes( e: KnockoutVirtualElement ): HTMLElement[];
+    emptyNode(node: KnockoutVirtualElement ): void;
+    firstChild(node: KnockoutVirtualElement ): KnockoutVirtualElement;
+	insertAfter( container: KnockoutVirtualElement, nodeToInsert: HTMLElement, insertAfter: HTMLElement ): void;
+    nextSibling(node: KnockoutVirtualElement): HTMLElement;
+    prepend(node: KnockoutVirtualElement, toInsert: HTMLElement ): void;
+    setDomNodeChildren(node: KnockoutVirtualElement, newChildren: { length: number;[index: number]: HTMLElement; } ): void;
+    childNodes(node: KnockoutVirtualElement ): HTMLElement[];
 }
 
 interface KnockoutExtenders {
@@ -197,11 +197,11 @@ interface KnockoutUtils {
     // utils.domManipulation.js
     //////////////////////////////////
 
-    simpleHtmlParse(html: string);
+    simpleHtmlParse(html: string): Array;
 
-    jQueryHtmlParse(html: string);
+    jQueryHtmlParse(html: string): Array;
 
-    parseHtmlFragment(html: string);
+    parseHtmlFragment(html: string): Array;
 
     setHtml(node: Element, html: string): void;
 
@@ -212,13 +212,13 @@ interface KnockoutUtils {
     //////////////////////////////////
 
     domData: {
-        get (node: Element, key: string);
+        get (node: Element, key: string): any;
 
-        set (node: Element, key: string, value: any);
+        set (node: Element, key: string, value: any): void;
 
-        getAll(node: Element, createIfNotFound: boolean);
+        getAll(node: Element, createIfNotFound: boolean): any;
 
-        clear(node: Element);
+        clear(node: Element): boolean;
     };
 
     //////////////////////////////////
@@ -226,13 +226,13 @@ interface KnockoutUtils {
     //////////////////////////////////
 
     domNodeDisposal: {
-        addDisposeCallback(node: Element, callback: Function);
+        addDisposeCallback(node: Element, callback: Function): void;
 
-        removeDisposeCallback(node: Element, callback: Function);
+        removeDisposeCallback(node: Element, callback: Function): void;
 
-        cleanNode(node: Element);
+        cleanNode(node: Element): Element;
 
-        removeNode(node: Element);
+        removeNode(node: Element): void;
     };
 
     //////////////////////////////////
@@ -261,9 +261,9 @@ interface KnockoutUtils {
 
     arrayPushAll<T>(array: KnockoutObservableArray<T>, valuesToPush: T[]): T[];
 
-    extend(target, source);
+    extend(target: Object, source: Object): Object;
 
-    emptyDomNode(domNode): void;
+    emptyDomNode(domNode: HTMLElement): void;
 
     moveCleanedNodesToContainerElement(nodes: any[]): HTMLElement;
 
@@ -336,9 +336,9 @@ interface KnockoutArrayChange<T> {
 
 interface KnockoutTemplateSourcesDomElement {
 
-    text(valueToWrite?);
+    text(valueToWrite?: any): any;
 
-    data(key, valueToWrite?);
+    data(key: string, valueToWrite?: any): any;
 }
 
 
@@ -360,7 +360,7 @@ interface KnockoutTemplateSources {
 
 interface KnockoutNativeTemplateEngine {
 
-    renderTemplateSource(templateSource, bindingContext, options?);
+    renderTemplateSource(templateSource: Object, bindingContext?: KnockoutBindingContext, options?: Object): Array;
 }
 
 //////////////////////////////////
@@ -369,15 +369,15 @@ interface KnockoutNativeTemplateEngine {
 
 interface KnockoutTemplateEngine extends KnockoutNativeTemplateEngine {
 
-    createJavaScriptEvaluatorBlock(script: string);
+    createJavaScriptEvaluatorBlock(script: string): string;
 
-    makeTemplateSource(template, templateDocument);
+    makeTemplateSource(template: any, templateDocument?: Document): any;
 
-    renderTemplate(template, bindingContext, options, templateDocument);
+    renderTemplate(template: any, bindingContext: KnockoutBindingContext, options: Object, templateDocument: Document): any;
 
-    isTemplateRewritten(template, templateDocument): boolean;
+    isTemplateRewritten(template: any, templateDocument: Document): boolean;
 
-    rewriteTemplate(template, rewriterCallback, templateDocument);
+    rewriteTemplate(template: any, rewriterCallback: Function, templateDocument: Document): void;
 }
 
 /////////////////////////////////
@@ -406,10 +406,10 @@ interface KnockoutStatic {
     isWriteableObservable(instance: any): boolean;
     isComputed(instance: any): boolean;
     dataFor(node: any): any;
-    removeNode(node: Element);
-    cleanNode(node: Element);
-    renderTemplate(template: Function, viewModel: any, options?: any, target?: any, renderMode?: any);
-    renderTemplate(template: string, viewModel: any, options?: any, target?: any, renderMode?: any);
+    removeNode(node: Element): void;
+    cleanNode(node: Element): Element;
+    renderTemplate(template: Function, viewModel: any, options?: any, target?: any, renderMode?: any): any;
+    renderTemplate(template: string, viewModel: any, options?: any, target?: any, renderMode?: any): any;
     unwrap(value: any): any;
 
     //////////////////////////////////
@@ -435,11 +435,12 @@ interface KnockoutStatic {
 
     templateRewriting: {
 
-        ensureTemplateIsRewritten(template, templateEngine, templateDocument);
+        ensureTemplateIsRewritten(template: Node, templateEngine: KnockoutTemplateEngine, templateDocument: Document): any;
+        ensureTemplateIsRewritten(template: string, templateEngine: KnockoutTemplateEngine, templateDocument: Document): any;
 
-        memoizeBindingAttributeSyntax(htmlString: string, templateEngine: KnockoutTemplateEngine);
+        memoizeBindingAttributeSyntax(htmlString: string, templateEngine: KnockoutTemplateEngine): any;
 
-        applyMemoizedBindingsToNextSibling(bindings);
+        applyMemoizedBindingsToNextSibling(bindings: any, nodeName: string): string;
     };
 
     //////////////////////////////////
@@ -463,22 +464,32 @@ interface KnockoutStatic {
 
         prototype: KnockoutTemplateEngine;
 
-        renderTemplateSource(templateSource, bindingContext, options);
+        renderTemplateSource(templateSource: Object, bindingContext: KnockoutBindingContext, options: Object): Node[];
 
         createJavaScriptEvaluatorBlock(script: string): string;
 
-        addTemplate(templateName, templateMarkup);
+        addTemplate(templateName: string, templateMarkup: string): void;
     };
 
     //////////////////////////////////
     // templating.js
     //////////////////////////////////
 
-    setTemplateEngine(templateEngine: KnockoutNativeTemplateEngine);
+    setTemplateEngine(templateEngine: KnockoutNativeTemplateEngine): void;
 
-    renderTemplate(template, dataOrBindingContext, options, targetNodeOrNodeArray, renderMode);
+    renderTemplate(template: Function, dataOrBindingContext: KnockoutBindingContext, options: Object, targetNodeOrNodeArray: Node, renderMode: string): any;
+    renderTemplate(template: any, dataOrBindingContext: KnockoutBindingContext, options: Object, targetNodeOrNodeArray: Node, renderMode: string): any;
+    renderTemplate(template: Function, dataOrBindingContext: any, options: Object, targetNodeOrNodeArray: Node, renderMode: string): any;
+    renderTemplate(template: any, dataOrBindingContext: any, options: Object, targetNodeOrNodeArray: Node, renderMode: string): any;
+    renderTemplate(template: Function, dataOrBindingContext: KnockoutBindingContext, options: Object, targetNodeOrNodeArray: Node[], renderMode: string): any;
+    renderTemplate(template: any, dataOrBindingContext: KnockoutBindingContext, options: Object, targetNodeOrNodeArray: Node[], renderMode: string): any;
+    renderTemplate(template: Function, dataOrBindingContext: any, options: Object, targetNodeOrNodeArray: Node[], renderMode: string): any;
+    renderTemplate(template: any, dataOrBindingContext: any, options: Object, targetNodeOrNodeArray: Node[], renderMode: string): any;
 
-    renderTemplateForEach(template, arrayOrObservableArray, options, targetNode, parentBindingContext);
+    renderTemplateForEach(template: Function, arrayOrObservableArray: Array, options: Object, targetNode: Node, parentBindingContext: KnockoutBindingContext): any;
+    renderTemplateForEach(template: any, arrayOrObservableArray: Array, options: Object, targetNode: Node, parentBindingContext: KnockoutBindingContext): any;
+    renderTemplateForEach(template: Function, arrayOrObservableArray: KnockoutObservable<Array>, options: Object, targetNode: Node, parentBindingContext: KnockoutBindingContext): any;
+    renderTemplateForEach(template: any, arrayOrObservableArray: KnockoutObservable<Array>, options: Object, targetNode: Node, parentBindingContext: KnockoutBindingContext): any;
 
     expressionRewriting: {
         bindingRewriteValidators: any;
@@ -494,9 +505,9 @@ interface KnockoutStatic {
 
     selectExtensions: {
 
-        readValue(element: any);
+        readValue(element: HTMLElement): any;
 
-        writeValue(element: any, value: any);
+        writeValue(element: HTMLElement, value: any): void;
     };
 }
 

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -123,7 +123,7 @@ interface KnockoutBindingContext {
     $parentContext?: KnockoutBindingContext;
 
     extend(properties: any): any;
-    createChildContext(dataItemOrAccessor: any, dataItemAlias: any, extendCallback?: Function): any;
+    createChildContext(dataItemOrAccessor: any, dataItemAlias?: any, extendCallback?: Function): any;
 }
 
 interface KnockoutBindingHandler {


### PR DESCRIPTION
There are probably still more overloads required for renderTemplate and renderTemplateForEach as these methods do a lot of different things and allow many possibilities in terms of types of arguments that can be passed.  I expect these overloads will need refining further in the future but it's certainly a start.

Also added missing remove overload from knockout.d.ts.

Note on 2nd commit:  I'd overlooked that dataItemAlias is optional in my first commit - second commit fixes this.
