### PR TITLE
Corrected type annotations and method signatures for ZyngaScroller

### DIFF
--- a/scroller/scroller.d.ts
+++ b/scroller/scroller.d.ts
@@ -38,10 +38,10 @@ declare class Scroller {
     finishPullToRefresh(): void;
     getValues(): ScrollValuesWithZoom;
     getScrollMax(): ScrollValues;
-    zoomTo(level: number, animate?: boolean, originLeft?: boolean, originTop?: boolean): void;
-    zoomBy(factor: number, animate?: boolean, originLeft?: boolean, originTop?: boolean): void;
-    scrollTo(left?: number, top?: number, animate?: number, zoom?: number): void;
-    scrollBy(left?: number, top?: number, animate?: number): void;
+    zoomTo(level: number, animate?: boolean, originLeft?: number, originTop?: number, callback?: Function): void;
+    zoomBy(factor: number, animate?: boolean, originLeft?: number, originTop?: number, callback?: Function): void;
+    scrollTo(left?: number, top?: number, animate?: boolean, zoom?: number): void;
+    scrollBy(left?: number, top?: number, animate?: boolean): void;
 
     doMouseZoom(wheelDelta: number, timeStamp: number, pageX: number, pageY: number): void;
     doTouchStart(touches: any[], timeStamp: number): void;


### PR DESCRIPTION
Corrected wrong types (number -> boolean, boolean -> number).
Added missing callback argument.

See:
[zynga/scroller L443](https://github.com/zynga/scroller/blob/dadd850722ad2be9a865e4d84cb76c0197b68734/src/Scroller.js#L443)
[zynga/scroller L512](https://github.com/zynga/scroller/blob/dadd850722ad2be9a865e4d84cb76c0197b68734/src/Scroller.js#L512)
[zynga/scroller L529](https://github.com/zynga/scroller/blob/dadd850722ad2be9a865e4d84cb76c0197b68734/src/Scroller.js#L529)
[zynga/scroller L610](https://github.com/zynga/scroller/blob/dadd850722ad2be9a865e4d84cb76c0197b68734/src/Scroller.js#L610)
