### PR TITLE
Remove the need of not necessary Html Element

### DIFF
--- a/jquery.gridster/gridster-tests.ts
+++ b/jquery.gridster/gridster-tests.ts
@@ -1,7 +1,5 @@
 /// <reference path="gridster.d.ts" />
 
-var el: HTMLElement = new HTMLElement();
-
 interface SerializeData {
 	x?: number;
 	y?: number;
@@ -18,7 +16,7 @@ var options: GridsterOptions = {
 	}
 };
 
-var gridster = <Gridster>$('.gridster ul').gridster(el, options).data('grister');
+var gridster = <Gridster>$('.gridster ul').gridster(options).data('grister');
 gridster.add_widget('<li class="new">The HTML of the widget...</li>', 2, 1);
 gridster.remove_widget($('gridster li').eq(3).get(0));
 var json = gridster.serialize<SerializeData>();

--- a/jquery.gridster/gridster.d.ts
+++ b/jquery.gridster/gridster.d.ts
@@ -160,11 +160,10 @@ interface JQuery {
 
 	/**
 	* Gridster
-	* @param el The HTMLElement that contains all the widgets.
 	* @param options An object with all the gridster options you want to overwrite.
 	* @return Gridster jQuery instance.
 	**/
-	gridster(el: HTMLElement, options?: GridsterOptions): JQuery;
+	gridster(options?: GridsterOptions): JQuery;
 }
 
 interface Gridster {


### PR DESCRIPTION
The current situation force the user to have a not necessary creation of
an HtmlElement object. In fact, you do not need. JQuery Gridster has a
plugin that take a single parameter which is the option. This is why
that Pull Request fix this issue but also the issue that when debugging
the unit test you can see that the injected options were the HtmlElement
instead of the real options.
