### PR TITLE
[gulp-less] Update the definition of IOptions

### DIFF
--- a/gulp-less/gulp-less-tests.ts
+++ b/gulp-less/gulp-less-tests.ts
@@ -4,6 +4,22 @@
 import gulp = require("gulp");
 import less = require("gulp-less");
 
+// Without options
+gulp.task("less", () => {
+    gulp.src("less/**/*.less")
+        .pipe(less())
+        .pipe(gulp.dest("public/css"));
+});
+
+// With an empty option object
+gulp.task("less", () => {
+    gulp.src("less/**/*.less")
+        .pipe(less({}))
+        .pipe(gulp.dest("public/css"));
+});
+
+
+// With some options
 gulp.task("less", () => {
     gulp.src("less/**/*.less")
         .pipe(less({

--- a/gulp-less/gulp-less.d.ts
+++ b/gulp-less/gulp-less.d.ts
@@ -8,7 +8,8 @@
 declare module "gulp-less" {
 
     interface IOptions {
-        paths: string[];
+        modifyVars?: {};
+        paths?: string[];
         plugins?: any[];
     }
 


### PR DESCRIPTION
I've updated the definitions according to my needs in my current project but it seems possible to use most (all?) options defined by less with gulp-less. I may spend some time in the future to fully update `gulp-less.d.ts` however I'm not sure which is the favored option:
- update the `less.d.ts` and have `gulp-less.d.ts` depends on it even though some options may not make sense for gulp-less.
- update `less.d.ts` and copy-paste to `gulp-less.d.ts` (I've seen copy-paste used in some other typing definitions so...)
