### PR TITLE
Replace nbsp by normal spaces

### DIFF
--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -424,22 +424,22 @@ declare module "express" {
              * @param code
              */
             status(code: number): Response;
-            
+
             /**
              * Set the response HTTP status code to `statusCode` and send its string representation as the response body.
              * @link http://expressjs.com/4x/api.html#res.sendStatus
-             * 
+             *
              * Examples:
-             * 
+             *
              *    res.sendStatus(200); // equivalent to res.status(200).send('OK')
              *    res.sendStatus(403); // equivalent to res.status(403).send('Forbidden')
              *    res.sendStatus(404); // equivalent to res.status(404).send('Not Found')
              *    res.sendStatus(500); // equivalent to res.status(500).send('Internal Server Error')
-             * 
+             *
              * @param code
              */
             sendStatus(code: number): Response;
-            
+
             /**
              * Set Link header field with the given `links`.
              *
@@ -796,7 +796,7 @@ declare module "express" {
             (req: Request, res: Response, next: Function): any;
         }
 
-        interface Handler extends RequestHandler {}
+        interface Handler extends RequestHandler {}
 
         interface RequestParamHandler {
             (req: Request, res: Response, next: Function, param: any): any;

--- a/handlebars/handlebars.d.ts
+++ b/handlebars/handlebars.d.ts
@@ -38,13 +38,13 @@ interface HandlebarsStatic extends HandlebarsCommon {
     compile(input: any, options?: any): HandlebarsTemplateDelegate;
 }
 
-interface HandlebarsTemplates {
-    [index: string]: HandlebarsTemplateDelegate;
+interface HandlebarsTemplates {
+    [index: string]: HandlebarsTemplateDelegate;
 }
 
-interface HandlebarsRuntimeStatic extends HandlebarsCommon {
+interface HandlebarsRuntimeStatic extends HandlebarsCommon {
     // Handlebars.templates is the default template namespace in precompiler.
-    templates: HandlebarsTemplates;
+    templates: HandlebarsTemplates;
 }
 
 declare module hbs {


### PR DESCRIPTION
These two files had some nbsp characters which I don't think should appear in code files. My editor also removed some trailing whitespaces.
