### PR TITLE
page.js: use ES6 modules instead of TS external modules

### DIFF
--- a/page/page-tests.ts
+++ b/page/page-tests.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="page.d.ts" />
 
-import page = require("page");
+import page from "page";
 
 //***********************************************************************
 // Basic Example

--- a/page/page.d.ts
+++ b/page/page.d.ts
@@ -210,7 +210,7 @@ declare module PageJS {
 
 declare module "page" {
     var page: PageJS.Static;
-    export = page;
+    export default page;
 }
 
 declare var page: PageJS.Static;


### PR DESCRIPTION
It's [recommended](https://github.com/Microsoft/TypeScript/issues/2242#issue-60179656) to use new ES6 modules instead of TS external modules. Current declaration doesn't allow to import page.js using ES6 syntax:

``` ts
import page from 'page'; // error: Module '"page"' has no default export;
```

The PR fixes this.
