### PR TITLE
Changing the context param to be OPTIONAL

### DIFF
--- a/handlebars/handlebars.d.ts
+++ b/handlebars/handlebars.d.ts
@@ -16,7 +16,7 @@ interface HandlebarsStatic {
     parse(input: string): boolean;
     logger: Logger;
     log(level: number, obj: any): void;
-    compile(input: any, options?: any): (context: any, options?: any) => string;
+    compile(input: any, options?: any): (context?: any, options?: any) => string;
     Logger: typeof Logger;
 }
 


### PR DESCRIPTION
The compile function returns a template function. The template function takes two parameters, `context` and `options`. These are both optional parameters. This commit fixes `context` to be optional.
