### PR TITLE
Update chrome.runtime

### DIFF
--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -1545,7 +1545,8 @@ declare module chrome.runtime {
     }
 
     interface Port {
-        postMessage: Function;
+        postMessage: (message: Object) => void;
+        disconnect: () => void;
         sender?: MessageSender;
         onDisconnect: chrome.events.Event;
         onMessage: PortMessageEvent;


### PR DESCRIPTION
chrome.runtime.Port has more properties.
See https://developer.chrome.com/extensions/runtime#type-Port

Change `postMessage` like `onMessage` was changed in 36f2213157fa535f5c4aef66da98559e9823e25c.
Add `disconnect` method.
