### PR TITLE
Fix ES6 Promise typings so that a void error callback does not mess up inference

### DIFF
--- a/es6-promise/es6-promise-tests.ts
+++ b/es6-promise/es6-promise-tests.ts
@@ -160,3 +160,32 @@ getJSON('story.json').then(function(story: Story) {
 }).then(function() {
   (<HTMLElement>document.querySelector('.spinner')).style.display = 'none';
 });
+
+interface T1 {
+    __t1: string;
+}
+
+interface T2 {
+    __t2: string;
+}
+
+interface T3 {
+    __t3: string;
+}
+
+function f1(): Promise<T1> {
+    return Promise.resolve({ __t1: "foo_t1" });
+}
+
+function f2(x: T1): T2 {
+    return { __t2: x.__t1 + ":foo_21" };
+}
+
+var x3 = f1()
+    .then(f2, (e: Error) => {
+    console.log("error 1");
+    throw e;
+})
+    .then((x: T2) => {
+    return { __t3: x.__t2 + "bar" };
+});

--- a/es6-promise/es6-promise.d.ts
+++ b/es6-promise/es6-promise.d.ts
@@ -4,7 +4,8 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 interface Thenable<R> {
-	then<U>(onFulfilled?: (value: R) => U | Thenable<U>,  onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
+    then<U>(onFulfilled?: (value: R) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
+    then<U>(onFulfilled?: (value: R) => U | Thenable<U>, onRejected?: (error: any) => void): Thenable<U>;
 }
 
 declare class Promise<R> implements Thenable<R> {
@@ -27,7 +28,8 @@ declare class Promise<R> implements Thenable<R> {
 	 * @param onFulfilled called when/if "promise" resolves
 	 * @param onRejected called when/if "promise" rejects
 	 */
-	then<U>(onFulfilled?: (value: R) => U | Thenable<U>,  onRejected?: (error: any) => U | Thenable<U>): Promise<U>;
+    then<U>(onFulfilled?: (value: R) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>): Promise<U>;
+    then<U>(onFulfilled?: (value: R) => U | Thenable<U>, onRejected?: (error: any) => void): Promise<U>;
 
 	/**
 	 * Sugar for promise.then(undefined, onRejected)


### PR DESCRIPTION
Type argument inference won't work if TResult tries to get inference candidates from a void error callback. I've added a signature that does not infer from the callback if it is void. This signature will be used if inference failed for the first signature.

This fixes #3632
