### PR TITLE
Fix the signature of D3.Transition.each

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -963,7 +963,29 @@ declare module D3 {
                 */
                 (elements: EventTarget[]): Transition;
             }
-            each: (type?: string, eachFunction?: (data: any, index: number) => any) => Transition;
+            each: {
+                /**
+                 * Immediately invokes the specified function for each element in the current
+                 * transition, passing in the current datum and index, with the this context
+                 * of the current DOM element. Similar to D3.Selection.each.
+                 *
+                 * @param eachFunction The function to be invoked for each element in the
+                 * current transition, passing in the current datum and index, with the this
+                 * context of the current DOM element.
+                 */
+                (eachFunction: (data: any, index: number) => any): Transition;
+                /**
+                 * Adds a listener for transition events, supporting "start", "end" and
+                 * "interrupt" events. The listener will be invoked for each individual
+                 * element in the transition.
+                 *
+                 * @param type Type of transition event. Supported values are "start", "end"
+                 * and "interrupt".
+                 * @param listener The listener to be invoked for each individual element in
+                 * the transition.
+                 */
+                (type: string, listener: (data: any, index: number) => any): Transition;
+            }
             transition: () => Transition;
             ease: (value: string, ...arrs: any[]) => Transition;
             attrTween(name: string, tween: (d: any, i: number, a: any) => BaseInterpolate): Transition;


### PR DESCRIPTION
Only the first argument of `D3.Transition.Transition.each` is optional, while the callback parameter is mandatory. Setting both parameters optional does not produce the expected behavior. We should use overload here.

See API reference of [transition.each](https://github.com/mbostock/d3/wiki/Transitions#each):

> ### transition.each([type, ]listener)
> 
> If type is specified, adds a listener for transition events, supporting "start", "end" and "interrupt" events. The listener will be invoked for each individual element in the transition.
> ...
> If type is not specified, behaves similarly to `selection.each`: immediately invokes the specified function for each element in the current transition, passing in the current datum `d` and index `i`, with the `this` context of the current DOM element. 
