### PR TITLE
Made ember object extend function's type definition to support variable...

### DIFF
--- a/ember/ember.d.ts
+++ b/ember/ember.d.ts
@@ -66,7 +66,7 @@ interface Array<T> {
     addArrayObserver(target: any, opts?: EnumerableConfigurationOptions): any[];
     addEnumerableObserver(target: any, opts: EnumerableConfigurationOptions): any[];
     any(callback: Function, target?: any): boolean;
-    anyBy(key: string, value?: string): boolean;
+    anyBy(key: string, value?: string): boolean
     arrayContentDidChange(startIdx: number, removeAmt: number, addAmt: number): any[];
     arrayContentWillChange(startIdx: number, removeAmt: number, addAmt: number): any[];
     someProperty(key: string, value?: any): boolean;
@@ -1421,7 +1421,7 @@ declare module Ember {
         /**
         Creates a subclass of the Object class.
         **/
-        static extend<T>(arguments?: CoreObjectArguments): T;
+        static extend<T>(...arguments?: CoreObjectArguments[]): T;
         /**
         Creates an instance of the class.
         @param arguments A hash containing values with which to initialize the newly instantiated object.


### PR DESCRIPTION
... arguments.

Ember's object extend function takes variable number of arguments as is evident clearly from http://emberjs.com/api/classes/Ember.Object.html#method_extend

Hence changing the type definition for extend function to follow rest parameter syntax.
