### PR TITLE
allow angular.d.ts to be imported using AMD

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -6,6 +6,11 @@
 
 /// <reference path="../jquery/jquery.d.ts" />
 
+declare module 'angular'{
+    export var angular:ng.IAngularStatic;
+}
+
+
 declare var angular: ng.IAngularStatic;
 
 // Support for painless dependency injection

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -7,9 +7,9 @@
 /// <reference path="../jquery/jquery.d.ts" />
 
 declare module 'angular'{
-    export var angular:ng.IAngularStatic;
+    var angular:ng.IAngularStatic;
+    export = angular;
 }
-
 
 declare var angular: ng.IAngularStatic;
 


### PR DESCRIPTION
currently if you do 
import angular = require("angular"); 
tsc will throw 2071 - Unable to resolve external module 'angular'
this 
declare module 'angular'{
    export var angular:ng.IAngularStatic;
}
declares such a module.
