### PR TITLE
Fixed the casing of the definition of auth0

### DIFF
--- a/auth0/auth0.d.ts
+++ b/auth0/auth0.d.ts
@@ -15,7 +15,7 @@ interface Location {
 
 /** This is the interface for the main Auth0 client. */
 interface Auth0Static {
-    
+
     new(options: Auth0ClientOptions): Auth0Static;
     changePassword(options: any, callback?: Function): void;
     decodeJwt(jwt: string): any;
@@ -40,7 +40,7 @@ interface Auth0ClientOptions {
     callbackOnLoactionHash?: boolean;
     domain: string;
     forceJSONP?: boolean;
-} 
+}
 
 /** Represents a normalized UserProfile. */
 interface Auth0UserProfile {
@@ -128,6 +128,6 @@ interface Auth0DelegationToken {
 
 declare var Auth0: Auth0Static;
 
-declare module "Auth0" {
+declare module "auth0" {
     export = Auth0
 }


### PR DESCRIPTION
Consider the following steps:

One installs auth0 via npm: `npm install auth0`

Note that `npm install Auth0` doesn't work, it needs to be lowercase.

On disk it will be stored in `node_modules\auth0`. 

So to import it in code one does `import Auth0 = require("auth0");`

This doesn't work with this definition, since it is case sensitive. 

And we can't do `import Auth0 = require("Auth0");` since `node` doesn't touch the case, it respects the filesystem, meaning problems on Linux/Mac (where enabled). 

Which is why I'm proposing this change, it is the best 'marriage' between the case-sensitive and case-insensitive world. 
