### PR TITLE
fix(mixpanel): Made identifiy id parameter optional

### DIFF
--- a/mixpanel/mixpanel.d.ts
+++ b/mixpanel/mixpanel.d.ts
@@ -26,7 +26,7 @@ interface Mixpanel
 
     unregister(propertyName:string):void;
 
-    identify(id:string):void;
+    identify(id?:string):void;
 
     get_distinct_id():string;
 


### PR DESCRIPTION
Identify's `Id` parameter is optional, but the definition file is requiring it. This change removes that requirement.
