### PR TITLE
wrench: Remove 'function' typo

### DIFF
--- a/wrench/wrench-tests.ts
+++ b/wrench/wrench-tests.ts
@@ -17,7 +17,7 @@ wrench.copyDirSyncRecursive(str, str, {
 });
 wrench.chmodSyncRecursive(str, num);
 wrench.chownSyncRecursive(str, num, num);
-wrench.mkdirSyncRecursivefunction(str, num);
+wrench.mkdirSyncRecursive(str, num);
 wrench.readdirRecursive(str, (err: Error, files: string[]) => {
 
 });

--- a/wrench/wrench.d.ts
+++ b/wrench/wrench.d.ts
@@ -11,7 +11,7 @@ declare module "wrench" {
 	export function copyDirSyncRecursive(sourceDir: string, newDirLocation: string, opts?: { preserve?: boolean; }): void;
 	export function chmodSyncRecursive(sourceDir: string, filemode: number): void;
 	export function chownSyncRecursive(sourceDir: string, uid: number, gid: number): void;
-	export function mkdirSyncRecursivefunction(path: string, mode: number): void;
+	export function mkdirSyncRecursive(path: string, mode: number): void;
 
 	export function readdirRecursive(baseDir: string, fn: (err: Error, files: string[]) => void): void;
 	export function rmdirRecursive(path: string, fn: (err: Error) => void): void;


### PR DESCRIPTION
Improvement to existing type definition.
- See https://github.com/ryanmcgrath/wrench-js#synchronous-operations for the typo

That function keyword is a typo that's not supposed to be there.
