### PR TITLE
Fix tslint errors in vinyl.d.ts.

### DIFF
--- a/vinyl/vinyl.d.ts
+++ b/vinyl/vinyl.d.ts
@@ -5,13 +5,13 @@
 
 /// <reference path="../node/node.d.ts" />
 
-declare module 'vinyl' {
+declare module "vinyl" {
 
-	import fs = require('fs');
+	import fs = require("fs");
 
 	/**
-	* A virtual file format.
-	*/
+	 * A virtual file format.
+	 */
 	class File {
 		constructor(options?: {
 			/**
@@ -19,55 +19,55 @@ declare module 'vinyl' {
 			*/
 			cwd?: string;
 			/**
-			* Used for relative pathing. Typically where a glob starts.
-			*/
+			 * Used for relative pathing. Typically where a glob starts.
+			 */
 			base?: string;
 			/**
-			* Full path to the file.
-			*/
+			 * Full path to the file.
+			 */
 			path?: string;
 			/**
-			* Path history. Has no effect if options.path is passed.
-			*/
+			 * Path history. Has no effect if options.path is passed.
+			 */
 			history?: string[];
 			/**
-			* The result of an fs.stat call. See fs.Stats for more information.
-			*/
+			 * The result of an fs.stat call. See fs.Stats for more information.
+			 */
 			stat?: fs.Stats;
 			/**
-			* File contents.
-			* Type: Buffer, Stream, or null
-			*/
+			 * File contents.
+			 * Type: Buffer, Stream, or null
+			 */
 			contents?: Buffer | NodeJS.ReadWriteStream;
 		});
 
 		/**
-		* Default: process.cwd()
-		*/
+		 * Default: process.cwd()
+		 */
 		public cwd: string;
 		/**
-		* Used for relative pathing. Typically where a glob starts.
-		*/
+		 * Used for relative pathing. Typically where a glob starts.
+		 */
 		public base: string;
 		/**
-		* Full path to the file.
-		*/
+		 * Full path to the file.
+		 */
 		public path: string;
 		public stat: fs.Stats;
 		/**
-		* Type: Buffer|Stream|null (Default: null)
-		*/
+		 * Type: Buffer|Stream|null (Default: null)
+		 */
 		public contents: Buffer | NodeJS.ReadableStream;
 		/**
-		* Returns path.relative for the file base and file path.
-		* Example:
-		*  var file = new File({
-		*    cwd: "/",
-		*    base: "/test/",
-		*    path: "/test/file.js"
-		*  });
-		*  console.log(file.relative); // file.js
-		*/
+		 * Returns path.relative for the file base and file path.
+		 * Example:
+		 *  var file = new File({
+		 *    cwd: "/",
+		 *    base: "/test/",
+		 *    path: "/test/file.js"
+		 *  });
+		 *  console.log(file.relative); // file.js
+		 */
 		public relative: string;
 
 		public isBuffer(): boolean;
@@ -79,28 +79,27 @@ declare module 'vinyl' {
 		public isDirectory(): boolean;
 
 		/**
-		* Returns a new File object with all attributes cloned. Custom attributes are deep-cloned.
-		*/
+		 * Returns a new File object with all attributes cloned. Custom attributes are deep-cloned.
+		 */
 		public clone(opts?: { contents?: boolean }): File;
 
 		/**
-		* If file.contents is a Buffer, it will write it to the stream.
-		* If file.contents is a Stream, it will pipe it to the stream.
-		* If file.contents is null, it will do nothing.
-		*/
+		 * If file.contents is a Buffer, it will write it to the stream.
+		 * If file.contents is a Stream, it will pipe it to the stream.
+		 * If file.contents is null, it will do nothing.
+		 */
 		public pipe<T extends NodeJS.ReadWriteStream>(
 			stream: T,
 			opts?: {
 				/**
-				* If false, the destination stream will not be ended (same as node core).
-				*/
+				 * If false, the destination stream will not be ended (same as node core).
+				 */
 				end?: boolean;
-			}
-		): T;
+			}): T;
 
 		/**
-		* Returns a pretty String interpretation of the File. Useful for console.log.
-		*/
+		 * Returns a pretty String interpretation of the File. Useful for console.log.
+		 */
 		public inspect(): string;
 	}
 


### PR DESCRIPTION
This fixes the tslint errors in vinyl.d.ts. I used the default tslint.json file. It's quite useful to fix tslint issues in definition files since it's often inconvenient to exclude the .d.ts files from tslint. In addition, a good coding style is never a bad thing.
