### PR TITLE
angularjs: Fix the finally method type signature

### DIFF
--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -377,34 +377,48 @@ module TestPromise {
         b: string;
         c: boolean;
     }
+    interface TOther {
+        d: number;
+        e: string;
+        f: boolean;
+    }
 
+    var tresult: TResult;
+    var tresultPromise: ng.IPromise<TResult>;
+    
+    var tother: TOther;
+    var totherPromise: ng.IPromise<TOther>;
+    
     var promise: angular.IPromise<TResult>;
-    interface IPromiseSuccessCallback<T, U> {
-        (promiseValue: T): angular.IHttpPromise<U>|angular.IPromise<U>|U|angular.IPromise<void>;
-    }
-    var successCallbackAnyFn: IPromiseSuccessCallback<TResult, any>;
-    var successCallbackTResultFn: IPromiseSuccessCallback<TResult, TResult>;
-    interface IPromiseErrorCallback<T> {
-        (error: any): angular.IHttpPromise<T>|angular.IPromise<T>|T;
-    }
-    var errorCallbackAnyFn: IPromiseErrorCallback<any>;
-    var errorCallbackTResultFn: IPromiseErrorCallback<TResult>;
 
     // promise.then
-    result = <angular.IPromise<any>>promise.then(successCallbackAnyFn);
-    result = <angular.IPromise<any>>promise.then(successCallbackAnyFn, (any) => any);
-    result = <angular.IPromise<any>>promise.then(successCallbackAnyFn, (any) => any, (any) => any);
-    result = <angular.IPromise<TResult>>promise.then<TResult>(successCallbackTResultFn);
-    result = <angular.IPromise<TResult>>promise.then<TResult>(successCallbackTResultFn, (any) => any);
-    result = <angular.IPromise<TResult>>promise.then<TResult>(successCallbackTResultFn, (any) => any, (any) => any);
-
+    result = <angular.IPromise<any>>promise.then((result) => any);
+    result = <angular.IPromise<any>>promise.then((result) => any, (any) => any);
+    result = <angular.IPromise<any>>promise.then((result) => any, (any) => any, (any) => any);
+    
+    result = <angular.IPromise<TResult>>promise.then((result) => result);
+    result = <angular.IPromise<TResult>>promise.then((result) => result, (any) => any);
+    result = <angular.IPromise<TResult>>promise.then((result) => result, (any) => any, (any) => any);
+    result = <angular.IPromise<TResult>>promise.then((result) => tresultPromise);
+    result = <angular.IPromise<TResult>>promise.then((result) => tresultPromise, (any) => any);
+    result = <angular.IPromise<TResult>>promise.then((result) => tresultPromise, (any) => any, (any) => any);
+    
+    result = <angular.IPromise<TOther>>promise.then((result) => tother);
+    result = <angular.IPromise<TOther>>promise.then((result) => tother, (any) => any);
+    result = <angular.IPromise<TOther>>promise.then((result) => tother, (any) => any, (any) => any);
+    result = <angular.IPromise<TOther>>promise.then((result) => totherPromise);
+    result = <angular.IPromise<TOther>>promise.then((result) => totherPromise, (any) => any);
+    result = <angular.IPromise<TOther>>promise.then((result) => totherPromise, (any) => any, (any) => any);
+    
     // promise.catch
-    result = <angular.IPromise<any>>promise.catch(errorCallbackAnyFn);
-    result = <angular.IPromise<TResult>>promise.catch<TResult>(errorCallbackTResultFn);
+    result = <angular.IPromise<any>>promise.catch((err) => any);
+    result = <angular.IPromise<TResult>>promise.catch((err) => tresult);
+    result = <angular.IPromise<TOther>>promise.catch((err) => tother);
 
     // promise.finally
-    result = <angular.IPromise<any>>promise.finally(() => any);
-    result = <angular.IPromise<TResult>>promise.finally<TResult>(() => any);
+    result = <angular.IPromise<TResult>>promise.finally(() => any);
+    result = <angular.IPromise<TResult>>promise.finally(() => tresult);
+    result = <angular.IPromise<TResult>>promise.finally(() => tother);
 }
 
 

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1061,7 +1061,7 @@ declare module angular {
          *
          * Because finally is a reserved word in JavaScript and reserved keywords are not supported as property names by ES3, you'll need to invoke the method like promise['finally'](callback) to make your code IE8 and Android 2.x compatible.
          */
-        finally<TResult>(finallyCallback: () => any): IPromise<TResult>;
+        finally(finallyCallback: () => any): IPromise<T>;
     }
 
     interface IDeferred<T> {


### PR DESCRIPTION
The finally method does not change the type of the returned promise - instead the original promise value is passed through unchanged.

[Here](http://codepen.io/anon/pen/OVKjKN?editors=101) is a CodePen which demonstrates the expected behaviour. 

Note: Finally `finally` handler will modify the value if they a) throw or b) return a promise which is rejected.
