### PR TITLE
Correct parameter type for Vector4.setAxisAngleFromRotationMatrix.

### DIFF
--- a/threejs/tests/math/test_unit_math.ts
+++ b/threejs/tests/math/test_unit_math.ts
@@ -3524,4 +3524,16 @@
         ok( a.equals( b ), "Passed!" );
         ok( b.equals( a ), "Passed!" );
     });
+
+    test( "setAxisAngleFromRotationMatrix", function() {
+        var TOL = 1e-9;
+
+        var r = new THREE.Matrix4().makeRotationZ(Math.PI / 2);
+        var v = new THREE.Vector4().setAxisAngleFromRotationMatrix(r);
+
+        ok( v.x == 0, "Passed!" );
+        ok( v.y == 0, "Passed!" );
+        ok( v.z == 1, "Passed!" );
+        ok( Math.abs(v.w - Math.PI / 2) < TOL, "Passed!" );
+    });
 };

--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -4166,7 +4166,7 @@ declare module THREE {
          * http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToAngle/index.htm
          * @param m assumes the upper 3x3 of m is a pure rotation matrix (i.e, unscaled)
          */
-        setAxisAngleFromRotationMatrix(m: Matrix3): Vector4;
+        setAxisAngleFromRotationMatrix(m: Matrix4): Vector4;
 
         min(v: Vector4): Vector4;
         max(v: Vector4): Vector4;


### PR DESCRIPTION
The parameter to Vector4.setAxisAngleFromRotationMatrix is a
Matrix4 from which the upper 3x3 matrix is used, not a Matrix3.

See https://github.com/mrdoob/three.js/blob/master/src/math/Vector4.js#L271
for a reference.

Successful build here: https://travis-ci.org/oscarlorentzon/DefinitelyTyped/builds/102062571 .
