### PR TITLE
Fix incorrect signature of JSONLoader.parse(...)

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -1782,7 +1782,7 @@ declare module THREE {
 
         loadAjaxJSON(context: JSONLoader, url: string, callback: (geometry: Geometry, materials: Material[]) => void , texturePath?: string, callbackProgress?: (progress: Progress) => void ): void;
 
-        parse(json: Object, texturePath?: string): { geometry: Geometry; materials?: Material[] };
+        parse(json: any, texturePath?: string): { geometry: Geometry; materials?: Material[] };
     }
 
     export interface JSonLoaderResultGeometry extends Geometry {

--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -1782,7 +1782,7 @@ declare module THREE {
 
         loadAjaxJSON(context: JSONLoader, url: string, callback: (geometry: Geometry, materials: Material[]) => void , texturePath?: string, callbackProgress?: (progress: Progress) => void ): void;
 
-        parse(json:string, texturePath:string): any;
+        parse(json: Object, texturePath?: string): { geometry: Geometry; materials?: Material[] };
     }
 
     export interface JSonLoaderResultGeometry extends Geometry {


### PR DESCRIPTION
The previous signature was incorrect.
- The first argument is an object, not a JSON string
- The second argument is optional
- ~~The return type is known, not `any`~~

I am using this API at the moment and know that this change is correct for r66 to r68 (the advertised version of these definitions).
