### PR TITLE
use method moved to Parent interface

### DIFF
--- a/svgjs/svgjs.d.ts
+++ b/svgjs/svgjs.d.ts
@@ -31,8 +31,6 @@ declare module svgjs {
         
         defs():Defs;
 
-        use(element:Element):Element;
-
         clear():void;
 
         mask():Mask;
@@ -220,7 +218,8 @@ declare module svgjs {
         path(data:string):Element;
         image(url:string, w?:number, h?:number):Element;
         text(text:string):Element;
-        text(adder:(element:Element)=>void):Element;        
+        text(adder:(element:Element)=>void):Element;
+        use(element:Element):Element;
 
         group():Element;
     }


### PR DESCRIPTION
moved the use method from doc interface to Parent interface so it can be used on all svgjs.element
