### PR TITLE
[material-ui] Fix some props

### DIFF
--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -123,6 +123,7 @@ declare namespace __MaterialUI {
     }
 
     interface AppCanvasProps extends React.Props<AppCanvas> {
+        style?: React.CSSProperties;
     }
     export class AppCanvas extends React.Component<AppCanvasProps, {}> {
     }
@@ -787,6 +788,7 @@ declare namespace __MaterialUI {
         menuItemStyle?: React.CSSProperties;
         selectedIndex?: number;
         underlineStyle?: React.CSSProperties;
+        underlineFocusStyle?: React.CSSProperties;
         iconStyle?: React.CSSProperties;
         labelStyle?: React.CSSProperties;
         style?: React.CSSProperties;
@@ -1140,7 +1142,7 @@ declare namespace __MaterialUI {
 
     namespace Tabs {
         interface TabProps extends React.Props<Tab> {
-            label?: string;
+            label?: any;
             value?: string;
             selected?: boolean;
             width?: string;
@@ -1257,7 +1259,9 @@ declare namespace __MaterialUI {
 
         interface TableRowColumnProps extends React.Props<TableRowColumn> {
             columnNumber?: number;
+            colSpan?: number;
             hoverable?: boolean;
+            onClick?: React.MouseEventHandler;
             onHover?: (e: React.MouseEvent, column: number) => void;
             onHoverExit?: (e: React.MouseEvent, column: number) => void;
             style?: React.CSSProperties;
@@ -1532,19 +1536,19 @@ declare namespace __MaterialUI {
         export class MenuDivider extends React.Component<MenuDividerProps, {}>{
         }
     }
-    
+
     namespace GridList {
-        
+
         interface GridListProps extends React.Props<GridList> {
             cols?: number;
             padding?: number;
             cellHeight?: number;
             style?: React.CSSProperties;
         }
-        
+
         export class GridList extends React.Component<GridListProps, {}>{
         }
-        
+
         interface GridTileProps extends React.Props<GridTile> {
             title?: string;
             subtitle?: __React.ReactNode;
@@ -1557,10 +1561,10 @@ declare namespace __MaterialUI {
             rootClass?: string | __React.Component<any,any>;
             style?: React.CSSProperties;
         }
-        
+
         export class GridTile extends React.Component<GridTileProps, {}>{
         }
-        
+
     }
 }    // __MaterialUI
 


### PR DESCRIPTION
Some props were missing on some components. Also Tab's `label` prop can take anything, not only `string`.
