### PR TITLE
fix(power-assert): use CommonJS style default export statement

### DIFF
--- a/power-assert/power-assert-tests.ts
+++ b/power-assert/power-assert-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./power-assert.d.ts" />
 
-import assert from "power-assert";
+import assert = require("power-assert");
 
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 

--- a/power-assert/power-assert.d.ts
+++ b/power-assert/power-assert.d.ts
@@ -66,5 +66,5 @@ declare namespace assert {
 }
 
 declare module "power-assert" {
-    export default assert;
+    export = assert;
 }


### PR DESCRIPTION
If ES6 style import statement is used in .ts, an assertion expression is compiled to the format that is not supported by power-assert like `power_assert_1.default.ok()`.

For examlple,

``` ts
// original .ts
import assert from 'power-assert';
import sut from '../';

describe('foo', () => {
    it('test #1', () => {
        assert.ok(sut() === 2);
    });
});
```

is compiled to

``` js
// generated .js
var power_assert_1 = require('power-assert');
var _1 = require('../');
describe('foo', function () {
    it('test #1', function () {
        power_assert_1.default.ok(_1.default() === 2);
    });
});
```

To resolve this problem, this PR changes to use CommonJS Style default export simply.
