### PR TITLE
Rewritten definitions for easy-table v1.0.0

### DIFF
--- a/easy-table/easy-table-0.2.0-tests.ts
+++ b/easy-table/easy-table-0.2.0-tests.ts
@@ -1,0 +1,15 @@
+/// <reference path="easy-table.d.ts" />
+
+import EasyTable = require('easy-table');
+
+var table = new EasyTable();
+
+table.cell('aa', 1);
+table.cell('bb',1);
+table.newRow();
+
+table.cell('aa', 1);
+table.cell('bb',1);
+
+table.print();
+

--- a/easy-table/easy-table-0.2.0-tests.ts
+++ b/easy-table/easy-table-0.2.0-tests.ts
@@ -12,4 +12,3 @@ table.cell('aa', 1);
 table.cell('bb',1);
 
 table.print();
-

--- a/easy-table/easy-table-0.2.0.d.ts
+++ b/easy-table/easy-table-0.2.0.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for easy-table 0.2.0
+// Project: https://github.com/eldargab/easy-table
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module "easy-table" {
+	class EasyTable {
+		constructor();
+
+		cell(label: string, value: any, printer?: EasyTable.CellPrinter, width?: number):void;
+		newRow(): void;
+		toString(): string;
+		printTransposed(): string;
+		print(): string;
+		sort(fields: string): void;
+		sort(comparer: (a: any, b: any) => number): void;
+		total(label: string, accumulator: EasyTable.Accumulator, totalPrinter: EasyTable.CellPrinter): void;
+	}
+
+	module EasyTable {
+		function printArray(array: any[], cellPrinter?: CellPrinter, tablePrinter?: Printer): string;
+		function printObject(object: any, cellPrinter?: CellPrinter, tablePrinter?: Printer): string;
+
+		//printer helpers
+		function Number(length: number): CellPrinter;
+		function RightPadder(char: string): CellPrinter;
+		function LeftPadder(char: string): CellPrinter;
+
+		interface CellPrinter extends Function {
+			(obj: any, cell: (label: string, value: any, width?: number) => void):string;
+		}
+		interface Printer extends Function {
+			(table: EasyTable):string;
+		}
+		interface Accumulator extends Function {
+			(sum: number, val: number, index: number, length: number):number;
+		}
+	}
+
+	export = EasyTable;
+}

--- a/easy-table/easy-table-tests.ts
+++ b/easy-table/easy-table-tests.ts
@@ -1,9 +1,7 @@
 ///<reference path="easy-table.d.ts" />
 
-//import * as Table from "easy-table";
-//import * as Table from "easy-table";
-
 import Table = require("easy-table");
+
 let data = [
 	{ id: 123123, desc: 'Something awesome', price: 1000.00 },
 	{ id: 245452, desc: 'Very interesting book', price: 11.45 },

--- a/easy-table/easy-table-tests.ts
+++ b/easy-table/easy-table-tests.ts
@@ -1,15 +1,105 @@
-/// <reference path="easy-table.d.ts" />
+///<reference path="easy-table.d.ts" />
 
-import EasyTable = require('easy-table');
+//import * as Table from "easy-table";
+//import * as Table from "easy-table";
 
-var table = new EasyTable();
+import Table = require("easy-table");
+let data = [
+	{ id: 123123, desc: 'Something awesome', price: 1000.00 },
+	{ id: 245452, desc: 'Very interesting book', price: 11.45 },
+	{ id: 232323, desc: 'Yet another product', price: 555.55 }
+];
 
-table.cell('aa', 1);
-table.cell('bb',1);
-table.newRow();
+interface IData {
+	id: number;
+	desc: string;
+	price: number;
+}
 
-table.cell('aa', 1);
-table.cell('bb',1);
+function sample_test() {
+	let t = new Table();
+	data.forEach(function(product) {
+		t.cell('Product Id', product.id);
+		t.cell('Description', product.desc);
+		t.cell('Price, USD', product.price, Table.number(2));
+		t.newRow();
+	});
+	console.log(t.toString());
+}
 
-table.print();
+function static_print() {
+	console.log(Table.print(data));
+}
 
+function currency(val: number, width?: number) {
+	var str = val.toFixed(2);
+	return width ? str : Table.padLeft(str, width);
+}
+
+function sample_2() {
+	Table.print<IData>(data, {
+		desc: { name: 'description' },
+		price: { printer: Table.number(2) }
+	});
+}
+
+function sample_3() {
+	Table.print(data, function(item, cell) {
+		cell('Product id', item.id)
+		cell('Price, USD', item.price)
+	}, function(table) {
+		return table.print()
+	})
+}
+
+function sample_4() {
+	Table.print(data[0]);
+}
+
+function sort_strings() {
+	let t = new Table();
+	t.sort(['Price, USD|des']) // will sort in descending order
+	t.sort(['Price, USD|asc']) // will sort in ascending order
+	t.sort(['Price, USD']) // sorts in ascending order by default
+}
+
+function totalling() {
+	let t = new Table();
+	t.total('Price, USD');
+	t.total('Price, USD', {
+		printer: Table.aggr.printer('Avg: ', currency),
+		reduce: Table.aggr.avg,
+		init: 0
+	})
+
+	// or alternatively
+	t.total('Price, USD', {
+		printer: (val, width) => {
+			return Table.padLeft('Avg: ' + currency(val), width);
+		},
+		reduce: (acc: number, val: number, idx: number, len: number) => {
+			acc = acc + val;
+			return idx + 1 == len ? acc / len : acc;
+		}
+	});
+}
+
+function other_samples() {
+	var t = new Table();
+
+	data.forEach(product => {
+		t.cell('Product Id', product.id)
+		t.cell('Description', product.desc)
+		t.cell('Price, USD', product.price, Table.number(2))
+		t.newRow()
+	})
+
+	t.sort(['Price, USD'])
+	t.total('Price, USD', {
+		printer: Table.number(2)
+	})
+
+	t.log()
+	Table.log(data, { price: { printer: Table.number(2) } })
+	Table.log(data[0])
+}

--- a/easy-table/easy-table-tests.ts
+++ b/easy-table/easy-table-tests.ts
@@ -8,7 +8,7 @@ let data = [
 	{ id: 232323, desc: 'Yet another product', price: 555.55 }
 ];
 
-interface IData {
+interface Data {
 	id: number;
 	desc: string;
 	price: number;
@@ -35,7 +35,7 @@ function currency(val: number, width?: number) {
 }
 
 function sample_2() {
-	Table.print<IData>(data, {
+	Table.print<Data>(data, {
 		desc: { name: 'description' },
 		price: { printer: Table.number(2) }
 	});

--- a/easy-table/easy-table.d.ts
+++ b/easy-table/easy-table.d.ts
@@ -1,40 +1,222 @@
-// Type definitions for easy-table 0.2.0
+// Type definitions for easy-table
 // Project: https://github.com/eldargab/easy-table
-// Definitions by: Bart van der Schoor <https://github.com/Bartvds>
+// Definitions by: Niklas Mollenhauer <https://github.com/nikeee>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare module "easy-table" {
+declare module "easy-table"
+{
 	class EasyTable {
-		constructor();
 
-		cell(label: string, value: any, printer?: EasyTable.CellPrinter, width?: number):void;
-		newRow(): void;
-		toString(): string;
-		printTransposed(): string;
-		print(): string;
-		sort(fields: string): void;
-		sort(comparer: (a: any, b: any) => number): void;
-		total(label: string, accumulator: EasyTable.Accumulator, totalPrinter: EasyTable.CellPrinter): void;
+		/**
+		 * String to separate columns
+		 */
+		public separator: string;
+
+		/**
+		 * Default printer
+		 */
+		public static string(value: any): string;
+
+		/**
+		 * Create a printer which right aligns the content by padding with `ch` on the left
+		 *
+		 * @param {String} ch
+		 * @returns {Function}
+		 */
+		public static leftPadder<T>(ch: number): CellPrinter<T>;
+
+		public static padLeft: CellPrinter<string>;
+
+		/**
+		 * Create a printer which pads with `ch` on the right
+		 *
+		 * @param {String} ch
+		 * @returns {Function}
+		 */
+		public static rightPadder<T>(ch: number): CellPrinter<T>;
+
+		public static padRight: CellPrinter<string>;
+
+		/**
+		 * Create a printer for numbers
+		 *
+		 * Will do right alignment and optionally fix the number of digits after decimal point
+		 *
+		 * @param {Number} [digits] - Number of digits for fixpoint notation
+		 * @returns {Function}
+		 */
+		public static number(digits?: number): CellPrinter<number>;
+
+		public constructor();
+
+		/**
+		 * Push the current row to the table and start a new one
+		 *
+		 * @returns {Table} `this`
+		 */
+		public newRow(): EasyTable;
+
+		/**
+		 * Write cell in the current row
+		 *
+		 * @param {String} col          - Column name
+		 * @param {Any} val             - Cell value
+		 * @param {Function} [printer]  - Printer function to format the value
+		 * @returns {Table} `this`
+		 */
+		public cell<T>(col: string, val: T, printer?: CellPrinter<T>): EasyTable;
+
+		/**
+		 * Get list of columns in printing order
+		 *
+		 * @returns {string[]}
+		 */
+		public columns(): string[];
+
+		/**
+		 * Format just rows, i.e. print the table without headers and totals
+		 *
+		 * @returns {String} String representaion of the table
+		 */
+		public print(): string;
+
+		/**
+		 * Format the table
+		 *
+		 * @returns {String}
+		 */
+		public toString(): string;
+
+		/**
+		 * Push delimeter row to the table (with each cell filled with dashs during printing)
+		 *
+		 * @param {String[]} [cols]
+		 * @returns {Table} `this`
+		 */
+		public pushDelimeter(cols?: string[]): EasyTable;
+
+		/**
+		 * Compute all totals and yield the results to `cb`
+		 *
+		 * @param {Function} cb - Callback function with signature `(column, value, printer)`
+		 */
+		public forEachTotal<T>(cb: (column: string, value: T, printer: CellPrinter<T>) => void): void;
+
+		/**
+		 * Format the table so that each row represents column and each column represents row
+		 *
+		 * @param {IPrintColumnOptions} [opts]
+		 * @returns {String}
+		 */
+		public printTransposed<T>(opts?: IPrintColumnOptions<T>): string;
+
+		/**
+		 * Sort the table
+		 *
+		 * @param {Function|string[]} [cmp] - Either compare function or a list of columns to sort on
+		 * @returns {Table} `this`
+		 */
+		public sort(cmp?: string[]): EasyTable;
+		/**
+		 * Sort the table
+		 *
+		 * @param {Function|string[]} [cmp] - Either compare function or a list of columns to sort on
+		 * @returns {Table} `this`
+		 */
+		public sort<T>(cmp?: CompareFunction<T>): EasyTable;
+
+		/**
+		 * Add a total for the column
+		 *
+		 * @param {String} col - column name
+		 * @param {Object} [opts]
+		 * @returns {Table} `this`
+		 */
+		public total<T>(col: string, opts?: ITotalOptions<T>): EasyTable;
+		/**
+		 * Predefined helpers for totals
+		 */
+		public static aggr: IAggregators;
+
+		/**
+		 * Print the array or object
+		 *
+		 * @param {Array|Object} obj - Object to print
+		 * @param {Function|Object} [format] - Format options
+		 * @param {Function} [cb] - Table post processing and formating
+		 * @returns {String}
+		 */
+		public static print<T>(obj: T | T[], format?: FormatFunction<T> | IFormatObject, cb?: TablePostProcessing): string;
+
+		/**
+		 * Same as `Table.print()` but yields the result to `console.log()`
+		 */
+		public static log<T>(obj: T | T[], format?: FormatFunction<T> | IFormatObject, cb?: TablePostProcessing): void;
+		/**
+		 * Same as `.toString()` but yields the result to `console.log()`
+		 */
+		public log(): void;
 	}
 
-	module EasyTable {
-		function printArray(array: any[], cellPrinter?: CellPrinter, tablePrinter?: Printer): string;
-		function printObject(object: any, cellPrinter?: CellPrinter, tablePrinter?: Printer): string;
+	type CellPrinter<T> = (val: T, width: number) => string;
+	type CompareFunction<T> = (a: T, b: T) => number;
+	type ReduceFunction<T> = (acc: T, val: T, idx: number, length: number) => T;
+	type FormatFunction<T> = (obj: T, cell: (name: string, val: any) => void) => void;
+	type TablePostProcessing = (result: EasyTable) => string;
 
-		//printer helpers
-		function Number(length: number): CellPrinter;
-		function RightPadder(char: string): CellPrinter;
-		function LeftPadder(char: string): CellPrinter;
+	interface IPrintColumnOptions<T> {
+		/**
+		 * Column separation string
+		 */
+		separator?: string;
+		/**
+		 * Printer to format column names
+		 */
+		namePrinter?: CellPrinter<T>;
+	}
 
-		interface CellPrinter extends Function {
-			(obj: any, cell: (label: string, value: any, width?: number) => void):string;
-		}
-		interface Printer extends Function {
-			(table: EasyTable):string;
-		}
-		interface Accumulator extends Function {
-			(sum: number, val: number, index: number, length: number):number;
-		}
+	interface IAggregators {
+		/**
+		 * Create a printer which formats the value with `printer`,
+		 * adds the `prefix` to it and right aligns the whole thing
+		 *
+		 * @param {String} prefix
+		 * @param {Function} printer
+		 * @returns {printer}
+		 */
+		printer<T>(prefix: string, printer: CellPrinter<T>): CellPrinter<T>;
+		/**
+		 * Sum reduction
+		 */
+		sum: any;
+		/**
+		 * Average reduction
+		 */
+		avg: any;
+	}
+
+	interface ITotalOptions<T> {
+		/**
+		 * reduce(acc, val, idx, length) function to compute the total value
+		 */
+		reduce?: ReduceFunction<T>;
+		/**
+		 * Printer to format the total cell
+		 */
+		printer?: CellPrinter<T>;
+		/**
+		 * Initial value for reduction
+		 */
+		init?: T;
+	}
+
+	interface IFormatObject {
+		[key: string]: IColumnFormat<any>;
+	}
+
+	interface IColumnFormat<T> {
+		name?: string;
+		printer?: CellPrinter<T>
 	}
 
 	export = EasyTable;

--- a/easy-table/easy-table.d.ts
+++ b/easy-table/easy-table.d.ts
@@ -23,7 +23,7 @@ declare module "easy-table"
 		 * @param {String} ch
 		 * @returns {Function}
 		 */
-		public static leftPadder<T>(ch: number): CellPrinter<T>;
+		public static leftPadder<T>(ch: string): CellPrinter<T>;
 
 		public static padLeft: CellPrinter<string>;
 
@@ -33,9 +33,9 @@ declare module "easy-table"
 		 * @param {String} ch
 		 * @returns {Function}
 		 */
-		public static rightPadder<T>(ch: number): CellPrinter<T>;
+		public static rightPadder<T>(ch: string): CellPrinter<T>;
 
-		public static padRight: CellPrinter<string>;
+		// public static padRight: CellPrinter<string>;
 
 		/**
 		 * Create a printer for numbers

--- a/easy-table/easy-table.d.ts
+++ b/easy-table/easy-table.d.ts
@@ -108,7 +108,7 @@ declare module "easy-table"
 		 * @param {IPrintColumnOptions} [opts]
 		 * @returns {String}
 		 */
-		public printTransposed<T>(opts?: IPrintColumnOptions<T>): string;
+		public printTransposed<T>(opts?: PrintColumnOptions<T>): string;
 
 		/**
 		 * Sort the table
@@ -132,11 +132,11 @@ declare module "easy-table"
 		 * @param {Object} [opts]
 		 * @returns {Table} `this`
 		 */
-		public total<T>(col: string, opts?: ITotalOptions<T>): EasyTable;
+		public total<T>(col: string, opts?: TotalOptions<T>): EasyTable;
 		/**
 		 * Predefined helpers for totals
 		 */
-		public static aggr: IAggregators;
+		public static aggr: Aggregators;
 
 		/**
 		 * Print the array or object
@@ -146,12 +146,12 @@ declare module "easy-table"
 		 * @param {Function} [cb] - Table post processing and formating
 		 * @returns {String}
 		 */
-		public static print<T>(obj: T | T[], format?: FormatFunction<T> | IFormatObject, cb?: TablePostProcessing): string;
+		public static print<T>(obj: T | T[], format?: FormatFunction<T> | FormatObject, cb?: TablePostProcessing): string;
 
 		/**
 		 * Same as `Table.print()` but yields the result to `console.log()`
 		 */
-		public static log<T>(obj: T | T[], format?: FormatFunction<T> | IFormatObject, cb?: TablePostProcessing): void;
+		public static log<T>(obj: T | T[], format?: FormatFunction<T> | FormatObject, cb?: TablePostProcessing): void;
 		/**
 		 * Same as `.toString()` but yields the result to `console.log()`
 		 */
@@ -164,7 +164,7 @@ declare module "easy-table"
 	type FormatFunction<T> = (obj: T, cell: (name: string, val: any) => void) => void;
 	type TablePostProcessing = (result: EasyTable) => string;
 
-	interface IPrintColumnOptions<T> {
+	interface PrintColumnOptions<T> {
 		/**
 		 * Column separation string
 		 */
@@ -175,7 +175,7 @@ declare module "easy-table"
 		namePrinter?: CellPrinter<T>;
 	}
 
-	interface IAggregators {
+	interface Aggregators {
 		/**
 		 * Create a printer which formats the value with `printer`,
 		 * adds the `prefix` to it and right aligns the whole thing
@@ -195,7 +195,7 @@ declare module "easy-table"
 		avg: any;
 	}
 
-	interface ITotalOptions<T> {
+	interface TotalOptions<T> {
 		/**
 		 * reduce(acc, val, idx, length) function to compute the total value
 		 */
@@ -210,11 +210,11 @@ declare module "easy-table"
 		init?: T;
 	}
 
-	interface IFormatObject {
-		[key: string]: IColumnFormat<any>;
+	interface FormatObject {
+		[key: string]: ColumnFormat<any>;
 	}
 
-	interface IColumnFormat<T> {
+	interface ColumnFormat<T> {
 		name?: string;
 		printer?: CellPrinter<T>
 	}


### PR DESCRIPTION
This PR adds completely new written definitions for [easy-table](https://www.npmjs.com/package/easy-table). There were many changes to the API of easy-table, so I decided to do a rewrite and moved the definitions of 0.2.0 to separate files (@Bartvds).

Docs: https://github.com/eldargab/easy-table/blob/master/README.md
Source: https://github.com/eldargab/easy-table/blob/master/lib/table.js

The tests contain all samples which are in the docs. 
