### PR TITLE
Added Notie definitions

### DIFF
--- a/notie/notie-tests.ts
+++ b/notie/notie-tests.ts
@@ -1,0 +1,24 @@
+/// <reference path='notie.d.ts' />
+
+notie.alert(1, 'Success!', 1.5);
+notie.alert(2, 'Warning<br><b>with</b><br><i>HTML</i><br><u>included.</u>', 2);
+notie.alert(3, 'Error.', 2.5);
+notie.alert(4, 'Information.', 2);
+
+notie.confirm('Are you sure you want to do that?', 'Yes', 'Cancel', function() {
+    notie.alert(1, 'Good choice!', 2);
+});
+notie.confirm('Are you sure?', 'Yes', 'Cancel', function() {
+    notie.confirm('Are you <b>really</b> sure?', 'Yes', 'Cancel', function() {
+        notie.confirm('Are you really <b>really</b> sure?', 'Yes', 'Cancel', function() {
+            notie.alert(1, 'Okay, jeez...', 2);
+        });
+    });
+});
+
+notie.input('Please enter your email address:', 'Submit', 'Cancel', 'email', 'name@example.com', function(value_entered) {
+    notie.alert(1, 'You entered: ' + value_entered, 2);
+});
+notie.input('What city do you live in?', 'Submit', 'Cancel', 'text', 'Enter your city:', function(value_entered) {
+    notie.alert(1, 'You entered: ' + value_entered, 2);
+}, 'New York');

--- a/notie/notie.d.ts
+++ b/notie/notie.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for notie.js
+// Project: https://github.com/jaredreich/notie.js
+// Definitions by: Mateus Demboski <https://github.com/mateusdemboski>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+ 
+declare var notie: {
+    alert: (type: number, message: string, seconds: number) => void;
+    confirm: (title: string, yes_text: string, no_text: string, yes_callback: () => void) => void;
+    input: (title: string, submit_text: string, cancel_text: string, type: string, placeholder: string, submit_callback: (value_entered: string) => void, prefilled_value_optional?: string) => void;
+};


### PR DESCRIPTION
This pull request add a bew type definition file for notie js plugin. Issue #8340
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
