### PR TITLE
Definition Fixes for node and express

### DIFF
--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -405,6 +405,12 @@ declare module "express" {
             //cookies: { string; remember: boolean; };
             cookies: any;
 
+	    /**
+             * Used to generate an anti-CSRF token.
+             * Placed by the CSRF protection middleware.
+             */
+	    csrfToken(): string;
+
             method: string;
 
             params: any;
@@ -1063,9 +1069,11 @@ declare module "express" {
              *    http.createServer(app).listen(80);
              *    https.createServer({ ... }, app).listen(443);
              */
-            listen(port: number, hostname: string, backlog: number, callback: Function): void;
+            listen(port: number, hostname: string, backlog: number, callback?: Function): void;
 
-            listen(port: number, callback: Function): void;
+            listen(port: number, hostname: string, callback?: Function): void;
+
+            listen(port: number, callback?: Function): void;
 
             listen(path: string, callback?: Function): void;
 
@@ -1471,13 +1479,12 @@ declare module "express" {
         /**
          * Anti CSRF:
          *
-         * CRSF protection middleware.
+         * CSRF protection middleware.
          *
-         * By default this middleware generates a token named "_csrf"
+         * This middleware adds a `req.csrfToken()` function to make a token
          * which should be added to requests which mutate
          * state, within a hidden form field, query-string etc. This
-         * token is validated against the visitor's `req.session._csrf`
-         * property.
+         * token is validated against the visitor's session.
          *
          * The default `value` function checks `req.body` generated
          * by the `bodyParser()` middleware, `req.query` generated
@@ -1488,11 +1495,11 @@ declare module "express" {
          *
          * Options:
          *
-         *    - `value` a function accepting the request, returning the token 
+         *    - `value` a function accepting the request, returning the token
          *
          * @param options
          */
-        export function csrf(options: any): Handler;
+        export function csrf(options?: {value?: Function}): Handler;
 
         /**
          * Directory:

--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -405,11 +405,11 @@ declare module "express" {
             //cookies: { string; remember: boolean; };
             cookies: any;
 
-	    /**
+            /**
              * Used to generate an anti-CSRF token.
              * Placed by the CSRF protection middleware.
              */
-	    csrfToken(): string;
+            csrfToken(): string;
 
             method: string;
 

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -15,11 +15,11 @@ declare var global: any;
 declare var __filename: string;
 declare var __dirname: string;
 
-declare function setTimeout(callback: () => void , ms: number): any;
-declare function clearTimeout(timeoutId: any): void;
-declare function setInterval(callback: () => void , ms: number): any;
-declare function clearInterval(intervalId: any): void;
-declare function setImmediate(callback: () => void ): any;
+declare function setTimeout(callback: (...args: any[]) => void , ms: number , ...args: any[]): Timer;
+declare function clearTimeout(timeoutId: Timer): void;
+declare function setInterval(callback: (...args: any[]) => void , ms: number , ...args: any[]): Timer;
+declare function clearInterval(intervalId: Timer): void;
+declare function setImmediate(callback: (...args: any[]) => void , ...args: any[]): any;
 declare function clearImmediate(immediateId: any): void;
 
 declare var require: {
@@ -193,6 +193,11 @@ interface NodeBuffer {
     writeDoubleBE(value: number, offset: number, noAssert?: boolean): void;
     fill(value: any, offset?: number, end?: number): void;
     INSPECT_MAX_BYTES: number;
+}
+
+interface Timer {
+    ref() : void;
+    unref() : void;
 }
 
 /************************************************
@@ -799,8 +804,8 @@ declare module "fs" {
     export function readSync(fd: string, buffer: NodeBuffer, offset: number, length: number, position: number): any[];
     export function readFile(filename: string, options: { encoding?: string; flag?: string; }, callback: (err: Error, data: any) => void): void;
     export function readFile(filename: string, callback: (err: Error, data: NodeBuffer) => void ): void;
-    export function readFileSync(filename: string): NodeBuffer;
-    export function readFileSync(filename: string, options: { encoding?: string; flag?: string; }): any;
+    export function readFileSync(filename: string, options?: { flag?: string; }): NodeBuffer;
+    export function readFileSync(filename: string, options: { encoding: string; flag?: string; }): string;
     export function writeFile(filename: string, data: any, callback?: (err: Error) => void): void;
     export function writeFile(filename: string, data: any, options: { encoding?: string; mode?: number; flag?: string; }, callback?: (err: Error) => void): void;
     export function writeFile(filename: string, data: any, options: { encoding?: string; mode?: string; flag?: string; }, callback?: (err: Error) => void): void;
@@ -811,10 +816,11 @@ declare module "fs" {
     export function appendFile(filename: string, data: any, callback?: (err: Error) => void): void;
     export function appendFileSync(filename: string, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): void;
     export function appendFileSync(filename: string, data: any, options?: { encoding?: string; mode?: string; flag?: string; }): void;
-    export function watchFile(filename: string, listener: { curr: Stats; prev: Stats; }): void;
-    export function watchFile(filename: string, options: { persistent?: boolean; interval?: number; }, listener: { curr: Stats; prev: Stats; }): void;
-    export function unwatchFile(filename: string, listener?: Stats): void;
-    export function watch(filename: string, options?: { persistent?: boolean; }, listener?: (event: string, filename: string) =>any): FSWatcher;
+    export function watchFile(filename: string, listener: (curr: Stats, prev: Stats)=>void): void;
+    export function watchFile(filename: string, options: { persistent?: boolean; interval?: number; }, listener: (curr: Stats, prev: Stats)=>void): void;
+    export function unwatchFile(filename: string, listener?: (curr: Stats, prev: Stats)=>void): void;
+    export function watch(filename: string, listener?: (event: string, filename: string) =>any): FSWatcher;
+    export function watch(filename: string, options: { persistent?: boolean; }, listener?: (event: string, filename: string) =>any): FSWatcher;
     export function exists(path: string, callback?: (exists: boolean) => void): void;
     export function existsSync(path: string): boolean;
     export function createReadStream(path: string, options?: {
@@ -1003,7 +1009,10 @@ declare module "crypto" {
     }
     export function getDiffieHellman(group_name: string): DiffieHellman;
     export function pbkdf2(password: string, salt: string, iterations: number, keylen: number, callback: (err: Error, derivedKey: string) => any): void;
-    export function randomBytes(size: number, callback?: (err: Error, buf: NodeBuffer) =>void ): void;
+    export function randomBytes(size: number): NodeBuffer;
+    export function randomBytes(size: number, callback: (err: Error, buf: NodeBuffer) =>void ): void;
+    export function pseudoRandomBytes(size: number): NodeBuffer;
+    export function pseudoRandomBytes(size: number, callback: (err: Error, buf: NodeBuffer) =>void ): void;
 }
 
 declare module "stream" {


### PR DESCRIPTION
node
- setTimeout, setInterval, setImmediate are fixed to accept more arguments.
- setTimeout, setInterval, clearTimeout, clearInterval are changed to return and accept objects of the new Timer interface, which exposes the ref() and unref() methods.
- fs.readFileSync is changed so that it returns a string if it is passed an options parameter with an "encoding" property, and returns a NodeBuffer otherwise.
- fs.watchFile and fs.unwatchFile listener parameters are fixed. listener is a callback with two parameters, not an object with two properties.
- fs.watch is fixed so a listener parameter can be given without an options parameter.
- crypto.randomBytes is fixed so that it can be called synchronously, returning a NodeBuffer.
- crypto.pseudoRandomBytes is added.

express
- app.listen is fixed so that it can be called with a port, hostname, and optional callback without a backlog parameter.
- app.listen is fixed so callback parameter is always optional.
- CSRF protection middleware definition is fixed so options parameter is optional.
- req.csrfToken method is added since the CSRF protection middleware has been updated.
