### PR TITLE
Update angular.d.ts to fix IHttpPromise.

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1262,7 +1262,7 @@ declare module ng {
         statusText?: string;
     }
 
-    interface IHttpPromise<T> extends IPromise<T> {
+    interface IHttpPromise<T> extends IPromise<IHttpPromiseCallbackArg<T>> {
         success(callback: IHttpPromiseCallback<T>): IHttpPromise<T>;
         error(callback: IHttpPromiseCallback<any>): IHttpPromise<T>;
         then<TResult>(successCallback: (response: IHttpPromiseCallbackArg<T>) => IPromise<TResult>|TResult, errorCallback?: (response: IHttpPromiseCallbackArg<any>) => any): IPromise<TResult>;


### PR DESCRIPTION
IHttpPromise<T> does not extend IPromise<T> directly.  It always transforms it with the response (of type T) as the `data` member.  See $httpProvider.$http.sendRec.resolvePromise(response, status, headers, statusText).  This matters when exploiting the inheritance to IPromise (for example in a return).
