### PR TITLE
Add an example of configuration file karma.conf.ts

### DIFF
--- a/karma/karma-tests.ts
+++ b/karma/karma-tests.ts
@@ -29,8 +29,8 @@ karma.runner.run({port: 9876}, (exitCode: number) => {
 });
 
 
-var Server = require('karma').Server;
-var server = new Server({port: 9876}, function(exitCode: number) {
+//var Server = require('karma').Server; => cannot use this syntax otherwise Server is of type any
+var server = new karma.Server({port: 9876}, function(exitCode: number) {
     console.log('Karma has exited with ' + exitCode);
     process.exit(exitCode);
 });
@@ -43,8 +43,8 @@ server.on('browser_register', function (browser: any) {
     console.log('A new browser was registered');
 });
 
-var runner = require('karma').runner;
-runner.run({port: 9876}, function(exitCode: number) {
+//var runner = require('karma').runner; => cannot use this syntax otherwise runner is of type any
+karma.runner.run({port: 9876}, function(exitCode: number) {
     console.log('Karma has exited with ' + exitCode);
     process.exit(exitCode);
 });

--- a/karma/karma-tests.ts
+++ b/karma/karma-tests.ts
@@ -30,7 +30,7 @@ karma.runner.run({port: 9876}, (exitCode: number) => {
 
 
 //var Server = require('karma').Server; => cannot use this syntax otherwise Server is of type any
-var server = new karma.Server({port: 9876}, function(exitCode: number) {
+var server = new karma.Server({logLevel: 'debug', port: 9876}, function(exitCode: number) {
     console.log('Karma has exited with ' + exitCode);
     process.exit(exitCode);
 });
@@ -57,6 +57,7 @@ var captured: boolean = karma.launcher.areAllCaptured();
 // Example of configuration file karma.conf.ts, see http://karma-runner.github.io/0.13/config/configuration-file.html
 module.exports = function(config: karma.Config) {
   config.set({
+    logLevel: config.LOG_DEBUG,
     basePath: '..',
     urlRoot: '/base/',
     frameworks: ['jasmine'],

--- a/karma/karma-tests.ts
+++ b/karma/karma-tests.ts
@@ -52,3 +52,43 @@ karma.runner.run({port: 9876}, function(exitCode: number) {
 //
 
 var captured: boolean = karma.launcher.areAllCaptured();
+
+
+// Example of configuration file karma.conf.ts, see http://karma-runner.github.io/0.13/config/configuration-file.html
+module.exports = function(config: karma.Config) {
+  config.set({
+    basePath: '..',
+    urlRoot: '/base/',
+    frameworks: ['jasmine'],
+
+    files: [
+      'file1.js',
+      'file2.js',
+      'file3.js',
+      {
+        pattern: '**/*.html',
+        included: false
+      }
+    ],
+
+    reporters: [
+      'progress',
+      'coverage'
+    ],
+
+    preprocessors: {
+      'app.js': ['coverage']
+    },
+
+    port: 9876,
+
+    autoWatch: true,
+
+    browsers: [
+      'Chrome',
+      'Firefox'
+    ],
+
+    singleRun: true
+  });
+};


### PR DESCRIPTION
Add an example of configuration file karma.conf.ts + also fix `Server` is of type any because of the syntax `Server = require('karma').Server`:

![karma-not-working](https://cloud.githubusercontent.com/assets/643434/10759238/8eeea63a-7cb6-11e5-898e-a55e9fba8529.png)

![karma-not-working2](https://cloud.githubusercontent.com/assets/643434/10759483/c51562a2-7cb7-11e5-99cc-a37b5532264c.png)

When fixed:

![karma-fixed](https://cloud.githubusercontent.com/assets/643434/10759424/80fdb3f8-7cb7-11e5-8af5-bb496ef3264c.png)
