### PR TITLE
dc.js - Fixes LineChart subclass

### DIFF
--- a/dcjs/dc.d.ts
+++ b/dcjs/dc.d.ts
@@ -263,7 +263,7 @@ declare module DC {
         radius: number;
     }
 
-    export interface LineChart extends StackMixin<BarChart>, CoordinateGridMixin<BarChart> {
+    export interface LineChart extends StackMixin<LineChart>, CoordinateGridMixin<LineChart> {
         interpolate: IGetSet<string, LineChart>;
         tension: IGetSet<number, LineChart>;
         defined: IGetSet<Accessor<any, boolean>, LineChart>;


### PR DESCRIPTION
LineChart class was incorrectly typed with BarChart.
