### PR TITLE
Update i18next and express-brute-memcached, add i18next plugins

### DIFF
--- a/connect-timeout/connect-timeout-tests.ts
+++ b/connect-timeout/connect-timeout-tests.ts
@@ -4,7 +4,7 @@
 /// <reference path="../express/express.d.ts" />
 
 import * as express from "express";
-import timeout from "connect-timeout";
+import * as timeout from "connect-timeout";
 import * as bodyParser from "body-parser";
 import * as cookieParser from "cookie-parser";
 

--- a/connect-timeout/connect-timeout.d.ts
+++ b/connect-timeout/connect-timeout.d.ts
@@ -23,17 +23,20 @@ declare module Express {
 declare module "connect-timeout" {
     import express = require("express");
 
-    /**
-     * @summary Interface for timeout options.
-     * @interface
-     */
-    interface TimeoutOptions extends Object {
+    module e {
         /**
-         * @summary Controls if this module will "respond" in the form of forwarding an error.
-         * @type {boolean}
+         * @summary Interface for timeout options.
+         * @interface
          */
-        respond: boolean;
+        interface TimeoutOptions {
+            /**
+             * @summary Controls if this module will "respond" in the form of forwarding an error.
+             * @type {boolean}
+             */
+            respond?: boolean;
+        }
     }
 
-    export default function timeout(timeout: string, options?: TimeoutOptions): express.RequestHandler;
+    function e(timeout: string, options?: e.TimeoutOptions): express.RequestHandler;
+    export = e;
 }

--- a/express-brute-memcached/express-brute-memcached-tests.ts
+++ b/express-brute-memcached/express-brute-memcached-tests.ts
@@ -2,9 +2,9 @@
 /// <reference path="../mongodb/mongodb.d.ts"/>
 /// <reference path="express-brute-memcached.d.ts"/>
 
-import express = require("express");
-import ExpressBrute = require("express-brute");
-import MemcachedStore = require("express-brute-memcached");
+import * as express from "express";
+import * as ExpressBrute from "express-brute";
+import MemcachedStore from "express-brute-memcached";
 
 var app = express();
 var store = new MemcachedStore("127.0.0.1");

--- a/express-brute-memcached/express-brute-memcached.d.ts
+++ b/express-brute-memcached/express-brute-memcached.d.ts
@@ -102,7 +102,7 @@ declare module "express-brute-memcached" {
      * @summary A memcached store adapter.
      * @class
      */
-    export = class MemcachedStore {
+    export default class MemcachedStore {
         /**
          * @summary Constructor.
          * @constructor

--- a/i18next-browser-languagedetector/i18next-browser-languagedetector-tests.ts
+++ b/i18next-browser-languagedetector/i18next-browser-languagedetector-tests.ts
@@ -1,0 +1,45 @@
+/// <reference path="../i18next/i18next.d.ts"/>
+/// <reference path="i18next-browser-languagedetector.d.ts"/>
+
+import * as i18next from 'i18next';
+import LngDetector from 'i18next-browser-languagedetector';
+
+var options = {
+    // order and from where user language should be detected
+    order: ['querystring', 'cookie', 'localStorage', 'navigator'],
+
+    // keys or params to lookup language from
+    lookupQuerystring: 'lng',
+    lookupCookie: 'i18next',
+    lookupLocalStorage: 'i18nextLng',
+
+    // cache user language on
+    caches: ['localStorage', 'cookie'],
+
+    // optional expire and domain for set cookie
+    cookieMinutes: 10,
+    cookieDomain: 'myDomain'
+};
+var myDetector = {
+    name: 'myDetectorsName',
+
+    lookup(options: Object) {
+        // options -> are passed in options
+        return 'en';
+    },
+
+    cacheUserLanguage(lng: string, options: Object) {
+        // options -> are passed in options
+        // lng -> current language, will be called after init and on changeLanguage
+
+        // store it
+    }
+};
+
+i18next.use(LngDetector).init({
+    detection: options
+});
+
+const lngDetector = new LngDetector(null, options);
+lngDetector.init(options);
+lngDetector.addDetector(myDetector);

--- a/i18next-browser-languagedetector/i18next-browser-languagedetector.d.ts
+++ b/i18next-browser-languagedetector/i18next-browser-languagedetector.d.ts
@@ -1,0 +1,88 @@
+// Type definitions for i18next-browser-languagedetector 0.0.14
+// Project: http://i18next.com/
+// Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+///<reference path="../express/express.d.ts"/>
+///<reference path="../i18next/i18next.d.ts"/>
+
+declare module I18next {
+    interface I18nextStatic extends i18nextBrowserLanguageDetector.I18nextStatic { }
+    interface I18nextOptions extends i18nextBrowserLanguageDetector.I18nextOptions { }
+}
+
+declare module i18nextBrowserLanguageDetector {
+    /**
+     * @summary Interface for Language detector options.
+     * @interface
+     */
+    interface LanguageDetectorOptions {
+        caches?: Array<string>|boolean;
+        cookieDomain?: string;
+        cookieExpirationDate?: Date;
+        lookupCookie?: string;
+        lookupFromPathIndex?: number;
+        lookupQuerystring?: string;
+        lookupSession?: string;
+        order?: Array<string>;
+    }
+
+    /**
+     * @summary Interface for custom detector.
+     * @interface
+     */
+    interface CustomDetector {
+        name: string;
+
+        //todo: Checks paramters type.
+        cacheUserLanguage: (lng: string, options: Object) => void;
+        lookup: (options: Object) => string;
+    }
+
+    /**
+     * @summary i18next options.
+     * @interface
+     */
+    interface I18nextOptions {
+        detection?: LanguageDetectorOptions;
+    }
+
+    /**
+     * @summary i18next interface.
+     * @interface
+     */
+    interface I18nextStatic {
+        use(module: LngDetector): I18nextStatic;
+    }
+
+    /**
+     * @summary i18next language detection.
+     * @class
+     */
+    class LngDetector {
+        /**
+         * @summary Constructor.
+         * @constructor
+         */
+        constructor(services?: any, options?: LanguageDetectorOptions);
+
+        /**
+         * @summary Adds detector.
+         * @param {CustomDetector} detector The custom detector.
+         */
+        addDetector(detector: CustomDetector): LngDetector;
+
+        /**
+         * @summary Initializes detector.
+         * @param {LanguageDetectorOptions} options The options.
+         */
+        init(options?: LanguageDetectorOptions): void;
+    }
+}
+
+declare module "i18next-browser-languagedetector" {
+    import * as express from "express";
+    import * as i18next from "i18next";
+
+    export default i18nextBrowserLanguageDetector.LngDetector;
+}

--- a/i18next-express-middleware/i18next-express-middleware.d.ts
+++ b/i18next-express-middleware/i18next-express-middleware.d.ts
@@ -6,19 +6,33 @@
 ///<reference path="../express/express.d.ts"/>
 ///<reference path="../i18next/i18next.d.ts"/>
 
-/**
- * @summary Interface for Language detector options.
- * @interface
- */
-interface LanguageDetectorOptions {
-    caches?: boolean;
-    cookieDomain?: string;
-    cookieExpirationDate?: Date;
-    lookupCookie?: string;
-    lookupFromPathIndex?: number;
-    lookupQuerystring?: string;
-    lookupSession?: string;
-    order?: Array<string>;
+declare module I18next {
+    interface I18nextOptions extends i18nextExpressMiddleware.I18nextOptions { }
+}
+
+declare module i18nextExpressMiddleware {
+    /**
+     * @summary Interface for Language detector options.
+     * @interface
+     */
+    interface LanguageDetectorOptions {
+        caches?: Array<string>|boolean;
+        cookieDomain?: string;
+        cookieExpirationDate?: Date;
+        lookupCookie?: string;
+        lookupFromPathIndex?: number;
+        lookupQuerystring?: string;
+        lookupSession?: string;
+        order?: Array<string>;
+    }
+
+    /**
+     * @summary i18next options.
+     * @interface
+     */
+    interface I18nextOptions {
+        detection?: LanguageDetectorOptions;
+    }
 }
 
 declare module "i18next-express-middleware" {

--- a/i18next-node-fs-backend/i18next-node-fs-backend-tests.ts
+++ b/i18next-node-fs-backend/i18next-node-fs-backend-tests.ts
@@ -1,0 +1,25 @@
+///<reference path="i18next-node-fs-backend.d.ts"/>
+
+import * as i18next from 'i18next';
+import * as Backend from 'i18next-node-fs-backend';
+
+var options = {
+    backend: {
+        // path where resources get loaded from
+        loadPath: '/locales/{{lng}}/{{ns}}.json',
+
+        // path to post missing resources
+        addPath: '/locales/{{lng}}/{{ns}}.missing.json',
+
+        // jsonIndent to use when storing json files
+        jsonIndent: 2
+    }
+};
+
+i18next.use(Backend).init(options);
+i18next.use(Backend).init({ backend: options.backend });
+
+var backend = new Backend(null, options.backend);
+
+backend = new Backend();
+backend.init(options.backend);

--- a/i18next-node-fs-backend/i18next-node-fs-backend.d.ts
+++ b/i18next-node-fs-backend/i18next-node-fs-backend.d.ts
@@ -1,0 +1,58 @@
+// Type definitions for i18next-node-fs-backend
+// Project: https://github.com/i18next/i18next-node-fs-backend
+// Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+///<reference path="../i18next/i18next.d.ts"/>
+
+declare module I18next {
+    interface I18nextOptions extends i18nextNodeFsBackEnd.I18nextOptions { }
+}
+
+declare module i18nextNodeFsBackEnd {
+    /**
+     * @summary Options for "i18next-node-fs-backend".
+     * @interface
+     */
+    interface i18nextNodeFsBackEndOptions {
+        // path where resources get loaded from
+        /**
+         * @summary Path where resources get loaded from.
+         * @type {string}
+         */
+        loadPath: string;
+
+        /**
+         * @summary Path to post missing resources
+         * @type {string}
+         */
+        addPath: string;
+
+        /**
+         * @summary jsonIndent to use when storing json files
+         * @type {number}
+         */
+        //
+        jsonIndent: number;
+    }
+
+    /**
+     * @summary Options for "i18next".
+     * @interface
+     */
+    interface I18nextOptions {
+        backend?: i18nextNodeFsBackEndOptions;
+    }
+}
+
+declare module "i18next-node-fs-backend" {
+    import * as i18next from "i18next";
+
+    class BackEnd {
+        constructor(services?: any, options?: Object);
+        init(options?: Object): void;
+    }
+
+    var out: typeof BackEnd;
+    export = out;
+}

--- a/i18next-sprintf-postprocessor/i18next-sprintf-postprocessor.d.ts
+++ b/i18next-sprintf-postprocessor/i18next-sprintf-postprocessor.d.ts
@@ -6,6 +6,17 @@
 ///<reference path="../express/express.d.ts"/>
 ///<reference path="../i18next/i18next.d.ts"/>
 
+declare module I18next {
+	interface I18nextOptions extends i18nextSprintfPostProcessor.I18nextOptions {}
+}
+
+declare module i18nextSprintfPostProcessor {
+    interface I18nextOptions {
+        overloadTranslationOptionHandler?(args: Array<any>): void;
+        process?(value: any, key: string, options: Object): void;
+    }
+}
+
 declare module "i18next-sprintf-postprocessor" {
     import i18next = require("i18next");
 

--- a/i18next/i18next.d.ts
+++ b/i18next/i18next.d.ts
@@ -10,6 +10,11 @@
 /// <reference path="../i18next-express-middleware/i18next-express-middleware.d.ts" />
 /// <reference path="../i18next-sprintf-postprocessor/i18next-sprintf-postprocessor.d.ts" />
 
+declare module I18next {
+    export interface I18nextStatic {}
+    export interface I18nextOptions {}
+}
+
 interface IResourceStore {
     [language: string]: IResourceStoreLanguage;
 }
@@ -30,12 +35,7 @@ interface I18nTranslateOptions extends I18nextOptions {
     context?: any;
 }
 
-interface i18nextSprintfPostProcessorStatic {
-    overloadTranslationOptionHandler?(args: Array<any>): void;
-    process?(value: any, key: string, options: Object): void;
-}
-
-interface I18nextOptions extends i18nextSprintfPostProcessorStatic {
+interface I18nextOptions extends I18next.I18nextOptions {
     lng?: string;                           // Default value: undefined
     load?: string;                          // Default value: 'all'
     preload?: string[];                     // Default value: []
@@ -85,7 +85,7 @@ interface I18nextOptions extends i18nextSprintfPostProcessorStatic {
     replace?: any;
 }
 
-interface I18nextStatic {
+interface I18nextStatic extends I18next.I18nextStatic {
 
     addPostProcessor(name: string, fn: (value: any, key: string, options: any) => string): void;
     addResources(language: string, namespace: string, resources: IResourceStoreKey): void;
@@ -107,7 +107,7 @@ interface I18nextStatic {
         regexEscape(str: string): string;
     };
     init(callback?: (err: any, t: (key: string, options?: any) => string) => void ): JQueryDeferred<any>;
-    init(options?: I18nextOptions|any, callback?: (err: any, t: (key: string, options?: any) => string) => void ): JQueryDeferred<any>; // NOTE: remove any for 'options' parameter.
+    init(options?: I18nextOptions, callback?: (err: any, t: (key: string, options?: any) => string) => void ): JQueryDeferred<any>;
     lng(): string;
     loadNamespace(namespace: string, callback?: () => void ): void;
     loadNamespaces(namespaces: string[], callback?: () => void ): void;


### PR DESCRIPTION
Add module to extend interface for "i18next".
Add default export for "express-brute-memcached".
Remove unnecessary interface for "i18next-express-middleware".
Add definitions for "i18next-browser-languagedetector" and "i18next-node-fs-backend".

@vvakame Here is a clean pull request.
