### PR TITLE
fix eventemitter2 in browser

### DIFF
--- a/eventemitter2/eventemitter2-tests.ts
+++ b/eventemitter2/eventemitter2-tests.ts
@@ -1,7 +1,19 @@
 ///<reference path="eventemitter2.d.ts"/>
 
-// import eventemitter2 = require("eventemitter2");
-// var EventEmitter2 = eventemitter2.EventEmitter2;
+// Example for CommonJS/AMD
+/*
+import eventemitter2 = require("eventemitter2");
+var EventEmitter2 = eventemitter2.EventEmitter2;
+
+class Child extends eventemitter2.EventEmitter2 {
+}
+*/
+
+// This class definition doesn't work in CommonJS/AMD.
+class Child extends EventEmitter2 {
+}
+
+var server = new EventEmitter2();
 
 function testConfiguration() {
     var foo = new EventEmitter2({
@@ -13,8 +25,6 @@ function testConfiguration() {
     var bar = new EventEmitter2({});
     var bazz = new EventEmitter2();
 }
-
-var server = new EventEmitter2();
 
 function testAddListener() {
     server.addListener('data', function (value1: any, value2: any, value3: any) {

--- a/eventemitter2/eventemitter2.d.ts
+++ b/eventemitter2/eventemitter2.d.ts
@@ -3,34 +3,146 @@
 // Definitions by: ryiwamoto <https://github.com/ryiwamoto/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare module eventemitter2 {
-    interface Configuration {
-        /**
-         * use wildcards
-         */
-        wildcard?: boolean;
+interface EventEmitter2Configuration {
+    /**
+     * use wildcards
+     */
+    wildcard?: boolean;
 
-        /**
-         * the delimiter used to segment namespaces, defaults to `.`.
-         */
-        delimiter?: string;
+    /**
+     * the delimiter used to segment namespaces, defaults to `.`.
+     */
+    delimiter?: string;
 
-        /**
-         * if you want to emit the newListener event set to true.
-         */
-        newListener?: boolean;
+    /**
+     * if you want to emit the newListener event set to true.
+     */
+    newListener?: boolean;
 
-        /**
-         * max listeners that can be assigned to an event, default 10.
-         */
-        maxListeners?: number;
-    }
+    /**
+     * max listeners that can be assigned to an event, default 10.
+     */
+    maxListeners?: number;
+}
 
+declare class EventEmitter2 {
+    /**
+     * @param conf
+     */
+    constructor(conf?: EventEmitter2Configuration);
+
+    /**
+     * Adds a listener to the end of the listeners array for the specified event.
+     * @param event
+     * @param listener
+     */
+    addListener(event: string, listener: Function): EventEmitter2;
+
+    /**
+     * Adds a listener to the end of the listeners array for the specified event.
+     * @param event
+     * @param listener
+     */
+    on(event: string, listener: Function): EventEmitter2;
+
+    /**
+     * Adds a listener that will be fired when any event is emitted.
+     * @param listener
+     */
+    onAny(listener: Function): EventEmitter2;
+
+    /**
+     * Removes the listener that will be fired when any event is emitted.
+     * @param listener
+     */
+    offAny(listener: Function): EventEmitter2;
+
+    /**
+     * Adds a one time listener for the event.
+     * The listener is invoked only the first time the event is fired, after which it is removed.
+     * @param event
+     * @param listener
+     */
+    once(event: string, listener: Function): EventEmitter2;
+
+    /**
+     * Adds a listener that will execute n times for the event before being removed.
+     * The listener is invoked only the first n times the event is fired, after which it is removed.
+     * @param event
+     * @param timesToListen
+     * @param listener
+     */
+    many(event: string, timesToListen: number, listener: Function): EventEmitter2;
+
+    /**
+     * Remove a listener from the listener array for the specified event.
+     * Caution: changes array indices in the listener array behind the listener.
+     * @param event
+     * @param listener
+     */
+    removeListener(event: string, listener: Function): EventEmitter2;
+
+    /**
+     * Remove a listener from the listener array for the specified event.
+     * Caution: changes array indices in the listener array behind the listener.
+     * @param event
+     * @param listener
+     */
+    off(event: string, listener: Function): EventEmitter2;
+
+    /**
+     * Removes all listeners, or those of the specified event.
+     * @param event
+     */
+    removeAllListeners(event?: string): EventEmitter2;
+
+    /**
+     * Removes all listeners, or those of the specified event.
+     * @param events
+     */
+    removeAllListeners(events: string[]): EventEmitter2;
+
+    /**
+     * By default EventEmitters will print a warning if more than 10 listeners are added to it.
+     * This is a useful default which helps finding memory leaks.
+     * Obviously not all Emitters should be limited to 10. This function allows that to be increased.
+     * Set to zero for unlimited.
+     * @param n
+     */
+    setMaxListeners(n: number): void;
+
+    /**
+     * Returns an array of listeners for the specified event. This array can be manipulated, e.g. to remove listeners.
+     * @param event
+     */
+    listeners(event: string): Function[];
+
+    /**
+     * Returns an array of listeners that are listening for any event that is specified.
+     * This array can be manipulated, e.g. to remove listeners.
+     */
+    listenersAny(): Function[];
+
+    /**
+     * Execute each of the listeners that may be listening for the specified event name in order with the list of arguments.
+     * @param event
+     * @param args
+     */
+    emit(event: string, ...args: string[]): boolean;
+
+    /**
+     * Execute each of the listeners that may be listening for the specified event name in order with the list of arguments.
+     * @param event
+     */
+    emit(event: string[]): boolean;
+}
+
+declare module "eventemitter2" {
     export class EventEmitter2 {
         /**
          * @param conf
          */
-        constructor(conf?: Configuration);
+        constructor(conf?: EventEmitter2Configuration);
 
         /**
          * Adds a listener to the end of the listeners array for the specified event.
@@ -139,8 +251,3 @@ declare module eventemitter2 {
     }
 }
 
-declare module "eventemitter2" {
-    export = eventemitter2;
-}
-
-declare var EventEmitter2: typeof eventemitter2.EventEmitter2;


### PR DESCRIPTION
Fix for EventEmitter2(https://github.com/asyncly/EventEmitter2) isuee: https://github.com/borisyankov/DefinitelyTyped/issues/3075

I added tests for class inheritance.
I have no idea to avoid duplicating EventEmitte2 class definition. Please teach me more efficient way.
