### PR TITLE
selectmenu widget param fix

### DIFF
--- a/jquerymobile/jquerymobile.d.ts
+++ b/jquerymobile/jquerymobile.d.ts
@@ -171,6 +171,7 @@ interface SelectMenuOptions {
     iconshadow?: boolean;
     initSelector?: string;
     inline?: boolean;
+    hidePlaceholderMenuItems: boolean;
     mini?: boolean;
     nativeMenu?: boolean;
     overlayTheme?: string;
@@ -463,8 +464,8 @@ interface JQuery {
     selectmenu(): JQuery;
     selectmenu(command: string): JQuery;
     selectmenu(command: string, update: boolean): JQuery;
-    selectmenu(options: CheckboxRadioOptions): JQuery;
-    selectmenu(events: CheckboxRadioEvents): JQuery;
+    selectmenu(options: SelectMenuOptions): JQuery;
+    selectmenu(events: SelectMenuEvents): JQuery;
 
     listview(): JQuery;
     listview(command: string): JQuery;


### PR DESCRIPTION
selectmenu widget has the wrong object defined for the param. selectmenuoption object is missing a property.
