### PR TITLE
Update to URI.d.ts

### DIFF
--- a/urijs/URI.d.ts
+++ b/urijs/URI.d.ts
@@ -72,7 +72,7 @@ declare class URI {
     segment(level: string): string;
     search(): string;
     search(qry: string): URI;
-    search(qry: boolean): Object;
+    search(qry: boolean): any;
     search(qry: Object): URI;
     query(): string;
     query(qry: string): URI;


### PR DESCRIPTION
uri.search(true) does return an object, but Typescript believes there is a difference between an Object and any.  Thus, if your querystring includes ?myParam=myValue, you should be able to access the value using uri.search(true).myParam.  However, the compiler threw the error "The property 'myParam' does not exist on on value of type 'Object'".  Changing the return type to any fixes this.
