### PR TITLE
add Stamplay.init definition for setting the app ID

### DIFF
--- a/stamplay-js-sdk/stamplay-js-sdk-tests.ts
+++ b/stamplay-js-sdk/stamplay-js-sdk-tests.ts
@@ -1,5 +1,5 @@
 /// <reference path="stamplay-js-sdk.d.ts" />
-
+Stamplay.init('sample');
 var userFn = Stamplay.User();
 var user = new userFn.Model;
 var colTags = Stamplay.Cobject('tag');

--- a/stamplay-js-sdk/stamplay-js-sdk.d.ts
+++ b/stamplay-js-sdk/stamplay-js-sdk.d.ts
@@ -26,6 +26,7 @@ declare module Stamplay {
   }
 
   export interface StamplayStatic {
+      init(appId : string) : void;
       User() : IStamplayObject
       Cobject(object : string) : IStamplayObject
   }


### PR DESCRIPTION
Add `Stamplay.init` definition for setting the app ID. It's basic configuration for Stamplay.

https://github.com/Stamplay/stamplay-js-sdk#getting-started
