### PR TITLE
lodash: signatures of the method _.capitalize changed

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -3537,8 +3537,20 @@ result = <string>_.camelCase('Foo Bar');
 result = <string>_('Foo Bar').camelCase();
 
 // _.capitalize
-result = <string>_.capitalize('fred');
-result = <string>_('fred').capitalize();
+module TestCapitalize {
+    {
+        let result: string;
+
+        result = _.capitalize('fred');
+        result = _('fred').capitalize();
+    }
+
+    {
+        let result: _.LoDashExplicitWrapper<string>;
+
+        result = _('fred').chain().capitalize();
+    }
+}
 
 // _.deburr
 result = <string>_.deburr('déjà vu');

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -8989,6 +8989,13 @@ declare module _ {
         capitalize(): string;
     }
 
+    interface LoDashExplicitWrapper<T> {
+        /**
+         * @see _.capitalize
+         */
+        capitalize(): LoDashExplicitWrapper<string>;
+    }
+
     //_.deburr
     interface LoDashStatic {
         /**


### PR DESCRIPTION
https://lodash.com/docs#capitalize
https://lodash.com/docs#_ (description of the chainable wrapper)
