### PR TITLE
Add prototype accessor `moment.fn`

### DIFF
--- a/moment/moment-external-tests.ts
+++ b/moment/moment-external-tests.ts
@@ -456,4 +456,8 @@ moment.locale('en', {
     }
 });
 
+moment.fn.toJSON = function() {
+    return this.format();
+};
+
 console.log(moment.version);

--- a/moment/moment-node.d.ts
+++ b/moment/moment-node.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Moment.js 2.8.0
 // Project: https://github.com/timrwood/moment
-// Definitions by: Michael Lakerveld <https://github.com/Lakerfield>, Aaron King <https://github.com/kingdango>, Hiroki Horiuchi <https://github.com/horiuchi>, Dick van den Brink <https://github.com/DickvdBrink>, Adi Dahiya <https://github.com/adidahiya>
+// Definitions by: Michael Lakerveld <https://github.com/Lakerfield>, Aaron King <https://github.com/kingdango>, Hiroki Horiuchi <https://github.com/horiuchi>, Dick van den Brink <https://github.com/DickvdBrink>, Adi Dahiya <https://github.com/adidahiya>, Matt Brooks <https://github.com/EnableSoftware>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module moment {
@@ -371,6 +371,7 @@ declare module moment {
     interface MomentStatic {
 
         version: string;
+        fn: Moment;
 
         (): Moment;
         (date: number): Moment;

--- a/moment/moment.d.ts
+++ b/moment/moment.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Moment.js 2.8.0
 // Project: https://github.com/timrwood/moment
-// Definitions by: Michael Lakerveld <https://github.com/Lakerfield>, Aaron King <https://github.com/kingdango>, Hiroki Horiuchi <https://github.com/horiuchi>, Dick van den Brink <https://github.com/DickvdBrink>, Adi Dahiya <https://github.com/adidahiya>
+// Definitions by: Michael Lakerveld <https://github.com/Lakerfield>, Aaron King <https://github.com/kingdango>, Hiroki Horiuchi <https://github.com/horiuchi>, Dick van den Brink <https://github.com/DickvdBrink>, Adi Dahiya <https://github.com/adidahiya>, Matt Brooks <https://github.com/EnableSoftware>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="moment-node.d.ts" />


### PR DESCRIPTION
The `Moment` prototype is exposed through `moment.fn`. See [moment issue #2540](https://github.com/moment/moment/issues/2540).
