### PR TITLE
three: Update as much as possible to r73

### DIFF
--- a/threejs/tests/canvas/canvas_camera_orthographic.ts
+++ b/threejs/tests/canvas/canvas_camera_orthographic.ts
@@ -54,7 +54,7 @@
         // Cubes
 
         var geometry2 = new THREE.BoxGeometry(50, 50, 50);
-        var material2 = new THREE.MeshLambertMaterial({ color: 0xffffff, shading: THREE.FlatShading, overdraw: 0.5 });
+        var material2 = new THREE.MeshLambertMaterial({ color: 0xffffff, overdraw: 0.5 });
 
         for (var i = 0; i < 100; i++) {
 

--- a/threejs/tests/canvas/canvas_lights_pointlights.ts
+++ b/threejs/tests/canvas/canvas_lights_pointlights.ts
@@ -54,7 +54,7 @@
         loader = new THREE.JSONLoader();
         loader.load('obj/WaltHeadLo.js', function (geometry) {
 
-            mesh = new THREE.Mesh(geometry, new THREE.MeshLambertMaterial({ color: 0xffffff, shading: THREE.FlatShading, overdraw: 0.5 }));
+            mesh = new THREE.Mesh(geometry, new THREE.MeshLambertMaterial({ color: 0xffffff, overdraw: 0.5 }));
             scene.add(mesh);
 
         });

--- a/threejs/tests/canvas/canvas_materials.ts
+++ b/threejs/tests/canvas/canvas_materials.ts
@@ -52,8 +52,8 @@
 
             new THREE.MeshBasicMaterial({ color: 0x00ffff, wireframe: true, side: THREE.DoubleSide }),
             new THREE.MeshBasicMaterial({ color: 0xff0000, blending: THREE.AdditiveBlending }),
-            new THREE.MeshLambertMaterial({ color: 0xffffff, shading: THREE.FlatShading, overdraw: 0.5 }),
-            new THREE.MeshLambertMaterial({ color: 0xffffff, shading: THREE.SmoothShading, overdraw: 0.5 }),
+            new THREE.MeshLambertMaterial({ color: 0xffffff, overdraw: 0.5 }),
+            new THREE.MeshLambertMaterial({ color: 0xffffff, overdraw: 0.5 }),
             new THREE.MeshDepthMaterial({ overdraw: 0.5 }),
             new THREE.MeshNormalMaterial({ overdraw: 0.5 }),
             new THREE.MeshBasicMaterial({ map: THREE.ImageUtils.loadTexture('textures/land_ocean_ice_cloud_2048.jpg') }),

--- a/threejs/tests/webgl/webgl_materials.ts
+++ b/threejs/tests/webgl/webgl_materials.ts
@@ -54,20 +54,20 @@
         texture.needsUpdate = true;
 
         materials.push(new THREE.MeshLambertMaterial({ map: texture, transparent: true }));
-        materials.push(new THREE.MeshLambertMaterial({ color: 0xdddddd, shading: THREE.FlatShading }));
+        materials.push(new THREE.MeshLambertMaterial({ color: 0xdddddd }));
         materials.push(new THREE.MeshPhongMaterial({ color: 0xdddddd, specular: 0x009900, shininess: 30, shading: THREE.FlatShading }));
         materials.push(new THREE.MeshNormalMaterial());
         materials.push(new THREE.MeshBasicMaterial({ color: 0xffaa00, transparent: true, blending: THREE.AdditiveBlending }));
         //materials.push( new THREE.MeshBasicMaterial( { color: 0xff0000, blending: THREE.SubtractiveBlending } ) );
 
-        materials.push(new THREE.MeshLambertMaterial({ color: 0xdddddd, shading: THREE.SmoothShading }));
+        materials.push(new THREE.MeshLambertMaterial({ color: 0xdddddd }));
         materials.push(new THREE.MeshPhongMaterial({ color: 0xdddddd, specular: 0x009900, shininess: 30, shading: THREE.SmoothShading, map: texture, transparent: true }));
         materials.push(new THREE.MeshNormalMaterial({ shading: THREE.SmoothShading }));
         materials.push(new THREE.MeshBasicMaterial({ color: 0xffaa00, wireframe: true }));
 
         materials.push(new THREE.MeshDepthMaterial());
 
-        materials.push(new THREE.MeshLambertMaterial({ color: 0x666666, emissive: 0xff0000, shading: THREE.SmoothShading }));
+        materials.push(new THREE.MeshLambertMaterial({ color: 0x666666, emissive: 0xff0000 }));
         materials.push(new THREE.MeshPhongMaterial({ color: 0x000000, specular: 0x666666, emissive: 0xff0000, shininess: 10, shading: THREE.SmoothShading, opacity: 0.9, transparent: true }));
 
         materials.push(new THREE.MeshBasicMaterial({ map: texture, transparent: true }));

--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -5618,6 +5618,23 @@ declare module THREE {
         addShape(shape: Shape, options?: any): void;
     }
 
+    interface SphereParameters {
+        radius: number;
+        widthSegments: number;
+        heightSegments: number;
+        phiStart: number;
+        phiLength: number;
+        thetaStart: number;
+        thetaLength: number;
+    }
+
+    export class SphereBufferGeometry extends BufferGeometry {
+        constructor(radius: number, widthSegments?: number, heightSegments?: number, phiStart?: number, phiLength?: number, thetaStart?: number, thetaLength?: number);
+
+        parameters: SphereParameters;
+
+    }
+
     /**
      * A class for generating sphere geometries
      */
@@ -5635,15 +5652,7 @@ declare module THREE {
          */
         constructor(radius: number, widthSegments?: number, heightSegments?: number, phiStart?: number, phiLength?: number, thetaStart?: number, thetaLength?: number);
 
-        parameters: {
-            radius: number;
-            widthSegments: number;
-            heightSegments: number;
-            phiStart: number;
-            phiLength: number;
-            thetaStart: number;
-            thetaLength: number;
-        };
+        parameters: SphereParameters;
     }
 
     export class TetrahedronGeometry extends PolyhedronGeometry {

--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -1,15 +1,13 @@
-// Type definitions for three.js r71
+// Type definitions for three.js r73
 // Project: http://mrdoob.github.com/three.js/
 // Definitions by: Kon <http://phyzkit.net/>, Satoru Kimura <https://github.com/gyohk>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
-
-interface WebGLRenderingContext {}
 
 declare module THREE {
     export var REVISION: string;
 
     // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent.button
-    export enum MOUSE {LEFT, MIDDLE, RIGHT}
+    export enum MOUSE { LEFT, MIDDLE, RIGHT }
 
     // GL STATE CONSTANTS
     export enum CullFace { }
@@ -531,14 +529,17 @@ declare module THREE {
         name: string;
         type: string;
         attributes: BufferAttribute|InterleavedBufferAttribute[];
-        attributesKeys: string[];
         /** Deprecated. Use groups instead. */
         drawcalls: { start: number; count: number; index: number; }[];
         /** Deprecated. Use groups instead. */
         offsets: { start: number; count: number; index: number; }[];
-        groups: {start: number, count: number, materialIndex?: number}[]
+        groups: { start: number, count: number, materialIndex?: number }[];
         boundingBox: Box3;
         boundingSphere: BoundingSphere;
+
+        addIndex(index: BufferAttribute): void;
+        setIndex(index: BufferAttribute): void;
+
         /** Deprecated. This overloaded method is deprecated. */
         addAttribute(name: string, array: any, itemSize: number): any;
         addAttribute(name: string, attribute: BufferAttribute|InterleavedBufferAttribute): void;
@@ -553,7 +554,7 @@ declare module THREE {
         addGroup(start: number, count: number, materialIndex?: number): void;
         clearGroups(): void;
 
-        setDrawRange(start:number, count:number): void;
+        setDrawRange(start: number, count: number): void;
 
         /**
          * Bakes matrix transform directly into vertex coordinates.
@@ -563,9 +564,9 @@ declare module THREE {
         rotateX(angle: number): BufferGeometry;
         rotateY(angle: number): BufferGeometry;
         rotateZ(angle: number): BufferGeometry;
-        translate(x:number, y:number, z:number): BufferGeometry;
-        scale(x:number, y:number, z:number): BufferGeometry;
-        lookAt(v:Vector3): void;
+        translate(x: number, y: number, z: number): BufferGeometry;
+        scale(x: number, y: number, z: number): BufferGeometry;
+        lookAt(v: Vector3): void;
 
         center(): Vector3;
 
@@ -594,19 +595,12 @@ declare module THREE {
          */
         computeVertexNormals(): void;
 
-        /**
-         * Computes vertex tangents.
-         * Based on http://www.terathon.com/code/tangent.html
-         * Geometry must have vertex UVs (layer 0 will be used).
-         */
-        computeTangents(): void;
-
         computeOffsets(size: number): void;
         merge(geometry: BufferGeometry, offset: number): BufferGeometry;
         normalizeNormals(): void;
-        reorderBuffers(indexBuffer: number, indexMap: number[], vertexCount: number): void;
         toJSON(): any;
         clone(): BufferGeometry;
+        copy(source: BufferGeometry): BufferGeometry;
 
         /**
          * Disposes the object from memory.
@@ -728,7 +722,7 @@ declare module THREE {
     /**
      * Deprecated. Use new THREE.BufferAttribute().setDynamic(true) instead.
      */
-    export class DynamicBufferAttribute extends BufferAttribute{
+    export class DynamicBufferAttribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
 
         updateRange: {
@@ -958,13 +952,6 @@ declare module THREE {
         morphTargets: MorphTarget[];
 
         /**
-         * Array of morph colors. Morph colors have similar structure as morph targets, each color set is a Javascript object:
-         *
-         *     morphColor = { name: "colorName", colors: [ new THREE.Color(), ... ] }
-         */
-        morphColors: MorphColor[];
-
-        /**
          * Array of morph normals. Morph normals have similar structure as morph targets, each normal set is a Javascript object:
          *
          *     morphNormal = { name: "NormalName", normals: [ new THREE.Vector3(), ... ] }
@@ -995,11 +982,6 @@ declare module THREE {
          * Bounding sphere.
          */
         boundingSphere: BoundingSphere;
-
-        /**
-         * True if geometry has tangents. Set in Geometry.computeTangents.
-         */
-        hasTangents: boolean;
 
         /**
          * Set to true if attribute buffers will need to change in runtime (using "dirty" flags).
@@ -1076,13 +1058,6 @@ declare module THREE {
          */
         computeMorphNormals(): void;
 
-        /**
-         * Computes vertex tangents.
-         * Based on <a href="http://www.terathon.com/code/tangent.html">http://www.terathon.com/code/tangent.html</a>
-         * Geometry must have vertex UVs (layer 0 will be used).
-         */
-        computeTangents(): void;
-
         computeLineDistances(): void;
 
         /**
@@ -1105,6 +1080,8 @@ declare module THREE {
          * Duplicated vertices are removed and faces' vertices are updated.
          */
         mergeVertices(): number;
+
+        sortFacesByMaterialIndex(): void;
 
         toJSON(): any;
 
@@ -1246,7 +1223,7 @@ declare module THREE {
          *
          */
         static DefaultUp: Vector3;
-
+        static DefaultMatrixAutoUpdate: boolean;
 
         /**
          * Order of axis for Euler angles.
@@ -1435,6 +1412,8 @@ declare module THREE {
     export interface RaycasterParameters {
         Sprite?: any;
         Mesh?: any;
+        Points?: any;
+        /** Deprecated, use Points */
         PointCloud?: any;
         LOD?: any;
         Line?: any;
@@ -1465,7 +1444,42 @@ declare module THREE {
 
         color: Color;
 
+        shadow: LightShadow;
+
+        /** Deprecated, use shadow */
+        shadowCameraFov: number;
+        shadowCameraNear: number;
+        shadowCameraFar: number;
+        shadowCameraLeft: number;
+        shadowCameraRight: number;
+        shadowCameraTop: number;
+        shadowCameraBottom: number;
+        shadowBias: number;
+        shadowDarkness: number;
+        shadowMapWidth: number;
+        shadowMapHeight: number;
+        shadowMap: RenderTarget;
+        shadowMapSize: number;
+        shadowCamera: Camera;
+        shadowMatrix: Matrix4;
+
         clone(light?: Light): Light;
+    }
+    
+    export class LightShadow {
+        constructor(camera: Camera);
+
+        camera: THREE.Camera;
+
+        bias: number;
+        darkness: number;
+
+        mapSize: THREE.Vector2;
+
+        map: any;
+        matrix: THREE.Matrix4;
+        
+        clone(): LightShadow;
     }
 
     /**
@@ -1485,20 +1499,6 @@ declare module THREE {
         constructor(hex?: number);
 
         clone(): AmbientLight;
-    }
-
-    export class AreaLight extends Light{
-        constructor(hex: number, intensity?: number);
-
-        normal: Vector3;
-        right: Vector3;
-        intensity: number;
-        width: number;
-        height: number;
-        constantAttenuation: number;
-        linearAttenuation: number;
-        quadraticAttenuation: number;
-
     }
 
     /**
@@ -1526,149 +1526,6 @@ declare module THREE {
          * Default — 1.0.
          */
         intensity: number;
-
-        /**
-         * If set to true light will cast dynamic shadows. Warning: This is expensive and requires tweaking to get shadows looking right.
-         * Default — false.
-         */
-        castShadow: boolean;
-
-        /**
-         * If set to true light will only cast shadow but not contribute any lighting (as if intensity was 0 but cheaper to compute).
-         * Default — false.
-         */
-        onlyShadow: boolean;
-
-        /**
-         * Orthographic shadow camera frustum parameter.
-         * Default — 50.
-         */
-        shadowCameraNear: number;
-
-        /**
-         * Orthographic shadow camera frustum parameter.
-         * Default — 5000.
-         */
-        shadowCameraFar: number;
-
-        /**
-         * Orthographic shadow camera frustum parameter.
-         * Default — -500.
-         */
-        shadowCameraLeft: number;
-
-        /**
-         * Orthographic shadow camera frustum parameter.
-         * Default — 500.
-         */
-        shadowCameraRight: number;
-
-        /**
-         * Orthographic shadow camera frustum parameter.
-         * Default — 500.
-         */
-        shadowCameraTop: number;
-
-        /**
-         * Orthographic shadow camera frustum parameter.
-         * Default — -500.
-         */
-        shadowCameraBottom: number;
-
-        /**
-         * Show debug shadow camera frustum.
-         * Default — false.
-         */
-        shadowCameraVisible: boolean;
-
-        /**
-         * Shadow map bias.
-         * Default — 0.
-         */
-        shadowBias: number;
-
-        /**
-         * Darkness of shadow casted by this light (from 0 to 1).
-         * Default — 0.5.
-         */
-        shadowDarkness: number;
-
-        /**
-         * Shadow map texture width in pixels.
-         * Default — 512.
-         */
-        shadowMapWidth: number;
-
-        /**
-         * Shadow map texture height in pixels.
-         * Default — 512.
-         */
-        shadowMapHeight: number;
-
-        /**
-         * Default — false.
-         */
-        shadowCascade: boolean;
-
-        /**
-         * Three.Vector3( 0, 0, -1000 ).
-         */
-        shadowCascadeOffset: Vector3;
-
-        /**
-         * Default — 2.
-         */
-        shadowCascadeCount: number;
-
-        /**
-         * Default — [ 0, 0, 0 ].
-         */
-        shadowCascadeBias: number[];
-
-        /**
-         * Default — [ 512, 512, 512 ].
-         */
-        shadowCascadeWidth: number[];
-
-        /**
-         * Default — [ 512, 512, 512 ].
-         */
-        shadowCascadeHeight: number[];
-
-        /**
-         * Default — [ -1.000, 0.990, 0.998 ].
-         */
-        shadowCascadeNearZ: number[];
-
-        /**
-         * Default — [ 0.990, 0.998, 1.000 ].
-         */
-        shadowCascadeFarZ: number[];
-
-        /**
-         * Default — [ ].
-         */
-        shadowCascadeArray: DirectionalLight[];
-
-        /**
-         * Default — null.
-         */
-        shadowMap: RenderTarget;
-
-        /**
-         * Default — null.
-         */
-        shadowMapSize: number;
-
-        /**
-         * Default — null.
-         */
-        shadowCamera: Camera;
-
-        /**
-         * Default — null.
-         */
-        shadowMatrix: Matrix4;
 
         clone(): DirectionalLight;
     }
@@ -1712,18 +1569,6 @@ declare module THREE {
 
     /**
      * A point light that can cast shadow in one direction.
-     *
-     * @example
-     * // white spotlight shining from the side, casting shadow
-     * var spotLight = new THREE.SpotLight( 0xffffff );
-     * spotLight.position.set( 100, 1000, 100 );
-     * spotLight.castShadow = true;
-     * spotLight.shadowMapWidth = 1024;
-     * spotLight.shadowMapHeight = 1024;
-     * spotLight.shadowCameraNear = 500;
-     * spotLight.shadowCameraFar = 4000;
-     * spotLight.shadowCameraFov = 30;
-     * scene.add( spotLight );
      */
     export class SpotLight extends Light {
         constructor(hex?: number, intensity?: number, distance?: number, angle?: number, exponent?: number, decay?: number);
@@ -1760,71 +1605,6 @@ declare module THREE {
 
         decay: number;
 
-        /**
-         * If set to true light will cast dynamic shadows. Warning: This is expensive and requires tweaking to get shadows looking right.
-         * Default — false.
-         */
-        castShadow: boolean;
-
-        /**
-         * If set to true light will only cast shadow but not contribute any lighting (as if intensity was 0 but cheaper to compute).
-         * Default — false.
-         */
-        onlyShadow: boolean;
-
-        /**
-         * Perspective shadow camera frustum near parameter.
-         * Default — 50.
-         */
-        shadowCameraNear: number;
-
-        /**
-         * Perspective shadow camera frustum far parameter.
-         * Default — 5000.
-         */
-        shadowCameraFar: number;
-
-        /**
-         * Perspective shadow camera frustum field of view parameter.
-         * Default — 50.
-         */
-        shadowCameraFov: number;
-
-        /**
-         * Show debug shadow camera frustum.
-         * Default — false.
-         */
-        shadowCameraVisible: boolean;
-
-        /**
-         * Shadow map bias.
-         * Default — 0.
-         */
-        shadowBias: number;
-
-        /**
-         * Darkness of shadow casted by this light (from 0 to 1).
-         * Default — 0.5.
-         */
-        shadowDarkness: number;
-
-        /**
-         * Shadow map texture width in pixels.
-         * Default — 512.
-         */
-        shadowMapWidth: number;
-
-        /**
-         * Shadow map texture height in pixels.
-         * Default — 512.
-         */
-        shadowMapHeight: number;
-
-        shadowMap: RenderTarget;
-        shadowMapSize: Vector2;
-        shadowCamera: Camera;
-        shadowMatrix: Matrix4;
-
         clone(): SpotLight;
     }
 
@@ -1849,17 +1629,7 @@ declare module THREE {
      *          message — error message
      */
     export class Loader {
-        constructor(showStatus?: boolean);
-
-        /**
-         * If true, show loading status in the statusDomElement.
-         */
-        showStatus: boolean;
-
-        /**
-         * This is the recipient of status messages.
-         */
-        statusDomElement: HTMLElement;
+        constructor();
 
         imageLoader: ImageLoader;
 
@@ -1887,20 +1657,18 @@ declare module THREE {
          */
         crossOrigin: string;
 
-        addStatusElement(): HTMLElement;
-        updateProgress(progress: Progress): void;
         extractUrlBase(url: string): string;
         initMaterials(materials: Material[], texturePath: string): Material[];
         needsTangents(materials: Material[]): boolean;
         createMaterial(m: Material, texturePath: string): boolean;
 
-        static Handlers:LoaderHandler;
+        static Handlers: LoaderHandler;
     }
 
-    export interface LoaderHandler{
-        handlers:any[];
-        add(regex:string, loader:Loader):void;
-        get(file: string):Loader;
+    export interface LoaderHandler {
+        handlers: any[];
+        add(regex: string, loader: Loader): void;
+        get(file: string): Loader;
     }
 
     export class BinaryTextureLoader {
@@ -1918,7 +1686,8 @@ declare module THREE {
         parse(json: any): BufferGeometry;
     }
 
-    export interface Cache{
+    export interface Cache {
+        enabled: boolean;
         files: any[];
 
         add(key: string, file: any): void;
@@ -1926,9 +1695,9 @@ declare module THREE {
         remove(key: string): void;
         clear(): void;
     }
-    export var Cache:Cache;
+    export var Cache: Cache;
 
-    export class CompressedTextureLoader{
+    export class CompressedTextureLoader {
         constructor();
 
         load(url: string, onLoad: (bufferGeometry: BufferGeometry) => void, onError?: (event: any) => void): void;
@@ -1970,7 +1739,7 @@ declare module THREE {
      * A loader for loading objects in JSON format.
      */
     export class JSONLoader extends Loader {
-        constructor(showStatus?: boolean);
+        constructor();
 
         withCredentials: boolean;
 
@@ -1992,6 +1761,8 @@ declare module THREE {
     export class LoadingManager {
         constructor(onLoad?: () => void, onProgress?: (url: string, loaded: number, total: number) => void, onError?: () => void);
 
+        onStart: () => void;
+
         /**
          * Will be called when load starts.
          * The default is a function with empty body.
@@ -2002,7 +1773,7 @@ declare module THREE {
          * Will be called while load progresses.
          * The default is a function with empty body.
          */
-        onProgress: (item:any, loaded:number, total:number) => void;
+        onProgress: (item: any, loaded: number, total: number) => void;
 
         /**
          * Will be called when each element in the scene completes loading.
@@ -2157,6 +1928,8 @@ declare module THREE {
         blendDstAlpha: number;
         blendEquationAlpha: number;
 
+        depthFunc: Function;
+
         /**
          * Whether to have depth test enabled when rendering this material. Default is true.
          */
@@ -2271,7 +2044,8 @@ declare module THREE {
     export interface MeshBasicMaterialParameters extends MaterialParameters{
         color?: number;
         map?: Texture;
-        lightMap?: Texture;
+        aoMap?: Texture;
+        aoMapIntensity?: number;
         specularMap?: Texture;
         alphaMap?: Texture;
         envMap?: Texture;
@@ -2294,7 +2068,8 @@ declare module THREE {
 
         color: Color;
         map: Texture;
-        lightMap: Texture;
+        aoMap: Texture;
+        aoMapIntensity: number;
         specularMap: Texture;
         alphaMap: Texture;
         envMap: Texture;
@@ -2341,10 +2116,7 @@ declare module THREE {
     export interface MeshLambertMaterialParameters extends MaterialParameters{
         color?: number;
         emissive?: number;
-        wrapAround?: boolean;
-        wrapRGB?: Vector3;
         map?: Texture;
-        lightMap?: Texture;
         specularMap?: Texture;
         alphaMap?: Texture;
         envMap?: Texture;
@@ -2352,7 +2124,6 @@ declare module THREE {
         reflectivity?: number;
         refractionRatio?: number;
         fog?: boolean;
-        shading?: Shading;
         wireframe?: boolean;
         wireframeLinewidth?: number;
         wireframeLinecap?: string;
@@ -2367,10 +2138,7 @@ declare module THREE {
         constructor(parameters?: MeshLambertMaterialParameters);
         color: Color;
         emissive: Color;
-        wrapAround: boolean;
-        wrapRGB: Vector3;
         map: Texture;
-        lightMap: Texture;
         specularMap: Texture;
         alphaMap: Texture;
         envMap: Texture;
@@ -2378,7 +2146,6 @@ declare module THREE {
         reflectivity: number;
         refractionRatio: number;
         fog: boolean;
-        shading: Shading;
         wireframe: boolean;
         wireframeLinewidth: number;
         wireframeLinecap: string;
@@ -2441,6 +2208,12 @@ declare module THREE {
         map?: Texture;
         /** Set light map. Default is null */
         lightMap?: Texture;
+        lightMapIntensity?: number;
+
+        aoMap?: Texture;
+        aoMapIntensity?: number;
+        emissiveMap?: Texture;
+
         /** Set specular map. Default is null */
         specularMap?: Texture;
         /** Set alpha map. Default is null */
@@ -2471,12 +2244,13 @@ declare module THREE {
         specular?: number;
         shininess?: number;
         metal?: boolean;
-        wrapAround?: boolean;
-        wrapRGB?: Vector3;
         bumpMap?: Texture;
         bumpScale?: number;
         normalMap?: Texture;
         normalScale?: Vector2;
+        displacementMap?: Texture;
+        displacementScale?: number;
+        displacementBias?: number;
         combine?: Combine;
         reflectivity?: number;
         refractionRatio?: number;
@@ -2491,14 +2265,19 @@ declare module THREE {
         specular: Color;
         shininess: number;
         metal: boolean;
-        wrapAround: boolean;
-        wrapRGB: Vector3;
         map: Texture;
         lightMap: Texture;
+        lightMapIntensity: number;
+        aoMap: Texture;
+        aoMapIntensity: number;
+        emissiveMap: Texture;
         bumpMap: Texture;
         bumpScale: number;
         normalMap: Texture;
         normalScale: Vector2;
+        displacementMap: Texture;
+        displacementScale: number;
+        displacementBias: number;
         specularMap: Texture;
         alphaMap: Texture;
         envMap: Texture;
@@ -2556,10 +2335,9 @@ declare module THREE {
 
     }
 
-    export interface ShaderMaterialParameters extends MaterialParameters{
+    export interface ShaderMaterialParameters extends MaterialParameters {
         defines?: any;
         uniforms?: any;
-        attributes?: any;
         vertexShader?: string;
         fragmentShader?: string;
         shading?: Shading;
@@ -2579,7 +2357,6 @@ declare module THREE {
 
         defines: any;
         uniforms: any;
-        attributes: any;
         vertexShader: string;
         fragmentShader: string;
         shading: Shading;
@@ -2596,7 +2373,7 @@ declare module THREE {
         clone(): ShaderMaterial;
     }
 
-    export interface SpriteMaterialParameters extends MaterialParameters{
+    export interface SpriteMaterialParameters extends MaterialParameters {
         color?: number;
         map?: Texture;
         rotation?: number;
@@ -3033,13 +2810,6 @@ declare module THREE {
          */
         clamp(x: number, a: number, b: number): number;
 
-        /**
-         * Clamps the x to be larger than a.
-         *
-         * @param x — Value to be clamped.
-         * @param a — Minimum value
-         */
-        clampBottom(x: number, a: number): number;
 
         /**
          * Linear mapping of x from range [a1, a2] to range [b1, b2].
@@ -3508,6 +3278,7 @@ declare module THREE {
         recast(t: number): Ray;
         closestPointToPoint(point: Vector3, optionalTarget?: Vector3): Vector3;
         distanceToPoint(point: Vector3): number;
+        distanceSqToPoint(point: Vector3): number;
         distanceSqToSegment(v0: Vector3, v1: Vector3, optionalPointOnRay?: Vector3, optionalPointOnSegment?: Vector3): number;
         isIntersectionSphere(sphere: Sphere): boolean;
         intersectSphere(sphere: Sphere, optionalTarget?: Vector3): Vector3;
@@ -3625,7 +3396,7 @@ declare module THREE {
     /**
      * ( interface Vector&lt;T&gt; )
      *
-     * Abstruct interface of Vector2, Vector3 and Vector4.
+     * Abstract interface of Vector2, Vector3 and Vector4.
      * Currently the members of Vector is NOT type safe because it accepts different typed vectors.
      * Those definitions will be changed when TypeScript innovates Generics to be type safe.
      *
@@ -3784,6 +3555,7 @@ declare module THREE {
          */
         addScalar(s: number): Vector2;
         addVectors(a: Vector2, b: Vector2): Vector2;
+        addScaledVector(v: Vector2, s: number): Vector2;
 
         /**
          * Subtracts v from this vector.
@@ -3813,6 +3585,7 @@ declare module THREE {
         max(v: Vector2): Vector2;
         clamp(min: Vector2, max: Vector2): Vector2;
         clampScalar(min: number, max: number): Vector2;
+        clampLength(min: number, max: number): Vector2;
         floor(): Vector2;
         ceil(): Vector2;
         round(): Vector2;
@@ -3837,6 +3610,11 @@ declare module THREE {
          * Computes length of this vector.
          */
         length(): number;
+
+        /**
+         * Computes Manhattan length of this vector.
+         */
+        lengthManhattan(): number;
 
         /**
          * Normalizes this vector.
@@ -3872,6 +3650,8 @@ declare module THREE {
         toArray(xy?: number[], offset?: number): number[];
 
         fromAttribute( attribute: BufferAttribute, index: number, offset?: number): Vector2;
+
+        rotateAround(center: Vector2, angle: number): Vector2;
 
         /**
          * Clones this vector.
@@ -3933,6 +3713,7 @@ declare module THREE {
          */
         add(a: Vector3): Vector3;
         addScalar(s: number): Vector3;
+        addScaledVector(v: Vector3, s: number): Vector3;
 
         /**
          * Sets this vector to a + b.
@@ -3977,6 +3758,7 @@ declare module THREE {
         max(v: Vector3): Vector3;
         clamp(min: Vector3, max: Vector3): Vector3;
         clampScalar(min: number, max: number): Vector3;
+        clampLength(min: number, max: number): Vector3;
         floor(): Vector3;
         ceil(): Vector3;
         round(): Vector3;
@@ -4121,6 +3903,7 @@ declare module THREE {
          * Sets this vector to a + b.
          */
         addVectors(a: Vector4, b: Vector4): Vector4;
+        addScaledVector(v: Vector4, s: number): Vector4;
 
         /**
          * Subtracts v from this vector.
@@ -4269,9 +4052,8 @@ declare module THREE {
         constructor(geometry?: BufferGeometry, material?: LineBasicMaterial, mode?: number);
         constructor(geometry?: BufferGeometry, material?: ShaderMaterial, mode?: number);
 
-        geometry: any; // Geometry or BufferGeometry;
+        geometry: Geometry|BufferGeometry;
         material: Material; // LineDashedMaterial or LineBasicMaterial or ShaderMaterial
-        mode: LineMode;
 
         raycast(raycaster: Raycaster, intersects: any): void;
         clone(object?: Line): Line;
@@ -4285,7 +4067,7 @@ declare module THREE {
         constructor(geometry?: BufferGeometry, material?: LineBasicMaterial);
         constructor(geometry?: BufferGeometry, material?: ShaderMaterial);
 
-        geometry: any; // Geometry or BufferGeometry;
+        geometry: Geometry|BufferGeometry;
         material: Material; // LineDashedMaterial or LineBasicMaterial or ShaderMaterial
 
         raycast(raycaster: Raycaster, intersects: any): void;
@@ -4299,6 +4081,8 @@ declare module THREE {
     export class LOD extends Object3D {
         constructor();
 
+        levels: any[];
+        /** Deprecated, use levels instead */
         objects: any[];
 
         addLevel(object: Object3D, distance?: number): void;
@@ -4312,7 +4096,7 @@ declare module THREE {
         constructor(geometry?: Geometry, material?: Material);
         constructor(geometry?: BufferGeometry, material?: Material);
 
-        geometry: Geometry;
+        geometry: Geometry|BufferGeometry;
         material: Material;
 
         updateMorphTargets(): void;
@@ -4398,6 +4182,7 @@ declare module THREE {
         calculateInverses(bone: Bone): void;
         pose(): void;
         update(): void;
+        clone(): Skeleton;
     }
 
     export class SkinnedMesh extends Mesh {
@@ -4512,9 +4297,7 @@ declare module THREE {
         /**
          * The HTML5 Canvas's 'webgl' context obtained from the canvas where the renderer will draw.
          */
-        //  If you are using three.d.ts with other complete definitions of webgl, context:WebGLRenderingContext is suitable.
-        //context:WebGLRenderingContext;
-        context: any;
+        context: WebGLRenderingContext;
 
         /**
          * Defines whether the renderer should automatically clear its output before rendering.
@@ -4540,6 +4323,8 @@ declare module THREE {
          * Defines whether the renderer should sort objects. Default is true.
          */
         sortObjects: boolean;
+
+        extensions: WebGLExtensions;
 
         gammaFactor: number;
 
@@ -4575,11 +4360,6 @@ declare module THREE {
         shadowMapDebug: boolean;
 
         /**
-         * Default is false.
-         */
-        shadowMapCascade: boolean;
-
-        /**
          * Default is 8.
          */
         maxMorphTargets: number;
@@ -4611,7 +4391,7 @@ declare module THREE {
             };
         };
 
-        shadowMapPlugin: ShadowMapPlugin;
+        shadowMap: WebGLShadowMap;
 
         /**
          * Return the WebGL context.
@@ -4620,19 +4400,22 @@ declare module THREE {
 
         forceContextLoss(): void;
 
-        /**
-         * Return a Boolean true if the context supports vertex textures.
-         */
+        capabilities: WebGLCapabilities;
+
+        /** Deprecated, use capabilities instead */
         supportsVertexTextures(): boolean;
         supportsFloatTextures(): boolean;
         supportsStandardDerivatives(): boolean;
         supportsCompressedTextureS3TC(): boolean;
         supportsCompressedTexturePVRTC(): boolean;
         supportsBlendMinMax(): boolean;
-        getMaxAnisotropy(): number;
         getPrecision(): string;
+
+        getMaxAnisotropy(): number;
         getPixelRatio(): number;
         setPixelRatio(value: number): void;
+        
+        getSize(): { width: number; height: number; };
 
         /**
          * Resizes the output canvas to (width, height), and also sets the viewport to fit that size, starting in (0, 0).
@@ -4695,6 +4478,7 @@ declare module THREE {
         clearStencil(): void;
         clearTarget(renderTarget:WebGLRenderTarget, color: boolean, depth: boolean, stencil: boolean): void;
         resetGLState(): void;
+        dispose(): void;
 
         /**
          * Tells the shadow map plugin to update using the passed scene and camera parameters.
@@ -4734,7 +4518,24 @@ declare module THREE {
         setRenderTarget(renderTarget: RenderTarget): void;
         readRenderTargetPixels( renderTarget: RenderTarget, x: number, y: number, width: number, height: number, buffer: any ): void;
     }
-
+    
+    export interface WebGLCapabilities {
+        getMaxPrecision(precision: string): string;
+        precision: string;
+        logarithmicDepthBuffer: boolean;
+        maxTextures: number;
+        maxVertexTextures: number;
+        maxTextureSize: number;
+        maxCubemapSize: number;
+        maxAttributes: number;
+        maxVertexUniforms: number;
+        maxVaryings: number;
+        maxFragmentUniforms: number;
+        vertexTextures: boolean;
+        floatFragmentTextures: boolean;
+        floatVertexTextures: boolean;
+    }
+  
     export interface RenderTarget {
     }
 
@@ -4886,17 +4687,23 @@ declare module THREE {
     };
 
     // Renderers / WebGL /////////////////////////////////////////////////////////////////////
-    export class WebGLExtensions{
-        constructor(gl: any); // WebGLRenderingContext
+    export class WebGLExtensions {
+        constructor(gl: WebGLRenderingContext);
 
         get(name: string): any;
     }
 
-    export class WebGLProgram{
+    export class WebGLProgram {
         constructor(renderer: WebGLRenderer, code: string, material: ShaderMaterial, parameters: WebGLRendererParameters);
+        
+        getUniforms(): any;
+        getAttributes(): any;
 
+        /** Deprecated, use getUniforms */
+        uniforms: any;
+        /** Deprecated, use getAttributes */
         attributes: any;
-        attributesKeys: string[];
+
         id: number;
         code: string;
         usedTimes: number;
@@ -4905,27 +4712,27 @@ declare module THREE {
         fragmentShader: WebGLShader;
     }
 
-    export class WebGLShader{
-        constructor(gl: any, type: string, string: string);
+    export class WebGLShader {
+        constructor(gl: WebGLRenderingContext, type: string, string: string);
     }
 
-    interface WebGLStateInstance{
-        new ( gl: any, paramThreeToGL: Function ): void;
+    interface WebGLStateInstance {
+        new(gl: WebGLRenderingContext, paramThreeToGL: Function): void;
         initAttributes(): void;
         enableAttribute(attribute: string): void;
         disableUnusedAttributes(): void;
-        setBlending( blending: number, blendEquation: number, blendSrc: number, blendDst: number, blendEquationAlpha: number, blendSrcAlpha: number, blendDstAlpha: number ): void;
-        setDepthTest( depthTest: number ): void;
-        setDepthWrite( depthWrite: number ): void;
-        setColorWrite( colorWrite: number ): void;
-        setDoubleSided( doubleSided: number ): void;
-        setFlipSided( flipSided: number ): void;
-        setLineWidth( width: number ): void;
+        setBlending(blending: number, blendEquation: number, blendSrc: number, blendDst: number, blendEquationAlpha: number, blendSrcAlpha: number, blendDstAlpha: number): void;
+        setDepthTest(depthTest: number): void;
+        setDepthWrite(depthWrite: number): void;
+        setColorWrite(colorWrite: number): void;
+        setDoubleSided(doubleSided: number): void;
+        setFlipSided(flipSided: number): void;
+        setLineWidth(width: number): void;
         setPolygonOffset(polygonoffset: number, factor: number, units: number): void;
         reset(): void;
     }
-    interface WebGLStateStatic{
-        ( gl: any, paramThreeToGL: Function ): WebGLStateInstance;
+    interface WebGLStateStatic {
+        (gl: WebGLRenderingContext, paramThreeToGL: Function): WebGLStateInstance;
     }
     export var WebGLState: WebGLStateStatic;
 
@@ -4956,8 +4763,12 @@ declare module THREE {
         render(scene: Scene, camera: Camera, viewportWidth: number, viewportHeight: number): void;
     }
 
-    export class ShadowMapPlugin implements RendererPlugin {
+    export class WebGLShadowMap implements RendererPlugin {
         constructor();
+
+        enabled: boolean;
+        type: ShadowMapType;
+        cullFace: CullFace;
 
         init(renderer: Renderer): void;
         render(scene: Scene, camera: Camera): void;
@@ -5046,6 +4857,20 @@ declare module THREE {
     }
 
     // Textures /////////////////////////////////////////////////////////////////////
+    export class CanvasTexture extends Texture {
+        constructor(
+            canvas?: HTMLCanvasElement,
+            mapping?: Mapping,
+            wrapS?: Wrapping,
+            wrapT?: Wrapping,
+            magFilter?: TextureFilter,
+            minFilter?: TextureFilter,
+            format?: PixelFormat,
+            type?: TextureDataType,
+            anisotropy?: number
+        );
+    }
+
     export class CompressedTexture extends Texture {
         constructor(
             mipmaps: ImageData[],
@@ -5147,6 +4972,7 @@ declare module THREE {
 
         clone(): Texture;
         update(): void;
+        toJSON(): any;
         dispose(): void;
 
         // EventDispatcher mixins
@@ -5416,15 +5242,15 @@ declare module THREE {
          */
         getTangentAt(u: number): T;
 
-        static Utils: {
-            tangentQuadraticBezier(t: number, p0: number, p1: number, p2: number): number;
-            tangentCubicBezier(t: number, p0: number, p1: number, p2: number, p3: number): number;
-            tangentSpline(t: number, p0: number, p1: number, p2: number, p3: number): number;
-            interpolate(p0: number, p1: number, p2: number, p3: number, t: number): number;
-        };
-
         static create(constructorFunc: Function, getPointFunc: Function): Function;
     }
+
+    export var CurveUtils: {
+        tangentQuadraticBezier(t: number, p0: number, p1: number, p2: number): number;
+        tangentCubicBezier(t: number, p0: number, p1: number, p2: number, p3: number): number;
+        tangentSpline(t: number, p0: number, p1: number, p2: number, p3: number): number;
+        interpolate(p0: number, p1: number, p2: number, p3: number, t: number): number;
+    };
 
     export interface BoundingBox {
         minX: number;
@@ -5494,8 +5320,8 @@ declare module THREE {
         splineThru(pts: Vector2[]): void;
         arc(aX: number, aY: number, aRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean): void;
         absarc(aX: number, aY: number, aRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean): void;
-        ellipse(aX: number, aY: number, xRadius: number, yRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean): void;
-        absellipse(aX: number, aY: number, xRadius: number, yRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean): void;
+        ellipse(aX: number, aY: number, xRadius: number, yRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean, aRotation: number): void;
+        absellipse(aX: number, aY: number, xRadius: number, yRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean, aRotation: number): void;
         getSpacedPoints(divisions?: number, closedPath?: boolean): Vector2[];
         getPoints(divisions?: number, closedPath?: boolean): Vector2[];
         toShapes(): Shape[];
@@ -5527,17 +5353,23 @@ declare module THREE {
 
     // Extras / Curves /////////////////////////////////////////////////////////////////////
     export class ArcCurve extends EllipseCurve {
-        constructor(aX: number, aY: number, aRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean );
+        constructor(aX: number, aY: number, aRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean, aRotation: number);
+    }
+
+    export class CatmullRomCurve3 extends Curve<Vector3> {
+        constructor(points?: Vector3[]);
+
+        points: Vector3[];
     }
 
     export class ClosedSplineCurve3 extends Curve<Vector3> {
-        constructor( points?:Vector3[] );
+        constructor(points?: Vector3[]);
 
-        points:Vector3[];
+        points: Vector3[];
     }
 
     export class CubicBezierCurve extends Curve<Vector2> {
-        constructor( v0: Vector2, v1: Vector2, v2: Vector2, v3: Vector2 );
+        constructor(v0: Vector2, v1: Vector2, v2: Vector2, v3: Vector2);
 
         v0: Vector2;
         v1: Vector2;
@@ -5545,7 +5377,7 @@ declare module THREE {
         v3: Vector2;
     }
     export class CubicBezierCurve3 extends Curve<Vector3> {
-        constructor( v0: Vector3, v1: Vector3, v2: Vector3, v3: Vector3 );
+        constructor(v0: Vector3, v1: Vector3, v2: Vector3, v3: Vector3);
 
         v0: Vector3;
         v1: Vector3;
@@ -5553,7 +5385,7 @@ declare module THREE {
         v3: Vector3;
     }
     export class EllipseCurve extends Curve<Vector2> {
-        constructor( aX: number, aY: number, xRadius: number, yRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean );
+        constructor(aX: number, aY: number, xRadius: number, yRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean, aRotation: number);
 
         aX: number;
         aY: number;
@@ -5562,6 +5394,7 @@ declare module THREE {
         aStartAngle: number;
         aEndAngle: number;
         aClockwise: boolean;
+        aRotation: number;
     }
     export class LineCurve extends Curve<Vector2> {
         constructor( v1: Vector2, v2: Vector2 );
@@ -5626,6 +5459,17 @@ declare module THREE {
         };
     }
 
+    export class CircleBufferGeometry extends BufferGeometry {
+        constructor(radius?: number, segments?: number, thetaStart?: number, thetaLength?: number);
+
+        parameters: {
+            radius: number;
+            segments: number;
+            thetaStart: number;
+            thetaLength: number;
+        };
+    }
+
     export class CircleGeometry extends Geometry {
         constructor(radius?: number, segments?: number, thetaStart?: number, thetaLength?: number);
 
@@ -5671,6 +5515,10 @@ declare module THREE {
             radius: number;
             detail: number;
         };
+    }
+
+    export class EdgesGeometry extends BufferGeometry {
+        constructor(geometry: Geometry|BufferGeometry, thresholdAngle?: number);
     }
 
     export class ExtrudeGeometry extends Geometry {
@@ -5862,8 +5710,10 @@ declare module THREE {
 
         static NoTaper(u?: number): number;
         static SinusoidalTaper(u: number): number;
-        static FrenetFrames(path: Path, segments: number, closed: boolean): void;
+    }
 
+    export class WireframeGeometry extends BufferGeometry {
+        constructor(geometry: Geometry|BufferGeometry);
     }
 
     // Extras / Helpers /////////////////////////////////////////////////////////////////////
@@ -6008,9 +5858,11 @@ declare module THREE {
     // Extras / Objects /////////////////////////////////////////////////////////////////////
 
     export class ImmediateRenderObject extends Object3D {
-        constructor();
+        constructor(material: Material);
 
-        render(renderCallback:Function): void;
+        material: Material;
+
+        render(renderCallback: Function): void;
     }
 
     export interface MorphBlendMeshAnimation {
@@ -6052,5 +5904,5 @@ declare module THREE {
 }
 
 declare module 'three' {
-    export=THREE;
+    export = THREE;
 }


### PR DESCRIPTION
Lots of Three.js update from r71 to r73, including light changes and WebGLCapabilities.

There's one failing test at the moment (`tests/webgl/webgl_custom_attributes.ts`) because attributes are no longer attached to shaders but to `BufferGeometry` instead and the test uses a `SphereGeometry`.

It should probably be updated to use a `SphereBufferGeometry` (which looks like it's missing even though it was [added in April](https://github.com/mrdoob/three.js/commit/723d3f4019ecc09a99376c08c00a5593e205f934)). Can someone help me fixing it properly? If not, I'll try and spend more time on it in the coming days.
