### PR TITLE
chrome.d.ts: fix argument type: Cookie -> Cookie[]

### DIFF
--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -397,7 +397,7 @@ declare module chrome.cookies {
     }
 
     export function getAllCookieStores(callback: (cookieStores: CookieStore[]) => void): void;
-    export function getAll(details: GetAllDetails, callback: (cookies: Cookie) => void): void;
+    export function getAll(details: GetAllDetails, callback: (cookies: Cookie[]) => void): void;
     export function set(details: SetDetails, callback?: (cookie?: Cookie) => void): void;
     export function remove(details: Details, callback?: (details: Details) => void): void;
     export function get(details: Details, callback: (cookie?: Cookie) => void): void;


### PR DESCRIPTION
callback function for chrome.cookies.getAll() should take Cookie[]
https://developer.chrome.com/extensions/cookies#method-getAll
