### PR TITLE
Fix gulp-* imports and namespaces

### DIFF
--- a/gulp-autoprefixer/gulp-autoprefixer.d.ts
+++ b/gulp-autoprefixer/gulp-autoprefixer.d.ts
@@ -6,15 +6,15 @@
 /// <reference path="../node/node.d.ts"/>
 
 declare module "gulp-autoprefixer" {
-    interface Options {
-        browsers?: string[];
-        cascade?: boolean;
-        remove?: boolean;
+    namespace autoPrefixer {
+        interface Options {
+            browsers?: string[];
+            cascade?: boolean;
+            remove?: boolean;
+        }
     }
 
-    function autoPrefixer(opts?: Options): NodeJS.ReadWriteStream;
-
-    namespace autoPrefixer {}
+    function autoPrefixer(opts?: autoPrefixer.Options): NodeJS.ReadWriteStream;
 
     export = autoPrefixer;
 }

--- a/gulp-rev-replace/gulp-rev-replace-tests.ts
+++ b/gulp-rev-replace/gulp-rev-replace-tests.ts
@@ -3,10 +3,10 @@
 /// <reference path="../gulp-rev/gulp-rev.d.ts" />
 /// <reference path="../gulp-useref/gulp-useref.d.ts" />
 
-import gulp = require('gulp');
-import revReplace = require('gulp-rev-replace');
-import rev = require('gulp-rev');
-import useref = require('gulp-useref');
+import * as gulp from 'gulp';
+import * as revReplace from 'gulp-rev-replace';
+import * as rev from 'gulp-rev';
+import * as useref from 'gulp-useref';
 
 gulp.task("index", () => {
     return gulp.src("src/index.html")

--- a/gulp-rev-replace/gulp-rev-replace.d.ts
+++ b/gulp-rev-replace/gulp-rev-replace.d.ts
@@ -6,16 +6,18 @@
 /// <reference path="../node/node.d.ts" />
 
 declare module 'gulp-rev-replace' {
-    interface IOptions {
-        canonicalUris?: boolean;
-        replaceInExtensions?: Array<string>;
-        prefix?: string;
-        manifest?: NodeJS.ReadWriteStream;
-        modifyUnreved?: Function;
-        modifyReved?: Function;
+  namespace revReplace {
+    interface Options {
+      canonicalUris?: boolean;
+      replaceInExtensions?: Array<string>;
+      prefix?: string;
+      manifest?: NodeJS.ReadWriteStream;
+      modifyUnreved?: Function;
+      modifyReved?: Function;
     }
+  }
 
-    function revReplace(options?: IOptions): NodeJS.ReadWriteStream;
+  function revReplace(options?: revReplace.Options): NodeJS.ReadWriteStream;
 
-    export = revReplace;
+  export = revReplace;
 }

--- a/gulp-size/gulp-size.d.ts
+++ b/gulp-size/gulp-size.d.ts
@@ -6,20 +6,20 @@
 /// <reference path="../node/node.d.ts" />
 
 declare module 'gulp-size' {
-    interface IOptions {
-        showFiles?: boolean;
-        gzip?: boolean;
-        title?: string;
+    namespace size {
+        interface Options {
+            showFiles?: boolean;
+            gzip?: boolean;
+            title?: string;
+        }
+
+        interface SizeStream extends NodeJS.ReadWriteStream {
+            size: number;
+            prettySize: string;
+        }
     }
 
-    interface ISizeStream extends NodeJS.ReadWriteStream {
-      size: number;
-      prettySize: string;
-    }
-
-    function size(options?: IOptions): ISizeStream;
-
-    namespace size {}
+    function size(options?: size.Options): size.SizeStream;
 
     export = size;
 }


### PR DESCRIPTION
- Move things inside the namespace so they can be reused from outside
- Fix import \* as
