### PR TITLE
Make lodash _().concat support its full auto-flattening API

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -123,6 +123,7 @@ result = <_.LoDashObjectWrapper<_.Dictionary<string>>>_(<{ [index: string]: stri
 
 //Wrapped array shortcut methods
 result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).concat(5, 6);
+result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).concat([5, 6]);
 result = <string>_([1, 2, 3, 4]).join(',');
 result = <number>_([1, 2, 3, 4]).pop();
 result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).push(5, 6, 7);

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -252,7 +252,7 @@ declare module _ {
     interface LoDashObjectWrapper<T> extends LoDashWrapperBase<T, LoDashObjectWrapper<T>> { }
 
     interface LoDashArrayWrapper<T> extends LoDashWrapperBase<T[], LoDashArrayWrapper<T>> {
-        concat(...items: T[]): LoDashArrayWrapper<T>;
+        concat(...items: Array<T|Array<T>>): LoDashArrayWrapper<T>;
         join(seperator?: string): string;
         pop(): T;
         push(...items: T[]): LoDashArrayWrapper<T>;


### PR DESCRIPTION
Currently _().concat only supports individual values, not passing arrays.

As shown in the example code in the [lodash docs](https://lodash.com/docs#prototype-concat) and the [concat() source](https://github.com/lodash/lodash/blob/3.10.1/lodash.src.js#L6162), lodash automatically performs a single level of flattening on any passed parameters. This means you can pass parameters that are either `T` or `Array<T>`, while the current types only support passing `T`. This is now a little more general, to support both.
