### PR TITLE
Improve jasmine.d.ts

### DIFF
--- a/jasmine-jquery/jasmine-jquery.d.ts
+++ b/jasmine-jquery/jasmine-jquery.d.ts
@@ -195,8 +195,8 @@ declare module jasmine {
          * // returns true
          * expect($('<div><ul></ul><h1>header</h1></div>')).toContainHtml('<ul></ul>')
          */
-        //toContainHtml(html: string): boolean;
-        
+        toContainHtml(html: string): boolean;
+
         /**
          * Check if DOM element has the given Text.
          * @param text Accepts a string or regular expression
@@ -213,8 +213,8 @@ declare module jasmine {
          * // returns true
          * expect($('<div><ul></ul><h1>header</h1></div>')).toContainText('header')
          */
-        //toContainText(text: string): boolean;
-        
+        toContainText(text: string): boolean;
+
         /**
          * Check if DOM element has the given value.
          * This can only be applied for element on with jQuery val() can be called.

--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -281,7 +281,7 @@ declare module jasmine {
 
         toBe(expected: any, expectationFailOutput?: any): boolean;
         toEqual(expected: any, expectationFailOutput?: any): boolean;
-        toMatch(expected: any, expectationFailOutput?: any): boolean;
+        toMatch(expected: string | RegExp, expectationFailOutput?: any): boolean;
         toBeDefined(expectationFailOutput?: any): boolean;
         toBeUndefined(expectationFailOutput?: any): boolean;
         toBeNull(expectationFailOutput?: any): boolean;
@@ -291,13 +291,12 @@ declare module jasmine {
         toHaveBeenCalled(): boolean;
         toHaveBeenCalledWith(...params: any[]): boolean;
         toContain(expected: any, expectationFailOutput?: any): boolean;
-        toBeLessThan(expected: any, expectationFailOutput?: any): boolean;
-        toBeGreaterThan(expected: any, expectationFailOutput?: any): boolean;
-        toBeCloseTo(expected: any, precision: any, expectationFailOutput?: any): boolean;
-        toContainHtml(expected: string): boolean;
-        toContainText(expected: string): boolean;
+        toBeLessThan(expected: number, expectationFailOutput?: any): boolean;
+        toBeGreaterThan(expected: number, expectationFailOutput?: any): boolean;
+        toBeCloseTo(expected: number, precision: any, expectationFailOutput?: any): boolean;
         toThrow(expected?: any): boolean;
-        toThrowError(expected?: any, message?: string): boolean;
+        toThrowError(message?: string | RegExp): boolean;
+        toThrowError(expected?: Error, message?: string | RegExp): boolean;
         not: Matchers;
 
         Any: Any;

--- a/knockout/tests/jasmine.extensions.d.ts
+++ b/knockout/tests/jasmine.extensions.d.ts
@@ -1,0 +1,10 @@
+// Knockout specs depend on custom Jasmine matchers
+// See https://github.com/knockout/knockout/blob/v3.4.0/spec/lib/jasmine.extensions.js
+// FYI jasmine-jquery.d.ts (https://github.com/velesin/jasmine-jquery) also defines toContainHtml() and toContainText()
+
+declare module jasmine {
+  interface Matchers {
+    toContainHtml(expected: string): boolean;
+    toContainText(expected: string): boolean;
+  }
+}

--- a/knockout/tests/knockout-templatingBehaviors-tests.ts
+++ b/knockout/tests/knockout-templatingBehaviors-tests.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../jasmine/jasmine.d.ts" />
+/// <reference path="jasmine.extensions.d.ts" />
 /// <reference path="../knockout.d.ts" />
 /// <reference path="../../knockout.mapping/knockout.mapping.d.ts" />
 


### PR DESCRIPTION
- Remove toContainHtml() and toContainText(): they are not part of Jasmine API
- Avoid the use of any for toMatch(), toBeLessThan(), toBeGreaterThan(), toBeCloseTo() and toThrowError()

And it magically fixes jasmine-jquery.d.ts :-)
