### PR TITLE
Added interpolate typings for functions in svg.line/area

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1952,13 +1952,13 @@ declare module D3 {
                 /**
                 * Get the interpolation accessor.
                 */
-                (): string;
+                (): string | ((points: number[][]) => string);
                 /**
                 * Set the interpolation accessor.
                 *
                 * @param interpolate The interpolation mode
                 */
-                (interpolate: string): Line;
+                (interpolate: string | ((points: number[][]) => string)): Line;
             };
             /**
             * Get or set the cardinal spline tension.
@@ -2248,13 +2248,13 @@ declare module D3 {
                 /**
                 * Get the interpolation accessor.
                 */
-                (): string;
+                (): string | ((points: number[][]) => string);
                 /**
                 * Set the interpolation accessor.
                 *
                 * @param interpolate The interpolation mode
                 */
-                (interpolate: string): Area;
+                (interpolate: string | ((points: number[][]) => string)): Area;
             };
             /**
             * Get or set the cardinal spline tension.


### PR DESCRIPTION
Adds custom interpolation function typings to svg.line and svg.area. Used in https://github.com/palantir/plottable/pull/1793
