### PR TITLE
office-js.d.ts has incorrect casing on the bodyType enum

### DIFF
--- a/office-js/office-js.d.ts
+++ b/office-js/office-js.d.ts
@@ -4689,7 +4689,7 @@ declare module Office.MailboxEnums {
         /**
          * The body is in HTML format
          */
-        HTML,
+        Html,
         /**
          * The body is in text format
          */


### PR DESCRIPTION
When calling:
`getTypeAsync(function (result) { ...}`

currently the definition is:
`Office.MailboxEnums.BodyType.HTML`

the value sent in result will not match this as the definition is incorrectly cased. 

The correct casing is:
`Office.MailboxEnums.BodyType.Html`
eg:
`if (result.value == Office.MailboxEnums.BodyType.Html) {...}`
