### PR TITLE
Fix IHttpPromiseCallbackArg.headers type

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1278,7 +1278,7 @@ declare module angular {
     interface IHttpPromiseCallbackArg<T> {
         data?: T;
         status?: number;
-        headers?: (headerName: string) => string;
+        headers?: IHttpHeadersGetter;
         config?: IRequestConfig;
         statusText?: string;
     }


### PR DESCRIPTION
This makes it possible to use `response.headers()`, not only `response.headers('foo')`. I guess this was forgotten in 0efa290c.
