### PR TITLE
Restangular: ICollection extends Array to inherit splice and indexOf

### DIFF
--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -115,13 +115,13 @@ declare module restangular {
     patch(queryParams?: any, headers?: any): IPromise<any>;
     clone(): IElement;
     plain(): any;
-	plain<T>(): T;
+    plain<T>(): T;
     withHttpConfig(httpConfig: IRequestConfig): IElement;
     save(queryParams?: any, headers?: any): IPromise<any>;
     getRestangularUrl(): string;
   }
 
-  interface ICollection extends IService {
+  interface ICollection extends IService, Array<any> {
     getList(queryParams?: any, headers?: any): ICollectionPromise<any>;
     getList<T>(queryParams?: any, headers?: any): ICollectionPromise<T>;
     post(elementToPost: any, queryParams?: any, headers?: any): IPromise<any>;
@@ -132,9 +132,9 @@ declare module restangular {
     patch(queryParams?: any, headers?: any): IPromise<any>;
     putElement(idx: any, params: any, headers: any): IPromise<any>;
     withHttpConfig(httpConfig: IRequestConfig): ICollection;
-	clone(): ICollection;
+    clone(): ICollection;
     plain(): any;
-	plain<T>(): T[];
+    plain<T>(): T[];
     getRestangularUrl(): string;
   }
 }


### PR DESCRIPTION
If you want to remove an object from a list of objects, you can do something like `things.remove(thingId)`.
If you don't want to reload all things, you probably want to remove this remotely deleted object also from your local collection. Afaik this isn't possible, because ICollection doesn't extend Array, so following snippet wouldn't work.

``` javascript
things.splice(things.indexOf(thing), 1);
```
