### PR TITLE
Use union types (TS 1.4) for ko.unwrap and ko.utils.unwrapObservable

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -442,7 +442,7 @@ interface KnockoutStatic {
     cleanNode(node: Element): Element;
     renderTemplate(template: Function, viewModel: any, options?: any, target?: any, renderMode?: any): any;
     renderTemplate(template: string, viewModel: any, options?: any, target?: any, renderMode?: any): any;
-	unwrap(value: any): any;
+	unwrap<T>(value: KnockoutObservable<T> | T): T;
 
 	computedContext: KnockoutComputedContext;
 

--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -306,7 +306,7 @@ interface KnockoutUtils {
 
     triggerEvent(element: any, eventType: any): void;
 
-    unwrapObservable<T>(value: KnockoutObservable<T>): T;
+    unwrapObservable<T>(value: KnockoutObservable<T> | T): T;
 
     peekObservable<T>(value: KnockoutObservable<T>): T;
 

--- a/knockout/tests/knockout-tests.ts
+++ b/knockout/tests/knockout-tests.ts
@@ -649,3 +649,10 @@ function test_Components() {
 		ko.components.register('name', { /* No config needed */ });
     }
 }
+
+function testUnwrapUnion() {
+    
+    var possibleObs: KnockoutObservable<number> | number;
+    var num = ko.unwrap(possibleObs);
+
+}


### PR DESCRIPTION
This change tightens up type safety considerably in any code where you use ko.unwrap to treat plain values and observables uniformly.

So it may be a breaking change at compile time, but on the upside it will likely eliminate some bugs at runtime. :)

BTW does DefinitelyTyped have a way of writing tests that are expected to fail compilation? i.e. the test passes only if the compiler emits an error. A test that is expected to succeed is not a valid test of this change.
