### PR TITLE
Added missing includes function overload

### DIFF
--- a/angular-ui-router/angular-ui-router.d.ts
+++ b/angular-ui-router/angular-ui-router.d.ts
@@ -257,6 +257,7 @@ declare module angular.ui {
         transitionTo(state: string, params?: {}, options?: IStateOptions): angular.IPromise<any>;
         transitionTo(state: IState, params?: {}, options?: IStateOptions): angular.IPromise<any>;
         includes(state: string, params?: {}): boolean;
+        includes(state: string, params?: {}, options?:any): boolean;
         is(state:string, params?: {}): boolean;
         is(state: IState, params?: {}): boolean;
         href(state: IState, params?: {}, options?: IHrefOptions): string;


### PR DESCRIPTION
The includes function call with an options object was not defined.
See: http://angular-ui.github.io/ui-router/site/#/api/ui.router.state.$state
