### PR TITLE
Allow polymer properties to be objects

### DIFF
--- a/polymer/polymer-tests.ts
+++ b/polymer/polymer-tests.ts
@@ -12,7 +12,11 @@ Polymer({
       reflectToAttribute: true,
       notify: true,
       computed: "__prop2()"
-    }
+    },
+    prop3: {
+        type: Object,
+        value: { "foo": "bar" },
+    },
   },
 
   hostAttributes: {

--- a/polymer/polymer.d.ts
+++ b/polymer/polymer.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for polymer v1.1.5
+// Type definitions for polymer v1.1.6
 // Project: https://github.com/Polymer/polymer
 // Definitions by: Louis Grignon <https://github.com/lgrignon>, Suguru Inatomi <https://github.com/laco0416>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -11,7 +11,7 @@ declare module polymer {
 
   interface PropObjectType {
     type: PropConstructorType;
-    value?: boolean | number | string | Function;
+    value?: boolean | number | string | Function | Object;
     reflectToAttribute?: boolean;
     readOnly?: boolean;
     notify?: boolean;


### PR DESCRIPTION
Previously the type for properties was too restrictive. Polymer properties can be objects too. This pull request updates the `polymer.PropObjectType` type to allow `value` field to be Object. It also updates the test to account for this case.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/definitelytyped/definitelytyped/7742)

<!-- Reviewable:end -->
