### PR TITLE
Added missing library features

### DIFF
--- a/highcharts/highcharts-tests.ts
+++ b/highcharts/highcharts-tests.ts
@@ -110,7 +110,9 @@ var highChartSettings: HighchartsOptions = {
     }]
 };
 
-var container = $("#container").highcharts(highChartSettings);
+var container = $("#container").highcharts(highChartSettings, function (chart) {
+    chart.series[0].setVisible(true, true);
+});
 
 var options = Highcharts.getOptions();
 

--- a/highcharts/highcharts.d.ts
+++ b/highcharts/highcharts.d.ts
@@ -1004,7 +1004,7 @@ interface HighchartsChartObject {
     options: HighchartsChartOptions;
     print(): void;
     redraw(): void;
-    series: HighchartsSeriesChart[];
+    series: HighchartsSeriesObject[];
     setSize(width: number, height: number): void;
     setSize(width: number, height: number, anumation: boolean): void;
     setSize(width: number, height: number, anumation: HighchartsAnimation): void;
@@ -1109,6 +1109,8 @@ interface HighchartsSeriesObject {
     setData(data: number[][], redraw: boolean): void;
     setData(data: HighchartsDataPoint[]): void; // HighchartsDataPoint[]
     setData(data: HighchartsDataPoint[], redraw: boolean): void;
+    setVisible(visible: boolean): void;
+    setVisible(visible: boolean, redraw: boolean): void;
     show(): void;
     type: string;
     visible: boolean;
@@ -1124,4 +1126,12 @@ interface JQuery {
     * @return current {JQuery} selector the current JQuery selector
     **/
     highcharts(options: HighchartsOptions): JQuery;
+    /**
+    * Creates a new Highcharts.Chart for the current JQuery selector; usually
+    * a div selected by $('#container')
+    * @param {HighchartsOptions} options Options for this chart
+    * @param callback Callback function used to manipulate the constructed chart instance
+    * @return current {JQuery} selector the current JQuery selector
+    **/
+    highcharts(options: HighchartsOptions, callback: (chart: HighchartsChartObject) => void): JQuery;
 }


### PR DESCRIPTION
Implemented the following changes.
- The HighchartsChartObject.series property should return
  HighchartsSeriesObject[] not HighchartsSeriesChart[].
- Added missing setVisible(...) overloaded method to the
  HighchartsSeriesObject interface.
- Added missing JQuery.highcharts(...) method overload containing
  callback function parameter used to manipulate the chart instance.
- Amended test file to exercise all changes in this commit.
