### PR TITLE
Remove hard reference to underscore typings

### DIFF
--- a/backbone/backbone.d.ts
+++ b/backbone/backbone.d.ts
@@ -4,7 +4,6 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../jquery/jquery.d.ts" />
-/// <reference path="../underscore/underscore.d.ts" />
 
 declare module Backbone {
 


### PR DESCRIPTION
I removed the hard reference to the underscore typings. Keeping this reference in here makes it impossible to mix lodash and underscore in the same projects. In my case, another library is bringing in lodash, so I don't really have a choice.

By leaving out this reference, underscore or lodash can be included separately, and the user will still get typing information on that.
