### PR TITLE
Adding availability for the DynamoDB Document Client

### DIFF
--- a/aws-sdk/aws-sdk.d.ts
+++ b/aws-sdk/aws-sdk.d.ts
@@ -154,6 +154,12 @@ declare module "aws-sdk" {
 		constructor(options?: any);
 	}
 
+	export module DynamoDB {
+		export class DocumentClient {
+			constructor(options?: any);
+		}
+	}
+
 	export module SQS {
 		
 		export interface SqsOptions {


### PR DESCRIPTION
The current version does not take into account the Document Client - added to version 2.2.0 of the aws-sdk.

The changes allows for proper usage.

https://blogs.aws.amazon.com/javascript/post/Tx1OVH5LUZAFC6T/Announcing-the-Amazon-DynamoDB-Document-Client-in-the-AWS-SDK-for-JavaScript
