### PR TITLE
Underscorejs pick takes strings or arrays of strings (or any combination of the two)

### DIFF
--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -1177,7 +1177,7 @@ interface UnderscoreStatic {
 	**/
 	pick(
 		object: any,
-		...keys: string[]): any;
+		...keys: any[]): any;
 
 	/**
 	* Return a copy of the object, filtered to omit the blacklisted keys (or array of keys).


### PR DESCRIPTION
The documentation for underscorejs says that _.pick can also take an array of strings.

After looking at the source, I've discovered that underscore will flatten arrays anywhere in the arguments.
