### PR TITLE
socket.io.d.ts: Declare Socket.conn as any

### DIFF
--- a/socket.io/socket.io.d.ts
+++ b/socket.io/socket.io.d.ts
@@ -55,7 +55,7 @@ declare module SocketIO {
     interface Socket {
         rooms: string[];
         client: Client;
-        conn: Socket;
+        conn: any;
         request: any;
         id: string;
         emit(name: string, ...args: any[]): Socket;


### PR DESCRIPTION
SocketIO.Socket.conn is an EngineIO.Socket, not a SocketIO.Socket so use any rather declaring as the wrong type.
