### PR TITLE
knockout.rx updated to v1.0

### DIFF
--- a/knockout.rx/knockout.rx.d.ts
+++ b/knockout.rx/knockout.rx.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for knockout.rx 0.1
+// Type definitions for knockout.rx 1.0
 // Project: https://github.com/Igorbek/knockout.rx
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -13,6 +13,7 @@ interface KnockoutSubscribableFunctions<T> {
 
 interface KnockoutObservableFunctions<T> {
 	toObservableWithReplyLatest(): Rx.Observable<T>;
+	toSubject(): Rx.ISubject<T>;
 }
 
 interface KnockoutComputedFunctions<T> {

--- a/knockout.rx/knockout.rx.d.ts
+++ b/knockout.rx/knockout.rx.d.ts
@@ -25,4 +25,8 @@ declare module Rx {
 		toKoSubscribable(): KnockoutSubscribable<T>;
 		toKoObservable(initialValue?: T): KnockoutObservable<T>;
 	}
+
+	interface Subject<T> {
+		toKoObservable(initialValue?: T): KnockoutObservable<T>;
+	}
 }


### PR DESCRIPTION
Added:
- `KnockoutObservable.toSubject`
- `Rx.Subject.toKoObservable`

By Igorbek/knockout.rx@c1f5a3a
