### PR TITLE
fix(build): angular old versions should only reference same version

### DIFF
--- a/angular2/http-2.0.0-alpha.37.d.ts
+++ b/angular2/http-2.0.0-alpha.37.d.ts
@@ -13,7 +13,7 @@
 // If you don't have them installed you can install them using TSD
 // https://github.com/DefinitelyTyped/tsd
 
-///<reference path="./angular2.d.ts"/>
+///<reference path="./angular2-2.0.0-alpha.37.d.ts"/>
 
 
 

--- a/angular2/http-2.0.0-alpha.38.d.ts
+++ b/angular2/http-2.0.0-alpha.38.d.ts
@@ -13,7 +13,7 @@
 // If you don't have them installed you can install them using TSD
 // https://github.com/DefinitelyTyped/tsd
 
-///<reference path="./angular2.d.ts"/>
+///<reference path="./angular2-2.0.0-alpha.38.d.ts"/>
 
 
 

--- a/angular2/http-2.0.0-alpha.39.d.ts
+++ b/angular2/http-2.0.0-alpha.39.d.ts
@@ -13,7 +13,7 @@
 // If you don't have them installed you can install them using TSD
 // https://github.com/DefinitelyTyped/tsd
 
-///<reference path="./angular2.d.ts"/>
+///<reference path="./angular2-2.0.0-alpha.39.d.ts"/>
 
 
 

--- a/angular2/router-2.0.0-alpha.31.d.ts
+++ b/angular2/router-2.0.0-alpha.31.d.ts
@@ -8,7 +8,7 @@
 // Please do not create manual edits or send pull requests
 // modifying this file.
 // ***********************************************************
-///<reference path="./angular2.d.ts"/>
+///<reference path="./angular2-2.0.0-alpha.31.d.ts"/>
 
 
 

--- a/angular2/router-2.0.0-alpha.35.d.ts
+++ b/angular2/router-2.0.0-alpha.35.d.ts
@@ -13,7 +13,7 @@
 // If you don't have them installed you can install them using TSD
 // https://github.com/DefinitelyTyped/tsd
 
-///<reference path="./angular2.d.ts"/>
+///<reference path="./angular2-2.0.0-alpha.35.d.ts"/>
 
 
 

--- a/angular2/router-2.0.0-alpha.36.d.ts
+++ b/angular2/router-2.0.0-alpha.36.d.ts
@@ -13,7 +13,7 @@
 // If you don't have them installed you can install them using TSD
 // https://github.com/DefinitelyTyped/tsd
 
-///<reference path="./angular2.d.ts"/>
+///<reference path="./angular2-2.0.0-alpha.36.d.ts"/>
 
 
 

--- a/angular2/router-2.0.0-alpha.37.d.ts
+++ b/angular2/router-2.0.0-alpha.37.d.ts
@@ -13,7 +13,7 @@
 // If you don't have them installed you can install them using TSD
 // https://github.com/DefinitelyTyped/tsd
 
-///<reference path="./angular2.d.ts"/>
+///<reference path="./angular2-2.0.0-alpha.37.d.ts"/>
 
 
 

--- a/angular2/router-2.0.0-alpha.38.d.ts
+++ b/angular2/router-2.0.0-alpha.38.d.ts
@@ -13,7 +13,7 @@
 // If you don't have them installed you can install them using TSD
 // https://github.com/DefinitelyTyped/tsd
 
-///<reference path="./angular2.d.ts"/>
+///<reference path="./angular2-2.0.0-alpha.38.d.ts"/>
 
 
 

--- a/angular2/router-2.0.0-alpha.39.d.ts
+++ b/angular2/router-2.0.0-alpha.39.d.ts
@@ -13,7 +13,7 @@
 // If you don't have them installed you can install them using TSD
 // https://github.com/DefinitelyTyped/tsd
 
-///<reference path="./angular2.d.ts"/>
+///<reference path="./angular2-2.0.0-alpha.39.d.ts"/>
 
 
 

--- a/angular2/test_lib-2.0.0-alpha.38.d.ts
+++ b/angular2/test_lib-2.0.0-alpha.38.d.ts
@@ -13,7 +13,7 @@
 // If you don't have them installed you can install them using TSD
 // https://github.com/DefinitelyTyped/tsd
 
-///<reference path="./angular2.d.ts"/>
+///<reference path="./angular2-2.0.0-alpha.38.d.ts"/>
 ///<reference path="../jasmine/jasmine.d.ts"/>
 
 

--- a/angular2/test_lib-2.0.0-alpha.39.d.ts
+++ b/angular2/test_lib-2.0.0-alpha.39.d.ts
@@ -13,7 +13,7 @@
 // If you don't have them installed you can install them using TSD
 // https://github.com/DefinitelyTyped/tsd
 
-///<reference path="./angular2.d.ts"/>
+///<reference path="./angular2-2.0.0-alpha.39.d.ts"/>
 ///<reference path="../jasmine/jasmine.d.ts"/>
 
 


### PR DESCRIPTION
Fixes #6224
