### PR TITLE
fix import

### DIFF
--- a/gulp-sort/gulp-sort-tests.ts
+++ b/gulp-sort/gulp-sort-tests.ts
@@ -3,9 +3,9 @@
 /// <reference path="../gulp/gulp" />
 /// <reference path="gulp-sort" />
 
-import gulp = require('gulp');
-import sort = require('gulp-sort');
-import gulpUtil = require('gulp-util');
+import * as gulp from 'gulp';
+import * as sort from 'gulp-sort';
+import * as gulpUtil from 'gulp-util';
 
 // default sort
 gulp.src('./src/js/**/*.js')
@@ -38,7 +38,7 @@ gulp.src('./src/js/**/*.js')
         }
     }))
     .pipe(gulp.dest('./build/js'));
-	
+
 function customComparator(file1: gulpUtil.File, file2: gulpUtil.File) {
     if (file1.path.indexOf('build') > -1) {
         return 1;

--- a/gulp-sort/gulp-sort.d.ts
+++ b/gulp-sort/gulp-sort.d.ts
@@ -8,11 +8,11 @@
 
 /** Sort files in stream by path or any custom sort comparator */
 declare module 'gulp-sort' {
-	
+
 	import gulpUtil = require('gulp-util');
-	
+
 	interface IOptions {
-		/** 
+		/**
 		 * A function to compare two files.
 		 * Returns:
 		 * -1 if file1 should be before file2,
@@ -23,9 +23,9 @@ declare module 'gulp-sort' {
 		/** Whether to sort in ascending order, default is true */
 		asc?: boolean;
 	}
-	
+
 	interface IComparatorFunction {
-		/** 
+		/**
 		 * A function to compare two files.
 		 * Returns:
 		 * -1 if file1 should be before file2,
@@ -34,11 +34,13 @@ declare module 'gulp-sort' {
 		 */
 		(file1: gulpUtil.File, file2: gulpUtil.File): number;
 	}
-	
+
 	/** Sort files in stream by path or any custom sort comparator */
 	function gulpSort(): NodeJS.ReadWriteStream;
 	function gulpSort(comparator: IComparatorFunction): NodeJS.ReadWriteStream;
 	function gulpSort(options: IOptions): NodeJS.ReadWriteStream;
-	
+
+	namespace gulpSort {}
+
 	export = gulpSort;
 }


### PR DESCRIPTION
fix failure when use

```
import * as watch from 'gulp-sort'
```

in Typescript 1.7
