### PR TITLE
Adds mousetrap-global-bind definitions and updates mousetrap to be loadable as an external module

### DIFF
--- a/mousetrap-global-bind/mousetrap-global-bind-tests.ts
+++ b/mousetrap-global-bind/mousetrap-global-bind-tests.ts
@@ -1,0 +1,42 @@
+/// <reference path="mousetrap-global-bind.d.ts"/>
+
+Mousetrap.globalBind('4', function() { console.log('4'); });
+Mousetrap.globalBind("?", function() { console.log('show shortcuts!'); });
+Mousetrap.globalBind('esc', function() { console.log('escape'); }, 'keyup');
+
+// combinations
+Mousetrap.globalBind('command+shift+K', function() { console.log('command shift k'); });
+
+// map multiple combinations to the same callback
+Mousetrap.globalBind(['command+k', 'ctrl+k'], function() {
+    console.log('command k or control k');
+
+    // return false to prevent default browser behavior
+    // and stop event from bubbling
+    return false;
+});
+
+// gmail style sequences
+Mousetrap.globalBind('g i', function() { console.log('go to inbox'); });
+Mousetrap.globalBind('* a', function() { console.log('select all'); });
+
+// konami code!
+Mousetrap.globalBind('up up down down left right left right b a enter', function() {
+    console.log('konami code');
+});
+
+Mousetrap.globalBind(['ctrl+s', 'meta+s'], (e, combo) => {
+    if (e.preventDefault) {
+        e.preventDefault();
+    } else {
+        // internet explorer
+        e.returnValue = false;
+    }
+});
+
+Mousetrap.unbind('?');
+
+Mousetrap.trigger('esc');
+Mousetrap.trigger('esc', 'keyup');
+
+Mousetrap.reset();

--- a/mousetrap-global-bind/mousetrap-global-bind.d.ts
+++ b/mousetrap-global-bind/mousetrap-global-bind.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for Mousetrap 1.4.6's global-bind extension
+// Project: http://craig.is/killing/mice#extensions.global
+// Definitions by: Andrew Bradley <https://github.com/cspotcode>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../mousetrap/mousetrap.d.ts" />
+
+interface MousetrapStatic {
+    globalBind(keys: string, callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
+    globalBind(keyArray: string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
+}

--- a/mousetrap/mousetrap-tests.ts
+++ b/mousetrap/mousetrap-tests.ts
@@ -41,3 +41,11 @@ Mousetrap.trigger('esc');
 Mousetrap.trigger('esc', 'keyup');
 
 Mousetrap.reset();
+
+// Test that Mousetrap can be loaded as an external module.
+// Assume that if the externally-loaded module can be assigned to a variable with the type of global Mousetrap,
+// then everything is working correctly.
+
+import importedMousetrap = require('mousetrap');
+var mousetrapModuleReference: typeof Mousetrap = importedMousetrap;
+

--- a/mousetrap/mousetrap.d.ts
+++ b/mousetrap/mousetrap.d.ts
@@ -19,3 +19,7 @@ interface MousetrapStatic {
 }
 
 declare var Mousetrap: MousetrapStatic;
+
+declare module "mousetrap" {
+    export = Mousetrap;
+}


### PR DESCRIPTION
This PR has two changes:
- First, I added type definitions for Mousetrap's global-bind plugin.
- Second, I extended Mousetrap's type definition to allow Mousetrap to be loaded as an external module: "mousetrap"

In both cases I've added the required tests.

If you'd like me to split these into two PRs, I can do that.
