### PR TITLE
add two missing functions to ip (subnet, cidrSubnet)

### DIFF
--- a/ip/ip-tests.ts
+++ b/ip/ip-tests.ts
@@ -17,3 +17,5 @@ ip.not("255.255.255.0");
 ip.or("192.168.0.1", "255.255.255.0");
 var buff:any = ip.toBuffer(myIP);
 ip.toString(buff);
+ip.subnet('192.168.1.134', '255.255.255.192');
+ip.cidrSubnet('192.168.1.134/26');

--- a/ip/ip.d.ts
+++ b/ip/ip.d.ts
@@ -5,6 +5,17 @@
 
 interface NodeBuffer { }
 
+interface SubnetInfo {
+    networkAddress: string;
+    firstAddress: string;
+    lastAddress: string;
+    broadcastAddress: string;
+    subnetMask: string;
+    subnetMaskLength: number;
+    numHosts: number;
+    length: number;
+}
+
 declare module "ip" {
     /**
      * Check two IP address are the same.
@@ -88,4 +99,17 @@ declare module "ip" {
      * Convert an IPv4 IP address from its the long numeric value to a string.
      **/
     export function fromLong(ip: number): string;
+
+    /**
+     * Get the subnet information.
+     * @param ip IP address.
+     * @param subnet Subnet address.
+     */
+    export function subnet(ip: string, subnet: string): SubnetInfo;
+
+    /**
+     * Get the subnet information.
+     * @param cidr CIDR address.
+     */
+    export function cidrSubnet(cidr: string): SubnetInfo;
 }


### PR DESCRIPTION
The two missing functions are mentioned in the homepage of the project: https://github.com/indutny/node-ip
