### PR TITLE
node-notifier: Remove unused reference

### DIFF
--- a/node-notifier/node-notifier.d.ts
+++ b/node-notifier/node-notifier.d.ts
@@ -3,7 +3,6 @@
 // Definitions by: Qubo <https://github.com/tkQubo>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-/// <reference path="../bluebird/bluebird.d.ts" />
 /// <reference path="../node/node.d.ts" />
 
 declare module "node-notifier" {


### PR DESCRIPTION
It can be removed.
It should be removed.
