### PR TITLE
[chai] Correct type of AssertionError

### DIFF
--- a/chai/chai.d.ts
+++ b/chai/chai.d.ts
@@ -19,7 +19,7 @@ declare module Chai {
         use(fn: (chai: any, utils: any) => void): any;
         assert: AssertStatic;
         config: Config;
-        AssertionError: AssertionError;
+        AssertionError: typeof AssertionError;
     }
 
     export interface ExpectStatic extends AssertionStatic {


### PR DESCRIPTION
AssertionError on the global chai object is the constructor for AssertionErrors, but the definition was written as though it was an instance of an assertion error.
