### PR TITLE
Allows to pass a generic Object to Logger.child() - see https://github.c...

### DIFF
--- a/bunyan/bunyan.d.ts
+++ b/bunyan/bunyan.d.ts
@@ -15,6 +15,7 @@ declare module "bunyan" {
         addStream(stream:Stream):void;
         addSerializers(serializers:Serializers):void;
         child(options:LoggerOptions, simple?:boolean):Logger;
+        child(obj:Object, simple?:boolean):Logger;
         reopenFileStreams():void;
 
         level(value:any /* number | string */):void;


### PR DESCRIPTION
Hi, this is my very first pull request. I hope this is correct. 
See https://github.com/trentm/node-bunyan#logchild for info on log.child() function in bunyan.
In fact I think the function should not accept a LoggerOptions but just a generic object.
Thanks.
Michele
