### PR TITLE
Added AMD Module for well-known name "amplify"

### DIFF
--- a/amplifyjs/amplifyjs.d.ts
+++ b/amplifyjs/amplifyjs.d.ts
@@ -179,4 +179,4 @@ interface amplifyStatic {
 }
 
 declare var amplify: amplifyStatic;
-
+declare module "amplify" { export =amplify; }


### PR DESCRIPTION
Hi - I've added a missing module definition to the amplify JS typing to allow it to be more easily used from AMD-based systems like requires.  Hope this is OK!
