### PR TITLE
 Fixed incorrect IGridOptions.rowEquality() signature

### DIFF
--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -809,10 +809,10 @@ declare module uiGrid {
         /**
          * By default, rows are compared using object equality.  This option can be overridden
          * to compare on any data item property or function
-         * @param {IGridRow} entityA First Data Item to compare
-         * @param {IGridRow} entityB Second Data Item to compare
+         * @param {any} entityA First Data Item to compare
+         * @param {any} entityB Second Data Item to compare
          */
-        rowEquality?(entityA: IGridRow, entityB: IGridRow): boolean;
+        rowEquality?(entityA: any, entityB: any): boolean;
         /**
          * This function is used to get and, if necessary, set the value uniquely identifying this row
          * (i.e. if an identity is not present it will set one).

--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -999,12 +999,6 @@ declare module uiGrid {
              */
             rowsVisibleChanged: (scope: ng.IScope, handler: rowsVisibleChangedHandler) => void;
             /**
-             * is raised after the sort criteria on one or more columns has changed
-             * @param {ng.IScope} scope Grid scope
-             * @param {rowsVisibleChangedHandler} handler callback
-             */
-            sortChanged: (scope: ng.IScope, handler: sortChangedHandler) => void;
-            /**
              * is raised when scroll begins. Is throttled, so won't be raised too frequently
              * @param {ng.IScope} scope Grid scope
              * @param {scrollBeginHandler} handler callback
@@ -1074,15 +1068,6 @@ declare module uiGrid {
         (scrollEvent: JQueryMouseEventObject): void;
     }
 
-    export interface sortChangedHandler {
-        /**
-         * Sort change event callback
-         * @param {IGridInstance} grid instance
-         * @param {IGridColumn} array of gridColumns that have sorting on them, sorted in priority order
-         */
-        (grid: IGridInstance, columns: IGridColumn[]): void;
-    }
-
     export module cellNav {
         /**
          * Column Definitions for cellNav feature, these are available to be set using the ui-grid
@@ -1143,7 +1128,6 @@ declare module uiGrid {
              * Brings the specified row and column into view, and sets focus to that cell
              * @param {any} rowEntity gridOptions.data[] array instance to make visible and set focus
              * @param {IColumnDef} colDef Column definition to make visible and set focus
-             * @returns {ng.IPromise<any>} a promise that is resolved after any scrolling is finished
              */
             scrollToFocus(rowEntity: any, colDef: IColumnDef): ng.IPromise<any>;
 

--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -999,6 +999,12 @@ declare module uiGrid {
              */
             rowsVisibleChanged: (scope: ng.IScope, handler: rowsVisibleChangedHandler) => void;
             /**
+             * is raised after the sort criteria on one or more columns has changed
+             * @param {ng.IScope} scope Grid scope
+             * @param {rowsVisibleChangedHandler} handler callback
+             */
+            sortChanged: (scope: ng.IScope, handler: sortChangedHandler) => void;
+            /**
              * is raised when scroll begins. Is throttled, so won't be raised too frequently
              * @param {ng.IScope} scope Grid scope
              * @param {scrollBeginHandler} handler callback
@@ -1068,6 +1074,15 @@ declare module uiGrid {
         (scrollEvent: JQueryMouseEventObject): void;
     }
 
+    export interface sortChangedHandler {
+        /**
+         * Sort change event callback
+         * @param {IGridInstance} grid instance
+         * @param {IGridColumn} array of gridColumns that have sorting on them, sorted in priority order
+         */
+        (grid: IGridInstance, columns: IGridColumn[]): void;
+    }
+
     export module cellNav {
         /**
          * Column Definitions for cellNav feature, these are available to be set using the ui-grid
@@ -1128,6 +1143,7 @@ declare module uiGrid {
              * Brings the specified row and column into view, and sets focus to that cell
              * @param {any} rowEntity gridOptions.data[] array instance to make visible and set focus
              * @param {IColumnDef} colDef Column definition to make visible and set focus
+             * @returns {ng.IPromise<any>} a promise that is resolved after any scrolling is finished
              */
             scrollToFocus(rowEntity: any, colDef: IColumnDef): ng.IPromise<any>;
 


### PR DESCRIPTION
Documentation for rowEquality shows that entities are compared, and not IGridRow instances. Original JS code of ui-grid confirms that. This PR fixes the issue by setting correct type "any" to rowEquality arguments.

http://ui-grid.info/docs/#/api/ui.grid.class:GridOptions
