### PR TITLE
Fixes on es6-promise

### DIFF
--- a/es6-promise/es6-promise-tests.ts
+++ b/es6-promise/es6-promise-tests.ts
@@ -74,6 +74,8 @@ promiseNumber = thenWithUndefinedFullFillAndPromiseReject;
 var thenWithNoResultAndNoReject = promiseString.then<number>();
 promiseNumber = thenWithNoResultAndNoReject;
 
+var voidPromise = new Promise<void>(function (resolve) { resolve(); });
+
 //catch test
 var catchWithSimpleResult = promiseString.catch(error => 10);	
 promiseNumber = catchWithSimpleResult;
@@ -81,6 +83,7 @@ promiseNumber = catchWithSimpleResult;
 var catchWithPromiseResult = promiseString.catch(error => Promise.resolve(10));	
 promiseNumber = catchWithPromiseResult;
 
+promiseString = promiseString.catch<string>(function () { throw new Error('Better error msg'); });
 
 //examples coming from http://www.html5rocks.com/en/tutorials/es6/promises/
 

--- a/es6-promise/es6-promise.d.ts
+++ b/es6-promise/es6-promise.d.ts
@@ -4,12 +4,12 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 interface Thenable<R> {
-	then<U>(onResolve?: (value: R) => Thenable<U>,  onReject?: (error: any) => Thenable<U>): Thenable<U>;
-	then<U>(onResolve?: (value: R) => Thenable<U>, onReject?: (error: any) => U): Thenable<U>;
-	then<U>(onResolve?: (value: R) => Thenable<U>, onReject?: (error: any) => void): Thenable<U>;
-	then<U>(onResolve?: (value: R) => U, onReject?: (error: any) => Thenable<U>): Thenable<U>;
-	then<U>(onResolve?: (value: R) => U, onReject?: (error: any) => U): Thenable<U>;
-	then<U>(onResolve?: (value: R) => U, onReject?: (error: any) => void): Thenable<U>;
+	then<U>(onFulfilled?: (value: R) => Thenable<U>,  onRejected?: (error: any) => Thenable<U>): Thenable<U>;
+	then<U>(onFulfilled?: (value: R) => Thenable<U>, onRejected?: (error: any) => U): Thenable<U>;
+	then<U>(onFulfilled?: (value: R) => Thenable<U>, onRejected?: (error: any) => void): Thenable<U>;
+	then<U>(onFulfilled?: (value: R) => U, onRejected?: (error: any) => Thenable<U>): Thenable<U>;
+	then<U>(onFulfilled?: (value: R) => U, onRejected?: (error: any) => U): Thenable<U>;
+	then<U>(onFulfilled?: (value: R) => U, onRejected?: (error: any) => void): Thenable<U>;
 }
 
 declare class Promise<R> implements Thenable<R> {
@@ -28,93 +28,93 @@ declare class Promise<R> implements Thenable<R> {
 	 * For consistency and debugging (eg stack traces), obj should be an instanceof Error. 
 	 * Any errors thrown in the constructor callback will be implicitly passed to reject().
 	 */
-	constructor(callback: (resolve : (result?: Thenable<R>) => void, reject: (error: any) => void) => void);
+	constructor(callback: (resolve : (thenable?: Thenable<R>) => void, reject: (error: any) => void) => void);
 
 	/**
-	 * onResolve is called when/if "promise" resolves. onReject is called when/if "promise" rejects. 
-	 * Both are optional, if either/both are omitted the next onResolve/onReject in the chain is called. 
+	 * onFulfilled is called when/if "promise" resolves. onRejected is called when/if "promise" rejects. 
+	 * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called. 
 	 * Both callbacks have a single parameter , the fulfillment value or rejection reason. 
-	 * "then" returns a new promise equivalent to the value you return from onResolve/onReject after being passed through Promise.resolve. 
+	 * "then" returns a new promise equivalent to the value you return from onFulfilled/onRejected after being passed through Promise.resolve. 
 	 * If an error is thrown in the callback, the returned promise rejects with that error.
 	 * 
-	 * @param onResolve called when/if "promise" resolves
-	 * @param onReject called when/if "promise" rejects
+	 * @param onFulfilled called when/if "promise" resolves
+	 * @param onRejected called when/if "promise" rejects
 	 */
-	then<U>(onResolve?: (value: R) => Thenable<U>,  onReject?: (error: any) => Thenable<U>): Promise<U>;
+	then<U>(onFulfilled?: (value: R) => Thenable<U>,  onRejected?: (error: any) => Thenable<U>): Promise<U>;
 	/**
-	 * onResolve is called when/if "promise" resolves. onReject is called when/if "promise" rejects. 
-	 * Both are optional, if either/both are omitted the next onResolve/onReject in the chain is called. 
+	 * onFulfilled is called when/if "promise" resolves. onRejected is called when/if "promise" rejects. 
+	 * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called. 
 	 * Both callbacks have a single parameter , the fulfillment value or rejection reason. 
-	 * "then" returns a new promise equivalent to the value you return from onResolve/onReject after being passed through Promise.resolve. 
+	 * "then" returns a new promise equivalent to the value you return from onFulfilled/onRejected after being passed through Promise.resolve. 
 	 * If an error is thrown in the callback, the returned promise rejects with that error.
 	 * 
-	 * @param onResolve called when/if "promise" resolves
-	 * @param onReject called when/if "promise" rejects
+	 * @param onFulfilled called when/if "promise" resolves
+	 * @param onRejected called when/if "promise" rejects
 	 */
-	then<U>(onResolve?: (value: R) => Thenable<U>, onReject?: (error: any) => U): Promise<U>;
+	then<U>(onFulfilled?: (value: R) => Thenable<U>, onRejected?: (error: any) => U): Promise<U>;
 	/**
-	 * onResolve is called when/if "promise" resolves. onReject is called when/if "promise" rejects.
-	 * Both are optional, if either/both are omitted the next onResolve/onReject in the chain is called.
+	 * onFulfilled is called when/if "promise" resolves. onRejected is called when/if "promise" rejects.
+	 * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called.
 	 * Both callbacks have a single parameter , the fulfillment value or rejection reason.
-	 * "then" returns a new promise equivalent to the value you return from onResolve/onReject after being passed through Promise.resolve.
+	 * "then" returns a new promise equivalent to the value you return from onFulfilled/onRejected after being passed through Promise.resolve.
 	 * If an error is thrown in the callback, the returned promise rejects with that error.
 	 *
-	 * @param onResolve called when/if "promise" resolves
-	 * @param onReject called when/if "promise" rejects
+	 * @param onFulfilled called when/if "promise" resolves
+	 * @param onRejected called when/if "promise" rejects
 	 */
-	then<U>(onResolve?: (value: R) => Thenable<U>,  onReject?: (error: any) => void): Promise<U>;
+	then<U>(onFulfilled?: (value: R) => Thenable<U>,  onRejected?: (error: any) => void): Promise<U>;
 	/**
-	 * onResolve is called when/if "promise" resolves. onReject is called when/if "promise" rejects. 
-	 * Both are optional, if either/both are omitted the next onResolve/onReject in the chain is called. 
+	 * onFulfilled is called when/if "promise" resolves. onRejected is called when/if "promise" rejects. 
+	 * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called. 
 	 * Both callbacks have a single parameter , the fulfillment value or rejection reason. 
-	 * "then" returns a new promise equivalent to the value you return from onResolve/onReject after being passed through Promise.resolve. 
+	 * "then" returns a new promise equivalent to the value you return from onFulfilled/onRejected after being passed through Promise.resolve. 
 	 * If an error is thrown in the callback, the returned promise rejects with that error.
 	 * 
-	 * @param onResolve called when/if "promise" resolves
-	 * @param onReject called when/if "promise" rejects
+	 * @param onFulfilled called when/if "promise" resolves
+	 * @param onRejected called when/if "promise" rejects
 	 */
-	then<U>(onResolve?: (value: R) => U, onReject?: (error: any) => Thenable<U>): Promise<U>;
+	then<U>(onFulfilled?: (value: R) => U, onRejected?: (error: any) => Thenable<U>): Promise<U>;
 	/**
-	 * onResolve is called when/if "promise" resolves. onReject is called when/if "promise" rejects. 
-	 * Both are optional, if either/both are omitted the next onResolve/onReject in the chain is called. 
+	 * onFulfilled is called when/if "promise" resolves. onRejected is called when/if "promise" rejects. 
+	 * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called. 
 	 * Both callbacks have a single parameter , the fulfillment value or rejection reason. 
-	 * "then" returns a new promise equivalent to the value you return from onResolve/onReject after being passed through Promise.resolve. 
+	 * "then" returns a new promise equivalent to the value you return from onFulfilled/onRejected after being passed through Promise.resolve. 
 	 * If an error is thrown in the callback, the returned promise rejects with that error.
 	 * 
-	 * @param onResolve called when/if "promise" resolves
-	 * @param onReject called when/if "promise" rejects
+	 * @param onFulfilled called when/if "promise" resolves
+	 * @param onRejected called when/if "promise" rejects
 	 */
-	then<U>(onResolve?: (value: R) => U, onReject?: (error: any) => U): Promise<U>;
+	then<U>(onFulfilled?: (value: R) => U, onRejected?: (error: any) => U): Promise<U>;
 	/**
-	 * onResolve is called when/if "promise" resolves. onReject is called when/if "promise" rejects.
-	 * Both are optional, if either/both are omitted the next onResolve/onReject in the chain is called.
+	 * onFulfilled is called when/if "promise" resolves. onRejected is called when/if "promise" rejects.
+	 * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called.
 	 * Both callbacks have a single parameter , the fulfillment value or rejection reason.
-	 * "then" returns a new promise equivalent to the value you return from onResolve/onReject after being passed through Promise.resolve.
+	 * "then" returns a new promise equivalent to the value you return from onFulfilled/onRejected after being passed through Promise.resolve.
 	 * If an error is thrown in the callback, the returned promise rejects with that error.
 	 *
-	 * @param onResolve called when/if "promise" resolves
-	 * @param onReject called when/if "promise" rejects
+	 * @param onFulfilled called when/if "promise" resolves
+	 * @param onRejected called when/if "promise" rejects
 	 */
-	then<U>(onResolve?: (value: R) => U, onReject?: (error: any) => void): Promise<U>;
+	then<U>(onFulfilled?: (value: R) => U, onRejected?: (error: any) => void): Promise<U>;
 
 	/**
-	 * Sugar for promise.then(undefined, onReject)
+	 * Sugar for promise.then(undefined, onRejected)
 	 * 
-	 * @param onReject called when/if "promise" rejects
+	 * @param onRejected called when/if "promise" rejects
 	 */
-	catch<U>(onReject?: (error: any) => Thenable<U>): Promise<U>;
+	catch<U>(onRejected?: (error: any) => Thenable<U>): Promise<U>;
 	/**
-	 * Sugar for promise.then(undefined, onReject)
+	 * Sugar for promise.then(undefined, onRejected)
 	 * 
-	 * @param onReject called when/if "promise" rejects
+	 * @param onRejected called when/if "promise" rejects
 	 */
-	catch<U>(onReject?: (error: any) => U): Promise<U>;
+	catch<U>(onRejected?: (error: any) => U): Promise<U>;
 	/**
-	 * Sugar for promise.then(undefined, onReject)
+	 * Sugar for promise.then(undefined, onRejected)
 	 *
-	 * @param onReject called when/if "promise" rejects
+	 * @param onRejected called when/if "promise" rejects
 	 */
-	catch<U>(onReject?: (error: any) => void): Promise<U>;
+	catch<U>(onRejected?: (error: any) => void): Promise<U>;
 }
 
 declare module Promise {

--- a/es6-promise/es6-promise.d.ts
+++ b/es6-promise/es6-promise.d.ts
@@ -4,10 +4,12 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 interface Thenable<R> {
-	then<U>(onResolve: (value: R) => Thenable<U>,  onReject: (error: any) => Thenable<U>): Thenable<U>;
-	then<U>(onResolve: (value: R) => Thenable<U>, onReject?: (error: any) => U): Thenable<U>;
-	then<U>(onResolve: (value: R) => U, onReject: (error: any) => Thenable<U>): Thenable<U>;
+	then<U>(onResolve?: (value: R) => Thenable<U>,  onReject?: (error: any) => Thenable<U>): Thenable<U>;
+	then<U>(onResolve?: (value: R) => Thenable<U>, onReject?: (error: any) => U): Thenable<U>;
+	then<U>(onResolve?: (value: R) => Thenable<U>, onReject?: (error: any) => void): Thenable<U>;
+	then<U>(onResolve?: (value: R) => U, onReject?: (error: any) => Thenable<U>): Thenable<U>;
 	then<U>(onResolve?: (value: R) => U, onReject?: (error: any) => U): Thenable<U>;
+	then<U>(onResolve?: (value: R) => U, onReject?: (error: any) => void): Thenable<U>;
 }
 
 declare class Promise<R> implements Thenable<R> {
@@ -18,7 +20,7 @@ declare class Promise<R> implements Thenable<R> {
 	 * For consistency and debugging (eg stack traces), obj should be an instanceof Error. 
 	 * Any errors thrown in the constructor callback will be implicitly passed to reject().
 	 */
-	constructor(callback: (resolve : (result: R) => void, reject: (error: any) => void) => void);
+	constructor(callback: (resolve : (result?: R) => void, reject: (error: any) => void) => void);
 	/**
 	 * If you call resolve in the body of the callback passed to the constructor, 
 	 * your promise will be fulfilled/rejected with the outcome of thenable passed to resolve.
@@ -26,7 +28,7 @@ declare class Promise<R> implements Thenable<R> {
 	 * For consistency and debugging (eg stack traces), obj should be an instanceof Error. 
 	 * Any errors thrown in the constructor callback will be implicitly passed to reject().
 	 */
-	constructor(callback: (resolve : (result: Thenable<R>) => void, reject: (error: any) => void) => void);
+	constructor(callback: (resolve : (result?: Thenable<R>) => void, reject: (error: any) => void) => void);
 
 	/**
 	 * onResolve is called when/if "promise" resolves. onReject is called when/if "promise" rejects. 
@@ -38,7 +40,7 @@ declare class Promise<R> implements Thenable<R> {
 	 * @param onResolve called when/if "promise" resolves
 	 * @param onReject called when/if "promise" rejects
 	 */
-	then<U>(onResolve: (value: R) => Thenable<U>,  onReject: (error: any) => Thenable<U>): Promise<U>;
+	then<U>(onResolve?: (value: R) => Thenable<U>,  onReject?: (error: any) => Thenable<U>): Promise<U>;
 	/**
 	 * onResolve is called when/if "promise" resolves. onReject is called when/if "promise" rejects. 
 	 * Both are optional, if either/both are omitted the next onResolve/onReject in the chain is called. 
@@ -49,7 +51,18 @@ declare class Promise<R> implements Thenable<R> {
 	 * @param onResolve called when/if "promise" resolves
 	 * @param onReject called when/if "promise" rejects
 	 */
-	then<U>(onResolve: (value: R) => Thenable<U>, onReject?: (error: any) => U): Promise<U>;
+	then<U>(onResolve?: (value: R) => Thenable<U>, onReject?: (error: any) => U): Promise<U>;
+	/**
+	 * onResolve is called when/if "promise" resolves. onReject is called when/if "promise" rejects.
+	 * Both are optional, if either/both are omitted the next onResolve/onReject in the chain is called.
+	 * Both callbacks have a single parameter , the fulfillment value or rejection reason.
+	 * "then" returns a new promise equivalent to the value you return from onResolve/onReject after being passed through Promise.resolve.
+	 * If an error is thrown in the callback, the returned promise rejects with that error.
+	 *
+	 * @param onResolve called when/if "promise" resolves
+	 * @param onReject called when/if "promise" rejects
+	 */
+	then<U>(onResolve?: (value: R) => Thenable<U>,  onReject?: (error: any) => void): Promise<U>;
 	/**
 	 * onResolve is called when/if "promise" resolves. onReject is called when/if "promise" rejects. 
 	 * Both are optional, if either/both are omitted the next onResolve/onReject in the chain is called. 
@@ -60,7 +73,7 @@ declare class Promise<R> implements Thenable<R> {
 	 * @param onResolve called when/if "promise" resolves
 	 * @param onReject called when/if "promise" rejects
 	 */
-	then<U>(onResolve: (value: R) => U, onReject: (error: any) => Thenable<U>): Promise<U>;
+	then<U>(onResolve?: (value: R) => U, onReject?: (error: any) => Thenable<U>): Promise<U>;
 	/**
 	 * onResolve is called when/if "promise" resolves. onReject is called when/if "promise" rejects. 
 	 * Both are optional, if either/both are omitted the next onResolve/onReject in the chain is called. 
@@ -72,7 +85,18 @@ declare class Promise<R> implements Thenable<R> {
 	 * @param onReject called when/if "promise" rejects
 	 */
 	then<U>(onResolve?: (value: R) => U, onReject?: (error: any) => U): Promise<U>;
-	
+	/**
+	 * onResolve is called when/if "promise" resolves. onReject is called when/if "promise" rejects.
+	 * Both are optional, if either/both are omitted the next onResolve/onReject in the chain is called.
+	 * Both callbacks have a single parameter , the fulfillment value or rejection reason.
+	 * "then" returns a new promise equivalent to the value you return from onResolve/onReject after being passed through Promise.resolve.
+	 * If an error is thrown in the callback, the returned promise rejects with that error.
+	 *
+	 * @param onResolve called when/if "promise" resolves
+	 * @param onReject called when/if "promise" rejects
+	 */
+	then<U>(onResolve?: (value: R) => U, onReject?: (error: any) => void): Promise<U>;
+
 	/**
 	 * Sugar for promise.then(undefined, onReject)
 	 * 
@@ -85,6 +109,12 @@ declare class Promise<R> implements Thenable<R> {
 	 * @param onReject called when/if "promise" rejects
 	 */
 	catch<U>(onReject?: (error: any) => U): Promise<U>;
+	/**
+	 * Sugar for promise.then(undefined, onReject)
+	 *
+	 * @param onReject called when/if "promise" rejects
+	 */
+	catch<U>(onReject?: (error: any) => void): Promise<U>;
 }
 
 declare module Promise {
@@ -95,14 +125,14 @@ declare module Promise {
 	/**
 	 * Make a promise that fulfills to obj.
 	 */
-	function cast<R>(object?: R): Promise<R>;
+	function cast<R>(object: R): Promise<R>;
 
 	/**
 	 * Make a new promise from the thenable. 
 	 * A thenable is promise-like in as far as it has a "then" method. 
 	 * This also creates a new promise if you pass it a genuine JavaScript promise, making it less efficient for casting than Promise.cast.
 	 */
-	function resolve<R>(thenable: Thenable<R>): Promise<R>;
+	function resolve<R>(thenable?: Thenable<R>): Promise<R>;
 	/**
 	 * Make a promise that fulfills to obj. Same as Promise.cast(obj) in this situation.
 	 */
@@ -111,7 +141,7 @@ declare module Promise {
 	/**
 	 * Make a promise that rejects to obj. For consistency and debugging (eg stack traces), obj should be an instanceof Error
 	 */
-	function reject(error?: any): Promise<any>;
+	function reject(error: any): Promise<any>;
 	
 	/**
 	 * Make a promise that fulfills when every item in the array fulfills, and rejects if (and when) any item rejects. 

--- a/es6-promise/es6-promise.d.ts
+++ b/es6-promise/es6-promise.d.ts
@@ -3,139 +3,133 @@
 // Definitions by: François de Campredon <https://github.com/fdecampredon/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-
 interface Thenable<R> {
-    then<U>(onFulfilled: (value: R) => Thenable<U>,  onRejected: (error: any) => Thenable<U>): Thenable<U>;
-    then<U>(onFulfilled: (value: R) => Thenable<U>, onRejected?: (error: any) => U): Thenable<U>;
-    then<U>(onFulfilled: (value: R) => U, onRejected: (error: any) => Thenable<U>): Thenable<U>;
-    then<U>(onFulfilled?: (value: R) => U, onRejected?: (error: any) => U): Thenable<U>;
-	
+	then<U>(onResolve: (value: R) => Thenable<U>,  onReject: (error: any) => Thenable<U>): Thenable<U>;
+	then<U>(onResolve: (value: R) => Thenable<U>, onReject?: (error: any) => U): Thenable<U>;
+	then<U>(onResolve: (value: R) => U, onReject: (error: any) => Thenable<U>): Thenable<U>;
+	then<U>(onResolve?: (value: R) => U, onReject?: (error: any) => U): Thenable<U>;
 }
 
 declare class Promise<R> implements Thenable<R> {
-    /**
-     * If you call resolve in the body of the callback passed to the constructor, 
-     * your promise is fulfilled with result object passed to resolve.
-     * If you call reject your promise is rejected with the object passed to resolve. 
-     * For consistency and debugging (eg stack traces), obj should be an instanceof Error. 
-     * Any errors thrown in the constructor callback will be implicitly passed to reject().
-     */
+	/**
+	 * If you call resolve in the body of the callback passed to the constructor, 
+	 * your promise is fulfilled with result object passed to resolve.
+	 * If you call reject your promise is rejected with the object passed to resolve. 
+	 * For consistency and debugging (eg stack traces), obj should be an instanceof Error. 
+	 * Any errors thrown in the constructor callback will be implicitly passed to reject().
+	 */
 	constructor(callback: (resolve : (result: R) => void, reject: (error: any) => void) => void);
-    /**
-     * If you call resolve in the body of the callback passed to the constructor, 
-     * your promise will be fulfilled/rejected with the outcome of thenable passed to resolve.
-     * If you call reject your promise is rejected with the object passed to resolve. 
-     * For consistency and debugging (eg stack traces), obj should be an instanceof Error. 
-     * Any errors thrown in the constructor callback will be implicitly passed to reject().
-     */
-	constructor(callback: (resolve : (thenable: Thenable<R>) => void, reject: (error: any) => void) => void);
+	/**
+	 * If you call resolve in the body of the callback passed to the constructor, 
+	 * your promise will be fulfilled/rejected with the outcome of thenable passed to resolve.
+	 * If you call reject your promise is rejected with the object passed to resolve. 
+	 * For consistency and debugging (eg stack traces), obj should be an instanceof Error. 
+	 * Any errors thrown in the constructor callback will be implicitly passed to reject().
+	 */
+	constructor(callback: (resolve : (result: Thenable<R>) => void, reject: (error: any) => void) => void);
+
+	/**
+	 * onResolve is called when/if "promise" resolves. onReject is called when/if "promise" rejects. 
+	 * Both are optional, if either/both are omitted the next onResolve/onReject in the chain is called. 
+	 * Both callbacks have a single parameter , the fulfillment value or rejection reason. 
+	 * "then" returns a new promise equivalent to the value you return from onResolve/onReject after being passed through Promise.resolve. 
+	 * If an error is thrown in the callback, the returned promise rejects with that error.
+	 * 
+	 * @param onResolve called when/if "promise" resolves
+	 * @param onReject called when/if "promise" rejects
+	 */
+	then<U>(onResolve: (value: R) => Thenable<U>,  onReject: (error: any) => Thenable<U>): Promise<U>;
+	/**
+	 * onResolve is called when/if "promise" resolves. onReject is called when/if "promise" rejects. 
+	 * Both are optional, if either/both are omitted the next onResolve/onReject in the chain is called. 
+	 * Both callbacks have a single parameter , the fulfillment value or rejection reason. 
+	 * "then" returns a new promise equivalent to the value you return from onResolve/onReject after being passed through Promise.resolve. 
+	 * If an error is thrown in the callback, the returned promise rejects with that error.
+	 * 
+	 * @param onResolve called when/if "promise" resolves
+	 * @param onReject called when/if "promise" rejects
+	 */
+	then<U>(onResolve: (value: R) => Thenable<U>, onReject?: (error: any) => U): Promise<U>;
+	/**
+	 * onResolve is called when/if "promise" resolves. onReject is called when/if "promise" rejects. 
+	 * Both are optional, if either/both are omitted the next onResolve/onReject in the chain is called. 
+	 * Both callbacks have a single parameter , the fulfillment value or rejection reason. 
+	 * "then" returns a new promise equivalent to the value you return from onResolve/onReject after being passed through Promise.resolve. 
+	 * If an error is thrown in the callback, the returned promise rejects with that error.
+	 * 
+	 * @param onResolve called when/if "promise" resolves
+	 * @param onReject called when/if "promise" rejects
+	 */
+	then<U>(onResolve: (value: R) => U, onReject: (error: any) => Thenable<U>): Promise<U>;
+	/**
+	 * onResolve is called when/if "promise" resolves. onReject is called when/if "promise" rejects. 
+	 * Both are optional, if either/both are omitted the next onResolve/onReject in the chain is called. 
+	 * Both callbacks have a single parameter , the fulfillment value or rejection reason. 
+	 * "then" returns a new promise equivalent to the value you return from onResolve/onReject after being passed through Promise.resolve. 
+	 * If an error is thrown in the callback, the returned promise rejects with that error.
+	 * 
+	 * @param onResolve called when/if "promise" resolves
+	 * @param onReject called when/if "promise" rejects
+	 */
+	then<U>(onResolve?: (value: R) => U, onReject?: (error: any) => U): Promise<U>;
 	
-    
-    /**
-     * onFulFill is called when/if "promise" resolves. onRejected is called when/if "promise" rejects. 
-     * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called. 
-     * Both callbacks have a single parameter , the fulfillment value or rejection reason. 
-     * "then" returns a new promise equivalent to the value you return from onFulfilled/onRejected after being passed through Promise.resolve. 
-     * If an error is thrown in the callback, the returned promise rejects with that error.
-     * 
-     * @param onFulFill called when/if "promise" resolves
-     * @param onReject called when/if "promise" rejects
-     */
-	then<U>(onFulfill: (value: R) => Thenable<U>,  onReject: (error: any) => Thenable<U>): Promise<U>;
-    /**
-     * onFulFill is called when/if "promise" resolves. onRejected is called when/if "promise" rejects. 
-     * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called. 
-     * Both callbacks have a single parameter , the fulfillment value or rejection reason. 
-     * "then" returns a new promise equivalent to the value you return from onFulfilled/onRejected after being passed through Promise.resolve. 
-     * If an error is thrown in the callback, the returned promise rejects with that error.
-     * 
-     * @param onFulFill called when/if "promise" resolves
-     * @param onReject called when/if "promise" rejects
-     */
-    then<U>(onFulfill: (value: R) => Thenable<U>, onReject?: (error: any) => U): Promise<U>;
-    /**
-     * onFulFill is called when/if "promise" resolves. onRejected is called when/if "promise" rejects. 
-     * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called. 
-     * Both callbacks have a single parameter , the fulfillment value or rejection reason. 
-     * "then" returns a new promise equivalent to the value you return from onFulfilled/onRejected after being passed through Promise.resolve. 
-     * If an error is thrown in the callback, the returned promise rejects with that error.
-     * 
-     * @param onFulFill called when/if "promise" resolves
-     * @param onReject called when/if "promise" rejects
-     */
-    then<U>(onFulfill: (value: R) => U, onReject: (error: any) => Thenable<U>): Promise<U>;
-    /**
-     * onFulFill is called when/if "promise" resolves. onRejected is called when/if "promise" rejects. 
-     * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called. 
-     * Both callbacks have a single parameter , the fulfillment value or rejection reason. 
-     * "then" returns a new promise equivalent to the value you return from onFulfilled/onRejected after being passed through Promise.resolve. 
-     * If an error is thrown in the callback, the returned promise rejects with that error.
-     * 
-     * @param onFulFill called when/if "promise" resolves
-     * @param onReject called when/if "promise" rejects
-     */
-    then<U>(onFulfill?: (value: R) => U, onReject?: (error: any) => U): Promise<U>;
-    
-    
-    /**
-     * Sugar for promise.then(undefined, onRejected)
-     * 
-     * @param onReject called when/if "promise" rejects
-     */
+	/**
+	 * Sugar for promise.then(undefined, onReject)
+	 * 
+	 * @param onReject called when/if "promise" rejects
+	 */
 	catch<U>(onReject?: (error: any) => Thenable<U>): Promise<U>;
-    /**
-     * Sugar for promise.then(undefined, onRejected)
-     * 
-     * @param onReject called when/if "promise" rejects
-     */
+	/**
+	 * Sugar for promise.then(undefined, onReject)
+	 * 
+	 * @param onReject called when/if "promise" rejects
+	 */
 	catch<U>(onReject?: (error: any) => U): Promise<U>;
 }
 
 declare module Promise {
-	
 	/**
 	 * Returns promise (only if promise.constructor == Promise)
 	 */
 	function cast<R>(promise: Promise<R>): Promise<R>;
-    /**
+	/**
 	 * Make a promise that fulfills to obj.
 	 */
 	function cast<R>(object?: R): Promise<R>;
-    
-	
-    /**
-     * Make a new promise from the thenable. 
-     * A thenable is promise-like in as far as it has a "then" method. 
-     * This also creates a new promise if you pass it a genuine JavaScript promise, making it less efficient for casting than Promise.cast.
-     */
+
+	/**
+	 * Make a new promise from the thenable. 
+	 * A thenable is promise-like in as far as it has a "then" method. 
+	 * This also creates a new promise if you pass it a genuine JavaScript promise, making it less efficient for casting than Promise.cast.
+	 */
 	function resolve<R>(thenable: Thenable<R>): Promise<R>;
-    /**
-     * Make a promise that fulfills to obj. Same as Promise.cast(obj) in this situation.
-     */
+	/**
+	 * Make a promise that fulfills to obj. Same as Promise.cast(obj) in this situation.
+	 */
 	function resolve<R>(object?: R): Promise<R>;
-    
+	
 	/**
 	 * Make a promise that rejects to obj. For consistency and debugging (eg stack traces), obj should be an instanceof Error
 	 */
 	function reject(error?: any): Promise<any>;
 	
-    /**
-     * Make a promise that fulfills when every item in the array fulfills, and rejects if (and when) any item rejects. 
-     * the array passed to all can be a mixture of promise-like objects and other objects. 
-     * The fulfillment value is an array (in order) of fulfillment values. The rejection value is the first rejection value.
-     */
+	/**
+	 * Make a promise that fulfills when every item in the array fulfills, and rejects if (and when) any item rejects. 
+	 * the array passed to all can be a mixture of promise-like objects and other objects. 
+	 * The fulfillment value is an array (in order) of fulfillment values. The rejection value is the first rejection value.
+	 */
 	function all<R>(promises: Promise<R>[]): Promise<R[]>;
 	
-    /**
-     * Make a Promise that fulfills when any item fulfills, and rejects if any item rejects.
-     */
+	/**
+	 * Make a Promise that fulfills when any item fulfills, and rejects if any item rejects.
+	 */
 	function race<R>(promises: Promise<R>[]): Promise<R>;
 }
 
 declare module 'es6-promise' {
-    var foo: typeof Promise; // Temp variable to reference Promise in local context
-    module rsvp {
-        export var Promise: typeof foo;
-    }
-    export = rsvp;
+	var foo: typeof Promise; // Temp variable to reference Promise in local context
+	module rsvp {
+		export var Promise: typeof foo;
+	}
+	export = rsvp;
 }


### PR DESCRIPTION
- Uniform parameters names (onFulfilled, onFulFill, onFulfill, onFulfilled => onResolve and onRejected => onReject)
- Example of new use cases:
  
  var p1: Promise&lt;boolean> = new Promise(function (resolve: Function) {
      resolve(true);
  }).catch<boolean>(function () {
      throw new Error('Better error msg');
  });
  
  var p2 = new Promise&lt;void>(function (resolve: Function) {
      resolve();
  });
