### PR TITLE
PR to update chai.d.ts to latest chai (chai@3.2.0)

### DIFF
--- a/chai/chai-2.0.0.d.ts
+++ b/chai/chai-2.0.0.d.ts
@@ -1,12 +1,9 @@
-// Type definitions for chai 3.2.0
+// Type definitions for chai 2.0.0
 // Project: http://chaijs.com/
 // Definitions by: Jed Mao <https://github.com/jedmao/>,
 //                 Bart van der Schoor <https://github.com/Bartvds>,
-//                 Andrew Brown <https://github.com/AGBrown>,
-//                 Olivier Chevet <https://github.com/olivr70>
+//                 Andrew Brown <https://github.com/AGBrown>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
-
-// <reference path="../assertion-error/assertion-error.d.ts"/>
 
 declare module Chai {
 
@@ -19,11 +16,9 @@ declare module Chai {
         use(fn: (chai: any, utils: any) => void): any;
         assert: AssertStatic;
         config: Config;
-        AssertionError: AssertionError;
     }
 
     export interface ExpectStatic extends AssertionStatic {
-        fail(actual?: any, expected?: any, message?: string, operator?: string): void;
     }
 
     export interface AssertStatic extends Assert {
@@ -54,20 +49,15 @@ declare module Chai {
     interface Assertion extends LanguageChains, NumericComparison, TypeComparison {
         not: Assertion;
         deep: Deep;
-        any: KeyFilter;
-        all: KeyFilter;
         a: TypeComparison;
         an: TypeComparison;
         include: Include;
-        includes: Include;
         contain: Include;
-        contains: Include;
         ok: Assertion;
         true: Assertion;
         false: Assertion;
         null: Assertion;
         undefined: Assertion;
-        NaN: Assertion;
         exist: Assertion;
         empty: Assertion;
         arguments: Assertion;
@@ -80,35 +70,20 @@ declare module Chai {
         property: Property;
         ownProperty: OwnProperty;
         haveOwnProperty: OwnProperty;
-        ownPropertyDescriptor: OwnPropertyDescriptor;
-        haveOwnPropertyDescriptor: OwnPropertyDescriptor;
         length: Length;
         lengthOf: Length;
-        match: Match;
-        matches: Match;
+        match(regexp: RegExp|string, message?: string): Assertion;
         string(string: string, message?: string): Assertion;
         keys: Keys;
         key(string: string): Assertion;
         throw: Throw;
         throws: Throw;
         Throw: Throw;
-        respondTo: RespondTo;
-        respondsTo: RespondTo;
+        respondTo(method: string, message?: string): Assertion;
         itself: Assertion;
-        satisfy: Satisfy;
-        satisfies: Satisfy;
+        satisfy(matcher: Function, message?: string): Assertion;
         closeTo(expected: number, delta: number, message?: string): Assertion;
         members: Members;
-        increase: PropertyChange;
-        increases: PropertyChange;
-        decrease: PropertyChange;
-        decreases: PropertyChange;
-        change: PropertyChange;
-        changes: PropertyChange;
-        extensible: Assertion;
-        sealed: Assertion;
-        frozen: Assertion;
-
     }
 
     interface LanguageChains {
@@ -159,11 +134,6 @@ declare module Chai {
         equal: Equal;
         include: Include;
         property: Property;
-        members: Members;
-    }
-
-    interface KeyFilter {
-        keys: Keys;
     }
 
     interface Equal {
@@ -178,11 +148,6 @@ declare module Chai {
         (name: string, message?: string): Assertion;
     }
 
-    interface OwnPropertyDescriptor {
-        (name: string, descriptor: PropertyDescriptor, message?: string): Assertion;
-        (name: string, message?: string): Assertion;
-    }
-
     interface Length extends LanguageChains, NumericComparison {
         (length: number, message?: string): Assertion;
     }
@@ -193,18 +158,11 @@ declare module Chai {
         (value: number, message?: string): Assertion;
         keys: Keys;
         members: Members;
-        any: KeyFilter;
-        all: KeyFilter;
-    }
-
-    interface Match {
-        (regexp: RegExp|string, message?: string): Assertion;
     }
 
     interface Keys {
         (...keys: string[]): Assertion;
         (keys: any[]): Assertion;
-        (keys: Object): Assertion;
     }
 
     interface Throw {
@@ -217,20 +175,8 @@ declare module Chai {
         (constructor: Function, expected?: RegExp, message?: string): Assertion;
     }
 
-    interface RespondTo {
-        (method: string, message?: string): Assertion;
-    }
-
-    interface Satisfy {
-        (matcher: Function, message?: string): Assertion;
-    }
-
     interface Members {
         (set: any[], message?: string): Assertion;
-    }
-
-    interface PropertyChange {
-        (object: Object, prop: string, msg?: string): Assertion;
     }
 
     export interface Assert {
@@ -243,9 +189,7 @@ declare module Chai {
         fail(actual?: any, expected?: any, msg?: string, operator?: string): void;
 
         ok(val: any, msg?: string): void;
-        isOk(val: any, msg?: string): void;
         notOk(val: any, msg?: string): void;
-        isNotOk(val: any, msg?: string): void;
 
         equal(act: any, exp: any, msg?: string): void;
         notEqual(act: any, exp: any, msg?: string): void;
@@ -264,12 +208,6 @@ declare module Chai {
 
         isUndefined(val: any, msg?: string): void;
         isDefined(val: any, msg?: string): void;
-
-        isNaN(val: any, msg?: string): void;
-        isNotNaN(val: any, msg?: string): void;
-
-        isAbove(val: number, abv: number, msg?: string): void;
-        isBelow(val: number, blw: number, msg?: string): void;
 
         isFunction(val: any, msg?: string): void;
         isNotFunction(val: any, msg?: string): void;
@@ -341,27 +279,9 @@ declare module Chai {
         closeTo(act: number, exp: number, delta: number, msg?: string): void;
 
         sameMembers(set1: any[], set2: any[], msg?: string): void;
-        sameDeepMembers(set1: any[], set2: any[], msg?: string): void;
-        includeMembers(superset: any[], subset: any[], msg?: string): void;
+        includeMembers(set1: any[], set2: any[], msg?: string): void;
 
         ifError(val: any, msg?: string): void;
-
-        isExtensible(obj: {}, msg?: string): void;
-        extensible(obj: {}, msg?: string): void;
-        isNotExtensible(obj: {}, msg?: string): void;
-        notExtensible(obj: {}, msg?: string): void;
-
-        isSealed(obj: {}, msg?: string): void;
-        sealed(obj: {}, msg?: string): void;
-        isNotSealed(obj: {}, msg?: string): void;
-        notSealed(obj: {}, msg?: string): void;
-
-        isFrozen(obj: Object, msg?: string): void;
-        frozen(obj: Object, msg?: string): void;
-        isNotFrozen(obj: Object, msg?: string): void;
-        notFrozen(obj: Object, msg?: string): void;
-
-
     }
 
     export interface Config {

--- a/chai/chai-tests.ts
+++ b/chai/chai-tests.ts
@@ -31,6 +31,16 @@ function fail() {
     err(() => {
         should.fail('foo', 'bar', 'should fail', 'equal');
     }, 'expected fail to throw an AssertionError');
+
+    err(() => {
+        expect.fail('foo', 'bar');
+    }, 'expected fail to throw an AssertionError');
+    err(() => {
+        expect.fail('foo', 'bar', 'should fail');
+    }, 'expected fail to throw an AssertionError');
+    err(() => {
+        expect.fail('foo', 'bar', 'should fail', 'equal');
+    }, 'expected fail to throw an AssertionError');
 }
 
 // ReSharper disable once InconsistentNaming
@@ -107,11 +117,20 @@ function _undefined() {
     }, 'expected \'\' to be undefined');
 }
 
+function _NaN() {
+    expect(NaN).to.be.NaN;
+    expect(12).to.be.not.NaN;
+    expect("NaN").to.be.not.NaN;
+    (NaN).should.be.NaN;
+    (12).should.be.not.NaN;
+    ("NaN").should.be.not.NaN;
+}
+
 function exist() {
     var foo = 'bar';
     expect(foo).to.exist;
     should.exist(foo);
-    expect(void(0)).to.not.exist;
+    expect(void (0)).to.not.exist;
     should.not.exist(void (0));
 }
 
@@ -128,8 +147,8 @@ function argumentsTest() {
 }
 
 function equal() {
-    expect(undefined).to.equal(void(0));
-    should.equal(undefined, void(0));
+    expect(undefined).to.equal(void (0));
+    should.equal(undefined, void (0));
 }
 
 function _typeof() {
@@ -372,6 +391,9 @@ function match() {
     expect('foobar').to.not.match(/^bar/);
     'foobar'.should.not.match(/^bar/);
 
+    expect('foobar').matches(/^foo/);
+    'foobar'.should.not.matches(/^bar/);
+
     err(() => {
         expect('foobar').to.match(/^bar/i, 'blah');
         'foobar'.should.match(/^bar/i, 'blah');
@@ -490,8 +512,8 @@ function deepEqual3() {
 function deepInclude() {
     expect(['foo', 'bar']).to.deep.include(['bar', 'foo']);
     ['foo', 'bar'].should.deep.include(['bar', 'foo']);
-    expect(['foo', 'bar']).not.to.deep.equal(['foo', 'baz' ]);
-    ['foo', 'bar'].should.not.deep.equal(['foo', 'baz' ]);
+    expect(['foo', 'bar']).not.to.deep.equal(['foo', 'baz']);
+    ['foo', 'bar'].should.not.deep.equal(['foo', 'baz']);
 }
 
 class FakeArgs {
@@ -670,6 +692,20 @@ function ownProperty() {
     }, 'blah: expected { length: 12 } to not have own property \'length\'');
 }
 
+function ownPropertyDescriptor() {
+    expect('test').to.have.ownPropertyDescriptor('length');
+    expect('test').to.have.ownPropertyDescriptor('length', { enumerable: false, configurable: false, writable: false, value: 4 });
+    expect('test').not.to.have.ownPropertyDescriptor('length', { enumerable: false, configurable: false, writable: false, value: 3 });
+    expect('test').to.haveOwnPropertyDescriptor('length').to.have.property('enumerable', false);
+    expect('test').to.haveOwnPropertyDescriptor('length').to.contain.keys('value');
+
+    'test'.should.have.ownPropertyDescriptor('length');
+    'test'.should.have.ownPropertyDescriptor('length', { enumerable: false, configurable: false, writable: false, value: 4 });
+    'test'.should.not.have.ownPropertyDescriptor('length', { enumerable: false, configurable: false, writable: false, value: 3 });
+    'test'.should.haveOwnPropertyDescriptor('length').to.have.property('enumerable', false);
+    'test'.should.haveOwnPropertyDescriptor('length').to.contain.keys('value');
+}
+
 function string() {
     expect('foobar').to.have.string('bar');
     'foobar'.should.have.string('bar');
@@ -707,6 +743,10 @@ function include() {
     ['foo', 'bar'].should.not.include('baz');
     expect(['foo', 'bar']).to.not.include(1);
     ['foo', 'bar'].should.not.include(1);
+    // alias
+
+    expect(['foo', 'bar']).includes('foo');
+    ['foo', 'bar'].should.includes('foo');
 
     err(() => {
         expect(['foo']).to.include('bar', 'blah');
@@ -732,6 +772,14 @@ function keys() {
     ({ foo: 1, bar: 2, baz: 3 }).should.contain.keys('bar', 'foo');
     expect({ foo: 1, bar: 2, baz: 3 }).to.contain.keys('baz');
     ({ foo: 1, bar: 2, baz: 3 }).should.contain.keys('baz');
+    // alias
+
+    expect({ foo: 1, bar: 2, baz: 3 }).contains.keys('baz');
+
+    expect({ foo: 1, bar: 2 }).to.have.all.keys(['foo', 'bar']);
+    expect({ foo: 1, bar: 2 }).to.have.any.keys(['foo', 'bar']);
+    ({ foo: 1, bar: 2, baz: 3 }).should.contain.all.keys('baz');
+    ({ foo: 1, bar: 2, baz: 3 }).should.contain.any.keys('baz');
 
     expect({ foo: 1, bar: 2 }).to.contain.keys('foo');
     ({ foo: 1, bar: 2 }).should.contain.keys('foo');
@@ -830,7 +878,28 @@ function chaining() {
     tea.should.be.a('object').and.have.property('name', 'chai');
 }
 
-class PoorlyConstructedError {}
+function exxtensible() {
+    expect({}).to.be.extensible;
+    expect(Object.preventExtensions({})).to.be.not.extensible;
+    ({}).should.be.extensible;
+    Object.preventExtensions({}).should.not.be.extensible;
+}
+function sealed() {
+    expect({}).to.be.not.sealed;
+    expect(Object.seal({})).to.be.sealed;
+    ({}).should.be.not.sealed;
+    Object.seal({}).should.be.sealed;
+}
+
+function frozen() {
+    expect({}).to.be.not.frozen;
+    expect(Object.freeze({})).to.be.frozen;
+    ({}).should.be.not.frozen;
+    Object.freeze({}).should.be.frozen;
+}
+
+
+class PoorlyConstructedError { }
 function _throw() {
     // See GH-45: some poorly-constructed custom errors don't have useful names
     // on either their constructor or their constructor prototype, but instead
@@ -1023,34 +1092,44 @@ function _throw() {
     }, 'blah: expected [Function] to throw error including \'hello\' but got \'testing\'');
 }
 
-function use(){
+function use() {
     // ReSharper disable once InconsistentNaming
     chai.use((_chai) => {
-      _chai.can.use.any();
+        _chai.can.use.any();
     });
 }
 
+class Klass {
+    val: number;
+    constructor() { this.val = 0; }
+    bar() { }
+
+    static baz() { }
+}
+
 function respondTo() {
-    var bar = {};
+    var obj = new Klass();
 
-    expect(Foo).to.respondTo('bar');
-    Foo.should.respondTo('bar');
-    expect(Foo).to.not.respondTo('foo');
-    Foo.should.not.respondTo('foo');
-    expect(Foo).itself.to.respondTo('func');
-    expect(Foo).itself.not.to.respondTo('bar');
+    expect(Klass).to.respondTo('bar');
+    expect(obj).respondsTo('bar');
+    Klass.should.respondTo('bar');
+    Klass.should.respondsTo('bar');
+    expect(Klass).to.not.respondTo('foo');
+    Klass.should.not.respondTo('foo');
+    expect(Klass).itself.to.respondTo('func');
+    expect(Klass).itself.not.to.respondTo('bar');
 
-    expect(bar).to.respondTo('foo');
-    bar.should.respondTo('foo');
-
-    err(() => {
-        expect(Foo).to.respondTo('baz', 'constructor');
-        Foo.should.respondTo('baz', 'constructor');
-    }, /^(constructor: expected)(.*)(\[Function: Foo\])(.*)(to respond to \'baz\')$/);
+    expect(obj).not.to.respondTo('foo');
+    obj.should.not.respondTo('foo');
 
     err(() => {
-        expect(bar).to.respondTo('baz', 'object');
-        bar.should.respondTo('baz', 'object');
+        expect(Klass).to.respondTo('baz', 'constructor');
+        Klass.should.respondTo('baz', 'constructor');
+    }, /^(constructor: expected)(.*)(\[Function: Klass\])(.*)(to respond to \'baz\')$/);
+
+    err(() => {
+        expect(obj).to.respondTo('baz', 'object');
+        obj.should.respondTo('baz', 'object');
     }, /^(object: expected)(.*)(\{ foo: \[Function\] \}|\{ Object \()(.*)(to respond to \'baz\')$/);
 }
 
@@ -1116,6 +1195,23 @@ function sameMembers() {
     [5, 4].should.not.have.same.members([6, 3]);
     expect([5, 4]).to.not.have.same.members([5, 4, 2]);
     [5, 4].should.not.have.same.members([5, 4, 2]);
+
+    assert.sameMembers([5, 4], [4, 5]);
+}
+function sameDeepMembers() {
+    expect([{ id: 5 }, { id: 4 }]).to.have.same.deep.members([{ id: 4 }, { id: 5 }]);
+    [{ id: 5 }, { id: 4 }].should.have.same.deep.members([{ id: 4 }, { id: 5 }]);
+    expect([{ id: 5 }, { id: 4 }]).to.have.same.members([{ id: 5 }, { id: 4 }]);
+    [{ id: 5 }, { id: 4 }].should.have.same.members([{ id: 5 }, { id: 4 }]);
+
+    expect([{ id: 5 }, { id: 4 }]).to.not.have.same.members([]);
+    [{ id: 5 }, { id: 4 }].should.not.have.same.members([]);
+    expect([{ id: 5 }, { id: 4 }]).to.not.have.same.members([{ id: 6 }, { id: 3 }]);
+    [{ id: 5 }, { id: 4 }].should.not.have.same.members([{ id: 6 }, { id: 3 }]);
+    expect([{ id: 5 }, { id: 4 }]).to.not.have.same.members([{ id: 5 }, { id: 4 }, { id: 2 }]);
+    [{ id: 5 }, { id: 4 }].should.not.have.same.members([{ id: 5 }, { id: 4 }, { id: 2 }]);
+
+    assert.sameDeepMembers([{ id: 5 }, { id: 4 }], [{ id: 4 }, { id: 5 }]);
 }
 
 function members() {
@@ -1127,16 +1223,48 @@ function members() {
     expect([5, 4]).not.members([5, 4, 2]);
 }
 
+function increaseDecreaseChange() {
+    var obj = { val: 10 };
+    var inc = () => { obj.val++; };
+    var dec = () => { obj.val--; };
+    var same = () => { };
+
+    expect(inc).to.increase(obj, "val");
+    expect(inc).increases(obj, "val");
+    expect(inc).to.change(obj, "val");
+
+    expect(dec).to.decrease(obj, "val");
+    expect(dec).decreases(obj, "val");
+    expect(dec).to.change(obj, "val");
+    expect(dec).changes(obj, "val");
+
+    expect(inc).to.not.decrease(obj, "val");
+    expect(dec).to.not.increase(obj, "val");
+    expect(same).to.not.increase(obj, "val");
+    expect(same).to.not.decrease(obj, "val");
+    expect(same).to.not.change(obj, "val");
+
+    inc.should.increase(obj, "val");
+    inc.should.change(obj, "val");
+
+    dec.should.decrease(obj, "val");
+    dec.should.change(obj, "val");
+
+    inc.should.not.decrease(obj, "val");
+    dec.should.not.increase(obj, "val");
+    same.should.not.change(obj, "val");
+}
+
 //tdd
-declare function suite(description: string, action: Function):void;
-declare function test(description: string, action: Function):void;
+declare function suite(description: string, action: Function): void;
+declare function test(description: string, action: Function): void;
 
 interface FieldObj {
     field: any;
 }
 
 class CrashyObject {
-    inspect (): void {
+    inspect(): void {
         throw new Error('Arg\'s inspect() called even though the test passed');
     }
 }
@@ -1172,6 +1300,9 @@ suite('assert', () => {
         assert.ok(true);
         assert.ok(1);
         assert.ok('test');
+        assert.isOk(true);
+        assert.isOk(1);
+        assert.isOk('test');
 
         err(() => {
             assert.ok(false);
@@ -1184,6 +1315,27 @@ suite('assert', () => {
         err(() => {
             assert.ok('');
         }, 'expected \'\' to be truthy');
+    });
+
+    test('notOk', () => {
+        assert.notOk(false);
+        assert.notOk(0);
+        assert.notOk('');
+        assert.isNotOk(false);
+        assert.isNotOk(0);
+        assert.isNotOk('');
+
+        err(() => {
+            assert.notOk(true);
+        }, 'expected true to be falsy');
+
+        err(() => {
+            assert.notOk(1);
+        }, 'expected 1 to be falsy');
+
+        err(() => {
+            assert.notOk('test');
+        }, 'expected \'test\' to be falsy');
     });
 
     test('isFalse', () => {
@@ -1199,7 +1351,7 @@ suite('assert', () => {
     });
 
     test('equal', () => {
-        assert.equal(void(0), undefined);
+        assert.equal(void (0), undefined);
     });
 
     test('typeof / notTypeOf', () => {
@@ -1288,19 +1440,19 @@ suite('assert', () => {
     });
 
     test('deepEqual', () => {
-        assert.deepEqual({tea: 'chai'}, {tea: 'chai'});
+        assert.deepEqual({ tea: 'chai' }, { tea: 'chai' });
 
         err(() => {
-            assert.deepEqual({tea: 'chai'}, {tea: 'black'});
+            assert.deepEqual({ tea: 'chai' }, { tea: 'black' });
         }, 'expected { tea: \'chai\' } to deeply equal { tea: \'black\' }');
 
         var obja = Object.create({ tea: 'chai' })
-        , objb = Object.create({ tea: 'chai' });
+            , objb = Object.create({ tea: 'chai' });
 
         assert.deepEqual(obja, objb);
 
-        var obj1 = Object.create({tea: 'chai'})
-        , obj2 = Object.create({tea: 'black'});
+        var obj1 = Object.create({ tea: 'chai' })
+            , obj2 = Object.create({ tea: 'black' });
 
         err(() => {
             assert.deepEqual(obj1, obj2);
@@ -1309,13 +1461,13 @@ suite('assert', () => {
 
     test('deepEqual (ordering)', () => {
         var a = { a: 'b', c: 'd' }
-        , b = { c: 'd', a: 'b' };
+            , b = { c: 'd', a: 'b' };
         assert.deepEqual(a, b);
     });
 
     test('deepEqual (circular)', () => {
-        var circularObject:any = {}
-        , secondCircularObject:any = {};
+        var circularObject: any = {}
+            , secondCircularObject: any = {};
         circularObject.field = circularObject;
         secondCircularObject.field = secondCircularObject;
 
@@ -1328,15 +1480,15 @@ suite('assert', () => {
     });
 
     test('notDeepEqual', () => {
-        assert.notDeepEqual({tea: 'jasmine'}, {tea: 'chai'});
+        assert.notDeepEqual({ tea: 'jasmine' }, { tea: 'chai' });
         err(() => {
-            assert.notDeepEqual({tea: 'chai'}, {tea: 'chai'});
+            assert.notDeepEqual({ tea: 'chai' }, { tea: 'chai' });
         }, 'expected { tea: \'chai\' } to not deeply equal { tea: \'chai\' }');
     });
 
     test('notDeepEqual (circular)', () => {
-        var circularObject:any = {}
-        , secondCircularObject:any = { tea: 'jasmine' };
+        var circularObject: any = {}
+            , secondCircularObject: any = { tea: 'jasmine' };
         circularObject.field = circularObject;
         secondCircularObject.field = secondCircularObject;
 
@@ -1378,6 +1530,22 @@ suite('assert', () => {
         err(() => {
             assert.isDefined(undefined);
         }, 'expected undefined to not equal undefined');
+    });
+
+    test('isNaN', () => {
+        assert.isNaN(NaN);
+
+        err(() => {
+            assert.isNaN(12);
+        }, 'expected 12 to be NaN');
+    });
+
+    test('isNotNaN', () => {
+        assert.isNotNaN(12);
+
+        err(() => {
+            assert.isNotNaN(NaN);
+        }, 'expected NaN to not NaN');
     });
 
     test('isFunction', () => {
@@ -1431,7 +1599,7 @@ suite('assert', () => {
 
     test('isNotString', () => {
         assert.isNotString(3);
-        assert.isNotString([ 'hello' ]);
+        assert.isNotString(['hello']);
 
         err(() => {
             assert.isNotString('hello');
@@ -1449,7 +1617,7 @@ suite('assert', () => {
 
     test('isNotNumber', () => {
         assert.isNotNumber('hello');
-        assert.isNotNumber([ 5 ]);
+        assert.isNotNumber([5]);
 
         err(() => {
             assert.isNotNumber(4);
@@ -1479,7 +1647,7 @@ suite('assert', () => {
 
     test('include', () => {
         assert.include('foobar', 'bar');
-        assert.include([ 1, 2, 3], 3);
+        assert.include([1, 2, 3], 3);
 
         err(() => {
             assert.include('foobar', 'baz');
@@ -1492,7 +1660,7 @@ suite('assert', () => {
 
     test('notInclude', () => {
         assert.notInclude('foobar', 'baz');
-        assert.notInclude([ 1, 2, 3 ], 4);
+        assert.notInclude([1, 2, 3], 4);
 
         err(() => {
             assert.notInclude('foobar', 'bar');
@@ -1738,5 +1906,43 @@ suite('assert', () => {
             assert.sameMembers([1, 54], [6, 1, 54]);
         }, 'expected [ 1, 54 ] to have the same members as [ 6, 1, 54 ]');
     });
+
+
+    test('isAbove', () => {
+        assert.isAbove(10, 5);
+
+        err(() => {
+            assert.isAbove(1, 5);
+        }, 'expected 1 to be above 5');
+        err(() => {
+            assert.isAbove(5, 5);
+        }, 'expected 5 to be above 5');
+    });
+
+    test('isBelow', () => {
+        assert.isBelow(5, 10);
+
+        err(() => {
+            assert.isBelow(5, 1);
+        }, 'expected 5 to be above 1');
+        err(() => {
+            assert.isBelow(5, 5);
+        }, 'expected 5 to be below 5');
+    });
+
+    test('extensible', () => { assert.extensible({}); });
+    test('isExtensible', () => { assert.isExtensible({}); });
+    test('notExtensible', () => { assert.notExtensible(Object.preventExtensions({})); });
+    test('isNotExtensible', () => { assert.isNotExtensible(Object.preventExtensions({})); });
+
+    test('sealed', () => { assert.sealed(Object.seal({})); });
+    test('isSealed', () => { assert.isSealed(Object.seal({})); });
+    test('notSealed', () => { assert.notSealed({}); });
+    test('isNotSealed', () => { assert.isNotSealed({}); });
+
+    test('frozen', () => { assert.frozen(Object.freeze({})); });
+    test('isFrozen', () => { assert.isFrozen(Object.freeze({})); });
+    test('notFrozen', () => { assert.notFrozen({}); });
+    test('isNotFrozen', () => { assert.isNotFrozen({}); });
 
 });


### PR DESCRIPTION
Hi everyone, 

Chai has changed a lot lately, and many intersting features were missing.

Support added for : all, any, fail, ownPropertyDescriptor, frozen, sealed, extensible, NaN, isAbove, isBelow, sameDeepMembers
Updated some assertions : keys(Object), matches
Added new aliases : contains, includes, isOk, isNotOk

**chai-tests.ts** was updated accordingly.

I also added a subfolder **tests**. It contains effective mocha tests.

To run those tests : 
1. run **setup.sh** once (it npm installs **mocha** and **chai**)
2. run **run.sh** to run the tests (it compiles the TS and invokes mocha)

The problem is that this directory is reported as "typing without test" and the npm test report marks it as failed. 2 options there : 
- just discard this directory (not nécessary for users of chai.d.ts)
  - I think it is a pity not to share this testing code
  - I think dt should not consider a subdirectory a a typing
- make a little change to dt to ignore subfolders

Hope this helps
