### PR TITLE
Make MenuOptions extend MenuEvents

### DIFF
--- a/jqueryui/jqueryui-tests.ts
+++ b/jqueryui/jqueryui-tests.ts
@@ -1471,6 +1471,7 @@ function test_menu() {
     $(".selector").menu({ position: { my: "left top", at: "right-5 top+5" } });
     $(".selector").menu({ role: null });
     $(".selector").menu("option", { disabled: true });
+    $(".selector").menu({ select: (e, ui) => { } });
 }
 
 

--- a/jqueryui/jqueryui.d.ts
+++ b/jqueryui/jqueryui.d.ts
@@ -498,7 +498,7 @@ declare module JQueryUI {
 
     // Menu //////////////////////////////////////////////////
 
-    interface MenuOptions {
+    interface MenuOptions extends MenuEvents {
         disabled?: boolean;
         icons?: any;
         menus?: string;
@@ -520,7 +520,7 @@ declare module JQueryUI {
         select?: MenuEvent;
     }
 
-    interface Menu extends Widget, MenuOptions, MenuEvents {
+    interface Menu extends Widget, MenuOptions {
     }
 
 

--- a/jqueryui/jqueryui.d.ts
+++ b/jqueryui/jqueryui.d.ts
@@ -507,6 +507,7 @@ declare module JQueryUI {
     }
 
     interface MenuUIParams {
+        item?: JQuery;
     }
 
     interface MenuEvent {


### PR DESCRIPTION
The menu widget definition does not allow a MenuEvents object to be passed to it during initialization. For example, this gives an error from TypeScript:

$el.menu({select: (e, ui) => { }});

I modified the MenuOptions definition to extend MenuEvents and removed MenuEvents from the Menu interface definition. This makes it consistent with how the other widgets are defined and allows both options and events to be defined when creating a menu widget.
