### PR TITLE
angular.mock.inject overload taking array DI syntax

### DIFF
--- a/angularjs/angular-mocks-tests.ts
+++ b/angularjs/angular-mocks-tests.ts
@@ -22,13 +22,13 @@ mock.inject(
     );
 
 mock.inject(
-    ['$rootScope', function ($rootScope) { return 1; }]);
+    ['$rootScope', function ($rootScope: ng.IRootScopeService) { return 1; }]);
 
 // This overload is not documented on the website, but flows from
 // how the injector works.
 mock.inject(
-    ['$rootScope', function ($rootScope) { return 1; }],
-    ['$rootScope', function ($rootScope) { return 2; }]);
+    ['$rootScope', function ($rootScope: ng.IRootScopeService) { return 1; }],
+    ['$rootScope', function ($rootScope: ng.IRootScopeService) { return 2; }]);
 
 mock.module('module1', 'module2');
 mock.module(

--- a/angularjs/angular-mocks-tests.ts
+++ b/angularjs/angular-mocks-tests.ts
@@ -21,6 +21,15 @@ mock.inject(
     function () { return 2; }
     );
 
+mock.inject(
+    ['$rootScope', function ($rootScope) { return 1; }]);
+
+// This overload is not documented on the website, but flows from
+// how the injector works.
+mock.inject(
+    ['$rootScope', function ($rootScope) { return 1; }],
+    ['$rootScope', function ($rootScope) { return 2; }]);
+
 mock.module('module1', 'module2');
 mock.module(
     function () { return 1; },

--- a/angularjs/angular-mocks.d.ts
+++ b/angularjs/angular-mocks.d.ts
@@ -30,6 +30,7 @@ declare module ng {
 
         // see http://docs.angularjs.org/api/angular.mock.inject
         inject(...fns: Function[]): any;
+        inject(...inlineAnnotatedConstructor: any[]): any; // this overload is undocumented, but works
 
         // see http://docs.angularjs.org/api/angular.mock.module
         module(...modules: string[]): any;


### PR DESCRIPTION
angular.mock.inject supports the array-style dependency injection format, e.g. angular.mock.inject(['$rootScope', function($rootScope) { /*foo */}]). This wasn't reflected in the angular-mocks.d.ts type declarations.
