### PR TITLE
angular-ui-bootstrap modal backdropClass

### DIFF
--- a/angular-ui-bootstrap/angular-ui-bootstrap-tests.ts
+++ b/angular-ui-bootstrap/angular-ui-bootstrap-tests.ts
@@ -141,6 +141,7 @@ testApp.controller('TestCtrl', (
         scope: $scope,
         template: "<div>i'm a template!</div>",
         templateUrl: '/templates/modal.html',
+        backdropClass: 'modal-backdrop-test',
         windowClass: 'modal-test'
     });
 

--- a/angular-ui-bootstrap/angular-ui-bootstrap.d.ts
+++ b/angular-ui-bootstrap/angular-ui-bootstrap.d.ts
@@ -265,6 +265,11 @@ declare module angular.ui.bootstrap {
         keyboard?: boolean;
 
         /**
+         * additional CSS class(es) to be added to a modal backdrop template
+         */
+        backdropClass?: string;
+
+        /**
          * additional CSS class(es) to be added to a modal window template
          */
         windowClass?: string;


### PR DESCRIPTION
Added missing backdropClass property of IModalSettings
Property described here: http://angular-ui.github.io/bootstrap/#/modal
