### PR TITLE
github-electron: Add makeSingleInstance() API to 'app' module

### DIFF
--- a/github-electron/github-electron-main-tests.ts
+++ b/github-electron/github-electron-main-tests.ts
@@ -35,6 +35,21 @@ app.on('window-all-closed', () => {
 		app.quit();
 });
 
+// Check single instance app
+var shouldQuit = app.makeSingleInstance(function(commandLine, workingDirectory) {
+  // Someone tried to run a second instance, we should focus our window
+  if (mainWindow) {
+    if (mainWindow.isMinimized()) mainWindow.restore();
+    mainWindow.focus();
+  }
+  return true;
+});
+
+if (shouldQuit) {
+  app.quit();
+  process.exit(0);
+}
+
 // This method will be called when Electron has done everything
 // initialization and ready for creating browser windows.
 app.on('ready', () => {

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -986,6 +986,12 @@ declare module GitHubElectron {
 		setUserTasks(tasks: Task[]): void;
 		dock: BrowserWindow;
 		commandLine: CommandLine;
+		/**
+		 * This method makes your application a Single Instance Application instead of allowing
+		 * multiple instances of your app to run, this will ensure that only a single instance
+		 * of your app is running, and other instances signal this instance and exit.
+		 */
+		makeSingleInstance(callback: (args: string[], workingDirectory: string) => boolean): boolean;
 	}
 
 	interface CommandLine {


### PR DESCRIPTION
Electron 0.34.1 introduced a new API `makeSingleInstance()`.
I added it to `github-electron.d.ts`.

Documentation for it is below:
https://github.com/atom/electron/blob/master/docs/api/app.md#appmakesingleinstancecallback
