### PR TITLE
Allows for extensibility (overloads) for get, the same way it is for …

### DIFF
--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -809,6 +809,11 @@ declare module "express" {
             (req: Request, res: Response, next: Function, param: any): any;
         }
 
+        interface IApplicationGetter extends IRouterMatcher<Application>
+        {
+            (name: string): any; // Getter
+        }
+
         interface Application extends IRouter<Application>, Express.Application {
             /**
              * Initialize the server.
@@ -870,11 +875,7 @@ declare module "express" {
              * @param val
              */
             set(setting: string, val: any): Application;
-            get: {
-                (name: string): any; // Getter
-                (name: string, ...handlers: RequestHandler[]): Application;
-                (name: RegExp, ...handlers: RequestHandler[]): Application;
-            };
+            get: IApplicationGetter;
 
             /**
              * Return the app's absolute pathname


### PR DESCRIPTION
I've had the need to overload the get and post methods from the Application interface in order to pass an array of handlers. To call like this:

get(path,[handler1,handler2,handler3])

instead of 

get(path,handler1,handler2,handler3)

The Javascript code is capable of doing this however, the definition doesn't allow it.

I created an external complementary definition to post as follows:

declare module "express"
{
    module e
    {
        interface IRouterMatcher<T>
        {
            (name: string, preHandlers: RequestHandler[], ...handlers: RequestHandler[]): T;
        }
    }
}

However, the way get is defined prevents me from doing the same with get. 

I've changed it so that this is allowed simply by defining n interface IApplicationGetter that extends  IRouterMatcher<T> and adds the app.get method (environment variable).

This change doesn't break anything and it makes it more consistent.
