### PR TITLE
Add registerSounds method declaration

### DIFF
--- a/soundjs/soundjs.d.ts
+++ b/soundjs/soundjs.d.ts
@@ -177,6 +177,7 @@ declare module createjs {
         static registerManifest(manifest: Object[], basePath: string): Object;
         static registerPlugins(plugins: any[]): boolean;
         static registerSound(src: string | Object, id?: string, data?: number | Object, basePath?: string): Object;
+        static registerSounds(sounds: Object[], basePath?: string): Object[];
         static removeAllSounds(): void;
         static removeManifest(manifest: any[], basePath: string): Object;
         static removeSound(src: string | Object, basePath: string): boolean;


### PR DESCRIPTION
SoundJS 0.6 provides a new method called registerSounds to replace the now-deprecated registerManifest method.
