### PR TITLE
Fix method name of rotate() in Vertices

### DIFF
--- a/matter-js/matter-js.d.ts
+++ b/matter-js/matter-js.d.ts
@@ -44,7 +44,7 @@ declare module Matter
     {
         /**
          * Clears the engine including the world, pairs and broadphase.
-         * @param engine 
+         * @param engine
          */
         static clear(engine:Engine):void;
 
@@ -844,24 +844,24 @@ declare module Matter
          */
             type?:string;
     }
-    
+
     export class Query
     {
         /**
          * Casts a ray segment against a set of bodies and returns all collisions, ray width is optional. Intersection points are not provided.
-         * 
-         * @param bodies 
-         * @param startPoint 
-         * @param endPoint 
+         *
+         * @param bodies
+         * @param startPoint
+         * @param endPoint
          * @param [rayWidth]
-         * 
+         *
          * @returns Object[] Collisions
          */
         static ray( bodies:Array<Body>,  startPoint:Vector,  endPoint:Vector,  rayWidth?:number ):Array<any>;
-        
+
         /**
          * Returns all bodies whose bounds are inside (or outside if set) the given set of bounds, from the given set of bodies.
-         * 
+         *
          * @param bodies
          * @param bounds
          * @returns Body[] The bodies matching the query
@@ -1375,7 +1375,7 @@ declare module Matter
          * @param vertices
          * @returns The polygon's moment of inertia
          */
-        static inertia( vertices:Array<Vector>,  mass:number ):number;
+        static inertia ( vertices:Array<Vector>,  mass:number ):number;
 
         /**
          * Rotates the set of vertices in-place.
@@ -1384,7 +1384,7 @@ declare module Matter
          * @param angle
          * @param point
          */
-        static static  ( vertices:Array<Vector>,  angle:number,  point:Vector ):void;
+        static rotate ( vertices:Array<Vector>,  angle:number,  point:Vector ):void;
 
         /**
          * Scales the vertices from a point (default is centre) in-place.


### PR DESCRIPTION
Also removed trailing whitespaces.
