### PR TITLE
Updating ObjectID to match current spec

### DIFF
--- a/mongodb/mongodb.d.ts
+++ b/mongodb/mongodb.d.ts
@@ -127,6 +127,14 @@ declare module "mongodb" {
     // Creates an ObjectID from a hex string representation of an ObjectID.
     // hexString – create a ObjectID from a passed in 24 byte hexstring.
     public static createFromHexString(hexString: string): ObjectID;
+    
+    // Checks if a value is a valid bson ObjectId
+    // id - Value to be checked
+    public static isValid(id: string): Boolean;
+    
+    // Generate a 12 byte id string used in ObjectID's
+    // time - optional parameter allowing to pass in a second based timestamp
+    public static generate(time?: number): string;
   }
 
   // Class documentation : http://mongodb.github.io/node-mongodb-native/api-bson-generated/binary.html

--- a/mongodb/mongodb.d.ts
+++ b/mongodb/mongodb.d.ts
@@ -134,7 +134,7 @@ declare module "mongodb" {
     
     // Generate a 12 byte id string used in ObjectID's
     // time - optional parameter allowing to pass in a second based timestamp
-    public static generate(time?: number): string;
+    public generate(time?: number): string;
   }
 
   // Class documentation : http://mongodb.github.io/node-mongodb-native/api-bson-generated/binary.html


### PR DESCRIPTION
The `ObjectID` class was missing two functions:
#### `isValid`
- [Documentation](http://mongodb.github.io/node-mongodb-native/2.0/api/ObjectID.html#.isValid)
- [Source Code](http://mongodb.github.io/node-mongodb-native/2.0/api/node_modules_bson_lib_bson_objectid.js.html#line241)
#### `generate`
- [Documentation](http://mongodb.github.io/node-mongodb-native/2.0/api/ObjectID.html#generate)
- [Source Code](http://mongodb.github.io/node-mongodb-native/2.0/api/node_modules_bson_lib_bson_objectid.js.html#line109)
