### PR TITLE
Fix three.js PlaneGeometry/PlaneBufferGeometry typing

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -5434,7 +5434,7 @@ declare module THREE {
         };
     }
 
-    export class PlaneBufferGeometry extends Geometry {
+    export class PlaneBufferGeometry extends BufferGeometry {
         constructor(width: number, height: number, widthSegments?: number, heightSegments?: number);
 
         parameters: {
@@ -5445,7 +5445,15 @@ declare module THREE {
         };
     }
 
-    export class PlaneGeometry extends PlaneBufferGeometry {
+    export class PlaneGeometry extends Geometry {
+        constructor(width: number, height: number, widthSegments?: number, heightSegments?: number);
+
+        parameters: {
+            width: number;
+            height: number;
+            widthSegments: number;
+            heightSegments: number;
+        };
     }
 
     export class PolyhedronGeometry extends Geometry {


### PR DESCRIPTION
- PlaneBufferGeometry is a subclass of BufferGeometry
- PlaneGeometry is a subclass of Geometry
- both have the same constructor signature
