### PR TITLE
Adding descriptor support for EventSimulator

### DIFF
--- a/react-addons/react-addons.d.ts
+++ b/react-addons/react-addons.d.ts
@@ -131,6 +131,7 @@ declare module React {
 
     export interface EventSimulator {
         (element: Element, eventData?: SyntheticEventData): void;
+        (descriptor: Descriptor<any>, eventData?: SyntheticEventData): void;
     }
 
     export interface Simulate {


### PR DESCRIPTION
It actually takes either a DOM Element or a React Descriptor.
