### PR TITLE
[react-bootstrap] add Collapse component typing

### DIFF
--- a/react-bootstrap/react-bootstrap-tests.tsx
+++ b/react-bootstrap/react-bootstrap-tests.tsx
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------------
 import * as React from 'react';
 import { Component, CSSProperties } from 'react';
-import { Button, ButtonToolbar, Modal, Well, ButtonGroup, DropdownButton, MenuItem, Panel, ListGroup, ListGroupItem, Accordion, Tooltip, OverlayTrigger, Popover, ProgressBar, Nav, NavItem, Navbar, NavDropdown, Tabs, Tab, Pager, PageItem, Pagination, Alert, Carousel, CarouselItem, Grid, Row, Col, Thumbnail, Label, Badge, Jumbotron, PageHeader, Glyphicon, Table, Input, ButtonInput } from 'react-bootstrap';
+import { Button, ButtonToolbar, Modal, Well, ButtonGroup, DropdownButton, MenuItem, Panel, ListGroup, ListGroupItem, Accordion, Tooltip, OverlayTrigger, Popover, ProgressBar, Nav, NavItem, Navbar, NavDropdown, Tabs, Tab, Pager, PageItem, Pagination, Alert, Carousel, CarouselItem, Grid, Row, Col, Thumbnail, Label, Badge, Jumbotron, PageHeader, Glyphicon, Table, Input, ButtonInput, Collapse, Fade } from 'react-bootstrap';
 
 
 export class ReactBootstrapTest extends Component<any, any> {
@@ -899,6 +899,24 @@ export class ReactBootstrapTest extends Component<any, any> {
                       </Col>
                     </Row>
                   </Input>
+                </div>
+
+                <div style={style}>
+                    <Collapse in={this.state.collapseTestIn}>
+                        I am collapsed
+                    </Collapse>
+                    <Button onClick={() => this.setState({ collapseTestIn: !this.state.collapseTestIn })}>
+                        Collapse toggle
+                    </Button>
+                </div>
+
+                <div style={style}>
+                    <Fade in={this.state.fadeTestIn}>
+                        I am collapsed
+                    </Fade>
+                    <Button onClick={() => this.setState({ fadeTestIn: !this.state.fadeTestIn })}>
+                        Fade toggle
+                    </Button>
                 </div>
             </div>
         );

--- a/react-bootstrap/react-bootstrap.d.ts
+++ b/react-bootstrap/react-bootstrap.d.ts
@@ -1,12 +1,12 @@
-// Type definitions for react-bootstrap 
+// Type definitions for react-bootstrap
 // Project: https://github.com/react-bootstrap/react-bootstrap
 // Definitions by: Walker Burgin <https://github.com/walkerburgin>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 ///<reference path="../react/react.d.ts"/>
-    
+
 declare module "react-bootstrap" {
-    // Import React 
+    // Import React
     import React = require("react");
 
 
@@ -25,7 +25,7 @@ declare module "react-bootstrap" {
         navDropdown?: boolean;
         componentClass?: string;
         href?: string;
-        onClick?: Function; // Add more specific type 
+        onClick?: Function; // Add more specific type
         target?: string;
         type?: string;
     }
@@ -64,22 +64,22 @@ declare module "react-bootstrap" {
     interface ButtonGroup extends React.ReactElement<ButtonGroupProps> { }
     interface ButtonGroupClass extends  React.ComponentClass<ButtonGroupProps> { }
     var ButtonGroup: ButtonGroupClass;
-    
+
 
     // <DropdownButton />
     // ----------------------------------------
     interface DropdownButtonProps extends React.Props<DropdownButtonClass> {
         bsStyle?: string;
         bsSize?: string;
-        buttonClassName?: string; 
+        buttonClassName?: string;
         className?: string;
         dropup?: boolean;
         href?: string;
-        id?: string | number; 
+        id?: string | number;
         navItem?: boolean;
         noCaret?: boolean;
-        onClick?: Function;  // TODO: Add more specifc type 
-        onSelect?: Function; // TODO: Add more specific type 
+        onClick?: Function;  // TODO: Add more specifc type
+        onSelect?: Function; // TODO: Add more specific type
         pullRight?: boolean;
         title?: any; // TODO: Add more specific type
     }
@@ -90,7 +90,7 @@ declare module "react-bootstrap" {
 
     // <SplitButton />
     // ----------------------------------------
-    interface SplitButtonProps extends React.Props<SplitButtonClass>{ 
+    interface SplitButtonProps extends React.Props<SplitButtonClass>{
         bsStyle?: string;
         bsSize?: string;
         className?: string;
@@ -98,9 +98,9 @@ declare module "react-bootstrap" {
         dropdownTitle?: any; // TODO: Add more specific type
         dropup?: boolean;
         href?: string;
-        id?: string; 
-        onClick?: Function;  // TODO: Add more specific type 
-        onSelect?: Function; // TODO: Add more specific type 
+        id?: string;
+        onClick?: Function;  // TODO: Add more specific type
+        onSelect?: Function; // TODO: Add more specific type
         pullRight?: boolean;
         target?: string;
         title?: any; // TODO: Add more specific type
@@ -144,8 +144,8 @@ declare module "react-bootstrap" {
         footer?: any; // TODO: Add more specific type
         header?: any; // TODO: Add more specific type
         id?: string;
-        onSelect?: Function; // TODO: Add more specific type 
-        onClick?: Function; // TODO: Add more specific type 
+        onSelect?: Function; // TODO: Add more specific type
+        onClick?: Function; // TODO: Add more specific type
     }
     interface Panel extends React.ReactElement<PanelProps> { }
     interface PanelClass extends React.ComponentClass<PanelProps> { }
@@ -164,7 +164,7 @@ declare module "react-bootstrap" {
         footer?: any; // TODO: Add more specific type
         header?: any; // TODO: Add more specific type
         id?: string;
-        onSelect?: Function; // TODO: Add more specific type 
+        onSelect?: Function; // TODO: Add more specific type
     }
     interface Accordion extends React.ReactElement<AccordionProps> { }
     interface AccordionClass extends  React.ComponentClass<AccordionProps> { }
@@ -173,7 +173,7 @@ declare module "react-bootstrap" {
 
     // <PanelGroup />
     // ----------------------------------------
-    interface PanelGroupProps extends React.Props<PanelGroupClass> { 
+    interface PanelGroupProps extends React.Props<PanelGroupClass> {
         accordion?: boolean;
         activeKey?: any;
         bsSize?: string;
@@ -190,7 +190,7 @@ declare module "react-bootstrap" {
     // <Modal.Dialog />
     // ----------------------------------------
     interface ModalDialogProps extends React.Props<ModalDialogClass> {
-        // TODO: Add more specific type 
+        // TODO: Add more specific type
     }
     interface ModalDialog extends React.ReactElement<ModalDialogProps> { }
     interface ModalDialogClass extends React.ComponentClass<ModalHeaderProps> { }
@@ -306,7 +306,7 @@ declare module "react-bootstrap" {
         bsSize?: string;
         bsStyle?: string;
         className?: string;
-        id?: string; 
+        id?: string;
         placement?: string;
         positionLeft?: number;
         positionTop?: number;
@@ -326,7 +326,7 @@ declare module "react-bootstrap" {
         bsSize?: string;
         bsStyle?: string;
         className?: string;
-        id?: string; 
+        id?: string;
         placement?: string;
         positionLeft?: number;
         positionTop?: number;
@@ -384,7 +384,7 @@ declare module "react-bootstrap" {
 
     // <Nav />
     // ----------------------------------------
-    // TODO: This one turned into a union of two different types 
+    // TODO: This one turned into a union of two different types
     interface NavProps extends React.Props<NavClass> {
         // Optional
         activeHref?: string;
@@ -499,7 +499,7 @@ declare module "react-bootstrap" {
         Toggle: NavbarToggleClass;
     }
     var Navbar: NavbarClass;
-    
+
     // <NavBrand />
     // ----------------------------------------
     interface NavBrandProps {
@@ -526,13 +526,13 @@ declare module "react-bootstrap" {
     // <Tabs />
     // ----------------------------------------
     interface TabsProps extends React.Props<TabsClass> {
-        activeKey?: any; 
+        activeKey?: any;
         animation?: boolean;
         bsStyle?: string;
         defaultActiveKey?: any;
         id?: string | number;
         onSelect?: Function;
-        paneWidth?: any; // TODO: Add more specific type 
+        paneWidth?: any; // TODO: Add more specific type
         position?: string;
         tabWidth?: any; // TODO: Add more specific type
     }
@@ -571,7 +571,7 @@ declare module "react-bootstrap" {
     interface PageItemProps extends React.Props<PageItemClass> {
         className?: string;
         disabled?: boolean;
-        eventKey?: any; 
+        eventKey?: any;
         href?: string;
         next?: boolean;
         onSelect?: Function;
@@ -639,7 +639,7 @@ declare module "react-bootstrap" {
         pauseOnHover?: boolean;
         prevIcon?: any; // TODO: Add more specific type
         slide?: boolean;
-        wrap?: boolean;   
+        wrap?: boolean;
     }
     interface Carousel extends React.ReactElement<CarouselProps> { }
     interface CarouselClass extends React.ComponentClass<CarouselProps> { }
@@ -668,7 +668,7 @@ declare module "react-bootstrap" {
     interface GridProps extends React.Props<GridClass> {
         className?: string;
         componentClass?: any; // TODO: Add more specific type
-        fluid?: boolean; 
+        fluid?: boolean;
     }
     interface Grid extends React.ReactElement<GridProps> { }
     interface GridClass extends React.ComponentClass<GridProps> { }
@@ -712,7 +712,7 @@ declare module "react-bootstrap" {
         xsPull?: number;
         xsPush?: number;
     }
-    interface Col extends React.ReactElement<ColProps> { } 
+    interface Col extends React.ReactElement<ColProps> { }
     interface ColClass extends React.ComponentClass<ColProps> { }
     var Col: ColClass;
 
@@ -729,7 +729,7 @@ declare module "react-bootstrap" {
     }
     interface Thumbnail extends React.ReactElement<ThumbnailProps> { }
     interface ThumbnailClass extends React.ComponentClass<ThumbnailProps> { }
-    var Thumbnail: ThumbnailClass;    
+    var Thumbnail: ThumbnailClass;
 
 
     // <ListGroup />
@@ -755,9 +755,9 @@ declare module "react-bootstrap" {
         eventKey?: any;
         header?: any; // TODO: Add more specific type
         href?: string;
-        key?: any; // TODO: Add more specific type 
+        key?: any; // TODO: Add more specific type
         listItem?: boolean;
-        onClick?: Function; // TODO: Add more specific type 
+        onClick?: Function; // TODO: Add more specific type
         target?: string;
     }
     interface ListGroupItem extends React.ReactElement<ListGroupItemProps> { }
@@ -825,7 +825,7 @@ declare module "react-bootstrap" {
     // ----------------------------------------
     interface GlyphiconProps extends React.Props<GlyphiconClass> {
         className?: string;
-        // Required 
+        // Required
         glyph: string;
     }
     interface Glyphicon extends React.ReactElement<GlyphiconProps> { }
@@ -866,18 +866,18 @@ declare module "react-bootstrap" {
         hasFeedback?: boolean;
         help?: any; // TODO: Add more specific type
         id?: string | number;
-        label?: any; // TODO: Add more specific type 
+        label?: any; // TODO: Add more specific type
         labelClassName?: string;
         multiple?: boolean;
         placeholder?: string;
         readOnly?: boolean;
         type?: string;
-        onChange?: Function; // TODO: Add more specific type 
-        onKeyDown?: Function; // TODO: Add more specific type 
-        onKeyUp?: Function; // TODO: Add more specific type 
-        onKeyPress?: Function; // TODO: Add more specific type 
+        onChange?: Function; // TODO: Add more specific type
+        onKeyDown?: Function; // TODO: Add more specific type
+        onKeyUp?: Function; // TODO: Add more specific type
+        onKeyPress?: Function; // TODO: Add more specific type
         value?: any; // TODO: Add more specific type
-        wrapperClassName?: string; 
+        wrapperClassName?: string;
     }
     interface Input extends React.ReactElement<InputProps> { }
     interface InputClass extends React.ComponentClass<InputProps> { }
@@ -900,13 +900,13 @@ declare module "react-bootstrap" {
         hasFeedback?: boolean;
         help?: any; // TODO: Add more specific type
         id?: string | number;
-        label?: any; // TODO: Add more specific type 
+        label?: any; // TODO: Add more specific type
         labelClassName?: string;
         multiple?: boolean;
-        onClick?: Function; // TODO: Add more specific type 
+        onClick?: Function; // TODO: Add more specific type
         type?: string;
         value?: any; // TODO: Add more specific type
-        wrapperClassName?: string; 
+        wrapperClassName?: string;
     }
     interface ButtonInput extends React.ReactElement<ButtonInputProps> { }
     interface ButtonInputClass extends React.ComponentClass<ButtonInputProps> { }
@@ -914,8 +914,8 @@ declare module "react-bootstrap" {
 
 
     // TODO: FormControls.Static
-  
-  
+
+
     // <Portal />
     // ----------------------------------------
     interface PortalProps extends React.Props<PortalClass> {
@@ -937,7 +937,7 @@ declare module "react-bootstrap" {
     interface PortalClass extends React.ComponentClass<PortalProps> { }
     var Portal: PortalClass;
 
-   
+
     // <Position />
     // ----------------------------------------
     interface PositionProps extends React.Props<PositionClass> {
@@ -977,4 +977,22 @@ declare module "react-bootstrap" {
     interface Fade extends React.ReactElement<FadeProps> { }
     interface FadeClass extends React.ComponentClass<FadeProps> { }
     var Fade: FadeClass;
+
+    // <Collapse />
+    // ----------------------------------------
+    interface CollapseProps extends React.Props<CollapseClass> {
+        in?: boolean;
+        onEnter?: Function;
+        onEntered?: Function;
+        onEntering?: Function;
+        onExit?: Function;
+        onExited?: Function;
+        onExiting?: Function;
+        timeout?: number;
+        transitionAppear?: boolean;
+        unmountOnExit?: boolean;
+    }
+    interface Collapse extends React.ReactElement<CollapseProps> { }
+    interface CollapseClass extends React.ComponentClass<CollapseProps> { }
+    var Collapse: CollapseClass;
 }


### PR DESCRIPTION
This PR updates existing typings for **react-bootstrap**. Existing version misses Collapse component typings and tests for Fade component.
