### PR TITLE
Added the Connection.id property to sockjs-node definitions

### DIFF
--- a/sockjs-node/sockjs-node.d.ts
+++ b/sockjs-node/sockjs-node.d.ts
@@ -45,6 +45,7 @@ declare module "sockjs" {
         prefix: string;
         protocol: string;
         readyState: number;
+        id: string;
 
         close(code?: string, reason?: string): boolean;
         destroy(): void;


### PR DESCRIPTION
The definition was added by the source code https://github.com/sockjs/sockjs-node/blob/v0.3.12/src/transport.coffee#L24
