### PR TITLE
Allow AMD/CommonJS loading of Cordova and Ionic Framework (shim)

### DIFF
--- a/cordova/cordova.d.ts
+++ b/cordova/cordova.d.ts
@@ -94,3 +94,7 @@ interface UrlUtil {
 
 /** Apache Cordova instance */
 declare var cordova: Cordova;
+
+declare module 'cordova' {
+    export = cordova;
+}

--- a/ionic/ionic.d.ts
+++ b/ionic/ionic.d.ts
@@ -5,6 +5,16 @@
 
 /// <reference path="../angularjs/angular.d.ts" />
 
+interface IonicStatic {
+    version: string;
+}
+
+declare var ionic: IonicStatic;
+
+declare module 'ionic' {
+    export = ionic;
+}
+
 declare module ionic {
     module actionSheet {
         interface IonicActionSheetService {


### PR DESCRIPTION
Example:

```
import ionic = require("ionic")
```
