### PR TITLE
GroupBy should return a _ChainOfArrays

### DIFF
--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -2630,13 +2630,13 @@ interface _Chain<T> {
 	* Wrapped type `any[]`.
 	* @see _.groupBy
 	**/
-	groupBy(iterator?: _.ListIterator<T, any>, context?: any): _Chain<T>;
+	groupBy(iterator?: _.ListIterator<T, any>, context?: any): _ChainOfArrays<T>;
 
 	/**
 	* Wrapped type `any[]`.
 	* @see _.groupBy
 	**/
-	groupBy(iterator: string, context?: any): _Chain<T>;
+	groupBy(iterator: string, context?: any): _ChainOfArrays<T>;
 
 	/**
 	* Wrapped type `any[]`.


### PR DESCRIPTION
GroupBy returns a chain of arrays. See [_.groupBy](http://underscorejs.org/#groupBy).
