### PR TITLE
Removing underscore references from backbone

### DIFF
--- a/backbone/backbone-global.d.ts.tscparams
+++ b/backbone/backbone-global.d.ts.tscparams
@@ -1,1 +1,1 @@
---noImplicitAny ../underscore/underscore.d.ts
+

--- a/backbone/backbone.d.ts
+++ b/backbone/backbone.d.ts
@@ -3,5 +3,4 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>, Natan Vivo <https://github.com/nvivo/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-/// <reference path="../underscore/underscore.d.ts" />
 /// <reference path="./backbone-global.d.ts" />


### PR DESCRIPTION
Removing the underscore references from backbone so that lodash can be
used instead if desired. This doesn’t affect the functionality of
backbone itself. I had already made this change, but it looks like
someone else’s PR overwrote it.
