### PR TITLE
Change react-bootstrap definition to reflect that <OverlayTrigger /> trigger attribute can also be an array of strings

### DIFF
--- a/react-bootstrap/react-bootstrap-tests.tsx
+++ b/react-bootstrap/react-bootstrap-tests.tsx
@@ -375,6 +375,9 @@ export class ReactBootstrapTest extends Component<any, any> {
                     <OverlayTrigger trigger='focus' placement='bottom' overlay={<Popover title='Popover bottom'><strong>Holy guacamole!</strong> Check this info.</Popover>}>
                       <Button bsStyle='default'>Focus</Button>
                     </OverlayTrigger>
+                    <OverlayTrigger trigger={['click', 'hover', 'focus']} placement='bottom' overlay={<Popover title='Popover bottom'><strong>Holy guacamole!</strong> Check this info.</Popover>}>
+                      <Button bsStyle='default'>Click or hover or focus</Button>
+                    </OverlayTrigger>
                     <OverlayTrigger trigger='click' rootClose placement='bottom' overlay={<Popover title='Popover bottom'><strong>Holy guacamole!</strong> Check this info.</Popover>}>
                       <Button bsStyle='default'>Click + rootClose</Button>
                     </OverlayTrigger>

--- a/react-bootstrap/react-bootstrap.d.ts
+++ b/react-bootstrap/react-bootstrap.d.ts
@@ -1,12 +1,12 @@
-// Type definitions for react-bootstrap 
+// Type definitions for react-bootstrap
 // Project: https://github.com/react-bootstrap/react-bootstrap
 // Definitions by: Walker Burgin <https://github.com/walkerburgin>, Vincent Siao <https://github.com/vsiao>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 ///<reference path="../react/react.d.ts"/>
-    
+
 declare module "react-bootstrap" {
-    // Import React 
+    // Import React
     import React = require("react");
 
 
@@ -25,7 +25,7 @@ declare module "react-bootstrap" {
         navDropdown?: boolean;
         componentClass?: string;
         href?: string;
-        onClick?: Function; // Add more specific type 
+        onClick?: Function; // Add more specific type
         target?: string;
         type?: string;
     }
@@ -66,15 +66,15 @@ declare module "react-bootstrap" {
     interface DropdownButtonProps extends React.Props<DropdownButton> {
         bsStyle?: string;
         bsSize?: string;
-        buttonClassName?: string; 
+        buttonClassName?: string;
         className?: string;
         dropup?: boolean;
         href?: string;
-        id?: string | number; 
+        id?: string | number;
         navItem?: boolean;
         noCaret?: boolean;
-        onClick?: Function;  // TODO: Add more specifc type 
-        onSelect?: Function; // TODO: Add more specific type 
+        onClick?: Function;  // TODO: Add more specifc type
+        onSelect?: Function; // TODO: Add more specific type
         pullRight?: boolean;
         title?: any; // TODO: Add more specific type
     }
@@ -83,7 +83,7 @@ declare module "react-bootstrap" {
 
     // <SplitButton />
     // ----------------------------------------
-    interface SplitButtonProps extends React.Props<SplitButton>{ 
+    interface SplitButtonProps extends React.Props<SplitButton>{
         bsStyle?: string;
         bsSize?: string;
         className?: string;
@@ -91,9 +91,9 @@ declare module "react-bootstrap" {
         dropdownTitle?: any; // TODO: Add more specific type
         dropup?: boolean;
         href?: string;
-        id?: string; 
-        onClick?: Function;  // TODO: Add more specific type 
-        onSelect?: Function; // TODO: Add more specific type 
+        id?: string;
+        onClick?: Function;  // TODO: Add more specific type
+        onSelect?: Function; // TODO: Add more specific type
         pullRight?: boolean;
         target?: string;
         title?: any; // TODO: Add more specific type
@@ -133,8 +133,8 @@ declare module "react-bootstrap" {
         footer?: any; // TODO: Add more specific type
         header?: any; // TODO: Add more specific type
         id?: string;
-        onSelect?: Function; // TODO: Add more specific type 
-        onClick?: Function; // TODO: Add more specific type 
+        onSelect?: Function; // TODO: Add more specific type
+        onClick?: Function; // TODO: Add more specific type
     }
     type Panel = React.ClassicComponent<PanelProps, {}>;
     var Panel: React.ClassicComponentClass<PanelProps>;
@@ -151,7 +151,7 @@ declare module "react-bootstrap" {
         footer?: any; // TODO: Add more specific type
         header?: any; // TODO: Add more specific type
         id?: string;
-        onSelect?: Function; // TODO: Add more specific type 
+        onSelect?: Function; // TODO: Add more specific type
     }
     type Accordion = React.ClassicComponent<AccordionProps, {}>;
     var Accordion: React.ClassicComponentClass<AccordionProps>;
@@ -173,7 +173,7 @@ declare module "react-bootstrap" {
     // <Modal.Dialog />
     // ----------------------------------------
     interface ModalDialogProps extends React.Props<ModalDialog> {
-        // TODO: Add more specific type 
+        // TODO: Add more specific type
     }
     type ModalDialog = React.ClassicComponent<ModalDialogProps, {}>;
     var ModalDialog: React.ClassicComponentClass<ModalDialogProps>;
@@ -268,7 +268,7 @@ declare module "react-bootstrap" {
         onExiting?: Function;
         placement?: string;
         rootClose?: boolean;
-        trigger?: string;
+        trigger?: string | string[];
     }
     type OverlayTrigger = React.ClassicComponent<OverlayTriggerProps, {}>;
     var OverlayTrigger: React.ClassicComponentClass<OverlayTriggerProps>;
@@ -282,7 +282,7 @@ declare module "react-bootstrap" {
         bsSize?: string;
         bsStyle?: string;
         className?: string;
-        id?: string; 
+        id?: string;
         placement?: string;
         positionLeft?: number;
         positionTop?: number;
@@ -300,7 +300,7 @@ declare module "react-bootstrap" {
         bsSize?: string;
         bsStyle?: string;
         className?: string;
-        id?: string; 
+        id?: string;
         placement?: string;
         positionLeft?: number;
         positionTop?: number;
@@ -352,7 +352,7 @@ declare module "react-bootstrap" {
 
     // <Nav />
     // ----------------------------------------
-    // TODO: This one turned into a union of two different types 
+    // TODO: This one turned into a union of two different types
     interface NavProps extends React.Props<Nav> {
         // Optional
         activeHref?: string;
@@ -479,13 +479,13 @@ declare module "react-bootstrap" {
     // <Tabs />
     // ----------------------------------------
     interface TabsProps extends React.Props<Tabs> {
-        activeKey?: any; 
+        activeKey?: any;
         animation?: boolean;
         bsStyle?: string;
         defaultActiveKey?: any;
         id?: string | number;
         onSelect?: Function;
-        paneWidth?: any; // TODO: Add more specific type 
+        paneWidth?: any; // TODO: Add more specific type
         position?: string;
         tabWidth?: any; // TODO: Add more specific type
     }
@@ -518,7 +518,7 @@ declare module "react-bootstrap" {
     interface PageItemProps extends React.Props<PageItem> {
         className?: string;
         disabled?: boolean;
-        eventKey?: any; 
+        eventKey?: any;
         href?: string;
         next?: boolean;
         onSelect?: Function;
@@ -580,7 +580,7 @@ declare module "react-bootstrap" {
         pauseOnHover?: boolean;
         prevIcon?: any; // TODO: Add more specific type
         slide?: boolean;
-        wrap?: boolean;   
+        wrap?: boolean;
     }
     type Carousel = React.ClassicComponent<CarouselProps, {}>;
     var Carousel: React.ClassicComponentClass<CarouselProps>;
@@ -605,7 +605,7 @@ declare module "react-bootstrap" {
     interface GridProps extends React.Props<Grid> {
         className?: string;
         componentClass?: any; // TODO: Add more specific type
-        fluid?: boolean; 
+        fluid?: boolean;
     }
     type Grid = React.ClassicComponent<GridProps, {}>;
     var Grid: React.ClassicComponentClass<GridProps>;
@@ -682,9 +682,9 @@ declare module "react-bootstrap" {
         eventKey?: any;
         header?: any; // TODO: Add more specific type
         href?: string;
-        key?: any; // TODO: Add more specific type 
+        key?: any; // TODO: Add more specific type
         listItem?: boolean;
-        onClick?: Function; // TODO: Add more specific type 
+        onClick?: Function; // TODO: Add more specific type
         target?: string;
     }
     class ListGroupItem extends React.Component<ListGroupItemProps, {}> {
@@ -740,7 +740,7 @@ declare module "react-bootstrap" {
     // ----------------------------------------
     interface GlyphiconProps extends React.Props<Glyphicon> {
         className?: string;
-        // Required 
+        // Required
         glyph: string;
     }
     type Glyphicon = React.ClassicComponent<GlyphiconProps, {}>;
@@ -777,18 +777,18 @@ declare module "react-bootstrap" {
         hasFeedback?: boolean;
         help?: any; // TODO: Add more specific type
         id?: string | number;
-        label?: any; // TODO: Add more specific type 
+        label?: any; // TODO: Add more specific type
         labelClassName?: string;
         multiple?: boolean;
         placeholder?: string;
         readOnly?: boolean;
         type?: string;
-        onChange?: Function; // TODO: Add more specific type 
-        onKeyDown?: Function; // TODO: Add more specific type 
-        onKeyUp?: Function; // TODO: Add more specific type 
-        onKeyPress?: Function; // TODO: Add more specific type 
+        onChange?: Function; // TODO: Add more specific type
+        onKeyDown?: Function; // TODO: Add more specific type
+        onKeyUp?: Function; // TODO: Add more specific type
+        onKeyPress?: Function; // TODO: Add more specific type
         value?: any; // TODO: Add more specific type
-        wrapperClassName?: string; 
+        wrapperClassName?: string;
     }
     // TODO: extends InputBase
     class Input extends React.Component<InputProps, {}> {
@@ -810,13 +810,13 @@ declare module "react-bootstrap" {
         hasFeedback?: boolean;
         help?: any; // TODO: Add more specific type
         id?: string | number;
-        label?: any; // TODO: Add more specific type 
+        label?: any; // TODO: Add more specific type
         labelClassName?: string;
         multiple?: boolean;
-        onClick?: Function; // TODO: Add more specific type 
+        onClick?: Function; // TODO: Add more specific type
         type?: string;
         value?: any; // TODO: Add more specific type
-        wrapperClassName?: string; 
+        wrapperClassName?: string;
     }
     // TODO: extends InputBase
     class ButtonInput extends React.Component<ButtonInputProps, {}> {
@@ -833,8 +833,8 @@ declare module "react-bootstrap" {
       Static: StaticClass;
     }
     var FormControls: FormControlsClass;
-  
-  
+
+
     // <Portal />
     // ----------------------------------------
     interface PortalProps extends React.Props<Portal> {
@@ -854,7 +854,7 @@ declare module "react-bootstrap" {
     }
     type Portal = React.ClassicComponent<PortalProps, {}>;
     var Portal: React.ClassicComponentClass<PortalProps>;
-   
+
     // <Position />
     // ----------------------------------------
     interface PositionProps extends React.Props<Position> {


### PR DESCRIPTION
Supporting source code: https://github.com/react-bootstrap/react-bootstrap/blob/master/src/OverlayTrigger.js#L35
