### PR TITLE
Adding support for custom nconf.formats 

### DIFF
--- a/nconf/nconf-tests.ts
+++ b/nconf/nconf-tests.ts
@@ -13,6 +13,7 @@ var opts: nconf.IOptions;
 var fopts: nconf.IFileOptions;
 var store: nconf.IStore;
 var callback: (err: Error) => void;
+var fmt: nconf.IFormat;
 
 value = nconf.clear(str, callback);
 value = nconf.get (str, callback);
@@ -37,7 +38,10 @@ p = nconf.env(opts);
 p = nconf.file(str);
 p = nconf.file(str, fopts);
 p = nconf.file(fopts);
-
+p = nconf.file({
+    format: fmt,
+    file: 'jsonFile.custom'
+});
 p = nconf.use(str);
 p = nconf.use(str, opts);
 
@@ -92,6 +96,18 @@ p = p.env(opts);
 p = p.file(str);
 p = p.file(str, fopts);
 p = p.file(fopts);
+p = p.file({
+    file: 'iniFile.ini',
+    format: nconf.formats.ini
+});
+p = p.file({
+    file: 'jsonFile.json',
+    format: nconf.formats.json
+});
+p = p.file({
+    file: 'jsonFile.custom',
+    format: fmt
+});
 p = p.use(str, opts);
 
 p = p.defaults(opts);
@@ -99,3 +115,10 @@ p.init(opts);
 p = p.overrides(opts);
 p.remove(str);
 store = p.create(str, opts);
+
+// - - - - - - - - - - - - - - - - - - - - - - - - -
+
+class CustomFmt implements nconf.IFormat  {
+    stringify(obj: any, replacer: any, spacing?: any): string { return ""; }
+    parse(str: string): any { return {} }
+};

--- a/nconf/nconf.d.ts
+++ b/nconf/nconf.d.ts
@@ -1,6 +1,6 @@
 ﻿// Type definitions for nconf
 // Project: https://github.com/flatiron/nconf
-// Definitions by: Jeff Goddard <https://github.com/jedigo>
+// Definitions by: Jeff Goddard <https://github.com/jedigo>, Jean-Martin Thibault <https://github.com/jmthibault>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 // Imported from: https://github.com/soywiz/typescript-node-definitions/nconf.d.ts
@@ -38,9 +38,14 @@ declare module "nconf" {
 	export function loadFiles(files: any, callback?: ICallbackFunction): void;
 	export function loadFilesSync(files: any, callback?: ICallbackFunction): void;
 
-	export enum formats {
-		json,
-		ini
+	export var formats: {
+		json: IFormat;
+		ini: IFormat;
+	};
+
+	export interface IFormat {
+		stringify: (obj: any, replacer: any, spacing?: any) => string;
+		parse: (str: string) => any;
 	}
 
 	export interface IOptions {
@@ -51,6 +56,7 @@ declare module "nconf" {
 		file?: string;
 		dir?: string;
 		search?: boolean;
+		format?: IFormat;
 		json_spacing?: number;
 	}
 


### PR DESCRIPTION
This allows developers to specify a pre-existing formatter or create a new custom one.
