### PR TITLE
Added optional media constraints for WebRTC

### DIFF
--- a/webrtc/MediaStream-tests.ts
+++ b/webrtc/MediaStream-tests.ts
@@ -9,7 +9,7 @@ navigator.getUserMedia(mediaStreamConstraints,
 	stream => {
 		console.log('label:' + stream.label);
 		console.log('ended:' + stream.ended);
-		stream.onended = event => console.log('Stream ended');
+		stream.onended = (event:Event) => console.log('Stream ended');
 		var objectUrl = URL.createObjectURL(stream);
 		var wkObjectUrl = webkitURL.createObjectURL(stream);
 	},
@@ -22,7 +22,7 @@ navigator.webkitGetUserMedia(mediaStreamConstraints,
 	stream => {
 		console.log('label:' + stream.label);
 		console.log('ended:' + stream.ended);
-		stream.onended = event => console.log('Stream ended');
+		stream.onended = (event:Event) => console.log('Stream ended');
 		var objectUrl = URL.createObjectURL(stream);
 		var wkObjectUrl = webkitURL.createObjectURL(stream);
 	},

--- a/webrtc/MediaStream-tests.ts
+++ b/webrtc/MediaStream-tests.ts
@@ -6,27 +6,27 @@ var mediaTrackConstraintArray: MediaTrackConstraint[] = [];
 var mediaTrackConstraints: MediaTrackConstraints = { mandatory: mediaTrackConstraintSet, optional: mediaTrackConstraintArray }
 
 navigator.getUserMedia(mediaStreamConstraints,
-	stream => {
-		console.log('label:' + stream.label);
-		console.log('ended:' + stream.ended);
-		stream.onended = (event:Event) => console.log('Stream ended');
-		var objectUrl = URL.createObjectURL(stream);
-		var wkObjectUrl = webkitURL.createObjectURL(stream);
-	},
-	error => {
-		console.log('Error message: ' + error.message);
-		console.log('Error name: ' + error.name);
-	});
+  stream => {
+    console.log('label:' + stream.label);
+    console.log('ended:' + stream.ended);
+    stream.onended = (event:Event) => console.log('Stream ended');
+    var objectUrl = URL.createObjectURL(stream);
+    var wkObjectUrl = webkitURL.createObjectURL(stream);
+  },
+  error => {
+    console.log('Error message: ' + error.message);
+    console.log('Error name: ' + error.name);
+  });
 
 navigator.webkitGetUserMedia(mediaStreamConstraints,
-	stream => {
-		console.log('label:' + stream.label);
-		console.log('ended:' + stream.ended);
-		stream.onended = (event:Event) => console.log('Stream ended');
-		var objectUrl = URL.createObjectURL(stream);
-		var wkObjectUrl = webkitURL.createObjectURL(stream);
-	},
-	error => {
-		console.log('Error message: ' + error.message);
-		console.log('Error name: ' + error.name);
-	});
+  stream => {
+    console.log('label:' + stream.label);
+    console.log('ended:' + stream.ended);
+    stream.onended = (event:Event) => console.log('Stream ended');
+    var objectUrl = URL.createObjectURL(stream);
+    var wkObjectUrl = webkitURL.createObjectURL(stream);
+  },
+  error => {
+    console.log('Error message: ' + error.message);
+    console.log('Error name: ' + error.name);
+  });

--- a/webrtc/MediaStream.d.ts
+++ b/webrtc/MediaStream.d.ts
@@ -6,158 +6,158 @@
 // Taken from http://dev.w3.org/2011/webrtc/editor/getusermedia.html
 
 interface MediaStreamConstraints {
-	audio: any;
-	video: any;
+  audio: any;
+  video: any;
 }
 declare var MediaStreamConstraints: {
-	prototype: MediaStreamConstraints;
-	new (): MediaStreamConstraints;
+  prototype: MediaStreamConstraints;
+  new (): MediaStreamConstraints;
 }
 
 interface MediaTrackConstraints {
-	mandatory: MediaTrackConstraintSet;
-	optional: MediaTrackConstraint[];
+  mandatory: MediaTrackConstraintSet;
+  optional: MediaTrackConstraint[];
 }
 declare var MediaTrackConstraints: {
-	prototype: MediaTrackConstraints;
-	new (): MediaTrackConstraints;
+  prototype: MediaTrackConstraints;
+  new (): MediaTrackConstraints;
 }
 
 // ks - Not defined in the source doc.
 interface MediaTrackConstraintSet {
 }
 declare var MediaTrackConstraintSet: {
-	prototype: MediaTrackConstraintSet;
-	new (): MediaTrackConstraintSet;
+  prototype: MediaTrackConstraintSet;
+  new (): MediaTrackConstraintSet;
 }
 
 // ks - Not defined in the source doc.
 interface MediaTrackConstraint {
 }
 declare var MediaTrackConstraint: {
-	prototype: MediaTrackConstraint;
-	new (): MediaTrackConstraints;
+  prototype: MediaTrackConstraint;
+  new (): MediaTrackConstraints;
 }
 
 interface Navigator {
-	getUserMedia(constraints: MediaStreamConstraints,
-							 successCallback: (stream: any) => void,
-							 errorCallback: (error: Error) => void) : void;
-	webkitGetUserMedia(constraints: MediaStreamConstraints,
-										 successCallback: (stream: any) => void,
-										 errorCallback: (error: Error) => void): void;
+  getUserMedia(constraints: MediaStreamConstraints,
+               successCallback: (stream: any) => void,
+               errorCallback: (error: Error) => void) : void;
+  webkitGetUserMedia(constraints: MediaStreamConstraints,
+                     successCallback: (stream: any) => void,
+                     errorCallback: (error: Error) => void): void;
 }
 
 interface EventHandler { (event: Event): void; }
 
 interface NavigatorUserMediaSuccessCallback {
-	(stream: LocalMediaStream): void;
+  (stream: LocalMediaStream): void;
 }
 
 interface NavigatorUserMediaError {
-	PERMISSION_DENIED: number; // = 1;
-	code: number;
+  PERMISSION_DENIED: number; // = 1;
+  code: number;
 }
 declare var NavigatorUserMediaError: {
-	prototype: NavigatorUserMediaError;
-	new (): NavigatorUserMediaError;
-	PERMISSION_DENIED: number; // = 1;
+  prototype: NavigatorUserMediaError;
+  new (): NavigatorUserMediaError;
+  PERMISSION_DENIED: number; // = 1;
 }
 
 interface NavigatorUserMediaErrorCallback {
-	(error: NavigatorUserMediaError): void;
+  (error: NavigatorUserMediaError): void;
 }
 
 interface MediaStreamTrackList {
-	length: number;
-	item: MediaStreamTrack;
-	add(track: MediaStreamTrack): void;
-	remove(track: MediaStreamTrack): void;
-	onaddtrack: (event: Event) => void;
-	onremovetrack: (event: Event) => void;
+  length: number;
+  item: MediaStreamTrack;
+  add(track: MediaStreamTrack): void;
+  remove(track: MediaStreamTrack): void;
+  onaddtrack: (event: Event) => void;
+  onremovetrack: (event: Event) => void;
 }
 declare var MediaStreamTrackList: {
-	prototype: MediaStreamTrackList;
-	new (): MediaStreamTrackList;
+  prototype: MediaStreamTrackList;
+  new (): MediaStreamTrackList;
 }
 declare var webkitMediaStreamTrackList: {
-	prototype: MediaStreamTrackList;
-	new (): MediaStreamTrackList;
+  prototype: MediaStreamTrackList;
+  new (): MediaStreamTrackList;
 }
 
 interface MediaStream {
-	label: string;
-	id: string;
-	getAudioTracks(): MediaStreamTrackList;
-	getVideoTracks(): MediaStreamTrackList;
-	ended: boolean;
-	onended: (event: Event) => void;
+  label: string;
+  id: string;
+  getAudioTracks(): MediaStreamTrackList;
+  getVideoTracks(): MediaStreamTrackList;
+  ended: boolean;
+  onended: (event: Event) => void;
 }
 declare var MediaStream: {
-	prototype: MediaStream;
-	new (): MediaStream;
-	new (trackContainers: MediaStream[]): MediaStream;
-	new (trackContainers: MediaStreamTrackList[]): MediaStream;
-	new (trackContainers: MediaStreamTrack[]): MediaStream;
+  prototype: MediaStream;
+  new (): MediaStream;
+  new (trackContainers: MediaStream[]): MediaStream;
+  new (trackContainers: MediaStreamTrackList[]): MediaStream;
+  new (trackContainers: MediaStreamTrack[]): MediaStream;
 }
 declare var webkitMediaStream: {
-	prototype: MediaStream;
-	new (): MediaStream;
-	new (trackContainers: MediaStream[]): MediaStream;
-	new (trackContainers: MediaStreamTrackList[]): MediaStream;
-	new (trackContainers: MediaStreamTrack[]): MediaStream;
+  prototype: MediaStream;
+  new (): MediaStream;
+  new (trackContainers: MediaStream[]): MediaStream;
+  new (trackContainers: MediaStreamTrackList[]): MediaStream;
+  new (trackContainers: MediaStreamTrack[]): MediaStream;
 }
 
 // an - not defined in source doc.
 interface SourceInfo {
-	label: string;
-	id: string;
-	kind: string;
-	facing: string;
+  label: string;
+  id: string;
+  kind: string;
+  facing: string;
 }
 declare var SourceInfo: {
-	prototype: SourceInfo;
+  prototype: SourceInfo;
 }
 
 interface LocalMediaStream extends MediaStream {
-	stop(): void;
+  stop(): void;
 }
 
 interface MediaStreamTrack {
-	kind: string;
-	label: string;
-	enabled: boolean;
-	LIVE: number; // = 0;
-	MUTED: number; // = 1;
-	ENDED: number; // = 2;
-	readyState: number;
-	onmute: (event: Event) => void;
-	onunmute: (event: Event) => void;
-	onended: (event: Event) => void;
+  kind: string;
+  label: string;
+  enabled: boolean;
+  LIVE: number; // = 0;
+  MUTED: number; // = 1;
+  ENDED: number; // = 2;
+  readyState: number;
+  onmute: (event: Event) => void;
+  onunmute: (event: Event) => void;
+  onended: (event: Event) => void;
 }
 declare var MediaStreamTrack: {
-	prototype: MediaStreamTrack;
-	new (): MediaStreamTrack;
-	LIVE: number; // = 0;
-	MUTED: number; // = 1;
-	ENDED: number; // = 2;
-	getSources: (callback: (sources: SourceInfo[]) => void) => void;
+  prototype: MediaStreamTrack;
+  new (): MediaStreamTrack;
+  LIVE: number; // = 0;
+  MUTED: number; // = 1;
+  ENDED: number; // = 2;
+  getSources: (callback: (sources: SourceInfo[]) => void) => void;
 }
 
 interface streamURL extends URL {
-	createObjectURL(stream: MediaStream): string;
+  createObjectURL(stream: MediaStream): string;
 }
 //declare var URL: {
-//	prototype: MediaStreamTrack;
-//	new (): URL;
-//	createObjectURL(stream: MediaStream): string;
+//  prototype: MediaStreamTrack;
+//  new (): URL;
+//  createObjectURL(stream: MediaStream): string;
 //}
 
 interface WebkitURL extends streamURL {
 }
 declare var webkitURL: {
-	prototype: WebkitURL;
-	new (): streamURL;
-	createObjectURL(stream: MediaStream): string;
+  prototype: WebkitURL;
+  new (): streamURL;
+  createObjectURL(stream: MediaStream): string;
 }
 

--- a/webrtc/MediaStream.d.ts
+++ b/webrtc/MediaStream.d.ts
@@ -40,13 +40,19 @@ declare var MediaTrackConstraint: {
 }
 
 interface Navigator {
-	getUserMedia(constraints: MediaStreamConstraints, successCallback: (stream: any) => void, errorCallback: (error: Error) => void);
-	webkitGetUserMedia(constraints: MediaStreamConstraints, successCallback: (stream: any) => void, errorCallback: (error: Error) => void);
+	getUserMedia(constraints: MediaStreamConstraints,
+							 successCallback: (stream: any) => void,
+							 errorCallback: (error: Error) => void) : void;
+	webkitGetUserMedia(constraints: MediaStreamConstraints,
+										 successCallback: (stream: any) => void,
+										 errorCallback: (error: Error) => void): void;
 }
 
 interface EventHandler { (event: Event): void; }
 
-interface NavigatorUserMediaSuccessCallback { (stream: LocalMediaStream): void; }
+interface NavigatorUserMediaSuccessCallback {
+	(stream: LocalMediaStream): void;
+}
 
 interface NavigatorUserMediaError {
 	PERMISSION_DENIED: number; // = 1;
@@ -58,7 +64,9 @@ declare var NavigatorUserMediaError: {
 	PERMISSION_DENIED: number; // = 1;
 }
 
-interface NavigatorUserMediaErrorCallback { (error: NavigatorUserMediaError): void; }
+interface NavigatorUserMediaErrorCallback {
+	(error: NavigatorUserMediaError): void;
+}
 
 interface MediaStreamTrackList {
 	length: number;
@@ -152,4 +160,4 @@ declare var webkitURL: {
 	new (): streamURL;
 	createObjectURL(stream: MediaStream): string;
 }
- 
+

--- a/webrtc/RTCPeerConnection-tests.ts
+++ b/webrtc/RTCPeerConnection-tests.ts
@@ -7,13 +7,13 @@ var constraints: MediaConstraints = { mandatory: { OfferToReceiveAudio: true, Of
 var peerConnection: RTCPeerConnection = new RTCPeerConnection(config, constraints);
 
 navigator.getUserMedia({ audio: true, video: true },
-	stream => {
-		peerConnection.addStream(stream);
-	},
-	error => {
-		console.log('Error message: ' + error.message);
-		console.log('Error name: ' + error.name);
-	});
+  stream => {
+    peerConnection.addStream(stream);
+  },
+  error => {
+    console.log('Error message: ' + error.message);
+    console.log('Error name: ' + error.name);
+  });
 
 peerConnection.onaddstream = ev => console.log(ev.type);
 peerConnection.ondatachannel = ev => console.log(ev.type);
@@ -25,25 +25,25 @@ peerConnection.onremovestream = ev => console.log(ev.type);
 peerConnection.onstatechange = ev => console.log(ev.type);
 
 peerConnection.createOffer(
-	offer => {
-		peerConnection.setLocalDescription(offer,
-			() => console.log("set local description"),
-			error => console.log("Error setting local description: " + error));
-	},
-	error => console.log("Error creating offer: " + error));
+  offer => {
+    peerConnection.setLocalDescription(offer,
+      () => console.log("set local description"),
+      error => console.log("Error setting local description: " + error));
+  },
+  error => console.log("Error creating offer: " + error));
 
 var type: string = RTCSdpType[RTCSdpType.offer];
 var offer: RTCSessionDescriptionInit = { type: type, sdp: "some sdp" };
 var sessionDescription = new RTCSessionDescription(offer);
 
 peerConnection.setRemoteDescription(sessionDescription, () => {
-	peerConnection.createAnswer(
-		answer => {
-			peerConnection.setLocalDescription(answer,
-				() => console.log('Set local description'),
-			error => console.log("Error setting local description from created answer: " + error + "; answer.sdp=" + answer.sdp));
-		},
-	error => console.log("Error creating answer: " + error));
+  peerConnection.createAnswer(
+    answer => {
+      peerConnection.setLocalDescription(answer,
+        () => console.log('Set local description'),
+      error => console.log("Error setting local description from created answer: " + error + "; answer.sdp=" + answer.sdp));
+    },
+  error => console.log("Error creating answer: " + error));
 },
 error => console.log('Error setting remote description: ' + error + "; offer.sdp=" + offer.sdp));
 

--- a/webrtc/RTCPeerConnection-tests.ts
+++ b/webrtc/RTCPeerConnection-tests.ts
@@ -1,10 +1,13 @@
 ﻿/// <reference path="MediaStream.d.ts" />
 /// <reference path="RTCPeerConnection.d.ts" />
 
-var config: RTCConfiguration = { iceServers: [{ url: "stun.l.google.com:19302" }] };
-var constraints: MediaConstraints = { mandatory: { OfferToReceiveAudio: true, OfferToReceiveVideo: true } };
+var config: RTCConfiguration =
+    { iceServers: [{ url: "stun.l.google.com:19302" }] };
+var constraints: RTCMediaConstraints =
+    { mandatory: { OfferToReceiveAudio: true, OfferToReceiveVideo: true } };
 
-var peerConnection: RTCPeerConnection = new RTCPeerConnection(config, constraints);
+var peerConnection: RTCPeerConnection =
+    new RTCPeerConnection(config, constraints);
 
 navigator.getUserMedia({ audio: true, video: true },
   stream => {
@@ -41,11 +44,15 @@ peerConnection.setRemoteDescription(sessionDescription, () => {
     answer => {
       peerConnection.setLocalDescription(answer,
         () => console.log('Set local description'),
-      error => console.log("Error setting local description from created answer: " + error + "; answer.sdp=" + answer.sdp));
+      error => console.log(
+          "Error setting local description from created answer: " + error +
+          "; answer.sdp=" + answer.sdp));
     },
   error => console.log("Error creating answer: " + error));
 },
-error => console.log('Error setting remote description: ' + error + "; offer.sdp=" + offer.sdp));
+error => console.log('Error setting remote description: ' + error +
+    "; offer.sdp=" + offer.sdp));
 
-var wkPeerConnection: webkitRTCPeerConnection = new webkitRTCPeerConnection(config, constraints);
+var wkPeerConnection: webkitRTCPeerConnection =
+    new webkitRTCPeerConnection(config, constraints);
 

--- a/webrtc/RTCPeerConnection-tests.ts
+++ b/webrtc/RTCPeerConnection-tests.ts
@@ -32,7 +32,7 @@ peerConnection.createOffer(
 	},
 	error => console.log("Error creating offer: " + error));
 
-var type: RTCSdpType = RTCSdpType.offer;
+var type: string = RTCSdpType[RTCSdpType.offer];
 var offer: RTCSessionDescriptionInit = { type: type, sdp: "some sdp" };
 var sessionDescription = new RTCSessionDescription(offer);
 

--- a/webrtc/RTCPeerConnection.d.ts
+++ b/webrtc/RTCPeerConnection.d.ts
@@ -43,7 +43,7 @@ interface mozRTCPeerConnection extends RTCPeerConnection {
 declare var mozRTCPeerConnection: {
   prototype: mozRTCPeerConnection;
   new (settings: RTCPeerConnectionConfig,
-       constraints?:MediaConstraints): mozRTCPeerConnection;
+       constraints?:RTCMediaConstraints): mozRTCPeerConnection;
 }
 // webkit (Chrome) specific prefixes.
 interface webkitRTCPeerConnection extends RTCPeerConnection {
@@ -51,12 +51,12 @@ interface webkitRTCPeerConnection extends RTCPeerConnection {
 declare var webkitRTCPeerConnection: {
   prototype: webkitRTCPeerConnection;
   new (settings: RTCPeerConnectionConfig,
-       constraints?:MediaConstraints): webkitRTCPeerConnection;
+       constraints?:RTCMediaConstraints): webkitRTCPeerConnection;
 }
 
 // For Chrome, look at the code here:
 // https://code.google.com/p/chromium/codesearch#chromium/src/third_party/libjingle/source/talk/app/webrtc/webrtcsession.cc&sq=package:chromium&dr=C&l=63
-interface OptionalMediaConstraint {
+interface RTCOptionalMediaConstraint {
   // When true, will use DTLS/SCTP data channels
   DtlsSrtpKeyAgreement?: boolean;
   // When true will use Rtp-based data channels (depreicated)
@@ -65,12 +65,12 @@ interface OptionalMediaConstraint {
 
 // ks 12/20/12 - There's more here that doesn't seem to be documented very well yet.
 // http://www.w3.org/TR/2013/WD-webrtc-20130910/
-interface MediaConstraints {
-  mandatory?: MediaOfferConstraints;
-  optional?: OptionalMediaConstraint[]
+interface RTCMediaConstraints {
+  mandatory?: RTCMediaOfferConstraints;
+  optional?: RTCOptionalMediaConstraint[]
 }
 
-interface MediaOfferConstraints {
+interface RTCMediaOfferConstraints {
   OfferToReceiveAudio: boolean;
   OfferToReceiveVideo: boolean;
 }
@@ -215,10 +215,10 @@ declare enum RTCSignalingState {
 interface RTCPeerConnection {
   createOffer(successCallback: RTCSessionDescriptionCallback,
               failureCallback?: RTCPeerConnectionErrorCallback,
-              constraints?: MediaConstraints): void;
+              constraints?: RTCMediaConstraints): void;
   createAnswer(successCallback: RTCSessionDescriptionCallback,
                failureCallback?: RTCPeerConnectionErrorCallback,
-               constraints?: MediaConstraints): void;
+               constraints?: RTCMediaConstraints): void;
   setLocalDescription(description: RTCSessionDescription,
                       successCallback?: RTCVoidCallback,
                       failureCallback?: RTCPeerConnectionErrorCallback): void;
@@ -229,7 +229,7 @@ interface RTCPeerConnection {
   remoteDescription: RTCSessionDescription;
   signalingState: string; // RTCSignalingState; see TODO(1)
   updateIce(configuration?: RTCConfiguration,
-            constraints?: MediaConstraints): void;
+            constraints?: RTCMediaConstraints): void;
   addIceCandidate(candidate: RTCIceCandidate): void;
   iceGatheringState: string;  // RTCIceGatheringState; see TODO(1)
   iceConnectionState: string;  // RTCIceConnectionState; see TODO(1)
@@ -238,7 +238,7 @@ interface RTCPeerConnection {
   createDataChannel(label?: string,
                     dataChannelDict?: RTCDataChannelInit): RTCDataChannel;
   ondatachannel: (event: Event) => void;
-  addStream(stream: MediaStream, constraints?: MediaConstraints): void;
+  addStream(stream: MediaStream, constraints?: RTCMediaConstraints): void;
   removeStream(stream: MediaStream): void;
   close(): void;
   onnegotiationneeded: (event: Event) => void;
@@ -255,7 +255,7 @@ interface RTCPeerConnection {
 declare var RTCPeerConnection: {
   prototype: RTCPeerConnection;
   new (configuration: RTCConfiguration,
-       constraints?: MediaConstraints): RTCPeerConnection;
+       constraints?: RTCMediaConstraints): RTCPeerConnection;
 }
 
 interface RTCIceCandidate {

--- a/webrtc/RTCPeerConnection.d.ts
+++ b/webrtc/RTCPeerConnection.d.ts
@@ -11,7 +11,7 @@
 // For a generic implementation see that deals with browser differences, see:
 //   https://code.google.com/p/webrtc/source/browse/stable/samples/js/base/adapter.js
 
-/// <reference path="MediaStream.d.ts" />
+/// <reference path='MediaStream.d.ts' />
 
 // TODO(1): Get Typescript to have string-enum types as WebRtc is full of string
 // enums.
@@ -19,9 +19,6 @@
 
 // TODO(2): get Typescript to have union types as WebRtc uses them.
 // https://typescript.codeplex.com/workitem/1364
-
-// TODO(3): Typescript type-abbreviations fail to be structural.
-// https://typescript.codeplex.com/workitem/2587
 
 interface RTCConfiguration {
 	iceServers: RTCIceServer[];
@@ -45,17 +42,20 @@ interface mozRTCPeerConnection extends RTCPeerConnection {
 }
 declare var mozRTCPeerConnection: {
 	prototype: mozRTCPeerConnection;
-	new (settings: RTCPeerConnectionConfig, constraints?:MediaConstraints): mozRTCPeerConnection;
+	new (settings: RTCPeerConnectionConfig,
+			 constraints?:MediaConstraints): mozRTCPeerConnection;
 }
 // webkit (Chrome) specific prefixes.
 interface webkitRTCPeerConnection extends RTCPeerConnection {
 }
 declare var webkitRTCPeerConnection: {
 	prototype: webkitRTCPeerConnection;
-	new (settings: RTCPeerConnectionConfig, constraints?:MediaConstraints): webkitRTCPeerConnection;
+	new (settings: RTCPeerConnectionConfig,
+			 constraints?:MediaConstraints): webkitRTCPeerConnection;
 }
 
-// For Chrome, look at the code here: https://code.google.com/p/chromium/codesearch#chromium/src/third_party/libjingle/source/talk/app/webrtc/webrtcsession.cc&sq=package:chromium&dr=C&l=63
+// For Chrome, look at the code here:
+// https://code.google.com/p/chromium/codesearch#chromium/src/third_party/libjingle/source/talk/app/webrtc/webrtcsession.cc&sq=package:chromium&dr=C&l=63
 interface OptionalMediaConstraint {
 	// When true, will use DTLS/SCTP data channels
 	DtlsSrtpKeyAgreement?: boolean;
@@ -75,22 +75,20 @@ interface MediaOfferConstraints {
 	OfferToReceiveVideo: boolean;
 }
 
+interface RTCSessionDescriptionInit {
+	type: string;  // RTCSdpType; See TODO(1)
+	sdp: string;
+}
+
 interface RTCSessionDescription {
-	type?: string;  // RTCSdpType; See TODO(3)
+	type?: string;  // RTCSdpType; See TODO(1)
 	sdp?: string;
 }
 declare var RTCSessionDescription: {
 	prototype: RTCSessionDescription;
 	new (descriptionInitDict?: RTCSessionDescriptionInit): RTCSessionDescription;
-}
-
-interface RTCSessionDescriptionInit {
-	type: string;  // RTCSdpType; See TODO(3)
-	sdp: string;
-}
-declare var RTCSessionDescriptionInit: {
-	prototype: RTCSessionDescriptionInit;
-	new (): RTCSessionDescriptionInit;
+	// TODO: Add serializer.
+	// See: http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCSdpType)
 }
 
 interface RTCDataChannelInit {
@@ -102,14 +100,12 @@ interface RTCDataChannelInit {
   id                  ?: number;  // unsigned short
 }
 
-interface RTCSdpType {
-	// http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcsdptype
-	// enum RTCSdpType {
-	//     "offer",
-	//     "pranswer",
-	//     "answer"
-	// };
-	string;
+// TODO(1)
+declare enum RTCSdpType {
+  // http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcsdptype
+  'offer',
+  'pranswer',
+  'answer'
 }
 
 interface RTCMessageEvent {
@@ -119,32 +115,33 @@ interface RTCMessageEvent {
 	data: any;
 }
 
-interface RTCDataChannelState {
+// TODO(1)
+declare enum RTCDataChannelState {
 	// http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCDataChannelState
-	// enum RTCDataChannelState {
-	//     "connecting",
-	//     "open",
-	//     "closing",
-	//     "closed"
-	// };
-	string;
+	'connecting',
+	'open',
+	'closing',
+	'closed'
 }
 
 interface RTCDataChannel extends EventTarget {
 	label: string;
 	reliable: boolean;
-	readyState: string; // RTCDataChannelState; see TODO(3)
+	readyState: string; // RTCDataChannelState; see TODO(1)
 	bufferedAmount: number;
+	binaryType: string;
+
 	onopen: (event: Event) => void;
 	onerror: (event: Event) => void;
 	onclose: (event: Event) => void;
-	close(): void;
 	onmessage: (event: RTCMessageEvent) => void;
-	binaryType: string;
-	send(data: string);
-	send(data: ArrayBuffer);
-	send(data: ArrayBufferView);
-	send(data: Blob);
+
+	close(): void;
+
+	send(data: string): void ;
+	send(data: ArrayBuffer): void;
+	send(data: ArrayBufferView): void;
+	send(data: Blob): void;
 }
 declare var RTCDataChannel: {
 	prototype: RTCDataChannel;
@@ -152,12 +149,11 @@ declare var RTCDataChannel: {
 }
 
 interface RTCDataChannelEvent extends Event {
-	constructor (eventInitDict: RTCDataChannelEventInit);
 	channel: RTCDataChannel;
 }
 declare var RTCDataChannelEvent: {
 	prototype: RTCDataChannelEvent;
-	new (eventInitDict: RTCDataChannelEventInit);
+	new (eventInitDict: RTCDataChannelEventInit): RTCDataChannelEvent;
 }
 
 interface RTCIceCandidateEvent extends Event {
@@ -185,58 +181,62 @@ interface RTCPeerConnectionErrorCallback {
 	(errorInformation: DOMError): void;
 }
 
-interface RTCIceGatheringState {
+// TODO(1)
+declare enum RTCIceGatheringState {
 	// http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicegatheringstate-enum
-	// enum RTCIceGatheringState {
-	//     "new",
-	//     "gathering",
-	//     "complete"
-	// };
-	string;
+	'new',
+	'gathering',
+	'complete'
 }
 
-interface RTCIceConnectionState {
+// TODO(1)
+declare enum RTCIceConnectionState {
 	// http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCIceConnectionState
-	// enum RTCIceConnectionState {
-	//     "new",
-	//     "checking",
-	//     "connected",
-	//     "completed",
-	//     "failed",
-	//     "disconnected",
-	//     "closed"
-	// };
-	string;
+  'new',
+  'checking',
+  'connected',
+  'completed',
+  'failed',
+  'disconnected',
+  'closed'
 }
 
-interface RTCSignalingState {
-	// http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCSignalingState
-	// enum RTCSignalingState {
-	//     "stable",
-	//     "have-local-offer",
-	//     "have-remote-offer",
-	//     "have-local-pranswer",
-	//     "have-remote-pranswer",
-	//     "closed"
-	// };
-	string;
+// TODO(1)
+declare enum RTCSignalingState {
+  // http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCSignalingState
+  'stable',
+  'have-local-offer',
+  'have-remote-offer',
+  'have-local-pranswer',
+  'have-remote-pranswer',
+  'closed'
 }
 
 interface RTCPeerConnection {
-	createOffer(successCallback: RTCSessionDescriptionCallback, failureCallback?: RTCPeerConnectionErrorCallback, constraints?: MediaConstraints): void;
-	createAnswer(successCallback: RTCSessionDescriptionCallback, failureCallback?: RTCPeerConnectionErrorCallback, constraints?: MediaConstraints): void;
-	setLocalDescription(description: RTCSessionDescription, successCallback?: RTCVoidCallback, failureCallback?: RTCPeerConnectionErrorCallback): void;
+	createOffer(successCallback: RTCSessionDescriptionCallback,
+							failureCallback?: RTCPeerConnectionErrorCallback,
+							constraints?: MediaConstraints): void;
+	createAnswer(successCallback: RTCSessionDescriptionCallback,
+							 failureCallback?: RTCPeerConnectionErrorCallback,
+							 constraints?: MediaConstraints): void;
+	setLocalDescription(description: RTCSessionDescription,
+											successCallback?: RTCVoidCallback,
+											failureCallback?: RTCPeerConnectionErrorCallback): void;
 	localDescription: RTCSessionDescription;
-	setRemoteDescription(description: RTCSessionDescription, successCallback?: RTCVoidCallback, failureCallback?: RTCPeerConnectionErrorCallback): void;
+	setRemoteDescription(description: RTCSessionDescription,
+		 									 successCallback?: RTCVoidCallback,
+		 									 failureCallback?: RTCPeerConnectionErrorCallback): void;
 	remoteDescription: RTCSessionDescription;
-	signalingState: string; // RTCSignalingState; see TODO(3)
-	updateIce(configuration?: RTCConfiguration, constraints?: MediaConstraints): void;
+	signalingState: string; // RTCSignalingState; see TODO(1)
+	updateIce(configuration?: RTCConfiguration,
+						constraints?: MediaConstraints): void;
 	addIceCandidate(candidate: RTCIceCandidate): void;
-	iceGatheringState: string;  // RTCIceGatheringState; see TODO(3)
-	iceConnectionState: string;  // RTCIceConnectionState; see TODO(3)
+	iceGatheringState: string;  // RTCIceGatheringState; see TODO(1)
+	iceConnectionState: string;  // RTCIceConnectionState; see TODO(1)
 	getLocalStreams(): MediaStream[];
 	getRemoteStreams(): MediaStream[];
-	createDataChannel(label?: string, dataChannelDict?: RTCDataChannelInit): RTCDataChannel;
+	createDataChannel(label?: string,
+										dataChannelDict?: RTCDataChannelInit): RTCDataChannel;
 	ondatachannel: (event: Event) => void;
 	addStream(stream: MediaStream, constraints?: MediaConstraints): void;
 	removeStream(stream: MediaStream): void;
@@ -254,7 +254,8 @@ interface RTCPeerConnection {
 }
 declare var RTCPeerConnection: {
 	prototype: RTCPeerConnection;
-	new (configuration: RTCConfiguration, constraints?: MediaConstraints): RTCPeerConnection;
+	new (configuration: RTCConfiguration,
+			 constraints?: MediaConstraints): RTCPeerConnection;
 }
 
 interface RTCIceCandidate {
@@ -264,7 +265,7 @@ interface RTCIceCandidate {
 }
 declare var RTCIceCandidate: {
 	prototype: RTCIceCandidate;
-	new (candidateInitDict?: RTCIceCandidate);
+	new (candidateInitDict?: RTCIceCandidate): RTCIceCandidate;
 }
 
 interface RTCIceCandidateInit {

--- a/webrtc/RTCPeerConnection.d.ts
+++ b/webrtc/RTCPeerConnection.d.ts
@@ -21,78 +21,78 @@
 // https://typescript.codeplex.com/workitem/1364
 
 interface RTCConfiguration {
-	iceServers: RTCIceServer[];
+  iceServers: RTCIceServer[];
 }
 declare var RTCConfiguration: {
-	prototype: RTCConfiguration;
-	new (): RTCConfiguration;
+  prototype: RTCConfiguration;
+  new (): RTCConfiguration;
 }
 
 interface RTCIceServer {
-	url: string;
-	credential?: string;
+  url: string;
+  credential?: string;
 }
 declare var RTCIceServer: {
-	prototype: RTCIceServer;
-	new (): RTCIceServer;
+  prototype: RTCIceServer;
+  new (): RTCIceServer;
 }
 
 // moz (Firefox) specific prefixes.
 interface mozRTCPeerConnection extends RTCPeerConnection {
 }
 declare var mozRTCPeerConnection: {
-	prototype: mozRTCPeerConnection;
-	new (settings: RTCPeerConnectionConfig,
-			 constraints?:MediaConstraints): mozRTCPeerConnection;
+  prototype: mozRTCPeerConnection;
+  new (settings: RTCPeerConnectionConfig,
+       constraints?:MediaConstraints): mozRTCPeerConnection;
 }
 // webkit (Chrome) specific prefixes.
 interface webkitRTCPeerConnection extends RTCPeerConnection {
 }
 declare var webkitRTCPeerConnection: {
-	prototype: webkitRTCPeerConnection;
-	new (settings: RTCPeerConnectionConfig,
-			 constraints?:MediaConstraints): webkitRTCPeerConnection;
+  prototype: webkitRTCPeerConnection;
+  new (settings: RTCPeerConnectionConfig,
+       constraints?:MediaConstraints): webkitRTCPeerConnection;
 }
 
 // For Chrome, look at the code here:
 // https://code.google.com/p/chromium/codesearch#chromium/src/third_party/libjingle/source/talk/app/webrtc/webrtcsession.cc&sq=package:chromium&dr=C&l=63
 interface OptionalMediaConstraint {
-	// When true, will use DTLS/SCTP data channels
-	DtlsSrtpKeyAgreement?: boolean;
-	// When true will use Rtp-based data channels (depreicated)
-	RtpDataChannels?: boolean;
+  // When true, will use DTLS/SCTP data channels
+  DtlsSrtpKeyAgreement?: boolean;
+  // When true will use Rtp-based data channels (depreicated)
+  RtpDataChannels?: boolean;
 }
 
 // ks 12/20/12 - There's more here that doesn't seem to be documented very well yet.
 // http://www.w3.org/TR/2013/WD-webrtc-20130910/
 interface MediaConstraints {
-	mandatory?: MediaOfferConstraints;
-	optional?: OptionalMediaConstraint[]
+  mandatory?: MediaOfferConstraints;
+  optional?: OptionalMediaConstraint[]
 }
 
 interface MediaOfferConstraints {
-	OfferToReceiveAudio: boolean;
-	OfferToReceiveVideo: boolean;
+  OfferToReceiveAudio: boolean;
+  OfferToReceiveVideo: boolean;
 }
 
 interface RTCSessionDescriptionInit {
-	type: string;  // RTCSdpType; See TODO(1)
-	sdp: string;
+  type: string;  // RTCSdpType; See TODO(1)
+  sdp: string;
 }
 
 interface RTCSessionDescription {
-	type?: string;  // RTCSdpType; See TODO(1)
-	sdp?: string;
+  type?: string;  // RTCSdpType; See TODO(1)
+  sdp?: string;
 }
 declare var RTCSessionDescription: {
-	prototype: RTCSessionDescription;
-	new (descriptionInitDict?: RTCSessionDescriptionInit): RTCSessionDescription;
-	// TODO: Add serializer.
-	// See: http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCSdpType)
+  prototype: RTCSessionDescription;
+  new (descriptionInitDict?: RTCSessionDescriptionInit): RTCSessionDescription;
+  // TODO: Add serializer.
+  // See: http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCSdpType)
 }
 
 interface RTCDataChannelInit {
-	ordered             ?: boolean; // messages must be sent in-order.
+  ordered             ?: boolean; // messages must be sent in-order.
   maxPacketLifeTime   ?: number;  // unsigned short
   maxRetransmits      ?: number;  // unsigned short
   protocol            ?: string;  // default = ''
@@ -109,89 +109,89 @@ declare enum RTCSdpType {
 }
 
 interface RTCMessageEvent {
-	// http://dev.w3.org/2011/webrtc/editor/webrtc.html#event-datachannel-message
-	// At present, this can be an: ArrayBuffer, a string, or a Blob.
-	// See TODO(2)
-	data: any;
+  // http://dev.w3.org/2011/webrtc/editor/webrtc.html#event-datachannel-message
+  // At present, this can be an: ArrayBuffer, a string, or a Blob.
+  // See TODO(2)
+  data: any;
 }
 
 // TODO(1)
 declare enum RTCDataChannelState {
-	// http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCDataChannelState
-	'connecting',
-	'open',
-	'closing',
-	'closed'
+  // http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCDataChannelState
+  'connecting',
+  'open',
+  'closing',
+  'closed'
 }
 
 interface RTCDataChannel extends EventTarget {
-	label: string;
-	reliable: boolean;
-	readyState: string; // RTCDataChannelState; see TODO(1)
-	bufferedAmount: number;
-	binaryType: string;
+  label: string;
+  reliable: boolean;
+  readyState: string; // RTCDataChannelState; see TODO(1)
+  bufferedAmount: number;
+  binaryType: string;
 
-	onopen: (event: Event) => void;
-	onerror: (event: Event) => void;
-	onclose: (event: Event) => void;
-	onmessage: (event: RTCMessageEvent) => void;
+  onopen: (event: Event) => void;
+  onerror: (event: Event) => void;
+  onclose: (event: Event) => void;
+  onmessage: (event: RTCMessageEvent) => void;
 
-	close(): void;
+  close(): void;
 
-	send(data: string): void ;
-	send(data: ArrayBuffer): void;
-	send(data: ArrayBufferView): void;
-	send(data: Blob): void;
+  send(data: string): void ;
+  send(data: ArrayBuffer): void;
+  send(data: ArrayBufferView): void;
+  send(data: Blob): void;
 }
 declare var RTCDataChannel: {
-	prototype: RTCDataChannel;
-	new (): RTCDataChannel;
+  prototype: RTCDataChannel;
+  new (): RTCDataChannel;
 }
 
 interface RTCDataChannelEvent extends Event {
-	channel: RTCDataChannel;
+  channel: RTCDataChannel;
 }
 declare var RTCDataChannelEvent: {
-	prototype: RTCDataChannelEvent;
-	new (eventInitDict: RTCDataChannelEventInit): RTCDataChannelEvent;
+  prototype: RTCDataChannelEvent;
+  new (eventInitDict: RTCDataChannelEventInit): RTCDataChannelEvent;
 }
 
 interface RTCIceCandidateEvent extends Event {
-	candidate: RTCIceCandidate;
+  candidate: RTCIceCandidate;
 }
 
 interface RTCMediaStreamEvent extends Event {
-	stream: MediaStream;
+  stream: MediaStream;
 }
 
 interface EventInit {
 }
 
 interface RTCDataChannelEventInit extends EventInit {
-	channel: RTCDataChannel;
+  channel: RTCDataChannel;
 }
 
 interface RTCVoidCallback {
-	(): void;
+  (): void;
 }
 interface RTCSessionDescriptionCallback {
-	(sdp: RTCSessionDescription): void;
+  (sdp: RTCSessionDescription): void;
 }
 interface RTCPeerConnectionErrorCallback {
-	(errorInformation: DOMError): void;
+  (errorInformation: DOMError): void;
 }
 
 // TODO(1)
 declare enum RTCIceGatheringState {
-	// http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicegatheringstate-enum
-	'new',
-	'gathering',
-	'complete'
+  // http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicegatheringstate-enum
+  'new',
+  'gathering',
+  'complete'
 }
 
 // TODO(1)
 declare enum RTCIceConnectionState {
-	// http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCIceConnectionState
+  // http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCIceConnectionState
   'new',
   'checking',
   'connected',
@@ -213,84 +213,84 @@ declare enum RTCSignalingState {
 }
 
 interface RTCPeerConnection {
-	createOffer(successCallback: RTCSessionDescriptionCallback,
-							failureCallback?: RTCPeerConnectionErrorCallback,
-							constraints?: MediaConstraints): void;
-	createAnswer(successCallback: RTCSessionDescriptionCallback,
-							 failureCallback?: RTCPeerConnectionErrorCallback,
-							 constraints?: MediaConstraints): void;
-	setLocalDescription(description: RTCSessionDescription,
-											successCallback?: RTCVoidCallback,
-											failureCallback?: RTCPeerConnectionErrorCallback): void;
-	localDescription: RTCSessionDescription;
-	setRemoteDescription(description: RTCSessionDescription,
-		 									 successCallback?: RTCVoidCallback,
-		 									 failureCallback?: RTCPeerConnectionErrorCallback): void;
-	remoteDescription: RTCSessionDescription;
-	signalingState: string; // RTCSignalingState; see TODO(1)
-	updateIce(configuration?: RTCConfiguration,
-						constraints?: MediaConstraints): void;
-	addIceCandidate(candidate: RTCIceCandidate): void;
-	iceGatheringState: string;  // RTCIceGatheringState; see TODO(1)
-	iceConnectionState: string;  // RTCIceConnectionState; see TODO(1)
-	getLocalStreams(): MediaStream[];
-	getRemoteStreams(): MediaStream[];
-	createDataChannel(label?: string,
-										dataChannelDict?: RTCDataChannelInit): RTCDataChannel;
-	ondatachannel: (event: Event) => void;
-	addStream(stream: MediaStream, constraints?: MediaConstraints): void;
-	removeStream(stream: MediaStream): void;
-	close(): void;
-	onnegotiationneeded: (event: Event) => void;
-	onconnecting: (event: Event) => void;
-	onopen: (event: Event) => void;
-	onaddstream: (event: RTCMediaStreamEvent) => void;
-	onremovestream: (event: RTCMediaStreamEvent) => void;
-	onstatechange: (event: Event) => void;
-	onicechange: (event: Event) => void;
-	onicecandidate: (event: RTCIceCandidateEvent) => void;
-	onidentityresult: (event: Event) => void;
-	onsignalingstatechange: (event: Event) => void;
+  createOffer(successCallback: RTCSessionDescriptionCallback,
+              failureCallback?: RTCPeerConnectionErrorCallback,
+              constraints?: MediaConstraints): void;
+  createAnswer(successCallback: RTCSessionDescriptionCallback,
+               failureCallback?: RTCPeerConnectionErrorCallback,
+               constraints?: MediaConstraints): void;
+  setLocalDescription(description: RTCSessionDescription,
+                      successCallback?: RTCVoidCallback,
+                      failureCallback?: RTCPeerConnectionErrorCallback): void;
+  localDescription: RTCSessionDescription;
+  setRemoteDescription(description: RTCSessionDescription,
+                        successCallback?: RTCVoidCallback,
+                        failureCallback?: RTCPeerConnectionErrorCallback): void;
+  remoteDescription: RTCSessionDescription;
+  signalingState: string; // RTCSignalingState; see TODO(1)
+  updateIce(configuration?: RTCConfiguration,
+            constraints?: MediaConstraints): void;
+  addIceCandidate(candidate: RTCIceCandidate): void;
+  iceGatheringState: string;  // RTCIceGatheringState; see TODO(1)
+  iceConnectionState: string;  // RTCIceConnectionState; see TODO(1)
+  getLocalStreams(): MediaStream[];
+  getRemoteStreams(): MediaStream[];
+  createDataChannel(label?: string,
+                    dataChannelDict?: RTCDataChannelInit): RTCDataChannel;
+  ondatachannel: (event: Event) => void;
+  addStream(stream: MediaStream, constraints?: MediaConstraints): void;
+  removeStream(stream: MediaStream): void;
+  close(): void;
+  onnegotiationneeded: (event: Event) => void;
+  onconnecting: (event: Event) => void;
+  onopen: (event: Event) => void;
+  onaddstream: (event: RTCMediaStreamEvent) => void;
+  onremovestream: (event: RTCMediaStreamEvent) => void;
+  onstatechange: (event: Event) => void;
+  onicechange: (event: Event) => void;
+  onicecandidate: (event: RTCIceCandidateEvent) => void;
+  onidentityresult: (event: Event) => void;
+  onsignalingstatechange: (event: Event) => void;
 }
 declare var RTCPeerConnection: {
-	prototype: RTCPeerConnection;
-	new (configuration: RTCConfiguration,
-			 constraints?: MediaConstraints): RTCPeerConnection;
+  prototype: RTCPeerConnection;
+  new (configuration: RTCConfiguration,
+       constraints?: MediaConstraints): RTCPeerConnection;
 }
 
 interface RTCIceCandidate {
-	candidate?: string;
-	sdpMid?: string;
-	sdpMLineIndex?: number;
+  candidate?: string;
+  sdpMid?: string;
+  sdpMLineIndex?: number;
 }
 declare var RTCIceCandidate: {
-	prototype: RTCIceCandidate;
-	new (candidateInitDict?: RTCIceCandidate): RTCIceCandidate;
+  prototype: RTCIceCandidate;
+  new (candidateInitDict?: RTCIceCandidate): RTCIceCandidate;
 }
 
 interface RTCIceCandidateInit {
-	candidate: string;
-	sdpMid: string;
-	sdpMLineIndex: number;
+  candidate: string;
+  sdpMid: string;
+  sdpMLineIndex: number;
 }
 declare var RTCIceCandidateInit:{
-	prototype: RTCIceCandidateInit;
-	new (): RTCIceCandidateInit;
+  prototype: RTCIceCandidateInit;
+  new (): RTCIceCandidateInit;
 }
 
 interface PeerConnectionIceEvent {
-	peer: RTCPeerConnection;
-	candidate: RTCIceCandidate;
+  peer: RTCPeerConnection;
+  candidate: RTCIceCandidate;
 }
 declare var PeerConnectionIceEvent: {
-	prototype: PeerConnectionIceEvent;
-	new (): PeerConnectionIceEvent;
+  prototype: PeerConnectionIceEvent;
+  new (): PeerConnectionIceEvent;
 }
 
 interface RTCPeerConnectionConfig {
-	iceServers: RTCIceServer[];
+  iceServers: RTCIceServer[];
 }
 declare var RTCPeerConnectionConfig: {
-	prototype: RTCPeerConnectionConfig;
-	new (): RTCPeerConnectionConfig;
+  prototype: RTCPeerConnectionConfig;
+  new (): RTCPeerConnectionConfig;
 }

--- a/webrtc/RTCPeerConnection.d.ts
+++ b/webrtc/RTCPeerConnection.d.ts
@@ -2,10 +2,26 @@
 // Project: http://dev.w3.org/2011/webrtc/
 // Definitions by: Ken Smith <https://github.com/smithkl42/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
-
+//
 // Definitions taken from http://dev.w3.org/2011/webrtc/editor/webrtc.html
+//
+// For example code see:
+//   https://code.google.com/p/webrtc/source/browse/stable/samples/js/apprtc/js/main.js
+//
+// For a generic implementation see that deals with browser differences, see:
+//   https://code.google.com/p/webrtc/source/browse/stable/samples/js/base/adapter.js
 
 /// <reference path="MediaStream.d.ts" />
+
+// TODO(1): Get Typescript to have string-enum types as WebRtc is full of string
+// enums.
+// https://typescript.codeplex.com/discussions/549207
+
+// TODO(2): get Typescript to have union types as WebRtc uses them.
+// https://typescript.codeplex.com/workitem/1364
+
+// TODO(3): Typescript type-abbreviations fail to be structural.
+// https://typescript.codeplex.com/workitem/2587
 
 interface RTCConfiguration {
 	iceServers: RTCIceServer[];
@@ -24,18 +40,19 @@ declare var RTCIceServer: {
 	new (): RTCIceServer;
 }
 
+// moz (Firefox) specific prefixes.
+interface mozRTCPeerConnection extends RTCPeerConnection {
+}
+declare var mozRTCPeerConnection: {
+	prototype: mozRTCPeerConnection;
+	new (settings: RTCPeerConnectionConfig, constraints?:MediaConstraints): mozRTCPeerConnection;
+}
+// webkit (Chrome) specific prefixes.
 interface webkitRTCPeerConnection extends RTCPeerConnection {
 }
 declare var webkitRTCPeerConnection: {
 	prototype: webkitRTCPeerConnection;
 	new (settings: RTCPeerConnectionConfig, constraints?:MediaConstraints): webkitRTCPeerConnection;
-}
-
-interface IceState {
-}
-declare var IceState: {
-	prototype: IceState;
-	new (): IceState;
 }
 
 // For Chrome, look at the code here: https://code.google.com/p/chromium/codesearch#chromium/src/third_party/libjingle/source/talk/app/webrtc/webrtcsession.cc&sq=package:chromium&dr=C&l=63
@@ -59,7 +76,7 @@ interface MediaOfferConstraints {
 }
 
 interface RTCSessionDescription {
-	type?: RTCSdpType;
+	type?: string;  // RTCSdpType; See TODO(3)
 	sdp?: string;
 }
 declare var RTCSessionDescription: {
@@ -68,7 +85,7 @@ declare var RTCSessionDescription: {
 }
 
 interface RTCSessionDescriptionInit {
-	type: RTCSdpType;
+	type: string;  // RTCSdpType; See TODO(3)
 	sdp: string;
 }
 declare var RTCSessionDescriptionInit: {
@@ -76,42 +93,57 @@ declare var RTCSessionDescriptionInit: {
 	new (): RTCSessionDescriptionInit;
 }
 
-interface SdpType {
-}
-
-interface RTCPeerState {
-}
-
 interface RTCDataChannelInit {
-	reliable: boolean;
+	ordered             ?: boolean; // messages must be sent in-order.
+  maxPacketLifeTime   ?: number;  // unsigned short
+  maxRetransmits      ?: number;  // unsigned short
+  protocol            ?: string;  // default = ''
+  negotiated          ?: boolean; // default = false;
+  id                  ?: number;  // unsigned short
 }
 
-declare enum RTCSdpType {
-	offer,
-	pranswer,
-	answer
+interface RTCSdpType {
+	// http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcsdptype
+	// enum RTCSdpType {
+	//     "offer",
+	//     "pranswer",
+	//     "answer"
+	// };
+	string;
 }
 
-declare enum RTCDataChannelState {
-	connecting,
-	open,
-	closing,
-	closed
+interface RTCMessageEvent {
+	// http://dev.w3.org/2011/webrtc/editor/webrtc.html#event-datachannel-message
+	// At present, this can be an: ArrayBuffer, a string, or a Blob.
+	// See TODO(2)
+	data: any;
+}
+
+interface RTCDataChannelState {
+	// http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCDataChannelState
+	// enum RTCDataChannelState {
+	//     "connecting",
+	//     "open",
+	//     "closing",
+	//     "closed"
+	// };
+	string;
 }
 
 interface RTCDataChannel extends EventTarget {
 	label: string;
 	reliable: boolean;
-	readyState: RTCDataChannelState;
+	readyState: string; // RTCDataChannelState; see TODO(3)
 	bufferedAmount: number;
-	onopen: (event: Event)=> void;
-	onerror: (event: Event)=> void;
-	onclose: (event: Event)=> void;
+	onopen: (event: Event) => void;
+	onerror: (event: Event) => void;
+	onclose: (event: Event) => void;
 	close(): void;
-	onmessage: (event: Event)=> void;
+	onmessage: (event: RTCMessageEvent) => void;
 	binaryType: string;
 	send(data: string);
 	send(data: ArrayBuffer);
+	send(data: ArrayBufferView);
 	send(data: Blob);
 }
 declare var RTCDataChannel: {
@@ -128,7 +160,7 @@ declare var RTCDataChannelEvent: {
 	new (eventInitDict: RTCDataChannelEventInit);
 }
 
-interface RTCIceCandidateEvent extends Event{
+interface RTCIceCandidateEvent extends Event {
 	candidate: RTCIceCandidate;
 }
 
@@ -150,21 +182,43 @@ interface RTCSessionDescriptionCallback {
 	(sdp: RTCSessionDescription): void;
 }
 interface RTCPeerConnectionErrorCallback {
-	(errorInformation: string): void;
+	(errorInformation: DOMError): void;
 }
 
-/** This should be an enum */
 interface RTCIceGatheringState {
+	// http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicegatheringstate-enum
+	// enum RTCIceGatheringState {
+	//     "new",
+	//     "gathering",
+	//     "complete"
+	// };
 	string;
 }
 
-/** This should be an enum */
 interface RTCIceConnectionState {
+	// http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCIceConnectionState
+	// enum RTCIceConnectionState {
+	//     "new",
+	//     "checking",
+	//     "connected",
+	//     "completed",
+	//     "failed",
+	//     "disconnected",
+	//     "closed"
+	// };
 	string;
 }
 
-/** This should be an enum */
-interface RTCSignalingState{
+interface RTCSignalingState {
+	// http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCSignalingState
+	// enum RTCSignalingState {
+	//     "stable",
+	//     "have-local-offer",
+	//     "have-remote-offer",
+	//     "have-local-pranswer",
+	//     "have-remote-pranswer",
+	//     "closed"
+	// };
 	string;
 }
 
@@ -175,27 +229,28 @@ interface RTCPeerConnection {
 	localDescription: RTCSessionDescription;
 	setRemoteDescription(description: RTCSessionDescription, successCallback?: RTCVoidCallback, failureCallback?: RTCPeerConnectionErrorCallback): void;
 	remoteDescription: RTCSessionDescription;
-	signalingState: RTCSignalingState;
+	signalingState: string; // RTCSignalingState; see TODO(3)
 	updateIce(configuration?: RTCConfiguration, constraints?: MediaConstraints): void;
 	addIceCandidate(candidate: RTCIceCandidate): void;
-	iceGatheringState: RTCIceGatheringState;
-	iceConnectionState: RTCIceConnectionState;
+	iceGatheringState: string;  // RTCIceGatheringState; see TODO(3)
+	iceConnectionState: string;  // RTCIceConnectionState; see TODO(3)
 	getLocalStreams(): MediaStream[];
 	getRemoteStreams(): MediaStream[];
 	createDataChannel(label?: string, dataChannelDict?: RTCDataChannelInit): RTCDataChannel;
-	ondatachannel: (event: Event)=> void;
+	ondatachannel: (event: Event) => void;
 	addStream(stream: MediaStream, constraints?: MediaConstraints): void;
 	removeStream(stream: MediaStream): void;
 	close(): void;
-	onnegotiationneeded: (event: Event)=> void;
-	onconnecting: (event: Event)=> void;
-	onopen: (event: Event)=> void;
-	onaddstream: (event: RTCMediaStreamEvent)=> void;
-	onremovestream: (event: RTCMediaStreamEvent)=> void;
-	onstatechange: (event: Event)=> void;
-	onicechange: (event: Event)=> void;
-	onicecandidate: (event: RTCIceCandidateEvent)=> void;
-	onidentityresult: (event: Event)=> void;
+	onnegotiationneeded: (event: Event) => void;
+	onconnecting: (event: Event) => void;
+	onopen: (event: Event) => void;
+	onaddstream: (event: RTCMediaStreamEvent) => void;
+	onremovestream: (event: RTCMediaStreamEvent) => void;
+	onstatechange: (event: Event) => void;
+	onicechange: (event: Event) => void;
+	onicecandidate: (event: RTCIceCandidateEvent) => void;
+	onidentityresult: (event: Event) => void;
+	onsignalingstatechange: (event: Event) => void;
 }
 declare var RTCPeerConnection: {
 	prototype: RTCPeerConnection;

--- a/webrtc/RTCPeerConnection.d.ts
+++ b/webrtc/RTCPeerConnection.d.ts
@@ -38,9 +38,19 @@ declare var IceState: {
 	new (): IceState;
 }
 
+// For Chrome, look at the code here: https://code.google.com/p/chromium/codesearch#chromium/src/third_party/libjingle/source/talk/app/webrtc/webrtcsession.cc&sq=package:chromium&dr=C&l=63
+interface OptionalMediaConstraint {
+	// When true, will use DTLS/SCTP data channels
+	DtlsSrtpKeyAgreement?: boolean;
+	// When true will use Rtp-based data channels (depreicated)
+	RtpDataChannels?: boolean;
+}
+
 // ks 12/20/12 - There's more here that doesn't seem to be documented very well yet.
+// http://www.w3.org/TR/2013/WD-webrtc-20130910/
 interface MediaConstraints {
-	mandatory: MediaOfferConstraints;
+	mandatory?: MediaOfferConstraints;
+	optional?: OptionalMediaConstraint[]
 }
 
 interface MediaOfferConstraints {

--- a/webrtc/RTCPeerConnection.d.ts
+++ b/webrtc/RTCPeerConnection.d.ts
@@ -212,6 +212,17 @@ declare enum RTCSignalingState {
   'closed'
 }
 
+// This is based on the current implementation of WebRtc in Chrome; the spec is
+// a little unclear on this.
+// http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCStatsReport
+interface RTCStatsReport {
+  stat(id: string): string;
+}
+
+interface RTCStatsCallback {
+  (report: RTCStatsReport): void;
+}
+
 interface RTCPeerConnection {
   createOffer(successCallback: RTCSessionDescriptionCallback,
               failureCallback?: RTCPeerConnectionErrorCallback,
@@ -251,6 +262,8 @@ interface RTCPeerConnection {
   onicecandidate: (event: RTCIceCandidateEvent) => void;
   onidentityresult: (event: Event) => void;
   onsignalingstatechange: (event: Event) => void;
+  getStats: (successCallback: RTCStatsCallback,
+             failureCallback: RTCPeerConnectionErrorCallback) => void;
 }
 declare var RTCPeerConnection: {
   prototype: RTCPeerConnection;


### PR DESCRIPTION
- Added optional constraints used by DTLS/SCTP data channels in WebRTC.
- Added TODOs for things that can be done when/if typescript is improved with links in case people want typescript to be better and want to vote on the issue.
- Removed unused IceState
- Added moz specific prefixes
- Fixed broken use of enum for things that are actually strings and added a TypeScript issue for the fix
- Added comments with WebIDL spec for enums
- Added RTCMessageEvent for data channels
- Support send with ArrayBufferView
- MediaConstraints now has RTC prefix to be consistent with the other interfaces.
