### PR TITLE
Fix typo on restify type definition

### DIFF
--- a/restify/restify-tests.ts
+++ b/restify/restify-tests.ts
@@ -98,7 +98,7 @@ server.get( /(.*)/, send);
 server.head(/(.*)/, send);
 
 new restify.ConflictError("test");
-new restify.InvalidArguementError("message");
+new restify.InvalidArgumentError("message");
 new restify.RestError("message");
 new restify.BadDigestError("message");
 new restify.BadMethodError("message");

--- a/restify/restify.d.ts
+++ b/restify/restify.d.ts
@@ -167,7 +167,7 @@ declare module "restify" {
   export function createClient(options?: ClientOptions): HttpClient;
 
   export class ConflictError { constructor(message?: any); }
-  export class InvalidArguementError { constructor(message?: any); }
+  export class InvalidArgumentError { constructor(message?: any); }
   export class RestError { constructor(message?: any); }
   export class BadDigestError { constructor(message: any); }
   export class BadMethodError { constructor(message: any); }


### PR DESCRIPTION
This little one turned me crazy. There was an extra letter in one of the predefined errors.
