### PR TITLE
Add type definition for autoUpdater.quitAndInstall() to github-electron

### DIFF
--- a/github-electron/github-electron-main-tests.ts
+++ b/github-electron/github-electron-main-tests.ts
@@ -227,6 +227,10 @@ app.commandLine.appendSwitch('vmodule', 'console=0');
 
 autoUpdater.setFeedURL('http://mycompany.com/myapp/latest?version=' + app.getVersion());
 
+autoUpdater.checkForUpdates();
+
+autoUpdater.quitAndInstall();
+
 // browser-window
 // https://github.com/atom/electron/blob/master/docs/api/browser-window.md
 

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -1190,7 +1190,7 @@ declare module Electron {
 		 * Restarts the app and installs the update after it has been downloaded.
 		 * It should only be called after update-downloaded has been emitted.
 		 */
-		 quitAndInstall(): any;
+		 quitAndInstall(): void;
 	}
 
 	module Dialog {

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -1186,11 +1186,11 @@ declare module Electron {
 		 * before using this API
 		 */
 		checkForUpdates(): any;
-    /**
-     * Restarts the app and installs the update after it has been downloaded.
-     * It should only be called after update-downloaded has been emitted.
-     */
-    quitAndInstall(): any;
+		/**
+		 * Restarts the app and installs the update after it has been downloaded.
+		 * It should only be called after update-downloaded has been emitted.
+		 */
+		 quitAndInstall(): any;
 	}
 
 	module Dialog {

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -1186,6 +1186,11 @@ declare module Electron {
 		 * before using this API
 		 */
 		checkForUpdates(): any;
+    /**
+     * Restarts the app and installs the update after it has been downloaded.
+     * It should only be called after update-downloaded has been emitted.
+     */
+    quitAndInstall(): any;
 	}
 
 	module Dialog {


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
    is correct naming convention?
    https://www.npmjs.com/package/electron-window-state
    http://bower.io/search/?q=electron-window-state
    others?
    has a test file? (electron-window-state/electron-window-state-tests.ts or electron-window-state/electron-window-state-tests.tsx)
    pass the Travis CI test?
