### PR TITLE
Update Anon Function Parameters in asyncTest

### DIFF
--- a/qunit/qunit.d.ts
+++ b/qunit/qunit.d.ts
@@ -381,7 +381,7 @@ interface QUnitStatic extends QUnitAssert{
 	* @param expected Number of assertions in this test
 	* @param test Function to close over assertions
 	*/
-	asyncTest(name: string, expected: number, test: () => any): any;
+	asyncTest(name: string, expected: number, test: (assert: QUnitAssert) => any): any;
 
 	/**
 	* Add an asynchronous test to run. The test must include a call to start().
@@ -392,7 +392,7 @@ interface QUnitStatic extends QUnitAssert{
 	* @param name Title of unit being tested
 	* @param test Function to close over assertions
 	*/
-	asyncTest(name: string, test: () => any): any;
+	asyncTest(name: string, test: (assert: QUnitAssert) => any): any;
 
 	/**
 	* Specify how many assertions are expected to run within a test.
@@ -662,7 +662,7 @@ declare function testStart(callback: (details: TestStartCallbackObject) => any):
 * @param expected Number of assertions in this test
 * @param test Function to close over assertions
 */
-declare function asyncTest(name: string, expected?: any, test?: () => any): any;
+declare function asyncTest(name: string, expected?: any, test?: (assert: QUnitAssert) => any): any;
 
 /**
 * Add an asynchronous test to run. The test must include a call to start().
@@ -673,7 +673,7 @@ declare function asyncTest(name: string, expected?: any, test?: () => any): any;
 * @param name Title of unit being tested
 * @param test Function to close over assertions
 */
-declare function asyncTest(name: string, test: () => any): any;
+declare function asyncTest(name: string, test: (assert: QUnitAssert) => any): any;
 
 /**
 * Specify how many assertions are expected to run within a test.


### PR DESCRIPTION
Encountered compiler errors on using asyncTest ... fixed by making sure that the assert is a function of the anon function
