### PR TITLE
Add type definition for the mime property exposed on serve-static.

### DIFF
--- a/serve-static/serve-static-tests.ts
+++ b/serve-static/serve-static-tests.ts
@@ -18,3 +18,9 @@ app.use(serveStatic('/3', {
         res.setHeader('Server', 'server-static middleware');
     }
 }));
+
+serveStatic.mime.define({
+    'application/babylon': ['babylon'],
+    'application/babylonmeshdata': ['babylonmeshdata'],
+    'application/fx': ['fx']
+});

--- a/serve-static/serve-static.d.ts
+++ b/serve-static/serve-static.d.ts
@@ -11,6 +11,7 @@
  =============================================== */
 
 /// <reference path="../express/express.d.ts" />
+/// <reference path="../mime/mime.d.ts" />
 
 declare module "serve-static" {
     import express = require('express');
@@ -74,6 +75,12 @@ declare module "serve-static" {
          */
         setHeaders?: (res: express.Response, path: string, stat: any) => any;
     }): express.Handler;
+
+    import m = require('mime');
+
+    module serveStatic {
+        var mime: typeof m;
+    }
 
     export = serveStatic;
 }


### PR DESCRIPTION
JS source of serve-static exposes npm module mime, see: https://github.com/expressjs/serve-static/blob/master/index.js#L122
