### PR TITLE
Three.js: WorldUVGenerator is a static field

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -5718,7 +5718,7 @@ declare module THREE {
         constructor(shape?: Shape, options?: any);
         constructor(shapes?: Shape[], options?: any);
 
-        WorldUVGenerator: {
+        static WorldUVGenerator: {
             generateTopUV(geometry: Geometry, indexA: number, indexB: number, indexC: number): Vector2[];
             generateSideWallUV(geometry: Geometry, indexA: number, indexB: number, indexC: number, indexD: number): Vector2[];
         };


### PR DESCRIPTION
On the class ExtrudeGeometry, WorldUVGenerator isn't an instance field, it is a static field on the class. 

The declaration files has here been updated to match that. 
