### PR TITLE
Fix vinyl-fs defs

### DIFF
--- a/vinyl-fs/vinyl-fs.d.ts
+++ b/vinyl-fs/vinyl-fs.d.ts
@@ -8,24 +8,20 @@
 
 declare module NodeJS {
 	interface WritableStream {
-		write(buffer: any/* Vinyl.IFile */, cb?: Function): boolean;
+		write(buffer: any/* Vinyl.File */, cb?: Function): boolean;
 	}
 }
 
 declare module "vinyl-fs" {
 	import _events = require("events");
+	import File = require("vinyl");
 
-	function src(globs:string, opt?:{read?:boolean;buffer?:boolean;}):NodeJS.ReadWriteStream;
+	function src(globs:string|string[], opt?:{read?:boolean;buffer?:boolean;}):NodeJS.ReadWriteStream;
 
-	function src(globs:string[], opt?:{read?:boolean;buffer?:boolean;}):NodeJS.ReadWriteStream;
+	function watch(globs:string|string[], cb?:(outEvt:{type:any;path:any;old:any;})=>void):_events.EventEmitter;
 
-	function watch(globs:string, cb?:(outEvt:{type:any;path:any;old:any;})=>void):_events.EventEmitter;
+	function watch(globs:string|string[], opt?:{interval?:number;debounceDelay?:number;cwd?:string;maxListeners?:Function;}, cb?:(outEvt:{type:any;path:any;old:any;})=>void):_events.EventEmitter;
 
-	function watch(globs:string[], cb?:(outEvt:{type:any;path:any;old:any;})=>void):_events.EventEmitter;
-
-	function watch(globs:string, opt?:{interval?:number;debounceDelay?:number;cwd?:string;maxListeners?:Function;}, cb?:(outEvt:{type:any;path:any;old:any;})=>void):_events.EventEmitter;
-
-	function watch(globs:string[], opt?:{interval?:number;debounceDelay?:number;cwd?:string;maxListeners?:Function;}, cb?:(outEvt:{type:any;path:any;old:any;})=>void):_events.EventEmitter;
-
-	function dest(folder:string, opt?:{cwd?:string; mode?:any/* number or string */;}):NodeJS.ReadWriteStream;
+	function dest(folder: string, opt?: { cwd?: string; mode?: number|string; }): NodeJS.ReadWriteStream;
+	function dest(getFolderPath: (file: File) => string): NodeJS.ReadWriteStream;
 }


### PR DESCRIPTION
Introduces union types and an additional `getFolderPath` function that can be supplied to the `.dest()` method. This is an undocumented feature, but [it exists](https://github.com/wearefractal/vinyl-fs/blob/master/lib/prepareWrite.js#L19-L25) and it is very useful!
