### PR TITLE
Added MousetrapInstance Interface.

### DIFF
--- a/mousetrap/mousetrap-tests.ts
+++ b/mousetrap/mousetrap-tests.ts
@@ -42,10 +42,18 @@ Mousetrap.trigger('esc', 'keyup');
 
 Mousetrap.reset();
 
+// Test that we can create an instance of mousetrap and attach the
+// event handler to the form element only, instead of the entire document.
+var element = document.querySelector('form');
+var instance = new Mousetrap(element);
+instance.bind('mod+s', function(){ console.log('Instance Saved'); });
+
+// Test that the factory method works as well.
+Mousetrap(element).bind('mod+s', function(){ console.log('Factory Saved'); });
+
 // Test that Mousetrap can be loaded as an external module.
 // Assume that if the externally-loaded module can be assigned to a variable with the type of global Mousetrap,
 // then everything is working correctly.
 
 import importedMousetrap = require('mousetrap');
 var mousetrapModuleReference: typeof Mousetrap = importedMousetrap;
-

--- a/mousetrap/mousetrap.d.ts
+++ b/mousetrap/mousetrap.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Mousetrap 1.2.2
+// Type definitions for Mousetrap 1.5.x
 // Project: http://craig.is/killing/mice
 // Definitions by: Dániel Tar <https://github.com/qcz>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -8,8 +8,19 @@ interface ExtendedKeyboardEvent extends KeyboardEvent {
 }
 
 interface MousetrapStatic {
+    (el: Element): MousetrapInstance;
+    new (el: Element): MousetrapInstance;
     stopCallback: (e: ExtendedKeyboardEvent, element: Element, combo: string) => boolean;
+    bind(keys: string, callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
+    bind(keyArray: string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
+    unbind(keys: string, action?: string): void;
+    unbind(keyArray: string[], action?: string): void;
+    trigger(keys: string, action?: string): void;
+    reset(): void;
+}
 
+interface MousetrapInstance {
+    stopCallback: (e: ExtendedKeyboardEvent, element: Element, combo: string) => boolean;
     bind(keys: string, callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
     bind(keyArray: string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
     unbind(keys: string, action?: string): void;


### PR DESCRIPTION
As of Mousetrap 1.5, attaching event handlers to specific elements is now possible.
see: WRAPPING SPECIFIC ELEMENTS @ https://craig.is/killing/mice
