### PR TITLE
Remove configure() definition in KnockoutValidationStatic

### DIFF
--- a/knockout.validation/knockout.validation.d.ts
+++ b/knockout.validation/knockout.validation.d.ts
@@ -108,7 +108,6 @@ interface KnockoutValidationGroup {
 
 interface KnockoutValidationStatic {
     init(options?: KnockoutValidationConfiguration, force?: boolean): void;
-    configure(options: KnockoutValidationConfiguration): void;
     reset(): void;
 
     group(obj: any, options?: any): KnockoutValidationErrors;


### PR DESCRIPTION
Configure is now deprecated in KV 2x. Init should be used instead.
