### PR TITLE
Added definitions for angular-loading-bar

### DIFF
--- a/angular-loading-bar/angular-loading-bar-tests.ts
+++ b/angular-loading-bar/angular-loading-bar-tests.ts
@@ -1,0 +1,15 @@
+/// <reference path="angular-loading-bar.d.ts" />
+
+var app = angular.module('testModule', ['angular-loading-bar']);
+
+class TestController {
+
+	constructor($http: ng.IHttpService) {
+
+		$http.get("http://xyz.com", { ignoreLoadingBar: true })
+		
+	}
+
+}
+
+app.controller('TestController', TestController);

--- a/angular-loading-bar/angular-loading-bar.d.ts
+++ b/angular-loading-bar/angular-loading-bar.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for angular-loading-bar
+// Project: https://github.com/chieffancypants/angular-loading-bar
+// Definitions by: Stephen Lautier <https://github.com/stephenlautier>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../angularjs/angular.d.ts" />
+
+
+declare module angular {
+
+	interface IRequestShortcutConfig {
+		/**
+		 * Indicates that the loading bar should be hidden.
+		 */
+		ignoreLoadingBar?: boolean;
+	}
+
+}


### PR DESCRIPTION
fixes type strictness for typescript 1.6+
