### PR TITLE
Dropzone constructor takes any

### DIFF
--- a/dropzone/dropzone.d.ts
+++ b/dropzone/dropzone.d.ts
@@ -54,7 +54,7 @@ interface DropzoneOptions {
 }
 
 declare class Dropzone {
-    constructor(container: string, options?: DropzoneOptions);
+    constructor(container: any, options?: DropzoneOptions);
     static autoDiscover: boolean;
     static options: any;
     static confirm: (question: string, accepted: () => void, rejected?: () => void) => void;

--- a/dropzone/dropzone.d.ts
+++ b/dropzone/dropzone.d.ts
@@ -54,7 +54,8 @@ interface DropzoneOptions {
 }
 
 declare class Dropzone {
-    constructor(container: any, options?: DropzoneOptions);
+    constructor(container: string, options?: DropzoneOptions);
+    constructor(container: HTMLElement, options?: DropzoneOptions);
     static autoDiscover: boolean;
     static options: any;
     static confirm: (question: string, accepted: () => void, rejected?: () => void) => void;


### PR DESCRIPTION
The docs say that the constructor can take a string selector, HtmlElement, or JQuery type as seen [here](http://www.dropzonejs.com/#toc_15).
