### PR TITLE
Add typings for contextjs 2.1.1

### DIFF
--- a/contextjs/contextjs-tests.ts
+++ b/contextjs/contextjs-tests.ts
@@ -1,0 +1,16 @@
+import context = require("contextjs");
+
+context.init();
+
+context.settings({compress: true});
+
+context.attach('#test', [
+  {header: 'header 1'},
+  {divider: true},
+  {text:'foobar', submenu: [
+    {text:'sub1'},
+    {text:'sub2'}
+  ]}
+]);
+
+context.destroy('#test');

--- a/contextjs/contextjs.d.ts
+++ b/contextjs/contextjs.d.ts
@@ -1,0 +1,33 @@
+// Type definitions for contextjs 2.1.1
+// Project: https://github.com/jakiestfu/Context.js
+// Definitions by: Kern Handa <https://github.com/kernhanda>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module "contextjs" {
+    interface MenuObject {
+        action?: (e: Event) => void;
+        divider?: boolean;
+        header?: string;
+        href?: string;
+        subMenu?: MenuObject[];
+        target?: string;
+        text?: string;
+    }
+
+    interface InitSettings {
+        above?: string | boolean;
+        compress?: boolean;
+        fadeSpeed?: number;
+        filter?: (e: Element) => void;
+        preventDoubleContext?: boolean;
+    }
+
+    module context {
+      function init(settings?: InitSettings): void;
+      function destroy(selector: any): void;
+      function attach(selector: any, menuObjects: MenuObject[]): void;
+      function settings(settings: InitSettings): void;
+    }
+
+    export = context;
+}


### PR DESCRIPTION
This adds typings for ContextJS 2.1.1, available at https://github.com/jakiestfu/Context.js.
