### PR TITLE
Fix async.waterfall signature (callback has variadic argument structure)

### DIFF
--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -96,7 +96,7 @@ interface Async {
     doWhilst(fn: AsyncVoidFunction, test: () => boolean, callback: (err: any) => void): void;
     until(test: () => boolean, fn: AsyncVoidFunction, callback: (err: any) => void): void;
     doUntil(fn: AsyncVoidFunction, test: () => boolean, callback: (err: any) => void): void;
-    waterfall(tasks: Function[], callback?: AsyncResultArrayCallback<any>): void;
+    waterfall(tasks: Function[], callback?: (err: any, ...arguments: any[]) => void): void;
     queue<T>(worker: AsyncWorker<T>, concurrency: number): AsyncQueue<T>;
     priorityQueue<T>(worker: AsyncWorker<T>, concurrency: number): AsyncPriorityQueue<T>;
     auto(tasks: any, callback?: AsyncResultArrayCallback<any>): void;


### PR DESCRIPTION
`async.waterfall`'s second argument, `callback`, has arguments that depend on how the final function in the `tasks` array calls its callback. I.e., `async.waterfall` does not aggregate the results from its constituent tasks like `async.parallel` or `async.series` does, but acts more like one of the functions in the `tasks` array (except that it is called immediately if any of the `tasks` callback with an error).

See [async#waterfall](https://github.com/caolan/async#waterfall) in the original documentation for more details.
