### PR TITLE
flot: fixed type for gridOptions.borderWidth

### DIFF
--- a/flot/jquery.flot.d.ts
+++ b/flot/jquery.flot.d.ts
@@ -46,7 +46,7 @@ declare module jquery.flot {
         labelMargin?: number;
         axisMargin?: number;
         markings?: any;             //array of markings or (fn: axes -> array of markings)
-        borderWidth: number;
+        borderWidth?: any;          // number or width object
         borderColor?: any;          // color or null
         minBorderMargin?: number;       // or null
         clickable?: boolean;


### PR DESCRIPTION
According to [the API document](https://github.com/flot/flot/blob/master/API.md), gridOptions.borderWidth can be a number or an object.

> "borderWidth" is the width of the border around the plot. Set it to
> 0 to disable the border. Set it to an object with "top", "right",
> "bottom" and "left" properties to use different widths.

This pull request changes gridOptions.borderWidth to type any. 
And also this property is modified as optional property.
