### PR TITLE
lodash: changed _.once() method

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -958,9 +958,10 @@ result = <TestNegateResult>_.negate<TestNegatePredicate, TestNegateResult>(testN
 result = <TestNegateResult>_(testNegatePredicate).negate().value();
 result = <TestNegateResult>_(testNegatePredicate).negate<TestNegateResult>().value();
 
-var initialize = _.once(function () { });
-initialize();
-initialize();
+// _.once
+result = <() => void>_.once<() => void>(function () {});
+result = <() => void>(_(function () {}).once().value());
+
 var returnedOnce = _.throttle(function (a: any) { return a * 5; }, 5);
 returnedOnce(4);
 

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -5616,13 +5616,20 @@ declare module _ {
     //_.once
     interface LoDashStatic {
         /**
-        * Creates a function that is restricted to execute func once. Repeat calls to the function
-        * will return the value of the first call. The func is executed with the this binding of the
-        * created function.
-        * @param func Function to only execute once.
-        * @return The new restricted function.
-        **/
+         * Creates a function that is restricted to invoking func once. Repeat calls to the function return the value
+         * of the first call. The func is invoked with the this binding and arguments of the created function.
+         * @param func The function to restrict.
+         * @return Returns the new restricted function.
+         */
+
         once<T extends Function>(func: T): T;
+    }
+
+    interface LoDashObjectWrapper<T> {
+        /**
+         * @see _.once
+         */
+        once(): LoDashObjectWrapper<T>;
     }
 
     //_.partial


### PR DESCRIPTION
https://lodash.com/docs#once
https://lodash.com/docs#_ (description of the chainable wrapper)
