### PR TITLE
Allow View's id and className to be functions

### DIFF
--- a/backbone/backbone-global.d.ts
+++ b/backbone/backbone-global.d.ts
@@ -326,8 +326,8 @@ declare module Backbone {
        // TODO: quickfix, this can't be fixed easy. The collection does not need to have the same model as the parent view.
       collection?: Backbone.Collection<any>; //was: Collection<TModel>;
       el?: any;
-      id?: string;
-      className?: string;
+      id?: string|(()=>string);
+      className?: string|(()=>string);
       tagName?: string;
       attributes?: {[id: string]: any};
     }
@@ -354,9 +354,9 @@ declare module Backbone {
         collection: Collection<TModel>;
         //template: (json, options?) => string;
         setElement(element: HTMLElement|JQuery, delegate?: boolean): View<TModel>;
-        id: string;
+        id: string|(()=>string);
         cid: string;
-        className: string;
+        className: string|(()=>string);
         tagName: string;
 
         el: any;


### PR DESCRIPTION
It's a fairly important part of Backbone's views that certain attributes (specifically `id` and `className`) can be either strings, or functions returning strings which are lazily evaluated. This lets you mix data from the model into these attributes when they are rendered, without a lot of screwing around in the view's `render` method.

With this change, instead of this...

``` typescript
class ProfileCard extends Backbone.ItemView<User> {
  className = "profile-card"

  render() {
    if (this.model.get('admin'))
      this.$el.addClass('admin')
  }
}
```

we can do this:

``` typescript
class ProfileCard extends Backbone.ItemView<User> {
  className = () => {
    return "profile-card " + (this.model.get('admin') ? 'admin': '';)
  }
}
```
