### PR TITLE
Update definitions and tests for yamljs

### DIFF
--- a/yamljs/yamljs-tests.ts
+++ b/yamljs/yamljs-tests.ts
@@ -1,7 +1,13 @@
 /// <reference path="yamljs.d.ts" />
 
-var yamlObj = YAML.parse("test: some yaml");
+import yamljs = require('yamljs');
 
-YAML.stringify(yamlObj);
+yamljs.load('yaml-testfile.yml');
 
-YAML.load("path/to/file.yaml");
+yamljs.parse('this_is_no_ymlstring');
+
+yamljs.stringify({ a : 'val', b : { ba : 123, bb : 'nothing' }});
+
+yamljs.stringify({ a : 'val', b : { ba : 123, bb : 'nothing' }}, 1);
+
+yamljs.stringify({ a : 'val', b : { ba : 123, bb : 'nothing' }}, 1, 2);

--- a/yamljs/yamljs-tests.ts
+++ b/yamljs/yamljs-tests.ts
@@ -1,13 +1,7 @@
 /// <reference path="yamljs.d.ts" />
 
-import yamljs = require('yamljs');
+var yamlObj = YAML.parse("test: some yaml");
 
-yamljs.load('yaml-testfile.yml');
+YAML.stringify(yamlObj);
 
-yamljs.parse('this_is_no_ymlstring');
-
-yamljs.stringify({ a : 'val', b : { ba : 123, bb : 'nothing' }});
-
-yamljs.stringify({ a : 'val', b : { ba : 123, bb : 'nothing' }}, 1);
-
-yamljs.stringify({ a : 'val', b : { ba : 123, bb : 'nothing' }}, 1, 2);
+YAML.load("path/to/file.yaml");

--- a/yamljs/yamljs.d.ts
+++ b/yamljs/yamljs.d.ts
@@ -1,9 +1,9 @@
-// Type definitions for yamljs 0.2.1
+// Type definitions for yamljs 0.2.3
 // Project: https://github.com/jeremyfa/yaml.js
 // Definitions by: Tim Jonischkat <http://www.tim-jonischkat.de>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare module "yamljs" {
+declare module YAML {
 
     export function load(path : string) : any;
 

--- a/yamljs/yamljs.d.ts
+++ b/yamljs/yamljs.d.ts
@@ -3,12 +3,14 @@
 // Definitions by: Tim Jonischkat <http://www.tim-jonischkat.de>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare module YAML {
+declare var YAML: {
+    load(path : string) : any;
 
-    export function load(path : string) : any;
+    stringify(nativeObject : any, inline? : number, spaces? : number) : string;
 
-    export function stringify(nativeObject : any, inline? : number, spaces? : number) : string;
+    parse(yamlString : string) : any;
+};
 
-    export function parse(yamlString : string) : any;
-
+declare module "yamljs" {
+    export = YAML;
 }


### PR DESCRIPTION
The definitions for yamljs do not work. The library provides window.YAML but the existing definition declares the module as "yamljs". Obviously this doesn't work when attempting to use the d.ts in a project. I've updated the module name so that the library can be used.
