### PR TITLE
ChartArea allows missing members

### DIFF
--- a/google.visualization/google.visualization.d.ts
+++ b/google.visualization/google.visualization.d.ts
@@ -244,10 +244,10 @@ declare module google {
         }
 
         export interface ChartArea {
-            top: any;
-            left: any;
-            width: any;
-            height: any;
+            top?: any;
+            left?: any;
+            width?: any;
+            height?: any;
         }
 
         export interface ChartLegend {


### PR DESCRIPTION
Small fix, the members should be optional in chartArea.

https://developers.google.com/chart/interactive/docs/gallery/linechart#Configuration_Options
