### PR TITLE
Knockout 3.2 fix for ko.components

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -545,7 +545,7 @@ interface KnockoutStatic {
         writeValue(element: HTMLElement, value: any): void;
     };
 
-    components: KnockoutComponents ;
+    components: KnockoutComponents;
 }
 
 interface KnockoutBindingProvider {

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -544,6 +544,8 @@ interface KnockoutStatic {
 
         writeValue(element: HTMLElement, value: any): void;
     };
+
+    components: KnockoutComponents ;
 }
 
 interface KnockoutBindingProvider {


### PR DESCRIPTION
According to the documentation ko.components is missing
http://knockoutjs.com/documentation/component-registration.html
