### PR TITLE
Update react version in comment to 0.13.3

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for React v0.13.1 (external module)
+// Type definitions for React v0.13.3 (external module)
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped


### PR DESCRIPTION
These definitions are for 0.13.3, but the header was still claiming "v0.13.1" - confused me for a while when I was installing typings recently.
