### PR TITLE
Add _.object(pairs)

### DIFF
--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -2041,7 +2041,6 @@ declare module _ {
             keys: List<string>,
             values: List<any>): TResult;
             
-            
         zipObject<TResult extends {}>(
             pairs: List<any>[][]) : TResult;
 

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -2040,6 +2040,10 @@ declare module _ {
         zipObject<TResult extends {}>(
             keys: List<string>,
             values: List<any>): TResult;
+            
+            
+        zipObject<TResult extends {}>(
+            pairs: List<any>[][]) : TResult;
 
         /**
         * @see _.object
@@ -2047,6 +2051,9 @@ declare module _ {
         object<TResult extends {}>(
             keys: List<string>,
             values: List<any>): TResult;
+        
+        object<TResult extends {}>(
+            pairs: List<any>[][]) : TResult;
     }
 
     /* *************


### PR DESCRIPTION
Lodash has a function to convert an array of keys and pairs (represented like `[[key, val], [key2, val2]]` into an an object (`{ key : val, key2 : val2 }`). 

I've added a definition for that function.
