### PR TITLE
PathOptions.pointerEvents

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -3278,7 +3278,7 @@ declare module L {
         /**
           * Sets the pointer-events attribute on the path if SVG backend is used.
           */
-        pointerEvents?: boolean;
+        pointerEvents?: string;
 
         /**
           * Custom class name set on an element.


### PR DESCRIPTION
PathOptions.pointerEvents should be string instead of boolean, see http://leafletjs.com/reference.html#path-pointerevents and https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events
