### PR TITLE
Add segments array to CircularInstance

### DIFF
--- a/chartjs/chart.d.ts
+++ b/chartjs/chart.d.ts
@@ -115,6 +115,7 @@ interface CircularInstance extends ChartInstance {
     update: () => void;
     addData: (valuesArray: CircularChartData[], index: number) => void;
     removeData: (index: number) => void;
+    segments: Array<CircularChartData>;
 }
 
 interface LineChartOptions extends ChartOptions {


### PR DESCRIPTION
This is needed because a circular instance are set by updating CircularIntance.segments[0].value. See update() example in the following documentation: http://www.chartjs.org/docs/#doughnut-pie-chart-prototype-methods.
