### PR TITLE
Fixed definition of KnockoutComputedContext.isInitial: should be function

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -586,7 +586,7 @@ interface KnockoutComponentConfig {
 
 interface KnockoutComputedContext {
 	getDependenciesCount(): number;
-	isInitial: boolean;
+	isInitial: () => boolean;
 	isSleeping: boolean;
 }
 


### PR DESCRIPTION
KnockoutComputedContext.isInitial was typed as boolean but is actually a function () => boolean.
