### PR TITLE
Fixed wrong auth event name, introduced enums for events

### DIFF
--- a/voximplant-websdk/voximplant-websdk-tests.ts
+++ b/voximplant-websdk/voximplant-websdk-tests.ts
@@ -7,37 +7,37 @@ vox.init({
 	micRequired: true 
 });
 
-vox.addEventListener("SDKReady", function(event: VoxImplant.Events.SDKReady) {
+vox.addEventListener(VoxImplant.Events.SDKReady, function(event: VoxImplant.Events.SDKReady) {
 	console.log("VoxImplant SDK ver. " + event.version + " initialized");
 	vox.connect();
 });
 
-vox.addEventListener("ConnectionEstablished", function(event: VoxImplant.Events.ConnectionEstablished) {
+vox.addEventListener(VoxImplant.Events.ConnectionEstablished, function(event: VoxImplant.Events.ConnectionEstablished) {
 	console.log("Connection established");
 	vox.login("username", "password");
 });
 
-vox.addEventListener("ConnectionClosed", function(event: VoxImplant.Events.ConnectionClosed) {
+vox.addEventListener(VoxImplant.Events.ConnectionClosed, function(event: VoxImplant.Events.ConnectionClosed) {
 	console.log("Connection closed");
 });
 
-vox.addEventListener("ConnectionFailed", function(event: VoxImplant.Events.ConnectionFailed) {
+vox.addEventListener(VoxImplant.Events.ConnectionFailed, function(event: VoxImplant.Events.ConnectionFailed) {
 	console.log("Connection failed. Reason: " + event.message);
 });
 
-vox.addEventListener("AuthEvent", function(event: VoxImplant.Events.AuthEvent) {
+vox.addEventListener(VoxImplant.Events.AuthResult, function(event: VoxImplant.Events.AuthResult) {
 	if (event.result === true) {
 		// Authorized successfully
 		console.log("Logged in as " + event.displayName);
 
 		call = vox.call("some_number", false);
-		call.addEventListener("Connected", function(callevent: VoxImplant.CallEvents.Connected) {
+		call.addEventListener(VoxImplant.CallEvents.Connected, function(callevent: VoxImplant.CallEvents.Connected) {
 			console.log("Call connected");
 		});
-		call.addEventListener("Failed", function(callevent: VoxImplant.CallEvents.Failed) {
+		call.addEventListener(VoxImplant.CallEvents.Failed, function(callevent: VoxImplant.CallEvents.Failed) {
 			console.log("Call failed, reason: " + callevent.reason);
 		});
-		call.addEventListener("Disconnected", function(callevent: VoxImplant.CallEvents.Disconnected) {
+		call.addEventListener(VoxImplant.CallEvents.Disconnected, function(callevent: VoxImplant.CallEvents.Disconnected) {
 			console.log("Call disconnected");
 		});
 
@@ -48,13 +48,13 @@ vox.addEventListener("AuthEvent", function(event: VoxImplant.Events.AuthEvent) {
 	}
 });
 
-vox.addEventListener("MicAccessResult", function(event: VoxImplant.Events.MicAccessResult) {
+vox.addEventListener(VoxImplant.Events.MicAccessResult, function(event: VoxImplant.Events.MicAccessResult) {
 	console.log("Microphone access allowed: " + event.result);
 });
 
-vox.addEventListener("IncomingCall", function(event: VoxImplant.Events.IncomingCall) {
+vox.addEventListener(VoxImplant.Events.IncomingCall, function(event: VoxImplant.Events.IncomingCall) {
 	call = event.call;
-	call.addEventListener("Connected", function(callevent: VoxImplant.CallEvents.Connected) {
+	call.addEventListener(VoxImplant.CallEvents.Connected, function(callevent: VoxImplant.CallEvents.Connected) {
 		console.log("Inbound Call Connected");
 		setTimeout(function() {
 			vox.disconnect();
@@ -63,11 +63,11 @@ vox.addEventListener("IncomingCall", function(event: VoxImplant.Events.IncomingC
 	call.answer();
 });
 
-vox.addEventListener("MessageReceived", function(event: VoxImplant.IMEvents.MessageReceived) {
+vox.addEventListener(VoxImplant.IMEvents.MessageReceived, function(event: VoxImplant.IMEvents.MessageReceived) {
 	console.log("Message received: " + event.content + " from " + event.id + " id " + event.message_id);
 });
 
-vox.addEventListener("SourcesInfoUpdated", function(event: VoxImplant.Events.SourcesInfoUpdated) {
+vox.addEventListener(VoxImplant.Events.SourcesInfoUpdated, function(event: VoxImplant.Events.SourcesInfoUpdated) {
 	var audioSources: VoxImplant.AudioSourceInfo[] = vox.audioSources(),
 		videoSources: VoxImplant.VideoSourceInfo[] = vox.videoSources();
 	console.log("Received recording sources data:");
@@ -78,7 +78,7 @@ vox.addEventListener("SourcesInfoUpdated", function(event: VoxImplant.Events.Sou
 	vox.useVideoSource(videoSources[0].id, function() { console.log('OK'); }, function() { console.log('Failed'); });
 });
 
-vox.addEventListener("RosterReceived", function(event: VoxImplant.IMEvents.RosterReceived) {
+vox.addEventListener(VoxImplant.IMEvents.RosterReceived, function(event: VoxImplant.IMEvents.RosterReceived) {
 	var roster: VoxImplant.RosterItem[] = event.roster;
 	console.log("Roster received: " + roster);
 });

--- a/voximplant-websdk/voximplant-websdk.d.ts
+++ b/voximplant-websdk/voximplant-websdk.d.ts
@@ -3,14 +3,60 @@
 // Definitions by: Alexey Aylarov <https://github.com/aylarov/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare namespace VoxImplant {	
+declare module VoxImplant {	
+
+	/**
+	*	VoxImplant.Client general events
+	*/
+	enum Events {
+		AuthResult,
+		ConnectionClosed,
+		ConnectionEstablished,
+		ConnectionFailed,
+		IMError,
+		IncomingCall,
+		MicAccessResult,
+		NetStatsReceived,
+		PlaybackFinished,
+		SDKReady,
+		SourcesInfoUpdated
+	}
+
+	/**
+	*	VoxImplant.Client Instant Messaging and Presence events
+	*/
+	enum IMEvents {
+		ChatStateUpdate,
+		MessageReceived,
+		MessageStatus,
+		PresenceUpdate,
+		RosterItemChange,
+		RosterPresenceUpdate,
+		RosterReceived,
+		SubscriptionRequest
+	}
+
+	/**
+	*	VoxImplant.Call events
+	*/
+	enum CallEvents {
+		Connected,
+		Disconnected,
+		Failed,
+		InfoReceived,
+		MessageReceived,
+		ProgressToneStart,
+		ProgressToneStop,
+		TransferComplete,
+		TransferFailed
+	}
 
 	module Events {
 
 		/**
 		*	Event dispatched after login , loginWithOneTimeKey, requestOneTimeLoginKey or loginWithCode function call
 		*/
-		interface AuthEvent {
+		interface AuthResult {
 			/**
 			*	Auth error code, possible values are: 301 - code for 'code' auth type was sent, 302 - key for 'onetimekey' auth type received, 401 - invalid password, 404 - invalid username, 403 - user account is frozen, 500 - internal error
 			*/
@@ -20,7 +66,7 @@ declare namespace VoxImplant {
 			*/
 			displayName?: string;
 			/**
-			*	This parameter is used to calculate hash parameter for loginWithOneTimeKey method. AuthEvent with the key dispatched after requestOneTimeLoginKey method was called
+			*	This parameter is used to calculate hash parameter for loginWithOneTimeKey method. AuthResult with the key dispatched after requestOneTimeLoginKey method was called
 			*/
 			key?: string;
 			/**
@@ -420,7 +466,7 @@ declare namespace VoxImplant {
 
 	}
 
-	type VoxImplantEvent = Events.AuthEvent | Events.ConnectionClosed | Events.ConnectionEstablished |
+	type VoxImplantEvent = Events.AuthResult | Events.ConnectionClosed | Events.ConnectionEstablished |
 		Events.ConnectionFailed | Events.IMError | Events.IncomingCall | Events.MicAccessResult | 
 		Events.NetStatsReceived | Events.PlaybackFinished | Events.SDKReady | Events.SourcesInfoUpdated;
 
@@ -666,7 +712,7 @@ declare namespace VoxImplant {
 		*	@param eventName Event name
 		*	@param eventHandler Handler function. A single parameter is passed - object with the event information
 		*/
-		addEventListener(eventName: string, eventHandler: (eventObject: VoxImplantEvent | VoxImplantIMEvent) => any): void;
+		addEventListener(eventName: VoxImplant.Events | VoxImplant.IMEvents, eventHandler: (eventObject: VoxImplantEvent | VoxImplantIMEvent) => any): void;
 		/**
 		*	Add roster item (IM)
 		*
@@ -727,7 +773,7 @@ declare namespace VoxImplant {
 		*
 		*	@param config Client configuration options
 		*/
-		init(config?: Config): void;
+		init(config: Config): void;
 		/**
 		*	Check if WebRTC support is available
 		*/
@@ -777,7 +823,7 @@ declare namespace VoxImplant {
 		*	@param eventName Event name
 		*	@param eventHandler Handler function
 		*/
-		removeEventListener(eventName: string, eventHandler: () => any): void;
+		removeEventListener(eventName: VoxImplant.Events | VoxImplant.IMEvents, eventHandler: () => any): void;
 		/**
 		*	Remove roster item (IM)
 		*
@@ -942,7 +988,7 @@ declare namespace VoxImplant {
 		*	@param eventName Event name
 		*	@param eventHandler Handler function. A single parameter is passed - object with the event information
 		*/
-		addEventListener(eventName: string, eventHandler: (eventObject: VoxImplantCallEvent) => any): void;	
+		addEventListener(eventName: VoxImplant.CallEvents, eventHandler: (eventObject: VoxImplantCallEvent) => any): void;	
 		/**
 		*	Answer on incoming call
 		*
@@ -1002,7 +1048,7 @@ declare namespace VoxImplant {
 		*	@param eventName Event name
 		*	@param eventHandler Handler function
 		*/
-		removeEventListener(eventName: string, eventHandler: () => any): void;
+		removeEventListener(eventName: VoxImplant.CallEvents, eventHandler: () => any): void;
 		/**
 		*	Send Info (SIP INFO) message inside the call
 		*
@@ -1162,8 +1208,4 @@ declare namespace VoxImplant {
 	*/
 	function version(): String;
 	
-}
-
-declare module "voximplant-websdk" {
-    export = VoxImplant;
 }


### PR DESCRIPTION
Now all event names are available via enums (VoxImplant.Events,
VoxImplant.IMEvents, VoxImplant.CallEvents). Fixed error in auth event
name: AuthEvent -> AuthResult
