### PR TITLE
jquery.contextMenu type definitions are now compatible with --noImplicitAny

### DIFF
--- a/jquery.contextMenu/jquery.contextMenu-tests.ts
+++ b/jquery.contextMenu/jquery.contextMenu-tests.ts
@@ -1,0 +1,19 @@
+/// <reference path="./jquery.contextMenu.d.ts" />
+
+//http://medialize.github.io/jQuery-contextMenu/docs.html
+
+//Disable a contextMenu trigger
+$(".some-selector").contextMenu(false);
+
+//Manually show a contextMenu
+$(".some-selector").contextMenu();
+$(".some-selector").contextMenu({x: 123, y: 123});
+
+//Manually hide a contextMenu
+$(".some-selector").contextMenu("hide");
+
+//Unregister contextMenu
+$.contextMenu('destroy', ".some-selector");
+
+//Unregister all contextMenus
+$.contextMenu('destroy');

--- a/jquery.contextMenu/jquery.contextMenu.d.ts
+++ b/jquery.contextMenu/jquery.contextMenu.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jQuery contextMenu 1.6.6
+// Type definitions for jQuery contextMenu 1.7.0
 // Project: http://medialize.github.com/jQuery-contextMenu/
 // Definitions by: Natan Vivo <https://github.com/nvivo/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -11,9 +11,9 @@ interface JQueryContextMenuOptions {
     trigger?: string;
     autoHide?: boolean;
     delay?: number;
-    determinePosition?: (menu) => void;
-    position?: (opt, x, y) => void;
-    positionSubmenu?: (menu) => void;
+    determinePosition?: (menu: JQuery) => void;
+    position?: (opt: JQuery, x: number, y: number) => void;
+    positionSubmenu?: (menu: JQuery) => void;
     zIndex?: number;
     animation?: {
         duration?: number;
@@ -26,9 +26,15 @@ interface JQueryContextMenuOptions {
     };
     callback?: (key: any, options: any) => any;
     items: any;
+    reposition?: boolean;
+    className?: string;
 }
 
 interface JQueryStatic {
     contextMenu(options?: JQueryContextMenuOptions): JQuery;
-    contextMenu(type: string): JQuery;
+    contextMenu(type: string, selector?: any): JQuery;
+}
+
+interface JQuery {
+    contextMenu(options?: any): JQuery;
 }

--- a/jquery.contextMenu/jquery.contextMenu.d.ts.tscparams
+++ b/jquery.contextMenu/jquery.contextMenu.d.ts.tscparams
@@ -1,1 +1,1 @@
-
+--noImplicitAny


### PR DESCRIPTION
Also added some missing definitions with tests.
for more details: http://medialize.github.io/jQuery-contextMenu/docs.html
