### PR TITLE
fix import

### DIFF
--- a/gulp-gh-pages/gulp-gh-pages-tests.ts
+++ b/gulp-gh-pages/gulp-gh-pages-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="./gulp-gh-pages.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
-import ghPages = require("gulp-gh-pages");
+import * as gulp from "gulp";
+import * as ghPages from "gulp-gh-pages";
 
 gulp.src("test.css")
     .pipe(ghPages());

--- a/gulp-gh-pages/gulp-gh-pages.d.ts
+++ b/gulp-gh-pages/gulp-gh-pages.d.ts
@@ -17,5 +17,7 @@ declare module "gulp-gh-pages" {
 
     function ghPages(opts?: Options): NodeJS.ReadWriteStream;
 
+    namespace ghPages {}
+
     export = ghPages;
 }


### PR DESCRIPTION
fix failure when use

```
import * as watch from 'gulp-gh-pages'
```

in Typescript 1.7
