### PR TITLE
Added CodeMirror meta addon

### DIFF
--- a/codemirror-meta/codemirror-meta-tests.ts
+++ b/codemirror-meta/codemirror-meta-tests.ts
@@ -1,0 +1,17 @@
+/// <reference path="codemirror-meta.d.ts" />
+
+var testModeInfo: CodeMirror.ModeInfo;
+testModeInfo = { name: "test name", mode: "test mode" };
+testModeInfo = { name: "test name", mode: "test mode", mime: "test/mime" };
+testModeInfo = { name: "test name", mode: "test mode", mimes: ["test/mime1", "test/mime2"] };
+testModeInfo = { name: "test name", mode: "test mode", alias: ["test alias"] };
+testModeInfo = { name: "test name", mode: "test mode", ext: ["test extension"] };
+testModeInfo = { name: "test name", mode: "test mode", file: /^TESTFILE$/ };
+testModeInfo = { name: "test name", mode: "test mode", mimes: ["test/mime1", "test/mime2"], alias: ["test alias"], ext: ["test extension"], file: /^TESTFILE$/ };
+
+CodeMirror.modeInfo.push(testModeInfo);
+
+CodeMirror.findModeByMIME("test/mime");
+CodeMirror.findModeByName("test mode");
+CodeMirror.findModeByFileName("test.java");
+CodeMirror.findModeByExtension("java");

--- a/codemirror-meta/codemirror-meta.d.ts
+++ b/codemirror-meta/codemirror-meta.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for CodeMirror meta addon
+// Project: https://github.com/marijnh/CodeMirror
+// Definitions by: bossqone <https://github.com/bossqone>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+// See docs https://codemirror.net/doc/manual.html#addon_meta
+
+/// <reference path="../codemirror/codemirror.d.ts" />
+
+declare module CodeMirror {
+    var modeInfo: CodeMirror.ModeInfo[];
+    
+    function findModeByMIME(mime: string): CodeMirror.ModeInfo;
+    function findModeByExtension(ext: string): CodeMirror.ModeInfo;
+    function findModeByFileName(filename: string): CodeMirror.ModeInfo;
+    function findModeByName(name: string): CodeMirror.ModeInfo;
+    
+    interface ModeInfo {
+        name: string;
+        mode: string;
+        mime?: string;
+        mimes?: string[];
+        ext?: string[];
+        file?: RegExp;
+        alias?: string[];
+    }
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
