### PR TITLE
github-electron: Add missing menu item option 'role'

### DIFF
--- a/github-electron/github-electron-main-tests.ts
+++ b/github-electron/github-electron-main-tests.ts
@@ -125,7 +125,40 @@ var dockMenu = Menu.buildFromTemplate([
 			<GitHubElectron.MenuItemOptions>{ label: 'Pro' }
 		]
 	},
-	<GitHubElectron.MenuItemOptions>{ label: 'New Command...' }
+	<GitHubElectron.MenuItemOptions>{ label: 'New Command...' },
+	<GitHubElectron.MenuItemOptions>{
+		label: 'Edit',
+		submenu: [
+			{
+				label: 'Undo',
+				accelerator: 'CmdOrCtrl+Z',
+				role: 'undo'
+			},
+			{
+				label: 'Redo',
+				accelerator: 'Shift+CmdOrCtrl+Z',
+				role: 'redo'
+			},
+			{
+				type: 'separator'
+			},
+			{
+				label: 'Cut',
+				accelerator: 'CmdOrCtrl+X',
+				role: 'cut'
+			},
+			{
+				label: 'Copy',
+				accelerator: 'CmdOrCtrl+C',
+				role: 'copy'
+			},
+			{
+				label: 'Paste',
+				accelerator: 'CmdOrCtrl+V',
+				role: 'paste'
+			},
+		]
+	},
 ]);
 app.dock.setMenu(dockMenu);
 

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -880,6 +880,10 @@ declare module GitHubElectron {
 		 * a given menu.
 		 */
 		position?: string;
+		/**
+		 * Define the action of the menu item, when specified the click property will be ignored
+		 */
+		role?: string;
 	}
 
 	class BrowserWindowProxy {


### PR DESCRIPTION
I noticed that `MenuItemOptions` lacks `role` option.  So I added.

https://github.com/atom/electron/blob/master/docs/api/menu-item.md#new-menuitemoptions
