### PR TITLE
request: Add gzip to Options

### DIFF
--- a/request/request.d.ts
+++ b/request/request.d.ts
@@ -85,6 +85,7 @@ declare module 'request' {
 			timeout?: number;
 			proxy?: any;
 			strictSSL?: boolean;
+			gzip?: boolean;
 		}
 
 		export interface RequestPart {


### PR DESCRIPTION
Adding back the `gzip` option to `request`. It disappeared for some reason.
- `gzip` - If `true`, add an `Accept-Encoding` header to request compressed content encodings from the server (if not already present) and decode supported content encodings in the response.  **Note:** Automatic decoding of the response content is performed on the body data returned through `request` (both through the `request` stream and passed to the callback function) but is not performed on the `response` stream (available from the `response` event) which is the unmodified `http.IncomingMessage` object which may contain compressed data. See example below.
