### PR TITLE
Create jquery.simulate.d.ts

### DIFF
--- a/jquery.simulate/jquery.simulate-tests.ts
+++ b/jquery.simulate/jquery.simulate-tests.ts
@@ -1,0 +1,6 @@
+/// <reference path="jquery.simulate-tests.d.ts"/>
+
+var $element = $("body");
+
+$element.simulate("click");
+$element.simulate("mousewheel", { detail: 50 });

--- a/jquery.simulate/jquery.simulate-tests.ts
+++ b/jquery.simulate/jquery.simulate-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path="jquery.simulate-tests.d.ts"/>
+/// <reference path="jquery.simulate.d.ts"/>
 
 var $element = $("body");
 

--- a/jquery.simulate/jquery.simulate.d.ts
+++ b/jquery.simulate/jquery.simulate.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for jquery.simulate.js
+// Project: https://github.com/jquery/jquery-simulate
+// Definitions by: Derek Cicerone <https://github.com/derekcicerone/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../jquery/jquery.d.ts"/>
+
+interface JQuery {
+
+    /**
+     * Simulates an event.
+     *
+     * @param type
+     *            the type of event (eg: "mousemove", "keydown", etc...)
+     * @param options
+     *            the options for the event (these are event-specific)
+     */
+    simulate(type: string, options?: any): void;
+}


### PR DESCRIPTION
I chose to go with a more relaxed definition (versus specifying the exact options allowed for each event type) because it would have required duplicating event definitions from lib.d.ts (the properties of the events in lib.d.ts are all mandatory whereas they would be optional in this usage).
