### PR TITLE
Represent Optimist API more correctly

### DIFF
--- a/optimist/optimist-tests.ts
+++ b/optimist/optimist-tests.ts
@@ -9,8 +9,8 @@ var num: number;
 var bool: boolean;
 var strArr: string[];
 
-var argv: optimist.Argv;
-var opt: optimist.Optimist;
+var argv: typeof optimist.argv;
+var opt: typeof optimist;
 
 argv = opt.argv;
 argv = opt.argv;

--- a/optimist/optimist.d.ts
+++ b/optimist/optimist.d.ts
@@ -40,10 +40,7 @@ declare module "optimist" {
 
         parse(args: string[]): Optimist;
 
-        argv: {
-            _: string[],
-            [key: string]: any
-        };
+        argv: any;
     }
     var t: Optimist;
 

--- a/optimist/optimist.d.ts
+++ b/optimist/optimist.d.ts
@@ -7,47 +7,45 @@
 
 declare module "optimist" {
 
-	function optimist(args: string[]): optimist.Optimist;
+    interface Optimist {
+        (args: string[]): Optimist
+        default(name: string, value: any): Optimist;
+        default(args: Object): Optimist;
 
-	module optimist {
-		export interface Optimist {
-			default(name: string, value: any): Optimist;
-			default(args: Object): Optimist;
+        boolean(name: string): Optimist;
+        boolean(names: string[]): Optimist;
 
-			boolean(name: string): Optimist;
-			boolean(names: string[]): Optimist;
+        string(name: string): Optimist;
+        string(names: string[]): Optimist;
 
-			string(name: string): Optimist;
-			string(names: string[]): Optimist;
+        wrap(columns: number): Optimist;
 
-			wrap(columns: number): Optimist;
+        help(): void;
+        showHelp(fn?: Function): void;
 
-			help(): void;
-			showHelp(fn?: Function): void;
+        usage(message: string): Optimist;
 
-			usage(message: string): Optimist;
+        demand(key: string): Optimist;
+        demand(key: number): Optimist;
+        demand(key: string[]): Optimist;
 
-			demand(key: string): Optimist;
-			demand(key: number): Optimist;
-			demand(key: string[]): Optimist;
+        alias(key: string, alias: string): Optimist;
 
-			alias(key: string, alias: string): Optimist;
+        describe(key: string, desc: string): Optimist;
 
-			describe(key: string, desc: string): Optimist;
+        options(obj: {[key: string]: {alias: string, describe: string, default?: any}}): Optimist;
+        options(key: string, opt: Object): Optimist;
 
-			options(key: string, opt: Object): Optimist;
+        check(fn: Function): Optimist;
 
-			check(fn: Function): void;
+        parse(args: string[]): Optimist;
 
-			parse(args: string[]): Optimist;
+        argv: {
+            _: string[],
+            [key: string]: any
+        };
+    }
+    var t: Optimist;
 
-			argv: Argv;
-		}
-
-		export interface Argv extends Object {
-			_: string[];
-		}
-	}
-
-	export = optimist;
+    export = t;
 }


### PR DESCRIPTION
Make it so the result of requiring it can actually be used as an optimist instance (rather than being force to pass in process.argv to get an instance). Additionally, check should be chainable and options should have the hash option.
