### PR TITLE
Update kineticjs.d.ts

### DIFF
--- a/kineticjs/kineticjs.d.ts
+++ b/kineticjs/kineticjs.d.ts
@@ -53,6 +53,7 @@ declare module Kinetic {
         moveUp(): void;
         name(): string;
         name(name: string): void;
+        remove(): any;
         rotate(theta: number): void;
         rotateDeg(deg: number): void;
 
@@ -124,7 +125,6 @@ declare module Kinetic {
         getChildren(): INode[];
         getIntersections(point: any): any;
         isAncestorOf(node: any): any;
-        remove(child: any): any;
         removeChildren(): any;
     }
 
@@ -136,6 +136,7 @@ declare module Kinetic {
         add(layer: ILayer): any;
         clear(): any;
         getContainer(): HTMLElement;
+        getContent(): HTMLElement;
         getDOM(): HTMLElement;
         getHeight(): number;
         getIntersection(pos: any): any;
@@ -481,7 +482,7 @@ declare module Kinetic {
     interface LineConfig extends DrawOptionsConfig, ObjectOptionsConfig {
         points: any;
         lineCap?: string;
-        dashArray?: any;
+        dash?: number[];
     }
 
     interface PolygonConfig extends DrawOptionsConfig, ObjectOptionsConfig {


### PR DESCRIPTION
- `Line` has no property `dashArray` but has `dash` : http://kineticjs.com/docs/Kinetic.Line.html  
- there is no `remove` function on `Container` : http://kineticjs.com/docs/Kinetic.Container.html that takes a child
- there is however a `remove` function on `Node` that removes an item from its parent. http://kineticjs.com/docs/Kinetic.Node.html This function exists in Container as well http://kineticjs.com/docs/Kinetic.Container.html (since container inherits from Node)
