### PR TITLE
Fixed typo and added a missing default property

### DIFF
--- a/angular-ui-bootstrap/angular-ui-bootstrap.d.ts
+++ b/angular-ui-bootstrap/angular-ui-bootstrap.d.ts
@@ -590,7 +590,14 @@ declare module angular.ui.bootstrap {
          *
          * @default false
          */
-        appendtoBody?: boolean;
+        appendToBody?: boolean;
+
+        /**
+         * Determines the default open triggers for tooltips and popovers
+         *
+         * @default 'mouseenter' for tooltip, 'click' for popover
+         */
+        trigger?: string;
     }
 
     interface ITooltipProvider {


### PR DESCRIPTION
The appendToBody property should have a capital T. In addition there is also a 'trigger' property on the options object that was missing altogether.
