### PR TITLE
Added missing templateNamespace to ng.IDirective interface

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1660,6 +1660,7 @@ declare module angular {
         restrict?: string;
         scope?: any;
         template?: any;
+        templateNamespace?: string;
         templateUrl?: any;
         terminal?: boolean;
         transclude?: any;


### PR DESCRIPTION
Documentation taken from AngularJS file

**templateNamespace**
String representing the document type used by the markup in the template.
AngularJS needs this information as those elements need to be created and cloned
in a special way when they are defined outside their usual containers like `<svg>` and `<math>`.
- `html` - All root nodes in the template are HTML. Root nodes may also be
  top-level elements such as `<svg>` or `<math>`.
- `svg` - The root nodes in the template are SVG elements (excluding `<math>`).
- `math` - The root nodes in the template are MathML elements (excluding `<svg>`).
  If no `templateNamespace` is specified, then the namespace is considered to be `html`.
