### PR TITLE
Fix minimist.Opts.alias possible values (to match minimist docs/functionality)

### DIFF
--- a/minimist/minimist-tests.ts
+++ b/minimist/minimist-tests.ts
@@ -19,6 +19,9 @@ opts.boolean = strArr;
 opts.alias = {
 	foo: strArr
 };
+opts.alias = {
+	foo: str
+};
 opts.default = {
 	foo: str
 };
@@ -29,7 +32,7 @@ opts.unknown = (arg: string) => {
 	if(/xyz/.test(arg)){
 		return true;
 	}
-	
+
 	return false;
 };
 opts.stopEarly = true;

--- a/minimist/minimist.d.ts
+++ b/minimist/minimist.d.ts
@@ -9,20 +9,17 @@ declare module 'minimist' {
 	module minimist {
 		export interface Opts {
 			// a string or array of strings argument names to always treat as strings
-			// string?: string;
 			string?: string|string[];
 			// a string or array of strings to always treat as booleans
-			// boolean?: string;
 			boolean?: boolean|string|string[];
 			// an object mapping string names to strings or arrays of string argument names to use
-			// alias?: {[key:string]: string};
-			alias?: {[key:string]: string[]};
+			alias?: {[key:string]: string|string[]};
 			// an object mapping string argument names to default values
 			default?: {[key:string]: any};
 			// when true, populate argv._ with everything after the first non-option
 			stopEarly?: boolean;
 			// a function which is invoked with a command line parameter not defined in the opts configuration object.
-			// If the function returns false, the unknown option is not added to argv			
+			// If the function returns false, the unknown option is not added to argv
 			unknown?: (arg: string) => boolean;
 			// when true, populate argv._ with everything before the -- and argv['--'] with everything after the --
 			'--'?: boolean;


### PR DESCRIPTION
The `alias` object can take an array of strings or just a string. It's right there in the docs, even in the copy&pasted doc fragment in the existing `minimist.d.ts`:

> ['alias' is] an object mapping string names to strings or arrays of string argument names to use
