### PR TITLE
fixed wrong definition of sockjs connection constants

### DIFF
--- a/sockjs/sockjs.d.ts
+++ b/sockjs/sockjs.d.ts
@@ -28,10 +28,6 @@ interface SockJS extends EventTarget {
     onclose: (ev: SJSCloseEvent) => any;
     send(data: any): void;
     close(code?: number, reason?: string): void;
-    OPEN: number;
-    CLOSING: number;
-    CONNECTING: number;
-    CLOSED: number;
 }
 
 declare var SockJS: {
@@ -49,4 +45,8 @@ declare var SockJS: {
             null_origin?: boolean;
         };
     }): SockJS;
+    OPEN: number;
+    CLOSING: number;
+    CONNECTING: number;
+    CLOSED: number;
 };


### PR DESCRIPTION
The defintion of SockJS connection constants was at the wrong place and led to wrong usage of them:
The sockjs instance has no OPEN, CLOSING, CONNECTING OR CLOSED variables. Instead the static SockJS.OPEN needs to be used.
