### PR TITLE
Updates to Electron

### DIFF
--- a/github-electron/github-electron-main-tests.ts
+++ b/github-electron/github-electron-main-tests.ts
@@ -31,7 +31,7 @@ require('crash-reporter').start();
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the javascript object is GCed.
-var mainWindow: GitHubElectron.BrowserWindow = null;
+var mainWindow: Electron.BrowserWindow = null;
 
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
@@ -72,6 +72,7 @@ app.on('ready', () => {
 	mainWindow.webContents.addWorkSpace('/path/to/workspace');
 	mainWindow.webContents.removeWorkSpace('/path/to/workspace');
 	var opened: boolean = mainWindow.webContents.isDevToolsOpened()
+    var focused = mainWindow.webContents.isDevToolsFocused();
 	// Emitted when the window is closed.
 	mainWindow.on('closed', () => {
 		// Dereference the window object, usually you would store windows
@@ -116,21 +117,21 @@ app.on('ready', () => {
 app.addRecentDocument('/Users/USERNAME/Desktop/work.type');
 app.clearRecentDocuments();
 var dockMenu = Menu.buildFromTemplate([
-	<GitHubElectron.MenuItemOptions>{
+	<Electron.MenuItemOptions>{
 		label: 'New Window',
 		click: () => {
 			console.log('New Window');
 		}
 	},
-	<GitHubElectron.MenuItemOptions>{
+	<Electron.MenuItemOptions>{
 		label: 'New Window with Settings',
 		submenu: [
-			<GitHubElectron.MenuItemOptions>{ label: 'Basic' },
-			<GitHubElectron.MenuItemOptions>{ label: 'Pro' }
+			<Electron.MenuItemOptions>{ label: 'Basic' },
+			<Electron.MenuItemOptions>{ label: 'Pro' }
 		]
 	},
-	<GitHubElectron.MenuItemOptions>{ label: 'New Command...' },
-	<GitHubElectron.MenuItemOptions>{
+	<Electron.MenuItemOptions>{ label: 'New Command...' },
+	<Electron.MenuItemOptions>{
 		label: 'Edit',
 		submenu: [
 			{
@@ -167,7 +168,7 @@ var dockMenu = Menu.buildFromTemplate([
 app.dock.setMenu(dockMenu);
 
 app.setUserTasks([
-	<GitHubElectron.Task>{
+	<Electron.Task>{
 		program: process.execPath,
 		arguments: '--new-window',
 		iconPath: process.execPath,
@@ -186,7 +187,7 @@ window.setDocumentEdited(true);
 // Online/Offline Event Detection
 // https://github.com/atom/electron/blob/master/docs/tutorial/online-offline-events.md
 
-var onlineStatusWindow: GitHubElectron.BrowserWindow;
+var onlineStatusWindow: Electron.BrowserWindow;
 
 app.on('ready', () => {
 	onlineStatusWindow = new BrowserWindow({ width: 0, height: 0, show: false });
@@ -275,12 +276,12 @@ globalShortcut.unregisterAll();
 // ipcMain
 // https://github.com/atom/electron/blob/master/docs/api/ipc-main-process.md
 
-ipcMain.on('asynchronous-message', (event: GitHubElectron.IPCMainEvent, arg: any) => {
+ipcMain.on('asynchronous-message', (event: Electron.IPCMainEvent, arg: any) => {
 	console.log(arg);  // prints "ping"
 	event.sender.send('asynchronous-reply', 'pong');
 });
 
-ipcMain.on('synchronous-message', (event: GitHubElectron.IPCMainEvent, arg: any) => {
+ipcMain.on('synchronous-message', (event: Electron.IPCMainEvent, arg: any) => {
 	console.log(arg);  // prints "ping"
 	event.returnValue = 'pong';
 });
@@ -460,7 +461,7 @@ app.on('ready', () => {
 // tray
 // https://github.com/atom/electron/blob/master/docs/api/tray.md
 
-var appIcon: GitHubElectron.Tray = null;
+var appIcon: Electron.Tray = null;
 app.on('ready', () => {
 	appIcon = new Tray('/path/to/my/icon');
 	var contextMenu = Menu.buildFromTemplate([

--- a/github-electron/github-electron-renderer-tests.ts
+++ b/github-electron/github-electron-renderer-tests.ts
@@ -24,7 +24,7 @@ ipcRenderer.send('asynchronous-message', 'ping');
 // remote
 // https://github.com/atom/electron/blob/master/docs/api/remote.md
 
-var BrowserWindow: typeof GitHubElectron.BrowserWindow = remote.require('browser-window');
+var BrowserWindow: typeof Electron.BrowserWindow = remote.require('browser-window');
 var win = new BrowserWindow({ width: 800, height: 600 });
 win.loadURL('https://github.com');
 
@@ -75,7 +75,7 @@ crashReporter.start({
 // nativeImage
 // https://github.com/atom/electron/blob/master/docs/api/native-image.md
 
-var Tray: typeof GitHubElectron.Tray = remote.require('Tray');
+var Tray: typeof Electron.Tray = remote.require('Tray');
 var appIcon2 = new Tray('/Users/somebody/images/icon.png');
 var window2 = new BrowserWindow({ icon: '/Users/somebody/images/window.png' });
 var image = clipboard.readImage();
@@ -85,9 +85,9 @@ var appIcon4 = new Tray('/Users/somebody/images/icon.png');
 // screen
 // https://github.com/atom/electron/blob/master/docs/api/screen.md
 
-var app: GitHubElectron.App = remote.require('app');
+var app: Electron.App = remote.require('app');
 
-var mainWindow: GitHubElectron.BrowserWindow = null;
+var mainWindow: Electron.BrowserWindow = null;
 
 app.on('ready', () => {
 	var size = screen.getPrimaryDisplay().workAreaSize;

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference path="../node/node.d.ts" />
 
-declare module GitHubElectron {
+declare module Electron {
 	/**
 	 * This class is used to represent an image.
 	 */
@@ -64,6 +64,34 @@ declare module GitHubElectron {
 		function writeImage(image: NativeImage, type?: string): void;
 	}
 
+	interface Display {
+		id:number;
+		bounds:Bounds;
+		workArea:Bounds;
+		size:Dimension;
+		workAreaSize:Dimension;
+		scaleFactor:number;
+		rotation:number;
+		touchSupport:string;
+	}
+
+	interface Bounds {
+		x:number;
+		y:number;
+		width:number;
+		height:number;
+	}
+
+	interface Dimension {
+		width:number;
+		height:number;
+	}
+
+	interface Point {
+		x:number;
+		y:number;
+	}
+
 	class Screen implements NodeJS.EventEmitter {
 		addListener(event: string, listener: Function): Screen;
 		on(event: string, listener: Function): Screen;
@@ -78,26 +106,23 @@ declare module GitHubElectron {
 		/**
 		 * @returns The current absolute position of the mouse pointer.
 		 */
-		getCursorScreenPoint(): any;
+		getCursorScreenPoint(): Point;
 		/**
 		 * @returns The primary display.
 		 */
-		getPrimaryDisplay(): any;
+		getPrimaryDisplay(): Display;
 		/**
 		 * @returns An array of displays that are currently available.
 		 */
-		getAllDisplays(): any[];
+		getAllDisplays(): Display[];
 		/**
 		 * @returns The display nearest the specified point.
 		 */
-		getDisplayNearestPoint(point: {
-			x: number;
-			y: number;
-		}): any;
+		getDisplayNearestPoint(point: Point): Display;
 		/**
 		 * @returns The display that most closely intersects the provided bounds.
 		 */
-		getDisplayMatching(rect: Rectangle): any;
+		getDisplayMatching(rect: Rectangle): Display;
 	}
 
 	/**
@@ -508,6 +533,7 @@ declare module GitHubElectron {
 		subpixelFontScaling?: boolean;
 		overlayFullscreenVideo?: boolean;
 		titleBarStyle?: string;
+		backgroundColor?: string;
 	}
 
 	interface Rectangle {
@@ -751,6 +777,10 @@ declare module GitHubElectron {
 		 */
 		isDevToolsOpened(): boolean;
 		/**
+		 * Returns whether the developer tools are focussed.
+		 */
+		isDevToolsFocused(): boolean;
+		/**
 		 * Toggle the developer tools.
 		 */
 		toggleDevTools(): void;
@@ -884,7 +914,7 @@ declare module GitHubElectron {
 		 * Should be specified for submenu type menu item, when it's specified the
 		 * type: 'submenu' can be omitted for the menu item
 		 */
-		submenu?: MenuItemOptions[];
+		submenu?: Menu;
 		/**
 		 * Unique within a single menu. If defined then it can be used as a reference
 		 * to this item by the position attribute.
@@ -1022,6 +1052,7 @@ declare module GitHubElectron {
 		 * of your app is running, and other instances signal this instance and exit.
 		 */
 		makeSingleInstance(callback: (args: string[], workingDirectory: string) => boolean): boolean;
+		setAppUserModelId(id: string): void;
 	}
 
 	interface CommandLine {
@@ -1057,7 +1088,7 @@ declare module GitHubElectron {
 		/**
 		 * Description of this task.
 		 */
-		description: string;
+		description?: string;
 		/**
 		 * The absolute path to an icon to be displayed in a JumpList, it can be
 		 * arbitrary resource file that contains an icon, usually you can specify
@@ -1069,9 +1100,9 @@ declare module GitHubElectron {
 		 * icons, set this value to identify the icon. If an icon file consists of
 		 * one icon, this value is 0.
 		 */
-		iconIndex: number;
-		commandLine: CommandLine;
-		dock: {
+		iconIndex?: number;
+		commandLine?: CommandLine;
+		dock?: {
 			/**
 			 * When critical is passed, the dock icon will bounce until either the
 			 * application becomes active or the request is canceled.
@@ -1180,6 +1211,19 @@ declare module GitHubElectron {
 			properties?: string|string[];
 		}
 
+		interface SaveDialogOptions {
+			title?: string;
+			defaultPath?: string;
+			/**
+			 * File types that can be displayed, see dialog.showOpenDialog for an example.
+			 */
+
+			filters?: {
+				name: string;
+				extensions: string[];
+			}[]
+		}
+
 		/**
 		 * @param browserWindow
 		 * @param options
@@ -1187,18 +1231,7 @@ declare module GitHubElectron {
 		 * @returns On success, returns the path of file chosen by the user, otherwise
 		 * returns undefined.
 		 */
-		export function showSaveDialog(browserWindow?: BrowserWindow, options?: {
-			title?: string;
-			defaultPath?: string;
-			/**
-			 * File types that can be displayed, see dialog.showOpenDialog for an example.
-			 */
-			 
-			filters?: {
-				name: string;
-				extensions: string[];
-			}[]
-		}, callback?: (fileName: string) => void): string;
+		export function showSaveDialog(browserWindow?: BrowserWindow, options?: SaveDialogOptions, callback?: (fileName: string) => void): string;
 
 		/**
 		 * Shows a message box. It will block until the message box is closed. It returns .
@@ -1237,6 +1270,8 @@ declare module GitHubElectron {
 			 */
 			detail?: string;
 			icon?: NativeImage;
+			noLink?: boolean;
+			cancelId?: number;
 		}
 	}
 
@@ -1308,11 +1343,11 @@ declare module GitHubElectron {
 		/**
 		 * @returns The contents of the clipboard as a NativeImage.
 		 */
-		readImage: typeof GitHubElectron.Clipboard.readImage;
+		readImage: typeof Electron.Clipboard.readImage;
 		/**
 		 * Writes the image into the clipboard.
 		 */
-		writeImage: typeof GitHubElectron.Clipboard.writeImage;
+		writeImage: typeof Electron.Clipboard.writeImage;
 		/**
 		 * Clears everything in clipboard.
 		 */
@@ -1631,19 +1666,19 @@ declare module GitHubElectron {
 		 * @returns On success, returns an array of file paths chosen by the user,
 		 * otherwise returns undefined.
 		 */
-		showOpenDialog: typeof GitHubElectron.Dialog.showOpenDialog;
+		showOpenDialog: typeof Electron.Dialog.showOpenDialog;
 		/**
 		 * @param callback If supplied, the API call will be asynchronous.
 		 * @returns On success, returns the path of file chosen by the user, otherwise
 		 * returns undefined.
 		 */
-		showSaveDialog: typeof GitHubElectron.Dialog.showSaveDialog;
+		showSaveDialog: typeof Electron.Dialog.showSaveDialog;
 		/**
 		 * Shows a message box. It will block until the message box is closed. It returns .
 		 * @param callback If supplied, the API call will be asynchronous.
 		 * @returns The index of the clicked button.
 		 */
-		showMessageBox: typeof GitHubElectron.Dialog.showMessageBox;
+		showMessageBox: typeof Electron.Dialog.showMessageBox;
 
 		/**
 		 * Runs a modal dialog that shows an error message. This API can be called safely
@@ -1773,26 +1808,26 @@ declare module GitHubElectron {
 	}
 
 	interface CommonElectron {
-		clipboard: GitHubElectron.Clipboard;
-		crashReporter: GitHubElectron.CrashReporter;
-		nativeImage: typeof GitHubElectron.NativeImage;
-		shell: GitHubElectron.Shell;
+		clipboard: Electron.Clipboard;
+		crashReporter: Electron.CrashReporter;
+		nativeImage: typeof Electron.NativeImage;
+		shell: Electron.Shell;
 
-		app: GitHubElectron.App;
-		autoUpdater: GitHubElectron.AutoUpdater;
-		BrowserWindow: typeof GitHubElectron.BrowserWindow;
-		contentTracing: GitHubElectron.ContentTracing;
-		dialog: GitHubElectron.Dialog;
-		ipcMain: GitHubElectron.IPCMain;
-		globalShortcut: GitHubElectron.GlobalShortcut;
-		Menu: typeof GitHubElectron.Menu;
-		MenuItem: typeof GitHubElectron.MenuItem;
+		app: Electron.App;
+		autoUpdater: Electron.AutoUpdater;
+		BrowserWindow: typeof Electron.BrowserWindow;
+		contentTracing: Electron.ContentTracing;
+		dialog: Electron.Dialog;
+		ipcMain: Electron.IPCMain;
+		globalShortcut: Electron.GlobalShortcut;
+		Menu: typeof Electron.Menu;
+		MenuItem: typeof Electron.MenuItem;
 		powerMonitor: NodeJS.EventEmitter;
-		powerSaveBlocker: GitHubElectron.PowerSaveBlocker;
-		protocol: GitHubElectron.Protocol;
-		screen: GitHubElectron.Screen;
-		session: GitHubElectron.Session;
-		Tray: typeof GitHubElectron.Tray;
+		powerSaveBlocker: Electron.PowerSaveBlocker;
+		protocol: Electron.Protocol;
+		screen: Electron.Screen;
+		session: Electron.Session;
+		Tray: typeof Electron.Tray;
 		hideInternalModules(): void;
 	}
 
@@ -1814,11 +1849,11 @@ declare module GitHubElectron {
 		getSources(options: any, callback: (error: Error, sources: DesktopCapturerSource[]) => any): void;
 	}
 
-	interface Electron extends CommonElectron {
-		desktopCapturer: GitHubElectron.DesktopCapturer;
-		ipcRenderer: GitHubElectron.IpcRenderer;
-		remote: GitHubElectron.Remote;
-		webFrame: GitHubElectron.WebFrame;
+	interface ElectronMainAndRenderer extends CommonElectron {
+		desktopCapturer: Electron.DesktopCapturer;
+		ipcRenderer: Electron.IpcRenderer;
+		remote: Electron.Remote;
+		webFrame: Electron.WebFrame;
 	}
 }
 
@@ -1827,7 +1862,7 @@ interface Window {
 	 * Creates a new window.
 	 * @returns An instance of BrowserWindowProxy class.
 	 */
-	open(url: string, frameName?: string, features?: string): GitHubElectron.BrowserWindowProxy;
+	open(url: string, frameName?: string, features?: string): Electron.BrowserWindowProxy;
 }
 
 interface File {
@@ -1838,10 +1873,10 @@ interface File {
 }
 
 declare module 'electron' {
-	var electron: GitHubElectron.Electron;
+	var electron: Electron.ElectronMainAndRenderer;
 	export = electron;
 }
 
 interface NodeRequireFunction {
-	(id: 'electron'): GitHubElectron.Electron;
+	(moduleName: 'electron'): Electron.ElectronMainAndRenderer;
 }

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -914,7 +914,7 @@ declare module Electron {
 		 * Should be specified for submenu type menu item, when it's specified the
 		 * type: 'submenu' can be omitted for the menu item
 		 */
-		submenu?: Menu;
+		submenu?: Menu|MenuItemOptions[];
 		/**
 		 * Unique within a single menu. If defined then it can be used as a reference
 		 * to this item by the position attribute.


### PR DESCRIPTION
Great work on the d.ts for Electron! VS Code is in the process of adopting Electron 0.35.5 and I made some changes to adjust for missing API.

I also renamed GithubElectron to Electron because it felt much nicer in the code to refer to the API as "Electron.BrowserWindow" compared to "GitHubElectron.BrowserWindow".
