### PR TITLE
Update d3.d.ts

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -808,7 +808,7 @@ declare module D3 {
         * Returns the first non-null element in the current selection. If the selection is empty,
         * returns null.
         */
-        node: () => Element;
+        node: <T extends Element>() => T;
     }
 
     export interface EnterSelection {


### PR DESCRIPTION
this makes the following possible from typescript:
`var context = canvas.node<HTMLCanvasElement>().getContext('2d');`

alternative to

`var context = (<HtmlCanvasElement>canvas.node()).getContext('2d');`
