### PR TITLE
chokidar improved

### DIFF
--- a/chokidar/chokidar-tests.ts
+++ b/chokidar/chokidar-tests.ts
@@ -3,7 +3,10 @@
 import fs = require('fs');
 import chokidar = require('chokidar');
 
-var watcher = chokidar.watch('file, dir, or glob', {
+var FSWatcher = chokidar.FSWatcher;
+var watcher = new FSWatcher();
+
+watcher = chokidar.watch('file, dir, or glob', {
     ignored: /[\/\\]\./, persistent: true
 });
 
@@ -17,7 +20,7 @@ watcher
     .on('unlinkDir', function(path:string) { log('Directory', path, 'has been removed'); })
     .on('error', function(error:any) { log('Error happened', error); })
     .on('ready', function() { log('Initial scan complete. Ready for changes.'); })
-    .on('raw', function(event:Event, path:string, details:any) { log('Raw event info:', event, path, details); })
+    .on('raw', function(event:Event, path:string, details:any) { log('Raw event info:', event, path, details); });
 
 // 'add', 'addDir' and 'change' events also receive stat() results as second
 // argument when available: http://nodejs.org/api/fs.html#fs_class_fs_stats

--- a/chokidar/chokidar.d.ts
+++ b/chokidar/chokidar.d.ts
@@ -1,25 +1,16 @@
 // Type definitions for chokidar 1.0.0
 // Project: https://github.com/paulmillr/chokidar
-// Definitions by: Stefan Steinhart <https://github.com/reppners/>
+// Definitions by: Stefan Steinhart <https://github.com/reppners/>, Arnaud Tournier <https://github.com/ltearno>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../node/node.d.ts" />
 
-declare module "fs"
-{
-    interface FSWatcher
-    {
-        add(fileDirOrGlob:string):void;
-        add(filesDirsOrGlobs:Array<string>):void;
-        unwatch(fileDirOrGlob:string):void;
-        unwatch(filesDirsOrGlobs:Array<string>):void;
-    }
-}
+declare module "chokidar" {
 
-declare module "chokidar"
-{
-    interface WatchOptions
-    {
+    import fs = require("fs");
+    import events = require("events");
+
+    export interface ChokidarOptions {
         persistent?:boolean;
         ignored?:any;
         ignoreInitial?:boolean;
@@ -35,8 +26,28 @@ declare module "chokidar"
         atomic?:boolean;
     }
 
-    import fs = require("fs");
+    export interface FSWatcher extends events.EventEmitter {
+        new(options?:ChokidarOptions): FSWatcher;
 
-    function watch( fileDirOrGlob:string, options?:WatchOptions ):fs.FSWatcher;
-    function watch( filesDirsOrGlobs:Array<string>, options?:WatchOptions ):fs.FSWatcher;
+        add(path:string | string[]): FSWatcher;
+        unwatch(path:string | string[]): FSWatcher;
+
+        close(): FSWatcher;
+
+        on(event:string, callback:Function): FSWatcher;
+
+        on(event:'add', callback:(path:string, stats?:fs.Stats)=> void): FSWatcher;
+        on(event:'addDir', callback:(path:string, stats?:fs.Stats)=> void): FSWatcher;
+        on(event:'change', callback:(path:string, stats?:fs.Stats)=> void): FSWatcher;
+        on(event:'unlink', callback:(path:string)=> void): FSWatcher;
+        on(event:'unlinkDir', callback:(path:string)=> void): FSWatcher;
+        on(event:'error', callback:(error:Error)=> void): FSWatcher;
+        on(event:'ready', callback:()=> void): FSWatcher;
+        on(event:'raw', callback:(event:any, path:string, details:any)=> void): FSWatcher;
+
+        on(event:'all', callback:(event:any, path:string)=> void): FSWatcher;
+    }
+
+    export var FSWatcher: FSWatcher;
+    export function watch(fileDirOrGlob:string | string[], options?:ChokidarOptions): FSWatcher;
 }


### PR DESCRIPTION
- added more specific typings inspired by https://github.com/ltearno/DefinitelyTyped/commit/a35314dfa44f5ab251279bdf192c41f7defe3301
- using new union types feature of typescript
- removed declaration merge on fs module because chokidar does not extend the FSWatcher but creates its own by extending EventEmitter

credits and thanks to [ltearno](https://github.com/ltearno)
