### PR TITLE
filesystem: Quality-of-life changes

### DIFF
--- a/filesystem/filesystem-tests.ts
+++ b/filesystem/filesystem-tests.ts
@@ -7,7 +7,7 @@ declare function writeDataToLogFile(fileWriter:FileWriterSync): void;
 
 function useAsyncFS(fs:FileSystem):void {
   // see getAsText example in [FILE-API-ED].
-  fs.root.getFile("already_there.txt", null, function (f:FileEntry): void{
+  fs.root.getFile("already_there.txt", null, function (f): void{
 
     // In the example of the specification, there is a following code:
     // 
@@ -19,7 +19,7 @@ function useAsyncFS(fs:FileSystem):void {
   });
 
   // But now we can also write to the file; see [FILE-WRITER-ED].
-  fs.root.getFile("logFile", {create: true}, function (f:FileEntry): void{
+  fs.root.getFile("logFile", {create: true}, function (f): void{
     f.createWriter(writeDataToLogFile);
   });
 }

--- a/filesystem/filesystem.d.ts
+++ b/filesystem/filesystem.d.ts
@@ -197,7 +197,7 @@ interface Entry {
      * @param successCallback A callback that is called to return the parent Entry.
      * @param errorCallback A callback that is called when errors happen.
      */
-    getParent(successCallback:EntryCallback, errorCallback?:ErrorCallback):void;
+    getParent(successCallback:DirectoryEntryCallback, errorCallback?:ErrorCallback):void;
 }
 
 /**
@@ -223,7 +223,7 @@ interface DirectoryEntry extends Entry {
      * @param successCallback A callback that is called to return the File selected or created.
      * @param errorCallback A callback that is called when errors happen.
      */
-    getFile(path:string, options?:Flags, successCallback?:EntryCallback, errorCallback?:ErrorCallback):void;
+    getFile(path:string, options?:Flags, successCallback?:FileEntryCallback, errorCallback?:ErrorCallback):void;
     
     /**
      * Creates or looks up a directory.
@@ -240,7 +240,7 @@ interface DirectoryEntry extends Entry {
      * @param errorCallback A callback that is called when errors happen.
      * 
      */
-    getDirectory(path:string, options?:Flags, successCallback?:EntryCallback, errorCallback?:ErrorCallback):void;
+    getDirectory(path:string, options?:Flags, successCallback?:DirectoryEntryCallback, errorCallback?:ErrorCallback):void;
     
     /**
      * Deletes a directory and all of its contents, if any. In the event of an error [e.g. trying to delete a directory that contains a file that cannot be removed], some of the contents of the directory may be deleted. It is an error to attempt to delete the root directory of a filesystem.
@@ -305,6 +305,26 @@ interface EntryCallback {
      * @param entry
      */
     (entry:Entry):void;
+}
+
+/**
+ * This interface is the callback used to look up FileEntry objects.
+ */
+interface FileEntryCallback {
+    /**
+     * @param entry
+     */
+    (entry:FileEntry):void;
+}
+
+/**
+ * This interface is the callback used to look up DirectoryEntry objects.
+ */
+interface DirectoryEntryCallback {
+    /**
+     * @param entry
+     */
+    (entry:DirectoryEntry):void;
 }
 
 /**


### PR DESCRIPTION
  Certain methods always return a specific Entry type. Define more
  specific callbacks so that typescript can infer when an Entry is
  a DirectoryEntry or FileEntry, removing the need to explicitly
  state the type in certain callbacks.

  Existing code using this definition should not be broken as a
  result of this change.

Signed-off-by: David Li jiawei.davidli@gmail.com
