### PR TITLE
Return Firebase as type from $ref

### DIFF
--- a/angularfire/angularfire-tests.ts
+++ b/angularfire/angularfire-tests.ts
@@ -46,7 +46,7 @@ myapp.controller("MyController", ["$scope", "$firebase", '$FirebaseObject', '$Fi
 
         // AngularFireObject
         {
-            var obj = sync.$asObject();
+            var obj = $FirebaseObject(ref);
 
             // $id
             if (obj.$id !== ref.name()) throw "error";
@@ -63,7 +63,7 @@ myapp.controller("MyController", ["$scope", "$firebase", '$FirebaseObject', '$Fi
             });
 
             // $ref()
-            if (obj.$ref() !== sync) throw "error";
+            if (obj.$ref() !== ref) throw "error";
 
             // $bindTo()
             obj.$bindTo($scope, "data").then(function () {
@@ -92,10 +92,10 @@ myapp.controller("MyController", ["$scope", "$firebase", '$FirebaseObject', '$Fi
 
         // AngularFireArray
         {
-            var list = sync.$asArray();
+            var list = $FirebaseArray(ref);
 
             // $ref()
-            if (list.$ref() !== sync) throw "error";
+            if (list.$ref() !== ref) throw "error";
 
             // $add()
             list.$add({ foo: "foo value" });

--- a/angularfire/angularfire.d.ts
+++ b/angularfire/angularfire.d.ts
@@ -33,7 +33,7 @@ interface AngularFireObject extends AngularFireSimpleObject {
 	$loaded(resolve?: (x: AngularFireObject) => ng.IHttpPromise<{}>, reject?: (err: any) => any): ng.IPromise<AngularFireObject>;
 	$loaded(resolve?: (x: AngularFireObject) => ng.IPromise<{}>, reject?: (err: any) => any): ng.IPromise<AngularFireObject>;
 	$loaded(resolve?: (x: AngularFireObject) => void, reject?: (err: any) => any): ng.IPromise<AngularFireObject>;
-	$ref(): AngularFire;
+	$ref(): Firebase;
 	$bindTo(scope: ng.IScope, varName: string): ng.IPromise<any>;
 	$watch(callback: Function, context?: any): Function;
 	$destroy(): void;
@@ -53,7 +53,7 @@ interface AngularFireArray extends Array<AngularFireSimpleObject> {
 	$loaded(resolve?: (x: AngularFireArray) => ng.IHttpPromise<{}>, reject?: (err: any) => any): ng.IPromise<AngularFireArray>;
 	$loaded(resolve?: (x: AngularFireArray) => ng.IPromise<{}>, reject?: (err: any) => any): ng.IPromise<AngularFireArray>;
 	$loaded(resolve?: (x: AngularFireArray) => void, reject?: (err: any) => any): ng.IPromise<AngularFireArray>;
-	$ref(): AngularFire;
+	$ref(): Firebase;
 	$watch(cb: (event: string, key: string, prevChild: string) => void, context?: any): Function;
 	$destroy(): void;
 }


### PR DESCRIPTION
This is what really happens in the source code for AngularFire 1.1.1 (and always has), for both AngularFireObject and AngularFireArray.

See https://github.com/firebase/angularfire/blob/1aa81906cdfb3e35e7c31fc6dee8a4922b1470ae/src/FirebaseObject.js#L125
