### PR TITLE
Making gapi.auth.authorize accept string|array

### DIFF
--- a/gapi/gapi.d.ts
+++ b/gapi/gapi.d.ts
@@ -48,7 +48,7 @@ declare module gapi.auth {
         /**
          * The auth scope or scopes to authorize. Auth scopes for individual APIs can be found in their documentation.
          */
-        scope?: any[]
+        scope?: any
     }, callback: (token: GoogleApiOAuth2TokenObject) => any): void;
     /**
      * Initializes the authorization feature. Call this when the client loads to prevent popup blockers from blocking the auth window on gapi.auth.authorize calls.


### PR DESCRIPTION
Per the docs[1] gapi.auth.authorize's scope parameter accepts a lone string, as well as an array of strings. From my limited testing the any type appears to accept both string and array of string.

1: https://developers.google.com/api-client-library/javascript/reference/referencedocs#gapiauthauthorize
