### PR TITLE
Fixed the 'os' modules tmpdir function declaration.

### DIFF
--- a/node/node-0.11.d.ts
+++ b/node/node-0.11.d.ts
@@ -465,7 +465,7 @@ declare module "zlib" {
 }
 
 declare module "os" {
-    export function tmpDir(): string;
+    export function tmpdir(): string;
     export function hostname(): string;
     export function type(): string;
     export function platform(): string;
@@ -767,13 +767,13 @@ declare module "dgram" {
         port: number;
         size: number;
     }
-    
+
     interface AddressInfo {
-        address: string; 
-        family: string; 
-        port: number; 
+        address: string;
+        family: string;
+        port: number;
     }
-    
+
     export function createSocket(type: string, callback?: (msg: Buffer, rinfo: RemoteInfo) => void): Socket;
 
     interface Socket extends events.EventEmitter {

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -465,7 +465,7 @@ declare module "zlib" {
 }
 
 declare module "os" {
-    export function tmpDir(): string;
+    export function tmpdir(): string;
     export function hostname(): string;
     export function type(): string;
     export function platform(): string;


### PR DESCRIPTION
Fixed an faulty declaration for the function name. It was called tmpDir() when the function actually is tmpdir():
- http://nodejs.org/api/os.html#os_os_tmpdir

Even took a quick peek into random 0.11.x API documents:
- http://nodejs.org/docs/v0.11.13/api/os.html#os_os_tmpdir 
