### PR TITLE
Condense RequestHandler signatures into one

### DIFF
--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -101,8 +101,7 @@ declare module "express" {
 
             route(path: string): IRoute;
 
-            use(...handler: RequestHandler[]): T;
-            use(handler: ErrorRequestHandler|RequestHandler): T;
+            use(...handler: (ErrorRequestHandler|RequestHandler)[]): T;
             use(path: string, ...handler: RequestHandler[]): T;
             use(path: string, handler: ErrorRequestHandler|RequestHandler): T;
             use(path: string[], ...handler: RequestHandler[]): T;


### PR DESCRIPTION
This enables the use of the ErrorRequestHandler interface in a simple use() call, which previously didn't work for me.

You can test this by adding a call to use(function(error, req, res, next) {}).
