### PR TITLE
Allow extension of the Matchers interface

### DIFF
--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -269,7 +269,7 @@ declare module jasmine {
         results(): NestedResults;
     }
 
-    interface Matchers {
+    export interface Matchers {
 
         new (env: Env, actual: any, spec: Env, isNot?: boolean): any;
 


### PR DESCRIPTION
Export the interface, so that it is possible to add new matchers along
with their signatures without having to modify this file. For example,
this allows the following definition in another file:

```
module jasmine {
    export interface Matchers {
        toBeSomethingElse(): boolean;
    }
}
```

The two interfaces will be combined, so this new matcher can be used
alongside the original ones.
