### PR TITLE
Add access to $state.$current.locals.globals

### DIFF
--- a/angular-ui-router/angular-ui-router-tests.ts
+++ b/angular-ui-router/angular-ui-router-tests.ts
@@ -148,6 +148,10 @@ class UrlLocatorTestService implements IUrlLocatorTestService {
         this.$state.get("myState");
         this.$state.get();
         this.$state.reload();
+        
+        // Accesses the currently resolved values for the current state
+        // http://stackoverflow.com/questions/28026620/is-there-a-way-to-access-resolved-state-dependencies-besides-injecting-them-into/28027023#28027023
+        var resolvedValues = this.$state.$current.locals.globals;
     }
 }
 

--- a/angular-ui-router/angular-ui-router.d.ts
+++ b/angular-ui-router/angular-ui-router.d.ts
@@ -169,10 +169,10 @@ declare module angular.ui {
         params: IStateParamsService;
         reload(): void;
         
-        $current: IStateServiceUtilities;
+        $current: IResolvedState;
     }
     
-    interface IStateServiceUtilities {
+    interface IResolvedState {
         locals: {
             /**
              * Currently resolved "resolve" values from the current state

--- a/angular-ui-router/angular-ui-router.d.ts
+++ b/angular-ui-router/angular-ui-router.d.ts
@@ -168,6 +168,17 @@ declare module angular.ui {
         current: IState;
         params: IStateParamsService;
         reload(): void;
+        
+        $current: IStateServiceUtilities;
+    }
+    
+    interface IStateServiceUtilities {
+        locals: {
+            /**
+             * Currently resolved "resolve" values from the current state
+             */
+            globals: { [key: string]: any; };
+        };
     }
 
     interface IStateParamsService {


### PR DESCRIPTION
Provides access to currently-resolved values based on the current state.  See [Stack Overflow - Is there a way to access resolved state dependencies besides injecting them into the controller?](http://stackoverflow.com/a/28027023/195653) for details.
