### PR TITLE
Fix nconf method unavailable while chaining

### DIFF
--- a/nconf/nconf-tests.ts
+++ b/nconf/nconf-tests.ts
@@ -97,6 +97,7 @@ p = p.argv(opts);
 p = p.env();
 p = p.env(opts);
 p = p.file(str);
+p = p.file(str, str);
 p = p.file(str, fopts);
 p = p.file(fopts);
 p = p.file({

--- a/nconf/nconf.d.ts
+++ b/nconf/nconf.d.ts
@@ -25,7 +25,7 @@ declare module "nconf" {
 	export function argv(options?: IOptions): Provider;
 	export function env(options?: IOptions): Provider;
 	export function file(name: string, options?: IFileOptions): Provider;
-	export function file(key: string, name: string): Provider;
+	export function file(name: string, filename: string): Provider;
 	export function file(options: IFileOptions): Provider;
 	export function use(name: string, options?: IOptions): Provider;
 	export function defaults(options?: IOptions): Provider;
@@ -49,8 +49,8 @@ declare module "nconf" {
 		parse: (str: string) => any;
 	}
 
-	export interface IOptions { 
-		[index: string]: any; 
+	export interface IOptions {
+		[index: string]: any;
 	}
 
 	export interface IFileOptions {
@@ -87,6 +87,7 @@ declare module "nconf" {
 		argv(options?: IOptions): Provider;
 		env(options?: IOptions): Provider;
 		file(name: string, options?: IFileOptions): Provider;
+		file(name: string, filename: string): Provider;
 		file(options: IFileOptions): Provider;
 		use(name: string, options?: IOptions): Provider;
 


### PR DESCRIPTION
Follow up for #8047. In that PR I overlooked the fact that I had to add the new method in 2 places, to enable method chaining. This is fixed in this PR.

Also brings the naming for parameters in line with similar methods.
