### PR TITLE
Backbone: Fixed History.Started being undefined

### DIFF
--- a/backbone/backbone-global.d.ts
+++ b/backbone/backbone-global.d.ts
@@ -301,7 +301,7 @@ declare module Backbone {
         checkUrl(e?: any): void;
         loadUrl(fragmentOverride: string): boolean;
         navigate(fragment: string, options?: any): boolean;
-        started: boolean;
+        static started: boolean;
         options: any;
 
         private _updateHash(location: Location, fragment: string, replace: boolean): void;


### PR DESCRIPTION
The History.started flag is set on the class rather than on the class instance (as it is set once globally). Attempts to read _Backbone.history.started_ (via the global history instance) always return undefined. Instead the typing should be static member (_Backbone.History.started_ is where the correct value is located). This can be seen at http://backbonejs.org/docs/backbone.html#section-203
