### PR TITLE
Rename references from deprecated 'ng' to 'angular'

### DIFF
--- a/angular-translate/angular-translate-tests.ts
+++ b/angular-translate/angular-translate-tests.ts
@@ -2,7 +2,7 @@
 
 var app = angular.module('at', ['pascalprecht.translate']);
 
-app.config(($translateProvider: ng.translate.ITranslateProvider) => {
+app.config(($translateProvider: angular.translate.ITranslateProvider) => {
     $translateProvider.translations('en', {
         TITLE: 'Hello',
         FOO: 'This is a paragraph.',
@@ -22,7 +22,7 @@ interface Scope extends ng.IScope {
     changeLanguage(key: any): void;
 }
 
-app.controller('Ctrl', ($scope: Scope, $translate: ng.translate.ITranslateService) => {
+app.controller('Ctrl', ($scope: Scope, $translate: angular.translate.ITranslateService) => {
     $scope['changeLanguage'] = function (key: any) {
         $translate.use(key);
     };

--- a/angular-translate/angular-translate.d.ts
+++ b/angular-translate/angular-translate.d.ts
@@ -33,8 +33,8 @@ declare module angular.translate {
     }
 
     interface ITranslateService {
-        (translationId: string, interpolateParams?: any, interpolationId?: string): ng.IPromise<string>;
-        (translationId: string[], interpolateParams?: any, interpolationId?: string): ng.IPromise<{ [key: string]: string }>;
+        (translationId: string, interpolateParams?: any, interpolationId?: string): angular.IPromise<string>;
+        (translationId: string[], interpolateParams?: any, interpolationId?: string): angular.IPromise<{ [key: string]: string }>;
         cloakClassName(): string;
         cloakClassName(name: string): ITranslateProvider;
         fallbackLanguage(langKey?: string): string;
@@ -44,17 +44,17 @@ declare module angular.translate {
         isPostCompilingEnabled(): boolean;
         preferredLanguage(langKey?: string): string;
         proposedLanguage(): string;
-        refresh(langKey?: string): ng.IPromise<void>;
+        refresh(langKey?: string): angular.IPromise<void>;
         storage(): IStorage;
         storageKey(): string;
         use(): string;
-        use(key: string): ng.IPromise<string>;
+        use(key: string): angular.IPromise<string>;
         useFallbackLanguage(langKey?: string): void;
         versionInfo(): string;
         loaderCache(): any;
     }
 
-    interface ITranslateProvider extends ng.IServiceProvider {
+    interface ITranslateProvider extends angular.IServiceProvider {
         translations(): ITranslationTable;
         translations(key: string, translationTable: ITranslationTable): ITranslateProvider;
         cloakClassName(): string;

--- a/angularjs/angular-resource-tests.ts
+++ b/angularjs/angular-resource-tests.ts
@@ -1,12 +1,12 @@
 /// <reference path="angular-resource.d.ts" />
 
-interface IMyResource extends ng.resource.IResource<IMyResource> { };
-interface IMyResourceClass extends ng.resource.IResourceClass<IMyResource> { };
+interface IMyResource extends angular.resource.IResource<IMyResource> { };
+interface IMyResourceClass extends angular.resource.IResourceClass<IMyResource> { };
 
 ///////////////////////////////////////
 // IActionDescriptor
 ///////////////////////////////////////
-var actionDescriptor: ng.resource.IActionDescriptor;
+var actionDescriptor: angular.resource.IActionDescriptor;
 
 actionDescriptor.headers = { header: 'value' };
 actionDescriptor.isArray = true;
@@ -19,7 +19,7 @@ actionDescriptor.params = { key: 'value' };
 ///////////////////////////////////////
 var resourceClass: IMyResourceClass;
 var resource: IMyResource;
-var resourceArray: ng.resource.IResourceArray<IMyResource>;
+var resourceArray: angular.resource.IResourceArray<IMyResource>;
 
 resource = resourceClass.delete();
 resource = resourceClass.delete({ key: 'value' });
@@ -49,7 +49,7 @@ resourceArray = resourceClass.query({ key: 'value' }, { key: 'value' });
 resourceArray = resourceClass.query({ key: 'value' }, { key: 'value' }, function () { });
 resourceArray = resourceClass.query({ key: 'value' }, { key: 'value' }, function () { }, function () { });
 resourceArray.push(resource);
-resourceArray.$promise.then(function(data: ng.resource.IResourceArray<IMyResource>) {});
+resourceArray.$promise.then(function(data: angular.resource.IResourceArray<IMyResource>) {});
 
 resource = resourceClass.remove();
 resource = resourceClass.remove({ key: 'value' });
@@ -73,8 +73,8 @@ resource = resourceClass.save({ key: 'value' }, { key: 'value' }, function () { 
 // IResource
 ///////////////////////////////////////
 
-var promise : ng.IPromise<IMyResource>;
-var arrayPromise : ng.IPromise<IMyResource[]>;
+var promise : angular.IPromise<IMyResource>;
+var arrayPromise : angular.IPromise<IMyResource[]>;
 
 promise = resource.$delete();
 promise = resource.$delete({ key: 'value' });
@@ -97,7 +97,7 @@ arrayPromise = resourceArray[0].$query({ key: 'value' }, function () { });
 arrayPromise = resourceArray[0].$query(function () { });
 arrayPromise = resourceArray[0].$query(function () { }, function () { });
 arrayPromise = resourceArray[0].$query({ key: 'value' }, function () { }, function () { });
-arrayPromise.then(function(data: ng.resource.IResourceArray<IMyResource>) {});
+arrayPromise.then(function(data: angular.resource.IResourceArray<IMyResource>) {});
 
 promise = resource.$remove();
 promise = resource.$remove({ key: 'value' });
@@ -116,7 +116,7 @@ promise = resource.$save({ key: 'value' }, function () { }, function () { });
 ///////////////////////////////////////
 // IResourceService
 ///////////////////////////////////////
-var resourceService: ng.resource.IResourceService;
+var resourceService: angular.resource.IResourceService;
 resourceClass = resourceService<IMyResource, IMyResourceClass>('test');
 resourceClass = resourceService<IMyResource>('test');
 resourceClass = resourceService('test');
@@ -125,12 +125,12 @@ resourceClass = resourceService('test');
 // IModule
 ///////////////////////////////////////
 var mod: ng.IModule;
-var resourceServiceFactoryFunction: ng.resource.IResourceServiceFactoryFunction<IMyResource>;
-var resourceService: ng.resource.IResourceService;
+var resourceServiceFactoryFunction: angular.resource.IResourceServiceFactoryFunction<IMyResource>;
+var resourceService: angular.resource.IResourceService;
 
 resourceClass = resourceServiceFactoryFunction<IMyResourceClass>(resourceService);
 
-resourceServiceFactoryFunction = function (resourceService: ng.resource.IResourceService) { return <any>resourceClass; };
+resourceServiceFactoryFunction = function (resourceService: angular.resource.IResourceService) { return <any>resourceClass; };
 mod = mod.factory('factory name', resourceServiceFactoryFunction);
 
 ///////////////////////////////////////

--- a/angularjs/angular-resource.d.ts
+++ b/angularjs/angular-resource.d.ts
@@ -104,28 +104,28 @@ declare module angular.resource {
     // Instance calls always return the the promise of the request which retrieved the object
     // https://github.com/angular/angular.js/blob/v1.2.0/src/ngResource/resource.js#L538-L546
     interface IResource<T> {
-        $get(): ng.IPromise<T>;
-        $get(params?: Object, success?: Function, error?: Function): ng.IPromise<T>;
-        $get(success: Function, error?: Function): ng.IPromise<T>;
+        $get(): angular.IPromise<T>;
+        $get(params?: Object, success?: Function, error?: Function): angular.IPromise<T>;
+        $get(success: Function, error?: Function): angular.IPromise<T>;
 
-        $query(): ng.IPromise<IResourceArray<T>>;
-        $query(params?: Object, success?: Function, error?: Function): ng.IPromise<IResourceArray<T>>;
-        $query(success: Function, error?: Function): ng.IPromise<IResourceArray<T>>;
+        $query(): angular.IPromise<IResourceArray<T>>;
+        $query(params?: Object, success?: Function, error?: Function): angular.IPromise<IResourceArray<T>>;
+        $query(success: Function, error?: Function): angular.IPromise<IResourceArray<T>>;
 
-        $save(): ng.IPromise<T>;
-        $save(params?: Object, success?: Function, error?: Function): ng.IPromise<T>;
-        $save(success: Function, error?: Function): ng.IPromise<T>;
+        $save(): angular.IPromise<T>;
+        $save(params?: Object, success?: Function, error?: Function): angular.IPromise<T>;
+        $save(success: Function, error?: Function): angular.IPromise<T>;
 
-        $remove(): ng.IPromise<T>;
-        $remove(params?: Object, success?: Function, error?: Function): ng.IPromise<T>;
-        $remove(success: Function, error?: Function): ng.IPromise<T>;
+        $remove(): angular.IPromise<T>;
+        $remove(params?: Object, success?: Function, error?: Function): angular.IPromise<T>;
+        $remove(success: Function, error?: Function): angular.IPromise<T>;
 
-        $delete(): ng.IPromise<T>;
-        $delete(params?: Object, success?: Function, error?: Function): ng.IPromise<T>;
-        $delete(success: Function, error?: Function): ng.IPromise<T>;
+        $delete(): angular.IPromise<T>;
+        $delete(params?: Object, success?: Function, error?: Function): angular.IPromise<T>;
+        $delete(success: Function, error?: Function): angular.IPromise<T>;
 
         /** the promise of the original server interaction that created this instance. **/
-        $promise : ng.IPromise<T>;
+        $promise : angular.IPromise<T>;
         $resolved : boolean;
     }
 
@@ -134,14 +134,14 @@ declare module angular.resource {
      */
     interface IResourceArray<T> extends Array<T> {
         /** the promise of the original server interaction that created this collection. **/
-        $promise : ng.IPromise<IResourceArray<T>>;
+        $promise : angular.IPromise<IResourceArray<T>>;
         $resolved : boolean;
     }
 
     /** when creating a resource factory via IModule.factory */
     interface IResourceServiceFactoryFunction<T> {
-        ($resource: ng.resource.IResourceService): IResourceClass<T>;
-        <U extends IResourceClass<T>>($resource: ng.resource.IResourceService): U;
+        ($resource: angular.resource.IResourceService): IResourceClass<T>;
+        <U extends IResourceClass<T>>($resource: angular.resource.IResourceService): U;
     }
 }
 
@@ -150,13 +150,13 @@ declare module angular {
 
     interface IModule {
         /** creating a resource service factory */
-        factory(name: string, resourceServiceFactoryFunction: ng.resource.IResourceServiceFactoryFunction<any>): IModule;
+        factory(name: string, resourceServiceFactoryFunction: angular.resource.IResourceServiceFactoryFunction<any>): IModule;
     }
 }
 
 interface Array<T>
 {
     /** the promise of the original server interaction that created this collection. **/
-    $promise : ng.IPromise<Array<T>>;
+    $promise : angular.IPromise<Array<T>>;
     $resolved : boolean;
 }

--- a/angularjs/angular-route.d.ts
+++ b/angularjs/angular-route.d.ts
@@ -63,7 +63,7 @@ declare module angular.route {
          *
          * {Array.<Object>} - route parameters extracted from the current $location.path() by applying the current route
          */
-        template?: string|{($routeParams?: ng.route.IRouteParamsService) : string;}
+        template?: string|{($routeParams?: angular.route.IRouteParamsService) : string;}
         /**
          * {string=|function()=}
          * Path or function that returns a path to an html template that should be used by ngView.
@@ -72,7 +72,7 @@ declare module angular.route {
          *
          * {Array.<Object>} - route parameters extracted from the current $location.path() by applying the current route
          */
-        templateUrl?: string|{ ($routeParams?: ng.route.IRouteParamsService): string; }
+        templateUrl?: string|{ ($routeParams?: angular.route.IRouteParamsService): string; }
         /**
          * {Object.<string, function>=} - An optional map of dependencies which should be injected into the controller. If any of these dependencies are promises, the router will wait for them all to be resolved or one to be rejected before the controller is instantiated. If all the promises are resolved successfully, the values of the resolved promises are injected and $routeChangeSuccess event is fired. If any of the promises are rejected the $routeChangeError event is fired. The map object is:
          *
@@ -91,7 +91,7 @@ declare module angular.route {
          * - {Object} - current $location.search()
          * - The custom redirectTo function is expected to return a string which will be used to update $location.path() and $location.search().
          */
-        redirectTo?: string|{($routeParams?: ng.route.IRouteParamsService, $locationPath?: string, $locationSearch?: any) : string};
+        redirectTo?: string|{($routeParams?: angular.route.IRouteParamsService, $locationPath?: string, $locationSearch?: any) : string};
         /**
          * Reload route when only $location.search() or $location.hash() changes.
          *

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -665,7 +665,7 @@ declare module angular {
     // TODO undocumented, so we need to get it from the source code
     ///////////////////////////////////////////////////////////////////////////
     interface IBrowserService {
-        defer: ng.ITimeoutService;
+        defer: angular.ITimeoutService;
         [key: string]: any;
     }
 


### PR DESCRIPTION
Updated references to _angular_ module through _ng_ variable that is deprecated.
