### PR TITLE
Add overload for nconf

### DIFF
--- a/nconf/nconf-tests.ts
+++ b/nconf/nconf-tests.ts
@@ -36,6 +36,7 @@ p = nconf.env();
 p = nconf.env(opts);
 
 p = nconf.file(str);
+p = nconf.file(str, str);
 p = nconf.file(str, fopts);
 p = nconf.file(fopts);
 p = nconf.file({

--- a/nconf/nconf.d.ts
+++ b/nconf/nconf.d.ts
@@ -25,6 +25,7 @@ declare module "nconf" {
 	export function argv(options?: IOptions): Provider;
 	export function env(options?: IOptions): Provider;
 	export function file(name: string, options?: IFileOptions): Provider;
+	export function file(key: string, name: string): Provider;
 	export function file(options: IFileOptions): Provider;
 	export function use(name: string, options?: IOptions): Provider;
 	export function defaults(options?: IOptions): Provider;


### PR DESCRIPTION
Adds an overload for `nconf.file('key', '/path/to/file')`. See [here](https://github.com/indexzero/nconf#file) for reference in the nconf documentation.
