### PR TITLE
Updated Force Layout nodes and links

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1237,6 +1237,21 @@ declare module D3 {
             source: GraphNode;
             target: GraphNode;
         }
+        
+        export interface GraphNodeForce {
+            index?: number;
+            x?: number;
+            y?: number;
+            px?: number;
+            py?: number;
+            fixed?: boolean;
+            weight?: number;
+        }
+
+        export interface GraphLinkForce {
+            source: GraphNodeForce;
+            target: GraphNodeForce;
+        }
 
         export interface ForceLayout {
             (): ForceLayout;
@@ -1287,14 +1302,14 @@ declare module D3 {
             };
 
             links: {
-                (): GraphLink[];
-                (arLinks: GraphLink[]): ForceLayout;
+                (): GraphLinkForce[];
+                (arLinks: GraphLinkForce[]): ForceLayout;
 
             };
             nodes:
             {
-                (): GraphNode[];
-                (arNodes: GraphNode[]): ForceLayout;
+                (): GraphNodeForce[];
+                (arNodes: GraphNodeForce[]): ForceLayout;
 
             };
             start(): ForceLayout;


### PR DESCRIPTION
Different layouts have different definitions for node objects and link objects.
I created a new `GraphNodeForce` and `GraphLinkForce` interface for the Force Layout.
See the [docs](https://github.com/mbostock/d3/wiki/Force-Layout#nodes) for more info.
