### PR TITLE
Support for request-ip

### DIFF
--- a/request-ip/request-ip-tests.ts
+++ b/request-ip/request-ip-tests.ts
@@ -1,0 +1,10 @@
+/// <reference path="../express/express.d.ts" />
+/// <reference path="request-ip.d.ts" />
+
+import express = require('express');
+import requestIp = require('request-ip');
+
+var ipMiddleware = function(req:express.Request, res:express.Response, next:Function) {
+    var clientIp = requestIp.getClientIp(req);
+    next();
+};

--- a/request-ip/request-ip.d.ts
+++ b/request-ip/request-ip.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for request-ip
+// Project: https://github.com/pbojinov/request-ip
+// Definitions by: Adam Babcock <https://github.com/mrhen>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module "request-ip" {
+    interface Request {
+        headers: {
+            'x-client-ip'?: string;
+            'x-forwarded-for'?: string;
+            'x-real-ip'?: string;
+            'x-cluster-client-ip'?: string;
+            'x-forwarded'?: string;
+            'forwarded-for'?: string;
+            'forwarded'?: string;
+        };
+        connection: {
+            remoteAddress?: string;
+            socket?: {
+                remoteAddress?: string
+            };
+        };
+        info?: {
+            remoteAddress?: string
+        };
+        socket?: {
+            remoteAddress?: string
+        };
+    }
+
+    export function getClientIp(req:Request):string;
+}


### PR DESCRIPTION
The Request interface is kind of odd because the module is doing some bizarre additional checks for fields that aren't on the main `express.Request` interface.

I chose to just make as many fields as I could optional just to play nice with everything. The tests only forces a match on `express.Request` but could easily be extended if necessary.
