### PR TITLE
UUID: enable es6 import syntax

### DIFF
--- a/uuid/UUID-tests.ts
+++ b/uuid/UUID-tests.ts
@@ -1,8 +1,14 @@
 /// <reference path="UUID.d.ts" />
+
+
+import UUID = require("UUID");
+
+
+const uuid1: string = UUID.generate()
+const uuid2: UUID.UUID = UUID.genV4()
+const uuid3: UUID.UUID = UUID.genV1()
+
 // Copied below from readme at https://github.com/LiosK/UUID.js
-
-
-
 
 // the simplest way to get an UUID (as a hexadecimal string)
 console.log(UUID.generate());  // "0db9a5fa-f532-4736-89d6-8819c7f3ac7b"

--- a/uuid/UUID.d.ts
+++ b/uuid/UUID.d.ts
@@ -1,64 +1,9 @@
-// Type definitions for UUID.js core-1.0
+// Type definitions for UUID.js v3.3.0
 // Project: https://github.com/LiosK/UUID.js
 // Definitions by: Jason Jarrett <https://github.com/staxmanade/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare module UUID {
-
-    interface UUIDStatic {
-
-        /**
-         * The simplest function to get an UUID string.
-         * @returns {string} A version 4 UUID string.
-         */
-        generate(): string;
-
-        /**
-         * Generates a version 4 {@link UUID}.
-         * @returns {UUID} A version 4 {@link UUID} object.
-         * @since 3.0
-         */
-        genV4(): UUID;
-
-
-        /**
-         * Generates a version 1 {@link UUID}.
-         * @returns {UUID} A version 1 {@link UUID} object.
-         * @since 3.0
-         */
-        genV1(): UUID;
-
-        /**
-         * Converts hexadecimal UUID string to an {@link UUID} object.
-         * @param {string} strId UUID hexadecimal string representation ("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx").
-         * @returns {UUID} {@link UUID} object or null.
-         * @since 3.0
-         */
-        parse(uuid: string): UUID;
-
-
-        /**
-         * Re-initializes version 1 UUID state.
-         * @since 3.0
-         */
-        resetState(): void;
-
-        /**
-         * Reinstalls {@link UUID.generate} method to emulate the interface of UUID.js version 2.x.
-         * @since 3.1
-         * @deprecated Version 2.x. compatible interface is not recommended.
-         */
-        makeBackwardCompatible(): void;
-    }
-
-    interface UUIDArray<T> extends Array<T> {
-        timeLow: string;
-        timeMid: string;
-        timeHiAndVersion: string;
-        clockSeqHiAndReserved: string;
-        clockSeqLow: string;
-        node: string;
-    }
+declare module "UUID" {
 
     interface UUID {
         intFields: UUIDArray<number>;
@@ -75,7 +20,7 @@ declare module UUID {
          * @param {UUID} uuid
          * @returns {bool} True if two {@link UUID} objects are equal.
          */
-        equals(uuid: UUID): boolean;
+        equals(uuid:UUID): boolean;
 
         /**
          * Returns UUID string representation.
@@ -83,6 +28,56 @@ declare module UUID {
          */
         toString(): string;
     }
-}
 
-declare var UUID:  UUID.UUIDStatic;
+    interface UUIDArray<T> extends Array<T> {
+        timeLow: string;
+        timeMid: string;
+        timeHiAndVersion: string;
+        clockSeqHiAndReserved: string;
+        clockSeqLow: string;
+        node: string;
+    }
+
+    /**
+     * The simplest function to get an UUID string.
+     * @returns {string} A version 4 UUID string.
+     */
+    export function generate(): string;
+
+    /**
+     * Generates a version 4 {@link UUID}.
+     * @returns {UUID} A version 4 {@link UUID} object.
+     * @since 3.0
+     */
+    export function genV4(): UUID;
+
+
+    /**
+     * Generates a version 1 {@link UUID}.
+     * @returns {UUID} A version 1 {@link UUID} object.
+     * @since 3.0
+     */
+    export function genV1(): UUID;
+
+    /**
+     * Converts hexadecimal UUID string to an {@link UUID} object.
+     * @param {string} uuid UUID hexadecimal string representation ("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx").
+     * @returns {UUID} {@link UUID} object or null.
+     * @since 3.0
+     */
+    export function parse(uuid:string): UUID;
+
+
+    /**
+     * Re-initializes version 1 UUID state.
+     * @since 3.0
+     */
+    export function resetState(): void;
+
+    /**
+     * Reinstalls {@link UUID.generate} method to emulate the interface of UUID.js version 2.x.
+     * @since 3.1
+     * @deprecated Version 2.x. compatible interface is not recommended.
+     */
+    export function makeBackwardCompatible(): void;
+}


### PR DESCRIPTION
Allows the use of UUID as a type for a new variable.  There wasn't a way to declare a UUID type in the previous definition.  This commit also enables the ES6 import syntax which I couldn't make work with the last version.
