### PR TITLE
[mocha] Adding definition of mocha.throwError, with test to cover it.

### DIFF
--- a/mocha/mocha-tests.ts
+++ b/mocha/mocha-tests.ts
@@ -249,3 +249,7 @@ function test_run_withOnComplete() {
         console.log(failures);
     });
 }
+
+function test_throwError() {
+    mocha.throwError(new Error("I'm an error!"));
+}

--- a/mocha/mocha.d.ts
+++ b/mocha/mocha.d.ts
@@ -100,6 +100,12 @@ declare class Mocha {
     invert(): Mocha;
     ignoreLeaks(value: boolean): Mocha;
     checkLeaks(): Mocha;
+    /**
+     * Function to allow assertion libraries to throw errors directly into mocha.
+     * This is useful when running tests in a browser because window.onerror will
+     * only receive the 'message' attribute of the Error.
+     */
+    throwError(error: Error): void;
     /** Enables growl support. */
     growl(): Mocha;
     globals(value: string): Mocha;


### PR DESCRIPTION
See implementation in Mocha's source code [here](https://github.com/mochajs/mocha/blob/c4393c456839d6bf2cbb4abb1cd177010ee06458/support/browser-entry.js#L98).
