### PR TITLE
Declare variable so import works

### DIFF
--- a/tv4/tv4.d.ts
+++ b/tv4/tv4.d.ts
@@ -43,5 +43,6 @@ interface TV4 {
 	errorCodes:TV4ErrorCodes;
 }
 declare module "tv4" {
-export = TV4;
+	var tv4: TV4
+	export = tv4;
 }


### PR DESCRIPTION
When declaring a module, it's necessary to declare a variable then
export it, else the import keyword won't work properly when using
modules.
