### PR TITLE
Bluebird: Make return type of promisifyAll less restrictive

### DIFF
--- a/bluebird/bluebird-1.0.d.ts
+++ b/bluebird/bluebird-1.0.d.ts
@@ -394,7 +394,7 @@ declare class Promise<R> implements Promise.Thenable<R> {
 	 * Note that the original methods on the object are not overwritten but new methods are created with the `Async`-postfix. For example, if you `promisifyAll()` the node.js `fs` object use `fs.statAsync()` to call the promisified `stat` method.
 	 */
 	// TODO how to model promisifyAll?
-	static promisifyAll(target: Object): Object;
+	static promisifyAll(target: Object): any;
 
 	/**
 	 * Returns a function that can use `yield` to run asynchronous code synchronously. This feature requires the support of generators which are drafted in the next version of the language. Node version greater than `0.11.2` is required and needs to be executed with the `--harmony-generators` (or `--harmony`) command-line switch.

--- a/bluebird/bluebird.d.ts
+++ b/bluebird/bluebird.d.ts
@@ -421,7 +421,7 @@ declare class Promise<R> implements Promise.Thenable<R>, Promise.Inspection<R> {
 	 * Note that the original methods on the object are not overwritten but new methods are created with the `Async`-postfix. For example, if you `promisifyAll()` the node.js `fs` object use `fs.statAsync()` to call the promisified `stat` method.
 	 */
 	// TODO how to model promisifyAll?
-	static promisifyAll(target: Object, options?: Promise.PromisifyAllOptions): Object;
+	static promisifyAll(target: Object, options?: Promise.PromisifyAllOptions): any;
 
 
 	/**


### PR DESCRIPTION
Previous return type of Object was too restrictive.

```
import bluebird = require('bluebird');
import superagent = require('superagent');

var request = bluebird.promisifyAll(superagent);

request.post('/example')
...
```

resulted in `Property 'post' does not exist on type 'Object'.`
