### PR TITLE
JQuery: make JQueryXHR.then method generic.

### DIFF
--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -199,6 +199,11 @@ function test_ajax() {
         console.log(jqXHR, textStatus, errorThrown);
     });
 
+    // generic then method
+    var p: JQueryPromise<number> = $.ajax({ url: "test.js" })
+        .then(() => "Hello")
+        .then((x) => x.length);
+
     // jqXHR object
     var jqXHR = $.ajax({
         url: "test.js"

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -180,7 +180,7 @@ interface JQueryXHR extends XMLHttpRequest, JQueryPromise<any> {
     /**
      * Incorporates the functionality of the .done() and .fail() methods, allowing (as of jQuery 1.8) the underlying Promise to be manipulated. Refer to deferred.then() for implementation details.
      */
-    then(doneCallback: (data: any, textStatus: string, jqXHR: JQueryXHR) => void, failCallback?: (jqXHR: JQueryXHR, textStatus: string, errorThrown: any) => void): JQueryPromise<any>;
+    then<R>(doneCallback: (data: any, textStatus: string, jqXHR: JQueryXHR) => R, failCallback?: (jqXHR: JQueryXHR, textStatus: string, errorThrown: any) => void): JQueryPromise<R>;
     /**
      * Property containing the parsed response if the response Content-Type is json
      */


### PR DESCRIPTION
This adds a type parameter `R` to `JQueryXHR.then` method so it will return `JQueryPromise<R>` instead of `JQueryPromise<any>`
