### PR TITLE
easeljs: add Stage to Ticker.addEventListener

### DIFF
--- a/easeljs/easeljs-tests.ts
+++ b/easeljs/easeljs-tests.ts
@@ -66,3 +66,9 @@ function colorMatrixTest() {
 
     shape.cache(-50, -50, 100, 100);
 }
+
+function test_canvas_tick() {
+    var canvas = <HTMLCanvasElement>document.getElementById('canvas');
+    var stage = new createjs.Stage(canvas);
+    var stage = createjs.Ticker.addEventListener("tick", stage);
+}

--- a/easeljs/easeljs.d.ts
+++ b/easeljs/easeljs.d.ts
@@ -728,6 +728,7 @@ declare module createjs {
         static setPaused(value: boolean): void;
 
         // EventDispatcher mixins
+        static addEventListener(type: string, listener: Stage, useCapture?: boolean): Stage;
         static addEventListener(type: string, listener: (eventObj: Object) => boolean, useCapture?: boolean): Function;
         static addEventListener(type: string, listener: (eventObj: Object) => void, useCapture?: boolean): Function;
         static addEventListener(type: string, listener: { handleEvent: (eventObj: Object) => boolean; }, useCapture?: boolean): Object;


### PR DESCRIPTION
Stage is supported as an eventListener for convenience.  For example:

```
createjs.Ticker.addEventListener("tick", stage);
```

See http://www.createjs.com/Docs/EaselJS/classes/Ticker.html
