### PR TITLE
useAnimation made optional in Callout

### DIFF
--- a/sharepoint/SharePoint.d.ts
+++ b/sharepoint/SharePoint.d.ts
@@ -861,9 +861,9 @@ declare class Callout {
     /** Re-renders the actions menu. Call after the actions menu is changed. */
     refreshActions(): void;
     /** Display the callout. Animation can be used only for IE9+ */
-    open(useAnimation: boolean);
+    open(useAnimation?: boolean);
     /** Hide the callout. Animation can be used only for IE9+ */
-    close(useAnimation: boolean);
+    close(useAnimation?: boolean);
     /** Display if hidden, hide if shown. */
     toggle(): void;
     /** Do not call this directly. Instead, use CalloutManager.remove */


### PR DESCRIPTION
useAnimation should be optional in Callout close and open. I couldn't find any official documentation on this, but SharePoint defaults to false if it is not set:

this.close = function(useAnimation) {
   useAnimation = m$.isBoolean(useAnimation) ? useAnimation : false;

Examples online also shows that this argument should be optional:
http://blog.alexboev.com/2012/08/custom-callouts-in-sharepoint-2013_21.html
