### PR TITLE
Fixed typo in D3js

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -2405,7 +2405,7 @@ declare module D3 {
             /*
             * Construct a threshold scale with a discrete output range.
             */
-            theshold(): ThresholdScale;
+            threshold(): ThresholdScale;
         }
 
         export interface Scale {


### PR DESCRIPTION
d3.d.ts typo in scale threshold function
