### PR TITLE
Adding "start" and "end" to createReadStream() options definition.

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1313,6 +1313,8 @@ declare module "fs" {
         fd?: string;
         mode?: number;
         bufferSize?: number;
+        start?:number;
+        end?:number;
     }): ReadStream;
     export function createReadStream(path: string, options?: {
         flags?: string;
@@ -1320,6 +1322,8 @@ declare module "fs" {
         fd?: string;
         mode?: string;
         bufferSize?: number;
+        start?:number;
+        end?:number;
     }): ReadStream;
     export function createWriteStream(path: string, options?: {
         flags?: string;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1310,18 +1310,9 @@ declare module "fs" {
     export function createReadStream(path: string, options?: {
         flags?: string;
         encoding?: string;
-        fd?: string;
+        fd?: number;
         mode?: number;
-        bufferSize?: number;
-        start?:number;
-        end?:number;
-    }): ReadStream;
-    export function createReadStream(path: string, options?: {
-        flags?: string;
-        encoding?: string;
-        fd?: string;
-        mode?: string;
-        bufferSize?: number;
+        autoClose?: boolean;
         start?:number;
         end?:number;
     }): ReadStream;


### PR DESCRIPTION
See node documentation here: https://nodejs.org/api/fs.html#fs_fs_createreadstream_path_options
