### PR TITLE
Correction to express-handlebars

### DIFF
--- a/express-handlebars/express-handlebars.d.ts
+++ b/express-handlebars/express-handlebars.d.ts
@@ -37,7 +37,7 @@ interface Exphbs {
     getTemplate(filePath: string, options?: PartialTemplateOptions): Promise<Function>;
     getTemplates(dirPath: string, options?: PartialTemplateOptions): Promise<Object>;
     render(filePath: string, context: Object, options?: RenderOptions): Promise<string>;
-    renderView(viewPath: string, optionsOrCallback?: any, callback?: () => string): void;
+    renderView(viewPath: string, optionsOrCallback: any, callback: () => string): void;
 }
 
 declare module "express-handlebars" {

--- a/express-handlebars/express-handlebars.d.ts
+++ b/express-handlebars/express-handlebars.d.ts
@@ -37,7 +37,7 @@ interface Exphbs {
     getTemplate(filePath: string, options?: PartialTemplateOptions): Promise<Function>;
     getTemplates(dirPath: string, options?: PartialTemplateOptions): Promise<Object>;
     render(filePath: string, context: Object, options?: RenderOptions): Promise<string>;
-    renderView(viewPath: string, optionsOrCallback: any, callback: () => string): void;
+    renderView(viewPath: string, optionsOrCallback: any, callback?: () => string): void;
 }
 
 declare module "express-handlebars" {


### PR DESCRIPTION
Correction: renderView takes optionsOrCallback as a mandatory argument (removed ?).
See: https://github.com/ericf/express-handlebars#renderviewviewpath-optionscallback-callback
