### PR TITLE
Add lastError to Sinon-Chrome

### DIFF
--- a/sinon-chrome/sinon-chrome.d.ts
+++ b/sinon-chrome/sinon-chrome.d.ts
@@ -411,6 +411,7 @@ declare module SinonChrome.runtime {
 
     export var id: string;
     export var getURL: Sinon.SinonSpy;
+    export var lastError: { message?: string };
 }
 
 declare module SinonChrome.sessions {


### PR DESCRIPTION
Adds the lastError property to Sinon-Chrome. Docs for the real property are at https://developer.chrome.com/extensions/runtime#property-lastError

This wasn't included before as the rest of the API is just the defined stubs, whereas lastError is a property that's initially undefined, and which you'd add in test code when you want to simulate an error. It doesn't actually exist in the SinonChrome codebase, interestingly, because it's only value is as a place to attach a property. Free to do that in JavaScript, but needs to be part of the interface to work in TypeScript.
