### PR TITLE
Cordova: multiple fixes

### DIFF
--- a/cordova/plugins/Contacts.d.ts
+++ b/cordova/plugins/Contacts.d.ts
@@ -143,9 +143,9 @@ interface ContactName {
     /** The contact's middle name. */
     middleName?: string;
     /** The contact's prefix (example Mr. or Dr.) */
-    honorifixPrefix?: string;
+    honorificPrefix?: string;
     /** The contact's suffix (example Esq.). */
-    honorifixSuffix?: string;
+    honorificSuffix?: string;
 }
 
 declare var ContactName: {
@@ -154,8 +154,8 @@ declare var ContactName: {
         familyName?: string,
         givenName?: string,
         middleName?: string,
-        honorifixPrefix?: string,
-        honorifixSuffix?: string): ContactName
+        honorificPrefix?: string,
+        honorificSuffix?: string): ContactName
 };
 
 /**
@@ -171,19 +171,19 @@ declare var ContactName: {
  * contains a base64-encoded image string.
  */
 interface ContactField {
-    /** Set to true if this ContactField contains the user's preferred value. */
-    pref: boolean;
     /** A string that indicates what type of field this is, home for example. */
     type: string;
     /** The value of the field, such as a phone number or email address. */
     value: string;
+    /** Set to true if this ContactField contains the user's preferred value. */
+    pref: boolean;
 }
 
 declare var ContactField: {
     /** Constructor for ContactField object */
     new(type?: string,
-        pref?: boolean,
-        value?: string): ContactField
+        value?: string,
+        pref?: boolean): ContactField
 };
 
 /**

--- a/cordova/plugins/FileSystem.d.ts
+++ b/cordova/plugins/FileSystem.d.ts
@@ -25,17 +25,7 @@ interface Window {
 
 /** This interface represents a file system. */
 interface FileSystem {
-    /**
-     * Constructor for FileSystem object
-     * @param name This is the name of the file system. The specifics of naming filesystems
-     *             is unspecified, but a name must be unique across the list of exposed file systems.
-     * @param root The root directory of the file system.
-     */
-    new (name: string, root: DirectoryEntry)
-    /**
-     * This is the name of the file system. The specifics of naming filesystems
-     * is unspecified, but a name must be unique across the list of exposed file systems.
-     */
+    /* The name of the file system, unique across the list of exposed file systems. */
     name: string;
     /** The root directory of the file system. */
     root: DirectoryEntry;
@@ -46,8 +36,6 @@ interface FileSystem {
  * each of which may be a File or DirectoryEntry.
  */
 interface Entry {
-    /** Constructor for Entry object */
-    new ( isFile: boolean, isDirectory: boolean, name: string, fullPath: string, fileSystem: FileSystem, nativeURL: string) ;
     /** Entry is a file. */
     isFile: boolean;
     /** Entry is a directory. */
@@ -265,13 +253,13 @@ interface FileSaver extends EventTarget {
  */
 interface FileWriter extends FileSaver {
     /**
-     * The byte offset at which the next write to the file will occur. This must be no greater than length.
-     * A newly-created FileWriter must have position set to 0.
+     * The byte offset at which the next write to the file will occur. This always less or equal than length.
+     * A newly-created FileWriter will have position set to 0.
      */
     position: number;
     /**
      * The length of the file. If the user does not have read access to the file,
-     * this must be the highest byte offset at which the user has written.
+     * this will be the highest byte offset at which the user has written.
      */
     length: number;
     /**
@@ -287,7 +275,7 @@ interface FileWriter extends FileSaver {
     seek(offset: number): void;
     /**
      * Changes the length of the file to that specified. If shortening the file, data beyond the new length
-     * must be discarded. If extending the file, the existing data must be zero-padded up to the new length.
+     * will be discarded. If extending the file, the existing data will be zero-padded up to the new length.
      * @param size The size to which the length of the file is to be adjusted, measured in bytes.
      */
     truncate(size: number): void;

--- a/cordova/plugins/Media.d.ts
+++ b/cordova/plugins/Media.d.ts
@@ -28,19 +28,6 @@ declare var Media: {
  */
 interface Media {
     /**
-     * Constructor for Media object.
-     * @param  src          A URI containing the audio content.
-     * @param  mediaSuccess The callback that executes after a Media object has completed
-     *                      the current play, record, or stop action.
-     * @param  mediaError   The callback that executes if an error occurs.
-     * @param  mediaStatus  The callback that executes to indicate status changes.
-     */
-    new (
-        src: string,
-        mediaSuccess: () => void,
-        mediaError?: (error: MediaError) => any,
-        mediaStatus?: (status: number) => void): Media;
-    /**
      * Returns the current position within an audio file. Also updates the Media object's position parameter.
      * @param mediaSuccess The callback that is passed the current position in seconds.
      * @param mediaError   The callback to execute if an error occurs.

--- a/cordova/plugins/WebSQL.d.ts
+++ b/cordova/plugins/WebSQL.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for Apache Cordova WebSQL plugin.
-// Project: https://github.com/sgrebnov/cordova-plugin-websql
+// Project: https://github.com/MSOpenTech/cordova-plugin-websql
 // Definitions by: Microsoft Open Technologies, Inc. <http://msopentech.com>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 // 
@@ -43,7 +43,7 @@ interface Database {
         successCallback?: () => void): void;
     name: string;
     version: string;
-    displayname: string;
+    displayName: string;
     size: number;
 }
 


### PR DESCRIPTION
- Rewrite ambiguous JSDoc comments if FileSystem.d.ts
- Fixed typos & arguments order for ContactField constructor
- Remove nonsense constructors in FileSystem.d.ts and Media.d.ts
- Fixed typo in WebSQL.d.ts
- Fixed repo hyperlink in WebSQL.d.ts
