### PR TITLE
Fix type for DatePickerProps formatDate

### DIFF
--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -319,7 +319,7 @@ declare namespace __MaterialUI {
         interface DatePickerProps extends React.Props<DatePicker> {
             autoOk?: boolean;
             defaultDate?: Date;
-            formatDate?: string;
+            formatDate?: (date:Date) => string;
             hintText?: string;
             floatingLabelText?: string;
             hideToolbarYearChange?: boolean;


### PR DESCRIPTION
It should be a function/callback, not a string. See Docs: http://www.material-ui.com/#/components/date-picker
