### PR TITLE
Add optional string parameter to removeAllListeners

### DIFF
--- a/socket.io/socket.io.d.ts
+++ b/socket.io/socket.io.d.ts
@@ -687,7 +687,7 @@ declare module SocketIO {
 		 * Removes all event listeners on this object
 		 * @return This Socket
 		 */
-		removeAllListeners(): Socket;
+		removeAllListeners( event?: string ): Socket;
 		
 		/**
 		 * Sets the maximum number of listeners this instance can have


### PR DESCRIPTION
As socket essentially extends EventEmitter (save emit), and EventEmitter allows passing an event string to removeAllListeners, the typings should be updated to reflect that. I've updated removeAllListeners to take an option event string parameter.

Reference [Node 4.1.1](https://nodejs.org/api/events.html#events_emitter_removealllisteners_event) & [Node 0.12.7](https://nodejs.org/docs/latest-v0.12.x/api/events.html#events_emitter_removealllisteners_event)

Also check out the definition of EventEmitter.removeAllListeners [in node.d.ts.](https://github.com/borisyankov/DefinitelyTyped/blob/master/node/node.d.ts#L175)
