### PR TITLE
update webrtc/MediaStream.d.ts, RTCPeerConnection.d.ts

### DIFF
--- a/webrtc/MediaStream-tests.ts
+++ b/webrtc/MediaStream-tests.ts
@@ -30,3 +30,17 @@ navigator.webkitGetUserMedia(mediaStreamConstraints,
     console.log('Error message: ' + error.message);
     console.log('Error name: ' + error.name);
   });
+
+
+navigator.mozGetUserMedia(mediaStreamConstraints,
+  stream => {
+    console.log('label:' + stream.label);
+    console.log('ended:' + stream.ended);
+    stream.onended = (event:Event) => console.log('Stream ended');
+    var objectUrl = URL.createObjectURL(stream);
+    var wkObjectUrl = webkitURL.createObjectURL(stream);
+  },
+  error => {
+    console.log('Error message: ' + error.message);
+    console.log('Error name: ' + error.name);
+  });

--- a/webrtc/MediaStream.d.ts
+++ b/webrtc/MediaStream.d.ts
@@ -12,7 +12,7 @@ interface MediaStreamConstraints {
 declare var MediaStreamConstraints: {
   prototype: MediaStreamConstraints;
   new (): MediaStreamConstraints;
-}
+};
 
 interface MediaTrackConstraints {
   mandatory: MediaTrackConstraintSet;
@@ -21,7 +21,7 @@ interface MediaTrackConstraints {
 declare var MediaTrackConstraints: {
   prototype: MediaTrackConstraints;
   new (): MediaTrackConstraints;
-}
+};
 
 // ks - Not defined in the source doc.
 interface MediaTrackConstraintSet {
@@ -29,7 +29,7 @@ interface MediaTrackConstraintSet {
 declare var MediaTrackConstraintSet: {
   prototype: MediaTrackConstraintSet;
   new (): MediaTrackConstraintSet;
-}
+};
 
 // ks - Not defined in the source doc.
 interface MediaTrackConstraint {
@@ -37,7 +37,7 @@ interface MediaTrackConstraint {
 declare var MediaTrackConstraint: {
   prototype: MediaTrackConstraint;
   new (): MediaTrackConstraints;
-}
+};
 
 interface Navigator {
   getUserMedia(constraints: MediaStreamConstraints,
@@ -46,6 +46,9 @@ interface Navigator {
   webkitGetUserMedia(constraints: MediaStreamConstraints,
                      successCallback: (stream: any) => void,
                      errorCallback: (error: Error) => void): void;
+  mozGetUserMedia(constraints: MediaStreamConstraints,
+                  successCallback: (stream: any) => void,
+                  errorCallback: (error: Error) => void): void;
 }
 
 interface EventHandler { (event: Event): void; }
@@ -62,7 +65,7 @@ declare var NavigatorUserMediaError: {
   prototype: NavigatorUserMediaError;
   new (): NavigatorUserMediaError;
   PERMISSION_DENIED: number; // = 1;
-}
+};
 
 interface NavigatorUserMediaErrorCallback {
   (error: NavigatorUserMediaError): void;
@@ -79,11 +82,11 @@ interface MediaStreamTrackList {
 declare var MediaStreamTrackList: {
   prototype: MediaStreamTrackList;
   new (): MediaStreamTrackList;
-}
+};
 declare var webkitMediaStreamTrackList: {
   prototype: MediaStreamTrackList;
   new (): MediaStreamTrackList;
-}
+};
 
 interface MediaStream {
   label: string;
@@ -99,14 +102,14 @@ declare var MediaStream: {
   new (trackContainers: MediaStream[]): MediaStream;
   new (trackContainers: MediaStreamTrackList[]): MediaStream;
   new (trackContainers: MediaStreamTrack[]): MediaStream;
-}
+};
 declare var webkitMediaStream: {
   prototype: MediaStream;
   new (): MediaStream;
   new (trackContainers: MediaStream[]): MediaStream;
   new (trackContainers: MediaStreamTrackList[]): MediaStream;
   new (trackContainers: MediaStreamTrack[]): MediaStream;
-}
+};
 
 // an - not defined in source doc.
 interface SourceInfo {
@@ -117,7 +120,7 @@ interface SourceInfo {
 }
 declare var SourceInfo: {
   prototype: SourceInfo;
-}
+};
 
 interface LocalMediaStream extends MediaStream {
   stop(): void;
@@ -142,7 +145,7 @@ declare var MediaStreamTrack: {
   MUTED: number; // = 1;
   ENDED: number; // = 2;
   getSources: (callback: (sources: SourceInfo[]) => void) => void;
-}
+};
 
 interface streamURL extends URL {
   createObjectURL(stream: MediaStream): string;
@@ -159,5 +162,5 @@ declare var webkitURL: {
   prototype: WebkitURL;
   new (): streamURL;
   createObjectURL(stream: MediaStream): string;
-}
+};
 

--- a/webrtc/RTCPeerConnection-tests.ts
+++ b/webrtc/RTCPeerConnection-tests.ts
@@ -53,6 +53,38 @@ peerConnection.setRemoteDescription(sessionDescription, () => {
 error => console.log('Error setting remote description: ' + error +
     "; offer.sdp=" + offer.sdp));
 
+var webkitSessionDescription = new webkitRTCSessionDescription(offer);
+
+peerConnection.setRemoteDescription(webkitSessionDescription, () => {
+  peerConnection.createAnswer(
+    answer => {
+      peerConnection.setLocalDescription(answer,
+        () => console.log('Set local description'),
+      error => console.log(
+         "Error setting local description from created answer: " + error +
+         "; answer.sdp=" + answer.sdp));
+    },
+  error => console.log("Error creating answer: " + error));
+},
+error => console.log('Error setting remote description: ' + error +
+    "; offer.sdp=" + offer.sdp));
+
+var mozSessionDescription = new mozRTCSessionDescription(offer);
+
+peerConnection.setRemoteDescription(mozSessionDescription, () => {
+  peerConnection.createAnswer(
+    answer => {
+      peerConnection.setLocalDescription(answer,
+        () => console.log('Set local description'),
+      error => console.log(
+         "Error setting local description from created answer: " + error +
+         "; answer.sdp=" + answer.sdp));
+    },
+  error => console.log("Error creating answer: " + error));
+},
+error => console.log('Error setting remote description: ' + error +
+    "; offer.sdp=" + offer.sdp));
+
 var wkPeerConnection: webkitRTCPeerConnection =
     new webkitRTCPeerConnection(config, constraints);
 

--- a/webrtc/RTCPeerConnection.d.ts
+++ b/webrtc/RTCPeerConnection.d.ts
@@ -26,7 +26,7 @@ interface RTCConfiguration {
 declare var RTCConfiguration: {
   prototype: RTCConfiguration;
   new (): RTCConfiguration;
-}
+};
 
 interface RTCIceServer {
   url: string;
@@ -35,7 +35,7 @@ interface RTCIceServer {
 declare var RTCIceServer: {
   prototype: RTCIceServer;
   new (): RTCIceServer;
-}
+};
 
 // moz (Firefox) specific prefixes.
 interface mozRTCPeerConnection extends RTCPeerConnection {
@@ -44,7 +44,7 @@ declare var mozRTCPeerConnection: {
   prototype: mozRTCPeerConnection;
   new (settings: RTCPeerConnectionConfig,
        constraints?:RTCMediaConstraints): mozRTCPeerConnection;
-}
+};
 // webkit (Chrome) specific prefixes.
 interface webkitRTCPeerConnection extends RTCPeerConnection {
 }
@@ -52,7 +52,7 @@ declare var webkitRTCPeerConnection: {
   prototype: webkitRTCPeerConnection;
   new (settings: RTCPeerConnectionConfig,
        constraints?:RTCMediaConstraints): webkitRTCPeerConnection;
-}
+};
 
 // For Chrome, look at the code here:
 // https://code.google.com/p/chromium/codesearch#chromium/src/third_party/libjingle/source/talk/app/webrtc/webrtcsession.cc&sq=package:chromium&dr=C&l=63
@@ -89,7 +89,27 @@ declare var RTCSessionDescription: {
   new (descriptionInitDict?: RTCSessionDescriptionInit): RTCSessionDescription;
   // TODO: Add serializer.
   // See: http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCSdpType)
+};
+
+interface webkitRTCSessionDescription extends RTCSessionDescription{
+  type?: string;
+  sdp?: string;
 }
+declare var webkitRTCSessionDescription: {
+  prototype: webkitRTCSessionDescription;
+  new (descriptionInitDict?: RTCSessionDescriptionInit): webkitRTCSessionDescription;
+};
+
+interface mozRTCSessionDescription extends RTCSessionDescription{
+  type?: string;
+  sdp?: string;
+}
+declare var mozRTCSessionDescription: {
+  prototype: mozRTCSessionDescription;
+  new (descriptionInitDict?: RTCSessionDescriptionInit): mozRTCSessionDescription;
+};
+
+
 
 interface RTCDataChannelInit {
   ordered             ?: boolean; // messages must be sent in-order.
@@ -146,7 +166,7 @@ interface RTCDataChannel extends EventTarget {
 declare var RTCDataChannel: {
   prototype: RTCDataChannel;
   new (): RTCDataChannel;
-}
+};
 
 interface RTCDataChannelEvent extends Event {
   channel: RTCDataChannel;
@@ -154,7 +174,7 @@ interface RTCDataChannelEvent extends Event {
 declare var RTCDataChannelEvent: {
   prototype: RTCDataChannelEvent;
   new (eventInitDict: RTCDataChannelEventInit): RTCDataChannelEvent;
-}
+};
 
 interface RTCIceCandidateEvent extends Event {
   candidate: RTCIceCandidate;
@@ -269,7 +289,7 @@ declare var RTCPeerConnection: {
   prototype: RTCPeerConnection;
   new (configuration: RTCConfiguration,
        constraints?: RTCMediaConstraints): RTCPeerConnection;
-}
+};
 
 interface RTCIceCandidate {
   candidate?: string;
@@ -279,7 +299,27 @@ interface RTCIceCandidate {
 declare var RTCIceCandidate: {
   prototype: RTCIceCandidate;
   new (candidateInitDict?: RTCIceCandidate): RTCIceCandidate;
+};
+
+interface webkitRTCIceCandidate extends RTCIceCandidate {
+  candidate?: string;
+  sdpMid?: string;
+  sdpMLineIndex?: number;
 }
+declare var webkitRTCIceCandidate: {
+  prototype: webkitRTCIceCandidate;
+  new (candidateInitDict?: webkitRTCIceCandidate): webkitRTCIceCandidate;
+};
+
+interface mozRTCIceCandidate extends RTCIceCandidate {
+  candidate?: string;
+  sdpMid?: string;
+  sdpMLineIndex?: number;
+}
+declare var mozRTCIceCandidate: {
+  prototype: mozRTCIceCandidate;
+  new (candidateInitDict?: mozRTCIceCandidate): mozRTCIceCandidate;
+};
 
 interface RTCIceCandidateInit {
   candidate: string;
@@ -289,7 +329,7 @@ interface RTCIceCandidateInit {
 declare var RTCIceCandidateInit:{
   prototype: RTCIceCandidateInit;
   new (): RTCIceCandidateInit;
-}
+};
 
 interface PeerConnectionIceEvent {
   peer: RTCPeerConnection;
@@ -298,7 +338,7 @@ interface PeerConnectionIceEvent {
 declare var PeerConnectionIceEvent: {
   prototype: PeerConnectionIceEvent;
   new (): PeerConnectionIceEvent;
-}
+};
 
 interface RTCPeerConnectionConfig {
   iceServers: RTCIceServer[];
@@ -306,4 +346,17 @@ interface RTCPeerConnectionConfig {
 declare var RTCPeerConnectionConfig: {
   prototype: RTCPeerConnectionConfig;
   new (): RTCPeerConnectionConfig;
+};
+
+interface Window{
+  RTCPeerConnection: RTCPeerConnection;
+  webkitRTCPeerConnection: webkitRTCPeerConnection;
+  mozRTCPeerConnection: mozRTCPeerConnection;
+  RTCSessionDescription: RTCSessionDescription;
+  webkitRTCSessionDescription: webkitRTCSessionDescription;
+  mozRTCSessionDescription: mozRTCSessionDescription;
+  RTCIceCandidate: RTCIceCandidate;
+  webkitRTCIceCandidate: webkitRTCIceCandidate;
+  mozRTCIceCandidate: mozRTCIceCandidate;
+  URL: URL;
 }


### PR DESCRIPTION
Update for Firefox Support

RTCPeerConnection.d.ts
- update Window Interface
- add webkitRTCSessionDescription, mozRTCSessionDescription, webkitRTCIceCandidate, mozRTCIceCandidate
- append semicolon at the end of "declare var" sentences.

MediaStream.d.ts
- add mozGetUserMedia
- append semicolon at the end of "declare var" sentences.

Usage Sample: https://github.com/nakakura/WebRTC-sample
