### PR TITLE
Remove require declaration from phantomjs typings

### DIFF
--- a/phantomjs/phantomjs.d.ts
+++ b/phantomjs/phantomjs.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Jed Hunsaker <https://github.com/jedhunsaker>, Mike Keesey <https://github.com/keesey>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare function require(module: string): any;
-
 declare var phantom: Phantom;
 
 interface Phantom {
@@ -45,7 +43,7 @@ interface System {
 }
 
 interface WebPage {
-	
+
 	// Properties
 	canGoBack: boolean;
 	canGoForward: boolean;
@@ -205,13 +203,13 @@ interface WebPageSettings {
 }
 
 interface FileSystem {
-	
+
 	// Properties
 	separator: string;
 	workingDirectory: string;
-	
+
 	// Functions
-	
+
 	// Query Functions
 	list(path: string): string[];
 	absolute(path: string): string;

--- a/phantomjs/phantomjs.d.ts
+++ b/phantomjs/phantomjs.d.ts
@@ -43,7 +43,7 @@ interface System {
 }
 
 interface WebPage {
-
+	
 	// Properties
 	canGoBack: boolean;
 	canGoForward: boolean;
@@ -203,13 +203,13 @@ interface WebPageSettings {
 }
 
 interface FileSystem {
-
+	
 	// Properties
 	separator: string;
 	workingDirectory: string;
-
+	
 	// Functions
-
+	
 	// Query Functions
 	list(path: string): string[];
 	absolute(path: string): string;


### PR DESCRIPTION
This declaration collides with the corresponding declaration in the node/node.d.ts typings:
`typings/node/node.d.ts(30,13): error TS2300: Duplicate identifier 'require'.`
 I am not sure why the phantomjs typings declare this function themselves, but removing it seems to solve the problem.
