### PR TITLE
yargs : Added the group() method

### DIFF
--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -244,6 +244,13 @@ function Argv$epilogue() {
   		.epilogue('for more information, find our manual at http://example.com');
 }
 
+function Argv$group() {
+	var argv = yargs
+		.boolean("justDoIt")
+		.group("justDoIt", "Flags :")
+		.string("what");
+}
+
 function Argv$reset() {
 	var ya = yargs
 		.usage('$0 command')

--- a/yargs/yargs.d.ts
+++ b/yargs/yargs.d.ts
@@ -93,6 +93,8 @@ declare module "yargs" {
 
 			epilog(msg: string): Argv;
 			epilogue(msg: string): Argv;
+			
+			group(key: string, groupName:string): Argv;
 
 			version(version: string, option?: string, description?: string): Argv;
 			version(version: () => string, option?: string, description?: string): Argv;


### PR DESCRIPTION
Note : due the recent change of .gitattributes/text = auto, all line endings are changed from CRLF to LF. That's why all lines are signaled as different in compare.
