### PR TITLE
Adds 'default' property to SchedulerStatic interface.

### DIFF
--- a/rx/rx-lite.d.ts
+++ b/rx/rx-lite.d.ts
@@ -150,6 +150,7 @@ declare module Rx {
 
 		immediate: IScheduler;
 		currentThread: ICurrentThreadScheduler;
+                default: IScheduler; // alias for Scheduler.timeout
 		timeout: IScheduler;
 	}
 


### PR DESCRIPTION
**default** is an alias for the, now legacy, **timeout** property on Scheduler.
