### PR TITLE
Remove global `module` definition from angular-mocks

### DIFF
--- a/angularjs/angular-mocks.d.ts
+++ b/angularjs/angular-mocks.d.ts
@@ -237,5 +237,6 @@ declare module angular {
 ///////////////////////////////////////////////////////////////////////////////
 // functions attached to global object (window)
 ///////////////////////////////////////////////////////////////////////////////
-declare var module: (...modules: any[]) => any;
+//Use `angular.mock.module` instead of `module`, as `module` conflicts with commonjs.
+//declare var module: (...modules: any[]) => any;
 declare var inject: angular.IInjectStatic;

--- a/bardjs/bardjs-tests.ts
+++ b/bardjs/bardjs-tests.ts
@@ -39,7 +39,7 @@ module bardTests {
         var myService: MyService;
         var $rootScope: angular.IRootScopeService;
 
-        beforeEach(module(bard.$httpBackend, 'myModule'));
+        beforeEach(angular.mock.module(bard.$httpBackend, 'myModule'));
 
         beforeEach(inject(function(_myService_: MyService, _$rootScope_: angular.IRootScopeService) {
             myService = _myService_;
@@ -63,7 +63,7 @@ module bardTests {
     function test_$q() {
         var myService: MyService;
 
-        beforeEach(module(bard.$q, bard.$httpBackend, 'myModule'));
+        beforeEach(angular.mock.module(bard.$q, bard.$httpBackend, 'myModule'));
 
         beforeEach(inject(function(_myService_: MyService) {
             myService = _myService_;
@@ -139,7 +139,7 @@ module bardTests {
      * bard.fakeLogger
      */
     function test_fakeLogger() {
-        beforeEach(module('myModule', bard.fakeLogger));
+        beforeEach(angular.mock.module('myModule', bard.fakeLogger));
         ////
         beforeEach(bard.appModule('myModule', bard.fakeLogger));
         ////
@@ -150,7 +150,7 @@ module bardTests {
      * bard.fakeRouteHelperProvider
      */
     function test_fakeRouteHelperProvider() {
-        beforeEach(module('myModule', bard.fakeRouteHelperProvider));
+        beforeEach(angular.mock.module('myModule', bard.fakeRouteHelperProvider));
         ////
         beforeEach(bard.appModule('myModule', bard.fakeRouteHelperProvider));
         ////
@@ -161,7 +161,7 @@ module bardTests {
      * bard.fakeRouteProvider
      */
     function test_fakeRouteProvider() {
-        beforeEach(module('myModule', bard.fakeRouteProvider));
+        beforeEach(angular.mock.module('myModule', bard.fakeRouteProvider));
         ////
         beforeEach(bard.appModule('myModule', bard.fakeRouteProvider));
         ////
@@ -172,7 +172,7 @@ module bardTests {
      * bard.fakeStateProvider
      */
     function test_fakeStateProvider() {
-        beforeEach(module('myModule', bard.fakeStateProvider));
+        beforeEach(angular.mock.module('myModule', bard.fakeStateProvider));
         ////
         beforeEach(bard.appModule('myModule', bard.fakeStateProvider));
         ////
@@ -183,7 +183,7 @@ module bardTests {
      * bard.fakeToastr
      */
     function test_fakeToastr() {
-        beforeEach(module('myModule', bard.fakeToastr));
+        beforeEach(angular.mock.module('myModule', bard.fakeToastr));
         ////
         beforeEach(bard.appModule('myModule', bard.fakeToastr));
         ////


### PR DESCRIPTION
Because it conficts with commonjs.

See http://wiki.commonjs.org/wiki/Modules/1.1:

> In a module, there must be a free variable "module", that is an Object.

Also see the existing `module` declaration on:
https://github.com/borisyankov/DefinitelyTyped/blob/27e02d6674ffe8186a567515b4c157bcf945911e/node/node.d.ts#L61

Workaround is to use `angular.mock.module` instead of `module`.

Closes #2072
