### PR TITLE
support es6 import syntax for gulp-babel

### DIFF
--- a/gulp-babel/gulp-babel.d.ts
+++ b/gulp-babel/gulp-babel.d.ts
@@ -36,5 +36,7 @@ declare module 'gulp-babel' {
 		retainLines?: boolean
 	}): NodeJS.ReadWriteStream;
 
+	module babel { }
+
 	export = babel;
 }


### PR DESCRIPTION
Using the same trick as https://github.com/DefinitelyTyped/DefinitelyTyped/pull/7063
