### PR TITLE
auth0.lock - fix module name

### DIFF
--- a/auth0.lock/auth0.lock.d.ts
+++ b/auth0.lock/auth0.lock.d.ts
@@ -78,6 +78,6 @@ interface Auth0LockStatic {
 
 declare var Auth0Lock: Auth0LockStatic;
 
-declare module "Auth0Lock" {
+declare module "auth0-lock" {
     export = Auth0Lock;
 }


### PR DESCRIPTION
The module name for auth0.lock is auth0-lock as seen in the example:

https://github.com/auth0/lock/blob/master/examples/webpack/src/app.js

I'm not sure where the Auth0Lock name came from, but typescript fails to
resolve the module with the name Auth0Lock.
