### PR TITLE
Add declaration for 'js-cookie'

### DIFF
--- a/js-cookie/js-cookie.d.ts
+++ b/js-cookie/js-cookie.d.ts
@@ -90,3 +90,7 @@ declare module Cookies {
 }
 
 declare var Cookies: Cookies.CookiesStatic;
+
+declare module 'js-cookie' {
+    export = Cookies;
+}


### PR DESCRIPTION
Supports e.g. `import Cookies = require('js-cookie')` for CommonJS.
