### PR TITLE
Reduced type severity of templateProvider in IState interface

### DIFF
--- a/angular-ui/angular-ui-router.d.ts
+++ b/angular-ui/angular-ui-router.d.ts
@@ -11,7 +11,7 @@ declare module ng.ui {
         name?: string;
         template?: any;
         templateUrl?: any;
-        templateProvider?: () => string;
+        templateProvider?: any;
         controller?: any;
         controllerAs?: string;
         controllerProvider?: any;


### PR DESCRIPTION
templateProvider can be an annotated function (any[]) like controllerProvider, so any is a more appropriate typing.
