### PR TITLE
[react-dnd] added types for collector functions (DragSource, DragTarget, DragLayer)

### DIFF
--- a/react-dnd/react-dnd.d.ts
+++ b/react-dnd/react-dnd.d.ts
@@ -38,14 +38,14 @@ declare module __ReactDnd {
     export function DragSource<P>(
         type: Identifier | ((props: P) => Identifier),
         spec: DragSourceSpec<P>,
-        collect: (connect: DragSourceConnector, monitor: DragSourceMonitor) => Object,
+        collect: DragSourceCollector,
         options?: DndOptions<P>
     ): (componentClass: React.ComponentClass<P>) => DndComponentClass<P>;
 
     export function DropTarget<P>(
         types: Identifier | Identifier[] | ((props: P) => Identifier | Identifier[]),
         spec: DropTargetSpec<P>,
-        collect: (connect: DropTargetConnector, monitor: DropTargetMonitor) => Object,
+        collect: DropTargetCollector,
         options?: DndOptions<P>
     ): (componentClass: React.ComponentClass<P>) => DndComponentClass<P>;
 
@@ -54,9 +54,13 @@ declare module __ReactDnd {
     ): (componentClass: React.ComponentClass<P>) => ContextComponentClass<P>;
 
     export function DragLayer<P>(
-        collect: (monitor: DragLayerMonitor) => Object,
+        collect: DragLayerCollector,
         options?: DndOptions<P>
     ): (componentClass: React.ComponentClass<P>) => DndComponentClass<P>;
+
+    type DragSourceCollector = (connect: DragSourceConnector, monitor: DragSourceMonitor) => Object;
+    type DropTargetCollector = (connect: DropTargetConnector, monitor: DropTargetMonitor) => Object;
+    type DragLayerCollector = (monitor: DragLayerMonitor) => Object;
 
     // Shared
     // ----------------------------------------------------------------------


### PR DESCRIPTION
I added distinct type definitions for the three types of collector functions that are used by the library.
This helps with type inference when declaring instances of those function types.

Without defined collector types, there is no type information for the function arguments:
![image](https://cloud.githubusercontent.com/assets/394294/13034242/8ca99b7a-d330-11e5-871e-2733517f68a2.png)

With the collector types in place, the type inference can do its work and tell us the correct types of the function arguments:
![image](https://cloud.githubusercontent.com/assets/394294/13034243/90edecd6-d330-11e5-9535-2d8bd1998784.png)

Regards,
Wolfgang
