### PR TITLE
Fix return value of transform in request-promise.d.ts

### DIFF
--- a/request-promise/request-promise.d.ts
+++ b/request-promise/request-promise.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Christopher Glantschnig <https://github.com/cglantschnig/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
+// Change [0]: 2015/08/20 - Aya Morisawa <https://github.com/AyaMorisawa>
+
 /// <reference path="../node/node.d.ts" />
 /// <reference path="../form-data/form-data.d.ts" />
 /// <reference path="../request/request.d.ts" />
@@ -22,7 +24,7 @@ declare module 'request-promise' {
     module RequestPromiseAPI {
         export interface Options extends request.Options {
             simple?: boolean;
-            transform?: (body: any, response: http.IncomingMessage) => number;
+            transform?: (body: any, response: http.IncomingMessage) => any;
             resolveWithFullResponse?: boolean;
         }
     }


### PR DESCRIPTION
The return value of `transform` function is not necessarily `number`.

See the test of request-promise: https://github.com/request/request-promise/blob/073afb69f43cb2ad81e904edea27c0746a5d0dfe/test/spec/request-test.js#L279
