### PR TITLE
Added type bindings for QTip2

### DIFF
--- a/qtip2/qtip2-tests.ts
+++ b/qtip2/qtip2-tests.ts
@@ -77,11 +77,11 @@ function testContentText() {
 
 	// Shorthand function
 	$a.qtip({
-		content: function(event, api) {	}
+		content: function(event: Event, api: QTip2.Api) {	}
 	});
 
 	$a.qtip({
-		content: function(event) { return 2; }
+		content: function(event: Event) { return 2; }
 	});
 
 	$a.qtip({
@@ -90,11 +90,11 @@ function testContentText() {
 
 	// Regular function
 	$a.qtip({
-		content: { text: function(event, api) {	} }
+		content: { text: function(event: Event, api: QTip2.Api) {} }
 	});
 
 	$a.qtip({
-		content: { text: function(event) { return 2; } }
+		content: { text: function(event: Event) { return 2; } }
 	});
 
 	$a.qtip({
@@ -161,11 +161,11 @@ function testContentTitle() {
 
 	// Shorthand function
 	$a.qtip({
-		content: { title: function(event, api) {} }
+		content: { title: function(event: Event, api: QTip2.Api) {} }
 	});
 
 	$a.qtip({
-		content: { title: function(event) { return 2; } }
+		content: { title: function(event: Event) { return 2; } }
 	});
 
 	$a.qtip({
@@ -174,11 +174,11 @@ function testContentTitle() {
 
 	// Regular function
 	$a.qtip({
-		content: { title: { text: function(event, api) { } } }
+		content: { title: { text: function(event: Event, api: QTip2.Api) { } } }
 	});
 
 	$a.qtip({
-		content: { title: { text: function(event) { return 2; } } }
+		content: { title: { text: function(event: Event) { return 2; } } }
 	});
 
 	$a.qtip({
@@ -240,7 +240,7 @@ function testPositionProperty() {
 			at: 'bottom right',
 			container: $('.edwin-odesseiron'),
 			viewport: $('.dynaheir'),
-			effect: function(api, pos, viewport) { },
+			effect: function(api: QTip2.Api, pos: any, viewport: any) { },
 			adjust: { x: 2 }
 		}
 	});
@@ -252,7 +252,7 @@ function testPositionProperty() {
 			at: true,
 			container: false,
 			viewport: true,
-			effect: function(api, pos) { return 2; },
+			effect: function(api: QTip2.Api, pos: any) { return 2; },
 			adjust: { y: 2 }
 		}
 	});
@@ -260,7 +260,7 @@ function testPositionProperty() {
 	$a.qtip({
 		position: {
 			target: 'mouse',
-			effect: function(api) {},
+			effect: function(api: QTip2.Api) {},
 			adjust: { x: 2, y: 2 }
 		}
 	});
@@ -534,4 +534,518 @@ function allTogetherNow() {
 			blur: null
 		}
 	});
+}
+
+
+/**
+ * http://qtip2.com/api#api-methods.get
+ */
+function testApiGetViaObject() {
+	$a.qtip({});
+
+	var api = $a.qtip('api');
+
+	<string | boolean> api.get('id');
+	<boolean> api.get('prerender');
+	<boolean> api.get('overwrite');
+	<boolean> api.get('suppress');
+	<any> api.get('metadata');
+
+	<QTip2.Content> api.get('content');
+	<QTip2.Text> api.get('content.text');
+	<string> api.get('content.attr');
+	<QTip2.Title> api.get('content.title');
+	<string | JQuery | boolean> api.get('content.button');
+
+	<QTip2.Position> api.get('position');
+	<string | boolean> api.get('position.my');
+	<string | boolean> api.get('position.at');
+	<QTip2.Target | boolean> api.get('position.target');
+	<JQuery | boolean> api.get('position.container');
+	<JQuery | boolean> api.get('position.viewport');
+	<boolean | ((api: any, pos: any, viewport: any) => any)>
+		api.get('position.effect');
+	<QTip2.PositionAdjust> api.get('position.adjust');
+
+	<QTip2.Show> api.get('show');
+	<JQuery | boolean> api.get('show.target');
+	<string | boolean> api.get('show.event');
+	<number> api.get('show.delay');
+	<JQuery | string | boolean> api.get('show.solo');
+	<boolean> api.get('show.ready');
+	<boolean | ((offset: any) => any)> api.get('show.effect');
+	<boolean | QTip2.Modal> api.get('show.modal');
+
+	<QTip2.Hide> api.get('hide');
+	<JQuery | boolean> api.get('hide.target');
+	<string | boolean> api.get('hide.event');
+	<number> api.get('hide.delay');
+	<string | boolean> api.get('hide.leave');
+	<number | boolean> api.get('hide.distance');
+	<boolean | ((offset: any) => any)> api.get('hide.effect');
+
+	<QTip2.Style> api.get('style');
+	<string | boolean> api.get('style.classes');
+	<boolean> api.get('style.def');
+	<boolean> api.get('style.widget');
+	<string | number | boolean> api.get('style.width');
+	<string | number | boolean> api.get('style.height');
+	<string | boolean | QTip2.Tip> api.get('style.tip');
+
+	<QTip2.Events> api.get('events');
+	<QTip2.EventApiFunc> api.get('events.render');
+	<QTip2.EventApiFunc> api.get('events.show');
+	<QTip2.EventApiFunc> api.get('events.hide');
+	<QTip2.EventApiFunc> api.get('events.toggle');
+	<QTip2.EventApiFunc> api.get('events.visible');
+	<QTip2.EventApiFunc> api.get('events.hidde');
+	<QTip2.EventApiFunc> api.get('events.move');
+	<QTip2.EventApiFunc> api.get('events.focus');
+	<QTip2.EventApiFunc> api.get('events.blur');
+}
+
+
+/**
+ * http://qtip2.com/api#api.updating
+ */
+function testApiGetViaString() {
+	$a.qtip({});
+
+	<string | boolean> $a.qtip('option', 'id');
+	<boolean> $a.qtip('option', 'prerender');
+	<boolean> $a.qtip('option', 'overwrite');
+	<boolean> $a.qtip('option', 'suppress');
+	<any> $a.qtip('option', 'metadata');
+
+	<QTip2.Content> $a.qtip('option', 'content');
+	<QTip2.Text> $a.qtip('option', 'content.text');
+	<string> $a.qtip('option', 'content.attr');
+	<QTip2.Title> $a.qtip('option', 'content.title');
+	<string | JQuery | boolean> $a.qtip('option', 'content.button');
+
+	<QTip2.Position> $a.qtip('option', 'position');
+	<string | boolean> $a.qtip('option', 'position.my');
+	<string | boolean> $a.qtip('option', 'position.at');
+	<QTip2.Target | boolean> $a.qtip('option', 'position.target');
+	<JQuery | boolean> $a.qtip('option', 'position.container');
+	<JQuery | boolean> $a.qtip('option', 'position.viewport');
+	<boolean | ((api: any, pos: any, viewport: any) => any)>
+		$a.qtip('option', 'position.effect');
+	<QTip2.PositionAdjust> $a.qtip('option', 'position.adjust');
+
+	<QTip2.Show> $a.qtip('option', 'show');
+	<JQuery | boolean> $a.qtip('option', 'show.target');
+	<string | boolean> $a.qtip('option', 'show.event');
+	<number> $a.qtip('option', 'show.delay');
+	<JQuery | string | boolean> $a.qtip('option', 'show.solo');
+	<boolean> $a.qtip('option', 'show.ready');
+	<boolean | ((offset: any) => any)> $a.qtip('option', 'show.effect');
+	<boolean | QTip2.Modal> $a.qtip('option', 'show.modal');
+
+	<QTip2.Hide> $a.qtip('option', 'hide');
+	<JQuery | boolean> $a.qtip('option', 'hide.target');
+	<string | boolean> $a.qtip('option', 'hide.event');
+	<number> $a.qtip('option', 'hide.delay');
+	<string | boolean> $a.qtip('option', 'hide.leave');
+	<number | boolean> $a.qtip('option', 'hide.distance');
+	<boolean | ((offset: any) => any)> $a.qtip('option', 'hide.effect');
+
+	<QTip2.Style> $a.qtip('option', 'style');
+	<string | boolean> $a.qtip('option', 'style.classes');
+	<boolean> $a.qtip('option', 'style.def');
+	<boolean> $a.qtip('option', 'style.widget');
+	<string | number | boolean> $a.qtip('option', 'style.width');
+	<string | number | boolean> $a.qtip('option', 'style.height');
+	<string | boolean | QTip2.Tip> $a.qtip('option', 'style.tip');
+
+	<QTip2.Events> $a.qtip('option', 'events');
+	<QTip2.EventApiFunc> $a.qtip('option', 'events.render');
+	<QTip2.EventApiFunc> $a.qtip('option', 'events.show');
+	<QTip2.EventApiFunc> $a.qtip('option', 'events.hide');
+	<QTip2.EventApiFunc> $a.qtip('option', 'events.toggle');
+	<QTip2.EventApiFunc> $a.qtip('option', 'events.visible');
+	<QTip2.EventApiFunc> $a.qtip('option', 'events.hidde');
+	<QTip2.EventApiFunc> $a.qtip('option', 'events.move');
+	<QTip2.EventApiFunc> $a.qtip('option', 'events.focus');
+	<QTip2.EventApiFunc> $a.qtip('option', 'events.blur');
+}
+
+
+/**
+ * http://qtip2.com/api#api-methods.set
+ */
+function testApiSetViaObject() {
+
+	// TODO
+	$a.qtip({});
+
+	var api = $a.qtip('api');
+
+	<QTip2.Api> api.set({
+		prerender: false,
+		id: false,
+		overwrite: true,
+		suppress: true,
+		content: {
+			title: true,
+			attr: 'title',
+			text: false,
+			button: false
+		},
+		position: {
+			my: 'top left',
+			at: 'bottom right',
+			target: false,
+			container: false,
+			viewport: false,
+			adjust: {
+				x: 0, y: 0,
+				mouse: true,
+				resize: true,
+				method: 'flip flip'
+			},
+			effect: function(api, pos, viewport) {
+				$(this).animate(pos, {
+					duration: 200,
+					queue: false
+				});
+			}
+		},
+		show: {
+			target: false,
+			event: 'mouseenter',
+			effect: true,
+			delay: 90,
+			solo: false,
+			ready: false,
+			modal: {
+				on: false,
+				effect: true,
+				blur: true,
+				escape: true
+			}
+		},
+		hide: {
+			target: false,
+			event: 'mouseleave',
+			effect: true,
+			delay: 0,
+			fixed: false,
+			inactive: false,
+			leave: 'window',
+			distance: false
+		},
+		style: {
+			classes: '',
+			widget: false,
+			width: false,
+			height: false,
+			tip: {
+				corner: true,
+				mimic: false,
+				width: 8,
+				height: 8,
+				border: true,
+				offset: 0
+			}
+		},
+		events: {
+			render: null,
+			move: null,
+			show: null,
+			hide: null,
+			toggle: null,
+			visible: null,
+			hidden: null,
+			focus: null,
+			blur: null
+		}
+	});
+
+	<QTip2.Api> api.set('id', <string | boolean> null);
+	<QTip2.Api> api.set('prerender', <boolean> null);
+	<QTip2.Api> api.set('overwrite', <boolean> null);
+	<QTip2.Api> api.set('suppress', <boolean> null);
+	<QTip2.Api> api.set('metadata', <any> null);
+
+	<QTip2.Api> api.set('content', <QTip2.Text | QTip2.Content> null);
+	<QTip2.Api> api.set('content.title', <QTip2.Title | { text: QTip2.Title }> null);
+	<QTip2.Api> api.set('content.text', <QTip2.Text> null);
+	<QTip2.Api> api.set('content.attr', <string> null);
+	<QTip2.Api> api.set('content.button', <string | JQuery | boolean> null);
+
+	<QTip2.Api> api.set('position', <string | QTip2.Position> null);
+	<QTip2.Api> api.set('position.my', <string | boolean> null);
+	<QTip2.Api> api.set('position.at', <string | boolean> null);
+	<QTip2.Api> api.set('position.target', <QTip2.Target | boolean> null);
+	<QTip2.Api> api.set('position.container', <JQuery | boolean> null);
+	<QTip2.Api> api.set('position.viewport', <JQuery | boolean> null);
+	<QTip2.Api> api.set('position.effect', <boolean | ((api: QTip2.Api, pos: any, viewport: any) => void)> null);
+	<QTip2.Api> api.set('position.adjust', <QTip2.PositionAdjust> null);
+
+	<QTip2.Api> api.set('show', <QTip2.Show> null);
+	<QTip2.Api> api.set('show.target', <JQuery | boolean> null);
+	<QTip2.Api> api.set('show.event', <string | boolean> null);
+	<QTip2.Api> api.set('show.delay', <number> null);
+	<QTip2.Api> api.set('show.solo', <JQuery | string | boolean> null);
+	<QTip2.Api> api.set('show.ready', <boolean> null);
+	<QTip2.Api> api.set('show.effect', <boolean | ((offset: any) => void)> null);
+	<QTip2.Api> api.set('show.modal', <boolean | QTip2.Modal> null);
+
+	<QTip2.Api> api.set('hide', <QTip2.Hide> null);
+	<QTip2.Api> api.set('hide.target', <JQuery | boolean> null);
+	<QTip2.Api> api.set('hide.event', <string | boolean> null);
+	<QTip2.Api> api.set('hide.inactive', <number | boolean> null);
+	<QTip2.Api> api.set('hide.fixed', <boolean> null);
+	<QTip2.Api> api.set('hide.leave', <string | boolean> null);
+	<QTip2.Api> api.set('hide.distance', <number | boolean> null);
+	<QTip2.Api> api.set('hide.effect', <boolean | ((offset: any) => void)> null);
+
+	<QTip2.Api> api.set('style', <QTip2.Style> null);
+	<QTip2.Api> api.set('style.classes', <string | boolean> null);
+	<QTip2.Api> api.set('style.def', <boolean> null);
+	<QTip2.Api> api.set('style.widget', <boolean> null);
+	<QTip2.Api> api.set('style.width', <string | number | boolean> null);
+	<QTip2.Api> api.set('style.height', <string | number | boolean> null);
+	<QTip2.Api> api.set('style.tip', <string | boolean | QTip2.Tip> null);
+
+	<QTip2.Api> api.set('events', <QTip2.Events> null);
+	<QTip2.Api> api.set('events.render', <QTip2.EventApiFunc> null);
+	<QTip2.Api> api.set('events.show', <QTip2.EventApiFunc> null);
+	<QTip2.Api> api.set('events.hide', <QTip2.EventApiFunc> null);
+	<QTip2.Api> api.set('events.toggle', <QTip2.EventApiFunc> null);
+	<QTip2.Api> api.set('events.visible', <QTip2.EventApiFunc> null);
+	<QTip2.Api> api.set('events.hidden', <QTip2.EventApiFunc> null);
+	<QTip2.Api> api.set('events.move', <QTip2.EventApiFunc> null);
+	<QTip2.Api> api.set('events.focus', <QTip2.EventApiFunc> null);
+	<QTip2.Api> api.set('events.blur', <QTip2.EventApiFunc> null);
+}
+
+
+/**
+ * http://qtip2.com/api#api.updating
+ */
+function testApiSetViaString() {
+	$a.qtip({});
+
+	<QTip2.Api> $a.qtip('option', {
+		prerender: false,
+		id: false,
+		overwrite: true,
+		suppress: true,
+		content: {
+			title: true,
+			attr: 'title',
+			text: false,
+			button: false
+		},
+		position: {
+			my: 'top left',
+			at: 'bottom right',
+			target: false,
+			container: false,
+			viewport: false,
+			adjust: {
+				x: 0, y: 0,
+				mouse: true,
+				resize: true,
+				method: 'flip flip'
+			},
+			effect: function(api: QTip2.Api, pos: any, viewport: any) {
+				$(this).animate(pos, {
+					duration: 200,
+					queue: false
+				});
+			}
+		},
+		show: {
+			target: false,
+			event: 'mouseenter',
+			effect: true,
+			delay: 90,
+			solo: false,
+			ready: false,
+			modal: {
+				on: false,
+				effect: true,
+				blur: true,
+				escape: true
+			}
+		},
+		hide: {
+			target: false,
+			event: 'mouseleave',
+			effect: true,
+			delay: 0,
+			fixed: false,
+			inactive: false,
+			leave: 'window',
+			distance: false
+		},
+		style: {
+			classes: '',
+			widget: false,
+			width: false,
+			height: false,
+			tip: {
+				corner: true,
+				mimic: false,
+				width: 8,
+				height: 8,
+				border: true,
+				offset: 0
+			}
+		},
+		events: {
+			render: null,
+			move: null,
+			show: null,
+			hide: null,
+			toggle: null,
+			visible: null,
+			hidden: null,
+			focus: null,
+			blur: null
+		}
+	});
+
+	<QTip2.Api> $a.qtip('option', 'id', <string | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'prerender', <boolean> null);
+	<QTip2.Api> $a.qtip('option', 'overwrite', <boolean> null);
+	<QTip2.Api> $a.qtip('option', 'suppress', <boolean> null);
+	<QTip2.Api> $a.qtip('option', 'metadata', <any> null);
+
+	<QTip2.Api> $a.qtip('option', 'content', <QTip2.Text | QTip2.Content> null);
+	<QTip2.Api> $a.qtip('option', 'content.title', <QTip2.Title | { text: QTip2.Title }> null);
+	<QTip2.Api> $a.qtip('option', 'content.text', <QTip2.Text> null);
+	<QTip2.Api> $a.qtip('option', 'content.attr', <string> null);
+	<QTip2.Api> $a.qtip('option', 'content.button', <string | JQuery | boolean> null);
+
+	<QTip2.Api> $a.qtip('option', 'position', <string | QTip2.Position> null);
+	<QTip2.Api> $a.qtip('option', 'position.my', <string | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'position.at', <string | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'position.target', <QTip2.Target | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'position.container', <JQuery | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'position.viewport', <JQuery | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'position.effect', <boolean | ((api: QTip2.Api, pos: any, viewport: any) => void)> null);
+	<QTip2.Api> $a.qtip('option', 'position.adjust', <QTip2.PositionAdjust> null);
+
+	<QTip2.Api> $a.qtip('option', 'show', <QTip2.Show> null);
+	<QTip2.Api> $a.qtip('option', 'show.target', <JQuery | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'show.event', <string | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'show.delay', <number> null);
+	<QTip2.Api> $a.qtip('option', 'show.solo', <JQuery | string | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'show.ready', <boolean> null);
+	<QTip2.Api> $a.qtip('option', 'show.effect', <boolean | ((offset: any) => void)> null);
+	<QTip2.Api> $a.qtip('option', 'show.modal', <boolean | QTip2.Modal> null);
+
+	<QTip2.Api> $a.qtip('option', 'hide', <QTip2.Hide> null);
+	<QTip2.Api> $a.qtip('option', 'hide.target', <JQuery | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'hide.event', <string | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'hide.inactive', <number | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'hide.fixed', <boolean> null);
+	<QTip2.Api> $a.qtip('option', 'hide.leave', <string | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'hide.distance', <number | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'hide.effect', <boolean | ((offset: any) => void)> null);
+
+	<QTip2.Api> $a.qtip('option', 'style', <QTip2.Style> null);
+	<QTip2.Api> $a.qtip('option', 'style.classes', <string | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'style.def', <boolean> null);
+	<QTip2.Api> $a.qtip('option', 'style.widget', <boolean> null);
+	<QTip2.Api> $a.qtip('option', 'style.width', <string | number | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'style.height', <string | number | boolean> null);
+	<QTip2.Api> $a.qtip('option', 'style.tip', <string | boolean | QTip2.Tip> null);
+
+	<QTip2.Api> $a.qtip('option', 'events', <QTip2.Events> null);
+	<QTip2.Api> $a.qtip('option', 'events.render', <QTip2.EventApiFunc> null);
+	<QTip2.Api> $a.qtip('option', 'events.show', <QTip2.EventApiFunc> null);
+	<QTip2.Api> $a.qtip('option', 'events.hide', <QTip2.EventApiFunc> null);
+	<QTip2.Api> $a.qtip('option', 'events.toggle', <QTip2.EventApiFunc> null);
+	<QTip2.Api> $a.qtip('option', 'events.visible', <QTip2.EventApiFunc> null);
+	<QTip2.Api> $a.qtip('option', 'events.hidden', <QTip2.EventApiFunc> null);
+	<QTip2.Api> $a.qtip('option', 'events.move', <QTip2.EventApiFunc> null);
+	<QTip2.Api> $a.qtip('option', 'events.focus', <QTip2.EventApiFunc> null);
+	<QTip2.Api> $a.qtip('option', 'events.blur', <QTip2.EventApiFunc> null);
+}
+
+
+/**
+ * http://qtip2.com/api#api-methods
+ */
+function testApiViaObject() {
+	$a.qtip({});
+
+	var api = $a.qtip('api');
+
+	<QTip2.Api> api.toggle();
+	<QTip2.Api> api.toggle(true);
+	<QTip2.Api> api.toggle(false, <Event> null);
+
+	<QTip2.Api> api.show();
+	<QTip2.Api> api.show(<Event> null);
+
+	<QTip2.Api> api.hide();
+	<QTip2.Api> api.hide(<Event> null);
+
+	<QTip2.Api> api.disable();
+	<QTip2.Api> api.disable(true);
+
+	<QTip2.Api> api.enable();
+
+	<QTip2.Api> api.reposition();
+	<QTip2.Api> api.reposition(<Event> null);
+	<QTip2.Api> api.reposition(<Event> null, true);
+
+	<QTip2.Api> api.focus();
+	<QTip2.Api> api.focus(<Event> null);
+
+	<QTip2.Api> api.blur();
+	<QTip2.Api> api.blur(<Event> null);
+
+	<QTip2.Api> api.destroy();
+	<QTip2.Api> api.destroy(true);
+}
+
+
+/**
+ * http://qtip2.com/api#api.updating
+ */
+function testApiMethodsViaString() {
+	<JQuery> $a.qtip('toggle');
+	<JQuery> $a.qtip('toggle', true);
+	<JQuery> $a.qtip('toggle', true, <Event> null);
+
+	<JQuery> $a.qtip('show');
+	<JQuery> $a.qtip('show', <Event> null);
+
+	<JQuery> $a.qtip('hide');
+	<JQuery> $a.qtip('hide', <Event> null);
+
+	<JQuery> $a.qtip('disable');
+	<JQuery> $a.qtip('disable', true);
+
+	<JQuery> $a.qtip('enable');
+
+	<JQuery> $a.qtip('reposition');
+	<JQuery> $a.qtip('reposition', <Event> null);
+	<JQuery> $a.qtip('reposition', <Event> null, true);
+
+	<JQuery> $a.qtip('focus');
+	<JQuery> $a.qtip('focus', <Event> null);
+
+	<JQuery> $a.qtip('blur');
+	<JQuery> $a.qtip('blur', <Event> null);
+
+	<JQuery> $a.qtip('destroy');
+	<JQuery> $a.qtip('destroy', true);
+}
+
+
+/**
+ * http://qtip2.com/options#global
+ *
+ * $.fn is of type any, therefore we can't (and don't need to) add type bindings for QTip2 globals under it.
+ */
+function testGlobals() {
+	$.fn.qtip.defaults.prerender = true;
 }

--- a/qtip2/qtip2-tests.ts
+++ b/qtip2/qtip2-tests.ts
@@ -1,0 +1,537 @@
+/// <reference path="qtip2.d.ts" />
+
+var $a = $('_');
+
+
+/**
+ * Test core properties (http://qtip2.com/options#core)
+ */
+function testCoreProperties() {
+	// Test with all core options specififed
+	$a.qtip({
+		content: 'Jan Jansen',
+		id: 'jan-jansen',
+		prerender: true,
+		overwrite: true,
+		suppress: true,
+		metadata: {
+			type: 'html5',
+			name: 'qtipopts'
+		}
+	});
+
+	// Test ID as boolean
+	$a.qtip({
+		content: 'yoshimo',
+		id: false
+	});
+
+	// Test with no options specified
+	$a.qtip({
+		content: 'aerie'
+	});
+}
+
+
+/**
+ * http://qtip2.com/options#content.text
+ */
+function testContentText() {
+	// Shorthand string
+	$a.qtip({
+		content: 'valygar'
+	});
+
+	// Regular string
+	$a.qtip({
+		content: { text: 'kivan' }
+	});
+
+	// Shorthand boolean
+	$a.qtip({
+		content: true
+	});
+
+	// Regular boolean
+	$a.qtip({
+		content: { text: true }
+	});
+
+	// Shorthand Deferred / Promise
+	$a.qtip({
+		content: $.Deferred().resolve('cernd')
+	});
+
+	$a.qtip({
+		content: $.Deferred().reject().promise()
+	});
+
+	// Regular Deferred / Promise
+	$a.qtip({
+		content: { text: $.Deferred().resolve('horatio') }
+	});
+
+	$a.qtip({
+		content: { text: $.Deferred().reject().promise() }
+	});
+
+	// Shorthand function
+	$a.qtip({
+		content: function(event, api) {	}
+	});
+
+	$a.qtip({
+		content: function(event) { return 2; }
+	});
+
+	$a.qtip({
+		content: function() { }
+	});
+
+	// Regular function
+	$a.qtip({
+		content: { text: function(event, api) {	} }
+	});
+
+	$a.qtip({
+		content: { text: function(event) { return 2; } }
+	});
+
+	$a.qtip({
+		content: { text: function() { } }
+	});
+
+	// Shorthand jQuery elements
+	$a.qtip({
+		content: $('.irenicus')
+	});
+
+	// Regular jQuery elements
+	$a.qtip({
+		content: { text: $('.irenicus') }
+	});
+}
+
+
+/**
+ * http://qtip2.com/options#content.title
+ */
+function testContentTitle() {
+	// Shorthand string
+	$a.qtip({
+		content: { title: 'keldorn' }
+	});
+
+	// Regular string
+	$a.qtip({
+		content: {
+			title: { text: 'nalia' }
+		}
+	});
+
+	// Shorthand boolean
+	$a.qtip({
+		content: { title: true }
+	});
+
+	// Regular boolean
+	$a.qtip({
+		content: {
+			title: { text: true }
+		}
+	});
+
+	// Shorthand Deferred / Promise
+	$a.qtip({
+		content: { title: $.Deferred().resolve('mazzy') }
+	});
+
+	$a.qtip({
+		content: { title: $.Deferred().reject().promise() }
+	});
+
+	// Regular Deferred / Promise
+	$a.qtip({
+		content: { title: { text: $.Deferred().resolve('bodhi') } }
+	});
+
+	$a.qtip({
+		content: { title: { text: $.Deferred().reject().promise() } }
+	});
+
+	// Shorthand function
+	$a.qtip({
+		content: { title: function(event, api) {} }
+	});
+
+	$a.qtip({
+		content: { title: function(event) { return 2; } }
+	});
+
+	$a.qtip({
+		content: { title: function() { } }
+	});
+
+	// Regular function
+	$a.qtip({
+		content: { title: { text: function(event, api) { } } }
+	});
+
+	$a.qtip({
+		content: { title: { text: function(event) { return 2; } } }
+	});
+
+	$a.qtip({
+		content: { title: { text: function() { } } }
+	});
+
+	// Shorthand jQuery elements
+	$a.qtip({
+		content: { title: $('.irenicus') }
+	});
+
+	// Regular jQuery elements
+	$a.qtip({
+		content: { title: { text: $('.irenicus') } }
+	});
+}
+
+
+/**
+ * http://qtip2.com/options#content.button
+ */
+function testContentButtonProperty() {
+	$a.qtip({
+		content: { button: $('.minsc') }
+	});
+
+	$a.qtip({
+		content: { button: 'jaheira' }
+	});
+
+	$a.qtip({
+		content: { button: true }
+	});
+}
+
+
+/**
+ * http://qtip2.com/options#content.attr
+ */
+function testContentAttrProperty() {
+	$a.qtip({
+		content: { attr: 'viconia' }
+	});
+}
+
+
+/**
+ * http://qtip2.com/options#position
+ */
+function testPositionProperty() {
+	// Shorthand
+	$a.qtip({ position: 'top left' });
+
+	// The below four calls test all combinations of all sub-properties
+	$a.qtip({
+		position: {
+			target: $('.khalid'),
+			my: 'top left',
+			at: 'bottom right',
+			container: $('.edwin-odesseiron'),
+			viewport: $('.dynaheir'),
+			effect: function(api, pos, viewport) { },
+			adjust: { x: 2 }
+		}
+	});
+
+	$a.qtip({
+		position: {
+			target: [2, 2],
+			my: true,
+			at: true,
+			container: false,
+			viewport: true,
+			effect: function(api, pos) { return 2; },
+			adjust: { y: 2 }
+		}
+	});
+
+	$a.qtip({
+		position: {
+			target: 'mouse',
+			effect: function(api) {},
+			adjust: { x: 2, y: 2 }
+		}
+	});
+
+	$a.qtip({
+		position: {
+			target: false,
+			effect: function() {},
+			adjust: {
+				mouse: true,
+				resize: true,
+				scroll: false,
+				method: 'flipinvert'
+			}
+		}
+	});
+
+	$a.qtip({
+		position: {
+			adjust: { }
+		}
+	});
+}
+
+
+/**
+ * http://qtip2.com/options#show
+ */
+function testShowProperty() {
+	// Shorthand
+	$a.qtip({ show: true });
+	$a.qtip({ show: 'mouseenter' });
+	$a.qtip({ show: $('.korgan') });
+
+	// The below calls test all combinations of all sub-properties
+	$a.qtip({
+		show: {
+			target: $('.gorion'),
+			event: false,
+			delay: 42,
+			solo: $('.imoen'),
+			ready: true,
+			effect: function(offset) {
+			},
+			modal: true
+		}
+	});
+
+	$a.qtip({
+		show: {
+			target: false,
+			event: 'mouseenter',
+			solo: '.qtips',
+			effect: true,
+			modal: {
+				on: true,
+				blur: false,
+				escape: true,
+				stealfocus: true,
+				effect: true
+			}
+		}
+	});
+
+	$a.qtip({
+		show: {
+			solo: false,
+			modal: {
+				effect: function(state) {}
+			}
+		}
+	});
+
+	$a.qtip({
+		show: {
+			modal: {}
+		}
+	});
+}
+
+
+/**
+ * http://qtip2.com/options#hide
+ */
+function testHideProperty() {
+	// Shorthand
+	$a.qtip({ hide: 'mouseenter' });
+	$a.qtip({ hide: $('.montaron') });
+
+	// The below calls test all combinations of all sub-properties
+	$a.qtip({
+		hide: {
+			target: $('.gorion'),
+			event: false,
+			delay: 42,
+			inactive: 64,
+			fixed: true,
+			leave: 'window',
+			distance: 32,
+			effect: function(offset) {
+			},
+		}
+	});
+
+	$a.qtip({
+		hide: {
+			target: false,
+			event: 'mouseenter',
+			inactive: false,
+			leave: false,
+			distance: false,
+			effect: true,
+		}
+	});
+}
+
+
+/**
+ * http://qtip2.com/options#style
+ */
+function testStyleProperty() {
+	// Shorthand
+	$a.qtip({ style: 'kagain' });
+
+	// The below calls test all combinations of all sub-properties
+	$a.qtip({
+		style: {
+			classes: 'anomen',
+			def: true,
+			widget: true,
+			width: '24pt',
+			height: '24pt',
+			tip: 'top left'
+		}
+	});
+
+	$a.qtip({
+		show: {
+			classes: false,
+			width: 24,
+			height: 24,
+			tip: false
+		}
+	});
+
+	$a.qtip({
+		show: {
+			classes: false,
+			width: false,
+			height: false,
+			tip: {
+				corner: 'bottom right',
+				mimic: 'bottom right',
+				border: 3,
+				width: 27,
+				height: 32,
+				offset: 1
+			}
+		}
+	});
+
+	$a.qtip({
+		show: {
+			tip: {
+				corner: true,
+				mimic: true,
+				border: false
+			}
+		}
+	});
+
+	$a.qtip({
+		show: {
+			tip: { }
+		}
+	});
+}
+
+
+function baseCase() {
+	$a.qtip();
+	$a.qtip({});
+
+	$a.qtip('horatio');
+	$a.qtip('activate');
+	$a.qtip('deactivate');
+}
+
+
+/**
+ * Test with all options specified. Copied from http://qtip2.com/options#global and amended.
+ */
+function allTogetherNow() {
+	$a.qtip({
+		prerender: false,
+		id: false,
+		overwrite: true,
+		suppress: true,
+		content: {
+			title: true,
+			attr: 'title',
+			text: false,
+			button: false
+		},
+		position: {
+			my: 'top left',
+			at: 'bottom right',
+			target: false,
+			container: false,
+			viewport: false,
+			adjust: {
+				x: 0, y: 0,
+				mouse: true,
+				resize: true,
+				method: 'flip flip'
+			},
+			effect: function(api, pos, viewport) {
+				$(this).animate(pos, {
+					duration: 200,
+					queue: false
+				});
+			}
+		},
+		show: {
+			target: false,
+			event: 'mouseenter',
+			effect: true,
+			delay: 90,
+			solo: false,
+			ready: false,
+			modal: {
+				on: false,
+				effect: true,
+				blur: true,
+				escape: true
+			}
+		},
+		hide: {
+			target: false,
+			event: 'mouseleave',
+			effect: true,
+			delay: 0,
+			fixed: false,
+			inactive: false,
+			leave: 'window',
+			distance: false
+		},
+		style: {
+			classes: '',
+			widget: false,
+			width: false,
+			height: false,
+			tip: {
+				corner: true,
+				mimic: false,
+				width: 8,
+				height: 8,
+				border: true,
+				offset: 0
+			}
+		},
+		events: {
+			render: null,
+			move: null,
+			show: null,
+			hide: null,
+			toggle: null,
+			visible: null,
+			hidden: null,
+			focus: null,
+			blur: null
+		}
+	});
+}

--- a/qtip2/qtip2-tests.ts.tscparams
+++ b/qtip2/qtip2-tests.ts.tscparams
@@ -1,0 +1,2 @@
+
+--noImplicitAny

--- a/qtip2/qtip2.d.ts
+++ b/qtip2/qtip2.d.ts
@@ -1,19 +1,24 @@
 // Type definitions for qtip2 v2.2.1
-// Project: http://http://qtip2.com/
+// Project: http://qtip2.com/
 // Definitions by: Nathan Pitman <https://github.com/Seltzer100/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 // Notes:
+//   - Type bindings for the QTip2 API and options are included. Bindings for global settings aren't required.
 //   - Deprecated functionality is not supported.
-
+//   - Where possible, things are strongly typed and 'any' is avoided.
+//   - QTip2 includes a lot of shorthand notation for various expressions. These bindings support it all.
 
 /// <reference path="../jquery/jquery.d.ts" />
 
 declare module QTip2 {
+	type EventApiFunc = (event: Event, api: Api) => void;
+
+
 	/**
 	 * Content property
 	 */
-	type Title = string | JQuery | Func | boolean | JQueryGenericPromise<any>;
-	type Text = string | JQuery | Func | boolean | JQueryGenericPromise<any>;
+	type Title = string | JQuery | EventApiFunc | boolean | JQueryGenericPromise<any>;
+	type Text = string | JQuery | EventApiFunc | boolean | JQueryGenericPromise<any>;
 
 	interface Content {
 		title?: Title | { text: Title };
@@ -43,7 +48,7 @@ declare module QTip2 {
 		target?: Target | boolean;
 		container?: JQuery | boolean;
 		viewport?: JQuery | boolean;
-		effect?: boolean | ((api: any, pos: any, viewport: any) => any);
+		effect?: boolean | ((api: Api, pos: any, viewport: any) => void);
 		adjust?: PositionAdjust;
 	}
 
@@ -57,7 +62,7 @@ declare module QTip2 {
 		delay?: number;
 		solo?: JQuery | string | boolean;
 		ready?: boolean;
-		effect?: boolean | ((offset: any) => any);
+		effect?: boolean | ((offset: any) => void);
 		modal?: boolean | Modal;
 	}
 
@@ -67,7 +72,7 @@ declare module QTip2 {
 		blur?: boolean;
 		escape?: boolean;
 		stealfocus?: boolean;
-		effect?: boolean | ((state: any) => any);
+		effect?: boolean | ((state: any) => void);
 	}
 
 
@@ -80,25 +85,15 @@ declare module QTip2 {
 		delay?: number;
 		inactive?: number | boolean;
 		fixed?: boolean;
-		// TODO: What is going on here?
 		leave?: string | boolean;
 		distance?: number | boolean;
-		effect?: boolean | ((offset: any) => any);
+		effect?: boolean | ((offset: any) => void);
 	}
 
 
 	/**
 	 * Style property
 	 */
-	interface Tip {
-		corner?: string | boolean;
-		mimic?: string | boolean;
-		border?: number | boolean;
-		width?: number;
-		height?: number;
-		offset?: number;
-	}
-
 	interface Style {
 		classes?: string | boolean;
 		def?: boolean;
@@ -108,22 +103,29 @@ declare module QTip2 {
 		tip?: string | boolean | Tip;
 	}
 
+	interface Tip {
+		corner?: string | boolean;
+		mimic?: string | boolean;
+		border?: number | boolean;
+		width?: number;
+		height?: number;
+		offset?: number;
+	}
+
 
 	/**
 	 * Events property
 	 */
-	type Func = (event: any, api: any) => any;
-
 	interface Events {
-		render?: Func;
-		show?: Func;
-		hide?: Func;
-		toggle?: Func;
-		visible?: Func;
-		hidden?: Func;
-		move?: Func;
-		focus?: Func;
-		blur?: Func;
+		render?: EventApiFunc;
+		show?: EventApiFunc;
+		hide?: EventApiFunc;
+		toggle?: EventApiFunc;
+		visible?: EventApiFunc;
+		hidden?: EventApiFunc;
+		move?: EventApiFunc;
+		focus?: EventApiFunc;
+		blur?: EventApiFunc;
 	}
 
 
@@ -143,11 +145,265 @@ declare module QTip2 {
 		hide?: string | JQuery | Hide;
 		events?: Events;
 	}
+
+
+	/**
+	 * API
+	 */
+	interface Api {
+		get(propertyName: 'id'): string | boolean;
+		get(propertyName: 'prerender'): boolean;
+		get(propertyName: 'overwrite'): boolean;
+		get(propertyName: 'suppress'): boolean;
+		get(propertyName: 'metadata'): any;
+		get(propertyName: 'content'): Content;
+		get(propertyName: 'content.text'): Text;
+		get(propertyName: 'content.attr'): string;
+		get(propertyName: 'content.title'): Title;
+		get(propertyName: 'content.button'): string | JQuery | boolean;
+		get(propertyName: 'position'): Position;
+		get(propertyName: 'position.my'): string | boolean;
+		get(propertyName: 'position.at'): string | boolean;
+		get(propertyName: 'position.target'): Target | boolean;
+		get(propertyName: 'position.container'): JQuery | boolean;
+		get(propertyName: 'position.viewport'): JQuery | boolean;
+		get(propertyName: 'position.effect'): boolean | ((api: any, pos: any, viewport: any) => void);
+		get(propertyName: 'position.adjust'): PositionAdjust;
+		get(propertyName: 'show'): Show;
+		get(propertyName: 'show.target'): JQuery | boolean;
+		get(propertyName: 'show.event'): string | boolean;
+		get(propertyName: 'show.delay'): number;
+		get(propertyName: 'show.solo'): JQuery | string | boolean;
+		get(propertyName: 'show.ready'): boolean;
+		get(propertyName: 'show.effect'): boolean | ((offset: any) => void);
+		get(propertyName: 'show.modal'): boolean | Modal;
+		get(propertyName: 'hide'): Hide;
+		get(propertyName: 'hide.target'): JQuery | boolean;
+		get(propertyName: 'hide.event'): string | boolean;
+		get(propertyName: 'hide.delay'): number;
+		get(propertyName: 'hide.leave'): string | boolean;
+		get(propertyName: 'hide.distance'): number | boolean;
+		get(propertyName: 'hide.effect'): boolean | ((offset: any) => void);
+		get(propertyName: 'style'): Style;
+		get(propertyName: 'style.classes'): string | boolean;
+		get(propertyName: 'style.def'): boolean;
+		get(propertyName: 'style.widget'): boolean;
+		get(propertyName: 'style.width'): string | number | boolean;
+		get(propertyName: 'style.height'): string | number | boolean;
+		get(propertyName: 'style.tip'): string | boolean | Tip;
+		get(propertyName: 'events'): Events;
+		get(propertyName: 'events.render'): EventApiFunc;
+		get(propertyName: 'events.show'): EventApiFunc;
+		get(propertyName: 'events.hide'): EventApiFunc;
+		get(propertyName: 'events.toggle'): EventApiFunc;
+		get(propertyName: 'events.visible'): EventApiFunc;
+		get(propertyName: 'events.hidden'): EventApiFunc;
+		get(propertyName: 'events.move'): EventApiFunc;
+		get(propertyName: 'events.focus'): EventApiFunc;
+		get(propertyName: 'events.blur'): EventApiFunc;
+		get(propertyName: string): any;
+
+		set(properties: QTipOptions): Api;
+		set(propertyName: 'id', value: string | boolean): Api;
+		set(propertyName: 'prerender', value: boolean): Api;
+		set(propertyName: 'overwrite', value: boolean): Api;
+		set(propertyName: 'suppress', value: boolean): Api;
+		set(propertyName: 'metadata', value: any): Api;
+		set(propertyName: 'content', value: Text | Content): Api;
+		set(propertyName: 'content.title', value: Title | { text: Title }): Api;
+		set(propertyName: 'content.text', value: Text): Api;
+		set(propertyName: 'content.attr', value: string): Api;
+		set(propertyName: 'content.button', value: string | JQuery | boolean): Api;
+		set(propertyName: 'position', value: Position): Api;
+		set(propertyName: 'position.my', value: string | boolean): Api;
+		set(propertyName: 'position.at', value: string | boolean): Api;
+		set(propertyName: 'position.target', value: Target | boolean): Api;
+		set(propertyName: 'position.container', value: JQuery | boolean): Api;
+		set(propertyName: 'position.viewport', value: JQuery | boolean): Api;
+		set(propertyName: 'position.effect', value: boolean | ((api: Api, pos: any, viewport: any) => void) ): Api;
+		set(propertyName: 'position.adjust', value: PositionAdjust): Api;
+		set(propertyName: 'show', value: Show): Api;
+		set(propertyName: 'show.target', value: JQuery | boolean): Api;
+		set(propertyName: 'show.event', value: string | boolean): Api;
+		set(propertyName: 'show.delay', value: number): Api;
+		set(propertyName: 'show.solo', value: JQuery | string | boolean): Api;
+		set(propertyName: 'show.ready', value: boolean): Api;
+		set(propertyName: 'show.effect', value: boolean | ((offset: any) => void)): Api;
+		set(propertyName: 'show.modal', value: boolean | Modal): Api;
+		set(propertyName: 'hide', value: Hide): Api;
+		set(propertyName: 'hide.target', value: JQuery | boolean): Api;
+		set(propertyName: 'hide.event', value: string | boolean): Api;
+		set(propertyName: 'hide.inactive', value: number | boolean): Api;
+		set(propertyName: 'hide.fixed', value: boolean): Api;
+		set(propertyName: 'hide.leave', value: string | boolean): Api;
+		set(propertyName: 'hide.distance', value: number | boolean): Api;
+		set(propertyName: 'hide.effect', value: boolean | ((offset: any) => void)): Api
+		set(propertyName: 'style', value: Style): Api;
+		set(propertyName: 'style.classes', value: string | boolean): Api;
+		set(propertyName: 'style.def', value: boolean): Api;
+		set(propertyName: 'style.widget', value: boolean): Api;
+		set(propertyName: 'style.width', value: string | number | boolean): Api;
+		set(propertyName: 'style.height', value: string | number | boolean): Api;
+		set(propertyName: 'style.tip', value: string | boolean | Tip): Api;
+		set(propertyName: 'events', value: Events): Api;
+		set(propertyName: 'events.render', value: EventApiFunc): Api;
+		set(propertyName: 'events.show', value: EventApiFunc): Api;
+		set(propertyName: 'events.hide', value: EventApiFunc): Api;
+		set(propertyName: 'events.toggle', value: EventApiFunc): Api;
+		set(propertyName: 'events.visible', value: EventApiFunc): Api;
+		set(propertyName: 'events.hidden', value: EventApiFunc): Api;
+		set(propertyName: 'events.move', value: EventApiFunc): Api;
+		set(propertyName: 'events.focus', value: EventApiFunc): Api;
+		set(propertyName: 'events.blur', value: EventApiFunc): Api;
+		set(propertyName: string, value: any): Api;
+
+		toggle(state?: boolean, event?: Event): Api;
+
+		show(event?: Event): Api;
+
+		hide(event?: Event): Api;
+
+		disable(state?: boolean): Api;
+
+		enable(): Api;
+
+		reposition(event?: Event, effect?: boolean): Api;
+
+		focus(event?: Event): Api;
+
+		blur(event?: Event): Api;
+
+		destroy(immediate?: boolean): Api;
+	}
 }
 
 
 interface JQuery {
-	qtip(): JQuery;
+	qtip(options?: QTip2.QTipOptions): JQuery;
 
-	qtip(options: QTip2.QTipOptions): JQuery;
+	qtip(methodName: 'api'): QTip2.Api;
+
+	qtip(methodName: 'option', propertyName: 'id'): string | boolean;
+	qtip(methodName: 'option', propertyName: 'prerender'): boolean;
+	qtip(methodName: 'option', propertyName: 'overwrite'): boolean;
+	qtip(methodName: 'option', propertyName: 'suppress'): boolean;
+	qtip(methodName: 'option', propertyName: 'metadata'): any;
+	qtip(methodName: 'option', propertyName: 'content'): QTip2.Content;
+	qtip(methodName: 'option', propertyName: 'content.text'): QTip2.Text;
+	qtip(methodName: 'option', propertyName: 'content.attr'): string;
+	qtip(methodName: 'option', propertyName: 'content.title'): QTip2.Title;
+	qtip(methodName: 'option', propertyName: 'content.button'): string | JQuery | boolean;
+	qtip(methodName: 'option', propertyName: 'position'): QTip2.Position;
+	qtip(methodName: 'option', propertyName: 'position.my'): string | boolean;
+	qtip(methodName: 'option', propertyName: 'position.at'): string | boolean;
+	qtip(methodName: 'option', propertyName: 'position.target'): QTip2.Target | boolean;
+	qtip(methodName: 'option', propertyName: 'position.container'): JQuery | boolean;
+	qtip(methodName: 'option', propertyName: 'position.viewport'): JQuery | boolean;
+	qtip(methodName: 'option', propertyName: 'position.effect'): boolean | ((api: QTip2.Api, pos: any, viewport: any) => void);
+	qtip(methodName: 'option', propertyName: 'position.adjust'): QTip2.PositionAdjust;
+	qtip(methodName: 'option', propertyName: 'show'): QTip2.Show;
+	qtip(methodName: 'option', propertyName: 'show.target'): JQuery | boolean;
+	qtip(methodName: 'option', propertyName: 'show.event'): string | boolean;
+	qtip(methodName: 'option', propertyName: 'show.delay'): number;
+	qtip(methodName: 'option', propertyName: 'show.solo'): JQuery | string | boolean;
+	qtip(methodName: 'option', propertyName: 'show.ready'): boolean;
+	qtip(methodName: 'option', propertyName: 'show.effect'): boolean | ((offset: any) => void);
+	qtip(methodName: 'option', propertyName: 'show.modal'): boolean | QTip2.Modal;
+	qtip(methodName: 'option', propertyName: 'hide'): QTip2.Hide;
+	qtip(methodName: 'option', propertyName: 'hide.target'): JQuery | boolean;
+	qtip(methodName: 'option', propertyName: 'hide.event'): string | boolean;
+	qtip(methodName: 'option', propertyName: 'hide.delay'): number;
+	qtip(methodName: 'option', propertyName: 'hide.leave'): string | boolean;
+	qtip(methodName: 'option', propertyName: 'hide.distance'): number | boolean;
+	qtip(methodName: 'option', propertyName: 'hide.effect'): boolean | ((offset: any) => void);
+	qtip(methodName: 'option', propertyName: 'style'): QTip2.Style;
+	qtip(methodName: 'option', propertyName: 'style.classes'): string | boolean;
+	qtip(methodName: 'option', propertyName: 'style.def'): boolean;
+	qtip(methodName: 'option', propertyName: 'style.widget'): boolean;
+	qtip(methodName: 'option', propertyName: 'style.width'): string | number | boolean;
+	qtip(methodName: 'option', propertyName: 'style.height'): string | number | boolean;
+	qtip(methodName: 'option', propertyName: 'style.tip'): string | boolean | QTip2.Tip;
+	qtip(methodName: 'option', propertyName: 'events'): QTip2.Events;
+	qtip(methodName: 'option', propertyName: 'events.render'): QTip2.EventApiFunc;
+	qtip(methodName: 'option', propertyName: 'events.show'): QTip2.EventApiFunc;
+	qtip(methodName: 'option', propertyName: 'events.hide'): QTip2.EventApiFunc;
+	qtip(methodName: 'option', propertyName: 'events.toggle'): QTip2.EventApiFunc;
+	qtip(methodName: 'option', propertyName: 'events.visible'): QTip2.EventApiFunc;
+	qtip(methodName: 'option', propertyName: 'events.hidden'): QTip2.EventApiFunc;
+	qtip(methodName: 'option', propertyName: 'events.move'): QTip2.EventApiFunc;
+	qtip(methodName: 'option', propertyName: 'events.focus'): QTip2.EventApiFunc;
+	qtip(methodName: 'option', propertyName: 'events.blur'): QTip2.EventApiFunc;
+
+	qtip(methodName: 'option', properties: QTip2.QTipOptions): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'id', value: string | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'prerender', value: boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'overwrite', value: boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'suppress', value: boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'metadata', value: any): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'content', value: QTip2.Text | QTip2.Content): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'content.title', value: QTip2.Title | { text: QTip2.Title }): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'content.text', value: QTip2.Text): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'content.attr', value: string): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'content.button', value: string | JQuery | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'position', value: QTip2.Position): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'position.my', value: string | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'position.at', value: string | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'position.target', value: QTip2.Target | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'position.container', value: JQuery | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'position.viewport', value: JQuery | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'position.effect', value: boolean | ((api: QTip2.Api, pos: any, viewport: any) => void) ): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'position.adjust', value: QTip2.PositionAdjust): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'show', value: QTip2.Show): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'show.target', value: JQuery | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'show.event', value: string | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'show.delay', value: number): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'show.solo', value: JQuery | string | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'show.ready', value: boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'show.effect', value: boolean | ((offset: any) => void)): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'show.modal', value: boolean | QTip2.Modal): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'hide', value: QTip2.Hide): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'hide.target', value: JQuery | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'hide.event', value: string | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'hide.inactive', value: number | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'hide.fixed', value: boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'hide.leave', value: string | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'hide.distance', value: number | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'hide.effect', value: boolean | ((offset: any) => void)): QTip2.Api
+	qtip(methodName: 'option', propertyName: 'style', value: QTip2.Style): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'style.classes', value: string | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'style.def', value: boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'style.widget', value: boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'style.width', value: string | number | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'style.height', value: string | number | boolean): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'style.tip', value: string | boolean | QTip2.Tip): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'events', value: QTip2.Events): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'events.render', value: QTip2.EventApiFunc): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'events.show', value: QTip2.EventApiFunc): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'events.hide', value: QTip2.EventApiFunc): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'events.toggle', value: QTip2.EventApiFunc): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'events.visible', value: QTip2.EventApiFunc): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'events.hidden', value: QTip2.EventApiFunc): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'events.move', value: QTip2.EventApiFunc): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'events.focus', value: QTip2.EventApiFunc): QTip2.Api;
+	qtip(methodName: 'option', propertyName: 'events.blur', value: QTip2.EventApiFunc): QTip2.Api;
+
+	qtip(methodName: 'toggle', state?: boolean, event?: Event): JQuery;
+
+	qtip(methodName: 'show', event?: Event): JQuery;
+
+	qtip(methodName: 'hide', event?: Event): JQuery;
+
+	qtip(methodName: 'disable', state?: boolean): JQuery;
+
+	qtip(methodName: 'enable'): JQuery
+
+	qtip(methodName: 'reposition', event?: Event, effect?: boolean): JQuery;
+
+	qtip(methodName: 'focus', event?: Event): JQuery;
+
+	qtip(methodName: 'blur', event?: Event): JQuery;
+
+	qtip(methodName: 'destroy', immediate?: boolean): JQuery;
+
+	qtip(methodName: string, p1?: any, p2?: any, p3?: any): any;
 }

--- a/qtip2/qtip2.d.ts
+++ b/qtip2/qtip2.d.ts
@@ -1,0 +1,153 @@
+// Type definitions for qtip2 v2.2.1
+// Project: http://http://qtip2.com/
+// Definitions by: Nathan Pitman <https://github.com/Seltzer100/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+// Notes:
+//   - Deprecated functionality is not supported.
+
+
+/// <reference path="../jquery/jquery.d.ts" />
+
+declare module QTip2 {
+	/**
+	 * Content property
+	 */
+	type Title = string | JQuery | Func | boolean | JQueryGenericPromise<any>;
+	type Text = string | JQuery | Func | boolean | JQueryGenericPromise<any>;
+
+	interface Content {
+		title?: Title | { text: Title };
+		text?: Text;
+		attr?: string;
+		button?: string | JQuery | boolean;
+	}
+
+
+	/**
+	 * Position property
+	 */
+	interface PositionAdjust {
+		x?: number;
+		y?: number;
+		mouse?: boolean;
+		resize?: boolean;
+		scroll?: boolean;
+		method?: string;
+	}
+
+	type Target = JQuery | number[] | string;
+
+	interface Position {
+		my?: string | boolean;
+		at?: string | boolean;
+		target?: Target | boolean;
+		container?: JQuery | boolean;
+		viewport?: JQuery | boolean;
+		effect?: boolean | ((api: any, pos: any, viewport: any) => any);
+		adjust?: PositionAdjust;
+	}
+
+
+	/**
+	 * Show property
+	 */
+	interface Show {
+		target?: JQuery | boolean;
+		event?: string | boolean;
+		delay?: number;
+		solo?: JQuery | string | boolean;
+		ready?: boolean;
+		effect?: boolean | ((offset: any) => any);
+		modal?: boolean | Modal;
+	}
+
+	interface Modal
+	{
+		on?: boolean;
+		blur?: boolean;
+		escape?: boolean;
+		stealfocus?: boolean;
+		effect?: boolean | ((state: any) => any);
+	}
+
+
+	/**
+	 * Hide property
+	 */
+	interface Hide {
+		target?: JQuery | boolean;
+		event?: string | boolean;
+		delay?: number;
+		inactive?: number | boolean;
+		fixed?: boolean;
+		// TODO: What is going on here?
+		leave?: string | boolean;
+		distance?: number | boolean;
+		effect?: boolean | ((offset: any) => any);
+	}
+
+
+	/**
+	 * Style property
+	 */
+	interface Tip {
+		corner?: string | boolean;
+		mimic?: string | boolean;
+		border?: number | boolean;
+		width?: number;
+		height?: number;
+		offset?: number;
+	}
+
+	interface Style {
+		classes?: string | boolean;
+		def?: boolean;
+		widget?: boolean;
+		width: string | number | boolean;
+		height: string | number | boolean;
+		tip?: string | boolean | Tip;
+	}
+
+
+	/**
+	 * Events property
+	 */
+	type Func = (event: any, api: any) => any;
+
+	interface Events {
+		render?: Func;
+		show?: Func;
+		hide?: Func;
+		toggle?: Func;
+		visible?: Func;
+		hidden?: Func;
+		move?: Func;
+		focus?: Func;
+		blur?: Func;
+	}
+
+
+	/**
+	 * Options
+	 */
+	interface QTipOptions {
+		id?: string | boolean;
+		prerender?: boolean;
+		overwrite?: boolean;
+		suppress?: boolean;
+		metadata?: any;
+		content?: Text | Content;
+		position?: string | Position;
+		style?: string | Style;
+		show?: string | boolean | JQuery | Show;
+		hide?: string | JQuery | Hide;
+		events?: Events;
+	}
+}
+
+
+interface JQuery {
+	qtip(): JQuery;
+
+	qtip(options: QTip2.QTipOptions): JQuery;
+}


### PR DESCRIPTION
I've written all of the tests, based on QTip2 docs. The qtip2 name is based on the npm package name [here](https://www.npmjs.com/package/qtip2). And I've been testing by executing npm test.
