### PR TITLE
remove duplicate symbols for TypeScript 1.5

### DIFF
--- a/interactjs/interact.d.ts
+++ b/interactjs/interact.d.ts
@@ -189,10 +189,8 @@ interface InteractEvent {
 }
 
 interface TouchEvent {
-    changedTouches: any[];
     pageX: number;
     pageY: number;
-    touches: any[];
     type: string;
 }
 


### PR DESCRIPTION
- 1.5's lib.d.ts already ships with symbols for changedTouches
  and touches, which conflicts with these symbols
