### PR TITLE
Added the indexer to the KnockoutValidationRuleDefinitions interface

### DIFF
--- a/knockout.validation/knockout.validation-tests.ts
+++ b/knockout.validation/knockout.validation-tests.ts
@@ -1,0 +1,13 @@
+/// <reference path="knockout.validation.d.ts"/>
+
+
+function test_validation_rules_indexer() {
+    // This is the validation rule taken from the knockout validation wiki, modified to include type information.
+    // https://github.com/Knockout-Contrib/Knockout-Validation/wiki/Custom-Validation-Rules
+    ko.validation.rules['mustEqual'] = {
+        validator: function (val: any, otherVal: any): boolean {
+            return val === otherVal;
+        },
+        message: 'The field must equal {0}'
+    };
+}

--- a/knockout.validation/knockout.validation.d.ts
+++ b/knockout.validation/knockout.validation.d.ts
@@ -85,6 +85,7 @@ interface KnockoutValidationRuleDefinitions {
     required: KnockoutValidationRuleDefinition;
     step: KnockoutValidationRuleDefinition;
     unique: KnockoutValidationRuleDefinition;
+    [name: string]: KnockoutValidationRuleDefinition;
 }
 
 interface KnockoutValidationRule {


### PR DESCRIPTION
There is currently no indexer present on the `KnockoutValidationRuleDefinitions` interface.

This results in `error TS7017: Index signature of object type implicitly has an 'any' type` when custom rules are added according to the [Custom Validation Rules section of the Knockout-Validation documentation](https://github.com/Knockout-Contrib/Knockout-Validation/wiki/Custom-Validation-Rules) and the file is compiled with the `--noImplicitAny` flag.

Adding the indexer to the interface allows the rules to be added according to the documentation.
