### PR TITLE
node.d.ts Support object type for Url.query

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -59,6 +59,10 @@ class Networker extends events.EventEmitter {
     }
 }
 
+////////////////////////////////////////////////////
+/// Url tests : http://nodejs.org/api/url.html
+////////////////////////////////////////////////////
+
 url.format(url.parse('http://www.example.com/xyz'));
 
 // https://google.com/search?q=you're%20a%20lizard%2C%20gary
@@ -68,6 +72,10 @@ url.format({
     pathname: 'search', 
     query: { q: "you're a lizard, gary" }
 });
+
+var helloUrl = url.parse('http://example.com/?hello=world', true)
+assert.equal(helloUrl.query.hello, 'world');
+
 
 // Old and new util.inspect APIs
 util.inspect(["This is nice"], false, 5);

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -658,7 +658,7 @@ declare module "url" {
         host: string;
         pathname: string;
         search: string;
-        query: string;
+        query: any; // string | Object
         slashes: boolean;
         hash?: string;
         path?: string;


### PR DESCRIPTION
In the Url module of Node, if you call `url.parse()` with the parseQueryString option then the `.query` property of the generated object is an object rather than a string. Eg:

``` javascript
url.parse('http://example.com/?hello=world').query == 'hello=world'
url.parse('http://example.com/?hello=world', true).query == { hello: 'world' }
```

Therefore `Url.query` needs to be changed to type `any` to allow both string and object
