### PR TITLE
Add requirejs-domready

### DIFF
--- a/requirejs-domready/domready-tests.ts
+++ b/requirejs-domready/domready-tests.ts
@@ -1,0 +1,7 @@
+/// <reference path="domready.d.ts" />
+
+import domReady = require("domReady");
+
+domReady(() => {
+    return domReady.version;
+});

--- a/requirejs-domready/domready-tests.ts.tscparams
+++ b/requirejs-domready/domready-tests.ts.tscparams
@@ -1,0 +1,1 @@
+--noImplicitAny --target es5 --module amd

--- a/requirejs-domready/domready.d.ts
+++ b/requirejs-domready/domready.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for domReady 2.0.1
+// Project: https://github.com/requirejs/domReady
+// Definitions by: Nobuhiro Nakamura <https://github.com/lefb766>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module "domReady" {
+    interface DomReady {
+        (callback: () => any): DomReady;
+        version: string;
+    }
+
+    let domReady: DomReady;
+
+    export = domReady;
+}


### PR DESCRIPTION
Wrote definitions for domReady (one from RequireJS).

Here are couple of explanations:
- I prefixed the directory name with `requirejs-` because the library is not available on npm and a package named `domready` already exists for another impl. The file names are kept in short forms for simplicity.
- I omitted the definition for `load` in the library. This method is required by the plugin mechanism of RequireJS (see http://requirejs.org/docs/plugins.html for details) and is suggested to be consumed only by RequireJS.
