### PR TITLE
removed `createCanvasForNode`

### DIFF
--- a/fabricjs/fabricjs.d.ts
+++ b/fabricjs/fabricjs.d.ts
@@ -5,7 +5,6 @@
 
 declare module fabric {
 
-    function createCanvasForNode(width: number, height: number): ICanvas;
     function getCSSRules(doc: SVGElement);
     function getGradientDefs(doc: SVGElement);
     function loadSVGFromString(text: string, callback: (results: IObject[], options) => void , reviver?: (el, obj) => void );


### PR DESCRIPTION
this function available as a property on the fabricjs object is no longer present in the current version of fabricjs.
