### PR TITLE
Fix the argument of ArrayLikeSequence.concat() in Lazy.js definitions

### DIFF
--- a/lazy.js/lazy.js-tests.ts
+++ b/lazy.js/lazy.js-tests.ts
@@ -156,7 +156,7 @@ obj = fooSequence.toObject();
 
 // ArrayLikeSequence
 
-fooArraySeq = fooArraySeq.concat();
+fooArraySeq = fooArraySeq.concat(fooArr);
 fooArraySeq = fooArraySeq.first();
 fooArraySeq = fooArraySeq.first(num);
 foo = fooArraySeq.get(num);

--- a/lazy.js/lazy.js.d.ts
+++ b/lazy.js/lazy.js.d.ts
@@ -176,7 +176,7 @@ declare module LazyJS {
 
     interface ArrayLikeSequence<T> extends Sequence<T> {
         // define()X;
-        concat(): ArrayLikeSequence<T>;
+        concat(var_args: T[]): ArrayLikeSequence<T>;
         first(count?: number): ArrayLikeSequence<T>;
         get(index: number): T;
         length(): number;


### PR DESCRIPTION
http://danieltao.com/lazy.js/docs/#ArrayLikeSequence-concat
