### PR TITLE
Added 'defaultFormat' to Moment.js definition

### DIFF
--- a/moment/moment-node.d.ts
+++ b/moment/moment-node.d.ts
@@ -467,6 +467,8 @@ declare module moment {
          */
         ISO_8601(): void;
 
+        defaultFormat: string;
+
     }
 
 }

--- a/moment/moment-tests.ts
+++ b/moment/moment-tests.ts
@@ -459,3 +459,5 @@ moment.locale('en', {
 });
 
 console.log(moment.version);
+
+moment.defaultFormat = 'YYYY-MM-DD HH:mm';


### PR DESCRIPTION
Hi guys,
Seems that 'defaultFormat' field is missed in Moment.js definition
http://momentjs.com/docs/#/displaying/format/
