### PR TITLE
 Support Nested Json Objects in Angular Translate

### DIFF
--- a/angular-translate/angular-translate.d.ts
+++ b/angular-translate/angular-translate.d.ts
@@ -13,7 +13,7 @@ declare module "angular-translate" {
 declare module angular.translate {
 
     interface ITranslationTable {
-        [key: string]: string;
+        [key: string]: any;
     }
 
     interface ILanguageKeyAlias {


### PR DESCRIPTION
@borisyankov  Angular Translate Supports Nested Json  Objects like the example given below 
https://angular-translate.github.io/docs/#/guide/02_getting-started
{
  "NAMESPACE": {
    "SUB_NAMESPACE": {
       "TRANSLATION_ID1": "This is a namespaced translation."
       }
    }
}

But the definition of the ITransitionTable restricts the support of Nested Json Objects

Current definition of ITransitionTable
interface ITranslationTable {
        [key: string]: string;
    }

Here we can have the value as only string and not Nested Json Objects.

I was wondering if  we can  change the value type to "any" in order to support Nested Json Objects.

interface ITranslationTable {
        [key: string]: any;
    }
