### PR TITLE
Bugfix: mysql.query.stream returns a stream.Readable.

### DIFF
--- a/mysql/mysql-tests.ts
+++ b/mysql/mysql-tests.ts
@@ -1,6 +1,8 @@
 ﻿/// <reference path="mysql.d.ts" />
 
+import fs = require('fs');
 import mysql = require('mysql');
+import stream = require('stream');
 
 /// Connections
 var connection = mysql.createConnection({
@@ -118,6 +120,8 @@ connection.config.queryFormat = function (query, values) {
 };
 
 connection.query("UPDATE posts SET title = :title", { title: "Hello MySQL" });
+
+var s: stream.Readable = connection.query("UPDATE posts SET title = :title", { title: "Hello MySQL" }).stream({ highWaterMark: 5 });
 
 connection.query('INSERT INTO posts SET ?', { title: 'test' }, function (err, result) {
     if (err) throw err;
@@ -243,9 +247,10 @@ query
         // all rows have been received
     });
 
+var writable = fs.createWriteStream('file.txt');
 connection.query('SELECT * FROM posts')
     .stream({ highWaterMark: 5 })
-    .pipe(() => { });
+    .pipe(writable);
 
 connection = mysql.createConnection({ multipleStatements: true });
 

--- a/mysql/mysql.d.ts
+++ b/mysql/mysql.d.ts
@@ -3,29 +3,27 @@
 // Definitions by: William Johnston <https://github.com/wjohnsto>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare module mysql {
-    export interface IMySql {
-        createConnection(connectionUri: string): IConnection;
-        createConnection(config: IConnectionConfig): IConnection;
+///<reference path='../node/node.d.ts' />
 
-        createPool(config: IPoolConfig): IPool;
+declare module "mysql" {
+	import stream = require("stream");
 
-        createPoolCluster(config?: IPoolClusterConfig): IPoolCluster;
+    function createConnection(connectionUri: string): IConnection;
+    function createConnection(config: IConnectionConfig): IConnection;
+	function createPool(config: IPoolConfig): IPool;
+	function createPoolCluster(config?: IPoolClusterConfig): IPoolCluster;
+	function escape(value: any): string;
+	function format(sql: string): string;
+	function format(sql: string, values: Array<any>): string;
 
-        escape(value: any): string;
-
-        format(sql: string): string;
-        format(sql: string, values: Array<any>): string;
-    }
-
-    export interface IConnectionStatic {
+    interface IConnectionStatic {
         createQuery(sql: string): IQuery;
         createQuery(sql: string, callback: (err: IError, ...args: any[]) => void): IQuery;
         createQuery(sql: string, values: Array<any>): IQuery;
         createQuery(sql: string, values: Array<any>, callback: (err: IError, ...args: any[]) => void): IQuery;
     }
 
-    export interface IConnection {
+    interface IConnection {
         config: IConnectionConfig;
 
         threadId: number;
@@ -68,7 +66,7 @@ declare module mysql {
         rollback(callback: () => void): void;
     }
 
-    export interface IPool {
+    interface IPool {
         config: IPoolConfig;
 
         getConnection(callback: (err: IError, connection: IConnection) => void): void;
@@ -80,7 +78,7 @@ declare module mysql {
         on(ev: 'error', callback: (err: IError) => void): IPool;
     }
 
-    export interface IPoolCluster {
+    interface IPoolCluster {
         config: IPoolClusterConfig;
 
         add(config: IPoolConfig): void;
@@ -101,7 +99,7 @@ declare module mysql {
         on(ev: 'error', callback: (err: IError) => void): IPoolCluster;
     }
 
-    export interface IQuery {
+    interface IQuery {
         /**
          * The SQL for a constructed query
          */
@@ -125,7 +123,7 @@ declare module mysql {
          * 
          * @param options The options for the stream.
          */
-        stream(options: IStreamOptions): IQuery;
+        stream(options: IStreamOptions): stream.Readable;
 
         /**
          * Pipes a stream downstream, providing automatic pause/resume based on the 
@@ -142,7 +140,7 @@ declare module mysql {
         on(ev: 'end', callback: () => void): IQuery;
     }
 
-    export interface IQueryFunction {
+    interface IQueryFunction {
         (sql: string): IQuery;
         (sql: string, callback: (err: IError, ...args: any[]) => void): IQuery;
         (sql: string, values: Array<any>): IQuery;
@@ -157,7 +155,7 @@ declare module mysql {
         (options: IQueryOptions, values: any, callback: (err: IError, ...args: any[]) => void): IQuery;
     }
 
-    export interface IQueryOptions {
+    interface IQueryOptions {
         /**
          * The SQL for the query
          */
@@ -200,7 +198,7 @@ declare module mysql {
         typeCast?: any;
     }
 
-    export interface IStreamOptions {
+    interface IStreamOptions {
         /**
          * Sets the max buffer size in objects of a stream
          */
@@ -212,7 +210,7 @@ declare module mysql {
         objectMode?: any;
     }
 
-    export interface IConnectionOptions {
+    interface IConnectionOptions {
         /**
          * The MySQL user to authenticate as
          */
@@ -236,7 +234,7 @@ declare module mysql {
         charset?: string;
     }
 
-    export interface IConnectionConfig extends IConnectionOptions {
+    interface IConnectionConfig extends IConnectionOptions {
         /**
          * The hostname of the database you are connecting to. (Default: localhost)
          */
@@ -356,7 +354,7 @@ declare module mysql {
         ssl?: any;
     }
 
-    export interface IPoolConfig extends IConnectionConfig {
+    interface IPoolConfig extends IConnectionConfig {
         /**
          * The milliseconds before a timeout occurs during the connection acquisition. This is slightly different from connectTimeout, 
          * because acquiring a pool connection does not always involve making a connection. (Default: 10 seconds)
@@ -382,7 +380,7 @@ declare module mysql {
         queueLimit?: number;
     }
 
-    export interface IPoolClusterConfig {
+    interface IPoolClusterConfig {
         /**
          * If true, PoolCluster will attempt to reconnect when connection fails. (Default: true)
          */
@@ -403,7 +401,7 @@ declare module mysql {
         defaultSelector?: string;
     }
 
-    export interface ISslCredentials {
+    interface ISslCredentials {
         /**
          * A string or buffer holding the PFX or PKCS12 encoded private key, certificate and CA certificates
          */
@@ -440,7 +438,7 @@ declare module mysql {
         ciphers?: string;
     }
 
-    export interface IError extends Error {
+    interface IError extends Error {
         /**
          * Either a MySQL server error (e.g. 'ER_ACCESS_DENIED_ERROR'), 
          * a node.js error (e.g. 'ECONNREFUSED') or an internal error 
@@ -478,10 +476,4 @@ declare module mysql {
          */
         fatal: boolean;
     }
-}
-
-declare module 'mysql' {
-    var mysql: mysql.IMySql;
-
-    export = mysql;
 }

--- a/mysql/mysql.d.ts
+++ b/mysql/mysql.d.ts
@@ -8,13 +8,23 @@
 declare module "mysql" {
 	import stream = require("stream");
 
-    function createConnection(connectionUri: string): IConnection;
-    function createConnection(config: IConnectionConfig): IConnection;
+	function createConnection(connectionUri: string): IConnection;
+	function createConnection(config: IConnectionConfig): IConnection;
 	function createPool(config: IPoolConfig): IPool;
 	function createPoolCluster(config?: IPoolClusterConfig): IPoolCluster;
 	function escape(value: any): string;
 	function format(sql: string): string;
 	function format(sql: string, values: Array<any>): string;
+
+	interface IMySql {
+		createConnection(connectionUri: string): IConnection;
+		createConnection(config: IConnectionConfig): IConnection;
+		createPool(config: IPoolConfig): IPool;
+		createPoolCluster(config?: IPoolClusterConfig): IPoolCluster;
+		escape(value: any): string;
+		format(sql: string): string;
+		format(sql: string, values: Array<any>): string;
+	}
 
     interface IConnectionStatic {
         createQuery(sql: string): IQuery;
@@ -477,3 +487,4 @@ declare module "mysql" {
         fatal: boolean;
     }
 }
+


### PR DESCRIPTION
See mysql docs at https://github.com/felixge/node-mysql#piping-results-with-streams2

Both the typings and the tests had a bug. According to the docs, IQuery.stream() returns a stream.Readable. In the typings, it returned a custom interface with a wrong pipe() method signature.

In order to import 'streams', I had to refactor the typings into an external module declaration. I don't think this is a problem since you cannot use node-mysql without node.
