### PR TITLE
Phonegap: Added StatusBar plugin interface

### DIFF
--- a/phonegap/phonegap.d.ts
+++ b/phonegap/phonegap.d.ts
@@ -575,6 +575,21 @@ interface LocalStorage {
 }
 */
 
+interface StatusBar {
+    isVisible: boolean;
+
+    overlaysWebView(doOverlay: boolean): void;
+    styleDefault(): void;
+    styleLightContent(): void;
+    styleBlackTranslucent(): void;
+    styleBlackOpaque(): void;
+    backgroundColorByName(colorname: string): void;
+    backgroundColorByHexString(hexString: string): void;
+    hide(): void;
+    show(): void;
+}
+declare var StatusBar: StatusBar;
+
 interface /*PhoneGapNavigator extends*/ Navigator {
     accelerometer: Accelerometer;
     camera: Camera;

--- a/phonegap/phonegap.d.ts
+++ b/phonegap/phonegap.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for PhoneGap 2.3
 // Project: http://phonegap.com
-// Definitions by: Boris Yankov <https://github.com/borisyankov/>
+// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Dick van den Brink <https://github.com/DickvdBrink>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 interface GeolocationError {


### PR DESCRIPTION
Added interface for the statusbar plugin. This plugin is supported on multiple platforms (WP7/8, iOS and Android)
Docs: https://github.com/apache/cordova-plugin-statusbar/blob/master/doc/index.md
