### PR TITLE
Fix invalid extend in backgrid tests

### DIFF
--- a/backgrid/backgrid-tests.ts
+++ b/backgrid/backgrid-tests.ts
@@ -23,7 +23,7 @@ class TestModel extends Backbone.Model {
 
 }
 
-class TestCollection extends Backbone.Collection<TestModel> {
+class TestCollection extends Backbone.Collection<Backbone.Model> {
 
     constructor(models?: any, options?: any) {
 	this.model = TestModel;


### PR DESCRIPTION
Model defines private variables, so for TestCollection to be compatible with Collection<Model> it needs to extend Collection<Model> to inherit its privates.

This is identified while testing the new version of TypeScript compiler. The new compiler caught this issue that was not detected before. 
