### PR TITLE
Make AutocompleteOptions optional

### DIFF
--- a/googlemaps/google.maps.d.ts
+++ b/googlemaps/google.maps.d.ts
@@ -1356,9 +1356,9 @@ declare module google.maps {
         }
 
         export interface AutocompleteOptions {
-            bounds: LatLngBounds;
-            componentRestrictions: ComponentRestrictions;
-            types: string[];
+            bounds?: LatLngBounds;
+            componentRestrictions?: ComponentRestrictions;
+            types?: string[];
         }
 
         export interface ComponentRestrictions {


### PR DESCRIPTION
The maps API treats the members of AutocompleteOptions as optional - update typings to reflect this.
