### PR TITLE
Improvements to m.prop, m.redraw.strategy.

### DIFF
--- a/mithril/mithril.d.ts
+++ b/mithril/mithril.d.ts
@@ -39,8 +39,8 @@ interface MithrilVirtualElement {
 }
 
 interface MithrilModule {
-	controller: Function;
-	view: Function;
+    controller: Function;
+    view: (controller?: any) => MithrilVirtualElement;
 }
 
 interface MithrilDeferred<T> {

--- a/mithril/mithril.d.ts
+++ b/mithril/mithril.d.ts
@@ -20,9 +20,9 @@ interface MithrilStatic {
 	route(path: string, params?: any, shouldReplaceHistory?: boolean): void;
 	route(): string;
 	route(element: Element, isInitialized: boolean): void;
-	request(options: MithrilXHROptions): MithrilPromise;
-	deferred(): MithrilDeferred;
-	sync(promises: MithrilPromise[]): MithrilPromise;
+	request(options: MithrilXHROptions): MithrilPromise<any>;
+	deferred<T>(): MithrilDeferred<T>;
+	sync<T>(promises: MithrilPromise<T>[]): MithrilPromise<T>;
 	startComputation(): void;
 	endComputation(): void;
 }
@@ -43,15 +43,15 @@ interface MithrilModule {
 	view: Function;
 }
 
-interface MithrilDeferred {
-	resolve(value?: any): void;
-	reject(value?: any): void;
-	promise: MithrilPromise;
+interface MithrilDeferred<T> {
+    resolve(value?: T): void;
+    reject(value?: any): void;
+    promise: MithrilPromise<T>;
 }
 
-interface MithrilPromise {
-	(value?: any): any;
-	then(successCallback?: (value: any) => any, errorCallback?: (value: any) => any): MithrilPromise;
+interface MithrilPromise<T> {
+    (value?: T): T;
+    then<R>(successCallback?: (value: T) => R, errorCallback?: (value: any) => any): MithrilPromise<R>;
 }
 
 interface MithrilXHROptions {

--- a/mithril/mithril.d.ts
+++ b/mithril/mithril.d.ts
@@ -8,7 +8,8 @@
 interface MithrilStatic {
 	(selector: string, attributes: Object, children?: any): MithrilVirtualElement;
 	(selector: string, children?: any): MithrilVirtualElement;
-	prop<T>(value?: T): (value?: T) => T;
+    prop<T>(value?: T): (value?: T) => T;
+    prop<T>(promise: MithrilPromise<T>): MithrilPromiseProperty<T>;
 	withAttr(property: string, callback: (value: any) => void): (e: Event) => any;
 	module(rootElement: Node, module: MithrilModule): void;
 	trust(html: string): String;
@@ -52,6 +53,13 @@ interface MithrilDeferred<T> {
 interface MithrilPromise<T> {
     (value?: T): T;
     then<R>(successCallback?: (value: T) => R, errorCallback?: (value: any) => any): MithrilPromise<R>;
+    then<R>(successCallback?: (value: T) => MithrilPromise<R>, errorCallback?: (value: any) => any): MithrilPromise<R>;
+}
+
+interface MithrilPromiseProperty<T> extends MithrilPromise<T> {
+    (): T;
+    (value: T): T;
+    toJSON(): T;
 }
 
 interface MithrilXHROptions {

--- a/mithril/mithril.d.ts
+++ b/mithril/mithril.d.ts
@@ -8,13 +8,13 @@
 interface MithrilStatic {
 	(selector: string, attributes: Object, children?: any): MithrilVirtualElement;
 	(selector: string, children?: any): MithrilVirtualElement;
-    prop<T>(value?: T): (value?: T) => T;
+	prop<T>(value?: T): (value?: T) => T;
 	withAttr(property: string, callback: (value: any) => void): (e: Event) => any;
 	module(rootElement: Node, module: MithrilModule): void;
 	trust(html: string): String;
 	render(rootElement: Element, children?: any): void;
 	render(rootElement: HTMLDocument, children?: any): void;
-    redraw: MithrilRedraw;
+	redraw: MithrilRedraw;
 	route(rootElement: Element, defaultRoute: string, routes: { [key: string]: MithrilModule }): void;
 	route(rootElement: HTMLDocument, defaultRoute: string, routes: { [key: string]: MithrilModule }): void;
 	route(path: string, params?: any, shouldReplaceHistory?: boolean): void;
@@ -28,8 +28,8 @@ interface MithrilStatic {
 }
 
 interface MithrilRedraw {
-    (): void;
-    strategy: (value?: string) => string;
+	(): void;
+	strategy: (value?: string) => string;
 }
 
 interface MithrilVirtualElement {

--- a/mithril/mithril.d.ts
+++ b/mithril/mithril.d.ts
@@ -8,13 +8,13 @@
 interface MithrilStatic {
 	(selector: string, attributes: Object, children?: any): MithrilVirtualElement;
 	(selector: string, children?: any): MithrilVirtualElement;
-	prop(value?: any): (value?: any) => any;
+    prop<T>(value?: T): (value?: T) => T;
 	withAttr(property: string, callback: (value: any) => void): (e: Event) => any;
 	module(rootElement: Node, module: MithrilModule): void;
 	trust(html: string): String;
 	render(rootElement: Element, children?: any): void;
 	render(rootElement: HTMLDocument, children?: any): void;
-	redraw(): void;
+    redraw: MithrilRedraw;
 	route(rootElement: Element, defaultRoute: string, routes: { [key: string]: MithrilModule }): void;
 	route(rootElement: HTMLDocument, defaultRoute: string, routes: { [key: string]: MithrilModule }): void;
 	route(path: string, params?: any, shouldReplaceHistory?: boolean): void;
@@ -25,6 +25,11 @@ interface MithrilStatic {
 	sync(promises: MithrilPromise[]): MithrilPromise;
 	startComputation(): void;
 	endComputation(): void;
+}
+
+interface MithrilRedraw {
+    (): void;
+    strategy: (value?: string) => string;
 }
 
 interface MithrilVirtualElement {


### PR DESCRIPTION
Makes m.prop() generic for better type inference, allows access to
m.redraw.strategy, which was previously impossible.
