### PR TITLE
Modified a method name.

### DIFF
--- a/onsenui/onsenui-tests.ts
+++ b/onsenui/onsenui-tests.ts
@@ -191,7 +191,7 @@ function onsTabbar(tabBar: TabbarView): void {
 		keepPage: true
 	};
 	tabBar.setActiveTab(2, options);
-	var activeTab: number = tabBar.getActiveTab();
+	var activeTab: number = tabBar.getActiveTabIndex();
 	tabBar.loadPage('myPage.html');
 	tabBar.on('eventName', null);
 	tabBar.once('eventName', null);

--- a/onsenui/onsenui.d.ts
+++ b/onsenui/onsenui.d.ts
@@ -634,7 +634,7 @@ interface TabbarView {
      * @return {Number} The index of the currently active tab
      * @description Returns tab index on current active tab. If active tab is not found, returns -1
      */
-    getActiveTab(): number;
+    getActiveTabIndex(): number;
     /**
      * @param {String} url Page URL. Can be either an HTML document or an <code>&lt;ons-template&gt;</code>
      * @description Displays a new page without changing the active index


### PR DESCRIPTION
TabbarView.getActiveTab() doesn't exist. 'getActiveTabIndex()` does exist instead. Maybe a typo.
For your reference. http://onsen.io/reference/ons-tabbar.html#methods-summary
