### PR TITLE
Added definition to route parameter handling

### DIFF
--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -78,6 +78,8 @@ declare module "express" {
             param(name: string, handler: RequestParamHandler): T;
             param(name: string, matcher: RegExp): T;
             param(name: string, mapper: (param: any) => any): T;
+            // Alternatively, you can pass only a callback, in which case you have the opportunity to alter the app.param() API
+            param(callback: (name: string, matcher: RegExp) => RequestParamHandler): T;
 
             /**
              * Special-cased "all" method, applying the given route `path`,


### PR DESCRIPTION
As stated in Express docs: "Alternatively, you can pass only a callback, in which case you have the opportunity to alter the app.param() API". This case for app.param() is currently missing from the definitions.
