### PR TITLE
SignalR HubProxy.on() and HubProxy.off() should accept the same parameters, since you unsubscribe the same method...

### DIFF
--- a/signalr/signalr-tests.ts
+++ b/signalr/signalr-tests.ts
@@ -113,8 +113,19 @@ function test_hubs() {
     proxy.on('addMessage', function (msg?) {
         console.log(msg);
     });
+        
+    //a listener may have more than 1 parameter, and you should be able to subscribe and unsubscribe
+    function listenerWithMoreParams(id: number, anything: string){
+    	console.log('listenerWithMoreParams -> ', arguments);
+    };
+    //subscribe
+    proxy.on('listenerWithMoreParams', listenerWithMoreParams);
+    
     var connection = $.hubConnection('http://localhost:8081/');
     connection.start({ jsonp: true });
+
+    //unsubscribe
+    proxy.off('listenerWithMoreParams', listenerWithMoreParams);
 }
 
 // Sample from : https://github.com/SignalR/SignalR/wiki/QuickStart-Hubs#javascript--html 

--- a/signalr/signalr.d.ts
+++ b/signalr/signalr.d.ts
@@ -77,7 +77,7 @@ interface HubProxy {
     init(connection: HubConnection, hubName: string): void;
     hasSubscriptions(): boolean;
     on(eventName: string, callback: (...msg: any[]) => void ): HubProxy;
-    off(eventName: string, callback: (msg: any) => void ): HubProxy;
+    off(eventName: string, callback: (...msg: any[]) => void ): HubProxy;
     invoke(methodName: string, ...args: any[]): JQueryDeferred<any>;
 }
 


### PR DESCRIPTION
HubProxy.on() and HubProxy.off() should accept the same parameters, since you unsubscribe the same method...
