### PR TITLE
Added FBResponseObject definition

### DIFF
--- a/fbsdk/fbsdk.d.ts
+++ b/fbsdk/fbsdk.d.ts
@@ -149,13 +149,17 @@ interface FBSDKCanvas{
     stopTimer(handler?: (fbResponseObject : Object) => any) : void;
 }
 
+interface FBResponseObject {
+    error: any;
+}
+
 interface FBSDK{
     /* This method is used to initialize and setup the SDK. */
     init(fbInitObject : FBInitParams) : void;
 
     /* This method lets you make calls to the Graph API. */
     api(path : string, method : string, callback : (fbResponseObject : Object) => any) :  Object;
-    api(path : string, params : Object, callback : (fbResponseObject : Object) => any) :  Object;
+    api(path : string, params : Object, callback : (fbResponseObject : FBResponseObject) => any) :  Object;
     api(path : string, method : string, params : Object, callback : (fbResponseObject : Object) => any) : Object;
 
     /* This method is used to trigger different forms of Facebook created UI dialogs. */


### PR DESCRIPTION
Typescript flags a "Property 'error' does not exist" message in the callback of a FB.api() call.
Example
function (response) {
    if (!response || **response.error**) {
        deferred.reject('Error occured');
    } else {
        deferred.resolve(response);
}
