### PR TITLE
BigScreen.d.ts - fixing ambient variable case

### DIFF
--- a/bigscreen/bigscreen.d.ts
+++ b/bigscreen/bigscreen.d.ts
@@ -19,7 +19,7 @@ interface BigScreenStatic {
     videoEnabled(video: HTMLVideoElement): boolean;
 }
 
-declare var bigscreen: BigScreenStatic;
+declare var BigScreen: BigScreenStatic;
 
 declare module "bigscreen" {
     export = bigscreen;


### PR DESCRIPTION
BigScreen adds itself to window as window.BigScreen, not window.bigscreen.
