### PR TITLE
Fix module export in state-machine typing

### DIFF
--- a/state-machine/state-machine.d.ts
+++ b/state-machine/state-machine.d.ts
@@ -79,5 +79,5 @@ interface StateMachine {
 declare var StateMachine: StateMachineStatic;
 
 declare module "state-machine" { 
-    export = StateMachineStatic; 
+    export = StateMachine; 
 }


### PR DESCRIPTION
The module declaration did not export the previously declared variable of type
`StateMachineStatic` but the interface `StateMachineStatic` itself. The
typescript compiler emitted the error `error TS2497: Module ''state-machine''
resolves to a non-module entity and cannot be imported using this construct.`
when trying to import the module via `import * as stateMachine from
'state-machine';`.
