### PR TITLE
pdf: correct the type of some attributes

### DIFF
--- a/pdf/pdf-tests.ts
+++ b/pdf/pdf-tests.ts
@@ -3,9 +3,18 @@
 //
 // Fetch the PDF document from the URL using promises
 //
+var pdfDoc: PDFDocumentProxy;
+var pageNum: number;
+
 PDFJS.getDocument('helloworld.pdf').then(function (pdf) {
 	// Using promise to fetch the page
-	pdf.getPage(1).then(function (page) {
+	pdfDoc = pdf;
+	pageNum = 1;
+	renderPage(pageNum);
+});
+
+function renderPage(pageNum: number) {
+	pdfDoc.getPage(pageNum).then(function (page) {
 		var scale = 1.5;
 		var viewport = page.getViewport(scale);
 
@@ -26,4 +35,11 @@ PDFJS.getDocument('helloworld.pdf').then(function (pdf) {
 		};
 		page.render(renderContext);
 	});
-});
+}
+
+function goNext() {
+    if (pdfDoc && pageNum < pdfDoc.numPages) {
+        ++pageNum;
+        renderPage(pageNum);
+    }
+}

--- a/pdf/pdf.d.ts
+++ b/pdf/pdf.d.ts
@@ -74,12 +74,12 @@ interface PDFDocumentProxy {
 	/**
 	* Total number of pages the PDF contains.
 	**/
-	numPages(): number;
+	numPages: number;
 
 	/**
 	* A unique ID to identify a PDF.  Not guaranteed to be unique.  [jbaldwin: haha what]
 	**/
-	fingerprint(): string;
+	fingerprint: string;
 
 	/**
 	* True if embedded document fonts are in use.  Will be set during rendering of the pages.


### PR DESCRIPTION
Fixed `PDFDocumentProxy.numPages` and `PDFDocumentProxy.fingerprint`. The type of them is a property, not a function or a method.

Reference:
- [API spec](https://github.com/mozilla/pdf.js/blob/305274cd45ed3b4931f983b31ebd4ffb999fb4c6/test/unit/api_spec.js#L45-L50)
- Impl
  - [`.numPages`](https://github.com/mozilla/pdf.js/blob/816f2f7e1dc604d52bbde29eb9357360dbeddbbe/src/core/core.js#L476)
  - [`.fingerprint`](https://github.com/mozilla/pdf.js/blob/816f2f7e1dc604d52bbde29eb9357360dbeddbbe/src/core/core.js#L512)
