### PR TITLE
Knex: fix arguments for TableBuilder.enu/enum

### DIFF
--- a/knex/knex-test.ts
+++ b/knex/knex-test.ts
@@ -353,6 +353,7 @@ knex.transaction(function(trx) {
 knex.schema.createTable('users', function (table) {
   table.increments();
   table.string('name');
+  table.enu('favorite_color', ['red', 'blue', 'green']);
   table.timestamps();
 });
 

--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -326,8 +326,8 @@ declare module "knex" {
       timestamp(columnName: string): ColumnBuilder;
       timestamps(): ColumnBuilder;
       binary(columnName: string): ColumnBuilder;
-      enum(columnName: string): ColumnBuilder;
-      enu(columnName: string): ColumnBuilder;
+      enum(columnName: string, values: Value[]): ColumnBuilder;
+      enu(columnName: string, values: Value[]): ColumnBuilder;
       json(columnName: string): ColumnBuilder;
       uuid(columnName: string): ColumnBuilder;
       comment(val: string): TableBuilder;


### PR DESCRIPTION
There's an error in the definitions for the `.enum` method (and its alias `.enu`); the method requires an array of values for the enum as an argument, as well as the column name.  See the documentation [here](http://knexjs.org/#Schema-enum).
