### PR TITLE
Ui-Grid: Fix Column Defs

### DIFF
--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -192,7 +192,7 @@ declare module uiGrid {
     export interface IGridOptions {
         aggregationCalcThrottle?: number;
         appScopeProvider?: ng.IScope | Object;
-        columnDefs?: IColumnDef;
+        columnDefs?: Array<IColumnDef>;
         columnFooterHeight?: number;
         columnVirtualizationThreshold?: number;
         data?: Array<any> | string;


### PR DESCRIPTION
Fix invalid type for IGridOptions.columnDefs.

This duplicates two stalled pull requests (both need to be rebased) #5079 and #5038.  This is a clean branch ready to be merged.  Please close the other two PR's.
