### PR TITLE
server.select() returns a server, not void

### DIFF
--- a/hapi/hapi-8.2.0.d.ts
+++ b/hapi/hapi-8.2.0.d.ts
@@ -2101,12 +2101,14 @@ declare module "hapi" {
 		Returns a server object with connections set to the requested subset. Selecting again on a selection operates as a logic AND statement between the individual selections.
 		var Hapi = require('hapi');
 		var server = new Hapi.Server();
-		server.connection({ port: 80, labels: ['a', 'b'] });
-		server.connection({ port: 8080, labels: ['a', 'c'] });
-		server.connection({ port: 8081, labels: ['b', 'c'] });
-		var a = server.select('a');     // 80, 8080
-		var ac = a.select('c');         // 8080*/
-		select(labels: string|string[]): void;
+		server.connection({ port: 80, labels: ['a'] });
+		server.connection({ port: 8080, labels: ['b'] });
+		server.connection({ port: 8081, labels: ['c'] });
+		server.connection({ port: 8082, labels: ['c','d'] });
+		var a = server.select('a');          // The server with port 80
+		var ab = server.select(['a','b']);   // A list of servers containing the server with port 80 and the server with port 8080
+		var c = server.select('c');          // A list of servers containing the server with port 8081 and the server with port 8082 */
+		select(labels: string|string[]): Server|Server[];
 		/** server.start([callback])
 		Starts the server connections by listening for incoming requests on the configured port of each listener (unless the connection was configured with autoListen set to false), where:
 		callback - optional callback when server startup is completed or failed with the signature function(err) where:

--- a/hapi/hapi.d.ts
+++ b/hapi/hapi.d.ts
@@ -2104,12 +2104,14 @@ declare module "hapi" {
 		Returns a server object with connections set to the requested subset. Selecting again on a selection operates as a logic AND statement between the individual selections.
 		var Hapi = require('hapi');
 		var server = new Hapi.Server();
-		server.connection({ port: 80, labels: ['a', 'b'] });
-		server.connection({ port: 8080, labels: ['a', 'c'] });
-		server.connection({ port: 8081, labels: ['b', 'c'] });
-		var a = server.select('a');     // 80, 8080
-		var ac = a.select('c');         // 8080*/
-		select(labels: string|string[]): void;
+		server.connection({ port: 80, labels: ['a'] });
+		server.connection({ port: 8080, labels: ['b'] });
+		server.connection({ port: 8081, labels: ['c'] });
+		server.connection({ port: 8082, labels: ['c','d'] });
+		var a = server.select('a');          // The server with port 80
+		var ab = server.select(['a','b']);   // A list of servers containing the server with port 80 and the server with port 8080
+		var c = server.select('c');          // A list of servers containing the server with port 8081 and the server with port 8082 */
+		select(labels: string|string[]): Server|Server[];
 		/** server.start([callback])
 		Starts the server connections by listening for incoming requests on the configured port of each listener (unless the connection was configured with autoListen set to false), where:
 		callback - optional callback when server startup is completed or failed with the signature function(err) where:


### PR DESCRIPTION
The return type of `Server.select()` should be `server|server[]`, and not `void`.

Please see the [documentation](http://hapijs.com/api/8.2.0#serverconnections).
