### PR TITLE
fix import

### DIFF
--- a/gulp-minify-css/gulp-minify-css-tests.ts
+++ b/gulp-minify-css/gulp-minify-css-tests.ts
@@ -1,8 +1,8 @@
 /// <reference path="./gulp-minify-css.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require("gulp");
-import minifyCSS = require("gulp-minify-css");
+import * as gulp from "gulp";
+import * as minifyCSS from "gulp-minify-css";
 
 gulp.task("minify-css", () => {
     gulp.src("css/**/*.css")

--- a/gulp-minify-css/gulp-minify-css.d.ts
+++ b/gulp-minify-css/gulp-minify-css.d.ts
@@ -27,5 +27,7 @@ declare module "gulp-minify-css" {
 
     function minifyCSS(options?: IOptions): NodeJS.ReadWriteStream;
 
+    namespace minifyCSS {}
+
     export = minifyCSS;
 }


### PR DESCRIPTION
fix failure when use

```
import * as watch from 'gulp-minify-css'
```

in Typescript 1.7
