### PR TITLE
async: Corrected APIs from forEach* to each*

### DIFF
--- a/async/async-tests.ts
+++ b/async/async-tests.ts
@@ -26,10 +26,11 @@ async.map(data, asyncProcess, function (err, results) {
 
 var openFiles = ['file1', 'file2'];
 var saveFile = function () { }
-async.forEach(openFiles, saveFile, function (err) { });
+async.each(openFiles, saveFile, function (err) { });
+async.eachSeries(openFiles, saveFile, function (err) { });
 
 var documents, requestApi;
-async.forEachLimit(documents, 20, requestApi, function (err) { });
+async.eachLimit(documents, 20, requestApi, function (err) { });
 
 async.map(['file1', 'file2', 'file3'], fs.stat, function (err, results) { });
 

--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -34,9 +34,9 @@ interface AsyncQueue<T> {
 interface Async {
 
     // Collections
-    forEach<T,R>(arr: T[], iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): void;
-    forEachSeries<T, R>(arr: T[], iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): void;
-    forEachLimit<T, R>(arr: T[], limit: number, iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): void;
+    each<T,R>(arr: T[], iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): void;
+    eachSeries<T, R>(arr: T[], iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): void;
+    eachLimit<T, R>(arr: T[], limit: number, iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): void;
     map<T, R>(arr: T[], iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): any;
     mapSeries<T, R>(arr: T[], iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): any;
     filter<T>(arr: T[], iterator: AsyncIterator<T, boolean>, callback: AsyncMultipleResultsCallback<T>): any;


### PR DESCRIPTION
The following APIs are incorrect and do not exist:
forEach
forEachSeries
forEachLimit

This commit refactors them to the following respectively:
each (https://github.com/caolan/async#each)
eachSeries (https://github.com/caolan/async#eachSeries)
eachLimit (https://github.com/caolan/async#eachLimit)

Additionally it adds a test for forEachSeries, which was missing.
