### PR TITLE
breeze.config declaration for registerAdapter missing a parameter

### DIFF
--- a/breeze/breeze-tests.ts
+++ b/breeze/breeze-tests.ts
@@ -867,8 +867,8 @@ function test_config() {
     s = config.interfaceInitialized.type;
     o = config.interfaceRegistry;
     o = config.objectRegistry;
-    config.registerAdapter("myAdapterName");
     var f1: Function;
+    config.registerAdapter("myAdapterName", f1);
     config.registerFunction(f1, "myFunction");
     config.registerType(f1, "myCtor");
     s = config.stringifyPad;

--- a/breeze/breeze.d.ts
+++ b/breeze/breeze.d.ts
@@ -884,7 +884,7 @@ declare module breeze.config {
     var interfaceInitialized: Event;
     var interfaceRegistry: Object;
     var objectRegistry: Object;
-    export function registerAdapter(interfaceName: string): void;
+    export function registerAdapter(interfaceName: string, adapterCtor: Object): void;
     export function registerFunction(fn: Function, fnName: string): void;
     export function registerType(ctor: Function, typeName: string): void;
     //static setProperties(config: Object): void; //deprecated

--- a/breeze/breeze.d.ts
+++ b/breeze/breeze.d.ts
@@ -884,7 +884,7 @@ declare module breeze.config {
     var interfaceInitialized: Event;
     var interfaceRegistry: Object;
     var objectRegistry: Object;
-    export function registerAdapter(interfaceName: string, adapterCtor: Object): void;
+    export function registerAdapter(interfaceName: string, adapterCtor: Function): void;
     export function registerFunction(fn: Function, fnName: string): void;
     export function registerType(ctor: Function, typeName: string): void;
     //static setProperties(config: Object): void; //deprecated


### PR DESCRIPTION
Small update to properly define the registerAdapter method with the missing adapterCtor parameter.
