### PR TITLE
Fix definition of `google.maps.GeocoderRequest()`

### DIFF
--- a/googlemaps/google.maps.d.ts
+++ b/googlemaps/google.maps.d.ts
@@ -820,7 +820,7 @@ declare module google.maps {
     export interface GeocoderRequest {
         address?: string;
         bounds?: LatLngBounds;
-        componentRestrictions: GeocoderComponentRestrictions;
+        componentRestrictions?: GeocoderComponentRestrictions;
         location?: LatLng|LatLngLiteral;
         region?: string;
     }


### PR DESCRIPTION
Fixes #4364.
