### PR TITLE
ADDED then method to hellojs

### DIFF
--- a/hellojs/hellojs.d.ts
+++ b/hellojs/hellojs.d.ts
@@ -44,6 +44,7 @@ interface HelloJSStatic extends HelloJSEvent {
     settings: HelloJSLoginOptions;
     (network: string): HelloJSStaticNamed;
     init(servicesDef: { [id: string]: HelloJSServiceDef; }): void;
+    then(callback: (json?: any) => void, errorCallback?: (boolOrJson?: any) => void);
 }
 
 interface HelloJSStaticNamed {

--- a/hellojs/hellojs.d.ts
+++ b/hellojs/hellojs.d.ts
@@ -44,7 +44,7 @@ interface HelloJSStatic extends HelloJSEvent {
     settings: HelloJSLoginOptions;
     (network: string): HelloJSStaticNamed;
     init(servicesDef: { [id: string]: HelloJSServiceDef; }): void;
-    then(callback: (json?: any) => void, errorCallback?: (boolOrJson?: any) => void);
+    then(callback: (json?: any) => void, errorCallback?: (boolOrJson?: any) => void): void;
 }
 
 interface HelloJSStaticNamed {


### PR DESCRIPTION
The `then` method is required for error handling with _hello.js_ (see [here](http://adodson.com/hello.js/#error-handling)).
