### PR TITLE
Added faceIndex property to interface THREE.Intersection

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -1633,6 +1633,7 @@ declare module THREE {
         distance: number;
         point: Vector3;
         face: Face3;
+        faceIndex: number;
         object: Object3D;
     }
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Added missing faceIndex property to THREE.Intersection, which is the type of object returned by THREE.Raycaster.intersectObject().  [Reference](http://threejs.org/docs/#Reference/Core/Raycaster.intersectObject)
