### PR TITLE
Update react-dom for ES6 module imports

### DIFF
--- a/react-dom/react-dom.d.ts
+++ b/react-dom/react-dom.d.ts
@@ -5,31 +5,31 @@
 
 /// <reference path="./../react/react.d.ts" />
 
-declare class __ReactDom {
-    public  render<P>(
+declare namespace __ReactDom {
+    function render<P>(
         element: __React.DOMElement<P>,
         container: Element,
         callback?: () => any): __React.DOMComponent<P>;
-    public render<P, S>(
+    function render<P, S>(
         element: __React.ClassicElement<P>,
         container: Element,
         callback?: () => any): __React.ClassicComponent<P, S>;
-    public render<P, S>(
+    function render<P, S>(
         element: __React.ReactElement<P>,
         container: Element,
         callback?: () => any): __React.Component<P, S>;
 
-    public findDOMNode<TElement extends Element>(
+    function findDOMNode<TElement extends Element>(
         componentOrElement: __React.Component<any, any> | Element): TElement;
-    public findDOMNode(
+    function findDOMNode(
         componentOrElement: __React.Component<any, any> | Element): Element;
 
-    public unmountComponentAtNode(container: Element): boolean;
+    function unmountComponentAtNode(container: Element): boolean;
 }
 
-declare class __ReactDomServer {
-    public  renderToString(element: __React.ReactElement<any>): string;
-    public  renderToStaticMarkup(element: __React.ReactElement<any>): string;
+declare namespace __ReactDomServer {
+    function renderToString(element: __React.ReactElement<any>): string;
+    function renderToStaticMarkup(element: __React.ReactElement<any>): string;
 }
 declare module "react-dom" {
     export  = __ReactDom


### PR DESCRIPTION
Change react-dom's definitions from class to namespace so it can be imported using ES6 syntax:

```
import * as React from 'react'; // works already
import * as ReactDOM from 'react-dom'; // works with this commit
```
