### PR TITLE
angularjs: allow $q.when to be called w/o args

### DIFF
--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -139,6 +139,12 @@ module HttpAndRegularPromiseTests {
         dPromise.then((snack: string) => {
             $scope.snack = snack;
         });
+
+        // $q.when may be called without arguments
+        var ePromise: ng.IPromise<Person> = $q.when();
+        ePromise.then(() => {
+            $scope.nothing = "really nothing";
+        });
     }
 
   // Test that we can pass around a type-checked success/error Promise Callback

--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -141,7 +141,7 @@ module HttpAndRegularPromiseTests {
         });
 
         // $q.when may be called without arguments
-        var ePromise: ng.IPromise<Person> = $q.when();
+        var ePromise: ng.IPromise<void> = $q.when();
         ePromise.then(() => {
             $scope.nothing = "really nothing";
         });

--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -95,6 +95,7 @@ module HttpAndRegularPromiseTests {
         theAnswer: number;
         letters: string[];
         snack: string;
+        nothing?: string;
     }
 
     var someController: Function = ($scope: SomeControllerScope, $http: ng.IHttpService, $q: ng.IQService) => {

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -565,6 +565,12 @@ declare module ng {
          * @param value Value or a promise
          */
         when<T>(value: T): IPromise<T>;
+        /**
+         * Wraps an object that might be a value or a (3rd party) then-able promise into a $q promise. This is useful when you are dealing with an object that might or might not be a promise, or if the promise comes from a source that can't be trusted.
+         * 
+         * @param value Value or a promise
+         */
+        when(): IPromise<void>;
     }
 
     interface IPromise<T> {


### PR DESCRIPTION
The current definition does not cover the case that the input type is void.
