### PR TITLE
Update winston definitions and tests

### DIFF
--- a/winston/winston-tests.ts
+++ b/winston/winston-tests.ts
@@ -4,14 +4,73 @@ import winston = require('winston');
 
 var str: string;
 var bool: boolean;
+var num: number;
 var metadata: any;
+var obj: any = {};
+
+var queryOptions: winston.QueryOptions;
+var transportOptions: winston.TransportOptions;
+var loggerOptions: winston.LoggerOptions = {
+  transports: [new (winston.Transport)()],
+  rewriters: [new (winston.Transport)()],
+  exceptionHandlers: [new (winston.Transport)()],
+  handleExceptions: false
+};
+
 var options: any;
 var value: any;
-var transport: winston.Transport;
+var transport: winston.TransportInstance;
+var logger: winston.LoggerInstance;
+var profiler: winston.ProfileHandler;
 
-transport = winston.transports.File;
+var writeableStream: NodeJS.WritableStream;
+var readableStream: NodeJS.ReadableStream;
+
+
+var transportStatic: winston.TransportStatic = winston.Transport;
+
+
+var transportInstance: winston.TransportInstance = new (winston.Transport)(transportOptions);
+transportInstance = new (winston.Transport)();
+
+var containerInstance: winston.ContainerInstance = new (winston.Container)(loggerOptions);
+winston.loggers.options.transports = [
+  new (winston.Transport)()
+];
+winston.loggers.add('category1', {
+  console: {
+    level: 'silly',
+    colorize: 'true',
+    label: 'category one'
+  },
+  file: {
+    filename: '/path/to/some/file'
+  },
+  transports: [
+    new (winston.Transport)()
+  ]
+});
+logger = winston.loggers.get('category1');
+
+bool = containerInstance.has(str);
+logger = containerInstance.get(str, loggerOptions);
+containerInstance.close(str);
+
 transport = winston.transports.Console;
+transport = winston.transports.DailyRotateFile;
+transport = winston.transports.File;
+transport = winston.transports.Http;
 transport = winston.transports.Loggly;
+transport = winston.transports.Memory
+transport = winston.transports.Webhook;
+
+value = transport.formatQuery({});
+queryOptions = transport.normalizeQuery(queryOptions);
+value = transport.formatResults([], {});
+transport.logException(str, metadata, () => { });
+
+winston.exitOnError = bool;
+
 
 winston.log(str, str);
 winston.log(str, str, metadata);
@@ -24,17 +83,139 @@ winston.warn(str, metadata);
 winston.error(str);
 winston.error(str, metadata);
 
-winston.add(transport, options);
-winston.remove(transport);
+winston.query(queryOptions, (err: Error, results: any): void => {
 
-winston.profile(str);
-
-winston.query(options, (err: any, results: any) => {
+});
+winston.query((err: Error, results: any): void => {
 
 });
 
-value = winston.stream(options);
+logger = winston.add(transport, transportOptions);
+logger = winston.remove(transport);
+
+winston.clear();
+logger = winston.profile(str, str, metadata, (err: Error, level: string, msg: string, meta: any):void => {
+
+});
+logger = winston.profile(str);
+profiler = winston.startTimer();
+winston.setLevels({});
+logger = winston.cli();
 
 winston.handleExceptions(transport);
-winston.exitOnError = bool;
+winston.unhandleExceptions(transport);
 
+readableStream = winston.stream(options);
+
+readableStream.on('log', function (log:any):void {
+  console.log(log);
+});
+
+
+
+logger = logger.extend(obj);
+logger.log(str, str);
+logger.log(str, str, metadata);
+logger.debug(str);
+logger.debug(str, metadata);
+logger.info(str);
+logger.info(str, metadata);
+logger.warn(str);
+logger.warn(str, metadata);
+logger.error(str);
+logger.error(str, metadata);
+
+logger.query(queryOptions, (err: Error, results: any): void => {
+
+});
+logger.query((err: Error, results: any): void => {
+
+});
+
+readableStream = winston.stream(options);
+logger.close();
+logger.handleExceptions(transport);
+logger.unhandleExceptions(transport);
+logger = logger.add(transport, transportOptions, bool);
+logger = logger.add(transport);
+logger.addRewriter(transport)[0];
+logger.clear();
+logger = logger.remove(transport);
+profiler = logger.startTimer();
+logger = logger.profile(str, str, metadata, (err: Error, level: string, msg: string, meta: any):void => {
+
+});
+value = logger.setLevels(value);
+logger = logger.cli();
+
+
+logger = profiler.done(str);
+logger = profiler.logger;
+profiler.start = new Date();
+
+
+/**
+ * New Logger instances with transports tests:
+ */
+
+var logger: winston.LoggerInstance = new (winston.Logger)({
+  transports: [
+    new (winston.transports.Console)({
+      level: str,
+      silent: bool,
+      colorize: bool,
+      timestamp: bool,
+    }),
+    new (winston.transports.DailyRotateFile)({
+      level: str,
+      silent: bool,
+      colorize: bool,
+      maxsize: num,
+      maxFiles: num,
+      prettyPrint: bool,
+      timestamp: bool,
+      filename: str,
+      dirname: str,
+      datePattern: str
+    }),
+    new (winston.transports.File)({
+      level: str,
+      silent: bool,
+      timestamp: bool,
+      filename: str,
+      maxsize: num,
+      maxFiles: num,
+      stream: writeableStream,
+    }),
+    new (winston.transports.Http)({
+      level: str,
+      host: str,
+      port: num,
+      path: str,
+      auth: { username: str, password: str },
+      ssl: {},
+    }),
+    new (winston.transports.Loggly)({
+      level: str,
+      subdomain: str,
+      auth: {},
+      inputName: str,
+      json: bool,
+    }),
+    new (winston.transports.Memory)({
+      level: str,
+      timestamp: bool,
+      label: str,
+    }),
+    new (winston.transports.Webhook)({
+      level: str,
+      name: str,
+      host: str,
+      port: num,
+      method: str,
+      path: str,
+      auth: { username: str, password: str },
+      ssl: {},
+    }),
+  ]
+});

--- a/winston/winston.d.ts
+++ b/winston/winston.d.ts
@@ -1,39 +1,174 @@
 // Type definitions for winston
 // Project: https://github.com/flatiron/winston
-// Definitions by: bonnici <https://github.com/bonnici>
+// Definitions by: bonnici <https://github.com/bonnici>, Peter Harris <https://github.com/codeanimal>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 // Imported from: https://github.com/soywiz/typescript-node-definitions/winston.d.ts
 
+/// <reference path="../node/node.d.ts" />
+
+
+//////// Here for backwards compatibility to older Node definitions ////////
+declare module NodeJS {
+  interface EventEmitter { }
+  interface ReadWriteStream { }
+}
+
+interface NodeEventEmitter extends NodeJS.EventEmitter { }
+interface ReadableStream extends NodeJS.ReadableStream { }
+////////////////////////////////////////////////////////////////////////////
+
 declare module "winston" {
-	export function log(level: string, message: string, metadata?: any): void;
-	export function debug(message: string, metadata?: any): void;
-	export function info(message: string, metadata?: any): void;
-	export function warn(message: string, metadata?: any): void;
-	export function error(message: string, metadata?: any): void;
 
-	export function add(transport: Transport, options: any): void;
-	export function remove(transport: Transport): void;
+  export var transports: Transports;
+  export var Transport: TransportStatic;
+  export var Logger: LoggerStatic;
+  export var Container: ContainerStatic;
+  export var loggers: ContainerInstance;
+  export var defaultLogger: LoggerInstance;
 
-	export function profile(name: string): void;
+  export var exitOnError: boolean;
 
-	export function query(options: any, done: (err: any, results: any) => void): void;
 
-	export function stream(options: any): any;
+  export function log(level: string, msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+  export function log(level: string, msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
 
-	export function handleExceptions(transport: Transport): void;
+  export function debug(msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+  export function debug(msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
 
-	export class Logger {
+  export function info(msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+  export function info(msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
 
-	}
+  export function warn(msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+  export function warn(msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
 
-	export interface Transport {
-	}
-	export interface Transports {
-		File: Transport;
-		Console: Transport;
-		Loggly: Transport;
-	}
-	export var transports: Transports;
-	export var exitOnError: boolean;
+  export function error(msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+  export function error(msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+
+  export function query(options: QueryOptions, callback?: (err: Error, results: any) => void): any;
+  export function query(callback: (err: Error, results: any) => void): any;
+  export function stream(options?: any): ReadableStream;
+  export function handleExceptions(...transports: TransportInstance[]): void;
+  export function unhandleExceptions(...transports: TransportInstance[]): void;
+  export function add(transport: TransportInstance, options?: TransportOptions, created?: boolean): LoggerInstance;
+  export function clear(): void;
+  export function remove(transport: TransportInstance): LoggerInstance;
+  export function startTimer(): ProfileHandler;
+  export function profile(id: string, msg?: string, meta?: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+  export function setLevels(target: any): any;
+  export function cli(): LoggerInstance;
+
+
+  export interface LoggerStatic {
+    new (options?: LoggerOptions);
+  }
+
+  export interface LoggerInstance extends NodeEventEmitter {
+    extend(target: any): LoggerInstance;
+
+    log(level: string, msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+    log(level: string, msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+
+    debug(msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+    debug(msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+
+    info(msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+    info(msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+
+    warn(msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+    warn(msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+
+    error(msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+    error(msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+
+    query(options: QueryOptions, callback?: (err: Error, results: any) => void): any;
+    query(callback: (err: Error, results: any) => void): any;
+    stream(options?: any): ReadableStream;
+    close(): void;
+    handleExceptions(...transports: TransportInstance[]): void;
+    unhandleExceptions(...transports: TransportInstance[]): void;
+    add(transport: TransportInstance, options?: TransportOptions, created?: boolean): LoggerInstance;
+    addRewriter(rewriter: TransportInstance): TransportInstance[];
+    clear(): void;
+    remove(transport: TransportInstance): LoggerInstance;
+    startTimer(): ProfileHandler;
+    profile(id: string, msg?: string, meta?: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+
+    setLevels(target: any): any;
+    cli(): LoggerInstance;
+  }
+
+  export interface LoggerOptions {
+    transports?: TransportInstance[];
+    rewriters?: TransportInstance[];
+    exceptionHandlers?: TransportInstance[];
+    handleExceptions?: boolean;
+
+    /**
+     * @type {(boolean|(err: Error) => void)}
+     */
+    exitOnError?: any;
+  }
+
+  export interface TransportStatic {
+    new (options?: TransportOptions): TransportInstance;
+  }
+
+  export interface TransportInstance extends TransportStatic, NodeEventEmitter {
+    formatQuery(query: any): any;
+    normalizeQuery(options: QueryOptions): QueryOptions;
+    formatResults(results: any, options: any): any;
+    logException(msg: string, meta: any, callback: () => void): void;
+  }
+
+  export interface ContainerStatic {
+    new (options: LoggerOptions): ContainerInstance;
+  }
+
+  export interface ContainerInstance extends ContainerStatic {
+    get(id: string, options?: LoggerOptions): LoggerInstance;
+    add(id: string, options: LoggerOptions): LoggerInstance;
+    has(id: string): boolean;
+    close(id: string): void;
+    options: LoggerOptions;
+    loggers: any;
+    default: LoggerOptions;
+  }
+
+  export interface Transports {
+    File: TransportInstance;
+    Console: TransportInstance;
+    Loggly: TransportInstance;
+    DailyRotateFile: TransportInstance;
+    Http: TransportInstance;
+    Memory: TransportInstance;
+    Webhook: TransportInstance;
+  }
+
+  export interface TransportOptions {
+    level?: string;
+    silent?: boolean;
+    raw?: boolean;
+    name?: string;
+    handleExceptions?: boolean;
+  }
+
+  export interface QueryOptions {
+    rows?: number;
+    limit?: number;
+    start?: number;
+    from?: Date;
+    until?: Date;
+    /**
+     * 'asc' or 'desc'
+     */
+    order?: string;
+    fields: any;
+  }
+
+  export interface ProfileHandler {
+    logger: LoggerInstance;
+    start: Date;
+    done: (msg: string) => LoggerInstance;
+  }
 }

--- a/winston/winston.d.ts
+++ b/winston/winston.d.ts
@@ -7,17 +7,6 @@
 
 /// <reference path="../node/node.d.ts" />
 
-
-//////// Here for backwards compatibility to older Node definitions ////////
-declare module NodeJS {
-  interface EventEmitter { }
-  interface ReadWriteStream { }
-}
-
-interface NodeEventEmitter extends NodeJS.EventEmitter { }
-interface ReadableStream extends NodeJS.ReadableStream { }
-////////////////////////////////////////////////////////////////////////////
-
 declare module "winston" {
 
   export var transports: Transports;
@@ -47,7 +36,7 @@ declare module "winston" {
 
   export function query(options: QueryOptions, callback?: (err: Error, results: any) => void): any;
   export function query(callback: (err: Error, results: any) => void): any;
-  export function stream(options?: any): ReadableStream;
+  export function stream(options?: any): NodeJS.ReadableStream;
   export function handleExceptions(...transports: TransportInstance[]): void;
   export function unhandleExceptions(...transports: TransportInstance[]): void;
   export function add(transport: TransportInstance, options?: TransportOptions, created?: boolean): LoggerInstance;
@@ -63,7 +52,7 @@ declare module "winston" {
     new (options?: LoggerOptions);
   }
 
-  export interface LoggerInstance extends NodeEventEmitter {
+  export interface LoggerInstance extends NodeJS.EventEmitter {
     extend(target: any): LoggerInstance;
 
     log(level: string, msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
@@ -83,7 +72,7 @@ declare module "winston" {
 
     query(options: QueryOptions, callback?: (err: Error, results: any) => void): any;
     query(callback: (err: Error, results: any) => void): any;
-    stream(options?: any): ReadableStream;
+    stream(options?: any): NodeJS.ReadableStream;
     close(): void;
     handleExceptions(...transports: TransportInstance[]): void;
     unhandleExceptions(...transports: TransportInstance[]): void;
@@ -114,7 +103,7 @@ declare module "winston" {
     new (options?: TransportOptions): TransportInstance;
   }
 
-  export interface TransportInstance extends TransportStatic, NodeEventEmitter {
+  export interface TransportInstance extends TransportStatic, NodeJS.EventEmitter {
     formatQuery(query: any): any;
     normalizeQuery(options: QueryOptions): QueryOptions;
     formatResults(results: any, options: any): any;


### PR DESCRIPTION
A large rewrite, with greater detailed definitions.

**BREAKING CHANGES:** `winston.Transport` and `winston.Logger` types have been
renamed to `winston.TransportStatic` and `winston.LoggerStatic`
respectively. Instantiating the types still uses the old syntax: `var
logger = new winston.Logger` but the return type's name has had "Static" appended.
