### PR TITLE
Added definitions for passport-strategy

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -253,7 +253,7 @@ All definitions files include a header with the author and editors, so at some p
 * [OpenLayers](https://github.com/openlayers/openlayers) (by [Ilya Bolkhovsky](https://github.com/bolhovsky/))
 * [Optimist](https://github.com/substack/node-optimist) (by [Carlos Ballesteros Velasco](https://github.com/soywiz))
 * [Passport](http://passportjs.org/) (by [Hiroki Horiuchi](https://github.com/horiuchi/))
-* [passport-strategy](http://passportjs.org/) (by [Lior Mualem](https://github.com/liorm))
+* [passport-strategy](https://github.com/jaredhanson/passport-strategy) (by [Lior Mualem](https://github.com/liorm))
 * [pathwatcher](http://atom.github.io/node-pathwatcher/) (by [vvakame](https://github.com/vvakame))
 * [Parallel.js](https://github.com/adambom/parallel.js) (by [Josh Baldwin](https://github.com/jbaldwin))
 * [Parsimmon](https://github.com/jayferd/parsimmon) (by [Bart van der Schoor](https://github.com/Bartvds))

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -253,6 +253,7 @@ All definitions files include a header with the author and editors, so at some p
 * [OpenLayers](https://github.com/openlayers/openlayers) (by [Ilya Bolkhovsky](https://github.com/bolhovsky/))
 * [Optimist](https://github.com/substack/node-optimist) (by [Carlos Ballesteros Velasco](https://github.com/soywiz))
 * [Passport](http://passportjs.org/) (by [Hiroki Horiuchi](https://github.com/horiuchi/))
+* [passport-strategy](http://passportjs.org/) (by [Lior Mualem](https://github.com/liorm))
 * [pathwatcher](http://atom.github.io/node-pathwatcher/) (by [vvakame](https://github.com/vvakame))
 * [Parallel.js](https://github.com/adambom/parallel.js) (by [Josh Baldwin](https://github.com/jbaldwin))
 * [Parsimmon](https://github.com/jayferd/parsimmon) (by [Bart van der Schoor](https://github.com/Bartvds))

--- a/passport-strategy/passport-strategy-test.ts
+++ b/passport-strategy/passport-strategy-test.ts
@@ -1,0 +1,48 @@
+
+import express = require('express');
+import passport = require('passport-strategy');
+
+
+export class Strategy extends passport.Strategy {
+    constructor(options: any, verify?: Function) {
+        if (typeof options == 'function') {
+            verify = options;
+            options = {};
+        }
+        if (!verify) {
+            throw new TypeError('DummyStrategy requires a verify callback');
+        }
+
+        super();
+
+        this.name = 'dummy';
+        this._verify = verify;
+        this._passReqToCallback = options.passReqToCallback;
+    }
+
+    name: string;
+
+    _verify: Function;
+    _passReqToCallback: boolean;
+
+    authenticate(req: express.Request, options?: any): void {
+        options = options || {};
+
+        // Test fail method.
+        this.fail({ message: options.missingTokenMessage || 'Missing token' }, 400);
+
+        var self = this;
+
+        function verified(err: Error, user: any, info: any) {
+            if (err) {
+                return self.error(err);
+            }
+            if (!user) {
+                return self.fail(info);
+            }
+            self.success(user, info);
+        }
+
+        verified(null, {}, {});
+    }
+}

--- a/passport-strategy/passport-strategy.d.ts
+++ b/passport-strategy/passport-strategy.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for Passport Strategy module v0.2.0
-// Project: http://passportjs.org
+// Project: https://github.com/jaredhanson/passport-strategy
 // Definitions by: Lior Mualem <https://github.com/liorm/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 

--- a/passport-strategy/passport-strategy.d.ts
+++ b/passport-strategy/passport-strategy.d.ts
@@ -1,0 +1,98 @@
+// Type definitions for Passport v0.2.0 Strategy module.
+// Project: http://passportjs.org
+// Definitions by: Lior Mualem <https://github.com/liorm/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../express/express.d.ts"/>
+/// <reference path="../passport/passport.d.ts"/>
+
+/**
+ * Using this module, one can easily implement a strategy using typescript by
+ * inheriting the 'Strategy' class and reimplementing the 'authenticate' method.
+ */
+
+declare module 'passport-strategy' {
+
+    import passport = require('passport');
+    import express = require('express');
+
+    class Strategy implements passport.Strategy {
+        /**
+         * Performs authentication for the request.
+         * Note: Virtual function - re-implement in the strategy.
+         * @param req The request to authenticate.
+         * @param options Options passed to the strategy.
+         */
+        authenticate(req: express.Request, options?: any): void;
+
+        //
+        // Augmented strategy functions.
+        // These are available only from the 'authenticate' function.
+        // They are added manually by the passport framework.
+        //
+
+        /**
+         * Authenticate `user`, with optional `info`.
+         *
+         * Strategies should call this function to successfully authenticate a
+         * user.  `user` should be an object supplied by the application after it
+         * has been given an opportunity to verify credentials.  `info` is an
+         * optional argument containing additional user information.  This is
+         * useful for third-party authentication strategies to pass profile
+         * details.
+         *
+         * @param {Object} user
+         * @param {Object} info
+         * @api public
+         */
+        success(user: any, info: any): void;
+
+        /**
+         * Fail authentication, with optional `challenge` and `status`, defaulting
+         * to 401.
+         *
+         * Strategies should call this function to fail an authentication attempt.
+         *
+         * @param {String} challenge (Can also be an object with 'message' and 'type' fields).
+         * @param {Number} status
+         * @api public
+         */
+        fail(challenge: any, status: number): void;
+        fail(status: number): void;
+
+        /**
+         * Redirect to `url` with optional `status`, defaulting to 302.
+         *
+         * Strategies should call this function to redirect the user (via their
+         * user agent) to a third-party website for authentication.
+         *
+         * @param {String} url
+         * @param {Number} status
+         * @api public
+         */
+        redirect(url: string, status?: number): void;
+
+        /**
+         * Pass without making a success or fail decision.
+         *
+         * Under most circumstances, Strategies should not need to call this
+         * function.  It exists primarily to allow previous authentication state
+         * to be restored, for example from an HTTP session.
+         *
+         * @api public
+         */
+        pass(): void;
+
+        /**
+         * Internal error while performing authentication.
+         *
+         * Strategies should call this function when an internal error occurs
+         * during the process of performing authentication; for example, if the
+         * user directory is not available.
+         *
+         * @param {Error} err
+         * @api public
+         */
+        error(err: Error): void;
+    }
+}

--- a/passport-strategy/passport-strategy.d.ts
+++ b/passport-strategy/passport-strategy.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Passport v0.2.0 Strategy module.
+// Type definitions for Passport Strategy module v0.2.0
 // Project: http://passportjs.org
 // Definitions by: Lior Mualem <https://github.com/liorm/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped


### PR DESCRIPTION
To be able to implement different strategies in typescript for passportjs

The augmented functions are not available in the documentations but are taken from the source code: https://github.com/jaredhanson/passport/blob/master/lib/middleware/authenticate.js#L171
