### PR TITLE
Make it possible to initialize a Backbone.Collection from raw objects

### DIFF
--- a/backbone/backbone.d.ts
+++ b/backbone/backbone.d.ts
@@ -173,8 +173,8 @@ declare module Backbone {
         models: TModel[];
         length: number;
 
-        constructor(models?: TModel[], options?: any);
-        initialize(models?: TModel[], options?: any): void;
+        constructor(models?: TModel[] | Object[], options?: any);
+        initialize(models?: TModel[] | Object[], options?: any): void;
 
         fetch(options?: CollectionFetchOptions): JQueryXHR;
 


### PR DESCRIPTION
The following syntax is supported in Backbone, but it's equivalent in Typescript is not able to compile:

```
var data = [
  { id: 1, bar: 'foo' },
  { id: 2, bar: 'baz' }
];

var myCollection = new Backbone.Collection(data);
```

As of now, the constructor expects an array of generic models. I've added the Object[] parameter type, in addition to the TModel[] type to make it possible to initialize the Collection with raw objects.
