### PR TITLE
Remove addLayer method from mapbox 

### DIFF
--- a/mapbox/mapbox.d.ts
+++ b/mapbox/mapbox.d.ts
@@ -44,7 +44,6 @@ declare module L.mapbox {
 		legendControl : L.mapbox.LegendControl;
 		shareControl  : L.mapbox.ShareControl;
 
-		addLayer(layer: any): any;
 		getTileJSON(): any;
 
 	}


### PR DESCRIPTION
Remove addLayer method from mapbox definition since it is not (or no longer is) in the Mapbox library (v2.2.1) and is shadowing the equivalent function in the Leaflet library.  This can be verified at, https://www.mapbox.com/mapbox.js/api/v2.2.1/l-mapbox-map/
