### PR TITLE
Fix: [simplebar] typo - Adds missing t to SimplebarOptions

### DIFF
--- a/simplebar/simplebar.d.ts
+++ b/simplebar/simplebar.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: Gregor Woiwode <https://github.com/gregonnet>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-interface SimplebarOpions {
+interface SimplebarOptions {
     autoHide?: boolean;
-    wrapContent?: boolean
+    wrapContent?: boolean;
 }
 
 interface JQuery {
@@ -18,7 +18,7 @@ interface JQuery {
         *
         * @param indicator if scrollbar should be faded out automatically.
         */
-        (options?: SimplebarOpions): JQuery;
+        (options?: SimplebarOptions): JQuery;
     };
 }
 
@@ -32,6 +32,6 @@ interface JQueryStatic {
         *
         * @param indicator if scrollbar should be faded out automatically.
         */
-        (options?: SimplebarOpions): JQuery;
+        (options?: SimplebarOptions): JQuery;
     };
 }


### PR DESCRIPTION
Hi,

I encountered a small misspelling and fixed it.

Needed tests passed for me locally
- tsc --noImplicitAny simplebar/simplebar-tests.ts
- tsc --noImplicitAny --module commonjs simplebar/simplebar-tests.ts
- npm test
- travis
