### PR TITLE
Jasmine: optional expectationFailOutput parameter added to matchers

### DIFF
--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -58,7 +58,7 @@ declare module jasmine {
     function addMatchers(matchers: CustomMatcherFactories): void;
     function stringMatching(str: string): Any;
     function stringMatching(str: RegExp): Any;
-    
+
     interface Any {
 
         new (expectedClass: any): any;
@@ -72,7 +72,7 @@ declare module jasmine {
         length: number;
         [n: number]: T;
     }
-    
+
     interface ArrayContaining {
         new (sample: any[]): any;
 
@@ -279,21 +279,21 @@ declare module jasmine {
         isNot?: boolean;
         message(): any;
 
-        toBe(expected: any): boolean;
-        toEqual(expected: any): boolean;
-        toMatch(expected: any): boolean;
-        toBeDefined(): boolean;
-        toBeUndefined(): boolean;
-        toBeNull(): boolean;
+        toBe(expected: any, expectationFailOutput?: any): boolean;
+        toEqual(expected: any, expectationFailOutput?: any): boolean;
+        toMatch(expected: any, expectationFailOutput?: any): boolean;
+        toBeDefined(expectationFailOutput?: any): boolean;
+        toBeUndefined(expectationFailOutput?: any): boolean;
+        toBeNull(expectationFailOutput?: any): boolean;
         toBeNaN(): boolean;
-        toBeTruthy(): boolean;
-        toBeFalsy(): boolean;
+        toBeTruthy(expectationFailOutput?: any): boolean;
+        toBeFalsy(expectationFailOutput?: any): boolean;
         toHaveBeenCalled(): boolean;
         toHaveBeenCalledWith(...params: any[]): boolean;
-        toContain(expected: any): boolean;
-        toBeLessThan(expected: any): boolean;
-        toBeGreaterThan(expected: any): boolean;
-        toBeCloseTo(expected: any, precision: any): boolean;
+        toContain(expected: any, expectationFailOutput?: any): boolean;
+        toBeLessThan(expected: any, expectationFailOutput?: any): boolean;
+        toBeGreaterThan(expected: any, expectationFailOutput?: any): boolean;
+        toBeCloseTo(expected: any, precision: any, expectationFailOutput?: any): boolean;
         toContainHtml(expected: string): boolean;
         toContainText(expected: string): boolean;
         toThrow(expected?: any): boolean;
@@ -450,7 +450,7 @@ declare module jasmine {
         /** By chaining the spy with calls.reset(), will clears all tracking for a spy **/
         reset(): void;
     }
-    
+
     interface CallInfo {
         /** The context (the this) for the call */
         object: any;


### PR DESCRIPTION
Currently in our project we don't have an ability to create custom matchers, nor as resources to maintain them.
As well as for some test cases there's not way to use something more that `toBeTruthy()` , or `toBeFalsy()`
That's why it's really important for us to have a way to get any information about reason of failed expectation in test.

Jasmine out-of-the-box is supporting those optional prams, but since we are using TS and your version of jsamine.d.ts - we need to have those optional prams to be added in matchers methods signatures.

In the proposed request I added an optional expectationFailOutput parameter to matchers for ability to track expectation fail reason in output message.

I've added and tested those params passing only to matchers that are actually passing those params to the output.

`npm test` is passing 100%

Reference links to jasmine's `.because(<message>)` discussion:

https://github.com/adobe/brackets/issues/2752

https://github.com/jasmine/jasmine/issues/641#issuecomment-54736801

Please consider this code-change - that would really help us. Thank you.
