### PR TITLE
Fix angular IAttributes#$normalize() definition

### DIFF
--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -507,7 +507,7 @@ function test_IAttributes(attributes: ng.IAttributes){
 }
 
 test_IAttributes({
-    $normalize: function (classVal){},
+    $normalize: function (classVal){ return "foo" },
     $addClass: function (classVal){},
     $removeClass: function(classVal){},
     $set: function(key, value){},

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -306,7 +306,7 @@ declare module angular {
          *
          * For further information check out the guide on @see https://docs.angularjs.org/guide/directive#matching-directives
          */
-        $normalize(name: string): void;
+        $normalize(name: string): string;
 
         /**
          * Adds the CSS class value specified by the classVal parameter to the


### PR DESCRIPTION
This method returns a string, not `void`.

https://docs.angularjs.org/api/ng/type/$compile.directive.Attributes
