### PR TITLE
Adapt the return type of attr() with one parameter of type string to …

### DIFF
--- a/libxmljs/libxmljs.d.ts
+++ b/libxmljs/libxmljs.d.ts
@@ -42,7 +42,7 @@ declare module "libxmljs" {
         name():string;
         name(newName:string):void;
         text():string;
-        attr(name:string):string;
+        attr(name:string):Attribute;
         attr(attr:Attribute):void;
         attr(attrObject:{[key:string]:string;}):void;
         attrs():Attribute[];


### PR DESCRIPTION
…be Attribute.

See here how it is used:
https://github.com/polotek/libxmljs/blame/master/README.md#L26
I also tried it locally and verified that the returned object has all of the methods of Attribute.
