### PR TITLE
Missing types on IEditor, fix ICommandRegistry

### DIFF
--- a/atom/atom.d.ts
+++ b/atom/atom.d.ts
@@ -165,7 +165,7 @@ declare module AtomCore {
 	}
 
 	interface ICommandRegistry {
-		add(selector: string, name: string, callback: (event: any) => void): void; // selector:'atom-editor'|'atom-workspace'
+		add(target: string, commandName: Object, callback?: (event: any) => void): any; // selector:'atom-editor'|'atom-workspace'
 		findCommands(params: Object): Object[];
 		dispatch(selector: any, name:string): void;
 	}
@@ -589,6 +589,7 @@ declare module AtomCore {
 		subscriptionCounts: any;
 		subscriptionsByObject: any; /* WeakMap */
 		subscriptions: Emissary.ISubscription[];
+		destroy():void;
 
 		mini: any;
 
@@ -780,6 +781,7 @@ declare module AtomCore {
 		moveCursorToNextWordBoundary():void;
 		moveCursorToBeginningOfNextParagraph():void;
 		moveCursorToBeginningOfPreviousParagraph():void;
+		moveToBottom():void;
 		scrollToCursorPosition(options:any):any;
 		pageUp():void;
 		pageDown():void;


### PR DESCRIPTION
`IEditor` has additional unregistered methods. [Docs](https://atom.io/docs/api/v1.5.3/TextEditor)

`ICommandRegistry` should take a string and object as params. [Docs](https://atom.io/docs/api/v1.5.3/CommandRegistry).

See code for `CommandRegistry.add`:

``` js
 CommandRegistry.prototype.add = function(target, commandName, callback) {
      var commands, disposable;
      if (typeof commandName === 'object') {
        commands = commandName;
        disposable = new CompositeDisposable;
        for (commandName in commands) {
          callback = commands[commandName];
          disposable.add(this.add(target, commandName, callback));
        }
        return disposable;
      }
      if (typeof callback !== 'function') {
        throw new Error("Can't register a command with non-function callback.");
      }
      if (typeof target === 'string') {
        validateSelector(target);
        return this.addSelectorBasedListener(target, commandName, callback);
      } else {
        return this.addInlineListener(target, commandName, callback);
      }
    };
```
