### PR TITLE
(cordova) union type for RegistrationOptions

### DIFF
--- a/cordova/plugins/Push.d.ts
+++ b/cordova/plugins/Push.d.ts
@@ -63,8 +63,8 @@ interface RegistrationOptions {
     channelName?: string;
     /** Callback, that is fired when notification arrived */
     ecb?: string;
-    badge?: boolean;
-    sound?: boolean;
-    alert?: boolean
+    badge?: boolean|string;
+    sound?: boolean|string;
+    alert?: boolean|string
 }
 


### PR DESCRIPTION
According to the API [documentation](https://github.com/phonegap-build/PushPlugin#register) the `register` function can be called using **string** values for **[badge, sound, alert]** attributes. However uppon [source code inspection](https://github.com/phonegap-build/PushPlugin/blob/master/src/ios/PushPlugin.m#L57-L106), all of those attributes work with either **string** or **boolean** values.

A _union type_ can be used for this scenario on the [RegistrationOptions](https://github.com/borisyankov/DefinitelyTyped/blob/master/cordova/plugins/Push.d.ts#L66-L68) so that all three of those attributes be defined as `boolean|string`.
