### PR TITLE
Lodash union types, optional args

### DIFF
--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -263,12 +263,12 @@ declare module _ {
         * @param array Array to compact.
         * @return (Array) Returns a new array of filtered values.
         **/
-        compact<T>(array: Array<T>): T[];
+        compact<T>(array?: Array<T>): T[];
 
         /**
         * @see _.compact
         **/
-        compact<T>(array: List<T>): T[];
+        compact<T>(array?: List<T>): T[];
     }
 
     interface LoDashArrayWrapper<T> {
@@ -288,13 +288,13 @@ declare module _ {
         * @return Returns a new array of filtered values.
         **/
         difference<T>(
-            array: Array<T>,
+            array?: Array<T>,
             ...others: Array<T>[]): T[];
         /**
         * @see _.difference
         **/
         difference<T>(
-            array: List<T>,
+            array?: List<T>,
             ...others: List<T>[]): T[];
     }
 
@@ -432,12 +432,12 @@ declare module _ {
         * @param array Retrieves the first element of this array.
         * @return Returns the first element of `array`.
         **/
-        first<T>(array: Array<T>): T;
+        first<T>(array?: Array<T>): T;
 
         /**
         * @see _.first
         **/
-        first<T>(array: List<T>): T;
+        first<T>(array?: List<T>): T;
 
         /**
         * @see _.first
@@ -5663,7 +5663,7 @@ declare module _ {
         * @param value The value to check.
         * @return True if the value is an arguments object, else false.
         **/
-        isArguments(value: any): boolean;
+        isArguments(value?: any): boolean;
     }
 
     //_.isArray
@@ -5673,7 +5673,7 @@ declare module _ {
         * @param value The value to check.
         * @return True if the value is an array, else false.
         **/
-        isArray(value: any): boolean;
+        isArray(value?: any): boolean;
     }
 
     //_.isBoolean
@@ -5683,7 +5683,7 @@ declare module _ {
         * @param value The value to check.
         * @return True if the value is a boolean value, else false.
         **/
-        isBoolean(value: any): boolean;
+        isBoolean(value?: any): boolean;
     }
 
     //_.isDate
@@ -5693,7 +5693,7 @@ declare module _ {
         * @param value The value to check.
         * @return True if the value is a date, else false.
         **/
-        isDate(value: any): boolean;
+        isDate(value?: any): boolean;
     }
 
     //_.isElement
@@ -5703,7 +5703,7 @@ declare module _ {
         * @param value The value to check.
         * @return True if the value is a DOM element, else false.
         **/
-        isElement(value: any): boolean;
+        isElement(value?: any): boolean;
     }
 
     //_.isEmpty
@@ -5714,22 +5714,7 @@ declare module _ {
         * @param value The value to inspect.
         * @return True if the value is empty, else false.
         **/
-        isEmpty(value: any[]): boolean;
-
-        /**
-        * @see _.isEmpty
-        **/
-        isEmpty(value: Dictionary<any>): boolean;
-
-        /**
-        * @see _.isEmpty
-        **/
-        isEmpty(value: string): boolean;
-
-        /**
-        * @see _.isEmpty
-        **/
-        isEmpty(value: any): boolean;
+        isEmpty(value?: any[]|Dictionary<any>|string|any): boolean;
     }
 
     //_.isEqual
@@ -5746,8 +5731,8 @@ declare module _ {
         * @return True if the values are equivalent, else false.
         **/
         isEqual(
-            a: any,
-            b: any,
+            a?: any,
+            b?: any,
             callback?: (a: any, b: any) => boolean,
             thisArg?: any): boolean;
     }
@@ -5762,7 +5747,7 @@ declare module _ {
         * @param value The value to check.
         * @return True if the value is finite, else false.
         **/
-        isFinite(value: any): boolean;
+        isFinite(value?: any): boolean;
     }
 
     //_.isFunction
@@ -5772,7 +5757,7 @@ declare module _ {
         * @param value The value to check.
         * @return True if the value is a function, else false.
         **/
-        isFunction(value: any): boolean;
+        isFunction(value?: any): boolean;
     }
 
     //_.isNaN
@@ -5785,7 +5770,7 @@ declare module _ {
         * @param value The value to check.
         * @return True if the value is NaN, else false.
         **/
-        isNaN(value: any): boolean;
+        isNaN(value?: any): boolean;
     }
 
     //_.isNull
@@ -5795,7 +5780,7 @@ declare module _ {
         * @param value The value to check.
         * @return True if the value is null, else false.
         **/
-        isNull(value: any): boolean;
+        isNull(value?: any): boolean;
     }
 
     //_.isNumber
@@ -5807,7 +5792,7 @@ declare module _ {
         * @param value The value to check.
         * @return True if the value is a number, else false.
         **/
-        isNumber(value: any): boolean;
+        isNumber(value?: any): boolean;
     }
 
     //_.isObject
@@ -5818,7 +5803,7 @@ declare module _ {
         * @param value The value to check.
         * @return True if the value is an object, else false.
         **/
-        isObject(value: any): boolean;
+        isObject(value?: any): boolean;
     }
 
     //_.isPlainObject
@@ -5828,7 +5813,7 @@ declare module _ {
         * @param value The value to check.
         * @return True if value is a plain object, else false.
         **/
-        isPlainObject(value: any): boolean;
+        isPlainObject(value?: any): boolean;
     }
 
     //_.isRegExp
@@ -5838,7 +5823,7 @@ declare module _ {
         * @param value The value to check.
         * @return True if the value is a regular expression, else false.
         **/
-        isRegExp(value: any): boolean;
+        isRegExp(value?: any): boolean;
     }
 
     //_.isString
@@ -5848,7 +5833,7 @@ declare module _ {
         * @param value The value to check.
         * @return True if the value is a string, else false.
         **/
-        isString(value: any): boolean;
+        isString(value?: any): boolean;
     }
 
     //_.isUndefined
@@ -5858,7 +5843,7 @@ declare module _ {
         * @param value The value to check.
         * @return True if the value is undefined, else false.
         **/
-        isUndefined(value: any): boolean;
+        isUndefined(value?: any): boolean;
     }
 
     //_.keys
@@ -5868,7 +5853,7 @@ declare module _ {
         * @param object The object to inspect.
         * @return An array of property names.
         **/
-        keys(object: any): string[];
+        keys(object?: any): string[];
     }
 
     interface LoDashObjectWrapper<T> {
@@ -6018,7 +6003,7 @@ declare module _ {
         * @param object The object to inspect.
         * @return Aew array of key-value pairs.
         **/
-        pairs(object: any): any[][];
+        pairs(object?: any): any[][];
     }
 
     interface LoDashObjectWrapper<T> {
@@ -6130,7 +6115,7 @@ declare module _ {
         * @param object The object to inspect.
         * @return Returns an array of property values.
         **/
-        values(object: any): any[];
+        values(object?: any): any[];
     }
 
     /**********
@@ -6156,10 +6141,8 @@ declare module _ {
         trimLeft(str?: string, chars?: string): string;
         trimRight(str?: string, chars?: string): string;
         trunc(str?: string, len?: number): string;
-        trunc(str?: string, options?: { length?: number; omission?: string; separator?: string }): string;
-        trunc(str?: string, options?: { length?: number; omission?: string; separator?: RegExp }): string;
-        words(str?: string, pattern?: string): string[];
-        words(str?: string, pattern?: RegExp): string[];
+        trunc(str?: string, options?: { length?: number; omission?: string; separator?: string|RegExp }): string;
+        words(str?: string, pattern?: string|RegExp): string[];
     }
 
     //_.parseInt
@@ -6174,7 +6157,7 @@ declare module _ {
         * @param radix The radix used to interpret the value to parse.
         * @return The new integer value.
         **/
-        parseInt(value: string, radix?: number): number;
+        parseInt(value?: string, radix?: number): number;
     }
 
     /*************
@@ -6187,7 +6170,7 @@ declare module _ {
         * @param string The string to escape.
         * @return The escaped string.
         **/
-        escape(str: string): string;
+        escape(str?: string): string;
     }
 
     //_.identity
@@ -6197,7 +6180,7 @@ declare module _ {
         * @param value Any value.
         * @return value.
         **/
-        identity<T>(value: T): T;
+        identity<T>(value?: T): T;
     }
 
     //_.mixin
@@ -6206,7 +6189,7 @@ declare module _ {
         * Adds function properties of a source object to the lodash function and chainable wrapper.
         * @param object The object of function properties to add to lodash.
         **/
-        mixin(object: Dictionary<(value: any) => any>): void;
+        mixin(object?: Dictionary<(value: any) => any>): void;
     }
 
     //_.noConflict


### PR DESCRIPTION
I was having issues passing in undefined variables, but lodash is actually really good about allowing you to do that without throwing errors, which means those args should be optional.
