### PR TITLE
Add definition for missing replyWithError method in nock

### DIFF
--- a/nock/nock.d.ts
+++ b/nock/nock.d.ts
@@ -56,6 +56,7 @@ declare module "nock" {
 			reply(responseCode: number, body?: Object, headers?: Object): Scope;
 			reply(responseCode: number, callback: (uri: string, body: string) => string, headers?: Object): Scope;
 			replyWithFile(responseCode: number, fileName: string): Scope;
+			replyWithError(errorMessage: string): Scope;
 
 			defaultReplyHeaders(headers: Object): Scope;
 


### PR DESCRIPTION
https://github.com/pgte/nock/blob/a407b73ac8f0daa947dccf4a29b86b8f99138157/lib/scope.js#L62
