### PR TITLE
normal() should return a number, not a string

### DIFF
--- a/chance/chance.d.ts
+++ b/chance/chance.d.ts
@@ -127,7 +127,7 @@ declare module Chance {
         guid(): string;
         hash(opts?: Options): string;
         n<T>(generator: () => T, count: number, opts?: Options): T[];
-        normal(opts?: Options): string;
+        normal(opts?: Options): number;
         radio(opts?: Options): string;
         rpg(dice: string): number[];
         rpg(dice: string, opts?: Options): number[]|number;


### PR DESCRIPTION
Small change to ensure the normal() function declares that it returns a number and not a string.
