### PR TITLE
Leaflet: Fix the L.tileLayer function typing

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -3655,25 +3655,27 @@ declare module L {
         }
     }
 
-    export class tileLayer {
+    export interface TileLayerFactory {
         
         /**
           * Instantiates a tile layer object given a URL template and optionally an options
           * object.
           */
-        function (urlTemplate: string, options?: TileLayerOptions): TileLayer;
+        (urlTemplate: string, options?: TileLayerOptions): TileLayer;
 
         /**
           * Instantiates a WMS tile layer object given a base URL of the WMS service and
           * a WMS parameters/options object.
           */
-        static wms(baseUrl: string, options: WMSOptions): L.TileLayer.WMS;
+        wms(baseUrl: string, options: WMSOptions): L.TileLayer.WMS;
 
         /**
           * Instantiates a Canvas tile layer object given an options object (optionally).
           */
-        static canvas(options?: TileLayerOptions): L.TileLayer.Canvas;
+        canvas(options?: TileLayerOptions): L.TileLayer.Canvas;
     }
+
+    export var tileLayer: TileLayerFactory;
 }
  
 declare module L {


### PR DESCRIPTION
The current version was being rejected by Typescript 1.0. The new typing
follows the advice from the Handbook.
