### PR TITLE
Changes required to IComponentOptions for AngularJS 1.5.0 release.

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1712,18 +1712,13 @@ declare module angular {
          */
         bindings?: any;
         /**
-         * Whether transclusion is enabled. Enabled by default.
+         * Whether transclusion is enabled. Also allow for transclude definition object for multislot transclusion.
          */
-        transclude?: boolean;
+        transclude?: any;
         /**
-         * Whether the new scope is isolated. Isolated by default.
+         * Allow require of directive controller.
          */
-        isolate?: boolean;
-        /**
-         * String of subset of EACM which restricts the component to specific directive declaration style. If omitted,
-         * this defaults to 'E'.
-         */
-        restrict?: string;
+        require?: any;
         $canActivate?: () => boolean;
         $routeConfig?: RouteDefinition[];
     }


### PR DESCRIPTION
In AngularJS 1.5.0 there are a few changes to the component interface as opposed to 1.5.0-RC.0:
- Scope is fixed as isolate.
- Restrict is fixed as Element

Also, in AngularJS 1.5 transclude can also accept a configuration object to support multislot transclusion.

And require was missing.

Changes made:
- removal of restrict and scope as they are now hard set to 'E' and isolate.
- addition of require
- change of transclude type to any to allow for multislot transclusion configuration object
