### PR TITLE
Fix: declare var require: NodeRequire

### DIFF
--- a/requirejs/require.d.ts
+++ b/requirejs/require.d.ts
@@ -393,5 +393,5 @@ interface RequireDefine {
 
 // Ambient declarations for 'require' and 'define'
 declare var requirejs: Require;
-declare var require: Require;
+declare var require: NodeRequire;
 declare var define: RequireDefine;


### PR DESCRIPTION
tsc reports an error that the require variable should be of type NodeRequire and not Require.
Works with this fix.
