### PR TITLE
[moment] Min and max use rest arguments

### DIFF
--- a/moment/moment-node.d.ts
+++ b/moment/moment-node.d.ts
@@ -453,8 +453,8 @@ declare module moment {
         weekdaysMin(format: string): string[];
         weekdaysMin(format: string, index: number): string;
 
-        min(moments: Moment[]): Moment;
-        max(moments: Moment[]): Moment;
+        min(...moments: Moment[]): Moment;
+        max(...moments: Moment[]): Moment;
 
         normalizeUnits(unit: string): string;
         relativeTimeThreshold(threshold: string): number|boolean;


### PR DESCRIPTION
As per http://momentjs.com/docs/#/get-set/max/ and http://momentjs.com/docs/#/get-set/min/
