### PR TITLE
[marked] add missing `renderer?` option on marked

### DIFF
--- a/marked/marked.d.ts
+++ b/marked/marked.d.ts
@@ -64,6 +64,13 @@ interface MarkedStatic {
 
 interface MarkedOptions {
     /**
+     * Type: object Default: new Renderer()
+     *
+     * An object containing functions to render tokens to HTML.
+     */
+    renderer?: Object; 
+
+    /**
      * Enable GitHub flavored markdown.
      */
     gfm?: boolean;


### PR DESCRIPTION
Also the fileformat is dos, with CRLF/^M everywhere, which is also weird. should it be utf-8 / unix ?
