### PR TITLE
Support JSX spread attribute

### DIFF
--- a/react/react-addons.d.ts
+++ b/react/react-addons.d.ts
@@ -125,6 +125,9 @@ declare module "react/addons" {
     var PropTypes: ReactPropTypes;
     var Children: ReactChildren;
 
+    // Hook for JSX spread syntax
+    var __spread: any;
+
     //
     // Component API
     // ----------------------------------------------------------------------

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -125,6 +125,9 @@ declare module React {
     var PropTypes: ReactPropTypes;
     var Children: ReactChildren;
 
+    // Hook for JSX spread syntax
+    var __spread: any;
+
     //
     // Component API
     // ----------------------------------------------------------------------


### PR DESCRIPTION
tx-jsx-loader (Webpack plugin) supports JSX with TypeScript,
but using JSX spread attirbute causes error becasue a necessary hook is missing.
I added a hook to use JSX spread attribute.
