### PR TITLE
Marked setOptions returns marked

### DIFF
--- a/marked/marked.d.ts
+++ b/marked/marked.d.ts
@@ -59,7 +59,7 @@ interface MarkedStatic {
      *
      * @param options Hash of options
      */
-    setOptions(options: MarkedOptions): void;
+    setOptions(options: MarkedOptions): MarkedStatic;
 }
 
 interface MarkedOptions {


### PR DESCRIPTION
When calling `setOptions` on marked, marked merges its original options with the new options and returns itself.
