### PR TITLE
socket.io: Update missing API

### DIFF
--- a/socket.io/socket.io.d.ts
+++ b/socket.io/socket.io.d.ts
@@ -23,7 +23,7 @@ interface Socket {
 	in(room: string): Socket;
 	to(room: string): Socket;
 	join(name: string, fn: Function): Socket;
-	unjoin(name: string, fn: Function): Socket;
+	leave(name: string, fn: Function): Socket;
 	set(key: string, value: any, fn: Function): Socket;
 	get(key: string, fn: Function): Socket;
 	has(key: string, fn: Function): Socket;


### PR DESCRIPTION
As shown in https://github.com/LearnBoost/socket.io/wiki/Rooms, the opposite method for 'join' is 'leave',  but now it has been mixed up with 'unjoin'.
