### PR TITLE
Update Angular module in angular-resource

### DIFF
--- a/angularjs/angular-resource.d.ts
+++ b/angularjs/angular-resource.d.ts
@@ -147,7 +147,7 @@ declare module angular.resource {
     }
 
     // IResourceServiceProvider used to configure global settings
-    interface IResourceServiceProvider extends ng.IServiceProvider {
+    interface IResourceServiceProvider extends angular.IServiceProvider {
 
         defaults: IResourceOptions;
     }


### PR DESCRIPTION
Angular module was updated from `ng` to `angular` but there was still a reference to the old module in `angular-resource`
