### PR TITLE
Add `xit` and `xdescribe`

### DIFF
--- a/mocha/mocha.d.ts
+++ b/mocha/mocha.d.ts
@@ -37,11 +37,13 @@ interface MochaDone {
 
 declare var mocha: Mocha;
 declare var describe: Mocha.IContextDefinition;
+declare var xdescribe: Mocha.IContextDefinition;
 // alias for `describe`
 declare var context: Mocha.IContextDefinition;
 // alias for `describe`
 declare var suite: Mocha.IContextDefinition;
 declare var it: Mocha.ITestDefinition;
+declare var xit: Mocha.ITestDefinition;
 // alias for `it`
 declare var test: Mocha.ITestDefinition;
 


### PR DESCRIPTION
In Mocha you can comment out tests by changing their `it` or `describe` blocks to `xit` or `xdescribe`. This change will add support for those functions.
