### PR TITLE
Multer: added typing for file in callbacks

### DIFF
--- a/multer/multer.d.ts
+++ b/multer/multer.d.ts
@@ -5,31 +5,34 @@
 
 /// <reference path="../express/express.d.ts" />
 
+
 declare module Express {
     export interface Request {
         files: {
-            [fieldname: string]: {
-                /** Field name specified in the form */
-                fieldname: string;
-                /** Name of the file on the user's computer */
-                originalname: string;
-                /** Renamed file name */
-                name: string;
-                /** Encoding type of the file */
-                encoding: string;
-                /** Mime type of the file */
-                mimetype: string;
-                /** Location of the uploaded file */
-                path: string;
-                /** Extension of the file */
-                extension: string;
-                /** Size of the file in bytes */
-                size: number;
-                /** If the file was truncated due to size limitation */
-                truncated: boolean;
-                /** Raw data (is null unless the inMemory option is true) */
-                buffer: Buffer;
-            }
+            [fieldname: string]: Multer.File
+        }
+    }
+
+    module Multer {
+        export interface File {
+            /** Field name specified in the form */
+            fieldname: string;
+            /** Name of the file on the user's computer */
+            originalname: string;
+            /** Encoding type of the file */
+            encoding: string;
+            /** Mime type of the file */
+            mimetype: string;
+            /** Size of the file in bytes */
+            size: number;
+            /** The folder to which the file has been saved (DiskStorage) */
+            destination: string;
+            /** The name of the file within the destination (DiskStorage) */
+            filename: string;
+            /** Location of the uploaded file (DiskStorage) */
+            path: string;
+            /** A Buffer of the entire file (MemoryStorage) */
+            buffer: Buffer;
         }
     }
 }
@@ -40,28 +43,6 @@ declare module "multer" {
     function multer(options?: multer.Options): express.RequestHandler;
 
     module multer {
-        type MulterFile = {
-            /** Field name specified in the form */
-            fieldname: string;
-            /** Name of the file on the user's computer */
-            originalname: string;
-            /** Renamed file name */
-            name: string;
-            /** Encoding type of the file */
-            encoding: string;
-            /** Mime type of the file */
-            mimetype: string;
-            /** Location of the uploaded file */
-            path: string;
-            /** Extension of the file */
-            extension: string;
-            /** Size of the file in bytes */
-            size: number;
-            /** If the file was truncated due to size limitation */
-            truncated: boolean;
-            /** Raw data (is null unless the inMemory option is true) */
-            buffer: Buffer;
-        };
 
         type Options = {
             /** The destination directory for the uploaded files. */
@@ -92,11 +73,11 @@ declare module "multer" {
             /** Function to rename the directory in which to place uploaded files. The dest parameter is the default value originally assigned or passed into multer. The req and res parameters are also passed into the function because they may contain information (eg session data) needed to create the path (eg get userid from the session). */
             changeDest?: (dest: string, req: Express.Request, res: Express.Response) => string;
             /** Event handler triggered when a file starts to be uploaded. A file object, with the following properties, is available to this function: fieldname, originalname, name, encoding, mimetype, path, and extension. */
-            onFileUploadStart?: (file: MulterFile, req: Express.Request, res: Express.Response) => void;
+            onFileUploadStart?: (file: Express.Multer.File, req: Express.Request, res: Express.Response) => void;
             /** Event handler triggered when a chunk of buffer is received. A buffer object along with a file object is available to the function. */
-            onFileUploadData?: (file: MulterFile, data: Buffer, req: Express.Request, res: Express.Response) => void;
+            onFileUploadData?: (file: Express.Multer.File, data: Buffer, req: Express.Request, res: Express.Response) => void;
             /** Event handler trigger when a file is completely uploaded. A file object is available to the function. */
-            onFileUploadComplete?: (file: MulterFile, req: Express.Request, res: Express.Response) => void;
+            onFileUploadComplete?: (file: Express.Multer.File, req: Express.Request, res: Express.Response) => void;
             /** Event handler triggered when the form parsing starts. */
             onParseStart?: () => void;
             /** Event handler triggered when the form parsing completes. The request object and the next objects are are passed to the function. */
@@ -104,7 +85,7 @@ declare module "multer" {
             /** Event handler for any errors encountering while processing the form. The error object and the next object is available to the function. If you are handling errors yourself, make sure to terminate the request or call the next() function, else the request will be left hanging. */
             onError?: () => void;
             /** Event handler triggered when a file size exceeds the specification in the limit object. No more files will be parsed after the limit is reached. */
-            onFileSizeLimit?: (file: MulterFile) => void;
+            onFileSizeLimit?: (file: Express.Multer.File) => void;
             /** Event handler triggered when the number of files exceed the specification in the limit object. No more files will be parsed after the limit is reached. */
             onFilesLimit?: () => void;
             /** Event handler triggered when the number of fields exceed the specification in the limit object. No more fields will be parsed after the limit is reached. */

--- a/multer/multer.d.ts
+++ b/multer/multer.d.ts
@@ -40,6 +40,29 @@ declare module "multer" {
     function multer(options?: multer.Options): express.RequestHandler;
 
     module multer {
+        type MulterFile = {
+            /** Field name specified in the form */
+            fieldname: string;
+            /** Name of the file on the user's computer */
+            originalname: string;
+            /** Renamed file name */
+            name: string;
+            /** Encoding type of the file */
+            encoding: string;
+            /** Mime type of the file */
+            mimetype: string;
+            /** Location of the uploaded file */
+            path: string;
+            /** Extension of the file */
+            extension: string;
+            /** Size of the file in bytes */
+            size: number;
+            /** If the file was truncated due to size limitation */
+            truncated: boolean;
+            /** Raw data (is null unless the inMemory option is true) */
+            buffer: Buffer;
+        };
+
         type Options = {
             /** The destination directory for the uploaded files. */
             dest?: string;
@@ -69,11 +92,11 @@ declare module "multer" {
             /** Function to rename the directory in which to place uploaded files. The dest parameter is the default value originally assigned or passed into multer. The req and res parameters are also passed into the function because they may contain information (eg session data) needed to create the path (eg get userid from the session). */
             changeDest?: (dest: string, req: Express.Request, res: Express.Response) => string;
             /** Event handler triggered when a file starts to be uploaded. A file object, with the following properties, is available to this function: fieldname, originalname, name, encoding, mimetype, path, and extension. */
-            onFileUploadStart?: (file: string, req: Express.Request, res: Express.Response) => void;
+            onFileUploadStart?: (file: MulterFile, req: Express.Request, res: Express.Response) => void;
             /** Event handler triggered when a chunk of buffer is received. A buffer object along with a file object is available to the function. */
-            onFileUploadData?: (file: string, data: Buffer, req: Express.Request, res: Express.Response) => void;
+            onFileUploadData?: (file: MulterFile, data: Buffer, req: Express.Request, res: Express.Response) => void;
             /** Event handler trigger when a file is completely uploaded. A file object is available to the function. */
-            onFileUploadComplete?: (file: string, req: Express.Request, res: Express.Response) => void;
+            onFileUploadComplete?: (file: MulterFile, req: Express.Request, res: Express.Response) => void;
             /** Event handler triggered when the form parsing starts. */
             onParseStart?: () => void;
             /** Event handler triggered when the form parsing completes. The request object and the next objects are are passed to the function. */
@@ -81,7 +104,7 @@ declare module "multer" {
             /** Event handler for any errors encountering while processing the form. The error object and the next object is available to the function. If you are handling errors yourself, make sure to terminate the request or call the next() function, else the request will be left hanging. */
             onError?: () => void;
             /** Event handler triggered when a file size exceeds the specification in the limit object. No more files will be parsed after the limit is reached. */
-            onFileSizeLimit?: (file: string) => void;
+            onFileSizeLimit?: (file: MulterFile) => void;
             /** Event handler triggered when the number of files exceed the specification in the limit object. No more files will be parsed after the limit is reached. */
             onFilesLimit?: () => void;
             /** Event handler triggered when the number of fields exceed the specification in the limit object. No more fields will be parsed after the limit is reached. */


### PR DESCRIPTION
The file argument in the arguments is the same type as the files on req.

Unfortunately my Typescript is very limited, I have no idea how to reuse the MulterFile type declaration in the Express module above so I just copied it ...
