### PR TITLE
Updating react-dom to support ES6 import syntax and adding tests

### DIFF
--- a/react-dom/react-dom-tests.ts
+++ b/react-dom/react-dom-tests.ts
@@ -1,0 +1,13 @@
+/// <reference path="react-dom.d.ts" />
+import * as React from 'react';
+import * as ReactDom from 'react-dom';
+import * as ReactDomServer from 'react-dom/server';
+
+var reactElement: React.ReactElement<{}>;
+var DOMElement = document.getElementById("main");
+
+var r: React.Component<{}, {}> = ReactDom.render(reactElement, DOMElement);
+var u: boolean = ReactDom.unmountComponentAtNode(DOMElement);
+
+var s: string = ReactDomServer.renderToString(reactElement);
+var m: string = ReactDomServer.renderToStaticMarkup(reactElement);

--- a/react-dom/react-dom.d.ts
+++ b/react-dom/react-dom.d.ts
@@ -5,31 +5,31 @@
 
 /// <reference path="./../react/react.d.ts" />
 
-declare class __ReactDom {
-    public  render<P>(
+declare module __ReactDom {
+    export function render<P>(
         element: __React.DOMElement<P>,
         container: Element,
         callback?: () => any): __React.DOMComponent<P>;
-    public render<P, S>(
+    export function render<P, S>(
         element: __React.ClassicElement<P>,
         container: Element,
         callback?: () => any): __React.ClassicComponent<P, S>;
-    public render<P, S>(
+    export function render<P, S>(
         element: __React.ReactElement<P>,
         container: Element,
         callback?: () => any): __React.Component<P, S>;
 
-    public findDOMNode<TElement extends Element>(
+    export function findDOMNode<TElement extends Element>(
         componentOrElement: __React.Component<any, any> | Element): TElement;
-    public findDOMNode(
+    export function findDOMNode(
         componentOrElement: __React.Component<any, any> | Element): Element;
 
-    public unmountComponentAtNode(container: Element): boolean;
+    export function unmountComponentAtNode(container: Element): boolean;
 }
 
-declare class __ReactDomServer {
-    public  renderToString(element: __React.ReactElement<any>): string;
-    public  renderToStaticMarkup(element: __React.ReactElement<any>): string;
+declare module __ReactDomServer {
+    export function renderToString(element: __React.ReactElement<any>): string;
+    export function renderToStaticMarkup(element: __React.ReactElement<any>): string;
 }
 declare module "react-dom" {
     export  = __ReactDom


### PR DESCRIPTION
``` typescript
import * as ReactDOM from 'react-dom'
```

This previously was failing as it was declared as a class. Now it will work with the new method and the old require method.
