### PR TITLE
Made all entries in github-electron's WebPreferences interface optional

### DIFF
--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -450,14 +450,14 @@ declare module GitHubElectron {
 	interface WebPreferences {
 		nodeIntegration?: boolean;
 		preload?: string;
-		partition: string;
-		zoomFactor: number;
-		javascript: boolean;
-		webSecurity: boolean;
-		allowDisplayingInsecureContent: boolean;
-		allowRunningInsecureContent: boolean;
-		images: boolean;
-		textAreasAreResizable: boolean;
+		partition?: string;
+		zoomFactor?: number;
+		javascript?: boolean;
+		webSecurity?: boolean;
+		allowDisplayingInsecureContent?: boolean;
+		allowRunningInsecureContent?: boolean;
+		images?: boolean;
+		textAreasAreResizable?: boolean;
 		webgl?: boolean;
 		webaudio?: boolean;
 		plugins?: boolean;


### PR DESCRIPTION
The [github-electron documentation](https://github.com/atom/electron/blob/master/docs/api/browser-window.md) features default values for each of these values. The interface should mark these parameters as optional to reflect the functionality of the library. 
