### PR TITLE
Fix #7979, request.d.ts : Options union types

### DIFF
--- a/request/request-tests.ts
+++ b/request/request-tests.ts
@@ -110,6 +110,15 @@ var options: request.Options = {
 	strictSSL: bool
 };
 
+// Below line has compile error, use OptionsWithUri or OptionsWithUrl instead. See #7979.
+// options.uri = str;
+
+const opt: request.OptionsWithUri = {
+  baseUrl: 'http://localhost',
+  uri: 'bar'
+};
+opt.uri = str;
+
 // --- --- --- --- --- --- --- --- --- --- --- ---
 
 agent = req.getAgent();

--- a/request/request.d.ts
+++ b/request/request.d.ts
@@ -125,7 +125,10 @@ declare module 'request' {
 			uri?: string;
 			url?: string;
 		}
-		export type Options = RequiredUriUrl & CoreOptions;
+
+        export type OptionsWithUri = UriOptions & CoreOptions;
+        export type OptionsWithUrl = UrlOptions & CoreOptions;
+        export type Options = OptionsWithUri | OptionsWithUrl;
 
 		export interface RequestCallback {
 			(error: any, response: http.IncomingMessage, body: any): void;


### PR DESCRIPTION
@joeskeen I didn't remove `type RequiredUriUrl = UriOptions | UrlOptions` because it was exported.
