### PR TITLE
angular: Add isolateScope() to jqLite

### DIFF
--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -223,6 +223,7 @@ foo.then((x) => {
 // angular.element() tests
 var element = angular.element("div.myApp");
 var scope: ng.IScope = element.scope();
+var isolateScope: ng.IScope = element.isolateScope();
 
 
 

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -969,6 +969,7 @@ declare module ng {
         controller(name: string): any;
         injector(): any;
         scope(): IScope;
+        isolateScope(): IScope;
 
         inheritedData(key: string, value: any): JQuery;
         inheritedData(obj: { [key: string]: any; }): JQuery;


### PR DESCRIPTION
This one method was missing from IAugmentedJQuery.  Pretty trivial stuff.
Docs: https://docs.angularjs.org/api/ng/function/angular.element#methods
