### PR TITLE
lodash: signatures of _.defer have been changed

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -4490,8 +4490,39 @@ source.addEventListener('message', <_.LoDashImplicitObjectWrapper<Function>>_(fu
 var returnedDebounce = _.throttle(function (a: any) { return a * 5; }, 5);
 returnedThrottled(4);
 
-result = <number>_.defer(function () { console.log('deferred'); });
-result = <_.LoDashImplicitWrapper<number>>_(function () { console.log('deferred'); }).defer();
+// _.defer
+module TestDefer {
+    type SampleFunc = (a: number, b: string) => boolean;
+
+    let func: SampleFunc;
+
+    {
+        let result: number;
+
+        result = _.defer<SampleFunc>(func);
+        result = _.defer<SampleFunc>(func, any);
+        result = _.defer<SampleFunc>(func, any, any);
+        result = _.defer<SampleFunc>(func, any, any, any);
+    }
+
+    {
+        let result: _.LoDashImplicitWrapper<number>;
+
+        result = _(func).defer();
+        result = _(func).defer(any);
+        result = _(func).defer(any, any);
+        result = _(func).defer(any, any, any);
+    }
+
+    {
+        let result: _.LoDashExplicitWrapper<number>;
+
+        result = _(func).chain().defer();
+        result = _(func).chain().defer(any);
+        result = _(func).chain().defer(any, any);
+        result = _(func).chain().defer(any, any, any);
+    }
+}
 
 // _.delay
 module TestDelay {

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -7913,22 +7913,31 @@ declare module _ {
     //_.defer
     interface LoDashStatic {
         /**
-        * Defers executing the func function until the current call stack has cleared. Additional
-        * arguments will be provided to func when it is invoked.
-        * @param func The function to defer.
-        * @param args Arguments to invoke the function with.
-        * @return The timer id.
-        **/
-        defer(
-            func: Function,
-            ...args: any[]): number;
+         * Defers invoking the func until the current call stack has cleared. Any additional arguments are provided to
+         * func when it’s invoked.
+         *
+         * @param func The function to defer.
+         * @param args The arguments to invoke the function with.
+         * @return Returns the timer id.
+         */
+        defer<T extends Function>(
+            func: T,
+            ...args: any[]
+        ): number;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
         /**
-        * @see _.defer
-        **/
+         * @see _.defer
+         */
         defer(...args: any[]): LoDashImplicitWrapper<number>;
+    }
+
+    interface LoDashExplicitObjectWrapper<T> {
+        /**
+         * @see _.defer
+         */
+        defer(...args: any[]): LoDashExplicitWrapper<number>;
     }
 
     //_.delay


### PR DESCRIPTION
https://lodash.com/docs#defer
https://lodash.com/docs#_ (description of the chainable wrapper)
