### PR TITLE
fix jsdom/jsdom-tests.ts

### DIFF
--- a/jsdom/jsdom-tests.ts
+++ b/jsdom/jsdom-tests.ts
@@ -47,5 +47,4 @@ jsdom.env({
     }
 });
 
-var window: Window = jsdom.jsdom("<div>foobar</div>").parentWindow;
 var document: Document = jsdom.jsdom("<html></html>");


### PR DESCRIPTION
```
jsdom/jsdom-tests.ts(50,55): error TS2339: Property 'parentWindow' does not exist on type 'Document'.
```

https://github.com/tmpvar/jsdom/blob/b547636ab5be043f6b0b53f1208b57616940c7c3/Changelog.md#400
