### PR TITLE
Update auth0.d.ts for typescript 1.5.0-beta

### DIFF
--- a/auth0/auth0.d.ts
+++ b/auth0/auth0.d.ts
@@ -9,10 +9,6 @@ interface Window {
     token: string;
 }
 
-interface Location {
-    origin: string;
-}
-
 /** This is the interface for the main Auth0 client. */
 interface Auth0Static {
     


### PR DESCRIPTION
Removed the Location interface due to a duplicate property added to lib.d.ts in 1.5.0-beta.
