### PR TITLE
modified xregexp.d.ts

### DIFF
--- a/xregexp/xregexp-tests.ts
+++ b/xregexp/xregexp-tests.ts
@@ -9,6 +9,7 @@ import TokenOpts = X.TokenOpts;
 var exp: RegExp;
 var expArr: RegExp[];
 var chain: RegExp[];
+var groupChain: { regex: RegExp; backref: string }[];
 var regex: RegExp;
 var value: any;
 var str: string;
@@ -91,6 +92,7 @@ XRegExp.install(obj);
 bool = XRegExp.isInstalled(str);
 bool = XRegExp.isRegExp(value);
 strArr = XRegExp.matchChain(str, chain);
+strArr = XRegExp.matchChain(str, groupChain);
 
 // --  --  --  --  --  --  --  --  --  --  --  --  --
 

--- a/xregexp/xregexp-tests.ts
+++ b/xregexp/xregexp-tests.ts
@@ -10,6 +10,7 @@ var exp: RegExp;
 var expArr: RegExp[];
 var chain: RegExp[];
 var groupChain: { regex: RegExp; backref: string }[];
+var groupChain1: { regex: RegExp; backref: number }[];
 var regex: RegExp;
 var value: any;
 var str: string;
@@ -93,6 +94,7 @@ bool = XRegExp.isInstalled(str);
 bool = XRegExp.isRegExp(value);
 strArr = XRegExp.matchChain(str, chain);
 strArr = XRegExp.matchChain(str, groupChain);
+strArr = XRegExp.matchChain(str, groupChain1);
 
 // --  --  --  --  --  --  --  --  --  --  --  --  --
 

--- a/xregexp/xregexp.d.ts
+++ b/xregexp/xregexp.d.ts
@@ -41,6 +41,7 @@ declare module 'xregexp' {
 		function isInstalled(feature: string): boolean;
 		function isRegExp(value: any): boolean;
 		function matchChain(str: string, chain: RegExp[]): string[];
+		function matchChain(str: string, chain: { regex: RegExp; backref: string }[]): string[];
 		function matchRecursive(str: string, left: string, right: string, flags?: string, options?: Object): string[];
 
 		function replace(str: string, search: string, replacement: string, scope?: string): string;

--- a/xregexp/xregexp.d.ts
+++ b/xregexp/xregexp.d.ts
@@ -42,6 +42,7 @@ declare module 'xregexp' {
 		function isRegExp(value: any): boolean;
 		function matchChain(str: string, chain: RegExp[]): string[];
 		function matchChain(str: string, chain: { regex: RegExp; backref: string }[]): string[];
+		function matchChain(str: string, chain: { regex: RegExp; backref: number }[]): string[];
 		function matchRecursive(str: string, left: string, right: string, flags?: string, options?: Object): string[];
 
 		function replace(str: string, search: string, replacement: string, scope?: string): string;


### PR DESCRIPTION
// Matchception: Finding matches within matches, while passing forward and
// returning specific backreferences
html = '<a href="http://xregexp.com/api/">XRegExp</a>' +
       '<a href="http://www.google.com/">Google</a>';
XRegExp.matchChain(html, [
  {regex: /<a href="([^"]+)">/i, backref: 1},
  {regex: XRegExp('(?i)^https?://(?<domain>[^/?#]+)'), backref: 'domain'}
]);
// -> ['xregexp.com', 'www.google.com']
