### PR TITLE
grunt.util.ISpawnOptions.cmd is optional

### DIFF
--- a/gruntjs/gruntjs.d.ts
+++ b/gruntjs/gruntjs.d.ts
@@ -1172,7 +1172,7 @@ declare module grunt {
             /**
              * The command to execute. It should be in the system path.
              */
-            cmd: string
+            cmd?: string
 
             /**
              * If specified, the same grunt bin that is currently running will be


### PR DESCRIPTION
The following options are perfectly valid but will yield a "not assignable" error:

```
var spawnOptions: grunt.util.ISpawnOptions = {grunt: true, args: ["mytask"]};
grunt.util.spawn(spawnOptions);
```
