### PR TITLE
Add ClientOps.password to redis typings

### DIFF
--- a/redis/redis.d.ts
+++ b/redis/redis.d.ts
@@ -46,6 +46,7 @@ declare module "redis" {
         connect_timeout?: number;
         max_attempts?: number;
         auth_pass?: string;
+        password?: string;
         family?: string;
         command_queue_high_water?: number;
         command_queue_low_water?: number;


### PR DESCRIPTION
password is an alias for auth_pass.
