### PR TITLE
Add support for Winston 'stringify' option

### DIFF
--- a/winston/winston.d.ts
+++ b/winston/winston.d.ts
@@ -49,7 +49,7 @@ declare module "winston" {
   export function addRewriter(rewriter: MetadataRewriter): void;
 
   export interface MetadataRewriter {
-      (level: string, msg: string, meta: any): any;
+    (level: string, msg: string, meta: any): any;
   }
 
   export interface LoggerStatic {
@@ -182,27 +182,34 @@ declare module "winston" {
     humanReadableUnhandledException?: boolean;
   }
 
-  export interface ConsoleTransportOptions extends TransportOptions {
+  export interface GenericTextTransportOptions {
     json?: boolean;
     colorize?: boolean;
     prettyPrint?: boolean;
     timestamp?: (Function|boolean);
     showLevel?: boolean;
     label?: string;
-    logstash?: boolean;
-    debugStdout?: boolean;
     depth?: number;
+    stringify?: Function;
   }
 
-  export interface DailyRotateFileTransportOptions extends TransportOptions {
-    json?: boolean;
-    colorize?: boolean;
-    prettyPrint?: boolean;
-    timestamp?: (Function|boolean);
-    showLevel?: boolean;
-    label?: string;
+  export interface GenericNetworkTransportOptions {
+    host?: string;
+    port?: number;
+    auth?: {
+      username: string;
+      password: string;
+    };
+    path?: string;
+  }
+
+  export interface ConsoleTransportOptions extends TransportOptions, GenericTextTransportOptions {
     logstash?: boolean;
-    depth?: number;
+    debugStdout?: boolean;
+  }
+
+  export interface DailyRotateFileTransportOptions extends TransportOptions, GenericTextTransportOptions {
+    logstash?: boolean;
     maxsize?: number;
     maxFiles?: number;
     eol?: string;
@@ -213,19 +220,12 @@ declare module "winston" {
     options?: {
       flags?: string;
       highWaterMark?: number;
-    }
+    };
     stream?: NodeJS.WritableStream;
   }
 
-  export interface FileTransportOptions extends TransportOptions {
-    json?: boolean;
-    colorize?: boolean;
-    prettyPrint?: boolean;
-    timestamp?: (Function|boolean);
-    showLevel?: boolean;
-    label?: string;
+  export interface FileTransportOptions extends TransportOptions, GenericTextTransportOptions {
     logstash?: boolean;
-    depth?: number;
     maxsize?: number;
     rotationFormat?: boolean;
     zippedArchive?: boolean;
@@ -238,40 +238,19 @@ declare module "winston" {
     options?: {
       flags?: string;
       highWaterMark?: number;
-    }
+    };
     stream?: NodeJS.WritableStream;
   }
 
-  export interface HttpTransportOptions extends TransportOptions {
+  export interface HttpTransportOptions extends TransportOptions, GenericNetworkTransportOptions {
     ssl?: boolean;
-    host?: string;
-    port?: number;
-    auth?: {
-      username: string;
-      password: string;
-    };
-    path?: string;
   }
 
-  export interface MemoryTransportOptions extends TransportOptions {
-    json?: boolean;
-    colorize?: boolean;
-    prettyPrint?: boolean;
-    timestamp?: (Function|boolean);
-    showLevel?: boolean;
-    label?: string;
-    depth?: number;
+  export interface MemoryTransportOptions extends TransportOptions, GenericTextTransportOptions {
   }
 
-  export interface WebhookTransportOptions extends TransportOptions {
-    host?: string;
-    port?: number;
+  export interface WebhookTransportOptions extends TransportOptions, GenericNetworkTransportOptions {
     method?: string;
-    path?: string;
-    auth?: {
-      username?: string;
-      password?: string;
-    };
     ssl?: {
       key?: any;
       cert?: any;


### PR DESCRIPTION
Winston supports the `stringify` option to be set to a function that will format messages. This works differently than the `formatter` option in that it handles formatting the `options`/`meta` object too. This isn't well documented (https://github.com/winstonjs/winston/issues/74, http://stackoverflow.com/questions/32131287/how-do-i-change-my-node-winston-json-output-to-be-single-line/32131307#32131307) or documented differently than the source code reads (https://github.com/winstonjs/winston/blob/master/docs/transports.md).

I also did a minor refactor to use multiple inheritance to follow the base types of loggers in Winston: `console`, `file`, `http`, `memory` with `console`, `file`, and `memory` all being text-based loggers and the `http` being a network-based logger. This made it easier to add the `stringify` option and makes it easier to maintain things going forward (reduces redundancy).
