### PR TITLE
Enable LF normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Auto detect text files and perform LF normalization
-* text=none
+* text=auto
 
 # Custom for Visual Studio
 *.cs     diff=csharp


### PR DESCRIPTION
Per git's documentation, the previous configuration (`text=none`) is equivalent to leaving `text` unspecified, which isn't useful.  `text=auto` means that all line endings are normalized to LF in the repository and will be checked out as LF on Mac & Linux, CRLF on Windows.  I think this makes more sense to avoid patches like #7823 where entire files are affected just because line endings were different.

https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html#_tt_text_tt
