### PR TITLE
updated $asyncValidators

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -150,12 +150,12 @@ declare module ng {
 
         /**
          * Creates a deep copy of source, which should be an object or an array.
-         * 
+         *
          * - If no destination is supplied, a copy of the object or array is created.
          * - If a destination is provided, all of its elements (for array) or properties (for objects) are deleted and then all elements/properties from the source are copied to it.
          * - If source is not an object or array (inc. null and undefined), source is returned.
          * - If source is identical to 'destination' an exception will be thrown.
-         * 
+         *
          * @param source The source that will be used to make a copy. Can be any type, including primitives, null, and undefined.
          * @param destination Destination into which the source is copied. If provided, must be of the same type as source.
          */
@@ -163,7 +163,7 @@ declare module ng {
 
         /**
          * Wraps a raw DOM element or HTML string as a jQuery element.
-         * 
+         *
          * If jQuery is available, angular.element is an alias for the jQuery function. If jQuery is not available, angular.element delegates to Angular's built-in subset of jQuery, called "jQuery lite" or "jqLite."
          */
         element: IAugmentedJQueryStatic;
@@ -290,14 +290,14 @@ declare module ng {
         controller(object: Object): IModule;
         /**
          * Register a new directive with the compiler.
-         * 
+         *
          * @param name Name of the directive in camel-case (i.e. ngBind which will match as ng-bind)
          * @param directiveFactory An injectable directive factory function.
          */
         directive(name: string, directiveFactory: IDirectiveFactory): IModule;
         /**
          * Register a new directive with the compiler.
-         * 
+         *
          * @param name Name of the directive in camel-case (i.e. ngBind which will match as ng-bind)
          * @param directiveFactory An injectable directive factory function.
          */
@@ -445,7 +445,7 @@ declare module ng {
         $untouched: boolean;
 
         $validators: IModelValidators;
-        $asyncValidators: IModelValidators;
+        $asyncValidators: IAsyncModelValidators;
 
         $pristine: boolean;
         $dirty: boolean;
@@ -455,6 +455,10 @@ declare module ng {
 
     interface IModelValidators {
         [index: string]: (...args: any[]) => boolean;
+    }
+
+    interface IAsyncModelValidators {
+        [index: string]: (...args: any[]) => ng.IPromise<boolean>;
     }
 
     interface IModelParser {
@@ -494,9 +498,9 @@ declare module ng {
 
         /**
          * Listens on events of a given type. See $emit for discussion of event life cycle.
-         * 
-         * The event listener function format is: function(event, args...). 
-         * 
+         *
+         * The event listener function format is: function(event, args...).
+         *
          * @param name Event name to listen on.
          * @param listener Function to call when the event is emitted.
          */
@@ -720,7 +724,7 @@ declare module ng {
         /**
          * Change path when called with parameter and return $location.
          * Note: Path should always begin with forward slash (/), this method will add the forward slash if it is missing.
-         * 
+         *
          * @param path New path
          */
         path(path: string): ILocationService;
@@ -730,22 +734,22 @@ declare module ng {
         replace(): ILocationService;
 
         /**
-         * Return search part (as object) of current url 
+         * Return search part (as object) of current url
          */
         search(): any;
 
         /**
          * Change search part when called with parameter and return $location.
-         * 
+         *
          * @param search When called with a single argument the method acts as a setter, setting the search component of $location to the specified value.
-         * 
+         *
          * If the argument is a hash object containing an array of values, these values will be encoded as duplicate search parameters in the url.
          */
         search(search: any): ILocationService;
 
         /**
          * Change search part when called with parameter and return $location.
-         * 
+         *
          * @param search New search params
          * @param paramValue If search is a string or a Number, then paramValue will override only a single search property. If paramValue is null, the property specified via the first argument will be deleted.
          */
@@ -753,7 +757,7 @@ declare module ng {
 
         /**
          * Change search part when called with parameter and return $location.
-         * 
+         *
          * @param search New search params
          * @param paramValue If search is a string or a Number, then paramValue will override only a single search property. If paramValue is null, the property specified via the first argument will be deleted.
          */
@@ -761,7 +765,7 @@ declare module ng {
 
         /**
          * Change search part when called with parameter and return $location.
-         * 
+         *
          * @param search New search params
          * @param paramValue If paramValue is an array, it will override the property of the search component of $location specified via the first argument.
          */
@@ -769,7 +773,7 @@ declare module ng {
 
         /**
          * Change search part when called with parameter and return $location.
-         * 
+         *
          * @param search New search params
          * @param paramValue If paramValue is true, the property specified via the first argument will be added with no value nor trailing equal sign.
          */
@@ -899,7 +903,7 @@ declare module ng {
 
         /**
          * Allows you to observe either the fulfillment or rejection of a promise, but to do so without modifying the final value. This is useful to release resources or do some clean-up that needs to be done whether the promise was rejected or resolved. See the full specification for more information.
-         * 
+         *
          * Because finally is a reserved word in JavaScript and reserved keywords are not supported as property names by ES3, you'll need to invoke the method like promise['finally'](callback) to make your code IE8 and Android 2.x compatible.
          */
         finally<TResult>(finallyCallback: () => any): IPromise<TResult>;


### PR DESCRIPTION
If you read the docs thoroughly (which I didn't at first) the function should return a promise.

An example usage of $asyncValidators inside a link function to check if the e-mail is not taken:

``` typescript
function (scope: ng.IScope, elem: JQuery, attrs: ng.IAttributes, ngModel:ng.INgModelController) {

                ngModel.$asyncValidators['emailAvailable'] = (modelValue:string, viewValue:string) => {
                    var value: string = modelValue || viewValue;

                    var deferred: ng.IDeferred<boolean> = $q.defer();

                    accountFactory.isEmailAvailable(<string>value).then(data => {
                        //the response of this call is OK, the address is free
                        deferred.resolve(true);
                    }, err => {
                        //An 4XX errorcode is given when the e-mail is already taken
                        deferred.reject("Email exists");
                    });

                    return deferred.promise;
                };
            }
```
