### PR TITLE
Add support for descriptions on hooks

### DIFF
--- a/mocha/mocha-tests.ts
+++ b/mocha/mocha-tests.ts
@@ -70,6 +70,10 @@ function test_before() {
     before(() => { });
 
     before((done) => { done(); });
+
+    before("my description", () => { });
+
+    before("my description", done => { });
 }
 
 function test_setup() {
@@ -82,6 +86,10 @@ function test_after() {
     after(() => { });
 
     after((done) => { done(); });
+
+    after("my description", () => { });
+
+    after("my description", done => { });
 }
 
 function test_teardown() {
@@ -94,6 +102,10 @@ function test_beforeEach() {
     beforeEach(() => { });
 
     beforeEach((done) => { done(); });
+
+    beforeEach("my description", () => { });
+
+    beforeEach("my description", done => { });
 }
 
 function test_suiteSetup() {
@@ -106,6 +118,10 @@ function test_afterEach() {
     afterEach(() => { });
 
     afterEach((done) => { done(); });
+
+    afterEach("my description", () => { });
+
+    afterEach("my description", done => { });
 }
 
 function test_suiteTeardown() {

--- a/mocha/mocha.d.ts
+++ b/mocha/mocha.d.ts
@@ -45,31 +45,53 @@ declare var xit: Mocha.ITestDefinition;
 // alias for `it`
 declare var test: Mocha.ITestDefinition;
 
-declare type HookAction = (() => void) | ((done: MochaDone) => void);
+declare function before(action: () => void): void;
 
-declare function before(action: HookAction): void;
+declare function before(action: (done: MochaDone) => void): void;
 
-declare function before(description: string, action: HookAction): void;
+declare function before(description: string, action: () => void): void;
 
-declare function setup(action: HookAction): void;
+declare function before(description: string, action: (done: MochaDone) => void): void;
 
-declare function after(action: HookAction): void;
+declare function setup(action: () => void): void;
 
-declare function after(description: string, action: HookAction): void;
+declare function setup(action: (done: MochaDone) => void): void;
 
-declare function teardown(action: HookAction): void;
+declare function after(action: () => void): void;
 
-declare function beforeEach(action: HookAction): void;
+declare function after(action: (done: MochaDone) => void): void;
 
-declare function beforeEach(description: string, action: HookAction): void;
+declare function after(description: string, action: () => void): void;
 
-declare function suiteSetup(action: HookAction): void;
+declare function after(description: string, action: (done: MochaDone) => void): void;
 
-declare function afterEach(action: HookAction): void;
+declare function teardown(action: () => void): void;
 
-declare function afterEach(description: string, action: HookAction): void;
+declare function teardown(action: (done: MochaDone) => void): void;
 
-declare function suiteTeardown(action: HookAction): void;
+declare function beforeEach(action: () => void): void;
+
+declare function beforeEach(action: (done: MochaDone) => void): void;
+
+declare function beforeEach(description: string, action: () => void): void;
+
+declare function beforeEach(description: string, action: (done: MochaDone) => void): void;
+
+declare function suiteSetup(action: () => void): void;
+
+declare function suiteSetup(action: (done: MochaDone) => void): void;
+
+declare function afterEach(action: () => void): void;
+
+declare function afterEach(action: (done: MochaDone) => void): void;
+
+declare function afterEach(description: string, action: () => void): void;
+
+declare function afterEach(description: string, action: (done: MochaDone) => void): void;
+
+declare function suiteTeardown(action: () => void): void;
+
+declare function suiteTeardown(action: (done: MochaDone) => void): void;
 
 declare class Mocha {
     constructor(options?: {

--- a/mocha/mocha.d.ts
+++ b/mocha/mocha.d.ts
@@ -45,37 +45,31 @@ declare var xit: Mocha.ITestDefinition;
 // alias for `it`
 declare var test: Mocha.ITestDefinition;
 
-declare function before(action: () => void): void;
+declare type HookAction = (() => void) | ((done: MochaDone) => void);
 
-declare function before(action: (done: MochaDone) => void): void;
+declare function before(action: HookAction): void;
 
-declare function setup(action: () => void): void;
+declare function before(description: string, action: HookAction): void;
 
-declare function setup(action: (done: MochaDone) => void): void;
+declare function setup(action: HookAction): void;
 
-declare function after(action: () => void): void;
+declare function after(action: HookAction): void;
 
-declare function after(action: (done: MochaDone) => void): void;
+declare function after(description: string, action: HookAction): void;
 
-declare function teardown(action: () => void): void;
+declare function teardown(action: HookAction): void;
 
-declare function teardown(action: (done: MochaDone) => void): void;
+declare function beforeEach(action: HookAction): void;
 
-declare function beforeEach(action: () => void): void;
+declare function beforeEach(description: string, action: HookAction): void;
 
-declare function beforeEach(action: (done: MochaDone) => void): void;
+declare function suiteSetup(action: HookAction): void;
 
-declare function suiteSetup(action: () => void): void;
+declare function afterEach(action: HookAction): void;
 
-declare function suiteSetup(action: (done: MochaDone) => void): void;
+declare function afterEach(description: string, action: HookAction): void;
 
-declare function afterEach(action: () => void): void;
-
-declare function afterEach(action: (done: MochaDone) => void): void;
-
-declare function suiteTeardown(action: () => void): void;
-
-declare function suiteTeardown(action: (done: MochaDone) => void): void;
+declare function suiteTeardown(action: HookAction): void;
 
 declare class Mocha {
     constructor(options?: {


### PR DESCRIPTION
- Includes before, after, beforeEach and afterEach

Note that I wasn't sure if the TDD interface hooks support descriptions, as I don't use it and it doesn't show any example of them being used in the documentation, hence why I haven't changed them.
