### PR TITLE
Updated missing Windows.ApplicationModel.Activation.ActivationKind enum values

### DIFF
--- a/winrt/winrt.d.ts
+++ b/winrt/winrt.d.ts
@@ -1541,7 +1541,24 @@ declare module Windows {
                 device,
                 printTaskSettings,
                 cameraSettings,
-                webAuthenticationBrokerContinuation
+                restrictedLaunch,
+                appointmentsProvider,
+                contact,
+                lockScreenCall,
+                voiceCommand,
+                lockScreen,
+                pickerReturned,
+                walletAction,
+                pickFileContinuation,
+                pickSaveFileContinuation,
+                pickFolderContinuation,
+                webAuthenticationBrokerContinuation,
+                webAccountProvider,
+                componentUI,
+                protocolForResults,
+                toastNotification,
+                print3DWorkflow,
+                dialReceiver
             }
             export interface IActivatedEventArgs {
                 kind: Windows.ApplicationModel.Activation.ActivationKind;


### PR DESCRIPTION
Updated missing ActivationKind enum values according to https://msdn.microsoft.com/en-us/library/windows.applicationmodel.activation.activationkind
