### PR TITLE
react.d.ts: Make a generic base version of HTMLAttributes and DOMAttributes

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -336,7 +336,7 @@ declare namespace __React {
         ref?: string | ((component: T) => any);
     }
 
-    interface DOMAttributes extends Props<DOMComponent<any>> {
+    interface DOMAttributesBase<T> extends Props<T> {
         onCopy?: ClipboardEventHandler;
         onCut?: ClipboardEventHandler;
         onPaste?: ClipboardEventHandler;
@@ -377,6 +377,9 @@ declare namespace __React {
         };
     }
 
+    interface DOMAttributes extends DOMAttributesBase<DOMComponent<any>> {
+    }
+
     // This interface is not complete. Only properties accepting
     // unitless numbers are listed here (see CSSProperty.js in React)
     interface CSSProperties {
@@ -406,9 +409,7 @@ declare namespace __React {
         [propertyName: string]: any;
     }
 
-    interface HTMLAttributes extends DOMAttributes {
-        ref?: string | ((component: HTMLComponent) => void);
-
+    interface HTMLAttributesBase<T> extends DOMAttributesBase<T> {
         accept?: string;
         acceptCharset?: string;
         accessKey?: string;
@@ -526,6 +527,9 @@ declare namespace __React {
         itemScope?: boolean;
         itemType?: string;
         unselectable?: boolean;
+    }
+
+    interface HTMLAttributes extends HTMLAttributesBase<HTMLComponent> {
     }
 
     interface SVGElementAttributes extends HTMLAttributes {
@@ -1133,7 +1137,7 @@ declare module "react/addons" {
         ref?: string | ((component: T) => any);
     }
 
-    interface DOMAttributes extends Props<DOMComponent<any>> {
+    interface DOMAttributesBase<T> extends Props<T> {
         onCopy?: ClipboardEventHandler;
         onCut?: ClipboardEventHandler;
         onPaste?: ClipboardEventHandler;
@@ -1174,6 +1178,9 @@ declare module "react/addons" {
         };
     }
 
+    interface DOMAttributes extends DOMAttributesBase<DOMComponent<any>> {
+    }
+
     // This interface is not complete. Only properties accepting
     // unitless numbers are listed here (see CSSProperty.js in React)
     interface CSSProperties {
@@ -1203,9 +1210,7 @@ declare module "react/addons" {
         [propertyName: string]: any;
     }
 
-    interface HTMLAttributes extends DOMAttributes {
-        ref?: string | ((component: HTMLComponent) => void);
-
+    interface HTMLAttributesBase<T> extends DOMAttributesBase<T> {
         accept?: string;
         acceptCharset?: string;
         accessKey?: string;
@@ -1323,6 +1328,9 @@ declare module "react/addons" {
         itemScope?: boolean;
         itemType?: string;
         unselectable?: boolean;
+    }
+
+    interface HTMLAttributes extends HTMLAttributesBase<HTMLComponent> {
     }
 
     interface SVGElementAttributes extends HTMLAttributes {


### PR DESCRIPTION
This is a minor change to allow for components that pass all remaining properties to an underlying HTML element.

It eliminates conflicts with the `React.Props.ref` property, since TypeScript doesn't allow the re-definition of a return type.  See Microsoft/TypeScript#3402.
