### PR TITLE
Fix $.attrs(object) for TS 0.9.5.

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -647,8 +647,8 @@ interface JQuery {
 
     attr(attributeName: string): string;
     attr(attributeName: string, value: any): JQuery;
-    attr(map: { [key: string]: any; }): JQuery;
     attr(attributeName: string, func: (index: any, attr: any) => any): JQuery;
+    attr(map: any): JQuery;
 
     hasClass(className: string): boolean;
 


### PR DESCRIPTION
Since TS 0.9.5, "{ [key: string]: any; }" does not map to literal objects anymore.
Accepting "any" is then required to accept object maps in attrs(). This shouldn't affect 0.9x.
