### PR TITLE
fix import

### DIFF
--- a/gulp-autoprefixer/gulp-autoprefixer-tests.ts
+++ b/gulp-autoprefixer/gulp-autoprefixer-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="./gulp-autoprefixer.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
-import autoprefixer = require("gulp-autoprefixer");
+import * as gulp from "gulp";
+import * as autoprefixer from "gulp-autoprefixer";
 
 gulp.src("test.css")
     .pipe(autoprefixer())

--- a/gulp-autoprefixer/gulp-autoprefixer.d.ts
+++ b/gulp-autoprefixer/gulp-autoprefixer.d.ts
@@ -14,5 +14,7 @@ declare module "gulp-autoprefixer" {
 
     function autoPrefixer(opts?: Options): NodeJS.ReadWriteStream;
 
+    namespace autoPrefixer {}
+
     export = autoPrefixer;
 }


### PR DESCRIPTION
fix failure when use

```
import * as watch from 'gulp-autoprefixer'
```

in Typescript 1.7
