### PR TITLE
amqplib: expose Option and Reply properties again (bugfix)

### DIFF
--- a/amqplib/amqplib-tests.ts
+++ b/amqplib/amqplib-tests.ts
@@ -63,5 +63,5 @@ amqpcb.connect("amqp://localhost", (err, connection) => {
 // test callback api properties
 var amqpcbMessage: amqpcb.Message;
 amqpcbMessage.properties.contentType = "application/json";
-var amqpcbAssertExchangeOptions: amqp.Options.AssertExchange;
-var anqpcbAssertExchangeReplies: amqp.Replies.AssertExchange;
+var amqpcbAssertExchangeOptions: amqpcb.Options.AssertExchange;
+var anqpcbAssertExchangeReplies: amqpcb.Replies.AssertExchange;

--- a/amqplib/amqplib-tests.ts
+++ b/amqplib/amqplib-tests.ts
@@ -24,7 +24,7 @@ amqp.connect("amqp://localhost")
 
 // test promise api properties
 var amqpMessage: amqp.Message;
-amqpMessage.properties.contentType === "application/json";
+amqpMessage.properties.contentType = "application/json";
 var amqpAssertExchangeOptions: amqp.Options.AssertExchange;
 var anqpAssertExchangeReplies: amqp.Replies.AssertExchange;
 
@@ -62,6 +62,6 @@ amqpcb.connect("amqp://localhost", (err, connection) => {
 
 // test callback api properties
 var amqpcbMessage: amqp.Message;
-amqpMessage.properties.contentType === "application/json";
+amqpcbMessage.properties.contentType = "application/json";
 var amqpcbAssertExchangeOptions: amqp.Options.AssertExchange;
 var anqpcbAssertExchangeReplies: amqp.Replies.AssertExchange;

--- a/amqplib/amqplib-tests.ts
+++ b/amqplib/amqplib-tests.ts
@@ -5,6 +5,7 @@ import amqp = require("amqplib");
 
 var msg = "Hello World";
 
+// test promise api
 amqp.connect("amqp://localhost")
     .then(connection => {
         return connection.createChannel()
@@ -20,6 +21,12 @@ amqp.connect("amqp://localhost")
             .then(channel => channel.consume("myQueue", newMsg => console.log("New Message: " + newMsg.content.toString())))
             .ensure(() => connection.close());
     });
+
+// test promise api properties
+var amqpMessage: amqp.Message;
+var amqpAssertExchangeOptions: amqp.Options.AssertExchange;
+var anqpAssertExchangeReplies: amqp.Replies.AssertExchange;
+
 
 // callback api tests
 import amqpcb = require("amqplib/callback_api");
@@ -51,3 +58,8 @@ amqpcb.connect("amqp://localhost", (err, connection) => {
         });
     }
 });
+
+// test callback api properties
+var amqpcbMessage: amqp.Message;
+var amqpcbAssertExchangeOptions: amqp.Options.AssertExchange;
+var anqpcbAssertExchangeReplies: amqp.Replies.AssertExchange;

--- a/amqplib/amqplib-tests.ts
+++ b/amqplib/amqplib-tests.ts
@@ -61,7 +61,7 @@ amqpcb.connect("amqp://localhost", (err, connection) => {
 });
 
 // test callback api properties
-var amqpcbMessage: amqp.Message;
+var amqpcbMessage: amqpcb.Message;
 amqpcbMessage.properties.contentType = "application/json";
 var amqpcbAssertExchangeOptions: amqp.Options.AssertExchange;
 var anqpcbAssertExchangeReplies: amqp.Replies.AssertExchange;

--- a/amqplib/amqplib-tests.ts
+++ b/amqplib/amqplib-tests.ts
@@ -24,6 +24,7 @@ amqp.connect("amqp://localhost")
 
 // test promise api properties
 var amqpMessage: amqp.Message;
+amqpMessage.properties.contentType === "application/json";
 var amqpAssertExchangeOptions: amqp.Options.AssertExchange;
 var anqpAssertExchangeReplies: amqp.Replies.AssertExchange;
 
@@ -61,5 +62,6 @@ amqpcb.connect("amqp://localhost", (err, connection) => {
 
 // test callback api properties
 var amqpcbMessage: amqp.Message;
+amqpMessage.properties.contentType === "application/json";
 var amqpcbAssertExchangeOptions: amqp.Options.AssertExchange;
 var anqpcbAssertExchangeReplies: amqp.Replies.AssertExchange;

--- a/amqplib/amqplib.d.ts
+++ b/amqplib/amqplib.d.ts
@@ -66,7 +66,7 @@ declare module "amqplib/properties" {
 
             contentType?: string;
             contentEncoding?: string;
-            headers?: Object;
+            headers?: any;
             priority?: number;
             correlationId?: string;
             replyTo?: string;
@@ -81,7 +81,7 @@ declare module "amqplib/properties" {
             noAck?: boolean;
             exclusive?: boolean;
             priority?: number;
-            arguments?: Object;
+            arguments?: any;
         }
         interface Get {
             noAck?: boolean;
@@ -90,8 +90,8 @@ declare module "amqplib/properties" {
 
     interface Message {
         content: Buffer;
-        fields: Object;
-        properties: Object;
+        fields: any;
+        properties: any;
     }
 }
 

--- a/amqplib/amqplib.d.ts
+++ b/amqplib/amqplib.d.ts
@@ -100,9 +100,9 @@ declare module "amqplib" {
     import events = require("events");
     import when = require("when");
     import shared = require("amqplib/properties")
-    import Replies = shared.Replies;
-    import Options = shared.Options;
-    import Message = shared.Message;
+    export import Replies = shared.Replies;
+    export import Options = shared.Options;
+    export import Message = shared.Message;
 
     interface Connection extends events.EventEmitter {
         close(): when.Promise<void>;
@@ -156,9 +156,9 @@ declare module "amqplib/callback_api" {
 
     import events = require("events");
     import shared = require("amqplib/properties")
-    import Replies = shared.Replies;
-    import Options = shared.Options;
-    import Message = shared.Message;
+    export import Replies = shared.Replies;
+    export import Options = shared.Options;
+    export import Message = shared.Message;
 
     interface Connection extends events.EventEmitter {
         close(callback?: (err: any) => void): void;


### PR DESCRIPTION
Forgot to export the Option, Reply and Message interfaces from within the 'amqplib' and 'amqplib/callback_api' modules. ( Oops! )

Fixed and added simple tests to check for them in the future. 
It is now compatible again with the original amqplib syntax.
