### PR TITLE
[Node] Fixing WritableStream.write and WritableStream.end.

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -91,11 +91,13 @@ interface EventEmitter {
 
 interface WritableStream extends EventEmitter {
     writable: boolean;
-    write(str: string, encoding?: string, fd?: string): boolean;
-    write(buffer: NodeBuffer): boolean;
+    write(buffer: NodeBuffer, cb?: Function): boolean;
+    write(str: string, cb?: Function): boolean;
+    write(str: string, encoding?: string, cb?: Function): boolean;
     end(): void;
-    end(str: string, enconding: string): void;
-    end(buffer: NodeBuffer): void;
+    end(buffer: NodeBuffer, cb?: Function): void;
+    end(str: string, cb?: Function): void;
+    end(str: string, encoding?: string, cb?: Function): void;
     destroy(): void;
     destroySoon(): void;
 }


### PR DESCRIPTION
Documentation for WritableStream.write:
http://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback

There's no 'fd' argument; that might have been a typo.

You can call `write` in the following ways:
- `write(data: Buffer)`
- `write(data: Buffer, cb: Function)`
- `write(data: String)`
- `write(data: String, cb: Function)`
- `write(data: String, encoding: String)`
- `write(data: String, encoding: String, cb: Function)`

The same goes to `end`, except `end` can be called with no arguments, too.

Documentation for WritableStream.end:
http://nodejs.org/api/stream.html#stream_writable_end_chunk_encoding_callback
