### PR TITLE
Add missing plain and clone method to restangular IElement

### DIFF
--- a/restangular/restangular-tests.ts
+++ b/restangular/restangular-tests.ts
@@ -82,6 +82,9 @@ myApp.controller('TestCtrl', (
   Restangular.one('accounts', 123).getList('buildings');
   Restangular.one('accounts', 123).getList<String>('buildings');
 
+  var accountData = Restangular.one('accounts', 123).plain();
+  var accountClone: restangular.IElement = Restangular.one('accounts', 123).clone();
+
   baseAccounts.getList().then(function (accounts) {
     var firstAccount = accounts[0];
     $scope.buildings = firstAccount.getList("buildings");

--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -112,6 +112,8 @@ declare module restangular {
     trace(queryParams?: any, headers?: any): IPromise<any>;
     options(queryParams?: any, headers?: any): IPromise<any>;
     patch(queryParams?: any, headers?: any): IPromise<any>;
+    clone(): IElement;
+    plain(): any;
     withHttpConfig(httpConfig: IRequestConfig): IElement;
     getRestangularUrl(): string;
   }


### PR DESCRIPTION
I added the `plain` and `clone` method as documented under [Element methods](https://github.com/mgonto/restangular#element-methods).
