### PR TITLE
httpBackend updated to match Angular documentation

### DIFF
--- a/angularjs/angular-mocks-tests.ts
+++ b/angularjs/angular-mocks-tests.ts
@@ -126,18 +126,35 @@ requestHandler = httpBackendService.expect('GET', /test.local/, function (data: 
 requestHandler = httpBackendService.expect('GET', /test.local/, { key: 'value' });
 requestHandler = httpBackendService.expect('GET', /test.local/, { key: 'value' }, { header: 'value' });
 requestHandler = httpBackendService.expect('GET', /test.local/, { key: 'value' }, function (headers: Object): boolean { return true; });
+requestHandler = httpBackendService.expect('GET', (url: string) => { return true; });
+requestHandler = httpBackendService.expect('GET', (url: string) => { return true; }, 'response data');
+requestHandler = httpBackendService.expect('GET', (url: string) => { return true; }, 'response data', { header: 'value' });
+requestHandler = httpBackendService.expect('GET', (url: string) => { return true; }, 'response data', function (headers: Object): boolean { return true; });
+requestHandler = httpBackendService.expect('GET', (url: string) => { return true; }, /response data/);
+requestHandler = httpBackendService.expect('GET', (url: string) => { return true; }, /response data/, { header: 'value' });
+requestHandler = httpBackendService.expect('GET', (url: string) => { return true; }, /response data/, function (headers: Object): boolean { return true; });
+requestHandler = httpBackendService.expect('GET', (url: string) => { return true; }, function (data: string): boolean { return true; });
+requestHandler = httpBackendService.expect('GET', (url: string) => { return true; }, function (data: string): boolean { return true; }, { header: 'value' });
+requestHandler = httpBackendService.expect('GET', (url: string) => { return true; }, function (data: string): boolean { return true; }, function (headers: Object): boolean { return true; });
+requestHandler = httpBackendService.expect('GET', (url: string) => { return true; }, { key: 'value' });
+requestHandler = httpBackendService.expect('GET', (url: string) => { return true; }, { key: 'value' }, { header: 'value' });
+requestHandler = httpBackendService.expect('GET', (url: string) => { return true; }, { key: 'value' }, function (headers: Object): boolean { return true; });
 
 requestHandler = httpBackendService.expectDELETE('http://test.local');
 requestHandler = httpBackendService.expectDELETE('http://test.local', { header: 'value' });
 requestHandler = httpBackendService.expectDELETE(/test.local/, { header: 'value' });
+requestHandler = httpBackendService.expectDELETE((url: string) => { return true; }, { header: 'value' });
 requestHandler = httpBackendService.expectGET('http://test.local');
 requestHandler = httpBackendService.expectGET('http://test.local', { header: 'value' });
 requestHandler = httpBackendService.expectGET(/test.local/, { header: 'value' });
+requestHandler = httpBackendService.expectGET((url: string) => { return true; }, { header: 'value' });
 requestHandler = httpBackendService.expectHEAD('http://test.local');
 requestHandler = httpBackendService.expectHEAD('http://test.local', { header: 'value' });
 requestHandler = httpBackendService.expectHEAD(/test.local/, { header: 'value' });
+requestHandler = httpBackendService.expectHEAD((url: string) => { return true; }, { header: 'value' });
 requestHandler = httpBackendService.expectJSONP('http://test.local');
 requestHandler = httpBackendService.expectJSONP(/test.local/);
+requestHandler = httpBackendService.expectJSONP((url: string) => { return true; });
 
 requestHandler = httpBackendService.expectPATCH('http://test.local');
 requestHandler = httpBackendService.expectPATCH('http://test.local', 'response data');
@@ -157,6 +174,15 @@ requestHandler = httpBackendService.expectPATCH(/test.local/, function (data: st
 requestHandler = httpBackendService.expectPATCH(/test.local/, function (data: string): boolean { return true; }, { header: 'value' });
 requestHandler = httpBackendService.expectPATCH(/test.local/, { key: 'value' });
 requestHandler = httpBackendService.expectPATCH(/test.local/, { key: 'value' }, { header: 'value' });
+requestHandler = httpBackendService.expectPATCH((url: string) => { return true; });
+requestHandler = httpBackendService.expectPATCH((url: string) => { return true; }, 'response data');
+requestHandler = httpBackendService.expectPATCH((url: string) => { return true; }, 'response data', { header: 'value' });
+requestHandler = httpBackendService.expectPATCH((url: string) => { return true; }, /response data/);
+requestHandler = httpBackendService.expectPATCH((url: string) => { return true; }, /response data/, { header: 'value' });
+requestHandler = httpBackendService.expectPATCH((url: string) => { return true; }, function (data: string): boolean { return true; });
+requestHandler = httpBackendService.expectPATCH((url: string) => { return true; }, function (data: string): boolean { return true; }, { header: 'value' });
+requestHandler = httpBackendService.expectPATCH((url: string) => { return true; }, { key: 'value' });
+requestHandler = httpBackendService.expectPATCH((url: string) => { return true; }, { key: 'value' }, { header: 'value' });
 
 requestHandler = httpBackendService.expectPOST('http://test.local');
 requestHandler = httpBackendService.expectPOST('http://test.local', 'response data');
@@ -176,6 +202,15 @@ requestHandler = httpBackendService.expectPOST(/test.local/, function (data: str
 requestHandler = httpBackendService.expectPOST(/test.local/, function (data: string): boolean { return true; }, { header: 'value' });
 requestHandler = httpBackendService.expectPOST(/test.local/, { key: 'value' });
 requestHandler = httpBackendService.expectPOST(/test.local/, { key: 'value' }, { header: 'value' });
+requestHandler = httpBackendService.expectPOST((url: string) => { return true; });
+requestHandler = httpBackendService.expectPOST((url: string) => { return true; }, 'response data');
+requestHandler = httpBackendService.expectPOST((url: string) => { return true; }, 'response data', { header: 'value' });
+requestHandler = httpBackendService.expectPOST((url: string) => { return true; }, /response data/);
+requestHandler = httpBackendService.expectPOST((url: string) => { return true; }, /response data/, { header: 'value' });
+requestHandler = httpBackendService.expectPOST((url: string) => { return true; }, function (data: string): boolean { return true; });
+requestHandler = httpBackendService.expectPOST((url: string) => { return true; }, function (data: string): boolean { return true; }, { header: 'value' });
+requestHandler = httpBackendService.expectPOST((url: string) => { return true; }, { key: 'value' });
+requestHandler = httpBackendService.expectPOST((url: string) => { return true; }, { key: 'value' }, { header: 'value' });
 
 requestHandler = httpBackendService.expectPUT('http://test.local');
 requestHandler = httpBackendService.expectPUT('http://test.local', 'response data');
@@ -195,6 +230,15 @@ requestHandler = httpBackendService.expectPUT(/test.local/, function (data: stri
 requestHandler = httpBackendService.expectPUT(/test.local/, function (data: string): boolean { return true; }, { header: 'value' });
 requestHandler = httpBackendService.expectPUT(/test.local/, { key: 'value' });
 requestHandler = httpBackendService.expectPUT(/test.local/, { key: 'value' }, { header: 'value' });
+requestHandler = httpBackendService.expectPUT((url: string) => { return true; });
+requestHandler = httpBackendService.expectPUT((url: string) => { return true; }, 'response data');
+requestHandler = httpBackendService.expectPUT((url: string) => { return true; }, 'response data', { header: 'value' });
+requestHandler = httpBackendService.expectPUT((url: string) => { return true; }, /response data/);
+requestHandler = httpBackendService.expectPUT((url: string) => { return true; }, /response data/, { header: 'value' });
+requestHandler = httpBackendService.expectPUT((url: string) => { return true; }, function (data: string): boolean { return true; });
+requestHandler = httpBackendService.expectPUT((url: string) => { return true; }, function (data: string): boolean { return true; }, { header: 'value' });
+requestHandler = httpBackendService.expectPUT((url: string) => { return true; }, { key: 'value' });
+requestHandler = httpBackendService.expectPUT((url: string) => { return true; }, { key: 'value' }, { header: 'value' });
 
 requestHandler = httpBackendService.when('GET', 'http://test.local');
 requestHandler = httpBackendService.when('GET', 'http://test.local', 'response data');
@@ -222,18 +266,35 @@ requestHandler = httpBackendService.when('GET', /test.local/, function (data: st
 requestHandler = httpBackendService.when('GET', /test.local/, { key: 'value' });
 requestHandler = httpBackendService.when('GET', /test.local/, { key: 'value' }, { header: 'value' });
 requestHandler = httpBackendService.when('GET', /test.local/, { key: 'value' }, function (headers: Object): boolean { return true; });
+requestHandler = httpBackendService.when('GET', (url: string) => { return true; });
+requestHandler = httpBackendService.when('GET', (url: string) => { return true; }, 'response data');
+requestHandler = httpBackendService.when('GET', (url: string) => { return true; }, 'response data', { header: 'value' });
+requestHandler = httpBackendService.when('GET', (url: string) => { return true; }, 'response data', function (headers: Object): boolean { return true; });
+requestHandler = httpBackendService.when('GET', (url: string) => { return true; }, /response data/);
+requestHandler = httpBackendService.when('GET', (url: string) => { return true; }, /response data/, { header: 'value' });
+requestHandler = httpBackendService.when('GET', (url: string) => { return true; }, /response data/, function (headers: Object): boolean { return true; });
+requestHandler = httpBackendService.when('GET', (url: string) => { return true; }, function (data: string): boolean { return true; });
+requestHandler = httpBackendService.when('GET', (url: string) => { return true; }, function (data: string): boolean { return true; }, { header: 'value' });
+requestHandler = httpBackendService.when('GET', (url: string) => { return true; }, function (data: string): boolean { return true; }, function (headers: Object): boolean { return true; });
+requestHandler = httpBackendService.when('GET', (url: string) => { return true; }, { key: 'value' });
+requestHandler = httpBackendService.when('GET', (url: string) => { return true; }, { key: 'value' }, { header: 'value' });
+requestHandler = httpBackendService.when('GET', (url: string) => { return true; }, { key: 'value' }, function (headers: Object): boolean { return true; });
 
 requestHandler = httpBackendService.whenDELETE('http://test.local');
 requestHandler = httpBackendService.whenDELETE('http://test.local', { header: 'value' });
 requestHandler = httpBackendService.whenDELETE(/test.local/, { header: 'value' });
+requestHandler = httpBackendService.whenDELETE((url: string) => { return true; }, { header: 'value' });
 requestHandler = httpBackendService.whenGET('http://test.local');
 requestHandler = httpBackendService.whenGET('http://test.local', { header: 'value' });
 requestHandler = httpBackendService.whenGET(/test.local/, { header: 'value' });
+requestHandler = httpBackendService.whenGET((url: string) => { return true; }, { header: 'value' });
 requestHandler = httpBackendService.whenHEAD('http://test.local');
 requestHandler = httpBackendService.whenHEAD('http://test.local', { header: 'value' });
 requestHandler = httpBackendService.whenHEAD(/test.local/, { header: 'value' });
+requestHandler = httpBackendService.whenHEAD((url: string) => { return true; }, { header: 'value' });
 requestHandler = httpBackendService.whenJSONP('http://test.local');
 requestHandler = httpBackendService.whenJSONP(/test.local/);
+requestHandler = httpBackendService.whenJSONP((url: string) => { return true; });
 
 requestHandler = httpBackendService.whenPATCH('http://test.local');
 requestHandler = httpBackendService.whenPATCH('http://test.local', 'response data');
@@ -253,6 +314,15 @@ requestHandler = httpBackendService.whenPATCH(/test.local/, function (data: stri
 requestHandler = httpBackendService.whenPATCH(/test.local/, function (data: string): boolean { return true; }, { header: 'value' });
 requestHandler = httpBackendService.whenPATCH(/test.local/, { key: 'value' });
 requestHandler = httpBackendService.whenPATCH(/test.local/, { key: 'value' }, { header: 'value' });
+requestHandler = httpBackendService.whenPATCH((url: string) => { return true; });
+requestHandler = httpBackendService.whenPATCH((url: string) => { return true; }, 'response data');
+requestHandler = httpBackendService.whenPATCH((url: string) => { return true; }, 'response data', { header: 'value' });
+requestHandler = httpBackendService.whenPATCH((url: string) => { return true; }, /response data/);
+requestHandler = httpBackendService.whenPATCH((url: string) => { return true; }, /response data/, { header: 'value' });
+requestHandler = httpBackendService.whenPATCH((url: string) => { return true; }, function (data: string): boolean { return true; });
+requestHandler = httpBackendService.whenPATCH((url: string) => { return true; }, function (data: string): boolean { return true; }, { header: 'value' });
+requestHandler = httpBackendService.whenPATCH((url: string) => { return true; }, { key: 'value' });
+requestHandler = httpBackendService.whenPATCH((url: string) => { return true; }, { key: 'value' }, { header: 'value' });
 
 requestHandler = httpBackendService.whenPOST('http://test.local');
 requestHandler = httpBackendService.whenPOST('http://test.local', 'response data');
@@ -272,6 +342,15 @@ requestHandler = httpBackendService.whenPOST(/test.local/, function (data: strin
 requestHandler = httpBackendService.whenPOST(/test.local/, function (data: string): boolean { return true; }, { header: 'value' });
 requestHandler = httpBackendService.whenPOST(/test.local/, { key: 'value' });
 requestHandler = httpBackendService.whenPOST(/test.local/, { key: 'value' }, { header: 'value' });
+requestHandler = httpBackendService.whenPOST((url: string) => { return true; });
+requestHandler = httpBackendService.whenPOST((url: string) => { return true; }, 'response data');
+requestHandler = httpBackendService.whenPOST((url: string) => { return true; }, 'response data', { header: 'value' });
+requestHandler = httpBackendService.whenPOST((url: string) => { return true; }, /response data/);
+requestHandler = httpBackendService.whenPOST((url: string) => { return true; }, /response data/, { header: 'value' });
+requestHandler = httpBackendService.whenPOST((url: string) => { return true; }, function (data: string): boolean { return true; });
+requestHandler = httpBackendService.whenPOST((url: string) => { return true; }, function (data: string): boolean { return true; }, { header: 'value' });
+requestHandler = httpBackendService.whenPOST((url: string) => { return true; }, { key: 'value' });
+requestHandler = httpBackendService.whenPOST((url: string) => { return true; }, { key: 'value' }, { header: 'value' });
 
 requestHandler = httpBackendService.whenPUT('http://test.local');
 requestHandler = httpBackendService.whenPUT('http://test.local', 'response data');
@@ -291,15 +370,32 @@ requestHandler = httpBackendService.whenPUT(/test.local/, function (data: string
 requestHandler = httpBackendService.whenPUT(/test.local/, function (data: string): boolean { return true; }, { header: 'value' });
 requestHandler = httpBackendService.whenPUT(/test.local/, { key: 'value' });
 requestHandler = httpBackendService.whenPUT(/test.local/, { key: 'value' }, { header: 'value' });
+requestHandler = httpBackendService.whenPUT((url: string) => { return true; });
+requestHandler = httpBackendService.whenPUT((url: string) => { return true; }, 'response data');
+requestHandler = httpBackendService.whenPUT((url: string) => { return true; }, 'response data', { header: 'value' });
+requestHandler = httpBackendService.whenPUT((url: string) => { return true; }, /response data/);
+requestHandler = httpBackendService.whenPUT((url: string) => { return true; }, /response data/, { header: 'value' });
+requestHandler = httpBackendService.whenPUT((url: string) => { return true; }, function (data: string): boolean { return true; });
+requestHandler = httpBackendService.whenPUT((url: string) => { return true; }, function (data: string): boolean { return true; }, { header: 'value' });
+requestHandler = httpBackendService.whenPUT((url: string) => { return true; }, { key: 'value' });
+requestHandler = httpBackendService.whenPUT((url: string) => { return true; }, { key: 'value' }, { header: 'value' });
 
 
 ///////////////////////////////////////
 // IRequestHandler
 ///////////////////////////////////////
 requestHandler.passThrough();
-requestHandler.respond(function () { });
+requestHandler.passThrough().passThrough();
+requestHandler.respond((method, url, data, headers) => [404, 'data', { header: 'value' }, 'responseText']);
+requestHandler.respond((method, url, data, headers) => [404, 'data', { header: 'value' }, 'responseText']).respond({});
+requestHandler.respond((method, url, data, headers) => { return [404, { key: 'value' }, { header: 'value' }, 'responseText']; });
+requestHandler.respond('data');
+requestHandler.respond('data').respond({});
 requestHandler.respond({ key: 'value' });
 requestHandler.respond({ key: 'value' }, { header: 'value' });
-requestHandler.respond(404);
+requestHandler.respond({ key: 'value' }, { header: 'value' }, 'responseText');
+requestHandler.respond(404, 'data');
+requestHandler.respond(404, 'data').respond({});
 requestHandler.respond(404, { key: 'value' });
 requestHandler.respond(404, { key: 'value' }, { header: 'value' });
+requestHandler.respond(404, { key: 'value' }, { header: 'value' }, 'responseText');

--- a/angularjs/angular-mocks-tests.ts
+++ b/angularjs/angular-mocks-tests.ts
@@ -384,6 +384,7 @@ requestHandler = httpBackendService.whenPUT((url: string) => { return true; }, {
 ///////////////////////////////////////
 // IRequestHandler
 ///////////////////////////////////////
+var expectedData = { key: 'value'};
 requestHandler.passThrough();
 requestHandler.passThrough().passThrough();
 requestHandler.respond((method, url, data, headers) => [404, 'data', { header: 'value' }, 'responseText']);
@@ -391,6 +392,7 @@ requestHandler.respond((method, url, data, headers) => [404, 'data', { header: '
 requestHandler.respond((method, url, data, headers) => { return [404, { key: 'value' }, { header: 'value' }, 'responseText']; });
 requestHandler.respond('data');
 requestHandler.respond('data').respond({});
+requestHandler.respond(expectedData);
 requestHandler.respond({ key: 'value' });
 requestHandler.respond({ key: 'value' }, { header: 'value' });
 requestHandler.respond({ key: 'value' }, { header: 'value' }, 'responseText');

--- a/angularjs/angular-mocks.d.ts
+++ b/angularjs/angular-mocks.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for Angular JS 1.3 (ngMock, ngMockE2E module)
 // Project: http://angularjs.org
-// Definitions by: Diego Vilar <http://github.com/diegovilar>
-// Definitions by: Tony Curtis <http://github.com/daltin>
+// Definitions by: Diego Vilar <http://github.com/diegovilar>, Tony Curtis <http://github.com/daltin>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="angular.d.ts" />
@@ -118,7 +117,6 @@ declare module angular {
           * Verifies that there are no outstanding requests that need to be flushed.
           */
         verifyNoOutstandingRequest(): void;
-
 
         /**
           * Creates a new request expectation. 
@@ -267,7 +265,15 @@ declare module angular {
     }
 
     export module mock {
-
+        // this interface makes it possible to diferentiate between a function parameter (in the first overload for IRequestHandler)
+        // and the data: string | Object parameter in the second overload. Since a function is an object, and the first overload 
+        // takes one function param and the second overload takes a data string or Object with the other two parameters being optional, 
+        // there was no type difference between respond((a,b,c,d) => {}) and respond({}). Using the JsonResponseData interface 
+        // as a type creates a difference in the signatures changing data: string | Object to data: string | JsonResponseData
+        interface JsonResponseData extends Object {
+            [key: string] : any;
+        }
+        
         // returned interface by the the mocked HttpBackendService expect/when methods
         interface IRequestHandler {
           
@@ -276,7 +282,16 @@ declare module angular {
               * Returns the RequestHandler object for possible overrides.
               * @param func Function that receives the request HTTP method, url, data, and headers and returns an array containing response status (number), data, headers, and status text.
               */
-            respond(func: ((method: string, url: string, data?: string | Object, headers?: Object) => [number, string, Object, string])): IRequestHandler;
+            respond(func: ((method: string, url: string, data: string | Object, headers: Object) => [number, string | Object, Object, string])): IRequestHandler;
+
+            /**
+              * Controls the response for a matched request using the HTTP status code 200 and supplied static data to construct the response. 
+              * Returns the RequestHandler object for possible overrides.
+              * @param data Data to add to the response.
+              * @param headers Headers object to add to the response.
+              * @param responseText Response text to add to the response.
+              */
+            respond(data: string | JsonResponseData, headers?: Object, responseText?: string): IRequestHandler;
 
             /**
               * Controls the response for a matched request using supplied static data to construct the response. 
@@ -287,15 +302,6 @@ declare module angular {
               * @param responseText Response text to add to the response.
               */
             respond(status: number, data: string | Object, headers?: Object, responseText?: string): IRequestHandler;
-
-            /**
-              * Controls the response for a matched request using the HTTP status code 200 and supplied static data to construct the response. 
-              * Returns the RequestHandler object for possible overrides.
-              * @param data Data to add to the response.
-              * @param headers Headers object to add to the response.
-              * @param responseText Response text to add to the response.
-              */
-            respond(data: string | {}, headers?: Object, responseText?: string): IRequestHandler;
 
             // Available when ngMockE2E is loaded
             /**

--- a/angularjs/angular-mocks.d.ts
+++ b/angularjs/angular-mocks.d.ts
@@ -265,15 +265,6 @@ declare module angular {
     }
 
     export module mock {
-        // this interface makes it possible to diferentiate between a function parameter (in the first overload for IRequestHandler)
-        // and the data: string | Object parameter in the second overload. Since a function is an object, and the first overload 
-        // takes one function param and the second overload takes a data string or Object with the other two parameters being optional, 
-        // there was no type difference between respond((a,b,c,d) => {}) and respond({}). Using the JsonResponseData interface 
-        // as a type creates a difference in the signatures changing data: string | Object to data: string | JsonResponseData
-        interface JsonResponseData extends Object {
-            [key: string] : any;
-        }
-        
         // returned interface by the the mocked HttpBackendService expect/when methods
         interface IRequestHandler {
           
@@ -285,15 +276,6 @@ declare module angular {
             respond(func: ((method: string, url: string, data: string | Object, headers: Object) => [number, string | Object, Object, string])): IRequestHandler;
 
             /**
-              * Controls the response for a matched request using the HTTP status code 200 and supplied static data to construct the response. 
-              * Returns the RequestHandler object for possible overrides.
-              * @param data Data to add to the response.
-              * @param headers Headers object to add to the response.
-              * @param responseText Response text to add to the response.
-              */
-            respond(data: string | JsonResponseData, headers?: Object, responseText?: string): IRequestHandler;
-
-            /**
               * Controls the response for a matched request using supplied static data to construct the response. 
               * Returns the RequestHandler object for possible overrides.
               * @param status HTTP status code to add to the response.
@@ -302,6 +284,15 @@ declare module angular {
               * @param responseText Response text to add to the response.
               */
             respond(status: number, data: string | Object, headers?: Object, responseText?: string): IRequestHandler;
+
+            /**
+              * Controls the response for a matched request using the HTTP status code 200 and supplied static data to construct the response. 
+              * Returns the RequestHandler object for possible overrides.
+              * @param data Data to add to the response.
+              * @param headers Headers object to add to the response.
+              * @param responseText Response text to add to the response.
+              */
+            respond(data: string | Object, headers?: Object, responseText?: string): IRequestHandler;
 
             // Available when ngMockE2E is loaded
             /**

--- a/angularjs/angular-mocks.d.ts
+++ b/angularjs/angular-mocks.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for Angular JS 1.3 (ngMock, ngMockE2E module)
 // Project: http://angularjs.org
 // Definitions by: Diego Vilar <http://github.com/diegovilar>
+// Definitions by: Tony Curtis <http://github.com/daltin>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="angular.d.ts" />
@@ -97,137 +98,210 @@ declare module angular {
     // see https://docs.angularjs.org/api/ngMock/service/$httpBackend
     ///////////////////////////////////////////////////////////////////////////
     interface IHttpBackendService {
+        /**
+          * Flushes all pending requests using the trained responses.
+          * @param count Number of responses to flush (in the order they arrived). If undefined, all pending requests will be flushed. 
+          */
         flush(count?: number): void;
+        
+        /**
+          * Resets all request expectations, but preserves all backend definitions.
+          */
         resetExpectations(): void;
+        
+        /**
+          * Verifies that all of the requests defined via the expect api were made. If any of the requests were not made, verifyNoOutstandingExpectation throws an exception.
+          */
         verifyNoOutstandingExpectation(): void;
+        
+        /**
+          * Verifies that there are no outstanding requests that need to be flushed.
+          */
         verifyNoOutstandingRequest(): void;
 
-        expect(method: string, url: string, data?: string, headers?: Object): mock.IRequestHandler;
-        expect(method: string, url: string, data?: string, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        expect(method: string, url: string, data?: RegExp, headers?: Object): mock.IRequestHandler;
-        expect(method: string, url: string, data?: RegExp, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        expect(method: string, url: string, data?: (data: string) => boolean, headers?: Object): mock.IRequestHandler;
-        expect(method: string, url: string, data?: (data: string) => boolean, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        expect(method: string, url: string, data?: Object, headers?: Object): mock.IRequestHandler;
-        expect(method: string, url: string, data?: Object, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        expect(method: string, url: RegExp, data?: string, headers?: Object): mock.IRequestHandler;
-        expect(method: string, url: RegExp, data?: string, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        expect(method: string, url: RegExp, data?: RegExp, headers?: Object): mock.IRequestHandler;
-        expect(method: string, url: RegExp, data?: RegExp, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        expect(method: string, url: RegExp, data?: (data: string) => boolean, headers?: Object): mock.IRequestHandler;
-        expect(method: string, url: RegExp, data?: (data: string) => boolean, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        expect(method: string, url: RegExp, data?: Object, headers?: Object): mock.IRequestHandler;
-        expect(method: string, url: RegExp, data?: Object, headers?: (object: Object) => boolean): mock.IRequestHandler;
 
-        expectDELETE(url: string, headers?: Object): mock.IRequestHandler;
-        expectDELETE(url: RegExp, headers?: Object): mock.IRequestHandler;
-        expectGET(url: string, headers?: Object): mock.IRequestHandler;
-        expectGET(url: RegExp, headers?: Object): mock.IRequestHandler;
-        expectHEAD(url: string, headers?: Object): mock.IRequestHandler;
-        expectHEAD(url: RegExp, headers?: Object): mock.IRequestHandler;
-        expectJSONP(url: string): mock.IRequestHandler;
-        expectJSONP(url: RegExp): mock.IRequestHandler;
+        /**
+          * Creates a new request expectation. 
+          * Throws a preformatted error if expectation(s) don't match supplied string, regular expression, object, or if function returns false.
+          * Returns an object with respond method that controls how a matched request is handled.
+          * @param method HTTP method.
+          * @param url HTTP url string, regular expression or function that receives a url and returns true if the url matches the current expctation.
+          * @param data HTTP request body string, json object, regular expression or function that receives the data and returns true if the data matches the current expectation.
+          * @param headers HTTP headers object or function that receives the headers and returns true if the headers match the current expectation.
+          */
+        expect(method: string, url: string | RegExp | ((url: string) => boolean), data?: string | RegExp | Object | ((data: string) => boolean), headers?: Object | ((object: Object) => boolean)) :mock.IRequestHandler;
 
-        expectPATCH(url: string, data?: string, headers?: Object): mock.IRequestHandler;
-        expectPATCH(url: string, data?: RegExp, headers?: Object): mock.IRequestHandler;
-        expectPATCH(url: string, data?: (data: string) => boolean, headers?: Object): mock.IRequestHandler;
-        expectPATCH(url: string, data?: Object, headers?: Object): mock.IRequestHandler;
-        expectPATCH(url: RegExp, data?: string, headers?: Object): mock.IRequestHandler;
-        expectPATCH(url: RegExp, data?: RegExp, headers?: Object): mock.IRequestHandler;
-        expectPATCH(url: RegExp, data?: (data: string) => boolean, headers?: Object): mock.IRequestHandler;
-        expectPATCH(url: RegExp, data?: Object, headers?: Object): mock.IRequestHandler;
+        /**
+          * Creates a new request expectation for DELETE requests.
+          * Throws a preformatted error if expectation(s) don't match supplied string, regular expression, object, or if function returns false.
+          * Returns an object with respond method that controls how a matched request is handled.
+          * @param url HTTP url string, regular expression or function that receives a url and returns true if the url is as expected.
+          * @param headers HTTP headers object to be compared with the HTTP headers in the request.
+        */
+        expectDELETE(url: string | RegExp | ((url: string) => boolean), headers?: Object): mock.IRequestHandler;
 
-        expectPOST(url: string, data?: string, headers?: Object): mock.IRequestHandler;
-        expectPOST(url: string, data?: RegExp, headers?: Object): mock.IRequestHandler;
-        expectPOST(url: string, data?: (data: string) => boolean, headers?: Object): mock.IRequestHandler;
-        expectPOST(url: string, data?: Object, headers?: Object): mock.IRequestHandler;
-        expectPOST(url: RegExp, data?: string, headers?: Object): mock.IRequestHandler;
-        expectPOST(url: RegExp, data?: RegExp, headers?: Object): mock.IRequestHandler;
-        expectPOST(url: RegExp, data?: (data: string) => boolean, headers?: Object): mock.IRequestHandler;
-        expectPOST(url: RegExp, data?: Object, headers?: Object): mock.IRequestHandler;
+        /**
+          * Creates a new request expectation for GET requests.
+          * Throws a preformatted error if expectation(s) don't match supplied string, regular expression, object, or if function returns false.
+          * Returns an object with respond method that controls how a matched request is handled.
+          * @param url HTTP url string, regular expression or function that receives a url and returns true if the url matches the current expctation.
+          * @param headers HTTP headers object to be compared with the HTTP headers in the request.
+          */
+        expectGET(url: string | RegExp | ((url: string) => boolean), headers?: Object): mock.IRequestHandler;
 
-        expectPUT(url: string, data?: string, headers?: Object): mock.IRequestHandler;
-        expectPUT(url: string, data?: RegExp, headers?: Object): mock.IRequestHandler;
-        expectPUT(url: string, data?: (data: string) => boolean, headers?: Object): mock.IRequestHandler;
-        expectPUT(url: string, data?: Object, headers?: Object): mock.IRequestHandler;
-        expectPUT(url: RegExp, data?: string, headers?: Object): mock.IRequestHandler;
-        expectPUT(url: RegExp, data?: RegExp, headers?: Object): mock.IRequestHandler;
-        expectPUT(url: RegExp, data?: (data: string) => boolean, headers?: Object): mock.IRequestHandler;
-        expectPUT(url: RegExp, data?: Object, headers?: Object): mock.IRequestHandler;
+        /**
+          * Creates a new request expectation for HEAD requests.
+          * Throws a preformatted error if expectation(s) don't match supplied string, regular expression, object, or if function returns false.
+          * Returns an object with respond method that controls how a matched request is handled.
+          * @param url HTTP url string, regular expression or function that receives a url and returns true if the url matches the current expctation.
+          * @param headers HTTP headers object to be compared with the HTTP headers in the request.
+          */
+        expectHEAD(url: string | RegExp | ((url: string) => boolean), headers?: Object): mock.IRequestHandler;
+        
+        /**
+          * Creates a new request expectation for JSONP requests.
+          * Throws a preformatted error if expectation(s) don't match supplied string, regular expression, or if function returns false.
+          * Returns an object with respond method that controls how a matched request is handled.
+          * @param url HTTP url string, regular expression or function that receives a url and returns true if the url matches the current expctation.
+          */        
+        expectJSONP(url: string | RegExp | ((url: string) => boolean)): mock.IRequestHandler;
 
-        when(method: string, url: string, data?: string, headers?: Object): mock.IRequestHandler;
-        when(method: string, url: string, data?: string, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        when(method: string, url: string, data?: RegExp, headers?: Object): mock.IRequestHandler;
-        when(method: string, url: string, data?: RegExp, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        when(method: string, url: string, data?: (data: string) => boolean, headers?: Object): mock.IRequestHandler;
-        when(method: string, url: string, data?: (data: string) => boolean, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        when(method: string, url: string, data?: Object, headers?: Object): mock.IRequestHandler;
-        when(method: string, url: string, data?: Object, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        when(method: string, url: RegExp, data?: string, headers?: Object): mock.IRequestHandler;
-        when(method: string, url: RegExp, data?: string, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        when(method: string, url: RegExp, data?: RegExp, headers?: Object): mock.IRequestHandler;
-        when(method: string, url: RegExp, data?: RegExp, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        when(method: string, url: RegExp, data?: (data: string) => boolean, headers?: Object): mock.IRequestHandler;
-        when(method: string, url: RegExp, data?: (data: string) => boolean, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        when(method: string, url: RegExp, data?: Object, headers?: Object): mock.IRequestHandler;
-        when(method: string, url: RegExp, data?: Object, headers?: (object: Object) => boolean): mock.IRequestHandler;
+        /**
+          * Creates a new request expectation for PATCH requests. 
+          * Throws a preformatted error if expectation(s) don't match supplied string, regular expression, object, or if function returns false.
+          * Returns an object with respond method that controls how a matched request is handled.
+          * @param url HTTP url string, regular expression or function that receives a url and returns true if the url matches the current expctation.
+          * @param data HTTP request body string, json object, regular expression or function that receives the data and returns true if the data matches the current expectation.
+          * @param headers HTTP headers object or function that receives the headers and returns true if the headers match the current expectation.
+          */
+        expectPATCH(url: string | RegExp | ((url: string) => boolean), data?: string | RegExp | Object | ((data: string) => boolean), headers?: Object): mock.IRequestHandler;
 
-        whenDELETE(url: string, headers?: Object): mock.IRequestHandler;
-        whenDELETE(url: string, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        whenDELETE(url: RegExp, headers?: Object): mock.IRequestHandler;
-        whenDELETE(url: RegExp, headers?: (object: Object) => boolean): mock.IRequestHandler;
+        /**
+          * Creates a new request expectation for POST requests. 
+          * Throws a preformatted error if expectation(s) don't match supplied string, regular expression, object, or if function returns false.
+          * Returns an object with respond method that controls how a matched request is handled.
+          * @param url HTTP url string, regular expression or function that receives a url and returns true if the url matches the current expctation.
+          * @param data HTTP request body string, json object, regular expression or function that receives the data and returns true if the data matches the current expectation.
+          * @param headers HTTP headers object or function that receives the headers and returns true if the headers match the current expectation.
+          */
+        expectPOST(url: string | RegExp | ((url: string) => boolean), data?: string | RegExp | Object | ((data: string) => boolean), headers?: Object): mock.IRequestHandler;
 
-        whenGET(url: string, headers?: Object): mock.IRequestHandler;
-        whenGET(url: string, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        whenGET(url: RegExp, headers?: Object): mock.IRequestHandler;
-        whenGET(url: RegExp, headers?: (object: Object) => boolean): mock.IRequestHandler;
+        /**
+          * Creates a new request expectation for PUT requests. 
+          * Throws a preformatted error if expectation(s) don't match supplied string, regular expression, object, or if function returns false.
+          * Returns an object with respond method that controls how a matched request is handled.
+          * @param url HTTP url string, regular expression or function that receives a url and returns true if the url matches the current expctation.
+          * @param data HTTP request body string, json object, regular expression or function that receives the data and returns true if the data matches the current expectation.
+          * @param headers HTTP headers object or function that receives the headers and returns true if the headers match the current expectation.
+          */
+        expectPUT(url: string | RegExp | ((url: string) => boolean), data?: string | RegExp | Object | ((data: string) => boolean), headers?: Object): mock.IRequestHandler;
 
-        whenHEAD(url: string, headers?: Object): mock.IRequestHandler;
-        whenHEAD(url: string, headers?: (object: Object) => boolean): mock.IRequestHandler;
-        whenHEAD(url: RegExp, headers?: Object): mock.IRequestHandler;
-        whenHEAD(url: RegExp, headers?: (object: Object) => boolean): mock.IRequestHandler;
+        /**
+          * Creates a new backend definition. 
+          * Returns an object with respond method that controls how a matched request is handled.
+          * @param method HTTP method.
+          * @param url HTTP url string, regular expression or function that receives a url and returns true if the url matches the current expctation.
+          * @param data HTTP request body string, json object, regular expression or function that receives the data and returns true if the data matches the current expectation.
+          * @param headers HTTP headers object or function that receives the headers and returns true if the headers match the current expectation.
+          */
+        when(method: string, url: string | RegExp | ((url: string) => boolean), data?: string | RegExp | Object | ((data: string) => boolean), headers?: Object | ((object: Object) => boolean)): mock.IRequestHandler;
 
-        whenJSONP(url: string): mock.IRequestHandler;
-        whenJSONP(url: RegExp): mock.IRequestHandler;
+        /**
+          * Creates a new backend definition for DELETE requests. 
+          * Returns an object with respond method that controls how a matched request is handled.
+          * @param url HTTP url string, regular expression or function that receives a url and returns true if the url matches the current expctation.
+          * @param headers HTTP headers object or function that receives the headers and returns true if the headers match the current expectation.
+          */
+        whenDELETE(url: string | RegExp | ((url: string) => boolean), headers?: Object | ((object: Object) => boolean)): mock.IRequestHandler;
 
-        whenPATCH(url: string, data?: string, headers?: Object): mock.IRequestHandler;
-        whenPATCH(url: string, data?: RegExp, headers?: Object): mock.IRequestHandler;
-        whenPATCH(url: string, data?: (data: string) => boolean, headers?: Object): mock.IRequestHandler;
-        whenPATCH(url: string, data?: Object, headers?: Object): mock.IRequestHandler;
-        whenPATCH(url: RegExp, data?: string, headers?: Object): mock.IRequestHandler;
-        whenPATCH(url: RegExp, data?: RegExp, headers?: Object): mock.IRequestHandler;
-        whenPATCH(url: RegExp, data?: (data: string) => boolean, headers?: Object): mock.IRequestHandler;
-        whenPATCH(url: RegExp, data?: Object, headers?: Object): mock.IRequestHandler;
+        /**
+          * Creates a new backend definition for GET requests. 
+          * Returns an object with respond method that controls how a matched request is handled.
+          * @param url HTTP url string, regular expression or function that receives a url and returns true if the url matches the current expctation.
+          * @param headers HTTP headers object or function that receives the headers and returns true if the headers match the current expectation.
+          */
+        whenGET(url: string | RegExp | ((url: string) => boolean), headers?: Object | ((object: Object) => boolean)): mock.IRequestHandler;
 
-        whenPOST(url: string, data?: string, headers?: Object): mock.IRequestHandler;
-        whenPOST(url: string, data?: RegExp, headers?: Object): mock.IRequestHandler;
-        whenPOST(url: string, data?: (data: string) => boolean, headers?: Object): mock.IRequestHandler;
-        whenPOST(url: string, data?: Object, headers?: Object): mock.IRequestHandler;
-        whenPOST(url: RegExp, data?: string, headers?: Object): mock.IRequestHandler;
-        whenPOST(url: RegExp, data?: RegExp, headers?: Object): mock.IRequestHandler;
-        whenPOST(url: RegExp, data?: (data: string) => boolean, headers?: Object): mock.IRequestHandler;
-        whenPOST(url: RegExp, data?: Object, headers?: Object): mock.IRequestHandler;
+        /**
+          * Creates a new backend definition for HEAD requests. 
+          * Returns an object with respond method that controls how a matched request is handled.
+          * @param url HTTP url string, regular expression or function that receives a url and returns true if the url matches the current expctation.
+          * @param headers HTTP headers object or function that receives the headers and returns true if the headers match the current expectation.
+          */
+        whenHEAD(url: string | RegExp | ((url: string) => boolean), headers?: Object | ((object: Object) => boolean)): mock.IRequestHandler;
 
-        whenPUT(url: string, data?: string, headers?: Object): mock.IRequestHandler;
-        whenPUT(url: string, data?: RegExp, headers?: Object): mock.IRequestHandler;
-        whenPUT(url: string, data?: (data: string) => boolean, headers?: Object): mock.IRequestHandler;
-        whenPUT(url: string, data?: Object, headers?: Object): mock.IRequestHandler;
-        whenPUT(url: RegExp, data?: string, headers?: Object): mock.IRequestHandler;
-        whenPUT(url: RegExp, data?: RegExp, headers?: Object): mock.IRequestHandler;
-        whenPUT(url: RegExp, data?: (data: string) => boolean, headers?: Object): mock.IRequestHandler;
-        whenPUT(url: RegExp, data?: Object, headers?: Object): mock.IRequestHandler;
+        /**
+          * Creates a new backend definition for JSONP requests. 
+          * Returns an object with respond method that controls how a matched request is handled.
+          * @param url HTTP url string, regular expression or function that receives a url and returns true if the url matches the current expctation.
+          * @param headers HTTP headers object or function that receives the headers and returns true if the headers match the current expectation.
+          */
+        whenJSONP(url: string | RegExp | ((url: string) => boolean)): mock.IRequestHandler;
+
+        /**
+          * Creates a new backend definition for PATCH requests. 
+          * Returns an object with respond method that controls how a matched request is handled.
+          * @param url HTTP url string, regular expression or function that receives a url and returns true if the url matches the current expctation.
+          * @param data HTTP request body string, json object, regular expression or function that receives the data and returns true if the data matches the current expectation.
+          * @param headers HTTP headers object or function that receives the headers and returns true if the headers match the current expectation.
+          */
+        whenPATCH(url: string | RegExp | ((url: string) => boolean), data?: string | RegExp | Object | ((data: string) => boolean), headers?: Object | ((object: Object) => boolean)): mock.IRequestHandler;
+
+        /**
+          * Creates a new backend definition for POST requests. 
+          * Returns an object with respond method that controls how a matched request is handled.
+          * @param url HTTP url string, regular expression or function that receives a url and returns true if the url matches the current expctation.
+          * @param data HTTP request body string, json object, regular expression or function that receives the data and returns true if the data matches the current expectation.
+          * @param headers HTTP headers object or function that receives the headers and returns true if the headers match the current expectation.
+          */
+        whenPOST(url: string | RegExp | ((url: string) => boolean), data?: string | RegExp | Object | ((data: string) => boolean), headers?: Object | ((object: Object) => boolean)): mock.IRequestHandler;
+
+        /**
+          * Creates a new backend definition for PUT requests. 
+          * Returns an object with respond method that controls how a matched request is handled.
+          * @param url HTTP url string, regular expression or function that receives a url and returns true if the url matches the current expctation.
+          * @param data HTTP request body string, json object, regular expression or function that receives the data and returns true if the data matches the current expectation.
+          * @param headers HTTP headers object or function that receives the headers and returns true if the headers match the current expectation.
+          */
+        whenPUT(url: string | RegExp | ((url: string) => boolean), data?: string | RegExp | Object | ((data: string) => boolean), headers?: Object | ((object: Object) => boolean)): mock.IRequestHandler;
     }
 
     export module mock {
 
         // returned interface by the the mocked HttpBackendService expect/when methods
         interface IRequestHandler {
-            respond(func: Function): void;
-            respond(status: number, data?: any, headers?: any): void;
-            respond(data: any, headers?: any): void;
+          
+            /**
+              * Controls the response for a matched request using a function to construct the response. 
+              * Returns the RequestHandler object for possible overrides.
+              * @param func Function that receives the request HTTP method, url, data, and headers and returns an array containing response status (number), data, headers, and status text.
+              */
+            respond(func: ((method: string, url: string, data?: string | Object, headers?: Object) => [number, string, Object, string])): IRequestHandler;
 
-            // Available wehn ngMockE2E is loaded
-            passThrough(): void;
+            /**
+              * Controls the response for a matched request using supplied static data to construct the response. 
+              * Returns the RequestHandler object for possible overrides.
+              * @param status HTTP status code to add to the response.
+              * @param data Data to add to the response.
+              * @param headers Headers object to add to the response.
+              * @param responseText Response text to add to the response.
+              */
+            respond(status: number, data: string | Object, headers?: Object, responseText?: string): IRequestHandler;
+
+            /**
+              * Controls the response for a matched request using the HTTP status code 200 and supplied static data to construct the response. 
+              * Returns the RequestHandler object for possible overrides.
+              * @param data Data to add to the response.
+              * @param headers Headers object to add to the response.
+              * @param responseText Response text to add to the response.
+              */
+            respond(data: string | {}, headers?: Object, responseText?: string): IRequestHandler;
+
+            // Available when ngMockE2E is loaded
+            /**
+              * Any request matching a backend definition or expectation with passThrough handler will be passed through to the real backend (an XHR request will be made to the server.)
+              */
+            passThrough(): IRequestHandler;
         }
 
     }


### PR DESCRIPTION
Changes to httpBackend to conform to angular documentation here: https://code.angularjs.org/1.3.16/docs/api/ngMock/service/$httpBackend
Mainly add the option to pass a function in the url parameter for expect and when function flavors. Updated IRequestHandler respond function to return an IRequestHandler, updated overloads.
Used union types to reduce over 100 overloads to 19 signatures.
Added documentation and tests.
