### PR TITLE
jsonwebtoken: Missing attributes in VerifyOption interface

### DIFF
--- a/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/jsonwebtoken/jsonwebtoken-tests.ts
@@ -57,6 +57,18 @@ jwt.verify(token, cert, { audience: 'urn:foo', issuer: 'urn:issuer' }, function(
   // if issuer mismatch, err == invalid issuer
 });
 
+// verify algorithm
+cert = fs.readFileSync('public.pem');  // get public key
+jwt.verify(token, cert, { algorithms: ['RS256'] }, function(err, decoded) {
+  // if issuer mismatch, err == invalid issuer
+});
+
+// verify without expiration check
+cert = fs.readFileSync('public.pem');  // get public key
+jwt.verify(token, cert, { ignoreExpiration: true }, function(err, decoded) {
+  // if issuer mismatch, err == invalid issuer
+});
+
 /**
  * jwt.decode
  * https://github.com/auth0/node-jsonwebtoken#jwtdecodetoken

--- a/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/jsonwebtoken/jsonwebtoken-tests.ts
@@ -60,13 +60,13 @@ jwt.verify(token, cert, { audience: 'urn:foo', issuer: 'urn:issuer' }, function(
 // verify algorithm
 cert = fs.readFileSync('public.pem');  // get public key
 jwt.verify(token, cert, { algorithms: ['RS256'] }, function(err, decoded) {
-  // if issuer mismatch, err == invalid issuer
+  // if algorithm mismatch, err == invalid algorithm
 });
 
 // verify without expiration check
 cert = fs.readFileSync('public.pem');  // get public key
 jwt.verify(token, cert, { ignoreExpiration: true }, function(err, decoded) {
-  // if issuer mismatch, err == invalid issuer
+  // if ignoreExpration == false and token is expired, err == expired token
 });
 
 /**

--- a/jsonwebtoken/jsonwebtoken.d.ts
+++ b/jsonwebtoken/jsonwebtoken.d.ts
@@ -36,8 +36,10 @@ declare module "jsonwebtoken" {
     }
 
     export interface VerifyOptions {
+        algorithms?: string[];
         audience?: string;
         issuer?: string;
+        ignoreExpiration?: boolean;
         maxAge?: string;
     }
 


### PR DESCRIPTION
The `VerifyOption` interface is missing the attributes `algorithms` and `ignoreExprations`. These are documented in the [README of the node-jsonwebtoken package](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback).
