### PR TITLE
addMethod params arguments vs array syntax

### DIFF
--- a/jquery.validation/jquery.validation.d.ts
+++ b/jquery.validation/jquery.validation.d.ts
@@ -51,7 +51,7 @@ interface Validator
 {
 	addClassRules(name: string, rules: any): void;
 	addClassRules(rules: any): void;
-	addMethod(name: string, method: (value: any, element: any, params: any[]) => any, message?: any): void;
+	addMethod(name: string, method: (value: any, element: any, params: any) => any, message?: any): void;
 	element(element: any): boolean;
 	form(): boolean;
 	format(template: string, ...arguments: string[]): string;

--- a/jquery.validation/jquery.validation.d.ts
+++ b/jquery.validation/jquery.validation.d.ts
@@ -51,7 +51,7 @@ interface Validator
 {
 	addClassRules(name: string, rules: any): void;
 	addClassRules(rules: any): void;
-	addMethod(name: string, method: (value: any, element: any, ...params: any[]) => any, message?: any): void;
+	addMethod(name: string, method: (value: any, element: any, params: any[]) => any, message?: any): void;
 	element(element: any): boolean;
 	form(): boolean;
 	format(template: string, ...arguments: string[]): string;


### PR DESCRIPTION
jQUery Validation does not send arguments but an array of the argument already built. By using the ... syntax of TypeScript, we get an array with one item that has the array sent by jQuery validation. I think the definition should use an array instead of arguments syntax.
