### PR TITLE
Add Headers.forEach() function, which was missing from whatwg-fetch.d.ts

### DIFF
--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -42,6 +42,7 @@ declare class Headers {
 	getAll(name: string): Array<string>;
 	has(name: string): boolean;
 	set(name: string, value: string): void;
+	forEach(callback: (value: string, name: string) => void): void;
 }
 
 declare class Body {


### PR DESCRIPTION
The Headers.forEach() function specification is here:

https://fetch.spec.whatwg.org/#headers-class

Specifically, the phrase "The value pairs to iterate over are the return value of running these steps" is meant to imply the ability to call this forEach() function.

The reference polyfill is here:
https://www.npmjs.com/package/whatwg-fetch

The polyfill code also implements forEach(), as shown in this excerpt from [fetch.js](https://github.com/github/fetch/blob/master/fetch.js):

``` javascript
  Headers.prototype.forEach = function(callback, thisArg) {
    Object.getOwnPropertyNames(this.map).forEach(function(name) {
      this.map[name].forEach(function(value) {
        callback.call(thisArg, value, name, this)
      }, this)
    }, this)
  }
```

Thus, I believe it makes sense to add this polyfill. 

@arusakov @vvakame 
