### PR TITLE
Add typings for Atom's event-kit library

### DIFF
--- a/event-kit/.editorconfig
+++ b/event-kit/.editorconfig
@@ -1,0 +1,3 @@
+[*.ts]
+indent_style = tab
+indent_size = 4

--- a/event-kit/event-kit-tests.ts
+++ b/event-kit/event-kit-tests.ts
@@ -1,0 +1,65 @@
+/// <reference path="./event-kit.d.ts" />
+
+// The following line only works in TypeScript 1.5
+//import { Disposable, CompositeDisposable, Emitter } from "event-kit";
+// DefinitelyTyped is still using TypeScript 1.4 to run tests
+// so until they upgrade we have to do the following instead
+import eventKit = require('event-kit');
+type Disposable = AtomEventKit.Disposable;
+var Disposable = eventKit.Disposable;
+type CompositeDisposable = AtomEventKit.CompositeDisposable;
+var CompositeDisposable = eventKit.CompositeDisposable;
+type Emitter = AtomEventKit.Emitter;
+var Emitter = eventKit.Emitter;
+
+// Emitter
+
+class User {
+	private emitter: Emitter;
+	name: string;
+
+	constructor() {
+		this.emitter = new Emitter();
+	}
+
+	onDidChangeName(callback: (name: string) => void): Disposable {
+		return this.emitter.on('did-change-name', callback);
+	}
+
+	setName(name: string): void {
+		if (this.name != name) {
+			this.name = name;
+			this.emitter.emit('did-change-name', name);
+		}
+	}
+
+	destroy(): void {
+		this.emitter.dispose();
+	}
+}
+
+// Disposable
+
+var disposable = new Disposable(() => {
+	// cleanup
+});
+disposable.dispose();
+
+var user = new User();
+var subscription = user.onDidChangeName((name: string) => {
+	console.log('User name change to: ' + name);
+});
+subscription.dispose();
+
+// CompositeDisposable
+
+var subscriptions = new CompositeDisposable();
+subscriptions.add(
+	user.onDidChangeName((name: string) => {
+		console.log('subscriber #1');
+	}),
+	user.onDidChangeName((name: string) => {
+		console.log('subscriber #2');
+	})
+);
+subscriptions.dispose();

--- a/event-kit/event-kit.d.ts
+++ b/event-kit/event-kit.d.ts
@@ -1,0 +1,82 @@
+// Type definitions for event-kit v1.2.0
+// Project: https://github.com/atom/event-kit
+// Definitions by: Vadim Macagon <https://github.com/enlight/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module AtomEventKit {
+	interface IDisposable {
+		dispose(): void;
+	}
+
+	/** Static side of the Disposable class. */
+	interface DisposableStatic {
+		prototype: Disposable;
+		new (disposalAction: Function): Disposable;
+	}
+
+	/** Instance side of the Disposable class. */
+	interface Disposable extends IDisposable {
+		disposed: boolean;
+
+		constructor: DisposableStatic;
+	}
+
+	/** A class that represent a handle to a resource that can be disposed. */
+	var Disposable: DisposableStatic;
+
+	/** Static side of the CompositeDisposable class. */
+	interface CompositeDisposableStatic {
+		prototype: CompositeDisposable;
+		new (...disposables: IDisposable[]): CompositeDisposable;
+	}
+
+	/** Instance side of the CompositeDisposable class. */
+	interface CompositeDisposable extends IDisposable {
+		disposed: boolean;
+
+		constructor: CompositeDisposableStatic;
+		add(...disposables: IDisposable[]): void;
+		remove(disposable: IDisposable): void;
+		clear(): void;
+	}
+
+	/**
+	 * A class that aggregates multiple [[Disposable]] instances together into a single disposable,
+	 * so that they can all be disposed as a group.
+	 */
+	var CompositeDisposable: CompositeDisposableStatic;
+
+	/** Static side of the Emitter class. */
+	interface EmitterStatic {
+		prototype: Emitter;
+		new (): Emitter;
+	}
+
+	/** Instance side of the Emitter class. */
+	interface Emitter {
+		isDisposed: boolean;
+
+		constructor: EmitterStatic;
+		dispose(): void;
+		/**
+		* Registers a handler to be invoked whenever the given event is emitted.
+		* @return An object that will unregister the handler when disposed.
+		*/
+		on(eventName: string, handler: (value: any) => void, unshift?: boolean): Disposable;
+		/**
+		* Registers a handler to be invoked *before* all previously registered handlers for
+		* the given event.
+		* @return An object that will unregister the handler when disposed.
+		*/
+		preempt(eventName: string, handler: (value: any) => void): Disposable;
+		/** Invokes any registered handlers for the given event. */
+		emit(eventName: string, value: any): void;
+	}
+
+	/** A utility class for implementing event-based APIs. */
+	var Emitter: EmitterStatic;
+}
+
+declare module "event-kit" {
+	export = AtomEventKit;
+}


### PR DESCRIPTION
I'm working on updating the type definitions for Atom 1.0, as part of that effort I've had to add/update type definitions for some libraries Atom depends on. Once this PR is merged in I'll submit PRs for the first-mate and atom-keymap libraries that depend on this one.
