### PR TITLE
Added unref() to child_process.ChildProcess in node.d.ts

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -823,6 +823,7 @@ declare module "child_process" {
         kill(signal?: string): void;
         send(message: any, sendHandle?: any): void;
         disconnect(): void;
+        unref(): void;
     }
 
     export function spawn(command: string, args?: string[], options?: {


### PR DESCRIPTION
`child_process.ChildProcess.unref()` isn't described in document.
But it actually exist and is described in document for `options.detached` of `child_process.spawn()`.

https://nodejs.org/api/child_process.html#child_process_options_detached

So I added `unref()` to `ChildProcess` class.
