### PR TITLE
[leaflet] remove conflicting export var Control

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -337,7 +337,6 @@ declare module L {
         Layers: Control.LayersStatic;
         Scale: Control.ScaleStatic;
     }
-    export var Control: ControlStatic;
 
     export interface Control extends IControl {
         /**


### PR DESCRIPTION
The `leaflet.d.ts` includes an `export var Control`, `export interface Control`, and `export namespace Control`. The first two break the build using TypeScript 1.6 in Visual Studio. I have found that removing the `export var Control` fixes the problem for me.
