### PR TITLE
Support for Deactivating Compiler Option "Allow implicit any" in AmplifyJS.d.ts

### DIFF
--- a/amplifyjs/amplifyjs.d.ts
+++ b/amplifyjs/amplifyjs.d.ts
@@ -50,7 +50,7 @@ interface amplifyRequest {
     *   success (optional): Function to invoke on success.
     *   error (optional): Function to invoke on error.
     */
-    (settings: amplifyRequestSettings);
+    (settings: amplifyRequestSettings): any;
 
     /***
     * Define a resource.


### PR DESCRIPTION
Currently Type Script is not happy with this DTS when you deactivate this Option. 
