### PR TITLE
Removed ko.utils.makeArray

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -325,8 +325,6 @@ interface KnockoutUtils {
 
     range(min: any, max: any): any;
 
-    makeArray(arrayLikeObject: any): any[];
-
     getFormFields(form: any, fieldName: string): any[];
 
     parseJson(jsonString: string): any;


### PR DESCRIPTION
As of the new versión 3.3.0, the ko.utils.makeArray isn't defined...
