### PR TITLE
Add 'opts' function definition

### DIFF
--- a/restify/restify-tests.ts
+++ b/restify/restify-tests.ts
@@ -92,12 +92,14 @@ server.put( '/hello', send);
 server.del( '/hello', send);
 server.get( '/hello', send);
 server.head('/hello', send);
+server.opts('/hello', send);
 
 server.post(/(.*)/, send);
 server.put( /(.*)/, send);
 server.del( /(.*)/, send);
 server.get( /(.*)/, send);
 server.head(/(.*)/, send);
+server.opts(/(.*)/, send);
 
 
 new restify.BadRequestError();

--- a/restify/restify.d.ts
+++ b/restify/restify.d.ts
@@ -87,6 +87,11 @@ declare module "restify" {
     head(route: any, routeCallBack: RequestHandler, ...routeCallBacks: RequestHandler[][]): any;
     head(route: any, routeCallBack: RequestHandler[], ...routeCallBacks: RequestHandler[][]): any;
 
+    opts(route: any, routeCallBack: RequestHandler, ...routeCallBacks: RequestHandler[]): any;
+    opts(route: any, routeCallBack: RequestHandler[], ...routeCallBacks: RequestHandler[]): any;
+    opts(route: any, routeCallBack: RequestHandler, ...routeCallBacks: RequestHandler[][]): any;
+    opts(route: any, routeCallBack: RequestHandler[], ...routeCallBacks: RequestHandler[][]): any;
+	
     name: string;
     version: string;
     log: Object;


### PR DESCRIPTION
Function 'opts' defines custom actions for "OPTIONS" header, similar to 'post', 'head', etc...
Mentioned in the official API docs: http://restify.com/#cors
