### PR TITLE
Angular GrowlV2 - added missing message methods; fixed module name

### DIFF
--- a/angular-growl-v2/angular-growl-v2-tests.ts
+++ b/angular-growl-v2/angular-growl-v2-tests.ts
@@ -58,4 +58,8 @@ app.controller("Ctrl", ($scope:angular.IScope,
     growlMessages.destroyAllMessages(0);
     growlMessages.addMessage(messages[0]);
     growlMessages.deleteMessage(messages[1]);
+    
+    var testMessage = growl.warning(message);
+    testMessage.setText("Some other message");
+    testMessage.destroy();
 });

--- a/angular-growl-v2/angular-growl-v2.d.ts
+++ b/angular-growl-v2/angular-growl-v2.d.ts
@@ -39,6 +39,16 @@ declare module angular.growl {
      */
     interface IGrowlMessage extends IGrowlMessageConfig {
         text: string;
+        
+        /**
+         * Destroy the message.
+         */
+        destroy(): void;
+        /**
+         * Update the message body.
+         * @param newText new message body
+         */
+        setText(newText: string): void;
     }
 
     /**
@@ -223,7 +233,7 @@ declare module angular.growl {
          * @param referenceId
          * @param limitMessages
          */
-        initDirective(referenceId: number, limitMessages: number): ng.IDirective;
+        initDirective(referenceId: number, limitMessages: number): angular.IDirective;
 
         /**
          * Get current messages


### PR DESCRIPTION
I've added missing methods available on returned message objects and updated reference to main angular module.
