### PR TITLE
Q:jQueryPromise converted implicitly to Q promise

### DIFF
--- a/q/Q-tests.ts
+++ b/q/Q-tests.ts
@@ -79,6 +79,9 @@ declare var jPromise: JQueryPromise<string>;
 Q<string>(jPromise).then(str => str.split(','));
 jPromise.then<number>(returnsNumPromise);
 
+// watch the typing flow through from jQueryPromise to Q.Promise
+Q(jPromise).then(str => str.split(','));
+
 declare var promiseArray: Q.IPromise<number>[];
 var qPromiseArray = promiseArray.map(p => Q<number>(p));
 var myNums: any[] = [2, 3, Q(4), 5, Q(6), Q(7)];

--- a/q/Q.d.ts
+++ b/q/Q.d.ts
@@ -3,8 +3,11 @@
 // Definitions by: Barrie Nemetchek, Andrew Gaspar
 // Definitions: https://github.com/borisyankov/DefinitelyTyped  
 
-declare function Q<T>(value: T): Q.Promise<T>;
+/// <reference path="../jquery/jquery.d.ts"/>
+
 declare function Q<T>(promise: Q.IPromise<T>): Q.Promise<T>;
+declare function Q<T>(promise: JQueryPromise<T>): Q.Promise<T>;
+declare function Q<T>(value: T): Q.Promise<T>;
 
 declare module Q {
     interface IPromise<T> {


### PR DESCRIPTION
jQuery ajax promises can be converted to Q promises following the guidance / examples here:

https://github.com/kriskowal/q/wiki/Coming-from-jQuery#converting-jquery-promises-to-q

and here:

https://gist.github.com/domenic/1604916

These are already supported in Q.d.ts using this syntax:

``` ts
 var jQueryPromise: JQueryPromise<MyType> = $.ajax({
     url: "myUrl",
     type: "GET"
 });
 var qPromise = Q<MyType>(jQueryPromise); // qPromise will be of type Q.Promise<MyType>
```

My change allows the promise typing to flow through implicitly:

``` ts
var jQueryPromise: JQueryPromise<MyType> = $.ajax({
    url: "myUrl",
    type: "GET"
});
var qPromise = Q(jQueryPromise); // qPromise will be of type Q.Promise<MyType>
```

I've updated the tests to reflect this.  The order of the Q overloads is key for getting this to work.  I haven't tested this with the 0.9.5 beta of TS and I don't know if the changes to the overload resolution rules that come with 0.9.5 might have some bearing on this.  Just something we might want to bear in mind for the future.
