### PR TITLE
MediaStream extends EventTarget, PeerJs.Peer.off

### DIFF
--- a/peerjs/peerjs-tests.ts
+++ b/peerjs/peerjs-tests.ts
@@ -42,11 +42,13 @@ var connection = peerById.connect("id", {
 
 var call = peerById.call('callto-id', (<any>window).localStream);
 
-peerById.on("open", ()=> console.log("open"));
+var openHandler=()=> console.log("open");
+peerById.on("open", openHandler);
 peerById.on("connection", (c)=> console.log("connection"));
 peerById.on("call", (media)=> console.log("call"));
 peerById.on("close", ()=> console.log("close"));
 peerById.on("disconnected", ()=> console.log("disconnected"));
 peerById.on("error", (err)=> console.log(err));
+peerById.off("open", openHandler);
 
 var connection2 = peerById.getConnection(peerByOption, "callto-id");

--- a/peerjs/peerjs.d.ts
+++ b/peerjs/peerjs.d.ts
@@ -5,7 +5,6 @@
 
 
 /// <reference path='../webrtc/RTCPeerConnection.d.ts' />
-/// <reference path="../EventEmitter3/EventEmitter3.d.ts" />
 
 declare module PeerJs{
     interface PeerJSOption{

--- a/peerjs/peerjs.d.ts
+++ b/peerjs/peerjs.d.ts
@@ -5,6 +5,7 @@
 
 
 /// <reference path='../webrtc/RTCPeerConnection.d.ts' />
+/// <reference path="../EventEmitter3/EventEmitter3.d.ts" />
 
 declare module PeerJs{
     interface PeerJSOption{
@@ -25,7 +26,7 @@ declare module PeerJs{
 
     }
 
-    interface DataConnection{
+    interface DataConnection {
         send(data: any): void;
         close(): void;
         on(event: string, cb: ()=>void): void;
@@ -33,6 +34,7 @@ declare module PeerJs{
         on(event: 'open', cb: ()=>void): void;
         on(event: 'close', cb: ()=>void): void;
         on(event: 'error', cb: (err: any)=>void): void;
+        off(event: string, fn: Function, once?: boolean): void;
         dataChannel: RTCDataChannel;
         label: string;
         metadata: any;
@@ -45,13 +47,14 @@ declare module PeerJs{
         buffSize: number;
     }
 
-    interface MediaConnection{
+    interface MediaConnection {
         answer(stream?: any): void;
         close(): void;
         on(event: string, cb: ()=>void): void;
         on(event: 'stream', cb: (stream: any)=>void): void;
         on(event: 'close', cb: ()=>void): void;
         on(event: 'error', cb: (err: any)=>void): void;
+        off(event: string, fn: Function, once?: boolean): void;
         open: boolean;
         metadata: any;
         peer: string;
@@ -70,7 +73,7 @@ declare module PeerJs{
         supports: utilSupportsObj;
     }
 
-    export interface Peer{
+    export interface Peer {
         /**
          *
          * @param id The brokering ID of the remote peer (their peer.id).
@@ -126,6 +129,13 @@ declare module PeerJs{
          * @param cb Callback Function
          */
         on(event: 'error', cb: (err: any)=>void): void;
+        /**
+         * Remove event listeners.(EventEmitter3)
+         * @param {String} event The event we want to remove.
+         * @param {Function} fn The listener that we need to find.
+         * @param {Boolean} once Only remove once listeners.
+         */
+        off(event: string, fn: Function, once?: boolean): void;
         /**
          * Close the connection to the server, leaving all existing data and media connections intact.
          */

--- a/webrtc/MediaStream-tests.ts
+++ b/webrtc/MediaStream-tests.ts
@@ -23,6 +23,7 @@ navigator.webkitGetUserMedia(mediaStreamConstraints,
     console.log('label:' + stream.label);
     console.log('ended:' + stream.ended);
     stream.onended = (event:Event) => console.log('Stream ended');
+    stream.addEventListener("ended", (event:Event) => console.log('Stream ended'));
     var objectUrl = URL.createObjectURL(stream);
     var wkObjectUrl = webkitURL.createObjectURL(stream);
   },
@@ -37,6 +38,7 @@ navigator.mozGetUserMedia(mediaStreamConstraints,
     console.log('label:' + stream.label);
     console.log('ended:' + stream.ended);
     stream.onended = (event:Event) => console.log('Stream ended');
+    stream.addEventListener("ended", (event:Event) => console.log('Stream ended'));
     var objectUrl = URL.createObjectURL(stream);
     var wkObjectUrl = webkitURL.createObjectURL(stream);
   },

--- a/webrtc/MediaStream.d.ts
+++ b/webrtc/MediaStream.d.ts
@@ -88,7 +88,7 @@ declare var webkitMediaStreamTrackList: {
   new (): MediaStreamTrackList;
 };
 
-interface MediaStream {
+interface MediaStream extends EventTarget{
   label: string;
   id: string;
   getAudioTracks(): MediaStreamTrackList;
@@ -126,7 +126,7 @@ interface LocalMediaStream extends MediaStream {
   stop(): void;
 }
 
-interface MediaStreamTrack {
+interface MediaStreamTrack extends EventTarget{
   kind: string;
   label: string;
   enabled: boolean;
@@ -163,4 +163,3 @@ declare var webkitURL: {
   new (): streamURL;
   createObjectURL(stream: MediaStream): string;
 };
-


### PR DESCRIPTION
MediaStream does not extend EventTarget interface probrem so I fixed.
PeerJs Peer has off method like removeEventListener.
