### PR TITLE
ckeditor: added contentsLangDirection property

### DIFF
--- a/ckeditor/ckeditor.d.ts
+++ b/ckeditor/ckeditor.d.ts
@@ -564,6 +564,7 @@ declare module CKEDITOR {
         colorButton_enableMore?: boolean;
         colorButton_colors?: string;
         contentsCss?: string | string[];
+        contentsLangDirection?: string;
         customConfig?: string;
         extraPlugins?: string;
         font_names?: string;


### PR DESCRIPTION
Updated the ckeditor.config interface to add the missing contentsLangDirection string property (http://docs.ckeditor.com/source/config.html#CKEDITOR-config-cfg-contentsLangDirection).
