### PR TITLE
JointJS/Rappid Added findModelsFromPoint definition to Graph, Handle interface and SelectionView class definitions.

### DIFF
--- a/jointjs/jointjs.d.ts
+++ b/jointjs/jointjs.d.ts
@@ -24,6 +24,7 @@ declare module joint {
             getConnectedLinks(cell: Cell, opt?: any): Link[];
             disconnectLinks(cell: Cell);
             removeLinks(cell: Cell);
+            findModelsFromPoint(point:{x : number; y: number}):Element[];
         }
 
         class Cell extends Backbone.Model {
@@ -95,7 +96,34 @@ declare module joint {
     
     }
 
-    module ui { }
+    module ui {
+        interface Handle {
+            name : string;
+            position : string;
+            icon: string;
+        }
+
+        class SelectionView extends Backbone.Model {
+            paper:joint.dia.Paper;
+            graph:joint.dia.Graph;
+            model:Backbone.Collection<joint.dia.Cell>;
+
+            constructor(opt:{
+                paper : joint.dia.Paper;
+                graph  : joint.dia.Graph;
+                model : Backbone.Collection<joint.dia.Cell>
+            });
+
+            createSelectionBox(cellView:joint.dia.CellView);
+            destroySelectionBox(cellView:joint.dia.CellView);
+            startSelecting(evt:any);
+            cancelSelection();
+
+            addHandle(handle:Handle);
+            removeHandle(name:string);
+            changeHandle(name:string, handle:Handle);
+        }
+    }
 
     module shapes {
         module basic {

--- a/jointjs/jointjs.d.ts
+++ b/jointjs/jointjs.d.ts
@@ -40,7 +40,6 @@ declare module joint {
         }
 
         class Element extends Cell {
-            wrapper : any;
             position(x: number, y: number): Element;
             translate(tx: number, ty?: number): Element;
             resize(width: number, height: number): Element;

--- a/jointjs/jointjs.d.ts
+++ b/jointjs/jointjs.d.ts
@@ -40,6 +40,7 @@ declare module joint {
         }
 
         class Element extends Cell {
+            wrapper : any;
             position(x: number, y: number): Element;
             translate(tx: number, ty?: number): Element;
             resize(width: number, height: number): Element;


### PR DESCRIPTION
Hi,

I'm working with JointJS/Rappid and I'm adding whatever I'm missing. Handle and SelectionView are from Rappid. If you prefer me to use a separate file for Rappid, please let me know (but as you can see they are within the same module).

Kind Regards,

DenEwout.
