### PR TITLE
Added definition and tests for should-promised library

### DIFF
--- a/should-promised/should-promised-tests.ts
+++ b/should-promised/should-promised-tests.ts
@@ -1,0 +1,21 @@
+/// <reference path="../should/should.d.ts" />
+/// <reference path="should-promised.d.ts" />
+/// <reference path="../bluebird/bluebird.d.ts" />
+
+var promise: Promise<number> = new Promise<number>(function (resolve, reject) {});
+
+promise.should.be.Promise;
+(10).should.not.be.a.Promise;
+
+promise.should.be.fulfilled;
+
+promise.should.be.rejected;
+
+promise.should.be.rejectedWith(Error);
+promise.should.be.rejectedWith('boom');
+promise.should.be.rejectedWith(/boom/);
+promise.should.be.rejectedWith(Error, { message: 'boom' });
+promise.should.be.rejectedWith({ message: 'boom' });
+
+promise.should.be.eventually.equal(10);
+promise.should.be.finally.equal(10);

--- a/should-promised/should-promised.d.ts
+++ b/should-promised/should-promised.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for should-promised
+// Project: https://github.com/shouldjs/promised
+// Definitions by: Yaroslav Admin <https://github.com/devoto13/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+interface ShouldAssertion {
+    Promise: ShouldAssertion;
+    fulfilled: ShouldAssertion;
+    rejected: ShouldAssertion;
+    rejectedWith(message: (string | Function | RegExp), properties?: Object): ShouldAssertion;
+    rejectedWith(message: Object): ShouldAssertion;
+    finally: ShouldAssertion;
+    eventually: ShouldAssertion;
+}


### PR DESCRIPTION
Sorry if I made some stupid errors, I'm not quite familiar with TypeScript. Also not sure is it good approach to require another library, but I need to have Promise object for testing:

`import Promise = require('bluebird');`

Probably it can be replaced by any value, but it's a bit more understandable as it is now.

If you have any comments, let me know and I'll fix it.
