### PR TITLE
Corrected linearGradient members (not 0 based)

### DIFF
--- a/highcharts/highcharts-tests.ts
+++ b/highcharts/highcharts-tests.ts
@@ -23,10 +23,10 @@ var animate: HighchartsAnimation = {
 
 var gradient: HighchartsGradient = {
     linearGradient: {
-        x0: 0,
-        y0: 0,
-        x1: 500,
-        y1: 500
+        x1: 0,
+        y1: 0,
+        x2: 500,
+        y2: 500
     },
     stops: [
         [0, 'rgb(255, 255, 255)'],

--- a/highcharts/highcharts.d.ts
+++ b/highcharts/highcharts.d.ts
@@ -166,7 +166,7 @@ interface HighchartsChartEvents {
 
 interface HighchartsGradient {
     linearGradient?: {
-        x0: number; y0: number; x1: number; y1: number;
+        x1: number; y1: number; x2: number; y2: number;
     };
     radialGradient?: {
         cx: number; cy: number; r: number;


### PR DESCRIPTION
See documentation: "Linear gradients in Highcharts have a similar syntax to that of SVG" ... "linearGradient holds another object literal that defines the start position (x1, y1) and the end position (x2, y2)"
http://www.highcharts.com/docs/chart-design-and-style/colors
http://www.w3schools.com/svg/svg_grad_linear.asp
