### PR TITLE
Fixed config type of $upload.http()

### DIFF
--- a/angular-file-upload/angular-file-upload.d.ts
+++ b/angular-file-upload/angular-file-upload.d.ts
@@ -9,7 +9,7 @@ declare module ng.angularFileUpload  {
 
     interface IUploadService {
 
-        http<T>(config: IFileUploadConfig): IUploadPromise<T>;
+        http<T>(config: ng.IRequestConfig): IUploadPromise<T>;
         upload<T>(config: IFileUploadConfig): IUploadPromise<T>;
     }
 


### PR DESCRIPTION
`$upload.http()` is used to send the file binary or any data to the server through the 'data' field in the config object, not the 'file' field. Hence, its config type should be just `ng.IRequestConfig`, and not `ng.IFileUploadConfig`
