### PR TITLE
Event Declaration Removal

### DIFF
--- a/bingmaps/Microsoft.Maps.AdvancedShapes.d.ts
+++ b/bingmaps/Microsoft.Maps.AdvancedShapes.d.ts
@@ -9,7 +9,7 @@ declare module Microsoft.Maps.AdvancedShapes {
 
     export class EntityCollection {
 
-        constructor(options: EntityCollectionOptions);
+        constructor(options?: EntityCollectionOptions);
 
         clear(): void;
         get(index: number): Entity;

--- a/bingmaps/Microsoft.Maps.AdvancedShapes.d.ts
+++ b/bingmaps/Microsoft.Maps.AdvancedShapes.d.ts
@@ -24,10 +24,6 @@ declare module Microsoft.Maps.AdvancedShapes {
         removeAt(index: number): Entity;
         setOptions(options: EntityCollectionOptions): void;
         toString(): string;
-
-        entityAdded: (args: EntityChangeArgs) => any;
-        entityChanged: (args: EntityChangeArgs) => any;
-        entityRemoved: (args: EntityChangeArgs) => any;
     }
 
     export class Polygon implements Entity {
@@ -43,15 +39,6 @@ declare module Microsoft.Maps.AdvancedShapes {
         setLocations(locations: Location[]): void;
         setOptions(options: PolylineOptions): void;
         toString(): string;
-
-        click: (eventArgs: MouseEventArgs) => void;
-        dbclick: (eventArgs: MouseEventArgs) => void;
-        entitychanged: (entity: Entity) => void;
-        mousedown: (eventArgs: MouseEventArgs) => void;
-        mouseout: (eventArgs: MouseEventArgs) => void;
-        mouseover: (eventArgs: MouseEventArgs) => void;
-        mouseup: (eventArgs: MouseEventArgs) => void;
-        rightclick: (eventArgs: MouseEventArgs) => void;
     }
 
 }

--- a/bingmaps/Microsoft.Maps.Directions.d.ts
+++ b/bingmaps/Microsoft.Maps.Directions.d.ts
@@ -79,10 +79,6 @@ declare module Microsoft.Maps.Directions {
         isExactLocation(): boolean;
         isViapoint(): boolean;
         setOptions(options: WaypointOptions): void;
-
-        changed: (args: WaypointEventArgs) => void;
-        geocoded: (args: WaypointEventArgs) => void;
-        reverseGeocoded: (args: WaypointEventArgs) => void;
     }
 
     export interface DirectionsRenderOptions {
@@ -185,27 +181,6 @@ declare module Microsoft.Maps.Directions {
         setMapView(): void;
         setRenderOptions(options: DirectionsRenderOptions): void;
         setRequestOptions(options: DirectionsRequestOptions): void;
-
-        afterRouteSelectorRender: (args: RouteSelectorRenderEventArgs) => void;
-        afterStepRender: (args: DirectionsStepRenderEventArgs) => void;
-        afterSummaryRender: (args: RouteSummaryRenderEventArgs) => void;
-        afterWaypointRender: (args: WaypointRenderEventArgs) => void;
-        beforeDisambiguationRender: (args: DisambiguationRenderEventArgs) => void;
-        beforeRouteSelectorRender: (args: RouteSelectorRenderEventArgs) => void;
-        beforeStepRender: (args: DirectionsStepRenderEventArgs) => void;
-        beforeSummaryRender: (args: RouteSummaryRenderEventArgs) => void;
-        beforeWaypointRender: (args: WaypointRenderEventArgs) => void;
-        directionsError: (args: DirectionsErrorEventArgs) => void;
-        directionsUpdated: (args: DirectionsEventArgs) => void;
-        dragDropCompleted: () => void;
-        itineraryStepClicked: (args: DirectionsStepEventArgs) => void;
-        mouseEnterRouteSelector: (args: RouteSelectorEventArgs) => void;
-        mouseEnterStep: (args: DirectionsStepEventArgs) => void;
-        mouseLeaveRouteSelector: (args: RouteSelectorEventArgs) => void;
-        mouseLeaveStep: (args: DirectionsStepEventArgs) => void;
-        routeSelectorClicked: (args: RouteSelectorEventArgs) => void;
-        waypointAdded: (args: WaypointEventArgs) => void;
-        waypointRemoved: (args: WaypointEventArgs) => void;
     }
 
     export interface DirectionsStepEventArgs {

--- a/bingmaps/Microsoft.Maps.Search.d.ts
+++ b/bingmaps/Microsoft.Maps.Search.d.ts
@@ -25,12 +25,12 @@ declare module Microsoft.Maps.Search {
      }
 
      export interface GeocodeRequestOptions {
-         bounds: LocationRect;
+         bounds?: LocationRect;
          callback: (result: GeocodeResult, userData: any) => any;
          count: number;
          errorCallback: (options: GeocodeRequestOptions) => any;
-         timeout: number;
-         userData: any;
+         timeout?: number;
+         userData?: any;
          where:string;
      }
 
@@ -73,9 +73,10 @@ declare module Microsoft.Maps.Search {
      export interface ReverseGeocodeRequestOptions {
          callback: (result: PlaceResult, userData: any) => any;
          errorCallback: (options: ReverseGeocodeRequestOptions) => any;
+         count:number;
          location: Location;
-         timeout: number;
-         userData:any;
+         timeout?: number;
+         userData?:any;
      }
 
      export class SearchManager {
@@ -107,13 +108,13 @@ declare module Microsoft.Maps.Search {
          callback:(result: SearchResponse, userData: any)=>any;
          count: number;
          errorCallback:(options: SearchRequestOptions)=>any;
-         query: string;
-         startIndex: number;
-         timeout: number;
-         entityType: string;
-         userData: any;
-         what: string;
-         where:string;
+         query?: string;
+         startIndex?: number;
+         timeout?: number;
+         entityType?: string;
+         userData?: any;
+         what?: string;
+         where?:string;
      }
 
      export interface SearchResponse {

--- a/bingmaps/Microsoft.Maps.VenueMaps.d.ts
+++ b/bingmaps/Microsoft.Maps.VenueMaps.d.ts
@@ -21,10 +21,6 @@ declare module Microsoft.Maps.VenueMaps {
         isInDOM(): boolean;
         removeFromDOM(): void;
         setHeight(height: number): void;
-
-        click: (eventArgs: MouseEventArgs) => any;
-        mouseOut: (eventArgs: MouseEventArgs) => any;
-        mouseOver: (eventArgs: MouseEventArgs) => any;
     }
 
     export enum DirectoryGrouping {
@@ -116,12 +112,6 @@ declare module Microsoft.Maps.VenueMaps {
         hide(): void;
         setActiveFloor(floor: string): void;
         show(): void;
-
-        click: (eventArgs: Primitive) => any;
-        close: () => any;
-        footprintclick: (eventArgs: Primitive) => any;
-        mouseout: (eventArgs: Primitive) => any;
-        mouseover: (eventArgs: Primitive) => any;
     }
 
     export interface VenueMapCreationOptions {

--- a/bingmaps/Microsoft.Maps.d.ts
+++ b/bingmaps/Microsoft.Maps.d.ts
@@ -139,27 +139,6 @@ declare module Microsoft.Maps {
         setView(options: ViewOptions): void;
         tryLocationToPixel(locations: Array<Location>, reference?: PixelReference): any;
         tryPixelToLocation(points: Array<Point>, reference?: PixelReference): any;
-
-        click: (eventArgs: MouseEventArgs) => void;
-        copyrightchanged: () => void;
-        dblclick: (eventArgs: MouseEventArgs) => void;
-        imagerychanged: () => void;
-        keydown: (eventArgs: KeyEventArgs) => void;
-        keypress: (eventArgs: KeyEventArgs) => void;
-        keyup: (eventArgs: KeyEventArgs) => void;
-        maptypechanged: () => void;
-        mousedown: (eventArgs: MouseEventArgs) => void;
-        mousemove: (eventArgs: MouseEventArgs) => void;
-        mouseout: (eventArgs: MouseEventArgs) => void;
-        mouseover: (eventArgs: MouseEventArgs) => void;
-        mouseup: (eventArgs: MouseEventArgs) => void;
-        mousewheel: (eventArgs: MouseEventArgs) => void;
-        rightlick: (eventArgs: MouseEventArgs) => void;
-        targetviewchanged: () => void;
-        tiledownloadcomplete: () => void;
-        viewchange: () => void;
-        viewchangeend: () => void;
-        viewchangestart: () => void;
     }
 
     export class MapMode {
@@ -294,10 +273,6 @@ declare module Microsoft.Maps {
         removeAt(index: number): Entity;
         setOptions(options: EntityCollectionOptions): void;
         toString(): string;
-
-        entityAdded: (args: EntityChangeArgs) => any;
-        entityChanged: (args: EntityChangeArgs) => any;
-        entityRemoved: (args: EntityChangeArgs) => any;
     }
 
     export class Infobox {
@@ -325,11 +300,6 @@ declare module Microsoft.Maps {
         setLocation(location: Location): void;
         setOptions(options: InfoboxOptions): void;
         toString(): string;
-
-        click: (eventArgs: MouseEventArgs) => void;
-        entitychanged: (entity: Entity) => void;
-        mouseenter: (eventArgs: MouseEventArgs) => void;
-        mouseleave: (eventArgs: MouseEventArgs) => void;
     }
 
     export interface Action {
@@ -378,15 +348,6 @@ declare module Microsoft.Maps {
         setLocations(locations: Array<Location>): void;
         setOptions(options: PolylineOptions): void;
         toString(): string;
-
-        click: (eventArgs: MouseEventArgs) => void;
-        dblclick: (eventArgs: MouseEventArgs) => void;
-        entitychanged: (entity: Entity) => void;
-        mousedown: (eventArgs: MouseEventArgs) => void;
-        mouseout: (eventArgs: MouseEventArgs) => void;
-        mouseover: (eventArgs: MouseEventArgs) => void;
-        mouseup: (eventArgs: MouseEventArgs) => void;
-        rightclick: (eventArgs: MouseEventArgs) => void;
     }
 
     export interface PolylineOptions {
@@ -410,15 +371,6 @@ declare module Microsoft.Maps {
         setLocations(locations: Location[]): void;
         setOptions(options: PolylineOptions): void;
         toString(): string;
-
-        click: (eventArgs: MouseEventArgs) => void;
-        dbclick: (eventArgs: MouseEventArgs) => void;
-        entitychanged: (entity: Entity) => void;
-        mousedown: (eventArgs: MouseEventArgs) => void;
-        mouseout: (eventArgs: MouseEventArgs) => void;
-        mouseover: (eventArgs: MouseEventArgs) => void;
-        mouseup: (eventArgs: MouseEventArgs) => void;
-        rightclick: (eventArgs: MouseEventArgs) => void;
     }
 
     export interface PolygonOptions {
@@ -446,18 +398,6 @@ declare module Microsoft.Maps {
         setLocation(location: Location): void;
         setOptions(options: PushpinOptions): void;
         toString(): string;
-
-        click: (eventArgs: MouseEventArgs) => void;
-        dblclick: (eventArgs: MouseEventArgs) => void;
-        drag: (object: Pushpin) => any;
-        dragend: (eventArgs: MouseEventArgs) => void;
-        dragstart: (eventArgs: MouseEventArgs) => void;
-        entitychanged: (object: { entity: Entity; }) => any;
-        mousedown: (eventArgs: MouseEventArgs) => void;
-        mouseout: (eventArgs: MouseEventArgs) => void;
-        mouseover: (eventArgs: MouseEventArgs) => void;
-        mouseup: (eventArgs: MouseEventArgs) => void;
-        rightclick: (eventArgs: MouseEventArgs) => void;
     }
 
     export enum EntityState {

--- a/bingmaps/Microsoft.Maps.d.ts
+++ b/bingmaps/Microsoft.Maps.d.ts
@@ -45,7 +45,7 @@ declare module Microsoft.Maps {
         getNorth(): number;
         getNorthwest(): Location;
         getSouth(): number;
-        getSouthEast(): Location;
+        getSoutheast(): Location;
         getWest(): number;
         intersects(rect: LocationRect): boolean;
         toString(): string;
@@ -251,14 +251,14 @@ declare module Microsoft.Maps {
     }
 
     export interface EntityCollectionOptions {
-        bubble: boolean;
-        visible: boolean;
-        zIndex: number;
+        bubble?: boolean;
+        visible?: boolean;
+        zIndex?: number;
     }
 
     export class EntityCollection {
 
-        constructor(options: EntityCollectionOptions);
+        constructor(options?: EntityCollectionOptions);
 
         clear(): void;
         get(index: number): Entity;
@@ -353,7 +353,7 @@ declare module Microsoft.Maps {
     export interface PolylineOptions {
 
         strokeColor: Color;
-        strokeDashArray: string;
+        strokeDashArray?: string;
         strokeThickness: number;
         visible: boolean;
     }
@@ -376,7 +376,7 @@ declare module Microsoft.Maps {
     export interface PolygonOptions {
 
         strokeColor: Color;
-        strokeDashArray: string;
+        strokeDashArray?: string;
         strokeThickness: number;
         visible: boolean;
     }
@@ -492,7 +492,7 @@ declare module Microsoft.Maps {
 
     export interface PositionCircleOptions {
         polygonOptions: PolygonOptions;
-        showOnMap: boolean;
+        showOnMap?: boolean;
     }
 
     export class PositionError {


### PR DESCRIPTION
Removed event declarations on classes where the events are actually registered using the Microsoft.Maps.Events.addHandler method. These fields don't actually appear (runtime) on the entities; despite being defined in the MS documentation.
