### PR TITLE
Made context argument optional ICompiledExpression

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -897,7 +897,7 @@ declare module angular {
     }
 
     interface ICompiledExpression {
-        (context: any, locals?: any): any;
+        (context?: any, locals?: any): any;
 
         literal: boolean;
         constant: boolean;


### PR DESCRIPTION
Changed the context parameter of the `Angular.ICompiledExpression` interface, marking it as optional. There are situations where it is not required.
