### PR TITLE
Values in localStorage are not only strings

### DIFF
--- a/angular-local-storage/angular-local-storage-tests.ts
+++ b/angular-local-storage/angular-local-storage-tests.ts
@@ -14,7 +14,7 @@ interface TestScope extends ng.IScope {
 
 module ng.local.storage.tests {
   export class TestController {
-    constructor($scope: TestScope, localStorageService: ng.local.storage.ILocalStorageService) {
+    constructor($scope: TestScope, localStorageService: ng.local.storage.ILocalStorageService<string>) {
       // isSupported
       if (localStorageService.isSupported) {
         // do something

--- a/angular-local-storage/angular-local-storage.d.ts
+++ b/angular-local-storage/angular-local-storage.d.ts
@@ -75,7 +75,7 @@ declare module ng.local.storage {
 
   }
 
-  interface ILocalStorageService {
+  interface ILocalStorageService<T> {
     /**
      * Checks if the browser support the current storage type(e.g: localStorage, sessionStorage).
      * Returns: Boolean
@@ -99,7 +99,7 @@ declare module ng.local.storage {
      * Returns: value from local storage
      * @param key
      */
-    get(key: string): string;
+    get(key: string): T;
     /**
      * Return array of keys for local storage, ignore keys that not owned.
      * Returns: value from local storage

--- a/angular-local-storage/angular-local-storage.d.ts
+++ b/angular-local-storage/angular-local-storage.d.ts
@@ -92,7 +92,7 @@ declare module ng.local.storage {
      * @param key
      * @param value
      */
-    set(key: string, value: string): boolean;
+    set(key: string, value: T): boolean;
     /**
      * Directly get a value from local storage.
      * If local storage is not supported, use cookies instead.


### PR DESCRIPTION
The user of the lib can put all types of values into localStorage. So the ILocalStorageService should be a generic.

Any issues regarding this change?
