### PR TITLE
Update JQuery export for ES6

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -3156,7 +3156,7 @@ interface JQuery {
     queue(queueName: string, callback: Function): JQuery;
 }
 declare module "jquery" {
-    export = $;
+    export default $;
 }
 declare var jQuery: JQueryStatic;
 declare var $: JQueryStatic;


### PR DESCRIPTION
Previously compiling with -t ES6 would fail with `error TS1203: Export assignment cannot be used when targeting ECMAScript 6 or higher. Consider using 'export default' instead`.

This appears to be the only such export in the JQuery definitions; the library compiles fine with ES6 output otherwise.
