### PR TITLE
HighchartsLegendOptions.useHTML?: boolean

### DIFF
--- a/highcharts/highcharts.d.ts
+++ b/highcharts/highcharts.d.ts
@@ -371,7 +371,7 @@ interface HighchartsLegendOptions {
     style?: HighchartsCSSObject;
     symbolPadding?: number;
     symbolWidth?: number;
-    useHTML?: number;
+    useHTML?: boolean;
     width?: number;
     x?: number;
     y?: number;


### PR DESCRIPTION
HighchartsLegendOptions.useHTML is boolean property, not numeric.

Sometimes i'm thinking that I'm the first person in the world who is using these definitions (
