### PR TITLE
added static html() methods to cheerio

### DIFF
--- a/cheerio/cheerio.d.ts
+++ b/cheerio/cheerio.d.ts
@@ -1,8 +1,6 @@
 // Type definitions for Cheerio v0.17.0
 // Project: https://github.com/cheeriojs/cheerio
-// Definitions by: Bret Little <https://github.com/blittle>
-// Definitions by: VILIC VANE <http://vilic.info>
-// Definitions by: Wayne Maurer <https://github.com/wmaurer>
+// Definitions by: Bret Little <https://github.com/blittle>, VILIC VANE <http://vilic.info>, Wayne Maurer <https://github.com/wmaurer>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 interface Cheerio {

--- a/cheerio/cheerio.d.ts
+++ b/cheerio/cheerio.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/cheeriojs/cheerio
 // Definitions by: Bret Little <https://github.com/blittle>
 // Definitions by: VILIC VANE <http://vilic.info>
+// Definitions by: Wayne Maurer <https://github.com/wmaurer>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 interface Cheerio {
@@ -190,6 +191,11 @@ interface CheerioStatic {
     root(): Cheerio;
     contains(container: CheerioElement, contained: CheerioElement): boolean;
     parseHTML(data: string, context?: Document, keepScripts?: boolean): Document[];
+
+    html(options?: CheerioOptionsInterface): string;
+    html(selector: string, options?: CheerioOptionsInterface): string;
+    html(element: Cheerio, options?: CheerioOptionsInterface): string;
+    html(element: CheerioElement, options?: CheerioOptionsInterface): string;
 }
 
 interface CheerioElement {


### PR DESCRIPTION
Two of the `$.html()` overloads are documented here:
https://github.com/cheeriojs/cheerio#rendering

The javascript source for the `html()` static method is here:
https://github.com/cheeriojs/cheerio/blob/master/lib/static.js#L41
