### PR TITLE
Added missing optional parameter of WebContents.loadUrl()

### DIFF
--- a/github-electron/github-electron-main-tests.ts
+++ b/github-electron/github-electron-main-tests.ts
@@ -43,6 +43,8 @@ app.on('ready', () => {
 
 	// and load the index.html of the app.
 	mainWindow.loadUrl(`file://${__dirname}/index.html`);
+	mainWindow.loadUrl('file://foo/bar', {userAgent: 'cool-agent', httpReferrer: 'greateRefferer'});
+	mainWindow.webContents.loadUrl('file://foo/bar', {userAgent: 'cool-agent', httpReferrer: 'greateRefferer'});
 
 	mainWindow.openDevTools()
 	var opened: boolean = mainWindow.isDevToolsOpened()

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -400,7 +400,10 @@ declare module GitHubElectron {
 		/**
 		 * Same with webContents.loadUrl(url).
 		 */
-		loadUrl(url: string): void;
+		loadUrl(url: string, options?: {
+			httpReferrer?: string;
+			userAgent?: string;
+		}): void;
 		/**
 		 * Same with webContents.reload.
 		 */
@@ -537,7 +540,10 @@ declare module GitHubElectron {
 		 * Loads the url in the window.
 		 * @param url Must contain the protocol prefix (e.g., the http:// or file://).
 		 */
-		loadUrl(url: string): void;
+		loadUrl(url: string, options?: {
+			httpReferrer?: string;
+			userAgent?: string;
+		}): void;
 		/**
 		 * @returns The URL of current web page.
 		 */


### PR DESCRIPTION
I added missing optional parameter of `loadUrl()` method in `BrowserWindow` and `WebContents`.

https://github.com/atom/electron/blob/master/docs/api/browser-window.md#winloadurlurl-options
