### PR TITLE
crossroads: specify return types explicitly.

### DIFF
--- a/crossroads/crossroads-tests.ts
+++ b/crossroads/crossroads-tests.ts
@@ -2,7 +2,7 @@
 
 //String rule with param:
 //match '/news/123' passing "123" as param to handler
-var route1 = crossroads.addRoute('/news/{id}', function(id){
+var route1 = crossroads.addRoute('/news/{id}', function(id: any){
   console.log(id);
 });
 
@@ -16,7 +16,7 @@ route2.matched.add(console.log, console);
 //RegExp rule:
 //match '/lorem/ipsum' passing "ipsum" as param to handler
 //note the capturing group around segment
-var route3 = crossroads.addRoute(/^\/lorem\/([a-z]+)$/, function(id){
+var route3 = crossroads.addRoute(/^\/lorem\/([a-z]+)$/, function(id: any){
   console.log(id);
 });
 
@@ -29,13 +29,13 @@ route4.matched.add(console.log, console);
 
 //Query String:
 //match 'foo.php?lorem=ipsum&dolor=amet'
-crossroads.addRoute('foo.php{?query}', function(query){
+crossroads.addRoute('foo.php{?query}', function(query: any){
     // query strings are decoded into objects
     console.log('lorem '+ query.lorem +' dolor sit '+ query.dolor);
 });
 
 var sectionRoute = crossroads.addRoute('/{section}/{id}');
-function onSectionMatch(section, id){
+function onSectionMatch(section: any, id: any){
   console.log(section +' - '+ id);
 }
 sectionRoute.matched.add(onSectionMatch);
@@ -46,21 +46,21 @@ crossroads.parse('/news/123');
 crossroads.parse('/news/123', ["lorem", "ipsum"]);
 
 var route1 = crossroads.addRoute('/news/{id}');
-crossroads.bypassed.add(function(request){
+crossroads.bypassed.add(function(request: any){
     console.log(request);
 });
 //won't match any route, triggering `bypassed` Signal
 crossroads.parse('/foo');
 
 
-crossroads.routed.add(function(request, data){
+crossroads.routed.add(function(request: any, data: any){
     console.log(request);
     console.log(data.route +' - '+ data.params +' - '+ data.isFirst);
 });
 crossroads.parse('/news/123'); //match `route1`, triggering `routed` Signal
 
 var otherRouter = crossroads.create();
-otherRouter.addRoute('/news/{id}', function(id){
+otherRouter.addRoute('/news/{id}', function(id: any){
     console.log(id);
 });
 otherRouter.parse('/news/123');
@@ -70,36 +70,36 @@ crossroads.bypassed.add(otherRouter.parse, otherRouter);
 // same effect as calling: `crossroads.pipe(otherRouter)`
 
 crossroads.normalizeFn = crossroads.NORM_AS_OBJECT;
-crossroads.addRoute('/{foo}/{bar}', function(vals){
+crossroads.addRoute('/{foo}/{bar}', function(vals: any){
     //can access captured values as object properties
     console.log(vals.foo +' - '+ vals.bar);
 });
 crossroads.parse('/lorem/ipsum');
 
 crossroads.normalizeFn = crossroads.NORM_AS_ARRAY;
-crossroads.addRoute('/{foo}/{bar}', function(vals){
+crossroads.addRoute('/{foo}/{bar}', function(vals: any){
     //can access captured values as Array items
     console.log(vals[0] +' - '+ vals[1]);
 });
 crossroads.parse('/dolor/amet');
 
-crossroads.normalizeFn = function(request, vals){
+crossroads.normalizeFn = function(request: any, vals: any){
     //make sure first argument is always "news"
     return ['news', vals.id];
 };
-crossroads.addRoute('/{cat}/{id}', function(cat, id){
+crossroads.addRoute('/{cat}/{id}', function(cat: any, id: any){
     console.log(cat +' - '+ id);
 });
 crossroads.parse('/article/123');
 
 crossroads.shouldTypecast = true; //default = false
-crossroads.addRoute('/news/{id}', function(id){
+crossroads.addRoute('/news/{id}', function(id: any){
     console.log(id); // 12 (remove trailing zeroes since it's typecasted)
 });
 crossroads.parse('/news/00012');
 
 crossroads.shouldTypecast = false; //default = false
-crossroads.addRoute('/news/{id}', function(id){
+crossroads.addRoute('/news/{id}', function(id: any){
     console.log(id); // "00012" (keep trailing zeroes)
 });
 crossroads.parse('/news/00012');
@@ -122,10 +122,10 @@ sectionRouter.unpipe(navRouter);
 sectionRouter.parse('bar');
 
 var route1 = crossroads.addRoute('/news/{id}');
-route1.matched.add(function(id){
+route1.matched.add(function(id: any){
   console.log('handler 1: '+ id);
 });
-route1.matched.add(function(id){
+route1.matched.add(function(id: any){
   console.log('handler 2: '+ id);
 });
 crossroads.parse('/news/123'); //will trigger both handlers of `route1`
@@ -145,7 +145,7 @@ route1.rules = {
      * @param {object} valuesObj  Values of all pattern segments.
      * @return {boolean} If segment value is valid.
      */
-    id : function(value, request, valuesObj){
+    id : function(value: any, request: string, valuesObj: any): boolean{
         if(isNaN(value)){
             return false;
         }else{
@@ -165,7 +165,7 @@ route1.rules = {
      * Note that request will be typecasted if value is a boolean
      * or number and crossroads.shouldTypecast = true (default = false).
      */
-    request_ : function(request){
+    request_ : function(request: any){
         return (request != '123');
     },
 
@@ -177,7 +177,7 @@ route1.rules = {
      *  also a property `request_`.
      * @return {array} Array containing parameters.
      */
-    normalize_ : function(request, vals){
+    normalize_ : function(request: any, vals: any): Array<any> {
         //ignore "date" since it isn't important for the application
         return [vals.section, vals.id];
     }
@@ -196,7 +196,7 @@ var route1 = crossroads.addRoute(/([\-\w]+)\/([\-\w]+)\/([\-\w]+)/);
 route1.rules = {
   '0' : ['blog', 'news', '123'],
   '1' : /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/,
-  '2' : function(value, request, valuesObj){
+  '2' : function(value: any, request: any, valuesObj: any){
           return ! isNaN(value);
         }
 };

--- a/crossroads/crossroads.d.ts
+++ b/crossroads/crossroads.d.ts
@@ -28,7 +28,7 @@ declare module CrossroadsJs {
         /**
          * Remove route from crossroads and destroy it, releasing memory.
          */
-        dispose();
+        dispose(): void;
 
         /**
          * Test if Route matches against request. Return true if request validate against route rules and pattern.
@@ -70,12 +70,12 @@ declare module CrossroadsJs {
          *
          * @param route Reference to the Route object returned by crossroads.addRoute().
          */
-        removeRoute(route: Route);
+        removeRoute(route: Route): void;
 
         /**
          * Remove all routes from crossroads collection.
          */
-        removeAllRoutes();
+        removeAllRoutes(): void;
 
         /**
          * Parse a string input and dispatch matched Signal of the first Route that matches the request.
@@ -83,7 +83,7 @@ declare module CrossroadsJs {
          * @param request String that should be evaluated and matched against Routes to define which Route handlers should be executed and which parameters should be passed to the handlers.
          * @param defaultargs Array containing values passed to matched/routed/bypassed signals as first arguments. Useful for node.js in case you need to access the request and response objects.
          */
-        parse(request: string, ...defaultArgs: any[]);
+        parse(request: string, ...defaultArgs: any[]): void;
 
         /**
          * Get number of Routes contained on the crossroads collection.
@@ -133,7 +133,7 @@ declare module CrossroadsJs {
         /**
          * Resets the Router internal state. Will clear reference to previously matched routes (so they won't dispatch switched signal when matching a new route) and reset last request.
          */
-        resetState();
+        resetState(): void;
 
         /**
          * Sets if Router should care about previous state, so multiple crossroads.parse() calls passing same argument would not trigger the routed, matched and bypassed signals.
@@ -143,12 +143,12 @@ declare module CrossroadsJs {
         /**
          * Pipe routers, so all crossroads.parse() calls will be forwarded to the other router as well.
          */
-        pipe(router: CrossRoadsStatic);
+        pipe(router: CrossRoadsStatic): void;
 
         /**
          * "Ceci n'est pas une pipe"
          */
-        unpipe(router: CrossRoadsStatic);
+        unpipe(router: CrossRoadsStatic): void;
     }
 }
 


### PR DESCRIPTION
This also fix the compile error which will happwn if you pass `noImplicitAny` to tsc.
