### PR TITLE
Changed the iso8601Week function of the Datepicker interface

### DIFF
--- a/jqueryui/jqueryui.d.ts
+++ b/jqueryui/jqueryui.d.ts
@@ -157,7 +157,7 @@ declare module JQueryUI {
         setDefaults(defaults: DatepickerOptions): void;
         formatDate(format: string, date: Date, settings?: DatepickerFormatDateOptions): string;
         parseDate(format: string, date: string, settings?: DatepickerFormatDateOptions): Date;
-        iso8601Week(date: Date): void;
+        iso8601Week(date: Date): number;
         noWeekends(): void;
     }
 


### PR DESCRIPTION
This function should return type 'number', not type 'void'. 
See: http://api.jqueryui.com/datepicker/
