### PR TITLE
removed es6-promise dependency from react-bootstrap

### DIFF
--- a/react-bootstrap/react-bootstrap.d.ts
+++ b/react-bootstrap/react-bootstrap.d.ts
@@ -4,7 +4,6 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 ///<reference path="../react/react.d.ts"/>
-///<reference path="../es6-promise/es6-promise.d.ts" />
     
 declare module "react-bootstrap" {
     // Import React 


### PR DESCRIPTION
React-Bootstrap package right now unnecessarily uses es6-promise module. This makes it incompatible in projects which use other Promise libraries such as Bluebird. No instance of Promise is used in react-bootstrap so removing the reference from teh module.
