### PR TITLE
fix d3 bisector type signature

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1090,8 +1090,8 @@ declare module d3 {
     export function bisectRight<T>(array: T[], x: T, lo?: number, hi?: number): number;
 
     export function bisector<T, U>(accessor: (x: T) => U): {
-        left: (array: T[], x: T, lo?: number, hi?: number) => number;
-        right: (array: T[], x: T, lo?: number, hi?: number) => number;
+        left: (array: T[], x: U, lo?: number, hi?: number) => number;
+        right: (array: T[], x: U, lo?: number, hi?: number) => number;
     }
 
     export function bisector<T, U>(comparator: (a: T, b: U) => number): {


### PR DESCRIPTION
Incorrect type of `bisector`'s `left` and `right`. 
According d3 [API reference](https://github.com/mbostock/d3/wiki/Arrays#d3_bisector), one can use `bisector` like this:

``` JS
var data = [
  {date: new Date(2011, 1, 1), value: 0.5},
  {date: new Date(2011, 2, 1), value: 0.6},
  {date: new Date(2011, 3, 1), value: 0.7},
  {date: new Date(2011, 4, 1), value: 0.8}
];
var bisect = d3.bisector(function(d) { return d.date; }).right;
bisect(data, new Date(2011, 1, 2));
```

So the second parameter has the same type of the return type of `accessor`.

The other overload of `bisector` is correct.
