### PR TITLE
handleUpgrades option support in ServerOptions interface

### DIFF
--- a/restify/restify.d.ts
+++ b/restify/restify.d.ts
@@ -110,6 +110,7 @@ declare module "restify" {
     version ?: string;
     responseTimeHeader ?: string;
     responseTimeFormatter ?: (durationInMilliseconds: number) => any;
+    handleUpgrades ?: boolean;
   }
 
   interface ClientOptions {


### PR DESCRIPTION
http://restify.com/#creating-a-server

In restify docs createServer method supports handleUpgrades parameter in ServerOptions object, but it's not present in the type's interface.
