### PR TITLE
Type definitions and tests for express-handlebars

### DIFF
--- a/express-handlebars/express-handlebars-tests.ts
+++ b/express-handlebars/express-handlebars-tests.ts
@@ -1,0 +1,15 @@
+/// <reference path="../node/node.d.ts" />
+/// <reference path="../express/express.d.ts" />
+/// <reference path="express-handlebars.d.ts" />
+
+import express = require('express');
+import exphbs = require('express-handlebars');
+
+var app = express();
+app.engine('handlebars', exphbs({defaultLayout: 'main'}));
+app.set('view engine', 'handlebars');
+
+app.listen(1337);
+console.log('Started dummy server on port 1337...');
+console.log('Done');
+process.exit(0);

--- a/express-handlebars/express-handlebars-tests.ts
+++ b/express-handlebars/express-handlebars-tests.ts
@@ -6,10 +6,12 @@ import express = require('express');
 import exphbs = require('express-handlebars');
 
 var app = express();
-app.engine('handlebars', exphbs({defaultLayout: 'main'}));
+var hbs: Exphbs = exphbs.create({defaultLayout: 'main'});
+
+app.engine('handlebars', hbs.engine);
 app.set('view engine', 'handlebars');
 
 app.listen(1337);
-console.log('Started dummy server on port 1337...');
+console.log('Test Express Handlebars app on port 1337..');
 console.log('Done');
 process.exit(0);

--- a/express-handlebars/express-handlebars.d.ts
+++ b/express-handlebars/express-handlebars.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Sam Saint-Pettersen <https://github.com/stpettersens>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-interface Promise {} // This should be replaced with a Promise type definition import.
+/// <reference path="../es6-promise/es6-promise.d.ts" />
 
 interface PartialTemplateOptions {
     cache?: boolean;
@@ -33,10 +33,10 @@ interface Exphbs {
     compiled: Object;
     precompiled: Object;
     create(options?: ExphbsOptions): Exphbs;
-    getPartials(options?: PartialTemplateOptions): Promise;
-    getTemplate(filePath: string, options?: PartialTemplateOptions): Promise;
-    getTemplates(dirPath: string, options?: PartialTemplateOptions): Promise;
-    render(filePath: string, context: Object, options?: RenderOptions): Promise;
+    getPartials(options?: PartialTemplateOptions): Promise<Object>;
+    getTemplate(filePath: string, options?: PartialTemplateOptions): Promise<Function>;
+    getTemplates(dirPath: string, options?: PartialTemplateOptions): Promise<Object>;
+    render(filePath: string, context: Object, options?: RenderOptions): Promise<string>;
     renderView(viewPath: string, optionsOrCallback?: any, callback?: Function): void;
 }
 

--- a/express-handlebars/express-handlebars.d.ts
+++ b/express-handlebars/express-handlebars.d.ts
@@ -37,7 +37,7 @@ interface Exphbs {
     getTemplate(filePath: string, options?: PartialTemplateOptions): Promise<Function>;
     getTemplates(dirPath: string, options?: PartialTemplateOptions): Promise<Object>;
     render(filePath: string, context: Object, options?: RenderOptions): Promise<string>;
-    renderView(viewPath: string, optionsOrCallback?: any, callback?: Function): void;
+    renderView(viewPath: string, optionsOrCallback?: any, callback?: () => string): void;
 }
 
 declare module "express-handlebars" {

--- a/express-handlebars/express-handlebars.d.ts
+++ b/express-handlebars/express-handlebars.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for express-handlebars
+// Project: https://github.com/ericf/express-handlebars
+// Definitions by: Sam Saint-Pettersen <https://github.com/stpettersens>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+interface ExphbsOptions {
+    handlebars?: any;
+    extname?: string;
+    layoutsDir?: string;
+    partialsDir?: string;
+    defaultLayout?: string;
+    helpers?: any;
+    compilerOptions?: any;
+}
+
+declare module "express-handlebars" {
+    function exphbs(options: ExphbsOptions): Function;
+    export = exphbs;
+}

--- a/express-handlebars/express-handlebars.d.ts
+++ b/express-handlebars/express-handlebars.d.ts
@@ -3,6 +3,20 @@
 // Definitions by: Sam Saint-Pettersen <https://github.com/stpettersens>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
+interface Promise {} // This should be replaced with a Promise type definition import.
+
+interface PartialTemplateOptions {
+    cache?: boolean;
+    precompiled?: boolean;
+}
+
+interface RenderOptions {
+    cache?: boolean;
+    data?: Object;
+    helpers?: any;
+    partials?: any;
+}
+
 interface ExphbsOptions {
     handlebars?: any;
     extname?: string;
@@ -13,7 +27,20 @@ interface ExphbsOptions {
     compilerOptions?: any;
 }
 
+interface Exphbs {
+    engine: Function;
+    extname: string;
+    compiled: Object;
+    precompiled: Object;
+    create(options?: ExphbsOptions): Exphbs;
+    getPartials(options?: PartialTemplateOptions): Promise;
+    getTemplate(filePath: string, options?: PartialTemplateOptions): Promise;
+    getTemplates(dirPath: string, options?: PartialTemplateOptions): Promise;
+    render(filePath: string, context: Object, options?: RenderOptions): Promise;
+    renderView(viewPath: string, optionsOrCallback?: any, callback?: Function): void;
+}
+
 declare module "express-handlebars" {
-    function exphbs(options: ExphbsOptions): Function;
+    var exphbs: Exphbs;
     export = exphbs;
 }


### PR DESCRIPTION
https://github.com/ericf/express-handlebars
http://www.npmjs.com/package/express-handlebars

I believe this is the full API (didn't define _ internal parts because I don't think you are supposed to use those directly). Let me know if you want me to tweak anything. 

As a side note, I did not define `function exphbs(options: ExphbsOptions): Function` like before as this broke using:

```
/// <reference path="../express/express.d.ts" />
/// <reference path="express-handlebars.d.ts" />
import express = require('express');
import exphbs = require('express-handlebars');

var app = express();
var hbs: Exphbs = exphbs.create({defaultLayout: 'main'});
app.engine('handlebars', hbs.engine); 
```

Please advise on how I can have both that and a direct function call like so in the same definition:

```
app.engine('handlebars', exphbs({defaultLayout: 'main'}));
```

Couldn't work that out myself. Thanks.
