### PR TITLE
Made keepEmptyLines optional

### DIFF
--- a/byline/byline.d.ts
+++ b/byline/byline.d.ts
@@ -9,7 +9,7 @@ declare module "byline" {
     import stream = require("stream");
 
     export interface LineStreamOptions extends stream.TransformOptions {
-        keepEmptyLines: boolean;
+        keepEmptyLines?: boolean;
     }
 
     export interface LineStream extends stream.Transform {


### PR DESCRIPTION
If one decides to only use something of `TransformOptions` (e.g. `encoding`), it wouldn't be possible to omit the `keepEmptyLines` option.
