### PR TITLE
whatwg-fetch strings enums declaration

### DIFF
--- a/whatwg-fetch/whatwg-fetch-tests.ts
+++ b/whatwg-fetch/whatwg-fetch-tests.ts
@@ -6,7 +6,10 @@ function test_fetchUrlWithOptions() {
 	headers.append("Content-Type", "application/json");
 	var requestOptions: RequestInit = {
 		method: "POST",
-		headers: headers
+		headers: headers,
+		mode: 'same-origin',
+		credentials: 'omit',
+		cache: 'default'
 	};
 	handlePromise(window.fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions));
 }
@@ -27,6 +30,9 @@ function test_fetchUrl() {
 
 function handlePromise(promise: Promise<Response>) {
 	promise.then((response) => {
+		if (response.type === 'basis') {
+			// for test only
+		}
 		return response.text();
 	}).then((text) => {
 		console.log(text);

--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -10,20 +10,20 @@ declare class Request {
 	method: string;
 	url: string;
 	headers: Headers;
-	context: RequestContext;
+	context: string|RequestContext;
 	referrer: string;
-	mode: RequestMode;
-	credentials: RequestCredentials;
-	cache: RequestCache;
+	mode: string|RequestMode;
+	credentials: string|RequestCredentials;
+	cache: string|RequestCache;
 }
 
 interface RequestInit {
 	method?: string;
 	headers?: HeaderInit|{ [index: string]: string };
 	body?: BodyInit;
-	mode?: RequestMode;
-	credentials?: RequestCredentials;
-	cache?: RequestCache;
+	mode?: string|RequestMode;
+	credentials?: string|RequestCredentials;
+	cache?: string|RequestCache;
 }
 
 declare enum RequestContext {
@@ -58,7 +58,7 @@ declare class Response extends Body {
 	constructor(body?: BodyInit, init?: ResponseInit);
 	error(): Response;
 	redirect(url: string, status: number): Response;
-	type: ResponseType;
+	type: string|ResponseType;
 	url: string;
 	status: number;
 	ok: boolean;


### PR DESCRIPTION
See https://fetch.spec.whatwg.org/#concept-request-credentials-mode. Credentials mode is one of "omit", "same-origin", and "include". Credentials property is a _string_ type.
Enums in whatwg-fetch.d.ts:

``` typescript
declare enum RequestCredentials { "omit", "same-origin", "include" }
```

Unfortunately, TypeScript (1.5, 1.6 beta) hasn't supported strings enum yet. Every enum in fact is a _number_. So I can compile this, but it's wrong:

``` typescript
window.fetch('/url', {
  credentials: 0
});
```

Cannot compile this, but it's correct:

``` typescript
window.fetch('/url', {
  credentials: 'same-origin'
});
// tsc error
// Type 'string' is not assignable to type 'RequestCredentials'
```

Finally:

``` typescript
window.fetch('/url', {
  credentials: RequestCredentials['same-origin']
});
```

Compiled to the same code of javascript (word by word) and TS don't provide any prefilling    RequstCredentils object in run time:

``` javascript
window.fetch('/url', {
  credentials: RequestCredentials['same-origin']
});
// browser error
// Uncaught ReferenceError: RequestCredentials is not defined
```

Maybe rewrite with [class approach](http://stackoverflow.com/a/15491832) to better times? 
