### PR TITLE
express-openapi: fix argument object of initialize method

### DIFF
--- a/express-openapi/express-openapi-tests.ts
+++ b/express-openapi/express-openapi-tests.ts
@@ -10,7 +10,14 @@ var api:openapi.InitializedApi;
 api = openapi.initialize({
     apiDoc: require('./api-doc.js'),
     app: app,
-    routes: './api-routes'
+    routes: './api-routes',
+    docPath: '/doc',
+    exposeApiDocs: true,
+    validateApiDoc: true,
+    errorTransformer: (openapiError, jsonschemaError) => {},
+    customFormats: {
+        myFormat: input => { return true; },
+    }
 });
 
 app.listen(3000);

--- a/express-openapi/express-openapi.d.ts
+++ b/express-openapi/express-openapi.d.ts
@@ -248,9 +248,14 @@ declare module "express-openapi" {
     }
 
     export interface Args {
-        apiDoc: OpenApi.ApiDefinition,
-        app: express.Application,
+        apiDoc: OpenApi.ApiDefinition
+        app: express.Application
         routes: string
+        docPath: string
+        errorTransformer(openapiError: OpenapiError, jsonschemaError: JsonschemaError): any
+        exposeApiDocs: boolean
+        validateApiDoc: boolean
+        customFormats: CustomFormats
     }
 
     export interface OperationFunction extends express.RequestHandler {
@@ -273,6 +278,33 @@ declare module "express-openapi" {
         patch?: Operation;
         options?: Operation;
         head?: Operation;
+    }
+
+    export interface OpenapiError {
+        errorCode: string
+        location: string
+        message: string
+        path: string
+    }
+
+    export interface CustomFormats {
+        [index: string]: CustomFormatValidator
+    }
+
+    // Following 2 interfaces are part of jsonschema package.
+    interface JsonschemaError {
+        property: string
+        message: string
+        schema: string|IJsonSchema
+        instance: any
+        name: string
+        argument: any
+        stack: string
+        toString(): string
+    }
+
+    interface CustomFormatValidator {
+        (input: any): boolean
     }
 
     interface IJsonSchema {

--- a/express-openapi/express-openapi.d.ts
+++ b/express-openapi/express-openapi.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for express-openapi 0.6.x
+// Type definitions for express-openapi 0.11.x
 // Project: https://github.com/kogosoftwarellc/express-openapi
 // Definitions by: TANAKA Koichi <https://github.com/mugeso/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped


### PR DESCRIPTION
Add lacked optional properties to argument object.
And add customFormats property, which added in v 0.11
