### PR TITLE
Atom: Add isTextEditor method to IWorkspace

### DIFF
--- a/atom/atom.d.ts
+++ b/atom/atom.d.ts
@@ -1100,6 +1100,7 @@ declare module AtomCore {
 		itemOpened(item:any):void;
 		onPaneItemDestroyed(item:any):void;
 		destroyed():void;
+		isTextEditor(object: any): boolean;
 
 		onDidChangeActivePaneItem(item:any):Disposable;
 	}


### PR DESCRIPTION
Documentation on this method is [here](https://atom.io/docs/api/v1.4.3/Workspace#instance-isTextEditor).
