### PR TITLE
Updated interface for Clock with mockDate() fn

### DIFF
--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -107,6 +107,7 @@ declare module jasmine {
         uninstall(): void;
         /** Calls to any registered callback are triggered when the clock is ticked forward via the jasmine.clock().tick function, which takes a number of milliseconds. */
         tick(ms: number): void;
+        mockDate(date?: Date): void;
     }
 
     interface CustomEqualityTester {


### PR DESCRIPTION
per [docs](http://jasmine.github.io/edge/introduction.html#section-Mocking_the_Date) there is `mockDate()` function
