### PR TITLE
Updated JQuery.map to return an array of any.

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -2983,7 +2983,7 @@ interface JQuery {
      * 
      * @param callback A function object that will be invoked for each element in the current set.
      */
-    map(callback: (index: number, domElement: Element) => any): JQuery;
+    map(callback: (index: number, domElement: Element) => any): Array<any>;
 
     /**
      * Get the immediately following sibling of each element in the set of matched elements. If a selector is provided, it retrieves the next sibling only if it matches that selector.


### PR DESCRIPTION
It was returning a JQuery instance which is not what it actually does, it returns an array of the results from the callback (could be other JQuery objects, ints, strings, or anything else).
