### PR TITLE
Fix signature of D3.ForceLayout.size()

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1279,10 +1279,8 @@ declare module D3 {
         export interface ForceLayout {
             (): ForceLayout;
             size: {
-                (): number;
+                (): number[];
                 (mysize: number[]): ForceLayout;
-                (accessor: (d: any, index: number) => {}): ForceLayout;
-
             };
             linkDistance: {
                 (): number;


### PR DESCRIPTION
Fix signatures of `D3.ForceLayout.size`:
1. It returns the current size as number array if no argument is supplied.
2. It cannot accept a function as size accessor.

See [API Reference](https://github.com/mbostock/d3/wiki/Force-Layout#size):

> If size is specified, sets the available layout size to the specified two-element array of numbers representing x and y. If size is not specified, returns the current size, which defaults to 1×1.

And source code for [definition](https://github.com/mbostock/d3/blob/v3.5.5/d3.js#L6300):

``` JS
    force.size = function(x) {
      if (!arguments.length) return size;
      size = x;
      return force;
    };
```

and [initialization](https://github.com/mbostock/d3/blob/v3.5.5/d3.js#L6208):

``` JS
size = [ 1, 1 ]
```
