### PR TITLE
axios: add functions to InterceptorManger

### DIFF
--- a/axios/axios-tests.ts
+++ b/axios/axios-tests.ts
@@ -18,10 +18,32 @@ axios.interceptors.request.use<any>(config => {
     return config;
 });
 
+
+const requestId: number = axios.interceptors.request.use<any>(
+    (config) => {
+        console.log("Method:" + config.method + " Url:" +config.url);
+        return config;
+    },
+    (error: any) => error);
+
+
+axios.interceptors.request.eject(requestId);
+axios.interceptors.request.eject(7);
+
+
 axios.interceptors.response.use<any>(config => {
     console.log("Status:" + config.status);
     return config;
 });
+
+const responseId: number = axios.interceptors.response.use<any>(
+    config => {
+        console.log("Status:" + config.status);
+        return config;
+    },
+    (error: any) => error);
+
+axios.interceptors.response.eject(responseId);
 
 axios.get<Repository>("https://api.github.com/repos/mzabriskie/axios")
      .then(r => console.log(r.config.method));

--- a/axios/axios.d.ts
+++ b/axios/axios.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for axios 0.8.1
+// Type definitions for axios 0.9.1
 // Project: https://github.com/mzabriskie/axios
 // Definitions by: Marcel Buesing <https://github.com/marcelbuesing>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -167,18 +167,34 @@ declare module Axios {
         response: ResponseInterceptor
     }
 
+    type InterceptorId = number;
+
     interface RequestInterceptor {
         /**
          * <U> - request body data type
          */
-        use<U>(fn: (config: AxiosXHRConfig<U>) => AxiosXHRConfig<U>): void;
+
+        use<U>(fulfilledFn: (config: AxiosXHRConfig<U>) => AxiosXHRConfig<U>): InterceptorId;
+
+        use<U>(fulfilledFn: (config: AxiosXHRConfig<U>) => AxiosXHRConfig<U>,
+               rejectedFn: (error: any) => any)
+            : InterceptorId;
+
+        eject(interceptorId: InterceptorId): void;
     }
 
     interface ResponseInterceptor {
         /**
          * <T> - expected response type
          */
-        use<T>(fn: (config: AxiosXHR<T>) => AxiosXHR<T>): void;
+
+        use<T>(fulfilledFn: (config: Axios.AxiosXHR<T>) => Axios.AxiosXHR<T>): InterceptorId;
+
+        use<T>(fulfilledFn: (config: Axios.AxiosXHR<T>) => Axios.AxiosXHR<T>,
+               rejectedFn: (error: any) => any)
+            : InterceptorId;
+
+        eject(interceptorId: InterceptorId): void;
     }
 
     /**


### PR DESCRIPTION
Both the request and response interceptor are InterceptorManager's

https://github.com/mzabriskie/axios/blob/master/lib/core/InterceptorManager.js

So, they have `use` and `eject` which were missing before.
