### PR TITLE
possible type spelling mistake

### DIFF
--- a/dexie/dexie.d.ts
+++ b/dexie/dexie.d.ts
@@ -38,7 +38,7 @@ declare class Dexie {
 
     static deepClone(obj: Object): Object;
 
-    version(versionNumber: Number): Dexie.Version
+    version(versionNumber: number): Dexie.Version
 
     on: {
         (eventName: string, subscriber: () => any): void;


### PR DESCRIPTION
There is no type called "Number" defined. It should be of type "number" instead
