### PR TITLE
Fix node-zeromq ArrayBuffer type to Buffer

### DIFF
--- a/node_zeromq/zmq-tests.ts
+++ b/node_zeromq/zmq-tests.ts
@@ -11,7 +11,7 @@ function test1() {
 function test2() {
     var sock = zmq.socket('push');
     sock.bindSync('tcp://127.0.0.1:3000');
-    sock.send(new ArrayBuffer(1000));
+    sock.send(new Buffer(1000));
 }
 
 function test3() {

--- a/node_zeromq/zmq.d.ts
+++ b/node_zeromq/zmq.d.ts
@@ -133,10 +133,10 @@ declare module 'zmq' {
         /**
          * Send the given `msg`.
          *
-         * @param msg The message
-         * @param flags Message flags
+         * @param msg {Buffer} The message
+         * @param flags {number} Optional message flags
          */
-        send(msg: ArrayBuffer, flags?: number): Socket;
+        send(msg: Buffer, flags?: number): Socket;
 
         /**
         * Send the given `msg`.


### PR DESCRIPTION
I noticed (the hard way) that node-zeromq expects a Node.js Buffer, not an ArrayBuffer.

The function is defined here:
https://github.com/JustinTulloss/zeromq.node/blob/master/lib/index.js#L444
