### PR TITLE
.g and .group arguments are optional in snapsvg

### DIFF
--- a/snapsvg/snapsvg.d.ts
+++ b/snapsvg/snapsvg.d.ts
@@ -216,8 +216,8 @@ declare module Snap {
 	clear():void;
 	el(name:string, attr:Object):Snap.Element;
 	gradient(gradient:string):any;
-	g(varargs:any):Object;
-	group(el:any,...els:any[]):any;
+	g(varargs?:any):any;
+	group(el?:any,...els:any[]):any;
 	mask(varargs:any):Object;
 	ptrn(x:number,y:number,width:number,height:number,vbx:number,vby:number,vbw:number,vbh:number):Object;
 	svg(x:number,y:number,width:number,height:number,vbx:number,vby:number,vbw:number,vbh:number):Object;


### PR DESCRIPTION
Per these docs:
http://snapsvg.io/docs/#Paper.g

The parameters to these functions are optional. This change stops the
TypeScript compiler complaining when you call them with no arguments.

Also, the return type of `g` and `group` should match (they are
aliases); and `any` has the benefit over `Object` here of allowing code
like `s.g().attr({id: "x"});`
