### PR TITLE
Update underscore.string.ts to support new  3.0.0 api

### DIFF
--- a/underscore.string/underscore.string.d.ts
+++ b/underscore.string/underscore.string.d.ts
@@ -10,6 +10,8 @@ interface UnderscoreStatic {
     string: UnderscoreStringStatic;
 }
 
+declare var s : UnderscoreStringStatic;
+
 interface UnderscoreStringStatic extends UnderscoreStringStaticExports {
     /**
      * Tests if string contains a substring.


### PR DESCRIPTION
The prebuild library now exports a `s` instead of beign embedded in `_.str`
See changelog :  https://github.com/epeli/underscore.string/blob/master/CHANGELOG.markdown#300

I've kept the interface UnderscoreStatic to support 2.x
