### PR TITLE
Add support for big.js v3.0.0

### DIFF
--- a/big.js/big.js-tests.ts
+++ b/big.js/big.js-tests.ts
@@ -231,3 +231,20 @@ function propertiesTest3() {
     y.e                        // 0
     y.s                        // -1
 }
+
+// see http://mikemcl.github.io/big.js/#faq
+// "How can I simultaneously use different decimal places and/or rounding mode settings for different Big numbers?"
+function testMultipleConstructors() {
+
+	var Big10 = Big();
+
+	// Set the decimal places of division operations for each constructor.
+	Big.DP = 3;
+	Big10.DP = 10;
+
+	var x = Big(5);
+	var y = Big10(5);
+
+	x.div(3)     // 1.667
+	y.div(3)     // 1.6666666667
+}

--- a/big.js/big.js.d.ts
+++ b/big.js/big.js.d.ts
@@ -42,6 +42,9 @@ declare module BigJsLibrary {
         (value: string): BigJS;
         /** A decimal value.  */
         (value: BigJS): BigJS;
+		
+		/** A decimal value.  */
+        (): BigJS;
     }
 
     /** BigJS instance methods */


### PR DESCRIPTION
The big.js v3.0.0 supports calling Big with a parameterless constructor.
