### PR TITLE
Add ui-router transition promise

### DIFF
--- a/angular-ui-router/angular-ui-router-tests.ts
+++ b/angular-ui-router/angular-ui-router-tests.ts
@@ -174,6 +174,20 @@ class UrlLocatorTestService implements IUrlLocatorTestService {
         this.$state.get();
         this.$state.reload();
         
+        // http://angular-ui.github.io/ui-router/site/#/api/ui.router.state.$state#properties
+        if (this.$state.transition) {
+          var transitionPromise: ng.IPromise<{}> = this.$state.transition;
+          transitionPromise.then(() => {
+            // transition success
+          }, () => {
+            // transition failure
+          }).catch(() => {
+            // transition failure
+          }).finally(() => {
+            // transition ended (success or failure)
+          });
+        }
+        
         // Accesses the currently resolved values for the current state
         // http://stackoverflow.com/questions/28026620/is-there-a-way-to-access-resolved-state-dependencies-besides-injecting-them-into/28027023#28027023
         var resolvedValues = this.$state.$current.locals.globals;

--- a/angular-ui-router/angular-ui-router.d.ts
+++ b/angular-ui-router/angular-ui-router.d.ts
@@ -240,9 +240,14 @@ declare module angular.ui {
         href(state: string, params?: {}, options?: IHrefOptions): string;
         get(state: string): IState;
         get(): IState[];
+        /** A reference to the state's config object. However you passed it in. Useful for accessing custom data. */
         current: IState;
+        /** A param object, e.g. {sectionId: section.id)}, that you'd like to test against the current active state. */
         params: IStateParamsService;
         reload(): void;
+        
+        /** Currently pending transition. A promise that'll resolve or reject. */
+        transition: ng.IPromise<{}>;
         
         $current: IResolvedState;
     }


### PR DESCRIPTION
Adds the `transition` promise according to http://angular-ui.github.io/ui-router/site/#/api/ui.router.state.$state#properties

Also copied simple jsdoc information for other properties.
