### PR TITLE
Lowercase all built-in types

### DIFF
--- a/openpgp/openpgp.d.ts
+++ b/openpgp/openpgp.d.ts
@@ -22,7 +22,7 @@ declare module openpgp {
     }
 
     interface Keyid {
-        bytes: String,
+        bytes: string,
     }
 
     interface Signature {
@@ -31,7 +31,7 @@ declare module openpgp {
     }
 
     interface VerifiedMessage {
-        text: String,
+        text: string,
         signatures: Array<Signature>
     }
 
@@ -41,34 +41,34 @@ declare module openpgp {
         @param publicKeys array of keys to verify signatures
         @param msg the message object with signed and encrypted data
      */
-    function decryptAndVerifyMessage(privateKey: key.Key, publicKeys: Array<key.Key>, msg: String): Promise<VerifiedMessage>;
+    function decryptAndVerifyMessage(privateKey: key.Key, publicKeys: Array<key.Key>, msg: string): Promise<VerifiedMessage>;
     /** Decrypts message and verifies signatures
 
         @param privateKey private key with decrypted secret key data
         @param publicKey single key to verify signatures
         @param msg the message object with signed and encrypted data
      */
-    function decryptAndVerifyMessage(privateKey: key.Key, publicKey: key.Key, msg: String): Promise<VerifiedMessage>;
+    function decryptAndVerifyMessage(privateKey: key.Key, publicKey: key.Key, msg: string): Promise<VerifiedMessage>;
 
     /** Decrypts message
 
         @param privateKey private key with decrypted secret key data
         @param msg the message object with the encrypted data
      */
-    function decryptMessage(privateKey: key.Key, msg: message.Message): Promise<String>;
+    function decryptMessage(privateKey: key.Key, msg: message.Message): Promise<string>;
 
     /** Encrypts message text with keys
         @param keys array of keys used to encrypt the message
         @param text message as native JavaScript string
         @returns encrypted ASCII armored message
      */
-    function encryptMessage(keys: Array<key.Key>, message: string): Promise<String>;
+    function encryptMessage(keys: Array<key.Key>, message: string): Promise<string>;
     /** Encrypts message text with keys
 
         @param single key used to encrypt the message
         @param text message as native JavaScript string
      */
-    function encryptMessage(key: key.Key, message: string): Promise<String>;
+    function encryptMessage(key: key.Key, message: string): Promise<string>;
 
     /** Generates a new OpenPGP key pair. Currently only supports RSA keys. Primary and subkey will be of same type.
         @param options
@@ -81,27 +81,27 @@ declare module openpgp {
         @param privateKey private key with decrypted secret key data for signing
         @param text private key with decrypted secret key data for signing
      */
-    function signAndEncryptMessage(publicKeys: Array<key.Key>, privateKey: key.Key, text: String): Promise<String>;
+    function signAndEncryptMessage(publicKeys: Array<key.Key>, privateKey: key.Key, text: string): Promise<string>;
     /** Signs message text and encrypts it
 
         @param publicKeys single key used to encrypt the message
         @param privateKey private key with decrypted secret key data for signing
         @param text private key with decrypted secret key data for signing
      */
-    function signAndEncryptMessage(publicKey: key.Key, privateKey: key.Key, text: String): Promise<String>;
+    function signAndEncryptMessage(publicKey: key.Key, privateKey: key.Key, text: string): Promise<string>;
 
     /** Signs a cleartext message
-    
+
         @param privateKeys array of keys with decrypted secret key data to sign cleartext
         @param text cleartext
      */
-    function signClearMessage(privateKeys: Array<key.Key>, text: String): Promise<String>;
+    function signClearMessage(privateKeys: Array<key.Key>, text: string): Promise<string>;
     /** Signs a cleartext message
-    
+
         @param privateKeys single key with decrypted secret key data to sign cleartext
         @param text cleartext
      */
-    function signClearMessage(privateKey: key.Key, text: String): Promise<String>;
+    function signClearMessage(privateKey: key.Key, text: string): Promise<string>;
 
     /** Verifies signatures of cleartext signed message
 
@@ -126,13 +126,13 @@ declare module openpgp.armor {
         @param partindex
         @param parttotal
      */
-    function armor(messagetype: enums.armor, body: Object, partindex: Number, parttotal: Number): String;
+    function armor(messagetype: enums.armor, body: Object, partindex: number, parttotal: number): string;
 
     /** DeArmor an OpenPGP armored message; verify the checksum and return the encoded bytes
 
         @param text OpenPGP armored message
      */
-    function dearmor(text: String): Object;
+    function dearmor(text: string): Object;
 }
 
 declare module openpgp.cleartext {
@@ -142,7 +142,7 @@ declare module openpgp.cleartext {
     interface CleartextMessage {
         /** Returns ASCII armored text of cleartext signed message
          */
-        armor(): String;
+        armor(): string;
 
         /** Returns the key IDs of the keys that signed the cleartext message
          */
@@ -150,7 +150,7 @@ declare module openpgp.cleartext {
 
         /** Get cleartext
          */
-        getText(): String;
+        getText(): string;
 
         /** Sign the cleartext message
             @param privateKeys private keys with decrypted secret key data for signing
@@ -163,41 +163,41 @@ declare module openpgp.cleartext {
         verify(keys: Array<key.Key>): Array<VerifiedMessage>;
     }
 
-    function readArmored(armoredText: String): CleartextMessage;
+    function readArmored(armoredText: string): CleartextMessage;
 }
 
 declare module openpgp.config {
     var prefer_hash_algorithm: enums.hash;
     var encryption_cipher: enums.symmetric;
     var compression: enums.compression;
-    var show_version: Boolean;
-    var show_comment: Boolean;
-    var integrity_protect: Boolean;
-    var keyserver: String;
-    var debug: Boolean;
+    var show_version: boolean;
+    var show_comment: boolean;
+    var integrity_protect: boolean;
+    var keyserver: string;
+    var debug: boolean;
 }
 
 declare module openpgp.crypto {
     interface Mpi {
-        data: Number,
-        read(input: String): Number,
-        write(): String,
+        data: number,
+        read(input: string): number,
+        write(): string,
     }
 
     /** Generating a session key for the specified symmetric algorithm
         @param algo Algorithm to use
      */
-    function generateSessionKey(algo: enums.symmetric): String;
+    function generateSessionKey(algo: enums.symmetric): string;
 
     /** generate random byte prefix as string for the specified algorithm
         @param algo Algorithm to use
      */
-    function getPrefixRandom(algo: enums.symmetric): String;
+    function getPrefixRandom(algo: enums.symmetric): string;
 
     /** Returns the number of integers comprising the private key of an algorithm
         @param algo The public key algorithm
      */
-    function getPrivateMpiCount(algo: enums.symmetric): Number;
+    function getPrivateMpiCount(algo: enums.symmetric): number;
 
     /** Decrypts data using the specified public key multiprecision integers of the private key, the specified secretMPIs of the private key and the specified algorithm.
         @param algo Algorithm to be used
@@ -222,8 +222,8 @@ declare module openpgp.crypto.cfb {
         @param ciphertext to be decrypted provided as a string
         @param resync a boolean value specifying if a resync of the IV should be used or not. The encrypteddatapacket uses the "old" style with a resync. Decryption within an encryptedintegrityprotecteddata packet is not resyncing the IV.
      */
-    function decrypt(cipherfn: String, key: String, ciphertext: String, resync: Boolean): String;
-    
+    function decrypt(cipherfn: string, key: string, ciphertext: string, resync: boolean): string;
+
     /** This function encrypts a given with the specified prefixrandom using the specified blockcipher to encrypt a message
         @param prefixrandom random bytes of block_size length provided as a string to be used in prefixing the data
         @param cipherfn the algorithm cipher class to encrypt data in one block_size encryption
@@ -231,14 +231,14 @@ declare module openpgp.crypto.cfb {
         @param key binary string representation of key to be used to encrypt the plaintext. This will be passed to the cipherfn
         @param resync a boolean value specifying if a resync of the IV should be used or not. The encrypteddatapacket uses the "old" style with a resync. Encryption within an encryptedintegrityprotecteddata packet is not resyncing the IV.
      */
-    function encrypt(prefixrandom: String, cipherfn: String, plaintext: String, key: String, resync: Boolean): String;
-    
+    function encrypt(prefixrandom: string, cipherfn: string, plaintext: string, key: string, resync: boolean): string;
+
     /** Decrypts the prefixed data for the Modification Detection Code (MDC) computation
         @param cipherfn cipherfn.encrypt Cipher function to use
         @param key binary string representation of key to be used to check the mdc This will be passed to the cipherfn
         @param ciphertext The encrypted data
      */
-    function mdc(cipherfn: Object, key: String, ciphertext: String): String;
+    function mdc(cipherfn: Object, key: string, ciphertext: string): string;
 }
 
 declare module openpgp.crypto.hash {
@@ -246,35 +246,35 @@ declare module openpgp.crypto.hash {
         @param algo Hash algorithm type
         @param data Data to be hashed
      */
-    function digest(algo: enums.hash, data: String): String;
+    function digest(algo: enums.hash, data: string): string;
 
     /** Returns the hash size in bytes of the specified hash algorithm type
         @param algo Hash algorithm type
      */
-    function getHashByteLength(algo: enums.hash): Number;
+    function getHashByteLength(algo: enums.hash): number;
 }
 
 declare module openpgp.crypto.random {
     /** Create a secure random big integer of bits length
         @param bits Bit length of the MPI to create
      */
-    function getRandomBigInteger(bits: Number): Number;
-    
+    function getRandomBigInteger(bits: number): number;
+
     /** Retrieve secure random byte string of the specified length
         @param length Length in bytes to generate
      */
-    function getRandomBytes(length: Number): String;
-    
+    function getRandomBytes(length: number): string;
+
     /** Helper routine which calls platform specific crypto random generator
-        @param buf 
+        @param buf
      */
     function getRandomValues(buf: Uint8Array): void;
-    
+
     /** Return a secure random number in the specified range
         @param from Min of the random number
         @param to Max of the random number (max 32bit)
      */
-    function getSecureRandom(from: Number, to: Number): Number;
+    function getSecureRandom(from: number, to: number): number;
 }
 
 declare module openpgp.crypto.signature {
@@ -285,16 +285,16 @@ declare module openpgp.crypto.signature {
         @param secretMPIs Private key multiprecision integers which is used to sign the data
         @param data Data to be signed
      */
-    function sign(hash_algo: enums.hash, algo: enums.publicKey, publicMPIs: Array<Mpi>, secretMPIs: Array<Mpi>, data: String): Mpi;
+    function sign(hash_algo: enums.hash, algo: enums.publicKey, publicMPIs: Array<Mpi>, secretMPIs: Array<Mpi>, data: string): Mpi;
 
-    /** 
+    /**
         @param algo public Key algorithm
         @param hash_algo Hash algorithm
         @param msg_MPIs Signature multiprecision integers
         @param publickey_MPIs Public key multiprecision integers
         @param data Data on where the signature was computed on
      */
-    function verify(algo: enums.publicKey, hash_algo: enums.hash, msg_MPIs: Array<Mpi>, publickey_MPIs: Array<Mpi>, data: String): Boolean;
+    function verify(algo: enums.publicKey, hash_algo: enums.hash, msg_MPIs: Array<Mpi>, publickey_MPIs: Array<Mpi>, data: string): boolean;
 }
 
 declare module openpgp.enums {
@@ -409,7 +409,7 @@ declare module openpgp.key {
 
         @param armoredText text to be parsed
      */
-    function readArmored(armoredText: String): KeyResult;
+    function readArmored(armoredText: string): KeyResult;
 
 }
 
@@ -419,7 +419,7 @@ declare module openpgp.message {
     interface Message {
         /** Returns ASCII armored text of message
          */
-        armor(): String,
+        armor(): string,
 
         /** Decrypt the message
             @param privateKey private key with decrypted secret data
@@ -437,7 +437,7 @@ declare module openpgp.message {
 
         /** Get literal data that is the body of the message
          */
-        getLiteralData(): String,
+        getLiteralData(): string,
 
         /** Returns the key IDs of the keys that signed the message
          */
@@ -445,7 +445,7 @@ declare module openpgp.message {
 
         /** Get literal data as text
          */
-        getText(): String,
+        getText(): string,
 
         /** Sign the message (the literal data packet of the message)
             @param privateKey private keys with decrypted secret key data for signing
@@ -465,18 +465,18 @@ declare module openpgp.message {
     /** creates new message object from binary data
         @param bytes
      */
-    function fromBinary(bytes: String): Message;
+    function fromBinary(bytes: string): Message;
 
     /** creates new message object from text
         @param text
      */
-    function fromText(text: String): Message;
+    function fromText(text: string): Message;
 
     /** reads an OpenPGP armored message and returns a message object
 
         @param armoredText text to be parsed
      */
-    function readArmored(armoredText: String): Message;
+    function readArmored(armoredText: string): Message;
 }
 
 declare module openpgp.packet {
@@ -508,33 +508,33 @@ declare module openpgp.packet {
     /** Allocate a new packet
         @param property name from enums.packet
      */
-    function newPacketFromTag(tag: String): Object;
+    function newPacketFromTag(tag: string): Object;
 }
 
 declare module openpgp.util {
     /** Convert an array of integers(0.255) to a string
         @param bin An array of (binary) integers to convert
      */
-    function bin2str(bin: Array<Number>): String;
+    function bin2str(bin: Array<number>): string;
 
     /** Calculates a 16bit sum of a string by adding each character codes modulus 65535
-        @param text String to create a sum of
+        @param text string to create a sum of
      */
-    function calc_checksum(text: String): Number;
+    function calc_checksum(text: string): number;
 
     /** Convert a string of utf8 bytes to a native javascript string
         @param utf8 A valid squence of utf8 bytes
      */
-    function decode_utf8(utf8: String): String
+    function decode_utf8(utf8: string): string
 
     /** Convert a native javascript string to a string of utf8 bytes
         param str The string to convert
      */
-    function encode_utf8(str: String): String
+    function encode_utf8(str: string): string
 
     /** Return the algorithm type as string
      */
-    function get_hashAlgorithmString(): String
+    function get_hashAlgorithmString(): string
 
     /** Get native Web Cryptography api. The default configuration is to use the api when available. But it can also be deactivated with config.useWebCrypto
      */
@@ -543,48 +543,48 @@ declare module openpgp.util {
     /** Create binary string from a hex encoded string
         @param str Hex string to convert
      */
-    function hex2bin(str: String): String;
+    function hex2bin(str: string): string;
 
     /** Creating a hex string from an binary array of integers (0..255)
         @param str Array of bytes to convert
      */
-    function hexidump(str: String): String;
+    function hexidump(str: string): string;
 
     /** Create hexstring from a binary
-        @param str String to convert
+        @param str string to convert
      */
-    function hexstrdump(str: String): String;
-    
+    function hexstrdump(str: string): string;
+
     /** Helper function to print a debug message. Debug messages are only printed if
-        @param str String of the debug message
+        @param str string of the debug message
      */
-    function print_debug(str: String): void;
-    
+    function print_debug(str: string): void;
+
     /** Helper function to print a debug message. Debug messages are only printed if
-        @param str String of the debug message
+        @param str string of the debug message
      */
-    function print_debug_hexstr_dump(str: String): void;
-    
+    function print_debug_hexstr_dump(str: string): void;
+
     /** Shifting a string to n bits right
         @param value The string to shift
         @param bitcount Amount of bits to shift (MUST be smaller than 9)
      */
-    function shiftRight(value: String, bitcount: Number): String;
-    
+    function shiftRight(value: string, bitcount: number): string;
+
     /** Convert a string to an array of integers(0.255)
-        @param str String to convert
+        @param str string to convert
      */
-    function str2bin(str: String): Array<Number>;
-    
+    function str2bin(str: string): Array<number>;
+
     /** Convert a string to a Uint8Array
-        @param str String to convert
+        @param str string to convert
      */
-    function str2Uint8Array(str: String): Uint8Array;
-    
+    function str2Uint8Array(str: string): Uint8Array;
+
     /** Convert a Uint8Array to a string. This currently functions the same as bin2str.
         @param bin An array of (binary) integers to convert
      */
-    function Uint8Array2str(bin: Uint8Array): String;
+    function Uint8Array2str(bin: Uint8Array): string;
 
 
 }


### PR DESCRIPTION
Change `String` to `string`, `Number` to `number` and `Boolean` to `boolean`.
