### PR TITLE
Fix typing information on GenericQuantitativeScale and derivatives

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -2691,19 +2691,19 @@ declare module D3 {
 
         export interface Scale extends GenericScale<Scale> { }
 
-        export interface GenericQuantitativeScale<S> extends GenericScale<S> {
+        export interface GenericQuantitativeScale<D, S> extends GenericScale<S> {
             /**
             * Get the range value corresponding to a given domain value.
             *
             * @param value Domain Value
             */
-            (value: number): number;
+            (value: D): number;
             /**
             * Get the domain value corresponding to a given range value.
             *
             * @param value Range Value
             */
-            invert(value: number): number;
+            invert(value: number): D;
             /**
             * Set the scale's output range, and enable rounding.
             *
@@ -2746,9 +2746,9 @@ declare module D3 {
             tickFormat(count: number, format?: string): (n: number) => string;
         }
 
-        export interface QuantitativeScale extends GenericQuantitativeScale<QuantitativeScale> { }
+        export interface QuantitativeScale<D> extends GenericQuantitativeScale<D, QuantitativeScale<D>> { }
 
-        export interface LinearScale extends GenericQuantitativeScale<LinearScale> { }
+        export interface LinearScale extends GenericQuantitativeScale<number, LinearScale> { }
 
         export interface IdentityScale extends GenericScale<IdentityScale> {
             /**
@@ -2777,11 +2777,11 @@ declare module D3 {
             tickFormat(count: number): (n: number) => string;
         }
 
-        export interface SqrtScale extends GenericQuantitativeScale<SqrtScale> { }
+        export interface SqrtScale extends GenericQuantitativeScale<number, SqrtScale> { }
 
-        export interface PowScale extends GenericQuantitativeScale<PowScale> { }
+        export interface PowScale extends GenericQuantitativeScale<number, PowScale> { }
 
-        export interface LogScale extends GenericQuantitativeScale<LogScale> { }
+        export interface LogScale extends GenericQuantitativeScale<number, LogScale> { }
 
         export interface OrdinalScale extends GenericScale<OrdinalScale> {
             rangePoints(interval: any[], padding?: number): OrdinalScale;
@@ -2799,21 +2799,11 @@ declare module D3 {
             quantiles(): any[];
         }
 
-        export interface TimeScale extends GenericScale<TimeScale> {
-            (value: Date): number;
-            invert(value: number): Date;
-            rangeRound: (values: any[]) => TimeScale;
-            interpolate: {
-                (): D3.Transition.Interpolate;
-                (factory: D3.Transition.InterpolateFactory): TimeScale;
-            };
-            clamp(clamp: boolean): TimeScale;
+        export interface TimeScale extends GenericQuantitativeScale<Date, TimeScale> {
             ticks: {
                 (count: number): any[];
                 (range: D3.Time.Range, count: number): any[];
             };
-            tickFormat(count: number): (n: number) => string;
-            nice(count?: number): TimeScale;
         }
     }
 

--- a/dcjs/dc.d.ts
+++ b/dcjs/dc.d.ts
@@ -187,7 +187,7 @@ declare module DC {
         isOrdinal(): boolean;
         xAxisLabel: IBiGetSet<string, number, T>;
         yAxisLabel: IBiGetSet<string, number, T>;
-        y: IGetSet<D3.Scale.GenericQuantitativeScale<any>, T>;
+        y: IGetSet<D3.Scale.GenericQuantitativeScale<any, any>, T>;
         yAxis: IGetSet<D3.Svg.Axis, T>;
         elasticY: IGetSet<boolean, T>;
         renderHorizontalGridLines: IGetSet<boolean, T>;
@@ -219,7 +219,7 @@ declare module DC {
     }
 
     export interface BubbleMixin<T> extends ColorMixin<T> {
-        r: IGetSet<D3.Scale.GenericQuantitativeScale<any>, T>;
+        r: IGetSet<D3.Scale.GenericQuantitativeScale<any, any>, T>;
         radiusValueAccessor: IGetSet<Accessor<any, number>, T>;
         minRadiusWithLabel: IGetSet<number, T>;
         maxBubbleRelativeSize: IGetSet<number, T>;
@@ -295,7 +295,7 @@ declare module DC {
         children(): Array<BaseMixin<any>>;
         shareColors: IGetSet<boolean, CompositeChart>;
         shareTitle: IGetSet<boolean, CompositeChart>;
-        rightY: IGetSet<D3.Scale.GenericQuantitativeScale<any>, CompositeChart>;
+        rightY: IGetSet<D3.Scale.GenericQuantitativeScale<any, any>, CompositeChart>;
         rightYAxis: IGetSet<D3.Svg.Axis, CompositeChart>;
     }
 
@@ -325,7 +325,7 @@ declare module DC {
     }
 
     export interface RowChart extends CapMixin<RowChart>, MarginMixin<RowChart>, ColorMixin<RowChart>, BaseMixin<RowChart> {
-        x: IGetSet<D3.Scale.GenericQuantitativeScale<any>, RowChart>;
+        x: IGetSet<D3.Scale.GenericQuantitativeScale<any, any>, RowChart>;
         renderTitleLabel: IGetSet<boolean, RowChart>;
         xAxis: IGetSet<D3.Svg.Axis, RowChart>;
         fixedBarHeight: IGetSet<number, RowChart>;


### PR DESCRIPTION
There were some issues associated with GenericQuantitativeScale as used here: https://github.com/palantir/plottable/pull/2163
