### PR TITLE
qs should be any

### DIFF
--- a/request/request.d.ts
+++ b/request/request.d.ts
@@ -67,7 +67,7 @@ declare module 'request' {
 			oauth?: OAuthOptions;
 			aws?: AWSOptions;
 			hawk ?: HawkOptions;
-			qs?: Object;
+			qs?: any;
 			json?: any;
 			multipart?: RequestPart[];
 			agentOptions?: any;


### PR DESCRIPTION
if `qs` is defined as an object type then if we want to access it like
this it will generate an error :

```
var requestOpt: request.Options = {
json: true,
qs: {
param1: '',
param2: {}
},
url: '',
};

requestOpt.qs.param1 // <= error
```
