### PR TITLE
Fix electron.nativeImage's type

### DIFF
--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -1700,7 +1700,7 @@ declare module GitHubElectron {
 	interface Electron {
 		clipboard: GitHubElectron.Clipboard;
 		crashReporter: GitHubElectron.CrashReporter;
-		nativeImage: GitHubElectron.NativeImage;
+		nativeImage: typeof GitHubElectron.NativeImage;
 		screen: GitHubElectron.Screen;
 		shell: GitHubElectron.Shell;
 		remote: GitHubElectron.Remote;


### PR DESCRIPTION
Hey folks! Thanks @rhysd for the v0.35 definition update!

I believe `require("electron").nativeImage` is the class itself, not an instance of it, so its type should be `typeof GitHubElectron.NativeImage`.
