### PR TITLE
material-ui: Fix ThemeDecorator signature

### DIFF
--- a/material-ui/material-ui-tests.tsx
+++ b/material-ui/material-ui-tests.tsx
@@ -30,6 +30,7 @@ import Menu = require('material-ui/lib/menus/menu');
 import MenuItem = require('material-ui/lib/menus/menu-item');
 import MenuDivider = require('material-ui/lib/menus/menu-divider');
 import ThemeManager = require('material-ui/lib/styles/theme-manager');
+import ThemeDecorator = require('material-ui/lib/styles/theme-decorator');
 import GridList = require('material-ui/lib/grid-list/grid-list');
 import GridTile = require('material-ui/lib/grid-list/grid-tile');
 
@@ -45,6 +46,17 @@ type CheckboxProps = __MaterialUI.CheckboxProps;
 type MuiTheme = __MaterialUI.Styles.MuiTheme;
 type TouchTapEvent = __MaterialUI.TouchTapEvent;
 
+// "http://material-ui.com/#/customization/themes"
+let muiTheme: MuiTheme = ThemeManager.getMuiTheme({
+    palette: {
+        accent1Color: Colors.cyan100
+    },
+    spacing: {
+
+    }
+});
+
+@ThemeDecorator(muiTheme)
 class MaterialUiTests extends React.Component<{}, {}> implements React.LinkedStateMixin {
 
     // injected with mixin
@@ -60,16 +72,6 @@ class MaterialUiTests extends React.Component<{}, {}> implements React.LinkedSta
     }
 
     render() {
-
-        // "http://material-ui.com/#/customization/themes"
-        let muiTheme: MuiTheme = ThemeManager.getMuiTheme({
-            palette: {
-                accent1Color: Colors.cyan100
-            },
-            spacing: {
-
-            }
-        });
 
         // "http://material-ui.com/#/customization/inline-styles"
         let element: React.ReactElement<any>;
@@ -461,19 +463,19 @@ class MaterialUiTests extends React.Component<{}, {}> implements React.LinkedSta
             hintText="Password Field"
             floatingLabelText="Password"
             type="password" />;
-            
+
 
         // "http://material-ui.com/#/components/time-picker"
 
 
         // "http://material-ui.com/#/components/toolbars"
-        
+
         // "http://material-ui.com/#/components/grid-list"
         element = <GridList
             cols={3}
             padding={50}
             cellHeight={200} />;
-            
+
         element = <GridTile
             title="GridTileTitle"
             actionIcon={<h1>GridTile</h1>}

--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -71,7 +71,7 @@ declare module "material-ui" {
     export import ToolbarTitle = __MaterialUI.Toolbar.ToolbarTitle; // require('material-ui/lib/toolbar/toolbar-title');
     export import Tooltip = __MaterialUI.Tooltip; // require('material-ui/lib/tooltip');
     export import Utils = __MaterialUI.Utils; // require('material-ui/lib/utils/');
-    
+
     export import GridList = __MaterialUI.GridList.GridList; // require('material-ui/lib/gridlist/grid-list');
     export import GridTile = __MaterialUI.GridList.GridTile; // require('material-ui/lib/gridlist/grid-tile');
 
@@ -1048,7 +1048,7 @@ declare namespace __MaterialUI {
             palette: ThemePalette;
         }
 
-        export function ThemeDecorator(muiTheme: Styles.MuiTheme): <P>(Component: React.ComponentClass<P>) => React.ComponentClass<P>;
+        export function ThemeDecorator(muiTheme: Styles.MuiTheme): <TFunction extends Function>(Component: TFunction) => TFunction;
 
         interface ThemeManager {
             getMuiTheme(rawTheme: RawTheme): MuiTheme;
@@ -1479,18 +1479,18 @@ declare namespace __MaterialUI {
         export class MenuDivider extends React.Component<MenuDividerProps, {}>{
         }
     }
-    
+
     namespace GridList {
-        
+
         interface GridListProps extends React.Props<GridList> {
             cols?: number;
             padding?: number;
             cellHeight?: number;
         }
-        
+
         export class GridList extends React.Component<GridListProps, {}>{
         }
-        
+
         interface GridTileProps extends React.Props<GridTile> {
             title?: string;
             subtitle?: __React.ReactNode;
@@ -1502,10 +1502,10 @@ declare namespace __MaterialUI {
             rows?: number;
             rootClass?: string | __React.Component<any,any>;
         }
-        
+
         export class GridTile extends React.Component<GridTileProps, {}>{
         }
-        
+
     }
 }    // __MaterialUI
 


### PR DESCRIPTION
Currently material-ui ThemeDecorator is mistyped and triggers error
TS1238.
