### PR TITLE
Fix type of argument 'expression' of IFilterOrderBy to allow mixing functions and strings

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -774,7 +774,7 @@ declare module angular {
          * @param reverse Reverse the order of the array.
          * @return Reverse the order of the array.
          */
-        <T>(array: T[], expression: string|string[]|((value: T) => any)|((value: T) => any)[], reverse?: boolean): T[];
+        <T>(array: T[], expression: string|((value: T) => any)|(((value: T) => any)|string)[], reverse?: boolean): T[];
     }
 
     /**


### PR DESCRIPTION
OrderBy filter of angular supports mixing of strings and functions in the expressions array. 
The current type definition restricts the expressions to an array having either only strings or only functions.
