### PR TITLE
Enable gulp-if.d.ts to be used as a global/external-agnostic module

### DIFF
--- a/gulp-if/gulp-if-tests.ts
+++ b/gulp-if/gulp-if-tests.ts
@@ -8,3 +8,19 @@ gulp.src("test.css")
 
 gulp.src("test.css")
     .pipe(_if(false, gulp.src("test.css"), gulp.src("test.css")));
+    
+/*
+ * When using gulp-load-plugins, it is useful to be able to 
+ * access type information through the plugin variable as well
+ */
+interface Plugins {
+    if: gulpIf.GulpIf;
+}
+
+var $: Plugins = require("gulp-load-plugins");
+
+gulp.src("test.css")
+    .pipe($.if(true, gulp.src("test.css")));
+
+gulp.src("test.css")
+    .pipe($.if(false, gulp.src("test.css"), gulp.src("test.css")));

--- a/gulp-if/gulp-if.d.ts
+++ b/gulp-if/gulp-if.d.ts
@@ -5,10 +5,15 @@
 
 /// <reference path="../node/node.d.ts"/>
 
+declare module gulpIf {
+    export interface GulpIf {
+        (condition: boolean,
+         stream: NodeJS.ReadWriteStream,
+         elseStream?: NodeJS.ReadWriteStream): NodeJS.ReadWriteStream    
+    }
+}
+
 declare module "gulp-if" {
-    function gulpIf(
-        condition: boolean,
-        stream: NodeJS.ReadWriteStream,
-        elseStream?: NodeJS.ReadWriteStream): NodeJS.ReadWriteStream;
-    export = gulpIf;
+    var gulp_if: gulpIf.GulpIf;
+    export = gulp_if;
 }


### PR DESCRIPTION
When using gulp-load-plugins, it is useful to be able to access type information for gulp-if or other plugins through the plugin variable as well as by 'require'-ing them.  This change takes the advice on global/external-agnostic libraries from the TypeScript documentation at: https://typescript.codeplex.com/wikipage?title=Writing%20Definition%20%28.d.ts%29%20Files
