### PR TITLE
Add multi-scale time format method

### DIFF
--- a/d3/d3-tests.ts
+++ b/d3/d3-tests.ts
@@ -2590,6 +2590,7 @@ function extentTest() {
 }
 
 // Tests for d3.time.format.multi
+// Adopted from http://bl.ocks.org/mbostock/4149176
 function multiTest() {
     var customTimeFormat = d3.time.format.multi([
         [".%L", function(d) { return d.getMilliseconds(); }],

--- a/d3/d3-tests.ts
+++ b/d3/d3-tests.ts
@@ -2588,3 +2588,40 @@ function extentTest() {
     d3.extent([3, "20"], (d) => { return d; });
     d3.extent(["3", 20], (d) => { return d; });
 }
+
+// Tests for d3.time.format.multi
+function multiTest() {
+    var customTimeFormat = d3.time.format.multi([
+        [".%L", function(d) { return d.getMilliseconds(); }],
+        [":%S", function(d) { return d.getSeconds(); }],
+        ["%I:%M", function(d) { return d.getMinutes(); }],
+        ["%I %p", function(d) { return d.getHours(); }],
+        ["%a %d", function(d) { return d.getDay() && d.getDate() != 1; }],
+        ["%b %d", function(d) { return d.getDate() != 1; }],
+        ["%B", function(d) { return d.getMonth(); }],
+        ["%Y", function() { return true; }]
+    ]);
+
+    var margin = {top: 250, right: 40, bottom: 250, left: 40},
+        width = 960 - margin.left - margin.right,
+        height = 500 - margin.top - margin.bottom;
+
+    var x = d3.time.scale()
+        .domain([new Date(2012, 0, 1), new Date(2013, 0, 1)])
+        .range([0, width]);
+
+    var xAxis = d3.svg.axis()
+        .scale(x)
+        .tickFormat(customTimeFormat);
+
+    var svg = d3.select("body").append("svg")
+        .attr("width", width + margin.left + margin.right)
+        .attr("height", height + margin.top + margin.bottom)
+      .append("g")
+        .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+    svg.append("g")
+        .attr("class", "x axis")
+        .attr("transform", "translate(0," + height + ")")
+        .call(xAxis);
+}

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1003,9 +1003,29 @@ declare module D3 {
             fridays: Range;
             saturdays: Range;
             format: {
-
+                /**
+                 * Constructs a new local time formatter using the given specifier.
+                 */
                 (specifier: string): TimeFormat;
-                utc: (specifier: string) => TimeFormat;
+                /**
+                 * Returns a new multi-resolution time format given the specified array of predicated formats.
+                 */
+                multi: (formats: any[][]) => TimeFormat;
+
+                utc: {
+                    /**
+                     * Constructs a new local time formatter using the given specifier.
+                     */
+                    (specifier: string): TimeFormat;
+                    /**
+                     * Returns a new multi-resolution UTC time format given the specified array of predicated formats.
+                     */
+                    multi: (formats: any[][]) => TimeFormat;
+                };
+
+                /**
+                 * The full ISO 8601 UTC time format: "%Y-%m-%dT%H:%M:%S.%LZ".
+                 */
                 iso: TimeFormat;
             };
 


### PR DESCRIPTION
Added `multi` method for both local and UTC formats, as described here:

https://github.com/mbostock/d3/wiki/Time-Formatting#format_multi

Added a test case taken from here: http://bl.ocks.org/mbostock/4149176
