### PR TITLE
Added overload for LoggerInterface.log() and its ilk to support format args.

### DIFF
--- a/winston/winston-tests.ts
+++ b/winston/winston-tests.ts
@@ -6,6 +6,8 @@ var str: string;
 var bool: boolean;
 var num: number;
 var metadata: any;
+var callback: (err: Error, level: string, msg: string, meta: any) => void;
+var arg: any;
 var obj: any = {};
 
 var queryOptions: winston.QueryOptions;
@@ -73,15 +75,30 @@ winston.exitOnError = bool;
 
 
 winston.log(str, str);
+winston.log(str, str, callback);
 winston.log(str, str, metadata);
+winston.log(str, str, metadata, callback);
+winston.log(str, str, arg, arg, metadata, callback);
 winston.debug(str);
+winston.debug(str, callback);
 winston.debug(str, metadata);
+winston.debug(str, metadata, callback);
+winston.debug(str, arg, arg, metadata, callback);
 winston.info(str);
+winston.info(str, callback);
 winston.info(str, metadata);
+winston.info(str, metadata, callback);
+winston.info(str, arg, arg, metadata, callback);
 winston.warn(str);
+winston.warn(str, callback);
 winston.warn(str, metadata);
+winston.warn(str, metadata, callback);
+winston.warn(str, arg, arg, metadata, callback);
 winston.error(str);
+winston.error(str, callback);
 winston.error(str, metadata);
+winston.error(str, metadata, callback);
+winston.error(str, arg, arg, metadata, callback);
 
 winston.query(queryOptions, (err: Error, results: any): void => {
 
@@ -115,15 +132,30 @@ readableStream.on('log', function (log:any):void {
 
 logger = logger.extend(obj);
 logger.log(str, str);
+logger.log(str, str, callback);
 logger.log(str, str, metadata);
+logger.log(str, str, metadata, callback);
+logger.log(str, str, arg, arg, metadata, callback);
 logger.debug(str);
+logger.debug(str, callback);
 logger.debug(str, metadata);
+logger.debug(str, metadata, callback);
+logger.debug(str, arg, arg, metadata, callback);
 logger.info(str);
+logger.info(str, callback);
 logger.info(str, metadata);
+logger.info(str, metadata, callback);
+logger.info(str, arg, arg, metadata, callback);
 logger.warn(str);
+logger.warn(str, callback);
 logger.warn(str, metadata);
+logger.warn(str, metadata, callback);
+logger.warn(str, arg, arg, metadata, callback);
 logger.error(str);
+logger.error(str, callback);
 logger.error(str, metadata);
+logger.error(str, metadata, callback);
+logger.error(str, arg, arg, metadata, callback);
 
 logger.query(queryOptions, (err: Error, results: any): void => {
 

--- a/winston/winston.d.ts
+++ b/winston/winston.d.ts
@@ -21,18 +21,23 @@ declare module "winston" {
 
   export function log(level: string, msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
   export function log(level: string, msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+  export function log(level: string, msg: string, ...args: any[]): LoggerInstance;
 
   export function debug(msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
   export function debug(msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+  export function debug(msg: string, ...args: any[]): LoggerInstance;
 
   export function info(msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
   export function info(msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+  export function info(msg: string, ...args: any[]): LoggerInstance;
 
   export function warn(msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
   export function warn(msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+  export function warn(msg: string, ...args: any[]): LoggerInstance;
 
   export function error(msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
   export function error(msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+  export function error(msg: string, ...args: any[]): LoggerInstance;
 
   export function query(options: QueryOptions, callback?: (err: Error, results: any) => void): any;
   export function query(callback: (err: Error, results: any) => void): any;
@@ -58,18 +63,23 @@ declare module "winston" {
 
     log(level: string, msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
     log(level: string, msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+    log(level: string, msg: string, ...args: any[]): LoggerInstance;
 
     debug(msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
     debug(msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+    debug(msg: string, ...args: any[]): LoggerInstance;
 
     info(msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
     info(msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+    info(msg: string, ...args: any[]): LoggerInstance;
 
     warn(msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
     warn(msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+    warn(msg: string, ...args: any[]): LoggerInstance;
 
     error(msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
     error(msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
+    error(msg: string, ...args: any[]): LoggerInstance;
 
     query(options: QueryOptions, callback?: (err: Error, results: any) => void): any;
     query(callback: (err: Error, results: any) => void): any;


### PR DESCRIPTION
 The current function overloads for LoggerInterface.log() block certain valid usages. For example:

```
logger.log('info', 'test message %s, %s', 'first', 'second');
```

Log calls in Wisnton support an odd function signature. [See examples](https://github.com/flatiron/winston#string-interpolation). In TypeScript it would be specified as follows:

```
export function log(level: string, msg: string, ...msgArgs: any[], meta?: object, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
```

But that is invalid because you can't have rest parameters in the middle of a function signature and object isn't a type. My solution is as follows:

```
export function log(level: string, msg: string, ...args: any[]): LoggerInstance;
```

This change has pros and cons, but I believe the pros outweigh the cons. The upside is that now all valid calls pass the TypeScript compiler. The downside is that the other two overloads now have no power. I have left them in to server as documentation.

Also added tests for LoggerInterface.log() with callbacks.
