### PR TITLE
Support converter option

### DIFF
--- a/jquery.cookie/jquery.cookie.d.ts
+++ b/jquery.cookie/jquery.cookie.d.ts
@@ -21,6 +21,8 @@ interface JQueryCookieStatic {
     (name: string): any;
     (name: string, value: string): void;
     (name: string, value: string, options: JQueryCookieOptions): void;
+    (name: string, converter: (value: string) => any): void;
+    (name: string, converter: (value: string) => any, options: JQueryCookieOptions): void;
     (name: string, value: any): void;
     (name: string, value: any, options: JQueryCookieOptions): void;
 }


### PR DESCRIPTION
jquery.cookie supports converter function in the second argument:

https://github.com/carhartl/jquery-cookie

Example for parsing a value into a number:

$.cookie('foo', '42');
$.cookie('foo', Number); // => 42
