### PR TITLE
Fix chrome.sockets.tcp.getSockets

### DIFF
--- a/chrome/chrome-app-tests.ts
+++ b/chrome/chrome-app-tests.ts
@@ -283,7 +283,7 @@ function test_socketsTcpServer(): void {
     chrome.sockets.udp.getInfo(socketId, (info: chrome.sockets.udp.SocketInfo) => { });
 
     // getSockets
-    chrome.sockets.tcp.getSockets(socketId, (infos: chrome.sockets.tcp.SocketInfo[]) => { });
+    chrome.sockets.tcp.getSockets((infos: chrome.sockets.tcp.SocketInfo[]) => { });
 }
 
 function test_socketsTcpServerEvents(): void {

--- a/chrome/chrome-app-tests.ts
+++ b/chrome/chrome-app-tests.ts
@@ -117,7 +117,7 @@ function test_socketsTcp(): void {
     chrome.sockets.tcp.getInfo(socketId, (info: chrome.sockets.tcp.SocketInfo) => { });
 
     // getSockets
-    chrome.sockets.tcp.getSockets(socketId, (infos: chrome.sockets.tcp.SocketInfo[]) => { });
+    chrome.sockets.tcp.getSockets((infos: chrome.sockets.tcp.SocketInfo[]) => { });
 }
 
 function test_socketsTcpEvents(): void {

--- a/chrome/chrome-app.d.ts
+++ b/chrome/chrome-app.d.ts
@@ -258,7 +258,7 @@ declare module chrome.sockets.tcp {
     export function send(socketId: number, data: ArrayBuffer, callback: (sendInfo: SendInfo) => void): void;
     export function close(socketId: number, callback?: () => void): void;
     export function getInfo(socketId: number, callback: (socketInfo: SocketInfo) => void): void;
-    export function getSockets(socketId: number, callback: (socketInfos: SocketInfo[]) => void): void;
+    export function getSockets(callback: (socketInfos: SocketInfo[]) => void): void;
 
     var onReceive: Event<ReceiveEventArgs>;
     var onReceiveError: Event<ReceiveErrorEventArgs>;


### PR DESCRIPTION
It doesn't accept socketId argument, but returns list of all the opened sockets.
