### PR TITLE
flot: fix unhighlight typo

### DIFF
--- a/flot/jquery.flot.d.ts
+++ b/flot/jquery.flot.d.ts
@@ -200,7 +200,7 @@ declare module jquery.flot {
 
     interface plot {
         highlight(series: dataSeries, datapoint: item): void;
-        unhightlight(): void;
+        unhighlight(): void;
         unhighlight(series: dataSeries, datapoint: item): void;
         setData(data: any): void;
         setupGrid(): void;


### PR DESCRIPTION
The method is "unhighlight", but the type definition declared a version
of it as "unhightlight".
