### PR TITLE
Add declaration for THREE.Euler.DefaultOrder

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -2971,6 +2971,8 @@ declare module THREE {
     }
 
     export class Euler {
+        static DefaultOrder: string;
+
         constructor(x?: number, y?: number, z?: number, order?: string);
 
         x: number;


### PR DESCRIPTION
THREE.js's Euler.DefaultOrder can be changed so it's good to have it exposed. See https://github.com/mrdoob/three.js/blob/1f968fe32c49e81a471ce1acc73c002778aee795/src/math/Euler.js#L18
