### PR TITLE
Update declaration of the Device interface

### DIFF
--- a/phonegap/phonegap.d.ts
+++ b/phonegap/phonegap.d.ts
@@ -257,6 +257,7 @@ interface Contacts {
 }
 
 interface Device {
+    available: boolean;
     name: string;
     cordova: string;
     platform: string;


### PR DESCRIPTION
The current version of interface for Device plugin is contains property available. 

See in the current version.
https://github.com/apache/cordova-plugin-device/blob/master/www/device.js
