### PR TITLE
[node] Adding fs.(Read|Write)Stream.close().

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -91,6 +91,7 @@ function stream_readable_pipe_test() {
     var z = zlib.createGzip();
     var w = fs.createWriteStream('file.txt.gz');
     r.pipe(z).pipe(w);
+    r.close();
 }
 
 ////////////////////////////////////////////////////

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -721,8 +721,8 @@ declare module "net" {
         setKeepAlive(enable?: boolean, initialDelay?: number): void;
         address(): { port: number; family: string; address: string; };
         unref(): void;
-		ref(): void;
-		
+        ref(): void;
+
         remoteAddress: string;
         remotePort: number;
         bytesRead: number;
@@ -770,13 +770,13 @@ declare module "dgram" {
         port: number;
         size: number;
     }
-    
+
     interface AddressInfo {
-        address: string; 
-        family: string; 
-        port: number; 
+        address: string;
+        family: string;
+        port: number;
     }
-    
+
     export function createSocket(type: string, callback?: (msg: Buffer, rinfo: RemoteInfo) => void): Socket;
 
     interface Socket extends events.EventEmitter {
@@ -823,8 +823,12 @@ declare module "fs" {
         close(): void;
     }
 
-    export interface ReadStream extends stream.Readable {}
-    export interface WriteStream extends stream.Writable {}
+    export interface ReadStream extends stream.Readable {
+        close(): void;
+    }
+    export interface WriteStream extends stream.Writable {
+        close(): void;
+    }
 
     export function rename(oldPath: string, newPath: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
     export function renameSync(oldPath: string, newPath: string): void;


### PR DESCRIPTION
It's undocumented, but it is present in the source code and programs rely on it.

Link to source: https://github.com/joyent/node/blob/master/lib/fs.js#L1710

I have also removed some extraneous whitespace, and fixed a tabbing issue.
