### PR TITLE
Corrected the definition for *SaveRequest

### DIFF
--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -845,11 +845,36 @@ declare namespace Parse {
             value?: string;
         }
 
-        interface AfterSaveRequest extends FunctionRequest {}
-        interface AfterDeleteRequest extends FunctionRequest {}
-        interface BeforeDeleteRequest extends FunctionRequest {}
+        interface AfterSaveRequest {
+            installationId?: String;
+            master?: boolean;
+            object?: Object;
+            user?: User;
+        }
+
+        interface AfterDeleteRequest {
+            installationId?: String;
+            master?: boolean;
+            object?: Object;
+            user?: User;
+        }
+
+        interface BeforeDeleteRequest {
+            installationId?: String;
+            master?: boolean;
+            object?: Object;
+            user?: User;
+        }
+
         interface BeforeDeleteResponse extends FunctionResponse {}
-        interface BeforeSaveRequest extends FunctionRequest {}
+
+        interface BeforeSaveRequest {
+            installationId?: String;
+            master?: boolean;
+            object?: Object;
+            user?: User;
+        }
+
         interface BeforeSaveResponse extends FunctionResponse {}
 
         function afterDelete(arg1: any, func?: (request: AfterDeleteRequest) => void): void;


### PR DESCRIPTION
AfterSaveRequest and other *SaveRequests do not extend FunctionRequest and have object property which is different from params. 
