### PR TITLE
Fix Node url.format() param type

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -4,6 +4,7 @@ import assert = require("assert");
 import fs = require("fs");
 import events = require("events");
 import zlib = require("zlib");
+import url = require('url');
 
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
@@ -38,6 +39,18 @@ class Networker extends events.EventEmitter {
         this.emit("mingling");
     }
 }
+
+url.format(url.parse('http://www.example.com/xyz'));
+
+// https://google.com/search?q=you're%20a%20lizard%2C%20gary
+url.format({
+    protocol: 'https', 
+    host: "google.com", 
+    pathname: 'search', 
+    query: { q: "you're a lizard, gary" }
+});
+
+
 
 ////////////////////////////////////////////////////
 /// Stream tests : http://nodejs.org/api/stream.html

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -599,8 +599,19 @@ declare module "url" {
         slashes: boolean;
     }
 
+    export interface UrlOptions {
+        protocol?: string;
+        auth?: string;
+        hostname?: string;
+        port?: string;
+        host?: string;
+        pathname?: string;
+        search?: string;
+        query?: any;
+    }
+
     export function parse(urlStr: string, parseQueryString?: boolean , slashesDenoteHost?: boolean ): Url;
-    export function format(url: Url): string;
+    export function format(url: UrlOptions): string;
     export function resolve(from: string, to: string): string;
 }
 


### PR DESCRIPTION
url.format() doesn't need all of the properties of the Url type returned from url.parse(), and some properties are different types (like `query` can be an object) so this changes it to use a separate UrlOptions interface.

Updated test script to check this works and to check that you can still pass in an Url.
