### PR TITLE
Added content param for IToastService.showSimple()

### DIFF
--- a/angular-material/angular-material.d.ts
+++ b/angular-material/angular-material.d.ts
@@ -144,7 +144,7 @@ declare module angular.material {
 
     interface IToastService {
         show(optionsOrPreset: IToastOptions|IToastPreset<any>): angular.IPromise<any>;
-        showSimple(): angular.IPromise<any>;
+        showSimple(content: string): angular.IPromise<any>;
         simple(): ISimpleToastPreset;
         build(): IToastPreset<any>;
         updateContent(): void;


### PR DESCRIPTION
This param was missing in the interface, but [according to the doc](https://github.com/angular/material/blob/master/src/components/toast/toast.js#L49) without it, it's rather useless.
