### PR TITLE
Correct Misspelled "IHttpRequestTransformer".

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1390,7 +1390,7 @@ declare module angular {
     }
 
     // See the jsdoc for transformData() at https://github.com/angular/angular.js/blob/master/src/ng/http.js#L228
-    interface IHttpResquestTransformer {
+    interface IHttpRequestTransformer {
         (data: any, headersGetter: IHttpHeadersGetter): any;
     }
 
@@ -1427,7 +1427,7 @@ declare module angular {
          * headers and returns its transformed (typically serialized) version.
          * @see {@link https://docs.angularjs.org/api/ng/service/$http#transforming-requests-and-responses}
          */
-        transformRequest?: IHttpResquestTransformer |IHttpResquestTransformer[];
+        transformRequest?: IHttpRequestTransformer |IHttpRequestTransformer[];
 
         /**
          * Transform function or an array of such functions. The transform function takes the http response body and


### PR DESCRIPTION
Was this intentional?  I am assuming whoever originally created, just copied IHttpResponseTransformer and changed to IHttpRequestTransformer missing the additional 'S' in there.  Maybe I am being to anal?
