### PR TITLE
Typed (generic) version of _.findKey

### DIFF
--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -6965,6 +6965,16 @@ declare module _ {
 
         /**
         * @see _.findKey
+        * @param callback The function called per iteration.
+        **/
+
+        findKey<T>(
+            object: Dictionary<T>,
+            callback: DictionaryIterator<T,boolean>,
+            thisArg?: any): string;
+
+        /**
+        * @see _.findKey
         * @param pluckValue _.pluck style callback
         **/
         findKey(


### PR DESCRIPTION
A fix for #6100, generic version of _.findKey
