### PR TITLE
lodash: signatures of the method _.unescape have been changed

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -4963,8 +4963,20 @@ module TestTrunc {
 }
 
 // _.unescape
-result = <string>_.unescape('fred, barney, &amp; pebbles');
-result = <string>_('fred, barney, &amp; pebbles').unescape();
+module TestUnescape {
+    {
+        let result: string;
+
+        result = _.unescape('fred, barney, &amp; pebbles');
+        result = _('fred, barney, &amp; pebbles').unescape();
+    }
+
+    {
+        let result: _.LoDashExplicitWrapper<string>;
+
+        result = _('fred, barney, &amp; pebbles').chain().unescape();
+    }
+}
 
 // _.words
 module TestWords {

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -10564,6 +10564,7 @@ declare module _ {
         /**
          * The inverse of _.escape; this method converts the HTML entities &amp;, &lt;, &gt;, &quot;, &#39;, and &#96;
          * in string to their corresponding characters.
+         *
          * @param string The string to unescape.
          * @return Returns the unescaped string.
          */
@@ -10575,6 +10576,13 @@ declare module _ {
          * @see _.unescape
          */
         unescape(): string;
+    }
+
+    interface LoDashExplicitWrapper<T> {
+        /**
+         * @see _.unescape
+         */
+        unescape(): LoDashExplicitWrapper<string>;
     }
 
     //_.words


### PR DESCRIPTION
https://lodash.com/docs#unescape
https://lodash.com/docs#_ (description of the chainable wrapper)
