### PR TITLE
Fix jasmine: message is optional in CustomMatcherResult.

### DIFF
--- a/jasmine/jasmine-tests.ts
+++ b/jasmine/jasmine-tests.ts
@@ -813,7 +813,7 @@ var customMatchers: jasmine.CustomMatcherFactories = {
                 if (expected === undefined) {
                     expected = '';
                 }
-                var result: jasmine.CustomMatcherResult = { pass: false, message: ''};
+                var result: jasmine.CustomMatcherResult = { pass: false };
 
                 result.pass = util.equals(actual.hyuk, "gawrsh" + expected, customEqualityTesters);
 

--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -129,7 +129,7 @@ declare module jasmine {
 
     interface CustomMatcherResult {
         pass: boolean;
-        message: string;
+        message?: string;
     }
 
     interface MatchersUtil {


### PR DESCRIPTION
See http://jasmine.github.io/2.2/custom_matcher.html#section-Failure_Messages
