### PR TITLE
remove Assertions from chai.d.ts

### DIFF
--- a/chai/chai.d.ts
+++ b/chai/chai.d.ts
@@ -9,31 +9,13 @@ declare module chai {
     function expect(target: any, message?: string): Expect;
 
     // Provides a way to extend the internals of Chai
-    function use(fn: (chai: any, utils: any) => void);
+    function use(fn: (chai: any, utils: any) => void): void;
 
     interface ExpectStatic {
         (target: any): Expect;
     }
 
-    interface Assertions {
-        attr(name, value?);
-        css(name, value?);
-        data(name, value?);
-        class(className);
-        id(id);
-        html(html);
-        text(text);
-        value(value);
-        visible;
-        hidden;
-        selected;
-        checked;
-        disabled;
-        empty;
-        exist;
-    }
-
-    interface Expect extends LanguageChains, NumericComparison, TypeComparison, Assertions {
+    interface Expect extends LanguageChains, NumericComparison, TypeComparison {
         not: Expect;
         deep: Deep;
         a: TypeComparison;


### PR DESCRIPTION
- this interface is insufficiently typed and leads to implicit-any
  errors. I propose removing this entirely as it actually types the
  jquery-chai plugin, not the core chai library. If anyone needs it
  in the future, a jquery-chai.d.ts with the correct typings can be
  created.
