### PR TITLE
Add amd definition for knockout.mapping

### DIFF
--- a/knockout.mapping/knockout.mapping.d.ts
+++ b/knockout.mapping/knockout.mapping.d.ts
@@ -46,3 +46,7 @@ interface KnockoutMapping {
 interface KnockoutStatic {
     mapping: KnockoutMapping;
 }
+
+declare module "knockout.mapping" {
+    export = KnockoutMapping;
+}


### PR DESCRIPTION
Allow knockout.mapping to be imported as an AMD module.

knockout.mapping is allowed to be imported as AMD or commonjs module without any configuration.
