### PR TITLE
make 1.4.1 behave on angular-ui-bootstrap

### DIFF
--- a/angular-ui-bootstrap/angular-ui-bootstrap.d.ts
+++ b/angular-ui-bootstrap/angular-ui-bootstrap.d.ts
@@ -206,12 +206,12 @@ declare module angular.ui.bootstrap {
         /**
          * Dismiss the dialog without assigning a value to the promise output
          */
-        $dismiss(reason?: any): void;
+        $dismiss?(reason?: any): void;
 
         /**
          * Close the dialog resolving the promise to the given value
          */
-        $close(result?: any): void;
+        $close?(result?: any): void;
     }
 
     interface IModalSettings {


### PR DESCRIPTION
Typescript 1.4.1 didn't like when creating a modal and setting the IModalSettings to a "plain" scope, erroring in (was working 1.2):

```
TS2345: src/client/modules/questionario.ts(124,38): TS2345: Argument of type '{ templateUrl: string; scope: IScope; }' is not assignable to parameter of type 'IModalSettings'.
    Types of property 'scope' are incompatible.     
        Type 'IScope' is not assignable to type 'IModalScope'.
```

the relevate code is: 

``` typescript
            popup(config: ng.ui.bootstrap.IModalSettings): ng.IPromise<any> {
                return this.$modal.open(config).result;
            }

// ...
                    var scope: ng.IScope = this.$scope.$new(true);
                    scope['questions'] = items.join(', ');
                    scope['singular'] = items.length === 1;

                    this.Alert.popup({
                        templateUrl: '/templates/alerta.html',
                        scope: scope
                    }).then(resolve, reject);
```

didn't know 1.4 became so picky about methods defined in interfaces
