### PR TITLE
Add additional off method that can accept a handler with extra arguments

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -2275,6 +2275,13 @@ interface JQuery {
      * Remove an event handler.
      *
      * @param events One or more space-separated event types and optional namespaces, or just namespaces, such as "click", "keydown.myPlugin", or ".myPlugin".
+     * @param handler A handler function previously attached for the event(s), or the special value false. Takes handler with extra args that can be attached with on().
+     */
+    off(events: string, handler: (eventObject: JQueryEventObject, ...args: any[]) => any): JQuery;
+    /**
+     * Remove an event handler.
+     *
+     * @param events One or more space-separated event types and optional namespaces, or just namespaces, such as "click", "keydown.myPlugin", or ".myPlugin".
      * @param handler A handler function previously attached for the event(s), or the special value false.
      */
     off(events: string, handler: (eventObject: JQueryEventObject) => any): JQuery;


### PR DESCRIPTION
While this is not part of jQuery API for off() it is possible to attach such a handler using on(). See http://api.jquery.com/on/ and http://api.jquery.com/off/.

May not be the best idea, but being able to attach a handler via on that you cannot remove via off is weird.
