### PR TITLE
Updated "google.maps.geometry.poly" to static

### DIFF
--- a/googlemaps/google.maps.d.ts
+++ b/googlemaps/google.maps.d.ts
@@ -1263,8 +1263,8 @@ declare module google.maps {
         }
 
         export class poly {
-            containsLocation(point: LatLng, polygon: Polygon): boolean;
-            isLocationOnEdge(point: LatLng, poly: any, tolerance?: number): boolean;
+            static containsLocation(point: LatLng, polygon: Polygon): boolean;
+            static isLocationOnEdge(point: LatLng, poly: any, tolerance?: number): boolean;
         }
     }
 


### PR DESCRIPTION
The 'poly' class should be static (as already correctly marked on the 'spherical' class).
