### PR TITLE
Add invertExtent to d3 Scale Interface

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -2635,6 +2635,7 @@ declare module D3 {
                 (): any[];
             };
             copy(): QuantizeScale;
+            invertExtent(y: any): any[];
         }
 
         export interface ThresholdScale extends Scale {

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -2442,6 +2442,7 @@ declare module D3 {
                 (values: any[]): Scale;
                 (): any[];
             };
+            invertExtent(y: any): any[];
             copy(): Scale;
         }
 
@@ -2635,7 +2636,6 @@ declare module D3 {
                 (): any[];
             };
             copy(): QuantizeScale;
-            invertExtent(y: any): any[];
         }
 
         export interface ThresholdScale extends Scale {


### PR DESCRIPTION
I needed to access intertExtent on a QuantizeScale. It was not part of the interface. I originally added it to the QuantizeScale interface and realized it belongs on Scale.
