### PR TITLE
RxJS: updated to version 2.2.24

### DIFF
--- a/rx.js/rx-lite.d.ts
+++ b/rx.js/rx-lite.d.ts
@@ -196,7 +196,6 @@ declare module Rx {
 
 	export interface Observable<T> extends IObservable<T> {
 		forEach(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;	// alias for subscribe
-		finalValue(): Observable<T>;
 		toArray(): Observable<T[]>;
 
 		catch(handler: (exception: any) => Observable<T>): Observable<T>;
@@ -234,9 +233,11 @@ declare module Rx {
 		mergeAll(): T;
 		mergeObservable(): T;	// alias for mergeAll
 		skipUntil<T2>(other: Observable<T2>): Observable<T>;
+		skipUntil<T2>(other: IPromise<T2>): Observable<T>;
 		switch(): T;
 		switchLatest(): T;	// alias for switch
 		takeUntil<T2>(other: Observable<T2>): Observable<T>;
+		takeUntil<T2>(other: IPromise<T2>): Observable<T>;
 		zip<T2, TResult>(second: Observable<T2>, resultSelector: (v1: T, v2: T2) => TResult): Observable<TResult>;
 		zip<T2, TResult>(second: IPromise<T2>, resultSelector: (v1: T, v2: T2) => TResult): Observable<TResult>;
 		zip<T2, T3, TResult>(second: Observable<T2>, third: Observable<T3>, resultSelector: (v1: T, v2: T2, v3: T3) => TResult): Observable<TResult>;

--- a/rx.js/rx.aggregates.d.ts
+++ b/rx.js/rx.aggregates.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Aggregates v2.2.20
+// Type definitions for RxJS-Aggregates v2.2.24
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.aggregates.d.ts
+++ b/rx.js/rx.aggregates.d.ts
@@ -8,6 +8,7 @@
 
 declare module Rx {
 	export interface Observable<T> {
+		finalValue(): Observable<T>;
 		aggregate(accumulator: (acc: T, value: T) => T): Observable<T>;
 		aggregate<TAcc>(seed: TAcc, accumulator: (acc: TAcc, value: T) => TAcc): Observable<TAcc>;
 

--- a/rx.js/rx.all.ts
+++ b/rx.js/rx.all.ts
@@ -1,0 +1,17 @@
+// Type definitions for RxJS-All v2.2.24
+// Project: http://rx.codeplex.com/
+// Definitions by: Carl de Billy <http://carl.debilly.net/>
+// Definitions by: Igor Oleinikov <https://github.com/Igorbek>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="rx.d.ts"/> 
+/// <reference path="rx.aggregates.d.ts"/> 
+/// <reference path="rx.time.d.ts"/> 
+/// <reference path="rx.async.d.ts"/> 
+/// <reference path="rx.binding.d.ts"/> 
+/// <reference path="rx.coincidence.d.ts"/> 
+/// <reference path="rx.experimental.d.ts"/> 
+/// <reference path="rx.joinpatterns.d.ts"/> 
+/// <reference path="rx.virtualtime.d.ts"/> 
+/// <reference path="rx.testing.d.ts"/>
+/// <reference path="rx.backpressure.d.ts" />

--- a/rx.js/rx.async.d.ts
+++ b/rx.js/rx.async.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Async v2.2.20
+// Type definitions for RxJS-Async v2.2.24
 // Project: http://rx.codeplex.com/
 // Definitions by: zoetrope <https://github.com/zoetrope>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.backpressure.d.ts
+++ b/rx.js/rx.backpressure.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for RxJS-BackPressure v2.2.20
+﻿// Type definitions for RxJS-BackPressure v2.2.24
 // Project: http://rx.codeplex.com/
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.binding.d.ts
+++ b/rx.js/rx.binding.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Binding v2.2.20
+// Type definitions for RxJS-Binding v2.2.24
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.coincidence-lite.d.ts
+++ b/rx.js/rx.coincidence-lite.d.ts
@@ -1,0 +1,32 @@
+// This file contains common part of defintions for rx.time.d.ts and rx.lite.d.ts
+// Do not include the file separately.
+
+///<reference path="rx-lite.d.ts" />
+
+declare module Rx {
+
+	interface Observable<T> {
+		/**
+		* Returns a new observable that triggers on the second and subsequent triggerings of the input observable. 
+		* The Nth triggering of the input observable passes the arguments from the N-1th and Nth triggering as a pair. 
+		* The argument passed to the N-1th triggering is held in hidden internal state until the Nth triggering occurs.
+		* @returns An observable that triggers on successive pairs of observations from the input observable as an array.
+		*/
+		pairwise(): Observable<T[]>;
+
+		/** 
+		* Returns two observables which partition the observations of the source by the given function.
+		* The first will trigger observations for those values for which the predicate returns true. 
+		* The second will trigger observations for those values where the predicate returns false. 
+		* The predicate is executed once for each subscribed observer. 
+		* Both also propagate all error observations arising from the source and each completes 
+		* when the source completes.
+		* @param predicate 
+		*    The function to determine which output Observable will trigger a particular observation.
+		* @returns
+		*    An array of observables. The first triggers when the predicate returns true, 
+		*    and the second triggers when the predicate returns false.
+		*/
+		partition(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg: any): Observable<T>[];
+	}
+}

--- a/rx.js/rx.coincidence.d.ts
+++ b/rx.js/rx.coincidence.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Coincidence v2.2.20
+// Type definitions for RxJS-Coincidence v2.2.24
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.coincidence.d.ts
+++ b/rx.js/rx.coincidence.d.ts
@@ -5,6 +5,7 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 ///<reference path="rx.d.ts" />
+///<reference path="rx.coincidence-lite.d.ts" />
 
 declare module Rx {
 

--- a/rx.js/rx.d.ts
+++ b/rx.js/rx.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for RxJS v2.2.20
+﻿// Type definitions for RxJS v2.2.24
 // Project: http://rx.codeplex.com/
 // Definitions by: gsino <http://www.codeplex.com/site/users/view/gsino>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.experimental.d.ts
+++ b/rx.js/rx.experimental.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Experimental v2.2.20
+// Type definitions for RxJS-Experimental v2.2.24
 // Project: https://github.com/Reactive-Extensions/RxJS/
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.joinpatterns.d.ts
+++ b/rx.js/rx.joinpatterns.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Join v2.2.20
+// Type definitions for RxJS-Join v2.2.24
 // Project: http://rx.codeplex.com/
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.lite.d.ts
+++ b/rx.js/rx.lite.d.ts
@@ -9,6 +9,7 @@
 ///<reference path="rx.binding-lite.d.ts" />
 ///<reference path="rx.time-lite.d.ts" />
 ///<reference path="rx.backpressure-lite.d.ts" />
+///<reference path="rx.coincidence-lite.d.ts" />
 
 declare module Rx {
 	export class Scheduler implements IScheduler {

--- a/rx.js/rx.testing.d.ts
+++ b/rx.js/rx.testing.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Testing v2.2.20
+// Type definitions for RxJS-Testing v2.2.24
 // Project: https://github.com/Reactive-Extensions/RxJS/
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.time-lite.d.ts
+++ b/rx.js/rx.time-lite.d.ts
@@ -39,7 +39,9 @@ declare module Rx {
 		skipWithTime(duration: number, scheduler?: IScheduler): Observable<T>;
 
 		skipUntilWithTime(startTime: Date, scheduler?: IScheduler): Observable<T>;
+		skipUntilWithTime(duration: number, scheduler?: IScheduler): Observable<T>;
 		takeUntilWithTime(endTime: Date, scheduler?: IScheduler): Observable<T>;
+		takeUntilWithTime(duration: number, scheduler?: IScheduler): Observable<T>;
 	}
 
 	interface ObservableStatic {

--- a/rx.js/rx.time.d.ts
+++ b/rx.js/rx.time.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Time v2.2.20
+// Type definitions for RxJS-Time v2.2.24
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.virtualtime.d.ts
+++ b/rx.js/rx.virtualtime.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-VirtualTime v2.2.20
+// Type definitions for RxJS-VirtualTime v2.2.24
 // Project: http://rx.codeplex.com/
 // Definitions by: gsino <http://www.codeplex.com/site/users/view/gsino>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>


### PR DESCRIPTION
- `skipUntil`, `takeUntil` takes promises
- `finalValue` moved to `aggregates` module
- added `pairwise` and `partition` instance operators (`coincidence` module)
- added overloads of `skipUntilWithTime` and `takeUntilWithTime` that take time duration
- version bump to 2.2.24
