### PR TITLE
Add support for dispose callbacks in knockout.projections library

### DIFF
--- a/knockout.projections/knockout.projections-tests.ts
+++ b/knockout.projections/knockout.projections-tests.ts
@@ -26,3 +26,31 @@ sourceItems.push(9);
 
 sourceItems.push(10);
 // evenSquares now contains [36, 16, 4, 100]
+
+// Testing mapping options
+
+interface IComplexItem {
+    value: string;
+    dispose(): void;
+}
+
+var complexItems = sourceItems.map({
+    mapping: x => {
+        var item: IComplexItem = {
+            value: (x * x).toString(),
+            dispose: () => { }
+        };
+
+        return item;
+    },
+    disposeItem: (item: IComplexItem) => item.dispose()
+});
+
+var complexItems2 = sourceItems.map({
+    mappingWithDisposeCallback: x => {
+        return {
+            mappedValue: (x * x).toString(),
+            dispose: () => { }
+        };
+    }
+});

--- a/knockout.projections/knockout.projections-tests.ts
+++ b/knockout.projections/knockout.projections-tests.ts
@@ -54,3 +54,11 @@ var complexItems2 = sourceItems.map({
         };
     }
 });
+
+// Test disposal
+
+evenSquares.dispose();
+
+complexItems.dispose();
+
+complexItems2.dispose();

--- a/knockout.projections/knockout.projections.d.ts
+++ b/knockout.projections/knockout.projections.d.ts
@@ -6,7 +6,17 @@
 /// <reference path="../knockout/knockout.d.ts" />
 
 interface KnockoutObservableArrayFunctions<T> {
-
-    map<TResult>(mapping: (value: T) => TResult): KnockoutObservableArray<TResult>;
+    map<TResult>(mappingOptions: {
+        mappingWithDisposeCallback: (value: T) => {
+            mappedValue: TResult;
+            dispose: () => void;
+        };
+    }): KnockoutObservableArray<TResult>;
+    map<TResult>(mappingOptions: {
+        mapping: (value: T) => TResult;
+        disposeItem?: (mappedItem: TResult) => void;
+    }): KnockoutObservableArray<TResult>;
+    map<TResult>(mappingOptions: (value: T) => TResult): KnockoutObservableArray<TResult>;
+    
     filter(predicate: (value: T) => boolean): KnockoutObservableArray<T>;
 }

--- a/knockout.projections/knockout.projections.d.ts
+++ b/knockout.projections/knockout.projections.d.ts
@@ -5,18 +5,21 @@
 
 /// <reference path="../knockout/knockout.d.ts" />
 
+interface KnockoutMappedObservableArray<T> extends KnockoutObservableArray<T>, KnockoutSubscription {
+}
+
 interface KnockoutObservableArrayFunctions<T> {
     map<TResult>(mappingOptions: {
         mappingWithDisposeCallback: (value: T) => {
             mappedValue: TResult;
             dispose: () => void;
         };
-    }): KnockoutObservableArray<TResult>;
+    }): KnockoutMappedObservableArray<TResult>;
     map<TResult>(mappingOptions: {
         mapping: (value: T) => TResult;
         disposeItem?: (mappedItem: TResult) => void;
-    }): KnockoutObservableArray<TResult>;
-    map<TResult>(mappingOptions: (value: T) => TResult): KnockoutObservableArray<TResult>;
+    }): KnockoutMappedObservableArray<TResult>;
+    map<TResult>(mappingOptions: (value: T) => TResult): KnockoutMappedObservableArray<TResult>;
     
-    filter(predicate: (value: T) => boolean): KnockoutObservableArray<T>;
+    filter(predicate: (value: T) => boolean): KnockoutMappedObservableArray<T>;
 }


### PR DESCRIPTION
The Knockout Projections library has overloads for the map method which take various forms of disposal callbacks. This change adds those overloads with proper generics handling.

The computed arrays returned by map and filter both support (and practically require) disposal. Added a type which extends KncokoutSubscription to add dispose support and modified the return types of map and filter accordingly.

Updated the tests to ensure backward-compatibility with existing code.

This should address issue #3777 .
