### PR TITLE
lodash: signatures of the method _.toPlainObject have been changed

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -2403,18 +2403,23 @@ result = <boolean>_([]).lte(2);
 result = <boolean>_({}).lte(2);
 
 // _.toPlainObject
-result = <Object>_.toPlainObject();
-result = <Object>_.toPlainObject(true);
-result = <Object>_.toPlainObject(1);
-result = <Object>_.toPlainObject('a');
-result = <Object>_.toPlainObject([]);
-result = <Object>_.toPlainObject({});
-result = <Object>_(true).toPlainObject();
-result = <Object>_(1).toPlainObject();
-result = <Object>_('a').toPlainObject();
-result = <Object>_([1]).toPlainObject();
-result = <Object>_<string>([]).toPlainObject();
-result = <Object>_({}).toPlainObject();
+module TestToPlainObject {
+    let result: TResult;
+
+    result = _.toPlainObject<TResult>();
+    result = _.toPlainObject<TResult>(true);
+    result = _.toPlainObject<TResult>(1);
+    result = _.toPlainObject<TResult>('a');
+    result = _.toPlainObject<TResult>([]);
+    result = _.toPlainObject<TResult>({});
+
+    result = _(true).toPlainObject<TResult>().value();
+    result = _(1).toPlainObject<TResult>().value();
+    result = _('a').toPlainObject<TResult>().value();
+    result = _([1]).toPlainObject<TResult>().value();
+    result = _<string>([]).toPlainObject<TResult>().value();
+    result = _({}).toPlainObject<TResult>().value();
+}
 
 /********
  * Math *

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -238,11 +238,6 @@ declare module _ {
         * @see _.value
         **/
         valueOf(): T;
-
-        /**
-         * @see _.toPlainObject
-         */
-        toPlainObject(): Object;
     }
 
     interface LoDashWrapper<T> extends LoDashWrapperBase<T, LoDashWrapper<T>> { }
@@ -7180,10 +7175,18 @@ declare module _ {
         /**
          * Converts value to a plain object flattening inherited enumerable properties of value to own properties
          * of the plain object.
+         *
          * @param value The value to convert.
          * @return Returns the converted plain object.
          */
-        toPlainObject(value?: any): Object;
+        toPlainObject<TResult extends {}>(value?: any): TResult;
+    }
+
+    interface LoDashWrapperBase<T, TWrapper> {
+        /**
+         * @see _.toPlainObject
+         */
+        toPlainObject<TResult extends {}>(): LoDashObjectWrapper<TResult>;
     }
 
     /********


### PR DESCRIPTION
https://lodash.com/docs#toPlainObject
https://lodash.com/docs#_ (description of the chainable wrapper)
