### PR TITLE
Threejs - added enum definitions and fixed a few mis-definitions

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for three.js r71
+﻿// Type definitions for three.js r71
 // Project: http://mrdoob.github.com/three.js/
 // Definitions by: Kon <http://phyzkit.net/>, Satoru Kimura <https://github.com/gyohk>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped  
@@ -8,22 +8,186 @@ interface WebGLRenderingContext {}
 declare module THREE {
     export var REVISION: string;
 
-    // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent.button
-    export enum MOUSE {LEFT, MIDDLE, RIGHT}
+    const enum MOUSE {
+        LEFT = 0,
+        MIDDLE = 1,
+        RIGHT = 2,
+    }
 
     // GL STATE CONSTANTS
-    export enum CullFace { }
+    const enum CullFace {
+        None = 0,
+        Back = 1,
+        Front = 2,
+        FrontBack = 3,
+    }
+
+
+    const enum FrontFaceDirection {
+        CW = 0,
+        CCW = 1,
+    }
+
+    // Shadowing Type
+    const enum ShadowMapType {
+        Basic = 0,
+        PCF = 1,
+        PCFSoft = 2,
+    }
+
+    // MATERIAL CONSTANTS
+
+    // side
+    const enum Side {
+        Front = 0,
+        Back = 1,
+        Double = 2,
+    }
+
+    // shading
+    const enum Shading {
+        None = 0,
+        Flat = 1,
+        Smooth = 2,
+    }
+
+    // colors
+    const enum Colors {
+        None = 0,
+        Face = 1,
+        Vertex = 2,
+    }
+
+    // blending modes
+    const enum Blending {
+        None = 0,
+        Normal = 1,
+        Additive = 2,
+        Subtractive = 3,
+        Multiply = 4,
+        Custom = 5,
+    }
+
+    // custom blending equations
+    // (numbers start from 100 not to clash with other
+    //  mappings to OpenGL constants defined in Texture.js)
+    const enum BlendingEquation {
+        Add = 100,
+        Subtract = 101,
+        ReverseSubtract = 102,
+    }
+
+    // custom blending destination factors
+    const enum BlendingDstFactor {
+        Zero = 200,
+        One = 201,
+        SrcColor = 202,
+        OneMinusSrcColor = 203,
+        SrcAlpha = 204,
+        OneMinusSrcAlpha = 205,
+        DstAlpha = 206,
+        OneMinusDstAlpha = 207,
+    }
+
+    // custom blending src factors
+    const enum BlendingSrcFactor {
+        //Zero = 200,
+        //One = 201,
+        //SrcAlpha = 204,
+        //OneMinusSrcAlpha = 205,
+        //DstAlpha = 206,
+        //OneMinusDstAlpha = 207,
+        DstColor = 208,
+        OneMinusDstColor = 209,
+        SrcAlphaSaturate = 210,
+    }
+
+    // TEXTURE CONSTANTS
+    // Operations
+    const enum Combine {
+        Multiply = 0,
+        Mix = 1,
+        Add = 2,
+    }
+
+    // Mapping modes 
+    interface Mapping {e
+        new (): { };
+    }
+    var UVMapping: Mapping;
+    var CubeReflectionMapping: Mapping;
+    var CubeRefractionMapping: Mapping;
+    var SphericalReflectionMapping: Mapping;
+    var SphericalRefractionMapping: Mapping;
+
+    // Wrapping modes
+    const enum Wrapping {
+        Repeat = 1000,
+        ClampToEdge = 1001,
+        MirroredRepeat = 1002,
+    }
+
+    // Filters
+    const enum TextureFilter {
+        Nearest = 1003,
+        NearestMipMapNearest = 1004,
+        NearestMipMapLinear = 1005,
+        Linear = 1006,
+        LinearMipMapNearest = 1007,
+        LinearMipMapLinear = 1008,
+    }
+
+    // Data types
+    const enum TextureDataType {
+        UnsignedByte = 1009,
+        Byte = 1010,
+        Short = 1011,
+        UnsignedShort = 1012,
+        Int = 1013,
+        UnsignedInt = 1014,
+        Float = 1015,
+    }
+
+    // Pixel types
+    const enum PixelType {
+        UnsignedShort4444 = 1016,
+        UnsignedShort5551 = 1017,
+        UnsignedShort565 = 1018,
+    }
+
+    // Pixel formats
+    const enum PixelFormat {
+        Alpha = 1019,
+        RGB = 1020,
+        RGBA = 1021,
+        Luminance = 1022,
+        LuminanceAlpha = 1023,
+    }
+
+    // Compressed texture formats
+    const enum CompressedPixelFormat {
+        RGB_S3TC_DXT1 = 2001,
+        RGBA_S3TC_DXT1 = 2002,
+        RGBA_S3TC_DXT3 = 2003,
+        RGBA_S3TC_DXT5 = 2004,
+    }
+
+    // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent.button
+    // export enum MOUSE {LEFT, MIDDLE, RIGHT}
+
+    // GL STATE CONSTANTS
+    // export enum CullFace { }
     export var CullFaceNone: CullFace;
     export var CullFaceBack: CullFace;
     export var CullFaceFront: CullFace;
     export var CullFaceFrontBack: CullFace;
 
-    export enum FrontFaceDirection { }
+    // export enum FrontFaceDirection { }
     export var FrontFaceDirectionCW: FrontFaceDirection;
     export var FrontFaceDirectionCCW: FrontFaceDirection;
 
     // Shadowing Type
-    export enum ShadowMapType { }
+    // export enum ShadowMapType { }
     export var BasicShadowMap: ShadowMapType;
     export var PCFShadowMap: ShadowMapType;
     export var PCFSoftShadowMap: ShadowMapType;
@@ -31,25 +195,25 @@ declare module THREE {
     // MATERIAL CONSTANTS
 
     // side
-    export enum Side { }
+    // export enum Side { }
     export var FrontSide: Side;
     export var BackSide: Side;
     export var DoubleSide: Side;
 
     // shading
-    export enum Shading { }
+    // export enum Shading { }
     export var NoShading: Shading;
     export var FlatShading: Shading;
     export var SmoothShading: Shading;
 
     // colors
-    export enum Colors { }
+    // export enum Colors { }
     export var NoColors: Colors;
     export var FaceColors: Colors;
     export var VertexColors: Colors;
 
     // blending modes
-    export enum Blending { }
+    // export enum Blending { }
     export var NoBlending: Blending;
     export var NormalBlending: Blending;
     export var AdditiveBlending: Blending;
@@ -60,7 +224,7 @@ declare module THREE {
     // custom blending equations
     // (numbers start from 100 not to clash with other
     //  mappings to OpenGL constants defined in Texture.js)
-    export enum BlendingEquation { }
+    // export enum BlendingEquation { }
     export var AddEquation: BlendingEquation;
     export var SubtractEquation: BlendingEquation;
     export var ReverseSubtractEquation: BlendingEquation;
@@ -68,7 +232,7 @@ declare module THREE {
     export var MaxEquation: BlendingEquation;
 
     // custom blending destination factors
-    export enum BlendingDstFactor { }
+    // export enum BlendingDstFactor { }
     export var ZeroFactor: BlendingDstFactor;
     export var OneFactor: BlendingDstFactor;
     export var SrcColorFactor: BlendingDstFactor;
@@ -79,20 +243,25 @@ declare module THREE {
     export var OneMinusDstAlphaFactor: BlendingDstFactor;
 
    // custom blending src factors
-    export enum BlendingSrcFactor { }
+    // export enum BlendingSrcFactor { }
     export var DstColorFactor: BlendingSrcFactor;
     export var OneMinusDstColorFactor: BlendingSrcFactor;
     export var SrcAlphaSaturateFactor: BlendingSrcFactor;
 
     // TEXTURE CONSTANTS
     // Operations
-    export enum Combine { }
+    // export enum Combine { }
     export var MultiplyOperation: Combine;
     export var MixOperation: Combine;
     export var AddOperation: Combine;
 
     // Mapping modes
-    export enum Mapping { }
+    // export enum Mapping { }
+    // These are functions, not enums
+    export interface Mapping {
+        new (): {};
+    }
+
     export var UVMapping: Mapping;
     export var CubeReflectionMapping: Mapping;
     export var CubeRefractionMapping: Mapping;
@@ -101,13 +270,13 @@ declare module THREE {
     export var SphericalReflectionMapping: Mapping;
 
     // Wrapping modes
-    export enum Wrapping { }
+    // export enum Wrapping { }
     export var RepeatWrapping: Wrapping;
     export var ClampToEdgeWrapping: Wrapping;
     export var MirroredRepeatWrapping: Wrapping;
 
     // Filters
-    export enum TextureFilter { }
+    // export enum TextureFilter { }
     export var NearestFilter: TextureFilter;
     export var NearestMipMapNearestFilter: TextureFilter;
     export var NearestMipMapLinearFilter: TextureFilter;
@@ -116,7 +285,7 @@ declare module THREE {
     export var LinearMipMapLinearFilter: TextureFilter;
 
     // Data types
-    export enum TextureDataType { }
+    // export enum TextureDataType { }
     export var UnsignedByteType: TextureDataType;
     export var ByteType: TextureDataType;
     export var ShortType: TextureDataType;
@@ -127,13 +296,13 @@ declare module THREE {
     export var HalfFloatType: TextureDataType;
 
     // Pixel types
-    export enum PixelType { }
+    // export enum PixelType { }
     export var UnsignedShort4444Type: PixelType;
     export var UnsignedShort5551Type: PixelType;
     export var UnsignedShort565Type: PixelType;
 
     // Pixel formats
-    export enum PixelFormat { }
+    // export enum PixelFormat { }
     export var AlphaFormat: PixelFormat;
     export var RGBFormat: PixelFormat;
     export var RGBAFormat: PixelFormat;
@@ -143,7 +312,7 @@ declare module THREE {
 
     // Compressed texture formats
     // DDS / ST3C Compressed texture formats
-    export enum CompressedPixelFormat { }
+    // export enum CompressedPixelFormat { }
     export var RGB_S3TC_DXT1_Format: CompressedPixelFormat;
     export var RGBA_S3TC_DXT1_Format: CompressedPixelFormat;
     export var RGBA_S3TC_DXT3_Format: CompressedPixelFormat;
@@ -5290,18 +5459,20 @@ declare module THREE {
         updateMatrixWorld(force?: boolean): void;
     }
 
-    export enum PathActions {
-        MOVE_TO,
-        LINE_TO,
-        QUADRATIC_CURVE_TO, // Bezier quadratic curve
-        BEZIER_CURVE_TO,     // Bezier cubic curve
-        CSPLINE_THRU,        // Catmull-rom spline
-        ARC,                // Circle
-        ELLIPSE,
+    export type PathAct = string;           // these are strings not enums
+
+    export interface PathActions {
+        MOVE_TO: PathAct;
+        LINE_TO: PathAct;
+        QUADRATIC_CURVE_TO: PathAct; // Bezier quadratic curve
+        BEZIER_CURVE_TO: PathAct;     // Bezier cubic curve
+        CSPLINE_THRU: PathAct;        // Catmull-rom spline
+        ARC: PathAct;                // Circle
+        ELLIPSE: PathAct;
     }
 
     export interface PathAction {
-        action: PathActions;
+        action: PathAct;
         args: any;
     }
 

--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -1,7 +1,7 @@
 ﻿// Type definitions for three.js r71
 // Project: http://mrdoob.github.com/three.js/
 // Definitions by: Kon <http://phyzkit.net/>, Satoru Kimura <https://github.com/gyohk>
-// Definitions: https://github.com/borisyankov/DefinitelyTyped  
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 interface WebGLRenderingContext {}
 
@@ -110,8 +110,8 @@ declare module THREE {
         Add = 2,
     }
 
-    // Mapping modes 
-    interface Mapping {e
+    // Mapping modes
+    interface Mapping {
         new (): { };
     }
     var UVMapping: Mapping;
@@ -755,21 +755,21 @@ declare module THREE {
      *
      * # Example
      *     var Car = function () {
-     *     
+     *
      *         EventDispatcher.call( this );
      *         this.start = function () {
-     *     
+     *
      *             this.dispatchEvent( { type: 'start', message: 'vroom vroom!' } );
-     *     
+     *
      *         };
-     *     
+     *
      *     };
      *
      *     var car = new Car();
      *     car.addEventListener( 'start', function ( event ) {
-     *     
+     *
      *         alert( event.message );
-     *     
+     *
      *     } );
      *     car.start();
      *
@@ -1391,7 +1391,7 @@ declare module THREE {
         getObjectByName(name: string): Object3D;
 
         getObjectByProperty( name: string, value: string ): Object3D;
-        
+
         getWorldPosition(optionalTarget?: Vector3): Vector3;
         getWorldQuaternion(optionalTarget?: Quaternion): Quaternion;
         getWorldRotation(optionalTarget?: Euler): Euler;
@@ -1913,16 +1913,16 @@ declare module THREE {
         add(regex:string, loader:Loader):void;
         get(file: string):Loader;
     }
-    
+
     export class BinaryTextureLoader {
         constructor();
-        
+
         load(url: string, onLoad: (dataTexture: DataTexture) => void, onProgress?: (event: any) => void, onError?: (event: any) => void): void;
     }
 
     export class BufferGeometryLoader {
         constructor(manager?: LoadingManager);
-        
+
         manager: LoadingManager;
         load(url: string, onLoad: (bufferGeometry: BufferGeometry) => void, onProgress?: (event: any) => void, onError?: (event: any) => void): void;
         setCrossOrigin(crossOrigin: string): void;
@@ -2060,10 +2060,10 @@ declare module THREE {
      */
     export class TextureLoader {
         constructor(manager?: LoadingManager);
-        
+
         manager: LoadingManager;
         crossOrigin: string;
-        
+
         /**
          * Begin loading from url
          *
@@ -3482,8 +3482,8 @@ declare module THREE {
          */
         multiplyQuaternions(a: Quaternion, b: Quaternion): Quaternion;
 
-        /** 
-          * Deprecated. Use Vector3.applyQuaternion instead 
+        /**
+          * Deprecated. Use Vector3.applyQuaternion instead
           */
         multiplyVector3(vector: Vector3): Vector3;
         slerp(qb: Quaternion, t: number): Quaternion;
@@ -4414,7 +4414,7 @@ declare module THREE {
         normalizeSkinWeights(): void;
         updateMatrixWorld(force?: boolean): void;
         clone(object?: SkinnedMesh): SkinnedMesh;
-        
+
         skeleton: Skeleton;
     }
 
@@ -5088,13 +5088,13 @@ declare module THREE {
             data: ImageData,
             width: number,
             height: number,
-            format: PixelFormat,
-            type: TextureDataType,
-            mapping: Mapping,
-            wrapS: Wrapping,
-            wrapT: Wrapping,
-            magFilter: TextureFilter,
-            minFilter: TextureFilter,
+            format?: PixelFormat,
+            type?: TextureDataType,
+            mapping?: Mapping,
+            wrapS?: Wrapping,
+            wrapT?: Wrapping,
+            magFilter?: TextureFilter,
+            minFilter?: TextureFilter,
             anisotropy?: number
         );
 
@@ -5841,8 +5841,8 @@ declare module THREE {
             heightScale: number;
         };
     }
-    
-    
+
+
     export class TubeGeometry extends Geometry {
         constructor(path: Path, segments?: number, radius?: number, radiusSegments?: number, closed?: boolean, taper?: (u: number) => number);
 
@@ -5861,7 +5861,7 @@ declare module THREE {
         static NoTaper(u?: number): number;
         static SinusoidalTaper(u: number): number;
         static FrenetFrames(path: Path, segments: number, closed: boolean): void;
-        
+
     }
 
     // Extras / Helpers /////////////////////////////////////////////////////////////////////

--- a/webcl/webcl-tests.ts
+++ b/webcl/webcl-tests.ts
@@ -1,0 +1,626 @@
+/// <reference path="webcl.d.ts" />
+/// <reference path="../jquery/jquery.d.ts" />
+
+class CLHException {
+    constructor(
+        public message: string
+        ) { }
+}
+
+class PlatformInfo {
+    EXTENTION: string;
+    NAME: string;
+    PROFILE: string;
+    VENDOR: string;
+    VERSION: string;
+
+    constructor(
+        public platform: WEBCL.WebCLPlatform,
+        public deviceInfos: DeviceInfo[]= new Array<DeviceInfo>()
+        ) {
+        this.PROFILE = platform.getInfo(WEBCL.PlatformInfo.PLATFORM_PROFILE);
+        this.VERSION = platform.getInfo(WEBCL.PlatformInfo.PLATFORM_VERSION);
+        this.NAME = platform.getInfo(WEBCL.PlatformInfo.PLATFORM_NAME);
+        this.VENDOR = platform.getInfo(WEBCL.PlatformInfo.PLATFORM_VENDOR);
+        this.EXTENTION = platform.getInfo(WEBCL.PlatformInfo.PLATFORM_EXTENSIONS);
+    }
+}
+
+class DeviceInfo {
+    ADDRESS_BITS: number;
+    AVAILABLE: boolean;
+    COMPILER_AVAILABLE: boolean;
+    DRIVER_VERSION: string;
+    ENDIAN_LITTLE: boolean;
+    ERROR_CORRECTION_SUPPORT: boolean;
+    EXECUTION_CAPABILITIES: WEBCL.DeviceExecCapabilitiesBits;
+    EXTENSIONS: string;
+    GLOBAL_MEM_CACHE_SIZE: number;
+    GLOBAL_MEM_CACHE_TYPE: WEBCL.DeviceMemCacheType;
+    GLOBAL_MEM_CACHELINE_SIZE: number;
+    GLOBAL_MEM_SIZE: number;
+    HOST_UNIFIED_MEMORY: boolean;
+    IMAGE_SUPPORT: boolean;
+    IMAGE2D_MAX_HEIGHT: number;
+    IMAGE2D_MAX_WIDTH: number;
+    IMAGE3D_MAX_DEPTH: number;
+    IMAGE3D_MAX_HEIGHT: number;
+    IMAGE3D_MAX_WIDTH: number;
+    LOCAL_MEM_SIZE: number;
+    LOCAL_MEM_TYPE: WEBCL.DeviceLocalMemType;
+    MAX_CLOCK_FREQUENCY: number;
+    MAX_COMPUTE_UNITS: number;
+    MAX_CONSTANT_ARGS: number;
+    MAX_CONSTANT_BUFFER_SIZE: number;
+    MAX_MEM_ALLOC_SIZE: number;
+    MAX_PARAMETER_SIZE: number;
+    MAX_READ_IMAGE_ARGS: number;
+    MAX_SAMPLERS: number;
+    MAX_WORK_GROUP_SIZE: number;
+    MAX_WORK_ITEM_DIMENSIONS: number;
+    MAX_WORK_ITEM_SIZES: number;
+    MAX_WRITE_IMAGE_ARGS: number;
+    MEM_BASE_ADDR_ALIGN: number;
+    NAME: string;
+    NATIVE_VECTOR_WIDTH_CHAR: number;
+    NATIVE_VECTOR_WIDTH_FLOAT: number;
+    NATIVE_VECTOR_WIDTH_INT: number;
+    NATIVE_VECTOR_WIDTH_LONG: number;
+    NATIVE_VECTOR_WIDTH_SHORT: number;
+    OPENCL_C_VERSION: string;
+    PLATFORM: WEBCL.WebCLPlatform;
+    PlatformInfo: PlatformInfo;
+    PREFERRED_VECTOR_WIDTH_CHAR: number;
+    PREFERRED_VECTOR_WIDTH_FLOAT: number;
+    PREFERRED_VECTOR_WIDTH_INT: number;
+    PREFERRED_VECTOR_WIDTH_LONG: number;
+    PREFERRED_VECTOR_WIDTH_SHORT: number;
+    PROFILE: string;
+    PROFILING_TIMER_RESOLUTION: number;
+    QUEUE_PROPERTIES: WEBCL.CommandQueueProperties;
+    SINGLE_FP_CONFIG: WEBCL.DeviceFPConfigBits;
+    TYPE: WEBCL.DeviceTypeBits;
+    VENDOR: string;
+    VENDOR_ID: number;
+    VERSION: string;
+
+    constructor(public device: WEBCL.WebCLDevice, platformInfo: PlatformInfo) {
+        this.ADDRESS_BITS = device.getInfo(WEBCL.DeviceInfo.DEVICE_ADDRESS_BITS);
+        this.AVAILABLE = device.getInfo(WEBCL.DeviceInfo.DEVICE_AVAILABLE);
+        this.COMPILER_AVAILABLE = device.getInfo(WEBCL.DeviceInfo.DEVICE_COMPILER_AVAILABLE);
+        this.DRIVER_VERSION = device.getInfo(WEBCL.DeviceInfo.DRIVER_VERSION);
+        this.ENDIAN_LITTLE = device.getInfo(WEBCL.DeviceInfo.DEVICE_ENDIAN_LITTLE);
+        this.ERROR_CORRECTION_SUPPORT = device.getInfo(WEBCL.DeviceInfo.DEVICE_ERROR_CORRECTION_SUPPORT);
+        this.EXECUTION_CAPABILITIES = device.getInfo(WEBCL.DeviceInfo.DEVICE_EXECUTION_CAPABILITIES);
+        this.EXTENSIONS = device.getInfo(WEBCL.DeviceInfo.DEVICE_EXTENSIONS);
+        this.GLOBAL_MEM_CACHE_SIZE = device.getInfo(WEBCL.DeviceInfo.DEVICE_GLOBAL_MEM_CACHE_SIZE);
+        this.GLOBAL_MEM_CACHE_TYPE = device.getInfo(WEBCL.DeviceInfo.DEVICE_GLOBAL_MEM_CACHE_TYPE);
+        this.GLOBAL_MEM_CACHELINE_SIZE = device.getInfo(WEBCL.DeviceInfo.DEVICE_GLOBAL_MEM_CACHELINE_SIZE);
+        this.GLOBAL_MEM_SIZE = device.getInfo(WEBCL.DeviceInfo.DEVICE_GLOBAL_MEM_SIZE);
+        this.HOST_UNIFIED_MEMORY = device.getInfo(WEBCL.DeviceInfo.DEVICE_HOST_UNIFIED_MEMORY);
+        this.IMAGE_SUPPORT = device.getInfo(WEBCL.DeviceInfo.DEVICE_IMAGE_SUPPORT);
+        this.IMAGE2D_MAX_HEIGHT = device.getInfo(WEBCL.DeviceInfo.DEVICE_IMAGE2D_MAX_HEIGHT);
+        this.IMAGE2D_MAX_WIDTH = device.getInfo(WEBCL.DeviceInfo.DEVICE_IMAGE2D_MAX_WIDTH);
+        this.IMAGE3D_MAX_DEPTH = device.getInfo(WEBCL.DeviceInfo.DEVICE_IMAGE3D_MAX_DEPTH);
+        this.IMAGE3D_MAX_HEIGHT = device.getInfo(WEBCL.DeviceInfo.DEVICE_IMAGE3D_MAX_HEIGHT);
+        this.IMAGE3D_MAX_WIDTH = device.getInfo(WEBCL.DeviceInfo.DEVICE_IMAGE3D_MAX_WIDTH);
+        this.LOCAL_MEM_SIZE = device.getInfo(WEBCL.DeviceInfo.DEVICE_LOCAL_MEM_SIZE);
+        this.LOCAL_MEM_TYPE = device.getInfo(WEBCL.DeviceInfo.DEVICE_LOCAL_MEM_TYPE);
+        this.MAX_CLOCK_FREQUENCY = device.getInfo(WEBCL.DeviceInfo.DEVICE_MAX_CLOCK_FREQUENCY);
+        this.MAX_COMPUTE_UNITS = device.getInfo(WEBCL.DeviceInfo.DEVICE_MAX_COMPUTE_UNITS);
+        this.MAX_CONSTANT_ARGS = device.getInfo(WEBCL.DeviceInfo.DEVICE_MAX_CONSTANT_ARGS);
+        this.MAX_CONSTANT_BUFFER_SIZE = device.getInfo(WEBCL.DeviceInfo.DEVICE_MAX_CONSTANT_BUFFER_SIZE);
+        this.MAX_MEM_ALLOC_SIZE = device.getInfo(WEBCL.DeviceInfo.DEVICE_MAX_MEM_ALLOC_SIZE);
+        this.MAX_PARAMETER_SIZE = device.getInfo(WEBCL.DeviceInfo.DEVICE_MAX_PARAMETER_SIZE);
+        this.MAX_READ_IMAGE_ARGS = device.getInfo(WEBCL.DeviceInfo.DEVICE_MAX_READ_IMAGE_ARGS);
+        this.MAX_SAMPLERS = device.getInfo(WEBCL.DeviceInfo.DEVICE_MAX_SAMPLERS);
+        this.MAX_WORK_GROUP_SIZE = device.getInfo(WEBCL.DeviceInfo.DEVICE_MAX_WORK_GROUP_SIZE);
+        this.MAX_WORK_ITEM_DIMENSIONS = device.getInfo(WEBCL.DeviceInfo.DEVICE_MAX_WORK_ITEM_DIMENSIONS);
+        this.MAX_WORK_ITEM_SIZES = device.getInfo(WEBCL.DeviceInfo.DEVICE_MAX_WORK_ITEM_SIZES);
+        this.MAX_WRITE_IMAGE_ARGS = device.getInfo(WEBCL.DeviceInfo.DEVICE_MAX_WRITE_IMAGE_ARGS);
+        this.MEM_BASE_ADDR_ALIGN = device.getInfo(WEBCL.DeviceInfo.DEVICE_MEM_BASE_ADDR_ALIGN);
+        this.NAME = device.getInfo(WEBCL.DeviceInfo.DEVICE_NAME);
+        this.NATIVE_VECTOR_WIDTH_CHAR = device.getInfo(WEBCL.DeviceInfo.DEVICE_NATIVE_VECTOR_WIDTH_CHAR);
+        this.NATIVE_VECTOR_WIDTH_FLOAT = device.getInfo(WEBCL.DeviceInfo.DEVICE_NATIVE_VECTOR_WIDTH_FLOAT);
+        this.NATIVE_VECTOR_WIDTH_INT = device.getInfo(WEBCL.DeviceInfo.DEVICE_NATIVE_VECTOR_WIDTH_INT);
+        this.NATIVE_VECTOR_WIDTH_LONG = device.getInfo(WEBCL.DeviceInfo.DEVICE_NATIVE_VECTOR_WIDTH_LONG);
+        this.NATIVE_VECTOR_WIDTH_SHORT = device.getInfo(WEBCL.DeviceInfo.DEVICE_NATIVE_VECTOR_WIDTH_SHORT);
+        this.OPENCL_C_VERSION = device.getInfo(WEBCL.DeviceInfo.DEVICE_OPENCL_C_VERSION);
+        this.PLATFORM = device.getInfo(WEBCL.DeviceInfo.DEVICE_PLATFORM);
+        this.PlatformInfo = platformInfo;
+        this.PREFERRED_VECTOR_WIDTH_CHAR = device.getInfo(WEBCL.DeviceInfo.DEVICE_PREFERRED_VECTOR_WIDTH_CHAR);
+        this.PREFERRED_VECTOR_WIDTH_FLOAT = device.getInfo(WEBCL.DeviceInfo.DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT);
+        this.PREFERRED_VECTOR_WIDTH_INT = device.getInfo(WEBCL.DeviceInfo.DEVICE_PREFERRED_VECTOR_WIDTH_INT);
+        this.PREFERRED_VECTOR_WIDTH_LONG = device.getInfo(WEBCL.DeviceInfo.DEVICE_PREFERRED_VECTOR_WIDTH_LONG);
+        this.PREFERRED_VECTOR_WIDTH_SHORT = device.getInfo(WEBCL.DeviceInfo.DEVICE_PREFERRED_VECTOR_WIDTH_SHORT);
+        this.PROFILE = device.getInfo(WEBCL.DeviceInfo.DEVICE_PROFILE);
+        this.PROFILING_TIMER_RESOLUTION = device.getInfo(WEBCL.DeviceInfo.DEVICE_PROFILING_TIMER_RESOLUTION);
+        this.QUEUE_PROPERTIES = device.getInfo(WEBCL.DeviceInfo.DEVICE_QUEUE_PROPERTIES);
+        this.SINGLE_FP_CONFIG = device.getInfo(WEBCL.DeviceInfo.DEVICE_SINGLE_FP_CONFIG);
+        this.TYPE = device.getInfo(WEBCL.DeviceInfo.DEVICE_TYPE);
+        this.VENDOR = device.getInfo(WEBCL.DeviceInfo.DEVICE_VENDOR);
+        this.VENDOR_ID = device.getInfo(WEBCL.DeviceInfo.DEVICE_VENDOR_ID);
+        this.VERSION = device.getInfo(WEBCL.DeviceInfo.DEVICE_VERSION);
+    }
+}
+
+class ContextInfo {
+    DEVICES: WEBCL.WebCLDevice[];
+
+    constructor(
+        public context: WEBCL.WebCLContext
+        ) {
+        this.DEVICES = context.getInfo(WEBCL.ContextInfo.CONTEXT_DEVICES);
+    }
+}
+
+class KernelWorkGroupInfo {
+    KERNEL_COMPILE_WORK_GROUP_SIZE: number;
+    KERNEL_LOCAL_MEM_SIZE: number;
+    KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE: number;
+    KERNEL_PRIVATE_MEM_SIZE: number;
+    KERNEL_WORK_GROUP_SIZE: number;
+
+    constructor(kernel: WEBCL.WebCLKernel, device: WEBCL.WebCLDevice) {
+        this.KERNEL_COMPILE_WORK_GROUP_SIZE = kernel.getWorkGroupInfo(device, WEBCL.KernelWorkGroupInfo.KERNEL_COMPILE_WORK_GROUP_SIZE);
+        this.KERNEL_LOCAL_MEM_SIZE = kernel.getWorkGroupInfo(device, WEBCL.KernelWorkGroupInfo.KERNEL_LOCAL_MEM_SIZE);
+        this.KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE = kernel.getWorkGroupInfo(device, WEBCL.KernelWorkGroupInfo.KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE);
+        this.KERNEL_PRIVATE_MEM_SIZE = kernel.getWorkGroupInfo(device, WEBCL.KernelWorkGroupInfo.KERNEL_PRIVATE_MEM_SIZE);
+        this.KERNEL_WORK_GROUP_SIZE = kernel.getWorkGroupInfo(device, WEBCL.KernelWorkGroupInfo.KERNEL_WORK_GROUP_SIZE);
+    }
+}
+
+class CommandQueueInfo {
+    CONTEXT: WEBCL.WebCLContext;
+    DEVICE: WEBCL.WebCLDevice;
+    PROPERTIES: WEBCL.CommandQueueProperties;
+
+    constructor(
+        public queue: WEBCL.WebCLCommandQueue
+        ) {
+        this.CONTEXT = queue.getInfo(WEBCL.ContextProperties.QUEUE_CONTEXT);
+        this.DEVICE = queue.getInfo(WEBCL.ContextProperties.QUEUE_DEVICE);
+        this.PROPERTIES = queue.getInfo(WEBCL.ContextProperties.QUEUE_PROPERTIES);
+    }
+}
+
+class MemoryObjectInfo {
+    TYPE: WEBCL.MemObjectType;
+    FLAGS: WEBCL.MemFlagsBits;
+    SIZE: number;
+    CONTEXT: WEBCL.WebCLContext;
+    ASSOCIATED_MEMOBJECT: WEBCL.WebCLBuffer;
+    OFFSET: number;
+
+    constructor(
+        public memoryObj: WEBCL.WebCLMemoryObject
+        ) {
+        this.TYPE = memoryObj.getInfo(WEBCL.MemInfo.MEM_TYPE);
+        this.FLAGS = memoryObj.getInfo(WEBCL.MemInfo.MEM_FLAGS);
+        this.SIZE = memoryObj.getInfo(WEBCL.MemInfo.MEM_SIZE);
+        this.CONTEXT = memoryObj.getInfo(WEBCL.MemInfo.MEM_CONTEXT);
+        this.ASSOCIATED_MEMOBJECT = memoryObj.getInfo(WEBCL.MemInfo.MEM_ASSOCIATED_MEMOBJECT);
+        this.OFFSET = memoryObj.getInfo(WEBCL.MemInfo.MEM_OFFSET);
+    }
+}
+
+class DeviceContext {
+    deviceInfo: DeviceInfo;
+    context: WEBCL.WebCLContext;
+
+    constructor(public device?: WEBCL.WebCLDevice) {
+        if (!device) {
+            this.context = window.webcl.createContext();
+            this.device = this.context.getInfo(WEBCL.ContextInfo.CONTEXT_DEVICES)[0];       // just use the first default device
+        }
+        else {
+            this.context = window.webcl.createContext(device);      // use the specified device
+        }
+        this.deviceInfo = new DeviceInfo(this.device, undefined);       // save all the info about the device
+    }
+}
+
+/**
+* just enough for kernel args that are one of the
+* UInt8Array, UInt16Array, etc. interfaces because they already the extra
+* members.
+* They will be used as
+* either WEBCLBuffers or ArrayBufferViews
+* TODO: How to handle WEBCLImages and WEBCLSamples
+*/
+interface KernelArgArrayBufferView extends ArrayBufferView {
+    BYTES_PER_ELEMENT: number;
+    length: number;
+}
+
+/**
+* This holds the information for an argument
+* passed as a WEBCLBuffer.
+* This holds the original host buffer as a convenience if the
+* same buffer is used for multiple calls.
+* Multiple kernels can use the same arguments
+*/
+class ArgCLBuffer {
+    public buffer: WEBCL.WebCLBuffer;
+
+    constructor(
+        public helper: WebCLHelper,
+        public hostArray: KernelArgArrayBufferView,     // NOTE: this can just be a UInt8Array, UInt16Array, etc.
+        public cpu2gpu: boolean,
+        public gpu2cpu: boolean
+        ) {
+        this.makeCLBuffer(this.helper.devContext);     // make it as a buffer with the host array as the template
+    }
+
+    makeCLBuffer(context: DeviceContext): void {
+        var rwflag: WEBCL.MemFlagsBits;
+        if (this.cpu2gpu) {
+            if (this.gpu2cpu) {
+                rwflag = WEBCL.MemFlagsBits.MEM_READ_WRITE;
+            }
+            else {
+                rwflag = WEBCL.MemFlagsBits.MEM_READ_ONLY;
+            }
+        }
+        else {
+            rwflag = WEBCL.MemFlagsBits.MEM_WRITE_ONLY;
+        }
+
+        this.buffer = context.context.createBuffer(rwflag, this.hostArray.length * this.hostArray.BYTES_PER_ELEMENT,
+            this.hostArray);        // make the CLBuffer for the host array
+    }
+
+    queueGPU2CPU() {
+        if (this.gpu2cpu) {
+            this.helper.queue.enqueueReadBuffer(this.buffer, false, 0, this.hostArray.length * this.hostArray.BYTES_PER_ELEMENT,
+                this.hostArray);       // queue up a write from the host mem to the GPU mem
+        }
+    }
+
+    queueCPU2GPU() {
+        if (this.cpu2gpu) {
+            this.helper.queue.enqueueWriteBuffer(this.buffer, false, 0, this.hostArray.length * this.hostArray.BYTES_PER_ELEMENT,
+                this.hostArray);       // queue up a write from the host mem to the GPU mem
+        }
+    }
+}
+
+/**
+* Holder for a single kernel
+*/
+class Kernel {
+    argCount: number = 0;
+    CLBuffers: ArgCLBuffer[] = [];       // the read and write buffers for the kernel
+    localWS: number[] = [];
+    globalWS: number[] = [];
+    bufferOffsets: number[] = [];
+    clEvent: WEBCL.WebCLEvent;
+    public executionTime: number;
+
+    constructor(
+        public helper: WebCLHelper,
+        public name: string,
+        public kernel: WEBCL.WebCLKernel,
+        public workGroupInfo?: KernelWorkGroupInfo
+        ) { }
+
+    addArg(arg: ArgCLBuffer): number;
+    addArg(arg: ArrayBufferView): number;
+    addArg(arg: number): number;
+    addArg(value: any): number {
+        if (typeof (value) === "number") {          // integer values
+            this.kernel.setArg(this.argCount, new Int32Array([<number>value]));
+        } else if (value instanceof ArgCLBuffer) {      // clBuffer
+            this.kernel.setArg(this.argCount,(<ArgCLBuffer> value).buffer);   // use the CLBuffer
+            this.CLBuffers.push(<ArgCLBuffer> value);           // add to buffer array
+        } else {                // all ArrayBufferView types
+           this.kernel.setArg(this.argCount, value);
+        }
+        this.argCount += 1;
+        return this.argCount - 1;
+    }
+
+    replaceArg(argIdx: number, arg: ArgCLBuffer): void;
+    replaceArg(argIdx: number, arg: number): void;
+    replaceArg(argIdx: number, arg: ArrayBufferView): void;
+    replaceArg(argIdx: number, value: any): void {
+        if (typeof (value) === "number") {
+            this.kernel.setArg(argIdx, new Uint32Array([<number>value]));
+        } else if (value instanceof ArgCLBuffer) {
+            this.kernel.setArg(argIdx, (<ArgCLBuffer> value).buffer);   // use the CLBuffer
+            this.CLBuffers[argIdx] = <ArgCLBuffer> value;           // replace entry is buffer array
+        }
+        else {
+           this.kernel.setArg(this.argCount, value);
+        }
+    }
+
+    setWorkSections(globalThreads: number[], localThreads?: number[], offsets?: number[]) {
+        this.globalWS = globalThreads;
+
+        if (localThreads) {
+            this.localWS = [];
+            localThreads.forEach((count, index) => {
+                this.localWS.push(count);
+                this.globalWS[index] = Math.ceil(globalThreads[index] / count) * count;
+            });
+
+        }
+        else {
+            this.localWS = undefined;
+        }
+
+        if (offsets) {
+            this.bufferOffsets = offsets;
+        }
+        else {
+            this.bufferOffsets = [];
+            globalThreads.forEach(() => {
+                this.bufferOffsets.push(0);
+            });
+        }
+    }
+
+    /**
+    * Queue the transfers from CPU to GPU memory
+    */
+    queueCPU2GPUBuffers(whichBuffers?: ArgCLBuffer[]) {
+        var buffers: ArgCLBuffer[];         // which to use
+        if (whichBuffers) {
+            buffers = whichBuffers;         // just the passed in ones
+        } else {                        // use all of them
+            buffers = this.CLBuffers;
+        }
+
+        buffers.forEach((value, idx) => {
+            if (value.cpu2gpu) {
+                value.queueCPU2GPU();
+            }
+        });     // load up all the GPU memory from the host for all the read arrays
+
+    }
+
+    /**
+    * Queue the transfers from GPU to CPU memory
+    */
+    queueGPU2CPUBuffers(whichBuffers?: ArgCLBuffer[]) {
+        var buffers: ArgCLBuffer[];         // which to use
+        if (whichBuffers) {
+            buffers = whichBuffers;         // just the passed in ones
+        } else {                        // use all of them
+            buffers = this.CLBuffers;
+        }
+
+        buffers.forEach((value, idx) => {
+            if (value.gpu2cpu) {
+                value.queueGPU2CPU();
+            }
+        });     // load up all the host arrays from the gpu memory for all the write arrays
+
+    }
+
+    /*
+    * add this kernel to the queue for execution
+    */
+    queueExecution() {
+        this.clEvent = new WebCLEvent();
+        this.helper.queue.enqueueNDRangeKernel(this.kernel, this.globalWS.length, this.bufferOffsets, this.globalWS, this.localWS, undefined, this.clEvent);  // the kernel
+    }
+
+    /**
+    * Load up all the GPU memory, queue the kernel,
+    * read the GPU memory back into the CPU memory
+    */
+    queueBuffersAndExecute() {
+        this.queueCPU2GPUBuffers();     // load up all the GPU memory from the host for all the read arrays
+
+        this.queueExecution();
+
+        this.queueGPU2CPUBuffers();
+
+        this.helper.finishQueue();
+
+        this.calcExecutionTime();
+
+    }
+
+    calcExecutionTime() {
+        if (this.helper.profileFlag && this.clEvent) {
+            var startTime: number;
+            var endTime: number;
+
+            startTime = this.clEvent.getProfilingInfo(WEBCL.ProfilingInfo.PROFILING_COMMAND_START);
+            endTime = this.clEvent.getProfilingInfo(WEBCL.ProfilingInfo.PROFILING_COMMAND_END);
+            this.executionTime = endTime - startTime;
+        }
+        else {
+            this.executionTime = undefined;
+        }
+    }
+}
+
+/**
+* This holds all the information and setup for a platform and device
+* for a program. Multiple kernels and arguments can be created which are
+* passed back to the user to manage.
+*/
+
+class WebCLHelper {
+    platforms: PlatformInfo[] = new Array<PlatformInfo>();
+    devContext: DeviceContext;         // context or undefined if released
+    queue: WEBCL.WebCLCommandQueue;     // the command queue for the device
+    programCode: string;                // the code for this progam
+    program: WEBCL.WebCLProgram;
+
+    // Create the helper and load up all the platforms and devices
+    constructor(public profileFlag: boolean = false) {
+        if (window.webcl == undefined) {
+            throw (new CLHException("Webcl not found"));
+        }
+        else {
+//            try {
+                var platforms = window.webcl.getPlatforms();
+                if (platforms.length < 1) {
+                    throw (new CLHException("WEBCL there but no platforms"));
+                }
+                else {
+                    var devicesCount = 0;       // keep track of total devices
+                    platforms.forEach(
+                        (platform) => {             // setup info for platform and get all of its devices
+                            var platformInfo = new PlatformInfo(platform);
+                            var devices = platform.getDevices();
+                            devicesCount += devices.length;
+                            devices.forEach(
+                                (device) => {
+                                    var deviceInfo = new DeviceInfo(device, platformInfo);     // get the info
+                                    platformInfo.deviceInfos.push(deviceInfo);      // add to this platform's devices
+                                });
+                            this.platforms.push(platformInfo);
+                        });
+
+                }
+                if (devicesCount < 1) {
+                    throw (new CLHException("Webcl there with " + this.platforms.length + " platforms, but no devices"));
+                }
+                this.setDeviceContext();        // set the device context using the default, can explicitly set if desired.
+/*            }
+            catch (ex) {
+                throw (ex)
+            }
+*/
+        }
+    }
+
+
+    /**
+    * Set a context for a particular device type using a list of types
+    * in preferred order. Normally this wouldn't be used since the helper constructor
+    * sets the default device as the context.
+    */
+    setDeviceContext(deviceTypes: WEBCL.DeviceTypeBits[]= [WEBCL.DeviceTypeBits.DEVICE_TYPE_DEFAULT] // optional, if empty default
+        ): DeviceContext {
+        var device: DeviceInfo;
+
+        deviceTypes.some((type) => {            // go through the input types in preference order
+            if ((type & WEBCL.DeviceTypeBits.DEVICE_TYPE_DEFAULT) != 0) {
+                device = null;
+                return true;
+            }
+            else {
+                device = this.platforms.reduce<DeviceInfo>((targetdevice, platform, index, array) => {
+                    if (!targetdevice) {
+                        platform.deviceInfos.some((deviceInfo: DeviceInfo) => {
+                            if ((deviceInfo.TYPE & type) != 0) {
+                                targetdevice = deviceInfo;
+                                return true;
+                            }
+                            else {
+                                return false;
+                            }
+                        });
+                    }
+                    return targetdevice;
+                }, undefined);
+                return (device != undefined);
+            }              // find the first device of the specified type
+        });
+
+        if (device === undefined) {
+            throw ("No device found");
+        }
+        else {
+            if (this.devContext) {
+                this.devContext.context.release();
+                this.devContext = undefined;
+            }
+            if (device === null) {
+                this.devContext = new DeviceContext();     // get the default context
+            }
+            else {              // use a specific one
+                this.devContext = new DeviceContext(device.device);        // get the context for the device
+            }
+            if (this.queue) {
+                this.queue.release();
+                this.queue = undefined;
+            }
+
+            this.queue = this.devContext.context.createCommandQueue(this.devContext.device, this.profileFlag ? WEBCL.CommandQueueProperties.QUEUE_PROFILING_ENABLE : undefined);
+
+            return this.devContext;
+        }
+    }
+
+    /*
+    * finish the queue
+    */
+    finishQueue() {
+        if (this.queue) {
+            this.queue.finish();
+        }
+    }
+
+    /*
+    * Set context, GPU preferred
+    * Only used if the default device as set in the constructor isn't correct
+    */
+    setGPUcontext(): DeviceContext {
+        return this.setDeviceContext([WEBCL.DeviceTypeBits.DEVICE_TYPE_GPU, WEBCL.DeviceTypeBits.DEVICE_TYPE_CPU]);
+    }
+
+    /*
+    * Set context, CPU preferred
+    * Only used if the default device as set in the constructor isn't correct
+    */
+    setCPUcontext(): DeviceContext {
+        return this.setDeviceContext([WEBCL.DeviceTypeBits.DEVICE_TYPE_CPU, WEBCL.DeviceTypeBits.DEVICE_TYPE_GPU]);
+    }
+
+    /**
+    * release the current context
+    */
+    releaseContext() {
+        if (this.devContext != undefined) {
+            this.devContext.context.releaseAll;
+            this.devContext = undefined;
+            this.queue = undefined;
+        }
+    }
+
+    createProgramFromElement(htmlID: string, options: string = undefined) {
+        var element: JQuery = jQuery("#" + htmlID);                  //x_Utilities.JQueryUtils.tryJQuery(() => jQuery("#" + htmlID));      // get the kernel code item
+        this.createProgram(element.text(), options);
+    }
+
+    createProgram(code: string, options: string = undefined) {
+        this.programCode = code;
+        this.program = this.devContext.context.createProgram(this.programCode);
+        this.program.build([this.devContext.device], options);
+    }
+
+    createKernelFromString(programSource: string, kernelName: string, options: string = undefined): Kernel {
+        this.createProgram(programSource, options);
+        return this.createKernel(kernelName);
+    }
+
+    createKernelFromElement(htmlID: string, kernelName: string, options: string = undefined) : Kernel {
+        this.createProgramFromElement(htmlID, options);
+        return this.createKernel(kernelName);
+    }
+
+    createKernel(kernelName: string): Kernel {
+        var kernel: WEBCL.WebCLKernel = this.program.createKernel(kernelName);      // create the kernel
+        var info: KernelWorkGroupInfo = new KernelWorkGroupInfo(kernel, this.devContext.device);        // get the info about it's workgroup
+        return new Kernel(this, kernelName, kernel, info);       // create and return the kernel holder
+    }
+
+    executeKernel(kernel: Kernel) {
+        kernel.queueBuffersAndExecute ();
+    }
+
+    createBufferArg(hostBuffer: KernelArgArrayBufferView, cpu2gpu: boolean, gpu2cpu: boolean): ArgCLBuffer {
+        return new ArgCLBuffer(this, hostBuffer, cpu2gpu, gpu2cpu);
+    }
+
+
+}
+

--- a/webcl/webcl.d.ts
+++ b/webcl/webcl.d.ts
@@ -1,0 +1,706 @@
+// Type definitions for WebCL 1.0
+// Project: https://www.khronos.org/registry/webcl/specs/1.0.0/
+// Definitions by: Ralph Brown <https://github.com/NCARalph>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+// Version 1.3 - Changed enums to static enums for TS 1.5
+// Version 1.2 - Fixed some more bugs, added WebCLEvent
+// Version 1.1 - Minor fixes to get more enums in place and fix some argument interface types
+// Version 1.0 - Initial version
+
+interface Window {
+    webcl: WEBCL.WebCL;
+}
+
+declare var WebCLEvent: { new (): WEBCL.WebCLEvent; };
+
+declare module WEBCL {
+    // 3.6.1
+    interface WebCLBuffer extends WebCLMemoryObject {
+        createSubBuffer(memFlags: MemFlagsBits, origin: number, sizeInBytes: number): WebCLBuffer;
+    }
+
+    //2.5
+    interface WebCLCallback { (event: WebCLEvent): void }
+
+
+    // 3.5
+    interface WebCLCommandQueue {
+
+        ////////////////////////////////////////////////////////////////////////////
+        //
+        // Copying: Buffer <-> Buffer, Image <-> Image, Buffer <-> Image
+        //
+
+        enqueueCopyBuffer(
+            srcBuffer: WebCLBuffer,
+            dstBuffer: WebCLBuffer,
+            srcOffset: number,
+            dstOffset: number,
+            numBytes: number,
+            eventWaitList?: WebCLEvent[],
+            event?: WebCLEvent): void;
+
+        enqueueCopyBufferRect(
+            srcBuffer: WebCLBuffer,
+            dstBuffer: WebCLBuffer,
+            srcOrigin: number[],
+            dstOrigin: number[],
+            region: number[],
+            srcRowPitch: number,
+            srcSlicePitch: number,
+            dstRowPitch: number,
+            dstSlicePitch: number,
+            eventWaitList?: WebCLEvent[],
+            event?: WebCLEvent): void;
+
+        enqueueCopyImage(
+            srcImage: WebCLImage,
+            dstImage: WebCLImage,
+            srcOrigin: number[],
+            dstOrigin: number[],
+            region: number[],
+            eventWaitList?: WebCLEvent[],
+            event?: WebCLEvent): void;
+
+        enqueueCopyImageToBuffer(
+            srcImage: WebCLImage,
+            dstBuffer: WebCLBuffer,
+            srcOrigin: number[],
+            srcRegion: number[],
+            dstOffset: number,
+            eventWaitList?: WebCLEvent[],
+            event?: WebCLEvent): void;
+
+        enqueueCopyBufferToImage(
+            srcBuffer: WebCLBuffer,
+            dstImage: WebCLImage,
+            srcOffset: number,
+            dstOrigin: number[],
+            dstRegion: number[],
+            eventWaitList?: WebCLEvent[],
+            event?: WebCLEvent): void;
+
+        ////////////////////////////////////////////////////////////////////////////
+        //
+        // Reading: Buffer -> Host, Image -> Host
+        //
+
+        enqueueReadBuffer(
+            buffer: WebCLBuffer,
+            blockingRead: boolean,
+            bufferOffset: number,
+            numBytes: number,
+            hostPtr: ArrayBufferView,
+            eventWaitList?: WebCLEvent[],
+            event?: WebCLEvent): void;
+
+        enqueueReadBufferRect(
+            buffer: WebCLBuffer,
+            blockingRead: boolean,
+            bufferOrigin: number[],
+            hostOrigin: number[],
+            region: number[],
+            bufferRowPitch: number,
+            bufferSlicePitch: number,
+            hostRowPitch: number,
+            hostSlicePitch: number,
+            hostPtr: ArrayBufferView,
+            eventWaitList?: WebCLEvent[],
+            event?: WebCLEvent): void;
+
+        enqueueReadImage(
+            image: WebCLImage,
+            blockingRead: boolean,
+            origin: number[],
+            region: number[],
+            hostRowPitch: number,
+            hostPtr: ArrayBufferView,
+            eventWaitList?: WebCLEvent[],
+            event?: WebCLEvent): void;
+
+        ////////////////////////////////////////////////////////////////////////////
+        //
+        // Writing: Host -> Buffer, Host -> Image
+        //
+
+        enqueueWriteBuffer(
+            buffer: WebCLBuffer,
+            blockingWrite: boolean,
+            bufferOffset: number,
+            numBytes: number,
+            hostPtr: ArrayBufferView,
+            eventWaitList?: WebCLEvent[],
+            event?: WebCLEvent): void;
+
+        enqueueWriteBufferRect(
+            buffer: WebCLBuffer,
+            blockingWrite: boolean,
+            bufferOrigin: number[],
+            hostOrigin: number[],
+            region: number[],
+            bufferRowPitch: number,
+            bufferSlicePitch: number,
+            hostRowPitch: number,
+            hostSlicePitch: number,
+            hostPtr: ArrayBufferView,
+            eventWaitList?: WebCLEvent[],
+            event?: WebCLEvent): void;
+
+        enqueueWriteImage(
+            image: WebCLImage,
+            blockingWrite: boolean,
+            origin: number[],
+            region: number[],
+            hostRowPitch: number,
+            hostPtr: ArrayBufferView,
+            eventWaitList?: WebCLEvent[],
+            event?: WebCLEvent): void;
+
+        ////////////////////////////////////////////////////////////////////////////
+        //
+        // Executing kernels
+        //
+
+        enqueueNDRangeKernel(
+            kernel: WebCLKernel,
+            workDim: number,
+            globalWorkOffset: number[],
+            globalWorkSize: number[],
+            localWorkSize?: number[],
+            eventWaitList?: WebCLEvent[],
+            event?: WebCLEvent): void;
+
+        ////////////////////////////////////////////////////////////////////////////
+        //
+        // Synchronization
+        //
+
+        enqueueMarker(event: WebCLEvent): void;
+
+        enqueueBarrier(): void;
+
+        enqueueWaitForEvents(eventWaitList: WebCLEvent[]): void;
+
+        finish(whenFinished?: WebCLCallback): void;
+
+        flush(): void;
+
+        ////////////////////////////////////////////////////////////////////////////
+        //
+        // Querying command queue information
+        //
+
+        getInfo(name: ContextProperties): any;
+
+        release(): void;
+    }
+
+    //3.4
+    interface WebCLContext {
+
+        createBuffer(memFlags: MemFlagsBits, sizeInBytes: number, hostPtr?: ArrayBufferView): WebCLBuffer;
+
+        createCommandQueue(device: WebCLDevice, properties?: CommandQueueProperties): WebCLCommandQueue;
+
+        createImage(memFlags: MemFlagsBits,
+            descriptor: WebCLImageDescriptor,
+            hostPtr?: ArrayBufferView): WebCLImage;
+
+        createProgram(source: string): WebCLProgram;
+
+        createSampler(normalizedCoords: number,
+            addressingMode: AddressingMode,
+            filterMode: FilterMode): WebCLSampler;
+
+        createUserEvent(): WebCLUserEvent;
+
+        getInfo(name: ContextInfo): any;
+
+        getSupportedImageFormats(memFlags?: MemFlagsBits): WebCLImageDescriptor[];
+
+        release(): void;
+
+        releaseAll(): void;
+    }
+
+    // 3.3
+    interface WebCLDevice {
+        getInfo(name: DeviceInfo): any;
+        getSupportedExtensions(): string[];
+        enableExtension(extensionName: string): boolean;
+    }
+
+    // 3.10
+    interface WebCLEvent {
+        getInfo(name: EventInfo): any;
+        getProfilingInfo(name: ProfilingInfo): number;
+        setCallback(commandExecCallbackType: CommandExecutionStatus, notify: WebCLCallback): void;
+        release(): void;
+    }
+
+    interface WebCLException extends DOMException {
+        name: string;              // A string representation of the numeric error code, e.g. "INVALID_VALUE"
+        message: string;         // An implementation-specific description of what caused the exception
+    }
+
+    // 3.6.2
+    interface WebCLImage extends WebCLMemoryObject {
+        getInfo(): WebCLImageDescriptor;
+    }
+
+    // 3.4.1
+    interface WebCLImageDescriptor {
+        channelOrder: ChannelOrder;
+        channelType: ChannelType;
+        width: number;
+        height: number;
+        rowPitch: number;
+    }
+
+    // 3.9
+    interface WebCLKernel {
+        getInfo(name: KernelInfo): any;
+        getWorkGroupInfo(device: WebCLDevice, name: KernelWorkGroupInfo): any;
+        getArgInfo(index: number): WebCLKernelArgInfo;
+        setArg(index: number, buffer: WebCLBuffer): void;
+        setArg(index: number, image: WebCLImage): void;
+        setArg(index: number, value: WebCLSampler): void;
+        setArg(index: number, value: ArrayBufferView): void;
+        release(): void;
+    }
+
+    // 3.9.1
+    interface WebCLKernelArgInfo {
+        name: string;
+        typeName: string;         // 'char', 'float', 'uint4', 'image2d_t', 'sampler_t', etc.
+        addressQualifier: string; // 'global', 'local', 'constant', or 'private'
+        accessQualifier: string;  // 'read_only', 'write_only', or 'none'
+    }
+
+    // 3.6
+    interface WebCLMemoryObject {
+        getInfo(name: MemInfo): any;
+        release(): void;
+    }
+
+    // 3.2
+    interface WebCLPlatform {
+        getInfo(name: PlatformInfo): any;
+        getDevices(deviceType?: DeviceTypeBits): WebCLDevice[];
+        getSupportedExtensions(): string[];
+        enableExtension(extensionName: string): boolean;
+    }
+
+    //3.8
+    interface WebCLProgram {
+        getInfo(name: ProgramInfo): any;
+
+        getBuildInfo(device: WebCLDevice, name: ProgramBuildInfo): any;
+
+        build(devices?: WebCLDevice[],
+            options?: string,
+            whenFinished?: WebCLCallback): void;
+
+        createKernel(kernelName: string): WebCLKernel;
+
+        createKernelsInProgram(): WebCLKernel[];
+
+        release(): void;
+    }
+
+    // 3.7
+    interface WebCLSampler {
+        getInfo(name: SamplerInfo): any;
+        release(): void;
+    }
+
+    // 3.10.1
+    interface WebCLUserEvent extends WebCLEvent {
+        setStatus(executionStatus: CommandExecutionStatus): void;
+    }
+
+    /* Error Codes */
+    const enum ErrorCodes {
+        SUCCESS = 0,
+        DEVICE_NOT_FOUND = -1,
+        DEVICE_NOT_AVAILABLE = -2,
+        COMPILER_NOT_AVAILABLE = -3,
+        MEM_OBJECT_ALLOCATION_FAILURE = -4,
+        OUT_OF_RESOURCES = -5,
+        OUT_OF_HOST_MEMORY = -6,
+        PROFILING_INFO_NOT_AVAILABLE = -7,
+        MEM_COPY_OVERLAP = -8,
+        IMAGE_FORMAT_MISMATCH = -9,
+        IMAGE_FORMAT_NOT_SUPPORTED = -10,
+        BUILD_PROGRAM_FAILURE = -11,
+        MAP_FAILURE = -12,
+        MISALIGNED_SUB_BUFFER_OFFSET = -13,
+        EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST = -14,
+        INVALID_VALUE = -30,
+        INVALID_DEVICE_TYPE = -31,
+        INVALID_PLATFORM = -32,
+        INVALID_DEVICE = -33,
+        INVALID_CONTEXT = -34,
+        INVALID_QUEUE_PROPERTIES = -35,
+        INVALID_COMMAND_QUEUE = -36,
+        INVALID_HOST_PTR = -37,
+        INVALID_MEM_OBJECT = -38,
+        INVALID_IMAGE_FORMAT_DESCRIPTOR = -39,
+        INVALID_IMAGE_SIZE = -40,
+        INVALID_SAMPLER = -41,
+        INVALID_BINARY = -42,
+        INVALID_BUILD_OPTIONS = -43,
+        INVALID_PROGRAM = -44,
+        INVALID_PROGRAM_EXECUTABLE = -45,
+        INVALID_KERNEL_NAME = -46,
+        INVALID_KERNEL_DEFINITION = -47,
+        INVALID_KERNEL = -48,
+        INVALID_ARG_INDEX = -49,
+        INVALID_ARG_VALUE = -50,
+        INVALID_ARG_SIZE = -51,
+        INVALID_KERNEL_ARGS = -52,
+        INVALID_WORK_DIMENSION = -53,
+        INVALID_WORK_GROUP_SIZE = -54,
+        INVALID_WORK_ITEM_SIZE = -55,
+        INVALID_GLOBAL_OFFSET = -56,
+        INVALID_EVENT_WAIT_LIST = -57,
+        INVALID_EVENT = -58,
+        INVALID_OPERATION = -59,
+        //INVALID_GL_OBJECT                         = -60, // moved to extension
+        INVALID_BUFFER_SIZE = -61,
+        //INVALID_MIP_LEVEL                         = -62, // moved to extension
+        INVALID_GLOBAL_WORK_SIZE = -63,
+        INVALID_PROPERTY = -64,
+    }
+
+    /* cl_bool */
+    const enum Bool {
+        FALSE = 0,
+        TRUE = 1,
+    }
+
+    /* cl_platforinfo */
+    const enum PlatformInfo {
+        PLATFORM_PROFILE = 0x0900,
+        PLATFORM_VERSION = 0x0901,
+        PLATFORM_NAME = 0x0902,
+        PLATFORM_VENDOR = 0x0903,
+        PLATFORM_EXTENSIONS = 0x0904,
+    }
+    /* cl_device_type - bitfield */
+    const enum DeviceTypeBits {
+        DEVICE_TYPE_DEFAULT = 0x1,
+        DEVICE_TYPE_CPU = 0x2,
+        DEVICE_TYPE_GPU = 0x4,
+        DEVICE_TYPE_ACCELERATOR = 0x8,
+        DEVICE_TYPE_ALL = 0xFFFFFFFF,
+    }
+    /* cl_device_info */
+    const enum DeviceInfo {
+        DEVICE_TYPE = 0x1000,
+        DEVICE_VENDOR_ID = 0x1001,
+        DEVICE_MAX_COMPUTE_UNITS = 0x1002,
+        DEVICE_MAX_WORK_ITEM_DIMENSIONS = 0x1003,
+        DEVICE_MAX_WORK_GROUP_SIZE = 0x1004,
+        DEVICE_MAX_WORK_ITEM_SIZES = 0x1005,
+        DEVICE_PREFERRED_VECTOR_WIDTH_CHAR = 0x1006,
+        DEVICE_PREFERRED_VECTOR_WIDTH_SHORT = 0x1007,
+        DEVICE_PREFERRED_VECTOR_WIDTH_INT = 0x1008,
+        DEVICE_PREFERRED_VECTOR_WIDTH_LONG = 0x1009,
+        DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT = 0x100A,
+        //DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE      = 0x100B, // moved to extension
+        DEVICE_MAX_CLOCK_FREQUENCY = 0x100C,
+        DEVICE_ADDRESS_BITS = 0x100D,
+        DEVICE_MAX_READ_IMAGE_ARGS = 0x100E,
+        DEVICE_MAX_WRITE_IMAGE_ARGS = 0x100F,
+        DEVICE_MAX_MEM_ALLOC_SIZE = 0x1010,
+        DEVICE_IMAGE2D_MAX_WIDTH = 0x1011,
+        DEVICE_IMAGE2D_MAX_HEIGHT = 0x1012,
+        DEVICE_IMAGE3D_MAX_WIDTH = 0x1013,
+        DEVICE_IMAGE3D_MAX_HEIGHT = 0x1014,
+        DEVICE_IMAGE3D_MAX_DEPTH = 0x1015,
+        DEVICE_IMAGE_SUPPORT = 0x1016,
+        DEVICE_MAX_PARAMETER_SIZE = 0x1017,
+        DEVICE_MAX_SAMPLERS = 0x1018,
+        DEVICE_MEM_BASE_ADDR_ALIGN = 0x1019,
+        //DEVICE_MIN_DATA_TYPE_ALIGN_SIZE           = 0x101A, // removed, deprecated in Open1.2
+        DEVICE_SINGLE_FP_CONFIG = 0x101B,
+        DEVICE_GLOBAL_MEM_CACHE_TYPE = 0x101C,
+        DEVICE_GLOBAL_MEM_CACHELINE_SIZE = 0x101D,
+        DEVICE_GLOBAL_MEM_CACHE_SIZE = 0x101E,
+        DEVICE_GLOBAL_MEM_SIZE = 0x101F,
+        DEVICE_MAX_CONSTANT_BUFFER_SIZE = 0x1020,
+        DEVICE_MAX_CONSTANT_ARGS = 0x1021,
+        DEVICE_LOCAL_MEM_TYPE = 0x1022,
+        DEVICE_LOCAL_MEM_SIZE = 0x1023,
+        DEVICE_ERROR_CORRECTION_SUPPORT = 0x1024,
+        DEVICE_PROFILING_TIMER_RESOLUTION = 0x1025,
+        DEVICE_ENDIAN_LITTLE = 0x1026,
+        DEVICE_AVAILABLE = 0x1027,
+        DEVICE_COMPILER_AVAILABLE = 0x1028,
+        DEVICE_EXECUTION_CAPABILITIES = 0x1029,
+        DEVICE_QUEUE_PROPERTIES = 0x102A,
+        DEVICE_NAME = 0x102B,
+        DEVICE_VENDOR = 0x102C,
+        DRIVER_VERSION = 0x102D,
+        DEVICE_PROFILE = 0x102E,
+        DEVICE_VERSION = 0x102F,
+        DEVICE_EXTENSIONS = 0x1030,
+        DEVICE_PLATFORM = 0x1031,
+        //DEVICE_DOUBLE_FP_CONFIG                   = 0x1032, // moved to extension
+        //DEVICE_HALF_FP_CONFIG                     = 0x1033, // moved to extension
+        //DEVICE_PREFERRED_VECTOR_WIDTH_HALF        = 0x1034, // moved to extension
+        DEVICE_HOST_UNIFIED_MEMORY = 0x1035,
+        DEVICE_NATIVE_VECTOR_WIDTH_CHAR = 0x1036,
+        DEVICE_NATIVE_VECTOR_WIDTH_SHORT = 0x1037,
+        DEVICE_NATIVE_VECTOR_WIDTH_INT = 0x1038,
+        DEVICE_NATIVE_VECTOR_WIDTH_LONG = 0x1039,
+        DEVICE_NATIVE_VECTOR_WIDTH_FLOAT = 0x103A,
+        //DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE         = 0x103B, // moved to extension
+        //DEVICE_NATIVE_VECTOR_WIDTH_HALF           = 0x103C, // moved to extension
+        DEVICE_OPENCL_C_VERSION = 0x103D,
+    }
+    /* cl_device_fp_config - bitfield */
+    const enum DeviceFPConfigBits {
+        FP_DENORM = 0x1,
+        FP_INF_NAN = 0x2,
+        FP_ROUND_TO_NEAREST = 0x4,
+        FP_ROUND_TO_ZERO = 0x8,
+        FP_ROUND_TO_INF = 0x10,
+        FP_FMA = 0x20,
+        FP_SOFT_FLOAT = 0x40,
+    }
+    /* cl_device_MEM_CACHE_type */
+    const enum DeviceMemCacheType {
+        NONE = 0x0,
+        READ_ONLY_CACHE = 0x1,
+        READ_WRITE_CACHE = 0x2,
+    }
+    /* cl_device_local_mem_type */
+    const enum DeviceLocalMemType {
+        LOCAL = 0x1,
+        GLOBAL = 0x2,
+    }
+    /* cl_device_exec_capabilities - bitfield */
+    const enum DeviceExecCapabilitiesBits {
+        EXEC_KERNEL = 0x1,
+        //EXEC_NATIVE_KERNEL                        = 0x2, // disallowed
+    }
+    /* cl_command_queue_properties - bitfield */
+    const enum CommandQueueProperties {
+        QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE = 0x1,
+        QUEUE_PROFILING_ENABLE = 0x2,
+    }
+    /* cl_context_info  */
+    const enum ContextInfo {
+        //CONTEXT_REFERENCE_COUNT                   = 0x1080, // disallowed
+        CONTEXT_DEVICES = 0x1081,
+        //CONTEXT_PROPERTIES                        = 0x1082, // disallowed, no context properties in WebCONTEXT_NUM_DEVICES = 0x1083,
+    }
+    /* cl_context_properties */
+    const enum ContextProperties {
+        //CONTEXT_PLATFORM                          = 0x1084, // disallowed, no context properties in Web /* cl_command_queue_info */
+        QUEUE_CONTEXT = 0x1090,
+        QUEUE_DEVICE = 0x1091,
+        //QUEUE_REFERENCE_COUNT                     = 0x1092, // disallowed
+        QUEUE_PROPERTIES = 0x1093,
+    }
+    /* cl_mem_flags - bitfield */
+    const enum MemFlagsBits {
+        MEM_READ_WRITE = 0x1,
+        MEM_WRITE_ONLY = 0x2,
+        MEM_READ_ONLY = 0x4,
+    }
+    /* cl_channel_order */
+    const enum ChannelOrder {
+        R = 0x10B0,
+        A = 0x10B1,
+        RG = 0x10B2,
+        RA = 0x10B3,
+        RGB = 0x10B4,
+        RGBA = 0x10B5,
+        BGRA = 0x10B6,
+        ARGB = 0x10B7,
+        INTENSITY = 0x10B8,
+        LUMINANCE = 0x10B9,
+        Rx = 0x10BA,
+        RGx = 0x10BB,
+        RGBx = 0x10BC,
+    }
+    /* cl_channel_type */
+    const enum ChannelType {
+        SNORM_INT8 = 0x10D0,
+        SNORM_INT16 = 0x10D1,
+        UNORM_INT8 = 0x10D2,
+        UNORM_INT16 = 0x10D3,
+        UNORM_SHORT_565 = 0x10D4,
+        UNORM_SHORT_555 = 0x10D5,
+        UNORM_INT_101010 = 0x10D6,
+        SIGNED_INT8 = 0x10D7,
+        SIGNED_INT16 = 0x10D8,
+        SIGNED_INT32 = 0x10D9,
+        UNSIGNED_INT8 = 0x10DA,
+        UNSIGNED_INT16 = 0x10DB,
+        UNSIGNED_INT32 = 0x10DC,
+        HALF_FLOAT = 0x10DD,
+        FLOAT = 0x10DE,
+    }
+    /* cl_meobject_type */
+    const enum MemObjectType {
+        MEM_OBJECT_BUFFER = 0x10F0,
+        MEM_OBJECT_IMAGE2D = 0x10F1,
+        MEM_OBJECT_IMAGE3D = 0x10F2,
+    }
+    /* cl_meinfo */
+    const enum MemInfo {
+        MEM_TYPE = 0x1100,
+        MEM_FLAGS = 0x1101,
+        MEM_SIZE = 0x1102,
+        //MEM_HOST_PTR                              = 0x1103, // disallowed
+        //MEM_MAP_COUNT                             = 0x1104, // disallowed
+        //MEM_REFERENCE_COUNT                       = 0x1105, // disallowed
+        MEM_CONTEXT = 0x1106,
+        MEM_ASSOCIATED_MEMOBJECT = 0x1107,
+        MEM_OFFSET = 0x1108,
+    }
+    /* cl_image_info */
+    const enum ImageInfo {
+        IMAGE_FORMAT = 0x1110,
+        IMAGE_ELEMENT_SIZE = 0x1111,
+        IMAGE_ROW_PITCH = 0x1112,
+        IMAGE_WIDTH = 0x1114,
+        IMAGE_HEIGHT = 0x1115,
+    }
+    /* cl_addressing_mode */
+    const enum AddressingMode {
+        //ADDRESS_NONE                              = 0x1130, // disallowed
+        ADDRESS_CLAMP_TO_EDGE = 0x1131,
+        ADDRESS_CLAMP = 0x1132,
+        ADDRESS_REPEAT = 0x1133,
+        ADDRESS_MIRRORED_REPEAT = 0x1134,
+    }
+    /* cl_filter_mode */
+    const enum FilterMode {
+        FILTER_NEAREST = 0x1140,
+        FILTER_LINEAR = 0x1141,
+    }
+    /* cl_sampler_info */
+    const enum SamplerInfo {
+        //SAMPLER_REFERENCE_COUNT                   = 0x1150, // disallowed
+        SAMPLER_CONTEXT = 0x1151,
+        SAMPLER_NORMALIZED_COORDS = 0x1152,
+        SAMPLER_ADDRESSING_MODE = 0x1153,
+        SAMPLER_FILTER_MODE = 0x1154,
+    }
+    /* cl_map_flags - bitfield */
+    //MAP_READ                                  = 0x1, // disallowed
+    //MAP_WRITE                                 = 0x2, // disallowed
+
+    /* cl_prograinfo */
+    const enum ProgramInfo {
+        //PROGRAM_REFERENCE_COUNT                   = 0x1160, // disallowed
+        PROGRAM_CONTEXT = 0x1161,
+        PROGRAM_NUM_DEVICES = 0x1162,
+        PROGRAM_DEVICES = 0x1163,
+        PROGRAM_SOURCE = 0x1164,
+        //PROGRAM_BINARY_SIZES                      = 0x1165, // disallowed
+        //PROGRAM_BINARIES                          = 0x1166, // disallowed
+    }
+    /* cl_program_build_info */
+    const enum ProgramBuildInfo {
+        PROGRAM_BUILD_STATUS = 0x1181,
+        PROGRAM_BUILD_OPTIONS = 0x1182,
+        PROGRAM_BUILD_LOG = 0x1183,
+    }
+    /* cl_build_status */
+    const enum BuildStatus {
+        BUILD_SUCCESS = 0,
+        BUILD_NONE = -1,
+        BUILD_ERROR = -2,
+        BUILD_IN_PROGRESS = -3,
+    }
+    /* cl_kernel_info */
+    const enum KernelInfo {
+        KERNEL_FUNCTION_NAME = 0x1190,
+        KERNEL_NUM_RGS = 0x1191,
+        //KERNEL_REFERENCE_COUNT                    = 0x1192, // disallowed
+        KERNEL_CONTEXT = 0x1193,
+        KERNEL_PROGRAM = 0x1194,
+    }
+    /* cl_kernel_work_group_info */
+    const enum KernelWorkGroupInfo {
+        KERNEL_WORK_GROUP_SIZE = 0x11B0,
+        KERNEL_COMPILE_WORK_GROUP_SIZE = 0x11B1,
+        KERNEL_LOCAL_MEM_SIZE = 0x11B2,
+        KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE = 0x11B3,
+        KERNEL_PRIVATE_MEM_SIZE = 0x11B4,
+    }
+    /* cl_event_info  */
+    const enum EventInfo {
+        EVENT_COMMAND_QUEUE = 0x11D0,
+        EVENT_COMMAND_TYPE = 0x11D1,
+        //EVENT_REFERENCE_COUNT                     = 0x11D2, // disallowed
+        EVENT_COMMAND_EXECUTION_STATUS = 0x11D3,
+        EVENT_CONTEXT = 0x11D4,
+    }
+    /* cl_command_type */
+    const enum CommandType {
+        COMMAND_NDRANGE_KERNEL = 0x11F0,
+        COMMAND_TASK = 0x11F1,
+        //COMMAND_NATIVE_KERNEL                     = 0x11F2, // disallowed
+        COMMAND_READ_BUFFER = 0x11F3,
+        COMMAND_WRITE_BUFFER = 0x11F4,
+        COMMAND_COPY_BUFFER = 0x11F5,
+        COMMAND_READ_IMAGE = 0x11F6,
+        COMMAND_WRITE_IMAGE = 0x11F7,
+        COMMAND_COPY_IMAGE = 0x11F8,
+        COMMAND_COPY_IMAGE_TO_BUFFER = 0x11F9,
+        COMMAND_COPY_BUFFER_TO_IMAGE = 0x11FA,
+        //COMMAND_MAP_BUFFER                        = 0x11FB, // disallowed
+        //COMMAND_MAP_IMAGE                         = 0x11FC, // disallowed
+        //COMMAND_UNMAP_MEM_OBJECT                  = 0x11FD, // disallowed
+        COMMAND_MARKER = 0x11FE,
+        //COMMAND_ACQUIRE_GL_OBJECTS                = 0x11FF, // moved to extension
+        //COMMAND_RELEASE_GL_OBJECTS                = 0x1200, // moved to extension
+        COMMAND_READ_BUFFER_RECT = 0x1201,
+        COMMAND_WRITE_BUFFER_RECT = 0x1202,
+        COMMAND_COPY_BUFFER_RECT = 0x1203,
+        COMMAND_USER = 0x1204,
+    }
+    /* command execution status */
+    const enum CommandExecutionStatus {
+        COMPLETE = 0x0,
+        RUNNING = 0x1,
+        SUBMITTED = 0x2,
+        QUEUED = 0x3,
+    }
+    /* cl_profiling_info  */
+    const enum ProfilingInfo {
+        PROFILING_COMMAND_QUEUED = 0x1280,
+        PROFILING_COMMAND_SUBMIT = 0x1281,
+        PROFILING_COMMAND_START = 0x1282,
+        PROFILING_COMMAND_END = 0x1283,
+    }
+
+    interface WebCL {
+        getPlatforms(): WebCLPlatform[];
+
+        createContext(deviceType?: DeviceTypeBits): WebCLContext;
+
+        createContext(platform: WebCLPlatform, deviceType?: DeviceTypeBits): WebCLContext;
+
+        createContext(device: WebCLDevice): WebCLContext;
+
+        createContext(devices: WebCLDevice[]): WebCLContext;
+
+        getSupportedExtensions(): string[];
+
+        enableExtension(extensionName: string): boolean;
+
+        waitForEvents(eventWaitList: WebCLEvent[],
+            whenFinished?: WebCLCallback): void;
+
+        releaseAll(): void;
+    }
+}


### PR DESCRIPTION
The full enum definitions let Intellisense work in Visual Studio, but the original variables are also still there so existing code doesn't break.

There were a couple of cases where variables were defined as enums but weren't, although, except for debugging, I'm not sure these are very significant.

Most of the arguments to the DataTexture constructor should be optional so I made them so.
