### PR TITLE
lodash: added _.prototype.commit() method

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -439,6 +439,20 @@ result = <number[]>_([1, 2]).zipWith<number>([1, 2], [1, 2], [1, 2], [1, 2], [1,
     result = _([1, 2, 3]).thru<number>((value: number[]) => value, any);
 }
 
+// _.prototype.commit
+{
+    let result: _.LoDashWrapper<number>;
+    result = _(42).commit();
+}
+{
+    let result: _.LoDashArrayWrapper<any>;
+    result = _<any>([]).commit();
+}
+{
+    let result: _.LoDashObjectWrapper<any>;
+    result = _({}).commit();
+}
+
 /**************
  * Collection *
  **************/

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -2056,6 +2056,16 @@ declare module _ {
             thisArg?: any): LoDashArrayWrapper<TResult>;
     }
 
+    // _.prototype.commit
+    interface LoDashWrapperBase<T, TWrapper> {
+        /**
+         * Executes the chained sequence and returns the wrapped result.
+         *
+         * @return Returns the new lodash wrapper instance.
+         */
+        commit(): TWrapper;
+    }
+
     /**************
      * Collection *
      **************/


### PR DESCRIPTION
https://lodash.com/docs#prototype-commit
https://lodash.com/docs#_ (description of the chainable wrapper)
