### PR TITLE
lodash: signatures of the method _.matches changed

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -3759,13 +3759,21 @@ module TestMatches {
     {
         let result: (value: any) => boolean;
         result = _.matches<TResult>(source);
-        result = _(source).matches().value();
     }
 
     {
         let result: (value: TResult) => boolean;
         result = _.matches<TResult, TResult>(source);
-        result = _(source).matches<TResult>().value();
+    }
+
+    {
+        let result: _.LoDashImplicitObjectWrapper<(value: TResult) => boolean>;
+        result = _(source).matches<TResult>();
+    }
+
+    {
+        let result: _.LoDashExplicitObjectWrapper<(value: TResult) => boolean>;
+        result = _(source).chain().matches<TResult>();
     }
 }
 

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -9567,16 +9567,12 @@ declare module _ {
          * @param source The object of property values to match.
          * @return Returns the new function.
          */
-        matches<T>(
-            source: T
-        ): (value: any) => boolean;
+        matches<T>(source: T): (value: any) => boolean;
 
         /**
          * @see _.matches
          */
-        matches<T, V>(
-            source: T
-        ): (value: V) => boolean;
+        matches<T, V>(source: T): (value: V) => boolean;
     }
 
     interface LoDashImplicitWrapperBase<T, TWrapper> {
@@ -9584,6 +9580,13 @@ declare module _ {
          * @see _.matches
          */
         matches<V>(): LoDashImplicitObjectWrapper<(value: V) => boolean>;
+    }
+
+    interface LoDashExplicitWrapperBase<T, TWrapper> {
+        /**
+         * @see _.matches
+         */
+        matches<V>(): LoDashExplicitObjectWrapper<(value: V) => boolean>;
     }
 
     //_.matchesProperty


### PR DESCRIPTION
https://lodash.com/docs#matches
https://lodash.com/docs#_ (description of the chainable wrapper)
