### PR TITLE
properly type string enums

### DIFF
--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -8,32 +8,35 @@ declare class Request extends Body {
 	method: string;
 	url: string;
 	headers: Headers;
-	context: string|RequestContext;
+	context: RequestContext;
 	referrer: string;
-	mode: string|RequestMode;
-	credentials: string|RequestCredentials;
-	cache: string|RequestCache;
+	mode: RequestMode;
+	credentials: RequestCredentials;
+	cache: RequestCache;
 }
 
 interface RequestInit {
 	method?: string;
 	headers?: HeaderInit|{ [index: string]: string };
 	body?: BodyInit;
-	mode?: string|RequestMode;
-	credentials?: string|RequestCredentials;
-	cache?: string|RequestCache;
+	mode?: RequestMode;
+	credentials?: RequestCredentials;
+	cache?: RequestCache;
 }
 
-declare enum RequestContext {
-	"audio", "beacon", "cspreport", "download", "embed", "eventsource", "favicon", "fetch",
-	"font", "form", "frame", "hyperlink", "iframe", "image", "imageset", "import",
-	"internal", "location", "manifest", "object", "ping", "plugin", "prefetch", "script",
-	"serviceworker", "sharedworker", "subresource", "style", "track", "video", "worker",
-	"xmlhttprequest", "xslt"
-}
-declare enum RequestMode { "same-origin", "no-cors", "cors" }
-declare enum RequestCredentials { "omit", "same-origin", "include" }
-declare enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" }
+type RequestContext =
+	"audio" | "beacon" | "cspreport" | "download" | "embed" |
+	"eventsource" | "favicon" | "fetch" | "font" | "form" | "frame" |
+	"hyperlink" | "iframe" | "image" | "imageset" | "import" |
+	"internal" | "location" | "manifest" | "object" | "ping" | "plugin" |
+	"prefetch" | "script" | "serviceworker" | "sharedworker" |
+	"subresource" | "style" | "track" | "video" | "worker" |
+	"xmlhttprequest" | "xslt";
+type RequestMode = "same-origin" | "no-cors" | "cors";
+type RequestCredentials = "omit" | "same-origin" | "include";
+type RequestCache =
+	"default" | "no-store" | "reload" | "no-cache" |
+	"force-cache" | "only-if-cached";
 
 declare class Headers {
 	append(name: string, value: string): void;
@@ -58,7 +61,7 @@ declare class Response extends Body {
 	constructor(body?: BodyInit, init?: ResponseInit);
 	error(): Response;
 	redirect(url: string, status: number): Response;
-	type: string|ResponseType;
+	type: ResponseType;
 	url: string;
 	status: number;
 	ok: boolean;
@@ -67,7 +70,7 @@ declare class Response extends Body {
 	clone(): Response;
 }
 
-declare enum ResponseType { "basic", "cors", "default", "error", "opaque" }
+type ResponseType = "basic" | "cors" | "default" | "error" | "opaque";
 
 interface ResponseInit {
 	status: number;


### PR DESCRIPTION
The API is defined in terms of strings.
TypeScript enums' values are numbers and are not correct for
this API.  Drop the enums and use the new string union type
instead, as it was designed for just this use case.

case 2. Improvement to existing type definition.
- see the spec here: https://fetch.spec.whatwg.org/#request-class .  They use the word "enum" there but it means "one of these strings", it doesn't mean "a TypeScript enum".  Search on that page for e.g. "same-origin" (with the quotes) to see that it's defined in terms of strings.
