### PR TITLE
jquery.ContextMenu - Fixed signature for items and inclusion of build

### DIFF
--- a/jquery.contextMenu/jquery.contextMenu.d.ts
+++ b/jquery.contextMenu/jquery.contextMenu.d.ts
@@ -24,8 +24,21 @@ interface JQueryContextMenuOptions {
         show?: () => void;
         hide?: () => void;
     };
+    build?: (trigger: any, e: Event) => any;
     callback?: (key: any, options: any) => any;
-    items: any;
+    items: JQueryContextMenuItems;
+}
+
+interface JQueryContextMenuItems {
+    [index: string]: JQueryContextMenuItemOptions
+}
+
+interface JQueryContextMenuItemOptions {
+    name: string;
+    icon?: string;
+    disabled: boolean;
+    accesskey?: string;
+    items?: JQueryContextMenuItems;
 }
 
 interface JQueryStatic {


### PR DESCRIPTION
Propose the following changes to the definition of jquery.contextMenu:
- items signature to be JQueryContextMenuItems,
- JQueryContextMenuItems to be signed byJQueryContextMenuItemOptions;
- inclusion of the option build (not sure about the way to sign this option).
