### PR TITLE
added toHaveBeenCalledTimes

### DIFF
--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -290,6 +290,7 @@ declare module jasmine {
         toBeFalsy(expectationFailOutput?: any): boolean;
         toHaveBeenCalled(): boolean;
         toHaveBeenCalledWith(...params: any[]): boolean;
+        toHaveBeenCalledTimes(expected: number): boolean;
         toContain(expected: any, expectationFailOutput?: any): boolean;
         toBeLessThan(expected: number, expectationFailOutput?: any): boolean;
         toBeGreaterThan(expected: number, expectationFailOutput?: any): boolean;


### PR DESCRIPTION
Jasmine matcher [toHaveBeenCalledTimes](https://github.com/jasmine/jasmine/blob/375a6f9fda57fdd896acce9abba7aca2e02b310a/src/core/matchers/toHaveBeenCalledTimes..js) was not included in the type definition.
