### PR TITLE
Added `target` property to ScrollSpyOptions

### DIFF
--- a/bootstrap/bootstrap-tests.ts
+++ b/bootstrap/bootstrap-tests.ts
@@ -17,6 +17,7 @@ $('#myModal').modal('toggle');
 $('.dropdown-toggle').dropdown();
 
 $('#navbar').scrollspy();
+$('body').scrollspy({ target: '#navbar-example' });
 
 $('#element').tooltip('show');
 

--- a/bootstrap/bootstrap.d.ts
+++ b/bootstrap/bootstrap.d.ts
@@ -22,6 +22,7 @@ interface ModalOptionsBackdropString {
 
 interface ScrollSpyOptions {
     offset?: number;
+    target?: string;
 }
 
 interface TooltipOptions {


### PR DESCRIPTION
The [docs](http://getbootstrap.com/javascript/#via-javascript-2) show this usage.

``` js
$('body').scrollspy({ target: '#navbar-example' })
```
