### PR TITLE
Make properties of IOptions optional.

### DIFF
--- a/jointjs/jointjs.d.ts
+++ b/jointjs/jointjs.d.ts
@@ -60,12 +60,12 @@ declare module joint {
         }
 
         interface IOptions {
-            width: number;
-            height: number;
-            gridSize: number;
-            perpendicularLinks: boolean;
-            elementView: ElementView;
-            linkView: LinkView;
+            width?: number;
+            height?: number;
+            gridSize?: number;
+            perpendicularLinks?: boolean;
+            elementView?: ElementView;
+            linkView?: LinkView;
         }
 
         class Paper extends Backbone.View<Backbone.Model> {


### PR DESCRIPTION
According to the [documentation](http://www.jointjs.com/api#joint.dia.Paper), the options **may** contain any of these properties, and as such they should not be required by the interface.
