### PR TITLE
Add missing Divider export

### DIFF
--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -25,6 +25,7 @@ declare module "material-ui" {
     export import DatePicker = __MaterialUI.DatePicker.DatePicker; // require('material-ui/lib/date-picker/date-picker');
     export import DatePickerDialog = __MaterialUI.DatePicker.DatePickerDialog; // require('material-ui/lib/date-picker/date-picker-dialog');
     export import Dialog = __MaterialUI.Dialog // require('material-ui/lib/dialog');
+    export import Divider = __MaterialUI.Divider // require('material-ui/lib/divider');
     export import DropDownMenu = __MaterialUI.Menus.DropDownMenu; // require('material-ui/lib/DropDownMenu/DropDownMenu');
     export import EnhancedButton = __MaterialUI.EnhancedButton; // require('material-ui/lib/enhanced-button');
     export import FlatButton = __MaterialUI.FlatButton; // require('material-ui/lib/flat-button');


### PR DESCRIPTION
Minor improvement of the definition of `material-ui`.

The current definition does not export [Divider](http://www.material-ui.com/#/components/divider) from the main `material-ui` module. The actual definition of `Divider` was already present.
