### PR TITLE
Fix "Cannot find name 'DataView'" error

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -12,6 +12,7 @@
 // compat for TypeScript 1.5.3
 // if you use with --target es3 or --target es5 and use below definitions,
 // use the lib.es6.d.ts that is bundled with TypeScript 1.5.3.
+interface DataViewConstructor {}
 interface MapConstructor {}
 interface WeakMapConstructor {}
 interface SetConstructor {}
@@ -265,7 +266,7 @@ declare module NodeJS {
         ArrayBuffer: typeof ArrayBuffer;
         Boolean: typeof Boolean;
         Buffer: typeof Buffer;
-        DataView: typeof DataView;
+        DataView: DataViewConstructor;
         Date: typeof Date;
         Error: typeof Error;
         EvalError: typeof EvalError;


### PR DESCRIPTION
ae21c4da5a27d9c13dfcf5f41b650366cfa05041 fixed `Map`, `WeakMap`, `Set` and `WeakSet` in node.d.ts.  However, `DataView` still has the same issue.

I got below error at using node.d.ts.

```
typings/node/node.d.ts(268, 26): error TS2304: Cannot find name 'DataView'.
```

I fixed `DataView` in the same way as ae21c4da5a27d9c13dfcf5f41b650366cfa05041.
