### PR TITLE
Remove emptyDomNode, which is not public in Knockout

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -281,8 +281,6 @@ interface KnockoutUtils {
 
     extend(target: Object, source: Object): Object;
 
-    emptyDomNode(domNode: HTMLElement): void;
-
     moveCleanedNodesToContainerElement(nodes: any[]): HTMLElement;
 
     cloneNodes(nodesArray: any[], shouldCleanNodes: boolean): any[];


### PR DESCRIPTION
`ko.emptyDomNode` is excluded from Knockout's minified version because it is treated as internal by Knockout code. This causes apps which compile against `emptyDomNode` to fail at runtime.
