### PR TITLE
Remove v2(), v3() from node-uuid def

### DIFF
--- a/node-uuid/node-uuid-base.d.ts
+++ b/node-uuid/node-uuid-base.d.ts
@@ -36,12 +36,6 @@ declare namespace __NodeUUID {
         v1(options?: UUIDOptions): string;
         v1(options?: UUIDOptions, buffer?: number[], offset?: number): number[];
 
-        v2(options?: UUIDOptions): string;
-        v2(options?: UUIDOptions, buffer?: number[], offset?: number): number[];
-
-        v3(options?: UUIDOptions): string;
-        v3(options?: UUIDOptions, buffer?: number[], offset?: number): number[];
-
         v4(options?: UUIDOptions): string;
         v4(options?: UUIDOptions, buffer?: number[], offset?: number): number[];
 

--- a/node-uuid/node-uuid-cjs-tests.ts
+++ b/node-uuid/node-uuid-cjs-tests.ts
@@ -3,8 +3,6 @@
 import nodeUuid = require('node-uuid');
 
 var uid1: string = nodeUuid.v1();
-var uid2: string = nodeUuid.v2();
-var uid3: string = nodeUuid.v3();
 var uid4: string = nodeUuid.v4();
 
 var options: __NodeUUID.UUIDOptions = {
@@ -24,6 +22,4 @@ nodeUuid.parse(uid4, buf, offset);
 nodeUuid.unparse(buf, offset);
 
 var uid21: number[] = nodeUuid.v1(options, padding, offset);
-var uid22: number[] = nodeUuid.v2(options, padding, offset);
-var uid23: number[] = nodeUuid.v3(options, padding, offset);
 var uid24: number[] = nodeUuid.v4(options, padding, offset);

--- a/node-uuid/node-uuid-global-tests.ts
+++ b/node-uuid/node-uuid-global-tests.ts
@@ -1,8 +1,6 @@
 /// <reference path="node-uuid-global.d.ts" />
 
 var uid1: string = uuid.v1();
-var uid2: string = uuid.v2();
-var uid3: string = uuid.v3();
 var uid4: string = uuid.v4();
 
 var options: __NodeUUID.UUIDOptions = {
@@ -22,6 +20,4 @@ uuid.parse(uid4, buf, offset);
 uuid.unparse(buf, offset);
 
 var uid21: number[] = uuid.v1(options, padding, offset);
-var uid22: number[] = uuid.v2(options, padding, offset);
-var uid23: number[] = uuid.v3(options, padding, offset);
 var uid24: number[] = uuid.v4(options, padding, offset);

--- a/node-uuid/node-uuid-tests.ts
+++ b/node-uuid/node-uuid-tests.ts
@@ -3,8 +3,6 @@
 import nodeUuid = require('node-uuid');
 
 var uid1: string = nodeUuid.v1();
-var uid2: string = nodeUuid.v2();
-var uid3: string = nodeUuid.v3();
 var uid4: string = nodeUuid.v4();
 
 var options: __NodeUUID.UUIDOptions = {
@@ -24,13 +22,9 @@ nodeUuid.parse(uid4, buf, offset);
 nodeUuid.unparse(buf, offset);
 
 var uid21: number[] = nodeUuid.v1(options, padding, offset);
-var uid22: number[] = nodeUuid.v2(options, padding, offset);
-var uid23: number[] = nodeUuid.v3(options, padding, offset);
 var uid24: number[] = nodeUuid.v4(options, padding, offset);
 
 var buffer: Buffer;
 
 var uid31: Buffer = nodeUuid.v1(options, buffer, offset);
-var uid32: Buffer = nodeUuid.v2(options, buffer, offset);
-var uid33: Buffer = nodeUuid.v3(options, buffer, offset);
 var uid34: Buffer = nodeUuid.v4(options, buffer, offset);

--- a/node-uuid/node-uuid.d.ts
+++ b/node-uuid/node-uuid.d.ts
@@ -23,14 +23,6 @@ declare module __NodeUUID {
         v1(options?: UUIDOptions, buffer?: number[], offset?: number): number[];
         v1(options?: UUIDOptions, buffer?: Buffer, offset?: number): Buffer;
 
-        v2(options?: UUIDOptions): string;
-        v2(options?: UUIDOptions, buffer?: number[], offset?: number): number[];
-        v2(options?: UUIDOptions, buffer?: Buffer, offset?: number): Buffer;
-
-        v3(options?: UUIDOptions): string;
-        v3(options?: UUIDOptions, buffer?: number[], offset?: number): number[];
-        v3(options?: UUIDOptions, buffer?: Buffer, offset?: number): Buffer;
-
         v4(options?: UUIDOptions): string;
         v4(options?: UUIDOptions, buffer?: number[], offset?: number): number[];
         v4(options?: UUIDOptions, buffer?: Buffer, offset?: number): Buffer;


### PR DESCRIPTION
Remove v2(), v3() from node-uuid definition: 

[node-uuid](https://github.com/broofa/node-uuid) doesn't actually have those methods. See both their website and the following screenshot: 

![screenshot_2016-02-25_00-10-14](https://cloud.githubusercontent.com/assets/304902/13310461/33e818c8-db54-11e5-8adb-66656981f6e1.png)
