### PR TITLE
FIX: D3.Events now inherit from the lib.d.ts Event interface.

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -42,14 +42,14 @@ declare module D3 {
         };
     }
 
-    export interface Event {
+    export interface D3Event extends Event{
         dx: number;
         dy: number;
         clientX: number;
         clientY: number;
         translate: number[];
         scale: number;
-        sourceEvent: Event;
+        sourceEvent: D3Event;
         x: number;
         y: number;
         keyCode: number;
@@ -65,7 +65,7 @@ declare module D3 {
         /**
         * Access the current user event for interaction
         */
-        event: Event;
+        event: D3Event;
 
         /**
         * Compare two values for sorting.


### PR DESCRIPTION
Addresses #2478. By [D3's documentation](https://github.com/mbostock/d3/wiki/Selections#d3_event), "the d3.event object is a DOM event". As such, I made D3's interface extend from the lib.d.js Event interface. I had to rename Event to D3Event in order to do this.

Should be a quick fix! Let me know if there is a problem!
