### PR TITLE
mdDialog.hide should return Promise instead of void

### DIFF
--- a/angular-material/angular-material-0.8.3.d.ts
+++ b/angular-material/angular-material-0.8.3.d.ts
@@ -59,7 +59,7 @@ declare module angular.material {
         show(dialog: MDDialogOptions|MDPresetDialog<any>): angular.IPromise<any>;
         confirm(): MDConfirmDialog;
         alert(): MDAlertDialog;
-        hide(response?: any): void;
+        hide(response?: any): angular.IPromise<any>;
         cancel(response?: any): void;
     }
 

--- a/angular-material/angular-material-0.9.0.d.ts
+++ b/angular-material/angular-material-0.9.0.d.ts
@@ -64,7 +64,7 @@ declare module angular.material {
         show(dialog: MDDialogOptions|MDAlertDialog|MDConfirmDialog): angular.IPromise<any>;
         confirm(): MDConfirmDialog;
         alert(): MDAlertDialog;
-        hide(response?: any): void;
+        hide(response?: any): angular.IPromise<any>;
         cancel(response?: any): void;
     }
 

--- a/angular-material/angular-material.d.ts
+++ b/angular-material/angular-material.d.ts
@@ -83,7 +83,7 @@ declare module angular.material {
         show(dialog: IDialogOptions|IAlertDialog|IConfirmDialog): angular.IPromise<any>;
         confirm(): IConfirmDialog;
         alert(): IAlertDialog;
-        hide(response?: any): void;
+        hide(response?: any): angular.IPromise<any>;
         cancel(response?: any): void;
     }
 


### PR DESCRIPTION
This changes allow us to run some code when dialog window was successfully closed.
