### PR TITLE
power-assert: Modify to es6 module standard format

### DIFF
--- a/power-assert/power-assert-tests.ts
+++ b/power-assert/power-assert-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./power-assert.d.ts" />
 
-import assert = require("power-assert");
+import assert from "power-assert";
 
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 

--- a/power-assert/power-assert.d.ts
+++ b/power-assert/power-assert.d.ts
@@ -9,7 +9,7 @@
 /// <reference path="../power-assert-formatter/power-assert-formatter.d.ts" />
 
 declare function assert(value:any, message?:string):void;
-declare module assert {
+declare namespace assert {
     export class AssertionError implements Error {
         name:string;
         message:string;
@@ -62,5 +62,5 @@ declare module assert {
 }
 
 declare module "power-assert" {
-    export = assert;
+    export default assert;
 }


### PR DESCRIPTION
Power assert supports es6 module standard format since version 1.1.0.

https://github.com/power-assert-js/power-assert
