### PR TITLE
Adding type definitions for dts-bundle

### DIFF
--- a/dts-bundle/dts-bundle-tests.ts
+++ b/dts-bundle/dts-bundle-tests.ts
@@ -1,0 +1,54 @@
+/// <reference path="./dts-bundle.d.ts"/>
+/// <reference path="../node/node.d.ts"/>
+import dts = require("dts-bundle");
+import os = require("os");
+
+var opts = {
+
+    // Required
+
+    // name of module likein package.json
+    // - used to declare module & import/require
+    name: 'cool-project',
+    // path to entry-point (generated .d.ts file for main module)
+    // - either relative or absolute
+    main: 'build/index.d.ts',
+
+    // Optional
+
+    // base directory to be used for discovering type declarations (i.e. from this project itself)
+    // - default: dirname of main
+    baseDir: 'build',
+    // path of output file
+    // - default: "<baseDir>/<name>.d.ts"
+    out: 'dist/cool-project.d.ts',
+    // include typings outside of the 'baseDir' (i.e. like node.d.ts)
+    // - default: false
+    externals: false,
+    // filter to exclude typings, either a RegExp or a callback. match path relative to opts.baseDir
+    // - RegExp: a match excludes the file
+    // - function: (file:String, external:Boolean) return true to exclude, false to allow
+    // - always use forward-slashes (even on Windows)
+    // - default: *pass*
+    exclude: /^defs\/$/,
+    // delete all source typings (i.e. "<baseDir>/**/*.d.ts")
+    // - default: false
+    removeSource: false,
+    // newline to use in output file
+    newline: os.EOL,
+    // indentation to use in output file
+    // - default 4 spaces
+    indent: '   ',
+    // prefix for rewriting module names
+    // - default '__'
+    prefix: '__',
+    // separator for rewriting module 'path' names
+    // - default: forward slash (like sub-modules)
+    separator: '/',
+    // enable verbose mode, prints detailed info about all references and includes/excludes
+    // - default: false
+    verbose: false
+};
+
+// run it
+dts.bundle(opts);

--- a/dts-bundle/dts-bundle.d.ts
+++ b/dts-bundle/dts-bundle.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for dts-bundle
+// Project: https://github.com/TypeStrong/dts-bundle
+// Definitions by: Asana <https://asana.com>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module "dts-bundle" {
+    interface Options {
+        name: string;
+        main: string;
+        baseDir?: string;
+        exclude?: RegExp;
+        externals?: boolean;
+        indent?: string;
+        newLine?: string;
+        out?: string;
+        prefix?: string;
+        removeSource?: boolean;
+        separator?: string;
+        verbose?: boolean;
+    }
+
+    export function bundle(opts: Options): void;
+}


### PR DESCRIPTION
DtsBundle is for bundling type definitions to be consumed by other
libraries.
