### PR TITLE
Q: moved from module + functions to interface approach

### DIFF
--- a/breeze/breeze.d.ts
+++ b/breeze/breeze.d.ts
@@ -204,9 +204,9 @@ declare module breeze {
     class DataServiceAdapter {
         checkForRecomposition(interfaceInitializedArgs: { interfaceName: string; isDefault: boolean}): void;
         initialize(): void;
-        fetchMetadata(metadataStore: MetadataStore, dataService: DataService): Q.Promise<any>;
-        executeQuery(mappingContext: Object): Q.Promise<any>;
-        saveChanges(saveContext: { resourceName: string }, saveBundle: Object): Q.Promise<SaveResult>;
+        fetchMetadata(metadataStore: MetadataStore, dataService: DataService): QPromise<any>;
+        executeQuery(mappingContext: Object): QPromise<any>;
+        saveChanges(saveContext: { resourceName: string }, saveBundle: Object): QPromise<SaveResult>;
         JsonResultsAdapter: JsonResultsAdapter;
     }
 
@@ -299,8 +299,8 @@ declare module breeze {
         getValidationErrors(property: IProperty): ValidationError[];
         hasValidationErrors: boolean;
 
-        loadNavigationProperty(navigationProperty: string, callback?: Function, errorCallback?: Function): Q.Promise<QueryResult>;
-        loadNavigationProperty(navigationProperty: NavigationProperty, callback?: Function, errorCallback?: Function): Q.Promise<QueryResult>;
+        loadNavigationProperty(navigationProperty: string, callback?: Function, errorCallback?: Function): QPromise<QueryResult>;
+        loadNavigationProperty(navigationProperty: NavigationProperty, callback?: Function, errorCallback?: Function): QPromise<QueryResult>;
 
         rejectChanges(): void;
 
@@ -380,15 +380,15 @@ declare module breeze {
         createEntity(typeName: string, config?: {}, entityState?: EntityStateSymbol) : Entity;
         createEntity(entityType: EntityType, config?: {}, entityState?: EntityStateSymbol): Entity;
         detachEntity(entity: Entity): boolean;
-        executeQuery(query: string, callback?: ExecuteQuerySuccessCallback, errorCallback?: ExecuteQueryErrorCallback): Q.Promise<QueryResult>;
-        executeQuery(query: EntityQuery, callback?: ExecuteQuerySuccessCallback, errorCallback?: ExecuteQueryErrorCallback): Q.Promise<QueryResult>;
+        executeQuery(query: string, callback?: ExecuteQuerySuccessCallback, errorCallback?: ExecuteQueryErrorCallback): QPromise<QueryResult>;
+        executeQuery(query: EntityQuery, callback?: ExecuteQuerySuccessCallback, errorCallback?: ExecuteQueryErrorCallback): QPromise<QueryResult>;
 
         executeQueryLocally(query: EntityQuery): Entity[];
         exportEntities(entities?: Entity[]): string;
-        fetchEntityByKey(typeName: string, keyValue: any, checkLocalCacheFirst?: boolean): Q.Promise<EntityByKeyResult>;
-        fetchEntityByKey(typeName: string, keyValues: any[], checkLocalCacheFirst?: boolean): Q.Promise<EntityByKeyResult>;
-        fetchEntityByKey(entityKey: EntityKey): Q.Promise<EntityByKeyResult>;
-        fetchMetadata(callback?: (schema: any) => void , errorCallback?: breeze.core.ErrorCallback): Q.Promise<any>;
+        fetchEntityByKey(typeName: string, keyValue: any, checkLocalCacheFirst?: boolean): QPromise<EntityByKeyResult>;
+        fetchEntityByKey(typeName: string, keyValues: any[], checkLocalCacheFirst?: boolean): QPromise<EntityByKeyResult>;
+        fetchEntityByKey(entityKey: EntityKey): QPromise<EntityByKeyResult>;
+        fetchMetadata(callback?: (schema: any) => void , errorCallback?: breeze.core.ErrorCallback): QPromise<any>;
         generateTempKeyValue(entity: Entity): any;
         getChanges(): Entity[];
         getChanges(entityTypeName: string): Entity[];
@@ -422,7 +422,7 @@ declare module breeze {
         importEntities(exportedData: Object, config?: { mergeStrategy?: StrategySymbol; }): EntityManager;
 
         rejectChanges(): Entity[];
-        saveChanges(entities?: Entity[], saveOptions?: SaveOptions, callback?: SaveChangesSuccessCallback, errorCallback?: SaveChangesErrorCallback): Q.Promise<SaveResult>;
+        saveChanges(entities?: Entity[], saveOptions?: SaveOptions, callback?: SaveChangesSuccessCallback, errorCallback?: SaveChangesErrorCallback): QPromise<SaveResult>;
         setProperties(config: EntityManagerProperties): void;
     }
 
@@ -493,7 +493,7 @@ declare module breeze {
 
         constructor (resourceName?: string);
 
-        execute(callback?: ExecuteQuerySuccessCallback, errorCallback?: ExecuteQueryErrorCallback): Q.Promise<QueryResult>;
+        execute(callback?: ExecuteQuerySuccessCallback, errorCallback?: ExecuteQueryErrorCallback): QPromise<QueryResult>;
         executeLocally(): Entity[];
         expand(propertyPaths: string[]): EntityQuery;
         expand(propertyPaths: string): EntityQuery;
@@ -645,8 +645,8 @@ declare module breeze {
         addDataService(dataService: DataService): void;
         addEntityType(structuralType: IStructuralType): void;
         exportMetadata(): string;
-        fetchMetadata(dataService: string, callback?: (data) => void , errorCallback?: breeze.core.ErrorCallback): Q.Promise<any>;
-        fetchMetadata(dataService: DataService, callback?: (data) => void , errorCallback?: breeze.core.ErrorCallback): Q.Promise<any>;
+        fetchMetadata(dataService: string, callback?: (data) => void , errorCallback?: breeze.core.ErrorCallback): QPromise<any>;
+        fetchMetadata(dataService: DataService, callback?: (data) => void , errorCallback?: breeze.core.ErrorCallback): QPromise<any>;
         getDataService(serviceName: string): DataService;
         getEntityType(entityTypeName: string, okIfNotFound?: boolean): IStructuralType;
         getEntityTypes(): IStructuralType[];

--- a/q/Q-tests.ts
+++ b/q/Q-tests.ts
@@ -54,7 +54,7 @@ Q.fcall(function () { })
     }).done();
 
 Q.allResolved([])
-.then(function (promises: Q.Promise<any>[]) {
+.then(function (promises: QPromise<any>[]) {
     promises.forEach(function (promise) {
         if (promise.isFulfilled()) {
             var value = promise.valueOf();
@@ -64,9 +64,9 @@ Q.allResolved([])
     })
 });
 
-declare var arrayPromise: Q.IPromise<number[]>;
-declare var stringPromise: Q.IPromise<string>;
-declare function returnsNumPromise(text: string): Q.Promise<number>;
+declare var arrayPromise: QIPromise<number[]>;
+declare var stringPromise: QIPromise<string>;
+declare function returnsNumPromise(text: string): QPromise<number>;
 
 Q<number[]>(arrayPromise) // type specification required
     .then(arr => arr.join(','))
@@ -79,10 +79,10 @@ declare var jPromise: JQueryPromise<string>;
 Q<string>(jPromise).then(str => str.split(','));
 jPromise.then<number>(returnsNumPromise);
 
-// watch the typing flow through from jQueryPromise to Q.Promise
+// watch the typing flow through from jQueryPromise to QPromise
 Q(jPromise).then(str => str.split(','));
 
-declare var promiseArray: Q.IPromise<number>[];
+declare var promiseArray: QIPromise<number>[];
 var qPromiseArray = promiseArray.map(p => Q<number>(p));
 var myNums: any[] = [2, 3, Q(4), 5, Q(6), Q(7)];
 
@@ -95,8 +95,8 @@ Q.fbind((dateString?: string) => new Date(dateString), "11/11/1991")().then(d =>
 Q.when(8, num => num + "!");
 Q.when(Q(8), num => num + "!").then(str => str.split(','));
 
-declare function saveToDisk(): Q.Promise<any>;
-declare function saveToCloud(): Q.Promise<any>;
+declare function saveToDisk(): QPromise<any>;
+declare function saveToCloud(): QPromise<any>;
 Q.allSettled([saveToDisk(), saveToCloud()]).spread(function (disk, cloud) {
     console.log("saved to disk:", disk.state === "fulfilled");
     console.log("saved to cloud:", cloud.state === "fulfilled");

--- a/q/Q.d.ts
+++ b/q/Q.d.ts
@@ -1,162 +1,164 @@
 // Type definitions for Q
 // Project: https://github.com/kriskowal/q
-// Definitions by: Barrie Nemetchek, Andrew Gaspar
+// Definitions by: Barrie Nemetchek, Andrew Gaspar, John Reilly
 // Definitions: https://github.com/borisyankov/DefinitelyTyped  
 
 /// <reference path="../jquery/jquery.d.ts"/>
 
-declare function Q<T>(promise: Q.IPromise<T>): Q.Promise<T>;
-declare function Q<T>(promise: JQueryPromise<T>): Q.Promise<T>;
-declare function Q<T>(value: T): Q.Promise<T>;
+interface QIPromise<T> {
+    then<U>(onFulfill: (value: T) => QIPromise<U>, onReject?: (reason: any) => QIPromise<U>): QIPromise<U>;
+    then<U>(onFulfill: (value: T) => QIPromise<U>, onReject?: (reason: any) => U): QIPromise<U>;
+    then<U>(onFulfill: (value: T) => U, onReject?: (reason: any) => QIPromise<U>): QIPromise<U>;
+    then<U>(onFulfill: (value: T) => U, onReject?: (reason: any) => U): QIPromise<U>;
+}
 
-declare module Q {
-    interface IPromise<T> {
-        then<U>(onFulfill: (value: T) => IPromise<U>, onReject?: (reason: any) => IPromise<U>): IPromise<U>;
-        then<U>(onFulfill: (value: T) => IPromise<U>, onReject?: (reason: any) => U): IPromise<U>;
-        then<U>(onFulfill: (value: T) => U, onReject?: (reason: any) => IPromise<U>): IPromise<U>;
-        then<U>(onFulfill: (value: T) => U, onReject?: (reason: any) => U): IPromise<U>;
-    }
+interface QDeferred<T> {
+    promise: QPromise<T>;
+    resolve(value: T): void;
+    reject(reason: any): void;
+    notify(value: any): void;
+    makeNodeResolver(): (reason: any, value: T) => void;
+}
 
-    interface Deferred<T> {
-        promise: Promise<T>;
-        resolve(value: T): void;
-        reject(reason: any): void;
-        notify(value: any): void;
-        makeNodeResolver(): (reason: any, value: T) => void;
-    }
+interface QPromise<T> {
+    fin(finallyCallback: () => any): QPromise<T>;
+    finally(finallyCallback: () => any): QPromise<T>;
 
-    interface Promise<T> {
-        fin(finallyCallback: () => any): Promise<T>;
-        finally(finallyCallback: () => any): Promise<T>;
+    then<U>(onFulfill: (value: T) => QIPromise<U>, onReject?: (reason: any) => QIPromise<U>, onProgress?: Function): QPromise<U>;
+    then<U>(onFulfill: (value: T) => QIPromise<U>, onReject?: (reason: any) => U, onProgress?: Function): QPromise<U>;
+    then<U>(onFulfill: (value: T) => U, onReject?: (reason: any) => QIPromise<U>, onProgress?: Function): QPromise<U>;
+    then<U>(onFulfill: (value: T) => U, onReject?: (reason: any) => U, onProgress?: Function): QPromise<U>;
 
-        then<U>(onFulfill: (value: T) => IPromise<U>, onReject?: (reason: any) => IPromise<U>, onProgress?: Function): Promise<U>;
-        then<U>(onFulfill: (value: T) => IPromise<U>, onReject?: (reason: any) => U, onProgress?: Function): Promise<U>;
-        then<U>(onFulfill: (value: T) => U, onReject?: (reason: any) => IPromise<U>, onProgress?: Function): Promise<U>;
-        then<U>(onFulfill: (value: T) => U, onReject?: (reason: any) => U, onProgress?: Function): Promise<U>;
+    spread<U>(onFulfilled: Function, onRejected?: Function): QPromise<U>;
 
-        spread<U>(onFulfilled: Function, onRejected?: Function): Promise<U>;
+    fail<U>(onRejected: (reason: any) => U): QPromise<U>;
+    fail<U>(onRejected: (reason: any) => QIPromise<U>): QPromise<U>;
+    catch<U>(onRejected: (reason: any) => U): QPromise<U>;
+    catch<U>(onRejected: (reason: any) => QIPromise<U>): QPromise<U>;
 
-        fail<U>(onRejected: (reason: any) => U): Promise<U>;
-        fail<U>(onRejected: (reason: any) => IPromise<U>): Promise<U>;
-        catch<U>(onRejected: (reason: any) => U): Promise<U>;
-        catch<U>(onRejected: (reason: any) => IPromise<U>): Promise<U>;
+    progress(onProgress: (progress: any) => any): QPromise<T>;
 
-        progress(onProgress: (progress: any) => any): Promise<T>;
+    done(onFulfilled?: (value: T) => any, onRejected?: (reason: any) => any, onProgress?: (progress: any) => any): void;
 
-        done(onFulfilled?: (value: T) => any, onRejected?: (reason: any) => any, onProgress?: (progress: any) => any): void;
+    get<U>(propertyName: String): QPromise<U>;
+    set<U>(propertyName: String, value: any): QPromise<U>;
+    delete<U>(propertyName: String): QPromise<U>;
+    post<U>(methodName: String, args: any[]): QPromise<U>;
+    invoke<U>(methodName: String, ...args: any[]): QPromise<U>;
+    fapply<U>(args: any[]): QPromise<U>;
+    fcall<U>(...args: any[]): QPromise<U>;
 
-        get<U>(propertyName: String): Promise<U>;
-        set<U>(propertyName: String, value: any): Promise<U>;
-        delete<U>(propertyName: String): Promise<U>;
-        post<U>(methodName: String, args: any[]): Promise<U>;
-        invoke<U>(methodName: String, ...args: any[]): Promise<U>;
-        fapply<U>(args: any[]): Promise<U>;
-        fcall<U>(...args: any[]): Promise<U>;
+    keys(): QPromise<string[]>;
 
-        keys(): Promise<string[]>;
-        
-        thenResolve<U>(value: U): Promise<U>;
-        thenReject(reason: any): Promise<T>;
-        timeout(ms: number, message?: string): Promise<T>;
-        delay(ms: number): Promise<T>;
+    thenResolve<U>(value: U): QPromise<U>;
+    thenReject(reason: any): QPromise<T>;
+    timeout(ms: number, message?: string): QPromise<T>;
+    delay(ms: number): QPromise<T>;
 
-        isFulfilled(): boolean;
-        isRejected(): boolean;
-        isPending(): boolean;
+    isFulfilled(): boolean;
+    isRejected(): boolean;
+    isPending(): boolean;
 
-        valueOf(): any;
+    valueOf(): any;
 
-        inspect(): PromiseState<T>;
-    }
+    inspect(): QPromiseState<T>;
+}
 
-    interface PromiseState<T> {
-        state: string /* "fulfilled", "rejected", "pending" */;
-        value?: T;
-        reason?: any;
-    }
+interface QPromiseState<T> {
+    state: string /* "fulfilled", "rejected", "pending" */;
+    value?: T;
+    reason?: any;
+}
+
+interface QStatic {
+
+    <T>(promise: QIPromise<T>): QPromise<T>;
+    <T>(promise: JQueryPromise<T>): QPromise<T>;
+    <T>(value: T): QPromise<T>;
 
     // if no fulfill, reject, or progress provided, returned promise will be of same type
-    export function when<T>(value: IPromise<T>): Promise<T>;
-    export function when<T>(value: T): Promise<T>;
+    when<T>(value: QIPromise<T>): QPromise<T>;
+    when<T>(value: T): QPromise<T>;
 
     // If a non-promise value is provided, it will not reject or progress
-    export function when<T, U>(value: T, onFulfilled: (val: T) => IPromise<U>): Promise<U>;
-    export function when<T, U>(value: T, onFulfilled: (val: T) => U): Promise<U>;
+    when<T, U>(value: T, onFulfilled: (val: T) => QIPromise<U>): QPromise<U>;
+    when<T, U>(value: T, onFulfilled: (val: T) => U): QPromise<U>;
 
-    export function when<T, U>(value: IPromise<T>, onFulfilled: (val: T) => IPromise<U>, onRejected?: (reason: any) => IPromise<U>, onProgress?: (progress: any) => any): Promise<U>;
-    export function when<T, U>(value: IPromise<T>, onFulfilled: (val: T) => IPromise<U>, onRejected?: (reason: any) => U, onProgress?: (progress: any) => any): Promise<U>;
-    export function when<T, U>(value: IPromise<T>, onFulfilled: (val: T) => U, onRejected?: (reason: any) => IPromise<U>, onProgress?: (progress: any) => any): Promise<U>;
-    export function when<T, U>(value: IPromise<T>, onFulfilled: (val: T) => U, onRejected?: (reason: any) => U, onProgress?: (progress: any) => any): Promise<U>;
+    when<T, U>(value: QIPromise<T>, onFulfilled: (val: T) => QIPromise<U>, onRejected?: (reason: any) => QIPromise<U>, onProgress?: (progress: any) => any): QPromise<U>;
+    when<T, U>(value: QIPromise<T>, onFulfilled: (val: T) => QIPromise<U>, onRejected?: (reason: any) => U, onProgress?: (progress: any) => any): QPromise<U>;
+    when<T, U>(value: QIPromise<T>, onFulfilled: (val: T) => U, onRejected?: (reason: any) => QIPromise<U>, onProgress?: (progress: any) => any): QPromise<U>;
+    when<T, U>(value: QIPromise<T>, onFulfilled: (val: T) => U, onRejected?: (reason: any) => U, onProgress?: (progress: any) => any): QPromise<U>;
     
-    //export function try(method: Function, ...args: any[]): Promise<any>; // <- This is broken currently - not sure how to fix.
+    //export function try(method: Function, ...args: any[]): QPromise<any>; // <- This is broken currently - not sure how to fix.
 
-    export function fbind<T>(method: (...args: any[]) => IPromise<T>, ...args: any[]): (...args: any[]) => Promise<T>;
-    export function fbind<T>(method: (...args: any[]) => T, ...args: any[]): (...args: any[]) => Promise<T>;
+    fbind<T>(method: (...args: any[]) => QIPromise<T>, ...args: any[]): (...args: any[]) => QPromise<T>;
+    fbind<T>(method: (...args: any[]) => T, ...args: any[]): (...args: any[]) => QPromise<T>;
 
-    export function fcall<T>(method: (...args: any[]) => T, ...args: any[]): Promise<T>;
+    fcall<T>(method: (...args: any[]) => T, ...args: any[]): QPromise<T>;
 
-    export function send<T>(obj: any, functionName: string, ...args: any[]): Promise<T>;
-    export function invoke<T>(obj: any, functionName: string, ...args: any[]): Promise<T>;
-    export function mcall<T>(obj: any, functionName: string, ...args: any[]): Promise<T>;
+    send<T>(obj: any, functionName: string, ...args: any[]): QPromise<T>;
+    invoke<T>(obj: any, functionName: string, ...args: any[]): QPromise<T>;
+    mcall<T>(obj: any, functionName: string, ...args: any[]): QPromise<T>;
 
-    export function nfbind<T>(nodeFunction: Function, ...args: any[]): (...args: any[]) => Promise<T>;
-    export function nfcall<T>(nodeFunction: Function, ...args: any[]): Promise<T>;
+    nfbind<T>(nodeFunction: Function, ...args: any[]): (...args: any[]) => QPromise<T>;
+    nfcall<T>(nodeFunction: Function, ...args: any[]): QPromise<T>;
 
-    export function ninvoke<T>(nodeModule: any, functionName: string, ...args: any[]): Promise<T>;
-    export function nsend<T>(nodeModule: any, functionName: string, ...args: any[]): Promise<T>;
-    export function nmcall<T>(nodeModule: any, functionName: string, ...args: any[]): Promise<T>;
+    ninvoke<T>(nodeModule: any, functionName: string, ...args: any[]): QPromise<T>;
+    nsend<T>(nodeModule: any, functionName: string, ...args: any[]): QPromise<T>;
+    nmcall<T>(nodeModule: any, functionName: string, ...args: any[]): QPromise<T>;
 
-    export function all<T>(promises: IPromise<T>[]): Promise<T[]>;
-    export function all<T>(promises: any[]): Promise<T[]>;
+    all<T>(promises: QIPromise<T>[]): QPromise<T[]>;
+    all<T>(promises: any[]): QPromise<T[]>;
     
-    export function allSettled<T>(promises: IPromise<T>[]): Promise<PromiseState<T>[]>;
-    export function allSettled<T>(promises: any[]): Promise<PromiseState<T>[]>;
+    allSettled<T>(promises: QIPromise<T>[]): QPromise<QPromiseState<T>[]>;
+    allSettled<T>(promises: any[]): QPromise<QPromiseState<T>[]>;
 
-    export function allResolved<T>(promises: IPromise<T>[]): Promise<Promise<T>[]>;
-    export function allResolved<T>(promises: any[]): Promise<Promise<T>[]>;
+    allResolved<T>(promises: QIPromise<T>[]): QPromise<QPromise<T>[]>;
+    allResolved<T>(promises: any[]): QPromise<QPromise<T>[]>;
 
-    export function spread<U>(promises: any[], onFulfilled: (...args: any[]) => IPromise<U>, onRejected: (reason: any) => IPromise<U>): Promise<U>;
-    export function spread<U>(promises: any[], onFulfilled: (...args: any[]) => IPromise<U>, onRejected: (reason: any) => U): Promise<U>;
-    export function spread<U>(promises: any[], onFulfilled: (...args: any[]) => U, onRejected: (reason: any) => IPromise<U>): Promise<U>;
-    export function spread<U>(promises: any[], onFulfilled: (...args: any[]) => U, onRejected: (reason: any) => U): Promise<U>;
+    spread<U>(promises: any[], onFulfilled: (...args: any[]) => QIPromise<U>, onRejected: (reason: any) => QIPromise<U>): QPromise<U>;
+    spread<U>(promises: any[], onFulfilled: (...args: any[]) => QIPromise<U>, onRejected: (reason: any) => U): QPromise<U>;
+    spread<U>(promises: any[], onFulfilled: (...args: any[]) => U, onRejected: (reason: any) => QIPromise<U>): QPromise<U>;
+    spread<U>(promises: any[], onFulfilled: (...args: any[]) => U, onRejected: (reason: any) => U): QPromise<U>;
     
-    export function spread<T, U>(promises: IPromise<T>[], onFulfilled: (...args: T[]) => IPromise<U>, onRejected: (reason: any) => IPromise<U>): Promise<U>;
-    export function spread<T, U>(promises: IPromise<T>[], onFulfilled: (...args: T[]) => IPromise<U>, onRejected: (reason: any) => U): Promise<U>;
-    export function spread<T, U>(promises: IPromise<T>[], onFulfilled: (...args: T[]) => U, onRejected: (reason: any) => IPromise<U>): Promise<U>;
-    export function spread<T, U>(promises: IPromise<T>[], onFulfilled: (...args: T[]) => U, onRejected: (reason: any) => U): Promise<U>;
+    spread<T, U>(promises: QIPromise<T>[], onFulfilled: (...args: T[]) => QIPromise<U>, onRejected: (reason: any) => QIPromise<U>): QPromise<U>;
+    spread<T, U>(promises: QIPromise<T>[], onFulfilled: (...args: T[]) => QIPromise<U>, onRejected: (reason: any) => U): QPromise<U>;
+    spread<T, U>(promises: QIPromise<T>[], onFulfilled: (...args: T[]) => U, onRejected: (reason: any) => QIPromise<U>): QPromise<U>;
+    spread<T, U>(promises: QIPromise<T>[], onFulfilled: (...args: T[]) => U, onRejected: (reason: any) => U): QPromise<U>;
     
-    export function timeout<T>(promise: Promise<T>, ms: number, message?: string): Promise<T>;
+    timeout<T>(promise: QPromise<T>, ms: number, message?: string): QPromise<T>;
 
-    export function delay<T>(promise: Promise<T>, ms: number): Promise<T>;
-    export function delay<T>(value: T, ms: number): Promise<T>;
+    delay<T>(promise: QPromise<T>, ms: number): QPromise<T>;
+    delay<T>(value: T, ms: number): QPromise<T>;
 
-    export function isFulfilled(promise: Promise<any>): boolean;
-    export function isRejected(promise: Promise<any>): boolean;
-    export function isPending(promise: Promise<any>): boolean;
+    isFulfilled(promise: QPromise<any>): boolean;
+    isRejected(promise: QPromise<any>): boolean;
+    isPending(promise: QPromise<any>): boolean;
 
-    export function defer<T>(): Deferred<T>;
+    defer<T>(): QDeferred<T>;
 
-    export function reject(reason?: any): Promise<any>;
+    reject(reason?: any): QPromise<any>;
 
-    export function promise<T>(resolver: (resolve: (val: IPromise<T>) => void , reject: (reason: any) => void , notify: (progress: any) => void ) => void ): Promise<T>;
-    export function promise<T>(resolver: (resolve: (val: T) => void , reject: (reason: any) => void , notify: (progress: any) => void ) => void ): Promise<T>;
+    promise<T>(resolver: (resolve: (val: QIPromise<T>) => void , reject: (reason: any) => void , notify: (progress: any) => void ) => void ): QPromise<T>;
+    promise<T>(resolver: (resolve: (val: T) => void , reject: (reason: any) => void , notify: (progress: any) => void ) => void ): QPromise<T>;
 
-    export function promised<T>(callback: (...args: any[]) => T): (...args: any[]) => Promise<T>;
+    promised<T>(callback: (...args: any[]) => T): (...args: any[]) => QPromise<T>;
 
-    export function isPromise(object: any): boolean;
-    export function isPromiseAlike(object: any): boolean;
-    export function isPending(object: any): boolean;
+    isPromise(object: any): boolean;
+    isPromiseAlike(object: any): boolean;
+    isPending(object: any): boolean;
 
-    export function async<T>(generatorFunction: any): (...args: any[]) => Promise<T>;
-    export function nextTick(callback: Function): void;
+    async<T>(generatorFunction: any): (...args: any[]) => QPromise<T>;
+    nextTick(callback: Function): void;
 
-    export var onerror: (reason: any) => void;
-    export var longStackSupport: boolean;
+    resolve<T>(object: QIPromise<T>): QPromise<T>;
+    resolve<T>(object: T): QPromise<T>;
 
-    export function resolve<T>(object: IPromise<T>): Promise<T>;
-    export function resolve<T>(object: T): Promise<T>;
+    onerror: (reason: any) => void;
+    longStackSupport: boolean;
 }
 
 declare module "q" {
     export = Q;
 }
+declare var Q: QStatic;


### PR DESCRIPTION
This change has been made to cater for what appears to be a bug with Declaration Merging in TypeScript 0.9.5.  You can find details on the problem [here](https://typescript.codeplex.com/workitem/1995) - also take a look at my comment [here](https://typescript.codeplex.com/workitem/1995#CommentContainer18).  If you could vote up this issue on CodePlex that would be greatly appreciated.  It would be good to get the fix made for the next version of  TypeScript.

There have been changes to the tests purely because interfaces are no longer nested in a module.  So the following changes in interface name apply:

`Q.Promise` => `QPromise`
`Q.IPromise` => `QIPromise`
`Q.Deferred` => `QDeferred`
`Q.PromiseState` => `QPromiseState`

The tests are otherwise unchanged and still pass on my machine.

I have _no_ intention to merge this myself without some input first from other Q users - ideally from @AndrewGaspar and @bnemetchek.

If this is merged then anyone who has reference to `Q.Promise`, `Q.IPromise`, `Q.Deferred` or `Q.PromiseState` will need to change these entries in their code.

For what it's worth I've only made these changes because of the TypeScript 0.9.5 bug.  Otherwise I was quite happy for the typings to be defined using  the module + functions approach.  But this seems to be necessary for now and may help other people who are otherwise holding off upgrading to TS 0.9.5.
