### PR TITLE
[node] export Stream as class, not interface

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1675,7 +1675,7 @@ declare module "crypto" {
 declare module "stream" {
     import * as events from "events";
 
-    export interface Stream extends events.EventEmitter {
+    export class Stream extends events.EventEmitter {
         pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
     }
 


### PR DESCRIPTION
require('stream').Stream in Node.js is a constructor.
