### PR TITLE
Add declare module "dagre"

### DIFF
--- a/dagre/dagre.d.ts
+++ b/dagre/dagre.d.ts
@@ -31,3 +31,7 @@ declare module Dagre{
 }
 
 declare var dagre: Dagre.DagreFactory;
+
+declare module "dagre" {
+    export = dagre;
+}


### PR DESCRIPTION
Resolve the error:
TS2307: Cannot find module 'dagre'

When we use dagre.js with typescript:
import \* as dagre from 'dagre';
