### PR TITLE
yargs: make 2nd parameter of version() optional

### DIFF
--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -155,3 +155,14 @@ function Argv$showHelp() {
 		.usage("$0 -operand1 number -operand2 number -operation [add|subtract]");
 	yargs1.showHelp();
 }
+
+function Argv$version() {
+	var argv1 = yargs
+		.version('1.0.0');
+
+	var argv2 = yargs
+		.version('1.0.0', '--version');
+
+	var argv3 = yargs
+		.version('1.0.0', '--version', 'description');
+}

--- a/yargs/yargs.d.ts
+++ b/yargs/yargs.d.ts
@@ -74,7 +74,7 @@ declare module "yargs" {
 			help(): string;
 			help(option: string, description?: string): Argv;
 
-			version(version: string, option: string, description?: string): Argv;
+			version(version: string, option?: string, description?: string): Argv;
 
 			showHelpOnFail(enable: boolean, message?: string): Argv;
 


### PR DESCRIPTION
The `option` parameter is optional, not required. See [yargs.version(version, [option], [description])](https://github.com/bcoe/yargs#versionversion-option-description).
