### PR TITLE
React: Added attributes 'width' and 'height' to SVGAttributes for Rect.

### DIFF
--- a/react/react-addons.d.ts
+++ b/react/react-addons.d.ts
@@ -518,9 +518,7 @@ declare module "react/addons" {
         unselectable?: boolean;
     }
 
-    interface SVGAttributes extends DOMAttributes {
-        ref?: string | ((component: SVGComponent) => void);
-
+    interface SVGAttributes extends HTMLAttributes {
         cx?: number | string;
         cy?: number | string;
         d?: string;
@@ -1048,4 +1046,3 @@ declare module "react/addons" {
         identifiedTouch(identifier: number): Touch;
     }
 }
-

--- a/react/react-addons.d.ts
+++ b/react/react-addons.d.ts
@@ -518,7 +518,9 @@ declare module "react/addons" {
         unselectable?: boolean;
     }
 
-    interface SVGAttributes extends HTMLAttributes {
+    interface SVGAttributes extends DOMAttributes {
+        ref?: string | ((component: SVGComponent) => void);
+
         cx?: number | string;
         cy?: number | string;
         d?: string;
@@ -532,6 +534,7 @@ declare module "react/addons" {
         fy?: number | string;
         gradientTransform?: string;
         gradientUnits?: string;
+        height?: number | string;
         markerEnd?: string;
         markerMid?: string;
         markerStart?: string;
@@ -556,6 +559,7 @@ declare module "react/addons" {
         transform?: string;
         version?: string;
         viewBox?: string;
+        width?: number | string;
         x1?: number | string;
         x2?: number | string;
         x?: number | string;

--- a/react/react-global.d.ts
+++ b/react/react-global.d.ts
@@ -524,9 +524,7 @@ declare module React {
         preserveAspectRatio?: string;
     }
 
-    interface SVGAttributes extends DOMAttributes {
-        ref?: string | ((component: SVGComponent) => void);
-
+    interface SVGAttributes extends HTMLAttributes {
         cx?: number | string;
         cy?: number | string;
         d?: string;

--- a/react/react-global.d.ts
+++ b/react/react-global.d.ts
@@ -524,7 +524,9 @@ declare module React {
         preserveAspectRatio?: string;
     }
 
-    interface SVGAttributes extends HTMLAttributes {
+    interface SVGAttributes extends DOMAttributes {
+        ref?: string | ((component: SVGComponent) => void);
+
         cx?: number | string;
         cy?: number | string;
         d?: string;
@@ -538,6 +540,7 @@ declare module React {
         fy?: number | string;
         gradientTransform?: string;
         gradientUnits?: string;
+        height?: number | string;
         markerEnd?: string;
         markerMid?: string;
         markerStart?: string;
@@ -562,6 +565,7 @@ declare module React {
         transform?: string;
         version?: string;
         viewBox?: string;
+        width?: number | string;
         x1?: number | string;
         x2?: number | string;
         x?: number | string;

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -524,7 +524,9 @@ declare module __React {
         preserveAspectRatio?: string;
     }
 
-    interface SVGAttributes extends HTMLAttributes {
+    interface SVGAttributes extends DOMAttributes {
+        ref?: string | ((component: SVGComponent) => void);
+
         cx?: number | string;
         cy?: number | string;
         d?: string;
@@ -538,6 +540,7 @@ declare module __React {
         fy?: number | string;
         gradientTransform?: string;
         gradientUnits?: string;
+        height?: number | string;
         markerEnd?: string;
         markerMid?: string;
         markerStart?: string;
@@ -562,6 +565,7 @@ declare module __React {
         transform?: string;
         version?: string;
         viewBox?: string;
+        width?: number | string;
         x1?: number | string;
         x2?: number | string;
         x?: number | string;

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -524,9 +524,7 @@ declare module __React {
         preserveAspectRatio?: string;
     }
 
-    interface SVGAttributes extends DOMAttributes {
-        ref?: string | ((component: SVGComponent) => void);
-
+    interface SVGAttributes extends HTMLAttributes {
         cx?: number | string;
         cy?: number | string;
         d?: string;
@@ -540,7 +538,6 @@ declare module __React {
         fy?: number | string;
         gradientTransform?: string;
         gradientUnits?: string;
-        height?: number | string;
         markerEnd?: string;
         markerMid?: string;
         markerStart?: string;
@@ -565,7 +562,6 @@ declare module __React {
         transform?: string;
         version?: string;
         viewBox?: string;
-        width?: number | string;
         x1?: number | string;
         x2?: number | string;
         x?: number | string;

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -540,6 +540,7 @@ declare module __React {
         fy?: number | string;
         gradientTransform?: string;
         gradientUnits?: string;
+        height?: number | string;
         markerEnd?: string;
         markerMid?: string;
         markerStart?: string;
@@ -564,6 +565,7 @@ declare module __React {
         transform?: string;
         version?: string;
         viewBox?: string;
+        width?: number | string;
         x1?: number | string;
         x2?: number | string;
         x?: number | string;


### PR DESCRIPTION
Without these attributes, it becomes an error when compiling tsx including the rect element.

> error TS2339: Property 'height' does not exist on type 'SVGAttributes'.
> error TS2339: Property 'width' does not exist on type 'SVGAttributes'.

These are not supported on the [document](http://facebook.github.io/react/docs/tags-and-attributes.html).
But it seems to work in the definition of HTMLDOMPropertyConfig.
