### PR TITLE
Added $promise & $resolved properties to ngResource.$resource & fixed spelling issue in angular.d.ts

### DIFF
--- a/angularjs/angular-resource.d.ts
+++ b/angularjs/angular-resource.d.ts
@@ -105,6 +105,10 @@ declare module ng.resource {
         $delete(dataOrParams: any, success: Function): T;
         $delete(success: Function, error?: Function): T;
         $delete(params: any, data: any, success?: Function, error?: Function): T;
+        
+        /** the promise of the original server interaction that created this instance. **/
+        $promise : ng.IPromise<T>;
+        $resolved : boolean;
     }
 
     /** when creating a resource factory via IModule.factory */
@@ -121,4 +125,11 @@ declare module ng {
         /** creating a resource service factory */
         factory(name: string, resourceServiceFactoryFunction: ng.resource.IResourceServiceFactoryFunction<any>): IModule;
     }
+}
+
+interface Array<T extends ng.resource.IResource<T>>
+{
+    /** the promise of the original server interaction that created this collection. **/
+    $promise : ng.IPromise<Array<T>>;
+    $resolved : boolean;
 }

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -79,7 +79,7 @@ declare module ng {
     ///////////////////////////////////////////////////////////////////////////
     interface IModule {
         animation(name: string, animationFactory: Function): IModule;
-        animation(name: string, inlineAnnotadedFunction: any[]): IModule;
+        animation(name: string, inlineAnnotatedFunction: any[]): IModule;
         animation(object: Object): IModule;
         /** configure existing services.
 		Use this method to register work which needs to be performed on module loading
@@ -88,29 +88,29 @@ declare module ng {
         /** configure existing services.
 		Use this method to register work which needs to be performed on module loading
 		 */
-        config(inlineAnnotadedFunction: any[]): IModule;
+        config(inlineAnnotatedFunction: any[]): IModule;
         constant(name: string, value: any): IModule;
         constant(object: Object): IModule;
         controller(name: string, controllerConstructor: Function): IModule;
-        controller(name: string, inlineAnnotadedConstructor: any[]): IModule;
+        controller(name: string, inlineAnnotatedConstructor: any[]): IModule;
         controller(object : Object): IModule;
         directive(name: string, directiveFactory: Function): IModule;
-        directive(name: string, inlineAnnotadedFunction: any[]): IModule;
+        directive(name: string, inlineAnnotatedFunction: any[]): IModule;
         directive(object: Object): IModule;
         factory(name: string, serviceFactoryFunction: Function): IModule;
-        factory(name: string, inlineAnnotadedFunction: any[]): IModule;
+        factory(name: string, inlineAnnotatedFunction: any[]): IModule;
         factory(object: Object): IModule;
         filter(name: string, filterFactoryFunction: Function): IModule;
-        filter(name: string, inlineAnnotadedFunction: any[]): IModule;
+        filter(name: string, inlineAnnotatedFunction: any[]): IModule;
         filter(object: Object): IModule;
         provider(name: string, serviceProviderConstructor: Function): IModule;
-        provider(name: string, inlineAnnotadedConstructor: any[]): IModule;
+        provider(name: string, inlineAnnotatedConstructor: any[]): IModule;
         provider(name: string, providerObject: auto.IProvider): IModule;
         provider(object: Object): IModule;
         run(initializationFunction: Function): IModule;
-        run(inlineAnnotadedFunction: any[]): IModule;
+        run(inlineAnnotatedFunction: any[]): IModule;
         service(name: string, serviceConstructor: Function): IModule;
-        service(name: string, inlineAnnotadedConstructor: any[]): IModule;
+        service(name: string, inlineAnnotatedConstructor: any[]): IModule;
         service(object: Object): IModule;
         value(name: string, value: any): IModule;
         value(object: Object): IModule;
@@ -570,7 +570,7 @@ declare module ng {
 
     interface IControllerProvider extends IServiceProvider {
         register(name: string, controllerConstructor: Function): void;
-        register(name: string, dependencyAnnotadedConstructor: any[]): void;
+        register(name: string, dependencyAnnotatedConstructor: any[]): void;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -818,11 +818,11 @@ declare module ng {
         ///////////////////////////////////////////////////////////////////////
         interface IInjectorService {
             annotate(fn: Function): string[];
-            annotate(inlineAnnotadedFunction: any[]): string[];
+            annotate(inlineAnnotatedFunction: any[]): string[];
             get(name: string): any;
             has(name: string): boolean; 
             instantiate(typeConstructor: Function, locals?: any): any;
-            invoke(inlineAnnotadedFunction: any[]): any;
+            invoke(inlineAnnotatedFunction: any[]): any;
             invoke(func: Function, context?: any, locals?: any): any;
         }
 
@@ -839,7 +839,7 @@ declare module ng {
             decorator(name: string, decorator: Function): void;
             decorator(name: string, decoratorInline: any[]): void;
             factory(name: string, serviceFactoryFunction: Function): ng.IServiceProvider;
-            factory(name: string, inlineAnnotadedFunction: any[]): ng.IServiceProvider;
+            factory(name: string, inlineAnnotatedFunction: any[]): ng.IServiceProvider;
             provider(name: string, provider: ng.IServiceProvider): ng.IServiceProvider;
             provider(name: string, serviceProviderConstructor: Function): ng.IServiceProvider;
             service(name: string, constructor: Function): ng.IServiceProvider;


### PR DESCRIPTION
[ngResource.$resource](http://docs.angularjs.org/api/ngResource.$resource) defines a `$promise` property and a `$resolve` property on the Resource. They are currently missing from the definition.

> Class actions return empty instance (with additional properties below). Instance actions return promise of the action.
> 
> The Resource instances and collection have these additional properties:
> 
> **$promise**: the promise of the original server interaction that created this instance or collection.
> 
> On success, the promise is resolved with the same resource instance or collection object, updated with data from server. This makes it easy to use in resolve section of $routeProvider.when() to defer view rendering until the resource(s) are loaded.
> 
> On failure, the promise is resolved with the http response object, without the resource property.
> 
> **$resolved**: true after first server interaction is completed (either with success or rejection), false before that. Knowing if the Resource has been resolved is useful in data-binding.

Access to the promise (`$promise`) is necessary if you want to be able to ensure a resource is loaded before instantiating the controller of the route, when using [`ngRoute.$routeProvider`](http://docs.angularjs.org/api/ngRoute.$routeProvider) or `uiRouter.$stateProvider`.

> `route.resolve`
> ... If any of these dependencies are promises, the router will wait for them all to be resolved or one to be rejected before the controller is instantiated.

Access to `$resolved` is useful if you want to data bind to an instance of a resource, and want to know if it is available.
