### PR TITLE
restangular: Add missing save method

### DIFF
--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -113,6 +113,7 @@ declare module restangular {
     options(queryParams?: any, headers?: any): IPromise<any>;
     patch(queryParams?: any, headers?: any): IPromise<any>;
     withHttpConfig(httpConfig: IRequestConfig): IElement;
+    save(queryParams?: any, headers?: any): IPromise<any>;
     getRestangularUrl(): string;
   }
 


### PR DESCRIPTION
I added the missing `save` method as documented under [Element methods](https://github.com/mgonto/restangular#element-methods).
