### PR TITLE
Leaflet: Allow using as an AMD module

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -4173,3 +4173,6 @@ declare var L_NO_TOUCH: boolean;
   */
 declare var L_DISABLE_3D: boolean;
  
+declare module "leaflet" {
+	export = L;
+}


### PR DESCRIPTION
This allows using Leaflet with code like:

``` typescript
import Leaflet = require('leaflet');
```
