### PR TITLE
findDOMNode is now in the root node

### DIFF
--- a/react/react-dom.d.ts
+++ b/react/react-dom.d.ts
@@ -6,47 +6,45 @@
 /// <reference path="react.d.ts" />
 
 declare namespace __React {
-    namespace __DOM {
-        function findDOMNode<E extends Element>(instance: ReactInstance): E;
-        function findDOMNode(instance: ReactInstance): Element;
+    function findDOMNode<E extends Element>(instance: ReactInstance): E;
+    function findDOMNode(instance: ReactInstance): Element;
 
-        function render<P>(
-            element: DOMElement<P>,
-            container: Element,
-            callback?: (element: Element) => any): Element;
-        function render<P, S>(
-            element: ClassicElement<P>,
-            container: Element,
-            callback?: (component: ClassicComponent<P, S>) => any): ClassicComponent<P, S>;
-        function render<P, S>(
-            element: ReactElement<P>,
-            container: Element,
-            callback?: (component: Component<P, S>) => any): Component<P, S>;
+    function render<P>(
+        element: DOMElement<P>,
+        container: Element,
+        callback?: (element: Element) => any): Element;
+    function render<P, S>(
+        element: ClassicElement<P>,
+        container: Element,
+        callback?: (component: ClassicComponent<P, S>) => any): ClassicComponent<P, S>;
+    function render<P, S>(
+        element: ReactElement<P>,
+        container: Element,
+        callback?: (component: Component<P, S>) => any): Component<P, S>;
 
-        function unmountComponentAtNode(container: Element): boolean;
+    function unmountComponentAtNode(container: Element): boolean;
 
-        var version: string;
+    var version: string;
 
-        function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
-        function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-        function unstable_batchedUpdates(callback: () => any): void;
+    function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
+    function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
+    function unstable_batchedUpdates(callback: () => any): void;
 
-        function unstable_renderSubtreeIntoContainer<P>(
-            parentComponent: Component<any, any>,
-            nextElement: DOMElement<P>,
-            container: Element,
-            callback?: (element: Element) => any): Element;
-        function unstable_renderSubtreeIntoContainer<P, S>(
-            parentComponent: Component<any, any>,
-            nextElement: ClassicElement<P>,
-            container: Element,
-            callback?: (component: ClassicComponent<P, S>) => any): ClassicComponent<P, S>;
-        function unstable_renderSubtreeIntoContainer<P, S>(
-            parentComponent: Component<any, any>,
-            nextElement: ReactElement<P>,
-            container: Element,
-            callback?: (component: Component<P, S>) => any): Component<P, S>;
-    }
+    function unstable_renderSubtreeIntoContainer<P>(
+        parentComponent: Component<any, any>,
+        nextElement: DOMElement<P>,
+        container: Element,
+        callback?: (element: Element) => any): Element;
+    function unstable_renderSubtreeIntoContainer<P, S>(
+        parentComponent: Component<any, any>,
+        nextElement: ClassicElement<P>,
+        container: Element,
+        callback?: (component: ClassicComponent<P, S>) => any): ClassicComponent<P, S>;
+    function unstable_renderSubtreeIntoContainer<P, S>(
+        parentComponent: Component<any, any>,
+        nextElement: ReactElement<P>,
+        container: Element,
+        callback?: (component: Component<P, S>) => any): Component<P, S>;
 
     namespace __DOMServer {
         function renderToString(element: ReactElement<any>): string;
@@ -56,7 +54,7 @@ declare namespace __React {
 }
 
 declare module "react-dom" {
-    import DOM = __React.__DOM;
+    import DOM = __React;
     export = DOM;
 }
 


### PR DESCRIPTION
**react dom is now at the root level**

more :  some function are also removed in the current version, I haven't change it for compatibly for now (they start with unstable_*). can you check
