### PR TITLE
Fixed the React.addons.update typing to work with TS1.6

### DIFF
--- a/react/react-global.d.ts
+++ b/react/react-global.d.ts
@@ -85,14 +85,19 @@ declare namespace __React {
     // Reat.addons.update
     // ----------------------------------------------------------------------
 
-    interface UpdateSpec {
+    interface UpdateSpecCommand {
         $set?: any;
         $merge?: {};
         $apply?(value: any): any;
-        // [key: string]: UpdateSpec;
     }
-
-    interface UpdateArraySpec extends UpdateSpec {
+    
+    interface UpdateSpecPath {
+        [key: string]: UpdateSpec;
+    }
+    
+    type UpdateSpec = UpdateSpecCommand | UpdateSpecPath;
+    
+    interface UpdateArraySpec extends UpdateSpecCommand {
         $push?: any[];
         $unshift?: any[];
         $splice?: any[][];

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -1668,15 +1668,20 @@ declare module "react/addons" {
     //
     // Reat.addons.update
     // ----------------------------------------------------------------------
-
-    interface UpdateSpec {
+    
+    interface UpdateSpecCommand {
         $set?: any;
         $merge?: {};
         $apply?(value: any): any;
-        // [key: string]: UpdateSpec;
     }
-
-    interface UpdateArraySpec extends UpdateSpec {
+    
+    interface UpdateSpecPath {
+        [key: string]: UpdateSpec;
+    }
+    
+    type UpdateSpec = UpdateSpecCommand | UpdateSpecPath;
+    
+    interface UpdateArraySpec extends UpdateSpecCommand {
         $push?: any[];
         $unshift?: any[];
         $splice?: any[][];


### PR DESCRIPTION
Typescript 1.6 types are a bit stricter so we need to explicitly specify that `update` can either take a dynamic property, or one of the command.s
