### PR TITLE
Update jasmine.d.ts

### DIFF
--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -45,6 +45,7 @@ declare module jasmine {
     function createSpyObj<T>(baseName: string, methodNames: any[]): T;
     function pp(value: any): string;
     function getEnv(): Env;
+    function addMatchers(matchers: any): Any;
 
     interface Any {
 


### PR DESCRIPTION
Recent Jasmine version defines an "addMatchers" method on the Jasmine interface.

https://github.com/pivotal/jasmine/wiki/Matchers

Current TypeScript definition file does not support this method, making it difficult to define custom matchers in TypeScript unit tests.
