### PR TITLE
Property manufacturer added to Cordova.Device

### DIFF
--- a/cordova/plugins/Device.d.ts
+++ b/cordova/plugins/Device.d.ts
@@ -26,6 +26,8 @@ interface Device {
     uuid: string;
     /** Get the operating system version. */
     version: string;
+	/** Get the device's manufacturer. */
+	manufacturer: string;
 }
 
 declare var device: Device;


### PR DESCRIPTION
This property exists in the Cordova implementation (device.js). Unfortunately it is not documented.
