### PR TITLE
ui-grid: fixed reference to the IGridRow type to refer to uiGrid.IGridRow within ui-grid plugins

### DIFF
--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -2823,7 +2823,7 @@ declare module uiGrid {
              * returns all selected rows as gridRows
              * @returns {Array<IGridRow>} The selected rows
              */
-            getSelectedGridRows(): Array<any>;
+            getSelectedGridRows(): Array<uiGrid.IGridRow>;
             /**
              * Gets selected rows as entities
              * @returns {Array<any>} Selected row entities

--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -1182,14 +1182,14 @@ declare module uiGrid {
         }
 
         export interface IRowColConstructor {
-            new (row: IGridRow, col: IGridColumn): IRowCol;
+            new (row: uiGrid.IGridRow, col: IGridColumn): IRowCol;
         }
 
         /**
          * A row and column pair that represents the intersection of these two entities
          */
         export interface IRowCol {
-            row: IGridRow;
+            row: uiGrid.IGridRow;
             col: IGridColumn;
             /**
              * Gets the intersection of where the row and column meet
@@ -1282,7 +1282,7 @@ declare module uiGrid {
                reader.readAsText( files[0] );
            }
              */
-            editFileChooserCallback?: (gridRow: IGridRow, gridCol: IGridColumn, files: FileList) => void;
+            editFileChooserCallback?: (gridRow: uiGrid.IGridRow, gridCol: IGridColumn, files: FileList) => void;
             /**
              * A bindable string value that is used when binding to edit controls instead of colDef.field
              * For example if you have a complex property on an object like:
@@ -1558,7 +1558,7 @@ declare module uiGrid {
              * @param {any} value The cell value
              * @returns {any} Formatted value
              */
-            exporterFieldCallback?: (grid: IGridInstance, row: IGridRow, col: IGridColumn, value: any) => any;
+            exporterFieldCallback?: (grid: IGridInstance, row: uiGrid.IGridRow, col: IGridColumn, value: any) => any;
             /**
              * A function to apply to the header displayNames before exporting. Useful for internationalisation,
              * for example if you were using angular-translate you'd set this to $translate.instant.
@@ -2823,12 +2823,12 @@ declare module uiGrid {
              * returns all selected rows as gridRows
              * @returns {Array<IGridRow>} The selected rows
              */
-            getSelectedGridRows(): Array<IGridRow>;
+            getSelectedGridRows(): Array<uiGrid.IGridRow>;
             /**
              * Gets selected rows as entities
              * @returns {Array<any>} Selected row entities
              */
-            getSelectedRows(): Array<IGridRow>;
+            getSelectedRows(): Array<uiGrid.IGridRow>;
             /**
              * Selects all rows.  Does nothing if multiselect = false
              * @param {ng.IAngularEvent} event object if raised from event
@@ -2844,7 +2844,7 @@ declare module uiGrid {
              * @param {any} rowEntity gridOptions.data[] array value
              * @param {ng.IAngularEvent} event object if raised from event
              */
-            selectRow(rowEntity: IGridRow, event?: ng.IAngularEvent): void;
+            selectRow(rowEntity: uiGrid.IGridRow, event?: ng.IAngularEvent): void;
             /**
              * Select the specified row by visible index
              * (i.e. if you specify row 0 you'll get the first visible row selected).
@@ -2871,13 +2871,13 @@ declare module uiGrid {
              * @param {any} rowEntity gridOptions.data[] array value
              * @param {ng.IAngularEvent} event object if raised from event
              */
-            toggleRowSelection(rowEntity: IGridRow, event?: ng.IAngularEvent): void;
+            toggleRowSelection(rowEntity: uiGrid.IGridRow, event?: ng.IAngularEvent): void;
             /**
              * UnSelect the data row
              * @param {any} rowEntity gridOptions.data[] array value
              * @param {ng.IAngularEvent} event object if raised from event
              */
-            unSelectRow(rowEntity: IGridRow, event?: ng.IAngularEvent): void;
+            unSelectRow(rowEntity: uiGrid.IGridRow, event?: ng.IAngularEvent): void;
 
             // Events
             on: {
@@ -2903,7 +2903,7 @@ declare module uiGrid {
              * @param {IGridRow} row The selected rows
              * @param {ng.IAngularEvent} event object if raised from event
              */
-            (row: IGridRow, event?: ng.IAngularEvent): void;
+            (row: uiGrid.IGridRow, event?: ng.IAngularEvent): void;
         }
 
         export interface rowSelectionChangedBatchHandler {
@@ -2912,7 +2912,7 @@ declare module uiGrid {
              * @param {IGridRow} row The selected rows
              * @param {ng.IAngularEvent} event object if raised from event
              */
-            (row: Array<IGridRow>, event?: ng.IAngularEvent): void;
+            (row: Array<uiGrid.IGridRow>, event?: ng.IAngularEvent): void;
         }
     }
 

--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -2823,12 +2823,12 @@ declare module uiGrid {
              * returns all selected rows as gridRows
              * @returns {Array<IGridRow>} The selected rows
              */
-            getSelectedGridRows(): Array<uiGrid.IGridRow>;
+            getSelectedGridRows(): Array<any>;
             /**
              * Gets selected rows as entities
              * @returns {Array<any>} Selected row entities
              */
-            getSelectedRows(): Array<uiGrid.IGridRow>;
+            getSelectedRows(): Array<any>;
             /**
              * Selects all rows.  Does nothing if multiselect = false
              * @param {ng.IAngularEvent} event object if raised from event
@@ -2844,7 +2844,7 @@ declare module uiGrid {
              * @param {any} rowEntity gridOptions.data[] array value
              * @param {ng.IAngularEvent} event object if raised from event
              */
-            selectRow(rowEntity: uiGrid.IGridRow, event?: ng.IAngularEvent): void;
+            selectRow(rowEntity: any, event?: ng.IAngularEvent): void;
             /**
              * Select the specified row by visible index
              * (i.e. if you specify row 0 you'll get the first visible row selected).
@@ -2871,13 +2871,13 @@ declare module uiGrid {
              * @param {any} rowEntity gridOptions.data[] array value
              * @param {ng.IAngularEvent} event object if raised from event
              */
-            toggleRowSelection(rowEntity: uiGrid.IGridRow, event?: ng.IAngularEvent): void;
+            toggleRowSelection(rowEntity: any, event?: ng.IAngularEvent): void;
             /**
              * UnSelect the data row
              * @param {any} rowEntity gridOptions.data[] array value
              * @param {ng.IAngularEvent} event object if raised from event
              */
-            unSelectRow(rowEntity: uiGrid.IGridRow, event?: ng.IAngularEvent): void;
+            unSelectRow(rowEntity: any, event?: ng.IAngularEvent): void;
 
             // Events
             on: {


### PR DESCRIPTION
Some of the plugins for ui-grid define an `IGridRow` interface to extend the possible options on the `row` object.  The main `IGridRow` interface extends all of the plugins' `IGridRow` interfaces so that you always get the best autocompletion.  But within the plugin modules, referring to the un-qualified `IGridRow` ends up resolving to the inner interface, with only a couple of options.  Using these plugin methods can therefore cause errors when trying to use other (non-plugin) fields on the `row` object.

I have qualified references to `IGridRow` within the plugin modules so the correct `IGridRow` (`uiGrid.IGridRow`) is used.
