### PR TITLE
Add completion and command parameter to yargs

### DIFF
--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -136,32 +136,32 @@ function Argv$options() {
 
 function command() {
 	var argv = yargs
-	.usage('npm <command>')
-	.command('install', 'tis a mighty fine package to install')
-	.command('publish', 'shiver me timbers, should you be sharing all that', yargs => {
-		argv = yargs.option('f', {
-			alias: 'force',
-			description: 'yar, it usually be a bad idea'
+		.usage('npm <command>')
+		.command('install', 'tis a mighty fine package to install')
+		.command('publish', 'shiver me timbers, should you be sharing all that', yargs => {
+			argv = yargs.option('f', {
+				alias: 'force',
+				description: 'yar, it usually be a bad idea'
+			})
+			.help('help')
+			.argv;
 		})
 		.help('help')
 		.argv;
-	})
-	.help('help')
-	.argv;
 }
 
 function completion_sync() {
 	var argv = yargs
-	.completion('completion', (current, argv) => {
-		// 'current' is the current command being completed.
-		// 'argv' is the parsed arguments so far.
-		// simply return an array of completions.
-		return [
-			'foo',
-			'bar'
-		];
-	})
-	.argv;
+		.completion('completion', (current, argv) => {
+			// 'current' is the current command being completed.
+			// 'argv' is the parsed arguments so far.
+			// simply return an array of completions.
+			return [
+				'foo',
+				'bar'
+			];
+		})
+		.argv;
 }
 
 function completion_async() {

--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -134,6 +134,22 @@ function Argv$options() {
 	;
 }
 
+function command() {
+	var argv = yargs
+	.usage('npm <command>')
+	.command('install', 'tis a mighty fine package to install')
+	.command('publish', 'shiver me timbers, should you be sharing all that', yargs => {
+		argv = yargs.option('f', {
+			alias: 'force',
+			description: 'yar, it usually be a bad idea'
+		})
+		.help('help')
+		.argv;
+	})
+	.help('help')
+	.argv;
+}
+
 function Argv$help() {
 	var yargs1 = yargs
 		.usage("$0 -operand1 number -operand2 number -operation [add|subtract]");

--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -150,6 +150,33 @@ function command() {
 	.argv;
 }
 
+function completion_sync() {
+	var argv = yargs
+	.completion('completion', (current, argv) => {
+		// 'current' is the current command being completed.
+		// 'argv' is the parsed arguments so far.
+		// simply return an array of completions.
+		return [
+			'foo',
+			'bar'
+		];
+	})
+	.argv;
+}
+
+function completion_async() {
+	var argv = yargs
+		.completion('completion', (current, argv, done) => {
+			setTimeout(function() {
+				done([
+					'apple',
+					'banana'
+				]);
+			}, 500);
+		})
+		.argv;
+}
+
 function Argv$help() {
 	var yargs1 = yargs
 		.usage("$0 -operand1 number -operand2 number -operation [add|subtract]");

--- a/yargs/yargs.d.ts
+++ b/yargs/yargs.d.ts
@@ -54,6 +54,7 @@ declare module "yargs" {
 			usage(options?: { [key: string]: Options }): Argv;
 
 			command(command: string, description: string): Argv;
+			command(command: string, description: string, fn: (args: Argv) => void): Argv;
 
 			example(command: string, description: string): Argv;
 

--- a/yargs/yargs.d.ts
+++ b/yargs/yargs.d.ts
@@ -56,6 +56,11 @@ declare module "yargs" {
 			command(command: string, description: string): Argv;
 			command(command: string, description: string, fn: (args: Argv) => void): Argv;
 
+			completion(cmd: string, fn?: SyncCompletionFunction): Argv;
+			completion(cmd: string, description?: string, fn?: SyncCompletionFunction): Argv;
+			completion(cmd: string, fn?: AsyncCompletionFunction): Argv;
+			completion(cmd: string, description?: string, fn?: AsyncCompletionFunction): Argv;
+
 			example(command: string, description: string): Argv;
 
 			check(func: (argv: any, aliases: { [alias: string]: string }) => any): Argv;
@@ -111,6 +116,9 @@ declare module "yargs" {
 			desc?: any;
 			requiresArg?: any;
 		}
+
+		type SyncCompletionFunction = (current: string, argv: any) => string[];
+		type AsyncCompletionFunction = (current: string, argv: any, done: (completion: string[]) => void) => void;
 	}
 
 	var yargs: yargs.Argv;


### PR DESCRIPTION
This PR adds
- the optional fn parameter to [command](https://www.npmjs.com/package/yargs#command-cmd-desc-fn)
- the [completion](https://www.npmjs.com/package/yargs#completion-cmd-description-fn) function
