### PR TITLE
added $ as the default export of jQuery so we can use the "import $ f…

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -3184,7 +3184,7 @@ interface JQuery {
     queue(queueName: string, callback: Function): JQuery;
 }
 declare module "jquery" {
-    export = $;
+    export default $;
 }
 declare var jQuery: JQueryStatic;
 declare var $: JQueryStatic;


### PR DESCRIPTION
…rom'query'" syntax; import $ = require('jquery') results in $ not being loaded properly when loaded through systemjs with jspm
