### PR TITLE
Fixed the type of stub to have its arguments

### DIFF
--- a/jasmine/jasmine-tests.ts
+++ b/jasmine/jasmine-tests.ts
@@ -455,7 +455,8 @@ describe("A spy", function () {
         foo.setBar(123);
         expect(bar).toEqual(123);
 
-        foo.setBar.and.stub();
+        foo.setBar.and.stub(1);
+        expect(bar).toEqual(1);
         bar = null;
 
         foo.setBar(123);

--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -382,7 +382,7 @@ declare module jasmine {
         /** By chaining the spy with and.throwError, all calls to the spy will throw the specified value. */
         throwError(msg: string): void;
         /** When a calling strategy is used for a spy, the original stubbing behavior can be returned at any time with and.stub. */
-        stub(): Spy;
+        stub(...params:any[]): Spy;
     }
 
     interface Calls {


### PR DESCRIPTION
Jasmine's `and.stub` is a stub for the original function, so it can be given arguments. This pull request adds the arguments to the type and adds an example to the tests.

TESTED: 
`tsc jasmine/jasmine-tests.ts`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/borisyankov/definitelytyped/3598)

<!-- Reviewable:end -->
