### PR TITLE
Renamed François to Francois (forgive me)

### DIFF
--- a/jquery.form/jquery.form.d.ts
+++ b/jquery.form/jquery.form.d.ts
@@ -1,6 +1,6 @@
 ﻿// Type definitions for jQuery.form.js 3.26.0-2013.01.28
 // Project: http://malsup.com/jquery/form/
-// Definitions by: François Guillot <http://fguillot.developpez.com/>
+// Definitions by: Francois Guillot <http://fguillot.developpez.com/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 


### PR DESCRIPTION
The 'ç' character is causing a compilation error in TypeScript 0.9.1+
