### PR TITLE
Update moment.js definitions for ISO-8601 format parsing in v2.7.0

### DIFF
--- a/moment/moment-external-tests.ts
+++ b/moment/moment-external-tests.ts
@@ -31,6 +31,13 @@ moment("20140101", ["YYYYMMDD"], true);
 moment("20140101", ["YYYYMMDD"], "en");
 moment("20140101", ["YYYYMMDD"], "en", true);
 
+moment(day.toISOString(), moment.ISO_8601);
+moment(day.toISOString(), moment.ISO_8601, true);
+moment(day.toISOString(), moment.ISO_8601, "en", true);
+moment(day.toISOString(), [moment.ISO_8601]);
+moment(day.toISOString(), [moment.ISO_8601], true);
+moment(day.toISOString(), [moment.ISO_8601], "en", true);
+
 var a = moment([2012]);
 var b = moment(a);
 a.year(2000);

--- a/moment/moment-tests.ts
+++ b/moment/moment-tests.ts
@@ -29,6 +29,13 @@ moment("20140101", ["YYYYMMDD"], true);
 moment("20140101", ["YYYYMMDD"], "en");
 moment("20140101", ["YYYYMMDD"], "en", true);
 
+moment(day.toISOString(), moment.ISO_8601);
+moment(day.toISOString(), moment.ISO_8601, true);
+moment(day.toISOString(), moment.ISO_8601, "en", true);
+moment(day.toISOString(), [moment.ISO_8601]);
+moment(day.toISOString(), [moment.ISO_8601], true);
+moment(day.toISOString(), [moment.ISO_8601], "en", true);
+
 var a = moment([2012]);
 var b = moment(a);
 a.year(2000);

--- a/moment/moment.d.ts
+++ b/moment/moment.d.ts
@@ -353,6 +353,10 @@ interface MomentStatic {
     (date: string, format?: string, language?: string, strict?: boolean): Moment;
     (date: string, formats: string[], strict?: boolean): Moment;
     (date: string, formats: string[], language?: string, strict?: boolean): Moment;
+    (date: string, specialFormat: () => void, strict?: boolean): Moment;
+    (date: string, specialFormat: () => void, language?: string, strict?: boolean): Moment;
+    (date: string, formatsIncludingSpecial: any[], strict?: boolean): Moment;
+    (date: string, formatsIncludingSpecial: any[], language?: string, strict?: boolean): Moment;
     (date: Date): Moment;
     (date: Moment): Moment;
     (date: Object): Moment;


### PR DESCRIPTION
Adds typings for functionality introduced [here](https://github.com/moment/moment/pull/1693)
