### PR TITLE
Fix cordova file-transfer plugin - download method

### DIFF
--- a/cordova/cordova-tests.ts
+++ b/cordova/cordova-tests.ts
@@ -176,8 +176,12 @@ file.download('http://some.server.com/download.php',
             console.error('Failed with exception ' + err.exception);
         }
     },
-    { headers: null },
-    true);
+    true,
+    {
+      headers: {
+        "Authorization": "Basic dGVzdHVzZXJuYW1lOnRlc3RwYXNzd29yZA=="
+      }
+    });
 
 file.upload('cdvfile://localhost/persistent/path/to/downloads/',
     'http://some.server.com/download.php',

--- a/cordova/plugins/FileTransfer.d.ts
+++ b/cordova/plugins/FileTransfer.d.ts
@@ -53,8 +53,8 @@ interface FileTransfer {
         target: string,
         successCallback: (fileEntry: FileEntry) => void,
         errorCallback: (error: FileTransferError) => void,
-        options?: FileDownloadOptions,
-        trustAllHosts?: boolean): void;
+        trustAllHosts?: boolean,
+        options?: FileDownloadOptions): void;
     /**
      * Aborts an in-progress transfer. The onerror callback is passed a FileTransferError object
      * which has an error code of FileTransferError.ABORT_ERR.
@@ -98,8 +98,8 @@ interface FileUploadOptions {
 
 /** Optional parameters for download method. */
 interface FileDownloadOptions {
-    /** A map of header name/header values. Use an array to specify more than one value. */
-    headers?: Object[];
+    /** A map of header name/header values. */
+    headers?: {};
 }
 
 /** A FileTransferError object is passed to an error callback when an error occurs. */


### PR DESCRIPTION
Typings of the download method of the cordova file-transfer plugin doesn't match with the implementation (see https://github.com/apache/cordova-plugin-file-transfer)
- trustAllHosts is before options
- options header parameters can't be an array, has to be an object
