### PR TITLE
add empty namespace declaration for chai-as-promised to allow es6 imports

### DIFF
--- a/chai-as-promised/chai-as-promised.d.ts
+++ b/chai-as-promised/chai-as-promised.d.ts
@@ -8,6 +8,7 @@
 
 declare module 'chai-as-promised' {
     function chaiAsPromised(chai: any, utils: any): void;
+    namespace chaiAsPromised {}
     export = chaiAsPromised;
 }
 


### PR DESCRIPTION
In order to be able to use the es6 import syntax with TypeScript an empty namespace must be added to the chaiAsPromised export. This is a known issue, see https://github.com/Microsoft/TypeScript/issues/5073, function export does not work with es6 imports. I didn't find a better/nicer way to solve this issue.
