### PR TITLE
Added baseUrl method to Jquery Address

### DIFF
--- a/jquery.address/jquery.address.d.ts
+++ b/jquery.address/jquery.address.d.ts
@@ -17,7 +17,7 @@ interface JQueryAddressStatic {
     parameter(name: string, value?: string): string;
     value(): string;
     history(value: boolean): void;
-    baseUrl(): string;
+    baseURL(): string;
 }
 
 interface JQueryAddress {

--- a/jquery.address/jquery.address.d.ts
+++ b/jquery.address/jquery.address.d.ts
@@ -16,7 +16,8 @@ interface JQueryAddressStatic {
     externalChange(eventhandler: Function): void;
     parameter(name: string, value?: string): string;
     value(): string;
-    history(value: boolean): void;    
+    history(value: boolean): void;
+    baseUrl(): string;
 }
 
 interface JQueryAddress {


### PR DESCRIPTION
Jquery Address is missing a few static methods according to the documentation (http://www.asual.com/jquery/address/docs/).
