### PR TITLE
Update angular.d.ts to allow IModule .config signature to accept object parameters

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -200,6 +200,7 @@ declare module angular {
          * @param inlineAnnotatedFunction Execute this function on module load. Useful for service configuration.
          */
         config(inlineAnnotatedFunction: any[]): IModule;
+        config(object: Object): IModule;
         /**
          * Register a constant service, such as a string, a number, an array, an object or a function, with the $injector. Unlike value it can be injected into a module configuration function (see config) and it cannot be overridden by an Angular decorator.
          *


### PR DESCRIPTION
If splitting the config into seperate files, this constructor overload is useful. For example, you might need a RoutesConfig.ts file. I have tested this on a project and Angular correctly accepts object references so we just need to update the type definition now.
#### Example
##### RoutesConfig.ts

```
export class RoutesConfig {

    static $inject = ['$stateProvider', '$urlRouterProvider', '$locationProvider'];

    constructor (private $stateProvider: angular.ui.IStateProvider, private $urlRouterProvider: angular.ui.IUrlRouterProvider, private $locationProvider: ng.ILocationProvider) {

        // Unmatched URLs, redirect to root
        $urlRouterProvider.otherwise('/');

        $stateProvider
            .state('home', {
                url: '/',
                template: '<route-home></route-home>'
            });

        $locationProvider.html5Mode(true);        
    }
}
```
##### Main.ts

```
import {RoutesConfig} from './common/RoutesConfig';
angular.module('myApp', [])
    .config(RoutesConfig)
```
