### PR TITLE
Added CM.registerHelper definition.

### DIFF
--- a/codemirror/codemirror-tests.ts
+++ b/codemirror/codemirror-tests.ts
@@ -39,10 +39,7 @@ var annotation: CodeMirror.Annotation = {
         ch: 0,
         line: 0
     },
-    to: {
-        ch: 1,
-        line: 0
-    },
+    to: CodeMirror.Pos(1),
     message: "test",
     severity: "warning"
 };
@@ -50,3 +47,6 @@ var annotation: CodeMirror.Annotation = {
 myCodeMirror.getValue();
 myCodeMirror.getValue("foo")
 myCodeMirror.setValue("bar");
+
+CodeMirror.registerHelper("lint", "javascript", {});
+

--- a/codemirror/codemirror.d.ts
+++ b/codemirror/codemirror.d.ts
@@ -816,7 +816,7 @@ declare module CodeMirror {
         /** Optional lint configuration to be used in conjunction with CodeMirror's linter addon. */
         lint?: boolean | LintOptions;
 
-        /** Optional value to be used in conjuction with CodeMirror’s placeholder add-on. */
+        /** Optional value to be used in conjunction with CodeMirror’s placeholder add-on. */
         placeholder?: string;
     }
 

--- a/codemirror/codemirror.d.ts
+++ b/codemirror/codemirror.d.ts
@@ -32,6 +32,11 @@ declare module CodeMirror {
     whenever a new CodeMirror instance is initialized. */
     function defineInitHook(func: Function): void;
 
+    /** Registers a helper value with the given name in the given namespace (type). This is used to define functionality
+    that may be looked up by mode. Will create (if it doesn't already exist) a property on the CodeMirror object for
+    the given type, pointing to an object that maps names to values. I.e. after doing
+    CodeMirror.registerHelper("hint", "foo", myFoo), the value CodeMirror.hint.foo will point to myFoo. */
+    function registerHelper(namespace: string, name: string, helper: any): void;
 
 
     function on(element: any, eventName: string, handler: Function): void;
@@ -651,8 +656,8 @@ declare module CodeMirror {
     }
 
     interface PositionConstructor {
-        new (line: number, ch: number): Position;
-        (line: number, ch: number): Position;
+        new (line: number, ch?: number): Position;
+        (line: number, ch?: number): Position;
     }
     
     interface Range{
@@ -811,8 +816,8 @@ declare module CodeMirror {
         /** Optional lint configuration to be used in conjunction with CodeMirror's linter addon. */
         lint?: boolean | LintOptions;
 
-	/** Optional value to be used in conduction with CodeMirror’s placeholder add-on. */
-	placeholder?: string;
+        /** Optional value to be used in conjuction with CodeMirror’s placeholder add-on. */
+        placeholder?: string;
     }
 
     interface TextMarkerOptions {


### PR DESCRIPTION
-- This is defined in the base library and
   used by a lot of addons.
-- Also fixed position constructor definition, as
   given by codemirror docs:

   CodeMirror.Pos(line: integer, ?ch: integer)
- A constructor for the {line, ch} objects that are
- used to represent positions in editor documents.
