### PR TITLE
Added Error to support stack

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -9,6 +9,11 @@
 *                                               *
 ************************************************/
 
+interface Error {
+    stack?: string;
+}
+
+
 // compat for TypeScript 1.5.3
 // if you use with --target es3 or --target es5 and use below definitions,
 // use the lib.es6.d.ts that is bundled with TypeScript 1.5.3.


### PR DESCRIPTION
Please see https://github.com/Microsoft/TypeScript/issues/4807

I added support for the default node.js behavior in which Error contains a _stack_ field.
