### PR TITLE
node: Split to 0.12.x and 4.x. Added http.RequestOptions.

### DIFF
--- a/node/node-0.12-tests.ts
+++ b/node/node-0.12-tests.ts
@@ -1,0 +1,411 @@
+/// <reference path="node-0.12.d.ts" />
+import * as assert from "assert";
+import * as fs from "fs";
+import * as events from "events";
+import * as zlib from "zlib";
+import * as url from "url";
+import * as util from "util";
+import * as crypto from "crypto";
+import * as tls from "tls";
+import * as http from "http";
+import * as net from "net";
+import * as dgram from "dgram";
+import * as querystring from "querystring";
+import * as path from "path";
+import * as readline from "readline";
+import * as childProcess from "child_process";
+
+assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
+
+assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");
+
+assert.equal(3, "3", "uses == comparator");
+
+assert.notStrictEqual(2, "2", "uses === comparator");
+
+assert.throws(() => { throw "a hammer at your face"; }, undefined, "DODGED IT");
+
+assert.doesNotThrow(() => {
+    if (false) { throw "a hammer at your face"; }
+}, undefined, "What the...*crunch*");
+
+////////////////////////////////////////////////////
+/// File system tests : http://nodejs.org/api/fs.html
+////////////////////////////////////////////////////
+fs.writeFile("thebible.txt",
+    "Do unto others as you would have them do unto you.",
+    assert.ifError);
+
+fs.write(1234, "test");
+
+fs.writeFile("Harry Potter",
+    "\"You be wizzing, Harry,\" jived Dumbledore.",
+    {
+        encoding: "ascii"
+    },
+    assert.ifError);
+
+var content: string,
+    buffer: Buffer;
+
+content = fs.readFileSync('testfile', 'utf8');
+content = fs.readFileSync('testfile', {encoding : 'utf8'});
+buffer = fs.readFileSync('testfile');
+buffer = fs.readFileSync('testfile', {flag : 'r'});
+fs.readFile('testfile', 'utf8', (err, data) => content = data);
+fs.readFile('testfile', {encoding : 'utf8'}, (err, data) => content = data);
+fs.readFile('testfile', (err, data) => buffer = data);
+fs.readFile('testfile', {flag : 'r'}, (err, data) => buffer = data);
+
+class Networker extends events.EventEmitter {
+    constructor() {
+        super();
+
+        this.emit("mingling");
+    }
+}
+
+var errno: number;
+fs.readFile('testfile', (err, data) => {
+    if (err && err.errno) {
+        errno = err.errno;
+    }
+});
+
+
+///////////////////////////////////////////////////////
+/// Buffer tests : https://nodejs.org/api/buffer.html
+///////////////////////////////////////////////////////
+
+function bufferTests() {
+    var utf8Buffer = new Buffer('test');
+    var base64Buffer = new Buffer('','base64');
+    var octets: Uint8Array = null;
+    var octetBuffer = new Buffer(octets);
+    console.log(Buffer.isBuffer(octetBuffer));
+    console.log(Buffer.isEncoding('utf8'));
+    console.log(Buffer.byteLength('xyz123'));
+    console.log(Buffer.byteLength('xyz123', 'ascii'));
+    var result1 = Buffer.concat([utf8Buffer, base64Buffer]);
+    var result2 = Buffer.concat([utf8Buffer, base64Buffer], 9999999);
+
+    // Test that TS 1.6 works with the 'as Buffer' annotation
+    // on isBuffer.
+    var a: Buffer | number;
+    a = new Buffer(10);
+    if (Buffer.isBuffer(a)) {
+        a.writeUInt8(3, 4);
+    }
+
+    // write* methods return offsets.
+    var b = new Buffer(16);
+    var result: number = b.writeUInt32LE(0, 0);
+    result = b.writeUInt16LE(0, 4);
+    result = b.writeUInt8(0, 6);
+    result = b.writeInt8(0, 7);
+    result = b.writeDoubleLE(0, 8);
+
+    // fill returns the input buffer.
+    b.fill('a').fill('b');
+}
+
+
+////////////////////////////////////////////////////
+/// Url tests : http://nodejs.org/api/url.html
+////////////////////////////////////////////////////
+
+url.format(url.parse('http://www.example.com/xyz'));
+
+// https://google.com/search?q=you're%20a%20lizard%2C%20gary
+url.format({
+    protocol: 'https',
+    host: "google.com",
+    pathname: 'search',
+    query: { q: "you're a lizard, gary" }
+});
+
+var helloUrl = url.parse('http://example.com/?hello=world', true)
+assert.equal(helloUrl.query.hello, 'world');
+
+
+// Old and new util.inspect APIs
+util.inspect(["This is nice"], false, 5);
+util.inspect(["This is nice"], { colors: true, depth: 5, customInspect: false });
+
+////////////////////////////////////////////////////
+/// Stream tests : http://nodejs.org/api/stream.html
+////////////////////////////////////////////////////
+
+// http://nodejs.org/api/stream.html#stream_readable_pipe_destination_options
+function stream_readable_pipe_test() {
+    var r = fs.createReadStream('file.txt');
+    var z = zlib.createGzip();
+    var w = fs.createWriteStream('file.txt.gz');
+    r.pipe(z).pipe(w);
+    r.close();
+}
+
+////////////////////////////////////////////////////
+/// Crypto tests : http://nodejs.org/api/crypto.html
+////////////////////////////////////////////////////
+
+var hmacResult: string = crypto.createHmac('md5', 'hello').update('world').digest('hex');
+
+function crypto_cipher_decipher_string_test() {
+	var key:Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
+	var clearText:string = "This is the clear text.";
+	var cipher:crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
+	var cipherText:string = cipher.update(clearText, "utf8", "hex");
+	cipherText += cipher.final("hex");
+
+	var decipher:crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
+	var clearText2:string = decipher.update(cipherText, "hex", "utf8");
+	clearText2 += decipher.final("utf8");
+
+	assert.equal(clearText2, clearText);
+}
+
+function crypto_cipher_decipher_buffer_test() {
+	var key:Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
+	var clearText:Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4]);
+	var cipher:crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
+	var cipherBuffers:Buffer[] = [];
+	cipherBuffers.push(cipher.update(clearText));
+	cipherBuffers.push(cipher.final());
+
+	var cipherText:Buffer = Buffer.concat(cipherBuffers);
+
+	var decipher:crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
+	var decipherBuffers:Buffer[] = [];
+	decipherBuffers.push(decipher.update(cipherText));
+	decipherBuffers.push(decipher.final());
+
+	var clearText2:Buffer = Buffer.concat(decipherBuffers);
+
+	assert.deepEqual(clearText2, clearText);
+}
+
+////////////////////////////////////////////////////
+/// TLS tests : http://nodejs.org/api/tls.html
+////////////////////////////////////////////////////
+
+var ctx: tls.SecureContext = tls.createSecureContext({
+    key: "NOT REALLY A KEY",
+    cert: "SOME CERTIFICATE",
+});
+var blah = ctx.context;
+
+////////////////////////////////////////////////////
+
+// Make sure .listen() and .close() retuern a Server instance
+http.createServer().listen(0).close().address();
+net.createServer().listen(0).close().address();
+
+var request = http.request('http://0.0.0.0');
+request.once('error', function () {});
+request.setNoDelay(true);
+request.abort();
+
+////////////////////////////////////////////////////
+/// Http tests : http://nodejs.org/api/http.html
+////////////////////////////////////////////////////
+module http_tests {
+    // Status codes
+    var code = 100;
+    var codeMessage = http.STATUS_CODES['400'];
+    var codeMessage = http.STATUS_CODES[400];
+
+	var agent: http.Agent = new http.Agent({
+		keepAlive: true,
+		keepAliveMsecs: 10000,
+		maxSockets: Infinity,
+		maxFreeSockets: 256
+	});
+
+	var agent: http.Agent = http.globalAgent;
+}
+
+////////////////////////////////////////////////////
+/// Dgram tests : http://nodejs.org/api/dgram.html
+////////////////////////////////////////////////////
+
+var ds: dgram.Socket = dgram.createSocket("udp4", (msg: Buffer, rinfo: dgram.RemoteInfo): void => {
+});
+var ai: dgram.AddressInfo = ds.address();
+ds.send(new Buffer("hello"), 0, 5, 5000, "127.0.0.1", (error: Error, bytes: number): void => {
+});
+
+////////////////////////////////////////////////////
+///Querystring tests : https://gist.github.com/musubu/2202583
+////////////////////////////////////////////////////
+
+var original: string = 'http://example.com/product/abcde.html';
+var escaped: string = querystring.escape(original);
+console.log(escaped);
+// http%3A%2F%2Fexample.com%2Fproduct%2Fabcde.html
+var unescaped: string = querystring.unescape(escaped);
+console.log(unescaped);
+// http://example.com/product/abcde.html
+
+////////////////////////////////////////////////////
+/// path tests : http://nodejs.org/api/path.html
+////////////////////////////////////////////////////
+
+module path_tests {
+
+    path.normalize('/foo/bar//baz/asdf/quux/..');
+
+    path.join('/foo', 'bar', 'baz/asdf', 'quux', '..');
+    // returns
+    //'/foo/bar/baz/asdf'
+
+    try {
+        path.join('foo', {}, 'bar');
+    }
+    catch(error) {
+
+    }
+
+    path.resolve('foo/bar', '/tmp/file/', '..', 'a/../subfile');
+    //Is similar to:
+    //
+    //cd foo/bar
+    //cd /tmp/file/
+    //cd ..
+    //    cd a/../subfile
+    //pwd
+
+    path.resolve('/foo/bar', './baz')
+    // returns
+    //    '/foo/bar/baz'
+
+    path.resolve('/foo/bar', '/tmp/file/')
+    // returns
+    //    '/tmp/file'
+
+    path.resolve('wwwroot', 'static_files/png/', '../gif/image.gif')
+    // if currently in /home/myself/node, it returns
+    //    '/home/myself/node/wwwroot/static_files/gif/image.gif'
+
+    path.isAbsolute('/foo/bar') // true
+    path.isAbsolute('/baz/..')  // true
+    path.isAbsolute('qux/')     // false
+    path.isAbsolute('.')        // false
+
+    path.isAbsolute('//server')  // true
+    path.isAbsolute('C:/foo/..') // true
+    path.isAbsolute('bar\\baz')   // false
+    path.isAbsolute('.')         // false
+
+    path.relative('C:\\orandea\\test\\aaa', 'C:\\orandea\\impl\\bbb')
+// returns
+//    '..\\..\\impl\\bbb'
+
+    path.relative('/data/orandea/test/aaa', '/data/orandea/impl/bbb')
+// returns
+//    '../../impl/bbb'
+
+    path.dirname('/foo/bar/baz/asdf/quux')
+// returns
+//    '/foo/bar/baz/asdf'
+
+    path.basename('/foo/bar/baz/asdf/quux.html')
+// returns
+//    'quux.html'
+
+    path.basename('/foo/bar/baz/asdf/quux.html', '.html')
+// returns
+//    'quux'
+
+    path.extname('index.html')
+// returns
+//    '.html'
+
+    path.extname('index.coffee.md')
+// returns
+//    '.md'
+
+    path.extname('index.')
+// returns
+//    '.'
+
+    path.extname('index')
+// returns
+//    ''
+
+    'foo/bar/baz'.split(path.sep)
+// returns
+//        ['foo', 'bar', 'baz']
+
+    'foo\\bar\\baz'.split(path.sep)
+// returns
+//        ['foo', 'bar', 'baz']
+
+    console.log(process.env.PATH)
+// '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin'
+
+    process.env.PATH.split(path.delimiter)
+// returns
+//        ['/usr/bin', '/bin', '/usr/sbin', '/sbin', '/usr/local/bin']
+
+    console.log(process.env.PATH)
+// 'C:\Windows\system32;C:\Windows;C:\Program Files\nodejs\'
+
+    process.env.PATH.split(path.delimiter)
+// returns
+//        ['C:\Windows\system32', 'C:\Windows', 'C:\Program Files\nodejs\']
+
+    path.parse('/home/user/dir/file.txt')
+// returns
+//    {
+//        root : "/",
+//        dir : "/home/user/dir",
+//        base : "file.txt",
+//        ext : ".txt",
+//        name : "file"
+//    }
+
+    path.parse('C:\\path\\dir\\index.html')
+// returns
+//    {
+//        root : "C:\",
+//        dir : "C:\path\dir",
+//        base : "index.html",
+//        ext : ".html",
+//        name : "index"
+//    }
+
+    path.format({
+        root : "/",
+        dir : "/home/user/dir",
+        base : "file.txt",
+        ext : ".txt",
+        name : "file"
+    });
+// returns
+//    '/home/user/dir/file.txt'
+}
+
+////////////////////////////////////////////////////
+///ReadLine tests : https://nodejs.org/api/readline.html
+////////////////////////////////////////////////////
+
+var rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+rl.setPrompt("$>");
+rl.prompt();
+rl.prompt(true);
+
+rl.question("do you like typescript?", function(answer: string) {
+  rl.close();
+});
+
+//////////////////////////////////////////////////////////////////////
+/// Child Process tests: https://nodejs.org/api/child_process.html ///
+//////////////////////////////////////////////////////////////////////
+
+childProcess.exec("echo test");
+childProcess.spawnSync("echo test");

--- a/node/node-0.12.d.ts
+++ b/node/node-0.12.d.ts
@@ -1,11 +1,11 @@
-// Type definitions for Node.js v4.x
+// Type definitions for Node.js v0.12.0
 // Project: http://nodejs.org/
 // Definitions by: Microsoft TypeScript <http://typescriptlang.org>, DefinitelyTyped <https://github.com/borisyankov/DefinitelyTyped>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /************************************************
 *                                               *
-*               Node.js v4.x API                *
+*               Node.js v0.12.0 API             *
 *                                               *
 ************************************************/
 
@@ -430,21 +430,6 @@ declare module "http" {
     import * as events from "events";
     import * as net from "net";
     import * as stream from "stream";
-    
-    export interface RequestOptions {
-        protocol?: string;
-        host?: string;
-        hostname?: string;
-        family?: number;
-        port?: number
-        localAddress?: string;
-        socketPath?: string;
-        method?: string;
-        path?: string;
-        headers?: { [key: string]: any };
-        auth?: string;
-        agent?: Agent;
-    }
 
     export interface Server extends events.EventEmitter {
         listen(port: number, hostname?: string, backlog?: number, callback?: Function): Server;
@@ -583,7 +568,7 @@ declare module "http" {
     };
     export function createServer(requestListener?: (request: IncomingMessage, response: ServerResponse) =>void ): Server;
     export function createClient(port?: number, host?: string): any;
-    export function request(options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
+    export function request(options: any, callback?: (res: IncomingMessage) => void): ClientRequest;
     export function get(options: any, callback?: (res: IncomingMessage) => void): ClientRequest;
     export var globalAgent: Agent;
 }
@@ -733,7 +718,15 @@ declare module "https" {
         SNICallback?: (servername: string) => any;
     }
 
-    export interface RequestOptions extends http.RequestOptions{
+    export interface RequestOptions {
+        host?: string;
+        hostname?: string;
+        port?: number;
+        path?: string;
+        method?: string;
+        headers?: any;
+        auth?: string;
+        agent?: any;
         pfx?: any;
         key?: any;
         passphrase?: string;
@@ -741,7 +734,6 @@ declare module "https" {
         ca?: any;
         ciphers?: string;
         rejectUnauthorized?: boolean;
-        secureProtocol?: string;
     }
 
     export interface Agent {
@@ -766,7 +758,7 @@ declare module "punycode" {
     export function toASCII(domain: string): string;
     export var ucs2: ucs2;
     interface ucs2 {
-        decode(string: string): number[];
+        decode(string: string): string;
         encode(codePoints: number[]): string;
     }
     export var version: any;


### PR DESCRIPTION
**Summary**
- Archived the current node.d.ts into node-0.12.d.ts.
- Archived the current node-tests.ts into node-0.12-tests.ts.
- Created `http.RequestOptions` again for 4.x and modified `http.request()` accordingly.
- Modified `https.RequestOptions` to correctly extend `http.RequestOptions`.

**Notes:**
The current node.d.ts should now track 4.x, continuing the pattern we followed for previous node versions.
We may have to repeat this process for 5.x at some point, but I wanted to separate out 4.x from 0.12.x first.

**References:**
https://nodejs.org/docs/v4.2.2/api/http.html#http_http_request_options_callback
https://nodejs.org/docs/v4.2.2/api/https.html#https_https_request_options_callback
