### PR TITLE
changed onpan function signature as it is called by x and y co-ordinates 

### DIFF
--- a/svg-pan-zoom/svg-pan-zoom.d.ts
+++ b/svg-pan-zoom/svg-pan-zoom.d.ts
@@ -18,7 +18,7 @@ declare module SvgPanZoom {
         beforeZoom?: (scale:number) => void;
         onZoom?: (scale:number) => void;
         beforePan?: (point:IPoint) => void;
-        onPan?: (point:IPoint) => void;
+        onPan?: (x:number, y:number) => void;
         refreshRate?: any; // in hz
     }
 
@@ -55,7 +55,7 @@ declare module SvgPanZoom {
 
         setBeforePan(fn: (point:IPoint)=> void): void;
 
-        setOnPan(fn: (point:IPoint)=> void): void;
+        setOnPan(fn: (x:number, y:number)=> void): void;
 
         enableZoom(): void;
 


### PR DESCRIPTION
Currently onPan function is called by IPoint interface with x and y property, but in original svg-pan-zoom library it is called by two seperate point as argument, so need to change it
