### PR TITLE
Changed model from (string | Object) to (string | { [key: string]: an…

### DIFF
--- a/angular-formly/angular-formly.d.ts
+++ b/angular-formly/angular-formly.d.ts
@@ -16,32 +16,34 @@ declare module 'angular-formly' {
 
 declare module AngularFormly {
 
-    interface IFieldArray extends Array<IFieldConfigurationObject | IFieldGroup> {
+	interface IFieldArray extends Array<IFieldConfigurationObject | IFieldGroup> {
 
-    }
+	}
 
 	interface IFieldGroup {
 		data?: {
-	            [key: string]: any;
-	        };
+			[key: string]: any;
+		};
 		className?: string;
 		elementAttributes?: string;
-        fieldGroup?: IFieldArray;
+		fieldGroup?: IFieldArray;
 		form?: Object;
 		hide?: boolean;
 		hideExpression?: string | IExpressionFunction;
 		key?: string | number;
-		model?: string | Object;
-        options?: IFormOptionsAPI;
-        templateOptions?: ITemplateOptions;
-        wrapper?: string | string[];
+		model?: string | {
+			[key: string]: any;
+		};
+		options?: IFormOptionsAPI;
+		templateOptions?: ITemplateOptions;
+		wrapper?: string | string[];
 	}
 
 
 	interface IFormOptionsAPI {
 		data?: {
-                    [key: string]: any;
-                };
+			[key: string]: any;
+		};
 		fieldTransform?: Function;
 		formState?: Object;
 		removeChromeAutoComplete?: boolean;
@@ -182,8 +184,8 @@ declare module AngularFormly {
 		 * see http://docs.angular-formly.com/docs/field-configuration-object#data-object
 		 */
 		data?: {
-                    [key: string]: any;
-                };
+			[key: string]: any;
+		};
 
 
 		/**
@@ -287,7 +289,9 @@ declare module AngularFormly {
 		 *
 		 * see http://docs.angular-formly.com/docs/field-configuration-object#model-object--string
 		 */
-		model?: Object | string;
+		model?: string | {
+			[key: string]: any;
+		};
 
 
 		/**
@@ -543,8 +547,8 @@ declare module AngularFormly {
 		defaultOptions?: IFieldConfigurationObject | Function;
 		controller?: Function | string | any[];
 		data?: {
-                    [key: string]: any;
-                };
+			[key: string]: any;
+		};
 		extends?: string;
 		link?: ng.IDirectiveLinkFn;
 		overwriteOk?: boolean;
@@ -612,7 +616,9 @@ declare module AngularFormly {
 		//The index of the field the form is on (in ng-repeat)
 		index: number;
 		//the model of the form (or the model specified by the field if it was specified).
-		model: Object | string;
+		model?: string | {
+			[key: string]: any;
+		};
 		//Shortcut to options.validation.errorExistsAndShouldBeVisible
 		showError: boolean;
 		//Shortcut to options.templateOptions


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

…y; })

Changed the type of the model properties of various interfaces from (string | Object) to (string | { [key: string]: any; }).
This change is to improve usability. While (string | Object) is correct and corresponds literally to the angular-formly docs, it does not allow for meaningful use without type casts.
Also corrected some formatting to match the prevailing style used in the file.
