### PR TITLE
ui-grid: Made the enableColumnResizing field optional.

### DIFF
--- a/ui-grid/ui-grid-tests.ts
+++ b/ui-grid/ui-grid-tests.ts
@@ -100,3 +100,5 @@ gridApi.core.queueGridRefresh()
 gridApi.core.queueRefresh();
 gridApi.core.registerColumnsProcessor(colProcessor, 100);
 
+var allDefaultsColumnDef: uiGrid.IColumnDef = {
+};

--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -2404,7 +2404,7 @@ declare module uiGrid {
              * Enable column resizing on an individual column
              * Defaults to GridOptions.enableColumnResizing
              */
-            enableColumnResizing: boolean;
+            enableColumnResizing?: boolean;
         }
         /**
          * Column Resizing Grid Options


### PR DESCRIPTION
Also added a test for creating an empty IColumnDef object, implying
setting everything to default values.
