### PR TITLE
SocketIOClient.Socket.off() arguments are optional

### DIFF
--- a/socket.io-client/socket.io-client.d.ts
+++ b/socket.io-client/socket.io-client.d.ts
@@ -27,6 +27,7 @@ declare module SocketIOClient {
         emit(event: string, ...args: any[]): Socket;
         listeners(event: string): Function[];
         hasListeners(event: string): boolean;
+        connected: boolean;
     }
 
     interface ManagerStatic {

--- a/socket.io-client/socket.io-client.d.ts
+++ b/socket.io-client/socket.io-client.d.ts
@@ -23,7 +23,7 @@ declare module SocketIOClient {
     interface Socket {
         on(event: string, fn: Function): Socket;
         once(event: string, fn: Function): Socket;
-        off(event: string, fn: Function): Socket;
+        off(event?: string, fn?: Function): Socket;
         emit(event: string, ...args: any[]): Socket;
         listeners(event: string): Function[];
         hasListeners(event: string): boolean;


### PR DESCRIPTION
The arguments are actually optional. Socket.io-client package mixes into itself the implementation of component-emitter package that declares off() method with two optional arguments.
You can see method declaration on lines 90-105 here:
https://github.com/component/emitter/blob/master/index.js
