### PR TITLE
Added WebContents.print(), webContents.printToPDF() and aliases for BrowserWindow

### DIFF
--- a/github-electron/github-electron-main-tests.ts
+++ b/github-electron/github-electron-main-tests.ts
@@ -51,6 +51,35 @@ app.on('ready', () => {
 		// when you should delete the corresponding element.
 		mainWindow = null;
 	});
+
+	mainWindow.print({silent: true, printBackground: false});
+	mainWindow.webContents.print({silent: true, printBackground: false});
+	mainWindow.print();
+	mainWindow.webContents.print();
+
+	mainWindow.print({silent: true, printBackground: false});
+	mainWindow.webContents.print({silent: true, printBackground: false});
+	mainWindow.print();
+	mainWindow.webContents.print();
+
+	mainWindow.printToPDF({
+		marginsType: 1,
+		pageSize: 'A3',
+		printBackground: true,
+		printSelectionOnly: true,
+		landscape: true,
+	}, (error: Error, data: Buffer) => {});
+
+	mainWindow.webContents.printToPDF({
+		marginsType: 1,
+		pageSize: 'A3',
+		printBackground: true,
+		printSelectionOnly: true,
+		landscape: true,
+	}, (error: Error, data: Buffer) => {});
+
+	mainWindow.printToPDF({}, (err, data) => {});
+	mainWindow.webContents.printToPDF({}, (err, data) => {});
 });
 
 // Desktop environment integration

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -377,17 +377,22 @@ declare module GitHubElectron {
 		capturePage(rect: Rectangle, callback: (image: NativeImage) => void): void;
 		capturePage(callback: (image: NativeImage) => void): void;
 		/**
-		 * Prints the window's web page. Calling window.print() in a web page is
-		 * equivalent to calling BrowserWindow.print({silent: false, printBackground: false}).
+		 * Same with webContents.print([options])
 		 */
 		print(options?: {
-			/**
-			 * When false, Electron will pick up system's default printer and default
-			 * settings for printing.
-			 */
 			silent?: boolean;
 			printBackground?: boolean;
 		}): void;
+		/**
+		 * Same with webContents.printToPDF([options])
+		 */
+		printToPDF(options: {
+			marginsType?: number;
+			pageSize?: string;
+			printBackground?: boolean;
+			printSelectionOnly?: boolean;
+			landscape?: boolean;
+		}, callback: (error: Error, data: Buffer) => void): void;
 		/**
 		 * Same with webContents.loadUrl(url).
 		 */
@@ -659,6 +664,62 @@ declare module GitHubElectron {
 			 * @param isFulfilled Whether the JS promise is fulfilled.
 			 */
 			(isFulfilled: boolean) => void): void;
+		/**
+		 *
+		 * Prints window's web page. When silent is set to false, Electron will pick up system's default printer and default settings for printing.
+		 * Calling window.print() in web page is equivalent to call WebContents.print({silent: false, printBackground: false}).
+		 * Note:
+		 *   On Windows, the print API relies on pdf.dll. If your application doesn't need print feature, you can safely remove pdf.dll in saving binary size.
+		 */
+		print(options?: {
+			/**
+			 *  Don't ask user for print settings, defaults to false
+			 */
+			silent?: boolean;
+			/**
+			 * Also prints the background color and image of the web page, defaults to false.
+			 */
+			printBackground: boolean;
+		}): void;
+		/**
+		 * Prints windows' web page as PDF with Chromium's preview printing custom settings.
+		 */
+		printToPDF(options: {
+			/**
+			 * Specify the type of margins to use. Default is 0.
+			 *   0 - default
+			 *   1 - none
+			 *   2 - minimum
+			 */
+			marginsType?: number;
+			/**
+			 * String - Specify page size of the generated PDF. Default is A4.
+			 *   A4
+			 *   A3
+			 *   Legal
+			 *   Letter
+			 *   Tabloid
+			 */
+			pageSize?: string;
+			/**
+			 * Whether to print CSS backgrounds. Default is false.
+			 */
+			printBackground?: boolean;
+			/**
+			 * Whether to print selection only. Default is false.
+			 */
+			printSelectionOnly?: boolean;
+			/**
+			 * true for landscape, false for portrait.  Default is false.
+			 */
+			landscape?: boolean;
+		},
+		/**
+		 * Callback function on completed converting to PDF.
+		 *   error Error
+		 *   data Buffer - PDF file content
+		 */
+		callback: (error: Error, data: Buffer) => void): void;
 		/**
 		 * Send args.. to the web page via channel in asynchronous message, the web page
 		 * can handle it by listening to the channel event of ipc module.


### PR DESCRIPTION
### Changes
1. Previously, only `BrowserWindow.print()` existed.  But it is just an alias of `WebContents.print()`
2. New API `WebContents.printToPDF()` and its alias `BrowserWindow.printToPDF()` were added to Electron.
### References
- `WebContents.print([options])`

https://github.com/atom/electron/blob/master/docs/api/browser-window.md#webcontentsprintoptions
- `WebContents.printToPDF(options, callback)`

https://github.com/atom/electron/blob/master/docs/api/browser-window.md#webcontentsprinttopdfoptions-callback
- `BrowserWindow`'s aliases

https://github.com/atom/electron/blob/master/docs/api/browser-window.md#browserwindowprintoptions
