### PR TITLE
angular.IRoute.controller can be defined as array

### DIFF
--- a/angularjs/angular-route-tests.ts
+++ b/angularjs/angular-route-tests.ts
@@ -1,3 +1,4 @@
+/// <reference path="angular.d.ts" />
 /// <reference path="angular-route.d.ts" />
 
 /**
@@ -28,6 +29,14 @@ $routeProvider
     })
     .when('/projects/:projectId/dashboard4', {
         controller: 'I am a string',
+        templateUrl: function ($routeParams?: ng.route.IRouteParamsService) {
+            return "I return a string"
+        }
+    })
+    .when('/projects/:projectId/dashboard5', {
+        controller: ['$log',function($log:ng.ILogService){
+            $log.info('I am array')
+        }],
         templateUrl: function ($routeParams?: ng.route.IRouteParamsService) {
             return "I return a string"
         }

--- a/angularjs/angular-route.d.ts
+++ b/angularjs/angular-route.d.ts
@@ -47,6 +47,7 @@ declare module angular.route {
 
     }
 
+    type InlineAnnotatedFunction = Function|Array<string|Function>
 
     /**
      * see http://docs.angularjs.org/api/ngRoute/provider/$routeProvider#when for API documentation
@@ -56,7 +57,7 @@ declare module angular.route {
          * {(string|function()=}
          * Controller fn that should be associated with newly created scope or the name of a registered controller if passed as a string.
          */
-        controller?: string|Function;
+        controller?: string|InlineAnnotatedFunction;
         /**
          * A controller alias name. If present the controller will be published to scope under the controllerAs name.
          */


### PR DESCRIPTION
This is minor change. The point is that controller in definition of route can be not only string or function but also whole injectable array
