### PR TITLE
Fix the very broken lodash flatten() type definitions

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -247,9 +247,10 @@ result = <Array<number>>_.flatten([1, [2], [[3]]], true);
 result = <Array<number>>_.flatten<number>([1, [2], [3, [[4]]]], true);
 result = <Array<number|boolean>>_.flatten<number|boolean>([1, [2], [3, [[false]]]], true);
 
-result = <_.LoDashArrayWrapper<number>>_([1, [2], [3, [[4]]]]).flatten();
+result = <_.LoDashArrayWrapper<number>>_([[1, 2], [3, 4], 5, 6]).flatten();
+result = <_.LoDashArrayWrapper<number|Array<Array<number>>>>_([1, [2], [3, [[4]]]]).flatten();
+
 result = <_.LoDashArrayWrapper<number>>_([1, [2], [3, [[4]]]]).flatten(true);
-result = <_.LoDashArrayWrapper<string>>_(stoogesQuotes).flatten('quotes');
 
 result = <number>_.indexOf([1, 2, 3, 1, 2, 3], 2);
 result = <number>_.indexOf([1, 2, 3, 1, 2, 3], 2, 3);

--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -239,10 +239,13 @@ result = <number[]>_([1, 2, 3]).take(function (num) {
 result = <IFoodOrganic[]>_(foodsOrganic).take('organic').value();
 result = <IFoodType[]>_(foodsType).take({ 'type': 'fruit' }).value();
 
-result = <number[]>_.flatten([1, [2], [3, [[4]]]]);
-result = <any[]>_.flatten([1, [2], [3, [[4]]]], true);
-var result: any
-result = <string[]>_.flatten(stoogesQuotes, 'quotes');
+result = <Array<number>>_.flatten([[1, 2], [3, 4]]);
+result = <Array<number>>_.flatten([[1, 2], [3, 4], 5, 6]);
+result = <Array<number|Array<Array<number>>>>_.flatten([1, [2], [3, [[4]]]]);
+
+result = <Array<number>>_.flatten([1, [2], [[3]]], true);
+result = <Array<number>>_.flatten<number>([1, [2], [3, [[4]]]], true);
+result = <Array<number|boolean>>_.flatten<number|boolean>([1, [2], [3, [[false]]]], true);
 
 result = <_.LoDashArrayWrapper<number>>_([1, [2], [3, [[4]]]]).flatten();
 result = <_.LoDashArrayWrapper<number>>_([1, [2], [3, [[4]]]]).flatten(true);

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -769,123 +769,28 @@ declare module _ {
         take<W>(whereValue: W): LoDashArrayWrapper<T>;
     }
 
+    interface MaybeNestedList<T> extends List<T|List<T>> { }
+    interface RecursiveList<T> extends List<T|RecursiveList<T>> { }
+
     //_.flatten
     interface LoDashStatic {
         /**
-        * Flattens a nested array (the nesting can be to any depth). If isShallow is truey, the
-        * array will only be flattened a single level. If a callback is provided each element of
-        * the array is passed through the callback before flattening. The callback is bound to
-        * thisArg and invoked with three arguments; (value, index, array).
-        *
-        * If a property name is provided for callback the created "_.pluck" style callback will
-        * return the property value of the given element.
-        *
-        * If an object is provided for callback the created "_.where" style callback will return
-        * true for elements that have the properties of the given object, else false.
-        * @param array The array to flatten.
-        * @param shallow If true then only flatten one level, optional, default = false.
-        * @return `array` flattened.
-        **/
-        flatten<T>(array: Array<any>, isShallow?: boolean): T[];
+         * Flattens a nested array.
+         *
+         * @param array The array to flatten.
+         * @return `array` flattened.
+         **/
+        flatten<T>(array: MaybeNestedList<T>): T[];
 
         /**
-        * @see _.flatten
-        **/
-        flatten<T>(array: List<any>, isShallow?: boolean): T[];
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<T>(
-            array: Array<any>,
-            isShallow: boolean,
-            callback: ListIterator<any, T>,
-            thisArg?: any): T[];
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<T>(
-            array: List<any>,
-            isShallow: boolean,
-            callback: ListIterator<any, T>,
-            thisArg?: any): T[];
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<T>(
-            array: Array<any>,
-            callback: ListIterator<any, T>,
-            thisArg?: any): T[];
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<T>(
-            array: List<any>,
-            callback: ListIterator<any, T>,
-            thisArg?: any): T[];
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<W, T>(
-            array: Array<any>,
-            isShallow: boolean,
-            whereValue: W): T[];
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<W, T>(
-            array: List<any>,
-            isShallow: boolean,
-            whereValue: W): T[];
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<W, T>(
-            array: Array<any>,
-            whereValue: W): T[];
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<W, T>(
-            array: List<any>,
-            whereValue: W): T[];
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<T>(
-            array: Array<any>,
-            isShallow: boolean,
-            pluckValue: string): T[];
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<T>(
-            array: List<any>,
-            isShallow: boolean,
-            pluckValue: string): T[];
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<T>(
-            array: Array<any>,
-            pluckValue: string): T[];
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<T>(
-            array: List<any>,
-            pluckValue: string): T[];
+         * Flattens a nested array. If isDeep is true the array is recursively flattened, otherwise it is only
+         * flattened a single level.
+         *
+         * @param array The array to flatten.
+         * @param deep Specify a deep flatten.
+         * @return `array` flattened.
+         **/
+        flatten<T>(array: RecursiveList<T>, isDeep: boolean): T[];
     }
 
     interface LoDashArrayWrapper<T> {

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -795,50 +795,14 @@ declare module _ {
 
     interface LoDashArrayWrapper<T> {
         /**
-        * @see _.flatten
-        **/
-        flatten<Flat>(isShallow?: boolean): LoDashArrayWrapper<Flat>;
+         * @see _.flatten
+         **/
+        flatten<T>(): LoDashArrayWrapper<any>;
 
         /**
         * @see _.flatten
         **/
-        flatten<Flat>(
-            isShallow: boolean,
-            callback: ListIterator<T, Flat>,
-            thisArg?: any): LoDashArrayWrapper<Flat>;
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<Flat>(
-            callback: ListIterator<T, Flat>,
-            thisArg?: any): LoDashArrayWrapper<Flat>;
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<Flat>(
-            isShallow: boolean,
-            pluckValue: string): LoDashArrayWrapper<Flat>;
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<Flat>(
-            pluckValue: string): LoDashArrayWrapper<Flat>;
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<Flat, W>(
-            isShallow: boolean,
-            whereValue: W): LoDashArrayWrapper<Flat>;
-
-        /**
-        * @see _.flatten
-        **/
-        flatten<Flat, W>(
-            whereValue: W): LoDashArrayWrapper<Flat>;
+        flatten<T>(isShallow: boolean): LoDashArrayWrapper<any>;
     }
 
     //_.indexOf

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -790,7 +790,7 @@ declare module _ {
          * @param deep Specify a deep flatten.
          * @return `array` flattened.
          **/
-        flatten<T>(array: RecursiveList<T>, isDeep: boolean): T[];
+        flatten<T>(array: RecursiveList<T>, isDeep: boolean): List<T> | RecursiveList<T>;
     }
 
     interface LoDashArrayWrapper<T> {


### PR DESCRIPTION
The current lodash flatten type definitions:
- Include method overloads that don't actually exist (in lodash or underscore or anywhere else I can find. My best guess is these were copied from _.map() and _.filter() accidentally somehow). You cannot pass a string to flatten() to pluck fields, or a callback to filter things, but we do currently have definitions for those overloads anyway
- Have tests that specific the wrong expected types (along with a broken implementation to match):
  
  The test for `_.flatten([1, [2], [3, [[4]]]])` expects a return type number[] (and gets it), but the actual return value of that expression is `[1, 2, 3, [[4]]]`, which is not a number[].
- Have overly specific types that exclude the real resulting type in most cases:
  
  `_([1, 2, 3]).flatten()` returns a lodash-wrapped `[1, 2, 3]`, and has type `LodashArrayWrapper<number>` which is correct (i.e. it works correctly, if you call flatten on an already-flattened array).
  `_([[1, 2, 3]]).flatten()` returns a lodash-wrapped `[1, 2, 3]` with type `LodashArrayWrapper<Array<number>>` (incorrect, for the normal case).

This patch fixes those, conveniently fixing #2835 en route, although there are a couple of parts worthy of a little debate I think (see below). The changes are:
- Type definitions for non-existent `_.flatten()` and `_().flatten()` methods overloads have been removed.
- `_(array).flatten()` and `_(array).flatten(bool)` now both return `any`, rather than the overly specific (and usually wrong) type there before. Being any more specific than this is possible I think, but requires some heavy duty work around the generics for LoDashArrayWrapper everywhere to get to something like `LoDashArrayWrapper<X, T extends RecursiveList<X>> { flatten(array: T): LoDashArrayWrapper<???, X> }`. Not sure that's practical, so I've at least made it work for now.
- _.flatten(array) now has the correct type and matching tests that actually track the real behaviour
- _.flatten(array, bool) is now more accurate, but not always (although that's still an improvement on the current state). I'm not sure if this can be better, or whether it's worthwhile investigating that further.
  
  The issue is that the type of the result depends on the value of the boolean 2nd argument:
  
  `_.flatten([[[1]]], true)` recursively flattens, and returns `[1]`. This has type `(number[][][]) => number[]`, or generally `(RecursiveList<T>) => T`. This is the type that I've given the method.
  
  `_.flatten([[[1]]], false)` meanwhile is equivalent to `_.flatten([[[1]]])`, and recurses only one level, returning `[[1]]`, so here has a type of `(number[][][]) => number[][]`. This doesn't match the type definition. On the other hand, this is definitely the unusual case for this method (since the 'false' is unnecessary), and falling back to the version without the extra argument will give you the correct type.
  
  How concerned is DefinitelyTyped generally about things like this? Any thoughts on how this bit could be improved? Perfect world would be to use the correct return type depending on the runtime boolean value of the flag whenever that's known (likely 99+% of the time), but I think that's impossible. Option C is to just make it any-typed, but I'd rather not if at all possible.
