### PR TITLE
qUnit fix

### DIFF
--- a/qunit/qunit.d.ts
+++ b/qunit/qunit.d.ts
@@ -134,9 +134,15 @@ interface Config {
 	current: Object;
 	reorder: boolean;
 	requireExpects: boolean;
-    testTimeout: number;
-	urlConfig: Array;
+	testTimeout: number;
+	urlConfig: Array<URLConfigItem>;
 	done: any;
+}
+
+interface URLConfigItem {
+	id: string;
+	label: string;
+	tooltip: string;
 }
 
 interface LifecycleObject {


### PR DESCRIPTION
Fix for error with TypeScript 0.9.5: "Generic type references must include all type arguments".

TypeScript 0.9.5 is a bit more strict with d.ts files.

The documentation at http://api.qunitjs.com/QUnit.config/ says that the urlConfig property is an array with an id, label, and tooltip property.  Based on the qUnit code, these are strings.  This fixes the compiler error in VS when using the qunit.d.ts file.
