### PR TITLE
Make RoutingContextProps implement MatchState rather than just implem…

### DIFF
--- a/react-router/react-router-1.0.0.d.ts
+++ b/react-router/react-router-1.0.0.d.ts
@@ -108,13 +108,8 @@ declare namespace ReactRouter {
     const IndexLink: Link
 
 
-    interface RoutingContextProps extends React.Props<RoutingContext> {
-        history: H.History
+    interface RoutingContextProps extends React.Props<RoutingContext>, MatchState {
         createElement: (component: RouteComponent, props: Object) => any
-        location: H.Location
-        routes: RouteConfig
-        params: Params
-        components?: RouteComponent[]
     }
     interface RoutingContext extends React.ComponentClass<RoutingContextProps> {}
     interface RoutingContextElement extends React.ReactElement<RoutingContextProps> {}


### PR DESCRIPTION
…ent elements of MatchState - causing problems when it comes to using React.CreateElement on RoutingContext as outputted by match
