### PR TITLE
sjcl: Allow loading as an external module

### DIFF
--- a/sjcl/sjcl.d.ts
+++ b/sjcl/sjcl.d.ts
@@ -554,3 +554,7 @@ declare module sjcl {
         }
     }
 }
+
+declare module "sjcl" {
+    export = sjcl;
+}


### PR DESCRIPTION
This allows using the sjcl in the following way:

``` typescript
import sjcl = require('sjcl');
```
