### PR TITLE
Export ViewModel and CollectionObservable

### DIFF
--- a/knockback/knockback.d.ts
+++ b/knockback/knockback.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-/// <reference path="../backbone/backbone.d.ts" />a
+/// <reference path="../backbone/backbone.d.ts" />
 /// <reference path="../knockout/knockout.d.ts" />
 
 declare module Knockback {

--- a/knockback/knockback.d.ts
+++ b/knockback/knockback.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-/// <reference path="../backbone/backbone.d.ts" />
+/// <reference path="../backbone/backbone.d.ts" />a
 /// <reference path="../knockout/knockout.d.ts" />
 
 declare module Knockback {
@@ -163,6 +163,8 @@ declare module Knockback {
     }
 
     interface Static extends Utils {
+    	ViewModel;
+    	CollectionObservable;
         collectionObservable(model?: Backbone.Collection<Backbone.Model>, options?: CollectionOptions): CollectionObservable;
     	/** Base class for observing model attributes. */
     	observable(


### PR DESCRIPTION
CollectionObservable and ViewModel are commonly extended by consumers of Knockback and are part of the public api. These should be added to the interface that is set to kb.
