### PR TITLE
Q.Promise: Remove reference to jQuery

### DIFF
--- a/q/Q-tests.ts
+++ b/q/Q-tests.ts
@@ -94,6 +94,7 @@ Q.fbind((dateString?: string) => new Date(dateString), "11/11/1991")().then(d =>
 
 Q.when(8, num => num + "!");
 Q.when(Q(8), num => num + "!").then(str => str.split(','));
+var voidPromise: Q.Promise<void> = Q.when();
 
 declare function saveToDisk(): Q.Promise<any>;
 declare function saveToCloud(): Q.Promise<any>;

--- a/q/Q.d.ts
+++ b/q/Q.d.ts
@@ -3,18 +3,11 @@
 // Definitions by: Barrie Nemetchek <https://github.com/bnemetchek>, Andrew Gaspar <https://github.com/AndrewGaspar/>, John Reilly <https://github.com/johnnyreilly>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped  
 
-/// <reference path="../jquery/jquery.d.ts"/>
-
 /**
  * If value is a Q promise, returns the promise.
  * If value is a promise from another library it is coerced into a Q promise (where possible).
  */
 declare function Q<T>(promise: Q.IPromise<T>): Q.Promise<T>;
-/**
- * If value is a Q promise, returns the promise.
- * If value is a promise from another library it is coerced into a Q promise (where possible).
- */
-declare function Q<T>(promise: JQueryPromise<T>): Q.Promise<T>;
 /**
  * If value is not a promise, returns a promise that is fulfilled with value.
  */

--- a/q/Q.d.ts
+++ b/q/Q.d.ts
@@ -188,6 +188,9 @@ declare module Q {
         reason?: any;
     }
 
+    // If no value provided, returned promise will be of void type
+    export function when(): Promise<void>;
+
     // if no fulfill, reject, or progress provided, returned promise will be of same type
     export function when<T>(value: IPromise<T>): Promise<T>;
     export function when<T>(value: T): Promise<T>;


### PR DESCRIPTION
Since the definition file for Q contains a reference to a JQueryPromise, I need to have the definition file for jQuery or I get an error when compiling. That overload seems superfluous anyway, since JQueryPromise<T> conforms to IPromise<T>, and there's already a method that takes an IPromise. This pull request would remove the coupling between jQuery and Q.

This pull request also contains my pull request #3214 for easier merging, but I wanted to discuss this change separately. 
