### PR TITLE
Added cardinal properties to L.LatLngBounds

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -1573,6 +1573,26 @@ declare module L {
           */
         getSouthEast(): LatLng;
 
+      	/**
+          * Returns the west longitude in degrees of the bounds.
+          */
+	getWest(): number;
+
+        /**
+          * Returns the east longitude in degrees of the bounds.
+          */
+	getEast(): number;
+
+        /**
+          * Returns the north latitude in degrees of the bounds.
+          */
+	getNorth(): number;
+
+        /**
+          * Returns the south latitude in degrees of the bounds.
+          */
+	getSouth(): number;
+
         /**
           * Returns the center point of the bounds.
           */


### PR DESCRIPTION
According to the Leaflet API and documentation, there were 4 missing property methods from the Leaflet.d.ts file for the L.LatLngBounds class, which have been added.

getNorth(): number
getSouth(): number
getWest(): number
getEast(): number

http://leafletjs.com/reference.html#latlngbounds
