### PR TITLE
Fix type of ElementFinder's IThenable interface

### DIFF
--- a/angular-protractor/angular-protractor.d.ts
+++ b/angular-protractor/angular-protractor.d.ts
@@ -534,7 +534,7 @@ declare module protractor {
         all(locator: webdriver.Locator): ElementArrayFinder;
     }
 
-    interface ElementFinder extends webdriver.IWebElement, webdriver.promise.IThenable<ElementFinder> {
+    interface ElementFinder extends webdriver.IWebElement, webdriver.promise.IThenable<any> {
         /**
         * Calls to element may be chained to find elements within a parent.
         *
@@ -700,103 +700,6 @@ declare module protractor {
         * @return {ElementFinder} which resolves to whether animation is allowed.
         */
         allowAnimations(value: string): ElementFinder;
-
-        /**
-         * Cancels the computation of this promise's value, rejecting the promise in the
-         * process. This method is a no-op if the promise has alreayd been resolved.
-         *
-         * @param {string=} opt_reason The reason this promise is being cancelled.
-         */
-        cancel(opt_reason?: string): void;
-
-
-        /** @return {boolean} Whether this promise's value is still being computed. */
-        isPending(): boolean;
-
-
-        /**
-         * Registers listeners for when this instance is resolved.
-         *
-         * @param {?(function(T): (R|webdriver.promise.Promise.<R>))=} opt_callback The
-         *     function to call if this promise is successfully resolved. The function
-         *     should expect a single argument: the promise's resolved value.
-         * @param {?(function(*): (R|webdriver.promise.Promise.<R>))=} opt_errback The
-         *     function to call if this promise is rejected. The function should expect
-         *     a single argument: the rejection reason.
-         * @return {!webdriver.promise.Promise.<R>} A new promise which will be
-         *     resolved with the result of the invoked callback.
-         * @template R
-         */
-        then<R>(opt_callback?: (value: ElementFinder) => any, opt_errback?: (error: any) => any): webdriver.promise.Promise<R>;
-
-
-        /**
-         * Registers a listener for when this promise is rejected. This is synonymous
-         * with the {@code catch} clause in a synchronous API:
-         * <pre><code>
-         *   // Synchronous API:
-         *   try {
-         *     doSynchronousWork();
-         *   } catch (ex) {
-         *     console.error(ex);
-         *   }
-         *
-         *   // Asynchronous promise API:
-         *   doAsynchronousWork().thenCatch(function(ex) {
-         *     console.error(ex);
-         *   });
-         * </code></pre>
-         *
-         * @param {function(*): (R|webdriver.promise.Promise.<R>)} errback The function
-         *     to call if this promise is rejected. The function should expect a single
-         *     argument: the rejection reason.
-         * @return {!webdriver.promise.Promise.<R>} A new promise which will be
-         *     resolved with the result of the invoked callback.
-         * @template R
-         */
-        thenCatch<R>(errback: (error: any) => any): webdriver.promise.Promise<R>;
-
-
-        /**
-         * Registers a listener to invoke when this promise is resolved, regardless
-         * of whether the promise's value was successfully computed. This function
-         * is synonymous with the {@code finally} clause in a synchronous API:
-         * <pre><code>
-         *   // Synchronous API:
-         *   try {
-         *     doSynchronousWork();
-         *   } finally {
-         *     cleanUp();
-         *   }
-         *
-         *   // Asynchronous promise API:
-         *   doAsynchronousWork().thenFinally(cleanUp);
-         * </code></pre>
-         *
-         * <b>Note:</b> similar to the {@code finally} clause, if the registered
-         * callback returns a rejected promise or throws an error, it will silently
-         * replace the rejection error (if any) from this promise:
-         * <pre><code>
-         *   try {
-         *     throw Error('one');
-         *   } finally {
-         *     throw Error('two');  // Hides Error: one
-         *   }
-         *
-         *   webdriver.promise.rejected(Error('one'))
-         *       .thenFinally(function() {
-         *         throw Error('two');  // Hides Error: one
-         *       });
-         * </code></pre>
-         *
-         *
-         * @param {function(): (R|webdriver.promise.Promise.<R>)} callback The function
-         *     to call when this promise is resolved.
-         * @return {!webdriver.promise.Promise.<R>} A promise that will be fulfilled
-         *     with the callback result.
-         * @template R
-         */
-        thenFinally<R>(callback: () => any): webdriver.promise.Promise<R>;
 
         /**
         * Create a shallow copy of ElementFinder.


### PR DESCRIPTION
There are 2 edits here:
1. Remove unnecessarily overridden methods in ElementFinder (they are defined in IThenable).
2. Change the parameterized type in IThenable to 'any' to account for things like ElementFinder.evaluate() which may return primitive values.
