### PR TITLE
Create lodash-global for global usage

### DIFF
--- a/backbone/backbone-with-lodash-tests.ts
+++ b/backbone/backbone-with-lodash-tests.ts
@@ -1,5 +1,5 @@
 /// <reference path="../jquery/jquery.d.ts" />
-/// <reference path="../lodash/lodash.d.ts" />
+/// <reference path="../lodash/lodash-global.d.ts" />
 /// <reference path="./backbone-global.d.ts" />
 
 function test_events() {

--- a/knex/knex-tests.ts
+++ b/knex/knex-tests.ts
@@ -1,7 +1,6 @@
 /// <reference path='knex.d.ts' />
-/// <reference path='../lodash/lodash.d.ts' />
+/// <reference path='../lodash/lodash-global.d.ts' />
 import Knex = require('knex');
-import _ = require('lodash');
 'use strict';
 // Initializing the Library
 var knex = Knex({

--- a/lodash-decorators/lodash-decorators-tests.ts
+++ b/lodash-decorators/lodash-decorators-tests.ts
@@ -1,5 +1,5 @@
 /// <reference path="lodash-decorators.d.ts" />
-/// <reference path="../lodash/lodash.d.ts" />
+/// <reference path="../lodash/lodash-global.d.ts" />
 
 //
 // With Arguments
@@ -102,7 +102,6 @@ person3.getUpperCaseName(); // JOE SMITH
 //
 
 //import { kebabCase } from 'lodash';
-import * as _ from 'lodash';
 
 class Person4 {
     firstName: string;

--- a/lodash-decorators/lodash-decorators.d.ts
+++ b/lodash-decorators/lodash-decorators.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Qubo <https://github.com/tkqubo>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-///<reference path="../lodash/lodash.d.ts"/>
+///<reference path="../lodash/lodash-global.d.ts"/>
 
 
 declare module "lodash-decorators" {

--- a/lodash/lodash-global-test.ts
+++ b/lodash/lodash-global-test.ts
@@ -1,6 +1,4 @@
-/// <reference path="lodash.d.ts" />
-
-import {_} from "lodash";
+/// <reference path="lodash-global.d.ts" />
 
 declare var $: any, jQuery: any;
 

--- a/lodash/lodash-global.d.ts
+++ b/lodash/lodash-global.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for Lo-Dash (global)
+// Project: http://lodash.com/
+// Definitions by: Brian Zengel <https://github.com/bczengel>, Ilya Mochalov <https://github.com/chrootsu>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="lodash.d.ts" />
+
+import _ = __Lodash;

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: Brian Zengel <https://github.com/bczengel>, Ilya Mochalov <https://github.com/chrootsu>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare var _: _.LoDashStatic;
+declare var __Lodash : __Lodash.LoDashStatic;
 
-declare module _ {
+declare module __Lodash {
     interface LoDashStatic {
         /**
         * Creates a lodash object which wraps the given value to enable intuitive method chaining.
@@ -125,7 +125,7 @@ declare module _ {
          * @param value The value to cache.
          * @return Returns the cache object.
          */
-        set(key: string, value: any): _.Dictionary<any>;
+        set(key: string, value: any): __Lodash.Dictionary<any>;
     }
 
     /**
@@ -1069,7 +1069,7 @@ declare module _ {
         object(
             props: List<StringRepresentable>,
             values?: List<any>
-        ): _.Dictionary<any>;
+        ): __Lodash.Dictionary<any>;
     }
 
     interface LoDashImplicitArrayWrapper<T> {
@@ -1078,21 +1078,21 @@ declare module _ {
          */
         object<TValues, TResult extends {}>(
             values?: List<TValues>
-        ): _.LoDashImplicitObjectWrapper<TResult>;
+        ): __Lodash.LoDashImplicitObjectWrapper<TResult>;
 
         /**
          * @see _.zipObject
          */
         object<TResult extends {}>(
             values?: List<any>
-        ): _.LoDashImplicitObjectWrapper<TResult>;
+        ): __Lodash.LoDashImplicitObjectWrapper<TResult>;
 
         /**
          * @see _.zipObject
          */
         object(
             values?: List<any>
-        ): _.LoDashImplicitObjectWrapper<_.Dictionary<any>>;
+        ): __Lodash.LoDashImplicitObjectWrapper<__Lodash.Dictionary<any>>;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
@@ -1101,21 +1101,21 @@ declare module _ {
          */
         object<TValues, TResult extends {}>(
             values?: List<TValues>
-        ): _.LoDashImplicitObjectWrapper<TResult>;
+        ): __Lodash.LoDashImplicitObjectWrapper<TResult>;
 
         /**
          * @see _.zipObject
          */
         object<TResult extends {}>(
             values?: List<any>
-        ): _.LoDashImplicitObjectWrapper<TResult>;
+        ): __Lodash.LoDashImplicitObjectWrapper<TResult>;
 
         /**
          * @see _.zipObject
          */
         object(
             values?: List<any>
-        ): _.LoDashImplicitObjectWrapper<_.Dictionary<any>>;
+        ): __Lodash.LoDashImplicitObjectWrapper<__Lodash.Dictionary<any>>;
     }
 
     //_.pull
@@ -2174,12 +2174,12 @@ declare module _ {
         /**
         * @see _.zip
         **/
-        zip(...arrays: any[][]): _.LoDashImplicitArrayWrapper<any[][]>;
+        zip(...arrays: any[][]): __Lodash.LoDashImplicitArrayWrapper<any[][]>;
 
         /**
         * @see _.zip
         **/
-        unzip(...arrays: any[]): _.LoDashImplicitArrayWrapper<any[][]>;
+        unzip(...arrays: any[]): __Lodash.LoDashImplicitArrayWrapper<any[][]>;
     }
 
     //_.zipObject
@@ -2214,7 +2214,7 @@ declare module _ {
         zipObject(
             props: List<StringRepresentable>,
             values?: List<any>
-        ): _.Dictionary<any>;
+        ): __Lodash.Dictionary<any>;
     }
 
     interface LoDashImplicitArrayWrapper<T> {
@@ -2223,21 +2223,21 @@ declare module _ {
          */
         zipObject<TValues, TResult extends {}>(
             values?: List<TValues>
-        ): _.LoDashImplicitObjectWrapper<TResult>;
+        ): __Lodash.LoDashImplicitObjectWrapper<TResult>;
 
         /**
          * @see _.zipObject
          */
         zipObject<TResult extends {}>(
             values?: List<any>
-        ): _.LoDashImplicitObjectWrapper<TResult>;
+        ): __Lodash.LoDashImplicitObjectWrapper<TResult>;
 
         /**
          * @see _.zipObject
          */
         zipObject(
             values?: List<any>
-        ): _.LoDashImplicitObjectWrapper<_.Dictionary<any>>;
+        ): __Lodash.LoDashImplicitObjectWrapper<__Lodash.Dictionary<any>>;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
@@ -2246,21 +2246,21 @@ declare module _ {
          */
         zipObject<TValues, TResult extends {}>(
             values?: List<TValues>
-        ): _.LoDashImplicitObjectWrapper<TResult>;
+        ): __Lodash.LoDashImplicitObjectWrapper<TResult>;
 
         /**
          * @see _.zipObject
          */
         zipObject<TResult extends {}>(
             values?: List<any>
-        ): _.LoDashImplicitObjectWrapper<TResult>;
+        ): __Lodash.LoDashImplicitObjectWrapper<TResult>;
 
         /**
          * @see _.zipObject
          */
         zipObject(
             values?: List<any>
-        ): _.LoDashImplicitObjectWrapper<_.Dictionary<any>>;
+        ): __Lodash.LoDashImplicitObjectWrapper<__Lodash.Dictionary<any>>;
     }
 
     //_.zipWith
@@ -4255,19 +4255,19 @@ declare module _ {
         **/
         groupBy(
             callback: ListIterator<T, any>,
-            thisArg?: any): _.LoDashImplicitObjectWrapper<_.Dictionary<T[]>>;
+            thisArg?: any): __Lodash.LoDashImplicitObjectWrapper<__Lodash.Dictionary<T[]>>;
 
         /**
         * @see _.groupBy
         **/
         groupBy(
-            pluckValue: string): _.LoDashImplicitObjectWrapper<_.Dictionary<T[]>>;
+            pluckValue: string): __Lodash.LoDashImplicitObjectWrapper<__Lodash.Dictionary<T[]>>;
 
         /**
         * @see _.groupBy
         **/
         groupBy<W>(
-            whereValue: W): _.LoDashImplicitObjectWrapper<_.Dictionary<T[]>>;
+            whereValue: W): __Lodash.LoDashImplicitObjectWrapper<__Lodash.Dictionary<T[]>>;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
@@ -4276,19 +4276,19 @@ declare module _ {
         **/
         groupBy<TValue>(
             callback: ListIterator<TValue, any>,
-            thisArg?: any): _.LoDashImplicitObjectWrapper<_.Dictionary<TValue[]>>;
+            thisArg?: any): __Lodash.LoDashImplicitObjectWrapper<__Lodash.Dictionary<TValue[]>>;
 
         /**
         * @see _.groupBy
         **/
         groupBy<TValue>(
-            pluckValue: string): _.LoDashImplicitObjectWrapper<_.Dictionary<TValue[]>>;
+            pluckValue: string): __Lodash.LoDashImplicitObjectWrapper<__Lodash.Dictionary<TValue[]>>;
 
         /**
         * @see _.groupBy
         **/
         groupBy<W, TValue>(
-            whereValue: W): _.LoDashImplicitObjectWrapper<_.Dictionary<TValue[]>>;
+            whereValue: W): __Lodash.LoDashImplicitObjectWrapper<__Lodash.Dictionary<TValue[]>>;
     }
 
     //_.indexBy
@@ -8331,7 +8331,7 @@ declare module _ {
         **/
         forIn<T extends {}>(
             callback: ObjectIterator<T, void>,
-            thisArg?: any): _.LoDashImplicitObjectWrapper<T>;
+            thisArg?: any): __Lodash.LoDashImplicitObjectWrapper<T>;
     }
 
     //_.forInRight
@@ -8364,7 +8364,7 @@ declare module _ {
         **/
         forInRight<T extends {}>(
             callback: ObjectIterator<T, void>,
-            thisArg?: any): _.LoDashImplicitObjectWrapper<T>;
+            thisArg?: any): __Lodash.LoDashImplicitObjectWrapper<T>;
     }
 
     //_.forOwn
@@ -8398,7 +8398,7 @@ declare module _ {
         **/
         forOwn<T extends {}>(
             callback: ObjectIterator<T, void>,
-            thisArg?: any): _.LoDashImplicitObjectWrapper<T>;
+            thisArg?: any): __Lodash.LoDashImplicitObjectWrapper<T>;
     }
 
     //_.forOwnRight
@@ -8430,7 +8430,7 @@ declare module _ {
         **/
         forOwnRight<T extends {}>(
             callback: ObjectIterator<T, void>,
-            thisArg?: any): _.LoDashImplicitObjectWrapper<T>;
+            thisArg?: any): __Lodash.LoDashImplicitObjectWrapper<T>;
     }
 
     //_.functions
@@ -8453,12 +8453,12 @@ declare module _ {
         /**
         * @see _.functions
         **/
-        functions(): _.LoDashImplicitArrayWrapper<string>;
+        functions(): __Lodash.LoDashImplicitArrayWrapper<string>;
 
         /**
         * @see _.functions
         **/
-        methods(): _.LoDashImplicitArrayWrapper<string>;
+        methods(): __Lodash.LoDashImplicitArrayWrapper<string>;
     }
 
     //_.get
@@ -10146,14 +10146,14 @@ declare module _ {
          *
          * @return Returns the lodash function.
          */
-        noConflict(): typeof _;
+        noConflict(): __Lodash.LoDashStatic;
     }
 
     interface LoDashImplicitWrapperBase<T, TWrapper> {
         /**
          * @see _.noConflict
          */
-        noConflict(): typeof _;
+        noConflict(): __Lodash.LoDashStatic;
     }
 
     //_.noop
@@ -10255,14 +10255,14 @@ declare module _ {
          * @param context The context object.
          * @return Returns a new lodash function.
          */
-        runInContext(context?: Object): typeof _;
+        runInContext(context?: Object): __Lodash.LoDashStatic;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
         /**
          * @see _.runInContext
          */
-        runInContext(): typeof _;
+        runInContext(): __Lodash.LoDashStatic;
     }
 
     //_.times
@@ -10364,5 +10364,5 @@ declare module _ {
 }
 
 declare module "lodash" {
-    export = _;
+    export {__Lodash as _};
 }

--- a/sequelize/sequelize-2.0.0.d.ts
+++ b/sequelize/sequelize-2.0.0.d.ts
@@ -6,7 +6,7 @@
 // Based on original work by: samuelneff <https://github.com/samuelneff/sequelize-auto-ts/blob/master/lib/sequelize.d.ts>
 
 /// <reference path="../node/node.d.ts" />
-/// <reference path="../lodash/lodash.d.ts" />
+/// <reference path="../lodash/lodash-global.d.ts" />
 
 declare module "sequelize"
 {

--- a/sequelize/sequelize.d.ts
+++ b/sequelize/sequelize.d.ts
@@ -5,7 +5,7 @@
 
 // Based on original work by: samuelneff <https://github.com/samuelneff/sequelize-auto-ts/blob/master/lib/sequelize.d.ts>
 
-/// <reference path="../lodash/lodash.d.ts" />
+/// <reference path="../lodash/lodash-global.d.ts" />
 /// <reference path="../bluebird/bluebird.d.ts" />
 /// <reference path="../validator/validator.d.ts" />
 

--- a/whatwg-fetch/whatwg-fetch-tests.ts
+++ b/whatwg-fetch/whatwg-fetch-tests.ts
@@ -1,5 +1,5 @@
 ﻿/// <reference path="whatwg-fetch.d.ts" />
-/// <reference path="../es6-promise/es6-promise.d.ts" />
+/// <reference path="../es6-shim/es6-shim.d.ts" />
 
 function test_fetchUrlWithOptions() {
 	var headers = new Headers();

--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Ryan Graham <https://github.com/ryan-codingintrigue>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-/// <reference path="../es6-promise/es6-promise.d.ts" />
+/// <reference path="../es6-shim/es6-shim.d.ts" />
 
 declare class Request extends Body {
 	constructor(input: string|Request, init?:RequestInit);


### PR DESCRIPTION
Following the pattern of [React](https://github.com/borisyankov/DefinitelyTyped/tree/master/react), this PR creates a `lodash-global.d.ts` type definition. 

Why is this necessary?

The following code compiles using the [current type definition](https://github.com/borisyankov/DefinitelyTyped/blob/d4b7845b6eb77bf6b11d6f83b35dc33c5305e756/lodash/lodash.d.ts):

``` typescript
/// <reference path="../typings/lodash/lodash.d.ts" />

console.log(_.isUndefined(5));
```

but fails at runtime unless you have loaded `lodash` elsewhere. For those, like me, who use [SystemJS](https://github.com/systemjs/systemjs) (or other modules loaders) to load modules, we need to declare dependencies via imports, and generally rely on the compiler to tell us when we have missed one (as is the case here).

This PR creates two (linked) versions of the type definition:
- For those people who are going to load `lodash` elsewhere and want to therefore take advantage of the global definitions, they should reference `lodash-global.d.ts`
- For those people who use module loaders and want the above code to be a compile error because they haven't imported `lodash`, they should use `lodash.d.ts`

So if instead I reference the `lodash.d.ts` in this PR, the above code would give a compile error:

```
error TS2304: Cannot find name '_'
```

This forces me to import:

``` typescript
/// <reference path="../typings/lodash/lodash.d.ts" />

import {_} from "lodash";

console.log(_.isUndefined(5));
```

The transpiled output then includes the relevant module loading code to ensure `lodash` has been loaded before use (in my case I'm using [SystemJS](https://github.com/systemjs/systemjs)):

``` javascript
System.register(["lodash"], function(exports_1) {
    var lodash_1;
    return {
        setters:[
            function (lodash_1_1) {
                lodash_1 = lodash_1_1;
            }],
        execute: function() {
            console.log(lodash_1._.isUndefined(5));
        }
    }
});
```
