### PR TITLE
Update(node.d.ts): add statusMessage property to interface ServerResponse

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -453,6 +453,7 @@ declare module "http" {
         writeHead(statusCode: number, reasonPhrase?: string, headers?: any): void;
         writeHead(statusCode: number, headers?: any): void;
         statusCode: number;
+        statusMessage: string;
         setHeader(name: string, value: string): void;
         sendDate: boolean;
         getHeader(name: string): string;


### PR DESCRIPTION
Seems [statusMessage](https://nodejs.org/api/http.html#http_response_statusmessage) is missing.
