### PR TITLE
followRedirect is documented to also accept a function

### DIFF
--- a/request/request.d.ts
+++ b/request/request.d.ts
@@ -79,7 +79,7 @@ declare module 'request' {
 			method?: string;
 			headers?: Headers;
 			body?: any;
-			followRedirect?: boolean;
+			followRedirect?: boolean|((response: http.IncomingMessage) => boolean);
 			followAllRedirects?: boolean;
 			maxRedirects?: number;
 			encoding?: string;


### PR DESCRIPTION
As documented here: https://www.npmjs.com/package/request#request-options-callback
#### request(options, callback)
- followRedirect - follow HTTP 3xx responses as redirects (default: true). This property can also be implemented as function which gets response object as a single argument and should return true if redirects should continue or false otherwise.
