### PR TITLE
Add method getItemsAsync and remove nullable in IPromise.done

### DIFF
--- a/winrt/winrt.d.ts
+++ b/winrt/winrt.d.ts
@@ -10171,6 +10171,7 @@ declare module Windows {
             getFilesAsync(): Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IVectorView<Windows.Storage.StorageFile>>;
             getFoldersAsync(): Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IVectorView<Windows.Storage.StorageFolder>>;
             getItemsAsync(): Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IVectorView<Windows.Storage.IStorageItem>>;
+            getItemsAsync(startIndex: number, maxItemsToRetrieve: number): Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IVectorView<Windows.Storage.IStorageItem>>;
         }
         export interface IStorageFile extends Windows.Storage.IStorageItem, Windows.Storage.Streams.IRandomAccessStreamReference, Windows.Storage.Streams.IInputStreamReference {
             contentType: string;
@@ -14736,7 +14737,7 @@ declare module Windows.Foundation {
         then<U>(success?: (value: T) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void ): IPromise<U>;
         then<U>(success?: (value: T) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void ): IPromise<U>;
         then<U>(success?: (value: T) => U, error?: (error: any) => U, progress?: (progress: any) => void ): IPromise<U>;
-        done?<U>(success?: (value: T) => any, error?: (error: any) => any, progress?: (progress: any) => void): void;
+        done<U>(success?: (value: T) => any, error?: (error: any) => any, progress?: (progress: any) => void): void;
 
         cancel(): void;
 


### PR DESCRIPTION
Hello @basarat , Here are the changes for compatibility with promises of WinJS and WinRT. I've also added a new function.

1.- Add definition method for get folder ítems with range 'getItemsAsync' (the class already contains):
https://msdn.microsoft.com/en-us/library/windows/apps/br227287.aspx?cs-save-lang=1&cs-lang=javascript#code-snippet-1

2.- remove nullable in IPromise.done for compatibility with promises of WinJS and WinRT.
currently occurs the following:

example:

``` javascript
var folder: WinJS.IPromise<Windows.Storage.IStorageFolder> = _storageFolder.getFolderAsync("path");
```

the error is: 
**Error 1029**
Can not convert 'Windows.Foundation.IAsyncOperation <Windows.Storage.StorageFolder>' in 'WinJS.IPromise <Windows.Storage.IStorageFolder>':
The property 'done' has been defined as optional in type 'Windows.Foundation.IPromise <T>',
but it is necessary in the type 'WinJS.IPromise <T>'.

WinRT currently contains this promise:

``` JavaScript
export interface IPromise<T> {
   ...
   done? <U>(success?: (value: T) => ...
   ...
}
```

and WinJS

``` JavaScript
export interface IPromise<T> {
   ...
   done<U>(onComplete?: (value: T) => ...
   ...
}
```

so that it is incompatible, to establish compatibility with the promise of WinJS must be removed nullable in done function of promise.
