### PR TITLE
Update angular-mocks.d.ts

### DIFF
--- a/angularjs/angular-mocks.d.ts
+++ b/angularjs/angular-mocks.d.ts
@@ -33,9 +33,7 @@ declare module ng {
         inject(...inlineAnnotatedConstructor: any[]): any; // this overload is undocumented, but works
 
         // see http://docs.angularjs.org/api/angular.mock.module
-        module(...modules: string[]): any;
-        module(...modules: Function[]): any;
-        module(modules: Object): any;
+        module(...modules: any[]): any;
 
         // see http://docs.angularjs.org/api/angular.mock.TzDate
         TzDate(offset: number, timestamp: number): Date;


### PR DESCRIPTION
allow 

``` ts
angular.mock.module("myApp", function($provide) {
    $provide.value("myService", {
        ...
    });
})
```

Also signature is consistent with the global in the same file: 

``` ts
declare var module: (...modules: any[]) => any;
```

Report : http://stackoverflow.com/q/24964829/390330
