### PR TITLE
Updating jquery.flot.d.ts. Fixing type for seriesOptions.color

### DIFF
--- a/flot/jquery.flot.d.ts
+++ b/flot/jquery.flot.d.ts
@@ -72,7 +72,7 @@ declare module jquery.flot {
     }
 
     interface seriesOptions {
-        color?: number;
+        color?: any;            // color or number
         label?: string;
         lines?: linesOptions;
         bars?: barsOptions;


### PR DESCRIPTION
Flot specifies that the color is either a number or a string. 

See: https://github.com/flot/flot/blob/master/API.md

---

> The format of a single series object is as follows:
> 
> ```
> {
>       color: color or number
>       ...
> }
> ```
> 
> If you don't specify color, the series will get a color from the 
> auto-generated colors. The color is either a CSS color 
> specification (like "rgb(255, 100, 123)") or an integer that 
> specifies which of auto-generated colors to select, e.g. 0 will get 
> color no. 0, etc.
