### PR TITLE
Fixing dropzone typings

### DIFF
--- a/dropzone/dropzone-commonjs-tests.ts
+++ b/dropzone/dropzone-commonjs-tests.ts
@@ -1,0 +1,187 @@
+/// <reference path="./dropzone.d.ts"/>
+
+import Dropzone = require("dropzone");
+
+const dropzoneFromString = new Dropzone(".test");
+const dropzoneFromElement = new Dropzone(document.getElementById("test"));
+
+const dropzoneWithOptions = new Dropzone(".test", {
+	url: "/some/url",
+	method: "post",
+	withCredentials: false,
+	parallelUploads: 2,
+	uploadMultiple: true,
+	maxFilesize: 1024,
+	paramName: "file",
+	createImageThumbnails: true,
+	maxThumbnailFilesize: 1024,
+	thumbnailWidth: 50,
+	thumbnailHeight: 50,
+	filesizeBase: 1000,
+	maxFiles: 100,
+	params: {
+		additional: "param"
+	},
+	clickable: true,
+	ignoreHiddenFiles: true,
+	acceptedFiles: "image/*",
+	autoProcessQueue: true,
+	autoQueue: true,
+	addRemoveLinks: true,
+	previewsContainer: "<div></div>",
+	capture: "camera",
+
+	dictDefaultMessage: "",
+	dictFallbackMessage: "",
+	dictFallbackText: "",
+	dictFileTooBig: "",
+	dictInvalidFileType: "",
+	dictResponseError: "",
+	dictCancelUpload: "",
+	dictCancelUploadConfirmation: "",
+	dictRemoveFile: "",
+	dictRemoveFileConfirmation: "",
+	dictMaxFilesExceeded: "",
+
+	accept: (file:DropzoneFile, done:(error?:string|Error) => void) => {
+		if (file.accepted) {
+			file.previewElement.classList.add("accepted");
+			file.previewTemplate.classList.add("accepted");
+			file.previewsContainer.classList.add("accepted");
+			done();
+		}
+		else {
+			done(new Error(file.status));
+		}
+	},
+	init: () => console.log("Initialized"),
+	forceFallback: false,
+	fallback: () => console.log("Fallback"),
+	resize: (file:DropzoneFile) => ({
+		srcX: 0,
+		srcY: 0,
+		trgX: 10,
+		trgY: 10,
+		srcWidth: 100,
+		srcHeight: 100,
+		trgWidth: 50,
+		trgHeight: 50,
+		optWidth: 50,
+		optHeight: 50
+	}),
+
+	drop: (e:DragEvent) => console.log("Drop"),
+	dragstart: (e:DragEvent) => console.log("Dragstart"),
+	dragend: (e:DragEvent) => console.log("Dragend"),
+	dragenter: (e:DragEvent) => console.log("Dragenter"),
+	dragover: (e:DragEvent) => console.log("Dragover"),
+	dragleave: (e:DragEvent) => console.log("Dragleave"),
+	paste: (e:DragEvent) => console.log("Paste"),
+
+	reset: () => console.log("Reset"),
+
+	addedfile: (file:DropzoneFile) => console.log("Addedfile"),
+	addedfiles: (files:DropzoneFile[]) => console.log("Addedfiles"),
+	removedfile: (file:DropzoneFile) => console.log("Removedfile"),
+	thumbnail: (file:DropzoneFile, dataUrl:string) => console.log("Thumbnail"),
+
+	error: (file:DropzoneFile, message:string|Error) => console.log("Error"),
+	errormultiple: (files:DropzoneFile[], message:string|Error) => console.log("Errormultiple"),
+
+	processing: (file:DropzoneFile) => console.log("Processing"),
+	processingmultiple: (files:DropzoneFile[]) => console.log("Processingmultiple"),
+
+	uploadprogress: (file:DropzoneFile, progress:number, bytesSent:number) => console.log("Uploadprogress"),
+	totaluploadprogress: (totalProgress:number, totalBytes:number, totalBytesSent:number) => console.log("Totaluploadprogress"),
+
+	sending: (file:DropzoneFile, xhr:XMLHttpRequest, formData:{}) => console.log("Sending"),
+	sendingmultiple: (files:DropzoneFile[], xhr:XMLHttpRequest, formData:{}) => console.log("Sendingmultiple"),
+
+	success: (file:DropzoneFile) => console.log("Success"),
+	successmultiple: (files:DropzoneFile[]) => console.log("Successmultiple"),
+
+	canceled: (file:DropzoneFile) => console.log("Canceled"),
+	canceledmultiple: (file:DropzoneFile[]) => console.log("Canceledmultiple"),
+
+	complete: (file:DropzoneFile) => console.log("Complete"),
+	completemultiple: (file:DropzoneFile[]) => console.log("Completemultiple"),
+
+	maxfilesexceeded: (file:DropzoneFile) => console.log("Maxfilesexceeded"),
+	maxfilesreached: (files:DropzoneFile[]) => console.log("Maxfilesreached"),
+	queuecomplete: () => console.log("Queuecomplete"),
+
+	previewTemplate: "<div></div>",
+});
+
+var dropzoneWithOptionsVariations:Dropzone;
+dropzoneWithOptionsVariations = new Dropzone(".test", {
+	clickable: ".test"
+});
+dropzoneWithOptionsVariations = new Dropzone(".test", {
+	clickable: document.getElementById("test")
+});
+dropzoneWithOptionsVariations = new Dropzone(".test", {
+	clickable: [".test", ".test"]
+});
+dropzoneWithOptionsVariations = new Dropzone(".test", {
+	clickable: [document.getElementById("test"), document.getElementById("test")]
+});
+dropzoneWithOptionsVariations = new Dropzone(".test", {
+	clickable: ["test", document.getElementById("test")]
+});
+
+const dropzone = new Dropzone(".test");
+
+dropzone.enable();
+dropzone.disable();
+
+dropzone.files.forEach(f => {
+	if (f.accepted) {
+		f.previewElement.classList.add("accepted");
+		f.previewTemplate.classList.add("accepted");
+		f.previewsContainer.classList.add("accepted");
+	}
+	else {
+		console.log(f.status.toUpperCase());
+	}
+});
+
+const firstFile = dropzone.files[0];
+dropzone.removeFile(firstFile);
+dropzone.addFile(firstFile);
+dropzone.enqueueFile(firstFile);
+dropzone.processFile(firstFile);
+dropzone.uploadFile(firstFile);
+dropzone.cancelUpload(firstFile);
+dropzone.createThumbnail(firstFile, () => {
+	console.log("createThumbnail")
+});
+dropzone.createThumbnailFromUrl(firstFile, "/some/url", () => {
+	console.log("createThumbnailFromUrl")
+});
+dropzone.accept(firstFile, (e:string|Error) => {
+	console.log(e);
+});
+
+const acceptedFiles = dropzone.getAcceptedFiles();
+dropzone.processFiles(acceptedFiles);
+
+const rejectedFiles = dropzone.getRejectedFiles();
+dropzone.enqueueFiles(rejectedFiles);
+
+const queuedFiles = dropzone.getQueuedFiles();
+dropzone.processFiles(queuedFiles);
+
+const uploadingFiles = dropzone.getUploadingFiles();
+dropzone.processFiles(uploadingFiles);
+
+const activeFiles = dropzone.getActiveFiles();
+dropzone.processFiles(activeFiles);
+
+const addedFiles = dropzone.getFilesWithStatus(Dropzone.ADDED);
+dropzone.processFiles(addedFiles);
+
+dropzone.processQueue();
+dropzone.removeAllFiles(true);
+
+dropzone.destroy();

--- a/dropzone/dropzone-tests.ts
+++ b/dropzone/dropzone-tests.ts
@@ -1,0 +1,185 @@
+/// <reference path="./dropzone.d.ts"/>
+
+const dropzoneFromString = new Dropzone(".test");
+const dropzoneFromElement = new Dropzone(document.getElementById("test"));
+
+const dropzoneWithOptions = new Dropzone(".test", {
+	url: "/some/url",
+	method: "post",
+	withCredentials: false,
+	parallelUploads: 2,
+	uploadMultiple: true,
+	maxFilesize: 1024,
+	paramName: "file",
+	createImageThumbnails: true,
+	maxThumbnailFilesize: 1024,
+	thumbnailWidth: 50,
+	thumbnailHeight: 50,
+	filesizeBase: 1000,
+	maxFiles: 100,
+	params: {
+		additional: "param"
+	},
+	clickable: true,
+	ignoreHiddenFiles: true,
+	acceptedFiles: "image/*",
+	autoProcessQueue: true,
+	autoQueue: true,
+	addRemoveLinks: true,
+	previewsContainer: "<div></div>",
+	capture: "camera",
+
+	dictDefaultMessage: "",
+	dictFallbackMessage: "",
+	dictFallbackText: "",
+	dictFileTooBig: "",
+	dictInvalidFileType: "",
+	dictResponseError: "",
+	dictCancelUpload: "",
+	dictCancelUploadConfirmation: "",
+	dictRemoveFile: "",
+	dictRemoveFileConfirmation: "",
+	dictMaxFilesExceeded: "",
+
+	accept: (file:DropzoneFile, done:(error?:string|Error) => void) => {
+		if (file.accepted) {
+			file.previewElement.classList.add("accepted");
+			file.previewTemplate.classList.add("accepted");
+			file.previewsContainer.classList.add("accepted");
+			done();
+		}
+		else {
+			done(new Error(file.status));
+		}
+	},
+	init: () => console.log("Initialized"),
+	forceFallback: false,
+	fallback: () => console.log("Fallback"),
+	resize: (file:DropzoneFile) => ({
+		srcX: 0,
+		srcY: 0,
+		trgX: 10,
+		trgY: 10,
+		srcWidth: 100,
+		srcHeight: 100,
+		trgWidth: 50,
+		trgHeight: 50,
+		optWidth: 50,
+		optHeight: 50
+	}),
+
+	drop: (e:DragEvent) => console.log("Drop"),
+	dragstart: (e:DragEvent) => console.log("Dragstart"),
+	dragend: (e:DragEvent) => console.log("Dragend"),
+	dragenter: (e:DragEvent) => console.log("Dragenter"),
+	dragover: (e:DragEvent) => console.log("Dragover"),
+	dragleave: (e:DragEvent) => console.log("Dragleave"),
+	paste: (e:DragEvent) => console.log("Paste"),
+
+	reset: () => console.log("Reset"),
+
+	addedfile: (file:DropzoneFile) => console.log("Addedfile"),
+	addedfiles: (files:DropzoneFile[]) => console.log("Addedfiles"),
+	removedfile: (file:DropzoneFile) => console.log("Removedfile"),
+	thumbnail: (file:DropzoneFile, dataUrl:string) => console.log("Thumbnail"),
+
+	error: (file:DropzoneFile, message:string|Error) => console.log("Error"),
+	errormultiple: (files:DropzoneFile[], message:string|Error) => console.log("Errormultiple"),
+
+	processing: (file:DropzoneFile) => console.log("Processing"),
+	processingmultiple: (files:DropzoneFile[]) => console.log("Processingmultiple"),
+
+	uploadprogress: (file:DropzoneFile, progress:number, bytesSent:number) => console.log("Uploadprogress"),
+	totaluploadprogress: (totalProgress:number, totalBytes:number, totalBytesSent:number) => console.log("Totaluploadprogress"),
+
+	sending: (file:DropzoneFile, xhr:XMLHttpRequest, formData:{}) => console.log("Sending"),
+	sendingmultiple: (files:DropzoneFile[], xhr:XMLHttpRequest, formData:{}) => console.log("Sendingmultiple"),
+
+	success: (file:DropzoneFile) => console.log("Success"),
+	successmultiple: (files:DropzoneFile[]) => console.log("Successmultiple"),
+
+	canceled: (file:DropzoneFile) => console.log("Canceled"),
+	canceledmultiple: (file:DropzoneFile[]) => console.log("Canceledmultiple"),
+
+	complete: (file:DropzoneFile) => console.log("Complete"),
+	completemultiple: (file:DropzoneFile[]) => console.log("Completemultiple"),
+
+	maxfilesexceeded: (file:DropzoneFile) => console.log("Maxfilesexceeded"),
+	maxfilesreached: (files:DropzoneFile[]) => console.log("Maxfilesreached"),
+	queuecomplete: () => console.log("Queuecomplete"),
+
+	previewTemplate: "<div></div>",
+});
+
+var dropzoneWithOptionsVariations:Dropzone;
+dropzoneWithOptionsVariations = new Dropzone(".test", {
+	clickable: ".test"
+});
+dropzoneWithOptionsVariations = new Dropzone(".test", {
+	clickable: document.getElementById("test")
+});
+dropzoneWithOptionsVariations = new Dropzone(".test", {
+	clickable: [".test", ".test"]
+});
+dropzoneWithOptionsVariations = new Dropzone(".test", {
+	clickable: [document.getElementById("test"), document.getElementById("test")]
+});
+dropzoneWithOptionsVariations = new Dropzone(".test", {
+	clickable: ["test", document.getElementById("test")]
+});
+
+const dropzone = new Dropzone(".test");
+
+dropzone.enable();
+dropzone.disable();
+
+dropzone.files.forEach(f => {
+	if (f.accepted) {
+		f.previewElement.classList.add("accepted");
+		f.previewTemplate.classList.add("accepted");
+		f.previewsContainer.classList.add("accepted");
+	}
+	else {
+		console.log(f.status.toUpperCase());
+	}
+});
+
+const firstFile = dropzone.files[0];
+dropzone.removeFile(firstFile);
+dropzone.addFile(firstFile);
+dropzone.enqueueFile(firstFile);
+dropzone.processFile(firstFile);
+dropzone.uploadFile(firstFile);
+dropzone.cancelUpload(firstFile);
+dropzone.createThumbnail(firstFile, () => {
+	console.log("createThumbnail")
+});
+dropzone.createThumbnailFromUrl(firstFile, "/some/url", () => {
+	console.log("createThumbnailFromUrl")
+});
+dropzone.accept(firstFile, (e:string|Error) => {
+	console.log(e);
+});
+
+const acceptedFiles = dropzone.getAcceptedFiles();
+dropzone.processFiles(acceptedFiles);
+
+const rejectedFiles = dropzone.getRejectedFiles();
+dropzone.enqueueFiles(rejectedFiles);
+
+const queuedFiles = dropzone.getQueuedFiles();
+dropzone.processFiles(queuedFiles);
+
+const uploadingFiles = dropzone.getUploadingFiles();
+dropzone.processFiles(uploadingFiles);
+
+const activeFiles = dropzone.getActiveFiles();
+dropzone.processFiles(activeFiles);
+
+const addedFiles = dropzone.getFilesWithStatus(Dropzone.ADDED);
+dropzone.processFiles(addedFiles);
+
+dropzone.processQueue();
+dropzone.removeAllFiles(true);
+
+dropzone.destroy();

--- a/dropzone/dropzone-tests.ts
+++ b/dropzone/dropzone-tests.ts
@@ -20,6 +20,9 @@ const dropzoneWithOptions = new Dropzone(".test", {
 	params: {
 		additional: "param"
 	},
+	headers: {
+		"Some-Header": "Value"
+	},
 	clickable: true,
 	ignoreHiddenFiles: true,
 	acceptedFiles: "image/*",

--- a/dropzone/dropzone.d.ts
+++ b/dropzone/dropzone.d.ts
@@ -1,9 +1,22 @@
 // Type definitions for Dropzone 4.0.1
 // Project: http://www.dropzonejs.com/
-// Definitions by: Natan Vivo <https://github.com/nvivo>, Andy Hawkins <https://github.com/a904guy/,http://a904guy.com/,http://www.bmbsqd.com>
+// Definitions by: Natan Vivo <https://github.com/nvivo>, Andy Hawkins <https://github.com/a904guy/,http://a904guy.com/,http://www.bmbsqd.com>, Vasya Aksyonov <https://github.com/outring>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../jquery/jquery.d.ts"/>
+
+interface DropzoneResizeInfo {
+	srcX?:number;
+	srcY?:number;
+	trgX?:number;
+	trgY?:number;
+	srcWidth?:number;
+	srcHeight?:number;
+	trgWidth?:number;
+	trgHeight?:number;
+	optWidth?:number;
+	optHeight?:number;
+}
 
 interface DropzoneFile extends File {
 	previewElement: HTMLElement;
@@ -18,109 +31,238 @@ interface DropzoneOptions {
 	method?: string;
 	withCredentials?: boolean;
 	parallelUploads?: number;
+	uploadMultiple?: boolean;
 	maxFilesize?: number;
 	paramName?: string;
-	uploadMultiple?: boolean;
-	headers?: any;
-	addRemoveLinks?: boolean;
-	previewsContainer?: string;
-	clickable?: any;
 	createImageThumbnails?: boolean;
 	maxThumbnailFilesize?: number;
 	thumbnailWidth?: number;
 	thumbnailHeight?: number;
+	filesizeBase?: number;
 	maxFiles?: number;
-	resize?: ( file?: any ) => any;
-	init?: () => void;
+	params?: {};
+	clickable?: boolean|string|HTMLElement|(string|HTMLElement)[];
+	ignoreHiddenFiles?: boolean;
 	acceptedFiles?: string;
-	accept?: ( file: DropzoneFile, doneCallback: ( ...args: any[] ) => void ) => void;
 	autoProcessQueue?: boolean;
-	previewTemplate?: string;
-	forceFallback?: boolean;
-	fallback?: () => void;
+	autoQueue?: boolean;
+	addRemoveLinks?: boolean;
+	previewsContainer?: boolean|string|HTMLElement;
+	capture?: string;
 
-	// dictionary options
 	dictDefaultMessage?: string;
 	dictFallbackMessage?: string;
 	dictFallbackText?: string;
-	dictInvalidFileType?: string;
 	dictFileTooBig?: string;
+	dictInvalidFileType?: string;
 	dictResponseError?: string;
 	dictCancelUpload?: string;
 	dictCancelUploadConfirmation?: string;
 	dictRemoveFile?: string;
 	dictRemoveFileConfirmation?: string;
 	dictMaxFilesExceeded?: string;
+
+	accept?(file:DropzoneFile, done:(error?:string|Error) => void):void;
+	init?():void;
+	forceFallback?: boolean;
+	fallback?():void;
+	resize?(file:DropzoneFile):DropzoneResizeInfo;
+
+	drop?(e:DragEvent):void;
+	dragstart?(e:DragEvent):void;
+	dragend?(e:DragEvent):void;
+	dragenter?(e:DragEvent):void;
+	dragover?(e:DragEvent):void;
+	dragleave?(e:DragEvent):void;
+	paste?(e:DragEvent):void;
+
+	reset?():void;
+
+	addedfile?(file:DropzoneFile):void;
+	addedfiles?(files:DropzoneFile[]):void;
+	removedfile?(file:DropzoneFile):void;
+	thumbnail?(file:DropzoneFile, dataUrl:string):void;
+
+	error?(file:DropzoneFile, message:string|Error, xhr:XMLHttpRequest):void;
+	errormultiple?(files:DropzoneFile[], message:string|Error, xhr:XMLHttpRequest):void;
+
+	processing?(file:DropzoneFile):void;
+	processingmultiple?(files:DropzoneFile[]):void;
+
+	uploadprogress?(file:DropzoneFile, progress:number, bytesSent:number):void;
+	totaluploadprogress?(totalProgress:number, totalBytes:number, totalBytesSent:number):void;
+
+	sending?(file:DropzoneFile, xhr:XMLHttpRequest, formData:{}):void;
+	sendingmultiple?(files:DropzoneFile[], xhr:XMLHttpRequest, formData:{}):void;
+
+	success?(file:DropzoneFile, responseText:string):void;
+	successmultiple?(files:DropzoneFile[], responseText:string):void;
+
+	canceled?(file:DropzoneFile):void;
+	canceledmultiple?(file:DropzoneFile[]):void;
+
+	complete?(file:DropzoneFile):void;
+	completemultiple?(file:DropzoneFile[]):void;
+
+	maxfilesexceeded?(file:DropzoneFile):void;
+	maxfilesreached?(files:DropzoneFile[]):void;
+	queuecomplete?():void;
+
+	previewTemplate?: string;
 }
 
 declare class Dropzone {
-	constructor( container: string, options?: DropzoneOptions );
-	constructor( container: HTMLElement, options?: DropzoneOptions );
+	constructor(container:string|HTMLElement, options?:DropzoneOptions);
 
-	static autoDiscover: boolean;
-	static options: any;
-	static confirm: ( question: string, accepted: () => void, rejected?: () => void ) => void;
+	static autoDiscover:boolean;
+	static options:any;
+	static confirm:(question:string, accepted:() => void, rejected?:() => void) => void;
 
-	files: DropzoneFile[];
+	static ADDED:string;
+	static QUEUED:string;
+	static ACCEPTED:string;
+	static UPLOADING:string;
+	static PROCESSING:string;
+	static CANCELED:string;
+	static ERROR:string;
+	static SUCCESS:string;
 
-	enable(): void;
-	disable(): void;
-	destroy(): Dropzone;
+	files:DropzoneFile[];
 
-	on( eventName: string, callback: ( ...args: any[] ) => any ): void;
+	enable():void;
 
-	off( eventName: string ): void;
+	disable():void;
 
-	addFile( file: DropzoneFile ): void;
+	destroy():Dropzone;
 
-	removeFile( file: DropzoneFile ): void;
+	addFile(file:DropzoneFile):void;
 
-	removeAllFiles( cancelIfNecessary?: boolean ): void;
+	removeFile(file:DropzoneFile):void;
 
-	processQueue(): void;
+	removeAllFiles(cancelIfNecessary?:boolean):void;
 
-	cancelUpload( file: DropzoneFile ): void;
+	processQueue():void;
 
-	processFiles ( files: DropzoneFile[] ): void;
-	processFile( file: DropzoneFile ): void;
+	cancelUpload(file:DropzoneFile):void;
 
-	uploadFile( file: DropzoneFile ): void;
+	processFiles(files:DropzoneFile[]):void;
 
-	getAcceptedFiles(): DropzoneFile[];
+	processFile(file:DropzoneFile):void;
 
-	getRejectedFiles(): DropzoneFile[];
+	uploadFile(file:DropzoneFile):void;
 
-	getQueuedFiles(): DropzoneFile[];
+	getAcceptedFiles():DropzoneFile[];
 
-	getUploadingFiles(): DropzoneFile[];
+	getRejectedFiles():DropzoneFile[];
 
-	accept( file: DropzoneFile, done: ( error?: string ) => {} ):void;
-	getActiveFiles(): DropzoneFile[];
-	getFilesWithStatus( status: string ): DropzoneFile[];
-	enqueueFile( file: DropzoneFile ): void;
-	enqueueFiles( file: DropzoneFile[] ): void;
-	createThumbnail( file: DropzoneFile, callback?: (...any: any[]) => {}): any;
-	createThumbnailFromUrl( file: DropzoneFile, url: string, callback?: ( ...any: any[] ) => any ): any;
+	getQueuedFiles():DropzoneFile[];
 
-	emit( eventName: string, file: DropzoneFile, str?: string ): void;
-	emit( eventName: "thumbnail", file: DropzoneFile, path: string ): void;
-	emit( eventName: "addedfile", file: DropzoneFile ): void;
-	emit( eventName: "removedfile", file: DropzoneFile ): void;
-	emit( eventName: "processing", file: DropzoneFile ): void;
-	emit( eventName: "canceled", file: DropzoneFile ): void;
-	emit( eventName: "complete", file: DropzoneFile ): void;
+	getUploadingFiles():DropzoneFile[];
 
-	emit( eventName: string, e: Event ): void;
-	emit( eventName: "drop", e: Event ): void;
-	emit( eventName: "dragstart", e: Event ): void;
-	emit( eventName: "dragend", e: Event ): void;
-	emit( eventName: "dragenter", e: Event ): void;
-	emit( eventName: "dragover", e: Event ): void;
-	emit( eventName: "dragleave", e: Event ): void;
+	accept(file:DropzoneFile, done:(error?:string|Error) => void):void;
+
+	getActiveFiles():DropzoneFile[];
+
+	getFilesWithStatus(status:string):DropzoneFile[];
+
+	enqueueFile(file:DropzoneFile):void;
+
+	enqueueFiles(file:DropzoneFile[]):void;
+
+	createThumbnail(file:DropzoneFile, callback?:(...args:any[]) => void):any;
+
+	createThumbnailFromUrl(file:DropzoneFile, url:string, callback?:(...args:any[]) => void):any;
+
+	on(eventName:string, callback:(...args:any[]) => void):void;
+
+	off(eventName:string):void;
+
+	emit(eventName:string, ...args:any[]):void;
+
+	on(eventName:"drop", callback:(e:DragEvent) => any):void;
+	on(eventName:"dragstart", callback:(e:DragEvent) => any):void;
+	on(eventName:"dragend", callback:(e:DragEvent) => any):void;
+	on(eventName:"dragenter", callback:(e:DragEvent) => any):void;
+	on(eventName:"dragover", callback:(e:DragEvent) => any):void;
+	on(eventName:"dragleave", callback:(e:DragEvent) => any):void;
+	on(eventName:"paste", callback:(e:DragEvent) => any):void;
+
+	on(eventName:"reset"):void;
+
+	on(eventName:"addedfile", callback:(file:DropzoneFile) => any):void;
+	on(eventName:"addedfiles", callback:(files:DropzoneFile[]) => any):void;
+	on(eventName:"removedfile", callback:(file:DropzoneFile) => any):void;
+	on(eventName:"thumbnail", callback:(file:DropzoneFile, dataUrl:string) => any):void;
+
+	on(eventName:"error", callback:(file:DropzoneFile, message:string|Error) => any):void;
+	on(eventName:"errormultiple", callback:(files:DropzoneFile[], message:string|Error) => any):void;
+
+	on(eventName:"processing", callback:(file:DropzoneFile) => any):void;
+	on(eventName:"processingmultiple", callback:(files:DropzoneFile[]) => any):void;
+
+	on(eventName:"uploadprogress", callback:(file:DropzoneFile, progress:number, bytesSent:number) => any):void;
+	on(eventName:"totaluploadprogress", callback:(totalProgress:number, totalBytes:number, totalBytesSent:number) => any):void;
+
+	on(eventName:"sending", callback:(file:DropzoneFile, xhr:XMLHttpRequest, formData:{}) => any):void;
+	on(eventName:"sendingmultiple", callback:(files:DropzoneFile[], xhr:XMLHttpRequest, formData:{}) => any):void;
+
+	on(eventName:"success", callback:(file:DropzoneFile) => any):void;
+	on(eventName:"successmultiple", callback:(files:DropzoneFile[]) => any):void;
+
+	on(eventName:"canceled", callback:(file:DropzoneFile) => any):void;
+	on(eventName:"canceledmultiple", callback:(file:DropzoneFile[]) => any):void;
+
+	on(eventName:"complete", callback:(file:DropzoneFile) => any):void;
+	on(eventName:"completemultiple", callback:(file:DropzoneFile[]) => any):void;
+
+	on(eventName:"maxfilesexceeded", callback:(file:DropzoneFile) => any):void;
+	on(eventName:"maxfilesreached", callback:(files:DropzoneFile[]) => any):void;
+	on(eventName:"queuecomplete"):void;
+
+	emit(eventName:"drop", e:DragEvent):void;
+	emit(eventName:"dragstart", e:DragEvent):void;
+	emit(eventName:"dragend", e:DragEvent):void;
+	emit(eventName:"dragenter", e:DragEvent):void;
+	emit(eventName:"dragover", e:DragEvent):void;
+	emit(eventName:"dragleave", e:DragEvent):void;
+	emit(eventName:"paste", e:DragEvent):void;
+
+	emit(eventName:"reset"):void;
+
+	emit(eventName:"addedfile", file:DropzoneFile):void;
+	emit(eventName:"addedfiles", files:DropzoneFile[]):void;
+	emit(eventName:"removedfile", file:DropzoneFile):void;
+	emit(eventName:"thumbnail", file:DropzoneFile, dataUrl:string):void;
+
+	emit(eventName:"error", file:DropzoneFile, message:string|Error):void;
+	emit(eventName:"errormultiple", files:DropzoneFile[], message:string|Error):void;
+
+	emit(eventName:"processing", file:DropzoneFile):void;
+	emit(eventName:"processingmultiple", files:DropzoneFile[]):void;
+
+	emit(eventName:"uploadprogress", file:DropzoneFile, progress:number, bytesSent:number):void;
+	emit(eventName:"totaluploadprogress", totalProgress:number, totalBytes:number, totalBytesSent:number):void;
+
+	emit(eventName:"sending", file:DropzoneFile, xhr:XMLHttpRequest, formData:{}):void;
+	emit(eventName:"sendingmultiple", files:DropzoneFile[], xhr:XMLHttpRequest, formData:{}):void;
+
+	emit(eventName:"success", file:DropzoneFile):void;
+	emit(eventName:"successmultiple", files:DropzoneFile[]):void;
+
+	emit(eventName:"canceled", file:DropzoneFile):void;
+	emit(eventName:"canceledmultiple", file:DropzoneFile[]):void;
+
+	emit(eventName:"complete", file:DropzoneFile):void;
+	emit(eventName:"completemultiple", file:DropzoneFile[]):void;
+
+	emit(eventName:"maxfilesexceeded", file:DropzoneFile):void;
+	emit(eventName:"maxfilesreached", files:DropzoneFile[]):void;
+	emit(eventName:"queuecomplete"):void;
+
 }
 
 interface JQuery {
-	dropzone( options: DropzoneOptions ): Dropzone;
+	dropzone(options:DropzoneOptions): Dropzone;
 }
 
 declare module "dropzone" {

--- a/dropzone/dropzone.d.ts
+++ b/dropzone/dropzone.d.ts
@@ -41,6 +41,7 @@ interface DropzoneOptions {
 	filesizeBase?: number;
 	maxFiles?: number;
 	params?: {};
+	headers?: {},
 	clickable?: boolean|string|HTMLElement|(string|HTMLElement)[];
 	ignoreHiddenFiles?: boolean;
 	acceptedFiles?: string;


### PR DESCRIPTION
Fixed dropzone typings to match [code](https://github.com/enyo/dropzone/blob/master/src/dropzone.coffee) and [docs](http://www.dropzonejs.com/). 
Previous version hadn't lots of options and had some weak or wrong typings for class members. And, of course, there were no tests.
