### PR TITLE
Added definitions for Handlebars Runtime

### DIFF
--- a/handlebars/handlebars.d.ts
+++ b/handlebars/handlebars.d.ts
@@ -4,20 +4,43 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 
+// Use either HandlebarsStatic or HandlebarsRuntimeStatic
 declare var Handlebars: HandlebarsStatic;
+//declare var Handlebars: HandlebarsRuntimeStatic;
 
-interface HandlebarsStatic {
+/**
+* Implement this interface on your MVW/MVVM/MVC views such as Backbone.View
+**/
+interface HandlebarsTemplatable {
+    template: HandlebarsTemplateDelegate;
+}
+
+interface HandlebarsTemplateDelegate {
+    (context: any, options?: any): string;
+}
+
+interface HandlebarsCommon {
     registerHelper(name: string, fn: Function, inverse?: boolean): void;
     registerPartial(name: string, str: any): void;
     K(): void;
     createFrame(object: any): any;
+
     Exception(message: string): void;
     SafeString: typeof SafeString;
-    parse(input: string): boolean;
+
     logger: Logger;
     log(level: number, obj: any): void;
-    compile(input: any, options?: any): (context?: any, options?: any) => string;
     Logger: typeof Logger;
+}
+
+interface HandlebarsStatic extends HandlebarsCommon {
+    parse(input: string): boolean;
+    compile(input: any, options?: any): HandlebarsTemplateDelegate;
+}
+
+interface HandlebarsRuntimeStatic extends HandlebarsCommon {
+    // Handlebars.templates is the default template namespace in precompiler.
+    templates: { (s: string): HandlebarsTemplateDelegate }[];
 }
 
 declare class SafeString {


### PR DESCRIPTION
User has to declare var `Handlebars` as either `HandlebarsStatic` or `HandlebarsRuntimeStatic` (one or the other, as you cannot have both of them in same app)
    - `HandlebarsStatic` is handlebars with template compiler
    - `HandlebarsRuntimeStatic` is handlebars runtime with no compiler (for when templates are pre-compiled at the server side)
