### PR TITLE
fix camelcase type definitions

### DIFF
--- a/camelcase/camelcase-tests.ts
+++ b/camelcase/camelcase-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./camelcase.d.ts" />
 
-import camelCase from 'camelcase';
+import camelCase = require('camelcase');
 
 camelCase('foo-bar');
 camelCase('foo_bar');

--- a/camelcase/camelcase.d.ts
+++ b/camelcase/camelcase.d.ts
@@ -4,5 +4,7 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module "camelcase" {
-	export default function camelcase(...args: string[]): string;
+	function camelcase(...args: string[]): string;
+	namespace camelcase {}
+	export = camelcase;
 }


### PR DESCRIPTION
The previous [camelcase](https://github.com/sindresorhus/camelcase) definitions where not correct as `export default` assumes a `default` property in the exported object. Fixed by these changes.

Also added empty namespace because of https://github.com/Microsoft/TypeScript/issues/5073.

@sindresorhus Can you :+1: for me?
