### PR TITLE
auth0: add user_metadata and app_metadata to profile

### DIFF
--- a/auth0/auth0.d.ts
+++ b/auth0/auth0.d.ts
@@ -51,6 +51,8 @@ interface Auth0UserProfile {
     user_id: string;
     /** Represents one or more Identities that may be associated with the User. */
     identities: Auth0Identity[];
+    user_metadata?: any;
+    app_metadata?: any;
 }
 
 /** Represents an Auth0UserProfile that has a Microsoft Account as the primary identity. */


### PR DESCRIPTION
This PR adds keys for `user_metadata` and `app_metadata`
