### PR TITLE
knockout.projections: Created typings and tests

### DIFF
--- a/knockout.projections/knockout.projections-tests.ts
+++ b/knockout.projections/knockout.projections-tests.ts
@@ -1,0 +1,30 @@
+// Type definitions for knockout-projections 1.0.0
+// Project: https://github.com/stevesanderson/knockout-projections
+// Definitions by: John Reilly <https://github.com/johnnyreilly>
+
+/// <reference path="../knockout/knockout.d.ts" />
+/// <reference path="knockout.projections.d.ts" />
+
+// Test map
+var sourceItems = ko.observableArray([1, 2, 3, 4, 5]);
+var squares = sourceItems.map(function (x) { return x * x; });
+var squaresAsStrings = sourceItems.map(function (x) { return (x * x).toString(); });
+
+sourceItems.push(6);
+// 'squares' has automatically updated and now contains [1, 4, 9, 16, 25, 36]
+// 'squaresAsStrings' has automatically updated and now contains ['1', '4', '9', '16', '25', '36']
+
+sourceItems.reverse();
+// 'squares' now contains [36, 25, 16, 9, 4, 1]
+// 'squaresAsStrings' now contains ['36', '25', '16', '9', '4', '1']
+
+// Test Filtering
+
+var evenSquares = squares.filter(function (x) { return x % 2 === 0; });
+// evenSquares is now an observable containing [36, 16, 4]
+
+sourceItems.push(9);
+// This has no effect on evenSquares, because 9*9=81 is odd
+
+sourceItems.push(10);
+// evenSquares now contains [36, 16, 4, 100]

--- a/knockout.projections/knockout.projections-tests.ts
+++ b/knockout.projections/knockout.projections-tests.ts
@@ -1,6 +1,4 @@
-// Type definitions for knockout-projections 1.0.0
-// Project: https://github.com/stevesanderson/knockout-projections
-// Definitions by: John Reilly <https://github.com/johnnyreilly>
+// Tests for knockout.projections.d.ts
 
 /// <reference path="../knockout/knockout.d.ts" />
 /// <reference path="knockout.projections.d.ts" />

--- a/knockout.projections/knockout.projections.d.ts
+++ b/knockout.projections/knockout.projections.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for knockout-projections 1.0.0
+// Project: https://github.com/stevesanderson/knockout-projections
+// Definitions by: John Reilly <https://github.com/johnnyreilly>
+
+/// <reference path="../knockout/knockout.d.ts" />
+
+interface KnockoutObservableArrayFunctions<T> {
+
+    map<TResult>(mapping: (value: T) => TResult): KnockoutObservableArray<TResult>;
+    filter(predicate: (value: T) => boolean): KnockoutObservableArray<T>;
+}


### PR DESCRIPTION
Created a typings file for [knockout-projections](https://github.com/stevesanderson/knockout-projections) which has just been open sourced:  http://blog.stevensanderson.com/2013/12/03/knockout-projections-a-plugin-for-efficient-observable-array-transformations/

Even though the name of the library is "knockout-projections" I have called the typings "knockout.projections" to follow the existing standard being used for knockout related typings in DefinitelyTyped.  I hope that's correct?
