### PR TITLE
Definitions for angular-ui-router-extras

### DIFF
--- a/ui-router-extras/ui-router-extras-tests.ts
+++ b/ui-router-extras/ui-router-extras-tests.ts
@@ -1,0 +1,23 @@
+/// <reference path="ui-router-extras.d.ts"/>
+
+var myApp = angular.module('testModule')
+
+myApp.config(($stateProvider: angular.ui.IStateProvider, $stickyStateProvider: angular.ui.IStickyStateProvider) => {
+	var state: angular.ui.IStickyState = {
+		name: 'test',
+		sticky: true,
+		controller: ($previousState: angular.ui.IPreviousStateService) => {
+			$previousState.memo('test-memo1');
+			$previousState.memo('test-memo2', 'test-state-name2');
+			$previousState.memo('test-memo3', 'test-state-name3', {});
+			$previousState.forget('test-memo3');
+			$previousState.go('test-memo2', {
+				location: true,
+				notify: true
+			});
+		}
+	};
+
+	$stickyStateProvider.enableDebug(true);
+	$stateProvider.state(state);
+});

--- a/ui-router-extras/ui-router-extras.d.ts
+++ b/ui-router-extras/ui-router-extras.d.ts
@@ -1,0 +1,83 @@
+// Type definitions for UI-Router Extras 0.0.14+ (ct.ui.router.extras module)
+// Project: https://github.com/christopherthielen/ui-router-extras
+// Definitions by: Michael Putters <https://github.com/mputters>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../angular-ui-router/angular-ui-router.d.ts" />
+
+// Support for AMD require
+declare module 'angular-ui-router-extras' {
+    var _: string;
+    export = _;
+}
+
+declare module angular.ui {
+
+    /**
+     * Previous state
+     */
+    interface IPreviousState {
+        state: IState;
+        params?: {};
+    }
+
+    /**
+     * Previous state service
+     */
+    interface IPreviousStateService {
+
+        /**
+         * Get a previous state
+         * @param memoName Memo name
+         * @return Previous state
+         */
+        get(memoName?: string): IPreviousState;
+
+        /**
+         * Go to a state
+         * @param memoName Memo name
+         * @param options State options
+         * @return Promise
+         */
+        go(memoName: string, options?: IStateOptions): angular.IPromise<any>;
+
+        /**
+         * Memorize a state
+         * @param memoName Memo name
+         * @param defaultStateName Default state name
+         * @param defaultStateParams Default state parameters
+         */
+        memo(memoName: string, defaultStateName?: string, defaultStateParams?: {}): void;
+
+        /**
+         * Forget a memorized name
+         * @param memoName Memo name
+         */
+        forget(memoName: string): void;
+
+    }
+
+    /**
+     * Sticky state
+     */
+    interface IStickyState extends angular.ui.IState {
+        sticky?: boolean;
+    }
+
+    /**
+     * Sticky state service
+     */
+    interface IStickyStateService {
+        getInactiveStates(): IStickyState[];
+    }
+
+    /**
+     * Sticky state provider
+     */
+    interface IStickyStateProvider extends angular.IServiceProvider {
+        debugMode(): boolean;
+        enableDebug(enabled: boolean): boolean;
+        registerStickyState(state: IStickyState): void;
+    }
+
+}


### PR DESCRIPTION
Type definitions for the UI Router extras library:
- sticky states
- previous state
