### PR TITLE
Added slice to Backbone.Collection

### DIFF
--- a/backbone/backbone.d.ts
+++ b/backbone/backbone.d.ts
@@ -247,6 +247,7 @@ declare module Backbone {
         select(iterator: any, context?: any): any[];
         size(): number;
         shuffle(): any[];
+        slice(min: number, max?: number): TModel[];
         some(iterator: (element: TModel, index: number) => boolean, context?: any): boolean;
         sortBy(iterator: (element: TModel, index: number) => number, context?: any): TModel[];
         sortBy(attribute: string, context?: any): TModel[];


### PR DESCRIPTION
Without it, TypeScript throws a type error, stating that `Collection<TModel>` does not have a method called `slice`.
