### PR TITLE
Mark "highlight" and "label" properties of CircularChartData as optional

### DIFF
--- a/chartjs/chart.d.ts
+++ b/chartjs/chart.d.ts
@@ -28,8 +28,8 @@ interface LinearChartData {
 interface CircularChartData {
     value: number;
     color: string;
-    highlight: string;
-    label: string;
+    highlight?: string;
+    label?: string;
 }
 
 interface ChartSettings {


### PR DESCRIPTION
The "highlight" and "label" properties of CircularChartData are actually optional: highlight defaults to color (https://github.com/nnnick/Chart.js/blob/master/src/Chart.Doughnut.js#L98), and label is only rendered when present (https://github.com/nnnick/Chart.js/blob/master/src/Chart.Doughnut.js#L35).
