### PR TITLE
Update webfontloader.d.ts

### DIFF
--- a/webfontloader/webfontloader.d.ts
+++ b/webfontloader/webfontloader.d.ts
@@ -35,8 +35,8 @@ declare module WebFont {
 		monotype?:Monotype;
 	}
 	export interface Google {
-		families?:Array<string>;	
-		text: string;
+		families:Array<string>;	
+		text?: string;
 	}
 	export interface Typekit {
 		id?:Array<string>;


### PR DESCRIPTION
The 'text' property of the Google interface is optional and used to character subsetting.
https://github.com/typekit/webfontloader#google
