### PR TITLE
For d3.js "typing": Make optional the before argument of enter().insert('')

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -811,7 +811,7 @@ declare module D3 {
 
     export interface EnterSelection {
         append: (name: string) => Selection;
-        insert: (name: string, before: string) => Selection;
+        insert: (name: string, before?: string) => Selection;
         select: (selector: string) => Selection;
         empty: () => boolean;
         node: () => Element;


### PR DESCRIPTION
From the documentation (https://github.com/mbostock/d3/wiki/Selections#insert):
 "For enter selections, the before selector may be omitted, [...]"

(hopefully this is the correct way to contribute a small fix...)
