### PR TITLE
Bugfix ionic.d.ts

### DIFF
--- a/ionic/ionic.d.ts
+++ b/ionic/ionic.d.ts
@@ -205,7 +205,7 @@ declare module ionic {
             scrollBy(left: number, top: number, shouldAnimate?: boolean): void;
             zoomTo(level: number, animate?: boolean, originLeft?: number, originTop?: number): void;
             zoomBy(factor: number, animate?: boolean, originLeft?: number, originTop?: number): void;
-            getScrollPosition(): {left: number, top: number};
+            getScrollPosition(): {left: number; top: number};
             anchorScroll(shouldAnimate?: boolean): void;
             freezeScroll(shouldFreeze?: boolean): boolean;
             freezeAllScrolls(shouldFreeze?: boolean): boolean;


### PR DESCRIPTION
Ionic typings will not compile due to syntax error. Fixed in this commit.
