### PR TITLE
Breeze: fetchEntityByKey

### DIFF
--- a/breeze/breeze.d.ts
+++ b/breeze/breeze.d.ts
@@ -385,7 +385,7 @@ declare module breeze {
         exportEntities(entities?: Entity[]): string;
         fetchEntityByKey(typeName: string, keyValue: any, checkLocalCacheFirst?: boolean): Q.Promise<EntityByKeyResult>;
         fetchEntityByKey(typeName: string, keyValues: any[], checkLocalCacheFirst?: boolean): Q.Promise<EntityByKeyResult>;
-        fetchEntityByKey(entityKey: EntityKey): Q.Promise<EntityByKeyResult>;
+        fetchEntityByKey(entityKey: EntityKey, checkLocalCacheFirst?: boolean): Q.Promise<EntityByKeyResult>;
         fetchMetadata(callback?: (schema: any) => void , errorCallback?: breeze.core.ErrorCallback): Q.Promise<any>;
         generateTempKeyValue(entity: Entity): any;
         getChanges(): Entity[];


### PR DESCRIPTION
The actual signature is specified in [here](http://www.breezejs.com/sites/all/apidocs/classes/EntityManager.html#method_fetchEntityByKey - overload)
`fetchEntityByKey ( entityKey, checkLocalCacheFirst )`
