### PR TITLE
Update backbone.d.ts

### DIFF
--- a/backbone/backbone.d.ts
+++ b/backbone/backbone.d.ts
@@ -146,7 +146,6 @@ declare module Backbone {
         previousAttributes(): any[];
         save(attributes?: any, options?: ModelSaveOptions): any;
         unset(attribute: string, options?: Silenceable): Model;
-        validate(attributes: any, options?: any): any;
 
         private _validate(attrs: any, options: any): boolean;
 
@@ -215,12 +214,10 @@ declare module Backbone {
         any(iterator: (element: TModel, index: number) => boolean, context?: any): boolean;
         collect(iterator: (element: TModel, index: number, context?: any) => any[], context?: any): any[];
         chain(): any;
-        compact(): TModel[];
         contains(value: any): boolean;
         countBy(iterator: (element: TModel, index: number) => any): _.Dictionary<number>;
         countBy(attribute: string): _.Dictionary<number>;
         detect(iterator: (item: any) => boolean, context?: any): any; // ???
-        difference(...model: TModel[]): TModel[];
         drop(): TModel;
         drop(n: number): TModel[];
         each(iterator: (element: TModel, index: number, list?: any) => void, context?: any): any;
@@ -229,7 +226,6 @@ declare module Backbone {
         find(iterator: (element: TModel, index: number) => boolean, context?: any): TModel;
         first(): TModel;
         first(n: number): TModel[];
-        flatten(shallow?: boolean): TModel[];
         foldl(iterator: (memo: any, element: TModel, index: number) => any, initialMemo: any, context?: any): any;
         forEach(iterator: (element: TModel, index: number, list?: any) => void, context?: any): any;
         groupBy(iterator: (element: TModel, index: number) => string, context?: any): _.Dictionary<TModel[]>;
@@ -239,7 +235,6 @@ declare module Backbone {
         initial(): TModel;
         initial(n: number): TModel[];
         inject(iterator: (memo: any, element: TModel, index: number) => any, initialMemo: any, context?: any): any;
-        intersection(...model: TModel[]): TModel[];
         isEmpty(object: any): boolean;
         invoke(methodName: string, arguments?: any[]): any;
         last(): TModel;
@@ -248,7 +243,6 @@ declare module Backbone {
         map(iterator: (element: TModel, index: number, context?: any) => any[], context?: any): any[];
         max(iterator?: (element: TModel, index: number) => any, context?: any): TModel;
         min(iterator?: (element: TModel, index: number) => any, context?: any): TModel;
-        object(...values: any[]): any[];
         reduce(iterator: (memo: any, element: TModel, index: number) => any, initialMemo: any, context?: any): any;
         select(iterator: any, context?: any): any[];
         size(): number;
@@ -257,8 +251,6 @@ declare module Backbone {
         sortBy(iterator: (element: TModel, index: number) => number, context?: any): TModel[];
         sortBy(attribute: string, context?: any): TModel[];
         sortedIndex(element: TModel, iterator?: (element: TModel, index: number) => number): number;
-        range(stop: number, step?: number): any;
-        range(start: number, stop: number, step?: number): any;
         reduceRight(iterator: (memo: any, element: TModel, index: number) => any, initialMemo: any, context?: any): any[];
         reject(iterator: (element: TModel, index: number) => boolean, context?: any): TModel[];
         rest(): TModel;
@@ -266,10 +258,7 @@ declare module Backbone {
         tail(): TModel;
         tail(n: number): TModel[];
         toArray(): any[];
-        union(...model: TModel[]): TModel[];
-        uniq(isSorted?: boolean, iterator?: (element: TModel, index: number) => boolean): TModel[];
         without(...values: any[]): TModel[];
-        zip(...model: TModel[]): TModel[];
     }
 
     class Router extends Events {
@@ -364,7 +353,6 @@ declare module Backbone {
         $(selector: any): JQuery;
         render(): View<TModel>;
         remove(): View<TModel>;
-        make(tagName: any, attributes?: any, content?: any): any;
         delegateEvents(events?: any): any;
         undelegateEvents(): any;
 


### PR DESCRIPTION
Removed methods from underscore that are no longer mixed in with Collection:
`compact difference flatten intersection object union uniq zip range`

Removed `make` method from `View`: nowhere to be found in 1.0, apparently dates from 0.9.0

Removed `validate` method from `Model`, only the `_validate` exists, I see no sign of ever a `validate` method being called nor triggered.
