### PR TITLE
Gulp  some modification

### DIFF
--- a/gulp-istanbul/gulp-istanbul-tests.ts
+++ b/gulp-istanbul/gulp-istanbul-tests.ts
@@ -7,7 +7,7 @@ function testFramework(): NodeJS.ReadWriteStream {
     return null;
 }
 
-gulp.task('test', function (cb) {
+gulp.task('test', function (cb: Function) {
     gulp.src(['lib/**/*.js', 'main.js'])
         .pipe(istanbul()) // Covering files
         .pipe(gulp.dest('test-tmp/'))
@@ -19,7 +19,7 @@ gulp.task('test', function (cb) {
         });
 });
 
-gulp.task('test', function (cb) {
+gulp.task('test', function (cb: Function) {
     gulp.src(['lib/**/*.js', 'main.js'])
         .pipe(istanbul({includeUntested: true})) // Covering files
         .pipe(istanbul.hookRequire())
@@ -31,7 +31,7 @@ gulp.task('test', function (cb) {
         });
 });
 
-gulp.task('test', function (cb) {
+gulp.task('test', function (cb: Function) {
     gulp.src(['lib/**/*.js', 'main.js'])
         .pipe(istanbul({includeUntested: true})) // Covering files
         .pipe(istanbul.hookRequire())

--- a/gulp-protractor/gulp-protractor.d.ts
+++ b/gulp-protractor/gulp-protractor.d.ts
@@ -7,6 +7,8 @@
 /// <reference path="../gulp/gulp.d.ts" />
 
 declare module 'gulp-protractor' {
+    import gulp = require('gulp');
+
     interface IOptions {
         configFile?: string;
         args?: Array<string>;

--- a/gulp-protractor/gulp-protractor.d.ts
+++ b/gulp-protractor/gulp-protractor.d.ts
@@ -18,8 +18,8 @@ declare module 'gulp-protractor' {
     interface IGulpProtractor {
         getProtractorDir(): string;
         protractor(options?: IOptions): NodeJS.ReadWriteStream;
-        webdriver_standalone: gulp.ITaskCallback;
-        webdriver_update: gulp.ITaskCallback;
+        webdriver_standalone: gulp.TaskCallback;
+        webdriver_update: gulp.TaskCallback;
     }
 
     var protractor: IGulpProtractor;

--- a/gulp-tsd/gulp-tsd-tests.ts
+++ b/gulp-tsd/gulp-tsd-tests.ts
@@ -9,7 +9,7 @@ gulp.task("tsd", () => {
         .pipe(tsd());
 });
 
-gulp.task("tsd:options", callback => {
+gulp.task("tsd:options", (callback: any) => {
     tsd({
         command: "reinstall",
         config: "tsd.json"

--- a/gulp-tsd/gulp-tsd.d.ts
+++ b/gulp-tsd/gulp-tsd.d.ts
@@ -7,6 +7,7 @@
 /// <reference path="../gulp/gulp.d.ts" />
 
 declare module "gulp-tsd" {
+    import gulp = require('gulp');
 
     interface IOptions {
         command?: string;

--- a/gulp-tsd/gulp-tsd.d.ts
+++ b/gulp-tsd/gulp-tsd.d.ts
@@ -16,7 +16,7 @@ declare module "gulp-tsd" {
         opts?: Object;
     }
 
-    function tsd(opts?: IOptions, callback?: gulp.ITaskCallback): NodeJS.ReadWriteStream;
+    function tsd(opts?: IOptions, callback?: gulp.TaskCallback): NodeJS.ReadWriteStream;
 
     export = tsd;
 }

--- a/gulp-watch/gulp-watch-tests.ts
+++ b/gulp-watch/gulp-watch-tests.ts
@@ -10,7 +10,7 @@ gulp.task('stream', () =>
         .pipe(gulp.dest('build'))
 );
 
-gulp.task('callback', (cb) =>
+gulp.task('callback', (cb: Function) =>
     watch('css/**/*.css', () =>
         gulp.src('css/**/*.css')
             .pipe(watch('css/**/*.css'))

--- a/gulp/gulp-tests.ts
+++ b/gulp/gulp-tests.ts
@@ -4,8 +4,8 @@
 import gulp = require("gulp");
 import browserSync = require("browser-sync");
 
-var typescript: gulp.IGulpPlugin = null; // this would be the TypeScript compiler
-var jasmine: gulp.IGulpPlugin = null; // this would be the jasmine test runner
+var typescript: gulp.GulpPlugin = null; // this would be the TypeScript compiler
+var jasmine: gulp.GulpPlugin = null; // this would be the jasmine test runner
 
 gulp.task('compile', function()
 {

--- a/gulp/gulp-tests.ts
+++ b/gulp/gulp-tests.ts
@@ -4,8 +4,8 @@
 import gulp = require("gulp");
 import browserSync = require("browser-sync");
 
-var typescript: IGulpPlugin = null; // this would be the TypeScript compiler
-var jasmine: IGulpPlugin = null; // this would be the jasmine test runner
+var typescript: gulp.IGulpPlugin = null; // this would be the TypeScript compiler
+var jasmine: gulp.IGulpPlugin = null; // this would be the jasmine test runner
 
 gulp.task('compile', function()
 {
@@ -29,6 +29,7 @@ gulp.task('test', ['compile', 'compile2'], function()
 });
 
 gulp.task('default', ['compile', 'test']);
+
 
 
 var opts = {};
@@ -66,3 +67,5 @@ gulp.task('serve', ['compile'], () => {
     var browser = browserSync.create();
     gulp.watch(['*.html', '*.ts'], ['compile', browser.reload]);
 });
+
+gulp.start('test', 'compile');

--- a/gulp/gulp.d.ts
+++ b/gulp/gulp.d.ts
@@ -46,7 +46,7 @@ declare module "gulp" {
             watch: WatchMethod;
         }
 
-        interface IGulpPlugin {
+        interface GulpPlugin {
             (...args: any[]): NodeJS.ReadWriteStream;
         }
 
@@ -57,22 +57,14 @@ declare module "gulp" {
              * @param glob a single glob or array of globs that indicate which files to watch for changes.
              * @param fn a callback or array of callbacks to be called on each change, or names of task(s) to run when a file changes, added with task().
              */
-            (glob: string|string[], fn: (IWatchCallback|string)): NodeJS.EventEmitter;
+            (glob: string|string[], fn: (WatchCallback|string)): NodeJS.EventEmitter;
             /**
              * Watch files and do something when a file changes. This always returns an EventEmitter that emits change events.
              *
              * @param glob a single glob or array of globs that indicate which files to watch for changes.
              * @param fn a callback or array of callbacks to be called on each change, or names of task(s) to run when a file changes, added with task().
              */
-            (glob: string|string[], fn: (IWatchCallback|string)[]): NodeJS.EventEmitter;
-            /**
-             * Watch files and do something when a file changes. This always returns an EventEmitter that emits change events.
-             *
-             * @param glob a single glob or array of globs that indicate which files to watch for changes.
-             * @param opt options, that are passed to the gaze library.
-             * @param fn a callback or array of callbacks to be called on each change, or names of task(s) to run when a file changes, added with task().
-             */
-            (glob: string|string[], opt: IWatchOptions, fn: (IWatchCallback|string)): NodeJS.EventEmitter;
+            (glob: string|string[], fn: (WatchCallback|string)[]): NodeJS.EventEmitter;
             /**
              * Watch files and do something when a file changes. This always returns an EventEmitter that emits change events.
              *
@@ -80,7 +72,15 @@ declare module "gulp" {
              * @param opt options, that are passed to the gaze library.
              * @param fn a callback or array of callbacks to be called on each change, or names of task(s) to run when a file changes, added with task().
              */
-            (glob: string|string[], opt: IWatchOptions, fn: (IWatchCallback|string)[]): NodeJS.EventEmitter;
+            (glob: string|string[], opt: WatchOptions, fn: (WatchCallback|string)): NodeJS.EventEmitter;
+            /**
+             * Watch files and do something when a file changes. This always returns an EventEmitter that emits change events.
+             *
+             * @param glob a single glob or array of globs that indicate which files to watch for changes.
+             * @param opt options, that are passed to the gaze library.
+             * @param fn a callback or array of callbacks to be called on each change, or names of task(s) to run when a file changes, added with task().
+             */
+            (glob: string|string[], opt: WatchOptions, fn: (WatchCallback|string)[]): NodeJS.EventEmitter;
 
         }
 
@@ -92,7 +92,7 @@ declare module "gulp" {
              * @param outFolder The path (output folder) to write files to. Or a function that returns it, the function will be provided a vinyl File instance.
              * @param opt
              */
-            (outFolder: string|((file:string)=>string), opt?: IDestOptions): NodeJS.ReadWriteStream;
+            (outFolder: string|((file: string) => string), opt?: DestOptions): NodeJS.ReadWriteStream;
         }
 
         interface SrcMethod {
@@ -101,7 +101,7 @@ declare module "gulp" {
              * @param glob Glob or array of globs to read.
              * @param opt Options to pass to node-glob through glob-stream.
              */
-            (glob: string|string[], opt?: ISrcOptions): NodeJS.ReadWriteStream;
+            (glob: string|string[], opt?: SrcOptions): NodeJS.ReadWriteStream;
         }
 
         /**
@@ -109,7 +109,7 @@ declare module "gulp" {
          * Specifies two options in addition to those used by node-glob:
          * https://github.com/isaacs/node-glob#options
          */
-        interface ISrcOptions {
+        interface SrcOptions {
             /**
              * Setting this to <code>false</code> will return <code>file.contents</code> as <code>null</code>
              * and not read the file at all.
@@ -231,7 +231,7 @@ declare module "gulp" {
             globDebug?: boolean;
         }
 
-        interface IDestOptions {
+        interface DestOptions {
             /**
              * The output folder. Only has an effect if provided output folder is relative.
              * Default: process.cwd()
@@ -249,7 +249,7 @@ declare module "gulp" {
          * Options that are passed to <code>gaze</code>.
          * https://github.com/shama/gaze
          */
-        interface IWatchOptions {
+        interface WatchOptions {
             /** Interval to pass to fs.watchFile. */
             interval?: number;
             /** Delay for events called in succession for the same file/event. */
@@ -260,7 +260,7 @@ declare module "gulp" {
             cwd?: string;
         }
 
-        interface IWatchEvent {
+        interface WatchEvent {
             /** The type of change that occurred, either added, changed or deleted. */
             type: string;
             /** The path to the file that triggered the event. */
@@ -270,17 +270,17 @@ declare module "gulp" {
         /**
          * Callback to be called on each watched file change.
          */
-        interface IWatchCallback {
-            (event:IWatchEvent): void;
+        interface WatchCallback {
+            (event: WatchEvent): void;
         }
 
-        interface ITaskCallback {
+        interface TaskCallback {
             /**
              * Defines a task.
              * Tasks may be made asynchronous if they are passing a callback or return a promise or a stream.
              * @param cb callback used to signal asynchronous completion. Caller includes <code>err</code> in case of error.
              */
-            (cb?:(err?:any)=>void): any;
+            (cb?: (err?: any) => void): any;
         }
     }
 

--- a/gulp/gulp.d.ts
+++ b/gulp/gulp.d.ts
@@ -4,268 +4,287 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../node/node.d.ts" />
-
-declare module gulp {
-
-    /**
-     * Options to pass to node-glob through glob-stream.
-     * Specifies two options in addition to those used by node-glob:
-     * https://github.com/isaacs/node-glob#options
-     */
-    interface ISrcOptions {
-        /**
-         * Setting this to <code>false</code> will return <code>file.contents</code> as <code>null</code>
-         * and not read the file at all.
-         * Default: <code>true</code>.
-         */
-        read?: boolean;
-
-        /**
-         * Setting this to false will return <code>file.contents</code> as a stream and not buffer files.
-         * This is useful when working with large files.
-         * Note: Plugins might not implement support for streams.
-         * Default: <code>true</code>.
-         */
-        buffer?: boolean;
-
-        /**
-         * The base path of a glob.
-         *
-         * Default is everything before a glob starts.
-         */
-        base?: string;
-
-        /**
-         * The current working directory in which to search.
-         * Defaults to process.cwd().
-         */
-        cwd?: string;
-
-        /**
-         * The place where patterns starting with / will be mounted onto.
-         * Defaults to path.resolve(options.cwd, "/") (/ on Unix systems, and C:\ or some such on Windows.)
-         */
-        root?: string;
-
-        /**
-         * Include .dot files in normal matches and globstar matches.
-         * Note that an explicit dot in a portion of the pattern will always match dot files.
-         */
-        dot?: boolean;
-
-        /**
-         * By default, a pattern starting with a forward-slash will be "mounted" onto the root setting, so that a valid
-         * filesystem path is returned. Set this flag to disable that behavior.
-         */
-        nomount?: boolean;
-
-        /**
-         * Add a / character to directory matches. Note that this requires additional stat calls.
-         */
-        mark?: boolean;
-
-        /**
-         * Don't sort the results.
-         */
-        nosort?: boolean;
-
-        /**
-         * Set to true to stat all results. This reduces performance somewhat, and is completely unnecessary, unless
-         * readdir is presumed to be an untrustworthy indicator of file existence. It will cause ELOOP to be triggered one
-         * level sooner in the case of cyclical symbolic links.
-         */
-        stat?: boolean;
-
-        /**
-         * When an unusual error is encountered when attempting to read a directory, a warning will be printed to stderr.
-         * Set the silent option to true to suppress these warnings.
-         */
-        silent?: boolean;
-
-        /**
-         * When an unusual error is encountered when attempting to read a directory, the process will just continue on in
-         * search of other matches. Set the strict option to raise an error in these cases.
-         */
-        strict?: boolean;
-
-        /**
-         * See cache property above. Pass in a previously generated cache object to save some fs calls.
-         */
-        cache?: boolean;
-
-        /**
-         * A cache of results of filesystem information, to prevent unnecessary stat calls.
-         * While it should not normally be necessary to set this, you may pass the statCache from one glob() call to the
-         * options object of another, if you know that the filesystem will not change between calls.
-         */
-        statCache?: boolean;
-
-        /**
-         * Perform a synchronous glob search.
-         */
-        sync?: boolean;
-
-        /**
-         * In some cases, brace-expanded patterns can result in the same file showing up multiple times in the result set.
-         * By default, this implementation prevents duplicates in the result set. Set this flag to disable that behavior.
-         */
-        nounique?: boolean;
-
-        /**
-         * Set to never return an empty set, instead returning a set containing the pattern itself.
-         * This is the default in glob(3).
-         */
-        nonull?: boolean;
-
-        /**
-         * Perform a case-insensitive match. Note that case-insensitive filesystems will sometimes result in glob returning
-         * results that are case-insensitively matched anyway, since readdir and stat will not raise an error.
-         */
-        nocase?: boolean;
-
-        /**
-         * Set to enable debug logging in minimatch and glob.
-         */
-        debug?: boolean;
-
-        /**
-         * Set to enable debug logging in glob, but not minimatch.
-         */
-        globDebug?: boolean;
-    }
-
-    interface IDestOptions {
-        /**
-         * The output folder. Only has an effect if provided output folder is relative.
-         * Default: process.cwd()
-         */
-        cwd?: string;
-
-        /**
-         * Octal permission string specifying mode for any folders that need to be created for output folder.
-         * Default: 0777.
-         */
-        mode?: string;
-    }
-
-    /**
-     * Options that are passed to <code>gaze</code>.
-     * https://github.com/shama/gaze
-     */
-    interface IWatchOptions {
-        /** Interval to pass to fs.watchFile. */
-        interval?: number;
-        /** Delay for events called in succession for the same file/event. */
-        debounceDelay?: number;
-        /** Force the watch mode. Either 'auto' (default), 'watch' (force native events), or 'poll' (force stat polling). */
-        mode?: string;
-        /** The current working directory to base file patterns from. Default is process.cwd().. */
-        cwd?: string;
-    }
-
-    interface IWatchEvent {
-        /** The type of change that occurred, either added, changed or deleted. */
-        type: string;
-        /** The path to the file that triggered the event. */
-        path: string;
-    }
-
-    /**
-     * Callback to be called on each watched file change.
-     */
-    interface IWatchCallback {
-        (event:IWatchEvent): void;
-    }
-
-    interface ITaskCallback {
-        /**
-         * Defines a task.
-         * Tasks may be made asynchronous if they are passing a callback or return a promise or a stream.
-         * @param cb callback used to signal asynchronous completion. Caller includes <code>err</code> in case of error.
-         */
-        (cb?:(err?:any)=>void): any;
-    }
-
-    interface EventEmitter {
-        any: any;
-    }
-
-    interface Gulp {
-        /**
-         * Define a task.
-         *
-         * @param name the name of the task. Tasks that you want to run from the command line should not have spaces in them.
-         * @param fn the function that performs the task's operations. Generally this takes the form of gulp.src().pipe(someplugin()).
-         */
-        task(name:string, fn:ITaskCallback): any;
-
-        /**
-         * Define a task.
-         *
-         * @param name the name of the task. Tasks that you want to run from the command line should not have spaces in them.
-         * @param dep an array of tasks to be executed and completed before your task will run.
-         * @param fn the function that performs the task's operations. Generally this takes the form of gulp.src().pipe(someplugin()).
-         */
-        task(name:string, dep:string[], fn?:ITaskCallback): any;
-
-
-        /**
-         * Takes a glob and represents a file structure. Can be piped to plugins.
-         * @param glob a glob string, using node-glob syntax
-         * @param opt an optional option object
-         */
-        src(glob:string, opt?:ISrcOptions): NodeJS.ReadWriteStream;
-
-        /**
-         * Takes a glob and represents a file structure. Can be piped to plugins.
-         * @param glob an array of glob strings, using node-glob syntax
-         * @param opt an optional option object
-         */
-        src(glob:string[], opt?:ISrcOptions): NodeJS.ReadWriteStream;
-
-
-        /**
-         * Can be piped to and it will write files. Re-emits all data passed to it so you can pipe to multiple folders.
-         * Folders that don't exist will be created.
-         *
-         * @param outFolder the path (output folder) to write files to.
-         * @param opt
-         */
-        dest(outFolder:string, opt?:IDestOptions): NodeJS.ReadWriteStream;
-
-        /**
-         * Can be piped to and it will write files. Re-emits all data passed to it so you can pipe to multiple folders.
-         * Folders that don't exist will be created.
-         *
-         * @param outFolder a function that converts a vinyl File instance into an output path
-         * @param opt
-         */
-        dest(outFolder:(file:string)=>string, opt?:IDestOptions): NodeJS.ReadWriteStream;
-
-
-        /**
-         * Watch files and do something when a file changes. This always returns an EventEmitter that emits change events.
-         *
-         * @param glob a single glob or array of globs that indicate which files to watch for changes.
-         * @param opt options, that are passed to the gaze library.
-         * @param fn a callback or array of callbacks to be called on each change, or names of task(s) to run when a file changes, added with gulp.task().
-         */
-        watch(glob:string, fn:(IWatchCallback|string)): EventEmitter;
-        watch(glob:string, fn:(IWatchCallback|string)[]): EventEmitter;
-        watch(glob:string, opt:IWatchOptions, fn:(IWatchCallback|string)): EventEmitter;
-        watch(glob:string, opt:IWatchOptions, fn:(IWatchCallback|string)[]): EventEmitter;
-        watch(glob:string[], fn:(IWatchCallback|string)): EventEmitter;
-        watch(glob:string[], fn:(IWatchCallback|string)[]): EventEmitter;
-        watch(glob:string[], opt:IWatchOptions, fn:(IWatchCallback|string)): EventEmitter;
-        watch(glob:string[], opt:IWatchOptions, fn:(IWatchCallback|string)[]): EventEmitter;
-    }
-}
+/// <reference path="../orchestrator/orchestrator.d.ts" />
 
 declare module "gulp" {
-    var _tmp:gulp.Gulp;
-    export = _tmp;
-}
+    import Orchestrator = require("orchestrator");
 
-interface IGulpPlugin {
-    (...args: any[]): NodeJS.ReadWriteStream;
+    namespace gulp {
+        interface Gulp extends Orchestrator {
+            /**
+             * Define a task
+             * @param name The name of the task.
+             * @param deps An array of task names to be executed and completed before your task will run.
+             * @param fn The function that performs the task's operations. For asynchronous tasks, you need to provide a hint when the task is complete:
+             * <ul>
+             *     <li>Take in a callback</li>
+             *     <li>Return a stream or a promise</li>
+             * </ul>
+             */
+            task: Orchestrator.AddMethod;
+            /**
+             * Emits files matching provided glob or an array of globs. Returns a stream of Vinyl files that can be piped to plugins.
+             * @param glob Glob or array of globs to read.
+             * @param opt Options to pass to node-glob through glob-stream.
+             */
+            src: SrcMethod;
+            /**
+             * Can be piped to and it will write files. Re-emits all data passed to it so you can pipe to multiple folders.
+             * Folders that don't exist will be created.
+             *
+             * @param outFolder The path (output folder) to write files to. Or a function that returns it, the function will be provided a vinyl File instance.
+             * @param opt
+             */
+            dest: DestMethod;
+            /**
+             * Watch files and do something when a file changes. This always returns an EventEmitter that emits change events.
+             *
+             * @param glob a single glob or array of globs that indicate which files to watch for changes.
+             * @param opt options, that are passed to the gaze library.
+             * @param fn a callback or array of callbacks to be called on each change, or names of task(s) to run when a file changes, added with task().
+             */
+            watch: WatchMethod;
+        }
+
+        interface IGulpPlugin {
+            (...args: any[]): NodeJS.ReadWriteStream;
+        }
+
+        interface WatchMethod {
+            /**
+             * Watch files and do something when a file changes. This always returns an EventEmitter that emits change events.
+             *
+             * @param glob a single glob or array of globs that indicate which files to watch for changes.
+             * @param fn a callback or array of callbacks to be called on each change, or names of task(s) to run when a file changes, added with task().
+             */
+            (glob: string|string[], fn: (IWatchCallback|string)): NodeJS.EventEmitter;
+            /**
+             * Watch files and do something when a file changes. This always returns an EventEmitter that emits change events.
+             *
+             * @param glob a single glob or array of globs that indicate which files to watch for changes.
+             * @param fn a callback or array of callbacks to be called on each change, or names of task(s) to run when a file changes, added with task().
+             */
+            (glob: string|string[], fn: (IWatchCallback|string)[]): NodeJS.EventEmitter;
+            /**
+             * Watch files and do something when a file changes. This always returns an EventEmitter that emits change events.
+             *
+             * @param glob a single glob or array of globs that indicate which files to watch for changes.
+             * @param opt options, that are passed to the gaze library.
+             * @param fn a callback or array of callbacks to be called on each change, or names of task(s) to run when a file changes, added with task().
+             */
+            (glob: string|string[], opt: IWatchOptions, fn: (IWatchCallback|string)): NodeJS.EventEmitter;
+            /**
+             * Watch files and do something when a file changes. This always returns an EventEmitter that emits change events.
+             *
+             * @param glob a single glob or array of globs that indicate which files to watch for changes.
+             * @param opt options, that are passed to the gaze library.
+             * @param fn a callback or array of callbacks to be called on each change, or names of task(s) to run when a file changes, added with task().
+             */
+            (glob: string|string[], opt: IWatchOptions, fn: (IWatchCallback|string)[]): NodeJS.EventEmitter;
+
+        }
+
+        interface DestMethod {
+            /**
+             * Can be piped to and it will write files. Re-emits all data passed to it so you can pipe to multiple folders.
+             * Folders that don't exist will be created.
+             *
+             * @param outFolder The path (output folder) to write files to. Or a function that returns it, the function will be provided a vinyl File instance.
+             * @param opt
+             */
+            (outFolder: string|((file:string)=>string), opt?: IDestOptions): NodeJS.ReadWriteStream;
+        }
+
+        interface SrcMethod {
+            /**
+             * Emits files matching provided glob or an array of globs. Returns a stream of Vinyl files that can be piped to plugins.
+             * @param glob Glob or array of globs to read.
+             * @param opt Options to pass to node-glob through glob-stream.
+             */
+            (glob: string|string[], opt?: ISrcOptions): NodeJS.ReadWriteStream;
+        }
+
+        /**
+         * Options to pass to node-glob through glob-stream.
+         * Specifies two options in addition to those used by node-glob:
+         * https://github.com/isaacs/node-glob#options
+         */
+        interface ISrcOptions {
+            /**
+             * Setting this to <code>false</code> will return <code>file.contents</code> as <code>null</code>
+             * and not read the file at all.
+             * Default: <code>true</code>.
+             */
+            read?: boolean;
+
+            /**
+             * Setting this to false will return <code>file.contents</code> as a stream and not buffer files.
+             * This is useful when working with large files.
+             * Note: Plugins might not implement support for streams.
+             * Default: <code>true</code>.
+             */
+            buffer?: boolean;
+
+            /**
+             * The base path of a glob.
+             *
+             * Default is everything before a glob starts.
+             */
+            base?: string;
+
+            /**
+             * The current working directory in which to search.
+             * Defaults to process.cwd().
+             */
+            cwd?: string;
+
+            /**
+             * The place where patterns starting with / will be mounted onto.
+             * Defaults to path.resolve(options.cwd, "/") (/ on Unix systems, and C:\ or some such on Windows.)
+             */
+            root?: string;
+
+            /**
+             * Include .dot files in normal matches and globstar matches.
+             * Note that an explicit dot in a portion of the pattern will always match dot files.
+             */
+            dot?: boolean;
+
+            /**
+             * By default, a pattern starting with a forward-slash will be "mounted" onto the root setting, so that a valid
+             * filesystem path is returned. Set this flag to disable that behavior.
+             */
+            nomount?: boolean;
+
+            /**
+             * Add a / character to directory matches. Note that this requires additional stat calls.
+             */
+            mark?: boolean;
+
+            /**
+             * Don't sort the results.
+             */
+            nosort?: boolean;
+
+            /**
+             * Set to true to stat all results. This reduces performance somewhat, and is completely unnecessary, unless
+             * readdir is presumed to be an untrustworthy indicator of file existence. It will cause ELOOP to be triggered one
+             * level sooner in the case of cyclical symbolic links.
+             */
+            stat?: boolean;
+
+            /**
+             * When an unusual error is encountered when attempting to read a directory, a warning will be printed to stderr.
+             * Set the silent option to true to suppress these warnings.
+             */
+            silent?: boolean;
+
+            /**
+             * When an unusual error is encountered when attempting to read a directory, the process will just continue on in
+             * search of other matches. Set the strict option to raise an error in these cases.
+             */
+            strict?: boolean;
+
+            /**
+             * See cache property above. Pass in a previously generated cache object to save some fs calls.
+             */
+            cache?: boolean;
+
+            /**
+             * A cache of results of filesystem information, to prevent unnecessary stat calls.
+             * While it should not normally be necessary to set this, you may pass the statCache from one glob() call to the
+             * options object of another, if you know that the filesystem will not change between calls.
+             */
+            statCache?: boolean;
+
+            /**
+             * Perform a synchronous glob search.
+             */
+            sync?: boolean;
+
+            /**
+             * In some cases, brace-expanded patterns can result in the same file showing up multiple times in the result set.
+             * By default, this implementation prevents duplicates in the result set. Set this flag to disable that behavior.
+             */
+            nounique?: boolean;
+
+            /**
+             * Set to never return an empty set, instead returning a set containing the pattern itself.
+             * This is the default in glob(3).
+             */
+            nonull?: boolean;
+
+            /**
+             * Perform a case-insensitive match. Note that case-insensitive filesystems will sometimes result in glob returning
+             * results that are case-insensitively matched anyway, since readdir and stat will not raise an error.
+             */
+            nocase?: boolean;
+
+            /**
+             * Set to enable debug logging in minimatch and glob.
+             */
+            debug?: boolean;
+
+            /**
+             * Set to enable debug logging in glob, but not minimatch.
+             */
+            globDebug?: boolean;
+        }
+
+        interface IDestOptions {
+            /**
+             * The output folder. Only has an effect if provided output folder is relative.
+             * Default: process.cwd()
+             */
+            cwd?: string;
+
+            /**
+             * Octal permission string specifying mode for any folders that need to be created for output folder.
+             * Default: 0777.
+             */
+            mode?: string;
+        }
+
+        /**
+         * Options that are passed to <code>gaze</code>.
+         * https://github.com/shama/gaze
+         */
+        interface IWatchOptions {
+            /** Interval to pass to fs.watchFile. */
+            interval?: number;
+            /** Delay for events called in succession for the same file/event. */
+            debounceDelay?: number;
+            /** Force the watch mode. Either 'auto' (default), 'watch' (force native events), or 'poll' (force stat polling). */
+            mode?: string;
+            /** The current working directory to base file patterns from. Default is process.cwd().. */
+            cwd?: string;
+        }
+
+        interface IWatchEvent {
+            /** The type of change that occurred, either added, changed or deleted. */
+            type: string;
+            /** The path to the file that triggered the event. */
+            path: string;
+        }
+
+        /**
+         * Callback to be called on each watched file change.
+         */
+        interface IWatchCallback {
+            (event:IWatchEvent): void;
+        }
+
+        interface ITaskCallback {
+            /**
+             * Defines a task.
+             * Tasks may be made asynchronous if they are passing a callback or return a promise or a stream.
+             * @param cb callback used to signal asynchronous completion. Caller includes <code>err</code> in case of error.
+             */
+            (cb?:(err?:any)=>void): any;
+        }
+    }
+
+    var gulp: gulp.Gulp;
+
+    export = gulp;
 }

--- a/run-sequence/run-sequence-tests.ts
+++ b/run-sequence/run-sequence-tests.ts
@@ -5,7 +5,7 @@ import gulp = require("gulp");
 import tmp = require("run-sequence");
 var runSequence = tmp.use(gulp);
 
-gulp.task("run-sequence", callback => {
+gulp.task("run-sequence", (callback: any) => {
     runSequence("task1",
         ["task2", "task3"],
         "taks4",

--- a/run-sequence/run-sequence.d.ts
+++ b/run-sequence/run-sequence.d.ts
@@ -7,6 +7,7 @@
 /// <reference path="../gulp/gulp.d.ts" />
 
 declare module "run-sequence" {
+    import gulp = require('gulp');
 
     interface IRunSequence {
         (...streams: (string | string[] | gulp.ITaskCallback)[]): NodeJS.ReadWriteStream;

--- a/run-sequence/run-sequence.d.ts
+++ b/run-sequence/run-sequence.d.ts
@@ -10,7 +10,7 @@ declare module "run-sequence" {
     import gulp = require('gulp');
 
     interface IRunSequence {
-        (...streams: (string | string[] | gulp.ITaskCallback)[]): NodeJS.ReadWriteStream;
+        (...streams: (string | string[] | gulp.TaskCallback)[]): NodeJS.ReadWriteStream;
 
         use(gulp: gulp.Gulp): IRunSequence;
     }


### PR DESCRIPTION
- Move IGulpPlugin into gulp namespace like other interfaces
- Gulp extends orchestrator to support methods like `start`, `hasTask`, etc.
- gulp#watch method returns NodeJS.EventEmitter for more detailed type information
- Remove prefix 'I' from the interfaces
