### PR TITLE
Added jquery-truncate-html definitions

### DIFF
--- a/jquery-truncate-html/jquery-truncate-html-tests.ts
+++ b/jquery-truncate-html/jquery-truncate-html-tests.ts
@@ -1,0 +1,5 @@
+/// <reference path="./jquery-truncate-html.d.ts" />
+
+jQuery('<p>Stuff and <i>Nonsense</i></p>').truncate({
+  length: 13
+}).html();

--- a/jquery-truncate-html/jquery-truncate-html-tests.ts
+++ b/jquery-truncate-html/jquery-truncate-html-tests.ts
@@ -1,5 +1,14 @@
 /// <reference path="./jquery-truncate-html.d.ts" />
 
-jQuery('<p>Stuff and <i>Nonsense</i></p>').truncate({
-  length: 13
-}).html();
+
+function truncateHtmlString(): string {
+    return $.truncate('<p>Stuff and <i>Nonsense</i></p>', {
+        length: 13
+    });
+}
+
+function truncateVirtualElement (): JQuery {
+    return $('<p>Stuff and <i>Nonsense</i></p>').truncate({
+        length: 13
+    });
+} 

--- a/jquery-truncate-html/jquery-truncate-html.d.ts
+++ b/jquery-truncate-html/jquery-truncate-html.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference path="../jquery/jquery.d.ts"/>
 
-interface ITruncateOptions{
+interface TruncateOptions{
     length?: number;
     stripTags?: boolean;
     words?: boolean;
@@ -14,9 +14,9 @@ interface ITruncateOptions{
 }
 
 interface JQuery{
-    truncate(options: ITruncateOptions) : JQuery;
+    truncate(options: TruncateOptions) : JQuery;
 }
 
 interface JQueryStatic {
-    truncate(html: string, options: ITruncateOptions) : string;
+    truncate(html: string, options: TruncateOptions) : string;
 }

--- a/jquery-truncate-html/jquery-truncate-html.d.ts
+++ b/jquery-truncate-html/jquery-truncate-html.d.ts
@@ -13,8 +13,8 @@ interface ITruncateOptions{
     ellipsis?: string;
 }
 
-interface jQuery{
-    truncate(options: ITruncateOptions) : jQuery;
+interface JQuery{
+    truncate(options: ITruncateOptions) : JQuery;
 }
 
 interface JQueryStatic {

--- a/jquery-truncate-html/jquery-truncate-html.d.ts
+++ b/jquery-truncate-html/jquery-truncate-html.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for jQuery-truncate-html.js 
+// Project: https://github.com/kbwood/timeentry
+// Definitions by: Abraão Alves <https://github.com/abraaoalves>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../jquery/jquery.d.ts"/>
+
+interface ITruncateOptions{
+    length?: number;
+    stripTags?: boolean;
+    words?: boolean;
+    noBreaks?: boolean;
+    ellipsis?: string;
+}
+
+interface jQuery{
+    truncate(options: ITruncateOptions) : jQuery;
+}
+
+interface JQueryStatic {
+    truncate(html: string, options: ITruncateOptions) : string;
+}


### PR DESCRIPTION
Add a new type definition. Issue #8345
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
