### PR TITLE
Fix class export, Add additional module in jsuri.d.ts

### DIFF
--- a/jsuri/jsuri.d.ts
+++ b/jsuri/jsuri.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for jsUri 1.3+
 // Project: https://github.com/derek-watson/jsUri
-// Definitions by: Chris Charabaruk <http://github.com/coldacid>
+// Definitions by: Chris Charabaruk <http://github.com/coldacid>, Florian Wagner <http://github.com/flqw>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module jsuri {
@@ -135,5 +135,9 @@ declare module jsuri {
 declare type Uri = jsuri.Uri;
 
 declare module 'jsuri' {
-  export = Uri;
+  export = jsuri.Uri;
+}
+
+declare module 'jsUri' {
+  export = jsuri.Uri;
 }


### PR DESCRIPTION
Fixes the class export for development with IntelliJ, adds an additional module for bower_component naming compatibility.
