### PR TITLE
Fixed typing for async.times.

### DIFF
--- a/async/async-tests.ts
+++ b/async/async-tests.ts
@@ -320,6 +320,10 @@ async.nextTick(function () {
 });
 call_order.push('one');
 
+async.times(4, function (n, callback) { });
+
+async.times(4, function (n, callback) { }, function (err, results) { });
+
 var slow_fn = function (name, callback) {
     callback(null, 123);
 };

--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -9,7 +9,7 @@ interface ErrorCallback { (err?: Error): void; }
 interface AsyncResultCallback<T> { (err: Error, result: T): void; }
 interface AsyncResultArrayCallback<T> { (err: Error, results: T[]): void; }
 interface AsyncResultObjectCallback<T> { (err: Error, results: Dictionary<T>): void; }
-interface AsyncTimesCallback<T> { (n: number, callback: AsyncResultArrayCallback<T>): void; }
+interface AsyncTimesCallback<T> { (n: number, callback: AsyncResultCallback<T>): void; }
 
 interface AsyncIterator<T> { (item: T, callback: ErrorCallback): void; }
 interface AsyncResultIterator<T, R> { (item: T, callback: AsyncResultCallback<R>): void; }
@@ -105,8 +105,8 @@ interface Async {
     apply(fn: Function, ...arguments: any[]): AsyncFunction<any>;
     nextTick(callback: Function): void;
 
-    times<T> (n: number, callback: AsyncTimesCallback<T>): void;
-    timesSeries<T> (n: number, callback: AsyncTimesCallback<T>): void;
+    times<T> (n: number, iterator: AsyncTimesCallback<T>, callback?: AsyncResultArrayCallback<T>): void;
+    timesSeries<T> (n: number, iterator: AsyncTimesCallback<T>, callback?: AsyncResultArrayCallback<T>): void;
 
     // Utils
     memoize(fn: Function, hasher?: Function): Function;


### PR DESCRIPTION
This makes it possible to use async.times(n, iterator, callback), not only async.times(n, iterator).
Also fix the wrong typing for async.times's iterator.
