### PR TITLE
Add d3.time.format.utc.multi

### DIFF
--- a/d3/d3-tests.ts
+++ b/d3/d3-tests.ts
@@ -2693,3 +2693,16 @@ function testD3MutlieTimeFormat() {
         ["%Y", function() { return true; }]
     ]);
 }
+
+function testMultiUtcFormat() {
+    var format = d3.time.format.utc.multi([
+        [".%L", function(d) { return d.getMilliseconds(); }],
+        [":%S", function(d) { return d.getSeconds(); }],
+        ["%I:%M", function(d) { return d.getMinutes(); }],
+        ["%I %p", function(d) { return d.getHours(); }],
+        ["%a %d", function(d) { return d.getDay() && d.getDate() != 1; }],
+        ["%b %d", function(d) { return d.getDate() != 1; }],
+        ["%B", function(d) { return d.getMonth(); }],
+        ["%Y", function() { return true; }]
+    ]);
+}

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1802,6 +1802,10 @@ declare module d3 {
         export module format {
             export function multi(formats: Array<[string, (d: Date) => boolean|number]>): Format;
             export function utc(specifier: string): Format;
+            module utc {
+                export function multi(formats: Array<[string, (d: Date) => boolean|number]>): Format;
+            }
+
             export var iso: Format;
         }
 


### PR DESCRIPTION
Per #5751, `d3.time.format.utc` has a `multi` property. I've added it and updated tests.
