### PR TITLE
add createMediaStreamDestination

### DIFF
--- a/webaudioapi/waa.d.ts
+++ b/webaudioapi/waa.d.ts
@@ -87,6 +87,11 @@ interface AudioContext {
     createMediaStreamSource(mediaStream: any): MediaStreamAudioSourceNode;
 
     /**
+     * Creates a MediaStreamAudioDestinationNode.
+     */
+    createMediaStreamDestination(): MediaStreamAudioDestinationNode;
+
+    /**
      * Creates a ScriptProcessorNode for direct audio processing using JavaScript. An exception will be thrown if bufferSize or numberOfInputChannels or numberOfOutputChannels are outside the valid range.
      * It is invalid for both numberOfInputChannels and numberOfOutputChannels to be zero.
      * @param bufferSize  the buffer size in units of sample-frames. It must be one of the following values: 256, 512, 1024, 2048, 4096, 8192, 16384. This value controls how frequently the onaudioprocess event handler is called and how many sample-frames need to be processed each call. Lower values for bufferSize will result in a lower (better) latency. Higher values will be necessary to avoid audio breakup and glitches. The value chosen must carefully balance between latency and audio quality.
@@ -1141,4 +1146,18 @@ interface WaveTable {
  *    numberOfOutputs : 1
  */
 interface MediaStreamAudioSourceNode extends AudioSourceNode {
+}
+
+/**
+ * This interface is an audio destination representing a MediaStream with a single AudioMediaStreamTrack. This MediaStream is created when the node is created and is accessible via the stream attribute. This stream can be used in a similar way as a MediaStream obtained via getUserMedia(), and can, for example, be sent to a remote peer using the RTCPeerConnection addStream() method.
+ *
+ *    numberOfInputs  : 1
+ *    numberOfOutputs : 0
+ *
+ *    channelCount = 2;
+ *    channelCountMode = "explicit";
+ *    channelInterpretation = "speakers";
+ */
+interface MediaStreamAudioDestinationNode extends AudioNode {
+  stream: MediaStream;
 }

--- a/webaudioapi/waa.d.ts
+++ b/webaudioapi/waa.d.ts
@@ -1159,5 +1159,5 @@ interface MediaStreamAudioSourceNode extends AudioSourceNode {
  *    channelInterpretation = "speakers";
  */
 interface MediaStreamAudioDestinationNode extends AudioNode {
-  stream: MediaStream;
+  stream: any;
 }


### PR DESCRIPTION
methods and interface are defined in http://webaudio.github.io/web-audio-api/ and implemented in latest chrome versions

I'm not sure to really undertsand how the directory is organized with waa.d.ts, waa-nightly.d.ts and waa-2012-08-02.d.ts, my understanding was that this should only go to waa.d.ts (according to the specs referenced in headers), and also not in test file.
