### PR TITLE
[esprima] adds esprima.Syntax object with constants

### DIFF
--- a/esprima/esprima.d.ts
+++ b/esprima/esprima.d.ts
@@ -6,29 +6,99 @@
 /// <reference path="../estree/estree.d.ts" />
 
 declare module esprima {
-    var version: string
-    function parse(code: string, options?: Options): ESTree.Program
-    function tokenize(code: string, options?: Options): Array<Token>
+
+    const version: string;
+
+    function parse(code: string, options?: Options): ESTree.Program;
+    function tokenize(code: string, options?: Options): Array<Token>;
 
     interface Token {
-        type: string
-        value: string
+        type: string;
+        value: string;
     }
 
     interface Comment extends ESTree.Node {
-        value: string
+        value: string;
     }
 
     interface Options {
-        loc?: boolean
-        range?: boolean
-        raw?: boolean
-        tokens?: boolean
-        comment?: boolean
-        attachComment?: boolean
-        tolerant?: boolean
-        source?: boolean
+        loc?: boolean;
+        range?: boolean;
+        raw?: boolean;
+        tokens?: boolean;
+        comment?: boolean;
+        attachComment?: boolean;
+        tolerant?: boolean;
+        source?: boolean;
     }
+
+    const Syntax: {
+        AssignmentExpression: string,
+        AssignmentPattern: string,
+        ArrayExpression: string,
+        ArrayPattern: string,
+        ArrowFunctionExpression: string,
+        BlockStatement: string,
+        BinaryExpression: string,
+        BreakStatement: string,
+        CallExpression: string,
+        CatchClause: string,
+        ClassBody: string,
+        ClassDeclaration: string,
+        ClassExpression: string,
+        ConditionalExpression: string,
+        ContinueStatement: string,
+        DoWhileStatement: string,
+        DebuggerStatement: string,
+        EmptyStatement: string,
+        ExportAllDeclaration: string,
+        ExportDefaultDeclaration: string,
+        ExportNamedDeclaration: string,
+        ExportSpecifier: string,
+        ExpressionStatement: string,
+        ForStatement: string,
+        ForOfStatement: string,
+        ForInStatement: string,
+        FunctionDeclaration: string,
+        FunctionExpression: string,
+        Identifier: string,
+        IfStatement: string,
+        ImportDeclaration: string,
+        ImportDefaultSpecifier: string,
+        ImportNamespaceSpecifier: string,
+        ImportSpecifier: string,
+        Literal: string,
+        LabeledStatement: string,
+        LogicalExpression: string,
+        MemberExpression: string,
+        MethodDefinition: string,
+        NewExpression: string,
+        ObjectExpression: string,
+        ObjectPattern: string,
+        Program: string,
+        Property: string,
+        RestElement: string,
+        ReturnStatement: string,
+        SequenceExpression: string,
+        SpreadElement: string,
+        Super: string,
+        SwitchCase: string,
+        SwitchStatement: string,
+        TaggedTemplateExpression: string,
+        TemplateElement: string,
+        TemplateLiteral: string,
+        ThisExpression: string,
+        ThrowStatement: string,
+        TryStatement: string,
+        UnaryExpression: string,
+        UpdateExpression: string,
+        VariableDeclaration: string,
+        VariableDeclarator: string,
+        WhileStatement: string,
+        WithStatement: string,
+        YieldExpression: string
+    };
+
 }
 
 declare module "esprima" {


### PR DESCRIPTION
See:
https://github.com/jquery/esprima/blob/master/esprima.js#L107
https://github.com/jquery/esprima/blob/master/esprima.js#L5616

The exported `Syntax`was not exposed in the type definition. Also bumped version to "2.4.1" since that is the latest released version (July 1).

Also corrected some code style issues, since the file was missing a few semicolons.
