### PR TITLE
Missing signature for router.use

### DIFF
--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -110,6 +110,7 @@ declare module "express" {
             use(path: string[], handler: ErrorRequestHandler): T;
             use(path: RegExp, ...handler: RequestHandler[]): T;
             use(path: RegExp, handler: ErrorRequestHandler): T;
+            use(path:string, router:Router): T;
         }
 
         export function Router(options?: any): Router;


### PR DESCRIPTION
http://expressjs.com/4x/api.html#router.use => this function could be used with (path:string,router:router)
