### PR TITLE
Fix type annotation in JsDoc

### DIFF
--- a/glidejs/glidejs.d.ts
+++ b/glidejs/glidejs.d.ts
@@ -32,7 +32,7 @@ declare module JQueryGlide {
         /**
          * Default: 500
          * Animation time in ms
-         * @type {Int}
+         * @type {number}
          */
         animationDuration?: number;
         /**


### PR DESCRIPTION
Use "number" instead of Int, which is non-existent
