### PR TITLE
[Leafet] L.marker accepts array of coordinates

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -2579,6 +2579,7 @@ declare module L {
       * Instantiates a Marker object given a geographical point and optionally
       * an options object.
       */
+    function marker(latlng: number[], options?: MarkerOptions): Marker;
     function marker(latlng: LatLng, options?: MarkerOptions): Marker;
 
     export class Marker extends Class implements ILayer, IEventPowered<Marker> {


### PR DESCRIPTION
L.marker also accepts an array of coordinates which will _then_ be converted internally to an instance of LatLng.
