### PR TITLE
fix import

### DIFF
--- a/gulp-less/gulp-less-tests.ts
+++ b/gulp-less/gulp-less-tests.ts
@@ -1,8 +1,8 @@
 /// <reference path="./gulp-less.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require("gulp");
-import less = require("gulp-less");
+import * as gulp from "gulp";
+import * as less from "gulp-less";
 
 // Without options
 gulp.task("less", () => {

--- a/gulp-less/gulp-less.d.ts
+++ b/gulp-less/gulp-less.d.ts
@@ -15,5 +15,7 @@ declare module "gulp-less" {
 
     function less(options?: IOptions): NodeJS.ReadWriteStream;
 
+    namespace less {}
+
     export = less;
 }


### PR DESCRIPTION
fix failure when use

```
import * as watch from 'gulp-less'
```

in Typescript 1.7
