### PR TITLE
Fix PDFPageProxy property getter types in pdf.d.ts

### DIFF
--- a/pdf/pdf.d.ts
+++ b/pdf/pdf.d.ts
@@ -221,22 +221,22 @@ interface PDFPageProxy {
 	/**
 	 * Page number of the page.  First page is 1.
 	 **/
-	pageNumber(): number;
+	pageNumber: number;
 
 	/**
 	 * The number of degrees the page is rotated clockwise.
 	 **/
-	rotate(): number;
+	rotate: number;
 
 	/**
 	 * The reference that points to this page.
 	 **/
-	ref(): PDFRef;
+	ref: PDFRef;
 
 	/**
 	 * @return An array of the visible portion of the PDF page in the user space units - [x1, y1, x2, y2].
 	 **/
-	view(): number[];
+	view: number[];
 
 	/**
 	 * @param scale The desired scale of the viewport.


### PR DESCRIPTION
`pageNumber`, `rotate`, `ref`, and `view` are property getters, not functions.

Resolves #6726
