### PR TITLE
fix import

### DIFF
--- a/gulp-flatten/gulp-flatten-tests.ts
+++ b/gulp-flatten/gulp-flatten-tests.ts
@@ -1,8 +1,8 @@
 /// <reference path="./gulp-flatten.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require("gulp");
-import flatten = require("gulp-flatten");
+import * as gulp from "gulp";
+import * as flatten from "gulp-flatten";
 
 gulp.task("flatten:simple", () => {
     gulp.src(["files/**/*.txt"])

--- a/gulp-flatten/gulp-flatten.d.ts
+++ b/gulp-flatten/gulp-flatten.d.ts
@@ -13,5 +13,7 @@ declare module "gulp-flatten" {
 
     function flatten(options?: IOptions): NodeJS.ReadWriteStream;
 
+    namespace flatten {}
+
     export = flatten;
 }


### PR DESCRIPTION
fix failure when use

```
import * as watch from 'gulp-flatten'
```

in Typescript 1.7
