### PR TITLE
jQuery: Added missing overloads with tests + contributors to head

### DIFF
--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -704,6 +704,13 @@ function test_click() {
     $("p").click();
 }
 
+function test_submit() {
+    $("#target").submit(function () {
+        alert("Handler for .submit() called.");
+    });
+    $("#target").submit();
+}
+
 function test_clone() {
     $('.hello').clone().appendTo('.goodbye');
     var $elem = $('#elem').data({ "arr": [1] }),
@@ -896,6 +903,7 @@ function test_dblclick() {
     divdbl.dblclick(function () {
         divdbl.toggleClass('dbl');
     });
+	$('#target').dblclick();
 }
 
 function test_deferred() {

--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -646,6 +646,7 @@ function test_change() {
         $('.target').change();
     });
     $("input[type='text']").change(function () { });
+    $("input[type='text']").change();
 }
 
 function test_children() {

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -678,6 +678,10 @@ interface JQuery {
     change(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
 
     /**
+     * Trigger the "click" event on an element.
+     */
+    click(): JQuery;
+    /**
      * Bind an event handler to the "click" JavaScript event
      *
      * @param eventData An object containing data that will be passed to the event handler.
@@ -691,6 +695,10 @@ interface JQuery {
      */
     click(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
 
+    /**
+     * Trigger the "dblclick" event on an element.
+     */
+    dblclick(): JQuery;
     /**
      * Bind an event handler to the "dblclick" JavaScript event
      *
@@ -707,6 +715,10 @@ interface JQuery {
 
     delegate(selector: any, eventType: string, handler: (eventObject: JQueryEventObject) => any): JQuery;
 
+    /**
+     * Trigger the "focus" event on an element.
+     */
+    focus(): JQuery;
     /**
      * Bind an event handler to the "focus" JavaScript event
      *
@@ -753,6 +765,10 @@ interface JQuery {
     hover(handlerInOut: (eventObject: JQueryEventObject) => any): JQuery;
 
     /**
+     * Trigger the "keydown" event on an element.
+     */
+    keydown(): JQuery;
+    /**
      * Bind an event handler to the "keydown" JavaScript event
      *
      * @param handler A function to execute each time the event is triggered.
@@ -767,6 +783,10 @@ interface JQuery {
     keydown(eventData?: any, handler?: (eventObject: JQueryKeyEventObject) => any): JQuery;
 
     /**
+     * Trigger the "keypress" event on an element.
+     */
+    keypress(): JQuery;
+    /**
      * Bind an event handler to the "keypress" JavaScript event
      *
      * @param handler A function to execute each time the event is triggered.
@@ -780,6 +800,10 @@ interface JQuery {
      */
     keypress(eventData?: any, handler?: (eventObject: JQueryKeyEventObject) => any): JQuery;
 
+    /**
+     * Trigger the "keyup" event on an element.
+     */
+    keyup(): JQuery;
     /**
      * Bind an event handler to the "keyup" JavaScript event
      *
@@ -850,6 +874,10 @@ interface JQuery {
     select(handler: (eventObject: JQueryEventObject) => any): JQuery;
     select(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
 
+    /**
+     * Trigger the "submit" event on an element.
+     */
+    submit(): JQuery;
     /**
      * Bind an event handler to the "submit" JavaScript event
      *

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -13,7 +13,10 @@ See the Apache Version 2.0 License for specific language governing permissions
 and limitations under the License.
 ***************************************************************************** */
 
-// Typing for the jQuery library, version 2.0.x
+// Typing for the jQuery library, version 1.10.x / 2.0.x
+// Project: http://jquery.com/
+// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Christian Hoffmeister <https://github.com/choffmeister>, Steve Fenton, Diullei Gomes <https://github.com/Diullei>, Tass Iliopoulos <https://github.com/tasoili>, Jason Swearingen, Sean Hill <https://github.com/seanski>, Guus Goossens <https://github.com/Guuz>, Kelly Summerlin <https://github.com/ksummerlin>, Basarat Ali Syed <https://github.com/basarat>, Nicholas Wolverson <https://github.com/nwolverson>, Derek Cicerone <https://github.com/derekcicerone>, Andrew Gaspar <https://github.com/AndrewGaspar>, James Harrison Fisher <https://github.com/jameshfisher>, Seikichi Kondo <https://github.com/seikichi>, Benjamin Jackman <https://github.com/benjaminjackman>, Poul Sorensen <https://github.com/s093294>, Josh Strobl <https://github.com/JoshStrobl>, John Reilly <https://github.com/johnnyreilly/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /*
     Interface for the AJAX setting that will configure the AJAX request
@@ -656,6 +659,10 @@ interface JQuery {
     blur(handler: (eventObject: JQueryEventObject) => any): JQuery;
     blur(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
 
+    /**
+     * Trigger the "change" event on an element.
+     */
+    change(): JQuery;
     /**
      * Bind an event handler to the "change" JavaScript event
      *


### PR DESCRIPTION
Hi Guys,

I added a number of missing overloads (with tests where necessary) and their associated JSDoc comments.

I also added all identifiable contributors to this file to the header.  Finally I amended the version to reflect that it supports both the 1.10.x / 2.0.x jQuery code branches (these both share the same API but under the cover the 2.0.x branch doesn't support IE 6 - 8)
