### PR TITLE
Update angular-file-upload.d.ts

### DIFF
--- a/angular-file-upload/angular-file-upload.d.ts
+++ b/angular-file-upload/angular-file-upload.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference path="../angularjs/angular.d.ts" />
 
-declare module angular.angularFileUpload  {
+declare module ng.angularFileUpload  {
 
     interface IUploadService {
 


### PR DESCRIPTION
Revert the change made by basarat because after this change the reference to 'IHttpPromise' and 'IHttpPromiseCallback' start to fail because these types are defined under the 'ng' module.
