### PR TITLE
update to Microsoft.Maps.d.ts

### DIFF
--- a/bingmaps/Microsoft.Maps.d.ts
+++ b/bingmaps/Microsoft.Maps.d.ts
@@ -67,8 +67,8 @@ declare module Microsoft.Maps {
 
     export class Events {
 
-        static addHandler(target: any, eventName: string, handler: () => void): any;
-        static addThrottledHandler(target: any, eventName: string, handler: () => void, throttleInterval: number): any;
+        static addHandler(target: any, eventName: string, handler: (e: any) => void): any;
+        static addThrottledHandler(target: any, eventName: string, handler: (e: any) => void, throttleInterval: number): any;
         static hasHandler(target: any, eventName: string): boolean;
         static invoke(target: any, eventName: string, args: any): void;
         static removeHandler(handlerId: any): void;


### PR DESCRIPTION
case 2. Improvement to existing type definition:

Adding the event to the Events.addHandler callback parameters. Documentation showing the event is passed into the callback: https://msdn.microsoft.com/en-us/library/gg427623.aspx
