### PR TITLE
Add object parsing overload to moment setter

### DIFF
--- a/moment/moment-node.d.ts
+++ b/moment/moment-node.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Moment.js 2.8.0
+// Type definitions for Moment.js 2.10.6
 // Project: https://github.com/timrwood/moment
 // Definitions by: Michael Lakerveld <https://github.com/Lakerfield>, Aaron King <https://github.com/kingdango>, Hiroki Horiuchi <https://github.com/horiuchi>, Dick van den Brink <https://github.com/DickvdBrink>, Adi Dahiya <https://github.com/adidahiya>, Matt Brooks <https://github.com/EnableSoftware>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -303,6 +303,7 @@ declare module moment {
 
         get(unit: string): number;
         set(unit: string, value: number): Moment;
+        set(input: MomentInput): Moment;
     }
 
     type formatFunction = () => string;

--- a/moment/moment-tests.ts
+++ b/moment/moment-tests.ts
@@ -127,6 +127,15 @@ moment().isoWeeks(45);
 moment().dayOfYear();
 moment().dayOfYear(45);
 
+moment().set('year', 2013);
+moment().set('month', 3);  // April
+moment().set('date', 1);
+moment().set('hour', 13);
+moment().set('minute', 20);
+moment().set('second', 30);
+moment().set('millisecond', 123);
+moment().set({'year': 2013, 'month': 3});
+
 var getMilliseconds: number = moment().milliseconds();
 var getSeconds: number = moment().seconds();
 var getMinutes: number = moment().minutes();


### PR DESCRIPTION
moment.set was missing the object parsing overload which was added in 2.9. Additionally there were no tests for set. Have copied the examples from moment docs.

See http://momentjs.com/docs/#/get-set/set/
