### PR TITLE
Added interfaces for versions of $location

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -518,6 +518,18 @@ declare module ng {
     // see http://docs.angularjs.org/api/ng.$locationProvider
     // see http://docs.angularjs.org/guide/dev_guide.services.$location
     ///////////////////////////////////////////////////////////////////////////
+    interface ILocationHtml5UrlService extends ILocationHashbangUrl {
+    }
+
+    interface ILocationHashbangUrl extends ILocationHashbangInHtml5Url {
+        $$parse(url: string): void;
+        $$compose(): void;
+    }
+
+    interface ILocationHashbangInHtml5Url extends ILocationService {
+        $$rewrite(url: string): string;
+    }
+
     interface ILocationService {
         absUrl(): string;
         hash(): string;


### PR DESCRIPTION
Created interfaces to support the following functions that angular has available depending on the type of object returned for the $location service:
$$parse
$$compose
$$rewrite

In angular.js:
LocationHashbangInHtml5Url, LocationHashbangUrl and LocationHtml5Url all have $$rewrite.
Only LocationHashbangUrl and LocationHtml5Url have $$parse and $$compose.
