### PR TITLE
Add definition for D3 chargeDistance

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1373,7 +1373,20 @@ declare module D3 {
                 (number:number): ForceLayout;
                 (accessor: (d: any, index: number) => number): ForceLayout;
             };
-
+            /**
+             * If distance is specified, sets the maximum distance over which 
+             * charge forces are applied. If distance is not specified, returns 
+             * the current maximum charge distance, which defaults to infinity. 
+             * Specifying a finite charge distance improves the performance of 
+             * the force layout and produces a more localized layout; 
+             * distance-limited charge forces are especially useful in 
+             * conjunction with custom gravity.
+             */
+            chargeDistance: {
+                (): number;
+                (distance: number): ForceLayout;
+                (accessor: (d: any, index: number) => number): ForceLayout;
+            };
             theta: {
                 (): number;
                 (number:number): ForceLayout;


### PR DESCRIPTION
The definition for `chargeDistance` function of D3 ForceLayout is missing: [force.chargeDistance([distance])](https://github.com/mbostock/d3/wiki/Force-Layout#chargeDistance).

> #### # force.**chargeDistance**([_distance_])
> 
> If distance is specified, sets the maximum distance over which charge forces are applied. If distance is not specified, returns the current maximum charge distance, which defaults to infinity. Specifying a finite charge distance improves the performance of the force layout and produces a more localized layout; distance-limited charge forces are especially useful in conjunction with custom gravity. For an example, see “Constellations of Directors and their Stars” (The New York Times).
