### PR TITLE
Update google analytics to include newer universal analytics

### DIFF
--- a/google.analytics/ga-tests.ts
+++ b/google.analytics/ga-tests.ts
@@ -1,25 +1,15 @@
 /// <reference path="ga.d.ts" />
 /// <reference path="../jasmine/jasmine.d.ts" />
 
-describe("tester Google Analytics Tracker _gat object", () => {
-
-    it("can set ga script element", () => {
-        ga = <HTMLScriptElement>document.createElement("script");
+describe('UniversalGoogleAnalytics', () => {
+    it('should be a function', () => {
+        ga('create', 'UA-65432-1');
+        ga('send', 'pageview');
     });
-
-    it("can set aync to true", () => {
-        ga.async = true;        
+    it('should have methods', () => {
+        ga.getAll();
+        ga.getByName('aNamedTracker');
     });
-
-    it("can set src to string url", () => {
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';;
-    });
-
-    it("can set type", () => {
-        ga.type = 'text/javascript';        
-    });
-    
-
 });
 
 describe("tester Google Analytics Tracker _gat object", () => {
@@ -27,7 +17,7 @@ describe("tester Google Analytics Tracker _gat object", () => {
         _gat._createTracker('UA-65432-1');
         _gat._createTracker('UA-65432-2', 't2');
     });
-    
+
     it("can create _getTrackerByName", () => {
         _gat._getTrackerByName();
         _gat._getTrackerByName('t2');
@@ -36,7 +26,7 @@ describe("tester Google Analytics Tracker _gat object", () => {
     it("can create _anonymizeIp", () => {
         _gat._anonymizeIp();
     });
-    
+
 });
 
 describe("tester Google Analytics Code  _gaq object", () => {
@@ -50,12 +40,12 @@ describe("tester Google Analytics Code  _gaq object", () => {
                 tracker._trackPageview();
             }
         );
-    });    
+    });
 });
 
 
 describe("tester Google Analytics Code  Tracker object", () => {
-    it("can create Tracker object and call methods", () => {               
+    it("can create Tracker object and call methods", () => {
         var tracker = _gat._getTrackerByName('UA-65432-1');
         tracker._trackPageview();
         tracker._getName();

--- a/google.analytics/ga-tests.ts
+++ b/google.analytics/ga-tests.ts
@@ -1,14 +1,29 @@
 /// <reference path="ga.d.ts" />
 /// <reference path="../jasmine/jasmine.d.ts" />
 
-describe('UniversalGoogleAnalytics', () => {
-    it('should be a function', () => {
-        ga('create', 'UA-65432-1');
+describe('UniversalAnalytics', () => {
+    it('should exercise all ga APIs', () => {
+        ga('create', 'UA-65432-1', 'auto');
+        ga('create', 'UA-65432-1', {some: 'config'});
+        ga('create', 'UA-65432-1', 'auto', {some: 'config'});
         ga('send', 'pageview');
-    });
-    it('should have methods', () => {
+        ga('send', 'pageview', {some: 'details'});
+        ga.create('UA-65432-1', 'auto');
+        ga.create('UA-65432-1', {some: 'config'});
+        ga.create('UA-65432-1', 'auto', {some: 'config'});
         ga.getAll();
         ga.getByName('aNamedTracker');
+    });
+    it('should excercise Tracker APIs', () => {
+        var tracker: UniversalAnalytics.Tracker = ga('create', 'UA-65432-1', 'auto');
+        var aString: string = tracker.get<string>('aString');
+        var aNumber: number = tracker.get<number>('aNumber');
+        var anObject: {} = tracker.get<{}>('anObject');
+        tracker.send('pageview');
+        tracker.send('pageview', {some: 'details'});
+        tracker.set('aString', aString);
+        tracker.set('aNumber', aNumber);
+        tracker.set('anObject', anObject);
     });
 });
 

--- a/google.analytics/ga-tests.ts
+++ b/google.analytics/ga-tests.ts
@@ -1,6 +1,21 @@
 /// <reference path="ga.d.ts" />
 /// <reference path="../jasmine/jasmine.d.ts" />
 
+describe("tester Google Analytics Tracker _gat object", () => {
+    it("can set ga script element", () => {
+        gaClassic = <HTMLScriptElement>document.createElement("script");
+    });
+    it("can set aync to true", () => {
+        gaClassic.async = true;
+     });
+    it("can set src to string url", () => {
+        gaClassic.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    });
+    it("can set type", () => {
+        gaClassic.type = 'text/javascript';
+    });
+});
+
 describe('UniversalAnalytics', () => {
     it('should exercise all ga APIs', () => {
         ga('create', 'UA-65432-1', 'auto');
@@ -76,6 +91,3 @@ describe("tester Google Analytics Code  Tracker object", () => {
         tracker._trackPageLoadTime();
     });
 });
-
-
-

--- a/google.analytics/ga.d.ts
+++ b/google.analytics/ga.d.ts
@@ -30,14 +30,19 @@ interface GoogleAnalyticsTracker {
     _anonymizeIp(): void;
 }
 
+interface GoogleAnalytics {
+    type: string;
+    src: string;
+    async: boolean;
+}
+
 declare module UniversalAnalytics {
     // https://developers.google.com/analytics/devguides/collection/analyticsjs/method-reference
 
     interface ga {
-        (command: string, trackingId: string, opt_configObject?: {}): UniversalAnalytics.Tracker;
+        (command: string, poly: string, opt_poly?: {}): UniversalAnalytics.Tracker;
         (command: string, trackingId: string, auto: string, opt_configObject?: {}): UniversalAnalytics.Tracker;
         (command: string, hitDetails: {}): void;
-        (command: string, hitType: string, hitDetails?: {}): void;
         create(trackingId: string, opt_configObject?: {}): UniversalAnalytics.Tracker;
         create(trackingId: string, auto: string, opt_configObject?: {}): UniversalAnalytics.Tracker;
         getAll(): UniversalAnalytics.Tracker[];
@@ -54,6 +59,7 @@ declare module UniversalAnalytics {
     }
 }
 
+declare var gaClassic: GoogleAnalytics;
 declare var ga: UniversalAnalytics.ga;
 declare var _gaq: GoogleAnalyticsCode;
 declare var _gat: GoogleAnalyticsTracker;

--- a/google.analytics/ga.d.ts
+++ b/google.analytics/ga.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for Google Analytics (Classic and Universal)
-// Project: https://developers.google.com/analytics/devguides/collection/gajs/
+// Project: https://developers.google.com/analytics/devguides/collection/gajs/, https://developers.google.com/analytics/devguides/collection/analyticsjs/method-reference
 // Definitions by: Ronnie Haakon Hegelund <http://ronniehegelund.blogspot.dk>, Pat Kujawa <http://patkujawa.com>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 

--- a/google.analytics/ga.d.ts
+++ b/google.analytics/ga.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for Google Analytics
+// Type definitions for Google Analytics (Classic and Universal)
 // Project: https://developers.google.com/analytics/devguides/collection/gajs/
-// Definitions by: Ronnie Haakon Hegelund <http://ronniehegelund.blogspot.dk>
+// Definitions by: Ronnie Haakon Hegelund <http://ronniehegelund.blogspot.dk>, Pat Kujawa <http://patkujawa.com>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare class Tracker {
@@ -30,19 +30,30 @@ interface GoogleAnalyticsTracker {
     _anonymizeIp(): void;
 }
 
-interface UniversalGoogleAnalytics {
-    (command: string, trackingId:string, opt_configObject?: {}): UniversalTracker;
-    (command: string, ...rest): void;
-    getAll(): UniversalTracker[];
-    getByName(trackerName: string): UniversalTracker;
+declare module UniversalAnalytics {
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/method-reference
+
+    interface ga {
+        (command: string, trackingId: string, opt_configObject?: {}): UniversalAnalytics.Tracker;
+        (command: string, trackingId: string, auto: string, opt_configObject?: {}): UniversalAnalytics.Tracker;
+        (command: string, hitDetails: {}): void;
+        (command: string, hitType: string, hitDetails?: {}): void;
+        create(trackingId: string, opt_configObject?: {}): UniversalAnalytics.Tracker;
+        create(trackingId: string, auto: string, opt_configObject?: {}): UniversalAnalytics.Tracker;
+        getAll(): UniversalAnalytics.Tracker[];
+        getByName(name: string): UniversalAnalytics.Tracker;
+    }
+
+    interface Tracker {
+        get<T>(fieldName: string): T;
+        send(hitType: string, opt_fieldObject?: {}): void;
+        set(fieldName: string, value: string): void;
+        set(fieldName: string, value: {}): void;
+        set(fieldName: string, value: number): void;
+        set(fieldName: string, value: boolean): void;
+    }
 }
 
-interface UniversalTracker {
-    get(...any): any;
-    send(...any): any;
-    set(...any): any;
-}
-
-declare var ga: UniversalGoogleAnalytics;
+declare var ga: UniversalAnalytics.ga;
 declare var _gaq: GoogleAnalyticsCode;
 declare var _gat: GoogleAnalyticsTracker;

--- a/google.analytics/ga.d.ts
+++ b/google.analytics/ga.d.ts
@@ -30,12 +30,19 @@ interface GoogleAnalyticsTracker {
     _anonymizeIp(): void;
 }
 
-interface GoogleAnalytics {
-    type: string;
-    src: string;
-    async: boolean;
+interface UniversalGoogleAnalytics {
+    (command: string, trackingId:string, opt_configObject?: {}): UniversalTracker;
+    (command: string, ...rest): void;
+    getAll(): UniversalTracker[];
+    getByName(trackerName: string): UniversalTracker;
 }
 
-declare var ga: GoogleAnalytics;
+interface UniversalTracker {
+    get(...any): any;
+    send(...any): any;
+    set(...any): any;
+}
+
+declare var ga: UniversalGoogleAnalytics;
 declare var _gaq: GoogleAnalyticsCode;
 declare var _gat: GoogleAnalyticsTracker;


### PR DESCRIPTION
GA has been updated and has a [new API](https://developers.google.com/analytics/devguides/collection/analyticsjs/method-reference). I added the most important top-level typedefs.
