### PR TITLE
nosafe param to Emscripten Module.getValue is optional

### DIFF
--- a/emscripten/emscripten-tests.ts
+++ b/emscripten/emscripten-tests.ts
@@ -11,6 +11,8 @@ function ModuleTest(): void {
 
     var myTypedArray = new Uint8Array(10);
     var buf = Module._malloc(myTypedArray.length*myTypedArray.BYTES_PER_ELEMENT);
+    Module.setValue(buf, 10, 'i32');
+    var x = Module.getValue(buf, 'i32') + 123;
     Module.HEAPU8.set(myTypedArray, buf);
     Module.ccall('my_function', 'number', ['number'], [buf]);
     Module._free(buf);

--- a/emscripten/emscripten.d.ts
+++ b/emscripten/emscripten.d.ts
@@ -22,8 +22,8 @@ declare module Module {
     function ccall(ident: string, returnType: string, argTypes: string[], args: any[]): any;
     function cwrap(ident: string, returnType: string, argTypes: string[]): any;
 
-    function setValue(ptr: number, value: any, type: string, noSafe: boolean): void;
-    function getValue(ptr: number, type: string, noSafe: boolean): any;
+    function setValue(ptr: number, value: any, type: string, noSafe?: boolean): void;
+    function getValue(ptr: number, type: string, noSafe?: boolean): number;
 
     var ALLOC_NORMAL: number;
     var ALLOC_STACK: number;


### PR DESCRIPTION
See [emscripten docs](http://kripken.github.io/emscripten-site/docs/api_reference/preamble.js.html#setValue).

`getValue` can retrieve a variety of types, but they're all numeric. So I set its return type to `number`.
