### PR TITLE
Angularjs: `IInjectorService.get` has an optional 2nd param.

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1693,7 +1693,7 @@ declare module angular {
         interface IInjectorService {
             annotate(fn: Function): string[];
             annotate(inlineAnnotatedFunction: any[]): string[];
-            get<T>(name: string): T;
+            get<T>(name: string, caller?: string): T;
             has(name: string): boolean;
             instantiate<T>(typeConstructor: Function, locals?: any): T;
             invoke(inlineAnnotatedFunction: any[]): any;


### PR DESCRIPTION
`caller` is an optional string to provide the origin of the function call for error messages. https://docs.angularjs.org/api/auto/service/$injector#get
