### PR TITLE
New definition for ngWYSIWYG

### DIFF
--- a/ngwysiwyg/ngwysiwyg-tests.ts
+++ b/ngwysiwyg/ngwysiwyg-tests.ts
@@ -2,7 +2,7 @@
 
 //import ngWYSIWYG = require("ngWYSIWYG");
 
-var options: ngWYSIWYGConfig = {
+var complete: ngWYSIWYG.Config = {
     sanitize: false,
     toolbar: [
         { name: "basicStyling", items: ["bold", "italic", "underline", "strikethrough", "subscript", "superscript", "-", "leftAlign", "centerAlign", "rightAlign", "blockJustify", "-"] },
@@ -13,4 +13,8 @@ var options: ngWYSIWYGConfig = {
         { name: "tools", items: ["print", "-"] },
         { name: "styling", items: ["font", "size", "format"] },
     ]
+};
+
+var partial: ngWYSIWYG.Config = {
+    sanitize: false
 };

--- a/ngwysiwyg/ngwysiwyg-tests.ts
+++ b/ngwysiwyg/ngwysiwyg-tests.ts
@@ -1,0 +1,16 @@
+/// <reference path="ngwysiwyg.d.ts" />
+
+//import ngWYSIWYG = require("ngWYSIWYG");
+
+var options: ngWYSIWYGConfig = {
+    sanitize: false,
+    toolbar: [
+        { name: "basicStyling", items: ["bold", "italic", "underline", "strikethrough", "subscript", "superscript", "-", "leftAlign", "centerAlign", "rightAlign", "blockJustify", "-"] },
+        { name: "paragraph", items: ["orderedList", "unorderedList", "outdent", "indent", "-"] },
+        { name: "doers", items: ["removeFormatting", "undo", "redo", "-"] },
+        { name: "colors", items: ["fontColor", "backgroundColor", "-"] },
+        { name: "links", items: ["image", "hr", "symbols", "link", "unlink", "-"] },
+        { name: "tools", items: ["print", "-"] },
+        { name: "styling", items: ["font", "size", "format"] },
+    ]
+};

--- a/ngwysiwyg/ngwysiwyg.d.ts
+++ b/ngwysiwyg/ngwysiwyg.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for Marked
+// Project: https://github.com/psergus/ngWYSIWYG
+// Definitions by: Patrick Mac Kay <https://github.com/patrick-mackay>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+interface ngWYSIWYGToolbar {
+    name: string;
+    items: string[];
+}
+
+interface ngWYSIWYGConfig {
+    sanitize: boolean;
+    toolbar: ngWYSIWYGToolbar[]
+}

--- a/ngwysiwyg/ngwysiwyg.d.ts
+++ b/ngwysiwyg/ngwysiwyg.d.ts
@@ -3,12 +3,14 @@
 // Definitions by: Patrick Mac Kay <https://github.com/patrick-mackay>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-interface ngWYSIWYGToolbar {
-    name: string;
-    items: string[];
-}
+declare module ngWYSIWYG {
+    export interface Toolbar {
+        name: string;
+        items: string[];
+    }
 
-interface ngWYSIWYGConfig {
-    sanitize: boolean;
-    toolbar: ngWYSIWYGToolbar[]
+    export interface Config {
+        sanitize: boolean;
+        toolbar?: Toolbar[];
+    }
 }


### PR DESCRIPTION
Interface definitions for an AngularJS wysiwyg component, developed by https://github.com/psergus.

I'm not sure what kind of tests can be created for interface definitions. Let me know if more is needed.

Couldn't find a standarized way of defining names and modules. I checked a few int the repo and I found that some people use modules to organize the names, others use compound names. I selected the second option, but if there is any guidance, please let me know.
