### PR TITLE
three: Update comment for WebGLRenderer.clear

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -4686,7 +4686,7 @@ declare module THREE {
 
         /**
          * Tells the renderer to clear its color, depth or stencil drawing buffer(s).
-         * If no parameters are passed, no buffer will be cleared.
+         * Arguments default to true
          */
         clear(color?: boolean, depth?: boolean, stencil?: boolean): void;
 


### PR DESCRIPTION
See http://threejs.org/docs/#Reference/Renderers/WebGLRenderer:

> .clear ( color, depth, stencil )
> Tells the renderer to clear its color, depth or stencil drawing buffer(s).
> Arguments default to true.

I guess it must have changed a while ago.
