### PR TITLE
material-ui: Add missing prop and newly-added props

### DIFF
--- a/material-ui/material-ui-tests.tsx
+++ b/material-ui/material-ui-tests.tsx
@@ -218,6 +218,12 @@ class MaterialUiTests extends React.Component<{}, {}> implements React.LinkedSta
             The actions in this window were passed in as an array of react objects.
             </Dialog>;
 
+        element = <Dialog
+            open={false}
+            defaultOpen
+            onRequestClose={(clicked: boolean) => console.log('requested')}>
+            <p>Tests for some new props</p>
+            </Dialog>;
 
         // "http://material-ui.com/#/components/dropdown-menu"
         let menuItems = [

--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -377,16 +377,20 @@ declare namespace __MaterialUI {
         contentStyle?: React.CSSProperties;
         modal?: boolean;
         openImmediately?: boolean;
+        open?: boolean;
+        defaultOpen?: boolean;
         repositionOnUpdate?: boolean;
         title?: React.ReactNode;
 
         onClickAway?: () => void;
         onDismiss?: () => void;
         onShow?: () => void;
+        onRequestClose?: (buttonClicked: boolean) => void;
     }
     export class Dialog extends React.Component<DialogProps, {}> {
         dismiss(): void;
         show(): void;
+        isOpen(): boolean;
     }
 
     interface DropDownIconProps extends React.Props<DropDownIcon> {
@@ -567,6 +571,7 @@ declare namespace __MaterialUI {
             nestedItems?: React.ReactElement<any>[];
             onKeyboardFocus?: React.FocusEventHandler;
             onNestedListToggle?: (item: ListItem) => void;
+            onClick?: React.MouseEventHandler;
             rightAvatar?: React.ReactElement<any>;
             rightIcon?: React.ReactElement<any>;
             rightIconButton?: React.ReactElement<any>;


### PR DESCRIPTION
- Add `onClick` to `ListItem` component.
- Add new props `open`, `defaultOpen`, `onRequestClose` and new method `isOpen()`.
