### PR TITLE
switched tester to tsc 1.1.0-1

### DIFF
--- a/_infrastructure/runner.js
+++ b/_infrastructure/runner.js
@@ -1,1 +1,22 @@
+var path = require('path');
+var fs = require('fs');
+
+function readJSON(target) {
+	return JSON.parse(fs.readFileSync(target, 'utf8'));
+}
+
+function getSemFloat(str) {
+	var m = /^[^\d]*(\d+)\.(\d+)/.exec(str);
+	return parseFloat(m[1] + '.' + m[2]);
+}
+
+var repo = readJSON(path.resolve(__dirname, '..', 'package.json'));
+var test = readJSON(path.resolve(__dirname, '..', 'node_modules', 'definition-tester', 'package.json'));
+
+// ultra lame semver major/minor check
+if (getSemFloat(repo.dependencies['definition-tester']) > getSemFloat(test.version)) {
+	console.log('DefinitelyTyped tester needs an update!\n\n   please run \'npm install\'\n');
+	process.exit(1);
+}
+
 require('definition-tester');

--- a/_infrastructure/runner.js
+++ b/_infrastructure/runner.js
@@ -11,10 +11,11 @@ function getSemFloat(str) {
 }
 
 var repo = readJSON(path.resolve(__dirname, '..', 'package.json'));
-var test = readJSON(path.resolve(__dirname, '..', 'node_modules', 'definition-tester', 'package.json'));
+
+var testerPath = path.resolve(__dirname, '..', 'node_modules', 'definition-tester', 'package.json');
 
 // ultra lame semver major/minor check
-if (getSemFloat(repo.dependencies['definition-tester']) > getSemFloat(test.version)) {
+if (!fs.existsSync(testerPath) || getSemFloat(repo.dependencies['definition-tester']) > getSemFloat(readJSON(testerPath).version)) {
 	console.log('DefinitelyTyped tester needs an update!\n\n   please run \'npm install\'\n');
 	process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -20,16 +20,20 @@
     "node": ">= 0.10.0"
   },
   "scripts": {
-    "test": "node ./_infrastructure/runner.js --test-changes",
-    "changes": "node ./_infrastructure/runner.js --test-changes",
-    "lint": "node ./_infrastructure/runner.js --lint-changes",
-    "all": "node ./_infrastructure/runner.js",
-    "dry": "node ./_infrastructure/runner.js --skip-tests --test-changes",
-    "list": "node ./_infrastructure/runner.js --skip-tests --print-files --print-refmap",
+    "test": "node ./_infrastructure/runner.js --changes",
+    "changes": "node ./_infrastructure/runner.js --changes",
+    "lint": "node ./_infrastructure/runner.js --lint",
+    "tscparams": "node ./_infrastructure/runner.js --tscparams --no-tests --no-headers",
+    "all": "node ./_infrastructure/runner.js ",
+    "dry": "node ./_infrastructure/runner.js --dry --changes",
+    "list": "node ./_infrastructure/runner.js --dry --print-files --print-refmap",
+    "last": "node ./_infrastructure/runner.js --dry --print-files --print-refmap --changes",
+    "files": "node ./_infrastructure/runner.js --dry --print-files",
+    "refmap": "node ./_infrastructure/runner.js --dry --print-refmap",
     "help": "node ./_infrastructure/runner.js -h"
   },
   "dependencies": {
-    "definition-tester": "~0.0.4"
+    "definition-tester": "~0.1.4"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
updated definition-tester 
- default to tsc v1.1.0-1
- some fixes (also by @vvakame)

added a version check to runner.js
- very simple local definition-tester semver check/prompt 
- catches outdated dependency (using `npm test` or `npm run <...>`)

for #2932
