### PR TITLE
Add definitions for CodeMirror's runmode addon

### DIFF
--- a/codemirror/codemirror-runmode-tests.ts
+++ b/codemirror/codemirror-runmode-tests.ts
@@ -1,0 +1,6 @@
+/// <reference path="codemirror.d.ts" />
+/// <reference path="codemirror-runmode.d.ts" />
+
+var query = "SELECT * FROM Table";
+
+CodeMirror.runMode(query, "text/x-sql", document.body);

--- a/codemirror/codemirror-runmode.d.ts
+++ b/codemirror/codemirror-runmode.d.ts
@@ -8,7 +8,7 @@
 declare module CodeMirror {
 
     /**
-     * Can be used to run a CodeMirror mode over text without actually opening an editor instance.
+     * Runs a CodeMirror mode over text without opening an editor instance.
      *
      * @param text The document to run through the highlighter.
      * @param mode The mode to use (must be loaded as normal).
@@ -18,5 +18,5 @@ declare module CodeMirror {
      *               tokens will be converted to span elements as in an editor,
      *               and inserted into the node (through innerHTML).
      */
-    function runMode(text : string, mode : any, output : any): void;
+    function runMode(text: string, modespec: any, callback: (HTMLElement | ((text: string, style: string) => void)), options? : { tabSize?: number; state?: any; }): void;
 }

--- a/codemirror/codemirror-runmode.d.ts
+++ b/codemirror/codemirror-runmode.d.ts
@@ -1,0 +1,22 @@
+﻿// Type definitions for CodeMirror
+// Project: https://github.com/marijnh/CodeMirror
+// Definitions by: Joseph Vaughan <https://github.com/Joev->
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// See docs https://codemirror.net/doc/manual.html#addon_runmode
+
+declare module CodeMirror {
+
+    /**
+     * Can be used to run a CodeMirror mode over text without actually opening an editor instance.
+     *
+     * @param text The document to run through the highlighter.
+     * @param mode The mode to use (must be loaded as normal).
+     * @param output If this is a function, it will be called for each token with
+     *               two arguments, the token's text and the token's style class
+     *               (may be null for unstyled tokens). If it is a DOM node, the
+     *               tokens will be converted to span elements as in an editor,
+     *               and inserted into the node (through innerHTML).
+     */
+    function runMode(text : string, mode : any, output : any): void;
+}


### PR DESCRIPTION
Adds definitions for CodeMIrror's [runmode](http://codemirror.net/doc/manual.html#addon_runmode) addon
