### PR TITLE
Add `Argv#command(cmd, desc)` to yargs

### DIFF
--- a/virtual-dom/virtual-dom.d.ts
+++ b/virtual-dom/virtual-dom.d.ts
@@ -1,0 +1,121 @@
+declare module VirtualDOM {
+  interface VHook {
+    hook(node: Element, propertyName: string): void;
+    unhook(node: Element, propertyName: string): void;
+  }
+
+  type EventHandler = (...args: any[]) => void;
+
+  interface VProperties {
+    attributes?: {[index: string]: string};
+    /**
+    I would like to use {[index: string]: string}, but then we couldn't use an
+    object literal when setting the styles, since TypeScript doesn't seem to
+    infer that {'fontSize': string; 'fontWeight': string;} is actually quite
+    assignable to the type { [index: string]: string; }
+    */
+    style?: any;
+    /**
+    The relaxation on `style` above is the reason why we need `any` as an option
+    on the indexer type.
+    */
+    [index: string]: any | string | boolean | number | VHook | EventHandler | {[index: string]: string | boolean | number};
+  }
+
+  interface VNode {
+    tagName: string;
+    properties: VProperties;
+    children: VTree[];
+    key?: string;
+    namespace?: string;
+    count: number;
+    hasWidgets: boolean;
+    hasThunks: boolean;
+    hooks: any[];
+    descendantHooks: any[];
+    version: string;
+    type: string; // 'VirtualNode'
+  }
+
+  interface VText {
+    text: string;
+    new (text: any);
+    version: string;
+    type: string; // 'VirtualText'
+  }
+
+  interface Widget {
+    type: string; // 'Widget'
+    init(): Element;
+    update(previous: Widget, domNode: Element): void;
+    destroy(node: Element): void;
+  }
+
+  interface Thunk {
+    type: string; // 'Thunk'
+    vnode: VTree;
+    render(previous: VTree): VTree;
+  }
+
+  type VTree = VText | VNode | Widget | Thunk;
+
+  // enum VPatch {
+  //   NONE = 0,
+  //   VTEXT = 1,
+  //   VNODE = 2,
+  //   WIDGET = 3,
+  //   PROPS = 4,
+  //   ORDER = 5,
+  //   INSERT = 6,
+  //   REMOVE = 7,
+  //   THUNK = 8
+  // }
+  interface VPatch {
+    vNode: VNode,
+    patch: any;
+    new(type: number, vNode: VNode, patch: any): VPatch;
+    version: string;
+    /**
+    type is set to 'VirtualPatch' on the prototype, but overridden in the
+    constructor with a number.
+    */
+    type: number;
+  }
+
+  interface createProperties extends VProperties {
+    key?: string;
+    namespace?: string;
+  }
+  type createChildren = Array<VTree[] | VTree | string[] | string>;
+
+  /**
+  create() calls either document.createElement() or document.createElementNS(),
+  for which the common denominator is Element (not HTMLElement).
+  */
+  function create(vnode: VText, opts?: {document?: Document, warn?: boolean}): Text;
+  function create(vnode: VNode | Widget | Thunk, opts?: {document?: Document, warn?: boolean}): Element;
+  function h(tagName: string, properties: createProperties, ...children: createChildren): VNode;
+  function h(tagName: string, ...children: createChildren): VNode;
+  function diff(left: VTree, right: VTree): VPatch[];
+  /**
+  patch() usually just returns rootNode after doing stuff to it, so we want
+  to preserve that type (though it will usually be just Element).
+  */
+  function patch<T extends Element>(rootNode: T, patches: VPatch[], renderOptions?: any): T;
+}
+
+declare module "virtual-dom/h" {
+  export = VirtualDOM.h;
+}
+declare module "virtual-dom/create-element" {
+  export = VirtualDOM.create;
+}
+declare module "virtual-dom/diff" {
+  export = VirtualDOM.diff;
+}
+declare module "virtual-dom/patch" {
+  export = VirtualDOM.patch;
+}
+declare module "virtual-dom" {
+  export = VirtualDOM;
+}

--- a/yargs/yargs.d.ts
+++ b/yargs/yargs.d.ts
@@ -53,6 +53,8 @@ declare module "yargs" {
 			usage(message: string, options?: { [key: string]: Options }): Argv;
 			usage(options?: { [key: string]: Options }): Argv;
 
+			command(command: string, description: string): Argv;
+
 			example(command: string, description: string): Argv;
 
 			check(func: (argv: { [key: string]: any }, aliases: { [alias: string]: string }) => boolean): Argv;


### PR DESCRIPTION
There is a `.command(cmd, desc)` option, similar (identical in syntax) to `.example(cmd, desc)`.

This commit adds that method to the `Argv` interface.

See https://github.com/chevex/yargs#commandcmd-desc for documentation reference.
