### PR TITLE
base-x and bs58: definitions and tests added

### DIFF
--- a/base-x/base-x-tests.ts
+++ b/base-x/base-x-tests.ts
@@ -1,0 +1,14 @@
+/// <reference path="./base-x.d.ts" />
+
+import * as basex from 'base-x';
+
+let bs16: BaseX.BaseConverter = basex('0123456789ABCDEF');
+
+{
+	let encoded: string;
+
+	encoded = bs16.encode([255]);
+	encoded = bs16.encode({0: 255, length: 1});
+}
+
+let decoded: number[] = bs16.decode('FF');

--- a/base-x/base-x.d.ts
+++ b/base-x/base-x.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for base-x v1.0.1
+// Project: https://github.com/cryptocoinjs/base-x
+// Definitions by: Ilya Mochalov <https://github.com/chrootsu>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare namespace BaseX {
+	interface EncodeBuffer {
+		[index: number]: number;
+		length: number;
+	}
+
+	interface BaseConverter {
+		encode: (buffer: EncodeBuffer) => string;
+		decode: (string: string) => number[];
+	}
+
+	interface Base {
+		(ALPHABET: string): BaseX.BaseConverter
+	}
+}
+
+declare module "base-x" {
+	namespace base {}
+
+	let base: BaseX.Base;
+
+	export = base;
+}

--- a/bs58/bs58-tests.ts
+++ b/bs58/bs58-tests.ts
@@ -1,0 +1,12 @@
+/// <reference path="./bs58.d.ts" />
+
+import * as bs58 from 'bs58';
+
+{
+	let encoded: string;
+
+	encoded = bs58.encode([255]);
+	encoded = bs58.encode({0: 255, length: 1});
+}
+
+let decoded: number[] = bs58.decode('5Q');

--- a/bs58/bs58.d.ts
+++ b/bs58/bs58.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for bs58 3.0.0
+// Project: https://github.com/cryptocoinjs/bs58
+// Definitions by: Ilya Mochalov <https://github.com/chrootsu>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../base-x/base-x.d.ts" />
+
+declare module "bs58" {
+	namespace base58 {}
+
+	let base58: BaseX.BaseConverter;
+
+	export = base58;
+}


### PR DESCRIPTION
`bs58` is a wrapper for `base-x`

https://www.npmjs.com/package/base-x
https://github.com/cryptocoinjs/base-x/tree/v1.0.1

https://www.npmjs.com/package/bs58
https://github.com/cryptocoinjs/bs58/tree/3.0.0
