### PR TITLE
AMD support

### DIFF
--- a/zeroclipboard/zeroclipboard.d.ts
+++ b/zeroclipboard/zeroclipboard.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/jonrohan/ZeroClipboard
 // Definitions by: Eric J. Smith <https://github.com/ejsmith>
 // Definitions by: Blake Niemyjski <https://github.com/niemyjski>
+// Definitions by: György Balássy <https://github.com/balassy>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare class ZeroClipboard {
@@ -35,3 +36,6 @@ interface ZeroClipboardOptions {
     hoverClass?: string;
     activeClass?: string;
 }
+
+// Support AMD.
+declare module "zeroclipboard" { export = ZeroClipboard; }


### PR DESCRIPTION
Added AMD support as the original ZeroClipboard.js has direct built-in support for AMD as well.
