### PR TITLE
PlayerOptions width and height should be strings, adds Player.destroy()

### DIFF
--- a/youtube/youtube.d.ts
+++ b/youtube/youtube.d.ts
@@ -50,8 +50,8 @@ declare module YT {
     }
 
     export interface PlayerOptions {
-        width?: number;
-        height?: number;
+        width?: string;
+        height?: string;
         videoId?: string;
         playerVars?: PlayerVars;
         events?: Events;
@@ -147,6 +147,9 @@ declare module YT {
 
         // Event Listener
         addEventListener(event: string, handler: EventHandler): void;
+        
+        // DOM
+        destroy(): void;
     }
 
     export enum PlayerState {

--- a/youtube/youtube.d.ts
+++ b/youtube/youtube.d.ts
@@ -50,8 +50,8 @@ declare module YT {
     }
 
     export interface PlayerOptions {
-        width?: string;
-        height?: string;
+        width?: string | number;
+        height?: string | number;
         videoId?: string;
         playerVars?: PlayerVars;
         events?: Events;


### PR DESCRIPTION
Per https://developers.google.com/youtube/iframe_api_reference PlayerOptions can be other than numbers, in fact in the API reference are created as strings even though they are specified as numbers: '100%' works.

Also adds the Player.destroy() method, which removes the iframe from the DOM.
