### PR TITLE
IconOptions to accept arrays and point objects

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -1088,7 +1088,7 @@ declare namespace L {
         /**
           * Size of the icon image in pixels.
           */
-        iconSize?: Point|number[];
+        iconSize?: Point|[number, number];
 
         /**
           * The coordinates of the "tip" of the icon (relative to its top left corner).
@@ -1096,7 +1096,7 @@ declare namespace L {
           * location. Centered by default if size is specified, also can be set in CSS
           * with negative margins.
           */
-        iconAnchor?: Point|number[];
+        iconAnchor?: Point|[number, number];
 
         /**
           * The URL to the icon shadow image. If not specified, no shadow image will be
@@ -1113,19 +1113,19 @@ declare namespace L {
         /**
           * Size of the shadow image in pixels.
           */
-        shadowSize?: Point|number[];
+        shadowSize?: Point|[number, number];
 
         /**
           * The coordinates of the "tip" of the shadow (relative to its top left corner)
           * (the same as iconAnchor if not specified).
           */
-        shadowAnchor?: Point|number[];
+        shadowAnchor?: Point|[number, number];
 
         /**
           * The coordinates of the point from which popups will "open", relative to the
           * icon anchor.
           */
-        popupAnchor?: Point|number[];
+        popupAnchor?: Point|[number, number];
 
         /**
           * A custom class name to assign to both icon and shadow images. Empty by default.

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -1088,7 +1088,7 @@ declare namespace L {
         /**
           * Size of the icon image in pixels.
           */
-        iconSize?: Point;
+        iconSize?: Point|number[];
 
         /**
           * The coordinates of the "tip" of the icon (relative to its top left corner).
@@ -1096,7 +1096,7 @@ declare namespace L {
           * location. Centered by default if size is specified, also can be set in CSS
           * with negative margins.
           */
-        iconAnchor?: Point;
+        iconAnchor?: Point|number[];
 
         /**
           * The URL to the icon shadow image. If not specified, no shadow image will be
@@ -1113,19 +1113,19 @@ declare namespace L {
         /**
           * Size of the shadow image in pixels.
           */
-        shadowSize?: Point;
+        shadowSize?: Point|number[];
 
         /**
           * The coordinates of the "tip" of the shadow (relative to its top left corner)
           * (the same as iconAnchor if not specified).
           */
-        shadowAnchor?: Point;
+        shadowAnchor?: Point|number[];
 
         /**
           * The coordinates of the point from which popups will "open", relative to the
           * icon anchor.
           */
-        popupAnchor?: Point;
+        popupAnchor?: Point|number[];
 
         /**
           * A custom class name to assign to both icon and shadow images. Empty by default.


### PR DESCRIPTION
All Leaflet methods and options that accept Point objects also accept them in a simple Array form (unless noted otherwise), so these lines are equivalent:

http://leafletjs.com/reference.html#point
