### PR TITLE
Export Rx as "rx" module for CommonJS loading

### DIFF
--- a/rx.js/rx.d.ts
+++ b/rx.js/rx.d.ts
@@ -354,3 +354,7 @@ declare module Rx {
 
 	export var AsyncSubject: AsyncSubjectStatic;
 }
+
+declare module "rx" {
+    export = Rx
+}


### PR DESCRIPTION
This commit exports Rx as "rx" so that

``` javascript
import Rx = require("rx");
```

works.

The name `rx` matches the package name in NPM: https://www.npmjs.org/package/rx.
