### PR TITLE
Kendo-ui: Pager.Page() not accepting a number

### DIFF
--- a/kendo-ui/kendo-ui.d.ts
+++ b/kendo-ui/kendo-ui.d.ts
@@ -4584,7 +4584,7 @@ declare module kendo.ui {
         dataSource: kendo.data.DataSource;
         totalPages(): number;
         pageSize(): number;
-        page(page: boolean): number;
+        page(page: number): number;
         refresh(): void;
         destroy(): void;
     }


### PR DESCRIPTION
Pager.Page() should accept a number (of the page to navigate to). Confirmed here:
http://www.telerik.com/forums/grid-pager-page()-parameter-typed-as-a-boolean
