### PR TITLE
Expose agent on supertest and cookie methods on superagent

### DIFF
--- a/superagent/superagent.d.ts
+++ b/superagent/superagent.d.ts
@@ -79,6 +79,8 @@ declare module "superagent" {
     unsubscribe(url: string, callback?: (err: Error, res: Response) => void): Request;
     patch(url: string, callback?: (err: Error, res: Response) => void): Request;
     parse(fn: Function): Request;
+    saveCookies(res: Response): void;
+    attachCookies(req: Request): void;
   }
 
   export function agent(): Agent;

--- a/supertest/supertest-tests.ts
+++ b/supertest/supertest-tests.ts
@@ -14,3 +14,19 @@ supertest(app)
   .end((err, res) => {
     if (err) throw err;
   });
+
+// cookie scenario
+var request = supertest(app);
+var agent = supertest.agent();
+request
+  .post('/login')
+  .end((err, res) => {
+    if (err) throw err;
+    agent.saveCookies(res);
+
+    var req = request.get('/admin');
+    agent.attachCookies(req);
+    req.expect(200, (err, res) => {
+      if (err) throw err;
+    });
+  });

--- a/supertest/supertest.d.ts
+++ b/supertest/supertest.d.ts
@@ -46,6 +46,8 @@ declare module "supertest" {
       unsubscribe(url: string): Test;
       patch(url: string): Test;
     }
+
+    function agent(): superagent.Agent;
   }
 
   function supertest(app: any): supertest.SuperTest;


### PR DESCRIPTION
Adding the agent function to supertest and exposing the cookie methods on superagent to enable testing paths requiring authentication in supertest.
