### PR TITLE
Ember: Improve routing-related typings

### DIFF
--- a/ember/ember.d.ts
+++ b/ember/ember.d.ts
@@ -346,6 +346,10 @@ declare module Ember {
         The call will be delayed until the DOM has become ready.
         **/
         ready: Function;
+        /**
+        Application's router.
+        **/
+        Router: Router;
     }
     /**
     This module implements Observer-friendly Array-like behavior. This mixin is picked up by the
@@ -1569,8 +1573,13 @@ declare module Ember {
         static metaForProperty(key: string): {};
         static isClass: boolean;
         static isMethod: boolean;
+        map(callback: Function): Router;
     }
-    var RouterDSL: Function;
+    class RouterDSL {
+        resource(name: string, options?: {}, callback?: Function): void;
+        resource(name: string, callback: Function): void;
+        route(name: string, options?: {}): void;
+    }
     var SHIM_ES5: boolean;
     var STRINGS: boolean;
     class Select extends View {
@@ -2261,7 +2270,7 @@ declare module Em {
     class RenderBuffer extends Ember.RenderBuffer { }
     class Route extends Ember.Route { }
     class Router extends Ember.Router { }
-    var RouterDSL: typeof Ember.RouterDSL;
+    class RouterDSL extends Ember.RouterDSL { }
     var SHIM_ES5: typeof Ember.SHIM_ES5;
     var STRINGS: typeof Ember.STRINGS;
     class Select extends Ember.Select { }


### PR DESCRIPTION
Links to the corresponding stuff in the official ember repository:
1. [Application.Router](https://github.com/emberjs/ember.js/blob/master/packages/ember-application/lib/system/application.js#L233)
2. [Router.map](https://github.com/emberjs/ember.js/blob/master/packages/ember-routing/lib/system/router.js#L714)
3. [RouterDSL](https://github.com/emberjs/ember.js/blob/master/packages/ember-routing/lib/system/dsl.js)

With latest ember, this stuff is necessary even in the [beginning of the official tutorial](http://emberjs.com/guides/getting-started/adding-a-route-and-template/).
It is now possible to do something like:

``` javascript
var App = Ember.Application.create<Ember.Application>();

App.Router.map(function () {
    <Ember.RouterDSL>
    this.resource('topCharts', function () {
        this.route('choose', { path: '/' });
        this.route('albums');
        this.route('songs');
        this.route('artists');
        this.route('playlists');
    });
});
```
