### PR TITLE
Add definitions for node-persist

### DIFF
--- a/node-persist/node-persist-tests.ts
+++ b/node-persist/node-persist-tests.ts
@@ -1,0 +1,47 @@
+/// <reference path="./node-persist.d.ts" />
+// node-persist tests
+// compile with --module=common
+
+import nodePersist = require("node-persist");
+
+var opts = Node
+nodePersist.init({
+    dir: __dirname + "/test",
+    continuous: false
+});
+nodePersist.setItem("someArray", [1,2,3], (err)=> {
+    nodePersist.getItem("someArray", (err: any, value: any)=> {
+        nodePersist.removeItem("someArray", (err) => err);
+    });
+});
+nodePersist.setItem("someString", "foo")
+           .then(() => nodePersist.getItem("someString"))
+           .then(() => nodePersist.removeItem("someString"))
+           .then(() => nodePersist.clear())
+           .then(() => null);
+
+interface TestObject {
+    foo: string;
+    two: number;
+}
+nodePersist.clear((err) => {
+    var testObject: TestObject = {foo: "bar", two: 2};
+    nodePersist.setItemSync("someObject", testObject);
+    testObject = nodePersist.getItemSync("someObject");
+    nodePersist.removeItem("someObject");
+    nodePersist.clearSync();
+});
+
+var values: Array<any> = nodePersist.values();
+var valuesWithKeyMatch: Array<any> = nodePersist.valuesWithKeyMatch("some");
+var keys: Array<string> = nodePersist.keys();
+var size: number = nodePersist.length();
+nodePersist.forEach((val) => {});
+try {
+    nodePersist.persist((err) => err);
+    nodePersist.persist().then(() => null);
+    nodePersist.persistSync;
+    nodePersist.persistKey("this", (err) => null);
+    nodePersist.persistKey("this").then(() => null);
+    nodePersist.persistKeySync("this");
+} catch(anyError){}

--- a/node-persist/node-persist.d.ts
+++ b/node-persist/node-persist.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for node-persist
+// Project: https://github.com/simonlast/node-persist
+// Definitions by: Spencer Williams <http://spencerwi.com/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+/// <reference path="../q/Q.d.ts" />
+
+declare module "node-persist" {
+    type milliseconds = number;
+    module NodePersist {
+        export interface InitOptions {
+            dir?: string;
+            stringify?: (toSerialize: any)=>string;
+            parse?: (serialized: string)=>any;
+            encoding?: string;
+            logging?: boolean|Function;
+            continuous?: boolean;
+            interval?: milliseconds|boolean;
+            ttl?: milliseconds|boolean;
+        }
+        export function init(options?: InitOptions, callback?: Function): Q.Promise<any>; 
+        export function initSync(options?: InitOptions): void;
+        export function getItem(key: string, callback?: (err: any, value: any)=>any): Q.Promise<any>;
+        export function getItemSync(key: string): any;
+        export function setItem(key: string, value: any, callback?: (err: any)=>any): Q.Promise<any>;
+        export function setItemSync(key: string, value: any): void;
+        export function removeItem(key: string, callback?: (err: any)=>any): Q.Promise<any>;
+        export function removeItemSync(key: string): void;
+        export function clear(callback?: (err: any)=>any): Q.Promise<any>;
+        export function clearSync(): void;
+        export function values(): Array<any>;
+        export function valuesWithKeyMatch(match: string): Array<any>;
+        export function keys(): Array<string>;
+        export function length(): number;
+        export function forEach(callback: (key: string, value: any)=>void): void;
+
+        export function persist(callback?: (err: any)=>any): Q.Promise<any>;
+        export function persistSync(): void;
+        export function persistKey(key: string, callback?: (err: any)=>any): Q.Promise<any>;
+        export function persistKeySync(key: string): void;
+    }
+    export = NodePersist;
+}


### PR DESCRIPTION
Adding support for Simon Last's [node-persist](https://github.com/simonlast/node-persist) (mostly so that tsc doesn't freak out when I import it. It is somewhat unfortunate that Typescript defs are required to prevent node imports from blowing up).
