### PR TITLE
React: Include required render() function in base React.Component class.

### DIFF
--- a/react/react-global.d.ts
+++ b/react/react-global.d.ts
@@ -136,6 +136,7 @@ declare module React {
         setState(f: (prevState: S, props: P) => S, callback?: () => any): void;
         setState(state: S, callback?: () => any): void;
         forceUpdate(): void;
+        render(): JSX.Element;
         props: P;
         state: S;
         context: any;

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -136,6 +136,7 @@ declare module __React {
         setState(f: (prevState: S, props: P) => S, callback?: () => any): void;
         setState(state: S, callback?: () => any): void;
         forceUpdate(): void;
+        render(): JSX.Element;
         props: P;
         state: S;
         context: any;


### PR DESCRIPTION
The new TSX mode in the TypeScript compiler has the requirements that
the element class constructor produces an element instance type that is
assignable to the type `JSX.ElementClass`.  To meet this `React.Component<P, S>`
must declare `render(): JSX.Element`.  Derived classes can be more
specific.

This should resolve my issues with running React-Router with the TSX mode, which caused Microsoft/TypeScript#3928 to be reopened.

@RyanCavanaugh @vvakame @vsiao
