### PR TITLE
Added typings for mocha-phantomjs library

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -255,6 +255,7 @@ All definitions files include a header with the author and editors, so at some p
 * [minimist](https://github.com/substack/minimist) (by [Bart van der Schoor](https://github.com/Bartvds))
 * [Mixpanel](https://github.com/mixpanel/mixpanel-js) (by [Knut Eirik Leira Hjelle](https://github.com/hjellek))
 * [mixto](https://github.com/atom/mixto) (by [vvakame](https://github.com/vvakame))
+* [mocha-phantomjs](https://github.com/metaskills/mocha-phantomjs) (by [ErikSchierboom](https://github.com/ErikSchierboom))
 * [Modernizr](http://modernizr.com/) (by [Boris Yankov](https://github.com/borisyankov) and [Theodore Brown](https://github.com/theodorejb/))
 * [Moment.js](https://github.com/timrwood/moment) (by [Michael Lakerveld](https://github.com/Lakerfield))
 * [MongoDB](http://mongodb.github.io/node-mongodb-native/) (from TypeScript samples, updated by [Niklas Mollenhauer](https://github.com/nikeee))

--- a/mocha-phantomjs/mocha-phantomjs-tests.ts
+++ b/mocha-phantomjs/mocha-phantomjs-tests.ts
@@ -1,0 +1,67 @@
+/// <reference path="mocha-phantomjs.d.ts" />
+
+function test_window() {
+	window.mochaPhantomJS();	
+}
+
+function test_window_options() {
+	var mochaPhantomJSWindowOptions = window.mochaPhantomJS();	
+	
+	var env:any = mochaPhantomJSWindowOptions.env;
+    var failures:number = mochaPhantomJSWindowOptions.failures;
+    var ended:boolean = mochaPhantomJSWindowOptions.ended;
+    var started:boolean = mochaPhantomJSWindowOptions.started;
+    
+	mochaPhantomJSWindowOptions.run();
+}
+
+function test_options() {	
+	mochaPhantomJS.url = 'http://www.test.com';
+    mochaPhantomJS.columns = 6;
+    mochaPhantomJS.mochaStartWait = 2;
+    mochaPhantomJS.startTime = new Date(2014, 10, 3);
+    
+	mochaPhantomJS.output = 'null';
+	mochaPhantomJS.output = 6;
+	mochaPhantomJS.output = function(){};
+}
+
+function test_run() {
+    mochaPhantomJS.run();
+}
+
+function test_customizeMocha_headers_option() {
+	mochaPhantomJS.customizeMocha({ headers: {'X-Test': 'foo', 'DNT': '1'} });
+}
+
+function test_customizeMocha_cookies_option() {
+	mochaPhantomJS.customizeMocha({ cookies: [
+		{ 'name':  'foo1', 'value': 'bar1', 'path': 'baz1' },
+		{ 'name':  'foo2', 'value': 'bar2', 'path': 'baz2' }
+	]});
+}
+
+function test_customizeMocha_viewportSize_option() {
+	mochaPhantomJS.customizeMocha({ viewportSize: 20 });
+}
+
+function test_customizeMocha_timeout_option() {
+	mochaPhantomJS.customizeMocha({ timeout: 2 });
+}
+
+function test_customizeMocha_file_option() {
+	mochaPhantomJS.customizeMocha({ file: 'test.txt' });
+}
+
+function test_customizeMocha_all_options() {
+	mochaPhantomJS.customizeMocha({ 
+		headers: {'X-Test': 'foo', 'DNT': '1'},
+		cookies: [
+			{ 'name':  'foo1', 'value': 'bar1', 'path': 'baz1' },
+			{ 'name':  'foo2', 'value': 'bar2', 'path': 'baz2' }
+		],
+		viewportSize: 20,
+		timeout: 2,
+		file: 'test.txt' 
+	});
+}

--- a/mocha-phantomjs/mocha-phantomjs.d.ts
+++ b/mocha-phantomjs/mocha-phantomjs.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for mocha-phantomjs v3.5.0
+// Project: http://metaskills.net/mocha-phantomjs/
+// Definitions by: Erik Schierboom <https://github.com/ErikSchierboom>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+interface MochaPhantomJsWindowOptions extends Window {
+    env: any;
+    failures: number;
+    ended: boolean;
+    started: boolean;
+    run(): void;
+}
+
+interface Window {
+    mochaPhantomJS(): MochaPhantomJsWindowOptions;
+}
+
+interface MochaPhantomJSOptions {
+    headers?: any;
+	cookies?: any[];
+	viewportSize?: number;
+    timeout?: number;
+    file?: string;
+}
+
+interface MochaPhantomJS {
+    url: string;
+    columns: number;
+    mochaStartWait: number;
+    startTime: Date;
+    output: any;
+	
+    run(): void;
+    customizeMocha(options: MochaPhantomJSOptions): void;    
+}
+
+declare var mochaPhantomJS: MochaPhantomJS;


### PR DESCRIPTION
This PR adds typings for the [`mocha-phantomjs`](https://github.com/metaskills/mocha-phantomjs) library.
