### PR TITLE
Generate up to 5 argument versions of when.lift, when.attempt, when.node.lift and when.node.call

### DIFF
--- a/when/build.js
+++ b/when/build.js
@@ -1,0 +1,7 @@
+var fs = require('fs');
+var ejs = require('ejs');
+
+var input = fs.readFileSync('./when.d.ts.ejs', { encoding: 'utf-8' });
+var output = ejs.render(input, { open: '<(', close: ')>' });
+
+fs.writeFileSync('./when.d.ts', output, { encoding: 'utf-8' });

--- a/when/package.json
+++ b/when/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "build": "node build.js"
+  },
+  "dependencies": {
+    "ejs": "^1.0.0"
+  }
+}

--- a/when/when-tests.ts
+++ b/when/when-tests.ts
@@ -18,9 +18,6 @@ var foreign = new ForeignPromise<number>(1);
 var error = new Error("boom!");
 var example: () => void;
 
-// TODO: with TypeScript 1.4 a lot of these functions should change to use PromiseOrValue<T>
-//    type PromiseOrValue<T> = Promise<T> | T;
-
 /* * * * * * *
  *   Core    *
  * * * * * * */
@@ -60,12 +57,29 @@ promise = when.attempt((a: number, b: number, c: number) => a + b + c, when(1), 
 
 /* when.lift(f) */
 
-// TODO: This is the major issue with lack of union types, it's not possible to represent the return type of when.lift without them.
+var liftedFunc0 = when.lift(() => 2);
+var liftedFunc1 = when.lift((a: number) => a + a);
+var liftedFunc2 = when.lift((a: number, b: number) => a + b);
+var liftedFunc3 = when.lift((a: number, b: number, c: number) => a + b + c);
 
-var liftedFunc0: () => when.Promise<number> = when.lift(() => 2);
-var liftedFunc1: (a: when.Promise<number>) => when.Promise<number> = when.lift((a: number) => a + a);
-var liftedFunc2: (a: when.Promise<number>, b: when.Promise<number>) => when.Promise<number> = when.lift((a: number, b: number) => a + b);
-var liftedFunc3: (a: when.Promise<number>, b: when.Promise<number>, c: when.Promise<number>) => when.Promise<number> = when.lift((a: number, b: number, c: number) => a + b + c);
+promise = liftedFunc0();
+
+promise = liftedFunc1(1);
+promise = liftedFunc1(when(1));
+
+promise = liftedFunc2(1, 2);
+promise = liftedFunc2(when(1), 2);
+promise = liftedFunc2(1, when(2));
+promise = liftedFunc2(when(1), when(2));
+
+promise = liftedFunc3(1, 2, 3);
+promise = liftedFunc3(when(1), 2, 3);
+promise = liftedFunc3(1, when(2), 3);
+promise = liftedFunc3(when(1), when(2), 3);
+promise = liftedFunc3(1, 2, when(3));
+promise = liftedFunc3(when(1), 2, when(3));
+promise = liftedFunc3(1, when(2), when(3));
+promise = liftedFunc3(when(1), when(2), when(3));
 
 /* when.join(...promises) */
 
@@ -196,17 +210,34 @@ import nodefn = require('when/node');
 
 /* node.lift */
 
-// TODO: Again it's not possible to represent the return type of node.lift without union types.
-
 var nodeFn0 = (callback: (err: any, result: number) => void) => callback(null, 0);
 var nodeFn1 = (a: number, callback: (err: any, result: number) => void) => callback(null, a);
 var nodeFn2 = (a: number, b: number, callback: (err: any, result: number) => void) => callback(null, a + b);
 var nodeFn3 = (a: number, b: number, c: number, callback: (err: any, result: number) => void) => callback(null, a + b + c);
 
-var promiseFunc0: () => when.Promise<number> = nodefn.lift(nodeFn0);
-var promiseFunc1: (a: when.Promise<number>) => when.Promise<number> = nodefn.lift(nodeFn1);
-var promiseFunc2: (a: when.Promise<number>, b: when.Promise<number>) => when.Promise<number> = nodefn.lift(nodeFn2);
-var promiseFunc3: (a: when.Promise<number>, b: when.Promise<number>, c: when.Promise<number>) => when.Promise<number> = nodefn.lift(nodeFn3);
+var liftedNodeFunc0 = nodefn.lift(nodeFn0);
+var liftedNodeFunc1 = nodefn.lift(nodeFn1);
+var liftedNodeFunc2 = nodefn.lift(nodeFn2);
+var liftedNodeFunc3 = nodefn.lift(nodeFn3);
+
+promise = liftedNodeFunc0();
+
+promise = liftedNodeFunc1(1);
+promise = liftedNodeFunc1(when(1));
+
+promise = liftedNodeFunc2(1, 2);
+promise = liftedNodeFunc2(when(1), 2);
+promise = liftedNodeFunc2(1, when(2));
+promise = liftedNodeFunc2(when(1), when(2));
+
+promise = liftedNodeFunc3(1, 2, 3);
+promise = liftedNodeFunc3(when(1), 2, 3);
+promise = liftedNodeFunc3(1, when(2), 3);
+promise = liftedNodeFunc3(when(1), when(2), 3);
+promise = liftedNodeFunc3(1, 2, when(3));
+promise = liftedNodeFunc3(when(1), 2, when(3));
+promise = liftedNodeFunc3(1, when(2), when(3));
+promise = liftedNodeFunc3(when(1), when(2), when(3));
 
 example = function() {
 	var resolveAddress = nodefn.lift(dns.resolve);

--- a/when/when.d.ts
+++ b/when/when.d.ts
@@ -3,6 +3,9 @@
 // Definitions by: Derek Cicerone <https://github.com/derekcicerone>, Wim Looman <https://github.com/Nemo157>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
+// This file is generated, please change when.d.ts.ejs and run
+// `npm install && npm run build` in the `when` directory to update it.
+
 declare function When<T>(value: When.Promise<T>): When.Promise<T>;
 declare function When<T>(value: When.Thenable<T>): When.Promise<T>;
 declare function When<T>(value: T): When.Promise<T>;
@@ -11,31 +14,9 @@ declare function When<T, U>(value: When.Promise<T>, transform: (val: T) => U): W
 declare function When<T, U>(value: When.Thenable<T>, transform: (val: T) => U): When.Promise<U>;
 declare function When<T, U>(value: T, transform: (val: T) => U): When.Promise<U>;
 
+
+
 declare module When {
-    function attempt<T>(f: () => T): Promise<T>;
-
-    function attempt<T, A>(f: (a: A) => T, a: Promise<A>): Promise<T>;
-    function attempt<T, A>(f: (a: A) => T, a: A): Promise<T>;
-
-    function attempt<T, A, B>(f: (a: A, b: B) => T, a: Promise<A>, b: Promise<B>): Promise<T>;
-    function attempt<T, A, B>(f: (a: A, b: B) => T, a: Promise<A>, b: B): Promise<T>;
-    function attempt<T, A, B>(f: (a: A, b: B) => T, a: A, b: Promise<B>): Promise<T>;
-    function attempt<T, A, B>(f: (a: A, b: B) => T, a: A, b: B): Promise<T>;
-
-    function attempt<T, A, B, C>(f: (a: A, b: B, c: C) => T, a: Promise<A>, b: Promise<B>, c: Promise<C>): Promise<T>;
-    function attempt<T, A, B, C>(f: (a: A, b: B, c: C) => T, a: Promise<A>, b: Promise<B>, c: C): Promise<T>;
-    function attempt<T, A, B, C>(f: (a: A, b: B, c: C) => T, a: Promise<A>, b: B, c: Promise<C>): Promise<T>;
-    function attempt<T, A, B, C>(f: (a: A, b: B, c: C) => T, a: Promise<A>, b: B, c: C): Promise<T>;
-    function attempt<T, A, B, C>(f: (a: A, b: B, c: C) => T, a: A, b: Promise<B>, c: Promise<C>): Promise<T>;
-    function attempt<T, A, B, C>(f: (a: A, b: B, c: C) => T, a: A, b: Promise<B>, c: C): Promise<T>;
-    function attempt<T, A, B, C>(f: (a: A, b: B, c: C) => T, a: A, b: B, c: Promise<C>): Promise<T>;
-    function attempt<T, A, B, C>(f: (a: A, b: B, c: C) => T, a: A, b: B, c: C): Promise<T>;
-
-    function lift<T>(f: () => T): () => Promise<T>;
-    function lift<T, A>(f: (a: A) => T): (a: Promise<A>) => Promise<T>;
-    function lift<T, A, B>(f: (a: A, b: B) => T): (a: Promise<A>, b: Promise<B>) => Promise<T>;
-    function lift<T, A, B, C>(f: (a: A, b: B, c: C) => T): (a: Promise<A>, b: Promise<B>, c: Promise<C>) => Promise<T>;
-
     function promise<T>(resolver: (resolve: (value: T) => void, reject: (reason: any) => void) => void): Promise<T>;
 
     function reject<T>(reason: any): Promise<T>;
@@ -158,6 +139,163 @@ declare module When {
         value?: T;
         reason?: any;
     }
+
+
+    interface LiftedFunction1<TResult, TArg0> {
+        (arg0: TArg0): Promise<TResult>;
+        (arg0: Promise<TArg0>): Promise<TResult>;
+    }
+
+    interface LiftedFunction2<TResult, TArg0, TArg1> {
+        (arg0: TArg0, arg1: TArg1): Promise<TResult>;
+        (arg0: TArg0, arg1: Promise<TArg1>): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: TArg1): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: Promise<TArg1>): Promise<TResult>;
+    }
+
+    interface LiftedFunction3<TResult, TArg0, TArg1, TArg2> {
+        (arg0: TArg0, arg1: TArg1, arg2: TArg2): Promise<TResult>;
+        (arg0: TArg0, arg1: TArg1, arg2: Promise<TArg2>): Promise<TResult>;
+        (arg0: TArg0, arg1: Promise<TArg1>, arg2: TArg2): Promise<TResult>;
+        (arg0: TArg0, arg1: Promise<TArg1>, arg2: Promise<TArg2>): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: TArg1, arg2: TArg2): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: TArg1, arg2: Promise<TArg2>): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: TArg2): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: Promise<TArg2>): Promise<TResult>;
+    }
+
+    interface LiftedFunction4<TResult, TArg0, TArg1, TArg2, TArg3> {
+        (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3): Promise<TResult>;
+        (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: Promise<TArg3>): Promise<TResult>;
+        (arg0: TArg0, arg1: TArg1, arg2: Promise<TArg2>, arg3: TArg3): Promise<TResult>;
+        (arg0: TArg0, arg1: TArg1, arg2: Promise<TArg2>, arg3: Promise<TArg3>): Promise<TResult>;
+        (arg0: TArg0, arg1: Promise<TArg1>, arg2: TArg2, arg3: TArg3): Promise<TResult>;
+        (arg0: TArg0, arg1: Promise<TArg1>, arg2: TArg2, arg3: Promise<TArg3>): Promise<TResult>;
+        (arg0: TArg0, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: TArg3): Promise<TResult>;
+        (arg0: TArg0, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: Promise<TArg3>): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: TArg3): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: Promise<TArg3>): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: TArg1, arg2: Promise<TArg2>, arg3: TArg3): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: TArg1, arg2: Promise<TArg2>, arg3: Promise<TArg3>): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: TArg2, arg3: TArg3): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: TArg2, arg3: Promise<TArg3>): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: TArg3): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: Promise<TArg3>): Promise<TResult>;
+    }
+
+    interface LiftedFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4> {
+        (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4): Promise<TResult>;
+        (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: Promise<TArg4>): Promise<TResult>;
+        (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: Promise<TArg3>, arg4: TArg4): Promise<TResult>;
+        (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: Promise<TArg3>, arg4: Promise<TArg4>): Promise<TResult>;
+        (arg0: TArg0, arg1: TArg1, arg2: Promise<TArg2>, arg3: TArg3, arg4: TArg4): Promise<TResult>;
+        (arg0: TArg0, arg1: TArg1, arg2: Promise<TArg2>, arg3: TArg3, arg4: Promise<TArg4>): Promise<TResult>;
+        (arg0: TArg0, arg1: TArg1, arg2: Promise<TArg2>, arg3: Promise<TArg3>, arg4: TArg4): Promise<TResult>;
+        (arg0: TArg0, arg1: TArg1, arg2: Promise<TArg2>, arg3: Promise<TArg3>, arg4: Promise<TArg4>): Promise<TResult>;
+        (arg0: TArg0, arg1: Promise<TArg1>, arg2: TArg2, arg3: TArg3, arg4: TArg4): Promise<TResult>;
+        (arg0: TArg0, arg1: Promise<TArg1>, arg2: TArg2, arg3: TArg3, arg4: Promise<TArg4>): Promise<TResult>;
+        (arg0: TArg0, arg1: Promise<TArg1>, arg2: TArg2, arg3: Promise<TArg3>, arg4: TArg4): Promise<TResult>;
+        (arg0: TArg0, arg1: Promise<TArg1>, arg2: TArg2, arg3: Promise<TArg3>, arg4: Promise<TArg4>): Promise<TResult>;
+        (arg0: TArg0, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: TArg3, arg4: TArg4): Promise<TResult>;
+        (arg0: TArg0, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: TArg3, arg4: Promise<TArg4>): Promise<TResult>;
+        (arg0: TArg0, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: Promise<TArg3>, arg4: TArg4): Promise<TResult>;
+        (arg0: TArg0, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: Promise<TArg3>, arg4: Promise<TArg4>): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: Promise<TArg4>): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: Promise<TArg3>, arg4: TArg4): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: Promise<TArg3>, arg4: Promise<TArg4>): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: TArg1, arg2: Promise<TArg2>, arg3: TArg3, arg4: TArg4): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: TArg1, arg2: Promise<TArg2>, arg3: TArg3, arg4: Promise<TArg4>): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: TArg1, arg2: Promise<TArg2>, arg3: Promise<TArg3>, arg4: TArg4): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: TArg1, arg2: Promise<TArg2>, arg3: Promise<TArg3>, arg4: Promise<TArg4>): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: TArg2, arg3: TArg3, arg4: TArg4): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: TArg2, arg3: TArg3, arg4: Promise<TArg4>): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: TArg2, arg3: Promise<TArg3>, arg4: TArg4): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: TArg2, arg3: Promise<TArg3>, arg4: Promise<TArg4>): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: TArg3, arg4: TArg4): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: TArg3, arg4: Promise<TArg4>): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: Promise<TArg3>, arg4: TArg4): Promise<TResult>;
+        (arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: Promise<TArg3>, arg4: Promise<TArg4>): Promise<TResult>;
+    }
+
+
+    function attempt<T>(f: () => T): Promise<T>;
+
+    function attempt<TResult, TArg0>(f: (arg0: TArg0) => TResult, arg0: TArg0): Promise<TResult>;
+    function attempt<TResult, TArg0>(f: (arg0: TArg0) => TResult, arg0: Promise<TArg0>): Promise<TResult>;
+
+    function attempt<TResult, TArg0, TArg1>(f: (arg0: TArg0, arg1: TArg1) => TResult, arg0: TArg0, arg1: TArg1): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1>(f: (arg0: TArg0, arg1: TArg1) => TResult, arg0: TArg0, arg1: Promise<TArg1>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1>(f: (arg0: TArg0, arg1: TArg1) => TResult, arg0: Promise<TArg0>, arg1: TArg1): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1>(f: (arg0: TArg0, arg1: TArg1) => TResult, arg0: Promise<TArg0>, arg1: Promise<TArg1>): Promise<TResult>;
+
+    function attempt<TResult, TArg0, TArg1, TArg2>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2) => TResult, arg0: TArg0, arg1: TArg1, arg2: TArg2): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2) => TResult, arg0: TArg0, arg1: TArg1, arg2: Promise<TArg2>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2) => TResult, arg0: TArg0, arg1: Promise<TArg1>, arg2: TArg2): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2) => TResult, arg0: TArg0, arg1: Promise<TArg1>, arg2: Promise<TArg2>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2) => TResult, arg0: Promise<TArg0>, arg1: TArg1, arg2: TArg2): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2) => TResult, arg0: Promise<TArg0>, arg1: TArg1, arg2: Promise<TArg2>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2) => TResult, arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: TArg2): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2) => TResult, arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: Promise<TArg2>): Promise<TResult>;
+
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult, arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult, arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: Promise<TArg3>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult, arg0: TArg0, arg1: TArg1, arg2: Promise<TArg2>, arg3: TArg3): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult, arg0: TArg0, arg1: TArg1, arg2: Promise<TArg2>, arg3: Promise<TArg3>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult, arg0: TArg0, arg1: Promise<TArg1>, arg2: TArg2, arg3: TArg3): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult, arg0: TArg0, arg1: Promise<TArg1>, arg2: TArg2, arg3: Promise<TArg3>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult, arg0: TArg0, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: TArg3): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult, arg0: TArg0, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: Promise<TArg3>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult, arg0: Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: TArg3): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult, arg0: Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: Promise<TArg3>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult, arg0: Promise<TArg0>, arg1: TArg1, arg2: Promise<TArg2>, arg3: TArg3): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult, arg0: Promise<TArg0>, arg1: TArg1, arg2: Promise<TArg2>, arg3: Promise<TArg3>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult, arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: TArg2, arg3: TArg3): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult, arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: TArg2, arg3: Promise<TArg3>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult, arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: TArg3): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult, arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: Promise<TArg3>): Promise<TResult>;
+
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: Promise<TArg4>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: Promise<TArg3>, arg4: TArg4): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: Promise<TArg3>, arg4: Promise<TArg4>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: TArg0, arg1: TArg1, arg2: Promise<TArg2>, arg3: TArg3, arg4: TArg4): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: TArg0, arg1: TArg1, arg2: Promise<TArg2>, arg3: TArg3, arg4: Promise<TArg4>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: TArg0, arg1: TArg1, arg2: Promise<TArg2>, arg3: Promise<TArg3>, arg4: TArg4): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: TArg0, arg1: TArg1, arg2: Promise<TArg2>, arg3: Promise<TArg3>, arg4: Promise<TArg4>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: TArg0, arg1: Promise<TArg1>, arg2: TArg2, arg3: TArg3, arg4: TArg4): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: TArg0, arg1: Promise<TArg1>, arg2: TArg2, arg3: TArg3, arg4: Promise<TArg4>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: TArg0, arg1: Promise<TArg1>, arg2: TArg2, arg3: Promise<TArg3>, arg4: TArg4): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: TArg0, arg1: Promise<TArg1>, arg2: TArg2, arg3: Promise<TArg3>, arg4: Promise<TArg4>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: TArg0, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: TArg3, arg4: TArg4): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: TArg0, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: TArg3, arg4: Promise<TArg4>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: TArg0, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: Promise<TArg3>, arg4: TArg4): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: TArg0, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: Promise<TArg3>, arg4: Promise<TArg4>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: Promise<TArg4>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: Promise<TArg3>, arg4: TArg4): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: Promise<TArg3>, arg4: Promise<TArg4>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: Promise<TArg0>, arg1: TArg1, arg2: Promise<TArg2>, arg3: TArg3, arg4: TArg4): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: Promise<TArg0>, arg1: TArg1, arg2: Promise<TArg2>, arg3: TArg3, arg4: Promise<TArg4>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: Promise<TArg0>, arg1: TArg1, arg2: Promise<TArg2>, arg3: Promise<TArg3>, arg4: TArg4): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: Promise<TArg0>, arg1: TArg1, arg2: Promise<TArg2>, arg3: Promise<TArg3>, arg4: Promise<TArg4>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: TArg2, arg3: TArg3, arg4: TArg4): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: TArg2, arg3: TArg3, arg4: Promise<TArg4>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: TArg2, arg3: Promise<TArg3>, arg4: TArg4): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: TArg2, arg3: Promise<TArg3>, arg4: Promise<TArg4>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: TArg3, arg4: TArg4): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: TArg3, arg4: Promise<TArg4>): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: Promise<TArg3>, arg4: TArg4): Promise<TResult>;
+    function attempt<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult, arg0: Promise<TArg0>, arg1: Promise<TArg1>, arg2: Promise<TArg2>, arg3: Promise<TArg3>, arg4: Promise<TArg4>): Promise<TResult>;
+
+
+    function lift<T>(f: () => T): () => Promise<T>;
+
+    function lift<TResult, TArg0>(f: (arg0: TArg0) => TResult): LiftedFunction1<TResult, TArg0>;
+    function lift<TResult, TArg0, TArg1>(f: (arg0: TArg0, arg1: TArg1) => TResult): LiftedFunction2<TResult, TArg0, TArg1>;
+    function lift<TResult, TArg0, TArg1, TArg2>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2) => TResult): LiftedFunction3<TResult, TArg0, TArg1, TArg2>;
+    function lift<TResult, TArg0, TArg1, TArg2, TArg3>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3) => TResult): LiftedFunction4<TResult, TArg0, TArg1, TArg2, TArg3>;
+    function lift<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4) => TResult): LiftedFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>;
 }
 
 declare module "when" {
@@ -167,46 +305,11 @@ declare module "when" {
 declare module "when/node" {
     import when = require('when');
 
-    function lift<TResult>(fn: (callback: (err: any, result: TResult) => void) => void): () => when.Promise<TResult>;
-    function lift<TArg1, TResult>(fn: (arg1: TArg1, callback: (err: any, result: TResult) => void) => void): (arg1: when.Promise<TArg1>) => when.Promise<TResult>;
-    function lift<TArg1, TArg2, TResult>(fn: (arg1: TArg1, arg2: TArg2, callback: (err: any, result: TResult) => void) => void): (arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>) => when.Promise<TResult>;
-    function lift<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void): (arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>) => when.Promise<TResult>;
-
-
     function liftAll(srcApi: any, transform?: (destApi: any, liftedFunc: Function, name: string) => any, destApi?: any): any;
-
-
-    function call<TResult>(fn: (callback: (err: any, result: TResult) => void) => void): when.Promise<TResult>;
-
-    function call<TArg1, TResult>(fn: (arg1: TArg1, callback: (err: any, result: TResult) => void) => void, arg1: TArg1): when.Promise<TResult>;
-    function call<TArg1, TResult>(fn: (arg1: TArg1, callback: (err: any, result: TResult) => void) => void, arg1: when.Promise<TArg1>): when.Promise<TResult>;
-
-    function call<TArg1, TArg2, TResult>(fn: (arg1: TArg1, arg2: TArg2, callback: (err: any, result: TResult) => void) => void, arg1: TArg1, arg2: TArg2): when.Promise<TResult>;
-    function call<TArg1, TArg2, TResult>(fn: (arg1: TArg1, arg2: TArg2, callback: (err: any, result: TResult) => void) => void, arg1: when.Promise<TArg1>, arg2: TArg2): when.Promise<TResult>;
-    function call<TArg1, TArg2, TResult>(fn: (arg1: TArg1, arg2: TArg2, callback: (err: any, result: TResult) => void) => void, arg1: TArg1, arg2: when.Promise<TArg2>): when.Promise<TResult>;
-    function call<TArg1, TArg2, TResult>(fn: (arg1: TArg1, arg2: TArg2, callback: (err: any, result: TResult) => void) => void, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>): when.Promise<TResult>;
-
-    function call<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void, arg1: TArg1, arg2: TArg2, arg3: TArg3): when.Promise<TResult>;
-    function call<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void, arg1: TArg1, arg2: TArg2, arg3: when.Promise<TArg3>): when.Promise<TResult>;
-    function call<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void, arg1: TArg1, arg2: when.Promise<TArg2>, arg3: TArg3): when.Promise<TResult>;
-    function call<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void, arg1: TArg1, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>): when.Promise<TResult>;
-    function call<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void, arg1: when.Promise<TArg1>, arg2: TArg2, arg3: TArg3): when.Promise<TResult>;
-    function call<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void, arg1: when.Promise<TArg1>, arg2: TArg2, arg3: when.Promise<TArg3>): when.Promise<TResult>;
-    function call<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: TArg3): when.Promise<TResult>;
-    function call<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>): when.Promise<TResult>;
-
-
-    function apply<TResult>(fn: (callback: (err: any, result: TResult) => void) => void, args: any[]): when.Promise<TResult>;
-    function apply<TResult>(fn: (arg1: any, callback: (err: any, result: TResult) => void) => void, args: any[]): when.Promise<TResult>;
-    function apply<TResult>(fn: (arg1: any, arg2: any, callback: (err: any, result: TResult) => void) => void, args: any[]): when.Promise<TResult>;
-    function apply<TResult>(fn: (arg1: any, arg2: any, arg3: any, callback: (err: any, result: TResult) => void) => void, args: any[]): when.Promise<TResult>;
-
 
     function liftCallback<TArg>(callback: (err: any, arg: TArg) => void): (value: when.Promise<TArg>) => when.Promise<TArg>;
 
-
     function bindCallback<TArg>(arg: when.Promise<TArg>, callback: (err: any, arg: TArg) => void): when.Promise<TArg>;
-
 
     interface Resolver<T> {
         reject(reason: any): void;
@@ -215,4 +318,116 @@ declare module "when/node" {
     }
 
     function createCallback<TArg>(resolver: Resolver<TArg>): (err: any, arg: TArg) => void;
+
+
+    interface NodeFunction0<TResult> {
+        (callback: (err: any, result: TResult) => void): void;
+    }
+
+    interface NodeFunction1<TResult, TArg0> {
+        (arg0: TArg0, callback: (err: any, result: TResult) => void): void;
+    }
+
+    interface NodeFunction2<TResult, TArg0, TArg1> {
+        (arg0: TArg0, arg1: TArg1, callback: (err: any, result: TResult) => void): void;
+    }
+
+    interface NodeFunction3<TResult, TArg0, TArg1, TArg2> {
+        (arg0: TArg0, arg1: TArg1, arg2: TArg2, callback: (err: any, result: TResult) => void): void;
+    }
+
+    interface NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3> {
+        (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void): void;
+    }
+
+    interface NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4> {
+        (arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4, callback: (err: any, result: TResult) => void): void;
+    }
+
+
+    function lift<TResult>(fn: (callback: (err: any, result: TResult) => void) => void): () => when.Promise<TResult>;
+
+    function lift<TResult, TArg0>(f: NodeFunction1<TResult, TArg0>): when.LiftedFunction1<TResult, TArg0>;
+    function lift<TResult, TArg0, TArg1>(f: NodeFunction2<TResult, TArg0, TArg1>): when.LiftedFunction2<TResult, TArg0, TArg1>;
+    function lift<TResult, TArg0, TArg1, TArg2>(f: NodeFunction3<TResult, TArg0, TArg1, TArg2>): when.LiftedFunction3<TResult, TArg0, TArg1, TArg2>;
+    function lift<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>): when.LiftedFunction4<TResult, TArg0, TArg1, TArg2, TArg3>;
+    function lift<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>): when.LiftedFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>;
+
+    function call<TResult>(fn: (callback: (err: any, result: TResult) => void) => void): when.Promise<TResult>;
+
+    function call<TResult, TArg0>(f: NodeFunction1<TResult, TArg0>, arg0: TArg0): when.Promise<TResult>;
+    function call<TResult, TArg0>(f: NodeFunction1<TResult, TArg0>, arg0: when.Promise<TArg0>): when.Promise<TResult>;
+
+    function call<TResult, TArg0, TArg1>(f: NodeFunction2<TResult, TArg0, TArg1>, arg0: TArg0, arg1: TArg1): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1>(f: NodeFunction2<TResult, TArg0, TArg1>, arg0: TArg0, arg1: when.Promise<TArg1>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1>(f: NodeFunction2<TResult, TArg0, TArg1>, arg0: when.Promise<TArg0>, arg1: TArg1): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1>(f: NodeFunction2<TResult, TArg0, TArg1>, arg0: when.Promise<TArg0>, arg1: when.Promise<TArg1>): when.Promise<TResult>;
+
+    function call<TResult, TArg0, TArg1, TArg2>(f: NodeFunction3<TResult, TArg0, TArg1, TArg2>, arg0: TArg0, arg1: TArg1, arg2: TArg2): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2>(f: NodeFunction3<TResult, TArg0, TArg1, TArg2>, arg0: TArg0, arg1: TArg1, arg2: when.Promise<TArg2>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2>(f: NodeFunction3<TResult, TArg0, TArg1, TArg2>, arg0: TArg0, arg1: when.Promise<TArg1>, arg2: TArg2): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2>(f: NodeFunction3<TResult, TArg0, TArg1, TArg2>, arg0: TArg0, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2>(f: NodeFunction3<TResult, TArg0, TArg1, TArg2>, arg0: when.Promise<TArg0>, arg1: TArg1, arg2: TArg2): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2>(f: NodeFunction3<TResult, TArg0, TArg1, TArg2>, arg0: when.Promise<TArg0>, arg1: TArg1, arg2: when.Promise<TArg2>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2>(f: NodeFunction3<TResult, TArg0, TArg1, TArg2>, arg0: when.Promise<TArg0>, arg1: when.Promise<TArg1>, arg2: TArg2): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2>(f: NodeFunction3<TResult, TArg0, TArg1, TArg2>, arg0: when.Promise<TArg0>, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>): when.Promise<TResult>;
+
+    function call<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>, arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>, arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: when.Promise<TArg3>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>, arg0: TArg0, arg1: TArg1, arg2: when.Promise<TArg2>, arg3: TArg3): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>, arg0: TArg0, arg1: TArg1, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>, arg0: TArg0, arg1: when.Promise<TArg1>, arg2: TArg2, arg3: TArg3): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>, arg0: TArg0, arg1: when.Promise<TArg1>, arg2: TArg2, arg3: when.Promise<TArg3>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>, arg0: TArg0, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: TArg3): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>, arg0: TArg0, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>, arg0: when.Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: TArg3): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>, arg0: when.Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: when.Promise<TArg3>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>, arg0: when.Promise<TArg0>, arg1: TArg1, arg2: when.Promise<TArg2>, arg3: TArg3): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>, arg0: when.Promise<TArg0>, arg1: TArg1, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>, arg0: when.Promise<TArg0>, arg1: when.Promise<TArg1>, arg2: TArg2, arg3: TArg3): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>, arg0: when.Promise<TArg0>, arg1: when.Promise<TArg1>, arg2: TArg2, arg3: when.Promise<TArg3>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>, arg0: when.Promise<TArg0>, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: TArg3): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3>(f: NodeFunction4<TResult, TArg0, TArg1, TArg2, TArg3>, arg0: when.Promise<TArg0>, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>): when.Promise<TResult>;
+
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: when.Promise<TArg4>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: when.Promise<TArg3>, arg4: TArg4): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: TArg0, arg1: TArg1, arg2: TArg2, arg3: when.Promise<TArg3>, arg4: when.Promise<TArg4>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: TArg0, arg1: TArg1, arg2: when.Promise<TArg2>, arg3: TArg3, arg4: TArg4): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: TArg0, arg1: TArg1, arg2: when.Promise<TArg2>, arg3: TArg3, arg4: when.Promise<TArg4>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: TArg0, arg1: TArg1, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>, arg4: TArg4): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: TArg0, arg1: TArg1, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>, arg4: when.Promise<TArg4>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: TArg0, arg1: when.Promise<TArg1>, arg2: TArg2, arg3: TArg3, arg4: TArg4): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: TArg0, arg1: when.Promise<TArg1>, arg2: TArg2, arg3: TArg3, arg4: when.Promise<TArg4>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: TArg0, arg1: when.Promise<TArg1>, arg2: TArg2, arg3: when.Promise<TArg3>, arg4: TArg4): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: TArg0, arg1: when.Promise<TArg1>, arg2: TArg2, arg3: when.Promise<TArg3>, arg4: when.Promise<TArg4>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: TArg0, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: TArg3, arg4: TArg4): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: TArg0, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: TArg3, arg4: when.Promise<TArg4>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: TArg0, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>, arg4: TArg4): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: TArg0, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>, arg4: when.Promise<TArg4>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: when.Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: TArg4): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: when.Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: TArg3, arg4: when.Promise<TArg4>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: when.Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: when.Promise<TArg3>, arg4: TArg4): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: when.Promise<TArg0>, arg1: TArg1, arg2: TArg2, arg3: when.Promise<TArg3>, arg4: when.Promise<TArg4>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: when.Promise<TArg0>, arg1: TArg1, arg2: when.Promise<TArg2>, arg3: TArg3, arg4: TArg4): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: when.Promise<TArg0>, arg1: TArg1, arg2: when.Promise<TArg2>, arg3: TArg3, arg4: when.Promise<TArg4>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: when.Promise<TArg0>, arg1: TArg1, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>, arg4: TArg4): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: when.Promise<TArg0>, arg1: TArg1, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>, arg4: when.Promise<TArg4>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: when.Promise<TArg0>, arg1: when.Promise<TArg1>, arg2: TArg2, arg3: TArg3, arg4: TArg4): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: when.Promise<TArg0>, arg1: when.Promise<TArg1>, arg2: TArg2, arg3: TArg3, arg4: when.Promise<TArg4>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: when.Promise<TArg0>, arg1: when.Promise<TArg1>, arg2: TArg2, arg3: when.Promise<TArg3>, arg4: TArg4): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: when.Promise<TArg0>, arg1: when.Promise<TArg1>, arg2: TArg2, arg3: when.Promise<TArg3>, arg4: when.Promise<TArg4>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: when.Promise<TArg0>, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: TArg3, arg4: TArg4): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: when.Promise<TArg0>, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: TArg3, arg4: when.Promise<TArg4>): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: when.Promise<TArg0>, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>, arg4: TArg4): when.Promise<TResult>;
+    function call<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>(f: NodeFunction5<TResult, TArg0, TArg1, TArg2, TArg3, TArg4>, arg0: when.Promise<TArg0>, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>, arg4: when.Promise<TArg4>): when.Promise<TResult>;
+
+
+
+    function apply<TResult>(fn: (callback: (err: any, result: TResult) => void) => void, args: any[]): when.Promise<TResult>;
+    function apply<TResult>(fn: (arg1: any, callback: (err: any, result: TResult) => void) => void, args: any[]): when.Promise<TResult>;
+    function apply<TResult>(fn: (arg1: any, arg2: any, callback: (err: any, result: TResult) => void) => void, args: any[]): when.Promise<TResult>;
+    function apply<TResult>(fn: (arg1: any, arg2: any, arg3: any, callback: (err: any, result: TResult) => void) => void, args: any[]): when.Promise<TResult>;
 }
+
+// vim:ft=typescript:sw=4:ts=4:et:

--- a/when/when.d.ts.ejs
+++ b/when/when.d.ts.ejs
@@ -1,0 +1,283 @@
+// Type definitions for When 2.4.0
+// Project: https://github.com/cujojs/when
+// Definitions by: Derek Cicerone <https://github.com/derekcicerone>, Wim Looman <https://github.com/Nemo157>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+// This file is <( 'not' )>generated, please change when.d.ts.ejs and run
+// `npm install && npm run build` in the `when` directory to update it.
+
+declare function When<T>(value: When.Promise<T>): When.Promise<T>;
+declare function When<T>(value: When.Thenable<T>): When.Promise<T>;
+declare function When<T>(value: T): When.Promise<T>;
+
+declare function When<T, U>(value: When.Promise<T>, transform: (val: T) => U): When.Promise<U>;
+declare function When<T, U>(value: When.Thenable<T>, transform: (val: T) => U): When.Promise<U>;
+declare function When<T, U>(value: T, transform: (val: T) => U): When.Promise<U>;
+
+<(
+    function combinations(count) {
+        if (count === 0) {
+            return [[]];
+        } else {
+            var result = [];
+            combinations(count - 1).forEach(function (combination) {
+                result.push(combination.concat(false));
+                result.push(combination.concat(true));
+            });
+            return result;
+        }
+    }
+
+    var allCombinations = [];
+    (function () {
+        for (var i = 0; i < 5; i++) {
+            allCombinations.push(combinations(i + 1));
+        }
+    })();
+
+    function TArgs(combination) {
+        combination.forEach(function (isPromise, i) {
+            )>TArg<(=i)><(
+            if (i != combination.length - 1) {
+                )>, <(
+            }
+        });
+    }
+
+    function args(combination) {
+        combination.forEach(function (isPromise, i) {
+            )>arg<(=i)>: TArg<(=i)><(
+            if (i != combination.length - 1) {
+                )>, <(
+            }
+        });
+    }
+
+    function PromiseArgs(combination, prefix) {
+        combination.forEach(function (isPromise, i) {
+            if (isPromise) {
+                )>arg<(=i)>: <(=prefix || '')>Promise<TArg<(=i)>><(
+            } else {
+                )>arg<(=i)>: TArg<(=i)><(
+            }
+            if (i != combination.length - 1) {
+                )>, <(
+            }
+        });
+    }
+)>
+
+declare module When {
+    function promise<T>(resolver: (resolve: (value: T) => void, reject: (reason: any) => void) => void): Promise<T>;
+
+    function reject<T>(reason: any): Promise<T>;
+
+    /**
+     * Return a promise that will resolve only once all the supplied promisesOrValues
+     * have resolved. The resolution value of the returned promise will be an array
+     * containing the resolution values of each of the promisesOrValues.
+     * @memberOf when
+     *
+     * @param promisesOrValues array of anything, may contain a mix
+     *      of {@link Promise}s and values
+     */
+    function all<T>(promisesOrValues: any[]): Promise<T>;
+
+    /**
+     * Creates a {promise, resolver} pair, either or both of which
+     * may be given out safely to consumers.
+     * The resolver has resolve, reject, and progress.  The promise
+     * has then plus extended promise API.
+     */
+    function defer<T>(): Deferred<T>;
+
+    /**
+     * Joins multiple promises into a single returned promise.
+     * @return a promise that will fulfill when *all* the input promises
+     * have fulfilled, or will reject when *any one* of the input promises rejects.
+     */
+    function join<T>(...promises: Promise<T>[]): Promise<T[]>;
+    /**
+     * Joins multiple promises into a single returned promise.
+     * @return a promise that will fulfill when *all* the input promises
+     * have fulfilled, or will reject when *any one* of the input promises rejects.
+     */
+    function join<T>(...promises: any[]): Promise<T[]>;
+
+    /**
+     * Returns a resolved promise. The returned promise will be
+     *  - fulfilled with promiseOrValue if it is a value, or
+     *  - if promiseOrValue is a promise
+     *    - fulfilled with promiseOrValue's value after it is fulfilled
+     *    - rejected with promiseOrValue's reason after it is rejected
+     */
+    function resolve<T>(promise: Promise<T>): Promise<T>;
+    function resolve<T>(foreign: Thenable<T>): Promise<T>;
+    function resolve<T>(value?: T): Promise<T>;
+
+    interface Deferred<T> {
+        notify(update: any): void;
+        promise: Promise<T>;
+        reject(reason: any): void;
+        resolve(value?: T): void;
+        resolve(value?: Promise<T>): void;
+    }
+
+    interface Promise<T> {
+        catch<U>(onRejected?: (reason: any) => Promise<U>): Promise<U>;
+        catch<U>(onRejected?: (reason: any) => U): Promise<U>;
+
+        catch<U>(filter: (reason: any) => boolean, onRejected?: (reason: any) => Promise<U>): Promise<U>;
+        catch<U>(filter: (reason: any) => boolean, onRejected?: (reason: any) => U): Promise<U>;
+
+        // Make sure you test any usage of these overloads, exceptionType must
+        // be a constructor with prototype set to an instance of Error.
+        catch<U>(exceptionType: any, onRejected?: (reason: any) => Promise<U>): Promise<U>;
+        catch<U>(exceptionType: any, onRejected?: (reason: any) => U): Promise<U>;
+
+        finally(onFulfilledOrRejected: Function): Promise<T>;
+
+        ensure(onFulfilledOrRejected: Function): Promise<T>;
+
+        inspect(): Snapshot<T>;
+
+        yield<U>(value: Promise<U>): Promise<U>;
+        yield<U>(value: U): Promise<U>;
+
+        else(value: T): Promise<T>;
+        orElse(value: T): Promise<T>;
+
+        tap(onFulfilledSideEffect: (value: T) => void): Promise<T>;
+
+        delay(milliseconds: number): Promise<T>;
+
+        timeout(milliseconds: number, reason?: any): Promise<T>;
+
+        with(thisArg: any): Promise<T>;
+        withThis(thisArg: any): Promise<T>;
+
+        otherwise<U>(onRejected?: (reason: any) => Promise<U>): Promise<U>;
+        otherwise<U>(onRejected?: (reason: any) => U): Promise<U>;
+
+        otherwise<U>(predicate: (reason: any) => boolean, onRejected?: (reason: any) => Promise<U>): Promise<U>;
+        otherwise<U>(predicate: (reason: any) => boolean, onRejected?: (reason: any) => U): Promise<U>;
+
+        // Make sure you test any usage of these overloads, exceptionType must
+        // be a constructor with prototype set to an instance of Error.
+        otherwise<U>(exceptionType: any, onRejected?: (reason: any) => Promise<U>): Promise<U>;
+        otherwise<U>(exceptionType: any, onRejected?: (reason: any) => U): Promise<U>;
+
+        then<U>(onFulfilled: (value: T) => Promise<U>, onRejected?: (reason: any) => Promise<U>, onProgress?: (update: any) => void): Promise<U>;
+        then<U>(onFulfilled: (value: T) => Promise<U>, onRejected?: (reason: any) => U, onProgress?: (update: any) => void): Promise<U>;
+        then<U>(onFulfilled: (value: T) => U, onRejected?: (reason: any) => Promise<U>, onProgress?: (update: any) => void): Promise<U>;
+        then<U>(onFulfilled: (value: T) => U, onRejected?: (reason: any) => U, onProgress?: (update: any) => void): Promise<U>;
+
+        done<U>(onFulfilled: (value: T) => void, onRejected?: (reason: any) => void): void;
+
+        fold<U, V>(combine: (value1: T, value2: V) => Promise<U>, value2: V): Promise<U>;
+        fold<U, V>(combine: (value1: T, value2: V) => Promise<U>, value2: Promise<V>): Promise<U>;
+
+        fold<U, V>(combine: (value1: T, value2: V) => U, value2: V): Promise<U>;
+        fold<U, V>(combine: (value1: T, value2: V) => U, value2: Promise<V>): Promise<U>;
+    }
+
+    interface Thenable<T> {
+        then<U>(onFulfilled: (value: T) => U, onRejected?: (reason: any) => U): Thenable<U>;
+    }
+
+    interface Snapshot<T> {
+        state: string;
+        value?: T;
+        reason?: any;
+    }
+
+<(
+allCombinations.forEach(function (combinations) {
+)>
+    interface LiftedFunction<(=combinations[0].length)><TResult, <( TArgs(combinations[0]) )>> {<(
+    combinations.forEach(function (combination) {
+)>
+        (<( PromiseArgs(combination) )>): Promise<TResult>;<(
+    });
+)>
+    }
+<( });)>
+
+    function attempt<T>(f: () => T): Promise<T>;
+<(
+allCombinations.forEach(function (combinations) {
+    combinations.forEach(function (combination) {
+)>
+    function attempt<TResult, <( TArgs(combination) )>>(f: (<( args(combination) )>) => TResult, <( PromiseArgs(combination) )>): Promise<TResult>;<(
+    });
+)>
+<( });)>
+
+    function lift<T>(f: () => T): () => Promise<T>;
+<(
+allCombinations.forEach(function (combinations) {
+)>
+    function lift<TResult, <( TArgs(combinations[0]) )>>(f: (<( args(combinations[0]) )>) => TResult): LiftedFunction<(=combinations[0].length)><TResult, <( TArgs(combinations[0]) )>>;<(
+    });
+)>
+}
+
+declare module "when" {
+    export = When;
+}
+
+declare module "when/node" {
+    import when = require('when');
+
+    function liftAll(srcApi: any, transform?: (destApi: any, liftedFunc: Function, name: string) => any, destApi?: any): any;
+
+    function liftCallback<TArg>(callback: (err: any, arg: TArg) => void): (value: when.Promise<TArg>) => when.Promise<TArg>;
+
+    function bindCallback<TArg>(arg: when.Promise<TArg>, callback: (err: any, arg: TArg) => void): when.Promise<TArg>;
+
+    interface Resolver<T> {
+        reject(reason: any): void;
+        resolve(value?: T): void;
+        resolve(value?: when.Promise<T>): void;
+    }
+
+    function createCallback<TArg>(resolver: Resolver<TArg>): (err: any, arg: TArg) => void;
+
+
+    interface NodeFunction0<TResult> {
+        (callback: (err: any, result: TResult) => void): void;
+    }
+<(
+allCombinations.forEach(function (combinations) {
+)>
+    interface NodeFunction<(=combinations[0].length)><TResult, <( TArgs(combinations[0]) )>> {
+        (<( args(combinations[0]) )>, callback: (err: any, result: TResult) => void): void;
+    }
+<( });)>
+
+    function lift<TResult>(fn: (callback: (err: any, result: TResult) => void) => void): () => when.Promise<TResult>;
+<(
+allCombinations.forEach(function (combinations) {
+)>
+    function lift<TResult, <( TArgs(combinations[0]) )>>(f: NodeFunction<(=combinations[0].length)><TResult, <( TArgs(combinations[0]) )>>): when.LiftedFunction<(=combinations[0].length)><TResult, <( TArgs(combinations[0]) )>>;<(
+    });
+)>
+
+    function call<TResult>(fn: (callback: (err: any, result: TResult) => void) => void): when.Promise<TResult>;
+<(
+allCombinations.forEach(function (combinations) {
+    combinations.forEach(function (combination) {
+)>
+    function call<TResult, <( TArgs(combination) )>>(f: NodeFunction<(=combination.length)><TResult, <( TArgs(combination) )>>, <( PromiseArgs(combination, 'when.') )>): when.Promise<TResult>;<(
+    });
+)>
+<( });)>
+
+
+    function apply<TResult>(fn: (callback: (err: any, result: TResult) => void) => void, args: any[]): when.Promise<TResult>;
+    function apply<TResult>(fn: (arg1: any, callback: (err: any, result: TResult) => void) => void, args: any[]): when.Promise<TResult>;
+    function apply<TResult>(fn: (arg1: any, arg2: any, callback: (err: any, result: TResult) => void) => void, args: any[]): when.Promise<TResult>;
+    function apply<TResult>(fn: (arg1: any, arg2: any, arg3: any, callback: (err: any, result: TResult) => void) => void, args: any[]): when.Promise<TResult>;
+}
+
+// vim:ft=typescript:sw=4:ts=4:et:


### PR DESCRIPTION
Not sure if there's any existing policy on generating the definition files, but this is the only way I could see to actually define anything over 3 argument variants without a massive hassle changing them. Even 3 arguments was getting a bit much to hand type.
