### PR TITLE
Fix interface for getIdxById in SlickGrid

### DIFF
--- a/slickgrid/SlickGrid-tests.ts
+++ b/slickgrid/SlickGrid-tests.ts
@@ -196,3 +196,7 @@ grid.setCellCssStyles("test", {
 	}
 });
 
+// Begin DataView tests
+var dataView = new Slick.Data.DataView<MyData>();
+var gridWithDataView = new Slick.Grid<MyData>('#grid2', dataView, columns, options);
+dataView.getIdxById('foo') + 5;

--- a/slickgrid/SlickGrid.d.ts
+++ b/slickgrid/SlickGrid.d.ts
@@ -1539,7 +1539,7 @@ declare module Slick {
 			*/
 			public expandGroup(...varArgs: string[]): void;
 			public getGroups(): Group<T, any>[];
-			public getIdxById(): string;
+			public getIdxById(string): number;
 			public getRowById(): T;
 			public getItemById(id: any): T;
 			public getItemByIdx(): T;

--- a/slickgrid/SlickGrid.d.ts
+++ b/slickgrid/SlickGrid.d.ts
@@ -1539,7 +1539,7 @@ declare module Slick {
 			*/
 			public expandGroup(...varArgs: string[]): void;
 			public getGroups(): Group<T, any>[];
-			public getIdxById(string): number;
+			public getIdxById(id: string): number;
 			public getRowById(): T;
 			public getItemById(id: any): T;
 			public getItemByIdx(): T;


### PR DESCRIPTION
It is clear by the name of this method that it takes an id (string) and returns and index (number).
