### PR TITLE
Update jquery.d.ts

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -1,6 +1,15 @@
 // Type definitions for jQuery 1.10.x / 2.0.x
 // Project: http://jquery.com/
-// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Christian Hoffmeister <https://github.com/choffmeister>, Steve Fenton, Diullei Gomes <https://github.com/Diullei>, Tass Iliopoulos <https://github.com/tasoili>, Jason Swearingen, Sean Hill <https://github.com/seanski>, Guus Goossens <https://github.com/Guuz>, Kelly Summerlin <https://github.com/ksummerlin>, Basarat Ali Syed <https://github.com/basarat>, Nicholas Wolverson <https://github.com/nwolverson>, Derek Cicerone <https://github.com/derekcicerone>, Andrew Gaspar <https://github.com/AndrewGaspar>, James Harrison Fisher <https://github.com/jameshfisher>, Seikichi Kondo <https://github.com/seikichi>, Benjamin Jackman <https://github.com/benjaminjackman>, Poul Sorensen <https://github.com/s093294>, Josh Strobl <https://github.com/JoshStrobl>, John Reilly <https://github.com/johnnyreilly/>
+// Definitions by: 
+// Boris Yankov <https://github.com/borisyankov/>, Christian Hoffmeister <https://github.com/choffmeister>, 
+// Steve Fenton, Diullei Gomes <https://github.com/Diullei>, Tass Iliopoulos <https://github.com/tasoili>, 
+// Jason Swearingen, Sean Hill <https://github.com/seanski>, Guus Goossens <https://github.com/Guuz>, 
+// Kelly Summerlin <https://github.com/ksummerlin>, Basarat Ali Syed <https://github.com/basarat>, 
+// Nicholas Wolverson <https://github.com/nwolverson>, Derek Cicerone <https://github.com/derekcicerone>, 
+// Andrew Gaspar <https://github.com/AndrewGaspar>, James Harrison Fisher <https://github.com/jameshfisher>, 
+// Seikichi Kondo <https://github.com/seikichi>, Benjamin Jackman <https://github.com/benjaminjackman>, 
+// Poul Sorensen <https://github.com/s093294>, Josh Strobl <https://github.com/JoshStrobl>, 
+// John Reilly <https://github.com/johnnyreilly/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /* *****************************************************************************
@@ -24,85 +33,157 @@ and limitations under the License.
  */
 interface JQueryAjaxSettings {
     /**
-     * The content type sent in the request header that tells the server what kind of response it will accept in return. If the accepts setting needs modification, it is recommended to do so once in the $.ajaxSetup() method.
+     * The content type sent in the request header that tells the server what kind of response it will accept in return.
+     * If the accepts setting needs modification, it is recommended to do so once in the $.ajaxSetup() method.
      */
     accepts?: any;
     /**
-     * By default, all requests are sent asynchronously (i.e. this is set to true by default). If you need synchronous requests, set this option to false. Cross-domain requests and dataType: "jsonp" requests do not support synchronous operation. Note that synchronous requests may temporarily lock the browser, disabling any actions while the request is active. As of jQuery 1.8, the use of async: false with jqXHR ($.Deferred) is deprecated; you must use the success/error/complete callback options instead of the corresponding methods of the jqXHR object such as jqXHR.done() or the deprecated jqXHR.success().
+     * By default, all requests are sent asynchronously (i.e. this is set to true by default). 
+     * If you need synchronous requests, set this option to false. 
+     * Cross-domain requests and dataType: "jsonp" requests do not support synchronous operation. 
+     * Note that synchronous requests may temporarily lock the browser, disabling any actions while 
+     * the request is active. As of jQuery 1.8, the use of async: false with jqXHR ($.Deferred) is deprecated; 
+     * you must use the success/error/complete callback options instead of the corresponding 
+     * methods of the jqXHR object such as jqXHR.done() or the deprecated jqXHR.success().
      */
     async?: boolean;
     /**
-     * A pre-request callback function that can be used to modify the jqXHR (in jQuery 1.4.x, XMLHTTPRequest) object before it is sent. Use this to set custom headers, etc. The jqXHR and settings objects are passed as arguments. This is an Ajax Event. Returning false in the beforeSend function will cancel the request. As of jQuery 1.5, the beforeSend option will be called regardless of the type of request.
+     * A pre-request callback function that can be used to modify the jqXHR (in jQuery 1.4.x, XMLHTTPRequest) 
+     * object before it is sent. Use this to set custom headers, etc. The jqXHR and settings objects are 
+     * passed as arguments. This is an Ajax Event. Returning false in the beforeSend function will cancel the request. 
+     * As of jQuery 1.5, the beforeSend option will be called regardless of the type of request.
      */
     beforeSend? (jqXHR: JQueryXHR, settings: JQueryAjaxSettings): any;
     /**
-     * If set to false, it will force requested pages not to be cached by the browser. Note: Setting cache to false will only work correctly with HEAD and GET requests. It works by appending "_={timestamp}" to the GET parameters. The parameter is not needed for other types of requests, except in IE8 when a POST is made to a URL that has already been requested by a GET.
+     * If set to false, it will force requested pages not to be cached by the browser. 
+     * Note: Setting cache to false will only work correctly with HEAD and GET requests. 
+     * It works by appending "_={timestamp}" to the GET parameters. 
+     * The parameter is not needed for other types of requests, except in IE8 when a POST is made to 
+     * a URL that has already been requested by a GET.
      */
     cache?: boolean;
     /**
-     * A function to be called when the request finishes (after success and error callbacks are executed). The function gets passed two arguments: The jqXHR (in jQuery 1.4.x, XMLHTTPRequest) object and a string categorizing the status of the request ("success", "notmodified", "error", "timeout", "abort", or "parsererror"). As of jQuery 1.5, the complete setting can accept an array of functions. Each function will be called in turn. This is an Ajax Event.
+     * A function to be called when the request finishes (after success and error callbacks are executed). 
+     * The function gets passed two arguments: The jqXHR (in jQuery 1.4.x, XMLHTTPRequest) object and 
+     * a string categorizing the status of the request 
+     * ("success", "notmodified", "error", "timeout", "abort", or "parsererror"). 
+     * As of jQuery 1.5, the complete setting can accept an array of functions. Each function will be called in turn. 
+     * This is an Ajax Event.
      */
     complete? (jqXHR: JQueryXHR, textStatus: string): any;
     /**
-     * An object of string/regular-expression pairs that determine how jQuery will parse the response, given its content type. (version added: 1.5)
+     * An object of string/regular-expression pairs that determine how jQuery will parse the response, given 
+     * its content type. (version added: 1.5)
      */
     contents?: { [key: string]: any; };
     //According to jQuery.ajax source code, ajax's option actually allows contentType to set to "false"
     // https://github.com/borisyankov/DefinitelyTyped/issues/742
     /**
-     * When sending data to the server, use this content type. Default is "application/x-www-form-urlencoded; charset=UTF-8", which is fine for most cases. If you explicitly pass in a content-type to $.ajax(), then it is always sent to the server (even if no data is sent). The W3C XMLHttpRequest specification dictates that the charset is always UTF-8; specifying another charset will not force the browser to change the encoding.
+     * When sending data to the server, use this content type. 
+     * Default is "application/x-www-form-urlencoded; charset=UTF-8", which is fine for most cases. 
+     * If you explicitly pass in a content-type to $.ajax(), then it is always sent to the server 
+     * (even if no data is sent). 
+     * The W3C XMLHttpRequest specification dictates that the charset is always UTF-8; specifying another charset 
+     * will not force the browser to change the encoding.
      */
     contentType?: any;
     /**
-     * This object will be made the context of all Ajax-related callbacks. By default, the context is an object that represents the ajax settings used in the call ($.ajaxSettings merged with the settings passed to $.ajax).
+     * This object will be made the context of all Ajax-related callbacks. 
+     * By default, the context is an object that represents the ajax settings used in the call 
+     * ($.ajaxSettings merged with the settings passed to $.ajax).
      */
     context?: any;
     /**
-     * An object containing dataType-to-dataType converters. Each converter's value is a function that returns the transformed value of the response. (version added: 1.5)
+     * An object containing dataType-to-dataType converters. 
+     * Each converter's value is a function that returns the transformed value of the response. (version added: 1.5)
      */
     converters?: { [key: string]: any; };
     /**
-     * If you wish to force a crossDomain request (such as JSONP) on the same domain, set the value of crossDomain to true. This allows, for example, server-side redirection to another domain. (version added: 1.5)
+     * If you wish to force a crossDomain request (such as JSONP) on the same domain, set the value of 
+     * crossDomain to true. 
+     * This allows, for example, server-side redirection to another domain. (version added: 1.5)
      */
     crossDomain?: boolean;
     /**
-     * Data to be sent to the server. It is converted to a query string, if not already a string. It's appended to the url for GET-requests. See processData option to prevent this automatic processing. Object must be Key/Value pairs. If value is an Array, jQuery serializes multiple values with same key based on the value of the traditional setting (described below).
+     * Data to be sent to the server. It is converted to a query string, if not already a string. 
+     * It's appended to the url for GET-requests. See processData option to prevent this automatic processing. 
+     * Object must be Key/Value pairs. 
+     * If value is an Array, jQuery serializes multiple values with same key based on the value of 
+     * the traditional setting (described below).
      */
     data?: any;
     /**
-     * A function to be used to handle the raw response data of XMLHttpRequest.This is a pre-filtering function to sanitize the response. You should return the sanitized data. The function accepts two arguments: The raw data returned from the server and the 'dataType' parameter.
+     * A function to be used to handle the raw response data of XMLHttpRequest.
+     * This is a pre-filtering function to sanitize the response. You should return the sanitized data. 
+     * The function accepts two arguments: The raw data returned from the server and the 'dataType' parameter.
      */
     dataFilter? (data: any, ty: any): any;
     /**
-     * The type of data that you're expecting back from the server. If none is specified, jQuery will try to infer it based on the MIME type of the response (an XML MIME type will yield XML, in 1.4 JSON will yield a JavaScript object, in 1.4 script will execute the script, and anything else will be returned as a string). 
+     * The type of data that you're expecting back from the server. 
+     * If none is specified, jQuery will try to infer it based on the MIME type of the response 
+     * (an XML MIME type will yield XML, in 1.4 JSON will yield a JavaScript object, in 1.4 script will execute the 
+     * script, and anything else will be returned as a string). 
      */
     dataType?: string;
     /**
-     * A function to be called if the request fails. The function receives three arguments: The jqXHR (in jQuery 1.4.x, XMLHttpRequest) object, a string describing the type of error that occurred and an optional exception object, if one occurred. Possible values for the second argument (besides null) are "timeout", "error", "abort", and "parsererror". When an HTTP error occurs, errorThrown receives the textual portion of the HTTP status, such as "Not Found" or "Internal Server Error." As of jQuery 1.5, the error setting can accept an array of functions. Each function will be called in turn. Note: This handler is not called for cross-domain script and cross-domain JSONP requests. This is an Ajax Event.
+     * A function to be called if the request fails. 
+     * The function receives three arguments: The jqXHR (in jQuery 1.4.x, XMLHttpRequest) object, a string describing 
+     * the type of error that occurred and an optional exception object, if one occurred. 
+     * Possible values for the second argument (besides null) are 
+     * "timeout", "error", "abort", and "parsererror". 
+     * When an HTTP error occurs, errorThrown receives the textual portion of the HTTP status, such as 
+     * "Not Found" or "Internal Server Error." 
+     * As of jQuery 1.5, the error setting can accept an array of functions. 
+     * Each function will be called in turn. 
+     * Note: This handler is not called for cross-domain script and cross-domain JSONP requests. 
+     * This is an Ajax Event.
      */
     error? (jqXHR: JQueryXHR, textStatus: string, errorThrow: string): any;
     /**
-     * Whether to trigger global Ajax event handlers for this request. The default is true. Set to false to prevent the global handlers like ajaxStart or ajaxStop from being triggered. This can be used to control various Ajax Events.
+     * Whether to trigger global Ajax event handlers for this request. 
+     * The default is true. Set to false to prevent the global handlers like ajaxStart or ajaxStop from being triggered.
+     * This can be used to control various Ajax Events.
      */
     global?: boolean;
     /**
-     * An object of additional header key/value pairs to send along with requests using the XMLHttpRequest transport. The header X-Requested-With: XMLHttpRequest is always added, but its default XMLHttpRequest value can be changed here. Values in the headers setting can also be overwritten from within the beforeSend function. (version added: 1.5)
+     * An object of additional header key/value pairs to send along with requests using the XMLHttpRequest transport. 
+     * The header X-Requested-With: XMLHttpRequest is always added, but its default XMLHttpRequest value can be changed 
+     * here. Values in the headers setting can also be overwritten from within the beforeSend function. 
+     * (version added: 1.5)
      */
     headers?: { [key: string]: any; };
     /**
-     * Allow the request to be successful only if the response has changed since the last request. This is done by checking the Last-Modified header. Default value is false, ignoring the header. In jQuery 1.4 this technique also checks the 'etag' specified by the server to catch unmodified data.
+     * Allow the request to be successful only if the response has changed since the last request. 
+     * This is done by checking the Last-Modified header. Default value is false, ignoring the header. 
+     * In jQuery 1.4 this technique also checks the 'etag' specified by the server to catch unmodified data.
      */
     ifModified?: boolean;
     /**
-     * Allow the current environment to be recognized as "local," (e.g. the filesystem), even if jQuery does not recognize it as such by default. The following protocols are currently recognized as local: file, *-extension, and widget. If the isLocal setting needs modification, it is recommended to do so once in the $.ajaxSetup() method. (version added: 1.5.1)
+     * Allow the current environment to be recognized as "local," (e.g. the filesystem), even if jQuery does 
+     * not recognize it as such by default. 
+     * The following protocols are currently recognized as local: file, *-extension, and widget. 
+     * If the isLocal setting needs modification, it is recommended to do so once in the $.ajaxSetup() method. 
+     * (version added: 1.5.1)
      */
     isLocal?: boolean;
     /**
-     * Override the callback function name in a jsonp request. This value will be used instead of 'callback' in the 'callback=?' part of the query string in the url. So {jsonp:'onJSONPLoad'} would result in 'onJSONPLoad=?' passed to the server. As of jQuery 1.5, setting the jsonp option to false prevents jQuery from adding the "?callback" string to the URL or attempting to use "=?" for transformation. In this case, you should also explicitly set the jsonpCallback setting. For example, { jsonp: false, jsonpCallback: "callbackName" }
+     * Override the callback function name in a jsonp request. 
+     * This value will be used instead of 'callback' in the 'callback=?' part of the query string in the url. 
+     * So {jsonp:'onJSONPLoad'} would result in 'onJSONPLoad=?' passed to the server. 
+     * As of jQuery 1.5, setting the jsonp option to false prevents jQuery from adding the "?callback" string to the URL 
+     * or attempting to use "=?" for transformation. 
+     * In this case, you should also explicitly set the jsonpCallback setting. 
+     * For example, { jsonp: false, jsonpCallback: "callbackName" }
      */
     jsonp?: any;
     /**
-     * Specify the callback function name for a JSONP request. This value will be used instead of the random name automatically generated by jQuery. It is preferable to let jQuery generate a unique name as it'll make it easier to manage the requests and provide callbacks and error handling. You may want to specify the callback when you want to enable better browser caching of GET requests. As of jQuery 1.5, you can also use a function for this setting, in which case the value of jsonpCallback is set to the return value of that function.
+     * Specify the callback function name for a JSONP request. 
+     * This value will be used instead of the random name automatically generated by jQuery. 
+     * It is preferable to let jQuery generate a unique name as it'll make it easier to manage the requests and 
+     * provide callbacks and error handling. 
+     * You may want to specify the callback when you want to enable better browser caching of GET requests. 
+     * As of jQuery 1.5, you can also use a function for this setting, in which case the value of jsonpCallback is 
+     * set to the return value of that function.
      */
     jsonpCallback?: any;
     /**
@@ -114,23 +195,41 @@ interface JQueryAjaxSettings {
      */
     password?: string;
     /**
-     * By default, data passed in to the data option as an object (technically, anything other than a string) will be processed and transformed into a query string, fitting to the default content-type "application/x-www-form-urlencoded". If you want to send a DOMDocument, or other non-processed data, set this option to false.
+     * By default, data passed in to the data option as an object (technically, anything other than a string) will 
+     * be processed and transformed into a query string, fitting to the default content-type "application/x-www-form-urlencoded". 
+     * If you want to send a DOMDocument, or other non-processed data, set this option to false.
      */
     processData?: boolean;
     /**
-     * Only applies when the "script" transport is used (e.g., cross-domain requests with "jsonp" or "script" dataType and "GET" type). Sets the charset attribute on the script tag used in the request. Used when the character set on the local page is not the same as the one on the remote script.
+     * Only applies when the "script" transport is used 
+     * (e.g., cross-domain requests with "jsonp" or "script" dataType and "GET" type). 
+     * Sets the charset attribute on the script tag used in the request. 
+     * Used when the character set on the local page is not the same as the one on the remote script.
      */
     scriptCharset?: string;
     /**
-     * An object of numeric HTTP codes and functions to be called when the response has the corresponding code. f the request is successful, the status code functions take the same parameters as the success callback; if it results in an error (including 3xx redirect), they take the same parameters as the error callback. (version added: 1.5)
+     * An object of numeric HTTP codes and functions to be called when the response has the corresponding code. 
+     * If the request is successful, the status code functions take the same parameters as the success callback; 
+     * if it results in an error (including 3xx redirect), they take the same parameters as the error callback. 
+     * (version added: 1.5)
      */
     statusCode?: { [key: string]: any; };
     /**
-     * A function to be called if the request succeeds. The function gets passed three arguments: The data returned from the server, formatted according to the dataType parameter; a string describing the status; and the jqXHR (in jQuery 1.4.x, XMLHttpRequest) object. As of jQuery 1.5, the success setting can accept an array of functions. Each function will be called in turn. This is an Ajax Event.
+     * A function to be called if the request succeeds. The function gets passed three arguments: 
+     * The data returned from the server, formatted according to the dataType parameter; 
+     * a string describing the status; and the jqXHR (in jQuery 1.4.x, XMLHttpRequest) object. 
+     * As of jQuery 1.5, the success setting can accept an array of functions. 
+     * Each function will be called in turn. This is an Ajax Event.
      */
     success? (data: any, textStatus: string, jqXHR: JQueryXHR): any;
     /**
-     * Set a timeout (in milliseconds) for the request. This will override any global timeout set with $.ajaxSetup(). The timeout period starts at the point the $.ajax call is made; if several other requests are in progress and the browser has no connections available, it is possible for a request to time out before it can be sent. In jQuery 1.4.x and below, the XMLHttpRequest object will be in an invalid state if the request times out; accessing any object members may throw an exception. In Firefox 3.0+ only, script and JSONP requests cannot be cancelled by a timeout; the script will run even if it arrives after the timeout period.
+     * Set a timeout (in milliseconds) for the request. This will override any global timeout set with $.ajaxSetup(). 
+     * The timeout period starts at the point the $.ajax call is made; if several other requests are in progress and 
+     * the browser has no connections available, it is possible for a request to time out before it can be sent. 
+     * In jQuery 1.4.x and below, the XMLHttpRequest object will be in an invalid state if the request times out; 
+     * accessing any object members may throw an exception. 
+     * In Firefox 3.0+ only, script and JSONP requests cannot be cancelled by a timeout; 
+     * the script will run even if it arrives after the timeout period.
      */
     timeout?: number;
     /**
@@ -138,7 +237,8 @@ interface JQueryAjaxSettings {
      */
     traditional?: boolean;
     /**
-     * The type of request to make ("POST" or "GET"), default is "GET". Note: Other HTTP request methods, such as PUT and DELETE, can also be used here, but they are not supported by all browsers.
+     * The type of request to make ("POST" or "GET"), default is "GET". 
+     * Note: Other HTTP request methods, such as PUT and DELETE, can also be used here, but they are not supported by all browsers.
      */
     type?: string;
     /**
@@ -150,11 +250,17 @@ interface JQueryAjaxSettings {
      */
     username?: string;
     /**
-     * Callback for creating the XMLHttpRequest object. Defaults to the ActiveXObject when available (IE), the XMLHttpRequest otherwise. Override to provide your own implementation for XMLHttpRequest or enhancements to the factory.
+     * Callback for creating the XMLHttpRequest object. 
+     * Defaults to the ActiveXObject when available (IE), the XMLHttpRequest otherwise. 
+     * Override to provide your own implementation for XMLHttpRequest or enhancements to the factory.
      */
     xhr?: any;
     /**
-     * An object of fieldName-fieldValue pairs to set on the native XHR object. For example, you can use it to set withCredentials to true for cross-domain requests if needed. In jQuery 1.5, the withCredentials property was not propagated to the native XHR and thus CORS requests requiring it would ignore this flag. For this reason, we recommend using jQuery 1.5.1+ should you require the use of it. (version added: 1.5.1)
+     * An object of fieldName-fieldValue pairs to set on the native XHR object. 
+     * For example, you can use it to set withCredentials to true for cross-domain requests if needed. 
+     * In jQuery 1.5, the withCredentials property was not propagated to the native XHR and 
+     * thus CORS requests requiring it would ignore this flag. 
+     * For this reason, we recommend using jQuery 1.5.1+ should you require the use of it. (version added: 1.5.1)
      */
     xhrFields?: { [key: string]: any; };
 }
@@ -164,7 +270,10 @@ interface JQueryAjaxSettings {
  */
 interface JQueryXHR extends XMLHttpRequest, JQueryPromise<any> {
     /**
-     * The .overrideMimeType() method may be used in the beforeSend() callback function, for example, to modify the response content-type header. As of jQuery 1.5.1, the jqXHR object also contains the overrideMimeType() method (it was available in jQuery 1.4.x, as well, but was temporarily removed in jQuery 1.5). 
+     * The .overrideMimeType() method may be used in the beforeSend() callback function, for example, 
+     * to modify the response content-type header. 
+     * As of jQuery 1.5.1, the jqXHR object also contains the overrideMimeType() method 
+     * (it was available in jQuery 1.4.x, as well, but was temporarily removed in jQuery 1.5). 
      */
     overrideMimeType(mimeType: string): any;
     abort(statusText?: string): void;
@@ -281,10 +390,10 @@ interface JQueryPromise<T> {
     // Deprecated - given no typings
     pipe(doneFilter?: (x: any) => any, failFilter?: (x: any) => any, progressFilter?: (x: any) => any): JQueryPromise<any>;
 
-    then<U>(onFulfill: (value: T) => U, onReject?: (...reasons: any[]) => U, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
-    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (...reasons: any[]) => U, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
-    then<U>(onFulfill: (value: T) => U, onReject?: (...reasons: any[]) => JQueryGenericPromise<U>, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
-    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (...reasons: any[]) => JQueryGenericPromise<U>, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
+    then<U>(onFulfill: (value: T) => U,	onReject?: (...reasons: any[]) => U, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
+    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>,	onReject?: (...reasons: any[]) => U, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
+    then<U>(onFulfill: (value: T) => U,	onReject?: (...reasons: any[]) => JQueryGenericPromise<U>, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
+    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>,	onReject?: (...reasons: any[]) => JQueryGenericPromise<U>, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
 
     // Because JQuery Promises Suck
     then<U>(onFulfill: (...values: any[]) => U, onReject?: (...reasons: any[]) => U, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
@@ -374,7 +483,8 @@ interface JQueryPopStateEventObject extends BaseJQueryEventObject {
     originalEvent: PopStateEvent;
 }
 
-interface JQueryEventObject extends BaseJQueryEventObject, JQueryInputEventObject, JQueryMouseEventObject, JQueryKeyEventObject, JQueryPopStateEventObject {
+interface JQueryEventObject extends BaseJQueryEventObject, 
+    JQueryInputEventObject, JQueryMouseEventObject, JQueryKeyEventObject, JQueryPopStateEventObject {
 }
 
 /*
@@ -453,11 +563,14 @@ interface JQueryAnimationOptions {
      */
     complete?: Function; 
     /**
-     * A function to be called for each animated property of each animated element. This function provides an opportunity to modify the Tween object to change the value of the property before it is set.
+     * A function to be called for each animated property of each animated element. 
+     * This function provides an opportunity to modify the Tween object to change the value of 
+     * the property before it is set.
      */
     step?: (now: number, tween: any) => any; 
     /**
-     * A function to be called after each step of the animation, only once per animated element regardless of the number of animated properties. (version added: 1.8)
+     * A function to be called after each step of the animation, only once per animated element 
+     * regardless of the number of animated properties. (version added: 1.8)
      */
     progress?: (animation: JQueryPromise<any>, progress: number, remainingMs: number) => any; 
     /**
@@ -469,19 +582,25 @@ interface JQueryAnimationOptions {
      */
     done?: (animation: JQueryPromise<any>, jumpedToEnd: boolean) => any; 
     /**
-     * A function to be called when the animation fails to complete (its Promise object is rejected). (version added: 1.8)
+     * A function to be called when the animation fails to complete (its Promise object is rejected). 
+     * (version added: 1.8)
      */
     fail?: (animation: JQueryPromise<any>, jumpedToEnd: boolean) => any; 
     /**
-     * A function to be called when the animation completes or stops without completing (its Promise object is either resolved or rejected). (version added: 1.8)
+     * A function to be called when the animation completes or stops without completing 
+     * (its Promise object is either resolved or rejected). (version added: 1.8)
      */
     always?: (animation: JQueryPromise<any>, jumpedToEnd: boolean) => any; 
     /**
-     * A Boolean indicating whether to place the animation in the effects queue. If false, the animation will begin immediately. As of jQuery 1.7, the queue option can also accept a string, in which case the animation is added to the queue represented by that string. When a custom queue name is used the animation does not automatically start; you must call .dequeue("queuename") to start it.
+     * A Boolean indicating whether to place the animation in the effects queue. 
+     * If false, the animation will begin immediately. As of jQuery 1.7, the queue option can also accept a string, 
+     * in which case the animation is added to the queue represented by that string. 
+     * When a custom queue name is used the animation does not automatically start; you must call .dequeue("queuename") to start it.
      */
     queue?: any; 
     /**
-     * A map of one or more of the CSS properties defined by the properties argument and their corresponding easing functions. (version added: 1.4)
+     * A map of one or more of the CSS properties defined by the properties argument and their corresponding easing functions. 
+     * (version added: 1.4)
      */
     specialEasing?: Object;
 }
@@ -494,14 +613,16 @@ interface JQueryStatic {
     /**
      * Perform an asynchronous HTTP (Ajax) request.
      *
-     * @param settings A set of key/value pairs that configure the Ajax request. All settings are optional. A default can be set for any option with $.ajaxSetup().
+     * @param settings A set of key/value pairs that configure the Ajax request. All settings are optional. 
+     * A default can be set for any option with $.ajaxSetup().
      */
     ajax(settings: JQueryAjaxSettings): JQueryXHR;
     /**
      * Perform an asynchronous HTTP (Ajax) request.
      *
      * @param url A string containing the URL to which the request is sent.
-     * @param settings A set of key/value pairs that configure the Ajax request. All settings are optional. A default can be set for any option with $.ajaxSetup().
+     * @param settings A set of key/value pairs that configure the Ajax request. All settings are optional. 
+     * A default can be set for any option with $.ajaxSetup().
      */
     ajax(url: string, settings?: JQueryAjaxSettings): JQueryXHR;
 
@@ -594,7 +715,8 @@ interface JQueryStatic {
      * Load data from the server using a HTTP POST request.
      *
      * @param url A string containing the URL to which the request is sent.
-     * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but can be null in that case.
+     * @param success A callback function that is executed if the request succeeds. 
+     * Required if dataType is provided, but can be null in that case.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
      */
     post(url: string, success?: (data: any, textStatus: string, jqXHR: JQueryXHR) => any, dataType?: string): JQueryXHR;
@@ -603,7 +725,8 @@ interface JQueryStatic {
      *
      * @param url A string containing the URL to which the request is sent.
      * @param data A plain object or string that is sent to the server with the request.
-     * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but can be null in that case.
+     * @param success A callback function that is executed if the request succeeds. 
+     * Required if dataType is provided, but can be null in that case.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
      */
     post(url: string, data?: Object, success?: (data: any, textStatus: string, jqXHR: JQueryXHR) => any, dataType?: string): JQueryXHR;
@@ -612,7 +735,8 @@ interface JQueryStatic {
      *
      * @param url A string containing the URL to which the request is sent.
      * @param data A plain object or string that is sent to the server with the request.
-     * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but can be null in that case.
+     * @param success A callback function that is executed if the request succeeds. 
+     * Required if dataType is provided, but can be null in that case.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
      */
     post(url: string, data?: string, success?: (data: any, textStatus: string, jqXHR: JQueryXHR) => any, dataType?: string): JQueryXHR;
@@ -699,31 +823,36 @@ interface JQueryStatic {
     /**
      * Relinquish jQuery's control of the $ variable.
      *
-     * @param removeAll A Boolean indicating whether to remove all jQuery variables from the global scope (including jQuery itself).
+     * @param removeAll A Boolean indicating whether to remove all jQuery variables from the global scope 
+     * (including jQuery itself).
      */
     noConflict(removeAll?: boolean): Object;
 
     /**
-     * Provides a way to execute callback functions based on one or more objects, usually Deferred objects that represent asynchronous events.
+     * Provides a way to execute callback functions based on one or more objects, 
+     * usually Deferred objects that represent asynchronous events.
      *
      * @param deferreds One or more Deferred objects, or plain JavaScript objects.
      */
     when<T>(...deferreds: JQueryGenericPromise<T>[]): JQueryPromise<T>;
     /**
-     * Provides a way to execute callback functions based on one or more objects, usually Deferred objects that represent asynchronous events.
+     * Provides a way to execute callback functions based on one or more objects, 
+     * usually Deferred objects that represent asynchronous events.
      *
      * @param deferreds One or more Deferred objects, or plain JavaScript objects.
      */
     when<T>(...deferreds: T[]): JQueryPromise<T>;
     /**
-     * Provides a way to execute callback functions based on one or more objects, usually Deferred objects that represent asynchronous events.
+     * Provides a way to execute callback functions based on one or more objects, 
+     * usually Deferred objects that represent asynchronous events.
      *
      * @param deferreds One or more Deferred objects, or plain JavaScript objects.
      */
     when<T>(...deferreds: any[]): JQueryPromise<T>;
 
     /**
-     * Hook directly into jQuery to override how particular CSS properties are retrieved or set, normalize CSS property naming, or create custom properties.
+     * Hook directly into jQuery to override how particular CSS properties are retrieved or 
+     * set, normalize CSS property naming, or create custom properties.
      */
     cssHooks: { [key: string]: any; };
     cssNumber: any;
@@ -737,14 +866,16 @@ interface JQueryStatic {
      */
     data<T>(element: Element, key: string, value: T): T;
     /**
-     * Returns value at named data store for the element, as set by jQuery.data(element, name, value), or the full data store for the element.
+     * Returns value at named data store for the element, as set by jQuery.data(element, name, value), or 
+     * the full data store for the element.
      *
      * @param element The DOM element to associate with the data.
      * @param key A string naming the piece of data to set.
      */
     data(element: Element, key: string): any;
     /**
-     * Returns value at named data store for the element, as set by jQuery.data(element, name, value), or the full data store for the element.
+     * Returns value at named data store for the element, as set by jQuery.data(element, name, value), or 
+     * the full data store for the element.
      *
      * @param element The DOM element to associate with the data.
      */
@@ -798,7 +929,9 @@ interface JQueryStatic {
     removeData(element: Element, name?: string): JQuery;
 
     /**
-     * A constructor function that returns a chainable utility object with methods to register multiple callbacks into callback queues, invoke callback queues, and relay the success or failure state of any synchronous or asynchronous function.
+     * A constructor function that returns a chainable utility object with methods to register multiple callbacks into 
+     * callback queues, invoke callback queues, and relay the success or failure state of any 
+     * synchronous or asynchronous function.
      *
      * @param beforeStart A function that is called just before the constructor returns.
      */
@@ -865,7 +998,9 @@ interface JQueryStatic {
     contains(container: Element, contained: Element): boolean;
 
     /**
-     * A generic iterator function, which can be used to seamlessly iterate over both objects and arrays. Arrays and array-like objects with a length property (such as a function's arguments object) are iterated by numeric index, from 0 to length-1. Other objects are iterated via their named properties.
+     * A generic iterator function, which can be used to seamlessly iterate over both objects and arrays. 
+     * Arrays and array-like objects with a length property (such as a function's arguments object) are 
+     * iterated by numeric index, from 0 to length-1. Other objects are iterated via their named properties.
      * 
      * @param collection The object or array to iterate over.
      * @param callback The function that will be executed on every object.
@@ -876,7 +1011,9 @@ interface JQueryStatic {
         ): any;
 
     /**
-     * A generic iterator function, which can be used to seamlessly iterate over both objects and arrays. Arrays and array-like objects with a length property (such as a function's arguments object) are iterated by numeric index, from 0 to length-1. Other objects are iterated via their named properties.
+     * A generic iterator function, which can be used to seamlessly iterate over both objects and arrays. 
+     * Arrays and array-like objects with a length property (such as a function's arguments object) are 
+     * iterated by numeric index, from 0 to length-1. Other objects are iterated via their named properties.
      * 
      * @param collection The object or array to iterate over.
      * @param callback The function that will be executed on every object.
@@ -889,7 +1026,8 @@ interface JQueryStatic {
     /**
      * Merge the contents of two or more objects together into the first object.
      *
-     * @param target An object that will receive the new properties if additional objects are passed in or that will extend the jQuery namespace if it is the sole argument.
+     * @param target An object that will receive the new properties if additional objects are passed in or 
+     * that will extend the jQuery namespace if it is the sole argument.
      * @param object1 An object containing additional properties to merge in.
      * @param objectN Additional objects containing properties to merge in.
      */
@@ -915,8 +1053,12 @@ interface JQueryStatic {
      * Finds the elements of an array which satisfy a filter function. The original array is not affected.
      *
      * @param array The array to search through.
-     * @param func The function to process each item against. The first argument to the function is the item, and the second argument is the index. The function should return a Boolean value.  this will be the global window object.
-     * @param invert If "invert" is false, or not provided, then the function returns an array consisting of all elements for which "callback" returns true. If "invert" is true, then the function returns an array consisting of all elements for which "callback" returns false.
+     * @param func The function to process each item against. The first argument to the function is the item, and 
+     * the second argument is the index. 
+     * The function should return a Boolean value.  this will be the global window object.
+     * @param invert If "invert" is false, or not provided, then the function returns an array consisting of 
+     * all elements for which "callback" returns true. 
+     * If "invert" is true, then the function returns an array consisting of all elements for which "callback" returns false.
      */
     grep<T>(array: T[], func: (elementOfArray: T, indexInArray: number) => boolean, invert?: boolean): T[];
 
@@ -983,14 +1125,21 @@ interface JQueryStatic {
      * Translate all items in an array or object to new array of items.
      * 
      * @param array The Array to translate.
-     * @param callback The function to process each item against. The first argument to the function is the array item, the second argument is the index in array The function can return any value. Within the function, this refers to the global (window) object.
+     * @param callback The function to process each item against. 
+     * The first argument to the function is the array item, the second argument is the index in array. 
+     * The function can return any value. Within the function, this refers to the global (window) object.
      */
     map<T, U>(array: T[], callback: (elementOfArray: T, indexInArray: number) => U): U[];
     /**
      * Translate all items in an array or object to new array of items.
      * 
      * @param arrayOrObject The Array or Object to translate.
-     * @param callback The function to process each item against. The first argument to the function is the value; the second argument is the index or key of the array or object property. The function can return any value to add to the array. A returned array will be flattened into the resulting array. Within the function, this refers to the global (window) object.
+     * @param callback The function to process each item against. 
+     * The first argument to the function is the value; 
+     * the second argument is the index or key of the array or object property. 
+     * The function can return any value to add to the array. 
+     * A returned array will be flattened into the resulting array. 
+     * Within the function, this refers to the global (window) object.
      */
     map(arrayOrObject: any, callback: (value: any, indexOrKey: any) => any): any;
 
@@ -1041,7 +1190,8 @@ interface JQueryStatic {
     type(obj: any): string;
 
     /**
-     * Sorts an array of DOM elements, in place, with the duplicates removed. Note that this only works on arrays of DOM elements, not strings or numbers.
+     * Sorts an array of DOM elements, in place, with the duplicates removed. 
+     * Note that this only works on arrays of DOM elements, not strings or numbers.
      * 
      * @param array The Array of DOM elements.
      */
@@ -1133,7 +1283,9 @@ interface JQuery {
     /**
      * Adds the specified class(es) to each of the set of matched elements.
      *
-     * @param function A function returning one or more space-separated class names to be added to the existing class name(s). Receives the index position of the element in the set and the existing class name(s) as arguments. Within the function, this refers to the current element in the set.
+     * @param function A function returning one or more space-separated class names to be added to the existing class name(s). 
+     * Receives the index position of the element in the set and the existing class name(s) as arguments. 
+     * Within the function, this refers to the current element in the set.
      */
     addClass(func: (index: number, className: string) => string): JQuery;
 
@@ -1166,7 +1318,8 @@ interface JQuery {
      * Set one or more attributes for the set of matched elements.
      *
      * @param attributeName The name of the attribute to set.
-     * @param func A function returning the value to set. this is the current element. Receives the index position of the element in the set and the old attribute value as arguments.
+     * @param func A function returning the value to set. this is the current element. 
+     * Receives the index position of the element in the set and the old attribute value as arguments.
      */
     attr(attributeName: string, func: (index: number, attr: any) => any): JQuery;
     /**
@@ -1196,13 +1349,21 @@ interface JQuery {
     /**
      * Set the HTML contents of each element in the set of matched elements.
      *
-     * @param func A function returning the HTML content to set. Receives the index position of the element in the set and the old HTML value as arguments. jQuery empties the element before calling the function; use the oldhtml argument to reference the previous content. Within the function, this refers to the current element in the set.
+     * @param func A function returning the HTML content to set. 
+     * Receives the index position of the element in the set and the old HTML value as arguments. 
+     * jQuery empties the element before calling the function; 
+     * use the oldhtml argument to reference the previous content. 
+     * Within the function, this refers to the current element in the set.
      */
     html(func: (index: number, oldhtml: string) => string): JQuery;
     /**
      * Set the HTML contents of each element in the set of matched elements.
      *
-     * @param func A function returning the HTML content to set. Receives the index position of the element in the set and the old HTML value as arguments. jQuery empties the element before calling the function; use the oldhtml argument to reference the previous content. Within the function, this refers to the current element in the set.
+     * @param func A function returning the HTML content to set. 
+     * Receives the index position of the element in the set and the old HTML value as arguments. 
+     * jQuery empties the element before calling the function; 
+     * use the oldhtml argument to reference the previous content. 
+     * Within the function, this refers to the current element in the set.
      */
 
     /**
@@ -1242,7 +1403,8 @@ interface JQuery {
      * Set one or more properties for the set of matched elements.
      *
      * @param propertyName The name of the property to set.
-     * @param func A function returning the value to set. Receives the index position of the element in the set and the old property value as arguments. Within the function, the keyword this refers to the current element.
+     * @param func A function returning the value to set. Receives the index position of the element in the set and 
+     * the old property value as arguments. Within the function, the keyword this refers to the current element.
      */
     prop(propertyName: string, func: (index: number, oldPropertyValue: any) => any): JQuery;
 
@@ -1256,13 +1418,15 @@ interface JQuery {
     /**
      * Remove a single class, multiple classes, or all classes from each element in the set of matched elements.
      *
-     * @param className One or more space-separated classes to be removed from the class attribute of each matched element.
+     * @param className One or more space-separated classes to be removed from the class attribute of 
+     * each matched element.
      */
     removeClass(className?: string): JQuery;
     /**
      * Remove a single class, multiple classes, or all classes from each element in the set of matched elements.
      *
-     * @param function A function returning one or more space-separated class names to be removed. Receives the index position of the element in the set and the old class value as arguments.
+     * @param function A function returning one or more space-separated class names to be removed. 
+     * Receives the index position of the element in the set and the old class value as arguments.
      */
     removeClass(func: (index: number, className: string) => string): JQuery;
 
@@ -1274,22 +1438,27 @@ interface JQuery {
     removeProp(propertyName: string): JQuery;
 
     /**
-     * Add or remove one or more classes from each element in the set of matched elements, depending on either the class's presence or the value of the switch argument.
+     * Add or remove one or more classes from each element in the set of matched elements, depending on 
+     * either the class's presence or the value of the switch argument.
      *
      * @param className One or more class names (separated by spaces) to be toggled for each element in the matched set.
      * @param swtch A Boolean (not just truthy/falsy) value to determine whether the class should be added or removed.
      */
     toggleClass(className: string, swtch?: boolean): JQuery;
     /**
-     * Add or remove one or more classes from each element in the set of matched elements, depending on either the class's presence or the value of the switch argument.
+     * Add or remove one or more classes from each element in the set of matched elements, depending on either 
+     * the class's presence or the value of the switch argument.
      *
      * @param swtch A boolean value to determine whether the class should be added or removed.
      */
     toggleClass(swtch?: boolean): JQuery;
     /**
-     * Add or remove one or more classes from each element in the set of matched elements, depending on either the class's presence or the value of the switch argument.
+     * Add or remove one or more classes from each element in the set of matched elements, depending on either 
+     * the class's presence or the value of the switch argument.
      *
-     * @param func A function that returns class names to be toggled in the class attribute of each element in the matched set. Receives the index position of the element in the set, the old class value, and the switch as arguments.
+     * @param func A function that returns class names to be toggled in the class attribute of each element in 
+     * the matched set. Receives the index position of the element in the set, the old class value, and 
+     * the switch as arguments.
      * @param swtch A boolean value to determine whether the class should be added or removed.
      */
     toggleClass(func: (index: number, className: string, swtch: boolean) => string, swtch?: boolean): JQuery;
@@ -1301,19 +1470,22 @@ interface JQuery {
     /**
      * Set the value of each element in the set of matched elements.
      *
-     * @param value A string of text or an array of strings corresponding to the value of each matched element to set as selected/checked.
+     * @param value A string of text or an array of strings corresponding to the value of 
+     * each matched element to set as selected/checked.
      */
     val(value: string): JQuery;
     /**
      * Set the value of each element in the set of matched elements.
      *
-     * @param value A string of text or an array of strings corresponding to the value of each matched element to set as selected/checked.
+     * @param value A string of text or an array of strings corresponding to the value of 
+     * each matched element to set as selected/checked.
      */
     val(value: string[]): JQuery;
     /**
      * Set the value of each element in the set of matched elements.
      *
-     * @param func A function returning the value to set. this is the current element. Receives the index position of the element in the set and the old value as arguments.
+     * @param func A function returning the value to set. this is the current element. 
+     * Receives the index position of the element in the set and the old value as arguments.
      */
     val(func: (index: number, value: any) => any): JQuery;
 
@@ -1355,14 +1527,16 @@ interface JQuery {
      * Set one or more CSS properties for the set of matched elements.
      *
      * @param propertyName A CSS property name.
-     * @param value A function returning the value to set. this is the current element. Receives the index position of the element in the set and the old value as arguments.
+     * @param value A function returning the value to set. this is the current element. Receives the index position of 
+     * the element in the set and the old value as arguments.
      */
     css(propertyName: string, value: (index: number, value: string) => string): JQuery;
     /**
      * Set one or more CSS properties for the set of matched elements.
      *
      * @param propertyName A CSS property name.
-     * @param value A function returning the value to set. this is the current element. Receives the index position of the element in the set and the old value as arguments.
+     * @param value A function returning the value to set. this is the current element. Receives the index position of 
+     * the element in the set and the old value as arguments.
      */
     css(propertyName: string, value: (index: number, value: number) => number): JQuery;
     /**
@@ -1379,47 +1553,55 @@ interface JQuery {
     /**
      * Set the CSS height of every matched element.
      *
-     * @param value An integer representing the number of pixels, or an integer with an optional unit of measure appended (as a string).
+     * @param value An integer representing the number of pixels, or an integer with an optional unit of 
+     * measure appended (as a string).
      */
     height(value: number): JQuery;
     /**
      * Set the CSS height of every matched element.
      *
-     * @param value An integer representing the number of pixels, or an integer with an optional unit of measure appended (as a string).
+     * @param value An integer representing the number of pixels, or an integer with an optional unit of 
+     * measure appended (as a string).
      */
     height(value: string): JQuery;
     /**
      * Set the CSS height of every matched element.
      *
-     * @param func A function returning the height to set. Receives the index position of the element in the set and the old height as arguments. Within the function, this refers to the current element in the set.
+     * @param func A function returning the height to set. Receives the index position of the element 
+     * in the set and the old height as arguments. Within the function, this refers to the current element in the set.
      */
     height(func: (index: number, height: number) => number): JQuery;
     /**
      * Set the CSS height of every matched element.
      *
-     * @param func A function returning the height to set. Receives the index position of the element in the set and the old height as arguments. Within the function, this refers to the current element in the set.
+     * @param func A function returning the height to set. Receives the index position of the element in 
+     * the set and the old height as arguments. Within the function, this refers to the current element in the set.
      */
     height(func: (index: number, height: string) => string): JQuery;
     /**
      * Set the CSS height of every matched element.
      *
-     * @param func A function returning the height to set. Receives the index position of the element in the set and the old height as arguments. Within the function, this refers to the current element in the set.
+     * @param func A function returning the height to set. Receives the index position of the element in 
+     * the set and the old height as arguments. Within the function, this refers to the current element in the set.
      */
     height(func: (index: number, height: string) => number): JQuery;
     /**
      * Set the CSS height of every matched element.
      *
-     * @param func A function returning the height to set. Receives the index position of the element in the set and the old height as arguments. Within the function, this refers to the current element in the set.
+     * @param func A function returning the height to set. Receives the index position of the element in 
+     * the set and the old height as arguments. Within the function, this refers to the current element in the set.
      */
     height(func: (index: number, height: number) => string): JQuery;
 
     /**
-     * Get the current computed height for the first element in the set of matched elements, including padding but not border.
+     * Get the current computed height for the first element in the set of matched elements, including 
+     * padding but not border.
      */
     innerHeight(): number;
 
     /**
-     * Get the current computed width for the first element in the set of matched elements, including padding but not border.
+     * Get the current computed width for the first element in the set of matched elements, including 
+     * padding but not border.
      */
     innerWidth(): number;
 
@@ -1428,27 +1610,35 @@ interface JQuery {
      */
     offset(): JQueryCoordinates;
     /**
-     * An object containing the properties top and left, which are integers indicating the new top and left coordinates for the elements.
+     * An object containing the properties top and left, which are integers indicating the new top and 
+     * left coordinates for the elements.
      *
-     * @param coordinates An object containing the properties top and left, which are integers indicating the new top and left coordinates for the elements.
+     * @param coordinates An object containing the properties top and left, which are integers indicating the 
+     * new top and left coordinates for the elements.
      */
     offset(coordinates: JQueryCoordinates): JQuery;
     /**
-     * An object containing the properties top and left, which are integers indicating the new top and left coordinates for the elements.
+     * An object containing the properties top and left, which are integers indicating the new top and left 
+     * coordinates for the elements.
      *
-     * @param func A function to return the coordinates to set. Receives the index of the element in the collection as the first argument and the current coordinates as the second argument. The function should return an object with the new top and left properties.
+     * @param func A function to return the coordinates to set. Receives the index of the element in the 
+     * collection as the first argument and the current coordinates as the second argument. 
+     * The function should return an object with the new top and left properties.
      */
     offset(func: (index: number, coords: JQueryCoordinates) => JQueryCoordinates): JQuery;
 
     /**
-     * Get the current computed height for the first element in the set of matched elements, including padding, border, and optionally margin. Returns an integer (without "px") representation of the value or null if called on an empty set of elements.
+     * Get the current computed height for the first element in the set of matched elements, including 
+     * padding, border, and optionally margin. Returns an integer (without "px") representation of the 
+     * value or null if called on an empty set of elements.
      *
      * @param includeMargin A Boolean indicating whether to include the element's margin in the calculation.
      */
     outerHeight(includeMargin?: boolean): number;
 
     /**
-     * Get the current computed width for the first element in the set of matched elements, including padding and border.
+     * Get the current computed width for the first element in the set of matched elements, including 
+     * padding and border.
      *
      * @param includeMargin A Boolean indicating whether to include the element's margin in the calculation.
      */
@@ -1460,7 +1650,8 @@ interface JQuery {
     position(): JQueryCoordinates;
 
     /**
-     * Get the current horizontal position of the scroll bar for the first element in the set of matched elements or set the horizontal position of the scroll bar for every matched element.
+     * Get the current horizontal position of the scroll bar for the first element in the set of matched elements or 
+     * set the horizontal position of the scroll bar for every matched element.
      */
     scrollLeft(): number;
     /**
@@ -1471,7 +1662,8 @@ interface JQuery {
     scrollLeft(value: number): JQuery;
 
     /**
-     * Get the current vertical position of the scroll bar for the first element in the set of matched elements or set the vertical position of the scroll bar for every matched element.
+     * Get the current vertical position of the scroll bar for the first element in the set of matched elements or 
+     * set the vertical position of the scroll bar for every matched element.
      */
     scrollTop(): number;
     /**
@@ -1488,37 +1680,43 @@ interface JQuery {
     /**
      * Set the CSS width of each element in the set of matched elements.
      *
-     * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     * @param value An integer representing the number of pixels, or an integer along with an optional unit of 
+     * measure appended (as a string).
      */
     width(value: number): JQuery;
     /**
      * Set the CSS width of each element in the set of matched elements.
      *
-     * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     * @param value An integer representing the number of pixels, or an integer along with an optional unit of 
+     * measure appended (as a string).
      */
     width(value: string): JQuery;
     /**
      * Set the CSS width of each element in the set of matched elements.
      *
-     * @param func A function returning the width to set. Receives the index position of the element in the set and the old width as arguments. Within the function, this refers to the current element in the set.
+     * @param func A function returning the width to set. Receives the index position of the element in the set and 
+     * the old width as arguments. Within the function, this refers to the current element in the set.
      */
     width(func: (index: number, width: number) => number): JQuery;
     /**
      * Set the CSS width of each element in the set of matched elements.
      *
-     * @param func A function returning the width to set. Receives the index position of the element in the set and the old width as arguments. Within the function, this refers to the current element in the set.
+     * @param func A function returning the width to set. Receives the index position of the element in the set and 
+     * the old width as arguments. Within the function, this refers to the current element in the set.
      */
     width(func: (index: number, width: string) => string): JQuery;
     /**
      * Set the CSS width of each element in the set of matched elements.
      *
-     * @param func A function returning the width to set. Receives the index position of the element in the set and the old width as arguments. Within the function, this refers to the current element in the set.
+     * @param func A function returning the width to set. Receives the index position of the element in the set and 
+     * the old width as arguments. Within the function, this refers to the current element in the set.
      */
     width(func: (index: number, width: string) => number): JQuery;
     /**
      * Set the CSS width of each element in the set of matched elements.
      *
-     * @param func A function returning the width to set. Receives the index position of the element in the set and the old width as arguments. Within the function, this refers to the current element in the set.
+     * @param func A function returning the width to set. Receives the index position of the element in the set and 
+     * the old width as arguments. Within the function, this refers to the current element in the set.
      */
     width(func: (index: number, width: number) => string): JQuery;
 
@@ -1543,13 +1741,15 @@ interface JQuery {
      */
     data(obj: { [key: string]: any; }): JQuery;
     /**
-     * Return the value at the named data store for the first element in the jQuery collection, as set by data(name, value) or by an HTML5 data-* attribute.
+     * Return the value at the named data store for the first element in the jQuery collection, 
+     * as set by data(name, value) or by an HTML5 data-* attribute.
      *
      * @param key Name of the data stored.
      */
     data(key: string): any;
     /**
-     * Return the value at the named data store for the first element in the jQuery collection, as set by data(name, value) or by an HTML5 data-* attribute.
+     * Return the value at the named data store for the first element in the jQuery collection, 
+     * as set by data(name, value) or by an HTML5 data-* attribute.
      */
     data(): any;
 
@@ -1563,7 +1763,8 @@ interface JQuery {
     /**
      * Remove a previously-stored piece of data.
      *
-     * @param name A string naming the piece of data to delete or space-separated string naming the pieces of data to delete.
+     * @param name A string naming the piece of data to delete or space-separated string naming the 
+     * pieces of data to delete.
      */
     removeData(name: string): JQuery;
     /**
@@ -1574,7 +1775,8 @@ interface JQuery {
     removeData(list: string[]): JQuery;
 
     /**
-     * Return a Promise object to observe when all actions of a certain type bound to the collection, queued or not, have finished.
+     * Return a Promise object to observe when all actions of a certain type bound to the collection, 
+     * queued or not, have finished.
      *
      * @param type The type of queue that needs to be observed. (default: fx)
      * @param target Object onto which the promise methods have to be attached
@@ -1626,7 +1828,8 @@ interface JQuery {
     /**
      * Set a timer to delay execution of subsequent items in the queue.
      *
-     * @param duration An integer indicating the number of milliseconds to delay execution of the next item in the queue.
+     * @param duration An integer indicating the number of milliseconds to delay execution of the next 
+     * item in the queue.
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
      */
     delay(duration: number, queueName?: string): JQuery;
@@ -1778,7 +1981,8 @@ interface JQuery {
     fadeToggle(options: JQueryAnimationOptions): JQuery;
 
     /**
-     * Stop the currently-running animation, remove all queued animations, and complete all animations for the matched elements.
+     * Stop the currently-running animation, remove all queued animations, and complete all animations for 
+     * the matched elements.
      *
      * @param queue The name of the queue in which to stop animations.
      */
@@ -2355,7 +2559,8 @@ interface JQuery {
     /**
      * Remove an event handler.
      *
-     * @param events One or more space-separated event types and optional namespaces, or just namespaces, such as "click", "keydown.myPlugin", or ".myPlugin".
+     * @param events One or more space-separated event types and optional namespaces, or just namespaces, such as 
+     * "click", "keydown.myPlugin", or ".myPlugin".
      * @param selector A selector which should match the one originally passed to .on() when attaching event handlers.
      * @param handler A handler function previously attached for the event(s), or the special value false.
      */
@@ -2363,14 +2568,16 @@ interface JQuery {
     /**
      * Remove an event handler.
      *
-     * @param events One or more space-separated event types and optional namespaces, or just namespaces, such as "click", "keydown.myPlugin", or ".myPlugin".
+     * @param events One or more space-separated event types and optional namespaces, or just namespaces, such as 
+     * "click", "keydown.myPlugin", or ".myPlugin".
      * @param handler A handler function previously attached for the event(s), or the special value false.
      */
     off(events: string, handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
      * Remove an event handler.
      *
-     * @param events An object where the string keys represent one or more space-separated event types and optional namespaces, and the values represent handler functions previously attached for the event(s).
+     * @param events An object where the string keys represent one or more space-separated event types and 
+     * optional namespaces, and the values represent handler functions previously attached for the event(s).
      * @param selector A selector which should match the one originally passed to .on() when attaching event handlers.
      */
     off(events: { [key: string]: any; }, selector?: string): JQuery;
@@ -2378,32 +2585,44 @@ interface JQuery {
     /**
      * Attach an event handler function for one or more events to the selected elements.
      *
-     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
-     * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false. Rest parameter args is for optional parameters passed to jQuery.trigger(). Note that the actual parameters on the event handler function must be marked as optional (? syntax).
+     * @param events One or more space-separated event types and optional namespaces, such as 
+     * "click" or "keydown.myPlugin".
+     * @param handler A function to execute when the event is triggered. The value false is also allowed as 
+     * a shorthand for a function that simply does return false. 
+     * Rest parameter args is for optional parameters passed to jQuery.trigger(). 
+     * Note that the actual parameters on the event handler function must be marked as optional (? syntax).
      */
     on(events: string, handler: (eventObject: JQueryEventObject, ...args: any[]) => any): JQuery;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      *
-     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
-     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the selector is null or omitted, the event is always triggered when it reaches the selected element.
-     * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
+     * @param events One or more space-separated event types and optional namespaces, such as 
+     * "click" or "keydown.myPlugin".
+     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. 
+     * If the selector is null or omitted, the event is always triggered when it reaches the selected element.
+     * @param handler A function to execute when the event is triggered. The value false is also allowed as
+     * a shorthand for a function that simply does return false.
      */
     on(events: string, selector: string, handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      *
-     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
-     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the selector is null or omitted, the event is always triggered when it reaches the selected element.
+     * @param events One or more space-separated event types and optional namespaces, such as 
+     * "click" or "keydown.myPlugin".
+     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. 
+     * If the selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event is triggered.
-     * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
+     * @param handler A function to execute when the event is triggered. 
+     * The value false is also allowed as a shorthand for a function that simply does return false.
      */
     on(events: string, selector: string, data: any, handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      *
-     * @param events An object in which the string keys represent one or more space-separated event types and optional namespaces, and the values represent a handler function to be called for the event(s).
-     * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If the selector is null or omitted, the handler is always called when it reaches the selected element.
+     * @param events An object in which the string keys represent one or more space-separated event types and 
+     * optional namespaces, and the values represent a handler function to be called for the event(s).
+     * @param selector A selector string to filter the descendants of the selected elements that will call the handler. 
+     * If the selector is null or omitted, the handler is always called when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event occurs.
      */
     on(events: { [key: string]: any; }, selector?: any, data?: any): JQuery;
@@ -2411,14 +2630,16 @@ interface JQuery {
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      *
-     * @param events A string containing one or more JavaScript event types, such as "click" or "submit," or custom event names.
+     * @param events A string containing one or more JavaScript event types, such as 
+     * "click" or "submit," or custom event names.
      * @param handler A function to execute at the time the event is triggered.
      */
     one(events: string, handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      *
-     * @param events A string containing one or more JavaScript event types, such as "click" or "submit," or custom event names.
+     * @param events A string containing one or more JavaScript event types, such as 
+     * "click" or "submit," or custom event names.
      * @param data An object containing data that will be passed to the event handler.
      * @param handler A function to execute at the time the event is triggered.
      */
@@ -2427,26 +2648,34 @@ interface JQuery {
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      *
-     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
-     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the selector is null or omitted, the event is always triggered when it reaches the selected element.
-     * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
+     * @param events One or more space-separated event types and optional namespaces, such as 
+     * "click" or "keydown.myPlugin".
+     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. 
+     * If the selector is null or omitted, the event is always triggered when it reaches the selected element.
+     * @param handler A function to execute when the event is triggered. 
+     * The value false is also allowed as a shorthand for a function that simply does return false.
      */
     one(events: string, selector: string, handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      *
-     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
-     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the selector is null or omitted, the event is always triggered when it reaches the selected element.
+     * @param events One or more space-separated event types and optional namespaces, such as 
+     * "click" or "keydown.myPlugin".
+     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. 
+     * If the selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event is triggered.
-     * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
+     * @param handler A function to execute when the event is triggered. 
+     * The value false is also allowed as a shorthand for a function that simply does return false.
      */
     one(events: string, selector: string, data: any, handler: (eventObject: JQueryEventObject) => any): JQuery;
 
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      *
-     * @param events An object in which the string keys represent one or more space-separated event types and optional namespaces, and the values represent a handler function to be called for the event(s).
-     * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If the selector is null or omitted, the handler is always called when it reaches the selected element.
+     * @param events An object in which the string keys represent one or more space-separated event types and 
+     * optional namespaces, and the values represent a handler function to be called for the event(s).
+     * @param selector A selector string to filter the descendants of the selected elements that will call the handler. 
+     * If the selector is null or omitted, the handler is always called when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event occurs.
      */
     one(events: { [key: string]: any; }, selector?: string, data?: any): JQuery;


### PR DESCRIPTION
I was getting a TSLint error due to the default line length allowance in Web Essentials 2013 (no option to change it).  So I have changed all lines to be < 140 chars long.  Some of the comments were >500 chars.

I ran into a problem with these interface declarations as I was unsure how to re-factor them (first 24 hours with TS):

interface JQueryGenericPromise<T> {
interface JQueryPromise<T> {

NOTE: I can't just indent them, because TSLint's defaults are to fail on trailing whitespace.

If someone could take a look and reduce their footprint to under 140 chars per line, that would stop people having to change their TSLint defaults to support this file.

Cheers,

Toby.
