### PR TITLE
RequestPromise to extend Promise<T>

### DIFF
--- a/request-promise/request-promise.d.ts
+++ b/request-promise/request-promise.d.ts
@@ -12,10 +12,7 @@ declare module 'request-promise' {
     import request = require('request');
     import http = require('http');
         
-    interface RequestPromise extends request.Request {
-        then(onFulfilled: Function, onRejected?: Function): Promise<any>;
-        catch(onRejected: Function): Promise<any>;
-        finally(onFinished: Function): Promise<any>;
+    interface RequestPromise extends request.Request, Promise<any> {
         promise(): Promise<any>;
     }
     

--- a/request-promise/request-promise.d.ts
+++ b/request-promise/request-promise.d.ts
@@ -12,7 +12,13 @@ declare module 'request-promise' {
     import request = require('request');
     import http = require('http');
         
-    interface RequestPromise extends request.Request, Promise<any> {
+    interface RequestPromise extends request.Request {
+        then<TResult>(onfulfilled?: (value: any) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>;
+        then<TResult>(onfulfilled?: (value: any) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<TResult>;
+        catch(onrejected?: (reason: any) => any | PromiseLike<any>): Promise<any>;
+        catch(onrejected?: (reason: any) => void): Promise<any>;
+        finally<TResult>(handler: () => PromiseLike<TResult>): Promise<any>;
+        finally<TResult>(handler: () => TResult): Promise<any>;
         promise(): Promise<any>;
     }
     


### PR DESCRIPTION
The current then/catch/finally in RequestPromise don't have proper definition. As a result `await` in Typescript 1.7 fails during compilation blaming that there's no proper `then` implementation.
