### PR TITLE
node: WritableStream.write() should use a union for Buffer|string

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -193,8 +193,7 @@ declare module NodeJS {
 
     export interface WritableStream extends EventEmitter {
         writable: boolean;
-        write(buffer: Buffer, cb?: Function): boolean;
-        write(str: string, cb?: Function): boolean;
+        write(buffer: Buffer|string, cb?: Function): boolean;
         write(str: string, encoding?: string, cb?: Function): boolean;
         end(): void;
         end(buffer: Buffer, cb?: Function): void;


### PR DESCRIPTION
I'm converting a node program I originally wrote in JS to TS, and
without this, the following pattern causes tsc to error out (tested
under 1.6):

```
let buf = current.read(); // current is a ReadableStream
if (buf !== null)
    output.write(buf);
```

With:

```
src/bin/cat.ts(28,17): error TS2345: Argument of type 'string | Buffer' is not assignable to parameter of type 'string'.
```
