### PR TITLE
Removed type queries used on interface members.

### DIFF
--- a/handlebars/handlebars.d.ts
+++ b/handlebars/handlebars.d.ts
@@ -30,7 +30,6 @@ interface HandlebarsCommon {
 
     logger: Logger;
     log(level: number, obj: any): void;
-    Logger: typeof Logger;
 }
 
 interface HandlebarsStatic extends HandlebarsCommon {

--- a/siesta/siesta.d.ts
+++ b/siesta/siesta.d.ts
@@ -256,7 +256,7 @@ declare module Siesta {
 
                     target?: any;
 
-                    el?: typeof target;
+                    el?: any;
                 }
             }
 


### PR DESCRIPTION
`typeof` cannot be used to refer to properties within an interface. It is currently permitted due to a bug in the TypeScript compiler which we plan to address.

Of the errors in DefinitelyTyped that this catches, I've done my best to understand the intent of the `.d.ts` files and make the appropriate changes.
