### PR TITLE
adding gapi.load(...)

### DIFF
--- a/gapi.auth2/gapi.auth2-tests.ts
+++ b/gapi.auth2/gapi.auth2-tests.ts
@@ -1,5 +1,16 @@
 /// <reference path="gapi.auth2.d.ts" />
 
+function test_load() {
+  gapi.load('auth2', function() {
+    gapi.auth2.init({
+      client_id: 'my-id',
+      cookie_policy: 'single_host_origin',
+      scope: 'https://www.googleapis.com/auth/plus.login',
+      fetch_basic_profile: true
+    })
+  })
+}
+
 function test_init(){
   var auth = gapi.auth2.init({
     client_id: 'my-id',

--- a/gapi.auth2/gapi.auth2.d.ts
+++ b/gapi.auth2/gapi.auth2.d.ts
@@ -5,6 +5,15 @@
 
 /// <reference path="../gapi/gapi.d.ts" />
 
+declare module gapi {
+
+    /**
+     * Pragmatically initialize gapi class member.
+     */
+    export function load(object: string, fn: any) : gapi.auth2.GoogleAuth;
+
+}
+
 declare module gapi.auth2 {
 
   /**


### PR DESCRIPTION
gapi object should offer the ability to pragmatically initialize gapi class members. this is done through gapi.load(...)
