### PR TITLE
Changed ITemplateOptions.{onChange, onBlue, etc.} to string | ITemplateOptions

### DIFF
--- a/angular-formly/angular-formly.d.ts
+++ b/angular-formly/angular-formly.d.ts
@@ -101,13 +101,13 @@ declare module AngularFormly {
 		type?: string;
 
 		//expression types
-		onBlur?: string | IExpresssionFunction;
-		onChange?: string | IExpresssionFunction;
-		onClick?: string | IExpresssionFunction;
-		onFocus?: string | IExpresssionFunction;
-		onKeydown?: string | IExpresssionFunction;
-		onKeypress?: string | IExpresssionFunction;
-		onKeyup?: string | IExpresssionFunction;
+		onBlur?: string | IExpressionFunction;
+		onChange?: string | IExpressionFunction;
+		onClick?: string | IExpressionFunction;
+		onFocus?: string | IExpressionFunction;
+		onKeydown?: string | IExpressionFunction;
+		onKeypress?: string | IExpressionFunction;
+		onKeyup?: string | IExpressionFunction;
 
 		//Bootstrap types
 		label?: string;

--- a/angular-formly/angular-formly.d.ts
+++ b/angular-formly/angular-formly.d.ts
@@ -101,13 +101,13 @@ declare module AngularFormly {
 		type?: string;
 
 		//expression types
-		onBlur?: string;
-		onChange?: string;
-		onClick?: string;
-		onFocus?: string;
-		onKeydown?: string;
-		onKeypress?: string;
-		onKeyup?: string;
+		onBlur?: string | IExpresssionFunction;
+		onChange?: string | IExpresssionFunction;
+		onClick?: string | IExpresssionFunction;
+		onFocus?: string | IExpresssionFunction;
+		onKeydown?: string | IExpresssionFunction;
+		onKeypress?: string | IExpresssionFunction;
+		onKeyup?: string | IExpresssionFunction;
 
 		//Bootstrap types
 		label?: string;


### PR DESCRIPTION
Changed the types of the `ITemplateOptions` properties `onBlur`, `onChange`, `onClick`, `onFocus`, `onKeydown`, `onKeypress`, and `onKeyup` from 

``` TypeScript
string
```

to

``` TypeScript
string | IExpresssionFunction
```
