### PR TITLE
Fixed bug in typeahead definition

### DIFF
--- a/typeahead/typeahead-tests.ts
+++ b/typeahead/typeahead-tests.ts
@@ -4,7 +4,6 @@
 //
 // Examples from http://twitter.github.com/typeahead.js/examples
 //
-declare var Hogan: string;
 
 var substringMatcher = function (strs: any) {
     return function findMatches(q: any, cb: any) {
@@ -24,11 +23,11 @@ var substringMatcher = function (strs: any) {
                 // JavaScript object, refer to typeahead docs for more info
                 matches.push({ value: str });
             }
-});
+        });
 
         cb(matches);
-    };
-};
+    }
+}
 
 var states = ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California',
     'Colorado', 'Connecticut', 'Delaware', 'Florida', 'Georgia', 'Hawaii',
@@ -41,18 +40,234 @@ var states = ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California',
     'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'
 ];
 
-$('#the-basics .typeahead').typeahead({
-  hint: true,
-  highlight: true,
-    minLength: 1
-},
-{
-        name: 'states',
-        displayKey: 'value',
-        source: substringMatcher(states)
-});
 
-module valueTest {
+function test_method_names() {
+    $('#the-basics .typeahead').typeahead('destroy');
+    $('#the-basics .typeahead').typeahead('open');
+    $('#the-basics .typeahead').typeahead('close');
+    $('#the-basics .typeahead').typeahead('val');
+    $('#the-basics .typeahead').typeahead('val', 'test value');    
+}
+
+
+function test_options() {
+
+    var dataSets: Twitter.Typeahead.Dataset[] = [];
+    
+    function with_empty_options() {
+        $('#the-basics .typeahead').typeahead({}, dataSets);
+    }
+
+    function with_hint_option() {
+        $('#the-basics .typeahead').typeahead({ hint: true }, dataSets);
+    }
+
+    function with_highlight_option() {
+        $('#the-basics .typeahead').typeahead({ highlight: true }, dataSets);
+    }
+
+    function with_minLength_option() {
+        $('#the-basics .typeahead').typeahead({ minLength: 1 }, dataSets);
+    }
+
+    function with_all_options() {
+        $('#the-basics .typeahead').typeahead({
+                hint: true,
+                highlight: true,
+                minLength: 1
+            },
+            dataSets
+        );
+    }
+}
+
+function test_datasets_array() {
+
+    var options: Twitter.Typeahead.Options = {};
+
+    function with_only_source() {
+        $('#the-basics .typeahead').typeahead(options, [{
+            source: substringMatcher(states)
+        }]);
+    }
+
+    function with_name_option() {
+
+        $('#the-basics .typeahead').typeahead(options, [{
+            name: 'states',
+            source: substringMatcher(states),
+        }]);
+    }
+
+    function with_displayKey_option() {
+        $('#the-basics .typeahead').typeahead(options, [{
+                displayKey: 'value',
+                source: substringMatcher(states)
+            }]
+        );
+    }
+
+    function with_templates_option() {
+        $('#the-basics .typeahead').typeahead(options, [{
+                templates: {},
+                source: substringMatcher(states)
+            }]
+        );
+    }
+
+    function with_all_options() {
+        $('#the-basics .typeahead').typeahead(options, [{
+                name: 'states',
+                displayKey: 'value',
+                templates: {},
+                source: substringMatcher(states)
+            }]
+        );
+    }
+
+    function with_multiple_datasets() {
+        $('#the-basics .typeahead').typeahead(options, [
+             {
+                name: 'states',
+                displayKey: 'value',
+                templates: {},
+                source: substringMatcher(states)
+            },
+            {
+                name: 'states alternative',
+                displayKey: 'value',
+                templates: {},
+                source: substringMatcher(states)
+            }
+        ]);
+    }
+}
+
+
+function test_datasets_objects() {
+
+    var options: Twitter.Typeahead.Options = {};
+
+    function with_only_source() {
+        $('#the-basics .typeahead').typeahead(options, {
+            source: substringMatcher(states)
+        });
+    }
+
+    function with_name_option() {
+
+        $('#the-basics .typeahead').typeahead(options, {
+            name: 'states',
+            source: substringMatcher(states),
+        });
+    }
+
+    function with_displayKey_option() {
+        $('#the-basics .typeahead').typeahead(options,
+            {
+                displayKey: 'value',
+                source: substringMatcher(states)
+            }
+        );
+    }
+
+    function with_templates_option() {
+        $('#the-basics .typeahead').typeahead(options,
+            {
+                templates: {},
+                source: substringMatcher(states)
+            }
+        );
+    }
+
+    function with_all_options() {
+        $('#the-basics .typeahead').typeahead(options,
+            {
+                name: 'states',
+                displayKey: 'value',
+                templates: {},
+                source: substringMatcher(states)
+            }
+        );
+    }
+
+    function with_multiple_objects() {
+        $('#the-basics .typeahead').typeahead(options, 
+            {
+                name: 'states',
+                displayKey: 'value',
+                templates: {},
+                source: substringMatcher(states)
+            },
+            {
+                name: 'states alternative',
+                displayKey: 'value',
+                templates: {},
+                source: substringMatcher(states)
+            }
+        );
+    }
+}
+
+function test_dataset_templates() {
+
+    var options: Twitter.Typeahead.Options = {};
+
+    function with_no_options() {
+        $('#the-basics .typeahead').typeahead(options, {
+            source: substringMatcher(states),
+            templates: {}
+        });
+    }
+
+    function with_empty_option() {
+        $('#the-basics .typeahead').typeahead(options, {
+            source: substringMatcher(states),
+            templates: { empty: 'no results' }
+        });
+    }
+
+    function with_footer_option() {
+        $('#the-basics .typeahead').typeahead(options, {
+            source: substringMatcher(states),
+            templates: { footer: 'custom footer' }
+        });
+    }
+
+    function with_header_option() {
+        $('#the-basics .typeahead').typeahead(options, {
+            source: substringMatcher(states),
+            templates: { header: 'custom header' }
+        });
+    }
+
+    function with_suggestion_option() {
+        $('#the-basics .typeahead').typeahead(options, {
+            source: substringMatcher(states),
+            templates: {               
+                suggestion: function(context) {
+                    return context.name;
+                }
+            }
+        });
+    }
+
+    function with_all_options() {
+        $('#the-basics .typeahead').typeahead(options, {
+            source: substringMatcher(states),
+            templates: {
+                empty: 'no results',        
+                footer: 'custom footer',
+                header: 'custom header',
+                suggestion: function(context) {
+                    return context.name;
+                }
+            }
+        });
+    }
+}
+
+function test_value() {
     var value: string = $('foo').typeahead('val');
     $('foo').typeahead('val', value);
 }

--- a/typeahead/typeahead.d.ts
+++ b/typeahead/typeahead.d.ts
@@ -107,7 +107,7 @@ declare module Twitter.Typeahead {
           */
         source: (query: string, cb: (result: any) => void) => void;
 
-    /**
+        /**
           * The name of the dataset. 
           * This will be appended to tt-dataset- to form the class name of the containing DOM element. 
           * Must only consist of underscores, dashes, letters (a-z), and numbers. 
@@ -159,7 +159,7 @@ declare module Twitter.Typeahead {
          * The associated suggestion object will serve as the context. 
          * Defaults to the value of displayKey wrapped in a p tag i.e. <p>{{value}}</p>.
           */
-        suggestion?: string;
+        suggestion?: (context: any) => string;
 
     }
 
@@ -186,6 +186,7 @@ declare module Twitter.Typeahead {
       minLength?: number;
     }
 }
+
 declare module Bloodhound
 {
   interface BloodhoundOptions<T>


### PR DESCRIPTION
There was a bug in the definition of the `Templates` interface. This stated that the `suggestion` property was a `string`, but this is actually a function. This PR fixes that issue and also adds tests.
