### PR TITLE
d3.entries accepts objects, not arrays (but returns an array).

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -212,7 +212,7 @@ declare module D3 {
         *
         * @param map Array of objects to get the key-value pairs from
         */
-        entries(map: any[]): any[];
+        entries(map: any): any[];
         /**
         * merge multiple arrays into one array
         *


### PR DESCRIPTION
See example usage in the docs - https://github.com/mbostock/d3/wiki/Arrays#wiki-d3_entries.
