### PR TITLE
jQuery.d.ts .on() declaration addition

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -2680,6 +2680,14 @@ interface JQuery {
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false. Rest parameter args is for optional parameters passed to jQuery.trigger(). Note that the actual parameters on the event handler function must be marked as optional (? syntax).
      */
     on(events: string, handler: (eventObject: JQueryEventObject, ...args: any[]) => any): JQuery;
+	/**
+	 * Attach an event handler function for one or more events to the selected elements.
+	 *
+	 * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
+	 * @param data Data to be passed to the handler in event.data when an event is triggered.
+	 * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
+	 */
+	on(events: string, data : any, handler: (eventObject: JQueryEventObject, ...args: any[]) => any): JQuery;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      *

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -2680,14 +2680,14 @@ interface JQuery {
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false. Rest parameter args is for optional parameters passed to jQuery.trigger(). Note that the actual parameters on the event handler function must be marked as optional (? syntax).
      */
     on(events: string, handler: (eventObject: JQueryEventObject, ...args: any[]) => any): JQuery;
-	/**
-	 * Attach an event handler function for one or more events to the selected elements.
-	 *
-	 * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
-	 * @param data Data to be passed to the handler in event.data when an event is triggered.
-	 * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
-	 */
-	on(events: string, data : any, handler: (eventObject: JQueryEventObject, ...args: any[]) => any): JQuery;
+    /**
+     * Attach an event handler function for one or more events to the selected elements.
+     *
+     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
+     * @param data Data to be passed to the handler in event.data when an event is triggered.
+     * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
+    */
+    on(events: string, data : any, handler: (eventObject: JQueryEventObject, ...args: any[]) => any): JQuery;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      *


### PR DESCRIPTION
According to http://api.jquery.com/on/, .on() has:
1. required events
2. optional selector
3. optional data
4. handler

Prior to this commit, you were allowed to call .on() with data added, but only if you added the optional (not required) selector. This commit allows you to call .on(events, data, handler) as allowed by jQuery.
