### PR TITLE
TrackballControls should extend EventDispatcher (threejs)

### DIFF
--- a/threejs/three-trackballcontrols.d.ts
+++ b/threejs/three-trackballcontrols.d.ts
@@ -6,7 +6,7 @@
 /// <reference path="./three.d.ts" />
 
 declare module THREE {
-    class TrackballControls {
+    class TrackballControls extends EventDispatcher {
         constructor(object:Camera, domElement?:HTMLElement);
 
         object:Camera;


### PR DESCRIPTION
Please see
https://github.com/mrdoob/three.js/blob/master/examples/js/controls/TrackballControls.js#L611

The prototype of THREE.TrackballControls is THREE.EventDispatcher.prototype.
