### PR TITLE
jQuery: removed undocumented properties

### DIFF
--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -448,11 +448,6 @@ function test_toggle() {
     });
 }
 
-function test_easing() {
-    var result: number = $.easing.linear(3);
-    var result: number = $.easing.swing(3);
-}
-
 function test_append() {
     $('.inner').append('<p>Test</p>');
     $('.container').append($('h2'));

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -1062,10 +1062,6 @@ interface JQueryStatic {
      * @param keepScripts A Boolean indicating whether to include scripts passed in the HTML string
      */
     parseHTML(data: string, context?: HTMLElement, keepScripts?: boolean): any[];
-
-    Animation(elem: any, properties: any, options: any): any;
-
-    easing: JQueryEasing;
 }
 
 /**


### PR DESCRIPTION
Animate and easing don't appear to be part of the official jQuery API.  Have removed them (and the associated easing test).  Now sending PR to see if this has any impact on other libraries.
