### PR TITLE
fix import

### DIFF
--- a/gulp-minify-html/gulp-minify-html-tests.ts
+++ b/gulp-minify-html/gulp-minify-html-tests.ts
@@ -1,8 +1,8 @@
 /// <reference path="gulp-minify-html.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require('gulp');
-import minifyHtml = require('gulp-minify-html');
+import * as gulp from 'gulp';
+import * as minifyHtml from 'gulp-minify-html';
 
 minifyHtml();
 minifyHtml({conditionals: true, loose: true});

--- a/gulp-minify-html/gulp-minify-html.d.ts
+++ b/gulp-minify-html/gulp-minify-html.d.ts
@@ -31,5 +31,7 @@ declare module 'gulp-minify-html' {
 
     function minifyHtml(options?: IOptions): NodeJS.ReadWriteStream;
 
+    namespace minifyHtml {}
+
     export = minifyHtml;
 }


### PR DESCRIPTION
fix failure when use

```
import * as watch from 'gulp-minify-html'
```

in Typescript 1.7
