### PR TITLE
Correcting array error

### DIFF
--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -107,7 +107,7 @@ declare module "express" {
             use(path: string, ...handler: RequestHandler[]): T;
             use(path: string, handler: ErrorRequestHandler): T;
             use(path: string[], ...handler: RequestHandler[]): T;
-            use(path: string[], handler: ErrorRequestHandler[]): T;
+            use(path: string[], handler: ErrorRequestHandler): T;
         }
 
         export function Router(options?: any): Router;


### PR DESCRIPTION
When I added string array to the path parameter on use, I accidentally added ErrorRequestHandler array too. It's not removed.
