### PR TITLE
jQuery:Added generic always/done/fail/progress

### DIFF
--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -2327,7 +2327,7 @@ function test_EventIsCallable() {
 }
 
 $.when($.ajax("/my/page.json")).then((a,b,c) => a.asdf); // is type JQueryPromise<any>
-$.when("asdf", "jkl;").done(x => x.length, x=> x.length);
+$.when("asdf", "jkl;").done((x,y) => x.length + y.length, (x,y) => x.length + y.length);
 
 var f1 = $.when("fetch"); // Is type JQueryPromise<string>
 var f2: JQueryPromise<string[]> = f1.then(s => [s, s]);

--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -898,6 +898,18 @@ function test_dblclick() {
 }
 
 function test_deferred() {
+
+    function returnPromise(): JQueryPromise<(data: { MyString: string; MyNumber: number; }, textStatus: string, jqXHR: JQueryXHR) => any> {
+        return $.ajax("test.php");
+    }
+    var x = returnPromise();
+    x.done((data, textStatus, jqXHR) => {
+        var myNumber: number = data.MyNumber;
+        var myString: string = data.MyString;
+        var theTextStatus: string = textStatus;
+        var thejqXHR: JQueryXHR = jqXHR;
+    });
+
     $.get("test.php").always(function () {
         alert("$.get completed with success or error callback arguments");
     });

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -94,6 +94,12 @@ interface JQueryGenericPromise<T> {
     Interface for the JQuery promise, part of callbacks
 */
 interface JQueryPromise<T> {
+    // Generic versions of callbacks
+    always(...alwaysCallbacks: T[]): JQueryPromise<T>;
+    done(...doneCallbacks: T[]): JQueryPromise<T>;
+    fail(...failCallbacks: T[]): JQueryPromise<T>;
+    progress(...progressCallbacks: T[]): JQueryPromise<T>;
+
     always(...alwaysCallbacks: any[]): JQueryPromise<T>;
     done(...doneCallbacks: any[]): JQueryPromise<T>;
     fail(...failCallbacks: any[]): JQueryPromise<T>;

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -124,6 +124,12 @@ interface JQueryPromise<T> {
     Interface for the JQuery deferred, part of callbacks
 */
 interface JQueryDeferred<T> extends JQueryPromise<T> {
+    // Generic versions of callbacks
+    always(...alwaysCallbacks: T[]): JQueryDeferred<T>;
+    done(...doneCallbacks: T[]): JQueryDeferred<T>;
+    fail(...failCallbacks: T[]): JQueryDeferred<T>;
+    progress(...progressCallbacks: T[]): JQueryDeferred<T>;
+
     always(...alwaysCallbacks: any[]): JQueryDeferred<T>;
     done(...doneCallbacks: any[]): JQueryDeferred<T>;
     fail(...failCallbacks: any[]): JQueryDeferred<T>;


### PR DESCRIPTION
Hi Guys,

I've added generic versions of the JQueryPromise callbacks for `always`, `done`, `fail` and `progress`.  I think that this is correct and I've added a test in for `done` to illustrate usage.

I'm approaching this mostly from the perspective of attempting to flow the typings through when using jQuery's AJAX goodness.  Essentially this change allows me to write a data service module which allows my `done` callbacks to pick up the typing defined in the data service module.

I _think_ this is correct (ie - it works in my own project) but I can't help but notice that my implementation is slightly different to the `then` implementation. I appreciate that they are not one and the same thing but if I've missed something here then please feel free to set me back on the right path. :-)
