### PR TITLE
async.d.ts: Corrected forEach* to each*

### DIFF
--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -34,9 +34,9 @@ interface AsyncQueue<T> {
 interface Async {
 
     // Collections
-    forEach<T,R>(arr: T[], iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): void;
-    forEachSeries<T, R>(arr: T[], iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): void;
-    forEachLimit<T, R>(arr: T[], limit: number, iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): void;
+    each<T,R>(arr: T[], iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): void;
+    eachSeries<T, R>(arr: T[], iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): void;
+    eachLimit<T, R>(arr: T[], limit: number, iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): void;
     map<T, R>(arr: T[], iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): any;
     mapSeries<T, R>(arr: T[], iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): any;
     filter<T>(arr: T[], iterator: AsyncIterator<T, boolean>, callback: AsyncMultipleResultsCallback<T>): any;


### PR DESCRIPTION
The following APIs are incorrect and do not exist:
forEach
forEachSeries
forEachLimit

They should be refactored to the following respectively:
each (https://github.com/caolan/async#each)
eachSeries (https://github.com/caolan/async#eachSeries)
eachLimit (https://github.com/caolan/async#eachLimit)
