### PR TITLE
change type of THREE.Quaternion.setFromUnitVectors

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -3189,7 +3189,7 @@ declare module THREE {
          * Sets this quaternion from rotation component of m. Adapted from http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm.
          */
         setFromRotationMatrix(m: Matrix4): Quaternion;
-        setFromUnitVectors(vFrom: Vector3, vTo: Vector4): Quaternion;
+        setFromUnitVectors(vFrom: Vector3, vTo: Vector3): Quaternion;
         /**
          * Inverts this quaternion.
          */


### PR DESCRIPTION
I think the parameter type should be Vector3.

[ref](https://github.com/mrdoob/three.js/blob/master/src/math/Quaternion.js#L257)  
[ref](http://threejs.org/docs/#Reference/Math/Quaternion)
