### PR TITLE
removed the misleading KeyBinding constructor in Ace.js

### DIFF
--- a/ace/ace.d.ts
+++ b/ace/ace.d.ts
@@ -77,9 +77,6 @@ declare module AceAjax {
 
         onTextInput(text: any): void;
     }
-    var KeyBinding: {
-        new(editor: Editor): KeyBinding;
-    }
 
     export interface TextMode {
 


### PR DESCRIPTION
When Ace initializes, it exposes one global variable, `ace`. 

But the declaration file says that it exposes two, `ace` and `AceAjax`. 
That is as such fine, because the `AceAJax` module mostly contains interfaces, and `AceAjax` creates a nice namespace. 

But inside the `AceAjax` there is a `var KeyBinding`, which means that the following code compiles without warnings: 

```
/// <reference path="ace.d.ts"/>
var constructor : { new(editor: AceAjax.Editor): AceAjax.KeyBinding; } = AceAjax.KeyBinding;
var binding : AceAjax.KeyBinding = new constructor(null);
```

Even though AceAjax is undefined. 

What I'm trying to say is that the constructor being there is misleading, and I think it should be removed. 
