### PR TITLE
lodash: fix for _.mixin, so that mixins with multi-argument functions be...

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -1040,6 +1040,12 @@ _.mixin({
     }
 });
 
+_.mixin({
+    'pushAll': function <T> (dest : Array<T>, src : Array<T>[]) {
+        return dest.push.apply(dest, src);
+    }
+});
+
 var lodash = <typeof _>_.noConflict();
 
 result = <number>_.parseInt('08');

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -6220,7 +6220,7 @@ declare module _ {
         * Adds function properties of a source object to the lodash function and chainable wrapper.
         * @param object The object of function properties to add to lodash.
         **/
-        mixin(object: Dictionary<(value: any) => any>): void;
+        mixin(object: Dictionary<Function>): void;
     }
 
     //_.noConflict


### PR DESCRIPTION
As the lodash mixin method is currently defined it is not possible to mixin functions with multiple arguments. I have relaxed the type definition a bit so that all types of functions are able to mixin. 
