### PR TITLE
lodash: signatures of _.flattenDeep have been changed

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -615,18 +615,40 @@ module TestFlattenDeep {
 
         result = _.flattenDeep<TResult>(recursiveArray);
         result = _.flattenDeep<TResult>(listOfMaybeRecursiveArraysOrValues);
-
-        result = _(recursiveArray).flattenDeep<TResult>().value();
-
-        result = _(listOfMaybeRecursiveArraysOrValues).flattenDeep<TResult>().value();
     }
 
     {
-        let result: any;
+        let result: any[];
 
         result = _.flattenDeep<TResult>(recursiveList);
+    }
 
-        result = _(recursiveList).flattenDeep().value();
+    {
+        let result: _.LoDashImplicitArrayWrapper<TResult>;
+
+        result = _(recursiveArray).flattenDeep<TResult>();
+
+        result = _(listOfMaybeRecursiveArraysOrValues).flattenDeep<TResult>();
+    }
+
+    {
+        let result: _.LoDashImplicitArrayWrapper<any>;
+
+        result = _(recursiveList).flattenDeep();
+    }
+
+    {
+        let result: _.LoDashExplicitArrayWrapper<TResult>;
+
+        result = _(recursiveArray).chain().flattenDeep<TResult>();
+
+        result = _(listOfMaybeRecursiveArraysOrValues).chain().flattenDeep<TResult>();
+    }
+
+    {
+        let result: _.LoDashExplicitArrayWrapper<any>;
+
+        result = _(recursiveList).chain().flattenDeep();
     }
 }
 

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -1131,14 +1131,28 @@ declare module _ {
         /**
          * @see _.flattenDeep
          */
-        flattenDeep<TResult>(): LoDashImplicitArrayWrapper<TResult>;
+        flattenDeep<T>(): LoDashImplicitArrayWrapper<T>;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
         /**
          * @see _.flattenDeep
          */
-        flattenDeep<TResult>(): LoDashImplicitArrayWrapper<TResult>;
+        flattenDeep<T>(): LoDashImplicitArrayWrapper<T>;
+    }
+
+    interface LoDashExplicitArrayWrapper<T> {
+        /**
+         * @see _.flattenDeep
+         */
+        flattenDeep<T>(): LoDashExplicitArrayWrapper<T>;
+    }
+
+    interface LoDashExplicitObjectWrapper<T> {
+        /**
+         * @see _.flattenDeep
+         */
+        flattenDeep<T>(): LoDashExplicitArrayWrapper<T>;
     }
 
     //_.head


### PR DESCRIPTION
https://lodash.com/docs#flattenDeep
https://lodash.com/docs#_ (description of the chainable wrapper)
