### PR TITLE
change fromEvent to allow element of any type

### DIFF
--- a/rx/rx.async-lite.d.ts
+++ b/rx/rx.async-lite.d.ts
@@ -65,8 +65,7 @@ declare module Rx {
 			<T>(func: Function, context?: any): (...args: any[]) => Observable<T>;
 		};
 
-		fromEvent<T>(element: NodeList, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
-		fromEvent<T>(element: Node, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
+		fromEvent<T>(element: any, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
         fromEventPattern<T>(addHandler: (handler: Function) => void, removeHandler: (handler: Function) => void, selector?: (arguments: any[])=>T): Observable<T>;
 	}
 }


### PR DESCRIPTION
this function can take a wide range of types for element as seen from docs: https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/fromevent.md

"element (Any): The DOMElement, NodeList, jQuery element, Zepto Element, Angular element, Ember.js element or EventEmitter to attach a listener. For Backbone.Marionette this would be the application or an EventAggregator object."
