### PR TITLE
Fixes for correcting 'arguments' semantics in tests

### DIFF
--- a/backgrid/backgrid.d.ts.tscparams
+++ b/backgrid/backgrid.d.ts.tscparams
@@ -1,1 +1,1 @@
-
+--target es5

--- a/node-git/node-git-tests.ts
+++ b/node-git/node-git-tests.ts
@@ -3,7 +3,7 @@
 import base = require("git");
 
 var git = new base.Git("../.git");
-git.call_git("", "clone", "", {}, ["https://github.com/borisyankov/DefinitelyTyped.git", "d.ts"], (err, data) => {
+git.call_git("", "clone", "", {}, ["https://github.com/borisyankov/DefinitelyTyped.git", "d.ts"], function (err, data) {
     console.log(arguments);
 });
 

--- a/should/should-tests.ts
+++ b/should/should-tests.ts
@@ -75,7 +75,7 @@ false
 false.should.be.false;
 (0).should.not.be.false;
 
-var args = (a: string, b: string, c: string) => { return arguments; };
+var args = function (a: string, b: string, c: string) { return arguments; };
 args.should.be.arguments;
 ['a'].should.not.be.arguments;
 

--- a/simple-cw-node/simple-cw-node-tests.ts
+++ b/simple-cw-node/simple-cw-node-tests.ts
@@ -10,7 +10,7 @@ var Deferred:any = client.Deferred;
 client.init({ token: 'YOUR_TOKEN' });
 
 // get your info.
-client.get('me', (err, res) => {
+client.get('me', function (err, res) {
 	console.log(arguments);
 });
 


### PR DESCRIPTION
Fixes for TypeScript 1.5's new policy for `arguments` in an arrow function.

Also a fix for a test that uses accessors.
