### PR TITLE
Sequelize's DataTypes.STRING can take a length parameter

### DIFF
--- a/sequelize/sequelize-tests.ts
+++ b/sequelize/sequelize-tests.ts
@@ -214,3 +214,9 @@ promiseMe = myModelInst.decrement({}, incrOpts);
 isBool = myModelInst.equal(myModelInst);
 isBool = myModelInst.equalsOneOf([myModelInst]);
 myModelPojo = myModelInst.toJSON();
+
+var DataTypes: Sequelize.DataTypes = Sequelize;
+DataTypes.STRING(64);
+DataTypes.STRING.BINARY(64);
+DataTypes.CHAR(64);
+DataTypes.CHAR.BINARY(64);

--- a/sequelize/sequelize.d.ts
+++ b/sequelize/sequelize.d.ts
@@ -2724,6 +2724,7 @@ declare module "sequelize"
         }
 
         interface DataTypeStringBase {
+            (length?: number, binary?: boolean): DataTypeStringBase;
             BINARY: DataTypeString;
         }
         interface DataTypeNumberBase {


### PR DESCRIPTION
Allows using Sequelize STRING datatype with a length specified, e.g. (in a model definition's attributes):

```
    description: {
        type: DataTypes.STRING(64),
        allowNull: false
    }
```
