### PR TITLE
Include padAngle to PieLayout interface

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1279,6 +1279,13 @@ declare module D3 {
                 (angle: (d : any) => number): PieLayout
                 (angle: (d : any, i: number) => number): PieLayout;
             };
+            padAngle: {
+                (): number;
+                (angle: number): PieLayout;
+                (angle: () => number): PieLayout;
+                (angle: (d : any) => number): PieLayout
+                (angle: (d : any, i: number) => number): PieLayout;
+            };
         }
 
         export interface ArcDescriptor {


### PR DESCRIPTION
Based on line 68 of pie.js https://github.com/mbostock/d3/blob/master/src/layout/pie.js
