### PR TITLE
Make count in RangeSelectorButton optional in highstock.d.ts

### DIFF
--- a/highcharts/highstock.d.ts
+++ b/highcharts/highstock.d.ts
@@ -30,7 +30,7 @@ interface HighstockNavigatorOptions {
 
 interface RangeSelectorButton {
     type: string; //Defines the timespan, can be one of 'millisecond', 'second', 'minute', 'day', 'week', 'month', 'ytd' (year to date), 'year' and 'all'.
-    count: number;
+    count?: number;
     text: string;
     dataGrouping?: any; //not sure how this works
 }


### PR DESCRIPTION
Referring to http://api.highcharts.com/highstock#rangeSelector.buttons when type is 'all' you can omit count.
