### PR TITLE
Chai now properly supports import

### DIFF
--- a/chai-jquery/chai-jquery-tests.ts
+++ b/chai-jquery/chai-jquery-tests.ts
@@ -1,10 +1,12 @@
-/// <reference path="../chai/chai.d.ts" />
 /// <reference path="chai-jquery.d.ts" />
 
 // tests taken from https://github.com/chaijs/chai-jquery
 
-declare var $;
-var expect = chai.expect;
+// ReSharper disable DuplicatingLocalDeclaration
+declare var expect: ExpectShouldStatic;
+declare var $: ChaiJQueryStatic;
+// ReSharper restore DuplicatingLocalDeclaration
+// ReSharper disable WrongExpressionStatement
 
 function test_attr() {
     expect($('#foo')).to.have.attr('id');
@@ -73,6 +75,7 @@ function test_exist() {
 }
 
 function test_match_selector() {
+    $('').should.match('');
     $('input').should.match('#foo');
 }
 

--- a/chai-jquery/chai-jquery.d.ts
+++ b/chai-jquery/chai-jquery.d.ts
@@ -4,34 +4,40 @@
 // DefinitelyTyped: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../chai/chai.d.ts" />
+/// <reference path="../jquery/jquery.d.ts" />
 
-declare module chai {
-    interface NameValueRegexMatcher {
-        match(value: RegExp): boolean;
-    }
+interface ChaiJQuery extends JQuery {
+    should: ChaiJQueryExpectShould;
+}
 
-    interface NameValueMatcher {
-        (name: string, value?: string): boolean;
-    }
+interface ChaiJQueryStatic extends JQueryStatic {
+    (selector: string, context?: any): ChaiJQuery;
+    (element: Element): ChaiJQuery;
+    (object: {}): ChaiJQuery;
+    (elementArray: Element[]): ChaiJQuery;
+    (object: ChaiJQuery): ChaiJQuery;
+    (func: Function): ChaiJQuery;
+    (array: any[]): ChaiJQuery;
+    (): ChaiJQuery;
+}
 
-    interface Have {
-        attr: NameValueMatcher;
-        css: NameValueMatcher;
-        data: NameValueMatcher;
-        class(className: string): boolean;
-        id(id: string): boolean;
-        html(html: string): boolean;
-        text(text: string): boolean;
-        value(text: string): boolean;
-        (selector: string): boolean;
-    }
-
-    interface Be {
-        visible: boolean;
-        hidden: boolean;
-        selected: boolean;
-        checked: boolean;
-        disabled: boolean;
-        (selector: string): boolean;
-    }
+interface ChaiJQueryExpectShould extends ExpectShould {
+    not: ChaiJQueryExpectShould;
+    ok: ChaiJQueryExpectShould;
+    true: ChaiJQueryExpectShould;
+    false: ChaiJQueryExpectShould;
+    null: ChaiJQueryExpectShould;
+    undefined: ChaiJQueryExpectShould;
+    exist: ChaiJQueryExpectShould;
+    empty: ChaiJQueryExpectShould;
+    arguments: ChaiJQueryExpectShould;
+    Arguments: ChaiJQueryExpectShould;
+    match(expression: RegExp, message?: string): ChaiJQueryExpectShould;
+    match(selector: string, message?: string): ChaiJQueryExpectShould;
+    string(string: string, message?: string): ChaiJQueryExpectShould;
+    key(string: string): ChaiJQueryExpectShould;
+    respondTo(method: string, message?: string): ChaiJQueryExpectShould;
+    itself: ChaiJQueryExpectShould;
+    satisfy(matcher: Function, message?: string): ChaiJQueryExpectShould;
+    closeTo(expected: number, delta: number, message?: string): ChaiJQueryExpectShould;
 }

--- a/chai/chai-assert-tests.ts
+++ b/chai/chai-assert-tests.ts
@@ -45,181 +45,181 @@ interface FieldObj {
 	field: any;
 }
 
-suite('assert', function () {
+suite('assert', () => {
 
-	test('assert', function () {
+	test('assert', () => {
 		var foo = 'bar';
 		assert(foo == 'bar', "expected foo to equal `bar`");
 
-		err(function () {
+		err(() => {
 			assert(foo == 'baz', "expected foo to equal `bar`");
 		}, "expected foo to equal `bar`");
 	});
 
-	test('fail', function () {
-		chai.expect(function () {
+	test('fail', () => {
+		chai.expect(() => {
 			assert.fail();
 		}).to.throw(chai.AssertionError);
 	});
 
-	test('isTrue', function () {
+	test('isTrue', () => {
 		assert.isTrue(true);
 
-		err(function () {
+		err(() => {
 			assert.isTrue(false);
 		}, "expected false to be true");
 
-		err(function () {
+		err(() => {
 			assert.isTrue(1);
 		}, "expected 1 to be true");
 
-		err(function () {
+		err(() => {
 			assert.isTrue('test');
 		}, "expected 'test' to be true");
 	});
 
-	test('ok', function () {
+	test('ok', () => {
 		assert.ok(true);
 		assert.ok(1);
 		assert.ok('test');
 
-		err(function () {
+		err(() => {
 			assert.ok(false);
 		}, "expected false to be truthy");
 
-		err(function () {
+		err(() => {
 			assert.ok(0);
 		}, "expected 0 to be truthy");
 
-		err(function () {
+		err(() => {
 			assert.ok('');
 		}, "expected '' to be truthy");
 	});
 
-	test('isFalse', function () {
+	test('isFalse', () => {
 		assert.isFalse(false);
 
-		err(function () {
+		err(() => {
 			assert.isFalse(true);
 		}, "expected true to be false");
 
-		err(function () {
+		err(() => {
 			assert.isFalse(0);
 		}, "expected 0 to be false");
 	});
 
-	test('equal', function () {
+	test('equal', () => {
 		var foo;
 		assert.equal(foo, undefined);
 	});
 
-	test('typeof / notTypeOf', function () {
+	test('typeof / notTypeOf', () => {
 		assert.typeOf('test', 'string');
 		assert.typeOf(true, 'boolean');
 		assert.typeOf(5, 'number');
 
-		err(function () {
+		err(() => {
 			assert.typeOf(5, 'string');
 		}, "expected 5 to be a string");
 
 	});
 
-	test('notTypeOf', function () {
+	test('notTypeOf', () => {
 		assert.notTypeOf('test', 'number');
 
-		err(function () {
+		err(() => {
 			assert.notTypeOf(5, 'number');
 		}, "expected 5 not to be a number");
 	});
 
-	test('instanceOf', function () {
+	test('instanceOf', () => {
 		function Foo() {
 		}
 
 		assert.instanceOf(new Foo(), Foo);
 
-		err(function () {
+		err(() => {
 			assert.instanceOf(5, Foo);
 		}, "expected 5 to be an instance of Foo");
 
 		function CrashyObject() {
 		};
-		CrashyObject.prototype.inspect = function () {
+		CrashyObject.prototype.inspect = () => {
 			throw new Error("Arg's inspect() called even though the test passed");
 		};
 		assert.instanceOf(new CrashyObject(), CrashyObject);
 	});
 
-	test('notInstanceOf', function () {
+	test('notInstanceOf', () => {
 		function Foo() {
 		}
 
 		assert.notInstanceOf(new Foo(), String);
 
-		err(function () {
+		err(() => {
 			assert.notInstanceOf(new Foo(), Foo);
 		}, "expected {} to not be an instance of Foo");
 	});
 
-	test('isObject', function () {
+	test('isObject', () => {
 		function Foo() {
 		}
 
 		assert.isObject({});
 		assert.isObject(new Foo());
 
-		err(function () {
+		err(() => {
 			assert.isObject(true);
 		}, "expected true to be an object");
 
-		err(function () {
+		err(() => {
 			assert.isObject(Foo);
 		}, "expected [Function: Foo] to be an object");
 
-		err(function () {
+		err(() => {
 			assert.isObject('foo');
 		}, "expected 'foo' to be an object");
 	});
 
-	test('isNotObject', function () {
+	test('isNotObject', () => {
 		function Foo() {
 		}
 
 		assert.isNotObject(5);
 
-		err(function () {
+		err(() => {
 			assert.isNotObject({});
 		}, "expected {} not to be an object");
 	});
 
-	test('notEqual', function () {
+	test('notEqual', () => {
 		assert.notEqual(3, 4);
 
-		err(function () {
+		err(() => {
 			assert.notEqual(5, 5);
 		}, "expected 5 to not equal 5");
 	});
 
-	test('strictEqual', function () {
+	test('strictEqual', () => {
 		assert.strictEqual('foo', 'foo');
 
-		err(function () {
+		err(() => {
 			assert.strictEqual('5', 5);
 		}, "expected \'5\' to equal 5");
 	});
 
-	test('notStrictEqual', function () {
+	test('notStrictEqual', () => {
 		assert.notStrictEqual(5, '5');
 
-		err(function () {
+		err(() => {
 			assert.notStrictEqual(5, 5);
 		}, "expected 5 to not equal 5");
 	});
 
-	test('deepEqual', function () {
+	test('deepEqual', () => {
 		assert.deepEqual({tea: 'chai'}, {tea: 'chai'});
 
-		err(function () {
+		err(() => {
 			assert.deepEqual({tea: 'chai'}, {tea: 'black'});
 		}, "expected { tea: \'chai\' } to deeply equal { tea: \'black\' }");
 
@@ -231,18 +231,18 @@ suite('assert', function () {
 		var obj1 = Object.create({tea: 'chai'})
 		, obj2 = Object.create({tea: 'black'});
 
-		err(function () {
+		err(() => {
 			assert.deepEqual(obj1, obj2);
 		}, "expected { tea: \'chai\' } to deeply equal { tea: \'black\' }");
 	});
 
-	test('deepEqual (ordering)', function () {
+	test('deepEqual (ordering)', () => {
 		var a = { a: 'b', c: 'd' }
 		, b = { c: 'd', a: 'b' };
 		assert.deepEqual(a, b);
 	});
 
-	test('deepEqual (circular)', function () {
+	test('deepEqual (circular)', () => {
 		var circularObject:any = {}
 		, secondCircularObject:any = {};
 		circularObject.field = circularObject;
@@ -250,20 +250,20 @@ suite('assert', function () {
 
 		assert.deepEqual(circularObject, secondCircularObject);
 
-		err(function () {
+		err(() => {
 			secondCircularObject.field2 = secondCircularObject;
 			assert.deepEqual(circularObject, secondCircularObject);
 		}, "expected { field: [Circular] } to deeply equal { Object (field, field2) }");
 	});
 
-	test('notDeepEqual', function () {
+	test('notDeepEqual', () => {
 		assert.notDeepEqual({tea: 'jasmine'}, {tea: 'chai'});
-		err(function () {
+		err(() => {
 			assert.notDeepEqual({tea: 'chai'}, {tea: 'chai'});
 		}, "expected { tea: \'chai\' } to not deeply equal { tea: \'chai\' }");
 	});
 
-	test('notDeepEqual (circular)', function () {
+	test('notDeepEqual (circular)', () => {
 		var circularObject:any = {}
 		, secondCircularObject:any = { tea: 'jasmine' };
 		circularObject.field = circularObject;
@@ -271,194 +271,194 @@ suite('assert', function () {
 
 		assert.notDeepEqual(circularObject, secondCircularObject);
 
-		err(function () {
+		err(() => {
 			delete secondCircularObject.tea;
 			assert.notDeepEqual(circularObject, secondCircularObject);
 		}, "expected { field: [Circular] } to not deeply equal { field: [Circular] }");
 	});
 
-	test('isNull', function () {
+	test('isNull', () => {
 		assert.isNull(null);
 
-		err(function () {
+		err(() => {
 			assert.isNull(undefined);
 		}, "expected undefined to equal null");
 	});
 
-	test('isNotNull', function () {
+	test('isNotNull', () => {
 		assert.isNotNull(undefined);
 
-		err(function () {
+		err(() => {
 			assert.isNotNull(null);
 		}, "expected null to not equal null");
 	});
 
-	test('isUndefined', function () {
+	test('isUndefined', () => {
 		assert.isUndefined(undefined);
 
-		err(function () {
+		err(() => {
 			assert.isUndefined(null);
 		}, "expected null to equal undefined");
 	});
 
-	test('isDefined', function () {
+	test('isDefined', () => {
 		assert.isDefined(null);
 
-		err(function () {
+		err(() => {
 			assert.isDefined(undefined);
 		}, "expected undefined to not equal undefined");
 	});
 
-	test('isFunction', function () {
-		var func = function () {
+	test('isFunction', () => {
+		var func = () => {
 		};
 		assert.isFunction(func);
 
-		err(function () {
+		err(() => {
 			assert.isFunction({});
 		}, "expected {} to be a function");
 	});
 
-	test('isNotFunction', function () {
+	test('isNotFunction', () => {
 		assert.isNotFunction(5);
 
-		err(function () {
-			assert.isNotFunction(function () {
+		err(() => {
+			assert.isNotFunction(() => {
 			});
 		}, "expected [Function] not to be a function");
 	});
 
-	test('isArray', function () {
+	test('isArray', () => {
 		assert.isArray([]);
 		assert.isArray(new Array<any>());
 
-		err(function () {
+		err(() => {
 			assert.isArray({});
 		}, "expected {} to be an array");
 	});
 
-	test('isNotArray', function () {
+	test('isNotArray', () => {
 		assert.isNotArray(3);
 
-		err(function () {
+		err(() => {
 			assert.isNotArray([]);
 		}, "expected [] not to be an array");
 
-		err(function () {
+		err(() => {
 			assert.isNotArray(new Array<any>());
 		}, "expected [] not to be an array");
 	});
 
-	test('isString', function () {
+	test('isString', () => {
 		assert.isString('Foo');
 		assert.isString(new String('foo'));
 
-		err(function () {
+		err(() => {
 			assert.isString(1);
 		}, "expected 1 to be a string");
 	});
 
-	test('isNotString', function () {
+	test('isNotString', () => {
 		assert.isNotString(3);
 		assert.isNotString([ 'hello' ]);
 
-		err(function () {
+		err(() => {
 			assert.isNotString('hello');
 		}, "expected 'hello' not to be a string");
 	});
 
-	test('isNumber', function () {
+	test('isNumber', () => {
 		assert.isNumber(1);
 		assert.isNumber(Number('3'));
 
-		err(function () {
+		err(() => {
 			assert.isNumber('1');
 		}, "expected \'1\' to be a number");
 	});
 
-	test('isNotNumber', function () {
+	test('isNotNumber', () => {
 		assert.isNotNumber('hello');
 		assert.isNotNumber([ 5 ]);
 
-		err(function () {
+		err(() => {
 			assert.isNotNumber(4);
 		}, "expected 4 not to be a number");
 	});
 
-	test('isBoolean', function () {
+	test('isBoolean', () => {
 		assert.isBoolean(true);
 		assert.isBoolean(false);
 
-		err(function () {
+		err(() => {
 			assert.isBoolean('1');
 		}, "expected \'1\' to be a boolean");
 	});
 
-	test('isNotBoolean', function () {
+	test('isNotBoolean', () => {
 		assert.isNotBoolean('true');
 
-		err(function () {
+		err(() => {
 			assert.isNotBoolean(true);
 		}, "expected true not to be a boolean");
 
-		err(function () {
+		err(() => {
 			assert.isNotBoolean(false);
 		}, "expected false not to be a boolean");
 	});
 
-	test('include', function () {
+	test('include', () => {
 		assert.include('foobar', 'bar');
 		assert.include([ 1, 2, 3], 3);
 
-		err(function () {
+		err(() => {
 			assert.include('foobar', 'baz');
 		}, "expected \'foobar\' to contain \'baz\'");
 
-		err(function () {
+		err(() => {
 			assert.include(undefined, 'bar');
 		}, "expected an array or string");
 	});
 
-	test('notInclude', function () {
+	test('notInclude', () => {
 		assert.notInclude('foobar', 'baz');
 		assert.notInclude([ 1, 2, 3 ], 4);
 
-		err(function () {
+		err(() => {
 			assert.notInclude('foobar', 'bar');
 		}, "expected \'foobar\' to not contain \'bar\'");
 
-		err(function () {
+		err(() => {
 			assert.notInclude(undefined, 'bar');
 		}, "expected an array or string");
 	});
 
-	test('lengthOf', function () {
+	test('lengthOf', () => {
 		assert.lengthOf([1, 2, 3], 3);
 		assert.lengthOf('foobar', 6);
 
-		err(function () {
+		err(() => {
 			assert.lengthOf('foobar', 5);
 		}, "expected 'foobar' to have a length of 5 but got 6");
 
-		err(function () {
+		err(() => {
 			assert.lengthOf(1, 5);
 		}, "expected 1 to have a property \'length\'");
 	});
 
-	test('match', function () {
+	test('match', () => {
 		assert.match('foobar', /^foo/);
 		assert.notMatch('foobar', /^bar/);
 
-		err(function () {
+		err(() => {
 			assert.match('foobar', /^bar/i);
 		}, "expected 'foobar' to match /^bar/i");
 
-		err(function () {
+		err(() => {
 			assert.notMatch('foobar', /^foo/i);
 		}, "expected 'foobar' not to match /^foo/i");
 	});
 
-	test('property', function () {
+	test('property', () => {
 		var obj = { foo: { bar: 'baz' } };
 		var simpleObj = { foo: 'bar' };
 		assert.property(obj, 'foo');
@@ -469,122 +469,122 @@ suite('assert', function () {
 		assert.deepPropertyVal(obj, 'foo.bar', 'baz');
 		assert.deepPropertyNotVal(obj, 'foo.bar', 'flow');
 
-		err(function () {
+		err(() => {
 			assert.property(obj, 'baz');
 		}, "expected { foo: { bar: 'baz' } } to have a property 'baz'");
 
-		err(function () {
+		err(() => {
 			assert.deepProperty(obj, 'foo.baz');
 		}, "expected { foo: { bar: 'baz' } } to have a deep property 'foo.baz'");
 
-		err(function () {
+		err(() => {
 			assert.notProperty(obj, 'foo');
 		}, "expected { foo: { bar: 'baz' } } to not have property 'foo'");
 
-		err(function () {
+		err(() => {
 			assert.notDeepProperty(obj, 'foo.bar');
 		}, "expected { foo: { bar: 'baz' } } to not have deep property 'foo.bar'");
 
-		err(function () {
+		err(() => {
 			assert.propertyVal(simpleObj, 'foo', 'ball');
 		}, "expected { foo: 'bar' } to have a property 'foo' of 'ball', but got 'bar'");
 
-		err(function () {
+		err(() => {
 			assert.deepPropertyVal(obj, 'foo.bar', 'ball');
 		}, "expected { foo: { bar: 'baz' } } to have a deep property 'foo.bar' of 'ball', but got 'baz'");
 
-		err(function () {
+		err(() => {
 			assert.propertyNotVal(simpleObj, 'foo', 'bar');
 		}, "expected { foo: 'bar' } to not have a property 'foo' of 'bar'");
 
-		err(function () {
+		err(() => {
 			assert.deepPropertyNotVal(obj, 'foo.bar', 'baz');
 		}, "expected { foo: { bar: 'baz' } } to not have a deep property 'foo.bar' of 'baz'");
 	});
 
-	test('throws', function () {
-		assert.throws(function () {
+	test('throws', () => {
+		assert.throws(() => {
 			throw new Error('foo');
 		});
-		assert.throws(function () {
+		assert.throws(() => {
 			throw new Error('bar');
 		}, 'bar');
-		assert.throws(function () {
+		assert.throws(() => {
 			throw new Error('bar');
 		}, /bar/);
-		assert.throws(function () {
+		assert.throws(() => {
 			throw new Error('bar');
 		}, Error);
-		assert.throws(function () {
+		assert.throws(() => {
 			throw new Error('bar');
 		}, Error, 'bar');
 
-		err(function () {
-			assert.throws(function () {
-				throw new Error('foo')
+		err(() => {
+			assert.throws(() => {
+				throw new Error('foo');
 			}, TypeError);
-		}, "expected [Function] to throw 'TypeError' but [Error: foo] was thrown")
+		}, "expected [Function] to throw 'TypeError' but [Error: foo] was thrown");
 
-		err(function () {
-			assert.throws(function () {
-				throw new Error('foo')
+		err(() => {
+			assert.throws(() => {
+				throw new Error('foo');
 			}, 'bar');
-		}, "expected [Function] to throw error including 'bar' but got 'foo'")
+		}, "expected [Function] to throw error including 'bar' but got 'foo'");
 
-		err(function () {
-			assert.throws(function () {
-				throw new Error('foo')
+		err(() => {
+			assert.throws(() => {
+				throw new Error('foo');
 			}, Error, 'bar');
-		}, "expected [Function] to throw error including 'bar' but got 'foo'")
+		}, "expected [Function] to throw error including 'bar' but got 'foo'");
 
-		err(function () {
-			assert.throws(function () {
-				throw new Error('foo')
+		err(() => {
+			assert.throws(() => {
+				throw new Error('foo');
 			}, TypeError, 'bar');
-		}, "expected [Function] to throw 'TypeError' but [Error: foo] was thrown")
+		}, "expected [Function] to throw 'TypeError' but [Error: foo] was thrown");
 
-		err(function () {
-			assert.throws(function () {
+		err(() => {
+			assert.throws(() => {
 			});
 		}, "expected [Function] to throw an error");
 
-		err(function () {
-			assert.throws(function () {
-				throw new Error('')
+		err(() => {
+			assert.throws(() => {
+				throw new Error('');
 			}, 'bar');
 		}, "expected [Function] to throw error including 'bar' but got ''");
 
-		err(function () {
-			assert.throws(function () {
-				throw new Error('')
+		err(() => {
+			assert.throws(() => {
+				throw new Error('');
 			}, /bar/);
 		}, "expected [Function] to throw error matching /bar/ but got ''");
 	});
 
-	test('doesNotThrow', function () {
-		assert.doesNotThrow(function () {
+	test('doesNotThrow', () => {
+		assert.doesNotThrow(() => {
 		});
-		assert.doesNotThrow(function () {
+		assert.doesNotThrow(() => {
 		}, 'foo');
 
-		err(function () {
-			assert.doesNotThrow(function () {
+		err(() => {
+			assert.doesNotThrow(() => {
 				throw new Error('foo');
 			});
 		}, 'expected [Function] to not throw an error but [Error: foo] was thrown');
 	});
 
-	test('ifError', function () {
+	test('ifError', () => {
 		assert.ifError(false);
 		assert.ifError(null);
 		assert.ifError(undefined);
 
-		err(function () {
+		err(() => {
 			assert.ifError('foo');
 		}, "expected \'foo\' to be falsy");
 	});
 
-	test('operator', function () {
+	test('operator', () => {
 		assert.operator(1, '<', 2);
 		assert.operator(2, '>', 1);
 		assert.operator(1, '==', 1);
@@ -593,77 +593,77 @@ suite('assert', function () {
 		assert.operator(1, '!=', 2);
 		assert.operator(1, '!==', 2);
 
-		err(function () {
+		err(() => {
 			assert.operator(1, '=', 2);
 		}, 'Invalid operator "="');
 
-		err(function () {
+		err(() => {
 			assert.operator(2, '<', 1);
 		}, "expected 2 to be < 1");
 
-		err(function () {
+		err(() => {
 			assert.operator(1, '>', 2);
 		}, "expected 1 to be > 2");
 
-		err(function () {
+		err(() => {
 			assert.operator(1, '==', 2);
 		}, "expected 1 to be == 2");
 
-		err(function () {
+		err(() => {
 			assert.operator(2, '<=', 1);
 		}, "expected 2 to be <= 1");
 
-		err(function () {
+		err(() => {
 			assert.operator(1, '>=', 2);
 		}, "expected 1 to be >= 2");
 
-		err(function () {
+		err(() => {
 			assert.operator(1, '!=', 1);
 		}, "expected 1 to be != 1");
 
-		err(function () {
+		err(() => {
 			assert.operator(1, '!==', '1');
 		}, "expected 1 to be !== \'1\'");
 	});
 
-	test('closeTo', function () {
+	test('closeTo', () => {
 		assert.closeTo(1.5, 1.0, 0.5);
 		assert.closeTo(10, 20, 20);
 		assert.closeTo(-10, 20, 30);
 
-		err(function () {
+		err(() => {
 			assert.closeTo(2, 1.0, 0.5);
 		}, "expected 2 to be close to 1 +/- 0.5");
 
-		err(function () {
+		err(() => {
 			assert.closeTo(-10, 20, 29);
 		}, "expected -10 to be close to 20 +/- 29");
 	});
 
-	test('members', function () {
+	test('members', () => {
 		assert.includeMembers([1, 2, 3], [2, 3]);
 		assert.includeMembers([1, 2, 3], []);
 		assert.includeMembers([1, 2, 3], [3]);
 
-		err(function () {
+		err(() => {
 			assert.includeMembers([5, 6], [7, 8]);
 		}, 'expected [ 5, 6 ] to be a superset of [ 7, 8 ]');
 
-		err(function () {
+		err(() => {
 			assert.includeMembers([5, 6], [5, 6, 0]);
 		}, 'expected [ 5, 6 ] to be a superset of [ 5, 6, 0 ]');
 	});
 
-	test('memberEquals', function () {
+	test('memberEquals', () => {
 		assert.sameMembers([], []);
 		assert.sameMembers([1, 2, 3], [3, 2, 1]);
 		assert.sameMembers([4, 2], [4, 2]);
 
-		err(function () {
+		err(() => {
 			assert.sameMembers([], [1, 2]);
 		}, 'expected [] to have the same members as [ 1, 2 ]');
 
-		err(function () {
+		err(() => {
 			assert.sameMembers([1, 54], [6, 1, 54]);
 		}, 'expected [ 1, 54 ] to have the same members as [ 6, 1, 54 ]');
 	});

--- a/chai/chai-tests.ts
+++ b/chai/chai-tests.ts
@@ -1,8 +1,11 @@
 /// <reference path="chai.d.ts" />
+import chai = require('chai');
+
 
 var expect = chai.expect;
 declare var err: Function;
 
+// ReSharper disable WrongExpressionStatement
 function chaiVersion() {
     expect(chai).to.have.property('version');
 }
@@ -17,9 +20,9 @@ function _true() {
     expect(false).to.not.be.true;
     expect(1).to.not.be.true;
 
-    err(() => {
+    err(()=> {
         expect('test').to.be.true;
-    }, "expected 'test' to be true")
+    }, "expected 'test' to be true");
 }
 
 function ok() {
@@ -42,33 +45,34 @@ function _false() {
     expect(true).to.not.be.false;
     expect(0).to.not.be.false;
 
-    err(() => {
+    err(()=> {
         expect('').to.be.false;
-    }, "expected '' to be false")
+    }, "expected '' to be false");
 }
 
 function _null() {
     expect(null).to.be.null;
     expect(false).to.not.be.null;
 
-    err(() => {
+    err(()=> {
         expect('').to.be.null;
-    }, "expected '' to be null")
+    }, "expected '' to be null");
 }
 
 function _undefined() {
     expect(undefined).to.be.undefined;
     expect(null).to.not.be.undefined;
 
-    err(() => {
+    err(()=> {
         expect('').to.be.undefined;
-    }, "expected '' to be undefined")
+    }, "expected '' to be undefined");
 }
 
 function exist() {
-    var foo = 'bar'
-        , bar;
+    var foo = 'bar';
+    var bar;
     expect(foo).to.exist;
+    // ReSharper disable once UsageOfPossiblyUnassignedValue
     expect(bar).to.not.exist;
 }
 
@@ -82,6 +86,7 @@ function arguments() {
 
 function equal() {
     var foo;
+    // ReSharper disable once UsageOfPossiblyUnassignedValue
     expect(undefined).to.equal(foo);
 }
 
@@ -102,7 +107,7 @@ function _typeof() {
     expect(new Object()).to.be.a('object');
     expect({}).to.be.a('object');
     expect([]).to.be.a('array');
-    expect(function () { }).to.be.a('function');
+    expect(() => { }).to.be.a('function');
     expect(null).to.be.a('null');
 
     err(() => {
@@ -689,7 +694,7 @@ function _throw() {
 }
 
 function use(){
-    chai.use(function (_chai, utils) {
+    chai.use((_chai, utils) => {
       _chai.can.use.any();
     });
 }

--- a/chai/chai.d.ts
+++ b/chai/chai.d.ts
@@ -4,162 +4,170 @@
 // DefinitelyTyped: https://github.com/borisyankov/DefinitelyTyped
 
 
-declare module chai {
+// ReSharper disable UsingOfReservedWord
+declare var __chai: ChaiStatic;
 
-    function expect(target: any): Expect;
+interface ChaiStatic {
+    expect(target: any): ExpectShould;
 
-    // Provides a way to extend the internals of Chai
-    function use(fn: (chai: any, utils: any) => void);
+    /**
+     * Provides a way to extend the internals of Chai
+     */
+    use(fn: (chai: any, utils: any) => void);
+}
 
-    interface ExpectStatic {
-        (target: any): Expect;
-    }
+interface ExpectShouldStatic {
+    (target: any): ExpectShould;
+}
 
-    interface Assertions {
-        attr(name, value?);
-        css(name, value?);
-        data(name, value?);
-        class(className);
-        id(id);
-        html(html);
-        text(text);
-        value(value);
-        visible;
-        hidden;
-        selected;
-        checked;
-        disabled;
-        empty;
-        exist;
-    }
+interface Assertions {
+    attr(name, value?);
+    css(name, value?);
+    data(name, value?);
+    class(className);
+    id(id);
+    html(html);
+    text(text);
+    value(value);
+    visible;
+    hidden;
+    selected;
+    checked;
+    disabled;
+    empty;
+    exist;
+}
 
-    interface Expect extends LanguageChains, NumericComparison, TypeComparison, Assertions {
-        not: Expect;
-        deep: Deep;
-        a: TypeComparison;
-        an: TypeComparison;
-        include: Include;
-        contain: Include;
-        ok: Expect;
-        true: Expect;
-        false: Expect;
-        null: Expect;
-        undefined: Expect;
-        exist: Expect;
-        empty: Expect;
-        arguments: Expect;
-        Arguments: Expect;
-        equal: Equal;
-        equals: Equal;
-        eq: Equal;
-        eql: Equal;
-        eqls: Equal;
-        property: Property;
-        ownProperty: OwnProperty;
-        haveOwnProperty: OwnProperty;
-        length: Length;
-        lengthOf: Length;
-        match(RegularExpression: RegExp, message?: string): Expect;
-        string(string: string, message?: string): Expect;
-        keys: Keys;
-        key(string: string): Expect;
-        throw: Throw;
-        throws: Throw;
-        Throw: Throw;
-        respondTo(method: string, message?: string): Expect;
-        itself: Expect;
-        satisfy(matcher: Function, message?: string): Expect;
-        closeTo(expected: number, delta: number, message?: string): Expect;
-        members: Members;
-    }
+interface ExpectShould extends LanguageChains, NumericComparison, TypeComparison, Assertions {
+    not: ExpectShould;
+    deep: Deep;
+    a: TypeComparison;
+    an: TypeComparison;
+    include: Include;
+    contain: Include;
+    ok: ExpectShould;
+    true: ExpectShould;
+    false: ExpectShould;
+    null: ExpectShould;
+    undefined: ExpectShould;
+    exist: ExpectShould;
+    empty: ExpectShould;
+    arguments: ExpectShould;
+    Arguments: ExpectShould;
+    equal: Equal;
+    equals: Equal;
+    eq: Equal;
+    eql: Equal;
+    eqls: Equal;
+    property: Property;
+    ownProperty: OwnProperty;
+    haveOwnProperty: OwnProperty;
+    length: Length;
+    lengthOf: Length;
+    match(expression: RegExp, message?: string): ExpectShould;
+    string(string: string, message?: string): ExpectShould;
+    keys: Keys;
+    key(string: string): ExpectShould;
+    throw: Throw;
+    throws: Throw;
+    Throw: Throw;
+    respondTo(method: string, message?: string): ExpectShould;
+    itself: ExpectShould;
+    satisfy(matcher: Function, message?: string): ExpectShould;
+    closeTo(expected: number, delta: number, message?: string): ExpectShould;
+    members: Members;
+}
 
-    interface LanguageChains {
-        to: Expect;
-        be: Expect;
-        been: Expect;
-        is: Expect;
-        that: Expect;
-        and: Expect;
-        have: Expect;
-        with: Expect;
-        at: Expect;
-        of: Expect;
-        same: Expect;
-    }
+interface LanguageChains {
+    to: ExpectShould;
+    be: ExpectShould;
+    been: ExpectShould;
+    is: ExpectShould;
+    that: ExpectShould;
+    and: ExpectShould;
+    have: ExpectShould;
+    with: ExpectShould;
+    at: ExpectShould;
+    of: ExpectShould;
+    same: ExpectShould;
+}
 
-    interface NumericComparison {
-        above: NumberComparer;
-        gt: NumberComparer;
-        greaterThan: NumberComparer;
-        least: NumberComparer;
-        gte: NumberComparer;
-        below: NumberComparer;
-        lt: NumberComparer;
-        lessThan: NumberComparer;
-        most: NumberComparer;
-        lte: NumberComparer;
-        within(start: number, finish: number, message?: string): Expect;
-    }
+interface NumericComparison {
+    above: NumberComparer;
+    gt: NumberComparer;
+    greaterThan: NumberComparer;
+    least: NumberComparer;
+    gte: NumberComparer;
+    below: NumberComparer;
+    lt: NumberComparer;
+    lessThan: NumberComparer;
+    most: NumberComparer;
+    lte: NumberComparer;
+    within(start: number, finish: number, message?: string): ExpectShould;
+}
 
-    interface NumberComparer {
-        (value: number, message?: string): Expect;
-    }
+interface NumberComparer {
+    (value: number, message?: string): ExpectShould;
+}
 
-    interface TypeComparison {
-        (type: string, message?: string): Expect;
-        instanceof: InstanceOf;
-        instanceOf: InstanceOf;
-    }
+interface TypeComparison {
+    (type: string, message?: string): ExpectShould;
+    instanceof: InstanceOf;
+    instanceOf: InstanceOf;
+}
 
-    interface InstanceOf {
-        (constructor: Object, message?: string): Expect;
-    }
+interface InstanceOf {
+    (constructor: Object, message?: string): ExpectShould;
+}
 
-    interface Deep {
-        equal: Equal;
-        property: Property;
-    }
+interface Deep {
+    equal: Equal;
+    property: Property;
+}
 
-    interface Equal {
-        (value: any, message?: string): Expect;
-    }
+interface Equal {
+    (value: any, message?: string): ExpectShould;
+}
 
-    interface Property {
-        (name: string, value?: any, message?: string): Expect;
-    }
+interface Property {
+    (name: string, value?: any, message?: string): ExpectShould;
+}
 
-    interface OwnProperty {
-        (name: string, message?: string): Expect;
-    }
+interface OwnProperty {
+    (name: string, message?: string): ExpectShould;
+}
 
-    interface Length extends LanguageChains, NumericComparison {
-        (length: number, message?: string): Expect;
-    }
+interface Length extends LanguageChains, NumericComparison {
+    (length: number, message?: string): ExpectShould;
+}
 
-    interface Include {
-        (value: Object, message?: string): Expect;
-        (value: string, message?: string): Expect;
-        (value: number, message?: string): Expect;
-        keys: Keys;
-        members: Members;
-    }
+interface Include {
+    (value: Object, message?: string): ExpectShould;
+    (value: string, message?: string): ExpectShould;
+    (value: number, message?: string): ExpectShould;
+    keys: Keys;
+    members: Members;
+}
 
-    interface Keys {
-        (...keys: string[]): Expect;
-        (keys: any[]): Expect;
-    }
+interface Keys {
+    (...keys: string[]): ExpectShould;
+    (keys: any[]): ExpectShould;
+}
 
-    interface Members {
-        (set: any[], message?: string): Expect;
-    }
+interface Members {
+    (set: any[], message?: string): ExpectShould;
+}
 
-    interface Throw {
-        (): Expect;
-        (expected: string, message?: string): Expect;
-        (expected: RegExp, message?: string): Expect;
-        (constructor: Error, expected?: string, message?: string): Expect;
-        (constructor: Error, expected?: RegExp, message?: string): Expect;
-        (constructor: Function, expected?: string, message?: string): Expect;
-        (constructor: Function, expected?: RegExp, message?: string): Expect;
-    }
+interface Throw {
+    (): ExpectShould;
+    (expected: string, message?: string): ExpectShould;
+    (expected: RegExp, message?: string): ExpectShould;
+    (constructor: Error, expected?: string, message?: string): ExpectShould;
+    (constructor: Error, expected?: RegExp, message?: string): ExpectShould;
+    (constructor: Function, expected?: string, message?: string): ExpectShould;
+    (constructor: Function, expected?: RegExp, message?: string): ExpectShould;
+}
+
+declare module "chai" {
+    export = __chai;
 }

--- a/i18next/i18next-tests.ts
+++ b/i18next/i18next-tests.ts
@@ -5,12 +5,14 @@
 /// <reference path="../jquery/jquery.d.ts" />
 /// <reference path="i18next.d.ts" />
 
+declare var sinon: SinonStatic;
+
 declare function done(): void;
  
 describe('i18next', function () {
 
     var i18n = $.i18n
-      , opts: I18nextOptions;
+      , opts: {};
 
     beforeEach(function () {
         opts = {

--- a/sinon-chai/sinon-chai-tests.ts
+++ b/sinon-chai/sinon-chai-tests.ts
@@ -1,14 +1,14 @@
 /// <reference path="../chai/chai.d.ts" />
 /// <reference path="sinon-chai.d.ts" />
 
-declare var expect: chai.ExpectStatic;
+declare var expect: SinonExpectShouldStatic;
+declare var spy: Function;
+declare var anotherSpy: Function;
+declare var context: {};
+declare var match: RegExp;
 
+// ReSharper disable WrongExpressionStatement
 function test() {
-    var spy: Function;
-    var anotherSpy: Function;
-    var context;
-    var match;
-
     expect(spy).to.have.been.called;
     expect(spy).to.have.been.calledOnce;
     expect(spy).to.have.been.calledTwice;

--- a/sinon-chai/sinon-chai.d.ts
+++ b/sinon-chai/sinon-chai.d.ts
@@ -5,24 +5,166 @@
 
 /// <reference path="../chai/chai.d.ts" />
 
-declare module chai {
-    interface Expect {
-        called: Expect;
-        calledOnce: Expect;
-        calledTwice: Expect;
-        calledThrice: Expect;
-        calledBefore(spy: Function): Expect;
-        calledAfter(spy: Function): Expect;
-        calledWithNew: Expect;
-        calledOn(context: any): Expect;
-        calledWith(...args: any[]): Expect;
-        calledWithExactly(...args: any[]): Expect;
-        calledWithMatch(...args: any[]): Expect;
-        returned(returnVal: any): Expect;
-        thrown(errorObjOrErrorTypeStringOrNothing: any): Expect;
-    }
+// ReSharper disable UsingOfReservedWord
+declare var __sinon_chai: SinonChaiStatic;
 
-    interface LanguageChains {
-        always: Expect;
-    }
+interface SinonChaiStatic {
+    expect(target: any): SinonExpectShould;
+
+    /**
+     * Provides a way to extend the internals of Chai
+     */
+    use(fn: (chai: any, utils: any) => void);
+}
+
+interface SinonExpectShouldStatic {
+    (target: any): SinonExpectShould;
+}
+
+interface SinonExpectShould extends SinonLanguageChains, SinonNumericComparison, SinonTypeComparison, Assertions {
+    not: SinonExpectShould;
+    deep: SinonDeep;
+    a: SinonTypeComparison;
+    an: SinonTypeComparison;
+    include: SinonInclude;
+    contain: SinonInclude;
+    ok: SinonExpectShould;
+    true: SinonExpectShould;
+    false: SinonExpectShould;
+    null: SinonExpectShould;
+    undefined: SinonExpectShould;
+    exist: SinonExpectShould;
+    empty: SinonExpectShould;
+    arguments: SinonExpectShould;
+    Arguments: SinonExpectShould;
+    equal: SinonEqual;
+    equals: SinonEqual;
+    eq: SinonEqual;
+    eql: SinonEqual;
+    eqls: SinonEqual;
+    property: SinonProperty;
+    ownProperty: SinonOwnProperty;
+    haveOwnProperty: SinonOwnProperty;
+    length: SinonLength;
+    lengthOf: SinonLength;
+    match(expression: RegExp, message?: string): SinonExpectShould;
+    string(string: string, message?: string): SinonExpectShould;
+    keys: SinonKeys;
+    key(string: string): SinonExpectShould;
+    throw: SinonThrow;
+    throws: SinonThrow;
+    Throw: SinonThrow;
+    respondTo(method: string, message?: string): SinonExpectShould;
+    itself: SinonExpectShould;
+    satisfy(matcher: Function, message?: string): SinonExpectShould;
+    closeTo(expected: number, delta: number, message?: string): SinonExpectShould;
+    members: SinonMembers;
+    called: SinonExpectShould;
+    calledOnce: SinonExpectShould;
+    calledTwice: SinonExpectShould;
+    calledThrice: SinonExpectShould;
+    calledBefore(spy: Function): SinonExpectShould;
+    calledAfter(spy: Function): SinonExpectShould;
+    calledWithNew: SinonExpectShould;
+    calledOn(context: any): SinonExpectShould;
+    calledWith(...args: any[]): SinonExpectShould;
+    calledWithExactly(...args: any[]): SinonExpectShould;
+    calledWithMatch(...args: any[]): SinonExpectShould;
+    returned(returnVal: any): SinonExpectShould;
+    thrown(errorObjOrErrorTypeStringOrNothing: any): SinonExpectShould;
+}
+
+interface SinonLanguageChains {
+    to: SinonExpectShould;
+    be: SinonExpectShould;
+    been: SinonExpectShould;
+    is: SinonExpectShould;
+    that: SinonExpectShould;
+    and: SinonExpectShould;
+    have: SinonExpectShould;
+    with: SinonExpectShould;
+    at: SinonExpectShould;
+    of: SinonExpectShould;
+    same: SinonExpectShould;
+    always: SinonExpectShould;
+}
+
+interface SinonNumericComparison {
+    above: SinonNumberComparer;
+    gt: SinonNumberComparer;
+    greaterThan: SinonNumberComparer;
+    least: SinonNumberComparer;
+    gte: SinonNumberComparer;
+    below: SinonNumberComparer;
+    lt: SinonNumberComparer;
+    lessThan: SinonNumberComparer;
+    most: SinonNumberComparer;
+    lte: SinonNumberComparer;
+    within(start: number, finish: number, message?: string): SinonExpectShould;
+}
+
+interface SinonNumberComparer {
+    (value: number, message?: string): SinonExpectShould;
+}
+
+interface SinonTypeComparison {
+    (type: string, message?: string): SinonExpectShould;
+    instanceof: SinonInstanceOf;
+    instanceOf: SinonInstanceOf;
+}
+
+interface SinonInstanceOf {
+    (constructor: Object, message?: string): SinonExpectShould;
+}
+
+interface SinonDeep {
+    equal: SinonEqual;
+    property: SinonProperty;
+}
+
+interface SinonEqual {
+    (value: any, message?: string): SinonExpectShould;
+}
+
+interface SinonProperty {
+    (name: string, value?: any, message?: string): SinonExpectShould;
+}
+
+interface SinonOwnProperty {
+    (name: string, message?: string): SinonExpectShould;
+}
+
+interface SinonLength extends SinonLanguageChains, SinonNumericComparison {
+    (length: number, message?: string): SinonExpectShould;
+}
+
+interface SinonInclude {
+    (value: Object, message?: string): SinonExpectShould;
+    (value: string, message?: string): SinonExpectShould;
+    (value: number, message?: string): SinonExpectShould;
+    keys: SinonKeys;
+    members: SinonMembers;
+}
+
+interface SinonKeys {
+    (...keys: string[]): SinonExpectShould;
+    (keys: any[]): SinonExpectShould;
+}
+
+interface SinonMembers {
+    (set: any[], message?: string): SinonExpectShould;
+}
+
+interface SinonThrow {
+    (): SinonExpectShould;
+    (expected: string, message?: string): SinonExpectShould;
+    (expected: RegExp, message?: string): SinonExpectShould;
+    (constructor: Error, expected?: string, message?: string): SinonExpectShould;
+    (constructor: Error, expected?: RegExp, message?: string): SinonExpectShould;
+    (constructor: Function, expected?: string, message?: string): SinonExpectShould;
+    (constructor: Function, expected?: RegExp, message?: string): SinonExpectShould;
+}
+
+declare module "sinon-chai" {
+    export = __sinon_chai;
 }

--- a/sinon/sinon-tests.ts
+++ b/sinon/sinon-tests.ts
@@ -1,5 +1,7 @@
 /// <reference path="sinon.d.ts" />
 
+declare var sinon: SinonStatic;
+
 function once(fn: Function) {
 	var returnValue: any, called = false;
 	return function () {
@@ -15,7 +17,11 @@ function testOne() {
 	var callback = sinon.spy();
 	var proxy = once(callback);
 	proxy();
-	if (callback.calledOnce) { console.log("test1 calledOnce success"); } else { console.log("test1 calledOnce failure"); }
+	if (callback.calledOnce) {
+		console.log("test1 calledOnce success");
+	} else {
+		console.log("test1 calledOnce failure");
+	}
 }
 
 function testTwo() {
@@ -23,7 +29,11 @@ function testTwo() {
 	var proxy = once(callback);
 	proxy();
 	proxy();
-	if (callback.calledOnce) { console.log("test2 calledOnce success"); } else { console.log("test2 calledOnce failure"); }
+	if (callback.calledOnce) {
+		console.log("test2 calledOnce success");
+	} else {
+		console.log("test2 calledOnce failure");
+	}
 }
 
 function testThree() {
@@ -31,8 +41,16 @@ function testThree() {
 	var callback = sinon.spy({}, "method");
 	var proxy = once(callback);
 	proxy.call(obj, callback, 1, 2, 3);
-	if (callback.calledOn(obj)) { console.log("test3 calledOn success"); } else { console.log("test3 calledOn failure"); }
-	if (callback.calledWith(callback, 1, 2, 3)) { console.log("test3 calledWith success"); } else { console.log("test3 calledWith failure"); }
+	if (callback.calledOn(obj)) {
+		console.log("test3 calledOn success");
+	} else {
+		console.log("test3 calledOn failure");
+	}
+	if (callback.calledWith(callback, 1, 2, 3)) {
+		console.log("test3 calledWith success");
+	} else {
+		console.log("test3 calledWith failure");
+	}
 }
 
 function testFour() {
@@ -40,7 +58,11 @@ function testFour() {
 	var callback = sinon.stub().returns(42);
 	var proxy = once(callback);
 	var val = proxy.apply(callback, [1, 2, 3]);
-	if (val == 42) { console.log("test4 returns success"); } else { console.log("test4 returns failure"); }
+	if (val == 42) {
+		console.log("test4 returns success");
+	} else {
+		console.log("test4 returns failure");
+	}
 }
 
 function testFive() {
@@ -48,14 +70,17 @@ function testFive() {
 	var callback = sinon.stub().returnsArg(1);
 	var proxy = once(callback);
 	var val = proxy.apply(callback, [1, 2, 3]);
-	if (val == 2) { console.log("test5 returnsArg success"); } else { console.log("test5 returnsArg failure"); }
+	if (val == 2) {
+		console.log("test5 returnsArg success");
+	} else {
+		console.log("test5 returnsArg failure");
+	}
 }
 
 var objectUnderTest: any = {
-	process: function (obj: any) {
-		// It doesn't really matter what's here because the stub is going to replace this function
-		var dummy = true;
-		if (dummy) { return obj.success(99); } else { obj.failure(99); }
+	process: (obj: any) => {
+		obj.failure(99);
+		return obj.success(99);
 	}
 };
 
@@ -63,14 +88,14 @@ function testSix() {
 	var obj = { thisObj: true };
 	var stub = sinon.stub(objectUnderTest, "process").yieldsTo("success");
 	var val = objectUnderTest.process({
-		success: function () { console.log("test6 yieldsTo success"); },
-		failure: function () { console.log("test6 yieldsTo failure"); }
+		success: () => { console.log("test6 yieldsTo success"); },
+		failure: () => { console.log("test6 yieldsTo failure"); }
 	});
 	stub.restore();
 }
 
 function testSeven() {
-	var obj = { functionToTest : function () { } };
+	var obj = { functionToTest : () => {} };
 	var mockObj = sinon.mock(obj);
 	obj.functionToTest();
 	mockObj.expects('functionToTest').once();

--- a/sinon/sinon.d.ts
+++ b/sinon/sinon.d.ts
@@ -91,8 +91,10 @@ interface SinonStub extends SinonSpy {
 	resetBehavior(): void;
 	returns(obj: any): SinonStub;
 	returnsArg(index: number): SinonStub;
+	// ReSharper disable UsingOfReservedWord
 	throws(type?: string): SinonStub;
 	throws(obj: any): SinonStub;
+	// ReSharper restore UsingOfReservedWord
 	callsArg(index: number): SinonStub;
 	callsArgOn(index: number, context: any): SinonStub;
 	callsArgWith(index: number, ...args: any[]): SinonStub;
@@ -389,4 +391,8 @@ interface SinonStatic {
 	log: (message: string) => void;
 }
 
-declare var sinon: SinonStatic;
+declare module "sinon" {
+	export = __sinon;
+}
+
+declare var __sinon: SinonStatic;


### PR DESCRIPTION
Now you can write:

``` ts
///<reference path='chai.d.ts'/>
import chai = require('chai');
chai.expect(true).to.be.true;
```

This PR originally failed on chai-jquery, but I fixed those issues too. Actually, chai-jquery wasn't really doing anything before now.
