### PR TITLE
node.js: Added `toJSON()` and `INSPECT_MAX_BYTES` to NodeBuffer interface

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -200,6 +200,7 @@ interface NodeBuffer {
     [index: number]: number;
     write(string: string, offset?: number, length?: number, encoding?: string): number;
     toString(encoding?: string, start?: number, end?: number): string;
+    toJSON(): any;
     length: number;
     copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
     slice(start?: number, end?: number): Buffer;
@@ -232,6 +233,7 @@ interface NodeBuffer {
     writeDoubleLE(value: number, offset: number, noAssert?: boolean): void;
     writeDoubleBE(value: number, offset: number, noAssert?: boolean): void;
     fill(value: any, offset?: number, end?: number): void;
+    INSPECT_MAX_BYTES: number;
 }
 
 /************************************************


### PR DESCRIPTION
See issue: https://github.com/borisyankov/DefinitelyTyped/issues/2147
See docs: http://nodejs.org/api/buffer.html

`toJSON()` and `INSPECT_MAX_BYTES` have been missing in the v.0.10 node.js definitions.

Added to the `NodeBuffer` interface for now, although it is marked as 'deprecated', as the interface `Buffer` extends `NodeBuffer`.
