### PR TITLE
Electron: Url to URL

### DIFF
--- a/github-electron/github-electron-main-tests.ts
+++ b/github-electron/github-electron-main-tests.ts
@@ -57,9 +57,9 @@ app.on('ready', () => {
 	mainWindow = new BrowserWindow({ width: 800, height: 600 });
 
 	// and load the index.html of the app.
-	mainWindow.loadUrl(`file://${__dirname}/index.html`);
-	mainWindow.loadUrl('file://foo/bar', {userAgent: 'cool-agent', httpReferrer: 'greateRefferer'});
-	mainWindow.webContents.loadUrl('file://foo/bar', {userAgent: 'cool-agent', httpReferrer: 'greateRefferer'});
+	mainWindow.loadURL(`file://${__dirname}/index.html`);
+	mainWindow.loadURL('file://foo/bar', {userAgent: 'cool-agent', httpReferrer: 'greateRefferer'});
+	mainWindow.webContents.loadURL('file://foo/bar', {userAgent: 'cool-agent', httpReferrer: 'greateRefferer'});
 
 	mainWindow.openDevTools()
 	var opened: boolean = mainWindow.isDevToolsOpened()
@@ -149,7 +149,7 @@ var onlineStatusWindow: GitHubElectron.BrowserWindow;
 
 app.on('ready', () => {
 	onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
-	onlineStatusWindow.loadUrl(`file://${__dirname}/online-status.html`);
+	onlineStatusWindow.loadURL(`file://${__dirname}/online-status.html`);
 });
 
 ipc.on('online-status-changed', (event: any, status: any) => {
@@ -165,7 +165,7 @@ app.on('ready', () => {
 		height: 600, 
 		'title-bar-style': 'hidden-inset',
 	});
-	window.loadUrl('https://github.com');
+	window.loadURL('https://github.com');
 });
 
 // Supported Chrome command line switches
@@ -179,7 +179,7 @@ app.commandLine.appendSwitch('vmodule', 'console=0');
 // auto-updater
 // https://github.com/atom/electron/blob/master/docs/api/auto-updater.md
 
-AutoUpdater.setFeedUrl('http://mycompany.com/myapp/latest?version=' + app.getVersion());
+AutoUpdater.setFeedURL('http://mycompany.com/myapp/latest?version=' + app.getVersion());
 
 // browser-window
 // https://github.com/atom/electron/blob/master/docs/api/browser-window.md
@@ -189,7 +189,7 @@ win.on('closed', () => {
 	win = null;
 });
 
-win.loadUrl('https://github.com');
+win.loadURL('https://github.com');
 win.show();
 
 // content-tracing
@@ -446,7 +446,7 @@ console.log(Clipboard.readText('selection'));
 CrashReporter.start({
 	productName: 'YourName',
 	companyName: 'YourCompany',
-	submitUrl: 'https://your-domain.com/url-to-submit',
+	submitURL: 'https://your-domain.com/url-to-submit',
 	autoSubmit: true
 });
 

--- a/github-electron/github-electron-renderer-tests.ts
+++ b/github-electron/github-electron-renderer-tests.ts
@@ -24,7 +24,7 @@ ipc.send('asynchronous-message', 'ping');
 
 var BrowserWindow: typeof GitHubElectron.BrowserWindow = remote.require('browser-window');
 var win = new BrowserWindow({ width: 800, height: 600 });
-win.loadUrl('https://github.com');
+win.loadURL('https://github.com');
 
 remote.getCurrentWindow().on('close', () => {
 	// blabla...
@@ -66,7 +66,7 @@ console.log(Clipboard.readText('selection'));
 CrashReporter.start({
 	productName: 'YourName',
 	companyName: 'YourCompany',
-	submitUrl: 'https://your-domain.com/url-to-submit',
+	submitURL: 'https://your-domain.com/url-to-submit',
 	autoSubmit: true
 });
 

--- a/github-electron/github-electron-renderer.d.ts
+++ b/github-electron/github-electron-renderer.d.ts
@@ -90,7 +90,7 @@ declare module GitHubElectron {
 		 * warnings. For example, https and data are secure schemes because they cannot be
 		 * corrupted by active network attackers.
 		 */
-		registerUrlSchemeAsSecure(scheme: string): void;
+		registerURLSchemeAsSecure(scheme: string): void;
 	}
 }
 

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -24,9 +24,9 @@ declare module GitHubElectron {
 		 */
 		static createFromBuffer(buffer: Buffer, scaleFactor?: number): NativeImage;
 		/**
-		 * Creates a new NativeImage instance from dataUrl
+		 * Creates a new NativeImage instance from dataURL
 		 */
-		static createFromDataUrl(dataUrl: string): NativeImage;
+		static createFromDataURL(dataURL: string): NativeImage;
 		/**
 		 * @returns Buffer Contains the image's PNG encoded data.
 		 */
@@ -38,7 +38,7 @@ declare module GitHubElectron {
 		/**
 		 * @returns string The data URL of the image.
 		 */
-		toDataUrl(): string;
+		toDataURL(): string;
 		/**
 		 * @returns boolean Whether the image is empty.
 		 */
@@ -398,9 +398,9 @@ declare module GitHubElectron {
 			landscape?: boolean;
 		}, callback: (error: Error, data: Buffer) => void): void;
 		/**
-		 * Same with webContents.loadUrl(url).
+		 * Same with webContents.loadURL(url).
 		 */
-		loadUrl(url: string, options?: {
+		loadURL(url: string, options?: {
 			httpReferrer?: string;
 			userAgent?: string;
 		}): void;
@@ -541,14 +541,14 @@ declare module GitHubElectron {
 		 * Loads the url in the window.
 		 * @param url Must contain the protocol prefix (e.g., the http:// or file://).
 		 */
-		loadUrl(url: string, options?: {
+		loadURL(url: string, options?: {
 			httpReferrer?: string;
 			userAgent?: string;
 		}): void;
 		/**
 		 * @returns The URL of current web page.
 		 */
-		getUrl(): string;
+		getURL(): string;
 		/**
 		 * @returns The title of web page.
 		 */
@@ -1108,9 +1108,9 @@ declare module GitHubElectron {
 		 * Set the url and initialize the auto updater.
 		 * The url cannot be changed once it is set.
 		 */
-		setFeedUrl(url: string): void;
+		setFeedURL(url: string): void;
 		/**
-		 * Ask the server whether there is an update, you have to call setFeedUrl
+		 * Ask the server whether there is an update, you have to call setFeedURL
 		 * before using this API
 		 */
 		checkForUpdates(): any;
@@ -1305,7 +1305,7 @@ declare module GitHubElectron {
 		* URL that crash reports would be sent to as POST.
 		* Default: http://54.249.141.255:1127/post
 		*/
-		submitUrl?: string;
+		submitURL?: string;
 		/**
 		* Send the crash report without user interaction.
 		* Default: true.


### PR DESCRIPTION
*Url is deprecated from v0.35.0. We use *URL instead.

see also:
https://github.com/atom/electron/commit/fbb8e61958c8950455883e2a4ae12088ba030a12
