### PR TITLE
append(), prepend(), before(), after() support for ZeptoCollection arg

### DIFF
--- a/zepto/zepto.d.ts
+++ b/zepto/zepto.d.ts
@@ -448,6 +448,11 @@ interface ZeptoCollection {
 	* @see ZeptoCollection.after
 	**/
 	after(content: HTMLElement[]): ZeptoCollection;
+	
+	/**
+	* @see ZeptoCollection.after
+	**/
+	after(content: HTMLElement[]): ZeptoCollection;
 
 	/**
 	* Append content to the DOM inside each individual element in the collection. The content can be an HTML string, a DOM node or an array of nodes.
@@ -465,6 +470,11 @@ interface ZeptoCollection {
 	* @see ZeptoCollection.append
 	**/
 	append(content: HTMLElement[]): ZeptoCollection;
+	
+	/**
+	* @see ZeptoCollection.append
+	**/
+	append(content: ZeptoCollection): ZeptoCollection;
 
 	/**
 	* Append elements from the current collection to the target element. This is like append, but with reversed operands.
@@ -526,6 +536,11 @@ interface ZeptoCollection {
 	* @see ZeptoCollection.before
 	**/
 	before(content: HTMLElement[]): ZeptoCollection;
+	
+	/**
+	* @see ZeptoCollection.before
+	**/
+	before(content: ZeptoCollection): ZeptoCollection;
 
 	/**
 	* Get immediate children of each element in the current collection. If selector is given, filter the results to only include ones matching the CSS selector.

--- a/zepto/zepto.d.ts
+++ b/zepto/zepto.d.ts
@@ -452,7 +452,7 @@ interface ZeptoCollection {
 	/**
 	* @see ZeptoCollection.after
 	**/
-	after(content: HTMLElement[]): ZeptoCollection;
+	after(content: ZeptoCollection): ZeptoCollection;
 
 	/**
 	* Append content to the DOM inside each individual element in the collection. The content can be an HTML string, a DOM node or an array of nodes.

--- a/zepto/zepto.d.ts
+++ b/zepto/zepto.d.ts
@@ -964,6 +964,12 @@ interface ZeptoCollection {
 	prepend(content: HTMLElement[]): ZeptoCollection;
 
 	/**
+	* @see ZeptoCollection.prepend
+	* @param content
+	**/
+	prepend(content: ZeptoCollection): ZeptoCollection;
+
+	/**
 	* Prepend elements of the current collection inside each of the target elements. This is like prepend, only with reversed operands.
 	* @param content
 	* @return


### PR DESCRIPTION
zepto.d.ts defines `append()`, `prepend()`, `before()` and `after()` methods for `string`, `HTMLElement` and `HTMLElement[]`, but Zepto also supports passing in `ZeptoCollection` as an argument. 

I've added four additional method overloads that define the support for passing in `ZeptoCollection`.
