### PR TITLE
node.d.ts fix ServerRequest/ClientResponse to IncomingMessage

### DIFF
--- a/formidable/formidable.d.ts
+++ b/formidable/formidable.d.ts
@@ -25,7 +25,7 @@ declare module "formidable" {
 		onPart: (part: Part) => void;
 
 		handlePart(part: Part): void;
-		parse(req: http.ServerRequest, callback?: (err: any, fields: Fields, files: Files) => any): void;
+		parse(req: http.IncomingMessage, callback?: (err: any, fields: Fields, files: Files) => any): void;
 	}
 
 	export interface Fields {

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -353,6 +353,10 @@ declare module "http" {
         statusMessage: string;
         socket: net.Socket;
     }
+    /**
+     * @deprecated Use IncomingMessage
+     */
+    export interface ClientResponse extends IncomingMessage { }
 
 	export interface AgentOptions {
 		/**

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -342,10 +342,22 @@ declare module "http" {
         trailers: any;
         rawTrailers: any;
         setTimeout(msecs: number, callback: Function): NodeJS.Timer;
-        method: string;
-        url: string;
-        statusCode: number;
-        statusMessage: string;
+        /**
+         * Only valid for request obtained from http.Server.
+         */
+        method?: string;
+        /**
+         * Only valid for request obtained from http.Server.
+         */
+        url?: string;
+        /**
+         * Only valid for response obtained from http.ClientRequest.
+         */
+        statusCode?: number;
+        /**
+         * Only valid for response obtained from http.ClientRequest.
+         */
+        statusMessage?: string;
         socket: net.Socket;
     }
     /**

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -340,14 +340,18 @@ declare module "http" {
         end(str: string, encoding?: string, cb?: Function): void;
         end(data?: any, encoding?: string): void;
     }
-    export interface ClientResponse extends events.EventEmitter, stream.Readable {
-        statusCode: number;
+    export interface IncomingMessage extends events.EventEmitter, stream.Readable {
         httpVersion: string;
         headers: any;
+        rawHeaders: string[];
         trailers: any;
-        setEncoding(encoding?: string): void;
-        pause(): void;
-        resume(): void;
+        rawTrailers: any;
+        setTimeout(msecs: number, callback: Function): NodeJS.Timer;
+        method: string;
+        url: string;
+        statusCode: number;
+        statusMessage: string;
+        socket: net.Socket;
     }
 
 	export interface AgentOptions {
@@ -392,8 +396,8 @@ declare module "http" {
     };
     export function createServer(requestListener?: (request: ServerRequest, response: ServerResponse) =>void ): Server;
     export function createClient(port?: number, host?: string): any;
-    export function request(options: any, callback?: Function): ClientRequest;
-    export function get(options: any, callback?: Function): ClientRequest;
+    export function request(options: any, callback?: (res: IncomingMessage) => void): ClientRequest;
+    export function get(options: any, callback?: (res: IncomingMessage) => void): ClientRequest;
     export var globalAgent: Agent;
 }
 
@@ -563,8 +567,8 @@ declare module "https" {
     };
     export interface Server extends tls.Server { }
     export function createServer(options: ServerOptions, requestListener?: Function): Server;
-    export function request(options: RequestOptions, callback?: (res: http.ClientResponse) =>void ): http.ClientRequest;
-    export function get(options: RequestOptions, callback?: (res: http.ClientResponse) =>void ): http.ClientRequest;
+    export function request(options: RequestOptions, callback?: (res: http.IncomingMessage) =>void ): http.ClientRequest;
+    export function get(options: RequestOptions, callback?: (res: http.IncomingMessage) =>void ): http.ClientRequest;
     export var globalAgent: Agent;
 }
 

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -282,15 +282,10 @@ declare module "http" {
         address(): { port: number; family: string; address: string; };
         maxHeadersCount: number;
     }
-    export interface ServerRequest extends events.EventEmitter, stream.Readable {
-        method: string;
-        url: string;
-        headers: any;
-        trailers: string;
-        httpVersion: string;
-        setEncoding(encoding?: string): void;
-        pause(): void;
-        resume(): void;
+    /**
+     * @deprecated Use IncomingMessage
+     */
+    export interface ServerRequest extends IncomingMessage {
         connection: net.Socket;
     }
     export interface ServerResponse extends events.EventEmitter, stream.Writable {
@@ -398,7 +393,7 @@ declare module "http" {
         [errorCode: number]: string;
         [errorCode: string]: string;
     };
-    export function createServer(requestListener?: (request: ServerRequest, response: ServerResponse) =>void ): Server;
+    export function createServer(requestListener?: (request: IncomingMessage, response: ServerResponse) =>void ): Server;
     export function createClient(port?: number, host?: string): any;
     export function request(options: any, callback?: (res: IncomingMessage) => void): ClientRequest;
     export function get(options: any, callback?: (res: IncomingMessage) => void): ClientRequest;


### PR DESCRIPTION
ses also: https://nodejs.org/api/http.html#http_http_incomingmessage

3 methods seems to have been deleted, but it exists at stream.Readable.
There keeps ClientResponse for compatibility.
