### PR TITLE
Added optional allowMerge parameter to non-static MetadataStore.importMetadata

### DIFF
--- a/breeze/breeze.d.ts
+++ b/breeze/breeze.d.ts
@@ -654,7 +654,7 @@ declare module breeze {
         getEntityTypes(): IStructuralType[];
         hasMetadataFor(serviceName: string): boolean;
         static importMetadata(exportedString: string): MetadataStore;
-        importMetadata(exportedString: string): MetadataStore;
+        importMetadata(exportedString: string, allowMerge?: boolean): MetadataStore;
         isEmpty(): boolean;
         registerEntityTypeCtor(entityTypeName: string, entityCtor: Function, initializationFn?: (entity: Entity) =>void ): void;
         trackUnmappedType(entityCtor: Function, interceptor?: Function): void;


### PR DESCRIPTION
Added optional "allowMerge?:boolean" to non-static importMetadata overload in class MetadataStore

see: http://www.breezejs.com/sites/all/apidocs/classes/MetadataStore.html#method_importMetadata
