### PR TITLE
Add back the assert global variable

### DIFF
--- a/chai/chai.d.ts
+++ b/chai/chai.d.ts
@@ -278,6 +278,8 @@ declare module chai {
     }
 }
 
+declare var assert: chai.Assert;
+
 declare module "chai" {
     export = chai;
 }


### PR DESCRIPTION
I think it was lost when chai-assert.d.ts was consolidated into chai.d.ts.  The global is correct and necessary for use of chai without a module system.
