### PR TITLE
Fix --noImplicitAny error

### DIFF
--- a/knockout.es5/knockout.es5-tests.ts
+++ b/knockout.es5/knockout.es5-tests.ts
@@ -5,7 +5,7 @@ var empty = {},
     observable = ko.observable(123),
     computed = ko.computed(function () { return observable() + 1; }),
     model = { prop: 100 },
-    notifiedValues = [];
+    notifiedValues: any[] = [];
 
 
 // Basic properties

--- a/knockout.es5/knockout.es5.d.ts
+++ b/knockout.es5/knockout.es5.d.ts
@@ -19,7 +19,7 @@ interface KnockoutDefinePropertyOptions {
 }
 
 interface Array<T> {
-	remove(item): T[];
+	remove(item: T): T[];
 	removeAll(items: T[]): T[];
 	removeAll(): T[];
 


### PR DESCRIPTION
Fix --noImplicitAny error
knockout.es5.d.ts(22,9): error TS7006: Parameter 'item' of 'remove' implicitly has an 'any' type.
knockout.es5-tests.ts(8,22): error TS7015: Array Literal implicitly has an 'any' type from widening.
