### PR TITLE
jasmine: add missing variable DEFAULT_TIMEOUT_INTERVAL

### DIFF
--- a/jasmine/jasmine-tests.ts
+++ b/jasmine/jasmine-tests.ts
@@ -698,3 +698,5 @@ describe("Asynchronous specs", function () {
     };
 
 })();
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;

--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -429,4 +429,5 @@ declare module jasmine {
 
     export var HtmlReporter: HtmlReporter;
     export var HtmlSpecFilter: HtmlSpecFilter;
+    export var DEFAULT_TIMEOUT_INTERVAL: number;
 }


### PR DESCRIPTION
This is new in jasmine 2.0. See http://jasmine.github.io/2.0/introduction.html#section-Asynchronous_Support.
