### PR TITLE
Fixes for test runner

### DIFF
--- a/_infrastructure/tests/compile-runner.bat
+++ b/_infrastructure/tests/compile-runner.bat
@@ -1,1 +1,1 @@
-tsc runner.ts --target ES5 --out runner.js --module commonjs
+tsc runner.ts --target ES5 --out runner.js --module commonjs --sourcemap

--- a/_infrastructure/tests/runner.js
+++ b/_infrastructure/tests/runner.js
@@ -1035,9 +1035,6 @@ var DT;
 
             // add a closure to queue
             this.queue.push(function () {
-                // when activate, add test to active list
-                _this.active.push(test);
-
                 // run it
                 var p = test.run();
                 p.then(defer.resolve.bind(defer), defer.reject.bind(defer));
@@ -1048,6 +1045,9 @@ var DT;
                     }
                     _this.step();
                 });
+
+                // return it
+                return test;
             });
             this.step();
 
@@ -1056,13 +1056,9 @@ var DT;
         };
 
         TestQueue.prototype.step = function () {
-            var _this = this;
-            // setTimeout to make it flush
-            setTimeout(function () {
-                while (_this.queue.length > 0 && _this.active.length < _this.concurrent) {
-                    _this.queue.pop().call(null);
-                }
-            }, 1);
+            while (this.queue.length > 0 && this.active.length < this.concurrent) {
+                this.active.push(this.queue.pop().call(null));
+            }
         };
         return TestQueue;
     })();
@@ -1314,4 +1310,7 @@ var DT;
         process.exit(2);
     });
 })(DT || (DT = {}));
+//grunt-start
+/// <reference path="../runner.ts" />
+//grunt-end
 //# sourceMappingURL=runner.js.map

--- a/_infrastructure/tests/runner.js
+++ b/_infrastructure/tests/runner.js
@@ -1293,10 +1293,12 @@ var DT;
         process.exit(0);
     }
 
+    var testFull = process.env['TRAVIS_BRANCH'] ? /\w\/full$/.test(process.env['TRAVIS_BRANCH']) : false;
+
     new TestRunner(dtPath, {
         concurrent: argv['single-thread'] ? 1 : Math.max(cpuCores, 2),
         tscVersion: argv['tsc-version'],
-        testChanges: argv['test-changes'],
+        testChanges: testFull ? false : argv['test-changes'],
         skipTests: argv['skip-tests'],
         printFiles: argv['print-files'],
         printRefMap: argv['print-refmap'],

--- a/_infrastructure/tests/runner.js
+++ b/_infrastructure/tests/runner.js
@@ -850,7 +850,7 @@ var DT;
 
     var Promise = require('bluebird');
 
-    var endDts = /\w\.ts$/i;
+    var endDts = /\w\.d\.ts$/i;
 
     /////////////////////////////////
     // .d.ts syntax inspection

--- a/_infrastructure/tests/runner.ts
+++ b/_infrastructure/tests/runner.ts
@@ -75,8 +75,6 @@ module DT {
 			var defer = Promise.defer();
 			// add a closure to queue
 			this.queue.push(() => {
-				// when activate, add test to active list
-				this.active.push(test);
 				// run it
 				var p = test.run();
 				p.then(defer.resolve.bind(defer), defer.reject.bind(defer));
@@ -87,6 +85,8 @@ module DT {
 					}
 					this.step();
 				});
+				// return it
+				return test;
 			});
 			this.step();
 			// defer it
@@ -94,12 +94,9 @@ module DT {
 		}
 
 		private step(): void {
-			// setTimeout to make it flush
-			setTimeout(() => {
-				while (this.queue.length > 0 && this.active.length < this.concurrent) {
-					this.queue.pop().call(null);
-				}
-			}, 1);
+			while (this.queue.length > 0 && this.active.length < this.concurrent) {
+				this.active.push(this.queue.pop().call(null));
+			}
 		}
 	}
 

--- a/_infrastructure/tests/runner.ts
+++ b/_infrastructure/tests/runner.ts
@@ -336,10 +336,12 @@ module DT {
 		process.exit(0);
 	}
 
+	var testFull = process.env['TRAVIS_BRANCH'] ? /\w\/full$/.test(process.env['TRAVIS_BRANCH']) : false;
+
 	new TestRunner(dtPath, {
 		concurrent: argv['single-thread'] ? 1 : Math.max(cpuCores, 2),
 		tscVersion: argv['tsc-version'],
-		testChanges: argv['test-changes'],
+		testChanges: testFull ? false : argv['test-changes'], // allow magic branch
 		skipTests: argv['skip-tests'],
 		printFiles: argv['print-files'],
 		printRefMap: argv['print-refmap'],

--- a/_infrastructure/tests/src/suite/syntax.ts
+++ b/_infrastructure/tests/src/suite/syntax.ts
@@ -6,7 +6,7 @@ module DT {
 
 	var Promise: typeof Promise = require('bluebird');
 
-	var endDts = /\w\.ts$/i;
+	var endDts = /\w\.d\.ts$/i;
 
 	/////////////////////////////////
 	// .d.ts syntax inspection


### PR DESCRIPTION
The runner's Syntax step compiled all .ts files instead of the .d.ts files. This RegExp fix cuts about 300 compiles and another 2 minutes (oops :grin:)

I also added a magic hack so when you use a branch ending on `/full` then travis will run the full test suite instead of the git changes. https://travis-ci.org/Bartvds/DefinitelyTyped/builds/20327360 with the other fix so done in 4 minutes (hah).

And also fixed a small flow flaw in the async code.
