### PR TITLE
Fixed deprecated express 3.x functions

### DIFF
--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -103,9 +103,9 @@ declare module "express" {
             route(path: string): IRoute;
 
             use(...handler: RequestHandler[]): T;
-            use(handler: ErrorRequestHandler): T;
+            use(handler: ErrorRequestHandler|RequestHandler): T;
             use(path: string, ...handler: RequestHandler[]): T;
-            use(path: string, handler: ErrorRequestHandler): T;
+            use(path: string, handler: ErrorRequestHandler|RequestHandler): T;
             use(path: string[], ...handler: RequestHandler[]): T;
             use(path: string[], handler: ErrorRequestHandler): T;
             use(path: RegExp, ...handler: RequestHandler[]): T;
@@ -200,20 +200,35 @@ declare module "express" {
             accepts(type: string[]): string;
 
             /**
-             * Check if the given `charset` is acceptable,
-             * otherwise you should respond with 406 "Not Acceptable".
+             * Returns the first accepted charset of the specified character sets,
+             * based on the request’s Accept-Charset HTTP header field.
+             * If none of the specified charsets is accepted, returns false.
              *
+             * For more information, or if you have issues or concerns, see accepts.
              * @param charset
              */
-            acceptsCharset(charset: string): boolean;
+            acceptsCharsets(charset?: string|string[]): string[];
 
             /**
-             * Check if the given `lang` is acceptable,
-             * otherwise you should respond with 406 "Not Acceptable".
+             * Returns the first accepted encoding of the specified encodings,
+             * based on the request’s Accept-Encoding HTTP header field.
+             * If none of the specified encodings is accepted, returns false.
+             *
+             * For more information, or if you have issues or concerns, see accepts.
+             * @param encoding
+             */
+            acceptsEncodings(encoding?: string|string[]): string[];
+
+            /**
+             * Returns the first accepted language of the specified languages,
+             * based on the request’s Accept-Language HTTP header field.
+             * If none of the specified languages is accepted, returns false.
+             *
+             * For more information, or if you have issues or concerns, see accepts.
              *
              * @param lang
              */
-            acceptsLanguage(lang: string): boolean;
+            acceptsLanguages(lang?: string|string[]): string[];
 
             /**
              * Parse Range header field,
@@ -239,28 +254,6 @@ declare module "express" {
              * ordered from highest quality to lowest.
              */
             accepted: MediaType[];
-
-            /**
-             * Return an array of Accepted languages
-             * ordered from highest quality to lowest.
-             *
-             * Examples:
-             *
-             *     Accept-Language: en;q=.5, en-us
-             *     ['en-us', 'en']
-             */
-            acceptedLanguages: any[];
-
-            /**
-             * Return an array of Accepted charsets
-             * ordered from highest quality to lowest.
-             *
-             * Examples:
-             *
-             *     Accept-Charset: iso-8859-5;q=.2, unicode-1-1;q=0.8
-             *     ['unicode-1-1', 'iso-8859-5']
-             */
-            acceptedCharsets: any[];
 
             /**
              * Return the value of param `name` when present or `defaultValue`.


### PR DESCRIPTION
- Fixed deprecated express 3.x functions as reported in issue https://github.com/DefinitelyTyped/DefinitelyTyped/issues/7507
- Also updated use() fonction when having only one handler parameter
