### PR TITLE
jsuri: need to declare global Uri as type instead of var

### DIFF
--- a/jsuri/jsuri.d.ts
+++ b/jsuri/jsuri.d.ts
@@ -132,7 +132,7 @@ declare module jsuri {
   }
 }
 
-declare var Uri : jsuri.Uri;
+declare type Uri = jsuri.Uri;
 
 declare module 'jsuri' {
   export = Uri;


### PR DESCRIPTION
Declaring the global Uri as a var instead of as a type leads to runtime
errors as the jsuri script leaks Uri to global directly when not loaded
via AMD or CommonJS, instead of leaking a jsuri module object.

Developers working with jsuri in the global namespace need to use Uri
directly instead of prfacing with jsuri in order to avoid runtime issues
with 'jsuri' being undefined.
