### PR TITLE
Add module declaration for AMD compatability

### DIFF
--- a/js-signals/js-signals.d.ts
+++ b/js-signals/js-signals.d.ts
@@ -5,6 +5,10 @@
 
 declare var signals: SignalWrapper;
 
+declare module "signals" {
+	export = signals;
+}
+
 interface SignalWrapper {
     Signal: Signal
 }


### PR DESCRIPTION
This adds a module declaration which enables use with the AMD module system. The exported symbol is `signals.Signal` so that we get the constructor exported as compared to having to do `new signals.Signal()`.
