### PR TITLE
Underscore: removing generics and overloading reduce

### DIFF
--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -1607,28 +1607,55 @@ interface Underscore<T> {
 	* Wrapped type `any[]`.
 	* @see _.reduce
 	**/
-	reduce<TResult>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): TResult;
+	reduce<TResult>(iterator: _.MemoIterator<T, TResult>, memo: TResult, context?: any): TResult;
+
+	/**
+	* Wrapped type `any[]`.
+	* @see _.reduce
+	**/
+	reduce(iterator: _.MemoIterator<T, T>, memo?: T, context?: any): T;
 
 	/**
 	* @see _.reduce
 	**/
-	inject<TResult>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): TResult;
+	inject<TResult>(iterator: _.MemoIterator<T, TResult>, memo: TResult, context?: any): TResult;
 
 	/**
 	* @see _.reduce
 	**/
-	foldl<TResult>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): TResult;
+	inject(iterator: _.MemoIterator<T, T>, memo?: T, context?: any): T;
+
+	/**
+	* @see _.reduce
+	**/
+	foldl<TResult>(iterator: _.MemoIterator<T, TResult>, memo: TResult, context?: any): TResult;
+
+	/**
+	* @see _.reduce
+	**/
+	foldl(iterator: _.MemoIterator<T, T>, memo?: T, context?: any): T;
 
 	/**
 	* Wrapped type `any[]`.
 	* @see _.reduceRight
 	**/
-	reduceRight<TResult>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): TResult;
+	reduceRight<TResult>(iterator: _.MemoIterator<T, TResult>, memo: TResult, context?: any): TResult;
+
+	/**
+	* Wrapped type `any[]`.
+	* @see _.reduceRight
+	**/
+	reduceRight(iterator: _.MemoIterator<T, T>, memo?: T, context?: any): T;
 
 	/**
 	* @see _.reduceRight
 	**/
-	foldr<TResult>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): TResult;
+	foldr<TResult>(iterator: _.MemoIterator<T, TResult>, memo: TResult, context?: any): TResult;
+
+	/**
+	* @see _.reduceRight
+	**/
+	foldr(iterator: _.MemoIterator<T, T>, memo?: T, context?: any): T;
 
 	/**
 	* Wrapped type `any[]`.

--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -176,8 +176,18 @@ interface UnderscoreStatic {
 	reduce<T, TResult>(
 		list: _.Collection<T>,
 		iterator: _.MemoIterator<T, TResult>,
-		memo?: TResult,
+		memo: TResult,
 		context?: any): TResult;
+
+	/**
+	* @see _.reduce
+	* @param memo Initial reduce state. If memo is omitted, the first value of list is used instead and iteration begins with the second.
+	**/
+	reduce<T>(
+		list: _.Collection<T>,
+		iterator: _.MemoIterator<T, T>,
+		memo?: T,
+		context?: any): T;
 
 	/**
 	* @see _.reduce
@@ -185,8 +195,17 @@ interface UnderscoreStatic {
 	inject<T, TResult>(
 		list: _.Collection<T>,
 		iterator: _.MemoIterator<T, TResult>,
-		memo?: TResult,
+		memo: TResult,
 		context?: any): TResult;
+
+	/**
+	* @see _.reduce
+	**/
+	inject<T>(
+		list: _.Collection<T>,
+		iterator: _.MemoIterator<T, T>,
+		memo?: T,
+		context?: any): T;
 
 	/**
 	* @see _.reduce
@@ -194,8 +213,17 @@ interface UnderscoreStatic {
 	foldl<T, TResult>(
 		list: _.Collection<T>,
 		iterator: _.MemoIterator<T, TResult>,
-		memo?: TResult,
+		memo: TResult,
 		context?: any): TResult;
+
+	/**
+	* @see _.reduce
+	**/
+	foldl<T>(
+		list: _.Collection<T>,
+		iterator: _.MemoIterator<T, T>,
+		memo?: T,
+		context?: any): T;
 
 	/**
 	* The right-associative version of reduce. Delegates to the JavaScript 1.8 version of
@@ -210,8 +238,18 @@ interface UnderscoreStatic {
 	reduceRight<T, TResult>(
 		list: _.Collection<T>,
 		iterator: _.MemoIterator<T, TResult>,
-		memo?: TResult,
+		memo: TResult,
 		context?: any): TResult;
+
+	/**
+	* @see _.reduceRight
+	* @param memo Initial reduce state. If memo is omitted, the first value of list is used instead and iteration begins with the second.
+	**/
+	reduceRight<T>(
+		list: _.Collection<T>,
+		iterator: _.MemoIterator<T, T>,
+		memo?: T,
+		context?: any): T;
 
 	/**
 	* @see _.reduceRight
@@ -219,8 +257,17 @@ interface UnderscoreStatic {
 	foldr<T, TResult>(
 		list: _.Collection<T>,
 		iterator: _.MemoIterator<T, TResult>,
-		memo?: TResult,
+		memo: TResult,
 		context?: any): TResult;
+
+	/**
+	* @see _.reduceRight
+	**/
+	foldr<T>(
+		list: _.Collection<T>,
+		iterator: _.MemoIterator<T, T>,
+		memo?: T,
+		context?: any): T;
 
 	/**
 	* Looks through each value in the list, returning the first one that passes a truth

--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -304,9 +304,9 @@ interface UnderscoreStatic {
 	* @param properties The properties to check for on each element within `list`.
 	* @return The elements within `list` that contain the required `properties`.
 	**/
-	where<T, U extends {}>(
+	where<T>(
 		list: _.List<T>,
-		properties: U): T[];
+		properties: {}): T[];
 
 	/**
 	* Looks through the list and returns the first value that matches all of the key-value pairs listed in properties.
@@ -314,9 +314,9 @@ interface UnderscoreStatic {
 	* @param properties Properties to look for on the elements within `list`.
 	* @return The first element in `list` that has all `properties`.
 	**/
-	findWhere<T, U extends {}>(
+	findWhere<T>(
 		list: _.List<T>,
-		properties: U): T;
+		properties: {}): T;
 
 	/**
 	* Returns the values in list without the elements that the truth test (iterator) passes.
@@ -1609,13 +1609,13 @@ interface Underscore<T> {
 	* Wrapped type `any[]`.
 	* @see _.where
 	**/
-	where<U extends {}>(properties: U): T[];
+	where(properties: {}): T[];
 
 	/**
 	* Wrapped type `any[]`.
 	* @see _.findWhere
 	**/
-	findWhere<U extends {}>(properties: U): T;
+	findWhere(properties: {}): T;
 
 	/**
 	* Wrapped type `any[]`.
@@ -2440,13 +2440,13 @@ interface _Chain<T> {
 	* Wrapped type `any[]`.
 	* @see _.where
 	**/
-	where<U extends {}>(properties: U): _Chain<T>;
+	where(properties: {}): _Chain<T>;
 
 	/**
 	* Wrapped type `any[]`.
 	* @see _.findWhere
 	**/
-	findWhere<U extends {}>(properties: U): _ChainSingle<T>;
+	findWhere(properties: {}): _ChainSingle<T>;
 
 	/**
 	* Wrapped type `any[]`.


### PR DESCRIPTION
What was the advantage of typing things with "U extends {}" ?

And for reduce, the memo argument is not optional if T doesn't equal TResult since then the first element of the list is the wrong type to be used as a replacement. Not sure if this minor point is worth adding almost a hundred lines though.
