### PR TITLE
Added experimentalDecorators option. Needed for Angular 2.

### DIFF
--- a/gulp-typescript/gulp-typescript.d.ts
+++ b/gulp-typescript/gulp-typescript.d.ts
@@ -30,6 +30,7 @@ declare module "gulp-typescript" {
             jsx?: string;
             declaration?: boolean;
             emitDecoratorMetadata?: boolean;
+            experimentalDecorators?: boolean;
             experimentalAsyncFunctions?: boolean;
             moduleResolution?: string;
             noEmitHelpers?: boolean;


### PR DESCRIPTION
According to the gulp-typescript documentation on npm, this option is fully supported.
