### PR TITLE
Fixed stringTokenize return type

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -274,7 +274,7 @@ interface KnockoutUtils {
 
     stringTrim(str: string): string;
 
-    stringTokenize(str: string, delimiter: string): string;
+    stringTokenize(str: string, delimiter: string): string[];
 
     stringStartsWith(str: string, startsWith: string): string;
 


### PR DESCRIPTION
The util function stringTokenize returns an string array according to the knockout source
