### PR TITLE
Updates to Intro.js Definition and Tests

### DIFF
--- a/intro.js/intro.js-tests.ts
+++ b/intro.js/intro.js-tests.ts
@@ -70,3 +70,11 @@ intro.start()
     })
     .addHints()
     .clone();
+
+introWithElement.start()
+    .exit()
+    .clone();
+    
+introWithQuerySelector.start()
+    .exit()
+    .clone();

--- a/intro.js/intro.js-tests.ts
+++ b/intro.js/intro.js-tests.ts
@@ -1,6 +1,8 @@
 /// <reference path="intro.js.d.ts" />
 
 var intro = introJs();
+var introWithElement = introJs(document.body);
+var introWithQuerySelector = introJs('body');
 
 intro.setOption('doneLabel', 'Next page');
 intro.setOption('overlayOpacity', 50);
@@ -53,4 +55,18 @@ intro.start()
     })
     .oncomplete(function () {
         alert('Done');
-    });
+    })
+    .onexit(function () {
+        alert('Exiting');
+    })
+    .onhintsadded(function () {
+        alert('Hints added');
+    })
+    .onhintclick(function (hintElement, item, stepId) {
+        element.getAttribute('class');
+    })
+    .onhintclose(function (stepId) {
+        alert('Hint close for Step ID ' + stepId);
+    })
+    .addHints()
+    .clone();

--- a/intro.js/intro.js-tests.ts
+++ b/intro.js/intro.js-tests.ts
@@ -50,8 +50,8 @@ intro.start()
     .onafterchange(function (element) {
         element.getAttribute('class');
     })
-    .onchange(function () {
-        alert('Changed');
+    .onchange(function (element) {
+        element.getAttribute('class');
     })
     .oncomplete(function () {
         alert('Done');

--- a/intro.js/intro.js-tests.ts
+++ b/intro.js/intro.js-tests.ts
@@ -63,7 +63,7 @@ intro.start()
         alert('Hints added');
     })
     .onhintclick(function (hintElement, item, stepId) {
-        element.getAttribute('class');
+        hintElement.getAttribute('class');
     })
     .onhintclose(function (stepId) {
         alert('Hint close for Step ID ' + stepId);

--- a/intro.js/intro.js.d.ts
+++ b/intro.js/intro.js.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for intro.js 1.1.1
+// Type definitions for intro.js 2.0
 // Project: https://github.com/usablica/intro.js
 // Definitions by: Maxime Fabre <https://github.com/anahkiasen/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -29,12 +29,15 @@ declare module IntroJs {
         overlayOpacity?: number;
         positionPrecedence?: string[];
         disableInteraction?: boolean;
+        hintPosition: string;
+        hintButtonLabel: string;
         steps: Step[];
     }
 
     interface IntroJs {
         start(): IntroJs;
         exit(): IntroJs;
+        clone(): IntroJs;
 
         goToStep(step: number): IntroJs;
         nextStep(): IntroJs;
@@ -48,12 +51,20 @@ declare module IntroJs {
         onexit(callback: Function): IntroJs;
         onbeforechange(callback: (element: HTMLElement) => any): IntroJs;
         onafterchange(callback: (element: HTMLElement) => any): IntroJs;
-        onchange(callback: Function): IntroJs;
+        onchange(callback: (element: HTMLElement) => any): IntroJs;
         oncomplete(callback: Function): IntroJs;
+        
+        addHints(): IntroJs;
+        
+        onhintsadded(callback: Function): IntroJs;
+        onhintclick(callback: (hintElement: HTMLElement, item: Step, stepId: number) => any): IntroJs;
+        onhintclose(callback: (stepId: number) => any): IntroJs;
     }
 
     interface Factory {
-        (element?: string): IntroJs;
+        (): IntroJs;
+        (element: HTMLElement): IntroJs;
+        (querySelector: string): IntroJs;
     }
 }
 

--- a/intro.js/intro.js.d.ts
+++ b/intro.js/intro.js.d.ts
@@ -29,9 +29,9 @@ declare module IntroJs {
         overlayOpacity?: number;
         positionPrecedence?: string[];
         disableInteraction?: boolean;
-        hintPosition: string;
-        hintButtonLabel: string;
-        steps: Step[];
+        hintPosition?: string;
+        hintButtonLabel?: string;
+        steps?: Step[];
     }
 
     interface IntroJs {


### PR DESCRIPTION
I've updated the definitions and test cases to support that latest version - v2.0 - of Intro.js. Changes since v1.1.1 that impacted the definitions were primarily around adding the 'hints' features.

Additionally, I updated the definition to match what the `IntroJs` constructor will accept. The only parameter passed into the `IntroJs` constructor is responsible for setting the `_targetElement` variable of the `IntroJs` object. The `IntroJs` constructor can be found starting on Line 1548 of [intro.js](https://github.com/usablica/intro.js/blob/2a3798778a9e4c8c4e6d793ab1ff11feb6c19927/intro.js). Valid scenarios include the following:
1. No parameter, which results in `_targetElement` being set to `document.body`;
2. An `HTMLElement` object, which is directly assigned to `_targetElement`; or
3. A string, which is used as a query selector to retrieve an element from the DOM and `_targetElement` is set to that DOM element.

The [GitHub repository for Intro.js](https://github.com/usablica/intro.js) contains the API documentation in its `README.md` file.
- [x] Tested with Travis on my fork
- [x] Reviewed by a DefinitelyTyped member.
