### PR TITLE
jQuery: continuing JSDoc

### DIFF
--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -418,7 +418,7 @@ function test_slideToggle() {
     $("#aa").click(function () {
         $("div:not(.still)").slideToggle("slow", function () {
             var n = parseInt($("span").text(), 10);
-            $("span").text(n + 1);
+            $("span").text((n + 1).toString());
         });
     });
 }
@@ -2143,13 +2143,13 @@ function test_html() {
 function test_inArray() {
     var arr: any[] = [4, "Pete", 8, "John"];
     var $spans = $("span");
-    $spans.eq(0).text(jQuery.inArray("John", arr));
-    $spans.eq(1).text(jQuery.inArray(4, arr));
-    $spans.eq(2).text(jQuery.inArray("Karl", arr));
-    $spans.eq(3).text(jQuery.inArray("Pete", arr, 2));
+    $spans.eq(0).text(jQuery.inArray("John", arr).toString());
+    $spans.eq(1).text(jQuery.inArray(4, arr).toString());
+    $spans.eq(2).text(jQuery.inArray("Karl", arr).toString());
+    $spans.eq(3).text(jQuery.inArray("Pete", arr, 2).toString());
 
     var arr2: number[] = [1, 2, 3, 4];
-    $spans.eq(1).text(jQuery.inArray(4, arr2));
+    $spans.eq(1).text(jQuery.inArray(4, arr2).toString());
 }
 
 function test_index() {
@@ -2384,7 +2384,7 @@ function test_isFunction() {
     ];
     jQuery.each(objs, function (i) {
         var isFunc = jQuery.isFunction(objs[i]);
-        $("span").eq(i).text(isFunc);
+        $("span").eq(i).text(isFunc.toString());
     });
     $.isFunction(function () { });
 }
@@ -2749,7 +2749,7 @@ function test_mouseenter() {
     var n = 0;
     $("div.enterleave").mouseenter(function () {
         $("p:first", this).text("mouse enter");
-        $("p:last", this).text(++n);
+        $("p:last", this).text((++n).toString());
     }).mouseleave(function () {
         $("p:first", this).text("mouse leave");
     });
@@ -2767,14 +2767,14 @@ function test_mouseleave() {
         $("p:first", this).text("mouse over");
     }).mouseout(function () {
         $("p:first", this).text("mouse out");
-        $("p:last", this).text(++i);
+        $("p:last", this).text((++i).toString());
     });
     var n = 0;
     $("div.enterleave").mouseenter(function () {
         $("p:first", this).text("mouse enter");
     }).mouseleave(function () {
         $("p:first", this).text("mouse leave");
-        $("p:last", this).text(++n);
+        $("p:last", this).text((++n).toString());
     });
 }
 
@@ -2805,7 +2805,7 @@ function test_mouseout() {
     var i = 0;
     $("div.overout").mouseout(function () {
         $("p:first", this).text("mouse out");
-        $("p:last", this).text(++i);
+        $("p:last", this).text((++i).toString());
     }).mouseover(function () {
         $("p:first", this).text("mouse over");
     });
@@ -2814,7 +2814,7 @@ function test_mouseout() {
         $("p:first", this).text("mouse enter");
     }).bind("mouseleave", function () {
         $("p:first", this).text("mouse leave");
-        $("p:last", this).text(++n);
+        $("p:last", this).text((++n).toString());
     });
 }
 
@@ -2847,7 +2847,7 @@ function test_mouseover() {
     var i = 0;
     $("div.overout").mouseover(function () {
         $("p:first", this).text("mouse over");
-        $("p:last", this).text(++i);
+        $("p:last", this).text((++i).toString());
     }).mouseout(function () {
         $("p:first", this).text("mouse out");
     });
@@ -2868,6 +2868,36 @@ function test_makeArray() {
     var obj = $('li');
     var arr = $.makeArray(obj);
     jQuery.isArray(arr) === true;
+}
+
+function test_replaceAll() {
+    $("<h2>New heading</h2>").replaceAll(".inner");
+    $(".first").replaceAll(".third");
+    $("<b>Paragraph. </b>").replaceAll("p");
+}
+
+function test_replaceWith() {
+    $("div.second").replaceWith("<h2>New heading</h2>");
+    $("div.inner").replaceWith("<h2>New heading</h2>");
+    $("div.third").replaceWith($(".first"));
+
+    $("button").click(function () {
+        $(this).replaceWith("<div>" + $(this).text() + "</div>");
+    });
+
+    $("p").replaceWith("<b>Paragraph. </b>");
+
+    $("p").click(function () {
+        $(this).replaceWith($("div"));
+    });
+
+    $("button").on("click", function () {
+        var $container = $("div.container").replaceWith(function () {
+            return $(this).contents();
+        });
+
+        $("p").append($container.attr("class"));
+    });
 }
 
 function test_map() {

--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -418,7 +418,7 @@ function test_slideToggle() {
     $("#aa").click(function () {
         $("div:not(.still)").slideToggle("slow", function () {
             var n = parseInt($("span").text(), 10);
-            $("span").text((n + 1).toString());
+            $("span").text(n + 1);
         });
     });
 }
@@ -763,7 +763,7 @@ function test_children() {
         var $kids = $(e.target).children();
         var len = $kids.addClass("hilite").length;
 
-        $("#results span:first").text(len.toString());
+        $("#results span:first").text(len);
         //$("#results span:last").text(e.target.tagName);
 
         e.preventDefault();
@@ -2143,13 +2143,13 @@ function test_html() {
 function test_inArray() {
     var arr: any[] = [4, "Pete", 8, "John"];
     var $spans = $("span");
-    $spans.eq(0).text(jQuery.inArray("John", arr).toString());
-    $spans.eq(1).text(jQuery.inArray(4, arr).toString());
-    $spans.eq(2).text(jQuery.inArray("Karl", arr).toString());
-    $spans.eq(3).text(jQuery.inArray("Pete", arr, 2).toString());
+    $spans.eq(0).text(jQuery.inArray("John", arr));
+    $spans.eq(1).text(jQuery.inArray(4, arr));
+    $spans.eq(2).text(jQuery.inArray("Karl", arr));
+    $spans.eq(3).text(jQuery.inArray("Pete", arr, 2));
 
     var arr2: number[] = [1, 2, 3, 4];
-    $spans.eq(1).text(jQuery.inArray(4, arr2).toString());
+    $spans.eq(1).text(jQuery.inArray(4, arr2));
 }
 
 function test_index() {
@@ -2384,7 +2384,7 @@ function test_isFunction() {
     ];
     jQuery.each(objs, function (i) {
         var isFunc = jQuery.isFunction(objs[i]);
-        $("span").eq(i).text(isFunc.toString());
+        $("span").eq(i).text(isFunc);
     });
     $.isFunction(function () { });
 }
@@ -2749,7 +2749,7 @@ function test_mouseenter() {
     var n = 0;
     $("div.enterleave").mouseenter(function () {
         $("p:first", this).text("mouse enter");
-        $("p:last", this).text((++n).toString());
+        $("p:last", this).text(++n);
     }).mouseleave(function () {
         $("p:first", this).text("mouse leave");
     });
@@ -2767,14 +2767,14 @@ function test_mouseleave() {
         $("p:first", this).text("mouse over");
     }).mouseout(function () {
         $("p:first", this).text("mouse out");
-        $("p:last", this).text((++i).toString());
+        $("p:last", this).text(++i);
     });
     var n = 0;
     $("div.enterleave").mouseenter(function () {
         $("p:first", this).text("mouse enter");
     }).mouseleave(function () {
         $("p:first", this).text("mouse leave");
-        $("p:last", this).text((++n).toString());
+        $("p:last", this).text(++n);
     });
 }
 
@@ -2805,7 +2805,7 @@ function test_mouseout() {
     var i = 0;
     $("div.overout").mouseout(function () {
         $("p:first", this).text("mouse out");
-        $("p:last", this).text((++i).toString());
+        $("p:last", this).text(++i);
     }).mouseover(function () {
         $("p:first", this).text("mouse over");
     });
@@ -2814,7 +2814,7 @@ function test_mouseout() {
         $("p:first", this).text("mouse enter");
     }).bind("mouseleave", function () {
         $("p:first", this).text("mouse leave");
-        $("p:last", this).text((++n).toString());
+        $("p:last", this).text(++n);
     });
 }
 
@@ -2847,7 +2847,7 @@ function test_mouseover() {
     var i = 0;
     $("div.overout").mouseover(function () {
         $("p:first", this).text("mouse over");
-        $("p:last", this).text((++i).toString());
+        $("p:last", this).text(++i);
     }).mouseout(function () {
         $("p:first", this).text("mouse out");
     });

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -3017,14 +3017,88 @@ interface JQuery {
      */
     remove(selector?: string): JQuery;
 
-    replaceAll(target: any): JQuery;
+    /**
+     * Replace each target element with the set of matched elements.
+     * 
+     * @param target A selector string, jQuery object, DOM element, or array of elements indicating which element(s) to replace.
+     */
+    replaceAll(target: JQuery): JQuery;
+    /**
+     * Replace each target element with the set of matched elements.
+     * 
+     * @param target A selector string, jQuery object, DOM element, or array of elements indicating which element(s) to replace.
+     */
+    replaceAll(target: any[]): JQuery;
+    /**
+     * Replace each target element with the set of matched elements.
+     * 
+     * @param target A selector string, jQuery object, DOM element, or array of elements indicating which element(s) to replace.
+     */
+    replaceAll(target: Element): JQuery;
+    /**
+     * Replace each target element with the set of matched elements.
+     * 
+     * @param target A selector string, jQuery object, DOM element, or array of elements indicating which element(s) to replace.
+     */
+    replaceAll(target: string): JQuery;
 
-    replaceWith(func: any): JQuery;
+    /**
+     * Replace each element in the set of matched elements with the provided new content and return the set of elements that was removed.
+     * 
+     * param newContent The content to insert. May be an HTML string, DOM element, array of DOM elements, or jQuery object.
+     */
+    replaceWith(newContent: JQuery): JQuery;
+    /**
+     * Replace each element in the set of matched elements with the provided new content and return the set of elements that was removed.
+     * 
+     * param newContent The content to insert. May be an HTML string, DOM element, array of DOM elements, or jQuery object.
+     */
+    replaceWith(newContent: any[]): JQuery;
+    /**
+     * Replace each element in the set of matched elements with the provided new content and return the set of elements that was removed.
+     * 
+     * param newContent The content to insert. May be an HTML string, DOM element, array of DOM elements, or jQuery object.
+     */
+    replaceWith(newContent: Element): JQuery;
+    /**
+     * Replace each element in the set of matched elements with the provided new content and return the set of elements that was removed.
+     * 
+     * param newContent The content to insert. May be an HTML string, DOM element, array of DOM elements, or jQuery object.
+     */
+    replaceWith(newContent: Text): JQuery;
+    /**
+     * Replace each element in the set of matched elements with the provided new content and return the set of elements that was removed.
+     * 
+     * param newContent The content to insert. May be an HTML string, DOM element, array of DOM elements, or jQuery object.
+     */
+    replaceWith(newContent: string): JQuery;
+    /**
+     * Replace each element in the set of matched elements with the provided new content and return the set of elements that was removed.
+     * 
+     * param func A function that returns content with which to replace the set of matched elements.
+     */
+    replaceWith(func: () => any): JQuery;
 
+    /**
+     * Get the combined text contents of each element in the set of matched elements, including their descendants.
+     */
     text(): string;
-    text(textString: any): JQuery;
-    text(textString: (index: number, text: string) => string): JQuery;
+    /**
+     * Set the content of each element in the set of matched elements to the specified text.
+     * 
+     * @param textString A string of text to set as the content of each matched element.
+     */
+    text(textString: string): JQuery;
+    /**
+     * Set the content of each element in the set of matched elements to the specified text.
+     * 
+     * @param func A function returning the text content to set. Receives the index position of the element in the set and the old text value as arguments.
+     */
+    text(func: (index: number, text: string) => string): JQuery;
 
+    /**
+     * Retrieve all the elements contained in the jQuery set, as an array.
+     */
     toArray(): any[];
 
     unwrap(): JQuery;

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -3086,9 +3086,21 @@ interface JQuery {
     /**
      * Set the content of each element in the set of matched elements to the specified text.
      * 
-     * @param textString A string of text to set as the content of each matched element.
+     * @param text The text to set as the content of each matched element.
      */
-    text(textString: string): JQuery;
+    text(text: string): JQuery;
+    /**
+     * Set the content of each element in the set of matched elements to the specified text.
+     * 
+     * @param text The text to set as the content of each matched element.
+     */
+    text(text: number): JQuery;
+    /**
+     * Set the content of each element in the set of matched elements to the specified text.
+     * 
+     * @param text The text to set as the content of each matched element.
+     */
+    text(text: boolean): JQuery;
     /**
      * Set the content of each element in the set of matched elements to the specified text.
      * 


### PR DESCRIPTION
Introducing missing test suites / tightening up typings along the way.

This PR could prove controversial as part of it makes the simple `text` setter API compliant.  i.e. It goes from this:

``` ts
text(textString: any): JQuery;
```

to this: 

``` ts
text(textString: string): JQuery;
```

as per http://api.jquery.com/text/#text-textString

However, the jQuery documentation is littered with examples of passing numbers / booleans etc to `text` instead of strings.  Some examples:
- http://api.jquery.com/jquery.inArray/#example-0
- http://api.jquery.com/slideToggle/#example-1
- http://api.jquery.com/jquery.isFunction/#example-0
- http://api.jquery.com/mouseenter/#example-0
- http://api.jquery.com/mouseleave/#example-0

This makes me think that the examples in the jQuery documentation are wrong or that the jQuery API documentation is wrong.  I don't know which.

@dmethvin could you pitch in here perhaps?
