### PR TITLE
Change reconnectionAttempts from boolean to number #6209

### DIFF
--- a/socket.io-client/socket.io-client-tests.ts
+++ b/socket.io-client/socket.io-client-tests.ts
@@ -55,3 +55,7 @@ function testUsingItJustAsACrossBrowserWebSocket() {
         });
     });
 }
+
+function testSettingReconnectionAttempts() {
+    var manager = io.Manager({ reconnection: true, timeout: 0, reconnectionAttempts: 2, reconnectionDelay: 10 });
+}

--- a/socket.io-client/socket.io-client.d.ts
+++ b/socket.io-client/socket.io-client.d.ts
@@ -458,7 +458,7 @@ declare module SocketIOClient {
 		 * How many reconnection attempts should we try?
 		 * @default Infinity
 		 */
-		reconnectionAttempts?: boolean;
+		reconnectionAttempts?: number;
 		
 		/**
 		 * The time delay in milliseconds between reconnection attempts


### PR DESCRIPTION
Fixes issue described in #6209 where socket.io has the reconnectionAttempts declared as a boolean instead of a number
