### PR TITLE
mongoose -- fix model constructor

### DIFF
--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -178,7 +178,7 @@ declare module "mongoose" {
   }
 
   export interface Model<T extends Document> extends NodeJS.EventEmitter {
-    new(doc?: Object): T;
+    new(doc?: Object, fields?: Object, skipInit?: boolean): T;
 
     aggregate(...aggregations: Object[]): Aggregate<T[]>;
     aggregate(aggregation: Object, callback: (err: any, res: T[]) => void): Promise<T[]>;


### PR DESCRIPTION
Mongoose describes model constructor with three arguments.
See https://github.com/Automattic/mongoose/blob/3.8.5/lib/model.js
