### PR TITLE
Added missing explicit void return for LevelUp batch functions

### DIFF
--- a/levelup/levelup.d.ts
+++ b/levelup/levelup.d.ts
@@ -22,8 +22,8 @@ interface LevelUp {
     del(key: any, options ?: { keyEncoding?: string; sync?: boolean }, callback ?: (error: any) => any): void;
 
 
-    batch(array: Batch[], options?: { keyEncoding?: string; valueEncoding?: string; sync?: boolean }, callback?: (error?: any)=>any);
-    batch(array: Batch[], callback?: (error?: any)=>any);
+    batch(array: Batch[], options?: { keyEncoding?: string; valueEncoding?: string; sync?: boolean }, callback?: (error?: any)=>any): void;
+    batch(array: Batch[], callback?: (error?: any)=>any): void;
     batch():LevelUpChain;
     isOpen():boolean;
     isClosed():boolean;


### PR DESCRIPTION
Added explicit `void` returns to the LevelUp definitions to make Travis happy.
