### PR TITLE
Update CSSProperties interface for typescript 1.6

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -398,6 +398,8 @@ declare module __React {
         fillOpacity?: number;
         strokeOpacity?: number;
         strokeWidth?: number;
+        
+		[other:string]: any;
     }
 
     interface HTMLAttributes extends DOMAttributes {


### PR DESCRIPTION
Adding CSSProperties other than those listed in the interface would result in an error in 1.6: http://stackoverflow.com/questions/31816061/why-am-i-getting-an-error-object-literal-may-only-specify-known-properties

This fixes that by allowing strings properties to be set as well.
