### PR TITLE
Missing static function of Error class

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -11,6 +11,7 @@
 
 interface Error {
     stack?: string;
+    static captureStackTrace(obj:Error, constructor?:function):void;
 }
 
 


### PR DESCRIPTION
According to https://nodejs.org/api/errors.html#errors_error_capturestacktrace_targetobject_constructoropt
Error class has a captureStackTrace function to make custom Errors.
