### PR TITLE
bootstrap-datepicker: Allow 'any' for datepicker(methodName) return type

### DIFF
--- a/bootstrap.datepicker/bootstrap.datepicker.d.ts
+++ b/bootstrap.datepicker/bootstrap.datepicker.d.ts
@@ -44,8 +44,8 @@ interface DatepickerEventObject extends JQueryEventObject {
 
 interface JQuery {
     datepicker(): JQuery;
-    datepicker(methodName: string): JQuery;
-    datepicker(methodName: string, params: any): JQuery;
+    datepicker(methodName: string): any;
+    datepicker(methodName: string, params: any): any;
     datepicker(options: DatepickerOptions): JQuery;
 
     off(events: "changeDate", selector?: string, handler?: (eventObject: DatepickerEventObject) => any): JQuery;


### PR DESCRIPTION
Closes #6454
