### PR TITLE
Fix async.d.ts each* signatures

### DIFF
--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -3,12 +3,14 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-interface AsyncMultipleResultsCallback<T> { (err: Error, results: T[]): any; }
-interface AsyncSingleResultCallback<T> { (err: Error, result: T): void; }
-interface AsyncTimesCallback<T> { (n: number, callback: AsyncMultipleResultsCallback<T>): void; }
+interface ErrorCallback { (err?: Error): void; }
+interface AsyncResultsCallback<T> { (err: Error, results: T[]): void; }
+interface AsyncResultCallback<T> { (err: Error, result: T): void; }
+interface AsyncTimesCallback<T> { (n: number, callback: AsyncResultsCallback<T>): void; }
 
-interface AsyncIterator<T, R> { (item: T, callback: AsyncSingleResultCallback<R>): void; }
-interface AsyncMemoIterator<T, R> { (memo: R, item: T, callback: AsyncSingleResultCallback<R>): void; }
+interface AsyncIterator<T> { (item: T, callback: ErrorCallback): void; }
+interface AsyncResultIterator<T, R> { (item: T, callback: AsyncResultCallback<R>): void; }
+interface AsyncMemoIterator<T, R> { (memo: R, item: T, callback: AsyncResultCallback<R>): void; }
 
 interface AsyncWorker<T> { (task: T, callback: Function): void; }
 
@@ -17,10 +19,10 @@ interface AsyncQueue<T> {
     concurrency: number;
     started: boolean;
     paused: boolean;
-    push(task: T, callback?: AsyncMultipleResultsCallback<T>): void;
-    push(task: T[], callback?: AsyncMultipleResultsCallback<T>): void;
-    unshift(task: T, callback?: AsyncMultipleResultsCallback<T>): void;
-    unshift(task: T[], callback?: AsyncMultipleResultsCallback<T>): void;
+    push(task: T, callback?: AsyncResultsCallback<T>): void;
+    push(task: T[], callback?: AsyncResultsCallback<T>): void;
+    unshift(task: T, callback?: AsyncResultsCallback<T>): void;
+    unshift(task: T[], callback?: AsyncResultsCallback<T>): void;
     saturated: () => any;
     empty: () => any;
     drain: () => any;
@@ -36,8 +38,8 @@ interface AsyncPriorityQueue<T> {
     concurrency: number;
     started: boolean;
     paused: boolean;
-    push(task: T, priority: number, callback?: AsyncMultipleResultsCallback<T>): void;
-    push(task: T[], priority: number, callback?: AsyncMultipleResultsCallback<T>): void;
+    push(task: T, priority: number, callback?: AsyncResultsCallback<T>): void;
+    push(task: T[], priority: number, callback?: AsyncResultsCallback<T>): void;
     saturated: () => any;
     empty: () => any;
     drain: () => any;
@@ -51,47 +53,48 @@ interface AsyncPriorityQueue<T> {
 interface Async {
 
     // Collections
-    each<T,R>(arr: T[], iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): void;
-    eachSeries<T, R>(arr: T[], iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): void;
-    eachLimit<T, R>(arr: T[], limit: number, iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): void;
-    map<T, R>(arr: T[], iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): any;
-    mapSeries<T, R>(arr: T[], iterator: AsyncIterator<T, R>, callback: AsyncMultipleResultsCallback<R>): any;
-    filter<T>(arr: T[], iterator: AsyncIterator<T, boolean>, callback: AsyncMultipleResultsCallback<T>): any;
-    select<T, R>(arr: T[], iterator: AsyncIterator<T, boolean>, callback: AsyncMultipleResultsCallback<T>): any;
-    filterSeries<T, R>(arr: T[], iterator: AsyncIterator<T, boolean>, callback: AsyncMultipleResultsCallback<T>): any;
-    selectSeries<T, R>(arr: T[], iterator: AsyncIterator<T, boolean>, callback: AsyncMultipleResultsCallback<T>): any;
-    reject<T>(arr: T[], iterator: AsyncIterator<T, boolean>, callback: AsyncMultipleResultsCallback<T>): any;
-    rejectSeries<T>(arr: T[], iterator: AsyncIterator<T, boolean>, callback: AsyncMultipleResultsCallback<T>): any;
-    reduce<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncSingleResultCallback<R>): any;
-    inject<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncSingleResultCallback<R>): any;
-    foldl<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncSingleResultCallback<R>): any;
-    reduceRight<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncSingleResultCallback<R>): any;
-    foldr<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncSingleResultCallback<R>): any;
-    detect<T>(arr: T[], iterator: AsyncIterator<T, boolean>, callback: AsyncMultipleResultsCallback<T>): any;
-    detectSeries<T>(arr: T[], iterator: AsyncIterator<T, boolean>, callback: AsyncMultipleResultsCallback<T>): any;
-    sortBy<T, V>(arr: T[], iterator: AsyncIterator<T, V>, callback: AsyncMultipleResultsCallback<T>): any;
-    some<T>(arr: T[], iterator: AsyncIterator<T, boolean>, callback: AsyncMultipleResultsCallback<T>): any;
-    any<T>(arr: T[], iterator: AsyncIterator<T, boolean>, callback: AsyncMultipleResultsCallback<T>): any;
-    every<T>(arr: T[], iterator: AsyncIterator<T, boolean>, callback: (result: boolean) => any): any;
-    all<T>(arr: T[], iterator: AsyncIterator<T, boolean>, callback: (result: boolean) => any): any;
-    concat<T, R>(arr: T[], iterator: AsyncIterator<T, R[]>, callback: AsyncMultipleResultsCallback<R>): any;
-    concatSeries<T, R>(arr: T[], iterator: AsyncIterator<T, R[]>, callback: AsyncMultipleResultsCallback<R>): any;
+    each<T>(arr: T[], iterator: AsyncIterator<T>, callback: ErrorCallback): void;
+    eachSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: ErrorCallback): void;
+    eachLimit<T>(arr: T[], limit: number, iterator: AsyncIterator<T>, callback: ErrorCallback): void;
+    map<T, R>(arr: T[], iterator: AsyncResultIterator<T, R>, callback: AsyncResultsCallback<R>): any;
+    mapSeries<T, R>(arr: T[], iterator: AsyncResultIterator<T, R>, callback: AsyncResultsCallback<R>): any;
+    mapLimit<T, R>(arr: T[], limit: number, iterator: AsyncResultIterator<T, R>, callback: AsyncResultsCallback<R>): any;
+    filter<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (results: T[]) => any): any;
+    select<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (results: T[]) => any): any;
+    filterSeries<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (results: T[]) => any): any;
+    selectSeries<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (results: T[]) => any): any;
+    reject<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (results: T[]) => any): any;
+    rejectSeries<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (results: T[]) => any): any;
+    reduce<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncResultCallback<R>): any;
+    inject<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncResultCallback<R>): any;
+    foldl<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncResultCallback<R>): any;
+    reduceRight<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncResultCallback<R>): any;
+    foldr<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncResultCallback<R>): any;
+    detect<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: AsyncResultsCallback<T>): any;
+    detectSeries<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: AsyncResultsCallback<T>): any;
+    sortBy<T, V>(arr: T[], iterator: AsyncResultIterator<T, V>, callback: AsyncResultsCallback<T>): any;
+    some<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: AsyncResultsCallback<T>): any;
+    any<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: AsyncResultsCallback<T>): any;
+    every<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (result: boolean) => any): any;
+    all<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (result: boolean) => any): any;
+    concat<T, R>(arr: T[], iterator: AsyncResultIterator<T, R[]>, callback: AsyncResultsCallback<R>): any;
+    concatSeries<T, R>(arr: T[], iterator: AsyncResultIterator<T, R[]>, callback: AsyncResultsCallback<R>): any;
 
     // Control Flow
-    series<T>(tasks: T[], callback?: AsyncMultipleResultsCallback<T>): void;
-    series<T>(tasks: T, callback?: AsyncMultipleResultsCallback<T>): void;
-    parallel<T>(tasks: T[], callback?: AsyncMultipleResultsCallback<T>): void;
-    parallel<T>(tasks: T, callback?: AsyncMultipleResultsCallback<T>): void;
-    parallelLimit<T>(tasks: T[], limit: number, callback?: AsyncMultipleResultsCallback<T>): void;
-    parallelLimit<T>(tasks: T, limit: number, callback?: AsyncMultipleResultsCallback<T>): void;
+    series<T>(tasks: T[], callback?: AsyncResultsCallback<T>): void;
+    series<T>(tasks: T, callback?: AsyncResultsCallback<T>): void;
+    parallel<T>(tasks: T[], callback?: AsyncResultsCallback<T>): void;
+    parallel<T>(tasks: T, callback?: AsyncResultsCallback<T>): void;
+    parallelLimit<T>(tasks: T[], limit: number, callback?: AsyncResultsCallback<T>): void;
+    parallelLimit<T>(tasks: T, limit: number, callback?: AsyncResultsCallback<T>): void;
     whilst(test: Function, fn: Function, callback: Function): void;
     until(test: Function, fn: Function, callback: Function): void;
-    waterfall<T>(tasks: T[], callback?: AsyncMultipleResultsCallback<T>): void;
-    waterfall<T>(tasks: T, callback?: AsyncMultipleResultsCallback<T>): void;
+    waterfall<T>(tasks: T[], callback?: AsyncResultsCallback<T>): void;
+    waterfall<T>(tasks: T, callback?: AsyncResultsCallback<T>): void;
     queue<T>(worker: AsyncWorker<T>, concurrency: number): AsyncQueue<T>;
     priorityQueue<T>(worker: AsyncWorker<T>, concurrency: number): AsyncPriorityQueue<T>;
-    // auto(tasks: any[], callback?: AsyncMultipleResultsCallback<T>): void;
-    auto(tasks: any, callback?: AsyncMultipleResultsCallback<any>): void;
+    // auto(tasks: any[], callback?: AsyncResultsCallback<T>): void;
+    auto(tasks: any, callback?: AsyncResultsCallback<any>): void;
     iterator(tasks: Function[]): Function;
     apply(fn: Function, ...arguments: any[]): void;
     nextTick<T>(callback: Function): void;


### PR DESCRIPTION
Sub-tasks:
1. Add generic ErrorCallback type
2. Rename AsyncIterator -> AsyncResultIterator
3. Add AsyncIterator as resultless iterator type
4. Change each, eachSeries, and eachLimit to use AsyncIterator, since the iterator callback returns nothing but an optional error (I tested this and no, they do not behave like map/mapSeries/mapLimit, even if you call them like that, which is what Ruby's Array does, e.g., `results = [1, 2, 3].each { |x| return x * 2 }`)
5. Rename AsyncMultipleResultsCallback -> AsyncResultsCallback
6. Rename AsyncSingleResultCallback -> AsyncResultCallback

5 and 6 are not bugfixes, as is 4, but they save space (and caolan's own async documentation doesn't suggest one wording over the other).
