### PR TITLE
NodeJs exec function optional callback parameter

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -679,8 +679,8 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
-    export function exec(command: string, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    export function exec(command: string, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
     export function execFile(file: string,
         callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
     export function execFile(file: string, args?: string[],


### PR DESCRIPTION
NodeJs exec function optional callback parameter #4141 
## Update demand :

callback args is called when process terminates, is possible to use events child.stdout.on to receive data before end of process.

callback? must be optional in exec function.

``` js
export function exec(command: string, options: {
        cwd?: string;
        stdio?: any;
        customFds?: any;
        env?: any;
        encoding?: string;
        timeout?: number;
        maxBuffer?: number;
        killSignal?: string;
    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;

    export function exec(command: string, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;

```
## Use case :

``` js

var exec = child_process.exec;
var child = exec('node -v');

child.stdout.on('data', function (data) {
         console.log('node -v', date, { value: data });
});

child.on('close', function (code) {
         console.log('closing code: ' + code);
});

```
