### PR TITLE
Change event in codemirror also have a `origin` field

### DIFF
--- a/codemirror/codemirror.d.ts
+++ b/codemirror/codemirror.d.ts
@@ -601,6 +601,8 @@ declare module CodeMirror {
         text: string[];
         /**  Text that used to be between from and to, which is overwritten by this change. */
         removed: string;
+        /**  String representing the origin of the change event and wether it can be merged with history */
+        origin: string;
     }
 
     interface EditorChangeLinkedList extends CodeMirror.EditorChange {


### PR DESCRIPTION
It can take different value depending on where it comes from and gover
history merging, various values are `+move` `+insert` `+remove`
`setValue`.
