### PR TITLE
Ui-grid columndefs array

### DIFF
--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -89,7 +89,7 @@ declare module uiGrid {
     export interface IGridOptions {
         aggregationCalcThrottle?: number;
         appScopeProvider?: ng.IScope;
-        columnDefs?: IColumnDef;
+        columnDefs?: Array<IColumnDef>;
         columnFooterHeight?: number;
         columnVirtualizationThreshold?: number;
         data?: Array<any>;


### PR DESCRIPTION
columnDefs (plural) need to be array in gridOptions.
