### PR TITLE
HighchartsDateTimeFormats: add missing millisecond

### DIFF
--- a/highcharts/highcharts.d.ts
+++ b/highcharts/highcharts.d.ts
@@ -13,6 +13,7 @@ interface HighchartsPosition {
 }
 
 interface HighchartsDateTimeFormats {
+    millisecond?: string; // '%H:%M:%S.%L'
     second?: string; // '%H:%M:%S'
     minute?: string; // '%H:%M'
     hour?: string; // '%H:%M'


### PR DESCRIPTION
dateTimeLabelFormats : millisecond 
http://api.highcharts.com/highcharts#xAxis.dateTimeLabelFormats
