### PR TITLE
Removal of obsolete parameter in Spy Interface

### DIFF
--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -369,7 +369,6 @@ declare module jasmine {
         mostRecentCall: { args: any[]; };
         argsForCall: any[];
         wasCalled: boolean;
-        callCount: number;
     }
 
     interface SpyAnd {


### PR DESCRIPTION
The callCount parameter does not exist in Jasmine versions > 2.0 but did exist in 1.3
