### PR TITLE
Added definition for Handlebars.Utils.escapeExpression()

### DIFF
--- a/handlebars/handlebars-tests.ts
+++ b/handlebars/handlebars-tests.ts
@@ -78,3 +78,5 @@ Handlebars.registerHelper('list', (items: any, fn: (item: any) => string) => {
 Handlebars.registerHelper('fullName', (person: typeof context.author) => {
     return person.firstName + ' ' + person.lastName;
 });
+
+var escapedExpression = Handlebars.Utils.escapeExpression('<script>alert(\'xss\');</script>');

--- a/handlebars/handlebars.d.ts
+++ b/handlebars/handlebars.d.ts
@@ -27,6 +27,7 @@ interface HandlebarsCommon {
 
     Exception(message: string): void;
     SafeString: typeof hbs.SafeString;
+    Utils: typeof hbs.Utils;
 
     logger: Logger;
     log(level: number, obj: any): void;
@@ -50,6 +51,10 @@ declare module hbs {
     class SafeString {
         constructor(str: string);
         static toString(): string;
+    }
+
+    class Utils {
+        static escapeExpression(str: string): string;
     }
 }
 

--- a/handlebars/handlebars.d.ts
+++ b/handlebars/handlebars.d.ts
@@ -53,8 +53,8 @@ declare module hbs {
         static toString(): string;
     }
 
-    class Utils {
-        static escapeExpression(str: string): string;
+    module Utils {
+        function escapeExpression(str: string): string;
     }
 }
 


### PR DESCRIPTION
It fixes https://github.com/borisyankov/DefinitelyTyped/issues/592
