### PR TITLE
express Response.sendStatus returns Response (not a Send object)

### DIFF
--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -438,7 +438,7 @@ declare module "express" {
              * 
              * @param code
              */
-            sendStatus(code: number): Send;
+            sendStatus(code: number): Response;
             
             /**
              * Set Link header field with the given `links`.


### PR DESCRIPTION
Note that in express.Response sendStatus returns `send(body)`...
https://github.com/strongloop/express/blob/master/lib/response.js#L327

...which returns `this` (Response object)...
https://github.com/strongloop/express/blob/master/lib/response.js#L193
