### PR TITLE
broser-sync: The baseDir parameter also ca be set multiple directories

### DIFF
--- a/browser-sync/browser-sync-tests.ts
+++ b/browser-sync/browser-sync-tests.ts
@@ -7,6 +7,13 @@ browserSync({
     }
 });
 
+// multiple base directory
+browserSync({
+    server: {
+        baseDir: ["app", "dist"]
+    }
+});
+
 browserSync({
     proxy: "yourlocal.dev"
 });

--- a/browser-sync/browser-sync.d.ts
+++ b/browser-sync/browser-sync.d.ts
@@ -65,7 +65,7 @@ declare module "browser-sync" {
         }
         
         interface ServerOptions {
-            baseDir?: string;
+            baseDir?: string | string[];
             directory?: boolean;
             index?: string;
             routes?: {[path: string]: string};


### PR DESCRIPTION
The baseDir parameter also ca be set multiple directories.
