### PR TITLE
Updated gitignore to ignore IntelliJ files and node modules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,24 +30,7 @@ Properties
 !_infrastructure/tests/*/*/*.js
 !_infrastructure/tests/*/*/*/*.js
 
-.idea/.name
+.idea
+*.iml
 
-.idea/DefinitelyTyped.iml
-
-.idea/encodings.xml
-
-.idea/libraries/Generated_files.xml
-
-.idea/misc.xml
-
-.idea/modules.xml
-
-.idea/scopes/scope_settings.xml
-
-.idea/vcs.xml
-
-.idea/workspace.xml
-
-.idea/watcherTasks.xml
-
-.idea/watcherTasks.xml
+node_modules


### PR DESCRIPTION
I figure just ignoring the .idea directory and the idea modules would be safest for other developers using IntelliJ IDEA

Also, I ignore any locally installed node modules.
