### PR TITLE
Removed (very) obsolete toNot* wasNot* matchers

### DIFF
--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -223,11 +223,8 @@ declare module jasmine {
         message(): any;
 
         toBe(expected: any): boolean;
-        toNotBe(expected: any): boolean;
         toEqual(expected: any): boolean;
-        toNotEqual(expected: any): boolean;
         toMatch(expected: any): boolean;
-        toNotMatch(expected: any): boolean;
         toBeDefined(): boolean;
         toBeUndefined(): boolean;
         toBeNull(): boolean;
@@ -235,10 +232,8 @@ declare module jasmine {
         toBeTruthy(): boolean;
         toBeFalsy(): boolean;
         toHaveBeenCalled(): boolean;
-        wasNotCalled(): boolean;
         toHaveBeenCalledWith(...params: any[]): boolean;
         toContain(expected: any): boolean;
-        toNotContain(expected: any): boolean;
         toBeLessThan(expected: any): boolean;
         toBeGreaterThan(expected: any): boolean;
         toBeCloseTo(expected: any, precision: any): boolean;

--- a/jasmine/legacy/jasmine-1.3.d.ts
+++ b/jasmine/legacy/jasmine-1.3.d.ts
@@ -215,11 +215,8 @@ declare module jasmine {
         message(): any;
 
         toBe(expected: any): boolean;
-        toNotBe(expected: any): boolean;
         toEqual(expected: any): boolean;
-        toNotEqual(expected: any): boolean;
         toMatch(expected: any): boolean;
-        toNotMatch(expected: any): boolean;
         toBeDefined(): boolean;
         toBeUndefined(): boolean;
         toBeNull(): boolean;
@@ -227,10 +224,8 @@ declare module jasmine {
         toBeTruthy(): boolean;
         toBeFalsy(): boolean;
         toHaveBeenCalled(): boolean;
-        wasNotCalled(): boolean;
         toHaveBeenCalledWith(...params: any[]): boolean;
         toContain(expected: any): boolean;
-        toNotContain(expected: any): boolean;
         toBeLessThan(expected: any): boolean;
         toBeGreaterThan(expected: any): boolean;
         toBeCloseTo(expected: any, precision: any): boolean;


### PR DESCRIPTION
Re issue #3149
Creating pull request as requested.
