### PR TITLE
Fix typo in IBarChartAxis

### DIFF
--- a/chartist/chartist.d.ts
+++ b/chartist/chartist.d.ts
@@ -182,7 +182,7 @@ declare module Chartist {
     labelOffset?: {
       x?: number;
       y?: number;
-    },
+    };
     showLabel?: boolean;
     showGrid?: boolean;
     labelInterpolationFnc?: Function;


### PR DESCRIPTION
Current version generates following error:

> Error:(185, 10) TS1005: ';' expected.

This pull request fixes this typo.
