### PR TITLE
lodash: signatures of the method _.once have been changed

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -3501,8 +3501,31 @@ result = <TestNegateResult>_(testNegatePredicate).negate().value();
 result = <TestNegateResult>_(testNegatePredicate).negate<TestNegateResult>().value();
 
 // _.once
-result = <() => void>_.once<() => void>(function () {});
-result = <() => void>(_(function () {}).once().value());
+module TestOnce {
+    interface Func {
+        (a: number, b: string): boolean;
+    }
+
+    let func: Func;
+
+    {
+        let result: Func;
+
+        result = _.once(func);
+    }
+
+    {
+        let result: _.LoDashImplicitObjectWrapper<Func>;
+
+        result = _(func).once();
+    }
+
+    {
+        let result: _.LoDashExplicitObjectWrapper<Func>;
+
+        result = _(func).chain().once();
+    }
+}
 
 var returnedOnce = _.throttle(function (a: any) { return a * 5; }, 5);
 returnedOnce(4);

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -7376,10 +7376,10 @@ declare module _ {
         /**
          * Creates a function that is restricted to invoking func once. Repeat calls to the function return the value
          * of the first call. The func is invoked with the this binding and arguments of the created function.
+         *
          * @param func The function to restrict.
          * @return Returns the new restricted function.
          */
-
         once<T extends Function>(func: T): T;
     }
 
@@ -7388,6 +7388,13 @@ declare module _ {
          * @see _.once
          */
         once(): LoDashImplicitObjectWrapper<T>;
+    }
+
+    interface LoDashExplicitObjectWrapper<T> {
+        /**
+         * @see _.once
+         */
+        once(): LoDashExplicitObjectWrapper<T>;
     }
 
     //_.partial


### PR DESCRIPTION
https://lodash.com/docs#once
https://lodash.com/docs#_ (description of the chainable wrapper)
