### PR TITLE
update node.d.ts (publicEncrypt & privateDecrypt)

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1672,12 +1672,12 @@ declare module "crypto" {
     export function pseudoRandomBytes(size: number, callback: (err: Error, buf: Buffer) =>void ): void;
     export interface RsaPublicKey {
         key: string;
-        padding: any;
+        padding?: any;
     }
     export interface RsaPrivateKey {
         key: string;
-        passphrase: string,
-        padding: any;
+        passphrase?: string,
+        padding?: any;
     }
     export function publicEncrypt(public_key: string|RsaPublicKey, buffer: Buffer): Buffer
     export function privateDecrypt(private_key: string|RsaPrivateKey, buffer: Buffer): Buffer

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1670,6 +1670,17 @@ declare module "crypto" {
     export function randomBytes(size: number, callback: (err: Error, buf: Buffer) =>void ): void;
     export function pseudoRandomBytes(size: number): Buffer;
     export function pseudoRandomBytes(size: number, callback: (err: Error, buf: Buffer) =>void ): void;
+    export interface RsaPublicKey {
+        key: string;
+        padding: any;
+    }
+    export interface RsaPrivateKey {
+        key: string;
+        passphrase: string,
+        padding: any;
+    }
+    export function publicEncrypt(public_key: string|RsaPublicKey, buffer: Buffer): Buffer
+    export function privateDecrypt(private_key: string|RsaPrivateKey, buffer: Buffer): Buffer
 }
 
 declare module "stream" {


### PR DESCRIPTION
hello,

i missed two functions in node.d.ts (added in node v0.12 see at https://nodejs.org/docs/v0.12.0/api/crypto.html#crypto_crypto_publicencrypt_public_key_buffer):

crypto.publicEncrypt(public_key, buffer)
crypto.privateDecrypt(private_key, buffer)

is it possible to add them? (see at my pull request)
