### PR TITLE
lodash: changed _.capitalize() method

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -1755,7 +1755,9 @@ result = <string>_.uniqueId();
 result = <string>_.camelCase('Foo Bar');
 result = <string>_('Foo Bar').camelCase();
 
+// _.capitalize
 result = <string>_.capitalize('fred');
+result = <string>_('fred').capitalize();
 
 // _.deburr
 result = <string>_.deburr('déjà vu');

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -7583,8 +7583,16 @@ declare module _ {
         camelCase(): string;
     }
 
+    //_.capitalize
     interface LoDashStatic {
-        capitalize(str?: string): string;
+        capitalize(string?: string): string;
+    }
+
+    interface LoDashWrapper<T> {
+        /**
+         * @see _.capitalize
+         */
+        capitalize(): string;
     }
 
     //_.deburr


### PR DESCRIPTION
https://lodash.com/docs#capitalize
https://lodash.com/docs#_ (description of the chainable wrapper)
