### PR TITLE
[react] Updated interface HTMLAttributes

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -1843,6 +1843,9 @@ declare namespace __React {
         results?: number;
         security?: string;
         unselectable?: boolean;
+        
+        // Allows aria- and data- Attributes
+        [key: string]: any;
     }
 
     interface SVGAttributes extends HTMLAttributes {

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -1845,7 +1845,7 @@ declare namespace __React {
         unselectable?: boolean;
         
         // Allows aria- and data- Attributes
-        [key: string]: any;
+        [key: string]: string | string[] | boolean | number | EventHandler<SyntheticEvent> | CSSProperties | {__html: string};
     }
 
     interface SVGAttributes extends HTMLAttributes {

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -1845,7 +1845,7 @@ declare namespace __React {
         unselectable?: boolean;
         
         // Allows aria- and data- Attributes
-        [key: string]: string | string[] | boolean | number | EventHandler<SyntheticEvent> | CSSProperties | {__html: string};
+        [key: string]: any;
     }
 
     interface SVGAttributes extends HTMLAttributes {


### PR DESCRIPTION
Added [key:string]: any; to HTMLAttributes to Support data- and aria- Attributes, which are unsupported currently.
