### PR TITLE
Add escape-string-regexp and format-unicorn type definitions.

### DIFF
--- a/escape-string-regexp/escape-string-regexp-tests.ts
+++ b/escape-string-regexp/escape-string-regexp-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="escape-string-regexp.d.ts"/>
 
-import escapeStringRegexp from 'escape-string-regexp';
+import escapeStringRegexp = require('escape-string-regexp');
 
 var inputString: string = '^abc$';
 var outputString: string;

--- a/escape-string-regexp/escape-string-regexp-tests.ts
+++ b/escape-string-regexp/escape-string-regexp-tests.ts
@@ -1,0 +1,8 @@
+/// <reference path="escape-string-regexp.d.ts"/>
+
+import escapeStringRegexp from 'escape-string-regexp';
+
+var inputString: string = '^abc$';
+var outputString: string;
+
+outputString = escapeStringRegexp(inputString);

--- a/escape-string-regexp/escape-string-regexp.d.ts
+++ b/escape-string-regexp/escape-string-regexp.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for escape-string-regexp
+// Project: https://github.com/sindresorhus/escape-string-regexp
+// Definitions by: kruncher <https://github.com/kruncher/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module "escape-string-regexp" {
+  
+  export default function (str: string): string;
+  
+}

--- a/escape-string-regexp/escape-string-regexp.d.ts
+++ b/escape-string-regexp/escape-string-regexp.d.ts
@@ -4,7 +4,9 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare module "escape-string-regexp" {
-  
-  export default function (str: string): string;
-  
+
+  function escapeStringRegexp(str: string): string;
+
+  export = escapeStringRegexp;
+
 }

--- a/format-unicorn/format-unicorn-safe-tests.ts
+++ b/format-unicorn/format-unicorn-safe-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="format-unicorn-safe.d.ts"/>
 
-import formatUnicorn from 'format-unicorn/safe';
+import formatUnicorn = require('format-unicorn/safe');
 
 // Safe version
 var outputString: string;

--- a/format-unicorn/format-unicorn-safe-tests.ts
+++ b/format-unicorn/format-unicorn-safe-tests.ts
@@ -1,0 +1,11 @@
+/// <reference path="format-unicorn-safe.d.ts"/>
+
+import formatUnicorn from 'format-unicorn/safe';
+
+// Safe version
+var outputString: string;
+
+outputString = formatUnicorn('Hello, {name}; you have {favoriteNumber}', {
+  name: "kruncher",
+  favoriteNumber: 42
+});

--- a/format-unicorn/format-unicorn-safe.d.ts
+++ b/format-unicorn/format-unicorn-safe.d.ts
@@ -5,6 +5,8 @@
 
 declare module 'format-unicorn/safe' {
 
-  export default function (str: string, replacements: { }): string;
+  function formatUnicornSafe(str: string, replacements: { }): string;
+
+  export = formatUnicornSafe;
 
 }

--- a/format-unicorn/format-unicorn-safe.d.ts
+++ b/format-unicorn/format-unicorn-safe.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for format-unicorn
+// Project: https://github.com/tallesl/format-unicorn
+// Definitions by: kruncher <https://github.com/kruncher/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module 'format-unicorn/safe' {
+
+  export default function (str: string, replacements: { }): string;
+
+}

--- a/format-unicorn/format-unicorn-tests.ts
+++ b/format-unicorn/format-unicorn-tests.ts
@@ -1,0 +1,11 @@
+/// <reference path="format-unicorn.d.ts"/>
+
+import 'format-unicorn';
+
+// Unsafe version
+var outputString: string;
+
+outputString = 'Hello, {name}; you have {favoriteNumber}'.formatUnicorn({
+  name: "kruncher",
+  favoriteNumber: 42
+});

--- a/format-unicorn/format-unicorn.d.ts
+++ b/format-unicorn/format-unicorn.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for format-unicorn
+// Project: https://github.com/tallesl/format-unicorn
+// Definitions by: kruncher <https://github.com/kruncher/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+interface String {
+  formatUnicorn(replacements: { }): string;
+}
+
+declare module "format-unicorn" {
+
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

This is my first contribution to the DefinitelyTyped project; I hope that I ticked all the boxes correctly!
