### PR TITLE
auto-launch: Fixed isEnabled() method

### DIFF
--- a/auto-launch/auto-launch-tests.ts
+++ b/auto-launch/auto-launch-tests.ts
@@ -14,4 +14,11 @@ var a2 = new AutoLaunch({
 
 a1.enable();
 a2.disable();
-var enabled: boolean = a1.isEnabled();
+
+a1.isEnabled(function(enabled: boolean) {
+    if (enabled) {
+        return;
+    }
+
+    a1.enable(function(err){ console.log(err.message); });
+});

--- a/auto-launch/auto-launch.d.ts
+++ b/auto-launch/auto-launch.d.ts
@@ -32,7 +32,7 @@ declare class AutoLaunch {
 	/**
 	 * Returns if auto start up is enabled
 	 */
-	isEnabled(callback?: (err: Error) => void): boolean;
+	isEnabled(callback: (enabled: boolean) => void): void;
 }
 
 declare module "auto-launch" {


### PR DESCRIPTION
`isEnabled` method passes boolean value to callback function.  I fixed it.

https://github.com/Teamwork/node-auto-launch#usage
