### PR TITLE
Add type definitions for gulp-html-replace

### DIFF
--- a/gulp-html-replace/gulp-html-replace-tests.ts
+++ b/gulp-html-replace/gulp-html-replace-tests.ts
@@ -1,0 +1,80 @@
+/// <reference path="gulp-html-replace.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+/// <reference path="../node/node.d.ts" />
+
+import * as gulp from 'gulp';
+import * as htmlreplace from 'gulp-html-replace';
+
+// Examples taken from README.md of the gulp-html-replace project:
+// https://www.npmjs.com/package/gulp-html-replace
+
+// Simple examples
+gulp.task('simple1', () => {
+  gulp.src('src')
+    .pipe(htmlreplace({ js: 'js/main.js' }))
+    .pipe(gulp.dest('dest'));
+});
+
+gulp.task('simple2', () => {
+  gulp.src('src')
+    .pipe(htmlreplace({ js: ['js/monster.js', 'js/hero.js'] }))
+    .pipe(gulp.dest('dest'));
+});
+
+// Advanced examples
+gulp.task('advanced1', () => {
+  gulp.src('src')
+    .pipe(htmlreplace({
+    js: 'js/main.js',
+    tpl: '<img src="%s" align="left" />'
+  }))
+    .pipe(gulp.dest('dest'));
+});
+
+gulp.task('advanced2', () => {
+  gulp.src('src')
+    .pipe(htmlreplace({
+    js: ['data-main.js', 'require-src.js'],
+    tpl: '<img src="%s" align="left" />'
+  }))
+    .pipe(gulp.dest('dest'));
+});
+
+// Extended replacements
+gulp.task('ext1', () => {
+  gulp.src('src')
+    .pipe(htmlreplace({
+    js: {
+      src: null,
+      tpl: '<script src="%f".js></script>'
+    }
+  }))
+    .pipe(gulp.dest('dest'));
+});
+
+gulp.task('ext2', () => {
+  gulp.src('src')
+    .pipe(htmlreplace({
+    js: {
+      src: 'dir',
+      tpl: '<script src="%f".js></script>'
+    }
+  }))
+    .pipe(gulp.dest('dest'));
+});
+
+// Options example
+gulp.task('options1', () => {
+  gulp.src('src')
+    .pipe(htmlreplace({
+    js: {
+      src: null,
+      tpl: '<script src="%f".js></script>'
+    }
+  }, {
+    keepUnassigned: false,
+    keepBlockTags: false,
+    resolvePaths: false
+  }))
+    .pipe(gulp.dest('dest'));
+});

--- a/gulp-html-replace/gulp-html-replace.d.ts
+++ b/gulp-html-replace/gulp-html-replace.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for gulp-html-replace v1.5.5
+// Project: https://www.npmjs.com/package/gulp-html-replace
+// Definitions by: Peter Juras <https://github.com/peterjuras>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference path="../node/node.d.ts" />
+
+declare module "gulp-html-replace" {
+  interface AdvancedTask {
+    src: string | string[];
+    tpl: string;
+  }
+
+  interface Tasks {
+    [taskId: string] : string | string[] | AdvancedTask;
+  }
+
+  interface Options {
+    keepUnassigned?: boolean;
+    keepBlockTags?: boolean;
+    resolvePaths?: boolean;
+  }
+
+  interface HtmlReplace {
+    (tasks: Tasks, options?: Options) : NodeJS.ReadWriteStream;
+  }
+
+  const htmlReplace : HtmlReplace;
+  export = htmlReplace;
+}


### PR DESCRIPTION
Added type definitions for [gulp-html-replace](https://www.npmjs.com/package/gulp-html-replace)
