### PR TITLE
Fixed specialized declaration ws.d.ts

### DIFF
--- a/ws/ws.d.ts
+++ b/ws/ws.d.ts
@@ -60,28 +60,29 @@ declare module "ws" {
         terminate(): void;
 
         // HTML5 WebSocket events
-        addEventListener(method: string, listener?: () => void): void;
         addEventListener(method: 'message', cb?: (event: {data: any; type: string; target: WebSocket}) => void): void;
         addEventListener(method: 'close', cb?: (event: {wasClean: boolean; code: number;
                                                         reason: string; target: WebSocket}) => void): void;
         addEventListener(method: 'error', cb?: (err: Error) => void): void;
         addEventListener(method: 'open', cb?: (event: {target: WebSocket}) => void): void;
+        addEventListener(method: string, listener?: () => void): void;
 
         // Events
-        on(event: string, listener: () => void): WebSocket;
         on(event: 'error', cb: (err: Error) => void): WebSocket;
         on(event: 'close', cb: (code: number, message: string) => void): WebSocket;
         on(event: 'message', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
         on(event: 'ping', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
         on(event: 'pong', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
         on(event: 'open', cb: () => void): WebSocket;
-        addListener(event: string, listener: () => void): WebSocket;
+        on(event: string, listener: () => void): WebSocket;
+        
         addListener(event: 'error', cb: (err: Error) => void): WebSocket;
         addListener(event: 'close', cb: (code: number, message: string) => void): WebSocket;
         addListener(event: 'message', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
         addListener(event: 'ping', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
         addListener(event: 'pong', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
         addListener(event: 'open', cb: () => void): WebSocket;
+        addListener(event: string, listener: () => void): WebSocket;
     }
 
     module WebSocket {
@@ -113,14 +114,15 @@ declare module "ws" {
                           upgradeHead: Buffer, callback: (client: WebSocket) => void): void;
 
             // Events
-            on(event: string, listener: () => void): Server;
             on(event: 'error', cb: (err: Error) => void): Server;
             on(event: 'headers', cb: (headers: string[]) => void): Server;
             on(event: 'connection', cb: (client: WebSocket) => void): Server;
-            addListener(event: string, listener: () => void): Server;
+            on(event: string, listener: () => void): Server;
+            
             addListener(event: 'error', cb: (err: Error) => void): Server;
             addListener(event: 'headers', cb: (headers: string[]) => void): Server;
             addListener(event: 'connection', cb: (client: WebSocket) => void): Server;
+            addListener(event: string, listener: () => void): Server;
         }
 
         export function createServer(options?: IServerOptions,


### PR DESCRIPTION
Typescript specification says:

"When writing overloaded declarations such as the one above it is important to list the non-specialized signature last. This is because overload resolution (section 4.12.1) processes the candidates in declaration order and picks the first one that matches."

Fixed this for Server and WebSocket class
