### PR TITLE
Remove import from angular.d.ts

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -13,8 +13,6 @@ interface Function {
     $inject?: string[];
 }
 
-// Collapse angular into ng
-import ng = angular;
 // Support AMD require
 declare module 'angular' {
     export = angular;


### PR DESCRIPTION
.d.ts files do not get compiled into the output files; therefore, referring to the "ng" module import causes a runtime error.
