### PR TITLE
Removed TaxonomySession.getTerms(string, boolean)

### DIFF
--- a/sharepoint/SharePoint.d.ts
+++ b/sharepoint/SharePoint.d.ts
@@ -6507,7 +6507,6 @@ declare module SP {
             static getTaxonomySession(context: SP.ClientContext): TaxonomySession;
             get_offlineTermStoreNames(): string[];
             get_termStores(): TermStoreCollection;
-            getTerms(termLabel: string, trimUnavailable: boolean): TermCollection;
             getTerms(labelMatchInformation: LabelMatchInformation): TermCollection;
             updateCache(): void;
             getTerm(guid: SP.Guid): Term;


### PR DESCRIPTION
There is no overload for getTerms on TaxonomySession that takes string
and boolean.

There is only a function that takes match information, see:

https://msdn.microsoft.com/en-us/library/office/dn312597.aspx
