### PR TITLE
Improves upon WebGL definitions in lib.d.ts

### DIFF
--- a/webgl/webgl-branding-tests.ts
+++ b/webgl/webgl-branding-tests.ts
@@ -1,0 +1,1 @@
+/// <reference path="webgl-branding.d.ts" />

--- a/webgl/webgl-branding-tests.ts
+++ b/webgl/webgl-branding-tests.ts
@@ -1,1 +1,36 @@
 /// <reference path="webgl-branding.d.ts" />
+
+// This test uses overload resolution rules to ensure that the types are considered 'different' by TypeScript.
+// If you remove the above header, the usages of _1, _2, etc will cause errors since all the types are equivalent. 
+
+var overloadCheck: {
+  (o: WebGLBuffer): { _2: any }
+  (o: WebGLFramebuffer): { _3: any }
+  (o: WebGLProgram): { _4: any }
+  (o: WebGLRenderbuffer): { _5: any }
+  (o: WebGLShader): { _6: any }
+  (o: WebGLTexture): { _7: any }
+  (o: WebGLUniformLocation): { _8: any }
+  
+  (o: WebGLQuery): { _9: any }
+  (o: WebGLSampler): { _10: any }
+  (o: WebGLSync): { _11: any }
+  (o: WebGLTransformFeedback): { _12: any }
+  (o: WebGLVertexArrayObject): { _13: any }
+  
+  (o: WebGLObject): { _1: any }
+}
+
+overloadCheck(null as WebGLObject)._1;
+overloadCheck(null as WebGLBuffer)._2;
+overloadCheck(null as WebGLFramebuffer)._3;
+overloadCheck(null as WebGLProgram)._4;
+overloadCheck(null as WebGLRenderbuffer)._5;
+overloadCheck(null as WebGLShader)._6;
+overloadCheck(null as WebGLTexture)._7;
+overloadCheck(null as WebGLUniformLocation)._8;
+overloadCheck(null as WebGLQuery)._9;
+overloadCheck(null as WebGLSampler)._10;
+overloadCheck(null as WebGLSync)._11;
+overloadCheck(null as WebGLTransformFeedback)._12;
+overloadCheck(null as WebGLVertexArrayObject)._13;

--- a/webgl/webgl-branding.d.ts
+++ b/webgl/webgl-branding.d.ts
@@ -2,3 +2,20 @@
 // Project: http://webgl.org/
 // Definitions by: Shane S. Anderson <https://github.com/ander-nz/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped/webgl
+
+// WebGL types
+interface WebGLObject { __WebGLObject: void; }
+interface WebGLBuffer { __WebGLBuffer: void; }
+interface WebGLFramebuffer { __WebGLFramebuffer: void; }
+interface WebGLProgram { __WebGLProgram: void; }
+interface WebGLRenderbuffer { __WebGLRenderbuffer: void; }
+interface WebGLShader { __WebGLShader: void; }
+interface WebGLTexture { __WebGLTexture: void; }
+interface WebGLUniformLocation { __WebGLUniformLocation: void; }
+
+// WebGL2 types
+interface WebGLQuery { __WebGLQuery: void; }
+interface WebGLSampler { __WebGLSampler: void; }
+interface WebGLSync { __WebGLSync: void; }
+interface WebGLTransformFeedback { __WebGLTransformFeedback: void; }
+interface WebGLVertexArrayObject { __WebGLVertexArrayObject: void; }

--- a/webgl/webgl-branding.d.ts
+++ b/webgl/webgl-branding.d.ts
@@ -1,0 +1,4 @@
+// Type definitions for WebGL
+// Project: http://webgl.org/
+// Definitions by: Shane S. Anderson <https://github.com/ander-nz/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped/webgl

--- a/webgl/webgl-branding.d.ts
+++ b/webgl/webgl-branding.d.ts
@@ -3,6 +3,9 @@
 // Definitions by: Shane S. Anderson <https://github.com/ander-nz/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped/webgl
 
+// This file adds 'branding' to the WebGL types to ensure that accidental assignments aren't made.
+// For example, var program: WebGLProgram = gl.createShader(...);
+
 // WebGL types
 interface WebGLObject { __WebGLObject: void; }
 interface WebGLBuffer { __WebGLBuffer: void; }

--- a/webgl/webgl-getcontext-tests.ts
+++ b/webgl/webgl-getcontext-tests.ts
@@ -24,6 +24,6 @@ gl2 = canvas.getContext("webgl2");
 gl2 = canvas.getContext("webgl2", { antialias: true });
 gl2 = canvas.getContext("webgl2", { antialias: true, preferLowPowerToHighPerformance: true });
 
-// Brand WebGL2RenderingContext to ensure type-checking.
+// Brand WebGL2RenderingContext to ensure type-checking within this test.
 // This is because webgl-getcontext.d.ts only defines it as an empty stub interface
 interface WebGL2RenderingContext { __WebGL2RenderingContext: void; }

--- a/webgl/webgl-getcontext-tests.ts
+++ b/webgl/webgl-getcontext-tests.ts
@@ -1,0 +1,1 @@
+/// <reference path="webgl-getcontext.d.ts" />

--- a/webgl/webgl-getcontext-tests.ts
+++ b/webgl/webgl-getcontext-tests.ts
@@ -1,1 +1,29 @@
 /// <reference path="webgl-getcontext.d.ts" />
+var canvas: HTMLCanvasElement;
+var c2d: CanvasRenderingContext2D;
+var gl: WebGLRenderingContext;
+var gl2: WebGL2RenderingContext;
+
+// Tests for 2d overloads of getContext
+c2d = canvas.getContext("2d");
+c2d = canvas.getContext("2d", { alpha: true });
+
+// Tests for webgl overloads of getContext
+gl = canvas.getContext("experimental-webgl");
+gl = canvas.getContext("experimental-webgl", { antialias: true });
+gl = canvas.getContext("experimental-webgl", { antialias: true, preferLowPowerToHighPerformance: true });
+gl = canvas.getContext("webgl");
+gl = canvas.getContext("webgl", { antialias: true });
+gl = canvas.getContext("webgl", { antialias: true, preferLowPowerToHighPerformance: true });
+
+// Tests for webgl2 overloads of getContext
+gl2 = canvas.getContext("experimental-webgl2");
+gl2 = canvas.getContext("experimental-webgl2", { antialias: true });
+gl2 = canvas.getContext("experimental-webgl2", { antialias: true, preferLowPowerToHighPerformance: true });
+gl2 = canvas.getContext("webgl2");
+gl2 = canvas.getContext("webgl2", { antialias: true });
+gl2 = canvas.getContext("webgl2", { antialias: true, preferLowPowerToHighPerformance: true });
+
+// Brand WebGL2RenderingContext to ensure type-checking.
+// This is because webgl-getcontext.d.ts only defines it as an empty stub interface
+interface WebGL2RenderingContext { __WebGL2RenderingContext: void; }

--- a/webgl/webgl-getcontext.d.ts
+++ b/webgl/webgl-getcontext.d.ts
@@ -1,0 +1,4 @@
+// Type definitions for WebGL
+// Project: http://webgl.org/
+// Definitions by: Shane S. Anderson <https://github.com/ander-nz/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped/webgl

--- a/webgl/webgl-getcontext.d.ts
+++ b/webgl/webgl-getcontext.d.ts
@@ -2,3 +2,28 @@
 // Project: http://webgl.org/
 // Definitions by: Shane S. Anderson <https://github.com/ander-nz/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped/webgl
+
+interface HTMLCanvasElement {
+  // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext
+  getContext(contextId: "2d", attributes?: CanvasContextAttributes): CanvasRenderingContext2D;
+  getContext(contextId: "experimental-webgl", attributes?: WebGLContextAttributes): WebGLRenderingContext;
+  getContext(contextId: "webgl", attributes?: WebGLContextAttributes): WebGLRenderingContext;
+  getContext(contextId: "experimental-webgl2", attributes?: WebGLContextAttributes): WebGL2RenderingContext;
+  getContext(contextId: "webgl2", attributes?: WebGLContextAttributes): WebGL2RenderingContext;
+  getContext(contextId: string, ...args: any[]): CanvasRenderingContext2D | WebGLRenderingContext | WebGL2RenderingContext;
+}
+
+interface CanvasContextAttributes {
+  // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext
+  alpha?: boolean;
+}
+
+interface WebGLContextAttributes {
+  // https://www.khronos.org/registry/webgl/specs/latest/1.0/index.html#WEBGLCONTEXTATTRIBUTES
+  preferLowPowerToHighPerformance?: boolean;
+  failIfMajorPerformanceCaveat?: boolean;
+}
+
+interface WebGL2RenderingContext {
+  // Defined in a separate definition file.
+}

--- a/webgl/webgl-getcontext.d.ts
+++ b/webgl/webgl-getcontext.d.ts
@@ -3,6 +3,9 @@
 // Definitions by: Shane S. Anderson <https://github.com/ander-nz/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped/webgl
 
+// These definitions update the getContext() overloads to support context attributes and "webgl" without "experimental-" prefix.
+// It also adds overloads for "webgl2" and "experimental-webgl2", but it only defines a stub interface for WebGL2RenderingContext.
+
 interface HTMLCanvasElement {
   // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext
   getContext(contextId: "2d", attributes?: CanvasContextAttributes): CanvasRenderingContext2D;


### PR DESCRIPTION
This pull request makes a couple of minor improvements to the built-in WebGL definitions.
- It changes the canvas.getContext(...) overloads to support an optional contextAttributes parameter.
- It adds a canvas.getContext("webgl", ...) overload (lib.d.ts only includes "experimental-webgl").
- It adds interface branding to the otherwise-empty WebGL object types (see below).
- It adds "webgl2" and "experimental-webgl2" as overloads that return a WebGL2RenderingContext (see below).
#### Interface branding

With lib.d.ts, the definitions for the various WebGL object types, such as WebGLShader and WebGLProgram, are exactly the same. This pull request fixes accidental type errors such as the following example:

``` js
var program: WebGLProgram = gl.createShader(...);
```
#### WebGL2RenderingContext

Note that while canvas.getContext("webgl") will return a WebGL2RenderingContext, the interface definition included in this library is an empty stub. It is intended that a separate webgl2 definitions file will be made to flesh out this interface.
