### PR TITLE
Add overload for http.Server.listen

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -340,6 +340,7 @@ declare module "http" {
 
     export interface Server extends events.EventEmitter {
         listen(port: number, hostname?: string, backlog?: number, callback?: Function): Server;
+        listen(port: number, hostname?: string, callback?: Function): Server;
         listen(path: string, callback?: Function): Server;
         listen(handle: any, listeningListener?: Function): Server;
         close(cb?: any): Server;


### PR DESCRIPTION
The backlog parameter should be optional while still accepting the port parameter.

The following program should be valid:

```
var http = require("http");
http.createServer().listen(80, "", function() { console.log("Server started!"); });
```

This pull request adds the missing overload.

The [official documentation](https://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback) shows that the various optional parameters are independent of one another: 

```
server.listen(port[, hostname][, backlog][, callback])
```

Otherwise it would be:

```
server.listen(port[, hostname][, backlog[, callback]])
```
