### PR TITLE
Added Showdown 0.3.1 definitions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -326,6 +326,7 @@ All definitions files include a header with the author and editors, so at some p
 * [Sencha Touch](http://www.sencha.com/products/touch/) (by [Brian Kotek](https://github.com/brian428))
 * [SharePoint](http://sptypescript.codeplex.com) (by [Stanislav Vyshchepan](http://gandjustas.blogspot.ru) and [Andrey Markeev](http://markeev.com))
 * [ShellJS](http://shelljs.org) (by [Niklas Mollenhauer](https://github.com/nikeee))
+* [Showdown](https://github.com/coreyti/showdown) (by [Chris Bowdon](https://github.com/cbowdon))
 * [SignalR](http://www.asp.net/signalr) (by [Boris Yankov](https://github.com/borisyankov))
 * [simple-cw-node](https://github.com/astronaughts/simple-cw-node) (by [vvakame](https://github.com/vvakame))
 * [Sinon](http://sinonjs.org/) (by [William Sears](https://github.com/mrbigdog2u))

--- a/showdown/showdown-tests.ts
+++ b/showdown/showdown-tests.ts
@@ -1,0 +1,20 @@
+/// <reference path="showdown.d.ts" />
+
+// compile: tsc showdown/showdown-tests.ts --noImplicitAny --module commonjs
+// run: node showdown/showdown-tests.js
+
+import Showdown = require('showdown');
+
+var exampleMarkdown = '#hello, markdown',
+    converter = new Showdown.converter(),
+    preloadedExtensions = [ 'github', 'twitter', 'prettify', 'table' ],
+    extensionsConverter = new Showdown.converter({ extensions: preloadedExtensions });
+
+console.log(converter.makeHtml(exampleMarkdown));
+// should log '<h1 id="hellomarkdown">hello, markdown</h1>'
+
+console.log(extensionsConverter.makeHtml(exampleMarkdown));
+// should log '<p><a href="http://twitter.com/search/%23hello">#hello</a>, markdown</p>'
+
+Showdown.forEach(preloadedExtensions, console.log);
+// should log each item in the above array

--- a/showdown/showdown.d.ts
+++ b/showdown/showdown.d.ts
@@ -83,4 +83,6 @@ declare module Showdown {
     function forEach<T>(obj: T[], callback: (value: T, index: number, array: T[]) => any): void;
 }
 
-export = Showdown;
+declare module "showdown" {
+    export = Showdown;
+}

--- a/showdown/showdown.d.ts
+++ b/showdown/showdown.d.ts
@@ -1,0 +1,86 @@
+// Type definitions for Showdown 0.3.1
+// Project: https://github.com/coreyti/showdown
+// Definitions by: cbowdon <https://github.com/cbowdon>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module Showdown {
+
+    /** Defined for information only - used in union type */
+    interface Replace {
+        /**
+         * This is just the replacer function argument to String.prototype.replace, signature from lib.d.ts
+         */
+        replace(substring: string, ...args: any[]): string;
+    }
+
+    interface Extension {
+        /**
+         * Describes what type of extension - language ext or output modifier.
+         * If absent, 'output modifier' type is assumed (contrary to comments in source).
+         */
+        type?: string;
+    }
+
+    interface LangExtension extends Extension {
+        filter? (text: string): string;
+    }
+
+    interface OutputModifier extends Extension {
+        /** Used to build a Regex */
+        regex?: string;
+        /** Similar to arg to String.prototype.replace (which is in fact called under the hood) */
+        replace?: any; // string | Replace
+    }
+
+    /**
+     * Defines a plugin/extension
+     * Each single extension can be one of two types:
+     *
+     * + Language Extension -- Language extensions are ones that that add new markdown syntax to showdown. For example, say you wanted ^^youtube http://www.youtube.com/watch?v=oHg5SJYRHA0 to automatically render as an embedded YouTube video, that would be a language extension.
+     * + Output Modifiers -- After showdown has run, and generated HTML, an output modifier would change that HTML. For example, say you wanted to change <div class="header"> to be <header>, that would be an output modifier.
+     *
+     * Each extension can provide two combinations of interfaces for showdown.
+     */
+    interface ShowdownExtension extends LangExtension, OutputModifier {
+    }
+
+    /** Defined for information only - used in union type */
+    interface Plugin {
+        (converter: Converter): ShowdownExtension[];
+    }
+
+    interface ConverterOptions {
+        extensions: any[]; // (string | Plugin)[]
+    }
+
+    interface Converter {
+        /**
+         * @param text The input text (markdown)
+         * @return The output HTML
+         */
+        makeHtml(text: string): string;
+    }
+
+    interface ConverterStatic {
+        /**
+         * @constructor
+         * @param converter_options Configuration object, describes which extensions to apply
+         */
+        new(converter_options?: ConverterOptions): Converter;
+    }
+
+    /** Constructor function for a Converter */
+    var converter: ConverterStatic;
+
+    /** Registered extensions */
+    var extensions: { [name: string]: ShowdownExtension };
+
+    /**
+     * Showdown defers to the ES5 native or other predefined forEach where available, otherwise simple loop
+     * @param obj An array of items
+     * @param callback Applied once to each item (signature here is from forEach in lib.d.ts)
+     */
+    function forEach<T>(obj: T[], callback: (value: T, index: number, array: T[]) => any): void;
+}
+
+export = Showdown;


### PR DESCRIPTION
I've added definitions for [Showdown](https://github.com/coreyti/showdown), the Markdown parser. Apologies for not signalling that I was working on this first. 

This branch is passing the Travis build and I've followed the contribution guidelines - however, if there any issues with it let me know and I'll be happy to fix it up.
