### PR TITLE
ui-grid: Fixed row getters in selection API.

### DIFF
--- a/ui-grid/ui-grid-tests.ts
+++ b/ui-grid/ui-grid-tests.ts
@@ -100,7 +100,7 @@ gridApi.core.queueGridRefresh()
 gridApi.core.queueRefresh();
 gridApi.core.registerColumnsProcessor(colProcessor, 100);
 
-var rowEntityToScrollTo = {anObject: "inGridOptionsData"};
+var rowEntityToScrollTo = {anObject: 'inGridOptionsData'};
 var columnDefToScrollTo: uiGrid.IColumnDef;
 gridInstance.scrollTo();
 gridInstance.scrollTo(rowEntityToScrollTo);

--- a/ui-grid/ui-grid-tests.ts
+++ b/ui-grid/ui-grid-tests.ts
@@ -100,5 +100,11 @@ gridApi.core.queueGridRefresh()
 gridApi.core.queueRefresh();
 gridApi.core.registerColumnsProcessor(colProcessor, 100);
 
+var rowEntityToScrollTo = {anObject: "inGridOptionsData"};
+var columnDefToScrollTo: uiGrid.IColumnDef;
+gridInstance.scrollTo();
+gridInstance.scrollTo(rowEntityToScrollTo);
+gridInstance.scrollTo(rowEntityToScrollTo, columnDefToScrollTo);
+
 var selectedRowEntities: Array<any> = gridApi.selection.getSelectedRows();
 var selectedGridRows: Array<uiGrid.IGridRow> = gridApi.selection.getSelectedGridRows();

--- a/ui-grid/ui-grid-tests.ts
+++ b/ui-grid/ui-grid-tests.ts
@@ -100,3 +100,5 @@ gridApi.core.queueGridRefresh()
 gridApi.core.queueRefresh();
 gridApi.core.registerColumnsProcessor(colProcessor, 100);
 
+var selectedRowEntities: Array<any> = gridApi.selection.getSelectedRows();
+var selectedGridRows: Array<uiGrid.IGridRow> = gridApi.selection.getSelectedGridRows();

--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -445,7 +445,7 @@ declare module uiGrid {
          * @param {IColumnDef} colDef to make visible
          * @returns {ng.IPromise<any>} a promise that is resolved after any scrolling is finished
          */
-        scrollTo(rowEntity: IGridRow, colDef: IColumnDef): ng.IPromise<any>;
+        scrollTo(rowEntity?: any, colDef?: IColumnDef): ng.IPromise<any>;
         /**
          * Scrolls the grid to make a certain row and column combo visible,
          * in the case that it is not completely visible on the screen already.

--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -2823,12 +2823,12 @@ declare module uiGrid {
              * returns all selected rows as gridRows
              * @returns {Array<IGridRow>} The selected rows
              */
-            getSelectedGridRows(): Array<IGridRow>;
+            getSelectedGridRows(): Array<uiGrid.IGridRow>;
             /**
              * Gets selected rows as entities
              * @returns {Array<any>} Selected row entities
              */
-            getSelectedRows(): Array<IGridRow>;
+            getSelectedRows(): Array<any>;
             /**
              * Selects all rows.  Does nothing if multiselect = false
              * @param {ng.IAngularEvent} event object if raised from event


### PR DESCRIPTION
See: http://ui-grid.info/docs/#/api/ui.grid.selection.api:PublicApi

getSelectedGridRows should return uiGrid.IGridRow, not the uiGrid.selection.IGridRow interface which only has the selection-specific properties.

getSelectedRows returns the selected entities, not grid rows.

Also, IGridInstance.scrollTo takes an object in the gridOptions.data array as parameter, not an IGridRow. Both parameters are optional. See https://github.com/angular-ui/ui-grid/blob/a42dab24532fb896725b9fc8359e4526e436c891/src/js/core/factories/Grid.js#L2419-L2440
