### PR TITLE
Fix Rx.Observable.scan seeded overload

### DIFF
--- a/rx/rx-lite-tests.ts
+++ b/rx/rx-lite-tests.ts
@@ -1,0 +1,13 @@
+/// <reference path="rx-lite.d.ts" />
+function test_scan() {
+
+	/* Without a seed */
+	const source1: Rx.Observable<number> = Rx.Observable.range(1, 3)
+		.scan((acc, x, i, source) => acc + x);
+
+	/* With a seed */
+	const source2: Rx.Observable<string> = Rx.Observable.range(1, 3)
+		.scan((acc, x, i, source) => acc + x, '...');
+
+}
+

--- a/rx/rx-lite.d.ts
+++ b/rx/rx-lite.d.ts
@@ -323,8 +323,20 @@ declare module Rx {
 		materialize(): Observable<Notification<T>>;
 		repeat(repeatCount?: number): Observable<T>;
 		retry(retryCount?: number): Observable<T>;
-		scan<TAcc>(accumulator: (acc: TAcc, value: T, seed: TAcc) => TAcc): Observable<TAcc>;
-		scan(accumulator: (acc: T, value: T) => T): Observable<T>;
+
+		/**
+		 *  Applies an accumulator function over an observable sequence and returns each intermediate result. The optional seed value is used as the initial accumulator value.
+		 *  For aggregation behavior with no intermediate results, see Observable.aggregate.
+		 * @example
+		 *  var res = source.scan(function (acc, x) { return acc + x; });
+		 *  var res = source.scan(function (acc, x) { return acc + x; }, 0);
+		 * @param accumulator An accumulator function to be invoked on each element.
+		 * @param seed The initial accumulator value.
+		 * @returns An observable sequence containing the accumulated values.
+		 */
+		scan<TAcc>(accumulator: (acc: TAcc, value: T, index?: number, source?: Observable<TAcc>) => TAcc, seed: TAcc): Observable<TAcc>;
+		scan(accumulator: (acc: T, value: T, index?: number, source?: Observable<T>) => T): Observable<T>;
+
 		skipLast(count: number): Observable<T>;
 		startWith(...values: T[]): Observable<T>;
 		startWith(scheduler: IScheduler, ...values: T[]): Observable<T>;


### PR DESCRIPTION
As per the docs here:

https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/scan.md

The seeded `scan` overload takes `seed` as a second argument. Also the function parameter actually receives `index` and `source`, not `seed`. 
