### PR TITLE
optimist: Argument to showHelp should be optional

### DIFF
--- a/optimist/optimist.d.ts
+++ b/optimist/optimist.d.ts
@@ -23,7 +23,7 @@ declare module "optimist" {
 			wrap(columns: number): Optimist;
 
 			help(): void;
-			showHelp(fn: Function): void;
+			showHelp(fn?: Function): void;
 
 			usage(message: string): Optimist;
 


### PR DESCRIPTION
For reference, see https://github.com/substack/node-optimist/blob/master/index.js#L179
