### PR TITLE
Most return types should be JQuery

### DIFF
--- a/select2/select2.d.ts
+++ b/select2/select2.d.ts
@@ -113,35 +113,35 @@ interface JQuery {
     /**
     * Reverts changes to DOM done by Select2. Any selection done via Select2 will be preserved.
     */
-    select2(method: 'destroy'): void;
+    select2(method: 'destroy'): JQuery;
     /**
     * Opens the dropdown
     */
-    select2(method: 'open'): void;
+    select2(method: 'open'): JQuery;
     /**
     * Closes the dropdown
     */
-    select2(method: 'close'): void;
+    select2(method: 'close'): JQuery;
     /**
     * Enables or disables Select2 and its underlying form component
     * @param value True if it should be enabled false if it should be disabled
     */
-    select2(method: 'enable', value: boolean): void;
+    select2(method: 'enable', value: boolean): JQuery;
     /**
     * Toggles readonly mode on Select2 and its underlying form component
     * @param value True if it should be readonly false if it should be read write
     */
-    select2(method: 'readonly', value: boolean): void;
+    select2(method: 'readonly', value: boolean): JQuery;
     /**
     * Retrieves the main container element that wraps all of DOM added by Select2
     */
-    select2(method: 'container'): HTMLElement;
+    select2(method: 'container'): JQuery;
     /**
     * Notifies Select2 that a drag and drop sorting operation has started
     */
-    select2(method: 'onSortStart'): void;
+    select2(method: 'onSortStart'): JQuery;
     /**
     * Notifies Select2 that a drag and drop sorting operation has finished
     */
-    select2(method: 'onSortEnd'): void;
+    select2(method: 'onSortEnd'): JQuery;
 }


### PR DESCRIPTION
Since select2 is a JQuery plugin, it support chaining therefore the majority of methods return a JQuery object (typically the original JQuery object besides 'container' which returns the container element).
