### PR TITLE
Updating jquery.autosize to the new API in 3.0.7

### DIFF
--- a/jquery.autosize/jquery.autosize-tests.ts
+++ b/jquery.autosize/jquery.autosize-tests.ts
@@ -1,0 +1,13 @@
+/// <reference path="jquery.autosize.d.ts" />
+
+// from a NodeList
+autosize(document.querySelectorAll('textarea'));
+
+// from a single Node
+autosize(document.querySelector('textarea'));
+
+// from a jQuery collection
+autosize($('textarea'));
+
+// from a single element
+autosize(document.getElementById('my-textarea'));

--- a/jquery.autosize/jquery.autosize.d.ts
+++ b/jquery.autosize/jquery.autosize.d.ts
@@ -1,21 +1,19 @@
-// Type definitions for jquery.autosize (un-versioned)
+// Type definitions for jquery.autosize 3.0.7
 // Project: http://www.jacklmoore.com/autosize/
 // Definitions by: Aaron T. King <https://github.com/kingdango>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../jquery/jquery.d.ts" />
-
-interface AutosizeOptions {
-	className?: string;
-	append?: string;
-	callback?: Function;
+declare module autosize {
+    interface AutosizeStatic {
+        (el: Element): void;
+        (el: NodeList): void;
+        (el: JQuery): void;
+    }
 }
 
-interface Autosize {
-	(): JQuery;
-	(options: AutosizeOptions): JQuery;
-}
+declare var autosize: autosize.AutosizeStatic;
 
-interface JQuery {
-	autosize: Autosize;
+declare module 'autosize' {
+    export = autosize;
 }


### PR DESCRIPTION
It appears that this plugin has a different API now. I updated appropriately and added tests. See http://www.jacklmoore.com/autosize/
