### PR TITLE
async: Corrected and updated to 1.4.2

### DIFF
--- a/async/async-tests.ts
+++ b/async/async-tests.ts
@@ -5,8 +5,19 @@ var fs, path;
 function callback() {}
 
 async.map(['file1', 'file2', 'file3'], fs.stat, function (err, results) { });
+async.mapSeries(['file1', 'file2', 'file3'], fs.stat, function (err, results) { });
+async.mapLimit(['file1', 'file2', 'file3'], 2, fs.stat, function (err, results) { });
 
 async.filter(['file1', 'file2', 'file3'], path.exists, function (results) { });
+async.filterSeries(['file1', 'file2', 'file3'], path.exists, function (results) { });
+async.filterLimit(['file1', 'file2', 'file3'], 2, path.exists, function (results) { });
+async.select(['file1', 'file2', 'file3'], path.exists, function (results) { });
+async.selectSeries(['file1', 'file2', 'file3'], path.exists, function (results) { });
+async.selectLimit(['file1', 'file2', 'file3'], 2, path.exists, function (results) { });
+
+async.reject(['file1', 'file2', 'file3'], path.exists, function (results) { });
+async.rejectSeries(['file1', 'file2', 'file3'], path.exists, function (results) { });
+async.rejectLimit(['file1', 'file2', 'file3'], 2, path.exists, function (results) { });
 
 async.parallel([
     function () { },
@@ -25,6 +36,11 @@ async.map(data, asyncProcess, function (err, results) {
 });
 
 var openFiles = ['file1', 'file2'];
+var openFilesObj = {
+    file1: "fileOne",
+    file2: "fileTwo"
+}
+
 var saveFile = function () { }
 async.each(openFiles, saveFile, function (err) { });
 async.eachSeries(openFiles, saveFile, function (err) { });
@@ -32,18 +48,34 @@ async.eachSeries(openFiles, saveFile, function (err) { });
 var documents, requestApi;
 async.eachLimit(documents, 20, requestApi, function (err) { });
 
-async.map(['file1', 'file2', 'file3'], fs.stat, function (err, results) { });
-
-async.filter(['file1', 'file2', 'file3'], path.exists, function (results) { });
+// forEachOf* functions. May accept array or object.
+function forEachOfIterator(item, key, forEachOfIteratorCallback) {
+    console.log("ForEach: item=" + item + ", key=" + key);
+    forEachOfIteratorCallback();
+}
+async.forEachOf(openFiles, forEachOfIterator, function (err) { });
+async.forEachOf(openFilesObj, forEachOfIterator, function (err) { });
+async.forEachOfSeries(openFiles, forEachOfIterator, function (err) { });
+async.forEachOfSeries(openFilesObj, forEachOfIterator, function (err) { });
+async.forEachOfLimit(openFiles, 2, forEachOfIterator, function (err) { });
+async.forEachOfLimit(openFilesObj, 2, forEachOfIterator, function (err) { });
 
 var process;
-async.reduce([1, 2, 3], 0, function (memo, item, callback) {
+var numArray = [1, 2, 3];
+function reducer(memo, item, callback) {
     process.nextTick(function () {
         callback(null, memo + item)
     });
-}, function (err, result) { });
+}
+async.reduce(numArray, 0, reducer, function (err, result) { });
+async.inject(numArray, 0, reducer, function (err, result) { });
+async.foldl(numArray, 0, reducer, function (err, result) { });
+async.reduceRight(numArray, 0, reducer, function (err, result) { });
+async.foldr(numArray, 0, reducer, function (err, result) { });
 
 async.detect(['file1', 'file2', 'file3'], path.exists, function (result) { });
+async.detectSeries(['file1', 'file2', 'file3'], path.exists, function (result) { });
+async.detectLimit(['file1', 'file2', 'file3'], 2, path.exists, function (result) { });
 
 async.sortBy(['file1', 'file2', 'file3'], function (file, callback) {
     fs.stat(file, function (err, stats) {
@@ -52,10 +84,18 @@ async.sortBy(['file1', 'file2', 'file3'], function (file, callback) {
 }, function (err, results) { });
 
 async.some(['file1', 'file2', 'file3'], path.exists, function (result) { });
+async.someLimit(['file1', 'file2', 'file3'], 2, path.exists, function (result) { });
+async.any(['file1', 'file2', 'file3'], path.exists, function (result) { });
 
 async.every(['file1', 'file2', 'file3'], path.exists, function (result) { });
+async.everyLimit(['file1', 'file2', 'file3'], 2, path.exists, function (result) { });
+async.all(['file1', 'file2', 'file3'], path.exists, function (result) { });
 
 async.concat(['dir1', 'dir2', 'dir3'], fs.readdir, function (err, files) { });
+async.concatSeries(['dir1', 'dir2', 'dir3'], fs.readdir, function (err, files) { });
+
+
+// Control Flow //
 
 async.series([
     function (callback) {
@@ -76,7 +116,6 @@ async.series<string>([
     },
 ],
 function (err, results) { });
-
 
 async.series({
     one: function (callback) {
@@ -173,20 +212,46 @@ async.parallel<number>({
         }, 100);
     },
 },
-function (err, results) { });
+    function (err, results) { });
 
-
-var count = 0;
-
-async.whilst(
-    function () { return count < 5; },
-    function (callback) {
-        count++;
-        setTimeout(callback, 1000);
+async.parallelLimit({
+    one: function (callback) {
+        setTimeout(function () {
+            callback(null, 1);
+        }, 200);
     },
-    function (err) { }
+    two: function (callback) {
+        setTimeout(function () {
+            callback(null, 2);
+        }, 100);
+    },
+},
+    2,
+    function (err, results) { }
 );
 
+
+function whileFn(callback) {
+    count++;
+    setTimeout(callback, 1000);
+}
+
+function whileTest() { return count < 5; }
+var count = 0;
+async.whilst(whileTest, whileFn, function (err) { });
+async.until(whileTest, whileFn, function (err) { });
+async.doWhilst(whileFn, whileTest, function (err) { });
+async.doUntil(whileFn, whileTest, function (err) { });
+
+async.during(function (testCallback) { testCallback(new Error(), false); }, function (callback) { callback() }, function (error) { console.log(error) });
+async.doDuring(function (callback) { callback() }, function (testCallback) { testCallback(new Error(), false); }, function (error) { console.log(error) });
+async.forever(function (errBack) {
+    errBack(new Error("Not going on forever."));
+},
+    function (error) {
+        console.log(error);
+    }
+);
 
 async.waterfall([
     function (callback) {
@@ -279,6 +344,26 @@ q2.unshift(['task3', 'task4', 'task5'], function (error) {
     console.log('Finished tasks');
 });
 
+// create a cargo object with payload 2
+var cargo = async.cargo(function (tasks, callback) {
+    for (var i = 0; i < tasks.length; i++) {
+        console.log('hello ' + tasks[i].name);
+    }
+    callback();
+}, 2);
+
+
+// add some items
+cargo.push({ name: 'foo' }, function (err) {
+    console.log('finished processing foo');
+});
+cargo.push({ name: 'bar' }, function (err) {
+    console.log('finished processing bar');
+});
+cargo.push({ name: 'baz' }, function (err) {
+    console.log('finished processing baz');
+});
+
 var filename = '';
 async.auto({
     get_data: function (callback) { },
@@ -290,6 +375,9 @@ async.auto({
     //arrays with different types are not accepted by TypeScript.
     email_link: ['write_file', <any>function (callback, results) { }]
 });
+
+async.retry(3, function (callback, results) { }, function (err, result) { });
+async.retry({ times: 3, interval: 200 }, function (callback, results) { }, function (err, result) { });
 
 
 async.parallel([
@@ -336,3 +424,20 @@ var slow_fn = function (name, callback) {
 };
 var fn = async.memoize(slow_fn);
 fn('some name', function () {});
+async.unmemoize(fn);
+async.ensureAsync(function () { });
+async.constant(42);
+async.asyncify(function () { });
+
+async.log(function (name, callback) {
+    setTimeout(function () {
+        callback(null, 'hello ' + name);
+    }, 0);
+}, "world"
+    );
+
+async.dir(function (name, callback) {
+    setTimeout(function () {
+        callback(null, { hello: name });
+    }, 1000);
+}, "world");

--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -1,36 +1,31 @@
-// Type definitions for Async 0.9.2
+// Type definitions for Async 1.4.2
 // Project: https://github.com/caolan/async
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>, Arseniy Maximov <https://github.com/kern0>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 interface Dictionary<T> { [key: string]: T; }
 
-// Common interface between Arrays and Array-like objects
-interface List<T> {
-    [index: number]: T;
-    length: number;
-}
-
 interface ErrorCallback { (err?: Error): void; }
 interface AsyncResultCallback<T> { (err: Error, result: T): void; }
 interface AsyncResultArrayCallback<T> { (err: Error, results: T[]): void; }
 interface AsyncResultObjectCallback<T> { (err: Error, results: Dictionary<T>): void; }
 
+interface AsyncFunction<T> { (callback: (err: Error, result?: T) => void): void; }
 interface AsyncIterator<T> { (item: T, callback: ErrorCallback): void; }
-interface AsyncForEachOfIterator<T> { (item: T, index: number, callback: ErrorCallback): void; }
+interface AsyncForEachOfIterator<T> { (item: T, key: number, callback: ErrorCallback): void; }
 interface AsyncResultIterator<T, R> { (item: T, callback: AsyncResultCallback<R>): void; }
 interface AsyncMemoIterator<T, R> { (memo: R, item: T, callback: AsyncResultCallback<R>): void; }
+interface AsyncBooleanIterator<T> { (item: T, callback: (truthValue: boolean) => void): void; }
 
 interface AsyncWorker<T> { (task: T, callback: ErrorCallback): void; }
-
-interface AsyncFunction<T> { (callback: AsyncResultCallback<T>): void; }
 interface AsyncVoidFunction { (callback: ErrorCallback): void; }
 
 interface AsyncQueue<T> {
     length(): number;
-    concurrency: number;
     started: boolean;
-    paused: boolean;
+    running(): number;
+    idle(): boolean;
+    concurrency: number;
     push(task: T, callback?: ErrorCallback): void;
     push(task: T[], callback?: ErrorCallback): void;
     unshift(task: T, callback?: ErrorCallback): void;
@@ -38,9 +33,8 @@ interface AsyncQueue<T> {
     saturated: () => any;
     empty: () => any;
     drain: () => any;
-    running(): number;
-    idle(): boolean;
-    pause(): void;
+    paused: boolean;
+    pause(): void
     resume(): void;
     kill(): void;
 }
@@ -62,41 +56,64 @@ interface AsyncPriorityQueue<T> {
     kill(): void;
 }
 
+interface AsyncCargo {
+    length(): number;
+    payload: number;
+    push(task: any, callback? : Function): void;
+    push(task: any[], callback? : Function): void;
+    saturated(): void;
+    empty(): void;
+    drain(): void;
+    idle(): boolean;
+    pause(): void;
+    resume(): void;
+    kill(): void;
+}
+
 interface Async {
 
     // Collections
-    each<T>(arr: T[], iterator: AsyncIterator<T>, callback: ErrorCallback): void;
-    eachSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback: ErrorCallback): void;
-    eachLimit<T>(arr: T[], limit: number, iterator: AsyncIterator<T>, callback: ErrorCallback): void;
-    forEachOf<T>(obj: List<T>, iterator: AsyncForEachOfIterator<T>, callback: ErrorCallback): void;
-    forEachOfSeries<T>(obj: List<T>, iterator: AsyncForEachOfIterator<T>, callback: ErrorCallback): void;
-    forEachOfLimit<T>(obj: List<T>, limit: number, iterator: AsyncForEachOfIterator<T>, callback: ErrorCallback): void;
-    map<T, R>(arr: T[], iterator: AsyncResultIterator<T, R>, callback: AsyncResultArrayCallback<R>): any;
-    mapSeries<T, R>(arr: T[], iterator: AsyncResultIterator<T, R>, callback: AsyncResultArrayCallback<R>): any;
-    mapLimit<T, R>(arr: T[], limit: number, iterator: AsyncResultIterator<T, R>, callback: AsyncResultArrayCallback<R>): any;
-    filter<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (results: T[]) => any): any;
-    select<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (results: T[]) => any): any;
-    filterSeries<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (results: T[]) => any): any;
-    selectSeries<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (results: T[]) => any): any;
-    reject<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (results: T[]) => any): any;
-    rejectSeries<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (results: T[]) => any): any;
-    reduce<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncResultCallback<R>): any;
-    inject<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncResultCallback<R>): any;
-    foldl<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncResultCallback<R>): any;
+    each<T>(arr: T[], iterator: AsyncIterator<T>, callback?: ErrorCallback): void;
+    eachSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback?: ErrorCallback): void;
+    eachLimit<T>(arr: T[], limit: number, iterator: AsyncIterator<T>, callback?: ErrorCallback): void;
+    forEachOf(obj: any, iterator: (item: any, key: [string|number], callback?: ErrorCallback) => void, callback: ErrorCallback): void;
+    forEachOf<T>(obj: T[], iterator: AsyncForEachOfIterator<T>, callback?: ErrorCallback): void;
+    forEachOfSeries(obj: any, iterator: (item: any, key: [string|number], callback?: ErrorCallback) => void, callback: ErrorCallback): void;
+    forEachOfSeries<T>(obj: T[], iterator: AsyncForEachOfIterator<T>, callback?: ErrorCallback): void;
+    forEachOfLimit(obj: any, limit: number, iterator: (item: any, key: [string|number], callback?: ErrorCallback) => void, callback: ErrorCallback): void;
+    forEachOfLimit<T>(obj: T[], limit: number, iterator: AsyncForEachOfIterator<T>, callback?: ErrorCallback): void;
+    map<T, R>(arr: T[], iterator: AsyncResultIterator<T, R>, callback?: AsyncResultArrayCallback<R>): any;
+    mapSeries<T, R>(arr: T[], iterator: AsyncResultIterator<T, R>, callback?: AsyncResultArrayCallback<R>): any;
+    mapLimit<T, R>(arr: T[], limit: number, iterator: AsyncResultIterator<T, R>, callback?: AsyncResultArrayCallback<R>): any;
+    filter<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback?: (results: T[]) => any): any;
+    select<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback?: (results: T[]) => any): any;
+    filterSeries<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback?: (results: T[]) => any): any;
+    selectSeries<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback?: (results: T[]) => any): any;
+    filterLimit<T>(arr: T[], limit: number, iterator: AsyncResultIterator<T, boolean>, callback?: (results: T[]) => any): any;
+    selectLimit<T>(arr: T[], limit: number, iterator: AsyncResultIterator<T, boolean>, callback?: (results: T[]) => any): any;
+    reject<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback?: (results: T[]) => any): any;
+    rejectSeries<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback?: (results: T[]) => any): any;
+    rejectLimit<T>(arr: T[], limit: number, iterator: AsyncResultIterator<T, boolean>, callback?: (results: T[]) => any): any;
+    reduce<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback?: AsyncResultCallback<R>): any;
+    inject<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback?: AsyncResultCallback<R>): any;
+    foldl<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback?: AsyncResultCallback<R>): any;
     reduceRight<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncResultCallback<R>): any;
     foldr<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncResultCallback<R>): any;
-    detect<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: AsyncResultArrayCallback<T>): any;
-    detectSeries<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: AsyncResultArrayCallback<T>): any;
-    sortBy<T, V>(arr: T[], iterator: AsyncResultIterator<T, V>, callback: AsyncResultArrayCallback<T>): any;
-    some<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: AsyncResultArrayCallback<T>): any;
-    any<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: AsyncResultArrayCallback<T>): any;
-    every<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (result: boolean) => any): any;
-    all<T>(arr: T[], iterator: AsyncResultIterator<T, boolean>, callback: (result: boolean) => any): any;
-    concat<T, R>(arr: T[], iterator: AsyncResultIterator<T, R[]>, callback: AsyncResultArrayCallback<R>): any;
-    concatSeries<T, R>(arr: T[], iterator: AsyncResultIterator<T, R[]>, callback: AsyncResultArrayCallback<R>): any;
+    detect<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: (result: T) => void): any;
+    detectSeries<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: (result: T) => void): any;
+    detectLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: (result: T) => void): any;
+    sortBy<T, V>(arr: T[], iterator: AsyncResultIterator<T, V>, callback?: AsyncResultArrayCallback<T>): any;
+    some<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: (result: boolean) => void): any;
+    someLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: (result: boolean) => void): any;
+    any<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: (result: boolean) => void): any;
+    every<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: (result: boolean) => any): any;
+    everyLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: (result: boolean) => any): any;
+    all<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: (result: boolean) => any): any;
+    concat<T, R>(arr: T[], iterator: AsyncResultIterator<T, R[]>, callback?: AsyncResultArrayCallback<R>): any;
+    concatSeries<T, R>(arr: T[], iterator: AsyncResultIterator<T, R[]>, callback?: AsyncResultArrayCallback<R>): any;
 
     // Control Flow
-    series<T>(tasks: Array<AsyncFunction<T>>, callback?: AsyncResultArrayCallback<T>): void;
+    series<T>(tasks: AsyncFunction<T>[], callback?: AsyncResultArrayCallback<T>): void;
     series<T>(tasks: Dictionary<AsyncFunction<T>>, callback?: AsyncResultObjectCallback<T>): void;
     parallel<T>(tasks: Array<AsyncFunction<T>>, callback?: AsyncResultArrayCallback<T>): void;
     parallel<T>(tasks: Dictionary<AsyncFunction<T>>, callback?: AsyncResultObjectCallback<T>): void;
@@ -106,20 +123,36 @@ interface Async {
     doWhilst(fn: AsyncVoidFunction, test: () => boolean, callback: (err: any) => void): void;
     until(test: () => boolean, fn: AsyncVoidFunction, callback: (err: any) => void): void;
     doUntil(fn: AsyncVoidFunction, test: () => boolean, callback: (err: any) => void): void;
-    waterfall(tasks: Function[], callback?: (err: any, ...arguments: any[]) => void): void;
-    queue<T>(worker: AsyncWorker<T>, concurrency: number): AsyncQueue<T>;
+    during(test: (testCallback : (error: Error, truth: boolean) => void) => void, fn: AsyncVoidFunction, callback: (err: any) => void): void;
+    doDuring(fn: AsyncVoidFunction, test: (testCallback: (error: Error, truth: boolean) => void) => void, callback: (err: any) => void): void;
+    forever(next: (errCallback : (err: Error) => void) => void, errBack: (err: Error) => void) : void;
+    waterfall(tasks: Function[], callback?: (err: Error, result: any) => void): void;
+    compose(...fns: Function[]): void;
+    seq(...fns: Function[]): void;
+    applyEach(fns: Function[], argsAndCallback: any[]): void;           // applyEach(fns, args..., callback). TS does not support ... for a middle argument. Callback is optional.
+    applyEachSeries(fns: Function[], argsAndCallback: any[]): void;     // applyEachSeries(fns, args..., callback). TS does not support ... for a middle argument. Callback is optional.
+    queue<T>(worker: AsyncWorker<T>, concurrency?: number): AsyncQueue<T>;
     priorityQueue<T>(worker: AsyncWorker<T>, concurrency: number): AsyncPriorityQueue<T>;
-    auto(tasks: any, callback?: AsyncResultArrayCallback<any>): void;
+    cargo(worker : (tasks: any[], callback : ErrorCallback) => void, payload? : number) : AsyncCargo;
+    auto(tasks: any, callback?: (error: Error, results: any) => void): void;
+    retry<T>(opts: number, task: (callback : AsyncResultCallback<T>, results: any) => void, callback: (error: Error, results: any) => void): void;
+    retry<T>(opts: { times: number, interval: number }, task: (callback: AsyncResultCallback<T>, results : any) => void, callback: (error: Error, results: any) => void): void;
     iterator(tasks: Function[]): Function;
     apply(fn: Function, ...arguments: any[]): AsyncFunction<any>;
     nextTick(callback: Function): void;
+    setImmediate(callback: Function): void;
 
-    times<R> (n: number, iterator: AsyncResultIterator<number, R>, callback: AsyncResultArrayCallback<R>): void;
-    timesSeries<R> (n: number, iterator: AsyncResultIterator<number, R>, callback: AsyncResultArrayCallback<R>): void;
+    times<T> (n: number, iterator: AsyncResultIterator<number, T>, callback: AsyncResultArrayCallback<T>): void;
+    timesSeries<T>(n: number, iterator: AsyncResultIterator<number, T>, callback: AsyncResultArrayCallback<T>): void;
+    timesLimit<T>(n: number, limit: number, iterator: AsyncResultIterator<number, T>, callback: AsyncResultArrayCallback<T>): void;
 
     // Utils
     memoize(fn: Function, hasher?: Function): Function;
     unmemoize(fn: Function): Function;
+    ensureAsync(fn: (... argsAndCallback: any[]) => void): Function;
+    constant(...values: any[]): Function;
+    asyncify(fn: Function): Function;
+    wrapSync(fn: Function): Function;
     log(fn: Function, ...arguments: any[]): void;
     dir(fn: Function, ...arguments: any[]): void;
     noConflict(): Async;


### PR DESCRIPTION
This commit updates API definitions for the async module.

**Background**
There were a lot of missing, testless, incorrect, and/or unnecessarily strict API definitions. I have attempted to carefully update them to the latest version of async as closely as possible to the documentation.

**Changelog:**
- Removed incorrect requirement for List<T> interface for forEachOf, forEachOfSeries, forEachOfLimit.
- Removed incorrect requirement for a result in the iterator for AsyncFunction, used in: series, parallel, parallelLimit, and apply
- forEachOf, forEachOfSeries, forEachOfLimit now also correctly accepts any object, instead of only array-like objects.
- Added APIs and/or tests for filterLimit, filterSeries, selectLimit, selectSeries, rejectLimit, detectSeries, detectLimit, someLimit, concatSeries, mapseries, forEachOf, forEachOfSeries, forEachOfLimit, inject, foldl, reduceRight, foldR, during, doDuring, forever, compose, cargo, applyEach, applyEachSeries, retry, setImmediate, timesLimit, constant, asyncify, wrapSync, log, dir.
- Corrected every, some, and detect APIs to not accept error as the first callback argument.
- Callbacks marked as optional in the API functions spec are correctly optional in the TSD.
