### PR TITLE
backbone-relational : added 'static' to methods according to the docs

### DIFF
--- a/backbone-relational/backbone-relational.d.ts
+++ b/backbone-relational/backbone-relational.d.ts
@@ -35,15 +35,15 @@ declare module Backbone {
 
         toJSON():any;
 
-        setup();
+        static setup();
 
-        build(attributes:any, options?:any);
+        static build(attributes:any, options?:any);
 
-        findOrCreate(attributes:string, options?:any);
+        static findOrCreate(attributes:string, options?:any);
 
-        findOrCreate(attributes:number, options?:any);
+        static findOrCreate(attributes:number, options?:any);
 
-        findOrCreate(attributes:any, options?:any);
+        static findOrCreate(attributes:any, options?:any);
     }
 
     export class Relation extends Model {
@@ -147,13 +147,13 @@ declare module Backbone {
 
         resolveIdForItem(type:any, item:any):any;
 
-        find(type:any, item:string):RelationalModel;
+        static find(type:any, item:string):RelationalModel;
 
-        find(type:any, item:number):RelationalModel;
+        static find(type:any, item:number):RelationalModel;
 
-        find(type:any, item:RelationalModel):RelationalModel;
+        static find(type:any, item:RelationalModel):RelationalModel;
 
-        find(type:any, item:any):RelationalModel;
+        static find(type:any, item:any):RelationalModel;
 
         register(model:RelationalModel):void;
 
@@ -169,3 +169,4 @@ declare module Backbone {
     }
 
 }
+


### PR DESCRIPTION
According to the [docs](http://backbonerelational.org) there are static methods in backbone-relational.  I had some problem using it in my project so I fixed all the methods marked 'static'.  @eirikhm, could you review it?

Thanks in advance.
