### PR TITLE
fix argument typing for Mixin.create in ember.d.ts

### DIFF
--- a/ember/ember.d.ts
+++ b/ember/ember.d.ts
@@ -1418,9 +1418,9 @@ declare module Ember {
         apply(obj: any): any;
         /**
         Creates an instance of the class.
-        @param args A hash containing values with which to initialize the newly instantiated object.
+        @param arguments A hash containing values with which to initialize the newly instantiated object.
         **/
-        static create<T extends Mixin>(...args: []): T;
+        static create<T extends Mixin>(...arguments: []): T;
         detect(obj: any): boolean;
         reopen<T extends Mixin>(args?: {}): T;
     }

--- a/ember/ember.d.ts
+++ b/ember/ember.d.ts
@@ -1420,7 +1420,7 @@ declare module Ember {
         Creates an instance of the class.
         @param arguments A hash containing values with which to initialize the newly instantiated object.
         **/
-        static create<T extends Mixin>(...arguments: []): T;
+        static create<T extends Mixin>(...arguments: CoreObjectArguments[]): T;
         detect(obj: any): boolean;
         reopen<T extends Mixin>(args?: {}): T;
     }

--- a/ember/ember.d.ts
+++ b/ember/ember.d.ts
@@ -1418,9 +1418,9 @@ declare module Ember {
         apply(obj: any): any;
         /**
         Creates an instance of the class.
-        @param arguments A hash containing values with which to initialize the newly instantiated object.
+        @param args A hash containing values with which to initialize the newly instantiated object.
         **/
-        static create<T extends Mixin>(args: {}): T;
+        static create<T extends Mixin>(...args: []): T;
         detect(obj: any): boolean;
         reopen<T extends Mixin>(args?: {}): T;
     }


### PR DESCRIPTION
`Mixin.create` can take not one, but multiple arguments like e.g. `Component.extend` to extend other mixins.
Ember code: https://github.com/emberjs/ember.js/blob/master/packages/ember-metal/lib/mixin.js#L589
This method in action: http://jsbin.com/kipenaxowe/edit?html,js,console
