### PR TITLE
Qunit: Add QunitAssert parameter to setup functions

### DIFF
--- a/qunit/qunit-tests.ts
+++ b/qunit/qunit-tests.ts
@@ -170,6 +170,30 @@ QUnit.module("module A", {
     }
 });
 
+QUnit.module("module with async setup and teardown", {
+    setup: function (assert) {
+        var done = assert.async();
+        setTimeout(function () {
+            // prepare something for all following tests
+        });
+    },
+    teardown: function (assert) {
+        // clean up after each test
+    }
+});
+
+QUnit.module("module with async setup and teardown", {
+    beforeEach: function (assert: QUnitAssert) {
+        var done = assert.async();
+        setTimeout(function () {
+            // prepare something for all following tests
+        });
+    },
+    afterEach: function () {
+        // clean up after each test
+    }
+});
+
 QUnit.test("a test", function (assert) {
 
     function square(x) {

--- a/qunit/qunit.d.ts
+++ b/qunit/qunit.d.ts
@@ -148,23 +148,27 @@ interface URLConfigItem {
 interface LifecycleObject {
     /**
      * Runs before each test
+     * @param assert
      * @deprecated
      */
-    setup?: () => void;
+    setup?: (assert: QUnitAssert) => void;
 
     /**
      * Runs after each test
+     * @param assert
      * @deprecated
      */
-    teardown?: () => void;
+    teardown?: (assert: QUnitAssert) => void;
     /**
      * Runs before each test
+     * @param assert
      */
-    beforeEach?: () => void;
+    beforeEach?: (assert: QUnitAssert) => void;
     /**
      * Runs after each test
+     * @param assert
      */
-    afterEach?: () => void;
+    afterEach?: (assert: QUnitAssert) => void;
 
     /**
      * Any additional properties on the hooks object will be added to that context.


### PR DESCRIPTION
The setup, teardown, beforeEach, afterEach functions are missing the QunitAssert parameter.
Like stated here:
http://qunitjs.com/upgrade-guide-2.x/#rename-module-hooks

This facilitates the usage of for example async code in the setup. This can currently be done without the QunitAssert by using Qunit.stop(), do your async code, and then Qunit.start() to run your tests, but both these functions are deprecated, and will be removed in Qunit 2.0.
