### PR TITLE
Backbone: Fixes for Model.isValid

### DIFF
--- a/backbone/backbone.d.ts
+++ b/backbone/backbone.d.ts
@@ -120,7 +120,7 @@ declare module Backbone {
         has(attribute: string): boolean;
         hasChanged(attribute?: string): boolean;
         isNew(): boolean;
-        isValid(): boolean;
+        isValid(options?:any): boolean;
         previous(attribute: string): any;
         previousAttributes(): any[];
         save(attributes?: any, options?: ModelSaveOptions): any;

--- a/backbone/backbone.d.ts
+++ b/backbone/backbone.d.ts
@@ -80,6 +80,7 @@ declare module Backbone {
     }
 
     class ModelBase extends Events {
+        url: string;
         url(): any;
         parse(response: any, options?: any): any;
         toJSON(options?: any): any;

--- a/backbone/backbone.d.ts
+++ b/backbone/backbone.d.ts
@@ -80,8 +80,7 @@ declare module Backbone {
     }
 
     class ModelBase extends Events {
-        url: string;
-        url(): any;
+        url: any;
         parse(response: any, options?: any): any;
         toJSON(options?: any): any;
         sync(...arg: any[]): JQueryXHR;

--- a/backbone/backbone.d.ts
+++ b/backbone/backbone.d.ts
@@ -80,7 +80,7 @@ declare module Backbone {
     }
 
     class ModelBase extends Events {
-        url: any;
+        url(): any;
         parse(response: any, options?: any): any;
         toJSON(options?: any): any;
         sync(...arg: any[]): JQueryXHR;


### PR DESCRIPTION
Model.isValid is now accepts optional options (see source)

I reverted the previous fix for Model.url, but this still needs to be solved somehow.
