### PR TITLE
Remove node.d.ts reference in shelljs.d.ts

### DIFF
--- a/shelljs/shelljs.d.ts
+++ b/shelljs/shelljs.d.ts
@@ -3,9 +3,6 @@
 // Definitions by: Niklas Mollenhauer <https://github.com/nikeee>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-
-///<reference path="../node/node.d.ts"/>
-
 declare module "shelljs"
 {
     import child = require("child_process");


### PR DESCRIPTION
The removed reference to node.d.ts in shelljs is an error in TypeScript 1.5.
