### PR TITLE
Cheerio: Missing function definition "contents()"

### DIFF
--- a/cheerio/cheerio.d.ts
+++ b/cheerio/cheerio.d.ts
@@ -74,6 +74,8 @@ interface Cheerio {
 
     children(selector?: string): Cheerio;
 
+    contents(): Cheerio;
+
     each(func: (index: number, element: CheerioElement) => any): Cheerio;
     map(func: (index: number, element: CheerioElement) => any): Cheerio;
 


### PR DESCRIPTION
See api documentation : https://github.com/cheeriojs/cheerio#contents
