### PR TITLE
Add definitions for scrypt-async v1.2.0

### DIFF
--- a/scrypt-async/scrypt-async-tests.ts
+++ b/scrypt-async/scrypt-async-tests.ts
@@ -1,0 +1,25 @@
+// Tests by: Kaur Kuut <https://github.com/xStrom>
+
+///<reference path="scrypt-async.d.ts" />
+
+var callback = function(key: string | number[]) { };
+
+scrypt("abc", "def", 10, 8, 32, 1000, callback, "base64");
+scrypt("abc", [4,5,6], 10, 8, 32, 1000, callback, "base64");
+scrypt([1,2,3], "def", 10, 8, 32, 1000, callback, "base64");
+scrypt([1,2,3], [4,5,6], 10, 8, 32, 1000, callback, "base64");
+
+scrypt("abc", "def", 10, 8, 32, 1000, callback);
+scrypt("abc", [4,5,6], 10, 8, 32, 1000, callback);
+scrypt([1,2,3], "def", 10, 8, 32, 1000, callback);
+scrypt([1,2,3], [4,5,6], 10, 8, 32, 1000, callback);
+
+scrypt("abc", "def", 10, 8, 32, callback, "base64");
+scrypt("abc", [4,5,6], 10, 8, 32, callback, "base64");
+scrypt([1,2,3], "def", 10, 8, 32, callback, "base64");
+scrypt([1,2,3], [4,5,6], 10, 8, 32, callback, "base64");
+
+scrypt("abc", "def", 10, 8, 32, callback);
+scrypt("abc", [4,5,6], 10, 8, 32, callback);
+scrypt([1,2,3], "def", 10, 8, 32, callback);
+scrypt([1,2,3], [4,5,6], 10, 8, 32, callback);

--- a/scrypt-async/scrypt-async.d.ts
+++ b/scrypt-async/scrypt-async.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for scrypt-async v1.2.0
+// Project: https://github.com/dchest/scrypt-async-js
+// Definitions by: Kaur Kuut <https://github.com/xStrom>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module ScryptAsync {
+	interface CallbackFunc {
+		(key: string): any;
+		(key: number[]): any;
+	}
+
+	interface ScryptStatic {
+		(password: string, salt: string, logN: number, r: number, dkLen: number, interruptStep: number, callback: CallbackFunc, encoding: string): void;
+		(password: string, salt: number[], logN: number, r: number, dkLen: number, interruptStep: number, callback: CallbackFunc, encoding: string): void;
+		(password: number[], salt: string, logN: number, r: number, dkLen: number, interruptStep: number, callback: CallbackFunc, encoding: string): void;
+		(password: number[], salt: number[], logN: number, r: number, dkLen: number, interruptStep: number, callback: CallbackFunc, encoding: string): void;
+		
+		(password: string, salt: string, logN: number, r: number, dkLen: number, interruptStep: number, callback: CallbackFunc): void;
+		(password: string, salt: number[], logN: number, r: number, dkLen: number, interruptStep: number, callback: CallbackFunc): void;
+		(password: number[], salt: string, logN: number, r: number, dkLen: number, interruptStep: number, callback: CallbackFunc): void;
+		(password: number[], salt: number[], logN: number, r: number, dkLen: number, interruptStep: number, callback: CallbackFunc): void;
+		
+		(password: string, salt: string, logN: number, r: number, dkLen: number, callback: CallbackFunc, encoding: string): void;
+		(password: string, salt: number[], logN: number, r: number, dkLen: number, callback: CallbackFunc, encoding: string): void;
+		(password: number[], salt: string, logN: number, r: number, dkLen: number, callback: CallbackFunc, encoding: string): void;
+		(password: number[], salt: number[], logN: number, r: number, dkLen: number, callback: CallbackFunc, encoding: string): void;
+		
+		(password: string, salt: string, logN: number, r: number, dkLen: number, callback: CallbackFunc): void;
+		(password: string, salt: number[], logN: number, r: number, dkLen: number, callback: CallbackFunc): void;
+		(password: number[], salt: string, logN: number, r: number, dkLen: number, callback: CallbackFunc): void;
+		(password: number[], salt: number[], logN: number, r: number, dkLen: number, callback: CallbackFunc): void;
+	}
+}
+
+declare var scrypt: ScryptAsync.ScryptStatic;
+
+declare module "scrypt-async" {
+	export = scrypt;
+}


### PR DESCRIPTION
This patch contains the definitions and tests for [scrypt-async](https://github.com/dchest/scrypt-async-js) v1.2.0.
