### PR TITLE
lodash: signatures of the method _.escape changed

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -3800,8 +3800,20 @@ module TestEndsWith {
 }
 
 // _.escape
-result = <string>_.escape('fred, barney, & pebbles');
-result = <string>_('fred, barney, & pebbles').escape();
+module TestEscape {
+    {
+        let result: string;
+
+        result = _.escape('fred, barney, & pebbles');
+        result = _('fred, barney, & pebbles').escape();
+    }
+
+    {
+        let result: _.LoDashExplicitWrapper<string>;
+
+        result = _('fred, barney, & pebbles').chain().escape();
+    }
+}
 
 // _.escapeRegExp
 module TestEscapeRegExp {

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -9234,6 +9234,18 @@ declare module _ {
     interface LoDashStatic {
         /**
          * Converts the characters "&", "<", ">", '"', "'", and "`", in string to their corresponding HTML entities.
+         *
+         * Note: No other characters are escaped. To escape additional characters use a third-party library like he.
+         *
+         * Though the ">" character is escaped for symmetry, characters like ">" and "/" don’t need escaping in HTML
+         * and have no special meaning unless they're part of a tag or unquoted attribute value. See Mathias Bynens’s
+         * article (under "semi-related fun fact") for more details.
+         *
+         * Backticks are escaped because in Internet Explorer < 9, they can break out of attribute values or HTML
+         * comments. See #59, #102, #108, and #133 of the HTML5 Security Cheatsheet for more details.
+         *
+         * When working with HTML you should always quote attribute values to reduce XSS vectors.
+         *
          * @param string The string to escape.
          * @return Returns the escaped string.
          */
@@ -9245,6 +9257,13 @@ declare module _ {
          * @see _.escape
          */
         escape(): string;
+    }
+
+    interface LoDashExplicitWrapper<T> {
+        /**
+         * @see _.escape
+         */
+        escape(): LoDashExplicitWrapper<string>;
     }
 
     // _.escapeRegExp


### PR DESCRIPTION
https://lodash.com/docs#escape
https://lodash.com/docs#_ (description of the chainable wrapper)
