### PR TITLE
Adds typing for sinon-stub-promise

### DIFF
--- a/sinon-stub-promise/sinon-stub-promise-tests.ts
+++ b/sinon-stub-promise/sinon-stub-promise-tests.ts
@@ -1,0 +1,13 @@
+/// <reference path="sinon-stub-promise.d.ts"/>
+function testResolve() {
+    var promise = sinon.stub().returnsPromise();
+    promise.resolves('test val');
+}
+
+function testReject() {
+    var promise = sinon.stub().returnsPromise();
+    promise.rejects('test val');
+}
+
+testResolve();
+testReject();

--- a/sinon-stub-promise/sinon-stub-promise.d.ts
+++ b/sinon-stub-promise/sinon-stub-promise.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for sinon-stub-promise v1.0.1
+// Project: https://github.com/substantial/sinon-stub-promise
+// Definitions by: Thiago Temple <https://github.com/vintem>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../sinon/sinon.d.ts"/>
+
+declare module Sinon {
+  interface SinonPromise {
+    resolves(value?: any): void;
+    rejects(value?: any): void;
+  }
+  
+  interface SinonStub {
+    returnsPromise(): SinonPromise;
+  }
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [X] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [X] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [X] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
