### PR TITLE
A fix for the victor.js TS definition file

### DIFF
--- a/victor/victor.d.ts
+++ b/victor/victor.d.ts
@@ -353,3 +353,7 @@ declare class Victor
     verticalAngleDeg():number;
 
 }
+
+declare module "victor" {
+	export = Victor;
+}


### PR DESCRIPTION
The Victor class is now correctly exported as default.
