### PR TITLE
Fix oclazyload to Resolve Issue #7477

### DIFF
--- a/oclazyload/oclazyload-tests.ts
+++ b/oclazyload/oclazyload-tests.ts
@@ -89,7 +89,7 @@ angular.module('app').controller(['$ocLazyLoadProvider', function ($ocLazyLoad: 
         'testModule2.js'
     ]);
 
-    $ocLazyLoad.inject('testModule');
+    var promise: ng.IPromise<any> = $ocLazyLoad.inject('testModule');
 
     $ocLazyLoad.toggleWatch(true);
 }]);

--- a/oclazyload/oclazyload.d.ts
+++ b/oclazyload/oclazyload.d.ts
@@ -43,7 +43,7 @@ declare module oc {
          * Injects a module with the associated name into Angular. Useful for manual injection when loading through RequireJS, SystemJS, etc. Useful in 
          * conjunction with the toggleWatch() method.
          */
-        inject(moduleName: string|string[]): boolean;
+        inject(moduleName: string|string[]): ng.IPromise<any>;
 
         /**
          * Enables or disables watching Angular for new modules. Useful in conjunction with the inject() method. Make sure to not keep the watch enabled


### PR DESCRIPTION
Per oclazyload's source code and on the suggestion of @MarkusKramer in Issue #7477, I updated the return type of the `inject` function to be `ng.IPromise<any>` instead of `boolean`. I also updated the corresponding test by assigning the result of the `inject` function to a variable typed as an `ng.IPromise<any>` object.
