### PR TITLE
Use RegExp in Express use function

### DIFF
--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -108,6 +108,8 @@ declare module "express" {
             use(path: string, handler: ErrorRequestHandler): T;
             use(path: string[], ...handler: RequestHandler[]): T;
             use(path: string[], handler: ErrorRequestHandler): T;
+            use(path: RegExp, ...handler: RequestHandler[]): T;
+            use(path: RegExp, handler: ErrorRequestHandler): T;
         }
 
         export function Router(options?: any): Router;


### PR DESCRIPTION
If these lines are not in the express.d.ts
, Regexp are not accepted in 
app.use( regexp, function(req,res,nex){
//dostuff
});
