### PR TITLE
Update the Definition file of D3.js to v3.5.0

### DIFF
--- a/d3/d3-tests.ts
+++ b/d3/d3-tests.ts
@@ -2736,7 +2736,7 @@ function quadtreeFindTest(){
       return [Math.random() * width, Math.random() * height];
     });
 
-    var quadtree = d3.geom.quadtree
+    var quadtree = d3.geom.quadtree()
         .extent([[-1, -1], [width + 1, height + 1]])
         (data);
 

--- a/d3/d3-tests.ts
+++ b/d3/d3-tests.ts
@@ -2785,3 +2785,41 @@ function quadtreeFindTest(){
       return nodes;
     }
 }
+
+//Tests for named d3.transition()
+//Adopted from http://bl.ocks.org/mbostock/5d8039fb983a29e2ad49
+function namedTransitionTest(){
+    var width = 960,
+    height = 500;
+
+    var svg = d3.select("body").append("svg")
+        .attr("width", width)
+        .attr("height", height);
+
+    svg.append("g")
+        .attr("transform", "translate(" + (width / 2) + "," + (height / 2) + ")")
+      .append("path")
+        .attr("d", d3.svg.symbol().type("cross").size(50000))
+        .call(twizzle, 20000)
+        .call(plonk, 2000);
+
+    function twizzle(path, duration) {
+      path.transition("twizzle")
+          .duration(duration)
+          .attrTween("transform", function() { return d3.interpolateString("rotate(0)", "rotate(720)"); })
+        .transition()
+          .duration(Math.random() * duration)
+          .each("end", function() { path.call(twizzle, duration); });
+    }
+
+    function plonk(path, duration) {
+      path.transition("plonk")
+          .duration(duration)
+          .style("stroke-width", "30px")
+        .transition()
+          .style("stroke-width", "0px")
+        .transition()
+          .duration(Math.random() * duration)
+          .each("end", function() { path.call(plonk, duration); });
+    }
+}

--- a/d3/d3-tests.ts
+++ b/d3/d3-tests.ts
@@ -2725,3 +2725,63 @@ function cornerRadiusTest(){
         .style("stroke-width", "1.5px")
         .attr("d", arc);
 }
+
+//Tests for d3.geom.quadtree.find
+//Adopted from http://bl.ocks.org/mbostock/9078690#index.html
+function quadtreeFindTest(){
+    var width = 960,
+    height = 500;
+
+    var data = d3.range(2500).map(function() {
+      return [Math.random() * width, Math.random() * height];
+    });
+
+    var quadtree = d3.geom.quadtree()
+        .extent([[-1, -1], [width + 1, height + 1]])
+        (data);
+
+    var svg = d3.select("body").append("svg")
+        .attr("width", width)
+        .attr("height", height);
+
+    svg.selectAll(".node")
+        .data(nodes(quadtree))
+      .enter().append("rect")
+        .attr("class", "node")
+        .attr("x", function(d) { return d.x0; })
+        .attr("y", function(d) { return d.y0; })
+        .attr("width", function(d) { return d.y1 - d.y0; })
+        .attr("height", function(d) { return d.x1 - d.x0; });
+
+    var point = svg.selectAll(".point")
+        .data(data)
+      .enter().append("circle")
+        .attr("class", "point")
+        .attr("cx", function(d) { return d[0]; })
+        .attr("cy", function(d) { return d[1]; })
+        .attr("r", 4);
+
+    svg.append("rect")
+        .attr("class", "overlay")
+        .attr("width", width)
+        .attr("height", height)
+        .on("mousemove", mousemoved);
+
+    function mousemoved() {
+      point.each(function(d) { d.scanned = false; });
+      var p = quadtree.find(d3.mouse(this));
+      point.classed("scanned", function(d) { return d.scanned; });
+      point.classed("selected", function(d) { return d === p; });
+    }
+
+    // Collapse the quadtree into an array of rectangles.
+    function nodes(quadtree) {
+      var nodes = [];
+      quadtree.visit(function(node, x0, y0, x1, y1) {
+        node.x0 = x0, node.y0 = y0;
+        node.x1 = x1, node.y1 = y1;
+        nodes.push(node);
+      });
+      return nodes;
+    }
+}

--- a/d3/d3-tests.ts
+++ b/d3/d3-tests.ts
@@ -2626,3 +2626,102 @@ function multiTest() {
         .attr("transform", "translate(0," + height + ")")
         .call(xAxis);
 }
+
+//Tests for d3.layout.pie.padAngle
+//Adopted from http://bl.ocks.org/mbostock/f098d146315be4d1db52
+function padAngleTest(){
+    var data = [1, 1, 2, 3, 5, 8, 13, 21];
+
+    var width = 960,
+        height = 500,
+        radius = height / 2 - 10;
+
+    var arc = d3.svg.arc()
+        .innerRadius(radius - 40)
+        .outerRadius(radius);
+
+    var pie = d3.layout.pie()
+        .padAngle(.02);
+
+    var color = d3.scale.category10();
+
+    var svg = d3.select("body").append("svg")
+        .attr("width", width)
+        .attr("height", height)
+      .append("g")
+        .attr("transform", "translate(" + width / 2 + "," + height / 2 + ")");
+
+    svg.selectAll("path")
+        .data(pie(data))
+      .enter().append("path")
+        .style("fill", function(d, i) { return color(i); })
+        .attr("d", arc);
+}
+
+//Tests for d3.svg.arc.cornerRadius
+//Adopted from http://bl.ocks.org/mbostock/aff9e559c5c9968b7ac6
+function cornerRadiusTest(){
+    var data = [1, 1, 2, 3, 5, 8, 13];
+
+    var width = 960,
+        height = 500,
+        outerRadius = height / 2 - 10,
+        innerRadius = outerRadius - 60,
+        cornerRadius = 12,
+        padAngle = .03;
+
+    var pie = d3.layout.pie()
+        .padAngle(padAngle);
+
+    var arcs = pie(data);
+
+    var arc = d3.svg.arc()
+        .innerRadius(innerRadius)
+        .outerRadius(outerRadius)
+        .cornerRadius(cornerRadius);
+
+    var color = d3.scale.category10();
+
+    var svg = d3.select("body").append("svg")
+        .attr("width", width)
+        .attr("height", height)
+      .append("g")
+        .attr("transform", "translate(" + width / 2 + "," + height / 2 + ")");
+
+    svg.append("circle")
+        .style("fill", "none")
+        .style("stroke", "#555")
+        .attr("r", innerRadius);
+
+    svg.append("circle")
+        .style("fill", "none")
+        .style("stroke", "#555")
+        .attr("r", outerRadius);
+
+    svg.append("g")
+        .style("stroke", "#555")
+        .style("fill", "none")
+        .attr("class", "corner")
+      .selectAll("circle")
+        .data(d3.merge(arcs.map(function(d) {
+          return [
+            {angle: d.startAngle + padAngle / 2, radius: outerRadius - cornerRadius, start: +1},
+            {angle:   d.endAngle - padAngle / 2, radius: outerRadius - cornerRadius, start: -1},
+            {angle:   d.endAngle - padAngle / 2 * outerRadius / innerRadius, radius: innerRadius + cornerRadius, start: -1},
+            {angle: d.startAngle + padAngle / 2 * outerRadius / innerRadius, radius: innerRadius + cornerRadius, start: +1}
+          ];
+        })))
+      .enter().append("circle")
+        .attr("cx", function(d) { return d.start * cornerRadius * Math.cos(d.angle) + Math.sqrt(d.radius * d.radius - cornerRadius * cornerRadius) * Math.sin(d.angle); })
+        .attr("cy", function(d) { return d.start * cornerRadius * Math.sin(d.angle) - Math.sqrt(d.radius * d.radius - cornerRadius * cornerRadius) * Math.cos(d.angle); })
+        .attr("r", cornerRadius);
+
+    svg.append("g").selectAll("path")
+        .data(arcs)
+      .enter().append("path")
+        .style("fill", function(d, i) { return color(i); })
+        .style("fill-opacity", .25)
+        .style("stroke", "#000")
+        .style("stroke-width", "1.5px")
+        .attr("d", arc);
+}

--- a/d3/d3-tests.ts
+++ b/d3/d3-tests.ts
@@ -2736,7 +2736,7 @@ function quadtreeFindTest(){
       return [Math.random() * width, Math.random() * height];
     });
 
-    var quadtree = d3.geom.quadtree()
+    var quadtree = d3.geom.quadtree
         .extent([[-1, -1], [width + 1, height + 1]])
         (data);
 

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -426,6 +426,10 @@ declare module D3 {
         */
         interpolateTransform: Transition.BaseInterpolate;
         /*
+        * Interpolate two views a and b of a two-dimensional plane
+        */
+        interpolateZoom:Transition.BaseInterpolate;
+        /*
         * The array of built-in interpolator factories
         */
         interpolators: Transition.InterpolateFactory[];

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1008,6 +1008,7 @@ declare module D3 {
             	(type: string, eachFunction: (data: any, index: number) => any) : Transition;
             }
             transition: () => Transition;
+            tween: (name: string, tween?: (d: any, i: number, a: any) => BaseInterpolate): Transition;
             ease: (value: string, ...arrs: any[]) => Transition;
             attrTween(name: string, tween: (d: any, i: number, a: any) => BaseInterpolate): Transition;
             styleTween(name: string, tween: (d: any, i: number, a: any) => BaseInterpolate, priority?: string): Transition;

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -3361,7 +3361,11 @@ declare module D3 {
             * Constructs a new quadtree for the specified array of points.
             */
             (points: Point[], width: number, height: number): Quadtree;
-
+            /**
+            * Constructs a new quadtree for the specified array of points.
+            * Each point cloud be store as array [x,y];
+            */
+            (points: Array<number[]>):Quadtree;
             x: {
                 (): (d: any) => any;
                 (accesor: (d: any) => any): QuadtreeFactory;

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -967,8 +967,8 @@ declare module D3 {
                 (elements: EventTarget[]): Transition;
             }
             each: {
-            	(type: (data: any, index: number) => any) => Transition;
-            	(type: string, eachFunction: (data: any, index: number) => any) => Transition;
+            	(type: (data: any, index: number) => any) : Transition;
+            	(type: string, eachFunction: (data: any, index: number) => any) : Transition;
             }
             transition: () => Transition;
             ease: (value: string, ...arrs: any[]) => Transition;

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -601,7 +601,7 @@ declare module D3 {
             (funct: () => boolean, delay?: number, mark?: number): void;
             flush(): void;
         }
-        transition(): Transition.Transition;
+        transition(name?: string): Transition.Transition;
 
         round(x: number, n: number): number;
     }
@@ -837,8 +837,9 @@ declare module D3 {
         /**
         * Starts a transition for the current selection. Transitions behave much like selections,
         * except operators animate smoothly over time rather than applying instantaneously.
+        * by giving transitions different names transitions can run at the same time on the same element without interference.
         */
-        transition(): Transition.Transition;
+        transition(name?: string): Transition.Transition;
 
         /**
         * Sorts the elements in the current selection according to the specified comparator

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -2699,6 +2699,7 @@ declare module D3 {
 
         export interface OrdinalScale extends GenericScale<OrdinalScale> {
             rangePoints(interval: any[], padding?: number): OrdinalScale;
+            rangeRoundPoints(interval: any[], padding?: number): OrdinalScale;
             rangeBands(interval: any[], padding?: number, outerPadding?: number): OrdinalScale;
             rangeRoundBands(interval: any[], padding?: number, outerPadding?: number): OrdinalScale;
             rangeBand(): number;

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -555,10 +555,15 @@ declare module D3 {
         functor<R,T>(value: (p : R) => T): (p : R) => T;
         functor<T>(value: T): (p : any) => T;
 
-        map(): Map<any>;
-        set(): Set<any>;
-        map<T>(object: {[key: string]: T; }): Map<T>;
-        set<T>(array: T[]): Set<T>;
+        map:{
+        	<T>():Map<T>;
+        	<T>(object: {[key: string]: T; }) : Map<T>;
+        	<T>(object: Array<T>, accessor?: (d: T, index: number)) : Map<T>;
+        }
+        set:{
+        	<T>():Set<T>;
+        	<T>(array: T[]):Set<T>;
+        }
         dispatch(...types: string[]): Dispatch;
         rebind(target: any, source: any, ...names: any[]): any;
         requote(str: string): string;

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -3383,6 +3383,10 @@ declare module D3 {
             */
             add(point: Point): void;
             visit(callback: any): void;
+            /**
+            * the point is a Array of number with two element : [x, y]
+            */
+            find(point: number[]):Point;
         }
 
         export interface Point {

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -119,7 +119,7 @@ declare module D3 {
         * @param arr Array to search
         * @param map Accsessor function
         */
-        extent<T, U>(arr: T[], map: (v: T) => U): U[];
+        extent<T, U>(arr: T[], map: (v: T, i?: number) => U): U[];
         /**
         * Find the minimum and maximum value in an array
         *
@@ -129,42 +129,72 @@ declare module D3 {
         /**
         * Compute the sum of an array of numbers
         *
-        * @param arr Array to search
+        * @param arr Array to compute
         * @param map Accsessor function
         */
-        sum<T>(arr: T[], map: (v: T) => number): number;
+        sum<T>(arr: T[], map: (v: T, i?: number) => number): number;
         /**
         * Compute the sum of an array of numbers
         *
-        * @param arr Array to search
+        * @param arr Array to compute
         */
         sum(arr: number[]): number;
         /**
         * Compute the arithmetic mean of an array of numbers
         *
-        * @param arr Array to search
+        * @param arr Array to compute
         * @param map Accsessor function
         */
-        mean<T>(arr: T[], map: (v: T) => number): number;
+        mean<T>(arr: T[], map: (v: T, i?: number) => number): number;
         /**
         * Compute the arithmetic mean of an array of numbers
         *
-        * @param arr Array to search
+        * @param arr Array to compute
         */
         mean(arr: number[]): number;
         /**
         * Compute the median of an array of numbers (the 0.5-quantile).
         *
-        * @param arr Array to search
+        * @param arr Array to compute
         * @param map Accsessor function
         */
-        median<T>(arr: T[], map: (v: T) => number): number;
+        median<T>(arr: T[], map: (v: T, i?: number) => number): number;
         /**
         * Compute the median of an array of numbers (the 0.5-quantile).
         *
-        * @param arr Array to search
+        * @param arr Array to compute
         */
         median(arr: number[]): number;
+
+        /**
+        * Compute the variance of an array of numbers.
+        *
+        * @param arr Array to compute
+        * @param map Accsessor function
+        */
+        variance<T>(arr: T[], map: (v: T, i?: number) => number): number;
+        /**
+        * Compute the variance of an array of numbers.
+        *
+        * @param arr Array to compute
+        */
+        variance(arr: number[]): number;
+
+        /**
+        * Compute the deviation of an array of numbers.
+        *
+        * @param arr Array to compute
+        * @param map Accsessor function
+        */
+        deviation<T>(arr: T[], map: (v: T, i?: number) => number): number;
+        /**
+        * Compute the deviation of an array of numbers.
+        *
+        * @param arr Array to compute
+        */
+        deviation(arr: number[]): number;
+
+
         /**
         * Compute a quantile for a sorted array of numbers.
         *
@@ -558,7 +588,7 @@ declare module D3 {
         map:{
         	<T>():Map<T>;
         	<T>(object: {[key: string]: T; }) : Map<T>;
-        	<T>(object: Array<T>, accessor?: (d: T, index: number)) : Map<T>;
+        	<T>(object: Array<T>, accessor?: (d: T, index?: number)) : Map<T>;
         }
         set:{
         	<T>():Set<T>;

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -2796,11 +2796,11 @@ declare module D3 {
             */
             scale: {
                 /**
-                * Get the current current zoom scale
+                * Get the current zoom scale
                 */
                 (): number;
                 /**
-                * Set the current current zoom scale
+                * Set the current zoom scale
                 *
                 * @param origin Zoom scale
                 */
@@ -2871,6 +2871,39 @@ declare module D3 {
                 */
                 (y: D3.Scale.Scale): Zoom;
             };
+
+            /**
+            * Gets or set the viewport size
+            */
+            size:{
+                /**
+                * Get the current viewport size
+                */
+                (): number[];
+                /**
+                * Set the viewport size
+                *
+                * @param viewport size
+                */
+                (extent: number[]): Zoom;
+            }
+
+            /**
+            * Gets or set the zoom duration
+            */
+            duration:{
+                /**
+                * Get the current zoom duration
+                */
+                (): number;
+                /**
+                * Set the zoom duration
+                *
+                * @param origin Zoom duration
+                */
+                (duration: number): Zoom;
+
+            }
         }
 
         export interface Drag {

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -588,7 +588,7 @@ declare module D3 {
         map:{
         	<T>():Map<T>;
         	<T>(object: {[key: string]: T; }) : Map<T>;
-        	<T>(object: Array<T>, accessor?: (d: T, index?: number)) : Map<T>;
+        	<T>(object: Array<T>, accessor?: (d: T, index?: number) => T) : Map<T>;
         }
         set:{
         	<T>():Set<T>;

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -966,10 +966,7 @@ declare module D3 {
                 */
                 (elements: EventTarget[]): Transition;
             }
-            each: {
-            	(type: (data: any, index: number) => any) => Transition;
-            	(type: string, eachFunction: (data: any, index: number) => any) => Transition;
-            }
+            each: (type?: any, eachFunction?: (data: any, index: number) => any) => Transition;
             transition: () => Transition;
             ease: (value: string, ...arrs: any[]) => Transition;
             attrTween(name: string, tween: (d: any, i: number, a: any) => BaseInterpolate): Transition;

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -209,8 +209,10 @@ declare module D3 {
         * Randomize the order of an array.
         *
         * @param arr Array to randomize
+        * @param low 
+        * @param high
         */
-        shuffle<T>(arr: T[]): T[];
+        shuffle<T>(arr: T[], low?: number, hight?: number): T[];
         /**
         * Reorder an array of elements according to an array of indexes
         *

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for d3JS
+// Type definitions for d3JS v3.5.0
 // Project: http://d3js.org/
 // Definitions by: Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -1231,6 +1231,13 @@ declare module D3 {
                 (angle: (d : any) => number): PieLayout
                 (angle: (d : any, i: number) => number): PieLayout;
             };
+            padAngle:{
+            	():number;
+            	(angle:number):PieLayout;
+            	(angle:()=>number):PieLayout;
+                (angle: (d : any) => number): PieLayout
+                (angle: (d : any, i: number) => number): PieLayout;
+            }
         }
 
         export interface ArcDescriptor {
@@ -1836,6 +1843,13 @@ declare module D3 {
                 (angle: (data: any) => number): Arc;
                 (angle: (data: any, index: number) => number): Arc;
             };
+            cornerRadius:{
+                (): (data: any, index?: number) => number;
+                (radius: number): Arc;
+                (radius: () => number): Arc;
+                (radius: (data: any) => number): Arc;
+                (radius: (data: any, index: number) => number): Arc;
+            }
             centroid(data: any, index?: number): number[];
         }
 

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -209,8 +209,8 @@ declare module D3 {
         * Randomize the order of an array.
         *
         * @param arr Array to randomize
-        * @param low 
-        * @param high
+        * @param low Lower bound index of array subset
+        * @param high Upper bound index of array subset
         */
         shuffle<T>(arr: T[], low?: number, hight?: number): T[];
         /**

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1009,7 +1009,6 @@ declare module D3 {
             	(type: string, eachFunction: (data: any, index: number) => any) : Transition;
             }
             transition: () => Transition;
-            tween: (name: string, tween?: (d: any, i: number, a: any) => BaseInterpolate): Transition;
             ease: (value: string, ...arrs: any[]) => Transition;
             attrTween(name: string, tween: (d: any, i: number, a: any) => BaseInterpolate): Transition;
             styleTween(name: string, tween: (d: any, i: number, a: any) => BaseInterpolate, priority?: string): Transition;

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -966,7 +966,7 @@ declare module D3 {
                 */
                 (elements: EventTarget[]): Transition;
             }
-            each: (type?: string, eachFunction?: (data: any, index: number) => any) => Transition;
+            each: (type?: any, eachFunction?: (data: any, index: number) => any) => Transition;
             transition: () => Transition;
             ease: (value: string, ...arrs: any[]) => Transition;
             attrTween(name: string, tween: (d: any, i: number, a: any) => BaseInterpolate): Transition;

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -966,7 +966,10 @@ declare module D3 {
                 */
                 (elements: EventTarget[]): Transition;
             }
-            each: (type?: any, eachFunction?: (data: any, index: number) => any) => Transition;
+            each: {
+            	(type: (data: any, index: number) => any) => Transition;
+            	(type: string, eachFunction: (data: any, index: number) => any) => Transition;
+            }
             transition: () => Transition;
             ease: (value: string, ...arrs: any[]) => Transition;
             attrTween(name: string, tween: (d: any, i: number, a: any) => BaseInterpolate): Transition;


### PR DESCRIPTION
1.Add the signature of InterpolateZoom. It seems that this method has been support from 2 years ago. However there is no signature of this method in the d.ts of D3.

2.Correct a signature. Base on the source code of D3, the first parameter of Transition.each(..) could be a callback function or a string variable.
