### PR TITLE
underscore: remove 'extends {}' constraint from each and map

### DIFF
--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -100,7 +100,7 @@ interface UnderscoreStatic {
 	* @param iterator Iterator function for each property on `obj`.
 	* @param context 'this' object in `iterator`, optional.
 	**/
-	each<T extends {}>(
+	each<T>(
 		object: _.Dictionary<T>,
 		iterator: _.ObjectIterator<T, void>,
 		context?: any): void;
@@ -116,7 +116,7 @@ interface UnderscoreStatic {
 	/**
 	* @see _.each
 	**/
-	forEach<T extends {}>(
+	forEach<T>(
 		object: _.Dictionary<T>,
 		iterator: _.ObjectIterator<T, void >,
 		context?: any): void;
@@ -142,7 +142,7 @@ interface UnderscoreStatic {
 	* @param context `this` object in `iterator`, optional.
 	* @return The mapped object result.
 	**/
-	map<T extends {}, TResult>(
+	map<T, TResult>(
 		object: _.Dictionary<T>,
 		iterator: _.ObjectIterator<T, TResult>,
 		context?: any): TResult[];
@@ -158,7 +158,7 @@ interface UnderscoreStatic {
 	/**
 	* @see _.map
 	**/
-	collect<T extends {}, TResult>(
+	collect<T, TResult>(
 		object: _.Dictionary<T>,
 		iterator: _.ObjectIterator<T, TResult>,
 		context?: any): TResult[];


### PR DESCRIPTION
The "each" (and "forEach") and "map" (and "collect") function definitions in underscore.d.ts have overloads to cover the case where these functions can take an object as the first parameter instead of a list.  These overloads all use the type parameter constraint "extends {}".  However, this type parameter constraint - that the property values of the given object must be a subtype of object - is incorrect.  The constraint is that the first parameter must be an object with property values of the same type (but that type need not be a subtype of object).  This constraint is already captured by declaring the first parameter to be of type _.Dictionary<T>.  It is unnecessarily constraining to also require T to be a subtype of object.  In cases where T is not an object, this extra constraint causes type errors even though the call to underscore works just fine.
