### PR TITLE
Add definitions for gulp-htmlmin, UglifyJS 2, clean-css and relateurl

### DIFF
--- a/clean-css/clean-css-tests.ts
+++ b/clean-css/clean-css-tests.ts
@@ -1,0 +1,55 @@
+/// <reference path="clean-css.d.ts" />
+
+import * as CleanCSS from 'clean-css';
+
+var source = 'a{font-weight:bold;}';
+var minified = new CleanCSS().minify(source).styles;
+
+var source = '@import url(http://path/to/remote/styles);';
+new CleanCSS().minify(source, function (error, minified) {
+  console.log(minified.styles);
+});
+
+const pathToOutputDirectory = 'path';
+
+new CleanCSS({ sourceMap: true, target: pathToOutputDirectory })
+  .minify(source, function (error, minified) {
+    // access minified.sourceMap for SourceMapGenerator object
+    // see https://github.com/mozilla/source-map/#sourcemapgenerator for more details
+    // see https://github.com/jakubpawlowicz/clean-css/blob/master/bin/cleancss#L114 on how it's used in clean-css' CLI
+    console.log(minified.sourceMap);
+});
+
+const inputSourceMapAsString = 'input';
+new CleanCSS({ sourceMap: inputSourceMapAsString, target: pathToOutputDirectory })
+  .minify(source, function (error, minified) {
+    // access minified.sourceMap to access SourceMapGenerator object
+    // see https://github.com/mozilla/source-map/#sourcemapgenerator for more details
+    // see https://github.com/jakubpawlowicz/clean-css/blob/master/bin/cleancss#L114 on how it's used in clean-css' CLI
+    console.log(minified.sourceMap);
+});
+
+new CleanCSS({ sourceMap: true, target: pathToOutputDirectory }).minify({
+  'path/to/source/1': {
+    styles: '...styles...',
+    sourceMap: '...source-map...'
+  },
+  'path/to/source/2': {
+    styles: '...styles...',
+    sourceMap: '...source-map...'
+  }
+}, function (error, minified) {
+  // access minified.sourceMap as above
+  console.log(minified.sourceMap);
+});
+
+new CleanCSS().minify(['path/to/file/one', 'path/to/file/two']);
+
+new CleanCSS().minify({
+  'path/to/file/one': {
+    styles: 'contents of file one'
+  },
+  'path/to/file/two': {
+    styles: 'contents of file two'
+  }
+});

--- a/clean-css/clean-css.d.ts
+++ b/clean-css/clean-css.d.ts
@@ -1,0 +1,109 @@
+// Type definitions for clean-css v3.4.9
+// Project: https://github.com/jakubpawlowicz/clean-css
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module 'clean-css' {
+  namespace CleanCSS {
+    interface Options {
+      // Set to false to disable advanced optimizations - selector & property merging, reduction, etc.
+      advanced?: boolean;
+
+      // Set to false to disable aggressive merging of properties.
+      aggressiveMerging?: boolean;
+
+      // Turns on benchmarking mode measuring time spent on cleaning up (run npm run bench to see example)
+      benchmark?: boolean;
+
+      // Enables compatibility mode
+      compatibility?: Object;
+
+      // Set to true to get minification statistics under stats property (see test/custom-test.js for examples)
+      debug?: boolean;
+
+      // A hash of options for @import inliner, see test/protocol-imports-test.js for examples, or this comment for a proxy use case.
+      inliner?: Object;
+
+      // Whether to keep line breaks (default is false)
+      keepBreaks?: boolean;
+
+      // * for keeping all (default), 1 for keeping first one only, 0 for removing all
+      keepSpecialComments?: string | number;
+
+      // Whether to merge @media at-rules (default is true)
+      mediaMerging?: boolean;
+
+      // Whether to process @import rules
+      processImport?: boolean;
+
+      // A list of @import rules, can be ['all'] (default), ['local'], ['remote'], or a blacklisted path e.g. ['!fonts.googleapis.com']
+      processImportFrom?: Array<string>;
+
+      // Set to false to skip URL rebasing
+      rebase?: boolean;
+
+      // Path to resolve relative @import rules and URLs
+      relativeTo?: string;
+
+      // Set to false to disable restructuring in advanced optimizations
+      restructuring?: boolean;
+
+      // Path to resolve absolute @import rules and rebase relative URLs
+      root?: string;
+
+      // Rounding precision; defaults to 2; -1 disables rounding
+      roundingPrecision?: number;
+
+      // Set to true to enable semantic merging mode which assumes BEM-like content (default is false as it's highly likely this will break your stylesheets - use with caution!)
+      semanticMerging?: boolean;
+
+      // Set to false to skip shorthand compacting (default is true unless sourceMap is set when it's false)
+      shorthandCompacting?: boolean;
+
+      // Exposes source map under sourceMap property, e.g. new CleanCSS().minify(source).sourceMap (default is false) If input styles are a product of CSS preprocessor (Less, Sass) an input source map can be passed as a string.
+      sourceMap?: boolean | string;
+
+      // Set to true to inline sources inside a source map's sourcesContent field (defaults to false) It is also required to process inlined sources from input source maps.
+      sourceMapInlineSources?: boolean;
+
+      // Path to a folder or an output file to which rebase all URLs
+      target?: string;
+    }
+
+    interface Output {
+      // Optimized output CSS as a string
+      styles: string;
+
+      // Output source map (if requested with sourceMap option)
+      sourceMap: string;
+
+      // A list of errors raised
+      errors: Array<string>;
+
+      // A list of warnings raised
+      warnings: Array<string>;
+
+      // A hash of statistic information (if requested with debug option)
+      stats: {
+        // Original content size (after import inlining)
+        originalSize: number;
+
+        // Optimized content size
+        minifiedSize: number;
+
+        // Time spent on optimizations
+        timeSpent: number;
+
+        // A ratio of output size to input size (e.g. 25% if content was reduced from 100 bytes to 75 bytes)
+        efficiency: number;
+      };
+    }
+  }
+
+  class CleanCSS {
+    constructor(options?: CleanCSS.Options);
+    minify(sources: string | Array<string> | Object, callback?: (error: any, minified: CleanCSS.Output) => void): CleanCSS.Output;
+  }
+
+  export = CleanCSS;
+}

--- a/gulp-htmlmin/gulp-htmlmin-tests.ts
+++ b/gulp-htmlmin/gulp-htmlmin-tests.ts
@@ -1,0 +1,11 @@
+/// <reference path="gulp-htmlmin.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import * as gulp from 'gulp';
+import * as htmlmin from 'gulp-htmlmin';
+
+gulp.task('minify', function() {
+  return gulp.src('src/*.html')
+    .pipe(htmlmin({collapseWhitespace: true}))
+    .pipe(gulp.dest('dist'))
+});

--- a/gulp-htmlmin/gulp-htmlmin.d.ts
+++ b/gulp-htmlmin/gulp-htmlmin.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for gulp-htmlmin v1.3.0
+// Project: https://github.com/jonschlinkert/gulp-htmlmin
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+/// <reference path="../html-minifier/html-minifier.d.ts" />
+
+declare module 'gulp-htmlmin' {
+    import * as HTMLMinifier from 'html-minifier';
+
+    namespace htmlmin {
+    }
+
+    function htmlmin(options?: HTMLMinifier.Options): NodeJS.ReadWriteStream;
+
+    export = htmlmin;
+}

--- a/gulp-minify-css/gulp-minify-css-tests.ts
+++ b/gulp-minify-css/gulp-minify-css-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path="./gulp-minify-css.d.ts" />
+/// <reference path="gulp-minify-css.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
 
 import * as gulp from "gulp";

--- a/gulp-minify-css/gulp-minify-css.d.ts
+++ b/gulp-minify-css/gulp-minify-css.d.ts
@@ -4,28 +4,12 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../node/node.d.ts" />
+/// <reference path="../clean-css/clean-css.d.ts" />
 
 declare module "gulp-minify-css" {
+    import * as CleanCSS from 'clean-css';
 
-    interface IOptions {
-        cache?: boolean;
-        advanced?: boolean;
-        aggressiveMerging?: boolean;
-        benchmark?: boolean;
-        compatibility?: string;
-        debug?: boolean;
-        inliner?: Object;
-        keepBreaks?: boolean;
-        keepSpecialComments?: string | number;
-        processImport?: boolean;
-        rebase?: boolean;
-        relativeTo?: string;
-        root?: string;
-        roundingPrecision?: number;
-        shorthandCompacting?: boolean;
-    }
-
-    function minifyCSS(options?: IOptions): NodeJS.ReadWriteStream;
+    function minifyCSS(options?: CleanCSS.Options): NodeJS.ReadWriteStream;
 
     namespace minifyCSS {}
 

--- a/gulp-minify-html/gulp-minify-html-tests.ts
+++ b/gulp-minify-html/gulp-minify-html-tests.ts
@@ -8,7 +8,7 @@ minifyHtml();
 minifyHtml({conditionals: true, loose: true});
 
 gulp.task('minify-html', () => {
-    var opts = {
+    var opts: minifyHtml.Options = {
         conditionals: true,
         spare: true
     };

--- a/gulp-minify-html/gulp-minify-html-tests.ts
+++ b/gulp-minify-html/gulp-minify-html-tests.ts
@@ -4,6 +4,8 @@
 import * as gulp from 'gulp';
 import * as minifyHtml from 'gulp-minify-html';
 
+// This package has been deprecated in favor of gulp-htmlmin, which should be faster and more comprehensive.
+
 minifyHtml();
 minifyHtml({conditionals: true, loose: true});
 

--- a/gulp-minify-html/gulp-minify-html.d.ts
+++ b/gulp-minify-html/gulp-minify-html.d.ts
@@ -5,8 +5,11 @@
 
 /// <reference path="../node/node.d.ts" />
 
+// This package has been deprecated in favor of gulp-htmlmin, which should be faster and more comprehensive.
+
 declare module 'gulp-minify-html' {
     namespace minifyHtml {
+        // Options from https://github.com/Swaagie/minimize#options
         interface Options {
             // Do not remove empty attributes
             empty?: boolean;

--- a/gulp-minify-html/gulp-minify-html.d.ts
+++ b/gulp-minify-html/gulp-minify-html.d.ts
@@ -6,32 +6,32 @@
 /// <reference path="../node/node.d.ts" />
 
 declare module 'gulp-minify-html' {
-    interface IOptions {
-        // Do not remove empty attributes
-        empty?: boolean;
+    namespace minifyHtml {
+        interface Options {
+            // Do not remove empty attributes
+            empty?: boolean;
 
-        // Do not strip CDATA from scripts
-        cdata?: boolean;
+            // Do not strip CDATA from scripts
+            cdata?: boolean;
 
-        // Do not remove comments
-        comments?: boolean;
+            // Do not remove comments
+            comments?: boolean;
 
-        // Do not remove conditional internet explorer comments
-        conditionals?: boolean;
+            // Do not remove conditional internet explorer comments
+            conditionals?: boolean;
 
-        // Do not remove redundant attributes
-        spare?: boolean;
+            // Do not remove redundant attributes
+            spare?: boolean;
 
-        // Do not remove arbitrary quotes
-        quotes?: boolean;
+            // Do not remove arbitrary quotes
+            quotes?: boolean;
 
-        // Preserve one whitespace
-        loose?: boolean;
+            // Preserve one whitespace
+            loose?: boolean;
+        }
     }
 
-    function minifyHtml(options?: IOptions): NodeJS.ReadWriteStream;
-
-    namespace minifyHtml {}
+    function minifyHtml(options?: minifyHtml.Options): NodeJS.ReadWriteStream;
 
     export = minifyHtml;
 }

--- a/gulp-uglify/gulp-uglify-tests.ts
+++ b/gulp-uglify/gulp-uglify-tests.ts
@@ -1,8 +1,8 @@
-/// <reference path="./gulp-uglify.d.ts"/>
+/// <reference path="gulp-uglify.d.ts"/>
 /// <reference path="../gulp/gulp.d.ts"/>
-import gulp = require("gulp");
-import uglify = require("gulp-uglify");
 
+import * as gulp from 'gulp';
+import * as uglify from 'gulp-uglify';
 
 gulp.task('compress', function() {
     var tsResult = gulp.src('lib/*.ts')

--- a/gulp-uglify/gulp-uglify.d.ts
+++ b/gulp-uglify/gulp-uglify.d.ts
@@ -4,172 +4,39 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../node/node.d.ts"/>
+/// <reference path="../uglify-js/uglify-js.d.ts"/>
 
 declare module "gulp-uglify" {
-    function GulpUglify(options?: IGulpUglifyOptions): NodeJS.ReadWriteStream;
+    import * as UglifyJS from 'uglify-js';
 
-    interface IGulpUglifyOptions {
-        /**
-         * Pass false to skip mangling names.
-         */
-        mangle?: boolean;
+    namespace GulpUglify {
+        interface Options {
+            /**
+             * Pass false to skip mangling names.
+             */
+            mangle?: boolean;
 
-        /**
-         * Pass if you wish to specify additional output options. The defaults are optimized for best compression.
-         */
-        output?: IOutputOptions;
+            /**
+             * Pass if you wish to specify additional output options. The defaults are optimized for best compression.
+             */
+            output?: UglifyJS.BeautifierOptions;
 
-        /**
-         * Pass an object to specify custom compressor options. Pass false to skip compression completely.
-         */
-        compress?: boolean;
+            /**
+             * Pass an object to specify custom compressor options. Pass false to skip compression completely.
+             */
+            compress?: UglifyJS.CompressorOptions | boolean;
 
-        /**
-         * A convenience option for options.output.comments. Defaults to preserving no comments.
-         * all - Preserve all comments in code blocks
-         * some - Preserve comments that start with a bang (!) or include a Closure Compiler directive (@preserve, @license, @cc_on)
-         * function - Specify your own comment preservation function. You will be passed the current node and the current comment and are expected to return either true or false.
-         */
-        preserverComments?: string|((node: any, comment: ITokenizer) => boolean);
+            /**
+             * A convenience option for options.output.comments. Defaults to preserving no comments.
+             * all - Preserve all comments in code blocks
+             * some - Preserve comments that start with a bang (!) or include a Closure Compiler directive (@preserve, @license, @cc_on)
+             * function - Specify your own comment preservation function. You will be passed the current node and the current comment and are expected to return either true or false.
+             */
+            preserverComments?: string|((node: any, comment: UglifyJS.Tokenizer) => boolean);
+        }
     }
 
-    interface IOutputOptions {
-        /**
-         * Start indentation on every line (only when `beautify`)
-         */
-        indent_start?: number;
+    function GulpUglify(options?: GulpUglify.Options): NodeJS.ReadWriteStream;
 
-        /**
-         * Indentation level (only when `beautify`)
-         */
-        indent_level?: number;
-
-        /**
-         * Quote all keys in object literals?
-         */
-        quote_keys?: boolean;
-
-        /**
-         * Add a space after colon signs?
-         */
-        space_colon?: boolean;
-
-        /**
-         * Output ASCII-safe? (encodes Unicode characters as ASCII)
-         */
-        ascii_only?: boolean;
-
-        /**
-         * Escape "</script"?
-         */
-        inline_script?: boolean;
-
-        /**
-         * Informative maximum line width (for beautified output)
-         */
-        width?: number;
-
-        /**
-         * Maximum line length (for non-beautified output)
-         */
-        max_line_len?: number;
-
-        /**
-         * Output IE-safe code?
-         */
-        ie_proof?: boolean;
-
-        /**
-         * Beautify output?
-         */
-        beautify?: boolean;
-
-        /**
-         * Output a source map
-         */
-        source_map?: ISourceMapOptions;
-
-        /**
-         * Use brackets every time?
-         */
-        bracketize?: boolean;
-
-        /**
-         * Output comments?
-         */
-        comments?: boolean;
-
-        /**
-         * Use semicolons to separate statements? (otherwise, newlines)
-         */
-        semicolons?: boolean;
-    }
-
-    interface ISourceMapOptions {
-        /**
-         * The compressed file name
-         */
-        file?: string;
-        /**
-         * The root URL to the original sources
-         */
-        root?: string;
-
-        /**
-         * The input source map.
-         * Useful when you compress code that was generated from some other source (possibly other programming language).
-         * If you have an input source map, pass it in this argument and UglifyJS will generate a mapping that maps back
-         * to the original source (as opposed to the compiled code that you are compressing).
-         */
-        orig? :Object|JSON;
-    }
-    
-    interface ITokenizer {
-        /**
-         * The type of this token.
-         * Can be "num", "string", "regexp", "operator", "punc", "atom", "name", "keyword", "comment1" or "comment2".
-         * "comment1" and "comment2" are for single-line, respectively multi-line comments.
-         */
-        type: string;
-        
-        /**
-         * The name of the file where this token originated from. Useful when compressing multiple files at once to generate the proper source map.
-         */
-        file: string;
-        
-        /**
-         * The "value" of the token.
-         * That's additional information and depends on the token type: "num", "string" and "regexp" tokens you get their literal value.
-         * - For "operator" you get the operator.
-         * - For "punc" it's the punctuation sign (parens, comma, semicolon etc).
-         * - For "atom", "name" and "keyword" it's the name of the identifier
-         * - For comments it's the body of the comment (excluding the initial "//" and "/*".
-         */
-        value: string;
-        
-        /**
-         * The line number of this token in the original code.
-         * 1-based index.
-         */
-        line: number;
-        
-        /**
-         * The column number of this token in the original code.
-         * 0-based index.
-         */
-        col: number;
-        
-        /**
-         * Short for "newline before", it's a boolean that tells us whether there was a newline before this node in the original source. It helps for automatic semicolon insertion.
-         * For multi-line comments in particular this will be set to true if there either was a newline before this comment, or * * if this comment contains a newline.
-         */
-        nlb: boolean;
-        
-        /**
-         * This doesn't apply for comment tokens, but for all other token types it will be an array of comment tokens that were found before.
-         */
-        comments_before: string[];
-    }
-    namespace GulpUglify {}
     export = GulpUglify;
 }

--- a/html-minifier/html-minifier-tests.ts
+++ b/html-minifier/html-minifier-tests.ts
@@ -1,0 +1,9 @@
+/// <reference path="html-minifier.d.ts" />
+
+import * as HTMLMinifier from 'html-minifier';
+const minify = HTMLMinifier.minify;
+
+var result = minify('<p title="blah" id="moo">foo</p>', {
+  removeAttributeQuotes: true
+});
+result; // '<p title=blah id=moo>foo</p>'

--- a/html-minifier/html-minifier.d.ts
+++ b/html-minifier/html-minifier.d.ts
@@ -1,0 +1,115 @@
+// Type definitions for HTMLMinifier v1.1.1
+// Project: https://github.com/kangax/html-minifier
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../uglify-js/uglify-js.d.ts" />
+/// <reference path="../clean-css/clean-css.d.ts" />
+/// <reference path="../relateurl/relateurl.d.ts" />
+
+declare module 'html-minifier' {
+  import * as UglifyJS from 'uglify-js';
+  import * as CleanCSS from 'clean-css';
+  import * as RelateUrl from 'relateurl';
+
+  namespace HTMLMinifier {
+    function minify(text: string, options?: Options): string;
+
+    interface Options {
+      // Strip HTML comments
+      removeComments?: boolean;
+
+      // Strip HTML comments from scripts and styles
+      removeCommentsFromCDATA?: boolean;
+
+      // Remove CDATA sections from script and style elements
+      removeCDATASectionsFromCDATA?: boolean;
+
+      // Collapse white space that contributes to text nodes in a document tree
+      collapseWhitespace?: boolean;
+
+      // Always collapse to 1 space (never remove it entirely). Must be used in conjunction with collapseWhitespace=true
+      conservativeCollapse?: boolean;
+
+      // Don't leave any spaces between display:inline; elements when collapsing. Must be used in conjunction with collapseWhitespace=true
+      collapseInlineTagWhitespace?: boolean;
+
+      // Always collapse to 1 line break (never remove it entirely) when whitespace between tags include a line break. Must be used in conjunction with collapseWhitespace=true
+      preserveLineBreaks?: boolean;
+
+      // Omit attribute values from boolean attributes
+      collapseBooleanAttributes?: boolean;
+
+      // Remove quotes around attributes when possible
+      removeAttributeQuotes?: boolean;
+
+      // Remove attributes when value matches default
+      removeRedundantAttributes?: boolean;
+
+      // Prevents the escaping of the values of attributes.
+      preventAttributesEscaping?: boolean;
+
+      // Replaces the doctype with the short (HTML5) doctype
+      useShortDoctype?: boolean;
+
+      // Remove all attributes with whitespace-only values
+      removeEmptyAttributes?: boolean;
+
+      // Remove type="text/javascript" from script tags. Other type attribute values are left intact.
+      removeScriptTypeAttributes?: boolean;
+
+      // Remove type="text/css" from style and link tags. Other type attribute values are left intact.
+      removeStyleLinkTypeAttributes?: boolean;
+
+      // Remove unrequired tags
+      removeOptionalTags?: boolean;
+
+      // Remove all elements with empty contents
+      removeEmptyElements?: boolean;
+
+      // Toggle linting
+      lint?: boolean;
+
+      // Keep the trailing slash on singleton elements
+      keepClosingSlash?: boolean;
+
+      // Treat attributes in case sensitive manner (useful for custom HTML tags.)
+      caseSensitive?: boolean;
+
+      // Minify Javascript in script elements and on* attributes (uses UglifyJS)
+      minifyJS?: boolean | UglifyJS.MinifyOptions;
+
+      // Minify CSS in style elements and style attributes (uses clean-css)
+      minifyCSS?: boolean | CleanCSS.Options;
+
+      // Minify URLs in various attributes (uses relateurl)
+      minifyURLs?: boolean | RelateUrl.Options;
+
+      // Array of regex'es that allow to ignore certain comments, when matched
+      ignoreCustomComments?: Array<RegExp>;
+
+      // Array of regex'es that allow to ignore certain fragments, when matched (e.g. <?php ... ?>, {{ ... }}, etc.)
+      ignoreCustomFragments?: Array<RegExp>;
+
+      // Array of strings corresponding to types of script elements to process through minifier (e.g. text/ng-template, text/x-handlebars-template, etc.)
+      processScripts?: Array<string>;
+
+      // Specify a maximum line length. Compressed output will be split by newlines at valid HTML split-points
+      maxLineLength?: number;
+
+      // Arrays of regex'es that allow to support custom attribute assign expressions (e.g. '<div flex?="{{mode != cover}}"></div>')
+      customAttrAssign?: Array<RegExp>;
+
+      // Arrays of regex'es that allow to support custom attribute surround expressions (e.g. <input {{#if value}}checked="checked"{{/if}}>)
+      customAttrSurround?: Array<RegExp>;
+
+      // Regex that specifies custom attribute to strip newlines from (e.g. /ng\-class/)
+      customAttrCollapse?: RegExp;
+
+      // Type of quote to use for attribute values (' or ")
+      quoteCharacter?: string;
+    }
+  }
+
+  export = HTMLMinifier;
+}

--- a/relateurl/relateurl-tests.ts
+++ b/relateurl/relateurl-tests.ts
@@ -1,0 +1,20 @@
+/// <reference path="relateurl.d.ts" />
+
+import * as RelateUrl from 'relateurl';
+
+var from = "http://www.domain.com/asdf/";
+var to = "http://www.domain.com/asdf/asdf";
+var to1 = "http://www.domain.com/asdf/asdf1";
+var to2 = "http://www.domain.com/asdf/asdf1";
+var to3 = "http://www.domain.com/asdf/asdf1";
+var options = {site: "http://www.domain.com/asdf2/"};
+var customOptions = {output: RelateUrl.ABSOLUTE};
+
+// Single Instance
+var result = RelateUrl.relate(from, to, options);
+
+// Reusable Instances
+var instance = new RelateUrl(from, options);
+var result1 = instance.relate(to1);
+var result2 = instance.relate(to2, customOptions);
+var result3 = instance.relate(to3);

--- a/relateurl/relateurl.d.ts
+++ b/relateurl/relateurl.d.ts
@@ -1,0 +1,125 @@
+// Type definitions for relateurl v0.2.6
+// Project: https://github.com/stevenvachon/relateurl
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module 'relateurl' {
+  namespace RelateUrl {
+    interface Options {
+      /**
+       * Type: Object
+       * Default value: {ftp:21, http:80, https:443}
+       *
+       * Extend the list with any ports you need. Any URLs containing these default ports will have them removed. Example: http://example.com:80/ will become http://example.com/.
+       */
+      defaultPorts?: Object;
+
+      /**
+       * Type: Array
+       * Default value: ["index.html"]
+       *
+       * Extend the list with any resources you need. Works with options.removeDirectoryIndexes.
+       */
+      directoryIndexes?: Array<string>;
+
+      /**
+       * Type: Boolean
+       * Default value: false
+       *
+       * This will, for example, consider any domains containing http://www.example.com/ to be related to any that contain http://example.com/.
+       */
+      ignore_www?: boolean;
+
+      /**
+       * Type: constant or String
+       * Choices: RelateUrl.ABSOLUTE,RelateUrl.PATH_RELATIVE,RelateUrl.ROOT_RELATIVE,RelateUrl.SHORTEST
+       * Choices: "absolute","pathRelative","rootRelative","shortest"
+       * Default value: RelateUrl.SHORTEST
+       *
+       * RelateUrl.ABSOLUTE will produce an absolute URL. Overrides options.schemeRelative with a value of false.
+       * RelateUrl.PATH_RELATIVE will produce something like ../child-of-parent/etc/.
+       * RelateUrl.ROOT_RELATIVE will produce something like /child-of-root/etc/.
+       * RelateUrl.SHORTEST will choose whichever is shortest between root- and path-relative.
+       */
+      output?: string;
+
+      /**
+       * Type: Array
+       * Default value: ["data","javascript","mailto"]
+       *
+       * Extend the list with any additional schemes. Example: javascript:something will not be modified.
+       */
+      rejectedSchemes?: Array<string>;
+
+      /**
+       * Type: Boolean
+       * Default value: false
+       *
+       * Remove user authentication information from the output URL.
+       */
+      removeAuth?: boolean;
+
+      /**
+       * Type: Boolean
+       * Default value: true
+       *
+       * Remove any resources that match any found in options.directoryIndexes.
+       */
+      removeDirectoryIndexes?: boolean;
+
+      /**
+       * Type: Boolean
+       * Default value: false
+       *
+       * Remove empty query variables. Example: http://domain.com/?var1&var2=&var3=asdf will become http://domain.com/?var3=adsf. This does not apply to unrelated URLs (with other protocols, auths, hosts and/or ports).
+       */
+      removeEmptyQueries?: boolean;
+
+      /**
+       * Type: Boolean
+       * Default value: true
+       *
+       * Remove trailing slashes from root paths. Example: http://domain.com/?var will become http://domain.com?var while http://domain.com/dir/?var will not be modified.
+       */
+      removeRootTrailingSlash?: boolean;
+
+      /**
+       * Type: Boolean
+       * Default value: true
+       *
+       * Output URLs relative to the scheme. Example: http://example.com/ will become //example.com/.
+       */
+      schemeRelative?: boolean;
+
+      /**
+       * Type: String
+       * Default value: undefined
+       *
+       * An options-based version of the from argument. If both are specified, from takes priority.
+       */
+      site?: string;
+
+      /**
+       * Type: Boolean
+       * Default value: true
+       *
+       * Passed to Node's url.parse.
+       */
+      slashesDenoteHost?: boolean;
+    }
+  }
+
+  class RelateUrl {
+    static ABSOLUTE: string;
+    static PATH_RELATIVE: string;
+    static ROOT_RELATIVE: string;
+    static SHORTEST: string;
+
+    static relate(from: string, to: string, options?: RelateUrl.Options): string;
+
+    constructor(from: string, options?: RelateUrl.Options);
+    relate(to: string, options?: RelateUrl.Options): string;
+  }
+
+  export = RelateUrl;
+}

--- a/uglify-js/uglify-js-tests.ts
+++ b/uglify-js/uglify-js-tests.ts
@@ -1,0 +1,73 @@
+/// <reference path="uglify-js.d.ts" />
+/// <reference path="../node/node.d.ts" />
+
+import * as UglifyJS from 'uglify-js';
+import * as fs from 'fs';
+
+var result = UglifyJS.minify("/path/to/file.js");
+console.log(result.code); // minified output
+// if you need to pass code instead of file name
+var result = UglifyJS.minify("var b = function () {};", {fromString: true});
+
+var result = UglifyJS.minify([ "file1.js", "file2.js", "file3.js" ]);
+console.log(result.code);
+
+var result = UglifyJS.minify([ "file1.js", "file2.js", "file3.js" ], {
+    outSourceMap: "out.js.map"
+});
+console.log(result.code); // minified output
+console.log(result.map);
+
+var result = UglifyJS.minify([ "file1.js", "file2.js", "file3.js" ], {
+    outSourceMap: "out.js.map",
+    sourceRoot: "http://example.com/src"
+});
+
+var result = UglifyJS.minify("compiled.js", {
+    inSourceMap: "compiled.js.map",
+    outSourceMap: "minified.js.map"
+});
+// same as before, it returns `code` and `map`
+
+const my_source_map_string = 'sourceMap';
+var result = UglifyJS.minify("compiled.js", {
+    inSourceMap: JSON.parse(my_source_map_string),
+    outSourceMap: "minified.js.map"
+});
+
+var toplevel_ast = UglifyJS.parse(code, {});
+
+var toplevel: UglifyJS.AST_Toplevel = null;
+const files = ['file1', 'file2'];
+files.forEach(function(file){
+    var code = fs.readFileSync(file, "utf8");
+    toplevel = UglifyJS.parse(code, {
+        filename: file,
+        toplevel: toplevel
+    });
+});
+
+toplevel.figure_out_scope()
+
+var compressor = UglifyJS.Compressor({});
+var compressed_ast = toplevel.transform(compressor);
+
+compressed_ast.figure_out_scope();
+compressed_ast.compute_char_frequency();
+compressed_ast.mangle_names();
+
+var stream = UglifyJS.OutputStream({});
+compressed_ast.print(stream);
+var code = stream.toString(); // this is your minified code
+
+var code = compressed_ast.print_to_string({});
+
+var source_map = UglifyJS.SourceMap({});
+var stream = UglifyJS.OutputStream({
+    //...
+    source_map: source_map
+});
+compressed_ast.print(stream);
+
+var code = stream.toString();
+var map = source_map.toString(); // json output for your source map

--- a/uglify-js/uglify-js.d.ts
+++ b/uglify-js/uglify-js.d.ts
@@ -1,0 +1,430 @@
+// Type definitions for UglifyJS 2 v2.6.1
+// Project: https://github.com/mishoo/UglifyJS2
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../source-map/source-map.d.ts" />
+
+declare module 'uglify-js' {
+  import * as MOZ_SourceMap from 'source-map';
+
+  namespace UglifyJS {
+    interface Tokenizer {
+      /**
+       * The type of this token.
+       * Can be "num", "string", "regexp", "operator", "punc", "atom", "name", "keyword", "comment1" or "comment2".
+       * "comment1" and "comment2" are for single-line, respectively multi-line comments.
+       */
+      type: string;
+
+      /**
+       * The name of the file where this token originated from. Useful when compressing multiple files at once to generate the proper source map.
+       */
+      file: string;
+
+      /**
+       * The "value" of the token.
+       * That's additional information and depends on the token type: "num", "string" and "regexp" tokens you get their literal value.
+       * - For "operator" you get the operator.
+       * - For "punc" it's the punctuation sign (parens, comma, semicolon etc).
+       * - For "atom", "name" and "keyword" it's the name of the identifier
+       * - For comments it's the body of the comment (excluding the initial "//" and "/*".
+       */
+      value: string;
+
+      /**
+       * The line number of this token in the original code.
+       * 1-based index.
+       */
+      line: number;
+
+      /**
+       * The column number of this token in the original code.
+       * 0-based index.
+       */
+      col: number;
+
+      /**
+       * Short for "newline before", it's a boolean that tells us whether there was a newline before this node in the original source. It helps for automatic semicolon insertion.
+       * For multi-line comments in particular this will be set to true if there either was a newline before this comment, or * * if this comment contains a newline.
+       */
+      nlb: boolean;
+
+      /**
+       * This doesn't apply for comment tokens, but for all other token types it will be an array of comment tokens that were found before.
+       */
+      comments_before: string[];
+    }
+
+    interface AST_Node {
+      // The first token of this node
+      start: AST_Node;
+
+      // The last token of this node
+      end: AST_Node;
+
+      transform(tt: TreeTransformer): AST_Toplevel;
+    }
+
+    interface AST_Toplevel extends AST_Node {
+      // UglifyJS contains a scope analyzer which figures out variable/function definitions, references etc.
+      // You need to call it manually before compression or mangling.
+      // The figure_out_scope method is defined only on the AST_Toplevel node.
+      figure_out_scope(): void;
+
+      // Get names that are optimized for GZip compression (names will be generated using the most frequent characters first)
+      compute_char_frequency(): void;
+
+      mangle_names(): void;
+
+      print(stream: OutputStream): void;
+
+      print_to_string(options?: BeautifierOptions): string;
+    }
+
+    interface MinifyOptions {
+      spidermonkey?: boolean;
+      outSourceMap?: string;
+      sourceRoot?: string;
+      inSourceMap?: string;
+      fromString?: boolean;
+      warnings?: boolean;
+      mangle?: Object;
+      output?: MinifyOutput,
+      compress?: Object;
+    }
+
+    interface MinifyOutput {
+      code: string;
+      map: string;
+    }
+
+    function minify(files: string | Array<string>, options?: MinifyOptions): MinifyOutput;
+
+
+    interface ParseOptions {
+      // Default is false
+      strict?: boolean;
+
+      // Input file name, default is null
+      filename?: string;
+
+      // Default is null
+      toplevel?: AST_Toplevel;
+    }
+
+    /**
+     * The parser creates a custom abstract syntax tree given a piece of JavaScript code.
+     * Perhaps you should read about the AST first.
+     */
+    function parse(code: string, options?: ParseOptions): AST_Toplevel;
+
+
+    interface BeautifierOptions {
+      /**
+       * Start indentation on every line (only when `beautify`)
+       */
+      indent_start?: number;
+
+      /**
+       * Indentation level (only when `beautify`)
+       */
+      indent_level?: number;
+
+      /**
+       * Quote all keys in object literals?
+       */
+      quote_keys?: boolean;
+
+      /**
+       * Add a space after colon signs?
+       */
+      space_colon?: boolean;
+
+      /**
+       * Output ASCII-safe? (encodes Unicode characters as ASCII)
+       */
+      ascii_only?: boolean;
+
+      /**
+       * Escape "</script"?
+       */
+      inline_script?: boolean;
+
+      /**
+       * Informative maximum line width (for beautified output)
+       */
+      width?: number;
+
+      /**
+       * Maximum line length (for non-beautified output)
+       */
+      max_line_len?: number;
+
+      /**
+       * Output IE-safe code?
+       */
+      ie_proof?: boolean;
+
+      /**
+       * Beautify output?
+       */
+      beautify?: boolean;
+
+      /**
+       * Output a source map
+       */
+      source_map?: SourceMapOptions;
+
+      /**
+       * Use brackets every time?
+       */
+      bracketize?: boolean;
+
+      /**
+       * Output comments?
+       */
+      comments?: boolean;
+
+      /**
+       * Use semicolons to separate statements? (otherwise, newlines)
+       */
+      semicolons?: boolean;
+    }
+
+    interface OutputStream {
+      // Return the output so far as a string
+      get(): string;
+      toString(): string;
+
+      // Insert one indentation string (usually 4 characters).
+      // Optionally pass true to indent half the width (I'm using that for case and default lines in switch blocks.
+      // If beautify is off, this function does nothing.
+      indent(half?: boolean): void;
+
+      // Return the current indentation width (not level; for example if we're in level 2 and indent_level is 4, this method would return 8.
+      indentation(): number;
+
+      // return the width of the current line text minus indentation.
+      current_width(): number
+
+      // Return true if current_width() is bigger than options.width (assuming options.width is non-null, non-zero).
+      should_break(): boolean;
+
+      // If beautification is on, this inserts a newline. Otherwise it does nothing.
+      newline(): void;
+
+      // Include the given string into the output, adjusting current_line, current_col and current_pos accordingly.
+      print(str: string): void;
+
+      // If beautification is on this always includes a space character.
+      // Otherwise it saves a hint somewhere that a space might be needed at current point.
+      // The space will go in at the next output but only when absolutely required, for example it will insert the space in return 10 but not in return"stuff".
+      space(): void;
+
+      // Inserts a comma, and calls space() — that is, if beautification is on you'll get a space after the comma.
+      comma(): void;
+
+      // Inserts a colon, and calls space() if options.space_colon is set.
+      colon(): void;
+
+      // Returns the last printed chunk.
+      last(): string;
+
+      // If beautification is on it always inserts a semicolon.
+      // Otherwise it saves a hint that a semicolon might be needed at current point.
+      // The semicolon is inserted when the next output comes in, only if required to not break the JS syntax.
+      semicolon(): void;
+
+      // Always inserts a semicolon and clears the hint that a semicolon might be needed.
+      force_semicolon(): void;
+
+      // Encodes any non-ASCII characters in string with JavaScript's conventions (using \uCODE).
+      to_ascii(str: string): void;
+
+      // Prints an identifier. If options.ascii_only is set, non-ASCII chars will be encoded with JavaScript conventions.
+      print_name(name: string): void;
+
+      // Prints a string. It adds quotes automatically.
+      // It prefers double-quotes, but will actually count any quotes in the string and will use single-quotes if the output proves to be shorter (depending on how many backslashes it has to insert).
+      // It encodes to ASCII if options.ascii_only is set.
+      print_string(str: string): void;
+
+      // Returns the width of the next indentation level. For example if current level is 2 and options.indent_level is 4, it'll return 12.
+      next_indent(): number;
+
+      // Sets the current indentation to col (column), calls the function and thereafter restores the previous indentation level.
+      // If beautification is off it simply calls func.
+      with_indent(col: number, func: Function): void;
+
+      // This is used to output blocks in curly brackets.
+      // It'll print an open bracket at current point, then call newline() and with the next indentation level it calls your func.
+      // Lastly, it'll print an indented closing bracket. As usual, if beautification is off you'll just get {x} where x is whatever func outputs.
+      with_block(func: Function): void;
+
+      // Adds parens around the output that your function prints.
+      with_parens(func: Function): void;
+
+      // Adds square brackets around the output that your function prints.
+      with_square(func: Function): void;
+
+      // If options.source_map is set, this will generate a source mapping between the given token (which should be an AST_Token-like object) and the current line/col.
+      // The name is optional; in most cases it will be inferred from the token.
+      add_mapping(token: AST_Node, name?: string): void;
+
+      // Returns the option with the given name.
+      option(name: string): any;
+
+      // Returns the current line in the output (1-based).
+      line(): number;
+
+      // Returns the current column in the output (zero-based).
+      col(): number;
+
+      // Push the given node into an internal stack. This is used to keep track of current node's parent(s).
+      push_node(node: AST_Node): void;
+
+      // Pops the top of the stack and returns it.
+      pop_node(): AST_Node;
+
+      // Returns that internal stack.
+      stack(): any;
+
+      // Returns the n-th parent node (where zero means the direct parent).
+      parent(n: number): AST_Node;
+    }
+
+    /**
+     * The code generator is a recursive process of getting back source code from an AST returned by the parser.
+     * Every AST node has a “print” method that takes an OutputStream and dumps the code from that node into it.
+     * The stream object supports a lot of options that control the output.
+     * You can specify whether you'd like to get human-readable (indented) output, the indentation level, whether you'd like to quote all properties in object literals etc.
+     */
+    function OutputStream(options?: BeautifierOptions): OutputStream;
+
+
+    interface SourceMapOptions {
+      /**
+       * The compressed file name
+       */
+      file?: string;
+
+      /**
+       * The root URL to the original sources
+       */
+      root?: string;
+
+      /**
+       * The input source map.
+       * Useful when you compress code that was generated from some other source (possibly other programming language).
+       * If you have an input source map, pass it in this argument and UglifyJS will generate a mapping that maps back
+       * to the original source (as opposed to the compiled code that you are compressing).
+       */
+      orig?: Object | JSON;
+    }
+
+    interface SourceMap {
+      add(source: string, gen_line: number, gen_col: number, orig_line: number, orig_col: number, name?: string): void;
+      get(): MOZ_SourceMap.SourceMapGenerator;
+      toString(): string;
+    }
+
+    /**
+     * The output stream keeps track of the current line/column in the output and can trivially generate a source mapping to the original code via Mozilla's source-map library.
+     * To use this functionality, you must load this library (it's automatically require-d by UglifyJS in the NodeJS version, but in a browser you must load it yourself)
+     * and make it available via the global MOZ_SourceMap variable.
+     */
+    function SourceMap(options?: SourceMapOptions): SourceMap;
+
+
+    interface CompressorOptions {
+      // Join consecutive statemets with the “comma operator”
+      sequences?: boolean;
+
+      // Optimize property access: a["foo"] → a.foo
+      properties?: boolean;
+
+      // Discard unreachable code
+      dead_code?: boolean;
+
+      // Discard “debugger” statements
+      drop_debugger?: boolean;
+
+      // Some unsafe optimizations (see below)
+      unsafe?: boolean;
+
+      // Optimize if-s and conditional expressions
+      conditionals?: boolean;
+
+      // Optimize comparisons
+      comparisons?: boolean;
+
+      // Evaluate constant expressions
+      evaluate?: boolean;
+
+      // Optimize boolean expressions
+      booleans?: boolean;
+
+      // Optimize loops
+      loops?: boolean;
+
+      // Drop unused variables/functions
+      unused?: boolean;
+
+      // Hoist function declarations
+      hoist_funs?: boolean;
+
+      // Hoist variable declarations
+      hoist_vars?: boolean;
+
+      // Optimize if-s followed by return/continue
+      if_return?: boolean;
+
+      // Join var declarations
+      join_vars?: boolean;
+
+      // Try to cascade `right` into `left` in sequences
+      cascade?: boolean;
+
+      // Drop side-effect-free statements
+      side_effects?: boolean;
+
+      // Warn about potentially dangerous optimizations/code
+      warnings?: boolean;
+
+      // Global definitions
+      global_defs?: Object;
+    }
+
+    /**
+     * The compressor is a tree transformer which reduces the code size by applying various optimizations on the AST
+     */
+    function Compressor(options?: CompressorOptions): AST_Toplevel;
+
+
+    // TODO
+    interface TreeWalker {
+    }
+
+    type visitor = (node: AST_Node, descend: Function) => boolean;
+
+    /**
+     * UglifyJS provides a TreeWalker object and every node has a walk method that given a walker will apply your visitor to each node in the tree.
+     * Your visitor can return a non-falsy value in order to prevent descending the current node.
+     */
+    function TreeWalker(visitor: visitor): TreeWalker;
+
+
+    // TODO
+    interface TreeTransformer extends TreeWalker {
+    }
+
+    /**
+     * The tree transformer is a special case of a tree walker.
+     * In fact it even inherits from TreeWalker and you can use the same methods, but initialization and visitor protocol are a bit different.
+     */
+    function TreeTransformer(before: visitor, after: visitor): TreeTransformer;
+  }
+
+  export = UglifyJS;
+}

--- a/webpack/webpack.d.ts
+++ b/webpack/webpack.d.ts
@@ -3,7 +3,11 @@
 // Definitions by: Qubo <https://github.com/tkqubo>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
+/// <reference path="../uglify-js/uglify-js.d.ts"/>
+
 declare module "webpack" {
+    import * as UglifyJS from 'uglify-js';
+
     namespace webpack {
         interface Configuration {
             context?: string;
@@ -426,7 +430,7 @@ declare module "webpack" {
                 new(preferEntry: boolean): Plugin;
             }
             interface UglifyJsPluginStatic {
-                new(options?: any): Plugin;
+                new(options?: UglifyJS.MinifyOptions): Plugin;
             }
             interface CommonsChunkPluginStatic {
                 new(chunkName: string, filenames?: string|string[]): Plugin;


### PR DESCRIPTION
Main goal: add definitions for [gulp-htmlmin](https://github.com/jonschlinkert/gulp-htmlmin).

gulp-htmlmin uses [HTMLMinifier](https://github.com/kangax/html-minifier), so I've added definitions for HTMLMinifier.
HTMLMinifier uses [UglifyJS 2](https://github.com/mishoo/UglifyJS2), [clean-css](https://github.com/jakubpawlowicz/clean-css) and [relateurl](https://github.com/stevenvachon/relateurl), so I've added definitions for them too.
Since other packages uses UglifyJS 2 and clean-css, I've refactored their definitions (webpack, gulp-uglify and gulp-minify-css).
