### PR TITLE
Correct history.js return type annotations

### DIFF
--- a/history/history.d.ts
+++ b/history/history.d.ts
@@ -5,23 +5,23 @@
 
 
 interface HistoryAdapter {
-    bind(element: any, event: string, callback: () => void);
-    trigger(element: any, event: string);
-    onDomLoad(callback: () => void);
+    bind(element: any, event: string, callback: () => void): void;
+    trigger(element: any, event: string): void;
+    onDomLoad(callback: () => void): void;
 }
 
-// Since History is defined in lib.d.ts as well 
+// Since History is defined in lib.d.ts as well
 // the name for our interfaces was chosen to be Historyjs
 // However at runtime you would need to do
-// https://github.com/borisyankov/DefinitelyTyped/issues/277 
+// https://github.com/borisyankov/DefinitelyTyped/issues/277
 // var Historyjs: Historyjs = <any>History;
 
 interface Historyjs {
 
     enabled: boolean;
 
-    pushState(data: any, title: string, url: string);
-    replaceState(data: any, title: string, url: string);
+    pushState(data: any, title: string, url: string): void;
+    replaceState(data: any, title: string, url: string): void;
     getState(): HistoryState;
     getStateByIndex(index: number): HistoryState;
     getCurrentIndex(): number;


### PR DESCRIPTION
This removes compilation errors related to functions having an "implied any" return type
