### PR TITLE
Add support for Child Mappings

### DIFF
--- a/knockout.mapping/knockout.mapping-tests.ts
+++ b/knockout.mapping/knockout.mapping-tests.ts
@@ -21,7 +21,7 @@ var updateOptions = {
 var targetOptions = {};
 var inputOptions = {};
 
-var mappingOptions = {
+var mappingOptions: KnockoutMappingOptions = {
     ignore: ['age'],
     include: ['name'],
     copy: ['height'],
@@ -29,9 +29,11 @@ var mappingOptions = {
     deferEvaluation: false,
     create: function (options: KnockoutMappingCreateOptions) { },
     update: function (options: KnockoutMappingUpdateOptions) { },
-    key: function (data: any) { return data; }
+    key: function (data: any) { return data; },
+    children: {
+        create: function (options: KnockoutMappingCreateOptions) { }
+    }
 }
-
 
 // Utility functions
 mapping.isMapped(inputModel);

--- a/knockout.mapping/knockout.mapping.d.ts
+++ b/knockout.mapping/knockout.mapping.d.ts
@@ -25,6 +25,7 @@ interface KnockoutMappingOptions {
     create?: (options: KnockoutMappingCreateOptions) => void;
     update?: (options: KnockoutMappingUpdateOptions) => void;
     key?: (data: any) => any;
+    [others: string]: any;
 }
 
 interface KnockoutMapping {

--- a/knockout.mapping/knockout.mapping.d.ts
+++ b/knockout.mapping/knockout.mapping.d.ts
@@ -25,7 +25,7 @@ interface KnockoutMappingOptions {
     create?: (options: KnockoutMappingCreateOptions) => void;
     update?: (options: KnockoutMappingUpdateOptions) => void;
     key?: (data: any) => any;
-    [others: string]: any;
+    [others: string]: KnockoutMappingOptions | string[] | boolean | Function;
 }
 
 interface KnockoutMapping {


### PR DESCRIPTION
This handles the following scenario from the Knockout Mapping tutorial:

```
var mapping = {
    'children': {
        key: function(data) {
            return ko.utils.unwrapObservable(data.id);
        }
    }
}
```

With the current version, this mapping cannot be compiled under Typescript 1.6.  My change allows this to be compiled.  I've updated the test to force a type in order to demonstrate the compile error if the change is removed.

I'm aware that the indexed type is not properly typed (using any), but I'm unsure if this is possible with TS or not.
