### PR TITLE
Update chrome.d.ts

### DIFF
--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -1524,8 +1524,11 @@ declare module chrome.runtime {
     }
 
     interface MessageSender {
-        id: string;
+        id?: string;
         tab?: chrome.tabs.Tab;
+        frameId?: number;
+        url?: string;
+        tlsChannelId?: string;
     }
 
     interface PlatformInfo {
@@ -1538,7 +1541,7 @@ declare module chrome.runtime {
         postMessage: Function;
         sender?: MessageSender;
         onDisconnect: chrome.events.Event;
-        onMessage: chrome.events.Event;
+        onMessage: PortMessageEvent;
         name: string;
     }
 
@@ -1548,6 +1551,10 @@ declare module chrome.runtime {
 
     interface UpdateCheckDetails {
         version: string;
+    }
+
+    interface PortMessageEvent extends chrome.events.Event {
+        addListener(callback: (message: Object, port: Port) => void): void;
     }
 
     interface ExtensionMessageEvent extends chrome.events.Event {


### PR DESCRIPTION
MessageSender has more properties.
https://developer.chrome.com/extensions/runtime#type-MessageSender

onMessage can be more type safe. It receives only objects serialized in JSON from native.
