### PR TITLE
Q: Support for the Q.noConflict() method.

### DIFF
--- a/q/Q.d.ts
+++ b/q/Q.d.ts
@@ -316,6 +316,13 @@ declare module Q {
      * Calling resolve with a non-promise value causes promise to be fulfilled with that value.
      */
     export function resolve<T>(object: T): Promise<T>;
+
+	/**
+	 * Resets the global "Q" variable to the value it has before Q was loaded.
+	 * This will either be undefined if there was no version or the version of Q which was already loaded before.
+	 * @returns { The last version of Q. } 
+	 */
+	export function noConflict(): typeof Q;
 }
 
 declare module "q" {


### PR DESCRIPTION
See also #4728
