### PR TITLE
Bluebird catch, then, fromNode improvements

### DIFF
--- a/bluebird/bluebird-tests.ts
+++ b/bluebird/bluebird-tests.ts
@@ -80,6 +80,7 @@ var voidProm: Promise<void>;
 
 var fooProm: Promise<Foo>;
 var barProm: Promise<Bar>;
+var fooOrBarProm: Promise<Foo|Bar>;
 var bazProm: Promise<Baz>;
 
 // - - - - - - - - - - - - - - - - -
@@ -237,36 +238,96 @@ barProm = barProm.then((value: Bar) => {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-barProm = fooProm.catch((reason: any) => {
+fooProm = fooProm.catch((reason: any) => {
+	return;
+});
+
+fooProm = fooProm.caught((reason: any) => {
+	return;
+});
+fooProm = fooProm.catch((error: any) => {
+	return true;
+}, (reason: any) => {
+	return;
+});
+fooProm = fooProm.caught((error: any) => {
+	return true;
+}, (reason: any) => {
+	return;
+});
+
+fooProm = fooProm.catch((reason: any) => {
+	return voidProm;
+});
+
+fooProm = fooProm.caught((reason: any) => {
+	return voidProm;
+});
+fooProm = fooProm.catch((error: any) => {
+	return true;
+}, (reason: any) => {
+	return voidProm;
+});
+fooProm = fooProm.caught((error: any) => {
+	return true;
+}, (reason: any) => {
+	return voidProm;
+});
+
+fooProm = fooProm.catch((reason: any) => {
+	//handle multiple valid return types simultaneously
+	if (true) {
+		return;
+	} else if (false) {
+		return voidProm;
+	} else if (foo) {
+		return foo;
+	}
+});
+
+fooOrBarProm = fooProm.catch((reason: any) => {
 	return bar;
 });
-barProm = fooProm.caught((reason: any) => {
+fooOrBarProm = fooProm.caught((reason: any) => {
 	return bar;
 });
 
-barProm = fooProm.catch((reason: any) => {
-	return bar;
+fooOrBarProm = fooProm.catch((error: any) => {
+	return true;
 }, (reason: any) => {
 	return bar;
 });
-barProm = fooProm.caught((reason: any) => {
-	return bar;
+fooOrBarProm = fooProm.caught((error: any) => {
+	return true;
 }, (reason: any) => {
 	return bar;
 });
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-barProm = fooProm.catch(Error, (reason: any) => {
+fooProm = fooProm.catch(Error, (reason: any) => {
+	return;
+});
+fooProm = fooProm.catch(Promise.CancellationError, (reason: any) => {
+	return;
+});
+fooProm = fooProm.caught(Error, (reason: any) => {
+	return;
+});
+fooProm = fooProm.caught(Promise.CancellationError, (reason: any) => {
+	return;
+});
+
+fooOrBarProm = fooProm.catch(Error, (reason: any) => {
 	return bar;
 });
-barProm = fooProm.catch(Promise.CancellationError, (reason: any) => {
+fooOrBarProm = fooProm.catch(Promise.CancellationError, (reason: any) => {
 	return bar;
 });
-barProm = fooProm.caught(Error, (reason: any) => {
+fooOrBarProm = fooProm.caught(Error, (reason: any) => {
 	return bar;
 });
-barProm = fooProm.caught(Promise.CancellationError, (reason: any) => {
+fooOrBarProm = fooProm.caught(Promise.CancellationError, (reason: any) => {
 	return bar;
 });
 

--- a/bluebird/bluebird-tests.ts
+++ b/bluebird/bluebird-tests.ts
@@ -150,6 +150,7 @@ var BlueBird: typeof Promise;
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 var nodeCallbackFunc = (callback: (err: any, result: string) => void) => {}
+var nodeCallbackFuncErrorOnly = (callback: (err: any) => void) => {}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -678,6 +679,7 @@ func = Promise.promisify(f, obj);
 
 obj = Promise.promisifyAll(obj);
 anyProm = Promise.fromNode(callback => nodeCallbackFunc(callback));
+anyProm = Promise.fromNode(callback => nodeCallbackFuncErrorOnly(callback));
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/bluebird/bluebird-tests.ts
+++ b/bluebird/bluebird-tests.ts
@@ -229,6 +229,21 @@ barProm = fooProm.then((value: Foo) => {
 });
 barProm = fooProm.then((value: Foo) => {
 	return bar;
+}, (reason: any) => {
+	return barProm;
+});
+barProm = fooProm.then((value: Foo) => {
+	return bar;
+}, (reason: any) => {
+	return;
+});
+barProm = fooProm.then((value: Foo) => {
+	return bar;
+}, (reason: any) => {
+	return voidProm;
+});
+barProm = fooProm.then((value: Foo) => {
+	return bar;
 });
 barProm = barProm.then((value: Bar) => {
 	if (value) return value;

--- a/bluebird/bluebird.d.ts
+++ b/bluebird/bluebird.d.ts
@@ -25,9 +25,9 @@ declare class Promise<R> implements Promise.Thenable<R>, Promise.Inspection<R> {
 	/**
 	 * Promises/A+ `.then()` with progress handler. Returns a new promise chained from this promise. The new promise will be rejected or resolved dedefer on the passed `fulfilledHandler`, `rejectedHandler` and the state of this promise.
 	 */
-	then<U>(onFulfill: (value: R) => U|Promise.Thenable<U>, onReject: (error: any) => Promise.Thenable<U>, onProgress?: (note: any) => any): Promise<U>;
-	then<U>(onFulfill: (value: R) => U|Promise.Thenable<U>, onReject?: (error: any) => U, onProgress?: (note: any) => any): Promise<U>;
-
+	then<U>(onFulfill: (value: R) => U|Promise.Thenable<U>, onReject?: (error: any) => U|Promise.Thenable<U>, onProgress?: (note: any) => any): Promise<U>;
+	then<U>(onFulfill: (value: R) => U|Promise.Thenable<U>, onReject?: (error: any) => void|Promise.Thenable<void>, onProgress?: (note: any) => any): Promise<U>;
+	
 	/**
 	 * This is a catch-all exception handler, shortcut for calling `.then(null, handler)` on this promise. Any exception happening in a `.then`-chain will propagate to nearest `.catch` handler.
 	 *
@@ -672,8 +672,8 @@ declare module Promise {
 	export function OperationalError(): OperationalError;
 
 	export interface Thenable<R> {
-		then<U>(onFulfilled: (value: R) => U|Thenable<U>, onRejected: (error: any) => Thenable<U>): Thenable<U>;
-		then<U>(onFulfilled: (value: R) => U|Thenable<U>, onRejected?: (error: any) => U): Thenable<U>;
+		then<U>(onFulfilled: (value: R) => U|Thenable<U>, onRejected?: (error: any) => U|Thenable<U>): Thenable<U>;
+		then<U>(onFulfilled: (value: R) => U|Thenable<U>, onRejected?: (error: any) => void|Thenable<void>): Thenable<U>;
 	}
 
 	export interface Resolver<R> {

--- a/bluebird/bluebird.d.ts
+++ b/bluebird/bluebird.d.ts
@@ -33,11 +33,11 @@ declare class Promise<R> implements Promise.Thenable<R>, Promise.Inspection<R> {
 	 *
 	 * Alias `.caught();` for compatibility with earlier ECMAScript version.
 	 */
-	catch<U>(onReject?: (error: any) => Promise.Thenable<U>): Promise<U>;
-	caught<U>(onReject?: (error: any) => Promise.Thenable<U>): Promise<U>;
+	catch(onReject?: (error: any) => R|Promise.Thenable<R>|void|Promise.Thenable<void>): Promise<R>;
+	caught(onReject?: (error: any) => R|Promise.Thenable<R>|void|Promise.Thenable<void>): Promise<R>;
 
-	catch<U>(onReject?: (error: any) => U): Promise<U>;
-	caught<U>(onReject?: (error: any) => U): Promise<U>;
+	catch<U>(onReject?: (error: any) => U|Promise.Thenable<U>): Promise<U|R>;
+	caught<U>(onReject?: (error: any) => U|Promise.Thenable<U>): Promise<U|R>;
 
 	/**
 	 * This extends `.catch` to work more like catch-clauses in languages like Java or C#. Instead of manually checking `instanceof` or `.name === "SomeError"`, you may specify a number of error constructors which are eligible for this catch handler. The catch handler that is first met that has eligible constructors specified, is the one that will be called.
@@ -46,17 +46,18 @@ declare class Promise<R> implements Promise.Thenable<R>, Promise.Inspection<R> {
 	 *
 	 * Alias `.caught();` for compatibility with earlier ECMAScript version.
 	 */
-	catch<U>(predicate: (error: any) => boolean, onReject: (error: any) => Promise.Thenable<U>): Promise<U>;
-	caught<U>(predicate: (error: any) => boolean, onReject: (error: any) => Promise.Thenable<U>): Promise<U>;
+	catch(predicate: (error: any) => boolean, onReject: (error: any) => R|Promise.Thenable<R>|void|Promise.Thenable<void>): Promise<R>;
+	caught(predicate: (error: any) => boolean, onReject: (error: any) => R|Promise.Thenable<R>|void|Promise.Thenable<void>): Promise<R>;
 
-	catch<U>(predicate: (error: any) => boolean, onReject: (error: any) => U): Promise<U>;
-	caught<U>(predicate: (error: any) => boolean, onReject: (error: any) => U): Promise<U>;
+	catch<U>(predicate: (error: any) => boolean, onReject: (error: any) => U|Promise.Thenable<U>): Promise<U|R>;
+	caught<U>(predicate: (error: any) => boolean, onReject: (error: any) => U|Promise.Thenable<U>): Promise<U|R>;
 
-	catch<U>(ErrorClass: Function, onReject: (error: any) => Promise.Thenable<U>): Promise<U>;
-	caught<U>(ErrorClass: Function, onReject: (error: any) => Promise.Thenable<U>): Promise<U>;
+	catch(ErrorClass: Function, onReject: (error: any) => R|Promise.Thenable<R>|void|Promise.Thenable<void>): Promise<R>;
+	caught(ErrorClass: Function, onReject: (error: any) => R|Promise.Thenable<R>|void|Promise.Thenable<void>): Promise<R>;
 
-	catch<U>(ErrorClass: Function, onReject: (error: any) => U): Promise<U>;
-	caught<U>(ErrorClass: Function, onReject: (error: any) => U): Promise<U>;
+	catch<U>(ErrorClass: Function, onReject: (error: any) => U|Promise.Thenable<U>): Promise<U|R>;
+	caught<U>(ErrorClass: Function, onReject: (error: any) => U|Promise.Thenable<U>): Promise<U|R>;
+
 
 	/**
 	 * Like `.catch` but instead of catching all types of exceptions, it only catches those that don't originate from thrown errors but rather from explicit rejections.

--- a/bluebird/bluebird.d.ts
+++ b/bluebird/bluebird.d.ts
@@ -426,7 +426,7 @@ declare class Promise<R> implements Promise.Thenable<R>, Promise.Inspection<R> {
 	/**
 	 * Returns a promise that is resolved by a node style callback function.
 	 */
-	static fromNode(resolver: (callback: (err: any, result: any) => void) => void): Promise<any>;
+	static fromNode(resolver: (callback: (err: any, result?: any) => void) => void): Promise<any>;
 
 	/**
 	 * Returns a function that can use `yield` to run asynchronous code synchronously. This feature requires the support of generators which are drafted in the next version of the language. Node version greater than `0.11.2` is required and needs to be executed with the `--harmony-generators` (or `--harmony`) command-line switch.


### PR DESCRIPTION
- Allow void returns in catch/then blocks
- Support union types for catch handlers that really need to return a different type than the original promise
- Allow calling fromNode for a callback that doesn't expect a result parameter
