### PR TITLE
Add _.flattenDeep to lodash

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -253,10 +253,14 @@ result = <Array<number>>_.flatten([1, [2], [[3]]], true);
 result = <Array<number>>_.flatten<number>([1, [2], [3, [[4]]]], true);
 result = <Array<number|boolean>>_.flatten<number|boolean>([1, [2], [3, [[false]]]], true);
 
+result = <Array<number>>_.flattenDeep<number>([[[[1]]]]);
+
 result = <_.LoDashArrayWrapper<number>>_([[1, 2], [3, 4], 5, 6]).flatten();
 result = <_.LoDashArrayWrapper<number|Array<Array<number>>>>_([1, [2], [3, [[4]]]]).flatten();
 
 result = <_.LoDashArrayWrapper<number>>_([1, [2], [3, [[4]]]]).flatten(true);
+
+result = <_.LoDashArrayWrapper<number>>_([1, [2], [3, [[4]]]]).flattenDeep();
 
 result = <number>_.indexOf([1, 2, 3, 1, 2, 3], 2);
 result = <number>_.indexOf([1, 2, 3, 1, 2, 3], 2, 3);

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -800,7 +800,9 @@ declare module _ {
     //_.flatten
     interface LoDashStatic {
         /**
-         * Flattens a nested array.
+         * Flattens a nested array a single level.
+         *
+         * _.flatten(x) is equivalent to _.flatten(x, false);
          *
          * @param array The array to flatten.
          * @return `array` flattened.
@@ -811,11 +813,24 @@ declare module _ {
          * Flattens a nested array. If isDeep is true the array is recursively flattened, otherwise it is only
          * flattened a single level.
          *
+         * If you know whether or not this should be recursively at compile time, you typically want to use a
+         * version without a boolean parameter (i.e. `_.flatten(x)` or `_.flattenDeep(x)`).
+         *
          * @param array The array to flatten.
          * @param deep Specify a deep flatten.
          * @return `array` flattened.
          **/
         flatten<T>(array: RecursiveList<T>, isDeep: boolean): List<T> | RecursiveList<T>;
+
+        /**
+         * Recursively flattens a nested array.
+         *
+         * _.flattenDeep(x) is equivalent to _.flatten(x, true);
+         *
+         * @param array The array to flatten
+         * @return `array` recursively flattened
+         */
+        flattenDeep<T>(array: RecursiveList<T>): List<T>
     }
 
     interface LoDashArrayWrapper<T> {
@@ -825,9 +840,14 @@ declare module _ {
         flatten<T>(): LoDashArrayWrapper<any>;
 
         /**
-        * @see _.flatten
-        **/
+         * @see _.flatten
+         **/
         flatten<T>(isShallow: boolean): LoDashArrayWrapper<any>;
+
+        /**
+         * @see _.flattenDeep
+         */
+        flattenDeep<T>(): LoDashArrayWrapper<any>;
     }
 
     //_.indexOf


### PR DESCRIPTION
This adds flatten deep, which was previously missing, and updates the flatten docs to reference it.

See https://lodash.com/docs#flattenDeep for the lodash details.
