### PR TITLE
angular's $anchorScroll can be called with an optional hash parameter

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1064,6 +1064,7 @@ declare module angular {
     ///////////////////////////////////////////////////////////////////////////
     interface IAnchorScrollService {
         (): void;
+        (hash: string): void;
         yOffset: any;
     }
 


### PR DESCRIPTION
angular's $anchorScroll can be called with an optional hash parameter.  See https://code.angularjs.org/1.4.1/docs/api/ng/service/$anchorScroll for supporting documentation
