### PR TITLE
Update type of DialogOptions.buttons

### DIFF
--- a/jqueryui/jqueryui.d.ts
+++ b/jqueryui/jqueryui.d.ts
@@ -341,7 +341,7 @@ declare module JQueryUI {
 
     interface DialogOptions extends DialogEvents {
         autoOpen?: boolean;
-        buttons?: { [buttonText: string]: () => void } | ButtonOptions[];
+        buttons?: { [buttonText: string]: (event?: Event) => void } | ButtonOptions[];
         closeOnEscape?: boolean;
         closeText?: string;
         dialogClass?: string;


### PR DESCRIPTION
Add event argument to DialogOptions.buttons callback.

See [buttons](http://api.jqueryui.com/dialog/#option-buttons):

> if you need access to the button, it is available as the target of the event object
