### PR TITLE
fix(angularjs): make Function.$inject optional

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -10,7 +10,7 @@ declare var angular: ng.IAngularStatic;
 
 // Support for painless dependency injection
 interface Function {
-    $inject:string[];
+    $inject?: string[];
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The $inject member of the global Function interface should be optional, to be consistent with actual functions.
