### PR TITLE
Updated extent - added [Date, Date] return type

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1055,6 +1055,11 @@ declare module d3 {
      * Return the min and max simultaneously.
      */
     export function extent<T>(array: T[], accessor: (datum: T, index: number) => string): [string, string];
+    
+    /**
+     * Return the min and max simultaneously.
+     */
+    export function extent<T>(array: T[], accessor: (datum: T, index: number) => Date): [Date, Date];
 
     /**
      * Return the min and max simultaneously.


### PR DESCRIPTION
The interfaces for extent don't seem to cover the common date extent scenario 

`x.domain(d3.extent(data, d=> d.date))` 

This use case where data is an array of objects currently gives type errors in typescript - maybe this fix is brittle and there's a better generic way to approach, but I can see there are already dedicated overloads for [number, number] and [string, string] and this sits with those
