### PR TITLE
Update moment-node.d.ts

### DIFF
--- a/moment/moment-node.d.ts
+++ b/moment/moment-node.d.ts
@@ -401,6 +401,7 @@ declare module moment {
         unix(timestamp: number): Moment;
 
         invalid(parsingFlags?: Object): Moment;
+        invalidAt(): number;
         isMoment(): boolean;
         isMoment(m: any): boolean;
         isDate(m: any): boolean;

--- a/moment/moment-node.d.ts
+++ b/moment/moment-node.d.ts
@@ -193,6 +193,7 @@ declare module moment {
         utc(): Moment; // current date/time in UTC mode
 
         isValid(): boolean;
+        invalidAt(): number;
 
         year(y: number): Moment;
         year(): number;
@@ -401,7 +402,6 @@ declare module moment {
         unix(timestamp: number): Moment;
 
         invalid(parsingFlags?: Object): Moment;
-        invalidAt(): number;
         isMoment(): boolean;
         isMoment(m: any): boolean;
         isDate(m: any): boolean;


### PR DESCRIPTION
According to http://momentjs.com/docs/#/parsing/is-valid/, there is a `invalidAt()` method, which is missing in this definition file.

Source: https://github.com/moment/moment/blob/develop/src/lib/moment/valid.js#L13

Thanks,
