### PR TITLE
Added config singleton and missing properties

### DIFF
--- a/ckeditor/ckeditor.d.ts
+++ b/ckeditor/ckeditor.d.ts
@@ -64,6 +64,7 @@ declare module CKEDITOR {
     var status: string;
     var timestamp: string;
     var version: string;
+    var config: config;
 
 
     // Methods
@@ -556,6 +557,7 @@ declare module CKEDITOR {
     }
 
     interface config {
+        contentsCss?: string | string[];
         startupMode?: string;
         removeButtons?: string;
         removePlugins?: string;
@@ -576,6 +578,7 @@ declare module CKEDITOR {
         height?: string | number;
         toolbarLocation?: string;
         readOnly?: boolean;
+        customConfig?: string;
     }
 
 


### PR DESCRIPTION
Added 
- `CKEDITOR.config` - singleton ([doc link](http://docs.ckeditor.com/#!/api/CKEDITOR.config))
- `config.contentsCss` - string or string array ([doc link](http://docs.ckeditor.com/#!/api/CKEDITOR.config-cfg-contentsCss))
- `config.customConfig` - string ([doc link](http://docs.ckeditor.com/#!/api/CKEDITOR.config-cfg-customConfig))

to CKEDITOR.d.ts
