### PR TITLE
fix import

### DIFF
--- a/gulp-dtsm/gulp-dtsm-tests.ts
+++ b/gulp-dtsm/gulp-dtsm-tests.ts
@@ -2,10 +2,9 @@
 /// <reference path="../node/node.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import dtsm = require('gulp-dtsm');
-import gulp = require('gulp');
+import * as dtsm from 'gulp-dtsm';
+import * as gulp from 'gulp';
 
 var stream: NodeJS.WritableStream = dtsm();
 
 gulp.task('dtsm', () => gulp.src('./dtsm.json').pipe(dtsm()));
-

--- a/gulp-dtsm/gulp-dtsm.d.ts
+++ b/gulp-dtsm/gulp-dtsm.d.ts
@@ -8,6 +8,7 @@
 declare module "gulp-dtsm" {
   function dtsm(): NodeJS.WritableStream;
 
+  namespace dtsm {}
+
   export = dtsm;
 }
-


### PR DESCRIPTION
fix failure when use

```
import * as watch from 'gulp-dtsm'
```

in Typescript 1.7
