### PR TITLE
Update angular.d.ts missing statusText property

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -629,6 +629,7 @@ declare module ng {
         status?: number;
         headers?: (headerName: string) => string;
         config?: IRequestConfig;
+        statusText?: string;
     }
 
     interface IHttpPromise<T> extends IPromise<T> {


### PR DESCRIPTION
On IHttpPromiseCallbackArg added missing statusText property.

From angular's API

```
data – {string|Object} – The response body transformed with the transform functions.
status – {number} – HTTP status code of the response.
headers – {function([headerName])} – Header getter function.
config – {Object} – The configuration object that was used to generate the request.
statusText – {string} – HTTP status text of the response.
```
