### PR TITLE
Fix tslint errors in through.d.ts.

### DIFF
--- a/through/through.d.ts
+++ b/through/through.d.ts
@@ -6,19 +6,19 @@
 /// <reference path="../node/node.d.ts" />
 
 declare module "through" {
-	import stream = require("stream");
+    import stream = require("stream");
 
-	function through(write?: (data: any) => void,
-		end?: () => void,
-		opts?: {
-			autoDestroy: boolean;
-		}): through.ThroughStream;
+    function through(write?: (data: any) => void,
+        end?: () => void,
+        opts?: {
+            autoDestroy: boolean;
+        }): through.ThroughStream;
 
-	module through {
-		export interface ThroughStream extends stream.Transform {
-			autoDestroy: boolean;
-		}
-	}
+    module through {
+        export interface ThroughStream extends stream.Transform {
+            autoDestroy: boolean;
+        }
+    }
 
-	export = through;
+    export = through;
 }


### PR DESCRIPTION
This fixes the tslint errors in through.d.ts. I used the default tslint.json file. It's quite useful to fix tslint issues in definition files since it's often inconvenient to exclude the .d.ts files from tslint. In addition, a good coding style is never a bad thing.
