### PR TITLE
Declare jszip as a module, in addition to the JSZip global

### DIFF
--- a/jszip/jszip.d.ts
+++ b/jszip/jszip.d.ts
@@ -170,3 +170,7 @@ declare var JSZip: {
     prototype: JSZip;
     support: JSZipSupport;
 }
+
+declare module "jszip" {
+    export = JSZip;
+}


### PR DESCRIPTION
I had a require.js (`--module amd`) powered project, and was having trouble getting require.js to play nicely with JSZip as required by a TypeScript file. When JSZip sees that AMD's define global is present, it doesn't export as the global `JSZip`, but the `jszip.d.ts` previously only supported global-style consumption. After some head-banging fun with TypeScript's undocumented `/// <amd-dependency path="lib/jszip" />` feature, and tricksy `jszip.d.ts` shims, I realized the reason why TypeScript didn't want to compile my `import-require` (with a one-two punch of TS2306 + TS2307) was because there was no `declare module ...` bit in jszip.d.ts.

I feel that not declaring the global would be the more proper solution, but to retain the widest compatibility possible, I only added the `declare module "jszip {...}` bit.

**References below:**

How jszip autodetects the AMD/commonjs/`<script>` handler:

```
function(e) {
  if ("object" == typeof exports && "undefined" != typeof module)
    module.exports = e();
  else if ("function" == typeof define && define.amd)
    define([], e);
  else {
    var f;
    "undefined" != typeof window ? f = window : "undefined" != typeof global ? f = global : "undefined" != typeof self && (f = self), f.JSZip = e()
  }
}(...)
```

[AMD style](http://stuk.github.io/jszip/documentation/examples.html#toc_1)

[CommonJS style](http://stuk.github.io/jszip/documentation/examples.html#toc_2)
