### PR TITLE
Update react.d.ts

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -2136,10 +2136,6 @@ declare namespace JSX {
         key?: string | number;
     }
 
-    interface IntrinsicClassAttributes<T> {
-        ref?: string | ((classInstance: T) => void);
-    }
-
     interface IntrinsicElements {
         // HTML
         a: React.HTMLProps<HTMLAnchorElement>;


### PR DESCRIPTION
Defining `ref` in `IntrinsicClassAttributes` causes compilation errors in TS 1.8.

`ref` should be inherited via `Props` (via `React.HTMLProps` or `React.SVGProps`)
