### PR TITLE
request.d.ts: fixing RequestAPI.Options.form type

### DIFF
--- a/request/request-tests.ts
+++ b/request/request-tests.ts
@@ -69,7 +69,7 @@ var options: request.Options = {
 
 	},
 	jar: value,
-	form: value,
+	form: obj,
 	oauth: value,
 	aws: aws,
 	qs: obj,

--- a/request/request.d.ts
+++ b/request/request.d.ts
@@ -61,7 +61,7 @@ declare module 'request' {
 			uri?: string;
 			callback?: (error: any, response: any, body: any) => void;
 			jar?: any; // CookieJar
-			form?: FormData;
+			form?: any; // Object or string
 			oauth?: OAuthOptions;
 			aws?: AWSOptions;
 			hawk ?: HawkOptions;


### PR DESCRIPTION
In the definition file for the [request](https://github.com/mikeal/request) library, `RequestAPI.Options.form`  is of type `FormData`. ([Line 64](https://github.com/borisyankov/DefinitelyTyped/blob/b0b4af1223f4f9449012688fa0c18f20cc3267e7/request/request.d.ts#L64))

This prevents you from writing code like the example given in the request docs, because a plain object can't be used as a value for `form`:

``` javascript
request.post('http://service.com/upload', {form:{key:'value'}})
```

From reading the request docs and source code I don't think this type is right; it needs to be either a POJO or a string, so I've modified the type to `any`
