### PR TITLE
fix interface property for react-router

### DIFF
--- a/react-router/react-router.d.ts
+++ b/react-router/react-router.d.ts
@@ -65,6 +65,7 @@ declare namespace ReactRouter {
         routes: PlainRoute[]
         params: Params
         components: RouteComponent[]
+        router: Router
     }
 
 
@@ -113,7 +114,7 @@ declare namespace ReactRouter {
     interface RouterContextProps extends React.Props<RouterContext> {
         history?: H.History
         router: Router
-        createElement: (component: RouteComponent, props: Object) => any
+        createElement?: (component: RouteComponent, props: Object) => any
         location: H.Location
         routes: RouteConfig
         params: Params


### PR DESCRIPTION
This patch is to fix type error for react-router module.
Unfortunately, there is no reference about two interface, but I can show a sample code about this.

the sample code is here
https://github.com/reactjs/react-router/blob/master/docs/guides/ServerRendering.md

sample code shows pass renderProps to RouterContext, renderProps type is RouterState interface, RouterContext require RouterContextProps. However RouterState and RouterContextProps is incompatible.(compatible is correct)

I check renderProps type at runtime, and I fix so.
