### PR TITLE
Fixes cyclical dependency between dojox.gfx.d.ts and dojox.geo.d.ts

### DIFF
--- a/dojo/dojox.gfx.d.ts
+++ b/dojo/dojox.gfx.d.ts
@@ -5276,7 +5276,7 @@ declare module dojox {
              * @param c an x component of a central point, or a central point             
              * @param d a y component of a central point             
              */
-            scaleAt(a: number, b: number, c: dojox.geo.openlayers.Point, d: number): dojox.gfx.matrix.Matrix2D;
+            scaleAt(a: number, b: number, c: dojox.gfx.Point, d: number): dojox.gfx.matrix.Matrix2D;
             /**
              * forms an x skewing matrix
              * The resulting matrix is used to skew points in the x dimension

--- a/dojo/dojox.gfx.d.ts
+++ b/dojo/dojox.gfx.d.ts
@@ -4,7 +4,6 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="dojo.d.ts" />
-/// <reference path="dojox.geo.d.ts" />
 declare module dojox {
     
     /**


### PR DESCRIPTION
Removed reference to dojox.geo.d.ts from dojox.gfx.d.ts (dojox.gfx has no actual dependency
on dojox.geo)
