### PR TITLE
export expect

### DIFF
--- a/chai/chai.d.ts
+++ b/chai/chai.d.ts
@@ -12,8 +12,8 @@ declare module chai {
         stack: string;
     }
 
-    function expect(target: any, message?: string): Expect;
-    
+    export function expect(target: any, message?: string): Expect;
+
     export var assert: Assert;
     export var config: Config;
 


### PR DESCRIPTION
expect should be exported, like assert or should, since right now it's not pointing / being used "anywhere"
