### PR TITLE
Changed order of method declarations for correct overloading

### DIFF
--- a/raphael/raphael.d.ts
+++ b/raphael/raphael.d.ts
@@ -28,9 +28,9 @@ interface RaphaelElement {
     animateWith(el: RaphaelElement, anim: RaphaelAnimation, params: any, ms: number, easing?: string, callback?: Function): RaphaelElement;
     animateWith(el: RaphaelElement, anim: RaphaelAnimation, animation: RaphaelAnimation): RaphaelElement;
     attr(attrName: string, value: any): RaphaelElement;
-    attr(params: any): RaphaelElement;
     attr(attrName: string): any;
     attr(attrNames: string[]): any[];
+    attr(params: any): RaphaelElement;
     click(handler: Function): RaphaelElement;
     clone(): RaphaelElement;
     data(key: string): any;


### PR DESCRIPTION
Overloaded method with more specific argument type needs to be declared before one with more general argument type. 
Otherwise, in this case, call like elemnent.attr("cx") gets resolved by a compiler with RaphaelElement::attr(params: any) instead of correct RaphaelElement::attr(attrName: string)
