### PR TITLE
Fixed missing editor related methods for SlickGrid Definitions

### DIFF
--- a/slickgrid/SlickGrid.d.ts
+++ b/slickgrid/SlickGrid.d.ts
@@ -501,6 +501,9 @@ declare module Slick {
 		* Width of the column in pixels. (May often be overridden by things like minWidth, maxWidth, forceFitColumns, etc.)
 		**/
 		width?: number;
+		
+		/** Called by Editors */
+		validator?: (input: any) => ValidateResults;
 	}
 
 	export interface EditorFactory {
@@ -1395,6 +1398,11 @@ declare module Slick {
 			column: Column<T>;
 			container: HTMLElement;
 			grid: Grid<T>;
+			gridPosition: CellPosition;
+			position: CellPosition;
+			item: Slick.SlickData;
+			commitChanges: () => void;
+			cancelChanges: () => void;
 		}
 
 		export class Editor<T extends Slick.SlickData> {
@@ -1540,10 +1548,11 @@ declare module Slick {
 			public expandGroup(...varArgs: string[]): void;
 			public getGroups(): Group<T, any>[];
 			public getIdxById(id: string): number;
-			public getRowById(): T;
+			public getRowById(id: string): number;
 			public getItemById(id: any): T;
 			public getItemByIdx(): T;
-			public mapRowsToIds(rowArray: T[]): string[];
+			public mapRowsToIds(rowArray: number[]): string[];
+			public mapIdsToRows(idArray: string[]): number[];
 			public setRefreshHints(hints: RefreshHints): void;
 			public setFilterArgs(args: any): void;
 			public refresh(): void;


### PR DESCRIPTION
Hello,

I found the SlickGrid definition was missing some methods required for implementation of editors, so I went ahead an added them:
- missing EditorFactory properties from https://github.com/mleibman/SlickGrid/wiki/Writing-custom-cell-editors
- Column.validator required by editor implementations: https://github.com/mleibman/SlickGrid/blob/master/slick.editors.js
- Types of DataView-Methods according to source: https://github.com/mleibman/SlickGrid/blob/master/slick.dataview.js
