### PR TITLE
RxJS: updated to version 2.2.25

### DIFF
--- a/rx.js/rx-lite.d.ts
+++ b/rx.js/rx-lite.d.ts
@@ -227,6 +227,11 @@ declare module Rx {
 		concat(sources: IPromise<T>[]): Observable<T>;
 		concatAll(): T;
 		concatObservable(): T;	// alias for concatAll
+		concatMap<T2, R>(selector: (value: T, index: number) => Observable<T2>, resultSelector: (value1: T, value2: T2, index: number) => R): Observable<R>;	// alias for selectConcat
+		concatMap<T2, R>(selector: (value: T, index: number) => IPromise<T2>, resultSelector: (value1: T, value2: T2, index: number) => R): Observable<R>;	// alias for selectConcat
+		concatMap<R>(selector: (value: T, index: number) => Observable<R>): Observable<R>;	// alias for selectConcat
+		concatMap<R>(selector: (value: T, index: number) => IPromise<R>): Observable<R>;	// alias for selectConcat
+		concatMap<R>(sequence: Observable<R>): Observable<R>;	// alias for selectConcat
 		merge(maxConcurrent: number): T;
 		merge(other: Observable<T>): Observable<T>;
 		merge(other: IPromise<T>): Observable<T>;
@@ -292,6 +297,12 @@ declare module Rx {
 		flatMap<TResult>(selector: (value: T) => IPromise<TResult>): Observable<TResult>;	// alias for selectMany
 		flatMap<TResult>(other: Observable<TResult>): Observable<TResult>;	// alias for selectMany
 		flatMap<TResult>(other: IPromise<TResult>): Observable<TResult>;	// alias for selectMany
+
+		selectConcat<T2, R>(selector: (value: T, index: number) => Observable<T2>, resultSelector: (value1: T, value2: T2, index: number) => R): Observable<R>;
+		selectConcat<T2, R>(selector: (value: T, index: number) => IPromise<T2>, resultSelector: (value1: T, value2: T2, index: number) => R): Observable<R>;
+		selectConcat<R>(selector: (value: T, index: number) => Observable<R>): Observable<R>;
+		selectConcat<R>(selector: (value: T, index: number) => IPromise<R>): Observable<R>;
+		selectConcat<R>(sequence: Observable<R>): Observable<R>;
 
 		/**
 		*  Projects each element of an observable sequence into a new sequence of observable sequences by incorporating the element's index and then 

--- a/rx.js/rx.aggregates.d.ts
+++ b/rx.js/rx.aggregates.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Aggregates v2.2.24
+// Type definitions for RxJS-Aggregates v2.2.25
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.all.ts
+++ b/rx.js/rx.all.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-All v2.2.24
+// Type definitions for RxJS-All v2.2.25
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.async.d.ts
+++ b/rx.js/rx.async.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Async v2.2.24
+// Type definitions for RxJS-Async v2.2.25
 // Project: http://rx.codeplex.com/
 // Definitions by: zoetrope <https://github.com/zoetrope>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.backpressure.d.ts
+++ b/rx.js/rx.backpressure.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for RxJS-BackPressure v2.2.24
+﻿// Type definitions for RxJS-BackPressure v2.2.25
 // Project: http://rx.codeplex.com/
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.binding.d.ts
+++ b/rx.js/rx.binding.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Binding v2.2.24
+// Type definitions for RxJS-Binding v2.2.25
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.coincidence.d.ts
+++ b/rx.js/rx.coincidence.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Coincidence v2.2.24
+// Type definitions for RxJS-Coincidence v2.2.25
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.d.ts
+++ b/rx.js/rx.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for RxJS v2.2.24
+﻿// Type definitions for RxJS v2.2.25
 // Project: http://rx.codeplex.com/
 // Definitions by: gsino <http://www.codeplex.com/site/users/view/gsino>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.experimental.d.ts
+++ b/rx.js/rx.experimental.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Experimental v2.2.24
+// Type definitions for RxJS-Experimental v2.2.25
 // Project: https://github.com/Reactive-Extensions/RxJS/
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.joinpatterns.d.ts
+++ b/rx.js/rx.joinpatterns.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Join v2.2.24
+// Type definitions for RxJS-Join v2.2.25
 // Project: http://rx.codeplex.com/
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.lite.d.ts
+++ b/rx.js/rx.lite.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for RxJS-Lite v2.2.20
+﻿// Type definitions for RxJS-Lite v2.2.25
 // Project: http://rx.codeplex.com/
 // Definitions by: gsino <http://www.codeplex.com/site/users/view/gsino>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.testing.d.ts
+++ b/rx.js/rx.testing.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Testing v2.2.24
+// Type definitions for RxJS-Testing v2.2.25
 // Project: https://github.com/Reactive-Extensions/RxJS/
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.time.d.ts
+++ b/rx.js/rx.time.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Time v2.2.24
+// Type definitions for RxJS-Time v2.2.25
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>

--- a/rx.js/rx.virtualtime.d.ts
+++ b/rx.js/rx.virtualtime.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-VirtualTime v2.2.24
+// Type definitions for RxJS-VirtualTime v2.2.25
 // Project: http://rx.codeplex.com/
 // Definitions by: gsino <http://www.codeplex.com/site/users/view/gsino>
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>


### PR DESCRIPTION
- added `selectConcat`/`concatMap`;
- version bump to 2.2.25.
