### PR TITLE
Specify structure $.fn.serializeArray() return val

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -629,6 +629,14 @@ interface JQueryCoordinates {
     top: number;
 }
 
+/**
+ * Elements in the array returned by serializeArray()
+ */
+interface JQuerySerializeArrayElement {
+    name: string;
+    value: string;
+}
+
 interface JQueryAnimationOptions { 
     /**
      * A string or number determining how long the animation will run.
@@ -1321,7 +1329,7 @@ interface JQuery {
     /**
      * Encode a set of form elements as an array of names and values.
      */
-    serializeArray(): Object[];
+    serializeArray(): JQuerySerializeArrayElement[];
 
     /**
      * Adds the specified class(es) to each of the set of matched elements.


### PR DESCRIPTION
`$.fn.serializeArray` returns an array of `{ name: string; value: string; }` elements. This patch declares that type explicitly, instead of `Object[]`.

See http://api.jquery.com/serializearray/
