### PR TITLE
Update Angulartics type definition to version 0.20.2

### DIFF
--- a/angulartics/angulartics.d.ts
+++ b/angulartics/angulartics.d.ts
@@ -21,7 +21,7 @@ declare module angulartics {
 
     interface IAnalyticsServiceProvider extends angular.IServiceProvider {
         virtualPageviews(value: boolean): void;
-        excludeRoutes(value: string[]):void;
+        excludeRoutes(value: string[]): void;
         firstPageview(value: boolean): void;
         withBase(value: boolean): void;
         withAutoBase(value: boolean): void;

--- a/angulartics/angulartics.d.ts
+++ b/angulartics/angulartics.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Angulartics v0.19.2
+// Type definitions for Angulartics v0.20.2
 // Project: http://luisfarzati.github.io/angulartics/
 // Definitions by: Steven Fan <https://github.com/stevenfan>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -21,6 +21,7 @@ declare module angulartics {
 
     interface IAnalyticsServiceProvider extends angular.IServiceProvider {
         virtualPageviews(value: boolean): void;
+        excludeRoutes(value: string[]):void;
         firstPageview(value: boolean): void;
         withBase(value: boolean): void;
         withAutoBase(value: boolean): void;


### PR DESCRIPTION
Newer version of Angulartics (0.20.2), brings a new feature that allows to exclude specific routes from pageview tracking.
Version release on 17/11/2015.
Project changes log: https://github.com/angulartics/angulartics/blob/master/CHANGELOG.md
Original plugin pull request and description: https://github.com/angulartics/angulartics/pull/419
