### PR TITLE
zstaggerTo supports much more than just any[]

### DIFF
--- a/greensock/greensock.d.ts
+++ b/greensock/greensock.d.ts
@@ -97,9 +97,9 @@ declare class TweenMax extends TweenLite {
     repeatDelay(value:number):any;
     static resumeAll(tweens?:boolean, delayedCalls?:boolean, timelines?:boolean):void;
     static set(target:Object, vars:Object):TweenMax;
-    static staggerFrom(targets:Object[], duration:number, vars:Object, stagger:number, onCompleteAll?:Function, onCompleteAllParams?:any[], onCompleteAllScope?:any):any[];
-    static staggerFromTo(targets:Object[], duration:number, fromVars:Object, toVars:Object, stagger:number, onCompleteAll?:Function, onCompleteAllParams?:any[], onCompleteAllScope?:any):any[];
-    static staggerTo(targets:Object[], duration:number, vars:Object, stagger:number, onCompleteAll?:Function, onCompleteAllParams?:any[], onCompleteAllScope?:any):any[];
+    static staggerFrom(targets:any, duration:number, vars:Object, stagger:number, onCompleteAll?:Function, onCompleteAllParams?:any[], onCompleteAllScope?:any):any[];
+    static staggerFromTo(targets:any, duration:number, fromVars:Object, toVars:Object, stagger:number, onCompleteAll?:Function, onCompleteAllParams?:any[], onCompleteAllScope?:any):any[];
+    static staggerTo(targets:any, duration:number, vars:Object, stagger:number, onCompleteAll?:Function, onCompleteAllParams?:any[], onCompleteAllScope?:any):any[];
     time(value:number, suppressEvents?:boolean):any;
     static to(target:Object, duration:number, vars:Object):TweenMax;
     totalDuration(value:number):any;
@@ -133,9 +133,9 @@ declare class TimelineLite extends SimpleTimeline {
     set(target: Object, vars: Object, position?:any):any;
     seek(position:any, suppressEvents?:boolean):any;
     shiftChildren(amount:number, adjustLabels?:boolean, ignoreBeforeTime?:number):any;
-    staggerFrom(targets:any[], duration:number, vars:Object, stagger?:number, position?:any, onCompleteAll?:Function, onCompleteAllParams?:any[], onCompleteScope?:any):any;
-    staggerFromTo(targets:any[], duration:number, fromVars:Object, toVars:Object, stagger?:number, position?:any, onCompleteAll?:Function, onCompleteAllParams?:any[], onCompleteAllScope?:any):any;
-    staggerTo(targets:any[], duration:number, vars:Object, stagger:number, position?:any, onCompleteAll?:Function, onCompleteAllParams?:any[], onCompleteAllScope?:any):any;
+    staggerFrom(targets:any, duration:number, vars:Object, stagger?:number, position?:any, onCompleteAll?:Function, onCompleteAllParams?:any[], onCompleteScope?:any):any;
+    staggerFromTo(targets:any, duration:number, fromVars:Object, toVars:Object, stagger?:number, position?:any, onCompleteAll?:Function, onCompleteAllParams?:any[], onCompleteAllScope?:any):any;
+    staggerTo(targets:any, duration:number, vars:Object, stagger:number, position?:any, onCompleteAll?:Function, onCompleteAllParams?:any[], onCompleteAllScope?:any):any;
     stop():any;
     to(target:Object, duration:number, vars:Object, position?:any):any;
     usesFrames():Boolean;


### PR DESCRIPTION
Ref documentation found at http://greensock.com/docs/#/HTML5/GSAP/TweenMax/staggerTo/ 

An array of target objects whose properties should be affected, or selector text that gets passed to TweenLite.selector (for selecting DOM elements). For example, if jQuery (or similar) is loaded and you pass ".myClass", it would act as though you passed in an array of DOM elements that had the "myClass" class applied. The same behavior applies if you pass a jQuery object containing multiple elements (like $(".myClass")).
