### PR TITLE
Add "has" in the LanguageChains

### DIFF
--- a/chai/chai.d.ts
+++ b/chai/chai.d.ts
@@ -94,6 +94,7 @@ declare module chai {
         that: Expect;
         and: Expect;
         have: Expect;
+        has: Expect;
         with: Expect;
         at: Expect;
         of: Expect;


### PR DESCRIPTION
"has" is the same as "have" but makes the sentences more _natural_.
Added it in the LanguageChains to make WebStorm recognise it.
