### PR TITLE
Add middleware to browser-sync Options

### DIFF
--- a/browser-sync/browser-sync.d.ts
+++ b/browser-sync/browser-sync.d.ts
@@ -34,7 +34,7 @@ declare module "browser-sync" {
              * Default: undefined
              * Note: requires at least version 2.6.0
              */
-            watchOptions?: ChokidarOptions;
+            watchOptions?: chokidar.WatchOptions;
             /**
              * Use the built-in static server for basic HTML/JS/CSS websites.
              * Default: false
@@ -243,17 +243,11 @@ declare module "browser-sync" {
              * Note: requires at least version 1.6.2
              */
             socket?: SocketOptions;
+            middleware?: MiddlewareHandler | MiddlewareHandler[];
         }
 
         interface Hash<T> {
             [path: string]: T;
-        }
-
-        interface ChokidarOptions {
-            interval?: number;
-            debounceDelay?: number;
-            mode?: string;
-            cwd?: string;
         }
 
         interface UIOptions { 


### PR DESCRIPTION
Although middleware is not listed as a browser-sync option in the [documentation](https://browsersync.io/docs/options/)

It does appear regularly in examples and unit tests:
- https://github.com/BrowserSync/browser-sync/blob/master/examples/middleware.css.injection.js
- https://github.com/BrowserSync/browser-sync/blob/master/test/specs/e2e/middleware/middleware.option.js

Removed the ChokidarOptions interface because it is out of sync with the chokidar documentation and definition file that is already referenced. I am not certain what to make of the debounceDelay and mode options since they do not appear in the full list of options from the [chokidar readme](https://github.com/paulmillr/chokidar). 
