### PR TITLE
mongoose.d.ts Document interface should define _id as any

### DIFF
--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -41,6 +41,16 @@ var schema: mongoose.Schema = new Schema({ name: String }, { collection: 'actor'
 schema.set('collection', 'actor');
 var Model = mongoose.model<IActor>('Actor', schema, 'actor');
 
+interface IZip extends mongoose.Document {
+    _id: string;
+}
+interface IPerson extends mongoose.Document {
+    _id: mongoose.Types.ObjectId;
+}
+interface IThing extends mongoose.Document {
+    _id: number;
+}
+
 var names: string[] = mongoose.modelNames();
 var names: string[] = db.modelNames();
 mongoose.plugin((schema: mongoose.Schema) => {

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -423,7 +423,7 @@ declare module "mongoose" {
 
   export interface Document {
     id?: string;
-    _id: Types.ObjectId;
+    _id: any;
 
     equals(doc: Document): boolean;
     get(path: string, type?: new(...args: any[]) => any): any;


### PR DESCRIPTION
In the Document interface definition of mongoose.d.ts, the _id field
definition of `_id: Types.ObjectId` was wrong, as it can be any type. This
PR changes the definition to `_id: any` to allow interfaces that
extend Document to refine the definition of _id as appropriate to match
the schema of the model/collection.

Closes #7499
