### PR TITLE
Fixed spelling error in pixi.js

### DIFF
--- a/pixi.js/pixi.js.d.ts
+++ b/pixi.js/pixi.js.d.ts
@@ -762,7 +762,7 @@ declare module PIXI {
         fragmentSrc: string;
 
         init(): void;
-        cachUniformLocations(keys: string): void;
+        cacheUniformLocations(keys: string): void;
         cacheAttributeLocations(keys: string): void;
         compile(): WebGLProgram;
         syncUniform(uniform: any): void;


### PR DESCRIPTION
The documentation didn't match the implementation. 
