### PR TITLE
feat(sequelize): add belongsToMany definition

### DIFF
--- a/sequelize/sequelize-tests.ts
+++ b/sequelize/sequelize-tests.ts
@@ -101,6 +101,8 @@ model.belongsTo<modelInst, modelPojo>(model);
 model.belongsTo<modelInst, modelPojo>(model, assocOpts);
 model.hasMany<modelInst, modelPojo>(model);
 model.hasMany<modelInst, modelPojo>(model, assocOpts);
+model.belongsToMany<modelInst, modelPojo>(model);
+model.belongsToMany<modelInst, modelPojo>(model, assocOpts);
 
 promiseMe = model.sync();
 promiseMe = model.drop(dropOpts);

--- a/sequelize/sequelize.d.ts
+++ b/sequelize/sequelize.d.ts
@@ -910,6 +910,14 @@ declare module "sequelize"
             belongsTo<TInstance, TPojo>(target: Model<TInstance, TPojo>, options?: AssociationOptions): void;
 
             /**
+             * Creates an association to connect sources with multiple targets. Furthermore the targets can also have connections to multiple sources.
+             *
+             * @param target
+             * @param options
+             */
+            belongsToMany<TInstance, TPojo>(target: Model<TInstance, TPojo>, options?: AssociationOptions): void;
+
+            /**
              * Create an association that is either 1:m or n:m.
              *
              * @param target


### PR DESCRIPTION
Added absent `belongsToMany`

[docs](http://sequelize.readthedocs.org/en/latest/docs/associations/#belongs-to-many-associations)
[github/sequelize](https://github.com/sequelize/sequelize/blob/master/lib/associations/belongs-to-many.js)
