### PR TITLE
angular mocks - global inject is an alias

### DIFF
--- a/angularjs/angular-mocks.d.ts
+++ b/angularjs/angular-mocks.d.ts
@@ -16,12 +16,6 @@ declare module "angular-mocks/ngAnimateMock" {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// functions attached to global object (window)
-///////////////////////////////////////////////////////////////////////////////
-declare var module: (...modules: any[]) => any;
-declare var inject: (...fns: Function[]) => any;
-
-///////////////////////////////////////////////////////////////////////////////
 // ngMock module (angular-mocks.js)
 ///////////////////////////////////////////////////////////////////////////////
 declare module angular {
@@ -33,30 +27,32 @@ declare module angular {
     interface IAngularStatic {
         mock: IMockStatic;
     }
+    
+    // see https://docs.angularjs.org/api/ngMock/function/angular.mock.inject
+    interface IInjectStatic {
+        (...fns: Function[]): any;
+        (...inlineAnnotatedConstructor: any[]): any; // this overload is undocumented, but works
+        strictDi(val?: boolean): void;
+    }
 
     interface IMockStatic {
-        // see http://docs.angularjs.org/api/angular.mock.dump
+        // see https://docs.angularjs.org/api/ngMock/function/angular.mock.dump
         dump(obj: any): string;
 
-        // see http://docs.angularjs.org/api/angular.mock.inject
-        inject: {
-            (...fns: Function[]): any;
-            (...inlineAnnotatedConstructor: any[]): any; // this overload is undocumented, but works
-            strictDi(val?: boolean): void;
-        }
+        inject: IInjectStatic
 
-        // see http://docs.angularjs.org/api/angular.mock.module
+        // see https://docs.angularjs.org/api/ngMock/function/angular.mock.module
         module(...modules: any[]): any;
 
-        // see http://docs.angularjs.org/api/angular.mock.TzDate
+        // see https://docs.angularjs.org/api/ngMock/type/angular.mock.TzDate
         TzDate(offset: number, timestamp: number): Date;
         TzDate(offset: number, timestamp: string): Date;
     }
 
     ///////////////////////////////////////////////////////////////////////////
     // ExceptionHandlerService
-    // see http://docs.angularjs.org/api/ngMock.$exceptionHandler
-    // see http://docs.angularjs.org/api/ngMock.$exceptionHandlerProvider
+    // see https://docs.angularjs.org/api/ngMock/service/$exceptionHandler
+    // see https://docs.angularjs.org/api/ngMock/provider/$exceptionHandlerProvider
     ///////////////////////////////////////////////////////////////////////////
     interface IExceptionHandlerProvider extends IServiceProvider {
         mode(mode: string): void;
@@ -64,7 +60,7 @@ declare module angular {
 
     ///////////////////////////////////////////////////////////////////////////
     // TimeoutService
-    // see http://docs.angularjs.org/api/ngMock.$timeout
+    // see https://docs.angularjs.org/api/ngMock/service/$timeout
     // Augments the original service
     ///////////////////////////////////////////////////////////////////////////
     interface ITimeoutService {
@@ -75,7 +71,7 @@ declare module angular {
 
     ///////////////////////////////////////////////////////////////////////////
     // IntervalService
-    // see http://docs.angularjs.org/api/ngMock.$interval
+    // see https://docs.angularjs.org/api/ngMock/service/$interval
     // Augments the original service
     ///////////////////////////////////////////////////////////////////////////
     interface IIntervalService {
@@ -84,7 +80,7 @@ declare module angular {
 
     ///////////////////////////////////////////////////////////////////////////
     // LogService
-    // see http://docs.angularjs.org/api/ngMock.$log
+    // see https://docs.angularjs.org/api/ngMock/service/$log
     // Augments the original service
     ///////////////////////////////////////////////////////////////////////////
     interface ILogService {
@@ -98,7 +94,7 @@ declare module angular {
 
     ///////////////////////////////////////////////////////////////////////////
     // HttpBackendService
-    // see http://docs.angularjs.org/api/ngMock.$httpBackend
+    // see https://docs.angularjs.org/api/ngMock/service/$httpBackend
     ///////////////////////////////////////////////////////////////////////////
     interface IHttpBackendService {
         flush(count?: number): void;
@@ -237,3 +233,9 @@ declare module angular {
     }
 
 }
+
+///////////////////////////////////////////////////////////////////////////////
+// functions attached to global object (window)
+///////////////////////////////////////////////////////////////////////////////
+declare var module: (...modules: any[]) => any;
+declare var inject: angular.IInjectStatic;


### PR DESCRIPTION
Adjust the global inject to be an actual alias to the inject definition.
This allows you to use the strict di version globally.
Also updated links to new format.
