### PR TITLE
updated signature of shell.task()

### DIFF
--- a/gulp-shell/gulp-shell.d.ts
+++ b/gulp-shell/gulp-shell.d.ts
@@ -10,7 +10,7 @@ declare module "gulp-shell" {
     namespace shell {
         interface Shell {
             (commands: string|string[], options?: Option): NodeJS.ReadWriteStream;
-            task(commands: string|string[], options?: Option): () => NodeJS.ReadWriteStream;
+            task(commands: string|string[], options?: Option): (done: Function) => NodeJS.ReadWriteStream;
         }
 
         interface Option {


### PR DESCRIPTION
added `done` function to method signature of `shell.task()`, so the result of `shell.task()` can be called with a callback like `shell.task()(done)`.
The callback is called after completion of the shell commands. So you can be sure, `done` is only called once the shell commands are processed.
