### PR TITLE
JQuery: Add support for outerWidth and outerHeight used as setters

### DIFF
--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -2178,6 +2178,8 @@ function test_outerHeight() {
     $("p:last").text(
         "outerHeight:" + p.outerHeight() +
         " , outerHeight( true ):" + p.outerHeight(true));
+
+    p.outerHeight(123);
 }
 
 function test_outerWidth() {
@@ -2185,6 +2187,8 @@ function test_outerWidth() {
     $("p:last").text(
         "outerWidth:" + p.outerWidth() +
         " , outerWidth( true ):" + p.outerWidth(true));
+
+    p.outerWidth(123);
 }
 
 function test_scrollLeft() {

--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -2166,11 +2166,17 @@ function test_index() {
 function test_innerHeight() {
     var p = $("p:first");
     $("p:last").text("innerHeight:" + p.innerHeight());
+
+    p.innerHeight(123);
+    p.innerHeight('123px');
 }
 
 function test_innerWidth() {
     var p = $("p:first");
     $("p:last").text("innerWidth:" + p.innerWidth());
+
+    p.innerWidth(123);
+    p.innerWidth('123px');
 }
 
 function test_outerHeight() {
@@ -2180,6 +2186,7 @@ function test_outerHeight() {
         " , outerHeight( true ):" + p.outerHeight(true));
 
     p.outerHeight(123);
+    p.outerHeight('123px');
 }
 
 function test_outerWidth() {
@@ -2189,6 +2196,7 @@ function test_outerWidth() {
         " , outerWidth( true ):" + p.outerWidth(true));
 
     p.outerWidth(123);
+    p.outerWidth('123px');
 }
 
 function test_scrollLeft() {

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -1448,11 +1448,25 @@ interface JQuery {
     outerHeight(includeMargin?: boolean): number;
 
     /**
+     * Sets the outer height on elements in the set of matched elements, including padding and border.
+     *
+     * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     */
+    outerHeight(height: number): JQuery;
+
+    /**
      * Get the current computed width for the first element in the set of matched elements, including padding and border.
      *
      * @param includeMargin A Boolean indicating whether to include the element's margin in the calculation.
      */
     outerWidth(includeMargin?: boolean): number;
+
+  /**
+   * Sets the outer width on elements in the set of matched elements, including padding and border.
+   *
+   * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+   */
+    outerWidth(width: number): JQuery;
 
     /**
      * Get the current coordinates of the first element in the set of matched elements, relative to the offset parent.

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -1419,9 +1419,37 @@ interface JQuery {
     innerHeight(): number;
 
     /**
+     * Sets the inner height on elements in the set of matched elements, including padding but not border.
+     *
+     * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     */
+    innerHeight(height: number): JQuery;
+
+    /**
+     * Sets the inner height on elements in the set of matched elements, including padding but not border.
+     *
+     * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     */
+    innerHeight(height: string): JQuery;
+
+    /**
      * Get the current computed width for the first element in the set of matched elements, including padding but not border.
      */
     innerWidth(): number;
+
+    /**
+     * Sets the inner width on elements in the set of matched elements, including padding but not border.
+     *
+     * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     */
+    innerWidth(width: number): JQuery;
+
+    /**
+     * Sets the inner width on elements in the set of matched elements, including padding but not border.
+     *
+     * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     */
+    innerWidth(width: string): JQuery;
 
     /**
      * Get the current coordinates of the first element in the set of matched elements, relative to the document.
@@ -1455,18 +1483,32 @@ interface JQuery {
     outerHeight(height: number): JQuery;
 
     /**
+     * Sets the outer height on elements in the set of matched elements, including padding and border.
+     *
+     * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     */
+    outerHeight(height: string): JQuery;
+
+    /**
      * Get the current computed width for the first element in the set of matched elements, including padding and border.
      *
      * @param includeMargin A Boolean indicating whether to include the element's margin in the calculation.
      */
     outerWidth(includeMargin?: boolean): number;
 
-  /**
-   * Sets the outer width on elements in the set of matched elements, including padding and border.
-   *
-   * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
-   */
+    /**
+     * Sets the outer width on elements in the set of matched elements, including padding and border.
+     *
+     * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     */
     outerWidth(width: number): JQuery;
+
+    /**
+     * Sets the outer width on elements in the set of matched elements, including padding and border.
+     *
+     * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     */
+    outerWidth(width: string): JQuery;
 
     /**
      * Get the current coordinates of the first element in the set of matched elements, relative to the offset parent.


### PR DESCRIPTION
As described in the following blog post, outerWidth and outerHeight can
now be used to set the size of elements.

http://blog.jquery.com/2012/08/16/jquery-1-8-box-sizing-width-csswidth-and-outerwidth/
