### PR TITLE
Three.js: Removed 2 classes that wasn't mentioned anywhere else.

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -312,18 +312,6 @@ declare module THREE {
         parse( json: any ): BooleanKeyframeTrack;
     }
 
-    export class ColorKeyframeTrack extends KeyframeTrack {
-        constructor(name: string, keys: any[]);
-
-        result: any;
-
-        setResult( value: any ): void;
-        lerpValues( value0: any, value1: any, alpha: number ): any;
-        compareValues( value0: any, value1: any ): boolean;
-        clone(): ColorKeyframeTrack;
-        parse( json: any ): ColorKeyframeTrack;
-    }
-
     export class NumberKeyframeTrack {
         constructor();
 
@@ -1908,15 +1896,6 @@ declare module THREE {
         handlers:any[];
         add(regex:string, loader:Loader):void;
         get(file: string):Loader;
-    }
-
-    export class AnimationLoader {
-        constructor(manager?: LoadingManager);
-
-        manager: LoadingManager;
-        load(url: string, onLoad: (animations: AnimationClip[]) => void, onProgress?: (event: any) => void, onError?: (event: any) => void): void;
-        setCrossOrigin(crossOrigin: string): void;
-        parse(json: any, onLoad: (animations: AnimationClip[])=>void): void;
     }
 
     export class BinaryTextureLoader {
@@ -4618,7 +4597,7 @@ declare module THREE {
         getMaxAnisotropy(): number;
         getPixelRatio(): number;
         setPixelRatio(value: number): void;
-        
+
         getSize(): { width: number; height: number; };
 
         /**
@@ -4960,7 +4939,7 @@ declare module THREE {
 
     export class WebGLProgram{
         constructor(renderer: WebGLRenderer, code: string, material: ShaderMaterial, parameters: WebGLRendererParameters);
-        
+
         getUniforms(): any;
         getAttributes(): any;
 


### PR DESCRIPTION
The declaration file stated that the classes AnimationLoader and ColorKeyframeTrack was on the THREE object. 
When one initializes the library, they aren't on the THREE object. 

Furthermore, I couldn't find anything in the documentation about them, and a ctrl + f in the Three.js source code revealed nothing about them. 

So what are they doing in the declaration file? 
