### PR TITLE
Added trailing semicolon to Bloodhound constructor.

### DIFF
--- a/typeahead/typeahead.d.ts
+++ b/typeahead/typeahead.d.ts
@@ -352,7 +352,7 @@ declare module Bloodhound
 }
 
 declare class Bloodhound<T> {
-  constructor(options: Bloodhound.BloodhoundOptions<T>)
+  constructor(options: Bloodhound.BloodhoundOptions<T>);
   /**
   * wraps the suggestion engine in an adapter that is compatible with the typeahead jQuery plugin
   */


### PR DESCRIPTION
Typescript 1.5.3 compiler flags the constructor's lack of a trailing semicolon.
