### PR TITLE
lodash #5244 join/pop/shift do not return wrappers

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -114,11 +114,11 @@ result = <_.LoDashObjectWrapper<_.Dictionary<string>>>_(<{ [index: string]: stri
 
 //Wrapped array shortcut methods
 result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).concat(5, 6);
-result = <_.LoDashWrapper<string>>_([1, 2, 3, 4]).join(',');
-result = <_.LoDashWrapper<number>>_([1, 2, 3, 4]).pop();
+result = <string>_([1, 2, 3, 4]).join(',');
+result = <number>_([1, 2, 3, 4]).pop();
 _([1, 2, 3, 4]).push(5, 6, 7);
 result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).reverse();
-result = <_.LoDashWrapper<number>>_([1, 2, 3, 4]).shift();
+result = <number>_([1, 2, 3, 4]).shift();
 result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).slice(1, 2);
 result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).slice(2);
 result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).sort((a, b) => 1);

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -219,11 +219,11 @@ declare module _ {
 
     interface LoDashArrayWrapper<T> extends LoDashWrapperBase<T[], LoDashArrayWrapper<T>> {
         concat(...items: T[]): LoDashArrayWrapper<T>;
-        join(seperator?: string): LoDashWrapper<string>;
-        pop(): LoDashWrapper<T>;
+        join(seperator?: string): string;
+        pop(): T;
         push(...items: T[]): void;
         reverse(): LoDashArrayWrapper<T>;
-        shift(): LoDashWrapper<T>;
+        shift(): T;
         slice(start: number, end?: number): LoDashArrayWrapper<T>;
         sort(compareFn?: (a: T, b: T) => number): LoDashArrayWrapper<T>;
         splice(start: number): LoDashArrayWrapper<T>;


### PR DESCRIPTION
_([1, 2]).join()    // "1,2"
_([1, 2]).pop()     // 2
_([1, 2]).shift()   // 1
