### PR TITLE
expect.js: There's missing export directive

### DIFF
--- a/expect.js/expect.js.d.ts
+++ b/expect.js/expect.js.d.ts
@@ -214,3 +214,9 @@ declare module Expect {
         own: Assertion;
     }
 }
+
+declare module "expect.js" {
+
+    export = expect;
+
+}


### PR DESCRIPTION
Without the "export" statement, my IDE does not recognize the library properly.
