### PR TITLE
Add Squire.js type definitions.

### DIFF
--- a/squirejs/squirejs-tests.ts
+++ b/squirejs/squirejs-tests.ts
@@ -1,0 +1,37 @@
+/// <reference path="squirejs.d.ts" />
+
+import Squire = require('Squire');
+
+// Default Configuration
+var injector = new Squire();
+
+// Different Context
+injector = new Squire('other-requirejs-context');
+
+// require(Array dependencies, Function callback, Function errback)
+injector.require(['a'], function(A: any) {}, function(err: any) {});
+
+// mock(String name | Object(name: mock), Object mock)
+injector.mock("a", {});
+injector.mock({a: {}});
+
+// store(String name | Array names)
+injector.store('a');
+injector.store(['a', 'b']);
+
+// clean(Optional (String name | Array names))
+injector.clean('a');
+injector.clean(['a', 'b']);
+injector.clean();
+
+// remove()
+injector.remove();
+
+// run()
+injector.run(['a'], function test(a: any) {})(function done() {});
+
+// Squire.Helpers.returns(Any what)
+Squire.Helpers.returns({});
+
+// Squire.Helpers.constructs(Any what)
+Squire.Helpers.constructs({});

--- a/squirejs/squirejs.d.ts
+++ b/squirejs/squirejs.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for Squire 0.2.1
+// Project: https://github.com/iammerrick/Squire.js
+// Definitions by: Bradley Ayers <https://github.com/bradleyayers>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module 'Squire' {
+    class Squire {
+        constructor();
+        constructor(context: string);
+        mock(name: string, mock: any): Squire;
+        mock(mocks: {[name: string]: any}): Squire;
+        require(dependencies: string[], callback: Function, errback: Function): Squire;
+        store(name: string | string[]): Squire;
+        clean(): Squire;
+        clean(name: string | string[]): Squire;
+        remove(): String;
+        run(dependencies: string[], test: Function): (done: Function) => void;
+    }
+
+    module Squire {
+        module Helpers {
+            export function returns<T>(what: T): () => T;
+            export function constructs<T>(what: T): () => (() => T);
+        }
+    }
+
+    export = Squire;
+}


### PR DESCRIPTION
It's published to NPM and Bower under different names, I've gone with the NPM name `squirejs` (see https://github.com/iammerrick/Squire.js/blob/master/package.json).
