### PR TITLE
[d3] Correct interpolate() signature 

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -2231,8 +2231,7 @@ declare module d3 {
                 interpolate(interpolate: "cardinal-open"): Radial<T>;
                 interpolate(interpolate: "cardinal-closed"): Radial<T>;
                 interpolate(interpolate: "monotone"): Radial<T>;
-                interpolate(interpolate: string): Radial<T>;
-                interpolate(interpolate: (points: Array<[number, number]>) => string): Radial<T>;
+                interpolate(interpolate: string | ((points: Array<[number, number]>) => string)): Radial<T>;
 
                 tension(): number;
                 tension(tension: number): Radial<T>;
@@ -2282,7 +2281,7 @@ declare module d3 {
             interpolate(interpolate: "cardinal"): Area<T>;
             interpolate(interpolate: "cardinal-open"): Area<T>;
             interpolate(interpolate: "monotone"): Area<T>;
-            interpolate(interpolate: string): Area<T>;
+            interpolate(interpolate: string | ((points: Array<[number, number]>) => string)): Area<T>;
 
             tension(): number;
             tension(tension: number): Area<T>;
@@ -2332,8 +2331,7 @@ declare module d3 {
                 interpolate(interpolate: "cardinal"): Radial<T>;
                 interpolate(interpolate: "cardinal-open"): Radial<T>;
                 interpolate(interpolate: "monotone"): Radial<T>;
-                interpolate(interpolate: string): Radial<T>;
-                interpolate(interpolate: (points: Array<[number, number]>) => string): Radial<T>;
+                interpolate(interpolate: string | ((points: Array<[number, number]>) => string)): Radial<T>;
 
                 tension(): number;
                 tension(tension: number): Radial<T>;

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -2193,8 +2193,7 @@ declare module d3 {
             interpolate(interpolate: "cardinal-open"): Line<T>;
             interpolate(interpolate: "cardinal-closed"): Line<T>;
             interpolate(interpolate: "monotone"): Line<T>;
-            interpolate(interpolate: string): Line<T>;
-            interpolate(interpolate: (points: Array<[number, number]>) => string): Line<T>;
+            interpolate(interpolate: string | ((points: Array<[number, number]>) => string)): Line<T>;
 
             tension(): number;
             tension(tension: number): Line<T>;


### PR DESCRIPTION
This code would not have compiled before 

``` typescript
/// <reference path="d3.d.ts" />

var line1 = d3.svg.line().interpolate("step");
var line2 = d3.svg.line().interpolate(line1.interpolate());
```

It compiles now. 

The reason for that is described here 
https://github.com/Microsoft/TypeScript/issues/1805

In short, since the return type of interpolate is the union `string | ((points: Array<[number, number]>) => string)`, that is what the argument should look like as well. Splitting it into overloaded methods does not work until TS#1805 is closed 
