### PR TITLE
Extend custom bindings API definition

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -124,6 +124,7 @@ interface KnockoutBindingContext {
 }
 
 interface KnockoutBindingAccessor {
+    (): any;
     get(name: string): any;
     has(name: string): boolean;
 }

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -123,9 +123,14 @@ interface KnockoutBindingContext {
     createChildContext(dataItemOrAccessor: any, dataItemAlias?: any, extendCallback?: Function): any;
 }
 
+interface KnockoutBindingAccessor {
+    get(name: string): any;
+    has(name: string): boolean;
+}
+
 interface KnockoutBindingHandler {
-    init?(element: any, valueAccessor: () => any, allBindingsAccessor: () => any, viewModel: any, bindingContext: KnockoutBindingContext): void;
-    update?(element: any, valueAccessor: () => any, allBindingsAccessor: () => any, viewModel: any, bindingContext: KnockoutBindingContext): void;
+    init? (element: any, valueAccessor: () => any, allBindingsAccessor: KnockoutBindingAccessor, viewModel: any, bindingContext: KnockoutBindingContext): void;
+    update? (element: any, valueAccessor: () => any, allBindingsAccessor: KnockoutBindingAccessor, viewModel: any, bindingContext: KnockoutBindingContext): void;
     options?: any;
 }
 

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -123,15 +123,15 @@ interface KnockoutBindingContext {
     createChildContext(dataItemOrAccessor: any, dataItemAlias?: any, extendCallback?: Function): any;
 }
 
-interface KnockoutBindingAccessor {
+interface KnockoutAllBindingsAccessor {
     (): any;
     get(name: string): any;
     has(name: string): boolean;
 }
 
 interface KnockoutBindingHandler {
-    init? (element: any, valueAccessor: () => any, allBindingsAccessor: KnockoutBindingAccessor, viewModel: any, bindingContext: KnockoutBindingContext): void;
-    update? (element: any, valueAccessor: () => any, allBindingsAccessor: KnockoutBindingAccessor, viewModel: any, bindingContext: KnockoutBindingContext): void;
+    init? (element: any, valueAccessor: () => any, allBindingsAccessor: KnockoutAllBindingsAccessor, viewModel: any, bindingContext: KnockoutBindingContext): void;
+    update? (element: any, valueAccessor: () => any, allBindingsAccessor: KnockoutAllBindingsAccessor, viewModel: any, bindingContext: KnockoutBindingContext): void;
     options?: any;
 }
 

--- a/knockout/tests/knockout-tests.ts
+++ b/knockout/tests/knockout-tests.ts
@@ -591,11 +591,15 @@ function test_allBindingsAccessor() {
     ko.bindingHandlers.allBindingsAccessorTest = {
         init: (element: any, valueAccessor: () => any, allBindingsAccessor: KnockoutAllBindingsAccessor, viewModel: any, bindingContext: KnockoutBindingContext) => {
             var allBindings = allBindingsAccessor();
+            var hasBinding = allBindingsAccessor.has("myBindingName");
             var myBinding = allBindingsAccessor.get("myBindingName");
+            var fnAccessorBinding = allBindingsAccessor().myBindingName;
         },
         update: (element: any, valueAccessor: () => any, allBindingsAccessor: KnockoutAllBindingsAccessor, viewModel: any, bindingContext: KnockoutBindingContext) => {
             var allBindings = allBindingsAccessor();
+            var hasBinding = allBindingsAccessor.has("myBindingName");
             var myBinding = allBindingsAccessor.get("myBindingName");
+            var fnAccessorBinding = allBindingsAccessor().myBindingName;
         }
     };
 }


### PR DESCRIPTION
Add KnockoutBindingAccessor interface to extend custom bindings API definition accordingly to the [documentation](http://knockoutjs.com/documentation/custom-bindings.html).
