### PR TITLE
chrome: `url` property of QueryInfo can be a array of strings

### DIFF
--- a/chrome/chrome-tests.ts
+++ b/chrome/chrome-tests.ts
@@ -197,3 +197,55 @@ function proxySettings() {
     // clear with a scope set
     chrome.proxy.settings.clear({ scope: 'regular' });
 }
+
+// https://developer.chrome.com/extensions/examples/api/contentSettings/popup.js
+function contentSettings() {
+  var incognito;
+  var url;
+
+  function settingChanged() {
+    var type = this.id;
+    var setting = this.value;
+    var pattern = /^file:/.test(url) ? url : url.replace(/\/[^\/]*?$/, '/*');
+    console.log(type+' setting for '+pattern+': '+setting);
+    // HACK: [type] is not recognised by the docserver's sample crawler, so
+    // mention an explicit
+    // type: chrome.contentSettings.cookies.set - See http://crbug.com/299634
+    chrome.contentSettings[type].set({
+          'primaryPattern': pattern,
+          'setting': setting,
+          'scope': (incognito ? 'incognito_session_only' : 'regular')
+        });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    chrome.tabs.query({active: true, currentWindow: true, url: ['http://*/*', 'https://*/*'] }, function(tabs) {
+      var current = tabs[0];
+      incognito = current.incognito;
+      url = current.url;
+      var types = ['cookies', 'images', 'javascript', 'location', 'plugins',
+                   'popups', 'notifications', 'fullscreen', 'mouselock',
+                   'microphone', 'camera', 'unsandboxedPlugins',
+                   'automaticDownloads'];
+      types.forEach(function(type) {
+        // HACK: [type] is not recognised by the docserver's sample crawler, so
+        // mention an explicit
+        // type: chrome.contentSettings.cookies.get - See http://crbug.com/299634
+        chrome.contentSettings[type] && chrome.contentSettings[type].get({
+              'primaryUrl': url,
+              'incognito': incognito
+            },
+            function(details) {
+              var input = <HTMLInputElement>document.getElementById(type);
+              input.disabled = false;
+              input.value = details.setting;
+            });
+      });
+    });
+
+    var selects = document.querySelectorAll('select');
+    for (var i = 0; i < selects.length; i++) {
+      selects[i].addEventListener('change', settingChanged);
+    }
+  });
+}

--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -1900,7 +1900,7 @@ declare module chrome.tabs {
         active?: boolean;
         index?: number;
         title?: string;
-        url?: string;
+        url?: string | string[];
         currentWindow?: boolean;
         highlighted?: boolean;
         pinned?: boolean;


### PR DESCRIPTION
refs. https://developer.chrome.com/extensions/tabs#method-query

Now `url` property of  `chrome.tabs.QueryInfo` can be an array of URL strings (or an URL string).
