### PR TITLE
Fix module export

### DIFF
--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -3160,8 +3160,8 @@ interface _ChainOfArrays<T> extends _Chain<T[]> {
 	flatten(): _Chain<T>;
 }
 
-declare var _: UnderscoreStatic;
+declare var underscore: UnderscoreStatic;
 
 declare module "underscore" {
-	export = _;
+	export = underscore;
 }


### PR DESCRIPTION
"declare var _" at the bottom conflicts with "declare module _" at the top and breaks typing support in certain IDEs.
