### PR TITLE
Updated stripe.d.ts

### DIFF
--- a/stripe/stripe.d.ts
+++ b/stripe/stripe.d.ts
@@ -62,6 +62,7 @@ interface StripeCardData {
     address_state?: string;
     address_zip?: string;
     address_country?: string;
+    createToken(data: StripeTokenData, responseHandler: (status: number, response: StripeTokenResponse) => void): void;
 }
 
 interface StripeBankAccount


### PR DESCRIPTION
Stripe allows `createToken` at the card object

Docs: https://stripe.com/docs/stripe.js#collecting-card-details
