### PR TITLE
fix import

### DIFF
--- a/gulp-inject/gulp-inject-tests.ts
+++ b/gulp-inject/gulp-inject-tests.ts
@@ -1,8 +1,8 @@
 /// <reference path="./gulp-inject.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require("gulp");
-import inject = require("gulp-inject");
+import * as gulp from "gulp";
+import * as inject from "gulp-inject";
 
 gulp.task("inject:simple", () => {
     gulp.src("src/index.html")

--- a/gulp-inject/gulp-inject.d.ts
+++ b/gulp-inject/gulp-inject.d.ts
@@ -35,5 +35,7 @@ declare module "gulp-inject" {
 
     function inject(sources: NodeJS.ReadableStream, options?: IOptions): NodeJS.ReadWriteStream;
 
+    namespace inject {}
+
     export = inject;
 }


### PR DESCRIPTION
fix failure when use

```
import * as watch from 'gulp-inject'
```

in Typescript 1.7
