### PR TITLE
d3: Transition.call(...) defines wrong signature

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1750,6 +1750,8 @@ declare module D3 {
 
         export interface Axis {
             (selection: Selection): void;
+            (transition: Transition.Transition): void;
+            
             scale: {
                 (): any;
                 (scale: any): Axis;

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -926,7 +926,7 @@ declare module D3 {
                 (name: string, value: any, priority?: string): Transition;
                 (name: string, valueFunction: (data: any, index: number) => any, priority?: string): Transition;
             };
-            call(callback: (selection: Selection) => void ): Transition;
+            call(callback: (transition: Transition, ...args: any[]) => void, ...args: any[]): Transition;
             /**
             * Select an element from the current document
             */


### PR DESCRIPTION
The D3 definition file contains an error in the signature of
Transition.call(...). The callback will be passed the transition
object and it supports optional arguments similar to
Selection.call(...).

Also see this documentation page for details:
https://github.com/mbostock/d3/wiki/Transitions#call
