### PR TITLE
Fixed angularjs promises then signature.

### DIFF
--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -387,9 +387,11 @@ module TestPromise {
 
     var tresult: TResult;
     var tresultPromise: ng.IPromise<TResult>;
+    var tresultHttpPromise: ng.IHttpPromise<TResult>;
     
     var tother: TOther;
     var totherPromise: ng.IPromise<TOther>;
+    var totherHttpPromise: ng.IHttpPromise<TOther>;
     
     var promise: angular.IPromise<TResult>;
 
@@ -404,6 +406,9 @@ module TestPromise {
     result = <angular.IPromise<TResult>>promise.then((result) => tresultPromise);
     result = <angular.IPromise<TResult>>promise.then((result) => tresultPromise, (any) => any);
     result = <angular.IPromise<TResult>>promise.then((result) => tresultPromise, (any) => any, (any) => any);
+    result = <angular.IPromise<ng.IHttpPromiseCallbackArg<TResult>>>promise.then((result) => tresultHttpPromise);
+    result = <angular.IPromise<ng.IHttpPromiseCallbackArg<TResult>>>promise.then((result) => tresultHttpPromise, (any) => any);
+    result = <angular.IPromise<ng.IHttpPromiseCallbackArg<TResult>>>promise.then((result) => tresultHttpPromise, (any) => any, (any) => any);
     
     result = <angular.IPromise<TOther>>promise.then((result) => tother);
     result = <angular.IPromise<TOther>>promise.then((result) => tother, (any) => any);
@@ -411,11 +416,18 @@ module TestPromise {
     result = <angular.IPromise<TOther>>promise.then((result) => totherPromise);
     result = <angular.IPromise<TOther>>promise.then((result) => totherPromise, (any) => any);
     result = <angular.IPromise<TOther>>promise.then((result) => totherPromise, (any) => any, (any) => any);
+    result = <angular.IPromise<ng.IHttpPromiseCallbackArg<TOther>>>promise.then((result) => totherHttpPromise);
+    result = <angular.IPromise<ng.IHttpPromiseCallbackArg<TOther>>>promise.then((result) => totherHttpPromise, (any) => any);
+    result = <angular.IPromise<ng.IHttpPromiseCallbackArg<TOther>>>promise.then((result) => totherHttpPromise, (any) => any, (any) => any);
     
     // promise.catch
     result = <angular.IPromise<any>>promise.catch((err) => any);
     result = <angular.IPromise<TResult>>promise.catch((err) => tresult);
+    result = <angular.IPromise<TResult>>promise.catch((err) => tresultPromise);
+    result = <angular.IPromise<ng.IHttpPromiseCallbackArg<TResult>>>promise.catch((err) => tresultHttpPromise);
     result = <angular.IPromise<TOther>>promise.catch((err) => tother);
+    result = <angular.IPromise<TOther>>promise.catch((err) => totherPromise);
+    result = <angular.IPromise<ng.IHttpPromiseCallbackArg<TOther>>>promise.catch((err) => totherHttpPromise);
 
     // promise.finally
     result = <angular.IPromise<TResult>>promise.finally(() => any);

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1067,12 +1067,12 @@ declare module angular {
          * The successCallBack may return IPromise<void> for when a $q.reject() needs to be returned
          * This method returns a new promise which is resolved or rejected via the return value of the successCallback, errorCallback. It also notifies via the return value of the notifyCallback method. The promise can not be resolved or rejected from the notifyCallback method.
          */
-        then<TResult>(successCallback: (promiseValue: T) => IHttpPromise<TResult>|IPromise<TResult>|TResult|IPromise<void>, errorCallback?: (reason: any) => any, notifyCallback?: (state: any) => any): IPromise<TResult>;
+        then<TResult>(successCallback: (promiseValue: T) => IPromise<TResult>|TResult, errorCallback?: (reason: any) => any, notifyCallback?: (state: any) => any): IPromise<TResult>;
 
         /**
          * Shorthand for promise.then(null, errorCallback)
          */
-        catch<TResult>(onRejected: (reason: any) => IHttpPromise<TResult>|IPromise<TResult>|TResult): IPromise<TResult>;
+        catch<TResult>(onRejected: (reason: any) => IPromise<TResult>|TResult): IPromise<TResult>;
 
         /**
          * Allows you to observe either the fulfillment or rejection of a promise, but to do so without modifying the final value. This is useful to release resources or do some clean-up that needs to be done whether the promise was rejected or resolved. See the full specification for more information.
@@ -1400,7 +1400,6 @@ declare module angular {
     interface IHttpPromise<T> extends IPromise<IHttpPromiseCallbackArg<T>> {
         success(callback: IHttpPromiseCallback<T>): IHttpPromise<T>;
         error(callback: IHttpPromiseCallback<any>): IHttpPromise<T>;
-        then<TResult>(successCallback: (response: IHttpPromiseCallbackArg<T>) => IPromise<TResult>|TResult, errorCallback?: (response: IHttpPromiseCallbackArg<any>) => any): IPromise<TResult>;
     }
 
     // See the jsdoc for transformData() at https://github.com/angular/angular.js/blob/master/src/ng/http.js#L228


### PR DESCRIPTION
Pull request #966 attempted to implement an overload to `angular.IPromise<T>.then(...)` to return `angular.IHttpPromise<T>` instances:
- a0b3d5f added an overload as follows:

``` ts
then<TResult>(successCallback: (promiseValue: T) => IHttpPromise<TResult>, errorCallback?: (reason: any) => any): IHttpPromise<TResult>;
```

However this change caused compilation errors.
- 8c6037d fixed this by changing the overload as follows:

``` ts
then<TResult>(successCallback: (promiseValue: T) => IHttpPromise<TResult>, errorCallback?: (reason: any) => any): IPromise<TResult>;
```

This change, effectively reversed the intent of the pull request.

When pull request #3488 introduced union types. This code started to fail in my **TypeScript 1.5.3** setup:

``` ts
var promise: angular.IPromise<string>;
var httpPromise: angular.IHttpPromise<number>;

var result = promise.then(result => {
    return httpPromise;
});
```

The returned error is:

```
Error   23  The type argument for type parameter 'TResult' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
  Type argument candidate 'IHttpPromiseCallbackArg<number>' is not a valid type argument because it is not a supertype of candidate 'number'.
```

`angular.IPromise<T>.then(...): angular.IHttpPromise<T>` never really got implemented, and shouldn't be (according to the deprecation notice in https://docs.angularjs.org/api/ng/service/$http#get).
