### PR TITLE
fixed the collection TModel workaround.

### DIFF
--- a/backbone/backbone.d.ts
+++ b/backbone/backbone.d.ts
@@ -169,9 +169,7 @@ declare module Backbone {
         **/
         private static extend(properties: any, classProperties?: any): any;
 
-        // TODO: this really has to be typeof TModel
-        //model: typeof TModel;
-        model: { new(): TModel; }; // workaround
+        model: new (...args:any[]) => TModel;
         models: TModel[];
         length: number;
 


### PR DESCRIPTION
Like this it is possible to pass the Type to the model property like following.

``` javascript
class MyCollection extends Backbone.Collection<MyModel> {

    constructor(models?:Array<MyModel>, options?:any) {
        this.model = MyModel;
        super(models, options);
    }

}
```
