### PR TITLE
controller field in IComponentOptions

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1685,7 +1685,7 @@ declare module angular {
          * Controller constructor function that should be associated with newly created scope or the name of a registered
          * controller if passed as a string. Empty function by default.
          */
-        controller?: string | Function;
+        controller?: any;
         /**
          * An identifier name for a reference to the controller. If present, the controller will be published to scope under
          * the controllerAs name. If not present, this will default to be the same as the component name.


### PR DESCRIPTION
Controller field in a component can accept string, function or an array with parameters and function ["service1","service2", ControllerFunction]

I think that controller field in IComponentOptions file has to be of any type, like a controller field in IDirective.
