### PR TITLE
[source-map] Fix incorrect `RawSourceMap.sourcesContents` field typing.

### DIFF
--- a/source-map/source-map-tests.ts
+++ b/source-map/source-map-tests.ts
@@ -11,7 +11,7 @@ function testSourceMapConsumer() {
             version: 'foo',
             sources: ['foo', 'bar'],
             names: ['foo', 'bar'],
-            sourcesContent: 'foo',
+            sourcesContent: ['foo'],
             mappings: 'foo'
         });
 

--- a/source-map/source-map.d.ts
+++ b/source-map/source-map.d.ts
@@ -13,7 +13,7 @@ declare module SourceMap {
         version: string;
         sources: Array<string>;
         names: Array<string>;
-        sourcesContent?: string;
+        sourcesContent?: string[];
         mappings: string;
     }
 


### PR DESCRIPTION
According to [the source map spec](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit?pli=1) and [the source-map documentation](https://github.com/mozilla/source-map/blob/ea182cea380f8a963151547a4ca1e6f2bcde1364/README.md#new-sourcemapconsumerrawsourcemap), this field is an array of strings, _not_ a single string. Each item in the string contains the source code of the corresponding item in the `RawSourceMap.sources` array.
