### PR TITLE
Update typeahead.d.ts

### DIFF
--- a/typeahead/typeahead.d.ts
+++ b/typeahead/typeahead.d.ts
@@ -181,7 +181,13 @@ declare module Twitter.Typeahead {
          * Defaults to value.
          */
         display?: string | ((obj: any) => string);
-
+        
+        /**
+         * Can be used in place of display above.
+         * 
+         */ 
+        displayKey?: string | ((obj: any) => string);
+        
         /**
          * A hash of templates to be used when rendering the dataset.
          * Note a precompiled template is a function that takes a JavaScript object as its first argument and returns a HTML string.


### PR DESCRIPTION
For some reasons when using typeahead dataset display field with angular, the bindings dont work properly across every field mapped. But displayKey works. According to the api https://github.com/twitter/typeahead.js/blob/master/src/typeahead/dataset.js#L47 both fields are accepted.
