### PR TITLE
add backbone.paginator.d.ts

### DIFF
--- a/backbone.paginator/backbone.paginator-tests.ts
+++ b/backbone.paginator/backbone.paginator-tests.ts
@@ -1,0 +1,305 @@
+/// <reference path="../jquery/jquery.d.ts" />
+/// <reference path="../backbone/backbone.d.ts" />
+/// <reference path="backbone.paginator.d.ts" />
+
+module BackbonePaginatorTests {
+
+  class TestModel extends Backbone.Model{};
+
+  var makeFetchOptions = <TCol extends Backbone.PageableCollection<TestModel>>() => {
+    return {
+      reset: true,
+      url:   'example.com',
+      beforeSend: (jqxhr: JQueryXHR) => {},
+      success: (model: TestModel, response: any, options: any) => {},
+      error:   (collection: TCol, jqxhr: JQueryXHR, options: any) => {},
+      parse: '',
+    };
+  };
+
+
+  module InitializingWithNoOption {
+
+    class TestCollection extends Backbone.PageableCollection<TestModel> {
+      constructor(){
+	super();
+      }
+    }
+
+    var testCollection = new TestCollection();
+
+  }
+
+
+
+  module InitializingWithOptions {
+
+    class TestCollection extends Backbone.PageableCollection<TestModel> {
+
+      constructor(models?: TestModel[],
+		  options?: Backbone.PageableInitialOptions){
+	super();
+      }
+
+    }
+
+    var testCollection1 = new TestCollection();
+
+    var testCollection2 = new TestCollection([
+      new TestModel(),
+      new TestModel()
+    ]);
+
+    var testCollection3 = new TestCollection([], {});
+
+    var testCollection4 = new TestCollection([],{
+      comparator: ()=>1,
+      full:       true,
+      state:      {},
+      queryParam: {},
+    });
+
+    var testCollection5 = new TestCollection([],{
+      state: {
+	firstPage:    0,
+	lastPage:     0,
+	currentPage:  0,
+	pageSize:     1,
+	totalPages:   1,
+	totalRecords: 1,
+	sortKey:      'id',
+	order:        1,
+      },
+      queryParam: {
+	currentPage:  'current_page',
+	pageSize:     'page_size',
+	totalPages:   'total_pages',
+	totalRecords: 'total_records',
+	sortKey:      'sort_key',
+	order:        'order',
+	directions:   '',
+      },
+    });
+
+    var testCollection6 = new TestCollection([
+      <TestModel>{},
+      <TestModel>{},
+    ]);
+
+  }
+
+
+
+  module Fetching {
+
+    class TestCollection extends Backbone.PageableCollection<TestModel> {
+      constructor(models?: TestModel[],
+		  options?: Backbone.PageableInitialOptions){
+	super();
+      }
+    }
+
+
+    var testCollection = new TestCollection();
+
+    var result:JQueryXHR = testCollection.fetch();
+
+    testCollection.fetch({});
+
+    testCollection.fetch(makeFetchOptions<TestCollection>());
+
+  }
+
+
+
+  module Paging {
+
+    class TestCollection extends Backbone.PageableCollection<TestModel> {
+      constructor(models?: TestModel[],
+		  options?: Backbone.PageableInitialOptions){
+	super();
+      }
+    }
+
+    var options = makeFetchOptions<TestCollection>();
+
+    var testCollection = new TestCollection();
+
+
+    var result:JQueryXHR|TestCollection = testCollection.getFirstPage();
+
+    testCollection.getFirstPage(options);
+   
+    // 'silent's type is boolean. (structural subtyping)
+    testCollection.getFirstPage({silent: 'aa'});
+    // 'url's type is string. (structural subtyping)
+    testCollection.getFirstPage({url: true});
+
+
+    result = testCollection.getLastPage();
+
+    testCollection.getLastPage(options);
+
+    // 'silent's type is boolean. (structural subtyping)
+    testCollection.getLastPage({silent: 'aa'});
+    // 'url's type is string. (structural subtyping)
+    testCollection.getLastPage({url: true});
+
+
+    result = testCollection.getNextPage();
+
+    testCollection.getNextPage(options);
+
+    // 'silent's type is boolean. (structural subtyping)
+    testCollection.getNextPage({silent: 'aa'});
+    // 'url's type is string. (structural subtyping)
+    testCollection.getNextPage({url: true});
+
+
+    result = testCollection.getPage(1);
+
+    testCollection.getPage("1", options);
+
+    // 'silent's type is boolean. (structural subtyping)
+    testCollection.getPage(1, {silent: 'aa'});
+    // 'url's type is string. (structural subtyping)
+    testCollection.getPage(1, {url: true});
+
+
+    result = testCollection.getPageByOffset(1);
+
+    testCollection.getPageByOffset(1, options);
+
+    // 'silent's type is boolean. (structural subtyping)
+    testCollection.getPageByOffset(1, {silent: 'aa'});
+    // 'url's type is string. (structural subtyping)
+    testCollection.getPageByOffset(1, {url: true});
+
+
+    result = testCollection.getPreviousPage();
+
+    testCollection.getPreviousPage(options);
+
+    // 'silent's type is boolean. (structural subtyping)
+    testCollection.getPreviousPage({silent: 'aa'});
+    // 'url's type is string. (structural subtyping)
+    testCollection.getPreviousPage({url: true});
+
+
+    var hasPage:boolean = testCollection.hasNextPage();
+
+    hasPage = testCollection.hasPreviousPage();
+
+  }
+
+
+
+
+  module Parse {
+
+    class TestCollection extends Backbone.PageableCollection<TestModel> {
+      constructor(models?: TestModel[],
+		  options?: Backbone.PageableInitialOptions){
+	super();
+      }
+    }
+
+    var testCollection = new TestCollection();
+
+    var result:any[] = testCollection.parse({}, {});
+
+
+    var resultLinks:any = testCollection.parseLinks({}, {});
+
+    resultLinks = testCollection.parseLinks({}, { xhr: $.ajax({}) } );
+
+
+    result = testCollection.parseRecords({}, {});
+
+
+    var resultState: Backbone.PageableState = testCollection.parseState(
+      {},
+      {
+	currentPage:  'current_page',
+	pageSize:     'page_size',
+	totalPages:   'total_pages',
+	totalRecords: 'total_records',
+	sortKey:      'sort_key',
+	order:        'order',
+	directions:   '',
+      },
+      {
+	firstPage:    0,
+	lastPage:     0,
+	currentPage:  0,
+	pageSize:     1,
+	totalPages:   1,
+	totalRecords: 1,
+	sortKey:      'id',
+	order:        1,
+      },
+      {});
+
+  }
+
+
+
+  module Setting {
+
+    class TestCollection extends Backbone.PageableCollection<TestModel> {
+      constructor(models?: TestModel[],
+		  options?: Backbone.PageableInitialOptions){
+	super();
+      }
+    }
+
+    var testCollection = new TestCollection();
+
+    var options = makeFetchOptions<TestCollection>();
+
+
+    var result1:JQueryXHR|TestCollection
+	    = testCollection.setPageSize(1, options);
+
+
+    var result2:TestCollection
+	    = testCollection.setSorting('id', 1, options);
+
+
+    result1 = testCollection.switchMode(
+		'server',
+		{fetch: true, resetState: true}
+	      );
+
+  }
+
+
+
+  module Syncing {
+
+    class TestCollection extends Backbone.PageableCollection<TestModel> {
+      constructor(models?: TestModel[],
+		  options?: Backbone.PageableInitialOptions){
+	super();
+      }
+    }
+
+    var testCollection = new TestCollection();
+
+
+    var result:JQueryXHR = testCollection.sync('server', new TestModel(), {});
+
+    result = testCollection.sync('server', testCollection, {});
+
+  }
+
+
+
+  module Confllict {
+
+    var result:typeof Backbone.PageableCollection
+	    = Backbone.PageableCollection.noConflict();
+
+  }
+
+}

--- a/backbone.paginator/backbone.paginator.d.ts
+++ b/backbone.paginator/backbone.paginator.d.ts
@@ -1,0 +1,120 @@
+// Type definitions for backbone.paginator 2.0.2
+// Project: https://github.com/backbone-paginator/backbone.paginator
+// Definitions by: Nyamazing <https://github.com/Nyamazing/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../backbone/backbone.d.ts" />
+
+declare module Backbone {
+
+  interface PageableState {
+    firstPage?:    number;
+    lastPage?:     number;
+    currentPage?:  number;
+    pageSize?:     number;
+    totalPages?:   number;
+    totalRecords?: number;
+    sortKey?:      string;
+    order?:        number;
+  }
+
+  interface PageableQueryParams {
+    currentPage?:  string;
+    pageSize?:     string;
+    totalPages?:   string;
+    totalRecords?: string;
+    sortKey?:      string;
+    order?:        string;
+    directions?:   any;
+  }
+
+  interface PageableInitialOptions {
+    comparator?: (...options: any[]) => number;
+    full?: boolean;
+    state?: PageableState;
+    queryParam?: PageableQueryParams;
+  }
+
+  interface PageableParseLinksOptions {
+    xhr?: JQueryXHR;
+  }
+
+  interface PageableSetSortingOptions<TModel extends Model> {
+    side?: string;
+    full?: boolean;
+    sortValue?: (model: TModel, sortKey: string) => any | string;
+  }
+
+  interface PageableSwitchModeOptions {
+    fetch?:      boolean;
+    resetState?: boolean;
+  }
+
+  type PageableGetPageOptions = CollectionFetchOptions|Silenceable;
+
+  class PageableCollection<TModel extends Model> extends Collection<Model>{
+
+    fullCollection: Collection<TModel>;
+    mode: string;
+    queryParams: PageableQueryParams;
+    state: PageableState;
+
+    constructor(models?: TModel[], options?: PageableInitialOptions);
+
+    fetch(options?: CollectionFetchOptions): JQueryXHR;
+
+    getFirstPage(options?: PageableGetPageOptions):
+                                    JQueryXHR|PageableCollection<TModel>;
+
+    getLastPage(options?:  PageableGetPageOptions):
+                                    JQueryXHR|PageableCollection<TModel>;
+
+    getNextPage(options?:  PageableGetPageOptions):
+                                    JQueryXHR|PageableCollection<TModel>;
+
+    getPage(index: number|string, options?: PageableGetPageOptions):
+                                    JQueryXHR|PageableCollection<TModel>;
+
+    getPageByOffset(offset: number, options?: PageableGetPageOptions):
+                                    JQueryXHR|PageableCollection<TModel>;
+
+    getPreviousPage(options?: PageableGetPageOptions):
+                                    JQueryXHR|PageableCollection<TModel>;
+
+    hasNextPage():     boolean;
+
+    hasPreviousPage(): boolean;
+
+    parse(resp: any, options?: any): any[];
+
+    parseLinks(resp: any, options?: PageableParseLinksOptions): any;
+
+    parseRecords(resp: any, options?: any): any[];
+
+    parseState(resp: any, queryParams: PageableQueryParams,
+               state: PageableState, options?: any): PageableState;
+
+    setPageSize(pageSize: number,
+                options?: CollectionFetchOptions):
+                    JQueryXHR|PageableCollection<TModel>;
+
+    setSorting(sortKey: string, order?: number,
+               options?: PageableSetSortingOptions<TModel>):
+                    PageableCollection<TModel>;
+
+    switchMode(mode?: string, options?: PageableSwitchModeOptions):
+                    JQueryXHR|PageableCollection<TModel>;
+
+    sync(method: string,
+         model: TModel|Collection<TModel>,
+         options?: any): JQueryXHR;
+
+    static noConflict(): typeof PageableCollection;
+
+  }
+}
+
+declare module 'backbone.marionette' {
+    import Backbone = require('backbone');
+}
+

--- a/backbone.paginator/backbone.paginator.d.ts
+++ b/backbone.paginator/backbone.paginator.d.ts
@@ -114,7 +114,3 @@ declare module Backbone {
   }
 }
 
-declare module 'backbone.marionette' {
-    import Backbone = require('backbone');
-}
-


### PR DESCRIPTION
Add definitions for backbone.paginator.
https://github.com/backbone-paginator/backbone.paginator

I wrote this in reference to  the following API reference.
https://backbone-paginator.github.io/backbone.paginator/api/

But, one concern is the following line. 
https://github.com/Nyamazing/DefinitelyTyped/blob/backbone.paginator.spike/backbone.paginator/backbone.paginator.d.ts#L53

`type PageableGetPageOptions = CollectionFetchOptions|Silenceable;`
This type alias has little effect by structural subtyping.

Thank you.
