### PR TITLE
fixed typing for async

### DIFF
--- a/async/async-explicit-tests.ts
+++ b/async/async-explicit-tests.ts
@@ -1,0 +1,44 @@
+/// <reference path="async.d.ts" />
+
+interface StringCallback { (err: Error, result: string): void; }
+interface AsyncStringGetter { (callback: StringCallback): void; }
+
+var taskArray: AsyncStringGetter[] = [
+    function (callback) {
+        setTimeout(function () {
+            callback(null, 'one');
+        }, 200);
+    },
+    function (callback) {
+        setTimeout(function () {
+            callback(null, 'two');
+        }, 100);
+    },
+];
+
+async.series(taskArray, function (err, results) { console.log(results[0].match(/o/)) });
+async.parallel(taskArray, function (err, results) { console.log(results[0].match(/o/)) });
+async.parallelLimit(taskArray, 3, function (err, results) { console.log(results[0].match(/o/)) });
+
+
+interface Lookup<T> { [key: string]: T; }
+interface NumberCallback { (err: Error, result: number): void; }
+interface AsyncNumberGetter { (callback: NumberCallback): void; }
+
+var taskDict: Lookup<AsyncNumberGetter> = {
+    one: function(callback){
+        setTimeout(function(){
+            callback(null, 1);
+        }, 200);
+    },
+    two: function(callback){
+        setTimeout(function(){
+            callback(null, 2);
+        }, 100);
+    }
+}
+
+async.series(taskDict, function(err, results) { console.log(results['one'].toFixed(1)) });
+async.parallel(taskDict, function(err, results) { console.log(results['one'].toFixed(1)) });
+async.parallelLimit(taskDict, 3, function(err, results) { console.log(results['one'].toFixed(1)) });
+

--- a/async/async-explicit-tests.ts.tscparams
+++ b/async/async-explicit-tests.ts.tscparams
@@ -1,0 +1,1 @@
+--noImplicitAny

--- a/async/async-tests.ts
+++ b/async/async-tests.ts
@@ -67,6 +67,17 @@ async.series([
 ],
 function (err, results) { });
 
+async.series<string>([
+    function (callback) {
+        callback(null, 'one');
+    },
+    function (callback) {
+        callback(null, 'two');
+    },
+],
+function (err, results) { });
+
+
 async.series({
     one: function (callback) {
         setTimeout(function () {
@@ -80,6 +91,21 @@ async.series({
     },
 },
 function (err, results) { });
+
+async.series<number>({
+    one: function (callback) {
+        setTimeout(function () {
+            callback(null, 1);
+        }, 200);
+    },
+    two: function (callback) {
+        setTimeout(function () {
+            callback(null, 2);
+        }, 100);
+    },
+},
+function (err, results) { });
+
 
 async.parallel([
     function (callback) {
@@ -95,8 +121,36 @@ async.parallel([
 ],
 function (err, results) { });
 
+async.parallel<string>([
+    function (callback) {
+        setTimeout(function () {
+            callback(null, 'one');
+        }, 200);
+    },
+    function (callback) {
+        setTimeout(function () {
+            callback(null, 'two');
+        }, 100);
+    },
+],
+function (err, results) { });
+
 
 async.parallel({
+    one: function (callback) {
+        setTimeout(function () {
+            callback(null, 1);
+        }, 200);
+    },
+    two: function (callback) {
+        setTimeout(function () {
+            callback(null, 2);
+        }, 100);
+    },
+},
+function (err, results) { });
+
+async.parallel<number>({
     one: function (callback) {
         setTimeout(function () {
             callback(null, 1);
@@ -136,7 +190,7 @@ async.waterfall([
 ], function (err, result) { });
 
 
-var q = async.queue(function (task: any, callback) {
+var q = async.queue<any>(function (task: any, callback) {
     console.log('hello ' + task.name);
     callback();
 }, 2);
@@ -189,29 +243,29 @@ q.resume();
 q.kill();
 
 // tests for strongly typed tasks
-var q2 = async.queue(function (task: string, callback) {
+var q2 = async.queue<string>(function (task: string, callback) {
     console.log('Task: ' + task);
     callback();
 }, 1);
 
 q2.push('task1');
 
-q2.push('task2', function (error, results: string[]) {
-    console.log('Finished tasks: ' + results.join(', '));
+q2.push('task2', function (error) {
+    console.log('Finished tasks');
 });
 
-q2.push(['task3', 'task4', 'task5'], function (error, results: string[]) {
-    console.log('Finished tasks: ' + results.join(', '));
+q2.push(['task3', 'task4', 'task5'], function (error) {
+    console.log('Finished tasks');
 });
 
 q2.unshift('task1');
 
-q2.unshift('task2', function (error, results: string[]) {
-    console.log('Finished tasks: ' + results.join(', '));
+q2.unshift('task2', function (error) {
+    console.log('Finished tasks');
 });
 
-q2.unshift(['task3', 'task4', 'task5'], function (error, results: string[]) {
-    console.log('Finished tasks: ' + results.join(', '));
+q2.unshift(['task3', 'task4', 'task5'], function (error) {
+    console.log('Finished tasks');
 });
 
 var filename = '';

--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -3,31 +3,32 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-interface Dict<T> { [key: string]: T; }
+interface Dictionary<T> { [key: string]: T; }
 
 interface ErrorCallback { (err?: Error): void; }
 interface AsyncResultCallback<T> { (err: Error, result: T): void; }
 interface AsyncResultArrayCallback<T> { (err: Error, results: T[]): void; }
-interface AsyncResultDictCallback<T> { (err: Error, results: Dict<T>): void; }
+interface AsyncResultObjectCallback<T> { (err: Error, results: Dictionary<T>): void; }
 interface AsyncTimesCallback<T> { (n: number, callback: AsyncResultArrayCallback<T>): void; }
 
 interface AsyncIterator<T> { (item: T, callback: ErrorCallback): void; }
 interface AsyncResultIterator<T, R> { (item: T, callback: AsyncResultCallback<R>): void; }
 interface AsyncMemoIterator<T, R> { (memo: R, item: T, callback: AsyncResultCallback<R>): void; }
 
-interface AsyncWorker<T> { (task: T, callback: Function): void; }
+interface AsyncWorker<T> { (task: T, callback: ErrorCallback): void; }
 
-interface AsyncTaskFn<T> { (callback: AsyncResultCallback<T>): void; }
+interface AsyncFunction<T> { (callback: AsyncResultCallback<T>): void; }
+interface AsyncVoidFunction { (callback: ErrorCallback): void; }
 
 interface AsyncQueue<T> {
     length(): number;
     concurrency: number;
     started: boolean;
     paused: boolean;
-    push(task: T, callback?: AsyncResultArrayCallback<T>): void;
-    push(task: T[], callback?: AsyncResultArrayCallback<T>): void;
-    unshift(task: T, callback?: AsyncResultArrayCallback<T>): void;
-    unshift(task: T[], callback?: AsyncResultArrayCallback<T>): void;
+    push(task: T, callback?: ErrorCallback): void;
+    push(task: T[], callback?: ErrorCallback): void;
+    unshift(task: T, callback?: ErrorCallback): void;
+    unshift(task: T[], callback?: ErrorCallback): void;
     saturated: () => any;
     empty: () => any;
     drain: () => any;
@@ -86,23 +87,23 @@ interface Async {
     concatSeries<T, R>(arr: T[], iterator: AsyncResultIterator<T, R[]>, callback: AsyncResultArrayCallback<R>): any;
 
     // Control Flow
-    series<T>(tasks: Array<AsyncTaskFn<T>>, callback?: AsyncResultArrayCallback<T>): void;
-    series<T>(tasks: Dict<AsyncTaskFn<T>>, callback?: AsyncResultDictCallback<T>): void;
-    parallel<T>(tasks: Array<AsyncTaskFn<T>>, callback?: AsyncResultArrayCallback<T>): void;
-    parallel<T>(tasks: Dict<AsyncTaskFn<T>>, callback?: AsyncResultDictCallback<T>): void;
-    parallelLimit<T>(tasks: Array<AsyncTaskFn<T>>, limit: number, callback?: AsyncResultArrayCallback<T>): void;
-    parallelLimit<T>(tasks: Dict<AsyncTaskFn<T>>, limit: number, callback?: AsyncResultDictCallback<T>): void;
-    whilst(test: Function, fn: Function, callback: Function): void;
-    until(test: Function, fn: Function, callback: Function): void;
-    waterfall<T>(tasks: Function[], callback?: AsyncResultArrayCallback<T>): void;
-    waterfall<T>(tasks: Function, callback?: AsyncResultArrayCallback<T>): void;
+    series<T>(tasks: Array<AsyncFunction<T>>, callback?: AsyncResultArrayCallback<T>): void;
+    series<T>(tasks: Dictionary<AsyncFunction<T>>, callback?: AsyncResultObjectCallback<T>): void;
+    parallel<T>(tasks: Array<AsyncFunction<T>>, callback?: AsyncResultArrayCallback<T>): void;
+    parallel<T>(tasks: Dictionary<AsyncFunction<T>>, callback?: AsyncResultObjectCallback<T>): void;
+    parallelLimit<T>(tasks: Array<AsyncFunction<T>>, limit: number, callback?: AsyncResultArrayCallback<T>): void;
+    parallelLimit<T>(tasks: Dictionary<AsyncFunction<T>>, limit: number, callback?: AsyncResultObjectCallback<T>): void;
+    whilst(test: () => boolean, fn: AsyncVoidFunction, callback: (err: any) => void): void;
+    doWhilst(fn: AsyncVoidFunction, test: () => boolean, callback: (err: any) => void): void;
+    until(test: () => boolean, fn: AsyncVoidFunction, callback: (err: any) => void): void;
+    doUntil(fn: AsyncVoidFunction, test: () => boolean, callback: (err: any) => void): void;
+    waterfall(tasks: Function[], callback?: AsyncResultArrayCallback<any>): void;
     queue<T>(worker: AsyncWorker<T>, concurrency: number): AsyncQueue<T>;
     priorityQueue<T>(worker: AsyncWorker<T>, concurrency: number): AsyncPriorityQueue<T>;
-    // auto(tasks: any[], callback?: AsyncResultArrayCallback<T>): void;
     auto(tasks: any, callback?: AsyncResultArrayCallback<any>): void;
     iterator(tasks: Function[]): Function;
-    apply<T>(fn: Function, ...arguments: any[]): AsyncTaskFn<T>;
-    nextTick<T>(callback: Function): void;
+    apply(fn: Function, ...arguments: any[]): AsyncFunction<any>;
+    nextTick(callback: Function): void;
 
     times<T> (n: number, callback: AsyncTimesCallback<T>): void;
     timesSeries<T> (n: number, callback: AsyncTimesCallback<T>): void;

--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -3,10 +3,13 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
+interface Dict<T> { [key: string]: T; }
+
 interface ErrorCallback { (err?: Error): void; }
-interface AsyncResultsCallback<T> { (err: Error, results: T[]): void; }
 interface AsyncResultCallback<T> { (err: Error, result: T): void; }
-interface AsyncTimesCallback<T> { (n: number, callback: AsyncResultsCallback<T>): void; }
+interface AsyncResultArrayCallback<T> { (err: Error, results: T[]): void; }
+interface AsyncResultDictCallback<T> { (err: Error, results: Dict<T>): void; }
+interface AsyncTimesCallback<T> { (n: number, callback: AsyncResultArrayCallback<T>): void; }
 
 interface AsyncIterator<T> { (item: T, callback: ErrorCallback): void; }
 interface AsyncResultIterator<T, R> { (item: T, callback: AsyncResultCallback<R>): void; }
@@ -14,15 +17,17 @@ interface AsyncMemoIterator<T, R> { (memo: R, item: T, callback: AsyncResultCall
 
 interface AsyncWorker<T> { (task: T, callback: Function): void; }
 
+interface AsyncTaskFn<T> { (callback: AsyncResultCallback<T>): void; }
+
 interface AsyncQueue<T> {
     length(): number;
     concurrency: number;
     started: boolean;
     paused: boolean;
-    push(task: T, callback?: AsyncResultsCallback<T>): void;
-    push(task: T[], callback?: AsyncResultsCallback<T>): void;
-    unshift(task: T, callback?: AsyncResultsCallback<T>): void;
-    unshift(task: T[], callback?: AsyncResultsCallback<T>): void;
+    push(task: T, callback?: AsyncResultArrayCallback<T>): void;
+    push(task: T[], callback?: AsyncResultArrayCallback<T>): void;
+    unshift(task: T, callback?: AsyncResultArrayCallback<T>): void;
+    unshift(task: T[], callback?: AsyncResultArrayCallback<T>): void;
     saturated: () => any;
     empty: () => any;
     drain: () => any;
@@ -38,8 +43,8 @@ interface AsyncPriorityQueue<T> {
     concurrency: number;
     started: boolean;
     paused: boolean;
-    push(task: T, priority: number, callback?: AsyncResultsCallback<T>): void;
-    push(task: T[], priority: number, callback?: AsyncResultsCallback<T>): void;
+    push(task: T, priority: number, callback?: AsyncResultArrayCallback<T>): void;
+    push(task: T[], priority: number, callback?: AsyncResultArrayCallback<T>): void;
     saturated: () => any;
     empty: () => any;
     drain: () => any;
@@ -56,9 +61,9 @@ interface Async {
     each<T>(arr: T[], iterator: AsyncIterator<T>, callback: ErrorCallback): void;
     eachSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: ErrorCallback): void;
     eachLimit<T>(arr: T[], limit: number, iterator: AsyncIterator<T>, callback: ErrorCallback): void;
-    map<T, R>(arr: T[], iterator: AsyncResultIterator<T, R>, callback: AsyncResultsCallback<R>): any;
-    mapSeries<T, R>(arr: T[], iterator: AsyncResultIterator<T, R>, callback: AsyncResultsCallback<R>): any;
-    mapLimit<T, R>(arr: T[], limit: number, iterator: AsyncResultIterator<T, R>, callback: AsyncResultsCallback<R>): any;
+    map<T, R>(arr: T[], iterator: AsyncResultIterator<T, R>, callback: AsyncResultArrayCallback<R>): any;
+    mapSeries<T, R>(arr: T[], iterator: AsyncResultIterator<T, R>, callback: AsyncResultArrayCallback<R>): any;
+    mapLimit<T, R>(arr: T[], limit: number, iterator: AsyncResultIterator<T, R>, callback: AsyncResultArrayCallback<R>): any;
     filter<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (results: T[]) => any): any;
     select<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (results: T[]) => any): any;
     filterSeries<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (results: T[]) => any): any;
@@ -70,33 +75,33 @@ interface Async {
     foldl<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncResultCallback<R>): any;
     reduceRight<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncResultCallback<R>): any;
     foldr<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncResultCallback<R>): any;
-    detect<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: AsyncResultsCallback<T>): any;
-    detectSeries<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: AsyncResultsCallback<T>): any;
-    sortBy<T, V>(arr: T[], iterator: AsyncResultIterator<T, V>, callback: AsyncResultsCallback<T>): any;
-    some<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: AsyncResultsCallback<T>): any;
-    any<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: AsyncResultsCallback<T>): any;
+    detect<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: AsyncResultArrayCallback<T>): any;
+    detectSeries<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: AsyncResultArrayCallback<T>): any;
+    sortBy<T, V>(arr: T[], iterator: AsyncResultIterator<T, V>, callback: AsyncResultArrayCallback<T>): any;
+    some<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: AsyncResultArrayCallback<T>): any;
+    any<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: AsyncResultArrayCallback<T>): any;
     every<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (result: boolean) => any): any;
     all<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (result: boolean) => any): any;
-    concat<T, R>(arr: T[], iterator: AsyncResultIterator<T, R[]>, callback: AsyncResultsCallback<R>): any;
-    concatSeries<T, R>(arr: T[], iterator: AsyncResultIterator<T, R[]>, callback: AsyncResultsCallback<R>): any;
+    concat<T, R>(arr: T[], iterator: AsyncResultIterator<T, R[]>, callback: AsyncResultArrayCallback<R>): any;
+    concatSeries<T, R>(arr: T[], iterator: AsyncResultIterator<T, R[]>, callback: AsyncResultArrayCallback<R>): any;
 
     // Control Flow
-    series<T>(tasks: T[], callback?: AsyncResultsCallback<T>): void;
-    series<T>(tasks: T, callback?: AsyncResultsCallback<T>): void;
-    parallel<T>(tasks: T[], callback?: AsyncResultsCallback<T>): void;
-    parallel<T>(tasks: T, callback?: AsyncResultsCallback<T>): void;
-    parallelLimit<T>(tasks: T[], limit: number, callback?: AsyncResultsCallback<T>): void;
-    parallelLimit<T>(tasks: T, limit: number, callback?: AsyncResultsCallback<T>): void;
+    series<T>(tasks: Array<AsyncTaskFn<T>>, callback?: AsyncResultArrayCallback<T>): void;
+    series<T>(tasks: Dict<AsyncTaskFn<T>>, callback?: AsyncResultDictCallback<T>): void;
+    parallel<T>(tasks: Array<AsyncTaskFn<T>>, callback?: AsyncResultArrayCallback<T>): void;
+    parallel<T>(tasks: Dict<AsyncTaskFn<T>>, callback?: AsyncResultDictCallback<T>): void;
+    parallelLimit<T>(tasks: Array<AsyncTaskFn<T>>, limit: number, callback?: AsyncResultArrayCallback<T>): void;
+    parallelLimit<T>(tasks: Dict<AsyncTaskFn<T>>, limit: number, callback?: AsyncResultDictCallback<T>): void;
     whilst(test: Function, fn: Function, callback: Function): void;
     until(test: Function, fn: Function, callback: Function): void;
-    waterfall<T>(tasks: T[], callback?: AsyncResultsCallback<T>): void;
-    waterfall<T>(tasks: T, callback?: AsyncResultsCallback<T>): void;
+    waterfall<T>(tasks: Function[], callback?: AsyncResultArrayCallback<T>): void;
+    waterfall<T>(tasks: Function, callback?: AsyncResultArrayCallback<T>): void;
     queue<T>(worker: AsyncWorker<T>, concurrency: number): AsyncQueue<T>;
     priorityQueue<T>(worker: AsyncWorker<T>, concurrency: number): AsyncPriorityQueue<T>;
-    // auto(tasks: any[], callback?: AsyncResultsCallback<T>): void;
-    auto(tasks: any, callback?: AsyncResultsCallback<any>): void;
+    // auto(tasks: any[], callback?: AsyncResultArrayCallback<T>): void;
+    auto(tasks: any, callback?: AsyncResultArrayCallback<any>): void;
     iterator(tasks: Function[]): Function;
-    apply(fn: Function, ...arguments: any[]): void;
+    apply<T>(fn: Function, ...arguments: any[]): AsyncTaskFn<T>;
     nextTick<T>(callback: Function): void;
 
     times<T> (n: number, callback: AsyncTimesCallback<T>): void;


### PR DESCRIPTION
The improved type system of TS 1.4.x finally failed on some of the definitions.

My main motivation was fixing was `async.parallel`:

```
parallel<T>(tasks: T[], callback?: AsyncResultsCallback<T>): void;
```

It is incorrect. Tasks are functions that callback T as a result. As above TS tries to pass 'task functions' as a result into the master callback which begets profound sorrow.
