### PR TITLE
jQuery: removed redundant interface

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -18,6 +18,7 @@ See the Apache Version 2.0 License for specific language governing permissions
 and limitations under the License.
 ***************************************************************************** */
 
+
 /**
  * Interface for the AJAX setting that will configure the AJAX request
  */

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -486,14 +486,6 @@ interface JQueryAnimationOptions {
 }
 
 /**
- * The interface used to specify easing functions.
- */
-interface JQueryEasing {
-    linear(p: number): number;
-    swing(p: number): number;
-}
-
-/**
  * Static members of jQuery (those on $ and jQuery themselves)
  */
 interface JQueryStatic {


### PR DESCRIPTION
Prompted by this email from Michal Kutil:

Dear John,
I would like to ask for this commit:
https://github.com/borisyankov/DefinitelyTyped/commit/e65a30bcc8bd5179302f67d3fc8cbb07c2bd3743

Did you remove “easing” property because it is not documented on http://api.jquery.com/ or because the JSDoc comment over property is missing?
If JSDoc comment is missing I can create one and send pull request.
On the other side, if you removed it because it is missing on http://api.jquery.com/, please remove unnecessary interface JQueryEasing, too.

Thank you for response and best regards,
Michal
