### PR TITLE
 HTMLAttributes property?:string won't allow recognition of interface

### DIFF
--- a/react/react-addons.d.ts
+++ b/react/react-addons.d.ts
@@ -511,7 +511,7 @@ declare module "react/addons" {
         // Non-standard Attributes
         autoCapitalize?: boolean;
         autoCorrect?: boolean;
-        property?: string;
+        // property?: string;
         itemProp?: string;
         itemScope?: boolean;
         itemType?: string;
@@ -1048,4 +1048,3 @@ declare module "react/addons" {
         identifiedTouch(identifier: number): Touch;
     }
 }
-

--- a/react/react-global.d.ts
+++ b/react/react-global.d.ts
@@ -511,7 +511,7 @@ declare module React {
         // Non-standard Attributes
         autoCapitalize?: boolean;
         autoCorrect?: boolean;
-        property?: string;
+        // property?: string;
         itemProp?: string;
         itemScope?: boolean;
         itemType?: string;
@@ -778,4 +778,3 @@ declare module React {
         identifiedTouch(identifier: number): Touch;
     }
 }
-

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -511,7 +511,7 @@ declare module "react" {
         // Non-standard Attributes
         autoCapitalize?: boolean;
         autoCorrect?: boolean;
-        property?: string;
+        // property?: string;
         itemProp?: string;
         itemScope?: boolean;
         itemType?: string;
@@ -778,4 +778,3 @@ declare module "react" {
         identifiedTouch(identifier: number): Touch;
     }
 }
-


### PR DESCRIPTION
//Bug:
let x = React.DOM.a( { cols : 2 }) // Doesn't work

//Expected
let x = React.DOM.a( { cols : 2 })

//Current Workaround
var modal = <React.HTMLAttributes>{}
modal.cols = 2
React.DOM.a( modal, "sample")
