### PR TITLE
Added CodeMirror loadmode addon

### DIFF
--- a/codemirror-loadmode/codemirror-loadmode-tests.ts
+++ b/codemirror-loadmode/codemirror-loadmode-tests.ts
@@ -1,0 +1,10 @@
+/// <reference path="codemirror-loadmode.d.ts" />
+
+var editor: CodeMirror.Editor = CodeMirror(document.body);
+
+CodeMirror.modeURL = "../mode/%N/%N.js";
+CodeMirror.requireMode("javascript", () => {});
+CodeMirror.autoLoadMode(editor, "javascript");
+
+CodeMirror.requireMode({ name: "javascript" }, () => {});
+CodeMirror.autoLoadMode(editor, { name: "javascript" });

--- a/codemirror-loadmode/codemirror-loadmode.d.ts
+++ b/codemirror-loadmode/codemirror-loadmode.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for CodeMirror loadmode addon
+// Project: https://github.com/marijnh/CodeMirror
+// Definitions by: bossqone <https://github.com/bossqone>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+// See docs https://codemirror.net/doc/manual.html#addon_loadmode
+
+/// <reference path="../codemirror/codemirror.d.ts" />
+
+declare module CodeMirror {
+    var modeURL: string;
+    
+    function requireMode(mode: string, cont: () => void): void;
+    function requireMode(mode: { name: string }, cont: () => void): void;
+    
+    function autoLoadMode(instance: CodeMirror.Editor, mode: string): void;
+    function autoLoadMode(instance: CodeMirror.Editor, mode: { name: string }): void;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
