### PR TITLE
updated Parsimmon to v0.4.0

### DIFF
--- a/parsimmon/parsimmon-tests.ts
+++ b/parsimmon/parsimmon-tests.ts
@@ -55,6 +55,11 @@ foo = fooPar.parse(str);
 fooPar = fooPar.or(fooPar);
 anyPar = fooPar.or(barPar);
 
+barPar = fooPar.chain((f) => {
+	foo = f;
+	return barPar;
+});
+
 barPar = fooPar.then((f) => {
 	foo = f;
 	return barPar;
@@ -82,6 +87,8 @@ fooArrPar = fooPar.atLeast(num);
 
 fooMarkPar = fooPar.mark();
 
+fooPar = fooPar.desc(str);
+
 // --  --  --  --  --  --  --  --  --  --  --  --  --
 
 strPar = P.string(str);
@@ -91,6 +98,10 @@ fooPar = P.succeed(foo);
 
 fooArrPar = P.seq(fooPar, fooPar);
 anyArrPar = P.seq(barPar, fooPar, numPar);
+
+fooPar = P.alt(fooPar, fooPar);
+anyPar = P.alt(barPar, fooPar, numPar);
+
 
 fooPar = P.lazy(() => {
 	return fooPar;
@@ -112,5 +123,5 @@ strPar = P.optWhitespace;
 
 strPar = P.any;
 strPar = P.all;
-strPar = P.eof;
+voidPar = P.eof;
 numPar = P.index;

--- a/parsimmon/parsimmon.d.ts
+++ b/parsimmon/parsimmon.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Parsimmon 0.3.0
+// Type definitions for Parsimmon 0.4.0
 // Project: https://github.com/jayferd/parsimmon
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -24,6 +24,10 @@ declare module 'parsimmon' {
 			 */
 			or(otherParser: Parser<T>): Parser<T>;
 			or<U>(otherParser: Parser<U>): Parser<any>;
+			/*
+			 returns a new parser which tries parser, and on success calls the given function with the result of the parse, which is expected to return another parser, which will be tried next
+			 */
+			chain<U>(next: (result: T) => Parser<U>): Parser<U>;
 			/*
 			 returns a new parser which tries parser, and on success calls the given function with the result of the parse, which is expected to return another parser.
 			 */
@@ -65,9 +69,11 @@ declare module 'parsimmon' {
 			 */
 			atLeast(n: number): Parser<T[]>;
 			/*
-			 yields an object with start, value, and end keys, where value is the original value yielded by the parser, and start and end are the indices in the stream that contain the parsed text.
+			 returns a new parser whose failure message is the passed description.
 			 */
 			mark(): Parser<Mark<T>>;
+
+			desc(description: string): Parser<T>;
 		}
 		/*
 		 is a parser that expects to find "my-string", and will yield the same.
@@ -87,12 +93,20 @@ declare module 'parsimmon' {
 		/*
 		 accepts a variable number of parsers that it expects to find in order, yielding an array of the results.
 		 */
+		export function seq<U>(...parsers: Parser<U>[]): Parser<U[]>;
 		export function seq(...parsers: Parser<any>[]): Parser<any[]>;
+
+		/*
+		 accepts a variable number of parsers, and yields the value of the first one that succeeds, backtracking in between.
+		 */
+		export function alt<U>(...parsers: Parser<U>[]): Parser<U>;
+		export function alt(...parsers: Parser<any>[]): Parser<any>;
 
 		/*
 		 accepts a function that returns a parser, which is evaluated the first time the parser is used. This is useful for referencing parsers that haven't yet been defined.
 		 */
 		export function lazy<U>(f: () => Parser<U>): Parser<U>;
+		export function lazy<U>(description: string, f: () => Parser<U>): Parser<U>;
 
 		/*
 		 fail paring with a message
@@ -135,7 +149,7 @@ declare module 'parsimmon' {
 		/*
 		 expects the end of the stream.
 		 */
-		export var eof: Parser<string>;
+		export var eof: Parser<void>;
 		/*
 		 is a parser that yields the current index of the parse.
 		 */


### PR DESCRIPTION
Finally `parser.desc()` so I can fix DT's `definition-header` module reporting.. hurray.
