### PR TITLE
$.parseJSON should return `any` instead of `Object`

### DIFF
--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -3116,6 +3116,22 @@ function test_parseHTML() {
 	  .appendTo( $log );
 }
 
+// http://api.jquery.com/jQuery.parseJSON/
+function test_parseJSON() {
+    // Return type should be any, not Object
+    var i = $.parseJSON('1');
+    var a = $.parseJSON('[1]');
+    var o = $.parseJSON('{"foo":"bar"}');
+    var s = $.parseJSON('"string"');
+    var n = $.parseJSON('null');
+
+    i instanceof Object; // false
+    a instanceof Object; // true
+    o instanceof Object; // true
+    s instanceof Object; // false
+    n instanceof Object; // false
+}
+
 function test_not() {
     $("li").not(":even").css("background-color", "red");
 

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -1214,7 +1214,7 @@ interface JQueryStatic {
      * 
      * @param json The JSON string to parse.
      */
-    parseJSON(json: string): Object;
+    parseJSON(json: string): any;
 
     /**
      * Parses a string into an XML document.


### PR DESCRIPTION
Here is my test:

``` js
var i = JSON.parse('1');
var a = JSON.parse('[1]');
var o = JSON.parse('{"foo":"bar"}');
var s = JSON.parse('"string"');
var n = JSON.parse('null');

i instanceof Object; // false
a instanceof Object; // true
o instanceof Object; // true
s instanceof Object; // false
n instanceof Object; // false
```

JSON.parse returns the `any` type so I think this method should do the same.

More of the discussion regarding this pull request can be found on the original commit 8c23d04a5b4a0505df042a82be90f95adff02d87

https://github.com/borisyankov/DefinitelyTyped/commit/8c23d04a5b4a0505df042a82be90f95adff02d87
