### PR TITLE
Add type definitions for gulp-json-editor

### DIFF
--- a/gulp-json-editor/gulp-json-editor-tests.ts
+++ b/gulp-json-editor/gulp-json-editor-tests.ts
@@ -1,0 +1,40 @@
+/// <reference path="gulp-json-editor.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import * as gulp from 'gulp';
+import * as jeditor from 'gulp-json-editor';
+
+// Samples taken from https://www.npmjs.com/package/gulp-json-editor
+
+/*
+  edit JSON object by merging with user specific object
+*/
+gulp.src("./manifest.json")
+  .pipe(jeditor({
+    'version': '1.2.3'
+  }))
+  .pipe(gulp.dest("./dest"));
+
+/*
+  edit JSON object by using user specific function
+*/
+gulp.src("./manifest.json")
+  .pipe(jeditor(function(json : any) {
+    json.version = "1.2.3";
+    return json; // must return JSON object.
+  }))
+  .pipe(gulp.dest("./dest"));
+
+/*
+  specify js-beautify option
+*/
+gulp.src("./manifest.json")
+  .pipe(jeditor({
+    'version': '1.2.3'
+  },
+  // the second argument is passed to js-beautify as its option
+  {
+    'indent_char': '\t',
+    'indent_size': 1
+  }))
+  .pipe(gulp.dest("./dest"));

--- a/gulp-json-editor/gulp-json-editor.d.ts
+++ b/gulp-json-editor/gulp-json-editor.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for gulp-json-editor v2.2.1
+// Project: https://www.npmjs.com/package/gulp-json-editor
+// Definitions by: Peter Juras <https://github.com/peterjuras>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference path="../node/node.d.ts" />
+/// <reference path="../js-beautify/js-beautify.d.ts" />
+
+declare module "gulp-json-editor" {
+
+  interface JEditor {
+    (mergeWith: any | ((json : any) => any ),
+    jsBeautifyOptions? : JsBeautifyOptions ) : NodeJS.ReadWriteStream;
+  }
+
+  const jeditor : JEditor;
+  export = jeditor;
+}

--- a/js-beautify/js-beautify.d.ts
+++ b/js-beautify/js-beautify.d.ts
@@ -2,28 +2,34 @@
 // Project: https://github.com/beautify-web/js-beautify/
 // Definitions by: Josh Goldberg <https://github.com/JoshuaKGoldberg/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
+// Type definitions for js_beautify
+// Project: https://github.com/beautify-web/js-beautify/
+// Definitions by: Josh Goldberg <https://github.com/JoshuaKGoldberg/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+interface JsBeautifyOptions {
+  indent_size?: number;
+  indent_char?: string;
+  eol?: string;
+  indent_level?: number;
+  indent_with_tabs?: boolean;
+  preserve_newlines?: boolean;
+  max_preserve_newlines?: number;
+  jslint_happy?: boolean;
+  space_after_anon_function?: boolean;
+  brace_style?: string;
+  keep_array_indentation?: boolean;
+  keep_function_indentation?: boolean;
+  space_before_conditional?: boolean;
+  break_chained_methods?: boolean;
+  eval_code?: boolean;
+  unescape_strings?: boolean;
+  wrap_line_length?: number;
+  wrap_attributes?: string;
+  wrap_attributes_indent_size?: number;
+  end_with_newline?: boolean;
+}
 
 declare var js_beautify: {
-    (js_source_text: string, options?: {
-        indent_size?: number;
-        indent_char?: string;
-        eol?: string;
-        indent_level?: number;
-        indent_with_tabs?: boolean;
-        preserve_newlines?: boolean;
-        max_preserve_newlines?: number;
-        jslint_happy: boolean;
-        space_after_anon_function: boolean;
-        brace_style: string;
-        keep_array_indentation: boolean;
-        keep_function_indentation: boolean;
-        space_before_conditional: boolean;
-        break_chained_methods: boolean;
-        eval_code: boolean;
-        unescape_strings: boolean;
-        wrap_line_length: number;
-        wrap_attributes: string;
-        wrap_attributes_indent_size: number;
-        end_with_newline: boolean;
-    }): string;
+  (js_source_text: string, options?: JsBeautifyOptions): string;
 };


### PR DESCRIPTION
Added type definitions for [gulp-json-editor](https://www.npmjs.com/package/gulp-json-editor).

JSBeautify options were modified to make them able for reuse within the new type definitions.
