### PR TITLE
[Node] Removing incorrect typing for `buffer.INSPECT_MAX_BYTES`.

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -195,7 +195,6 @@ interface NodeBuffer {
     writeDoubleLE(value: number, offset: number, noAssert?: boolean): void;
     writeDoubleBE(value: number, offset: number, noAssert?: boolean): void;
     fill(value: any, offset?: number, end?: number): void;
-    INSPECT_MAX_BYTES: number;
 }
 
 interface NodeTimer {


### PR DESCRIPTION
From http://nodejs.org/api/buffer.html#buffer_buffer_inspect_max_bytes:

"...this is a property on the buffer module returned by require('buffer'), not on the Buffer global, or a buffer instance."

The Node typings do not have a notion of a buffer module, and introducing one would be more work than might be useful. It contains a reference to `Buffer` and `SlowBuffer`, which are currently defined as variables in the typings. I believe I would need to redefine these in the module definition.

If anyone has any ideas for how to efficiently restructure this, let me know. But, regardless, the first step is removing this incorrect typing.
