### PR TITLE
Update `async` library types

### DIFF
--- a/async/async-tests.ts
+++ b/async/async-tests.ts
@@ -67,7 +67,31 @@ async.series([
 ],
 function (err, results) { });
 
+async.series<string>([
+    function (callback) {
+        callback(null, 'one');
+    },
+    function (callback) {
+        callback(null, 'two');
+    },
+],
+function (err, results) { });
+
 async.series({
+    one: function (callback) {
+        setTimeout(function () {
+            callback(null, 1);
+        }, 200);
+    },
+    two: function (callback) {
+        setTimeout(function () {
+            callback(null, 2);
+        }, 100);
+    },
+},
+function (err, results) { });
+
+async.series<number>({
     one: function (callback) {
         setTimeout(function () {
             callback(null, 1);
@@ -95,6 +119,19 @@ async.parallel([
 ],
 function (err, results) { });
 
+async.parallel<string>([
+    function (callback) {
+        setTimeout(function () {
+            callback(null, 'one');
+        }, 200);
+    },
+    function (callback) {
+        setTimeout(function () {
+            callback(null, 'two');
+        }, 100);
+    },
+],
+function (err, results) { });
 
 async.parallel({
     one: function (callback) {
@@ -110,6 +147,19 @@ async.parallel({
 },
 function (err, results) { });
 
+async.parallel<number>({
+    one: function (callback) {
+        setTimeout(function () {
+            callback(null, 1);
+        }, 200);
+    },
+    two: function (callback) {
+        setTimeout(function () {
+            callback(null, 2);
+        }, 100);
+    },
+},
+function (err, results) { });
 
 var count = 0;
 
@@ -136,7 +186,7 @@ async.waterfall([
 ], function (err, result) { });
 
 
-var q = async.queue(function (task: any, callback) {
+var q = async.queue<any>(function (task, callback) {
     console.log('hello ' + task.name);
     callback();
 }, 2);
@@ -189,29 +239,29 @@ q.resume();
 q.kill();
 
 // tests for strongly typed tasks
-var q2 = async.queue(function (task: string, callback) {
+var q2 = async.queue<string>(function (task, callback) {
     console.log('Task: ' + task);
     callback();
 }, 1);
 
 q2.push('task1');
 
-q2.push('task2', function (error, results: string[]) {
-    console.log('Finished tasks: ' + results.join(', '));
+q2.push('task2', function (error) {
+    console.log('Finished tasks');
 });
 
-q2.push(['task3', 'task4', 'task5'], function (error, results: string[]) {
-    console.log('Finished tasks: ' + results.join(', '));
+q2.push(['task3', 'task4', 'task5'], function (error) {
+    console.log('Finished tasks');
 });
 
 q2.unshift('task1');
 
-q2.unshift('task2', function (error, results: string[]) {
-    console.log('Finished tasks: ' + results.join(', '));
+q2.unshift('task2', function (error) {
+    console.log('Finished tasks');
 });
 
-q2.unshift(['task3', 'task4', 'task5'], function (error, results: string[]) {
-    console.log('Finished tasks: ' + results.join(', '));
+q2.unshift(['task3', 'task4', 'task5'], function (error) {
+    console.log('Finished tasks');
 });
 
 var filename = '';

--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -4,25 +4,32 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 interface ErrorCallback { (err?: Error): void; }
-interface AsyncResultsCallback<T> { (err: Error, results: T[]): void; }
-interface AsyncResultCallback<T> { (err: Error, result: T): void; }
+interface AsyncResultsCallback<T> { (err?: Error, results?: T[]): void; }
+interface AsyncResultCallback<T> { (err?: Error, result?: T): void; }
+interface AsyncRestResultsCallback<T> { (err?: Error, ...results: T[]): void; }
 interface AsyncTimesCallback<T> { (n: number, callback: AsyncResultsCallback<T>): void; }
 
 interface AsyncIterator<T> { (item: T, callback: ErrorCallback): void; }
 interface AsyncResultIterator<T, R> { (item: T, callback: AsyncResultCallback<R>): void; }
 interface AsyncMemoIterator<T, R> { (memo: R, item: T, callback: AsyncResultCallback<R>): void; }
 
-interface AsyncWorker<T> { (task: T, callback: Function): void; }
+interface AsyncWorker<T> { (task: T, callback: ErrorCallback): void; }
+
+interface AsyncFunction<T> { (callback: AsyncResultCallback<T>): void; }
+interface AsyncVoidFunction { (callback: ErrorCallback): void; }
+interface AsyncRestResultsFunction<T> { (callback: AsyncRestResultsCallback<T>): void; }
+
+interface Dictionary<T> { [index: string]: T; }
 
 interface AsyncQueue<T> {
     length(): number;
     concurrency: number;
     started: boolean;
     paused: boolean;
-    push(task: T, callback?: AsyncResultsCallback<T>): void;
-    push(task: T[], callback?: AsyncResultsCallback<T>): void;
-    unshift(task: T, callback?: AsyncResultsCallback<T>): void;
-    unshift(task: T[], callback?: AsyncResultsCallback<T>): void;
+    push(task: T, callback?: ErrorCallback): void;
+    push(task: T[], callback?: ErrorCallback): void;
+    unshift(task: T, callback?: ErrorCallback): void;
+    unshift(task: T[], callback?: ErrorCallback): void;
     saturated: () => any;
     empty: () => any;
     drain: () => any;
@@ -81,23 +88,23 @@ interface Async {
     concatSeries<T, R>(arr: T[], iterator: AsyncResultIterator<T, R[]>, callback: AsyncResultsCallback<R>): any;
 
     // Control Flow
-    series<T>(tasks: T[], callback?: AsyncResultsCallback<T>): void;
-    series<T>(tasks: T, callback?: AsyncResultsCallback<T>): void;
-    parallel<T>(tasks: T[], callback?: AsyncResultsCallback<T>): void;
-    parallel<T>(tasks: T, callback?: AsyncResultsCallback<T>): void;
-    parallelLimit<T>(tasks: T[], limit: number, callback?: AsyncResultsCallback<T>): void;
-    parallelLimit<T>(tasks: T, limit: number, callback?: AsyncResultsCallback<T>): void;
-    whilst(test: Function, fn: Function, callback: Function): void;
-    until(test: Function, fn: Function, callback: Function): void;
-    waterfall<T>(tasks: T[], callback?: AsyncResultsCallback<T>): void;
-    waterfall<T>(tasks: T, callback?: AsyncResultsCallback<T>): void;
+    series<T>(tasks: AsyncFunction<T>[], callback?: AsyncResultsCallback<T>): void;
+    series<T>(tasks: Dictionary<AsyncFunction<T>>, callback?: AsyncResultsCallback<T>): void;
+    parallel<T>(tasks: AsyncFunction<T>[], callback?: AsyncResultsCallback<T>): void;
+    parallel<T>(tasks: Dictionary<AsyncFunction<T>>, callback?: AsyncResultsCallback<T>): void;
+    parallelLimit<T>(tasks: AsyncFunction<T>[], limit: number, callback?: AsyncResultsCallback<T>): void;
+    parallelLimit<T>(tasks: Dictionary<AsyncFunction<T>>, limit: number, callback?: AsyncResultsCallback<T>): void;
+    whilst(test: () => boolean, fn: AsyncVoidFunction, callback: (err: any) => void): void;
+    doWhilst(fn: AsyncVoidFunction, test: () => boolean, callback: (err: any) => void): void;
+    until(test: () => boolean, fn: AsyncVoidFunction, callback: (err: any) => void): void;
+    doUntil(fn: AsyncVoidFunction, test: () => boolean, callback: (err: any) => void): void;
+    waterfall(tasks: Function[], callback?: AsyncResultsCallback<any>): void;
     queue<T>(worker: AsyncWorker<T>, concurrency: number): AsyncQueue<T>;
     priorityQueue<T>(worker: AsyncWorker<T>, concurrency: number): AsyncPriorityQueue<T>;
-    // auto(tasks: any[], callback?: AsyncResultsCallback<T>): void;
     auto(tasks: any, callback?: AsyncResultsCallback<any>): void;
     iterator(tasks: Function[]): Function;
-    apply(fn: Function, ...arguments: any[]): void;
-    nextTick<T>(callback: Function): void;
+    apply(fn: Function, ...arguments: any[]): AsyncFunction<any>;
+    nextTick(callback: Function): void;
 
     times<T> (n: number, callback: AsyncTimesCallback<T>): void;
     timesSeries<T> (n: number, callback: AsyncTimesCallback<T>): void;


### PR DESCRIPTION
- Fix incorrect signatures for `series`/`parallel`/`parallelLimit`
- Add `doWhilst and`doUntil`
- Add return type to `apply`
- Improve typing of `waterfall`, `while` and `until`
- Add several named types needed in these signatures
- Correct `push` and `unshift` and tests that don't match API behaviour
