### PR TITLE
Allow for ES6 Import of Restangular

### DIFF
--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -6,6 +6,13 @@
 
 /// <reference path="../angularjs/angular.d.ts" />
 
+// Support AMD require (copying angular.d.ts approach)
+// allows for import {IRequestConfig} from 'restangular' ES6 approach
+declare module 'restangular' {
+    export = restangular;
+}
+
+
 
 declare module restangular {
 


### PR DESCRIPTION
As per the comment, but allows for valid importing of the modules from restangular using the ES6 syntax.

Copies the approach uses in angular.d.ts
