### PR TITLE
fragmentPrefix(string) returns URI

### DIFF
--- a/urijs/URI.d.ts
+++ b/urijs/URI.d.ts
@@ -95,7 +95,7 @@ declare class URI {
     removeQuery(qry: Object): URI;
     addFragment(fragment: string): URI;
     //fragmentPrefix: string;
-    fragmentPrefix(prefix: string);
+    fragmentPrefix(prefix: string): URI;
     normalize(): URI;
     normalizeProtocol(): URI;
     normalizeHostname(): URI;


### PR DESCRIPTION
I found that URI fragmentPrefix(string) did not have a return type,
and it seems to return URI so here it is.
