### PR TITLE
decorateElement renamed to decorateInputElement

### DIFF
--- a/knockout.validation/knockout.validation.d.ts
+++ b/knockout.validation/knockout.validation.d.ts
@@ -17,7 +17,7 @@ interface KnockoutValidationConfiguration {
     insertMessages?: boolean;
     parseInputAttributes?: boolean;
     writeInputAttributes?: boolean;
-    decorateElement?: boolean;
+    decorateInputElement?: boolean;
     errorClass?: string;
     errorElementClass?: string;
     errorMessageClass?: string;


### PR DESCRIPTION
See: https://github.com/Knockout-Contrib/Knockout-Validation/wiki/Configuration which states that "Note that this was previously called decorateElement, and this config option was renamed 2013-11-21."
