### PR TITLE
d3.d.dts: Rename "QuantitiveScale" to "QuantitativeScale" for consistency 

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -749,7 +749,7 @@ declare module D3 {
         insert: (name: string, before: string) => Selection;
         remove: () => Selection;
         empty: () => boolean;
-            
+
         data: {
             (values: (data: any, index?: number) => any[], key?: (data: any, index?: number) => any): UpdateSelection;
             (values: any[], key?: (data: any, index?: number) => any): UpdateSelection;
@@ -2508,7 +2508,7 @@ declare module D3 {
             copy(): Scale;
         }
 
-        export interface QuantitiveScale extends Scale {
+        export interface QuantitativeScale extends Scale {
             /**
             * Get the range value corresponding to a given domain value.
             *
@@ -2530,7 +2530,7 @@ declare module D3 {
                 *
                 * @param value The input domain
                 */
-                (values: any[]): QuantitiveScale;
+                (values: any[]): QuantitativeScale;
                 /**
                 * Get the scale's input domain.
                 */
@@ -2545,7 +2545,7 @@ declare module D3 {
                 *
                 * @param value The output range.
                 */
-                (values: any[]): QuantitiveScale;
+                (values: any[]): QuantitativeScale;
                 /**
                 * Get the scale's output range.
                 */
@@ -2556,26 +2556,26 @@ declare module D3 {
             *
             * @param value The output range.
             */
-            rangeRound: (values: any[]) => QuantitiveScale;
+            rangeRound: (values: any[]) => QuantitativeScale;
             /**
             * get or set the scale's output interpolator.
             */
             interpolate: {
                 (): D3.Transition.Interpolate;
-                (factory: D3.Transition.Interpolate): QuantitiveScale;
+                (factory: D3.Transition.Interpolate): QuantitativeScale;
             };
             /**
             * enable or disable clamping of the output range.
             *
             * @param clamp Enable or disable
             */
-            clamp(clamp: boolean): QuantitiveScale;
+            clamp(clamp: boolean): QuantitativeScale;
             /**
             * extend the scale domain to nice round numbers.
-            * 
+            *
             * @param count Optional number of ticks to exactly fit the domain
             */
-            nice(count?: number): QuantitiveScale;
+            nice(count?: number): QuantitativeScale;
             /**
             * get representative values from the input domain.
             *
@@ -2591,10 +2591,10 @@ declare module D3 {
             /**
             * create a new scale from an existing scale..
             */
-            copy(): QuantitiveScale;
+            copy(): QuantitativeScale;
         }
 
-        export interface LinearScale extends QuantitiveScale {
+        export interface LinearScale extends QuantitativeScale {
             /**
             * Get the range value corresponding to a given domain value.
             *
@@ -2630,7 +2630,7 @@ declare module D3 {
             tickFormat(count: number): (n: number) => string;
         }
 
-        export interface SqrtScale extends QuantitiveScale {
+        export interface SqrtScale extends QuantitativeScale {
             /**
             * Get the range value corresponding to a given domain value.
             *
@@ -2639,7 +2639,7 @@ declare module D3 {
             (value: number): number;
         }
 
-        export interface PowScale extends QuantitiveScale {
+        export interface PowScale extends QuantitativeScale {
             /**
             * Get the range value corresponding to a given domain value.
             *
@@ -2648,7 +2648,7 @@ declare module D3 {
             (value: number): number;
         }
 
-        export interface LogScale extends QuantitiveScale {
+        export interface LogScale extends QuantitativeScale {
             /**
             * Get the range value corresponding to a given domain value.
             *
@@ -3417,7 +3417,7 @@ declare module D3 {
                 *
                 * @param constant The new constant value.
                 */
-                (constant: number): Voronoi<T>;   
+                (constant: number): Voronoi<T>;
             }
             clipExtent: {
                 /**


### PR DESCRIPTION
Adds consistency with d3's API docs and common usage of the english language.

Close #2573

As copied from the issue:
Right now in d3.d.ts the base class for numerical scales is called "QuantitiveScale". However, in the D3 API reference, such scales are described as "Quantitative Scales" (just look at the spelling in this URL: https://github.com/mbostock/d3/wiki/Quantitative-Scales). Also, Google Trends shows that the word "Quantitative" is far more frequently used than "Quantitive" (http://www.google.com/trends/explore#q=quantitive%2C%20quantitative&cmpt=q) although they have the same meaning (http://grammarist.com/usage/quantitative-quantitive/)
