### PR TITLE
Add JSDoc for JQueryXHR.abort method.

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -167,6 +167,9 @@ interface JQueryXHR extends XMLHttpRequest, JQueryPromise<any> {
      * The .overrideMimeType() method may be used in the beforeSend() callback function, for example, to modify the response content-type header. As of jQuery 1.5.1, the jqXHR object also contains the overrideMimeType() method (it was available in jQuery 1.4.x, as well, but was temporarily removed in jQuery 1.5). 
      */
     overrideMimeType(mimeType: string): any;
+    /**
+     * Cancel the request. Pass the statusText as textStatus parameter for done callback, "canceled" will be passed if not provided.
+     */
     abort(statusText?: string): void;
 }
 


### PR DESCRIPTION
Inspired the description from its source code:
https://github.com/jquery/jquery/blob/d41e81980ea89e56c04eb14d8c27f4692b367604/src/ajax.js#L487
