### PR TITLE
Extend when definitions with union support

### DIFF
--- a/when/when-tests.ts
+++ b/when/when-tests.ts
@@ -41,51 +41,51 @@ promise = when.attempt(() => 1);
 promise = when.attempt((a: number) => a + a, 1);
 promise = when.attempt((a: number) => a + a, when(1));
 
-promise = when.attempt((a: number, b: number) => a + b, 1, 2);
-promise = when.attempt((a: number, b: number) => a + b, 1, when(2));
-promise = when.attempt((a: number, b: number) => a + b, when(1), 2);
-promise = when.attempt((a: number, b: number) => a + b, when(1), when(2));
+promise = when.attempt((a: number, b: string) => a, 1, '2');
+promise = when.attempt((a: number, b: string) => a, 1, when('2'));
+promise = when.attempt((a: number, b: string) => a, when(1), '2');
+promise = when.attempt((a: number, b: string) => a, when(1), when('2'));
 
-promise = when.attempt((a: number, b: number, c: number) => a + b + c, 1, 2, 3);
-promise = when.attempt((a: number, b: number, c: number) => a + b + c, 1, when(2), 3);
-promise = when.attempt((a: number, b: number, c: number) => a + b + c, when(1), 2, 3);
-promise = when.attempt((a: number, b: number, c: number) => a + b + c, when(1), when(2), 3);
-promise = when.attempt((a: number, b: number, c: number) => a + b + c, 1, 2, when(3));
-promise = when.attempt((a: number, b: number, c: number) => a + b + c, 1, when(2), when(3));
-promise = when.attempt((a: number, b: number, c: number) => a + b + c, when(1), 2, when(3));
-promise = when.attempt((a: number, b: number, c: number) => a + b + c, when(1), when(2), when(3));
+promise = when.attempt((a: number, b: string, c: boolean) => a, 1, '2', true);
+promise = when.attempt((a: number, b: string, c: boolean) => a, 1, when('2'), true);
+promise = when.attempt((a: number, b: string, c: boolean) => a, when(1), '2', true);
+promise = when.attempt((a: number, b: string, c: boolean) => a, when(1), when('2'), true);
+promise = when.attempt((a: number, b: string, c: boolean) => a, 1, '2', when(true));
+promise = when.attempt((a: number, b: string, c: boolean) => a, 1, when('2'), when(true));
+promise = when.attempt((a: number, b: string, c: boolean) => a, when(1), '2', when(true));
+promise = when.attempt((a: number, b: string, c: boolean) => a, when(1), when('2'), when(true));
 
-promise = when.attempt((a: number, b: number, c: number, d: number, e: number) => a + b + c + d + e, when(1), when(2), when(3), when(4), when(5));
+promise = when.attempt((a: number, b: string, c: boolean, d: number, e: string) => a, when(1), when('2'), when(true), when(4), when('5'));
 
 /* when.lift(f) */
 
-var liftedFunc0 = when.lift(() => 2);
-var liftedFunc1 = when.lift((a: number) => a + a);
-var liftedFunc2 = when.lift((a: number, b: number) => a + b);
-var liftedFunc3 = when.lift((a: number, b: number, c: number) => a + b + c);
+var liftedFunc0 = when.lift(() => 0);
+var liftedFunc1 = when.lift((a: number) => a);
+var liftedFunc2 = when.lift((a: number, b: string) => a);
+var liftedFunc3 = when.lift((a: number, b: string, c: boolean) => a);
 
-var liftedFunc5 = when.lift((a: number, b: number, c: number, d: number, e: number) => a + b + c + d + e);
+var liftedFunc5 = when.lift((a: number, b: string, c: boolean, d: number, e: string) => a);
 
 promise = liftedFunc0();
 
 promise = liftedFunc1(1);
 promise = liftedFunc1(when(1));
 
-promise = liftedFunc2(1, 2);
-promise = liftedFunc2(when(1), 2);
-promise = liftedFunc2(1, when(2));
-promise = liftedFunc2(when(1), when(2));
+promise = liftedFunc2(1, '2');
+promise = liftedFunc2(when(1), '2');
+promise = liftedFunc2(1, when('2'));
+promise = liftedFunc2(when(1), when('2'));
 
-promise = liftedFunc3(1, 2, 3);
-promise = liftedFunc3(when(1), 2, 3);
-promise = liftedFunc3(1, when(2), 3);
-promise = liftedFunc3(when(1), when(2), 3);
-promise = liftedFunc3(1, 2, when(3));
-promise = liftedFunc3(when(1), 2, when(3));
-promise = liftedFunc3(1, when(2), when(3));
-promise = liftedFunc3(when(1), when(2), when(3));
+promise = liftedFunc3(1, '2', true);
+promise = liftedFunc3(when(1), '2', true);
+promise = liftedFunc3(1, when('2'), true);
+promise = liftedFunc3(when(1), when('2'), true);
+promise = liftedFunc3(1, '2', when(true));
+promise = liftedFunc3(when(1), '2', when(true));
+promise = liftedFunc3(1, when('2'), when(true));
+promise = liftedFunc3(when(1), when('2'), when(true));
 
-promise = liftedFunc5(when(1), when(2), when(3), when(4), when(5));
+promise = liftedFunc5(when(1), when('2'), when(true), when(4), when('5'));
 
 /* when.join(...promises) */
 
@@ -133,16 +133,16 @@ promise = when(1).then((val: number) => when(val + val), (err: any) => 2);
 /* promise.spread(onFulfilledArray) */
 
 // TODO: Work out how to do this...
-// promise = when([1, 2, 3]).spread((a: number, b: number) => a + b);
-// promise = when([1, 2, 3]).spread((a: number, b: number) => when(a + b));
+// promise = when([1, '2', true]).spread((a: number, b: string, c: boolean) => a);
+// promise = when([1, '2', true]).spread((a: number, b: string, c: boolean) => when(a));
 
 /* promise.fold(combine, promise2) */
 
-promise = when(1).fold((a: number, b: number) => a + b, 2);
-promise = when(1).fold((a: number, b: number) => a + b, when(2));
+promise = when(1).fold((a: number, b: string) => a, '2');
+promise = when(1).fold((a: number, b: string) => a, when('2'));
 
-promise = when(1).fold((a: number, b: number) => when(a + b), 2);
-promise = when(1).fold((a: number, b: number) => when(a + b), when(2));
+promise = when(1).fold((a: number, b: string) => when(a), '2');
+promise = when(1).fold((a: number, b: string) => when(a), when('2'));
 
 /* promise.catch(onRejected) */
 
@@ -218,10 +218,10 @@ import nodefn = require('when/node');
 
 var nodeFn0 = (callback: (err: any, result: number) => void) => callback(null, 0);
 var nodeFn1 = (a: number, callback: (err: any, result: number) => void) => callback(null, a);
-var nodeFn2 = (a: number, b: number, callback: (err: any, result: number) => void) => callback(null, a + b);
-var nodeFn3 = (a: number, b: number, c: number, callback: (err: any, result: number) => void) => callback(null, a + b + c);
+var nodeFn2 = (a: number, b: string, callback: (err: any, result: number) => void) => callback(null, a);
+var nodeFn3 = (a: number, b: string, c: boolean, callback: (err: any, result: number) => void) => callback(null, a);
 
-var nodeFn5 = (a: number, b: number, c: number, d: number, e: number, callback: (err: any, result: number) => void) => callback(null, a + b + c + d + e);
+var nodeFn5 = (a: number, b: string, c: boolean, d: number, e: string, callback: (err: any, result: number) => void) => callback(null, a);
 
 var liftedNodeFunc0 = nodefn.lift(nodeFn0);
 var liftedNodeFunc1 = nodefn.lift(nodeFn1);
@@ -235,21 +235,21 @@ promise = liftedNodeFunc0();
 promise = liftedNodeFunc1(1);
 promise = liftedNodeFunc1(when(1));
 
-promise = liftedNodeFunc2(1, 2);
-promise = liftedNodeFunc2(when(1), 2);
-promise = liftedNodeFunc2(1, when(2));
-promise = liftedNodeFunc2(when(1), when(2));
+promise = liftedNodeFunc2(1, '2');
+promise = liftedNodeFunc2(when(1), '2');
+promise = liftedNodeFunc2(1, when('2'));
+promise = liftedNodeFunc2(when(1), when('2'));
 
-promise = liftedNodeFunc3(1, 2, 3);
-promise = liftedNodeFunc3(when(1), 2, 3);
-promise = liftedNodeFunc3(1, when(2), 3);
-promise = liftedNodeFunc3(when(1), when(2), 3);
-promise = liftedNodeFunc3(1, 2, when(3));
-promise = liftedNodeFunc3(when(1), 2, when(3));
-promise = liftedNodeFunc3(1, when(2), when(3));
-promise = liftedNodeFunc3(when(1), when(2), when(3));
+promise = liftedNodeFunc3(1, '2', true);
+promise = liftedNodeFunc3(when(1), '2', true);
+promise = liftedNodeFunc3(1, when('2'), true);
+promise = liftedNodeFunc3(when(1), when('2'), true);
+promise = liftedNodeFunc3(1, '2', when(true));
+promise = liftedNodeFunc3(when(1), '2', when(true));
+promise = liftedNodeFunc3(1, when('2'), when(true));
+promise = liftedNodeFunc3(when(1), when('2'), when(true));
 
-promise = liftedNodeFunc5(when(1), when(2), when(3), when(4), when(5));
+promise = liftedNodeFunc5(when(1), when('2'), when(true), when(4), when('5'));
 
 example = function() {
 	var resolveAddress = nodefn.lift(dns.resolve);
@@ -314,21 +314,21 @@ promise = nodefn.call(nodeFn0);
 promise = nodefn.call(nodeFn1, 1);
 promise = nodefn.call(nodeFn1, when(1));
 
-promise = nodefn.call(nodeFn2, 1, 2);
-promise = nodefn.call(nodeFn2, 1, when(2));
-promise = nodefn.call(nodeFn2, when(1), 2);
-promise = nodefn.call(nodeFn2, when(1), when(2));
+promise = nodefn.call(nodeFn2, 1, '2');
+promise = nodefn.call(nodeFn2, 1, when('2'));
+promise = nodefn.call(nodeFn2, when(1), '2');
+promise = nodefn.call(nodeFn2, when(1), when('2'));
 
-promise = nodefn.call(nodeFn3, 1, 2, 3);
-promise = nodefn.call(nodeFn3, 1, when(2), 3);
-promise = nodefn.call(nodeFn3, when(1), 2, 3);
-promise = nodefn.call(nodeFn3, when(1), when(2), 3);
-promise = nodefn.call(nodeFn3, 1, 2, when(3));
-promise = nodefn.call(nodeFn3, 1, when(2), when(3));
-promise = nodefn.call(nodeFn3, when(1), 2, when(3));
-promise = nodefn.call(nodeFn3, when(1), when(2), when(3));
+promise = nodefn.call(nodeFn3, 1, '2', true);
+promise = nodefn.call(nodeFn3, 1, when('2'), true);
+promise = nodefn.call(nodeFn3, when(1), '2', true);
+promise = nodefn.call(nodeFn3, when(1), when('2'), true);
+promise = nodefn.call(nodeFn3, 1, '2', when(true));
+promise = nodefn.call(nodeFn3, 1, when('2'), when(true));
+promise = nodefn.call(nodeFn3, when(1), '2', when(true));
+promise = nodefn.call(nodeFn3, when(1), when('2'), when(true));
 
-promise = nodefn.call(nodeFn5, when(1), when(2), when(3), when(4), when(5));
+promise = nodefn.call(nodeFn5, when(1), when('2'), when(true), when(4), when('5'));
 
 example = function () {
 	var loadPasswd = nodefn.call(fs.readFile, '/etc/passwd');
@@ -340,7 +340,7 @@ example = function () {
 
 /* node.apply */
 
-promise = nodefn.apply(nodeFn2, [1, 2]);
+promise = nodefn.apply(nodeFn2, [1, '2']);
 
 example = function () {
 	var loadPasswd = nodefn.apply(fs.readFile, ['/etc/passwd']);
@@ -375,7 +375,7 @@ example = function () {
 
 example = function () {
 	when.promise((resolve, reject) =>
-			nodeFn2(1, 2, nodefn.createCallback({ resolve: resolve, reject: reject })))
+			nodeFn2(1, '2', nodefn.createCallback({ resolve: resolve, reject: reject })))
 		.then(
 			(value: number) => console.log(value),
 			(err: any) => console.error(err));

--- a/when/when-tests.ts
+++ b/when/when-tests.ts
@@ -18,9 +18,6 @@ var foreign = new ForeignPromise<number>(1);
 var error = new Error("boom!");
 var example: () => void;
 
-// TODO: with TypeScript 1.4 a lot of these functions should change to use PromiseOrValue<T>
-//    type PromiseOrValue<T> = Promise<T> | T;
-
 /* * * * * * *
  *   Core    *
  * * * * * * */
@@ -58,14 +55,37 @@ promise = when.attempt((a: number, b: number, c: number) => a + b + c, 1, when(2
 promise = when.attempt((a: number, b: number, c: number) => a + b + c, when(1), 2, when(3));
 promise = when.attempt((a: number, b: number, c: number) => a + b + c, when(1), when(2), when(3));
 
+promise = when.attempt((a: number, b: number, c: number, d: number, e: number) => a + b + c + d + e, when(1), when(2), when(3), when(4), when(5));
+
 /* when.lift(f) */
 
-// TODO: This is the major issue with lack of union types, it's not possible to represent the return type of when.lift without them.
+var liftedFunc0 = when.lift(() => 2);
+var liftedFunc1 = when.lift((a: number) => a + a);
+var liftedFunc2 = when.lift((a: number, b: number) => a + b);
+var liftedFunc3 = when.lift((a: number, b: number, c: number) => a + b + c);
 
-var liftedFunc0: () => when.Promise<number> = when.lift(() => 2);
-var liftedFunc1: (a: when.Promise<number>) => when.Promise<number> = when.lift((a: number) => a + a);
-var liftedFunc2: (a: when.Promise<number>, b: when.Promise<number>) => when.Promise<number> = when.lift((a: number, b: number) => a + b);
-var liftedFunc3: (a: when.Promise<number>, b: when.Promise<number>, c: when.Promise<number>) => when.Promise<number> = when.lift((a: number, b: number, c: number) => a + b + c);
+var liftedFunc5 = when.lift((a: number, b: number, c: number, d: number, e: number) => a + b + c + d + e);
+
+promise = liftedFunc0();
+
+promise = liftedFunc1(1);
+promise = liftedFunc1(when(1));
+
+promise = liftedFunc2(1, 2);
+promise = liftedFunc2(when(1), 2);
+promise = liftedFunc2(1, when(2));
+promise = liftedFunc2(when(1), when(2));
+
+promise = liftedFunc3(1, 2, 3);
+promise = liftedFunc3(when(1), 2, 3);
+promise = liftedFunc3(1, when(2), 3);
+promise = liftedFunc3(when(1), when(2), 3);
+promise = liftedFunc3(1, 2, when(3));
+promise = liftedFunc3(when(1), 2, when(3));
+promise = liftedFunc3(1, when(2), when(3));
+promise = liftedFunc3(when(1), when(2), when(3));
+
+promise = liftedFunc5(when(1), when(2), when(3), when(4), when(5));
 
 /* when.join(...promises) */
 
@@ -196,17 +216,40 @@ import nodefn = require('when/node');
 
 /* node.lift */
 
-// TODO: Again it's not possible to represent the return type of node.lift without union types.
-
 var nodeFn0 = (callback: (err: any, result: number) => void) => callback(null, 0);
 var nodeFn1 = (a: number, callback: (err: any, result: number) => void) => callback(null, a);
 var nodeFn2 = (a: number, b: number, callback: (err: any, result: number) => void) => callback(null, a + b);
 var nodeFn3 = (a: number, b: number, c: number, callback: (err: any, result: number) => void) => callback(null, a + b + c);
 
-var promiseFunc0: () => when.Promise<number> = nodefn.lift(nodeFn0);
-var promiseFunc1: (a: when.Promise<number>) => when.Promise<number> = nodefn.lift(nodeFn1);
-var promiseFunc2: (a: when.Promise<number>, b: when.Promise<number>) => when.Promise<number> = nodefn.lift(nodeFn2);
-var promiseFunc3: (a: when.Promise<number>, b: when.Promise<number>, c: when.Promise<number>) => when.Promise<number> = nodefn.lift(nodeFn3);
+var nodeFn5 = (a: number, b: number, c: number, d: number, e: number, callback: (err: any, result: number) => void) => callback(null, a + b + c + d + e);
+
+var liftedNodeFunc0 = nodefn.lift(nodeFn0);
+var liftedNodeFunc1 = nodefn.lift(nodeFn1);
+var liftedNodeFunc2 = nodefn.lift(nodeFn2);
+var liftedNodeFunc3 = nodefn.lift(nodeFn3);
+
+var liftedNodeFunc5 = nodefn.lift(nodeFn5);
+
+promise = liftedNodeFunc0();
+
+promise = liftedNodeFunc1(1);
+promise = liftedNodeFunc1(when(1));
+
+promise = liftedNodeFunc2(1, 2);
+promise = liftedNodeFunc2(when(1), 2);
+promise = liftedNodeFunc2(1, when(2));
+promise = liftedNodeFunc2(when(1), when(2));
+
+promise = liftedNodeFunc3(1, 2, 3);
+promise = liftedNodeFunc3(when(1), 2, 3);
+promise = liftedNodeFunc3(1, when(2), 3);
+promise = liftedNodeFunc3(when(1), when(2), 3);
+promise = liftedNodeFunc3(1, 2, when(3));
+promise = liftedNodeFunc3(when(1), 2, when(3));
+promise = liftedNodeFunc3(1, when(2), when(3));
+promise = liftedNodeFunc3(when(1), when(2), when(3));
+
+promise = liftedNodeFunc5(when(1), when(2), when(3), when(4), when(5));
 
 example = function() {
 	var resolveAddress = nodefn.lift(dns.resolve);
@@ -284,6 +327,8 @@ promise = nodefn.call(nodeFn3, 1, 2, when(3));
 promise = nodefn.call(nodeFn3, 1, when(2), when(3));
 promise = nodefn.call(nodeFn3, when(1), 2, when(3));
 promise = nodefn.call(nodeFn3, when(1), when(2), when(3));
+
+promise = nodefn.call(nodeFn5, when(1), when(2), when(3), when(4), when(5));
 
 example = function () {
 	var loadPasswd = nodefn.call(fs.readFile, '/etc/passwd');

--- a/when/when.d.ts
+++ b/when/when.d.ts
@@ -12,29 +12,79 @@ declare function When<T, U>(value: When.Thenable<T>, transform: (val: T) => U): 
 declare function When<T, U>(value: T, transform: (val: T) => U): When.Promise<U>;
 
 declare module When {
-    function attempt<T>(f: () => T): Promise<T>;
+    // Helper interfaces
+    module _ {
+        interface Fn0<T> { (): T }
+        interface Fn1<A1, T> { (a1: A1): T }
+        interface Fn2<A1, A2, T> { (a1: A1, a2: A2): T }
+        interface Fn3<A1, A2, A3, T> { (a1: A1, a2: A2, a3: A3): T }
+        interface Fn4<A1, A2, A3, A4, T> { (a1: A1, a2: A2, a3: A3, a4: A4): T }
+        interface Fn5<A1, A2, A3, A4, A5, T> { (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5): T }
+        interface Fn6<A1, A2, A3, A4, A5, A6, T> { (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6): T }
 
-    function attempt<T, A>(f: (a: A) => T, a: Promise<A>): Promise<T>;
-    function attempt<T, A>(f: (a: A) => T, a: A): Promise<T>;
+        interface LiftedFn0<T> extends Fn0<Promise<T>> { }
+        interface LiftedFn1<A1, T> extends Fn1<A1 | Promise<A1>, Promise<T>> { }
+        interface LiftedFn2<A1, A2, T> extends Fn2<A1 | Promise<A1>, A2 | Promise<A2>, Promise<T>> { }
+        interface LiftedFn3<A1, A2, A3, T> extends Fn3<A1 | Promise<A1>, A2 | Promise<A2>, A3 | Promise<A3>, Promise<T>> { }
+        interface LiftedFn4<A1, A2, A3, A4, T> extends Fn4<A1 | Promise<A1>, A2 | Promise<A2>, A3 | Promise<A3>, A4 | Promise<A4>, Promise<T>> { }
+        interface LiftedFn5<A1, A2, A3, A4, A5, T> extends Fn5<A1 | Promise<A1>, A2 | Promise<A2>, A3 | Promise<A3>, A4 | Promise<A4>, A5 | Promise<A5>, Promise<T>> { }
 
-    function attempt<T, A, B>(f: (a: A, b: B) => T, a: Promise<A>, b: Promise<B>): Promise<T>;
-    function attempt<T, A, B>(f: (a: A, b: B) => T, a: Promise<A>, b: B): Promise<T>;
-    function attempt<T, A, B>(f: (a: A, b: B) => T, a: A, b: Promise<B>): Promise<T>;
-    function attempt<T, A, B>(f: (a: A, b: B) => T, a: A, b: B): Promise<T>;
+        interface NodeCallback<T> { (err: any, result: T): void }
 
-    function attempt<T, A, B, C>(f: (a: A, b: B, c: C) => T, a: Promise<A>, b: Promise<B>, c: Promise<C>): Promise<T>;
-    function attempt<T, A, B, C>(f: (a: A, b: B, c: C) => T, a: Promise<A>, b: Promise<B>, c: C): Promise<T>;
-    function attempt<T, A, B, C>(f: (a: A, b: B, c: C) => T, a: Promise<A>, b: B, c: Promise<C>): Promise<T>;
-    function attempt<T, A, B, C>(f: (a: A, b: B, c: C) => T, a: Promise<A>, b: B, c: C): Promise<T>;
-    function attempt<T, A, B, C>(f: (a: A, b: B, c: C) => T, a: A, b: Promise<B>, c: Promise<C>): Promise<T>;
-    function attempt<T, A, B, C>(f: (a: A, b: B, c: C) => T, a: A, b: Promise<B>, c: C): Promise<T>;
-    function attempt<T, A, B, C>(f: (a: A, b: B, c: C) => T, a: A, b: B, c: Promise<C>): Promise<T>;
-    function attempt<T, A, B, C>(f: (a: A, b: B, c: C) => T, a: A, b: B, c: C): Promise<T>;
+        interface NodeFn0<T> extends _.Fn1<NodeCallback<T>, void> { }
+        interface NodeFn1<A1, T> extends _.Fn2<A1, NodeCallback<T>, void> { }
+        interface NodeFn2<A1, A2, T> extends _.Fn3<A1, A2, NodeCallback<T>, void> { }
+        interface NodeFn3<A1, A2, A3, T> extends _.Fn4<A1, A2, A3, NodeCallback<T>, void> { }
+        interface NodeFn4<A1, A2, A3, A4, T> extends _.Fn5<A1, A2, A3, A4, NodeCallback<T>, void> { }
+        interface NodeFn5<A1, A2, A3, A4, A5, T> extends _.Fn6<A1, A2, A3, A4, A5, NodeCallback<T>, void> { }
+    }
 
-    function lift<T>(f: () => T): () => Promise<T>;
-    function lift<T, A>(f: (a: A) => T): (a: Promise<A>) => Promise<T>;
-    function lift<T, A, B>(f: (a: A, b: B) => T): (a: Promise<A>, b: Promise<B>) => Promise<T>;
-    function lift<T, A, B, C>(f: (a: A, b: B, c: C) => T): (a: Promise<A>, b: Promise<B>, c: Promise<C>) => Promise<T>;
+    function attempt<T>(
+        f: _.Fn0<T>
+    ): Promise<T>;
+
+    function attempt<A1, T>(
+        f: _.Fn1<A1, T>,
+        arg1: A1 | Promise<A1>
+    ): Promise<T>;
+
+    function attempt<A1, A2, T>(
+        f: _.Fn2<A1, A2, T>,
+        arg1: A1 | Promise<A1>,
+        arg2: A2 | Promise<A2>
+    ): Promise<T>;
+
+    function attempt<A1, A2, A3, T>(
+        f: _.Fn3<A1, A2, A3, T>,
+        arg1: A1 | Promise<A1>,
+        arg2: A2 | Promise<A2>,
+        arg3: A3 | Promise<A3>
+    ): Promise<T>;
+
+    function attempt<A1, A2, A3, A4, T>(
+        f: _.Fn4<A1, A2, A3, A4, T>,
+        arg1: A1 | Promise<A1>,
+        arg2: A2 | Promise<A2>,
+        arg3: A3 | Promise<A3>,
+        arg4: A4 | Promise<A4>
+    ): Promise<T>;
+
+    function attempt<A1, A2, A3, A4, A5, T>(
+        f: _.Fn5<A1, A2, A3, A4, A5, T>,
+        arg1: A1 | Promise<A1>,
+        arg2: A2 | Promise<A2>,
+        arg3: A3 | Promise<A3>,
+        arg4: A4 | Promise<A4>,
+        arg5: A5 | Promise<A5>
+    ): Promise<T>;
+
+
+    function lift<T>(f: _.Fn0<T>): _.LiftedFn0<T>;
+    function lift<A1, T>(f: _.Fn1<A1, T>): _.LiftedFn1<A1, T>;
+    function lift<A1, A2, T>(f: _.Fn2<A1, A2, T>): _.LiftedFn2<A1, A2, T>;
+    function lift<A1, A2, A3, T>(f: _.Fn3<A1, A2, A3, T>): _.LiftedFn3<A1, A2, A3, T>;
+    function lift<A1, A2, A3, A4, T>(f: _.Fn4<A1, A2, A3, A4, T>): _.LiftedFn4<A1, A2, A3, A4, T>;
+    function lift<A1, A2, A3, A4, A5, T>(f: _.Fn5<A1, A2, A3, A4, A5, T>): _.LiftedFn5<A1, A2, A3, A4, A5, T>;
 
     function promise<T>(resolver: (resolve: (value: T) => void, reject: (reason: any) => void) => void): Promise<T>;
 
@@ -92,16 +142,13 @@ declare module When {
     }
 
     interface Promise<T> {
-        catch<U>(onRejected?: (reason: any) => Promise<U>): Promise<U>;
-        catch<U>(onRejected?: (reason: any) => U): Promise<U>;
+        catch<U>(onRejected?: (reason: any) => U | Promise<U>): Promise<U>;
 
-        catch<U>(filter: (reason: any) => boolean, onRejected?: (reason: any) => Promise<U>): Promise<U>;
-        catch<U>(filter: (reason: any) => boolean, onRejected?: (reason: any) => U): Promise<U>;
+        catch<U>(filter: (reason: any) => boolean, onRejected?: (reason: any) => U | Promise<U>): Promise<U>;
 
         // Make sure you test any usage of these overloads, exceptionType must
         // be a constructor with prototype set to an instance of Error.
         catch<U>(exceptionType: any, onRejected?: (reason: any) => Promise<U>): Promise<U>;
-        catch<U>(exceptionType: any, onRejected?: (reason: any) => U): Promise<U>;
 
         finally(onFulfilledOrRejected: Function): Promise<T>;
 
@@ -109,8 +156,7 @@ declare module When {
 
         inspect(): Snapshot<T>;
 
-        yield<U>(value: Promise<U>): Promise<U>;
-        yield<U>(value: U): Promise<U>;
+        yield<U>(value: U | Promise<U>): Promise<U>;
 
         else(value: T): Promise<T>;
         orElse(value: T): Promise<T>;
@@ -124,29 +170,19 @@ declare module When {
         with(thisArg: any): Promise<T>;
         withThis(thisArg: any): Promise<T>;
 
-        otherwise<U>(onRejected?: (reason: any) => Promise<U>): Promise<U>;
-        otherwise<U>(onRejected?: (reason: any) => U): Promise<U>;
+        otherwise<U>(onRejected?: (reason: any) => U | Promise<U>): Promise<U>;
 
-        otherwise<U>(predicate: (reason: any) => boolean, onRejected?: (reason: any) => Promise<U>): Promise<U>;
-        otherwise<U>(predicate: (reason: any) => boolean, onRejected?: (reason: any) => U): Promise<U>;
+        otherwise<U>(predicate: (reason: any) => boolean, onRejected?: (reason: any) => U | Promise<U>): Promise<U>;
 
         // Make sure you test any usage of these overloads, exceptionType must
         // be a constructor with prototype set to an instance of Error.
-        otherwise<U>(exceptionType: any, onRejected?: (reason: any) => Promise<U>): Promise<U>;
-        otherwise<U>(exceptionType: any, onRejected?: (reason: any) => U): Promise<U>;
+        otherwise<U>(exceptionType: any, onRejected?: (reason: any) => U | Promise<U>): Promise<U>;
 
-        then<U>(onFulfilled: (value: T) => Promise<U>, onRejected?: (reason: any) => Promise<U>, onProgress?: (update: any) => void): Promise<U>;
-        then<U>(onFulfilled: (value: T) => Promise<U>, onRejected?: (reason: any) => U, onProgress?: (update: any) => void): Promise<U>;
-        then<U>(onFulfilled: (value: T) => U, onRejected?: (reason: any) => Promise<U>, onProgress?: (update: any) => void): Promise<U>;
-        then<U>(onFulfilled: (value: T) => U, onRejected?: (reason: any) => U, onProgress?: (update: any) => void): Promise<U>;
+        then<U>(onFulfilled: (value: T) => U | Promise<U>, onRejected?: (reason: any) => U | Promise<U>, onProgress?: (update: any) => void): Promise<U>;
 
         done<U>(onFulfilled: (value: T) => void, onRejected?: (reason: any) => void): void;
 
-        fold<U, V>(combine: (value1: T, value2: V) => Promise<U>, value2: V): Promise<U>;
-        fold<U, V>(combine: (value1: T, value2: V) => Promise<U>, value2: Promise<V>): Promise<U>;
-
-        fold<U, V>(combine: (value1: T, value2: V) => U, value2: V): Promise<U>;
-        fold<U, V>(combine: (value1: T, value2: V) => U, value2: Promise<V>): Promise<U>;
+        fold<U, V>(combine: (value1: T, value2: V) => U | Promise<U>, value2: V | Promise<V>): Promise<U>;
     }
 
     interface Thenable<T> {
@@ -166,40 +202,65 @@ declare module "when" {
 
 declare module "when/node" {
     import when = require('when');
+    import _ = when._;
 
-    function lift<TResult>(fn: (callback: (err: any, result: TResult) => void) => void): () => when.Promise<TResult>;
-    function lift<TArg1, TResult>(fn: (arg1: TArg1, callback: (err: any, result: TResult) => void) => void): (arg1: when.Promise<TArg1>) => when.Promise<TResult>;
-    function lift<TArg1, TArg2, TResult>(fn: (arg1: TArg1, arg2: TArg2, callback: (err: any, result: TResult) => void) => void): (arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>) => when.Promise<TResult>;
-    function lift<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void): (arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>) => when.Promise<TResult>;
+    function lift<T>(fn: _.NodeFn0<T>): _.LiftedFn0<T>;
+    function lift<A1, T>(fn: _.NodeFn1<A1, T>): _.LiftedFn1<A1, T>;
+    function lift<A1, A2, T>(fn: _.NodeFn2<A1, A2, T>): _.LiftedFn2<A1, A2, T>;
+    function lift<A1, A2, A3, T>(fn: _.NodeFn3<A1, A2, A3, T>): _.LiftedFn3<A1, A2, A3, T>;
+    function lift<A1, A2, A3, A4, T>(fn: _.NodeFn4<A1, A2, A3, A4, T>): _.LiftedFn4<A1, A2, A3, A4, T>;
+    function lift<A1, A2, A3, A4, A5, T>(fn: _.NodeFn5<A1, A2, A3, A4, A5, T>): _.LiftedFn5<A1, A2, A3, A4, A5, T>;
+
+
+    function call<T>(
+        fn: _.NodeFn0<T>
+    ): when.Promise<T>;
+
+    function call<A1, T>(
+        fn: _.NodeFn1<A1, T>,
+        arg1: A1 | when.Promise<A1>
+    ): when.Promise<T>;
+
+    function call<A1, A2, T>(
+        fn: _.NodeFn2<A1, A2, T>,
+        arg1: A1 | when.Promise<A1>,
+        arg2: A2 | when.Promise<A2>
+    ): when.Promise<T>;
+
+    function call<A1, A2, A3, T>(
+        fn: _.NodeFn3<A1, A2, A3, T>,
+        arg1: A1 | when.Promise<A1>,
+        arg2: A2 | when.Promise<A2>,
+        arg3: A3 | when.Promise<A3>
+    ): when.Promise<T>;
+
+    function call<A1, A2, A3, A4, T>(
+        fn: _.NodeFn4<A1, A2, A3, A4, T>,
+        arg1: A1 | when.Promise<A1>,
+        arg2: A2 | when.Promise<A2>,
+        arg3: A3 | when.Promise<A3>,
+        arg4: A4 | when.Promise<A4>
+    ): when.Promise<T>;
+
+    function call<A1, A2, A3, A4, A5, T>(
+        fn: _.NodeFn5<A1, A2, A3, A4, A5, T>,
+        arg1: A1 | when.Promise<A1>,
+        arg2: A2 | when.Promise<A2>,
+        arg3: A3 | when.Promise<A3>,
+        arg4: A4 | when.Promise<A4>,
+        arg5: A5 | when.Promise<A5>
+    ): when.Promise<T>;
+
+
+    function apply<T>(fn: _.NodeFn0<T>, args: any[]): when.Promise<T>;
+    function apply<T>(fn: _.NodeFn1<any, T>, args: any[]): when.Promise<T>;
+    function apply<T>(fn: _.NodeFn2<any, any, T>, args: any[]): when.Promise<T>;
+    function apply<T>(fn: _.NodeFn3<any, any, any, T>, args: any[]): when.Promise<T>;
+    function apply<T>(fn: _.NodeFn4<any, any, any, any, T>, args: any[]): when.Promise<T>;
+    function apply<T>(fn: _.NodeFn5<any, any, any, any, any, T>, args: any[]): when.Promise<T>;
 
 
     function liftAll(srcApi: any, transform?: (destApi: any, liftedFunc: Function, name: string) => any, destApi?: any): any;
-
-
-    function call<TResult>(fn: (callback: (err: any, result: TResult) => void) => void): when.Promise<TResult>;
-
-    function call<TArg1, TResult>(fn: (arg1: TArg1, callback: (err: any, result: TResult) => void) => void, arg1: TArg1): when.Promise<TResult>;
-    function call<TArg1, TResult>(fn: (arg1: TArg1, callback: (err: any, result: TResult) => void) => void, arg1: when.Promise<TArg1>): when.Promise<TResult>;
-
-    function call<TArg1, TArg2, TResult>(fn: (arg1: TArg1, arg2: TArg2, callback: (err: any, result: TResult) => void) => void, arg1: TArg1, arg2: TArg2): when.Promise<TResult>;
-    function call<TArg1, TArg2, TResult>(fn: (arg1: TArg1, arg2: TArg2, callback: (err: any, result: TResult) => void) => void, arg1: when.Promise<TArg1>, arg2: TArg2): when.Promise<TResult>;
-    function call<TArg1, TArg2, TResult>(fn: (arg1: TArg1, arg2: TArg2, callback: (err: any, result: TResult) => void) => void, arg1: TArg1, arg2: when.Promise<TArg2>): when.Promise<TResult>;
-    function call<TArg1, TArg2, TResult>(fn: (arg1: TArg1, arg2: TArg2, callback: (err: any, result: TResult) => void) => void, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>): when.Promise<TResult>;
-
-    function call<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void, arg1: TArg1, arg2: TArg2, arg3: TArg3): when.Promise<TResult>;
-    function call<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void, arg1: TArg1, arg2: TArg2, arg3: when.Promise<TArg3>): when.Promise<TResult>;
-    function call<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void, arg1: TArg1, arg2: when.Promise<TArg2>, arg3: TArg3): when.Promise<TResult>;
-    function call<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void, arg1: TArg1, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>): when.Promise<TResult>;
-    function call<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void, arg1: when.Promise<TArg1>, arg2: TArg2, arg3: TArg3): when.Promise<TResult>;
-    function call<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void, arg1: when.Promise<TArg1>, arg2: TArg2, arg3: when.Promise<TArg3>): when.Promise<TResult>;
-    function call<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: TArg3): when.Promise<TResult>;
-    function call<TArg1, TArg2, TArg3, TResult>(fn: (arg1: TArg1, arg2: TArg2, arg3: TArg3, callback: (err: any, result: TResult) => void) => void, arg1: when.Promise<TArg1>, arg2: when.Promise<TArg2>, arg3: when.Promise<TArg3>): when.Promise<TResult>;
-
-
-    function apply<TResult>(fn: (callback: (err: any, result: TResult) => void) => void, args: any[]): when.Promise<TResult>;
-    function apply<TResult>(fn: (arg1: any, callback: (err: any, result: TResult) => void) => void, args: any[]): when.Promise<TResult>;
-    function apply<TResult>(fn: (arg1: any, arg2: any, callback: (err: any, result: TResult) => void) => void, args: any[]): when.Promise<TResult>;
-    function apply<TResult>(fn: (arg1: any, arg2: any, arg3: any, callback: (err: any, result: TResult) => void) => void, args: any[]): when.Promise<TResult>;
 
 
     function liftCallback<TArg>(callback: (err: any, arg: TArg) => void): (value: when.Promise<TArg>) => when.Promise<TArg>;


### PR DESCRIPTION
Checks all variations of up to 3 argument versions of variadic functions along with the 5 argument version. Uses some helper interfaces to reduce noise when reading the function signatures (seems like the `Fn*` and `NodeFn*` interfaces should exist elsewhere, although importing them would add a dependency on another file...)
