### PR TITLE
Path is defined as a class, thus extending not implementing Path.

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -4968,7 +4968,7 @@ declare module THREE {
     /**
      * Defines a 2d shape plane using paths.
      */
-    export class Shape implements Path {
+    export class Shape extends Path {
         constructor(points?: Vector2[]);
 
         holes: Path[];


### PR DESCRIPTION
Typescript 1.0.0 error'd on this line, I suspect because Path is defined as a class not an interface. Changing from implements to extends made the error go away. 

hth, brett
