### PR TITLE
Add support for 'passReqToCallback' to passport-local

### DIFF
--- a/passport-local/passport-local.d.ts
+++ b/passport-local/passport-local.d.ts
@@ -13,6 +13,7 @@ declare module 'passport-local' {
     interface IStrategyOptions {
         usernameField?: string;
         passwordField?: string;
+        passReqToCallback?: boolean;
     }
 
     interface IVerifyOptions {
@@ -20,6 +21,7 @@ declare module 'passport-local' {
     }
 
     interface VerifyFunction {
+        (req: express.Request, username: string, password: string, done: (error: any, user?: any, options?: IVerifyOptions) => void): void;
         (username: string, password: string, done: (error: any, user?: any, options?: IVerifyOptions) => void): void;
     }
 


### PR DESCRIPTION
When 'passReqToCallback' is true, 'req' will be passed as the first argument to the verify callback.
