### PR TITLE
Support for KO 3.0 array change subscription

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -52,9 +52,16 @@ interface KnockoutSubscription {
 	dispose(): void;
 }
 
+interface KnockoutSubscribtionArrayChangeEvent<T> {
+    status: string;
+    value: T;
+    index: number
+}
+
 interface KnockoutSubscribable<T> extends KnockoutSubscribableFunctions<T> {
 	subscribe(callback: (newValue: T) => void, target?: any, event?: string): KnockoutSubscription;
 	subscribe<TEvent>(callback: (newValue: TEvent) => void, target: any, event: string): KnockoutSubscription;
+	subscribe<TItem>(callback:(changes: KnockoutSubscribtionArrayChangeEvent<TItem>[])=> void, target: any, event: string): KnockoutSubscription;
 	extend(requestedExtenders: { [key: string]: any; }): KnockoutSubscribable<T>;
 	getSubscriptionsCount(): number;
 }


### PR DESCRIPTION
Maybe there is a better way to get this in, but this is what I use atm to give me the hints when doing .subscribe.

From one of my use cases in a generic class.

```
        childs: KnockoutObservableArray<T> = ko.observableArray([]);
        this.childs.subscribe((changes: KnockoutSubscribtionArrayChangeEvent<T>[]) => {
            changes.forEach(change => {
                if (change.status === 'added') {
                    change.value.layout = this;                        
                } else if (change.status === 'removed') {
                   delete change.value.layout;
                }
            });
        }, null, "arrayChange");
```
