### PR TITLE
Fixed the callback function parameter type in https.request and https.get

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -528,8 +528,8 @@ declare module "https" {
     };
     export interface Server extends tls.Server { }
     export function createServer(options: ServerOptions, requestListener?: Function): Server;
-    export function request(options: RequestOptions, callback?: (res: events.EventEmitter) =>void ): http.ClientRequest;
-    export function get(options: RequestOptions, callback?: (res: events.EventEmitter) =>void ): http.ClientRequest;
+    export function request(options: RequestOptions, callback?: (res: http.ClientResponse) =>void ): http.ClientRequest;
+    export function get(options: RequestOptions, callback?: (res: http.ClientResponse) =>void ): http.ClientRequest;
     export var globalAgent: Agent;
 }
 


### PR DESCRIPTION
events.EventEmitter cannot be a response object in callback of https.request and https.get . It should be http.ClientResponse object which is derived from events.EventEmitter and stream.Readable.  
