### PR TITLE
github-electron: Added 'title-bar-style' option to BrowserWindowOptions

### DIFF
--- a/github-electron/github-electron-main-tests.ts
+++ b/github-electron/github-electron-main-tests.ts
@@ -145,7 +145,11 @@ ipc.on('online-status-changed', (event: any, status: any) => {
 // https://github.com/atom/electron/blob/master/docs/api/synopsis.md
 
 app.on('ready', () => {
-	window = new BrowserWindow({ width: 800, height: 600 });
+	window = new BrowserWindow({
+		width: 800,
+		height: 600, 
+		'title-bar-style': 'hidden-inset',
+	});
 	window.loadUrl('https://github.com');
 });
 

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -515,6 +515,7 @@ declare module GitHubElectron {
 		'shared-worker'?: boolean;
 		'direct-write'?: boolean;
 		'page-visibility'?: boolean;
+		'title-bar-style'?: string;
 	}
 
 	interface Rectangle {


### PR DESCRIPTION
The documentation is below:

https://github.com/atom/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions
