### PR TITLE
Added TouchEvent type to the originalEvent object.

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -448,7 +448,7 @@ interface BaseJQueryEventObject extends Event {
     isImmediatePropagationStopped(): boolean;
     isPropagationStopped(): boolean;
     namespace: string;
-    originalEvent: Event;
+    originalEvent: Event & TouchEvent;
     preventDefault(): any;
     relatedTarget: Element;
     result: any;


### PR DESCRIPTION
http://stackoverflow.com/questions/16674963/event-originalevent-jquery

> event.originalEvent is usually just the native event (also described here).
> However, if the browser is compatible, and the event was a touch event then that API will be exposed through event.originalEvent.
> The short answer is that event.originalEvent is not always the same, it depends on which event type triggered the handler, and on the environment of the browser.
