### PR TITLE
Nock match header regex

### DIFF
--- a/nock/nock-tests.ts
+++ b/nock/nock-tests.ts
@@ -72,7 +72,10 @@ inst = inst.twice();
 inst = inst.thrice();
 
 inst = inst.defaultReplyHeaders(value);
+
 inst = inst.matchHeader(str, str);
+inst = inst.matchHeader(str, regex);
+inst = inst.matchHeader(str, (val: string) => true);
 
 inst = inst.delay(num);
 inst = inst.delayConnection(num);

--- a/nock/nock.d.ts
+++ b/nock/nock.d.ts
@@ -58,7 +58,7 @@ declare module "nock" {
 			
 			matchHeader(name: string, value: string): Scope;
 			matchHeader(name: string, regex: RegExp): Scope;
-			matchHeader(name: string, fn: (value: string) => bool): Scope;
+			matchHeader(name: string, fn: (value: string) => boolean): Scope;
 
 			filteringPath(regex: RegExp, replace: string): Scope;
 			filteringPath(fn: (path: string) => string): Scope;

--- a/nock/nock.d.ts
+++ b/nock/nock.d.ts
@@ -55,7 +55,10 @@ declare module "nock" {
 			replyWithFile(responseCode: number, fileName: string): Scope;
 
 			defaultReplyHeaders(headers: Object): Scope;
+			
 			matchHeader(name: string, value: string): Scope;
+			matchHeader(name: string, regex: RegExp): Scope;
+			matchHeader(name: string, fn: (value: string) => bool): Scope;
 
 			filteringPath(regex: RegExp, replace: string): Scope;
 			filteringPath(fn: (path: string) => string): Scope;


### PR DESCRIPTION
https://github.com/pgte/nock/blob/master/README.md#request-headers-matching, I really hope the second example in the readme is relying on automatic string -> number conversion or something otherwise I don't really know how this should be represented.
