### PR TITLE
ckeditor: added CKEDITOR.lang type definition

### DIFF
--- a/ckeditor/ckeditor.d.ts
+++ b/ckeditor/ckeditor.d.ts
@@ -1139,4 +1139,12 @@ declare module CKEDITOR {
         function isTabEnabled(editor: editor, dialogName: string, tabName: string): boolean;
         function okButton(): void;
     }
+
+    module lang {
+        var languages: any;
+        var rtl: any;
+
+        function load(languageCode: string, defaultLanguage: string, callback: Function): void;
+        function detect(defaultLanguage: string, probeLanguage: string): string;
+    }
 }


### PR DESCRIPTION
Added the missing CKEDITOR.lang type definition (stores language-related
functions - see
https://github.com/ckeditor/ckeditor-dev/blob/master/core/lang.js)
