### PR TITLE
bunyan: fix ts1202 errors when targeting es6

### DIFF
--- a/bunyan/bunyan-test.ts
+++ b/bunyan/bunyan-test.ts
@@ -1,6 +1,6 @@
 /// <reference path="bunyan.d.ts" />
 
-import bunyan = require('bunyan');
+import * as bunyan from 'bunyan';
 
 var ringBufferOptions:bunyan.RingBufferOptions = {
     limit: 100

--- a/bunyan/bunyan.d.ts
+++ b/bunyan/bunyan.d.ts
@@ -6,9 +6,7 @@
 /// <reference path="../node/node.d.ts" />
 
 declare module "bunyan" {
-    import events = require('events');
-    import EventEmitter = events.EventEmitter;
-    import WritableStream = NodeJS.WritableStream;
+    import { EventEmitter } from 'events';
 
     class Logger extends EventEmitter {
         constructor(options:LoggerOptions);
@@ -52,7 +50,7 @@ declare module "bunyan" {
         name: string;
         streams?: Stream[];
         level?: string | number;
-        stream?: WritableStream;
+        stream?: NodeJS.WritableStream;
         serializers?: Serializers;
         src?: boolean;
     }
@@ -65,7 +63,7 @@ declare module "bunyan" {
         type?: string;
         level?: number | string;
         path?: string;
-        stream?: WritableStream | Stream;
+        stream?: NodeJS.WritableStream | Stream;
         closeOnExit?: boolean;
     }
 


### PR DESCRIPTION
Before this change:

```
[ray@localhost DefinitelyTyped]$ tsc --noImplicitAny bunyan/bunyan-test.ts --module commonjs --target es6
bunyan/bunyan-test.ts(3,1): error TS1202: Import assignment cannot be
used when targeting ECMAScript 6 or higher. Consider using 'import * as
ns from "mod"', 'import {a} from "mod"' or 'import d from "mod"'
instead.
bunyan/bunyan.d.ts(9,5): error TS1202: Import assignment cannot be used
when targeting ECMAScript 6 or higher. Consider using 'import * as ns
from "mod"', 'import {a} from "mod"' or 'import d from "mod"' instead.
[ray@localhost DefinitelyTyped]$
```

After this change:

```
[ray@localhost DefinitelyTyped]$ tsc --noImplicitAny bunyan/bunyan-test.ts --module commonjs --target es6
[ray@localhost DefinitelyTyped]$
```
