### PR TITLE
Revert creation of ComponentClassType and add additional validation.

### DIFF
--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -59,11 +59,24 @@ var reactClass = React.createClass<Props>({
     }
 });
 
+class PureReactClass implements React.Component<Props> {
+    getDOMNode: <TElement extends Element>() => TElement;
+    isMounted: () => boolean;
+
+    props: Props;
+    setProps: (nextProps: Props, callback?: () => any) => void;
+    replaceProps: (nextProps: Props, callback?: () => any) => void;
+}
+
 var reactElement: React.ReactElement<Props> =
     React.createElement<Props>(reactClass, props);
 
+reactElement = React.createElement(PureReactClass, props);
+
 var reactFactory: React.ComponentFactory<Props> =
     React.createFactory<Props>(reactClass);
+
+reactFactory = React.createFactory(PureReactClass);
 
 var component: React.Component<Props> =
     React.render<Props>(reactElement, container);

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -42,7 +42,10 @@ declare module React {
     }
 
     interface ComponentClass<P> extends ComponentStatics<P> {
+        // Not intended for usage. Please do not call "new MyComponent()"
         new (): Component<P>;
+        // Deprecated in 0.12. See http://fb.me/react-legacyfactory
+        // (props: P): ReactElement<P>;
     }
 
     //

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -41,14 +41,8 @@ declare module React {
         propTypes?: ValidationMap<P>;
     }
 
-    interface ComponentClassType<P> extends ComponentStatics<P> {
-        new (): ComponentClass<P>;
-    }
-
-    interface ComponentClass<P> {
-        // Deprecated in 0.12. See http://fb.me/react-legacyfactory
-        // new(props: P): ReactElement<P>;
-        // (props: P): ReactElement<P>;
+    interface ComponentClass<P> extends ComponentStatics<P> {
+        new (): Component<P>;
     }
 
     //
@@ -67,9 +61,9 @@ declare module React {
     // ----------------------------------------------------------------------
 
     interface TopLevelAPI {
-        createClass<P>(spec: ComponentSpec<P, any>): ComponentClassType<P>;
-        createElement<P>(type: any/*ReactType*/, props: P, ...children: any/*ReactNode*/[]): ReactElement<P>;
-        createFactory<P>(componentClass: ComponentClassType<P>): ComponentFactory<P>;
+        createClass<P>(spec: ComponentSpec<P, any>): ComponentClass<P>;
+        createElement<P>(type: ComponentClass<P> | string, props: P, ...children: any/*ReactNode*/[]): ReactElement<P>;
+        createFactory<P>(componentClass: ComponentClass<P>): ComponentFactory<P>;
         render<P>(element: ReactElement<P>, container: Element, callback?: () => any): Component<P>;
         unmountComponentAtNode(container: Element): boolean;
         renderToString(element: ReactElement<any>): string;
@@ -674,6 +668,9 @@ declare module React {
         transitionLeave?: boolean;
     }
 
+    interface CSSTransitionGroup extends ComponentClass<CSSTransitionGroupProps> {}
+    interface TransitionGroup extends ComponentClass<TransitionGroupProps> {}
+
     //
     // React.addons (Mixins)
     // ----------------------------------------------------------------------
@@ -874,10 +871,10 @@ declare module React {
 
     interface AddonsExports extends Exports {
         addons: {
-            CSSTransitionGroup: ComponentClassType<CSSTransitionGroupProps>;
+            CSSTransitionGroup: CSSTransitionGroup;
             LinkedStateMixin: LinkedStateMixin;
             PureRenderMixin: PureRenderMixin;
-            TransitionGroup: ComponentClassType<TransitionGroupProps>;
+            TransitionGroup: TransitionGroup;
 
             batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
             batchedUpdates<A>(callback: (a: A) => any, a: A): void;


### PR DESCRIPTION
This is a followup to #3492 

This reverts the previous PR which added `ComponentClassType` but keeps the original intent by adding `new (): Component<P>` to `ComponentClass`.

Additionally it adds additional validation to `React.createElement` which was the bigger picture goal that the previous PR was attempting to lay the foundation for. Let me explain. Take the following example:

```
import React = require('react/addons');
import TypedReact = require('typed-react');

interface Props {
    prop: number;
}

class Pure implements React.Component<Props> {
    getDOMNode: <TElement extends Element>() => TElement;
    isMounted: () => boolean;

    props: Props;
    setProps: (nextProps: Props, callback?: () => any) => void;
    replaceProps: (nextProps: Props, callback?: () => any) => void;
}

class TypedReactPure extends TypedReact.Component<Props, any> {
    /* ... */
}

var TypedReactCreated = TypedReact.createClass(TypedReactPure);

// note the invalid type of the prop
React.createElement(Pure, { prop: '' });
React.createElement(TypedReactPure, { prop: '' });
React.createElement(TypedReactCreated, { prop: '' });
```

This is showing what is possible with React v0.13. Notably the "Pure" and "TypedReactPure" options become possible. Today TypeScript does not catch the mismatched type on "prop" when calling `React.createElement` because `createElement` is modeled to accept `any`. In this PR I've modeled `createElement` to accept as its type argument `ComponentClass<P> | string`. With just this change (and by **not** adding `new (): Component<P>` to `ComponentClass`) we get the following from TypeScript:

```
React.createElement(Pure, { prop: '' });
React.createElement(TypedReactPure, { prop: '' });
React.createElement(TypedReactCreated, { prop: '' }); /// <- this correctly errors
```

By then adding in `new (): Component<P>` we get this:

```
React.createElement(Pure, { prop: '' }); // <- this correctly errors
React.createElement(TypedReactPure, { prop: '' }); // <- this correctly errors
React.createElement(TypedReactCreated, { prop: '' }); // <- this correctly errors
```

Hopefully this helps explain my what I meant when I previously said this becomes more important in v0.13. However, the change is fully compatible with v0.12 (and still more correct as previously explained).

Additionally this uses the new union type available in TypeScript 1.4. I'm not sure how everyone feels about that. It seems a lot of other definitions have started upgrading.

Paging @pspeter3 and @vsiao 
