### PR TITLE
Allow nodeFn.apply to accept an IArguments in addition to arrays

### DIFF
--- a/when/when-tests.ts
+++ b/when/when-tests.ts
@@ -380,6 +380,10 @@ example = function () {
 
 promise = nodefn.apply(nodeFn2, [1, '2']);
 
+example = function() {
+	nodefn.apply(fs.read, arguments);
+}
+
 example = function () {
 	var loadPasswd = nodefn.apply(fs.readFile, ['/etc/passwd']);
 

--- a/when/when.d.ts
+++ b/when/when.d.ts
@@ -316,12 +316,12 @@ declare module "when/node" {
     ): when.Promise<T>;
 
 
-    function apply<T>(fn: _.NodeFn0<T>, args: any[]): when.Promise<T>;
-    function apply<T>(fn: _.NodeFn1<any, T>, args: any[]): when.Promise<T>;
-    function apply<T>(fn: _.NodeFn2<any, any, T>, args: any[]): when.Promise<T>;
-    function apply<T>(fn: _.NodeFn3<any, any, any, T>, args: any[]): when.Promise<T>;
-    function apply<T>(fn: _.NodeFn4<any, any, any, any, T>, args: any[]): when.Promise<T>;
-    function apply<T>(fn: _.NodeFn5<any, any, any, any, any, T>, args: any[]): when.Promise<T>;
+    function apply<T>(fn: _.NodeFn0<T>, args: any[] | IArguments): when.Promise<T>;
+    function apply<T>(fn: _.NodeFn1<any, T>, args: any[] | IArguments): when.Promise<T>;
+    function apply<T>(fn: _.NodeFn2<any, any, T>, args: any[] | IArguments): when.Promise<T>;
+    function apply<T>(fn: _.NodeFn3<any, any, any, T>, args: any[] | IArguments): when.Promise<T>;
+    function apply<T>(fn: _.NodeFn4<any, any, any, any, T>, args: any[] | IArguments): when.Promise<T>;
+    function apply<T>(fn: _.NodeFn5<any, any, any, any, any, T>, args: any[] | IArguments): when.Promise<T>;
 
 
     function liftAll(srcApi: any, transform?: (destApi: any, liftedFunc: Function, name: string) => any, destApi?: any): any;


### PR DESCRIPTION
Allows the `apply` function to take in an `IArguments`. Seems to work fine from my testing - but probably worth having a second set of eyes checking that it makes sense.
