### PR TITLE
add sharedworker/SharedWorker.d.ts

### DIFF
--- a/sharedworker/SharedWorker-tests.ts
+++ b/sharedworker/SharedWorker-tests.ts
@@ -1,0 +1,9 @@
+///<reference path="SharedWorker.d.ts" />
+
+var worker_with_name = new SharedWorker('worker.js', "worker");
+
+var worker = new SharedWorker('worker.js');
+
+worker.port.onmessage = function(e) {
+    console.log(e);
+};

--- a/sharedworker/SharedWorker.d.ts
+++ b/sharedworker/SharedWorker.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for SharedWorker
+// Project: http://www.w3.org/TR/workers/
+// Definitions by: Toshiya Nakakura <https://github.com/nakakura>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module SharedWorker {
+    interface AbstractWorker extends EventTarget {
+        onerror: (ev: ErrorEvent) => any;
+    }
+
+    export interface SharedWorker extends AbstractWorker {
+        /**
+         * the value it was assigned by the object's constructor.
+         * It represents the MessagePort for communicating with the shared worker.
+         * @type {MessagePort}
+         */
+        port: MessagePort;
+    }
+}
+
+declare var SharedWorker: {
+    prototype: SharedWorker.SharedWorker;
+    /***
+     *
+     * @param {string} stringUrl    Pathname to JavaScript file
+     * @param {string} name         Name of the worker to execute
+     */
+    new (stringUrl: string, name?: string): SharedWorker.SharedWorker;
+};


### PR DESCRIPTION
TypeScript partly supports WebWorker.
It has typings for WebWorker in lib.webworker.d.ts,
 but doesn't have typings for SharedWorker.
(https://github.com/Microsoft/TypeScript/blob/master/bin/lib.webworker.d.ts)

I added it.
