### PR TITLE
Add module declaration to bootstrap.d.ts

### DIFF
--- a/bootstrap/bootstrap.d.ts
+++ b/bootstrap/bootstrap.d.ts
@@ -107,3 +107,6 @@ interface JQuery {
 
     affix(options?: AffixOptions): JQuery;
 }
+
+declare module "bootstrap" {
+}


### PR DESCRIPTION
This change allows the use of AMD modules in TypeScript that have module dependencies on bootstrap.js. Minimal repro/example:

```
import bootstrap = require("bootstrap");
export module MyModule {
  // dummy reference to bootstrap so it ends up in the generated require call
  bootstrap;
}
```

This compiles to (with `tsc --module amd test.ts bootstrap.d.ts`):

```
define(["require", "exports", "bootstrap"], function(require, exports, bootstrap) {
    (function (MyModule) {
        bootstrap;
    })(exports.MyModule || (exports.MyModule = {}));
    var MyModule = exports.MyModule;
});
```
