### PR TITLE
Request definition and ResponseInit type corrections

### DIFF
--- a/whatwg-fetch/whatwg-fetch-tests.ts
+++ b/whatwg-fetch/whatwg-fetch-tests.ts
@@ -41,7 +41,7 @@ function test_fetchUrlWithRequestObject() {
 
 function handlePromise(promise: Promise<Response>) {
 	promise.then((response) => {
-		if (response.type === 'basis') {
+		if (response.type === 'basic') {
 			// for test only
 		}
 		return response.text();

--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference path="../es6-promise/es6-promise.d.ts" />
 
-declare class Request {
+declare class Request extends Body {
 	constructor(input: string|Request, init?:RequestInit);
 	method: string;
 	url: string;
@@ -69,10 +69,10 @@ declare class Response extends Body {
 
 declare enum ResponseType { "basic", "cors", "default", "error", "opaque" }
 
-declare class ResponseInit {
+interface ResponseInit {
 	status: number;
-	statusText: string;
-	headers: HeaderInit;
+	statusText?: string;
+	headers?: HeaderInit;
 }
 
 declare type HeaderInit = Headers|Array<string>;


### PR DESCRIPTION
`Request` needs to extend `Body` class - reference can be found [here](https://developer.mozilla.org/en-US/docs/Web/API/Request) and [here as well](https://developer.mozilla.org/en-US/docs/Web/API/Body)
`ResponseInit` needs to have `statusText` and `headers` as optional properties as found in the example [here](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response)
corrected typo in test case from "basis" to "basic"
@ryan-codingintrigue any feedback on the changes would be appreciated
