### PR TITLE
standard css properties for react.d.ts

### DIFF
--- a/react/react-global.d.ts
+++ b/react/react-global.d.ts
@@ -392,10 +392,25 @@ declare module React {
         widows?: number;
         zIndex?: number;
         zoom?: number;
-        
-        display?:string;
-        
+        display?: string;
+        width?: string;
+        height?: string;
+        position?: string;
+        overflow?: string;
+        textDecoration?: string;
+        color?: string;
+        marginTop?: number;
+        float?: string;
+        backgroundColor?: string;
+        left?: string | number;
+        top?: string | number;
+        right?: string | number;
+        bottom?:string | number;
+        marginLeft?:string|number;
+        marginRight?:string| number;
+        verticalAlign?: string;
 
+        
         // SVG-related properties
         fillOpacity?: number;
         strokeOpacity?: number;

--- a/react/react-global.d.ts
+++ b/react/react-global.d.ts
@@ -392,6 +392,9 @@ declare module React {
         widows?: number;
         zIndex?: number;
         zoom?: number;
+        
+        display?:string;
+        
 
         // SVG-related properties
         fillOpacity?: number;

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -392,7 +392,23 @@ declare module __React {
         widows?: number;
         zIndex?: number;
         zoom?: number;
-
+        display?: string;
+        width?: string;
+        height?: string;
+        position?: string;
+        overflow?: string;
+        textDecoration?: string;
+        color?: string;
+        marginTop?: number;
+        float?: string;
+        backgroundColor?: string;
+        left?: string | number;
+        top?: string | number;
+        right?: string | number;
+        bottom?:string | number;
+        marginLeft?:string|number;
+        marginRight?:string| number;
+        verticalAlign?: string;
         // SVG-related properties
         fillOpacity?: number;
         strokeOpacity?: number;


### PR DESCRIPTION
i tryed to add style attribute: style={{display: 'block'}}> but CSSProperties not contains 'display'.
As i understand, should populate this interface with snadard css properties?
