### PR TITLE
react/future/react-0.13 improvements for support in IntelliJ

### DIFF
--- a/react/future/react-0.13.0.d.ts
+++ b/react/future/react-0.13.0.d.ts
@@ -27,6 +27,20 @@ declare module "react" {
     type ReactHTMLElement = ReactDOMElement<HTMLAttributes>;
     type ReactSVGElement = ReactDOMElement<SVGAttributes>;
 
+
+    //
+    // React Nodes
+    // http://facebook.github.io/react/docs/glossary.html
+    // ----------------------------------------------------------------------
+
+    type ReactText = string | number;
+    type ReactChild = ReactElementBase<any, any> | ReactText;
+
+    // Should be Array<ReactNode> but type aliases cannot be recursive
+    type ReactFragment = Array<ReactChild | any[] | boolean>;
+    type ReactNode = ReactChild | ReactFragment | boolean;
+
+
     //
     // Factories
     // ----------------------------------------------------------------------
@@ -46,17 +60,6 @@ declare module "react" {
     type HTMLFactory = DOMFactory<HTMLAttributes>;
     type SVGFactory = DOMFactory<SVGAttributes>;
 
-    //
-    // React Nodes
-    // http://facebook.github.io/react/docs/glossary.html
-    // ----------------------------------------------------------------------
-
-    type ReactText = string | number;
-    type ReactChild = ReactElementBase<any, any> | ReactText;
-
-    // Should be Array<ReactNode> but type aliases cannot be recursive
-    type ReactFragment = Array<ReactChild | any[] | boolean>;
-    type ReactNode = ReactChild | ReactFragment | boolean;
 
     //
     // Top Level API

--- a/react/future/react-0.13.0.d.ts
+++ b/react/future/react-0.13.0.d.ts
@@ -75,18 +75,26 @@ declare module "react" {
     function createFactory<P>(
         type: ComponentClass<P, any>): Factory<P>;
 
+    //
+    // Unfortunately these definitions are too stringent and do not allow a sufficiently flexible syntax for the Element Type
+    // see example project with react-templates at:  https://github.com/bgrieder/react-templates-typescript-test.git
+    //
+    //function createElement<P>(
+    //    type: string,
+    //    props?: P,
+    //    ...children: ReactNode[]): ReactDOMElement<P>;
+    //function createElement<P>(
+    //    type: ClassicComponentClass<P, any> | string,
+    //    props?: P,
+    //    ...children: ReactNode[]): ReactClassicElement<P>;
+    //function createElement<P>(
+    //    type: ComponentClass<P, any>,
+    //    props?: P,
+    //    ...children: ReactNode[]): ReactElement<P>;
     function createElement<P>(
-        type: string,
+        etype: any,
         props?: P,
         ...children: ReactNode[]): ReactDOMElement<P>;
-    function createElement<P>(
-        type: ClassicComponentClass<P, any> | string,
-        props?: P,
-        ...children: ReactNode[]): ReactClassicElement<P>;
-    function createElement<P>(
-        type: ComponentClass<P, any>,
-        props?: P,
-        ...children: ReactNode[]): ReactElement<P>;
 
     function render<P>(
         element: ReactDOMElement<P>,

--- a/react/future/react-addons-0.13.0.d.ts
+++ b/react/future/react-addons-0.13.0.d.ts
@@ -74,18 +74,26 @@ declare module "react/addons" {
     function createFactory<P>(
         type: ComponentClass<P, any>): Factory<P>;
 
+    //
+    // Unfortunately these definitions are too stringent and do not allow a sufficiently flexible syntax for the Element Type
+    // see example project with react-templates at:  https://github.com/bgrieder/react-templates-typescript-test.git
+    //
+    //function createElement<P>(
+    //    type: string,
+    //    props?: P,
+    //    ...children: ReactNode[]): ReactDOMElement<P>;
+    //function createElement<P>(
+    //    type: ClassicComponentClass<P, any> | string,
+    //    props?: P,
+    //    ...children: ReactNode[]): ReactClassicElement<P>;
+    //function createElement<P>(
+    //    type: ComponentClass<P, any>,
+    //    props?: P,
+    //    ...children: ReactNode[]): ReactElement<P>;
     function createElement<P>(
-        type: string,
+        etype: any,
         props?: P,
         ...children: ReactNode[]): ReactDOMElement<P>;
-    function createElement<P>(
-        type: ClassicComponentClass<P, any> | string,
-        props?: P,
-        ...children: ReactNode[]): ReactClassicElement<P>;
-    function createElement<P>(
-        type: ComponentClass<P, any>,
-        props?: P,
-        ...children: ReactNode[]): ReactElement<P>;
 
     function render<P>(
         element: ReactDOMElement<P>,

--- a/react/future/react-addons-0.13.0.d.ts
+++ b/react/future/react-addons-0.13.0.d.ts
@@ -27,6 +27,19 @@ declare module "react/addons" {
     type ReactHTMLElement = ReactDOMElement<HTMLAttributes>;
     type ReactSVGElement = ReactDOMElement<SVGAttributes>;
 
+
+    //
+    // React Nodes
+    // http://facebook.github.io/react/docs/glossary.html
+    // ----------------------------------------------------------------------
+
+    type ReactText = string | number;
+    type ReactChild = ReactElementBase<any, any> | ReactText;
+
+    // Should be Array<ReactNode> but type aliases cannot be recursive
+    type ReactFragment = Array<ReactChild | any[] | boolean>;
+    type ReactNode = ReactChild | ReactFragment | boolean;
+
     //
     // Factories
     // ----------------------------------------------------------------------
@@ -46,17 +59,6 @@ declare module "react/addons" {
     type HTMLFactory = DOMFactory<HTMLAttributes>;
     type SVGFactory = DOMFactory<SVGAttributes>;
 
-    //
-    // React Nodes
-    // http://facebook.github.io/react/docs/glossary.html
-    // ----------------------------------------------------------------------
-
-    type ReactText = string | number;
-    type ReactChild = ReactElementBase<any, any> | ReactText;
-
-    // Should be Array<ReactNode> but type aliases cannot be recursive
-    type ReactFragment = Array<ReactChild | any[] | boolean>;
-    type ReactNode = ReactChild | ReactFragment | boolean;
 
     //
     // Top Level API
@@ -716,6 +718,30 @@ declare module "react/addons" {
         only(children: ReactNode): ReactChild;
     }
 
+
+    //
+    // React.addons (Transitions)
+    // ----------------------------------------------------------------------
+
+    type ReactType = ComponentClass<any, any> | string;
+
+    interface TransitionGroupProps {
+        component?: ReactType;
+        childFactory?: (child: ReactElement<any>) => ReactElement<any>;
+    }
+
+    interface CSSTransitionGroupProps extends TransitionGroupProps {
+        transitionName: string;
+        transitionAppear?: boolean;
+        transitionEnter?: boolean;
+        transitionLeave?: boolean;
+    }
+
+    type CSSTransitionGroup =
+        ComponentClass<CSSTransitionGroupProps, any>;
+    type TransitionGroup =
+        ComponentClass<TransitionGroupProps, any>;
+
     //
     // React.addons
     // ----------------------------------------------------------------------
@@ -744,28 +770,6 @@ declare module "react/addons" {
         TestUtils: ReactTestUtils;
     };
 
-    //
-    // React.addons (Transitions)
-    // ----------------------------------------------------------------------
-
-    type ReactType = ComponentClass<any, any> | string;
-
-    interface TransitionGroupProps {
-        component?: ReactType;
-        childFactory?: (child: ReactElement<any>) => ReactElement<any>;
-    }
-
-    interface CSSTransitionGroupProps extends TransitionGroupProps {
-        transitionName: string;
-        transitionAppear?: boolean;
-        transitionEnter?: boolean;
-        transitionLeave?: boolean;
-    }
-
-    type CSSTransitionGroup =
-        ComponentClass<CSSTransitionGroupProps, any>;
-    type TransitionGroup =
-        ComponentClass<TransitionGroupProps, any>;
 
     //
     // React.addons (Mixins)


### PR DESCRIPTION
-slight reordering of definitions so that IntelliJ/Webstorm new support for TypeScript 1.4 syntax does not choke

-loosening of `React.createElement` definition so that imported `Component` classes can be easily passed as parameters. See project at https://github.com/bgrieder/react-templates-typescript-test.git for example (main.rt.ts)
