### PR TITLE
node.js: [bugfix] Moved `INSPECT_MAX_BYTES` to the buffer module.

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -233,7 +233,6 @@ interface NodeBuffer {
     writeDoubleLE(value: number, offset: number, noAssert?: boolean): void;
     writeDoubleBE(value: number, offset: number, noAssert?: boolean): void;
     fill(value: any, offset?: number, end?: number): void;
-    INSPECT_MAX_BYTES: number;
 }
 
 /************************************************
@@ -241,6 +240,10 @@ interface NodeBuffer {
 *                   MODULES                     *
 *                                               *
 ************************************************/
+declare module "buffer" {
+    export var INSPECT_MAX_BYTES: number;
+}
+
 declare module "querystring" {
     export function stringify(obj: any, sep?: string, eq?: string): string;
     export function parse(str: string, sep?: string, eq?: string, options?: { maxKeys?: number; }): any;


### PR DESCRIPTION
(node.js definitions)
There's a mistake in pull request #2154 concerning `INSPECT_MAX_BYTES`

From the [docs](http://nodejs.org/api/buffer.html#buffer_buffer_inspect_max_bytes):

"Note that this is a property on the buffer module returned by `require('buffer')`, not on the Buffer global, or a buffer instance."

A short test showed that, despite the ambiguity (right? :) of the sentence, `INSPECT_MAX_BYTES` does neither exist on the Buffer global nor on a buffer instance.
