### PR TITLE
Accept JQuery in PopoverOptions' `container`

### DIFF
--- a/bootstrap/bootstrap.d.ts
+++ b/bootstrap/bootstrap.d.ts
@@ -48,7 +48,7 @@ interface PopoverOptions {
     template?: string;
     content?: any;
     delay?: number | Object;
-    container?: string | boolean;
+    container?: string | boolean | JQuery;
     viewport?: string | Function | Object;
 }
 


### PR DESCRIPTION
updates the typings to reflect the behavior that bootstrap already provides
