### PR TITLE
Fixed KnockoutComputed polymorphism

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -68,11 +68,8 @@ interface KnockoutComputedStatic {
     (options?: any): KnockoutComputed<any>;
 }
 
-interface KnockoutComputed<T> extends KnockoutSubscribable<T>, KnockoutComputedFunctions<T> {
-	(): T;
-	(value: T): void;
-
-	peek(): T;
+interface KnockoutComputed<T> extends KnockoutObservable<T>, KnockoutComputedFunctions<T> {
+	
 	dispose(): void;
 	isActive(): boolean;
 	getDependenciesCount(): number;
@@ -100,8 +97,8 @@ interface KnockoutObservable<T> extends KnockoutSubscribable<T>, KnockoutObserva
 	(value: T): void;
 
 	peek(): T;
-	valueHasMutated(): void;
-	valueWillMutate(): void;
+	valueHasMutated?:{(): void;};
+	valueWillMutate?:{(): void;};
     extend(requestedExtenders: { [key: string]: any; }): KnockoutObservable<T>;
 }
 

--- a/knockout/tests/knockout-tests.ts
+++ b/knockout/tests/knockout-tests.ts
@@ -570,4 +570,17 @@ function test_misc() {
     ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
         $(element).datepicker("destroy");
     });
+	
+	this.observableFactory = function(): KnockoutObservable<number>{
+	    if (true) {
+			return ko.computed({
+				read:function(){ 
+					return 3; 
+				}
+			});
+		} else {
+			return ko.observable(3);
+		}
+	}
+	
 }


### PR DESCRIPTION
Previously it was difficult to do polymorphic/covariant hotness such as...

``` javascript
function getSomething(): KnockoutObservable<T> {
    if (something) {
        return ko.computed(...);
    } else {
        return ko.observable(...);
    }
}
```

...because KnockoutComputed was not typed as a valid KnockoutObservable.

I updated KnockoutComputed to inherit from KnockoutObservable, therefore enabling this situation.
