### PR TITLE
Adding catch method onto ES6-promise Thenable

### DIFF
--- a/es6-promise/es6-promise-tests.ts
+++ b/es6-promise/es6-promise-tests.ts
@@ -68,6 +68,9 @@ promiseNumber = thenWithUndefinedFullFillAndPromiseReject;
 var thenWithNoResultAndNoReject = promiseString.then<number>();
 promiseNumber = thenWithNoResultAndNoReject;
 
+var catchAfterThen = promiseString.then().catch<number>();
+promiseNumber = catchAfterThen;
+
 var voidPromise = new Promise<void>(function (resolve) { resolve(); });
 
 //catch test

--- a/es6-promise/es6-promise.d.ts
+++ b/es6-promise/es6-promise.d.ts
@@ -6,6 +6,7 @@
 interface Thenable<R> {
     then<U>(onFulfilled?: (value: R) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
     then<U>(onFulfilled?: (value: R) => U | Thenable<U>, onRejected?: (error: any) => void): Thenable<U>;
+    catch<U>(onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
 }
 
 declare class Promise<R> implements Thenable<R> {

--- a/promises-a-plus/promises-a-plus-tests.ts
+++ b/promises-a-plus/promises-a-plus-tests.ts
@@ -4,9 +4,9 @@
 /// <reference path="../q/Q.d.ts"/>
 /// <reference path="../when/when"/>
 
-var thenNum: PromisesAPlus.Thenable<number>; 
-var thenStr: PromisesAPlus.Thenable<string>; 
-var thenBool: PromisesAPlus.Thenable<boolean>; 
+var thenNum: PromisesAPlus.Thenable<number>;
+var thenStr: PromisesAPlus.Thenable<string>;
+var thenBool: PromisesAPlus.Thenable<boolean>;
 
 var impl: PromisesAPlus.PromiseImpl;
 
@@ -45,9 +45,9 @@ function testCompatibleWithRxJS() {
 }
 
 function testCompatibleWithES6Promises() {
-	// from spec to ES6
-	var es6ThenNum: Thenable<number> = thenNum;
-	var es6ThenStr: Thenable<string> = thenStr;
+	// define ES6 thenables
+	var es6ThenNum: Thenable<number>;
+	var es6ThenStr: Thenable<string>;
 
 	// from ES6 to spec
 	thenNum = es6ThenNum;


### PR DESCRIPTION
This fixes #4400

ES6 Promises have `catch` on the prototype. Since `Thenable` is just for interface purposes, and `Thenables` are actually instances of the `Promise` class, they have a `catch` method.
