### PR TITLE
Make eventemitter3 compatible with TypeScript 1.6 (still works with 1.5.3 as well)

### DIFF
--- a/eventemitter3/eventemitter3.d.ts
+++ b/eventemitter3/eventemitter3.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module EventEmitter3 {
-    export class EventEmitter {
+    class Base {
         /**
          * Minimal EventEmitter interface that is molded against the Node.js
          * EventEmitter interface.
@@ -81,13 +81,14 @@ declare module EventEmitter3 {
         //
         setMaxListeners(): EventEmitter;
     }
+    export class EventEmitter extends Base { }
     export module EventEmitter {
         //
         // Expose the module.
         //
-        export class EventEmitter extends EventEmitter3.EventEmitter {}
-        export class EventEmitter2 extends EventEmitter3.EventEmitter {}
-        export class EventEmitter3 extends EventEmitter3.EventEmitter {}
+        export class EventEmitter extends Base {}
+        export class EventEmitter2 extends Base {}
+        export class EventEmitter3 extends Base {}
     }
 }
 


### PR DESCRIPTION
I don't think the current eventemitter3.d.ts will be compatible with TypeScript 1.6. The following commands demonstrates the problem (output prepended with # to make it easier to cut and paste):

```
mkdir /tmp/eventemitter_test && cd /tmp/eventemitter_test
npm install typescript@next
# typescript@1.6.0-dev.20150808 node_modules/typescript
wget --quiet "https://raw.githubusercontent.com/borisyankov/DefinitelyTyped/master/eventemitter3/eventemitter3-test.ts"
wget --quiet "https://raw.githubusercontent.com/borisyankov/DefinitelyTyped/master/eventemitter3/eventemitter3.d.ts"
./node_modules/.bin/tsc --module commonjs eventemitter3-test.ts 
```

Giving the errors

```
eventemitter3-test.ts(11,9): error TS2322: Type 'EventEmitter3.EventEmitter.EventEmitter' is not assignable to type 'EventEmitter'.
  Property 'listeners' is missing in type 'EventEmitter'.
eventemitter3-test.ts(12,9): error TS2322: Type 'EventEmitter2' is not assignable to type 'EventEmitter'.
  Property 'listeners' is missing in type 'EventEmitter2'.
eventemitter3-test.ts(13,9): error TS2322: Type 'EventEmitter3' is not assignable to type 'EventEmitter'.
  Property 'listeners' is missing in type 'EventEmitter3'.
eventemitter3.d.ts(88,57): error TS2339: Property 'EventEmitter' does not exist on type 'typeof EventEmitter3'.
eventemitter3.d.ts(89,58): error TS2339: Property 'EventEmitter' does not exist on type 'typeof EventEmitter3'.
eventemitter3.d.ts(90,22): error TS2506: 'EventEmitter3' is referenced directly or indirectly in its own base expression.
eventemitter3.d.ts(90,58): error TS2339: Property 'EventEmitter' does not exist on type 'typeof EventEmitter3'.
```

If you change "npm install typescript@next" to "npm install typescript" (and thus get version 1.5.3 if you do it right now) in the above commands it will work.

I think the problem is described in https://github.com/Microsoft/TypeScript/issues/3602 . Some kind of name conflict that worked before but is no longer allowed in TypeScript 1.6.

This pull request fixes so the eventemitter3.d.ts works with both TypeScript 1.5.3 and the  current 1.6 nightly version, but I'm very uncertain if it is fixed in the right way. I don't understand much of the .d.ts files despite many hours of trying to make sense of them.
