### PR TITLE
lodash: signatures of the method _.padRight changed

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -3579,12 +3579,28 @@ result = <string>_('abc').padLeft(6);
 result = <string>_('abc').padLeft(6, '_-');
 
 // _.padRight
-result = <string>_.padRight('abc');
-result = <string>_.padRight('abc', 6);
-result = <string>_.padRight('abc', 6, '_-');
-result = <string>_('abc').padRight();
-result = <string>_('abc').padRight(6);
-result = <string>_('abc').padRight(6, '_-');
+module TestPadRight {
+    {
+        let result: string;
+
+        result = _.padRight('abc');
+        result = _.padRight('abc', 6);
+        result = _.padRight('abc', 6, '_-');
+
+        result = _('abc').padRight();
+        result = _('abc').padRight(6);
+        result = _('abc').padRight(6, '_-');
+    }
+
+    {
+        let result: _.LoDashExplicitWrapper<string>;
+
+        result = _('abc').chain().padRight();
+        result = _('abc').chain().padRight(6);
+        result = _('abc').chain().padRight(6, '_-');
+    }
+}
+
 
 // _.parseInt
 result = <number>_.parseInt('08');

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -9123,20 +9123,37 @@ declare module _ {
         /**
          * Pads string on the right side if it’s shorter than length. Padding characters are truncated if they exceed
          * length.
+         *
          * @param string The string to pad.
          * @param length The padding length.
          * @param chars The string used as padding.
          * @return Returns the padded string.
          */
-        padRight(string?: string, length?: number, chars?: string): string;
+        padRight(
+            string?: string,
+            length?: number,
+            chars?: string
+        ): string;
     }
 
-    //_.padRight
     interface LoDashImplicitWrapper<T> {
         /**
          * @see _.padRight
          */
-        padRight(length?: number, chars?: string): string;
+        padRight(
+            length?: number,
+            chars?: string
+        ): string;
+    }
+
+    interface LoDashExplicitWrapper<T> {
+        /**
+         * @see _.padRight
+         */
+        padRight(
+            length?: number,
+            chars?: string
+        ): LoDashExplicitWrapper<string>;
     }
 
     //_.parseInt


### PR DESCRIPTION
https://lodash.com/docs#padRight
https://lodash.com/docs#_ (description of the chainable wrapper)
