### PR TITLE
Make companyName and submitURL option required on crashReporter.start

### DIFF
--- a/github-electron/github-electron-main-tests.ts
+++ b/github-electron/github-electron-main-tests.ts
@@ -26,9 +26,6 @@ import path = require('path');
 // Quick start
 // https://github.com/atom/electron/blob/master/docs/tutorial/quick-start.md
 
-// Report crashes to our server.
-require('crash-reporter').start();
-
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the javascript object is GCed.
 var mainWindow: GitHubElectron.BrowserWindow = null;

--- a/github-electron/github-electron-main-tests.ts
+++ b/github-electron/github-electron-main-tests.ts
@@ -497,7 +497,10 @@ crashReporter.start({
 	productName: 'YourName',
 	companyName: 'YourCompany',
 	submitURL: 'https://your-domain.com/url-to-submit',
-	autoSubmit: true
+	autoSubmit: true,
+	extra: {
+		someKey: "value"
+	}
 });
 
 // nativeImage

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -1353,7 +1353,7 @@ declare module GitHubElectron {
 		* Only string properties are send correctly.
 		* Nested objects are not supported.
 		*/
-		extra?: any;
+		extra?: {[prop: string]: string};
 	}
 
 	interface CrashReporterPayload extends Object {

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -1193,7 +1193,7 @@ declare module GitHubElectron {
 			/**
 			 * File types that can be displayed, see dialog.showOpenDialog for an example.
 			 */
-			 
+
 			filters?: {
 				name: string;
 				extensions: string[];
@@ -1334,15 +1334,11 @@ declare module GitHubElectron {
 		* Default: Electron
 		*/
 		productName?: string;
-		/**
-		* Default: GitHub, Inc.
-		*/
-		companyName?: string;
+		companyName: string;
 		/**
 		* URL that crash reports would be sent to as POST.
-		* Default: http://54.249.141.255:1127/post
 		*/
-		submitURL?: string;
+		submitURL: string;
 		/**
 		* Send the crash report without user interaction.
 		* Default: true.
@@ -1357,7 +1353,7 @@ declare module GitHubElectron {
 		* Only string properties are send correctly.
 		* Nested objects are not supported.
 		*/
-		extra?: {};
+		extra?: any;
 	}
 
 	interface CrashReporterPayload extends Object {
@@ -1401,7 +1397,7 @@ declare module GitHubElectron {
 	}
 
 	interface CrashReporter {
-		start(options?: CrashReporterStartOptions): void;
+		start(options: CrashReporterStartOptions): void;
 
 		/**
 		 * @returns The date and ID of the last crash report. When there was no crash report


### PR DESCRIPTION
https://github.com/atom/electron/blob/v0.36.4/docs/api/crash-reporter.md#crashreporterstartoptions
Now companyName and submitURL properties are required in crashReporter.start parameter.
