### PR TITLE
Added an override for support for jQuery

### DIFF
--- a/jquery.gridster/gridster.d.ts
+++ b/jquery.gridster/gridster.d.ts
@@ -214,6 +214,16 @@ interface Gridster {
 	remove_widget(el: HTMLElement, callback: (el: HTMLElement) => void): Gridster;
 
 	/**
+	* @see remove_widget
+	**/
+	remove_widget(el: JQuery, silent?: boolean, callback?: (el: HTMLElement) => void): Gridster;
+
+	/**
+	* @see remove_widget
+	**/
+	remove_widget(el: JQuery, callback: (el: HTMLElement) => void): Gridster;
+
+	/**
 	* Returns a serialized array of the widgets in the grid.
 	* @param $widgets The collection of jQuery wrap ed HTMLElements you want to serialize.  If no argument is passed a l widgets will be serialized.
 	* @return Returns an array of objects with the data specified in the serialized_params option.

--- a/jquery.gridster/gridster.d.ts
+++ b/jquery.gridster/gridster.d.ts
@@ -185,6 +185,11 @@ interface Gridster {
 	add_widget(html: HTMLElement, size_x?: number, size_y?: number, col?: number, row?: number): JQuery;
 
 	/**
+	* @see add_widget
+	**/
+	add_widget(html: JQuery, size_x?: number, size_y?: number, col?: number, row?: number): JQuery;
+
+	/**
 	* Change the size of a widget.
 	* @param $widget The jQuery wrapped HTMLElement that represents the widget is going to be resized.
 	* @param size_x The number of rows that the widget is going to span.  Defaults to current size_x.


### PR DESCRIPTION
Gridster's `add_widget` ultimately passes on the first parameter to jQuery, and jQuery accepts either a string, a DOM element, or a jQuery object.

`add_widget`'s first parameter should reflect what jQuery supports.
