### PR TITLE
[gruntjs] Fixing grunt.util.spawn 'opts' argument attribute

### DIFF
--- a/gruntjs/gruntjs.d.ts
+++ b/gruntjs/gruntjs.d.ts
@@ -1155,7 +1155,13 @@ declare module grunt {
             /**
              * Additional options for the Node.js child_process spawn method.
              */
-            opts?: ISpawnOptions
+            opts?: {
+                cwd?: string
+                stdio?: any
+                custom?: any
+                env?: any
+                detached?: boolean
+            }
 
             /**
              * If this value is set and an error occurs, it will be used as the value


### PR DESCRIPTION
Fixing a bug on the 'opts' attribute on the first argument to grunt.util.spawn.

The 'opts' property on ISpawnOptions specifies "Additional options for the Node.js child_process spawn method." according to http://gruntjs.com/api/grunt.util#grunt.util.spawn

However, the previous typing incorrectly recursively typed this as ISpawnOptions. child_process.spawn takes different arguments from grunt.util.spawn.

I have copied in the appropriate typing from node/node.d.ts, as it is not an exported interface type. A quick inspection of the grunt source verifies that this object is passed uninspected to child_process.spawn, so all properties on the argument are potentially relevant.
