### PR TITLE
Add type definitions of shuffle-array package

### DIFF
--- a/shuffle-array/shuffle-array-tests.ts
+++ b/shuffle-array/shuffle-array-tests.ts
@@ -1,0 +1,20 @@
+/// <reference path="../shuffle-array/shuffle-array.d.ts" />
+
+import shuffle = require('shuffle-array');
+
+// shuffle()
+var a = [1, 2, 3, 4, 5];
+var result: number[];
+result = shuffle(a);
+result = shuffle(a, {});
+result = shuffle(a, {copy: true});
+result = shuffle(a, {rng: () => 0});
+result = shuffle(a, {copy: true, rng: () => 0});
+
+var b = ['aaa', 'bbb', 'ccc']
+var result2: string[];
+result2 = shuffle.pick(b);
+result2 = shuffle.pick(b, {});
+result2 = shuffle.pick(b, {picks: 3});
+result2 = shuffle.pick(b, {rng: () => 0});
+result2 = shuffle.pick(b, {picks: 3, rng: () => 0});

--- a/shuffle-array/shuffle-array.d.ts
+++ b/shuffle-array/shuffle-array.d.ts
@@ -1,0 +1,42 @@
+// Type definitions for shuffle-array
+// Project: https://github.com/pazguille/shuffle-array
+// Definitions by: rhysd <https://rhysd.github.io>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "shuffle-array" {
+	/**
+	 * copy - Sets if should return a shuffled copy of the given array. By default it's a falsy value.
+	 * rng - Specifies a custom random number generator.
+	 */
+	interface ShuffleOption {
+		copy?: boolean;
+		rng?: () => number;
+	}
+	/**
+	 * picks - Specifies how many random elements you want to pick. By default it picks 1.
+	 * rng - Specifies a custom random number generator.
+	 */
+	interface PickOption {
+		picks?: number;
+		rng?: () => number;
+	}
+	interface ShuffleArray {
+		/**
+		 * Randomizes the order of the elements in a given array.
+		 *
+		 * arr - The given array.
+		 * options - Optional configuration options.
+		 */
+		<T>(arr: T[], options?: ShuffleOption): T[];
+		/**
+		 * Pick one or more random elements from the given array.
+		 *
+		 * arr - The given array.
+		 * options - Optional configuration options.
+		 */
+		pick<T>(arr: T[], options?: Object): T[];
+	}
+	var shuffle: ShuffleArray;
+	export = shuffle;
+}
+


### PR DESCRIPTION
I added type definitions for shuffle-array.  API document is [here](https://github.com/pazguille/shuffle-array#api)
