### PR TITLE
added missing declaration for optional dynamicHash property 

### DIFF
--- a/durandal/durandal.d.ts
+++ b/durandal/durandal.d.ts
@@ -1541,6 +1541,7 @@ interface DurandalRelativeRouteSettings {
     moduleId?: string;
     route?: string;
     fromParent?: boolean;
+	dynamicHash?: string;
 }
 
 interface DurandalRouterBase<T> extends DurandalEventSupport<T> {


### PR DESCRIPTION
added missing declaration for optional dynamicHash property on DurandallRelativeRouteSettings to support TypeScript 1.6 tightened compilation rules
