### PR TITLE
More specific type constraints

### DIFF
--- a/react-redux/react-redux-tests.tsx
+++ b/react-redux/react-redux-tests.tsx
@@ -76,7 +76,7 @@ React.render((
 // https://github.com/rackt/react-redux/blob/master/docs/api.md
 //
 declare var routes: Route;
-declare var store: Store;
+declare var store: Store<any>;
 declare var routerState: RouterState;
 class MyRootComponent extends Component<any, any> {
 

--- a/react-redux/react-redux.d.ts
+++ b/react-redux/react-redux.d.ts
@@ -54,11 +54,11 @@ declare module "react-redux" {
     pure: boolean;
   }
 
-  export interface Property<T> {
+  export interface Property<S> {
     /**
      * The single Redux store in your application.
      */
-    store?: Store<T>;
+    store?: Store<S>;
     children?: Function;
   }
 

--- a/react-redux/react-redux.d.ts
+++ b/react-redux/react-redux.d.ts
@@ -54,16 +54,16 @@ declare module "react-redux" {
     pure: boolean;
   }
 
-  export interface Property {
+  export interface Property<T> {
     /**
      * The single Redux store in your application.
      */
-    store?: Store;
+    store?: Store<T>;
     children?: Function;
   }
 
   /**
    * Makes the Redux store available to the connect() calls in the component hierarchy below.
    */
-  export class Provider extends Component<Property, {}> { }
+  export class Provider extends Component<Property<any>, {}> { }
 }

--- a/redux-devtools/redux-devtools-tests.tsx
+++ b/redux-devtools/redux-devtools-tests.tsx
@@ -8,12 +8,12 @@ import { DevTools, DebugPanel, LogMonitor } from 'redux-devtools/lib/react';
 import * as React from 'react';
 import { Component } from 'react';
 
-declare var m1: Middleware;
-declare var m2: Middleware;
-declare var m3: Middleware;
-declare var reducer: Reducer;
+declare var m1: Middleware<any>;
+declare var m2: Middleware<any>;
+declare var m3: Middleware<any>;
+declare var reducer: Reducer<any>;
 class CounterApp extends Component<any, any> { };
-class Provider extends Component<{ store: any }, any> { };
+class Provider extends Component<{ store: Redux.Store<any> }, any> { };
 
 const finalCreateStore = compose(
     // Enables your middleware:
@@ -23,7 +23,11 @@ const finalCreateStore = compose(
     // Lets you write ?debug_session=<name> in address bar to persist debug sessions
     persistState(window.location.href.match(/[?&]debug_session=([^&]+)\b/))
 )(createStore);
-const store = finalCreateStore(reducer);
+const store: Redux.Store<any> = finalCreateStore(reducer);
+
+// If you have components with parameterized types, you need to create a
+// class that binds those types before you try to use them in JSX.
+class MyDevTools extends DevTools<any, any> { }
 
 class Root extends Component<any, any> {
     render() {
@@ -33,7 +37,7 @@ class Root extends Component<any, any> {
                     {() => <CounterApp />}
                 </Provider>
                 <DebugPanel top right bottom>
-                    <DevTools store={store} monitor={LogMonitor} />
+                    <MyDevTools store={store} monitor={LogMonitor} />
                 </DebugPanel>
             </div>
         );
@@ -52,7 +56,7 @@ class App extends Component<any, any> {
                     {() => <CounterApp />}
                 </Provider>
                 <DebugPanel top right bottom>
-                    <DevTools store={store}
+                    <MyDevTools store={store}
                         monitor={LogMonitor}
                         visibleOnLoad={true} />
                 </DebugPanel>

--- a/redux-devtools/redux-devtools.d.ts
+++ b/redux-devtools/redux-devtools.d.ts
@@ -14,24 +14,24 @@ declare module "redux-devtools" {
 declare module "redux-devtools/lib/react" {
     import * as React from 'react';
 
-    export class DevTools extends React.Component<any, any> {
+    export class DevTools<P,S> extends React.Component<P, S> {
 
     }
 
-    export interface DevToolsProps {
+    export interface DevToolsProps<S> {
         monitor: Function;
-        store: Store;
+        store: Store<S>;
     }
 
-    export interface Store {
-        devToolStore: DevToolStore;
+    export interface Store<S> {
+        devToolStore: DevToolStore<S>;
     }
 
-    export class DevToolStore extends React.Component<any, any> {
-        dispatch: Function;
+    export class DevToolStore<S> extends React.Component<void, S> {
+        dispatch: Redux.Dispatch;
     }
 
-    export class DebugPanel extends React.Component<DebugPanelProps, any> { }
+    export class DebugPanel extends React.Component<DebugPanelProps, void> { }
 
     export interface DebugPanelProps {
         position?: string;
@@ -52,10 +52,10 @@ declare module "redux-devtools/lib/react" {
         getStyle?: () => DebugPanelProps;
     }
 
-    export class LogMonitor extends React.Component<LogMonitorProps, any> { }
+    export class LogMonitor<S> extends React.Component<LogMonitorProps<S>, void> { }
 
-    export interface LogMonitorProps {
-        computedStates?: ComputedState[];
+    export interface LogMonitorProps<S> {
+        computedStates?: ComputedState<S>[];
         currentStateIndex?: number;
         monitorState?: MonitorState;
         stagedActions?: Action[];
@@ -72,13 +72,13 @@ declare module "redux-devtools/lib/react" {
         theme?: Theme|string;
     }
 
-    export interface ComputedState {
-        state?: any;
+    export interface ComputedState<T> {
+        state?: T;
         error?: string;
     }
 
     export interface MonitorState {
-        isViaible?: boolean;
+        isViable?: boolean;
     }
 
     export interface Action {
@@ -106,4 +106,3 @@ declare module "redux-devtools/lib/react" {
         base0F: string;
     }
 }
-

--- a/redux-logger/redux-logger.d.ts
+++ b/redux-logger/redux-logger.d.ts
@@ -7,16 +7,17 @@
 
 declare module 'redux-logger' {
 
-  interface ReduxLoggerOptions {
-    actionTransformer?: (action: any) => any;
+  // In this case, T is the type that represents the state involved.
+  interface ReduxLoggerOptions<T> {
+    actionTransformer?: (action: Redux.Action) => Redux.Action;
     collapsed?: boolean;
     duration?: boolean;
     level?: string;
     logger?: any;
-    predicate?: (getState: Function, action: any) => boolean;
+    predicate?: (getState: () => T, action: Redux.Action) => boolean;
     timestamp?: boolean;
-    transformer?: (state:any) => any;
+    transformer?: (state:T) => any;
   }
 
-  export default function createLogger(options?: ReduxLoggerOptions): Redux.Middleware;
+  export default function createLogger<T>(options?: ReduxLoggerOptions<T>): Redux.Middleware<T>;
 }

--- a/redux-thunk/redux-thunk.d.ts
+++ b/redux-thunk/redux-thunk.d.ts
@@ -8,10 +8,10 @@
 declare module "redux-thunk" {
     import { Middleware, Dispatch } from 'redux';
 
-    export interface Thunk<T> extends Middleware<T> { }
+    export interface Thunk<S> extends Middleware<S> { }
 
     export interface ThunkInterface {
-        <T>(dispatch: Dispatch, getState?: () => T): any;
+        <S>(dispatch: Dispatch, getState?: () => S): any;
     }
 
     var thunk: Thunk<any>;

--- a/redux-thunk/redux-thunk.d.ts
+++ b/redux-thunk/redux-thunk.d.ts
@@ -8,13 +8,13 @@
 declare module "redux-thunk" {
     import { Middleware, Dispatch } from 'redux';
 
-    export interface Thunk extends Middleware { }
+    export interface Thunk<T> extends Middleware<T> { }
 
     export interface ThunkInterface {
         <T>(dispatch: Dispatch, getState?: () => T): any;
     }
 
-    var thunk: Thunk;
+    var thunk: Thunk<any>;
 
     export default thunk;
 }

--- a/redux-thunk/redux-thunk.d.ts
+++ b/redux-thunk/redux-thunk.d.ts
@@ -18,4 +18,3 @@ declare module "redux-thunk" {
 
     export default thunk;
 }
-

--- a/redux/redux-tests.ts
+++ b/redux/redux-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./redux.d.ts" />
 
-function counter(state: any, action: any) {
+function counter(state: number, action: Redux.Action) {
     if (!state) {
         state = 0;
     }
@@ -15,7 +15,7 @@ function counter(state: any, action: any) {
 }
 
 function loggingMiddleware() {
-    return (next: Redux.Dispatch) => (action: any) => {
+    return (next: Redux.Dispatch) => (action: Redux.Action) => {
         console.log(action.type);
         next(action);
     };

--- a/redux/redux.d.ts
+++ b/redux/redux.d.ts
@@ -24,8 +24,8 @@ declare module Redux {
         getState(): T;
     }
 
-	// Reducer is a function that takes a state of type T and an
-	// action and returns a new state, also of type T
+    // Reducer is a function that takes a state of type T and an
+    // action and returns a new state, also of type T
     interface Reducer<T> extends Function {
         (state: T, action: any): T;
     }
@@ -36,24 +36,24 @@ declare module Redux {
         <A extends Action>(action: A): A;
     }
 
-	// MiddlewareArg is an instance of middleware that provides a
-	// dispatch method and a getState method.  The type parameter T is
-	// the type of the state.  No type parameter is provided on
-	// Dispatch because the middleware generally needs to be able to
-	// handle any type of action.
+    // MiddlewareArg is an instance of middleware that provides a
+    // dispatch method and a getState method.  The type parameter T is
+    // the type of the state.  No type parameter is provided on
+    // Dispatch because the middleware generally needs to be able to
+    // handle any type of action.
     interface MiddlewareArg<T> {
         dispatch: Dispatch;
         getState: () => T;
     }
 
-	// Middleware is constructed from an instance of MiddlewareArg<T> where
-	// T is the type of the state.
+    // Middleware is constructed from an instance of MiddlewareArg<T> where
+    // T is the type of the state.
     interface Middleware<T> extends Function {
         (obj: MiddlewareArg<T>): Function;
     }
 
-	// Store manages the state of the system.  The state of the system
-	// should be of type T.
+    // Store manages the state of the system.  The state of the system
+    // should be of type T.
     class Store<T> {
         getReducer(): Reducer<T>;
         replaceReducer(nextReducer: Reducer<T>): void;
@@ -62,14 +62,14 @@ declare module Redux {
         subscribe(listener: () => void): () => void;
     }
 
-	// StoreCreator describes any function that can be used to create
-	// a Store<T> (where T is the type of the state).  This type is
-	// used to describe the return type of applyMiddleware since
-	// produces special function that can be used to create a store
-	// that integrates a collection of middleware.
-	interface StoreCreator<T> extends Function {
-		(reducer: Reducer<T>, initialState?: T): Store<T>;
-	}
+    // StoreCreator describes any function that can be used to create
+    // a Store<T> (where T is the type of the state).  This type is
+    // used to describe the return type of applyMiddleware since
+    // produces special function that can be used to create a store
+    // that integrates a collection of middleware.
+    interface StoreCreator<T> extends Function {
+        (reducer: Reducer<T>, initialState?: T): Store<T>;
+    }
 
     function createStore<T>(reducer: Reducer<T>, initialState?: T): Store<T>;
     function bindActionCreators<C>(actionCreators: C, dispatch: Dispatch): C;

--- a/redux/redux.d.ts
+++ b/redux/redux.d.ts
@@ -13,13 +13,13 @@ declare module Redux {
         meta?: any
     };
 
-	// Not used...?
-	interface ActionCreator extends Function {
+    // Not used...?
+    interface ActionCreator extends Function {
         (...args: any[]): Action;
     }
 
-	// Also not used here...
-	interface StoreMethods<T,A extends Action> {
+    // Also not used here...
+    interface StoreMethods<T,A extends Action> {
         dispatch: Dispatch;
         getState(): T;
     }
@@ -30,8 +30,8 @@ declare module Redux {
         (state: T, action: any): T;
     }
 
-	// Dispatch is a function that takes an action of type A and
-	// returns an instance of that same action (still of type A)
+    // Dispatch is a function that takes an action of type A and
+    // returns an instance of that same action (still of type A)
     interface Dispatch extends Function {
         <A extends Action>(action: A): A;
     }

--- a/redux/redux.d.ts
+++ b/redux/redux.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for Redux v3.0.0
 // Project: https://github.com/rackt/redux
-// Definitions by: William Buchwalter <https://github.com/wbuchwalter/>, Vincent Prouillet <https://github.com/Keats/>
+// Definitions by: William Buchwalter <https://github.com/wbuchwalter/>,
+//                 Vincent Prouillet <https://github.com/Keats/>,
+//                 Michael Tiller <https://github.com/xogeny/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module Redux {

--- a/redux/redux.d.ts
+++ b/redux/redux.d.ts
@@ -1,21 +1,21 @@
-// Type definitions for Redux v1.0.0
+// Type definitions for Redux v3.0.0
 // Project: https://github.com/rackt/redux
 // Definitions by: William Buchwalter <https://github.com/wbuchwalter/>, Vincent Prouillet <https://github.com/Keats/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module Redux {
     // Minimalist Action definition
-    type Action = {
+    interface Action {
         type: string;
     }
     
     // FSA-compliant action (from redux-actions.d.ts)
     // See: https://github.com/acdlite/flux-standard-action
-    type FluxStandardAction<P,M> extends Action = {
+    interface FluxStandardAction<P,M> extends Action {
         payload?: P
         error?: boolean
         meta?: M
-    };
+    }
 
     // Not used...?
     interface ActionCreator extends Function {

--- a/redux/redux.d.ts
+++ b/redux/redux.d.ts
@@ -23,7 +23,7 @@ declare module Redux {
     // Reducer is a function that takes a state of type S and an
     // action and returns a new state, also of type S
     interface Reducer<S> extends Function {
-        (state: T, action: any): S;
+        (state: S, action: any): S;
     }
 
     // Dispatch is a function that takes an action of type A and

--- a/redux/redux.d.ts
+++ b/redux/redux.d.ts
@@ -4,13 +4,17 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module Redux {
+    // Minimalist Action definition
+    type Action = {
+        type: string;
+    }
+    
     // FSA-compliant action (from redux-actions.d.ts)
     // See: https://github.com/acdlite/flux-standard-action
-    type Action = {
-        type: string
-        payload?: any
+    type FluxStandardAction<P,M> extends Action = {
+        payload?: P
         error?: boolean
-        meta?: any
+        meta?: M
     };
 
     // Not used...?

--- a/redux/redux.d.ts
+++ b/redux/redux.d.ts
@@ -4,46 +4,77 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module Redux {
+    // FSA-compliant action (from redux-actions.d.ts)
+    // See: https://github.com/acdlite/flux-standard-action
+    type Action = {
+        type: string
+        payload?: any
+        error?: boolean
+        meta?: any
+    };
 
-    interface ActionCreator extends Function {
-        (...args: any[]): any;
+	// Not used...?
+	interface ActionCreator extends Function {
+        (...args: any[]): Action;
     }
 
-    interface Reducer extends Function {
-        (state: any, action: any): any;
+	// Also not used here...
+	interface StoreMethods<T,A extends Action> {
+        dispatch: Dispatch;
+        getState(): T;
     }
 
+	// Reducer is a function that takes a state of type T and an
+	// action and returns a new state, also of type T
+    interface Reducer<T> extends Function {
+        (state: T, action: any): T;
+    }
+
+	// Dispatch is a function that takes an action of type A and
+	// returns an instance of that same action (still of type A)
     interface Dispatch extends Function {
-        (action: any): any;
+        <A extends Action>(action: A): A;
     }
 
-    interface StoreMethods {
+	// MiddlewareArg is an instance of middleware that provides a
+	// dispatch method and a getState method.  The type parameter T is
+	// the type of the state.  No type parameter is provided on
+	// Dispatch because the middleware generally needs to be able to
+	// handle any type of action.
+    interface MiddlewareArg<T> {
         dispatch: Dispatch;
-        getState(): any;
+        getState: () => T;
     }
 
-
-    interface MiddlewareArg {
-        dispatch: Dispatch;
-        getState: Function;
+	// Middleware is constructed from an instance of MiddlewareArg<T> where
+	// T is the type of the state.
+    interface Middleware<T> extends Function {
+        (obj: MiddlewareArg<T>): Function;
     }
 
-    interface Middleware extends Function {
-        (obj: MiddlewareArg): Function;
+	// Store manages the state of the system.  The state of the system
+	// should be of type T.
+    class Store<T> {
+        getReducer(): Reducer<T>;
+        replaceReducer(nextReducer: Reducer<T>): void;
+        dispatch<A extends Action>(action: A): A;
+        getState(): T;
+        subscribe(listener: () => void): () => void;
     }
 
-    class Store {
-        getReducer(): Reducer;
-        replaceReducer(nextReducer: Reducer): void;
-        dispatch(action: any): any;
-        getState(): any;
-        subscribe(listener: Function): Function;
-    }
+	// StoreCreator describes any function that can be used to create
+	// a Store<T> (where T is the type of the state).  This type is
+	// used to describe the return type of applyMiddleware since
+	// produces special function that can be used to create a store
+	// that integrates a collection of middleware.
+	interface StoreCreator<T> extends Function {
+		(reducer: Reducer<T>, initialState?: T): Store<T>;
+	}
 
-    function createStore(reducer: Reducer, initialState?: any): Store;
-    function bindActionCreators<T>(actionCreators: T, dispatch: Dispatch): T;
-    function combineReducers(reducers: any): Reducer;
-    function applyMiddleware(...middlewares: Middleware[]): Function;
+    function createStore<T>(reducer: Reducer<T>, initialState?: T): Store<T>;
+    function bindActionCreators<C>(actionCreators: C, dispatch: Dispatch): C;
+    function combineReducers<T>(reducers: { [key: string]: Reducer<T> }): Reducer<T>;
+    function applyMiddleware<T>(...middlewares: Middleware<T>[]): (c: StoreCreator<T>) => StoreCreator<T>;
     function compose<T extends Function>(...functions: Function[]): T;
 }
 

--- a/redux/redux.d.ts
+++ b/redux/redux.d.ts
@@ -8,14 +8,6 @@ declare module Redux {
     interface Action {
         type: string;
     }
-    
-    // FSA-compliant action (from redux-actions.d.ts)
-    // See: https://github.com/acdlite/flux-standard-action
-    interface FluxStandardAction<P,M> extends Action {
-        payload?: P
-        error?: boolean
-        meta?: M
-    }
 
     // Not used...?
     interface ActionCreator extends Function {
@@ -23,63 +15,63 @@ declare module Redux {
     }
 
     // Also not used here...
-    interface StoreMethods<T,A extends Action> {
+    interface StoreMethods<S,A extends Action> {
         dispatch: Dispatch;
-        getState(): T;
+        getState(): S;
     }
 
-    // Reducer is a function that takes a state of type T and an
-    // action and returns a new state, also of type T
-    interface Reducer<T> extends Function {
-        (state: T, action: any): T;
+    // Reducer is a function that takes a state of type S and an
+    // action and returns a new state, also of type S
+    interface Reducer<S> extends Function {
+        (state: T, action: any): S;
     }
 
     // Dispatch is a function that takes an action of type A and
     // returns an instance of that same action (still of type A)
     interface Dispatch extends Function {
-        <A extends Action>(action: A): A;
+        <A extends Action>(action: A): any;
     }
 
     // MiddlewareArg is an instance of middleware that provides a
-    // dispatch method and a getState method.  The type parameter T is
+    // dispatch method and a getState method.  The type parameter S is
     // the type of the state.  No type parameter is provided on
     // Dispatch because the middleware generally needs to be able to
     // handle any type of action.
-    interface MiddlewareArg<T> {
+    interface MiddlewareArg<S> {
         dispatch: Dispatch;
-        getState: () => T;
+        getState: () => S;
     }
 
-    // Middleware is constructed from an instance of MiddlewareArg<T> where
-    // T is the type of the state.
-    interface Middleware<T> extends Function {
-        (obj: MiddlewareArg<T>): Function;
+    // Middleware is constructed from an instance of MiddlewareArg<S> where
+    // S is the type of the state.
+    interface Middleware<S> extends Function {
+        (obj: MiddlewareArg<S>): Function;
     }
 
     // Store manages the state of the system.  The state of the system
-    // should be of type T.
-    class Store<T> {
-        getReducer(): Reducer<T>;
-        replaceReducer(nextReducer: Reducer<T>): void;
-        dispatch<A extends Action>(action: A): A;
-        getState(): T;
+    // should be of type S.
+    class Store<S> {
+        getReducer(): Reducer<S>;
+        replaceReducer(nextReducer: Reducer<S>): void;
+        dispatch<A extends Action>(action: A): any;
+        getState(): S;
         subscribe(listener: () => void): () => void;
     }
 
     // StoreCreator describes any function that can be used to create
-    // a Store<T> (where T is the type of the state).  This type is
+    // a Store<S> (where S is the type of the state).  This type is
     // used to describe the return type of applyMiddleware since
     // produces special function that can be used to create a store
     // that integrates a collection of middleware.
-    interface StoreCreator<T> extends Function {
-        (reducer: Reducer<T>, initialState?: T): Store<T>;
+    interface StoreCreator<S> extends Function {
+        (reducer: Reducer<S>, initialState?: S): Store<S>;
     }
 
-    function createStore<T>(reducer: Reducer<T>, initialState?: T): Store<T>;
+    function createStore<S>(reducer: Reducer<S>, initialState?: S): Store<S>;
     function bindActionCreators<C>(actionCreators: C, dispatch: Dispatch): C;
-    function combineReducers<T>(reducers: { [key: string]: Reducer<T> }): Reducer<T>;
-    function applyMiddleware<T>(...middlewares: Middleware<T>[]): (c: StoreCreator<T>) => StoreCreator<T>;
-    function compose<T extends Function>(...functions: Function[]): T;
+    function combineReducers<S>(reducers: { [key: string]: Reducer<S> }): Reducer<S>;
+    function applyMiddleware<S>(...middlewares: Middleware<S>[]): (c: StoreCreator<S>) => StoreCreator<S>;
+    function compose<F extends Function>(...functions: Function[]): F;
 }
 
 declare module "redux" {


### PR DESCRIPTION
I made an attempt to provide more specific type constraints in these definitions.  For example, a dispatch call returns its argument, so I tried to reflect that.  Similarly, a reducer always returns a value that is the same type as its first argument.  Furthermore, I added a type parameter to `Store` to indicate the type of state it is carrying around.

I also added a formal definition of `Action` so checks for things like the presence of `type` and `payload` can be made.

Using these definitions, the `redux-tests.ts` still passes, as is.  But this provides a lot more checking.  In addition, the presence of types provides some much needed documentation.  Even with the `redux` documentation, I had a hard time figuring out exactly what the arguments and return values should be.

Note that `ActionCreator` and `StoreMethods` are not used anywhere in this file.  I'm not sure what they are here for since they clearly are not part of the API.  I think they should really be removed but I left them in for some degree of backward compatibility.

I'm just starting to use `redux`, so I don't have a really thorough way to test this.
