### PR TITLE
Add definition of Slider constructor

### DIFF
--- a/bootstrap-slider/bootstrap-slider.d.ts
+++ b/bootstrap-slider/bootstrap-slider.d.ts
@@ -137,6 +137,13 @@ interface JQueryEventObject {
     value: number|ChangeValue;
 }
 
+interface SliderStatics {
+	new (selector: string, opts: SliderOptions): Slider;
+	prototype: Slider;
+}
+
+declare var Slider: SliderStatics;
+
 /**
  * This class is actually not used when using the jQuery version of bootstrap-slider
  * The method documentation is still here thouh.


### PR DESCRIPTION
https://github.com/seiyria/bootstrap-slider#using-bootstrap-slider-without-jquery

Although intended for use without JQuery (which would mean we would need a separate type definition file which doesn't reference JQuery) it can be used alongside the JQuery `$` usage.
