### PR TITLE
Underscore: Add types for functions extendOwn() and assign()

### DIFF
--- a/underscore/underscore-tests.ts
+++ b/underscore/underscore-tests.ts
@@ -177,6 +177,8 @@ _.pairs({ one: 1, two: 2, three: 3 });
 _.invert({ Moe: "Moses", Larry: "Louis", Curly: "Jerome" });
 _.functions(_);
 _.extend({ name: 'moe' }, { age: 50 });
+_.extendOwn({ name: 'moe'}, { age: 50 });
+_.assign({ name: 'moe'}, { age: 50 });
 _.pick({ name: 'moe', age: 50, userid: 'moe1' }, 'name', 'age');
 _.omit({ name: 'moe', age: 50, userid: 'moe1' }, 'name');
 _.omit({ name: 'moe', age: 50, userid: 'moe1' }, 'name', 'age');

--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -1237,6 +1237,20 @@ interface UnderscoreStatic {
 		...sources: any[]): any;
 
 	/**
+	* Like extend, but only copies own properties over to the destination object. (alias: assign)
+	*/
+	extendOwn(
+		destination: any,
+		...source: any[]): any;
+		
+	/**
+	* Like extend, but only copies own properties over to the destination object. (alias: extendOwn)
+	*/
+	assign(
+		destination: any,
+		...source: any[]): any;
+
+	/**
 	* Return a copy of the object, filtered to only have values for the whitelisted keys
 	* (or array of valid keys).
 	* @param object Object to strip unwanted key/value pairs.


### PR DESCRIPTION
Two functions (which are just two names for one function) missing from underscore.d.ts.

The documentation is from http://underscorejs.org/#extendOwn
