### PR TITLE
corrected fetch args to support Request

### DIFF
--- a/whatwg-fetch/whatwg-fetch-tests.ts
+++ b/whatwg-fetch/whatwg-fetch-tests.ts
@@ -25,6 +25,17 @@ function test_fetchUrl() {
 	handlePromise(window.fetch("http://www.andlabs.net/html5/uCOR.php"));
 }
 
+function test_fetchUrlWithRequestObject() {
+	var requestOptions: RequestInit = {
+		method: "POST",
+		headers: {
+			'Content-Type': 'application/json'
+		}
+	};
+	var request: Request = new Request("http://www.andlabs.net/html5/uCOR.php", requestOptions);
+	handlePromise(window.fetch(request));
+}
+
 function handlePromise(promise: Promise<Response>) {
 	promise.then((response) => {
 		return response.text();

--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -80,5 +80,5 @@ declare type BodyInit = Blob|FormData|string;
 declare type RequestInfo = Request|string;
 
 interface Window {
-	fetch(url: string, init?: RequestInit): Promise<Response>;
+	fetch(url: string|Request, init?: RequestInit): Promise<Response>;
 }


### PR DESCRIPTION
based on the definition of whatwg-fetch API definitions I noticed that the fetch API also supports passing in a Request Object instead of just a string for the first argument. I have added the Request as another type which can be accepted. You can find the details of the same spec [here](https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch). @vvakame would like to get your comments on this. Also the definition of ResponseInit seems to enforce that statusText and headers be mandatorily included when creating a Response Object, those two properties seem to be optional from one of the examples on the MDN documentation from [here](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response)
