### PR TITLE
Add no-arg overload of selection.data()

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -714,6 +714,7 @@ declare module D3 {
         data: {
             (values: (data: any, index?: number) => any[], key?: (data: any, index?: number) => string): UpdateSelection;
             (values: any[], key?: (data: any, index?: number) => string): UpdateSelection;
+            (): any[];
         };
 
         datum: {


### PR DESCRIPTION
There is a no-arg version of [the `data()` method on selections](https://github.com/mbostock/d3/wiki/Selections#wiki-data) which returns the previously-assigned data. From the docs:

> If values is not specified, then this method returns the array of data for the first group in the selection.
