### PR TITLE
Created new definitions for ko.plus library

### DIFF
--- a/ko.plus/ko.plus-tests.ts
+++ b/ko.plus/ko.plus-tests.ts
@@ -9,6 +9,8 @@
 /*
     Version 1.0 - initial commit
 
+    Version 1.1 - added test for makeEditable
+
     Note: Typescript version 1.4 or higher is required for union types
     and type declarations
 */
@@ -64,6 +66,8 @@ function EditableTests() {
 
     var edit4 = ko.editable<string|number>(1); // with union types
     var edit5 = ko.editable<string|number>("test"); 
+
+    ko.editable.makeEditable(this);
 
     // test getting the value
     var value = edit1();

--- a/ko.plus/ko.plus-tests.ts
+++ b/ko.plus/ko.plus-tests.ts
@@ -1,0 +1,128 @@
+/// <reference path="ko.plus.d.ts" />
+/// <reference path="../knockout/knockout.d.ts" />
+
+// Tests for ko.plus.d.ts
+// Project: https://github.com/stevegreatrex/ko.plus
+// Definitions by: Howard Richards <https://github.com/conficient>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/*
+    Version 1.0 - initial commit
+
+    Note: Typescript version 1.4 or higher is required for union types
+    and type declarations
+*/
+
+function CommandTests() {
+    
+    // initalize command with an execute method
+    var cmd1 = ko.command(() => {
+        return "Hello cmd1";
+    });
+	
+    // initialize command and add done and fail callbacks
+    var cmd2 = ko.command(() => {
+        return "Hello cmd2";
+    })
+        .done((data: any) => {
+        alert("success");
+    })
+        .fail((error: string) => {
+        alert(error);
+    });
+
+    // initialize command with options (action only)
+    var cmd3 = ko.command({
+        action: () => { return "Hello cmd3"; }
+    });
+
+    // initialize command with options (action only)
+    var cmd4 = ko.command({
+        action: () => { return "Hello cmd4"; }
+    });
+
+
+    // test execute the command
+    cmd1();
+    	
+    // test properties of the commmand
+    var isRunning = cmd1.isRunning();
+    var failed = cmd1.failed();
+    var completed = cmd1.completed();
+    var canExecute = cmd1.canExecute();
+
+}
+
+function EditableTests() {
+
+    // test ko.editable initializers
+    var edit1 = ko.editable<boolean>(); // no intializer
+
+    var edit2 = ko.editable<string>("test"); // with typed initializer
+
+    var edit3 = ko.editable<any>({ test: true }); // with anything
+
+    var edit4 = ko.editable<string|number>(1); // with union types
+    var edit5 = ko.editable<string|number>("test"); 
+
+    // test getting the value
+    var value = edit1();
+
+    // test editable
+    var isEditing = edit1.isEditing();
+
+    // test editableArray functions:
+    edit1.beginEdit();
+    edit1.endEdit();
+    edit1.cancelEdit();
+    edit1.rollback();
+}
+
+function EditableArrayTests() {
+
+    // test ko.editable intializers
+    var edit1 = ko.editableArray<boolean>(); // no init value
+
+    var edit2 = ko.editableArray<number>([1, 2, 3]); // init value
+
+    var edit3 = ko.editableArray<any>(["a", 1, false, {}]); // mixed
+
+    var edit4 = ko.editableArray<number|string>(["a", 1]); // constrained
+
+    // test getting the array value
+    var value = edit1();
+
+    // test properties
+    var isEditing = edit1.isEditing();
+
+    // test functions:
+    edit1.beginEdit();
+    edit1.endEdit();
+    edit1.cancelEdit();
+    edit1.rollback();
+
+}
+
+function SortableTests() {
+
+    // sorting is added via an extender, there are no .d.ts 
+    // types for this at present
+    var sort1 = ko.observableArray([1, 2, 3]).extend({ sortable: true });
+
+    // extended sort definition with key+descending
+    var sort2 = ko.observableArray([
+        { id: 3, name: "alice" },
+        { id: 2, name: "james" },
+        { id: 1, name: "bob" },
+    ]).extend({
+        sortable: {
+            key: 'id',
+            descending: false
+        }
+    });
+
+    sort2.setSourceKey("id");
+    sort2.sortDescending(true);
+    sort2.setSourceKey("name");
+    sort2.sortDescending(false);
+}

--- a/ko.plus/ko.plus.d.ts
+++ b/ko.plus/ko.plus.d.ts
@@ -14,21 +14,20 @@
  *
  * Version 1.0 - initial commit
  *
+ * Version 1.1 - fixed bug - makeEditable is now a function on .editable
+ *               also refactored how the Editable classes inherit to simplify
  */
-
 
 //
 // Add methods to the 'ko' Knockout object
 //
 interface KnockoutStatic {
-
     // create a command - two overloads
     command: (param: KoPlus.Callback | KoPlus.CommandOptions) => KoPlus.Command;
 
     editable: KoPlus.EditableStatic;
     editableArray: KoPlus.EditableArrayStatic;
 }
-
 
 //#region Sortable type extensions
 
@@ -46,12 +45,10 @@ interface KnockoutObservableArray<T> {
 
 //#endregion
 
-
 //
-// declare new binding handlers in ko-plus
+// declare new binding handlers in ko.plus
 //
 interface KnockoutBindingHandlers {
-
     loadingWhen: KnockoutBindingHandler;
 
     command: KnockoutBindingHandler;
@@ -60,13 +57,11 @@ interface KnockoutBindingHandlers {
 }
 
 //
-// namespace for ko-plus types
+// namespace for ko.plus types
 //
 declare module KoPlus {
-
     // predefine a callback type
     export type Callback = () => void;
-
 
     //#region Command types
 
@@ -78,7 +73,7 @@ declare module KoPlus {
         (): void;
 
         //
-        // properties: https://github.com/stevegreatrex/ko.plus#properties 
+        // properties: https://github.com/stevegreatrex/ko.plus#properties
         //
         isRunning: KnockoutObservable<boolean>;
 
@@ -89,7 +84,7 @@ declare module KoPlus {
         completed: KnockoutObservable<boolean>;
 
         //
-        // functions 
+        // functions
         // see https://github.com/stevegreatrex/ko.plus#functions
         //
         done: (callback: (data: any) => void) => Command;
@@ -99,7 +94,6 @@ declare module KoPlus {
         always: (callback: Callback) => Command;
 
         then: (resolve: Callback, reject: Callback) => Command;
-
     }
 
     //
@@ -107,7 +101,6 @@ declare module KoPlus {
     // see https://github.com/stevegreatrex/ko.plus#options
     //
     export interface CommandOptions {
-
         // [required] sets the command action method
         action: Callback;
 
@@ -122,22 +115,23 @@ declare module KoPlus {
 
     //#region Editable types
 
-    export interface EditableArrayStatic {
-        fn: KnockoutObservableArrayFunctions<any>;
-        <T>(value?: Array<T>): EditableArray<T>;
-    }
-
-    export interface EditableStatic {
-        fn: KnockoutObservableFunctions<any>;
+    export interface EditableStatic extends KnockoutObservableStatic {
         <T>(value?: T): Editable<T>;
 
         makeEditable(target: any): void;
     }
 
+    export interface EditableArrayStatic extends KnockoutObservableArrayStatic {
+        <T>(value?: Array<T>): EditableArray<T>;
+
+        makeEditable(target: any): void; //>
+    }
+
     //
     // defines common editable functions and isEditing property
+    // (used by both editable and editableArray
     //
-    export interface EditableBase<T> extends KnockoutObservableFunctions<T> {
+    export interface EditableFunctions {
         isEditing: KnockoutObservable<boolean>;
         beginEdit(): void;
         endEdit(): void;
@@ -145,23 +139,17 @@ declare module KoPlus {
         rollback(): void;
     }
 
-    export interface Editable<T> extends EditableBase<T> {
-        (): T;
-        (value: T): void;
-
-        subscribe(callback: (newValue: T) => void, target?: any, topic?: string): KnockoutSubscription;
-        notifySubscribers(valueToWrite: T, topic?: string): void;
+    //
+    // extend the standard KnockoutObservable to add editable functions
+    //
+    export interface Editable<T> extends KnockoutObservable<T>, EditableFunctions {
     }
 
-    export interface EditableArray<T> extends KnockoutObservableArrayFunctions<T>, EditableBase<T> {
-        (): T[];
-        (value: T[]): void;
-
-        subscribe(callback: (newValue: T[]) => void, target?: any, topic?: string): KnockoutSubscription;
-        notifySubscribers(valueToWrite: T[], topic?: string): void;
+    //
+    // extend the standard KnockoutObservableArray to add editable functions
+    //
+    export interface EditableArray<T> extends KnockoutObservableArray<T>, EditableFunctions {
     }
-
 
     //#endregion
-
 }

--- a/ko.plus/ko.plus.d.ts
+++ b/ko.plus/ko.plus.d.ts
@@ -1,0 +1,167 @@
+// Type definitions for ko.plus v0.0.21
+// Project: https://github.com/stevegreatrex/ko.plus
+// Definitions by: Howard Richards <https://github.com/conficient>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../knockout/knockout.d.ts" />
+
+/**
+ *
+ * Extensions to KO to provide a command, editable and sortable patterns
+ * - available at http://www.nuget.org/packages/ko.plus/
+ *
+ * (requires TypeScript version 1.4 or higher)
+ *
+ * Version 1.0 - initial commit
+ *
+ */
+
+
+//
+// Add methods to the 'ko' Knockout object
+//
+interface KnockoutStatic {
+
+    // create a command - two overloads
+    command: (param: KoPlus.Callback | KoPlus.CommandOptions) => KoPlus.Command;
+
+    editable: KoPlus.EditableStatic;
+    editableArray: KoPlus.EditableArrayStatic;
+}
+
+
+//#region Sortable type extensions
+
+//
+// extends the KnockoutObservableArray to add sorting methods
+// see https://github.com/stevegreatrex/ko.plus#properties-and-functions
+//
+interface KnockoutObservableArray<T> {
+    sortKey: KnockoutObservable<string>;
+
+    sortDescending: KnockoutObservable<boolean>;
+
+    setSourceKey: (key: string) => void;
+}
+
+//#endregion
+
+
+//
+// declare new binding handlers in ko-plus
+//
+interface KnockoutBindingHandlers {
+
+    loadingWhen: KnockoutBindingHandler;
+
+    command: KnockoutBindingHandler;
+
+    sortBy: KnockoutBindingHandler;
+}
+
+//
+// namespace for ko-plus types
+//
+declare module KoPlus {
+
+    // predefine a callback type
+    export type Callback = () => void;
+
+
+    //#region Command types
+
+    //
+    // the Command interface - returned by ko.command(..)
+    //
+    export interface Command {
+        // execute the command
+        (): void;
+
+        //
+        // properties: https://github.com/stevegreatrex/ko.plus#properties 
+        //
+        isRunning: KnockoutObservable<boolean>;
+
+        canExecute: KnockoutComputed<boolean>;
+
+        failed: KnockoutObservable<boolean>;
+
+        completed: KnockoutObservable<boolean>;
+
+        //
+        // functions 
+        // see https://github.com/stevegreatrex/ko.plus#functions
+        //
+        done: (callback: (data: any) => void) => Command;
+
+        fail: (callback: (error: string) => void) => Command;
+
+        always: (callback: Callback) => Command;
+
+        then: (resolve: Callback, reject: Callback) => Command;
+
+    }
+
+    //
+    // options when defining a command using the option method
+    // see https://github.com/stevegreatrex/ko.plus#options
+    //
+    export interface CommandOptions {
+
+        // [required] sets the command action method
+        action: Callback;
+
+        // [optional] function to determine if command can be executed
+        canExecute?: () => boolean;
+
+        // [optional] context to use in the command
+        context?: any;
+    }
+
+    //#endregion
+
+    //#region Editable types
+
+    export interface EditableArrayStatic {
+        fn: KnockoutObservableArrayFunctions<any>;
+        <T>(value?: Array<T>): EditableArray<T>;
+    }
+
+    export interface EditableStatic {
+        fn: KnockoutObservableFunctions<any>;
+        <T>(value?: T): Editable<T>;
+
+        makeEditable(target: any): void;
+    }
+
+    //
+    // defines common editable functions and isEditing property
+    //
+    export interface EditableBase<T> extends KnockoutObservableFunctions<T> {
+        isEditing: KnockoutObservable<boolean>;
+        beginEdit(): void;
+        endEdit(): void;
+        cancelEdit(): void;
+        rollback(): void;
+    }
+
+    export interface Editable<T> extends EditableBase<T> {
+        (): T;
+        (value: T): void;
+
+        subscribe(callback: (newValue: T) => void, target?: any, topic?: string): KnockoutSubscription;
+        notifySubscribers(valueToWrite: T, topic?: string): void;
+    }
+
+    export interface EditableArray<T> extends KnockoutObservableArrayFunctions<T>, EditableBase<T> {
+        (): T[];
+        (value: T[]): void;
+
+        subscribe(callback: (newValue: T[]) => void, target?: any, topic?: string): KnockoutSubscription;
+        notifySubscribers(valueToWrite: T[], topic?: string): void;
+    }
+
+
+    //#endregion
+
+}


### PR DESCRIPTION
New submission for ko.plus - this is a set of extensions for knockout.js

See https://github.com/stevegreatrex/ko.plus

Ran tests using `tsc` method, using TypeScript v1.4 compiler, no errors or warnings

`npm test` didn't work for some reason:

```
C:\Users\Howard\Documents\GitHub\DefinitelyTyped>npm test

> DefinitelyTyped@0.0.1 test C:\Users\Howard\Documents\GitHub\DefinitelyTyped
> ./node_modules/.bin/dt --changes

'.' is not recognized as an internal or external command,
operable program or batch file.
npm ERR! weird error 1
npm ERR! not ok code 0
```
