### PR TITLE
requirejs: remove duplicate field in RequireConfig

### DIFF
--- a/requirejs/require.d.ts
+++ b/requirejs/require.d.ts
@@ -88,10 +88,6 @@ interface RequireConfig {
 	// baseUrl.
 	paths?: { [key: string]: any; };
 
-	// Allows configuring multiple module IDs to be found in
-	// another script.
-	bundles?: { [key: string]: any; };
-
 	// Dictionary of Shim's.
 	// does not cover case of key->string[]
 	shim?: { [key: string]: RequireShim; };


### PR DESCRIPTION
The field "bundles" was added twice to RequireConfig, first in 0d39cb0 and then again in d4c83f1c8. This PR removes the latter duplicate.
