### PR TITLE
Update react.d.ts

### DIFF
--- a/react/react-addons-tests.ts
+++ b/react/react-addons-tests.ts
@@ -1,7 +1,36 @@
 /// <reference path="react.d.ts" />
 import React = require("react/addons");
 
-// TestUtils
+var isImportant: boolean;
+var isRead: boolean;
+var classSet: React.ClassSet = {
+    "message": true,
+    "message-important": isImportant,
+    "message-read": isRead
+};
+var cx = React.addons.classSet;
+var classes: string = cx(classSet);
+
+//
+// React.addons (Transitions)
+// --------------------------------------------------------------------------
+
+React.createFactory(React.addons.TransitionGroup)({ component: "div" });
+React.createFactory(React.addons.CSSTransitionGroup)({
+    component: React.createClass({
+        render: (): React.ReactElement<any> => null
+    }),
+    childFactory: (c) => c,
+    transitionName: "transition",
+    transitionAppear: false,
+    transitionEnter: true,
+    transitionLeave: true
+});
+
+//
+// React.addons.TestUtils
+// --------------------------------------------------------------------------
+
 var that: React.CompositeComponent<any, any>;
 var node = that.refs["input"].getDOMNode();
 React.addons.TestUtils.Simulate.click(node);
@@ -16,27 +45,24 @@ interface GreetingState {
 }
 interface Greeting extends React.CompositeComponent<GreetingProps, GreetingState> {
 }
-var Greeting = React.createClass({displayName: "Greeting",
+var Greeting = React.createClass({
+    displayName: "Greeting",
     getInitialState: function() {
         return {morning: true};
     },
     render: function() {
         var me = <Greeting>this;
-        return React.DOM.div(null, (me.state.morning ? "Hello" : "Goodbye "), me.props.name);
+        return React.DOM.div(
+            null,
+            me.state.morning ? "Hello " : "Goodbye ",
+            me.props.name);
     }
 });
 
-var root = React.addons.TestUtils.renderIntoDocument(React.createElement(Greeting, {name: "John"}));
-var greeting = <Greeting>React.addons.TestUtils.findRenderedComponentWithType(root, Greeting);
+var root = React.addons.TestUtils.renderIntoDocument(
+    React.createElement(Greeting, {name: "John"}));
+var greeting = <Greeting>React.addons.TestUtils
+    .findRenderedComponentWithType(root, Greeting);
 greeting.setState({
     morning: false
-});
-
-var isImportant: boolean;
-var isRead: boolean;
-var cx = React.addons.classSet;
-var classes: string = cx({
-    "message": true,
-    "message-important": isImportant,
-    "message-read": isRead
 });

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -116,6 +116,30 @@ var myComponent = <MyComponent>compComponent;
 myComponent.reset();
 
 //
+// Attributes
+// --------------------------------------------------------------------------
+
+var divStyle = { // CSSProperties
+    flex: "1 1 main-size",
+    backgroundImage: "url('hello.png')"
+};
+var htmlAttr = {
+    children: ["Hello world", [null], React.DOM.span(null)],
+    className: "test-attr",
+    style: divStyle,
+    onClick: (event: React.MouseEvent) => {
+        event.preventDefault();
+        event.stopPropagation();
+    },
+    dangerouslySetInnerHTML: {
+        __html: "<strong>STRONG</strong>"
+    }
+};
+React.DOM.div(htmlAttr);
+React.DOM.span(htmlAttr);
+React.DOM.input(htmlAttr);
+
+//
 // PropTypes
 // --------------------------------------------------------------------------
 

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -119,12 +119,13 @@ myComponent.reset();
 // Attributes
 // --------------------------------------------------------------------------
 
+var children = ["Hello world", [null], React.DOM.span(null)];
 var divStyle = { // CSSProperties
     flex: "1 1 main-size",
     backgroundImage: "url('hello.png')"
 };
 var htmlAttr = {
-    children: ["Hello world", [null], React.DOM.span(null)],
+    children: children,
     className: "test-attr",
     style: divStyle,
     onClick: (event: React.MouseEvent) => {
@@ -140,7 +141,7 @@ React.DOM.span(htmlAttr);
 React.DOM.input(htmlAttr);
 
 //
-// PropTypes
+// React.PropTypes
 // --------------------------------------------------------------------------
 
 var PropTypesSpecification: React.ComponentSpec<any, any> = {
@@ -179,6 +180,18 @@ var PropTypesSpecification: React.ComponentSpec<any, any> = {
         return null;
     }
 };
+
+//
+// React.Children
+// --------------------------------------------------------------------------
+
+var childMap: { [key: string]: number } =
+    React.Children.map<number>(children, (child) => { return 42; });
+React.Children.forEach(children, (child) => {});
+var nChildren: number = React.Children.count(children);
+var onlyChild = React.Children.only([null, [[["Hallo"], true]], false, {
+    test: null
+}]);
 
 //
 // Example from http://facebook.github.io/react/

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -18,6 +18,8 @@ interface MyComponent extends React.CompositeComponent<Props, State> {
 }
 
 var props: Props = {
+    key: 42,
+    ref: "myComponent42",
     hello: "world",
     foo: 42,
     bar: true
@@ -124,7 +126,9 @@ var divStyle = { // CSSProperties
     flex: "1 1 main-size",
     backgroundImage: "url('hello.png')"
 };
-var htmlAttr = {
+var htmlAttr: React.HTMLAttributes = {
+    key: 36,
+    ref: "htmlComponent",
     children: children,
     className: "test-attr",
     style: divStyle,

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -60,7 +60,7 @@ var reactClass: React.ComponentClass<Props> = React.createClass<Props>({
 var reactElement: React.ReactElement<Props> =
     React.createElement<Props>(reactClass, props);
 
-var reactFactory: React.Factory<Props> =
+var reactFactory: React.ComponentFactory<Props> =
     React.createFactory<Props>(reactClass);
 
 var component: React.Component<Props> =

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -285,7 +285,7 @@ declare module React {
 
     interface CSSProperties {
         columnCount?: number;
-        flex?: number;
+        flex?: any; // number | string
         flexGrow?: number;
         flexShrink?: number;
         fontWeight?: number;
@@ -301,8 +301,6 @@ declare module React {
         // SVG-related properties
         fillOpacity?: number;
         strokeOpacity?: number;
-
-        [key: string]: any; // number | string
     }
 
     interface HTMLAttributes extends ReactAttributes {

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -26,7 +26,10 @@ declare module React {
 
     // type ReactText = string | number;
     // type Fragment = ReactNode[];
-    // type ReactNode = ReactElement<any, any> | Fragment | ReactText;
+    // type ReactNode = ReactElement<any> | Fragment | ReactText | KeyMap;
+    // interface KeyMap {
+    //     [key: string]: ReactNode;
+    // }
 
     //
     // React Components 
@@ -63,7 +66,7 @@ declare module React {
         createClass<P>(spec: ComponentSpec<P, any>): ComponentClass<P>;
         createElement<P>(type: any/*ReactType*/, props: P, ...children: any/*ReactNode*/[]): ReactElement<P>;
         createFactory<P>(componentClass: ComponentClass<P>): ComponentFactory<P>;
-        render<P>(element: ReactElement<P>, container: Element, callback?: () => void): Component<P>;
+        render<P>(element: ReactElement<P>, container: Element, callback?: () => any): Component<P>;
         unmountComponentAtNode(container: Element): boolean;
         renderToString(element: ReactElement<any>): string;
         renderToStaticMarkup(element: ReactElement<any>): string;
@@ -83,8 +86,8 @@ declare module React {
         isMounted(): boolean;
 
         props: P;
-        setProps(nextProps: P, callback?: () => void): void;
-        replaceProps(nextProps: P, callback?: () => void): void;
+        setProps(nextProps: P, callback?: () => any): void;
+        replaceProps(nextProps: P, callback?: () => any): void;
     }
 
     interface DOMComponent<P> extends Component<P> {
@@ -96,9 +99,9 @@ declare module React {
     
     interface CompositeComponent<P, S> extends Component<P>, ComponentSpec<P, S> {
         state: S;
-        setState(nextState: S, callback?: () => void): void;
-        replaceState(nextState: S, callback?: () => void): void;
-        forceUpdate(callback?: () => void): void;
+        setState(nextState: S, callback?: () => any): void;
+        replaceState(nextState: S, callback?: () => any): void;
+        forceUpdate(callback?: () => any): void;
         refs: {
             [key: string]: Component<any>
         };
@@ -634,11 +637,13 @@ declare module React {
     // React.Children
     // ----------------------------------------------------------------------
 
+    // type Child = ReactElement<any> | ReactText;
+
     interface ReactChildren {
-        map<T>(children: any/*ReactNode*/, fn: (child: any/*ReactNode*/) => T): { [key:string]: T };
-        forEach(children: any/*ReactNode*/, fn: (child: any/*ReactNode*/) => any): void;
+        map<T>(children: any/*ReactNode*/, fn: (child: any/*Child*/) => T): { [key:string]: T };
+        forEach(children: any/*ReactNode*/, fn: (child: any/*Child*/) => any): void;
         count(children: any/*ReactNode*/): number;
-        only(children: any/*ReactNode*/): any;
+        only(children: any/*ReactNode*/): any/*Child*/;
     }
 
     //
@@ -865,9 +870,9 @@ declare module React {
             PureRenderMixin: PureRenderMixin;
             TransitionGroup: TransitionGroup;
 
-            batchedUpdates<A, B>(callback: (a: A, b: B) => void, a: A, b: B): void;
-            batchedUpdates<A>(callback: (a: A) => void, a: A): void;
-            batchedUpdates(callback: () => void): void;
+            batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
+            batchedUpdates<A>(callback: (a: A) => any, a: A): void;
+            batchedUpdates(callback: () => any): void;
 
             classSet(cx: { [key: string]: boolean }): string;
             cloneWithProps<P>(element: ReactElement<P>, props: P): ReactElement<P>;

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -19,7 +19,6 @@ declare module React {
 
     interface ReactHTMLElement extends ReactElement<HTMLAttributes> {}
     interface ReactSVGElement extends ReactElement<SVGAttributes> {}
-    interface ComponentElement<P> extends ReactElement<P> {}
 
     //
     // React Nodes 
@@ -49,13 +48,12 @@ declare module React {
     // ReactElement Factories
     // ----------------------------------------------------------------------
 
-    interface Factory<P> {
+    interface ComponentFactory<P> {
         (props?: P, ...children: any/*ReactNode*/[]): ReactElement<P>;
     }
     
-    interface HTMLFactory extends Factory<HTMLAttributes> {}
-    interface SVGFactory extends Factory<SVGAttributes> {}
-    interface ComponentFactory<P> extends Factory<P> {}
+    interface HTMLFactory extends ComponentFactory<HTMLAttributes> {}
+    interface SVGFactory extends ComponentFactory<SVGAttributes> {}
 
     //
     // Top-Level API
@@ -64,7 +62,7 @@ declare module React {
     interface TopLevelAPI {
         createClass<P>(spec: ComponentSpec<P, any>): ComponentClass<P>;
         createElement<P>(type: any/*ReactType*/, props: P, ...children: any/*ReactNode*/[]): ReactElement<P>;
-        createFactory<P>(componentClass: ComponentClass<P>): Factory<P>;
+        createFactory<P>(componentClass: ComponentClass<P>): ComponentFactory<P>;
         render<P>(element: ReactElement<P>, container: Element, callback?: () => void): Component<P>;
         unmountComponentAtNode(container: Element): boolean;
         renderToString(element: ReactElement<any>): string;

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -242,7 +242,7 @@ declare module React {
 
     export interface ReactAttributes {
         children?: any; // ReactNode
-        key?: string;
+        key?: any; // number | string
         ref?: string;
 
         // Event Attributes

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -647,19 +647,27 @@ declare module React {
     }
 
     //
-    // React.addons (Transitions)
+    // React.addons
     // ----------------------------------------------------------------------
 
-    interface CSSTransitionGroupProps {
-        transitionName: string;
-        transitionAppear?: boolean;
-        transitionEnter?: boolean;
-        transitionLeave?: boolean;
+    interface ClassSet {
+        [key: string]: boolean;
     }
+
+    //
+    // React.addons (Transitions)
+    // ----------------------------------------------------------------------
 
     interface TransitionGroupProps {
         component?: any; // ReactType
         childFactory?: (child: ReactElement<any>) => ReactElement<any>;
+    }
+
+    interface CSSTransitionGroupProps extends TransitionGroupProps {
+        transitionName: string;
+        transitionAppear?: boolean;
+        transitionEnter?: boolean;
+        transitionLeave?: boolean;
     }
 
     interface CSSTransitionGroup extends ComponentClass<CSSTransitionGroupProps> {}
@@ -874,7 +882,7 @@ declare module React {
             batchedUpdates<A>(callback: (a: A) => any, a: A): void;
             batchedUpdates(callback: () => any): void;
 
-            classSet(cx: { [key: string]: boolean }): string;
+            classSet(cx: ClassSet): string;
             cloneWithProps<P>(element: ReactElement<P>, props: P): ReactElement<P>;
 
             update(value: any[], spec: UpdateArraySpec): any[];


### PR DESCRIPTION
- Removes `React.ComponentElement<P>` in favor of `React.Element<P>`.
- Removes `React.Factory<P>` in favor of `React.ComponentFactory<P>`.
- Change callback return types to `any` instead of `void` per best practices.
- Update `React.Children` types and add tests to `react-tests.ts`.
- Add `React.ClassSet` interface for use with `addons.classSet`.
- Fix DOMAttributes `key` type (`any; // number | string`).

cc @pspeter3
