### PR TITLE
Update react-addons-css-transition-group.d.ts with Timeout properties

### DIFF
--- a/react/react-addons-css-transition-group.d.ts
+++ b/react/react-addons-css-transition-group.d.ts
@@ -20,8 +20,11 @@ declare namespace __React {
     interface CSSTransitionGroupProps extends TransitionGroupProps {
         transitionName: string | CSSTransitionGroupTransitionName;
         transitionAppear?: boolean;
+        transitionAppearTimeout?: number;
         transitionEnter?: boolean;
+        transitionEnterTimeout?: number;
         transitionLeave?: boolean;
+        transitionLeaveTimeout?: number;
     }
     
     type CSSTransitionGroup = ComponentClass<CSSTransitionGroupProps>;


### PR DESCRIPTION
Added missing `transitionAppearTimeout`, `transitionEnterTimeout`, `transitionLeaveTimeout` to `CSSTransitionGroupProps`
