### PR TITLE
React.js - add onLoad event to DOMAttributesBase

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -313,6 +313,8 @@ declare namespace __React {
         deltaZ: number;
     }
 
+    interface LoadEvent extends SyntheticEvent {}
+
     //
     // Event Handler Types
     // ----------------------------------------------------------------------
@@ -330,6 +332,7 @@ declare namespace __React {
     interface TouchEventHandler extends EventHandler<TouchEvent> {}
     interface UIEventHandler extends EventHandler<UIEvent> {}
     interface WheelEventHandler extends EventHandler<WheelEvent> {}
+    interface LoadEventHandler extends EventHandler<LoadEvent> {}
 
     //
     // Props / DOM Attributes
@@ -377,6 +380,7 @@ declare namespace __React {
         onTouchStart?: TouchEventHandler;
         onScroll?: UIEventHandler;
         onWheel?: WheelEventHandler;
+        onLoad?: LoadEventHandler;
 
         className?: string;
         id?: string;


### PR DESCRIPTION
I recognized a missing event while rewriting a large application to typescript. 

According to the documentation (https://facebook.github.io/react/tips/dom-event-listeners.html) e.g. the `img` tag has an `onLoad` event, which is not part of the DOMAttributesBase interface.

I tried to compile a render function which create an `img` element and with the current definitions it fails.
