### PR TITLE
[React] Updates and Fixes (0.13.3)

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -1,10 +1,11 @@
-# React v0.13.0 Type Definitions
+# React v0.13.3 Type Definitions
 
 This folder contains the following `.d.ts` files:
-* `react-0.13.0.d.ts` declares the external module `"react"`
-* `react-addons-0.13.0.d.ts` declares the external module `"react/addons"`
-* `react-global-0.13.0.d.ts` declares the internal module `React` in the global namespace
-* `react-addons-global-0.13.0.d.ts` extends the global `React` module with `addons`
+* `react.d.ts` declares the external module `"react"`
+* `react-addons.d.ts` declares the external module `"react/addons"`
+* `react-global.d.ts` declares the internal module `React` in the global namespace
+* `react-addons-global.d.ts` extends the global `React` module with `addons`
 
-Interfaces are duplicated between these files; please take care to keep them in sync when making changes. See [#3615](https://github.com/borisyankov/DefinitelyTyped/pull/3615) for relevant discussion.
+Interfaces are duplicated between these files; please take care to keep them in sync when making changes.
+See [#3615](https://github.com/borisyankov/DefinitelyTyped/pull/3615) for relevant discussion.
 

--- a/react/react-addons-global.d.ts
+++ b/react/react-addons-global.d.ts
@@ -9,33 +9,39 @@ declare module React {
     // React.addons
     // ----------------------------------------------------------------------
 
-    export var addons: {
-        CSSTransitionGroup: CSSTransitionGroup;
-        LinkedStateMixin: LinkedStateMixin;
-        PureRenderMixin: PureRenderMixin;
-        TransitionGroup: TransitionGroup;
+    export module addons {
+        export var CSSTransitionGroup: CSSTransitionGroup;
+        export var TransitionGroup: TransitionGroup;
 
-        batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
-        batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-        batchedUpdates(callback: () => any): void;
+        export var LinkedStateMixin: LinkedStateMixin;
+        export var PureRenderMixin: PureRenderMixin;
+
+        export function batchedUpdates<A, B>(
+            callback: (a: A, b: B) => any, a: A, b: B): void;
+        export function batchedUpdates<A>(callback: (a: A) => any, a: A): void;
+        export function batchedUpdates(callback: () => any): void;
 
         // deprecated: use petehunt/react-classset or JedWatson/classnames
-        classSet(cx: { [key: string]: boolean }): string;
-        classSet(...classList: string[]): string;
+        export function classSet(cx: { [key: string]: boolean }): string;
+        export function classSet(...classList: string[]): string;
 
-        cloneWithProps<P>(element: DOMElement<P>, props: P): DOMElement<P>;
-        cloneWithProps<P>(element: ClassicElement<P>, props: P): ClassicElement<P>;
-        cloneWithProps<P>(element: ReactElement<P>, props: P): ReactElement<P>;
+        export function cloneWithProps<P>(
+            element: DOMElement<P>, props: P): DOMElement<P>;
+        export function cloneWithProps<P>(
+            element: ClassicElement<P>, props: P): ClassicElement<P>;
+        export function cloneWithProps<P>(
+            element: ReactElement<P>, props: P): ReactElement<P>;
 
-        createFragment(object: { [key: string]: ReactNode }): ReactFragment;
+        export function createFragment(
+            object: { [key: string]: ReactNode }): ReactFragment;
 
-        update(value: any[], spec: UpdateArraySpec): any[];
-        update(value: {}, spec: UpdateSpec): any;
+        export function update(value: any[], spec: UpdateArraySpec): any[];
+        export function update(value: {}, spec: UpdateSpec): any;
 
         // Development tools
-        Perf: ReactPerf;
-        TestUtils: ReactTestUtils;
-    };
+        export import Perf = ReactPerf;
+        export import TestUtils = ReactTestUtils;
+    }
 
     //
     // React.addons (Transitions)
@@ -114,14 +120,14 @@ declare module React {
         totalTime: number;
     }
 
-    interface ReactPerf {
-        start(): void;
-        stop(): void;
-        printInclusive(measurements: Measurements[]): void;
-        printExclusive(measurements: Measurements[]): void;
-        printWasted(measurements: Measurements[]): void;
-        printDOM(measurements: Measurements[]): void;
-        getLastMeasurements(): Measurements[];
+    module ReactPerf {
+        export function start(): void;
+        export function stop(): void;
+        export function printInclusive(measurements: Measurements[]): void;
+        export function printExclusive(measurements: Measurements[]): void;
+        export function printWasted(measurements: Measurements[]): void;
+        export function printDOM(measurements: Measurements[]): void;
+        export function getLastMeasurements(): Measurements[];
     }
 
     //
@@ -132,55 +138,59 @@ declare module React {
         new(): any;
     }
 
-    interface ReactTestUtils {
-        Simulate: Simulate;
+    module ReactTestUtils {
+        export import Simulate = ReactSimulate;
 
-        renderIntoDocument<P>(element: ReactElement<P>): Component<P, any>;
-        renderIntoDocument<C extends Component<any, any>>(element: ReactElement<any>): C;
+        export function renderIntoDocument<P>(
+            element: ReactElement<P>): Component<P, any>;
+        export function renderIntoDocument<C extends Component<any, any>>(
+            element: ReactElement<any>): C;
 
-        mockComponent(mocked: MockedComponentClass, mockTagName?: string): ReactTestUtils;
+        export function mockComponent(
+            mocked: MockedComponentClass, mockTagName?: string): typeof ReactTestUtils;
 
-        isElementOfType(element: ReactElement<any>, type: ReactType): boolean;
-        isTextComponent(instance: Component<any, any>): boolean;
-        isDOMComponent(instance: Component<any, any>): boolean;
-        isCompositeComponent(instance: Component<any, any>): boolean;
-        isCompositeComponentWithType(
+        export function isElementOfType(
+            element: ReactElement<any>, type: ReactType): boolean;
+        export function isTextComponent(instance: Component<any, any>): boolean;
+        export function isDOMComponent(instance: Component<any, any>): boolean;
+        export function isCompositeComponent(instance: Component<any, any>): boolean;
+        export function isCompositeComponentWithType(
             instance: Component<any, any>,
             type: ComponentClass<any>): boolean;
 
-        findAllInRenderedTree(
+        export function findAllInRenderedTree(
             tree: Component<any, any>,
             fn: (i: Component<any, any>) => boolean): Component<any, any>;
 
-        scryRenderedDOMComponentsWithClass(
+        export function scryRenderedDOMComponentsWithClass(
             tree: Component<any, any>,
             className: string): DOMComponent<any>[];
-        findRenderedDOMComponentWithClass(
+        export function findRenderedDOMComponentWithClass(
             tree: Component<any, any>,
             className: string): DOMComponent<any>;
 
-        scryRenderedDOMComponentsWithTag(
+        export function scryRenderedDOMComponentsWithTag(
             tree: Component<any, any>,
             tagName: string): DOMComponent<any>[];
-        findRenderedDOMComponentWithTag(
+        export function findRenderedDOMComponentWithTag(
             tree: Component<any, any>,
             tagName: string): DOMComponent<any>;
 
-        scryRenderedComponentsWithType<P>(
+        export function scryRenderedComponentsWithType<P>(
             tree: Component<any, any>,
             type: ComponentClass<P>): Component<P, {}>[];
-        scryRenderedComponentsWithType<C extends Component<any, any>>(
+        export function scryRenderedComponentsWithType<C extends Component<any, any>>(
             tree: Component<any, any>,
             type: ComponentClass<any>): C[];
 
-        findRenderedComponentWithType<P>(
+        export function findRenderedComponentWithType<P>(
             tree: Component<any, any>,
             type: ComponentClass<P>): Component<P, {}>;
-        findRenderedComponentWithType<C extends Component<any, any>>(
+        export function findRenderedComponentWithType<C extends Component<any, any>>(
             tree: Component<any, any>,
             type: ComponentClass<any>): C;
 
-        createRenderer(): ShallowRenderer;
+        export function createRenderer(): ShallowRenderer;
     }
 
     interface SyntheticEventData {
@@ -222,40 +232,40 @@ declare module React {
         (component: Component<any, any>, eventData?: SyntheticEventData): void;
     }
 
-    interface Simulate {
-        blur: EventSimulator;
-        change: EventSimulator;
-        click: EventSimulator;
-        cut: EventSimulator;
-        doubleClick: EventSimulator;
-        drag: EventSimulator;
-        dragEnd: EventSimulator;
-        dragEnter: EventSimulator;
-        dragExit: EventSimulator;
-        dragLeave: EventSimulator;
-        dragOver: EventSimulator;
-        dragStart: EventSimulator;
-        drop: EventSimulator;
-        focus: EventSimulator;
-        input: EventSimulator;
-        keyDown: EventSimulator;
-        keyPress: EventSimulator;
-        keyUp: EventSimulator;
-        mouseDown: EventSimulator;
-        mouseEnter: EventSimulator;
-        mouseLeave: EventSimulator;
-        mouseMove: EventSimulator;
-        mouseOut: EventSimulator;
-        mouseOver: EventSimulator;
-        mouseUp: EventSimulator;
-        paste: EventSimulator;
-        scroll: EventSimulator;
-        submit: EventSimulator;
-        touchCancel: EventSimulator;
-        touchEnd: EventSimulator;
-        touchMove: EventSimulator;
-        touchStart: EventSimulator;
-        wheel: EventSimulator;
+    module ReactSimulate {
+        export var blur: EventSimulator;
+        export var change: EventSimulator;
+        export var click: EventSimulator;
+        export var cut: EventSimulator;
+        export var doubleClick: EventSimulator;
+        export var drag: EventSimulator;
+        export var dragEnd: EventSimulator;
+        export var dragEnter: EventSimulator;
+        export var dragExit: EventSimulator;
+        export var dragLeave: EventSimulator;
+        export var dragOver: EventSimulator;
+        export var dragStart: EventSimulator;
+        export var drop: EventSimulator;
+        export var focus: EventSimulator;
+        export var input: EventSimulator;
+        export var keyDown: EventSimulator;
+        export var keyPress: EventSimulator;
+        export var keyUp: EventSimulator;
+        export var mouseDown: EventSimulator;
+        export var mouseEnter: EventSimulator;
+        export var mouseLeave: EventSimulator;
+        export var mouseMove: EventSimulator;
+        export var mouseOut: EventSimulator;
+        export var mouseOver: EventSimulator;
+        export var mouseUp: EventSimulator;
+        export var paste: EventSimulator;
+        export var scroll: EventSimulator;
+        export var submit: EventSimulator;
+        export var touchCancel: EventSimulator;
+        export var touchEnd: EventSimulator;
+        export var touchMove: EventSimulator;
+        export var touchStart: EventSimulator;
+        export var wheel: EventSimulator;
     }
 
     class ShallowRenderer {

--- a/react/react-addons-global.d.ts
+++ b/react/react-addons-global.d.ts
@@ -269,7 +269,8 @@ declare module React {
     }
 
     class ShallowRenderer {
-        getRenderOutput<C extends Component<any, any>>(): C;
+        getRenderOutput<E extends ReactElement<any>>(): E;
+        getRenderOutput(): ReactElement<any>;
         render(element: ReactElement<any>, context?: any): void;
         unmount(): void;
     }

--- a/react/react-addons-tests.ts
+++ b/react/react-addons-tests.ts
@@ -406,5 +406,5 @@ TestUtils.Simulate.keyDown(node, { key: "Enter" });
 var renderer: React.ShallowRenderer =
     TestUtils.createRenderer();
 renderer.render(React.createElement(Timer));
-var output: Timer = renderer.getRenderOutput<Timer>();
-
+var output: React.ReactElement<React.Props<Timer>> =
+    renderer.getRenderOutput();

--- a/react/react-addons-tests.ts
+++ b/react/react-addons-tests.ts
@@ -1,6 +1,8 @@
 /// <reference path="react-addons.d.ts" />
 import React = require("react/addons");
 
+import TestUtils = React.addons.TestUtils;
+
 interface Props extends React.Props<MyComponent> {
     hello: string;
     world?: string;
@@ -397,12 +399,12 @@ React.createFactory(React.addons.CSSTransitionGroup)({
 // --------------------------------------------------------------------------
 
 var node: Element;
-React.addons.TestUtils.Simulate.click(node);
-React.addons.TestUtils.Simulate.change(node);
-React.addons.TestUtils.Simulate.keyDown(node, { key: "Enter" });
+TestUtils.Simulate.click(node);
+TestUtils.Simulate.change(node);
+TestUtils.Simulate.keyDown(node, { key: "Enter" });
 
 var renderer: React.ShallowRenderer =
-    React.addons.TestUtils.createRenderer();
+    TestUtils.createRenderer();
 renderer.render(React.createElement(Timer));
 var output: Timer = renderer.getRenderOutput<Timer>();
 

--- a/react/react-addons.d.ts
+++ b/react/react-addons.d.ts
@@ -744,33 +744,39 @@ declare module "react/addons" {
     // React.addons
     // ----------------------------------------------------------------------
 
-    export var addons: {
-        CSSTransitionGroup: CSSTransitionGroup;
-        LinkedStateMixin: LinkedStateMixin;
-        PureRenderMixin: PureRenderMixin;
-        TransitionGroup: TransitionGroup;
+    export module addons {
+        export var CSSTransitionGroup: CSSTransitionGroup;
+        export var TransitionGroup: TransitionGroup;
 
-        batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
-        batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-        batchedUpdates(callback: () => any): void;
+        export var LinkedStateMixin: LinkedStateMixin;
+        export var PureRenderMixin: PureRenderMixin;
+
+        export function batchedUpdates<A, B>(
+            callback: (a: A, b: B) => any, a: A, b: B): void;
+        export function batchedUpdates<A>(callback: (a: A) => any, a: A): void;
+        export function batchedUpdates(callback: () => any): void;
 
         // deprecated: use petehunt/react-classset or JedWatson/classnames
-        classSet(cx: { [key: string]: boolean }): string;
-        classSet(...classList: string[]): string;
+        export function classSet(cx: { [key: string]: boolean }): string;
+        export function classSet(...classList: string[]): string;
 
-        cloneWithProps<P>(element: DOMElement<P>, props: P): DOMElement<P>;
-        cloneWithProps<P>(element: ClassicElement<P>, props: P): ClassicElement<P>;
-        cloneWithProps<P>(element: ReactElement<P>, props: P): ReactElement<P>;
+        export function cloneWithProps<P>(
+            element: DOMElement<P>, props: P): DOMElement<P>;
+        export function cloneWithProps<P>(
+            element: ClassicElement<P>, props: P): ClassicElement<P>;
+        export function cloneWithProps<P>(
+            element: ReactElement<P>, props: P): ReactElement<P>;
 
-        createFragment(object: { [key: string]: ReactNode }): ReactFragment;
+        export function createFragment(
+            object: { [key: string]: ReactNode }): ReactFragment;
 
-        update(value: any[], spec: UpdateArraySpec): any[];
-        update(value: {}, spec: UpdateSpec): any;
+        export function update(value: any[], spec: UpdateArraySpec): any[];
+        export function update(value: {}, spec: UpdateSpec): any;
 
         // Development tools
-        Perf: ReactPerf;
-        TestUtils: ReactTestUtils;
-    };
+        export import Perf = ReactPerf;
+        export import TestUtils = ReactTestUtils;
+    }
 
     //
     // React.addons (Transitions)
@@ -849,14 +855,14 @@ declare module "react/addons" {
         totalTime: number;
     }
 
-    interface ReactPerf {
-        start(): void;
-        stop(): void;
-        printInclusive(measurements: Measurements[]): void;
-        printExclusive(measurements: Measurements[]): void;
-        printWasted(measurements: Measurements[]): void;
-        printDOM(measurements: Measurements[]): void;
-        getLastMeasurements(): Measurements[];
+    module ReactPerf {
+        export function start(): void;
+        export function stop(): void;
+        export function printInclusive(measurements: Measurements[]): void;
+        export function printExclusive(measurements: Measurements[]): void;
+        export function printWasted(measurements: Measurements[]): void;
+        export function printDOM(measurements: Measurements[]): void;
+        export function getLastMeasurements(): Measurements[];
     }
 
     //
@@ -867,55 +873,59 @@ declare module "react/addons" {
         new(): any;
     }
 
-    interface ReactTestUtils {
-        Simulate: Simulate;
+    module ReactTestUtils {
+        export import Simulate = ReactSimulate;
 
-        renderIntoDocument<P>(element: ReactElement<P>): Component<P, any>;
-        renderIntoDocument<C extends Component<any, any>>(element: ReactElement<any>): C;
+        export function renderIntoDocument<P>(
+            element: ReactElement<P>): Component<P, any>;
+        export function renderIntoDocument<C extends Component<any, any>>(
+            element: ReactElement<any>): C;
 
-        mockComponent(mocked: MockedComponentClass, mockTagName?: string): ReactTestUtils;
+        export function mockComponent(
+            mocked: MockedComponentClass, mockTagName?: string): typeof ReactTestUtils;
 
-        isElementOfType(element: ReactElement<any>, type: ReactType): boolean;
-        isTextComponent(instance: Component<any, any>): boolean;
-        isDOMComponent(instance: Component<any, any>): boolean;
-        isCompositeComponent(instance: Component<any, any>): boolean;
-        isCompositeComponentWithType(
+        export function isElementOfType(
+            element: ReactElement<any>, type: ReactType): boolean;
+        export function isTextComponent(instance: Component<any, any>): boolean;
+        export function isDOMComponent(instance: Component<any, any>): boolean;
+        export function isCompositeComponent(instance: Component<any, any>): boolean;
+        export function isCompositeComponentWithType(
             instance: Component<any, any>,
             type: ComponentClass<any>): boolean;
 
-        findAllInRenderedTree(
+        export function findAllInRenderedTree(
             tree: Component<any, any>,
             fn: (i: Component<any, any>) => boolean): Component<any, any>;
 
-        scryRenderedDOMComponentsWithClass(
+        export function scryRenderedDOMComponentsWithClass(
             tree: Component<any, any>,
             className: string): DOMComponent<any>[];
-        findRenderedDOMComponentWithClass(
+        export function findRenderedDOMComponentWithClass(
             tree: Component<any, any>,
             className: string): DOMComponent<any>;
 
-        scryRenderedDOMComponentsWithTag(
+        export function scryRenderedDOMComponentsWithTag(
             tree: Component<any, any>,
             tagName: string): DOMComponent<any>[];
-        findRenderedDOMComponentWithTag(
+        export function findRenderedDOMComponentWithTag(
             tree: Component<any, any>,
             tagName: string): DOMComponent<any>;
 
-        scryRenderedComponentsWithType<P>(
+        export function scryRenderedComponentsWithType<P>(
             tree: Component<any, any>,
             type: ComponentClass<P>): Component<P, {}>[];
-        scryRenderedComponentsWithType<C extends Component<any, any>>(
+        export function scryRenderedComponentsWithType<C extends Component<any, any>>(
             tree: Component<any, any>,
             type: ComponentClass<any>): C[];
 
-        findRenderedComponentWithType<P>(
+        export function findRenderedComponentWithType<P>(
             tree: Component<any, any>,
             type: ComponentClass<P>): Component<P, {}>;
-        findRenderedComponentWithType<C extends Component<any, any>>(
+        export function findRenderedComponentWithType<C extends Component<any, any>>(
             tree: Component<any, any>,
             type: ComponentClass<any>): C;
 
-        createRenderer(): ShallowRenderer;
+        export function createRenderer(): ShallowRenderer;
     }
 
     interface SyntheticEventData {
@@ -957,40 +967,40 @@ declare module "react/addons" {
         (component: Component<any, any>, eventData?: SyntheticEventData): void;
     }
 
-    interface Simulate {
-        blur: EventSimulator;
-        change: EventSimulator;
-        click: EventSimulator;
-        cut: EventSimulator;
-        doubleClick: EventSimulator;
-        drag: EventSimulator;
-        dragEnd: EventSimulator;
-        dragEnter: EventSimulator;
-        dragExit: EventSimulator;
-        dragLeave: EventSimulator;
-        dragOver: EventSimulator;
-        dragStart: EventSimulator;
-        drop: EventSimulator;
-        focus: EventSimulator;
-        input: EventSimulator;
-        keyDown: EventSimulator;
-        keyPress: EventSimulator;
-        keyUp: EventSimulator;
-        mouseDown: EventSimulator;
-        mouseEnter: EventSimulator;
-        mouseLeave: EventSimulator;
-        mouseMove: EventSimulator;
-        mouseOut: EventSimulator;
-        mouseOver: EventSimulator;
-        mouseUp: EventSimulator;
-        paste: EventSimulator;
-        scroll: EventSimulator;
-        submit: EventSimulator;
-        touchCancel: EventSimulator;
-        touchEnd: EventSimulator;
-        touchMove: EventSimulator;
-        touchStart: EventSimulator;
-        wheel: EventSimulator;
+    module ReactSimulate {
+        export var blur: EventSimulator;
+        export var change: EventSimulator;
+        export var click: EventSimulator;
+        export var cut: EventSimulator;
+        export var doubleClick: EventSimulator;
+        export var drag: EventSimulator;
+        export var dragEnd: EventSimulator;
+        export var dragEnter: EventSimulator;
+        export var dragExit: EventSimulator;
+        export var dragLeave: EventSimulator;
+        export var dragOver: EventSimulator;
+        export var dragStart: EventSimulator;
+        export var drop: EventSimulator;
+        export var focus: EventSimulator;
+        export var input: EventSimulator;
+        export var keyDown: EventSimulator;
+        export var keyPress: EventSimulator;
+        export var keyUp: EventSimulator;
+        export var mouseDown: EventSimulator;
+        export var mouseEnter: EventSimulator;
+        export var mouseLeave: EventSimulator;
+        export var mouseMove: EventSimulator;
+        export var mouseOut: EventSimulator;
+        export var mouseOver: EventSimulator;
+        export var mouseUp: EventSimulator;
+        export var paste: EventSimulator;
+        export var scroll: EventSimulator;
+        export var submit: EventSimulator;
+        export var touchCancel: EventSimulator;
+        export var touchEnd: EventSimulator;
+        export var touchMove: EventSimulator;
+        export var touchStart: EventSimulator;
+        export var wheel: EventSimulator;
     }
 
     class ShallowRenderer {

--- a/react/react-addons.d.ts
+++ b/react/react-addons.d.ts
@@ -435,10 +435,16 @@ declare module "react/addons" {
         draggable?: boolean;
         encType?: string;
         form?: string;
+        formAction?: string;
+        formEncType?: string;
+        formMethod?: string;
         formNoValidate?: boolean;
+        formTarget?: string;
         frameBorder?: number | string;
+        headers?: string;
         height?: number | string;
         hidden?: boolean;
+        high?: number;
         href?: string;
         hrefLang?: string;
         htmlFor?: string;
@@ -449,7 +455,10 @@ declare module "react/addons" {
         lang?: string;
         list?: string;
         loop?: boolean;
+        low?: number;
         manifest?: string;
+        marginHeight?: number;
+        marginWidth?: number;
         max?: number | string;
         maxLength?: number;
         media?: string;
@@ -461,6 +470,7 @@ declare module "react/addons" {
         name?: string;
         noValidate?: boolean;
         open?: boolean;
+        optimum?: number;
         pattern?: string;
         placeholder?: string;
         poster?: string;
@@ -474,9 +484,8 @@ declare module "react/addons" {
         rowSpan?: number;
         sandbox?: string;
         scope?: string;
-        scrollLeft?: number;
+        scoped?: boolean;
         scrolling?: string;
-        scrollTop?: number;
         seamless?: boolean;
         selected?: boolean;
         shape?: string;
@@ -506,6 +515,7 @@ declare module "react/addons" {
         itemProp?: string;
         itemScope?: boolean;
         itemType?: string;
+        unselectable?: boolean;
     }
 
     interface SVGAttributes extends DOMAttributes {

--- a/react/react-addons.d.ts
+++ b/react/react-addons.d.ts
@@ -1004,7 +1004,8 @@ declare module "react/addons" {
     }
 
     class ShallowRenderer {
-        getRenderOutput<C extends Component<any, any>>(): C;
+        getRenderOutput<E extends ReactElement<any>>(): E;
+        getRenderOutput(): ReactElement<any>;
         render(element: ReactElement<any>, context?: any): void;
         unmount(): void;
     }

--- a/react/react-global.d.ts
+++ b/react/react-global.d.ts
@@ -435,10 +435,16 @@ declare module React {
         draggable?: boolean;
         encType?: string;
         form?: string;
+        formAction?: string;
+        formEncType?: string;
+        formMethod?: string;
         formNoValidate?: boolean;
+        formTarget?: string;
         frameBorder?: number | string;
+        headers?: string;
         height?: number | string;
         hidden?: boolean;
+        high?: number;
         href?: string;
         hrefLang?: string;
         htmlFor?: string;
@@ -449,7 +455,10 @@ declare module React {
         lang?: string;
         list?: string;
         loop?: boolean;
+        low?: number;
         manifest?: string;
+        marginHeight?: number;
+        marginWidth?: number;
         max?: number | string;
         maxLength?: number;
         media?: string;
@@ -461,6 +470,7 @@ declare module React {
         name?: string;
         noValidate?: boolean;
         open?: boolean;
+        optimum?: number;
         pattern?: string;
         placeholder?: string;
         poster?: string;
@@ -474,9 +484,8 @@ declare module React {
         rowSpan?: number;
         sandbox?: string;
         scope?: string;
-        scrollLeft?: number;
+        scoped?: boolean;
         scrolling?: string;
-        scrollTop?: number;
         seamless?: boolean;
         selected?: boolean;
         shape?: string;
@@ -506,6 +515,7 @@ declare module React {
         itemProp?: string;
         itemScope?: boolean;
         itemType?: string;
+        unselectable?: boolean;
     }
 
     interface SVGAttributes extends DOMAttributes {

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -435,10 +435,16 @@ declare module "react" {
         draggable?: boolean;
         encType?: string;
         form?: string;
+        formAction?: string;
+        formEncType?: string;
+        formMethod?: string;
         formNoValidate?: boolean;
+        formTarget?: string;
         frameBorder?: number | string;
+        headers?: string;
         height?: number | string;
         hidden?: boolean;
+        high?: number;
         href?: string;
         hrefLang?: string;
         htmlFor?: string;
@@ -449,7 +455,10 @@ declare module "react" {
         lang?: string;
         list?: string;
         loop?: boolean;
+        low?: number;
         manifest?: string;
+        marginHeight?: number;
+        marginWidth?: number;
         max?: number | string;
         maxLength?: number;
         media?: string;
@@ -461,6 +470,7 @@ declare module "react" {
         name?: string;
         noValidate?: boolean;
         open?: boolean;
+        optimum?: number;
         pattern?: string;
         placeholder?: string;
         poster?: string;
@@ -474,9 +484,8 @@ declare module "react" {
         rowSpan?: number;
         sandbox?: string;
         scope?: string;
-        scrollLeft?: number;
+        scoped?: boolean;
         scrolling?: string;
-        scrollTop?: number;
         seamless?: boolean;
         selected?: boolean;
         shape?: string;
@@ -506,6 +515,7 @@ declare module "react" {
         itemProp?: string;
         itemScope?: boolean;
         itemType?: string;
+        unselectable?: boolean;
     }
 
     interface SVGAttributes extends DOMAttributes {


### PR DESCRIPTION
- `var addons` is now `module addons` which allows you to make import aliases

``` ts
import React = require("react/addons");
import TestUtils = React.addons.TestUtils; // not possible before
```
- fixed return type of `ShallowRenderer.getRenderOutput()` to be `ReactElement`, not `Component`
- update `HTMLAttributes` interface to correspond to list at https://facebook.github.io/react/docs/tags-and-attributes.html

cc @pspeter3 @jbrantly 
