### PR TITLE
Removed the default keyword  as it confuses some IDEs

### DIFF
--- a/localForage/localForage.d.ts
+++ b/localForage/localForage.d.ts
@@ -91,6 +91,6 @@ interface LocalForage {
 }
 
 declare module "localforage" {
-    var localforage: LocalForage;
-    export default localforage;
+    export var localforage: LocalForage;
+	export default localforage;
 }


### PR DESCRIPTION
See discussion in https://github.com/mozilla/localForage/issues/494
