### PR TITLE
d3: Typed Scale interface to remove duplicate code

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1648,13 +1648,13 @@ declare module D3 {
                 /**
                 * Gets  the x-scale associated with the brush
                 */
-                (): D3.Scale.Scale;
+                (): D3.Scale.UntypedScale;
                 /**
                 * Sets the x-scale associated with the brush
                 *
                 * @param accessor The new Scale
                 */
-                (scale: D3.Scale.Scale): Brush;
+                (scale: D3.Scale.UntypedScale): Brush;
             };
             /**
             * Gets or sets the x-scale associated with the brush
@@ -1663,13 +1663,13 @@ declare module D3 {
                 /**
                 * Gets  the x-scale associated with the brush
                 */
-                (): D3.Scale.Scale;
+                (): D3.Scale.UntypedScale;
                 /**
                 * Sets the x-scale associated with the brush
                 *
                 * @param accessor The new Scale
                 */
-                (scale: D3.Scale.Scale): Brush;
+                (scale: D3.Scale.UntypedScale): Brush;
             };
             /**
             * Gets or sets the current brush extent
@@ -2518,21 +2518,23 @@ declare module D3 {
             threshold(): ThresholdScale;
         }
 
-        export interface Scale {
+        export interface Scale<S> {
             (value: any): any;
             domain: {
-                (values: any[]): Scale;
+                (values: any[]): S;
                 (): any[];
             };
             range: {
-                (values: any[]): Scale;
+                (values: any[]): S;
                 (): any[];
             };
             invertExtent?(y: any): any[];
-            copy(): Scale;
+            copy(): S;
         }
 
-        export interface QuantitativeScale extends Scale {
+        export interface UntypedScale extends Scale<UntypedScale> { }
+
+        export interface QuantitativeScale<S> extends Scale<S> {
             /**
             * Get the range value corresponding to a given domain value.
             *
@@ -2546,47 +2548,17 @@ declare module D3 {
             */
             invert(value: number): number;
             /**
-            * Get or set the scale's input domain.
-            */
-            domain: {
-                /**
-                * Set the scale's input domain.
-                *
-                * @param value The input domain
-                */
-                (values: any[]): QuantitativeScale;
-                /**
-                * Get the scale's input domain.
-                */
-                (): any[];
-            };
-            /**
-            * get or set the scale's output range.
-            */
-            range: {
-                /**
-                * Set the scale's output range.
-                *
-                * @param value The output range.
-                */
-                (values: any[]): QuantitativeScale;
-                /**
-                * Get the scale's output range.
-                */
-                (): any[];
-            };
-            /**
             * Set the scale's output range, and enable rounding.
             *
             * @param value The output range.
             */
-            rangeRound: (values: any[]) => QuantitativeScale;
+            rangeRound: (values: any[]) => S;
             /**
             * get or set the scale's output interpolator.
             */
             interpolate: {
                 (): D3.Transition.Interpolate;
-                (factory: D3.Transition.Interpolate): QuantitativeScale;
+                (factory: D3.Transition.Interpolate): S;
             };
             /**
             * enable or disable clamping of the output range.
@@ -2595,14 +2567,14 @@ declare module D3 {
             */
             clamp: {
                 (): boolean;
-                (clamp: boolean): QuantitativeScale;
+                (clamp: boolean): S;
             }
             /**
             * extend the scale domain to nice round numbers.
             *
             * @param count Optional number of ticks to exactly fit the domain
             */
-            nice(count?: number): QuantitativeScale;
+            nice(count?: number): S;
             /**
             * get representative values from the input domain.
             *
@@ -2615,22 +2587,11 @@ declare module D3 {
             * @param count Aproximate representative values to return
             */
             tickFormat(count: number, format?: string): (n: number) => string;
-            /**
-            * create a new scale from an existing scale..
-            */
-            copy(): QuantitativeScale;
         }
 
-        export interface LinearScale extends QuantitativeScale {
-            /**
-            * Get the range value corresponding to a given domain value.
-            *
-            * @param value Domain Value
-            */
-            (value: number): number;
-        }
+        export interface LinearScale extends QuantitativeScale<LinearScale> { }
 
-        export interface IdentityScale extends Scale {
+        export interface IdentityScale extends Scale<IdentityScale> {
             /**
             * Get the range value corresponding to a given domain value.
             *
@@ -2657,132 +2618,31 @@ declare module D3 {
             tickFormat(count: number): (n: number) => string;
         }
 
-        export interface SqrtScale extends QuantitativeScale {
-            /**
-            * Get the range value corresponding to a given domain value.
-            *
-            * @param value Domain Value
-            */
-            (value: number): number;
-        }
+        export interface SqrtScale extends QuantitativeScale<SqrtScale> { }
 
-        export interface PowScale extends QuantitativeScale {
-            /**
-            * Get the range value corresponding to a given domain value.
-            *
-            * @param value Domain Value
-            */
-            (value: number): number;
-        }
+        export interface PowScale extends QuantitativeScale<PowScale> { }
 
-        export interface LogScale extends QuantitativeScale {
-            /**
-            * Get the range value corresponding to a given domain value.
-            *
-            * @param value Domain Value
-            */
-            (value: number): number;
-        }
+        export interface LogScale extends QuantitativeScale<LogScale> { }
 
-        export interface OrdinalScale extends Scale {
-            /**
-            * Get the range value corresponding to a given domain value.
-            *
-            * @param value Domain Value
-            */
-            (value: any): any;
-            /**
-            * Get or set the scale's input domain.
-            */
-            domain: {
-                /**
-                * Set the scale's input domain.
-                *
-                * @param value The input domain
-                */
-                (values: any[]): OrdinalScale;
-                /**
-                * Get the scale's input domain.
-                */
-                (): any[];
-            };
-            /**
-            * get or set the scale's output range.
-            */
-            range: {
-                /**
-                * Set the scale's output range.
-                *
-                * @param value The output range.
-                */
-                (values: any[]): OrdinalScale;
-                /**
-                * Get the scale's output range.
-                */
-                (): any[];
-            };
+        export interface OrdinalScale extends Scale<OrdinalScale> {
             rangePoints(interval: any[], padding?: number): OrdinalScale;
             rangeBands(interval: any[], padding?: number, outerPadding?: number): OrdinalScale;
             rangeRoundBands(interval: any[], padding?: number, outerPadding?: number): OrdinalScale;
             rangeBand(): number;
             rangeExtent(): any[];
-            /**
-            * create a new scale from an existing scale..
-            */
-            copy(): OrdinalScale;
         }
 
-        export interface QuantizeScale extends Scale {
-            (value: any): any;
-            domain: {
-                (values: number[]): QuantizeScale;
-                (): any[];
-            };
-            range: {
-                (values: any[]): QuantizeScale;
-                (): any[];
-            };
-            copy(): QuantizeScale;
-        }
+        export interface QuantizeScale extends Scale<QuantizeScale> { }
 
-        export interface ThresholdScale extends Scale {
-            (value: any): any;
-            domain: {
-                (values: number[]): ThresholdScale;
-                (): any[];
-            };
-            range: {
-                (values: any[]): ThresholdScale;
-                (): any[];
-            };
-            copy(): ThresholdScale;
-        }
+        export interface ThresholdScale extends Scale<ThresholdScale> { }
 
-        export interface QuantileScale extends Scale {
-            (value: any): any;
-            domain: {
-                (values: number[]): QuantileScale;
-                (): any[];
-            };
-            range: {
-                (values: any[]): QuantileScale;
-                (): any[];
-            };
+        export interface QuantileScale extends Scale<QuantileScale> {
             quantiles(): any[];
-            copy(): QuantileScale;
         }
 
-        export interface TimeScale extends Scale {
+        export interface TimeScale extends Scale<TimeScale> {
             (value: Date): number;
             invert(value: number): Date;
-            domain: {
-                (values: any[]): TimeScale;
-                (): any[];
-            };
-            range: {
-                (values: any[]): TimeScale;
-                (): any[];
-            };
             rangeRound: (values: any[]) => TimeScale;
             interpolate: {
                 (): D3.Transition.Interpolate;
@@ -2794,7 +2654,6 @@ declare module D3 {
                 (range: D3.Time.Range, count: number): any[];
             };
             tickFormat(count: number): (n: number) => string;
-            copy(): TimeScale;
             nice(count?: number): TimeScale;
         }
     }
@@ -2883,13 +2742,13 @@ declare module D3 {
                 /**
                 * Get the X-Scale
                 */
-                (): D3.Scale.Scale;
+                (): D3.Scale.UntypedScale;
                 /**
                 * Set the X-Scale to be adjusted
                 *
                 * @param x The X Scale
                 */
-                (x: D3.Scale.Scale): Zoom;
+                (x: D3.Scale.UntypedScale): Zoom;
 
             };
 
@@ -2900,13 +2759,13 @@ declare module D3 {
                 /**
                 * Get the Y-Scale
                 */
-                (): D3.Scale.Scale;
+                (): D3.Scale.UntypedScale;
                 /**
                 * Set the Y-Scale to be adjusted
                 *
                 * @param y The Y Scale
                 */
-                (y: D3.Scale.Scale): Zoom;
+                (y: D3.Scale.UntypedScale): Zoom;
             };
         }
 

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1648,13 +1648,13 @@ declare module D3 {
                 /**
                 * Gets  the x-scale associated with the brush
                 */
-                (): D3.Scale.UntypedScale;
+                (): D3.Scale.Scale;
                 /**
                 * Sets the x-scale associated with the brush
                 *
                 * @param accessor The new Scale
                 */
-                (scale: D3.Scale.UntypedScale): Brush;
+                (scale: D3.Scale.Scale): Brush;
             };
             /**
             * Gets or sets the x-scale associated with the brush
@@ -1663,13 +1663,13 @@ declare module D3 {
                 /**
                 * Gets  the x-scale associated with the brush
                 */
-                (): D3.Scale.UntypedScale;
+                (): D3.Scale.Scale;
                 /**
                 * Sets the x-scale associated with the brush
                 *
                 * @param accessor The new Scale
                 */
-                (scale: D3.Scale.UntypedScale): Brush;
+                (scale: D3.Scale.Scale): Brush;
             };
             /**
             * Gets or sets the current brush extent
@@ -2518,7 +2518,7 @@ declare module D3 {
             threshold(): ThresholdScale;
         }
 
-        export interface Scale<S> {
+        export interface GenericScale<S> {
             (value: any): any;
             domain: {
                 (values: any[]): S;
@@ -2532,9 +2532,9 @@ declare module D3 {
             copy(): S;
         }
 
-        export interface UntypedScale extends Scale<UntypedScale> { }
+        export interface Scale extends GenericScale<Scale> { }
 
-        export interface QuantitativeScale<S> extends Scale<S> {
+        export interface GenericQuantitativeScale<S> extends GenericScale<S> {
             /**
             * Get the range value corresponding to a given domain value.
             *
@@ -2589,9 +2589,11 @@ declare module D3 {
             tickFormat(count: number, format?: string): (n: number) => string;
         }
 
-        export interface LinearScale extends QuantitativeScale<LinearScale> { }
+        export interface QuantitativeScale extends GenericQuantitativeScale<QuantitativeScale> { }
 
-        export interface IdentityScale extends Scale<IdentityScale> {
+        export interface LinearScale extends GenericQuantitativeScale<LinearScale> { }
+
+        export interface IdentityScale extends GenericScale<IdentityScale> {
             /**
             * Get the range value corresponding to a given domain value.
             *
@@ -2618,13 +2620,13 @@ declare module D3 {
             tickFormat(count: number): (n: number) => string;
         }
 
-        export interface SqrtScale extends QuantitativeScale<SqrtScale> { }
+        export interface SqrtScale extends GenericQuantitativeScale<SqrtScale> { }
 
-        export interface PowScale extends QuantitativeScale<PowScale> { }
+        export interface PowScale extends GenericQuantitativeScale<PowScale> { }
 
-        export interface LogScale extends QuantitativeScale<LogScale> { }
+        export interface LogScale extends GenericQuantitativeScale<LogScale> { }
 
-        export interface OrdinalScale extends Scale<OrdinalScale> {
+        export interface OrdinalScale extends GenericScale<OrdinalScale> {
             rangePoints(interval: any[], padding?: number): OrdinalScale;
             rangeBands(interval: any[], padding?: number, outerPadding?: number): OrdinalScale;
             rangeRoundBands(interval: any[], padding?: number, outerPadding?: number): OrdinalScale;
@@ -2632,15 +2634,15 @@ declare module D3 {
             rangeExtent(): any[];
         }
 
-        export interface QuantizeScale extends Scale<QuantizeScale> { }
+        export interface QuantizeScale extends GenericScale<QuantizeScale> { }
 
-        export interface ThresholdScale extends Scale<ThresholdScale> { }
+        export interface ThresholdScale extends GenericScale<ThresholdScale> { }
 
-        export interface QuantileScale extends Scale<QuantileScale> {
+        export interface QuantileScale extends GenericScale<QuantileScale> {
             quantiles(): any[];
         }
 
-        export interface TimeScale extends Scale<TimeScale> {
+        export interface TimeScale extends GenericScale<TimeScale> {
             (value: Date): number;
             invert(value: number): Date;
             rangeRound: (values: any[]) => TimeScale;
@@ -2742,13 +2744,13 @@ declare module D3 {
                 /**
                 * Get the X-Scale
                 */
-                (): D3.Scale.UntypedScale;
+                (): D3.Scale.Scale;
                 /**
                 * Set the X-Scale to be adjusted
                 *
                 * @param x The X Scale
                 */
-                (x: D3.Scale.UntypedScale): Zoom;
+                (x: D3.Scale.Scale): Zoom;
 
             };
 
@@ -2759,13 +2761,13 @@ declare module D3 {
                 /**
                 * Get the Y-Scale
                 */
-                (): D3.Scale.UntypedScale;
+                (): D3.Scale.Scale;
                 /**
                 * Set the Y-Scale to be adjusted
                 *
                 * @param y The Y Scale
                 */
-                (y: D3.Scale.UntypedScale): Zoom;
+                (y: D3.Scale.Scale): Zoom;
             };
         }
 


### PR DESCRIPTION
It is easier to understand what each interface that extends Scale actually does differently if the reader does not have to wade through redeclarations of domain, range, and copy.
