### PR TITLE
typeahead.js update

### DIFF
--- a/typeahead/typeahead-tests.ts
+++ b/typeahead/typeahead-tests.ts
@@ -1,4 +1,5 @@
 ﻿/// <reference path="../jquery/jquery.d.ts"/>
+/// <reference path="../handlebars/handlebars.d.ts"/>
 /// <reference path="typeahead.d.ts"/>
 
 //
@@ -6,301 +7,589 @@
 //
 
 var substringMatcher = function (strs: any) {
-    return function findMatches(q: any, cb: any) {
-        var matches: any, substrRegex: any;
+	return function findMatches(q: any, cb: any) {
+		var matches: any, substrRegex: any;
 
-        // an array that will be populated with substring matches
-        matches = [];
+		// an array that will be populated with substring matches
+		matches = [];
 
-        // regex used to determine if a string contains the substring `q`
-        substrRegex = new RegExp(q, 'i');
+		// regex used to determine if a string contains the substring `q`
+		substrRegex = new RegExp(q, 'i');
 
-        // iterate through the pool of strings and for any string that
-        // contains the substring `q`, add it to the `matches` array
-        $.each(strs, function (i, str) {
-            if (substrRegex.test(str)) {
-                // the typeahead jQuery plugin expects suggestions to a
-                // JavaScript object, refer to typeahead docs for more info
-                matches.push({ value: str });
-            }
-        });
+		// iterate through the pool of strings and for any string that
+		// contains the substring `q`, add it to the `matches` array
+		$.each(strs, function (i, str) {
+			if (substrRegex.test(str)) {
+				// the typeahead jQuery plugin expects suggestions to a
+				// JavaScript object, refer to typeahead docs for more info
+				matches.push({ value: str });
+			}
+		});
 
-        cb(matches);
-    }
+		cb(matches);
+	}
 }
 
 var states = ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California',
-    'Colorado', 'Connecticut', 'Delaware', 'Florida', 'Georgia', 'Hawaii',
-    'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana',
-    'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota',
-    'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire',
-    'New Jersey', 'New Mexico', 'New York', 'North Carolina', 'North Dakota',
-    'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island',
-    'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont',
-    'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'
+	'Colorado', 'Connecticut', 'Delaware', 'Florida', 'Georgia', 'Hawaii',
+	'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana',
+	'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota',
+	'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire',
+	'New Jersey', 'New Mexico', 'New York', 'North Carolina', 'North Dakota',
+	'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island',
+	'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont',
+	'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'
 ];
 
 
-function test_method_names() {
-    $('#the-basics .typeahead').typeahead('destroy');
-    $('#the-basics .typeahead').typeahead('open');
-    $('#the-basics .typeahead').typeahead('close');
-    $('#the-basics .typeahead').typeahead('val');
-    $('#the-basics .typeahead').typeahead('val', 'test value');    
+function testMethodNames() {
+	$('#the-basics .typeahead').typeahead('destroy');
+	$('#the-basics .typeahead').typeahead('open');
+	$('#the-basics .typeahead').typeahead('close');
+	$('#the-basics .typeahead').typeahead('val');
+	$('#the-basics .typeahead').typeahead('val', 'test value');	
 }
 
 
-function test_options() {
+function testOptions() {
+	var dataSets: Twitter.Typeahead.Dataset<string>[] = [];
+	
+	function withEmptyOptions() {
+		$('#the-basics .typeahead').typeahead({}, dataSets);
+	}
 
-    var dataSets: Twitter.Typeahead.Dataset[] = [];
-    
-    function with_empty_options() {
-        $('#the-basics .typeahead').typeahead({}, dataSets);
-    }
+	function withHintOption() {
+		$('#the-basics .typeahead').typeahead({ hint: true }, dataSets);
+	}
 
-    function with_hint_option() {
-        $('#the-basics .typeahead').typeahead({ hint: true }, dataSets);
-    }
+	function withHighlightOption() {
+		$('#the-basics .typeahead').typeahead({ highlight: true }, dataSets);
+	}
 
-    function with_highlight_option() {
-        $('#the-basics .typeahead').typeahead({ highlight: true }, dataSets);
-    }
+	function withMinLengthOption() {
+		$('#the-basics .typeahead').typeahead({ minLength: 1 }, dataSets);
+	}
 
-    function with_minLength_option() {
-        $('#the-basics .typeahead').typeahead({ minLength: 1 }, dataSets);
-    }
-
-    function with_all_options() {
-        $('#the-basics .typeahead').typeahead({
-                hint: true,
-                highlight: true,
-                minLength: 1
-            },
-            dataSets
-        );
-    }
+	function withAllOptions() {
+		$('#the-basics .typeahead').typeahead({
+				hint: true,
+				highlight: true,
+				minLength: 1
+			},
+			dataSets
+		);
+	}
 }
 
-function test_datasets_array() {
+function testDatasetsArray() {
+	var options: Twitter.Typeahead.Options = {};
 
-    var options: Twitter.Typeahead.Options = {};
+	function withOnlySource() {
+		$('#the-basics .typeahead').typeahead(options, [{
+			source: substringMatcher(states)
+		}]);
+	}
 
-    function with_only_source() {
-        $('#the-basics .typeahead').typeahead(options, [{
-            source: substringMatcher(states)
-        }]);
-    }
+	function withNameOption() {
+		$('#the-basics .typeahead').typeahead(options, [{
+			name: 'states',
+			source: substringMatcher(states),
+		}]);
+	}
 
-    function with_name_option() {
+	function withAsyncOption() {
+		$('#the-basics .typeahead').typeahead(options, [{
+			async: false,
+			source: substringMatcher(states),
+		}]);
+	}
 
-        $('#the-basics .typeahead').typeahead(options, [{
-            name: 'states',
-            source: substringMatcher(states),
-        }]);
-    }
+	function withLimitOption() {
+		$('#the-basics .typeahead').typeahead(options, [{
+			limit: 3,
+			source: substringMatcher(states),
+		}]);
+	}
 
-    function with_displayKey_option() {
-        $('#the-basics .typeahead').typeahead(options, [{
-                displayKey: 'value',
-                source: substringMatcher(states)
-            }]
-        );
-    }
+	function withDisplayOption() {
+		$('#the-basics .typeahead').typeahead(options, [{
+				display: 'value',
+				source: substringMatcher(states)
+			}]
+		);
 
-    function with_templates_option() {
-        $('#the-basics .typeahead').typeahead(options, [{
-                templates: {},
-                source: substringMatcher(states)
-            }]
-        );
-    }
+		$('#the-basics .typeahead').typeahead(options, [{
+				display: (x: any) => x,
+				source: substringMatcher(states)
+			}]
+		);
+	}
 
-    function with_all_options() {
-        $('#the-basics .typeahead').typeahead(options, [{
-                name: 'states',
-                displayKey: 'value',
-                templates: {},
-                source: substringMatcher(states)
-            }]
-        );
-    }
+	function withTemplatesOption() {
+		$('#the-basics .typeahead').typeahead(options, [{
+				templates: {},
+				source: substringMatcher(states)
+			}]
+		);
+	}
 
-    function with_multiple_datasets() {
-        $('#the-basics .typeahead').typeahead(options, [
-             {
-                name: 'states',
-                displayKey: 'value',
-                templates: {},
-                source: substringMatcher(states)
-            },
-            {
-                name: 'states alternative',
-                displayKey: 'value',
-                templates: {},
-                source: substringMatcher(states)
-            }
-        ]);
-    }
+	function withAllOptions() {
+		$('#the-basics .typeahead').typeahead(options, [{
+				name: 'states',
+				display: 'value',
+				templates: {},
+				source: substringMatcher(states)
+			}]
+		);
+	}
+
+	function withMultipleDatasets() {
+		$('#the-basics .typeahead').typeahead(options, [
+			{
+				name: 'states',
+				display: 'value',
+				templates: {},
+				source: substringMatcher(states)
+			},
+			{
+				name: 'states alternative',
+				display: 'value',
+				templates: {},
+				source: substringMatcher(states)
+			}
+		]);
+	}
 }
 
 
-function test_datasets_objects() {
+function testDatasetsObjects() {
 
-    var options: Twitter.Typeahead.Options = {};
+	var options: Twitter.Typeahead.Options = {};
 
-    function with_only_source() {
-        $('#the-basics .typeahead').typeahead(options, {
-            source: substringMatcher(states)
-        });
-    }
+	function withOnlySource() {
+		$('#the-basics .typeahead').typeahead(options, {
+			source: substringMatcher(states)
+		});
+	}
 
-    function with_name_option() {
+	function withNameOption() {
 
-        $('#the-basics .typeahead').typeahead(options, {
-            name: 'states',
-            source: substringMatcher(states),
-        });
-    }
+		$('#the-basics .typeahead').typeahead(options, {
+			name: 'states',
+			source: substringMatcher(states),
+		});
+	}
 
-    function with_displayKey_option() {
-        $('#the-basics .typeahead').typeahead(options,
-            {
-                displayKey: 'value',
-                source: substringMatcher(states)
-            }
-        );
-    }
+	function withDisplayKeyOption() {
+		$('#the-basics .typeahead').typeahead(options,
+			{
+				display: 'value',
+				source: substringMatcher(states)
+			}
+		);
+	}
 
-    function with_templates_option() {
-        $('#the-basics .typeahead').typeahead(options,
-            {
-                templates: {},
-                source: substringMatcher(states)
-            }
-        );
-    }
+	function withTemplatesOption() {
+		$('#the-basics .typeahead').typeahead(options,
+			{
+				templates: {},
+				source: substringMatcher(states)
+			}
+		);
+	}
 
-    function with_all_options() {
-        $('#the-basics .typeahead').typeahead(options,
-            {
-                name: 'states',
-                displayKey: 'value',
-                templates: {},
-                source: substringMatcher(states)
-            }
-        );
-    }
+	function withAllOptions() {
+		$('#the-basics .typeahead').typeahead(options,
+			{
+				name: 'states',
+				display: 'value',
+				templates: {},
+				source: substringMatcher(states)
+			}
+		);
+	}
 
-    function with_multiple_objects() {
-        $('#the-basics .typeahead').typeahead(options, 
-            {
-                name: 'states',
-                displayKey: 'value',
-                templates: {},
-                source: substringMatcher(states)
-            },
-            {
-                name: 'states alternative',
-                displayKey: 'value',
-                templates: {},
-                source: substringMatcher(states)
-            }
-        );
-    }
+	function withMultipleObjects() {
+		$('#the-basics .typeahead').typeahead(options, 
+			{
+				name: 'states',
+				display: 'value',
+				templates: {},
+				source: substringMatcher(states)
+			},
+			{
+				name: 'states alternative',
+				display: 'value',
+				templates: {},
+				source: substringMatcher(states)
+			}
+		);
+	}
 }
 
-function test_dataset_templates() {
+function testDatasetTemplates() {
+	var options: Twitter.Typeahead.Options = {};
 
-    var options: Twitter.Typeahead.Options = {};
+	function withNoOptions() {
+		$('#the-basics .typeahead').typeahead(options, {
+			source: substringMatcher(states),
+			templates: {}
+		});
+	}
 
-    function with_no_options() {
-        $('#the-basics .typeahead').typeahead(options, {
-            source: substringMatcher(states),
-            templates: {}
-        });
-    }
+	function withNotFoundOption() {
+		$('#the-basics .typeahead').typeahead(options, {
+			source: substringMatcher(states),
+			templates: { notFound: 'no results' }
+		});
+	}
 
-    function with_empty_option() {
-        $('#the-basics .typeahead').typeahead(options, {
-            source: substringMatcher(states),
-            templates: { empty: 'no results' }
-        });
-    }
+	function withNotFoundOptionAsAFunction() {
+		$('#the-basics .typeahead').typeahead(options, {
+			source: substringMatcher(states),
+			templates: {
+				notFound: function(context: any) {
+					return context.name;
+				}
+			}
+		});
+	}
 
-    function with_empty_option_as_a_function() {
-        $('#the-basics .typeahead').typeahead(options, {
-            source: substringMatcher(states),
-            templates: {
-                empty: function(context: any) {
-                    return context.name;
-                }
-            }
-        });
-    }
+	function withFooterOption() {
+		$('#the-basics .typeahead').typeahead(options, {
+			source: substringMatcher(states),
+			templates: { footer: 'custom footer' }
+		});
+	}
 
-    function with_footer_option() {
-        $('#the-basics .typeahead').typeahead(options, {
-            source: substringMatcher(states),
-            templates: { footer: 'custom footer' }
-        });
-    }
+	function withFooterOptionAsAFunction() {
+		$('#the-basics .typeahead').typeahead(options, {
+			source: substringMatcher(states),
+			templates: {
+				footer: function(context: any) {
+					return context.name;
+				}
+			}
+		});
+	}
 
-    function with_footer_option_as_a_function() {
-        $('#the-basics .typeahead').typeahead(options, {
-            source: substringMatcher(states),
-            templates: {
-                footer: function(context: any) {
-                    return context.name;
-                }
-            }
-        });
-    }
+	function withHeaderOption() {
+		$('#the-basics .typeahead').typeahead(options, {
+			source: substringMatcher(states),
+			templates: { header: 'custom header' }
+		});
+	}
 
-    function with_header_option() {
-        $('#the-basics .typeahead').typeahead(options, {
-            source: substringMatcher(states),
-            templates: { header: 'custom header' }
-        });
-    }
+	function withHeaderOptionAsAFunction() {
+		$('#the-basics .typeahead').typeahead(options, {
+			source: substringMatcher(states),
+			templates: {
+				header: function(context: any) {
+					return context.name;
+				}
+			}
+		});
+	}
 
-    function with_header_option_as_a_function() {
-        $('#the-basics .typeahead').typeahead(options, {
-            source: substringMatcher(states),
-            templates: {
-                header: function(context: any) {
-                    return context.name;
-                }
-            }
-        });
-    }
+	function withSuggestionOption() {
+		$('#the-basics .typeahead').typeahead(options, {
+			source: substringMatcher(states),
+			templates: {			   
+				suggestion: function(context) {
+					return context.name;
+				}
+			}
+		});
+	}
 
-    function with_suggestion_option() {
-        $('#the-basics .typeahead').typeahead(options, {
-            source: substringMatcher(states),
-            templates: {               
-                suggestion: function(context) {
-                    return context.name;
-                }
-            }
-        });
-    }
-
-    function with_all_options() {
-        $('#the-basics .typeahead').typeahead(options, {
-            source: substringMatcher(states),
-            templates: {
-                empty: 'no results',        
-                footer: 'custom footer',
-                header: 'custom header',
-                suggestion: function(context) {
-                    return context.name;
-                }
-            }
-        });
-    }
+	function withAllOptions() {
+		$('#the-basics .typeahead').typeahead(options, {
+			source: substringMatcher(states),
+			templates: {
+				empty: 'no results',		
+				footer: 'custom footer',
+				header: 'custom header',
+				suggestion: function(context) {
+					return context.name;
+				}
+			}
+		});
+	}
 }
 
-function test_value() {
-    var value: string = $('foo').typeahead('val');
-    $('foo').typeahead('val', value);
+function testValue() {
+	var value: string = $('foo').typeahead('val');
+	$('foo').typeahead('val', value);
+}
+
+
+function bloodhoundTests() {
+
+	// Test Bloodhound.BloodhoundOptions<T>
+	function testOptions() {
+		
+		function withMinimalOptions() {
+			new Bloodhound({
+				datumTokenizer: Bloodhound.tokenizers.whitespace,
+				queryTokenizer: Bloodhound.tokenizers.whitespace
+			})
+		}
+		
+		function testLocalProperty() {
+			new Bloodhound({
+				datumTokenizer: Bloodhound.tokenizers.whitespace,
+				queryTokenizer: Bloodhound.tokenizers.whitespace,
+				local: ['cat', 'dog', 'catdog']
+			});
+
+			new Bloodhound({
+				datumTokenizer: Bloodhound.tokenizers.whitespace,
+				queryTokenizer: Bloodhound.tokenizers.whitespace,
+				local: () => ['cat', 'dog', 'catdog']
+			});
+		}
+
+		function testNonMaximalPrefetchProperty() {
+			new Bloodhound({
+				datumTokenizer: Bloodhound.tokenizers.whitespace,
+				queryTokenizer: Bloodhound.tokenizers.whitespace,
+				prefetch: 'http://prefetch'
+			});
+
+			new Bloodhound({
+				datumTokenizer: Bloodhound.tokenizers.whitespace,
+				queryTokenizer: Bloodhound.tokenizers.whitespace,
+				prefetch: {
+					url: 'http://prefetch'
+				}
+			});
+		}
+
+		function testNonMaximalRemoteProperty() {
+			new Bloodhound({
+				datumTokenizer: Bloodhound.tokenizers.whitespace,
+				queryTokenizer: Bloodhound.tokenizers.whitespace,
+				remote: 'http://remote'
+			});
+
+			new Bloodhound({
+				datumTokenizer: Bloodhound.tokenizers.whitespace,
+				queryTokenizer: Bloodhound.tokenizers.whitespace,
+				remote: {
+					url: 'http://remote'
+				}
+			});
+		}
+		
+		function testMaximalOptions() {
+			// By casting to T wherever possible, we verify internal consistency
+			new Bloodhound({
+				datumTokenizer: Bloodhound.tokenizers.whitespace,
+				queryTokenizer: Bloodhound.tokenizers.whitespace,
+				initialize: false,
+				identify: (datum: string) => 'some id',
+				sufficient: 5,
+				sorter: (a: string, b: string) => 2,
+				local: ['cat', 'dog', 'catdog'],
+				prefetch: {
+					url: 'http://prefetchurl',
+					cache: false,
+					ttl: 123423,
+					cacheKey: 'some key',
+					thumbprint: 'thumbprint',
+					prepare: settings => settings,
+					transform: response => response
+				},
+				remote: {
+					url: 'http://remote',
+					prepare: (query, settings) => settings,
+					wildcard: 'wildcard',
+					rateLimitBy: 'debounce',
+					rateLimitWait: 300,
+					transform: response => response
+				}
+			})
+		}
+
+	}
+
+}
+
+
+/**
+ * Taken from http://twitter.github.io/typeahead.js/examples/
+ *
+ * I believe some of them are obsolete or incorrect and have changed them accordingly. Best example is 
+ * setting datumTokenizer as Bloodhound.tokenizers.obj.whitespace('team'), a string[].
+ */
+function examples() {
+
+	function basics() {
+		$('#the-basics .typeahead').typeahead({
+			hint: true,
+			highlight: true,
+			minLength: 1
+		}, {
+			name: 'states',
+			source: substringMatcher(states)
+		});
+	}
+
+
+	function suggestionEngine() {
+		// constructs the suggestion engine
+		var statesEngine = new Bloodhound({
+			datumTokenizer: Bloodhound.tokenizers.whitespace,
+			queryTokenizer: Bloodhound.tokenizers.whitespace,
+			// `states` is an array of state names defined in "The Basics"
+			local: states
+		});
+		
+		$('#bloodhound .typeahead').typeahead({
+			hint: true,
+			highlight: true,
+			minLength: 1
+		}, {
+			name: 'states',
+			source: statesEngine
+		});
+	}
+
+	var countries = new Bloodhound({
+		datumTokenizer: Bloodhound.tokenizers.whitespace,
+		queryTokenizer: Bloodhound.tokenizers.whitespace,
+		// url points to a json file that contains an array of country names, see
+		// https://github.com/twitter/typeahead.js/blob/gh-pages/data/countries.json
+		prefetch: '../data/countries.json'
+	});
+
+	var bestPictures = new Bloodhound({
+			datumTokenizer: Bloodhound.tokenizers.obj.whitespace,
+			queryTokenizer: Bloodhound.tokenizers.whitespace,
+			prefetch: '../data/films/post_1960.json',
+			remote: {
+				url: '../data/films/queries/%QUERY.json',
+				wildcard: '%QUERY'
+			}
+		});
+	
+	function prefetch() {
+		// passing in `null` for the `options` arguments will result in the default
+		// options being used
+		$('#prefetch .typeahead').typeahead(null, {
+			name: 'countries',
+			source: countries
+		});
+	}
+
+	function remote() {
+		$('#remote .typeahead').typeahead(null, {
+			name: 'best-pictures',
+			display: 'value',
+			source: bestPictures
+		});
+	}
+
+	function customTemplates() {
+		$('#custom-templates .typeahead').typeahead(null, {
+			name: 'best-pictures',
+			display: 'value',
+			source: bestPictures,
+			templates: {
+				empty: [
+					'<div class="empty-message">',
+					'unable to find any Best Picture winners that match the current query',
+					'</div>'
+				].join('\n'),
+				suggestion: Handlebars.compile('<div><strong>{{value}}</strong> – {{year}}</div>')
+			}
+		});
+	}
+
+	function defaultSuggestions() {
+		var nflTeams = new Bloodhound({
+			datumTokenizer: Bloodhound.tokenizers.obj.whitespace,
+			queryTokenizer: Bloodhound.tokenizers.whitespace,
+			identify: function(obj: any) { return obj.team; },
+			prefetch: '../data/nfl.json'
+		});
+		
+		function nflTeamsWithDefaults(q: string, sync: any) {
+			if (q === '') {
+				sync(nflTeams.get('Detroit Lions', 'Green Bay Packers', 'Chicago Bears'));
+			} else {
+				nflTeams.search(q, sync);
+			}
+		}
+		
+		$('#default-suggestions .typeahead').typeahead({
+			minLength: 0,
+			highlight: true
+		}, {
+			name: 'nfl-teams',
+			display: 'team',
+			source: nflTeamsWithDefaults
+		});
+	}
+
+	function multipleDatasets() {
+		var nbaTeams = new Bloodhound({
+			datumTokenizer: Bloodhound.tokenizers.obj.whitespace,
+			queryTokenizer: Bloodhound.tokenizers.whitespace,
+			prefetch: '../data/nba.json'
+		});
+		
+		var nhlTeams = new Bloodhound({
+			datumTokenizer: Bloodhound.tokenizers.obj.whitespace,
+			queryTokenizer: Bloodhound.tokenizers.whitespace,
+			prefetch: '../data/nhl.json'
+		});
+		
+		$('#multiple-datasets .typeahead').typeahead({
+			highlight: true
+		}, {
+			name: 'nba-teams',
+			display: 'team',
+			source: nbaTeams,
+			templates: {
+				header: '<h3 class="league-name">NBA Teams</h3>'
+			}
+		}, {
+			name: 'nhl-teams',
+			display: 'team',
+			source: nhlTeams,
+			templates: {
+				header: '<h3 class="league-name">NHL Teams</h3>'
+			}
+		});
+	}
+
+	function scrollableDropdownMenu() {
+		$('#scrollable-dropdown-menu .typeahead').typeahead(null, {
+			name: 'countries',
+			limit: 10,
+			source: countries
+		});
+	}
+
+	function rtlSupport() {
+		var arabicPhrases = new Bloodhound({
+			datumTokenizer: Bloodhound.tokenizers.whitespace,
+			queryTokenizer: Bloodhound.tokenizers.whitespace,
+			local: [
+				"الإنجليزية",
+				"نعم",
+				"لا",
+				"مرحبا",
+				"أهلا"
+			]
+		});
+		
+		$('#rtl-support .typeahead').typeahead({
+			hint: false
+		}, {
+			name: 'arabic-phrases',
+			source: arabicPhrases
+		});
+	}
 }

--- a/typeahead/typeahead.d.ts
+++ b/typeahead/typeahead.d.ts
@@ -1,413 +1,478 @@
-// Type definitions for typeahead.js 0.10.4
+// Type definitions for typeahead.js 0.11.1
 // Project: http://twitter.github.io/typeahead.js/
-// Definitions by: Ivaylo Gochkov <https://github.com/igochkov/>, Gidon Junge <https://github.com/gjunge/>
+// Definitions by: Ivaylo Gochkov <https://github.com/igochkov/>, Gidon Junge <https://github.com/gjunge/>, Nathan Pitman <https://github.com/Seltzer/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../jquery/jquery.d.ts"/>
 
 interface JQuery {
+	/**
+	 * Removes typeahead functionality and reverts the input element back to its original state.
+	 */
+	typeahead(methodName: 'destroy'): JQuery;
 
-    /**
-     * Destroys previously initialized typeaheads. This entails reverting
-     * DOM modifications and removing event handlers.
-      *
-      * @constructor
-     * @param methodName Method 'destroy'
-      */
-    typeahead(methodName: 'destroy'): JQuery;
+	/**
+	 * Opens the suggestion menu.
+	 */
+	typeahead(methodName: 'open'): JQuery;
 
-    /**
-     * Opens the dropdown menu of typeahead. Note that being open does not mean that the menu is visible.
-     * The menu is only visible when it is open and has content.
-      *
-      * @constructor
-     * @param methodName Method 'open'
-      */
-    typeahead(methodName: 'open'): JQuery;
+	/**
+	 * Closes the suggestion menu.
+	 */
+	typeahead(methodName: 'close'): JQuery;
 
-    /**
-     * Closes the dropdown menu of typeahead.
-     *
-     * @constructor
-     * @param methodName Method 'close'
-     */
-    typeahead(methodName: 'close'): JQuery;
+	/**
+	 * Returns the current value of the typeahead. The value is the text the user has entered into the input element.
+	 */
+	typeahead(methodName: 'val'): string;
 
-    /**
-     * Returns the current value of the typeahead.
-     * The value is the text the user has entered into the input element.
-      *
-      * @constructor
-     * @param methodName Method 'val'
-      */
-    typeahead(methodName: 'val'): string;
+	/**
+	 * Sets the value of the typeahead. This should be used in place of jQuery#val.
+	 */
+	typeahead(methodName: 'val', val: string): JQuery;
+	
+	/**
+	 * For a given input[type="text"], enables typeahead functionality. options is an options hash that's 
+	 * used for configuration. Refer to Options for more info regarding the available configs. Subsequent 
+	 * arguments (*datasets), are individual option hashes for datasets. For more details regarding datasets, refer to Datasets.
+	 */
+	typeahead<TDatum>(options: Twitter.Typeahead.Options, datasets: Twitter.Typeahead.Dataset<TDatum>[]): JQuery;
 
-    /**
-      * Sets the value of the typeahead. This should be used in place of jQuery#val.
-      *
-      * @constructor
-      * @param methodName Method 'val'
-      * @param query The value to be set
-      */
-    typeahead(methodName: 'val', val: string): JQuery;
+	/**
+	 * For a given input[type="text"], enables typeahead functionality. options is an options hash that's 
+	 * used for configuration. Refer to Options for more info regarding the available configs. Subsequent 
+	 * arguments (*datasets), are individual option hashes for datasets. For more details regarding datasets, refer to Datasets.
+	 */
+	typeahead<TDatum>(options: Twitter.Typeahead.Options, ... datasets: Twitter.Typeahead.Dataset<TDatum>[]): JQuery;
 
-    /**
-      * Accommodates the val overload.
-      *
-      * @constructor
-      * @param methodName Method name ('val')
-      */
-    typeahead(methodName: string): string;
+	/**
+	 * Required to accommodate above overloads
+	 */
+	typeahead(methodName: string): string;
 
-
-    /**
-      * Accommodates multiple overloads.
-      *
-      * @constructor
-      * @param methodName Method name
-      * @param query The query to be set in case method 'val' is used.
-      */
-    typeahead(methodName: string, query: string): JQuery;
-
-    /**
-      * Accomodates specifying options such as hint and highlight.
-      * This is in correspondence to the examples mentioned in http://twitter.github.io/typeahead.js/examples/
-      *
-      * @constructor
-      * @param options ('hint' or 'highlight' or 'minLength' all of which are optional)
-      * @param datasets Array of datasets
-      */
-    typeahead(options: Twitter.Typeahead.Options, datasets: Twitter.Typeahead.Dataset[]): JQuery;
-
-    /**
-      * Accomodates specifying options such as hint and highlight.
-      * This is in correspondence to the examples mentioned in http://twitter.github.io/typeahead.js/examples/
-      *
-      * @constructor
-      * @param options ('hint' or 'highlight' or 'minLength' all of which are optional)
-      * @param datasets One or more datasets passed in as arguments.
-      */
-    typeahead(options: Twitter.Typeahead.Options, ... datasets: Twitter.Typeahead.Dataset[]): JQuery;
+	/**
+	 * Required to accommodate above overloads
+	 */
+	typeahead(methodName: string, query: string): JQuery;
 }
+
 
 declare module Twitter.Typeahead {
-    /**
-      * A dataset is an object that defines a set of data that hydrates
-      * suggestions. Typeaheads can be backed by multiple datasets.
-      * Given a query, a typeahead instance will inspect its backing
-      * datasets and display relevant suggestions to the end-user.
-      */
-    interface Dataset {
-        /**
-         * The backing data source for suggestions.
-         * Expected to be a function with the signature (query, cb).
-         * It is expected that the function will compute the suggestion set (i.e. an array of JavaScript objects) for query and then invoke cb with said set.
-         * cb can be invoked synchronously or asynchronously.
-         *
-          */
-        source: (query: string, cb: (result: any) => void) => void;
+	/**
+	 * A dataset is an object that defines a set of data that hydrates
+	 * suggestions. Typeaheads can be backed by multiple datasets.
+	 * Given a query, a typeahead instance will inspect its backing
+	 * datasets and display relevant suggestions to the end-user.
+	 */
+	interface Dataset<TDatum> {
+		/**
+		 * The backing data source for suggestions. Expected to be a function with the signature 
+		 * (query, syncResults, asyncResults). syncResults should be called with suggestions computed synchronously 
+		 * and asyncResults should be called with suggestions computed asynchronously (e.g. suggestions that come 
+		 * for an AJAX request). source can also be a Bloodhound instance. Required.
+		 */
+		source: Bloodhound<TDatum>
+			| ((query: string, syncResults?: (results: TDatum[]) => void, asyncResults?: (results: TDatum[]) => void) => void);
 
-        /**
-          * The name of the dataset.
-          * This will be appended to tt-dataset- to form the class name of the containing DOM element.
-          * Must only consist of underscores, dashes, letters (a-z), and numbers.
-          * Defaults to a random number.
-          */
-        name?: string;
+		/**
+		 * Lets the dataset know if async suggestions should be expected. If not set, this information is inferred 
+		 * from the signature of source i.e. if the source function expects 3 arguments, async will be set to true.
+		 */
+		async?: boolean;
+		
+		/**
+		 * The name of the dataset. This will be appended to {{classNames.dataset}}- to form the class name of the 
+		 * containing DOM element. Must only consist of underscores, dashes, letters (a-z), and numbers. Defaults 
+		 * to a random number.
+		 */
+		name?: string;
 
-        /**
-         * For a given suggestion object, determines the string representation of it.
-         * This will be used when setting the value of the input control after a suggestion is selected. Can be either a key string or a function that transforms a suggestion object into a string.
-         * Defaults to value.
-          */
-        displayKey?: string;
+		/**
+		 * The max number of suggestions to be displayed. Defaults to 5.
+		 */
+		limit?: number;
 
-        /**
-         * A hash of templates to be used when rendering the dataset.
-         * Note a precompiled template is a function that takes a JavaScript object as its first argument and returns a HTML string.
-          */
-        templates?: Templates;
-    }
+		/**
+		 * For a given suggestion, determines the string representation of it. This will be used when setting the 
+		 * value of the input control after a suggestion is selected. Can be either a key string or a function 
+		 * that transforms a suggestion object into a string. Defaults to stringifying the suggestion.
+		 */
+		display?: string | ((suggestion: any) => string);
+
+		/**
+		 * A hash of templates to be used when rendering the dataset.
+		 */
+		templates?: Templates;
+	}
+
+	
+	/**
+	 * Note a precompiled template is a function that takes a JavaScript object as its first argument and returns a HTML string.
+	 */
+	type PrecompiledTemplate = (obj: any) => string;
+
+	interface Templates {
+		/**
+		 * Rendered when 0 suggestions are available for the given query. Can be either a HTML string or a precompiled 
+		 * template. If it's a precompiled template, the passed in context will contain query
+		 */
+		notFound?: string | PrecompiledTemplate;
+
+		/**
+		 * Rendered when 0 synchronous suggestions are available but asynchronous suggestions 
+		 * are expected. Can be either a HTML string or a precompiled template. If it's a 
+		 * precompiled template, the passed in context will contain query.
+		 */
+		pending?: string | PrecompiledTemplate;
+		
+		/**
+		 * Rendered at the bottom of the dataset when suggestions are present. Can be either a HTML string 
+		 * or a precompiled template. If it's a precompiled template, the passed in context will contain 
+		 * query and suggestions.
+		 */
+		footer?: string | PrecompiledTemplate;
+
+		/**
+		* Rendered at the top of the dataset when suggestions are present. Can be either a HTML string 
+		 * or a precompiled template. If it's a precompiled template, the passed in context will contain 
+		 * query and suggestions.
+		*/
+		header?: string | PrecompiledTemplate;
+
+		/**
+		 * Used to render a single suggestion. If set, this has to be a precompiled template. The associated 
+		 * suggestion object will serve as the context. Defaults to the value of display wrapped in a div tag i.e. <div>{{value}}</div>.
+		 */
+		suggestion?: PrecompiledTemplate;
+	}
 
 
-    interface Templates {
+	interface ClassNames {
+		/**
+		 * Added to input that's initialized into a typeahead. Defaults to tt-input.
+		 */
+		input?: string;
 
-        /**
-         * Rendered when 0 suggestions are available for the given query.
-         * Can be either a HTML string or a precompiled template.
-         * If it's a precompiled template, the passed in context will contain query
-          */
-        empty?: any;
+		/**
+		 * Added to hint input. Defaults to tt-hint.
+		 */
+		hint?: string;
 
-        /**
-         * Rendered at the bottom of the dataset.
-         * Can be either a HTML string or a precompiled template.
-         * If it's a precompiled template, the passed in context will contain query and isEmpty.
-          */
-        footer?: any;
+		/**
+		 * Added to menu element. Defaults to tt-menu.
+		 */
+		menu?: string;
 
-        /**
-         * Rendered at the top of the dataset.
-         * Can be either a HTML string or a precompiled template.
-         * If it's a precompiled template, the passed in context will contain query and isEmpty.
-          */
-        header?: any;
+		/**
+		 * Added to dataset elements. to Defaults to tt-dataset.
+		 */
+		dataset?: string;
 
-        /**
-         * Used to render a single suggestion.
-         * If set, this has to be a precompiled template.
-         * The associated suggestion object will serve as the context.
-         * Defaults to the value of displayKey wrapped in a p tag i.e. <p>{{value}}</p>.
-          */
-        suggestion?: (datum: any) => string;
+		/**
+		 * Added to suggestion elements. Defaults to tt-suggestion.
+		 */
+		suggestion?: string;
 
-    }
+		/**
+		 * Added to menu element when it contains no content. Defaults to tt-empty.
+		 */
+		empty?: string;
 
+		/**
+		 *  Added to menu element when it is opened. Defaults to tt-open.
+		 */
+		open?: string;
 
-     /**
-      * When initializing a typeahead, there are a number of options you can configure.
-      */
-    interface Options {
-      /**
-        * highlight:  If true, when suggestions are rendered,
-        * pattern matches for the current query in text nodes will be wrapped in a strong element.
-        * Defaults to false.
-        */
-      highlight?: boolean;
+		/**
+		 * Added to suggestion element when menu cursor moves to said suggestion. Defaults to tt-cursor.
+		 */
+		cursor?: string;
 
-      /**
-        * If false, the typeahead will not show a hint. Defaults to true.
-        */
-      hint?: boolean;
+		/**
+		 * Added to the element that wraps highlighted text. Defaults to tt-highlight.
+		 */
+		highlight?: string;		
+	}
 
-      /**
-        * The minimum character length needed before suggestions start getting rendered. Defaults to 1.
-        */
-      minLength?: number;
-    }
+	
+	/**
+	 * When initializing a typeahead, there are a number of options you can configure.
+	 */
+	interface Options {
+		/**
+		 * If true, when suggestions are rendered, pattern matches for the current query in text nodes 
+		 * will be wrapped in a strong element with its class set to {{classNames.highlight}}. Defaults to false.
+		 */
+		highlight?: boolean;
+
+		/**
+		 * If false, the typeahead will not show a hint. Defaults to true.
+		 */
+		hint?: boolean;
+
+		/**
+		 * The minimum character length needed before suggestions start getting rendered. Defaults to 1.
+		 */
+		minLength?: number;
+		
+		/**
+		 * For overriding the default class names used. See Class Names for more details.
+		 */
+		classNames?: ClassNames;
+	}
 }
 
-declare module Bloodhound
-{
-  interface BloodhoundOptions<T>
-  {
-    /**
-    * Transforms a datum into an array of string tokens
-    *
-    * @constructor
-    * @param datum individual units that compose the dataset
-    */
-    datumTokenizer?: any;
-    /**
-    * Transforms a query into an array of string tokens
-    *
-    * @constructor
-    * @param query tokenizer query
-    */
-    queryTokenizer?: any;
-    /**
-    *  The max number of suggestions to return from Bloodhound#get.
-    * If not reached, the data source will attempt to backfill the suggestions from remote. Defaults to 5
-    */
-    limit?: number;
-    /**
-    *  If set, this is expected to be a function with the signature (remoteMatch, localMatch) that returns true if the datums are duplicates or false otherwise.
-    *  If not set, duplicate detection will not be performed.
-    */
-    dupDetector?: (remoteMatch: T, localMatch: T) => boolean;
-    /**
-    * A compare function used to sort matched datums for a given query.
-    */
-    sorter?: (a: T, b: T) => number;
-    /**
-    *An array of datums or a function that returns an array of datums.
-    */
-    local?: () => T[];
-    /**
-    * Can be a URL to a JSON file containing an array of datums or, if more configurability is needed, a prefetch options hash.
-    */
-    prefetch?: PrefetchOptions<T>;
-    /**
-    *  Can be a URL to fetch suggestions from when the data provided by local and prefetch is insufficient or, if more configurability is needed, a remote options hash.
-    */
-    remote?: RemoteOptions<T>;
-  }
 
-  /**
-  * Prefetched data is fetched and processed on initialization.
-  * If the browser supports localStorage, the processed data will be cached
-  * there to prevent additional network requests on subsequent page loads.
-  */
-  interface PrefetchOptions<T>
-  {
-    /**
-    * A URL to a JSON file containing an array of datums. Required.
-    */
-    url: string;
-    /**
-    * The time (in milliseconds) the prefetched data should be cached
-    * in localStorage. Defaults to 86400000 (1 day).
-    */
-    ttl?: number;
-    /**
-    * A function that transforms the response body into an array of datums.
-    *
-    * @param parsedResponse Response body
-    */
-    filter?: (parsedResponse: any) => T[];
-    /** The key that data will be stored in local storage under. Defaults to value of url.
-    *
-    */
-    cacheKey?: string;
-    /**
-    * A string used for thumbprinting prefetched data. If this doesn't match what's stored in local storage, the data will be refetched.
-    */
-    thumbprint?: string;
-    /**
-    * The ajax settings object passed to jQuery.ajax.
-    */
-    ajax?: JQueryAjaxSettings;
-  }
+declare module Bloodhound {
+	/**
+	 * When instantiating a Bloodhound suggestion engine, there are a number of options you can configure.
+	 */
+	interface BloodhoundOptions<TDatum>	{
+		/**
+		 * A function with the signature (datum) that transforms a datum into an array of string tokens. Required.
+		 */
+		datumTokenizer: (datum: TDatum) => string[];
+	  
+		/**
+		 * A function with the signature (query) that transforms a query into an array of string tokens. Required.
+		 */
+		queryTokenizer: (query: string) => string[];
 
-  /**
-  * Remote data is only used when the data provided by local and prefetch
-  * is insufficient. In order to prevent an obscene number of requests
-  * being made to remote endpoint, typeahead.js rate-limits remote requests.
-  */
-  interface RemoteOptions<T>
-  {
-    /**
-    * A URL to make requests to when the data provided by local and
-    * prefetch is insufficient. Required.
-    */
-    url: string;
-    /**
-    * The pattern in url that will be replaced with the user's query
-    * when a request is made. Defaults to %QUERY.
-    */
-    wildcard?: string;
-    /**
-    * Overrides the request URL. If set, no wildcard substitution will
-    * be performed on url.
-    *
-    * @param url Replacement URL
-    * @param uriEncodedQuery Encoded query
-    * @returns A valid URL
-    */
-    replace?: (url: string, uriEncodedQuery: string) => string;
-    /**
-    * The function used for rate-limiting network requests.
-    * Can be either 'debounce' or 'throttle'. Defaults to 'debounce'.
-    */
-    rateLimitby?: string;
-    /**
-    * The time interval in milliseconds that will be used by rateLimitFn.
-    * Defaults to 300.
-    */
-    rateLimitWait?: number;
+		/**
+		 * If set to false, the Bloodhound instance will not be implicitly initialized by the constructor function. Defaults to true.
+		 */
+		initialize?: boolean;
 
-    /**
-    * Transforms the response body into an array of datums.
-    *
-    * @param parsedResponse Response body
-    */
-    filter?: (parsedResponse: any) => T[];
-    /**
-    * The ajax settings object passed to jQuery.ajax.
-    */
-    ajax?: JQueryAjaxSettings;
-  }
+		/**
+		 * Given a datum, this function is expected to return a unique id for it. Defaults to JSON.stringify. Note that it is highly 
+		 * recommended to override this option.
+		 */
+		identify?: (datum: TDatum) => any;
 
-  /**
-  * The most common tokenization methods.
-  */
-  interface Tokenizers
-  {
-    /**
-    * Split a given string on whitespace characters.
-    */
-    whitespace(query: string): string[];
-    /**
-    * Split a given string on non-word characters.
-    */
-    nonword(query: string): string[];
+		/**
+		 * If the number of datums provided from the internal search index is less than sufficient, remote will be used to 
+		 * backfill search requests triggered by calling #search. Defaults to 5.
+		 */
+		sufficient?: number;
 
-   /**
-   * Instances of the most common tokenization methods.
-   */
-    obj: ObjTokenizer;
-  }
+		/**
+		 * A compare function used to sort data returned from the internal search index.
+		 */
+		sorter?: (a: TDatum, b: TDatum) => number;
+		
+		/**
+		 * An array of data or a function that returns an array of data. The data will be added to the internal search index when 
+		 * #initialize is called.
+		 */
+		local?: TDatum[] | (() => TDatum[]);
 
-  interface ObjTokenizer
-  {
-    /**
-    * Split a given string on whitespace characters.
-    */
-    whitespace(query: string): string[];
-    /**
-    * Split a given string on non-word characters.
-    */
-    nonword(query: string): string[];
-  }
+		/**
+		 * Can be a URL to a JSON file containing an array of datums or, if more configurability is needed, a prefetch options hash.
+		 */
+		prefetch?: string | PrefetchOptions<TDatum>;
+		
+		/**
+		 * Can be a URL to fetch suggestions from when the data provided by local and prefetch is insufficient or, if 
+		 * more configurability is needed, a remote options hash.
+		 */
+		remote?: string | RemoteOptions<TDatum>;
+	}
+
+	
+	/**
+	 * Prefetched data is fetched and processed on initialization. If the browser supports local storage, the processed data will 
+	 * be cached there to prevent additional network requests on subsequent page loads.
+	 */
+	interface PrefetchOptions<TDatum> {
+		/**
+		 * The URL prefetch data should be loaded from. Required.
+		 */
+		url: string;
+
+		/**
+		 * If false, will not attempt to read or write to local storage and will always load prefetch data 
+		 * from url on initialization. Defaults to true.
+		 */
+		cache?: boolean;
+		
+		/**
+		 * The time (in milliseconds) the prefetched data should be cached in local storage. Defaults to 86400000 (1 day).
+		 */
+		ttl?: number;
+
+		/**
+		 * The key that data will be stored in local storage under. Defaults to value of url.
+		 */
+		cacheKey?: string;
+
+		/**
+		 * A string used for thumbprinting prefetched data. If this doesn't match what's stored in local storage, the data will be refetched.
+		 */
+		thumbprint?: string;
+
+		/**
+		 * A function that provides a hook to allow you to prepare the settings object passed to transport 
+		 * when a request is about to be made. The function signature should be prepare(settings) where 
+		 * settings is the default settings object created internally by the Bloodhound instance. The 
+		 * prepare function should return a settings object. Defaults to the identity function.
+		 */
+		prepare?: ((settings: BloodhoundOptions<TDatum>) => BloodhoundOptions<TDatum>);
+
+		/**
+		 * A function with the signature transform(response) that allows you to transform the prefetch response 
+		 * before the Bloodhound instance operates on it. Defaults to the identity function.
+		 */
+		transform?: (response: any) => void;
+	}
+
+	
+	/**
+	 * Bloodhound only goes to the network when the internal search engine cannot provide a sufficient number of results.
+	 * In order to prevent an obscene number of requests being made to the remote endpoint, requests are rate-limited.
+	 */
+	interface RemoteOptions<TDatum>	{
+		/**
+		 * The URL remote data should be loaded from. Required.
+		 */
+		url: string;
+
+		/**
+		 * A function that provides a hook to allow you to prepare the settings object passed to transport 
+		 * when a request is about to be made. The function signature should be prepare(settings) where 
+		 * settings is the default settings object created internally by the Bloodhound instance. The 
+		 * prepare function should return a settings object. Defaults to the identity function.
+		 */
+		prepare?: ((query: string, settings: BloodhoundOptions<TDatum>) => BloodhoundOptions<TDatum>);
+		
+		/**
+		 * A convenience option for prepare. If set, prepare will be a function that replaces the value of 
+		 * this option in url with the URI encoded query.
+		 */
+		wildcard?: string;
+				
+		/**
+		 * The function used for rate-limiting network requests.
+		 * Can be either 'debounce' or 'throttle'. Defaults to 'debounce'.
+		 */
+		rateLimitBy?: string;
+
+		/**
+		 * The time interval in milliseconds that will be used by rateLimitBy. Defaults to 300.
+		 */
+		rateLimitWait?: number;
+
+		/**
+		 * A function with the signature transform(response) that allows you to transform the prefetch response 
+		 * before the Bloodhound instance operates on it. Defaults to the identity function.
+		 */
+		transform?: (response: any) => void;
+	}
+
+	
+	/**
+	 * The most common tokenization methods.
+	 */
+	interface Tokenizers {
+		/**
+		 * Split a given string on whitespace characters.
+		 */
+		whitespace(query: string): string[];
+		
+		/**
+		 * Split a given string on non-word characters.
+		 */
+		nonword(query: string): string[];
+
+		/**
+		 * Instances of the most common tokenization methods.
+		 */
+		obj: ObjTokenizer;
+	}
+	
+
+	interface ObjTokenizer {
+		/**
+		 * Split a given string on whitespace characters.
+		 */
+		whitespace(query: string): string[];
+		
+		/**
+		 * Split a given string on non-word characters.
+		 */
+		nonword(query: string): string[];
+	}
 }
 
-declare class Bloodhound<T> {
-  constructor(options: Bloodhound.BloodhoundOptions<T>)
-  /**
-  * wraps the suggestion engine in an adapter that is compatible with the typeahead jQuery plugin
-  */
-  public ttAdapter(): any;
-  /**
-  * Kicks off the initialization of the suggestion engine. This includes processing the data provided through local and fetching/processing the data provided through prefetch.
-  * Until initialized, all other methods will behave as no-ops.
-  * Returns a jQuery promise which is resolved when engine has been initialized.
-  *
-  * After the initial call of initialize, how subsequent invocations of the method behave depends on the reinitialize argument.
-  * If reinitialize is falsy, the method will not execute the initialization logic and will just return the same jQuery promise returned by the initial invocation.
-  * If reinitialize is truthy, the method will behave as if it were being called for the first time.
-  *
-  * var promise1 = engine.initialize();
-  * var promise2 = engine.initialize();
-  * var promise3 = engine.initialize(true);
-  *
-  * promise1 === promise2;
-  * promise3 !== promise1 && promise3 !== promise2;
-  */
-  public initialize(reinitialize?: boolean): JQueryPromise<any>;
-  /**
-  * Takes one argument, datums, which is expected to be an array of datums.
-  * The passed in datums will get added to the search index that powers the suggestion engine.
-  */
-  public add(datums: T[]): void;
-  /**
-  * Removes all suggestions from the search index.
-  */
-  public clear(): void;
-  /**
-  * If you're using prefetch, data gets cached in local storage in an effort to cut down on unnecessary network requests.
-  * clearPrefetchCache offers a way to programmatically clear said cache.
-  */
-  public clearPrefetchCache(): void;
-  /**
-  * If you're using remote, Bloodhound will cache the 10 most recent responses in an effort to provide a better user experience.
-  * clearRemoteCache offers a way to programmatically clear said cache.
-  */
-  public clearRemoteCache(): void;
-  /**
-  * Returns a reference to the Bloodhound constructor and reverts window.Bloodhound to its previous value. Can be used to avoid naming collisions.
-  */
-  public noConflict(): any;
 
-  /**
-  * Computes a set of suggestions for query. cb will be invoked with an array of datums that represent said set.
-  * cb will always be invoked once synchronously with suggestions that were available on the client.
-  * If those suggestions are insufficient (# of suggestions is less than limit) and remote was configured, cb may also be invoked asynchronously with the suggestions available on the client mixed with suggestions from the remote source.
-  */
-  public get(query: string, cb: (datums: T[]) => void): void;
+declare class Bloodhound<TDatum> {
+	constructor(options: Bloodhound.BloodhoundOptions<TDatum>)
+	
 
-  /**
-  * The Bloodhound suggestion engine is token-based, so how datums and queries are tokenized plays a vital role in the quality of search results.
-  * Specify how you want datums and queries tokenized.
-  */
-  public static tokenizers: Bloodhound.Tokenizers;
+	/**
+	 * Kicks off the initialization of the suggestion engine. Initialization entails adding the data provided 
+	 * by local and prefetch to the internal search index as well as setting up transport mechanism used by
+	 * remote. Before #initialize is called, the #get and #search methods will effectively be no-ops.
+	 * 
+	 * Note, unless the initialize option is false, this method is implicitly called by the constructor.
+	 * 
+	 * After initialization, how subsequent invocations of #initialize behave depends on the reinitialize 
+	 * argument. If reinitialize is falsy, the method will not execute the initialization logic and will 
+	 * just return the same jQuery promise returned by the initial invocation. If reinitialize is truthy, 
+	 * the method will behave as if it were being called for the first time.
+	 */
+	public initialize(reinitialize?: boolean): JQueryPromise<any>;
+	
+	/**
+	 * Takes one argument, data, which is expected to be an array. The data passed in will get added to the 
+	 * internal search index.
+	 */
+	public add(data: TDatum[]): Bloodhound<TDatum>;
+	
+	/**
+	 * Clears the internal search index that's powered by local, prefetch, and #add.
+	 */
+	public clear(): Bloodhound<TDatum>;
+	
+	/**
+	 * Returns a reference to the Bloodhound constructor and reverts window.Bloodhound to its previous value. Can be used to avoid naming collisions.
+	 */
+	public noConflict(): any;
+
+	/**
+	 * Returns the data in the local search index corresponding to ids.
+	 */
+	public get(ids: any[]): TDatum[];
+
+	/**
+	 * Unofficial
+	 */
+	public get(... ids: any[]): TDatum[];
+
+	/**
+	 * Returns the data that matches query. Matches found in the local search index will be passed to the sync callback. 
+	 * If the data passed to sync doesn't contain at least sufficient number of datums, remote data will be requested 
+	 * and then passed to the async callback.
+	 */
+	public search(query: string, sync: (result: TDatum[]) => void, async?: (result: TDatum[]) => void): Bloodhound<TDatum>;
+	
+	/**
+	 * The Bloodhound suggestion engine is token-based, so how datums and queries are tokenized plays a vital role in the quality 
+	 * of search results. Specify how you want datums and queries tokenized.
+	 */
+	public static tokenizers: Bloodhound.Tokenizers;
+
+	/**
+	 * Unofficial
+	 */
+	public clearPrefetchCache(): Bloodhound<TDatum>;
+
+	/**
+	 * Unofficial
+	 */
+	public clearRemoteCache(): void;
+
+	/**
+	 * Unofficial
+	 */
+	public ttAdapter(): any;
 }


### PR DESCRIPTION
Major changes:
- Updated bindings/tests/docs to deal with typeahead rewrite between v0.10.4 and v0.11.1
- Previously, only Bloodhound types were generic. Now other typeahead types are too. It means we can replace <any> with <TDatum> in many places.
- Fixed Bloodhound methods so that they return Bloodhound<TDatum> rather than void.
- Added typeahead examples as tests
- Added Bloodhound tests
- Marked unofficial functions as such
- Fixed inconsistencies with commenting, braces, casing and whitespace across all files

Sorry about the nasty diff.
