### PR TITLE
Add angular-fullscreen type definition

### DIFF
--- a/angular-fullscreen/angular-fullscreen-tests.ts
+++ b/angular-fullscreen/angular-fullscreen-tests.ts
@@ -1,0 +1,12 @@
+/// <reference path="angular-fullscreen.d.ts" />
+
+angular
+  .module('TestApp', ['FBAngular'])
+  .controller('TestCtrl', (Fullscreen: ng.fullscreen.IFullscreen) => {
+    Fullscreen.all();
+    Fullscreen.toggleAll();
+    Fullscreen.enable(document.getElementById('test-id'));
+    Fullscreen.cancel();
+    Fullscreen.isEnabled();
+    Fullscreen.isSupported();
+  });

--- a/angular-fullscreen/angular-fullscreen.d.ts
+++ b/angular-fullscreen/angular-fullscreen.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for AngularJS HTML5 Fullscreen v1.0.1
+// Project: https://github.com/fabiobiondi/angular-fullscreen
+// Definitions by: Julien Paroche <https://github.com/julienpa>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/angular-fullscreen
+
+/// <reference path="../angularjs/angular.d.ts" />
+
+declare module angular.fullscreen {
+
+  /**
+   * Prefixing interface name with "I" is not recommended: http://www.typescriptlang.org/Handbook#writing-dts-files
+   * However, we let it here to keep consistency with all the other Angular-related definitions
+   */
+  interface IFullscreen {
+    // enable document fullscreen
+    all(): void;
+
+    // enable or disable the document fullscreen
+    toggleAll(): void;
+
+    // enable fullscreen to a specific element
+    enable(element: Element|HTMLElement): void;
+
+    // disable fullscreen
+    cancel(): void;
+
+    // return true if fullscreen is enabled, otherwise false
+    isEnabled(): boolean;
+
+    // return true if fullscreen API is supported by your browser
+    isSupported(): boolean;
+  }
+
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
### PR content
- Add interface for Fullscreen type definition
- Wrap it in angular.fullscreen module
- Add test Angular module
