### PR TITLE
Make Chome API event.hasListener return a boolean

### DIFF
--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -869,7 +869,7 @@ declare module chrome.events {
         addListener(callback: Function): void;
         getRules(callback: (rules: Rule[]) => void): void;
         getRules(ruleIdentifiers: string[], callback: (rules: Rule[]) => void): void;
-        hasListener(callback: Function): void;
+        hasListener(callback: Function): boolean;
         removeRules(ruleIdentifiers?: string[], callback?: Function): void;
         addRules(rules: Rule[], callback?: (rules: Rule[]) => void): void;
         removeListener(callback: Function): void;


### PR DESCRIPTION
Tiny fix: Chrome's `hasListener(listener)` method was marked as returning `void`, but it actually returns a boolean.

See https://developer.chrome.com/extensions/events#method-Event-hasListener for reference.
