### PR TITLE
Enhanced mongodb definitions

### DIFF
--- a/mongodb/mongodb-tests.ts
+++ b/mongodb/mongodb-tests.ts
@@ -17,7 +17,7 @@ class MongoTester {
     }
 
     public connect(): Promise<boolean> {
-        return MongoDB.MongoClient.connect(this._dbURL).then((db) => {
+        return MongoDB.MongoClient.connect(this._dbURL).then((db: MongoDB.Db) => {
             this._dbHandle = db;
             this._collectionHandle = this._dbHandle.collection(this._collectionName);
             return Promise.resolve(true);
@@ -50,11 +50,11 @@ client.connect().then(() => {
 }).then(() => {
     console.log("Populated database...");
     return client.count();
-}).then((tCount) => {
+}).then((tCount: number) => {
     console.log("Counted", tCount, "docs!!!11");
     return client.cleanUp();
 }).then(() => {
     console.log("Finished & Cleaned!");
-}).catch((error) => {
+}).catch((error: Error) => {
     console.log(error);
 });

--- a/mongodb/mongodb.d.ts
+++ b/mongodb/mongodb.d.ts
@@ -5,6 +5,8 @@
 
 // Documentation : http://mongodb.github.io/node-mongodb-native/
 
+/// <reference path="../bluebird/bluebird.d.ts" />
+
 declare module mongodb {
 
     export var ReadPreference: {

--- a/mongodb/mongodb.d.ts
+++ b/mongodb/mongodb.d.ts
@@ -674,7 +674,7 @@ declare module mongodb {
         pipe(): void;
 
         // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#project
-        project(value: number): Cursor;
+        project(value: any): this;
 
         // http://mongodb.github.io/node-mongodb-native/2.0/api/external-Readable.html#read
         read(size: number): string | Buffer | void;
@@ -870,6 +870,25 @@ declare module mongodb {
 
         // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#out
         out(destination: number): AggregationCursor;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#returnKey
+        redact(document: any): AggregationCursor;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#rewind
+        rewind(): AggregationCursor;
+        
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#skip
+        skip(value: number): AggregationCursor;
+        
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#sort
+        sort(document: any): AggregationCursor;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#toArray
+        toArray(callback: AggregationCursorResultCallback<any>): void;
+        toArray(): Promise<any>;
+        
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#unwind
+        unwind(field: number): AggregationCursor;
     }
 
     // Class documentation : http://mongodb.github.io/node-mongodb-native/api-generated/cursorstream.html

--- a/mongodb/mongodb.d.ts
+++ b/mongodb/mongodb.d.ts
@@ -6,6 +6,7 @@
 // Documentation : http://mongodb.github.io/node-mongodb-native/
 
 /// <reference path="../bluebird/bluebird.d.ts" />
+/// <reference path="../node/node.d.ts" />
 
 declare module mongodb {
 

--- a/mongodb/mongodb.d.ts
+++ b/mongodb/mongodb.d.ts
@@ -610,9 +610,10 @@ declare module mongodb {
         indexes(callback: MongoCallback<any>): void;
 
         // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#aggregate
-        aggregate(pipeline: Array<any>, options?: CollectionAggregationOptions): Promise<any>;
+        aggregate(pipeline: Array<any>, options?: CollectionAggregationOptions): AggregationCursor;
         aggregate(pipeline: Array<any>, options: CollectionAggregationOptions, callback: MongoCallback<any>): void;
-
+        aggregate(): AggregationCursor;
+        
         // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#stats
         stats(options: { scale: number }): Promise<any>;
         stats(options: { scale: number }, callback: MongoCallback<any>): void;

--- a/mongodb/mongodb.d.ts
+++ b/mongodb/mongodb.d.ts
@@ -5,539 +5,916 @@
 
 // Documentation : http://mongodb.github.io/node-mongodb-native/
 
-/// <reference path='../node/node.d.ts' />
+declare module mongodb {
 
-declare module "mongodb" {
+    export var ReadPreference: {
+        PRIMARY: string;
+        PRIMARY_PREFERRED: string;
+        SECONDARY: string;
+        SECONDARY_PREFERRED: string;
+        NEAREST: string;
+    };
 
-  // Class documentation : http://mongodb.github.io/node-mongodb-native/api-generated/mongoclient.html
-  export class MongoClient{
-    constructor(serverConfig: any, options: any);
+    // Class documentation : http://mongodb.github.io/node-mongodb-native/api-generated/mongoclient.html
+    export class MongoClient {
+        constructor(serverConfig: any, options: any);
 
-    static connect(uri: string, options: any, callback: (err: Error, db: Db) => void): void;
-    static connect(uri: string, callback: (err: Error, db: Db) => void): void;
-  }
+        public static connect(uri: string, options: any, callback: (err: Error, db: Db) => void): void;
+        public static connect(uri: string, callback: (err: Error, db: Db) => void): void;
+    }
 
-  // Class documentation : http://mongodb.github.io/node-mongodb-native/api-generated/server.html
-  export class Server {
-    constructor (host: string, port: number, opts?: ServerOptions);
+    // Class documentation : http://mongodb.github.io/node-mongodb-native/api-generated/server.html
+    export class Server {
+        constructor(host: string, port: number, opts?: ServerOptions);
 
-    public connect(): any;
-  }
+        public connect(): any;
+    }
 
-  // Class documentation : http://mongodb.github.io/node-mongodb-native/api-generated/db.html
-  export class Db {
-    constructor (databaseName: string, serverConfig: Server, dbOptions?: DbCreateOptions);
+    // Class documentation : http://mongodb.github.io/node-mongodb-native/api-generated/db.html
+    export class Db {
+        constructor(databaseName: string, serverConfig: Server, dbOptions?: DbCreateOptions);
 
-    public db(dbName: string): Db;
+        public db(dbName: string): Db;
 
-    public open(callback: (err : Error, db : Db) => void ): void;
-    public close(forceClose?: boolean, callback?: (err: Error, result: any) => void ): void;
-    public admin(callback: (err: Error, result: any) => void ): any;
-    public collectionsInfo(collectionName: string, callback?: (err: Error, result: any) => void ): void;
-    public collectionNames(collectionName: string, options: any, callback?: (err: Error, result: any) => void ): void;
+        public open(callback: (err: Error, db: Db) => void): void;
+        public close(forceClose?: boolean, callback?: MongoCallback<any>): void;
+        public admin(callback: MongoCallback<any>): any;
+        public collectionsInfo(collectionName: string, callback?: MongoCallback<any>): void;
+        public collectionNames(collectionName: string, options: any, callback?: MongoCallback<any>): void;
 
-    public collection(collectionName: string): Collection;
-    public collection(collectionName: string, callback: (err: Error, collection: Collection) => void ): Collection;
-    public collection(collectionName: string, options: MongoCollectionOptions, callback: (err: Error, collection: Collection) => void ): Collection;
+        public collection(collectionName: string): Collection;
+        public collection(collectionName: string, callback: (err: Error, collection: Collection) => void): Collection;
+        public collection(collectionName: string, options: MongoCollectionOptions, callback: (err: Error, collection: Collection) => void): Collection;
 
-    public collections(callback: (err: Error, collections: Collection[]) => void ): void;
-    public eval(code: any, parameters: any[], options?: any, callback?: (err: Error, result: any) => void ): void;
-    //public dereference(dbRef: DbRef, callback: (err: Error, result: any) => void): void;
+        public collections(callback: (err: Error, collections: Collection[]) => void): void;
+        public eval(code: any, parameters: any[], options?: any, callback?: MongoCallback<any>): void;
+        //public dereference(dbRef: DbRef, callback: MongoCallback<any>): void;
 
-    public logout(options: any, callback?: (err: Error, result: any) => void ): void;
-    public logout(callback: (err: Error, result: any) => void ): void;
+        public logout(options: any, callback?: MongoCallback<any>): void;
+        public logout(callback: MongoCallback<any>): void;
 
-    public authenticate(userName: string, password: string, callback?: (err: Error, result: any) => void ): void;
-    public authenticate(userName: string, password: string, options: any, callback?: (err: Error, result: any) => void ): void;
+        public authenticate(userName: string, password: string, callback?: MongoCallback<any>): void;
+        public authenticate(userName: string, password: string, options: any, callback?: MongoCallback<any>): void;
 
-    public addUser(username: string, password: string, callback?: (err: Error, result: any) => void ): void;
-    public addUser(username: string, password: string, options: any, callback?: (err: Error, result: any) => void ): void;
+        public addUser(username: string, password: string, callback?: MongoCallback<any>): void;
+        public addUser(username: string, password: string, options: any, callback?: MongoCallback<any>): void;
 
-    public removeUser(username: string, callback?: (err: Error, result: any) => void ): void;
-    public removeUser(username: string, options: any, callback?: (err: Error, result: any) => void ): void;
+        public removeUser(username: string, callback?: MongoCallback<any>): void;
+        public removeUser(username: string, options: any, callback?: MongoCallback<any>): void;
 
-    public createCollection(collectionName: string, callback?: (err: Error, result: Collection) => void ): void;
-    public createCollection(collectionName: string, options: CollectionCreateOptions, callback?: (err: Error, result: any) => void ): void;
+        public createCollection(collectionName: string, callback?: (err: Error, result: Collection) => void): void;
+        public createCollection(collectionName: string, options: CollectionCreateOptions, callback?: MongoCallback<any>): void;
 
-    public command(selector: Object, callback?: (err: Error, result: any) => void ): void;
-    public command(selector: Object, options: any, callback?: (err: Error, result: any) => void ): void;
+        public command(selector: Object, callback?: MongoCallback<any>): void;
+        public command(selector: Object, options: any, callback?: MongoCallback<any>): void;
 
-    public dropCollection(collectionName: string, callback?: (err: Error, result: any) => void ): void;
-    public renameCollection(fromCollection: string, toCollection: string, callback?: (err: Error, result: any) => void ): void;
+        public dropCollection(collectionName: string, callback?: MongoCallback<any>): void;
+        public renameCollection(fromCollection: string, toCollection: string, callback?: MongoCallback<any>): void;
 
-    public lastError(options: Object, connectionOptions: any, callback: (err: Error, result: any) => void ): void;
-    public previousError(options: Object, callback: (err: Error, result: any) => void ): void;
+        public lastError(options: Object, connectionOptions: any, callback: MongoCallback<any>): void;
+        public previousError(options: Object, callback: MongoCallback<any>): void;
 
-    // error = lastError
-    // lastStatus = lastError
+        // error = lastError
+        // lastStatus = lastError
 
-    public executeDbCommand(command_hash: any, callback?: (err: Error, result: any) => void ): void;
-    public executeDbCommand(command_hash: any, options: any, callback?: (err: Error, result: any) => void ): void;
+        public executeDbCommand(command_hash: any, callback?: MongoCallback<any>): void;
+        public executeDbCommand(command_hash: any, options: any, callback?: MongoCallback<any>): void;
 
-    public executeDbAdminCommand(command_hash: any, callback?: (err: Error, result: any) => void ): void;
-    public executeDbAdminCommand(command_hash: any, options: any, callback?: (err: Error, result: any) => void ): void;
+        public executeDbAdminCommand(command_hash: any, callback?: MongoCallback<any>): void;
+        public executeDbAdminCommand(command_hash: any, options: any, callback?: MongoCallback<any>): void;
 
-    public resetErrorHistory(callback?: (err: Error, result: any) => void ): void;
-    public resetErrorHistory(options: any, callback?: (err: Error, result: any) => void ): void;
+        public resetErrorHistory(callback?: MongoCallback<any>): void;
+        public resetErrorHistory(options: any, callback?: MongoCallback<any>): void;
 
-    public createIndex(collectionName: any, fieldOrSpec: any, options: IndexOptions, callback: Function): void;
-    public ensureIndex(collectionName: any, fieldOrSpec: any, options: IndexOptions, callback: Function): void;
+        public createIndex(collectionName: any, fieldOrSpec: any, options: MongoIndexOptions, callback: Function): void;
+        public ensureIndex(collectionName: any, fieldOrSpec: any, options: MongoIndexOptions, callback: Function): void;
 
-    public cursorInfo(options: any, callback: Function): void;
+        public cursorInfo(options: any, callback: Function): void;
 
-    public dropIndex(collectionName: string, indexName: string, callback: Function): void;
-    public reIndex(collectionName: string, callback: Function): void;
-    public indexInformation(collectionName: string, options: any, callback: Function): void;
-    public dropDatabase(callback: (err: Error, result: any) => void ): void;
+        public dropIndex(collectionName: string, indexName: string, callback: Function): void;
+        public reIndex(collectionName: string, callback: Function): void;
+        public indexInformation(collectionName: string, options: any, callback: Function): void;
+        public dropDatabase(callback: MongoCallback<any>): void;
 
-    public stats(options: any, callback: Function): void;
-    public _registerHandler(db_command: any, raw: any, connection: any, exhaust: any, callback: Function): void;
-    public _reRegisterHandler(newId: any, object: any, callback: Function): void;
-    public _callHandler(id: any, document: any, err: any): any;
-    public _hasHandler(id: any): any;
-    public _removeHandler(id: any): any;
-    public _findHandler(id: any): { id: string; callback: Function; };
-    public __executeQueryCommand(self: any, db_command: any, options: any, callback: any): void;
+        public stats(options: any, callback: Function): void;
+        public _registerHandler(db_command: any, raw: any, connection: any, exhaust: any, callback: Function): void;
+        public _reRegisterHandler(newId: any, object: any, callback: Function): void;
+        public _callHandler(id: any, document: any, err: any): any;
+        public _hasHandler(id: any): any;
+        public _removeHandler(id: any): any;
+        public _findHandler(id: any): { id: string; callback: Function; };
+        public __executeQueryCommand(self: any, db_command: any, options: any, callback: any): void;
 
-    public DEFAULT_URL: string;
+        public DEFAULT_URL: string;
+
+        public connect(url: string, options: { uri_decode_auth?: boolean; }, callback: MongoCallback<any>): void;
+
+        public addListener(event: string, handler: (param: any) => any): any;
+    }
+
+    // Class documentation : http://mongodb.github.io/node-mongodb-native/api-bson-generated/objectid.html
+    // Last update: doc. version 1.3.13 (28.08.2013)
+    export class ObjectID {
+        constructor(s?: string);
 
-    public connect(url: string, options: { uri_decode_auth?: boolean; }, callback: (err: Error, result: any) => void ): void;
+        // Returns the ObjectID id as a 24 byte hex string representation
+        public toHexString(): string;
 
-    public addListener(event: string, handler:(param: any) => any): any;
-  }
+        // Compares the equality of this ObjectID with otherID.
+        public equals(otherID: ObjectID): boolean;
 
-  // Class documentation : http://mongodb.github.io/node-mongodb-native/api-bson-generated/objectid.html
-  // Last update: doc. version 1.3.13 (28.08.2013)
-  export class ObjectID {
-    constructor (s?: string);
-
-    // Returns the ObjectID id as a 24 byte hex string representation
-    public toHexString() : string;
-
-    // Compares the equality of this ObjectID with otherID.
-    public equals(otherID: ObjectID) : boolean;
-
-    // Returns the generation date (accurate up to the second) that this ID was generated.
-    public getTimestamp(): Date;
-
-    // Creates an ObjectID from a second based number, with the rest of the ObjectID zeroed out. Used for comparisons or sorting the ObjectID.
-    // time – an integer number representing a number of seconds.
-    public static createFromTime(time: number): ObjectID;
-
-    // Creates an ObjectID from a hex string representation of an ObjectID.
-    // hexString – create a ObjectID from a passed in 24 byte hexstring.
-    public static createFromHexString(hexString: string): ObjectID;
-    
-    // Checks if a value is a valid bson ObjectId
-    // id - Value to be checked
-    public static isValid(id: string): Boolean;
-    
-    // Generate a 12 byte id string used in ObjectID's
-    // time - optional parameter allowing to pass in a second based timestamp
-    public generate(time?: number): string;
-  }
-
-  // Class documentation : http://mongodb.github.io/node-mongodb-native/api-bson-generated/binary.html
-  export class Binary {
-    constructor (buffer: Buffer, subType?: number);
-
-    // Updates this binary with byte_value
-    put(byte_value: any): void;
-
-    // Writes a buffer or string to the binary
-    write(buffer: any, offset: number): void;
-
-    // Reads length bytes starting at position.
-    read(position: number, length: number): Buffer;
-
-    // Returns the value of this binary as a string.
-    value(): string;
-
-    // The length of the binary.
-    length(): number;
-  }
-
-  export interface SocketOptions {
-    //= set seconds before connection times out default:0
-    timeout?: number;
-    //= Disables the Nagle algorithm default:true
-    noDelay?: boolean;
-    //= Set if keepAlive is used default:0 , which means no keepAlive, set higher than 0 for keepAlive
-    keepAlive?: number;
-    //= ‘ascii’|’utf8’|’base64’ default:null
-    encoding?: string;
-  }
-
-  export interface ServerOptions {
-    // - to reconnect automatically, default:false
-    auto_reconnect?: boolean;
-    // - specify the number of connections in the pool default:1
-    poolSize?: number;
-    // - a collection of pr socket settings
-    socketOptions?: any;
-  }
-
-  export interface PKFactory {
-    counter: number;
-    createPk: () => number;
-  }
+        // Returns the generation date (accurate up to the second) that this ID was generated.
+        public getTimestamp(): Date;
 
-  // See : http://mongodb.github.io/node-mongodb-native/api-generated/db.html
-  // Current definition by documentation version 1.3.13 (28.08.2013)
-  export interface DbCreateOptions {
-    //  the write concern for the operation where < 1 is no acknowlegement of write and w >= 1, w = ‘majority’ or tag acknowledges the write.
-    w?: any;
+        // Creates an ObjectID from a second based number, with the rest of the ObjectID zeroed out. Used for comparisons or sorting the ObjectID.
+        // time – an integer number representing a number of seconds.
+        public static createFromTime(time: number): ObjectID;
 
-    // set the timeout for waiting for write concern to finish (combines with w option).
-    wtimeout?: number;
-
-    //  write waits for fsync before returning. default:false.
-    fsync?: boolean;
+        // Creates an ObjectID from a hex string representation of an ObjectID.
+        // hexString – create a ObjectID from a passed in 24 byte hexstring.
+        public static createFromHexString(hexString: string): ObjectID;
 
-    // write waits for journal sync before returning. default:false.
-    journal?: boolean;
+        // Checks if a value is a valid bson ObjectId
+        // id - Value to be checked
+        public static isValid(id: string): Boolean;
 
-    // the prefered read preference. use 'ReadPreference' class.
-    readPreference?: string;
+        // Generate a 12 byte id string used in ObjectID's
+        // time - optional parameter allowing to pass in a second based timestamp
+        public generate(time?: number): string;
+    }
 
-    // use c++ bson parser. default:false.
-    native_parser?: boolean;
+    // Class documentation : http://mongodb.github.io/node-mongodb-native/api-bson-generated/binary.html
+    export class Binary {
+        constructor(buffer: Buffer, subType?: number);
 
-    // force server to create _id fields instead of client. default:false.
-    forceServerObjectId?: boolean;
+        // Updates this binary with byte_value
+        put(byte_value: any): void;
 
-    // custom primary key factory to generate _id values (see Custom primary keys).
-    pkFactory?: PKFactory;
+        // Writes a buffer or string to the binary
+        write(buffer: any, offset: number): void;
 
-    // serialize functions. default:false.
-    serializeFunctions?: boolean;
+        // Reads length bytes starting at position.
+        read(position: number, length: number): Buffer;
 
-    // peform operations using raw bson buffers. default:false.
-    raw?: boolean;
+        // Returns the value of this binary as a string.
+        value(): string;
 
-    // record query statistics during execution. default:false.
-    recordQueryStats?: boolean;
+        // The length of the binary.
+        length(): number;
+    }
 
-    // number of miliseconds between retries. default:5000.
-    retryMiliSeconds?: number;
+    export interface SocketOptions {
+        //= set seconds before connection times out default:0
+        timeout?: number;
+        //= Disables the Nagle algorithm default:true
+        noDelay?: boolean;
+        //= Set if keepAlive is used default:0 , which means no keepAlive, set higher than 0 for keepAlive
+        keepAlive?: number;
+        //= ‘ascii’|’utf8’|’base64’ default:null
+        encoding?: string;
+    }
 
-    // number of retries off connection. default:5.
-    numberOfRetries?: number;
+    export interface ServerOptions {
+        // - to reconnect automatically, default:false
+        auto_reconnect?: boolean;
+        // - specify the number of connections in the pool default:1
+        poolSize?: number;
+        // - a collection of pr socket settings
+        socketOptions?: any;
+    }
 
-    // an object representing a logger that you want to use, needs to support functions debug, log, error. default:null.
-    logger?: Object
+    export interface PKFactory {
+        counter: number;
+        createPk: () => number;
+    }
 
-    // force setting of SlaveOk flag on queries (only use when explicitly connecting to a secondary server). default:null.
-    slaveOk?: number;
+    // See : http://mongodb.github.io/node-mongodb-native/api-generated/db.html
+    // Current definition by documentation version 1.3.13 (28.08.2013)
+    export interface DbCreateOptions {
+        //  the write concern for the operation where < 1 is no acknowlegement of write and w >= 1, w = ‘majority’ or tag acknowledges the write.
+        w?: any;
 
-    // when deserializing a Long will fit it into a Number if it’s smaller than 53 bits. default:true.
-    promoteLongs?: boolean;
-  }
+        // set the timeout for waiting for write concern to finish (combines with w option).
+        wtimeout?: number;
 
-  export class ReadPreference {
-    public static PRIMARY: string;
-    public static PRIMARY_PREFERRED: string;
-    public static SECONDARY: string;
-    public static SECONDARY_PREFERRED: string;
-    public static NEAREST: string;
-  }
+        //  write waits for fsync before returning. default:false.
+        fsync?: boolean;
 
-  // See : http://mongodb.github.io/node-mongodb-native/api-generated/collection.html
-  // Current definition by documentation version 1.3.13 (28.08.2013)
-  export interface CollectionCreateOptions {
-    // the prefered read preference. use 'ReadPreference' class.
-    readPreference?: string;
+        // write waits for journal sync before returning. default:false.
+        journal?: boolean;
 
-    // Allow reads from secondaries. default:false.
-    slaveOk?: boolean;
+        // the prefered read preference. use 'ReadPreference' class.
+        readPreference?: string;
 
-    // serialize functions on the document. default:false.
-    serializeFunctions?: boolean;
+        // use c++ bson parser. default:false.
+        native_parser?: boolean;
 
-    // perform all operations using raw bson objects. default:false.
-    raw?: boolean;
+        // force server to create _id fields instead of client. default:false.
+        forceServerObjectId?: boolean;
 
-    // object overriding the basic ObjectID primary key generation.
-    pkFactory?: PKFactory;
-  }
+        // custom primary key factory to generate _id values (see Custom primary keys).
+        pkFactory?: PKFactory;
 
-  // Documentation: http://docs.mongodb.org/manual/reference/command/collStats/
-  export interface CollStats {
-    // Namespace.
-    ns: string;
+        // serialize functions. default:false.
+        serializeFunctions?: boolean;
 
-    // Number of documents.
-    count: number;
+        // peform operations using raw bson buffers. default:false.
+        raw?: boolean;
 
-    // Collection size in bytes.
-    size: number;
+        // record query statistics during execution. default:false.
+        recordQueryStats?: boolean;
 
-    // Average object size in bytes.
-    avgObjSize: number;
+        // number of miliseconds between retries. default:5000.
+        retryMiliSeconds?: number;
 
-    // (Pre)allocated space for the collection in bytes.
-    storageSize: number;
+        // number of retries off connection. default:5.
+        numberOfRetries?: number;
 
-    // Number of extents (contiguously allocated chunks of datafile space).
-    numExtents: number;
+        // an object representing a logger that you want to use, needs to support functions debug, log, error. default:null.
+        logger?: Object
 
-    // Number of indexes.
-    nindexes: number;
+        // force setting of SlaveOk flag on queries (only use when explicitly connecting to a secondary server). default:null.
+        slaveOk?: number;
 
-    // Size of the most recently created extent in bytes.
-    lastExtentSize: number;
+        // when deserializing a Long will fit it into a Number if it’s smaller than 53 bits. default:true.
+        promoteLongs?: boolean;
+    }
 
-    // Padding can speed up updates if documents grow.
-    paddingFactor: number;
-    flags: number;
+    // See : http://mongodb.github.io/node-mongodb-native/api-generated/collection.html
+    // Current definition by documentation version 1.3.13 (28.08.2013)
+    export interface CollectionCreateOptions {
+        // the prefered read preference. use 'ReadPreference' class.
+        readPreference?: string;
 
-     // Total index size in bytes.
-    totalIndexSize: number;
+        // Allow reads from secondaries. default:false.
+        slaveOk?: boolean;
 
-    // Size of specific indexes in bytes.
-    indexSizes: {
+        // serialize functions on the document. default:false.
+        serializeFunctions?: boolean;
+
+        // perform all operations using raw bson objects. default:false.
+        raw?: boolean;
+
+        // object overriding the basic ObjectID primary key generation.
+        pkFactory?: PKFactory;
+    }
+
+    // Documentation: http://docs.mongodb.org/manual/reference/command/collStats/
+    export interface CollStats {
+        // Namespace.
+        ns: string;
+
+        // Number of documents.
+        count: number;
+
+        // Collection size in bytes.
+        size: number;
+
+        // Average object size in bytes.
+        avgObjSize: number;
+
+        // (Pre)allocated space for the collection in bytes.
+        storageSize: number;
+
+        // Number of extents (contiguously allocated chunks of datafile space).
+        numExtents: number;
+
+        // Number of indexes.
+        nindexes: number;
+
+        // Size of the most recently created extent in bytes.
+        lastExtentSize: number;
+
+        // Padding can speed up updates if documents grow.
+        paddingFactor: number;
+        flags: number;
+
+        // Total index size in bytes.
+        totalIndexSize: number;
+
+        // Size of specific indexes in bytes.
+        indexSizes: {
             _id_: number;
             username: number;
+        };
+    }
+
+    export interface MongoCallback<T> {
+        (error: MongoError, result: T): void;
+    }
+
+    type AnyArray = Array<any>;
+    type DocumentArray = Array<Object>;
+    type StringArray = Array<string>;
+
+    interface ToArrayResultCallback {
+        (error: MongoError, documents: DocumentArray): void;
+    }
+
+    export interface CollectionInsertOptions {
+        // The write concern.
+        w?: number | string;
+        // The write concern timeout.
+        wtimeout?: number;
+        // Specify a journal write concern.
+        j?: boolean;
+        // Serialize functions on any object.
+        serializeFunctions?: boolean;
+        // Execute write operation in ordered or unordered fashion.
+        forceServerObjectId?: boolean;
+        // Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+        bypassDocumentValidation?: boolean;
+    }
+
+    export interface CollectionSaveDeleteOptions {
+        // The write concern.
+        w?: number | string;
+
+        // The write concern timeout.
+        wtimeout?: number;
+
+        // Specify a journal write concern.
+        j?: boolean;
+    }
+
+    export interface CollectionRenameOptions {
+        // Drop the target name collection if it previously exists.
+        dropTarget?: boolean;
+    }
+
+    export interface CollectionUpdateOptions {
+        // Update operation is an upsert.
+        upsert?: boolean;
+
+        // The write concern.
+        w?: number | string;
+
+        // The write concern timeout.
+        wtimeout?: number;
+
+        // Specify a journal write concern.
+        j?: boolean;
+
+        // Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+        bypassDocumentValidation?: boolean;
+    }
+
+    export interface CollectionReadPreference {
+        new (mode: string, tags: Object): CollectionReadPreference;
+        mode: string;
+        tags: Object;
+        isValid: (mode: string) => boolean;
+    }
+
+    export interface CollectionDistinctOptions {
+        readPreference: CollectionReadPreference | string;
+    }
+
+    export interface MongoCountPreferences {
+        // The limit of documents to count.
+        limit?: number;
+        // The number of documents to skip for the count.
+        skip?: boolean;
+        // An index name hint for the query.
+        hint?: string;
+        // The preferred read preference
+        // (ReadPreference.PRIMARY,
+        // ReadPreference.PRIMARY_PREFERRED,
+        // ReadPreference.SECONDARY,
+        // ReadPreference.SECONDARY_PREFERRED,
+        // ReadPreference.NEAREST).
+        readPreference?: CollectionReadPreference | string;
+    }
+
+    export interface MongoDeleteOptions {
+        // Limits the fields to return for all matching documents.
+        projection?: Object;
+        // Determines which document the operation modifies if the query selects multiple documents.
+        sort?: Object;
+        // The maximum amount of time to allow the query to run.
+        maxTimeMS?: number;
+    }
+
+    export interface MongoFindUpdateReplaceOptions {
+        // Limits the fields to return for all matching documents.
+        projection?: Object;
+        // Determines which document the operation modifies if the query selects multiple documents.
+        sort?: Object;
+        // The maximum amount of time to allow the query to run.
+        maxTimeMS?: number;
+        // Upsert the document if it does not exist.
+        upsert?: boolean;
+        // When false, returns the updated document rather than the original. The default is true.
+        returnOriginal?: boolean;
+    }
+
+    export interface MongoIndexOptions {
+        // The write concern.
+        w?: number | string;
+        // The write concern timeout.
+        wtimeout?: number;
+        // Specify a journal write concern.
+        j?: boolean;
+        // Creates an unique index.
+        unique?: boolean;
+        // Creates a sparse index.
+        sparse?: boolean;
+        // Creates the index in the background, yielding whenever possible.
+        background?: boolean;
+        // A unique index cannot be created on a key that has pre-existing duplicate values.
+        // If you would like to create the index anyway, keeping the first document the database indexes and
+        // deleting all subsequent documents that have duplicate value
+        dropDups?: boolean;
+        // For geo spatial indexes set the lower bound for the co-ordinates.
+        min?: number;
+        // For geo spatial indexes set the high bound for the co-ordinates.
+        max?: number;
+        // Specify the format version of the indexes.
+        v?: number;
+        // Allows you to expire data on indexes applied to a data (MongoDB 2.2 or higher)
+        expireAfterSeconds?: number;
+        // Override the auto generated index name (useful if the resulting name is larger than 128 bytes)
+        name?: number;
+    }
+
+    export interface CollectionGeoNearOptions {
+        readPreference?: CollectionReadPreference | string;
+        num?: number;
+        minDistance?: number;
+        maxDistance?: number;
+        distanceMultiplier?: number;
+        query?: Object;
+        spherical?: boolean;
+        uniqueDocs?: boolean;
+        includeLocs?: boolean;
+    }
+
+    export interface CollectionGeoHaystackSearchOptions {
+        readPreference?: CollectionReadPreference | string;
+        maxDistance?: number;
+        search?: Object;
+        limit?: number;
+    }
+
+    export interface CollectionAggregationOptions {
+        readPreference?: CollectionReadPreference | string;
+        // Return the query as cursor, on 2.6 > it returns as a real cursor
+        // on pre 2.6 it returns as an emulated cursor.
+        cursor?: { batchSize: number };
+        // Explain returns the aggregation execution plan (requires mongodb 2.6 >).
+        explain?: boolean;
+        // lets the server know if it can use disk to store
+        // temporary results for the aggregation (requires mongodb 2.6 >).
+        allowDiskUse?: boolean;
+        // specifies a cumulative time limit in milliseconds for processing operations
+        // on the cursor. MongoDB interrupts the operation at the earliest following interrupt point.
+        maxTimeMS?: boolean;
+        // Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+        bypassDocumentValidation?: boolean;
+    }
+
+    // Documentation : http://mongodb.github.io/node-mongodb-native/api-generated/collection.html
+    export interface Collection {
+        new (db: Db, collectionName: string, pkFactory?: Object, options?: CollectionCreateOptions): Collection; // is this right?
+
+        // Get the collection name.
+        collectionName: string;
+        // Get the full collection namespace.
+        namespace: string;
+        // The current write concern values.
+        writeConcern: Object;
+        // The current read concern values.
+        readConcern: Object;
+        // Get current index hint for collection.
+        hint: Object;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#insertOne
+        insertOne(doc: Object, options?: CollectionInsertOptions): Promise<any>;
+        insertOne(doc: Object, options: CollectionInsertOptions, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#insertMany
+        insertMany(docs: DocumentArray, options?: CollectionInsertOptions): Promise<any>;
+        insertMany(docs: DocumentArray, options: CollectionInsertOptions, callback: MongoCallback<any>): void
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#deleteOne
+        deleteOne(filter: Object, options?: CollectionSaveDeleteOptions): Promise<any>;
+        deleteOne(filter: Object, options: CollectionSaveDeleteOptions, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#deleteMany
+        deleteMany(filter: Object, options?: CollectionSaveDeleteOptions): Promise<any>;
+        deleteMany(filter: Object, options: CollectionSaveDeleteOptions, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#rename
+        rename(newName: string, options?: CollectionRenameOptions): Promise<any>;
+        rename(newName: string, options: CollectionRenameOptions, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#updateOne
+        updateOne(filter: Object, update: Object): Promise<any>;
+        updateOne(filter: Object, update: Object, options: CollectionUpdateOptions, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#updateMany
+        updateMany(filter: Object, update: Object): Promise<any>;
+        updateMany(filter: Object, update: Object, options: CollectionUpdateOptions, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#distinct
+        distinct(key: string, query: Object, options?: CollectionDistinctOptions): Promise<any>;
+        distinct(key: string, query: Object, options: CollectionDistinctOptions, callback: MongoCallback<any>): void
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#count
+        count(query: Object, options?: MongoCountPreferences): Promise<any>;
+        count(query: Object, options: MongoCountPreferences, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#drop
+        drop(): Promise<any>;
+        drop(callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#findOneAndDelete
+        findOneAndDelete(filter: Object, options?: MongoDeleteOptions): Promise<any>;
+        findOneAndDelete(filter: Object, options: MongoDeleteOptions, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#findOneAndReplace
+        findOneAndReplace(filter: Object, replacement: Object, options?: MongoFindUpdateReplaceOptions): Promise<any>;
+        findOneAndReplace(filter: Object, replacement: Object, options: MongoFindUpdateReplaceOptions, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#findOneAndUpdate
+        findOneAndUpdate(filter: Object, update: Object, options?: MongoFindUpdateReplaceOptions): Promise<any>;
+        findOneAndUpdate(filter: Object, update: Object, options: MongoFindUpdateReplaceOptions, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#find
+        find(query: Object): Cursor;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#createIndex
+        createIndex(fieldOrSpec: string | Object, options?: MongoIndexOptions): Promise<any>;
+        createIndex(fieldOrSpec: string | Object, options: MongoIndexOptions, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#ensureIndex
+        ensureIndex(fieldOrSpec: string | Object, options?: MongoIndexOptions): Promise<any>;
+        ensureIndex(fieldOrSpec: string | Object, options: MongoIndexOptions, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#indexInformation
+        indexInformation(options?: { full: boolean }): Promise<any>;
+        indexInformation(options: { full: boolean }, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#dropIndex
+        dropIndex(indexName: string, options?: CollectionSaveDeleteOptions): Promise<any>;
+        dropIndex(indexName: string, options: CollectionSaveDeleteOptions, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#dropIndexes
+        dropIndexes(): Promise<any>;
+        dropIndexes(callback?: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#reIndex
+        reIndex(): Promise<any>;
+        reIndex(callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#mapReduce
+        mapReduce(map: Function | string, reduce: Function | string, options?: MapReduceOptions): Promise<any>;
+        mapReduce(map: Function | string, reduce: Function | string, options: MapReduceOptions, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#group
+        group(keys: Object | Array<any> | Function | Code,
+            condition: Object, initial: Object,
+            reduce: Function | Code, finalize: Function | Code,
+            command: boolean,
+            options: CollectionReadPreference,
+            callback: MongoCallback<any>): void;
+
+        group(keys: Object | Array<any> | Function | Code,
+            condition: Object, initial: Object,
+            reduce: Function | Code, finalize: Function | Code,
+            command: boolean,
+            options?: CollectionReadPreference): Promise<any>;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#options
+        options(): Promise<any>;
+        options(callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#isCapped
+        isCapped(): Promise<any>;
+        isCapped(callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#indexExists
+        indexExists(indexes: string | StringArray): Promise<any>;
+        indexExists(indexes: string | StringArray, callback: Function): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#geoNear
+        geoNear(x: number, y: number, options?: CollectionGeoNearOptions): Promise<any>;
+        geoNear(x: number, y: number, options: CollectionGeoNearOptions, callback: Function): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#geoHaystackSearch
+        geoHaystackSearch(x: number, y: number, options?: CollectionGeoHaystackSearchOptions): Promise<any>;
+        geoHaystackSearch(x: number, y: number, options: CollectionGeoHaystackSearchOptions, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#indexes
+        indexes(): Promise<any>;
+        indexes(callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#aggregate
+        aggregate(pipeline: Array<any>, options?: CollectionAggregationOptions): Promise<any>;
+        aggregate(pipeline: Array<any>, options: CollectionAggregationOptions, callback: MongoCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#stats
+        stats(options: { scale: number }): Promise<any>;
+        stats(options: { scale: number }, callback: MongoCallback<any>): void;
+    }
+
+    export interface MapReduceOptions {
+        out?: Object;
+        query?: Object;
+        sort?: Object;
+        limit?: number;
+        keeptemp?: boolean;
+        finalize?: any;
+        scope?: Object;
+        jsMode?: boolean;
+        verbose?: boolean;
+        readPreference?: string;
+    }
+
+    export interface Code {
+        code: string | Function;
+        scope?: Object;
+    }
+
+    export interface CursorCommentOptions {
+        skip?: number;
+        limit?: number;
+        maxTimeMS?: number;
+        hint?: CollectionReadPreference | string;
+    }
+
+    export interface MongoError {
+        message: string;
+        create(options: Object): MongoError;
+    }
+
+    export interface MongoIteratorCallback {
+        (doc: Object): void;
+    }
+
+    export interface MongoEndCallback {
+        (error: MongoError): void;
+    }
+
+    export interface Writable { }
+    export interface Stream { }
+
+    export interface Readable {
+        destination: Writable;
+        options?: Object;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/external-Readable.html#pause
+        pause(): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/external-Readable.html#pipe
+        pipe(): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#project
+        project(value: number): Cursor;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/external-Readable.html#read
+        read(size: number): string | Buffer | void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/external-Readable.html#resume
+        resume(): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/external-Readable.html#setEncoding
+        setEncoding(encoding: string): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/external-Readable.html#unpipe
+        unpipe(destination?: Writable): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/external-Readable.html#unshift
+        unshift(stream: Buffer | string): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/external-Readable.html#unshift
+        wrap(stream: Stream): void;
+    }
+
+    export var CursorEvent: {
+        close: void;
+        data: Object;
+        end: void;
+        readable: void;
     };
-  }
 
-  // Documentation : http://mongodb.github.io/node-mongodb-native/api-generated/collection.html
-  export interface Collection {
-    new (db: Db, collectionName: string, pkFactory?: Object, options?: CollectionCreateOptions): Collection; // is this right?
-    /**
-     * @deprecated use insertOne or insertMany
-     * Documentation : http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#insert
-     */
-    insert(query: any, callback: (err: Error, result: any) => void): void;
-    insert(query: any, options: { safe?: any; continueOnError?: boolean; keepGoing?: boolean; serializeFunctions?: boolean; }, callback: (err: Error, result: any) => void): void;
+    export interface Cursor extends Readable {
+        sortValue: string;
+        timeout: boolean;
+        readPreference: CollectionReadPreference;
 
-    // Documentation : http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#insertOne
-    insertOne(doc:any, callback: (err: Error, result: any) => void) :void;
-    insertOne(doc: any, options: { w?: any; wtimeout?: number; j?: boolean; serializeFunctions?: boolean; forceServerObjectId?: boolean }, callback: (err: Error, result: any) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#addCursorFlag
+        addCursorFlag(flag: string, value: boolean): Cursor;
 
-    // Documentation : http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#insertMany
-    insertMany(docs: any, callback: (err: Error, result: any) => void): void;
-    insertMany(docs: any, options: { w?: any; wtimeout?: number; j?: boolean; serializeFunctions?: boolean; forceServerObjectId?: boolean }, callback: (err: Error, result: any) => void): void;
-    /**
-     * @deprecated use deleteOne or deleteMany
-     * Documentation : http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#remove
-     */
-    remove(selector: Object, callback?: (err: Error, result: any) => void): void;
-    remove(selector: Object, options: { safe?: any; single?: boolean; }, callback?: (err: Error, result: any) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#addQueryModifier
+        addQueryModifier(name: string, value: boolean): Cursor;
 
-    // Documentation : http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#deleteOne
-    deleteOne(filter: any, callback: (err: Error, result: any) => void): void;
-    deleteOne(filter: any, options: { w?: any; wtimeout?: number; j?: boolean;}, callback: (err: Error, result: any) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#batchSize
+        batchSize(value: number): Cursor;
 
-    // Documentation : http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#deleteMany
-    deleteMany(filter: any, callback: (err: Error, result: any) => void): void;
-    deleteMany(filter: any, options: { w?: any; wtimeout?: number; j?: boolean;}, callback: (err: Error, result: any) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#clone
+        clone(): Cursor;
 
-    rename(newName: String, callback?: (err: Error, result: any) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#close
+        close(): Promise<any>;
+        close(callback: MongoCallback<any>): Cursor;
 
-    save(doc: any, callback : (err: Error, result: any) => void): void;
-    save(doc: any, options: { w?: any; wtimeout?: number; j?: boolean;}, callback : (err: Error, result: any) => void): void;
-    /**
-     * @deprecated use updateOne or updateMany
-     * Documentation : http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#update
-     */
-    update(selector: Object, document: any, callback?: (err: Error, result: any) => void): void;
-    update(selector: Object, document: any, options: { safe?: boolean; upsert?: any; multi?: boolean; serializeFunctions?: boolean; }, callback: (err: Error, result: any) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#comment
+        comment(): Cursor;
 
-    // Documentation : http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#updateOne
-    updateOne(filter: Object, update: any, callback: (err: Error, result: any) => void): void;
-    updateOne(filter: Object, update: any, options: { upsert?: boolean; w?: any; wtimeout?: number; j?: boolean;}, callback: (err: Error, result: any) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#count
+        count(applySkipLimit: boolean, options?: CursorCommentOptions): Promise<any>;
+        count(applySkipLimit: boolean, options: CursorCommentOptions, callback: MongoCallback<any>): void;
 
-    // Documentation : http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#updateMany
-    updateMany(filter: Object, update: any, callback: (err: Error, result: any) => void): void;
-    updateMany(filter: Object, update: any, options: { upsert?: boolean; w?: any; wtimeout?: number; j?: boolean;}, callback: (err: Error, result: any) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#explain
+        explain(): Promise<any>;
+        explain(callback: MongoCallback<any>): void;
 
-    distinct(key: string, query: Object, callback: (err: Error, result: any) => void): void;
-    distinct(key: string, query: Object, options: { readPreference: string; }, callback: (err: Error, result: any) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#forEach
+        // NOTE:
+        // The return value specified in the docs as {null}.
+        // Not sure what this is, So for now it's void.
+        forEach(iterator: MongoIteratorCallback, callback: MongoEndCallback): void;
 
-    count(callback: (err: Error, result: any) => void): void;
-    count(query: Object, callback: (err: Error, result: any) => void): void;
-    count(query: Object, options: { readPreference: string; }, callback: (err: Error, result: any) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#hasNext
+        hasNext(): Promise<any>;
+        hasNext(callback: MongoCallback<any>): void;
 
-    drop(callback?: (err: Error, result: any) => void): void;
-    /**
-     * @deprecated use findOneAndUpdate, findOneAndReplace or findOneAndDelete
-     * Documentation : http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#findAndModify
-     */
-    findAndModify(query: Object, sort: any[], doc: Object, callback: (err: Error, result: any) => void): void;
-    findAndModify(query: Object, sort: any[], doc: Object, options: { safe?: any; remove?: boolean; upsert?: boolean; new?: boolean; }, callback: (err: Error, result: any) => void): void;
-    /**
-     * @deprecated use findOneAndDelete
-     * Documentation : http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#findAndRemove
-     */
-    findAndRemove(query : Object, sort? : any[], callback?: (err: Error, result: any) => void): void;
-    findAndRemove(query : Object, sort? : any[], options?: { safe: any; }, callback?: (err: Error, result: any) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#hint
+        hint(hint: Object): Cursor;
 
-    // Documentation : http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#findOneAndDelete
-    findOneAndDelete(filter: any, callback: (err: Error, result: any) => void): void;
-    findOneAndDelete(filter: any, options: { projection?: any; sort?: any; maxTimeMS?: number; }, callback: (err: Error, result: any) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#isClosed
+        isClosed(): boolean;
 
-    // Documentation : http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#findOneAndReplace
-    findOneAndReplace(filter: any, replacement: any, callback: (err: Error, result: any) => void): void;
-    findOneAndReplace(filter: any, replacement: any, options: { projection?: any; sort?: any; maxTimeMS?: number; upsert?: boolean; returnOriginal?: boolean }, callback: (err: Error, result: any) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#limit
+        limit(value: number): Cursor;
 
-    // Documentation : http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#findOneAndUpdate
-    findOneAndUpdate(filter: any, update: any, callback: (err: Error, result: any) => void): void;
-    findOneAndUpdate(filter: any, update: any, options: { projection?: any; sort?: any; maxTimeMS?: number; upsert?: boolean; returnOriginal?: boolean }, callback: (err: Error, result: any) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#map
+        // NOTE:
+        // The return value specified in the docs as {null}.
+        // Not sure what this is, So for now it's void.
+        map(transform: Function): void;
 
-    find(callback?: (err: Error, result: Cursor) => void): Cursor;
-    find(selector: Object, callback?: (err: Error, result: Cursor) => void): Cursor;
-    find(selector: Object, fields: any, callback?: (err: Error, result: Cursor) => void): Cursor;
-    find(selector: Object, options: CollectionFindOptions, callback?: (err: Error, result: Cursor) => void): Cursor;
-    find(selector: Object, fields: any, options: CollectionFindOptions, callback?: (err: Error, result: Cursor) => void): Cursor;
-    find(selector: Object, fields: any, skip: number, limit: number, callback?: (err: Error, result: Cursor) => void): Cursor;
-    find(selector: Object, fields: any, skip: number, limit: number, timeout: number, callback?: (err: Error, result: Cursor) => void): Cursor;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#max
+        max(value: number): Cursor;
 
-    findOne(callback?: (err: Error, result: any) => void): Cursor;
-    findOne(selector: Object, callback?: (err: Error, result: any) => void): Cursor;
-    findOne(selector: Object, fields: any, callback?: (err: Error, result: any) => void): Cursor;
-    findOne(selector: Object, options: CollectionFindOptions, callback?: (err: Error, result: any) => void): Cursor;
-    findOne(selector: Object, fields: any, options: CollectionFindOptions, callback?: (err: Error, result: any) => void): Cursor;
-    findOne(selector: Object, fields: any, skip: number, limit: number, callback?: (err: Error, result: any) => void): Cursor;
-    findOne(selector: Object, fields: any, skip: number, limit: number, timeout: number, callback?: (err: Error, result: any) => void): Cursor;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#maxScan
+        maxScan(maxScan: Object): Cursor;
 
-    createIndex(fieldOrSpec: any, callback: (err: Error, indexName: string) => void): void;
-    createIndex(fieldOrSpec: any, options: IndexOptions, callback: (err: Error, indexName: string) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#maxTimeMS
+        maxTimeMS(value: number): Cursor;
 
-    ensureIndex(fieldOrSpec: any, callback: (err: Error, indexName: string) => void): void;
-    ensureIndex(fieldOrSpec: any, options: IndexOptions, callback: (err: Error, indexName: string) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#min
+        min(value: number): Cursor;
 
-    indexInformation(options: any, callback: Function): void;
-    dropIndex(name: string, callback: Function): void;
-    dropAllIndexes(callback: Function): void;
-    // dropIndexes = dropAllIndexes
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#next
+        next(): Promise<any>;
+        next(callback: MongoCallback<any>): void;
 
-    reIndex(callback: Function): void;
-    mapReduce(map: Function, reduce: Function, options: MapReduceOptions, callback: Function): void;
-    group(keys: Object, condition: Object, initial: Object, reduce: Function, finalize: Function, command: boolean, options: {readPreference: string}, callback: Function): void;
-    options(callback: Function): void;
-    isCapped(callback: Function): void;
-    indexExists(indexes: string, callback: Function): void;
-    geoNear(x: number, y: number, callback: Function): void;
-    geoNear(x: number, y: number, options: Object, callback: Function): void;
-    geoHaystackSearch(x: number, y: number, callback: Function): void;
-    geoHaystackSearch(x: number, y: number, options: Object, callback: Function): void;
-    indexes(callback: Function): void;
-    aggregate(pipeline: any[], callback: (err: Error, results: any) => void): void;
-    aggregate(pipeline: any[], options: {readPreference: string}, callback: (err: Error, results: any) => void): void;
-    stats(options: {readPreference: string; scale: number}, callback: (err: Error, results: CollStats) => void): void;
-    stats(callback: (err: Error, results: CollStats) => void): void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#next
+        returnKey(returnKey: Object): Cursor;
 
-    hint: any;
-  }
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#setCursorOption
+        setCursorOption(field: string, value: Object): Cursor;
 
-  export interface MapReduceOptions {
-    out?: Object;
-    query?: Object;
-    sort?: Object;
-    limit?: number;
-    keeptemp?: boolean;
-    finalize?: any;
-    scope?: Object;
-    jsMode?: boolean;
-    verbose?: boolean;
-    readPreference?: string;
-  }
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#setReadPreference
+        setReadPreference(readPreference: string | CollectionReadPreference): Cursor;
 
-  export interface IndexOptions {
-    w?: any;
-    wtimeout?: number;
-    fsync?: boolean;
-    journal?: boolean;
-    unique?: boolean;
-    sparse?: boolean;
-    background?: boolean;
-    dropDups?: boolean;
-    min?: number;
-    max?: number;
-    v?: number;
-    expireAfterSeconds?: number;
-    name?: string;
-  }
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#showRecordId
+        showRecordId(showRecordId: Object): Cursor;
 
-  // Class documentation : http://mongodb.github.io/node-mongodb-native/api-generated/cursor.html
-  // Last update: doc. version 1.3.13 (29.08.2013)
-  export class Cursor {
-    // INTERNAL TYPE
-    // constructor (db: Db, collection: Collection, selector, fields, skip, limit, sort, hint, explain, snapshot, timeout, tailable, batchSize, slaveOk, raw, read, returnKey, maxScan, min, max, showDiskLoc, comment, awaitdata, numberOfRetries, dbName, tailableRetryInterval, exhaust, partial);
-    // constructor(db: Db, collection: Collection, selector, fields, options);
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#skip
+        skip(value: number): Cursor;
 
-    rewind() : Cursor;
-    toArray(callback: (err: Error, results: any[]) => any) : void;
-    each(callback: (err: Error, item: any) => void) : void;
-    count(applySkipLimit: boolean, callback: (err: Error, count: number) => void) : void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#snapshot
+        snapshot(snapshot: Object): Cursor;
 
-    sort(keyOrList: any, callback? : (err: Error, result: any) => void): Cursor;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#sort
+        sort(keyOrList: string | Array<any> | Object, direction: number): Cursor;
 
-    // this determines how the results are sorted. "asc", "ascending" or 1 for asceding order while "desc", "desceding or -1 for descending order. Note that the strings are case insensitive.
-    sort(keyOrList: String, direction : string, callback : (err: Error, result: any) => void): Cursor;
-    limit(limit: number, callback?: (err: Error, result: any) => void): Cursor;
-    setReadPreference(preference: string, callback?: Function): Cursor;
-    skip(skip: number, callback?: (err: Error, result: any) => void): Cursor;
-    batchSize(batchSize: number, callback?: (err: Error, result: any) => void): Cursor;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#stream
+        stream(options: Object): Cursor;
 
-    nextObject(callback: (err: Error, doc: any) => void) : void;
-    explain(callback: (err: Error, result: any) => void) : void;
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/Cursor.html#toArray
+        toArray(): Promise<any>;
+        toArray(callback: ToArrayResultCallback): void;
 
-    stream(): CursorStream;
+        // This method is in the docs but the link is broken.
+        rewind(): Cursor;
 
-    close(callback: (err: Error, result: any) => void) : void;
-    isClosed(): boolean;
+    }
 
-    public static INIT: number;
-    public static OPEN: number;
-    public static CLOSED: number;
-    public static GET_MORE: number;
-  }
+    // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#~endCallback
+    export interface AggregationCursorEndCallback {
+        (error: MongoError): void;
+    }
 
-  // Class documentation : http://mongodb.github.io/node-mongodb-native/api-generated/cursorstream.html
-  // Last update: doc. version 1.3.13 (29.08.2013)
-  export class CursorStream {
-    constructor(cursor: Cursor);
+    // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#~iteratorCallback
+    export interface AggregationCursorIteratorCallback<T> {
+        (doc: T): void;
+    }
 
-    public pause(): any;
-    public resume(): any;
-    public destroy(): any;
-  }
+    // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#~resultCallback
+    export interface AggregationCursorResultCallback<T> {
+        (error: MongoError, result: T): void;
+    }
 
-  export interface CollectionFindOptions {
-    limit?: number;
-    sort?: any;
-    fields?: Object;
-    skip?: number;
-    hint?: Object;
-    explain?: boolean;
-    snapshot?: boolean;
-    timeout?: boolean;
-    tailtable?: boolean;
-    tailableRetryInterval?: number;
-    numberOfRetries?: number;
-    awaitdata?: boolean;
-    oplogReplay?: boolean;
-    exhaust?: boolean;
-    batchSize?: number;
-    returnKey?: boolean;
-    maxScan?: number;
-    min?: number;
-    max?: number;
-    showDiskLoc?: boolean;
-    comment?: String;
-    raw?: boolean;
-    readPreference?: String;
-    partial?: boolean;
-  }
+    // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#~toArrayResultCallback
+    export interface AggregationCursorToArrayResultCallback<T> {
+        (error: MongoError, result: T[]): void;
+    }
 
-  export interface MongoCollectionOptions {
-    safe?: any;
-    serializeFunctions?: any;
-    strict?: boolean;
-    raw?: boolean;
-    pkFactory?: any;
-    readPreference?: string;
-  }
+    export interface AggregationCursor extends Readable {
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#batchSize
+        batchSize(value: number): AggregationCursor;
+        
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#clone
+        clone(): AggregationCursor;
+        
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#close
+        close(callback: AggregationCursorResultCallback<any>): void;
+        close(): Promise<any>;
+        
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#each
+        each(callback: AggregationCursorResultCallback<any>): void;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#explain
+        explain(callback: AggregationCursorResultCallback<any>): void;
+        explain(): Promise<any>;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#geoNear
+        geoNear(document: any): AggregationCursor;
+        
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#group
+        group(document: any): AggregationCursor;
+        
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#isClosed
+        isClosed(): boolean;
+        
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#limit
+        limit(value: number): AggregationCursor;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#match
+        match(document: any): AggregationCursor;
+        
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#maxTimeMS
+        maxTimeMS(value: number): AggregationCursor;
+        
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#next
+        next(cb: AggregationCursorResultCallback<any>): void;
+        next(): Promise<any>;
+
+        // http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html#out
+        out(destination: number): AggregationCursor;
+    }
+
+    // Class documentation : http://mongodb.github.io/node-mongodb-native/api-generated/cursorstream.html
+    // Last update: doc. version 1.3.13 (29.08.2013)
+    export interface CursorStream {
+        new (cursor: Cursor): CursorStream;
+
+        pause(): any;
+        resume(): any;
+        destroy(): any;
+    }
+
+    export interface CollectionFindOptions {
+        limit?: number;
+        sort?: any;
+        fields?: Object;
+        skip?: number;
+        hint?: Object;
+        explain?: boolean;
+        snapshot?: boolean;
+        timeout?: boolean;
+        tailtable?: boolean;
+        tailableRetryInterval?: number;
+        numberOfRetries?: number;
+        awaitdata?: boolean;
+        oplogReplay?: boolean;
+        exhaust?: boolean;
+        batchSize?: number;
+        returnKey?: boolean;
+        maxScan?: number;
+        min?: number;
+        max?: number;
+        showDiskLoc?: boolean;
+        comment?: String;
+        raw?: boolean;
+        readPreference?: String;
+        partial?: boolean;
+    }
+
+    export interface MongoCollectionOptions {
+        safe?: any;
+        serializeFunctions?: any;
+        strict?: boolean;
+        raw?: boolean;
+        pkFactory?: any;
+        readPreference?: string;
+    }
+}
+
+declare module "mongodb" {
+    export = mongodb;
 }


### PR DESCRIPTION
The mongodb definitions are still quite far away from the official docs and library implementation, but I have added support for promises (i.e. methods now return promises too) and also, added the implementation for [AggregationCursor](http://mongodb.github.io/node-mongodb-native/2.0/api/AggregationCursor.html)

This PR includes the other, rejected but helpfull PR created by @Think7 [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/7396#issuecomment-167878155);
