### PR TITLE
Added missing flag 'v8debug' to Global interface

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -334,6 +334,7 @@ declare module NodeJS {
         undefined: typeof undefined;
         unescape: (str: string) => string;
         gc: () => void;
+        v8debug?: any;
     }
 
     export interface Timer {


### PR DESCRIPTION
'v8debug' is an optional flag that will be set in NodeJS globals upon using the 'debug-brk' command parameter.
We're using it to dynamically detect when app is running in debug-mode.

(When not on debug-mode, the 'v8debug' flag is undefined)
