### PR TITLE
flow.js: fix `testChunks` spelling

### DIFF
--- a/flowjs/flowjs-tests.ts
+++ b/flowjs/flowjs-tests.ts
@@ -41,7 +41,7 @@ flowOptions.testMethod = "";
 flowOptions.uploadMethod = "";
 flowOptions.allowDuplicateUploads = true;
 flowOptions.prioritizeFirstAndLastChunk = true;
-flowOptions.testchunks = true;
+flowOptions.testChunks = true;
 flowOptions.preprocess = () => {};
 flowOptions.initFileFn = () => {};
 flowOptions.generateUniqueIdentifier = () => {};

--- a/flowjs/flowjs.d.ts
+++ b/flowjs/flowjs.d.ts
@@ -44,7 +44,7 @@ declare module flowjs {
         uploadMethod?: string;
         allowDuplicateUploads?: boolean;
         prioritizeFirstAndLastChunk?: boolean;
-        testchunks?: boolean;
+        testChunks?: boolean;
         preprocess?: Function;
         initFileFn?: Function;
         generateUniqueIdentifier?: Function;


### PR DESCRIPTION
Change `testchunks` to `testChunks`, according to https://github.com/flowjs/flow.js#configuration.
