### PR TITLE
Update KnockoutMappingUpdateOptions to add the missing target field

### DIFF
--- a/knockout.mapping/knockout.mapping-tests.ts
+++ b/knockout.mapping/knockout.mapping-tests.ts
@@ -15,6 +15,7 @@ var createOptions = {
 var updateOptions = {
     data: inputData,
     parent: parent,
+    target: inputModel,
     observable: ko.observable(7)
 }
 
@@ -48,6 +49,18 @@ mapping.fromJS(inputData, inputOptions, inputModel);
 mapping.fromJSON(inputJSON);
 mapping.fromJSON(inputJSON, targetOptions);
 mapping.fromJSON(inputJSON, inputOptions, inputModel);
+
+mapping.fromJS(inputJSON, {
+    fieldNeedingCustomOptions: {
+        key: (data: any) => data.id,
+        create: (options: KnockoutMappingCreateOptions) => {
+            return mapping.fromJS(options.data);
+        },
+        update: (options: KnockoutMappingUpdateOptions) => {
+            return mapping.fromJS(options.data, options.target);
+        }
+    }
+});
 
 // toJS function
 mapping.toJS(inputModel);

--- a/knockout.mapping/knockout.mapping.d.ts
+++ b/knockout.mapping/knockout.mapping.d.ts
@@ -13,7 +13,8 @@ interface KnockoutMappingCreateOptions {
 interface KnockoutMappingUpdateOptions {
     data: any;
     parent: any;
-    observable: KnockoutObservable<any>;
+    target: any;
+    observable?: KnockoutObservable<any>;
 }
 
 interface KnockoutMappingOptions {


### PR DESCRIPTION
Also makes the `observable` field optional as it's only present if `target`
is a writable observable.
