### PR TITLE
Fix the params type in EventEmitter2.emit

### DIFF
--- a/eventemitter2/eventemitter2.d.ts
+++ b/eventemitter2/eventemitter2.d.ts
@@ -128,7 +128,7 @@ declare class EventEmitter2 {
      * @param event
      * @param args
      */
-    emit(event: string, ...args: string[]): boolean;
+    emit(event: string, ...args: any[]): boolean;
 
     /**
      * Execute each of the listeners that may be listening for the specified event name in order with the list of arguments.
@@ -241,7 +241,7 @@ declare module "eventemitter2" {
          * @param event
          * @param args
          */
-        emit(event: string, ...args: string[]): boolean;
+        emit(event: string, ...args: any[]): boolean;
 
         /**
          * Execute each of the listeners that may be listening for the specified event name in order with the list of arguments.


### PR DESCRIPTION
The params type was updated in EventEmitter2.emit.

See the API documentation here:
https://github.com/asyncly/EventEmitter2#emitteremitevent-arg1-arg2-
