### PR TITLE
Add visionmedia/debug, a tiny npm package for debugging

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -67,6 +67,7 @@ All definitions files include a header with the author and editors, so at some p
 * [Crossfilter](https://github.com/square/crossfilter) (by [Schmulik Raskin](https://github.com/schmuli))
 * [crypto-js](https://code.google.com/p/crypto-js/) (by [Gia Bảo @ Sân Đình](https://github.com/giabao)). @see [cryptojs.d.ts repo](https://github.com/giabao/cryptojs.d.ts)
 * [d3.js](http://d3js.org/) (from TypeScript samples)
+* [debug](https://github.com/visionmedia/debug) (by [Seon-Wook Park](https://github.com/swook))
 * [dhtmlxGantt](http://dhtmlx.com/docs/products/dhtmlxGantt) (by [Maksim Kozhukh](http://github.com/mkozhukh))
 * [dhtmlxScheduler](http://dhtmlx.com/docs/products/dhtmlxScheduler) (by [Maksim Kozhukh](http://github.com/mkozhukh))
 * [diff](https://github.com/kpdecker/jsdiff) (by [vvakame](http://github.com/vvakame))

--- a/debug/debug-tests.ts
+++ b/debug/debug-tests.ts
@@ -1,0 +1,20 @@
+/// <reference path="../node/node.d.ts" />
+/// <reference path="debug.d.ts" />
+
+import debug = require("debug");
+
+debug.disable();
+debug.enable("DefinitelyTyped:*");
+
+var log: debug.Debugger = debug("DefinitelyTyped:log");
+
+log("Just text");
+log("Formatted test (%d arg)", 1);
+log("Formatted %s (%d args)", "test", 2);
+
+log("Enabled?: %s", debug.enabled("DefinitelyTyped:log"));
+log("Namespace: %s", log.namespace);
+
+var error: debug.Debugger = debug("DefinitelyTyped:error");
+error.log = console.error.bind(console);
+error("This should be printed to stderr");

--- a/debug/debug.d.ts
+++ b/debug/debug.d.ts
@@ -1,0 +1,30 @@
+// Type definitions for debug
+// Project: https://github.com/visionmedia/debug
+// Definitions by: Seon-Wook Park <https://github.com/swook>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module "debug" {
+
+    function d(namespace: string): d.Debugger;
+
+    module d {
+        export var log: Function;
+
+        function enable(namespaces: string): void;
+        function disable(): void;
+
+        function enabled(namespace: string): boolean;
+
+        export interface Debugger {
+            (formatter: any, ...args: any[]): void;
+
+            enabled:   boolean;
+            log:       Function;
+            namespace: string;
+        }
+    }
+
+    export = d;
+
+}
+


### PR DESCRIPTION
This request provides typedefs for the npm package, debug.

With these definitions, it is possible to use the debug package as shown in the test file, by importing the module via `require`, then calling it to create a `debug.Debugger` instance.
