### PR TITLE
Fix trap suggestion

### DIFF
--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -3373,7 +3373,10 @@ function test_promise_then_change_type() {
 }
 
 function test_promise_then_not_return_deferred() {
+  var state: string;
+
   var deferred: JQueryDeferred<any> = $.Deferred();
+  state = deferred.state();
   deferred = deferred.progress();
   deferred = deferred.done();
   deferred = deferred.fail();
@@ -3381,15 +3384,14 @@ function test_promise_then_not_return_deferred() {
   deferred = deferred.notify();
   deferred = deferred.resolve();
   deferred = deferred.reject();
-  deferred.state();
   promise = deferred.promise();
   promise = deferred.then(function () { });
 
   var promise: JQueryPromise<any> = $.Deferred().promise();
+  state = promise.state();
   promise = promise.then(function () { });
   promise = promise.progress();
   promise = promise.done();
   promise = promise.fail();
   promise = promise.always();
-  promise.state();
 }

--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -3212,7 +3212,7 @@ function test_EventIsCallable() {
 }
 
 $.when<any>($.ajax("/my/page.json")).then(a => a.asdf); // is type JQueryPromise<any>
-$.when($.ajax("/my/page.json")).then((a?,b?,c?) => a.asdf); // is type JQueryPromise<any>
+$.when<any>($.ajax("/my/page.json")).then((a?,b?,c?) => a.asdf); // is type JQueryPromise<any>
 $.when("asdf", "jkl;").done((x,y) => x.length + y.length, (x,y) => x.length + y.length);
 
 var f1 = $.when("fetch"); // Is type JQueryPromise<string>
@@ -3370,4 +3370,26 @@ function test_promise_then_change_type() {
 	count().done(data => {
 	}).fail((exception: Error) => {
 	});
+}
+
+function test_promise_then_not_return_deferred() {
+  var deferred: JQueryDeferred<any> = $.Deferred();
+  deferred = deferred.progress();
+  deferred = deferred.done();
+  deferred = deferred.fail();
+  deferred = deferred.always();
+  deferred = deferred.notify();
+  deferred = deferred.resolve();
+  deferred = deferred.reject();
+  deferred.state();
+  promise = deferred.promise();
+  promise = deferred.then(function () { });
+
+  var promise: JQueryPromise<any> = $.Deferred().promise();
+  promise = promise.then(function () { });
+  promise = promise.progress();
+  promise = promise.done();
+  promise = promise.fail();
+  promise = promise.always();
+  promise.state();
 }

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -276,7 +276,7 @@ interface JQueryGenericPromise<T> {
      * @param doneFilter A function that is called when the Deferred is resolved.
      * @param failFilter An optional function that is called when the Deferred is rejected.
      */
-    then<U>(doneFilter: (value: T, ...values: any[]) => U|JQueryGenericPromise<U>, failFilter?: (...reasons: any[]) => U|JQueryGenericPromise<U>, progressFilter?: (...progression: any[]) => any): JQueryPromise<U>;
+    then<U>(doneFilter: (value: T, ...values: any[]) => U|JQueryPromise<U>, failFilter?: (...reasons: any[]) => U|JQueryPromise<U>, progressFilter?: (...progression: any[]) => any): JQueryPromise<U>;
 
     /**
      * Determine the current state of a Deferred object.

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -276,7 +276,15 @@ interface JQueryGenericPromise<T> {
      * @param doneFilter A function that is called when the Deferred is resolved.
      * @param failFilter An optional function that is called when the Deferred is rejected.
      */
-    then<U>(doneFilter: (value: T) => U|JQueryGenericPromise<U>, failFilter?: (reason: any) => U|JQueryGenericPromise<U>): JQueryGenericPromise<U>;
+    then<U>(doneFilter: (value: T, ...values: any[]) => U|JQueryGenericPromise<U>, failFilter?: (...reasons: any[]) => U|JQueryGenericPromise<U>, progressFilter?: (...progression: any[]) => any): JQueryPromise<U>;
+
+    /**
+     * Determine the current state of a Deferred object.
+     */
+    state(): string;
+
+    // Deprecated - given no typings
+    pipe(doneFilter?: (x: any) => any, failFilter?: (x: any) => any, progressFilter?: (x: any) => any): JQueryPromise<any>;
 }
 
 /**
@@ -293,7 +301,40 @@ interface JQueryPromiseOperator<T, U> {
 /**
  * Interface for the JQuery promise, part of callbacks
  */
-interface JQueryPromise<T> {
+interface JQueryPromise<T> extends JQueryGenericPromise<T> {
+    /**
+     * Add handlers to be called when the Deferred object is either resolved or rejected.
+     * 
+     * @param alwaysCallbacks1 A function, or array of functions, that is called when the Deferred is resolved or rejected.
+     * @param alwaysCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
+     */
+    always(alwaysCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...alwaysCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
+    /**
+     * Add handlers to be called when the Deferred object is resolved.
+     * 
+     * @param doneCallbacks1 A function, or array of functions, that are called when the Deferred is resolved.
+     * @param doneCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
+     */
+    done(doneCallback1?: JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[], ...doneCallbackN: Array<JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[]>): JQueryPromise<T>;
+    /**
+     * Add handlers to be called when the Deferred object is rejected.
+     * 
+     * @param failCallbacks1 A function, or array of functions, that are called when the Deferred is rejected.
+     * @param failCallbacks2 Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
+     */
+    fail(failCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...failCallbacksN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
+    /**
+     * Add handlers to be called when the Deferred object generates progress notifications.
+     * 
+     * @param progressCallbacks A function, or array of functions, to be called when the Deferred generates progress notifications.
+     */
+    progress(progressCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...progressCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
+}
+
+/**
+ * Interface for the JQuery deferred, part of callbacks
+ */
+interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
     /**
      * Add handlers to be called when the Deferred object is either resolved or rejected.
      * 
@@ -322,38 +363,6 @@ interface JQueryPromise<T> {
      */
     progress(progressCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...progressCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryDeferred<T>;
 
-    /**
-     * Determine the current state of a Deferred object.
-     */
-    state(): string;
-
-    // Deprecated - given no typings
-    pipe(doneFilter?: (x: any) => any, failFilter?: (x: any) => any, progressFilter?: (x: any) => any): JQueryPromise<any>;
-
-    /**
-     * Add handlers to be called when the Deferred object is resolved, rejected, or still in progress.
-     * 
-     * @param doneFilter A function that is called when the Deferred is resolved.
-     * @param failFilter An optional function that is called when the Deferred is rejected.
-     * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-     */
-    then<U>(doneFilter: (value: T) => U|JQueryGenericPromise<U>, failFilter?: (...reasons: any[]) => U|JQueryGenericPromise<U>, progressFilter?: (...progression: any[]) => any): JQueryPromise<U>;
-
-    // Because JQuery Promises Suck
-    /**
-     * Add handlers to be called when the Deferred object is resolved, rejected, or still in progress.
-     * 
-     * @param doneFilter A function that is called when the Deferred is resolved.
-     * @param failFilter An optional function that is called when the Deferred is rejected.
-     * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-     */
-    then<U>(doneFilter: (...values: any[]) => U|JQueryGenericPromise<U>, failFilter?: (...reasons: any[]) => U|JQueryGenericPromise<U>, progressFilter?: (...progression: any[]) => any): JQueryPromise<U>;
-}
-
-/**
- * Interface for the JQuery deferred, part of callbacks
- */
-interface JQueryDeferred<T> extends JQueryPromise<T> {
     /**
      * Call the progressCallbacks on a Deferred object with the given args.
      * 
@@ -765,19 +774,7 @@ interface JQueryStatic {
      *
      * @param deferreds One or more Deferred objects, or plain JavaScript objects.
      */
-    when<T>(...deferreds: JQueryGenericPromise<T>[]): JQueryPromise<T>;
-    /**
-     * Provides a way to execute callback functions based on one or more objects, usually Deferred objects that represent asynchronous events.
-     *
-     * @param deferreds One or more Deferred objects, or plain JavaScript objects.
-     */
-    when<T>(...deferreds: T[]): JQueryPromise<T>;
-    /**
-     * Provides a way to execute callback functions based on one or more objects, usually Deferred objects that represent asynchronous events.
-     *
-     * @param deferreds One or more Deferred objects, or plain JavaScript objects.
-     */
-    when<T>(...deferreds: any[]): JQueryPromise<T>;
+    when<T>(...deferreds: Array<T|JQueryPromise<T>/* as JQueryDeferred<T> */>): JQueryPromise<T>;
 
     /**
      * Hook directly into jQuery to override how particular CSS properties are retrieved or set, normalize CSS property naming, or create custom properties.

--- a/q/Q-tests.ts
+++ b/q/Q-tests.ts
@@ -67,6 +67,7 @@ Q.allResolved([])
 declare var arrayPromise: Q.IPromise<number[]>;
 declare var stringPromise: Q.IPromise<string>;
 declare function returnsNumPromise(text: string): Q.Promise<number>;
+declare function returnsNumPromise(text: string): JQueryPromise<number>;
 
 Q<number[]>(arrayPromise) // type specification required
     .then(arr => arr.join(','))


### PR DESCRIPTION
Sorry, my previous fix has a problem!
jQuery official specification is wrong and trap!

> http://api.jquery.com/deferred.done/
> deferred.done( doneCallbacks [, doneCallbacks ] ) **Returns: Deferred**

Definable this code by official specification, but this code error occurs.

``` js
$.Deferred().done().resolve(); // done
$.Deferred().promise().done().resolve(); // runtime error
$.Deferred().then(function () { }).done().resolve(); // runtime error
```

This problem has not been covered by tests.
So I added a test.

Total diff.
https://github.com/borisyankov/DefinitelyTyped/compare/69bdfb0884020e41f17a1dd80ad4c77de2636874...falsandtru:jquery-deferred
