### PR TITLE
expiresInMinutes is deprecated, use expiresIn instead

### DIFF
--- a/jsonwebtoken/jsonwebtoken.d.ts
+++ b/jsonwebtoken/jsonwebtoken.d.ts
@@ -22,8 +22,13 @@ declare module "jsonwebtoken" {
          * - none:     No digital signature or MAC value included
          */
         algorithm?: string;
-        /** @member {number} - Lifetime for the token in minutes */
+        /** 
+         *@deprecated - see expiresIn
+         *@member {number} - Lifetime for the token in minutes 
+         */
         expiresInMinutes?: number;
+        /** @member {string} - Lifetime for the token expressed in a string describing a time span [rauchg/ms](https://github.com/rauchg/ms.js). Eg: `60`, `"2 days"`, `"10h"`, `"7d"` */
+        expiresIn?: string;
         audience?: string;
         subject?: string;
         issuer?: string;
@@ -33,6 +38,7 @@ declare module "jsonwebtoken" {
     export interface VerifyOptions {
         audience?: string;
         issuer?: string;
+        maxAge?: string;
     }
 
     export interface VerifyCallbak {


### PR DESCRIPTION
`SignOptions.expiresInMinutes` is deprecated, see more at https://github.com/auth0/node-jsonwebtoken/blob/master/index.js
