### PR TITLE
Fix to IFilterPredicateFunc<T>

### DIFF
--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -941,10 +941,10 @@ function ngFilterTyping() {
     $filter("name")(items, "test");
     $filter("name")(items, {name: "test"});
     $filter("name")(items, (val, index, array) => {
-        return array;
+        return true;
     });
     $filter("name")(items, (val, index, array) => {
-        return array;
+        return true;
     }, (actual, expected) => {
         return actual == expected;
     });

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -794,7 +794,7 @@ declare module angular {
     }
     
     interface IFilterPredicateFunc<T> {
-        (value: T, index: number, array: T[]): T[];
+        (value: T, index: number, array: T[]): boolean;
     }
     
     interface IFilterComparatorFunc<T> {


### PR DESCRIPTION
From the angular docs (https://docs.angularjs.org/api/ng/filter/filter):

> function(value, index, array): A predicate function can be used to write arbitrary filters. The function is called for each element of the array, with the element, its index, and the entire array itself as arguments. The final result is an array of those elements that the predicate returned true for.

So the predicate function should return a boolean value instead of an array.
