### PR TITLE
Add "should" property to any Object

### DIFF
--- a/chai/chai-tests.ts
+++ b/chai/chai-tests.ts
@@ -38,6 +38,12 @@ function ok() {
     }, "expected 'test' to be falsy");
 }
 
+function should() {
+    var obj: Object = {};
+    expect(obj).to.have.property('should');
+    expect(obj.should).to.have.property('to');
+}
+
 function _false() {
     expect(false).to.be.false;
     expect(true).to.not.be.false;

--- a/chai/chai.d.ts
+++ b/chai/chai.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for chai 1.7.2
 // Project: http://chaijs.com/
-// Definitions by: Jed Hunsaker <https://github.com/jedhunsaker/>, Bart van der Schoor <https://github.com/Bartvds>
+// Definitions by: Jed Hunsaker <https://github.com/jedhunsaker/>, Bart van der Schoor <https://github.com/Bartvds>, otiai10 <https://github.com/otiai10>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module chai {
@@ -13,6 +13,12 @@ declare module chai {
     }
 
     export function expect(target: any, message?: string): Expect;
+
+    // The should style allows for the same chainable assertions as the expect interface, by extending any object to have 'should' property.
+    export function should(): Expect;
+    interface ShouldChainable {
+        should: Expect;
+    }
 
     export var assert: Assert;
     export var config: Config;
@@ -282,3 +288,5 @@ declare module chai {
 declare module "chai" {
     export = chai;
 }
+
+interface Object extends chai.ShouldChainable {}


### PR DESCRIPTION
# Summary
- Add exported `should()` method and `should` property to `Object`
# Reference
- http://chaijs.com/guide/styles/#should

> The should style allows for the same chainable assertions as the expect interface, however it extends each object with a should property to start your chain. This style has some issues when used Internet Explorer, so be aware of browser compatibility.

``` js
var should = require('chai').should() //actually call the the function
  , foo = 'bar'
  , beverages = { tea: [ 'chai', 'matcha', 'oolong' ] };

foo.should.be.a('string');
foo.should.equal('bar');
foo.should.have.length(3);
beverages.should.have.property('tea').with.length(3);
```
