### PR TITLE
Correct the signature of setHeader

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -502,7 +502,7 @@ declare module "http" {
         statusCode: number;
         statusMessage: string;
         headersSent: boolean;
-        setHeader(name: string, value: string): void;
+        setHeader(name: string, value: string | string[]): void;
         sendDate: boolean;
         getHeader(name: string): string;
         removeHeader(name: string): void;


### PR DESCRIPTION
setHeader() takes either a string or a string array as it's second argument.

See https://nodejs.org/api/http.html#http_response_setheader_name_value
