### PR TITLE
linq.3.0.3-Beta4 fix: noImplicitAny

### DIFF
--- a/linq/linq.3.0.3-Beta4.d.ts
+++ b/linq/linq.3.0.3-Beta4.d.ts
@@ -33,7 +33,7 @@ declare module linqjs {
         rangeDown(start: number, count: number, step?: number): Enumerable;
         rangeTo(start: number, to: number, step?: number): Enumerable;
         repeat(element: any, count?: number): Enumerable;
-        repeatWithFinalize(initializer: () => any, finalizer: (element) => void ): Enumerable;
+        repeatWithFinalize(initializer: () => any, finalizer: (element: any) => void ): Enumerable;
         generate(func: () => any, count?: number): Enumerable;
         toInfinity(start?: number, step?: number): Enumerable;
         toNegativeInfinity(start?: number, step?: number): Enumerable;
@@ -42,7 +42,7 @@ declare module linqjs {
     }
 
     interface Enumerable {
-        constructor (getEnumerator: () => IEnumerator);
+        constructor(getEnumerator: () => IEnumerator): Enumerable;
         getEnumerator(): IEnumerator;
 
         // Extension Methods


### PR DESCRIPTION
Fix compiling with noImplictAny option.
