### PR TITLE
Added properties to RaphaelFont interface

### DIFF
--- a/raphael/raphael.d.ts
+++ b/raphael/raphael.d.ts
@@ -19,7 +19,9 @@ interface RaphaelAnimation {
 }
 
 interface RaphaelFont {
-
+    w:number;
+    face:any;
+    glyphs:any;
 }
 
 interface RaphaelElement {


### PR DESCRIPTION
Hi, noticed the the RaphaelFont interface is empty. Added missing properties to it. 
Based on:
https://github.com/DmitryBaranovskiy/raphael/blob/master/raphael.js#L5484-L5486
