### PR TITLE
big.js.d.ts: use const enum instead of enum

### DIFF
--- a/big.js/big.js.d.ts
+++ b/big.js/big.js.d.ts
@@ -6,7 +6,7 @@
 
 declare module BigJsLibrary {
 
-    export enum RoundingMode {
+    export const enum RoundingMode {
         RoundTowardsZero = 0,
         RoundTowardsNearestAwayFromZero = 1,
         RoundTowardsNearestTowardsEven = 2,


### PR DESCRIPTION
otherwise typescript will generate a script that will try to access a variable that doesn't exist

https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#const-enum-completely-inlined-enums
