### PR TITLE
React transition group fix

### DIFF
--- a/react/react-addons-transition-group.d.ts
+++ b/react/react-addons-transition-group.d.ts
@@ -8,6 +8,7 @@
 declare namespace __React {
 
     interface TransitionGroupProps {
+        className?: string;
         component?: ReactType;
         childFactory?: (child: ReactElement<any>) => ReactElement<any>;
     }


### PR DESCRIPTION
I am currently upgrading my codebase to React 0.14 from 0.13.3 and so I have also upgraded the typings. I recognised, that typings are now separated as I'm using quite heavily the `CssTransitionGroup` component.

I have been always adding to `CssTransitionGroup` the `className` prop. Afaik all components have this prop. 

Unfortunately this is not reflected in the typings, so I have added `className` to the base type `TransitionGroup`. I'm not sure if this is really the case since I couldn't find it explicitly in the docs of React: https://facebook.github.io/react/docs/animation.html

I kindly ask to confirm if this is valid or not and merge if you agree.
