### PR TITLE
Fix #4620: Add module declaration for 'module' magic module

### DIFF
--- a/requirejs/require-tests.ts
+++ b/requirejs/require-tests.ts
@@ -41,3 +41,11 @@ require(['main'], (main: any, $: any, _: any, Backbone: any) => {
 var recOne = require.config({ baseUrl: 'js' });
 recOne(['core'], function (core: any) {/*some code*/});
 
+// Tests for 'module' magic module typings
+// (Using 'module' only actually makes sense in an external module)
+
+import module = require('module');
+
+var moduleConfig: any = module.config();
+var moduleId: string =  module.id;
+var moduleUri: string = module.uri;

--- a/requirejs/require.d.ts
+++ b/requirejs/require.d.ts
@@ -29,6 +29,15 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 */
 
+declare module 'module' {
+    var mod: {
+        config: () => any;
+        id: string;
+        uri: string;
+    }
+    export = mod;
+}
+
 interface RequireError extends Error {
 
 	/**
@@ -342,7 +351,7 @@ interface RequireDefine {
 	*	callback return module definition
 	**/
 	(name: string, ready: Function): void;
-	
+
 	/**
 	* Used to allow a clear indicator that a global define function (as needed for script src browser loading) conforms
 	* to the AMD API, any global define function SHOULD have a property called "amd" whose value is an object.


### PR DESCRIPTION
This adds a module declaration with typings for the [`module` magic module](https://github.com/jrburke/requirejs/wiki/Differences-between-the-simplified-CommonJS-wrapper-and-standard-AMD-define#module), along with tests.

Fixes #4620.
