### PR TITLE
fix bootstrap.datepicker type

### DIFF
--- a/bootstrap.datepicker/bootstrap.datepicker.d.ts
+++ b/bootstrap.datepicker/bootstrap.datepicker.d.ts
@@ -8,8 +8,8 @@
 interface DatepickerOptions {
     format?: string;
     weekStart?: number;
-    startDate?: Date;
-    endDate?: Date;
+    startDate?: any;
+    endDate?: any;
     autoclose?: boolean;
     startView?: number;
     todayBtn?: boolean;


### PR DESCRIPTION
Param `startDate` and `endDate` are not only Date type.
#1841
