### PR TITLE
Added missing moment and moment.utc overloads.

### DIFF
--- a/moment/moment-tests.ts
+++ b/moment/moment-tests.ts
@@ -21,6 +21,14 @@ var array = [2010, 1, 14, 15, 25, 50, 125];
 var day11 = moment(Date.UTC.apply({}, array));
 var day12 = moment.unix(1318781876);
 
+moment({ years: 2010, months: 3, days: 5, hours: 15, minutes: 10, seconds: 3, milliseconds: 123 });
+moment("20140101", "YYYYMMDD", true);
+moment("20140101", "YYYYMMDD", "en");
+moment("20140101", "YYYYMMDD", "en", true);
+moment("20140101", ["YYYYMMDD"], true);
+moment("20140101", ["YYYYMMDD"], "en");
+moment("20140101", ["YYYYMMDD"], "en", true);
+
 var a = moment([2012]);
 var b = moment(a);
 a.year(2000);
@@ -29,8 +37,16 @@ b.year(); // 2012
 moment.utc();
 moment.utc(12345);
 moment.utc([12, 34, 56]);
+moment.utc({ years: 2010, months: 3, days: 5, hours: 15, minutes: 10, seconds: 3, milliseconds: 123 });
 moment.utc("1-2-3");
 moment.utc("1-2-3", "3-2-1");
+moment.utc("1-2-3", "3-2-1", true);
+moment.utc("1-2-3", "3-2-1", "en");
+moment.utc("1-2-3", "3-2-1", "en", true);
+moment.utc("01-01-2014", ["DD-MM-YYYY", "MM-DD-YYYY"]);
+moment.utc("01-01-2014", ["DD-MM-YYYY", "MM-DD-YYYY"], true);
+moment.utc("01-01-2014", ["DD-MM-YYYY", "MM-DD-YYYY"], "en");
+moment.utc("01-01-2014", ["DD-MM-YYYY", "MM-DD-YYYY"], "en", true);
 
 var a2 = moment.utc([2011, 0, 1, 8]);
 a.hours();

--- a/moment/moment.d.ts
+++ b/moment/moment.d.ts
@@ -257,24 +257,28 @@ interface MomentRelativeTime {
 interface MomentStatic {
 
     (): Moment;
-	(dateObject: Object, language?: string, strict?: boolean): Moment;
-    (date: number, language?: string, strict?: boolean): Moment;
-    (date: string, language?: string, strict?: boolean): Moment;
-    (date: string, format: string, language?: string, strict?: boolean): Moment;
-	(date: string, formats: string[], language?: string, strict?: boolean): Moment;
-    (date: Date, language?: string, strict?: boolean): Moment;
-    (date: number[], language?: string, strict?: boolean): Moment;
-    (clone: Moment): Moment;
+    (date: number): Moment;
+    (date: number[]): Moment;
+    (date: string, format?: string, strict?: boolean): Moment;
+    (date: string, format?: string, language?: string, strict?: boolean): Moment;
+    (date: string, formats: string[], strict?: boolean): Moment;
+    (date: string, formats: string[], language?: string, strict?: boolean): Moment;
+    (date: Date): Moment;
+    (date: Moment): Moment;
+    (date: Object): Moment;
+
+    utc(): Moment;
+    utc(date: number): Moment;
+    utc(date: number[]): Moment;
+    utc(date: string, format?: string, strict?: boolean): Moment;
+    utc(date: string, format?: string, language?: string, strict?: boolean): Moment;
+    utc(date: string, formats: string[], strict?: boolean): Moment;
+    utc(date: string, formats: string[], language?: string, strict?: boolean): Moment;
+    utc(date: Date): Moment;
+    utc(date: Moment): Moment;
+    utc(date: Object): Moment;
 
     unix(timestamp: number): Moment;
-
-    utc(): Moment; // current date/time in UTC mode
-    utc(Number: number): Moment; // milliseconds since the Unix Epoch in UTC mode
-    utc(array: number[]): Moment; // parse an array of numbers matching Date.UTC() parameters
-    utc(String: string): Moment; // parse string into UTC mode
-    utc(String1: string, String2: string): Moment; // parse a string and format into UTC mode
-	utc(date: Date): Moment;
-	utc(clone: Moment): Moment;
 
     isMoment(): boolean;
     isMoment(m: any): boolean;


### PR DESCRIPTION
- Added moment(string, string?, boolean?) overload for specifying date,
  format and strict parsing flag.
- Added moment(string, string?, string?, boolean?) overload for
  specifying date, format, language and strict parsing flag.
- Added moment(string, string[], boolean?) overload for specifying date,
  multiple formats and strict parsing flag.
- Added moment(string, string[], string?, boolean?) overload for
  specifying date, multiple formats, language and strict parsing flag.
- Modified parameter names for moment.utc(...) methods to match those
  for the similar moment(...) method overloads.
- Ensured all moment(...) methods have a moment.utc(...) equivalent.
- Added tests for all newly added overloads.
- Added missing tests for some existing overloads.
