### PR TITLE
Added calendar Property to GlobalizeCulture

### DIFF
--- a/globalize/globalize.d.ts
+++ b/globalize/globalize.d.ts
@@ -91,6 +91,7 @@ interface GlobalizeCulture {
     isRTL: boolean;
     language: string;
     numberFormat: GlobalizeNumberFormat;
+    calendar: GlobalizeCalendar;
     calendars: GlobalizeCalendars;
     messages: any;
 }


### PR DESCRIPTION
The calendar Property is used to get and set the default calendar. See
https://github.com/jquery/globalize/tree/79ae658b842f75f58199d6e9074e01f7ce207468#defining-culture-information and https://github.com/jquery/globalize/blob/79ae658b842f75f58199d6e9074e01f7ce207468/lib/globalize.js#L263

This is against the 0.x branch of Globalize. (1.x is in alpha)
