### PR TITLE
Change window.plugins type to interface

### DIFF
--- a/cordova/plugins/Push.d.ts
+++ b/cordova/plugins/Push.d.ts
@@ -7,14 +7,16 @@
 // Licensed under the MIT license.
 
 interface Window {
-    plugins: {
-        /**
-         * This plugin allows to receive push notifications. The Android implementation uses
-         * Google's GCM (Google Cloud Messaging) service,
-         * whereas the iOS version is based on Apple APNS Notifications
-         */
-        pushNotification: PushNotification
-    }
+    plugins: Plugins
+}
+
+interface Plugins {
+    /**
+     * This plugin allows to receive push notifications. The Android implementation uses
+     * Google's GCM (Google Cloud Messaging) service,
+     * whereas the iOS version is based on Apple APNS Notifications
+     */
+    pushNotification: PushNotification
 }
 
 /**


### PR DESCRIPTION
Change the type of window.plugins from an object literal specific to Push.d.ts to an interface called Plugins, which can be modified by other code.
