### PR TITLE
various knockout test fixes

### DIFF
--- a/knockout/tests/knockout-tests.ts
+++ b/knockout/tests/knockout-tests.ts
@@ -180,8 +180,6 @@ function test_bindings() {
         init: function (element, valueAccessor) {
             var value = ko.utils.unwrapObservable(valueAccessor());
             $(element).toggle(value);
-        },
-        update: function (element, valueAccessor, allBindingsAccessor) {
         }
     };
     ko.bindingHandlers.hasFocus = {

--- a/knockout/tests/knockout-tests.ts
+++ b/knockout/tests/knockout-tests.ts
@@ -56,13 +56,13 @@ function test_computed() {
     function MyViewModel1() {
         this.price = ko.observable(25.99);
 
-        this.formattedPrice = ko.computed({
+        this.formattedPrice = ko.computed<string>({
             read: function () {
                 return '$' + this.price().toFixed(2);
             },
             write: function (value) {
-                value = parseFloat(value.replace(/[^\.\d]/g, ""));
-                this.price(isNaN(value) ? 0 : value);
+                var num = parseFloat(value.replace(/[^\.\d]/g, ""));
+                this.price(isNaN(num) ? 0 : num);
             },
             owner: this
         });

--- a/knockout/tests/knockout-tests.ts
+++ b/knockout/tests/knockout-tests.ts
@@ -124,7 +124,7 @@ function test_observableArrays() {
     myObservableArray.unshift('Some new value');
     myObservableArray.shift();
     myObservableArray.reverse();
-    myObservableArray.sort(function (left, right) { return left.lastName == right.lastName ? 0 : (left.lastName < right.lastName ? -1 : 1) });
+    myObservableArray.sort(function (left, right) { return left == right ? 0 : (left < right ? -1 : 1) });
     myObservableArray.splice(1, 3);
 
     myObservableArray.remove('Blah');


### PR DESCRIPTION
Corrected various knockout tests which were not properly following the rules of static typing.

These errors were exposed by the new 0.9.5 plugin, however they were not technically 'correct' by the TypeScript spec beforehand (even though no errors were reported by the plugin).
