### PR TITLE
Add delegate and undelegate methods to View

### DIFF
--- a/backbone/backbone-global.d.ts
+++ b/backbone/backbone-global.d.ts
@@ -367,7 +367,9 @@ declare module Backbone {
         remove(): View<TModel>;
         make(tagName: any, attributes?: any, content?: any): any;
         delegateEvents(events?: EventsHash): any;
+        delegate(eventName: string, selector: string, listener: Function): View<TModel>;
         undelegateEvents(): any;
+        undelegate(eventName: string, selector?: string, listener?: Function): View<TModel>;
 
         _ensureElement(): void;
     }


### PR DESCRIPTION
Backbone allows delegating and undelegating single events on view classes as stated in the [annotated source](http://backbonejs.org/docs/backbone.html#section-163). This pull requests add the two methods to the View class.
