### PR TITLE
Made any parameter explicit and added tests

### DIFF
--- a/knockout.mapping/knockout.mapping-tests.ts
+++ b/knockout.mapping/knockout.mapping-tests.ts
@@ -1,0 +1,67 @@
+/// <reference path="knockout.mapping.d.ts" />
+/// <reference path="../knockout/knockout.d.ts" />
+
+var inputJSON = '{ name: "foo" }';
+var inputData = { name: 'foo' };
+var inputModel = { name: 'bar' };
+var inputParent = { name: 'parent' };
+var options = {};
+
+var createOptions = {
+    data: inputData,
+    parent: parent
+}
+
+var updateOptions = {
+    data: inputData,
+    parent: parent,
+    observable: ko.observable(7)
+}
+
+var targetOptions = {};
+var inputOptions = {};
+
+var mappingOptions = {
+    ignore: ['age'],
+    include: ['name'],
+    copy: ['height'],
+    mappedProperties: ['age', 'name'],
+    deferEvaluation: false,
+    create: function (options: KnockoutMappingCreateOptions) { },
+    update: function (options: KnockoutMappingUpdateOptions) { },
+    key: function (data: any) { return data; }
+}
+
+
+// Utility functions
+mapping.isMapped(inputModel);
+mapping.defaultOptions();
+mapping.resetDefaultOptions();
+mapping.getType(inputModel);
+
+// fromJS function
+mapping.fromJS(inputData);
+mapping.fromJS(inputData, targetOptions);
+mapping.fromJS(inputData, inputOptions, inputModel);
+
+// fromJSON function
+mapping.fromJSON(inputJSON);
+mapping.fromJSON(inputJSON, targetOptions);
+mapping.fromJSON(inputJSON, inputOptions, inputModel);
+
+// toJS function
+mapping.toJS(inputModel);
+mapping.toJS(inputModel, mappingOptions);
+
+// toJSON function
+mapping.toJSON(inputModel);
+mapping.toJSON(inputModel, mappingOptions);
+
+// visitModel function
+mapping.visitModel(inputModel, function (x: any) { return x; }, {});
+mapping.visitModel(inputModel, function (x: any) { return x; }, { visitedObjects: null });
+mapping.visitModel(inputModel, function (x: any) { return x; }, { parentName: 'parent' });
+mapping.visitModel(inputModel, function (x: any) { return x; }, { ignore: ['age'] });
+mapping.visitModel(inputModel, function (x: any) { return x; }, { copy: ['height'] });
+mapping.visitModel(inputModel, function (x: any) { return x; }, { include: ['name'] });
+mapping.visitModel(inputModel, function (x: any) { return x; }, { visitedObjects: null, parentName: 'parent', ignore: ['age'], copy: ['height'], include: ['name'] });

--- a/knockout.mapping/knockout.mapping.d.ts
+++ b/knockout.mapping/knockout.mapping.d.ts
@@ -40,7 +40,7 @@ interface KnockoutMapping {
     defaultOptions(): KnockoutMappingOptions;
     resetDefaultOptions(): void;
     getType(x: any): any;
-    visitModel(rootObject: any, callback: Function, options?: { visitedObjects?; parentName?; ignore?; copy?; include?; }): any;
+    visitModel(rootObject: any, callback: Function, options?: { visitedObjects?: any; parentName?: string; ignore?: string[]; copy?: string[]; include?: string[]; }): any;
 }
 
 interface KnockoutStatic {


### PR DESCRIPTION
The knockout.mapping library typings file had a problem where the parameters for the `visitModel` function did not have a type at all. This caused compilation with the implicit any parameter to fail. This PR fixes this and also adds unit tests in the process.
