### PR TITLE
RxJS: updated to version 2.2.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,7 @@ Properties
 *.iml
 *.js.map
 
+#rx.js
+!rx.js
+
 node_modules

--- a/rx.js/rx.async-tests.ts
+++ b/rx.js/rx.async-tests.ts
@@ -66,7 +66,11 @@ module Rx.Tests.Async {
 			new<T>(resolver: (resolvePromise: (value: T)=> void, rejectPromise: (reason: any)=> void)=> void): Rx.IPromise<T>;
 		};
 
+		Rx.config.Promise = promiseImpl;
+
 		var p: IPromise<number> = obsNum.toPromise(promiseImpl);
+
+		p = obsNum.toPromise();
 
 		p = p.then(x=> x);
 		p = p.then(x=> p);

--- a/rx.js/rx.async-tests.ts
+++ b/rx.js/rx.async-tests.ts
@@ -81,4 +81,8 @@ module Rx.Tests.Async {
 		ps = p.then(x=> "");
 		ps = p.then(x=> ps);
 	}
+
+	function startAsync() {
+		var o: Rx.Observable<string> = Rx.Observable.startAsync(() => <Rx.IPromise<string>>null);
+	}
 }

--- a/rx.js/rx.async.d.ts
+++ b/rx.js/rx.async.d.ts
@@ -83,30 +83,5 @@ declare module Rx {
 		fromEvent<T>(element: NodeList, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
 		fromEvent<T>(element: Node, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
         fromEventPattern<T>(addHandler: (handler: Function) => void, removeHandler: (handler: Function) => void, selector?: (arguments: any[])=>T): Observable<T>;
-
-		fromPromise<T>(promise: IPromise<T>): Observable<T>;
-		fromPromise<T>(promise: any): Observable<T>;
-	}
-
-	interface Observable<T> {
-		/**
-		 * Converts an existing observable sequence to an ES6 Compatible Promise
-		 * @example
-		 * var promise = Rx.Observable.return(42).toPromise(RSVP.Promise);
-		 * @param The constructor of the promise
-		 * @returns An ES6 compatible promise with the last value from the observable sequence.
-		 */
-		toPromise<TPromise extends IPromise<T>>(promiseCtor: { new (resolver: (resolvePromise: (value: T) => void, rejectPromise: (reason: any) => void) => void): TPromise; }): TPromise;
-		toPromise(promiseCtor: { new (resolver: (resolvePromise: (value: T) => void, rejectPromise: (reason: any) => void) => void): IPromise<T>; }): IPromise<T>;
-	}
-
-	/**
-	 * Promise A+
-	 */
-	export interface IPromise<T> {
-		then<R>(onFulfilled: (value: T) => IPromise<R>, onRejected: (reason: any) => IPromise<R>): IPromise<R>;
-		then<R>(onFulfilled: (value: T) => IPromise<R>, onRejected?: (reason: any) => R): IPromise<R>;
-		then<R>(onFulfilled: (value: T) => R, onRejected: (reason: any) => IPromise<R>): IPromise<R>;
-		then<R>(onFulfilled?: (value: T) => R, onRejected?: (reason: any) => R): IPromise<R>;
 	}
 }

--- a/rx.js/rx.async.d.ts
+++ b/rx.js/rx.async.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Async package 2.2.11
+// Type definitions for RxJS-Async package 2.2.15
 // Project: http://rx.codeplex.com/
 // Definitions by: zoetrope <https://github.com/zoetrope>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
@@ -9,6 +9,13 @@
 declare module Rx {
     interface ObservableStatic {
 		start<T>(func: () => T, scheduler?: IScheduler, context?: any): Observable<T>;
+
+		/**
+		* Invokes the asynchronous function, surfacing the result through an observable sequence.
+		* @param functionAsync Asynchronous function which returns a Promise to run.
+		* @returns An observable sequence exposing the function's result value, or an exception.
+		*/
+		startAsync<T>(functionAsync: () => IPromise<T>): Observable<T>;
 
         toAsync<TResult>(func: () => TResult, scheduler?: IScheduler, context?: any): () => Observable<TResult>;
 		toAsync<T1, TResult>(func: (arg1: T1) => TResult, scheduler?: IScheduler, context?: any): (arg1: T1) => Observable<TResult>;

--- a/rx.js/rx.async.d.ts
+++ b/rx.js/rx.async.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Async package 2.2.15
+// Type definitions for RxJS-Async v2.2.15
 // Project: http://rx.codeplex.com/
 // Definitions by: zoetrope <https://github.com/zoetrope>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.backpressure-tests.ts
+++ b/rx.js/rx.backpressure-tests.ts
@@ -1,0 +1,22 @@
+﻿// Tests for RxJS-BackPressure TypeScript definitions
+// Tests by Igor Oleinikov <https://github.com/Igorbek>
+
+///<reference path="rx.d.ts" />
+///<reference path="rx.backpressure.d.ts" />
+
+function testPausable() {
+	var o: Rx.Observable<string>;
+
+	var pauser = new Rx.Subject<boolean>();
+
+	var p = o.pausable(pauser);
+	p = o.pausableBuffered(pauser);
+}
+
+function testControlled() {
+	var o: Rx.Observable<string>;
+	var c = o.controlled();
+
+	var d: Rx.IDisposable = c.request();
+	d = c.request(5);
+}

--- a/rx.js/rx.backpressure.d.ts
+++ b/rx.js/rx.backpressure.d.ts
@@ -1,0 +1,43 @@
+﻿// Type definitions for RxJS-BackPressure v2.2.15
+// Project: http://rx.codeplex.com/
+// Definitions by: Igor Oleinikov <https://github.com/Igorbek>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+///<reference path="rx.d.ts" />
+
+declare module Rx {
+	export interface Observable<T> {
+		/**
+		* Pauses the underlying observable sequence based upon the observable sequence which yields true/false.
+		* @example
+		* var pauser = new Rx.Subject();
+		* var source = Rx.Observable.interval(100).pausable(pauser);
+		* @param pauser The observable sequence used to pause the underlying sequence.
+		* @returns The observable sequence which is paused based upon the pauser.
+		*/
+		pausable(pauser: Observable<boolean>): Observable<T>;
+
+		/**
+		* Pauses the underlying observable sequence based upon the observable sequence which yields true/false,
+		* and yields the values that were buffered while paused.
+		* @example
+		* var pauser = new Rx.Subject();
+		* var source = Rx.Observable.interval(100).pausableBuffered(pauser);
+		* @param pauser The observable sequence used to pause the underlying sequence.
+		* @returns The observable sequence which is paused based upon the pauser.
+		*/
+		pausableBuffered(pauser: Observable<boolean>): Observable<T>;
+
+		/**
+		* Attaches a controller to the observable sequence with the ability to queue.
+		* @example
+		* var source = Rx.Observable.interval(100).controlled();
+		* source.request(3); // Reads 3 values
+		*/
+		controlled(enableQueue?: boolean): ControlledObservable<T>;
+	}
+
+	export interface ControlledObservable<T> extends Observable<T> {
+		request(numberOfItems?: number): IDisposable;
+	}
+}

--- a/rx.js/rx.d.ts
+++ b/rx.js/rx.d.ts
@@ -233,11 +233,14 @@ declare module Rx {
 		combineLatest<T2, T3, T4, T5, TResult>(second: Observable<T2>, third: Observable<T3>, fourth: Observable<T4>, fifth: Observable<T5>, resultSelector: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => TResult): Observable<TResult>;
 		combineLatest<TOther, TResult>(souces: Observable<TOther>[], resultSelector: (firstValue: T, ...otherValues: TOther[]) => TResult): Observable<TResult>;
 		concat(...sources: Observable<T>[]): Observable<T>;
+		concat(...sources: IPromise<T>[]): Observable<T>;
 		concat(sources: Observable<T>[]): Observable<T>;
+		concat(sources: IPromise<T>[]): Observable<T>;
 		concatAll(): T;
 		concatObservable(): T;	// alias for concatAll
-		merge(maxConcurrent: number): Observable<T>;
+		merge(maxConcurrent: number): T;
 		merge(other: Observable<T>): Observable<T>;
+		merge(other: IPromise<T>): Observable<T>;
 		mergeAll(): T;
 		mergeObservable(): T;	// alias for mergeAll
 		onErrorResumeNext(second: Observable<T>): Observable<T>;
@@ -342,11 +345,17 @@ declare module Rx {
 		catch<T>(...sources: Observable<T>[]): Observable<T>;
 		catchException<T>(...sources: Observable<T>[]): Observable<T>;	// alias for catch
 		concat<T>(...sources: Observable<T>[]): Observable<T>;
+		concat<T>(...sources: IPromise<T>[]): Observable<T>;
 		concat<T>(sources: Observable<T>[]): Observable<T>;
+		concat<T>(sources: IPromise<T>[]): Observable<T>;
 		merge<T>(...sources: Observable<T>[]): Observable<T>;
+		merge<T>(...sources: IPromise<T>[]): Observable<T>;
 		merge<T>(sources: Observable<T>[]): Observable<T>;
+		merge<T>(sources: IPromise<T>[]): Observable<T>;
 		merge<T>(scheduler: IScheduler, ...sources: Observable<T>[]): Observable<T>;
+		merge<T>(scheduler: IScheduler, ...sources: IPromise<T>[]): Observable<T>;
 		merge<T>(scheduler: IScheduler, sources: Observable<T>[]): Observable<T>;
+		merge<T>(scheduler: IScheduler, sources: IPromise<T>[]): Observable<T>;
 		onErrorResumeNext<T>(...sources: Observable<T>[]): Observable<T>;
 		onErrorResumeNext<T>(sources: Observable<T>[]): Observable<T>;
 		zip<T1, T2, TResult>(first: Observable<T1>, sources: Observable<T2>[], resultSelector: (item1: T1, right: Observable<T2>) => TResult): Observable<TResult>;

--- a/rx.js/rx.d.ts
+++ b/rx.js/rx.d.ts
@@ -47,7 +47,7 @@ declare module Rx {
 	}
 
 	export module config {
-		export var Promise: { new <T>(resolve: (value: T) => void, reject: (reason: any) => void): IPromise<T>; };
+		export var Promise: { new <T>(resolver: (resolvePromise: (value: T) => void, rejectPromise: (reason: any) => void) => void): IPromise<T>; };
 	}
 
 	export interface IDisposable {

--- a/rx.js/rx.d.ts
+++ b/rx.js/rx.d.ts
@@ -245,7 +245,8 @@ declare module Rx {
 		mergeObservable(): T;	// alias for mergeAll
 		onErrorResumeNext(second: Observable<T>): Observable<T>;
 		skipUntil<T2>(other: Observable<T2>): Observable<T>;
-		switchLatest(): T;
+		switch(): T;
+		switchLatest(): T;	// alias for switch
 		takeUntil<T2>(other: Observable<T2>): Observable<T>;
 		zip<T2, TResult>(second: Observable<T2>, resultSelector: (v1: T, v2: T2) => TResult): Observable<TResult>;
 		zip<T2, T3, TResult>(second: Observable<T2>, third: Observable<T3>, resultSelector: (v1: T, v2: T2, v3: T3) => TResult): Observable<TResult>;
@@ -285,11 +286,17 @@ declare module Rx {
 		select<TResult>(selector: (value: T, index: number, source: Observable<T>) => TResult, thisArg?: any): Observable<TResult>;
 		map<TResult>(selector: (value: T, index: number, source: Observable<T>) => TResult, thisArg?: any): Observable<TResult>;	// alias for select
 		selectMany<TOther, TResult>(selector: (value: T) => Observable<TOther>, resultSelector: (item: T, other: TOther) => TResult): Observable<TResult>;
+		selectMany<TOther, TResult>(selector: (value: T) => IPromise<TOther>, resultSelector: (item: T, other: TOther) => TResult): Observable<TResult>;
 		selectMany<TResult>(selector: (value: T) => Observable<TResult>): Observable<TResult>;
+		selectMany<TResult>(selector: (value: T) => IPromise<TResult>): Observable<TResult>;
 		selectMany<TResult>(other: Observable<TResult>): Observable<TResult>;
+		selectMany<TResult>(other: IPromise<TResult>): Observable<TResult>;
 		flatMap<TOther, TResult>(selector: (value: T) => Observable<TOther>, resultSelector: (item: T, other: TOther) => TResult): Observable<TResult>;	// alias for selectMany
+		flatMap<TOther, TResult>(selector: (value: T) => IPromise<TOther>, resultSelector: (item: T, other: TOther) => TResult): Observable<TResult>;	// alias for selectMany
 		flatMap<TResult>(selector: (value: T) => Observable<TResult>): Observable<TResult>;	// alias for selectMany
+		flatMap<TResult>(selector: (value: T) => IPromise<TResult>): Observable<TResult>;	// alias for selectMany
 		flatMap<TResult>(other: Observable<TResult>): Observable<TResult>;	// alias for selectMany
+		flatMap<TResult>(other: IPromise<TResult>): Observable<TResult>;	// alias for selectMany
 		skip(count: number): Observable<T>;
 		skipWhile(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): Observable<T>;
 		take(count: number, scheduler?: IScheduler): Observable<T>;

--- a/rx.js/rx.d.ts
+++ b/rx.js/rx.d.ts
@@ -1,11 +1,11 @@
-﻿// Type definitions for RxJS v2.2.13
+﻿// Type definitions for RxJS v2.2.15
 // Project: http://rx.codeplex.com/
 // Definitions by: gsino <http://www.codeplex.com/site/users/view/gsino>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module Rx {
-	export module Internals {
+	export module internals {
 		function isEqual(left: any, right: any): boolean;
 		function inherits(child: Function, parent: Function): Function;
 		function addProperties(obj: Object, ...sourcces: Object[]): void;
@@ -44,6 +44,10 @@ declare module Rx {
 			isCancelled(): boolean;
 			invokeCore(): IDisposable;
 		}
+	}
+
+	export module config {
+		
 	}
 
 	export interface IDisposable {

--- a/rx.js/rx.d.ts
+++ b/rx.js/rx.d.ts
@@ -363,6 +363,19 @@ declare module Rx {
 		* @returns An Observable sequence which wraps the existing promise success and failure.
 		*/
 		fromPromise<T>(promise: IPromise<T>): Observable<T>;
+
+		/**
+		* Converts a generator function to an observable sequence, using an optional scheduler to enumerate the generator.
+		* BUG: it have been defined for Observable instance.
+		*  
+		* @example
+		*  var res = Rx.Observable.fromGenerator(function* () { yield 42; });
+		*  var res = Rx.Observable.fromArray(function* () { yield 42; }, Rx.Scheduler.timeout);
+		* @param genFn Generator function.
+		* @param [scheduler] Scheduler to run the enumeration of the input sequence on.
+		* @returns The observable sequence whose elements are pulled from the given generator sequence.
+		*/
+		fromGenerator<T>(genFn: () => { next(): { done: boolean; value?: T; }; }, scheduler?: IScheduler): Observable<T>;
 	}
 
 	export var Observable: ObservableStatic;

--- a/rx.js/rx.time.d.ts
+++ b/rx.js/rx.time.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS "Aggregates"
+// Type definitions for RxJS-Time v2.2.15
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.virtualtime.d.ts
+++ b/rx.js/rx.virtualtime.d.ts
@@ -27,7 +27,7 @@ declare module Rx {
 		/* protected abstract */ toDateTimeOffset(duetime: TAbsolute): number;
 		/* protected abstract */ toRelative(duetime: number): TRelative;
 
-		/* protected */ getNext(): Internals.ScheduledItem<TAbsolute>;
+		/* protected */ getNext(): internals.ScheduledItem<TAbsolute>;
 	}
 
 	export class HistoricalScheduler extends VirtualTimeScheduler<number, number> {


### PR DESCRIPTION
- Core
  - renamed `Internals` to `internals`;
  - moved promises from Async to Core;
  - added `config` with promises configuration;
  - added `Observable.fromGenerator` method;
  - added overloads for `merge`, `concat`, `selectMany`/`flatMap` taking promises instead of observables;
- Async
  - added tests for promises;
  - added `startAsync` method;
- BackPressure (new package):
  - added `pausable`, `pausableBuffered`, `controlled` methods and `ControlledObservable` interface.
