### PR TITLE
Fix type of createjs.Ticker.paused

### DIFF
--- a/easeljs/easeljs.d.ts
+++ b/easeljs/easeljs.d.ts
@@ -925,7 +925,7 @@ declare module createjs {
         static framerate: number;
         static interval: number;
         static maxDelta: number;
-        static paused: number;
+        static paused: boolean;
         static RAF: string;
         static RAF_SYNCHED: string;
         static TIMEOUT: string;


### PR DESCRIPTION
The type of createjs.Ticker.paused property was declared as "number" when it should be "boolean".
