### PR TITLE
Postal.js v1.0.6

### DIFF
--- a/postal/postal-0.8.9.d.ts
+++ b/postal/postal-0.8.9.d.ts
@@ -1,0 +1,71 @@
+// Type definitions for Postal v0.8.9
+// Project: https://github.com/postaljs/postal.js
+// Definitions by: Lokesh Peta <https://github.com/lokeshpeta/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../underscore/underscore.d.ts" />
+
+interface IConfiguration{
+	SYSTEM_CHANNEL: string;
+	DEFAULT_CHANNEL: string;
+	resolver: any;
+}
+
+interface ISubscriptionDefinition{
+	unsubscribe(): void;
+	subscribe(callback: (data: any, envelope: IEnvelope)=> void): void;
+	defer():ISubscriptionDefinition;
+	disposeAfter(maxCalls: number): ISubscriptionDefinition;
+	distinctUntilChanged(): ISubscriptionDefinition;
+	once(): ISubscriptionDefinition;
+	withConstraint(predicate: Function): ISubscriptionDefinition;
+	withConstraints(predicates: Array<Function>): ISubscriptionDefinition;
+	
+	withContext(context: any): ISubscriptionDefinition;
+	withDebounce(milliseconds: number, immediate: boolean ): ISubscriptionDefinition;
+	withDelay(milliseconds: number): ISubscriptionDefinition;
+	withThrottle(milliseconds: number): ISubscriptionDefinition;
+}
+
+interface IEnvelope{
+	topic: string;
+	data?: any;
+
+	/*Uses DEFAULT_CHANNEL if no channel is provided*/
+	channel?: string;
+
+	timeStamp?: string;
+}
+
+
+interface IChannelDefinition {
+	subscribe(topic: string): ISubscriptionDefinition;
+	subscribe(topic: string, callback: (data: any, envelope: IEnvelope)=> void): ISubscriptionDefinition;
+
+	publish(topic: string, data?: any): void;
+	publish(envelope: IEnvelope): void;
+
+	channel: string;
+}
+
+interface IPostalUtils{
+	getSubscribersFor(channel: string, tpc: any): any;
+	reset(): void;
+}
+
+interface IPostal {
+	channel(name?:string): IChannelDefinition;
+	
+	linkChannels(sources: IEnvelope | IEnvelope[], destinations:  IEnvelope | IEnvelope[]): ISubscriptionDefinition[];
+	
+	utils: IPostalUtils;
+
+	configuration: IConfiguration;
+}
+
+declare var postal: IPostal;
+
+declare module "postal" {
+    var postal: IPostal;
+    export = postal;
+}


### PR DESCRIPTION
Updated definitions for [`postal`](https://github.com/borisyankov/DefinitelyTyped/tree/master/postal), bringing it up-to-date with [`v1.0.6`](https://github.com/postaljs/postal.js/releases/tag/v1.0.6). 

Retain support for the existing [`v0.8.9`](https://github.com/borisyankov/DefinitelyTyped/blob/c40afe52fbf8575a85f0dd88589d579f64793e9d/postal/postal.d.ts) by renaming the current `postal.d.ts` to a versioned filename.

Tests remain as is.

cc @lokeshpeta who previously updated this definition
