### PR TITLE
fix snapsvg Matrix() and matrix() typings

### DIFF
--- a/snapsvg/snapsvg.d.ts
+++ b/snapsvg/snapsvg.d.ts
@@ -57,7 +57,7 @@ declare module Snap {
 	export var filter:Filter;
 	export var path:Path;
 
-        export function Matrix():void;
+	export function Matrix():void;
 	export function matrix(a:number,b:number,c:number,d:number,e:number,f:number):Matrix;
 	export function matrix(svgMatrix:SVGMatrix):Matrix;
 

--- a/snapsvg/snapsvg.d.ts
+++ b/snapsvg/snapsvg.d.ts
@@ -15,7 +15,7 @@ declare module mina {
     }
 
     export interface AnimationDescriptor {
-		id: string;
+        id: string;
         start: number;
         end: number;
         b: number;
@@ -35,7 +35,7 @@ declare module mina {
         pause(): void;
         resume(): void;
         update(): void;
-	}
+    }
 
 	export function backin(n:number):number;
 	export function backout(n:number):number;
@@ -57,8 +57,9 @@ declare module Snap {
 	export var filter:Filter;
 	export var path:Path;
 
-	export function Matrix(a:number,b:number,c:number,d:number,e:number,f:number):Matrix;
-	export function Matrix(svgMatrix:SVGMatrix):Matrix;
+        export function Matrix():void;
+	export function matrix(a:number,b:number,c:number,d:number,e:number,f:number):Matrix;
+	export function matrix(svgMatrix:SVGMatrix):Matrix;
 
 	export function ajax(url:string,postData:string,callback:Function,scope?:Object):XMLHttpRequest;
 	export function ajax(url:string,postData:Object,callback:Function,scope?:Object):XMLHttpRequest;


### PR DESCRIPTION
There seemed to be some confusion between the functions "Matrix()" (argument-less constructor function) and "matrix()" (utility function that takes arguments and returns a Matrix object).

Previously, the definition had "Matrix()" as the utility function and omitted the constructor function, which would result in TS errors on something as simple as "var m1 = new Matrix()".

See http://snapsvg.io/docs/#Snap.Matrix
