### PR TITLE
Fix knockout ko.utils.stringifyJson definition

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -310,7 +310,7 @@ interface KnockoutUtils {
 
     parseJson(jsonString: string): any;
 
-    stringifyJson(data: any, replacer: Function, space: string): string;
+    stringifyJson(data: any, replacer?: Function, space?: string): string;
 
     postJson(urlOrForm: any, data: any, options: any): void;
 


### PR DESCRIPTION
Allow `ko.utils.stringifyJson` method to be called without any **replacer** nor **space** arguments. 
