### PR TITLE
Added missing tests.

### DIFF
--- a/routie/routie-tests.ts
+++ b/routie/routie-tests.ts
@@ -1,0 +1,57 @@
+/// <reference path="routie.d.ts" />
+
+// BASIC
+
+// There are three ways to call routie. Here is the most basic way:
+
+routie("users", function () {
+    // This gets called when hash == #users
+});
+
+// If you want to define multiple routes you can pass in an object like this: 
+
+routie({
+    "users": function () {
+    },
+    "about": function () {
+    }
+});
+
+// If you want to trigger a route manually, you can call routie like this: 
+
+routie("users/bob");  // window.location.hash will be #users/bob
+
+// ADVANCED
+
+// Routie also supports regex style routes, so you can do advanced routing like this:
+
+routie("users/:name", function (name) {
+    // name == "bob";
+});
+
+routie("users/bob");
+
+// Optional params:
+
+routie("users/?:name", function (name) {
+    //name == undefined
+    //then
+    //name == bob
+});
+
+routie("users/");
+routie("users/bob");
+
+// Wildcard: 
+
+routie("users/*", function () {
+});
+
+routie("users/12312312");
+
+// Catch all:
+
+routie("*", function () {
+});
+
+routie("anything");

--- a/routie/routie.d.ts
+++ b/routie/routie.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 interface Route {
-    constructor(path: string, name: string);
+    constructor(path: string, name: string): Route;
     addHandler(fn: Function): void;
     removeHandler(fn: Function): void;
     run(params: any): void;


### PR DESCRIPTION
- Added routie-tests.ts file
- Tweaked definition file for compilation using tsc --noImplicitAny

Note that the 'Route' interface is not referenced elsewhere in the definition file nor in the new tests file. I've added a return type of 'Route' to the constructor property of this interface, in place of the implicit 'any'. This seemed the most logical way to support the compilation requirements for the pull request. However, I cannot be 100% sure as it isn't clear what this interface, in particular the constructor property, is intended for.
