### PR TITLE
add empty namespace declaration for chai-as-promised to allow es6 imports

### DIFF
--- a/vinyl-source-stream/vinyl-source-stream.d.ts
+++ b/vinyl-source-stream/vinyl-source-stream.d.ts
@@ -7,5 +7,6 @@
 
 declare module "vinyl-source-stream" {
     function vinylSourceStream(filename: string): NodeJS.ReadWriteStream;
+    namespace vinylSourceStream {}
     export = vinylSourceStream;
 }


### PR DESCRIPTION
See https://github.com/Microsoft/TypeScript/issues/5073 and  #6697
