### PR TITLE
node-uuid: Let require("node-uuid") work in nodejs

### DIFF
--- a/node-uuid/node-uuid.d.ts
+++ b/node-uuid/node-uuid.d.ts
@@ -46,7 +46,7 @@ interface UUID {
     v4(options?: UUIDOptions, buffer?: Buffer, offset?: number): string
 }
 
-declare module 'uuid' {
+declare module "node-uuid" {
     var uuid: UUID;
     export = uuid;
 }


### PR DESCRIPTION
I cannot use

```
import uuid = require("uuid");
```

since the nodejs package is called "node-uuid".

With this change this is possible.
