### PR TITLE
Change error from string to Error

### DIFF
--- a/oboe/oboe.d.ts
+++ b/oboe/oboe.d.ts
@@ -51,7 +51,7 @@ declare module "oboe" {
 		}
 
 		interface FailReason {
-			thrown?: string;
+			thrown?: Error;
 			statusCode?: number;
 			body?: string;
 			jsonBody?: Object;


### PR DESCRIPTION
This field should be an Error object, not a string. See http://oboejs.com/api#fail-event
