### PR TITLE
fix import

### DIFF
--- a/gulp-csso/gulp-csso-tests.ts
+++ b/gulp-csso/gulp-csso-tests.ts
@@ -1,8 +1,8 @@
 /// <reference path="gulp-csso.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require('gulp');
-import csso = require('gulp-csso');
+import * as gulp from 'gulp';
+import * as csso from 'gulp-csso';
 
 gulp.task('default', () =>
     gulp.src('./main.css')

--- a/gulp-csso/gulp-csso.d.ts
+++ b/gulp-csso/gulp-csso.d.ts
@@ -7,6 +7,6 @@
 
 declare module 'gulp-csso' {
     function csso(structureMinimization?: boolean): NodeJS.ReadWriteStream;
-
+    namespace csso {}
     export = csso;
 }


### PR DESCRIPTION
fix failure when use

```
import * as watch from 'gulp-csso'
```

in Typescript 1.7
