### PR TITLE
Make IObservable.off() args optional in fabricjs.d.ts

### DIFF
--- a/fabricjs/fabricjs.d.ts
+++ b/fabricjs/fabricjs.d.ts
@@ -345,7 +345,7 @@ declare module fabric {
      * @param eventName Event name (eg. 'after:render') or object with key/value pairs (eg. {'after:render': handler, 'selection:cleared': handler})
      * @param handler Function to be deleted from EventListeners
      */
-    off(eventName: string|any, handler: (e: IEvent) => any): T;
+    off(eventName?: string|any, handler?: (e: IEvent) => any): T;
   }
 
   // animation mixin


### PR DESCRIPTION
As specified in the [fabric.js documentation](http://fabricjs.com/docs/fabric.Observable.html#off), `IObservable.off()` accepts two optional arguments.
