### PR TITLE
path function to allow (string | number)[]

### DIFF
--- a/raphael/raphael.d.ts
+++ b/raphael/raphael.d.ts
@@ -210,7 +210,7 @@ interface RaphaelPaper {
     getFont(family: string, weight?: number, style?: string, stretch?: string): RaphaelFont;
     height: number;
     image(src: string, x: number, y: number, width: number, height: number): RaphaelElement;
-    path(pathString?: string): RaphaelPath;
+    path(pathString?: string | (string | number)[]): RaphaelPath;
     print(x: number, y: number, str: string, font: RaphaelFont, size?: number, origin?: string, letter_spacing?: number): RaphaelPath;
     rect(x: number, y: number, width: number, height: number, r?: number): RaphaelElement;
     remove(): void;


### PR DESCRIPTION
It is totally legal to have something like this: paper.path(['M' + (startX), (startY), 'L' + (startX), (startY)]);
