### PR TITLE
Add basic type definition for Hopscotch [new library]

### DIFF
--- a/hopscotch/hopscotch-tests.ts
+++ b/hopscotch/hopscotch-tests.ts
@@ -1,0 +1,55 @@
+/// <reference path="hopscotch.d.ts" />
+
+var tourDefinition = {
+  id: 'intro-tour',
+  steps: [
+    {
+      target: '.popupTarget',
+      placement: 'bottom',
+      title: 'A tour step',
+      content: 'A tour message'
+    },
+    {
+      target: [".aSelector"],
+      placement: 'bottom',
+
+      yOffset: 10,
+      width: 400,
+      xOffset: -420,
+      arrowOffset: 380
+    },
+    {
+      target: '.domainPatterns form',
+      placement: 'right',
+      title: 'A question?',
+      content: "Hello!",
+      onShow: function () { }
+    },
+    {
+      target: '.home-button',
+      placement: 'left',
+      title: "Let's get started",
+      content: "Content",
+
+      multipage: true,
+      nextOnTargetClick: true,
+      showNextButton: false
+    },
+    {
+      target: '.buttons',
+      placement: 'top',
+      
+      title: 'Another title',
+      content: "A message",
+
+      showNextButton: false,
+      nextOnTargetClick: true,
+      onShow: function () { }
+    }
+  ],
+  skipIfNoElement: false,
+  onClose: function () { },
+  onEnd: function () { }
+};
+
+hopscotch.startTour(tourDefinition);

--- a/hopscotch/hopscotch.d.ts
+++ b/hopscotch/hopscotch.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for Hopscotch v0.2.5
+// Project: http://linkedin.github.io/hopscotch/
+// Definitions by: Tim Perry <https://github.com/pimterry>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+interface TourDefinition {
+  id: string;
+  steps: StepDefinition[];
+
+  skipIfNoElement: boolean;
+
+  onEnd: () => void;
+  onClose: () => void;
+}
+
+interface StepDefinition {
+  placement: string;
+  target: string | HTMLElement | Array<string | HTMLElement>
+
+  title?: string;
+  content?: string;
+
+  xOffset?: number;
+  yOffset?: number;
+  arrowOffset?: number;
+
+  height?: number;
+  width?: number;
+
+  multipage?: boolean;
+  showNextButton?: boolean;
+  nextOnTargetClick?: boolean;
+
+  onShow?: () => void;
+}
+
+interface HopscotchStatic {
+  startTour(tour: TourDefinition, stepNum?: number): void;
+}
+
+declare var hopscotch: HopscotchStatic;
+
+declare module "hopscotch" {
+  export = hopscotch;
+}


### PR DESCRIPTION
This adds a basic minimal API for [Hopscotch](http://linkedin.github.io/hopscotch/); LinkedIn's library for building product tour/walkthroughs.

It's quite minimal, just the core of the API that I've needed so far to get a basic tour working (I've been building it up as I've been using things). I'll try and update it to pull in all the other possible optional fields and the docs sometime soon too.
