### PR TITLE
Fix class name

### DIFF
--- a/google.feeds/google.feed.api.d.ts
+++ b/google.feeds/google.feed.api.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module google.feeds {
-    export class feed {
+    export class Feed {
         constructor();
         constructor(url: string);
         findFeeds(query?: string, callback?: (result: findResult) => void ): void;


### PR DESCRIPTION
"feed" in the case of an error occurs during instantiation. (Uncaught TypeError: undefined is not a function)
If you are are If described as intentionally "feed", please let me know the reason.
