### PR TITLE
Optimist parity

### DIFF
--- a/optimist/optimist-tests.ts
+++ b/optimist/optimist-tests.ts
@@ -2,45 +2,48 @@
 
 import optimist = require('optimist');
 
-var fn: Function;
+var checkFn: (argv: any) => any;
+var logFn: (message: string) => void;
 var str: string;
 var value: any;
 var num: number;
-var bool: boolean;
-var strArr: string[];
 
-var argv: optimist.Argv;
-var opt: optimist.Optimist;
+var argv: any;
+var opt: optimist.Opt;
+var parser: optimist.Parser;
 
-argv = opt.argv;
-argv = opt.argv;
-argv = optimist(strArr).argv;
+argv = parser.argv;
+argv = optimist([str]);
+argv = optimist.parse([str]);
 
-opt = optimist(strArr).default(str, value);
-opt = optimist(strArr).default({});
+parser = parser.alias(str, str);
+parser = parser.alias(str, [str]);
+parser = parser.alias({});
 
-opt = optimist(strArr).boolean(str);
-opt = optimist(strArr).boolean(strArr);
+parser = parser.default(str, value);
+parser = parser.default({});
 
-opt = optimist(strArr).string(str);
-opt = optimist(strArr).string(strArr);
+parser = parser.demand(str);
+parser = parser.demand(num);
+parser = parser.demand([str]);
 
-opt = opt.wrap(num);
+parser = parser.describe(str, str);
+parser = parser.describe({});
 
-opt.help();
-opt.showHelp(fn);
+parser = parser.options(str, opt);
+parser = parser.options({});
 
-opt = opt.usage(str);
+parser = parser.usage(str);
 
-opt = opt.demand(str);
-opt = opt.demand(num);
-opt = opt.demand(strArr);
+parser.check(checkFn);
 
-opt = opt.alias(str, str);
+parser = parser.boolean(str);
+parser = parser.boolean([str]);
 
-opt = opt.describe(str, str);
+parser = parser.string(str);
+parser = parser.string([str]);
 
-opt = opt.options(str, Object);
+parser = parser.wrap(num);
 
-opt.check(fn);
-opt = opt.parse(strArr);
+parser.help();
+parser.showHelp(logFn);

--- a/optimist/optimist-tests.ts
+++ b/optimist/optimist-tests.ts
@@ -35,7 +35,7 @@ parser = parser.options({});
 
 parser = parser.usage(str);
 
-parser.check(checkFn);
+parser = parser.check(checkFn);
 
 parser = parser.boolean(str);
 parser = parser.boolean([str]);

--- a/optimist/optimist.d.ts
+++ b/optimist/optimist.d.ts
@@ -1,53 +1,89 @@
 // Type definitions for optimist
 // Project: https://github.com/substack/node-optimist
-// Definitions by: Carlos Ballesteros Velasco <https://github.com/soywiz>
-// Definitions: https://github.com/borisyankov/DefinitelyTyped
-
-// Imported from: https://github.com/soywiz/typescript-node-definitions/optimist.d.ts
+// Definitions by: Carlos Ballesteros Velasco <https://github.com/soywiz>, Christopher Brown <https://github.com/chbrown>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module "optimist" {
 
-	function optimist(args: string[]): optimist.Optimist;
-
 	module optimist {
-		export interface Optimist {
-			default(name: string, value: any): Optimist;
-			default(args: Object): Optimist;
-
-			boolean(name: string): Optimist;
-			boolean(names: string[]): Optimist;
-
-			string(name: string): Optimist;
-			string(names: string[]): Optimist;
-
-			wrap(columns: number): Optimist;
-
-			help(): void;
-			showHelp(fn?: Function): void;
-
-			usage(message: string): Optimist;
-
-			demand(key: string): Optimist;
-			demand(key: number): Optimist;
-			demand(key: string[]): Optimist;
-
-			alias(key: string, alias: string): Optimist;
-
-			describe(key: string, desc: string): Optimist;
-
-			options(key: string, opt: Object): Optimist;
-
-			check(fn: Function): void;
-
-			parse(args: string[]): Optimist;
-
-			argv: Argv;
+		interface Opt {
+			alias?: string | string[];
+			default?: any;
+			demand?: string | number | string[];
+			describe?: string;
+			type?: string;
 		}
 
-		export interface Argv extends Object {
-			_: string[];
+		interface Parser {
+			/** Implicitly use process.argv array to construct the argv object */
+			argv: any;
+			/** Pass in the process.argv yourself */
+			(args: string[]): any;
+			/** Use .parse() to do the same thing as treating optimist as a function */
+			parse(args: string[]): any;
+
+			// The types below follow the order and documentation of https://github.com/substack/node-optimist
+
+			/** Set key names as equivalent such that updates to a key will propagate to aliases and vice-versa. */
+			alias(key: string, alias: string | string[]): Parser;
+			/** Take an object that maps keys to aliases. */
+			alias(aliases: {[index: string]: string | string[]}): Parser;
+
+			/** Set argv[key] to value if no option was specified on process.argv */
+			default(key: string, value: any): Parser;
+			/** Take an object that maps keys to default values */
+			default(defaults: {[index: string]: any}): Parser;
+
+			/** Show the usage information and exit if key wasn't specified in process.argv */
+			demand(key: string): Parser;
+			/** Demand at least as many non-option arguments, which show up in argv._ */
+			demand(key: number): Parser;
+			/** Demand each element in key */
+			demand(key: string[]): Parser;
+
+			/** Describe a key for the generated usage information */
+			describe(key: string, desc: string): Parser;
+			/** Take an object that maps keys to descriptions */
+			describe(descriptions: {[index: string]: string}): Parser;
+
+			/** Instead of chaining together, e.g. optimist.alias().demand().default()...,
+			you can specify keys in opt for each of the chainable methods. */
+			options(key: string, opt: Opt): Parser;
+			/** Take an object that maps keys to opt parameters */
+			options(options: {[index: string]: Opt}): Parser;
+
+			/** Set a usage message to show which commands to use. Inside message,
+			the string $0 will get interpolated to the current script name or node
+			command for the present script similar to how $0 works in bash or perl. */
+			usage(message: string): Parser;
+
+			/** Check that certain conditions are met in the provided arguments. If fn
+			throws or returns false, show the thrown error, usage information, and exit.
+			*/
+			check(fn: (argv: any) => any): void;
+
+			/** Interpret key as a boolean. If a non-flag option follows key in process.argv,
+			that string won't get set as the value of key. If key never shows up as a
+			flag in process.arguments, argv[key] will be false. */
+			boolean(key: string): Parser;
+			/** Interpret all the elements as booleans. */
+			boolean(key: string[]): Parser;
+
+			/** Tell the parser logic not to interpret key as a number or boolean. This can be useful if you need to preserve leading zeros in an input. */
+			string(key: string): Parser;
+			/** Interpret all the elements as strings */
+			string(key: string[]): Parser;
+
+			/** Format usage output to wrap at columns many columns. */
+			wrap(columns: number): Parser;
+
+			/** Return the generated usage string. */
+			help(): string;
+			/** Print the usage data using fn for printing (defaults to console.error). */
+			showHelp(fn?: (message: string) => void): void;
 		}
 	}
 
+	var optimist: optimist.Parser;
 	export = optimist;
 }

--- a/optimist/optimist.d.ts
+++ b/optimist/optimist.d.ts
@@ -60,7 +60,7 @@ declare module "optimist" {
 			/** Check that certain conditions are met in the provided arguments. If fn
 			throws or returns false, show the thrown error, usage information, and exit.
 			*/
-			check(fn: (argv: any) => any): void;
+			check(fn: (argv: any) => any): Parser;
 
 			/** Interpret key as a boolean. If a non-flag option follows key in process.argv,
 			that string won't get set as the value of key. If key never shows up as a


### PR DESCRIPTION
yargs is the successor to optimist, and its type declarations are better. This PR models optimist's declarations like yargs's, while much more closely following the optimist docs: https://github.com/substack/node-optimist
