### PR TITLE
Add sample() to LoDashArrayWrapper interface

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -605,6 +605,8 @@ result = <IFoodCombined[]>_(foodsCombined).reject({ 'type': 'fruit' }).value();
 
 result = <number>_.sample([1, 2, 3, 4]);
 result = <number[]>_.sample([1, 2, 3, 4], 2);
+result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).sample();
+result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).sample(2);
 
 result = <number[]>_.shuffle([1, 2, 3, 4, 5, 6]);
 result = <_.LoDashArrayWrapper<number>>_([1, 2, 3]).shuffle();

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -22,7 +22,7 @@ declare module _ {
         * forEach, forEachRight, forIn, forInRight, forOwn, forOwnRight, functions, groupBy,
         * indexBy, initial, intersection, invert, invoke, keys, map, max, memoize, merge, min,
         * object, omit, once, pairs, partial, partialRight, pick, pluck, pull, push, range, reject,
-        * remove, rest, reverse, shuffle, slice, sort, sortBy, splice, tap, throttle, times,
+        * remove, rest, reverse, sample, shuffle, slice, sort, sortBy, splice, tap, throttle, times,
         * toArray, transform, union, uniq, unshift, unzip, values, where, without, wrap, and zip
         *
         * The non-chainable wrapper functions are:
@@ -4557,6 +4557,18 @@ declare module _ {
         * @param n The number of elements to sample.
         **/
         sample<T>(collection: Dictionary<T>, n: number): T[];
+    }
+
+    interface LoDashArrayWrapper<T> {
+        /**
+         * @see _.sample
+         **/
+        sample(n: number): LoDashArrayWrapper<T>;
+
+        /**
+         * @see _.sample
+         **/
+        sample(): LoDashArrayWrapper<T>;
     }
 
     //_.shuffle


### PR DESCRIPTION
- Adds two additional definitions to `LoDashArrayWrapper` interface to allow usage of `sample()` functions in chains like so:

``` javascript
_.chain([1,2,3,4]).sample().value()
// or
_.chain([1,2,3,4]).sample(2).value()
```
- Adds new lines to `lodash-tests.ts` that compiles said expressions.
