### PR TITLE
update express-jwt for 1.6

### DIFF
--- a/express-jwt/express-jwt.d.ts
+++ b/express-jwt/express-jwt.d.ts
@@ -12,12 +12,22 @@ declare module "express-jwt" {
 
     function jwt(options: jwt.Options): jwt.RequestHandler;
 
+    interface IDoneCallback<T> {
+        (err: Error, result: T): void;
+    }
+
+    type ICallback = <T>(req: express.Request, payload: T, done: IDoneCallback<boolean>) => void;
+
     module jwt {
         export interface Options {
-            secret: string;
+            secret: string|ICallback;
             userProperty?: string;
             skip?: string[];
             credentialsRequired?: boolean;
+            isRevoked?: boolean;
+            requestProperty?: string;
+            getToken?: ICallback;
+            [property: string]: any;
         }
         export interface RequestHandler extends express.RequestHandler {
             unless?: typeof unless;


### PR DESCRIPTION
Object literals must have either a `[property: string]: any`, otherwise it fails with `Object literal may only specify known properties, and 'requestProperty' does not exist in type 'Options'.`
