### PR TITLE
Update README build status badge to correct URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DefinitelyTyped [![Build Status](https://travis-ci.org/borisyankov/DefinitelyTyped.png?branch=master)](https://travis-ci.org/borisyankov/DefinitelyTyped)
+# DefinitelyTyped [![Build Status](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped.png?branch=master)](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped)
 
 [![Join the chat at https://gitter.im/borisyankov/DefinitelyTyped](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/borisyankov/DefinitelyTyped?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 


### PR DESCRIPTION
Looks like the build has moved from https://travis-ci.org/borisyankov/DefinitelyTyped to https://travis-ci.org/DefinitelyTyped/DefinitelyTyped, which breaks the badge in the README. This updates that.
