### PR TITLE
Write a spec to verify a bug related to jQuery.ajax method

### DIFF
--- a/jquery.pjax/jquery.pjax-tests.ts
+++ b/jquery.pjax/jquery.pjax-tests.ts
@@ -1,0 +1,9 @@
+/// <reference path="jquery.pjax.d.ts" />
+/// <reference path="../jquery/jquery.d.ts" />
+
+function test_fn_pjax() {
+    $(document).pjax("a");
+    $(document).pjax("a", "#pjax-container");
+    $(document).pjax("a", {push: true});
+    $(document).pjax("a", "#pjax-container", {push: true});
+}

--- a/jquery.pjax/jquery.pjax.d.ts
+++ b/jquery.pjax/jquery.pjax.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for jquery-pjax
+// Project: https://github.com/defunkt/jquery-pjax
+
+/// <reference path="../jquery/jquery.d.ts" />
+
+interface JQuery {
+    /*
+     * Tell PJAX to listen links with delegation selector that, when click on them, fetches the href with ajax into the container.
+     * Tries to make sure the back button and ctrl+click work the way you'd expect.
+     * If `options.container` is not defined, the `data-pjax` attribute of the link will be treated as container,
+     * If such an attribute is not defined too, the context runs with this statement will be treated as container.
+     * @param delegationSelector The selector to limit which links PJAX should listen on.
+     * @param options A valid jQuery ajax options object that may include these pjax specific options:
+     * - container: A jQuery selector indicates where to stick the response body. E.g., $(container).html(xhr.responseBody).
+     * - push: Whether to pushState the URL. Defaults to true (of course).
+     * - replace: Want to use replaceState instead? That's cool.
+     * @return Returns the jQuery object
+     */
+    pjax(delegationSelector: string, options?: JQueryAjaxSettings): JQuery;
+
+    /*
+     * Tell PJAX to listen links with delegation selector that, when click on them, fetches the href with ajax into the container.
+     * Tries to make sure the back button and ctrl+click work the way you'd expect.
+     * If `options.container` is not defined, the `data-pjax` attribute of the link will be treated as container,
+     * If such an attribute is not defined too, the context runs with this statement will be treated as container.
+     * @param delegationSelector The selector to limit which links PJAX should listen on.
+     * @param containerSelector A jQuery selector indicates where to stick the response body. E.g., $(container).html(xhr.responseBody).
+     * @param options A valid jQuery ajax options object that may include these pjax specific options:
+     * - container: A jQuery selector indicates where to stick the response body. The containerSelector has priority.
+     * - push: Whether to pushState the URL. Defaults to true (of course).
+     * - replace: Want to use replaceState instead? That's cool.
+     * @return Returns the jQuery object
+     */
+    pjax(delegationSelector: string, containerSelector?: string, options?: JQueryAjaxSettings): JQuery;
+}

--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -736,7 +736,7 @@ function test_callbacksFunctions() {
     callbacks.add(bar);
     callbacks.fire('world');
     callbacks.disable();
-    
+
     // Test the disabled state of the list
     console.log(callbacks.disabled());
     // Outputs: true
@@ -3301,4 +3301,3 @@ function test_deferred_promise() {
         }
         );
 }
-

--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -150,6 +150,15 @@ function test_ajax() {
         url: "test.js",
         dataType: "script"
     });
+
+    // treat $.ajax() as a promise (as of 1.8)
+    $.ajax({
+        url: "test.js"
+    }).then((data, textStatus, jqXHR) => {
+        console.log(data, textStatus, jqXHR);
+    }, (jqXHR, textStatus, errorThrown) => {
+        console.log(jqXHR, textStatus, errorThrown);
+    });
 }
 
 function test_ajaxComplete() {

--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -151,7 +151,38 @@ function test_ajax() {
         dataType: "script"
     });
 
-    // treat $.ajax() as a promise (as of 1.8)
+    // Test the jqXHR object returned by $.ajax() as of 1.5
+    // More details: http://api.jquery.com/jQuery.ajax/#jqXHR
+
+    // done method
+    $.ajax({
+        url: "test.js"
+    }).done((data, textStatus, jqXHR) => {
+        console.log(data, textStatus, jqXHR);
+    });
+
+    // fail method
+    $.ajax({
+        url: "test.js"
+    }).fail((jqXHR, textStatus, errorThrown) => {
+        console.log(jqXHR, textStatus, errorThrown);
+    });
+
+    // always method with successful request
+    $.ajax({
+        url: "test.js"
+    }).always((data, textStatus, jqXHR) => {
+        console.log(data, textStatus, jqXHR);
+    });
+
+    // always method with failed request
+    $.ajax({
+        url: "test.js"
+    }).always((jqXHR, textStatus, errorThrown) => {
+        console.log(jqXHR, textStatus, errorThrown);
+    });
+
+    // then method (as of 1.8)
     $.ajax({
         url: "test.js"
     }).then((data, textStatus, jqXHR) => {

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -168,6 +168,10 @@ interface JQueryXHR extends XMLHttpRequest, JQueryPromise<any> {
      */
     overrideMimeType(mimeType: string): any;
     abort(statusText?: string): void;
+    /**
+     * Incorporates the functionality of the .done() and .fail() methods, allowing (as of jQuery 1.8) the underlying Promise to be manipulated. Refer to deferred.then() for implementation details.
+     */
+    then(doneCallback: (data: any, textStatus: string, jqXHR: JQueryXHR) => void, failCallback: (jqXHR: JQueryXHR, textStatus: string, errorThrown: any) => void): JQueryPromise<any>;
 }
 
 /**


### PR DESCRIPTION
The definition file does not leverage the returned value of $.ajax() method well. The official syntax is

```
jqXHR.then(function( data, textStatus, jqXHR ) {}, function( jqXHR, textStatus, errorThrown ) {});
```

(From: http://api.jquery.com/jQuery.ajax/)

But, it does not get compilation.
