### PR TITLE
lodash: add generic _.remove

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -270,6 +270,7 @@ result = <number[]>_.range(0);
 result = <number[]>_.remove([1, 2, 3, 4, 5, 6], function (num: number) { return num % 2 == 0; });
 result = <IFoodOrganic[]>_.remove(foodsOrganic, 'organic');
 result = <IFoodType[]>_.remove(foodsType, { 'type': 'vegetable' });
+var typedResult: IFoodType[] = _.remove([ <IFoodType>{ name: 'apple' }, <IFoodType>{ name: 'orange' }], <IFoodType>{ name: 'orange' });
 
 result = <number>_.sortedIndex([20, 30, 50], 40);
 result = <number>_.sortedIndex([{ 'x': 20 }, { 'x': 30 }, { 'x': 50 }], { 'x': 40 }, 'x');

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -1296,6 +1296,14 @@ declare module _ {
         remove(
             array: List<any>,
             wherealue?: Dictionary<any>): any[];
+
+        /**
+         * @see _.remove
+         * @param item The item to remove
+         **/
+        remove<T>(
+            array:Array<T>,
+            item:T): T[];
     }
 
     //_.rest


### PR DESCRIPTION
Fixes a compilation error I was getting:

```
2345 Argument of type 'IEmployee' is not assignable to parameter of type 'Dictionary<any>'.
```

for the following:

```
var employees: IEmployee[];
var employee: IEmployee;
_.remove(employees, employee);
```
