### PR TITLE
Fix: IIntervalService missing optional function arguments

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -615,7 +615,7 @@ declare module angular {
     // see http://docs.angularjs.org/api/ng.$interval
     ///////////////////////////////////////////////////////////////////////////
     interface IIntervalService {
-        (func: Function, delay: number, count?: number, invokeApply?: boolean): IPromise<any>;
+        (func: Function, delay: number, count?: number, invokeApply?: boolean, ...args: any[]): IPromise<any>;
         cancel(promise: IPromise<any>): boolean;
     }
 


### PR DESCRIPTION
IIntervalService can take arguments to be passed to the function (`[Pass]`):

> $interval(fn, delay, [count], [invokeApply], [Pass]);

This adds this to the definition.
