### PR TITLE
codemirror.d.ts: Changed the Doc class type to an interface 

### DIFF
--- a/codemirror/codemirror.d.ts
+++ b/codemirror/codemirror.d.ts
@@ -7,6 +7,8 @@ declare function CodeMirror(host: HTMLElement, options?: CodeMirror.EditorConfig
 declare function CodeMirror(callback: (host: HTMLElement) => void , options?: CodeMirror.EditorConfiguration): CodeMirror.Editor;
 
 declare module CodeMirror {
+    export var Doc : CodeMirror.Doc;
+    export var Pos: CodeMirror.Position;
     export var Pass: any;
 
     function fromTextArea(host: HTMLTextAreaElement, options?: EditorConfiguration): CodeMirror.EditorFromTextArea;
@@ -387,8 +389,8 @@ declare module CodeMirror {
         getTextArea(): HTMLTextAreaElement;
     }
 
-    class Doc {
-        constructor (text: string, mode?: any, firstLineNumber?: number);
+    interface Doc {
+        new (text: string, mode?: any, firstLineNumber?: number): Doc;
 
         /** Get the current editor content. You can pass it an optional argument to specify the string to be used to separate lines (defaults to "\n"). */
         getValue(seperator?: string): string;
@@ -616,6 +618,7 @@ declare module CodeMirror {
     }
 
     interface Position {
+        new (line: number, ch: number): Position;
         ch: number;
         line: number;
     }


### PR DESCRIPTION
This allows the user to extend the definition for the CodeMirror.Doc interface over multiple files. This is useful because some CodeMirror add-ons extend CodeMirror.Doc, and it's better to extend the CodeMirror.Doc interface in add-on specific typing files rather than in the main CodeMirror type file.

In particular, it allows someone writing typings for CodeMirror add-ons which add properties to Doc or Editor to write

```
interface Doc {
    addedProperty: addedPropertyType
}
```

Previously, when Doc was a class, it was not possible to extend the Doc type because of how TypeScript works.

Existing codemirror-tests.ts still pass.
