### PR TITLE
return appropriate Types array if not specify Type value.

### DIFF
--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -11979,7 +11979,8 @@ declare module _ {
          * @param object The object to query.
          * @return Returns an array of property values.
          */
-        values<T>(object?: any): T[];
+        values<T>(object?: { [idx: number]: T }): T[];
+        values<T>(object?: { [idx: string]: T }): T[];
     }
 
     interface LoDashImplicitObjectWrapper<T> {


### PR DESCRIPTION
``` javascript
import { values } from 'lodash';
class Foo { ... }

const fooMap = { "a": new Foo(), "b": new Foo() };

// following fooList is typed as `Foo[]`
const fooList = values<Foo>(fooMap); // -> Foo[]

// but following is typed as `{}[]`
const fooList = values(fooMap); // -> {}[]
```

I made _.values better typed.
