### PR TITLE
Bugfix in async.d.ts: error parameter in callbacks is listed as string b...

### DIFF
--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -3,8 +3,8 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-interface AsyncMultipleResultsCallback<T> { (err: string, results: T[]): any; }
-interface AsyncSingleResultCallback<T> { (err: string, result: T): void; }
+interface AsyncMultipleResultsCallback<T> { (err: Error, results: T[]): any; }
+interface AsyncSingleResultCallback<T> { (err: Error, result: T): void; }
 interface AsyncTimesCallback<T> { (n: number, callback: AsyncMultipleResultsCallback<T>): void; }
 
 interface AsyncIterator<T, R> { (item: T, callback: AsyncSingleResultCallback<R>): void; }


### PR DESCRIPTION
Bugfix in async.d.ts: error parameter in callbacks is listed as string but Error objects are put in by the async implementation. Note that this change will break existing code but I think rightly so.
