### PR TITLE
Added isPhone property from WinJS 2.1

### DIFF
--- a/winjs/winjs.d.ts
+++ b/winjs/winjs.d.ts
@@ -8314,6 +8314,11 @@ declare module WinJS.Utilities {
     **/
     var hasWinRT: boolean;
 
+	/**
+	 * Indicates whether the app is running on Windows Phone.
+	**/
+	var isPhone: boolean;
+
     //#endregion Properties
 
 	//#region Interfaces


### PR DESCRIPTION
Added WinJS 2.1 isPhone property to support WinJS 2.0 and WinJS 2.1 code
sharing in "Universal" Shared projects.

See http://msdn.microsoft.com/en-us/library/windows/apps/dn607959.aspx.
