### PR TITLE
Unquoted nodeunit module name

### DIFF
--- a/nodeunit/nodeunit-tests.ts
+++ b/nodeunit/nodeunit-tests.ts
@@ -1,7 +1,5 @@
 /// <reference path="nodeunit.d.ts" />
 
-import nodeunit = require('nodeunit');
-
 var num: number;
 var value: any;
 var actual: any;
@@ -13,7 +11,7 @@ var block: () =>{
 
 };
 
-export var testGroup: nodeunit.ITestGroup = {
+var testGroup: nodeunit.ITestGroup = {
 	setUp: function (callback: nodeunit.ICallbackFunction) {
 		callback();
 	},

--- a/nodeunit/nodeunit.d.ts
+++ b/nodeunit/nodeunit.d.ts
@@ -5,7 +5,7 @@
 
 // Imported from: https://github.com/soywiz/typescript-node-definitions/nodeunit.d.ts
 
-declare module 'nodeunit' {
+declare module nodeunit {
 	export interface Test {
 		done: ICallbackFunction;
 		expect(num: number): void;


### PR DESCRIPTION
Quoted name was confusing auto-completion and checking in Webstorm IDE. I don't think it should have any other negative effects.
