### PR TITLE
underscore funtion return type fixed

### DIFF
--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -278,7 +278,7 @@ interface UnderscoreStatic {
     findIndex<T>(
         list: _.List<T>,
         iterator: _.ListIterator<T, boolean>,
-        context?: any): T;
+        context?: any): number;
 
 
 	/**


### PR DESCRIPTION
underscore _.findIndex now returns the correct type (number instead of the element type)
