### PR TITLE
fix import

### DIFF
--- a/gulp-mocha/gulp-mocha-tests.ts
+++ b/gulp-mocha/gulp-mocha-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="./gulp-mocha.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
-import mocha = require("gulp-mocha");
+import * as gulp from "gulp";
+import * as mocha from "gulp-mocha";
 
 gulp.task('default', function () {
     return gulp.src('test.js', {read: false})

--- a/gulp-mocha/gulp-mocha.d.ts
+++ b/gulp-mocha/gulp-mocha.d.ts
@@ -8,5 +8,6 @@
 
 declare module "gulp-mocha" {
     function mocha(setupOptions?: MochaSetupOptions): NodeJS.ReadWriteStream;
+    namespace mocha {}
     export = mocha;
 }


### PR DESCRIPTION
fix failure when use

```
import * as watch from 'gulp-mocha'
```

in Typescript 1.7
