### PR TITLE
RegExp support for Router.route;

### DIFF
--- a/backbone/backbone.d.ts
+++ b/backbone/backbone.d.ts
@@ -279,6 +279,7 @@ declare module Backbone {
         constructor(options?: RouterOptions);
         initialize(options?: RouterOptions): void;
         route(route: string, name: string, callback?: Function): Router;
+        route(route: RegExp, name: string, callback?: Function): Router;
         navigate(fragment: string, options?: NavigateOptions): Router;
         navigate(fragment: string, trigger?: boolean): Router;
 


### PR DESCRIPTION
Router.route allows for regular expressions, as well as strings, for the "route" argument. See http://backbonejs.org/#Router-route
