### PR TITLE
underscore.d.ts uniqueId always returns a string

### DIFF
--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -1573,12 +1573,7 @@ interface UnderscoreStatic {
 	* @param prefix A prefix string to start the unique ID with.
 	* @return Unique string ID beginning with `prefix`.
 	**/
-	uniqueId(prefix: string): string;
-
-	/**
-	* @see _.uniqueId
-	**/
-	uniqueId(): number;
+	uniqueId(prefix?: string): string;
 
 	/**
 	* Escapes a string for insertion into HTML, replacing &, <, >, ", ', and / characters.


### PR DESCRIPTION
  _.uniqueId = function(prefix) {
    var id = ++idCounter + '';
    return prefix ? prefix + id : id;
  };

always returns string
