### PR TITLE
Add BrowserWindow.isDevToolsOpened()

### DIFF
--- a/github-electron/github-electron-main-tests.ts
+++ b/github-electron/github-electron-main-tests.ts
@@ -44,6 +44,9 @@ app.on('ready', () => {
 	// and load the index.html of the app.
 	mainWindow.loadUrl(`file://${__dirname}/index.html`);
 
+	mainWindow.openDevTools()
+	var opened: boolean = mainWindow.isDevToolsOpened()
+	mainWindow.toggleDevTools()
 	// Emitted when the window is closed.
 	mainWindow.on('closed', () => {
 		// Dereference the window object, usually you would store windows

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -357,6 +357,10 @@ declare module GitHubElectron {
 		 */
 		closeDevTools(): void;
 		/**
+		 * Returns whether the developer tools are opened.
+		 */
+		isDevToolsOpened(): boolean;
+		/**
 		 * Toggle the developer tools.
 		 */
 		toggleDevTools(): void;


### PR DESCRIPTION
I added missing API `isDevToolsOpened()` of `BrowserWindow`.

The API document is below.
https://github.com/atom/electron/blob/master/docs/api/browser-window.md#winisdevtoolsopened
