### PR TITLE
Update Swig to latest version

### DIFF
--- a/swig/swig-tests.ts
+++ b/swig/swig-tests.ts
@@ -26,7 +26,7 @@ swig.setDefaults(opts);
 swig.setDefaultTZOffset(num);
 swigObj = new swig.Swig(opts);
 str = swig.compileFile(str)();
-swig.compileFile(str, {}, function (err: any, render: (locals: any) => string) {
+swig.compileFile(str, {}, function (err: Error, render: (locals: any) => string) {
     str = render({});
 });
 str = swig.compile(str)();
@@ -38,14 +38,14 @@ swig.setExtension("test", function (v: string) { return 'test: ' + v });
 value = swig.precompile(str, opts);
 str = swig.render(str, opts);
 str = swig.renderFile(str, {});
-swig.renderFile(str, {}, function (err, output: string) {
+swig.renderFile(str, {}, function (err: Error, output: string) {
 
 });
 console.log(swig.version);
 
 
 str = swigObj.compileFile(str)();
-swigObj.compileFile(str, opts, function (err: any, render: (locals: any) => string) {
+swigObj.compileFile(str, opts, function (err: Error, render: (locals: any) => string) {
     str = render({});
 });
 str = swigObj.compile(str)();
@@ -57,6 +57,6 @@ swigObj.setExtension("test", function (v: string) { return 'test: ' + v });
 value = swigObj.precompile(str, opts);
 str = swigObj.render(str, opts);
 str = swigObj.renderFile(str, {});
-swigObj.renderFile(str, {}, function (err, output: string) {
+swigObj.renderFile(str, {}, function (err: Error, output: string) {
 
 });

--- a/swig/swig-tests.ts
+++ b/swig/swig-tests.ts
@@ -2,24 +2,61 @@
 
 import swig = require('swig');
 
+var swigObj: swig.Swig;
 var value: any;
 var str: string;
 var num: number;
 var bool: boolean;
 
-var opts: swig.Options = {
-	allowErrors: bool,
-	autoescape: bool,
-	cache: bool,
-	encoding: str,
-	filters: value,
-	root: str,
-	tags: value,
-	extensions: value,
-	tzOffset: num
+function replaceMs(input:string): string {
+    return input.replace(/m/g, 'f');
+}
+
+var opts: swig.SwigOptions = {
+    autoescape: bool,
+    cache: value,
+    cmtControls: ["", ""],
+    loader: swig.loaders.fs(),
+    locals: { testVal: "my test" },
+    tagControls: ["", ""],
+    varControls: ["", ""]
 };
 
-swig.init(opts);
-value = swig.compileFile(str);
-value = swig.compile(str);
-value = swig.compile(str, opts);
+swig.setDefaults(opts);
+swig.setDefaultTZOffset(num);
+swigObj = new swig.Swig(opts);
+str = swig.compileFile(str)();
+swig.compileFile(str, {}, function (err: any, render: (locals: any) => string) {
+    str = render({});
+});
+str = swig.compile(str)();
+str = swig.compile(str, opts)();
+swig.invalidateCache();
+swig.setFilter("replaceMs", replaceMs);
+swig.setTag('tacos', function (): boolean { return true; }, function (): string { return 'Tacos' }, true, true);
+swig.setExtension("test", function (v: string) { return 'test: ' + v });
+value = swig.precompile(str, opts);
+str = swig.render(str, opts);
+str = swig.renderFile(str, {});
+swig.renderFile(str, {}, function (err, output: string) {
+
+});
+console.log(swig.version);
+
+
+str = swigObj.compileFile(str)();
+swigObj.compileFile(str, opts, function (err: any, render: (locals: any) => string) {
+    str = render({});
+});
+str = swigObj.compile(str)();
+str = swigObj.compile(str, opts)();
+swigObj.invalidateCache();
+swigObj.setFilter("replaceMs", replaceMs);
+swigObj.setTag('tacos', function (): boolean { return true; }, function (): string { return 'Tacos' }, true, true);
+swigObj.setExtension("test", function (v: string) { return 'test: ' + v });
+value = swigObj.precompile(str, opts);
+str = swigObj.render(str, opts);
+str = swigObj.renderFile(str, {});
+swigObj.renderFile(str, {}, function (err, output: string) {
+
+});

--- a/swig/swig.d.ts
+++ b/swig/swig.d.ts
@@ -15,7 +15,7 @@ declare module "swig" {
             ): void;
         setTag(
             name: string,
-            parse: (str?: string, line?: string, parser?: Object, types?: TYPES, stack?: any, opts?: Object, swig?: Swig) => boolean,
+            parse: (str?: string, line?: string, parser?: Object, types?: lexer.TYPES, stack?: any, opts?: Object, swig?: Swig) => boolean,
             compile: (compiler?: (content?: string, parents?: any, options?: any, blockName?: string) => string, args?: any[], content?: string, parents?: any, options?: any, blockName?: string) => string,
             ends?: boolean,
             blockLevel?: boolean
@@ -35,65 +35,69 @@ declare module "swig" {
         loaders: typeof loaders;
     }
 
-    export interface TYPES {
-        /** Whitespace */
-        WHITESPACE: number;
-        /** Plain string */
-        STRING: number;
-        /** Variable filter */
-        FILTER: number;
-        /** Empty variable filter */
-        FILTEREMPTY: number;
-        /** Function */
-        FUNCTION: number;
-        /** Function with no arguments */
-        FUNCTIONEMPTY: number;
-        /** Open parenthesis */
-        PARENOPEN: number;
-        /** Close parenthesis */
-        PARENCLOSE: number;
-        /** Comma */
-        COMMA: number;
-        /** Variable */
-        VAR: number;
-        /** Number */
-        NUMBER: number;
-        /** Math operator */
-        OPERATOR: number;
-        /** Open square bracket */
-        BRACKETOPEN: number;
-        /** Close square bracket */
-        BRACKETCLOSE: number;
-        /** Key on an object using dot-notation */
-        DOTKEY: number;
-        /** Start of an array */
-        ARRAYOPEN: number;
-        /** End of an array
-         * Currently unused
-        ARRAYCLOSE: number, */
-        /** Open curly brace */
-        CURLYOPEN: number;
-        /** Close curly brace */
-        CURLYCLOSE: number;
-        /** Colon (:) */
-        COLON: number;
-        /** JavaScript-valid comparator */
-        COMPARATOR: number;
-        /** Boolean logic */
-        LOGIC: number;
-        /** Boolean logic "not" */
-        NOT: number;
-        /** true or false */
-        BOOL: number;
-        /** Variable assignment */
-        ASSIGNMENT: number;
-        /** Start of a method */
-        METHODOPEN: number;
-        /** End of a method
-         * Currently unused
-        METHODEND: 26, */
-        /** Unknown type */
-        UNKNOWN: number
+    export module lexer {
+        export enum TYPES {
+            /** Whitespace */
+            WHITESPACE = 0,
+            /** Plain string */
+            STRING = 1,
+            /** Variable filter */
+            FILTER = 2,
+            /** Empty variable filter */
+            FILTEREMPTY = 3,
+            /** Function */
+            FUNCTION = 4,
+            /** Function with no arguments */
+            FUNCTIONEMPTY = 5,
+            /** Open parenthesis */
+            PARENOPEN = 6,
+            /** Close parenthesis */
+            PARENCLOSE = 7,
+            /** Comma */
+            COMMA = 8,
+            /** Variable */
+            VAR = 9,
+            /** Number */
+            NUMBER = 10,
+            /** Math operator */
+            OPERATOR = 11,
+            /** Open square bracket */
+            BRACKETOPEN = 12,
+            /** Close square bracket */
+            BRACKETCLOSE = 13,
+            /** Key on an object using dot-notation */
+            DOTKEY = 14,
+            /** Start of an array */
+            ARRAYOPEN = 15,
+            /** End of an array
+             * Currently unused
+            ARRAYCLOSE = 16, */
+            /** Open curly brace */
+            CURLYOPEN = 17,
+            /** Close curly brace */
+            CURLYCLOSE = 18,
+            /** Colon (:) */
+            COLON = 19,
+            /** JavaScript-valid comparator */
+            COMPARATOR = 20,
+            /** Boolean logic */
+            LOGIC = 21,
+            /** Boolean logic "not" */
+            NOT = 22,
+            /** true or false */
+            BOOL = 23,
+            /** Variable assignment */
+            ASSIGNMENT = 24,
+            /** Start of a method */
+            METHODOPEN = 25,
+            /** End of a method
+             * Currently unused
+            METHODEND = 26, */
+            /** Unknown type */
+            UNKNOWN = 100
+        }
+
+        export function read(str: string): string[];
     }
 
     export interface SwigOptions {
@@ -126,7 +130,7 @@ declare module "swig" {
         ): void;
     export function setTag(
         name: string,
-        parse: (str?: string, line?: string, parser?: Object, types?: TYPES, stack?: any, opts?: Object, swig?: Swig) => boolean,
+        parse: (str?: string, line?: string, parser?: Object, types?: lexer.TYPES, stack?: any, opts?: Object, swig?: Swig) => boolean,
         compile: (compiler?: (content?: string, parents?: any, options?: any, blockName?: string) => string, args?: any[], content?: string, parents?: any, options?: any, blockName?: string) => string,
         ends?: boolean,
         blockLevel?: boolean

--- a/swig/swig.d.ts
+++ b/swig/swig.d.ts
@@ -145,7 +145,7 @@ declare module "swig" {
         blockLevel?: boolean
         ): void;
     export function setExtension(name: string, object: any): void;
-    export function parseFile(pathName: string, options?: any);
+    export function parseFile(pathName: string, options?: any): parser.ParseReturn;
     export function precompile(source: string, options?: SwigOptions): any;
     export function compile(source: string, options?: SwigOptions): (locals?: any) => string;
     export function compileFile(pathname: string, options: SwigOptions, cb: (err: Error, compiledRender: (locals?: any) => string) => void): void;

--- a/swig/swig.d.ts
+++ b/swig/swig.d.ts
@@ -21,13 +21,13 @@ declare module "swig" {
             blockLevel?: boolean
             ): void;
         setExtension(name: string, object: any): void;
-        parseFile(pathName: string, options?: any);
+        parseFile(pathName: string, options?: any): parser.ParseReturn;
         precompile(source: string, options?: SwigOptions): any;
         compile(source: string, options?: SwigOptions): (locals?: any) => string;
-        compileFile(pathname: string, options: SwigOptions, cb: (err: any, compiledRender: (locals?: any) => string) => void): void;
+        compileFile(pathname: string, options: SwigOptions, cb: (err: Error, compiledRender: (locals?: any) => string) => void): void;
         compileFile(pathname: string, options?: SwigOptions): (locals?: any) => string;
         render(source: string, options?: SwigOptions): string;
-        renderFile(pathName: string, locals: any, cb: (err: any, output: string) => void): void;
+        renderFile(pathName: string, locals: any, cb: (err: Error, output: string) => void): void;
         renderFile(pathName: string, locals?: any): string
         run(templateFn: Function, locals?: any, filePath?: string): string;
         invalidateCache(): void;
@@ -100,6 +100,15 @@ declare module "swig" {
         export function read(str: string): string[];
     }
 
+    export module parser {
+        interface ParseReturn {
+            name: string;
+            parent: any;
+            tokens: any[];
+            blocks: any;
+        }
+    }
+
     export interface SwigOptions {
         autoescape?: boolean;
         cache?: any;
@@ -112,8 +121,8 @@ declare module "swig" {
 
     export interface TemplateLoader {
         resolve(to: string, from: string): string;
-        load(identifier, callback?: (err: any, data: any) => void): void;
-        load(identifier): any;
+        load(identifier: string, callback?: (err: Error, data: any) => void): void;
+        load(identifier:string): any;
     }
 
     export module loaders {
@@ -139,10 +148,10 @@ declare module "swig" {
     export function parseFile(pathName: string, options?: any);
     export function precompile(source: string, options?: SwigOptions): any;
     export function compile(source: string, options?: SwigOptions): (locals?: any) => string;
-    export function compileFile(pathname: string, options: SwigOptions, cb: (err: any, compiledRender: (locals?: any) => string) => void): void;
+    export function compileFile(pathname: string, options: SwigOptions, cb: (err: Error, compiledRender: (locals?: any) => string) => void): void;
     export function compileFile(pathname: string, options?: SwigOptions): (locals?: any) => string;
     export function render(source: string, options?: SwigOptions): string;
-    export function renderFile(pathName: string, locals: any, cb: (err: any, output: string) => void): void;
+    export function renderFile(pathName: string, locals: any, cb: (err: Error, output: string) => void): void;
     export function renderFile(pathName: string, locals?: any): string
     export function run(templateFn: Function, locals?: any, filePath?: string): string;
     export function invalidateCache(): void;

--- a/swig/swig.d.ts
+++ b/swig/swig.d.ts
@@ -1,27 +1,145 @@
 // Type definitions for swig
 // Project: http://github.com/paularmstrong/swig
-// Definitions by: Carlos Ballesteros Velasco <https://github.com/soywiz>
+// Definitions by: Peter Harris <https://github.com/CodeAnimal>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
-
-// Imported from: https://github.com/soywiz/typescript-node-definitions/swig.d.ts
 
 // API Documentation : http://paularmstrong.github.io/swig/docs/api/
 
 declare module "swig" {
-	export function init(options: Options): void;
-	export function compileFile(filepath: string): any;
-	export function compile(source: string, options?: Options): any;
-	export function renderFile(pathName: string, locals?: any, cb?: (err: any, output: string) => void): string;
+    export class Swig {
+        constructor(options?: SwigOptions);
 
-	export interface Options {
-		allowErrors?: boolean;
-		autoescape?: boolean;
-		cache?: boolean;
-		encoding?: string;
-		filters?: any;
-		root?: string;
-		tags?: any;
-		extensions?: any;
-		tzOffset?: number;
-	}
+        setFilter(
+            name: string,
+            method: (input: any, ...args: any[]) => string
+            ): void;
+        setTag(
+            name: string,
+            parse: (str?: string, line?: string, parser?: Object, types?: TYPES, stack?: any, opts?: Object, swig?: Swig) => boolean,
+            compile: (compiler?: (content?: string, parents?: any, options?: any, blockName?: string) => string, args?: any[], content?: string, parents?: any, options?: any, blockName?: string) => string,
+            ends?: boolean,
+            blockLevel?: boolean
+            ): void;
+        setExtension(name: string, object: any): void;
+        parseFile(pathName: string, options?: any);
+        precompile(source: string, options?: SwigOptions): any;
+        compile(source: string, options?: SwigOptions): (locals?: any) => string;
+        compileFile(pathname: string, options: SwigOptions, cb: (err: any, compiledRender: (locals?: any) => string) => void): void;
+        compileFile(pathname: string, options?: SwigOptions): (locals?: any) => string;
+        render(source: string, options?: SwigOptions): string;
+        renderFile(pathName: string, locals: any, cb: (err: any, output: string) => void): void;
+        renderFile(pathName: string, locals?: any): string
+        run(templateFn: Function, locals?: any, filePath?: string): string;
+        invalidateCache(): void;
+
+        loaders: typeof loaders;
+    }
+
+    export interface TYPES {
+        /** Whitespace */
+        WHITESPACE: number;
+        /** Plain string */
+        STRING: number;
+        /** Variable filter */
+        FILTER: number;
+        /** Empty variable filter */
+        FILTEREMPTY: number;
+        /** Function */
+        FUNCTION: number;
+        /** Function with no arguments */
+        FUNCTIONEMPTY: number;
+        /** Open parenthesis */
+        PARENOPEN: number;
+        /** Close parenthesis */
+        PARENCLOSE: number;
+        /** Comma */
+        COMMA: number;
+        /** Variable */
+        VAR: number;
+        /** Number */
+        NUMBER: number;
+        /** Math operator */
+        OPERATOR: number;
+        /** Open square bracket */
+        BRACKETOPEN: number;
+        /** Close square bracket */
+        BRACKETCLOSE: number;
+        /** Key on an object using dot-notation */
+        DOTKEY: number;
+        /** Start of an array */
+        ARRAYOPEN: number;
+        /** End of an array
+         * Currently unused
+        ARRAYCLOSE: number, */
+        /** Open curly brace */
+        CURLYOPEN: number;
+        /** Close curly brace */
+        CURLYCLOSE: number;
+        /** Colon (:) */
+        COLON: number;
+        /** JavaScript-valid comparator */
+        COMPARATOR: number;
+        /** Boolean logic */
+        LOGIC: number;
+        /** Boolean logic "not" */
+        NOT: number;
+        /** true or false */
+        BOOL: number;
+        /** Variable assignment */
+        ASSIGNMENT: number;
+        /** Start of a method */
+        METHODOPEN: number;
+        /** End of a method
+         * Currently unused
+        METHODEND: 26, */
+        /** Unknown type */
+        UNKNOWN: number
+    }
+
+    export interface SwigOptions {
+        autoescape?: boolean;
+        cache?: any;
+        cmtControls?: string[];
+        loader?: TemplateLoader;
+        locals?: any;
+        tagControls?: string[];
+        varControls?: string[];
+    }
+
+    export interface TemplateLoader {
+        resolve(to: string, from: string): string;
+        load(identifier, callback?: (err: any, data: any) => void): void;
+        load(identifier): any;
+    }
+
+    export module loaders {
+        export function fs(basepath?: string, encoding?: string): TemplateLoader;
+        export function memory(mapping: any, basepath?: string): TemplateLoader;
+    }
+
+    export var version: string;
+    export function setDefaults(options: SwigOptions): void;
+    export function setDefaultTZOffset(offset: number): void;
+    export function setFilter(
+        name: string,
+        method: (input: any, ...args: any[]) => string
+        ): void;
+    export function setTag(
+        name: string,
+        parse: (str?: string, line?: string, parser?: Object, types?: TYPES, stack?: any, opts?: Object, swig?: Swig) => boolean,
+        compile: (compiler?: (content?: string, parents?: any, options?: any, blockName?: string) => string, args?: any[], content?: string, parents?: any, options?: any, blockName?: string) => string,
+        ends?: boolean,
+        blockLevel?: boolean
+        ): void;
+    export function setExtension(name: string, object: any): void;
+    export function parseFile(pathName: string, options?: any);
+    export function precompile(source: string, options?: SwigOptions): any;
+    export function compile(source: string, options?: SwigOptions): (locals?: any) => string;
+    export function compileFile(pathname: string, options: SwigOptions, cb: (err: any, compiledRender: (locals?: any) => string) => void): void;
+    export function compileFile(pathname: string, options?: SwigOptions): (locals?: any) => string;
+    export function render(source: string, options?: SwigOptions): string;
+    export function renderFile(pathName: string, locals: any, cb: (err: any, output: string) => void): void;
+    export function renderFile(pathName: string, locals?: any): string
+    export function run(templateFn: Function, locals?: any, filePath?: string): string;
+    export function invalidateCache(): void;
 }


### PR DESCRIPTION
The swig definitions have been totally rewritten to the latest version
as of time of commit.

See: http://paularmstrong.github.io/swig/docs/api/ for how the API
should work.

I have also updated the tests to hopefully catch any obvious issues.
