### PR TITLE
Fix ErrnoException `errno` type

### DIFF
--- a/node/node-0.10.d.ts
+++ b/node/node-0.10.d.ts
@@ -79,7 +79,7 @@ declare var Buffer: {
 ************************************************/
 declare module NodeJS {
     export interface ErrnoException extends Error {
-        errno?: any;
+        errno?: number;
         code?: string;
         path?: string;
         syscall?: string;

--- a/node/node-0.11-tests.ts
+++ b/node/node-0.11-tests.ts
@@ -60,6 +60,13 @@ class Networker extends events.EventEmitter {
     }
 }
 
+var errno: number;
+fs.readFile('testfile', (err, data) => {
+    if (err && err.errno) {
+        errno = err.errno;
+    }
+});
+
 url.format(url.parse('http://www.example.com/xyz'));
 
 // https://google.com/search?q=you're%20a%20lizard%2C%20gary

--- a/node/node-0.11.d.ts
+++ b/node/node-0.11.d.ts
@@ -79,7 +79,7 @@ declare var Buffer: {
 ************************************************/
 declare module NodeJS {
     export interface ErrnoException extends Error {
-        errno?: any;
+        errno?: number;
         code?: string;
         path?: string;
         syscall?: string;

--- a/node/node-0.8.8.d.ts
+++ b/node/node-0.8.8.d.ts
@@ -68,6 +68,12 @@ declare var Buffer: {
 *                   INTERFACES                  *
 *                                               *
 ************************************************/
+interface ErrnoException extends Error {
+    errno?: number;
+    code?: string;
+    path?: string;
+    syscall?: string;
+}
 
 interface EventEmitter {
     addListener(event: string, listener: Function);
@@ -730,9 +736,9 @@ declare module "fs" {
     export function fchmodSync(fd: string, mode: string): void;
     export function lchmod(path: string, mode: string, callback?: Function): void;
     export function lchmodSync(path: string, mode: string): void;
-    export function stat(path: string, callback?: (err: Error, stats: Stats) =>any): Stats;
-    export function lstat(path: string, callback?: (err: Error, stats: Stats) =>any): Stats;
-    export function fstat(fd: string, callback?: (err: Error, stats: Stats) =>any): Stats;
+    export function stat(path: string, callback?: (err: ErrnoException, stats: Stats) =>any): Stats;
+    export function lstat(path: string, callback?: (err: ErrnoException, stats: Stats) =>any): Stats;
+    export function fstat(fd: string, callback?: (err: ErrnoException, stats: Stats) =>any): Stats;
     export function statSync(path: string): Stats;
     export function lstatSync(path: string): Stats;
     export function fstatSync(fd: string): Stats;
@@ -740,9 +746,9 @@ declare module "fs" {
     export function linkSync(srcpath: string, dstpath: string): void;
     export function symlink(srcpath: string, dstpath: string, type?: string, callback?: Function): void;
     export function symlinkSync(srcpath: string, dstpath: string, type?: string): void;
-    export function readlink(path: string, callback?: (err: Error, linkString: string) =>any): void;
-    export function realpath(path: string, callback?: (err: Error, resolvedPath: string) =>any): void;
-    export function realpath(path: string, cache: string, callback: (err: Error, resolvedPath: string) =>any): void;
+    export function readlink(path: string, callback?: (err: ErrnoException, linkString: string) =>any): void;
+    export function realpath(path: string, callback?: (err: ErrnoException, resolvedPath: string) =>any): void;
+    export function realpath(path: string, cache: string, callback: (err: ErrnoException, resolvedPath: string) =>any): void;
     export function realpathSync(path: string, cache?: string): void;
     export function unlink(path: string, callback?: Function): void;
     export function unlinkSync(path: string): void;
@@ -750,11 +756,11 @@ declare module "fs" {
     export function rmdirSync(path: string): void;
     export function mkdir(path: string, mode?: string, callback?: Function): void;
     export function mkdirSync(path: string, mode?: string): void;
-    export function readdir(path: string, callback?: (err: Error, files: string[]) => void): void;
+    export function readdir(path: string, callback?: (err: ErrnoException, files: string[]) => void): void;
     export function readdirSync(path: string): string[];
     export function close(fd: string, callback?: Function): void;
     export function closeSync(fd: string): void;
-    export function open(path: string, flags: string, mode?: string, callback?: (err: Error, fd: string) =>any): void;
+    export function open(path: string, flags: string, mode?: string, callback?: (err: ErrnoException, fd: string) =>any): void;
     export function openSync(path: string, flags: string, mode?: string): void;
     export function utimes(path: string, atime: number, mtime: number, callback?: Function): void;
     export function utimesSync(path: string, atime: number, mtime: number): void;
@@ -766,8 +772,8 @@ declare module "fs" {
     export function writeSync(fd: string, buffer: Buffer, offset: number, length: number, position: number): void;
     export function read(fd: string, buffer: Buffer, offset: number, length: number, position: number, callback?: (err: Error, bytesRead: number, buffer: Buffer) => void): void;
     export function readSync(fd: string, buffer: Buffer, offset: number, length: number, position: number): any[];
-    export function readFile(filename: string, encoding: string, callback: (err: Error, data: string) => void ): void;
-    export function readFile(filename: string, callback: (err: Error, data: Buffer) => void ): void;
+    export function readFile(filename: string, encoding: string, callback: (err: ErrnoException, data: string) => void ): void;
+    export function readFile(filename: string, callback: (err: ErrnoException, data: Buffer) => void ): void;
     export function readFileSync(filename: string): Buffer;
     export function readFileSync(filename: string, encoding: string): string;
     export function writeFile(filename: string, data: any, callback?: (err) => void): void;

--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -61,6 +61,13 @@ class Networker extends events.EventEmitter {
     }
 }
 
+var errno: number;
+fs.readFile('testfile', (err, data) => {
+    if (err && err.errno) {
+        errno = err.errno;
+    }
+});
+
 ////////////////////////////////////////////////////
 /// Url tests : http://nodejs.org/api/url.html
 ////////////////////////////////////////////////////

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -79,7 +79,7 @@ declare var Buffer: {
 ************************************************/
 declare module NodeJS {
     export interface ErrnoException extends Error {
-        errno?: any;
+        errno?: number;
         code?: string;
         path?: string;
         syscall?: string;


### PR DESCRIPTION
It's a number (technically an integer) in all Node API versions that have a corresponding .d.ts file here.

Relevant lines:

https://github.com/joyent/node/blob/v0.8.8-release/src/node.cc#L769-L806
https://github.com/joyent/node/blob/v0.10.1-release/src/node.cc#L750
https://github.com/joyent/node/blob/v0.11.13-release/src/node.cc#L752
https://github.com/joyent/node/blob/v0.12.0-release/src/node.cc#L762

I added the ErrnoException type to the Node 0.8.8 .d.ts file, since it did, in fact, exist with the same interface then (This has actually been the case [since at least 0.4](https://github.com/joyent/node/blob/v0.4/src/node.cc#L1022-L1063)).
