### PR TITLE
Revert "Fixed error in test for indexedDB"

### DIFF
--- a/modernizr/modernizr.d.ts
+++ b/modernizr/modernizr.d.ts
@@ -75,7 +75,7 @@ interface ModernizrStatic {
     history: boolean;
     audio: Audioboolean;
     video: Videoboolean;
-    indexedDB: boolean;
+    indexeddb: boolean;
     input: Inputboolean;
     inputtypes: InputTypesboolean;
     localstorage: boolean;


### PR DESCRIPTION
I believe the #2778 PR essentially "fixed" working code and introduced an error, which of course is my bad. 

I had just looked at the code which has the following test:

```
    tests['indexedDB'] = function() {
        return !!testPropsAll("indexedDB", window);
    };    tests['websockets'] = function() {
        return 'WebSocket' in window || 'MozWebSocket' in window;
    };
```

and thus assumed that the name of the test was also the keyname, something which holds true for all the other tests. Unfortunately this assumption did not hold true, as I failed to notice the following code:

```
    for ( var feature in tests ) {
        if ( hasOwnProp(tests, feature) ) {
            featureName  = feature.toLowerCase();
            Modernizr[featureName] = tests[feature]();
```

This essentially exposes all the named tests above as lowercased names. Thus the original was right all the time, and by checking the actual Modernizr object in the console one can see that Modernizr.indexeddb does in fact return `true`, whereas Modernizr.indexedDB returns `undefined`. 

Terribly sorry for introducing this error.
