### PR TITLE
Corrected Nodejs querystring (un)escape definitions

### DIFF
--- a/node/node-0.11-tests.ts
+++ b/node/node-0.11-tests.ts
@@ -10,6 +10,7 @@ import crypto = require("crypto");
 import http = require("http");
 import net = require("net");
 import dgram = require("dgram");
+import querystring = require('querystring');
 
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
@@ -122,4 +123,14 @@ var ai: dgram.AddressInfo = ds.address();
 ds.send(new Buffer("hello"), 0, 5, 5000, "127.0.0.1", (error: Error, bytes: number): void => {
 });
 
+////////////////////////////////////////////////////
+///Querystring tests : https://gist.github.com/musubu/2202583
+////////////////////////////////////////////////////
 
+var original: string = 'http://example.com/product/abcde.html';
+var escaped: string = querystring.escape(original);
+console.log(escaped);
+// http%3A%2F%2Fexample.com%2Fproduct%2Fabcde.html
+var unescaped: string = querystring.unescape(escaped);
+console.log(unescaped); 
+// http://example.com/product/abcde.html

--- a/node/node-0.11.d.ts
+++ b/node/node-0.11.d.ts
@@ -250,8 +250,8 @@ declare module "buffer" {
 declare module "querystring" {
     export function stringify(obj: any, sep?: string, eq?: string): string;
     export function parse(str: string, sep?: string, eq?: string, options?: { maxKeys?: number; }): any;
-    export function escape(): any;
-    export function unescape(): any;
+    export function escape(str: string): string;
+    export function unescape(str: string): string;
 }
 
 declare module "events" {

--- a/node/node-0.8.8.d.ts
+++ b/node/node-0.8.8.d.ts
@@ -203,8 +203,8 @@ interface Buffer {
 declare module "querystring" {
     export function stringify(obj: any, sep?: string, eq?: string): string;
     export function parse(str: string, sep?: string, eq?: string, options?: { maxKeys?: number; }): any;
-    export function escape(): any;
-    export function unescape(): any;
+    export function escape(str: string): string;
+    export function unescape(str: string): string;
 }
 
 declare module "events" {

--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -10,6 +10,7 @@ import crypto = require("crypto");
 import http = require("http");
 import net = require("net");
 import dgram = require("dgram");
+import querystring = require('querystring');
 
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
@@ -165,4 +166,14 @@ var ai: dgram.AddressInfo = ds.address();
 ds.send(new Buffer("hello"), 0, 5, 5000, "127.0.0.1", (error: Error, bytes: number): void => {
 });
 
+////////////////////////////////////////////////////
+///Querystring tests : https://gist.github.com/musubu/2202583
+////////////////////////////////////////////////////
 
+var original: string = 'http://example.com/product/abcde.html';
+var escaped: string = querystring.escape(original);
+console.log(escaped);
+// http%3A%2F%2Fexample.com%2Fproduct%2Fabcde.html
+var unescaped: string = querystring.unescape(escaped);
+console.log(unescaped); 
+// http://example.com/product/abcde.html

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -250,8 +250,8 @@ declare module "buffer" {
 declare module "querystring" {
     export function stringify(obj: any, sep?: string, eq?: string): string;
     export function parse(str: string, sep?: string, eq?: string, options?: { maxKeys?: number; }): any;
-    export function escape(): any;
-    export function unescape(): any;
+    export function escape(str: string): string;
+    export function unescape(str: string): string;
 }
 
 declare module "events" {


### PR DESCRIPTION
Corrected escape and unescape functions signatures from NodeJS's querystring module.

Both functions take a string as input parameter and return the same string escaped or unescaped (depending on the function).
Previous declaration was declaring no input param and a return type of any.

Added a test code from a real world application.
