### PR TITLE
Update jqueryui.d.ts

### DIFF
--- a/jqueryui/jqueryui.d.ts
+++ b/jqueryui/jqueryui.d.ts
@@ -507,7 +507,7 @@ declare module JQueryUI {
 
     interface ProgressbarOptions {
         disabled?: boolean;
-        value?: number;
+        value?: number | boolean;
     }
 
     interface ProgressbarUIParams {


### PR DESCRIPTION
According to https://api.jqueryui.com/1.10/progressbar/#option-value `value` property can be set to `false` to create an indeterminate progressbar.
