### PR TITLE
updated jssha (new version: 2.0)

### DIFF
--- a/jssha/jssha-1.6.0-tests.ts
+++ b/jssha/jssha-1.6.0-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path="jssha.d.ts" />
+/// <reference path="jssha-1.6.0.d.ts" />
 /// <reference path="../node/node.d.ts" />
 
 var imported = require("jssha");

--- a/jssha/jssha-1.6.0.d.ts
+++ b/jssha/jssha-1.6.0.d.ts
@@ -6,8 +6,8 @@
 
 declare module jsSHA {
     export interface OutputFormatOptions {
-        outputUpper : boolean;
-        b64Pad : string;
+        outputUpper? : boolean;
+        b64Pad? : string;
     }
 
     export interface jsSHA {

--- a/jssha/jssha-1.6.0.d.ts
+++ b/jssha/jssha-1.6.0.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jsSHA
+// Type definitions for jsSHA-1.6.0
 // Project: https://github.com/Caligatio/jsSHA
 // Definitions by: David Li <https://github.com/randombk>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/jssha/jssha-tests.ts
+++ b/jssha/jssha-tests.ts
@@ -1,30 +1,29 @@
 /// <reference path="jssha.d.ts" />
 /// <reference path="../node/node.d.ts" />
 
-var imported = require("jssha");
+import imported = require("jssha");
 
 // constructor
-let shaObj1:jsSHA.jsSHA = imported("SHA-256", "HEX");
-let shaObj2:jsSHA.jsSHA = new jsSHA("SHA-512", "TEXT");
-let shaObj3:jsSHA.jsSHA = new jsSHA("SHA-512", "TEXT", { });
-let shaObj4:jsSHA.jsSHA = new jsSHA("SHA-512", "TEXT", { encoding: "UTF" });
-let shaObj5:jsSHA.jsSHA = new jsSHA("SHA-512", "TEXT", { numRounds: 1 });
-let shaObj6:jsSHA.jsSHA = new jsSHA("SHA-512", "TEXT", { encoding: "UTF", numRounds: 1 });
+let shaObj1:jsSHA.jsSHA = new imported("SHA-512", "TEXT");
+let shaObj2:jsSHA.jsSHA = new imported("SHA-512", "TEXT", { });
+let shaObj3:jsSHA.jsSHA = new imported("SHA-512", "TEXT", { encoding: "UTF8" });
+let shaObj4:jsSHA.jsSHA = new imported("SHA-512", "TEXT", { numRounds: 1 });
+let shaObj5:jsSHA.jsSHA = new imported("SHA-512", "TEXT", { encoding: "UTF8", numRounds: 1 });
 
 // setHMACKey
 shaObj1.setHMACKey("key", "TEXT");
-shaObj1.setHMACKey("key", "TEXT", { });
-shaObj1.setHMACKey("key", "TEXT", { encoding: "UTF" });
+shaObj2.setHMACKey("key", "TEXT", { });
+shaObj3.setHMACKey("key", "TEXT", { encoding: "UTF8" });
 
 // update
 shaObj1.update("This is a test");
 
 // getHash
-let hash1:string = shaObj1.getHash("HEX");
-let hash2:string = shaObj1.getHash("HEX", {});
-let hash3:string = shaObj1.getHash("HEX", { b64Pad: "=" });
-let hash4:string = shaObj1.getHash("HEX", { outputUpper: true });
-let hash5:string = shaObj1.getHash("HEX", { outputUpper: true, b64Pad: '=' });
+let hash1:string = shaObj4.getHash("HEX");
+let hash2:string = shaObj4.getHash("HEX", {});
+let hash3:string = shaObj4.getHash("HEX", { b64Pad: "=" });
+let hash4:string = shaObj4.getHash("HEX", { outputUpper: true });
+let hash5:string = shaObj4.getHash("HEX", { outputUpper: true, b64Pad: '=' });
 
 // getHMAC
 let hmac1:string = shaObj1.getHMAC("HEX");
@@ -36,14 +35,14 @@ let hmac5:string = shaObj1.getHMAC("HEX", { outputUpper: true, b64Pad: '=' });
 
 // examples from the readme.md (https://github.com/Caligatio/jsSHA/blob/v2.0.2/README.md)
 {
-	var shaObj = new jsSHA("SHA-512", "TEXT");
+	var shaObj = new imported("SHA-512", "TEXT");
 	shaObj.update("This is a test");
 	var hash = shaObj.getHash("HEX");
 }
 
 
 {
-	let shaObj = new jsSHA("SHA-256", "TEXT");
+	let shaObj = new imported("SHA-256", "TEXT");
 	shaObj.setHMACKey("abc", "TEXT");
 	shaObj.update("This is a test");
 	let hmac = shaObj.getHMAC("HEX");

--- a/jssha/jssha-tests.ts
+++ b/jssha/jssha-tests.ts
@@ -1,0 +1,50 @@
+/// <reference path="jssha.d.ts" />
+/// <reference path="../node/node.d.ts" />
+
+var imported = require("jssha");
+
+// constructor
+let shaObj1:jsSHA.jsSHA = imported("SHA-256", "HEX");
+let shaObj2:jsSHA.jsSHA = new jsSHA("SHA-512", "TEXT");
+let shaObj3:jsSHA.jsSHA = new jsSHA("SHA-512", "TEXT", { });
+let shaObj4:jsSHA.jsSHA = new jsSHA("SHA-512", "TEXT", { encoding: "UTF" });
+let shaObj5:jsSHA.jsSHA = new jsSHA("SHA-512", "TEXT", { numRounds: 1 });
+let shaObj6:jsSHA.jsSHA = new jsSHA("SHA-512", "TEXT", { encoding: "UTF", numRounds: 1 });
+
+// setHMACKey
+shaObj1.setHMACKey("key", "TEXT");
+shaObj1.setHMACKey("key", "TEXT", { });
+shaObj1.setHMACKey("key", "TEXT", { encoding: "UTF" });
+
+// update
+shaObj1.update("This is a test");
+
+// getHash
+let hash1:string = shaObj1.getHash("HEX");
+let hash2:string = shaObj1.getHash("HEX", {});
+let hash3:string = shaObj1.getHash("HEX", { b64Pad: "=" });
+let hash4:string = shaObj1.getHash("HEX", { outputUpper: true });
+let hash5:string = shaObj1.getHash("HEX", { outputUpper: true, b64Pad: '=' });
+
+// getHMAC
+let hmac1:string = shaObj1.getHMAC("HEX");
+let hmac2:string = shaObj1.getHMAC("HEX", {});
+let hmac3:string = shaObj1.getHMAC("HEX", { b64Pad: "=" });
+let hmac4:string = shaObj1.getHMAC("HEX", { outputUpper: true });
+let hmac5:string = shaObj1.getHMAC("HEX", { outputUpper: true, b64Pad: '=' });
+
+
+// examples from the readme.md (https://github.com/Caligatio/jsSHA/blob/v2.0.2/README.md)
+{
+	var shaObj = new jsSHA("SHA-512", "TEXT");
+	shaObj.update("This is a test");
+	var hash = shaObj.getHash("HEX");
+}
+
+
+{
+	let shaObj = new jsSHA("SHA-256", "TEXT");
+	shaObj.setHMACKey("abc", "TEXT");
+	shaObj.update("This is a test");
+	let hmac = shaObj.getHMAC("HEX");
+}

--- a/jssha/jssha.d.ts
+++ b/jssha/jssha.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for jsSHA
 // Project: https://github.com/Caligatio/jsSHA
-// Definitions by: Tobias Kahlert <https://github.com/SrTobi>
-// Definitions: https://github.com/SrTobi/DefinitelyTyped
+// Definitions by: David Li <https://github.com/randombk>, Tobias Kahlert <https://github.com/SrTobi>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 
 declare module jsSHA {

--- a/jssha/jssha.d.ts
+++ b/jssha/jssha.d.ts
@@ -79,7 +79,7 @@ declare module jsSHA {
     }
 }
 
-declare var jsSHA: jsSHA.jsSHA;
 declare module 'jssha' {
+	var jsSHA: jsSHA.jsSHA;
     export = jsSHA;
 }

--- a/jssha/jssha.d.ts
+++ b/jssha/jssha.d.ts
@@ -40,7 +40,7 @@ declare module jsSHA {
 		 *
 		 * @param {string} key The key used to calculate the HMAC
 		 * @param {string} inputFormat The format of key, HEX, TEXT, B64, or BYTES
-		 * @param {{encoding : (string|undefined)}=} options Associative array
+		 * @param {{encoding : (string|undefined)}=} encodingOpts Associative array
 		 *   of input format options
 		 */
         setHMACKey(key:string, inputFormat:string, encodingOpts?:EncodingOptions):void;
@@ -60,7 +60,7 @@ declare module jsSHA {
 		 *
 		 * @param {string} format The desired output formatting (B64, HEX, or BYTES)
 		 * @param {{outputUpper : (boolean|undefined), b64Pad : (string|undefined)}=}
-		 *   options Hash list of output formatting options
+		 *   outputFormatOpts Hash list of output formatting options
 		 * @return {string} The string representation of the hash in the format
 		 *   specified
 		 */
@@ -73,7 +73,7 @@ declare module jsSHA {
 		 * @param {string} format The desired output formatting
 		 *   (B64, HEX, or BYTES)
 		 * @param {{outputUpper : (boolean|undefined), b64Pad : (string|undefined)}=}
-		 *   options associative array of output formatting options
+		 *   outputFormatOpts associative array of output formatting options
 		 * @return {string} The string representation of the hash in the format
 		 *   specified
 		 */

--- a/jssha/jssha.d.ts
+++ b/jssha/jssha.d.ts
@@ -24,8 +24,6 @@ declare module jsSHA {
          * jsSHA is the workhorse of the library.  Instantiate it with the string to
          * be hashed as the parameter
          *
-         * @constructor
-         * @this {jsSHA}
          * @param {string} variant The desired SHA variant (SHA-1, SHA-224, SHA-256,
          *   SHA-384, or SHA-512)
          * @param {string} inputFormat The format of srcString: HEX, TEXT, B64, or BYTES

--- a/jssha/jssha.d.ts
+++ b/jssha/jssha.d.ts
@@ -1,0 +1,87 @@
+// Type definitions for jsSHA
+// Project: https://github.com/Caligatio/jsSHA
+// Definitions by: Tobias Kahlert <https://github.com/SrTobi>
+// Definitions: https://github.com/SrTobi/DefinitelyTyped
+
+
+declare module jsSHA {
+    
+    export interface EncodingOptions {
+        encoding? : string;
+    }
+    
+    export interface Options extends EncodingOptions {
+        numRounds? : number;
+    }
+    
+    export interface OutputFormatOptions {
+        outputUpper? : boolean;
+        b64Pad? : string;
+    }
+
+    export interface jsSHA {
+        /**
+         * jsSHA is the workhorse of the library.  Instantiate it with the string to
+         * be hashed as the parameter
+         *
+         * @constructor
+         * @this {jsSHA}
+         * @param {string} variant The desired SHA variant (SHA-1, SHA-224, SHA-256,
+         *   SHA-384, or SHA-512)
+         * @param {string} inputFormat The format of srcString: HEX, TEXT, B64, or BYTES
+         * @param {{encoding: (string|undefined), numRounds: (string|undefined)}=}
+         *   options Optional values
+         */
+        new (variant:string, inputFormat:string, options?:Options):jsSHA;
+
+        /**
+		 * Sets the HMAC key for an eventual getHMAC call.  Must be called
+		 * immediately after jsSHA object instantiation
+		 *
+		 * @param {string} key The key used to calculate the HMAC
+		 * @param {string} inputFormat The format of key, HEX, TEXT, B64, or BYTES
+		 * @param {{encoding : (string|undefined)}=} options Associative array
+		 *   of input format options
+		 */
+        setHMACKey(key:string, inputFormat:string, encodingOpts?:EncodingOptions):void;
+        
+        /**
+		 * Takes strString and hashes as many blocks as possible.  Stores the
+		 * rest for either a future update or getHash call.
+		 *
+		 * @param {string} srcString The string to be hashed
+		 */
+        update(srcString:string):void;
+
+
+        /**
+		 * Returns the desired SHA hash of the string specified at instantiation
+		 * using the specified parameters
+		 *
+		 * @param {string} format The desired output formatting (B64, HEX, or BYTES)
+		 * @param {{outputUpper : (boolean|undefined), b64Pad : (string|undefined)}=}
+		 *   options Hash list of output formatting options
+		 * @return {string} The string representation of the hash in the format
+		 *   specified
+		 */
+        getHash(format:string, outputFormatOpts?:OutputFormatOptions):string;
+
+        /**
+		 * Returns the the HMAC in the specified format using the key given by
+		 * a previous setHMACKey call.
+		 *
+		 * @param {string} format The desired output formatting
+		 *   (B64, HEX, or BYTES)
+		 * @param {{outputUpper : (boolean|undefined), b64Pad : (string|undefined)}=}
+		 *   options associative array of output formatting options
+		 * @return {string} The string representation of the hash in the format
+		 *   specified
+		 */
+        getHMAC(format:string, outputFormatOpts?:OutputFormatOptions):string;
+    }
+}
+
+declare var jsSHA: jsSHA.jsSHA;
+declare module 'jssha' {
+    export = jsSHA;
+}


### PR DESCRIPTION
jssha is in version 2.0 for some time now, but the type definitions are still version 1.6. I moved the old definitions to a new file (jssha-1.6.0.d.ts) and added the definitions for the new versions (in jssha.d.ts).

With 2.0 jssha had a complete api change. I simply copied the documentation to create the type definitions and added some tests. I also fixed a minor error in the old definitions.
