### PR TITLE
fix request.d.ts CookieJar signature

### DIFF
--- a/request/request-tests.ts
+++ b/request/request-tests.ts
@@ -46,9 +46,9 @@ str = cookie.path;
 str = cookie.toString();
 
 var jar: request.CookieJar;
-jar.add(cookie);
-cookie = jar.get(req);
-str = jar.cookieString(req);
+jar.setCookie(cookie, uri);
+str = jar.getCookieString(uri);
+var cookies: request.Cookie[] = jar.getCookies(uri);
 
 var aws: request.AWSOptions;
 str = aws.secret;

--- a/request/request.d.ts
+++ b/request/request.d.ts
@@ -163,7 +163,7 @@ declare module 'request' {
 		export interface CookieJar {
 			setCookie(cookie: Cookie, uri: string|url.Url, options?: any): void
 			getCookieString(uri: string|url.Url): string
-			getCookies(uri: string|url.Url): Cookies[]
+			getCookies(uri: string|url.Url): Cookie[]
 		}
 
 		export interface CookieValue {

--- a/request/request.d.ts
+++ b/request/request.d.ts
@@ -12,6 +12,7 @@ declare module 'request' {
 	import stream = require('stream');
 	import http = require('http');
 	import FormData = require('form-data');
+	import url = require('url');
 
 	export = RequestAPI;
 
@@ -160,9 +161,9 @@ declare module 'request' {
 		}
 
 		export interface CookieJar {
-			add(cookie: Cookie): void;
-			get(req: Request): Cookie;
-			cookieString(req: Request): string;
+			setCookie(cookie: Cookie, uri: string|url.Url, options?: any): void
+			getCookieString(uri: string|url.Url): string
+			getCookies(uri: string|url.Url): Cookies[]
 		}
 
 		export interface CookieValue {


### PR DESCRIPTION
fixing the CookieJar signature current version describes the underlying tough-cookie api

but it's not the request.CookieJar api https://github.com/request/request/blob/master/lib/cookies.js

made also a pullrequest to the  https://github.com/soywiz/typescript-node-definitions repo
