### PR TITLE
Added missing CodeMirror.Doc method - listSelections

### DIFF
--- a/codemirror/codemirror.d.ts
+++ b/codemirror/codemirror.d.ts
@@ -471,6 +471,10 @@ declare module CodeMirror {
         It may be "start" , "end" , "head"(the side of the selection that moves when you press shift + arrow),
         or "anchor"(the fixed side of the selection).Omitting the argument is the same as passing "head".A { line , ch } object will be returned. */
         getCursor(start?: string): CodeMirror.Position;
+        
+        /** Retrieves a list of all current selections. These will always be sorted, and never overlap (overlapping selections are merged). 
+        Each object in the array contains anchor and head properties referring to {line, ch} objects. */
+        listSelections(): { anchor: CodeMirror.Position; head: CodeMirror.Position }[];
 
         /** Return true if any text is selected. */
         somethingSelected(): boolean;


### PR DESCRIPTION
The missing method is listed in documentation in [Selection](https://codemirror.net/doc/manual.html#api_selection) section between `doc.getCursor` and `doc.somethingSelected` methods.
