### PR TITLE
Field name fix

### DIFF
--- a/jquery.dataTables/jquery.dataTables.d.ts
+++ b/jquery.dataTables/jquery.dataTables.d.ts
@@ -343,7 +343,7 @@ declare module DataTables
 		bLengthChange: boolean;
 		bPaginate: boolean;
 		bProcessing: boolean;
-		bServerSize: boolean;
+		bServerSide: boolean;
 		bSort: boolean;
 		bSortClasses: boolean;
 		bStateSave: boolean;


### PR DESCRIPTION
According to official documentation correct name is bServerSide

http://datatables.net/docs/DataTables/1.9.0/DataTable.models.oSettings.oFeatures.html
