### PR TITLE
Updated definitions for sax-js 

### DIFF
--- a/sax/sax-tests.ts
+++ b/sax/sax-tests.ts
@@ -1,44 +1,89 @@
 /// <reference path="../node/node.d.ts" />
 /// <reference path="./sax.d.ts" />
 import sax = require("sax");
-
-var opts: sax.SAXOptions = {
-  lowercase: true,
-  normalize: true,
-  xmlns: true,
-  position: true
-};
-
-var parser = sax.parser(/*strict=*/true, opts);
-
-parser.onerror = function(e: Error) {
-};
-
-parser.ontext = function(text: string) {
-};
-
-parser.onopentag = function(tag: sax.QualifiedTag) {
-  for (let attr in tag.attributes)
-    console.log(typeof(attr));
-};
-
-parser.onattribute = function(attr: { name: string; value: string; }) {
-};
-
-parser.onend = function() {
-};
-
-parser.write("<xml>Hello, <who name=\"world\">world</who>!</xml>").close();
-
-
-var saxStream = sax.createStream(/*strict=*/true, opts);
-
-saxStream.on("error", function(e: Error) {
-  this._parser.error = null;
-  this._parser.resume();
-});
-
 import fs = require("fs");
-fs.createReadStream("file.xml")
-  .pipe(saxStream)
-  .pipe(fs.createWriteStream("file-copy.xml"));
+
+(function xmlnsTests() {
+    let opts: sax.SAXOptions = {
+        lowercase: true,
+        normalize: true,
+        xmlns: true,
+        position: true
+    };
+
+    let parser = sax.parser(/*strict=*/true, opts);
+
+    parser.onerror = function(e: Error) {
+    };
+
+    parser.ontext = function(text: string) {
+    };
+
+    parser.onopentag = function(tag: sax.QualifiedTag) {
+        let prefix: string = tag.prefix;
+        let local: string = tag.local;
+        let uri: string = tag.uri;
+        let name: string = tag.name;
+        let isSelfClosing: boolean = tag.isSelfClosing;
+
+        let attr: sax.QualifiedAttribute = tag.attributes["name"];
+        if (attr) {
+            let attrPrefix: string = attr.prefix;
+            let attrLocal: string = attr.local;
+            let attrUri: string = attr.uri;
+            let attrName: string = attr.name;
+            let attrValue: string = attr.value;
+        }
+    };
+
+    parser.onattribute = function(attr: { name: string; value: string; }) {
+    };
+
+    parser.onend = function() {
+    };
+
+    parser.write("<xml>Hello, <who name=\"world\">world</who>!</xml>").close();
+
+
+    let saxStream = sax.createStream(/*strict=*/true, opts);
+
+    saxStream.on("error", function(e: Error) {
+        this._parser.error = null;
+        this._parser.resume();
+    });
+
+    fs.createReadStream("file.xml")
+        .pipe(saxStream)
+        .pipe(fs.createWriteStream("file-copy.xml"));
+})();
+
+(function noXmlnsTests() {
+    let opts: sax.SAXOptions = {
+        lowercase: true,
+        normalize: true,
+        xmlns: false,
+        position: true
+    };
+
+    let parser = sax.parser(/*strict=*/true, opts);
+
+    parser.onerror = function(e: Error) {
+    };
+
+    parser.ontext = function(text: string) {
+    };
+
+    parser.onopentag = function(tag: sax.Tag) {
+        let name: string = tag.name;
+        let isSelfClosing: boolean = tag.isSelfClosing;
+        let attrValue: string = tag.attributes["name"];
+    };
+
+    parser.onattribute = function(attr: { name: string; value: string; }) {
+    };
+
+    parser.onend = function() {
+    };
+
+    parser.write("<xml>Hello, <who name=\"world\">world</who>!</xml>").close();
+})();

--- a/sax/sax-tests.ts
+++ b/sax/sax-tests.ts
@@ -17,7 +17,9 @@ parser.onerror = function(e: Error) {
 parser.ontext = function(text: string) {
 };
 
-parser.onopentag = function(tag: sax.Tag) {
+parser.onopentag = function(tag: sax.QualifiedTag) {
+  for (let attr in tag.attributes)
+    console.log(typeof(attr));
 };
 
 parser.onattribute = function(attr: { name: string; value: string; }) {
@@ -40,4 +42,3 @@ import fs = require("fs");
 fs.createReadStream("file.xml")
   .pipe(saxStream)
   .pipe(fs.createWriteStream("file-copy.xml"));
-

--- a/sax/sax.d.ts
+++ b/sax/sax.d.ts
@@ -16,16 +16,38 @@ declare module "sax" {
         position?: boolean;
     }
 
-    export interface Tag {
-        name: string;
-        attributes: { [key: string]: string };
-
-        // Available if opt.xmlns
-        ns?: { [key: string]: string };
-        prefix?: string;
-        local?: string;
-        uri?: string;
+    export interface QualifiedName {
+      name: string;
+      prefix: string;
+      local: string;
+      uri: string;
     }
+
+    export interface Attribute extends QualifiedName {
+      value: string;
+    }
+
+    interface BaseTag {
+      name: string;
+      isSelfClosing: boolean;
+    }
+
+    export interface QualifiedTag extends QualifiedName, BaseTag {
+        ns: { [key: string]: string };
+        attributes: { [key: string]: Attribute };
+    }
+
+    export interface Tag extends BaseTag {
+      attributes: { [key: string]: string };
+    }
+
+    // export interface Tag extends BaseTag {
+    //   // If opt.xmlns available
+    //     ns?: { [key: string]: string };
+    //     // If opt.xmlns available, the attributes map value is an object type
+    //     attributes: { [key: string]: string | Attribute };
+    //     isSelfClosing: boolean;
+    // }
 
     export function parser(strict: boolean, opt: SAXOptions): SAXParser;
     export class SAXParser {
@@ -54,7 +76,7 @@ declare module "sax" {
         ontext(t: string): void;
         ondoctype(doctype: string): void;
         onprocessinginstruction(node: { name: string; body: string }): void;
-        onopentag(tag: Tag): void;
+        onopentag(tag: Tag | QualifiedTag): void;
         onclosetag(tagName: string): void;
         onattribute(attr: { name: string; value: string }): void;
         oncomment(comment: string): void;
@@ -75,4 +97,3 @@ declare module "sax" {
         private _parser: SAXParser;
     }
 }
-

--- a/sax/sax.d.ts
+++ b/sax/sax.d.ts
@@ -17,19 +17,19 @@ declare module "sax" {
     }
 
     export interface QualifiedName {
-      name: string;
-      prefix: string;
-      local: string;
-      uri: string;
+        name: string;
+        prefix: string;
+        local: string;
+        uri: string;
     }
 
     export interface Attribute extends QualifiedName {
-      value: string;
+        value: string;
     }
 
     interface BaseTag {
-      name: string;
-      isSelfClosing: boolean;
+        name: string;
+        isSelfClosing: boolean;
     }
 
     // Interface used when the xmlns option is set
@@ -39,7 +39,7 @@ declare module "sax" {
     }
 
     export interface Tag extends BaseTag {
-      attributes: { [key: string]: string };
+        attributes: { [key: string]: string };
     }
 
     export function parser(strict: boolean, opt: SAXOptions): SAXParser;

--- a/sax/sax.d.ts
+++ b/sax/sax.d.ts
@@ -23,7 +23,7 @@ declare module "sax" {
         uri: string;
     }
 
-    export interface Attribute extends QualifiedName {
+    export interface QualifiedAttribute extends QualifiedName {
         value: string;
     }
 
@@ -35,7 +35,7 @@ declare module "sax" {
     // Interface used when the xmlns option is set
     export interface QualifiedTag extends QualifiedName, BaseTag {
         ns: { [key: string]: string };
-        attributes: { [key: string]: Attribute };
+        attributes: { [key: string]: QualifiedAttribute };
     }
 
     export interface Tag extends BaseTag {

--- a/sax/sax.d.ts
+++ b/sax/sax.d.ts
@@ -32,6 +32,7 @@ declare module "sax" {
       isSelfClosing: boolean;
     }
 
+    // Interface used when the xmlns option is set
     export interface QualifiedTag extends QualifiedName, BaseTag {
         ns: { [key: string]: string };
         attributes: { [key: string]: Attribute };
@@ -40,14 +41,6 @@ declare module "sax" {
     export interface Tag extends BaseTag {
       attributes: { [key: string]: string };
     }
-
-    // export interface Tag extends BaseTag {
-    //   // If opt.xmlns available
-    //     ns?: { [key: string]: string };
-    //     // If opt.xmlns available, the attributes map value is an object type
-    //     attributes: { [key: string]: string | Attribute };
-    //     isSelfClosing: boolean;
-    // }
 
     export function parser(strict: boolean, opt: SAXOptions): SAXParser;
     export class SAXParser {


### PR DESCRIPTION
Updates to the sax type definitions to include the isSelfClosing attribute and to fix the fact that, when the xmlns option is enabled, the attributes property in the tag element is of type [key: string]: Attribute, being Attribute a similar interface to Tag.

As a consequence, the onopentag method is changed to onopentag(tag: Tag | QualifiedTag): void, where:

```
    interface Tag {
      name: string;
      isSelfClosing: boolean;
      attributes: { [key: string]: string };
    }

    interface QualifiedTag {
      name: string;
      prefix: string;
      local: string;
      uri: string;
      ns: { [key: string]: string };
      attributes: { [key: string]: Attribute };
    }

   interface Attribute {
      name: string;
      prefix: string;
      local: string;
      uri: string;
      value: string;
   }
```
