### PR TITLE
Change type of IFieldConfigurationObject.elementAttributes to hash

### DIFF
--- a/angular-formly/angular-formly.d.ts
+++ b/angular-formly/angular-formly.d.ts
@@ -198,7 +198,9 @@ declare module AngularFormly {
 		className?: string;
 
 
-		elementAttributes?: string;
+		elementAttributes?: {
+			[key: string]: string;
+		};
 
 
 		/**


### PR DESCRIPTION
Formly requires this property to be an object. A string value causes ApiCheck to throw.
