### PR TITLE
[touch-events] Index TouchList as array

### DIFF
--- a/touch-events/touch-event-tests.ts
+++ b/touch-events/touch-event-tests.ts
@@ -16,6 +16,7 @@ flag = touchEvent.shiftKey;
 
 var len:number = list.length;
 touch = list.item(0);
+touch == list[0];
 
 var x: number;
 var y: number;

--- a/touch-events/touch-events.d.ts
+++ b/touch-events/touch-events.d.ts
@@ -16,6 +16,7 @@ interface TouchEvent extends UIEvent {
 interface TouchList {
     length: number;
     item: (index: number) => Touch;
+    [index: number]: Touch;
 }
 
 interface Touch {


### PR DESCRIPTION
myTouchList[123] is allowed as an alias for myTouchList.item(123).

https://developer.mozilla.org/en-US/docs/Web/API/TouchList
and
http://www.w3.org/TR/touch-events/#idl-def-TouchList

Tested the proposed change on ff mobile, works fine. Didn't check the -test.ts file, should be fine too.
