### PR TITLE
Add exists function to i18next

### DIFF
--- a/i18next/i18next-tests.ts
+++ b/i18next/i18next-tests.ts
@@ -6,7 +6,7 @@
 /// <reference path="i18next.d.ts" />
 
 declare function done(): void;
- 
+
 describe('i18next', function () {
 
     var i18n = $.i18n
@@ -682,6 +682,23 @@ describe('i18next', function () {
 
             it('it should translate correctly', function () {
                 expect(i18n.t('empty')).to.be('');
+            });
+        });
+
+        describe('exists functionality', function () {
+            var resStore = {
+                dev: { translation: { empty: '' } },
+                en: { translation: {} },
+                'en-US': { translation: {} }
+            };
+
+            beforeEach(function (done) {
+                i18n.init($.extend(opts, { resStore: resStore }),
+                    function (t) { done(); });
+            });
+
+            it('it should be able to test if a key exists', function () {
+                expect(i18n.exists('empty')).to.be(false);
             });
         });
 

--- a/i18next/i18next.d.ts
+++ b/i18next/i18next.d.ts
@@ -109,6 +109,7 @@ interface I18nextStatic {
     };
     t(key: string, options?: any): string;
     translate(key: string, options?: any): string;
+    exists(key: string, options?: any): boolean;
 }
 
 // jQuery extensions
@@ -118,9 +119,9 @@ interface JQueryStatic {
 }
 
 interface JQuery {
-    /*  Note: options are same options as used by the translate function. Alternatively by 
-        setting init option or translation option 'useDataAttrOptions = true' the Options 
-        for translation will be read and cached in the elements data-i18n-options attribute. 
+    /*  Note: options are same options as used by the translate function. Alternatively by
+        setting init option or translation option 'useDataAttrOptions = true' the Options
+        for translation will be read and cached in the elements data-i18n-options attribute.
     */
     i18n: (options?: I18nextOptions) => void;
 }


### PR DESCRIPTION
The exists function is documented here:

http://i18next.com/pages/doc_features.html
"check if a key exists: i18n.exists("my.key", options); // same options as in t function"

This pull request includes a new test for the function.
