### PR TITLE
Added interface for pjax:popstate event

### DIFF
--- a/jquery.pjax/jquery.pjax-tests.ts
+++ b/jquery.pjax/jquery.pjax-tests.ts
@@ -58,3 +58,11 @@ function test_defauluts() {
 function test_support() {
     console.log($.support.pjax);
 }
+
+function test_events() {
+	$(document).on('pjax:popstate', function(e: PjaxPopStateEventObject) {
+		if (e.direction === 'back') {
+			console.log('pjax:popstate is OK');
+		}
+	});
+}

--- a/jquery.pjax/jquery.pjax.d.ts
+++ b/jquery.pjax/jquery.pjax.d.ts
@@ -5,6 +5,16 @@
 
 /// <reference path="../jquery/jquery.d.ts" />
 
+/**
+ * Interface for pjax:popstate event.
+ */
+interface PjaxPopStateEventObject extends JQueryEventObject {
+    /**
+     * Navigation direction. Could be "back" or "forward".
+     */
+    direction: string
+}
+
 interface PjaxSettings extends JQueryAjaxSettings {
     /**
      * A jQuery selector indicates where to stick the response body. E.g., $(container).html(xhr.responseBody).


### PR DESCRIPTION
Covers the following case:

``` typescript
$(document).on('pjax:popstate', function(e: PjaxPopStateEventObject) {
    if (e.direction === 'back') {
        console.log('pjax:popstate is OK');
    }
});
```
