### PR TITLE
include the global cordova variable on the window object

### DIFF
--- a/cordova/cordova-tests.ts
+++ b/cordova/cordova-tests.ts
@@ -8,6 +8,8 @@
 
 console.log('cordova.version: ' + cordova.version + ', cordova.platformId: ' + cordova.platformId);
 
+console.log(typeof window.cordova);
+
 cordova.exec(null, null, "NativeClassName", "MethodName");
 
 cordova.define('mymodule', (req, exp, mod)=> {

--- a/cordova/cordova.d.ts
+++ b/cordova/cordova.d.ts
@@ -72,6 +72,10 @@ interface Document {
     removeEventListener(type: string, listener: (ev: Event) => any, useCapture?: boolean): void;
 }
 
+interface Window {
+  cordova:Cordova;
+}
+
 // cordova/argscheck module
 interface ArgsCheck {
     checkArgs(argsSpec: string, functionName: string, args: any[], callee?: any): void;


### PR DESCRIPTION
I've added the global cordova variable to the `Window` interface as cordova does attach it globally.
