### PR TITLE
Improved Promise typedef (follow lib intentions)

### DIFF
--- a/parse/parse-tests.ts
+++ b/parse/parse-tests.ts
@@ -398,3 +398,14 @@ function test_view() {
     var model = Parse.User.current();
     var view = new Parse.View<Parse.User>();
 }
+
+function test_promise() {
+
+	// Using static method 'Parse.Promise.when' and instance method 'then' input 0..n input parameter style (...value: Promise<T>[])
+    Parse.Promise.when(new Parse.Promise()).then((result) => { }, (reason) => { });
+    Parse.Promise.when(new Parse.Promise(), new Parse.Promise(), new Parse.Promise()).then((r1, r2, r3) => { }, (reason) => { });
+
+	// Using static method Parse.Promise.when  and instance method 'then' input array of Promise (...value: Promise<T>[])
+   Parse.Promise.when([new Parse.Promise()]).then((r) => { }, (reason) => { });
+   Parse.Promise.when([new Parse.Promise(), new Parse.Promise(), new Parse.Promise()]).then((r1, r2, r3) => { }, (reason) => { });
+}

--- a/parse/parse-tests.ts
+++ b/parse/parse-tests.ts
@@ -192,7 +192,16 @@ function test_file() {
         // result
     });
 
-    // TODO: Check
+	// Test multiple promises with "then"
+    var p1 = Parse.Promise.as(Parse.Cloud.httpRequest({ url: file.url() }));
+    var p2 = Parse.Promise.as(Parse.Cloud.httpRequest({ url: file.url() }));
+    var p3 = Parse.Promise.as(Parse.Cloud.httpRequest({ url: file.url() }));
+    Parse.Promise.when(p1, p2, p3).then((r1, r2, r3) =>
+    {
+       // results: r1, r2, r3
+    });
+
+   // TODO: Check
 }
 
 function test_analytics() {

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -83,29 +83,30 @@ declare module Parse {
 
     interface IPromise<T> {
 
-        then<U>(resolvedCallback: (value: T) => IPromise<U>, rejectedCallback?: (reason: any) => IPromise<U>): IPromise<T>;
-        then<U>(resolvedCallback: (value: T) => U, rejectedCallback?: (reason: any) => IPromise<U>): IPromise<U>;
-        then<U>(resolvedCallback: (value: T) => U, rejectedCallback?: (reason: any) => U): IPromise<U>;
+        then<U>(resolvedCallback: (...value: T[]) => IPromise<U>, rejectedCallback?: (reason: any) => IPromise<U>): IPromise<T>;
+        then<U>(resolvedCallback: (...value: T[]) => U, rejectedCallback?: (reason: any) => IPromise<U>): IPromise<U>;
+        then<U>(resolvedCallback: (...value: T[]) => U, rejectedCallback?: (reason: any) => U): IPromise<U>;
     }
 
-    interface Promise<T> {
+    class Promise<T> {
 
         always(callback: Function): Promise<T>;
-        as(): Promise<T>;
+        static as<T>(value?: any): Promise<T>;
         done(callback: Function): Promise<T>;
-        error(): Promise<T>;
+        static error<T>(): Promise<T>;
         fail(callback: Function): Promise<T>;
-        is(): Promise<T>;
+        static is<T>(promise: Promise<T>): Promise<T>;
         reject(error: any): void;
         resolve(result: any): void;
-        then<U>(resolvedCallback: (value: T) => Promise<U>,
+        then<U>(resolvedCallback: (...value: T[]) => Promise<U>,
                 rejectedCallback?: (reason: any) => Promise<U>): IPromise<T>;
-        then<U>(resolvedCallback: (value: T) => U,
+        then<U>(resolvedCallback: (...value: T[]) => U,
             rejectedCallback?: (reason: any) => IPromise<U>): IPromise<T>;
-        then<U>(resolvedCallback: (value: T) => U,
+        then<U>(resolvedCallback: (...value: T[]) => U,
             rejectedCallback?: (reason: any) => U): IPromise<T>;
 
-        when(promises: Promise<T>[]): Promise<T>;
+        static when<T>(promises: Promise<T>[]): Promise<T>;
+        static when<T>(...promises: Promise<T>[]): Promise<T>;
     }
 
     interface IBaseObject {

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -86,6 +86,12 @@ declare module Parse {
         then<U>(resolvedCallback: (...value: T[]) => IPromise<U>, rejectedCallback?: (reason: any) => IPromise<U>): IPromise<T>;
         then<U>(resolvedCallback: (...value: T[]) => U, rejectedCallback?: (reason: any) => IPromise<U>): IPromise<U>;
         then<U>(resolvedCallback: (...value: T[]) => U, rejectedCallback?: (reason: any) => U): IPromise<U>;
+        then<U>(resolvedCallback: (value: T) => void, rejectedCallback?: (reason: any) => U): IPromise<U>;
+
+        then<U>(resolvedCallback: (...value: T[]) => IPromise<U>, rejectedCallback?: (reason: any) => IPromise<U>): IPromise<T>;
+        then<U>(resolvedCallback: (...value: T[]) => U, rejectedCallback?: (reason: any) => IPromise<U>): IPromise<U>;
+        then<U>(resolvedCallback: (...value: T[]) => U, rejectedCallback?: (reason: any) => U): IPromise<U>;
+        then<U>(resolvedCallback: (...value: T[]) => void, rejectedCallback?: (reason: any) => U): IPromise<U>;
     }
 
     class Promise<T> {
@@ -104,8 +110,14 @@ declare module Parse {
             rejectedCallback?: (reason: any) => IPromise<U>): IPromise<T>;
         then<U>(resolvedCallback: (...value: T[]) => U,
             rejectedCallback?: (reason: any) => U): IPromise<T>;
+		then<U>(resolvedCallback: (value: T) => void, rejectedCallback?: (reason: any) => U): IPromise<T>;
 
-        static when<T>(promises: Promise<T>[]): Promise<T>;
+		then<U>(resolvedCallback: (...value: T[]) => Promise<U>, rejectedCallback?: (reason: any) => Promise<U>): IPromise<T>;
+		then<U>(resolvedCallback: (...value: T[]) => U, rejectedCallback?: (reason: any) => IPromise<U>): IPromise<T>;
+		then<U>(resolvedCallback: (...value: T[]) => U, rejectedCallback?: (reason: any) => U): IPromise<T>;
+		then<U>(resolvedCallback: (...value: T[]) => void, rejectedCallback?: (reason: any) => U): IPromise<T>;
+
+		static when<T>(promises: Promise<T>[]): Promise<T>;
         static when<T>(...promises: Promise<T>[]): Promise<T>;
     }
 


### PR DESCRIPTION
I propose the following changes to parse.com typedefs
It's my first ever contribution to a github project, so i think i need to signal you that I have made changes and request a pull in to the main branch.
But I must admit i clueless to how this github stuff works :)
Punch me if I am doing it wrong...

Interface Promise<T> was missing the static methods: as, error, is and
when
- Changed interface Promise<T> to class promise<T>
- Added static methods of 'as', 'error', 'is' and 'when'
- Removed instance methods 'as', 'error', 'is' and 'when'
- Changed resolvedCallback of 'then' to use ...value: T[] instead of
  value: T (lib intention)
- Changed interface IPromise<T> to use ...value: T[] instead of value: T
  (lib intention)
