### PR TITLE
angular-ui-router: transitionTo() and reload() return promises

### DIFF
--- a/angular-ui-router/angular-ui-router.d.ts
+++ b/angular-ui-router/angular-ui-router.d.ts
@@ -229,10 +229,10 @@ declare module angular.ui {
          */
         go(to: string, params?: {}, options?: IStateOptions): angular.IPromise<any>;
         go(to: IState, params?: {}, options?: IStateOptions): angular.IPromise<any>;
-        transitionTo(state: string, params?: {}, updateLocation?: boolean): void;
-        transitionTo(state: IState, params?: {}, updateLocation?: boolean): void;
-        transitionTo(state: string, params?: {}, options?: IStateOptions): void;
-        transitionTo(state: IState, params?: {}, options?: IStateOptions): void;
+        transitionTo(state: string, params?: {}, updateLocation?: boolean): ng.IPromise<any>;
+        transitionTo(state: IState, params?: {}, updateLocation?: boolean): ng.IPromise<any>;
+        transitionTo(state: string, params?: {}, options?: IStateOptions): ng.IPromise<any>;
+        transitionTo(state: IState, params?: {}, options?: IStateOptions): ng.IPromise<any>;
         includes(state: string, params?: {}): boolean;
         is(state:string, params?: {}): boolean;
         is(state: IState, params?: {}): boolean;
@@ -244,7 +244,7 @@ declare module angular.ui {
         current: IState;
         /** A param object, e.g. {sectionId: section.id)}, that you'd like to test against the current active state. */
         params: IStateParamsService;
-        reload(): void;
+        reload(): ng.IPromise<any>;
 
         /** Currently pending transition. A promise that'll resolve or reject. */
         transition: ng.IPromise<{}>;


### PR DESCRIPTION
$state.transitionTo() and $state.reload() return promises as documented here:
http://angular-ui.github.io/ui-router/site/#/api/ui.router.state.$state
