### PR TITLE
Added property for query string parameters

### DIFF
--- a/signalr/signalr.d.ts
+++ b/signalr/signalr.d.ts
@@ -36,6 +36,7 @@ interface SignalR {
     logging: boolean;
     messageId: string;
     url: string;
+    qs: any;
 
     (url: string, queryString?: any, logging?: boolean): SignalR;
     hubConnection(url?: string): SignalR;


### PR DESCRIPTION
Property qs for SignalR connection could be used to pass additional parameters to new SignalR persistent/hub connections. It is available since 1.0 and is present in 2.0 version of SignalR

Please see 
http://stackoverflow.com/questions/13542453/signalr-1-0-send-data-to-a-specific-client which is posted November, 2012.
