### PR TITLE
Update react.d.ts - Validate static members of React.Component

### DIFF
--- a/react-dnd/react-dnd-tests.ts
+++ b/react-dnd/react-dnd-tests.ts
@@ -80,6 +80,8 @@ module Knight {
     }
 
     export class Knight extends React.Component<KnightP, {}> {
+        static defaultProps: KnightP;
+        
         static create = React.createFactory(Knight);
 
         componentDidMount() {
@@ -153,6 +155,8 @@ module BoardSquare {
     }
 
     export class BoardSquare extends React.Component<BoardSquareP, {}> {
+        static defaultProps: BoardSquareP;
+        
         private _renderOverlay = (color: string) => {
             return r.div({
                 style: {

--- a/react/react-addons-tests.ts
+++ b/react/react-addons-tests.ts
@@ -84,6 +84,8 @@ class ModernComponent extends React.Component<Props, State>
     static childContextTypes: React.ValidationMap<ChildContext> = {
         someOtherValue: React.PropTypes.string
     }
+    
+    static defaultProps: Props;
 
     context: Context;
 

--- a/react/react-global-tests.ts
+++ b/react/react-global-tests.ts
@@ -81,6 +81,8 @@ class ModernComponent extends React.Component<Props, State>
         someOtherValue: React.PropTypes.string
     }
     
+    static defaultProps: Props;
+    
     context: Context;
     
     getChildContext() {

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -82,6 +82,8 @@ class ModernComponent extends React.Component<Props, State>
         someOtherValue: React.PropTypes.string
     }
     
+    static defaultProps: Props;
+    
     context: Context;
     
     getChildContext() {

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -132,6 +132,11 @@ declare namespace __React {
 
     // Base component for plain JS classes
     class Component<P, S> implements ComponentLifecycle<P, S> {
+        static propTypes: ValidationMap<any>;
+        static contextTypes: ValidationMap<any>;
+        static childContextTypes: ValidationMap<any>;
+        static defaultProps: Props<any>;
+        
         constructor(props?: P, context?: any);
         setState(f: (prevState: S, props: P) => S, callback?: () => any): void;
         setState(state: S, callback?: () => any): void;
@@ -929,6 +934,11 @@ declare module "react/addons" {
 
     // Base component for plain JS classes
     class Component<P, S> implements ComponentLifecycle<P, S> {
+        static propTypes: ValidationMap<any>;
+        static contextTypes: ValidationMap<any>;
+        static childContextTypes: ValidationMap<any>;
+        static defaultProps: Props<any>;
+        
         constructor(props?: P, context?: any);
         setState(f: (prevState: S, props: P) => S, callback?: () => any): void;
         setState(state: S, callback?: () => any): void;


### PR DESCRIPTION
Make static side of React.Component compatible with definition of React.ComponentClass. This ensures validation when we use ES6-style classes to extend from React.Component, as opposed to using React.createClass.
