### PR TITLE
fixed execSync and execFileSync return type

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -899,7 +899,7 @@ declare module "child_process" {
         maxBuffer?: number;
         killSignal?: string;
         encoding?: string;
-    }): ChildProcess;
+    }): string | Buffer;
     export function execFileSync(command: string, args?: string[], options?: {
         cwd?: string;
         input?: string|Buffer;
@@ -911,7 +911,7 @@ declare module "child_process" {
         maxBuffer?: number;
         killSignal?: string;
         encoding?: string;
-    }): ChildProcess;
+    }): string | Buffer;
 }
 
 declare module "url" {


### PR DESCRIPTION
child_process.execSync and execFileSync return string|Buffer, not ChildProcess, see [node.js Documentation](https://nodejs.org/docs/latest-v0.12.x/api/child_process.html#child_process_child_process_execfilesync_command_args_options)
