### PR TITLE
Add options parameter to form-data append method

### DIFF
--- a/form-data/form-data.d.ts
+++ b/form-data/form-data.d.ts
@@ -7,7 +7,7 @@
 
 declare module "form-data" {
 	export class FormData {
-		append(key: string, value: any): FormData;
+		append(key: string, value: any, options?: any): FormData;
 		getHeaders(): Object;
 		// TODO expand pipe
 		pipe(to: any): any;


### PR DESCRIPTION
The `append` method in `form-data` library optionally supports the third parameter, `options`. (https://github.com/form-data/node-form-data/blob/master/lib/form_data.js#L24). It can be a string or an object, so `any` type is most suitable for it.
