### PR TITLE
material-ui: Added type of <Badge> component

### DIFF
--- a/material-ui/material-ui-tests.tsx
+++ b/material-ui/material-ui-tests.tsx
@@ -7,6 +7,7 @@ import * as LinkedStateMixin from "react-addons-linked-state-mixin";
 import Checkbox = require("material-ui/lib/checkbox");
 import Colors = require("material-ui/lib/styles/colors");
 import AppBar = require("material-ui/lib/app-bar");
+import Badge = require("material-ui/lib/badge");
 import IconButton = require("material-ui/lib/icon-button");
 import FlatButton = require("material-ui/lib/flat-button");
 import Avatar = require("material-ui/lib/avatar");
@@ -132,6 +133,17 @@ class MaterialUiTests extends React.Component<{}, {}> implements React.LinkedSta
             backgroundColor={Colors.purple500}>
             </Avatar>
 
+        // "http://material-ui.com/#/components/badge"
+        element = <Badge badgeContent={<span>Hello</span>}>
+                    <Avatar color={Colors.deepOrange300} />
+                  </Badge>;
+        element = <Badge
+                    primary
+                    badgeContent={<span>Hello</span>}
+                    badgeStyle={{height: '24px', width: '24px'}}
+                  >
+                    This text has a badge!
+                  </Badge>;
 
         // "http://material-ui.com/#/components/buttons"
         element = <FlatButton linkButton={true} href="https://github.com/callemall/material-ui" secondary={true} label="GitHub">

--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -9,6 +9,7 @@ declare module "material-ui" {
     export import AppBar = __MaterialUI.AppBar; // require('material-ui/lib/app-bar');
     export import AppCanvas = __MaterialUI.AppCanvas; // require('material-ui/lib/app-canvas');
     export import Avatar = __MaterialUI.Avatar; // require('material-ui/lib/avatar');
+    export import Badge = __MaterialUI.Badge; // require('material-ui/lib/badge');
     export import BeforeAfterWrapper = __MaterialUI.BeforeAfterWrapper; // require('material-ui/lib/before-after-wrapper');
     export import Card = __MaterialUI.Card.Card; // require('material-ui/lib/card/card');
     export import CardActions = __MaterialUI.Card.CardActions; // require('material-ui/lib/card/card-actions');
@@ -135,6 +136,16 @@ declare namespace __MaterialUI {
         style?: React.CSSProperties;
     }
     export class Avatar extends React.Component<AvatarProps, {}> {
+    }
+
+    interface BadgeProps extends React.Props<Badge> {
+        badgeContent: React.ReactElement<any> | string | number;
+        primary?: boolean;
+        secondary?: boolean;
+        style?: React.CSSProperties;
+        badgeStyle?: React.CSSProperties;
+    }
+    export class Badge extends React.Component<BadgeProps, {}> {
     }
 
     interface BeforeAfterWrapperProps extends React.Props<BeforeAfterWrapper> {
@@ -1524,6 +1535,11 @@ declare module 'material-ui/lib/app-canvas' {
 declare module 'material-ui/lib/avatar' {
     import Avatar = __MaterialUI.Avatar;
     export = Avatar;
+}
+
+declare module "material-ui/lib/badge" {
+    import Badge = __MaterialUI.Badge;
+    export = Badge;
 }
 
 declare module 'material-ui/lib/before-after-wrapper' {


### PR DESCRIPTION
I found that material-ui.d.ts lacks type definition of `<Badge>` component.  I fixed it.
Documentation of the component is below.

http://material-ui.com/#/components/badge

Of course I confirmed that a test passed.
