### PR TITLE
react-native: Param added to ScrollView onScroll

### DIFF
--- a/react-native/react-native.d.ts
+++ b/react-native/react-native.d.ts
@@ -2712,7 +2712,7 @@ declare namespace  __React {
          * Fires at most once per frame during scrolling.
          * The frequency of the events can be contolled using the scrollEventThrottle prop.
          */
-        onScroll?: () => void
+        onScroll?: (event?: { nativeEvent: NativeScrollEvent }) => void
 
         /**
          * Experimental: When true offscreen child views (whose `overflow` value is


### PR DESCRIPTION
The onScroll callback has a `nativeEvent` field in an `event` parameter: https://github.com/facebook/react-native/blob/a99c5160eeeedec0d08afca1a7cda235418765f4/ReactAndroid/src/androidTest/assets/ScrollViewTestModule.js#L45

I can't figure out a way to access this parameter without the typescript compiler thinking it's an error (without this fix).

Thanks!
