### PR TITLE
fix moment#diff() definitions

### DIFF
--- a/moment/moment-node.d.ts
+++ b/moment/moment-node.d.ts
@@ -280,9 +280,9 @@ declare module moment {
         to(f: MomentComparable, suffix?: boolean): string;
         toNow(withoutPrefix?: boolean): string;
 
-        diff(b: Moment): number;
-        diff(b: Moment, unitOfTime: string): number;
-        diff(b: Moment, unitOfTime: string, round: boolean): number;
+        diff(b: MomentComparable): number;
+        diff(b: MomentComparable, unitOfTime: string): number;
+        diff(b: MomentComparable, unitOfTime: string, round: boolean): number;
 
         toArray(): number[];
         toDate(): Date;


### PR DESCRIPTION
moment#diff()  accepts a `MonentComparable` as the first argument .

Docs: http://momentjs.com/docs/#/displaying/difference/
