### PR TITLE
underscore: remove method 'value' from interface 'UnderscoreStatic'

### DIFF
--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -1614,13 +1614,6 @@ interface UnderscoreStatic {
 	**/
 	chain<T>(obj: T[]): _Chain<T>;
 	chain<T extends {}>(obj: T): _Chain<T>;
-
-	/**
-	* Extracts the value of a wrapped object.
-	* @param obj Wrapped object to extract the value from.
-	* @return Value of `obj`.
-	**/
-	value<T, TResult>(obj: T): TResult;
 }
 
 interface Underscore<T> {
@@ -2463,7 +2456,8 @@ interface Underscore<T> {
 
 	/**
 	* Wrapped type `any`.
-	* @see _.value
+	* Extracts the value of a wrapped object.
+	* @return Value of the wrapped object.
 	**/
 	value<TResult>(): TResult;
 }


### PR DESCRIPTION
`_.value` is not available as a static method.

```
> typeof _.value;
< "undefined"
> typeof _().value;
< "function"
```

http://underscorejs.org/#value
