### PR TITLE
Added support for d3 QuantitiveScale.nice argument: count

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -2438,8 +2438,10 @@ declare module D3 {
             clamp(clamp: boolean): QuantitiveScale;
             /**
             * extend the scale domain to nice round numbers.
+            * 
+            * @param count Optional number of ticks to exactly fit the domain
             */
-            nice(): QuantitiveScale;
+            nice(count?: number): QuantitiveScale;
             /**
             * get representative values from the input domain.
             *


### PR DESCRIPTION
See [the documentation](https://github.com/mbostock/d3/wiki/Quantitative-Scales#wiki-linear_nice) for details.

Tested in my codebase and works well.
