### PR TITLE
AngularJS Binding: Changed order of IHttpPromise.then for promise chaining

### DIFF
--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -220,6 +220,17 @@ foo.then((x) => {
 });
 
 
+var httpFoo: ng.IHttpPromise<number>;
+httpFoo.then((x) => {
+    // When returning a promise the generic type must be inferred.
+    var innerPromise : ng.IPromise<number>;
+    return innerPromise;
+}).then((x) => {
+    // must still be number.
+    x.toFixed();
+});
+
+
 // angular.element() tests
 var element = angular.element("div.myApp");
 var scope: ng.IScope = element.scope();

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -801,8 +801,8 @@ declare module ng {
     interface IHttpPromise<T> extends IPromise<T> {
         success(callback: IHttpPromiseCallback<T>): IHttpPromise<T>;
         error(callback: IHttpPromiseCallback<T>): IHttpPromise<T>;
-        then<TResult>(successCallback: (response: IHttpPromiseCallbackArg<T>) => TResult, errorCallback?: (response: IHttpPromiseCallbackArg<T>) => any): IPromise<TResult>;
         then<TResult>(successCallback: (response: IHttpPromiseCallbackArg<T>) => IPromise<TResult>, errorCallback?: (response: IHttpPromiseCallbackArg<T>) => any): IPromise<TResult>;
+        then<TResult>(successCallback: (response: IHttpPromiseCallbackArg<T>) => TResult, errorCallback?: (response: IHttpPromiseCallbackArg<T>) => any): IPromise<TResult>;
     }
 
     interface IHttpProvider extends IServiceProvider {


### PR DESCRIPTION
previously the following code resulted in tmp beeing of type:
`ng.IPromise<ng.IPromise<{}>>` but it should be just `ng.IPromise<{}>`:

```
var tmp = this.$http.get('').then((result) => this.$q.defer().promise);
```
