### PR TITLE
Support TypeScript 1.7 modules

### DIFF
--- a/sinon-chai/sinon-chai.d.ts
+++ b/sinon-chai/sinon-chai.d.ts
@@ -80,5 +80,6 @@ declare module Chai {
 
 declare module "sinon-chai" {
     function sinonChai(chai: any, utils: any): void;
+    namespace sinonChai { }
     export = sinonChai;
 }


### PR DESCRIPTION
This fix allows to import modules in TypesScript 1.7 using `import` keyword, like:
import \* as sinonChai from 'sinon-chai';

The current version gives compilation error: "Module sinon-chai resolves to a non-module entity"
