### PR TITLE
Correctly declare the return type of promise.filter and promise.map

### DIFF
--- a/bluebird/bluebird-tests.ts
+++ b/bluebird/bluebird-tests.ts
@@ -477,10 +477,10 @@ barProm = fooProm.race<Bar>();
 
 //TODO fix collection inference
 
-barProm = fooProm.map<Foo, Bar>((item: Foo, index: number, arrayLength: number) => {
+barArrProm = fooProm.map<Foo, Bar>((item: Foo, index: number, arrayLength: number) => {
 	return bar;
 });
-barProm = fooProm.map<Foo, Bar>((item: Foo) => {
+barArrProm = fooProm.map<Foo, Bar>((item: Foo) => {
 	return bar;
 });
 
@@ -495,10 +495,10 @@ barProm = fooProm.reduce<Foo, Bar>((memo: Bar, item: Foo) => {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-fooProm = fooProm.filter<Foo>((item: Foo, index: number, arrayLength: number) => {
+fooArrProm = fooArrProm.filter<Foo>((item: Foo, index: number, arrayLength: number) => {
 	return bool;
 });
-fooProm = fooProm.filter<Foo>((item: Foo) => {
+fooArrProm = fooArrProm.filter<Foo>((item: Foo) => {
 	return bool;
 });
 

--- a/bluebird/bluebird.d.ts
+++ b/bluebird/bluebird.d.ts
@@ -296,8 +296,8 @@ declare class Promise<R> implements Promise.Thenable<R> {
 	 * Same as calling `Promise.map(thisPromise, mapper)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
 	 */
 	// TODO type inference from array-resolving promise?
-	map<Q, U>(mapper: (item: Q, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U>;
-	map<Q, U>(mapper: (item: Q, index: number, arrayLength: number) => U): Promise<U>;
+	map<Q, U>(mapper: (item: Q, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+	map<Q, U>(mapper: (item: Q, index: number, arrayLength: number) => U): Promise<U[]>;
 
 	/**
 	 * Same as calling `Promise.reduce(thisPromise, Function reducer, initialValue)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
@@ -310,8 +310,8 @@ declare class Promise<R> implements Promise.Thenable<R> {
 	 * Same as calling ``Promise.filter(thisPromise, filterer)``. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
 	 */
 	// TODO type inference from array-resolving promise?
-	filter<U>(filterer: (item: U, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<U>;
-	filter<U>(filterer: (item: U, index: number, arrayLength: number) => boolean): Promise<U>;
+	filter<U>(filterer: (item: U, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<U[]>;
+	filter<U>(filterer: (item: U, index: number, arrayLength: number) => boolean): Promise<U[]>;
 
 	/**
 	 * Start the chain of promises with `Promise.try`. Any synchronous exceptions will be turned into rejections on the returned promise.


### PR DESCRIPTION
As per #2788 - it appears that the definition of `promise.map<T>` and `promise.filter<T>` is a promise which would be resolved with a single object (`promise<T>`) rather than an array of them (`promise<T[]>`).

Example of 'real life' usage:

``` js
p1 = Promise.resolve([1, 2, 3]);                    // Promise<number[]>
p2 = p1.filter(function (n) { return n % 2 > 0; }); // Promise<number[]>
p3 = p2.map(function (n) { return n * 2; });        // Promise<number[]>

p3.then(console.log.bind(console));                 // [2, 6]
```

/cc @Bartvds 
