### PR TITLE
Make the type of koa's ctx accessible

### DIFF
--- a/koa/koa.d.ts
+++ b/koa/koa.d.ts
@@ -8,6 +8,10 @@
     import * as Koa from "koa"
     const app = new Koa()
 
+    async function (ctx: Koa.IContext, next: Function) {
+      // ...
+    }
+
  =============================================== */
 /// <reference path="../node/node.d.ts" />
 
@@ -16,99 +20,101 @@ declare module "koa" {
   import * as http from "http";
   import * as net from "net";
 
-  interface IContext extends IRequest, IResponse {
-      body?: any;
-      request?: IRequest;
-      response?: IResponse;
-      originalUrl?: string;
-      state?: any;
-      name?: string;
-      cookies?: any;
-      writable?: Boolean;
-      respond?: Boolean;
-      app?: Koa;
-      req?: http.IncomingMessage;
-      res?: http.ServerResponse;
-      onerror(err: any): void;
-      toJSON(): any;
-      inspect(): any;
-      throw(): void;
-      assert(): void;
-  }
+  module Koa {
+    export interface IContext extends IRequest, IResponse {
+        body?: any;
+        request?: IRequest;
+        response?: IResponse;
+        originalUrl?: string;
+        state?: any;
+        name?: string;
+        cookies?: any;
+        writable?: Boolean;
+        respond?: Boolean;
+        app?: Koa;
+        req?: http.IncomingMessage;
+        res?: http.ServerResponse;
+        onerror(err: any): void;
+        toJSON(): any;
+        inspect(): any;
+        throw(code?: any, message?: any): void;
+        assert(): void;
+    }
 
-  interface IRequest {
-      _querycache?: string;
-      app?: Koa;
-      req?: http.IncomingMessage;
-      res?: http.ServerResponse;
-      response?: IResponse;
-      ctx?: IContext;
-      headers?: any;
-      header?: any;
-      method?: string;
-      length?: any;
-      url?: string;
-      origin?: string;
-      originalUrl?: string;
-      href?: string;
-      path?: string;
-      querystring?: string;
-      query?: any;
-      search?: string;
-      idempotent?: Boolean;
-      socket?: net.Socket;
-      protocol?: string;
-      host?: string;
-      hostname?: string;
-      fresh?: Boolean;
-      stale?: Boolean;
-      charset?: string;
-      secure?: Boolean;
-      ips?: Array<string>;
-      ip?: string;
-      subdomains?: Array<string>;
-      accept?: any;
-      type?: string;
-      accepts?: () => any;
-      acceptsEncodings?: () => any;
-      acceptsCharsets?: () => any;
-      acceptsLanguages?: () => any;
-      is?: (types: any) => any;
-      toJSON?: () => any;
-      inspect?: () => any;
-      get?: (field: string) => string;
-  }
+    export interface IRequest {
+        _querycache?: string;
+        app?: Koa;
+        req?: http.IncomingMessage;
+        res?: http.ServerResponse;
+        response?: IResponse;
+        ctx?: IContext;
+        headers?: any;
+        header?: any;
+        method?: string;
+        length?: any;
+        url?: string;
+        origin?: string;
+        originalUrl?: string;
+        href?: string;
+        path?: string;
+        querystring?: string;
+        query?: any;
+        search?: string;
+        idempotent?: Boolean;
+        socket?: net.Socket;
+        protocol?: string;
+        host?: string;
+        hostname?: string;
+        fresh?: Boolean;
+        stale?: Boolean;
+        charset?: string;
+        secure?: Boolean;
+        ips?: Array<string>;
+        ip?: string;
+        subdomains?: Array<string>;
+        accept?: any;
+        type?: string;
+        accepts?: () => any;
+        acceptsEncodings?: () => any;
+        acceptsCharsets?: () => any;
+        acceptsLanguages?: () => any;
+        is?: (types: any) => any;
+        toJSON?: () => any;
+        inspect?: () => any;
+        get?: (field: string) => string;
+    }
 
-  interface IResponse {
-      _body?: any;
-      _explicitStatus?: Boolean;
-      app?: Koa;
-      res?: http.ServerResponse;
-      req?: http.IncomingMessage;
-      ctx?: IContext;
-      request?: IRequest;
-      socket?: net.Socket;
-      header?: any;
-      headers?: any;
-      status?: number;
-      message?: string;
-      type?: string;
-      body?: any;
-      length?: any;
-      headerSent?: Boolean;
-      lastModified?: Date;
-      etag?: string;
-      writable?: Boolean;
-      is?: (types: any) => any;
-      redirect?: (url: string, alt: string) => void;
-      attachment?: (filename?: string) => void;
-      vary?: (field: string) => void;
-      get?: (field: string) => string;
-      set?: (field: any, val: any) => void;
-      remove?: (field: string) => void;
-      append?: (field: string, val: any) => void;
-      toJSON?: () => any;
-      inspect?: () => any;
+    export interface IResponse {
+        _body?: any;
+        _explicitStatus?: Boolean;
+        app?: Koa;
+        res?: http.ServerResponse;
+        req?: http.IncomingMessage;
+        ctx?: IContext;
+        request?: IRequest;
+        socket?: net.Socket;
+        header?: any;
+        headers?: any;
+        status?: number;
+        message?: string;
+        type?: string;
+        body?: any;
+        length?: any;
+        headerSent?: Boolean;
+        lastModified?: Date;
+        etag?: string;
+        writable?: Boolean;
+        is?: (types: any) => any;
+        redirect?: (url: string, alt: string) => void;
+        attachment?: (filename?: string) => void;
+        vary?: (field: string) => void;
+        get?: (field: string) => string;
+        set?: (field: any, val: any) => void;
+        remove?: (field: string) => void;
+        append?: (field: string, val: any) => void;
+        toJSON?: () => any;
+        inspect?: () => any;
+    }
   }
 
   class Koa extends EventEmitter {
@@ -117,12 +123,12 @@ declare module "koa" {
       proxy: Boolean;
       server: http.Server;
       env: string;
-      context: IContext;
-      request: IRequest;
-      response: IResponse;
+      context: Koa.IContext;
+      request: Koa.IRequest;
+      response: Koa.IResponse;
       silent: Boolean;
       constructor();
-      use(middleware: (ctx: IContext, next: Function) => any): Koa;
+      use(middleware: (ctx: Koa.IContext, next: Function) => any): Koa;
       callback(): (req: http.IncomingMessage, res: http.ServerResponse) => void;
       listen(port: number, callback?: Function): http.Server;
       toJSON(): any;
@@ -131,6 +137,5 @@ declare module "koa" {
   }
 
   namespace Koa {}
-
   export = Koa;
 }

--- a/koa/koa.d.ts
+++ b/koa/koa.d.ts
@@ -8,7 +8,7 @@
     import * as Koa from "koa"
     const app = new Koa()
 
-    async function (ctx: Koa.IContext, next: Function) {
+    async function (ctx: Koa.Context, next: Function) {
       // ...
     }
 
@@ -21,10 +21,10 @@ declare module "koa" {
   import * as net from "net";
 
   module Koa {
-    export interface IContext extends IRequest, IResponse {
+    export interface Context extends Request, Response {
         body?: any;
-        request?: IRequest;
-        response?: IResponse;
+        request?: Request;
+        response?: Response;
         originalUrl?: string;
         state?: any;
         name?: string;
@@ -41,13 +41,13 @@ declare module "koa" {
         assert(): void;
     }
 
-    export interface IRequest {
+    export interface Request {
         _querycache?: string;
         app?: Koa;
         req?: http.IncomingMessage;
         res?: http.ServerResponse;
-        response?: IResponse;
-        ctx?: IContext;
+        response?: Response;
+        ctx?: Context;
         headers?: any;
         header?: any;
         method?: string;
@@ -84,14 +84,14 @@ declare module "koa" {
         get?: (field: string) => string;
     }
 
-    export interface IResponse {
+    export interface Response {
         _body?: any;
         _explicitStatus?: Boolean;
         app?: Koa;
         res?: http.ServerResponse;
         req?: http.IncomingMessage;
-        ctx?: IContext;
-        request?: IRequest;
+        ctx?: Context;
+        request?: Request;
         socket?: net.Socket;
         header?: any;
         headers?: any;
@@ -123,12 +123,12 @@ declare module "koa" {
       proxy: Boolean;
       server: http.Server;
       env: string;
-      context: Koa.IContext;
-      request: Koa.IRequest;
-      response: Koa.IResponse;
+      context: Koa.Context;
+      request: Koa.Request;
+      response: Koa.Response;
       silent: Boolean;
       constructor();
-      use(middleware: (ctx: Koa.IContext, next: Function) => any): Koa;
+      use(middleware: (ctx: Koa.Context, next: Function) => any): Koa;
       callback(): (req: http.IncomingMessage, res: http.ServerResponse) => void;
       listen(port: number, callback?: Function): http.Server;
       toJSON(): any;


### PR DESCRIPTION
When using some third party's `koa` middleware libraries, we need use the type of `koa`'s ctx directly. Then we could:

``` ts
import * as Koa from 'koa'

async function (ctx: Koa.Context, next: Function) {
  // ...
}
```
