### PR TITLE
Made the signature of INgModelController.$validators more precise

### DIFF
--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -703,3 +703,29 @@ module locationTests {
     $location.url() == '/foo/bar?x=y'
     $location.absUrl() == 'http://example.com/#!/foo/bar?x=y'
 }
+
+// NgModelController
+function NgModelControllerTyping() {
+    var ngModel: angular.INgModelController;
+    var $http: angular.IHttpService;
+    var $q: angular.IQService;
+
+    // See https://docs.angularjs.org/api/ng/type/ngModel.NgModelController#$validators
+    ngModel.$validators['validCharacters'] = function(modelValue, viewValue) {
+        var value = modelValue || viewValue;
+        return /[0-9]+/.test(value) &&
+            /[a-z]+/.test(value) &&
+            /[A-Z]+/.test(value) &&
+            /\W+/.test(value);
+    };
+
+    ngModel.$asyncValidators['uniqueUsername'] = function(modelValue, viewValue) {
+        var value = modelValue || viewValue;
+        return $http.get('/api/users/' + value).
+            then(function resolved() {
+                return $q.reject('exists');
+            }, function rejected() {
+                return true;
+            });
+    };
+}

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -524,11 +524,11 @@ declare module angular {
     }
 
     interface IModelValidators {
-        [index: string]: (...args: any[]) => boolean;
+        [index: string]: (modelValue: any, viewValue: string) => boolean;
     }
 
     interface IAsyncModelValidators {
-        [index: string]: (...args: any[]) => IPromise<boolean>;
+        [index: string]: (modelValue: any, viewValue: string) => IPromise<any>;
     }
 
     interface IModelParser {


### PR DESCRIPTION
And corrected the return type of $asyncValidators.

Per the [docs](https://docs.angularjs.org/api/ng/type/ngModel.NgModelController#$validators), `IModelValidators` should only accept two arguments instead of a var-arg. Also, the content type of the `IPromise` returned in `IAsyncModelValidators` should not be constrained.

Tests included.
