### PR TITLE
RX: Fix typo in Rx.Observable.fromIterable method name

### DIFF
--- a/rx/rx-lite.d.ts
+++ b/rx/rx-lite.d.ts
@@ -481,7 +481,7 @@ declare module Rx {
 		* @param [scheduler] Scheduler to run the enumeration of the input sequence on.
 		* @returns The observable sequence whose elements are pulled from the given generator sequence.
 		*/
-		fromItreable<T>(generator: () => { next(): { done: boolean; value?: T; }; }, scheduler?: IScheduler): Observable<T>;
+		fromIterable<T>(generator: () => { next(): { done: boolean; value?: T; }; }, scheduler?: IScheduler): Observable<T>;
 
 		/**
 		*  Converts an iterable into an Observable sequence
@@ -493,7 +493,7 @@ declare module Rx {
 		* @param [scheduler] Scheduler to run the enumeration of the input sequence on.
 		* @returns The observable sequence whose elements are pulled from the given generator sequence.
 		*/
-		fromItreable<T>(iterable: {}, scheduler?: IScheduler): Observable<T>;	// todo: can't describe ES6 Iterable via TypeScript type system
+		fromIterable<T>(iterable: {}, scheduler?: IScheduler): Observable<T>;	// todo: can't describe ES6 Iterable via TypeScript type system
 		generate<TState, TResult>(initialState: TState, condition: (state: TState) => boolean, iterate: (state: TState) => TState, resultSelector: (state: TState) => TResult, scheduler?: IScheduler): Observable<TResult>;
 		never<T>(): Observable<T>;
 
@@ -625,11 +625,11 @@ declare module Rx {
 		hasObservers(): boolean;
 	}
 
-    export interface Subject<T> extends ISubject<T> {
-    }
+	export interface Subject<T> extends ISubject<T> {
+	}
 
-    interface SubjectStatic {
-        new <T>(): Subject<T>;
+	interface SubjectStatic {
+		new <T>(): Subject<T>;
 		create<T>(observer?: Observer<T>, observable?: Observable<T>): ISubject<T>;
 	}
 


### PR DESCRIPTION
A method was misnamed `fromItreable` instead of `fromIterable`.
