### PR TITLE
Add optional filters to webNavigation events

### DIFF
--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -140,7 +140,7 @@ declare module chrome.browserAction {
 
     interface TitleDetails {
         title: string;
-        tabId?: number;WebNavigationReferenceFragmentUpdatedEvent
+        tabId?: number;
     }
 
     interface TabDetails {

--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -140,7 +140,7 @@ declare module chrome.browserAction {
 
     interface TitleDetails {
         title: string;
-        tabId?: number;
+        tabId?: number;WebNavigationReferenceFragmentUpdatedEvent
     }
 
     interface TabDetails {
@@ -2173,20 +2173,24 @@ declare module chrome.webNavigation {
         error: string;
     }
 
+    interface WebNavigationEventFilters {
+        url: chrome.events.UrlFilter[];
+    }
+
     interface WebNavigationReferenceFragmentUpdatedEvent extends chrome.events.Event {
-        addListener(callback: (details: ReferenceFragmentUpdatedDetails) => void): void;
+        addListener(callback: (details: ReferenceFragmentUpdatedDetails) => void, filters? : WebNavigationEventFilters): void;
     }
 
     interface WebNavigationCompletedEvent extends chrome.events.Event {
-        addListener(callback: (details: CompletedDetails) => void): void;
+        addListener(callback: (details: CompletedDetails) => void, filters? : WebNavigationEventFilters): void;
     }
 
     interface WebNavigationHistoryStateUpdatedEvent extends chrome.events.Event {
-        addListener(callback: (details: HistoryStateUpdatedDetails) => void): void;
+        addListener(callback: (details: HistoryStateUpdatedDetails) => void, filters?: WebNavigationEventFilters): void;
     }
 
     interface WebNavigationCreatedNavigationTargetEvent extends chrome.events.Event {
-        addListener(callback: (details: CreatedNavigationTargetDetails) => void): void;
+        addListener(callback: (details: CreatedNavigationTargetDetails) => void, filters?: WebNavigationEventFilters): void;
     }
 
     interface WebNavigationTabReplacedEvent extends chrome.events.Event {
@@ -2194,19 +2198,19 @@ declare module chrome.webNavigation {
     }
 
     interface WebNavigationBeforeNavigateEvent extends chrome.events.Event {
-        addListener(callback: (details: BeforeNavigateDetails) => void): void;
+        addListener(callback: (details: BeforeNavigateDetails) => void, filters?: WebNavigationEventFilters): void;
     }
 
     interface WebNavigationCommittedEvent extends chrome.events.Event {
-        addListener(callback: (details: CommittedDetails) => void): void;
+        addListener(callback: (details: CommittedDetails) => void, filters?: WebNavigationEventFilters): void;
     }
 
     interface WebNavigationDomContentLoadedEvent extends chrome.events.Event {
-        addListener(callback: (details: DomContentLoadedDetails) => void): void;
+        addListener(callback: (details: DomContentLoadedDetails) => void, filters?: WebNavigationEventFilters): void;
     }
 
     interface WebNavigationErrorOccurredEvent extends chrome.events.Event {
-        addListener(callback: (details: ErrorOccurredDetails) => void): void;
+        addListener(callback: (details: ErrorOccurredDetails) => void, filters?: WebNavigationEventFilters): void;
     }
 
     export function getFrame(details: GetFrameDetails, callback: (details?: GetFrameResultDetails) => void): void;


### PR DESCRIPTION
There is an additional argument according to https://developer.chrome.com/extensions/webNavigation
Filters argument is not well documented but present.
Sample from Google:
https://developer.chrome.com/extensions/examples/extensions/gmail/background.js
