### PR TITLE
Missing rotate

### DIFF
--- a/raphael/raphael.d.ts
+++ b/raphael/raphael.d.ts
@@ -64,6 +64,7 @@ interface RaphaelElement {
     remove(): void;
     removeData(key?: string): RaphaelElement;
     resume(anim?: RaphaelAnimation): RaphaelElement;
+    rotate(deg: number, cx?: number, cy?: number): RaphaelElement;
     setTime(anim: RaphaelAnimation): void;
     setTime(anim: RaphaelAnimation, value: number): RaphaelElement;
     show(): RaphaelElement;


### PR DESCRIPTION
Adds rotation by given angle around given point to the list of transformations of the element.
