### PR TITLE
Added missing 'returnValue' to jasmine.CallInfo

### DIFF
--- a/jasmine/jasmine-tests.ts
+++ b/jasmine/jasmine-tests.ts
@@ -512,21 +512,21 @@ describe("A spy", function () {
     it("can provide the context and arguments to all calls", function () {
         foo.setBar(123);
 
-        expect(foo.setBar.calls.all()).toEqual([{ object: foo, args: [123] }]);
+        expect(foo.setBar.calls.all()).toEqual([{ object: foo, args: [123], returnValue: undefined }]);
     });
 
     it("has a shortcut to the most recent call", function () {
         foo.setBar(123);
         foo.setBar(456, "baz");
 
-        expect(foo.setBar.calls.mostRecent()).toEqual({ object: foo, args: [456, "baz"] });
+        expect(foo.setBar.calls.mostRecent()).toEqual({ object: foo, args: [456, "baz"], returnValue: undefined });
     });
 
     it("has a shortcut to the first call", function () {
         foo.setBar(123);
         foo.setBar(456, "baz");
 
-        expect(foo.setBar.calls.first()).toEqual({ object: foo, args: [123] });
+        expect(foo.setBar.calls.first()).toEqual({ object: foo, args: [123], returnValue: undefined });
     });
 
     it("can be reset", function () {

--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -456,6 +456,8 @@ declare module jasmine {
         object: any;
         /** All arguments passed to the call */
         args: any[];
+        /** The return value of the call */
+        returnValue: any;
     }
 
     interface Util {


### PR DESCRIPTION
Added missing `returnValue` to `jasmine.CallInfo` interface

case 2. Improvement to existing type definition.
- jasmine 2.2 documentation: http://jasmine.github.io/2.2/introduction.html
- jasmine 2.2 source code reference: https://github.com/jasmine/jasmine/blob/v2.2.0/src/core/base.js#L80
