### PR TITLE
Fix JQueryUI Slider definitions

### DIFF
--- a/jqueryui/jqueryui.d.ts
+++ b/jqueryui/jqueryui.d.ts
@@ -609,11 +609,14 @@ declare module JQueryUI {
         orientation?: string;
         range?: any; // boolean or string
         step?: number;
-        // value?: number;
-        // values?: number[];
+        value?: number;
+        values?: number[];
     }
 
     interface SliderUIParams {
+        handle?: JQuery;
+        value?: number;
+        values?: number[];
     }
 
     interface SliderEvent {


### PR DESCRIPTION
Based on http://api.jqueryui.com/slider/ and confirmed in usage. The uncommented SliderOptions members were commented out in f9be59c5bd when they were mistakenly defined as methods. The methods were removed two weeks later in b824ffb0f3, but the comments were not removed to restore value & values as (non-method) members.
