### PR TITLE
Fix deferred object type mismatch

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -360,27 +360,27 @@ interface JQueryDeferred<T> extends JQueryPromise<T> {
      * @param alwaysCallbacks1 A function, or array of functions, that is called when the Deferred is resolved or rejected.
      * @param alwaysCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
      */
-    always(alwaysCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...alwaysCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
+    always(alwaysCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...alwaysCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryDeferred<T>;
     /**
      * Add handlers to be called when the Deferred object is resolved.
      * 
      * @param doneCallbacks1 A function, or array of functions, that are called when the Deferred is resolved.
      * @param doneCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
      */
-    done(doneCallback1?: JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[], ...doneCallbackN: Array<JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[]>): JQueryPromise<T>;
+    done(doneCallback1?: JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[], ...doneCallbackN: Array<JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[]>): JQueryDeferred<T>;
     /**
      * Add handlers to be called when the Deferred object is rejected.
      * 
      * @param failCallbacks1 A function, or array of functions, that are called when the Deferred is rejected.
      * @param failCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
      */
-    fail(failCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...failCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
+    fail(failCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...failCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryDeferred<T>;
     /**
      * Add handlers to be called when the Deferred object generates progress notifications.
      * 
      * @param progressCallbacks A function, or array of functions, to be called when the Deferred generates progress notifications.
      */
-    progress(progressCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...progressCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
+    progress(progressCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...progressCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryDeferred<T>;
 
     /**
      * Call the progressCallbacks on a Deferred object with the given args.

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -300,27 +300,27 @@ interface JQueryPromise<T> {
      * @param alwaysCallbacks1 A function, or array of functions, that is called when the Deferred is resolved or rejected.
      * @param alwaysCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
      */
-    always(alwaysCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...alwaysCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
+    always(alwaysCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...alwaysCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryDeferred<T>;
     /**
      * Add handlers to be called when the Deferred object is resolved.
      * 
      * @param doneCallbacks1 A function, or array of functions, that are called when the Deferred is resolved.
      * @param doneCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
      */
-    done(doneCallback1?: JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[], ...doneCallbackN: Array<JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[]>): JQueryPromise<T>;
+    done(doneCallback1?: JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[], ...doneCallbackN: Array<JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[]>): JQueryDeferred<T>;
     /**
      * Add handlers to be called when the Deferred object is rejected.
      * 
      * @param failCallbacks1 A function, or array of functions, that are called when the Deferred is rejected.
      * @param failCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
      */
-    fail(failCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...failCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
+    fail(failCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...failCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryDeferred<T>;
     /**
      * Add handlers to be called when the Deferred object generates progress notifications.
      * 
      * @param progressCallbacks A function, or array of functions, to be called when the Deferred generates progress notifications.
      */
-    progress(progressCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...progressCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
+    progress(progressCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...progressCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryDeferred<T>;
 
     /**
      * Determine the current state of a Deferred object.
@@ -354,34 +354,6 @@ interface JQueryPromise<T> {
  * Interface for the JQuery deferred, part of callbacks
  */
 interface JQueryDeferred<T> extends JQueryPromise<T> {
-    /**
-     * Add handlers to be called when the Deferred object is either resolved or rejected.
-     * 
-     * @param alwaysCallbacks1 A function, or array of functions, that is called when the Deferred is resolved or rejected.
-     * @param alwaysCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
-     */
-    always(alwaysCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...alwaysCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryDeferred<T>;
-    /**
-     * Add handlers to be called when the Deferred object is resolved.
-     * 
-     * @param doneCallbacks1 A function, or array of functions, that are called when the Deferred is resolved.
-     * @param doneCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
-     */
-    done(doneCallback1?: JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[], ...doneCallbackN: Array<JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[]>): JQueryDeferred<T>;
-    /**
-     * Add handlers to be called when the Deferred object is rejected.
-     * 
-     * @param failCallbacks1 A function, or array of functions, that are called when the Deferred is rejected.
-     * @param failCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
-     */
-    fail(failCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...failCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryDeferred<T>;
-    /**
-     * Add handlers to be called when the Deferred object generates progress notifications.
-     * 
-     * @param progressCallbacks A function, or array of functions, to be called when the Deferred generates progress notifications.
-     */
-    progress(progressCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...progressCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryDeferred<T>;
-
     /**
      * Call the progressCallbacks on a Deferred object with the given args.
      * 

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -283,12 +283,12 @@ interface JQueryGenericPromise<T> {
  * Interface for the JQuery promise/deferred callbacks
  */
 interface JQueryPromiseCallback<T> {
-    (value?: T, ...args: any[]): void;
+    (value?: T, ...args: T[]): void;
 }
 
-interface JQueryPromiseOperator<T, R> {
-    (callback: JQueryPromiseCallback<T>, ...callbacks: JQueryPromiseCallback<T>[]): JQueryPromise<R>;
-    (callback: JQueryPromiseCallback<T>[], ...callbacks: JQueryPromiseCallback<T>[]): JQueryPromise<R>;
+interface JQueryPromiseOperator<T, U> {
+    (callback1: JQueryPromiseCallback<T>, ...callbackN: JQueryPromiseCallback<T>[]): JQueryPromise<U>;
+    (callbacks1: JQueryPromiseCallback<T>[], ...callbacksN: JQueryPromiseCallback<T>[][]): JQueryPromise<U>;
 }
 
 /**
@@ -301,28 +301,31 @@ interface JQueryPromise<T> {
      * @param alwaysCallbacks1 A function, or array of functions, that is called when the Deferred is resolved or rejected.
      * @param alwaysCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
      */
-    always: JQueryPromiseOperator<any, T>;
+    always(alwaysCallback1?: JQueryPromiseCallback<T>, ...alwaysCallbackN: JQueryPromiseCallback<T>[]): JQueryPromise<T>;
+    always(alwaysCallbacks1?: JQueryPromiseCallback<T>[], ...alwaysCallbacksN: JQueryPromiseCallback<T>[][]): JQueryPromise<T>;
     /**
      * Add handlers to be called when the Deferred object is resolved.
      * 
      * @param doneCallbacks1 A function, or array of functions, that are called when the Deferred is resolved.
      * @param doneCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
      */
-    done: JQueryPromiseOperator<T, T>;
+    done(doneCallback1?: JQueryPromiseCallback<T>, ...doneCallbackN: JQueryPromiseCallback<T>[]): JQueryPromise<T>;
+    done(doneCallbacks1?: JQueryPromiseCallback<T>[], ...doneCallbacksN: JQueryPromiseCallback<T>[][]): JQueryPromise<T>;
     /**
      * Add handlers to be called when the Deferred object is rejected.
      * 
      * @param failCallbacks1 A function, or array of functions, that are called when the Deferred is rejected.
      * @param failCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
      */
-    fail: JQueryPromiseOperator<any, T>;
+    fail(failCallback1?: JQueryPromiseCallback<T>, ...failCallbackN: JQueryPromiseCallback<T>[]): JQueryPromise<T>;
+    fail(failCallbacks1?: JQueryPromiseCallback<T>[], ...failCallbacksN: JQueryPromiseCallback<T>[][]): JQueryPromise<T>;
     /**
      * Add handlers to be called when the Deferred object generates progress notifications.
      * 
      * @param progressCallbacks A function, or array of functions, to be called when the Deferred generates progress notifications.
      */
-    progress(progressCallback: JQueryPromiseCallback<T>): JQueryPromise<T>;
-    progress(progressCallbacks: JQueryPromiseCallback<T>[]): JQueryPromise<T>;
+    progress(progressCallback1?: JQueryPromiseCallback<T>, ...progressCallbackN: JQueryPromiseCallback<T>[]): JQueryPromise<T>;
+    progress(progressCallback1s?: JQueryPromiseCallback<T>[], ...progressCallbacksN: JQueryPromiseCallback<T>[][]): JQueryPromise<T>;
 
     /**
      * Determine the current state of a Deferred object.
@@ -362,44 +365,38 @@ interface JQueryDeferred<T> extends JQueryPromise<T> {
      * @param alwaysCallbacks1 A function, or array of functions, that is called when the Deferred is resolved or rejected.
      * @param alwaysCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
      */
-    always(alwaysCallbacks1?: JQueryPromiseCallback<T>, ...alwaysCallbacks2: JQueryPromiseCallback<T>[]): JQueryDeferred<T>;
-    always(alwaysCallbacks1?: JQueryPromiseCallback<T>[], ...alwaysCallbacks2: JQueryPromiseCallback<T>[]): JQueryDeferred<T>;
-    always(alwaysCallbacks1?: JQueryPromiseCallback<T>, ...alwaysCallbacks2: any[]): JQueryDeferred<T>;
-    always(alwaysCallbacks1?: JQueryPromiseCallback<T>[], ...alwaysCallbacks2: any[]): JQueryDeferred<T>;
+    always(alwaysCallback1?: JQueryPromiseCallback<T>, ...alwaysCallbackN: JQueryPromiseCallback<T>[]): JQueryDeferred<T>;
+    always(alwaysCallbacks1?: JQueryPromiseCallback<T>[], ...alwaysCallbacksN: JQueryPromiseCallback<T>[][]): JQueryDeferred<T>;
     /**
      * Add handlers to be called when the Deferred object is resolved.
      * 
      * @param doneCallbacks1 A function, or array of functions, that are called when the Deferred is resolved.
      * @param doneCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
      */
-    done(doneCallbacks1?: JQueryPromiseCallback<T>, ...doneCallbacks2: JQueryPromiseCallback<T>[]): JQueryDeferred<T>;
-    done(doneCallbacks1?: JQueryPromiseCallback<T>[], ...doneCallbacks2: JQueryPromiseCallback<T>[]): JQueryDeferred<T>;
-    done(doneCallbacks1?: JQueryPromiseCallback<T>, ...doneCallbacks2: any[]): JQueryDeferred<T>;
-    done(doneCallbacks1?: JQueryPromiseCallback<T>[], ...doneCallbacks2: any[]): JQueryDeferred<T>;
+    done(doneCallback1?: JQueryPromiseCallback<T>, ...doneCallbackN: JQueryPromiseCallback<T>[]): JQueryDeferred<T>;
+    done(doneCallbacks1?: JQueryPromiseCallback<T>[], ...doneCallbacksN: JQueryPromiseCallback<T>[][]): JQueryDeferred<T>;
     /**
      * Add handlers to be called when the Deferred object is rejected.
      * 
      * @param failCallbacks1 A function, or array of functions, that are called when the Deferred is rejected.
      * @param failCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
      */
-    fail(failCallbacks1?: JQueryPromiseCallback<T>, ...failCallbacks2: JQueryPromiseCallback<T>[]): JQueryDeferred<T>;
-    fail(failCallbacks1?: JQueryPromiseCallback<T>[], ...failCallbacks2: JQueryPromiseCallback<T>[]): JQueryDeferred<T>;
-    fail(failCallbacks1?: JQueryPromiseCallback<T>, ...failCallbacks2: any[]): JQueryDeferred<T>;
-    fail(failCallbacks1?: JQueryPromiseCallback<T>[], ...failCallbacks2: any[]): JQueryDeferred<T>;
+    fail(failCallback1?: JQueryPromiseCallback<T>, ...failCallbackN: JQueryPromiseCallback<T>[]): JQueryDeferred<T>;
+    fail(failCallbacks1?: JQueryPromiseCallback<T>[], ...failCallbacksN: JQueryPromiseCallback<T>[][]): JQueryDeferred<T>;
     /**
      * Add handlers to be called when the Deferred object generates progress notifications.
      * 
      * @param progressCallbacks A function, or array of functions, to be called when the Deferred generates progress notifications.
      */
-    progress(progressCallback: JQueryPromiseCallback<T>): JQueryDeferred<T>;
-    progress(progressCallbacks: JQueryPromiseCallback<T>[]): JQueryDeferred<T>;
+    progress(progressCallback1?: JQueryPromiseCallback<T>, ...progressCallbackN: JQueryPromiseCallback<T>[]): JQueryDeferred<T>;
+    progress(progressCallbacks1?: JQueryPromiseCallback<T>[], ...progressCallbacksN: JQueryPromiseCallback<T>[][]): JQueryDeferred<T>;
 
     /**
      * Call the progressCallbacks on a Deferred object with the given args.
      * 
      * @param args Optional arguments that are passed to the progressCallbacks.
      */
-    notify(...args: any[]): JQueryDeferred<T>;
+    notify(...args: T[]): JQueryDeferred<T>;
 
     /**
      * Call the progressCallbacks on a Deferred object with the given context and args.
@@ -407,21 +404,21 @@ interface JQueryDeferred<T> extends JQueryPromise<T> {
      * @param context Context passed to the progressCallbacks as the this object.
      * @param args Optional arguments that are passed to the progressCallbacks.
      */
-    notifyWith(context: any, ...args: any[]): JQueryDeferred<T>;
+    notifyWith(context: any, ...args: T[]): JQueryDeferred<T>;
 
     /**
      * Reject a Deferred object and call any failCallbacks with the given args.
      * 
      * @param args Optional arguments that are passed to the failCallbacks.
      */
-    reject(...args: any[]): JQueryDeferred<T>;
+    reject(...args: T[]): JQueryDeferred<T>;
     /**
      * Reject a Deferred object and call any failCallbacks with the given context and args.
      * 
      * @param context Context passed to the failCallbacks as the this object.
      * @param args An optional array of arguments that are passed to the failCallbacks.
      */
-    rejectWith(context: any, ...args: any[]): JQueryDeferred<T>;
+    rejectWith(context: any, ...args: T[]): JQueryDeferred<T>;
 
     /**
      * Resolve a Deferred object and call any doneCallbacks with the given args.
@@ -429,7 +426,7 @@ interface JQueryDeferred<T> extends JQueryPromise<T> {
      * @param value First argument passed to doneCallbacks.
      * @param args Optional subsequent arguments that are passed to the doneCallbacks.
      */
-    resolve(value?: T, ...args: any[]): JQueryDeferred<T>;
+    resolve(value?: T, ...args: T[]): JQueryDeferred<T>;
 
     /**
      * Resolve a Deferred object and call any doneCallbacks with the given context and args.
@@ -437,7 +434,7 @@ interface JQueryDeferred<T> extends JQueryPromise<T> {
      * @param context Context passed to the doneCallbacks as the this object.
      * @param args An optional array of arguments that are passed to the doneCallbacks.
      */
-    resolveWith(context: any, ...args: any[]): JQueryDeferred<T>;
+    resolveWith(context: any, ...args: T[]): JQueryDeferred<T>;
 
     /**
      * Return a Deferred's Promise object.

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -283,12 +283,11 @@ interface JQueryGenericPromise<T> {
  * Interface for the JQuery promise/deferred callbacks
  */
 interface JQueryPromiseCallback<T> {
-    (value?: T, ...args: T[]): void;
+    (value?: T, ...args: any[]): void;
 }
 
 interface JQueryPromiseOperator<T, U> {
-    (callback1: JQueryPromiseCallback<T>, ...callbackN: JQueryPromiseCallback<T>[]): JQueryPromise<U>;
-    (callbacks1: JQueryPromiseCallback<T>[], ...callbacksN: JQueryPromiseCallback<T>[][]): JQueryPromise<U>;
+    (callback1: JQueryPromiseCallback<T>|JQueryPromiseCallback<any>[], ...callbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<U>;
 }
 
 /**
@@ -301,31 +300,27 @@ interface JQueryPromise<T> {
      * @param alwaysCallbacks1 A function, or array of functions, that is called when the Deferred is resolved or rejected.
      * @param alwaysCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
      */
-    always(alwaysCallback1?: JQueryPromiseCallback<T>, ...alwaysCallbackN: JQueryPromiseCallback<T>[]): JQueryPromise<T>;
-    always(alwaysCallbacks1?: JQueryPromiseCallback<T>[], ...alwaysCallbacksN: JQueryPromiseCallback<T>[][]): JQueryPromise<T>;
+    always(alwaysCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...alwaysCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
     /**
      * Add handlers to be called when the Deferred object is resolved.
      * 
      * @param doneCallbacks1 A function, or array of functions, that are called when the Deferred is resolved.
      * @param doneCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
      */
-    done(doneCallback1?: JQueryPromiseCallback<T>, ...doneCallbackN: JQueryPromiseCallback<T>[]): JQueryPromise<T>;
-    done(doneCallbacks1?: JQueryPromiseCallback<T>[], ...doneCallbacksN: JQueryPromiseCallback<T>[][]): JQueryPromise<T>;
+    done(doneCallback1?: JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[], ...doneCallbackN: Array<JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[]>): JQueryPromise<T>;
     /**
      * Add handlers to be called when the Deferred object is rejected.
      * 
      * @param failCallbacks1 A function, or array of functions, that are called when the Deferred is rejected.
      * @param failCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
      */
-    fail(failCallback1?: JQueryPromiseCallback<T>, ...failCallbackN: JQueryPromiseCallback<T>[]): JQueryPromise<T>;
-    fail(failCallbacks1?: JQueryPromiseCallback<T>[], ...failCallbacksN: JQueryPromiseCallback<T>[][]): JQueryPromise<T>;
+    fail(failCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...failCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
     /**
      * Add handlers to be called when the Deferred object generates progress notifications.
      * 
      * @param progressCallbacks A function, or array of functions, to be called when the Deferred generates progress notifications.
      */
-    progress(progressCallback1?: JQueryPromiseCallback<T>, ...progressCallbackN: JQueryPromiseCallback<T>[]): JQueryPromise<T>;
-    progress(progressCallback1s?: JQueryPromiseCallback<T>[], ...progressCallbacksN: JQueryPromiseCallback<T>[][]): JQueryPromise<T>;
+    progress(progressCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...progressCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
 
     /**
      * Determine the current state of a Deferred object.
@@ -365,38 +360,34 @@ interface JQueryDeferred<T> extends JQueryPromise<T> {
      * @param alwaysCallbacks1 A function, or array of functions, that is called when the Deferred is resolved or rejected.
      * @param alwaysCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
      */
-    always(alwaysCallback1?: JQueryPromiseCallback<T>, ...alwaysCallbackN: JQueryPromiseCallback<T>[]): JQueryDeferred<T>;
-    always(alwaysCallbacks1?: JQueryPromiseCallback<T>[], ...alwaysCallbacksN: JQueryPromiseCallback<T>[][]): JQueryDeferred<T>;
+    always(alwaysCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...alwaysCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
     /**
      * Add handlers to be called when the Deferred object is resolved.
      * 
      * @param doneCallbacks1 A function, or array of functions, that are called when the Deferred is resolved.
      * @param doneCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
      */
-    done(doneCallback1?: JQueryPromiseCallback<T>, ...doneCallbackN: JQueryPromiseCallback<T>[]): JQueryDeferred<T>;
-    done(doneCallbacks1?: JQueryPromiseCallback<T>[], ...doneCallbacksN: JQueryPromiseCallback<T>[][]): JQueryDeferred<T>;
+    done(doneCallback1?: JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[], ...doneCallbackN: Array<JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[]>): JQueryPromise<T>;
     /**
      * Add handlers to be called when the Deferred object is rejected.
      * 
      * @param failCallbacks1 A function, or array of functions, that are called when the Deferred is rejected.
      * @param failCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
      */
-    fail(failCallback1?: JQueryPromiseCallback<T>, ...failCallbackN: JQueryPromiseCallback<T>[]): JQueryDeferred<T>;
-    fail(failCallbacks1?: JQueryPromiseCallback<T>[], ...failCallbacksN: JQueryPromiseCallback<T>[][]): JQueryDeferred<T>;
+    fail(failCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...failCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
     /**
      * Add handlers to be called when the Deferred object generates progress notifications.
      * 
      * @param progressCallbacks A function, or array of functions, to be called when the Deferred generates progress notifications.
      */
-    progress(progressCallback1?: JQueryPromiseCallback<T>, ...progressCallbackN: JQueryPromiseCallback<T>[]): JQueryDeferred<T>;
-    progress(progressCallbacks1?: JQueryPromiseCallback<T>[], ...progressCallbacksN: JQueryPromiseCallback<T>[][]): JQueryDeferred<T>;
+    progress(progressCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...progressCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
 
     /**
      * Call the progressCallbacks on a Deferred object with the given args.
      * 
      * @param args Optional arguments that are passed to the progressCallbacks.
      */
-    notify(...args: T[]): JQueryDeferred<T>;
+    notify(value?: any, ...args: any[]): JQueryDeferred<T>;
 
     /**
      * Call the progressCallbacks on a Deferred object with the given context and args.
@@ -404,21 +395,21 @@ interface JQueryDeferred<T> extends JQueryPromise<T> {
      * @param context Context passed to the progressCallbacks as the this object.
      * @param args Optional arguments that are passed to the progressCallbacks.
      */
-    notifyWith(context: any, ...args: T[]): JQueryDeferred<T>;
+    notifyWith(context: any, value?: any, ...args: any[]): JQueryDeferred<T>;
 
     /**
      * Reject a Deferred object and call any failCallbacks with the given args.
      * 
      * @param args Optional arguments that are passed to the failCallbacks.
      */
-    reject(...args: T[]): JQueryDeferred<T>;
+    reject(value?: any, ...args: any[]): JQueryDeferred<T>;
     /**
      * Reject a Deferred object and call any failCallbacks with the given context and args.
      * 
      * @param context Context passed to the failCallbacks as the this object.
      * @param args An optional array of arguments that are passed to the failCallbacks.
      */
-    rejectWith(context: any, ...args: T[]): JQueryDeferred<T>;
+    rejectWith(context: any, value?: any, ...args: any[]): JQueryDeferred<T>;
 
     /**
      * Resolve a Deferred object and call any doneCallbacks with the given args.
@@ -426,7 +417,7 @@ interface JQueryDeferred<T> extends JQueryPromise<T> {
      * @param value First argument passed to doneCallbacks.
      * @param args Optional subsequent arguments that are passed to the doneCallbacks.
      */
-    resolve(value?: T, ...args: T[]): JQueryDeferred<T>;
+    resolve(value?: T, ...args: any[]): JQueryDeferred<T>;
 
     /**
      * Resolve a Deferred object and call any doneCallbacks with the given context and args.
@@ -434,7 +425,7 @@ interface JQueryDeferred<T> extends JQueryPromise<T> {
      * @param context Context passed to the doneCallbacks as the this object.
      * @param args An optional array of arguments that are passed to the doneCallbacks.
      */
-    resolveWith(context: any, ...args: T[]): JQueryDeferred<T>;
+    resolveWith(context: any, value?: T, ...args: any[]): JQueryDeferred<T>;
 
     /**
      * Return a Deferred's Promise object.

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -287,7 +287,7 @@ interface JQueryPromiseCallback<T> {
 }
 
 interface JQueryPromiseOperator<T, U> {
-    (callback1: JQueryPromiseCallback<T>|JQueryPromiseCallback<any>[], ...callbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<U>;
+    (callback1: JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[], ...callbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<U>;
 }
 
 /**


### PR DESCRIPTION
# ~~Generics~~
## ~~T => any~~

Current definition is `T => any`.
Fixed definition is `T => T`.
## ~~T[] => any[]~~

Current definition is `T, ...T[] => T, ...any[]` and `...T[] => ...any[]`.
Fixed definition is `...T[] => ...T[]`.
# Parameter

Current definition is `(T[], ...T[])`.
Fixed definition is `(T[], ...T[][])`.
# Massaging callback type

Current definition operatable messaging value in `done/fail/always` methods.
Fixed definition unoperatable messaging value.
# Messaging return type

Current `progress/done/fail/always` methods definition return promise type.
Fixed to return deferred type.
# Source

http://api.jquery.com/category/deferred-object/
