### PR TITLE
Update colors.d.ts to work with TypeScript import

### DIFF
--- a/colors/colors.d.ts
+++ b/colors/colors.d.ts
@@ -3,6 +3,10 @@
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
+declare module "colors" {
+    export function setTheme(theme:any):any;
+}
+
 interface String {
     bold:string;
     italic:string;


### PR DESCRIPTION
The file lacked a module delcaration, so it would not work with the following code:

```
import colors = require("colors");
```

I did not move the existing `interface` as it does not belong in the `module` as it's global (applying to `String` and not scoped).
