### PR TITLE
make ionicLoading options optional

### DIFF
--- a/ionic/ionic.d.ts
+++ b/ionic/ionic.d.ts
@@ -56,7 +56,7 @@ declare module ionic {
     }
     module loading {
         interface IonicLoadingService {
-            show(opts: IonicLoadingOptions): void;
+            show(opts?: IonicLoadingOptions): void;
             hide(): void;
         }
         interface IonicLoadingOptions {


### PR DESCRIPTION
Ionic does't require any loading option to be passed, so making `opts` mandatory is wrong.
If you don't pass any options, the typescript compiler will throw an error. 

This makes opts optional 
