### PR TITLE
Fix _.sum over properties by name in Lodash

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -5796,8 +5796,12 @@ module TestRound {
 // _.sum
 module TestSum {
     let array: number[];
+    let objectArray: { 'age': number }[];
+
     let list: _.List<number>;
     let dictionary: _.Dictionary<number>;
+
+    let objectToIterateOver: { 'a': { 'age': number }, 'b': { 'age' : number } };
 
     let listIterator: (value: number, index: number, collection: _.List<number>) => number;
     let dictionaryIterator: (value: number, key: string, collection: _.Dictionary<number>) => number;
@@ -5809,36 +5813,36 @@ module TestSum {
         result = _.sum<number>(array);
         result = _.sum<number>(array, listIterator);
         result = _.sum<number>(array, listIterator, any);
-        result = _.sum<number>(array, '');
 
+        result = _.sum(objectArray, 'age');
 
         result = _.sum(list);
         result = _.sum<number>(list);
         result = _.sum<number>(list, listIterator);
         result = _.sum<number>(list, listIterator, any);
-        result = _.sum<number>(list, '');
 
         result = _.sum(dictionary);
         result = _.sum<number>(dictionary);
         result = _.sum<number>(dictionary, dictionaryIterator);
         result = _.sum<number>(dictionary, dictionaryIterator, any);
-        result = _.sum<number>(dictionary, '');
+
+        result = _.sum(objectToIterateOver, 'age');
 
         result = _(array).sum();
         result = _(array).sum(listIterator);
         result = _(array).sum(listIterator, any);
-        result = _(array).sum('');
 
+        result = _(objectArray).sum('age');
 
         result = _(list).sum();
         result = _(list).sum<number>(listIterator);
         result = _(list).sum<number>(listIterator, any);
-        result = _(list).sum('');
 
         result = _(dictionary).sum();
         result = _(dictionary).sum<number>(dictionaryIterator);
         result = _(dictionary).sum<number>(dictionaryIterator, any);
-        result = _(dictionary).sum('');
+
+        result = _(objectToIterateOver).sum('age');
     }
 
     {
@@ -5847,18 +5851,18 @@ module TestSum {
         result = _(array).chain().sum();
         result = _(array).chain().sum(listIterator);
         result = _(array).chain().sum(listIterator, any);
-        result = _(array).chain().sum('');
 
+        result = _(objectArray).chain().sum('age');
 
         result = _(list).chain().sum();
         result = _(list).chain().sum<number>(listIterator);
         result = _(list).chain().sum<number>(listIterator, any);
-        result = _(list).chain().sum('');
 
         result = _(dictionary).chain().sum();
         result = _(dictionary).chain().sum<number>(dictionaryIterator);
         result = _(dictionary).chain().sum<number>(dictionaryIterator, any);
-        result = _(dictionary).chain().sum('');
+
+        result = _(objectToIterateOver).chain().sum('age');
     }
 }
 

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -9946,8 +9946,8 @@ declare module _ {
         /**
          * @see _.sum
          */
-        sum<T>(
-            collection: List<number>|Dictionary<number>,
+        sum(
+            collection: List<{}>|{},
             iteratee: string
         ): number;
 


### PR DESCRIPTION
A [recent change](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/991fda1fd551b913940dfa26028aa98263f1b6c9) broke `_.sum` when used with a string property argument.

Paraphrasing the example in [the Lodash documentation](https://lodash.com/docs#sum) itself gives:

``` javascript
var objects = [
  { 'n': 4 },
  { 'n': 6 }
];

// using the `_.property` callback shorthand
_.sum(objects, 'n'); // Returns 10
```

In the above linked change the type of this overload was changed to `sum<T>(collection: List<number>|Dictionary<number>): number`, which disallows this example (and rejects lots of my happily working code too).

More specifically, this change means you could only use the property callback shorthand version with lists or dictionaries of numbers, which is actually almost the only case which you don't really want (since you're very unlikely to ever be picking and summing properties of the numbers in an array, rather than the numbers themselves). Instead, you want to be able to sum over any iterable type (so, basically anything), which has a number-typed property of the given name (which isn't something we can check at compile time in TypeScript)

This generalises the type again to fix that. The type is now _very_ general, but it has to be; you genuinly are allowed to sum over pretty much whatever you like if you provide a property name, since we can't tell if that property will exist statically, and I don't think there's anything we can do to be more specific about that (at least until https://github.com/Microsoft/TypeScript/issues/1295 lands, one day).
