### PR TITLE
amqplib -- add missed property to AssertQueue interface

### DIFF
--- a/amqplib/amqplib.d.ts
+++ b/amqplib/amqplib.d.ts
@@ -38,6 +38,7 @@ declare module "amqplib/properties" {
             messageTtl?: number;
             expires?: number;
             deadLetterExchange?: string;
+            deadLetterRoutingKey?: string;
             maxLength?: number;
         }
         interface DeleteQueue {


### PR DESCRIPTION
There isn't a property «deadLetterRoutingKey» in current (amqplib.d.ts) AssertQueue interface.
See http://www.squaremobius.net/amqp.node/channel_api.html#channel_assertQueue
