### PR TITLE
angular-translate: fixed es6 imports to have types properly exported instead of string

### DIFF
--- a/angular-translate/angular-translate.d.ts
+++ b/angular-translate/angular-translate.d.ts
@@ -6,8 +6,8 @@
 /// <reference path="../angularjs/angular.d.ts" />
 
 declare module "angular-translate" {
-    var _: string;
-    export = _;
+    import ngt = angular.translate;
+    export = ngt;
 }
 
 declare module angular.translate {


### PR DESCRIPTION
Currently imports for ES6 modules is defined as strings and types are not working correctly, this has been changed in order to provide the correct typings.
