### PR TITLE
Allow "tokenGetter" function to use many parameters

### DIFF
--- a/angular-jwt/angular-jwt.d.ts
+++ b/angular-jwt/angular-jwt.d.ts
@@ -25,6 +25,6 @@ declare module angular.jwt {
     }
 
     interface IJwtInterceptor {
-        tokenGetter(): string;
+        tokenGetter(...params : any[]): string;
     }
 }


### PR DESCRIPTION
It can be useful to inject some services/factories/providers into the "tokenGetter" function. 
This modification does not affect the previous implementations. 
