### PR TITLE
Update removeListeners for chrome and chrome-app

### DIFF
--- a/chrome/chrome-app-tests.ts
+++ b/chrome/chrome-app-tests.ts
@@ -15,11 +15,13 @@ var createOptions: cwindow.CreateWindowOptions = {
 };
 
 //Create new window on app launch
-chrome.app.runtime.onLaunched.addListener(function (launchData: runtime.LaunchData) {
+var onLaunchedListener = function (launchData: runtime.LaunchData) {
     chrome.app.window.create('app/url', createOptions, function (created_window: cwindow.AppWindow) {
         return;
     });
-});
+};
+chrome.app.runtime.onLaunched.addListener(onLaunchedListener);
+chrome.app.runtime.onLaunched.removeListener(onLaunchedListener);
 
 chrome.app.runtime.onRestarted.addListener(function () { return; });
 

--- a/chrome/chrome-app.d.ts
+++ b/chrome/chrome-app.d.ts
@@ -24,10 +24,12 @@ declare module chrome.app.runtime {
 
     interface LaunchedEvent {
         addListener(callback: (launchData: LaunchData) => void): void;
+        removeListener(callback: Function): void;
     }
 
     interface RestartedEvent {
         addListener(callback: () => void): void;
+        removeListener(callback: Function): void;
     }
 
     var onLaunched: LaunchedEvent;
@@ -138,7 +140,7 @@ declare module chrome.app.window {
 
     interface WindowEvent {
         addListener(callback: () => void): void;
-        removeListener(callback: () => void): void;
+        removeListener(callback: Function): void;
     }
 
     var onBoundsChanged: WindowEvent;

--- a/chrome/chrome-tests.ts
+++ b/chrome/chrome-tests.ts
@@ -258,7 +258,10 @@ chrome.storage.sync.get("myKey", function (loadedData) {
   var myValue: { x: number } = loadedData["myKey"];
 });
 
-chrome.storage.onChanged.addListener(function (changes) {
+var storageChangedListener = function (changes) {
   var myNewValue: { x: number } = changes["myKey"].newValue;
   var myOldValue: { x: number } = changes["myKey"].oldValue;
-});
+};
+
+chrome.storage.onChanged.addListener(storageChangedListener);
+chrome.storage.onChanged.removeListener(storageChangedListener);

--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -2596,7 +2596,7 @@ declare module chrome.events {
 		 * The callback parameter should be a function that looks like this:
 		 * function() {...}; 
 		 */
-        removeListener(callback: () => void): void;
+        removeListener(callback: Function): void;
         hasListeners(): boolean;
     }
 


### PR DESCRIPTION
In chrome-app, the removeListener function was missing on some of the
events.  In chrome, the removeListener function specifies that the
listener may not accept any arguments, which causes an issue for any
events where the callback function takes an argument.

I did want to have a way from the events in chrome-app to explicitly extend chrome.events.Event, but there does not seem to be a good way to do that.  Let me know if you have ideas.
