### PR TITLE
Sigma.JS: Added labels definition to svg edges

### DIFF
--- a/sigmajs/sigmajs-tests.ts
+++ b/sigmajs/sigmajs-tests.ts
@@ -26,6 +26,10 @@ module SigmaJsTests {
     sigma.canvas.edges['def'] = function() {};
     sigma.svg.nodes['def'] = {create: (obj: SigmaJs.Node) => { return new Element(); },
                        update: (obj: SigmaJs.Node) => { return; }};
+    sigma.svg.edges['def'] = {create: (obj: SigmaJs.Edge) => { return new Element(); },
+                              update: (obj: SigmaJs.Edge) => { return; }};
+    sigma.svg.edges.labels['def'] = {create: (obj: SigmaJs.Edge) => { return new Element(); },
+                                     update: (obj: SigmaJs.Edge) => { return; }};
 
     var N = 100;
     var E = 500;

--- a/sigmajs/sigmajs.d.ts
+++ b/sigmajs/sigmajs.d.ts
@@ -287,9 +287,16 @@ declare module SigmaJs{
     }
 
     interface SVG {
-        edges: {[renderType: string]: SVGObject<SigmaJs.Edge>};
+        edges: {
+            labels: SVGEdgeLabels;
+            [renderType: string]: SVGObject<SigmaJs.Edge> | SVGEdgeLabels;
+        };
         labels: {[renderType: string]: SVGObject<SigmaJs.Node>};
         nodes: {[renderType: string]: SVGObject<SigmaJs.Node>};
+    }
+
+    interface SVGEdgeLabels {
+        [renderType: string]: SVGObject<SigmaJs.Edge>;
     }
 
     interface SVGObject<T> {


### PR DESCRIPTION
The renderer for edge labels is nested under the edges object in SigmaJs (along with the renderers for the edges themselves), so this will allow for accessing both the edge label and edge renderers.
