### PR TITLE
chai: enable chain style calling to use()

### DIFF
--- a/chai/chai-tests.ts
+++ b/chai/chai-tests.ts
@@ -1097,6 +1097,12 @@ function use() {
     chai.use((_chai) => {
         _chai.can.use.any();
     });
+
+    // chain style: use mulptile plug-ins
+    let expect = chai
+        .use((_chai, util) => {})
+        .use((_chai, util) => {})
+        .expect;
 }
 
 class Klass {

--- a/chai/chai.d.ts
+++ b/chai/chai.d.ts
@@ -17,7 +17,7 @@ declare module Chai {
         /**
          * Provides a way to extend the internals of Chai
          */
-        use(fn: (chai: any, utils: any) => void): any;
+        use(fn: (chai: any, utils: any) => void): ChaiStatic;
         assert: AssertStatic;
         config: Config;
         AssertionError: typeof AssertionError;


### PR DESCRIPTION
Declare `use()` return type to enable chain style calling.

``` js
const expect = chai.use(sinonChai).expect;
```

instead of

``` js
chai.use(sinonChai);
const expect = chai.expect;
```
