### PR TITLE
Add missed required parameter 'el: RapaelElement' to insertAfter() and insertBefore() methods

### DIFF
--- a/raphael/raphael.d.ts
+++ b/raphael/raphael.d.ts
@@ -42,8 +42,8 @@ interface RaphaelElement {
     hide(): RaphaelElement;
     hover(f_in: Function, f_out: Function, icontext?: any, ocontext?: any): RaphaelElement;
     id: string;
-    insertAfter(): RaphaelElement;
-    insertBefore(): RaphaelElement;
+    insertAfter(el: RaphaelElement): RaphaelElement;
+    insertBefore(el: RaphaelElement): RaphaelElement;
     isPointInside(x: number, y: number): boolean;
     isVisible(): boolean;
     matrix: RaphaelMatrix;

--- a/raphael/raphael.d.ts
+++ b/raphael/raphael.d.ts
@@ -129,8 +129,8 @@ interface RaphaelSet {
     hide(): RaphaelSet;
     hover(f_in: Function, f_out: Function, icontext?: any, ocontext?: any): RaphaelSet;
     id: string;
-    insertAfter(): RaphaelSet;
-    insertBefore(): RaphaelSet;
+    insertAfter(el: RaphaelElement): RaphaelSet;
+    insertBefore(el: RaphaelElement): RaphaelSet;
     isPointInside(x: number, y: number): boolean;
     isVisible(): boolean;
     matrix: RaphaelMatrix;


### PR DESCRIPTION
According the source code there are missed required parameter 'el: RaphaelElement' in methods insertAfter() and insertBefore() methods of raphael.d.ts
