### PR TITLE
ICollectionPromise<T> should extend ng.IPromise with an array of T

### DIFF
--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -15,7 +15,7 @@ declare module restangular {
     $object: T;
 }
 
-  interface ICollectionPromise<T> extends ng.IPromise<T> {
+  interface ICollectionPromise<T> extends ng.IPromise<T[]> {
     push(object: any): ICollectionPromise<T>;
     call(methodName: string, params?: any): ICollectionPromise<T>;
     get(fieldName: string): ICollectionPromise<T>;

--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -114,6 +114,7 @@ declare module restangular {
     patch(queryParams?: any, headers?: any): IPromise<any>;
     clone(): IElement;
     plain(): any;
+	plain<T>(): T;
     withHttpConfig(httpConfig: IRequestConfig): IElement;
     save(queryParams?: any, headers?: any): IPromise<any>;
     getRestangularUrl(): string;
@@ -130,6 +131,9 @@ declare module restangular {
     patch(queryParams?: any, headers?: any): IPromise<any>;
     putElement(idx: any, params: any, headers: any): IPromise<any>;
     withHttpConfig(httpConfig: IRequestConfig): ICollection;
+	clone(): ICollection;
+    plain(): any;
+	plain<T>(): T[];
     getRestangularUrl(): string;
   }
 }


### PR DESCRIPTION
ICollectionPromise<T> extends ng.IPromise<T> is the equivalent of
interface IPromise<T> extends ng.IPromise<T> for arrays of T. Therefore
it makes no sense to extend ng.IPromise with just T. Instead it has to
be an array of T.

The consequence of this bug can be observed when calling

Restangular.all('someEntity').getList<SomeEntity>().then((entities) =>
{...})

In this case the TypeScript compiler handles entities as SomeEntity, not
SomeEntity[].
