### PR TITLE
Add AMD declaration for Moment.js

### DIFF
--- a/moment/moment.d.ts
+++ b/moment/moment.d.ts
@@ -319,3 +319,7 @@ interface MomentStatic {
 }
 
 declare var moment: MomentStatic;
+
+declare module 'moment' {
+	export = MomentStatic;
+}


### PR DESCRIPTION
Add a standard AMD declaration module to Moment.js. This seems particularly important to have in the declaration file because Moment.js includes a deprecation warning when attempting to use it as a global instead of a module.
