### PR TITLE
mocha.d.ts: Boolean should be boolean.

### DIFF
--- a/mocha/mocha.d.ts
+++ b/mocha/mocha.d.ts
@@ -37,10 +37,10 @@ interface MochaSetupOptions {
     reporter?: any;
 
     // bail on the first test failure
-    bail?: Boolean;
+    bail?: boolean;
 
     // ignore global leaks
-    ignoreLeaks?: Boolean;
+    ignoreLeaks?: boolean;
 
     // grep string or regexp to filter tests with
     grep?: any;


### PR DESCRIPTION
`Boolean` isn't the right name for the `boolean` type.
