### PR TITLE
Update dhtmlxscheduler.d.ts

### DIFF
--- a/dhtmlxscheduler/dhtmlxscheduler.d.ts
+++ b/dhtmlxscheduler/dhtmlxscheduler.d.ts
@@ -1229,7 +1229,7 @@ interface SchedulerStatic{
 	 * return the event object by its id
 	 * @param event_id event_id
 	*/
-	getEvent(event_id: any);
+	getEvent<T>(event_id: any): T;
 
 	/**
 	 * gets the event's end date


### PR DESCRIPTION
use generic to strongly define the return type for `getEvent`
