### PR TITLE
Fixes bug in grunt definitions

### DIFF
--- a/gruntjs/gruntjs.d.ts
+++ b/gruntjs/gruntjs.d.ts
@@ -122,8 +122,7 @@ declare module grunt {
          * {@link http://gruntjs.com/sample-gruntfile}
          */
         interface IProjectConfig{
-            [plugin: string]: any
-            pkg: any; // unfortunate. It is actually a string
+            [plugin: string]: any;
         }                
 
         /**


### PR DESCRIPTION
Removes `pkg` property from `IProjectConfig` interface (the config object passed to `grunt.initConfig`) because it is not necessary; it is merely a commonly-used convention.
