### PR TITLE
Fixed link definition on IDirective with union type

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1448,7 +1448,7 @@ declare module ng {
         controller?: any;
         controllerAs?: string;
         bindToController?: boolean;
-        link?: IDirectiveLinkFn;
+        link?: IDirectiveLinkFn | IDirectivePrePost;
         name?: string;
         priority?: number;
         replace?: boolean;


### PR DESCRIPTION
Added IDirectivePrePost alternative to link.
See: https://docs.angularjs.org/api/ng/service/$compile
Requires TypeScript 1.4 with union type support.
