### PR TITLE
fix import

### DIFF
--- a/gulp-debug/gulp-debug-tests.ts
+++ b/gulp-debug/gulp-debug-tests.ts
@@ -1,8 +1,8 @@
 /// <reference path="gulp-debug.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require('gulp');
-import debug = require('gulp-debug');
+import * as gulp from 'gulp';
+import * as debug from 'gulp-debug';
 
 gulp.task('default', () =>
     gulp.src('foo.js')

--- a/gulp-debug/gulp-debug.d.ts
+++ b/gulp-debug/gulp-debug.d.ts
@@ -13,5 +13,7 @@ declare module 'gulp-debug' {
 
     function debug(options?: IOptions): NodeJS.ReadWriteStream;
 
+    namespace debug {}
+
     export = debug;
 }

--- a/gulp-size/gulp-size-tests.ts
+++ b/gulp-size/gulp-size-tests.ts
@@ -2,9 +2,9 @@
 /// <reference path="../gulp/gulp.d.ts" />
 /// <reference path="../gulp-debug/gulp-debug.d.ts" />
 
-import gulp = require('gulp');
-import size = require('gulp-size');
-import debug = require('gulp-debug');
+import * as gulp from 'gulp';
+import * as size from 'gulp-size';
+import * as debug from 'gulp-debug';
 
 gulp.task('default', () =>
     gulp.src('fixture.js')

--- a/gulp-size/gulp-size.d.ts
+++ b/gulp-size/gulp-size.d.ts
@@ -19,5 +19,7 @@ declare module 'gulp-size' {
 
     function size(options?: IOptions): ISizeStream;
 
+    namespace size {}
+
     export = size;
 }


### PR DESCRIPTION
fix failure when use

```
import * as watch from 'gulp-debug'
```

in Typescript 1.7
