### PR TITLE
add definitions for koa 2.x

### DIFF
--- a/koa2/koa2-tests.ts
+++ b/koa2/koa2-tests.ts
@@ -1,0 +1,20 @@
+/// <reference path="koa2.d.ts" />
+import * as Koa from "koa";
+
+const app = new Koa();
+
+app.use((ctx, next) => {
+  const start: any = new Date();
+  return next().then(() => {
+    const end: any = new Date();
+    const ms = end - start;
+    console.log(`${ctx.method} ${ctx.url} - ${ms}ms`);
+  });
+});
+
+// response
+app.use(ctx => {
+  ctx.body = "Hello World";
+});
+
+app.listen(3000);

--- a/koa2/koa2.d.ts
+++ b/koa2/koa2.d.ts
@@ -1,0 +1,134 @@
+// Type definitions for Koa 2.x
+// Project: http://koajs.com
+// Definitions by: DavidCai1993 <https://github.com/DavidCai1993>
+
+/* =================== USAGE ===================
+
+    import * as Koa from 'koa'
+    const app = new Koa()
+
+ =============================================== */
+/// <reference path="../node/node.d.ts" />
+
+declare module 'koa' {
+  import { EventEmitter } from 'events';
+  import * as http from 'http';
+  import * as net from 'net';
+
+  interface IContext extends IRequest, IResponse {
+      body?: any;
+      request?: IRequest;
+      response?: IResponse;
+      originalUrl?: string;
+      state?: any;
+      name?: string;
+      cookies?: any;
+      writable?: Boolean;
+      respond?: Boolean;
+      app?: Koa;
+      req?: http.IncomingMessage;
+      res?: http.ServerResponse;
+      onerror(err: any): void;
+      toJSON(): any;
+      inspect(): any;
+      throw(): void;
+      assert(): void;
+  }
+
+  interface IRequest {
+      _querycache?: string;
+      app?: Koa;
+      req?: http.IncomingMessage;
+      res?: http.ServerResponse;
+      response?: IResponse;
+      ctx?: IContext;
+      headers?: any;
+      header?: any;
+      method?: string;
+      length?: any;
+      url?: string;
+      origin?: string;
+      originalUrl?: string;
+      href?: string;
+      path?: string;
+      querystring?: string;
+      query?: any;
+      search?: string;
+      idempotent?: Boolean;
+      socket?: net.Socket;
+      protocol?: string;
+      host?: string;
+      hostname?: string;
+      fresh?: Boolean;
+      stale?: Boolean;
+      charset?: string;
+      secure?: Boolean;
+      ips?: Array<string>;
+      ip?: string;
+      subdomains?: Array<string>;
+      accept?: any;
+      type?: string;
+      accepts?: () => any;
+      acceptsEncodings?: () => any;
+      acceptsCharsets?: () => any;
+      acceptsLanguages?: () => any;
+      is?: (types: any) => any;
+      toJSON?: () => any;
+      inspect?: () => any;
+      get?: (field: string) => string;
+  }
+
+  interface IResponse {
+      _body?: any;
+      _explicitStatus?: Boolean;
+      app?: Koa;
+      res?: http.ServerResponse;
+      req?: http.IncomingMessage;
+      ctx?: IContext;
+      request?: IRequest;
+      socket?: net.Socket;
+      header?: any;
+      headers?: any;
+      status?: number;
+      message?: string;
+      type?: string;
+      body?: any;
+      length?: any;
+      headerSent?: Boolean;
+      lastModified?: Date;
+      etag?: string;
+      writable?: Boolean;
+      is?: (types: any) => any;
+      redirect?: (url: string, alt: string) => void;
+      attachment?: (filename?: string) => void;
+      vary?: (field: string) => void;
+      get?: (field: string) => string;
+      set?: (field: any, val: any) => void;
+      remove?: (field: string) => void;
+      append?: (field: string, val: any) => void;
+      toJSON?: () => any;
+      inspect?: () => any;
+  }
+
+  class Koa extends EventEmitter {
+      keys: Array<string>;
+      subdomainOffset: number;
+      proxy: Boolean;
+      server: http.Server;
+      env: string;
+      context: IContext;
+      request: IRequest;
+      response: IResponse;
+      silent: Boolean;
+      constructor();
+      use(middleware: (ctx: IContext, next: Function) => any): Koa;
+      callback(): (req: http.IncomingMessage, res: http.ServerResponse) => void;
+      listen(port: number, callback?: Function): http.Server;
+      toJSON(): any;
+      inspect(): any;
+      onerror(err: any): void;
+  }
+
+  var K: typeof Koa
+  export = K
+}


### PR DESCRIPTION
Because today we can not directly define the type of `this` of koa's middleware function, so it's just the definition file for koa 2.x, which puts all it's context in the first parameter of the middleware function. For those who are using koa 2.x .
