### PR TITLE
Liberalize type of d3.event

### DIFF
--- a/d3/d3-tests.ts
+++ b/d3/d3-tests.ts
@@ -873,7 +873,7 @@ function populationPyramid() {
         // Allow the arrow keys to change the displayed year.
         window.focus();
         d3.select(window).on("keydown", function () {
-            switch ((<any> d3.event).keyCode) {
+            switch (d3.event.keyCode) {
                 case 37: year = Math.max(year0, year - 10); break;
                 case 39: year = Math.min(year1, year + 10); break;
             }
@@ -1291,12 +1291,12 @@ function forceDirectedVoronoi() {
     d3.select(window)
         .on("keydown", function() {
             // shift
-            if((<any> d3.event).keyCode == 16) {
+            if(d3.event.keyCode == 16) {
                 zoomToAdd = false
             }
      
             // s
-            if((<any> d3.event).keyCode == 83) {
+            if(d3.event.keyCode == 83) {
                 simulate = !simulate
                 if(simulate) {
                     force.start()
@@ -2664,4 +2664,17 @@ function multiTest() {
         .attr("class", "x axis")
         .attr("transform", "translate(0," + height + ")")
         .call(xAxis);
+}
+
+function testD3Events () {
+    d3.select('svg')
+        .on('click', () => {
+            var coords = [d3.event.pageX, d3.event.pageY];
+            console.log("clicked", d3.event.target, "at " + coords);
+        })
+        .on('keypress', () => {
+            if (d3.event.shiftKey) {
+                console.log('shift + ' + d3.event.which);
+            }
+        });
 }

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -918,7 +918,13 @@ declare module d3 {
     }
 
     /**
-     * The current event's value. Use this variable in a handler registered with selection.on.
+     * Interface for any and all d3 events.
+     */
+    interface Event extends KeyboardEvent, MouseEvent {
+    }
+
+    /**
+     * The current event's value. Use this variable in a handler registered with `selection.on`.
      */
     export var event: Event;
 


### PR DESCRIPTION
To address #4590 and issues like it, I've created an interface `Event` that extends both `KeyboardEvent` and `MouseEvent`. It should probably extend others, but this should do for starters. It's impossible to really know what event is being handled since d3 uses a single global value (for shame!), so perhaps it's best to pretend it's of many types and let the user handle it as they see fit.

The interface `d3.Event` is currently empty, but I'll try to find some time to document the properties d3 adds in some situations.
