### PR TITLE
github-electron: Adding all available options to the BrowserWindowOptions interface

### DIFF
--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -456,8 +456,53 @@ declare module GitHubElectron {
 		isVisibleOnAllWorkspaces(): boolean;
 	}
 
+	// Includes all options BrowserWindow can take as of this writing
+	// http://electron.atom.io/docs/v0.29.0/api/browser-window/
 	interface BrowserWindowOptions extends Rectangle {
 		show?: boolean;
+		'use-content-size'?: boolean;
+		center?: boolean;
+		'min-width'?: number;
+		'min-height'?: number;
+		'max-width'?: number;
+		'max-height'?: number;
+		resizable?: boolean;
+		'always-on-top'?: boolean;
+		fullscreen?: boolean;
+		'skip-taskbar'?: boolean;
+		'zoom-factor'?: number;
+		kiosk?: boolean;
+		title?: string;
+		icon?: NativeImage;
+		frame?: boolean;
+		'node-integration'?: boolean;
+		'accept-first-mouse'?: boolean;
+		'disable-auto-hide-cursor'?: boolean;
+		'auto-hide-menu-bar'?: boolean;
+		'enable-larger-than-screen'?: boolean;
+		'dark-theme'?: boolean;
+		preload?: string;
+		transparent?: boolean;
+		type?: string;
+		'standard-window'?: boolean;
+		'web-preferences'?: any; // Object
+		javascript?: boolean;
+		'web-security'?: boolean;
+		images?: boolean;
+		java?: boolean;
+		'text-areas-are-resizable'?: boolean;
+		webgl?: boolean;
+		webaudio?: boolean;
+		plugins?: boolean;
+		'extra-plugin-dirs'?: string[];
+		'experimental-features'?: boolean;
+		'experimental-canvas-features'?: boolean;
+		'subpixel-font-scaling'?: boolean;
+		'overlay-scrollbars'?: boolean;
+		'overlay-fullscreen-video'?: boolean;
+		'shared-worker'?: boolean;
+		'direct-write'?: boolean;
+		'page-visibility'?: boolean;
 	}
 
 	interface Rectangle {

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -473,7 +473,7 @@ declare module GitHubElectron {
 		'zoom-factor'?: number;
 		kiosk?: boolean;
 		title?: string;
-		icon?: NativeImage;
+		icon?: NativeImage|string;
 		frame?: boolean;
 		'node-integration'?: boolean;
 		'accept-first-mouse'?: boolean;


### PR DESCRIPTION
Added all currently available options to a new BrowserWindow in github's electron.
API here: http://electron.atom.io/docs/v0.29.0/api/browser-window/
