### PR TITLE
Add `which` chainable keyword.

### DIFF
--- a/chai/chai.d.ts
+++ b/chai/chai.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for chai 1.7.2
+// Type definitions for chai 2.0.0
 // Project: http://chaijs.com/
 // Definitions by: Jed Hunsaker <https://github.com/jedhunsaker/>, Bart van der Schoor <https://github.com/Bartvds>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -92,6 +92,7 @@ declare module chai {
         been: Expect;
         is: Expect;
         that: Expect;
+        which: Expect;
         and: Expect;
         have: Expect;
         has: Expect;


### PR DESCRIPTION
See https://github.com/chaijs/chai/releases/tag/v2.0.0 and chaijs/chai#347.

I'm sure there's a lot of other changes that need to be made to get full 2.0 compatibility, but 1.7.2 is almost 2 years old now so it is probably time to move forward.
