### PR TITLE
Added Transaction Type access

### DIFF
--- a/sequelize/sequelize-tests.ts
+++ b/sequelize/sequelize-tests.ts
@@ -1567,3 +1567,13 @@ s.transaction( function() {
 s.transaction( { isolationLevel : 'SERIALIZABLE' }, function( t ) { return Promise.resolve(); } );
 s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.SERIALIZABLE }, (t) => Promise.resolve() );
 s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.READ_COMMITTED }, (t) => Promise.resolve() );
+
+// transaction types
+new Sequelize( '', { transactionType: 'DEFERRED' } );
+new Sequelize( '', { transactionType: Sequelize.Transaction.TYPES.DEFERRED} );
+new Sequelize( '', { transactionType: Sequelize.Transaction.TYPES.IMMEDIATE} );
+new Sequelize( '', { transactionType: Sequelize.Transaction.TYPES.EXCLUSIVE} );
+s.transaction( { type : 'DEFERRED' }, (t) => Promise.resolve() );
+s.transaction( { type : s.Transaction.TYPES.DEFERRED }, (t) => Promise.resolve() );
+s.transaction( { type : s.Transaction.TYPES.IMMEDIATE }, (t) => Promise.resolve() );
+s.transaction( { type : s.Transaction.TYPES.EXCLUSIVE }, (t) => Promise.resolve() );

--- a/sequelize/sequelize.d.ts
+++ b/sequelize/sequelize.d.ts
@@ -5176,6 +5176,14 @@ declare module "sequelize" {
              */
             isolationLevel? : string;
 
+            /**
+             * Set the default transaction type. See `Sequelize.Transaction.TRANSACTION_TYPES` for possible
+             * options.
+             *
+             * Defaults to 'DEFERRED'
+             */
+            transactionType? : string;
+
         }
 
         /**
@@ -5787,6 +5795,41 @@ declare module "sequelize" {
             ISOLATION_LEVELS : TransactionIsolationLevels;
 
             /**
+             * Transaction type can be set per-transaction by passing `options.type` to
+             * `sequelize.transaction`. Default to `DEFERRED` but you can override the default isolation level
+             * by passing `options.transactionType` in `new Sequelize`.
+             *
+             * The transaction types to use when starting a transaction:
+             *
+             * ```js
+             * {
+             *   DEFERRED: "DEFERRED",
+             *   IMMEDIATE: "IMMEDIATE",
+             *   EXCLUSIVE: "EXCLUSIVE"
+             * }
+             * ```
+             *
+             * Pass in the transaction type the first argument:
+             *
+             * ```js
+             * return sequelize.transaction({
+             *   type: Sequelize.Transaction.EXCLUSIVE
+             * }, function (t) {
+             *
+             *  // your transactions
+             *
+             * }).then(function(result) {
+             *   // transaction has been committed. Do something after the commit if required.
+             * }).catch(function(err) {
+             *   // do something with the err.
+             * });
+             * ```
+             *
+             * @see TRANSACTION_TYPES
+             */
+            TRANSACTION_TYPES : TransactionTypes;
+
+            /**
              * Possible options for row locking. Used in conjuction with `find` calls:
              *
              * ```js
@@ -5838,6 +5881,17 @@ declare module "sequelize" {
         }
 
         /**
+         * Transaction type can be set per-transaction by passing `options.type` to `sequelize.transaction`.
+         * Default to `DEFERRED` but you can override the default isolation level by passing
+         * `options.transactionType` in `new Sequelize`.
+         */
+        interface TransactionTypes {
+          DEFERRED: string; // 'DEFERRED'
+          IMMEDIATE: string; // 'IMMEDIATE'
+          EXCLUSIVE: string; // 'EXCLUSIVE'
+        }
+
+        /**
          * Possible options for row locking. Used in conjuction with `find` calls:
          */
         interface TransactionLock {
@@ -5860,6 +5914,11 @@ declare module "sequelize" {
              *  See `Sequelize.Transaction.ISOLATION_LEVELS` for possible options
              */
             isolationLevel?: string;
+
+            /**
+             *  See `Sequelize.Transaction.TRANSACTION_TYPES` for possible options
+             */
+            type?: string;
 
             /**
              * A function that gets executed while running the query to log the sql.

--- a/sequelize/sequelize.d.ts
+++ b/sequelize/sequelize.d.ts
@@ -5177,7 +5177,7 @@ declare module "sequelize" {
             isolationLevel? : string;
 
             /**
-             * Set the default transaction type. See `Sequelize.Transaction.TRANSACTION_TYPES` for possible
+             * Set the default transaction type. See `Sequelize.Transaction.TYPES` for possible
              * options.
              *
              * Defaults to 'DEFERRED'
@@ -5825,9 +5825,9 @@ declare module "sequelize" {
              * });
              * ```
              *
-             * @see TRANSACTION_TYPES
+             * @see Sequelize.Transaction.TYPES
              */
-            TRANSACTION_TYPES : TransactionTypes;
+            TYPES : TransactionTypes;
 
             /**
              * Possible options for row locking. Used in conjuction with `find` calls:
@@ -5916,7 +5916,7 @@ declare module "sequelize" {
             isolationLevel?: string;
 
             /**
-             *  See `Sequelize.Transaction.TRANSACTION_TYPES` for possible options
+             *  See `Sequelize.Transaction.TYPES` for possible options
              */
             type?: string;
 


### PR DESCRIPTION
Transaction types allow for databases like sqlite to specify what kind of transaction it should start.  An example would be an exclusive transaction that locks down the entire database instead of the default "deferred" transaction type.
