### PR TITLE
Add definitions for electron-prebuilt package

### DIFF
--- a/github-electron/electron-prebuilt-tests.ts
+++ b/github-electron/electron-prebuilt-tests.ts
@@ -1,0 +1,7 @@
+/// <reference path="electron-prebuilt.d.ts" />
+/// <reference path="../node/node.d.ts" />
+
+import electron = require('electron-prebuilt');
+import child_process = require('child_process');
+
+child_process.spawn(electron);

--- a/github-electron/electron-prebuilt.d.ts
+++ b/github-electron/electron-prebuilt.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for electron-prebuilt 0.30.1
+// Project: https://github.com/mafintosh/electron-prebuilt
+// Definitions by: rhysd <https://github.com/rhysd>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module 'electron-prebuilt' {
+	var electron: string;
+	export = electron;
+}
+


### PR DESCRIPTION
I added definitions for API of electron-prebuilt package.
There is already a directory for GitHub Electron.  So I added electron-prebuilt.d.ts to it.  If I should add new `electron-prebuilt` directory, please let me know that.
