### PR TITLE
Updated return type for RequestPromiseAPI.Options.

### DIFF
--- a/request-promise/request-promise.d.ts
+++ b/request-promise/request-promise.d.ts
@@ -22,7 +22,7 @@ declare module 'request-promise' {
     module RequestPromiseAPI {
         export interface Options extends request.Options {
             simple?: boolean;
-            transform?: (body: any, response: http.IncomingMessage) => number;
+            transform?: (body: any, response: http.IncomingMessage) => any;
             resolveWithFullResponse?: boolean;
         }
     }


### PR DESCRIPTION
Updated the return type for method 'transform' of Options object, previously this had a return type of number.
