### PR TITLE
add missing axis parameter to flot tickFormatter

### DIFF
--- a/flot/jquery.flot.d.ts
+++ b/flot/jquery.flot.d.ts
@@ -107,7 +107,7 @@ declare module jquery.flot {
         ticks?: any;                                    // null or number or ticks array or (fn: axis -> ticks array)
         tickSize?: any;                                 // number or array
         minTickSize?: any;                              // number or array
-        tickFormatter?: (t: number) => string;                            // (fn: number, object -> string) or string
+        tickFormatter?: (t: number, a?: axis) => string;                            // (fn: number, object -> string) or string
         tickDecimals?: number;
 
         labelWidth?: number;


### PR DESCRIPTION
The tickFormatter entry for a flot axis definition now has the optional
axis argument available.
