### PR TITLE
"parent" argument of Restangular.service() should be optional

### DIFF
--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -93,7 +93,7 @@ declare module restangular {
     withConfig(configurer: (RestangularProvider: IProvider) => any): IService;
     restangularizeElement(parent: any, element: any, route: string, collection?: any, reqParams?: any): IElement;
     restangularizeCollection(parent: any, element: any, route: string): ICollection;
-    service(route: string, parent: any): IService;
+    service(route: string, parent?: any): IService;
     stripRestangular(element: any): any;
   }
 


### PR DESCRIPTION
The documentation as well as the actual source code of Restangular
define the parent argument of Restangular.service(route, parent) as
optional:

https://github.com/mgonto/restangular#decoupled-restangular-service

function toService(route, parent) {
[...]
var collection = (parent || service).all(route);
