### PR TITLE
KoLiteCommandOptions.execute must be a function

### DIFF
--- a/kolite/kolite.d.ts
+++ b/kolite/kolite.d.ts
@@ -63,13 +63,13 @@ interface KoliteAsyncCommand extends KoliteCommand {
 }
 
 interface KoLiteCommandOptions {
-    execute?: any;
+    execute(...args: any[]): any;
     canExecute?: (isExecuting: boolean) => any;
 }
 
 interface KnockoutStatic {
     command(options: KoLiteCommandOptions): KoliteCommand;
-    asyncCommand(optons: KoLiteCommandOptions): KoliteAsyncCommand;
+    asyncCommand(options: KoLiteCommandOptions): KoliteAsyncCommand;
 }
 
 interface KnockoutUtils {


### PR DESCRIPTION
Before this it caused the options-object to be of any object (function, number, array etc).
