### PR TITLE
Update XRegExp to 3.0.0

### DIFF
--- a/xregexp/xregexp-tests.ts
+++ b/xregexp/xregexp-tests.ts
@@ -8,6 +8,7 @@ import TokenOpts = X.TokenOpts;
 
 var exp: RegExp;
 var expArr: RegExp[];
+var expArrArr: RegExp[][];
 var chain: RegExp[];
 var groupChain: { regex: RegExp; backref: string }[];
 var groupChain1: { regex: RegExp; backref: number }[];
@@ -19,6 +20,7 @@ var search: string;
 var searchEx: RegExp;
 var bool: boolean;
 var strArr: string[];
+var strArrArr: string[][];
 var pattern: string;
 var flags: string;
 var right: string;
@@ -39,6 +41,14 @@ regex = XRegExp(str, flags);
 regex = XRegExp(regex);
 
 str =  XRegExp.version;
+
+// --  --  --  --  --  --  --  --  --  --  --  --  --
+
+regex = X(str);
+regex = X(str, flags);
+regex = X(regex);
+
+str =  X.version;
 
 // --  --  --  --  --  --  --  --  --  --  --  --  --
 
@@ -74,13 +84,6 @@ matchArr = XRegExp.forEach(str, regex, (match, index, input, regexp) => {
 	str = input;
 	num = index;
 	matchArr = match;
-}, obj);
-
-matchArr = XRegExp.forEach(str, regex, (match, index, input, regexp) => {
-	exp = regexp;
-	str = input;
-	num = index;
-	matchArr = match;
 });
 
 // --  --  --  --  --  --  --  --  --  --  --  --  --
@@ -92,6 +95,11 @@ XRegExp.install(obj);
 
 bool = XRegExp.isInstalled(str);
 bool = XRegExp.isRegExp(value);
+
+strArr = XRegExp.match(str, regex);
+strArr = XRegExp.match(str, regex, scope);
+str = XRegExp.match(str, regex, "one");
+
 strArr = XRegExp.matchChain(str, chain);
 strArr = XRegExp.matchChain(str, groupChain);
 strArr = XRegExp.matchChain(str, groupChain1);
@@ -112,6 +120,11 @@ str = XRegExp.replace(str, searchEx, str, scope);
 str = XRegExp.replace(str, searchEx, str);
 str = XRegExp.replace(str, searchEx, replacer, scope);
 str = XRegExp.replace(str, searchEx, replacer);
+
+// --  --  --  --  --  --  --  --  --  --  --  --  --
+str = XRegExp.replaceEach(str, expArrArr);
+str = XRegExp.replaceEach(str, strArrArr);
+str = XRegExp.replaceEach(str, [[str, exp], [str, exp]]);
 
 // --  --  --  --  --  --  --  --  --  --  --  --  --
 
@@ -135,4 +148,3 @@ regex = XRegExp.union(strArr, flags);
 regex = XRegExp.union(strArr);
 
 // --  --  --  --  --  --  --  --  --  --  --  --  --
-

--- a/xregexp/xregexp.d.ts
+++ b/xregexp/xregexp.d.ts
@@ -1,38 +1,58 @@
-// Type definitions for XRegExp 2.0.0
+// Type definitions for XRegExp 3.0.0
 // Project: http://xregexp.com
-// Definitions by: Bart van der Schoor <https://github.com/Bartvds>
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>,
+//                 Johannes Fahrenkrug <https://github.com/jfahrenkrug>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module 'xregexp' {
-	// scopes: 'default', 'class', or 'all'
-	/*
-	 Native flags:
-	 g - global
-	 i - ignore case
-	 m - multiline anchors
-	 y - sticky (Firefox 3+)
-	 Additional XRegExp flags:
-	 n - explicit capture
-	 s - dot matches all (aka singleline)
-	 x - free-spacing and line comments (aka extended)
-	 */
-	export interface TokenOpts {
-		scope?: string;
-		trigger?: () => boolean;
-		customFlags?: string;
-	}
 
-	export function XRegExp(pattern: string, flags?: string): RegExp;
-	export function XRegExp(pattern: RegExp): RegExp;
+	function OuterXRegExp(pattern: string, flags?: string): RegExp;
+	function OuterXRegExp(pattern: RegExp): RegExp;
 
-	export module XRegExp {
+	module OuterXRegExp {
+		// scopes: 'default', 'class', or 'all'
+		/*
+		 Native flags:
+		 g - global
+		 i - ignore case
+		 m - multiline anchors
+		 y - sticky (Firefox 3+)
+		 Additional XRegExp flags:
+		 n - explicit capture
+		 s - dot matches all (aka singleline)
+		 x - free-spacing and line comments (aka extended)
+		 */
+		interface TokenOpts {
+			scope?: string;
+			trigger?: () => boolean;
+			customFlags?: string;
+		}
+
+		function XRegExp(pattern: string, flags?: string): RegExp;
+		function XRegExp(pattern: RegExp): RegExp;
+
+		/* Since xregexp 3.0.0 can be used either via
+
+				import X = require('xregexp');
+				X();
+
+			or via
+
+				import XRegExp = X.XRegExp;
+				XRegExp()
+
+			I had to duplicate the function declarations. I could simply not
+			find another way to accomplish this with TypeScript.
+		*/
+
+		// begin API definitions
 		function addToken(regex: RegExp, handler: (matchArr: RegExpExecArray, scope: string) => string, options?: TokenOpts): void;
 
 		function build(pattern: string, subs: string[], flags?: string): RegExp;
 		function cache(pattern: string, flags?: string): RegExp;
 		function escape(str: string): string;
 		function exec(str: string, regex: RegExp, pos?: number, sticky?: boolean): RegExpExecArray;
-		function forEach(str: string, regex: RegExp, callback: (matchArr: RegExpExecArray, index: number, input: string, regexp: RegExp) => void, context?: Object): any;
+		function forEach(str: string, regex: RegExp, callback: (matchArr: RegExpExecArray, index: number, input: string, regexp: RegExp) => void): any;
 		function globalize(regex: RegExp): RegExp;
 
 		function install(options: string): void;
@@ -40,6 +60,10 @@ declare module 'xregexp' {
 
 		function isInstalled(feature: string): boolean;
 		function isRegExp(value: any): boolean;
+		function match(str: string, regex: RegExp, scope: string): any;
+		function match(str: string, regex: RegExp, scope: "one"): string;
+		function match(str: string, regex: RegExp, scope: "all"): string[];
+		function match(str: string, regex: RegExp): string[];
 		function matchChain(str: string, chain: RegExp[]): string[];
 		function matchChain(str: string, chain: { regex: RegExp; backref: string }[]): string[];
 		function matchChain(str: string, chain: { regex: RegExp; backref: number }[]): string[];
@@ -49,6 +73,7 @@ declare module 'xregexp' {
 		function replace(str: string, search: string, replacement: Function, scope?: string): string;
 		function replace(str: string, search: RegExp, replacement: string, scope?: string): string;
 		function replace(str: string, search: RegExp, replacement: Function, scope?: string): string;
+		function replaceEach(str: string, replacements: Array<RegExp|string>[]): string;
 
 		function split(str: string, separator: string, limit?: number): string[];
 		function split(str: string, separator: RegExp, limit?: number): string[];
@@ -60,5 +85,52 @@ declare module 'xregexp' {
 
 		function union(patterns: string[], flags?: string): RegExp;
 		var version: string;
+		// end API definitions
+
+		module XRegExp {
+			// begin API definitions
+			function addToken(regex: RegExp, handler: (matchArr: RegExpExecArray, scope: string) => string, options?: TokenOpts): void;
+
+			function build(pattern: string, subs: string[], flags?: string): RegExp;
+			function cache(pattern: string, flags?: string): RegExp;
+			function escape(str: string): string;
+			function exec(str: string, regex: RegExp, pos?: number, sticky?: boolean): RegExpExecArray;
+			function forEach(str: string, regex: RegExp, callback: (matchArr: RegExpExecArray, index: number, input: string, regexp: RegExp) => void): any;
+			function globalize(regex: RegExp): RegExp;
+
+			function install(options: string): void;
+			function install(options: Object): void;
+
+			function isInstalled(feature: string): boolean;
+			function isRegExp(value: any): boolean;
+			function match(str: string, regex: RegExp, scope: string): any;
+			function match(str: string, regex: RegExp, scope: "one"): string;
+			function match(str: string, regex: RegExp, scope: "all"): string[];
+			function match(str: string, regex: RegExp): string[];
+			function matchChain(str: string, chain: RegExp[]): string[];
+			function matchChain(str: string, chain: { regex: RegExp; backref: string }[]): string[];
+			function matchChain(str: string, chain: { regex: RegExp; backref: number }[]): string[];
+			function matchRecursive(str: string, left: string, right: string, flags?: string, options?: Object): string[];
+
+			function replace(str: string, search: string, replacement: string, scope?: string): string;
+			function replace(str: string, search: string, replacement: Function, scope?: string): string;
+			function replace(str: string, search: RegExp, replacement: string, scope?: string): string;
+			function replace(str: string, search: RegExp, replacement: Function, scope?: string): string;
+			function replaceEach(str: string, replacements: Array<RegExp|string>[]): string;
+
+			function split(str: string, separator: string, limit?: number): string[];
+			function split(str: string, separator: RegExp, limit?: number): string[];
+
+			function test(str: string, regex: RegExp, pos?: number, sticky?: boolean): boolean;
+
+			function uninstall(options: Object): void;
+			function uninstall(options: string): void;
+
+			function union(patterns: string[], flags?: string): RegExp;
+			var version: string;
+			// end API definitions
+		}
 	}
+
+	export = OuterXRegExp;
 }


### PR DESCRIPTION
This updates the definitions for XRegExp to the recently released version 3.0.0.

I tried all kinds of things (classes with static methods, interfaces, etc) to **not** duplicate the function definitions, but to no avail. I had to duplicate them because XRegExp can now be used in two ways:

```
import X = require('xregexp');
X();
```

or via

```
import XRegExp = X.XRegExp;
XRegExp()
```

I found no other way to solve this in TypeScript. If we can DRY this up somehow, please let me know how :)
