### PR TITLE
Adds missing method CORS on restify type definition

### DIFF
--- a/restify/restify.d.ts
+++ b/restify/restify.d.ts
@@ -160,6 +160,17 @@ declare module "restify" {
     (req: Request, res: Response, next: Next): any;
   }
 
+  interface CORS {
+      (cors?: {
+          origins?: string[];
+          credentials?: boolean;
+          headers?: string[];
+      }): RequestHandler;
+      origins: string[];
+      ALLOW_HEADERS: string[];
+      credentials: boolean;
+  }
+
   export function createServer(options?: ServerOptions): Server;
 
   export function createJsonClient(options?: ClientOptions): Client;
@@ -199,4 +210,5 @@ declare module "restify" {
   export function auditLogger(options?: Object): Function;
   export function fullResponse(): RequestHandler;
   export var defaultResponseHeaders : any;
+  export var CORS: CORS;
 }


### PR DESCRIPTION
I got the definitions from the source [here](https://github.com/mcavage/node-restify/blob/master/lib/plugins/cors.js)
