### PR TITLE
Update TestUtils.findRenderedComponentWithType

### DIFF
--- a/react-addons/react-addons-tests.ts
+++ b/react-addons/react-addons-tests.ts
@@ -113,21 +113,27 @@ React.addons.TestUtils.Simulate.click(node);
 React.addons.TestUtils.Simulate.change(node);
 React.addons.TestUtils.Simulate.keyDown(node, {key: "Enter"});
 
-var GoodbyeMessage = React.createClass({displayName: 'GoodbyeMessage',
+var Greeting = React.createClass({displayName: 'Greeting',
+    getInitialState: function() {
+        return {morning: true};
+    },
     render: function() {
-        return React.DOM.div(null, "Goodbye ", (<React.Component<{name: string}, any>>this).props.name);
+        var me = <React.Component<{name: string}, {morning: boolean}>>this;
+        return React.DOM.div(null, (me.state.morning ? "Hello" : "Goodbye "), me.props.name);
     }
 });
-React.addons.TestUtils.renderIntoDocument(GoodbyeMessage({name: "John"}));
+
+var root = React.addons.TestUtils.renderIntoDocument(Greeting({name: "John"}));
+var greeting = React.addons.TestUtils.findRenderedComponentWithType(root, Greeting);
+greeting.setState({
+    morning: false
+});
 
 var isImportant: boolean;
 var isRead: boolean;
 var cx = React.addons.classSet;
-var classes = cx({
+var classes: string = cx({
     'message': true,
     'message-important': isImportant,
     'message-read': isRead
 });
-
-
-

--- a/react-addons/react-addons.d.ts
+++ b/react-addons/react-addons.d.ts
@@ -93,8 +93,9 @@ declare module React {
         findRenderedDOMComponentWithClass(tree: ReactElement<any, any>, className: string): ReactElement<any, any>;
         scryRenderedDOMComponentsWithTag(tree: ReactElement<any, any>, className: string): ReactElement<any, any>[];
         findRenderedDOMComponentWithTag(tree: ReactElement<any, any>, tagName: string): ReactElement<any, any>;
-        scryFindRenderedComponentsWithTag(tree: ReactElement<any, any>, componentClass: Function): ReactElement<any, any>[];
-        findRenderedComponentWithType(tree: ReactElement<any, any>, componentClass: Function): ReactElement<any, any>;
+        scryRenderedComponentsWithTag(tree: ReactElement<any, any>, componentClass: Function): ReactElement<any, any>[];
+        findRenderedComponentWithType<P>(tree: ReactElement<any, any>, componentClass: ReactComponentFactory<P>): Component<P, any>;
+        scryRenderedComponentsWithType<P>(tree: ReactElement<any, any>, componentClass: ReactComponentFactory<P>): Component<P, any>[];
     }
 
     export interface SyntheticEventData {


### PR DESCRIPTION
This function gets that actual React component rather than
the element. This allows the tester to call functions like setState
on the component as shown in the new test.
