### PR TITLE
First arg of resolve method should be optional.

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -482,7 +482,7 @@ interface JQueryDeferred<T> extends JQueryPromise<T> {
      * @param value First argument passed to doneCallbacks.
      * @param args Optional subsequent arguments that are passed to the doneCallbacks.
      */
-    resolve(value: T, ...args: any[]): JQueryDeferred<T>;
+    resolve(value?: T, ...args: any[]): JQueryDeferred<T>;
 
     // COMMENTED OUT AS MAKES resolve LESS USEFUL - PERHAPS REMOVE ENTIRELY LATER
     /**


### PR DESCRIPTION
This is because you may want to resolve a deferred without passing anything.

The change made in commit 99fa7392 breaks this ability.
