### PR TITLE
lodash: Add _.matchesProperty style to _.find

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -403,15 +403,13 @@ result = <number[]>_([1, 2, 3, 4, 5, 6]).select(function (num) { return num % 2 
 result = <IFoodCombined[]>_(foodsCombined).select('organic').value();
 result = <IFoodCombined[]>_(foodsCombined).select({ 'type': 'fruit' }).value();
 
-result = <number>_.find([1, 2, 3, 4], function (num) {
-    return num % 2 == 0;
-});
+result = <number>_.find([1, 2, 3, 4], num => num % 2 == 0);
 result = <IFoodCombined>_.find(foodsCombined, { 'type': 'vegetable' });
+result = <IFoodCombined>_.find(foodsCombined, 'type', 'vegetable');
 result = <IFoodCombined>_.find(foodsCombined, 'organic');
-result = <number>_([1, 2, 3, 4]).find(function (num) {
-    return num % 2 == 0;
-});
+result = <number>_([1, 2, 3, 4]).find(num => num % 2 == 0);
 result = <IFoodCombined>_(foodsCombined).find({ 'type': 'vegetable' });
+result = <IFoodCombined>_(foodsCombined).find('type', 'vegetable');
 result = <IFoodCombined>_(foodsCombined).find('organic');
 
 result = <number>_.detect([1, 2, 3, 4], function (num) {

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -2710,15 +2710,19 @@ declare module _ {
     //_.find
     interface LoDashStatic {
         /**
-        * Iterates over elements of a collection, returning the first element that the callback
-        * returns truey for. The callback is bound to thisArg and invoked with three arguments;
-        * (value, index|key, collection).
+        * Iterates over elements of collection, returning the first element predicate returns
+        * truthy for. The predicate is bound to thisArg and invoked with three arguments:
+        * (value, index|key, collection). 
         *
-        * If a property name is provided for callback the created "_.pluck" style callback will
-        * return the property value of the given element.
+        * If a property name is provided for predicate the created _.property style callback
+        * returns the property value of the given element. 
         *
-        * If an object is provided for callback the created "_.where" style callback will return
+        * If a value is also provided for thisArg the created _.matchesProperty style callback
+        * returns true for elements that have a matching property value, else false. 
+        *
+        * If an object is provided for predicate the created _.matches style callback returns
         * true for elements that have the properties of the given object, else false.
+        *
         * @param collection Searches for a value in this list.
         * @param callback The function called per iteration.
         * @param thisArg The this binding of callback.
@@ -2728,11 +2732,19 @@ declare module _ {
             collection: Array<T>,
             callback: ListIterator<T, boolean>,
             thisArg?: any): T;
+        detect<T>(
+            collection: Array<T>,
+            callback: ListIterator<T, boolean>,
+            thisArg?: any): T;
 
         /**
         * @see _.find
         **/
         find<T>(
+            collection: List<T>,
+            callback: ListIterator<T, boolean>,
+            thisArg?: any): T;
+        detect<T>(
             collection: List<T>,
             callback: ListIterator<T, boolean>,
             thisArg?: any): T;
@@ -2744,74 +2756,6 @@ declare module _ {
             collection: Dictionary<T>,
             callback: DictionaryIterator<T, boolean>,
             thisArg?: any): T;
-
-        /**
-        * @see _.find
-        * @param _.pluck style callback
-        **/
-        find<W, T>(
-            collection: Array<T>,
-            whereValue: W): T;
-
-        /**
-        * @see _.find
-        * @param _.pluck style callback
-        **/
-        find<W, T>(
-            collection: List<T>,
-            whereValue: W): T;
-
-        /**
-        * @see _.find
-        * @param _.pluck style callback
-        **/
-        find<W, T>(
-            collection: Dictionary<T>,
-            whereValue: W): T;
-
-        /**
-        * @see _.find
-        * @param _.where style callback
-        **/
-        find<T>(
-            collection: Array<T>,
-            pluckValue: string): T;
-
-        /**
-        * @see _.find
-        * @param _.where style callback
-        **/
-        find<T>(
-            collection: List<T>,
-            pluckValue: string): T;
-
-        /**
-        * @see _.find
-        * @param _.where style callback
-        **/
-        find<T>(
-            collection: Dictionary<T>,
-            pluckValue: string): T;
-
-        /**
-        * @see _.find
-        **/
-        detect<T>(
-            collection: Array<T>,
-            callback: ListIterator<T, boolean>,
-            thisArg?: any): T;
-
-        /**
-        * @see _.find
-        **/
-        detect<T>(
-            collection: List<T>,
-            callback: ListIterator<T, boolean>,
-            thisArg?: any): T;
-
-        /**
-        * @see _.find
-        **/
         detect<T>(
             collection: Dictionary<T>,
             callback: DictionaryIterator<T, boolean>,
@@ -2819,50 +2763,37 @@ declare module _ {
 
         /**
         * @see _.find
-        * @param _.pluck style callback
+        * @param _.matches style callback
         **/
+        find<W, T>(
+            collection: Array<T>|List<T>|Dictionary<T>,
+            whereValue: W): T;
         detect<W, T>(
-            collection: Array<T>,
+            collection: Array<T>|List<T>|Dictionary<T>,
             whereValue: W): T;
 
         /**
         * @see _.find
-        * @param _.pluck style callback
+        * @param _.matchesProperty style callback
         **/
-        detect<W, T>(
-            collection: List<T>,
-            whereValue: W): T;
-
-        /**
-        * @see _.find
-        * @param _.pluck style callback
-        **/
-        detect<W, T>(
-            collection: Dictionary<T>,
-            whereValue: W): T;
-
-        /**
-        * @see _.find
-        * @param _.where style callback
-        **/
+        find<T>(
+            collection: Array<T>|List<T>|Dictionary<T>,
+            path: string,
+            srcValue: any): T;
         detect<T>(
-            collection: Array<T>,
+            collection: Array<T>|List<T>|Dictionary<T>,
+            path: string,
+            srcValue: any): T;
+
+        /**
+        * @see _.find
+        * @param _.property style callback
+        **/
+        find<T>(
+            collection: Array<T>|List<T>|Dictionary<T>,
             pluckValue: string): T;
-
-        /**
-        * @see _.find
-        * @param _.where style callback
-        **/
         detect<T>(
-            collection: List<T>,
-            pluckValue: string): T;
-
-        /**
-        * @see _.find
-        * @param _.where style callback
-        **/
-        detect<T>(
-            collection: Dictionary<T>,
+            collection: Array<T>|List<T>|Dictionary<T>,
             pluckValue: string): T;
 
         /**
@@ -2891,7 +2822,7 @@ declare module _ {
 
         /**
         * @see _.find
-        * @param _.pluck style callback
+        * @param _.matches style callback
         **/
         findWhere<W, T>(
             collection: Array<T>,
@@ -2899,7 +2830,7 @@ declare module _ {
 
         /**
         * @see _.find
-        * @param _.pluck style callback
+        * @param _.matches style callback
         **/
         findWhere<W, T>(
             collection: List<T>,
@@ -2907,7 +2838,7 @@ declare module _ {
 
         /**
         * @see _.find
-        * @param _.pluck style callback
+        * @param _.matches style callback
         **/
         findWhere<W, T>(
             collection: Dictionary<T>,
@@ -2915,7 +2846,7 @@ declare module _ {
 
         /**
         * @see _.find
-        * @param _.where style callback
+        * @param _.property style callback
         **/
         findWhere<T>(
             collection: Array<T>,
@@ -2923,7 +2854,7 @@ declare module _ {
 
         /**
         * @see _.find
-        * @param _.where style callback
+        * @param _.property style callback
         **/
         findWhere<T>(
             collection: List<T>,
@@ -2931,7 +2862,7 @@ declare module _ {
 
         /**
         * @see _.find
-        * @param _.where style callback
+        * @param _.property style callback
         **/
         findWhere<T>(
             collection: Dictionary<T>,
@@ -2947,14 +2878,20 @@ declare module _ {
             thisArg?: any): T;
         /**
         * @see _.find
-        * @param _.where style callback
+        * @param _.matches style callback
         */
         find<W>(
             whereValue: W): T;
-
         /**
         * @see _.find
-        * @param _.where style callback
+        * @param _.matchesProperty style callback
+        */
+        find(
+            path: string,
+            srcValue: any): T;
+        /**
+        * @see _.find
+        * @param _.property style callback
         */
         find(
             pluckValue: string): T;

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -2732,6 +2732,11 @@ declare module _ {
             collection: Array<T>,
             callback: ListIterator<T, boolean>,
             thisArg?: any): T;
+
+        /**
+	* Alias of _.find
+        * @see _.find
+        **/
         detect<T>(
             collection: Array<T>,
             callback: ListIterator<T, boolean>,
@@ -2744,6 +2749,11 @@ declare module _ {
             collection: List<T>,
             callback: ListIterator<T, boolean>,
             thisArg?: any): T;
+
+        /**
+	* Alias of _.find
+        * @see _.find
+        **/
         detect<T>(
             collection: List<T>,
             callback: ListIterator<T, boolean>,
@@ -2756,6 +2766,11 @@ declare module _ {
             collection: Dictionary<T>,
             callback: DictionaryIterator<T, boolean>,
             thisArg?: any): T;
+
+        /**
+	* Alias of _.find
+        * @see _.find
+        **/
         detect<T>(
             collection: Dictionary<T>,
             callback: DictionaryIterator<T, boolean>,
@@ -2768,6 +2783,12 @@ declare module _ {
         find<W, T>(
             collection: Array<T>|List<T>|Dictionary<T>,
             whereValue: W): T;
+
+        /**
+	* Alias of _.find
+        * @see _.find
+        * @param _.matches style callback
+        **/
         detect<W, T>(
             collection: Array<T>|List<T>|Dictionary<T>,
             whereValue: W): T;
@@ -2780,6 +2801,12 @@ declare module _ {
             collection: Array<T>|List<T>|Dictionary<T>,
             path: string,
             srcValue: any): T;
+
+        /**
+	* Alias of _.find
+        * @see _.find
+        * @param _.matchesProperty style callback
+        **/
         detect<T>(
             collection: Array<T>|List<T>|Dictionary<T>,
             path: string,
@@ -2792,6 +2819,12 @@ declare module _ {
         find<T>(
             collection: Array<T>|List<T>|Dictionary<T>,
             pluckValue: string): T;
+
+        /**
+	* Alias of _.find
+        * @see _.find
+        * @param _.property style callback
+        **/
         detect<T>(
             collection: Array<T>|List<T>|Dictionary<T>,
             pluckValue: string): T;


### PR DESCRIPTION
- Sync with latest documentation
- Add a _.find([{id: ‘a’}, ‘id’, ‘a’) support
- Reduce verbose using union type
