### PR TITLE
react-bootstrap: added 'show' property to ModalProps

### DIFF
--- a/react-bootstrap/react-bootstrap.d.ts
+++ b/react-bootstrap/react-bootstrap.d.ts
@@ -249,6 +249,7 @@ declare module "react-bootstrap" {
         dialogComponent?: any; // TODO: Add more specific type
         enforceFocus?: boolean;
         keyboard?: boolean;
+        show?: boolean;
     }
     interface Modal extends React.ReactElement<ModalProps> { }
     interface ModalClass extends React.ComponentClass<ModalProps> { 


### PR DESCRIPTION
Source: https://github.com/react-bootstrap/react-bootstrap/blob/master/src/Modal.js#L127
The Modal component is useless without this property.
