### PR TITLE
Connect typings

### DIFF
--- a/connect/connect-tests.ts
+++ b/connect/connect-tests.ts
@@ -1,0 +1,32 @@
+/// <reference path="./connect.d.ts" />
+
+import * as http from "http";
+import * as connect from "connect";
+
+const app = connect();
+
+// log all requests
+app.use((req, res, next) => {
+    console.log(req, res);
+    next();
+});
+
+// Stop on errors
+app.use((err, req, res, next) => {
+    if (err) {
+        return res.end(`Error: ${err}`);
+    }
+    
+    next();
+});
+
+// respond to all requests
+app.use((req, res) => {
+    res.end("Hello from Connect!\n");
+});
+
+//create node.js http server and listen on port
+http.createServer(app).listen(3000);
+
+//create node.js http server and listen on port using connect shortcut
+app.listen(3000);

--- a/connect/connect-tests.ts
+++ b/connect/connect-tests.ts
@@ -6,13 +6,13 @@ import * as connect from "connect";
 const app = connect();
 
 // log all requests
-app.use((req, res, next) => {
+app.use((req: http.IncomingMessage, res: http.ServerResponse, next: Function) => {
     console.log(req, res);
     next();
 });
 
 // Stop on errors
-app.use((err, req, res, next) => {
+app.use((err: Error, req: http.IncomingMessage, res: http.ServerResponse, next: Function) => {
     if (err) {
         return res.end(`Error: ${err}`);
     }
@@ -21,7 +21,7 @@ app.use((err, req, res, next) => {
 });
 
 // respond to all requests
-app.use((req, res) => {
+app.use((req: http.IncomingMessage, res: http.ServerResponse) => {
     res.end("Hello from Connect!\n");
 });
 

--- a/connect/connect.d.ts
+++ b/connect/connect.d.ts
@@ -16,8 +16,13 @@ declare module "connect" {
     
     module createServer {
     	export type ServerHandle = HandleFunction | http.Server;
-    	export type HandleFunction = (req: http.IncomingMessage, res: http.ServerResponse, next: Function) => void;
-    	
+
+        export interface HandleFunction {
+            (req: http.IncomingMessage, res: http.ServerResponse): void;
+            (req: http.IncomingMessage, res: http.ServerResponse, next: Function): void;
+            (err: Error, req: http.IncomingMessage, res: http.ServerResponse, next: Function): void;
+        }
+
     	export interface ServerStackItem {
             route: string;
             handle: ServerHandle;
@@ -25,10 +30,10 @@ declare module "connect" {
     	
         export interface Server extends NodeJS.EventEmitter {
             (req: http.IncomingMessage, res: http.ServerResponse, next: Function) => void;
-            
+
             route: string;
             stack: ServerStackItem[];
-            
+
             /**
             * Utilize the given middleware `handle` to the given `route`,
             * defaulting to _/_. This "route" is the mount-point for the
@@ -44,7 +49,7 @@ declare module "connect" {
             */
             use(fn: HandleFunction): Server;
             use(route: string, fn: HandleFunction): Server;
-            		
+		
             /**
             * Handle server requests, punting them down
             * the middleware stack.
@@ -52,8 +57,7 @@ declare module "connect" {
             * @private
             */
             handle(req: http.IncomingMessage, res: http.ServerResponse, next: Function): void;
-            
-            		
+		
             /**
             * Listen for connections.
             *

--- a/connect/connect.d.ts
+++ b/connect/connect.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for connect v3.4.0.
+// Type definitions for connect v3.4.0
 // Project: https://github.com/senchalabs/connect
 // Definitions by: Maxime LUCE <https://github.com/SomaticIT/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -16,12 +16,11 @@ declare module "connect" {
     
     module createServer {
     	export type ServerHandle = HandleFunction | http.Server;
-
-        export interface HandleFunction {
-            (req: http.IncomingMessage, res: http.ServerResponse): void;
-            (req: http.IncomingMessage, res: http.ServerResponse, next: Function): void;
-            (err: Error, req: http.IncomingMessage, res: http.ServerResponse, next: Function): void;
-        }
+        
+        export type SimpleHandleFunction = (req: http.IncomingMessage, res: http.ServerResponse) => void;
+        export type NextHandleFunction = (req: http.IncomingMessage, res: http.ServerResponse, next: Function) => void;
+        export type ErrorHandleFunction = (err: Error, req: http.IncomingMessage, res: http.ServerResponse, next: Function) => void;
+        export type HandleFunction = SimpleHandleFunction | NextHandleFunction | ErrorHandleFunction;
 
     	export interface ServerStackItem {
             route: string;
@@ -29,7 +28,7 @@ declare module "connect" {
     	}
     	
         export interface Server extends NodeJS.EventEmitter {
-            (req: http.IncomingMessage, res: http.ServerResponse, next: Function) => void;
+            (req: http.IncomingMessage, res: http.ServerResponse, next?: Function): void;
 
             route: string;
             stack: ServerStackItem[];

--- a/connect/connect.d.ts
+++ b/connect/connect.d.ts
@@ -1,0 +1,89 @@
+// Type definitions for connect v3.4.0.
+// Project: https://github.com/senchalabs/connect
+// Definitions by: Maxime LUCE <https://github.com/SomaticIT/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module "connect" {
+    import * as http from "http";
+    
+    /**
+     * Create a new connect server.
+     * @public
+     */
+    function createServer(): createServer.Server;
+    
+    module createServer {
+    	export type ServerHandle = HandleFunction | http.Server;
+    	export type HandleFunction = (req: http.IncomingMessage, res: http.ServerResponse, next: Function) => void;
+    	
+    	export interface ServerStackItem {
+            route: string;
+            handle: ServerHandle;
+    	}
+    	
+        export interface Server extends NodeJS.EventEmitter {
+            (req: http.IncomingMessage, res: http.ServerResponse, next: Function) => void;
+            
+            route: string;
+            stack: ServerStackItem[];
+            
+            /**
+            * Utilize the given middleware `handle` to the given `route`,
+            * defaulting to _/_. This "route" is the mount-point for the
+            * middleware, when given a value other than _/_ the middleware
+            * is only effective when that segment is present in the request's
+            * pathname.
+            *
+            * For example if we were to mount a function at _/admin_, it would
+            * be invoked on _/admin_, and _/admin/settings_, however it would
+            * not be invoked for _/_, or _/posts_.
+            *
+            * @public
+            */
+            use(fn: HandleFunction): Server;
+            use(route: string, fn: HandleFunction): Server;
+            		
+            /**
+            * Handle server requests, punting them down
+            * the middleware stack.
+            *
+            * @private
+            */
+            handle(req: http.IncomingMessage, res: http.ServerResponse, next: Function): void;
+            
+            		
+            /**
+            * Listen for connections.
+            *
+            * This method takes the same arguments
+            * as node's `http.Server#listen()`.
+            *
+            * HTTP and HTTPS:
+            *
+            * If you run your application both as HTTP
+            * and HTTPS you may wrap them individually,
+            * since your Connect "server" is really just
+            * a JavaScript `Function`.
+            *
+            *      var connect = require('connect')
+            *        , http = require('http')
+            *        , https = require('https');
+            *
+            *      var app = connect();
+            *
+            *      http.createServer(app).listen(80);
+            *      https.createServer(options, app).listen(443);
+            *
+            * @api public
+            */
+            listen(port: number, hostname?: string, backlog?: number, callback?: Function): http.Server;
+            listen(port: number, hostname?: string, callback?: Function): http.Server;
+            listen(path: string, callback?: Function): http.Server;
+            listen(handle: any, listeningListener?: Function): http.Server;
+        }
+    }
+    
+    export = createServer;
+}


### PR DESCRIPTION
Add typings for connect project.

Others middleware typings (like serve-static, connect-flash, etc.) should use this project instead of express for base typings (as more simple).

Thanks.
