### PR TITLE
Knockout fix Observable Array sort/reverse return type

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -30,9 +30,9 @@ interface KnockoutObservableArrayFunctions<T> {
     push(...items: T[]): void;
     shift(): T;
     unshift(...items: T[]): number;
-    reverse(): T[];
-    sort(): void;
-    sort(compareFunction: (left: T, right: T) => number): void;
+    reverse(): KnockoutObservableArray<T>;
+    sort(): KnockoutObservableArray<T>;
+    sort(compareFunction: (left: T, right: T) => number): KnockoutObservableArray<T>;
 
     // Ko specific
     [key: string]: KnockoutBindingHandler;


### PR DESCRIPTION
The sort and reverse method on KnockoutObservableArray<T> return KnockoutObservableArray<T>.
