### PR TITLE
added missing properties to Instruction interface in angular-componenent-router

### DIFF
--- a/angularjs/angular-component-router.d.ts
+++ b/angularjs/angular-component-router.d.ts
@@ -38,7 +38,7 @@ declare module angular {
     interface Instruction {
         component: ComponentInstruction;
         child: Instruction;
-        auxInstruction: {[key: string]: Instruction} = {};
+        auxInstruction: {[key: string]: Instruction};
 
         urlPath(): string;
 

--- a/angularjs/angular-component-router.d.ts
+++ b/angularjs/angular-component-router.d.ts
@@ -36,6 +36,9 @@ declare module angular {
      * ```
      */
     interface Instruction {
+        component: ComponentInstruction;
+        child: Instruction;
+        auxInstruction: {[key: string]: Instruction} = {};
 
         urlPath(): string;
 


### PR DESCRIPTION
I forgot to add these properties in my initial pull request. The corresponding code can be found [here](https://github.com/angular/angular/blob/master/modules/angular2/src/router/instruction.ts#L110-L112). Unfortunately there is no documentation for them yet :/
