### PR TITLE
Add respondImmediately property to SinonFakeServer

### DIFF
--- a/sinon/sinon.d.ts
+++ b/sinon/sinon.d.ts
@@ -264,6 +264,7 @@ declare module Sinon {
         fakeHTTPMethods: boolean;
         getHTTPMethod: (request: SinonFakeXMLHttpRequest) => string;
         requests: SinonFakeXMLHttpRequest[];
+        respondImmediately: boolean;
 
         // Methods
         respondWith(body: string): void;


### PR DESCRIPTION
`server.respondImmediately = true;`

If set, the server will respond to every request immediately and synchronously. This is ideal for faking the server from within a test without having to call server.respond() after each request made in that test. As this is synchronous and immediate, this is not suitable for simulating actual network latency in tests or mockups. To simulate network latency with automatic responses, see server.autoRespond and server.autoRespondAfter.

http://sinonjs.org/docs/
