### PR TITLE
Partial updates for lodash to 3.10.0

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -221,19 +221,19 @@ result = <number[]>_([1, 2, 3]).head(function (num) {
 result = <IFoodOrganic[]>_(foodsOrganic).head('organic').value();
 result = <IFoodType[]>_(foodsType).head({ 'type': 'fruit' }).value();
 
-result = <number>_.take([1, 2, 3]);
+result = <number[]>_.take([1, 2, 3]);
 result = <number[]>_.take([1, 2, 3], 2);
-result = <number[]>_.take([1, 2, 3], (num) => num < 3);
-result = <IFoodOrganic[]>_.take(foodsOrganic, 'organic');
-result = <IFoodType[]>_.take(foodsType, { 'type': 'fruit' });
+result = <number[]>_.takeWhile([1, 2, 3], (num) => num < 3);
+result = <boolean[]>_.takeWhile(foodsOrganic, 'organic');
+result = <IFoodType[]>_.takeWhile(foodsType, { 'type': 'fruit' });
 
-result = <number>_([1, 2, 3]).take();
+result = <number[]>_([1, 2, 3]).take().value();
 result = <number[]>_([1, 2, 3]).take(2).value();
-result = <number[]>_([1, 2, 3]).take(function (num) {
+result = <number[]>_([1, 2, 3]).takeWhile(function (num) {
     return num < 3;
 }).value();
-result = <IFoodOrganic[]>_(foodsOrganic).take('organic').value();
-result = <IFoodType[]>_(foodsType).take({ 'type': 'fruit' }).value();
+result = <boolean[]>_(foodsType).takeWhile('organic').value();
+result = <IFoodType[]>_(foodsType).takeWhile({ 'type': 'fruit' }).value();
 
 result = <Array<number>>_.flatten([[1, 2], [3, 4]]);
 result = <Array<number>>_.flatten([[1, 2], [3, 4], 5, 6]);
@@ -309,6 +309,8 @@ result = <number>_.sortedIndex(['twenty', 'thirty', 'fifty'], 'fourty', function
 }, sortedIndexDict);
 
 result = <number[]>_.union([1, 2, 3], [101, 2, 1, 10], [2, 1]);
+
+result = <number[]>_([1, 2, 3]).union([101, 2, 1, 10], [2, 1]).value();
 
 result = <number[]>_.uniq([1, 2, 1, 3, 1]);
 result = <number[]>_.uniq([1, 1, 2, 2, 3], true);
@@ -392,6 +394,7 @@ result = <boolean>_.all([true, 1, null, 'yes'], Boolean);
 result = <boolean>_.all(stoogesAges, 'age');
 result = <boolean>_.all(stoogesAges, { 'age': 50 });
 
+result = <number[]>_.filter([1, 2, 3, 4, 5, 6]);
 result = <number[]>_.filter([1, 2, 3, 4, 5, 6], function (num) { return num % 2 == 0; });
 result = <IFoodCombined[]>_.filter(foodsCombined, 'organic');
 result = <IFoodCombined[]>_.filter(foodsCombined, { 'type': 'fruit' });
@@ -654,6 +657,7 @@ result = <string[]>_.sortBy(['banana', 'strawberry', 'apple'], 'length');
 result = <number[]>_([1, 2, 3]).sortBy(function (num) { return Math.sin(num); }).value();
 result = <number[]>_([1, 2, 3]).sortBy(function (num) { return this.sin(num); }, Math).value();
 result = <string[]>_(['banana', 'strawberry', 'apple']).sortBy('length').value();
+result = <IFoodOrganic[]>_(foodsOrganic).sortByAll('organic', (food) => food.name, { organic: true }).value();
 
 (function (a: number, b: number, c: number, d: number): Array<number> { return _.toArray(arguments).slice(1); })(1, 2, 3, 4);
 result = <number[]>_.toArray([1, 2, 3, 4]);

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -615,12 +615,12 @@ declare module _ {
         /**
         * @see _.first
         **/
-        take<T>(array: Array<T>): T;
+        take<T>(array: Array<T>): T[];
 
         /**
         * @see _.first
         **/
-        take<T>(array: List<T>): T;
+        take<T>(array: List<T>): T[];
 
         /**
         * @see _.first
@@ -637,48 +637,36 @@ declare module _ {
             n: number): T[];
 
         /**
-        * @see _.first
-        **/
-        take<T>(
-            array: Array<T>,
-            callback: ListIterator<T, boolean>,
-            thisArg?: any): T[];
-
+         * Takes the first items from an array or list based on a predicate
+         * @param array The array or list of items on which the result set will be based
+         * @param predicate A predicate function to determine whether a value will be taken. Optional; defaults to identity.
+         * @param [thisArg] The this binding of predicate.
+         */
+        takeWhile<T>(
+            array: (Array<T>|List<T>),
+            predicate?: ListIterator<T, boolean>,
+            thisArg?: any 
+        ): T[];
+        
         /**
-        * @see _.first
-        **/
-        take<T>(
-            array: List<T>,
-            callback: ListIterator<T, boolean>,
-            thisArg?: any): T[];
-
+         * Takes the first items from an array or list based on a predicate
+         * @param array The array or list of items on which the result set will be based
+         * @param pluckValue Uses a _.property style callback to return the property value of the given element
+         */
+        takeWhile<T>(
+            array: (Array<T>|List<T>),
+            pluckValue: string
+        ): any[];
+        
         /**
-        * @see _.first
-        **/
-        take<T>(
-            array: Array<T>,
-            pluckValue: string): T[];
-
-        /**
-        * @see _.first
-        **/
-        take<T>(
-            array: List<T>,
-            pluckValue: string): T[];
-
-        /**
-        * @see _.first
-        **/
-        take<W, T>(
-            array: Array<T>,
-            whereValue: W): T[];
-
-        /**
-        * @see _.first
-        **/
-        take<W, T>(
-            array: List<T>,
-            whereValue: W): T[];
+         * Takes the first items from an array or list based on a predicate
+         * @param array The array or list of items on which the result set will be based
+         * @param whereValue Uses a _.matches style callback to return the first elements that match the given value
+         */
+        takeWhile<W, T>(
+            array: (Array<T>|List<T>),
+            whereValue: W
+        ): T[];
     }
 
     interface LoDashArrayWrapper<T> {
@@ -749,7 +737,7 @@ declare module _ {
         /**
         * @see _.first
         **/
-        take(): T;
+        take(): LoDashArrayWrapper<T>;
 
         /**
         * @see _.first
@@ -758,25 +746,28 @@ declare module _ {
         take(n: number): LoDashArrayWrapper<T>;
 
         /**
-        * @see _.first
-        * @param callback The function called per element.
+        * Takes the first items based on a predicate
+        * @param predicate The function called per element.
         * @param [thisArg] The this binding of callback.
         **/
-        take(
-            callback: ListIterator<T, boolean>,
+        takeWhile(
+            predicate: ListIterator<T, boolean>,
             thisArg?: any): LoDashArrayWrapper<T>;
 
         /**
-        * @see _.first
-        * @param pluckValue "_.pluck" style callback value
+        * Takes the first items based on a predicate
+        * @param pluckValue Uses a _.property style callback to return the property value of the given element
         **/
-        take(pluckValue: string): LoDashArrayWrapper<T>;
+        takeWhile<T>(
+            pluckValue: string): LoDashArrayWrapper<any>;
 
         /**
-        * @see _.first
-        * @param whereValue "_.where" style callback value
+        * Takes the first items based on a predicate
+        * @param whereValue Uses a _.matches style callback to return the first elements that match the given value
         **/
-        take<W>(whereValue: W): LoDashArrayWrapper<T>;
+        takeWhile<W, T>(
+            whereValue: W): LoDashArrayWrapper<T>;
+
     }
 
     interface MaybeNestedList<T> extends List<T|List<T>> { }
@@ -1518,6 +1509,13 @@ declare module _ {
         * @see _.union
         **/
         union<T>(...arrays: List<T>[]): T[];
+    }
+    
+    interface LoDashArrayWrapper<T> {
+        /**
+        * @see _.union
+        **/
+        union<T>(...arrays: (Array<T>|List<T>)[]): LoDashArrayWrapper<T>;
     }
 
     //_.uniq
@@ -2429,6 +2427,16 @@ declare module _ {
     interface LoDashStatic {
         /**
         * Iterates over elements of a collection, returning an array of all elements the
+        * identity function returns truey for.
+        * 
+        * @param collection The collection to iterate over.
+        * @return Returns a new array of elements that passed the callback check.
+        **/
+        filter<T>(
+            collection: (Array<T>|List<T>)): T[];
+            
+        /**
+        * Iterates over elements of a collection, returning an array of all elements the
         * callback returns truey for. The callback is bound to thisArg and invoked with three
         * arguments; (value, index|key, collection).
         *
@@ -2585,6 +2593,11 @@ declare module _ {
     }
 
     interface LoDashArrayWrapper<T> {
+        /**
+        * @see _.filter
+        **/
+        filter(): LoDashArrayWrapper<T>;
+            
         /**
         * @see _.filter
         **/
@@ -4805,6 +4818,15 @@ declare module _ {
         sortBy<W, T>(
             collection: List<T>,
             whereValue: W): T[];
+            
+        /**
+         * Sorts by all the given arguments, using either ListIterator, pluckValue, or whereValue foramts
+         * @param args The rules by which to sort
+         */
+        sortByAll<T>(
+            collection: (Array<T>|List<T>),
+            ...args: (ListIterator<T, boolean>|Object|string)[]
+        ): T[];
     }
 
     interface LoDashArrayWrapper<T> {
@@ -4826,6 +4848,12 @@ declare module _ {
         * @param whereValue _.where style callback
         **/
         sortBy<W>(whereValue: W): LoDashArrayWrapper<T>;
+        
+        /**
+         * Sorts by all the given arguments, using either ListIterator, pluckValue, or whereValue foramts
+         * @param args The rules by which to sort
+         */
+        sortByAll(...args: (ListIterator<T, boolean>|Object|string)[]): LoDashArrayWrapper<T>;
     }
 
     //_.toArray


### PR DESCRIPTION
Updates for lodash according to docs and usage:
- [_.take](https://lodash.com/docs#take) no longer accepts predicates
- [_.takeWhile](https://lodash.com/docs#takeWhile) added to accept predicates
- [_.filter](https://lodash.com/docs#filter) can have predicate optional
- [_.union](https://lodash.com/docs#union) is chainable
- [_.sortByAll](https://lodash.com/docs#sortByAll) can accept multiple predicates
