### PR TITLE
Removing quotes from easystarjs type definition classname.

### DIFF
--- a/easystarjs/easystarjs.d.ts
+++ b/easystarjs/easystarjs.d.ts
@@ -3,8 +3,8 @@
 // Definitions by: Magnus Gustafsson <https://github.com/borundin>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped  
 /*
-easystarjs.d.ts may be freely distributed under the MIT license.
-*/
+ easystarjs.d.ts may be freely distributed under the MIT license.
+ */
 
 declare module easystarjs
 {
@@ -31,4 +31,6 @@ declare module easystarjs
     }
 }
 
- 
+declare module "easystarjs" {
+    export = easystarjs;
+}

--- a/easystarjs/easystarjs.d.ts
+++ b/easystarjs/easystarjs.d.ts
@@ -6,7 +6,7 @@
 easystarjs.d.ts may be freely distributed under the MIT license.
 */
 
-declare module "easystarjs"
+declare module easystarjs
 {
     class js
     {


### PR DESCRIPTION
The EasyStar.js type definition file is (I believe -- it doesn't work in my IDE) erroneous because the classname is surrounded in quotes.
