### PR TITLE
More precise type for $routeProvider.resolve

### DIFF
--- a/angularjs/angular-route.d.ts
+++ b/angularjs/angular-route.d.ts
@@ -75,7 +75,7 @@ declare module ng.route {
          * - key - {string}: a name of a dependency to be injected into the controller.
          * - factory - {string|function}: If string then it is an alias for a service. Otherwise if function, then it is injected and the return value is treated as the dependency. If the result is a promise, it is resolved before its value is injected into the controller. Be aware that ngRoute.$routeParams will still refer to the previous route within these resolve functions. Use $route.current.params to access the new route parameters, instead.
          */
-        resolve?: any;
+	 resolve?: {[key: string]: any};
         /**
          * {(string|function())=}
          * Value to update $location path with and trigger route redirection.


### PR DESCRIPTION
`$routeProvider.resolve` is documented to take a map with string keys and injectable values. The values are best modeled as `any` for now (until union types are a thing), but the top-level value should be typed as a map.
