### PR TITLE
Update react.d.ts

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -8,7 +8,7 @@ declare module "react" {
 }
 
 declare module React {
-    export function createClass<P, S>(specification: Specification<P, S>): ReactComponentFactory<P>;
+    export function createClass<P, S>(specification: Specification<P, S>): ReactElementFactory<P>;
 
     export function createFactory<P>(clazz: ReactComponentFactory<P>): ReactComponentFactory<P>;
 


### PR DESCRIPTION
createClass should return ReactElementFactory instead of ReactComponentFactory I guess

i.e..:
var ReactClass = React.createClass(...)
&lt;ReactClass /&gt;   // fine

var ReactFactory = React.createFactory(...)
&lt;ReactFactory&gt;  // gives error
