### PR TITLE
Refactoring of interfaces for SlickGrid event args

### DIFF
--- a/slickgrid/SlickGrid.d.ts
+++ b/slickgrid/SlickGrid.d.ts
@@ -507,11 +507,11 @@ declare module Slick {
 		getEditor<T>(column: Column<T>): Editors.Editor<T>;
 	}
 
-	export interface FormatterFactory<T extends Slick.SlickData> {
+	export interface FormatterFactory<T extends SlickData> {
 		getFormatter(column: Column<T>): Formatter<any>;
 	}
 
-	export interface GridOptions<T extends Slick.SlickData> {
+	export interface GridOptions<T extends SlickData> {
 
 		/**
 		* Makes cell editors load asynchronously after a small delay. This greatly increases keyboard navigation speed.
@@ -863,7 +863,7 @@ declare module Slick {
 		* todo: no docs or comments available
 		* @return
 		**/
-		public getSortColumns(): Column<T>[];
+		public getSortColumns(): { columnId: string; sortAsc: boolean }[];
 
 		/**
 		* Updates an existing column definition and a corresponding header DOM element with the new title and tooltip.
@@ -1106,39 +1106,39 @@ declare module Slick {
 
 		// #region Events
 
-		public onScroll: Slick.Event<OnScrollEventData>;
-		public onSort: Slick.Event<OnSortEventData<T>>;
-		public onHeaderMouseEnter: Slick.Event<OnHeaderMouseEventData<T>>;
-		public onHeaderMouseLeave: Slick.Event<OnHeaderMouseEventData<T>>;
-		public onHeaderContextMenu: Slick.Event<OnHeaderContextMenuEventData<T>>;
-		public onHeaderClick: Slick.Event<OnHeaderClickEventData<T>>;
-		public onHeaderCellRendered: Slick.Event<OnHeaderCellRenderedEventData<T>>;
-		public onBeforeHeaderCellDestroy: Slick.Event<OnBeforeHeaderCellDestroyEventData<T>>;
-		public onHeaderRowCellRendered: Slick.Event<OnHeaderRowCellRenderedEventData<T>>;
-		public onBeforeHeaderRowCellDestroy: Slick.Event<OnBeforeHeaderRowCellDestroyEventData<T>>;
-		public onMouseEnter: Slick.Event<OnMouseEnterEventData>;
-		public onMouseLeave: Slick.Event<OnMouseLeaveEventData>;
-		public onClick: Slick.Event<OnClickEventData>;
-		public onDblClick: Slick.Event<OnDblClickEventData>;
-		public onContextMenu: Slick.Event<OnContextMenuEventData>;
-		public onKeyDown: Slick.Event<OnKeyDownEventData>;
-		public onAddNewRow: Slick.Event<OnAddNewRowEventData<T>>;
-		public onValidationError: Slick.Event<OnValidationErrorEventData<T>>;
-		public onColumnsReordered: Slick.Event<OnColumnsReorderedEventData>;
-		public onColumnsResized: Slick.Event<OnColumnsResizedEventData>;
-		public onCellChange: Slick.Event<OnCellChangeEventData<T>>;
-		public onBeforeEditCell: Slick.Event<OnBeforeEditCellEventData<T>>;
-		public onBeforeCellEditorDestroy: Slick.Event<OnBeforeCellEditorDestroyEventData<T>>;
-		public onBeforeDestroy: Slick.Event<OnBeforeDestroyEventData>;
-		public onActiveCellChanged: Slick.Event<OnActiveCellChangedEventData>;
-		public onActiveCellPositionChanged: Slick.Event<OnActiveCellPositionChangedEventData>;
-		public onDragInit: Slick.Event<OnDragInitEventData>;
-		public onDragStart: Slick.Event<OnDragStartEventData>;
-		public onDrag: Slick.Event<OnDragEventData>;
-		public onDragEnd: Slick.Event<OnDragEndEventData>;
-		public onSelectedRowsChanged: Slick.Event<OnSelectedRowsChangedEventData>;
-		public onCellCssStylesChanged: Slick.Event<OnCellCssStylesChangedEventData>;
-		public onViewportChanged: Slick.Event<OnViewportChangedEventData>;
+		public onScroll: Slick.Event<OnScrollEventArgs<T>>;
+		public onSort: Slick.Event<OnSortEventArgs<T>>;
+		public onHeaderMouseEnter: Slick.Event<OnHeaderMouseEventArgs<T>>;
+		public onHeaderMouseLeave: Slick.Event<OnHeaderMouseEventArgs<T>>;
+		public onHeaderContextMenu: Slick.Event<OnHeaderContextMenuEventArgs<T>>;
+		public onHeaderClick: Slick.Event<OnHeaderClickEventArgs<T>>;
+		public onHeaderCellRendered: Slick.Event<OnHeaderCellRenderedEventArgs<T>>;
+		public onBeforeHeaderCellDestroy: Slick.Event<OnBeforeHeaderCellDestroyEventArgs<T>>;
+		public onHeaderRowCellRendered: Slick.Event<OnHeaderRowCellRenderedEventArgs<T>>;
+		public onBeforeHeaderRowCellDestroy: Slick.Event<OnBeforeHeaderRowCellDestroyEventArgs<T>>;
+		public onMouseEnter: Slick.Event<OnMouseEnterEventArgs<T>>;
+		public onMouseLeave: Slick.Event<OnMouseLeaveEventArgs<T>>;
+		public onClick: Slick.Event<OnClickEventArgs<T>>;
+		public onDblClick: Slick.Event<OnDblClickEventArgs<T>>;
+		public onContextMenu: Slick.Event<OnContextMenuEventArgs<T>>;
+		public onKeyDown: Slick.Event<OnKeyDownEventArgs<T>>;
+		public onAddNewRow: Slick.Event<OnAddNewRowEventArgs<T>>;
+		public onValidationError: Slick.Event<OnValidationErrorEventArgs<T>>;
+		public onColumnsReordered: Slick.Event<OnColumnsReorderedEventArgs<T>>;
+		public onColumnsResized: Slick.Event<OnColumnsResizedEventArgs<T>>;
+		public onCellChange: Slick.Event<OnCellChangeEventArgs<T>>;
+		public onBeforeEditCell: Slick.Event<OnBeforeEditCellEventArgs<T>>;
+		public onBeforeCellEditorDestroy: Slick.Event<OnBeforeCellEditorDestroyEventArgs<T>>;
+		public onBeforeDestroy: Slick.Event<OnBeforeDestroyEventArgs<T>>;
+		public onActiveCellChanged: Slick.Event<OnActiveCellChangedEventArgs<T>>;
+		public onActiveCellPositionChanged: Slick.Event<OnActiveCellPositionChangedEventArgs<T>>;
+		public onDragInit: Slick.Event<OnDragInitEventArgs<T>>;
+		public onDragStart: Slick.Event<OnDragStartEventArgs<T>>;
+		public onDrag: Slick.Event<OnDragEventArgs<T>>;
+		public onDragEnd: Slick.Event<OnDragEndEventArgs<T>>;
+		public onSelectedRowsChanged: Slick.Event<OnSelectedRowsChangedEventArgs<T>>;
+		public onCellCssStylesChanged: Slick.Event<OnCellCssStylesChangedEventArgs<T>>;
+		public onViewportChanged: Slick.Event<OnViewportChangedEventArgs<T>>;
 		// #endregion Events
 
 		// #region Plugins
@@ -1177,74 +1177,78 @@ declare module Slick {
 		// #endregion Editors
 	}
 
-	export interface OnCellCssStylesChangedEventData {
+	export interface GridEventArgs<T extends SlickData> {
+		grid: Grid<T>;
+	}
+
+	export interface OnCellCssStylesChangedEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		key: string;
 		hash: CellCssStylesHash;
 	}
 
-	export interface OnSelectedRowsChangedEventData {
+	export interface OnSelectedRowsChangedEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		rows: number[];
 	}
 
-	export interface OnDragEndEventData {
+	export interface OnDragEndEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		// todo: need to understand $canvas drag event parameter's 'dd' object
 		// the documentation is not enlightening
 	}
 
-	export interface OnDragEventData {
+	export interface OnDragEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		// todo: need to understand $canvas drag event parameter's 'dd' object
 		// the documentation is not enlightening
 	}
 
-	export interface OnDragStartEventData {
+	export interface OnDragStartEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		// todo: need to understand $canvas drag event parameter's 'dd' object
 		// the documentation is not enlightening
 	}
 
-	export interface OnDragInitEventData {
+	export interface OnDragInitEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		// todo: need to understand $canvas drag event parameter's 'dd' object
 		// the documentation is not enlightening
 	}
 
-	export interface OnActiveCellPositionChangedEventData {
+	export interface OnActiveCellPositionChangedEventArgs<T extends SlickData> extends GridEventArgs<T> {
 
 	}
 
-	export interface OnActiveCellChangedEventData {
+	export interface OnActiveCellChangedEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		row: number;
 		cell: number;
 	}
 
-	export interface OnBeforeDestroyEventData {
+	export interface OnBeforeDestroyEventArgs<T extends SlickData> extends GridEventArgs<T> {
 
 	}
 
-	export interface OnBeforeCellEditorDestroyEventData<T extends Slick.SlickData> {
+	export interface OnBeforeCellEditorDestroyEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		editor: Editors.Editor<T>;
 	}
 
-	export interface OnBeforeEditCellEventData<T extends SlickData> {
+	export interface OnBeforeEditCellEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		row: number;
 		cell: number;
 		item: T;
 		column: Column<T>;
 	}
 
-	export interface OnCellChangeEventData<T extends SlickData> {
+	export interface OnCellChangeEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		row: number;
 		cell: number;
 		item: T;
 	}
 
-	export interface OnColumnsResizedEventData {
+	export interface OnColumnsResizedEventArgs<T extends SlickData> extends GridEventArgs<T> {
 
 	}
 
-	export interface OnColumnsReorderedEventData {
+	export interface OnColumnsReorderedEventArgs<T extends SlickData> extends GridEventArgs<T> {
 
 	}
 
-	export interface OnValidationErrorEventData<T extends SlickData> {
+	export interface OnValidationErrorEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		editor: Editors.Editor<T>;
 		cellNode: HTMLElement;
 		validationResults: ValidateResults;
@@ -1253,90 +1257,89 @@ declare module Slick {
 		column: Column<T>;
 	}
 
-	export interface OnAddNewRowEventData<T extends SlickData> {
+	export interface OnAddNewRowEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		item: T;
 		column: Column<T>;
 	}
 
-	export interface OnKeyDownEventData {
+	export interface OnKeyDownEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		row: number;
 		cell: number;
 	}
 
-	export interface OnContextMenuEventData {
+	export interface OnContextMenuEventArgs<T extends SlickData> extends GridEventArgs<T> {
 
 	}
 
-	export interface OnDblClickEventData {
+	export interface OnDblClickEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		row: number;
 		cell: number;
 	}
 
-	export interface OnClickEventData {
+	export interface OnClickEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		row: number;
 		cell: number;
 	}
 
-	export interface OnMouseLeaveEventData {
+	export interface OnMouseLeaveEventArgs<T extends SlickData> extends GridEventArgs<T> {
 
 	}
 
-	export interface OnMouseEnterEventData {
+	export interface OnMouseEnterEventArgs<T extends SlickData> extends GridEventArgs<T> {
 
 	}
 
-	export interface OnBeforeHeaderRowCellDestroyEventData<T extends SlickData> {
+	export interface OnBeforeHeaderRowCellDestroyEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		node: HTMLElement; // todo: might be JQuery instance
 		column: Column<T>;
 	}
 
-	export interface OnHeaderRowCellRenderedEventData<T extends SlickData> {
+	export interface OnHeaderRowCellRenderedEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		node: HTMLElement; // todo: might be JQuery instance
 		column: Column<T>;
 	}
 
-	export interface OnBeforeHeaderCellDestroyEventData<T extends SlickData> {
+	export interface OnBeforeHeaderCellDestroyEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		node: HTMLElement; // todo: might be JQuery instance
 		column: Column<T>;
 	}
 
-	export interface OnHeaderCellRenderedEventData<T extends SlickData> {
+	export interface OnHeaderCellRenderedEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		node: HTMLElement;	// todo: might be JQuery instance
 		column: Column<T>;
 	}
 
-	export interface OnHeaderClickEventData<T extends SlickData> {
+	export interface OnHeaderClickEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		column: Column<T>;
 	}
 
-	export interface OnHeaderContextMenuEventData<T extends SlickData> {
+	export interface OnHeaderContextMenuEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		column: Column<T>;
 	}
 
-	export interface OnHeaderMouseEventData<T extends SlickData> {
+	export interface OnHeaderMouseEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		column: Column<T>;
 	}
 
-	// todo: merge with existing column definition
-	export interface Column<T extends SlickData> {
-		sortCol?: Column<T>;
-		sortAsc?: boolean;
-	}
-
-	export interface OnSortEventData<T extends SlickData> {
+	export interface OnSortEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		multiColumnSort: boolean;
-		sortCol?: Column<T>;
-		sortCols: Column<T>[];
-		sortAsc?: boolean;
+		sortCol?: SortColumn<T>;
+		sortCols?: SortColumn<T>[];
+		sortAsc: boolean;
 	}
 
-	export interface OnScrollEventData {
+	export interface OnScrollEventArgs<T extends SlickData> extends GridEventArgs<T> {
 		scrollLeft: number;
 		scrollTop: number;
 	}
 
-	export interface OnViewportChangedEventData {
+	export interface OnViewportChangedEventArgs<T extends SlickData> extends GridEventArgs<T> {
 
+	}
+
+	export interface SortColumn<T extends SlickData> {
+		sortCol: Column<T>;
+		sortAsc: boolean;
 	}
 
 	export interface Cell {
@@ -1449,7 +1452,7 @@ declare module Slick {
 		}
 	}
 
-	export interface Formatter<T extends Slick.SlickData> {
+	export interface Formatter<T extends SlickData> {
         (row: number, cell: number, value: any, columnDef: Column<T>, dataContext: SlickData): string;
 	}
 

--- a/slickgrid/slick.headerbuttons.d.ts
+++ b/slickgrid/slick.headerbuttons.d.ts
@@ -24,7 +24,7 @@ declare module Slick {
         tooltip?: string;
     }
 
-    export interface OnCommandEventData<T extends SlickData> {
+    export interface OnCommandEventArgs<T extends SlickData> {
         grid: Grid<T>;
         column: Column<T>;
         command: string;
@@ -35,7 +35,7 @@ declare module Slick {
 
         export class HeaderButtons<T extends SlickData> extends Plugin<T> {
             constructor();
-            public onCommand: Event<OnCommandEventData<T>>;
+            public onCommand: Event<OnCommandEventArgs<T>>;
         }
     }
 }


### PR DESCRIPTION
PR for #5729 
Also `trigger` method of SlickGrid adds `grid` property to the arguments of every event. So I declared base interface `GridEventArgs<T>` for all event interfaces. Therefore all these interfaces are generics now (earlier some of them were generics and others were not).
