### PR TITLE
Added function declarations for ExecuteOrDelayUntilBodyLoaded, Execut…

### DIFF
--- a/sharepoint/SharePoint.d.ts
+++ b/sharepoint/SharePoint.d.ts
@@ -8,6 +8,9 @@
 declare var _spBodyOnLoadFunctions: Function[];
 declare var _spBodyOnLoadFunctionNames: string[];
 declare var _spBodyOnLoadCalled: boolean;
+declare function ExecuteOrDelayUntilBodyLoaded(initFunc: () => void): void;
+declare function ExecuteOrDelayUntilScriptLoaded(func: () => void, depScriptFileName: string): boolean;
+declare function ExecuteOrDelayUntilEventNotified(func: Function, eventName: string): boolean;
 
 declare module SP {
     export class SOD {


### PR DESCRIPTION
…eOrDelayUntilScriptLoaded and ExecuteOrDelayUntilEventNotified. These are already declared under SP.SOD, but they can also be accessed directly on Window. 

ExecuteOrDelayUntilBodyLoaded is not accessable under SP.SOD.
