### PR TITLE
Added parameter to sendResponse

### DIFF
--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -2646,13 +2646,13 @@ declare module chrome.extension {
 		 * Parameter request: The request sent by the calling script. 
 		 * Parameter sendResponse: Function to call (at most once) when you have a response. The argument should be any JSON-ifiable object, or undefined if there is no response. If you have more than one onRequest listener in the same document, then only one may send a response. 
 		 */
-		addListener(callback: (request: any, sender: runtime.MessageSender, sendResponse: () => void) => void): void;
+		addListener(callback: (request: any, sender: runtime.MessageSender, sendResponse: (response: any) => void) => void): void;
 		/**
 		 * @param callback The callback parameter should be a function that looks like this: 
 		 * function(runtime.MessageSender sender, function sendResponse) {...}; 
 		 * Parameter sendResponse: Function to call (at most once) when you have a response. The argument should be any JSON-ifiable object, or undefined if there is no response. If you have more than one onRequest listener in the same document, then only one may send a response. 
 		 */
-		addListener(callback: (sender: runtime.MessageSender, sendResponse: () => void) => void): void;
+		addListener(callback: (sender: runtime.MessageSender, sendResponse: (response: any) => void) => void): void;
     }
 
 	/**
@@ -5553,7 +5553,7 @@ declare module chrome.runtime {
 		 * Optional parameter message: The message sent by the calling script. 
 		 * Parameter sendResponse: Function to call (at most once) when you have a response. The argument should be any JSON-ifiable object. If you have more than one onMessage listener in the same document, then only one may send a response. This function becomes invalid when the event listener returns, unless you return true from the event listener to indicate you wish to send a response asynchronously (this will keep the message channel open to the other end until sendResponse is called). 
 		 */
-        addListener(callback: (message: any, sender: MessageSender, sendResponse: Function) => void): void;
+        addListener(callback: (message: any, sender: MessageSender, sendResponse: (response: any) => void) => void): void;
     }
 
     interface ExtensionConnectEvent extends chrome.events.Event {


### PR DESCRIPTION
The existing comments surrounding the usage of sendResponse clearly indicates that a value is to be passed to sendResponse. Additionally, every usage I've found of sendResponse validates those comments. 
