### PR TITLE
Reflect API changes in express-handlebars

### DIFF
--- a/express-handlebars/express-handlebars-tests.ts
+++ b/express-handlebars/express-handlebars-tests.ts
@@ -6,9 +6,8 @@ import express = require('express');
 import exphbs = require('express-handlebars');
 
 var app = express();
-var hbs: Exphbs = exphbs.create({defaultLayout: 'main'});
 
-app.engine('handlebars', hbs.engine);
+app.engine('handlebars', exphbs({defaultLayout: 'main'}));
 app.set('view engine', 'handlebars');
 
 app.listen(1337);

--- a/express-handlebars/express-handlebars.d.ts
+++ b/express-handlebars/express-handlebars.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for express-handlebars
 // Project: https://github.com/ericf/express-handlebars
 // Definitions by: Sam Saint-Pettersen <https://github.com/stpettersens>
+// Updated by: Igor Dultsev <https://github.com/yhaskell>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../es6-promise/es6-promise.d.ts" />
@@ -40,7 +41,12 @@ interface Exphbs {
     renderView(viewPath: string, optionsOrCallback: any, callback?: () => string): void;
 }
 
+interface ExpressHandlebars {
+  (options?: ExphbsOptions): Function;
+  create (options?: ExphbsOptions): Exphbs;
+}
+
 declare module "express-handlebars" {
-    var exphbs: Exphbs;
+    var exphbs: ExpressHandlebars;
     export = exphbs;
 }

--- a/express-handlebars/express-handlebars.d.ts
+++ b/express-handlebars/express-handlebars.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for express-handlebars
 // Project: https://github.com/ericf/express-handlebars
-// Definitions by: Sam Saint-Pettersen <https://github.com/stpettersens>
-// Updated by: Igor Dultsev <https://github.com/yhaskell>
+// Definitions by: Sam Saint-Pettersen <https://github.com/stpettersens>, Igor Dultsev <https://github.com/yhaskell>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../es6-promise/es6-promise.d.ts" />


### PR DESCRIPTION
Express-handlebars changed return value of `require()`, and this is a patch that contains a fix to this issue.

@stpettersens, could you please review and approve? 

Thanks.
