### PR TITLE
ix.js: aligned with 0.9.5

### DIFF
--- a/ix.js/ix.d.ts
+++ b/ix.js/ix.d.ts
@@ -48,7 +48,7 @@ declare module Ix {
 
 		startWith(...values: T[]): Enumerable<T>;
 
-		scan<TSeed, TAccumulator>(seed: TSeed, accumulate: (acc: TAccumulator, item: T) => TAccumulator): Enumerable<TAccumulator>;
+		scan<TAccumulate>(seed: TAccumulate, accumulate: (acc: TAccumulate, item: T) => TAccumulate): Enumerable<TAccumulate>;
 		scan(accumulate: (acc: T, item: T) => T): Enumerable<T>;
 
 		takeLast(count: number): Enumerable<T>;

--- a/ix.js/l2o-tests.ts
+++ b/ix.js/l2o-tests.ts
@@ -41,7 +41,7 @@ ax.aggregate("", (acc, i) => acc + i, acc=> acc.length);
 ax.aggregate("", (acc, i) => acc + i);
 ax.aggregate((acc, i) => acc + i);
 
-ax.reduce((acc, i) => acc + i, 100);
+//ax.reduce((acc, i) => acc + i, 100);	// bug: https://typescript.codeplex.com/workitem/1960
 ax.reduce((acc, i) => acc + i);
 
 ax.all(item => true);
@@ -83,7 +83,7 @@ dx.distinct((d1, d2) => d1 === d2);
 ax.elementAt(2);
 ax.elementAtOrDefault(2);
 
-//ax.except(bx, ec_ns);	// bug https://typescript.codeplex.com/workitem/1841
+ax.except(bx, ec_ns);
 bx.except(fx);
 
 ax.first();
@@ -96,14 +96,14 @@ ax.singleOrDefault();
 ax.forEach(a => console.log(a));
 ax.forEach(a => console.log(a), cx);
 
-//bx.groupBy(b => b.length);						// spec 3.5.2, waiting for restriction on generative recursion removal
+bx.groupBy(b => b.length);
 bx.groupBy(b => b.length, b => "[" + b + "]");
 bx.groupBy(b => b.length, b => "[" + b + "]", (l, values) => l + values.count());
 bx.groupBy(b => b.length, false, (l, values) => l + values.count());
 bx.groupBy(b => b.length, b => "[" + b + "]", (l, values) => l + values.count(), ec_nn);
 bx.groupBy(b => b.length, b => "[" + b + "]", false, (x, y) => x == y);
 bx.groupBy(b => b.length, false, (l, values) => l + values.count(), ec_nn);
-//bx.groupBy(b => b.length, false, false, ec_nn);	// spec 3.5.2, waiting for restriction on generative recursion removal
+bx.groupBy(b => b.length, false, false, ec_nn);
 
 ax.groupJoin(bx, a => a, b => b, (a, b) => [a, b], ec_ns);
 ax.groupJoin(bx, a => a, b => b.length, (a, b) => [a, b]);
@@ -111,7 +111,7 @@ ax.groupJoin(bx, a => a, b => b.length, (a, b) => [a, b]);
 ax.join(bx, a => a, b => b, (a, b) => [a, b], ec_ns);
 ax.join(bx, a => a, b => b.length, (a, b) => [a, b]);
 
-//ax.intersect(bx, ec_ns);	// bug https://typescript.codeplex.com/workitem/1841
+ax.intersect(bx, ec_ns);
 ax.intersect(cx);
 ax.union(cx);
 
@@ -142,14 +142,14 @@ ax.takeWhile(a => a > 10);
 ax.toArray();
 
 bx.toDictionary(b => b.length, b => 10, ec_nn);
-//bx.toDictionary(b => b.length, false, ec_nn);	// spec 3.5.2, waiting for restriction on generative recursion removal
+bx.toDictionary(b => b.length, false, ec_nn);
 bx.toDictionary(b => b.length, b => 10);
-//bx.toDictionary(b => b.length);				// spec 3.5.2, waiting for restriction on generative recursion removal
+bx.toDictionary(b => b.length);
 
 bx.toLookup(b => b.length, b => 10, ec_nn);
-//bx.toLookup(b => b.length, false, ec_nn);		// spec 3.5.2, waiting for restriction on generative recursion removal
+bx.toLookup(b => b.length, false, ec_nn);
 bx.toLookup(b => b.length, b => 10);
-//bx.toLookup(b => b.length);					// spec 3.5.2, waiting for restriction on generative recursion removal
+bx.toLookup(b => b.length);
 
 ax.where(a=> a > 10, {});
 ax.where(a=> a > 10);

--- a/ix.js/l2o-tests.ts
+++ b/ix.js/l2o-tests.ts
@@ -42,6 +42,7 @@ ax.aggregate("", (acc, i) => acc + i);
 ax.aggregate((acc, i) => acc + i);
 
 //ax.reduce((acc, i) => acc + i, 100);	// bug: https://typescript.codeplex.com/workitem/1960
+ax.reduce<number>((acc, i) => acc + i, 100);
 ax.reduce((acc, i) => acc + i);
 
 ax.all(item => true);

--- a/ix.js/l2o.d.ts
+++ b/ix.js/l2o.d.ts
@@ -91,9 +91,8 @@ declare module Ix {
 		groupBy<TKey, TElement>(
 			keySelector: (item: T) => TKey,
 			elementSelector: (item: T) => TElement): Grouping<TKey, TElement>;
-		// spec 3.5.2, waiting for restriction on generative recursion removal
-		/*groupBy<TKey>(
-			keySelector: (item: T) => TKey): Grouping<TKey, T>;*/
+		groupBy<TKey>(
+			keySelector: (item: T) => TKey): Grouping<TKey, T>;
 
 		// if need to set comparer without resultSelector
 		groupBy<TKey, TElement>(
@@ -108,12 +107,11 @@ declare module Ix {
 			resultSelector: (key: TKey, values: Enumerable<T>) => TResult,
 			comparer?: EqualityComparer<TKey, TKey>): Enumerable<TResult>;
 		// if need to set comparer without elementSelector and resultSelector
-		// spec 3.5.2, waiting for restriction on generative recursion removal
-		/*groupBy<TKey>(
+		groupBy<TKey>(
 			keySelector: (item: T) => TKey,
 			_: boolean,
 			__: boolean,
-			comparer: EqualityComparer<TKey, TKey>): Grouping<TKey, T>;*/
+			comparer: EqualityComparer<TKey, TKey>): Grouping<TKey, T>;
 
 		groupJoin<TInner, TOuterKey, TInnerKey, TResult>(
 			inner: Enumerable<TInner>,
@@ -169,29 +167,25 @@ declare module Ix {
 			keySelector: (item: T) => TKey,
 			elementSelector: (item: T) => TValue,
 			comparer?: EqualityComparer<TKey, TKey>): Dictionary<TKey, TValue>;
-		// spec 3.5.2, waiting for restriction on generative recursion removal
-		/*toDictionary<TKey>(
-			keySelector: (item: T) => TKey): Dictionary<TKey, T>;*/
+		toDictionary<TKey>(
+			keySelector: (item: T) => TKey): Dictionary<TKey, T>;
 		// if need to set comparer without elementSelector
-		// spec 3.5.2, waiting for restriction on generative recursion removal
-		/*toDictionary<TKey>(
+		toDictionary<TKey>(
 			keySelector: (item: T) => TKey,
 			_: boolean,
-			comparer: EqualityComparer<TKey, TKey>): Dictionary<TKey, T>;*/
+			comparer: EqualityComparer<TKey, TKey>): Dictionary<TKey, T>;
 
 		toLookup<TKey, TValue>(
 			keySelector: (item: T) => TKey,
 			elementSelector: (item: T) => TValue,
 			comparer?: EqualityComparer<TKey, TKey>): Lookup<TKey, TValue>;
-		// spec 3.5.2, waiting for restriction on generative recursion removal
-		/*toLookup<TKey>(
-			keySelector: (item: T) => TKey): Lookup<TKey, T>;*/
+		toLookup<TKey>(
+			keySelector: (item: T) => TKey): Lookup<TKey, T>;
 		// if need to set comparer without elementSelector
-		// spec 3.5.2, waiting for restriction on generative recursion removal
-		/*toLookup<TKey>(
+		toLookup<TKey>(
 			keySelector: (item: T) => TKey,
 			_: boolean,
-			comparer: EqualityComparer<TKey, TKey>): Lookup<TKey, T>;*/
+			comparer: EqualityComparer<TKey, TKey>): Lookup<TKey, T>;
 
 		where(selector: EnumerablePredicate<T>, thisArg?: any): Enumerable<T>;
 		filter(selector: EnumerablePredicate<T>, thisArg?: any): Enumerable<T>;


### PR DESCRIPTION
Added overloads of some functions that get work in 0.9.5 after removing restriction on generative recursion from TypeScript's spec.
