### PR TITLE
knex: Changed export to allow to define typed knex migration scripts (export Knex interface)

### DIFF
--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -41,6 +41,8 @@ declare module "knex" {
     fn: any;
   }
 
+  function Knex( config : Config ) : Knex;
+
   //
   // QueryInterface
   //
@@ -452,6 +454,5 @@ declare module "knex" {
     tableName?: string;
   }
 
-  var _: KnexStatic;
-  export = _;
+  export = Knex;
 }

--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -343,6 +343,9 @@ declare module "knex" {
     uuid(columnName: string): ColumnBuilder;
     comment(val: string): TableBuilder;
     specificType(columnName: string, type: string): ColumnBuilder;
+    primary(columnNames: string[]) : TableBuilder;
+    index(columnNames: string[], indexName?: string, indexType?: string) : TableBuilder;
+    unique(columnNames: string[], indexName?: string) : TableBuilder;    
   }
 
   interface CreateTableBuilder extends TableBuilder {


### PR DESCRIPTION
The previous version the factory function to create a Knex instance, only.

This change exports the Knex interface itself and declares an additional factory function called "Knex" to preserve the existing behavior.
