### PR TITLE
Fix AngularJS $q.when definition

### DIFF
--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -94,6 +94,7 @@ module HttpAndRegularPromiseTests {
         person: Person;
         theAnswer: number;
         letters: string[];
+		snack: string;
     }
 
     var someController: Function = ($scope: SomeControllerScope, $http: ng.IHttpService, $q: ng.IQService) => {
@@ -132,6 +133,12 @@ module HttpAndRegularPromiseTests {
         cPromise.then((letters: string[]) => {
             $scope.letters = letters;
         });
+
+		// When $q.when is passed an IPromise<T>, it returns an IPromise<T>
+		var dPromise: ng.IPromise<string> = $q.when($q.when("ALBATROSS!"));
+		dPromise.then((snack: string) => {
+			$scope.snack = snack;
+		});
     }
 
   // Test that we can pass around a type-checked success/error Promise Callback

--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -94,7 +94,7 @@ module HttpAndRegularPromiseTests {
         person: Person;
         theAnswer: number;
         letters: string[];
-		snack: string;
+        snack: string;
     }
 
     var someController: Function = ($scope: SomeControllerScope, $http: ng.IHttpService, $q: ng.IQService) => {
@@ -134,11 +134,11 @@ module HttpAndRegularPromiseTests {
             $scope.letters = letters;
         });
 
-		// When $q.when is passed an IPromise<T>, it returns an IPromise<T>
-		var dPromise: ng.IPromise<string> = $q.when($q.when("ALBATROSS!"));
-		dPromise.then((snack: string) => {
-			$scope.snack = snack;
-		});
+        // When $q.when is passed an IPromise<T>, it returns an IPromise<T>
+        var dPromise: ng.IPromise<string> = $q.when($q.when("ALBATROSS!"));
+        dPromise.then((snack: string) => {
+            $scope.snack = snack;
+        });
     }
 
   // Test that we can pass around a type-checked success/error Promise Callback

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -455,6 +455,7 @@ declare module ng {
         all(promises: {[id: string]: IPromise<any>;}): IPromise<{[id: string]: any}>;
         defer<T>(): IDeferred<T>;
         reject(reason?: any): IPromise<void>;
+        when<T>(value: IPromise<T>): IPromise<T>;
         when<T>(value: T): IPromise<T>;
     }
 


### PR DESCRIPTION
When $q.when is called on a promise<T>, it returns a promise<T>, not a promise of a promise. The angular docs aren't totally clear on this, but it can be verified by checking out the [code](https://github.com/angular/angular.js/blob/master/src/ng/q.js) or running the following:

``` typescript
var foo = $q.when(1);
foo.then(x => console.log(x)); // logs 1
var bar = $q.when($q.when(2));
bar.then(x => console.log(x)); // logs 2
```
