### PR TITLE
Import type definitions for express.static from serve-static instead …

### DIFF
--- a/express/express-tests.ts
+++ b/express/express-tests.ts
@@ -6,6 +6,9 @@ var app = express();
 app.engine('jade', require('jade').__express);
 app.engine('html', require('ejs').renderFile);
 
+express.static.mime.define({
+	'application/fx': ['fx']
+});
 app.use('/static', express.static(__dirname + '/public'));
 
 // simple logger

--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -11,6 +11,7 @@
  =============================================== */
 
 /// <reference path="../node/node.d.ts" />
+/// <reference path="../serve-static/serve-static.d.ts" />
 
 declare module Express {
 
@@ -24,6 +25,7 @@ declare module Express {
 
 declare module "express" {
     import http = require('http');
+    import serveStatic = require('serve-static');
 
     function e(): e.Express;
 
@@ -1067,31 +1069,7 @@ declare module "express" {
             response: Response;
         }
 
-        /**
-         * Static:
-         *
-         *   Static file server with the given `root` path.
-         *
-         * Examples:
-         *
-         *     var oneDay = 86400000;
-         *
-         *     connect()
-         *       .use(connect.static(__dirname + '/public'))
-         *
-         *     connect()
-         *       .use(connect.static(__dirname + '/public', { maxAge: oneDay }))
-         *
-         * Options:
-         *
-         *    - `maxAge`     Browser cache maxAge in milliseconds. defaults to 0
-         *    - `hidden`     Allow transfer of hidden files. defaults to false
-         *    - `redirect`   Redirect to trailing "/" when the pathname is a dir. defaults to true
-         *
-         * @param root
-         * @param options
-         */
-        function static(root: string, options?: any): RequestHandler;
+        var static: typeof serveStatic;
     }
 
     export = e;


### PR DESCRIPTION
…of only supporting the call signature.

Express exposes serve-static as express.static: https://github.com/strongloop/express/blob/master/lib/express.js#L60
Prior to this change, the type definitions would only consist of the call signature of serve-static, but serve static also has member variables. By importing the entire type definition from serve-static and using it for express.static, both the call signature and the members can be used.

`npm test` passes both locally and on [Travis](https://travis-ci.org/rehmsen/DefinitelyTyped/builds/67404105). 
