### PR TITLE
autobahn.d.ts: Remove dependence on jquery.d.ts

### DIFF
--- a/autobahn/autobahn.d.ts
+++ b/autobahn/autobahn.d.ts
@@ -4,7 +4,6 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../when/when.d.ts" />
-/// <reference path="../jquery/jquery.d.ts" />
 
 declare module autobahn {
 
@@ -194,7 +193,7 @@ declare module autobahn {
         type: string;
     }
 
-    type DeferFactory = () => JQueryPromise<any>;
+    type DeferFactory = () => When.Promise<any>;
 
     type OnChallengeHandler = (session: Session, method: string, extra: any) => When.Promise<string>;
 


### PR DESCRIPTION
jQuery declares a global var `$` which makes it potentially conflict with other declarations, for example angular-protractor

autobahn.d.ts doesn't need to depend on jquery.d.ts since the only thing it used, JqueryPromise, can be replaced with when.Promise
