### PR TITLE
express: Request.host has been deprecated, use .hostname instead

### DIFF
--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -349,6 +349,11 @@ declare module "express" {
             /**
              * Parse the "Host" header field hostname.
              */
+            hostname: string;
+
+            /**
+             * @deprecated Use hostname instead.
+             */
             host: string;
 
             /**


### PR DESCRIPTION
Express [has deprecated `Request.host`](https://github.com/strongloop/express/blob/e9c9f95ade0f20a048861ac886d4767a839d5286/lib/request.js#L400), replacing it with `Request.hostname` [in July 2014](https://github.com/strongloop/express/commit/e6eeec3f0392f32271309e92aec965b00bbb777d). This pull request brings the definition in line with this change.
