### PR TITLE
Fixed broken Component.setState definition

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -133,7 +133,7 @@ declare module React {
     class Component<P, S> implements ComponentLifecycle<P, S> {
         constructor(props?: P, context?: any);
         setState(f: (prevState: S, props: P) => S, callback?: () => any): void;
-        setState(state: S, callback?: () => any): void;
+        setState(state: any, callback?: () => any): void;
         forceUpdate(): void;
         props: P;
         state: S;


### PR DESCRIPTION
React's documentation specifies that Component.setState is supposed to accept state deltas, but this .d.ts file requires it to pass a full state object.
