### PR TITLE
Exposed XML classes

### DIFF
--- a/xmlbuilder/xmlbuilder-tests.ts
+++ b/xmlbuilder/xmlbuilder-tests.ts
@@ -1,7 +1,8 @@
 /// <reference path="xmlbuilder.d.ts" />
 
 import xmlbuilder = require('xmlbuilder');
-var xml = xmlbuilder.create;
+var builder = xmlbuilder.builder;
+var xml = builder.create;
 
 // https://github.com/oozcitak/xmlbuilder-js/blob/master/test/comment.coffee
 xml('comment', {}, {}, { headless: true }).comment('<>\'"&\t\n\r').end();

--- a/xmlbuilder/xmlbuilder-tests.ts
+++ b/xmlbuilder/xmlbuilder-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="xmlbuilder.d.ts" />
 
 import xmlbuilder = require('xmlbuilder');
-var builder = xmlbuilder.builder;
+var builder = xmlbuilder.xmlbuilder
 var xml = builder.create;
 
 // https://github.com/oozcitak/xmlbuilder-js/blob/master/test/comment.coffee

--- a/xmlbuilder/xmlbuilder.d.ts
+++ b/xmlbuilder/xmlbuilder.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module 'xmlbuilder' {
-    class XMLDocType {
+    export class XMLDocType {
         clone(): XMLDocType;
         element(name: string, value?: Object): XMLDocType;
         attList(elementName: string, attributeName: string, attributeType: string, defaultValueType?: string, defaultValue?: any): XMLDocType;
@@ -30,7 +30,7 @@ declare module 'xmlbuilder' {
         doc(): any;
     }
 
-    class XMLElementOrXMLNode {
+    export class XMLElementOrXMLNode {
         // XMLElement:
         clone(): XMLElementOrXMLNode;
         attribute(name: any, value?: any): XMLElementOrXMLNode;
@@ -82,13 +82,7 @@ declare module 'xmlbuilder' {
         u(): XMLElementOrXMLNode;
     }
 
-    module xmlbuilder {
+    export module xmlbuilder {
         function create(name: string, xmldec?: Object, doctype?: any, options?: Object): XMLElementOrXMLNode;
-    }
-    
-    export = {
-      builder: xmlbuilder,
-      XMLDocType: XMLDocType,
-      XMLElementOrXMLNode: XMLElementOrXMLNode
     }
 }

--- a/xmlbuilder/xmlbuilder.d.ts
+++ b/xmlbuilder/xmlbuilder.d.ts
@@ -4,7 +4,6 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module 'xmlbuilder' {
-    export = xmlbuilder;
     class XMLDocType {
         clone(): XMLDocType;
         element(name: string, value?: Object): XMLDocType;
@@ -85,5 +84,11 @@ declare module 'xmlbuilder' {
 
     module xmlbuilder {
         function create(name: string, xmldec?: Object, doctype?: any, options?: Object): XMLElementOrXMLNode;
+    }
+    
+    export = {
+      builder: xmlbuilder,
+      XMLDocType: XMLDocType,
+      XMLElementOrXMLNode: XMLElementOrXMLNode
     }
 }


### PR DESCRIPTION
This is a breaking change since it will affect how you import this library in TypeScript.  This is needed so you can pass XML instances between various methods without losing type safety and code hinting.
