### PR TITLE
Allow for custom keys in TileLayerOptions

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -4176,6 +4176,11 @@ declare namespace L {
           * When this option is set, the TileLayer only loads tiles that are in the given geographical bounds.
           */
         bounds?: LatLngBounds;
+        
+        /**
+          * Custom keys may be specified in TileLayerOptions so they can be used in a provided URL template.
+          */
+        [additionalKeys: string]: any;
     }
 }
 


### PR DESCRIPTION
According to https://github.com/Microsoft/TypeScript/issues/3755, properties not previously defined in a type will now be marked as errors during compilation in TypeScript 1.6 and later. 

Since a TileLayerOptions object is dynamically evaluated for custom properties that might be used in a provided tile URL template, the TypeScript change breaks this functionality.

The proposed change adds a string indexer (one of the suggested changes in the link above), which fixes the issue.
