### PR TITLE
Make errback an optional argument (Squire.js)

### DIFF
--- a/squirejs/squirejs.d.ts
+++ b/squirejs/squirejs.d.ts
@@ -9,7 +9,7 @@ declare module 'Squire' {
         constructor(context: string);
         mock(name: string, mock: any): Squire;
         mock(mocks: {[name: string]: any}): Squire;
-        require(dependencies: string[], callback: Function, errback: Function): Squire;
+        require(dependencies: string[], callback: Function, errback?: Function): Squire;
         store(name: string | string[]): Squire;
         clean(): Squire;
         clean(name: string | string[]): Squire;


### PR DESCRIPTION
Actually Squire.js uses `require(module: string | modules: string[], ready?: Function, errback?: Function)` method of requirejs, where errback is [optional](https://github.com/borisyankov/DefinitelyTyped/blob/master/requirejs/require.d.ts#L250)
