### PR TITLE
Update Dropzone success signature.

### DIFF
--- a/dropzone/dropzone-tests.ts
+++ b/dropzone/dropzone-tests.ts
@@ -131,6 +131,13 @@ dropzoneWithOptionsVariations = new Dropzone(".test", {
 	clickable: ["test", document.getElementById("test")]
 });
 
+dropzoneWithOptionsVariations = new Dropzone(".test", {
+    success: (file:DropzoneFile, response:Object) => console.log(file, response)
+});
+dropzoneWithOptionsVariations = new Dropzone(".test", {
+    success: (file:DropzoneFile, response:string) => console.log(file, response)
+});
+
 const dropzone = new Dropzone(".test");
 
 dropzone.enable();

--- a/dropzone/dropzone.d.ts
+++ b/dropzone/dropzone.d.ts
@@ -96,7 +96,7 @@ interface DropzoneOptions {
 	sending?(file:DropzoneFile, xhr:XMLHttpRequest, formData:{}):void;
 	sendingmultiple?(files:DropzoneFile[], xhr:XMLHttpRequest, formData:{}):void;
 
-	success?(file:DropzoneFile, responseText:string):void;
+	success?(file: DropzoneFile, response: Object|string): void;
 	successmultiple?(files:DropzoneFile[], responseText:string):void;
 
 	canceled?(file:DropzoneFile):void;


### PR DESCRIPTION
The success method can return either a json object or a string object in dropzone 4.0.1. Dropzone checks the type and if it's application/json it automatically converts it to json.

You can see where dropzon does the check at https://github.com/enyo/dropzone/blob/master/dist/dropzone.js#L1290
