### PR TITLE
Add Lodash contains/include/includes as chained methods

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -370,15 +370,30 @@ result = <boolean>_.contains([1, 2, 3], 1, 2);
 result = <boolean>_.contains({ 'moe': 30, 'larry': 40, 'curly': 67 }, 40);
 result = <boolean>_.contains('curly', 'ur');
 
+result = <boolean>_([1, 2, 3]).contains(1);
+result = <boolean>_([1, 2, 3]).contains(1, 2);
+result = <boolean>_({ 'moe': 30, 'larry': 40, 'curly': 67 }).contains(40);
+result = <boolean>_('curly').contains('ur');
+
 result = <boolean>_.include([1, 2, 3], 1);
 result = <boolean>_.include([1, 2, 3], 1, 2);
 result = <boolean>_.include({ 'moe': 30, 'larry': 40, 'curly': 67 }, 40);
 result = <boolean>_.include('curly', 'ur');
 
+result = <boolean>_([1, 2, 3]).include(1);
+result = <boolean>_([1, 2, 3]).include(1, 2);
+result = <boolean>_({ 'moe': 30, 'larry': 40, 'curly': 67 }).include(40);
+result = <boolean>_('curly').include('ur');
+
 result = <boolean>_.includes([1, 2, 3], 1);
 result = <boolean>_.includes([1, 2, 3], 1, 2);
 result = <boolean>_.includes({ 'moe': 30, 'larry': 40, 'curly': 67 }, 40);
 result = <boolean>_.includes('curly', 'ur');
+
+result = <boolean>_([1, 2, 3]).includes(1);
+result = <boolean>_([1, 2, 3]).includes(1, 2);
+result = <boolean>_({ 'moe': 30, 'larry': 40, 'curly': 67 }).includes(40);
+result = <boolean>_('curly').includes('ur');
 
 result = <_.Dictionary<number>>_.countBy([4.3, 6.1, 6.4], function (num) { return Math.floor(num); });
 result = <_.Dictionary<number>>_.countBy([4.3, 6.1, 6.4], function (num) { return this.floor(num); }, Math);

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -190,6 +190,8 @@ declare module _ {
 
     interface LoDashWrapper<T> extends LoDashWrapperBase<T, LoDashWrapper<T>> { }
 
+    interface LoDashStringWrapper extends LoDashWrapper<string> { }
+
     interface LoDashObjectWrapper<T> extends LoDashWrapperBase<T, LoDashObjectWrapper<T>> { }
 
     interface LoDashArrayWrapper<T> extends LoDashWrapperBase<T[], LoDashArrayWrapper<T>> {
@@ -2183,7 +2185,7 @@ declare module _ {
         includes<TValue>(target: TValue, fromIndex?: number): boolean;
     }
 
-    interface LoDashStringWrapper extends LoDashWrapper<string> {
+    interface LoDashStringWrapper {
         /**
          * @see _.contains
          **/

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -39,7 +39,7 @@ declare module _ {
         * Explicit chaining can be enabled by using the _.chain method.
         **/
         (value: number): LoDashWrapper<number>;
-        (value: string): LoDashWrapper<string>;
+        (value: string): LoDashStringWrapper;
         (value: boolean): LoDashWrapper<boolean>;
         (value: Array<number>): LoDashNumberArrayWrapper;
         <T>(value: Array<T>): LoDashArrayWrapper<T>;
@@ -2147,6 +2147,57 @@ declare module _ {
             searchString: string,
             targetString: string,
             fromIndex?: number): boolean;
+    }
+
+    interface LoDashArrayWrapper<T> {
+        /**
+         * @see _.contains
+         **/
+        contains(target: T, fromIndex?: number): boolean;
+
+        /**
+         * @see _.contains
+         **/
+        include(target: T, fromIndex?: number): boolean;
+
+        /**
+         * @see _.contains
+         **/
+        includes(target: T, fromIndex?: number): boolean;
+    }
+
+    interface LoDashObjectWrapper<T> {
+        /**
+         * @see _.contains
+         **/
+        contains(target: any, fromIndex?: number): boolean;
+
+        /**
+         * @see _.contains
+         **/
+        include(target: any, fromIndex?: number): boolean;
+
+        /**
+         * @see _.contains
+         **/
+        includes(target: any, fromIndex?: number): boolean;
+    }
+
+    interface LoDashStringWrapper extends LoDashWrapper<string> {
+        /**
+         * @see _.contains
+         **/
+        contains(target: string, fromIndex?: number): boolean;
+
+        /**
+         * @see _.contains
+         **/
+        include(target: string, fromIndex?: number): boolean;
+
+        /**
+         * @see _.contains
+         **/
+        includes(target: string, fromIndex?: number): boolean;
     }
 
     //_.countBy

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -2170,17 +2170,17 @@ declare module _ {
         /**
          * @see _.contains
          **/
-        contains(target: any, fromIndex?: number): boolean;
+        contains<TValue>(target: TValue, fromIndex?: number): boolean;
 
         /**
          * @see _.contains
          **/
-        include(target: any, fromIndex?: number): boolean;
+        include<TValue>(target: TValue, fromIndex?: number): boolean;
 
         /**
          * @see _.contains
          **/
-        includes(target: any, fromIndex?: number): boolean;
+        includes<TValue>(target: TValue, fromIndex?: number): boolean;
     }
 
     interface LoDashStringWrapper extends LoDashWrapper<string> {


### PR DESCRIPTION
The current API allows `_.contains([1,2,3], 1)` (and the equivalent include/includes aliases), but doesn't allow the chained versions: `_([1, 2, 3]).contains(1);`.

This patch fixes that. Note that it adds a new Lodash interface (`LoDashStringWrapper`) because contains is defined over strings but not numbers or booleans (the other two `LoDashWrapper<T>` types).
