### PR TITLE
Update chrome settings interface

### DIFF
--- a/chrome/chrome-tests.ts
+++ b/chrome/chrome-tests.ts
@@ -174,3 +174,26 @@ function catBlock () {
         // extraInfoSpec
         ["blocking"]);
 }
+
+// contrived settings example
+function proxySettings() {
+    chrome.proxy.settings.get({ incognito: false }, (details) => {
+        var val = details.value;
+        var level: string = details.levelOfControl;
+        var incognito: boolean = details.incognitoSpecific;
+    });
+
+    // bare minimum set call
+    chrome.proxy.settings.set({ value: 'something' });
+
+    // add a scope and callback
+    chrome.proxy.settings.set({
+        value: 'something',
+        scope: 'regular'
+    }, () => {});
+
+    chrome.proxy.settings.clear({});
+
+    // clear with a scope set
+    chrome.proxy.settings.clear({ scope: 'regular' });
+}

--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -2061,14 +2061,19 @@ declare module chrome.ttsEngine {
 // Types
 ////////////////////
 declare module chrome.types {
-    interface ChromeSettingSetDetails {
+    interface ChromeSettingClearDetails {
         scope?: string;
+    }
+
+    interface ChromeSettingSetDetails extends ChromeSettingClearDetails {
         value: any;
     }
 
     interface ChromeSettingGetDetails {
         incognito?: boolean;
     }
+
+    type DetailsCallback = (details: ChromeSettingGetResultDetails) => void;
 
     interface ChromeSettingGetResultDetails {
         levelOfControl: string;
@@ -2077,7 +2082,7 @@ declare module chrome.types {
     }
 
     interface ChromeSettingChangedEvent extends chrome.events.Event {
-        addListener(callback: (details: ChromeSettingGetResultDetails) => void): void;
+        addListener(callback: DetailsCallback): void;
     }
 
     interface ChromeSetting {
@@ -2086,7 +2091,8 @@ declare module chrome.types {
             callback?: Function;
         };
         set(details: ChromeSettingSetDetails, callback?: Function): void;
-        get(details: ChromeSettingGetDetails, callback?: ChromeSettingGetResultDetails): void;
+        get(details: ChromeSettingGetDetails, callback?: DetailsCallback): void;
+        clear(details: ChromeSettingClearDetails, callback?: Function): void;
         onChange: ChromeSettingChangedEvent;
     }
 }


### PR DESCRIPTION
This fixes two errors in the settings interface for chrome: the
interface was completely missing the clear method and the callback
parameter of the get method was defined as being an object instead of
a function.

This also adds a test for the settings interface.
