### PR TITLE
jsSHA browser global definition & test.

### DIFF
--- a/jssha/jssha-tests.ts
+++ b/jssha/jssha-tests.ts
@@ -47,3 +47,10 @@ let hmac5:string = shaObj1.getHMAC("HEX", { outputUpper: true, b64Pad: '=' });
 	shaObj.update("This is a test");
 	let hmac = shaObj.getHMAC("HEX");
 }
+
+// Browser global test
+{
+	var shaObj = new jsSHA("SHA-512", "TEXT");
+	shaObj.update("This is a test");
+	var hash = shaObj.getHash("HEX");
+}

--- a/jssha/jssha.d.ts
+++ b/jssha/jssha.d.ts
@@ -79,7 +79,7 @@ declare module jsSHA {
     }
 }
 
+declare var jsSHA: jsSHA.jsSHA;
 declare module 'jssha' {
-	var jsSHA: jsSHA.jsSHA;
     export = jsSHA;
 }


### PR DESCRIPTION
Pull request #6891 removed the global `jsSHA` definition. The test would have caught this error, but that pull request also removed the test. This global var definitely exists, is used by people in production, and [can be seen in the jsSHA source here](https://github.com/Caligatio/jsSHA/blob/de0cf6817e2125388c39ffc2a478ff4f8a69405a/src/sha_dev.js#L1698).

I have added back both the definition and the test for it.
