### PR TITLE
Add AMD module export for NProgress

### DIFF
--- a/nprogress/NProgress.d.ts
+++ b/nprogress/NProgress.d.ts
@@ -110,3 +110,7 @@ interface NProgressConfigureOptions {
 }
 
 declare var NProgress: NProgressStatic;
+
+declare module "nprogress" {
+    export = NProgress;
+}


### PR DESCRIPTION
The NProgress module didn't export an AMD module yet. It does now.
