### PR TITLE
Change the input type of defineMessages to T

### DIFF
--- a/react-intl/react-intl.d.ts
+++ b/react-intl/react-intl.d.ts
@@ -24,7 +24,7 @@ declare module ReactIntl {
         [key: string]: FormattedMessage.MessageDescriptor
     }
 
-    function defineMessages<T extends Messages>(messages: Messages): T;
+    function defineMessages<T extends Messages>(messages: T): T;
 
     interface IntlShape extends React.Requireable<any> {
     }


### PR DESCRIPTION
This allows for full intellisense on the return value, so `messages.foo` will work.
