### PR TITLE
Use DictionaryIterator for Dictionary functions

### DIFF
--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -2229,7 +2229,7 @@ declare module _ {
         **/
         countBy<T>(
             collection: Dictionary<T>,
-            callback?: ListIterator<T, any>,
+            callback?: DictionaryIterator<T, any>,
             thisArg?: any): Dictionary<number>;
 
         /**
@@ -2314,7 +2314,7 @@ declare module _ {
         **/
         every<T>(
             collection: Dictionary<T>,
-            callback?: ListIterator<T, boolean>,
+            callback?: DictionaryIterator<T, boolean>,
             thisArg?: any): boolean;
 
         /**
@@ -2386,7 +2386,7 @@ declare module _ {
         **/
         all<T>(
             collection: Dictionary<T>,
-            callback?: ListIterator<T, boolean>,
+            callback?: DictionaryIterator<T, boolean>,
             thisArg?: any): boolean;
 
         /**
@@ -2473,7 +2473,7 @@ declare module _ {
         **/
         filter<T>(
             collection: Dictionary<T>,
-            callback: ListIterator<T, boolean>,
+            callback: DictionaryIterator<T, boolean>,
             thisArg?: any): T[];
 
         /**
@@ -2545,7 +2545,7 @@ declare module _ {
         **/
         select<T>(
             collection: Dictionary<T>,
-            callback: ListIterator<T, boolean>,
+            callback: DictionaryIterator<T, boolean>,
             thisArg?: any): T[];
 
         /**
@@ -2685,7 +2685,7 @@ declare module _ {
         **/
         find<T>(
             collection: Dictionary<T>,
-            callback: ListIterator<T, boolean>,
+            callback: DictionaryIterator<T, boolean>,
             thisArg?: any): T;
 
         /**
@@ -2757,7 +2757,7 @@ declare module _ {
         **/
         detect<T>(
             collection: Dictionary<T>,
-            callback: ListIterator<T, boolean>,
+            callback: DictionaryIterator<T, boolean>,
             thisArg?: any): T;
 
         /**
@@ -2829,7 +2829,7 @@ declare module _ {
         **/
         findWhere<T>(
             collection: Dictionary<T>,
-            callback: ListIterator<T, boolean>,
+            callback: DictionaryIterator<T, boolean>,
             thisArg?: any): T;
 
         /**
@@ -2931,7 +2931,7 @@ declare module _ {
         **/
         findLast<T>(
             collection: Dictionary<T>,
-            callback: ListIterator<T, boolean>,
+            callback: DictionaryIterator<T, boolean>,
             thisArg?: any): T;
 
         /**
@@ -3033,7 +3033,7 @@ declare module _ {
         **/
         forEach<T extends {}>(
             object: Dictionary<T>,
-            callback: ObjectIterator<T, void>,
+            callback: DictionaryIterator<T, void>,
             thisArg?: any): Dictionary<T>;
 
         /**
@@ -3068,7 +3068,7 @@ declare module _ {
         **/
         each<T extends {}>(
             object: Dictionary<T>,
-            callback: ObjectIterator<T, void>,
+            callback: DictionaryIterator<T, void>,
             thisArg?: any): Dictionary<T>;
 
         /**
@@ -3139,7 +3139,7 @@ declare module _ {
         **/
         forEachRight<T extends {}>(
             object: Dictionary<T>,
-            callback: ObjectIterator<T, void>,
+            callback: DictionaryIterator<T, void>,
             thisArg?: any): Dictionary<T>;
 
         /**
@@ -3166,7 +3166,7 @@ declare module _ {
         **/
         eachRight<T extends {}>(
             object: Dictionary<T>,
-            callback: ObjectIterator<T, void>,
+            callback: DictionaryIterator<T, void>,
             thisArg?: any): Dictionary<T>;
     }
 
@@ -3272,7 +3272,7 @@ declare module _ {
         **/
         groupBy<T>(
             collection: Dictionary<T>,
-            callback?: ListIterator<T, any>,
+            callback?: DictionaryIterator<T, any>,
             thisArg?: any): Dictionary<T[]>;
 
         /**
@@ -3494,7 +3494,7 @@ declare module _ {
         **/
         map<T extends {}, TResult>(
             object: Dictionary<T>,
-            callback: ObjectIterator<T, TResult>,
+            callback: DictionaryIterator<T, TResult>,
             thisArg?: any): TResult[];
 
         /**
@@ -3534,7 +3534,7 @@ declare module _ {
         **/
         collect<T extends {}, TResult>(
             object: Dictionary<T>,
-            callback: ObjectIterator<T, TResult>,
+            callback: DictionaryIterator<T, TResult>,
             thisArg?: any): TResult[];
 
         /**
@@ -3633,7 +3633,7 @@ declare module _ {
         **/
         max<T>(
             collection: Dictionary<T>,
-            callback?: ListIterator<T, any>,
+            callback?: DictionaryIterator<T, any>,
             thisArg?: any): T;
 
         /**
@@ -4266,7 +4266,7 @@ declare module _ {
         **/
         reject<T>(
             collection: Dictionary<T>,
-            callback: ListIterator<T, boolean>,
+            callback: DictionaryIterator<T, boolean>,
             thisArg?: any): T[];
 
         /**
@@ -4463,7 +4463,7 @@ declare module _ {
         **/
         some<T>(
             collection: Dictionary<T>,
-            callback?: ListIterator<T, boolean>,
+            callback?: DictionaryIterator<T, boolean>,
             thisArg?: any): boolean;
 
         /**
@@ -4543,7 +4543,7 @@ declare module _ {
         **/
         any<T>(
             collection: Dictionary<T>,
-            callback?: ListIterator<T, boolean>,
+            callback?: DictionaryIterator<T, boolean>,
             thisArg?: any): boolean;
 
         /**
@@ -5486,7 +5486,7 @@ declare module _ {
         **/
         forIn<T>(
             object: Dictionary<T>,
-            callback?: ObjectIterator<T, void>,
+            callback?: DictionaryIterator<T, void>,
             thisArg?: any): Dictionary<T>;
 
         /**
@@ -5519,7 +5519,7 @@ declare module _ {
         **/
         forInRight<T extends {}>(
             object: Dictionary<T>,
-            callback?: ObjectIterator<T, void>,
+            callback?: DictionaryIterator<T, void>,
             thisArg?: any): Dictionary<T>;
 
         /**
@@ -5553,7 +5553,7 @@ declare module _ {
         **/
         forOwn<T extends {}>(
             object: Dictionary<T>,
-            callback?: ObjectIterator<T, void>,
+            callback?: DictionaryIterator<T, void>,
             thisArg?: any): Dictionary<T>;
 
         /**
@@ -5586,7 +5586,7 @@ declare module _ {
         **/
         forOwnRight<T extends {}>(
             object: Dictionary<T>,
-            callback?: ObjectIterator<T, void>,
+            callback?: DictionaryIterator<T, void>,
             thisArg?: any): Dictionary<T>;
         /**
         * @see _.forOwnRight
@@ -6380,11 +6380,15 @@ declare module _ {
     }
     
     interface ListIterator<T, TResult> {
-        (value: T, index: number, list: T[]): TResult;
+        (value: T, index: number, collection: T[]): TResult;
+    }
+
+    interface DictionaryIterator<T, TResult> {
+        (value: T, key: string, collection: Dictionary<T>): TResult;
     }
 
     interface ObjectIterator<T, TResult> {
-        (element: T, key: string, list: any): TResult;
+        (element: T, key: string, collection: any): TResult;
     }
 
     interface MemoVoidIterator<T, TResult> {


### PR DESCRIPTION
Without DictionaryIterator the simplest code is impossible to write:

var myDictionary : {[x:string]: string;}

_.filter(myDictionary, (v, k, c) => { return k == "A"; })
