### PR TITLE
Changed signatures on constructors

### DIFF
--- a/moment/moment.d.ts
+++ b/moment/moment.d.ts
@@ -258,16 +258,16 @@ interface MomentRelativeTime {
 
 interface MomentStatic {
 
-    (): Moment;
-    (date: number): Moment;
-    (date: number[]): Moment;
-    (date: string, format?: string, strict?: boolean): Moment;
-    (date: string, format?: string, language?: string, strict?: boolean): Moment;
-    (date: string, formats: string[], strict?: boolean): Moment;
-    (date: string, formats: string[], language?: string, strict?: boolean): Moment;
-    (date: Date): Moment;
-    (date: Moment): Moment;
-    (date: Object): Moment;
+    new();
+    new(date: number);
+    new(date: number[]);
+    new(date: string, format?: string, strict?: boolean);
+    new(date: string, format?: string, language?: string, strict?: boolean);
+    new(date: string, formats: string[], strict?: boolean);
+    new(date: string, formats: string[], language?: string, strict?: boolean);
+    new(date: Date);
+    new(date: Moment);
+    new(date: Object);
 
     utc(): Moment;
     utc(date: number): Moment;

--- a/moment/moment.d.ts
+++ b/moment/moment.d.ts
@@ -258,17 +258,17 @@ interface MomentRelativeTime {
 
 interface MomentStatic {
 
-    new();
-    new(date: number);
-    new(date: number[]);
-    new(date: string, format?: string, strict?: boolean);
-    new(date: string, format?: string, language?: string, strict?: boolean);
-    new(date: string, formats: string[], strict?: boolean);
-    new(date: string, formats: string[], language?: string, strict?: boolean);
-    new(date: Date);
-    new(date: Moment);
-    new(date: Object);
-
+    new(): Moment;
+    new(date: number): Moment;
+    new(date: number[]): Moment;
+    new(date: string, format?: string, strict?: boolean): Moment;
+    new(date: string, format?: string, language?: string, strict?: boolean): Moment;
+    new(date: string, formats: string[], strict?: boolean): Moment;
+    new(date: string, formats: string[], language?: string, strict?: boolean): Moment;
+    new(date: Date): Moment;
+    new(date: Moment): Moment;
+    new(date: Object): Moment;
+    
     utc(): Moment;
     utc(date: number): Moment;
     utc(date: number[]): Moment;


### PR DESCRIPTION
With the latest version of TypeScript some issues were apparent with the constructors for momentStatic returning a type. I looked into it and the correct way to define constructors in interfaces is with the `new` keyword. 

References:
https://typescript.codeplex.com/workitem/925
http://stackoverflow.com/questions/13407036/how-does-typescript-interfaces-with-construct-signatures-work/13408029#13408029
