### PR TITLE
Fix TS naming conflict

### DIFF
--- a/angular-scenario/angular-scenario.d.ts
+++ b/angular-scenario/angular-scenario.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference path="../jquery/jquery.d.ts" />
 
-declare module ng {
+declare module angular {
     export interface IAngularStatic {
         scenario: any;
     }


### PR DESCRIPTION
`declare module ng {...` will cause a TypeScript compiler error
`Import declaration conflicts with local declaration of 'ng'`
