### PR TITLE
[React] Changed `autoCapitalize` attribute from boolean to string

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -1822,7 +1822,7 @@ declare namespace __React {
         vocab?: string;
 
         // Non-standard Attributes
-        autoCapitalize?: boolean;
+        autoCapitalize?: string;
         autoCorrect?: string;
         autoSave?: string;
         color?: string;


### PR DESCRIPTION
From https://developer.mozilla.org/en/docs/Web/HTML/Element/form

The possible values for `autoCapitalize` are:
- `none`
- `sentences`
- `words`
- `characters`

So should be `string`, not `boolean`.
