### PR TITLE
Updated pegjs typings to also mirror parser api

### DIFF
--- a/pegjs/pegjs-tests.ts
+++ b/pegjs/pegjs-tests.ts
@@ -1,5 +1,49 @@
 /// <reference path="./pegjs.d.ts" />
+{
+    let input: string;
+    let result = PEG.parse(input);
+    console.log(result);
+}
 
-var input: string;
-var result = PEG.parse(input);
-console.log(result);
+import * as pegjs from 'pegjs';
+
+{
+    let pegparser: pegjs.Parser = pegjs.buildParser("start = ('a' / 'b')+");
+
+    try {
+        let result: string = pegparser.parse("abba");
+    } catch (error) {
+        if (error instanceof pegparser.SyntaxError) {
+            
+        }
+    }
+}
+
+{
+    let parser = pegjs.buildParser("A = 'test'", {
+        cache: true,
+        allowedStartRules: ["A"],
+        optimize: "speed",
+        plugins: []
+    })
+}
+
+try {
+    let parserOrSource: pegjs.Parser | string = pegjs.buildParser("A = 'test'", {output: "source"});
+} catch (error) {
+    if (error instanceof pegjs.GrammarError) {
+        let e: pegjs.GrammarError = error;
+    } else if (error instanceof pegjs.parser.SyntaxError) {
+        let e: pegjs.parser.SyntaxError = error;
+    }
+    
+    let e: pegjs.PegjsError = error;
+    console.log(e.expected[0].description);
+    console.log(e.expected[0].type);
+    console.log(e.expected[0].value);
+    console.log(e.location.end.column);
+    console.log(e.location.end.offset);
+    console.log(e.location.end.line);
+    console.log(e.message);
+    console.log(e.name);
+}

--- a/pegjs/pegjs.d.ts
+++ b/pegjs/pegjs.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for PEG.js
 // Project: http://pegjs.majda.cz/
-// Definitions by: vvakame <https://github.com/vvakame>
+// Definitions by: vvakame <https://github.com/vvakame>, Tobias Kahlert <https://github.com/SrTobi>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module PEG {
@@ -27,4 +27,58 @@ declare module PEG {
 		name:string;
 		message:string;
 	}
+}
+
+declare module "pegjs" {
+    
+    type Location = PEG.Location;
+    type LocationRange = PEG.LocationRange;
+    
+    interface ExpectedItem {
+        type: string;
+        value?: string;
+        description: string;
+    }
+    
+    interface PegjsError extends Error {
+        name: string;
+        message: string;
+        location: LocationRange;
+        found?: any;
+        expected?: ExpectedItem[];
+        stack?: any;
+    }
+    
+    type GrammarError = PegjsError;
+    var GrammarError: any;
+
+    interface ParserOptions {
+        startRule: string;
+        tracer: any;
+    }
+
+    interface Parser {
+        parse(input: string, options?:ParserOptions): any;
+        
+        SyntaxError: any;
+    }
+    
+    interface BuildOptions {
+        cache?: boolean;
+        allowedStartRules?: string[];
+        optimize?: string;
+        plugins?: any[];
+    }
+    
+    interface OutputBuildOptions extends BuildOptions {
+        output?: string;
+    }
+    
+    function buildParser(grammar: string, options?: BuildOptions): Parser;
+    function buildParser(grammar: string, options?: OutputBuildOptions): Parser | string;
+    
+    module parser {
+        type SyntaxError = PegjsError;
+        var SyntaxError: any;
+    }
 }


### PR DESCRIPTION
The current pegjs definition defines typings for already compiled pegjs files. I added an ambient module with typings for the parser api. I didn't touched the existing typings. [Here](http://pegjs.org/documentation) is the documentation of pegjs.
