### PR TITLE
Improved visionmedia/debug to include non-amd version

### DIFF
--- a/debug/debug-tests.ts
+++ b/debug/debug-tests.ts
@@ -1,4 +1,3 @@
-/// <reference path="../node/node.d.ts" />
 /// <reference path="debug.d.ts" />
 
 import debug = require("debug");
@@ -6,7 +5,7 @@ import debug = require("debug");
 debug.disable();
 debug.enable("DefinitelyTyped:*");
 
-var log: debug.Debugger = debug("DefinitelyTyped:log");
+var log:debug.IDebugger = debug("DefinitelyTyped:log");
 
 log("Just text");
 log("Formatted test (%d arg)", 1);
@@ -15,6 +14,6 @@ log("Formatted %s (%d args)", "test", 2);
 log("Enabled?: %s", debug.enabled("DefinitelyTyped:log"));
 log("Namespace: %s", log.namespace);
 
-var error: debug.Debugger = debug("DefinitelyTyped:error");
+var error:debug.IDebugger = debug("DefinitelyTyped:error");
 error.log = console.error.bind(console);
 error("This should be printed to stderr");

--- a/debug/debug.d.ts
+++ b/debug/debug.d.ts
@@ -1,30 +1,39 @@
 // Type definitions for debug
 // Project: https://github.com/visionmedia/debug
 // Definitions by: Seon-Wook Park <https://github.com/swook>
+// Definitions by: Gal Talmor <https://github.com/galtalmor>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare module "debug" {
+declare var debug:debug.IDebug;
 
-    function d(namespace: string): d.Debugger;
-
-    module d {
-        export var log: Function;
-
-        function enable(namespaces: string): void;
-        function disable(): void;
-
-        function enabled(namespace: string): boolean;
-
-        export interface Debugger {
-            (formatter: any, ...args: any[]): void;
-
-            enabled:   boolean;
-            log:       Function;
-            namespace: string;
-        }
-    }
-
-    export = d;
-
+// Support AMD require
+declare module 'debug' {
+    export = debug;
 }
 
+declare module debug {
+    export interface IDebug {
+        (namespace: string):debug.IDebugger,
+        coerce:(val:any)=>any,
+        disable:()=>void,
+        enable:(namespaces:string)=>void,
+        enabled:(namespaces:string)=>boolean,
+
+        names:string[],
+        skips:string[],
+
+        formatters:IFormatters
+    }
+
+    export interface IFormatters {
+        [formatter:string]: Function
+    }
+
+    export interface IDebugger {
+        (formatter: any, ...args: any[]): void;
+
+        enabled:boolean;
+        log:Function;
+        namespace:string;
+    }
+}

--- a/debug/debug.d.ts
+++ b/debug/debug.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for debug
 // Project: https://github.com/visionmedia/debug
-// Definitions by: Seon-Wook Park <https://github.com/swook>
-// Definitions by: Gal Talmor <https://github.com/galtalmor>
+// Definitions by: Seon-Wook Park <https://github.com/swook>, Gal Talmor <https://github.com/galtalmor>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare var debug:debug.IDebug;

--- a/debug/debug.d.ts
+++ b/debug/debug.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Seon-Wook Park <https://github.com/swook>, Gal Talmor <https://github.com/galtalmor>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare var debug:debug.IDebug;
+declare var debug: debug.IDebug;
 
 // Support AMD require
 declare module 'debug' {
@@ -12,27 +12,27 @@ declare module 'debug' {
 
 declare module debug {
     export interface IDebug {
-        (namespace: string):debug.IDebugger,
-        coerce:(val:any)=>any,
-        disable:()=>void,
-        enable:(namespaces:string)=>void,
-        enabled:(namespaces:string)=>boolean,
+        (namespace: string): debug.IDebugger,
+        coerce: (val: any) => any,
+        disable: () => void,
+        enable: (namespaces: string) => void,
+        enabled: (namespaces: string) => boolean,
 
-        names:string[],
-        skips:string[],
+        names: string[],
+        skips: string[],
 
-        formatters:IFormatters
+        formatters: IFormatters
     }
 
     export interface IFormatters {
-        [formatter:string]: Function
+        [formatter: string]: Function
     }
 
     export interface IDebugger {
         (formatter: any, ...args: any[]): void;
 
-        enabled:boolean;
-        log:Function;
-        namespace:string;
+        enabled: boolean;
+        log: Function;
+        namespace: string;
     }
 }


### PR DESCRIPTION
Improved visionmedia/debug, a tiny npm package for debugging.
Added both AMD and non-AMD definition support
