### PR TITLE
react: change context of Component from {} to any

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -123,7 +123,7 @@ declare namespace __React {
         render(): JSX.Element;
         props: P;
         state: S;
-        context: {};
+        context: any;
         refs: {
             [key: string]: ReactInstance
         };


### PR DESCRIPTION
The context may not be an empty object if `static contextTypes` is defined in the Component. `any` fits the type better as there may be properties defined.
