### PR TITLE
added missing method 'getBoundingRect()' for fabric.js

### DIFF
--- a/fabricjs/fabricjs.d.ts
+++ b/fabricjs/fabricjs.d.ts
@@ -335,6 +335,7 @@ declare module fabric {
         drawBorders(context: CanvasRenderingContext2D): IObject;
         drawCorners(context: CanvasRenderingContext2D): IObject;
         get (property: string): any;
+        getBoundingRect(): {left:number; top:number; width:number; height:number};
         getBoundingRectHeight(): number;
         getBoundingRectWidth(): number;
         getSvgStyles(): string;


### PR DESCRIPTION
added missing method 'getBoundingRect()' for fabric.js which is available since ~1.0.4 (current version 1.4.10)

Nothing more to say ;-)
