### PR TITLE
Update three.d.ts

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -4108,6 +4108,8 @@ declare module THREE {
         normalizeSkinWeights(): void;
         updateMatrixWorld(force?: boolean): void;
         clone(object?: SkinnedMesh): SkinnedMesh;
+        
+        skeleton: Skeleton;
     }
 
     export class Sprite extends Object3D {


### PR DESCRIPTION
Three.js has 'skeleton' field in THREE.SkinnedMesh class but there is no declaration in this d.ts.
https://github.com/mrdoob/three.js/blob/master/src/objects/SkinnedMesh.js#L83
