### PR TITLE
Fixing rx-lite module name

### DIFF
--- a/rx/rx.lite.d.ts
+++ b/rx/rx.lite.d.ts
@@ -10,6 +10,6 @@
 ///<reference path="rx.backpressure-lite.d.ts" />
 ///<reference path="rx.coincidence-lite.d.ts" />
 
-declare module "rx.lite" {
+declare module "rx-lite" {
 	export = Rx;
 }


### PR DESCRIPTION
The module for rx-lite should be 'rx-lite', not 'rx.lite'. See https://www.npmjs.com/package/rx-lite
