### PR TITLE
Added explicit return type

### DIFF
--- a/jquery.address/jquery.address.d.ts
+++ b/jquery.address/jquery.address.d.ts
@@ -6,7 +6,7 @@
 /// <reference path="../jquery/jquery.d.ts" />
 
 interface JQueryAddressStatic {
-    ();
+    (): any;
     /**
      * Binds any supported event type to a function with support for an optional map of data.
      */


### PR DESCRIPTION
Without explicit return types everywhere, the definition cannot be used in projects that build with --noImplicitAny flag.
