### PR TITLE
Removing enum that's not available in code. This property takes strings.

### DIFF
--- a/intro.js/intro.js-tests.ts
+++ b/intro.js/intro.js-tests.ts
@@ -3,6 +3,8 @@
 var intro = introJs();
 
 intro.setOption('doneLabel', 'Next page');
+intro.setOption('overlayOpacity', 50);
+intro.setOption('showProgress', true);
 intro.setOptions({
     steps: [
         {

--- a/intro.js/intro.js-tests.ts
+++ b/intro.js/intro.js-tests.ts
@@ -11,11 +11,11 @@ intro.setOptions({
             intro: "Hello world!"
         },
         {
-            element: document.querySelector('#step1'),
+            element: document.querySelector('#step1') as HTMLElement,
             intro  : "This is a tooltip."
         },
         {
-            element : document.querySelectorAll('#step2')[0],
+            element : document.querySelectorAll('#step2')[0] as HTMLElement,
             intro   : "Ok, wasn't that fun?",
             position: 'right'
         },

--- a/intro.js/intro.js-tests.ts
+++ b/intro.js/intro.js-tests.ts
@@ -11,11 +11,11 @@ intro.setOptions({
             intro: "Hello world!"
         },
         {
-            element: document.querySelector('#step1') as HTMLElement,
+            element: document.querySelector('#step1'),
             intro  : "This is a tooltip."
         },
         {
-            element : document.querySelectorAll('#step2')[0] as HTMLElement,
+            element : document.querySelectorAll('#step2')[0],
             intro   : "Ok, wasn't that fun?",
             position: 'right'
         },

--- a/intro.js/intro.js.d.ts
+++ b/intro.js/intro.js.d.ts
@@ -6,7 +6,7 @@
 declare module IntroJs {
     interface Step {
         intro: string;
-        element?: string|HTMLElement;
+        element?: string|HTMLElement|Element;
         position?: string;
     }
 

--- a/intro.js/intro.js.d.ts
+++ b/intro.js/intro.js.d.ts
@@ -4,10 +4,17 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module IntroJs {
+    enum Positions {
+        top,
+        left,
+        right,
+        bottom
+    }
+
     interface Step {
         intro: string;
         element?: string|HTMLElement|Element;
-        position?: string;
+        position?: string|Positions;
     }
 
     interface Options {

--- a/intro.js/intro.js.d.ts
+++ b/intro.js/intro.js.d.ts
@@ -4,17 +4,10 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module IntroJs {
-    enum Positions {
-        top,
-        left,
-        right,
-        bottom
-    }
-
     interface Step {
         intro: string;
-        element?: string|HTMLElement|Element;
-        position?: string|Positions;
+        element?: string | HTMLElement | Element;
+        position?: string;
     }
 
     interface Options {
@@ -49,7 +42,7 @@ declare module IntroJs {
 
         refresh(): IntroJs;
 
-        setOption(option: string, value: string|number|boolean): IntroJs;
+        setOption(option: string, value: string | number | boolean): IntroJs;
         setOptions(options: Options): IntroJs;
 
         onexit(callback: Function): IntroJs;

--- a/intro.js/intro.js.d.ts
+++ b/intro.js/intro.js.d.ts
@@ -42,7 +42,7 @@ declare module IntroJs {
 
         refresh(): IntroJs;
 
-        setOption(option: string, value: string|number): IntroJs;
+        setOption(option: string, value: string|number|boolean): IntroJs;
         setOptions(options: Options): IntroJs;
 
         onexit(callback: Function): IntroJs;

--- a/intro.js/intro.js.d.ts
+++ b/intro.js/intro.js.d.ts
@@ -1,20 +1,13 @@
-// Type definitions for intro.js 1.0.0
+// Type definitions for intro.js 1.1.1
 // Project: https://github.com/usablica/intro.js
 // Definitions by: Maxime Fabre <https://github.com/anahkiasen/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module IntroJs {
-    enum Positions {
-        top,
-        left,
-        right,
-        bottom
-    }
-
     interface Step {
         intro: string;
         element?: string|HTMLElement;
-        position?: Positions;
+        position?: string;
     }
 
     interface Options {


### PR DESCRIPTION
idk why an enum was used here as a parameter type.  IntroJS requires a string, and using an enum that's only provided in the TypeDefs produces a JS error `Uncaught ReferenceError: IntroJs is not defined`  The position enums weren't even being used in the tests anyway, so it was untested code to begin with.

**Bad**

``` javascript
{
    intro: "This is neat",
    element: "#my-element",
    position: IntroJs.Positions.top
}
```

**Good**

``` javascript
{
    intro: "This is neat",
    element: "#my-element",
    position: "top"
}
```

I also had to update the `element` option to now accept `string | HTMLElement | Element` .  Previously it only accepted `string | HTMLElement` and the tests used `document.querySelector("#my-element")` which returned an `Element` type which was incompatible with the TypeDefs it was testing!
