### PR TITLE
added missing getValue() definition for Rx.BehaviorSubject

### DIFF
--- a/rx/rx.binding-lite.d.ts
+++ b/rx/rx.binding-lite.d.ts
@@ -7,6 +7,7 @@
 
 declare module Rx {
 	export interface BehaviorSubject<T> extends Subject<T> {
+		getValue(): T;
 	}
 
 	interface BehaviorSubjectStatic {


### PR DESCRIPTION
definition for BehaviorSubject getValue method is missing

https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/subjects/behaviorsubject.md#rxbehaviorsubjectprototypegetvalue
