### PR TITLE
Change the type of a field in IGridOptions

### DIFF
--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -89,7 +89,7 @@ declare module uiGrid {
     export interface IGridOptions {
         aggregationCalcThrottle?: number;
         appScopeProvider?: ng.IScope;
-        columnDefs?: IColumnDef;
+        columnDefs?: Array<IColumnDef>;
         columnFooterHeight?: number;
         columnVirtualizationThreshold?: number;
         data?: Array<any>;


### PR DESCRIPTION
The type of `columnDefs` field in the IGridOptions is defined as an 'Array of columnDef objects' (http://ui-grid.info/docs/#/api/ui.grid.class:GridOptions). This change reflects this. 
