### PR TITLE
Bugfix in minimatch.d.ts

### DIFF
--- a/minimatch/minimatch-tests.ts
+++ b/minimatch/minimatch-tests.ts
@@ -13,3 +13,7 @@ var f = ["test.ts"];
 mm.match(f, pattern, options);
 
 mm.filter('foo')('bar');
+
+var s: string = "hello";
+var b: boolean = mm(s, pattern, options);
+var b: boolean = mm(s, pattern);

--- a/minimatch/minimatch.d.ts
+++ b/minimatch/minimatch.d.ts
@@ -1,11 +1,11 @@
-// Type definitions for Minimatch
+// Type definitions for Minimatch 1.0.0
 // Project: https://github.com/isaacs/minimatch
 // Definitions by: vvakame <https://github.com/vvakame/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module "minimatch" {
 
-	function M(target:string, pattern:string, options?:M.IOptions):void;
+	function M(target:string, pattern:string, options?:M.IOptions): boolean;
 
 	module M {
 		function match(filenames:string[], pattern:string, options?:IOptions):string[];


### PR DESCRIPTION
From README.md:  the exported function returns a boolean not a void.

var minimatch = require("minimatch")
minimatch("bar.foo", "*.foo") // true!
