### PR TITLE
Use correct templateProvider and url definitions in angular.ui.IState.

### DIFF
--- a/angular-ui-router/angular-ui-router.d.ts
+++ b/angular-ui-router/angular-ui-router.d.ts
@@ -20,7 +20,7 @@ declare module angular.ui {
         /**
          * Function, returns HTML content string
          */
-        templateProvider?: Function;
+        templateProvider?: Function | Array<any>;
         /**
          * A controller paired to the state. Function OR name as String
          */
@@ -41,7 +41,7 @@ declare module angular.ui {
         /**
          * A url with optional parameters. When a state is navigated or transitioned to, the $stateParams service will be populated with any parameters that were passed.
          */
-        url?: string;
+        url?: string | IUrlMatcher;
         /**
          * A map which optionally configures parameters declared in the url, or defines additional non-url parameters. Only use this within a state if you are not using url. Otherwise you can specify your parameters within the url. When a state is navigated or transitioned to, the $stateParams service will be populated with any parameters that were passed.
          */


### PR DESCRIPTION
- See https://github.com/angular-ui/ui-router/wiki/URL-Routing#urlmatcherfactory-and-urlmatchers for a use of url that is non-string.
- templateProvider needs to accept an Array<any> to allow it to participate in by-name DI within Angular.
