### PR TITLE
fix typo on D3 layout "separation" method

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1162,7 +1162,7 @@ declare module D3 {
             /**
             * If separation is specified, uses the specified function to compute separation between neighboring nodes. If separation is not specified, returns the current separation function
             */
-            seperation: {
+            separation: {
                 /**
                 * Gets the current separation function
                 */
@@ -1170,7 +1170,7 @@ declare module D3 {
                 /**
                 * Sets the specified function to compute separation between neighboring nodes
                 */
-                (seperation: (a: GraphNode, b: GraphNode) => number): TreeLayout;
+                (separation: (a: GraphNode, b: GraphNode) => number): TreeLayout;
             };
             /**
             * Gets or sets the available layout size
@@ -1382,9 +1382,9 @@ declare module D3 {
             }
             nodes(root: GraphNode): GraphNode[];
             links(nodes: GraphNode[]): GraphLink[];
-            seperation: {
+            separation: {
                 (): (a: GraphNode, b: GraphNode) => number;
-                (seperation: (a: GraphNode, b: GraphNode) => number): ClusterLayout;
+                (separation: (a: GraphNode, b: GraphNode) => number): ClusterLayout;
             }
             size: {
                 (): number[];


### PR DESCRIPTION
"separation" is the method name and was named "seperation" into the definition file.
