### PR TITLE
Leaflet: fix default icon constructor

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -991,9 +991,9 @@ declare module L {
         export class Default extends Icon {
 
             /**
-              * Creates an icon instance with default options.
+              * Creates a default icon instance with the given options.
               */
-            constructor(options: IconOptions);
+            constructor(options?: IconOptions);
 
             static imagePath: string;
         }


### PR DESCRIPTION
This fix allows this code (which worked in an earlier version):

var icon = new L.Icon.Default();
