### PR TITLE
Update map function to allow Element argument

### DIFF
--- a/mapbox/mapbox.d.ts
+++ b/mapbox/mapbox.d.ts
@@ -18,8 +18,8 @@ declare module L.mapbox {
 	/**
 	 * Create and automatically configure a map with layers, markers, and interactivity.
 	 */
-	function map(element: string, id: string, options?: MapOptions): L.mapbox.Map;
-	function map(element: string, tilejson: any, options?: MapOptions): L.mapbox.Map;
+	function map(element: string|Element, id: string, options?: MapOptions): L.mapbox.Map;
+	function map(element: string|Element, tilejson: any, options?: MapOptions): L.mapbox.Map;
 
 	interface MapOptions extends L.Map.MapOptions {
 		featureLayer?  : FeatureLayerOptions;


### PR DESCRIPTION
The map(...) function allows both string and Element types as the first argument, documented here, https://www.mapbox.com/mapbox.js/api/v2.2.2/l-mapbox-map/

I've updated accordingly.
