### PR TITLE
Allow FirebaseQuery.equalTo() to take boolean values

### DIFF
--- a/firebase/firebase.d.ts
+++ b/firebase/firebase.d.ts
@@ -143,6 +143,7 @@ interface FirebaseQuery {
 	 */
 	equalTo(value: string, key?: string): FirebaseQuery;
 	equalTo(value: number, key?: string): FirebaseQuery;
+	equalTo(value: boolean, key?: string): FirebaseQuery;
 	/**
 	 * Generates a new Query object limited to the first certain number of children.
 	 */


### PR DESCRIPTION
FirebaseQuery.equalTo() can take boolean values. See https://www.firebase.com/docs/web/api/query/equalto.html
