### PR TITLE
applyBindings: made the viewmodel optional

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -412,7 +412,7 @@ interface KnockoutStatic {
     virtualElements: KnockoutVirtualElements;
     extenders: KnockoutExtenders;
 
-    applyBindings(viewModel: any, rootNode?: any): void;
+    applyBindings(viewModel?: any, rootNode?: any): void;
 	applyBindingsToDescendants(viewModel: any, rootNode: any): void;
 	applyBindingAccessorsToNode(node: Node, bindings: (bindingContext: KnockoutBindingContext, node: Node) => {}, bindingContext: KnockoutBindingContext): void;
 	applyBindingAccessorsToNode(node: Node, bindings: {}, bindingContext: KnockoutBindingContext): void;


### PR DESCRIPTION
In order to use it for binding custom components, you can use appyBindings() without any arguments.
