### PR TITLE
Corrected the microsoft-ajax PageLoadingEventArgs class.

### DIFF
--- a/microsoft-ajax/microsoft.ajax-tests.ts
+++ b/microsoft-ajax/microsoft.ajax-tests.ts
@@ -660,7 +660,7 @@ function Sys_WebForms_PageRequestManager_Tests() {
     }
     var pageLoadingRequestHandler = (sender: any, args: Sys.WebForms.PageLoadingEventArgs) => {
         var dataItems: any = args.get_dataItems();
-        var panelsDeleted: HTMLDivElement[] = args.get_panelsDeleted();
+        var panelsDeleted: HTMLDivElement[] = args.get_panelsDeleting();
         var panelsUpdating = args.get_panelsUpdating();
         var empty: Sys.EventArgs = args.Empty;
     }

--- a/microsoft-ajax/microsoft.ajax.d.ts
+++ b/microsoft-ajax/microsoft.ajax.d.ts
@@ -3829,7 +3829,7 @@ declare module Sys {
             * The pageLoading event of the Sys.WebForms.PageRequestManager class uses a PageLoadingEventArgs object to return its event data.
             * @return An array of <div> elements that will be deleted from the DOM. If no elements will be deleted, the property returns null.
             */
-            get_panelsDeleted(): HTMLDivElement[];
+            get_panelsDeleting(): HTMLDivElement[];
             /**
             * Gets an array of HTML <div> elements that represent UpdatePanel controls that will be updated in the DOM as a result of the current asynchronous postback.
             * If the contents of any UpdatePanel controls will be updated as the result of a partial-page update, the panelsUpdating property contains an array that references the corresponding <div> elements. 


### PR DESCRIPTION
Note that although the documentation sometimes incorrectly refers to get_panelsDeleted()  - e.g. on http://msdn.microsoft.com/en-us/library/bb397684%28v=vs.100%29.aspx - the actual function is get_panelsDeleting() - see http://msdn.microsoft.com/en-us/library/bb310960%28v=vs.100%29.aspx
