### PR TITLE
Add definition for angular ngMock's IIntervalService#flush

### DIFF
--- a/angularjs/angular-mocks-tests.ts
+++ b/angularjs/angular-mocks-tests.ts
@@ -50,7 +50,7 @@ exceptionHandlerProvider.mode('log');
 
 
 ///////////////////////////////////////
-// IExceptionHandlerProvider
+// ITimeoutService
 ///////////////////////////////////////
 var timeoutService: ng.ITimeoutService;
 
@@ -60,6 +60,14 @@ timeoutService.flushNext();
 timeoutService.flushNext(1234);
 timeoutService.verifyNoPendingTasks();
 
+////////////////////////////////////////
+// IIntervalService
+////////////////////////////////////////
+var intervalService: ng.IIntervalService;
+var intervalServiceTimeActuallyAdvanced: number;
+
+intervalServiceTimeActuallyAdvanced = intervalService.flush();
+intervalServiceTimeActuallyAdvanced = intervalService.flush(1234);
 
 ///////////////////////////////////////
 // ILogService, ILogCall

--- a/angularjs/angular-mocks.d.ts
+++ b/angularjs/angular-mocks.d.ts
@@ -61,6 +61,15 @@ declare module ng {
         flushNext(expectedDelay?: number): void;
         verifyNoPendingTasks(): void;
     }
+    
+    ///////////////////////////////////////////////////////////////////////////
+    // IntervalService
+    // see http://docs.angularjs.org/api/ngMock.$interval
+    // Augments the original service
+    ///////////////////////////////////////////////////////////////////////////
+    interface IIntervalService {
+        flush(millis?: number): number;
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     // LogService


### PR DESCRIPTION
https://docs.angularjs.org/api/ngMock/service/$interval#flush had no definition, preventing my team writing a test. Added a definition for it.
