### PR TITLE
Update RxJS to version 2.2.28

### DIFF
--- a/rx.js/rx-lite.d.ts
+++ b/rx.js/rx-lite.d.ts
@@ -352,6 +352,16 @@ declare module Rx {
 		* @returns An ES6 compatible promise with the last value from the observable sequence.
 		*/
 		toPromise(promiseCtor?: { new (resolver: (resolvePromise: (value: T) => void, rejectPromise: (reason: any) => void) => void): IPromise<T>; }): IPromise<T>;
+
+		// Experimental Flattening
+
+		/**
+		* Performs a exclusive waiting for the first to finish before subscribing to another observable.
+		* Observables that come in between subscriptions will be dropped on the floor.
+		* Can be applied on `Observable<Observable<R>>` or `Observable<IPromise<R>>`.
+		* @returns A exclusive observable with only the results that happen when subscribed.
+		*/
+		exclusive<R>(): Observable<T>;
 	}
 
 	interface ObservableStatic {

--- a/rx.js/rx-lite.d.ts
+++ b/rx.js/rx-lite.d.ts
@@ -324,6 +324,16 @@ declare module Rx {
 		*  and that at any point in time produces the elements of the most recent inner observable sequence that has been received.
 		*/
 		flatMapLatest<TResult>(selector: (value: T, index: number, source: Observable<T>) => TResult, thisArg?: any): Observable<TResult>;	// alias for selectSwitch
+		/**
+		*  Projects each element of an observable sequence into a new sequence of observable sequences by incorporating the element's index and then 
+		*  transforms an observable sequence of observable sequences into an observable sequence producing values only from the most recent observable sequence.
+		* @param selector A transform function to apply to each source element; the second parameter of the function represents the index of the source element.
+		* @param [thisArg] Object to use as this when executing callback.
+		* @since 2.2.28
+		* @returns An observable sequence whose elements are the result of invoking the transform function on each element of source producing an Observable of Observable sequences 
+		*  and that at any point in time produces the elements of the most recent inner observable sequence that has been received.
+		*/
+		switchMap<TResult>(selector: (value: T, index: number, source: Observable<T>) => TResult, thisArg?: any): Observable<TResult>;	// alias for selectSwitch
 
 		skip(count: number): Observable<T>;
 		skipWhile(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): Observable<T>;
@@ -436,6 +446,9 @@ declare module Rx {
 		range(start: number, count: number, scheduler?: IScheduler): Observable<number>;
 		repeat<T>(value: T, repeatCount?: number, scheduler?: IScheduler): Observable<T>;
 		return<T>(value: T, scheduler?: IScheduler): Observable<T>;
+		/**
+		 * @since 2.2.28
+		 */
 		just<T>(value: T, scheduler?: IScheduler): Observable<T>;	// alias for return
 		returnValue<T>(value: T, scheduler?: IScheduler): Observable<T>;	// alias for return
 		throw<T>(exception: Error, scheduler?: IScheduler): Observable<T>;

--- a/rx.js/rx-lite.d.ts
+++ b/rx.js/rx-lite.d.ts
@@ -359,6 +359,7 @@ declare module Rx {
 		* Performs a exclusive waiting for the first to finish before subscribing to another observable.
 		* Observables that come in between subscriptions will be dropped on the floor.
 		* Can be applied on `Observable<Observable<R>>` or `Observable<IPromise<R>>`.
+		* @since 2.2.28
 		* @returns A exclusive observable with only the results that happen when subscribed.
 		*/
 		exclusive<R>(): Observable<R>;
@@ -367,6 +368,7 @@ declare module Rx {
 		* Performs a exclusive map waiting for the first to finish before subscribing to another observable.
 		* Observables that come in between subscriptions will be dropped on the floor.
 		* Can be applied on `Observable<Observable<I>>` or `Observable<IPromise<I>>`.
+		* @since 2.2.28
 		* @param selector Selector to invoke for every item in the current subscription.
 		* @param [thisArg] An optional context to invoke with the selector parameter.
 		* @returns {An exclusive observable with only the results that happen when subscribed.
@@ -417,6 +419,7 @@ declare module Rx {
 		* 
 		* @example
 		*  var res = Rx.Observable.of(1, 2, 3);
+		* @since 2.2.28
 		* @returns The observable sequence whose elements are pulled from the given arguments.
 		*/
 		of<T>(...values: T[]): Observable<T>;
@@ -425,6 +428,7 @@ declare module Rx {
 		*  This method creates a new Observable instance with a variable number of arguments, regardless of number or type of the arguments. 
 		* @example
 		*  var res = Rx.Observable.ofWithScheduler(Rx.Scheduler.timeout, 1, 2, 3);
+		* @since 2.2.28
 		* @param [scheduler] A scheduler to use for scheduling the arguments.
 		* @returns The observable sequence whose elements are pulled from the given arguments.
 		*/

--- a/rx.js/rx-lite.d.ts
+++ b/rx.js/rx-lite.d.ts
@@ -436,6 +436,7 @@ declare module Rx {
 		range(start: number, count: number, scheduler?: IScheduler): Observable<number>;
 		repeat<T>(value: T, repeatCount?: number, scheduler?: IScheduler): Observable<T>;
 		return<T>(value: T, scheduler?: IScheduler): Observable<T>;
+		just<T>(value: T, scheduler?: IScheduler): Observable<T>;	// alias for return
 		returnValue<T>(value: T, scheduler?: IScheduler): Observable<T>;	// alias for return
 		throw<T>(exception: Error, scheduler?: IScheduler): Observable<T>;
 		throw<T>(exception: any, scheduler?: IScheduler): Observable<T>;

--- a/rx.js/rx-lite.d.ts
+++ b/rx.js/rx-lite.d.ts
@@ -391,6 +391,24 @@ declare module Rx {
 		fromItreable<T>(iterable: {}, scheduler?: IScheduler): Observable<T>;	// todo: can't describe ES6 Iterable via TypeScript type system
 		generate<TState, TResult>(initialState: TState, condition: (state: TState) => boolean, iterate: (state: TState) => TState, resultSelector: (state: TState) => TResult, scheduler?: IScheduler): Observable<TResult>;
 		never<T>(): Observable<T>;
+
+		/**
+		*  This method creates a new Observable instance with a variable number of arguments, regardless of number or type of the arguments.
+		* 
+		* @example
+		*  var res = Rx.Observable.of(1, 2, 3);
+		* @returns The observable sequence whose elements are pulled from the given arguments.
+		*/
+		of<T>(...values: T[]): Observable<T>;
+
+		/**
+		*  This method creates a new Observable instance with a variable number of arguments, regardless of number or type of the arguments. 
+		* @example
+		*  var res = Rx.Observable.ofWithScheduler(Rx.Scheduler.timeout, 1, 2, 3);
+		* @param [scheduler] A scheduler to use for scheduling the arguments.
+		* @returns The observable sequence whose elements are pulled from the given arguments.
+		*/
+		ofWithScheduler<T>(scheduler?: IScheduler, ...values: T[]): Observable<T>;
 		range(start: number, count: number, scheduler?: IScheduler): Observable<number>;
 		repeat<T>(value: T, repeatCount?: number, scheduler?: IScheduler): Observable<T>;
 		return<T>(value: T, scheduler?: IScheduler): Observable<T>;

--- a/rx.js/rx-lite.d.ts
+++ b/rx.js/rx-lite.d.ts
@@ -361,7 +361,17 @@ declare module Rx {
 		* Can be applied on `Observable<Observable<R>>` or `Observable<IPromise<R>>`.
 		* @returns A exclusive observable with only the results that happen when subscribed.
 		*/
-		exclusive<R>(): Observable<T>;
+		exclusive<R>(): Observable<R>;
+
+		/**
+		* Performs a exclusive map waiting for the first to finish before subscribing to another observable.
+		* Observables that come in between subscriptions will be dropped on the floor.
+		* Can be applied on `Observable<Observable<I>>` or `Observable<IPromise<I>>`.
+		* @param selector Selector to invoke for every item in the current subscription.
+		* @param [thisArg] An optional context to invoke with the selector parameter.
+		* @returns {An exclusive observable with only the results that happen when subscribed.
+		*/
+		exclusiveMap<I, R>(selector: (value: I, index: number, source: Observable<I>) => R, thisArg?: any): Observable<R>;
 	}
 
 	interface ObservableStatic {

--- a/rx.js/rx.aggregates.d.ts
+++ b/rx.js/rx.aggregates.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Aggregates v2.2.25
+// Type definitions for RxJS-Aggregates v2.2.28
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>, Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.all.ts
+++ b/rx.js/rx.all.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-All v2.2.25
+// Type definitions for RxJS-All v2.2.28
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>, Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.async.d.ts
+++ b/rx.js/rx.async.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Async v2.2.25
+// Type definitions for RxJS-Async v2.2.28
 // Project: http://rx.codeplex.com/
 // Definitions by: zoetrope <https://github.com/zoetrope>, Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.backpressure.d.ts
+++ b/rx.js/rx.backpressure.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for RxJS-BackPressure v2.2.25
+﻿// Type definitions for RxJS-BackPressure v2.2.28
 // Project: http://rx.codeplex.com/
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.binding-lite.d.ts
+++ b/rx.js/rx.binding-lite.d.ts
@@ -67,5 +67,6 @@ declare module Rx {
 		shareValue(initialValue: T): Observable<T>;
 		replay(selector?: boolean, bufferSize?: number, window?: number, scheduler?: IScheduler): ConnectableObservable<T>;	// hack to catch first omitted parameter
 		replay(selector: (source: ConnectableObservable<T>) => Observable<T>, bufferSize?: number, window?: number, scheduler?: IScheduler): Observable<T>;
+		shareReplay(bufferSize?: number, window?: number, scheduler?: IScheduler): Observable<T>;
 	}
 }

--- a/rx.js/rx.binding.d.ts
+++ b/rx.js/rx.binding.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Binding v2.2.25
+// Type definitions for RxJS-Binding v2.2.28
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>, Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.binding.d.ts
+++ b/rx.js/rx.binding.d.ts
@@ -6,12 +6,6 @@
 ///<reference path="rx.d.ts" />
 ///<reference path="rx.binding-lite.d.ts" />
 
-declare module Rx {
-	export interface Observable<T> {
-		replayWhileObserved(bufferSize?: number, window?: number, scheduler?: IScheduler): Observable<T>;
-	}
-}
-
 declare module "rx.binding" {
 	export = Rx;
 }

--- a/rx.js/rx.coincidence.d.ts
+++ b/rx.js/rx.coincidence.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Coincidence v2.2.25
+// Type definitions for RxJS-Coincidence v2.2.28
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>, Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.d.ts
+++ b/rx.js/rx.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for RxJS v2.2.25
+﻿// Type definitions for RxJS v2.2.28
 // Project: http://rx.codeplex.com/
 // Definitions by: gsino <http://www.codeplex.com/site/users/view/gsino>, Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.experimental.d.ts
+++ b/rx.js/rx.experimental.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Experimental v2.2.25
+// Type definitions for RxJS-Experimental v2.2.28
 // Project: https://github.com/Reactive-Extensions/RxJS/
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.joinpatterns.d.ts
+++ b/rx.js/rx.joinpatterns.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Join v2.2.25
+// Type definitions for RxJS-Join v2.2.28
 // Project: http://rx.codeplex.com/
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.lite.d.ts
+++ b/rx.js/rx.lite.d.ts
@@ -43,10 +43,6 @@ declare module Rx {
 		schedulePeriodic(period: number, action: () => void): IDisposable;
 		schedulePeriodicWithState<TState>(state: TState, period: number, action: (state: TState) => TState): IDisposable;
 	}
-
-	export interface Observable<T> {
-		shareReplay(bufferSize?: number, window?: number, scheduler?: IScheduler): Observable<T>;	// same as replayWhileObserved in rx.binding.d.ts
-	}
 }
 
 declare module "rx.lite" {

--- a/rx.js/rx.lite.d.ts
+++ b/rx.js/rx.lite.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for RxJS-Lite v2.2.25
+﻿// Type definitions for RxJS-Lite v2.2.28
 // Project: http://rx.codeplex.com/
 // Definitions by: gsino <http://www.codeplex.com/site/users/view/gsino>, Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.testing.d.ts
+++ b/rx.js/rx.testing.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Testing v2.2.25
+// Type definitions for RxJS-Testing v2.2.28
 // Project: https://github.com/Reactive-Extensions/RxJS/
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.time.d.ts
+++ b/rx.js/rx.time.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-Time v2.2.25
+// Type definitions for RxJS-Time v2.2.28
 // Project: http://rx.codeplex.com/
 // Definitions by: Carl de Billy <http://carl.debilly.net/>, Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx.js/rx.virtualtime.d.ts
+++ b/rx.js/rx.virtualtime.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS-VirtualTime v2.2.25
+// Type definitions for RxJS-VirtualTime v2.2.28
 // Project: http://rx.codeplex.com/
 // Definitions by: gsino <http://www.codeplex.com/site/users/view/gsino>, Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped


### PR DESCRIPTION
- added `of`, experimental `exclusive`, `exclusiveMap` operators;
- `shareReplay` now in all distributions.
- added `switchMap`, `just` aliases.
