### PR TITLE
React: add __spread method.

### DIFF
--- a/react/react-0.13.3.d.ts
+++ b/react/react-0.13.3.d.ts
@@ -806,6 +806,12 @@ declare namespace __React {
         item(index: number): Touch;
         identifiedTouch(identifier: number): Touch;
     }
+
+    //
+    // React internal functions called in JSX generation.
+    //
+
+    function __spread(target: any, ...sources: any[]): any;
 }
 
 declare module "react" {

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -2117,6 +2117,12 @@ declare namespace __React {
         item(index: number): Touch;
         identifiedTouch(identifier: number): Touch;
     }
+
+    //
+    // React internal functions called in JSX generation.
+    //
+
+    function __spread(target: any, ...sources: any[]): any;
 }
 
 declare module "react" {


### PR DESCRIPTION
This method is used when translating JSX spread syntax. Note that there is alread #4832, but that seems to be only about tsx, this is about jsx in general.

See also https://facebook.github.io/react/docs/jsx-spread.html
