### PR TITLE
Leaflet: Not every class constructor inherits fields from the default ClassStatic

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -41,7 +41,7 @@ declare module L {
     export function bounds(points: Point[]): Bounds;
 
 
-    export interface BoundsStatic extends ClassStatic {
+    export interface BoundsStatic {
         /**
           * Creates a Bounds object from two coordinates (usually top-left and bottom-right
           * corners).
@@ -1453,7 +1453,7 @@ declare namespace L {
       */
     function latLng(coords: LatLngExpression): LatLng;
 
-    export interface LatLngStatic extends ClassStatic {
+    export interface LatLngStatic {
         /**
           * Creates an object representing a geographical point with the given latitude
           * and longitude.
@@ -1539,7 +1539,7 @@ declare namespace L {
       */
     function latLngBounds(latlngs: LatLngBoundsExpression): LatLngBounds;
 
-    export interface LatLngBoundsStatic extends ClassStatic {
+    export interface LatLngBoundsStatic {
         /**
           * Creates a LatLngBounds object by defining south-west and north-east corners
           * of the rectangle.
@@ -2442,7 +2442,7 @@ declare namespace L {
         options: Map.MapOptions;
 
         /**
-          * Iterates over the layers of the map, optionally specifying context 
+          * Iterates over the layers of the map, optionally specifying context
 		  * of the iterator function.
           */
         eachLayer(fn: (layer: ILayer) => void, context?: any): Map;
@@ -3401,7 +3401,7 @@ declare namespace L {
       */
     function point(x: number, y: number, round?: boolean): Point;
 
-    export interface PointStatic extends ClassStatic {
+    export interface PointStatic {
         /**
           * Creates a Point object with the given x and y coordinates. If optional round
           * is set to true, rounds the x and y values.
@@ -4182,7 +4182,7 @@ declare namespace L {
           * When this option is set, the TileLayer only loads tiles that are in the given geographical bounds.
           */
         bounds?: LatLngBounds;
-        
+
         /**
           * Custom keys may be specified in TileLayerOptions so they can be used in a provided URL template.
           */
@@ -4191,7 +4191,7 @@ declare namespace L {
 }
 
 declare namespace L {
-    export interface TransformationStatic extends ClassStatic {
+    export interface TransformationStatic {
         /**
           * Creates a transformation object with the given coefficients.
           */


### PR DESCRIPTION
The declaration file stated that for classes like Bounds, the static constructor extended ClassStatic. 
This is however not the case, since classes like L.Bounds are just a "plain" constructor, that doesn't inherit from anything. 

The declaration leads one be believe that expressions such as: `L.Bounds.extend([...])` should succeed. However `L.Bounds.extend` is undefined. 

This pull-request fixes that issue for the relevant classes. 
