### PR TITLE
Convert module "smoothie" to a namespace

### DIFF
--- a/smoothie/smoothie.d.ts
+++ b/smoothie/smoothie.d.ts
@@ -3,12 +3,7 @@
 // Definitions by: Drew Noakes <https://drewnoakes.com>, Mike H. Hawley <https://github.com/mikehhawley>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped/smoothie
 
-// NOTE this reference is here to make the DefinitelyTyped `npm test` suite pass and
-//      may be removed if you are using this module declaration in isolation from the
-//      rest of DefinitelyTyped.
-/// <reference path="../node/node.d.ts" />
-
-declare module "smoothie"
+declare module smoothie
 {
     export interface ITimeSeriesOptions
     {
@@ -189,4 +184,8 @@ declare module "smoothie"
 
         render(canvas?: HTMLCanvasElement, time?: number): void;
     }
+}
+
+declare module "smoothie" {
+    export = smoothie;
 }


### PR DESCRIPTION
Currently, "smoothie" is an external module (now called "module").
This commit converts this module to an internal module (now called
namespace), and exports the (external) module "smoothie". Smoothie
can therefore be used as an external module or as an internal module.

I also removed the dependency to ../node/node.d.ts because it seemed
useless. The comment said that it was there only for the DefinitelyTyped
'npm test', which now works without it.
