### PR TITLE
fix import

### DIFF
--- a/gulp-load-plugins/gulp-load-plugins-tests.ts
+++ b/gulp-load-plugins/gulp-load-plugins-tests.ts
@@ -3,9 +3,9 @@
 /// <reference path="../gulp-concat/gulp-concat" />
 /// <reference path="gulp-load-plugins" />
 
-import gulp = require('gulp');
-import gulpConcat = require('gulp-concat');
-import gulpLoadPlugins = require('gulp-load-plugins');
+import * as gulp from 'gulp';
+import * as gulpConcat from 'gulp-concat';
+import * as gulpLoadPlugins from 'gulp-load-plugins';
 
 interface GulpPlugins extends IGulpPlugins {
 	concat: typeof gulpConcat;
@@ -29,8 +29,8 @@ gulp.task('taskName', () => {
 });
 
 /*
- * From 0.8.0, you can pass in an object of mappings for renaming plugins. For example, 
- * imagine you want to load the  gulp-ruby-sass  plugin, but want to refer to it as just 
+ * From 0.8.0, you can pass in an object of mappings for renaming plugins. For example,
+ * imagine you want to load the  gulp-ruby-sass  plugin, but want to refer to it as just
  *  sass :
  */
 plugins = gulpLoadPlugins<GulpPlugins>({
@@ -39,9 +39,9 @@ plugins = gulpLoadPlugins<GulpPlugins>({
 	}
 });
 /*
- * gulp-load-plugins  comes with npm scope support. The major difference is that scoped 
- * plugins are accessible through an object on  plugins  that represents the scope. For 
- * example, if the plugin is  @myco/gulp-test-plugin  then you can access the plugin as 
+ * gulp-load-plugins  comes with npm scope support. The major difference is that scoped
+ * plugins are accessible through an object on  plugins  that represents the scope. For
+ * example, if the plugin is  @myco/gulp-test-plugin  then you can access the plugin as
  * shown in the following example:
  */
 interface GulpPlugins {
@@ -49,5 +49,5 @@ interface GulpPlugins {
 		testPlugin(): NodeJS.ReadWriteStream;
 	}
 }
- 
+
 plugins.myco.testPlugin();

--- a/gulp-load-plugins/gulp-load-plugins.d.ts
+++ b/gulp-load-plugins/gulp-load-plugins.d.ts
@@ -7,7 +7,7 @@
 
 /** Loads in any gulp plugins and attaches them to an object, freeing you up from having to manually require each gulp plugin. */
 declare module 'gulp-load-plugins' {
-	
+
 	interface IOptions {
 		/** the glob(s) to search for, default ['gulp-*', 'gulp.*'] */
 		pattern?: string[];
@@ -24,14 +24,16 @@ declare module 'gulp-load-plugins' {
 		/** a mapping of plugins to rename, the key being the NPM name of the package, and the value being an alias you define */
 		rename?: IPluginNameMappings;
 	}
-	
+
 	interface IPluginNameMappings {
 		[npmPackageName: string]: string
 	}
-	
+
 	/** Loads in any gulp plugins and attaches them to an object, freeing you up from having to manually require each gulp plugin. */
 	function gulpLoadPlugins<T extends IGulpPlugins>(options?: IOptions): T;
-	
+
+	namespace gulpLoadPlugins {}
+
 	export = gulpLoadPlugins;
 }
 


### PR DESCRIPTION
fix failure when use

```
import * as watch from 'gulp-load-plugins'
```

in Typescript 1.7
