### PR TITLE
Leaflet: Removed a function that doesn't exist.

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -805,13 +805,6 @@ declare namespace L {
 }
 
 declare namespace L {
-
-    /**
-      * Creates a Draggable object for moving the given element when you start dragging
-      * the dragHandle element (equals the element itself by default).
-      */
-    function draggable(element: HTMLElement, dragHandle?: HTMLElement): Draggable;
-
     export interface DraggableStatic extends ClassStatic {
         /**
           * Creates a Draggable object for moving the given element when you start dragging


### PR DESCRIPTION
Draggable (with an uppercase D) does exist on the L object. 
But draggable (with lowercase d), doesn't. 

Somehow the second is still in the declaration file. 
