### PR TITLE
ThenByDescending(keySelector: T): OrderedEnumerable<T>;

### DIFF
--- a/linq/linq.d.ts
+++ b/linq/linq.d.ts
@@ -208,7 +208,7 @@ declare module linq {
         ThenBy(keySelector: ($) => T): OrderedEnumerable<T>;
         ThenBy(keySelector: string): OrderedEnumerable<T>;
         ThenByDescending(keySelector: ($) => T): OrderedEnumerable<T>;
-        ThenByDescending(keySelector: T): OrderedEnumerable<T>;
+        ThenByDescending(keySelector: string): OrderedEnumerable<T>;
     }
 
     interface Grouping<T> extends Enumerable<T> {


### PR DESCRIPTION
replacing 
ThenByDescending(keySelector: T): OrderedEnumerable<T>; 
with 
ThenByDescending(keySelector: string): OrderedEnumerable<T>;
