### PR TITLE
react-bootstrap. Use React.Props as base interface for all Props.

### DIFF
--- a/react-bootstrap/react-bootstrap.d.ts
+++ b/react-bootstrap/react-bootstrap.d.ts
@@ -12,7 +12,7 @@ declare module "react-bootstrap" {
 
     // <Button />
     // ----------------------------------------
-    interface ButtonProps { 
+    interface ButtonProps extends React.Props<ButtonClass>{
 
         // Optional
         active?: boolean;
@@ -20,6 +20,7 @@ declare module "react-bootstrap" {
         block?: boolean;
         bsStyle?: string;
         bsSize?: string;
+        className?: string;
         navItem?: boolean;
         navDropdown?: boolean;
         componentClass?: string;
@@ -35,12 +36,13 @@ declare module "react-bootstrap" {
 
     // <ButtonToolbar />
     // ----------------------------------------
-    interface ButtonToolbarProps { 
+    interface ButtonToolbarProps extends React.Props<ButtonToolbarClass> {
 
         // Optional
         block?: boolean;
         bsSize?: string;
         bsStyle?: string;
+        className?: string;
         justified?: boolean;
         vertical?: boolean;
     }
@@ -50,11 +52,12 @@ declare module "react-bootstrap" {
 
     // <ButtonGroup />
     // ----------------------------------------
-    interface ButtonGroupProps { 
+    interface ButtonGroupProps extends React.Props<ButtonGroupClass> {
         // Optional
         block?: boolean;
         bsSize?: string;
         bsStyle?: string;
+        className?: string;
         justified?: boolean;
         vertical?: boolean;
     }
@@ -65,16 +68,14 @@ declare module "react-bootstrap" {
 
     // <DropdownButton />
     // ----------------------------------------
-    interface DropdownButtonProps { 
+    interface DropdownButtonProps extends React.Props<DropdownButtonClass> {
         bsStyle?: string;
         bsSize?: string;
         buttonClassName?: string; 
-        children?: any; // TODO: Add more specific type 
         className?: string;
         dropup?: boolean;
         href?: string;
         id?: string | number; 
-        key?: any; // TODO: Add more specific type
         navItem?: boolean;
         noCaret?: boolean;
         onClick?: Function;  // TODO: Add more specifc type 
@@ -89,10 +90,9 @@ declare module "react-bootstrap" {
 
     // <SplitButton />
     // ----------------------------------------
-    interface SplitButtonProps { 
+    interface SplitButtonProps extends React.Props<SplitButtonClass>{ 
         bsStyle?: string;
         bsSize?: string;
-        children?: any; // TODO: Add more specific type 
         className?: string;
         disabled?: boolean;
         dropdownTitle?: any; // TODO: Add more specific type
@@ -112,14 +112,14 @@ declare module "react-bootstrap" {
 
     // <MenuItem />
     // ----------------------------------------
-    interface MenuItemProps { 
+    interface MenuItemProps extends React.Props<MenuItemClass> {
         active?: boolean;
+        className?: string;
         disabled?: boolean;
         divider?: boolean;
         eventKey?: any;
         header?: boolean;
         href?: string;
-        key?: any; 
         onSelect?: Function;
         target?: string;
         title?: string;
@@ -131,7 +131,8 @@ declare module "react-bootstrap" {
 
     // <Panel />
     // ----------------------------------------
-    interface PanelProps { 
+    interface PanelProps extends React.Props<PanelClass> {
+        className?: string;
         bsSize?: string;
         bsStyle?: string;
         collapsible?: boolean;
@@ -151,7 +152,7 @@ declare module "react-bootstrap" {
 
     // <Accordion />
     // ----------------------------------------
-    interface AccordionProps { 
+    interface AccordionProps extends React.Props<AccordionClass> {
         bsSize?: string;
         bsStyle?: string;
         collapsible?: boolean;
@@ -170,12 +171,11 @@ declare module "react-bootstrap" {
 
     // <PanelGroup />
     // ----------------------------------------
-    interface PanelGroupProps { 
+    interface PanelGroupProps extends React.Props<PanelGroupClass> { 
         accordion?: boolean;
         activeKey?: any;
         bsSize?: string;
         bsStyle?: string;
-        children?: any;
         className?: string;
         defaultActiveKey?: any;
         onSelect?: Function;
@@ -187,7 +187,7 @@ declare module "react-bootstrap" {
 
     // <Modal.Dialog />
     // ----------------------------------------
-    interface ModalDialogProps {
+    interface ModalDialogProps extends React.Props<ModalDialogClass> {
         // TODO: Add more specific type 
     }
     interface ModalDialog extends React.ReactElement<ModalDialogProps> { }
@@ -196,7 +196,8 @@ declare module "react-bootstrap" {
 
     // <Modal.Header />
     // ----------------------------------------
-    interface ModalHeaderProps {
+  interface ModalHeaderProps extends React.Props<ModalHeaderClass> {
+        className?: string;
         closeButton?: boolean;
         modalClassName?: string;
         onHide?: Function;
@@ -208,7 +209,8 @@ declare module "react-bootstrap" {
 
     // <Modal.Title/>
     // ----------------------------------------
-    interface ModalTitleProps {
+    interface ModalTitleProps extends React.Props<ModalTitleClass> {
+        className?: string;
         modalClassName?: string;
     }
     interface ModalTitle extends React.ReactElement<ModalTitleProps> { }
@@ -217,7 +219,8 @@ declare module "react-bootstrap" {
 
     // <Modal.Body />
     // ----------------------------------------
-    interface ModalBodyProps {
+    interface ModalBodyProps extends React.Props<ModalBodyClass> {
+        className?: string;
         modalClassName?: string;
     }
     interface ModalBody extends React.ReactElement<ModalBodyProps> { }
@@ -226,7 +229,8 @@ declare module "react-bootstrap" {
 
     // <Modal.Footer />
     // ----------------------------------------
-    interface ModalFooterProps {
+    interface ModalFooterProps extends React.Props<ModalFooterClass> {
+        className?: string;
         modalClassName?: string;
     }
     interface ModalFooter extends React.ReactElement<ModalFooterProps> { }
@@ -235,7 +239,7 @@ declare module "react-bootstrap" {
 
     // <Modal />
     // ----------------------------------------
-    interface ModalProps { 
+    interface ModalProps extends React.Props<ModalClass> {
         // Required
         onHide: Function;
 
@@ -249,9 +253,10 @@ declare module "react-bootstrap" {
         dialogComponent?: any; // TODO: Add more specific type
         enforceFocus?: boolean;
         keyboard?: boolean;
+        show?: boolean;
     }
     interface Modal extends React.ReactElement<ModalProps> { }
-    interface ModalClass extends React.ComponentClass<ModalProps> { 
+    interface ModalClass extends React.ComponentClass<ModalProps> {
         Header: ModalHeaderClass;
         Title: ModalTitleClass;
         Body: ModalBodyClass;
@@ -263,7 +268,7 @@ declare module "react-bootstrap" {
 
     // <OverlayTrigger />
     // ----------------------------------------
-    interface OverlayTriggerProps { 
+    interface OverlayTriggerProps extends React.Props<OverlayTriggerClass> {
         // Required
         overlay: any; // TODO: Add more specific type
 
@@ -292,7 +297,7 @@ declare module "react-bootstrap" {
 
     // <Tooltip />
     // ----------------------------------------
-    interface TooltipProps {
+    interface TooltipProps extends React.Props<TooltipClass> {
         // Optional
         arrowOffsetLeft?: number | string;
         arrowOffsetTop?: number | string;
@@ -312,12 +317,13 @@ declare module "react-bootstrap" {
 
     // <Popover/>
     // ----------------------------------------
-    interface PopoverProps {
+    interface PopoverProps  extends React.Props<PopoverClass> {
         // Optional
         arrowOffsetLeft?: number | string;
         arrowOffsetTop?: number | string;
         bsSize?: string;
         bsStyle?: string;
+        className?: string;
         id?: string; 
         placement?: string;
         positionLeft?: number;
@@ -331,7 +337,7 @@ declare module "react-bootstrap" {
 
     // <Overlay />
     // ----------------------------------------
-    interface OverlayProps {
+    interface OverlayProps extends React.Props<OverlayClass> {
         // Optional
         animation?: any; // TODO: Add more specific type
         container?: any; // TODO: Add more specific type
@@ -355,16 +361,14 @@ declare module "react-bootstrap" {
 
     // <ProgressBar />
     // ----------------------------------------
-    interface ProgressBarProps {
+    interface ProgressBarProps extends React.Props<ProgressBarClass> {
         // Optional
         active?: boolean;
         bsSize?: string;
         bsStyle?: string;
-        children?: any; // TODO: Add more specific type
         className?: string;
         interpolatedClass?: any; // TODO: Add more specific type
         label?: any; // TODO: Add more specific type
-        key?: number; // TODO: Add more specific type
         max?: number;
         min?: number;
         now?: number;
@@ -379,7 +383,7 @@ declare module "react-bootstrap" {
     // <Nav />
     // ----------------------------------------
     // TODO: This one turned into a union of two different types 
-    interface NavProps {
+    interface NavProps extends React.Props<NavClass> {
         // Optional
         activeHref?: string;
         activeKey?: any;
@@ -406,11 +410,12 @@ declare module "react-bootstrap" {
 
     // <NavItem />
     // ----------------------------------------
-    interface NavItemProps {
+    interface NavItemProps extends React.Props<NavItemClass> {
         active?: boolean;
         brand?: any; // TODO: Add more specific type
         bsSize?: string;
         bsStyle?: string;
+        className?: string;
         componentClass?: any; // TODO: Add more specific type
         defaultNavExpanded?: boolean;
         disabled?: boolean;
@@ -422,6 +427,7 @@ declare module "react-bootstrap" {
         inverse?: boolean;
         linkId?: string;
         navExpanded?: boolean;
+        onClick?: Function;
         onSelect?: Function;
         onToggle?: Function;
         role?: string;
@@ -438,10 +444,11 @@ declare module "react-bootstrap" {
 
     // <Navbar />
     // ----------------------------------------
-    interface NavbarProps {
+    interface NavbarProps extends React.Props<NavbarClass> {
         brand?: any; // TODO: Add more specific type
         bsSize?: string;
         bsStyle?: string;
+        className?: string;
         componentClass?: any; // TODO: Add more specific type
         defaultNavExpanded?: boolean;
         fixedBottom?: boolean;
@@ -462,7 +469,8 @@ declare module "react-bootstrap" {
 
     // <NavDropdown />
     // ----------------------------------------
-    interface NavDropdownProps {
+    interface NavDropdownProps extends React.Props<NavDropdownClass> {
+        className?: string;
         eventKey?: any;
         title?: string;
         id?: string;
@@ -474,7 +482,7 @@ declare module "react-bootstrap" {
 
     // <Tabs />
     // ----------------------------------------
-    interface TabsProps {
+    interface TabsProps extends React.Props<TabsClass> {
         activeKey?: any; 
         animation?: boolean;
         bsStyle?: string;
@@ -492,8 +500,9 @@ declare module "react-bootstrap" {
 
     // <Tab />
     // ----------------------------------------
-    interface TabProps {
+    interface TabProps extends React.Props<TabClass> {
         animation?: boolean;
+        className?: string;
         disabled?: boolean;
         eventKey?: any; // TODO: Add more specific type
         title?: any; // TODO: Add more specific type
@@ -505,7 +514,8 @@ declare module "react-bootstrap" {
 
     // <Pager />
     // ----------------------------------------
-    interface PagerProps {
+    interface PagerProps extends React.Props<PagerClass> {
+        className?: string;
         onSelect?: Function;
     }
     interface Pager extends React.ReactElement<PagerProps> { }
@@ -515,7 +525,8 @@ declare module "react-bootstrap" {
 
     // <PageItem />
     // ----------------------------------------
-    interface PageItemProps {
+    interface PageItemProps extends React.Props<PageItemClass> {
+        className?: string;
         disabled?: boolean;
         eventKey?: any; 
         href?: string;
@@ -532,11 +543,12 @@ declare module "react-bootstrap" {
 
     // <Pagination />
     // ----------------------------------------
-    interface PaginationProps {
+    interface PaginationProps extends React.Props<PaginationClass> {
         activePage?: number;
         bsSize?: string;
         bsStyle?: string;
         buttonComponentClass?: any; // TODO: Add more specific type
+        className?: string;
         ellipsis?: boolean;
         first?: boolean;
         items?: number;
@@ -553,9 +565,10 @@ declare module "react-bootstrap" {
 
     // <Alert />
     // ----------------------------------------
-    interface AlertProps {
+    interface AlertProps extends React.Props<AlertClass> {
         bsSize?: string;
         bsStyle?: string;
+        className?: string;
         closeLabel?: string;
         dismissAfter?: number;
         onDismiss?: Function;
@@ -567,10 +580,11 @@ declare module "react-bootstrap" {
 
     // <Carousel />
     // ----------------------------------------
-    interface CarouselProps {
+    interface CarouselProps extends React.Props<CarouselClass> {
         activeIndex?: number;
         bsSize?: string;
         bsStyle?: string;
+        className?: string;
         controls?: boolean;
         defaultActiveIndex?: number;
         direction?: string;
@@ -591,11 +605,12 @@ declare module "react-bootstrap" {
 
     // <CarouselItem />
     // ----------------------------------------
-    interface CarouselItemProps {
+    interface CarouselItemProps extends React.Props<CarouselItemClass> {
         active?: boolean;
         animtateIn?: boolean;
         animateOut?: boolean;
         caption?: any; // TODO: Add more specific type
+        className?: string;
         direction?: string;
         index?: number;
         onAnimateOutEnd?: Function;
@@ -607,7 +622,8 @@ declare module "react-bootstrap" {
 
     // <Grid />
     // ----------------------------------------
-    interface GridProps {
+    interface GridProps extends React.Props<GridClass> {
+        className?: string;
         componentClass?: any; // TODO: Add more specific type
         fluid?: boolean; 
     }
@@ -618,7 +634,7 @@ declare module "react-bootstrap" {
 
     // <Row />
     // ----------------------------------------
-    interface RowProps {
+    interface RowProps extends React.Props<RowClass> {
         className?: string;
         componentClass?: any; // TODO: Add more specific type
     }
@@ -629,7 +645,8 @@ declare module "react-bootstrap" {
 
     // <Col />
     // ----------------------------------------
-    interface ColProps {
+    interface ColProps extends React.Props<ColClass> {
+        className?: string;
         componentClass?: any; // TODO: Add more specific type
         lg?: number;
         lgOffset?: number;
@@ -655,10 +672,11 @@ declare module "react-bootstrap" {
 
     // <Thumbnail />
     // ----------------------------------------
-    interface ThumbnailProps {
+    interface ThumbnailProps extends React.Props<ThumbnailClass> {
         alt?: string;
         bsSize?: string;
         bsStyle?: string;
+        className?: string;
         href?: string;
         src?: string;
     }
@@ -669,7 +687,7 @@ declare module "react-bootstrap" {
 
     // <ListGroup />
     // ----------------------------------------
-    interface ListGroupProps {
+    interface ListGroupProps extends React.Props<ListGroupClass> {
         className?: string;
         id?: string | number;
         fill?: boolean; // TODO: Add more specific type
@@ -681,7 +699,7 @@ declare module "react-bootstrap" {
 
     // <ListGroupItem />
     // ----------------------------------------
-    interface ListGroupItemProps {
+    interface ListGroupItemProps extends React.Props<ListGroupItemClass> {
         active?: any;
         bsSize?: string;
         bsStyle?: string;
@@ -702,9 +720,10 @@ declare module "react-bootstrap" {
 
     // <Label />
     // ----------------------------------------
-    interface LabelProps {
+    interface LabelProps extends React.Props<LabelClass> {
         bsSize?: string;
         bsStyle?: string;
+        className?: string;
     }
     interface Label extends React.ReactElement<LabelProps> { }
     interface LabelClass extends React.ComponentClass<LabelProps> { }
@@ -713,7 +732,8 @@ declare module "react-bootstrap" {
 
     // <Badge />
     // ----------------------------------------
-    interface BadgeProps {
+    interface BadgeProps extends React.Props<BadgeClass> {
+        className?: string;
         pullRight?: boolean;
     }
     interface Badge extends React.ReactElement<BadgeProps> { }
@@ -723,7 +743,8 @@ declare module "react-bootstrap" {
 
     // <Jumbotron />
     // ----------------------------------------
-    interface JumbotronProps {
+    interface JumbotronProps extends React.Props<JumbotronClass> {
+        className?: string;
         componentClass?: any; // TODO: Add more specific type
     }
     interface Jumbotron extends React.ReactElement<JumbotronProps> { }
@@ -733,8 +754,8 @@ declare module "react-bootstrap" {
 
     // <PageHeader />
     // ----------------------------------------
-    interface PageHeaderProps {
-        // No props 
+    interface PageHeaderProps extends React.Props<PageHeaderClass> {
+        className?: string;
     }
     interface PageHeader extends React.ReactElement<PageHeaderProps> { }
     interface PageHeaderClass extends React.ComponentClass<PageHeaderProps> { }
@@ -743,9 +764,10 @@ declare module "react-bootstrap" {
 
     // <Well />
     // ----------------------------------------
-    interface WellProps {
+    interface WellProps extends React.Props<WellClass> {
         bsSize?: string;
         bsStyle?: string;
+        className?: string;
     }
     interface Well extends React.ReactElement<WellProps> { }
     interface WellClass extends React.ComponentClass<WellProps> { }
@@ -754,7 +776,8 @@ declare module "react-bootstrap" {
 
     // <Glyphicon />
     // ----------------------------------------
-    interface GlyphiconProps {
+    interface GlyphiconProps extends React.Props<GlyphiconClass> {
+        className?: string;
         // Required 
         glyph: string;
     }
@@ -765,8 +788,9 @@ declare module "react-bootstrap" {
 
     // <Table />
     // ----------------------------------------
-    interface TableProps {
+    interface TableProps extends React.Props<TableClass> {
         bordered?: boolean;
+        className?: string;
         condensed?: boolean;
         hover?: boolean;
         responsive?: boolean;
@@ -779,13 +803,14 @@ declare module "react-bootstrap" {
 
     // <Input />
     // ----------------------------------------
-    interface InputProps {
+    interface InputProps extends React.Props<InputClass> {
         addonAfter?: any; // TODO: Add more specific type
         addonBefore?: any; // TODO: Add more specific type
         bsSize?: string;
         bsStyle?: string;
         buttonAfter?: any; // TODO: Add more specific type
-        buttonBefore?: any; // TODO: Add more specific type 
+        buttonBefore?: any; // TODO: Add more specific type
+        className?: string;
         checked?: boolean;
         disabled?: boolean;
         feedbackIcon?: any; // TODO: Add more specific type
@@ -797,7 +822,6 @@ declare module "react-bootstrap" {
         labelClassName?: string;
         multiple?: boolean;
         placeholder?: string;
-        ref?: string;
         readOnly?: boolean;
         type?: string;
         onChange?: Function; // TODO: Add more specific type 
@@ -814,13 +838,14 @@ declare module "react-bootstrap" {
 
     // <ButtonInput />
     // ----------------------------------------
-    interface ButtonInputProps { 
+    interface ButtonInputProps extends React.Props<ButtonInputClass> {
         addonAfter?: any; // TODO: Add more specific type
         addonBefore?: any; // TODO: Add more specific type
         bsSize?: string;
         bsStyle?: string;
         buttonAfter?: any; // TODO: Add more specific type
-        buttonBefore?: any; // TODO: Add more specific type 
+        buttonBefore?: any; // TODO: Add more specific type
+        className?: string;
         disabled?: boolean;
         feedbackIcon?: any; // TODO: Add more specific type
         groupClassName?: string;
@@ -845,7 +870,7 @@ declare module "react-bootstrap" {
   
     // <Portal />
     // ----------------------------------------
-    interface PortalProps { 
+    interface PortalProps extends React.Props<PortalClass> {
         dimension?: string | Function;
         getDimensionValue?: Function;
         in?: boolean;
@@ -867,7 +892,7 @@ declare module "react-bootstrap" {
    
     // <Position />
     // ----------------------------------------
-    interface PositionProps { 
+    interface PositionProps extends React.Props<PositionClass> {
         dimension?: string | Function;
         getDimensionValue?: Function;
         in?: boolean;
@@ -889,7 +914,7 @@ declare module "react-bootstrap" {
 
     // <Fade />
     // ----------------------------------------
-    interface FadeProps { 
+    interface FadeProps extends React.Props<FadeClass> {
         in?: boolean;
         onEnter?: Function;
         onEntered?: Function;


### PR DESCRIPTION
It is convenient to use React.Props as base class for all components props.
It allows to use key and ref properties with all bootstrap components.

Also add missing properties like className, etc.
