### PR TITLE
Add typing for Map.eachLayer from Leaflet

### DIFF
--- a/leaflet/leaflet-tests.ts
+++ b/leaflet/leaflet-tests.ts
@@ -131,6 +131,7 @@ var layer = L.tileLayer("http://{s}.example.net/{x}/{y}/{z}.png");
 
 map.addLayer(layer);
 map.addLayer(layer, false);
+map.eachLayer(l => {});
 
 map.removeLayer(layer);
 map.hasLayer(layer);

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -516,7 +516,7 @@ declare module L {
         function (options?: ControlOptions): Control;
     }
 
-    namespace control {
+    export namespace control {
 
         /**
           * Creates a zoom control.
@@ -2441,6 +2441,12 @@ declare namespace L {
           */
         options: Map.MapOptions;
 
+        /**
+          * Iterates over the layers of the map, optionally specifying context 
+		  * of the iterator function.
+          */
+        eachLayer(fn: (layer: ILayer) => void, context?: any): Map;
+
         ////////////////
         ////////////////
         addEventListener(type: string, fn: (e: LeafletEvent) => void, context?: any): Map;
@@ -3261,7 +3267,7 @@ declare namespace L {
         off(eventMap?: any, context?: any): Path;
     }
 
-    namespace Path {
+    export namespace Path {
         /**
           * True if SVG is used for vector rendering (true for most modern browsers).
           */


### PR DESCRIPTION
Method documented here was missing: http://leafletjs.com/reference.html#map-eachlayer
