### PR TITLE
angular.d.ts IDocumentService extends IAugmentedJQuery

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -430,7 +430,7 @@ declare module ng {
     // DocumentService
     // see http://docs.angularjs.org/api/ng.$document
     ///////////////////////////////////////////////////////////////////////////
-    interface IDocumentService extends Document {}
+    interface IDocumentService extends IAugmentedJQuery {}
 
     ///////////////////////////////////////////////////////////////////////////
     // ExceptionHandlerService


### PR DESCRIPTION
Updated `IDocumentService` to extend `IAugmentedJQuery` rather than `Document`. As per [the API](http://docs.angularjs.org/api/ng.$document) it provides:

> A jQuery or jqLite wrapper for the browser's window.document object.

This is raised [in issue 1357](https://github.com/borisyankov/DefinitelyTyped/issues/1357).
