### PR TITLE
acorn: Add `getLineInfo()` function type defintion

### DIFF
--- a/acorn/acorn.d.ts
+++ b/acorn/acorn.d.ts
@@ -9,6 +9,7 @@ declare module acorn {
     var version: string;
     function parse(input: string, options?: Options): ESTree.Program;
     function parseExpressionAt(input: string, pos: number, options?: Options): ESTree.Expression;
+    function getLineInfo(input: string, offset: number): ESTree.Position;
     var defaultOptions: Options;
 
     interface TokenType {


### PR DESCRIPTION
This commit adds the `getLineInfo()` function type definition for
[acorn](https://github.com/marijnh/acorn).

Below is the link to the exported function for reference:
https://github.com/marijnh/acorn/blob/f91990989104eb1558a1dc42364415403874153c/src/locutil.js#L31
