### PR TITLE
Made every type declaration explicit to prevent compilation errors.

### DIFF
--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -24,46 +24,46 @@ interface Restangular extends RestangularCustom {
     all(route: string): RestangularCollection;
     allUrl(route: string, url: string): RestangularCollection;
     copy(fromElement: any): RestangularElement;
-    withConfig(configurer: (RestangularProvider) => any): Restangular;
-    restangularizeElement(parent: any, element: any, route: string, collection?, reqParams?): RestangularElement;
+    withConfig(configurer: (RestangularProvider: RestangularProvider) => any): Restangular;
+    restangularizeElement(parent: any, element: any, route: string, collection?: any, reqParams?: any): RestangularElement;
     restangularizeCollection(parent: any, element: any, route: string): RestangularCollection;
     stripRestangular(element: any): any;
 }
 
 interface RestangularElement extends Restangular {
-    get (queryParams?: any, headers?: any): ng.IPromise<any>;
+    get(queryParams?: any, headers?: any): ng.IPromise<any>;
     getList(subElement: any, queryParams?: any, headers?: any): ng.IPromise<any>;
     put(queryParams?: any, headers?: any): ng.IPromise<any>;
-    post(subElement, elementToPost, queryParams?, headers?): ng.IPromise<any>;
-    remove(queryParams?, headers?): ng.IPromise<any>;
-    head(queryParams?, headers?): ng.IPromise<any>;
-    trace(queryParams?, headers?): ng.IPromise<any>;
-    options(queryParams?, headers?): ng.IPromise<any>;
-    patch(queryParams?, headers?): ng.IPromise<any>;
+    post(subElement: any, elementToPost: any, queryParams?: any, headers?: any): ng.IPromise<any>;
+    remove(queryParams?: any, headers?: any): ng.IPromise<any>;
+    head(queryParams?: any, headers?: any): ng.IPromise<any>;
+    trace(queryParams?: any, headers?: any): ng.IPromise<any>;
+    options(queryParams?: any, headers?: any): ng.IPromise<any>;
+    patch(queryParams?: any, headers?: any): ng.IPromise<any>;
     withHttpConfig(httpConfig: RestangularRequestConfig): RestangularElement;
     getRestangularUrl(): string;
 }
 
 interface RestangularCollection extends Restangular {
-    getList(queryParams?, headers?): ng.IPromise<any>;
-    post(elementToPost, queryParams?, headers?): ng.IPromise<any>;
-    head(queryParams?, headers?): ng.IPromise<any>;
-    trace(queryParams?, headers?): ng.IPromise<any>;
-    options(queryParams?, headers?): ng.IPromise<any>;
-    patch(queryParams?, headers?): ng.IPromise<any>;
-    putElement(idx, params, headers): ng.IPromise<any>;
+    getList(queryParams?: any, headers?: any): ng.IPromise<any>;
+    post(elementToPost: any, queryParams?: any, headers?: any): ng.IPromise<any>;
+    head(queryParams?: any, headers?: any): ng.IPromise<any>;
+    trace(queryParams?: any, headers?: any): ng.IPromise<any>;
+    options(queryParams?: any, headers?: any): ng.IPromise<any>;
+    patch(queryParams?: any, headers?: any): ng.IPromise<any>;
+    putElement(idx: any, params: any, headers: any): ng.IPromise<any>;
     withHttpConfig(httpConfig: RestangularRequestConfig): RestangularCollection;
     getRestangularUrl(): string;
 }
 
 interface RestangularCustom {
-    customGET(path, params?, headers?): ng.IPromise<any>;
-    customGETLIST(path, params?, headers?): ng.IPromise<any>;
-    customDELETE(path, params?, headers?): ng.IPromise<any>;
-    customPOST(path, params?, headers?, elem?): ng.IPromise<any>;
-    customPUT(path, params?, headers?, elem?): ng.IPromise<any>;
-    customOperation(operation, path, params?, headers?, elem?): ng.IPromise<any>;
-    addRestangularMethod(name, operation, path?, params?, headers?, elem?): ng.IPromise<any>;
+    customGET(path: string, params?: any, headers?: any): ng.IPromise<any>;
+    customGETLIST(path: string, params?: any, headers?: any): ng.IPromise<any>;
+    customDELETE(path: string, params?: any, headers?: any): ng.IPromise<any>;
+    customPOST(path: string, params?: any, headers?: any, elem?: any): ng.IPromise<any>;
+    customPUT(path: string, params?: any, headers?: any, elem?: any): ng.IPromise<any>;
+    customOperation(operation: string, path: string, params?: any, headers?: any, elem?: any): ng.IPromise<any>;
+    addRestangularMethod(name: string, operation: string, path?: string, params?: any, headers?: any, elem?: any): ng.IPromise<any>;
 }
 
 interface RestangularProvider {
@@ -76,8 +76,8 @@ interface RestangularProvider {
     setOnElemRestangularized(callback: (elem: any, isCollection: boolean, what: string, restangular: Restangular) => any): void;
     setResponseInterceptor(responseInterceptor: (data: any, operation: string, what: string, url: string, response: RestangularResponse, deferred: ng.IDeferred<any>) => any): void;
     setResponseExtractor(responseInterceptor: (data: any, operation: string, what: string, url: string, response: RestangularResponse, deferred: ng.IDeferred<any>) => any): void;
-    setRequestInterceptor(requestInterceptor: (element: any, operation: string, what: string, url: string) => any);
-    setFullRequestInterceptor(fullRequestInterceptor: (element: any, operation: string, what: string, url: string, headers: any, params: any) => {element: any; headers: any; params: any});
+    setRequestInterceptor(requestInterceptor: (element: any, operation: string, what: string, url: string) => any): void;
+    setFullRequestInterceptor(fullRequestInterceptor: (element: any, operation: string, what: string, url: string, headers: any, params: any) => {element: any; headers: any; params: any}): void;
     setErrorInterceptor(errorInterceptor: (response: RestangularResponse) => any): void;
     setRestangularFields(fields: {[fieldName: string]: string}): void;
     setMethodOverriders(overriders: string[]): void;


### PR DESCRIPTION
I have explicitly stated every type declaration (mostly :any) in the code so that there are no errors when compiling with --noImplicitAny.
