### PR TITLE
Adding typings for oauth.js

### DIFF
--- a/oauth.js/oauth.js-tests.ts
+++ b/oauth.js/oauth.js-tests.ts
@@ -1,0 +1,95 @@
+/// <reference path=".\oauth.js.d.ts" />
+
+var encoded1: string = OAuth.percentEncode("abcあいう");
+var encoded2: string = OAuth.percentEncode(["abc", "あいう"]);
+var decoded1: string = OAuth.decodePercent("abc%E3%81%82%E3%81%84%E3%81%86");
+
+var list: OAuth.ParameterList;
+list = OAuth.getParameterList([["name1", "value1"], ["name2", "value2"]]);
+list = OAuth.getParameterList({ name1: "value1", name2: "value2" });
+list = OAuth.getParameterList("name1=value1&name2=value2");
+
+var map: OAuth.ParameterMap;
+map = OAuth.getParameterMap([["name1", "value1"], ["name2", "value2"]]);
+map = OAuth.getParameterMap({ name1: "value1", name2: "value2" });
+map = OAuth.getParameterMap("name1=value1&name2=value2");
+
+var param: string;
+param = OAuth.getParameter([["name1", "value1"], ["name2", "value2"]], "name1");
+param = OAuth.getParameter({ name1: "value1", name2: "value2" }, "name1");
+param = OAuth.getParameter("name1=value1&name2=value2", "name1");
+
+var formEncoded1: string = OAuth.formEncode([["name1", "value1"], ["name2", "value2"]]);
+var formEncoded2: string = OAuth.formEncode({ name1: "value1", name2: "value2" });
+
+var formDecoded1: OAuth.ParameterList = OAuth.decodeForm("name1=value1&name2=value2");
+
+var message1: OAuth.Message = { action: "http://example.org/", method: "GET", parameters: [] };
+OAuth.setParameter(message1, "name1", "value1");
+var message2: OAuth.Message = { action: "http://example.org/", method: "GET", parameters: {} };
+OAuth.setParameter(message2, "name1", "value1");
+
+var message3: OAuth.Message = { action: "http://example.org/", method: "GET", parameters: [] };
+OAuth.setParameters(message3, [["name1", "value1"], ["name2", "value2"]]);
+OAuth.setParameters(message3, { name3: "value3", name4: "value4" });
+OAuth.setParameters(message3, "name5=value5&name6=value6");
+var message4: OAuth.Message = { action: "http://example.org/", method: "GET", parameters: {} };
+OAuth.setParameters(message4, [["name1", "value1"], ["name2", "value2"]]);
+OAuth.setParameters(message4, { name3: "value3", name4: "value4" });
+OAuth.setParameters(message4, "name5=value5&name6=value6");
+
+var accessor: OAuth.Accessor = { consumerKey: "ck", consumerSecret: "cs", token: "t", tokenSecret: "ts" };
+var message5: OAuth.Message = { action: "http://example.org/", method: "GET", parameters: [["name1", "value1"]] };
+OAuth.completeRequest(message5, accessor);
+var message6: OAuth.Message = { action: "http://example.org/", method: "GET", parameters: { name1: "value1" } };
+OAuth.completeRequest(message6, accessor);
+
+var message7: OAuth.Message = { action: "http://example.org/", method: "GET", parameters: [["name1", "value1"]] };
+OAuth.setTimestampAndNonce(message7);
+var message8: OAuth.Message = { action: "http://example.org/", method: "GET", parameters: { name1: "value1" } };
+OAuth.setTimestampAndNonce(message8);
+
+var url1: string = OAuth.addToURL("http://example.org/", [["name1", "value1"]]);
+var url2: string = OAuth.addToURL("http://example.org/?name1=value1", [["name1", "value1"]]);
+var url3: string = OAuth.addToURL("http://example.org/", { name1: "value1" });
+var url4: string = OAuth.addToURL("http://example.org/?name1=value1", { name1: "value1" });
+
+var authorizationHeader1: string = OAuth.getAuthorizationHeader("realm", [["name1", "value1"], ["oauth_param1", "oauth_value1"]]);
+var authorizationHeader2: string = OAuth.getAuthorizationHeader("realm", { name1: "value1", oauth_param1: "oauth_value1" });
+var authorizationHeader3: string = OAuth.getAuthorizationHeader("realm", "name1=value1&oauth_param1=oauth_value1");
+
+OAuth.correctTimestampFromSrc();
+OAuth.correctTimestampFromSrc("timestamp_param_name");
+
+OAuth.correctTimestamp((new Date()).getTime() / 1000);
+
+var timeCorrectionMsec: number = OAuth.timeCorrectionMsec;
+
+var timestamp: number = OAuth.timestamp();
+
+var nonce: string = OAuth.nonce(16);
+
+
+var message9: OAuth.Message = { method: "GET", action: "http://example.org/1", parameters: [] };
+var baseString: string = OAuth.SignatureMethod.getBaseString(message9);
+
+var normalizedUrl: string = OAuth.SignatureMethod.normalizeUrl("http://example.org:80/2");
+
+var uri: OAuth.Uri = OAuth.SignatureMethod.parseUri("http://example.org:80/3?name1=value1&name2=value2");
+
+var normalizedParameters1: string = OAuth.SignatureMethod.normalizeParameters([["name1", "value1"], ["name2", "value2"]]);
+var normalizedParameters2: string = OAuth.SignatureMethod.normalizeParameters({ name1: "value1", name2: "value2" });
+
+var message10: OAuth.Message = { action: "http://example.org/", method: "GET", parameters: [["name1", "value1"]] };
+OAuth.SignatureMethod.sign(message9, accessor);
+
+var signatureMethodConstructor: { new (): OAuth.SignatureMethod; } =
+        OAuth.SignatureMethod.makeSubclass(function getSignature(baseString) { return this.key });
+OAuth.SignatureMethod.registerMethodClass(["PLAINTEXT"], signatureMethodConstructor);
+
+var signatureMethod1: OAuth.SignatureMethod = OAuth.SignatureMethod.newMethod("PLAINTEXT", accessor);
+var message11: OAuth.Message = { action: "http://example.org/", method: "GET", parameters: [["name1", "value1"]] };
+var signature: string = signatureMethod1.sign(message11);
+var signatureMethod2: OAuth.SignatureMethod = new signatureMethodConstructor();
+signatureMethod2.initialize("PLAINTEXT", accessor);
+

--- a/oauth.js/oauth.js-tests.ts
+++ b/oauth.js/oauth.js-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path=".\oauth.js.d.ts" />
+/// <reference path="oauth.js.d.ts" />
 
 var encoded1: string = OAuth.percentEncode("abcあいう");
 var encoded2: string = OAuth.percentEncode(["abc", "あいう"]);

--- a/oauth.js/oauth.js.d.ts
+++ b/oauth.js/oauth.js.d.ts
@@ -1,0 +1,197 @@
+// Type definitions for JavaScript software for implementing an OAuth consumer
+// Project: https://code.google.com/p/oauth/
+// Definitions by: NOBUOKA Yu <https://github.com/nobuoka>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module OAuth {
+
+    /** An Array of name-value pairs [[name, value], [name2, value2]]. */
+    type ParameterList = [string, string][];
+
+    /** A map {name: value, name2: value2}. */
+    type ParameterMap = { [name: string]: string; };
+
+    type ParameterListOrMap = ParameterList|ParameterMap;
+    
+    /**
+     * An OAuth message is represented as an object like this:
+     *   { method: "GET", action: "http://server.com/path", parameters: ... }
+     */
+    interface Message {
+        action: string;
+        method: string;
+        parameters: ParameterListOrMap;
+    }
+
+    /**
+     * SignatureMethod expects an accessor object to be like this:
+     *   {tokenSecret: "lakjsdflkj...", consumerSecret: "QOUEWRI..", accessorSecret: "xcmvzc..."}
+     * The accessorSecret property is optional.
+     */
+    interface Accessor {
+        consumerKey: string;
+        consumerSecret: string;
+        accessorSecret?: string;
+        token: string;
+        tokenSecret: string;
+    }
+
+    /**
+     * Encode text value according to OAuth Percent Encoding.
+     * @see {@link https://tools.ietf.org/html/rfc5849#section-3.6}
+     * @param s Target text value.
+     */
+    function percentEncode(s: string): string;
+    
+    /**
+     * Encode text values according to OAuth Percent Encoding.
+     * Encoded values are joined with an ampersand character (&) in between them.
+     * @see {@link https://tools.ietf.org/html/rfc5849#section-3.6}
+     * @param s Target text values.
+     */
+    function percentEncode(s: string[]): string;
+    
+    /**
+     * Decode percent-encoded value.
+     * @see {@link https://tools.ietf.org/html/rfc5849#section-3.6}
+     * @param s Target percent-encoded value.
+     */
+    function decodePercent(s: string): string;
+
+    /**
+     * Convert the given parameters to an Array of name-value pairs.
+     */
+    function getParameterList(parameters: ParameterListOrMap): ParameterList;
+
+    /**
+     * Convert the given parameters to an Array of name-value pairs.
+     */
+    function getParameterList(parameters: string): ParameterList;
+
+    /**
+     * Convert the given parameters to a map from name to value.
+     */
+    function getParameterMap(parameters: ParameterListOrMap): ParameterMap;
+
+    /**
+     * Convert the given parameters to a map from name to value.
+     */
+    function getParameterMap(parameters: string): ParameterMap;
+
+    function getParameter(parameters: ParameterListOrMap, name: string): string;
+    function getParameter(parameters: string, name: string): string;
+
+    function formEncode(parameters: ParameterListOrMap): string;
+
+    function decodeForm(form: string): ParameterList;
+
+    function setParameter(message: Message, name: string, value: string): void;
+
+    function setParameters(message: Message, parameters: ParameterListOrMap): void;
+    function setParameters(message: Message, parameters: string): void;
+    
+    /**
+     * Fill in parameters to help construct a request message.
+     * This function doesn't fill in every parameter.
+     * @param message Target request message.
+     * @param accessor Accessor object. The accessorSecret property is optional.
+     */
+    function completeRequest(message: Message, accessor: Accessor): void;
+
+    function setTimestampAndNonce(message: Message): void;
+
+    /**
+     * Add specified parameters into URL as query parameters.
+     * @param url URL that parameters added into.
+     * @param parameters Parameters added into URL.
+     * @return New URL string.
+     */
+    function addToURL(url: string, parameters: ParameterListOrMap): string;
+
+    /** Construct the value of the Authorization header for an HTTP request. */
+    function getAuthorizationHeader(realm: string, parameters: ParameterListOrMap): string;
+    function getAuthorizationHeader(realm: string, parameters: string): string;
+    
+    /** Correct the time using a parameter from the URL from which the last script was loaded. */
+    function correctTimestampFromSrc(parameterName?: string): void;
+
+    /** Generate timestamps starting with the given value. */
+    function correctTimestamp(timestamp: number): void;
+    
+    /** The difference between the correct time and my clock. */
+    var timeCorrectionMsec: number;
+
+    function timestamp(): number;
+
+    function nonce(length: number): string;
+
+    interface Uri {
+        source: string;
+        protocol: string;
+        authority: string;
+        userInfo: string;
+        user: string;
+        password: string;
+        host: string;
+        port: string;
+        relative: string;
+        path: string;
+        directory: string;
+        file: string;
+        query: string;
+        anchor: string;
+    }
+
+    interface SignatureMethodStatic {
+        sign(message: Message, accessor: Accessor): void;
+
+        /** Instantiate a SignatureMethod for the given method name. */
+        newMethod(name: string, accessor: Accessor): SignatureMethod;
+
+        /** A map from signature method name to constructor. */
+        REGISTERED: { [name: string]: { new (): SignatureMethod }; };
+
+        /**
+         * Subsequently, the given constructor will be used for the named methods.
+         * The constructor will be called with no parameters.
+         * The resulting object should usually implement getSignature(baseString).
+         * You can easily define such a constructor by calling makeSubclass method.
+         */
+        registerMethodClass(names: string[], classConstructor: { new(): SignatureMethod }): void;
+
+        /**
+         * Create a subclass of OAuth.SignatureMethod, with the given getSignature function.
+         * @param getSignatureFunction 
+         */
+        makeSubclass(getSignatureFunction: (baseString: string) => string): { new(): SignatureMethod };
+
+        /**
+         * Generate a signature base string from a Message object.
+         * @see {@link https://tools.ietf.org/html/rfc5849#section-3.4.1}
+         * @param message Source of the signature base string.
+         */
+        getBaseString(message: Message): string;
+
+        normalizeUrl(url: string): string;
+
+        parseUri(str: string): Uri;
+
+        normalizeParameters(parameters: [string, string][]|{ [key: string]: string; }): string;
+    }
+
+    interface SignatureMethod {
+        getSignature(baseString: string): string;
+
+        key: string;
+
+        /** Add a signature to the message. */
+        sign(message: Message): string;
+
+        /** Set the key string for signing. */
+        initialize(name: string, accessor: Accessor): void;
+    }
+
+    var SignatureMethod: SignatureMethodStatic;
+
+}
+

--- a/oauth.js/oauth.js.d.ts
+++ b/oauth.js/oauth.js.d.ts
@@ -176,7 +176,7 @@ declare module OAuth {
 
         parseUri(str: string): Uri;
 
-        normalizeParameters(parameters: [string, string][]|{ [key: string]: string; }): string;
+        normalizeParameters(parameters: ParameterListOrMap): string;
     }
 
     interface SignatureMethod {


### PR DESCRIPTION
I wrote a type definition file for JavaScript software for implementing an OAuth consumer.
- Target library : http://oauth.googlecode.com/svn/code/javascript/
- Project page : https://code.google.com/p/oauth/

This library is not published to npm or bower. Therefore I named it “oauth.js”, which doesn't shadow an existing npm name.

> If the library is not published on npm use a new identifier, as long as it doesn't shadow an existing npm name.
