### PR TITLE
adding linky filter to ngSanitize

### DIFF
--- a/angularjs/angular-sanitize-tests.ts
+++ b/angularjs/angular-sanitize-tests.ts
@@ -1,0 +1,10 @@
+/// <reference path="angular-sanitize.d.ts" />
+
+var shouldBeString: string;
+
+declare var $sanitizeService: ng.sanitize.ISanitizeService;
+shouldBeString = $sanitizeService(shouldBeString);
+
+declare var $linky: ng.sanitize.filter.ILinky;
+shouldBeString = $linky(shouldBeString);
+shouldBeString = $linky(shouldBeString, shouldBeString);

--- a/angularjs/angular-sanitize.d.ts
+++ b/angularjs/angular-sanitize.d.ts
@@ -19,4 +19,17 @@ declare module ng.sanitize {
         (html: string): string;
     }
 
+    ///////////////////////////////////////////////////////////////////////////
+    // Filters included with the ngSanitize
+    // see https://github.com/angular/angular.js/tree/v1.2.0/src/ngSanitize/filter
+    ///////////////////////////////////////////////////////////////////////////
+    export module filter {
+
+        // Finds links in text input and turns them into html links. 
+        // Supports http/https/ftp/mailto and plain email address links.
+        // see http://code.angularjs.org/1.2.0/docs/api/ngSanitize.filter:linky
+        interface ILinky {
+            (text: string, target?: string): string;
+        }
+    }
 }


### PR DESCRIPTION
The linky filter is used to _sanitize_ (escape html) and linkify text
- added module for [ngSanitize filters](https://github.com/angular/angular.js/tree/v1.2.0/src/ngSanitize/filter)
- added [linky filter](http://code.angularjs.org/1.2.0/docs/api/ngSanitize.filter:linky) to angular 1.2 ng.sanitize module
