### PR TITLE
adding support for angular.component method Angular 1.3+

### DIFF
--- a/angular-component/angular-component-tests.ts
+++ b/angular-component/angular-component-tests.ts
@@ -1,0 +1,35 @@
+/// <reference path="../angularjs/angular.d.ts" />
+/// <reference path="angular-component.d.ts" />
+
+// example taken from https://github.com/toddmotto/angular-component
+angular
+.module('app', [])
+.component('counter', {
+    bindings: {
+      count: '='
+    },
+    controller: 'CounterCtrl',
+    template: function () {
+      return [
+        '<div class="counter">',
+          '<p>Counter component</p>',
+          '<input type="text" ng-model="counter.count">',
+          '<button type="button" ng-click="counter.decrement();">-</button>',
+          '<button type="button" ng-click="counter.increment();">+</button>',
+        '</div>'
+      ].join('');
+    }
+})
+.controller('CounterCtrl', function CounterCtrl() {
+  function increment() {
+    this.count++;
+  }
+  function decrement() {
+    this.count--;
+  }
+  this.increment = increment;
+  this.decrement = decrement;
+})
+.controller('MainCtrl', function MainCtrl() {
+  this.count = 4;
+});

--- a/angular-component/angular-component.d.ts
+++ b/angular-component/angular-component.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for angular.component() for AngularJS 1.3+
+// Project: https://github.com/toddmotto/angular-component
+// Definitions by: Tushar Sonawane <https://github.com/tushkiz>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../angularjs/angular.d.ts" />
+
+declare module angular {
+
+  ///////////////////////////////////////////////////////////////////////////
+  // Module
+  // see http://docs.angularjs.org/api/angular.Module
+  ///////////////////////////////////////////////////////////////////////////
+  interface IModule {
+    /**
+     * Register a new component with the compiler.
+     *
+     * @param name Name of the component in camel-case (i.e. ngBind which will match as ng-bind)
+     * @param options Component definition object.
+     */
+    component(name: string, options: IComponent): IModule;
+  }
+
+  ///////////////////////////////////////////////////////////////////////////
+  // Component
+  // see https://github.com/toddmotto/angular-component
+  ///////////////////////////////////////////////////////////////////////////
+  interface IComponent {
+    bindings?: Object;
+    controller?: string|Function;
+    controllerAs?: string;
+    isolate?: boolean;
+    template?: string|Function;
+    templateUrl?: string|Function;
+    transclude?: boolean;
+    restrict?: string;
+    $canActivate?: Function;
+    $routeConfig?: Object
+  }
+
+}


### PR DESCRIPTION
This adds support for Angular v1.3+ back-port of 1.5's component() method by @toddmotto

More info [angular-component](https://github.com/toddmotto/angular-component)
