### PR TITLE
Adds an updated copy of redux bindings for 3.0.5, including generic stores

### DIFF
--- a/redux/redux-3.0.5.d.ts
+++ b/redux/redux-3.0.5.d.ts
@@ -1,0 +1,86 @@
+// Type definitions for Redux v3.0.5
+// Project: https://github.com/rackt/redux
+// Definitions by: William Buchwalter <https://github.com/wbuchwalter/>, Vincent Prouillet <https://github.com/Keats/>, Michael Bennett <https://github.com/bennett000/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare let Redux: Redux.ReduxStatic;
+
+declare module 'redux' {
+  export = Redux;
+}
+
+declare module Redux {
+
+  interface IAction {}
+
+  interface Action extends IAction{
+    type: string;
+    payload?: any;
+    error?: boolean;
+    meta?: any;
+  }
+
+  interface ActionAsync extends IAction {
+    (...args: any[]):any;
+  }
+
+  interface Map<T> {
+    [id: string]: T;
+  }
+
+  interface ActionCreator {
+    (...args: any[]): IAction;
+  }
+
+  interface Listener {
+    (): void;
+  }
+
+  interface Unsubscribe {
+    (): void;
+  }
+
+  interface Reducer<T> {
+    (state: T, action: Action): T;
+  }
+
+  interface Dispatch {
+    (action: IAction): IAction;
+  }
+
+  interface PartialDispatch {
+    (): IAction;
+  }
+
+  interface MiddlewareArg<T> {
+    dispatch: Dispatch;
+    getState: T;
+  }
+
+  interface Middleware<T> {
+    (obj: MiddlewareArg<T>): Function;
+  }
+
+  interface Store<T> {
+    replaceReducer(nextReducer: Reducer<T>): void;
+    dispatch(action: IAction): IAction;
+    getState(): T;
+    subscribe(listener: Listener): Unsubscribe;
+  }
+
+  interface CreateStore<T> {
+    (reducer: Reducer<T>, initialState?: T): Store<T>;
+  }
+
+  interface ReduxStatic {
+    createStore<T>(reducer: Reducer<T>, initialState?: T): Store<T>;
+    bindActionCreators<T extends Map<ActionCreator>,
+      TP extends Map<PartialDispatch>>(actionCreators: T,
+                                       dispatch: Dispatch): TP;
+    bindActionCreators(actionCreator: ActionCreator,
+                          dispatch: Dispatch): ActionCreator;
+    combineReducers<T>(reducers: Map<Reducer<any>>): Reducer<T>;
+    applyMiddleware<T>(...middlewares: Middleware<T>[]): CreateStore<T>;
+    compose<T extends Function>(...functions: Function[]): T;
+  }
+}

--- a/redux/redux-tests-3.0.5.ts
+++ b/redux/redux-tests-3.0.5.ts
@@ -1,0 +1,89 @@
+/// <reference path="./redux-3.0.5.d.ts" />
+
+// some hypothetical root state container
+class RootState {
+  leafReducerA: number[];
+  leafReducerB: string[];
+}
+
+// some hypothetical leaf reducer / "leaf store init"
+const leafReducerA = (state:number[] = [], action:Redux.Action) => {
+  return state;
+};
+
+// some other hypothetical leaf reducer / "leaf store init"
+const leafReducerB = (state:string[] = [], action:Redux.Action) => {
+  return state;
+};
+
+// to be used as a replacement reducer
+const someReplacementReducer = (state:RootState = {
+  leafReducerA: [1],
+  leafReducerB: ['hello']
+}, action: Redux.Action) => {
+  return state;
+};
+
+// combine the reducers into the root reducer
+const rootReducer = Redux.combineReducers<RootState>({
+  leafReducerA,
+  leafReducerB
+});
+
+// configure a store
+interface ComposedCreateStore extends Redux.CreateStore<RootState> {}
+
+// This bit is quite awkward still, it _should_ ideally mock applying a
+// thunk, or other middleware, but it needs work
+const finalCreateStore = <ComposedCreateStore>Redux
+  .compose(Redux.applyMiddleware<any>(() => () => 0))(Redux.createStore);
+
+// finally create the store
+const store = finalCreateStore(rootReducer);
+
+store.dispatch({
+  type: 'TEST'
+});
+
+// subscribe
+store.subscribe(() => {
+  // get state
+  let someNumbers:number[] = store.getState().leafReducerA;
+  let someStrings:string[] = store.getState().leafReducerB;
+});
+
+// replace the reducer function
+store.replaceReducer(someReplacementReducer);
+
+// bind action creators to dispatcher, function example
+const blah = Redux.bindActionCreators(() => {
+  return { type: 'TEST', payload: 'blah' };
+}, store.dispatch);
+
+blah();
+
+interface ActionCreators {
+  [key: string]: any;
+  testFun: Redux.ActionCreator;
+  testBye: Redux.ActionCreator;
+}
+
+interface PartialActionCreators {
+  [key: string]: any;
+  testFun: Redux.PartialDispatch;
+  testBye: Redux.PartialDispatch;
+}
+
+// bind action creators to dispatch, map example
+const actions = Redux.bindActionCreators<ActionCreators,
+  PartialActionCreators>({
+  testFun: () => { return { type: 'TEST', payload: 'fun' }},
+  testBye: () => { return { type: 'TEST', payload: 'bye' }}
+}, store.dispatch);
+
+actions.testFun();
+actions.testBye();
+
+// async action creators
+const asyncAction: Redux.ActionAsync =
+  (dispatch: Redux.Dispatch, getState) => {};


### PR DESCRIPTION
Hey, I hope this PR is on point with respect to your contribution guide.  There are a few things I'm not quite sure about that I might have messed up though:

DT docs say: 

> In case there are multiple versions supported, the latest one will be without a version number in the file  name. Older versions will be in the form of library-1.2.0.d.ts where the postfix should resemble a valid semantic version number (semver).

But if I do that, it breaks a few other dependent libraries that refer to this `d.ts`.

I am going to be doing a bunch of redux work though, and it's likely I will want to upgrade the other (dependent) redux typings, but DT docs also say:

> It is recommended to split your contributions for different JS packages into their own git branches so you can have multiple pending PR's.

Also I have not yet assessed the work involved in updating the other typings to use generics, and (hopefully) conform to the "Ghost Module" style.
