### PR TITLE
strokeMiterlimit was left out of the React 0.14 typings

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -1864,6 +1864,7 @@ declare namespace __React {
         stroke?: string;
         strokeDasharray?: string;
         strokeLinecap?: string;
+        strokeMiterlimit?: string;
         strokeOpacity?: number | string;
         strokeWidth?: number | string;
         textAnchor?: string;


### PR DESCRIPTION
This is exactly the same thing as the already merged https://github.com/DefinitelyTyped/DefinitelyTyped/pull/5896 for React 0.13, but it got left out of the React 0.14 updates somehow :)
