### PR TITLE
lodash: signatures of the method _.uniqueId have been changed

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -5807,9 +5807,22 @@ module TestTimes {
 }
 
 // _.uniqueId
-result = <string>_.uniqueId();
-result = <string>_.uniqueId('');
-result = <string>_('').uniqueId();
+module TestUniqueId {
+    {
+        let result: string;
+
+        result = _.uniqueId();
+        result = _.uniqueId('');
+
+        result = _('').uniqueId();
+    }
+
+    {
+        let result: _.LoDashExplicitWrapper<string>;
+
+        result = _('').chain().uniqueId();
+    }
+}
 
 result = <string>_.VERSION;
 result = <_.Support>_.support;

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -11557,6 +11557,7 @@ declare module _ {
     interface LoDashStatic {
         /**
          * Generates a unique ID. If prefix is provided the ID is appended to it.
+         *
          * @param prefix The value to prefix the ID with.
          * @return Returns the unique ID.
          */
@@ -11568,6 +11569,13 @@ declare module _ {
          * @see _.uniqueId
          */
         uniqueId(): string;
+    }
+
+    interface LoDashExplicitWrapper<T> {
+        /**
+         * @see _.uniqueId
+         */
+        uniqueId(): LoDashExplicitWrapper<string>;
     }
 
     interface ListIterator<T, TResult> {


### PR DESCRIPTION
https://lodash.com/docs#uniqueId
https://lodash.com/docs#_ (description of the chainable wrapper)
