### PR TITLE
Fix bluebird constructor definitions

### DIFF
--- a/bluebird/bluebird-1.0.d.ts
+++ b/bluebird/bluebird-1.0.d.ts
@@ -20,8 +20,7 @@ declare class Promise<R> implements Promise.Thenable<R> {
 	/**
 	 * Create a new promise. The passed in function will receive functions `resolve` and `reject` as its arguments which can be called to seal the fate of the created promise.
 	 */
-	constructor(callback: (resolve: (thenable: Promise.Thenable<R>) => void, reject: (error: any) => void) => void);
-	constructor(callback: (resolve: (result: R) => void, reject: (error: any) => void) => void);
+	constructor(callback: (resolve: (thenableOrResult: R | Promise.Thenable<R>) => void, reject: (error: any) => void) => void);
 
 	/**
 	 * Promises/A+ `.then()` with progress handler. Returns a new promise chained from this promise. The new promise will be rejected or resolved dedefer on the passed `fulfilledHandler`, `rejectedHandler` and the state of this promise.

--- a/bluebird/bluebird.d.ts
+++ b/bluebird/bluebird.d.ts
@@ -20,8 +20,7 @@ declare class Promise<R> implements Promise.Thenable<R>, Promise.Inspection<R> {
 	/**
 	 * Create a new promise. The passed in function will receive functions `resolve` and `reject` as its arguments which can be called to seal the fate of the created promise.
 	 */
-	constructor(callback: (resolve: (thenable: Promise.Thenable<R>) => void, reject: (error: any) => void) => void);
-	constructor(callback: (resolve: (result: R) => void, reject: (error: any) => void) => void);
+	constructor(callback: (resolve: (thenableOrResult: R | Promise.Thenable<R>) => void, reject: (error: any) => void) => void);
 
 	/**
 	 * Promises/A+ `.then()` with progress handler. Returns a new promise chained from this promise. The new promise will be rejected or resolved dedefer on the passed `fulfilledHandler`, `rejectedHandler` and the state of this promise.


### PR DESCRIPTION
You can find reasoning and explanation here: https://github.com/Microsoft/TypeScript/issues/4254

Basically without this, I cannot just use new `Promise<number>` and have `resolve(123)` because of 

```
error TS2345: Argument of type 'number' is not assignable to parameter of type 'Thenable<number>'.
  Property 'then' is missing in type 'Number'.
```
