### PR TITLE
MatchArgs can also take a string

### DIFF
--- a/react-router/react-router.d.ts
+++ b/react-router/react-router.d.ts
@@ -231,7 +231,7 @@ declare namespace ReactRouter {
     interface MatchArgs {
         routes?: RouteConfig
         history?: H.History
-        location?: H.Location
+        location?: H.Location | string
         parseQueryString?: ParseQueryString
         stringifyQuery?: StringifyQuery
     }


### PR DESCRIPTION
MatchArgs `location` is either a HistoryModule.Location, or a url string, which is converted to location automatically.
