### PR TITLE
Restify routing

### DIFF
--- a/restify/restify.d.ts
+++ b/restify/restify.d.ts
@@ -51,7 +51,10 @@ declare module "restify" {
   }
 
   interface Server extends http.Server {
-    use: (... handler: any[]) => any;
+    use(handler: RequestHandler, ...handlers: RequestHandler[]): any;
+    use(handler: RequestHandler[], ...handlers: RequestHandler[]): any;
+    use(handler: RequestHandler, ...handlers: RequestHandler[][]): any;
+    use(handler: RequestHandler[], ...handlers: RequestHandler[][]): any;
 
     post(route: any, routeCallBack: RequestHandler, ...routeCallBacks: RequestHandler[]): any;
     post(route: any, routeCallBack: RequestHandler[], ...routeCallBacks: RequestHandler[]): any;
@@ -89,9 +92,9 @@ declare module "restify" {
     acceptable: string[];
     url: string;
     address: () => addressInterface;
-    listen: (... args: any[]) => any;
-    close: (... args: any[]) => any;
-    pre: (routeCallBack: RequestHandler) => any;
+    listen(... args: any[]): any;
+    close(... args: any[]): any;
+    pre(routeCallBack: RequestHandler): any;
 
   }
 

--- a/restify/restify.d.ts
+++ b/restify/restify.d.ts
@@ -152,12 +152,12 @@ declare module "restify" {
     overrides?: Object;
   }
 
-  interface next {
+  interface Next {
     (err?: any): any;
   }
 
   interface RequestHandler {
-    (req: Request, res: Response, next: next): any;
+    (req: Request, res: Response, next: Next): any;
   }
 
   export function createServer(options?: ServerOptions): Server;

--- a/restify/restify.d.ts
+++ b/restify/restify.d.ts
@@ -52,12 +52,37 @@ declare module "restify" {
 
   interface Server extends http.Server {
     use: (... handler: any[]) => any;
-    post: (route: any, routeCallBack: RequestHandler) => any;
-    patch: (route: any, routeCallBack: RequestHandler) => any;
-    put: (route: any, routeCallBack: RequestHandler) => any;
-    del: (route: any, routeCallBack: RequestHandler) => any;
-    get: (route: any, routeCallBack: RequestHandler) => any;
-    head: (route: any, routeCallBack: RequestHandler) => any;
+
+    post(route: any, routeCallBack: RequestHandler, ...routeCallBacks: RequestHandler[]): any;
+    post(route: any, routeCallBack: RequestHandler[], ...routeCallBacks: RequestHandler[]): any;
+    post(route: any, routeCallBack: RequestHandler, ...routeCallBacks: RequestHandler[][]): any;
+    post(route: any, routeCallBack: RequestHandler[], ...routeCallBacks: RequestHandler[][]): any;
+
+    patch(route: any, routeCallBack: RequestHandler, ...routeCallBacks: RequestHandler[]): any;
+    patch(route: any, routeCallBack: RequestHandler[], ...routeCallBacks: RequestHandler[]): any;
+    patch(route: any, routeCallBack: RequestHandler, ...routeCallBacks: RequestHandler[][]): any;
+    patch(route: any, routeCallBack: RequestHandler[], ...routeCallBacks: RequestHandler[][]): any;
+
+    put(route: any, routeCallBack: RequestHandler, ...routeCallBacks: RequestHandler[]): any;
+    put(route: any, routeCallBack: RequestHandler[], ...routeCallBacks: RequestHandler[]): any;
+    put(route: any, routeCallBack: RequestHandler, ...routeCallBacks: RequestHandler[][]): any;
+    put(route: any, routeCallBack: RequestHandler[], ...routeCallBacks: RequestHandler[][]): any;
+
+    del(route: any, routeCallBack: RequestHandler, ...routeCallBacks: RequestHandler[]): any;
+    del(route: any, routeCallBack: RequestHandler[], ...routeCallBacks: RequestHandler[]): any;
+    del(route: any, routeCallBack: RequestHandler, ...routeCallBacks: RequestHandler[][]): any;
+    del(route: any, routeCallBack: RequestHandler[], ...routeCallBacks: RequestHandler[][]): any;
+
+    get(route: any, routeCallBack: RequestHandler, ...routeCallBacks: RequestHandler[]): any;
+    get(route: any, routeCallBack: RequestHandler[], ...routeCallBacks: RequestHandler[]): any;
+    get(route: any, routeCallBack: RequestHandler, ...routeCallBacks: RequestHandler[][]): any;
+    get(route: any, routeCallBack: RequestHandler[], ...routeCallBacks: RequestHandler[][]): any;
+
+    head(route: any, routeCallBack: RequestHandler, ...routeCallBacks: RequestHandler[]): any;
+    head(route: any, routeCallBack: RequestHandler[], ...routeCallBacks: RequestHandler[]): any;
+    head(route: any, routeCallBack: RequestHandler, ...routeCallBacks: RequestHandler[][]): any;
+    head(route: any, routeCallBack: RequestHandler[], ...routeCallBacks: RequestHandler[][]): any;
+
     name: string;
     version: string;
     log: Object;
@@ -124,8 +149,12 @@ declare module "restify" {
     overrides?: Object;
   }
 
+  interface next {
+    (err?: any): any;
+  }
+
   interface RequestHandler {
-    (req: Request, res: Response, next: Function): any;
+    (req: Request, res: Response, next: next): any;
   }
 
   export function createServer(options?: ServerOptions): Server;


### PR DESCRIPTION
1. Added 'next' interface
2. Route binding methods and "use" method can have multiple request handlers and accepts arrays of handlers

Documentation here: http://mcavage.me/node-restify/#Routing
