### PR TITLE
Proxyquire uses a fluent api

### DIFF
--- a/proxyquire/proxyquire.d.ts
+++ b/proxyquire/proxyquire.d.ts
@@ -14,8 +14,8 @@ interface Proxyquire {
     noCallThru(): Proxyquire;
     callThru(): Proxyquire;
 
-    noPreserveCache(): void;
-    preserveCache(): void;
+    noPreserveCache(): Proxyquire;
+    preserveCache(): Proxyquire;
 }
 
 declare module 'proxyquire' {


### PR DESCRIPTION
All of its api configuration methods return an object with the `Proxyquire` type.
