### PR TITLE
typeahead.js reflect api changes

### DIFF
--- a/typeahead/typeahead.d.ts
+++ b/typeahead/typeahead.d.ts
@@ -399,6 +399,8 @@ declare module Bloodhound {
          * @returns A JqueryAjaxSettings object.
          */
         prepare?: (query: string, settings: JQueryAjaxSettings) => JQueryAjaxSettings;
+        
+        transform: (reponse: any) => any;
     }
 
     /**

--- a/typeahead/typeahead.d.ts
+++ b/typeahead/typeahead.d.ts
@@ -165,7 +165,7 @@ declare module Twitter.Typeahead {
          * cb can be invoked synchronously or asynchronously.
          *
           */
-        source: ((query: string, syncResults: (result: Array<any>) => void, asyncResults?: (result: Array<any>) => void) => void);
+        source: ((query: string, syncResults: (result: Array<any>) => void, asyncResults?: (result: Array<any>) => void) => void) | Bloodhound<any>;
 
         /**
           * The name of the dataset.

--- a/typeahead/typeahead.d.ts
+++ b/typeahead/typeahead.d.ts
@@ -188,6 +188,11 @@ declare module Twitter.Typeahead {
           */
         templates?: Templates;
         async?: boolean;
+        
+        /**
+         * The max number of suggestions to be displayed. Defaults to 5.
+         */
+        limit?: number
     }
 
 


### PR DESCRIPTION
The current version of typeahead.js 0.11.1 has two signatures different than in the d.ts file
See https://github.com/twitter/typeahead.js/blob/master/doc/jquery_typeahead.md#datasets and https://github.com/twitter/typeahead.js/blob/master/doc/bloodhound.md#remote
