### PR TITLE
Add channel support to backbone.wreqr in marionette.d.ts

### DIFF
--- a/marionette/marionette.d.ts
+++ b/marionette/marionette.d.ts
@@ -57,13 +57,35 @@ declare module Backbone {
     // Backbone.Wreqr
     module Wreqr {
 
+        class radio {
+            
+            static channel(channelName: string): Channel;
+
+        }
+
+        class Channel {
+            
+            constructor(channelName: string);
+            
+            vent: Backbone.Wreqr.EventAggregator;
+            reqres: Backbone.Wreqr.RequestResponse;
+            commands: Backbone.Wreqr.Commands;
+            channelName: string;
+            
+            reset(): Channel;
+            connectEvents(hash: string, context: any): Channel;
+            connectCommands(hash: string, context: any): Channel;
+            connectRequests(hash: string, context: any): Channel;
+
+        }
+        
         class Handlers extends Backbone.Events {
 
             constructor(options?: any);
 
             options: any;
 
-            setHandler(name: string, handler: any, context: any): void;
+            setHandler(name: string, handler: any, context?: any): void;
             hasHandler(name: string): boolean;
             getHandler(name: string): Function;
             removeHandler(name: string);

--- a/marionette/marionette.d.ts
+++ b/marionette/marionette.d.ts
@@ -57,9 +57,9 @@ declare module Backbone {
     // Backbone.Wreqr
     module Wreqr {
 
-        class radio {
+        module radio {
             
-            static channel(channelName: string): Channel;
+            function channel(channelName: string): Channel;
 
         }
 


### PR DESCRIPTION
Marionette.d.ts includes definitions for Backbone.Wreqr, but does not support the recommended way of using the Wreqr channels as officially documented: https://github.com/marionettejs/backbone.marionette/blob/master/docs/marionette.application.md#accessing-the-global-channel

I've added the Channel object, and a definition to the Radio class as well. This is only a means of getting a specific channel through the channel() method, so while it is possible to create an instance of Radio, I've chosen only to include channel() method, and make it static.

This makes it possible to access the instance of a channel with the name 'global' like this (created if not found), as recommended in the documentation: 
var channel = Backbone.Wreqr.radio.channel('global');
// channel.vent;

Finally, I've made the parameter context of the setHandler method in the Backbone.Wreqr.Handlers class optional, as this adheres to the actual implementation.
