### PR TITLE
bluebird: Update fromCallback API

### DIFF
--- a/bluebird/bluebird-tests.ts
+++ b/bluebird/bluebird-tests.ts
@@ -766,6 +766,13 @@ func = Promise.promisify(f, obj);
 obj = Promise.promisifyAll(obj);
 anyProm = Promise.fromNode(callback => nodeCallbackFunc(callback));
 anyProm = Promise.fromNode(callback => nodeCallbackFuncErrorOnly(callback));
+anyProm = Promise.fromNode(callback => nodeCallbackFunc(callback), {multiArgs : true});
+anyProm = Promise.fromNode(callback => nodeCallbackFuncErrorOnly(callback), {multiArgs : true});
+
+anyProm = Promise.fromCallback(callback => nodeCallbackFunc(callback));
+anyProm = Promise.fromCallback(callback => nodeCallbackFuncErrorOnly(callback));
+anyProm = Promise.fromCallback(callback => nodeCallbackFunc(callback), {multiArgs : true});
+anyProm = Promise.fromCallback(callback => nodeCallbackFuncErrorOnly(callback), {multiArgs : true});
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/bluebird/bluebird.d.ts
+++ b/bluebird/bluebird.d.ts
@@ -137,7 +137,8 @@ interface PromiseConstructor {
     /**
      * Returns a promise that is resolved by a node style callback function.
      */
-    fromNode(resolver: (callback: (err: any, result?: any) => void) => void): Promise<any>;
+    fromNode(resolver: (callback: (err: any, result?: any) => void) => void, options? : {multiArgs? : boolean}): Promise<any>;
+    fromCallback(resolver: (callback: (err: any, result?: any) => void) => void, options? : {multiArgs? : boolean}): Promise<any>;
 
     /**
      * Returns a function that can use `yield` to run asynchronous code synchronously. This feature requires the support of generators which are drafted in the next version of the language. Node version greater than `0.11.2` is required and needs to be executed with the `--harmony-generators` (or `--harmony`) command-line switch.


### PR DESCRIPTION
This updates the fromCallback and fromNode API to match the current documentation: http://bluebirdjs.com/docs/api/promise.fromcallback.html
