### PR TITLE
Fixed generics return value of Window and Buffer operators

### DIFF
--- a/rx.js/rx.time.d.ts
+++ b/rx.js/rx.time.d.ts
@@ -25,12 +25,12 @@ declare module Rx {
 
 		delay(dueTime: number, scheduler?: IScheduler): Observable<T>;
 		throttle(dueTime: number, scheduler?: IScheduler): Observable<T>;
-		windowWithTime(timeSpan: number, timeShift: number, scheduler?: IScheduler): Observable<T>;
-		windowWithTime(timeSpan: number, scheduler?: IScheduler): Observable<T>;
-		windowWithTimeOrCount(timeSpan: number, count: number, scheduler?: IScheduler): Observable<T>;
-		bufferWithTime(timeSpan: number, timeShift: number, scheduler?: IScheduler): Observable<T>;
-		bufferWithTime(timeSpan: number, scheduler?: IScheduler): Observable<T>;
-		bufferWithTimeOrCount(timeSpan: number, count: number, scheduler?: IScheduler): Observable<T>;
+		windowWithTime(timeSpan: number, timeShift: number, scheduler?: IScheduler): Observable<Observable<T>>;
+		windowWithTime(timeSpan: number, scheduler?: IScheduler): Observable<Observable<T>>;
+		windowWithTimeOrCount(timeSpan: number, count: number, scheduler?: IScheduler): Observable<Observable<T>>;
+		bufferWithTime(timeSpan: number, timeShift: number, scheduler?: IScheduler): Observable<T[]>;
+		bufferWithTime(timeSpan: number, scheduler?: IScheduler): Observable<T[]>;
+		bufferWithTimeOrCount(timeSpan: number, count: number, scheduler?: IScheduler): Observable<T[]>;
 		timeInterval(scheduler?: IScheduler): Observable<TimeInterval<T>>;
 		timestamp(scheduler?: IScheduler): Observable<Timestamp<T>>;
 		sample(interval: number, scheduler?: IScheduler): Observable<T>;


### PR DESCRIPTION
Generics values where incorrect.  The correct result for windowWithXXX
operators is Observable<Observable<T>> and for bufferWithXXX it's
Observable<T[]>
