### PR TITLE
Gridstack improvements

### DIFF
--- a/gridstack/gridstack-tests.ts
+++ b/gridstack/gridstack-tests.ts
@@ -13,11 +13,11 @@ var options: IGridstackOptions = {
         cursor: "myCursor"
     }
 };
-var gridstack: GridStack = $(document).gridstack(options).data("gridstack");
+var gridstack = $(document).gridstack(options).data("gridstack");
 
 gridstack.add_widget("test", 1, 2, 3, 4);
 gridstack.batch_update();
 gridstack.cell_height();;
 gridstack.cell_height(2);
 gridstack.cell_width();
-gridstack.get_cell_from_pixel(<MousePosition>{ left:20, top: 20 });
+gridstack.get_cell_from_pixel({ left:20, top: 20 });

--- a/gridstack/gridstack-tests.ts
+++ b/gridstack/gridstack-tests.ts
@@ -7,7 +7,7 @@
 // Definitions by: Pascal Senn <https://github.com/PascalSenn/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-var options: IGridstackOptions = {
+var options: GridStack.IGridstackOptions = {
     float: true,
     draggable: {
         cursor: "myCursor"

--- a/gridstack/gridstack-tests.ts
+++ b/gridstack/gridstack-tests.ts
@@ -13,7 +13,7 @@ var options: IGridstackOptions = {
         cursor: "myCursor"
     }
 };
-var gridstack:GridStack = $(document).gridstack(options);
+var gridstack: GridStack = $(document).gridstack(options).data("gridstack");
 
 gridstack.add_widget("test", 1, 2, 3, 4);
 gridstack.batch_update();

--- a/gridstack/gridstack-tests.ts
+++ b/gridstack/gridstack-tests.ts
@@ -7,8 +7,11 @@
 // Definitions by: Pascal Senn <https://github.com/PascalSenn/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-var options = <IGridstackOptions> {
-    float: true
+var options: IGridstackOptions = {
+    float: true,
+    draggable: {
+        cursor: "myCursor"
+    }
 };
 var gridstack:GridStack = $(document).gridstack(options);
 

--- a/gridstack/gridstack-tests.ts
+++ b/gridstack/gridstack-tests.ts
@@ -15,7 +15,7 @@ var options: IGridstackOptions = {
 };
 var gridstack:GridStack = $(document).gridstack(options);
 
-gridstack.add_widget("test", 1, 2, 3, 4, true);
+gridstack.add_widget("test", 1, 2, 3, 4);
 gridstack.batch_update();
 gridstack.cell_height();;
 gridstack.cell_height(2);

--- a/gridstack/gridstack.d.ts
+++ b/gridstack/gridstack.d.ts
@@ -8,45 +8,62 @@
 interface JQuery {
     gridstack(options: IGridstackOptions): JQuery;
     data(key: 'gridstack'): GridStack;
+    data(key: '_gridstack_node'): GridStackNode;
 }
 
 type GridStackElement = string | Element | JQuery | {};
 
+interface GridStackNode {
+    auto_position: boolean;
+    locked: boolean;
+    no_move: boolean;
+    no_resize: boolean;
+    x: number | string;
+    y: number | string;
+    width: number | string;
+    height: number | string;
+    max_height: number | string;
+    max_width: number | string;
+    min_width: number | string;
+    min_height: number | string;
+}
+
+
 interface GridStack {
     /**
-     * Creates new widget and returns it.
-     *
-     *   Widget will be always placed even if result height is more than actual grid height. You need to use will_it_fit method before calling add_widget for additional check.
-     * 
-     * @param {GridStackElement} el widget to add
-     * @param {number} x widget position x
-     * @param {number} y widget position y
-     * @param {number} width  widget dimension width
-     * @param {number} height widget dimension height
-     * @param {boolean} auto_position if true then x, y parameters will be ignored and widget will be places on the first available position
-     */
+        * Creates new widget and returns it.
+        *
+        *   Widget will be always placed even if result height is more than actual grid height. You need to use will_it_fit method before calling add_widget for additional check.
+        * 
+        * @param {GridStackElement} el widget to add
+        * @param {number} x widget position x
+        * @param {number} y widget position y
+        * @param {number} width  widget dimension width
+        * @param {number} height widget dimension height
+        * @param {boolean} auto_position if true then x, y parameters will be ignored and widget will be places on the first available position
+        */
     add_widget(el: GridStackElement, x?: number, y?: number, width?: number, height?: number, auto_position?: boolean): JQuery
     /**
     * Initializes batch updates. You will see no changes until commit method is called.
     */
-    batch_update():void
+    batch_update(): void
     /**
     * Gets current cell height.
     */
-    cell_height():number
+    cell_height(): number
     /**
     * Update current cell height. This method rebuilds an internal CSS style sheet. Note: You can expect performance issues if call this method too often.
     * @param {number} val the cell height
     */
-    cell_height(val:number):void
+    cell_height(val: number): void
     /**
     * Gets current cell width.
     */
-    cell_width():number
+    cell_width(): number
     /**
     * Finishes batch updates. Updates DOM nodes. You must call it after batch_update.
     */
-    commit():void
+    commit(): void
     /**
     * Destroys a grid instance.
     */
@@ -90,7 +107,7 @@ interface GridStack {
     * @param {number} val A numeric value of the number of rows
     */
     min_height(el: GridStackElement, val: number): void
-     /*
+    /*
     * Enables/Disables moving.
     * @param {GridStackElement} el widget to modify.
     * @param {number} val if true widget will be draggable.
@@ -149,8 +166,8 @@ interface GridStack {
     * @param {number} height  new dimensions height. If value is null or undefined it will be ignored.
     * @param {boolean} auto_position  if true then x, y parameters will be ignored and widget will be places on the first available position
     */
-    will_it_fit(x: number, y: number, width: number, height: number, auto_position:boolean):boolean
-    
+    will_it_fit(x: number, y: number, width: number, height: number, auto_position: boolean): boolean
+
 
 }
 /**
@@ -158,59 +175,49 @@ interface GridStack {
 */
 interface MousePosition {
     top: number,
-    left:number,
+    left: number,
 }
 /**
 *   Defines the position of a cell inside the grid 
 */
 interface CellPosition {
     x: number,
-    y:number
+    y: number
 }
-declare module GridStackUI {
-    interface Utils {
-        /**
-        * Sorts array of nodes
-        *@param nodes array to sort
-        *@param dir 1 for asc, -1 for desc (optional)
-        *@param width width of the grid. If undefined the width will be calculated automatically (optional).
-        **/
-        sort(nodes: HTMLElement[], dir: number, width: number): void
-    }
-}
+
 /**
 * Gridstack Options
 * Defines the options for a Gridstack 
 */
 interface IGridstackOptions {
     /**
-     * if true the resizing handles are shown even if the user is not hovering over the widget (default: false)
-     */
+        * if true the resizing handles are shown even if the user is not hovering over the widget (default: false)
+        */
     always_show_resize_handle?: boolean;
     /**
-     * turns animation on (default: true)
-     */
+        * turns animation on (default: true)
+        */
     animate?: boolean;
     /**
-     * if false gridstack will not initialize existing items (default: true)
-     */
+        * if false gridstack will not initialize existing items (default: true)
+        */
     auto?: boolean;
     /**
-     *  one cell height (default: 60)
-     */
+        *  one cell height (default: 60)
+        */
     cell_height?: number;
     /**
-     * allows to override jQuery UI draggable options. (default: { handle: '.grid-stack-item-content', scroll: true, appendTo: 'body' })
-     */
+        * allows to override jQuery UI draggable options. (default: { handle: '.grid-stack-item-content', scroll: true, appendTo: 'body' })
+        */
     draggable?: JQueryUI.DraggableOptions;
     /**
     * draggable handle selector (default: '.grid-stack-item-content')
     */
-     handle?: string;
+    handle?: string;
     /**
     * maximum rows amount.Default is 0 which means no maximum rows
     */
-     height?: number;
+    height?: number;
     /** 
     * enable floating widgets (default: false) See example
     */
@@ -218,7 +225,7 @@ interface IGridstackOptions {
     /**
     * widget class (default: 'grid-stack-item')
     */
-     item_class?: string;
+    item_class?: string;
     /** 
     * minimal width.If window width is less, grid will be shown in one - column mode (default: 768)
     */
@@ -234,13 +241,25 @@ interface IGridstackOptions {
     /**
     * makes grid static (default false).If true widgets are not movable/ resizable.You don't even need jQueryUI draggable/resizable. A CSS class grid-stack-static is also added to the container.
     */
-    static_grid?: boolean; 
+    static_grid?: boolean;
     /**
     * vertical gap size (default: 20)
     */
-    vertical_margin?: number; 
+    vertical_margin?: number;
     /**
     * amount of columns (default: 12)
     */
     width?: number;
+}
+
+declare namespace GridStackUI {
+    interface Utils {
+        /**
+        * Sorts array of nodes
+        *@param nodes array to sort
+        *@param dir 1 for asc, -1 for desc (optional)
+        *@param width width of the grid. If undefined the width will be calculated automatically (optional).
+        **/
+        sort(nodes: HTMLElement[], dir: number, width: number): void
+    }
 }

--- a/gridstack/gridstack.d.ts
+++ b/gridstack/gridstack.d.ts
@@ -32,7 +32,7 @@ declare namespace GridStack {
 
     interface GridStack {
         /**
-        * Creates new widget and returns it.
+        * Creates new widget, adds it to the grid and DOM, and returns it.
         *
         *   Widget will be always placed even if result height is more than actual grid height. You need to use will_it_fit method before calling add_widget for additional check.
         * 
@@ -44,6 +44,12 @@ declare namespace GridStack {
         * @param {boolean} auto_position if true then x, y parameters will be ignored and widget will be places on the first available position
         */
         add_widget(el: GridStackElement, x?: number, y?: number, width?: number, height?: number, auto_position?: boolean): JQuery
+        /**
+        * Creates new widget, adds it to the grid, and returns it.
+        *
+        * @param {GridStackElement} el widget to create
+        */
+        make_widget(el: GridStackElement): JQuery
         /**
         * Initializes batch updates. You will see no changes until commit method is called.
         */
@@ -131,7 +137,7 @@ declare namespace GridStack {
         /**
         * Removes all widgets from the grid.
         */
-        remove_all(): void
+        remove_all(detach_node?: boolean): void
         /**
         * Changes widget size
         * @param {GridStackElement} el  widget to modify

--- a/gridstack/gridstack.d.ts
+++ b/gridstack/gridstack.d.ts
@@ -6,31 +6,32 @@
 /// <reference path="../jqueryui/jqueryui.d.ts" />
 
 interface JQuery {
-    gridstack(options: IGridstackOptions): JQuery;
-    data(key: 'gridstack'): GridStack;
-    data(key: '_gridstack_node'): GridStackNode;
+    gridstack(options: GridStack.IGridstackOptions): JQuery;
+    data(key: 'gridstack'): GridStack.GridStack;
+    data(key: '_gridstack_node'): GridStack.GridStackNode;
 }
 
-type GridStackElement = string | Element | JQuery | {};
+declare namespace GridStack {
+    type GridStackElement = string | Element | JQuery | {};
 
-interface GridStackNode {
-    auto_position: boolean;
-    locked: boolean;
-    no_move: boolean;
-    no_resize: boolean;
-    x: number | string;
-    y: number | string;
-    width: number | string;
-    height: number | string;
-    max_height: number | string;
-    max_width: number | string;
-    min_width: number | string;
-    min_height: number | string;
-}
+    interface GridStackNode {
+        auto_position: boolean;
+        locked: boolean;
+        no_move: boolean;
+        no_resize: boolean;
+        x: number | string;
+        y: number | string;
+        width: number | string;
+        height: number | string;
+        max_height: number | string;
+        max_width: number | string;
+        min_width: number | string;
+        min_height: number | string;
+    }
 
 
-interface GridStack {
-    /**
+    interface GridStack {
+        /**
         * Creates new widget and returns it.
         *
         *   Widget will be always placed even if result height is more than actual grid height. You need to use will_it_fit method before calling add_widget for additional check.
@@ -42,214 +43,215 @@ interface GridStack {
         * @param {number} height widget dimension height
         * @param {boolean} auto_position if true then x, y parameters will be ignored and widget will be places on the first available position
         */
-    add_widget(el: GridStackElement, x?: number, y?: number, width?: number, height?: number, auto_position?: boolean): JQuery
-    /**
-    * Initializes batch updates. You will see no changes until commit method is called.
-    */
-    batch_update(): void
-    /**
-    * Gets current cell height.
-    */
-    cell_height(): number
-    /**
-    * Update current cell height. This method rebuilds an internal CSS style sheet. Note: You can expect performance issues if call this method too often.
-    * @param {number} val the cell height
-    */
-    cell_height(val: number): void
-    /**
-    * Gets current cell width.
-    */
-    cell_width(): number
-    /**
-    * Finishes batch updates. Updates DOM nodes. You must call it after batch_update.
-    */
-    commit(): void
-    /**
-    * Destroys a grid instance.
-    */
-    destroy(): void
-    /*
-    * Disables widgets moving/resizing.
-    */
-    disable(): void
-    /*
-    * Enables widgets moving/resizing.
-    */
-    enable(): void
-    /*
-    * Get the position of the cell under a pixel on screen.
-    * @param  {MousePosition}  position the position of the pixel to resolve in absolute coordinates, as an object with top and leftproperties
-    */
-    get_cell_from_pixel(position: MousePosition): CellPosition,
-    /*
-    * Checks if specified area is empty.
-    * @param {number} x the position x.
-    * @param {number} y the position y. 
-    * @param {number} width the width of to check
-    * @param {number} height the height of to check
-    */
-    is_area_empty(x: number, y: number, width: number, height: number): void
-    /*
-    * Locks/unlocks widget.
-    * @param {GridStackElement} el widget to modify.
-    * @param {boolean} val if true widget will be locked.
-    */
-    locked(el: GridStackElement, val: boolean): void
-    /*
-    * Set the minWidth for a widget.
-    * @param {GridStackElement} el widget to modify.
-    * @param {number} val A numeric value of the number of columns
-    */
-    min_width(el: GridStackElement, val: number): void
-    /*
-    * Set the minHeight for a widget.
-    * @param {GridStackElement} el widget to modify.
-    * @param {number} val A numeric value of the number of rows
-    */
-    min_height(el: GridStackElement, val: number): void
-    /*
-    * Enables/Disables moving.
-    * @param {GridStackElement} el widget to modify.
-    * @param {number} val if true widget will be draggable.
-    */
-    movable(el: GridStackElement, val: boolean): void
-    /**
-    * Changes widget position
-    * @param {GridStackElement} el  widget to modify
-    * @param {number} x new position x. If value is null or undefined it will be ignored.
-    * @param {number} y new position y. If value is null or undefined it will be ignored.
-    * 
-    */
-    move(el: GridStackElement, x: number, y: number): void
-    /**
-    * Removes widget from the grid.
-    * @param {GridStackElement} el  widget to modify
-    * @param {boolean} detach_node if false DOM node won't be removed from the tree (Optional. Default true).
-    */
-    remove_widget(el: GridStackElement, detach_node?: boolean): void
-    /**
-    * Removes all widgets from the grid.
-    */
-    remove_all(): void
-    /**
-    * Changes widget size
-    * @param {GridStackElement} el  widget to modify
-    * @param {number} width new dimensions width. If value is null or undefined it will be ignored.
-    * @param {number} height  new dimensions height. If value is null or undefined it will be ignored.
-    */
-    resize(el: GridStackElement, width: number, height: number): void
-    /**
-    * Enables/Disables resizing.
-    * @param {GridStackElement} el  widget to modify
-    * @param {boolean} val  if true widget will be resizable.
-    */
-    resizable(el: GridStackElement, val: boolean): void
-    /**
-    * Toggle the grid static state. Also toggle the grid-stack-static class.
-    * @param {boolean} static_value if true the grid become static.
-    */
-    set_static(static_value: boolean): void
-    /**
-    * Updates widget position/size.
-    * @param {GridStackElement} el  widget to modify
-    * @param {number} x new position x. If value is null or undefined it will be ignored.
-    * @param {number} y new position y. If value is null or undefined it will be ignored.
-    * @param {number} width new dimensions width. If value is null or undefined it will be ignored.
-    * @param {number} height  new dimensions height. If value is null or undefined it will be ignored.
-    */
-    update(el: GridStackElement, x: number, y: number, width: number, height: number): void
-    /**
-    * Returns true if the height of the grid will be less the vertical constraint. Always returns true if grid doesn't have height constraint.
-    * @param {number} x new position x. If value is null or undefined it will be ignored.
-    * @param {number} y new position y. If value is null or undefined it will be ignored.
-    * @param {number} width new dimensions width. If value is null or undefined it will be ignored.
-    * @param {number} height  new dimensions height. If value is null or undefined it will be ignored.
-    * @param {boolean} auto_position  if true then x, y parameters will be ignored and widget will be places on the first available position
-    */
-    will_it_fit(x: number, y: number, width: number, height: number, auto_position: boolean): boolean
+        add_widget(el: GridStackElement, x?: number, y?: number, width?: number, height?: number, auto_position?: boolean): JQuery
+        /**
+        * Initializes batch updates. You will see no changes until commit method is called.
+        */
+        batch_update(): void
+        /**
+        * Gets current cell height.
+        */
+        cell_height(): number
+        /**
+        * Update current cell height. This method rebuilds an internal CSS style sheet. Note: You can expect performance issues if call this method too often.
+        * @param {number} val the cell height
+        */
+        cell_height(val: number): void
+        /**
+        * Gets current cell width.
+        */
+        cell_width(): number
+        /**
+        * Finishes batch updates. Updates DOM nodes. You must call it after batch_update.
+        */
+        commit(): void
+        /**
+        * Destroys a grid instance.
+        */
+        destroy(): void
+        /*
+        * Disables widgets moving/resizing.
+        */
+        disable(): void
+        /*
+        * Enables widgets moving/resizing.
+        */
+        enable(): void
+        /*
+        * Get the position of the cell under a pixel on screen.
+        * @param  {MousePosition}  position the position of the pixel to resolve in absolute coordinates, as an object with top and leftproperties
+        */
+        get_cell_from_pixel(position: MousePosition): CellPosition,
+        /*
+        * Checks if specified area is empty.
+        * @param {number} x the position x.
+        * @param {number} y the position y. 
+        * @param {number} width the width of to check
+        * @param {number} height the height of to check
+        */
+        is_area_empty(x: number, y: number, width: number, height: number): void
+        /*
+        * Locks/unlocks widget.
+        * @param {GridStackElement} el widget to modify.
+        * @param {boolean} val if true widget will be locked.
+        */
+        locked(el: GridStackElement, val: boolean): void
+        /*
+        * Set the minWidth for a widget.
+        * @param {GridStackElement} el widget to modify.
+        * @param {number} val A numeric value of the number of columns
+        */
+        min_width(el: GridStackElement, val: number): void
+        /*
+        * Set the minHeight for a widget.
+        * @param {GridStackElement} el widget to modify.
+        * @param {number} val A numeric value of the number of rows
+        */
+        min_height(el: GridStackElement, val: number): void
+        /*
+        * Enables/Disables moving.
+        * @param {GridStackElement} el widget to modify.
+        * @param {number} val if true widget will be draggable.
+        */
+        movable(el: GridStackElement, val: boolean): void
+        /**
+        * Changes widget position
+        * @param {GridStackElement} el  widget to modify
+        * @param {number} x new position x. If value is null or undefined it will be ignored.
+        * @param {number} y new position y. If value is null or undefined it will be ignored.
+        * 
+        */
+        move(el: GridStackElement, x: number, y: number): void
+        /**
+        * Removes widget from the grid.
+        * @param {GridStackElement} el  widget to modify
+        * @param {boolean} detach_node if false DOM node won't be removed from the tree (Optional. Default true).
+        */
+        remove_widget(el: GridStackElement, detach_node?: boolean): void
+        /**
+        * Removes all widgets from the grid.
+        */
+        remove_all(): void
+        /**
+        * Changes widget size
+        * @param {GridStackElement} el  widget to modify
+        * @param {number} width new dimensions width. If value is null or undefined it will be ignored.
+        * @param {number} height  new dimensions height. If value is null or undefined it will be ignored.
+        */
+        resize(el: GridStackElement, width: number, height: number): void
+        /**
+        * Enables/Disables resizing.
+        * @param {GridStackElement} el  widget to modify
+        * @param {boolean} val  if true widget will be resizable.
+        */
+        resizable(el: GridStackElement, val: boolean): void
+        /**
+        * Toggle the grid static state. Also toggle the grid-stack-static class.
+        * @param {boolean} static_value if true the grid become static.
+        */
+        set_static(static_value: boolean): void
+        /**
+        * Updates widget position/size.
+        * @param {GridStackElement} el  widget to modify
+        * @param {number} x new position x. If value is null or undefined it will be ignored.
+        * @param {number} y new position y. If value is null or undefined it will be ignored.
+        * @param {number} width new dimensions width. If value is null or undefined it will be ignored.
+        * @param {number} height  new dimensions height. If value is null or undefined it will be ignored.
+        */
+        update(el: GridStackElement, x: number, y: number, width: number, height: number): void
+        /**
+        * Returns true if the height of the grid will be less the vertical constraint. Always returns true if grid doesn't have height constraint.
+        * @param {number} x new position x. If value is null or undefined it will be ignored.
+        * @param {number} y new position y. If value is null or undefined it will be ignored.
+        * @param {number} width new dimensions width. If value is null or undefined it will be ignored.
+        * @param {number} height  new dimensions height. If value is null or undefined it will be ignored.
+        * @param {boolean} auto_position  if true then x, y parameters will be ignored and widget will be places on the first available position
+        */
+        will_it_fit(x: number, y: number, width: number, height: number, auto_position: boolean): boolean
 
 
-}
-/**
-* Defines the coordiantes of a object
-*/
-interface MousePosition {
-    top: number,
-    left: number,
-}
-/**
-*   Defines the position of a cell inside the grid 
-*/
-interface CellPosition {
-    x: number,
-    y: number
-}
+    }
+    /**
+    * Defines the coordiantes of a object
+    */
+    interface MousePosition {
+        top: number,
+        left: number,
+    }
+    /**
+    *   Defines the position of a cell inside the grid 
+    */
+    interface CellPosition {
+        x: number,
+        y: number
+    }
 
-/**
-* Gridstack Options
-* Defines the options for a Gridstack 
-*/
-interface IGridstackOptions {
     /**
-        * if true the resizing handles are shown even if the user is not hovering over the widget (default: false)
+    * Gridstack Options
+    * Defines the options for a Gridstack 
+    */
+    interface IGridstackOptions {
+        /**
+            * if true the resizing handles are shown even if the user is not hovering over the widget (default: false)
+            */
+        always_show_resize_handle?: boolean;
+        /**
+            * turns animation on (default: true)
+            */
+        animate?: boolean;
+        /**
+            * if false gridstack will not initialize existing items (default: true)
+            */
+        auto?: boolean;
+        /**
+            *  one cell height (default: 60)
+            */
+        cell_height?: number;
+        /**
+            * allows to override jQuery UI draggable options. (default: { handle: '.grid-stack-item-content', scroll: true, appendTo: 'body' })
+            */
+        draggable?: JQueryUI.DraggableOptions;
+        /**
+        * draggable handle selector (default: '.grid-stack-item-content')
         */
-    always_show_resize_handle?: boolean;
-    /**
-        * turns animation on (default: true)
+        handle?: string;
+        /**
+        * maximum rows amount.Default is 0 which means no maximum rows
         */
-    animate?: boolean;
-    /**
-        * if false gridstack will not initialize existing items (default: true)
+        height?: number;
+        /** 
+        * enable floating widgets (default: false) See example
         */
-    auto?: boolean;
-    /**
-        *  one cell height (default: 60)
+        float?: boolean;
+        /**
+        * widget class (default: 'grid-stack-item')
         */
-    cell_height?: number;
-    /**
-        * allows to override jQuery UI draggable options. (default: { handle: '.grid-stack-item-content', scroll: true, appendTo: 'body' })
+        item_class?: string;
+        /** 
+        * minimal width.If window width is less, grid will be shown in one - column mode (default: 768)
         */
-    draggable?: JQueryUI.DraggableOptions;
-    /**
-    * draggable handle selector (default: '.grid-stack-item-content')
-    */
-    handle?: string;
-    /**
-    * maximum rows amount.Default is 0 which means no maximum rows
-    */
-    height?: number;
-    /** 
-    * enable floating widgets (default: false) See example
-    */
-    float?: boolean;
-    /**
-    * widget class (default: 'grid-stack-item')
-    */
-    item_class?: string;
-    /** 
-    * minimal width.If window width is less, grid will be shown in one - column mode (default: 768)
-    */
-    min_width?: number;
-    /**
-    * class for placeholder (default: 'grid-stack-placeholder')
-    */
-    placeholder_class?: string;
-    /**
-    * allows to override jQuery UI resizable options. (default: { autoHide: true, handles: 'se' })
-    */
-    resizable?: JQueryUI.ResizableOptions;
-    /**
-    * makes grid static (default false).If true widgets are not movable/ resizable.You don't even need jQueryUI draggable/resizable. A CSS class grid-stack-static is also added to the container.
-    */
-    static_grid?: boolean;
-    /**
-    * vertical gap size (default: 20)
-    */
-    vertical_margin?: number;
-    /**
-    * amount of columns (default: 12)
-    */
-    width?: number;
+        min_width?: number;
+        /**
+        * class for placeholder (default: 'grid-stack-placeholder')
+        */
+        placeholder_class?: string;
+        /**
+        * allows to override jQuery UI resizable options. (default: { autoHide: true, handles: 'se' })
+        */
+        resizable?: JQueryUI.ResizableOptions;
+        /**
+        * makes grid static (default false).If true widgets are not movable/ resizable.You don't even need jQueryUI draggable/resizable. A CSS class grid-stack-static is also added to the container.
+        */
+        static_grid?: boolean;
+        /**
+        * vertical gap size (default: 20)
+        */
+        vertical_margin?: number;
+        /**
+        * amount of columns (default: 12)
+        */
+        width?: number;
+    }
 }
 
 declare namespace GridStackUI {

--- a/gridstack/gridstack.d.ts
+++ b/gridstack/gridstack.d.ts
@@ -181,61 +181,61 @@ interface IGridstackOptions {
     /**
      * if true the resizing handles are shown even if the user is not hovering over the widget (default: false)
      */
-    always_show_resize_handle: boolean;
+    always_show_resize_handle?: boolean;
     /**
      * turns animation on (default: true)
      */
-    animate: boolean;
+    animate?: boolean;
     /**
      * if false gridstack will not initialize existing items (default: true)
      */
-    auto: boolean;
+    auto?: boolean;
     /**
      *  one cell height (default: 60)
      */
-    cell_height: number;
+    cell_height?: number;
     /**
      * allows to override jQuery UI draggable options. (default: { handle: '.grid-stack-item-content', scroll: true, appendTo: 'body' })
      */
-    draggable: {};
+    draggable?: {};
     /**
     * draggable handle selector (default: '.grid-stack-item-content')
     */
-     handle: string;
+     handle?: string;
     /**
     * maximum rows amount.Default is 0 which means no maximum rows
     */
-     height: number;
+     height?: number;
     /** 
     * enable floating widgets (default: false) See example
     */
-    float: boolean;
+    float?: boolean;
     /**
     * widget class (default: 'grid-stack-item')
     */
-     item_class: string;
+     item_class?: string;
     /** 
     * minimal width.If window width is less, grid will be shown in one - column mode (default: 768)
     */
-    min_width: number;
+    min_width?: number;
     /**
     * class for placeholder (default: 'grid-stack-placeholder')
     */
-    placeholder_class: string;
+    placeholder_class?: string;
     /**
     * allows to override jQuery UI resizable options. (default: { autoHide: true, handles: 'se' })
     */
-    resizable: {};
+    resizable?: {};
     /**
     * makes grid static (default false).If true widgets are not movable/ resizable.You don't even need jQueryUI draggable/resizable. A CSS class grid-stack-static is also added to the container.
     */
-    static_grid: boolean; 
+    static_grid?: boolean; 
     /**
     * vertical gap size (default: 20)
     */
-    vertical_margin: number; 
+    vertical_margin?: number; 
     /**
     * amount of columns (default: 12)
     */
-    width: number;
+    width?: number;
 }

--- a/gridstack/gridstack.d.ts
+++ b/gridstack/gridstack.d.ts
@@ -6,7 +6,8 @@
 /// <reference path="../jqueryui/jqueryui.d.ts" />
 
 interface JQuery {
-    gridstack (options: IGridstackOptions):GridStack
+    gridstack(options: IGridstackOptions): JQuery;
+    data(key: 'gridstack'): GridStack;
 }
 
 type GridStackElement = string | Element | JQuery | {};

--- a/gridstack/gridstack.d.ts
+++ b/gridstack/gridstack.d.ts
@@ -15,14 +15,14 @@ interface GridStack {
      *
      *   Widget will be always placed even if result height is more than actual grid height. You need to use will_it_fit method before calling add_widget for additional check.
      * 
-     * @param {string} el widget to add
+     * @param {string | Element | JQuery | {}} el widget to add
      * @param {number} x widget position x
      * @param {number} y widget position y
      * @param {number} width  widget dimension width
      * @param {number} height widget dimension height
      * @param {boolean} auto_position if true then x, y parameters will be ignored and widget will be places on the first available position
      */
-    add_widget(el: string, x?: number, y?: number, width?: number, height?: number, auto_position?: boolean): JQuery
+    add_widget(el: string | Element | JQuery | {}, x?: number, y?: number, width?: number, height?: number, auto_position?: boolean): JQuery
     /**
     * Initializes batch updates. You will see no changes until commit method is called.
     */

--- a/gridstack/gridstack.d.ts
+++ b/gridstack/gridstack.d.ts
@@ -1,8 +1,9 @@
-﻿/// <reference path="../jqueryui/jqueryui.d.ts" />
-// Type definitions for Gridstack
+﻿// Type definitions for Gridstack
 // Project: http://troolee.github.io/gridstack.js/
 // Definitions by: Pascal Senn <https://github.com/PascalSenn/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../jqueryui/jqueryui.d.ts" />
 
 interface JQuery {
     gridstack (options: IGridstackOptions):GridStack

--- a/gridstack/gridstack.d.ts
+++ b/gridstack/gridstack.d.ts
@@ -9,20 +9,22 @@ interface JQuery {
     gridstack (options: IGridstackOptions):GridStack
 }
 
+type GridStackElement = string | Element | JQuery | {};
+
 interface GridStack {
     /**
      * Creates new widget and returns it.
      *
      *   Widget will be always placed even if result height is more than actual grid height. You need to use will_it_fit method before calling add_widget for additional check.
      * 
-     * @param {string | Element | JQuery | {}} el widget to add
+     * @param {GridStackElement} el widget to add
      * @param {number} x widget position x
      * @param {number} y widget position y
      * @param {number} width  widget dimension width
      * @param {number} height widget dimension height
      * @param {boolean} auto_position if true then x, y parameters will be ignored and widget will be places on the first available position
      */
-    add_widget(el: string | Element | JQuery | {}, x?: number, y?: number, width?: number, height?: number, auto_position?: boolean): JQuery
+    add_widget(el: GridStackElement, x?: number, y?: number, width?: number, height?: number, auto_position?: boolean): JQuery
     /**
     * Initializes batch updates. You will see no changes until commit method is called.
     */
@@ -71,59 +73,59 @@ interface GridStack {
     is_area_empty(x: number, y: number, width: number, height: number): void
     /*
     * Locks/unlocks widget.
-    * @param {HTMLElement} el widget to modify.
+    * @param {GridStackElement} el widget to modify.
     * @param {boolean} val if true widget will be locked.
     */
-    locked(el: HTMLElement, val: boolean): void
+    locked(el: GridStackElement, val: boolean): void
     /*
     * Set the minWidth for a widget.
-    * @param {HTMLElement} el widget to modify.
+    * @param {GridStackElement} el widget to modify.
     * @param {number} val A numeric value of the number of columns
     */
-    min_width(el: HTMLElement, val: number): void
+    min_width(el: GridStackElement, val: number): void
     /*
     * Set the minHeight for a widget.
-    * @param {HTMLElement} el widget to modify.
+    * @param {GridStackElement} el widget to modify.
     * @param {number} val A numeric value of the number of rows
     */
-    min_height(el: HTMLElement, val: number): void
+    min_height(el: GridStackElement, val: number): void
      /*
     * Enables/Disables moving.
-    * @param {HTMLElement} el widget to modify.
+    * @param {GridStackElement} el widget to modify.
     * @param {number} val if true widget will be draggable.
     */
-    movable(el: HTMLElement, val: boolean): void
+    movable(el: GridStackElement, val: boolean): void
     /**
     * Changes widget position
-    * @param {HTMLElement} el  widget to modify
+    * @param {GridStackElement} el  widget to modify
     * @param {number} x new position x. If value is null or undefined it will be ignored.
     * @param {number} y new position y. If value is null or undefined it will be ignored.
     * 
     */
-    move(el: HTMLElement, x: number, y: number): void
+    move(el: GridStackElement, x: number, y: number): void
     /**
     * Removes widget from the grid.
-    * @param {HTMLElement} el  widget to modify
+    * @param {GridStackElement} el  widget to modify
     * @param {boolean} detach_node if false DOM node won't be removed from the tree (Optional. Default true).
     */
-    remove_widget(el: HTMLElement, detach_node?: boolean): void
+    remove_widget(el: GridStackElement, detach_node?: boolean): void
     /**
     * Removes all widgets from the grid.
     */
     remove_all(): void
     /**
     * Changes widget size
-    * @param {HTMLElement} el  widget to modify
+    * @param {GridStackElement} el  widget to modify
     * @param {number} width new dimensions width. If value is null or undefined it will be ignored.
     * @param {number} height  new dimensions height. If value is null or undefined it will be ignored.
     */
-    resize(el: HTMLElement, width: number, height: number): void
+    resize(el: GridStackElement, width: number, height: number): void
     /**
     * Enables/Disables resizing.
-    * @param {HTMLElement} el  widget to modify
+    * @param {GridStackElement} el  widget to modify
     * @param {boolean} val  if true widget will be resizable.
     */
-    resizable(el: HTMLElement, val: boolean): void
+    resizable(el: GridStackElement, val: boolean): void
     /**
     * Toggle the grid static state. Also toggle the grid-stack-static class.
     * @param {boolean} static_value if true the grid become static.
@@ -131,13 +133,13 @@ interface GridStack {
     set_static(static_value: boolean): void
     /**
     * Updates widget position/size.
-    * @param {HTMLElement} el  widget to modify
+    * @param {GridStackElement} el  widget to modify
     * @param {number} x new position x. If value is null or undefined it will be ignored.
     * @param {number} y new position y. If value is null or undefined it will be ignored.
     * @param {number} width new dimensions width. If value is null or undefined it will be ignored.
     * @param {number} height  new dimensions height. If value is null or undefined it will be ignored.
     */
-    update(el: HTMLElement, x: number, y: number, width: number, height: number): void
+    update(el: GridStackElement, x: number, y: number, width: number, height: number): void
     /**
     * Returns true if the height of the grid will be less the vertical constraint. Always returns true if grid doesn't have height constraint.
     * @param {number} x new position x. If value is null or undefined it will be ignored.

--- a/gridstack/gridstack.d.ts
+++ b/gridstack/gridstack.d.ts
@@ -21,7 +21,7 @@ interface GridStack {
      * @param {number} height widget dimension height
      * @param {boolean} auto_position if true then x, y parameters will be ignored and widget will be places on the first available position
      */
-    add_widget(el: string, x: number, y: number, width: number, height: number, auto_position: boolean): JQuery
+    add_widget(el: string, x?: number, y?: number, width?: number, height?: number, auto_position?: boolean): JQuery
     /**
     * Initializes batch updates. You will see no changes until commit method is called.
     */

--- a/gridstack/gridstack.d.ts
+++ b/gridstack/gridstack.d.ts
@@ -1,4 +1,5 @@
-﻿// Type definitions for Gridstack
+﻿/// <reference path="../jqueryui/jqueryui.d.ts" />
+// Type definitions for Gridstack
 // Project: http://troolee.github.io/gridstack.js/
 // Definitions by: Pascal Senn <https://github.com/PascalSenn/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -197,7 +198,7 @@ interface IGridstackOptions {
     /**
      * allows to override jQuery UI draggable options. (default: { handle: '.grid-stack-item-content', scroll: true, appendTo: 'body' })
      */
-    draggable?: {};
+    draggable?: JQueryUI.DraggableOptions;
     /**
     * draggable handle selector (default: '.grid-stack-item-content')
     */
@@ -225,7 +226,7 @@ interface IGridstackOptions {
     /**
     * allows to override jQuery UI resizable options. (default: { autoHide: true, handles: 'se' })
     */
-    resizable?: {};
+    resizable?: JQueryUI.ResizableOptions;
     /**
     * makes grid static (default false).If true widgets are not movable/ resizable.You don't even need jQueryUI draggable/resizable. A CSS class grid-stack-static is also added to the container.
     */


### PR DESCRIPTION
This pull request makes all of the members of `IGridstackOptions` optional, as they all have [defaults](https://github.com/troolee/gridstack.js/tree/master/doc#options). 

Also, changed the types of `IGridstackOptions` members `draggable` and `resizable` from `{}` to `JQueryUI.DraggableOptions` and `JQueryUI.ResizableOptions`, respectively, since that is what the library expects. 
