### PR TITLE
three: Add missing shadowMap WebGLRenderer member

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -4588,6 +4588,8 @@ declare module THREE {
             };
         };
 
+        shadowMap: WebGLShadowMapInstance;
+
         /**
          * Return the WebGL context.
          */


### PR DESCRIPTION
The `shadowMap` member was removed as part of #6743. I believe it was accidental since Three.js still has it (both in `master` and in `dev`).
