### PR TITLE
underscore: fix _.chain(Dictionary), _.values(Dictionary), _(Dictionary)

### DIFF
--- a/underscore/underscore-tests.ts
+++ b/underscore/underscore-tests.ts
@@ -494,5 +494,9 @@ function strong_typed_values_tests() {
     return [r.title, true];
   }).object().value();
 
+  _(dictionaryLike).each((x) => {
+    console.log(x.title);
+    console.log(x.value.toFixed());
+  })
   _.values<{title: string, value: number}>(dictionaryLike);
 }

--- a/underscore/underscore-tests.ts
+++ b/underscore/underscore-tests.ts
@@ -479,3 +479,20 @@ _.chain(obj).map(function (value, key) {
     empty[key] = value;
     console.log("vk", value, key);
 });
+
+function strong_typed_values_tests() {
+  var dictionaryLike: { [k: string] : {title: string, value: number} } = {
+         'test' : { title: 'item1', value: 5 },
+         'another' : { title: 'item2', value: 8 },
+         'third' : { title: 'item3', value: 10 }
+      },
+      empty = {};
+
+  _.chain(dictionaryLike).values().filter((r) => {
+    return r.value >= 8;
+  }).map((r) => {
+    return [r.title, true];
+  }).object().value();
+
+  _.values<{title: string, value: number}>(dictionaryLike);
+}

--- a/underscore/underscore-tests.ts
+++ b/underscore/underscore-tests.ts
@@ -493,10 +493,11 @@ function strong_typed_values_tests() {
         return [r.title, true];
     }).object().value();
 
-    _(dictionaryLike).each((x) => {
+    var x: number = _(dictionaryLike).chain().filter((x) => {
         console.log(x.title);
         console.log(x.value.toFixed());
-    });
+        return x.title == 'item1';
+    }).size().value();
 
     _.values<{title: string, value: number}>(dictionaryLike);
 }

--- a/underscore/underscore-tests.ts
+++ b/underscore/underscore-tests.ts
@@ -481,22 +481,22 @@ _.chain(obj).map(function (value, key) {
 });
 
 function strong_typed_values_tests() {
-  var dictionaryLike: { [k: string] : {title: string, value: number} } = {
-         'test' : { title: 'item1', value: 5 },
-         'another' : { title: 'item2', value: 8 },
-         'third' : { title: 'item3', value: 10 }
-      },
-      empty = {};
+    var dictionaryLike: { [k: string] : {title: string, value: number} } = {
+        'test' : { title: 'item1', value: 5 },
+        'another' : { title: 'item2', value: 8 },
+        'third' : { title: 'item3', value: 10 }
+    };
 
-  _.chain(dictionaryLike).values().filter((r) => {
-    return r.value >= 8;
-  }).map((r) => {
-    return [r.title, true];
-  }).object().value();
+    _.chain(dictionaryLike).values().filter((r) => {
+        return r.value >= 8;
+    }).map((r) => {
+        return [r.title, true];
+    }).object().value();
 
-  _(dictionaryLike).each((x) => {
-    console.log(x.title);
-    console.log(x.value.toFixed());
-  })
-  _.values<{title: string, value: number}>(dictionaryLike);
+    _(dictionaryLike).each((x) => {
+        console.log(x.title);
+        console.log(x.value.toFixed());
+    });
+
+    _.values<{title: string, value: number}>(dictionaryLike);
 }

--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -76,6 +76,7 @@ interface UnderscoreStatic {
 	* as the first parameter can be invoked through this function.
 	* @param key First argument to Underscore object functions.
 	**/
+	<T>(value: _.Dictionary<T>): Underscore<T>;
 	<T>(value: Array<T>): Underscore<T>;
 	<T>(value: T): Underscore<T>;
 

--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -1197,6 +1197,13 @@ interface UnderscoreStatic {
 	* @param object Retrieve the values of all the properties on this object.
 	* @return List of all the values on `object`.
 	**/
+	values<T>(object: _.Dictionary<T>): T[];
+
+	/**
+	* Return all of the values of the object's properties.
+	* @param object Retrieve the values of all the properties on this object.
+	* @return List of all the values on `object`.
+	**/
 	values(object: any): any[];
     
     /**
@@ -1641,6 +1648,7 @@ interface UnderscoreStatic {
 	* @return Wrapped `obj`.
 	**/
 	chain<T>(obj: T[]): _Chain<T>;
+	chain<T>(obj: _.Dictionary<T>): _Chain<T>;
 	chain<T extends {}>(obj: T): _Chain<T>;
 }
 

--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -2824,7 +2824,7 @@ interface _Chain<T> {
 	* Wrapped type `any`.
 	* @see _.size
 	**/
-	size(): _Chain<T>;
+	size(): _ChainSingle<number>;
 
 	/*********
 	* Arrays *


### PR DESCRIPTION
Added some tests for previously broken, but valid calls.

Also fixes `_.chain(obj).size().value()` to return `number` instead of `T[]`.
