### PR TITLE
Update whatwg-fetch.d.ts

### DIFF
--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -51,7 +51,7 @@ declare class Body {
 	arrayBuffer(): Promise<ArrayBuffer>;
 	blob(): Promise<Blob>;
 	formData(): Promise<FormData>;
-	json(): Promise<JSON>;
+	json(): Promise<any>;
 	text(): Promise<string>;
 }
 declare class Response extends Body {


### PR DESCRIPTION
The json method when invoked, must return the result of running consume body with JSON. This implies that it must have the same return value as JSON.parse, which is any.
