### PR TITLE
[Node] Updating stream interfaces and removing redundant interfaces.

### DIFF
--- a/browser-harness/browser-harness.d.ts
+++ b/browser-harness/browser-harness.d.ts
@@ -6,28 +6,27 @@
 /// <reference path="../node/node.d.ts" />
 
 declare module "browser-harness" {
-    import nodeEvents = require("events");
 
-    interface HarnessEvents extends nodeEvents.NodeEventEmitter {
-        once(event: string, listener: (driver: Driver) => void): nodeEvents.NodeEventEmitter;
-        once(event: 'ready', listener: (driver: Driver) => void): nodeEvents.NodeEventEmitter;
+    interface HarnessEvents extends NodeEventEmitter {
+        once(event: string, listener: (driver: Driver) => void): NodeEventEmitter;
+        once(event: 'ready', listener: (driver: Driver) => void): NodeEventEmitter;
 
-        on(event: string, listener: (driver: Driver) => void): nodeEvents.NodeEventEmitter;
-        on(event: 'ready', listener: (driver: Driver) => void): nodeEvents.NodeEventEmitter;
+        on(event: string, listener: (driver: Driver) => void): NodeEventEmitter;
+        on(event: 'ready', listener: (driver: Driver) => void): NodeEventEmitter;
     }
 
-    interface DriverEvents extends nodeEvents.NodeEventEmitter {
-        once(event: string, listener: (text: string) => void): nodeEvents.NodeEventEmitter;
-        once(event: 'console.log', listener: (text: string) => void): nodeEvents.NodeEventEmitter;
-        once(event: 'console.warn', listener: (text: string) => void): nodeEvents.NodeEventEmitter;
-        once(event: 'console.error', listener: (text: string) => void): nodeEvents.NodeEventEmitter;
-        once(event: 'window.onerror', listener: (text: string) => void): nodeEvents.NodeEventEmitter;
+    interface DriverEvents extends NodeEventEmitter {
+        once(event: string, listener: (text: string) => void): NodeEventEmitter;
+        once(event: 'console.log', listener: (text: string) => void): NodeEventEmitter;
+        once(event: 'console.warn', listener: (text: string) => void): NodeEventEmitter;
+        once(event: 'console.error', listener: (text: string) => void): NodeEventEmitter;
+        once(event: 'window.onerror', listener: (text: string) => void): NodeEventEmitter;
 
-        on(event: string, listener: (text: string) => void): nodeEvents.NodeEventEmitter;
-        on(event: 'console.log', listener: (text: string) => void): nodeEvents.NodeEventEmitter;
-        on(event: 'console.warn', listener: (text: string) => void): nodeEvents.NodeEventEmitter;
-        on(event: 'console.error', listener: (text: string) => void): nodeEvents.NodeEventEmitter;
-        on(event: 'window.onerror', listener: (text: string) => void): nodeEvents.NodeEventEmitter;
+        on(event: string, listener: (text: string) => void): NodeEventEmitter;
+        on(event: 'console.log', listener: (text: string) => void): NodeEventEmitter;
+        on(event: 'console.warn', listener: (text: string) => void): NodeEventEmitter;
+        on(event: 'console.error', listener: (text: string) => void): NodeEventEmitter;
+        on(event: 'window.onerror', listener: (text: string) => void): NodeEventEmitter;
     }
 
     export interface Driver {

--- a/browserify/browserify.d.ts
+++ b/browserify/browserify.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference path="../node/node.d.ts" />
 
-interface BrowserifyObject extends EventEmitter {
+interface BrowserifyObject extends NodeEventEmitter {
 	add(file: string): BrowserifyObject;
 	require(file: string, opts?: {
 		expose: string;
@@ -31,6 +31,6 @@ declare module "browserify" {
 		entries?: string[];
 		noParse?: string[];
 	}): BrowserifyObject;
-	
+
 	export = browserify;
 }

--- a/jake/jake.d.ts
+++ b/jake/jake.d.ts
@@ -124,7 +124,7 @@ declare module jake{
 	 * @event stderr When the stderr for the child-process recieves data. This streams the stderr data. Passes one arg, the chunk of data.
 	 * @event error When a shell-command
 	 */
-	export interface Exec extends EventEmitter{
+	export interface Exec extends NodeEventEmitter {
 		constructor(cmds:string[], callback?:()=>void, opts?:ExecOptions);
 		constructor(cmds:string[], opts?:ExecOptions,  callback?:()=>void);
 		constructor(cmds:string,   callback?:()=>void, opts?:ExecOptions);
@@ -182,7 +182,7 @@ declare module jake{
 	 *
 	 * @event complete
 	 */
-	export class Task implements EventEmitter {
+	export class Task implements NodeEventEmitter {
 		/**
 		 * @name name The name of the Task
 		 * @param prereqs Prerequisites to be run before this task
@@ -201,11 +201,11 @@ declare module jake{
 		 */
 		reenable(): void;
 
-		addListener(event: string, listener: Function): EventEmitter;
-        on(event: string, listener: Function): EventEmitter;
-        once(event: string, listener: Function): EventEmitter;
-        removeListener(event: string, listener: Function): EventEmitter;
-        removeAllListeners(event?: string): EventEmitter;
+		addListener(event: string, listener: Function): NodeEventEmitter;
+        on(event: string, listener: Function): NodeEventEmitter;
+        once(event: string, listener: Function): NodeEventEmitter;
+        removeListener(event: string, listener: Function): NodeEventEmitter;
+        removeAllListeners(event?: string): NodeEventEmitter;
         setMaxListeners(n: number): void;
         listeners(event: string): Function[];
         emit(event: string, arg1?: any, arg2?: any): boolean;

--- a/msnodesql/msnodesql.d.ts
+++ b/msnodesql/msnodesql.d.ts
@@ -55,5 +55,5 @@ declare module "msnodesql" {
         close(immediately: boolean, callback?: ErrorCallback);
     }
 
-    interface StreamEvents extends EventEmitter { }
+    interface StreamEvents extends NodeEventEmitter { }
 }

--- a/through/through.d.ts
+++ b/through/through.d.ts
@@ -15,7 +15,7 @@ declare module "through" {
 		}): through.ThroughStream;
 
 	module through {
-		export interface ThroughStream extends Stream.ReadWriteStream {
+		export interface ThroughStream extends ReadWriteStream {
 			autoDestroy: boolean;
 		}
 	}


### PR DESCRIPTION
We duplicated the EventEmitter and Stream interfaces in the "event" module, so I removed the redundant interface definitions.

I have updated the ReadableStream/WritableStream interfaces in accordance with the current documentation:
http://nodejs.org/api/stream.html

I added class definitions for Writable/Transform/Duplex/PassThrough in 'event'. These classes are described in the following Node documentation:
http://nodejs.org/api/stream.html#stream_api_for_stream_implementors

As a result of these changes, I needed to slightly alter other typings to refer to the new interface name. This was unavoidable; I had to rename the `EventEmitter` interface to `NodeEventEmitter` to avoid clashing with the `events.EventEmitter` class that implements `NodeEventEmitter`.
