### PR TITLE
[d3] Add optional accessor argument to CSV-like parsers.

### DIFF
--- a/d3/d3-tests.ts
+++ b/d3/d3-tests.ts
@@ -2671,3 +2671,16 @@ function keyboardEventsTest() {
         }
     });
 }
+
+// Tests using an accessor function with the CSV parser.
+// From d3 wiki: https://github.com/mbostock/d3/wiki/CSV
+d3.csv("example.csv", function(d) {
+  return {
+    year: new Date(+d.Year, 0, 1), // convert "Year" column to Date
+    make: d.Make,
+    model: d.Model,
+    length: +d.Length // convert "Length" column to number
+  };
+}, function(error, rows) {
+  console.log(rows);
+});

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -715,6 +715,14 @@ declare module D3 {
         */
         (url: string, callback?: (error: any, response: any[]) => void ): Xhr;
         /**
+        * Request a delimited values file
+        *
+        * @param url Url to request
+        * @param accessor Accessor function called by d3.csv.parse on each row's data. Uses the return value as the row's data. 
+        * @param callback Function to invoke when resource is loaded or the request fails
+        */
+        (url: string, accessor?: (d: any) => any, callback?: (error: any, response: any[]) => void ): Xhr; 
+        /**
         * Arbitrary Delimiters:
         * Constructs a new parser for the given delimiter and mime type. For example, to parse values separated by "|", the vertical bar character, use:
         * var dsv = d3.dsv("|", "text/plain");


### PR DESCRIPTION
d3's parsers accept an optional accessor argument in addition to the callback argument. It's [documented here](https://github.com/mbostock/d3/wiki/CSV).

I've added the necessary overload, as well as a test to cover the new overload.
