### PR TITLE
Added the clipPath SVG element

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -2250,6 +2250,7 @@ declare namespace JSX {
         svg: React.SVGProps;
 
         circle: React.SVGProps;
+        clipPath: React.SVGProps;
         defs: React.SVGProps;
         ellipse: React.SVGProps;
         g: React.SVGProps;


### PR DESCRIPTION
Not sure when it was added, but the current version of react supports the clipPath element: http://facebook.github.io/react/docs/tags-and-attributes.html
