### PR TITLE
Update cordova.d.ts with plugins property

### DIFF
--- a/cordova/cordova.d.ts
+++ b/cordova/cordova.d.ts
@@ -42,6 +42,8 @@ interface Cordova {
     define(moduleName: string, factory: (require: any, exports: any, module: any) => any): void;
     /** Access a Cordova module by name. */
     require(moduleName: string): any;
+    /** Access plugins object. */
+    plugins: any;
 }
 
 // cordova/argscheck module


### PR DESCRIPTION
You can now go `cordova.plugins`.
E.g. one would require this when building an [ionic](http://ionicframework.com) app, e.g. `cordova.plugins.Keyboard` etc.
