### PR TITLE
Add type declarations for unorm: both importable module and ambient var

### DIFF
--- a/unorm/unorm-tests.ts
+++ b/unorm/unorm-tests.ts
@@ -1,0 +1,11 @@
+/// <reference path="unorm.d.ts" />
+import unorm = require("unorm");
+
+function listNormalizations(raw: string) {
+  return [
+    unorm.nfd(raw),
+    unorm.nfkd(raw),
+    unorm.nfc(raw),
+    unorm.nfkc(raw),
+  ];
+}

--- a/unorm/unorm.d.ts
+++ b/unorm/unorm.d.ts
@@ -1,0 +1,14 @@
+declare module unorm {
+  interface Static {
+    nfd(str: string): string;
+    nfkd(str: string): string;
+    nfc(str: string): string;
+    nfkc(str: string): string;
+  }
+}
+
+declare var unorm: unorm.Static;
+
+declare module "unorm" {
+  export = unorm;
+}

--- a/unorm/unorm.d.ts
+++ b/unorm/unorm.d.ts
@@ -1,3 +1,8 @@
+// Type definitions for unorm 1.3.3
+// Project: https://github.com/walling/unorm
+// Definitions by: Christopher Brown <https://github.com/chbrown>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
 declare module unorm {
   interface Static {
     nfd(str: string): string;


### PR DESCRIPTION
[`unorm`](https://www.npmjs.com/package/unorm) has a minimal [API](https://www.npmjs.com/package/unorm#functions).
