### PR TITLE
Restangular: Generic method overloads for get<T>(), getList<T>() and post<T>()

### DIFF
--- a/restangular/restangular-tests.ts
+++ b/restangular/restangular-tests.ts
@@ -22,7 +22,7 @@ myApp.config((RestangularProvider: restangular.IProvider) => {
   RestangularProvider.setRequestInterceptor(function (element, operation, route, url) {
   });
 
-  RestangularProvider.addElementTransformer('accounts', false, function (elem) {
+  RestangularProvider.addElementTransformer('accounts', false, function (elem: any) {
       elem.accountName = 'Changed';
       return elem;
   });
@@ -108,7 +108,7 @@ myApp.controller('TestCtrl', (
       console.log("There was an error saving");
     });
 
-    firstAccount.getList("users", {query: "params"}).then(function(users) {
+    firstAccount.getList("users", {query: "params"}).then(function(users: any) {
       users.post({userName: 'unknown'});
       users.customGET("messages", {param: "myParam"});
 
@@ -155,7 +155,7 @@ myApp.controller('TestCtrl', (
     configurer.setRequestInterceptor(function (element, operation, route, url) {
     });
 
-    configurer.addElementTransformer('accounts', false, function (elem) {
+    configurer.addElementTransformer('accounts', false, function (elem: any) {
         elem.accountName = 'Changed';
         return elem;
     });

--- a/restangular/restangular-tests.ts
+++ b/restangular/restangular-tests.ts
@@ -74,9 +74,13 @@ myApp.controller('TestCtrl', (
   baseAccounts.post(newAccount);
 
   Restangular.allUrl('googlers', 'http://www.google.com/').getList();
+  Restangular.allUrl('googlers', 'http://www.google.com/').getList<String>();
   Restangular.oneUrl('googlers', 'http://www.google.com/1').get();
+  Restangular.oneUrl('googlers', 'http://www.google.com/1').get<String>();
   Restangular.one('accounts', 123).one('buildings', 456).get();
+  Restangular.one('accounts', 123).one('buildings', 456).get<String>();
   Restangular.one('accounts', 123).getList('buildings');
+  Restangular.one('accounts', 123).getList<String>('buildings');
 
   baseAccounts.getList().then(function (accounts) {
     var firstAccount = accounts[0];

--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -99,10 +99,14 @@ declare module restangular {
 
   interface IElement extends IService {
     get(queryParams?: any, headers?: any): IPromise<any>;
+    get<T>(queryParams?: any, headers?: any): IPromise<T>;
     getList(subElement?: any, queryParams?: any, headers?: any): ICollectionPromise<any>;
+    getList<T>(subElement?: any, queryParams?: any, headers?: any): ICollectionPromise<T>;
     put(queryParams?: any, headers?: any): IPromise<any>;
     post(subElement: any, elementToPost: any, queryParams?: any, headers?: any): IPromise<any>;
+    post<T>(subElement: any, elementToPost: T, queryParams?: any, headers?: any): IPromise<T>;
     post(elementToPost: any, queryParams?: any, headers?: any): IPromise<any>;
+    post<T>(elementToPost: T, queryParams?: any, headers?: any): IPromise<T>;
     remove(queryParams?: any, headers?: any): IPromise<any>;
     head(queryParams?: any, headers?: any): IPromise<any>;
     trace(queryParams?: any, headers?: any): IPromise<any>;
@@ -114,7 +118,9 @@ declare module restangular {
 
   interface ICollection extends IService {
     getList(queryParams?: any, headers?: any): ICollectionPromise<any>;
+    getList<T>(queryParams?: any, headers?: any): ICollectionPromise<T>;
     post(elementToPost: any, queryParams?: any, headers?: any): IPromise<any>;
+    post<T>(elementToPost: T, queryParams?: any, headers?: any): IPromise<T>;
     head(queryParams?: any, headers?: any): IPromise<any>;
     trace(queryParams?: any, headers?: any): IPromise<any>;
     options(queryParams?: any, headers?: any): IPromise<any>;


### PR DESCRIPTION
These changes made it easier for me to use restangular.

Simple example below:

```
class Account {
    name: string;
}
interface IIndexScope extends ng.IScope {
    accounts: Account[];
}
[...]
$scope.accounts = Restangular.all('api/accounts').getList<Account>().$object;
```
