### PR TITLE
Add cache property for select2 ajax options

### DIFF
--- a/select2/select2-tests.ts
+++ b/select2/select2-tests.ts
@@ -56,6 +56,7 @@ $("#e6").select2({
     ajax: {
         url: "http://api.rottentomatoes.com/api/public/v1.0/movies.json",
         dataType: 'jsonp',
+        cache: false,
         data: function (term, page) {
             return {
                 q: term,

--- a/select2/select2.d.ts
+++ b/select2/select2.d.ts
@@ -26,6 +26,7 @@ interface Select2AjaxOptions {
     url?: any;
     dataType?: string;
     quietMillis?: number;
+    cache?: boolean;
     data?: (term: string, page: number, context: any) => any;
     results?: (term: any, page: number, context: any) => any;
 }


### PR DESCRIPTION
The select2 library has a `cache` property that can be used for client-side caching on AJAX requests.

Documentation: http://select2.github.io/select2/
