### PR TITLE
chrome.runtime.openOptionsPage

### DIFF
--- a/chrome/chrome-tests.ts
+++ b/chrome/chrome-tests.ts
@@ -249,3 +249,12 @@ function contentSettings() {
     }
   });
 }
+
+// https://developer.chrome.com/extensions/runtime#method-openOptionsPage
+function testOptionsPage() {
+  chrome.runtime.openOptionsPage();
+  chrome.runtime.openOptionsPage(function() {
+    // Do a thing ...
+  });
+}
+

--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -1649,6 +1649,7 @@ declare module chrome.runtime {
     export function getPackageDirectoryEntry(callback: (directoryEntry: any) => void): void;
     export function getPlatformInfo(callback: (platformInfo: PlatformInfo) => void): void;
     export function getURL(path: string): string;
+    export function openOptionsPage(callback?: () => void): void;
     export function reload(): void;
     export function requestUpdateCheck(callback: (status: string, details?: UpdateCheckDetails) => void): void;
     export function restart(): void;


### PR DESCRIPTION
Added in Chrome 42. https://developer.chrome.com/extensions/runtime#method-openOptionsPage
