### PR TITLE
Add remove() to ionic.modal.IonicModalController

### DIFF
--- a/ionic/ionic-tests.ts
+++ b/ionic/ionic-tests.ts
@@ -149,6 +149,7 @@ class IonicTestController {
         ionicModalController.initialize(modalOptions);
         ionicModalController.show().then(() => console.log("shown modal"))
         ionicModalController.hide().then(() => console.log("hid modal"))
+        ionicModalController.remove().then(() => console.log("removed modal"))
         var isShown: boolean = ionicModalController.isShown();
 
         this.$ionicModal.fromTemplateUrl("templateUrl", modalOptions)

--- a/ionic/ionic.d.ts
+++ b/ionic/ionic.d.ts
@@ -174,6 +174,7 @@ declare module ionic {
             initialize(options: IonicModalOptions): void;
             show(): ng.IPromise<void>;
             hide(): ng.IPromise<void>;
+            remove(): ng.IPromise<void>;
             isShown(): boolean;
         }
 


### PR DESCRIPTION
Per api: http://ionicframework.com/docs/api/controller/ionicModal/

note the note in the ionic source code:

"Be sure to call [remove()](#remove) when you are done with each modal
 to clean it up and avoid memory leaks."

https://github.com/driftyco/ionic/blob/af1bfef327e685585244c6051c4d38b98aa6c62a/js/angular/service/modal.js#L87

@spencerwi
