### PR TITLE
Update md-toast text to textContent for 1.0.0-rc5

### DIFF
--- a/angular-material/angular-material-tests.ts
+++ b/angular-material/angular-material-tests.ts
@@ -96,5 +96,5 @@ myApp.controller('SidenavController', ($scope: ng.IScope, $mdSidenav: ng.materia
 });
 
 myApp.controller('ToastController', ($scope: ng.IScope, $mdToast: ng.material.IToastService) => {
-    $scope['openToast'] = () => $mdToast.show($mdToast.simple().content('Hello!'));
+    $scope['openToast'] = () => $mdToast.show($mdToast.simple().textContent('Hello!'));
 });

--- a/angular-material/angular-material.d.ts
+++ b/angular-material/angular-material.d.ts
@@ -116,7 +116,7 @@ declare module angular.material {
     }
 
     interface IToastPreset<T> {
-        content(content: string): T;
+        textContent(content: string): T;
         action(action: string): T;
         highlightAction(highlightAction: boolean): T;
         capsule(capsule: boolean): T;

--- a/angular-material/angular-material.d.ts
+++ b/angular-material/angular-material.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Angular Material 0.10.1-rc1+ (angular.material module)
+// Type definitions for Angular Material 1.0.0-rc5+ (angular.material module)
 // Project: https://github.com/angular/material
 // Definitions by: Matt Traynham <https://github.com/mtraynham>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped


### PR DESCRIPTION
md-toast now uses textContent instead of content - content is deprecated
