### PR TITLE
Update util.inspect API.

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -5,6 +5,7 @@ import fs = require("fs");
 import events = require("events");
 import zlib = require("zlib");
 import url = require('url');
+import util = require("util");
 
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
@@ -50,7 +51,9 @@ url.format({
     query: { q: "you're a lizard, gary" }
 });
 
-
+// Old and new util.inspect APIs
+util.inspect(["This is nice"], false, 5);
+util.inspect(["This is nice"], { colors: true, depth: 5, customInspect: false });
 
 ////////////////////////////////////////////////////
 /// Stream tests : http://nodejs.org/api/stream.html

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1074,6 +1074,13 @@ declare module "stream" {
 }
 
 declare module "util" {
+    export interface InspectOptions {
+        showHidden?: boolean;
+        depth?: number;
+        colors?: boolean;
+        customInspect?: boolean;
+    }
+
     export function format(format: any, ...param: any[]): string;
     export function debug(string: string): void;
     export function error(...param: any[]): void;
@@ -1081,6 +1088,7 @@ declare module "util" {
     export function print(...param: any[]): void;
     export function log(string: string): void;
     export function inspect(object: any, showHidden?: boolean, depth?: number, color?: boolean): string;
+    export function inspect(object: any, options: InspectOptions): string;
     export function isArray(object: any): boolean;
     export function isRegExp(object: any): boolean;
     export function isDate(object: any): boolean;


### PR DESCRIPTION
Latest API has an options object as the second parameter
instead of separate parameters. The old API is still supported
so have added the new signature as an overload.

ref http://nodejs.org/api/util.html#util_util_inspect_object_options

Updated node-tests.ts
