### PR TITLE
Added AddClasses option to DroppableOptions interface in jQueryUI

### DIFF
--- a/jqueryui/jqueryui.d.ts
+++ b/jqueryui/jqueryui.d.ts
@@ -474,9 +474,10 @@ declare module JQueryUI {
     }
 
     interface DroppableOptions extends DroppableEvents {
-        disabled?: boolean;
         accept?: any;
         activeClass?: string;
+        addClasses?: boolean;
+        disabled?: boolean;
         greedy?: boolean;
         hoverClass?: string;
         scope?: string;


### PR DESCRIPTION
The AddClasses option seems to be missing from the DroppableOptions interface for jQueryUI.

I have added it to the interface and alphabetically re-ordered the options so they match with the jQueryUI documentation.
