### PR TITLE
Declare purl as string literal

### DIFF
--- a/purl/purl.d.ts
+++ b/purl/purl.d.ts
@@ -48,3 +48,7 @@ declare function purl(): purl.Url;
  * @param someUrl the url to be parsed
  */
 declare function purl(someUrl: string): purl.Url;
+
+declare module "purl" {
+    export = purl;
+}


### PR DESCRIPTION
Declare purl as string literal so we can do ´import purl = require("purl")´.
