### PR TITLE
Add host and port to TlsOptions struct

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -198,6 +198,13 @@ var ctx: tls.SecureContext = tls.createSecureContext({
 });
 var blah = ctx.context;
 
+var tlsOpts: tls.TlsOptions = {
+	host: "127.0.0.1",
+	port: 55
+};
+var tlsSocket = tls.connect(tlsOpts);
+
+
 ////////////////////////////////////////////////////
 
 // Make sure .listen() and .close() retuern a Server instance

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1535,6 +1535,8 @@ declare module "tls" {
     var CLIENT_RENEG_WINDOW: number;
 
     export interface TlsOptions {
+        host?: string;
+        port?: number;
         pfx?: any;   //string or buffer
         key?: any;   //string or buffer
         passphrase?: string;


### PR DESCRIPTION
Host and port were missing from the options struct that you pass to tls.connect()

See also https://nodejs.org/dist/latest-v4.x/docs/api/tls.html#tls_tls_connect_options_callback
