### PR TITLE
split IDirectivePrePost in interfaces containing at least 1 non-optional field

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1744,9 +1744,17 @@ declare module angular {
         ): void;
     }
 
+    interface IDirectivePre {
+        pre: IDirectiveLinkFn;       
+    }
+
+    interface IDirectivePost {        
+        post: IDirectiveLinkFn;
+    }
+
     interface IDirectivePrePost {
-        pre?: IDirectiveLinkFn;
-        post?: IDirectiveLinkFn;
+        pre: IDirectiveLinkFn;
+        post: IDirectiveLinkFn;
     }
 
     interface IDirectiveCompileFn {
@@ -1762,7 +1770,7 @@ declare module angular {
         controller?: any;
         controllerAs?: string;
         bindToController?: boolean|Object;
-        link?: IDirectiveLinkFn | IDirectivePrePost;
+        link?: IDirectiveLinkFn | IDirectivePrePost | IDirectivePre | IDirectivePost;
         name?: string;
         priority?: number;
         replace?: boolean;


### PR DESCRIPTION
When using typescript and directives [as it is usually done](http://stackoverflow.com/questions/23711158/angularjs-typescript-directive-link-function) (creating a class implementing ng.IDirective), an annoying problem occurs:
 The lack of strong typing on the 'link' function. This is due to its union type including an interface with only optional members (ng.IDirectivePrePost), effectively allowing 'link' to be anything(a primitive type, a function with a different signature than the other member of the union type ng.IDirectiveLinkFn, etc.).

This change would allow enforcing strong typing on the 'link' ng.IDirective member.
