### PR TITLE
RxJS: updated to version 2.2.18

### DIFF
--- a/rx.js/rx-lite.ts
+++ b/rx.js/rx-lite.ts
@@ -45,6 +45,19 @@ declare module Rx {
 		export var Promise: { new <T>(resolver: (resolvePromise: (value: T) => void, rejectPromise: (reason: any) => void) => void): IPromise<T>; };
 	}
 
+	export module helpers {
+		function noop(): void;
+		function identity<T>(value: T): T;
+		function defaultNow(): number;
+		function defaultComparer(left: any, right: any): boolean;
+		function defaultSubComparer(left: any, right: any): number;
+		function defaultKeySerializer(key: any): string;
+		function defaultError(err: any): void;
+		function isPromise(p: any): boolean;
+		function asArray<T>(...args: T[]): T[];
+		function not(value: any): boolean;
+	}
+
 	export interface IDisposable {
 		dispose(): void;
 	}

--- a/rx.js/rx-lite.ts
+++ b/rx.js/rx-lite.ts
@@ -320,6 +320,7 @@ declare module Rx {
 		create<T>(subscribe: (observer: Observer<T>) => IDisposable): Observable<T>;
 		createWithDisposable<T>(subscribe: (observer: Observer<T>) => IDisposable): Observable<T>;
 		defer<T>(observableFactory: () => Observable<T>): Observable<T>;
+		defer<T>(observableFactory: () => IPromise<T>): Observable<T>;
 		empty<T>(scheduler?: IScheduler): Observable<T>;
 		fromArray<T>(array: T[], scheduler?: IScheduler): Observable<T>;
 		fromArray<T>(array: { length: number;[index: number]: T; }, scheduler?: IScheduler): Observable<T>;
@@ -360,9 +361,13 @@ declare module Rx {
 		throwException<T>(exception: any, scheduler?: IScheduler): Observable<T>;	// alias for throw
 
 		catch<T>(sources: Observable<T>[]): Observable<T>;
+		catch<T>(sources: IPromise<T>[]): Observable<T>;
 		catchException<T>(sources: Observable<T>[]): Observable<T>;	// alias for catch
+		catchException<T>(sources: IPromise<T>[]): Observable<T>;	// alias for catch
 		catch<T>(...sources: Observable<T>[]): Observable<T>;
+		catch<T>(...sources: IPromise<T>[]): Observable<T>;
 		catchException<T>(...sources: Observable<T>[]): Observable<T>;	// alias for catch
+		catchException<T>(...sources: IPromise<T>[]): Observable<T>;	// alias for catch
 		concat<T>(...sources: Observable<T>[]): Observable<T>;
 		concat<T>(...sources: IPromise<T>[]): Observable<T>;
 		concat<T>(sources: Observable<T>[]): Observable<T>;

--- a/rx.js/rx.async.d.ts
+++ b/rx.js/rx.async.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Async v2.2.17
+// Type definitions for RxJS-Async v2.2.18
 // Project: http://rx.codeplex.com/
 // Definitions by: zoetrope <https://github.com/zoetrope>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.backpressure.d.ts
+++ b/rx.js/rx.backpressure.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for RxJS-BackPressure v2.2.15
+﻿// Type definitions for RxJS-BackPressure v2.2.18
 // Project: http://rx.codeplex.com/
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.binding.d.ts
+++ b/rx.js/rx.binding.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Binding v2.2.17
+// Type definitions for RxJS-Binding v2.2.18
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.d.ts
+++ b/rx.js/rx.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for RxJS v2.2.17
+﻿// Type definitions for RxJS v2.2.18
 // Project: http://rx.codeplex.com/
 // Definitions by: gsino <http://www.codeplex.com/site/users/view/gsino>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.lite.d.ts
+++ b/rx.js/rx.lite.d.ts
@@ -47,14 +47,4 @@ declare module Rx {
 	export interface Observable<T> {
 		shareReplay(bufferSize?: number, window?: number, scheduler?: IScheduler): Observable<T>;	// same as replayWhileObserved in rx.binding.d.ts
 	}
-
-	export interface ObservableStatic {
-		generateWithTime<TState, TResult>(
-			initialState: TState,
-			condition: (state: TState) => boolean,
-			iterate: (state: TState) => TState,
-			resultSelector: (state: TState) => TResult,
-			timeSelector: (state: TState) => number,
-			scheduler?: IScheduler): Observable<TResult>;
-	}
 }

--- a/rx.js/rx.lite.d.ts
+++ b/rx.js/rx.lite.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for RxJS-Lite v2.2.17
+﻿// Type definitions for RxJS-Lite v2.2.18
 // Project: http://rx.codeplex.com/
 // Definitions by: gsino <http://www.codeplex.com/site/users/view/gsino>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.time-lite.ts
+++ b/rx.js/rx.time-lite.ts
@@ -47,5 +47,12 @@ declare module Rx {
 		interval(dutTime: number, period: number, scheduler?: IScheduler): Observable<number>;
 		timer(dueTime: number, period: number, scheduler: IScheduler): Observable<number>;
 		timer(dueTime: number, scheduler: IScheduler): Observable<number>;
+		generateWithRelativeTime<TState, TResult>(
+			initialState: TState,
+			condition: (state: TState) => boolean,
+			iterate: (state: TState) => TState,
+			resultSelector: (state: TState) => TResult,
+			timeSelector: (state: TState) => number,
+			scheduler?: IScheduler): Observable<TResult>;
 	}
 }

--- a/rx.js/rx.time.d.ts
+++ b/rx.js/rx.time.d.ts
@@ -28,13 +28,5 @@ declare module Rx {
 			resultSelector: (state: TState) => TResult,
 			timeSelector: (state: TState) => Date,
 			scheduler?: IScheduler): Observable<TResult>;
-
-		generateWithRelativeTime<TState, TResult>(
-			initialState: TState,
-			condition: (state: TState) => boolean,
-			iterate: (state: TState) => TState,
-			resultSelector: (state: TState) => TResult,
-			timeSelector: (state: TState) => number,
-			scheduler?: IScheduler): Observable<TResult>;
 	}
 }

--- a/rx.js/rx.time.d.ts
+++ b/rx.js/rx.time.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Time v2.2.17
+// Type definitions for RxJS-Time v2.2.18
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.virtualtime.d.ts
+++ b/rx.js/rx.virtualtime.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-VirtualTime package 2.2
+// Type definitions for RxJS-VirtualTime package 2.2.18
 // Project: http://rx.codeplex.com/
 // Definitions by: gsino <http://www.codeplex.com/site/users/view/gsino>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>


### PR DESCRIPTION
- `generateWithTime` from `rx.lite.d.ts` was renamed to `generateWithRelativeTime` and moved as common part to `rx.time-lite.ts`
- added `Rx.helpers` functions
- added overloads of `defer` and `catch`/`catchException` with handle promises.
