### PR TITLE
[react 0.13] Discern new vs old style components through render

### DIFF
--- a/react/react-0.13.0-tests.ts
+++ b/react/react-0.13.0-tests.ts
@@ -42,7 +42,7 @@ var INPUT_REF: string = "input";
 // Top-Level API
 // --------------------------------------------------------------------------
 
-var reactClass: React.ComponentClass<Props, State, Context> = React.createClass<Props, State, Context>({
+var reactClassicClass: React.ClassicComponentClass<Props, State, Context> = React.createClass<Props, State, Context>({
     getDefaultProps: () => {
         return <Props>{
             hello: undefined,
@@ -68,6 +68,8 @@ var reactClass: React.ComponentClass<Props, State, Context> = React.createClass<
             }));
     }
 });
+
+var reactClass: React.ComponentClass<Props, State, Context> = reactClassicClass;
 
 class ModernComponent extends React.Component<Props, State, Context> implements React.ChildContextProvider<ChildContext> {
     constructor(props: Props, context: Context) {
@@ -149,6 +151,11 @@ var isValid = React.isValidElement(reactElement); // true
 React.initializeTouchEvents(true);
 var domNode: Element = React.findDOMNode(component);
 
+var reactClassicElement: React.ReactClassicElement<Props>;
+reactClassicElement = React.createElement<Props>(reactClassicClass, props);
+var classicComponent: React.ClassicComponent<Props, State, Context>;
+classicComponent = React.render<Props, State>(reactClassicElement, container);
+
 //
 // React Elements
 // --------------------------------------------------------------------------
@@ -177,8 +184,6 @@ component.setState({ inputValue: "!!!" });
 component.forceUpdate();
 
 // classic
-var classicComponent = <React.ClassicComponent<Props, State, Context>>component;
-
 var htmlElement: Element = classicComponent.getDOMNode();
 var divElement: HTMLDivElement = classicComponent.getDOMNode<HTMLDivElement>();
 var isMounted: boolean = classicComponent.isMounted();

--- a/react/react-0.13.0.d.ts
+++ b/react/react-0.13.0.d.ts
@@ -17,6 +17,9 @@ declare module React {
         ref: string;
     }
 
+    interface ReactClassicElement<P> extends ReactElement<P> {
+    }
+
     interface ReactHTMLElement extends ReactElement<HTMLAttributes> {}
     interface ReactSVGElement extends ReactElement<SVGAttributes> {}
 
@@ -112,8 +115,10 @@ declare module React {
 
     interface TopLevelAPI {
         createClass<P, S, C>(spec: ComponentSpec<P, S, C>): ClassicComponentClass<P, S, C>;
+        createElement<P>(type: ClassicComponentClass<P, any, any>, props: P, ...children: ReactNode[]): ReactClassicElement<P>;
         createElement<P>(type: ComponentClass<P, any, any> | string, props: P, ...children: ReactNode[]): ReactElement<P>;
         createFactory<P>(type: ComponentClass<P, any, any> | string): ComponentFactory<P>;
+        render<P, S>(element: ReactClassicElement<P>, container: Element, callback?: () => any): ClassicComponent<P, S, any>;
         render<P, S>(element: ReactElement<P>, container: Element, callback?: () => any): Component<P, S, any>;
         unmountComponentAtNode(container: Element): boolean;
         renderToString(element: ReactElement<any>): string;


### PR DESCRIPTION
By overloading createElement() for the ClassicComponentClass and
creating a separate ReactClassicElement type, we can keep track of which
calls to render() should create a ClassicComponent versus a new style
Component. Useful for keeping the old API, which makes migration easier.
