### PR TITLE
gruntjs: Fixed type of IExpandedFilesConfig.cwd

### DIFF
--- a/gruntjs/gruntjs-tests.ts
+++ b/gruntjs/gruntjs-tests.ts
@@ -68,7 +68,17 @@ exports = (grunt: IGrunt) => {
     asyncedTwoArgs(2, "values", (result: string) => {
         console.log(result);
     });
-    var fileMaps = grunt.file.expandMapping([''], '', { ext: '.js' });
+
+    // tests for module grunt.file
+    var expandedFilesConfig: grunt.file.IExpandedFilesConfig = {
+        expand: true,
+        cwd: 'src',
+        src: ['**/*.ts'],
+        dest: 'build',
+        ext: '.js',
+        flatten: false
+    };
+    var fileMaps = grunt.file.expandMapping([''], '', expandedFilesConfig);
     fileMaps.length;
     fileMaps[0].src.length;
     fileMaps[0].dest;

--- a/gruntjs/gruntjs.d.ts
+++ b/gruntjs/gruntjs.d.ts
@@ -604,7 +604,7 @@ declare module grunt {
             /**
              * All {@link IExpandedFilesConfig.src} matches are relative to (but don't include) this path.
              */
-            cwd?: boolean
+            cwd?: string
 
             /**
              * Replace any existing extension with this value in generated {@link IExpandedFilesConfig.dest} paths.


### PR DESCRIPTION
Changed type of IExpandedFilesConfig.cwd from boolean to string. Added
simple test for interface IExpandedFilesConfig as well.

fixes #4207
