### PR TITLE
Update Drop and Tether typings

### DIFF
--- a/drop/drop.d.ts
+++ b/drop/drop.d.ts
@@ -1,17 +1,36 @@
-// Type definitions for Drop v1.3.0
+// Type definitions for Drop v1.4
 // Project: http://github.hubspot.com/drop/
 // Definitions by: Adi Dahiya <https://github.com/adidahiya>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 ///<reference path="../tether/tether.d.ts" />
 
-declare module drop {
+// global Drop constructor
+declare class Drop {
+    constructor(options: Drop.IDropOptions);
 
-    interface DropStatic {
-        new(options: IDropOptions): Drop;
-        createContext(options: IDropContextOptions): DropStatic;
-    }
+    public content: HTMLElement;
+    public element: HTMLElement;
+    public tether: Tether;
+    public open(): void;
+    public close(): void;
+    public remove(): void;
+    public toggle(): void;
+    public isOpened(): boolean;
+    public position(): void;
+    public destroy(): void;
 
+    /*
+     * Drop instances fire "open" and "close" events.
+     */
+    public on(event: string, handler: Function, context?: any): void;
+    public once(event: string, handler: Function, context?: any): void;
+    public off(event: string, handler?: Function): void;
+
+    public static createContext(options: Drop.IDropContextOptions): Drop;
+}
+
+declare module Drop {
     interface IDropContextOptions {
         classPrefix?: string;
         defaults?: IDropOptions;
@@ -27,33 +46,11 @@ declare module drop {
         constrainToScrollParent?: boolean;
         remove?: boolean;
         beforeClose?: () => boolean;
-        tetherOptions?: tether.ITetherOptions;
+        tetherOptions?: Tether.ITetherOptions;
     }
-
-    interface Drop {
-        content: HTMLElement;
-        element: HTMLElement;
-        tether: tether.Tether;
-        open(): void;
-        close(): void;
-        remove(): void;
-        toggle(): void;
-        isOpened(): boolean;
-        position(): void;
-        destroy(): void;
-        /*
-         * Drop instances fire "open" and "close" events.
-         */
-        on(event: string, handler: Function, context?: any): void;
-        once(event: string, handler: Function, context?: any): void;
-        off(event: string, handler?: Function): void;
-    }
-
 }
 
 declare module "drop" {
-    export = drop;
+    export = Drop;
 }
-
-declare var Drop: drop.DropStatic;
 

--- a/tether/tether.d.ts
+++ b/tether/tether.d.ts
@@ -1,14 +1,22 @@
-// Type definitions for Tether v0.6
+// Type definitions for Tether v1.1
 // Project: http://github.hubspot.com/tether/
 // Definitions by: Adi Dahiya <https://github.com/adidahiya>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare module tether {
+// global Tether constructor
+declare class Tether {
+    constructor(options: Tether.ITetherOptions);
 
-    interface TetherStatic {
-        new(options: ITetherOptions): Tether;
-    }
+    public setOptions(options: Tether.ITetherOptions): void;
+    public disable(): void;
+    public enable(): void;
+    public destroy(): void;
+    public position(): void;
 
+    public static position(): void;
+}
+
+declare namespace Tether {
     interface ITetherOptions {
         attachment?: string;
         classes?: {[className: string]: boolean};
@@ -31,20 +39,9 @@ declare module tether {
         pinnedClass?: string;
         to?: string | HTMLElement | number[];
     }
-
-    interface Tether {
-        setOptions(options: ITetherOptions): void;
-        disable(): void;
-        enable(): void;
-        destroy(): void;
-        position(): void;
-    }
-
 }
 
 declare module "tether" {
-    export = tether;
+    export = Tether;
 }
-
-declare var Tether: tether.TetherStatic;
 


### PR DESCRIPTION
This is a breaking change that simplifies the definition files and exports the right thing for the external modules. Previously, the external module export was wrong (the global `Drop` and `Tether` constructors are exported when these libraries are imported in CommonJS, not the namespaces as the typings suggested).
