### PR TITLE
Add definitions for conveniently writing gulpfile with TypeScript

### DIFF
--- a/gulp-concat/gulp-concat-tests.ts
+++ b/gulp-concat/gulp-concat-tests.ts
@@ -1,0 +1,23 @@
+/// <reference path="./gulp-concat.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require("gulp");
+import concat = require("gulp-concat");
+
+gulp.task("concat:simple", () => {
+    gulp.src(["file*.txt"])
+        .pipe(concat("file.txt"))
+        .pipe(gulp.dest("build"));
+});
+
+gulp.task("concat:newLine", () => {
+    gulp.src(["file*.txt"])
+        .pipe(concat("file.txt", { newLine: ";" }))
+        .pipe(gulp.dest("build"));
+});
+
+gulp.task("concat:vinyl", () => {
+    gulp.src(["file*.txt"])
+        .pipe(concat({ path: "file.txt", stat: { mode: 0666 } }))
+        .pipe(gulp.dest("build"));
+});

--- a/gulp-concat/gulp-concat.d.ts
+++ b/gulp-concat/gulp-concat.d.ts
@@ -1,0 +1,42 @@
+// Type definitions for gulp-concat
+// Project: http://github.com/wearefractal/gulp-concat
+// Definitions by: Keita Kagurazaka <https://github.com/k-kagurazaka>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module "gulp-concat" {
+
+    interface IOptions {
+        newLine: string;
+    }
+
+    interface IFsStats {
+        dev?: number;
+        ino?: number;
+        mode?: number;
+        nlink?: number;
+        uid?: number;
+        gid?: number;
+        rdev?: number;
+        size?: number;
+        blksize?: number;
+        blocks?: number;
+        atime?: Date;
+        mtime?: Date;
+        ctime?: Date;
+    }
+
+    interface IVinylOptions {
+        cwd?: string;
+        base?: string;
+        path?: string;
+        stat?: IFsStats;
+        contents?: NodeJS.ReadableStream | Buffer;
+    }
+
+    function concat(filename: string, options?: IOptions): NodeJS.ReadWriteStream;
+    function concat(options: IVinylOptions): NodeJS.ReadWriteStream;
+
+    export = concat;
+}

--- a/gulp-flatten/gulp-flatten-tests.ts
+++ b/gulp-flatten/gulp-flatten-tests.ts
@@ -1,0 +1,17 @@
+/// <reference path="./gulp-flatten.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require("gulp");
+import flatten = require("gulp-flatten");
+
+gulp.task("flatten:simple", () => {
+    gulp.src(["files/**/*.txt"])
+        .pipe(flatten())
+        .pipe(gulp.dest("build"));
+});
+
+gulp.task("flatten:newPath", () => {
+    gulp.src(["files/**/*.txt"])
+        .pipe(flatten({ newPath: "new/path" }))
+        .pipe(gulp.dest("build"));
+});

--- a/gulp-flatten/gulp-flatten.d.ts
+++ b/gulp-flatten/gulp-flatten.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for gulp-flatten
+// Project: https://github.com/armed/gulp-flatten
+// Definitions by: Keita Kagurazaka <https://github.com/k-kagurazaka>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module "gulp-flatten" {
+
+    interface IOptions {
+        newPath: string;
+    }
+
+    function flatten(options?: IOptions): NodeJS.ReadWriteStream;
+
+    export = flatten;
+}

--- a/gulp-inject/gulp-inject-tests.ts
+++ b/gulp-inject/gulp-inject-tests.ts
@@ -1,0 +1,41 @@
+/// <reference path="./gulp-inject.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require("gulp");
+import inject = require("gulp-inject");
+
+gulp.task("inject:simple", () => {
+    gulp.src("src/index.html")
+        .pipe(inject(gulp.src(["src/**/*.js", "src/**/*.css"], { read: false })))
+        .pipe(gulp.dest("build"));
+});
+
+gulp.task("inject:relative", () => {
+    gulp.src(["src/index.html"])
+        .pipe(inject(gulp.src(["src/**/*.js", "src/**/*.css"], { read: false }), { relative: true }))
+        .pipe(gulp.dest("build"));
+});
+
+gulp.task("inject:starttag", () => {
+    gulp.src(["src/index.html"])
+        .pipe(inject(gulp.src(["src/**/*.js", "src/**/*.css"], { read: false }), { starttag: "<!-- inject:head:{{ext}} -->" }))
+        .pipe(gulp.dest("build"));
+});
+
+gulp.task("inject:name", () => {
+    gulp.src(["src/index.html"])
+        .pipe(inject(gulp.src(["src/**/*.js", "src/**/*.css"], { read: false }), { name: "head" }))
+        .pipe(gulp.dest("build"));
+});
+
+gulp.task("inject:transform", () => {
+    gulp.src(["files.json"])
+        .pipe(inject(gulp.src(["src/**/*.js", "src/**/*.css", "src/**/*.html"], { read: false }), {
+            starttag: "\"{{ext}}\": [",
+            endtag: "]",
+            transform: (filepath, file, i, length) => {
+                return "  \"" + filepath + "\"" + (i + 1 < length ? "," : "");
+            }
+        }))
+        .pipe(gulp.dest("build"));
+});

--- a/gulp-inject/gulp-inject.d.ts
+++ b/gulp-inject/gulp-inject.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for gulp-inject
+// Project: https://github.com/klei/gulp-inject
+// Definitions by: Keita Kagurazaka <https://github.com/k-kagurazaka>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+/// <reference path="../vinyl/vinyl.d.ts" />
+
+declare module "gulp-inject" {
+
+    import File = require("vinyl");
+
+    interface ITagFunction {
+        (targetExt: string, sourceExt: string): string;
+    }
+
+    interface ITransformFunction {
+        (filepath: string, file?: File, index?: number, length?: number, targetFile?: File): string;
+    }
+
+    interface IOptions {
+        ignorePath?: string | string[];
+        relative?: boolean;
+        addPrefix?: string;
+        addRootSlash?: boolean;
+        name?: string;
+        starttag?: string | ITagFunction;
+        endtag?: string | ITagFunction;
+        transform?: ITransformFunction;
+        selfClosingTag?: boolean;
+    }
+
+    function inject(sources: NodeJS.ReadableStream, options?: IOptions): NodeJS.ReadWriteStream;
+
+    export = inject;
+}

--- a/gulp-less/gulp-less-tests.ts
+++ b/gulp-less/gulp-less-tests.ts
@@ -1,0 +1,13 @@
+/// <reference path="./gulp-less.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require("gulp");
+import less = require("gulp-less");
+
+gulp.task("less", () => {
+    gulp.src("less/**/*.less")
+        .pipe(less({
+            paths: ["less/includes"]
+        }))
+        .pipe(gulp.dest("public/css"));
+});

--- a/gulp-less/gulp-less.d.ts
+++ b/gulp-less/gulp-less.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for gulp-less
+// Project: https://github.com/plus3network/gulp-less
+// Definitions by: Keita Kagurazaka <https://github.com/k-kagurazaka>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module "gulp-less" {
+
+    interface IOptions {
+        paths: string[];
+        plugins?: any[];
+    }
+
+    function less(options?: IOptions): NodeJS.ReadWriteStream;
+
+    export = less;
+}

--- a/gulp-minify-css/gulp-minify-css-tests.ts
+++ b/gulp-minify-css/gulp-minify-css-tests.ts
@@ -1,0 +1,11 @@
+/// <reference path="./gulp-minify-css.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require("gulp");
+import minifyCSS = require("gulp-minify-css");
+
+gulp.task("minify-css", () => {
+    gulp.src("css/**/*.css")
+        .pipe(minifyCSS({ keepBreaks: true }))
+        .pipe(gulp.dest("dist"));
+});

--- a/gulp-minify-css/gulp-minify-css.d.ts
+++ b/gulp-minify-css/gulp-minify-css.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for gulp-minify-css
+// Project: https://github.com/jonathanepollack/gulp-minify-css
+// Definitions by: Keita Kagurazaka <https://github.com/k-kagurazaka>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module "gulp-minify-css" {
+
+    interface IOptions {
+        cache?: boolean;
+        advanced?: boolean;
+        aggressiveMerging?: boolean;
+        benchmark?: boolean;
+        compatibility?: string;
+        debug?: boolean;
+        inliner?: Object;
+        keepBreaks?: boolean;
+        keepSpecialComments?: string | number;
+        processImport?: boolean;
+        rebase?: boolean;
+        relativeTo?: string;
+        root?: string;
+        roundingPrecision?: number;
+        shorthandCompacting?: boolean;
+    }
+
+    function minifyCSS(options?: IOptions): NodeJS.ReadWriteStream;
+
+    export = minifyCSS;
+}

--- a/gulp-tsd/gulp-tsd-tests.ts
+++ b/gulp-tsd/gulp-tsd-tests.ts
@@ -1,0 +1,17 @@
+/// <reference path="./gulp-tsd.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require("gulp");
+import tsd = require("gulp-tsd");
+
+gulp.task("tsd", () => {
+    gulp.src("gulp_tsd.json")
+        .pipe(tsd());
+});
+
+gulp.task("tsd:options", callback => {
+    tsd({
+        command: "reinstall",
+        config: "tsd.json"
+    }, callback);
+});

--- a/gulp-tsd/gulp-tsd.d.ts
+++ b/gulp-tsd/gulp-tsd.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for gulp-tsd
+// Project: https://github.com/moznion/gulp-tsd
+// Definitions by: Keita Kagurazaka <https://github.com/k-kagurazaka>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+declare module "gulp-tsd" {
+
+    interface IOptions {
+        command?: string;
+        latest?: boolean;
+        config?: string;
+        opts?: Object;
+    }
+
+    function tsd(opts?: IOptions, callback?: gulp.ITaskCallback): NodeJS.ReadWriteStream;
+
+    export = tsd;
+}

--- a/main-bower-files/main-bower-files-tests.ts
+++ b/main-bower-files/main-bower-files-tests.ts
@@ -1,0 +1,31 @@
+/// <reference path="./main-bower-files.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require("gulp");
+import mainBowerFiles = require("main-bower-files");
+
+gulp.task("main-bower-files:simple", () => {
+    gulp.src(mainBowerFiles())
+        .pipe(gulp.dest("dist/bower"));
+});
+
+gulp.task("main-bower-files:options", () => {
+    var files = mainBowerFiles({
+        debugging: false,
+        env: process.env.NODE_ENV,
+        paths: {
+            bowerDirectory: "path/for/bower_components",
+            bowerrc: "path/for/.bowerrc",
+            bowerJson: "path/for/bower.json"
+        },
+        checkExistence: false,
+        includeDev: false,
+        includeSelf: false,
+        filter: (filepath) => {
+            return filepath.indexOf("search") >= 0;
+        }
+    });
+
+    gulp.src(files, { base: "path/to/bower_components" })
+        .pipe(gulp.dest("dist/bower"));
+});

--- a/main-bower-files/main-bower-files.d.ts
+++ b/main-bower-files/main-bower-files.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for main-bower-files
+// Project: https://github.com/ck86/main-bower-files
+// Definitions by: Keita Kagurazaka <https://github.com/k-kagurazaka>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module "main-bower-files" {
+
+    interface IPaths {
+        bowerDirectory?: string;
+        bowerrc?: string;
+        bowerJson?: string;
+    }
+
+    interface IFilterFunction {
+        (filepath: string): boolean;
+    }
+
+    interface IOptions {
+        debugging?: boolean;
+        main?: string | string[] | Object;
+        env?: string;
+        paths?: IPaths | string;
+        checkExistence?: boolean;
+        includeDev?: boolean | string;
+        includeSelf?: boolean;
+        filter?: RegExp | IFilterFunction | string | string[];
+    }
+
+    function mainBowerFiles(options?: IOptions): string[];
+
+    export = mainBowerFiles;
+}

--- a/merge-stream/merge-stream-tests.ts
+++ b/merge-stream/merge-stream-tests.ts
@@ -1,0 +1,13 @@
+/// <reference path="./merge-stream.d.ts" />
+
+import stream = require("stream");
+import Stream = stream.Readable;
+import merge = require("merge-stream");
+
+var stream1 = new Stream();
+var stream2 = new Stream();
+
+var merged = merge(stream1, stream2);
+
+var stream3 = new Stream();
+merged.add(stream3);

--- a/merge-stream/merge-stream.d.ts
+++ b/merge-stream/merge-stream.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for merge-stream
+// Project: https://github.com/grncdr/merge-stream
+// Definitions by: Keita Kagurazaka <https://github.com/k-kagurazaka>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts"/>
+
+declare module "merge-stream" {
+
+    interface IMergedStream extends NodeJS.ReadWriteStream {
+        add: (source: NodeJS.ReadableStream) => IMergedStream;
+    }
+
+    function merge<T extends NodeJS.ReadableStream>(...streams: T[]): IMergedStream;
+    export = merge;
+}

--- a/run-sequence/run-sequence-tests.ts
+++ b/run-sequence/run-sequence-tests.ts
@@ -1,0 +1,33 @@
+/// <reference path="./run-sequence.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require("gulp");
+import tmp = require("run-sequence");
+var runSequence = tmp.use(gulp);
+
+gulp.task("run-sequence", callback => {
+    runSequence("task1",
+        ["task2", "task3"],
+        "taks4",
+        callback);
+});
+
+gulp.task("task1", () => {
+    gulp.src("file1.txt")
+        .pipe(gulp.dest("build"));
+});
+
+gulp.task("task2", () => {
+    gulp.src("file2.txt")
+        .pipe(gulp.dest("build"));
+});
+
+gulp.task("task3", () => {
+    gulp.src("file3.txt")
+        .pipe(gulp.dest("build"));
+});
+
+gulp.task("task4", () => {
+    gulp.src("file4.txt")
+        .pipe(gulp.dest("build"));
+});

--- a/run-sequence/run-sequence.d.ts
+++ b/run-sequence/run-sequence.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for run-sequence
+// Project: https://github.com/OverZealous/run-sequence
+// Definitions by: Keita Kagurazaka <https://github.com/k-kagurazaka>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+declare module "run-sequence" {
+
+    interface IRunSequence {
+        (...streams: (string | string[] | gulp.ITaskCallback)[]): NodeJS.ReadWriteStream;
+
+        use(gulp: gulp.Gulp): IRunSequence;
+    }
+
+    var _tmp: IRunSequence;
+    export = _tmp;
+}

--- a/stream-series/stream-series-tests.ts
+++ b/stream-series/stream-series-tests.ts
@@ -1,0 +1,12 @@
+/// <reference path="./stream-series.d.ts" />
+
+import stream = require("stream");
+import Stream = stream.Duplex;
+import series = require("stream-series");
+
+var stream1 = new Stream();
+var stream2 = new Stream();
+var stream3 = new Stream();
+
+var orderedStream = series(stream1, stream3, stream2);
+console.log(orderedStream.toString());

--- a/stream-series/stream-series.d.ts
+++ b/stream-series/stream-series.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for stream-series
+// Project: https://github.com/rschmukler/stream-series
+// Definitions by: Keita Kagurazaka <https://github.com/k-kagurazaka>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module "stream-series" {
+    function series<T extends NodeJS.ReadableStream>(...streams: T[]): NodeJS.ReadWriteStream;
+    export = series;
+}


### PR DESCRIPTION
Hi,

I  created some definitions and tests for writing gulpfile with TypeScript conveniently.
A complete list of packages which are dealt with by this pull-request as follows.
- [gulp-concat](http://github.com/wearefractal/gulp-concat)
- [gulp-flatten](https://github.com/armed/gulp-flatten)
- [gulp-inject](https://github.com/klei/gulp-inject)
- [gulp-less](https://github.com/plus3network/gulp-less)
- [gulp-minify-css](https://github.com/jonathanepollack/gulp-minify-css)
- [gulp-tsd](https://github.com/moznion/gulp-tsd)
- [main-bower-files](https://github.com/ck86/main-bower-files)
- [merge-stream](https://github.com/grncdr/merge-stream)
- [run-sequence](https://github.com/OverZealous/run-sequence)
- [stream-series](https://github.com/rschmukler/stream-series)
