### PR TITLE
gulp-typescript - added createProject overload

### DIFF
--- a/gulp-typescript/gulp-typescript-tests.ts
+++ b/gulp-typescript/gulp-typescript-tests.ts
@@ -26,6 +26,11 @@ var tsProject = typescript.createProject({
     noExternalResolve: true
 });
 
+
+var mainTscProject = typescript.createProject("tsconfig.json", {
+   target: "es6"
+});
+
 gulp.task('scripts', function() {
     var tsResult = gulp.src('lib/*.ts')
         .pipe(typescript(tsProject));

--- a/gulp-typescript/gulp-typescript.d.ts
+++ b/gulp-typescript/gulp-typescript.d.ts
@@ -8,7 +8,7 @@
 declare module "gulp-typescript" {
     function GulpTypescript(params: GulpTypescript.Params, filters?: GulpTypescript.FilterSettings, reporter?: GulpTypescript.Reporter): GulpTypescript.CompilationStream;
 
-    module GulpTypescript {        
+    module GulpTypescript {
         export function createProject(params: Params): Params;
         export function createProject(file: string, params: Params): Params;
         export function filter(filters: FilterSettings): CompilationStream;

--- a/gulp-typescript/gulp-typescript.d.ts
+++ b/gulp-typescript/gulp-typescript.d.ts
@@ -8,8 +8,9 @@
 declare module "gulp-typescript" {
     function GulpTypescript(params: GulpTypescript.Params, filters?: GulpTypescript.FilterSettings, reporter?: GulpTypescript.Reporter): GulpTypescript.CompilationStream;
 
-    module GulpTypescript {
+    module GulpTypescript {        
         export function createProject(params: Params): Params;
+        export function createProject(file: string, params: Params): Params;
         export function filter(filters: FilterSettings): CompilationStream;
         interface Params {
             declarationFiles?: boolean;


### PR DESCRIPTION
Implemented overload which loads the existing config, which is generally used to keep in sync editor tooling + build settings using tsconfig.json
