### PR TITLE
Update express router type, to work around typescript issue #1805

### DIFF
--- a/express/express-tests.ts
+++ b/express/express-tests.ts
@@ -21,7 +21,25 @@ app.get('/', function(req, res){
     res.send('hello world');
 });
 
-var router = express.Router();
+const router = express.Router();
+
+
+const pathStr : string = 'test';
+const pathRE : RegExp = /test/;
+const path = true? pathStr : pathRE;
+
+router.get(path);
+router.put(path)
+router.post(path);
+router.delete(path);
+router.get(pathStr);
+router.put(pathStr)
+router.post(pathStr);
+router.delete(pathStr);
+router.get(pathRE);
+router.put(pathRE)
+router.post(pathRE);
+router.delete(pathRE);
 
 router.use((req, res, next) => { next(); })
 router.route('/users')

--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -44,8 +44,7 @@ declare module "express" {
         }
 
         interface IRouterMatcher<T> {
-            (name: string, ...handlers: RequestHandler[]): T;
-            (name: RegExp, ...handlers: RequestHandler[]): T;
+            (name: string|RegExp, ...handlers: RequestHandler[]): T;
         }
 
         interface IRouter<T> extends RequestHandler {
@@ -881,8 +880,7 @@ declare module "express" {
             set(setting: string, val: any): Application;
             get: {
                 (name: string): any; // Getter
-                (name: string, ...handlers: RequestHandler[]): Application;
-                (name: RegExp, ...handlers: RequestHandler[]): Application;
+                (name: string|RegExp, ...handlers: RequestHandler[]): Application;
             };
 
             /**


### PR DESCRIPTION
https://github.com/Microsoft/TypeScript/issues/1805

Prevents the safe unification of these two overloads, so we need to update it manually.
