### PR TITLE
Relax headers function type in http promise callbacks.

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1201,7 +1201,7 @@ declare module ng {
     }
 
     interface IHttpPromiseCallback<T> {
-        (data: T, status: number, headers: (headerName: string) => string, config: IRequestConfig): void;
+        (data: T, status: number, headers: (headerName?: string) => string, config: IRequestConfig): void;
     }
 
     interface IHttpPromiseCallbackArg<T> {


### PR DESCRIPTION
if you pass no arguments, you get the entire headers structure back.
