### PR TITLE
Updated Gulp to be compatible with TypeScript new import/export syntax.

### DIFF
--- a/gulp-autoprefixer/gulp-autoprefixer-tests.ts
+++ b/gulp-autoprefixer/gulp-autoprefixer-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./gulp-autoprefixer.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
+import gulp from "gulp";
 import autoprefixer = require("gulp-autoprefixer");
 
 gulp.src("test.css")

--- a/gulp-concat/gulp-concat-tests.ts
+++ b/gulp-concat/gulp-concat-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="./gulp-concat.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require("gulp");
+import gulp from "gulp";
 import concat = require("gulp-concat");
 
 gulp.task("concat:simple", () => {

--- a/gulp-csso/gulp-csso-tests.ts
+++ b/gulp-csso/gulp-csso-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="gulp-csso.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require('gulp');
+import gulp from 'gulp';
 import csso = require('gulp-csso');
 
 gulp.task('default', () =>

--- a/gulp-debug/gulp-debug-tests.ts
+++ b/gulp-debug/gulp-debug-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="gulp-debug.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require('gulp');
+import gulp from 'gulp';
 import debug = require('gulp-debug');
 
 gulp.task('default', () =>

--- a/gulp-flatten/gulp-flatten-tests.ts
+++ b/gulp-flatten/gulp-flatten-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="./gulp-flatten.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require("gulp");
+import gulp from "gulp";
 import flatten = require("gulp-flatten");
 
 gulp.task("flatten:simple", () => {

--- a/gulp-gh-pages/gulp-gh-pages-tests.ts
+++ b/gulp-gh-pages/gulp-gh-pages-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./gulp-gh-pages.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
+import gulp from "gulp";
 import ghPages = require("gulp-gh-pages");
 
 gulp.src("test.css")

--- a/gulp-if/gulp-if-tests.ts
+++ b/gulp-if/gulp-if-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./gulp-if.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
+import gulp from "gulp";
 import _if = require("gulp-if");
 
 gulp.src("test.css")

--- a/gulp-inject/gulp-inject-tests.ts
+++ b/gulp-inject/gulp-inject-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="./gulp-inject.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require("gulp");
+import gulp from "gulp";
 import inject = require("gulp-inject");
 
 gulp.task("inject:simple", () => {

--- a/gulp-istanbul/gulp-istanbul-tests.ts
+++ b/gulp-istanbul/gulp-istanbul-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./gulp-istanbul.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
+import gulp from "gulp";
 import istanbul = require("gulp-istanbul");
 
 function testFramework(): NodeJS.ReadWriteStream {

--- a/gulp-jasmine-browser/gulp-jasmine-browser-tests.ts
+++ b/gulp-jasmine-browser/gulp-jasmine-browser-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="gulp-jasmine-browser.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require('gulp');
+import gulp from 'gulp';
 import jasmineBrowser = require('gulp-jasmine-browser');
 
 gulp.task('jasmine', () =>

--- a/gulp-less/gulp-less-tests.ts
+++ b/gulp-less/gulp-less-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="./gulp-less.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require("gulp");
+import gulp from "gulp";
 import less = require("gulp-less");
 
 gulp.task("less", () => {

--- a/gulp-load-plugins/gulp-load-plugins-tests.ts
+++ b/gulp-load-plugins/gulp-load-plugins-tests.ts
@@ -3,7 +3,7 @@
 /// <reference path="../gulp-concat/gulp-concat" />
 /// <reference path="gulp-load-plugins" />
 
-import gulp = require('gulp');
+import gulp from 'gulp';
 import gulpConcat = require('gulp-concat');
 import gulpLoadPlugins = require('gulp-load-plugins');
 

--- a/gulp-minify-css/gulp-minify-css-tests.ts
+++ b/gulp-minify-css/gulp-minify-css-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="./gulp-minify-css.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require("gulp");
+import gulp from "gulp";
 import minifyCSS = require("gulp-minify-css");
 
 gulp.task("minify-css", () => {

--- a/gulp-minify-html/gulp-minify-html-tests.ts
+++ b/gulp-minify-html/gulp-minify-html-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="gulp-minify-html.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require('gulp');
+import gulp from 'gulp';
 import minifyHtml = require('gulp-minify-html');
 
 minifyHtml();

--- a/gulp-mocha/gulp-mocha-tests.ts
+++ b/gulp-mocha/gulp-mocha-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./gulp-mocha.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
+import gulp from "gulp";
 import mocha = require("gulp-mocha");
 
 gulp.task('default', function () {

--- a/gulp-protractor/gulp-protractor-tests.ts
+++ b/gulp-protractor/gulp-protractor-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="gulp-protractor.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require('gulp');
+import gulp from 'gulp';
 import protractor = require('gulp-protractor');
 
 gulp.src(["./src/tests/*.js"])

--- a/gulp-rename/gulp-rename-tests.ts
+++ b/gulp-rename/gulp-rename-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./gulp-rename.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
+import gulp from "gulp";
 import rename = require("gulp-rename");
 
 // rename via string

--- a/gulp-replace/gulp-replace-tests.ts
+++ b/gulp-replace/gulp-replace-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./gulp-replace.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
+import gulp from "gulp";
 import replace = require("gulp-replace");
 
 gulp.task('templates', function(){

--- a/gulp-rev-replace/gulp-rev-replace-tests.ts
+++ b/gulp-rev-replace/gulp-rev-replace-tests.ts
@@ -3,7 +3,7 @@
 /// <reference path="../gulp-rev/gulp-rev.d.ts" />
 /// <reference path="../gulp-useref/gulp-useref.d.ts" />
 
-import gulp = require('gulp');
+import gulp from 'gulp';
 import revReplace = require('gulp-rev-replace');
 import rev = require('gulp-rev');
 import useref = require('gulp-useref');

--- a/gulp-rev/gulp-rev-tests.ts
+++ b/gulp-rev/gulp-rev-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="gulp-rev.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require('gulp');
+import gulp from 'gulp';
 import rev = require('gulp-rev');
 
 gulp.task('default', () =>

--- a/gulp-ruby-sass/gulp-ruby-sass-tests.ts
+++ b/gulp-ruby-sass/gulp-ruby-sass-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./gulp-ruby-sass.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
+import gulp from "gulp";
 import sass = require("gulp-ruby-sass");
 
 gulp.task('sass', function () {

--- a/gulp-sass/gulp-sass-tests.ts
+++ b/gulp-sass/gulp-sass-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./gulp-sass.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
+import gulp from "gulp";
 import sass = require("gulp-sass");
 
 gulp.task('sass', function () {

--- a/gulp-size/gulp-size-tests.ts
+++ b/gulp-size/gulp-size-tests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../gulp/gulp.d.ts" />
 /// <reference path="../gulp-debug/gulp-debug.d.ts" />
 
-import gulp = require('gulp');
+import gulp from 'gulp';
 import size = require('gulp-size');
 import debug = require('gulp-debug');
 

--- a/gulp-sourcemaps/gulp-sourcemaps-tests.ts
+++ b/gulp-sourcemaps/gulp-sourcemaps-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./gulp-sourcemaps.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
+import gulp from "gulp";
 import sourcemaps = require("gulp-sourcemaps");
 
 function plugin1(): NodeJS.ReadWriteStream { return null; }

--- a/gulp-tsd/gulp-tsd-tests.ts
+++ b/gulp-tsd/gulp-tsd-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="./gulp-tsd.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require("gulp");
+import gulp from "gulp";
 import tsd = require("gulp-tsd");
 
 gulp.task("tsd", () => {

--- a/gulp-tslint/gulp-tslint-tests.ts
+++ b/gulp-tslint/gulp-tslint-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="./gulp-tslint.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
 /// <reference path="../vinyl/vinyl.d.ts"/>
-import gulp = require("gulp");
+import gulp from "gulp";
 import tslint = require("gulp-tslint");
 import vinyl = require("vinyl");
 

--- a/gulp-typedoc/gulp-typedoc-tests.ts
+++ b/gulp-typedoc/gulp-typedoc-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./gulp-typedoc.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
+import gulp from "gulp";
 import typedoc = require("gulp-typedoc");
 
 gulp.task("typedoc", function() {

--- a/gulp-typescript/gulp-typescript-tests.ts
+++ b/gulp-typescript/gulp-typescript-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./gulp-typescript.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
+import gulp from "gulp";
 import typescript = require("gulp-typescript");
 
 function merge(streams: NodeJS.ReadWriteStream[]): NodeJS.ReadWriteStream {

--- a/gulp-uglify/gulp-uglify-tests.ts
+++ b/gulp-uglify/gulp-uglify-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./gulp-uglify.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
+import gulp from "gulp";
 import uglify = require("gulp-uglify");
 
 

--- a/gulp-useref/gulp-useref-tests.ts
+++ b/gulp-useref/gulp-useref-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="gulp-useref.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require('gulp');
+import gulp from 'gulp';
 import useref = require('gulp-useref');
 
 gulp.task('default', () => {

--- a/gulp-util/gulp-util-tests.ts
+++ b/gulp-util/gulp-util-tests.ts
@@ -4,7 +4,7 @@
 /// <reference path='../through2/through2.d.ts' />
 /// <reference path='gulp-util.d.ts' />
 
-import gulp = require('gulp');
+import gulp from 'gulp';
 import util = require('gulp-util');
 import path = require('path');
 import should = require('should');

--- a/gulp-watch/gulp-watch-tests.ts
+++ b/gulp-watch/gulp-watch-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="gulp-watch.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require('gulp');
+import gulp from 'gulp';
 import watch = require('gulp-watch');
 
 gulp.task('stream', () =>

--- a/gulp/gulp-tests.ts
+++ b/gulp/gulp-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="gulp.d.ts" />
 /// <reference path="../browser-sync/browser-sync.d.ts"/>
 
-import gulp = require("gulp");
+import gulp from "gulp";
 import browserSync = require("browser-sync");
 
 var typescript: IGulpPlugin = null; // this would be the TypeScript compiler

--- a/gulp/gulp.d.ts
+++ b/gulp/gulp.d.ts
@@ -263,7 +263,7 @@ declare module gulp {
 
 declare module "gulp" {
     var _tmp:gulp.Gulp;
-    export = _tmp;
+    export default _tmp;
 }
 
 interface IGulpPlugin {

--- a/karma/karma-tests.ts
+++ b/karma/karma-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="karma.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require('gulp');
+import gulp from 'gulp';
 import karma = require('karma');
 
 function runKarma(singleRun: boolean): void {

--- a/main-bower-files/main-bower-files-tests.ts
+++ b/main-bower-files/main-bower-files-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="./main-bower-files.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require("gulp");
+import gulp from "gulp";
 import mainBowerFiles = require("main-bower-files");
 
 gulp.task("main-bower-files:simple", () => {

--- a/merge2/merge2-tests.ts
+++ b/merge2/merge2-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="merge2.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require('gulp');
+import gulp from 'gulp';
 import merge2 = require('merge2');
 
 gulp.task('app-js', () =>

--- a/run-sequence/run-sequence-tests.ts
+++ b/run-sequence/run-sequence-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="./run-sequence.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require("gulp");
+import gulp from "gulp";
 import tmp = require("run-sequence");
 var runSequence = tmp.use(gulp);
 

--- a/vinyl-source-stream/vinyl-source-stream-tests.ts
+++ b/vinyl-source-stream/vinyl-source-stream-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./vinyl-source-stream.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
+import gulp from "gulp";
 import vinylSourceStream = require("vinyl-source-stream");
 
 gulp.src("test.js")


### PR DESCRIPTION
Compatible with TypeScript 1.5.3+ when using the new import/export syntax. All declarations files depending on Gulp had to be updated too. Declarations are no longer compatible with the old "Import Require Declarations" syntax.
