### PR TITLE
PolylineOptions should extend PathOption

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -3448,7 +3448,7 @@ declare module L {
 
 declare module L {
 
-    export interface PolylineOptions {
+    export interface PolylineOptions extends PathOptions {
 
         /**
           * How much to simplify the polyline on each zoom level. More means better performance


### PR DESCRIPTION
`PolylineOptions` should extend `PathOptions`, so that user could supply options in the base class
