### PR TITLE
Added "tween.js" module declaration

### DIFF
--- a/tween.js/tween.js.d.ts
+++ b/tween.js/tween.js.d.ts
@@ -98,3 +98,7 @@ interface TweenInterpolation {
     Factorial(n): number;
   };
 }
+
+declare module "tween.js" {
+  export = TWEEN;
+}


### PR DESCRIPTION
Enables support for `import TWEEN = require("tween.js")` syntax required by browserify/tsify.
