### PR TITLE
lodash: fixed push() and unshift() methods of Array wrapper

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -125,7 +125,7 @@ result = <_.LoDashObjectWrapper<_.Dictionary<string>>>_(<{ [index: string]: stri
 result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).concat(5, 6);
 result = <string>_([1, 2, 3, 4]).join(',');
 result = <number>_([1, 2, 3, 4]).pop();
-_([1, 2, 3, 4]).push(5, 6, 7);
+result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).push(5, 6, 7);
 result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).reverse();
 result = <number>_([1, 2, 3, 4]).shift();
 result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).slice(1, 2);
@@ -133,7 +133,7 @@ result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).slice(2);
 result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).sort((a, b) => 1);
 result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).splice(1);
 result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).splice(1, 2, 5, 6);
-result = <_.LoDashWrapper<number>>_([1, 2, 3, 4]).unshift(5, 6);
+result = <_.LoDashArrayWrapper<number>>_([1, 2, 3, 4]).unshift(5, 6);
 
 result = <number[]>_.tap([1, 2, 3, 4], function (array) { console.log(array); });
 result = <_.LoDashWrapper<string>>_('test').tap(function (value) { console.log(value); });

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -255,14 +255,14 @@ declare module _ {
         concat(...items: T[]): LoDashArrayWrapper<T>;
         join(seperator?: string): string;
         pop(): T;
-        push(...items: T[]): void;
+        push(...items: T[]): LoDashArrayWrapper<T>;
         reverse(): LoDashArrayWrapper<T>;
         shift(): T;
         slice(start: number, end?: number): LoDashArrayWrapper<T>;
         sort(compareFn?: (a: T, b: T) => number): LoDashArrayWrapper<T>;
         splice(start: number): LoDashArrayWrapper<T>;
         splice(start: number, deleteCount: number, ...items: any[]): LoDashArrayWrapper<T>;
-        unshift(...items: any[]): LoDashWrapper<number>;
+        unshift(...items: T[]): LoDashArrayWrapper<T>;
     }
 
     interface LoDashNumberArrayWrapper extends LoDashArrayWrapper<number> { }


### PR DESCRIPTION
I could not find a reference to the documentation, but it works that way:

``` javascript
console.log(_([1, 2]).push(3, 4).value())
// -> [1, 2, 3, 4]

console.log(_([3, 4]).unshift(1, 2).value())
// -> [1, 2, 3, 4]
```
