### PR TITLE
[webaudioapi] Specialize event handler type

### DIFF
--- a/webaudioapi/waa-tests.ts
+++ b/webaudioapi/waa-tests.ts
@@ -323,3 +323,11 @@ declare var footstepsBuffer: any;
     context.startRendering();
 }
 
+// Test automatic type inference of the audio processing event handler
+() => {
+    var context = new AudioContext();
+    var recorder = context.createScriptProcessor(2048, 1, 1);
+    recorder.onaudioprocess = function (e) {
+        e.inputBuffer;
+    };
+}

--- a/webaudioapi/waa.d.ts
+++ b/webaudioapi/waa.d.ts
@@ -601,6 +601,10 @@ interface AudioBufferSourceNode extends AudioNode {
 interface MediaElementAudioSourceNode extends AudioNode {
 }
 
+interface AudioProcessingEventHandler {
+    (e: AudioProcessingEvent): void;
+}
+
 /**
  * This interface is an AudioNode which can generate, process, or analyse audio directly using JavaScript.
  *
@@ -617,7 +621,7 @@ interface ScriptProcessorNode  extends AudioNode {
     /**
      * An event listener which is called periodically for audio processing. An event of type AudioProcessingEvent will be passed to the event handler.
      */
-    onaudioprocess: EventHandler;
+    onaudioprocess: AudioProcessingEventHandler;
 
     /**
      * The size of the buffer (in sample-frames) which needs to be processed each time onprocessaudio is called. Legal values are (256, 512, 1024, 2048, 4096, 8192, 16384).


### PR DESCRIPTION
The event handler was defined to take an argument of generic type Event:
this loses the audio event specific type info as defined in the (unused)
AudioProcessingEvent interface.

This patch declares the onaudioprocessing event handler as accepting an
argument of the correct type.
