### PR TITLE
Updates sinon-chai definition and tests to support loading sinon-chai as a chai plugin.

### DIFF
--- a/sinon-chai/sinon-chai-tests.ts
+++ b/sinon-chai/sinon-chai-tests.ts
@@ -3,12 +3,17 @@
 
 declare var expect: chai.ExpectStatic;
 
+import chai = require('chai');
+import sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);
+
 function test() {
     var spy: Function;
     var anotherSpy: Function;
-    var context;
-    var match;
-
+    var context: any;
+    var match: any;
+    
     expect(spy).to.have.been.called;
     expect(spy).to.have.been.calledOnce;
     expect(spy).to.have.been.calledTwice;

--- a/sinon-chai/sinon-chai.d.ts
+++ b/sinon-chai/sinon-chai.d.ts
@@ -26,3 +26,8 @@ declare module chai {
         always: Expect;
     }
 }
+
+declare module "sinon-chai" {
+    function exports(_chai: typeof chai, utils: any): void;
+    export = exports;
+}


### PR DESCRIPTION
- usage is as follows:
  import sinonChai = require('sinon-chai');
  chai.use(sinonChai);
- Also updates the tests to compile with --noImplicitAny

Technically this is two separate changes: updating the definitions to support `chai.use()` and fixing the tests to play nice with --noImplicitAny.  Let me know if I need to split this into two commits.
