### PR TITLE
Update SuperAgent and SuperTest

### DIFF
--- a/superagent/superagent-tests.ts
+++ b/superagent/superagent-tests.ts
@@ -1,17 +1,20 @@
-/// <reference path="./superagent.d.ts" />
+/// <reference path="superagent.d.ts" />
 /// <reference path="../node/node.d.ts" />
 
 // via: http://visionmedia.github.io/superagent/
 
-import request = require('superagent')
-import fs = require('fs');
+import * as request from 'superagent';
+import * as fs from 'fs';
+
+// Examples taken from https://github.com/visionmedia/superagent/blob/gh-pages/docs/index.md
+// and https://github.com/visionmedia/superagent/blob/master/Readme.md
 
 request
   .post('/api/pet')
   .send({ name: 'Manny', species: 'cat' })
   .set('X-API-Key', 'foobar')
   .set('Accept', 'application/json')
-  .end((res: request.Response) => {
+  .end((err, res) => {
     if (res.ok) {
       console.log('yay got ' + JSON.stringify(res.body));
     } else {
@@ -25,7 +28,7 @@ agent
   .send({ name: 'Manny', species: 'cat' })
   .set('X-API-Key', 'foobar')
   .set('Accept', 'application/json')
-  .end((res: request.Response) => {
+  .end((err, res) => {
     if (res.error) {
       console.log('oh no ' + res.error.message);
     } else {
@@ -33,8 +36,19 @@ agent
     }
   });
 
+// Plugins
+var nocache = require('superagent-no-cache');
+var prefix = require('superagent-prefix')('/static');
 
-var callback = (res: request.Response) => {};
+request
+  .get('/some-url')
+  .use(prefix) // Prefixes *only* this request
+  .use(nocache) // Prevents caching of *only* this request
+  .end(function(err, res){
+      // Do something
+  });
+
+var callback = (err: any, res: request.Response) => {};
 
 // Request basics
 request
@@ -43,6 +57,10 @@ request
 
 request('GET', '/search')
   .end(callback);
+
+request
+   .get('http://example.com/search')
+   .end(callback);
 
 request
   .head('/favicon.ico')
@@ -100,6 +118,12 @@ request
   .query('range=1..5')
   .end(callback);
 
+// HEAD requests
+request
+  .head('/users')
+  .query({ email: 'joe@smith.com' })
+  .end(callback);
+
 // POST / PUT requests
 request.post('/user')
   .set('Content-Type', 'application/json')
@@ -139,6 +163,7 @@ request.post('/user')
 request.post('/user')
   .type('png');
 
+// Setting Accept
 request.get('/user')
   .accept('application/json');
 
@@ -254,5 +279,3 @@ request
   .attach('image', 'path/to/tobi.png')
   .on('error', (err: any) => {})
   .end(callback);
-
-

--- a/superagent/superagent.d.ts
+++ b/superagent/superagent.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for SuperAgent 0.15.4
+// Type definitions for SuperAgent v1.4.0
 // Project: https://github.com/visionmedia/superagent
 // Definitions by: Alex Varju <https://github.com/varju/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -8,7 +8,7 @@
 declare module "superagent" {
   import stream = require('stream');
 
-  type CallbackHandler = { (err: any, res: request.Response): void; }|{ (res: request.Response): void; };
+  type CallbackHandler = (err: any, res: request.Response) => void;
 
   var request: request.SuperAgentStatic;
 
@@ -102,6 +102,7 @@ declare module "superagent" {
       set(field: Object): Req;
       timeout(ms: number): Req;
       type(val: string): Req;
+      use(fn: Function): Req;
       withCredentials(): Req;
       write(data: string, encoding?: string): Req;
       write(data: Buffer, encoding?: string): Req;

--- a/supertest/supertest-tests.ts
+++ b/supertest/supertest-tests.ts
@@ -1,8 +1,8 @@
 /// <reference path="supertest.d.ts" />
 /// <reference path="../express/express.d.ts" />
 
-import supertest = require('supertest')
-import express = require('express');
+import * as supertest from 'supertest';
+import * as express from 'express';
 
 var app = express();
 
@@ -11,7 +11,7 @@ supertest(app)
   .expect('Content-Type', /json/)
   .expect('Content-Length', '20')
   .expect(201)
-  .end((err: any, res: supertest.Response) => {
+  .end((err, res) => {
     if (err) throw err;
   });
 
@@ -56,4 +56,3 @@ function hasPreviousAndNextKeys(res: supertest.Response) {
   if (!('next' in res.body)) return "missing next key";
   if (!('prev' in res.body)) throw new Error("missing prev key");
 }
-

--- a/supertest/supertest.d.ts
+++ b/supertest/supertest.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for SuperTest 0.14.0
+// Type definitions for SuperTest v1.1.0
 // Project: https://github.com/visionmedia/supertest
 // Definitions by: Alex Varju <https://github.com/varju/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -8,7 +8,7 @@
 declare module "supertest" {
   import superagent = require('superagent');
 
-  type CallbackHandler = { (err: any, res: supertest.Response): void; }|{ (res: supertest.Response): void; };
+  type CallbackHandler = (err: any, res: supertest.Response) => void;
 
   function supertest(app: any): supertest.SuperTest;
 
@@ -29,6 +29,7 @@ declare module "supertest" {
       expect(field: string, val: string, callback?: CallbackHandler): Test;
       expect(field: string, val: RegExp, callback?: CallbackHandler): Test;
       expect(checker: (res: Response) => any): Test;
+      end(callback?: CallbackHandler): Test;
     }
 
     interface Response extends superagent.Response {


### PR DESCRIPTION
Fix #6498

Update SuperAgent to version 1.4.0:
- Callback now always takes 2 arguments, see visionmedia/superagent@e440274
- Add Request.use()
- Improve tests

Update SuperTest to version 1.1.0:
- Callback now always takes 2 arguments, see visionmedia/superagent@e440274
- Override superagent.Request.end() so it takes the proper callback signature
