### PR TITLE
Add onCall(n) and friends to SinonStub definition

### DIFF
--- a/angular-ui/angular-ui-router-tests.ts
+++ b/angular-ui/angular-ui-router-tests.ts
@@ -13,6 +13,10 @@ myApp.config((
     $urlMatcherFactory: ng.ui.IUrlMatcherFactory) => {
 
   var matcher: ng.ui.IUrlMatcher = $urlMatcherFactory.compile("/foo/:bar?param1");
+  var obj: Object = matcher.exec('/user/bob', { x:'1', q:'hello' });
+  var concat: ng.ui.IUrlMatcher = matcher.concat('/test');
+  var str: string = matcher.format({ id:'bob', q:'yes' });
+  var arr: string[] = matcher.parameters();
   
   $urlRouterProvider
       .when('/test', '/list')

--- a/angular-ui/angular-ui-router.d.ts
+++ b/angular-ui/angular-ui-router.d.ts
@@ -33,13 +33,13 @@ declare module ng.ui {
     interface IUrlMatcher {
         concat(pattern: string): IUrlMatcher;
         exec(path: string, searchParams: {}): {};
+        parameters(): string[];
+        format(values: {}): string;
     }
 
     interface IUrlMatcherFactory {
         compile(pattern: string): IUrlMatcher;
         isMatcher(o: any): boolean;
-        parameters(): string[];
-        format(values: {}): string;
     }
 
     interface IUrlRouterProvider extends IServiceProvider {

--- a/sinon/sinon.d.ts
+++ b/sinon/sinon.d.ts
@@ -101,6 +101,10 @@ interface SinonStub extends SinonSpy {
 	callsArgOnAsync(index: number, context: any): SinonStub;
 	callsArgWithAsync(index: number, ...args: any[]): SinonStub;
 	callsArgOnWithAsync(index: number, context: any, ...args: any[]): SinonStub;
+	onCall(n: number): SinonStub;
+	onFirstCall(): SinonStub;
+	onSecondCall(): SinonStub;
+	onThirdCall(): SinonStub;
 	yields(...args: any[]): SinonStub;
 	yieldsOn(context: any, ...args: any[]): SinonStub;
 	yieldsTo(property: string, ...args: any[]): SinonStub;


### PR DESCRIPTION
These were added in Sinon 1.8, and the definition claims to be Sinon
1.8.1

From documentation:
"As of Sinon version 1.8, you can use the onCall method to make a stub
respond differently on consecutive calls."

http://sinonjs.org/docs/
