### PR TITLE
[JointJS] Add missing methods from js, concretize generics on classes inheriting from BackboneJS, fix generics in classes dependent on JointJS (rappid)

### DIFF
--- a/jointjs/jointjs.d.ts
+++ b/jointjs/jointjs.d.ts
@@ -18,10 +18,13 @@ declare module joint {
         class Graph extends Backbone.Model {
             addCell(cell:Cell) : void;
             addCells(cells:Cell[]) : void;
+            getCells(): Cell[];
+            getElements(): Element[];
             initialize() : void;
             fromJSON(json:any) : void;
             toJSON() : Object;
             clear() : void;
+            getLinks(): Link[];
             getConnectedLinks(cell:Cell, opt?:any):Link[];
             disconnectLinks(cell:Cell) : void;
             removeLinks(cell:Cell) : void;
@@ -38,6 +41,7 @@ declare module joint {
             getEmbeddedCells():Cell[];
             clone(opt?:any):Backbone.Model;      // @todo: return can either be Cell or Cell[].
             attr(attrs:any):Cell;
+            prop(props:string, value?:any, opt?:any):any;
         }
 
         class Element extends Cell {
@@ -59,13 +63,14 @@ declare module joint {
             remove(): void;
         }
 
-        interface IOptions {
-            width?: number;
-            height?: number;
-            gridSize?: number;
+        interface IOptions extends Backbone.ViewOptions<Backbone.Model>{
+            width: number;
+            height: number;
+            gridSize: number;
             perpendicularLinks?: boolean;
             elementView?: ElementView;
             linkView?: LinkView;
+            defaultLink?: (joint.dia.Link | {():joint.dia.Link});
         }
 
         class Paper extends Backbone.View<Backbone.Model> {
@@ -74,18 +79,18 @@ declare module joint {
             setDimensions(width:number, height:number) : void;
             scale(sx:number, sy?:number, ox?:number, oy?:number):Paper;
             rotate(deg:number, ox?:number, oy?:number):Paper;      // @todo not released yet though it's in the source code already
-            findView(el:any):CellView;
-            findViewByModel(modelOrId:any):CellView;
-            findViewsFromPoint(p:{ x: number; y: number; }):CellView[];
-            findViewsInArea(r:{ x: number; y: number; width: number; height: number; }):CellView[];
+            findView(el:any):CellView<Cell>;
+            findViewByModel(modelOrId:any):CellView<Cell>;
+            findViewsFromPoint(p:{ x: number; y: number; }):CellView<Cell>[];
+            findViewsInArea(r:{ x: number; y: number; width: number; height: number; }):CellView<Cell>[];
             fitToContent(opt?:any): void;
         }
 
-        class ElementView extends CellView {
+        class ElementView extends CellView<Element> {
             scale(sx:number, sy:number) : void;
         }
 
-        class CellView extends Backbone.View<Cell> {
+        class CellView<T extends Backbone.Model> extends Backbone.View<T> {
             getBBox():{ x: number; y: number; width: number; height: number; };
             highlight(el?:any): void;
             unhighlight(el?:any): void;
@@ -99,7 +104,7 @@ declare module joint {
             pointerup(evt:any, x:number, y:number):void;
         }
 
-        class LinkView extends CellView {
+        class LinkView extends CellView<Link> {
             getConnectionLength():number;
             getPointAtLength(length:number):{ x: number; y: number; };
         }

--- a/jointjs/jointjs.d.ts
+++ b/jointjs/jointjs.d.ts
@@ -139,6 +139,7 @@ declare module joint {
         function supplement(objects:any[]):any;
         function deepMixin(objects:any[]):any;
         function deepSupplement(objects:any[], defaultIndicator?:any):any;
+        function breakText(text:string, size:{width?:number, height?:number}):string;
     }
 
 }

--- a/jointjs/jointjs.d.ts
+++ b/jointjs/jointjs.d.ts
@@ -64,9 +64,9 @@ declare module joint {
         }
 
         interface IOptions extends Backbone.ViewOptions<Backbone.Model>{
-            width: number;
-            height: number;
-            gridSize: number;
+            width?: number;
+            height?: number;
+            gridSize?: number;
             perpendicularLinks?: boolean;
             elementView?: ElementView;
             linkView?: LinkView;

--- a/jointjs/jointjs.d.ts
+++ b/jointjs/jointjs.d.ts
@@ -126,6 +126,10 @@ declare module joint {
             class Image extends Generic {
             }
         }
+        module devs {
+            class Model extends basic.Generic{
+            }
+        }
     }
 
     module util {

--- a/jointjs/jointjs.d.ts
+++ b/jointjs/jointjs.d.ts
@@ -40,7 +40,7 @@ declare module joint {
             unembed(cell:Cell) : void;
             getEmbeddedCells():Cell[];
             clone(opt?:any):Backbone.Model;      // @todo: return can either be Cell or Cell[].
-            attr(attrs:any):Cell;
+            attr(attrs:any):Cell; // @todo: is really always a Cell returned?
             prop(props:string, value?:any, opt?:any):any;
         }
 

--- a/jointjs/jointjs.d.ts
+++ b/jointjs/jointjs.d.ts
@@ -40,7 +40,7 @@ declare module joint {
             unembed(cell:Cell) : void;
             getEmbeddedCells():Cell[];
             clone(opt?:any):Backbone.Model;      // @todo: return can either be Cell or Cell[].
-            attr(attrs:any):Cell; // @todo: is really always a Cell returned?
+            attr(attrs:any):Cell; // @rapidtodo: is really always a Cell returned?
             prop(props:string, value?:any, opt?:any):any;
         }
 
@@ -74,6 +74,8 @@ declare module joint {
         }
 
         class Paper extends Backbone.View<Backbone.Model> {
+            constructor(options:IOptions)
+
             options:IOptions;
 
             setDimensions(width:number, height:number) : void;

--- a/rappid/rappid.d.ts
+++ b/rappid/rappid.d.ts
@@ -25,8 +25,8 @@ declare module joint{
                 model : Backbone.Collection<joint.dia.Cell>
             });
 
-            createSelectionBox(cellView:joint.dia.CellView) : void;
-            destroySelectionBox(cellView:joint.dia.CellView) : void;
+            createSelectionBox(cellView:joint.dia.CellView<joint.dia.Cell>) : void;
+            destroySelectionBox(cellView:joint.dia.CellView<joint.dia.Cell>) : void;
             startSelecting(evt:any) : void;
             cancelSelection() : void;
 


### PR DESCRIPTION
Essentially I added three things to the definitions:
- Methods on Graph, Paper, Cell and util which are present in the js source but not in the typings
- Added generics to some classes which inherit from Backbone
- Added type defintions for joint.shapes.devs.Model which is used in the official tutorials and is present in a separate file in the node package

Please see the commit messages for more details on each topic.
