### PR TITLE
Updated Body-parser urlencoded option

### DIFF
--- a/body-parser/body-parser.d.ts
+++ b/body-parser/body-parser.d.ts
@@ -110,7 +110,7 @@ declare module "body-parser" {
             defaultCharset?: string;
         }): express.RequestHandler;
 
-        export function urlencoded(options?: {
+        export function urlencoded(options: {
             /**
              * if deflated bodies will be inflated. (default: true)
              */
@@ -128,9 +128,9 @@ declare module "body-parser" {
              */
             verify?: (req: express.Request, res: express.Response, buf: Buffer, encoding: string) => void;
             /**
-             * parse extended syntax with the qs module. (default: true)
+             * parse extended syntax with the qs module.
              */
-            extended?: boolean;
+            extended: boolean;
         }): express.RequestHandler;
     }
 


### PR DESCRIPTION
The urlencoded extended option is no longer optional
The default value has been deprecated.
https://github.com/expressjs/body-parser#bodyparserurlencodedoptions
