### PR TITLE
highcharts-theme property

### DIFF
--- a/highcharts/highcharts.d.ts
+++ b/highcharts/highcharts.d.ts
@@ -6010,6 +6010,11 @@ interface HighchartsStatic {
     getOptions(): HighchartsOptions;
 
     map(array: any[], fn: Function): any[];
+	
+	/**
+     * Use this object to set the theme globally for all charts
+     */
+	theme: HighchartsGlobalOptions;
 }
 
 declare var Highcharts: HighchartsStatic;

--- a/highcharts/highcharts.d.ts
+++ b/highcharts/highcharts.d.ts
@@ -5474,6 +5474,14 @@ interface HighchartsGlobalOptions extends HighchartsOptions {
     lang?: HighchartsLangObject;
 }
 
+interface HighchartsThemeOptions extends HighchartsGlobalOptions {
+    legendBackgroundColor?: string;
+    background2?: string | HighchartsGradient;
+    dataLabelsColor?: string;
+    textColor?: string;
+    maskColor?: string;
+}
+
 interface HighchartsDateFormatSpecifiers
 {
     [index: string]: (timestamp: number) => string;
@@ -6014,7 +6022,7 @@ interface HighchartsStatic {
 	/**
      * Use this object to set the theme globally for all charts
      */
-	theme: HighchartsGlobalOptions;
+	theme: HighchartsThemeOptions;
 }
 
 declare var Highcharts: HighchartsStatic;


### PR DESCRIPTION
![hctheme](https://cloud.githubusercontent.com/assets/5859358/11989847/f6718830-aa2a-11e5-953f-7f691a5357b5.jpg)
interface HighchartsStatic is missing "theme" property. Typescript
throws error when used the same.Added theme in interface
HighchartsStatic
