### PR TITLE
Highcharts - HighchartsOptions.yAxis support for multiple axis

### DIFF
--- a/highcharts/highcharts-tests.ts
+++ b/highcharts/highcharts-tests.ts
@@ -135,3 +135,11 @@ var highChartSettings: HighchartsOptions = {
 var container = $("#container").highcharts(highChartSettings, (chart) => {
     chart.series[0].setVisible(true, true);
 });
+
+
+var singleYAxisOptions: HighchartsOptions = {
+    yAxis: {}
+};
+var multipleYAxisOptions: HighchartsOptions = {
+    yAxis: [{},{}]
+};

--- a/highcharts/highcharts.d.ts
+++ b/highcharts/highcharts.d.ts
@@ -1169,7 +1169,7 @@ interface HighchartsOptions {
     title?: HighchartsTitleOptions;
     tooltip?: HighchartsTooltipOptions;
     xAxis?: HighchartsAxisOptions;
-    yAxis?: HighchartsAxisOptions;
+    yAxis?: HighchartsAxisOptions|HighchartsAxisOptions[];
 }
 
 interface HighchartsGlobalOptions extends HighchartsOptions {


### PR DESCRIPTION
The yAxis property of HighchartsOptions can be either a single HighchartsAxisOptions or an array of HighchartsAxisOptions for charts with multiple yAxis. See http://api.highcharts.com/highcharts#yAxis.

I also added some tests for creating a HighchartsOptions variable with a single or multiple axis, but they are redundant at least for the moment. The reason they are redundant since all of the interface properties are optional compilation will not fail.
