### PR TITLE
Add synchronous operation support to node-tmp definitions

### DIFF
--- a/tmp/tmp-tests.ts
+++ b/tmp/tmp-tests.ts
@@ -44,3 +44,25 @@ tmp.tmpName({ template: '/tmp/tmp-XXXXXX' }, (err, path) => {
 });
 
 tmp.setGracefulCleanup();
+
+var tmpobj = tmp.fileSync();
+console.log("File: ", tmpobj.name);
+console.log("Filedescriptor: ", tmpobj.fd);
+tmpobj.removeCallback();
+
+tmpobj = tmp.dirSync();
+console.log("Dir: ", tmpobj.name);
+tmpobj.removeCallback();
+
+var name = tmp.tmpNameSync();
+console.log("Created temporary filename: ", name);
+
+tmpobj = tmp.fileSync({ mode: 644, prefix: 'prefix-', postfix: '.txt' });
+console.log("File: ", tmpobj.name);
+console.log("Filedescriptor: ", tmpobj.fd);
+
+tmpobj = tmp.dirSync({ mode: 750, prefix: 'myTmpDir_' });
+console.log("Dir: ", tmpobj.name);
+
+var tmpname  = tmp.tmpNameSync({ template: '/tmp/tmp-XXXXXX' });
+console.log("Created temporary filename: ", tmpname );

--- a/tmp/tmp.d.ts
+++ b/tmp/tmp.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for tmp v0.0.24
+﻿// Type definitions for tmp v0.0.28
 // Project: https://www.npmjs.com/package/tmp
 // Definitions by: Jared Klopper <https://github.com/optical>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -6,8 +6,11 @@
 declare module "tmp" {
 
 	module tmp {
-		interface Options {
+		interface Options extends SimpleOptions {
 			mode?: number;
+		}
+		
+		interface SimpleOptions {
 			prefix?: string;
 			postfix?: string;
 			template?: string;
@@ -16,15 +19,27 @@ declare module "tmp" {
 			keep?: boolean;
 			unsafeCleanup?: boolean;
 		}
+		
+		interface SynchrounousResult {
+			name: string;
+			fd: number;
+			removeCallback: () => void;
+		}
 
 		function file(callback: (err: any, path: string, fd: number, cleanupCallback: () => void) => void): void;
 		function file(config: Options, callback?: (err: any, path: string, fd: number, cleanupCallback: () => void) => void): void;
 		
+		function fileSync(config?: Options): SynchrounousResult;
+				
 		function dir(callback: (err: any, path: string, cleanupCallback: () => void) => void): void;
 		function dir(config: Options, callback?: (err: any, path: string, cleanupCallback: () => void) => void): void;
 
+		function dirSync(config?: Options): SynchrounousResult;
+
 		function tmpName(callback: (err: any, path: string) => void): void;
-		function tmpName(config: Options, callback?: (err: any, path: string) => void): void;
+		function tmpName(config: SimpleOptions, callback?: (err: any, path: string) => void): void;
+
+		function tmpNameSync(config?: SimpleOptions): string;
 
 		function setGracefulCleanup(): void;
 	}


### PR DESCRIPTION
This updates the tmp definitions with the latest version and adds tests taken from their readme examples.
