### PR TITLE
Add assert.deepStrictEqual and assert.notDeepStrictEqual to node.d.ts

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -23,6 +23,8 @@ assert.equal(3, "3", "uses == comparator");
 
 assert.notStrictEqual(2, "2", "uses === comparator");
 
+assert.notDeepStrictEqual({ x: { y: "3" } }, { x: { y: 3 } }, "uses === comparator");
+
 assert.throws(() => { throw "a hammer at your face"; }, undefined, "DODGED IT");
 
 assert.doesNotThrow(() => {

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -430,7 +430,7 @@ declare module "http" {
     import * as events from "events";
     import * as net from "net";
     import * as stream from "stream";
-    
+
     export interface RequestOptions {
         protocol?: string;
         host?: string;
@@ -1808,6 +1808,8 @@ declare module "assert" {
         export function notDeepEqual(acutal: any, expected: any, message?: string): void;
         export function strictEqual(actual: any, expected: any, message?: string): void;
         export function notStrictEqual(actual: any, expected: any, message?: string): void;
+        export function deepStrictEqual(actual: any, expected: any, message?: string): void;
+        export function notDeepStrictEqual(actual: any, expected: any, message?: string): void;
         export var throws: {
             (block: Function, message?: string): void;
             (block: Function, error: Function, message?: string): void;


### PR DESCRIPTION
[io.js 1.2.0](https://github.com/nodejs/node/blob/v1.2.0/CHANGELOG.md#notable-changes) added [deepStrictEqual](https://nodejs.org/api/assert.html#assert_assert_deepstrictequal_actual_expected_message) and [notDeepStrictEqual](https://nodejs.org/api/assert.html#assert_assert_notdeepstrictequal_actual_expected_message) to assert.
