### PR TITLE
[decimal.js] Change module name to standard 'decimal.js'.

### DIFF
--- a/decimal.js/decimal.js.d.ts
+++ b/decimal.js/decimal.js.d.ts
@@ -6,7 +6,7 @@
 declare var Decimal: decimal.IDecimalStatic;
 
 // Support AMD require
-declare module 'decimal' {
+declare module 'decimal.js' {
     export = Decimal;
 }
 


### PR DESCRIPTION
This change is small, but it will remove a minor headache for me. :smiley:

The current typings use the module name "decimal", which is [a different NPM package](https://www.npmjs.com/package/decimal).

decimal.js is in the [npm package of the same name](https://www.npmjs.com/package/decimal.js). In a Node or Browserify setting, you use it with `require('decimal.js')`. Thus, I've changed the typings to use the module name 'decimal.js'.

Let me know if you have any questions.
