### PR TITLE
Add type definitions for gulp-jspm

### DIFF
--- a/gulp-jspm/gulp-jspm-tests.ts
+++ b/gulp-jspm/gulp-jspm-tests.ts
@@ -1,0 +1,33 @@
+/// <reference path="gulp-jspm.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import * as gulp from 'gulp';
+import * as gulpJspm from 'gulp-jspm';
+
+// Examples taken from https://www.npmjs.com/package/gulp-jspm
+gulp.task('default', function(){
+    return gulp.src('src/main.js')
+        .pipe(gulpJspm())
+        .pipe(gulp.dest('build/'));
+});
+
+// Options
+gulp.src('src/main.js')
+    .pipe(gulpJspm({arithmetic: '- message'})) // exclude message.js from bundle
+    .pipe(gulp.dest('build/'));
+
+gulp.src('src/main.js')
+    .pipe(gulpJspm({selfExecutingBundle: true})) // `jspm bundle-sfx main`
+    .pipe(gulp.dest('build/'));
+
+gulp.src('src/main.jsx')
+    .pipe(gulpJspm({plugin: true})) // `jspm bundle main.jsx!`
+    .pipe(gulp.dest('build/'));
+gulp.src('src/main.jsx')
+    .pipe(gulpJspm({plugin: 'jsx'})) // `jspm bundle main.jsx!jsx`
+    .pipe(gulp.dest('build/'));
+ 
+// all other options given to gulp-jspm are passed on to jspm, e.g.
+gulp.src('src/main.js')
+    .pipe(gulpJspm({inject: true})) // `jspm bundle main --inject`
+    .pipe(gulp.dest('build/'));

--- a/gulp-jspm/gulp-jspm.d.ts
+++ b/gulp-jspm/gulp-jspm.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for gulp-jspm v0.5.4
+// Project: https://www.npmjs.com/package/gulp-jspm
+// Definitions by: Peter Juras <https://github.com/peterjuras>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference path="../node/node.d.ts" />
+
+declare module "gulp-jspm" {
+  interface Options {
+    arithmetic?: string;
+    selfExecutingBundle?: boolean;
+    plugin?: boolean | string;
+    inject?: boolean;
+    minify?: boolean;
+  }
+
+  interface GulpJspm {
+    (options?: Options) : NodeJS.ReadWriteStream;
+  }
+
+  const gulpJspm : GulpJspm;
+  export = gulpJspm;
+}


### PR DESCRIPTION
Added type definitions for [gulp-jspm](https://www.npmjs.com/package/gulp-jspm)
