### PR TITLE
fix(ng-file-upload): allow File[] in upload config

### DIFF
--- a/ng-file-upload/ng-file-upload-tests.ts
+++ b/ng-file-upload/ng-file-upload-tests.ts
@@ -40,7 +40,7 @@ module controllers {
 		        .error((data: any, status: number, response: any, headers: any) => {
 			        console.error(data, status, response, headers);
 		        })
-				.success((data: any, status: number, headers: any, config: angular.angularFileUpload.IFileUploadConfig) => {
+				.success((data: any, status: number, headers: any, config: angular.angularFileUpload.IFileUploadConfigFile) => {
 			        // file is uploaded successfully
 					console.log("Success!", data, status, headers, config);
 		        });

--- a/ng-file-upload/ng-file-upload.d.ts
+++ b/ng-file-upload/ng-file-upload.d.ts
@@ -10,7 +10,7 @@ declare module angular.angularFileUpload  {
     interface IUploadService {
 
         http<T>(config: IRequestConfig): IUploadPromise<T>;
-        upload<T>(config: IFileUploadConfig): IUploadPromise<T>;
+        upload<T>(config: IFileUploadConfigFiles|IFileUploadConfigFile): IUploadPromise<T>;
     }
 
     interface IUploadPromise<T> extends IHttpPromise<T> {
@@ -19,14 +19,25 @@ declare module angular.angularFileUpload  {
         xhr(callback: IHttpPromiseCallback<T>): IUploadPromise<T>;
     }
 
-    interface IFileUploadConfig extends IRequestConfig {
+    interface IFileUploadConfigFile extends IRequestConfig {
 
         file: File;
         fileName?: string;
     }
 
+    interface IFileUploadConfigFiles extends IRequestConfig {
+
+        file: File[];
+        fileName?: string;
+    }
+
+    interface IFilesProgressEvent extends ProgressEvent {
+
+        config: IFileUploadConfigFiles;
+    }
+
     interface IFileProgressEvent extends ProgressEvent {
 
-        config: IFileUploadConfig;
+        config: IFileUploadConfigFile;
     }
-} 
+}


### PR DESCRIPTION
File[] is allowed to be used in IFileUploadConfig.
