### PR TITLE
Update c3.d.ts

### DIFF
--- a/c3/c3.d.ts
+++ b/c3/c3.d.ts
@@ -1067,3 +1067,7 @@ declare module c3 {
 
     export function generate(config: ChartConfiguration): ChartAPI;
 }
+
+declare module "c3" {
+    export = c3;
+}


### PR DESCRIPTION
Just a small change to declare c3 as an exported module so the definitions show up in AMD modules (e.g. when using require.js with Typescript).
