### PR TITLE
Add missing overloads to moment-timezone

### DIFF
--- a/moment-timezone/moment-timezone-tests.ts
+++ b/moment-timezone/moment-timezone-tests.ts
@@ -8,10 +8,15 @@ june.tz('America/Los_Angeles').format('ha z');
 var a = moment.tz("2013-11-18 11:55", "America/Toronto");
 var b = moment.tz("May 12th 2014 8PM", "MMM Do YYYY hA", "America/Toronto");
 var c = moment.tz(1403454068850, "America/Toronto");
+var d = moment.tz("May 12th 2014 8PM", "MMM Do YYYY hA", true, "America/Toronto");
+
+a.tz();
 
 var arr = [2013, 5, 1],
     str = "2013-12-01",
     obj = { year : 2013, month : 5, day : 1 };
+
+moment.tz("America/Los_Angeles");
 
 moment.tz(arr, "America/Los_Angeles");
 moment.tz(str, "America/Los_Angeles");

--- a/moment-timezone/moment-timezone.d.ts
+++ b/moment-timezone/moment-timezone.d.ts
@@ -7,6 +7,7 @@
 
 declare module moment {
     interface Moment {
+        tz(): string;
         tz(timezone: string): Moment;
     }
 
@@ -27,9 +28,11 @@ interface MomentZone {
 }
 
 interface MomentTimezone {
+    (timezone: string): moment.Moment;
     (date: number, timezone: string): moment.Moment;
     (date: number[], timezone: string): moment.Moment;
     (date: string, format: string, timezone: string): moment.Moment;
+    (date: string, format: string, useStrict: boolean, timezone: string): moment.Moment;
     (date: Date, timezone: string): moment.Moment;
     (date: moment.Moment, timezone: string): moment.Moment;
     (date: Object, timezone: string): moment.Moment;


### PR DESCRIPTION
- Added missing tz overloads for constructing a moment at now in a specific timezone and constructing a moment from a string using strict parsing and specific timezone.
- Added missing getter tz for getting the current timezone of a moment instance.
