### PR TITLE
express.d.ts: define next() function type

### DIFF
--- a/express/express-tests.ts
+++ b/express/express-tests.ts
@@ -17,6 +17,12 @@ app.use(function(req, res, next){
     next();
 });
 
+app.use(function(err: any, req: express.Request, res: express.Response, next: express.NextFunction) {
+    console.error(err);
+    next(err);
+});
+
+
 app.get('/', function(req, res){
     res.send('hello world');
 });
@@ -46,6 +52,13 @@ router.route('/users')
     .get((req, res, next) => {
         res.send(req.query['token']);
     });
+
+router.get('/user/:id', function(req, res, next) {
+    if (req.params.id == 0) next('route');
+    else next();
+}, function(req, res, next) {
+    res.render('regular');
+});
 
 app.use((req, res, next) => {
     // hacky trick, router is just a handler

--- a/express/express.d.ts
+++ b/express/express.d.ts
@@ -407,9 +407,9 @@ declare module "express" {
             originalUrl: string;
 
             url: string;
-            
+
             baseUrl: string;
-            
+
             app: Application;
         }
 
@@ -796,18 +796,23 @@ declare module "express" {
             charset: string;
         }
 
+        interface NextFunction {
+            (): void;
+            (err: any): void;
+        }
+
         interface ErrorRequestHandler {
-            (err: any, req: Request, res: Response, next: Function): any;
+            (err: any, req: Request, res: Response, next: NextFunction): any;
         }
 
         interface RequestHandler {
-            (req: Request, res: Response, next: Function): any;
+            (req: Request, res: Response, next: NextFunction): any;
         }
 
         interface Handler extends RequestHandler {}
 
         interface RequestParamHandler {
-            (req: Request, res: Response, next: Function, param: any): any;
+            (req: Request, res: Response, next: NextFunction, param: any): any;
         }
 
         interface Application extends IRouter<Application>, Express.Application {


### PR DESCRIPTION
In express.d.ts the `next` function in `RequestHandler` and `ErrorRequestHandler` was simply defined as `Function`. This PR is to define `next` function precisely.

According to Express document, there are three use cases of `next()`:

``` js
next();
next(err);
next('route');
```
