### PR TITLE
Fix event functions

### DIFF
--- a/zepto/zepto.d.ts
+++ b/zepto/zepto.d.ts
@@ -1316,12 +1316,12 @@ interface ZeptoCollection {
 	* @param fn
 	* @return
 	**/
-	off(type: string, selector: string, fn: (e: Event) => boolean): ZeptoCollection;
+	off(type: string, selector: string, fn: (e: Event) => any): ZeptoCollection;
 
 	/**
 	* @see ZeptoCollection.off
 	**/
-	off(type: string, fn: (e: Event) => boolean): ZeptoCollection;
+	off(type: string, fn: (e: Event) => any): ZeptoCollection;
 
 	/**
 	* @see ZeptoCollection.off
@@ -1347,12 +1347,12 @@ interface ZeptoCollection {
 	* @param fn
 	* @return
 	**/
-	on(type: string, selector: string, fn: (e: Event) => boolean): ZeptoCollection;
+	on(type: string, selector: string, fn: (e: Event) => any): ZeptoCollection;
 
 	/**
 	* @see ZeptoCollection.on
 	**/
-	on(type: string, fn: (e: Event) => boolean): ZeptoCollection;
+	on(type: string, fn: (e: Event) => any): ZeptoCollection;
 	// todo: v0.9 will introduce string literals
 	//on(type: 'ajaxStart', fn: ZeptoAjaxStartEvent): ZeptoCollection;
 	//on(type: 'ajaxBeforeSend', fn: ZeptoAjaxBeforeSendEvent): ZeptoCollection;
@@ -1406,7 +1406,7 @@ interface ZeptoCollection {
 	* @param fn
 	* @return
 	**/
-	unbind(type: string, fn: (e: Event) => boolean): ZeptoCollection;
+	unbind(type: string, fn: (e: Event) => any): ZeptoCollection;
 
 	/**
 	* Detach event handler added with delegate.
@@ -1416,7 +1416,7 @@ interface ZeptoCollection {
 	* @param fn
 	* @return
 	**/
-	undelegate(selector: string, type: string, fn: (e: Event) => boolean): ZeptoCollection;
+	undelegate(selector: string, type: string, fn: (e: Event) => any): ZeptoCollection;
 
     focusin(): ZeptoCollection;
     focusin(fn: (e: Event) => any): ZeptoCollection;


### PR DESCRIPTION
jQuery like event functions is defined in jquery.d.ts as follows:

``` js
on(events: string, handler: (eventObject: JQueryEventObject, ...args: any[]) => any): JQuery;
```

https://github.com/borisyankov/DefinitelyTyped/blob/master/jquery/jquery.d.ts

And they are used in zepto official tests as follows:

``` js
this.el.on('click', function(){ numArgs = arguments.length })
```

https://github.com/madrobby/zepto/blob/master/test/event.html

Therefore, I think that this definitions is better.
