### PR TITLE
easeljs: fix decompose return type

### DIFF
--- a/easeljs/easeljs-tests.ts
+++ b/easeljs/easeljs-tests.ts
@@ -77,5 +77,12 @@ function matrixDecompose() {
     var matrix = new createjs.Matrix2D();
     var shape = new createjs.Shape();
     var transform = matrix.decompose(shape);
-    var transform2 = matrix.decompose();
+    var transformData = matrix.decompose();
+    shape.x = transformData.x;
+    shape.y = transformData.y;
+    shape.scaleX = transformData.scaleX;
+    shape.scaleY = transformData.scaleY;
+    shape.skewX = transformData.skewX;
+    shape.skewY = transformData.skewY;
+    shape.rotation = transformData.rotation;
 }

--- a/easeljs/easeljs.d.ts
+++ b/easeljs/easeljs.d.ts
@@ -383,7 +383,7 @@ declare module createjs {
         appendTransform(x: number, y: number, scaleX: number, scaleY: number, rotation: number, skewX: number, skewY: number, regX?: number, regY?: number): Matrix2D;
         clone(): Matrix2D;
         copy(matrix: Matrix2D): Matrix2D;
-        decompose(): Matrix2D;
+        decompose(): {x: number; y: number; scaleX: number; scaleY: number; rotation: number; skewX: number; skewY: number};
         decompose(target: Object): Matrix2D;
         identity(): Matrix2D;
         initialize(a?: number, b?: number, c?: number, d?: number, tx?: number, ty?: number): Matrix2D;


### PR DESCRIPTION
I got the return type wrong.

With no args, Matrix2D decompose returns a new object with similar
properties to a DisplayObject.

http://www.createjs.com/Docs/EaselJS/classes/Matrix2D.html#method_decompose
