### PR TITLE
Fixed exporting cheerio module

### DIFF
--- a/cheerio/cheerio-tests.ts
+++ b/cheerio/cheerio-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="cheerio.d.ts" />
 
-import cheerio from 'cheerio';
+import * as cheerio from 'cheerio';
 
 /*
  * LOADING

--- a/cheerio/cheerio.d.ts
+++ b/cheerio/cheerio.d.ts
@@ -262,5 +262,5 @@ interface CheerioAPI extends CheerioSelector {
 declare var cheerio:CheerioAPI;
 
 declare module "cheerio" {
-    export default cheerio;
+    export = cheerio;
 }


### PR DESCRIPTION
cheerio is intended to be used as below:

``` javascript
var cheerio = require('cheerio'),
    $ = cheerio.load('<h2 class="title">Hello world</h2>');
```

So we should use `import * as cheerio from "cheerio"` in TypeScript.  However, `cheerio` was defined with `export default` in cheerio.d.ts.

I think the author was confused by the difference between TypeScript's and ES6's 'default export'.

Ref: https://github.com/cheeriojs/cheerio#introduction
