### PR TITLE
[refactor] Switch from Array<type> notation to type[] syntactic sugar.

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -417,7 +417,7 @@ declare module D3 {
         /*
         * The array of built-in interpolator factories
         */
-        interpolators: Array<Transition.InterpolateFactory>;
+        interpolators: Transition.InterpolateFactory[];
         /**
         * Layouts
         */
@@ -525,11 +525,11 @@ declare module D3 {
         /**
         * gets the mouse position relative to a specified container.
         */
-        mouse(container: any): Array<number>;
+        mouse(container: any): number[];
         /**
         * gets the touch positions relative to a specified container.
         */
-        touches(container: any): Array<Array<number>>;
+        touches(container: any): number[][];
 
         /**
         * If the specified value is a function, returns the specified value.
@@ -542,8 +542,8 @@ declare module D3 {
         set(): Set<any>;
         map<T>(object: {[key: string]: T; }): Map<T>;
         set<T>(array: T[]): Set<T>;
-        dispatch(...types: Array<string>): Dispatch;
-        rebind(target: any, source: any, ...names: Array<any>): any;
+        dispatch(...types: string[]): Dispatch;
+        rebind(target: any, source: any, ...names: any[]): any;
         requote(str: string): string;
         timer: {
             (funct: () => boolean, delay?: number, mark?: number): void;
@@ -1134,11 +1134,11 @@ declare module D3 {
             /**
             * Runs the tree layout
             */
-            nodes(root: GraphNode): Array<GraphNode>;
+            nodes(root: GraphNode): GraphNode[];
             /**
             * Given the specified array of nodes, such as those returned by nodes, returns an array of objects representing the links from parent to child for each node
             */
-            links(nodes: Array<GraphNode>): Array<GraphLink>;
+            links(nodes: GraphNode[]): GraphLink[];
             /**
             * If separation is specified, uses the specified function to compute separation between neighboring nodes. If separation is not specified, returns the current separation function
             */
@@ -1159,11 +1159,11 @@ declare module D3 {
                 /**
                 * Gets the available layout size
                 */
-                (): Array<number>;
+                (): number[];
                 /**
                 * Sets the available layout size
                 */
-                (size: Array<number>): TreeLayout;
+                (size: number[]): TreeLayout;
             };
             /**
             * Gets or sets the available node size
@@ -1172,11 +1172,11 @@ declare module D3 {
                 /**
                 * Gets the available node size
                 */
-                (): Array<number>;
+                (): number[];
                 /**
                 * Sets the available node size
                 */
-                (size: Array<number>): TreeLayout;
+                (size: number[]): TreeLayout;
             };
         }
 
@@ -1323,13 +1323,13 @@ declare module D3 {
         }
 
         export interface BundleLayout{
-            (links: Array<GraphLink>): Array<Array<GraphNode>>;
+            (links: GraphLink[]): GraphNode[][];
         }
 
         export interface ChordLayout {
             matrix: {
-                (): Array<Array<number>>;
-                (matrix: Array<Array<number>>): ChordLayout;
+                (): number[][];
+                (matrix: number[][]): ChordLayout;
             }
             padding: {
                 (): number;
@@ -1347,8 +1347,8 @@ declare module D3 {
                 (): (a: number, b: number) => number;
                 (comparator: (a: number, b: number) => number): ChordLayout;
             }
-            chords(): Array<GraphLink>;
-            groups(): Array<ArcDescriptor>;
+            chords(): GraphLink[];
+            groups(): ArcDescriptor[];
         }
 
         export interface ClusterLayout{
@@ -1357,18 +1357,18 @@ declare module D3 {
                 (comparator: (a: GraphNode, b: GraphNode) => number): ClusterLayout;
             }
             children: {
-                (): (d: any, i?: number) => Array<GraphNode>;
-                (children: (d: any, i?: number) => Array<GraphNode>): ClusterLayout;
+                (): (d: any, i?: number) => GraphNode[];
+                (children: (d: any, i?: number) => GraphNode[]): ClusterLayout;
             }
-            nodes(root: GraphNode): Array<GraphNode>;
-            links(nodes: Array<GraphNode>): Array<GraphLink>;
+            nodes(root: GraphNode): GraphNode[];
+            links(nodes: GraphNode[]): GraphLink[];
             seperation: {
                 (): (a: GraphNode, b: GraphNode) => number;
                 (seperation: (a: GraphNode, b: GraphNode) => number): ClusterLayout;
             }
             size: {
-                (): Array<number>;
-                (size: Array<number>): ClusterLayout;
+                (): number[];
+                (size: number[]): ClusterLayout;
             }
             value: {
                 (): (node: GraphNode) => number;
@@ -1382,11 +1382,11 @@ declare module D3 {
                 (comparator: (a: GraphNode, b: GraphNode) => number): HierarchyLayout;
             }
             children: {
-                (): (d: any, i?: number) => Array<GraphNode>;
-                (children: (d: any, i?: number) => Array<GraphNode>): HierarchyLayout;
+                (): (d: any, i?: number) => GraphNode[];
+                (children: (d: any, i?: number) => GraphNode[]): HierarchyLayout;
             }
-            nodes(root: GraphNode): Array<GraphNode>;
-            links(nodes: Array<GraphNode>): Array<GraphLink>;
+            nodes(root: GraphNode): GraphNode[];
+            links(nodes: GraphNode[]): GraphLink[];
             value: {
                 (): (node: GraphNode) => number;
                 (value: (node: GraphNode) => number): HierarchyLayout;
@@ -1401,21 +1401,21 @@ declare module D3 {
         }
 
         export interface HistogramLayout {
-            (values: Array<any>, index?: number): Array<Bin>;
+            (values: any[], index?: number): Bin[];
             value: {
                 (): (value: any) => any;
                 (accessor: (value: any) => any): HistogramLayout
             }
             range: {
-                (): (value: any, index: number) => Array<number>;
-                (range: (value: any, index: number) => Array<number>): HistogramLayout;
-                (range: Array<number>): HistogramLayout;
+                (): (value: any, index: number) => number[];
+                (range: (value: any, index: number) => number[]): HistogramLayout;
+                (range: number[]): HistogramLayout;
             }
             bins: {
-                (): (range: Array<any>, index: number) => Array<number>;
-                (bins: (range: Array<any>, index: number) => Array<number>): HistogramLayout;
+                (): (range: any[], index: number) => number[];
+                (bins: (range: any[], index: number) => number[]): HistogramLayout;
                 (bins: number): HistogramLayout;
-                (bins: Array<number>): HistogramLayout;
+                (bins: number[]): HistogramLayout;
             }
             frequency: {
                 (): boolean;
@@ -1429,18 +1429,18 @@ declare module D3 {
                 (comparator: (a: GraphNode, b: GraphNode) => number): PackLayout;
             }
             children: {
-                (): (d: any, i?: number) => Array<GraphNode>;
-                (children: (d: any, i?: number) => Array<GraphNode>): PackLayout;
+                (): (d: any, i?: number) => GraphNode[];
+                (children: (d: any, i?: number) => GraphNode[]): PackLayout;
             }
-            nodes(root: GraphNode): Array<GraphNode>;
-            links(nodes: Array<GraphNode>): Array<GraphLink>;
+            nodes(root: GraphNode): GraphNode[];
+            links(nodes: GraphNode[]): GraphLink[];
             value: {
                 (): (node: GraphNode) => number;
                 (value: (node: GraphNode) => number): PackLayout;
             }
             size: {
-                (): Array<number>;
-                (size: Array<number>): PackLayout;
+                (): number[];
+                (size: number[]): PackLayout;
             }
             padding: {
                 (): number;
@@ -1454,18 +1454,18 @@ declare module D3 {
                 (comparator: (a: GraphNode, b: GraphNode) => number): PackLayout;
             }
             children: {
-                (): (d: any, i?: number) => Array<GraphNode>;
-                (children: (d: any, i?: number) => Array<GraphNode>): PackLayout;
+                (): (d: any, i?: number) => GraphNode[];
+                (children: (d: any, i?: number) => GraphNode[]): PackLayout;
             }
-            nodes(root: GraphNode): Array<GraphNode>;
-            links(nodes: Array<GraphNode>): Array<GraphLink>;
+            nodes(root: GraphNode): GraphNode[];
+            links(nodes: GraphNode[]): GraphLink[];
             value: {
                 (): (node: GraphNode) => number;
                 (value: (node: GraphNode) => number): PackLayout;
             }
             size: {
-                (): Array<number>;
-                (size: Array<number>): PackLayout;
+                (): number[];
+                (size: number[]): PackLayout;
             }
         }
 
@@ -1475,18 +1475,18 @@ declare module D3 {
                 (comparator: (a: GraphNode, b: GraphNode) => number): TreeMapLayout;
             }
             children: {
-                (): (d: any, i?: number) => Array<GraphNode>;
-                (children: (d: any, i?: number) => Array<GraphNode>): TreeMapLayout;
+                (): (d: any, i?: number) => GraphNode[];
+                (children: (d: any, i?: number) => GraphNode[]): TreeMapLayout;
             }
-            nodes(root: GraphNode): Array<GraphNode>;
-            links(nodes: Array<GraphNode>): Array<GraphLink>;
+            nodes(root: GraphNode): GraphNode[];
+            links(nodes: GraphNode[]): GraphLink[];
             value: {
                 (): (node: GraphNode) => number;
                 (value: (node: GraphNode) => number): TreeMapLayout;
             }
             size: {
-                (): Array<number>;
-                (size: Array<number>): TreeMapLayout;
+                (): number[];
+                (size: number[]): TreeMapLayout;
             }
             padding: {
                 (): number;
@@ -1648,7 +1648,7 @@ declare module D3 {
             /**
             * The array of supported symbol types.
             */
-            symbolTypes: Array<string>;
+            symbolTypes: string[];
         }
 
         export interface Symbol {
@@ -2463,9 +2463,9 @@ declare module D3 {
         export interface Diagonal {
             (datum: any, index?: number): string;
             projection: {
-                (): (datum: any, index?: number) => Array<number>;
-                (proj: (datum: any) => Array<number>): Diagonal;
-                (proj: (datum: any, index: number) => Array<number>): Diagonal;
+                (): (datum: any, index?: number) => number[];
+                (proj: (datum: any) => number[]): Diagonal;
+                (proj: (datum: any, index: number) => number[]): Diagonal;
             };
             source: {
                 (): (datum: any, index?: number) => any;
@@ -2842,19 +2842,19 @@ declare module D3 {
             /**
             * compute the latitude-longitude bounding box for a given feature.
             */
-            bounds(feature: any): Array<Array<number>>;
+            bounds(feature: any): number[][];
             /**
             * compute the spherical centroid of a given feature.
             */
-            centroid(feature: any): Array<number>;
+            centroid(feature: any): number[];
             /**
             * compute the great-arc distance between two points.
             */
-            distance(a: Array<number>, b: Array<number>): number;
+            distance(a: number[], b: number[]): number;
             /**
             * interpolate between two points along a great arc.
             */
-            interpolate(a: Array<number>, b: Array<number>): (t: number) => Array<number>;
+            interpolate(a: number[], b: number[]): (t: number) => number[];
             /**
             * compute the length of a line string or the circumference of a polygon.
             */
@@ -2967,7 +2967,7 @@ declare module D3 {
             /**
             *
             */
-            rotation(rotation: Array<number>): Rotation;
+            rotation(rotation: number[]): Rotation;
         }
 
         export interface Path {
@@ -3041,11 +3041,11 @@ declare module D3 {
         }
 
         export interface Circle {
-            (...args: Array<any>): GeoJSON;
+            (...args: any[]): GeoJSON;
             origin: {
-                (): Array<number>;
-                (origin: Array<number>): Circle;
-                (origin: (...args: Array<any>) => Array<number>): Circle;
+                (): number[];
+                (origin: number[]): Circle;
+                (origin: (...args: any[]) => number[]): Circle;
             }
             angle: {
                 (): number;
@@ -3059,31 +3059,31 @@ declare module D3 {
 
         export interface Graticule{
             (): GeoJSON;
-            lines(): Array<GeoJSON>;
+            lines(): GeoJSON[];
             outline(): GeoJSON;
             extent: {
-                (): Array<Array<number>>;
-                (extent: Array<Array<number>>): Graticule;
+                (): number[][];
+                (extent: number[][]): Graticule;
             }
             minorExtent: {
-                (): Array<Array<number>>;
-                (extent: Array<Array<number>>): Graticule;
+                (): number[][];
+                (extent: number[][]): Graticule;
             }
             majorExtent: {
-                (): Array<Array<number>>;
-                (extent: Array<Array<number>>): Graticule;
+                (): number[][];
+                (extent: number[][]): Graticule;
             }
             step: {
-                (): Array<Array<number>>;
-                (extent: Array<Array<number>>): Graticule;
+                (): number[][];
+                (extent: number[][]): Graticule;
             }
             minorStep: {
-                (): Array<Array<number>>;
-                (extent: Array<Array<number>>): Graticule;
+                (): number[][];
+                (extent: number[][]): Graticule;
             }
             majorStep: {
-                (): Array<Array<number>>;
-                (extent: Array<Array<number>>): Graticule;
+                (): number[][];
+                (extent: number[][]): Graticule;
             }
             precision: {
                 (): number;
@@ -3109,33 +3109,33 @@ declare module D3 {
         }
 
         export interface GeoJSON {
-            coordinates: Array<Array<number>>;
+            coordinates: number[][];
             type: string;
         }
 
         export interface RawProjection {
-            (lambda: number, phi: number): Array<number>;
-            invert?(x: number, y: number): Array<number>;
+            (lambda: number, phi: number): number[];
+            invert?(x: number, y: number): number[];
         }
 
         export interface Projection {
-            (coordinates: Array<number>): Array<number>;
-            invert?(point: Array<number>): Array<number>;
+            (coordinates: number[]): number[];
+            invert?(point: number[]): number[];
             rotate: {
-                (): Array<number>;
-                (rotation: Array<number>): Projection;
+                (): number[];
+                (rotation: number[]): Projection;
             };
             center: {
-                (): Array<number>;
-                (location: Array<number>): Projection;
+                (): number[];
+                (location: number[]): Projection;
             };
             parallels: {
-                (): Array<number>;
-                (location: Array<number>): Projection;
+                (): number[];
+                (location: number[]): Projection;
             };
             translate: {
-                (): Array<number>;
-                (point: Array<number>): Projection;
+                (): number[];
+                (point: number[]): Projection;
             };
             scale: {
                 (): number;
@@ -3146,8 +3146,8 @@ declare module D3 {
                 (angle: number): Projection;
             };
             clipExtent: {
-                (): Array<Array<number>>;
-                (extent: Array<Array<number>>): Projection;
+                (): number[][];
+                (extent: number[][]): Projection;
             };
             precision: {
                 (): number;
@@ -3166,8 +3166,8 @@ declare module D3 {
         }
 
         export interface Rotation extends Array<any> {
-            (location: Array<number>): Rotation;
-            invert(location: Array<number>): Rotation;
+            (location: number[]): Rotation;
+            invert(location: number[]): Rotation;
         }
 
         export interface ProjectionMutator {
@@ -3182,11 +3182,11 @@ declare module D3 {
             /**
             * compute the Voronoi diagram for the specified points.
             */
-            voronoi(vertices: Array<Vertice>): Array<Polygon>;
+            voronoi(vertices: Vertice[]): Polygon[];
             /**
             * compute the Delaunay triangulation for the specified points.
             */
-            delaunay(vertices?: Array<Vertice>): Array<Polygon>;
+            delaunay(vertices?: Vertice[]): Polygon[];
             /**
             * constructs a quadtree for an array of points.
             */
@@ -3194,21 +3194,21 @@ declare module D3 {
             /**
             * Constructs a new quadtree for the specified array of points.
             */
-            quadtree(points: Array<Point>, x1: number, y1: number, x2: number, y2: number): Quadtree;
+            quadtree(points: Point[], x1: number, y1: number, x2: number, y2: number): Quadtree;
             /**
             * Constructs a new quadtree for the specified array of points.
             */
-            quadtree(points: Array<Point>, width: number, height: number): Quadtree;
+            quadtree(points: Point[], width: number, height: number): Quadtree;
             /**
             * Returns the input array of vertices with additional methods attached
             */
-            polygon(vertices:Array<Vertice>): Polygon;
+            polygon(vertices:Vertice[]): Polygon;
             /**
             * creates a new hull layout with the default settings.
             */
             hull(): Hull;
 
-            hull(vertices:Array<Vertice>): Array<Vertice>;
+            hull(vertices:Vertice[]): Vertice[];
         }
 
         export interface Vertice extends Array<number> {
@@ -3226,7 +3226,7 @@ declare module D3 {
             /**
             * Returns a two-element array representing the centroid of this polygon.
             */
-            centroid(): Array<number>;
+            centroid(): number[];
             /**
             * Clips the subject polygon against this polygon
             */
@@ -3241,11 +3241,11 @@ declare module D3 {
             /**
             * Constructs a new quadtree for the specified array of points.
             */
-            (points: Array<Point>, x1: number, y1: number, x2: number, y2: number): Quadtree;
+            (points: Point[], x1: number, y1: number, x2: number, y2: number): Quadtree;
             /**
             * Constructs a new quadtree for the specified array of points.
             */
-            (points: Array<Point>, width: number, height: number): Quadtree;
+            (points: Point[], width: number, height: number): Quadtree;
 
             x: {
                 (): (d: any) => any;
@@ -3257,10 +3257,10 @@ declare module D3 {
                 (accesor: (d: any) => any): QuadtreeFactory;
 
             }
-            size(): Array<number>;
-            size(size: Array<number>): QuadtreeFactory;
-            extent(): Array<Array<number>>;
-            extent(points: Array<Array<number>>): QuadtreeFactory;
+            size(): number[];
+            size(size: number[]): QuadtreeFactory;
+            extent(): number[][];
+            extent(points: number[][]): QuadtreeFactory;
         }
 
         export interface Quadtree {
@@ -3280,15 +3280,15 @@ declare module D3 {
             /**
             * Compute the Voronoi diagram for the specified data.
             */
-            (data: Array<T>): Array<Polygon>;
+            (data: T[]): Polygon[];
             /**
             * Compute the graph links for the Voronoi diagram for the specified data.
             */
-            links(data: Array<T>): Array<Layout.GraphLink>;
+            links(data: T[]): Layout.GraphLink[];
             /**
             * Compute the triangles for the Voronoi diagram for the specified data.
             */
-            triangles(data: Array<T>): Array<Array<number>>;
+            triangles(data: T[]): number[][];
             x: {
                 /**
                 * Get the x-coordinate accessor.
@@ -3333,30 +3333,30 @@ declare module D3 {
                 /**
                 * Get the clip extent.
                 */
-                (): Array<Array<number>>;
+                (): number[][];
                 /**
                 * Set the clip extent.
                 *
                 * @param extent The new clip extent.
                 */
-                (extent: Array<Array<number>>): Voronoi<T>;
+                (extent: number[][]): Voronoi<T>;
             }
             size: {
                 /**
                 * Get the size.
                 */
-                (): Array<number>;
+                (): number[];
                 /**
                 * Set the size, equivalent to a clip extent starting from (0,0).
                 *
                 * @param size The new size.
                 */
-                (size: Array<number>): Voronoi<T>;
+                (size: number[]): Voronoi<T>;
             }
         }
 
         export interface Hull {
-            (vertices: Array<Vertice>): Array<Vertice>;
+            (vertices: Vertice[]): Vertice[];
             x: {
                 (): (d: any) => any;
                 (accesor: (d: any) => any): any;


### PR DESCRIPTION
This is more idiomatic.
Exactly the same semantics as before, per section 3.6.4 of the [Typescript Lang Specification](http://www.typescriptlang.org/Content/TypeScript%20Language%20Specification.pdf).

I verified that it compiles (both on the test code and for [Plottable.js](https://github.com/palantir/plottable/))
