### PR TITLE
Fix showSaveDialog method signature

### DIFF
--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -1193,8 +1193,12 @@ declare module GitHubElectron {
 			/**
 			 * File types that can be displayed, see dialog.showOpenDialog for an example.
 			 */
-			filters?: string[];
-		}, callback?: (fileName: string) => void): void;
+			 
+			filters?: {
+				name: string;
+				extensions: string[];
+			}[]
+		}, callback?: (fileName: string) => void): string;
 
 		/**
 		 * Shows a message box. It will block until the message box is closed. It returns .


### PR DESCRIPTION
showSaveDialog() filters have the same format as showOpenDialog() filters. It also returns a string containing the file name

As per:
https://github.com/atom/electron/blob/master/docs/api/dialog.md
