### PR TITLE
extends restangular IProvider in IService interface

### DIFF
--- a/restangular/restangular-tests.ts
+++ b/restangular/restangular-tests.ts
@@ -81,6 +81,50 @@ myApp.controller('TestCtrl', (
   Restangular.one('accounts', 123).one('buildings', 456).get<String>();
   Restangular.one('accounts', 123).getList('buildings');
   Restangular.one('accounts', 123).getList<String>('buildings');
+  
+  Restangular.setBaseUrl('/api/v1');
+  Restangular.setExtraFields(['name']);
+  Restangular.setResponseExtractor(function (response, operation) {
+      return response.data;
+  });
+
+  Restangular.setDefaultHttpFields({ cache: true });
+  Restangular.setMethodOverriders(["put", "patch"]);
+
+  Restangular.setErrorInterceptor(function (response) {
+      console.error('' + response.status + ' ' + response.data);
+  });
+
+  Restangular.setRequestSuffix('.json');
+
+  Restangular.setRequestInterceptor(function (element, operation, route, url) {
+  });
+
+  Restangular.addElementTransformer('accounts', false, function (elem: any) {
+      elem.accountName = 'Changed';
+      return elem;
+  });
+
+  Restangular.setRestangularFields({
+    id: "_id",
+    route: "restangularRoute",
+    selfLink: "self.href"
+  });
+
+  Restangular.addRequestInterceptor(function(element, operation, route, url) {
+    delete element.name;
+    return element;
+  });
+
+  Restangular.setFullRequestInterceptor(function(element, operation, route, url, headers, params, httpConfig) {
+    delete element.name;
+    return {
+      element: element,
+      params: params,
+      headers: headers,
+      httpConfig: httpConfig
+    };
+  });
 
   var accountData = Restangular.one('accounts', 123).plain();
   var accountClone: restangular.IElement = Restangular.one('accounts', 123).clone();

--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -83,7 +83,7 @@ declare module restangular {
     addRestangularMethod(name: string, operation: string, path?: string, params?: any, headers?: any, elem?: any): IPromise<any>;
   }
 
-  interface IService extends ICustom {
+  interface IService extends ICustom, IProvider {
     one(route: string, id?: number): IElement;
     one(route: string, id?: string): IElement;
     oneUrl(route: string, url: string): IElement;


### PR DESCRIPTION
Extends restangular IProvider in IService interface to reflect properties exposed on the service object at run-time. If you inspect the Restangular service object, or look at the code behind it, it has all the methods from RestangularProvider.

http://i.imgur.com/i8e8dgq.png
