### PR TITLE
More appropriate interface name for OpenStreetMap's models

### DIFF
--- a/osmtogeojson/osmtogeojson-tests.ts
+++ b/osmtogeojson/osmtogeojson-tests.ts
@@ -33,7 +33,7 @@ osmtogeojson(xml, {
   uninterestingTags: {foo:true}
 });
 
-let json: OsmJSON.Root = {
+let json: OsmJSON.OsmJSONObject = {
   elements: [
     {
       type: "node",

--- a/osmtogeojson/osmtogeojson.d.ts
+++ b/osmtogeojson/osmtogeojson.d.ts
@@ -5,8 +5,8 @@
 
 declare module "osmtogeojson" {
   export interface OsmToGeoJSON {
-    (data: Document|OsmJSON.Root, options?: Options): GeoJSON.GeoJSONObject;
-    toGeojson(data: Document|OsmJSON.Root, options?: Options): GeoJSON.GeoJSONObject;
+    (data: Document|OsmJSON.OsmJSONObject, options?: Options): GeoJSON.GeoJSONObject;
+    toGeojson(data: Document|OsmJSON.OsmJSONObject, options?: Options): GeoJSON.GeoJSONObject;
   }
 
   export interface Options {
@@ -54,11 +54,11 @@ declare module "osmtogeojson" {
   }
 
   export namespace OsmJSON {
-    export interface Root {
+    export interface OsmJSONObject {
       elements: (Node|Way|Relationship)[];
     }
 
-    export interface OsmJSONObject {
+    export interface Element {
       type: string;
       id: number;
       tags?: { [name: string]: string; }
@@ -69,16 +69,16 @@ declare module "osmtogeojson" {
       uid?: number;
     }
 
-    export interface Node extends OsmJSONObject {
+    export interface Node extends Element {
       lat: number;
       lon: number;
     }
 
-    export interface Way extends OsmJSONObject {
+    export interface Way extends Element {
       nodes: number[];
     }
 
-    export interface Relationship extends OsmJSONObject {
+    export interface Relationship extends Element {
       members: Member[];
     }
 


### PR DESCRIPTION
Sorry this is a minor fix, but the I want to change interface name to reflect wiki's description.

c.f. http://wiki.openstreetmap.org/wiki/Elements
