### PR TITLE
Update stream interface for Bunyan to support `period` and `count` for `rotating-file` type.

### DIFF
--- a/bunyan/bunyan-test.ts
+++ b/bunyan/bunyan-test.ts
@@ -40,7 +40,9 @@ var options:bunyan.LoggerOptions = {
         type: 'rotating-file',
         path: '/tmp/test2.log',
         level: bunyan.INFO,
-        closeOnExit: false
+        closeOnExit: false,
+        period: '1d',
+        count: 3
     }, {
         type: 'raw',
         stream: process.stderr,

--- a/bunyan/bunyan.d.ts
+++ b/bunyan/bunyan.d.ts
@@ -65,6 +65,8 @@ declare module "bunyan" {
         path?: string;
         stream?: NodeJS.WritableStream | Stream;
         closeOnExit?: boolean;
+        period?: string;
+        count?: number;
     }
 
     export var stdSerializers:Serializers;


### PR DESCRIPTION
According to the [doc](https://github.com/trentm/node-bunyan#stream-type-rotating-file) one should be able to specify `period` and `count` for `rotating-file`-streams.
