### PR TITLE
Updated i18next.translate(... options) Missing Parameter Type

### DIFF
--- a/i18next/i18next.d.ts
+++ b/i18next/i18next.d.ts
@@ -17,6 +17,10 @@ interface IResourceStoreKey {
     [key: string]: any;
 }
 
+interface I18nTranslateOptions extends I18nextOptions {
+    defaultValue?: any; // normally a string
+}
+
 interface I18nextOptions {
     lng?: string;                           // Default value: undefined
     load?: string;                          // Default value: 'all'
@@ -108,8 +112,8 @@ interface I18nextStatic {
         load: (languages: string[], options: I18nextOptions, callback: (err: Error, store: IResourceStore) => void ) => void;
         postMissing: (language: string, namespace: string, key: string, defaultValue: any, languages: string[]) => void;
     };
-    t(key: string, options?: any): string;
-    translate(key: string, options?: any): string;
+    t(key: string, options?: I18nTranslateOptions): string;
+    translate(key: string, options?: I18nTranslateOptions): string;
     exists(key: string, options?: any): boolean;
 }
 


### PR DESCRIPTION
Added parameter type to i18next.translate function based on source code from https://github.com/jamuhl/i18next/
Compiled test file successfully. 
