### PR TITLE
stylus: Add missing Renderer.render() variant

### DIFF
--- a/stylus/stylus.d.ts
+++ b/stylus/stylus.d.ts
@@ -648,6 +648,11 @@ declare module Stylus {
         render(callback: RenderCallback): void;
 
         /**
+         * Parse and evaluate AST and return the result.
+         */
+        render(): string;
+
+        /**
          * Get dependencies of the compiled file.
          */
         deps(filename: string): string[];


### PR DESCRIPTION
As per https://github.com/stylus/stylus/blob/f3e15bbf156f0bfcc8f39a84462621e84131d9b7/lib/renderer.js#L69, stylus's `Renderer.render()` can be called without a callback (it will throw errors if any are encountered, instead of passing them to a callback, and will return the generated CSS directly).
