### PR TITLE
Added queue.push() method overload for strongly typed queues

### DIFF
--- a/async/async-tests.ts
+++ b/async/async-tests.ts
@@ -156,6 +156,22 @@ q.push([{ name: 'baz' }, { name: 'bay' }, { name: 'bax' }], function (err) {
     console.log('finished processing bar');
 });
 
+// tests for strongly typed tasks
+var q2 = async.queue(function (task: string, callback) {
+    console.log('Task: ' + task);
+    callback();
+}, 1);
+
+q2.push('task1');
+
+q2.push('task2', function (error, results: string[]) {
+    console.log('Finished tasks: ' + results.join(', '));
+});
+
+q2.push(['task3', 'task4', 'task5'], function (error, results: string[]) {
+    console.log('Finished tasks: ' + results.join(', '));
+});
+
 var filename = '';
 async.auto({
     get_data: function (callback) { },

--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -16,6 +16,7 @@ interface AsyncQueue<T> {
     length(): number;
     concurrency: number;
     push(task: T, callback?: AsyncMultipleResultsCallback<T>): void;
+    push(task: T[], callback?: AsyncMultipleResultsCallback<T>): void;
     saturated: AsyncMultipleResultsCallback<T>;
     empty: AsyncMultipleResultsCallback<T>;
     drain: AsyncMultipleResultsCallback<T>;


### PR DESCRIPTION
queue.push() method can accept an array of objects. If the queue was created using a task of type **any** the push() method would accept array in tests but this didn't work for task object that was defined as strongly typed. In that case push() method would accept only one task object as first parameter.

This change allows you to pass array of strongly typed objects to the queue.push() method.
