### PR TITLE
createOffer and createAnswer broken

### DIFF
--- a/webrtc/RTCPeerConnection.d.ts
+++ b/webrtc/RTCPeerConnection.d.ts
@@ -71,8 +71,8 @@ interface RTCMediaConstraints {
 }
 
 interface RTCMediaOfferConstraints {
-  offerToReceiveAudio: boolean;
-  offerToReceiveVideo: boolean;
+  OfferToReceiveAudio: boolean;
+  OfferToReceiveVideo: boolean;
 }
 
 interface RTCSessionDescriptionInit {


### PR DESCRIPTION
When `RTCMediaOfferConstraints` properties have first letter lowercase than `RTCPeerConnection.createOffer()` and `RTCPeerConnection.createAnswer()` methods throw exception that constraints are invalid in chrome browser.
