### PR TITLE
Add support for chaining and calls on Jasmine spies

### DIFF
--- a/jasmine/jasmine-tests.ts
+++ b/jasmine/jasmine-tests.ts
@@ -400,6 +400,44 @@ describe("A spy, when configured to throw a value", function () {
     });
 });
 
+describe("A spy, when configured with multiple actions", function () {
+    var foo: any, bar: any, fetchedBar: any;
+
+    beforeEach(function () {
+        foo = {
+            setBar: function (value: any) {
+                bar = value;
+            },
+            getBar: function () {
+                return bar;
+            }
+        };
+
+        spyOn(foo, 'getBar').and.callThrough().and.callFake(() => {
+          this.fakeCalled = true;
+        });
+
+        foo.setBar(123);
+        fetchedBar = foo.getBar();
+    });
+
+    it("tracks that the spy was called", function () {
+        expect(foo.getBar).toHaveBeenCalled();
+    });
+
+    it("should not effect other functions", function () {
+        expect(bar).toEqual(123);
+    });
+
+    it("when called returns the requested value", function () {
+        expect(fetchedBar).toEqual(123);
+    });
+
+    it("should have called the fake implementation", function () {
+        expect(this.fakeCalled).toEqual(true);
+    });
+});
+
 describe("A spy", function () {
     var foo: any, bar: any = null;
 

--- a/jasmine/jasmine-tests.ts
+++ b/jasmine/jasmine-tests.ts
@@ -714,6 +714,22 @@ describe("Asynchronous specs", function () {
     });
 });
 
+describe("Fail", function () {
+
+  it("should fail test when called without arguments", function () {
+    fail();
+  });
+
+  it("should fail test when called with a fail message", function () {
+    fail("The test failed");
+  });
+
+  it("should fail test when called an error", function () {
+    fail(new Error("The test failed with this error"));
+  });
+
+});
+
 (() => {
     // from boot.js
     var env = jasmine.getEnv();

--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Jasmine 2.1
 // Project: http://pivotal.github.com/jasmine/
-// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Theodore Brown <https://github.com/theodorejb>
+// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Theodore Brown <https://github.com/theodorejb>, David Pärsson <https://github.com/davidparsson/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 
@@ -372,15 +372,15 @@ declare module jasmine {
 
     interface SpyAnd {
         /** By chaining the spy with and.callThrough, the spy will still track all calls to it but in addition it will delegate to the actual implementation. */
-        callThrough(): void;
+        callThrough(): Spy;
         /** By chaining the spy with and.returnValue, all calls to the function will return a specific value. */
         returnValue(val: any): void;
         /** By chaining the spy with and.callFake, all calls to the spy will delegate to the supplied function. */
-        callFake(fn: Function): void;
+        callFake(fn: Function): Spy;
         /** By chaining the spy with and.throwError, all calls to the spy will throw the specified value. */
         throwError(msg: string): void;
         /** When a calling strategy is used for a spy, the original stubbing behavior can be returned at any time with and.stub. */
-        stub(): void;
+        stub(): Spy;
     }
 
     interface Calls {

--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -33,6 +33,8 @@ declare function afterAll(action: (done: () => void) => void): void;
 declare function expect(spy: Function): jasmine.Matchers;
 declare function expect(actual: any): jasmine.Matchers;
 
+declare function fail(e?: any): void;
+
 declare function spyOn(object: any, method: string): jasmine.Spy;
 
 declare function runs(asyncMethod: Function): void;


### PR DESCRIPTION
Jasmine has support for chaining actions on spies, like this

```
spyOn(foo, 'getBar').and.callThrough().and.callFake(() => {
  this.fakeCalled = true;
});
```

but this is not reflected by the current type definitions.

Tests are added, and the Travis build is passing: https://travis-ci.org/davidparsson/DefinitelyTyped/builds/49322143
