### PR TITLE
correct fullCalendar.Options.weekNumberTitle type

### DIFF
--- a/fullCalendar/fullCalendar.d.ts
+++ b/fullCalendar/fullCalendar.d.ts
@@ -84,7 +84,7 @@ declare module FullCalendar {
         monthNamesShort?: Array<string>;
         dayNames?: Array<string>;
         dayNamesShort?: Array<string>;
-        weekNumberTitle?: number;
+        weekNumberTitle?: string;
 
         // Clicking & Hovering - http://arshaw.com/fullcalendar/docs/mouse/
 


### PR DESCRIPTION
The type of weekNumberTitle should be string and not number according to
documentation.

Test runs when the parameter --noImplicitAny is omitted, but that was the case before this pull request too.
