### PR TITLE
Update gulp-watch.d.ts

### DIFF
--- a/gulp-watch/gulp-watch-tests.ts
+++ b/gulp-watch/gulp-watch-tests.ts
@@ -1,8 +1,8 @@
 /// <reference path="gulp-watch.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require('gulp');
-import watch = require('gulp-watch');
+import * as gulp from 'gulp';
+import * as watch from 'gulp-watch';
 
 gulp.task('stream', () =>
     gulp.src('css/**/*.css')

--- a/gulp-watch/gulp-watch.d.ts
+++ b/gulp-watch/gulp-watch.d.ts
@@ -22,6 +22,6 @@ declare module 'gulp-watch' {
     }
 
     function watch(glob: string | Array<string>, options?: IOptions, callback?: Function): IWatchStream;
-
+    namespace watch {}
     export = watch;
 }


### PR DESCRIPTION
fix failure when use

```
import * as watch from 'gulp-watch'
```

in Typescript 1.7
