### PR TITLE
Color.brighter has an optional number parameter

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1492,7 +1492,7 @@ declare module D3 {
             /**
             * increase lightness by some exponential factor (gamma)
             */
-            brighter(k: number): Color;
+            brighter(k?: number): Color;
             /**
             * decrease lightness by some exponential factor (gamma)
             */


### PR DESCRIPTION
Color.brighter has an optional number parameter, it is not required.
