### PR TITLE
Update angular-translate to return module name.

### DIFF
--- a/angular-translate/angular-translate.d.ts
+++ b/angular-translate/angular-translate.d.ts
@@ -5,6 +5,11 @@
 
 /// <reference path="../angularjs/angular.d.ts" />
 
+declare module "angular-translate" {
+    var _: string;
+    export = _;
+}
+
 declare module angular.translate {
 
     interface ITranslationTable {


### PR DESCRIPTION
Adds TypeScript support for the following (which is already supported by the latest angular-translate):

``` typescript
import * as ngTranslate from 'angular-translate';

ngTranslate; //=> 'pascalprecht.translate'
```
