### PR TITLE
mongoose: fixes for ObjectId

### DIFF
--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -364,5 +364,14 @@ schema.virtual('display_name')
   .get(function(): string { return this.name; })
   .set((value: string): void => {});
 
-var id : mongoose.Types.ObjectId;
+var id: mongoose.Types.ObjectId = new mongoose.Types.ObjectId('foo');
+var id2: mongoose.Types.ObjectId = new mongoose.Types.ObjectId(123);
+var id2: mongoose.Types.ObjectId = mongoose.Types.ObjectId.createFromTime(123);
+var id2: mongoose.Types.ObjectId = mongoose.Types.ObjectId.createFromHexString('foo');
 var s = id.toHexString();
+var valid = id.isValid();
+var eq = id.equals(id2);
+
+var kitty1 = new Kitty({});
+var kitty2 = new Kitty({});
+var kittyEq = kitty1._id.equals(kitty2._id);

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -79,7 +79,13 @@ declare module "mongoose" {
   }
   export module Types {
     export class ObjectId {
-        toHexString(): string;
+      constructor(id: string|number);
+      toHexString(): string;
+      equals(other: ObjectId): boolean;
+      getTimestamp(): Date;
+      isValid(): boolean;
+      static createFromTime(time: number): ObjectId;
+      static createFromHexString(hexString: string): ObjectId;
     }
   }
 
@@ -374,7 +380,7 @@ declare module "mongoose" {
 
   export interface Document {
     id?: string;
-    _id: string;
+    _id: Types.ObjectId;
 
     equals(doc: Document): boolean;
     get(path: string, type?: new(...args: any[]) => any): any;


### PR DESCRIPTION
added missing ObjectId methods, changed Document _id property from string to ObjectId
