### PR TITLE
Added another alias module

### DIFF
--- a/urijs/URIjs.d.ts
+++ b/urijs/URIjs.d.ts
@@ -230,3 +230,7 @@ declare var URI: uri.URIStatic;
 declare module 'URI' {
     export = URI;
 }
+
+declare module 'urijs' {
+    export = URI;
+}


### PR DESCRIPTION
I found I had to add this to get Typescript and webpack to both be happy with this.  The other names are ok for the Typescript compiler, but when you go to load underlying code, webpack gets confused because the name doesn't match the `npm` name.
