### PR TITLE
Add missing 'new' to PouchDB test

### DIFF
--- a/pouchDB/pouch-tests.ts
+++ b/pouchDB/pouch-tests.ts
@@ -9,7 +9,7 @@ window.alert = function (thing?: string) {
 var pouch: PouchDB;
 
 function pouchTests() {
-    PouchDB('testdb', function (err: PouchError, res: PouchDB) {
+    new PouchDB('testdb', function (err: PouchError, res: PouchDB) {
 		if (err) {
 			alert('Error ' + err.status + ' occurred ' + err.error + ' - ' + err.reason);
 		}


### PR DESCRIPTION
Update test for PouchDB, by adding the missing 'new' to the call. PouchDB interface only contain construct signatures and no call signatures.

This is identified while testing the new version of TypeScript compiler. The new compiler caught this issue that was not detected before. 
