### PR TITLE
Remove unnecessary extra generic parameter in Lodash's _().where

### DIFF
--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -5153,7 +5153,7 @@ declare module _ {
         /**
         * @see _.where
         **/
-        where<T, U extends {}>(properties: U): LoDashArrayWrapper<T>;
+        where<U extends {}>(properties: U): LoDashArrayWrapper<T>;
     }
 
     /********


### PR DESCRIPTION
The chained `_().where()` in Lodash had a generic method parameter T (in addition to another U parameter, untouched by this change).

It's already on a generic type though, which already introduces a T parameter (`LoDashArrayWrapper<T>`).

At best I would've thought this method parameter redundant. In reality though it seems to hide the other generic parameter, or something like that, so TypeScript can't infer the generic parameter on the return type of this function, even though it's on a `LoDashArrayWrapper<T>` and returns a `LoDashArrayWrapper<T>`. That means I have to cast the final result I get back every time, annoyingly.

Note that `.where()` is always returning elements of the same type as the original array, so this is always safe, and this also now closer matches the definition of `_().reject` at https://github.com/borisyankov/DefinitelyTyped/blob/master/lodash/lodash.d.ts#L4570, which should have an identical type, and does already work correctly for me.
