### PR TITLE
node: Added 'stack' to NodeJS.ErrnoException

### DIFF
--- a/node/node-0.10.d.ts
+++ b/node/node-0.10.d.ts
@@ -83,6 +83,7 @@ declare module NodeJS {
         code?: string;
         path?: string;
         syscall?: string;
+        stack?: string;
     }
 
     export interface EventEmitter {

--- a/node/node-0.11.d.ts
+++ b/node/node-0.11.d.ts
@@ -83,6 +83,7 @@ declare module NodeJS {
         code?: string;
         path?: string;
         syscall?: string;
+        stack?: string;
     }
 
     export interface EventEmitter {

--- a/node/node-0.8.8.d.ts
+++ b/node/node-0.8.8.d.ts
@@ -73,6 +73,7 @@ interface ErrnoException extends Error {
     code?: string;
     path?: string;
     syscall?: string;
+    stack?: string;
 }
 
 interface EventEmitter {

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -144,6 +144,7 @@ declare module NodeJS {
         code?: string;
         path?: string;
         syscall?: string;
+        stack?: string;
     }
 
     export interface EventEmitter {


### PR DESCRIPTION
Node's `Error` object (denoted by `NodeJS.ErrnoException`) has a member `stack` which was missing from all node versions in DefinitelyTyped.

I noticed this when doing the dreaded log and rethrow:

```
process.on("uncaughtException", function(error : NodeJS.ErrnoException) {
    console.log(error.stack);    // Would show error TS2339: Property 'stack' does not exist on type 'ErrnoException'.
    throw error;
});
```

This seems to be a V8 thing.
