### PR TITLE
[filesystem] FileSystem `root` is a DirectoryEntry.

### DIFF
--- a/filesystem/filesystem.d.ts
+++ b/filesystem/filesystem.d.ts
@@ -110,7 +110,7 @@ interface FileSystem{
      * The root directory of the file system.
      * @readonly
      */
-    root:any;
+    root: DirectoryEntry;
 }
 
 interface Entry {


### PR DESCRIPTION
This is specified in the official standard:
http://www.w3.org/TR/file-system-api/#the-filesystem-interface

Interestingly enough, these typings already specify the `root` of FileSystemSync (the synchronous version of the API) to be a DirectorySync. This must have been an oversight of the original author of these typings.
