### PR TITLE
Lovefield.d.ts : the timing option in RawForeignKeySpec type is wrong

### DIFF
--- a/angularjs-toaster/angularjs-toaster.d.ts
+++ b/angularjs-toaster/angularjs-toaster.d.ts
@@ -16,7 +16,7 @@ declare module ngtoaster {
     error(params: IPopParams): void
     error(title?:string, body?:string, timeout?:number, bodyOutputType?:string, clickHandler?:EventListener,
         toasterId?:number): void
-    into(params: IPopParams): void
+    info(params: IPopParams): void
     info(title?:string, body?:string, timeout?:number, bodyOutputType?:string, clickHandler?:EventListener,
         toasterId?:number): void
     wait(params: IPopParams): void

--- a/request-promise/request-promise.d.ts
+++ b/request-promise/request-promise.d.ts
@@ -22,7 +22,7 @@ declare module 'request-promise' {
     module RequestPromiseAPI {
         export interface Options extends request.Options {
             simple?: boolean;
-            transform?: (body: any, response: http.IncomingMessage) => number;
+            transform?: (body: any, response: http.IncomingMessage) => any;
             resolveWithFullResponse?: boolean;
         }
     }


### PR DESCRIPTION
Actually, in RawForeignKeySpec, the options "action" and "timing" are both of type ConstraintAction. The "timing" option should be of type "ConstraintTiming" like this:

type RawForeignKeySpec = {
local: string
ref: string
action: lf.ConstraintAction
timing: lf.ConstraintTiming
}
