### PR TITLE
Fix types of addRewriters (winston 1.x)

### DIFF
--- a/winston/winston-tests.ts
+++ b/winston/winston-tests.ts
@@ -140,7 +140,7 @@ logger.handleExceptions(transport);
 logger.unhandleExceptions(transport);
 logger = logger.add(transport, transportOptions, bool);
 logger = logger.add(transport);
-logger.addRewriter(transport)[0];
+
 logger.clear();
 logger = logger.remove(transport);
 profiler = logger.startTimer();
@@ -155,7 +155,12 @@ logger = profiler.done(str);
 logger = profiler.logger;
 profiler.start = new Date();
 
+let testRewriter : winston.MetadataRewriter;
+testRewriter = function(level: string, msg: string, meta: any) {
+    return meta;
+}
 
+winston.addRewriter(testRewriter);
 /**
  * New Logger instances with transports tests:
  */

--- a/winston/winston.d.ts
+++ b/winston/winston.d.ts
@@ -46,7 +46,11 @@ declare module "winston" {
   export function addColors(target: any): any;
   export function setLevels(target: any): any;
   export function cli(): LoggerInstance;
-
+  export function addRewriter(rewriter: MetadataRewriter): void;
+  
+  export interface MetadataRewriter {
+      (level: string, msg: string, meta: any): any;
+  }
 
   export interface LoggerStatic {
     new (options?: LoggerOptions): LoggerInstance;
@@ -77,7 +81,7 @@ declare module "winston" {
     handleExceptions(...transports: TransportInstance[]): void;
     unhandleExceptions(...transports: TransportInstance[]): void;
     add(transport: TransportInstance, options?: TransportOptions, created?: boolean): LoggerInstance;
-    addRewriter(rewriter: TransportInstance): TransportInstance[];
+    addRewriter(rewriter: MetadataRewriter): void;
     clear(): void;
     remove(transport: TransportInstance): LoggerInstance;
     startTimer(): ProfileHandler;
@@ -140,7 +144,7 @@ declare module "winston" {
   }
 
   export interface WinstonModuleTrasportInstance extends TransportInstance {
-    new (options?: WinstonMoudleTransportOptions): WinstonModuleTrasportInstance;
+    new (options?: WinstonModuleTransportOptions): WinstonModuleTrasportInstance;
   }
 
   export interface ContainerStatic {
@@ -275,7 +279,7 @@ declare module "winston" {
     };
   }
 
-  export interface WinstonMoudleTransportOptions extends TransportOptions {
+  export interface WinstonModuleTransportOptions extends TransportOptions {
     [optionName: string]: any;
   }
 


### PR DESCRIPTION
The docs in winston were outright wrong (a bad copy/paste job) which caused wrong types to be declared here

PR for winston: https://github.com/winstonjs/winston/pull/784
