### PR TITLE
Add support for headers as object in whatwg-fetch

### DIFF
--- a/whatwg-fetch/whatwg-fetch-tests.ts
+++ b/whatwg-fetch/whatwg-fetch-tests.ts
@@ -11,6 +11,16 @@ function test_fetchUrlWithOptions() {
 	handlePromise(window.fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions));
 }
 
+function test_fetchUrlWithHeadersObject() {
+	var requestOptions: RequestInit = {
+		method: "POST",
+		headers: {
+			'Content-Type': 'application/json'
+		}
+	};
+	handlePromise(window.fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions));
+}
+
 function test_fetchUrl() {
 	handlePromise(window.fetch("http://www.andlabs.net/html5/uCOR.php"));
 }

--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -19,7 +19,7 @@ declare class Request {
 
 interface RequestInit {
 	method?: string;
-	headers?: HeaderInit;
+	headers?: HeaderInit|{ [index: string]: string };
 	body?: BodyInit;
 	mode?: RequestMode;
 	credentials?: RequestCredentials;


### PR DESCRIPTION
The current typing supports passing headers through the Headers class,
but the spec also supports passing headers as an object mapping header
names to header values. See the [Github example](https://github.com/github/fetch#post-json).
