### PR TITLE
allow arbitrary key names when setting defaults

### DIFF
--- a/nconf/nconf-tests.ts
+++ b/nconf/nconf-tests.ts
@@ -48,6 +48,8 @@ p = nconf.use(str, opts);
 p = nconf.defaults();
 p = nconf.defaults(opts);
 
+p = nconf.defaults({foo: 'bar'});
+
 nconf.init();
 nconf.init(opts);
 

--- a/nconf/nconf.d.ts
+++ b/nconf/nconf.d.ts
@@ -48,11 +48,12 @@ declare module "nconf" {
 		parse: (str: string) => any;
 	}
 
-	export interface IOptions {
-		type?: string;
+	export interface IOptions { 
+		[index: string]: any; 
 	}
 
-	export interface IFileOptions extends IOptions {
+	export interface IFileOptions {
+		type?: string;
 		file?: string;
 		dir?: string;
 		search?: boolean;


### PR DESCRIPTION
this is first day of learning typescript so this may/may not make sense.

i try to use nconf and when settings defaults i get this error message: 
error TS2345: Argument of type '{ 'asset_host': string; 'backend_host': string; }' is not assignable to parameter of type 'IOptions'.
  Object literal may only specify known properties, and ''asset_host'' does not exist in type 'IOptions'.

when the code looked like
nconf.defaults({ 'asset_host': 'foo', 'backend_host': 'bar'});

the only defaults i could set was 
nconf.defaults({ 'type': 'foo' });
but it doesnt make a lot of sense to pre define the key names that the user can pass.
