### PR TITLE
Made all of the GraphNode values optional

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1236,24 +1236,24 @@ declare module D3 {
         }
 
         export interface GraphNode  {
-            id: number;
-            index: number;
-            name: string;
-            px: number;
-            py: number;
-            size: number;
-            weight: number;
-            x: number;
-            y: number;
-            subindex: number;
-            startAngle: number;
-            endAngle: number;
-            value: number;
-            fixed: boolean;
-            children: GraphNode[];
-            _children: GraphNode[];
-            parent: GraphNode;
-            depth: number;
+            id?: number;
+            index?: number;
+            name?: string;
+            px?: number;
+            py?: number;
+            size?: number;
+            weight?: number;
+            x?: number;
+            y?: number;
+            subindex?: number;
+            startAngle?: number;
+            endAngle?: number;
+            value?: number;
+            fixed?: boolean;
+            children?: GraphNode[];
+            _children?: GraphNode[];
+            parent?: GraphNode;
+            depth?: number;
         }
 
         export interface GraphLink {


### PR DESCRIPTION
When passing data to a d3 structure the data can be very flexible.
The current interface of the GraphNode requires many data attributes
to be present, most of which aren't required to draw the
visualization. In fact, d3 calculates some of them itself, so passing
them to the GraphNode would be redundant.

In this example http://bl.ocks.org/mbostock/4063269#flare.json, Mike
Bostock uses the attribute className to identify name and packageName
to identify color in the GraphNode. This means that he doesn't only
ignore all of the attributes DefintelyTyped provides, but comes up
with his own attributes. This means that the data passed in could in
fact be a hashmap/js object type with arbitrary attributes. It's only
when the data is used with d3 methods to identify what attribute
represents size/color etc... that the type becomes relevant.

So either the GraphNode should be less restrictive (or in fact an
arbitrary hashmap) or I've misunderstood some core concept.

You don't have to necessarily merge this pull request, if I'm right
some parts will have to be rewritten (GraphNodes seem to be used
everywhere), but hopefully it might spark some discussion.
