### PR TITLE
Makes `require` generic in node.d.ts

### DIFF
--- a/browserify/browserify-tests.ts
+++ b/browserify/browserify-tests.ts
@@ -8,5 +8,5 @@ b.add('./browser/main.js');
 b.transform('deamdify');
 b.bundle().pipe(fs.createWriteStream('bundle.js'));
 
-var customBrowsify: Browserify = require("browserify");
+var customBrowsify = require<Browserify>("browserify");
 customBrowsify({entries: []});

--- a/commander/commander-tests.ts
+++ b/commander/commander-tests.ts
@@ -1,7 +1,7 @@
 ///<reference path="commander.d.ts"/>
 
 // NOTE: import statement can not use in TypeScript 1.0.1
-var program:commander.IExportedCommand = require('commander');
+var program = require<commander.IExportedCommand>('commander');
 
 declare module commander {
     interface IExportedCommand {

--- a/each/each-tests.ts
+++ b/each/each-tests.ts
@@ -36,6 +36,6 @@ function testEach() {
 
 	var each: Each = EachStaticClass([1, 2, 3]);
 
-	var EachReq: EachStatic = require("each");
+	var EachReq = require<EachStatic>("each");
 	var each: Each = EachReq([4, 5, 6]);
 }

--- a/express/express-tests.ts
+++ b/express/express-tests.ts
@@ -3,8 +3,8 @@
 import express = require('express');
 var app = express();
 
-app.engine('jade', require('jade').__express);
-app.engine('html', require('ejs').renderFile);
+app.engine('jade', require<any>('jade').__express);  // TODO: use import for jade and ejs
+app.engine('html', require<any>('ejs').renderFile);
 
 app.use('/static', express.static(__dirname + '/public'));
 

--- a/gulp-util/gulp-util-tests.ts
+++ b/gulp-util/gulp-util-tests.ts
@@ -10,7 +10,7 @@ import path = require('path');
 import should = require('should');
 import Stream = require('stream');
 import through = require('through2');
-var es = require('event-stream');
+var es = require<any>('event-stream'); // TODO: reference event-stream.d.ts and use import
 
 // ReSharper disable WrongExpressionStatement
 describe('File()', () => {
@@ -219,7 +219,7 @@ describe('template()', () => {
 	//});
 
 	it('should ignore modified templateSettings', done => {
-		var templateSettings = require('lodash.templatesettings');
+		var templateSettings = require<any>('lodash.templatesettings');
 		templateSettings.interpolate = /\{\{([\s\S]+?)\}\}/g;
 
 		var opt = {

--- a/imap/imap-tests.ts
+++ b/imap/imap-tests.ts
@@ -9,8 +9,10 @@
 
 
 import Imap     = require('imap');
+import fs       = require('fs');
 import util     = require('util');
 import inspect  = util.inspect;
+
 
 var imap = new Imap({
     user: 'mygmailname@gmail.com',
@@ -119,8 +121,6 @@ openInbox(function(err : Error, box : IMAP.Box) {
 
 
 // using the functions and variables already defined in the first example ...
-
-var fs = require('fs');
 
 openInbox(function(err : Error, box : IMAP.Box) {
     if (err) throw err;

--- a/jake/jake-tests.ts
+++ b/jake/jake-tests.ts
@@ -2,6 +2,7 @@
 /// <reference path="jake.d.ts" />
 
 import path = require("path");
+import assert = require('assert');
 
 desc('This is the default task.');
 task('default', function (params) {
@@ -234,8 +235,7 @@ var t = new jake.TestTask('fonebone', function () {
   this.testName = 'testMainAndAdapters';
 });
 
-var assert = require('assert')
-  , tests;
+var tests;
 
 tests = {
   'sync test': function () {

--- a/mongodb/mongodb-tests.ts
+++ b/mongodb/mongodb-tests.ts
@@ -3,8 +3,8 @@
 // Test source : https://github.com/mongodb/node-mongodb-native
 import mongodb = require('mongodb');
 var MongoClient = mongodb.MongoClient;
-
-var format = require('util').format;
+import util = require('util');
+var format = util.format;
 MongoClient.connect('mongodb://127.0.0.1:27017/test', function (err, db) {
     if (err) throw err;
 

--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="mongoose.d.ts" />
 
-var fs = require('fs');
+import fs = require('fs');
 import mongoose = require('mongoose');
 
 var createInstance = new mongoose.Mongoose();

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -28,7 +28,7 @@ declare function setImmediate(callback: (...args: any[]) => void, ...args: any[]
 declare function clearImmediate(immediateId: any): void;
 
 declare var require: {
-    (id: string): any;
+    <TModule>(id: string): TModule;
     resolve(id:string): string;
     cache: any;
     extensions: any;

--- a/q-io/Q-io-tests.ts
+++ b/q-io/Q-io-tests.ts
@@ -1,8 +1,8 @@
 /// <reference path="../q/Q.d.ts" />
 /// <reference path="Q-io.d.ts" />
 
-var fs:typeof QioFS = require('q-io/fs');
-var http:typeof QioHTTP = require('q-io/http');
+var fs = require<typeof QioFS>('q-io/fs');
+var http = require<typeof QioHTTP>('q-io/http');
 
 var bool:boolean;
 var num:number;

--- a/stylus/stylus-tests.ts
+++ b/stylus/stylus-tests.ts
@@ -42,7 +42,7 @@ stylus(str)
  * https://github.com/LearnBoost/stylus/blob/master/docs/js.md#includepath
  */
 stylus(str)
-    .include(require('nib').path)
+    .include(require<any>('nib').path) // TODO: use import
     .include(process.env.HOME + '/mixins')
     .render(function (err, css) {
         // logic

--- a/traceback/traceback-tests.ts
+++ b/traceback/traceback-tests.ts
@@ -24,6 +24,6 @@ function testTraceback() {
 
 	var traceback: Traceback[] = TracebackStaticClass();
 
-	var TBReq: TracebackStatic = require('traceback');
+	var TBReq = require<TracebackStatic>('traceback');
 	var traceback: Traceback[] = TBReq();
 }

--- a/websocket/websocket-tests.ts
+++ b/websocket/websocket-tests.ts
@@ -48,7 +48,7 @@ import http = require('http');
 }
 
 {
-    var WebSocketClient = require('websocket').client;
+    var WebSocketClient = require<any>('websocket').client;
     var client = new WebSocketClient();
 
     client.on('connectFailed', (error: Error) => {


### PR DESCRIPTION
Helps trap explicit-any errors when writing `var foo = require('foo');` instead of `import`.

See Microsoft/TypeScript#1569 for details
