### PR TITLE
Added missing strict property to MongoCollectionOptions type of mongodb.d.ts

### DIFF
--- a/mongodb/mongodb.d.ts
+++ b/mongodb/mongodb.d.ts
@@ -527,6 +527,7 @@ declare module "mongodb" {
   export interface MongoCollectionOptions {
     safe?: any;
     serializeFunctions?: any;
+    strict?: boolean;
     raw?: boolean;
     pkFactory?: any;
     readPreference?: string;


### PR DESCRIPTION
Added the optional "strict" property that is missing from the MongoCollectionOptions type of the mongodb.d.ts definition
