### PR TITLE
universal-analytics: Argument order, overloads

### DIFF
--- a/universal-analytics/universal-analytics-test.ts
+++ b/universal-analytics/universal-analytics-test.ts
@@ -14,15 +14,15 @@ client = client.debug();
 client.send();
 
 client = client.pageview(str);
-client.pageview(str, (err:any) => {});
+client = client.pageview(str, (err:any) => {});
 client = client.pageview(params);
-client.pageview(params, (err:any) => {});
+client = client.pageview(params, (err:any) => {});
 client = client.pageview(str, str);
-client.pageview(str, str, (err:any) => {});
+client = client.pageview(str, str, (err:any) => {});
 client = client.pageview(str, str, str);
-client.pageview(str, str, str, (err:any) => {});
+client = client.pageview(str, str, str, (err:any) => {});
 client = client.pageview(str, str, str, params);
-client.pageview(str, str, str, params, (err:any) => {});
+client = client.pageview(str, str, str, params, (err:any) => {});
 
 
 client = client.event(str, str);

--- a/universal-analytics/universal-analytics-test.ts
+++ b/universal-analytics/universal-analytics-test.ts
@@ -1,6 +1,6 @@
 /// <reference path="universal-analytics.d.ts" />
 
-var ui:UniversalAnalytics;
+import ui = require('universal-analytics');
 
 var str:string;
 var num:number;

--- a/universal-analytics/universal-analytics-test.ts
+++ b/universal-analytics/universal-analytics-test.ts
@@ -21,6 +21,8 @@ client = client.pageview(str, str);
 client.pageview(str, str, (err:any) => {});
 client = client.pageview(str, str, str);
 client.pageview(str, str, str, (err:any) => {});
+client = client.pageview(str, str, str, params);
+client.pageview(str, str, str, params, (err:any) => {});
 
 
 client = client.event(str, str);

--- a/universal-analytics/universal-analytics.d.ts
+++ b/universal-analytics/universal-analytics.d.ts
@@ -20,8 +20,10 @@ declare module UniversalAnalytics {
         pageview(params:Object, callback?:(err:any) => void):void;
         pageview(path:string, hostname:string):Client;
         pageview(path:string, hostname:string, callback?:(err:any) => void):void;
-        pageview(path:string, title:string, hostname:string):Client;
-        pageview(path:string, title:string, hostname:string, callback?:(err:any) => void):void;
+        pageview(path:string, hostname:string, title:string):Client;
+        pageview(path:string, hostname:string, title:string, callback?:(err:any) => void):void;
+        pageview(path:string, hostname:string, title:string, params:Object):Client;
+        pageview(path:string, hostname:string, title:string, params:Object, callback?:(err:any) => void):void;
 
 
         event(category:string, action:string):Client;

--- a/universal-analytics/universal-analytics.d.ts
+++ b/universal-analytics/universal-analytics.d.ts
@@ -14,16 +14,11 @@ declare module UniversalAnalytics {
 
         send():void;
 
-        pageview(path:string):Client;
-        pageview(path:string, callback?:(err:any) => void):void;
-        pageview(params:Object):Client;
-        pageview(params:Object, callback?:(err:any) => void):void;
-        pageview(path:string, hostname:string):Client;
-        pageview(path:string, hostname:string, callback?:(err:any) => void):void;
-        pageview(path:string, hostname:string, title:string):Client;
-        pageview(path:string, hostname:string, title:string, callback?:(err:any) => void):void;
-        pageview(path:string, hostname:string, title:string, params:Object):Client;
-        pageview(path:string, hostname:string, title:string, params:Object, callback?:(err:any) => void):void;
+        pageview(params:Object, callback?:(err:any) => void):Client;
+        pageview(path:string, callback:(err:any) => void):Client;
+        pageview(path:string, hostname:string, callback:(err:any) => void):Client;
+        pageview(path:string, hostname:string, title:string, callback:(err:any) => void):Client;
+        pageview(path:string, hostname?:string, title?:string, params?:Object, callback?:(err:any) => void):Client;
 
 
         event(category:string, action:string):Client;

--- a/universal-analytics/universal-analytics.d.ts
+++ b/universal-analytics/universal-analytics.d.ts
@@ -3,10 +3,6 @@
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-interface UniversalAnalytics {
-    (accountID:string, uuid?:string, opts?:Object):UniversalAnalytics.Client;
-}
-
 declare module UniversalAnalytics {
 
     interface Client {
@@ -87,5 +83,6 @@ declare module UniversalAnalytics {
 }
 
 declare module 'universal-analytics' {
-export = UniversalAnalytics;
+    function universalAnalytics(accountID: string, uuid?: string, opts?: Object): UniversalAnalytics.Client;
+    export = universalAnalytics;
 }


### PR DESCRIPTION
Based on my reading of the [`pageview()` function](https://github.com/peaksandpies/universal-analytics/blob/master/lib/index.js#L96) it seems like the existing type definitions had `hostname` and `title` backwards in the parameters list (which is a trivial error since they have the same type).  Also, the function was missing a few overloads with the full list of parameters.
