### PR TITLE
Allow 'chance' to be callable, and also self-referential as a module

### DIFF
--- a/chance/chance-tests.ts
+++ b/chance/chance-tests.ts
@@ -34,3 +34,6 @@ chance.mixin({
 });
 
 var timeString: string = chance.time();
+
+var chanceConstructedWithSeed100 = new Chance(100);
+var chanceCalledWithSeed100 = Chance()

--- a/chance/chance.d.ts
+++ b/chance/chance.d.ts
@@ -5,7 +5,10 @@
 declare module Chance {
 
     interface ChanceStatic {
-        Chance(): Chance;
+        (): Chance
+        (seed: number): Chance
+        (generator: () => any): Chance
+
         new(): Chance;
         new(seed: number): Chance;
         new(generator: () => any): Chance;
@@ -209,5 +212,10 @@ declare var Chance: Chance.ChanceStatic;
 
 // import Chance = require('chance');
 declare module 'chance' {
+    interface ExportedChance extends Chance.ChanceStatic {
+        Chance: ExportedChance;
+    }
+    var Chance: ExportedChance;
+
     export = Chance;
 }


### PR DESCRIPTION
Previously, when using ES6-style syntax as so:

``` TypeScript
import { Chance } from "chance";
```

one could only _call_ `Chance`:

``` TypeScript
var chance = Chance();
```

This change allows users to also construct `Chance` as the actual runtime permits:

```
var chance = new Chance():
```

It also accounts for the fact that Chance behaves the same whether constructed or called.
