### PR TITLE
lodash: Fix _.has and _.result

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -1571,6 +1571,10 @@ result = <void>_(any).noop(true, 'a', 1);
 
 var object = {
     'cheese': 'crumpets',
+    'one': 1,
+    'nested': {
+        'two': 2
+    },
     'stuff': function () {
         return 'nonsense';
     }
@@ -1578,6 +1582,8 @@ var object = {
 
 result = <string>_.result(object, 'cheese');
 result = <string>_.result(object, 'stuff');
+result = _.result<number>(object, 'one');
+result = _.result<number>(object, ['nested', 'two'] );
 
 var tempObject = {};
 result = <typeof _>_.runInContext(tempObject);

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -6810,13 +6810,12 @@ declare module _ {
     //_.has
     interface LoDashStatic {
         /**
-        * Checks if the specified object property exists and is a direct property, instead of an
-        * inherited property.
-        * @param object The object to check.
-        * @param property The property to check for.
-        * @return True if key is a direct property, else false.
+        * Checks if path is a direct property.
+        * @param object The object to query.
+        * @param path The path to check.
+        * @return True if path is a direct property, else False.
         **/
-        has(object: any, property: string): boolean;
+        has(object: any, path: string|string[]): boolean;
     }
 
     //_.invert
@@ -7822,12 +7821,14 @@ declare module _ {
         /**
         * Resolves the value of property on object. If property is a function it will be invoked with
         * the this binding of object and its result returned, else the property value is returned. If
-        * object is falsey then undefined is returned.
-        * @param object The object to inspect.
-        * @param property The property to get the value of.
+        * object is false then undefined is returned.
+        * @param object The object to query.
+        * @param path The path of the property to resolve.
+        * @param defaultValue The value returned if the resolved value is undefined.
         * @return The resolved value.
         **/
-        result(object: any, property: string): any;
+
+        result<T>(object: any, path: string|string[], defaultValue?: T): T;
     }
 
     //_.runInContext


### PR DESCRIPTION
Fixing _.has and _.result:
- has: doc + added support for arrays on path
- result: add return type + doc + added support for arrays on path
