### PR TITLE
Add test for Jasmine's jasmine.clock().mockDate(baseTime)

### DIFF
--- a/jasmine/jasmine-tests.ts
+++ b/jasmine/jasmine-tests.ts
@@ -721,6 +721,17 @@ describe("Manually ticking the Jasmine Clock", function () {
         jasmine.clock().tick(50);
         expect(timerCallback.calls.count()).toEqual(2);
     });
+
+    describe("Mocking the Date object", function(){
+        it("mocks the Date object and sets it to a given time", function() {
+            var baseTime = new Date(2013, 9, 23);
+
+            jasmine.clock().mockDate(baseTime);
+
+            jasmine.clock().tick(50);
+            expect(new Date().getTime()).toEqual(baseTime.getTime() + 50);
+        });
+    });
 });
 
 describe("Asynchronous specs", function () {


### PR DESCRIPTION
The type definition is already there, but it's missing a test
