### PR TITLE
Backbone Generics (TSC 1.0)

### DIFF
--- a/backbone-relational/backbone-relational.d.ts
+++ b/backbone-relational/backbone-relational.d.ts
@@ -5,12 +5,15 @@
 
 
 /// <reference path="../jquery/jquery.d.ts" />
-
 /// <reference path="../backbone/backbone.d.ts" />
 
 declare module Backbone {
-    export class RelationalModel extends Model {
-        static extend(properties:any, classProperties?:any):any; // do not use, prefer TypeScript's extend functionality
+    class RelationalModel extends Model {
+        /**
+        * Do not use, prefer TypeScript's extend functionality.
+        **/
+        //private static extend(properties:any, classProperties?:any):any;
+
         relations:any;
         subModelTypes:any;
         subModelTypeAttribute:any;
@@ -58,7 +61,7 @@ declare module Backbone {
 
         setRelated(related:Model):void;
 
-        setRelated(related:Collection):void;
+        setRelated(related:Collection<Model>):void;
 
         getReverseRelations(model:RelationalModel):Relation;
 
@@ -78,15 +81,15 @@ declare module Backbone {
 
         setKeyContents(keyContents:number[]):void;
 
-        setKeyContents(keyContents:Collection):void;
+        setKeyContents(keyContents:Collection<Model>):void;
 
         onChange(model:Model, attr:any, options:any):void;
 
-        handleAddition(model:Model, coll:Collection, options:any):void;
+        handleAddition(model:Model, coll:Collection<Model>, options:any):void;
 
-        handleRemoval(model:Model, coll:Collection, options:any):void;
+        handleRemoval(model:Model, coll:Collection<Model>, options:any):void;
 
-        handleReset(coll:Collection, options:any):void;
+        handleReset(coll:Collection<Model>, options:any):void;
 
         tryAddRelated(model:Model, coll:any, options:any):void;
 
@@ -135,9 +138,9 @@ declare module Backbone {
 
         processOrphanRelations():void;
 
-        retroFitRelation(relation:RelationalModel, create:boolean):Collection;
+        retroFitRelation(relation:RelationalModel, create:boolean):Collection<Model>;
 
-        getCollection(type:RelationalModel, create:boolean):Collection;
+        getCollection(type:RelationalModel, create:boolean):Collection<Model>;
 
         getObjectByName(name:string):any;
 
@@ -158,7 +161,7 @@ declare module Backbone {
 
         update(model:RelationalModel):void;
 
-        unregister(model:RelationalModel, collection:Collection, options:any):void;
+        unregister(model:RelationalModel, collection:Collection<Model>, options:any):void;
 
         reset():void;
 

--- a/backbone/backbone.d.ts
+++ b/backbone/backbone.d.ts
@@ -6,6 +6,7 @@
 
 
 /// <reference path="../jquery/jquery.d.ts" />
+/// <reference path="../underscore/underscore.d.ts" />
 
 declare module Backbone {
 
@@ -67,7 +68,7 @@ declare module Backbone {
     }
 
     class Events {
-        on(eventName: any, callback?: Function, context?: any): any;
+        on(eventName: string, callback?: Function, context?: any): any;
         off(eventName?: string, callback?: Function, context?: any): any;
         trigger(eventName: string, ...args: any[]): any;
         bind(eventName: string, callback: Function, context?: any): any;
@@ -86,17 +87,22 @@ declare module Backbone {
         sync(...arg: any[]): JQueryXHR;
     }
 
-    interface OptionalDefaults {
-        defaults?(): any;
-    }
+    class Model extends ModelBase {
 
-    class Model extends ModelBase implements OptionalDefaults {
-
-        static extend(properties: any, classProperties?: any): any; // do not use, prefer TypeScript's extend functionality
+        /**
+        * Do not use, prefer TypeScript's extend functionality.
+        **/
+        private static extend(properties: any, classProperties?: any): any;
 
         attributes: any;
         changed: any[];
         cid: string;
+        /**
+        * Default attributes for the model. It can be an object hash or a method returning an object hash.
+        * For assigning an object hash, do it like this: this.defaults = <any>{ attribute: value, ... };
+        * That works only if you set it in the constructor or the initialize method.
+        **/
+        defaults(): any;
         id: any;
         idAttribute: string;
         validationError: any;
@@ -127,7 +133,7 @@ declare module Backbone {
         unset(attribute: string, options?: Silenceable): Model;
         validate(attributes: any, options?: any): any;
 
-        _validate(attrs: any, options: any): boolean;
+        private _validate(attrs: any, options: any): boolean;
 
         // mixins from underscore
 
@@ -141,115 +147,125 @@ declare module Backbone {
         omit(...keys: string[]): any;
     }
 
-    class Collection extends ModelBase {
+    class Collection<TModel extends Model> extends ModelBase {
 
-        static extend(properties: any, classProperties?: any): any; // do not use, prefer TypeScript's extend functionality
+        /**
+        * Do not use, prefer TypeScript's extend functionality.
+        **/
+        private static extend(properties: any, classProperties?: any): any;
 
-        model: any;
-        models: any;
-        collection: Model;
+        // TODO: this really has to be typeof TModel
+        //model: typeof TModel;
+        model: { new(): TModel; }; // workaround
+        models: TModel[];
+        collection: TModel;
         length: number;
 
-        constructor(models?: any, options?: any);
+        constructor(models?: TModel[], options?: any);
 
         fetch(options?: CollectionFetchOptions): JQueryXHR;
 
-        comparator(element: Model): any;
-        comparator(compare: Model, to?: Model): any;
+        comparator(element: TModel): number;
+        comparator(compare: TModel, to?: TModel): number;
 
-        add(model: Model, options?: AddOptions): Collection;
-        add(model: any, options?: AddOptions): Collection;
-        add(models: Model[], options?: AddOptions): Collection;
-        add(models: any[], options?: AddOptions): Collection;
-        at(index: number): Model;
-        get(id: any): Model;
-        create(attributes: any, options?: ModelSaveOptions): Model;
+        add(model: TModel, options?: AddOptions): Collection<TModel>;
+        add(models: TModel[], options?: AddOptions): Collection<TModel>;
+        at(index: number): TModel;
+        get(id: string): TModel;
+        create(attributes: any, options?: ModelSaveOptions): TModel;
         pluck(attribute: string): any[];
-        push(model: Model, options?: AddOptions): Model;
-        pop(options?: Silenceable): Model;
-        remove(model: Model, options?: Silenceable): Model;
-        remove(models: Model[], options?: Silenceable): Model[];
-        reset(models?: Model[], options?: Silenceable): Model[];
-        reset(models?: any[], options?: Silenceable): Model[];
-        set(models?: any[], options?: Silenceable): Model[];
-		shift(options?: Silenceable): Model;
-        sort(options?: Silenceable): Collection;
-        unshift(model: Model, options?: AddOptions): Model;
-        where(properies: any): Model[];
-        findWhere(properties: any): Model;
+        push(model: TModel, options?: AddOptions): TModel;
+        pop(options?: Silenceable): TModel;
+        remove(model: TModel, options?: Silenceable): TModel;
+        remove(models: TModel[], options?: Silenceable): TModel[];
+        reset(models?: TModel[], options?: Silenceable): TModel[];
+        set(models?: TModel[], options?: Silenceable): TModel[];
+        shift(options?: Silenceable): TModel;
+        sort(options?: Silenceable): Collection<TModel>;
+        unshift(model: TModel, options?: AddOptions): TModel;
+        where(properies: any): TModel[];
+        findWhere(properties: any): TModel;
 
-        _prepareModel(attrs?: any, options?: any): any;
-        _removeReference(model: Model): void;
-        _onModelEvent(event: string, model: Model, collection: Collection, options: any): void;
+        private _prepareModel(attrs?: any, options?: any): any;
+        private _removeReference(model: TModel): void;
+        private _onModelEvent(event: string, model: TModel, collection: Collection<TModel>, options: any): void;
 
         // mixins from underscore
 
-        all(iterator: (element: Model, index: number) => boolean, context?: any): boolean;
-        any(iterator: (element: Model, index: number) => boolean, context?: any): boolean;
-        collect(iterator: (element: Model, index: number, context?: any) => any[], context?: any): any[];
+        all(iterator: (element: TModel, index: number) => boolean, context?: any): boolean;
+        any(iterator: (element: TModel, index: number) => boolean, context?: any): boolean;
+        collect(iterator: (element: TModel, index: number, context?: any) => any[], context?: any): any[];
         chain(): any;
-        compact(): Model[];
+        compact(): TModel[];
         contains(value: any): boolean;
-        countBy(iterator: (element: Model, index: number) => any): any[];
-        countBy(attribute: string): any[];
+        countBy(iterator: (element: TModel, index: number) => any): _.Dictionary<number>;
+        countBy(attribute: string): _.Dictionary<number>;
         detect(iterator: (item: any) => boolean, context?: any): any; // ???
-        difference(...model: Model[]): Model[];
-        drop(): Model;
-        drop(n: number): Model[];
-        each(iterator: (element: Model, index: number, list?: any) => void , context?: any): any;
-        every(iterator: (element: Model, index: number) => boolean, context?: any): boolean;
-        filter(iterator: (element: Model, index: number) => boolean, context?: any): Model[];
-        find(iterator: (element: Model, index: number) => boolean, context?: any): Model;
-        first(): Model;
-        first(n: number): Model[];
-        flatten(shallow?: boolean): Model[];
-        foldl(iterator: (memo: any, element: Model, index: number) => any, initialMemo: any, context?: any): any;
-        forEach(iterator: (element: Model, index: number, list?: any) => void , context?: any): any;
+        difference(...model: TModel[]): TModel[];
+        drop(): TModel;
+        drop(n: number): TModel[];
+        each(iterator: (element: TModel, index: number, list?: any) => void, context?: any): any;
+        every(iterator: (element: TModel, index: number) => boolean, context?: any): boolean;
+        filter(iterator: (element: TModel, index: number) => boolean, context?: any): TModel[];
+        find(iterator: (element: TModel, index: number) => boolean, context?: any): TModel;
+        first(): TModel;
+        first(n: number): TModel[];
+        flatten(shallow?: boolean): TModel[];
+        foldl(iterator: (memo: any, element: TModel, index: number) => any, initialMemo: any, context?: any): any;
+        forEach(iterator: (element: TModel, index: number, list?: any) => void, context?: any): any;
+        groupBy(iterator: (element: TModel, index: number) => string, context?: any): _.Dictionary<TModel[]>;
+        groupBy(attribute: string, context?: any): _.Dictionary<TModel[]>;
         include(value: any): boolean;
-        indexOf(element: Model, isSorted?: boolean): number;
-        initial(): Model;
-        initial(n: number): Model[];
-        inject(iterator: (memo: any, element: Model, index: number) => any, initialMemo: any, context?: any): any;
-        intersection(...model: Model[]): Model[];
+        indexOf(element: TModel, isSorted?: boolean): number;
+        initial(): TModel;
+        initial(n: number): TModel[];
+        inject(iterator: (memo: any, element: TModel, index: number) => any, initialMemo: any, context?: any): any;
+        intersection(...model: TModel[]): TModel[];
         isEmpty(object: any): boolean;
         invoke(methodName: string, arguments?: any[]): any;
-        last(): Model;
-        last(n: number): Model[];
-        lastIndexOf(element: Model, fromIndex?: number): number;
-        map(iterator: (element: Model, index: number, context?: any) => any[], context?: any): any[];
-        max(iterator?: (element: Model, index: number) => any, context?: any): Model;
-        min(iterator?: (element: Model, index: number) => any, context?: any): Model;
+        last(): TModel;
+        last(n: number): TModel[];
+        lastIndexOf(element: TModel, fromIndex?: number): number;
+        map(iterator: (element: TModel, index: number, context?: any) => any[], context?: any): any[];
+        max(iterator?: (element: TModel, index: number) => any, context?: any): TModel;
+        min(iterator?: (element: TModel, index: number) => any, context?: any): TModel;
         object(...values: any[]): any[];
-        reduce(iterator: (memo: any, element: Model, index: number) => any, initialMemo: any, context?: any): any;
+        reduce(iterator: (memo: any, element: TModel, index: number) => any, initialMemo: any, context?: any): any;
         select(iterator: any, context?: any): any[];
         size(): number;
         shuffle(): any[];
-        some(iterator: (element: Model, index: number) => boolean, context?: any): boolean;
-        sortBy(iterator: (element: Model, index: number) => number, context?: any): Model[];
-        sortBy(attribute: string, context?: any): Model[];
-        sortedIndex(element: Model, iterator?: (element: Model, index: number) => number): number;
+        some(iterator: (element: TModel, index: number) => boolean, context?: any): boolean;
+        sortBy(iterator: (element: TModel, index: number) => number, context?: any): TModel[];
+        sortBy(attribute: string, context?: any): TModel[];
+        sortedIndex(element: TModel, iterator?: (element: TModel, index: number) => number): number;
         range(stop: number, step?: number): any;
         range(start: number, stop: number, step?: number): any;
-        reduceRight(iterator: (memo: any, element: Model, index: number) => any, initialMemo: any, context?: any): any[];
-        reject(iterator: (element: Model, index: number) => boolean, context?: any): Model[];
-        rest(): Model;
-        rest(n: number): Model[];
-        tail(): Model;
-        tail(n: number): Model[];
+        reduceRight(iterator: (memo: any, element: TModel, index: number) => any, initialMemo: any, context?: any): any[];
+        reject(iterator: (element: TModel, index: number) => boolean, context?: any): TModel[];
+        rest(): TModel;
+        rest(n: number): TModel[];
+        tail(): TModel;
+        tail(n: number): TModel[];
         toArray(): any[];
-        union(...model: Model[]): Model[];
-        uniq(isSorted?: boolean, iterator?: (element: Model, index: number) => boolean): Model[];
-        without(...values: any[]): Model[];
-        zip(...model: Model[]): Model[];
+        union(...model: TModel[]): TModel[];
+        uniq(isSorted?: boolean, iterator?: (element: TModel, index: number) => boolean): TModel[];
+        without(...values: any[]): TModel[];
+        zip(...model: TModel[]): TModel[];
     }
 
-    interface OptionalRoutes {
-        routes?(): any;
-    }
+    class Router extends Events {
 
-    class Router extends Events implements OptionalRoutes {
+        /**
+        * Do not use, prefer TypeScript's extend functionality.
+        **/
+        private static extend(properties: any, classProperties?: any): any;
 
-        static extend(properties: any, classProperties?: any): any; // do not use, prefer TypeScript's extend functionality
+        /**
+        * Routes hash or a method returning the routes hash that maps URLs with parameters to methods on your Router.
+        * For assigning routes as object hash, do it like this: this.routes = <any>{ "route": callback, ... };
+        * That works only if you set it in the constructor or the initialize method.
+        **/
+        routes(): any;
 
         constructor(options?: RouterOptions);
         initialize(options?: RouterOptions): void;
@@ -257,9 +273,9 @@ declare module Backbone {
         navigate(fragment: string, options?: NavigateOptions): Router;
         navigate(fragment: string, trigger?: boolean): Router;
 
-        _bindRoutes(): void;
-        _routeToRegExp(route: string): RegExp;
-        _extractParameters(route: RegExp, fragment: string): string[];
+        private _bindRoutes(): void;
+        private _routeToRegExp(route: string): RegExp;
+        private _extractParameters(route: RegExp, fragment: string): string[];
     }
 
     var history: History;
@@ -279,14 +295,14 @@ declare module Backbone {
         loadUrl(fragmentOverride: string): boolean;
         navigate(fragment: string, options?: any): boolean;
         started: boolean;
-		options: any;
-		
-        _updateHash(location: Location, fragment: string, replace: boolean): void;
+        options: any;
+
+        private _updateHash(location: Location, fragment: string, replace: boolean): void;
     }
 
-    interface ViewOptions {
-        model?: Backbone.Model;
-        collection?: Backbone.Collection;
+    interface ViewOptions<TModel extends Model> {
+        model?: TModel;
+        collection?: Backbone.Collection<TModel>;
         el?: any;
         id?: string;
         className?: string;
@@ -294,35 +310,41 @@ declare module Backbone {
         attributes?: any[];
     }
 
-    interface OptionalEvents {
-        events?(): any;
-    }
+    class View<TModel extends Model> extends Events {
 
-    class View extends Events implements OptionalEvents {
+        /**
+        * Do not use, prefer TypeScript's extend functionality.
+        **/
+        private static extend(properties: any, classProperties?: any): any;
 
-        static extend(properties: any, classProperties?: any): any; // do not use, prefer TypeScript's extend functionality
+        constructor(options?: ViewOptions<TModel>);
 
-        constructor(options?: ViewOptions);
+        /**
+        * Events hash or a method returning the events hash that maps events/selectors to methods on your View.
+        * For assigning events as object hash, do it like this: this.events = <any>{ "event:selector": callback, ... };
+        * That works only if you set it in the constructor or the initialize method.
+        **/
+        events(): any;
 
         $(selector: string): JQuery;
-        model: Model;
-        collection: Collection;
-        make(tagName: string, attrs?: any, opts?: any): View;
-        setElement(element: HTMLElement, delegate?: boolean): View;
-        setElement(element: JQuery, delegate?: boolean): View;
+        model: TModel;
+        collection: Collection<TModel>;
+        //template: (json, options?) => string;
+        make(tagName: string, attrs?: any, opts?: any): View<TModel>;
+        setElement(element: HTMLElement, delegate?: boolean): View<TModel>;
+        setElement(element: JQuery, delegate?: boolean): View<TModel>;
         id: string;
         cid: string;
         className: string;
         tagName: string;
-        options: any;
 
         el: any;
         $el: JQuery;
-        setElement(element: any): View;
+        setElement(element: any): View<TModel>;
         attributes: any;
         $(selector: any): JQuery;
-        render(): View;
-        remove(): View;
+        render(): View<TModel>;
+        remove(): View<TModel>;
         make(tagName: any, attributes?: any, content?: any): any;
         delegateEvents(events?: any): any;
         undelegateEvents(): any;
@@ -333,14 +355,12 @@ declare module Backbone {
     // SYNC
     function sync(method: string, model: Model, options?: JQueryAjaxSettings): any;
     function ajax(options?: JQueryAjaxSettings): JQueryXHR;
-	var emulateHTTP: boolean;
+    var emulateHTTP: boolean;
     var emulateJSONBackbone: boolean;
 
     // Utility
     function noConflict(): typeof Backbone;
     function setDomLibrary(jQueryNew: any): any;
-	
-    var $: JQueryStatic;
 }
 
 declare module "backbone" {

--- a/backgrid/backgrid-tests.ts
+++ b/backgrid/backgrid-tests.ts
@@ -23,7 +23,7 @@ class TestModel extends Backbone.Model {
 
 }
 
-class TestCollection extends Backbone.Collection {
+class TestCollection extends Backbone.Collection<TestModel> {
 
     constructor(models?: any, options?: any) {
 	this.model = TestModel;
@@ -41,11 +41,11 @@ class TestCollection extends Backbone.Collection {
     }
 }
 
-class TestView extends Backbone.View {
+class TestView extends Backbone.View<TestModel> {
     gridView: Backgrid.Grid;
     testCollection: TestCollection;
     
-    constructor(viewOptions?: Backbone.ViewOptions) {
+    constructor(viewOptions?: Backbone.ViewOptions<TestModel>) {
 	this.testCollection = new TestCollection();
 	this.gridView = new Backgrid.Grid({
             columns: [new Backgrid.Column({name: "FirstName", cell: "string", label: "First Name"}), 

--- a/backgrid/backgrid.d.ts
+++ b/backgrid/backgrid.d.ts
@@ -9,20 +9,20 @@ declare module Backgrid {
 
     interface GridOptions {
 	columns: Column[];
-	collection: Backbone.Collection;
+	collection: Backbone.Collection<Backbone.Model>;
 	header: Header;
 	body: Body;
 	row: Row;
 	footer: Footer;
     }
 
-    class Header extends Backbone.View {
+    class Header extends Backbone.View<Backbone.Model> {
     }
 
-    class Footer extends Backbone.View {
+    class Footer extends Backbone.View<Backbone.Model> {
     }
     
-    class Row extends Backbone.View {
+    class Row extends Backbone.View<Backbone.Model> {
     }
 
     class Command {
@@ -50,19 +50,19 @@ declare module Backgrid {
 	initialize(options?: any);
     }
 
-    class Body extends Backbone.View {
+    class Body extends Backbone.View<Backbone.Model> {
 	tagName: string;
 
 	initialize(options?: any);
-	insertRow(model: Backbone.Model, collection: Backbone.Collection, options: any);
+	insertRow(model: Backbone.Model, collection: Backbone.Collection<Backbone.Model>, options: any);
 	moveToNextCell(model: Backbone.Model, cell: Column, command: Command);
 	refresh(): Body;
 	remove(): Body;
-	removeRow(model: Backbone.Model, collection: Backbone.Collection, options: any);
+	removeRow(model: Backbone.Model, collection: Backbone.Collection<Backbone.Model>, options: any);
 	render(): Body;
     }
 
-    class Grid extends Backbone.View {
+    class Grid extends Backbone.View<Backbone.Model> {
 	body: Backgrid.Body;
 	className: string;
 	footer: any;
@@ -72,10 +72,10 @@ declare module Backgrid {
 	initialize(options: any);
 	getSelectedModels(): Backbone.Model[];
 	insertColumn(...options: any[]): Grid;
-	insertRow(model: Backbone.Model, collection: Backbone.Collection, options: any);
+	insertRow(model: Backbone.Model, collection: Backbone.Collection<Backbone.Model>, options: any);
 	remove():Grid;
 	removeColumn(...options: any[]): Grid;
-	removeRow(model: Backbone.Model, collection: Backbone.Collection, options: any);
+	removeRow(model: Backbone.Model, collection: Backbone.Collection<Backbone.Model>, options: any);
 	render():Grid;
     }
 

--- a/giraffe/giraffe-tests.ts
+++ b/giraffe/giraffe-tests.ts
@@ -3,13 +3,13 @@
 class User extends Giraffe.Model {
 }
 
-class MainView extends Giraffe.View {
+class MainView extends Giraffe.View<User> {
   
   constructor(options?) {
     this.appEvents = {
       'startup': 'app_onStartup'
-    } 
-    super(options)
+    }
+    super(options);
   }
 
   app_onStartup() {
@@ -23,11 +23,11 @@ class MyApp extends Giraffe.App {
     this.routes= {
       '': 'home'
     }
-    super()
+    super();
   }
 
   home() {
-    this.attach( new MainView )
+    this.attach(new MainView);
   }
 
 }

--- a/giraffe/giraffe.d.ts
+++ b/giraffe/giraffe.d.ts
@@ -38,8 +38,8 @@ declare module Giraffe {
   interface AppMap {
     [ cid:string ]: App;
   }
-  interface ViewMap {
-    [ cid:string ]: View;
+  interface ViewMap<TModel extends Model> {
+    [ cid:string ]: View<TModel>;
   }
   interface StringMap {
     [ def:string ]: string;
@@ -49,7 +49,7 @@ declare module Giraffe {
   var apps: AppMap;
   var defaultOptions: DefaultOptions;
   var version: string;
-  var views: ViewMap;
+  var views: ViewMap<Model>;
 
   function bindAppEvents( instance:GiraffeObject ): GiraffeObject;
   function bindDataEvents( instance:GiraffeObject ): GiraffeObject;
@@ -64,9 +64,10 @@ declare module Giraffe {
 
   function wrapFn( obj:any, name:string, before:Function, after:Function);
 
-  class Collection extends Backbone.Collection implements GiraffeObject {
+  class Collection<TModel extends Model> extends Backbone.Collection<TModel> implements GiraffeObject {
     app: App;
-    model: Model;
+    //model: typeof TModel;
+    model: { new (): TModel; }; // workaround
   }
 
   class Model extends Backbone.Model implements GiraffeObject {
@@ -85,46 +86,46 @@ declare module Giraffe {
     reload( url:string );
   }
 
-  class View extends Backbone.View implements GiraffeObject {
+  class View<TModel extends Model> extends Backbone.View<TModel> implements GiraffeObject {
     app: App;
     appEvents: StringMap;
-    children: View[];
+    children: View<TModel>[];
     dataEvents: StringMap;
     defaultOptions: DefaultOptions;
     documentTitle: string;
-    parent: View;
+    parent: View<TModel>;
     template: any;
     ui: StringMap;
 
-    attachTo( el:any, options?:AttachmentOptions ): View;
-    attach( view:View, options?:AttachmentOptions ): View;
+    attachTo( el:any, options?:AttachmentOptions ): View<TModel>;
+    attach( view:View<TModel>, options?:AttachmentOptions ): View<TModel>;
     isAttached( el:any ): boolean;
 
-    render( options?:any ): View;
+    render( options?:any ): View<TModel>;
     beforeRender();
     afterRender();
     templateStrategy(): string;
     serialize(): any;
 
-    setParent( parent:View ): View;
+    setParent( parent:View<TModel> ): View<TModel>;
 
-    addChild( child:View ): View;
-    addChildren( children:View[] ): View;
-    removeChild( child:View, preserve?:boolean ): View;
-    removeChildren( preserve?:boolean ): View;
+    addChild( child:View<TModel> ): View<TModel>;
+    addChildren( children:View<TModel>[] ): View<TModel>;
+    removeChild( child:View<TModel>, preserve?:boolean ): View<TModel>;
+    removeChildren( preserve?:boolean ): View<TModel>;
 
-    detach( preserve?:boolean ): View;
-    detachChildren( preserve?:boolean ): View;
+    detach( preserve?:boolean ): View<TModel>;
+    detachChildren( preserve?:boolean ): View<TModel>;
 
     invoke( method:string, ...args:any[] );
 
-    dispose(): View;
-    beforeDispose(): View;
-    afterDispose(): View;
+    dispose(): View<TModel>;
+    beforeDispose(): View<TModel>;
+    afterDispose(): View<TModel>;
 
-    static detachByElement( el:any, preserve?:boolean ): View;
-    static getClosestView( el:any ): View;
-    static getByCid( cid:string ): View;
+    static detachByElement( el:any, preserve?:boolean ): View<Model>;
+    static getClosestView<TModel>( el:any ): View<Model>;
+    static getByCid( cid:string ): View<Model>;
     static to$El( el:any, parent?:any, allowParentMatch?:boolean ): JQuery;
     static setDocumentEvents( events:string[], prefix?:string ): string[];
     static removeDocumentEvents( prefix?:string );
@@ -132,7 +133,7 @@ declare module Giraffe {
     static setTemplateStrategy( strategy:any, instance?:any );
   }
 
-  class App extends View {
+  class App extends View<Model> {
     routes: StringMap;
 
     addInitializer( initializer:( options?:any, callback?:()=>void )=>void ): App;
@@ -146,23 +147,23 @@ declare module Giraffe {
       app: App;
     }
 
-    class CollectionView extends View {
+    class CollectionView<TModel extends Model> extends View<TModel> {
 
-      collection: Collection;
-      modelView: View;
+      collection: Collection<TModel>;
+      modelView: View<TModel>;
       modelViewArgs: any[];
       modelViewEl: any;
       renderOnChange: boolean;
 
-      findByModel( model:Model ): View;
-      addOne( model:Model ): View;
-      removeOne( model:Model ): View;
+      findByModel( model:Model ): View<TModel>;
+      addOne( model:Model ): View<TModel>;
+      removeOne( model:Model ): View<TModel>;
 
       static getDefaults( ctx:any ): any;
     }
 
-    class FastCollectionView extends View {
-      collection: Collection;
+    class FastCollectionView<TModel extends Model> extends View<TModel> {
+      collection: Collection<TModel>;
       modelTemplate: any;
       modelTemplateStrategy: string;
       modelEl: any;
@@ -170,11 +171,11 @@ declare module Giraffe {
 
       modelSerialize(): any;
 
-      addAll(): View;
-      addOne( model:Model ): View;
-      removeOne( model:Model ): View;
+      addAll(): View<TModel>;
+      addOne( model:Model ): View<TModel>;
+      removeOne( model:Model ): View<TModel>;
 
-      removeByIndex( index:number ): View;
+      removeByIndex( index:number ): View<TModel>;
       findElByModel( model:Model ): JQuery;
       findElByIndex( index:number ): JQuery;
       findModelByEl( el:any ): Model;

--- a/jointjs/jointjs.d.ts
+++ b/jointjs/jointjs.d.ts
@@ -38,20 +38,19 @@ declare module joint {
             attr(attrs: any): Cell;
         }
 
-
-
         class Element extends Cell {
             position(x: number, y: number): Element;
             translate(tx: number, ty?: number): Element;
             resize(width: number, height: number): Element;
             rotate(angle: number, absolute): Element;
         }
+
         interface IDefaults {
             type: string;
         }
 
         class Link extends Cell {
-            defaults: IDefaults;
+            defaults(): IDefaults;
             disconnect(): Link;
             label(idx?: number, value?: any): any;   // @todo: returns either a label under idx or Link if both idx and value were passed
         }
@@ -65,7 +64,7 @@ declare module joint {
             linkView: LinkView;
         }
 
-        class Paper extends Backbone.View {
+        class Paper extends Backbone.View<Backbone.Model> {
             options: IOptions;
             setDimensions(width: number, height: number);
             scale(sx: number, sy?: number, ox?: number, oy?: number): Paper;
@@ -80,7 +79,8 @@ declare module joint {
         class ElementView extends CellView  {
             scale(sx: number, sy: number);
         }
-        class CellView extends Backbone.View {
+
+        class CellView extends Backbone.View<Cell> {
             getBBox(): { x: number; y: number; width: number; height: number; };
             highlight(el?: any);
             unhighlight(el?: any);
@@ -94,7 +94,9 @@ declare module joint {
         }
     
     }
+
     module ui { }
+
     module shapes {
         module basic {
             class Generic extends joint.dia.Element { }
@@ -104,6 +106,7 @@ declare module joint {
             class Image extends Generic { }
         }
     }
+
     module util {
         function uuid(): string;
         function guid(obj: any): string;
@@ -112,4 +115,5 @@ declare module joint {
         function deepMixin(objects: any[]): any;
         function deepSupplement(objects: any[], defaultIndicator?: any): any;
     }
+
 }

--- a/knockback/knockback.d.ts
+++ b/knockback/knockback.d.ts
@@ -126,8 +126,8 @@ declare module Knockback {
     }
 
     interface CollectionObservable extends KnockoutObservableArray<any> {
-        collection(colleciton: Backbone.Collection);
-        collection(): Backbone.Collection;
+        collection(colleciton: Backbone.Collection<Backbone.Model>);
+        collection(): Backbone.Collection<Backbone.Model>;
         destroy();
         shareOptions():  CollectionOptions;
         filters(id: any) : Backbone.Model;
@@ -163,7 +163,7 @@ declare module Knockback {
     }
 
     interface Static extends Utils {
-    	collectionObservable(model?: Backbone.Collection, options?: CollectionOptions): CollectionObservable;
+        collectionObservable(model?: Backbone.Collection<Backbone.Model>, options?: CollectionOptions): CollectionObservable;
     	/** Base class for observing model attributes. */
     	observable(
 			/** the model to observe (can be null) */

--- a/marionette/marionette.d.ts
+++ b/marionette/marionette.d.ts
@@ -11,49 +11,49 @@
 declare module Backbone {
 
     // Backbone.BabySitter
-    class ChildViewContainer {
+    class ChildViewContainer<TModel extends Backbone.Model> {
 
         constructor(initialViews?: any[]);
 
-        add(view: View, customIndex?: number);
-        findByModel(model): View;
-        findByModelCid(modelCid): View;
-        findByCustom(index: number): View;
-        findByIndex(index: number): View;
-        findByCid(cid): View;
-        remove(view: View);
+        add(view: View<TModel>, customIndex?: number);
+        findByModel(model): View<TModel>;
+        findByModelCid(modelCid): View<TModel>;
+        findByCustom(index: number): View<TModel>;
+        findByIndex(index: number): View<TModel>;
+        findByCid(cid): View<TModel>;
+        remove(view: View<TModel>);
         call(method);
         apply(method: any, args?: any[]);
 
         //mixins from Collection (copied from Backbone's Collection declaration)
 
-        all(iterator: (element: View, index: number) => boolean, context?: any): boolean;
-        any(iterator: (element: View, index: number) => boolean, context?: any): boolean;
+        all(iterator: (element: View<TModel>, index: number) => boolean, context?: any): boolean;
+        any(iterator: (element: View<TModel>, index: number) => boolean, context?: any): boolean;
         contains(value: any): boolean;
         detect(iterator: (item: any) => boolean, context?: any): any;
-        each(iterator: (element: View, index: number, list?: any) => void , context?: any);
-        every(iterator: (element: View, index: number) => boolean, context?: any): boolean;
-        filter(iterator: (element: View, index: number) => boolean, context?: any): View[];
-        find(iterator: (element: View, index: number) => boolean, context?: any): View;
-        first(): View;
-        forEach(iterator: (element: View, index: number, list?: any) => void , context?: any);
+        each(iterator: (element: View<TModel>, index: number, list?: any) => void , context?: any);
+        every(iterator: (element: View<TModel>, index: number) => boolean, context?: any): boolean;
+        filter(iterator: (element: View<TModel>, index: number) => boolean, context?: any): View<TModel>[];
+        find(iterator: (element: View<TModel>, index: number) => boolean, context?: any): View<TModel>;
+        first(): View<TModel>;
+        forEach(iterator: (element: View<TModel>, index: number, list?: any) => void , context?: any);
         include(value: any): boolean;
-        initial(): View;
-        initial(n: number): View[];
+        initial(): View<TModel>;
+        initial(n: number): View<TModel>[];
         invoke(methodName: string, arguments?: any[]);
         isEmpty(object: any): boolean;
-        last(): View;
-        last(n: number): View[];
-        lastIndexOf(element: View, fromIndex?: number): number;
-        map(iterator: (element: View, index: number, context?: any) => any[], context?: any): any[];
+        last(): View<TModel>;
+        last(n: number): View<TModel>[];
+        lastIndexOf(element: View<TModel>, fromIndex?: number): number;
+        map(iterator: (element: View<TModel>, index: number, context?: any) => any[], context?: any): any[];
         pluck(attribute: string): any[];
-        reject(iterator: (element: View, index: number) => boolean, context?: any): View[];
-        rest(): View;
-        rest(n: number): View[];
+        reject(iterator: (element: View<TModel>, index: number) => boolean, context?: any): View<TModel>[];
+        rest(): View<TModel>;
+        rest(n: number): View<TModel>[];
         select(iterator: any, context?: any): any[];
-        some(iterator: (element: View, index: number) => boolean, context?: any): boolean;
+        some(iterator: (element: View<TModel>, index: number) => boolean, context?: any): boolean;
         toArray(): any[];
-        without(...values: any[]): View[];
+        without(...values: any[]): View<TModel>[];
     }
 
     // Backbone.Wreqr
@@ -107,7 +107,7 @@ declare module Marionette {
 
     function getOption(target, optionName): any;
     function triggerMethod(name, ...args: any[]): any;
-    function MonitorDOMRefresh(view: Backbone.View): void;
+    function MonitorDOMRefresh(view: Backbone.View<Backbone.Model>): void;
     function bindEntityEvents(target, entity, bindings);
     function unbindEntityEvents(target, entity, bindings);
 
@@ -121,24 +121,24 @@ declare module Marionette {
         close();
     }
 
-    class Region extends Backbone.Events {
+    class Region<TModel extends Backbone.Model> extends Backbone.Events {
 
-        static buildRegion(regionConfig, defaultRegionType): Region;
+        static buildRegion(regionConfig, defaultRegionType): Region<Backbone.Model>;
 
         el: any;
 
-        show(view: Backbone.View): void;
+        show(view: Backbone.View<TModel>): void;
         ensureEl(): void;
-        open(view: Backbone.View): void;
+        open(view: Backbone.View<TModel>): void;
         close(): void;
-        attachView(view: Backbone.View);
+        attachView(view: Backbone.View<TModel>);
         reset();
     }
 
-    class RegionManager extends Controller {
+    class RegionManager<TModel extends Backbone.Model> extends Controller {
         addRegions(regionDefinitions, defaults?): any;
-        addRegion(name, definition): Region;
-        get (name: string): Region;
+        addRegion(name, definition): Region<TModel>;
+        get(name: string): Region<TModel>;
         removeRegion(name): void;
         removeRegions(): void;
         closeRegions(): void;
@@ -146,33 +146,33 @@ declare module Marionette {
 
         //mixins from Collection (copied from Backbone's Collection declaration)
 
-        all(iterator: (element: Region, index: number) => boolean, context?: any): boolean;
-        any(iterator: (element: Region, index: number) => boolean, context?: any): boolean;
+        all(iterator: (element: Region<TModel>, index: number) => boolean, context?: any): boolean;
+        any(iterator: (element: Region<TModel>, index: number) => boolean, context?: any): boolean;
         contains(value: any): boolean;
         detect(iterator: (item: any) => boolean, context?: any): any;
-        each(iterator: (element: Region, index: number, list?: any) => void , context?: any);
-        every(iterator: (element: Region, index: number) => boolean, context?: any): boolean;
-        filter(iterator: (element: Region, index: number) => boolean, context?: any): Region[];
-        find(iterator: (element: Region, index: number) => boolean, context?: any): Region;
-        first(): Region;
-        forEach(iterator: (element: Region, index: number, list?: any) => void , context?: any);
+        each(iterator: (element: Region<TModel>, index: number, list?: any) => void , context?: any);
+        every(iterator: (element: Region<TModel>, index: number) => boolean, context?: any): boolean;
+        filter(iterator: (element: Region<TModel>, index: number) => boolean, context?: any): Region<TModel>[];
+        find(iterator: (element: Region<TModel>, index: number) => boolean, context?: any): Region<TModel>;
+        first(): Region<TModel>;
+        forEach(iterator: (element: Region<TModel>, index: number, list?: any) => void , context?: any);
         include(value: any): boolean;
-        initial(): Region;
-        initial(n: number): Region[];
+        initial(): Region<TModel>;
+        initial(n: number): Region<TModel>[];
         invoke(methodName: string, arguments?: any[]);
         isEmpty(object: any): boolean;
-        last(): Region;
-        last(n: number): Region[];
-        lastIndexOf(element: Region, fromIndex?: number): number;
-        map(iterator: (element: Region, index: number, context?: any) => any[], context?: any): any[];
+        last(): Region<TModel>;
+        last(n: number): Region<TModel>[];
+        lastIndexOf(element: Region<TModel>, fromIndex?: number): number;
+        map(iterator: (element: Region<TModel>, index: number, context?: any) => any[], context?: any): any[];
         pluck(attribute: string): any[];
-        reject(iterator: (element: Region, index: number) => boolean, context?: any): Region[];
-        rest(): Region;
-        rest(n: number): Region[];
+        reject(iterator: (element: Region<TModel>, index: number) => boolean, context?: any): Region<TModel>[];
+        rest(): Region<TModel>;
+        rest(n: number): Region<TModel>[];
         select(iterator: any, context?: any): any[];
-        some(iterator: (element: Region, index: number) => boolean, context?: any): boolean;
+        some(iterator: (element: Region<TModel>, index: number) => boolean, context?: any): boolean;
         toArray(): any[];
-        without(...values: any[]): Region[];
+        without(...values: any[]): Region<TModel>[];
     }
 
     class TemplateCache {
@@ -187,7 +187,7 @@ declare module Marionette {
         static render(template, data): void;
     }
 
-    class View extends Backbone.View {
+    class View<TModel extends Backbone.Model> extends Backbone.View<TModel> {
 
         constructor(options?: any);
 
@@ -208,72 +208,72 @@ declare module Marionette {
         triggerMethod(name, ...args: any[]): any;
     }
 
-    class ItemView extends View {
+    class ItemView<TModel extends Backbone.Model> extends View<TModel> {
 
         constructor(options?: any);
 
         ui: any;
 
         serializeData(): any;
-        render(): ItemView;
+        render(): ItemView<TModel>;
         close();
     }
 
-    class CollectionView extends View {
+    class CollectionView<TModel extends Backbone.Model> extends View<TModel> {
         constructor(options?: any);
 
         itemView: any;
         children: any;
 
         //_initialEvents();
-        addChildView(item: View, collection: View, options?: any);
+        addChildView(item: View<TModel>, collection: View<TModel>, options?: any);
         onShowCalled();
 
         triggerBeforeRender();
         triggerRendered();
-        render(): CollectionView;
+        render(): CollectionView<TModel>;
 
-        getItemView(item: any): ItemView;
-        addItemView(item: any, ItemView: ItemView, index: Number);
-        addChildViewEventForwarding(view: View);
-        renderItemView(view: View, index: Number);
+        getItemView(item: any): ItemView<TModel>;
+        addItemView(item: any, ItemView: ItemView<TModel>, index: Number);
+        addChildViewEventForwarding(view: View<TModel>);
+        renderItemView(view: View<TModel>, index: Number);
         buildItemView(item: any, ItemViewType: any, itemViewOptions: any): any;
         removeItemView(item: any);
-        removeChildView(view: View);
+        removeChildView(view: View<TModel>);
 
         checkEmpty();
 
-        appendHtml(collectionView: View, itemView: View, index: Number);
+        appendHtml(collectionView: View<TModel>, itemView: View<TModel>, index: Number);
 
         close();
         closeChildren();
     }
 
-    class CompositeView extends CollectionView {
+    class CompositeView<TModel extends Backbone.Model> extends CollectionView<TModel> {
 
         constructor(options?: any);
 
         itemView: any;
         itemViewContainer: string;
 
-		render(): CompositeView;
+        render(): CompositeView<TModel>;
         appendHtml(cv: any, iv: any);
         renderModel(): any;
     }
 
-    class Layout extends ItemView {
+    class Layout<TModel extends Backbone.Model> extends ItemView<TModel> {
 
         constructor(options?: any);
 
-        addRegion(name: string, definition: any): Region;
+        addRegion(name: string, definition: any): Region<TModel>;
         addRegions(regions: any): any;
-		render(): Layout;
+        render(): Layout<TModel>;
         removeRegion(name: string);
     }
     
     interface AppRouterOptions extends Backbone.RouterOptions {
-    	appRoutes: any;
-    	controller: any;
+        appRoutes: any;
+        controller: any;
     }
 
     class AppRouter extends Backbone.Router {
@@ -284,7 +284,7 @@ declare module Marionette {
         
     }
 
-    class Application extends Backbone.Events {
+    class Application<TModel extends Backbone.Model> extends Backbone.Events {
 
         vent: Backbone.Wreqr.EventAggregator;
         commands: Backbone.Wreqr.Commands;
@@ -297,15 +297,15 @@ declare module Marionette {
         start(options?);
         addRegions(regions);
         closeRegions(): void;
-        removeRegion(region: Region);
-        getRegion(regionName: string): Region;
+        removeRegion(region: Region<TModel>);
+        getRegion(regionName: string): Region<TModel>;
         module(moduleNames, moduleDefinition);
     }
 
     // modules mapped for convenience, but you should probably use TypeScript modules instead
-    class Module extends Backbone.Events {
+    class Module<TModel extends Backbone.Model> extends Backbone.Events {
 
-        constructor(moduleName: string, app: Application);
+        constructor(moduleName: string, app: Application<TModel>);
 
         submodules: any;
         triggerMethod(name, ...args: any[]): any;
@@ -319,7 +319,7 @@ declare module Marionette {
 }
 
 declare module 'backbone.marionette' {
-	import Backbone = require('backbone');
-	
-	export = Marionette;
+    import Backbone = require('backbone');
+
+    export = Marionette;
 }


### PR DESCRIPTION
Giving this another shot now that TypeScript 1.0 is released. This is being used in a rather large backbone.js project. Here are some breaking changes for the consumer code:
- The `extend` class is set as private. Use TypeScript class syntax to extend Model, Collection, View and Router.
- All code that inherits from backbone classes have to define generic parameters in their declarations. (This is going to be a typing requirement until [generics parameter overloads](https://typescript.codeplex.com/workitem/2438) are supported by the compiler)
- Have to use `typeof` keyword when assigning model type for a Collection. For example (from backbone-tests.ts):

```
class Library extends Backbone.Collection<Book> {
    model: typeof Book;
}
```

**Other changes:**

The main change is the modifications in `backbone.d.ts` which adds Generics to backbone classes. This brings a very good type checking on Models everywhere in backbone apps, however, this also affects a bunch of other libraries and tests that depend on it:

```
backbone/backbone-tests.ts
backbone-relational/backbone-relational.d.ts
backbone-relational/backbone-relational-tests.ts
backgrid/backgrid.d.ts
backgrid/backgrid-tests.ts
giraffe/giraffe.d.ts
giraffe/giraffe-tests.ts
jointjs/jointjs.d.ts
knockback/knockback.d.ts
marionette/marionette.d.ts
```

Also:
- With this change `backbone.d.ts` adds reference to `underscore.d.ts` for using some of the interfaces in underscore.
- Added `groupBy` merhods to backbone
- Added/updated tests for new changes
- Declared methods for `defaults`, `routes`, and `events` and added JSDoc comments on how to use them as properties that receive object literals (since that is supported by backbone too). The new compiler behavior is that it won't allow defining methods if they are declared as member properties in the base class, but the opposite is allowed by casting the assigned value to `any`. With this workaround (casting to `any`) the implementing classes can use either approach supported by BackboneJS: using object literal or function returning object literal for `defaults`, `routes`, and `events`. See https://typescript.codeplex.com/workitem/2441 also see `SettingDefaults` in backbone tests for how this is used.
