### PR TITLE
Proper ui support for marionette views

### DIFF
--- a/marionette/marionette.d.ts
+++ b/marionette/marionette.d.ts
@@ -213,7 +213,7 @@ declare module Marionette {
 
         modelEvents: any;
         collectionEvents: any;
-        ui: any;
+        ui(): any;
 
         getTemplate(): any;
         mixinTemplateHelpers(target?: any): any;
@@ -232,7 +232,7 @@ declare module Marionette {
 
         constructor(options?: any);
 
-        ui: any;
+        ui(): any;
 
         serializeData(): any;
         render(): ItemView<TModel>;


### PR DESCRIPTION
I changed the property ui to be a function to be able to use it in the same way as events. Otherwise ui cannot be used.
