### PR TITLE
jasmine-jquery: Make second parameter of toHaveAttr() and toHaveProp() optional

### DIFF
--- a/jasmine-jquery/jasmine-jquery-tests.ts
+++ b/jasmine-jquery/jasmine-jquery-tests.ts
@@ -16,7 +16,9 @@ describe("Jasmine jQuery extension", () => {
         expect($('<span></span>').addClass('js-something')).toBeMatchedBy('.js-something');
         expect($('<span></span>')).toExist();
         expect($('<div id="some-id"></div>')).toHaveAttr('id', 'some-id');
+        expect($('<input type="checkbox" checked="checked"/>')).toHaveAttr('type');
         expect($('<div id="some-id"></div>')).toHaveProp('id', 'some-id');
+        expect($('<input type="checkbox" checked="checked"/>')).toHaveProp('checked');
         expect($('')).toHaveBeenTriggered();
         expect($('')).toHaveBeenTriggeredOn('#some-id');
         expect($('')).toHaveBeenTriggeredOnAndWith('#some-id', 'eventParam');
@@ -132,4 +134,4 @@ describe("Jasmine jQuery extension", () => {
             expect(spyEvent).toHaveBeenStopped();
         });
     });
-})
+});

--- a/jasmine-jquery/jasmine-jquery.d.ts
+++ b/jasmine-jquery/jasmine-jquery.d.ts
@@ -90,8 +90,8 @@ declare module jasmine {
         toBeEmpty(): boolean;
         toExist(): boolean;
         toHaveLength(length: number): boolean;
-        toHaveAttr(attributeName: string, expectedAttributeValue): boolean;
-        toHaveProp(propertyName: string, expectedPropertyValue): boolean;
+        toHaveAttr(attributeName: string, expectedAttributeValue?): boolean;
+        toHaveProp(propertyName: string, expectedPropertyValue?): boolean;
         toHaveId(id: string): boolean;
         toHaveHtml(html: string): boolean;
         //toContainHtml(html: string): boolean;


### PR DESCRIPTION
According to https://github.com/velesin/jasmine-jquery, "attribute value is optional" for toHaveAttr(attributeName, attributeValue), and "property value is optional" for toHaveProp(propertyName, propertyValue).  This pull request fixes that.
