### PR TITLE
Returntypes improved

### DIFF
--- a/cordova-plugin-app-version/cordova-plugin-app-version.d.ts
+++ b/cordova-plugin-app-version/cordova-plugin-app-version.d.ts
@@ -3,13 +3,14 @@
 // Definitions by: Markus Wagner <https://github.com/Ritzlgrmft/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
+/// <reference path="../jquery/jquery.d.ts" />
 /// <reference path="../q/Q.d.ts" />
 
 interface Cordova {
-    getAppVersion: {
-		getAppName: () => Q.IPromise<string>;
-		getPackageName: () => Q.IPromise<string>;
-		getVersionCode: () => Q.IPromise<string>;
-		getVersionNumber: () => Q.IPromise<string>;
+	getAppVersion: {
+		getAppName: () => Q.IPromise<string> | JQueryPromise<string>;
+		getPackageName: () => Q.IPromise<string> | JQueryPromise<string>;
+		getVersionCode: () => Q.IPromise<string> | JQueryPromise<string>;
+		getVersionNumber: () => Q.IPromise<string> | JQueryPromise<string>;
 	};
 }


### PR DESCRIPTION
Depending on the available frameworks, the plugin uses either a promise from jQuery or from AngularJS. This behavior is now also respected in the definition file.
