### PR TITLE
Remove conflicted decomposed class declaration

### DIFF
--- a/date.format.js/date.format.d.ts
+++ b/date.format.js/date.format.d.ts
@@ -180,32 +180,6 @@ interface Date {
   format(mask?: string, utc?: boolean) : string;
 }
 
-declare var Date: {
-  new (): Date;
-  new (value: number): Date;
-  new (value: string): Date;
-  new (year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): Date;
-  (): string;
-  prototype: Date;
-  /**
-   * Parses a string containing a date, and returns the number of milliseconds between that date and midnight, January 1, 1970.
-   * @param s A date string
-   */
-  parse(s: string): number;
-  /**
-   * Returns the number of milliseconds between midnight, January 1, 1970 Universal Coordinated Time (UTC) (or GMT) and the specified date.
-   * @param year The full year designation is required for cross-century date accuracy. If year is between 0 and 99 is used, then year is assumed to be 1900 + year.
-   * @param month The month as an number between 0 and 11 (January to December).
-   * @param date The date as an number between 1 and 31.
-   * @param hours Must be supplied if minutes is supplied. An number from 0 to 23 (midnight to 11pm) that specifies the hour.
-   * @param minutes Must be supplied if seconds is supplied. An number from 0 to 59 that specifies the minutes.
-   * @param seconds Must be supplied if milliseconds is supplied. An number from 0 to 59 that specifies the seconds.
-   * @param ms An number from 0 to 999 that specifies the milliseconds.
-   */
-  UTC(year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): number;
-  now(): number;
-};
-
 // Some common format strings
 interface DateFormatMasks {
   "default": string;


### PR DESCRIPTION
With the [readonly](https://github.com/Microsoft/TypeScript/pull/6532) feature merged into the master which contains applying readonly flag to `lib.d.ts` [this line](https://github.com/Microsoft/TypeScript/pull/6532/files#diff-bb79b63a7716353d369c9977aa623545R799), we need to remove re-declare of `Date` in `date.format.d.ts`
