### PR TITLE
Fixed wrong draw() method description

### DIFF
--- a/jquery.dataTables/jquery.dataTables.d.ts
+++ b/jquery.dataTables/jquery.dataTables.d.ts
@@ -182,7 +182,7 @@ declare module DataTables {
         destroy(remove?: boolean): DataTable;
 
         /**
-        * Destroy the DataTables in the current context.
+        * Redraw the table.
         *
         * @param reset Reset (default) or hold the current paging position. A full re-sort and re-filter is performed when this method is called, which is why the pagination reset is the default action.
         */


### PR DESCRIPTION
It seems `draw()` method description has been copy-pasted from `destroy()` method.
Now fixed.
Proof http://datatables.net/reference/api/draw%28%29
