### PR TITLE
Add moment AMD definition (require shim)

### DIFF
--- a/moment/moment.d.ts
+++ b/moment/moment.d.ts
@@ -324,3 +324,7 @@ interface MomentStatic {
 }
 
 declare var moment: MomentStatic;
+
+declare module "moment" {
+    export = moment;
+}


### PR DESCRIPTION
Allow to use moment as an AMD module.
It is possible using RequireJS [shim](http://requirejs.org/docs/api.html#config-shim) for instance.
