### PR TITLE
Highcharts: Remove jquery dependency

### DIFF
--- a/highcharts/highcharts-tests.ts
+++ b/highcharts/highcharts-tests.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="highcharts.d.ts" />
+/// <reference path="highcharts.d.ts" />
 /// <reference path="../jquery/jquery.d.ts" />
 
 function originalTests() {

--- a/highcharts/highcharts.d.ts
+++ b/highcharts/highcharts.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Damiano Gambarotto <http://github.com/damianog>, Dan Lewi Harkestad <http://github.com/baltie>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-/// <reference path='../jquery/jquery.d.ts' />
-
 interface HighchartsPosition {
     align?: string;
     verticalAlign?: string;

--- a/highcharts/highstock-tests.ts
+++ b/highcharts/highstock-tests.ts
@@ -1,4 +1,5 @@
-﻿/// <reference path="highstock.d.ts" /> 
+/// <reference path="highstock.d.ts" />
+/// <reference path="../jquery/jquery.d.ts" />
 
 var someData = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
@@ -46,7 +47,7 @@ $(function () {
             inputBoxHeight: 18,
             inputStyle: {
                 color: '#039',
-                fontWeight: 'bold'                
+                fontWeight: 'bold'
             },
             labelStyle: {
                 color: 'silver',
@@ -61,4 +62,3 @@ $(function () {
         }]
     });
 });
-

--- a/highcharts/highstock.d.ts
+++ b/highcharts/highstock.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for Highstock 2.1.5
+// Type definitions for Highstock 2.1.5
 // Project: http://www.highcharts.com/
 // Definitions by: David Deutsch <http://github.com/DavidKDeutsch>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped


### PR DESCRIPTION
Highcharts itself doesn't actually require jQuery to run. jQuery is an optional plugin. Since TypeScript automatically does interface composition, and jQuery component of Highcharts is implemented using interface, the `<reference>` is not required. Adding it causes `tsd` to pull in unnecessary dependency into people's project. 

Tasks performed:
- Remove jQuery referece from `.d.ts`
- Add jQuery reference to test file
- Strip BOM
