### PR TITLE
Converting ungeneric "Array" to "any[]"

### DIFF
--- a/ace/ace.d.ts
+++ b/ace/ace.d.ts
@@ -624,7 +624,7 @@ declare module AceAjax {
          * Sets a breakpoint on every row number given by `rows`. This function also emites the `'changeBreakpoint'` event.
          * @param rows An array of row indices
         **/
-        setBreakpoints(rows: Array);
+        setBreakpoints(rows: any[]);
 
         /**
          * Removes all breakpoints on the rows. This function also emites the `'changeBreakpoint'` event.
@@ -679,7 +679,7 @@ declare module AceAjax {
          * Returns an array containing the IDs of all the markers, either front or back.
          * @param inFront If `true`, indicates you only want front markers; `false` indicates only back markers
         **/
-        getMarkers(inFront: boolean): Array;
+        getMarkers(inFront: boolean): any[];
 
         /**
          * Sets annotations for the `EditSession`. This functions emits the `'changeAnnotation'` event.
@@ -823,14 +823,14 @@ declare module AceAjax {
          * @param deltas An array of previous changes
          * @param dontSelect [If `true`, doesn't select the range of where the change occured]{: #dontSelect}
         **/
-        undoChanges(deltas: Array, dontSelect: boolean): Range;
+        undoChanges(deltas: any[], dontSelect: boolean): Range;
 
         /**
          * Re-implements a previously undone change to your document.
          * @param deltas An array of previous changes
          * @param dontSelect {:dontSelect}
         **/
-        redoChanges(deltas: Array, dontSelect: boolean): Range;
+        redoChanges(deltas: any[], dontSelect: boolean): Range;
 
         /**
          * Enables or disables highlighting of the range where an undo occured.
@@ -2778,7 +2778,7 @@ declare module AceAjax {
          * Sets annotations for the gutter.
          * @param annotations An array containing annotations
         **/
-        setAnnotations(annotations: Array);
+        setAnnotations(annotations: any[]);
 
         /**
          * Updates the cursor icon.

--- a/breeze/breeze-tests.ts
+++ b/breeze/breeze-tests.ts
@@ -819,9 +819,9 @@ function test_corefns() {
     f1 = core.propEq("name", "Joe");
     f1 = core.pluck("name");
 
-    var a1: Array;
-    var a2: Array;
-    var a3: Array;
+    var a1: any[];
+    var a2: any[];
+    var a3: any[];
     var b: boolean;
     var n: number;
 

--- a/breeze/breeze.d.ts
+++ b/breeze/breeze.d.ts
@@ -62,12 +62,12 @@ declare module breeze.core {
     export function extend(target: Object, source: Object): Object;
     export function propEq(propertyName: string, value: any): (obj: Object) => boolean;
     export function pluck(propertyName: string): (obj: Object) => any;
-    export function arrayEquals(a1:Array, a2:Array, equalsFn: (e1:any, e2:any) => boolean): boolean;
-    export function arrayFirst(a1:Array, predicate: (e:any) => boolean): any;
-    export function arrayIndexOf(a1: Array, predicate: (e: any) => boolean): number;
-    export function arrayRemoveItem(array: Array, item: any, shouldRemoveMultiple: boolean): any;
-    export function arrayRemoveItem(array: Array, predicate: (e: any) => boolean, shouldRemoveMultiple: boolean): any;
-    export function arrayZip(a1: Array, a2: Array, callback: (e1:any, e2:any) => any): Array;
+    export function arrayEquals(a1: any[], a2: any[], equalsFn: (e1:any, e2:any) => boolean): boolean;
+    export function arrayFirst(a1: any[], predicate: (e:any) => boolean): any;
+    export function arrayIndexOf(a1: any[], predicate: (e: any) => boolean): number;
+    export function arrayRemoveItem(array: any[], item: any, shouldRemoveMultiple: boolean): any;
+    export function arrayRemoveItem(array: any[], predicate: (e: any) => boolean, shouldRemoveMultiple: boolean): any;
+    export function arrayZip(a1: any[], a2: any[], callback: (e1:any, e2:any) => any): any[];
 
     export function requireLib(libnames: string, errMessage: string): Object;
     export function using(obj: Object, property: string, tempValue: any, fn: () => any): any;

--- a/casperjs/casperjs.d.ts
+++ b/casperjs/casperjs.d.ts
@@ -138,7 +138,7 @@ interface ElementInfo {
 }
 
 interface CasperOptions {
-	clientScripts?: Array;
+	clientScripts?: any[];
 	exitOnError?: boolean;
 	httpStatusHandlers?: any;
 	logLevel?: string;
@@ -155,7 +155,7 @@ interface CasperOptions {
 	onWaitTimeout?: Function;
 	page?: WebPage;
 	pageSettings?: any;
-	remoteScripts?: Array;
+	remoteScripts?: any[];
 	safeLogs?: boolean;
 	stepTimeout?: number;
 	timeout?: number;
@@ -205,7 +205,7 @@ interface Tester {
 	assertNot(subject: any, message?: string): any;
 	assertNotEquals(testValue: any, expected: any, message?: string): any;
 	assertNotVisible(selector: string, message?: string): any;
-	assertRaises(fn: Function, args: Array, message?: string): any;
+	assertRaises(fn: Function, args: any[], message?: string): any;
 	assertSelectorDoesntHaveText(selector: string, text: string, message?: string): any;
 	assertSelectorExists(selector: string, message?: string): any;
 	assertSelectorHasText(selector: string, text: string, message?: string): any;
@@ -283,5 +283,5 @@ interface Utils {
 	mergeObjects(origin: any, add: any): any;
 	node(name: string, attributes: any): any;
 	serialize(value: any): any;
-	unique(array: Array): any;
+	unique(array: any[]): any;
 }

--- a/chai/chai.d.ts
+++ b/chai/chai.d.ts
@@ -146,11 +146,11 @@ declare module chai {
 
     interface Keys {
         (...keys: string[]): Expect;
-        (keys: Array): Expect;
+        (keys: any[]): Expect;
     }
 
     interface Members {
-        (set: Array, message?: string): Expect;
+        (set: any[], message?: string): Expect;
     }
 
     interface Throw {

--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -230,7 +230,7 @@ declare module "express" {
              *
              * @param size
              */
-            range(size: number): Array;
+            range(size: number): any[];
 
             /**
              * Return an array of Accepted media types
@@ -247,7 +247,7 @@ declare module "express" {
              *         type: 'text',
              *         subtype: 'html' } ]
              */
-            accepted: Array;
+            accepted: any[];
 
             /**
              * Return an array of Accepted languages
@@ -258,7 +258,7 @@ declare module "express" {
              *     Accept-Language: en;q=.5, en-us
              *     ['en-us', 'en']
              */
-            acceptedLanguages: Array;
+            acceptedLanguages: any[];
 
             /**
              * Return an array of Accepted charsets
@@ -269,7 +269,7 @@ declare module "express" {
              *     Accept-Charset: iso-8859-5;q=.2, unicode-1-1;q=0.8
              *     ['unicode-1-1', 'iso-8859-5']
              */
-            acceptedCharsets: Array;
+            acceptedCharsets: any[];
 
             /**
              * Return the value of param `name` when present or `defaultValue`.
@@ -884,7 +884,7 @@ declare module "express" {
              */
             param(name: string, fn: Function): Application;
 
-            param(name: Array, fn: Function): Application;
+            param(name: any[], fn: Function): Application;
 
             /**
              * Assign `setting` to `val`, or return `setting`'s value.

--- a/flight/flight.d.ts
+++ b/flight/flight.d.ts
@@ -218,8 +218,8 @@ declare module Flight {
         merge(obj1: Object, obj2: Object, ...args: any[]): Object;
         push(base: Object, extra: Object, protect?: boolean): void;
         throttle(func: Function, wait: number): Function;
-        toArray(obj: Object, from?: number): Array;
-        uniqueArray(array: Array): Array;
+        toArray(obj: Object, from?: number): any[];
+        uniqueArray(array: any[]): any[];
     }
 
     export interface EventData {

--- a/goJS/goJS.d.ts
+++ b/goJS/goJS.d.ts
@@ -2102,7 +2102,7 @@ declare module go {
         defaultAlignment: Spot;
 
         /**Gets or sets the default dash array for a particular column's separator.*/
-        defaultColumnSeparatorDashArray: Array;
+        defaultColumnSeparatorDashArray: any[];
 
         /**Gets or sets the default Brush stroke (or CSS color string) for columns in a Table Panel provided a given column has a nonzero RowColumnDefinition#separatorStrokeWidth.*/
         defaultColumnSeparatorStroke: any;
@@ -2111,7 +2111,7 @@ declare module go {
         defaultColumnSeparatorStrokeWidth: number;
 
         /**Gets or sets the default dash array for a particular row's separator.*/
-        defaultRowSeparatorDashArray: Array;
+        defaultRowSeparatorDashArray: any[];
 
         /**Gets or sets the default Brush stroke (or CSS color string) for rows in a Table Panel provided a given row has a nonzero RowColumnDefinition#separatorStrokeWidth.*/
         defaultRowSeparatorStroke: any;
@@ -2135,7 +2135,7 @@ declare module go {
         gridOrigin: Point;
 
         /**Gets or sets a JavaScript Array of values or objects, each of which will be represented by a Panel as elements in this Panel.*/
-        itemArray: Array;
+        itemArray: any[];
 
         /**Gets or sets the name of the item data property that returns a string describing that data's category, or a function that takes an item data object and returns that string; the default value is the name 'category'.*/
         itemCategoryProperty: any;
@@ -2690,7 +2690,7 @@ declare module go {
         position: number;
 
         /**Gets or sets the dash array for dashing the spacing provided this row or column has a nonzero RowColumnDefinition#separatorStrokeWidth and non-null RowColumnDefinition#separatorStroke.*/
-        separatorDashArray: Array;
+        separatorDashArray: any[];
 
         /**Gets or sets the additional padding for a particular row or column, a Margin (or number for a uniform Margin).*/
         separatorPadding: any;
@@ -2787,7 +2787,7 @@ declare module go {
         strokeCap: string;
 
         /**Gets or sets the dash array for creating dashed lines.*/
-        strokeDashArray: Array;
+        strokeDashArray: any[];
 
         /**Gets or sets the offset for dashed lines, used in the phase pattern.*/
         strokeDashOffset: number;
@@ -4547,7 +4547,7 @@ declare module go {
         * @param {Array} arr an Array that is the value of some Panel's Panel#itemArray.
         * @param {*} val the new value to be pushed onto the array.
         */
-        addArrayItem(arr: Array, val: any);
+        addArrayItem(arr: any[], val: any);
 
         /**
         * Register an event handler that is called when there is a ChangedEvent.
@@ -4633,7 +4633,7 @@ declare module go {
         * @param {number} idx the zero-based array index where the new value will be inserted; use -1 to push the new value on the end of the array.
         * @param {*} val the new value to be inserted into the array.
         */
-        insertArrayItem(arr: Array, idx: number, val: any);
+        insertArrayItem(arr: any[], idx: number, val: any);
 
         /**
         * This method is called when a node data object is added to the model to make sure that
@@ -4689,7 +4689,7 @@ declare module go {
         * @param {number=} idx the zero-based array index of the data item to be removed from the array;
         *   if not supplied it will remove the last item of the array.
         */
-        removeArrayItem(arr: Array, idx?: number);
+        removeArrayItem(arr: any[], idx?: number);
 
         /**
         * Unregister an event handler listener.
@@ -6283,7 +6283,7 @@ declare module go {
         childPortSpot: Spot;
 
         /**Gets or sets the logical children for this node.*/
-        children: Array;
+        children: any[];
 
         /**Gets the number of immediate children this node has.*/
         childrenCount: number;
@@ -6292,7 +6292,7 @@ declare module go {
         commentMargin: number;
 
         /**Gets or sets an array of Nodes that will be positioned near this node.*/
-        comments: Array;
+        comments: any[];
 
         /**Gets or sets the space to leave between consecutive comments.*/
         commentSpacing: number;
@@ -7924,7 +7924,7 @@ declare module go {
         /**
         * Produces a JavaScript Array from the contents of this List.
         */
-        toArray(): Array;
+        toArray(): any[];
 
         /**
         * Converts the List to a Set.
@@ -8013,7 +8013,7 @@ declare module go {
         /**
         * Produces a JavaScript Array of key/value pair objects from the contents of this Map.
         */
-        toArray(): Array;
+        toArray(): any[];
 
         /**
         * Produces a Set that provides a read-only view onto the keys of this Map.
@@ -8109,7 +8109,7 @@ declare module go {
         /**
         * Produces a JavaScript Array from the contents of this Set.
         */
-        toArray(): Array;
+        toArray(): any[];
 
         /**
         * Converts the Set to a List.

--- a/highcharts/highcharts.d.ts
+++ b/highcharts/highcharts.d.ts
@@ -1058,7 +1058,7 @@ interface HighchartsStatic {
     setOptions(options: HighchartsOptions): HighchartsOptions;
     getOptions(): HighchartsOptions;
     
-    map(array: Array, any): Array;
+    map(array: any[], any): any[];
 }
 declare var Highcharts: HighchartsStatic;
 

--- a/humane/humane.d.ts
+++ b/humane/humane.d.ts
@@ -33,7 +33,7 @@ interface Humane {
     log(message: string, options: HumaneOptions): Humane;
     log(message: string, callback: Function, options: HumaneOptions): Humane;
 
-    log(listOfMessages: Array): Humane;
+    log(listOfMessages: any[]): Humane;
 }
 
 declare var humane: Humane;

--- a/jquery.noty/jquery.noty.d.ts
+++ b/jquery.noty/jquery.noty.d.ts
@@ -16,7 +16,7 @@ interface NotyOptions {
 	timeout?: number;
 	force?: boolean;
 	modal?: boolean;
-	closeWith?: Array;
+	closeWith?: any[];
 	callback?: NotyCallbackOptions;
 	buttons?: any;
 }

--- a/knockout.deferred.updates/knockout.deferred.updates.d.ts
+++ b/knockout.deferred.updates/knockout.deferred.updates.d.ts
@@ -6,8 +6,8 @@
 /// <reference path="../knockout/knockout.d.ts" />
 
 interface KnockoutDeferredTasks {
-    processImmediate(evaluator: Function, object?: any, args?: Array): any;
-    processDelayed(evaluator: Function, distinct?: boolean, options?: Array): boolean;
+    processImmediate(evaluator: Function, object?: any, args?: any[]): any;
+    processDelayed(evaluator: Function, distinct?: boolean, options?: any[]): boolean;
     makeProcessedCallback(evaluator: Function): void;
 }
 
@@ -17,7 +17,7 @@ interface KnockoutStatic {
     processAllDeferredBindingUpdates(): void;
     processAllDeferredUpdates(): void;
     evaluateAsynchronously(evaluator: Function, timeout?: any): number;
-    ignoreDependencies(callback: Function, callbackTarget: any, callbackArgs?: Array);
+    ignoreDependencies(callback: Function, callbackTarget: any, callbackArgs?: any[]);
 }
 
 // Observables

--- a/knockout/knockout.amd.d.ts
+++ b/knockout/knockout.amd.d.ts
@@ -77,10 +77,10 @@ declare module 'knockout' {
     export function renderTemplate(template: any, dataOrBindingContext: KnockoutBindingContext, options: Object, targetNodeOrNodeArray: Node[], renderMode: string): any;
     export function renderTemplate(template: Function, dataOrBindingContext: any, options: Object, targetNodeOrNodeArray: Node[], renderMode: string): any;
     export function renderTemplate(template: any, dataOrBindingContext: any, options: Object, targetNodeOrNodeArray: Node[], renderMode: string): any;
-    export function renderTemplateForEach(template: Function, arrayOrObservableArray: Array, options: Object, targetNode: Node, parentBindingContext: KnockoutBindingContext): any;
-    export function renderTemplateForEach(template: any, arrayOrObservableArray: Array, options: Object, targetNode: Node, parentBindingContext: KnockoutBindingContext): any;
-    export function renderTemplateForEach(template: Function, arrayOrObservableArray: KnockoutObservable<Array>, options: Object, targetNode: Node, parentBindingContext: KnockoutBindingContext): any;
-    export function renderTemplateForEach(template: any, arrayOrObservableArray: KnockoutObservable < Array>, options: Object, targetNode: Node, parentBindingContext: KnockoutBindingContext): any;
+    export function renderTemplateForEach(template: Function, arrayOrObservableArray: any[], options: Object, targetNode: Node, parentBindingContext: KnockoutBindingContext): any;
+    export function renderTemplateForEach(template: any, arrayOrObservableArray: any[], options: Object, targetNode: Node, parentBindingContext: KnockoutBindingContext): any;
+    export function renderTemplateForEach(template: Function, arrayOrObservableArray: KnockoutObservable<any[]>, options: Object, targetNode: Node, parentBindingContext: KnockoutBindingContext): any;
+    export function renderTemplateForEach(template: any, arrayOrObservableArray: KnockoutObservable <any[]>, options: Object, targetNode: Node, parentBindingContext: KnockoutBindingContext): any;
     export var expressionRewriting: {
         bindingRewriteValidators: any;
     };

--- a/less/less.d.ts
+++ b/less/less.d.ts
@@ -16,7 +16,7 @@ declare module "less" {
         callExtract;
         stack;
         column;
-        extract: Array;
+        extract: any[];
     }
 
     interface Options {
@@ -257,15 +257,15 @@ declare module "less" {
             variable(): Rule;
             rulesets(): Ruleset[];
             find(selector: Selector, self: Rule): Rule[];
-            joinSelectors(paths: string[], context: Array[], selectors: Selector[]): void;
-            joinSelector(paths: string[], context: Array[], selector: Selector): void;
+            joinSelectors(paths: string[], context: any[][], selectors: Selector[]): void;
+            joinSelector(paths: string[], context: any[][], selector: Selector): void;
             mergeElementsOnToSelectors(elements: Element[], selectors: Selector[]): void;
         }
 
         export class Ruleset extends AbstractRuleset {
             constructor(selectors: Selector[], rules: Rule[], strictImports);
 
-            toCSS(context?: Array[], env?: Options): string;
+            toCSS(context?: any[][], env?: Options): string;
         }
 
         export class Element implements IInjectable {
@@ -476,7 +476,7 @@ declare module "less" {
             emptySelectors(): Selector[];
             evalTop(env: Options): IEvalable;
             evalNested(env: Options): Ruleset;
-            permute(arr: Array): Array;
+            permute(arr: any[]): any[];
             bubbleSelectors(selectors: Selector[]): void;
         }
 
@@ -499,7 +499,7 @@ declare module "less" {
         }
 
         export var debugInfo: DebugInfoFunction;
-        export function find(obj: Array, fun: Function): any;
+        export function find(obj: any[], fun: Function): any;
         export function jsify(obj: any): string;
         export function operate(op: string, a: number, b: number): number;
 

--- a/mocha/mocha.d.ts
+++ b/mocha/mocha.d.ts
@@ -31,7 +31,7 @@ interface MochaSetupOptions {
     ui?: string;
 
     //array of accepted globals
-    globals?: Array;
+    globals?: any[];
 
     // reporter instance (function or string), defaults to `mocha.reporters.Dot`
     reporter?: any;

--- a/modernizr/modernizr.d.ts
+++ b/modernizr/modernizr.d.ts
@@ -92,7 +92,7 @@ interface ModernizrStatic {
     touch: boolean;
     webgl: boolean;
 
-    load(resources: Array): void;
+    load(resources: any[]): void;
     load(resourceObject: any): void;
     load(resourceString: string): void;
 

--- a/noVNC/noVNC.d.ts
+++ b/noVNC/noVNC.d.ts
@@ -99,7 +99,7 @@ declare class RFB {
 	sendCtrlAltDel(): void;
 	sendKey(code: number, down: boolean): void;
 	clipboardPasteFrom(text: string): void;
-	testMode(override_send: (arr: Array) => boolean, data_mode: string): void;
+	testMode(override_send: (arr: any[]) => boolean, data_mode: string): void;
 }
 
 interface Display {

--- a/node_zeromq/zmq.d.ts
+++ b/node_zeromq/zmq.d.ts
@@ -142,7 +142,7 @@ declare module 'zmq' {
         * @param msg The message
         * @param flags Message flags
         */
-        send(msg: Array, flags?: number): Socket;
+        send(msg: any[], flags?: number): Socket;
 
         /**
          * Close the socket.

--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -313,7 +313,7 @@ declare module OpenLayers {
          * application. In addition, the units property must also be set.
          * Use <resolutions> instead wherever possible.
          */
-        scales: Array;
+        scales: any[];
 
         /**
          * A list of map resolutions (map units per pixel) in descending
@@ -321,7 +321,7 @@ declare module OpenLayers {
          * based on other resolution related properties (maxExtent,
          * maxResolution, maxScale, etc.).
          */
-        resolutions: Array;
+        resolutions: any[];
 
         /**
          * The maximum extent for the layer.  Defaults to null.
@@ -923,7 +923,7 @@ declare module OpenLayers {
         /**
          * Return a list of all points in this geometry.
          */
-        getVertices(nodes: boolean): Array;
+        getVertices(nodes: boolean): any[];
 
         /**
          * Return whether or not the geometry is at the specified location
@@ -1695,8 +1695,8 @@ declare module OpenLayers {
          * {Array} An array of items where the given property matches the given
          * criteria.
          */
-        getBy(array: string, property: string, match: string): Array;
-        getBy(array: string, property: string, match: Object): Array;
+        getBy(array: string, property: string, match: string): any[];
+        getBy(array: string, property: string, match: Object): any[];
 
         /**
          * APIMethod: getLayersBy
@@ -2865,7 +2865,7 @@ declare module OpenLayers {
             /**
              * Return a list of all points in this geometry.
              */
-            getVertices(nodes: boolean): Array;
+            getVertices(nodes: boolean): any[];
 
             static CLASS_NAME: string;
         }
@@ -2929,7 +2929,7 @@ declare module OpenLayers {
             /**
              * Return a list of all points in this geometry.
              */
-            getVertices(nodes: boolean): Array;
+            getVertices(nodes: boolean): any[];
         }
 
         export class Curve extends Geometry.MultiPoint {

--- a/preloadjs/preloadjs.d.ts
+++ b/preloadjs/preloadjs.d.ts
@@ -81,7 +81,7 @@ declare module createjs {
         getResult(value: string, rawResult?: boolean): Object;
         removeAll(): void;
         remove(idsOrUrls: string): void;
-        remove(idsOrUrls: Array): void;
+        remove(idsOrUrls: any[]): void;
         reset(): void;
         setMaxConnections(value: number): void;
         setUseXHR(value: boolean): void;

--- a/raphael/raphael.d.ts
+++ b/raphael/raphael.d.ts
@@ -28,7 +28,7 @@ interface RaphaelElement {
     animateWith(el: RaphaelElement, anim: RaphaelAnimation, params: any, ms: number, easing?: string, callback?: Function): RaphaelElement;
     animateWith(el: RaphaelElement, anim: RaphaelAnimation, animation: RaphaelAnimation): RaphaelElement;
     attr(attrName: string, value: any): RaphaelElement;
-    attr(params: { [key: string]: any; }): RaphaelElement;
+    attr(params: any): RaphaelElement;
     attr(attrName: string): any;
     attr(attrNames: string[]): any[];
     click(handler: Function): RaphaelElement;
@@ -228,13 +228,13 @@ interface RaphaelStatic {
     (container: HTMLElement, width: number, height: number, callback?: Function): RaphaelPaper;
     (container: string, width: number, height: number, callback?: Function): RaphaelPaper;
     (x: number, y: number, width: number, height: number, callback?: Function): RaphaelPaper;
-    (all: Array, callback?: Function): RaphaelPaper;
+    (all: any[], callback?: Function): RaphaelPaper;
     (onReadyCallback?: Function): RaphaelPaper;
 
     angle(x1: number, y1: number, x2: number, y2: number, x3?: number, y3?: number): number;
     animation(params: any, ms: number, easing?: string, callback?: Function): RaphaelAnimation;
     bezierBBox(p1x: number, p1y: number, c1x: number, c1y: number, c2x: number, c2y: number, p2x: number, p2y: number): { min: { x: number; y: number; }; max: { x: number; y: number; }; };
-    bezierBBox(bez: Array): { min: { x: number; y: number; }; max: { x: number; y: number; }; };
+    bezierBBox(bez: any[]): { min: { x: number; y: number; }; max: { x: number; y: number; }; };
     color(clr: string): { r: number; g: number; b: number; hex: string; error: boolean; h: number; s: number; v: number; l: number; };
     createUUID(): string;
     deg(deg: number): number;
@@ -269,7 +269,7 @@ interface RaphaelStatic {
     path2curve(pathString: string): string[];
     path2curve(pathString: string[]): string[];
     pathBBox(path: string): BoundingBox;
-    pathIntersection(path1: string, path2: string): { x: number; y: number; t1: number; t2: number; segment1: number; segment2: number; bez1: Array; bez2: Array; }[];
+    pathIntersection(path1: string, path2: string): { x: number; y: number; t1: number; t2: number; segment1: number; segment2: number; bez1: any[]; bez2: any[]; }[];
     pathToRelative(pathString: string): string[];
     pathToRelative(pathString: string[]): string[];
     rad(deg: number): number;

--- a/should/should.d.ts
+++ b/should/should.d.ts
@@ -37,7 +37,7 @@ interface ShouldAssertion {
   property(name: string, val: any, description?: string): ShouldAssertion;
   ownProperty(name: string, description?: string): ShouldAssertion;
   include(obj: any, description?: string): ShouldAssertion;
-  includeEql(obj: Array, description?: string): ShouldAssertion;
+  includeEql(obj: any[], description?: string): ShouldAssertion;
   contain(obj: any): ShouldAssertion;
   keys(...allKeys: string[]): ShouldAssertion;
   keys(allKeys: string[]): ShouldAssertion;

--- a/soundjs/soundjs.d.ts
+++ b/soundjs/soundjs.d.ts
@@ -159,7 +159,7 @@ declare module createjs {
         static PLAY_INITED: string;
         static PLAY_INTERRUPTED: string;
         static PLAY_SUCCEEDED: string;
-		static SUPPORTED_EXTENSIONS: Array;
+		static SUPPORTED_EXTENSIONS: any[];
 		static EXTENSION_MAP: Object;
 		static defaultInterruptBehavior: string;
 
@@ -179,7 +179,7 @@ declare module createjs {
         static registerPlugin(plugin: Object): boolean;
         static registerPlugins(plugins: Object[]): boolean;
 		static registerSound(src: Object, id?: string, data?: Object, preload?: boolean): Object;
-		static registerManifest(manifest: Array);
+		static registerManifest(manifest: any[]);
         static resume(id: string): void;
         static setMasterVolume(value: number): boolean;
         static setMute(isMuted: boolean): boolean;

--- a/swiper/swiper.d.ts
+++ b/swiper/swiper.d.ts
@@ -90,7 +90,7 @@ interface SwiperOptions {
 
     // Slides Loader
     loader?: {
-        slides?: Array;
+        slides?: any[];
         slidesHTMLType?: string;
         surroundGroups?: number;
         logic?: string;
@@ -178,7 +178,7 @@ declare class Swiper {
     setWrapperTransition(duration): void;
 
     // Slides API
-    slides: Array<SwiperSlide>;
+    slides: SwiperSlide[];
     createSlide(html: string, slideClassList?: string, element?: string): SwiperSlide;
     appendSlide(html: string, slideClassList?: string, element?: string): SwiperSlide;
     appendSlide(slideInstance: HTMLElement): SwiperSlide;

--- a/underscore.string/underscore.string.d.ts
+++ b/underscore.string/underscore.string.d.ts
@@ -30,7 +30,7 @@ declare module 'underscore.string' {
      * @param str String to chop
      * @param step Size of the pieces
      */
-    function chop(str: string, step: number): Array;
+    function chop(str: string, step: number): any[];
 
     /**
      * Compress some whitespaces to one.
@@ -52,7 +52,7 @@ declare module 'underscore.string' {
      * ('Hello') => ['H','e','l','l','o']
      * @param str
      */
-    function chars(str: string): Array;
+    function chars(str: string): any[];
 
     /**
      * Returns a copy of the string in which all the case-based characters have had their case swapped.
@@ -127,7 +127,7 @@ declare module 'underscore.string' {
      * ('Hello\nWorld') => ['Hello', 'World']
      * @param str
      */
-    function lines(str: string): Array;
+    function lines(str: string): any[];
 
     /**
      * Return reversed string.
@@ -279,7 +279,7 @@ declare module 'underscore.string' {
      * @param str
      * @param delimiter
      */
-    function words(str: string, delimiter?: string): Array;
+    function words(str: string, delimiter?: string): any[];
 
     /**
      * Pads a string with characters until the total string length is equal to the passed length parameter.
@@ -435,7 +435,7 @@ declare module 'underscore.string' {
      * @param lastSeparator
      * @param serial
      */
-    function toSentence(array: Array, separator?: string, lastSeparator?: string, serial?: boolean): string;
+    function toSentence(array: any[], separator?: string, lastSeparator?: string, serial?: boolean): string;
 
     /**
      * The same as toSentence, but uses ', ' as default for lastSeparator.
@@ -443,7 +443,7 @@ declare module 'underscore.string' {
      * @param separator
      * @param lastSeparator
      */
-    function toSentenceSerial(array: Array, separator?: string, lastSeparator?: string): string;
+    function toSentenceSerial(array: any[], separator?: string, lastSeparator?: string): string;
 
     /**
      * Transform text into a URL slug. Replaces whitespaces, accentuated, and special characters with a dash.
@@ -523,6 +523,6 @@ declare module 'underscore.string' {
      * @param trueValues
      * @param falseValues
      */
-    function toBoolean(str: string, trueValues?: Array, falseValues?: Array): boolean;
+    function toBoolean(str: string, trueValues?: any[], falseValues?: any[]): boolean;
 
 }

--- a/zepto/zepto.d.ts
+++ b/zepto/zepto.d.ts
@@ -1407,7 +1407,7 @@ interface ZeptoCollection {
 	* Serialize form into an array of objects with name and value properties. Disabled form controls, buttons, and unchecked radio buttons/checkboxes are skipped. The result doesn’t include data from file inputs.
 	* @return Array with name value pairs from the Form.
 	**/
-	serializeArray(): Array;
+	serializeArray(): any[];
 
 	/**
 	* Trigger or attach a handler for the submit event. When no function given, trigger the “submit” event on the current form and have it perform its submit action unless preventDefault() was called for the event.


### PR DESCRIPTION
Starting a new pull request as I can't see how I can modify the old one before reopening.  Removed the extra character from zepto.d.ts (not sure how it got there) and reverting the changes to ember (I didn't notice it has its own class called Array).

TypeScript 0.9.5 beta does not allow generic type references without the type argument.  This code will still compile for 0.9.1 users.  Flight and Ember have further compile problems in 0.9.5 that I don't feel qualified to address as I'm not versed in those libraries.
