### PR TITLE
Added new() to IResourceClass

### DIFF
--- a/angularjs/angular-resource.d.ts
+++ b/angularjs/angular-resource.d.ts
@@ -51,6 +51,7 @@ declare module ng.resource {
     // to be considered as parameters to the request.
     // https://github.com/angular/angular.js/blob/v1.2.0/src/ngResource/resource.js#L461-L465
     interface IResourceClass<T> {
+        new(dataOrParams? : any) : T;
         get(): T;
         get(dataOrParams: any): T;
         get(dataOrParams: any, success: Function): T;


### PR DESCRIPTION
Added `new(dataOrParams? : any) : T;` to `IResourceClass<T>` to allow creation of a new instance of the resource using the `new` keyword, which is required to create a new resource object of type `T`. 

In the [AngularJS documentation example](http://docs.angularjs.org/api/ngResource/service/$resource) this change would allow for line 27 `new CreditCard({number:'0123'});` where `CreditCard` is `IResourceClass<CreditCard>`. Without this change we get `error TS2083: Invalid 'new' expression.` when new-ing the resource.
