### PR TITLE
angular-animate - updated enabled

### DIFF
--- a/angularjs/angular-animate.d.ts
+++ b/angularjs/angular-animate.d.ts
@@ -30,11 +30,11 @@ declare module angular.animate {
         /**
         * Globally enables / disables animations.
         *
-        * @param value If provided then set the animation on or off.
         * @param element If provided then the element will be used to represent the enable/disable operation.
+        * @param value If provided then set the animation on or off.
         * @returns current animation state
         */
-        enabled(value?: boolean, element?: JQuery): boolean;
+        enabled(element?: JQuery, value?: boolean): boolean;
 
         /**
          * Performs an inline animation on the element.


### PR DESCRIPTION
Updated angular-animate $animate.enabled as per angular changes. (after 1.3.14 > 1.4.0)

new - https://code.angularjs.org/1.4.4/docs/api/ng/service/$animate
old - https://code.angularjs.org/1.3.14/docs/api/ngAnimate/service/$animate

Apologies for the previous request of this, I had reverted the change from master to submit another.
