### PR TITLE
JQuery: Added missing html(obj: JQuery) method

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -1272,6 +1272,7 @@ interface JQuery {
      *
      * @param func A function returning the HTML content to set. Receives the index position of the element in the set and the old HTML value as arguments. jQuery empties the element before calling the function; use the oldhtml argument to reference the previous content. Within the function, this refers to the current element in the set.
      */
+    html(func: JQuery): JQuery;
 
     /**
      * Get the value of a property for the first element in the set of matched elements.


### PR DESCRIPTION
Seems this was accidentally removed in: https://github.com/borisyankov/DefinitelyTyped/commit/15e56b924dc8b5b4f1ebece97a62250b81b270ed
