### PR TITLE
parse: Remove reference for node, jquery and underscore

### DIFF
--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -3,10 +3,6 @@
 // Definitions by: Ullisen Media Group <http://ullisenmedia.com>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-/// <reference path="../node/node.d.ts" />
-/// <reference path="../jquery/jquery.d.ts" />
-/// <reference path="../underscore/underscore.d.ts" />
-
 declare namespace Parse {
 
     var applicationId: string;


### PR DESCRIPTION
There is no need at all to include those references here. All it does is global namespace pollution. If I'm using node, why would I want jQuery? And it I'm in a browser, why get everything from node?

Specially since I'm in a browser and I don't use neither jQuery nor Underscore.

They are referenced nowhere on the declaration code.
