### PR TITLE
Resolved: Type reference cannot refer to a property - for $.ui.keyCode

### DIFF
--- a/jqueryui/jqueryui.d.ts
+++ b/jqueryui/jqueryui.d.ts
@@ -714,7 +714,7 @@ declare module JQueryUI {
         distance?: number;
     }
 
-    interface keyCode {
+    interface KeyCode {
         BACKSPACE: number;
         COMMA: number;
         DELETE: number;
@@ -751,7 +751,7 @@ declare module JQueryUI {
         buttonset: Button;
         datepicker: Datepicker;
         dialog: Dialog;
-        keyCode: keyCode;
+        keyCode: KeyCode;
         menu: Menu;
         progressbar: Progressbar;
         slider: Slider;


### PR DESCRIPTION
The interface of the property `$.ui.keyCode` uses a non-standard name `keyCode` which clashes with the property name, giving error `Type reference cannot refer to a property`. 

Changing the interface name from `keyCode` to `KeyCode` follows the interface naming convention and resolves this issue.
