### PR TITLE
Enhanced call interface definitions

### DIFF
--- a/angularjs/angular-resource-tests.ts
+++ b/angularjs/angular-resource-tests.ts
@@ -19,7 +19,9 @@ actionDescriptor.params = { key: 'value' };
 ///////////////////////////////////////
 var resourceClass: IMyResourceClass;
 var resource: IMyResource;
-var resourceArray: IMyResource[];
+var resourceArray: ng.resource.IResourceArray<IMyResource>;
+var promise : ng.IPromise<IMyResource>;
+var arrayPromise : ng.IPromise<IMyResource[]>;
 
 resource = resourceClass.delete();
 resource = resourceClass.delete({ key: 'value' });
@@ -30,6 +32,15 @@ resource = resourceClass.delete({ key: 'value' }, { key: 'value' });
 resource = resourceClass.delete({ key: 'value' }, { key: 'value' }, function () { });
 resource = resourceClass.delete({ key: 'value' }, { key: 'value' }, function () { }, function () { });
 
+promise = resource.$delete();
+promise = resource.$delete({ key: 'value' });
+promise = resource.$delete({ key: 'value' }, function () { });
+promise = resource.$delete(function () { });
+promise = resource.$delete(function () { }, function () { });
+promise = resource.$delete({ key: 'value' }, { key: 'value' });
+promise = resource.$delete({ key: 'value' }, { key: 'value' }, function () { });
+promise = resource.$delete({ key: 'value' }, { key: 'value' }, function () { }, function () { });
+
 resource = resourceClass.get();
 resource = resourceClass.get({ key: 'value' });
 resource = resourceClass.get({ key: 'value' }, function () { });
@@ -38,6 +49,15 @@ resource = resourceClass.get(function () { }, function () { });
 resource = resourceClass.get({ key: 'value' }, { key: 'value' });
 resource = resourceClass.get({ key: 'value' }, { key: 'value' }, function () { });
 resource = resourceClass.get({ key: 'value' }, { key: 'value' }, function () { }, function () { });
+
+promise = resource.$get();
+promise = resource.$get({ key: 'value' });
+promise = resource.$get({ key: 'value' }, function () { });
+promise = resource.$get(function () { });
+promise = resource.$get(function () { }, function () { });
+promise = resource.$get({ key: 'value' }, { key: 'value' });
+promise = resource.$get({ key: 'value' }, { key: 'value' }, function () { });
+promise = resource.$get({ key: 'value' }, { key: 'value' }, function () { }, function () { });
 
 resourceArray = resourceClass.query();
 resourceArray = resourceClass.query({ key: 'value' });
@@ -48,6 +68,15 @@ resourceArray = resourceClass.query({ key: 'value' }, { key: 'value' });
 resourceArray = resourceClass.query({ key: 'value' }, { key: 'value' }, function () { });
 resourceArray = resourceClass.query({ key: 'value' }, { key: 'value' }, function () { }, function () { });
 
+arrayPromise = resourceArray[0].query();
+arrayPromise = resourceArray[0].query({ key: 'value' });
+arrayPromise = resourceArray[0].query({ key: 'value' }, function () { });
+arrayPromise = resourceArray[0].query(function () { });
+arrayPromise = resourceArray[0].query(function () { }, function () { });
+arrayPromise = resourceArray[0].query({ key: 'value' }, { key: 'value' });
+arrayPromise = resourceArray[0].query({ key: 'value' }, { key: 'value' }, function () { });
+arrayPromise = resourceArray[0].query({ key: 'value' }, { key: 'value' }, function () { }, function () { });
+
 resource = resourceClass.remove();
 resource = resourceClass.remove({ key: 'value' });
 resource = resourceClass.remove({ key: 'value' }, function () { });
@@ -57,6 +86,15 @@ resource = resourceClass.remove({ key: 'value' }, { key: 'value' });
 resource = resourceClass.remove({ key: 'value' }, { key: 'value' }, function () { });
 resource = resourceClass.remove({ key: 'value' }, { key: 'value' }, function () { }, function () { });
 
+promise = resource.$remove();
+promise = resource.$remove({ key: 'value' });
+promise = resource.$remove({ key: 'value' }, function () { });
+promise = resource.$remove(function () { });
+promise = resource.$remove(function () { }, function () { });
+promise = resource.$remove({ key: 'value' }, { key: 'value' });
+promise = resource.$remove({ key: 'value' }, { key: 'value' }, function () { });
+promise = resource.$remove({ key: 'value' }, { key: 'value' }, function () { }, function () { });
+
 resource = resourceClass.save();
 resource = resourceClass.save({ key: 'value' });
 resource = resourceClass.save({ key: 'value' }, function () { });
@@ -65,6 +103,15 @@ resource = resourceClass.save(function () { }, function () { });
 resource = resourceClass.save({ key: 'value' }, { key: 'value' });
 resource = resourceClass.save({ key: 'value' }, { key: 'value' }, function () { });
 resource = resourceClass.save({ key: 'value' }, { key: 'value' }, function () { }, function () { });
+
+promise = resource.$save();
+promise = resource.$save({ key: 'value' });
+promise = resource.$save({ key: 'value' }, function () { });
+promise = resource.$save(function () { });
+promise = resource.$save(function () { }, function () { });
+promise = resource.$save({ key: 'value' }, { key: 'value' });
+promise = resource.$save({ key: 'value' }, { key: 'value' }, function () { });
+promise = resource.$save({ key: 'value' }, { key: 'value' }, function () { }, function () { });
 
 ///////////////////////////////////////
 // IResourceService

--- a/angularjs/angular-resource-tests.ts
+++ b/angularjs/angular-resource-tests.ts
@@ -79,45 +79,35 @@ promise = resource.$delete({ key: 'value' });
 promise = resource.$delete({ key: 'value' }, function () { });
 promise = resource.$delete(function () { });
 promise = resource.$delete(function () { }, function () { });
-promise = resource.$delete({ key: 'value' }, { key: 'value' });
-promise = resource.$delete({ key: 'value' }, { key: 'value' }, function () { });
-promise = resource.$delete({ key: 'value' }, { key: 'value' }, function () { }, function () { });
+promise = resource.$delete({ key: 'value' }, function () { }, function () { });
 
 promise = resource.$get();
 promise = resource.$get({ key: 'value' });
 promise = resource.$get({ key: 'value' }, function () { });
 promise = resource.$get(function () { });
 promise = resource.$get(function () { }, function () { });
-promise = resource.$get({ key: 'value' }, { key: 'value' });
-promise = resource.$get({ key: 'value' }, { key: 'value' }, function () { });
-promise = resource.$get({ key: 'value' }, { key: 'value' }, function () { }, function () { });
+promise = resource.$get({ key: 'value' }, function () { }, function () { });
 
 arrayPromise = resourceArray[0].$query();
 arrayPromise = resourceArray[0].$query({ key: 'value' });
 arrayPromise = resourceArray[0].$query({ key: 'value' }, function () { });
 arrayPromise = resourceArray[0].$query(function () { });
 arrayPromise = resourceArray[0].$query(function () { }, function () { });
-arrayPromise = resourceArray[0].$query({ key: 'value' }, { key: 'value' });
-arrayPromise = resourceArray[0].$query({ key: 'value' }, { key: 'value' }, function () { });
-arrayPromise = resourceArray[0].$query({ key: 'value' }, { key: 'value' }, function () { }, function () { });
+arrayPromise = resourceArray[0].$query({ key: 'value' }, function () { }, function () { });
 
 promise = resource.$remove();
 promise = resource.$remove({ key: 'value' });
 promise = resource.$remove({ key: 'value' }, function () { });
 promise = resource.$remove(function () { });
 promise = resource.$remove(function () { }, function () { });
-promise = resource.$remove({ key: 'value' }, { key: 'value' });
-promise = resource.$remove({ key: 'value' }, { key: 'value' }, function () { });
-promise = resource.$remove({ key: 'value' }, { key: 'value' }, function () { }, function () { });
+promise = resource.$remove({ key: 'value' }, function () { }, function () { });
 
 promise = resource.$save();
 promise = resource.$save({ key: 'value' });
 promise = resource.$save({ key: 'value' }, function () { });
 promise = resource.$save(function () { });
 promise = resource.$save(function () { }, function () { });
-promise = resource.$save({ key: 'value' }, { key: 'value' });
-promise = resource.$save({ key: 'value' }, { key: 'value' }, function () { });
-promise = resource.$save({ key: 'value' }, { key: 'value' }, function () { }, function () { });
+promise = resource.$save({ key: 'value' }, function () { }, function () { });
 
 ///////////////////////////////////////
 // IResourceService

--- a/angularjs/angular-resource-tests.ts
+++ b/angularjs/angular-resource-tests.ts
@@ -20,8 +20,6 @@ actionDescriptor.params = { key: 'value' };
 var resourceClass: IMyResourceClass;
 var resource: IMyResource;
 var resourceArray: ng.resource.IResourceArray<IMyResource>;
-var promise : ng.IPromise<IMyResource>;
-var arrayPromise : ng.IPromise<IMyResource[]>;
 
 resource = resourceClass.delete();
 resource = resourceClass.delete({ key: 'value' });
@@ -32,15 +30,6 @@ resource = resourceClass.delete({ key: 'value' }, { key: 'value' });
 resource = resourceClass.delete({ key: 'value' }, { key: 'value' }, function () { });
 resource = resourceClass.delete({ key: 'value' }, { key: 'value' }, function () { }, function () { });
 
-promise = resource.$delete();
-promise = resource.$delete({ key: 'value' });
-promise = resource.$delete({ key: 'value' }, function () { });
-promise = resource.$delete(function () { });
-promise = resource.$delete(function () { }, function () { });
-promise = resource.$delete({ key: 'value' }, { key: 'value' });
-promise = resource.$delete({ key: 'value' }, { key: 'value' }, function () { });
-promise = resource.$delete({ key: 'value' }, { key: 'value' }, function () { }, function () { });
-
 resource = resourceClass.get();
 resource = resourceClass.get({ key: 'value' });
 resource = resourceClass.get({ key: 'value' }, function () { });
@@ -50,15 +39,6 @@ resource = resourceClass.get({ key: 'value' }, { key: 'value' });
 resource = resourceClass.get({ key: 'value' }, { key: 'value' }, function () { });
 resource = resourceClass.get({ key: 'value' }, { key: 'value' }, function () { }, function () { });
 
-promise = resource.$get();
-promise = resource.$get({ key: 'value' });
-promise = resource.$get({ key: 'value' }, function () { });
-promise = resource.$get(function () { });
-promise = resource.$get(function () { }, function () { });
-promise = resource.$get({ key: 'value' }, { key: 'value' });
-promise = resource.$get({ key: 'value' }, { key: 'value' }, function () { });
-promise = resource.$get({ key: 'value' }, { key: 'value' }, function () { }, function () { });
-
 resourceArray = resourceClass.query();
 resourceArray = resourceClass.query({ key: 'value' });
 resourceArray = resourceClass.query({ key: 'value' }, function () { });
@@ -67,15 +47,7 @@ resourceArray = resourceClass.query(function () { }, function () { });
 resourceArray = resourceClass.query({ key: 'value' }, { key: 'value' });
 resourceArray = resourceClass.query({ key: 'value' }, { key: 'value' }, function () { });
 resourceArray = resourceClass.query({ key: 'value' }, { key: 'value' }, function () { }, function () { });
-
-arrayPromise = resourceArray[0].query();
-arrayPromise = resourceArray[0].query({ key: 'value' });
-arrayPromise = resourceArray[0].query({ key: 'value' }, function () { });
-arrayPromise = resourceArray[0].query(function () { });
-arrayPromise = resourceArray[0].query(function () { }, function () { });
-arrayPromise = resourceArray[0].query({ key: 'value' }, { key: 'value' });
-arrayPromise = resourceArray[0].query({ key: 'value' }, { key: 'value' }, function () { });
-arrayPromise = resourceArray[0].query({ key: 'value' }, { key: 'value' }, function () { }, function () { });
+resourceArray.push(resource);
 
 resource = resourceClass.remove();
 resource = resourceClass.remove({ key: 'value' });
@@ -86,15 +58,6 @@ resource = resourceClass.remove({ key: 'value' }, { key: 'value' });
 resource = resourceClass.remove({ key: 'value' }, { key: 'value' }, function () { });
 resource = resourceClass.remove({ key: 'value' }, { key: 'value' }, function () { }, function () { });
 
-promise = resource.$remove();
-promise = resource.$remove({ key: 'value' });
-promise = resource.$remove({ key: 'value' }, function () { });
-promise = resource.$remove(function () { });
-promise = resource.$remove(function () { }, function () { });
-promise = resource.$remove({ key: 'value' }, { key: 'value' });
-promise = resource.$remove({ key: 'value' }, { key: 'value' }, function () { });
-promise = resource.$remove({ key: 'value' }, { key: 'value' }, function () { }, function () { });
-
 resource = resourceClass.save();
 resource = resourceClass.save({ key: 'value' });
 resource = resourceClass.save({ key: 'value' }, function () { });
@@ -103,6 +66,49 @@ resource = resourceClass.save(function () { }, function () { });
 resource = resourceClass.save({ key: 'value' }, { key: 'value' });
 resource = resourceClass.save({ key: 'value' }, { key: 'value' }, function () { });
 resource = resourceClass.save({ key: 'value' }, { key: 'value' }, function () { }, function () { });
+
+///////////////////////////////////////
+// IResource
+///////////////////////////////////////
+
+var promise : ng.IPromise<IMyResource>;
+var arrayPromise : ng.IPromise<IMyResource[]>;
+
+promise = resource.$delete();
+promise = resource.$delete({ key: 'value' });
+promise = resource.$delete({ key: 'value' }, function () { });
+promise = resource.$delete(function () { });
+promise = resource.$delete(function () { }, function () { });
+promise = resource.$delete({ key: 'value' }, { key: 'value' });
+promise = resource.$delete({ key: 'value' }, { key: 'value' }, function () { });
+promise = resource.$delete({ key: 'value' }, { key: 'value' }, function () { }, function () { });
+
+promise = resource.$get();
+promise = resource.$get({ key: 'value' });
+promise = resource.$get({ key: 'value' }, function () { });
+promise = resource.$get(function () { });
+promise = resource.$get(function () { }, function () { });
+promise = resource.$get({ key: 'value' }, { key: 'value' });
+promise = resource.$get({ key: 'value' }, { key: 'value' }, function () { });
+promise = resource.$get({ key: 'value' }, { key: 'value' }, function () { }, function () { });
+
+arrayPromise = resourceArray[0].$query();
+arrayPromise = resourceArray[0].$query({ key: 'value' });
+arrayPromise = resourceArray[0].$query({ key: 'value' }, function () { });
+arrayPromise = resourceArray[0].$query(function () { });
+arrayPromise = resourceArray[0].$query(function () { }, function () { });
+arrayPromise = resourceArray[0].$query({ key: 'value' }, { key: 'value' });
+arrayPromise = resourceArray[0].$query({ key: 'value' }, { key: 'value' }, function () { });
+arrayPromise = resourceArray[0].$query({ key: 'value' }, { key: 'value' }, function () { }, function () { });
+
+promise = resource.$remove();
+promise = resource.$remove({ key: 'value' });
+promise = resource.$remove({ key: 'value' }, function () { });
+promise = resource.$remove(function () { });
+promise = resource.$remove(function () { }, function () { });
+promise = resource.$remove({ key: 'value' }, { key: 'value' });
+promise = resource.$remove({ key: 'value' }, { key: 'value' }, function () { });
+promise = resource.$remove({ key: 'value' }, { key: 'value' }, function () { }, function () { });
 
 promise = resource.$save();
 promise = resource.$save({ key: 'value' });
@@ -132,3 +138,7 @@ resourceClass = resourceServiceFactoryFunction<IMyResourceClass>(resourceService
 
 resourceServiceFactoryFunction = function (resourceService: ng.resource.IResourceService) { return <any>resourceClass; };
 mod = mod.factory('factory name', resourceServiceFactoryFunction);
+
+///////////////////////////////////////
+// IResource
+///////////////////////////////////////

--- a/angularjs/angular-resource-tests.ts
+++ b/angularjs/angular-resource-tests.ts
@@ -29,6 +29,7 @@ resource = resourceClass.delete(function () { }, function () { });
 resource = resourceClass.delete({ key: 'value' }, { key: 'value' });
 resource = resourceClass.delete({ key: 'value' }, { key: 'value' }, function () { });
 resource = resourceClass.delete({ key: 'value' }, { key: 'value' }, function () { }, function () { });
+resource.$promise.then(function(data: IMyResource) {});
 
 resource = resourceClass.get();
 resource = resourceClass.get({ key: 'value' });
@@ -48,6 +49,7 @@ resourceArray = resourceClass.query({ key: 'value' }, { key: 'value' });
 resourceArray = resourceClass.query({ key: 'value' }, { key: 'value' }, function () { });
 resourceArray = resourceClass.query({ key: 'value' }, { key: 'value' }, function () { }, function () { });
 resourceArray.push(resource);
+resourceArray.$promise.then(function(data: ng.resource.IResourceArray<IMyResource>) {});
 
 resource = resourceClass.remove();
 resource = resourceClass.remove({ key: 'value' });
@@ -80,6 +82,7 @@ promise = resource.$delete({ key: 'value' }, function () { });
 promise = resource.$delete(function () { });
 promise = resource.$delete(function () { }, function () { });
 promise = resource.$delete({ key: 'value' }, function () { }, function () { });
+promise.then(function(data: IMyResource) {});
 
 promise = resource.$get();
 promise = resource.$get({ key: 'value' });
@@ -94,6 +97,7 @@ arrayPromise = resourceArray[0].$query({ key: 'value' }, function () { });
 arrayPromise = resourceArray[0].$query(function () { });
 arrayPromise = resourceArray[0].$query(function () { }, function () { });
 arrayPromise = resourceArray[0].$query({ key: 'value' }, function () { }, function () { });
+arrayPromise.then(function(data: ng.resource.IResourceArray<IMyResource>) {});
 
 promise = resource.$remove();
 promise = resource.$remove({ key: 'value' });

--- a/angularjs/angular-resource.d.ts
+++ b/angularjs/angular-resource.d.ts
@@ -50,79 +50,69 @@ declare module ng.resource {
     // PATCH (in other words, methods with body). Otherwise, it's going
     // to be considered as parameters to the request.
     // https://github.com/angular/angular.js/blob/v1.2.0/src/ngResource/resource.js#L461-L465
+    //
+    // Only those methods with an HTTP body do have 'data' as first parameter:
+    // https://github.com/angular/angular.js/blob/v1.2.0/src/ngResource/resource.js#L463
+    // More specifically, those methods are POST, PUT and PATCH:
+    // https://github.com/angular/angular.js/blob/v1.2.0/src/ngResource/resource.js#L432
+    //
+    // Also, static calls always return the IResource (or IResourceArray) retrieved
+    // https://github.com/angular/angular.js/blob/v1.2.0/src/ngResource/resource.js#L538-L549
     interface IResourceClass<T> {
         new(dataOrParams? : any) : T;
         get(): T;
         get(params: Object): T;
         get(success: Function, error?: Function): T;
         get(params: Object, success: Function, error?: Function): T;
-        get(params: Object, data: Object, success?: Function): T;
-        get(params: Object, data: Object, success: Function, error?: Function): T;
+        get(params: Object, data: Object, success?: Function, error?: Function): T;
 
         query(): IResourceArray<T>;
         query(params: Object): IResourceArray<T>;
         query(success: Function, error?: Function): IResourceArray<T>;
         query(params: Object, success: Function, error?: Function): IResourceArray<T>;
-        query(params: Object, data: Object, success?: Function): IResourceArray<T>;
-        query(params: Object, data: Object, success: Function, error?: Function): IResourceArray<T>;
+        query(params: Object, data: Object, success?: Function, error?: Function): IResourceArray<T>;
 
         save(): T;
         save(data: Object): T;
         save(success: Function, error?: Function): T;
         save(data: Object, success: Function, error?: Function): T;
-        save(params: Object, data: Object, success?: Function): T;
-        save(params: Object, data: Object, success: Function, error?: Function): T;
+        save(params: Object, data: Object, success?: Function, error?: Function): T;
 
         remove(): T;
         remove(params: Object): T;
         remove(success: Function, error?: Function): T;
         remove(params: Object, success: Function, error?: Function): T;
-        remove(params: Object, data: Object, success?: Function): T;
-        remove(params: Object, data: Object, success: Function, error?: Function): T;
+        remove(params: Object, data: Object, success?: Function, error?: Function): T;
 
         delete(): T;
         delete(params: Object): T;
         delete(success: Function, error?: Function): T;
         delete(params: Object, success: Function, error?: Function): T;
-        delete(params: Object, data: Object, success?: Function): T;
-        delete(params: Object, data: Object, success: Function, error?: Function): T;
+        delete(params: Object, data: Object, success?: Function, error?: Function): T;
     }
 
+    // Instance calls always return the the promise of the request which retrieved the object
+    // https://github.com/angular/angular.js/blob/v1.2.0/src/ngResource/resource.js#L538-L546
     interface IResource<T> {
         $get(): ng.IPromise<T>;
-        $get(params: Object): ng.IPromise<T>;
+        $get(params?: Object, success?: Function, error?: Function): ng.IPromise<T>;
         $get(success: Function, error?: Function): ng.IPromise<T>;
-        $get(params: Object, success: Function, error?: Function): ng.IPromise<T>;
-        $get(params: Object, data: Object, success?: Function): ng.IPromise<T>;
-        $get(params: Object, data: Object, success: Function, error?: Function): ng.IPromise<T>;
 
         $query(): ng.IPromise<T[]>;
-        $query(params: Object): ng.IPromise<T[]>;
+        $query(params?: Object, success?: Function, error?: Function): ng.IPromise<T[]>;
         $query(success: Function, error?: Function): ng.IPromise<T[]>;
-        $query(params: Object, success: Function, error?: Function): ng.IPromise<T[]>;
-        $query(params: Object, data: Object, success?: Function): ng.IPromise<T[]>;
-        $query(params: Object, data: Object, success: Function, error?: Function): ng.IPromise<T[]>;
 
         $save(): ng.IPromise<T>;
-        $save(data: Object): ng.IPromise<T>;
+        $save(params?: Object, success?: Function, error?: Function): ng.IPromise<T>;
         $save(success: Function, error?: Function): ng.IPromise<T>;
-        $save(data: Object, success: Function, error?: Function): ng.IPromise<T>;
-        $save(params: Object, data: Object, success?: Function): ng.IPromise<T>;
-        $save(params: Object, data: Object, success: Function, error?: Function): ng.IPromise<T>;
 
         $remove(): ng.IPromise<T>;
-        $remove(params: Object): ng.IPromise<T>;
+        $remove(params?: Object, success?: Function, error?: Function): ng.IPromise<T>;
         $remove(success: Function, error?: Function): ng.IPromise<T>;
-        $remove(params: Object, success: Function, error?: Function): ng.IPromise<T>;
-        $remove(params: Object, data: Object, success?: Function): ng.IPromise<T>;
-        $remove(params: Object, data: Object, success: Function, error?: Function): ng.IPromise<T>;
 
         $delete(): ng.IPromise<T>;
-        $delete(params: Object): ng.IPromise<T>;
+        $delete(params?: Object, success?: Function, error?: Function): ng.IPromise<T>;
         $delete(success: Function, error?: Function): ng.IPromise<T>;
-        $delete(params: Object, success: Function, error?: Function): ng.IPromise<T>;
-        $delete(params: Object, data: Object, success?: Function): ng.IPromise<T>;
-        $delete(params: Object, data: Object, success: Function, error?: Function): ng.IPromise<T>;
 
         /** the promise of the original server interaction that created this instance. **/
         $promise : ng.IPromise<T>;

--- a/angularjs/angular-resource.d.ts
+++ b/angularjs/angular-resource.d.ts
@@ -98,9 +98,9 @@ declare module ng.resource {
         $get(params?: Object, success?: Function, error?: Function): ng.IPromise<T>;
         $get(success: Function, error?: Function): ng.IPromise<T>;
 
-        $query(): ng.IPromise<T[]>;
-        $query(params?: Object, success?: Function, error?: Function): ng.IPromise<T[]>;
-        $query(success: Function, error?: Function): ng.IPromise<T[]>;
+        $query(): ng.IPromise<IResourceArray<T>>;
+        $query(params?: Object, success?: Function, error?: Function): ng.IPromise<IResourceArray<T>>;
+        $query(success: Function, error?: Function): ng.IPromise<IResourceArray<T>>;
 
         $save(): ng.IPromise<T>;
         $save(params?: Object, success?: Function, error?: Function): ng.IPromise<T>;
@@ -124,7 +124,7 @@ declare module ng.resource {
      */
     interface IResourceArray<T> extends Array<T> {
         /** the promise of the original server interaction that created this collection. **/
-        $promise : ng.IPromise<T[]>;
+        $promise : ng.IPromise<IResourceArray<T>>;
         $resolved : boolean;
     }
 

--- a/angularjs/angular-resource.d.ts
+++ b/angularjs/angular-resource.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Angular JS 1.2 (ngResource module)
 // Project: http://angularjs.org
-// Definitions by: Diego Vilar <http://github.com/diegovilar>
+// Definitions by: Diego Vilar <http://github.com/diegovilar>, Michael Jess <http://github.com/miffels> (minor enhancements)
 // Definitions: https://github.com/daptiv/DefinitelyTyped
 
 /// <reference path="angular.d.ts" />
@@ -129,11 +129,12 @@ declare module ng.resource {
         $resolved : boolean;
     }
 
-    interface Array {}
-
-    interface IResourceArray<T> extends Array {
+    /**
+     * Really just a regular Array object with $promise and $resolve attached to it
+     */
+    interface IResourceArray<T> extends Array<T> {
         /** the promise of the original server interaction that created this collection. **/
-        $promise : ng.IPromise<T>;
+        $promise : ng.IPromise<T[]>;
         $resolved : boolean;
     }
 

--- a/angularjs/angular-resource.d.ts
+++ b/angularjs/angular-resource.d.ts
@@ -53,60 +53,86 @@ declare module ng.resource {
     interface IResourceClass<T> {
         new(dataOrParams? : any) : T;
         get(): T;
-        get(dataOrParams: any): T;
-        get(dataOrParams: any, success: Function): T;
+        get(params: Object): T;
         get(success: Function, error?: Function): T;
-        get(params: any, data: any, success?: Function, error?: Function): T;
+        get(params: Object, success: Function, error?: Function): T;
+        get(params: Object, data: Object, success?: Function): T;
+        get(params: Object, data: Object, success: Function, error?: Function): T;
+
+        query(): IResourceArray<T>;
+        query(params: Object): IResourceArray<T>;
+        query(success: Function, error?: Function): IResourceArray<T>;
+        query(params: Object, success: Function, error?: Function): IResourceArray<T>;
+        query(params: Object, data: Object, success?: Function): IResourceArray<T>;
+        query(params: Object, data: Object, success: Function, error?: Function): IResourceArray<T>;
+
         save(): T;
-        save(dataOrParams: any): T;
-        save(dataOrParams: any, success: Function): T;
+        save(data: Object): T;
         save(success: Function, error?: Function): T;
-        save(params: any, data: any, success?: Function, error?: Function): T;
-        query(): T[];
-        query(dataOrParams: any): T[];
-        query(dataOrParams: any, success: Function): T[];
-        query(success: Function, error?: Function): T[];
-        query(params: any, data: any, success?: Function, error?: Function): T[];
+        save(data: Object, success: Function, error?: Function): T;
+        save(params: Object, data: Object, success?: Function): T;
+        save(params: Object, data: Object, success: Function, error?: Function): T;
+
         remove(): T;
-        remove(dataOrParams: any): T;
-        remove(dataOrParams: any, success: Function): T;
+        remove(params: Object): T;
         remove(success: Function, error?: Function): T;
-        remove(params: any, data: any, success?: Function, error?: Function): T;
+        remove(params: Object, success: Function, error?: Function): T;
+        remove(params: Object, data: Object, success?: Function): T;
+        remove(params: Object, data: Object, success: Function, error?: Function): T;
+
         delete(): T;
-        delete(dataOrParams: any): T;
-        delete(dataOrParams: any, success: Function): T;
+        delete(params: Object): T;
         delete(success: Function, error?: Function): T;
-        delete(params: any, data: any, success?: Function, error?: Function): T;
+        delete(params: Object, success: Function, error?: Function): T;
+        delete(params: Object, data: Object, success?: Function): T;
+        delete(params: Object, data: Object, success: Function, error?: Function): T;
     }
 
     interface IResource<T> {
-        $get(): T;
-        $get(dataOrParams: any): T;
-        $get(dataOrParams: any, success: Function): T;
-        $get(success: Function, error?: Function): T;
-        $get(params: any, data: any, success?: Function, error?: Function): T;
-        $save(): T;
-        $save(dataOrParams: any): T;
-        $save(dataOrParams: any, success: Function): T;
-        $save(success: Function, error?: Function): T;
-        $save(params: any, data: any, success?: Function, error?: Function): T;
-        $query(): T[];
-        $query(dataOrParams: any): T[];
-        $query(dataOrParams: any, success: Function): T[];
-        $query(success: Function, error?: Function): T[];
-        $query(params: any, data: any, success?: Function, error?: Function): T[];
-        $remove(): T;
-        $remove(dataOrParams: any): T;
-        $remove(dataOrParams: any, success: Function): T;
-        $remove(success: Function, error?: Function): T;
-        $remove(params: any, data: any, success?: Function, error?: Function): T;
-        $delete(): T;
-        $delete(dataOrParams: any): T;
-        $delete(dataOrParams: any, success: Function): T;
-        $delete(success: Function, error?: Function): T;
-        $delete(params: any, data: any, success?: Function, error?: Function): T;
-        
+        $get(): ng.IPromise<T>;
+        $get(params: Object): ng.IPromise<T>;
+        $get(success: Function, error?: Function): ng.IPromise<T>;
+        $get(params: Object, success: Function, error?: Function): ng.IPromise<T>;
+        $get(params: Object, data: Object, success?: Function): ng.IPromise<T>;
+        $get(params: Object, data: Object, success: Function, error?: Function): ng.IPromise<T>;
+
+        $query(): ng.IPromise<T[]>;
+        $query(params: Object): ng.IPromise<T[]>;
+        $query(success: Function, error?: Function): ng.IPromise<T[]>;
+        $query(params: Object, success: Function, error?: Function): ng.IPromise<T[]>;
+        $query(params: Object, data: Object, success?: Function): ng.IPromise<T[]>;
+        $query(params: Object, data: Object, success: Function, error?: Function): ng.IPromise<T[]>;
+
+        $save(): ng.IPromise<T>;
+        $save(data: Object): ng.IPromise<T>;
+        $save(success: Function, error?: Function): ng.IPromise<T>;
+        $save(data: Object, success: Function, error?: Function): ng.IPromise<T>;
+        $save(params: Object, data: Object, success?: Function): ng.IPromise<T>;
+        $save(params: Object, data: Object, success: Function, error?: Function): ng.IPromise<T>;
+
+        $remove(): ng.IPromise<T>;
+        $remove(params: Object): ng.IPromise<T>;
+        $remove(success: Function, error?: Function): ng.IPromise<T>;
+        $remove(params: Object, success: Function, error?: Function): ng.IPromise<T>;
+        $remove(params: Object, data: Object, success?: Function): ng.IPromise<T>;
+        $remove(params: Object, data: Object, success: Function, error?: Function): ng.IPromise<T>;
+
+        $delete(): ng.IPromise<T>;
+        $delete(params: Object): ng.IPromise<T>;
+        $delete(success: Function, error?: Function): ng.IPromise<T>;
+        $delete(params: Object, success: Function, error?: Function): ng.IPromise<T>;
+        $delete(params: Object, data: Object, success?: Function): ng.IPromise<T>;
+        $delete(params: Object, data: Object, success: Function, error?: Function): ng.IPromise<T>;
+
         /** the promise of the original server interaction that created this instance. **/
+        $promise : ng.IPromise<T>;
+        $resolved : boolean;
+    }
+
+    interface Array {}
+
+    interface IResourceArray<T> extends Array {
+        /** the promise of the original server interaction that created this collection. **/
         $promise : ng.IPromise<T>;
         $resolved : boolean;
     }


### PR DESCRIPTION
The call interface of `angular-resource` (`IResourceClass` `query`, `get`, `save`, `update`, `delete` and their respective `IResource` `$`-prefixed instance counterparts) was not fully reflected by the previous TypeScript definitions. This pull request focuses on four issues:
1. The type definitions would often say `dataOrParams` in the method signatures even though it is possible to make a clearer statement (see [the code](https://github.com/angular/angular.js/blob/v1.2.0/src/ngResource/resource.js#L463-L464)). `dataOrParams` has been replaced by `data` or `params` respectively, where it is appropriate.
2. `angular-resource` distinguishes between instance calls and static calls (the former being prefixed by `$`). First of all, these are different in their return types: Instance calls always return a promise, while static calls always return the instance (or collection) retrieved (see [the code](https://github.com/angular/angular.js/blob/v1.2.0/src/ngResource/resource.js#L538-L549))
3. Another difference between static and instance calls is that the interface of instance calls is much simpler (see [the code](https://github.com/angular/angular.js/blob/v1.2.0/src/ngResource/resource.js#L553-L560))
4. Finally, `query` does not simply return an array of `IResource` objects, but the array with `$promise` and `$resolved` appended. I created a new type (`IResourceArray`) for that.
