### PR TITLE
add better curry

### DIFF
--- a/better-curry/better-curry-tests.ts
+++ b/better-curry/better-curry-tests.ts
@@ -1,0 +1,25 @@
+/// <reference path="better-curry.d.ts" />
+
+import bc = require('better-curry');
+bc.flatten([1,2,3,[1,2],['a']]) === [];
+bc.MAX_OPTIMIZED = 5;
+
+function fn(...args: number[]): number[] {
+    return [].concat([1]);
+}
+
+function fn2(arg1: string, arg2: any): number {
+    return parseInt(arg1 + String(arg2)) + 1;
+}
+
+bc.predefine(fn, [1,2])() === [];
+bc.predefine(fn, [1,2]).__length === 3;
+
+var f = bc.wrap(fn2, {}, 10, true);
+f('1', 2) === 3;
+
+var delegate = bc.delegate({}, 'ok');
+delegate.access('ok') === delegate;
+delegate.getter('getter').setter('setter') === delegate;
+delegate.all(['1','2']);
+delegate.revoke('adsf').access('asdf');

--- a/better-curry/better-curry-tests.ts
+++ b/better-curry/better-curry-tests.ts
@@ -23,3 +23,5 @@ delegate.access('ok') === delegate;
 delegate.getter('getter').setter('setter') === delegate;
 delegate.all(['1','2']);
 delegate.revoke('adsf').access('asdf');
+
+BetterCurry.wrap(fn2, {}, -1, false).__length === 10;

--- a/better-curry/better-curry.d.ts
+++ b/better-curry/better-curry.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for better-curry
+// Project: https://github.com/pocesar/js-bettercurry
+// Definitions by: Paulo Cesar <https://github.com/pocesar>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare var BetterCurry: BetterCurryModule.BetterCurry;
+
+declare module BetterCurryModule {
+
+    export interface DelegateOptions {
+        as?: string;
+        len?: number;
+        args?: any[];
+        name?: string;
+    }
+
+    export class Delegate<T> {
+        proto: T;
+        target: string;
+        methods: any[];
+        getters: any[];
+        setters: any[];
+        all: (skip?: string[]) => void;
+        method: (name: string|DelegateOptions) => Delegate<T>;
+        getter: (name: string|DelegateOptions) => Delegate<T>;
+        setter: (name: string|DelegateOptions) => Delegate<T>;
+        access: (name: string|DelegateOptions) => Delegate<T>;
+        revoke: (name: string) => Delegate<T>;
+        constructor(proto: T, target: string);
+    }
+
+    export interface OriginalFunctionReminder<T> extends Function {
+        __length: number;
+    }
+
+    export interface BetterCurry {
+        predefine: <T extends Function>(fn: T, args: any[], context?: Object, len?: number, checkArguments?: boolean) => OriginalFunctionReminder<T>;
+        wrap: <T extends Function>(fn: T, context?: Object, len?: number, checkArguments?: boolean) => OriginalFunctionReminder<T>;
+        flatten: (...args: Array<Array<any>|any>) => any[];
+        delegate: <T>(proto: T, target: string) => Delegate<T>;
+        MAX_OPTIMIZED: number;
+    }
+
+}
+
+declare module 'better-curry' {
+    var bc: BetterCurryModule.BetterCurry;
+
+    export = bc;
+}


### PR DESCRIPTION
A question, is it possible to return the hinted function return value and apply to the OriginalFunctionReminder<T>? Like:

``` typescript
f('1', 2) === '3'; // should fail, but works, because the original function returns a number
```
