### PR TITLE
React: couple of improvements

### DIFF
--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -104,4 +104,4 @@ var Timer = React.createClass({displayName: 'Timer',
     }
 });
 
-React.render(Timer(null), mountNode);
+React.render(Timer(), mountNode);

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -72,13 +72,23 @@ React.createClass(PropTypesSpecification);
 
 var mountNode: Element;
 
-var HelloMessage = React.createClass({displayName: 'HelloMessage',
+interface HelloMessageProps {
+    name: string;
+}
+
+var HelloMessage = React.createClass<HelloMessageProps, any>({displayName: 'HelloMessage',
     render: function() {
-        return React.DOM.div(null, "Hello ", (<React.Component<{name: string}, any>>this).props.name);
+        return React.DOM.div(null, "Hello ", (<React.Component<HelloMessageProps, any>>this).props.name);
     }
 });
 
-React.render(HelloMessage({name: "John"}), mountNode);
+// This code - calling a component directly - is deprecated in v0.12
+// See http://fb.me/react-legacyfactory
+React.render(HelloMessage({ name: "John" }), mountNode);
+
+// Create a factory instead
+var HelloMessageFactory = React.createFactory(HelloMessage)
+React.render(HelloMessageFactory({ name: "John" }), mountNode)
 
 var Timer = React.createClass({displayName: 'Timer',
     getInitialState: function() {

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module "react" {
-export = React;
+    export = React;
 }
 
 declare module React {
@@ -50,11 +50,11 @@ declare module React {
 
 
     export interface ReactComponentFactory<P> {
-        (properties: P, ...children: any[]): ReactComponentElement<P>;
+        (properties?: P, ...children: any[]): ReactComponentElement<P>;
     }
 
     export interface ReactElementFactory<P> {
-        (properties: P, ...children: any[]): ReactDOMElement<P>;
+        (properties?: P, ...children: any[]): ReactDOMElement<P>;
     }
 
     export interface DomElement extends ReactElementFactory<DomAttributes> {

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -117,6 +117,11 @@ declare module React {
 
     export interface DomReferencer {
         getDOMNode(): Element;
+        /**
+        * Use this overload to cast the returned element to a more specific type.
+        * Eg: var name = this.refs['name'].getDOMNode<HTMLInputElement>().value
+        */
+        getDOMNode<TElement extends Element>(): TElement;
     }
 
     export interface Component<P, S> extends DomReferencer {


### PR DESCRIPTION
Couple of improvements for Reactjs
1. Enabled calling a component factory with no arguments, eg `MyComponent()` (first argument was required in the defs, so you had to do `MyComponent(null)` if you didn't want to pass anything in)
2. Added a convenience overload to `getDOMNode()`, with generic parameter of an element type, to cast the returned html element to a more specific type of `Element`, eg `HTMLInputElement`, `HTMLAnchorElement` etc.
   Eg `this.refs['name'].getDOMNode<HTMLInputElement>().value`

Also an update in the tests for v0.12
