### PR TITLE
Update knex.d.ts MariaConnectionConfig to support all properties

### DIFF
--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -413,12 +413,36 @@ declare module "knex" {
       debug?: boolean;
     }
 
+    // Config object for mariasql: https://github.com/mscdex/node-mariasql#client-methods
     interface MariaSqlConnectionConfig {
-      host: string;
-      user: string;
-      password: string;
-      db: string;
-      debug?: boolean;
+      user?: string;
+      password?: string;
+      host?: string;
+      port?: number;
+      unixSocket?: string;
+      protocol?: string;
+      db?: string;
+      keepQueries?: boolean;
+      multiStatements?: boolean;
+      connTimeout?: number;
+      pingInterval?: number;
+      secureAuth?: boolean;
+      compress?: boolean;
+      ssl?: boolean|MariaSslConfiguration;
+      local_infile?: boolean;
+      read_default_file?: string;
+      read_default_group?: string;
+      charset?: string;
+      streamHWM?: number;
+    }
+
+    interface MariaSslConfiguration {
+      key?: string;
+      cert?: string;
+      ca?: string;
+      capath?: string;
+      cipher?: string;
+      rejectUnauthorized?: boolean;
     }
 
     /** Used with SQLite3 adapter */


### PR DESCRIPTION
Update knex.d.ts MariaConnectionConfig to support all properties defined for mariasql driver as defined here:
https://github.com/mscdex/node-mariasql#client-methods
