### PR TITLE
Inline annotated function support added to service method on IProvideService

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1876,6 +1876,7 @@ declare module angular {
             provider(name: string, provider: IServiceProvider): IServiceProvider;
             provider(name: string, serviceProviderConstructor: Function): IServiceProvider;
             service(name: string, constructor: Function): IServiceProvider;
+            service(name: string, inlineAnnotatedFunction: any[]): IServiceProvider;
             value(name: string, value: any): IServiceProvider;
         }
 


### PR DESCRIPTION
Angularjs does support inline annotated function declarations for services but this was missing from the type definition.
