### PR TITLE
Angular-hotkeys : Chaining when hotkeys is bound to a $scope object

### DIFF
--- a/angular-hotkeys/angular-hotkeys-tests.ts
+++ b/angular-hotkeys/angular-hotkeys-tests.ts
@@ -14,3 +14,12 @@ hotkeyProvider.toggleCheatSheet();
 
 hotkeyProvider.add(hotkeyObj.combo, hotkeyObj.description ,hotkeyObj.callback);
 
+hotkeyProvider.bindTo(scope)
+	.add(hotkeyObj)
+	.add(hotkeyObj)
+	.add({
+		combo: 'w',
+		description: 'blah blah',
+		callback: function() {}
+	});
+

--- a/angular-hotkeys/angular-hotkeys.d.ts
+++ b/angular-hotkeys/angular-hotkeys.d.ts
@@ -17,13 +17,19 @@ declare module ng.hotkeys {
 
         add(hotkeyObj: ng.hotkeys.Hotkey): void;
 
-        bindTo(scope : ng.IScope): ng.hotkeys.HotkeysProvider;
+        bindTo(scope : ng.IScope): ng.hotkeys.HotkeysProviderChained;
 
         del(combo: string): void;
 
         get(combo: string): ng.hotkeys.Hotkey;
 
         toggleCheatSheet(): void;
+    }
+
+    interface HotkeysProviderChained {
+        add(combo: string, description: string, callback: (event: Event, hotkeys: ng.hotkeys.Hotkey) => void): HotkeysProviderChained;
+
+        add(hotkeyObj: ng.hotkeys.Hotkey): HotkeysProviderChained;
     }
 
     interface Hotkey {


### PR DESCRIPTION
The bindTo method doesn't return a HotkeysProvider but a [specific object](https://github.com/chieffancypants/angular-hotkeys/blob/master/src/hotkeys.js#L451-L463).
