### PR TITLE
Fixed error in test for indexedDB

### DIFF
--- a/modernizr/modernizr.d.ts
+++ b/modernizr/modernizr.d.ts
@@ -75,7 +75,7 @@ interface ModernizrStatic {
     history: boolean;
     audio: Audioboolean;
     video: Videoboolean;
-    indexeddb: boolean;
+    indexedDB: boolean;
     input: Inputboolean;
     inputtypes: InputTypesboolean;
     localstorage: boolean;


### PR DESCRIPTION
While Modernizr 3 uses 'indexeddb' (lower caps), the Modernizr 2 versions all use 'indexedDB'.
