### PR TITLE
Fix "ThenBy" and "ThenByDescending" in linq.d.ts

### DIFF
--- a/linq/linq.d.ts
+++ b/linq/linq.d.ts
@@ -205,9 +205,9 @@ declare module linq {
     }
 
     interface OrderedEnumerable<T> extends Enumerable<T> {
-        ThenBy(keySelector: ($) => T): OrderedEnumerable<T>;
+        ThenBy(keySelector: ($: T) => any): OrderedEnumerable<T>;
         ThenBy(keySelector: string): OrderedEnumerable<T>;
-        ThenByDescending(keySelector: ($) => T): OrderedEnumerable<T>;
+        ThenByDescending(keySelector: ($: T) => any): OrderedEnumerable<T>;
         ThenByDescending(keySelector: string): OrderedEnumerable<T>;
     }
 


### PR DESCRIPTION
Fixes #6699

I changed the interface "OrderedEnumerable<T>" in "linq.d.ts". The methods "ThenBy" and
"ThenByDescending" now have the keySelector: ($: T) => any.
