### PR TITLE
Added KnockoutObservableArray.Push([]) support in addition to open-ended function arguments

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -23,6 +23,7 @@ interface KnockoutObservableArrayFunctions<T> {
     splice(start: number, deleteCount: number, ...items: T[]): T[];
     pop(): T;
     push(...items: T[]): void;
+    push(items: T[]): void;
     shift(): T;
     unshift(...items: T[]): number;
     reverse(): T[];

--- a/knockout/tests/knockout-tests.ts
+++ b/knockout/tests/knockout-tests.ts
@@ -120,6 +120,7 @@ function test_observableArrays() {
 
     myObservableArray.indexOf('Blah');
     myObservableArray.push('Some new value');
+    myObservableArray.push('Some new value', 'another value');
     myObservableArray.pop();
     myObservableArray.unshift('Some new value');
     myObservableArray.shift();
@@ -136,6 +137,10 @@ function test_observableArrays() {
     myObservableArray.destroyAll(['Chad', 132, undefined]);
     myObservableArray.destroyAll();
 
+    var myTypedObservableArray = ko.observableArray<string>();
+    myTypedObservableArray.push(['Some new value', 'another value']);
+    myTypedObservableArray.push('Some new value', 'another value');
+    
     ko.utils.arrayForEach(myObservableArray(), function (item) { });
 }
 


### PR DESCRIPTION
You can now pass in a plain array in to KnockoutObservableArray.push. The existing type definition only supported open-ended function arguements like this:
`myObservableArray('foo', 'bar')`
This change allow you to pass in an array like this:
`myObservableArray.push(['foo', 'bar'])`
