### PR TITLE
lodash: signatures of _.invert have been changed

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -6399,12 +6399,30 @@ module TestHas {
 }
 
 // _.invert
-{
-    let result: TResult;
-    result = _.invert<Object, TResult>({});
-    result = _.invert<Object, TResult>({}, true);
-    result = _({}).invert<TResult>().value();
-    result = _({}).invert<TResult>(true).value();
+module TestInvert {
+    {
+        let result: TResult;
+
+        result = _.invert<Object, TResult>({});
+        result = _.invert<Object, TResult>({}, true);
+
+        result = _.invert<TResult>({});
+        result = _.invert<TResult>({}, true);
+    }
+
+    {
+        let result: _.LoDashImplicitObjectWrapper<TResult>;
+
+        result = _({}).invert<TResult>();
+        result = _({}).invert<TResult>(true);
+    }
+
+    {
+        let result: _.LoDashExplicitObjectWrapper<TResult>;
+
+        result = _({}).chain().invert<TResult>();
+        result = _({}).chain().invert<TResult>(true);
+    }
 }
 
 // _.keys

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -10823,7 +10823,18 @@ declare module _ {
          * @param multiValue Allow multiple values per key.
          * @return Returns the new inverted object.
          */
-        invert<T extends {}, TResult extends {}>(object: T, multiValue?: boolean): TResult;
+        invert<T extends {}, TResult extends {}>(
+            object: T,
+            multiValue?: boolean
+        ): TResult;
+
+        /**
+         * @see _.invert
+         */
+        invert<TResult extends {}>(
+            object: Object,
+            multiValue?: boolean
+        ): TResult;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
@@ -10831,6 +10842,13 @@ declare module _ {
          * @see _.invert
          */
         invert<TResult extends {}>(multiValue?: boolean): LoDashImplicitObjectWrapper<TResult>;
+    }
+
+    interface LoDashExplicitObjectWrapper<T> {
+        /**
+         * @see _.invert
+         */
+        invert<TResult extends {}>(multiValue?: boolean): LoDashExplicitObjectWrapper<TResult>;
     }
 
     //_.keys


### PR DESCRIPTION
https://lodash.com/docs#invert
https://lodash.com/docs#_ (description of the chainable wrapper)
