### PR TITLE
Fixed wrong action creators type

### DIFF
--- a/redux-router/redux-router-tests.ts
+++ b/redux-router/redux-router-tests.ts
@@ -1,2 +1,8 @@
 ///<reference path="redux-router.d.ts" />
-import { reduxReactRouter, routerStateReducer, ReduxRouter } from 'redux-router';
+import { reduxReactRouter, routerStateReducer, ReduxRouter, pushState } from 'redux-router';
+
+export function someAsyncReduxAction(someArg: Object) {
+    return function(dispatch: (action: Object) => void) {
+        dispatch(pushState(null, someArg));
+    };
+}

--- a/redux-router/redux-router.d.ts
+++ b/redux-router/redux-router.d.ts
@@ -34,7 +34,7 @@ declare namespace __ReduxRouter {
     export function routerDidChange(state: any): ReduxRouterAction;
     export function initRoutes(routes: any): ReduxRouterAction;
     export function replaceRoutes(routes: any): ReduxRouterAction;
-    export function historyAPI(method: any): (...args: any[]) => ReduxRouterAction;
+    export function historyAPI(method: any): (...args: Object[]) => ReduxRouterAction;
 }
 
 declare module "redux-router/lib/routerStateReducer" {
@@ -59,14 +59,14 @@ declare module "redux-router/lib/actionCreators" {
     export const initRoutes: typeof __ReduxRouter.initRoutes;
     export const replaceRoutes: typeof __ReduxRouter.replaceRoutes;
     export const historyAPI: typeof __ReduxRouter.historyAPI;
-    export const pushState: __ReduxRouter.historyAPI;
-    export const push: __ReduxRouter.historyAPI;
-    export const replaceState: __ReduxRouter.historyAPI;
-    export const replace: __ReduxRouter.historyAPI;
-    export const setState: __ReduxRouter.historyAPI;
-    export const go: __ReduxRouter.historyAPI;
-    export const goBack: __ReduxRouter.historyAPI;
-    export const goForward: __ReduxRouter.historyAPI;
+    export const pushState: (...args: Object[]) => __ReduxRouter.ReduxRouterAction;
+    export const push: (...args: Object[]) => __ReduxRouter.ReduxRouterAction;
+    export const replaceState: (...args: Object[]) => __ReduxRouter.ReduxRouterAction;
+    export const replace: (...args: Object[]) => __ReduxRouter.ReduxRouterAction;
+    export const setState: (...args: Object[]) => __ReduxRouter.ReduxRouterAction;
+    export const go: (...args: Object[]) => __ReduxRouter.ReduxRouterAction;
+    export const goBack: (...args: Object[]) => __ReduxRouter.ReduxRouterAction;
+    export const goForward: (...args: Object[]) => __ReduxRouter.ReduxRouterAction;
 }
 
 declare module "redux-router" {

--- a/redux-router/redux-router.d.ts
+++ b/redux-router/redux-router.d.ts
@@ -34,7 +34,7 @@ declare namespace __ReduxRouter {
     export function routerDidChange(state: any): ReduxRouterAction;
     export function initRoutes(routes: any): ReduxRouterAction;
     export function replaceRoutes(routes: any): ReduxRouterAction;
-    export function historyAPI(method: any): ReduxRouterAction;
+    export function historyAPI(method: any): (...args: any[]) => ReduxRouterAction;
 }
 
 declare module "redux-router/lib/routerStateReducer" {
@@ -59,14 +59,14 @@ declare module "redux-router/lib/actionCreators" {
     export const initRoutes: typeof __ReduxRouter.initRoutes;
     export const replaceRoutes: typeof __ReduxRouter.replaceRoutes;
     export const historyAPI: typeof __ReduxRouter.historyAPI;
-    export const pushState: __ReduxRouter.ReduxRouterAction;
-    export const push: __ReduxRouter.ReduxRouterAction;
-    export const replaceState: __ReduxRouter.ReduxRouterAction;
-    export const replace: __ReduxRouter.ReduxRouterAction;
-    export const setState: __ReduxRouter.ReduxRouterAction;
-    export const go: __ReduxRouter.ReduxRouterAction;
-    export const goBack: __ReduxRouter.ReduxRouterAction;
-    export const goForward: __ReduxRouter.ReduxRouterAction;
+    export const pushState: __ReduxRouter.historyAPI;
+    export const push: __ReduxRouter.historyAPI;
+    export const replaceState: __ReduxRouter.historyAPI;
+    export const replace: __ReduxRouter.historyAPI;
+    export const setState: __ReduxRouter.historyAPI;
+    export const go: __ReduxRouter.historyAPI;
+    export const goBack: __ReduxRouter.historyAPI;
+    export const goForward: __ReduxRouter.historyAPI;
 }
 
 declare module "redux-router" {


### PR DESCRIPTION
Using some of the redux-router action creators like pushState :

```
import { pushState } from 'redux-router';

export function saveEngagementAsVisibleSuccess(goTo) {
    return function(dispatch) {
        dispatch(pushState(null, goTo));
    }
}
```

Throws the following error:

```
Error TS2349: Cannot invoke an expression whose type lacks a call signature.

```

The redux-router [source code](https://github.com/acdlite/redux-router/blob/master/src/actionCreators.js#L46-L63) declare those as functions not objects:

```
export function historyAPI(method) {
  return (...args) => ({
    type: HISTORY_API,
    payload: {
      method,
      args
    }
  });
}

export const pushState = historyAPI('pushState');
export const push = historyAPI('push');
export const replaceState = historyAPI('replaceState');
export const replace = historyAPI('replace');
export const setState = historyAPI('setState');
export const go = historyAPI('go');
export const goBack = historyAPI('goBack');
export const goForward = historyAPI('goForward');
```

So I have update the types from `__ReduxRouter.ReduxRouterAction` to `(...args: any[]) => __ReduxRouter.ReduxRouterAction`:

```
export const pushState: (...args: any[]) => __ReduxRouter.ReduxRouterAction;
export const push: (...args: any[]) => __ReduxRouter.ReduxRouterAction;
export const replaceState: (...args: any[]) => __ReduxRouter.ReduxRouterAction;
export const replace: (...args: any[]) => __ReduxRouter.ReduxRouterAction;
export const setState: (...args: any[]) => __ReduxRouter.ReduxRouterAction;
export const go: (...args: any[]) => __ReduxRouter.ReduxRouterAction;
export const goBack: (...args: any[]) => __ReduxRouter.ReduxRouterAction;
export const goForward: (...args: any[]) => __ReduxRouter.ReduxRouterAction;
```
