### PR TITLE
fix 'module not found' error for is_js

### DIFF
--- a/is_js/is_js.d.ts
+++ b/is_js/is_js.d.ts
@@ -1318,6 +1318,6 @@ interface Is extends IsStatic {
 
 declare var is: Is;
 
-declare module 'is' {
+declare module 'is_js' {
     export = is;
 }


### PR DESCRIPTION
According to is_js source module is exported as `is_js` not as `is`
source: https://github.com/arasatasaygin/is.js/blob/master/is.js#L18

Typing in actual state cause 'module not found' error.
