### PR TITLE
socket.io: Add "in" method to SocketIO.Namespace, "handshake" property to SocketIO.Socket

### DIFF
--- a/socket.io/socket.io.d.ts
+++ b/socket.io/socket.io.d.ts
@@ -59,6 +59,17 @@ declare module SocketIO {
         conn: any;
         request: any;
         id: string;
+        handshake: {
+            headers: any;
+            time: string;
+            address: any;
+            xdomain: boolean;
+            secure: boolean;
+            issued: number;
+            url: string;
+            query: any;
+        };
+
         emit(name: string, ...args: any[]): Socket;
         join(name: string, fn?: Function): Socket;
         leave(name: string, fn?: Function): Socket;

--- a/socket.io/socket.io.d.ts
+++ b/socket.io/socket.io.d.ts
@@ -46,6 +46,7 @@ declare module SocketIO {
         name: string;
         connected: { [id: string]: Socket };
         use(fn: Function): Namespace;
+        in(room: string): Namespace;
 
         on(event: 'connection', listener: (socket: Socket) => void): Namespace;
         on(event: 'connect', listener: (socket: Socket) => void): Namespace;


### PR DESCRIPTION
This should be valid:

```
import * as sio from "socket.io";
let io = sio("");
let nsp = io.of("myNamespace");
nsp.in("someRoom").emit("...");
```

But the current definition is lacking the `in` method on `SocketIO.Namespace` so I added it.

Also added [`SocketIO.Socket.handshake`](https://github.com/Automattic/socket.io/blob/3f72dd3322bcefff07b5976ab817766e421d237b/lib/socket.js#L107) which is [not currently documented on the website](https://github.com/Automattic/socket.io-website/issues/21).
