### PR TITLE
accounting.js type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Other means to get the definitions
 
 List of Definitions
 -------------------
+* [accounting.js](http://josscrowcroft.github.io/accounting.js/) (by [Sergey Gerasimov](https://github.com/gerich-home))
 * [Ace Cloud9 Editor](http://ace.ajax.org/) (by [Diullei Gomes](https://github.com/Diullei))
 * [Add To Home Screen] (http://cubiq.org/add-to-home-screen) (by [James Wilkins] (http://www.codeplex.com/site/users/view/jamesnw))
 * [AmCharts](http://www.amcharts.com/) (by [Covobonomo](https://github.com/covobonomo/))

--- a/accounting/accounting-tests.ts
+++ b/accounting/accounting-tests.ts
@@ -1,0 +1,107 @@
+﻿/// <reference path="accounting.d.ts"/>
+
+// formatMoney
+
+// Default usage:
+accounting.formatMoney(12345678); // $12,345,678.00
+
+// European formatting (custom symbol and separators), could also use options object as second param:
+accounting.formatMoney(4999.99, "€", 2, ".", ","); // €4.999,99
+
+// Negative values are formatted nicely, too:
+accounting.formatMoney(-500000, "£ ", 0); // £ -500,000
+
+// Simple `format` string allows control of symbol position [%v = value, %s = symbol]:
+accounting.formatMoney(5318008, { symbol: "GBP", format: "%v %s" }); // 5,318,008.00 GBP
+
+// Example usage with options object:
+accounting.formatMoney(5318008, {
+    symbol: "GBP",
+    precision: 0,
+    thousand: "·",
+    format: {
+        pos: "%s %v",
+        neg: "%s (%v)",
+        zero: "%s  --"
+    }
+});
+
+// Will recursively format an array of values:
+accounting.formatMoney([123, 456, [78, 9]], "$", 0); // ["$123", "$456", ["$78", "$9"]]
+
+
+
+// formatColumn
+
+// Format list of numbers for display:
+accounting.formatColumn([123.5, 3456.49, 777888.99, 12345678, -5432], "$ ");
+
+// Example usage (NB. use a space after the symbol to add arbitrary padding to all values):
+accounting.formatColumn([123, 12345], "$ ", 0); // ["$    123", "$ 12,345"]
+
+// List of numbers can be a multi-dimensional array (formatColumn is applied recursively):
+accounting.formatColumn([[1, 100], [900, 9]]); // [["$  1.00", "$100.00"], ["$900.00", "$  9.00"]]
+
+
+
+// formatNumber
+
+// Example usage:
+accounting.formatNumber(5318008); // 5,318,008
+accounting.formatNumber(9876543.21, 3, " "); // 9 876 543.210
+accounting.formatNumber(4999.99, 2, ".", ","); // 4.999,99
+
+// Example usage with options object:
+accounting.formatNumber(5318008, {
+    precision: 3,
+    thousand: " "
+});
+
+// Will recursively format an array of values:
+accounting.formatNumber([123456, [7890, 123]]); // ["123,456", ["7,890", "123"]]
+
+
+
+// toFixed
+
+(0.615).toFixed(2); // "0.61"
+accounting.toFixed(0.615, 2); // "0.62"
+
+
+
+
+// unformat
+
+// Example usage:
+accounting.unformat("£ 12,345,678.90 GBP"); // 12345678.9
+accounting.unformat("GBP £ 12,345,678.90"); // 12345678.9
+
+// If a non-standard decimal separator was used (eg. a comma) unformat() will need it in order to work out
+// which part of the number is a decimal/float:
+accounting.unformat("€ 1.000.000,00", ","); // 1000000
+
+// Settings object that controls default parameters for library methods:
+accounting.settings = {
+    currency: {
+        symbol: "$",    // default currency symbol is '$'
+        format: "%s%v", // controls output: %s = symbol, %v = value/number (can be object: see below)
+        decimal: ".",   // decimal point separator
+        thousand: ",",  // thousands separator
+        precision: 2    // decimal places
+    },
+    number: {
+        precision: 0,   // default precision on numbers is 0
+        thousand: ",",
+        decimal: "."
+    }
+};
+
+// These can be changed externally to edit the library's defaults:
+accounting.settings.currency.format = "%s %v";
+
+// Format can be an object, with `pos`, `neg` and `zero`:
+accounting.settings.currency.format = {
+    pos: "%s %v",   // for positive values, eg. "$ 1.00" (required)
+    neg: "%s (%v)", // for negative values, eg. "$ (1.00)" [optional]
+    zero: "%s  -- "  // for zero values, eg. "$  --" [optional]
+};

--- a/accounting/accounting.d.ts
+++ b/accounting/accounting.d.ts
@@ -1,0 +1,79 @@
+// Type definitions for accounting.js 0.3.2
+// Project: http://josscrowcroft.github.io/accounting.js/
+// Definitions by: Sergey Gerasimov <https://github.com/gerich-home/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+interface IAccountingCurrencyFormat {
+    pos: string;         // for positive values, eg. "$ 1.00"
+	neg?: string;        // for negative values, eg. "$ (1.00)"
+	zero?: string;       // for zero values, eg. "$  --"
+}
+
+interface IAccountingCurrencySettings<TFormat> {
+    symbol?: string;     // default currency symbol is '$'
+    format?: TFormat;    // controls output: %s = symbol, %v = value/number
+    decimal?: string;    // decimal point separator
+    thousand?: string;   // thousands separator
+    precision?: number   // decimal places
+}
+
+interface IAccountingNumberSettings {
+    precision?: number;  // default precision on numbers is 0
+    thousand?: string;
+    decimal?: string;
+}
+
+interface IAccountingSettings {
+    currency: IAccountingCurrencySettings<any>; // IAccountingCurrencySettings<string> or IAccountingCurrencySettings<IAccountingCurrencyFormat>
+    number: IAccountingNumberSettings;
+}
+
+interface IAccountingStatic {
+    // format any number into currency
+    formatMoney(number: number, symbol?: string, precision?: number, thousand?: string, decimal?: string, format?: string): string;
+    formatMoney(number: number, options: IAccountingCurrencySettings<string>): string;
+    formatMoney(number: number, options: IAccountingCurrencySettings<IAccountingCurrencyFormat>): string;
+
+    formatMoney(numbers: number[], symbol?: string, precision?: number, thousand?: string, decimal?: string, format?: string): string[];
+    formatMoney(numbers: number[], options: IAccountingCurrencySettings<string>): string[];
+    formatMoney(numbers: number[], options: IAccountingCurrencySettings<IAccountingCurrencyFormat>): string[];
+
+    // generic case (any array of numbers)
+    formatMoney(numbers: any[], symbol?: string, precision?: number, thousand?: string, decimal?: string, format?: string): any[];
+    formatMoney(numbers: any[], options: IAccountingCurrencySettings<string>): any[];
+    formatMoney(numbers: any[], options: IAccountingCurrencySettings<IAccountingCurrencyFormat>): any[];
+
+    // format a list of values for column-display
+    formatColumn(numbers: number[], symbol?: string, precision?: number, thousand?: string, decimal?: string, format?: string): string[];
+    formatColumn(numbers: number[], options: IAccountingCurrencySettings<string>): string[];
+    formatColumn(numbers: number[], options: IAccountingCurrencySettings<IAccountingCurrencyFormat>): string[];
+
+    formatColumn(numbers: number[][], symbol?: string, precision?: number, thousand?: string, decimal?: string, format?: string): string[][];
+    formatColumn(numbers: number[][], options: IAccountingCurrencySettings<string>): string[][];
+    formatColumn(numbers: number[][], options: IAccountingCurrencySettings<IAccountingCurrencyFormat>): string[][];
+
+    // format a number with custom precision and localisation
+    formatNumber(number: number, precision?: number, thousand?: string, decimal?: string): string;
+    formatNumber(number: number, options: IAccountingNumberSettings): string;
+
+    formatNumber(number: number[], precision?: number, thousand?: string, decimal?: string): string[];
+    formatNumber(number: number[], options: IAccountingNumberSettings): string[];
+
+    formatNumber(number: any[], precision?: number, thousand?: string, decimal?: string): any[];
+    formatNumber(number: any[], options: IAccountingNumberSettings): any[];
+
+    // better rounding for floating point numbers
+    toFixed(number: number, precision?: number): string;
+
+    // get a value from any formatted number/currency string
+    unformat(string: string, decimal?: string): number;
+
+    // settings object that controls default parameters for library methods
+    settings: IAccountingSettings;
+}
+
+declare var accounting: IAccountingStatic;
+
+declare module "accounting" {
+    export = accounting;
+}


### PR DESCRIPTION
There are some problems in definitions of unregular arrays for some parameters and some problems in the settings object (at this line: currency: IAccountingCurrencySettings<any>; // IAccountingCurrencySettings<string> or IAccountingCurrencySettings<IAccountingCurrencyFormat>)
