### PR TITLE
 Adding the default logger's `level` property.

### DIFF
--- a/winston/winston-tests.ts
+++ b/winston/winston-tests.ts
@@ -8,6 +8,8 @@ var num: number;
 var metadata: any;
 var obj: any = {};
 
+winston.level = 'debug';
+
 var queryOptions: winston.QueryOptions;
 var transportOptions: winston.TransportOptions;
 var loggerOptions: winston.LoggerOptions = {

--- a/winston/winston.d.ts
+++ b/winston/winston.d.ts
@@ -17,7 +17,7 @@ declare module "winston" {
   export var defaultLogger: LoggerInstance;
 
   export var exitOnError: boolean;
-
+  export var level: string;
 
   export function log(level: string, msg: string, meta: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
   export function log(level: string, msg: string, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;


### PR DESCRIPTION
The definition for the default logger's level property is missing from the definition file.
