### PR TITLE
Added definitions for _(...)groupBy and toArray()

### DIFF
--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -3192,6 +3192,34 @@ declare module _ {
             whereValue: W): _.LoDashObjectWrapper<Dictionary<T[]>>;
     }
 
+    interface LoDashArrayWrapper<T> {
+        /**
+        * @see _.toArray
+        **/
+        toArray(): LoDashWrapper<any>;
+    }
+
+    interface LoDashObjectWrapper<T> {
+        /**
+        * @see _.groupBy
+        **/
+        groupBy(
+            callback: ListIterator<T, any>,
+            thisArg?: any): LoDashArrayWrapper<Dictionary<T[]>>;
+
+        /**
+        * @see _.groupBy
+        **/
+        groupBy(
+            pluckValue: string): LoDashArrayWrapper<Dictionary<T[]>>;
+
+        /**
+        * @see _.groupBy
+        **/
+        groupBy<W>(
+            whereValue: W): LoDashArrayWrapper<Dictionary<T[]>>;
+    }
+
     //_.indexBy
     interface LoDashStatic {
         /**


### PR DESCRIPTION
With lodash.d.ts v0.17 a call to `groupBy` followed by a call to `toArray()` before get the array value would not be recognized by TypeScript, causing the .ts compilation to fail.

Example:

``` javascript
    _([{prop1: "a", prop2: "b"}]).groupBy("prop2").toArray().value();
```

With the added definitions the above code compiles succesfully. :-)
