### PR TITLE
[node] parameter type of "signal" in process.kill

### DIFF
--- a/node/node-0.10.d.ts
+++ b/node/node-0.10.d.ts
@@ -176,7 +176,7 @@ declare module NodeJS {
                 visibility: string;
             };
         };
-        kill(pid: number, signal?: string): void;
+        kill(pid:number, signal?: string|number): void;
         pid: number;
         title: string;
         arch: string;

--- a/node/node-0.11.d.ts
+++ b/node/node-0.11.d.ts
@@ -176,7 +176,7 @@ declare module NodeJS {
                 visibility: string;
             };
         };
-        kill(pid: number, signal?: string): void;
+        kill(pid:number, signal?: string|number): void;
         pid: number;
         title: string;
         arch: string;

--- a/node/node-0.12.d.ts
+++ b/node/node-0.12.d.ts
@@ -256,7 +256,7 @@ declare module NodeJS {
                 visibility: string;
             };
         };
-        kill(pid: number, signal?: string): void;
+        kill(pid:number, signal?: string|number): void;
         pid: number;
         title: string;
         arch: string;

--- a/node/node-0.8.8.d.ts
+++ b/node/node-0.8.8.d.ts
@@ -150,7 +150,7 @@ interface NodeProcess extends EventEmitter {
         visibility: string;
     };
     };
-    kill(pid: number, signal?: string): void;
+    kill(pid:number, signal?: string|number): void;
     pid: number;
     title: string;
     arch: string;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -256,7 +256,7 @@ declare module NodeJS {
                 visibility: string;
             };
         };
-        kill(pid: number, signal?: string): void;
+        kill(pid:number, signal?: string|number): void;
         pid: number;
         title: string;
         arch: string;


### PR DESCRIPTION
process.kill(pid:number, signal?:string): void;
shouldbe
process.kill(pid:number, signal?: string|number): void;

signal 0 can be used to test for the existence of a process.

see
https://nodejs.org/dist/latest-v5.x/docs/api/process.html#process_signal_events

Note that Windows does not support sending Signals, but Node.js offers some emulation with process.kill(), and child_process.kill(). Sending signal 0 can be used to test for the existence of a process. Sending SIGINT, SIGTERM, and SIGKILL cause the unconditional termination of the target process.
