### PR TITLE
Fixes in 'temp' definitions

### DIFF
--- a/temp/temp-tests.ts
+++ b/temp/temp-tests.ts
@@ -11,6 +11,8 @@ function testCleanup() {
         }
         else {
             const { files, dirs } = result;
+            files.toPrecision(4);
+            files.toPrecision(4);
         }
     });
 }
@@ -22,16 +24,22 @@ function testCleanupSync() {
     }
     else {
         const { dirs, files } = cleanupResult
+        dirs.toPrecision(4);
+        files.toPrecision(4);
     }
 }
 
 function testOpen() {
     temp.open({ dir: "tempDir", prefix: "pref", suffix: "suff" }, (err, result) => {
         const { path, fd } = result;
+        path.length;
+        fd.toPrecision(5);
     });
 
     temp.open("strPrefix", (err, result) => {
         const { path, fd } = result;
+        path.length;
+        fd.toPrecision(5);
     });
 }
 
@@ -45,23 +53,24 @@ function testCreateWriteStream() {
     stream.write("data");
 }
 
-function testMkDir() {
-    temp.mkDir("prefix", (err, dirPath) => {
+function testMkdir() {
+    temp.mkdir("prefix", (err, dirPath) => {
         dirPath.length;
     });
 }
 
-function testMkDirSync() {
-    const result = temp.mkDirSync("prefix");
+function testMkdirSync() {
+    const result = temp.mkdirSync("prefix");
     result.length;
 }
 
 function testPath() {
-    temp.path({ suffix: "justSuffix" }, "defaultPrefix");
+    const p = temp.path({ suffix: "justSuffix" }, "defaultPrefix");
+    p.length;
 }
 
 function testTrack() {
-    const tempChained = temp.track(true).track(false);
+    const tempChained = temp.track().track(true).track(false);
     tempChained.dir;
     tempChained.cleanupSync();
 }

--- a/temp/temp.d.ts
+++ b/temp/temp.d.ts
@@ -17,13 +17,13 @@ declare module "temp" {
 
     export var dir: string;
 
-    export function track(value: boolean): typeof temp;
+    export function track(value?: boolean): typeof temp;
 
-    export function mkDir(affixes: string, callback?: (err: any, dirPath: string) => void): void;
-    export function mkDir(affixes: AffixOptions, callback?: (err: any, dirPath: string) => void): void;
+    export function mkdir(affixes: string, callback?: (err: any, dirPath: string) => void): void;
+    export function mkdir(affixes: AffixOptions, callback?: (err: any, dirPath: string) => void): void;
 
-    export function mkDirSync(affixes: string): string;
-    export function mkDirSync(affixes: AffixOptions): string;
+    export function mkdirSync(affixes: string): string;
+    export function mkdirSync(affixes: AffixOptions): string;
 
     export function open(affixes: string, callback?: (err: any, result: {path: string, fd: number}) => void): void;
     export function open(affixes: AffixOptions, callback?: (err: any, result: {path: string, fd: number}) => void): void;
@@ -31,8 +31,8 @@ declare module "temp" {
     export function openSync(affixes: string): { path: string, fd: number };
     export function openSync(affixes: AffixOptions): { path: string, fd: number };
 
-    export function path(affixes: string, defaultPrefix: string): void;
-    export function path(affixes: AffixOptions, defaultPrefix: string): void;
+    export function path(affixes: string, defaultPrefix: string): string;
+    export function path(affixes: AffixOptions, defaultPrefix: string): string;
 
     export function cleanup(callback?: (result: boolean | {files: number, dirs?: number}) => void): void;
 


### PR DESCRIPTION
Fixed casing for 'mkdir', return type of 'path', optionality of the 'track' parameter
