### PR TITLE
Add typings for packages 'electron-packager' and 'electron-builder'

### DIFF
--- a/electron-builder/electron-builder-tests.ts
+++ b/electron-builder/electron-builder-tests.ts
@@ -1,0 +1,54 @@
+/// <reference path="./electron-builder.d.ts" />
+
+import * as factory from "electron-builder";
+const builder = factory.init();
+
+function callback(err: Error) {
+	const msg = err.message;
+}
+
+builder.build({
+	appPath: ".",
+	out: "out",
+	platform: "win",
+	config: {
+		osx: {
+			title: "myapplication",
+			icon: "icon.icns",
+			"icon-size": 80,
+			background: "installer.png",
+			contents: [
+				{ x: 438, y: 344, type: "link", path: "/Applications" },
+				{ x: 192, y: 344, type: "file" },
+			]
+		},
+		win: {
+			title: "myapplication",
+			icon: "icon.ico"
+		}
+	}
+}, callback);
+
+const bldr = require("electron-builder").init();
+
+bldr.build({
+	appPath: ".",
+	out: "out",
+	platform: "osx",
+	config: {
+		osx: {
+			title: "myapplication",
+			icon: "icon.icns",
+			"icon-size": 80,
+			background: "installer.png",
+			contents: [
+				{ x: 438, y: 344, type: "link", path: "/Applications" },
+				{ x: 192, y: 344, type: "file" },
+			]
+		},
+		win: {
+			title: "myapplication",
+			icon: "icon.ico"
+		}
+	}
+}, callback);

--- a/electron-builder/electron-builder.d.ts
+++ b/electron-builder/electron-builder.d.ts
@@ -1,0 +1,90 @@
+// Type definitions for electron-builder v2.0.2
+// Project: https://github.com/loopline-systems/electron-builder
+// Definitions by: Maxime LUCE <https://github.com/SomaticIT/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare namespace ElectronBuilder {
+
+    /** Electron-builder Options. */
+    export interface Options {
+        /** Source application path. */
+        appPath: string;
+
+        /** Platforms to build. Allowed values: win, osx, all. */
+        platform: string;
+
+        /** Path or Object. Configuration for build. */
+        config: string | Config;
+
+        /** The output directory. */
+        out?: string;
+
+    }
+
+    /** Build configuration by platforms. */
+    export interface Config {
+        /** Configurations for Mac OS X. */
+        osx: {
+            /** Installer title. */
+            title: string;
+            /** Installer background. */
+            background: string;
+            /** Installer icon. */
+            icon: string;
+            /** Installer icon size. */
+            "icon-size": number;
+            /** Installer custom contents. */
+            contents: [OsxContents, OsxContents]
+        };
+
+        /** Configurations for Windows. */
+        win: {
+            /** Installer title. */
+            title: string;
+            /** Installer icon. */
+            icon: string;
+        };
+    }
+
+    /** OSX Installer custom contents. */
+    export interface OsxContents {
+        /** Horizontal position on installer screen (in pixels). */
+        x: number;
+        /** Vertical position on installer screen (in pixels). */
+        y: number;
+        /** Content type. Allowed values are "file", "link". */
+        type: string;
+        /** Link only. Customize link destination path. */
+        path?: string;
+    }
+
+    /** Electron-builder done callback. */
+    export interface Callback {
+        /**
+         * Callback wich is called when electron-builder is done.
+         * @param err - Contains errors if any.
+         */
+        (err: Error): void
+    }
+
+    /** Prototype for electron-builder. */
+    export interface Builder {
+        /**
+         * Build the installer for given platform.
+         *
+         * @param opts - Options to configure installer.
+         * @param callback - Callback which is called when building is done or an error occured.
+         */
+        build(opts: Options, callback: Callback): void;
+    }
+}
+
+declare module "electron-builder" {
+    export function init(): ElectronBuilder.Builder;
+}
+
+interface NodeRequireFunction {
+    (id: "electron-builder"): { init(): ElectronBuilder.Builder };
+}

--- a/electron-packager/electron-packager-tests.ts
+++ b/electron-packager/electron-packager-tests.ts
@@ -1,0 +1,41 @@
+/// <reference path="./electron-packager.d.ts" />
+
+import * as packager from "electron-packager";
+
+function callback(err: Error, appPath: string) {
+	const
+		msg = err.message,
+		index = appPath.indexOf("test");
+}
+
+packager({
+	dir: ".",
+	name: "myapplication",
+	platform: "win32",
+	arch: "all",
+	version: "0.34.0"
+}, callback);
+
+packager({
+	dir: ".",
+	name: "myapplication",
+	version: "0.34.0",
+	all: true
+}, callback);
+
+const pkger = require("electron-packager");
+
+pkger({
+	dir: ".",
+	name: "myapplication",
+	platform: "win32",
+	arch: "all",
+	version: "0.34.0"
+}, callback);
+
+pkger({
+	dir: ".",
+	name: "myapplication",
+	version: "0.34.0",
+	all: true
+}, callback);

--- a/electron-packager/electron-packager.d.ts
+++ b/electron-packager/electron-packager.d.ts
@@ -1,0 +1,115 @@
+// Type definitions for electron-packager v5.1.0
+// Project: https://github.com/maxogden/electron-packager
+// Definitions by: Maxime LUCE <https://github.com/SomaticIT/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare namespace ElectronPackager {
+    /** Electron-packager Options. */
+    export interface Options {
+        /** The source directory. */
+        dir: string;
+        /** The application name. */
+        name: string;
+        /**
+         * Allowed values: linux, win32, darwin, all. Not required if `all` is used.
+         * Arbitrary combinations of individual platforms are also supported via a comma-delimited string or array of strings.
+         */
+        platform?: string | string[];
+        /** Allowed values: ia32, x64, all Not required if `all` is used. */
+        arch?: string;
+        /** Electron version (without the "v"). See https://github.com/atom/electron/releases. */
+        version: string;
+
+        /** Shortcut for `--arch=all --platform=all`. */
+        all?: boolean;
+        /** The output directory. */
+        out?: string;
+        /**
+         * Currently you must look for conversion tools in order to supply an icon in the format required by the platform:
+         * - OS X: `.icns`
+         * - Windows: `.ico`
+         *
+         * For Linux builds, this option is not required, as the dock/window list icon is set via the icon option in the BrowserWindow contructor.
+         * Setting the icon in the file manager is not currently supported.
+         *
+         * If the file extension is omitted, it is auto-completed to the correct extension based on the platform,
+         * including when `--platform=all` is in effect.
+         */
+        icon?: string;
+
+        /** The bundle identifier to use in the app plist. */
+        "app-bundle-id"?: string;
+        /** The release version to set for the app. */
+        "app-version"?: string;
+        /** The build version to set for the app (OS X only). */
+        "build-version"?: string;
+        /** The bundle identifier to use in the app helper plist. */
+        "helper-bundle-id"?: string;
+        /** Object hash of application metadata to embed into the executable (Windows only). */
+        "version-string"?: VersionString;
+
+        /** The directory of cached electron downloads. Defaults to "$HOME/.electron". */
+        cache?: string;
+        /** Do not copy files into App whose filenames regex .match this string. */
+        ignore?: RegExp;
+        /** Runs `npm prune --production` on the app. */
+        prune?: boolean;
+        /** If output directory for a platform already exists, replaces it rather than skipping it. */
+        overwrite?: boolean;
+        /** Packages the source code within your app into an archive. */
+        asar?: boolean;
+        /** Unpacks the files to app.asar.unpacked directory whose filenames regex .match this string. */
+        "asar-unpack"?: string;
+        /** Should contain the identity to be used when running `codesign` (OS X only). */
+        sign?: string;
+    }
+
+    /** Object hash of application metadata to embed into the executable (Windows only). */
+    export interface VersionString {
+        CompanyName?: string;
+        LegalCopyright?: string;
+        FileDescription?: string;
+        OriginalFilename?: string;
+        FileVersion?: string;
+        ProductVersion?: string;
+        ProductName?: string;
+        InternalName?: string;
+    }
+
+    /** Electron-packager done callback. */
+    export interface Callback {
+        /**
+         * Callback wich is called when electron-packager is done.
+         *
+         * @param err - Contains errors if any.
+         * @param appPath - Path to the newly created application.
+         */
+        (err: Error, appPath: string): void
+    }
+
+    /** Electron-packager function */
+    export interface Packager {
+        /**
+         * This will:
+         * - Find or download the correct release of Electron
+         * - Use that version of electron to create a app in <out>/<appname>-<platform>-<arch>
+         *
+         * You should be able to launch the app on the platform you built for. If not, check your settings and try again.
+         *
+         * @param opts - Options to configure packaging.
+         * @param callback - Callback which is called when packaging is done or an error occured.
+         */
+        (opts: Options, callback: Callback): void;
+    }
+}
+
+declare module "electron-packager" {
+    const packager: ElectronPackager.Packager;
+    export = packager;
+}
+
+interface NodeRequireFunction {
+    (id: "electron-packager"): ElectronPackager.Packager;
+}


### PR DESCRIPTION
Hello,

This PR adds typings for packages `'electron-packager` and `electron-builder`.
They can be used in combination to build electron packages and create installers.

Thanks.
