### PR TITLE
Changed interface Templates to support Handlebars templates

### DIFF
--- a/typeahead/typeahead-tests.ts
+++ b/typeahead/typeahead-tests.ts
@@ -227,6 +227,17 @@ function test_dataset_templates() {
         });
     }
 
+    function with_empty_option_as_a_function() {
+        $('#the-basics .typeahead').typeahead(options, {
+            source: substringMatcher(states),
+            templates: {
+                empty: function(context: any) {
+                    return context.name;
+                }
+            }
+        });
+    }
+
     function with_footer_option() {
         $('#the-basics .typeahead').typeahead(options, {
             source: substringMatcher(states),
@@ -234,10 +245,32 @@ function test_dataset_templates() {
         });
     }
 
+    function with_footer_option_as_a_function() {
+        $('#the-basics .typeahead').typeahead(options, {
+            source: substringMatcher(states),
+            templates: {
+                footer: function(context: any) {
+                    return context.name;
+                }
+            }
+        });
+    }
+
     function with_header_option() {
         $('#the-basics .typeahead').typeahead(options, {
             source: substringMatcher(states),
             templates: { header: 'custom header' }
+        });
+    }
+
+    function with_header_option_as_a_function() {
+        $('#the-basics .typeahead').typeahead(options, {
+            source: substringMatcher(states),
+            templates: {
+                header: function(context: any) {
+                    return context.name;
+                }
+            }
         });
     }
 

--- a/typeahead/typeahead.d.ts
+++ b/typeahead/typeahead.d.ts
@@ -137,21 +137,21 @@ declare module Twitter.Typeahead {
          * Can be either a HTML string or a precompiled template.
          * If it's a precompiled template, the passed in context will contain query
           */
-        empty?: string;
+        empty?: any;
 
         /**
          * Rendered at the bottom of the dataset.
          * Can be either a HTML string or a precompiled template.
          * If it's a precompiled template, the passed in context will contain query and isEmpty.
           */
-        footer?: string;
+        footer?: any;
 
         /**
          * Rendered at the top of the dataset.
          * Can be either a HTML string or a precompiled template.
          * If it's a precompiled template, the passed in context will contain query and isEmpty.
           */
-        header?: string;
+        header?: any;
 
         /**
          * Used to render a single suggestion.


### PR DESCRIPTION
Changed interface Templates to support Handlebars templates as header, footer and empty. For now the type has to be any, because Union types are not implemented yet.
