### PR TITLE
Missing "require" property on IComponentOptions

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1707,6 +1707,10 @@ declare module angular {
          */
         templateUrl?: string | Function;
         /**
+         * Define object mapping to other directive or component required controllers.
+         */
+        require?: any;
+        /**
          * Define DOM attribute binding to component properties. Component properties are always bound to the component
          * controller and not to the scope.
          */


### PR DESCRIPTION
Added missing require property on IComponentOptions
