### PR TITLE
Update angular-scenario.d.ts 'enter' lacks return-type annotation

### DIFF
--- a/angularjs/angular-scenario.d.ts
+++ b/angularjs/angular-scenario.d.ts
@@ -80,7 +80,7 @@ declare module angularScenario {
     }
 
     export interface Input {
-        enter(value: any);
+        enter(value: any): any;
         check(): any;
         select(radioButtonValue: any): any;
         val(): Future;


### PR DESCRIPTION
'enter' lacks return-type annotation, implicitly has an 'any' return type
