### PR TITLE
Rename Timer to NodeTimer

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -15,10 +15,10 @@ declare var global: any;
 declare var __filename: string;
 declare var __dirname: string;
 
-declare function setTimeout(callback: (...args: any[]) => void , ms: number , ...args: any[]): Timer;
-declare function clearTimeout(timeoutId: Timer): void;
-declare function setInterval(callback: (...args: any[]) => void , ms: number , ...args: any[]): Timer;
-declare function clearInterval(intervalId: Timer): void;
+declare function setTimeout(callback: (...args: any[]) => void , ms: number , ...args: any[]): NodeTimer;
+declare function clearTimeout(timeoutId: NodeTimer): void;
+declare function setInterval(callback: (...args: any[]) => void , ms: number , ...args: any[]): NodeTimer;
+declare function clearInterval(intervalId: NodeTimer): void;
 declare function setImmediate(callback: (...args: any[]) => void , ...args: any[]): any;
 declare function clearImmediate(immediateId: any): void;
 
@@ -198,7 +198,7 @@ interface NodeBuffer {
     INSPECT_MAX_BYTES: number;
 }
 
-interface Timer {
+interface NodeTimer {
     ref() : void;
     unref() : void;
 }


### PR DESCRIPTION
This commit fixes #1321
[We discussed it.](https://github.com/borisyankov/DefinitelyTyped/pull/1321#discussion_r7878861)
