### PR TITLE
extending Error on ValidationError

### DIFF
--- a/joi/joi.d.ts
+++ b/joi/joi.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for joi v4.6.0
 // Project: https://github.com/spumko/joi
-// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Laurence Dougal Myers <https://github.com/laurence-myers>
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Laurence Dougal Myers <https://github.com/laurence-myers>, Christopher Glantschnig <https://github.com/cglantschnig>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 // TODO express type of Schema in a type-parameter (.default, .valid, .example etc)
@@ -120,7 +120,7 @@ declare module 'joi' {
 		cidr?: string
 	}
 
-	export interface ValidationError {
+	export interface ValidationError extends Error {
 		message: string;
 		details: ValidationErrorItem[];
 		simple(): string;


### PR DESCRIPTION
Extending the ValidationError vom joi with normal Error, so that it can be used with [Boom](https://github.com/hapijs/boom) (from the hapi ecosystem).

In Boom types you can find the following line:
`export function wrap(error: Error, statusCode?: number, message?: string): BoomError;`

Now you can write something like:

```
var result = Joi.validate(payload, schema);
if (result.error) {
     return Boom.wrap(result.error, 400);
 }
```
