### PR TITLE
fix import

### DIFF
--- a/gulp-tsd/gulp-tsd-tests.ts
+++ b/gulp-tsd/gulp-tsd-tests.ts
@@ -1,8 +1,8 @@
 /// <reference path="./gulp-tsd.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
-import gulp = require("gulp");
-import tsd = require("gulp-tsd");
+import * as gulp from "gulp";
+import * as tsd from "gulp-tsd";
 
 gulp.task("tsd", () => {
     gulp.src("gulp_tsd.json")

--- a/gulp-tsd/gulp-tsd.d.ts
+++ b/gulp-tsd/gulp-tsd.d.ts
@@ -18,5 +18,7 @@ declare module "gulp-tsd" {
 
     function tsd(opts?: IOptions, callback?: gulp.TaskCallback): NodeJS.ReadWriteStream;
 
+    namespace tsd {}
+
     export = tsd;
 }


### PR DESCRIPTION
fix failure when use

```
import * as watch from 'gulp-tsd'
```

in Typescript 1.7
