### PR TITLE
Improved WebContents type definition

### DIFF
--- a/github-electron/github-electron-main-tests.ts
+++ b/github-electron/github-electron-main-tests.ts
@@ -61,9 +61,11 @@ app.on('ready', () => {
 	mainWindow.loadUrl('file://foo/bar', {userAgent: 'cool-agent', httpReferrer: 'greateRefferer'});
 	mainWindow.webContents.loadUrl('file://foo/bar', {userAgent: 'cool-agent', httpReferrer: 'greateRefferer'});
 
-	mainWindow.openDevTools()
-	var opened: boolean = mainWindow.isDevToolsOpened()
-	mainWindow.toggleDevTools()
+	mainWindow.webContents.openDevTools();
+	mainWindow.webContents.toggleDevTools();
+	mainWindow.webContents.openDevTools({detach: true});
+	mainWindow.webContents.closeDevTools();
+	var opened: boolean = mainWindow.webContents.isDevToolsOpened()
 	// Emitted when the window is closed.
 	mainWindow.on('closed', () => {
 		// Dereference the window object, usually you would store windows
@@ -344,7 +346,7 @@ var template = [
 			{
 				label: 'Toggle DevTools',
 				accelerator: 'Alt+Command+I',
-				click: () => { BrowserWindow.getFocusedWindow().toggleDevTools(); }
+				click: () => { BrowserWindow.getFocusedWindow().webContents.toggleDevTools(); }
 			}
 		]
 	},

--- a/github-electron/github-electron-main-tests.ts
+++ b/github-electron/github-electron-main-tests.ts
@@ -65,6 +65,8 @@ app.on('ready', () => {
 	mainWindow.webContents.toggleDevTools();
 	mainWindow.webContents.openDevTools({detach: true});
 	mainWindow.webContents.closeDevTools();
+	mainWindow.webContents.addWorkSpace('/path/to/workspace');
+	mainWindow.webContents.removeWorkSpace('/path/to/workspace');
 	var opened: boolean = mainWindow.webContents.isDevToolsOpened()
 	// Emitted when the window is closed.
 	mainWindow.on('closed', () => {

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -711,6 +711,14 @@ declare module GitHubElectron {
 		 */
 		callback: (error: Error, data: Buffer) => void): void;
 		/**
+		 * Adds the specified path to DevTools workspace.
+		 */
+		addWorkSpace(path: string): void;
+		/**
+		 * Removes the specified path from DevTools workspace.
+		 */
+		removeWorkSpace(path: string): void;
+		/**
 		 * Opens the developer tools.
 		 */
 		openDevTools(options?: {

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -343,27 +343,6 @@ declare module GitHubElectron {
 		 * @returns Whether the window's document has been edited.
 		 */
 		isDocumentEdited(): boolean;
-		/**
-		 * Opens the developer tools.
-		 */
-		openDevTools(options?: {
-			/**
-			 * Opens devtools in a new window.
-			 */
-			detach?: boolean;
-		}): void;
-		/**
-		 * Closes the developer tools.
-		 */
-		closeDevTools(): void;
-		/**
-		 * Returns whether the developer tools are opened.
-		 */
-		isDevToolsOpened(): boolean;
-		/**
-		 * Toggle the developer tools.
-		 */
-		toggleDevTools(): void;
 		reloadIgnoringCache(): void;
 		/**
 		 * Starts inspecting element at position (x, y).
@@ -731,6 +710,27 @@ declare module GitHubElectron {
 		 *   data Buffer - PDF file content
 		 */
 		callback: (error: Error, data: Buffer) => void): void;
+		/**
+		 * Opens the developer tools.
+		 */
+		openDevTools(options?: {
+			/**
+			 * Opens devtools in a new window.
+			 */
+			detach?: boolean;
+		}): void;
+		/**
+		 * Closes the developer tools.
+		 */
+		closeDevTools(): void;
+		/**
+		 * Returns whether the developer tools are opened.
+		 */
+		isDevToolsOpened(): boolean;
+		/**
+		 * Toggle the developer tools.
+		 */
+		toggleDevTools(): void;
 		/**
 		 * Send args.. to the web page via channel in asynchronous message, the web page
 		 * can handle it by listening to the channel event of ipc module.


### PR DESCRIPTION
- DevTools-related methods are moved from BrowserWindow to WebContents

DevTools-related methods are no longer defined in `BrowserWindow`.

https://github.com/atom/electron/blob/master/docs/api/browser-window.md

Instead, they are defined in `WebContents`.

https://github.com/atom/electron/blob/master/docs/api/web-contents.md
- Added `addWorkSpace()` and `removeWorkSpace()` to WebContents
