### PR TITLE
Add missing ; to swig.d.ts

### DIFF
--- a/swig/swig.d.ts
+++ b/swig/swig.d.ts
@@ -28,7 +28,7 @@ declare module "swig" {
         compileFile(pathname: string, options?: SwigOptions): (locals?: any) => string;
         render(source: string, options?: SwigOptions): string;
         renderFile(pathName: string, locals: any, cb: (err: Error, output: string) => void): void;
-        renderFile(pathName: string, locals?: any): string
+        renderFile(pathName: string, locals?: any): string;
         run(templateFn: Function, locals?: any, filePath?: string): string;
         invalidateCache(): void;
 


### PR DESCRIPTION
Swig.d.ts was missing a ; in line 31. This leads to warnings in this file.
