### PR TITLE
jquery.contextMenu: add support for the 'build' option

### DIFF
--- a/jquery.contextMenu/jquery.contextMenu.d.ts
+++ b/jquery.contextMenu/jquery.contextMenu.d.ts
@@ -4,9 +4,7 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../jquery/jquery.d.ts" />
-
-interface JQueryContextMenuOptions {
-    selector: string;
+interface JQueryContextMenuOptionsBase {
     appendTo?: string;
     trigger?: string;
     autoHide?: boolean;
@@ -30,8 +28,18 @@ interface JQueryContextMenuOptions {
     className?: string;
 }
 
+interface JQueryContextMenuOptions extends JQueryContextMenuOptionsBase {
+    selector: string;
+}
+
+interface JQueryContextMenuTriggerOptions {
+    selector: string;
+    build: (trigger: JQuery, event: JQueryMouseEventObject) => JQueryContextMenuOptionsBase;    
+}
+
 interface JQueryStatic {
     contextMenu(options?: JQueryContextMenuOptions): JQuery;
+    contextMenu(options?: JQueryContextMenuTriggerOptions): JQuery;
     contextMenu(type: string, selector?: any): JQuery;
 }
 

--- a/jquery.contextMenu/jquery.contextMenu.d.ts
+++ b/jquery.contextMenu/jquery.contextMenu.d.ts
@@ -34,6 +34,7 @@ interface JQueryContextMenuOptions extends JQueryContextMenuOptionsBase {
 
 interface JQueryContextMenuTriggerOptions {
     selector: string;
+    trigger?: string;
     build: (trigger: JQuery, event: JQueryMouseEventObject) => JQueryContextMenuOptionsBase;    
 }
 


### PR DESCRIPTION
jquery.contextMenu supports on demand creation of the context menu using the option 'build'. 'build' takes a callback function that returns a options instance. Therefore the init call may contain only the options 'selector', 'trigger', and 'build'.

Fixes #7288.
