### PR TITLE
update signature of Promise.all and Promise.race

### DIFF
--- a/es6-promise/es6-promise.d.ts
+++ b/es6-promise/es6-promise.d.ts
@@ -54,12 +54,12 @@ declare module Promise {
 	 * the array passed to all can be a mixture of promise-like objects and other objects.
 	 * The fulfillment value is an array (in order) of fulfillment values. The rejection value is the first rejection value.
 	 */
-	function all<R>(promises: Promise<R>[]): Promise<R[]>;
+	function all<R>(promises: (R | Thenable<R>)[]): Promise<R[]>;
 
 	/**
 	 * Make a Promise that fulfills when any item fulfills, and rejects if any item rejects.
 	 */
-	function race<R>(promises: Promise<R>[]): Promise<R>;
+	function race<R>(promises: (R | Thenable<R>)[]): Promise<R>;
 }
 
 declare module 'es6-promise' {


### PR DESCRIPTION
This updates `Promise.all` and `Promise.race` to accept arrays of regular objects and thenable objects in accordance with the spec: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all

```
If something passed in the iterable array is not a promise, it's converted to one by Promise.resolve. 
```
