### PR TITLE
Reorder select2 overloads from most specific to least specific so overlo...

### DIFF
--- a/select2/select2.d.ts
+++ b/select2/select2.d.ts
@@ -87,9 +87,7 @@ interface JQuery {
 
     select2(): JQuery;
     select2(it: IdTextPair): JQuery;
-    select2(options: Select2Options): JQuery;
-    select2(method: string): any;
-    select2(method: string, value: any, trigger?: boolean): any;
+
     /**
     * Get the id value of the current selection
     */
@@ -144,4 +142,8 @@ interface JQuery {
     * Notifies Select2 that a drag and drop sorting operation has finished
     */
     select2(method: 'onSortEnd'): void;
+
+    select2(method: string): any;
+    select2(method: string, value: any, trigger?: boolean): any;
+    select2(options: Select2Options): JQuery;
 }


### PR DESCRIPTION
...ad resolution behaves as expected.

Discovered while investigating https://typescript.codeplex.com/workitem/2182. When TypeScript detects ambiguous overloads it resolves to the first candidate signature in the type definition, so it is important to author overloads in order of most specific to least specific. In particular, string overloads must come after specialized signatures or else the specialized signatures will never be called. In addition, the Select2Options type has 0 required parameters, which means it is an extremely permissive type and should be listed last or else nearly any single parameter overload will resolve to the overload which takes a Select2Options argument if it is listed first. Concrete examples of the behavior prior to this fix:

``` JavaScript
var r1 = $(null).select2('data'); // specialized signature returned JQuery, should be 'any'
var r2 = $(null).select2('destroy'); // specialized signature returned JQuery, should be 'void'
var r3 = $(null).select2('hmm'); // string signature returned JQuery, should be 'any'
var r4 = $(null).select2({ tags: null }); // Select2Options signature returns JQuery
var r5 = $(null).select2({ id: 1, text: 'hello' }); // IdTextPair signature returns JQuery
```

My first pull request so hopefully I did this correctly :)
