### PR TITLE
AngularJS 1.4 - `bindToController` object definition.

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Angular JS 1.3+
+// Type definitions for Angular JS 1.4+
 // Project: http://angularjs.org
 // Definitions by: Diego Vilar <http://github.com/diegovilar>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -1550,7 +1550,7 @@ declare module angular {
         compile?: IDirectiveCompileFn;
         controller?: any;
         controllerAs?: string;
-        bindToController?: boolean;
+        bindToController?: any;
         link?: IDirectiveLinkFn | IDirectivePrePost;
         name?: string;
         priority?: number;

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1550,7 +1550,7 @@ declare module angular {
         compile?: IDirectiveCompileFn;
         controller?: any;
         controllerAs?: string;
-        bindToController?: any;
+        bindToController?: boolean|Object;
         link?: IDirectiveLinkFn | IDirectivePrePost;
         name?: string;
         priority?: number;


### PR DESCRIPTION
This PR supports using `bindToController` as an object (see: https://github.com/angular/angular.js/blob/master/CHANGELOG.md#features-9).
