### PR TITLE
Corrected an issue that didn't allow me to use an extended PageableCo…

### DIFF
--- a/backbone.paginator/backbone.paginator.d.ts
+++ b/backbone.paginator/backbone.paginator.d.ts
@@ -52,7 +52,7 @@ declare module Backbone {
 
   type PageableGetPageOptions = CollectionFetchOptions|Silenceable;
 
-  class PageableCollection<TModel extends Model> extends Collection<Model>{
+  class PageableCollection<TModel extends Model> extends Collection<TModel>{
 
     fullCollection: Collection<TModel>;
     mode: string;


### PR DESCRIPTION
I dont know if this is a bug or i'm doing it wrong..

i have a class that extends PageableCollection:

```
class PaginationCollection<T extends Backbone.Model> extends Backbone.PageableCollection<T> {
// extra functionality that works with our pagination concepts.
}
```

then i got a specific collection that extends from my custom paginationCollection of T where T is ProductionOrder model.

```
class ProductionOrders extends PaginationCollection<ProductionOrder> {
}
```

Lastly i got my composite view:

```
class TableView extends Marionette.CompositeView<ProductionOrder> {
    collection: ProductionOrders
}
```

this gives me a compile error telling me that 
Class 'TableView' incorrectly extends base class 'CompositeView<SomeEntity>'.
  Types of property 'collection' are incompatible.
  Type 'ProductionOrders' is not assignable to type 'Collection<ProductionOrder>'.
  Types of property 'model' are incompatible.

if i go to the d.ts file and change extended class to TModel instead of Model, the compiler is happy and everything works :-)
