### PR TITLE
Update to typings of consolidate.js

### DIFF
--- a/consolidate/consolidate-tests.ts
+++ b/consolidate/consolidate-tests.ts
@@ -1,27 +1,168 @@
 /// <reference path="consolidate.d.ts" />
+import cons = require('consolidate');
 
-import consolidate = require('consolidate');
+var path: string = 'test/path';
+var options = {user: 'tobi'};
+var fn = function(err: Error, html: string) {};
 
-var path: string = null;
-var options: any = null;
-var fn: any = null;
+cons.atpl(path);
+cons.atpl(path, options);
+cons.atpl(path, options, fn);
 
-consolidate.clearCache();
-consolidate.jade(path, options, fn);
-consolidate.dust(path, options, fn);
-consolidate.swig(path, options, fn);
-consolidate.liquor(path, options, fn);
-consolidate.ejs(path, options, fn);
-consolidate.eco(path, options, fn);
-consolidate.jazz(path, options, fn);
-consolidate.jqtpl(path, options, fn);
-consolidate.haml(path, options, fn);
-consolidate.whiskers(path, options, fn);
-//consolidate.'haml-coffee':Function;
-consolidate.hogan(path, options, fn);
-consolidate.handlebars(path, options, fn);
-consolidate.underscore(path, options, fn);
-consolidate.qejs(path, options, fn);
-consolidate.walrus(path, options, fn);
-consolidate.mustache(path, options, fn);
-consolidate.dot(path, options, fn);
+cons.dot(path);
+cons.dot(path, options);
+cons.dot(path, options, fn);
+
+cons.dust(path);
+cons.dust(path, options);
+cons.dust(path, options, fn);
+
+cons.eco(path);
+cons.eco(path, options);
+cons.eco(path, options, fn);
+
+cons.ect(path);
+cons.ect(path, options);
+cons.ect(path, options, fn);
+
+cons.ejs(path);
+cons.ejs(path, options);
+cons.ejs(path, options, fn);
+
+cons.haml(path);
+cons.haml(path, options);
+cons.haml(path, options, fn);
+
+// TODO figure out how to type haml-coffee
+// cons['haml-coffee'](path, options, fn);
+
+cons.hamlet(path);
+cons.hamlet(path, options);
+cons.hamlet(path, options, fn);
+
+cons.handlebars(path);
+cons.handlebars(path, options);
+cons.handlebars(path, options, fn);
+
+cons.hogan(path);
+cons.hogan(path, options);
+cons.hogan(path, options, fn);
+
+cons.htmling(path);
+cons.htmling(path, options);
+cons.htmling(path, options, fn);
+
+cons.jade(path);
+cons.jade(path, options);
+cons.jade(path, options, fn);
+
+cons.jazz(path);
+cons.jazz(path, options);
+cons.jazz(path, options, fn);
+
+cons.jqtpl(path);
+cons.jqtpl(path, options);
+cons.jqtpl(path, options, fn);
+
+cons.just(path);
+cons.just(path, options);
+cons.just(path, options, fn);
+
+cons.liquid(path);
+cons.liquid(path, options);
+cons.liquid(path, options, fn);
+
+cons.liquor(path);
+cons.liquor(path, options);
+cons.liquor(path, options, fn);
+
+cons.lodash(path);
+cons.lodash(path, options);
+cons.lodash(path, options, fn);
+
+cons.mote(path);
+cons.mote(path, options);
+cons.mote(path, options, fn);
+
+cons.mustache(path);
+cons.mustache(path, options);
+cons.mustache(path, options, fn);
+
+cons.nunjucks(path);
+cons.nunjucks(path, options);
+cons.nunjucks(path, options, fn);
+
+cons.qejs(path);
+cons.qejs(path, options);
+cons.qejs(path, options, fn);
+
+cons.ractive(path);
+cons.ractive(path, options);
+cons.ractive(path, options, fn);
+
+cons.react(path);
+cons.react(path, options);
+cons.react(path, options, fn);
+
+cons.swig(path);
+cons.swig(path, options);
+cons.swig(path, options, fn);
+
+cons.templayed(path);
+cons.templayed(path, options);
+cons.templayed(path, options, fn);
+
+cons.toffee(path);
+cons.toffee(path, options);
+cons.toffee(path, options, fn);
+
+cons.underscore(path);
+cons.underscore(path, options);
+cons.underscore(path, options, fn);
+
+cons.walrus(path);
+cons.walrus(path, options);
+cons.walrus(path, options, fn);
+
+cons.whiskers(path);
+cons.whiskers(path, options);
+cons.whiskers(path, options, fn);
+
+/**
+ * Examples from documentation
+ * https://github.com/tj/consolidate.js/
+ */
+// Common use
+cons.swig('views/page.html', { user: 'tobi' }, function(err, html) {
+  if (err) throw err;
+  console.log(html);
+});
+
+// Options object is optional
+cons.swig('views/page.html', function(err, html) {
+  if (err) throw err;
+  console.log(html);
+});
+
+// To dynamically pass the engine, simply use the subscript operator and a variable:
+cons['swig']('views/page.html', { user: 'tobi' }, function(err, html) {
+  if (err) throw err;
+  console.log(html);
+});
+
+// Returns a promise if no is callback passed in:
+cons.swig('views/page.html', { user: 'tobi' })
+  .then(function(html) {
+    console.log(html);
+  })
+  .catch(function(err) {
+    throw err;
+  });
+
+// Caching
+cons.swig('views/page.html', { cache: false, user: 'tobi' }, function(err, html) {
+  if (err) throw err;
+  console.log(html);
+});
+
+

--- a/consolidate/consolidate.d.ts
+++ b/consolidate/consolidate.d.ts
@@ -6,25 +6,76 @@
 // Imported from: https://github.com/soywiz/typescript-node-definitions/consolidate.d.ts
 
 /// <reference path="../node/node.d.ts" />
+/// <reference path="../bluebird/bluebird.d.ts" />
+
 
 declare module "consolidate" {
-	export function clearCache(): void;
-	export var jade: (path: String, options: any, fn: any) => void;
-	export var dust: (path: String, options: any, fn: any) => void;
-	export var swig: (path: String, options: any, fn: any) => void;
-	export var liquor: (path: String, options: any, fn: any) => void;
-	export var ejs: (path: String, options: any, fn: any) => void;
-	export var eco: (path: String, options: any, fn: any) => void;
-	export var jazz: (path: String, options: any, fn: any) => void;
-	export var jqtpl: (path: String, options: any, fn: any) => void;
-	export var haml: (path: String, options: any, fn: any) => void;
-	export var whiskers: (path: String, options: any, fn: any) => void;
-	//export var 'haml-coffee':Function;
-	export var hogan: (path: String, options: any, fn: any) => void;
-	export var handlebars: (path: String, options: any, fn: any) => void;
-	export var underscore: (path: String, options: any, fn: any) => void;
-	export var qejs: (path: String, options: any, fn: any) => void;
-	export var walrus: (path: String, options: any, fn: any) => void;
-	export var mustache: (path: String, options: any, fn: any) => void;
-	export var dot: (path: String, options: any, fn: any) => void;
+	var cons: Consolidate;
+
+	export = cons;
+
+	interface Consolidate {
+		/**
+ 		 * expose the instance of the engine
+	   */
+		requires: Object;
+
+		/**
+		 * Clear the cache.
+		 *
+		 * @api public
+		 */
+		clearCache(): void;
+		// template engines
+		atpl: RendererInterface;
+		// atpl(path: String, fn: (err: Error, html: String) => any ): any;
+		// atpl(path: String, options: Options, fn: (err: Error, html: String) => any): any;
+		// atpl(path: String, options?: Options): Promise<String>;
+
+		// atpl: TemplateProperty;
+		dot: RendererInterface;
+		dust: RendererInterface;
+		eco: RendererInterface;
+		ejs: RendererInterface;
+		ect: RendererInterface;
+		haml: RendererInterface;
+		// TODO figure out how to do haml-coffee
+		hamlet: RendererInterface;
+		handlebars: RendererInterface;
+		hogan: RendererInterface;
+		htmling: RendererInterface;
+		jade: RendererInterface;
+		jazz: RendererInterface;
+		jqtpl: RendererInterface;
+		just: RendererInterface;
+		liquid: RendererInterface;
+		liquor: RendererInterface;
+		lodash: RendererInterface;
+		mote: RendererInterface;
+		mustache: RendererInterface;
+		nunjucks: RendererInterface;
+		qejs: RendererInterface;
+		ractive: RendererInterface;
+		react: RendererInterface;
+		swig: RendererInterface;
+		templayed: RendererInterface;
+		toffee: RendererInterface;
+		underscore: RendererInterface;
+		walrus: RendererInterface;
+		whiskers: RendererInterface;
+	}
+
+	interface RendererInterface {
+		render(path: String, fn: (err: Error, html: String) => any): any;
+
+		render(path: String, options: {cache?: boolean, [otherOptions: string]: any}, fn: (err: Error, html: String) => any): any;
+
+		render(path: String, options?: { cache?: boolean, [otherOptions: string]: any }): Promise<String>;
+
+		(path: String, fn: (err: Error, html: String) => any): any;
+
+		(path: String, options: { cache?: boolean, [otherOptions: string]: any }, fn: (err: Error, html: String) => any): any;
+
+		(path: String, options?: { cache?: boolean, [otherOptions: string]: any }): Promise<String>;
+	}
 }

--- a/consolidate/consolidate.d.ts
+++ b/consolidate/consolidate.d.ts
@@ -1,13 +1,12 @@
 // Type definitions for consolidate
 // Project: https://github.com/visionmedia/consolidate.js
-// Definitions by: Carlos Ballesteros Velasco <https://github.com/soywiz>
+// Definitions by: Carlos Ballesteros Velasco <https://github.com/soywiz>, Theo Sherry <https://github.com/theosherry>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 // Imported from: https://github.com/soywiz/typescript-node-definitions/consolidate.d.ts
 
 /// <reference path="../node/node.d.ts" />
 /// <reference path="../bluebird/bluebird.d.ts" />
-
 
 declare module "consolidate" {
 	var cons: Consolidate;
@@ -28,11 +27,6 @@ declare module "consolidate" {
 		clearCache(): void;
 		// template engines
 		atpl: RendererInterface;
-		// atpl(path: String, fn: (err: Error, html: String) => any ): any;
-		// atpl(path: String, options: Options, fn: (err: Error, html: String) => any): any;
-		// atpl(path: String, options?: Options): Promise<String>;
-
-		// atpl: TemplateProperty;
 		dot: RendererInterface;
 		dust: RendererInterface;
 		eco: RendererInterface;


### PR DESCRIPTION
The consolidate.js type definition file was pretty out of date.  I added support for the new template engines consolidate.js supports.  I also added support for the various types that the supported engines can take on.  For example, they return Promises if no callback is given, and the options parameter is optional.
