### PR TITLE
RTCPeerConnection.d.ts & MediaStream.d.ts improvements

### DIFF
--- a/webrtc/MediaStream.d.ts
+++ b/webrtc/MediaStream.d.ts
@@ -174,6 +174,9 @@ interface NavigatorGetUserMedia {
      errorCallback: (error: MediaStreamError) => void): void;
 }
 
+// to use with adapter.js, see: https://github.com/webrtc/adapter
+declare var getUserMedia: NavigatorGetUserMedia;
+
 interface Navigator {
     getUserMedia: NavigatorGetUserMedia;
 

--- a/webrtc/RTCPeerConnection-tests.ts
+++ b/webrtc/RTCPeerConnection-tests.ts
@@ -1,8 +1,8 @@
-﻿/// <reference path="MediaStream.d.ts" />
+/// <reference path="MediaStream.d.ts" />
 /// <reference path="RTCPeerConnection.d.ts" />
 
 var config: RTCConfiguration =
-    { iceServers: [{ url: "stun.l.google.com:19302" }] };
+    { iceServers: [{ urls: "stun.l.google.com:19302" }] };
 var constraints: RTCMediaConstraints =
     { mandatory: { offerToReceiveAudio: true, offerToReceiveVideo: true } };
 

--- a/webrtc/RTCPeerConnection.d.ts
+++ b/webrtc/RTCPeerConnection.d.ts
@@ -29,7 +29,7 @@ declare var RTCConfiguration: {
 };
 
 interface RTCIceServer {
-  url: string;
+  urls: string;
   credential?: string;
 }
 declare var RTCIceServer: {


### PR DESCRIPTION
"url" in interface RTCIceServer (webrtc/RTCPeerConnection.d.ts) is deprecated, changed to "urls"
added "declare var getUserMedia: NavigatorGetUserMedia;" for use with adapter.js see: https://github.com/webrtc/adapter
