### PR TITLE
JQuery map should return any; as per http://api.jquery.com/jquery.map/

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -2995,7 +2995,7 @@ interface JQuery {
      * 
      * @param callback A function object that will be invoked for each element in the current set.
      */
-    map(callback: (index: number, domElement: Element) => any): JQuery;
+    map(callback: (index: number, domElement: Element) => any): any;
 
     /**
      * Get the immediately following sibling of each element in the set of matched elements. If a selector is provided, it retrieves the next sibling only if it matches that selector.


### PR DESCRIPTION
map(callback: (index: number, domElement: Element) => any): any;

so this code, should and is valid:
var checkboxes : string[] = $("#table").find(".checkboxes").map(function (index, element) { return $(element).val(); });
