### PR TITLE
updated royalSlider typings

### DIFF
--- a/royalslider/royalslider-tests.ts
+++ b/royalslider/royalslider-tests.ts
@@ -100,7 +100,7 @@ jQuery(document).ready(function ($) {
 // Another example: $(".royalSlider").royalSlider('goTo', 3);
 // But it's recommended to get instance once if you have many calls:
 
-var slider = $(".royalSlider").royalSlider();
+var slider: RoyalSlider.RoyalSlider = $(".royalSlider").royalSlider().data('royalSlider');
 
 slider.goTo(3); // go to slide with id
 slider.next();  // next slide

--- a/royalslider/royalslider.d.ts
+++ b/royalslider/royalslider.d.ts
@@ -492,5 +492,5 @@ interface JQuery {
     *
     * @param options The options
     */
-    royalSlider(options?: RoyalSlider.RoyalSliderOptions): RoyalSlider.RoyalSlider;
+    royalSlider(options?: RoyalSlider.RoyalSliderOptions): JQuery;
 }


### PR DESCRIPTION
Fixed an error in the typings: The constructor method returns a jQuery object, not a royalSlider object.
