### PR TITLE
Reflect actual Argv#check() usage in check() type declaration

### DIFF
--- a/yargs/yargs.d.ts
+++ b/yargs/yargs.d.ts
@@ -57,8 +57,7 @@ declare module "yargs" {
 
 			example(command: string, description: string): Argv;
 
-			check(func: (argv: { [key: string]: any }, aliases: { [alias: string]: string }) => boolean): Argv;
-			check(func: (argv: { [key: string]: any }, aliases: { [alias: string]: string }) => string): Argv;
+			check(func: (argv: any, aliases: { [alias: string]: string }) => any): Argv;
 
 			boolean(key: string): Argv;
 			boolean(keys: string[]): Argv;


### PR DESCRIPTION
`yargs.Argv#check()` is actually more flexible than currently described.

See https://github.com/bcoe/yargs#checkfn
