### PR TITLE
Update d3.geom.quadtree<T>(..) to accept arguments

### DIFF
--- a/d3/d3-tests.ts
+++ b/d3/d3-tests.ts
@@ -1448,17 +1448,17 @@ function quadtree() {
     }
 
     // Collapse the quadtree into an array of rectangles.
-    function nodes(quadtree: d3.geom.quadtree.Quadtree<[number, number]>) {
+    function nodes(quadtree: d3.geom.quadtree.QuadtreeNode<[number, number]>) {
         var nodes: Array<{x: number; y: number; width: number; height: number}> = [];
-        quadtree.visit(function (node, x1, y1, x2, y2) {
+        quadtree.visit(function (node: d3.geom.quadtree.Node<[number, number]>, x1: number, y1: number, x2:number, y2: number) {
             nodes.push({ x: x1, y: y1, width: x2 - x1, height: y2 - y1 });
         } );
         return nodes;
     }
 
     // Find the nodes within the specified rectangle.
-    function search(quadtree: d3.geom.quadtree.Quadtree<{ scanned?: boolean; selected?: boolean; 0: number; 1: number }>, x0: number, y0: number, x3: number, y3: number) {
-        quadtree.visit(function (node, x1, y1, x2, y2) {
+    function search(quadtree: d3.geom.quadtree.QuadtreeNode<{ scanned?: boolean; selected?: boolean; 0: number; 1: number }>, x0: number, y0: number, x3: number, y3: number) {
+        quadtree.visit(function (node: d3.geom.quadtree.Node<{ scanned?: boolean; selected?: boolean; 0: number; 1: number }>, x1: number, y1: number, x2:number, y2: number) {
             var p = node.point;
             if (p) {
                 p.scanned = true;

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -3251,7 +3251,7 @@ declare module d3 {
         export function delaunay(vertices: Array<[number, number]>): Array<[[number, number], [number, number], [number, number]]>;
 
         export function quadtree(): Quadtree<[number, number]>;
-        export function quadtree<T>(): Quadtree<T>;
+        export function quadtree<T>(nodes: T[], x1?: number, y1?: number, x2?: number, y2?: number): quadtree.QuadtreeNode<T>;
 
         module quadtree {
             interface Node<T> {
@@ -3262,7 +3262,7 @@ declare module d3 {
                 y: number;
             }
 
-            interface Quadtree<T> extends Node<T> {
+            interface QuadtreeNode<T> extends Node<T> {
                 add(point: T): void;
                 visit(callback: (node: Node<T>, x1: number, y1: number, x2: number, y2: number) => boolean | void): void;
                 find(point: [number, number]): T;
@@ -3270,7 +3270,7 @@ declare module d3 {
         }
 
         interface Quadtree<T> {
-            (points: T[]): quadtree.Quadtree<T>;
+            (points: T[]): quadtree.QuadtreeNode<T>;
 
             x(): (datum: T, index: number) => number;
             x(x: number): Quadtree<T>;

--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -108,6 +108,8 @@ declare module "express" {
             use(path: string, handler: ErrorRequestHandler): T;
             use(path: string[], ...handler: RequestHandler[]): T;
             use(path: string[], handler: ErrorRequestHandler): T;
+            use(path: RegExp, ...handler: RequestHandler[]): T;
+            use(path: RegExp, handler: ErrorRequestHandler): T;
         }
 
         export function Router(options?: any): Router;

--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -34,7 +34,7 @@ assert.doesNotThrow(() => {
 fs.writeFile("thebible.txt",
     "Do unto others as you would have them do unto you.",
     assert.ifError);
-    
+
 fs.write(1234, "test");
 
 fs.writeFile("Harry Potter",
@@ -87,6 +87,25 @@ function bufferTests() {
     console.log(Buffer.byteLength('xyz123', 'ascii'));
     var result1 = Buffer.concat([utf8Buffer, base64Buffer]);
     var result2 = Buffer.concat([utf8Buffer, base64Buffer], 9999999);
+
+    // Test that TS 1.6 works with the 'as Buffer' annotation
+    // on isBuffer.
+    var a: Buffer | number;
+    a = new Buffer(10);
+    if (Buffer.isBuffer(a)) {
+        a.writeUInt8(3, 4);
+    }
+
+    // write* methods return offsets.
+    var b = new Buffer(16);
+    var result: number = b.writeUInt32LE(0, 0);
+    result = b.writeUInt16LE(0, 4);
+    result = b.writeUInt8(0, 6);
+    result = b.writeInt8(0, 7);
+    result = b.writeDoubleLE(0, 8);
+
+    // fill returns the input buffer.
+    b.fill('a').fill('b');
 }
 
 

--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -13,6 +13,7 @@ import * as dgram from "dgram";
 import * as querystring from "querystring";
 import * as path from "path";
 import * as readline from "readline";
+import * as childProcess from "child_process";
 
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
@@ -34,7 +35,7 @@ assert.doesNotThrow(() => {
 fs.writeFile("thebible.txt",
     "Do unto others as you would have them do unto you.",
     assert.ifError);
-    
+
 fs.write(1234, "test");
 
 fs.writeFile("Harry Potter",
@@ -382,3 +383,10 @@ rl.prompt(true);
 rl.question("do you like typescript?", function(answer: string) {
   rl.close();
 });
+
+//////////////////////////////////////////////////////////////////////
+/// Child Process tests: https://nodejs.org/api/child_process.html ///
+//////////////////////////////////////////////////////////////////////
+
+childProcess.exec("echo test");
+childProcess.spawnSync("echo test");

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -119,7 +119,7 @@ declare var Buffer: {
      *
      * @param obj object to test.
      */
-    isBuffer(obj: any): boolean;
+    isBuffer(obj: any): obj is Buffer;
     /**
      * Returns true if {encoding} is a valid encoding argument.
      * Valid string encodings in Node 0.12: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
@@ -377,21 +377,21 @@ interface NodeBuffer {
     readFloatBE(offset: number, noAssert?: boolean): number;
     readDoubleLE(offset: number, noAssert?: boolean): number;
     readDoubleBE(offset: number, noAssert?: boolean): number;
-    writeUInt8(value: number, offset: number, noAssert?: boolean): void;
-    writeUInt16LE(value: number, offset: number, noAssert?: boolean): void;
-    writeUInt16BE(value: number, offset: number, noAssert?: boolean): void;
-    writeUInt32LE(value: number, offset: number, noAssert?: boolean): void;
-    writeUInt32BE(value: number, offset: number, noAssert?: boolean): void;
-    writeInt8(value: number, offset: number, noAssert?: boolean): void;
-    writeInt16LE(value: number, offset: number, noAssert?: boolean): void;
-    writeInt16BE(value: number, offset: number, noAssert?: boolean): void;
-    writeInt32LE(value: number, offset: number, noAssert?: boolean): void;
-    writeInt32BE(value: number, offset: number, noAssert?: boolean): void;
-    writeFloatLE(value: number, offset: number, noAssert?: boolean): void;
-    writeFloatBE(value: number, offset: number, noAssert?: boolean): void;
-    writeDoubleLE(value: number, offset: number, noAssert?: boolean): void;
-    writeDoubleBE(value: number, offset: number, noAssert?: boolean): void;
-    fill(value: any, offset?: number, end?: number): void;
+    writeUInt8(value: number, offset: number, noAssert?: boolean): number;
+    writeUInt16LE(value: number, offset: number, noAssert?: boolean): number;
+    writeUInt16BE(value: number, offset: number, noAssert?: boolean): number;
+    writeUInt32LE(value: number, offset: number, noAssert?: boolean): number;
+    writeUInt32BE(value: number, offset: number, noAssert?: boolean): number;
+    writeInt8(value: number, offset: number, noAssert?: boolean): number;
+    writeInt16LE(value: number, offset: number, noAssert?: boolean): number;
+    writeInt16BE(value: number, offset: number, noAssert?: boolean): number;
+    writeInt32LE(value: number, offset: number, noAssert?: boolean): number;
+    writeInt32BE(value: number, offset: number, noAssert?: boolean): number;
+    writeFloatLE(value: number, offset: number, noAssert?: boolean): number;
+    writeFloatBE(value: number, offset: number, noAssert?: boolean): number;
+    writeDoubleLE(value: number, offset: number, noAssert?: boolean): number;
+    writeDoubleBE(value: number, offset: number, noAssert?: boolean): number;
+    fill(value: any, offset?: number, end?: number): Buffer;
 }
 
 /************************************************

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -868,6 +868,26 @@ declare module "child_process" {
         env?: any;
         encoding?: string;
     }): ChildProcess;
+    export function spawnSync(command: string, args?: string[], options?: {
+        cwd?: string;
+        input?: string | Buffer;
+        stdio?: any;
+        env?: any;
+        uid?: number;
+        gid?: number;
+        timeout?: number;
+        maxBuffer?: number;
+        killSignal?: string;
+        encoding?: string;
+    }): {
+        pid: number;
+        output: string[];
+        stdout: string | Buffer;
+        stderr: string | Buffer;
+        status: number;
+        signal: string;
+        error: Error;
+    };
     export function execSync(command: string, options?: {
         cwd?: string;
         input?: string|Buffer;

--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -136,32 +136,32 @@ function Argv$options() {
 
 function command() {
 	var argv = yargs
-	.usage('npm <command>')
-	.command('install', 'tis a mighty fine package to install')
-	.command('publish', 'shiver me timbers, should you be sharing all that', yargs => {
-		argv = yargs.option('f', {
-			alias: 'force',
-			description: 'yar, it usually be a bad idea'
+		.usage('npm <command>')
+		.command('install', 'tis a mighty fine package to install')
+		.command('publish', 'shiver me timbers, should you be sharing all that', yargs => {
+			argv = yargs.option('f', {
+				alias: 'force',
+				description: 'yar, it usually be a bad idea'
+			})
+			.help('help')
+			.argv;
 		})
 		.help('help')
 		.argv;
-	})
-	.help('help')
-	.argv;
 }
 
 function completion_sync() {
 	var argv = yargs
-	.completion('completion', (current, argv) => {
-		// 'current' is the current command being completed.
-		// 'argv' is the parsed arguments so far.
-		// simply return an array of completions.
-		return [
-			'foo',
-			'bar'
-		];
-	})
-	.argv;
+		.completion('completion', (current, argv) => {
+			// 'current' is the current command being completed.
+			// 'argv' is the parsed arguments so far.
+			// simply return an array of completions.
+			return [
+				'foo',
+				'bar'
+			];
+		})
+		.argv;
 }
 
 function completion_async() {

--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -134,6 +134,22 @@ function Argv$options() {
 	;
 }
 
+function command() {
+	var argv = yargs
+	.usage('npm <command>')
+	.command('install', 'tis a mighty fine package to install')
+	.command('publish', 'shiver me timbers, should you be sharing all that', yargs => {
+		argv = yargs.option('f', {
+			alias: 'force',
+			description: 'yar, it usually be a bad idea'
+		})
+		.help('help')
+		.argv;
+	})
+	.help('help')
+	.argv;
+}
+
 function Argv$help() {
 	var yargs1 = yargs
 		.usage("$0 -operand1 number -operand2 number -operation [add|subtract]");

--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -150,6 +150,33 @@ function command() {
 	.argv;
 }
 
+function completion_sync() {
+	var argv = yargs
+	.completion('completion', (current, argv) => {
+		// 'current' is the current command being completed.
+		// 'argv' is the parsed arguments so far.
+		// simply return an array of completions.
+		return [
+			'foo',
+			'bar'
+		];
+	})
+	.argv;
+}
+
+function completion_async() {
+	var argv = yargs
+		.completion('completion', (current, argv, done) => {
+			setTimeout(function() {
+				done([
+					'apple',
+					'banana'
+				]);
+			}, 500);
+		})
+		.argv;
+}
+
 function Argv$help() {
 	var yargs1 = yargs
 		.usage("$0 -operand1 number -operand2 number -operation [add|subtract]");

--- a/yargs/yargs.d.ts
+++ b/yargs/yargs.d.ts
@@ -54,6 +54,7 @@ declare module "yargs" {
 			usage(options?: { [key: string]: Options }): Argv;
 
 			command(command: string, description: string): Argv;
+			command(command: string, description: string, fn: (args: Argv) => void): Argv;
 
 			example(command: string, description: string): Argv;
 

--- a/yargs/yargs.d.ts
+++ b/yargs/yargs.d.ts
@@ -56,6 +56,11 @@ declare module "yargs" {
 			command(command: string, description: string): Argv;
 			command(command: string, description: string, fn: (args: Argv) => void): Argv;
 
+			completion(cmd: string, fn?: SyncCompletionFunction): Argv;
+			completion(cmd: string, description?: string, fn?: SyncCompletionFunction): Argv;
+			completion(cmd: string, fn?: AsyncCompletionFunction): Argv;
+			completion(cmd: string, description?: string, fn?: AsyncCompletionFunction): Argv;
+
 			example(command: string, description: string): Argv;
 
 			check(func: (argv: any, aliases: { [alias: string]: string }) => any): Argv;
@@ -111,6 +116,9 @@ declare module "yargs" {
 			desc?: any;
 			requiresArg?: any;
 		}
+
+		type SyncCompletionFunction = (current: string, argv: any) => string[];
+		type AsyncCompletionFunction = (current: string, argv: any, done: (completion: string[]) => void) => void;
 	}
 
 	var yargs: yargs.Argv;


### PR DESCRIPTION
d3.geom.quadtree<T>(..) should accept 4 arguments
Rename quadtree.Quadtree to quadtree.QuadtreeNode to differentiate the interface from Quadtree
