### PR TITLE
Add test/example of semi-typesafe extending of leaflet classes

### DIFF
--- a/leaflet/leaflet-tests.ts
+++ b/leaflet/leaflet-tests.ts
@@ -299,3 +299,29 @@ tileLayer.bringToBack()
 	.redraw()
 	.setUrl('http://perdu.com')
 	.getContainer();
+
+module CustomControl {
+	export interface Options {
+		title: string;
+		position?: string;
+	}
+}
+interface CustomControl extends L.Control {
+	getTitle(): string;
+	setTitle(title: string): CustomControl;
+}
+var CustomControl: { new(options: CustomControl.Options): CustomControl };
+CustomControl = L.Control.extend<CustomControl.Options, CustomControl>({
+	initialize: function(options: CustomControl.Options) {
+		L.Control.prototype.initialize.call(this, {
+			position: options.position || 'bottomleft',
+		});
+		this.title = options.title;
+	},
+	getTitle: function() {
+		return this.title;
+	},
+	setTitle: function(title: string) {
+		this.title = title;
+	},
+});


### PR DESCRIPTION
As a follow-on from PR #3637 this adds a test that the leaflet class extension method returns the correct type to allow subclassing using leaflets builtin class system.
