### PR TITLE
loosen restrictive type signature for d3 diagonal

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -2492,11 +2492,11 @@ declare module d3 {
 
             source(): (d: Link, i: number) => Node;
             source(source: Node): Diagonal<Link, Node>;
-            source(source: (d: Link, i: number) => Node): Diagonal<Link, Node>;
+            source(source: (d: Link, i: number) => { x: number; y: number; }): Diagonal<Link, Node>;
 
             target(): (d: Link, i: number) => Node;
             target(target: Node): Diagonal<Link, Node>;
-            target(target: (d: Link, i: number) => Node): Diagonal<Link, Node>;
+            target(target: (d: Link, i: number) => { x: number; y: number; }): Diagonal<Link, Node>;
 
             projection(): (d: Node, i: number) => [number, number];
             projection(projection: (d: Node, i: number) => [number, number]): Diagonal<Link, Node>;


### PR DESCRIPTION
The current type signature forces the source and target functions to return a full-fledged node, when the documentation and the implementation only need an {x, y} object.

This becomes troublesome when you want source/target to apply some accessor transformation that you do not want to apply to your actual Nodes.

The same transformation might be also applied to the Chord type. I am not familiar with it though.
