### PR TITLE
React.render() return value incorrect

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -18,7 +18,7 @@ declare module React {
 
     export function createElement(type: string, props: SvgAttributes, ...children: any[]): ReactSVGElement;
 
-    export function render<P>(component: ReactComponentElement<P>, container: Element, callback?: () => void): ReactComponentElement<P>;
+    export function render<P>(component: ReactComponentElement<P>, container: Element, callback?: () => void): Component<P, void>;
 
     export function render(component: ReactHTMLElement, container: Element, callback?: () => void): ReactHTMLElement;
 


### PR DESCRIPTION
React.render does not return an element but a component. It's the `this` from the render callback:

> Instances of a React Component are created internally in React when rendering. These instances are reused in subsequent renders, and can be accessed in your component methods as this. The only way to get a handle to a React Component instance outside of React is by storing the return value of React.render. Inside other Components, you may use refs to achieve the same result.

http://facebook.github.io/react/docs/component-api.html

This particular pull request is probably not perfect (e.g. I don't know what to pass as the type parameter for state so I just set it to `void`). It does scratch my particular itch, though; calling `.setProps(..)` on the return value of `React.render(...)` is now possible.

Sorry if I misunderstood. By no means a react expert. Nor typescript, for that matter.

Cheers

(oh and sorry for the newline at the end I used github's web interface for this PR didn't know it would add that)
