### PR TITLE
Adding support for meteor-persistant-session.

### DIFF
--- a/meteor-persistent-session/meteor-persistent-session-tests.ts
+++ b/meteor-persistent-session/meteor-persistent-session-tests.ts
@@ -1,0 +1,19 @@
+/// <reference path="meteor-persistent-session.d.ts" />
+
+Session.setTemp('a', 'a');
+Session.setPersistent('a', 'a');
+Session.setAuth('a', 'a');
+
+Session.setDefaultTemp('a', 'a');
+Session.setDefaultPersistent('a', 'a');
+Session.setDefaultAuth('a', 'a');
+
+Session.makeTemp('a');
+Session.makePersistent('a');
+Session.makeAuth('a');
+
+Session.clear();
+Session.clear('a');
+Session.clearTemp();
+Session.clearPersistent();
+Session.clearAuth();

--- a/meteor-persistent-session/meteor-persistent-session.d.ts
+++ b/meteor-persistent-session/meteor-persistent-session.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for u2622:persistent-session
+// Project: https://github.com/okgrow/meteor-persistent-session
+// Definitions by: Robbie Van Gorkom <https://github.com/vangorra>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../meteor/meteor.d.ts" />
+
+declare module Session {
+    function setTemp(key: string, value: string | number | boolean | any /** Null **/ | any /** Undefined **/): boolean;
+    function setPersistent(key: string, value: string | number | boolean | any /** Null **/ | any /** Undefined **/): boolean;
+    function setAuth(key: string, value: string | number | boolean | any /** Null **/ | any /** Undefined **/): boolean;
+
+    function setDefaultTemp(key: string, value: EJSONable | any /** Undefined **/): void;
+    function setDefaultPersistent(key: string, value: EJSONable | any /** Undefined **/): void;
+    function setDefaultAuth(key: string, value: EJSONable | any /** Undefined **/): void;
+
+    function makeTemp(key: string) : void;
+    function makePersistent(key: string) : void;
+    function makeAuth(key: string) : void;
+
+    function clear() : void;
+    function clear(key: string) : void;
+    function clearTemp() : void;
+    function clearPersistent() : void;
+    function clearAuth() : void;
+}


### PR DESCRIPTION
This is a meteor AtmosphereJS package and does not exist on npm.
