### PR TITLE
Added iScroll 5 typings

### DIFF
--- a/iscroll/iscroll-5-lite.d.ts
+++ b/iscroll/iscroll-5-lite.d.ts
@@ -1,0 +1,48 @@
+// Type definitions for iScroll Lite 4.1
+// Project: http://cubiq.org/iscroll-4
+// Definitions by: Boris Yankov <https://github.com/borisyankov/> and Christiaan Rakowski <https://github.com/csrakowski/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+
+interface iScrollEvent {
+    (e: Event): void;
+}
+
+interface iScrollOptions {
+    hScroll?: boolean;
+    vScroll?: boolean;
+    x?: number;
+    y?: number;
+    bounce?: boolean;
+    bounceLock?: boolean;
+    momentum?: boolean;
+    lockDirection?: boolean;
+    useTransform?: boolean;
+    useTransition?: boolean;
+
+    // Events
+    onRefresh?: iScrollEvent;
+    onBeforeScrollStart?: iScrollEvent;
+    onScrollStart?: iScrollEvent;
+    onBeforeScrollMove?: iScrollEvent;
+    onScrollMove?: iScrollEvent;
+    onBeforeScrollEnd?: iScrollEvent;
+    onScrollEnd?: iScrollEvent;
+    onTouchEnd?: iScrollEvent;
+    onDestroy?: iScrollEvent;
+}
+
+declare class iScroll {
+
+    constructor (element: string, options?: iScrollOptions);
+	constructor (element: HTMLElement, options?: iScrollOptions);
+
+    destroy(): void;
+    refresh(): void;
+    scrollTo(x: number, y: number, time?: number, relative?: boolean): void;
+    scrollToElement(element: string, time?: number): void;
+    scrollToElement(element: HTMLElement, time?: number): void;
+    disable(): void;
+    enable(): void;
+    stop(): void;
+}

--- a/iscroll/iscroll-5-lite.d.ts
+++ b/iscroll/iscroll-5-lite.d.ts
@@ -20,7 +20,7 @@ interface IScrollOptions {
 	useTransition?: boolean;
 }
 
-declare class iScroll {
+declare class IScroll {
 
 	constructor (element: string, options?: IScrollOptions);
 	constructor (element: HTMLElement, options?: IScrollOptions);

--- a/iscroll/iscroll-5-lite.d.ts
+++ b/iscroll/iscroll-5-lite.d.ts
@@ -4,8 +4,12 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 interface IScrollOptions {
-	hScroll?: boolean;
-	vScroll?: boolean;
+	//hScroll?: boolean;
+	//vScroll?: boolean;
+
+	scrollX?: boolean;
+	scrollY?: boolean;
+
 	x?: number;
 	y?: number;
 	bounce?: boolean;
@@ -13,7 +17,7 @@ interface IScrollOptions {
 	momentum?: boolean;
 	lockDirection?: boolean;
 	useTransform?: boolean;
-	useTransition?: boolean;	
+	useTransition?: boolean;
 }
 
 declare class iScroll {

--- a/iscroll/iscroll-5-lite.d.ts
+++ b/iscroll/iscroll-5-lite.d.ts
@@ -1,48 +1,35 @@
-// Type definitions for iScroll Lite 4.1
-// Project: http://cubiq.org/iscroll-4
-// Definitions by: Boris Yankov <https://github.com/borisyankov/> and Christiaan Rakowski <https://github.com/csrakowski/>
+// Type definitions for iScroll Lite 5
+// Project: http://cubiq.org/iscroll-5-ready-for-beta-test
+// Definitions by: Christiaan Rakowski <https://github.com/csrakowski/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-
-interface iScrollEvent {
-    (e: Event): void;
-}
-
-interface iScrollOptions {
-    hScroll?: boolean;
-    vScroll?: boolean;
-    x?: number;
-    y?: number;
-    bounce?: boolean;
-    bounceLock?: boolean;
-    momentum?: boolean;
-    lockDirection?: boolean;
-    useTransform?: boolean;
-    useTransition?: boolean;
-
-    // Events
-    onRefresh?: iScrollEvent;
-    onBeforeScrollStart?: iScrollEvent;
-    onScrollStart?: iScrollEvent;
-    onBeforeScrollMove?: iScrollEvent;
-    onScrollMove?: iScrollEvent;
-    onBeforeScrollEnd?: iScrollEvent;
-    onScrollEnd?: iScrollEvent;
-    onTouchEnd?: iScrollEvent;
-    onDestroy?: iScrollEvent;
+interface IScrollOptions {
+	hScroll?: boolean;
+	vScroll?: boolean;
+	x?: number;
+	y?: number;
+	bounce?: boolean;
+	bounceLock?: boolean;
+	momentum?: boolean;
+	lockDirection?: boolean;
+	useTransform?: boolean;
+	useTransition?: boolean;	
 }
 
 declare class iScroll {
 
-    constructor (element: string, options?: iScrollOptions);
-	constructor (element: HTMLElement, options?: iScrollOptions);
+	constructor (element: string, options?: IScrollOptions);
+	constructor (element: HTMLElement, options?: IScrollOptions);
 
-    destroy(): void;
-    refresh(): void;
-    scrollTo(x: number, y: number, time?: number, relative?: boolean): void;
-    scrollToElement(element: string, time?: number): void;
-    scrollToElement(element: HTMLElement, time?: number): void;
-    disable(): void;
-    enable(): void;
-    stop(): void;
+	destroy(): void;
+	refresh(): void;
+	scrollTo(x: number, y: number, time?: number, relative?: boolean): void;
+	scrollToElement(element: string, time?: number): void;
+	scrollToElement(element: HTMLElement, time?: number): void;
+	disable(): void;
+	enable(): void;
+	stop(): void;
+
+	// Events
+	on: (type: string, fn: () => void) => void;
 }

--- a/iscroll/iscroll-5-tests.ts
+++ b/iscroll/iscroll-5-tests.ts
@@ -1,0 +1,31 @@
+/// <reference path="iscroll.d.ts" />
+
+var myScroll1 = new iScroll('wrapper');
+var myScroll2 = new iScroll('wrapper', { hScrollbar: false, vScrollbar: false });
+var myScroll3= new iScroll('wrapper', {
+    snap: true,
+    momentum: false,
+    hScrollbar: false,
+    vScrollbar: false
+});
+var myScroll4 = new iScroll('wrapper', {
+    snap: 'li',
+    momentum: false,
+    hScrollbar: false,
+    vScrollbar: false
+});
+var myScroll6 = new iScroll('wrapper', { scrollbarClass: 'myScrollbar' });
+
+myScroll1.refresh();
+myScroll1.scrollTo(0, 100);
+myScroll1.scrollTo(0, 100, 200);
+myScroll1.scrollTo(0, 100, 200, true);
+
+myScroll1.scrollToElement('selectedElement');
+myScroll1.scrollToElement('selectedElement', 250);
+
+myScroll1.scrollToElement(document.getElementById('selectedElement'));
+myScroll1.scrollToElement(document.getElementById('selectedElement'), 250);
+
+var myScroll7 = new iScroll(document.getElementById('wrapper'));
+var myScroll8 = new iScroll(document.getElementById('wrapper'), { scrollbarClass: 'myScrollbar' });

--- a/iscroll/iscroll-5-tests.ts
+++ b/iscroll/iscroll-5-tests.ts
@@ -1,20 +1,23 @@
-/// <reference path="iscroll.d.ts" />
+/// <reference path="iscroll-5.d.ts" />
 
-var myScroll1 = new iScroll('wrapper');
-var myScroll2 = new iScroll('wrapper', { hScrollbar: false, vScrollbar: false });
-var myScroll3= new iScroll('wrapper', {
+var myScroll1 = new IScroll('#wrapper');
+var myScroll2 = new IScroll('#wrapper', { hScrollbar: false, vScrollbar: false });
+var myScroll3 = new IScroll('#wrapper', {
     snap: true,
     momentum: false,
     hScrollbar: false,
     vScrollbar: false
 });
-var myScroll4 = new iScroll('wrapper', {
+var myScroll4 = new IScroll('#wrapper', {
     snap: 'li',
     momentum: false,
     hScrollbar: false,
     vScrollbar: false
 });
-var myScroll6 = new iScroll('wrapper', { scrollbarClass: 'myScrollbar' });
+var myScroll6 = new IScroll('#wrapper', { scrollbarClass: 'myScrollbar' });
+var myScroll7 = new IScroll('#wrapper', { bounceEasing: 'elastic', bounceTime: 1200 });
+
+var myScroll8 = new IScroll('#wrapper', { eventPassthrough: true, scrollX: true, scrollY: false, preventDefault: false });
 
 myScroll1.refresh();
 myScroll1.scrollTo(0, 100);
@@ -27,5 +30,7 @@ myScroll1.scrollToElement('selectedElement', 250);
 myScroll1.scrollToElement(document.getElementById('selectedElement'));
 myScroll1.scrollToElement(document.getElementById('selectedElement'), 250);
 
-var myScroll7 = new iScroll(document.getElementById('wrapper'));
-var myScroll8 = new iScroll(document.getElementById('wrapper'), { scrollbarClass: 'myScrollbar' });
+myScroll2.on('scrollStart', function () { console.log('scroll started'); });
+
+var myScroll9 = new IScroll(document.getElementById('wrapper'));
+var myScroll10 = new IScroll(document.getElementById('wrapper'), { scrollbarClass: 'myScrollbar' });

--- a/iscroll/iscroll-5.d.ts
+++ b/iscroll/iscroll-5.d.ts
@@ -1,0 +1,76 @@
+// Type definitions for iScroll 4.2
+// Project: http://cubiq.org/iscroll-4
+// Definitions by: Boris Yankov <https://github.com/borisyankov/> and Christiaan Rakowski <https://github.com/csrakowski/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+
+interface iScrollEvent {
+    (e: Event): void;
+}
+
+interface iScrollOptions {
+    hScroll?: boolean;
+    vScroll?: boolean;
+    x?: number;
+    y?: number;
+    bounce?: boolean;
+    bounceLock?: boolean;
+    momentum?: boolean;
+    lockDirection?: boolean;
+    useTransform?: boolean;
+    useTransition?: boolean;
+    topOffset?: number;
+    checkDOMChanges?: boolean;
+    handleClick?: boolean;
+
+    // Scrollbar
+    hScrollbar?: boolean;
+    vScrollbar?: boolean;
+    fixedScrollbar?: boolean;
+    hideScrollbar?: boolean;
+    fadeScrollbar?: boolean;
+    scrollbarClass?: string;
+
+    // Zoom
+    zoom?: boolean;
+    zoomMin?: number;
+    zoomMax?: number;
+    doubleTapZoom?: number;
+    wheelAction?: string;
+
+    // Snap
+    snap?: any;
+    snapThreshold?: number;
+
+    // Events
+    onRefresh?: iScrollEvent;
+    onBeforeScrollStart?: iScrollEvent;
+    onScrollStart?: iScrollEvent;
+    onBeforeScrollMove?: iScrollEvent;
+    onScrollMove?: iScrollEvent;
+    onBeforeScrollEnd?: iScrollEvent;
+    onScrollEnd?: iScrollEvent;
+    onTouchEnd?: iScrollEvent;
+    onDestroy?: iScrollEvent;
+    onZoomStart?: iScrollEvent;
+    onZoom?: iScrollEvent;
+    onZoomEnd?: iScrollEvent;
+}
+
+declare class iScroll {
+
+    constructor (element: string, options?: iScrollOptions);
+	constructor (element: HTMLElement, options?: iScrollOptions);
+
+    destroy(): void;
+    refresh(): void;
+    scrollTo(x: number, y: number, time?: number, relative?: boolean): void;
+    scrollToElement(element: string, time?: number): void;
+    scrollToElement(element: HTMLElement, time?: number): void;
+    scrollToPage(pageX: number, pageY: number, time?: number): void;
+    disable(): void;
+    enable(): void;
+    stop(): void;
+    zoom(x: number, y: number, scale: number, time?: number): void;
+    isReady(): boolean;
+}

--- a/iscroll/iscroll-5.d.ts
+++ b/iscroll/iscroll-5.d.ts
@@ -1,76 +1,60 @@
-// Type definitions for iScroll 4.2
-// Project: http://cubiq.org/iscroll-4
-// Definitions by: Boris Yankov <https://github.com/borisyankov/> and Christiaan Rakowski <https://github.com/csrakowski/>
+// Type definitions for iScroll 5
+// Project: http://cubiq.org/iscroll-5-ready-for-beta-test
+// Definitions by: Christiaan Rakowski <https://github.com/csrakowski/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
+interface IScrollOptions {
+	hScroll?: boolean;
+	vScroll?: boolean;
+	x?: number;
+	y?: number;
+	bounce?: boolean;
+	bounceLock?: boolean;
+	momentum?: boolean;
+	lockDirection?: boolean;
+	useTransform?: boolean;
+	useTransition?: boolean;
+	topOffset?: number;
+	checkDOMChanges?: boolean;
+	handleClick?: boolean;
 
-interface iScrollEvent {
-    (e: Event): void;
+	// Scrollbar
+	hScrollbar?: boolean;
+	vScrollbar?: boolean;
+	fixedScrollbar?: boolean;
+	hideScrollbar?: boolean;
+	fadeScrollbar?: boolean;
+	scrollbarClass?: string;
+
+	// Zoom
+	zoom?: boolean;
+	zoomMin?: number;
+	zoomMax?: number;
+	doubleTapZoom?: number;
+	wheelAction?: string;
+
+	// Snap
+	snap?: any;
+	snapThreshold?: number;
 }
 
-interface iScrollOptions {
-    hScroll?: boolean;
-    vScroll?: boolean;
-    x?: number;
-    y?: number;
-    bounce?: boolean;
-    bounceLock?: boolean;
-    momentum?: boolean;
-    lockDirection?: boolean;
-    useTransform?: boolean;
-    useTransition?: boolean;
-    topOffset?: number;
-    checkDOMChanges?: boolean;
-    handleClick?: boolean;
+declare class IScroll {
 
-    // Scrollbar
-    hScrollbar?: boolean;
-    vScrollbar?: boolean;
-    fixedScrollbar?: boolean;
-    hideScrollbar?: boolean;
-    fadeScrollbar?: boolean;
-    scrollbarClass?: string;
+	constructor (element: string, options?: IScrollOptions);
+	constructor (element: HTMLElement, options?: IScrollOptions);
 
-    // Zoom
-    zoom?: boolean;
-    zoomMin?: number;
-    zoomMax?: number;
-    doubleTapZoom?: number;
-    wheelAction?: string;
+	destroy(): void;
+	refresh(): void;
+	scrollTo(x: number, y: number, time?: number, relative?: boolean): void;
+	scrollToElement(element: string, time?: number): void;
+	scrollToElement(element: HTMLElement, time?: number): void;
+	scrollToPage(pageX: number, pageY: number, time?: number): void;
+	disable(): void;
+	enable(): void;
+	stop(): void;
+	zoom(x: number, y: number, scale: number, time?: number): void;
+	isReady(): boolean;
 
-    // Snap
-    snap?: any;
-    snapThreshold?: number;
-
-    // Events
-    onRefresh?: iScrollEvent;
-    onBeforeScrollStart?: iScrollEvent;
-    onScrollStart?: iScrollEvent;
-    onBeforeScrollMove?: iScrollEvent;
-    onScrollMove?: iScrollEvent;
-    onBeforeScrollEnd?: iScrollEvent;
-    onScrollEnd?: iScrollEvent;
-    onTouchEnd?: iScrollEvent;
-    onDestroy?: iScrollEvent;
-    onZoomStart?: iScrollEvent;
-    onZoom?: iScrollEvent;
-    onZoomEnd?: iScrollEvent;
-}
-
-declare class iScroll {
-
-    constructor (element: string, options?: iScrollOptions);
-	constructor (element: HTMLElement, options?: iScrollOptions);
-
-    destroy(): void;
-    refresh(): void;
-    scrollTo(x: number, y: number, time?: number, relative?: boolean): void;
-    scrollToElement(element: string, time?: number): void;
-    scrollToElement(element: HTMLElement, time?: number): void;
-    scrollToPage(pageX: number, pageY: number, time?: number): void;
-    disable(): void;
-    enable(): void;
-    stop(): void;
-    zoom(x: number, y: number, scale: number, time?: number): void;
-    isReady(): boolean;
+	// Events
+	on: (type: string, fn: () => void) => void;
 }

--- a/iscroll/iscroll-5.d.ts
+++ b/iscroll/iscroll-5.d.ts
@@ -4,8 +4,8 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 interface IScrollOptions {
-	hScroll?: boolean;
-	vScroll?: boolean;
+	//hScroll?: boolean;
+	//vScroll?: boolean;
 	x?: number;
 	y?: number;
 	bounce?: boolean;
@@ -33,9 +33,40 @@ interface IScrollOptions {
 	doubleTapZoom?: number;
 	wheelAction?: string;
 
-	// Snap
+	
+	///String or boolean
 	snap?: any;
 	snapThreshold?: number;
+
+	//new in IScroll 5?
+
+	resizeIndicator?: boolean;
+	mouseWheelSpeed?: number;
+	startX?: number;
+	startY?: number;
+	scrollX?: boolean;
+	scrollY?: boolean;
+	directionLockThreshold?: number;
+
+	bounceTime?: number;
+
+	///String or function
+	bounceEasing?: any;
+	
+	preventDefault?: boolean;
+	preventDefaultException?: boolean;
+
+	HWCompositing?: boolean;
+
+	freeScroll?: boolean;
+
+	resizePolling?: number;
+	tap?: boolean;
+	click?: boolean;
+	invertWheelDirection?: boolean;
+
+	///Boolean or string
+	eventPassthrough?: any;
 }
 
 declare class IScroll {


### PR DESCRIPTION
iScroll version 5 changed it's object name from iScroll to IScroll.
To prevent breaking builds for other people (still on v4) I thought it would be best to add a new file and leave the old one untouched.
I have not yet fully checked all the options, but plan to do so this week, and update with a new pull request when I have.
I also plan on adding some documentation/intellisence, also for the version 4 typings.
