### PR TITLE
Highcharts Query selector to return Chart object

### DIFF
--- a/highcharts/highcharts.d.ts
+++ b/highcharts/highcharts.d.ts
@@ -1119,6 +1119,7 @@ interface HighchartsSeriesObject {
 }
 
 interface JQuery {
+    highcharts(): HighchartsChartObject;
     /**
     * Creates a new Highcharts.Chart for the current JQuery selector; usually
     * a div selected by $('#container')


### PR DESCRIPTION
According to http://api.highcharts.com/highcharts#Highcharts the 'Highchart()' function should return a Highchart object.
