### PR TITLE
Missing deferIntercept in angular-ui-router.

### DIFF
--- a/angular-ui-router/angular-ui-router.d.ts
+++ b/angular-ui-router/angular-ui-router.d.ts
@@ -114,6 +114,14 @@ declare module angular.ui {
         otherwise(path: string): IUrlRouterProvider;
         rule(handler: Function): IUrlRouterProvider;
         rule(handler: any[]): IUrlRouterProvider;
+        /**
+         * Disables (or enables) deferring location change interception.
+         *
+         * If you wish to customize the behavior of syncing the URL (for example, if you wish to defer a transition but maintain the current URL), call this method at configuration time. Then, at run time, call $urlRouter.listen() after you have configured your own $locationChangeSuccess event handler.
+         *
+         * @param {boolean} defer Indicates whether to defer location change interception. Passing no parameter is equivalent to true.
+         */
+        deferIntercept(defer?: boolean): void;
     }
 
     interface IStateOptions {


### PR DESCRIPTION
Added definition for IUrlRouterProvider.deferIntercept in angular-ui-router.
Docs: http://angular-ui.github.io/ui-router/site/#/api/ui.router.router.$urlRouterProvider
