### PR TITLE
updated SpyAnd return values

### DIFF
--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -423,11 +423,11 @@ declare module jasmine {
         /** By chaining the spy with and.callThrough, the spy will still track all calls to it but in addition it will delegate to the actual implementation. */
         callThrough(): Spy;
         /** By chaining the spy with and.returnValue, all calls to the function will return a specific value. */
-        returnValue(val: any): void;
+        returnValue(val: any): Spy;
         /** By chaining the spy with and.callFake, all calls to the spy will delegate to the supplied function. */
         callFake(fn: Function): Spy;
         /** By chaining the spy with and.throwError, all calls to the spy will throw the specified value. */
-        throwError(msg: string): void;
+        throwError(msg: string): Spy;
         /** When a calling strategy is used for a spy, the original stubbing behavior can be returned at any time with and.stub. */
         stub(): Spy;
     }


### PR DESCRIPTION
In jasmine 2.X API, `SpyAnd` corresponding methods return spy objects, and not void as current interface defines.
