### PR TITLE
Add optional `options` argument to Bluebird's promisifyAll()

### DIFF
--- a/bluebird/bluebird.d.ts
+++ b/bluebird/bluebird.d.ts
@@ -416,7 +416,7 @@ declare class Promise<R> implements Promise.Thenable<R>, Promise.Inspection<R> {
 	 * Note that the original methods on the object are not overwritten but new methods are created with the `Async`-postfix. For example, if you `promisifyAll()` the node.js `fs` object use `fs.statAsync()` to call the promisified `stat` method.
 	 */
 	// TODO how to model promisifyAll?
-	static promisifyAll(target: Object): Object;
+	static promisifyAll(target: Object, options?: Object): Object;
 
 	/**
 	 * Returns a function that can use `yield` to run asynchronous code synchronously. This feature requires the support of generators which are drafted in the next version of the language. Node version greater than `0.11.2` is required and needs to be executed with the `--harmony-generators` (or `--harmony`) command-line switch.


### PR DESCRIPTION
To allow for custom promisifiers, filters and suffixes.

For example, the following (JavaScript, ES5) example from the Bluebird README was not possible prior to this edit:

``` JavaScript
function DOMPromisifier(originalMethod) {
    // return a function
    return function promisified() {
        var args = [].slice.call(arguments);
        // Needed so that the original method can be called with the correct receiver
        var self = this;
        // which returns a promise
        return new Promise(function(resolve, reject) {
            args.push(resolve, reject);
            originalMethod.apply(self, args);
        });
    };
}

// Promisify e.g. chrome.browserAction
Promise.promisifyAll(chrome.browserAction, {promisifier: DOMPromisifier});
```

After the edit, the following (TypeScript) example now works:

``` TypeScript
import * as bluebird from 'bluebird';

function customPromisifier(originalMethod) {

  // return a function
  return function promisified () {
    let args = [].slice.call(arguments);

    // which returns a promise
    return new bluebird(
      (resolve, reject) => {
        args.push(resolve, reject);
        originalMethod.apply(this, args);
      }
    );
  };
}

this.newlyPromisifiedFn = bluebird.promisifyAll(this.unpromisifiedFn, {
      promisifier: customPromisifier
    });
```

(ref: https://github.com/petkaantonov/bluebird/blob/master/API.md#option-promisifier)
