### PR TITLE
Correct signature of `toThrowError`

### DIFF
--- a/jasmine/jasmine-tests.ts
+++ b/jasmine/jasmine-tests.ts
@@ -150,6 +150,17 @@ describe("Included matchers:", function () {
         expect(foo).not.toThrow();
         expect(bar).toThrow();
     });
+
+    it("The 'toThrowError' matcher is for testing a specific thrown exception", function() {
+        var foo = function() {
+            throw new TypeError("foo bar baz");
+        };
+
+        expect(foo).toThrowError("foo bar baz");
+        expect(foo).toThrowError(/bar/);
+        expect(foo).toThrowError(TypeError);
+        expect(foo).toThrowError(TypeError, "foo bar baz");
+    });
 });
 
 describe("A spec", function () {

--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -297,7 +297,7 @@ declare module jasmine {
         toBeCloseTo(expected: number, precision: any, expectationFailOutput?: any): boolean;
         toThrow(expected?: any): boolean;
         toThrowError(message?: string | RegExp): boolean;
-        toThrowError(expected?: Error, message?: string | RegExp): boolean;
+        toThrowError(expected?: new (...args: any[]) => Error, message?: string | RegExp): boolean;
         not: Matchers;
 
         Any: Any;


### PR DESCRIPTION
Jasmine expects an Error TYPE not an Error VALUE as first parameter. The provided test is copied from the Jasmine website http://jasmine.github.io/2.4/introduction.html
