### PR TITLE
mustache: declare mustache module

### DIFF
--- a/mustache/mustache.d.ts
+++ b/mustache/mustache.d.ts
@@ -47,3 +47,7 @@ interface MustacheStatic {
 }
 
 declare var Mustache: MustacheStatic;
+
+declare module 'mustache' {
+	export = Mustache;
+}


### PR DESCRIPTION
Modern mustache defines the 'mustache' module for use under both NPM
and bower.  Define that here so we can use require('mustache') in
TypeScript without complaint.
