### PR TITLE
Add type definitions for gulp-strip-debug

### DIFF
--- a/gulp-strip-debug/gulp-strip-debug-tests.ts
+++ b/gulp-strip-debug/gulp-strip-debug-tests.ts
@@ -1,0 +1,12 @@
+/// <reference path="gulp-strip-debug.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import * as gulp from 'gulp';
+import * as stripDebug from 'gulp-strip-debug';
+
+// Example taken from https://www.npmjs.com/package/gulp-strip-debug
+gulp.task('default', function () {
+	return gulp.src('src/app.js')
+		.pipe(stripDebug())
+		.pipe(gulp.dest('dist'));
+});

--- a/gulp-strip-debug/gulp-strip-debug.d.ts
+++ b/gulp-strip-debug/gulp-strip-debug.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for gulp-strip-debug v1.1.0
+// Project: https://www.npmjs.com/package/gulp-strip-debug
+// Definitions by: Peter Juras <https://github.com/peterjuras>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference path="../node/node.d.ts" />
+
+declare module "gulp-strip-debug" {
+  const gulpStripDebug : () => NodeJS.ReadWriteStream;
+  export = gulpStripDebug;
+}


### PR DESCRIPTION
Added type definitions for [gulp-strip-debug](https://www.npmjs.com/package/gulp-strip-debug)
