### PR TITLE
More TypeScript definitions for gulp plugins

### DIFF
--- a/gulp-debug/gulp-debug-tests.ts
+++ b/gulp-debug/gulp-debug-tests.ts
@@ -1,0 +1,14 @@
+/// <reference path="gulp-debug.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require('gulp');
+import debug = require('gulp-debug');
+
+gulp.task('default', () =>
+    gulp.src('foo.js')
+        .pipe(debug({title: 'unicorn:'}))
+        .pipe(gulp.dest('dist'))
+);
+
+
+debug();

--- a/gulp-debug/gulp-debug.d.ts
+++ b/gulp-debug/gulp-debug.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for gulp-debug v2.0.1
+// Project: https://github.com/sindresorhus/gulp-debug
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module 'gulp-debug' {
+    interface IOptions {
+        title?: string;
+        minimal?: boolean;
+    }
+
+    function debug(options?: IOptions): NodeJS.ReadWriteStream;
+
+    export = debug;
+}

--- a/gulp-jasmine-browser/gulp-jasmine-browser-tests.ts
+++ b/gulp-jasmine-browser/gulp-jasmine-browser-tests.ts
@@ -1,0 +1,32 @@
+/// <reference path="gulp-jasmine-browser.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require('gulp');
+import jasmineBrowser = require('gulp-jasmine-browser');
+
+gulp.task('jasmine', () =>
+  gulp.src(['src/**/*.js', 'spec/**/*_spec.js'])
+    .pipe(jasmineBrowser.specRunner())
+    .pipe(jasmineBrowser.server({port: 8888}))
+);
+
+
+gulp.task('jasmine-phantom', () =>
+  gulp.src(['src/**/*.js', 'spec/**/*_spec.js'])
+    .pipe(jasmineBrowser.specRunner({console: true}))
+    .pipe(jasmineBrowser.headless())
+);
+
+
+gulp.task('jasmine-slimerjs', () =>
+  gulp.src(['src/**/*.js', 'spec/**/*_spec.js'])
+    .pipe(jasmineBrowser.specRunner({console: true}))
+    .pipe(jasmineBrowser.headless({driver: 'slimerjs'}))
+);
+
+
+gulp.task('jasmine', () =>
+  gulp.src('spec/**/*_spec.js')
+    .pipe(jasmineBrowser.specRunner())
+    .pipe(jasmineBrowser.server())
+);

--- a/gulp-jasmine-browser/gulp-jasmine-browser.d.ts
+++ b/gulp-jasmine-browser/gulp-jasmine-browser.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for gulp-jasmine-browser v0.1.4
+// Project: https://github.com/jasmine/gulp-jasmine-browser
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module 'gulp-jasmine-browser' {
+    interface IJasmineBrowser {
+        specRunner(options?: any): NodeJS.ReadWriteStream;
+        server(options?: any): NodeJS.ReadWriteStream;
+        headless(options?: any): NodeJS.ReadWriteStream;
+    }
+
+    var jasmineBrowser: IJasmineBrowser;
+    export = jasmineBrowser;
+}

--- a/gulp-protractor/gulp-protractor-tests.ts
+++ b/gulp-protractor/gulp-protractor-tests.ts
@@ -1,0 +1,20 @@
+/// <reference path="gulp-protractor.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require('gulp');
+import protractor = require('gulp-protractor');
+
+gulp.src(["./src/tests/*.js"])
+    .pipe(protractor.protractor({
+        configFile: "test/protractor.config.js",
+        args: ['--baseUrl', 'http://127.0.0.1:8000']
+    }))
+
+
+gulp.task('webdriver_standalone', protractor.webdriver_standalone);
+
+
+gulp.task('webdriver-update', protractor.webdriver_update);
+
+
+console.log(protractor.getProtractorDir());

--- a/gulp-protractor/gulp-protractor.d.ts
+++ b/gulp-protractor/gulp-protractor.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for gulp-protractor v1.0.0
+// Project: https://github.com/mllrsohn/gulp-protractor
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+declare module 'gulp-protractor' {
+    interface IOptions {
+        configFile?: string;
+        args?: Array<string>;
+        debug?: boolean;
+    }
+
+    interface IGulpProtractor {
+        getProtractorDir(): string;
+        protractor(options?: IOptions): NodeJS.ReadWriteStream;
+        webdriver_standalone: gulp.ITaskCallback;
+        webdriver_update: gulp.ITaskCallback;
+    }
+
+    var protractor: IGulpProtractor;
+    export = protractor;
+}

--- a/gulp-rev-replace/gulp-rev-replace-tests.ts
+++ b/gulp-rev-replace/gulp-rev-replace-tests.ts
@@ -1,0 +1,63 @@
+/// <reference path="gulp-rev-replace.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+/// <reference path="../gulp-rev/gulp-rev.d.ts" />
+/// <reference path="../gulp-useref/gulp-useref.d.ts" />
+
+import gulp = require('gulp');
+import revReplace = require('gulp-rev-replace');
+import rev = require('gulp-rev');
+import useref = require('gulp-useref');
+
+gulp.task("index", () => {
+    var userefAssets = useref.assets();
+
+    return gulp.src("src/index.html")
+        .pipe(userefAssets)      // Concatenate with gulp-useref
+        .pipe(rev())                // Rename the concatenated files
+        .pipe(userefAssets.restore())
+        .pipe(useref())
+        .pipe(revReplace())         // Substitute in new filenames
+        .pipe(gulp.dest('public'));
+});
+
+
+var opt = {
+    srcFolder: 'src',
+    distFolder: 'dist'
+}
+
+gulp.task("revision", ["dist:css", "dist:js"], () =>
+    gulp.src(["dist/**/*.css", "dist/**/*.js"])
+        .pipe(rev())
+        .pipe(gulp.dest(opt.distFolder))
+        .pipe(rev.manifest())
+        .pipe(gulp.dest(opt.distFolder))
+);
+
+gulp.task("revreplace", ["revision"], () => {
+    var manifest = gulp.src("./" + opt.distFolder + "/rev-manifest.json");
+
+    return gulp.src(opt.srcFolder + "/index.html")
+        .pipe(revReplace({manifest: manifest}))
+        .pipe(gulp.dest(opt.distFolder));
+});
+
+
+function replaceJsIfMap(filename: string): string {
+    if (filename.indexOf('.map') > -1) {
+        return filename.replace('js/', '');
+    }
+    return filename;
+}
+
+gulp.task("revreplace", ["revision"], () => {
+    var manifest = gulp.src("./" + opt.distFolder + "/rev-manifest.json");
+
+    return gulp.src(opt.distFolder + '**/*.js')
+        .pipe(revReplace({
+            manifest: manifest,
+            modifyUnreved: replaceJsIfMap,
+            modifyReved: replaceJsIfMap
+        }))
+        .pipe(gulp.dest(opt.distFolder));
+});

--- a/gulp-rev-replace/gulp-rev-replace.d.ts
+++ b/gulp-rev-replace/gulp-rev-replace.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for gulp-rev-replace v0.2.1
+// Project: https://github.com/jamesknelson/gulp-rev-replace
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module 'gulp-rev-replace' {
+    interface IOptions {
+        canonicalUris?: boolean;
+        replaceInExtensions?: Array<string>;
+        prefix?: string;
+        manifest?: NodeJS.ReadWriteStream;
+        modifyUnreved?: Function;
+        modifyReved?: Function;
+    }
+
+    function revReplace(options?: IOptions): NodeJS.ReadWriteStream;
+
+    export = revReplace;
+}

--- a/gulp-rev/gulp-rev-tests.ts
+++ b/gulp-rev/gulp-rev-tests.ts
@@ -1,0 +1,36 @@
+/// <reference path="gulp-rev.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require('gulp');
+import rev = require('gulp-rev');
+
+gulp.task('default', () =>
+    gulp.src('src/*.css')
+        .pipe(rev())
+        .pipe(gulp.dest('dist'))
+);
+
+gulp.task('default', () =>
+    // by default, gulp would pick `assets/css` as the base,
+    // so we need to set it explicitly:
+    gulp.src(['assets/css/*.css', 'assets/js/*.js'], {base: 'assets'})
+        .pipe(gulp.dest('build/assets'))  // copy original assets to build dir
+        .pipe(rev())
+        .pipe(gulp.dest('build/assets'))  // write rev'd assets to build dir
+        .pipe(rev.manifest())
+        .pipe(gulp.dest('build/assets')) // write manifest to build dir
+);
+
+gulp.task('default', () =>
+    // by default, gulp would pick `assets/css` as the base,
+    // so we need to set it explicitly:
+    gulp.src(['assets/css/*.css', 'assets/js/*.js'], {base: 'assets'})
+        .pipe(gulp.dest('build/assets'))
+        .pipe(rev())
+        .pipe(gulp.dest('build/assets'))
+        .pipe(rev.manifest({
+            base: 'build/assets',
+            merge: true // merge with the existing manifest (if one exists)
+        }))
+        .pipe(gulp.dest('build/assets'))
+);

--- a/gulp-rev/gulp-rev.d.ts
+++ b/gulp-rev/gulp-rev.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for gulp-csso v5.0.1
+// Project: https://github.com/sindresorhus/gulp-rev
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module 'gulp-rev' {
+    interface IOptions {
+        base?: string;
+        cwd?: string;
+        merge?: boolean;
+    }
+
+    interface IRev {
+        (): NodeJS.ReadWriteStream;
+
+        manifest(): NodeJS.ReadWriteStream;
+        manifest(path?: string): NodeJS.ReadWriteStream;
+        manifest(options?: IOptions): NodeJS.ReadWriteStream;
+        manifest(path?: string, options?: IOptions): NodeJS.ReadWriteStream;
+    }
+
+    var rev: IRev;
+    export = rev;
+}

--- a/gulp-size/gulp-size-tests.ts
+++ b/gulp-size/gulp-size-tests.ts
@@ -1,0 +1,27 @@
+/// <reference path="gulp-size.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+/// <reference path="../gulp-debug/gulp-debug.d.ts" />
+
+import gulp = require('gulp');
+import size = require('gulp-size');
+import debug = require('gulp-debug');
+
+gulp.task('default', () =>
+    gulp.src('fixture.js')
+        .pipe(size())
+        .pipe(gulp.dest('dist'))
+);
+
+
+gulp.task('default', () => {
+    var s = size();
+
+    return gulp.src('fixture.js')
+        .pipe(s)
+        .pipe(gulp.dest('dist'))
+        .pipe(debug({title: 'Total size ' + s.prettySize}));
+});
+
+
+size();
+size({showFiles: true, gzip: true});

--- a/gulp-size/gulp-size.d.ts
+++ b/gulp-size/gulp-size.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for gulp-size v1.2.3
+// Project: https://github.com/sindresorhus/gulp-size
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module 'gulp-size' {
+    interface IOptions {
+        showFiles?: boolean;
+        gzip?: boolean;
+        title?: string;
+    }
+
+    interface ISizeStream extends NodeJS.ReadWriteStream {
+      size: number;
+      prettySize: string;
+    }
+
+    function size(options?: IOptions): ISizeStream;
+
+    export = size;
+}

--- a/gulp-useref/gulp-useref-tests.ts
+++ b/gulp-useref/gulp-useref-tests.ts
@@ -1,0 +1,15 @@
+/// <reference path="gulp-useref.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require('gulp');
+import useref = require('gulp-useref');
+
+gulp.task('default', () => {
+    var assets = useref.assets();
+
+    return gulp.src('app/*.html')
+        .pipe(assets)
+        .pipe(assets.restore())
+        .pipe(useref())
+        .pipe(gulp.dest('dist'));
+});

--- a/gulp-useref/gulp-useref.d.ts
+++ b/gulp-useref/gulp-useref.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for gulp-useref v1.2.0
+// Project: https://github.com/jonkemp/gulp-useref
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module 'gulp-useref' {
+    interface IAssetsOptions {
+        searchPath?: string | string[];
+        noconcat?: boolean;
+    }
+
+    interface IAssetsStream extends NodeJS.ReadWriteStream {
+        restore(): NodeJS.ReadWriteStream;
+    }
+
+    interface IUseref {
+        (options?: any): NodeJS.ReadWriteStream;
+        assets(options?: IAssetsOptions): IAssetsStream;
+    }
+
+    var useref: IUseref;
+    export = useref;
+}

--- a/gulp-watch/gulp-watch-tests.ts
+++ b/gulp-watch/gulp-watch-tests.ts
@@ -1,0 +1,19 @@
+/// <reference path="gulp-watch.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require('gulp');
+import watch = require('gulp-watch');
+
+gulp.task('stream', () =>
+    gulp.src('css/**/*.css')
+        .pipe(watch('css/**/*.css'))
+        .pipe(gulp.dest('build'))
+);
+
+gulp.task('callback', (cb) =>
+    watch('css/**/*.css', () =>
+        gulp.src('css/**/*.css')
+            .pipe(watch('css/**/*.css'))
+            .on('end', cb)
+    )
+);

--- a/gulp-watch/gulp-watch-tests.ts
+++ b/gulp-watch/gulp-watch-tests.ts
@@ -17,3 +17,14 @@ gulp.task('callback', (cb) =>
             .on('end', cb)
     )
 );
+
+gulp.task('build', () => {
+    var files = [
+        'app/**/*.ts',
+        'lib/**/*.ts',
+        'components/**/*.ts',
+    ];
+
+    gulp.src(files, { base: '..' })
+        .pipe(watch(files, { base: '..' }));
+});

--- a/gulp-watch/gulp-watch.d.ts
+++ b/gulp-watch/gulp-watch.d.ts
@@ -21,7 +21,7 @@ declare module 'gulp-watch' {
         close(): NodeJS.ReadWriteStream;
     }
 
-    function watch(glob: string, options?: IOptions, callback?: Function): IWatchStream;
+    function watch(glob: string | Array<string>, options?: IOptions, callback?: Function): IWatchStream;
 
     export = watch;
 }

--- a/gulp-watch/gulp-watch.d.ts
+++ b/gulp-watch/gulp-watch.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for gulp-watch v4.1.1
+// Project: https://github.com/floatdrop/gulp-watch
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module 'gulp-watch' {
+    interface IOptions {
+        ignoreInitial?: boolean;
+        events?: Array<string>;
+        base?: string;
+        name?: string;
+        verbose?: boolean;
+        readDelay?: number;
+    }
+
+    interface IWatchStream extends NodeJS.ReadWriteStream {
+        add(path: string | Array<string>): NodeJS.ReadWriteStream;
+        unwatch(path: string | Array<string>): NodeJS.ReadWriteStream;
+        close(): NodeJS.ReadWriteStream;
+    }
+
+    function watch(glob: string, options?: IOptions, callback?: Function): IWatchStream;
+
+    export = watch;
+}

--- a/karma/karma-tests.ts
+++ b/karma/karma-tests.ts
@@ -1,0 +1,26 @@
+/// <reference path="karma.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require('gulp');
+import karma = require('karma');
+
+function runKarma(singleRun: boolean): void {
+  karma.server.start({
+    configFile: __dirname + '/karma.conf.js',
+    singleRun: singleRun
+  });
+}
+
+gulp.task('test:unit:karma', ['build:test:unit'], () => runKarma(true));
+
+
+karma.server.start({port: 9876}, (exitCode) => {
+  console.log('Karma has exited with ' + exitCode);
+  process.exit(exitCode);
+});
+
+
+karma.runner.run({port: 9876}, (exitCode) => {
+  console.log('Karma has exited with ' + exitCode);
+  process.exit(exitCode);
+});

--- a/karma/karma.d.ts
+++ b/karma/karma.d.ts
@@ -1,0 +1,24 @@
+// Type definitions for karma v0.12.37
+// Project: https://github.com/karma-runner/karma
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module 'karma' {
+    // See Karma public API https://karma-runner.github.io/0.12/dev/public-api.html
+
+    interface IKarmaServer {
+        start(options?: any, callback?: (exitCode: number) => void): void;
+    }
+
+    interface IKarmaRunner {
+        run(options?: any, callback?: (exitCode: number) => void): void;
+    }
+
+    interface IKarma {
+        server: IKarmaServer;
+        runner: IKarmaRunner;
+    }
+
+    var karma: IKarma;
+    export = karma;
+}

--- a/merge2/merge2-tests.ts
+++ b/merge2/merge2-tests.ts
@@ -1,0 +1,64 @@
+/// <reference path="merge2.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require('gulp');
+import merge2 = require('merge2');
+
+gulp.task('app-js', () =>
+  merge2(
+      gulp.src('static/src/tpl/*.html'),
+      gulp.src([
+        'static/src/js/app.js',
+        'static/src/js/locale_zh-cn.js',
+        'static/src/js/router.js',
+        'static/src/js/tools.js',
+        'static/src/js/services.js',
+        'static/src/js/filters.js',
+        'static/src/js/directives.js',
+        'static/src/js/controllers.js'
+      ])
+    )
+    .pipe(gulp.dest('static/dist/js/'))
+);
+
+
+var stream1 = gulp.src('*.html');
+var stream2 = gulp.src('*.html');
+var stream3 = gulp.src('*.html');
+var stream4 = gulp.src('*.html');
+var stream5 = gulp.src('*.html');
+var stream6 = gulp.src('*.html');
+var stream7 = gulp.src('*.html');
+
+
+var stream = merge2([stream1, stream2], stream3, {end: false})
+//...
+stream.add(stream4, stream5);
+//..
+stream.end();
+
+
+// equal to merge2([stream1, stream2], stream3)
+var stream = merge2();
+stream.add([stream1, stream2]);
+stream.add(stream3);
+
+
+// merge order:
+//   1. merge `stream1`;
+//   2. merge `stream2` and `stream3` in parallel after `stream1` merged;
+//   3. merge 'stream4' after `stream2` and `stream3` merged;
+var stream = merge2(stream1, [stream2, stream3], stream4);
+
+// merge order:
+//   1. merge `stream5` and `stream6` in parallel after `stream4` merged;
+//   2. merge 'stream7' after `stream5` and `stream6` merged;
+stream.add([stream5, stream6], stream7);
+
+
+// nest merge
+// equal to merge2(stream1, stream2, stream6, stream3, [stream4, stream5]);
+var streamA = merge2(stream1, stream2);
+var streamB = merge2(stream3, [stream4, stream5]);
+var stream = merge2(streamA, streamB);
+streamA.add(stream6);

--- a/merge2/merge2.d.ts
+++ b/merge2/merge2.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for merge2 v0.3.6
+// Project: https://github.com/teambition/merge2
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module 'merge2' {
+    interface IOptions {
+        end?: boolean;
+        objectMode?: boolean;
+    }
+
+    interface IMerge2Stream extends NodeJS.ReadWriteStream {
+      add(...args: Array<NodeJS.ReadWriteStream | IMerge2Stream | Array<NodeJS.ReadWriteStream | IMerge2Stream | IOptions>>): IMerge2Stream;
+    }
+
+    function merge2(...args: Array<NodeJS.ReadWriteStream | IMerge2Stream | Array<NodeJS.ReadWriteStream | IMerge2Stream> | IOptions>): IMerge2Stream;
+
+    export = merge2;
+}


### PR DESCRIPTION
This pull request + my [others](https://github.com/borisyankov/DefinitelyTyped/pulls/tkrotoff) allow to write complex `gulpfile.ts`.

Hope that now others will start to write gulpfiles using TypeScript and contribute more gulp plugins.

You just have to name your gulpfile `gulpfile.ts` instead of `gulpfile.js` and gulp takes care of it. See https://github.com/gulpjs/gulp/issues/1099
