### PR TITLE
Correct type for i18next fallback language initialization option

### DIFF
--- a/i18next/i18next.d.ts
+++ b/i18next/i18next.d.ts
@@ -23,7 +23,7 @@ interface I18nextOptions {
     preload?: string[];                     // Default value: []
     lowerCaseLng?: boolean;                    // Default value: false
     returnObjectTrees?: boolean;               // Default value: false
-    fallbackLng?: string;                   // Default value: 'dev'
+    fallbackLng?: string|boolean;           // Default value: 'dev'
     detectLngQS?: string;                   // Default value: 'setLng'
     ns?: any;                               // Default value: 'translation' (string), can also be an object
     nsseparator?: string;                   // Default value: '::'


### PR DESCRIPTION
Allows for a Boolean value to be supplied for `I18nextOptions.fallbackLng`. Passing false in this field disables a fallback language. This is a [documented option](http://i18next.com/pages/doc_init.html) (see "Unset/Set fallback language").
