### PR TITLE
update angular-translate to version 2.1.0

### DIFF
--- a/angular-translate/angular-translate.d.ts
+++ b/angular-translate/angular-translate.d.ts
@@ -22,7 +22,7 @@ declare module ng.translate {
     }
 
     interface ITranslateService {
-        (key: string, ...params: string[]): string;
+        (key: string, ...params: string[]): ng.IPromise<string>;
         fallbackLanguage(): string;
         preferredLanguage(): string;
         proposedLanguage(): string;


### PR DESCRIPTION
version 2.1.0 uses promises for the `$translate` service ([doc](http://angular-translate.github.io/docs/#/api/pascalprecht.translate.$translate))
