### PR TITLE
Fix the params type in angular-ui-router

### DIFF
--- a/angular-ui/angular-ui-router-tests.ts
+++ b/angular-ui/angular-ui-router-tests.ts
@@ -17,7 +17,7 @@ myApp.config((
   var concat: ng.ui.IUrlMatcher = matcher.concat('/test');
   var str: string = matcher.format({ id:'bob', q:'yes' });
   var arr: string[] = matcher.parameters();
-  
+
   $urlRouterProvider
       .when('/test', '/list')
       .when('/test', '/list')
@@ -34,7 +34,11 @@ myApp.config((
   $stateProvider
     .state('state1', {
       url: "/state1",
-      templateUrl: "partials/state1.html"
+      templateUrl: "partials/state1.html",
+      params: {
+        param1: "defaultValue",
+        param2: undefined
+      }
     })
     .state('state1.list', {
       url: "/list",
@@ -135,7 +139,7 @@ myApp.service("urlLocatorTest", UrlLocatorTestService);
 
 module UiViewScrollProviderTests {
     var app = angular.module("uiViewScrollProviderTests", ["ui.router"]);
-    
+
     app.config(['$uiViewScrollProvider', function($uiViewScrollProvider: ng.ui.IUiViewScrollProvider) {
         // This prevents unwanted scrolling to the active nested state view.
         // Use this when you have nested states, but you don't want the browser to scroll down the page

--- a/angular-ui/angular-ui-router.d.ts
+++ b/angular-ui/angular-ui-router.d.ts
@@ -17,7 +17,7 @@ declare module ng.ui {
         controllerProvider?: any;
         resolve?: {};
         url?: string;
-        params?: any[];
+        params?: any;
         views?: {};
         abstract?: boolean;
         onEnter?: any;
@@ -108,10 +108,10 @@ declare module ng.ui {
     	 */
         sync(): void;
     }
-    
+
     interface IUiViewScrollProvider {
         /*
-         * Reverts back to using the core $anchorScroll service for scrolling 
+         * Reverts back to using the core $anchorScroll service for scrolling
          * based on the url anchor.
          */
         useAnchorScroll(): void;


### PR DESCRIPTION
The params type was updated in angular-ui.

See the API documentation here:
http://angular-ui.github.io/ui-router/site/#/api/ui.router.state.$stateProvider

It changed from an array to an object. I don't see a better way to express the type until TypeScript gets union types.

I also added a test for it.
