### PR TITLE
Node.js: Added child_process.spawnSync

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -13,6 +13,7 @@ import * as dgram from "dgram";
 import * as querystring from "querystring";
 import * as path from "path";
 import * as readline from "readline";
+import * as childProcess from "child_process";
 
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
@@ -34,7 +35,7 @@ assert.doesNotThrow(() => {
 fs.writeFile("thebible.txt",
     "Do unto others as you would have them do unto you.",
     assert.ifError);
-    
+
 fs.write(1234, "test");
 
 fs.writeFile("Harry Potter",
@@ -382,3 +383,10 @@ rl.prompt(true);
 rl.question("do you like typescript?", function(answer: string) {
   rl.close();
 });
+
+//////////////////////////////////////////////////////////////////////
+/// Child Process tests: https://nodejs.org/api/child_process.html ///
+//////////////////////////////////////////////////////////////////////
+
+childProcess.exec("echo test");
+childProcess.spawnSync("echo test");

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -868,6 +868,26 @@ declare module "child_process" {
         env?: any;
         encoding?: string;
     }): ChildProcess;
+    export function spawnSync(command: string, args?: string[], options?: {
+        cwd?: string;
+        input?: string | Buffer;
+        stdio?: any;
+        env?: any;
+        uid?: number;
+        gid?: number;
+        timeout?: number;
+        maxBuffer?: number;
+        killSignal?: string;
+        encoding?: string;
+    }): {
+        pid: number;
+        output: string[];
+        stdout: string | Buffer;
+        stderr: string | Buffer;
+        status: number;
+        signal: string;
+        error: Error;
+    };
     export function execSync(command: string, options?: {
         cwd?: string;
         input?: string|Buffer;


### PR DESCRIPTION
The node documentation and source code contains [the child_process.spawnSync](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options) function, but the current version of node.d.ts doesn't. This commit adds the method.
