### PR TITLE
Allow Boolean value on attr()

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -1359,6 +1359,13 @@ interface JQuery {
      * @param value A value to set for the attribute.
      */
     attr(attributeName: string, value: number): JQuery;
+        /**
+     * Set one or more attributes for the set of matched elements.
+     *
+     * @param attributeName The name of the attribute to set.
+     * @param value A value to set for the attribute.
+     */
+    attr(attributeName: string, value: boolean): JQuery;
     /**
      * Set one or more attributes for the set of matched elements.
      *


### PR DESCRIPTION
Allow Boolean value on attr() function to be able to set boolean value with it as second parameter.

Exemple : $(element).attr("disabled", true).

Needed as putting true between quotes brake that since it become a string and it isn't treated the same way.
