### PR TITLE
Node: Fix punycode.ucs2.decode return type

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -758,7 +758,7 @@ declare module "punycode" {
     export function toASCII(domain: string): string;
     export var ucs2: ucs2;
     interface ucs2 {
-        decode(string: string): string;
+        decode(string: string): number[];
         encode(codePoints: number[]): string;
     }
     export var version: any;


### PR DESCRIPTION
API Reference: https://nodejs.org/api/punycode.html#punycode_punycode_ucs2_decode_string
