### PR TITLE
Marked as compatible with r12

### DIFF
--- a/stats/stats.d.ts
+++ b/stats/stats.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Stats.js r11
+// Type definitions for Stats.js r12
 // Project: http://github.com/mrdoob/stats.js
 // Definitions by: Gregory Dalton <https://github.com/gregolai>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped


### PR DESCRIPTION
Marked the definitions as being compatible with r12 as the interface did not change
