### PR TITLE
Fix parameter typing for the SpriteSheetBuilder's "addAnimation" method in CreateJS

### DIFF
--- a/easeljs/easeljs.d.ts
+++ b/easeljs/easeljs.d.ts
@@ -52,7 +52,7 @@ declare module createjs {
         // methods
         clone(): Bitmap;
     }
-
+    
 
     export class BitmapText extends DisplayObject {
         constructor(text?:string, spriteSheet?:SpriteSheet);
@@ -66,7 +66,7 @@ declare module createjs {
         spriteSheet: SpriteSheet;
         text: string;
     }
-
+    
     export class BlurFilter extends Filter {
         constructor(blurX?: number, blurY?: number, quality?: number);
 
@@ -115,7 +115,7 @@ declare module createjs {
         greenOffset: number;
         redMultiplier: number;
         redOffset: number;
-
+        
         // methods
         clone(): ColorFilter;
     }
@@ -139,7 +139,7 @@ declare module createjs {
         toArray(): number[];
         toString(): string;
     }
-
+    
     export class ColorMatrixFilter extends Filter {
         constructor(matrix: number[] | ColorMatrix);
 
@@ -149,7 +149,7 @@ declare module createjs {
         // methods
         clone(): ColorMatrixFilter;
     }
-
+    
 
     export class Container extends DisplayObject {
         constructor();
@@ -183,7 +183,7 @@ declare module createjs {
         swapChildren(child1: DisplayObject, child2: DisplayObject): void;
         swapChildrenAt(index1: number, index2: number): void;
     }
-
+    
     export class DisplayObject extends EventDispatcher {
         constructor();
 
@@ -268,7 +268,7 @@ declare module createjs {
 
         // properties
         htmlElement: HTMLElement;
-
+        
         // methods
         clone(): DisplayObject; // throw error
         set(props: Object): DOMElement;
@@ -589,7 +589,7 @@ declare module createjs {
 
     export class MouseEvent extends Event {
         constructor(type: string, bubbles: boolean, cancelable: boolean, stageX: number, stageY: number, nativeEvent: NativeMouseEvent, pointerID: number, primary: boolean, rawX: number, rawY: number);
-
+        
         // properties
         isTouch: boolean;
         localX: number;
@@ -601,10 +601,10 @@ declare module createjs {
         rawY: number;
         stageX: number;
         stageY: number;
-
+        
         // methods
         clone(): MouseEvent;
-
+        
         // EventDispatcher mixins
         addEventListener(type: string, listener: (eventObj: Object) => boolean, useCapture?: boolean): Function;
         addEventListener(type: string, listener: (eventObj: Object) => void, useCapture?: boolean): Function;
@@ -670,12 +670,12 @@ declare module createjs {
         play(): void;
         stop(): void;
     }
-
+    
     export class MovieClipPlugin {
         // methods
         tween(tween: Tween, prop: string, value: string | number | boolean, startValues: any[], endValues: any[], ratio: number, wait: Object, end: Object): void;
     }
-
+    
     export class Point {
         constructor(x?: number, y?: number);
 
@@ -756,7 +756,7 @@ declare module createjs {
         offset: number;
         paused: boolean;
         spriteSheet: SpriteSheet;
-
+        
         // methods
         advance(time?: number): void;
         clone(): Sprite;
@@ -767,7 +767,7 @@ declare module createjs {
         set(props: Object): Sprite;
         setTransform(x?: number, y?: number, scaleX?: number, scaleY?: number, rotation?: number, skewX?: number, skewY?: number, regX?: number, regY?: number): Sprite;
         stop(): void;
-
+        
     }
 
     export class SpriteContainer extends Container
@@ -798,7 +798,7 @@ declare module createjs {
         animations: string[];
         complete: boolean;
         framerate: number;
-
+        
         // methods
         clone(): SpriteSheet;
         getAnimation(name: string): SpriteSheetAnimation;
@@ -883,7 +883,7 @@ declare module createjs {
         preventSelection: boolean;
         snapToPixelEnabled: boolean;  // deprecated
         tickOnUpdate: boolean;
-
+        
         // methods
         clear(): void;
         clone(): Stage;
@@ -892,7 +892,7 @@ declare module createjs {
         tick(props?: Object): void;
         toDataURL(backgroundColor: string, mimeType: string): string;
         update(...arg: any[]): void;
-
+        
     }
 
 

--- a/easeljs/easeljs.d.ts
+++ b/easeljs/easeljs.d.ts
@@ -52,7 +52,7 @@ declare module createjs {
         // methods
         clone(): Bitmap;
     }
-    
+
 
     export class BitmapText extends DisplayObject {
         constructor(text?:string, spriteSheet?:SpriteSheet);
@@ -66,7 +66,7 @@ declare module createjs {
         spriteSheet: SpriteSheet;
         text: string;
     }
-    
+
     export class BlurFilter extends Filter {
         constructor(blurX?: number, blurY?: number, quality?: number);
 
@@ -115,7 +115,7 @@ declare module createjs {
         greenOffset: number;
         redMultiplier: number;
         redOffset: number;
-        
+
         // methods
         clone(): ColorFilter;
     }
@@ -139,7 +139,7 @@ declare module createjs {
         toArray(): number[];
         toString(): string;
     }
-    
+
     export class ColorMatrixFilter extends Filter {
         constructor(matrix: number[] | ColorMatrix);
 
@@ -149,7 +149,7 @@ declare module createjs {
         // methods
         clone(): ColorMatrixFilter;
     }
-    
+
 
     export class Container extends DisplayObject {
         constructor();
@@ -183,7 +183,7 @@ declare module createjs {
         swapChildren(child1: DisplayObject, child2: DisplayObject): void;
         swapChildrenAt(index1: number, index2: number): void;
     }
-    
+
     export class DisplayObject extends EventDispatcher {
         constructor();
 
@@ -268,7 +268,7 @@ declare module createjs {
 
         // properties
         htmlElement: HTMLElement;
-        
+
         // methods
         clone(): DisplayObject; // throw error
         set(props: Object): DOMElement;
@@ -589,7 +589,7 @@ declare module createjs {
 
     export class MouseEvent extends Event {
         constructor(type: string, bubbles: boolean, cancelable: boolean, stageX: number, stageY: number, nativeEvent: NativeMouseEvent, pointerID: number, primary: boolean, rawX: number, rawY: number);
-        
+
         // properties
         isTouch: boolean;
         localX: number;
@@ -601,10 +601,10 @@ declare module createjs {
         rawY: number;
         stageX: number;
         stageY: number;
-        
+
         // methods
         clone(): MouseEvent;
-        
+
         // EventDispatcher mixins
         addEventListener(type: string, listener: (eventObj: Object) => boolean, useCapture?: boolean): Function;
         addEventListener(type: string, listener: (eventObj: Object) => void, useCapture?: boolean): Function;
@@ -670,12 +670,12 @@ declare module createjs {
         play(): void;
         stop(): void;
     }
-    
+
     export class MovieClipPlugin {
         // methods
         tween(tween: Tween, prop: string, value: string | number | boolean, startValues: any[], endValues: any[], ratio: number, wait: Object, end: Object): void;
     }
-    
+
     export class Point {
         constructor(x?: number, y?: number);
 
@@ -756,7 +756,7 @@ declare module createjs {
         offset: number;
         paused: boolean;
         spriteSheet: SpriteSheet;
-        
+
         // methods
         advance(time?: number): void;
         clone(): Sprite;
@@ -767,7 +767,7 @@ declare module createjs {
         set(props: Object): Sprite;
         setTransform(x?: number, y?: number, scaleX?: number, scaleY?: number, rotation?: number, skewX?: number, skewY?: number, regX?: number, regY?: number): Sprite;
         stop(): void;
-        
+
     }
 
     export class SpriteContainer extends Container
@@ -798,7 +798,7 @@ declare module createjs {
         animations: string[];
         complete: boolean;
         framerate: number;
-        
+
         // methods
         clone(): SpriteSheet;
         getAnimation(name: string): SpriteSheetAnimation;
@@ -825,7 +825,7 @@ declare module createjs {
         timeSlice: number;
 
         // methods
-        addAnimation(name: string, frames: number[], next?: string, frequency?: number): void;
+        addAnimation(name: string, frames: number[], next?: string|boolean, frequency?: number): void;
         addFrame(source: DisplayObject, sourceRect?: Rectangle, scale?: number, setupFunction?: () => any, setupData?: Object): number;
         addMovieClip(source: MovieClip, sourceRect?: Rectangle, scale?: number, setupFunction?: () => any, setupData?: Object, labelFunction?: () => any): void;
         build(): SpriteSheet;
@@ -883,7 +883,7 @@ declare module createjs {
         preventSelection: boolean;
         snapToPixelEnabled: boolean;  // deprecated
         tickOnUpdate: boolean;
-        
+
         // methods
         clear(): void;
         clone(): Stage;
@@ -892,7 +892,7 @@ declare module createjs {
         tick(props?: Object): void;
         toDataURL(backgroundColor: string, mimeType: string): string;
         update(...arg: any[]): void;
-        
+
     }
 
 


### PR DESCRIPTION
Easel's docs list the "next" parameter as a String but the text of their docs states it can also be a boolean. 

Relevant documentation: "Specifies the name of the animation to continue to after this animation ends. You can also pass false to have the animation stop when it ends. By default it will loop to the start of the same animation."
