### PR TITLE
chai: added string-named module

### DIFF
--- a/chai/chai.d.ts
+++ b/chai/chai.d.ts
@@ -163,3 +163,7 @@ declare module chai {
         (constructor: Function, expected?: RegExp, message?: string): Expect;
     }
 }
+
+declare module "chai" { 
+     export = chai;
+}


### PR DESCRIPTION
For using with require() syntax.
