### PR TITLE
lodash: add _.sum

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -39,6 +39,10 @@ interface IKey {
     code: number;
 }
 
+interface IDictionary<T> {
+    [index: string]: T;
+}
+
 var foodsOrganic: IFoodOrganic[] = [
     { name: 'banana', organic: true },
     { name: 'beet', organic: false },
@@ -61,7 +65,10 @@ var stoogesAges: IStoogesAge[] = [
     { 'name': 'moe', 'age': 40 },
     { 'name': 'larry', 'age': 50 }
 ];
-
+var stoogesAgesDict: IDictionary<IStoogesAge> = {
+    first: { 'name': 'moe', 'age': 40 },
+    second: { 'name': 'larry', 'age': 50 }
+};
 var stoogesCombined: IStoogesCombined[] = [
     { 'name': 'curly', 'age': 30, 'quotes': ['Oh, a wise guy, eh?', 'Poifect!'] },
     { 'name': 'moe', 'age': 40, 'quotes': ['Spread out!', 'You knucklehead!'] }
@@ -500,6 +507,23 @@ result = <IStoogesAge>_.min(stoogesAges, 'age');
 result = <_.LoDashWrapper<number>>_([4, 2, 8, 6]).min();
 result = <_.LoDashWrapper<IStoogesAge>>_(stoogesAges).min(function (stooge) { return stooge.age; });
 result = <_.LoDashWrapper<IStoogesAge>>_(stoogesAges).min('age');
+
+result = <number>_.sum([4, 2, 8, 6]);
+result = <number>_.sum([4, 2, 8, 6], function(v) { return v; });
+result = <number>_.sum({a: 2, b: 4});
+result = <number>_.sum({a: 2, b: 4}, function(v) { return v; });
+result = <number>_.sum(stoogesAges, function (stooge) { return stooge.age; });
+result = <number>_.sum(stoogesAges, 'age');
+result = <number>_.sum(stoogesAgesDict, function(stooge) { return stooge.age; });
+result = <number>_.sum(stoogesAgesDict, 'age');
+result = <number>_([4, 2, 8, 6]).sum();
+result = <number>_([4, 2, 8, 6]).sum(function(v) { return v; });
+result = <number>_({a: 2, b: 4}).sum();
+result = <number>_({a: 2, b: 4}).sum(function(v) { return v; });
+result = <number>_(stoogesAges).sum(function (stooge) { return stooge.age; });
+result = <number>_(stoogesAges).sum('age');
+result = <number>_(stoogesAgesDict).sum(function (stooge) { return stooge.age; });
+result = <number>_(stoogesAgesDict).sum('age');
 
 result = <string[]>_.pluck(stoogesAges, 'name');
 result = <string[]>_(stoogesAges).pluck('name').value();

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -41,6 +41,7 @@ declare module _ {
         (value: number): LoDashWrapper<number>;
         (value: string): LoDashWrapper<string>;
         (value: boolean): LoDashWrapper<boolean>;
+        (value: Array<number>): LoDashNumberArrayWrapper;
         <T>(value: Array<T>): LoDashArrayWrapper<T>;
         <T extends {}>(value: T): LoDashObjectWrapper<T>;
         (value: any): LoDashWrapper<any>;
@@ -204,6 +205,8 @@ declare module _ {
         splice(start: number, deleteCount: number, ...items: any[]): LoDashArrayWrapper<T>;
         unshift(...items: any[]): LoDashWrapper<number>;
     }
+
+    interface LoDashNumberArrayWrapper extends LoDashArrayWrapper<number> { }
 
     //_.chain
     interface LoDashStatic {
@@ -3917,12 +3920,21 @@ declare module _ {
             property: string): number;
     }
     
-    interface LoDashArrayWrapper<T> {
+    interface LoDashNumberArrayWrapper {
         /**
         * @see _.sum
         **/
         sum(): number
 
+        /**
+        * @see _.sum
+        **/
+        sum(
+            iteratee: ListIterator<number, number>,
+            thisArg?: any): number;
+    }
+
+    interface LoDashArrayWrapper<T> {
         /**
         * @see _.sum
         **/

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -3842,6 +3842,122 @@ declare module _ {
         min<W>(
             whereValue: W): LoDashWrapper<T>;
     }
+    
+    //_.sum
+    interface LoDashStatic {
+        /**
+        * Gets the sum of the values in collection.
+        *
+        * @param collection The collection to iterate over.
+        * @param iteratee The function invoked per iteration.
+        * @param thisArg The this binding of iteratee.
+        * @return Returns the sum.
+        **/
+        sum(
+            collection: Array<number>): number;
+            
+        /**
+        * @see _.sum
+        **/
+        sum(
+            collection: List<number>): number;
+            
+        /**
+        * @see _.sum
+        **/
+        sum(
+            collection: Dictionary<number>): number;
+            
+        /**
+        * @see _.sum
+        **/
+        sum<T>(
+            collection: Array<T>,
+            iteratee: ListIterator<T, number>,
+            thisArg?: any): number;
+
+        /**
+        * @see _.sum
+        **/
+        sum<T>(
+            collection: List<T>,
+            iteratee: ListIterator<T, number>,
+            thisArg?: any): number;
+
+        /**
+        * @see _.sum
+        **/
+        sum<T>(
+            collection: Dictionary<T>,
+            iteratee: ObjectIterator<T, number>,
+            thisArg?: any): number;
+
+        /**
+        * @see _.sum
+        * @param property _.property callback shorthand.
+        **/
+        sum<T>(
+            collection: Array<T>,
+            property: string): number;
+
+        /**
+        * @see _.sum
+        * @param property _.property callback shorthand.
+        **/
+        sum<T>(
+            collection: List<T>,
+            property: string): number;
+
+        /**
+        * @see _.sum
+        * @param property _.property callback shorthand.
+        **/
+        sum<T>(
+            collection: Dictionary<T>,
+            property: string): number;
+    }
+    
+    interface LoDashArrayWrapper<T> {
+        /**
+        * @see _.sum
+        **/
+        sum(): number
+
+        /**
+        * @see _.sum
+        **/
+        sum(
+            iteratee: ListIterator<T, number>,
+            thisArg?: any): number;
+
+        /**
+        * @see _.sum
+        * @param property _.property callback shorthand.
+        **/
+        sum(
+            property: string): number;
+    }
+    
+    interface LoDashObjectWrapper<T> {
+        /**
+        * @see _.sum
+        **/
+        sum(): number
+    
+        /**
+        * @see _.sum
+        **/
+        sum(
+            iteratee: ObjectIterator<any, number>,
+            thisArg?: any): number;
+
+        /**
+        * @see _.sum
+        * @param property _.property callback shorthand.
+        **/
+        sum(
+            property: string): number;
+    }
 
     //_.pluck
     interface LoDashStatic {


### PR DESCRIPTION
This adds a definition for the [_.sum](https://lodash.com/docs#sum) function.
There are two things I'm not happy about in this pull request:

---

In this test line:

``` typescript
result = <number>_([4, 2, 8, 6]).sum();
```

If we replace `2` by `'abc'` it still compiles without error. It would be better to enforce that the array is an array of numbers.

---

In this test line:

``` typescript
result = <number>_(stoogesAgesDict).sum(function (stooge) { return stooge.age; });
```

If we replace `stooge.age` by a bogus property like `stooge.xyz` it still compiles without error.

---

Both issues are made more complicated by the lodash wrapping. In the second case, I believe the cause is that when we wrap `stoogesAgesDict` (of type `Dictionary<IStoogesAge>`) by calling `_(stoogesAgesDict)`, the type information for the values of `stoogesAgesDict` is lost and the anonymous function is called with `stooge: any` instead of `stooge: IStoogeAge`.

I'm still relatively new at TypeScript and might have missed the solution for the two issues above. It'd be great if someone could have a second look. :)
