### PR TITLE
Phonegap: Fixed Filesystem api

### DIFF
--- a/phonegap/phonegap.d.ts
+++ b/phonegap/phonegap.d.ts
@@ -367,7 +367,7 @@ interface FileUploadResult {
 
 interface Flags {
     create: boolean;
-    exclusive: boolean;
+    exclusive?: boolean;
 }
 
 /*


### PR DESCRIPTION
exclusive is optional: see example here http://dev.w3.org/2009/dap/file-system/file-dir-sys.html#the-flags-dictionary
