### PR TITLE
Fixed name of variable for browser global context

### DIFF
--- a/deep-diff/deep-diff.d.ts
+++ b/deep-diff/deep-diff.d.ts
@@ -34,7 +34,7 @@ declare module deepDiff {
     }
 }
 
-declare var diff: deepDiff.IDeepDiff;
+declare var DeepDiff: deepDiff.IDeepDiff;
 
 declare module "deep-diff" {
     var diff: deepDiff.IDeepDiff;


### PR DESCRIPTION
As seen here: 

https://www.npmjs.com/package/deep-diff#importing

Deep diff attaches itself to the browser's global context as "DeepDiff". Updated the type definition to reflect this / support browser use.
