### PR TITLE
Fixed lack of array type in PropObjectType interface

### DIFF
--- a/polymer/polymer-tests.ts
+++ b/polymer/polymer-tests.ts
@@ -16,6 +16,10 @@ Polymer({
     prop3: {
       type: Array,
       value: []
+    },
+    prop4: {
+      type: Object,
+      value: {}
     }
   },
 

--- a/polymer/polymer-tests.ts
+++ b/polymer/polymer-tests.ts
@@ -12,6 +12,10 @@ Polymer({
       reflectToAttribute: true,
       notify: true,
       computed: "__prop2()"
+    },
+    prop3: {
+      type: Array,
+      value: []
     }
   },
 

--- a/polymer/polymer.d.ts
+++ b/polymer/polymer.d.ts
@@ -11,7 +11,7 @@ declare module polymer {
 
   interface PropObjectType {
     type: PropConstructorType;
-    value?:boolean|number|string|Function;
+    value?:boolean|number|string|Function|any[];
     reflectToAttributes?:boolean;
     notify?:boolean;
     readOnly?:boolean;

--- a/polymer/polymer.d.ts
+++ b/polymer/polymer.d.ts
@@ -11,7 +11,7 @@ declare module polymer {
 
   interface PropObjectType {
     type: PropConstructorType;
-    value?:boolean|number|string|Function|any[];
+    value?:boolean|number|string|Function|any[]|Object;
     reflectToAttributes?:boolean;
     notify?:boolean;
     readOnly?:boolean;


### PR DESCRIPTION
Polymer can take an array as the value of property.  `PropConstructorType` can take Array constoructor but `PropObjectType` can't take a value of array.  This PR fixes the bug.
