### PR TITLE
Moved definitions to 'restify' namespace, added inheritance of Server, Request and Response 

### DIFF
--- a/restify/restify.d.ts
+++ b/restify/restify.d.ts
@@ -3,13 +3,20 @@
 // Definitions by: Bret Little <https://github.com/blittle>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-interface addressInterface {
+/// <reference path="../node/node.d.ts" />
+
+
+declare module "restify" {
+  import http = require('http');
+
+
+  interface addressInterface {
     port: number;
     family: string;
     address: string;
-}
+  }
 
-interface Request {
+  interface Request extends http.ServerRequest {
     header: (key: string, defaultValue?: string) => any;
     accepts: (type: string) => boolean;
     is: (type: string) => boolean;
@@ -24,9 +31,9 @@ interface Request {
     secure: boolean;
     time: number;
     params: any;
-}
+  }
 
-interface Response {
+  interface Response extends http.ServerResponse {
     header: (key: string, value ?: any) => any;
     cache: (type?: any, options?: Object) => any;
     status: (code: number) => any;
@@ -39,9 +46,9 @@ interface Response {
     headers: Object;
     statusCode: number;
     id: string;
-}
+  }
 
-interface Server {
+  interface Server extends http.Server {
     use: (... handler: any[]) => any;
     post: (route: any, routeCallBack: RequestHadler) => any;
     patch: (route: any, routeCallBack: RequestHadler) => any;
@@ -60,9 +67,9 @@ interface Server {
     close: (... args: any[]) => any;
     pre: (routeCallBack: RequestHadler) => any;
 
-}
+  }
 
-interface ServerOptions {
+  interface ServerOptions {
     certificate ?: string;
     key ?: string;
     formatters ?: Object;
@@ -72,9 +79,9 @@ interface ServerOptions {
     version ?: string;
     responseTimeHeader ?: string;
     responseTimeFormatter ?: (durationInMilliseconds: number) => any;
-}
+  }
 
-interface ClientOptions {
+  interface ClientOptions {
     accept?: string;
     connectTimeout?: number;
     dtrace?: Object;
@@ -86,26 +93,26 @@ interface ClientOptions {
     url?: string;
     userAgent?: string;
     version?: string;
-}
+  }
 
-interface Client {
+  interface Client {
     get: (path: string, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
     head: (path: string, callback?: (err: any, req: Request, res: Response) => any) => any;
     post: (path: string, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
     put: (path: string, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
     del: (path: string, callback?: (err: any, req: Request, res: Response) => any) => any;
     basicAuth: (username: string, password: string) => any;
-}
+  }
 
-interface HttpClient extends Client {
+  interface HttpClient extends Client {
     get: (path?: any, callback?: Function) => any;
     head: (path?:any, callback?: Function) => any;
     post: (opts?: any, callback?: Function) => any;
     put: (opts?: any, callback?: Function) => any;
     del: (opts?: any, callback?: Function) => any;
-}
+  }
 
-interface ThrottleOptions {
+  interface ThrottleOptions {
     burst?: number;
     rate?: number;
     ip?: boolean;
@@ -114,13 +121,12 @@ interface ThrottleOptions {
     tokensTable?: Object;
     maxKeys?: number;
     overrides?: Object;
-}
+  }
 
-interface RequestHadler {
+  interface RequestHadler {
     (req: Request, res: Response, next: Function): any;
-}
+  }
 
-declare module "restify" {
     export function createServer(options?: ServerOptions): Server;
 
     export function createJsonClient(options?: ClientOptions): Client;


### PR DESCRIPTION
Moved definitions from global ( evil :) ) context to 'restify' module/namespace, added inheritance of Server, Request and Response from nodejs 'http' module

documentation here: http://mcavage.me/node-restify/
