### PR TITLE
Google maps HeatmapLayerOptions definition changes.

### DIFF
--- a/googlemaps/google.maps.d.ts
+++ b/googlemaps/google.maps.d.ts
@@ -1574,13 +1574,13 @@ declare module google.maps {
         }
 
         export interface HeatmapLayerOptions {
-            data: LatLng[];
-            dissipating: boolean;
-            gradient: string[];
-            map: Map;
-            maxIntensity: number;
-            opacity: number;
-            radius: number;
+            data: any;
+            dissipating?: boolean;
+            gradient?: string[];
+            map?: Map;
+            maxIntensity?: number;
+            opacity?: number;
+            radius?: number;
         }
 
         export interface WeightedLocation {


### PR DESCRIPTION
The data property can be either an MVCArray or LatLng[]. All other properties are optional.
