### PR TITLE
Fix Malformed type for execSync::options.input

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -652,7 +652,7 @@ declare module "child_process" {
     }): ChildProcess;
     export function execSync(command: string, options?: {
         cwd?: string;
-        input?: string|Buffer;
+        input?: any; // string | Buffer;
         stdio?: any;
         env?: any;
         uid?: number;


### PR DESCRIPTION
type cannot be piped, swapped to `any` to allow for manual passing of either `string` or `Buffer`.

all other multi-types are similarly declared in this file (line 677, e.g.)
