### PR TITLE
Remove useless reference to RxJS definitions

### DIFF
--- a/knockout.rx/knockout.rx.d.ts
+++ b/knockout.rx/knockout.rx.d.ts
@@ -4,6 +4,7 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../knockout/knockout.d.ts"/>
+/// <reference path="../rx.js/rx.d.ts"/>
 
 interface KnockoutSubscribableFunctions<T> {
 	toObservable(event?: string): Rx.Observable<T>;

--- a/knockout.rx/knockout.rx.d.ts
+++ b/knockout.rx/knockout.rx.d.ts
@@ -4,7 +4,6 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../knockout/knockout.d.ts"/>
-/// <reference path="../rx.js/rx.d.ts"/>
 
 interface KnockoutSubscribableFunctions<T> {
 	toObservable(event?: string): Rx.Observable<T>;
@@ -21,6 +20,8 @@ interface KnockoutComputedFunctions<T> {
 }
 
 declare module Rx {
+	interface ISubject<T> { }
+
 	interface Observable<T> {
 		toKoSubscribable(): KnockoutSubscribable<T>;
 		toKoObservable(initialValue?: T): KnockoutObservable<T>;

--- a/knockout.rx/knockout.rx.d.ts
+++ b/knockout.rx/knockout.rx.d.ts
@@ -4,7 +4,6 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../knockout/knockout.d.ts"/>
-/// <reference path="../rx.js/rx.d.ts"/>
 
 interface KnockoutSubscribableFunctions<T> {
 	toObservable(event?: string): Rx.Observable<T>;


### PR DESCRIPTION
This reference is not needed and is now causing problem because the
definitelyTyped for RxJS is now part of the RxJS package directly.  The
Nuget package dependency will be removed automatically.
