### PR TITLE
node bug fix, make ReadableStream the same as stream.ReadableStream

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -95,7 +95,7 @@ interface ReadableStream extends EventEmitter {
     pause(): void;
     resume(): void;
     destroy(): void;
-    pipe(destination: WritableStream, options?: { end?: boolean; }): void;
+    pipe<T extends WritableStream>(destination: T, options?: { end?: boolean; }): T;
 }
 
 interface NodeProcess extends EventEmitter {


### PR DESCRIPTION
This simply applies the same change to RedableStream that was made to stream.ReadableStream in: https://github.com/borisyankov/DefinitelyTyped/commit/d0139df89deb691b3a25506e942d41707c8afce8

It avoids this error:
![node_pipe](https://f.cloud.github.com/assets/80104/1609664/88770380-5551-11e3-9cb1-9e33d0bb130b.png)
