### PR TITLE
Fix ui-grid.d.ts syntax

### DIFF
--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -734,13 +734,13 @@ declare module uiGrid {
          * to load when scrolling up
          * @default false
          */
-        infiniteScrollUp?: boolean,
+        infiniteScrollUp?: boolean;
         /**
          * Inform the grid of whether there are rows
          * to load scrolling down
          * @default true
          */
-        infiniteScrollDown?: boolean,
+        infiniteScrollDown?: boolean;
         /**
          * Defaults to 200
          * @default 200


### PR DESCRIPTION
ui-grid.d.ts had comma instead of semicolon. Typescript compiler reported it as an error
