### PR TITLE
Correct parameter optionality

### DIFF
--- a/greensock/greensock.d.ts
+++ b/greensock/greensock.d.ts
@@ -7,7 +7,7 @@
 // Version 1.1 (TypeScript 0.9)
 
 interface IDispatcher {
-    addEventListener(type:string, callback:Function, scope:Object, useParam:boolean, priority:number):void;
+    addEventListener(type:string, callback:Function, scope?:Object, useParam?:boolean, priority?:number):void;
     removeEventListener(type:string, callback:Function):void;
 }
 


### PR DESCRIPTION
The last three parameters of ticker.addEventListener are optional. See: http://api.greensock.com/js/com/greensock/TweenMax.html#ticker
