### PR TITLE
Change Parse.Promise to be a class

### DIFF
--- a/parse/parse-tests.ts
+++ b/parse/parse-tests.ts
@@ -400,3 +400,16 @@ function test_view() {
     var model = Parse.User.current();
     var view = new Parse.View<Parse.User>();
 }
+
+function test_promise() {
+    let resolved = Parse.Promise.as(true);
+    let rejected = Parse.Promise.error("an error object");
+    Parse.Promise.when([resolved, rejected]).then(function() {
+        // success
+    }, function() {
+        // failed
+    });
+
+    // can check whether an object is a Parse.Promise object or not
+    Parse.Promise.is(resolved);
+}

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -72,14 +72,16 @@ declare namespace Parse {
         then<U>(resolvedCallback: (value: T) => U, rejectedCallback?: (reason: any) => U): IPromise<U>;
     }
 
-    interface Promise<T> {
+    class Promise<T> {
+
+        static as(resolvedValue: any): Promise<any>;
+        static error(error: any): Promise<any>;
+        static is(possiblePromise: any): Boolean;
+        static when(promises: Promise<any>[]): Promise<any>;
 
         always(callback: Function): Promise<T>;
-        as(): Promise<T>;
         done(callback: Function): Promise<T>;
-        error(): Promise<T>;
         fail(callback: Function): Promise<T>;
-        is(): Promise<T>;
         reject(error: any): void;
         resolve(result: any): void;
         then<U>(resolvedCallback: (value: T) => Promise<U>,
@@ -88,8 +90,6 @@ declare namespace Parse {
             rejectedCallback?: (reason: any) => IPromise<U>): IPromise<T>;
         then<U>(resolvedCallback: (value: T) => U,
             rejectedCallback?: (reason: any) => U): IPromise<T>;
-
-        when(promises: Promise<T>[]): Promise<T>;
     }
 
     interface IBaseObject {

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -1050,11 +1050,11 @@ declare namespace Parse {
 
 }
 
-declare module "parse" {
-    var type: typeof Parse;
-    var subType: {
-        Parse: typeof type;
-    }
+declare module "parse/node" {
+    export = { Parse };
+}
 
-    export = subType;
+declare module "parse" {
+    import parse = require("parse/node");
+    export = parse
 }

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -74,8 +74,8 @@ declare namespace Parse {
 
     class Promise<T> {
 
-        static as(resolvedValue: any): Promise<any>;
-        static error(error: any): Promise<any>;
+        static as<U>(resolvedValue: U): Promise<U>;
+        static error<U>(error: U): Promise<U>;
         static is(possiblePromise: any): Boolean;
         static when(promises: Promise<any>[]): Promise<any>;
 


### PR DESCRIPTION
As [Parse JS SDK documentation](https://parse.com/docs/js/api/classes/Parse.Promise.html), one should be able to create `Promise` objects with `Parse.Promise.error()`, `Parse.Promise.as()`. (or `new` keyword)

This pull request change the type of `Promise` from `interface` to `class` and also update `is`, `error`, `as` and `when` methods to be static method with corresponding arguments.

With this change, we can utilize `Promise` functionality provided by Parse.
