### PR TITLE
lodash: signatures of the method _.after have been changed

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -3262,17 +3262,33 @@ module TestNow {
 /*************
  * Functions *
  *************/
-var saves = ['profile', 'settings'];
-var asyncSave = (obj: any) => obj.done();
-var done: Function;
 
-done = _.after(saves.length, function () {
-    console.log('Done saving!');
-});
+// _after
+module TestAfter {
+    interface Func {
+        (a: string, b: number): boolean;
+    }
 
-done = _(saves.length).after(function () {
-    console.log('Done saving!');
-}).value();
+    let func: Func;
+
+    {
+        let result: Func;
+
+        _.after(42, func);
+    }
+
+    {
+        let result: _.LoDashImplicitObjectWrapper<Func>;
+
+        _(42).after(func);
+    }
+
+    {
+        let result: _.LoDashExplicitObjectWrapper<Func>;
+
+        _(42).chain().after(func);
+    }
+}
 
 // _.ary
 result = <number[]>['6', '8', '10'].map(_.ary<(s: string) => number>(parseInt, 1));

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -6779,22 +6779,30 @@ declare module _ {
     //_.after
     interface LoDashStatic {
         /**
-        * Creates a function that executes func, with the this binding and arguments of the
-        * created function, only after being called n times.
-        * @param n The number of times the function must be called before func is executed.
-        * @param func The function to restrict.
-        * @return The new restricted function.
-        **/
-        after(
+         * The opposite of _.before; this method creates a function that invokes func once it’s called n or more times.
+         *
+         * @param n The number of calls before func is invoked.
+         * @param func The function to restrict.
+         * @return Returns the new restricted function.
+         */
+        after<TFunc extends Function>(
             n: number,
-            func: Function): Function;
+            func: TFunc
+        ): TFunc;
     }
 
     interface LoDashImplicitWrapper<T> {
         /**
         * @see _.after
         **/
-        after(func: Function): LoDashImplicitObjectWrapper<Function>;
+        after<TFunc extends Function>(func: TFunc): LoDashImplicitObjectWrapper<TFunc>;
+    }
+
+    interface LoDashExplicitWrapper<T> {
+        /**
+         * @see _.after
+         **/
+        after<TFunc extends Function>(func: TFunc): LoDashExplicitObjectWrapper<TFunc>;
     }
 
     //_.ary


### PR DESCRIPTION
https://lodash.com/docs#after
https://lodash.com/docs#_ (description of the chainable wrapper)
