### PR TITLE
Fixes compilation error

### DIFF
--- a/redux-router/redux-router.d.ts
+++ b/redux-router/redux-router.d.ts
@@ -16,10 +16,6 @@ declare namespace __ReduxRouter {
     */
     export class ReduxRouter extends React.Component<any, any> { }
     /**
-    * A component that renders a React Router app using router state from a Redux store.
-    */
-    export class ReactRouter { }
-    /**
     * A Redux store enhancer that adds router state to the store.
     */
     export var reduxReactRouter: any;
@@ -46,7 +42,8 @@ declare module "redux-router/lib/routerStateReducer" {
 }
 
 declare module "redux-router/lib/ReduxRouter" {
-    export default __ReduxRouter.ReactRouter;
+    import Router from "react-router";
+    export default Router;
 }
 
 declare module "redux-router/lib/client" {


### PR DESCRIPTION
When importing the `ReduxRouter`:

```
/// <reference path="../../interfaces/interfaces.d.ts" />

import * as React from 'react';
import { Provider } from 'react-redux';
import { ReduxRouter } from 'redux-router';
import configureStore from "../../store/configureStore.ts";

const store = configureStore();

class Root extends React.Component<any,any> {

  constructor(props) {
    super(props);
  }

  render() {
    return (
      <Provider store={store}>
        <ReduxRouter />
      </Provider>
    )
  }
}

export default Root;
```

There was a compilation error on `<ReduxRouter />` because `ReactRouter` is not a JSX element and has no render method.

This was caused because original file contained:

```
/**
* A component that renders a React Router app using router state from a Redux store.
*/
export class ReactRouter { }
```

The exported `ReactRouter` class is empty but it is supposed to be the `ReactRouter`. 

I removed the empty class and exported the the `ReactRouter` instead:

```
declare module "redux-router/lib/ReduxRouter" {
    import Router from "react-router";
    export default Router;
}
```
