### PR TITLE
Added export `"codemirror"`

### DIFF
--- a/codemirror/codemirror.d.ts
+++ b/codemirror/codemirror.d.ts
@@ -1086,3 +1086,6 @@ declare module CodeMirror {
         to?: Position;
     }
 }
+declare module "codemirror" {
+    export = CodeMirror;
+}


### PR DESCRIPTION
Without this, there isn't any way to load CodeMirror the CommonJS way.
