### PR TITLE
Add empty send() method for superagent

### DIFF
--- a/superagent/superagent-tests.ts
+++ b/superagent/superagent-tests.ts
@@ -56,6 +56,11 @@ request
   .delete('/user/1')
   .end(callback);
 
+request
+  .delete('/user/1')
+  .send()
+  .end(callback);
+
 request('/search')
   .end(callback);
 

--- a/superagent/superagent.d.ts
+++ b/superagent/superagent.d.ts
@@ -97,6 +97,7 @@ declare module "superagent" {
       redirects(n: number): Req;
       send(data: string): Req;
       send(data: Object): Req;
+      send(): Req;
       set(field: string, val: string): Req;
       set(field: Object): Req;
       timeout(ms: number): Req;


### PR DESCRIPTION
#5212

As best as I can tell, `send()` is actually optional so people could just remove the empty send call entirely... but superagent doesn't seem to mind
