### PR TITLE
Add Sync versions for all convenience methods in Node.js's zlib module

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -596,12 +596,19 @@ declare module "zlib" {
     export function createUnzip(options?: ZlibOptions): Unzip;
 
     export function deflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function deflateSync(buf: Buffer, options?: ZlibOptions): any;
     export function deflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function deflateRawSync(buf: Buffer, options?: ZlibOptions): any;
     export function gzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function gzipSync(buf: Buffer, options?: ZlibOptions): any;
     export function gunzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function gunzipSync(buf: Buffer, options?: ZlibOptions): any;
     export function inflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function inflateSync(buf: Buffer, options?: ZlibOptions): any;
     export function inflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function inflateRawSync(buf: Buffer, options?: ZlibOptions): any;
     export function unzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function unzipSync(buf: Buffer, options?: ZlibOptions): any;
 
     // Constants
     export var Z_NO_FLUSH: number;


### PR DESCRIPTION
Pretty straightforward. See https://nodejs.org/api/zlib.html#zlib_convenience_methods for documentation.
