### PR TITLE
Change type of LaunchDataEntry.entry from File to FileEntry

### DIFF
--- a/chrome/chrome-app.d.ts
+++ b/chrome/chrome-app.d.ts
@@ -18,7 +18,7 @@ declare module chrome.app.runtime {
     }
 
     interface LaunchDataItem {
-        entry: File;
+        entry: FileEntry;
         type: string;
     }
 


### PR DESCRIPTION
entry property of LaunchDataItem is actually a FileEntry, not a File. See https://developer.chrome.com/apps/app_runtime#event-onLaunched
