### PR TITLE
Fix for angular-resource with TS 1.1

### DIFF
--- a/angularjs/angular-resource-tests.ts
+++ b/angularjs/angular-resource-tests.ts
@@ -21,6 +21,9 @@ var resourceClass: IMyResourceClass;
 var resource: IMyResource;
 var resourceArray: ng.resource.IResourceArray<IMyResource>;
 
+resource = resourceClass();
+resource = new resourceClass();
+
 resource = resourceClass.delete();
 resource = resourceClass.delete({ key: 'value' });
 resource = resourceClass.delete({ key: 'value' }, function () { });

--- a/angularjs/angular-resource.d.ts
+++ b/angularjs/angular-resource.d.ts
@@ -59,6 +59,7 @@ declare module ng.resource {
     // Also, static calls always return the IResource (or IResourceArray) retrieved
     // https://github.com/angular/angular.js/blob/v1.2.0/src/ngResource/resource.js#L538-L549
     interface IResourceClass<T> {
+	    (dataOrParams?: any): T;
         new(dataOrParams? : any) : T;
         get(): T;
         get(params: Object): T;


### PR DESCRIPTION
This is a fix for angular-resource for the TypeScript 1.1 compiler.  Works fine for 1.0 also.  TypeScript 1.0 didn't seem to mind "forgetting to call new" - even though this isn't actually required by the library.
