### PR TITLE
Pass query parameters as an object

### DIFF
--- a/chai-http/chai-http-tests.ts
+++ b/chai-http/chai-http-tests.ts
@@ -41,8 +41,7 @@ chai.request(app)
 
 chai.request(app)
 	.get('/search')
-	.query('name', 'foo')
-	.query('limit', '10');
+	.query({name: 'foo', limit: 10});
 
 chai.request(app)
 	.put('/user/me')

--- a/chai-http/chai-http.d.ts
+++ b/chai-http/chai-http.d.ts
@@ -41,7 +41,7 @@ declare module chaiHttp {
 		attach(field: string, file: string, filename: string): Request;
 		attach(field: string, file: Buffer, filename: string): Request;
 		set(field: string, val: string): Request;
-		query(key: string, value: string): Request;
+		query(params: Object): Request;
 		send(data: Object): Request;
 		auth(user: string, name: string): Request;
 		field(name: string, val: string): Request;


### PR DESCRIPTION
Query parameters should now be passed as an object instead of key/value pairs, see https://github.com/chaijs/chai-http/pull/33 for details
