### PR TITLE
Updated browserify.d.ts to allow require without import.

### DIFF
--- a/browserify/browserify-tests.ts
+++ b/browserify/browserify-tests.ts
@@ -1,7 +1,12 @@
+/// <reference path="browserify.d.ts"/>
+
 import browserify = require("browserify");
 import fs = require("fs");
 
-var b = browserify();
+var b: BrowserifyObject = browserify();
 b.add('./browser/main.js');
 b.transform('deamdify');
 b.bundle().pipe(fs.createWriteStream('bundle.js'));
+
+var customBrowsify: Browserify = require("browserify");
+customBrowsify({entries: []});

--- a/browserify/browserify.d.ts
+++ b/browserify/browserify.d.ts
@@ -6,33 +6,36 @@
 /// <reference path="../node/node.d.ts" />
 
 interface BrowserifyObject extends NodeJS.EventEmitter {
-	add(file: string): BrowserifyObject;
-	require(file: string, opts?: {
-		expose: string;
-	}): BrowserifyObject;
-	bundle(opts?: {
-		insertGlobals?: boolean;
-		detectGlobals?: boolean;
-		debug?: boolean;
-		standalone?: string;
-		insertGlobalVars?: any;
-	}, cb?: (err: any, src: any) => void): NodeJS.ReadableStream;
+  add(file:string): BrowserifyObject;
+  require(file:string, opts?:{
+    expose: string;
+  }): BrowserifyObject;
+  bundle(opts?:{
+    insertGlobals?: boolean;
+    detectGlobals?: boolean;
+    debug?: boolean;
+    standalone?: string;
+    insertGlobalVars?: any;
+  }, cb?:(err:any, src:any) => void): NodeJS.ReadableStream;
 
-	external(file: string): BrowserifyObject;
-	ignore(file: string): BrowserifyObject;
-	transform(tr: string): BrowserifyObject;
-	transform(tr: Function): BrowserifyObject;
-	plugin(plugin: string, opts?: any): BrowserifyObject;
-  	plugin(plugin: Function, opts?: any): BrowserifyObject;
+  external(file:string): BrowserifyObject;
+  ignore(file:string): BrowserifyObject;
+  transform(tr:string): BrowserifyObject;
+  transform(tr:Function): BrowserifyObject;
+  plugin(plugin:string, opts?:any): BrowserifyObject;
+  plugin(plugin:Function, opts?:any): BrowserifyObject;
+}
+
+interface Browserify {
+  (): BrowserifyObject;
+  (files:string[]): BrowserifyObject;
+  (opts:{
+    entries?: string[];
+    noParse?: string[];
+  }): BrowserifyObject;
 }
 
 declare module "browserify" {
-	function browserify(): BrowserifyObject;
-	function browserify(files: string[]): BrowserifyObject;
-	function browserify(opts: {
-		entries?: string[];
-		noParse?: string[];
-	}): BrowserifyObject;
-
-	export = browserify;
+  var browserify: Browserify;
+  export = browserify;
 }


### PR DESCRIPTION
I am using this in a gulpfile where import isn't working for me. I want to keep the type information about the Browserify module by assigning the result.

``` typescript
var browserify: BrowserifyModule = require("browserify");
```
