### PR TITLE
WinRT readBytes fix

### DIFF
--- a/winrt/winrt.d.ts
+++ b/winrt/winrt.d.ts
@@ -9268,7 +9268,7 @@ declare module Windows {
                 unconsumedBufferLength: number;
                 unicodeEncoding: Windows.Storage.Streams.UnicodeEncoding;
                 readByte(): number;
-                readBytes(): Uint8Array;
+                readBytes(value: Uint8Array): void;
                 readBuffer(length: number): Windows.Storage.Streams.IBuffer;
                 readBoolean(): boolean;
                 readGuid(): string;
@@ -9297,7 +9297,7 @@ declare module Windows {
                 unconsumedBufferLength: number;
                 unicodeEncoding: Windows.Storage.Streams.UnicodeEncoding;
                 readByte(): number;
-                readBytes(): Uint8Array;
+                readBytes(value: Uint8Array): void;
                 readBuffer(length: number): Windows.Storage.Streams.IBuffer;
                 readBoolean(): boolean;
                 readGuid(): string;

--- a/winrt/winrt.d.ts
+++ b/winrt/winrt.d.ts
@@ -9268,6 +9268,7 @@ declare module Windows {
                 unconsumedBufferLength: number;
                 unicodeEncoding: Windows.Storage.Streams.UnicodeEncoding;
                 readByte(): number;
+                readBytes(value: number[]): void;
                 readBytes(value: Uint8Array): void;
                 readBuffer(length: number): Windows.Storage.Streams.IBuffer;
                 readBoolean(): boolean;
@@ -9297,6 +9298,7 @@ declare module Windows {
                 unconsumedBufferLength: number;
                 unicodeEncoding: Windows.Storage.Streams.UnicodeEncoding;
                 readByte(): number;
+                readBytes(value: number[]): void;
                 readBytes(value: Uint8Array): void;
                 readBuffer(length: number): Windows.Storage.Streams.IBuffer;
                 readBoolean(): boolean;
@@ -9345,6 +9347,7 @@ declare module Windows {
                 unicodeEncoding: Windows.Storage.Streams.UnicodeEncoding;
                 unstoredBufferLength: number;
                 writeByte(value: number): void;
+                writeBytes(value: number[]): void;
                 writeBytes(value: Uint8Array): void;
                 writeBuffer(buffer: Windows.Storage.Streams.IBuffer): void;
                 writeBuffer(buffer: Windows.Storage.Streams.IBuffer, start: number, count: number): void;
@@ -9377,6 +9380,7 @@ declare module Windows {
                 unicodeEncoding: Windows.Storage.Streams.UnicodeEncoding;
                 unstoredBufferLength: number;
                 writeByte(value: number): void;
+                writeBytes(value: number[]): void;
                 writeBytes(value: Uint8Array): void;
                 writeBuffer(buffer: Windows.Storage.Streams.IBuffer): void;
                 writeBuffer(buffer: Windows.Storage.Streams.IBuffer, start: number, count: number): void;


### PR DESCRIPTION
Calling `readBytes()` without any parameters causes runtime error, and `readBytes(value)` works as expected.

https://social.msdn.microsoft.com/Forums/windowsapps/en-US/a335ce9a-c838-45d8-b65a-0b2a3aa9fb79/how-to-the-get-the-original-file-in-order-to-send-it-over-a-winjsxhr-put?forum=winappswithhtml5
