### PR TITLE
$routeprovider - property

### DIFF
--- a/angularjs/angular-route.d.ts
+++ b/angularjs/angular-route.d.ts
@@ -128,6 +128,12 @@ declare module angular.route {
     }
 
     interface IRouteProvider extends IServiceProvider {
+		/**
+         * Match routes without being case sensitive
+         *
+         * This option defaults to false. If the option is set to true, then the particular route can be matched without being case sensitive
+         */
+        caseInsensitiveMatch?: boolean;
         /**
          * Sets route definition that will be used on route change when no other route definition is matched.
          *


### PR DESCRIPTION
As per AngularJs Documentation,
(https://docs.angularjs.org/api/ngRoute/provider/$routeProvider) ,
$routeProvider has a property "caseInsensitiveMatch" , which can
be used to turn off the case sensitive match globally. This is missing currently in DT. Please add this. As of now, i am manually adding this in my tsd.d.ts
