### PR TITLE
react-dom wasn't usable

### DIFF
--- a/react-dom/react-dom.d.ts
+++ b/react-dom/react-dom.d.ts
@@ -5,36 +5,36 @@
 
 /// <reference path="./../react/react.d.ts" />
 
-declare class __ReactDom {
-    public  render<P>(
+declare namespace __ReactDom {
+    function render<P>(
         element: __React.DOMElement<P>,
         container: Element,
         callback?: () => any): __React.DOMComponent<P>;
-    public render<P, S>(
+    function render<P, S>(
         element: __React.ClassicElement<P>,
         container: Element,
         callback?: () => any): __React.ClassicComponent<P, S>;
-    public render<P, S>(
+    function render<P, S>(
         element: __React.ReactElement<P>,
         container: Element,
         callback?: () => any): __React.Component<P, S>;
 
-    public findDOMNode<TElement extends Element>(
+    function findDOMNode<TElement extends Element>(
         componentOrElement: __React.Component<any, any> | Element): TElement;
-    public findDOMNode(
+    function findDOMNode(
         componentOrElement: __React.Component<any, any> | Element): Element;
 
-    public unmountComponentAtNode(container: Element): boolean;
+    function unmountComponentAtNode(container: Element): boolean;
 }
 
-declare class __ReactDomServer {
-    public  renderToString(element: __React.ReactElement<any>): string;
-    public  renderToStaticMarkup(element: __React.ReactElement<any>): string;
+declare namespace __ReactDomServer {
+    function renderToString(element: __React.ReactElement<any>): string;
+    function renderToStaticMarkup(element: __React.ReactElement<any>): string;
 }
 declare module "react-dom" {
-    export  = __ReactDom
+    export = __ReactDom
 }
 
 declare module "react-dom/server" {
-    export  = __ReactDomServer
+    export = __ReactDomServer
 }


### PR DESCRIPTION
 error TS2339: Property 'render' does not exist on type 'typeof __ReactDom'.

in

import React = require("react");
import ReactDOM = require("react-dom");

// console.log(form.ContactForm);

ReactDOM.render(React.createElement(form.ContactForm), document.getElementById("four"));
