### PR TITLE
Definition for karma-coverage

### DIFF
--- a/istanbul/istanbul-tests.ts
+++ b/istanbul/istanbul-tests.ts
@@ -1,0 +1,27 @@
+/// <reference path="istanbul.d.ts" />
+
+import * as istanbul from 'istanbul';
+
+// Instrument code
+var instrumenter = new istanbul.Instrumenter();
+
+var generatedCode = instrumenter.instrumentSync('function meaningOfLife() { return 42; }',
+    'filename.js');
+
+
+// Generate reports given a bunch of coverage JSON objects
+var collector = new istanbul.Collector(),
+    reporter = new istanbul.Reporter(),
+    sync = false;
+
+var obj1 = {},
+    obj2 = {};
+
+collector.add(obj1);
+collector.add(obj2); //etc.
+
+reporter.add('text');
+reporter.addAll([ 'lcov', 'clover' ]);
+reporter.write(collector, sync, function () {
+    console.log('All reports generated');
+});

--- a/istanbul/istanbul.d.ts
+++ b/istanbul/istanbul.d.ts
@@ -1,0 +1,73 @@
+// Type definitions for Istanbul v0.4.0
+// Project: https://github.com/gotwarlost/istanbul
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module 'istanbul' {
+  namespace istanbul {
+    interface Istanbul {
+      new (options?: any): Istanbul;
+      Collector: Collector;
+      config: Config;
+      ContentWriter: ContentWriter;
+      FileWriter: FileWriter;
+      hook: Hook;
+      Instrumenter: Instrumenter;
+      Report: Report;
+      Reporter: Reporter;
+      Store: Store;
+      utils: ObjectUtils;
+      VERSION: string;
+      Writer: Writer;
+    }
+
+    interface Collector {
+      new (options?: any): Collector;
+      add(coverage: any, testName?: string): void;
+    }
+
+    interface Config {
+    }
+
+    interface ContentWriter {
+    }
+
+    interface FileWriter {
+    }
+
+    interface Hook {
+    }
+
+    interface Instrumenter {
+      new (options?: any): Instrumenter;
+      instrumentSync(code: string, filename: string): string;
+    }
+
+    interface Report {
+    }
+
+    interface Configuration {
+      new (obj: any, overrides: any): Configuration;
+    }
+
+    interface Reporter {
+      new (cfg?: Configuration, dir?: string): Reporter;
+      add(fmt: string): void;
+      addAll(fmts: Array<string>): void;
+      write(collector: Collector, sync: boolean, callback: Function): void;
+    }
+
+    interface Store {
+    }
+
+    interface ObjectUtils {
+    }
+
+    interface Writer {
+    }
+  }
+
+  var istanbul: istanbul.Istanbul;
+
+  export = istanbul;
+}

--- a/karma-coverage/karma-coverage-tests.ts
+++ b/karma-coverage/karma-coverage-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="karma-coverage.d.ts" />
 
-import karma = require('karma');
+import * as karma from 'karma-coverage';
 
 
 // See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/README.md#basic

--- a/karma-coverage/karma-coverage-tests.ts
+++ b/karma-coverage/karma-coverage-tests.ts
@@ -1,0 +1,220 @@
+/// <reference path="karma-coverage.d.ts" />
+
+import karma = require('karma');
+
+
+// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/README.md#basic
+module.exports = function(config: karma.Config) {
+  config.set({
+    files: [
+      'src/**/*.js',
+      'test/**/*.js'
+    ],
+
+    // coverage reporter generates the coverage
+    reporters: ['progress', 'coverage'],
+
+    preprocessors: {
+      // source files, that you wanna generate coverage for
+      // do not include tests or libraries
+      // (these files will be instrumented by Istanbul)
+      'src/**/*.js': ['coverage']
+    },
+
+    // optionally, configure the reporter
+    coverageReporter: {
+      type : 'html',
+      dir : 'coverage/'
+    }
+  });
+};
+
+// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/README.md#advanced-multiple-reporters
+module.exports = function(config: karma.Config) {
+  config.set({
+    files: [
+      'src/**/*.js',
+      'test/**/*.js'
+    ],
+    reporters: ['progress', 'coverage'],
+    preprocessors: {
+      'src/**/*.js': ['coverage']
+    },
+    coverageReporter: {
+      // specify a common output directory
+      dir: 'build/reports/coverage',
+      reporters: [
+        // reporters not supporting the `file` property
+        { type: 'html', subdir: 'report-html' },
+        { type: 'lcov', subdir: 'report-lcov' },
+        // reporters supporting the `file` property, use `subdir` to directly
+        // output them in the `dir` directory
+        { type: 'cobertura', subdir: '.', file: 'cobertura.txt' },
+        { type: 'lcovonly', subdir: '.', file: 'report-lcovonly.txt' },
+        { type: 'teamcity', subdir: '.', file: 'teamcity.txt' },
+        { type: 'text', subdir: '.', file: 'text.txt' },
+        { type: 'text-summary', subdir: '.', file: 'text-summary.txt' },
+      ]
+    }
+  });
+};
+
+// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/README.md#dont-minify-instrumenter-output
+module.exports = function(config: karma.Config) {
+  config.set({
+    coverageReporter: {
+      instrumenterOptions: {
+        istanbul: { noCompact: true }
+      }
+    }
+  });
+};
+
+// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/docs/configuration.md#subdir
+module.exports = function(config: karma.Config) {
+  config.set({
+    coverageReporter: {
+      dir: 'coverage',
+      subdir: '.'
+      // Would output the results into: .'/coverage/'
+    }
+  });
+};
+
+module.exports = function(config: karma.Config) {
+  config.set({
+    coverageReporter: {
+      dir: 'coverage',
+      subdir: 'report'
+      // Would output the results into: .'/coverage/report/'
+    }
+  });
+};
+
+module.exports = function(config: karma.Config) {
+  config.set({
+    coverageReporter: {
+      dir: 'coverage',
+      subdir: function(browser) {
+        // normalization process to keep a consistent browser name accross different
+        // OS
+        return browser.toLowerCase().split(/[ /-]/)[0];
+      }
+      // Would output the results into: './coverage/firefox/'
+    }
+  });
+};
+
+// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/docs/configuration.md#file
+module.exports = function(config: karma.Config) {
+  config.set({
+    coverageReporter: {
+      type : 'text',
+      dir : 'coverage/',
+      file : 'coverage.txt'
+    }
+  });
+};
+
+// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/docs/configuration.md#check
+module.exports = function(config: karma.Config) {
+  config.set({
+    coverageReporter: {
+      check: {
+        global: {
+          statements: 50,
+          branches: 50,
+          functions: 50,
+          lines: 50,
+          excludes: [
+            'foo/bar/**/*.js'
+          ]
+        },
+        each: {
+          statements: 50,
+          branches: 50,
+          functions: 50,
+          lines: 50,
+          excludes: [
+            'other/directory/**/*.js'
+          ],
+          overrides: {
+            'baz/component/**/*.js': {
+              statements: 98
+            }
+          }
+        }
+      }
+    }
+  });
+};
+
+// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/docs/configuration.md#watermarks
+module.exports = function(config: karma.Config) {
+  config.set({
+    coverageReporter: {
+      watermarks: {
+        statements: [ 50, 75 ],
+        functions: [ 50, 75 ],
+        branches: [ 50, 75 ],
+        lines: [ 50, 75 ]
+      }
+    }
+  });
+};
+
+// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/docs/configuration.md#sourcestore
+module.exports = function(config: karma.Config) {
+  config.set({
+    coverageReporter: {
+      type : 'text',
+      dir : 'coverage/',
+      file : 'coverage.txt',
+      sourceStore : require('istanbul').Store.create('fslookup')
+    }
+  });
+};
+
+// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/docs/configuration.md#reporters
+module.exports = function(config: karma.Config) {
+  config.set({
+    coverageReporter: {
+      reporters:[
+        {type: 'html', dir:'coverage/'},
+        {type: 'teamcity'},
+        {type: 'text-summary'}
+      ],
+    }
+  });
+};
+
+// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/docs/configuration.md#instrumenter
+module.exports = function(config: karma.Config) {
+  config.set({
+    coverageReporter: {
+      instrumenters: { ibrik : require('ibrik') },
+      instrumenter: {
+        '**/*.coffee': 'ibrik'
+      },
+      // ...
+    }
+  });
+};
+
+var to5Options = { experimental: true };
+
+// [...]
+
+module.exports = function(config: karma.Config) {
+  config.set({
+    coverageReporter: {
+      instrumenters: { isparta : require('isparta') },
+      instrumenter: {
+        '**/*.js': 'isparta'
+      },
+      instrumenterOptions: {
+        isparta: { to5 : to5Options }
+      }
+    }
+  });
+};

--- a/karma-coverage/karma-coverage.d.ts
+++ b/karma-coverage/karma-coverage.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for karma-coverage v0.5.3
+// Project: https://github.com/karma-runner/karma-coverage
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../karma/karma.d.ts" />
+
+declare module 'karma' {
+  namespace karma {
+    interface ConfigOptions {
+      /**
+       * See https://github.com/karma-runner/karma-coverage/blob/master/docs/configuration.md
+       */
+      coverageReporter?: (Reporter|Reporter[]);
+    }
+
+    interface Reporter {
+      type?: string;
+      dir?: string;
+      subdir?: string | ((browser: string) => string);
+      check?: any;
+      watermarks?: any;
+      includeAllSources?: boolean;
+      sourceStore?: any; // Should be istanbul.Store
+      instrumenter?: any;
+    }
+  }
+}

--- a/karma-coverage/karma-coverage.d.ts
+++ b/karma-coverage/karma-coverage.d.ts
@@ -4,10 +4,20 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../karma/karma.d.ts" />
+/// <reference path="../istanbul/istanbul.d.ts" />
 
-declare module 'karma' {
-  namespace karma {
-    interface ConfigOptions {
+declare module 'karma-coverage' {
+  import * as karma from 'karma';
+  import * as istanbul from 'istanbul';
+
+  namespace karmaCoverage {
+    interface Karma extends karma.Karma {}
+
+    interface Config extends karma.Config {
+      set: (config: ConfigOptions) => void;
+    }
+
+    interface ConfigOptions extends karma.ConfigOptions {
       /**
        * See https://github.com/karma-runner/karma-coverage/blob/master/docs/configuration.md
        */
@@ -21,8 +31,12 @@ declare module 'karma' {
       check?: any;
       watermarks?: any;
       includeAllSources?: boolean;
-      sourceStore?: any; // Should be istanbul.Store
+      sourceStore?: istanbul.Store;
       instrumenter?: any;
     }
   }
+
+  var karmaCoverage: karmaCoverage.Karma;
+
+  export = karmaCoverage;
 }

--- a/karma/karma.d.ts
+++ b/karma/karma.d.ts
@@ -82,8 +82,8 @@ declare module 'karma' {
         interface ServerCallback {
             (exitCode: number): void;
         }
-        
-        interface Config { 
+
+        interface Config {
             set: (config: ConfigOptions) => void;
             LOG_DISABLE: string;
             LOG_ERROR: string;
@@ -91,7 +91,7 @@ declare module 'karma' {
             LOG_INFO: string;
             LOG_DEBUG: string;
         }
-        
+
         interface ConfigFile {
             configFile: string;
         }


### PR DESCRIPTION
Definitions for [karma-coverage](https://github.com/karma-runner/karma-coverage) and [Istanbul](https://github.com/gotwarlost/istanbul) (since karma-coverage uses Istanbul).

~~This is not to be merged for now.~~

~~I would like to add the definition for [karma-coverage](https://github.com/karma-runner/karma-coverage) but I could not find a way to "extend" an already defined interface (in this example one from [karma](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma/karma.d.ts#L99)) from another `.d.ts` file.~~

~~Help/working example welcome.~~
