### PR TITLE
Support global 'Should' and 'window.Should' for should.js

### DIFF
--- a/should/should-tests.ts
+++ b/should/should-tests.ts
@@ -39,6 +39,9 @@ should.not.exist(false);
 should.not.exist('');
 should.not.exist({});
 
+Should.exist(null);
+window.Should.exist(null);
+
 user.should.have.property('pets').with.lengthOf(4);
 user.pets.should.have.lengthOf(4);
 user.should.be.of.type('object').and.have.property('name', 'tj');

--- a/should/should.d.ts
+++ b/should/should.d.ts
@@ -112,6 +112,10 @@ interface Internal extends ShouldInternal {
 }
 
 declare var should: Internal;
+declare var Should: Internal;
+interface Window {
+  Should: Internal;
+}
 
 declare module "should" {
   export = should;


### PR DESCRIPTION
When using [should.js](https://github.com/visionmedia/should.js) with in-browser mode (see https://github.com/visionmedia/should.js/#in-browser) the `Should` (upper-case) and `window.Should` variables were not recognized by `tsc`.
