### PR TITLE
Adds back "$.html(any)" as valid overload.

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -808,10 +808,11 @@ interface JQuery {
      */
     html(func: (index: number, oldhtml: string) => string): JQuery;
     /**
-     * Set the HTML contents of each element in the set of matched elements.
-     *
-     * @param func A function returning the HTML content to set. Receives the index position of the element in the set and the old HTML value as arguments. jQuery empties the element before calling the function; use the oldhtml argument to reference the previous content. Within the function, this refers to the current element in the set.
-     */
+    * Set the HTML contents of each element in the set of matched elements.
+    *
+    * @param content An htmlString or Element or Array or jQuery object.
+    */
+    html(content: any): JQuery;
 
     /**
      * Get the value of a property for the first element in the set of matched elements.


### PR DESCRIPTION
Jquery documentation is wrong, as html is actually .empty().append(), and the parameter for append is mapped as "htmlString or Element or Array or jQuery".
