### PR TITLE
Update typeahead.d.ts

### DIFF
--- a/typeahead/typeahead-tests.ts
+++ b/typeahead/typeahead-tests.ts
@@ -71,3 +71,16 @@ $('.example-films .typeahead').typeahead([
         engine: Hogan
     }
 ]);
+
+//Basic substring search
+//Specifies options along with datasets. In this case the dataset uses a custom substring matcher function as its source
+$('#the-basics .typeahead').typeahead({
+  hint: true,
+  highlight: true,
+  minLength: 1
+},
+{
+  name: 'states',
+  displayKey: 'value',
+  source: substringMatcher(states)
+});

--- a/typeahead/typeahead-tests.ts
+++ b/typeahead/typeahead-tests.ts
@@ -72,15 +72,16 @@ $('.example-films .typeahead').typeahead([
     }
 ]);
 
-//Basic substring search
-//Specifies options along with datasets. In this case the dataset uses a custom substring matcher function as its source
-$('#the-basics .typeahead').typeahead({
+// Countries - Modified the first test here to add options
+// Specifies options to display hint with a highlight and adds a minimum length restriction for search
+// Prefetches data, stores it in localStorage, and searches it on the client
+$('.example-countries .typeahead').typeahead({
   hint: true,
   highlight: true,
-  minLength: 1
+  minLength: 2
 },
 {
-  name: 'states',
-  displayKey: 'value',
-  source: substringMatcher(states)
+  name: 'countries',
+  prefetch: '../data/countries.json',
+  limit: 10
 });

--- a/typeahead/typeahead.d.ts
+++ b/typeahead/typeahead.d.ts
@@ -50,6 +50,16 @@ interface JQuery {
       * @param query The query to be set in case method 'setQuery' is used.
       */
     typeahead(methodName: string, query: string): JQuery;
+    
+    /**
+      * Accomodates specifying options such as hint and highlight.
+      * This is in correspondence to the examples mentioned in http://twitter.github.io/typeahead.js/examples/
+      *
+      * @constructor
+      * @param options ('hint' or 'highlight' or 'minLength' all of which are optional)
+      * @param dataset Array of datasets
+      */
+    typeahead(options: Twitter.Typeahead.Options, dataset: Twitter.Typeahead.Dataset): JQuery;
 }
 
 declare module Twitter.Typeahead {
@@ -242,5 +252,27 @@ declare module Twitter.Typeahead {
           * matching datums with a given query.
           */
         tokens: string[];
+    }
+    
+     /**
+      * When initializing a typeahead, there are a number of options you can configure.
+      */
+    interface Options {
+      /**
+        * highlight:  If true, when suggestions are rendered, 
+        * pattern matches for the current query in text nodes will be wrapped in a strong element.
+        * Defaults to false. 
+        */
+      highlight?: boolean;
+
+      /**
+        * If false, the typeahead will not show a hint. Defaults to true.
+        */
+      hint?: boolean;
+
+      /**
+        * The minimum character length needed before suggestions start getting rendered. Defaults to 1.
+        */
+      minLength?: number;
     }
 }


### PR DESCRIPTION
added support for call typeahead(options, dataset) where options include hint, highlight and minLength all of which are optional.
