### PR TITLE
Added getRegion method to marionette.d.ts

### DIFF
--- a/marionette/marionette.d.ts
+++ b/marionette/marionette.d.ts
@@ -1128,6 +1128,9 @@ declare module Marionette {
          * Add multiple regions as a {name: definition, name2: def2} object literal.
          */
         addRegions(regions: any): any;
+        
+	/** Returns a region from the layout view */
+        getRegion(name: string): Region;
 
         /**
          * Renders the view.


### PR DESCRIPTION
`getRegion()` property of a [Marionette.LayoutView](http://marionettejs.com/docs/v2.4.2/marionette.layoutview.html) seems to be missing from the Marionette specification entirely. I've added it in this pull request.
