### PR TITLE
Add definitions for the Piwik NodeJS tracker

### DIFF
--- a/piwik-tracker/piwik-tracker-tests.ts
+++ b/piwik-tracker/piwik-tracker-tests.ts
@@ -9,7 +9,7 @@ var PiwikTracker = require('piwik-tracker');
 var piwik = new PiwikTracker(1, 'http://mywebsite.com/piwik.php');
  
 // Optional: Respond to tracking errors 
-piwik.on('error', function(err) {
+piwik.on('error', function(err : Error) {
   console.log('error tracking request: ', err)
 })
  

--- a/piwik-tracker/piwik-tracker-tests.ts
+++ b/piwik-tracker/piwik-tracker-tests.ts
@@ -1,0 +1,28 @@
+/// <reference path="../node/node.d.ts" />
+/// <reference path="piwik-tracker.d.ts" />
+
+// Example code taken from https://www.npmjs.com/package/piwik-tracker
+
+var PiwikTracker = require('piwik-tracker');
+ 
+// Initialize with your site ID and Piwik URL 
+var piwik = new PiwikTracker(1, 'http://mywebsite.com/piwik.php');
+ 
+// Optional: Respond to tracking errors 
+piwik.on('error', function(err) {
+  console.log('error tracking request: ', err)
+})
+ 
+// Track a request URL: 
+// Either as a simple string … 
+piwik.track('http://example.com/track/this/url');
+ 
+// … or provide further options: 
+piwik.track({
+  url: 'http://example.com/track/this/url',
+  action_name: 'This will be shown in your dashboard',
+  ua: 'Node.js v0.10.24',
+  cvar: JSON.stringify({
+    '1': ['custom variable name', 'custom variable value']
+  })
+});

--- a/piwik-tracker/piwik-tracker.d.ts
+++ b/piwik-tracker/piwik-tracker.d.ts
@@ -7,6 +7,8 @@
 
 declare module "piwik-tracker" {
 	
+	import events = require('events');
+	
 	export = PiwikTracker;
 	
 	// refer to http://developer.piwik.org/api-reference/tracking-api
@@ -85,7 +87,7 @@ declare module "piwik-tracker" {
 		send_image? : number;
 	}
 	
-	class PiwikTracker extends EventEmitter {
+	class PiwikTracker extends events.EventEmitter {
 		constructor(siteId : number, trackerUrl : string);
 		track(options : PiwikTrackOptions) : void;
 	}

--- a/piwik-tracker/piwik-tracker.d.ts
+++ b/piwik-tracker/piwik-tracker.d.ts
@@ -83,7 +83,7 @@ declare module "piwik-tracker" {
 		send_image? : number;
 	}
 	
-	class PiwikTracker {
+	class PiwikTracker extends EventEmitter {
 		constructor(siteId : number, trackerUrl : string);
 		track(options : PiwikTrackOptions) : void;
 	}

--- a/piwik-tracker/piwik-tracker.d.ts
+++ b/piwik-tracker/piwik-tracker.d.ts
@@ -1,0 +1,91 @@
+// Type definitions for PiwikTracker v0.1.1
+// Project: http://piwik.org - https://www.npmjs.com/package/piwik-tracker
+// Definitions by: Guilherme Bernal <https://github.com/lbguilherme>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module "piwik-tracker" {
+	
+	export = PiwikTracker;
+	
+	// refer to http://developer.piwik.org/api-reference/tracking-api
+	interface PiwikTrackOptions {
+		// Required parameters
+		url : string;
+		
+		// Recommended parameters
+		action_name? : string;
+		_id? : string;
+		rand? : string;
+		apiv? : number;
+		
+		// Optional User info
+		urlref? : string;
+		_cvar? : string;
+		_idvc? : string;
+		_viewts? : string;
+		_idts? : string;
+		_rcn? : string;
+		_rck? : string;
+		res? : string;
+		h? : number;
+		m? : number;
+		s? : number;
+		ua? : string;
+		lang? : string;
+		uid? : string;
+		cid? : string;
+		new_visit? : number;
+		
+		// Optional Action info
+		cvar? : string;
+		link? : string;
+		download? : string;
+		search? : string;
+		search_cat? : string;
+		search_count? : number;
+		idgoal? : number;
+		revenue? : number;
+		gt_ms? : number;
+		cs? : string;
+		
+		// Optional Event Tracking info
+		e_c? : string;
+		e_a? : string;
+		e_n? : string;
+		e_v? : string;
+		
+		// Optional Content Tracking info
+		c_n? : string;
+		c_p? : string;
+		c_t? : string;
+		c_i? : string;
+		
+		// Optional Ecommerce info
+		ec_id? : string;
+		ec_items? : string;
+		ec_st? : number;
+		ec_tx? : number;
+		ec_sh? : number;
+		ec_dt? : number;
+		_ects? : number;
+		
+		// Other parameters (require authentication via token_auth)
+		token_auth? : string;
+		cip? : string;
+		cdt? : string;
+		country? : string;
+		region? : string;
+		city? : string;
+		lat? : string;
+		long? : string;
+		
+		// Other parameters
+		send_image? : number;
+	}
+	
+	class PiwikTracker {
+		constructor(siteId : number, trackerUrl : string);
+		track(options : PiwikTrackOptions) : void;
+	}
+	
+}

--- a/piwik-tracker/piwik-tracker.d.ts
+++ b/piwik-tracker/piwik-tracker.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for PiwikTracker v0.1.1
-// Project: http://piwik.org - https://www.npmjs.com/package/piwik-tracker
+// Project: https://www.npmjs.com/package/piwik-tracker
 // Definitions by: Guilherme Bernal <https://github.com/lbguilherme>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 

--- a/piwik-tracker/piwik-tracker.d.ts
+++ b/piwik-tracker/piwik-tracker.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Guilherme Bernal <https://github.com/lbguilherme>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
+/// <reference path="../node/node.d.ts" />
+
 declare module "piwik-tracker" {
 	
 	export = PiwikTracker;


### PR DESCRIPTION
Piwik.org is a tracker similar to Google Analitics, but can run on your own server. These definitions are for the node api.
