### PR TITLE
Fixed property name on Matrix2D from 'atx' to 'tx'

### DIFF
--- a/easeljs/easeljs.d.ts
+++ b/easeljs/easeljs.d.ts
@@ -382,7 +382,7 @@ declare module createjs {
         // properties
         a: number;
         alpha: number;
-        atx: number;
+        tx: number;
         b: number;
         c: number;
         compositeOperation: string;


### PR DESCRIPTION
Just a typo I think as there is no property called 'atx' on createjs.Matrix2D in EaselJS 0.6
