### PR TITLE
react.d.ts: Change union type to intersection type

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -112,7 +112,7 @@ declare namespace __React {
     // Component API
     // ----------------------------------------------------------------------
 
-    type ReactInstance = Component<any, any> | Element;
+    type ReactInstance = Component<any, any> & Element;
 
     // Base component for plain JS classes
     class Component<P, S> implements ComponentLifecycle<P, S> {

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -112,7 +112,7 @@ declare namespace __React {
     // Component API
     // ----------------------------------------------------------------------
 
-    type ReactInstance = Component<any, any> & Element;
+    type ReactInstance = Component<any, any> | Element;
 
     // Base component for plain JS classes
     class Component<P, S> implements ComponentLifecycle<P, S> {
@@ -125,7 +125,7 @@ declare namespace __React {
         state: S;
         context: {};
         refs: {
-            [key: string]: ReactInstance
+            [key: string]: Component<any, any> & Element
         };
     }
 


### PR DESCRIPTION
`type ReactInstance = Component<any, any> | Element` is wrong. Trying to accessing any `Element`'s property gives me a compilation error:

```
this.refs['refname'].scrollHeight // error TS2339: Property 'scrollHeight' does not exist on type 'Component<any, any> | Element'.
```

This happening because of [typescript union type spec](https://github.com/Microsoft/TypeScript/issues/805):

> The type A|B has a property P of type X|Y if A has a property P of type X and B has a property P of type Y.
> _(from Properties section)_

Instead of using union type, there should be [intersection type](https://github.com/Microsoft/TypeScript/pull/3622), which completely fits to this case:

> The type A & B has a property P if A has a property P or B has a property P.
> _(from Properties section)_

So, there should be `type ReactInstance =  Component<any, any> & Element`

See also #6205 
