### PR TITLE
 Underscore.js: Fix for chained calls to first()

### DIFF
--- a/underscore/underscore-tests.ts
+++ b/underscore/underscore-tests.ts
@@ -328,4 +328,8 @@ function chain_tests() {
 		.flatten()
 		.find(num => num % 2 == 0)
 		.value();
+		
+	var firstVal: number = _.chain([1, 2, 3])
+		.first()
+		.value();
 }

--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -2620,7 +2620,7 @@ interface _Chain<T> {
 	* Wrapped type `any[]`.
 	* @see _.first
 	**/
-	first(): _Chain<T>;
+	first(): _ChainSingle<T>;
 
 	/**
 	* Wrapped type `any[]`.


### PR DESCRIPTION
Updated chained calls to first() so that they return a _ChainSingle<T> instead of _Chain<T>. This causes a future call to value() to return a single T rather than an array of T which matches underscore's behavior.
