### PR TITLE
howler and tween.js are available as CommonJS modules

### DIFF
--- a/howlerjs/howler.d.ts
+++ b/howlerjs/howler.d.ts
@@ -71,3 +71,10 @@ declare class Howl {
     unload(): void;
 }
 
+
+declare module 'howler' {
+    export={
+        Howler : Howler,
+        Howl : Howl
+    };
+}

--- a/tween.js/tween.js.d.ts
+++ b/tween.js/tween.js.d.ts
@@ -98,3 +98,7 @@ interface TweenInterpolation {
     Factorial(n): number;
   };
 }
+
+declare module 'tween.js' {
+  export = TWEEN;
+}


### PR DESCRIPTION
I'm switching from bower to browserify, and as such from globals to require'd modules, so I'm finding a few definitions that lack the CommonJS module definitions.
