### PR TITLE
Add overload for Backbone.Events.on()

### DIFF
--- a/backbone/backbone-global.d.ts
+++ b/backbone/backbone-global.d.ts
@@ -65,6 +65,18 @@ declare module Backbone {
         reset?: boolean;
     }
 
+    interface ObjectHash {
+        [key: string]: any;
+    }
+
+    interface RoutesHash {
+        [routePattern: string]: string | {(...urlParts: string[]): void};
+    }
+
+    interface EventsHash {
+        [selector: string]: string | {(eventObject: JQueryEventObject): void};
+    }
+
     class Events {
         on(eventName: string, callback?: Function, context?: any): any;
         off(eventName?: string, callback?: Function, context?: any): any;
@@ -102,7 +114,7 @@ declare module Backbone {
         * For assigning an object hash, do it like this: this.defaults = <any>{ attribute: value, ... };
         * That works only if you set it in the constructor or the initialize method.
         **/
-        defaults(): any;
+        defaults(): ObjectHash;
         id: any;
         idAttribute: string;
         validationError: any;
@@ -272,7 +284,7 @@ declare module Backbone {
         * For assigning routes as object hash, do it like this: this.routes = <any>{ "route": callback, ... };
         * That works only if you set it in the constructor or the initialize method.
         **/
-        routes: any;
+        routes: RoutesHash | any;
 
         constructor(options?: RouterOptions);
         initialize(options?: RouterOptions): void;
@@ -310,7 +322,7 @@ declare module Backbone {
    interface ViewOptions<TModel extends Model> {
       model?: TModel;
        // TODO: quickfix, this can't be fixed easy. The collection does not need to have the same model as the parent view.
-      collection?: Backbone.Collection<any>;
+      collection?: Backbone.Collection<any>; //was: Collection<TModel>;
       el?: any;
       id?: string;
       className?: string;
@@ -333,7 +345,7 @@ declare module Backbone {
         * For assigning events as object hash, do it like this: this.events = <any>{ "event:selector": callback, ... };
         * That works only if you set it in the constructor or the initialize method.
         **/
-        events(): any;
+        events(): EventsHash;
 
         $(selector: string): JQuery;
         model: TModel;
@@ -353,7 +365,7 @@ declare module Backbone {
         render(): View<TModel>;
         remove(): View<TModel>;
         make(tagName: any, attributes?: any, content?: any): any;
-        delegateEvents(events?: any): any;
+        delegateEvents(events?: EventsHash): any;
         undelegateEvents(): any;
 
         _ensureElement(): void;

--- a/backbone/backbone-global.d.ts
+++ b/backbone/backbone-global.d.ts
@@ -79,6 +79,7 @@ declare module Backbone {
 
     class Events {
         on(eventName: string, callback?: Function, context?: any): any;
+        on(eventMap: EventsHash): any;
         off(eventName?: string, callback?: Function, context?: any): any;
         trigger(eventName: string, ...args: any[]): any;
         bind(eventName: string, callback: Function, context?: any): any;


### PR DESCRIPTION
This adds event map syntax for the `Backbone.Events.on()` function as described here: http://backbonejs.org/#Events-on reported by @loicraux

``` javascript
book.on({
  "change:author": authorPane.update,
  "change:title change:subtitle": titleView.update,
  "destroy": bookView.remove
});
```

Also adds interfaces for ObjectHash, RoutesHash and EventsHash.
