### PR TITLE
Support multiple 'from' states

### DIFF
--- a/state-machine/state-machine.d.ts
+++ b/state-machine/state-machine.d.ts
@@ -11,7 +11,7 @@ interface StateMachineErrorCallback {
 
 interface StateMachineEventDef {
     name: string;
-    from: string;
+    from: any;    // string or string[]
     to: string;
 }
 


### PR DESCRIPTION
According to https://github.com/jakesgordon/javascript-state-machine:
"If an event is allowed from multiple states, and always transitions to the same state, then simply provide an array of states in the from attribute of an event."

So the from property can be of type string or string[], so "any" is required here.
