### PR TITLE
Typings for pisco.prettyforms

### DIFF
--- a/pisco.prettyforms/pisco.prettyforms.d.ts
+++ b/pisco.prettyforms/pisco.prettyforms.d.ts
@@ -1,0 +1,33 @@
+﻿// Type definitions for pisco.prettyforms 1.0.0
+// Project: https://github.com/albertofortes/piscoPrettyForms
+// Definitions by: Petr Kadlec <https://github.com/mormegil-cz/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../jquery/jquery.d.ts" />
+
+interface PiscoPrettyformsOptions {
+    /**
+     * Currently unused
+     */
+    className?: string;
+    /**
+     * The width of styled SELECT elements
+     */
+    selectWidth?: any; // number | string
+    /**
+     * Additional custom CSS class to be added to the styled elements
+     */
+    customClass?: string;
+}
+
+interface JQuery {
+    /**
+     * Prettify the form elements
+     * @param options The options
+     * @example
+     * $('.pretty').piscoPrettyForms({
+     *   selectWidth: 200
+     * });
+     */
+    piscoPrettyForms(options?: PiscoPrettyformsOptions): JQuery;
+}


### PR DESCRIPTION
I am not sure if typings for such a small not-exactly-reference-quality library should go to the main DefinitelyTyped repository. However, I needed the definitions, so I’m sharing them in case somebody wants them.
