### PR TITLE
Remove quotes around chrome.debugger module for proper behaviour.

### DIFF
--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -1346,7 +1346,7 @@ declare module chrome.cookies {
  * Availability: Since Chrome 18. 
  * Permissions:  "debugger" 
  */
-declare module "chrome.debugger" {
+declare module chrome.debugger {
 	/** Debuggee identifier. Either tabId or extensionId must be specified */
     interface Debuggee {
 		/** Optional. The id of the tab which you intend to debug.  */


### PR DESCRIPTION
IntelliJ recognition wasn't working properly with the quotes. I removed them so that TypeScript expansion works properly.
