### PR TITLE
Added Missing functions to the fabric.util class

### DIFF
--- a/fabricjs/fabricjs.d.ts
+++ b/fabricjs/fabricjs.d.ts
@@ -881,5 +881,19 @@ declare module fabric {
         toArray(arrayLike): any[];
         toFixed(number, fractionDigits);
         wrapElement(element: HTMLElement, wrapper, attributes);
+        rotatePoint(point: IPoint, origin: IPoint, radians: number);
+        transformPoint(p: IPoint, t: any[], ignoreOffset: boolean);
+        invertTransform(t: any[]);
+        parseUnit(value: number|string, fontSize?: number);
+        getKlass(type: string, namespace: string); 
+        resolveNamespace(namespace: string);
+        enlivenObjects(objects: any[], callback: Function, namespace: string, reviver: Function);
+        drawDashedLine(ctx: CanvasRenderingContext2D, x: number, y: number, x2: number, y2: number, da: any[]);
+        createCanvasElement(canvasEl?: HTMLElement);
+        createImage();
+        createAccessors(klass: Object);
+        clipContext(receiver: IObject, ctx: CanvasRenderingContext2D);
+        isTransparent(ctx: CanvasRenderingContext2D, x: number, y: number, tolerance: number);
+
     }
 }


### PR DESCRIPTION
Found some missing properties from the fabric.util namespace when
converting this example to TypeScript. http://fabricjs.com/animated-sprite/

Added in the missing functions from the the latest fabric master.
