### PR TITLE
Fixes typing for 1.5.0 components and tightens typings for directives

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1710,7 +1710,7 @@ declare module angular {
          * Define DOM attribute binding to component properties. Component properties are always bound to the component
          * controller and not to the scope.
          */
-        bindings?: Object;
+        bindings?: any;
         /**
          * Whether transclusion is enabled. Enabled by default.
          */
@@ -1766,7 +1766,7 @@ declare module angular {
         name?: string;
         priority?: number;
         replace?: boolean;
-        require? : string | Array<string>;
+        require? : any;
         restrict?: string;
         scope?: any;
         template?: string | Function;

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1715,7 +1715,7 @@ declare module angular {
          * Whether transclusion is enabled. Enabled by default.
          */
         transclude?: boolean;
-        require? : string | Array<string>;
+        require? : {};
         $canActivate?: () => boolean;
         $routeConfig?: RouteDefinition[];
     }

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1685,7 +1685,7 @@ declare module angular {
          * Controller constructor function that should be associated with newly created scope or the name of a registered
          * controller if passed as a string. Empty function by default.
          */
-        controller?: string | Function;
+        controller?: any;
         /**
          * An identifier name for a reference to the controller. If present, the controller will be published to scope under
          * the controllerAs name. If not present, this will default to be the same as the component name.

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1710,20 +1710,12 @@ declare module angular {
          * Define DOM attribute binding to component properties. Component properties are always bound to the component
          * controller and not to the scope.
          */
-        bindings?: any;
+        bindings?: Object;
         /**
          * Whether transclusion is enabled. Enabled by default.
          */
         transclude?: boolean;
-        /**
-         * Whether the new scope is isolated. Isolated by default.
-         */
-        isolate?: boolean;
-        /**
-         * String of subset of EACM which restricts the component to specific directive declaration style. If omitted,
-         * this defaults to 'E'.
-         */
-        restrict?: string;
+        require? : string | Array<string>;
         $canActivate?: () => boolean;
         $routeConfig?: RouteDefinition[];
     }
@@ -1774,12 +1766,12 @@ declare module angular {
         name?: string;
         priority?: number;
         replace?: boolean;
-        require?: any;
+        require? : string | Array<string>;
         restrict?: string;
         scope?: any;
-        template?: any;
+        template?: string | Function;
         templateNamespace?: string;
-        templateUrl?: any;
+        templateUrl?: string | Function;
         terminal?: boolean;
         transclude?: any;
     }

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1715,7 +1715,7 @@ declare module angular {
          * Whether transclusion is enabled. Enabled by default.
          */
         transclude?: boolean;
-        require? : {};
+        require? : Object;
         $canActivate?: () => boolean;
         $routeConfig?: RouteDefinition[];
     }


### PR DESCRIPTION
As per https://docs.angularjs.org/guide/component

components does not support 'restrict' or 'isolate' but they do 'require'.

Also I added few restrictions on IDirective.
