### PR TITLE
P2 module not in quotes

### DIFF
--- a/p2/p2.d.ts
+++ b/p2/p2.d.ts
@@ -4,6 +4,10 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module "p2" {
+    export = p2;
+}
+
+declare module p2 {
 
     export class AABB {
 

--- a/p2/p2.d.ts
+++ b/p2/p2.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Clark Stevenson <https://github.com/clark-stevenson>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare module p2 {
+declare module "p2" {
 
     export class AABB {
 


### PR DESCRIPTION
The module name should be in quotes. Otherwise you get this error:

```
error TS2307: Cannot find module 'p2'.
```
