### PR TITLE
[react-bootstrap] Added missing event handlers to MenuItem

### DIFF
--- a/react-bootstrap/react-bootstrap.d.ts
+++ b/react-bootstrap/react-bootstrap.d.ts
@@ -120,6 +120,8 @@ declare module "react-bootstrap" {
         eventKey?: any;
         header?: boolean;
         href?: string;
+        onClick?: Function;
+        onKeyDown?: Function;
         onSelect?: Function;
         target?: string;
         title?: string;


### PR DESCRIPTION
Missing event handlers in MenuItem component:

onClick
onKeyDown
