### PR TITLE
Crossfilter group all

### DIFF
--- a/crossfilter/crossfilter-tests.ts
+++ b/crossfilter/crossfilter-tests.ts
@@ -25,8 +25,8 @@ var payments = crossfilter<Payment>([
 ]);
 
 var total_payments : number = payments.groupAll<number>().reduce(
-    function(p,v) { return p+=v; },
-    function(p,v) { return p-=v; },
+    function(p,v) { return p+=v.total; },
+    function(p,v) { return p-=v.total; },
     function() { return 0; } ).value();
 
 var paymentsByTotal = payments.dimension((d) => d.total);

--- a/crossfilter/crossfilter-tests.ts
+++ b/crossfilter/crossfilter-tests.ts
@@ -24,6 +24,11 @@ var payments = crossfilter<Payment>([
   {date: "2011-11-14T17:29:52Z", quantity: 1, total: 200, tip: 100, type: "visa"}
 ]);
 
+var total_payments : number = payments.groupAll<number>().reduce(
+    function(p,v) { return p+=v; },
+    function(p,v) { return p-=v; },
+    function() { return 0; } ).value();
+
 var paymentsByTotal = payments.dimension((d) => d.total);
 
 // Filters

--- a/crossfilter/crossfilter.d.ts
+++ b/crossfilter/crossfilter.d.ts
@@ -58,12 +58,12 @@ declare module CrossFilter {
         (array: T[], lo: number, hi: number): T[];
     }
 
-    export interface GroupAll<T> {
-        reduce<TValue>(add: (p: TValue, v: T) => TValue, remove: (p: TValue, v: T) => TValue, initial: () => TValue): GroupAll<T>;
-        reduceCount(): GroupAll<T>;
-        reduceSum(value: Selector<T>): GroupAll<T>;
-        dispose(): GroupAll<T>;
-        value(): T;
+    export interface GroupAll<T, TValue> {
+        reduce<TValue>(add: (p: TValue, v: T) => TValue, remove: (p: TValue, v: T) => TValue, initial: () => TValue): GroupAll<T, TValue>;
+        reduceCount(): GroupAll<T, TValue>;
+        reduceSum(value: Selector<T>): GroupAll<T, TValue>;
+        dispose(): GroupAll<T, TValue>;
+        value(): TValue;
     }
 
     export interface Grouping<TKey, TValue> {
@@ -87,7 +87,8 @@ declare module CrossFilter {
         add(records: T[]): CrossFilter<T>;
         remove(): CrossFilter<T>;
         size(): number;
-        groupAll(): GroupAll<T>;
+        GroupAll(): GroupAll<T, T>;
+        groupAll<TValue>(): GroupAll<T, TValue>;
         dimension<TDimension>(value: (data: T) => TDimension): Dimension<T, TDimension>;
     }
 
@@ -103,8 +104,9 @@ declare module CrossFilter {
         bottom(k: number): T[];
         dispose(): void;
 		group(): Group<T, TDimension, TDimension>;
-		group<TGroup>(groupValue: (data: TDimension) => TGroup): Group<T, TDimension, TGroup>;
-        groupAll(): GroupAll<T>;
+        group<TGroup>(groupValue: (data: TDimension) => TGroup): Group<T, TDimension, TGroup>;
+        groupAll(): GroupAll<T, T>;
+        groupAll<TValue>(): GroupAll<T, TValue>;
     }
 }
 


### PR DESCRIPTION
Fix Crossfilter's groupAll() to provide a generic override that allows it to reduce to a value that is of a different type then the dataset.
