### PR TITLE
Add overload to allow both forms of global property setting in calq

### DIFF
--- a/calq/calq.d.ts
+++ b/calq/calq.d.ts
@@ -21,7 +21,7 @@ declare module Calq
         trackPageView(action?:string):void;
 
         setGlobalProperty(name:string, value:any):void;
-        setGlobalProperty(params?: {[index:string]: any}):void;
+        setGlobalProperty(params: {[index:string]: any}):void;
     }
 
     interface User

--- a/calq/calq.d.ts
+++ b/calq/calq.d.ts
@@ -19,7 +19,9 @@ declare module Calq
         trackSale(action:string, params:{[index:string]:any}, currency:string, amount:number):void;
         trackHTMLLink(action:string, params?:{[index:string]:any}):void;
         trackPageView(action?:string):void;
-        setGlobalProperty(name:string,value:any):void;
+
+        setGlobalProperty(name:string, value:any):void;
+        setGlobalProperty(params?: {[index:string]: any}):void;
     }
 
     interface User


### PR DESCRIPTION
As noted in the docs on the setGlobalProperty function - https://api.calq.io/lib/js/core-1.0.js (search for setGlobalProperty) - it's possible to pass either a key and a value, or a whole object of keys and values. This PR lets you do both.
