### PR TITLE
Marking gapi.client.request body param as any

### DIFF
--- a/gapi/gapi.d.ts
+++ b/gapi/gapi.d.ts
@@ -99,7 +99,7 @@ declare module gapi.client {
         /**
          * The HTTP request body (applies to PUT or POST).
          */
-        body?: string;
+        body?: any;
         /**
          * If supplied, the request is executed immediately and no gapi.client.HttpRequest object is returned
          */


### PR DESCRIPTION
The gapi.js library will JSON.stringify the body param to send it over the wire.
