### PR TITLE
[node] Updating write* methods to return offsets, fill to return the Buffer,…

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -34,7 +34,7 @@ assert.doesNotThrow(() => {
 fs.writeFile("thebible.txt",
     "Do unto others as you would have them do unto you.",
     assert.ifError);
-    
+
 fs.write(1234, "test");
 
 fs.writeFile("Harry Potter",
@@ -87,6 +87,25 @@ function bufferTests() {
     console.log(Buffer.byteLength('xyz123', 'ascii'));
     var result1 = Buffer.concat([utf8Buffer, base64Buffer]);
     var result2 = Buffer.concat([utf8Buffer, base64Buffer], 9999999);
+
+    // Test that TS 1.6 works with the 'as Buffer' annotation
+    // on isBuffer.
+    var a: Buffer | number;
+    a = new Buffer(10);
+    if (Buffer.isBuffer(a)) {
+        a.writeUInt8(3, 4);
+    }
+
+    // write* methods return offsets.
+    var b = new Buffer(16);
+    var result: number = b.writeUInt32LE(0, 0);
+    result = b.writeUInt16LE(0, 4);
+    result = b.writeUInt8(0, 6);
+    result = b.writeInt8(0, 7);
+    result = b.writeDoubleLE(0, 8);
+
+    // fill returns the input buffer.
+    b.fill('a').fill('b');
 }
 
 

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -119,7 +119,7 @@ declare var Buffer: {
      *
      * @param obj object to test.
      */
-    isBuffer(obj: any): boolean;
+    isBuffer(obj: any): obj is Buffer;
     /**
      * Returns true if {encoding} is a valid encoding argument.
      * Valid string encodings in Node 0.12: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
@@ -377,21 +377,21 @@ interface NodeBuffer {
     readFloatBE(offset: number, noAssert?: boolean): number;
     readDoubleLE(offset: number, noAssert?: boolean): number;
     readDoubleBE(offset: number, noAssert?: boolean): number;
-    writeUInt8(value: number, offset: number, noAssert?: boolean): void;
-    writeUInt16LE(value: number, offset: number, noAssert?: boolean): void;
-    writeUInt16BE(value: number, offset: number, noAssert?: boolean): void;
-    writeUInt32LE(value: number, offset: number, noAssert?: boolean): void;
-    writeUInt32BE(value: number, offset: number, noAssert?: boolean): void;
-    writeInt8(value: number, offset: number, noAssert?: boolean): void;
-    writeInt16LE(value: number, offset: number, noAssert?: boolean): void;
-    writeInt16BE(value: number, offset: number, noAssert?: boolean): void;
-    writeInt32LE(value: number, offset: number, noAssert?: boolean): void;
-    writeInt32BE(value: number, offset: number, noAssert?: boolean): void;
-    writeFloatLE(value: number, offset: number, noAssert?: boolean): void;
-    writeFloatBE(value: number, offset: number, noAssert?: boolean): void;
-    writeDoubleLE(value: number, offset: number, noAssert?: boolean): void;
-    writeDoubleBE(value: number, offset: number, noAssert?: boolean): void;
-    fill(value: any, offset?: number, end?: number): void;
+    writeUInt8(value: number, offset: number, noAssert?: boolean): number;
+    writeUInt16LE(value: number, offset: number, noAssert?: boolean): number;
+    writeUInt16BE(value: number, offset: number, noAssert?: boolean): number;
+    writeUInt32LE(value: number, offset: number, noAssert?: boolean): number;
+    writeUInt32BE(value: number, offset: number, noAssert?: boolean): number;
+    writeInt8(value: number, offset: number, noAssert?: boolean): number;
+    writeInt16LE(value: number, offset: number, noAssert?: boolean): number;
+    writeInt16BE(value: number, offset: number, noAssert?: boolean): number;
+    writeInt32LE(value: number, offset: number, noAssert?: boolean): number;
+    writeInt32BE(value: number, offset: number, noAssert?: boolean): number;
+    writeFloatLE(value: number, offset: number, noAssert?: boolean): number;
+    writeFloatBE(value: number, offset: number, noAssert?: boolean): number;
+    writeDoubleLE(value: number, offset: number, noAssert?: boolean): number;
+    writeDoubleBE(value: number, offset: number, noAssert?: boolean): number;
+    fill(value: any, offset?: number, end?: number): Buffer;
 }
 
 /************************************************


### PR DESCRIPTION
I've made the following changes to `Buffer`:
- **`write*` methods return a number.** [Node unit tests check for this](https://github.com/nodejs/node/blob/master/test/parallel/test-buffer.js#L773).
- **`fill` returns a Buffer.** Node's implementation explicitly returns the input Buffer.
- **`isBuffer` is a type guard.** It only returns `true` when the input is a `Buffer`, which is perfect for the new user-defined type guard feature of TS 1.6. :smile: 

I've added tests for this functionality, as well.

Let me know if you have questions or concerns!
