### PR TITLE
express-validator: fix and new methods

### DIFF
--- a/express-validator/express-validator-tests.ts
+++ b/express-validator/express-validator-tests.ts
@@ -18,7 +18,7 @@ app.post('/:urlparam', function(req: express.Request, res: express.Response) {
   req.checkParams('urlparam', 'Invalid urlparam').isAlpha();
   req.checkQuery('getparam', 'Invalid getparam').isInt();
   req.checkHeader('testHeader', 'Invalid testHeader').isLowercase().isUppercase();
-  req.checkFiles('testFiles', 'Invalid testFiles').isUrl();
+  req.checkFiles('testFiles', 'Invalid testFiles').isURL();
 
 
   // OR assert can be used to check on all 3 types of params.

--- a/express-validator/express-validator.d.ts
+++ b/express-validator/express-validator.d.ts
@@ -65,7 +65,7 @@ declare module ExpressValidator {
 		/**
 		 * Accepts http, https, ftp
 		 */
-		isUrl(): Validator;
+		isURL(): Validator;
 		/**
 		 * Combines isIPv4 and isIPv6
 		 */
@@ -111,6 +111,7 @@ declare module ExpressValidator {
 		/**
 		 * max is optional
 		 */
+		isLength(min:number, max?:number): Validator;
 		len(min:number, max?:number): Validator;
 		/**
 		 * Version can be 3, 4 or 5 or empty, see http://en.wikipedia.org/wiki/Universally_unique_identifier
@@ -154,6 +155,14 @@ declare module ExpressValidator {
 		 * Check an input only when the input exists
 		 */
 		optional(): Validator;
+		/**
+		 * Check string to be a valid date according to ISO 8601
+		 */
+		isISO8601(): Validator;
+		/**
+		 * Check string to be a valid mongoID
+		 */
+		isMongoId(): Validator;
 	}
 
 	interface Sanitizer {


### PR DESCRIPTION
Method isUrl() should be isURL().
New methods are now available in validator.js. This pull requests adds isLength(), isMongoId() and is ISO8601()
