### PR TITLE
mdToast use textContent for 1.0.0-rc5

### DIFF
--- a/angular-material/angular-material.d.ts
+++ b/angular-material/angular-material.d.ts
@@ -116,7 +116,7 @@ declare module angular.material {
     }
 
     interface IToastPreset<T> {
-        content(content: string): T;
+        textContent(content: string): T;
         action(action: string): T;
         highlightAction(highlightAction: boolean): T;
         capsule(capsule: boolean): T;


### PR DESCRIPTION
md-toast now uses textContent instead of content - content is deprecated
https://github.com/angular/material/blob/v1.0.0-rc5/CHANGELOG.md#breaking-changes
