### PR TITLE
Add missing Google Maps Data Layer API

### DIFF
--- a/googlemaps/google.maps-tests.ts
+++ b/googlemaps/google.maps-tests.ts
@@ -1,0 +1,107 @@
+// Test file for Google Maps JavaScript API Definition file
+/// <reference path="google.maps.d.ts" />
+
+var map = new google.maps.Map(document.querySelector("☺"));
+
+/***** Data *****/
+ 
+new google.maps.Data();
+new google.maps.Data({ map: map });
+ 
+var latLng = new google.maps.LatLng(52.201203, -1.724370),
+    feature = new google.maps.Data.Feature(),
+    geometry = new google.maps.Data.Geometry();
+
+var data = map.data;
+
+data.add(feature);
+
+data.add({
+    geometry: latLng,
+    id: "Test feature",
+    properties: {}
+});
+
+var isIn: boolean = map.data.contains(feature);
+
+data.forEach((feature: google.maps.Data.Feature) => {
+    console.log(feature.getId());
+});
+
+var map: google.maps.Map = data.getMap();
+data.setMap(map);
+
+var style = data.getStyle();
+data.setStyle(style);
+
+data.setStyle({
+    clickable: true,
+    cursor: "pointer",
+    fillColor: "#79B55B",
+    fillOpacity: 1,
+    icon: {},
+    shape: { coords: [1, 2, 3], type: "circle" },
+    strokeColor: "#79B55B",
+    strokeOpacity: 1,
+    strokeWeight: 1,
+    title: "string",
+    visible: true,
+    zIndex: 1
+});
+
+data.overrideStyle(feature, { visible: true });
+
+data.revertStyle(feature);
+
+data.addGeoJson({});
+data.addGeoJson({}, { idPropertyName: "Test feature" });
+
+data.loadGeoJson("http://magicGeoJsonSource.com");
+
+data.loadGeoJson(
+    "http://magicGeoJsonSource.com",
+    { idPropertyName: "test" });
+    
+data.loadGeoJson(
+    "http://magicGeoJsonSource.com",
+    { idPropertyName: "test" },
+    (features) => {
+        for (var i = 0, len = features.length; i < len; i++) {
+            console.log(features[i].getId());
+        }
+    });
+
+data.toGeoJson((feature) => { });
+
+var dataMouseEvent: google.maps.Data.MouseEvent = {
+    feature: feature,
+    latLng: latLng,
+    stop: (): void => {}
+};
+
+var addFeatureEvent : google.maps.Data.AddFeatureEvent = {
+    feature: feature
+};
+
+var removeFeatureEvent: google.maps.Data.RemoveFeatureEvent = {
+    feature: feature
+};
+
+var setGeometryEvent: google.maps.Data.SetGeometryEvent  = {
+    feature: feature,
+    newGeometry: geometry,
+    oldGeometry: geometry,
+};
+
+var setPropertyEvent: google.maps.Data.SetPropertyEvent = {
+    feature: feature,
+    name: "test",
+    newValue: {},
+    oldValue: {}
+};
+ 
+var removePropertyEvent: google.maps.Data.RemovePropertyEvent = {
+    feature: feature,
+    name: "test",
+    oldValue: {}
+};

--- a/googlemaps/google.maps.d.ts
+++ b/googlemaps/google.maps.d.ts
@@ -208,7 +208,7 @@ declare module google.maps {
     }
 
     /***** Data *****/
-     export class Data extends MVCObject {
+    export class Data extends MVCObject {
         constructor(options?: Data.DataOptions);
         add(feature: Data.Feature|Data.FeatureOptions): Data.Feature;
         addGeoJson(geoJson: Object, options?: Data.GeoJsonOptions): Data.Feature[];
@@ -308,14 +308,14 @@ declare module google.maps {
         }
         
         export class Polygon extends Data.Geometry {
-            constructor(elements: LinearRing[]|LatLng[]); // TODO LatLngLiteral
+            constructor(elements: LinearRing[]|LatLng[][]); // TODO LatLngLiteral
             getArray(): LinearRing[];
             getAt(n: number): LinearRing;
             getLength(): number;
         }
         
         export class MultiPolygon extends Data.Geometry {
-            constructor(elements: Data.Polygon[]|LinearRing[]|LatLng[][]); // TODO LatLngLiteral
+            constructor(elements: Data.Polygon[]|LinearRing[][]|LatLng[][][]); // TODO LatLngLiteral
             getArray(): Data.Polygon[];
             getAt(n: number): Data.Polygon;
             getLength(): number;

--- a/googlemaps/google.maps.d.ts
+++ b/googlemaps/google.maps.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for Google Geolocation 0.4.8
+// Type definitions for Google Maps JavaScript API 3.19
 // Project: https://developers.google.com/maps/
-// Definitions by: Folia A/S <http://www.folia.dk>
+// Definitions by: Folia A/S <http://www.folia.dk>, Chris Wrench <https://github.com/cgwrench>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /*
@@ -80,9 +80,10 @@ declare module google.maps {
         setStreetView(panorama: StreetViewPanorama): void;
         setTilt(tilt: number): void;
         setZoom(zoom: number): void;
-        controls: MVCArray[]; //Array.<MVCArray.<Node >>
+        controls: MVCArray[]; //Array<MVCArray.<Node >>
+        data: Data;
         mapTypes: MapTypeRegistry;
-        overlayMapTypes: MVCArray; // MVCArray.<MapType>
+        overlayMapTypes: MVCArray; // MVCArray<MapType>
     }
 
     export interface MapOptions {
@@ -204,6 +205,159 @@ declare module google.maps {
         SMALL,
         ANDROID,
         ZOOM_PAN
+    }
+
+    /***** Data *****/
+     export class Data extends MVCObject {
+        constructor(options?: Data.DataOptions);
+        add(feature: Data.Feature|Data.FeatureOptions): Data.Feature;
+        addGeoJson(geoJson: Object, options?: Data.GeoJsonOptions): Data.Feature[];
+        contains(feature: Data.Feature): boolean;
+        forEach(callback: (feature: Data.Feature) => void): void;
+        getFeatureById(id: number|string): Data.Feature;
+        getMap(): Map;
+        getStyle(): Data.StylingFunction|Data.StyleOptions;
+        loadGeoJson(url: string, options?: Data.GeoJsonOptions, callback?: (features: Data.Feature[]) => void): void;
+        overrideStyle(feature: Data.Feature, style: Data.StyleOptions): void;
+        remove(feature: Data.Feature): void;
+        revertStyle(feature?: Data.Feature): void;
+        setMap(map: Map): void;
+        setStyle(style: Data.StylingFunction|Data.StyleOptions): void;
+        toGeoJson(callback: (feature: Object) => void): void;
+    }
+        
+    export module Data {
+        export interface DataOptions {
+            map?: Map;
+            style?: Data.StylingFunction|Data.StyleOptions;
+        }
+
+        export interface GeoJsonOptions {
+            idPropertyName?: string;
+        }
+
+        export interface StyleOptions {
+            clickable?: boolean;
+            cursor?: string;
+            fillColor?: string;
+            fillOpacity?: number;
+            icon?: any; // TODO string|Icon|Symbol;
+            shape?: MarkerShape;
+            strokeColor?: string;
+            strokeOpacity?: number;
+            strokeWeight?: number;
+            title?: string;
+            visible?: boolean;
+            zIndex?: number;
+        }
+
+        export type StylingFunction = (feature: Data.Feature) => Data.StyleOptions;
+
+        export class Feature {
+            constructor(options?: Data.FeatureOptions);
+            forEachProperty(callback: (value: any, name: string) => void): void;
+            getGeometry(): Data.Geometry;
+            getId(): number|string;
+            getProperty(name: string): any;
+            removeProperty(name: string): void;
+            setGeometry(newGeometry: Data.Geometry|LatLng): void; // TODO LatLngLiteral
+            setProperty(name: string, newValue: any): void
+            toGeoJson(callback: (feature: Object) => void): void
+        }
+
+        export interface FeatureOptions {
+            geometry?: Data.Geometry|LatLng; // TODO LatLngLiteral
+            id?: number|string;
+            properties?: Object;
+        }
+
+        export class Geometry {
+            getType(): string;
+        }
+        
+        export class Point extends Data.Geometry {
+            constructor(latLng: LatLng);  // TODO LatLngLiteral
+            get(): LatLng;
+        }
+        
+        export class MultiPoint extends Data.Geometry {
+            constructor(elements: LatLng[]);  // TODO LatLngLiteral
+            getAt(n: number): LatLng;
+            getLength(): number;
+        }
+        
+        export class LineString extends Data.Geometry {
+            constructor(elements: LatLng[]);  // TODO LatLngLiteral
+            getArray(): LatLng[];
+            getAt(n: number): LatLng;
+            getLength(): number;
+        }
+        
+        export class MultiLineString extends Data.Geometry {
+            constructor(elements: Data.LineString[]|LatLng[]); // TODO LatLngLiteral
+            getArray(): Data.LineString[];
+            getAt(n: number): Data.LineString;
+            getLength(): number;
+        }
+        
+        export class LinearRing extends Data.Geometry {
+            constructor(elements: LatLng[]); // TODO LatLngLiteral
+            getArray(): LatLng[];
+            getAt(n: number): LatLng;
+            getLength(): number;
+        }
+        
+        export class Polygon extends Data.Geometry {
+            constructor(elements: LinearRing[]|LatLng[]); // TODO LatLngLiteral
+            getArray(): LinearRing[];
+            getAt(n: number): LinearRing;
+            getLength(): number;
+        }
+        
+        export class MultiPolygon extends Data.Geometry {
+            constructor(elements: Data.Polygon[]|LinearRing[]|LatLng[][]); // TODO LatLngLiteral
+            getArray(): Data.Polygon[];
+            getAt(n: number): Data.Polygon;
+            getLength(): number;
+        }
+        
+        export class GeometryCollection extends Data.Geometry {
+            constructor(elements: Data.Geometry[]|LatLng[]); // TODO LatLngLiteral
+            getArray(): Data.Geometry[];
+            getAt(n: number): Data.Geometry;
+            getLength(): number;
+        }
+        
+        export interface MouseEvent extends google.maps.MouseEvent {
+            feature: Data.Feature;
+        }
+        
+        export interface AddFeatureEvent {
+            feature: Data.Feature;
+        }
+        
+        export interface RemoveFeatureEvent {
+            feature: Data.Feature;
+        }
+        
+        export interface SetGeometryEvent  {
+            feature: Data.Feature;
+            newGeometry: Data.Geometry;
+            oldGeometry: Data.Geometry;
+        }
+        
+        export interface SetPropertyEvent  {
+            feature: Data.Feature;
+            name: string;
+            newValue: any;
+            oldValue: any;
+        } 
+        
+        export interface RemovePropertyEvent  {
+            feature: Data.Feature;
+            name: string;
+            oldValue: any;
+        }           
     }
 
     /***** Overlays *****/


### PR DESCRIPTION
Fixes #2249.
- Add a `data` property to the `Map` class.
- Add Google Maps test file and Data Layer API tests.
- Add the following classes and interfaces which form the Data Layer API:
  - `Data`
  - `Data.DataOptions`
  - `Data.GeoJsonOptions`
  - `Data.StyleOptions`
  - `Data.StylingFunction`
  - `Data.Feature`
  - `Data.FeatureOptions`
  - `Data.Geometry`
  - `Data.Point`
  - `Data.MultiPoint`
  - `Data.LineString`
  - `Data.MultiLineString`
  - `Data.LinearRing`
  - `Data.Polygon`
  - `Data.MultiPolygon`
  - `Data.GeometryCollection`
  - `Data.MouseEvent`
  - `Data.AddFeatureEvent`
  - `Data.RemoveFeatureEvent`
  - `Data.SetGeometryEvent`
  - `Data.SetPropertyEvent`
  - `Data.RemovePropertyEvent`
