### PR TITLE
Dojo - Support TypeScript 1.5

### DIFF
--- a/dojo/dojo.d.ts
+++ b/dojo/dojo.d.ts
@@ -3098,7 +3098,7 @@ declare module dojo {
      */
     class Stateful {
         constructor();
-        inherited: {(arguments: IArguments): any};
+        inherited: {(args: IArguments): any};
         /**
          * Get a property on a Stateful instance.
          * Get a named property on a Stateful object. The property may


### PR DESCRIPTION
According to TypeScript 1.5 beta compiler, there is an error in this line.

```
Invalid use of 'arguments'. Class definitions are automatically in strict mode.
```
