### PR TITLE
Phonegap: Added Keyboard plugin

### DIFF
--- a/phonegap/phonegap.d.ts
+++ b/phonegap/phonegap.d.ts
@@ -590,6 +590,21 @@ interface StatusBar {
 }
 declare var StatusBar: StatusBar;
 
+interface Keyboard {
+    automaticScrollToTopOnHiding: boolean;
+    isVisible: boolean;
+
+    onshow: Function;
+    onhide: Function;
+    onshowing: Function;
+    onhiding: Function;
+
+    disableScrollingInShrinkView(disable: boolean): void;
+    hideFormAccessoryBar(hide: boolean): void;
+    shrinkView(shrink: boolean): void;
+}
+declare var Keyboard: Keyboard;
+
 interface /*PhoneGapNavigator extends*/ Navigator {
     accelerometer: Accelerometer;
     camera: Camera;


### PR DESCRIPTION
Added interfaces for keyboard plugin.
docs: https://github.com/apache/cordova-plugins/tree/master/keyboard

Small side-note: this (currently) an iOS only plugin so is this something you guys would like in the global definition file?
