### PR TITLE
flot: fix interaction typo

### DIFF
--- a/flot/jquery.flot.d.ts
+++ b/flot/jquery.flot.d.ts
@@ -16,7 +16,7 @@ declare module jquery.flot {
         xaxes?: axisOptions[];
         yaxes?: axisOptions[];
         grid?: gridOptions;
-        interfaction?: interaction;
+        interaction?: interaction;
         hooks?: hooks;
     }
 


### PR DESCRIPTION
jquery.flot.plotOptions declares a field called "interfaction" that
should actually be "interaction".
