### PR TITLE
Adding methods directly to Date and DateConstructor .

### DIFF
--- a/datejs/datejs-tests.ts
+++ b/datejs/datejs-tests.ts
@@ -2,19 +2,16 @@
 /// <reference path="sugarpak.d.ts" />
 
 function tests() {
-    // TypeScript alias
-    var DateJS: IDateJSStatic = <any>Date;
-
-	// What date is next thursday?
-	DateJS.today().next().thursday();
+    // What date is next thursday?
+	Date.today().next().thursday();
 
 	// Add 3 days to Today
-	DateJS.today().add(3).days();
+	Date.today().add(3).days();
 
 	// Is today Friday?
-	DateJS.today().is().friday();
+	Date.today().is().friday();
 
-    var is = DateJS.today().is();
+    var is = Date.today().is();
 
 	// Number fun
 	(3).days().ago();
@@ -24,22 +21,22 @@ function tests() {
 	n.months().fromNow();
 
 	// Set to 8:30 AM on the 15th day of the month
-	DateJS.today().set(<any>{ day: 15, hour: 8, minute: 30 });
+	Date.today().set(<any>{ day: 15, hour: 8, minute: 30 });
 
-    DateJS.today().is().january();
-    DateJS.today().is().november();
-    DateJS.today().add(1).day().is().saturday();
+    Date.today().is().january();
+    Date.today().is().november();
+    Date.today().add(1).day().is().saturday();
 
 	// Convert text into Date
-	DateJS.parse('today');
-	DateJS.parse('t + 5 d'); // today + 5 days
-	DateJS.parse('next thursday');
-	DateJS.parse('February 20th 1973');
-	DateJS.parse('Thu, 1 July 2004 22:30:00');
+	Date.parse('today');
+	Date.parse('t + 5 d'); // today + 5 days
+	Date.parse('next thursday');
+	Date.parse('February 20th 1973');
+	Date.parse('Thu, 1 July 2004 22:30:00');
 
-    var future: IDateJS = DateJS.today().add(2).months();
-    var someDate: IDateJS = DateJS.today().next().april().add(2).days();
+    var future: IDateJS = Date.today().add(2).months();
+    var someDate: IDateJS = Date.today().next().april().add(2).days();
     someDate.same().week(future); // true|false;
     someDate.same().day(); // true|false;
-    DateJS.today().toObject().day;
+    Date.today().toObject().day;
 }

--- a/datejs/datejs.d.ts
+++ b/datejs/datejs.d.ts
@@ -1,7 +1,10 @@
-// Type definitions for DateJS
+﻿// Type definitions for DateJS
 // Project: http://www.datejs.com/
 // Definitions by: David Khristepher Santos <http://github.com/rupertavery>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+//NOTE: This definition file is for the library located at http://datejs.googlecode.com/svn/ and documented at https://code.google.com/p/datejs/wiki/APIDocumentation
+//That version of the library is more recent than the one provided at https://code.google.com/p/datejs/downloads/list, which has a slightly different API
 
 /** Defines a structure to be used in the add and set instance methods */
 interface IDateJSLiteral {
@@ -15,13 +18,13 @@ interface IDateJSLiteral {
 }
 
 /** DateJS Public Static Methods */
-interface IDateJSStatic extends IDateJS {
+interface DateConstructor {
     /** Gets a date that is set to the current date. The time is set to the start of the day (00:00 or 12:00 AM) */
-    today(): IDateJS;
+    today(): Date;
     /** Compares the first date to the second date and returns an number indication of their relative values. -1 = this is lessthan date. 0 = values are equal. 1 = this is greaterthan date. */
-    compare(date1: IDateJS, date2: IDateJS): number;
+    compare(date1: Date, date2: Date): number;
     /** Compares the first Date object to the second Date object and returns true if they are equal. */
-    equals(date1: IDateJS, date2?: IDateJS): boolean;
+    equals(date1: Date, date2?: Date): boolean;
     /** Gets the day number (0-6) if given a culture-specific string which is a valid full or abbreviated day name. */
     getDayNumberFromName(dayName: string): number;
     /** Gets the month number (0-11) if given a culture-specific string which is a valid full or abbreviated month name. */
@@ -35,11 +38,11 @@ interface IDateJSStatic extends IDateJS {
     /** Gets the timezone offset if given a culture-specific string which is a valid full or abbreviated timezone name and a boolean indicating whether daylight savings time is in effect. */
     getTimezoneOffset(timezoneAbbreviation?: string, isDayLightSavingsTime?: boolean): number;
     /** Converts the specified string value into its JavaScript Date equivalent using culture-specific format information. */
-    parse(dateString: string): IDateJS;
+    parse(dateString: string): Date;
     /** Converts the specified string value into its JavaScript Date equivalent using the specified format. The format of the string value must match one of the supplied formats exactly. */
-    parseExact(dateString: string, formatString: string): IDateJS;
+    parseExact(dateString: string, formatString: string): Date;
     /** Converts the specified string value into its JavaScript Date equivalent using the specified formats (array). The format of the string value must match one of the supplied formats exactly. */
-    parseExact(dateString: string, formatArray: string[]): IDateJS;
+    parseExact(dateString: string, formatArray: string[]): Date;
     /** Validates the number is within an acceptable range for the days in a month [0-MaxDaysInMonth]. */
     validateDay(day: number, fullYear: number, monthNumber: number): boolean;
     /** Validates the number is within an acceptable range for hours[0 - 23].Returns true if within range, otherwise false. */
@@ -57,45 +60,45 @@ interface IDateJSStatic extends IDateJS {
 }
 
 /** DateJS Public Instance Methods */
-interface IDateJS extends Date {
+interface Date {
     /** Adds(or subtracts) to the value of the year, month, day, hour, minute, second, millisecond of the date instance using given configuration object. Positive and Negative values allowed. */
-    add(config?: IDateJSLiteral): IDateJS;
+    add(config?: IDateJSLiteral): Date;
     /** Adds the specified number of milliseconds to this instance. */
-    addMilliseconds(milliseconds: number): IDateJS;
+    addMilliseconds(milliseconds: number): Date;
     /** Adds the specified number of seconds to this instance given the number of seconds to add.The number can be positive or negative. */
-    addSeconds(seconds: number): IDateJS;
+    addSeconds(seconds: number): Date;
     /** Adds the specified number of minutes to this instance given the number of minutes to add.The number can be positive or negative. */
-    addMinutes(minutes: number): IDateJS;
+    addMinutes(minutes: number): Date;
     /** Adds the specified number of hours to this instance given the number of hours to add.The number can be positive or negative. */
-    addHours(hours: number): IDateJS;
+    addHours(hours: number): Date;
     /** Adds the specified number of days to this instance.The number can be positive or negative. */
-    addDays(days: number): IDateJS;
+    addDays(days: number): Date;
     /** Adds the specified number of weeks to this instance given the number of weeks to add.The number can be positive or negative. */
-    addWeeks(weeks: number): IDateJS;
+    addWeeks(weeks: number): Date;
     /** Adds the specified number of months to this instance given the number of months to add.The number can be positive or negative. */
-    addMonths(months: number): IDateJS;
+    addMonths(months: number): Date;
     /** Adds the specified number of years to this instance given the number of years to add.The number can be positive or negative. */
-    addYears(years: number): IDateJS;
+    addYears(years: number): Date;
     /** Resets the time of this Date object to 12:00 AM(00:00), which is the start of the day. */
-    clearTime(): IDateJS;
+    clearTime(): Date;
     /** Resets the time of this Date object to the current time('now'). */
-    setTimeToNow(): IDateJS;
+    setTimeToNow(): Date;
     /** Returns a new Date object that is an exact date and time copy of the original instance. */
-    clone(): IDateJS;
+    clone(): Date;
     /** Determines if this instance is between a range of two dates or equal to either the start or end dates. */
-    between(startDate: IDateJS, endDate: IDateJS): boolean;
+    between(startDate: Date, endDate: Date): boolean;
     /** Compares this instance to a Date object and returns an number indication of their relative values. -1 = this is lessthan date. 0 = values are equal. 1 = this is greaterthan date. */
-    compareTo(date: IDateJS): number;
+    compareTo(date: Date): number;
     /** Compares this instance to another Date object and returns true if they are equal, otherwise false. */
-    equals(date: IDateJS): boolean;
+    equals(date: Date): boolean;
     /** Determines if this date occurs after the date to compare to. */
-    isAfter(date: IDateJS): boolean;
+    isAfter(date: Date): boolean;
     /** Determines if this date occurs before the date to compare to. */
-    isBefore(date: IDateJS): boolean;
+    isBefore(date: Date): boolean;
     /** Determines if the current Date instance occurs on the same Date as the supplied 'date'. */
-    isToday(date: IDateJS): boolean;
+    isToday(date: Date): boolean;
     /** Returns the number of milliseconds between this date and date. */
-    getElapsed(date: IDateJS): number;
+    getElapsed(date: Date): number;
     /** Get the Ordinal day (numeric day number) of the year, adjusted for leap year. Returns 1 through 365 (366 in leap years) */
     getOrdinalNumber(): number;
     /** Get the timezone abbreviation of the current date. */
@@ -107,30 +110,35 @@ interface IDateJS extends Date {
     /** Get the ISO 8601 week number. Week one ("01") is the week which contains the first Thursday of the year. Monday is considered the first day of the week. */
     getISOWeek(): string;
     /** Moves the date to Monday of the week set. Week one (1) is the week which contains the first Thursday of the year. */
-    setWeek(week: number): IDateJS;
+    setWeek(week: number): Date;
     /** Indicates whether Daylight Saving Time is observed in the current time zone. */
     hasDaylightSavingTime(): boolean;
     /** Indicates whether this Date instance is within the Daylight Saving Time range for the current time zone. */
     isDaylightSavingTime(): boolean;
-    /** Move to the next or previous dayOfWeek. Whether to move into the future (+1) or past(-1) is controlled by the optional direction parameter. */
-    moveToDayOfWeek(dayOfWeek: number, direction: number): IDateJS;
+	/** Move to the next or previous dayOfWeek. Whether to move into the future (+1) or past(-1) is controlled by the optional direction parameter. */
+    moveToDayOfWeek(dayOfWeek: number, direction: number): Date;
     /** Moves the date to the first day of the month. */
-    moveToFirstDayOfMonth(): IDateJS;
+    moveToFirstDayOfMonth(): Date;
     /** Moves the date to the last day of the month. */
-    moveToLastDayOfMonth(): IDateJS;
+    moveToLastDayOfMonth(): Date;
     /** Move to the next or previous month.Whether to move into the future(+1) or past(-1) is controlled by the optional direction parameter. */
-    moveToMonth(month: number, direction: number): IDateJS;
+    moveToMonth(month: number, direction: number): Date;
     /** Moves the date to the next nth occurrence of the dayOfWeek starting from the beginning of the month. The number (-1) is a magic number and will return the last occurrence of the dayOfWeek in the month. */
-    moveToNthOccurrence(dayOfWeek: number, occurrence: number): IDateJS;
+    moveToNthOccurrence(dayOfWeek: number, occurrence: number): Date;
     /** Set the value of year, month, day, hour, minute, second, millisecond of date instance using given configuration object. */
-    set(config: IDateJSLiteral): IDateJS;
+    set(config: IDateJSLiteral): Date;
     /** Set the timezone for the current date using a culture - specific timezone abbreviation("PST").Note that in most JavaScript implementations, this will appear to change the time since the timezone is always based on the locale. */
-    setTimezone(timezoneAbbreviation: string): IDateJS;
+    setTimezone(timezoneAbbreviation: string): Date;
     /** Set the timezone for the current date using an offset(-0700).Note that in most JavaScript implementations, this will appear to change the time since the timezone is always based on the locale. */
-    setTimezoneOffset(timezoneOffset: number): IDateJS;
+    setTimezoneOffset(timezoneOffset: number): Date;
     /** Converts the current date instance into a string with an ISO 8601 format.The date is converted to it's UTC value. As per the ISO 8601 specification, the string will be wrapped with double quotation marks ("). */
     toISOString(): string;
     /** Converts the value of the current Date object to its equivalent string representation.Use format argument to specify format(optional).See FormatSpecifiers for more info. */
     toString(format?: string): string;
 }
 
+
+//NOTE: IDateJSStatic and IDateJS are provided here solely for backwards compatability with previous versions of this particular definition file (datejs.d.ts.)
+//DO NOT use them in new code (and it is strongly suggested you remove their use in any existing code); simply use the Javascript Date class instead.
+interface IDateJS extends Date { }
+interface IDateJSStatic extends DateConstructor { }

--- a/datejs/sugarpak.d.ts
+++ b/datejs/sugarpak.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for DateJS - SugarPak Extensions
+﻿// Type definitions for DateJS - SugarPak Extensions
 // Project: http://www.datejs.com/
 // Definitions by: David Khristepher Santos <http://github.com/rupertavery>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -7,67 +7,67 @@
 declare module sugarpak {
 
     export interface IAddOrientation {
-        millisecond(): IDateJS;
-        second(): IDateJS;
-        minute(): IDateJS;
-        hour(): IDateJS;
-        day(): IDateJS;
-        week(): IDateJS;
-        month(): IDateJS;
-        year(): IDateJS;
+        millisecond(): Date;
+        second(): Date;
+        minute(): Date;
+        hour(): Date;
+        day(): Date;
+        week(): Date;
+        month(): Date;
+        year(): Date;
 
-        milliseconds(): IDateJS;
-        seconds(): IDateJS;
-        minutes(): IDateJS;
-        hours(): IDateJS;
-        days(): IDateJS;
-        weeks(): IDateJS;
-        months(): IDateJS;
-        years(): IDateJS;
+        milliseconds(): Date;
+        seconds(): Date;
+        minutes(): Date;
+        hours(): Date;
+        days(): Date;
+        weeks(): Date;
+        months(): Date;
+        years(): Date;
     }
 
     export interface IOrientation extends IAddOrientation {
-        monday(): IDateJS;
-        tuesday(): IDateJS;
-        wednesday(): IDateJS;
-        thursday(): IDateJS;
-        friday(): IDateJS;
-        saturday(): IDateJS;
-        sunday(): IDateJS;
+        monday(): Date;
+        tuesday(): Date;
+        wednesday(): Date;
+        thursday(): Date;
+        friday(): Date;
+        saturday(): Date;
+        sunday(): Date;
 
-        mon(): IDateJS;
-        tue(): IDateJS;
-        wed(): IDateJS;
-        thu(): IDateJS;
-        fri(): IDateJS;
-        sat(): IDateJS;
-        sun(): IDateJS;
+        mon(): Date;
+        tue(): Date;
+        wed(): Date;
+        thu(): Date;
+        fri(): Date;
+        sat(): Date;
+        sun(): Date;
 
-        january(): IDateJS;
-        february(): IDateJS;
-        march(): IDateJS;
-        april(): IDateJS;
-        may(): IDateJS;
-        june(): IDateJS;
-        july(): IDateJS;
-        august(): IDateJS;
-        september(): IDateJS;
-        october(): IDateJS;
-        november(): IDateJS;
-        december(): IDateJS;
+        january(): Date;
+        february(): Date;
+        march(): Date;
+        april(): Date;
+        may(): Date;
+        june(): Date;
+        july(): Date;
+        august(): Date;
+        september(): Date;
+        october(): Date;
+        november(): Date;
+        december(): Date;
 
-        jan(): IDateJS;
-        feb(): IDateJS;
-        mar(): IDateJS;
-        apr(): IDateJS;
+        jan(): Date;
+        feb(): Date;
+        mar(): Date;
+        apr(): Date;
         // may 
-        jun(): IDateJS;
-        jul(): IDateJS;
-        aug(): IDateJS;
-        sep(): IDateJS;
-        oct(): IDateJS;
-        nov(): IDateJS;
-        dec(): IDateJS;
+        jun(): Date;
+        jul(): Date;
+        aug(): Date;
+        sep(): Date;
+        oct(): Date;
+        nov(): Date;
+        dec(): Date;
     }
 
     export interface IPredicate {
@@ -116,30 +116,30 @@ declare module sugarpak {
 
         weekday(): boolean;
 
-        day(date?: IDateJS): boolean;
-        week(date?: IDateJS): boolean;
-        month(date?: IDateJS): boolean;
-        year(date?: IDateJS): boolean;
+        day(date?: Date): boolean;
+        week(date?: Date): boolean;
+        month(date?: Date): boolean;
+        year(date?: Date): boolean;
 
 
     }
 
     export interface IDatePartComparer {
-        millisecond(date?: IDateJS): boolean;
-        second(date?: IDateJS): boolean;
-        minute(date?: IDateJS): boolean;
-        hour(date?: IDateJS): boolean;
-        day(date?: IDateJS): boolean;
-        week(date?: IDateJS): boolean;
-        month(date?: IDateJS): boolean;
-        year(date?: IDateJS): boolean;
+        millisecond(date?: Date): boolean;
+        second(date?: Date): boolean;
+        minute(date?: Date): boolean;
+        hour(date?: Date): boolean;
+        day(date?: Date): boolean;
+        week(date?: Date): boolean;
+        month(date?: Date): boolean;
+        year(date?: Date): boolean;
     }
 
     export interface IDateElementEvaluator {
-        ago(): IDateJS;
-        before(): IDateJS;
-        fromNow(): IDateJS;
-        after(): IDateJS;
+        ago(): Date;
+        before(): Date;
+        fromNow(): Date;
+        after(): Date;
     }
 
     export interface IDateElement {
@@ -178,10 +178,10 @@ declare module sugarpak {
 
 }
 
-interface IDateJS {
+interface Date {
     add(n: number): sugarpak.IAddOrientation;
-    at(time: string): IDateJS;
-    at(time: sugarpak.ITimeLiteral): IDateJS;
+    at(time: string): Date;
+    at(time: sugarpak.ITimeLiteral): Date;
     is(): sugarpak.IPredicate;
     next(): sugarpak.IOrientation;
     last(): sugarpak.IOrientation;
@@ -199,7 +199,7 @@ interface IDateJS {
     toObject(): sugarpak.IDateLiteral;
 }
 
-interface IDateJSStatic {
+interface DateConstructor {
     /** Contains the day-of-week value for Monday */
     MONDAY: number;
     /** Contains the day-of-week value for Tuesday */
@@ -215,57 +215,57 @@ interface IDateJSStatic {
     /** Contains the day-of-week value for Sunday */
     SUNDAY: number;
     /** Instantiates a DateJS object from a literal */
-    fromObject(date: sugarpak.IDateLiteral): IDateJS;
+    fromObject(date: sugarpak.IDateLiteral): Date;
 
     next(): sugarpak.IOrientation;
     last(): sugarpak.IOrientation;
     prev(): sugarpak.IOrientation;
     previous(): sugarpak.IOrientation;
 
-    january(): IDateJS;
-    february(): IDateJS;
-    march(): IDateJS;
-    april(): IDateJS;
-    may(): IDateJS;
-    june(): IDateJS;
-    july(): IDateJS;
-    august(): IDateJS;
-    september(): IDateJS;
-    october(): IDateJS;
-    november(): IDateJS;
-    december(): IDateJS;
+    january(): Date;
+    february(): Date;
+    march(): Date;
+    april(): Date;
+    may(): Date;
+    june(): Date;
+    july(): Date;
+    august(): Date;
+    september(): Date;
+    october(): Date;
+    november(): Date;
+    december(): Date;
 
-    monday(): IDateJS;
-    tuesday(): IDateJS;
-    wednesday(): IDateJS;
-    thursday(): IDateJS;
-    friday(): IDateJS;
-    saturday(): IDateJS;
-    sunday(): IDateJS;
+    monday(): Date;
+    tuesday(): Date;
+    wednesday(): Date;
+    thursday(): Date;
+    friday(): Date;
+    saturday(): Date;
+    sunday(): Date;
 
-    mon(): IDateJS;
-    tue(): IDateJS;
-    wed(): IDateJS;
-    thu(): IDateJS;
-    fri(): IDateJS;
-    sat(): IDateJS;
-    sun(): IDateJS;
+    mon(): Date;
+    tue(): Date;
+    wed(): Date;
+    thu(): Date;
+    fri(): Date;
+    sat(): Date;
+    sun(): Date;
 
-    jan(): IDateJS;
-    feb(): IDateJS;
-    mar(): IDateJS;
-    apr(): IDateJS;
+    jan(): Date;
+    feb(): Date;
+    mar(): Date;
+    apr(): Date;
     // may 
-    jun(): IDateJS;
-    jul(): IDateJS;
-    aug(): IDateJS;
-    sep(): IDateJS;
-    oct(): IDateJS;
-    nov(): IDateJS;
-    dec(): IDateJS;
+    jun(): Date;
+    jul(): Date;
+    aug(): Date;
+    sep(): Date;
+    oct(): Date;
+    nov(): Date;
+    dec(): Date;
 
 }
 
 interface Number extends sugarpak.IDateElement {
-    // extend the Number type with all the IDateJS goodness
+    // extend the Number type with all the Date goodness
 }


### PR DESCRIPTION
Adding methods directly to Date and DateConstructor as opposed to creating separate interfaces, reflecting DateJs's direct modification of Date.Prototype and Date, respectively. This allows you to call methods like Date.today() without casting Date to IDateJSStatic, for example (see difference in test file). I reluctantly left in IDateJS and IDateJSStatic so that existing code that uses this definition file will not break, though (for some strange reason) IDateJSStatic used to extend IDateJS, so it is not _totally_ backwards compatible (I have made IDateJSStatic extend DateConstructor, and IDateJS extend Date). That being said, it is trivial to change code that currently uses those interfaces to instead use Date and DateConstructor as appropriate. 
