### PR TITLE
Adding isNavigationPropertyLoaded on EntityAspect class

### DIFF
--- a/breeze/breeze.d.ts
+++ b/breeze/breeze.d.ts
@@ -297,6 +297,8 @@ declare module breeze {
         getValidationErrors(property: IProperty): ValidationError[];
         hasValidationErrors: boolean;
 
+        isNavigationPropertyLoaded(navigationProperty: string): boolean;
+        isNavigationPropertyLoaded(navigationProperty: NavigationProperty): boolean;
         loadNavigationProperty(navigationProperty: string, callback?: Function, errorCallback?: Function): Q.Promise<QueryResult>;
         loadNavigationProperty(navigationProperty: NavigationProperty, callback?: Function, errorCallback?: Function): Q.Promise<QueryResult>;
 


### PR DESCRIPTION
breezejs documentation reference a function that wasn't declared in this file. 
cf:http://www.breezejs.com/sites/all/apidocs/classes/EntityAspect.html
