### PR TITLE
Request: allow method chaining with .on()

### DIFF
--- a/request/request-tests.ts
+++ b/request/request-tests.ts
@@ -197,3 +197,10 @@ r.post(str);
 r(options);
 r.get(options);
 r.post(options);
+
+request
+.get('http://example.com/example.png')
+.on('response', function(response) {
+	// check response
+})
+.pipe(request.put('http://another.com/another.png'));

--- a/request/request-tests.ts
+++ b/request/request-tests.ts
@@ -200,7 +200,7 @@ r.post(options);
 
 request
 .get('http://example.com/example.png')
-.on('response', function(response) {
+.on('response', function(response: any) {
 	// check response
 })
 .pipe(request.put('http://another.com/another.png'));

--- a/request/request.d.ts
+++ b/request/request.d.ts
@@ -110,6 +110,8 @@ declare module 'request' {
 			oauth(oauth: OAuthOptions): Request;
 			jar(jar: CookieJar): Request;
 
+			on(event: string, listener: Function): Request;
+
 			write(buffer: Buffer, cb?: Function): boolean;
 			write(str: string, cb?: Function): boolean;
 			write(str: string, encoding: string, cb?: Function): boolean;


### PR DESCRIPTION
Request needs to return correct type from inherited methods like .on().
