### PR TITLE
change ResultSet.rows from Object[] to any[]

### DIFF
--- a/any-db/any-db.d.ts
+++ b/any-db/any-db.d.ts
@@ -50,7 +50,7 @@ declare module "any-db" {
 		/**
 		 * Result rows
 		 */
-		rows: Object[];
+		rows: any[];
 		/**
 		 * Result field descriptions
 		 */


### PR DESCRIPTION
I think it is better to use `any[]` rather than `Object[]`. So the row can be used like `row.id` rather than `row['id']` in most case.
