### PR TITLE
node: Update fs.create(Read|Write)Stream definition

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1310,21 +1310,15 @@ declare module "fs" {
     export function createReadStream(path: string, options?: {
         flags?: string;
         encoding?: string;
-        fd?: string;
+        fd?: number;
         mode?: number;
-        bufferSize?: number;
-    }): ReadStream;
-    export function createReadStream(path: string, options?: {
-        flags?: string;
-        encoding?: string;
-        fd?: string;
-        mode?: string;
-        bufferSize?: number;
+        autoClose?: boolean;
     }): ReadStream;
     export function createWriteStream(path: string, options?: {
         flags?: string;
         encoding?: string;
-        string?: string;
+        fd?: number;
+        mode?: number;
     }): WriteStream;
 }
 


### PR DESCRIPTION
This commit includes the following changes:
- Remove duplicate type definition for `fs.createReadStream`.
- Update `options` object typings for both functions to match the keys
  and types specified in the Node.js v0.12.x documentation.

Links to the aforementioned functions are provided below for reference:
- http://nodejs.org/docs/latest-v0.12.x/api/fs.html#fs_fs_createreadstream_path_options
- http://nodejs.org/docs/latest-v0.12.x/api/fs.html#fs_fs_createwritestream_path_options
