### PR TITLE
Added string to ModelOptions backdrop property.

### DIFF
--- a/bootstrap/bootstrap.d.ts
+++ b/bootstrap/bootstrap.d.ts
@@ -7,7 +7,7 @@
 /// <reference path="../jquery/jquery.d.ts"/>
 
 interface ModalOptions {
-    backdrop?: boolean;
+    backdrop?: boolean|string;
     keyboard?: boolean;
     show?: boolean;
     remote?: string;


### PR DESCRIPTION
The existing interfaces don't allow for the following use of ModelOptions.

```
options = <ModalOptions>{
    backdrop: forceUserInteraction ? "static" : true
};
```
