### PR TITLE
Fixed parameter's type of Tray.setImage()

### DIFF
--- a/github-electron/github-electron-main-tests.ts
+++ b/github-electron/github-electron-main-tests.ts
@@ -409,6 +409,7 @@ app.on('ready', () => {
 	]);
 	appIcon.setToolTip('This is my application.');
 	appIcon.setContextMenu(contextMenu);
+	appIcon.setImage('/path/to/new/icon');
 });
 
 // clipboard

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -1212,7 +1212,7 @@ declare module GitHubElectron {
 		/**
 		 * Sets the image associated with this tray icon.
 		 */
-		setImage(image: NativeImage): void;
+		setImage(image: NativeImage|string): void;
 		/**
 		 * Sets the image associated with this tray icon when pressed.
 		 */


### PR DESCRIPTION
`Tray.setImage()` can take `string` parameter the same as constructor of `Tray`.
