### PR TITLE
[mssql] add typed queries & batches

### DIFF
--- a/mssql/mssql-tests.ts
+++ b/mssql/mssql-tests.ts
@@ -66,6 +66,15 @@ var connection: sql.Connection = new sql.Connection(config, function (err: any) 
             }
         });
 
+        requestStoredProcedure.execute<Entity>('StoredProcedureName', function (err, recordsets, returnValue) {
+            if (err != null) {
+                console.error('Error happened calling Query: ' + err.name + " " + err.message);
+            }
+            else {
+                console.info(returnValue);
+            }
+        });
+
         var requestStoredProcedureWithOutput = new sql.Request(connection);
         var testId: number = 0;
         var testString: string = 'test';
@@ -83,6 +92,15 @@ var connection: sql.Connection = new sql.Connection(config, function (err: any) 
         requestStoredProcedureWithOutput.input("name", sql.DateTime2(5), new Date());     // datetime2(5)
 
         requestStoredProcedure.execute('StoredProcedureName', function (err, recordsets, returnValue) {
+            if (err != null) {
+                console.error('Error happened calling Query: ' + err.name + " " + err.message);
+            }
+            else {
+                console.info(requestStoredProcedureWithOutput.parameters['output'].value);
+            }
+        });
+
+        requestStoredProcedure.execute<Entity>('StoredProcedureName', function (err, recordsets, returnValue) {
             if (err != null) {
                 console.error('Error happened calling Query: ' + err.name + " " + err.message);
             }

--- a/mssql/mssql-tests.ts
+++ b/mssql/mssql-tests.ts
@@ -3,6 +3,10 @@
 
 import sql = require('mssql');
 
+interface Entity{
+  value: number;
+}
+
 var config: sql.config = {
     user: 'user',
     password: 'password',
@@ -30,6 +34,18 @@ var connection: sql.Connection = new sql.Connection(config, function (err: any) 
             }
             // checking to see if the articles returned as at least one.
             else if (recordSet.length > 0) {
+            }
+        });
+
+        getArticlesQuery = "SELECT 1 as value FROM TABLE";
+
+        requestQuery.query<Entity>(getArticlesQuery, function (err, recordSet) {
+            if (err) {
+                console.error('Error happened calling Query: ' + err.name + " " + err.message);
+
+            }
+            // checking to see if the articles returned as at least one.
+            else if (recordSet.length > 0 && recordSet[0].value) {
             }
         });
 
@@ -109,8 +125,10 @@ function test_promise_returns() {
 
     var request = new sql.Request();
     request.batch('create procedure #temporary as select * from table').then((recordset) => { });
+    request.batch<Entity>('create procedure #temporary as select * from table;select 1 as value').then((recordset) => { });
     request.bulk(new sql.Table("table_name")).then(() => { });
     request.query('SELECT 1').then((recordset) => { });
+    request.query<Entity>('SELECT 1 as value').then(res => {    });
     request.execute('procedure_name').then((recordset) => { });
 }
 
@@ -120,7 +138,7 @@ function test_request_constructor() {
     var connection: sql.Connection = new sql.Connection(config);
     var preparedStatment = new sql.PreparedStatement(connection);
     var transaction = new sql.Transaction(connection);
-    
+
     var request1 = new sql.Request(connection);
     var request2 = new sql.Request(preparedStatment);
     var request3 = new sql.Request(transaction);

--- a/mssql/mssql.d.ts
+++ b/mssql/mssql.d.ts
@@ -7,7 +7,7 @@
 /// <reference path="../es6-promise/es6-promise.d.ts" />
 
 declare module "mssql" {
-    import events = require('events'); 
+    import events = require('events');
 
     type sqlTypeWithNoParams       = { type: sqlTypeFactoryWithNoParams }
     type sqlTypeWithLength         = { type: sqlTypeFactoryWithLength, length: number }
@@ -206,9 +206,13 @@ declare module "mssql" {
         public output(name: string, type: any, value?: any): void;
         public pipe(stream: NodeJS.WritableStream): void;
         public query(command: string): Promise<void>;
+        public query<Entity>(command: string): Promise<Entity[]>;
         public query(command: string, callback: (err?: any, recordset?: any) => void): void;
+        public query<Entity>(command: string, callback: (err?: any, recordset?: Entity[]) => void): void;
         public batch(batch: string): Promise<recordSet>;
+        public batch<Entity>(batch: string): Promise<Entity[]>;
         public batch(batch: string, callback: (err?: any, recordset?: any) => void): void;
+        public batch<Entity>(batch: string, callback: (err?: any, recordset?: Entity[]) => void): void;
         public bulk(table: Table): Promise<void>;
         public bulk(table: Table, callback: (err: any, rowCount: any) => void): void;
         public cancel(): void;

--- a/mssql/mssql.d.ts
+++ b/mssql/mssql.d.ts
@@ -200,7 +200,7 @@ declare module "mssql" {
         public constructor(transaction: Transaction);
         public constructor(preparedStatement: PreparedStatement);
         public execute(procedure: string): Promise<recordSet>;
-        public execute(procedure: string, callback: (err?: any, recordsets?: any, returnValue?: any) => void): void;
+        public execute<Entity>(procedure: string, callback: (err?: any, recordsets?: Entity[], returnValue?: any) => void): void;
         public input(name: string, value: any): void;
         public input(name: string, type: any, value: any): void;
         public output(name: string, type: any, value?: any): void;
@@ -258,7 +258,9 @@ declare module "mssql" {
         public prepare(statement?: string): Promise<void>;
         public prepare(statement?: string, callback?: (err?: any) => void): void;
         public execute(values: Object): Promise<recordSet>;
+        public execute<Entity>(values: Object): Promise<Entity[]>;
         public execute(values: Object, callback: (err: any, recordSet: recordSet) => void): void;
+        public execute<Entity>(values: Object, callback: (err: any, recordSet: Entity[]) => void): void;
         public unprepare(): Promise<void>;
         public unprepare(callback: (err?: any) => void): void;
     }


### PR DESCRIPTION
Queries weren't typed with the result type, so the `then` syntax was unusable (the resultset was void).

With the fix you can now do:

```
interface Entity{
  value: number;
}
request.query<Entity>('select 1 as value').then(res => {
  console.log(res[0].value);
});
```

Types for queries not using the `then` syntax were also added.
Same changes were applied to batches.
