### PR TITLE
Moment: fix locale

### DIFF
--- a/moment/moment-external-tests.ts
+++ b/moment/moment-external-tests.ts
@@ -87,6 +87,13 @@ m2.add('hours', 24).hours();
 var duration = moment.duration({'days': 1});
 moment([2012, 0, 31]).add(duration);
 
+moment().add('seconds', 1);
+moment().add('seconds', '1');
+moment().add(1, 'seconds');
+
+moment().add('1', 'seconds');
+moment().add('seconds', '1');
+
 moment().subtract('days', 7);
 
 moment().seconds(30);

--- a/moment/moment-external-tests.ts
+++ b/moment/moment-external-tests.ts
@@ -230,8 +230,13 @@ adur.subtract(bdur).days();
 adur.subtract(1).days();
 adur.subtract(1, 'd').days();
 
+// Selecting a language
+moment.locale();
+moment.locale('en');
+moment.locale(['en', 'fr']);
+
 // Defining a custom language: 
-moment.localeData('en', {
+moment.locale('en', {
     months: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
     monthsShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
     weekdays: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
@@ -289,14 +294,14 @@ moment.localeData('en', {
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     months : [
         "January", "February", "March", "April", "May", "June", "July",
         "August", "September", "October", "November", "December"
     ]
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     months : function (momentToFormat: Moment, format: string) {
         // momentToFormat is the moment currently being formatted
         // format is the formatting string
@@ -308,14 +313,14 @@ moment.localeData('en', {
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     monthsShort : [
         "Jan", "Feb", "Mar", "Apr", "May", "Jun",
         "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
     ]
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     monthsShort : function (momentToFormat: Moment, format: string) {
         if (/^MMMM/.test(format)) {
             return this.nominative[momentToFormat.month()];
@@ -325,39 +330,39 @@ moment.localeData('en', {
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     weekdays : [
         "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
     ]
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     weekdays : function (momentToFormat: Moment) {
         return this.weekdays[momentToFormat.day()];
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     weekdaysShort : ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     weekdaysShort : function (momentToFormat: Moment) {
         return this.weekdaysShort[momentToFormat.day()];
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     weekdaysMin : ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     weekdaysMin : function (momentToFormat: Moment) {
         return this.weekdaysMin[momentToFormat.day()];
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     longDateFormat : {
         LT: "h:mm A",
         L: "MM/DD/YYYY",
@@ -371,7 +376,7 @@ moment.localeData('en', {
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     longDateFormat : {
         LT: "h:mm A",
         L: "MM/DD/YYYY",
@@ -381,7 +386,7 @@ moment.localeData('en', {
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     relativeTime : {
         future: "in %s",
         past:   "%s ago",
@@ -399,7 +404,7 @@ moment.localeData('en', {
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     meridiem : function (hour, minute, isLowercase) {
         if (hour < 9) {
             return "早上";
@@ -415,7 +420,7 @@ moment.localeData('en', {
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     calendar : {
         lastDay : '[Yesterday at] LT',
         sameDay : '[Today at] LT',
@@ -428,7 +433,7 @@ moment.localeData('en', {
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     ordinal : function (number) {
         var b = number % 10;
         var output = (~~ (number % 100 / 10) === 1) ? 'th' :

--- a/moment/moment-external-tests.ts
+++ b/moment/moment-external-tests.ts
@@ -18,7 +18,7 @@ var now = moment();
 var day7 = moment([2010, 1, 14, 15, 25, 50, 125]);
 var day8 = moment([2010]);
 var day9 = moment([2010, 6]);
-var day10 = moment([2010, 6, 10]); 
+var day10 = moment([2010, 6, 10]);
 var array = [2010, 1, 14, 15, 25, 50, 125];
 var day11 = moment(Date.UTC.apply({}, array));
 var day12 = moment.unix(1318781876);
@@ -62,8 +62,8 @@ a.hours();
 a.local();
 a.hours();
 
-moment("2011-10-10", "YYYY-MM-DD").isValid(); 
-moment("2011-10-50", "YYYY-MM-DD").isValid(); 
+moment("2011-10-10", "YYYY-MM-DD").isValid();
+moment("2011-10-50", "YYYY-MM-DD").isValid();
 moment("2011-10-10T10:20:90").isValid();
 moment([2011, 0, 1]).isValid();
 moment([2011, 0, 50]).isValid();
@@ -74,16 +74,16 @@ moment().add('days', 7).subtract('months', 1).year(2009).hours(0).minutes(0).sec
 moment().add('days', 7);
 moment().add('days', 7).add('months', 1);
 moment().add({days:7,months:1});
-moment().add('milliseconds', 1000000); 
+moment().add('milliseconds', 1000000);
 moment().add('days', 360);
-moment([2010, 0, 31]);  
+moment([2010, 0, 31]);
 moment([2010, 0, 31]).add('months', 1);
 var m = moment(new Date(2011, 2, 12, 5, 0, 0));
-m.hours(); 
+m.hours();
 m.add('days', 1).hours();
-var m2 = moment(new Date(2011, 2, 12, 5, 0, 0)); 
+var m2 = moment(new Date(2011, 2, 12, 5, 0, 0));
 m2.hours();
-m2.add('hours', 24).hours(); 
+m2.add('hours', 24).hours();
 var duration = moment.duration({'days': 1});
 moment([2012, 0, 31]).add(duration);
 
@@ -99,14 +99,14 @@ moment().subtract('days', 7);
 moment().seconds(30);
 moment().minutes(30);
 
-moment().hours(12); 
+moment().hours(12);
 moment().date(5);
 moment().day(5);
 moment().day("Sunday");
 moment().month(5);
 moment().month("January");
 moment().year(1984);
-moment().startOf('year'); 
+moment().startOf('year');
 moment().month(0).date(1).hours(0).minutes(0).seconds(0).milliseconds(0);
 moment().startOf('hour');
 moment().minutes(0).seconds(0).milliseconds(0);
@@ -127,10 +127,10 @@ moment().isoWeek(45);
 moment().isoWeeks();
 moment().isoWeeks(45);
 
-var getMilliseconds: number = moment().milliseconds(); 
-var getSeconds: number = moment().seconds(); 
-var getMinutes: number = moment().minutes(); 
-var getHours: number = moment().hours(); 
+var getMilliseconds: number = moment().milliseconds();
+var getSeconds: number = moment().seconds();
+var getMinutes: number = moment().minutes();
+var getHours: number = moment().hours();
 var getDate: number = moment().date();
 var getDay: number = moment().day();
 var getMonth: number = moment().month();
@@ -145,11 +145,11 @@ a3.utc();
 a3.hours();
 
 var a4 = moment([2010, 1, 14, 15, 25, 50, 125]);
-a4.format("dddd, MMMM Do YYYY, h:mm:ss a"); 
+a4.format("dddd, MMMM Do YYYY, h:mm:ss a");
 a4.format("ddd, hA");
 
 moment().format('\\L');
-moment().format('[today] DDDD'); 
+moment().format('[today] DDDD');
 
 var a5 = moment([2007, 0, 29]);
 var b5 = moment([2007, 0, 28]);
@@ -158,8 +158,8 @@ a5.from(b5);
 var a6 = moment([2007, 0, 29]);
 var b6 = moment([2007, 0, 28]);
 a6.from(b6);
-a6.from([2007, 0, 28]);         
-a6.from(new Date(2007, 0, 28)); 
+a6.from([2007, 0, 28]);
+a6.from(new Date(2007, 0, 28));
 a6.from("1-28-2007");
 
 var a7 = moment();
@@ -168,23 +168,23 @@ a7.from(b7);
 
 var start = moment([2007, 0, 5]);
 var end = moment([2007, 0, 10]);
-start.from(end);   
+start.from(end);
 start.from(end, true);
 
-moment([2007, 0, 29]).fromNow(); 
-moment([2007, 0, 29]).fromNow();     
-moment([2007, 0, 29]).fromNow(true); 
+moment([2007, 0, 29]).fromNow();
+moment([2007, 0, 29]).fromNow();
+moment([2007, 0, 29]).fromNow(true);
 
 var a8 = moment([2007, 0, 29]);
 var b8 = moment([2007, 0, 28]);
 a8.diff(b8) ;
 a8.diff(b8, 'days');
-a8.diff(b8, 'years')      
+a8.diff(b8, 'years')
 a8.diff(b8, 'years', true);
 
 moment([2007, 0, 29]).toDate();
 moment([2007, 1, 23]).toISOString();
-moment(1318874398806).valueOf(); 
+moment(1318874398806).valueOf();
 moment(1318874398806).unix();
 moment([2000]).isLeapYear();
 moment().zone();
@@ -198,12 +198,12 @@ moment.isMoment(moment());
 moment.localeData('fr');
 moment(1316116057189).fromNow();
 
-moment.localeData('en'); 
+moment.localeData('en');
 var globalLang = moment();
 var localLang = moment();
-localLang.localeData('fr'); 
-localLang.format('LLLL'); 
-globalLang.format('LLLL'); 
+localLang.localeData('fr');
+localLang.format('LLLL');
+globalLang.format('LLLL');
 
 moment.duration(100);
 moment.duration(2, 'seconds');
@@ -235,7 +235,7 @@ moment.locale();
 moment.locale('en');
 moment.locale(['en', 'fr']);
 
-// Defining a custom language: 
+// Defining a custom language:
 moment.locale('en', {
     months: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
     monthsShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],

--- a/moment/moment-tests.ts
+++ b/moment/moment-tests.ts
@@ -16,7 +16,7 @@ var now = moment();
 var day7 = moment([2010, 1, 14, 15, 25, 50, 125]);
 var day8 = moment([2010]);
 var day9 = moment([2010, 6]);
-var day10 = moment([2010, 6, 10]); 
+var day10 = moment([2010, 6, 10]);
 var array = [2010, 1, 14, 15, 25, 50, 125];
 var day11 = moment(Date.UTC.apply({}, array));
 var day12 = moment.unix(1318781876);
@@ -60,8 +60,8 @@ a.hours();
 a.local();
 a.hours();
 
-moment("2011-10-10", "YYYY-MM-DD").isValid(); 
-moment("2011-10-50", "YYYY-MM-DD").isValid(); 
+moment("2011-10-10", "YYYY-MM-DD").isValid();
+moment("2011-10-50", "YYYY-MM-DD").isValid();
 moment("2011-10-10T10:20:90").isValid();
 moment([2011, 0, 1]).isValid();
 moment([2011, 0, 50]).isValid();
@@ -72,16 +72,16 @@ moment().add('days', 7).subtract('months', 1).year(2009).hours(0).minutes(0).sec
 moment().add('days', 7);
 moment().add('days', 7).add('months', 1);
 moment().add({days:7,months:1});
-moment().add('milliseconds', 1000000); 
+moment().add('milliseconds', 1000000);
 moment().add('days', 360);
-moment([2010, 0, 31]);  
+moment([2010, 0, 31]);
 moment([2010, 0, 31]).add('months', 1);
 var m = moment(new Date(2011, 2, 12, 5, 0, 0));
-m.hours(); 
+m.hours();
 m.add('days', 1).hours();
-var m2 = moment(new Date(2011, 2, 12, 5, 0, 0)); 
+var m2 = moment(new Date(2011, 2, 12, 5, 0, 0));
 m2.hours();
-m2.add('hours', 24).hours(); 
+m2.add('hours', 24).hours();
 var duration = moment.duration({'days': 1});
 moment([2012, 0, 31]).add(duration);
 
@@ -97,14 +97,14 @@ moment().subtract('days', 7);
 moment().seconds(30);
 moment().minutes(30);
 
-moment().hours(12); 
+moment().hours(12);
 moment().date(5);
 moment().day(5);
 moment().day("Sunday");
 moment().month(5);
 moment().month("January");
 moment().year(1984);
-moment().startOf('year'); 
+moment().startOf('year');
 moment().month(0).date(1).hours(0).minutes(0).seconds(0).milliseconds(0);
 moment().startOf('hour');
 moment().minutes(0).seconds(0).milliseconds(0);
@@ -125,10 +125,10 @@ moment().isoWeek(45);
 moment().isoWeeks();
 moment().isoWeeks(45);
 
-var getMilliseconds: number = moment().milliseconds(); 
-var getSeconds: number = moment().seconds(); 
-var getMinutes: number = moment().minutes(); 
-var getHours: number = moment().hours(); 
+var getMilliseconds: number = moment().milliseconds();
+var getSeconds: number = moment().seconds();
+var getMinutes: number = moment().minutes();
+var getHours: number = moment().hours();
 var getDate: number = moment().date();
 var getDay: number = moment().day();
 var getMonth: number = moment().month();
@@ -143,11 +143,11 @@ a3.utc();
 a3.hours();
 
 var a4 = moment([2010, 1, 14, 15, 25, 50, 125]);
-a4.format("dddd, MMMM Do YYYY, h:mm:ss a"); 
+a4.format("dddd, MMMM Do YYYY, h:mm:ss a");
 a4.format("ddd, hA");
 
 moment().format('\\L');
-moment().format('[today] DDDD'); 
+moment().format('[today] DDDD');
 
 var a5 = moment([2007, 0, 29]);
 var b5 = moment([2007, 0, 28]);
@@ -156,8 +156,8 @@ a5.from(b5);
 var a6 = moment([2007, 0, 29]);
 var b6 = moment([2007, 0, 28]);
 a6.from(b6);
-a6.from([2007, 0, 28]);         
-a6.from(new Date(2007, 0, 28)); 
+a6.from([2007, 0, 28]);
+a6.from(new Date(2007, 0, 28));
 a6.from("1-28-2007");
 
 var a7 = moment();
@@ -166,23 +166,23 @@ a7.from(b7);
 
 var start = moment([2007, 0, 5]);
 var end = moment([2007, 0, 10]);
-start.from(end);   
+start.from(end);
 start.from(end, true);
 
-moment([2007, 0, 29]).fromNow(); 
-moment([2007, 0, 29]).fromNow();     
-moment([2007, 0, 29]).fromNow(true); 
+moment([2007, 0, 29]).fromNow();
+moment([2007, 0, 29]).fromNow();
+moment([2007, 0, 29]).fromNow(true);
 
 var a8 = moment([2007, 0, 29]);
 var b8 = moment([2007, 0, 28]);
 a8.diff(b8) ;
 a8.diff(b8, 'days');
-a8.diff(b8, 'years')      
+a8.diff(b8, 'years')
 a8.diff(b8, 'years', true);
 
 moment([2007, 0, 29]).toDate();
 moment([2007, 1, 23]).toISOString();
-moment(1318874398806).valueOf(); 
+moment(1318874398806).valueOf();
 moment(1318874398806).unix();
 moment([2000]).isLeapYear();
 moment().zone();
@@ -196,12 +196,12 @@ moment.isMoment(moment());
 moment.localeData('fr');
 moment(1316116057189).fromNow();
 
-moment.localeData('en'); 
+moment.localeData('en');
 var globalLang = moment();
 var localLang = moment();
-localLang.localeData('fr'); 
-localLang.format('LLLL'); 
-globalLang.format('LLLL'); 
+localLang.localeData('fr');
+localLang.format('LLLL');
+globalLang.format('LLLL');
 
 moment.duration(100);
 moment.duration(2, 'seconds');
@@ -233,7 +233,7 @@ moment.locale();
 moment.locale('en');
 moment.locale(['en', 'fr']);
 
-// Defining a custom language: 
+// Defining a custom language:
 moment.locale('en', {
     months: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
     monthsShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],

--- a/moment/moment-tests.ts
+++ b/moment/moment-tests.ts
@@ -228,8 +228,13 @@ adur.subtract(bdur).days();
 adur.subtract(1).days();
 adur.subtract(1, 'd').days();
 
+// Selecting a language
+moment.locale();
+moment.locale('en');
+moment.locale(['en', 'fr']);
+
 // Defining a custom language: 
-moment.localeData('en', {
+moment.locale('en', {
     months: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
     monthsShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
     weekdays: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
@@ -287,14 +292,14 @@ moment.localeData('en', {
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     months : [
         "January", "February", "March", "April", "May", "June", "July",
         "August", "September", "October", "November", "December"
     ]
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     months : function (momentToFormat: Moment, format: string) {
         // momentToFormat is the moment currently being formatted
         // format is the formatting string
@@ -306,14 +311,14 @@ moment.localeData('en', {
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     monthsShort : [
         "Jan", "Feb", "Mar", "Apr", "May", "Jun",
         "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
     ]
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     monthsShort : function (momentToFormat: Moment, format: string) {
         if (/^MMMM/.test(format)) {
             return this.nominative[momentToFormat.month()];
@@ -323,39 +328,39 @@ moment.localeData('en', {
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     weekdays : [
         "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
     ]
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     weekdays : function (momentToFormat: Moment) {
         return this.weekdays[momentToFormat.day()];
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     weekdaysShort : ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     weekdaysShort : function (momentToFormat: Moment) {
         return this.weekdaysShort[momentToFormat.day()];
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     weekdaysMin : ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     weekdaysMin : function (momentToFormat: Moment) {
         return this.weekdaysMin[momentToFormat.day()];
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     longDateFormat : {
         LT: "h:mm A",
         L: "MM/DD/YYYY",
@@ -369,7 +374,7 @@ moment.localeData('en', {
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     longDateFormat : {
         LT: "h:mm A",
         L: "MM/DD/YYYY",
@@ -379,7 +384,7 @@ moment.localeData('en', {
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     relativeTime : {
         future: "in %s",
         past:   "%s ago",
@@ -397,7 +402,7 @@ moment.localeData('en', {
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     meridiem : function (hour, minute, isLowercase) {
         if (hour < 9) {
             return "早上";
@@ -413,7 +418,7 @@ moment.localeData('en', {
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     calendar : {
         lastDay : '[Yesterday at] LT',
         sameDay : '[Today at] LT',
@@ -426,7 +431,7 @@ moment.localeData('en', {
     }
 });
 
-moment.localeData('en', {
+moment.locale('en', {
     ordinal : function (number) {
         var b = number % 10;
         var output = (~~ (number % 100 / 10) === 1) ? 'th' :

--- a/moment/moment.d.ts
+++ b/moment/moment.d.ts
@@ -382,8 +382,11 @@ interface MomentStatic {
     lang(language?: string): string;
     lang(language?: string, definition?: MomentLanguage): string;
 
-    localeData(language?: string): string;
-    localeData(language?: string, definition?: MomentLanguage): string;
+    locale(language?: string): string;
+    locale(language?: string[]): string;
+    locale(language?: string, definition?: MomentLanguage): string;
+
+    localeData(language?: string): MomentLanguage;
 
     longDateFormat: any;
     relativeTime: any;


### PR DESCRIPTION
I noticed that `moment.locale()` was missing from the definition. When I had a look on it I was confused because the definition did not really match the moment.js documentation. I tried to fix this as good as possible while changing as little as possible. Still I am not entirely sure if I've got it right.
