### PR TITLE
Update Oboe.js definition

### DIFF
--- a/oboe/oboe-tests.ts
+++ b/oboe/oboe-tests.ts
@@ -32,3 +32,18 @@ oboe('/content')
 			console.error('no such content');
 		}
 	});
+
+oboe('friends.json')
+	.node('friend', function (parsedJson) {
+		console.log('friend parsed', parsedJson);
+	});
+
+oboe('friends.json')
+	.node({
+		'friend': function (parsedJson) {
+			console.log('friend parsed', parsedJson);
+		},
+		'!': function (parsedJson) {
+			console.log('root parsed', parsedJson);
+		}
+	});

--- a/oboe/oboe.d.ts
+++ b/oboe/oboe.d.ts
@@ -5,64 +5,66 @@
 
 /// <reference path="../node/node.d.ts" />
 
-declare module "oboe" {
-	import stream = require('stream');
-
-	function oboe(url: string): oboe.Oboe;
-	function oboe(options: oboe.Options): oboe.Oboe;
-	function oboe(stream: stream.Readable): oboe.Oboe;
-
-	module oboe {
-		var drop: {};
-
-		interface Oboe {
-			done(callback: (result: any) => void): Oboe;
-
-			fail(callback: (result: FailReason) => void): Oboe;
-
-			node(pattern: string, callback: CallbackSignature): Oboe;
-			node(patterns: PatternMap): Oboe;
-
-			on(event: string, pattern: string, callback: CallbackSignature): Oboe;
-			on(eventPattern: string, callback: CallbackSignature): Oboe;
-
-			path(pattern: string, callback: CallbackSignature): Oboe;
-			path(listeners: any): Oboe;
-
-			removeListener(eventPattern: string, callback: CallbackSignature): Oboe;
-			removeListener(event: string, pattern: string, callback: CallbackSignature): Oboe;
-
-			start(callback: (status: number, headers: Object) => void): Oboe;
-
-			abort():void;
-
-			source: string;
-		}
-
-		interface CallbackSignature {
-			(node: any, pathOrHeaders: any, ancestors: Object[]): any;
-		}
-
-		interface Options {
-			url: string;
-			method?: string;
-			headers?: Object;
-			body?: any;
-			cached?: boolean;
-			withCredentials?: boolean;
-		}
-
-		interface FailReason {
-			thrown?: Error;
-			statusCode?: number;
-			body?: string;
-			jsonBody?: Object;
-		}
-
-		interface PatternMap {
-			[pattern: string]: CallbackSignature
-		}
+declare module oboe {
+	interface OboeFunction extends Function {
+		drop: Object;
+		(url: string): oboe.Oboe;
+		(options: oboe.Options): oboe.Oboe;
+		(stream: NodeJS.ReadableStream): oboe.Oboe;
 	}
 
+	interface Oboe {
+		done(callback: (result: any) => void): Oboe;
+
+		fail(callback: (result: FailReason) => void): Oboe;
+
+		node(pattern: string, callback: CallbackSignature): Oboe;
+		node(patterns: PatternMap): Oboe;
+
+		on(event: string, pattern: string, callback: CallbackSignature): Oboe;
+		on(eventPattern: string, callback: CallbackSignature): Oboe;
+
+		path(pattern: string, callback: CallbackSignature): Oboe;
+		path(listeners: any): Oboe;
+
+		removeListener(eventPattern: string, callback: CallbackSignature): Oboe;
+		removeListener(event: string, pattern: string, callback: CallbackSignature): Oboe;
+
+		start(callback: (status: number, headers: Object) => void): Oboe;
+
+		abort():void;
+
+		source: string;
+	}
+
+	interface CallbackSignature {
+          (node: any, pathOrHeaders: any, ancestors: Object[]): any;
+	}
+
+	interface Options {
+		url: string;
+		method?: string;
+		headers?: Object;
+		body?: any;
+		cached?: boolean;
+		withCredentials?: boolean;
+	}
+
+	interface FailReason {
+		thrown?: Error;
+		statusCode?: number;
+		body?: string;
+		jsonBody?: Object;
+	}
+
+	interface PatternMap {
+	  [pattern: string]: CallbackSignature
+	}
+}
+
+declare var oboe: oboe.OboeFunction;
+
+declare module "oboe" {
+	var oboe: oboe.OboeFunction;
 	export = oboe;
 }

--- a/oboe/oboe.d.ts
+++ b/oboe/oboe.d.ts
@@ -65,6 +65,5 @@ declare module oboe {
 declare var oboe: oboe.OboeFunction;
 
 declare module "oboe" {
-	var oboe: oboe.OboeFunction;
 	export = oboe;
 }

--- a/oboe/oboe.d.ts
+++ b/oboe/oboe.d.ts
@@ -8,9 +8,9 @@
 declare module oboe {
 	interface OboeFunction extends Function {
 		drop: Object;
-		(url: string): oboe.Oboe;
-		(options: oboe.Options): oboe.Oboe;
-		(stream: NodeJS.ReadableStream): oboe.Oboe;
+		(url: string): Oboe;
+		(options: Options): Oboe;
+		(stream: NodeJS.ReadableStream): Oboe;
 	}
 
 	interface Oboe {

--- a/oboe/oboe.d.ts
+++ b/oboe/oboe.d.ts
@@ -10,10 +10,9 @@ declare module "oboe" {
 
 	function oboe(url: string): oboe.Oboe;
 	function oboe(options: oboe.Options): oboe.Oboe;
-	function oboe(stream: stream.Readable) : oboe.Oboe;
+	function oboe(stream: stream.Readable): oboe.Oboe;
 
 	module oboe {
-
 		var drop: {};
 
 		interface Oboe {
@@ -22,6 +21,7 @@ declare module "oboe" {
 			fail(callback: (result: FailReason) => void): Oboe;
 
 			node(pattern: string, callback: CallbackSignature): Oboe;
+			node(patterns: PatternMap): Oboe;
 
 			on(event: string, pattern: string, callback: CallbackSignature): Oboe;
 			on(eventPattern: string, callback: CallbackSignature): Oboe;
@@ -33,14 +33,14 @@ declare module "oboe" {
 			removeListener(event: string, pattern: string, callback: CallbackSignature): Oboe;
 
 			start(callback: (status: number, headers: Object) => void): Oboe;
-			
+
 			abort():void;
 
 			source: string;
 		}
 
 		interface CallbackSignature {
-            (node: any, pathOrHeaders: any, ancestors: Object[]): any;
+			(node: any, pathOrHeaders: any, ancestors: Object[]): any;
 		}
 
 		interface Options {
@@ -58,8 +58,11 @@ declare module "oboe" {
 			body?: string;
 			jsonBody?: Object;
 		}
+
+		interface PatternMap {
+			[pattern: string]: CallbackSignature
+		}
 	}
 
 	export = oboe;
 }
-


### PR DESCRIPTION
Added a missing function definition for the node event.

Refactored the definition so the definitions can be referenced without having to import the module which allows for referencing in other ambient module definitions.
