### PR TITLE
Fix a optional parameter on Hammer.js

### DIFF
--- a/hammerjs/hammerjs.d.ts
+++ b/hammerjs/hammerjs.d.ts
@@ -107,7 +107,7 @@ interface HammerManager
   emit( event:string, data:any ):void;
   get( recogniser:Recognizer ):Recognizer;
   get( recogniser:string ):Recognizer;
-  off( events:string, handler:( event:HammerInput ) => void ):void;
+  off( events:string, handler?:( event:HammerInput ) => void ):void;
   on( events:string, handler:( event:HammerInput ) => void ):void;
   recognize( inputData:any ):void;
   remove( recogniser:Recognizer ):HammerManager;


### PR DESCRIPTION
the .off method on a instance of HammerManager must have a handler as optional, see: http://hammerjs.github.io/jsdoc/Manager.html#off
