### PR TITLE
Update to fix S3 with latest AWS SDK

### DIFF
--- a/aws-sdk/aws-sdk.d.ts
+++ b/aws-sdk/aws-sdk.d.ts
@@ -147,7 +147,8 @@ declare module "aws-sdk" {
 
 	export class S3 {
 		constructor(options?: any);
-		public client: s3.Client;
+		putObject(params: s3.PutObjectRequest, callback: (err: any, data: any) => void): void;
+		getObject(params: s3.GetObjectRequest, callback: (err: any, data: any) => void): void;
 	}
 
 	export class DynamoDB {
@@ -1042,14 +1043,7 @@ declare module "aws-sdk" {
 	}
 
 	export module s3 {
-
-		export interface Client {
-			config: ClientConfig;
-
-			putObject(params: PutObjectRequest, callback: (err: any, data: any) => void): void;
-			getObject(params: GetObjectRequest, callback: (err: any, data: any) => void): void;
-		}
-
+		
 		export interface PutObjectRequest {
 			ACL?: string;
 			Body?: any;


### PR DESCRIPTION
I removed the nested S3 Client interface, because it doesn't seem to be present in the latest AWS JS SDK (2.2.31).
