### PR TITLE
Fixed bootstrap.paginator "itemTexts" option signature

### DIFF
--- a/bootstrap.paginator/bootstrap.paginator.d.ts
+++ b/bootstrap.paginator/bootstrap.paginator.d.ts
@@ -14,7 +14,7 @@ interface PaginatorOptions{
     totalPages?: number;
     pageUrl?: (type, page, current) => string;
     shouldShowPage?: boolean;
-    itemText?: (type, page, current) => any;
+    itemTexts?: (type:string, page:number, current:number) => string;
     tooltipTitles?: (type, page, current) => string;
     useBootstrapTooltip?: boolean;
     bootstrapTooltipOptions?: {};

--- a/bootstrap.paginator/bootstrap.paginator.d.ts
+++ b/bootstrap.paginator/bootstrap.paginator.d.ts
@@ -18,6 +18,7 @@ interface PaginatorOptions{
     tooltipTitles?: (type, page, current) => string;
     useBootstrapTooltip?: boolean;
     bootstrapTooltipOptions?: {};
+    bootstrapMajorVersion?: number;
     onPageClicked?: (event, originalEvent, type, page) => void;
     onPageChanged?: (event, originalEvent, type, page) => void;
 }


### PR DESCRIPTION
The option name is wrong, and the signature lacked specificity.
This fixes the name (adds the "s" at the end), and adds the types to the function signature.
