### PR TITLE
Update pickadate.d.ts typing for container option

### DIFF
--- a/pickadate/pickadate.d.ts
+++ b/pickadate/pickadate.d.ts
@@ -141,8 +141,8 @@ declare module Pickadate {
         // Disable dates (elements can be Dates, [YEAR, MONTH, DATE] arrays, or integers of the week)
         disable?: any[];
 
-        // Root container selector
-        container?: string
+        // Root container selector (string) or element (JQuery)
+        container?: any;
 
         // Events
         onStart?: () => void;
@@ -238,8 +238,8 @@ declare module Pickadate {
         // Disable dates (elements can be Dates, [YEAR, MONTH, DATE] arrays, or integers of the week)
         disable?: any[];
 
-        // Root container selector
-        container?: string
+        // Root container selector (string) or element (JQuery)
+        container?: any;
 
         // Events
         onStart?: () => void;


### PR DESCRIPTION
Pickadate.js allows for the container option to be either a selector string
or DOM element. The latter is useful in many situations. See this line in the source:
https://github.com/amsul/pickadate.js/blob/dev/lib/picker.js#L119
