### PR TITLE
Added new type definition library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Other means to get the definitions
 List of Definitions
 -------------------
 * [Ace Cloud9 Editor](http://ace.ajax.org/) (by [Diullei Gomes](https://github.com/Diullei))
+* [Add To Home Screen] (http://cubiq.org/add-to-home-screen) (by [James Wilkins] (http://www.codeplex.com/site/users/view/jamesnw))
 * [AmCharts](http://www.amcharts.com/) (by [Covobonomo](https://github.com/covobonomo/))
 * [AngularJS](http://angularjs.org) (by [Diego Vilar](https://github.com/diegovilar)) ([wiki](https://github.com/borisyankov/DefinitelyTyped/wiki/AngularJS-Definitions-Usage-Notes))
 * [Arbiter](http://arbiterjs.com/) (by [Arash Shakery](https://github.com/arash16))

--- a/add2home/add2home-tests.ts
+++ b/add2home/add2home-tests.ts
@@ -1,0 +1,5 @@
+/// <reference path="add2home.d.ts" />
+
+addToHome.show(false);
+addToHome.close();
+addToHome.reset();

--- a/add2home/add2home.d.ts
+++ b/add2home/add2home.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for add2home v2.0.5
+// Project: http://cubiq.org/add-to-home-screen
+// Definitions by: James Wilkins <http://www.codeplex.com/site/users/view/jamesnw>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare var addToHome: {
+    /** Shows the popup.
+    * @param {boolean} overrideChecks Override all the compatibility checks and always show the popup.
+    */
+    show: (overrideChecks: boolean) => void;
+    /** Closes the popup. */
+    close: () => void;
+    /** Reset the local and session storages so the popup will show again (for automatic mode - has no affect if manually opening the popup). */
+    reset: () => void;
+};


### PR DESCRIPTION
Added add2home (Add To home Screen) for iPhone and iPad apps.  The library's purpose is to show a popup bubble to notify/remind users that they can add the app to the devices home screen.
