### PR TITLE
Include Arrays in use method

### DIFF
--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -106,6 +106,8 @@ declare module "express" {
             use(handler: ErrorRequestHandler): T;
             use(path: string, ...handler: RequestHandler[]): T;
             use(path: string, handler: ErrorRequestHandler): T;
+            use(path: string[], ...handler: RequestHandler[]): T;
+            use(path: string[], handler: ErrorRequestHandler[]): T;
         }
 
         export function Router(options?: any): Router;


### PR DESCRIPTION
Express 4.x API reference for app.use includes the use of Arrays. This update adds this to the definition file.
