### PR TITLE
Add Argv#command(...) to yargs

### DIFF
--- a/yargs/yargs.d.ts
+++ b/yargs/yargs.d.ts
@@ -53,6 +53,8 @@ declare module "yargs" {
 			usage(message: string, options?: { [key: string]: Options }): Argv;
 			usage(options?: { [key: string]: Options }): Argv;
 
+			command(command: string, description: string): Argv;
+
 			example(command: string, description: string): Argv;
 
 			check(func: (argv: { [key: string]: any }, aliases: { [alias: string]: string }) => boolean): Argv;


### PR DESCRIPTION
There is a `.command(cmd, desc)` option, similar (identical in syntax) to `.example(cmd, desc)`.

This commit adds that method to the `Argv` interface.

See https://github.com/chevex/yargs#commandcmd-desc for documentation reference.

Closing #4259 since that was based off my fork's master branch (just me being lazy) but now I need to use master for other stuff.
