### PR TITLE
Type definitions for urlsafe-base64 v1.0.0

### DIFF
--- a/urlsafe-base64/urlsafe-base64-tests.ts
+++ b/urlsafe-base64/urlsafe-base64-tests.ts
@@ -1,0 +1,9 @@
+/// <reference path="urlsafe-base64.d.ts" />
+
+import URLSafeBase64 = require('urlsafe-base64');
+
+var base64 = URLSafeBase64.encode(new Buffer('3Rpbmd1aXNoZWQ', 'base64'));
+
+var buf = URLSafeBase64.decode('3Rpbmd1aXNoZWQ');
+
+var isValid = URLSafeBase64.validate('3Rpbmd1aXNoZWQ');

--- a/urlsafe-base64/urlsafe-base64.d.ts
+++ b/urlsafe-base64/urlsafe-base64.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for urlsafe-base64 v1.0.0
+// Project: https://github.com/RGBboy/urlsafe-base64
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts"/>
+
+declare module 'urlsafe-base64' {
+    /**
+     * Library version.
+     */
+    export var version: string;
+
+    /**
+     * .encode
+     *
+     * return an encoded Buffer as URL Safe Base64
+     *
+     * Note: This function encodes to the RFC 4648 Spec where '+' is encoded
+     *       as '-' and '/' is encoded as '_'. The padding character '=' is
+     *       removed.
+     *
+     * @param {Buffer} buffer
+     * @return {String}
+     * @api public
+     */
+    export function encode(buffer: Buffer): string;
+
+    /**
+     * .decode
+     *
+     * return an decoded URL Safe Base64 as Buffer
+     *
+     * @param {String}
+     * @return {Buffer}
+     * @api public
+     */
+    export function decode(base64: string): Buffer;
+
+    /**
+     * .validate
+     *
+     * Validates a string if it is URL Safe Base64 encoded.
+     *
+     * @param {String}
+     * @return {Boolean}
+     * @api public
+     */
+    export function validate(base64: string): boolean;
+}


### PR DESCRIPTION
Project page: https://github.com/RGBboy/urlsafe-base64
npm package: https://www.npmjs.com/package/urlsafe-base64

FYI similar libraries:
- https://www.npmjs.com/package/base64url (command line)
- https://www.npmjs.com/package/base64-url
