### PR TITLE
Whatwg-fetch: Allow body.json typed result

### DIFF
--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -52,6 +52,7 @@ declare class Body {
 	blob(): Promise<Blob>;
 	formData(): Promise<FormData>;
 	json(): Promise<any>;
+	json<T>(): Promise<T>;
 	text(): Promise<string>;
 }
 declare class Response extends Body {


### PR DESCRIPTION
Useful to avoid assertions and keep a consistent code
