### PR TITLE
support optional scope on ITemplateLinkingFunction

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -543,7 +543,9 @@ declare module ng {
     }
 
     interface ITemplateLinkingFunction {
-        (scope?: IScope, cloneAttachFn?: ICloneAttachFunction): JQuery;
+        // If the scope is provided, then the cloneAttachFn must be as well.
+        (scope: IScope, cloneAttachFn: ICloneAttachFunction): JQuery;
+        // If one argument is provided, then it's assumed to be the cloneAttachFn.
         (cloneAttachFn?: ICloneAttachFunction): JQuery;
     }
 

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -537,9 +537,15 @@ declare module ng {
         directive(directivesMap: any): ICompileProvider;
     }
 
-    interface ITemplateLinkingFunction {
+    interface ICloneAttachFunction {
         // Let's hint but not force cloneAttachFn's signature
-        (scope: IScope, cloneAttachFn?: (clonedElement?: JQuery, scope?: IScope) => any): JQuery;
+        (clonedElement?: JQuery, scope?: IScope): any
+    }
+
+    interface ITemplateLinkingFunction {
+        (scope: IScope, cloneAttachFn?: ICloneAttachFunction): JQuery;
+        // scope argument is optional
+        (cloneAttachFn?: ICloneAttachFunction): JQuery;
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -543,7 +543,7 @@ declare module ng {
     }
 
     interface ITemplateLinkingFunction {
-        (scope: IScope, cloneAttachFn?: ICloneAttachFunction): JQuery;
+        (scope?: IScope, cloneAttachFn?: ICloneAttachFunction): JQuery;
         // scope argument is optional
         (cloneAttachFn?: ICloneAttachFunction): JQuery;
     }

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -544,7 +544,6 @@ declare module ng {
 
     interface ITemplateLinkingFunction {
         (scope?: IScope, cloneAttachFn?: ICloneAttachFunction): JQuery;
-        // scope argument is optional
         (cloneAttachFn?: ICloneAttachFunction): JQuery;
     }
 

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -539,7 +539,7 @@ declare module ng {
 
     interface ICloneAttachFunction {
         // Let's hint but not force cloneAttachFn's signature
-        (clonedElement?: JQuery, scope?: IScope): any
+        (clonedElement?: JQuery, scope?: IScope): any;
     }
 
     interface ITemplateLinkingFunction {


### PR DESCRIPTION
The scope parameter on ITemplateLinkingFunction is optional.  This expands the interface to support this case.  I also broke ICloneAttachFunction into its own interface to avoid repeating its definition.
