### PR TITLE
Fix three.js Vector3 typing

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -3674,7 +3674,7 @@ declare module THREE {
         /**
          * Adds v to this vector.
          */
-        add(a: Object): Vector3;
+        add(a: Vector): Vector3;
         addScalar(s: number): Vector3;
 
         /**


### PR DESCRIPTION
The `add` method expects an argument of type `Vector`, this was `Object` in the declaration of `Vector3`.
