### PR TITLE
(restangular) Fix argument order in custom methods

### DIFF
--- a/restangular/restangular-tests.ts
+++ b/restangular/restangular-tests.ts
@@ -75,7 +75,7 @@ function test_basic() {
 
     $scope.account = account.get({ single: true });
 
-    account.customPOST("messages", { param: "myParam" }, {}, { name: "My Message" })
+    account.customPOST({ name: "My Message" }, "messages", { param: "myParam" }, {})
 }
 
 function test_config() {

--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -60,8 +60,8 @@ interface RestangularCustom {
     customGET(path: string, params?: any, headers?: any): ng.IPromise<any>;
     customGETLIST(path: string, params?: any, headers?: any): ng.IPromise<any>;
     customDELETE(path: string, params?: any, headers?: any): ng.IPromise<any>;
-    customPOST(path: string, params?: any, headers?: any, elem?: any): ng.IPromise<any>;
-    customPUT(path: string, params?: any, headers?: any, elem?: any): ng.IPromise<any>;
+    customPOST(elem?: any, path?: string, params?: any, headers?: any): ng.IPromise<any>;
+    customPUT(elem?: any, path?: string, params?: any, headers?: any): ng.IPromise<any>;
     customOperation(operation: string, path: string, params?: any, headers?: any, elem?: any): ng.IPromise<any>;
     addRestangularMethod(name: string, operation: string, path?: string, params?: any, headers?: any, elem?: any): ng.IPromise<any>;
 }


### PR DESCRIPTION
The arguments were in the wrong order for two of the custom methods. Documentation [here](https://github.com/mgonto/restangular#custom-methods).
