### PR TITLE
jsonwebtoken - Updated SignCallback to match functionality correctly.

### DIFF
--- a/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/jsonwebtoken/jsonwebtoken-tests.ts
@@ -24,6 +24,11 @@ token = jwt.sign({ foo: 'bar' }, 'shhhhh');
 cert = fs.readFileSync('private.key');  // get private key
 token = jwt.sign({ foo: 'bar' }, cert, { algorithm: 'RS256'});
 
+// sign asynchronously
+jwt.sign({ foo: 'bar' }, cert, { algorithm: 'RS256' }, function(token: string) {
+  console.log(token);
+});
+
 /**
  * jwt.verify
  * https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback

--- a/jsonwebtoken/jsonwebtoken.d.ts
+++ b/jsonwebtoken/jsonwebtoken.d.ts
@@ -1,6 +1,6 @@
 ﻿// Type definitions for jsonwebtoken 0.4.0
 // Project: https://github.com/auth0/node-jsonwebtoken
-// Definitions by: Maxime LUCE <https://github.com/SomaticIT>
+// Definitions by: Maxime LUCE <https://github.com/SomaticIT>, Daniel Heim <https://github.com/danielheim>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../node/node.d.ts" />
@@ -53,7 +53,7 @@ declare module "jsonwebtoken" {
     }
 
     export interface SignCallback {
-        (err: Error, encoded: string): void;
+        (encoded: string): void;
     }
 
     /**


### PR DESCRIPTION
The `sign` async functionality only returns a token, as per the [example](https://github.com/auth0/node-jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback).
