### PR TITLE
refactoring due to «ng» not available for newer angularjs versions, also structure and module name following angularjs style

### DIFF
--- a/angulartics/angulartics-tests.ts
+++ b/angulartics/angulartics-tests.ts
@@ -3,7 +3,7 @@
 
 module Analytics {
     angular.module("angulartics.app", ["angulartics"])
-        .config(["$analyticsProvider", ($analyticsProvider: Angulartics.IAnalyticsServiceProvider) => {
+        .config(["$analyticsProvider", ($analyticsProvider:angulartics.IAnalyticsServiceProvider) => {
             angulartics.waitForVendorApi("location", 1000, (message: string) => {
                 console.log(message);
             });
@@ -17,9 +17,8 @@ module Analytics {
                 console.log(action);
             });
 
-            $analyticsProvider.registerPageTrack((path: string, locationObj: ng.ILocationService) => {
+            $analyticsProvider.registerPageTrack((path:string, locationObj:angular.ILocationService) => {
                 console.log("viewed " + path);
             });
         }]);
 }
-

--- a/angulartics/angulartics.d.ts
+++ b/angulartics/angulartics.d.ts
@@ -4,16 +4,15 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../angularjs/angular.d.ts" />
+declare module angulartics {
 
-interface Angulartics {
-    waitForVendorApi(objectName: string, delay: number, containsField?: any, registerFn?: any, onTimeout?: boolean): void;
-}
-
-declare module Angulartics {
+    interface IAngularticsStatic {
+        waitForVendorApi(objectName:string, delay:number, containsField?:any, registerFn?:any, onTimeout?:boolean): void;
+    }
 
     interface IAnalyticsService {
         eventTrack(eventName: string, properties?: any): any;
-        pageTrack(path: string, location?: ng.ILocationService): any;
+        pageTrack(path:string, location?:angular.ILocationService): any;
         setAlias(alias: string): any;
         setUsername(username: string): any;
         setUserProperties(properties: any): any;
@@ -27,7 +26,7 @@ declare module Angulartics {
         withAutoBase(value: boolean): void;
         developerMode(value: boolean): void;
 
-        registerPageTrack(callback: (path: string, location?: ng.ILocationService) => any): void;
+        registerPageTrack(callback:(path:string, location?:angular.ILocationService) => any): void;
         registerEventTrack(callback: (eventName: string, properties?: any) => any): void;
         registerSetAlias(callback: (alias: string) => any): void
         registerSetUsername(callback: (username: string) => any): void
@@ -36,4 +35,4 @@ declare module Angulartics {
     }
 }
 
-declare var angulartics:Angulartics;
+declare var angulartics:angulartics.IAngularticsStatic;


### PR DESCRIPTION
- update namespace of angular to «angular» instead of «ng», newer versions don't support «ng» anymore
- include static interface inside the module following the style how angularjs does it
- refactor module name to use lowercase following angularjs naming-style
