### PR TITLE
Augment min/max signature for non-numeric types

### DIFF
--- a/ix.js/l2o.d.ts
+++ b/ix.js/l2o.d.ts
@@ -54,8 +54,10 @@ declare module Ix {
 		some(predicate?: EnumerablePredicate<T>, thisArg?: any): boolean; // alias
 
 		average(selector?: EnumerableFunc<T, number>): number;
-		max(selector?: EnumerableFunc<T, number>): number;
-		min(selector?: EnumerableFunc<T, number>): number;
+		max(): T;
+	        max<TResult>(selector: EnumerableFunc<T, TResult>): TResult;
+	        min(): T;
+	        min<TResult>(selector: EnumerableFunc<T, TResult>): TResult;
 		sum(selector?: EnumerableFunc<T, number>): number;
 
 		concat<T>(...sources: Enumerable<T>[]): Enumerable<T>;


### PR DESCRIPTION
Made min/max signature generic to support non-numeric types, such as dates.
