### PR TITLE
Fix too restrictive sortable options.

### DIFF
--- a/jqueryui/jqueryui.d.ts
+++ b/jqueryui/jqueryui.d.ts
@@ -463,8 +463,8 @@ declare module JQueryUI {
     interface SortableOptions {
         appendTo?: any; // jQuery, Element, Selector or string
         axis?: string;
-        cancel?: string;
-        connectWith?: string;
+        cancel?: any; // Selector
+        connectWith?: any; // Selector
         containment?: any; // Element, Selector or string
         cursor?: string;
         cursorAt?: any;


### PR DESCRIPTION
From jquery docs: "If Selector is specified as the type of an argument, it accepts everything that the jQuery constructor accepts, eg. Strings, Elements, Lists of Elements." - http://api.jquery.com/Types/#Selector
