### PR TITLE
Update electron-packager.d.ts

### DIFF
--- a/electron-packager/electron-packager.d.ts
+++ b/electron-packager/electron-packager.d.ts
@@ -81,12 +81,12 @@ declare namespace ElectronPackager {
     /** Electron-packager done callback. */
     export interface Callback {
         /**
-         * Callback wich is called when electron-packager is done.
+         * Callback which is called when electron-packager is done.
          *
          * @param err - Contains errors if any.
-         * @param appPath - Path to the newly created application.
+         * @param appPath - Path(s) to the newly created application(s).
          */
-        (err: Error, appPath: string): void
+        (err: Error, appPath: string|string[]): void
     }
 
     /** Electron-packager function */


### PR DESCRIPTION
The `electron-packager` passes a list of strings rather than just a string to its callback if multiple platforms or archs where requested.
