### PR TITLE
Correct THREE.MOUSE enum

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -11,10 +11,7 @@ declare module THREE {
     export var REVISION: string;
 
     // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent.button
-    export enum MOUSE { }
-    export var LEFT: MOUSE;
-    export var MIDDLE: MOUSE;
-    export var RIGHT: MOUSE;
+    export enum MOUSE {LEFT, MIDDLE, RIGHT}
 
     // GL STATE CONSTANTS
     export enum CullFace { }


### PR DESCRIPTION
Two changes to bring the definitions up-to-date with Three.js:
1. Correct enum `THREE.MOUSE` to include `{LEFT, MIDDLE, RIGHT}`. Without this change, the typescript type checker complains when referencing e.g. `THREE.MOUSE.LEFT`:

```
Error:(65, 51) TS2339: Property 'LEFT' does not exist on type 'typeof MOUSE'.
```
1. Remove properties `THREE.LEFT`, `THREE.MIDDLE`, and `THREE.RIGHT` as those are not defined in the most recent version (r71) of [Three.js](https://github.com/mrdoob/three.js/blob/master/src/Three.js). Those symbols exist only inside the enum, per above.
