### PR TITLE
Adds missing restify.pre methods

### DIFF
--- a/restify/restify-tests.ts
+++ b/restify/restify-tests.ts
@@ -28,6 +28,8 @@ server = restify.createServer({
     responseTimeFormatter : (durationInMilliseconds: number) => {}
 });
 
+server.pre(restify.pre.sanitizePath());
+
 server.on('someEvent', ()=>{});
 
 

--- a/restify/restify.d.ts
+++ b/restify/restify.d.ts
@@ -211,4 +211,10 @@ declare module "restify" {
   export function fullResponse(): RequestHandler;
   export var defaultResponseHeaders : any;
   export var CORS: CORS;
+  
+  export module pre {
+      export function pause(): RequestHandler;
+      export function sanitizePath(options?: any): RequestHandler;
+      export function userAgentConnection(options?: any): RequestHandler;
+  }
 }


### PR DESCRIPTION
Adds the missing `pre` methods to the restify type definition.

[pre on the restify source code](https://github.com/mcavage/node-restify/blob/master/lib/plugins/index.js#L25-L29)
