### PR TITLE
Add missing weeks properties to momentInput interface #6044

### DIFF
--- a/moment/moment-node.d.ts
+++ b/moment/moment-node.d.ts
@@ -19,6 +19,13 @@ declare module moment {
         month?: number;
         /** Month */
         M?: number;
+        
+        /** Week */
+        weeks?: number;
+        /** Week */
+        week?: number;
+        /** Week */
+        w?: number;
 
         /** Day/Date */
         days?: number;


### PR DESCRIPTION
As explained in #6044 the MomentInput interface was missing the properties for weeks. 
