### PR TITLE
Fixed express definition and added asciify definitions.

### DIFF
--- a/asciify/asciify-tests.ts
+++ b/asciify/asciify-tests.ts
@@ -1,0 +1,9 @@
+/// <reference path="./asciify.d.ts" />
+
+import asciify = require('asciify');
+
+asciify('Whoa', function(err, result){console.log(result)});
+asciify('Whoa', '3-d', function(err, result){console.log(result)});
+asciify('Whoa', {font:'3-d'}, function(err, result){console.log(result)});
+
+asciify.getFonts(function(err, fonts) { fonts.slice(0); });

--- a/asciify/asciify.d.ts
+++ b/asciify/asciify.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for asciify 1.3.5
+// Project: https://www.npmjs.org/package/asciify
+// Definitions by: Alan Norbauer http://alan.norbauer.com
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+interface AsciifyOptions {
+    font?: string;
+    maxWidth?: number;
+    color?: string;
+}
+
+interface AsciifyCallback {
+    // err is sometimes a string and sometimes an Error
+    (err: any, asciifiedText: string): void
+}
+
+declare module "asciify" {
+    function asciify(text: string, callback: AsciifyCallback): void;
+    function asciify(text: string, options: string, callback: AsciifyCallback): void;
+    function asciify(text: string, options: AsciifyOptions, callback: AsciifyCallback): void;
+
+    module asciify {
+        function getFonts(callback: (err: Error, fonts: string[]) => void): void;
+    }
+
+    export = asciify
+}

--- a/asciify/asciify.ts.tscparams
+++ b/asciify/asciify.ts.tscparams
@@ -1,0 +1,1 @@
+"--noImplicitAny --module commonjs"

--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -258,7 +258,7 @@ declare module "express" {
 
             header(name: string): string;
 
-            headers: string[];
+            headers: { [key: string]: string; };
 
             /**
              * Check if the given `type(s)` is acceptable, returning


### PR DESCRIPTION
Fixed express definition: request.headers is not a string array, it is a string => string map. Getting this wrong will cause errors when noImplicitAny is used and one tries to assign headers["foo"] to a string.

Added definitions for asciify library.
