### PR TITLE
add open event for dialog(as build failed in TypeScript 1.7)

### DIFF
--- a/jqueryui/jqueryui.d.ts
+++ b/jqueryui/jqueryui.d.ts
@@ -362,7 +362,8 @@ declare module JQueryUI {
         title?: string;
         width?: any; // number or string
         zIndex?: number;
-
+		
+		open?: DialogEvent;
         close?: DialogEvent;
     }
 


### PR DESCRIPTION
when i use TypeScript 1.7 to build my old project(with TypeScript 1.4), the build failed as no "open" event, build passed after "open" event added.
