### PR TITLE
Fix .fail<> generic precedence bug and missing generic on .reject()

### DIFF
--- a/q/Q-tests.ts
+++ b/q/Q-tests.ts
@@ -138,3 +138,49 @@ class Repo {
 
 var kitty = new Repo();
 Q.nbind(kitty.find, kitty)({ cute: true }).done((kitties: any[]) => {});
+
+
+/*
+ * Test: Can "rethrow" rejected promises
+ */
+module TestCanRethrowRejectedPromises {
+
+    interface Foo {
+        a: number;
+    }
+
+    function nestedBar(): Q.Promise<Foo> {
+        var deferred = Q.defer<Foo>();
+
+        return deferred.promise;
+    }
+
+    function bar(): Q.Promise<Foo> {
+        return nestedBar()
+            .then((foo:Foo) => {
+                console.log("Lorem ipsum");
+            })
+            .fail((error) => {
+                console.log("Intermediate error handling");
+
+                /*
+                 * Cannot do this, because:
+                 *     error TS2322: Type 'Promise<void>' is not assignable to type 'Promise<Foo>'
+                 */
+                //throw error;
+
+                return Q.reject<Foo>(error);
+            })
+        ;
+    }
+
+    bar()
+        .finally(() => {
+            console.log("Cleanup")
+        })
+        .done()
+    ;
+
+}
+
+

--- a/q/Q.d.ts
+++ b/q/Q.d.ts
@@ -74,8 +74,8 @@ declare module Q {
          */
         spread<U>(onFulfilled: Function, onRejected?: Function): Promise<U>;
 
-        fail<U>(onRejected: (reason: any) => U): Promise<U>;
         fail<U>(onRejected: (reason: any) => IPromise<U>): Promise<U>;
+        fail<U>(onRejected: (reason: any) => U): Promise<U>;
         /**
          * A sugar method, equivalent to promise.then(undefined, onRejected).
          */
@@ -329,7 +329,7 @@ declare module Q {
     /**
      * Returns a promise that is rejected with reason.
      */
-    export function reject(reason?: any): Promise<any>;
+    export function reject<T>(reason?: any): Promise<T>;
 
     export function Promise<T>(resolver: (resolve: (val: IPromise<T>) => void , reject: (reason: any) => void , notify: (progress: any) => void ) => void ): Promise<T>;
     export function Promise<T>(resolver: (resolve: (val: T) => void , reject: (reason: any) => void , notify: (progress: any) => void ) => void ): Promise<T>;


### PR DESCRIPTION
1. `.fail<U>` overloads are in a wrong order
2.  `.reject` is defined without a generic and returns `Q.Promise<any>`
