### PR TITLE
d3.js cluster links property should return a collection

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -2810,7 +2810,7 @@ declare module d3 {
 
             nodes(root: T): T[];
 
-            links(nodes: T[]): cluster.Link<T>;
+            links(nodes: T[]): cluster.Link<T>[];
 
             children(): (node: T) => T[];
             children(accessor: (node: T) => T[]): Cluster<T>;


### PR DESCRIPTION
The property links of a Cluster should return a collection of Link<Result> as it's directly usable in the data(data: NewDatum[]).
