### PR TITLE
Fix for AMD require import.

### DIFF
--- a/autobahn/autobahn.d.ts
+++ b/autobahn/autobahn.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../when/when.d.ts" />
-declare module autobahn {
+declare module "autobahn" {
 
     export class Session {
         id: number;


### PR DESCRIPTION
Solves "Cannot find extenal module: autobahn".

Don't ask me why...
