### PR TITLE
Added continuation-local-storage access to Sequelize

### DIFF
--- a/sequelize/sequelize.d.ts
+++ b/sequelize/sequelize.d.ts
@@ -5365,6 +5365,11 @@ declare module "sequelize" {
              */
             new ( uri : string, options? : Options ) : Sequelize;
 
+            /**
+             * Provide access to continuation-local-storage (http://docs.sequelizejs.com/en/latest/api/sequelize/#transactionoptions-promise)
+             */
+            cls: any;
+
         }
 
         interface QueryOptionsTransactionRequired { }


### PR DESCRIPTION
Sequelize has a "cls" object that can be set to use continuation-local-storage.  Documentation here: http://docs.sequelizejs.com/en/latest/api/sequelize/#transactionoptions-promise

I have exposed the "cls" object on the static sequelize class.  continuation-local-storage does not have a typings file or I would have typed the cls object.
