### PR TITLE
Fix return type of D3.Selection.classed(string) to boolean

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -728,7 +728,7 @@ declare module D3 {
         };
 
         classed: {
-            (name: string): string;
+            (name: string): boolean;
             (name: string, value: any): Selection;
             (name: string, valueFunction: (data: any, index: number) => any): Selection;
             (classValueMap: Object): Selection;


### PR DESCRIPTION
According to D3 [API Reference](https://github.com/mbostock/d3/wiki/Selections#classed):

> If value is not specified, returns true if and only if the first non-null element in this selection has the specified class. This is generally useful only if you know the selection contains exactly one element.

And its [implementation](https://github.com/mbostock/d3/blob/master/d3.js#L685) actually only returns boolean:

``` javascript
 d3_selectionPrototype.classed = function(name, value) {
    if (arguments.length < 2) {
      if (typeof name === "string") {
        var node = this.node(), n = (name = d3_selection_classes(name)).length, i = -1;
        if (value = node.classList) {
          while (++i < n) if (!value.contains(name[i])) return false;
        } else {
          value = node.getAttribute("class");
          while (++i < n) if (!d3_selection_classedRe(name[i]).test(value)) return false;
        }
        return true;
      }
      // ...
```
