### PR TITLE
Support AMD

### DIFF
--- a/state-machine/state-machine.d.ts
+++ b/state-machine/state-machine.d.ts
@@ -79,3 +79,7 @@ interface StateMachine {
 }
 
 declare var StateMachine: StateMachineStatic;
+
+declare module "state-machine" { 
+    export = StateMachineStatic; 
+}


### PR DESCRIPTION
Added an export module, because the original state-machine.js supports AMD, which feature was not available from TypeScript before this patch.
