### PR TITLE
Add a configuration config object that supports mariasql client syntax

### DIFF
--- a/knex/knex-tests.ts
+++ b/knex/knex-tests.ts
@@ -22,6 +22,18 @@ var knex = Knex({
   }
 });
 
+// Mariasql configuration
+var knex = Knex({
+  debug: true,
+  client: 'mariasql',
+  connection: {
+    host     : '127.0.0.1',
+    user     : 'your_database_user',
+    password : 'your_database_password',
+    db       : 'myapp_test'
+  }
+});
+
 // Pooling
 var knex = Knex({
   client: 'mysql',

--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -399,7 +399,7 @@ declare module "knex" {
       debug?: boolean;
       client?: string;
       dialect?: string;
-      connection: string|ConnectionConfig|
+      connection: string|ConnectionConfig|MariaSqlConnectionConfig|
         Sqlite3ConnectionConfig|SocketConnectionConfig;
       pool?: PoolConfig;
       migrations?: MigrationConfig;
@@ -410,6 +410,14 @@ declare module "knex" {
       user: string;
       password: string;
       database: string;
+      debug?: boolean;
+    }
+
+    interface MariaSqlConnectionConfig {
+      host: string;
+      user: string;
+      password: string;
+      db: string;
       debug?: boolean;
     }
 


### PR DESCRIPTION
Knex supports using the mariasql client but the format of the configuration config object it requires is different from the ones currently in the type definition file. Mariasql expects the database name to be in the "db" property rather than "database". I have created a definition for a configuration config type which supports the necessary properties.
