### PR TITLE
Spin.js - Encapsulate code into a module

### DIFF
--- a/spin/spin-tests.ts
+++ b/spin/spin-tests.ts
@@ -1,11 +1,11 @@
 /// <reference path="spin.d.ts" />
 
-var spinner = new Spinner().spin();
+var spinner = new Spin.Spinner().spin();
 target.appendChild(spinner.el);
 
 var target = document.getElementById('foo');
 var opts = { speed: 5, color: '#abcdef' };
-var spinner2 = new Spinner(opts).spin(target);
+var spinner2 = new Spin.Spinner(opts).spin(target);
 
 var opts2 = {
     lines: 10,
@@ -27,4 +27,4 @@ var opts2 = {
 };
 
 var newTarget = document.getElementById('bar');
-var spinner3 = new Spinner(opts2).spin(newTarget);
+var spinner3 = new Spin.Spinner(opts2).spin(newTarget);

--- a/spin/spin.d.ts
+++ b/spin/spin.d.ts
@@ -3,44 +3,45 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>, Theodore Brown <https://github.com/theodorejb/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
+declare module Spin {
+    interface SpinnerOptions {
+        lines?: number; // The number of lines to draw
+        length?: number; // The length of each line
+        width?: number;  // The line thickness
+        radius?: number; // The radius of the inner circle
+        corners?: number; // Corner roundness (0..1)
+        rotate?: number; // The rotation offset
+        direction?: number; // 1: clockwise, -1: counterclockwise
+        color?: any; // #rgb or #rrggbb or array of colors
+        speed?: number; // Rounds per second
+        trail?: number; // Afterglow percentage
+        shadow?: boolean; // Whether to render a shadow
+        hwaccel?: boolean; // Whether to use hardware acceleration
+        className?: string; // The CSS class to assign to the spinner
+        zIndex?: number; // The z-index (defaults to 2000000000)
+        top?: string; // Top position relative to parent in px
+        left?: string; // Left position relative to parent in px
+    }
 
-interface SpinnerOptions {
-    lines?: number; // The number of lines to draw
-    length?: number; // The length of each line
-    width?: number;  // The line thickness
-    radius?: number; // The radius of the inner circle
-    corners?: number; // Corner roundness (0..1)
-    rotate?: number; // The rotation offset
-    direction?: number; // 1: clockwise, -1: counterclockwise
-    color?: any; // #rgb or #rrggbb or array of colors
-    speed?: number; // Rounds per second
-    trail?: number; // Afterglow percentage
-    shadow?: boolean; // Whether to render a shadow
-    hwaccel?: boolean; // Whether to use hardware acceleration
-    className?: string; // The CSS class to assign to the spinner
-    zIndex?: number; // The z-index (defaults to 2000000000)
-    top?: string; // Top position relative to parent in px
-    left?: string; // Left position relative to parent in px
-}
 
+    declare class Spinner {
+        /** The Spinner's HTML element - can be used to manually insert the spinner into the DOM  */
+        public el: HTMLElement;
+        constructor(options?: SpinnerOptions);
 
-declare class Spinner {
-    /** The Spinner's HTML element - can be used to manually insert the spinner into the DOM  */
-    public el: HTMLElement;
-    constructor(options?: SpinnerOptions);
+        /**
+         * Adds the spinner to the given target element. If this instance is already
+         * spinning, it is automatically removed from its previous target by calling
+         * stop() internally.
+         */
+        spin(target?: HTMLElement): Spinner;
 
-    /**
-     * Adds the spinner to the given target element. If this instance is already
-     * spinning, it is automatically removed from its previous target by calling
-     * stop() internally.
-     */
-    spin(target?: HTMLElement): Spinner;
-
-    /**
-     * Stops and removes the Spinner.
-     * Stopped spinners may be reused by calling spin() again.
-     */
-    stop(): Spinner;
-    lines(el:HTMLElement, o:SpinnerOptions):HTMLElement;
-    opacity(el:HTMLElement, i:number, val:number, o:SpinnerOptions):void;
+        /**
+         * Stops and removes the Spinner.
+         * Stopped spinners may be reused by calling spin() again.
+         */
+        stop(): Spinner;
+        lines(el:HTMLElement, o:SpinnerOptions):HTMLElement;
+        opacity(el:HTMLElement, i:number, val:number, o:SpinnerOptions):void;
+    }
 }

--- a/spin/spin.d.ts
+++ b/spin/spin.d.ts
@@ -24,7 +24,7 @@ declare module Spin {
     }
 
 
-    declare class Spinner {
+    class Spinner {
         /** The Spinner's HTML element - can be used to manually insert the spinner into the DOM  */
         public el: HTMLElement;
         constructor(options?: SpinnerOptions);


### PR DESCRIPTION
That code is for the library `spin.js`, so it is better to encapsulate it into a `module Spin` to avoid conflicts.
