### PR TITLE
Knockout's component.register is missing an empty config case

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -564,6 +564,7 @@ interface KnockoutComponents {
     register(componentName: string, config: KnockoutComponentRegisterFnViewModel): void;
     register(componentName: string, config: KnockoutComponentRegisterStringTemplateFnViewModel): void;
     register(componentName: string, config: KnockoutComponentRegisterAMD): void;
+    register(componentName: string, config: {}): void;
 
 	isRegistered(componentName: string): boolean;
 	unregister(componentName: string): void;

--- a/knockout/tests/knockout-tests.ts
+++ b/knockout/tests/knockout-tests.ts
@@ -645,6 +645,7 @@ function test_Components() {
         // object template for element and inline function (commonly used in examples)
         ko.components.register("name", { template: { require: "module" }, viewModel: { instance: null } });
 
-        //
+        // Empty config for registering custom elements that are handled by name convention
+		ko.components.register('name', { /* No config needed */ });
     }
 }


### PR DESCRIPTION
Added case for registering a custom component with an empty config for custom elements, where loading is handled by name convention
