### PR TITLE
Update mocha.d.ts: add `context` statement

### DIFF
--- a/mocha/mocha-tests.ts
+++ b/mocha/mocha-tests.ts
@@ -12,6 +12,18 @@ function test_describe() {
     });
 }
 
+function test_context() {
+    context('some context', () => { });
+
+    context.only('some context', () => { });
+
+    context.skip('some context', () => { });
+
+    context('some context', function() {
+        this.timeout(2000);
+    });
+}
+
 function test_it() {
 
     it('does something', () => { });

--- a/mocha/mocha.d.ts
+++ b/mocha/mocha.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for mocha 1.17.1
 // Project: http://visionmedia.github.io/mocha/
-// Definitions by: Kazi Manzur Rashid <https://github.com/kazimanzurrashid/>
+// Definitions by: Kazi Manzur Rashid <https://github.com/kazimanzurrashid/> and otiai10 <https://github.com/otiai10>
 // DefinitelyTyped: https://github.com/borisyankov/DefinitelyTyped
 
 interface Mocha {
@@ -56,6 +56,14 @@ declare var describe : {
     (description: string, spec: () => void): void;
     only(description: string, spec: () => void): void;
     skip(description: string, spec: () => void): void;
+    timeout(ms: number): void;
+}
+
+// alias for `describe`
+declare var context : {
+    (contextTitle: string, spec: () => void): void;
+    only(contextTitle: string, spec: () => void): void;
+    skip(contextTitle: string, spec: () => void): void;
     timeout(ms: number): void;
 }
 


### PR DESCRIPTION
Reference to `context` statement is not in [mocha official document](http://visionmedia.github.io/mocha/), but it is recognized and works well.

It is just an alias for `describe`.

(very thanks to hokaccha)

---

Code

https://github.com/visionmedia/mocha/blob/master/mocha.js#L952

---

FYI?

<blockquote class="twitter-tweet" lang="ja"><p><a href="https://twitter.com/otiai10">@otiai10</a> 公式ドキュメントにはないようですね。僕が実装したころと変わってなければ単なる describe のエイリアスのはずです。</p>&mdash; Kazuhito Hokamura (@hokaccha) <a href="https://twitter.com/hokaccha/statuses/468985582236889089">2014, 5月 21</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


http://d.hatena.ne.jp/hokaccha/20120802/1343892304
