### PR TITLE
Please stop changing the todayBtn type...

### DIFF
--- a/bootstrap.datepicker/bootstrap.datepicker.d.ts
+++ b/bootstrap.datepicker/bootstrap.datepicker.d.ts
@@ -12,7 +12,7 @@ interface DatepickerOptions {
     endDate?: any;
     autoclose?: boolean;
     startView?: number;
-    todayBtn?: boolean;
+    todayBtn?: any;
     todayHighlight?: boolean;
     keyboardNavigation?: boolean;
     language?: string;


### PR DESCRIPTION
$('#start').datepicker({
                startDate: new Date(2013, 0, 0),
                endDate: moment().startOf('day').toDate(),
                todayBtn: 'linked'
            })
