### PR TITLE
Rename the type variable for es6-promise from R to T to match lib.d.ts.

### DIFF
--- a/es6-promise/es6-promise.d.ts
+++ b/es6-promise/es6-promise.d.ts
@@ -3,13 +3,13 @@
 // Definitions by: François de Campredon <https://github.com/fdecampredon/>, vvakame <https://github.com/vvakame>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-interface Thenable<R> {
-    then<U>(onFulfilled?: (value: R) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
-    then<U>(onFulfilled?: (value: R) => U | Thenable<U>, onRejected?: (error: any) => void): Thenable<U>;
+interface Thenable<T> {
+    then<U>(onFulfilled?: (value: T) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
+    then<U>(onFulfilled?: (value: T) => U | Thenable<U>, onRejected?: (error: any) => void): Thenable<U>;
     catch<U>(onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
 }
 
-declare class Promise<R> implements Thenable<R> {
+declare class Promise<T> implements Thenable<T> {
 	/**
 	 * If you call resolve in the body of the callback passed to the constructor,
 	 * your promise is fulfilled with result object passed to resolve.
@@ -17,7 +17,7 @@ declare class Promise<R> implements Thenable<R> {
 	 * For consistency and debugging (eg stack traces), obj should be an instanceof Error.
 	 * Any errors thrown in the constructor callback will be implicitly passed to reject().
 	 */
-	constructor(callback: (resolve : (value?: R | Thenable<R>) => void, reject: (error?: any) => void) => void);
+	constructor(callback: (resolve : (value?: T | Thenable<T>) => void, reject: (error?: any) => void) => void);
 
 	/**
 	 * onFulfilled is called when/if "promise" resolves. onRejected is called when/if "promise" rejects.
@@ -29,8 +29,8 @@ declare class Promise<R> implements Thenable<R> {
 	 * @param onFulfilled called when/if "promise" resolves
 	 * @param onRejected called when/if "promise" rejects
 	 */
-    then<U>(onFulfilled?: (value: R) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>): Promise<U>;
-    then<U>(onFulfilled?: (value: R) => U | Thenable<U>, onRejected?: (error: any) => void): Promise<U>;
+    then<U>(onFulfilled?: (value: T) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>): Promise<U>;
+    then<U>(onFulfilled?: (value: T) => U | Thenable<U>, onRejected?: (error: any) => void): Promise<U>;
 
 	/**
 	 * Sugar for promise.then(undefined, onRejected)
@@ -45,7 +45,7 @@ declare module Promise {
 	 * Make a new promise from the thenable.
 	 * A thenable is promise-like in as far as it has a "then" method.
 	 */
-	function resolve<R>(value?: R | Thenable<R>): Promise<R>;
+	function resolve<T>(value?: T | Thenable<T>): Promise<T>;
 
 	/**
 	 * Make a promise that rejects to obj. For consistency and debugging (eg stack traces), obj should be an instanceof Error
@@ -57,12 +57,12 @@ declare module Promise {
 	 * the array passed to all can be a mixture of promise-like objects and other objects.
 	 * The fulfillment value is an array (in order) of fulfillment values. The rejection value is the first rejection value.
 	 */
-	function all<R>(promises: (R | Thenable<R>)[]): Promise<R[]>;
+	function all<T>(promises: (T | Thenable<T>)[]): Promise<T[]>;
 
 	/**
 	 * Make a Promise that fulfills when any item fulfills, and rejects if any item rejects.
 	 */
-	function race<R>(promises: (R | Thenable<R>)[]): Promise<R>;
+	function race<T>(promises: (T | Thenable<T>)[]): Promise<T>;
 }
 
 declare module 'es6-promise' {


### PR DESCRIPTION
This fixes an issue where two definitions for Promise that /should/ agree
(i.e., be assignable to one another) aren't, and instead the immensely
confusing error message:

```
error TS2314: Generic type 'Promise<T, R>' requires 2 type argument(s).
```

Even though all the present definitions are paramaterized with a single type
variable, Typescript appears to assume that the two different names are
referring to two different types and therefore you must supply both. Here I
changed it to T from R so that it matches lib.d.ts.

For reference, this error occured for me specifically when I had both
es6-promise and bluebird typings present. bluebird uses T already.
