### PR TITLE
Fix dropzone signatures

### DIFF
--- a/dropzone/dropzone.d.ts
+++ b/dropzone/dropzone.d.ts
@@ -39,7 +39,7 @@ interface DropzoneOptions {
     forceFallback?: boolean;
     fallback?: () => void;
 
-    // dictionary options 
+    // dictionary options
     dictDefaultMessage?: string;
     dictFallbackMessage?: string;
     dictFallbackText?: string;
@@ -72,7 +72,7 @@ declare class Dropzone {
     getRejectedFiles(): DropzoneFile[];
     getQueuedFiles(): DropzoneFile[];
     getUploadingFiles(): DropzoneFile[];
-    
+
     emit(eventName: string, file: DropzoneFile, str?: string);
     emit(eventName: "thumbnail", file: DropzoneFile, path: string);
     emit(eventName: "addedfile", file: DropzoneFile);

--- a/dropzone/dropzone.d.ts
+++ b/dropzone/dropzone.d.ts
@@ -24,7 +24,7 @@ interface DropzoneOptions {
     headers?: any;
     addRemoveLinks?: boolean;
     previewsContainer?: string;
-    clickable?: boolean;
+    clickable?: any;
     createImageThumbnails?: boolean;
     maxThumbnailFilesize?: number;
     thumbnailWidth?: number;

--- a/dropzone/dropzone.d.ts
+++ b/dropzone/dropzone.d.ts
@@ -66,7 +66,7 @@ declare class Dropzone {
     off(eventName): void;
 
     removeFile(file: DropzoneFile): void;
-    removeAllFiles(): void;
+    removeAllFiles(cancelIfNecessary?: boolean): void;
     processQueue(): void;
     getAcceptedFiles(): DropzoneFile[];
     getRejectedFiles(): DropzoneFile[];


### PR DESCRIPTION
clickable can be a boolean or a string representing an HTML element.

removeAllFiles takes an optional boolean.
