### PR TITLE
Create a non-instantiated Xrm module

### DIFF
--- a/microsoft-sdk-soap/microsoft-sdk-soap.d.ts
+++ b/microsoft-sdk-soap/microsoft-sdk-soap.d.ts
@@ -2657,22 +2657,22 @@ declare module Sdk.Mdq
 
     export interface IEntityMetadata
     {
-        ActivityTypeMask: any;
+        ActivityTypeMask: number;
         Attributes: IAttributeMetadata[];
         AutoCreateAccessTeams: any;
         AutoRouteToOwnerQueue: boolean;
-        CanBeInManyToMany: boolean;
-        CanBePrimaryEntityInRelationship: boolean;
-        CanBeRelatedEntityInRelationship: boolean;
-        CanCreateAttributes: boolean;
-        CanCreateCharts: boolean;
-        CanCreateForms: boolean;
-        CanCreateViews: boolean;
-        CanModifyAdditionalSettings: boolean;
+        CanBeInManyToMany: ManagedProperty<boolean>;
+        CanBePrimaryEntityInRelationship: ManagedProperty<boolean>;
+        CanBeRelatedEntityInRelationship: ManagedProperty<boolean>;
+        CanCreateAttributes: ManagedProperty<boolean>;
+        CanCreateCharts: ManagedProperty<boolean>;
+        CanCreateForms: ManagedProperty<boolean>;
+        CanCreateViews: ManagedProperty<boolean>;
+        CanModifyAdditionalSettings: ManagedProperty<boolean>;
         CanTriggerWorkflow: boolean;
-        Description: string;
-        DisplayCollectionName: string;
-        DisplayName: string;
+        Description: Label;
+        DisplayCollectionName: Label;
+        DisplayName: Label;
         IconLargeName: string;
         IconMediumName: string;
         IconSmallName: string;
@@ -2680,60 +2680,145 @@ declare module Sdk.Mdq
         IsActivity: boolean;
         IsActivityParty: boolean;
         IsAIRUpdated: boolean;
-        IsAuditEnabled: boolean;
+        IsAuditEnabled: ManagedProperty<boolean>;
         IsAvailableOffline: boolean;
         IsBusinessProcessEnabled: boolean;
         IsChildEntity: boolean;
-        IsConnectionsEnabled: boolean;
+        IsConnectionsEnabled: ManagedProperty<boolean>;
         IsCustomEntity: boolean;
-        IsCustomizable: boolean;
+        IsCustomizable: ManagedProperty<boolean>;
         IsDocumentManagementEnabled: boolean;
-        IsDuplicateDetectionEnabled: boolean;
+        IsDuplicateDetectionEnabled: ManagedProperty<boolean>;
         IsEnabledForCharts: boolean;
         IsImportable: boolean;
         IsIntersect: boolean;
-        IsMailMergeEnabled: boolean;
+        IsMailMergeEnabled: ManagedProperty<boolean>;
         IsManaged: boolean;
-        IsMappable: boolean;
+        IsMappable: ManagedProperty<boolean>;
         IsQuickCreateEnabled: boolean;
         IsReadingPaneEnabled: boolean;
         IsRenameable: boolean;
         IsValidForAdvancedFind: boolean;
-        IsValidForQueue: boolean;
-        IsVisibleInMobile: boolean;
+        IsValidForQueue: ManagedProperty<boolean>;
+        IsVisibleInMobile: ManagedProperty<boolean>;
         IsVisibleInMobileClient: boolean;
         LogicalName: string;
-        ManyToManyRelationships: any;
-        ManyToOneRelationships: any;
+        ManyToManyRelationships: ManyToManyRelationshipMetadata;
+        ManyToOneRelationships: OneToManyRelationshipMetadata;
         MetadataId: string;
         ObjectTypeCode: number;
-        OneToManyRelationships: any;
-        OwnershipType: string;
+        OneToManyRelationships: OneToManyRelationshipMetadata;
+        OwnershipType: "BusinessOwned" | "BusinessParented" | "None	OrganizationOwned" | "TeamOwned	UserOwned";
         PrimaryIdAttribute: string;
         PrimaryImageAttribute: string;
         PrimaryNameAttribute: string;
-        Privileges: any;
+        Privileges: SecurityPrivilegeMetadata[];
         RecurrenceBaseEntityLogicalName: string;
         ReportViewName: string;
         SchemaName: string;
     }
 
+    export interface SecurityPrivilegeMetadata
+    {
+        CanBeBasic: boolean;
+        CanBeDeep: boolean;
+        CanBeEntityReference: boolean;
+        CanBeGlobal: boolean;
+        CanBeLocal: boolean;
+        CanBeParentEntityReference: boolean;
+        ExtensionData: boolean;
+        Name: string;
+        PrivilegeId: string;
+        PrivilegeType: "Append" | "AppendTo" | "Assign" | "Create" | "Delete" | "None" | "Read" | "Share" | "Write";
+    }
+
+    export interface OneToManyRelationshipMetadata
+    {
+        AssociatedMenuConfiguration: AssociatedMenuConfiguration;
+        CascadeConfiguration: CascadeConfiguration;
+        HasChanged: any;
+        IntroducedVersion: any;
+        IsCustomizable: ManagedProperty<boolean>;
+        IsCustomRelationship: boolean;
+        IsHierarchical: any;
+        IsManaged: boolean;
+        IsValidForAdvancedFind: boolean;
+        MetadataId: string;
+        ReferencedAttribute: string;
+        ReferencedEntity: string;
+        ReferencingAttribute: string;
+        ReferencingEntity: string;
+        RelationshipType: string;
+        SchemaName: string;
+        SecurityTypes: any;
+    }
+
+    export interface CascadeConfiguration
+    {
+        Assign: CascadeType;
+        Delete: CascadeType;
+        ExtensionData: CascadeType;
+        Merge: CascadeType;
+        Reparent: CascadeType;
+        Share: CascadeType;
+        Unshare: CascadeType;
+    }
+
+    export type CascadeType = "Active" | "Cascade" | "NoCascade" | "UserOwned";
+
+    export interface ManyToManyRelationshipMetadata
+    {
+        Entity1AssociatedMenuConfiguration: AssociatedMenuConfiguration;
+        Entity1IntersectAttribute: string;
+        Entity1LogicalName: string;
+        Entity2AssociatedMenuConfiguration: AssociatedMenuConfiguration;
+        Entity2IntersectAttribute: string;
+        Entity2LogicalName: string;
+        HasChanged: boolean;
+        IntersectEntityName: string;
+        IntroducedVersion: any;
+        IsCustomizable: ManagedProperty<boolean>;
+        IsCustomRelationship: boolean;
+        IsManaged: boolean;
+        IsValidForAdvancedFind: boolean;
+        MetadataId: string;
+        RelationshipType: RelationshipType;
+        SchemaName: string;
+        SecurityTypes: SecurityType;
+    }
+
+    export interface AssociatedMenuConfiguration
+    {
+        Behavior: AssociatedMenuBehavior;
+        Group: AssociatedMenuGroup;
+        Label: Label;
+        Order: number;
+    }
+
+    export type AssociatedMenuBehavior = "DoNotDisplay" | "UseCollectionName" | "UseLabel";
+
+    export type AssociatedMenuGroup = "Details" | "Marketing" | "Sales" | "Service";
+
+    export type RelationshipType = "Default" | "ManyToManyRelationship" | "OneToManyRelationship";
+
+    export type SecurityType = "Append" | "Inheritance" | "None" | "ParentChild" | "Pointer";
+
     export interface IAttributeMetadata
     {
-        AttributeOf: any;
-        AttributeType: any;
-        AttributeTypeName: string;
+        AttributeOf: string;
+        AttributeType: "Customer" | "DateTime" | "Decimal" | "Double" | "EntityName" | "Integer" | "Lookup" | "ManagedProperty" | "Memo" | "Money" | "Owner" | "PartyList" | "Picklist" | "State" | "Status" | "Uniqueidentifier" | "Virtual"
+        AttributeTypeName: "BigIntType" | "BooleanType" | "CalendarRulesType" | "CustomerType" | "DateTimeType" | "DecimalType" | "DoubleType" | "EntityNameType" | "ImageType" | "IntegerType" | "LookupType" | "ManagedPropertyType" | "MemoType" | "MoneyType" | "OwnerType" | "PartyListType" | "PicklistType" | "StateType	StatusType" | "StringType" | "UniqueidentifierType" | "VirtualType";
         CalculationOf: any;
         CanBeSecuredForCreate: boolean;
         CanBeSecuredForRead: boolean;
         CanBeSecuredForUpdate: boolean;
-        CanModifyAdditionalSettings: boolean;
+        CanModifyAdditionalSettings: ManagedProperty<boolean>;
         ColumnNumber: number;
         DefaultFormValue: any;
         DefaultValue: any;
         DeprecatedVersion: any;
-        Description: string;
-        DisplayName: string;
+        Description: Label;
+        DisplayName: Label;
         EntityLogicalName: string;
         Format: any;
         FormatName: string;
@@ -2741,13 +2826,13 @@ declare module Sdk.Mdq
         IntroducedVersion: any;
         IsAuditEnabled: boolean;
         IsCustomAttribute: boolean;
-        IsCustomizable: boolean;
+        IsCustomizable: ManagedProperty<boolean>;
         IsManaged: boolean;
         IsPrimaryId: boolean;
         IsPrimaryName: boolean;
-        IsRenameable: boolean;
+        IsRenameable: ManagedProperty<boolean>;
         IsSecured: boolean;
-        IsValidForAdvancedFind: boolean;
+        IsValidForAdvancedFind: ManagedProperty<boolean>;
         IsValidForCreate: boolean;
         IsValidForRead: boolean;
         IsValidForUpdate: boolean;
@@ -2760,10 +2845,32 @@ declare module Sdk.Mdq
         OptionSet: any;
         Precision: any;
         PrecisionSource: any;
-        RequiredLevel: any;
+        RequiredLevel: ManagedProperty<string>;
         SchemaName: string;
         Targets: string[];
         YomiOf: any;
+    }
+
+    export interface ManagedProperty<T>
+    {
+        CanBeChanged: boolean;
+        ManagedPropertyLogicalName: string;
+        Value: T;
+    }
+
+    export interface Label
+    {
+        LocalizedLabels: LocalizedLabel[];
+        UserLocalizedLabel: LocalizedLabel;
+    }
+
+    export interface LocalizedLabel
+    {
+        Label: string;
+        LangaugeCode: number;
+        MetadataId: string;
+        HasChanged: boolean;
+        IsManaged: boolean;
     }
 
     module ValueEnums

--- a/xrm/parature.d.ts
+++ b/xrm/parature.d.ts
@@ -12,7 +12,7 @@ declare module Xrm.Page
      *
      * @sa  Control
      */
-    export interface KbSearchControl extends Control
+    export interface KbSearchControl extends XrmInterface.Page.Control
     {
         /**
          * Use this method to add an event handler to the OnResultOpened event.

--- a/xrm/parature.d.ts
+++ b/xrm/parature.d.ts
@@ -12,7 +12,7 @@ declare module Xrm.Page
      *
      * @sa  Control
      */
-    export interface KbSearchControl extends XrmInterface.Page.Control
+    export interface KbSearchControl extends Xrm.Page.Control
     {
         /**
          * Use this method to add an event handler to the OnResultOpened event.

--- a/xrm/xrm-tests.ts
+++ b/xrm/xrm-tests.ts
@@ -1,6 +1,11 @@
 /// <reference path="xrm.d.ts" />
 /// <reference path="parature.d.ts" />
 
+/// Demonstrate usage in the browser's window object
+
+window.Xrm.Utility.alertDialog( "message", () => {} );
+parent.Xrm.Page.context.getOrgLcid();
+
 /// Demonstrate clientglobalcontext.d.ts 
 
 function _getContext()
@@ -27,11 +32,11 @@ var grids = Xrm.Page.getControl(( control ) =>
     return control.getControlType() === "subgrid";
 });
 
-var selectedGridReferences: XrmInterface.Page.LookupValue[] = [];
+var selectedGridReferences: Xrm.Page.LookupValue[] = [];
 
 /// Demonstrate iterator typing with v7.1 additions
 
-grids.forEach(( gridControl: XrmInterface.Page.GridControl ) =>
+grids.forEach(( gridControl: Xrm.Page.GridControl ) =>
 {
     gridControl.getGrid().getSelectedRows().forEach(( row ) =>
     {
@@ -41,8 +46,8 @@ grids.forEach(( gridControl: XrmInterface.Page.GridControl ) =>
 
 /// Demonstrate generic overload vs typecast
 
-var lookupAttribute = <XrmInterface.Page.LookupControl>Xrm.Page.getControl( "customerid" );
-var lookupAttribute2 = Xrm.Page.getControl<XrmInterface.Page.LookupControl>( "customerid" );
+var lookupAttribute = <Xrm.Page.LookupControl>Xrm.Page.getControl( "customerid" );
+var lookupAttribute2 = Xrm.Page.getControl<Xrm.Page.LookupControl>( "customerid" );
 
 /// Demonstrate ES6 String literal syntax
 
@@ -91,7 +96,7 @@ Xrm.Page.data.entity.addOnSave(( context ) =>
 {
     var eventArgs = context.getEventArgs();
 
-    if ( eventArgs.getSaveMode() === XrmInterface.Page.SaveMode.AutoSave || eventArgs.getSaveMode() === XrmInterface.Page.SaveMode.SaveAndClose )
+    if ( eventArgs.getSaveMode() === XrmEnum.SaveMode.AutoSave || eventArgs.getSaveMode() === XrmEnum.SaveMode.SaveAndClose )
         eventArgs.preventDefault();
 });
 

--- a/xrm/xrm-tests.ts
+++ b/xrm/xrm-tests.ts
@@ -27,11 +27,11 @@ var grids = Xrm.Page.getControl(( control ) =>
     return control.getControlType() === "subgrid";
 });
 
-var selectedGridReferences: Xrm.Page.LookupValue[] = [];
+var selectedGridReferences: XrmInterface.Page.LookupValue[] = [];
 
 /// Demonstrate iterator typing with v7.1 additions
 
-grids.forEach(( gridControl: Xrm.Page.GridControl ) =>
+grids.forEach(( gridControl: XrmInterface.Page.GridControl ) =>
 {
     gridControl.getGrid().getSelectedRows().forEach(( row ) =>
     {
@@ -41,8 +41,8 @@ grids.forEach(( gridControl: Xrm.Page.GridControl ) =>
 
 /// Demonstrate generic overload vs typecast
 
-var lookupAttribute = <Xrm.Page.LookupControl>Xrm.Page.getControl( "customerid" );
-var lookupAttribute2 = Xrm.Page.getControl<Xrm.Page.LookupControl>( "customerid" );
+var lookupAttribute = <XrmInterface.Page.LookupControl>Xrm.Page.getControl( "customerid" );
+var lookupAttribute2 = Xrm.Page.getControl<XrmInterface.Page.LookupControl>( "customerid" );
 
 /// Demonstrate ES6 String literal syntax
 
@@ -91,7 +91,7 @@ Xrm.Page.data.entity.addOnSave(( context ) =>
 {
     var eventArgs = context.getEventArgs();
 
-    if ( eventArgs.getSaveMode() === Xrm.Page.SaveMode.AutoSave || eventArgs.getSaveMode() === Xrm.Page.SaveMode.SaveAndClose )
+    if ( eventArgs.getSaveMode() === XrmInterface.Page.SaveMode.AutoSave || eventArgs.getSaveMode() === XrmInterface.Page.SaveMode.SaveAndClose )
         eventArgs.preventDefault();
 });
 

--- a/xrm/xrm.d.ts
+++ b/xrm/xrm.d.ts
@@ -1,5 +1,3 @@
-// Compiled using typings@0.6.10
-// Source: https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/1209610bb338b0e50d15920c82d8f4e312faee26/xrm/xrm.d.ts
 // Type definitions for Microsoft Dynamics xRM API v7.1
 // Project: http://www.microsoft.com/en-us/download/details.aspx?id=44567
 // Definitions by: David Berry <https://github.com/6ix4our/>, Matt Ngan <https://github.com/mattngan/>, Markus Mauch <https://github.com/markusmauch/>

--- a/xrm/xrm.d.ts
+++ b/xrm/xrm.d.ts
@@ -1,9 +1,235 @@
-﻿// Type definitions for Microsoft Dynamics xRM API v7.1
+// Compiled using typings@0.6.10
+// Source: https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/1209610bb338b0e50d15920c82d8f4e312faee26/xrm/xrm.d.ts
+// Type definitions for Microsoft Dynamics xRM API v7.1
 // Project: http://www.microsoft.com/en-us/download/details.aspx?id=44567
-// Definitions by: David Berry <https://github.com/6ix4our/>, Matt Ngan <https://github.com/mattngan/>
+// Definitions by: David Berry <https://github.com/6ix4our/>, Matt Ngan <https://github.com/mattngan/>, Markus Mauch <https://github.com/markusmauch/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare module Xrm
+/**
+ * Injects the Xrm object and GetGlobalContext function into the global namespace.
+ */
+declare var Xrm: XrmStatic;
+declare function GetGlobalContext(): XrmInterface.Context;
+
+/**
+ * Extends the Window interface defined in lib.d.ts and makes the Xrm object and GetGlobalContext function accessible from any window object (window, parent, top, etc.).
+ */
+interface Window
+{
+    /**
+     * A reference to the xRM global object.
+     */
+    Xrm: XrmStatic;
+        
+    /**
+     * Gets the xRM application context, for HTML web resources, included by ClientGlobalContext.js.aspx
+     * @returns {Xrm.Context}   The application context for the user's current session.
+     * @remarks The ClientGlobalContext.js.aspx page will include some global event handlers. These event handlers will
+     *          cancel the onselectstart, contextmenu, and ondragstart events.
+     */
+    GetGlobalContext(): XrmInterface.Context;
+}
+
+/**
+ * Static xRM object.
+ */
+interface XrmStatic
+{
+    /**
+     * Provides a namespace container for the context, data and ui objects.
+     */
+    Page: {
+        /**
+         * Provides methods to retrieve information specific to an organization, a user, or parameters passed to a page.
+         */
+        context: XrmInterface.Context;
+        
+        /**
+         * Provides methods to work with the form.
+         */
+        data: XrmInterface.Data;
+        
+        /**
+         * Contains properties and methods to retrieve information about the user interface as well as collections for several subcomponents of the form.
+         */
+        ui: XrmInterface.Ui;
+        
+        /**
+         * Gets all attributes.
+         *
+         * @return  An array of attributes.
+         */
+        getAttribute(): XrmInterface.Page.Attribute[];
+
+        /**
+         * Gets an attribute matching attributeName.
+         *
+         * @tparam  T   An Attribute type.
+         * @param   {string}    attributeName   Name of the attribute.
+         *
+         * @return  The attribute.
+         */
+        getAttribute<T extends XrmInterface.Page.Attribute>( attributeName: string ): T;
+
+        /**
+         * Gets an attribute matching attributeName.
+         *
+         * @param   {string}    attributeName   Name of the attribute.
+         *
+         * @return  The attribute.
+         */
+        getAttribute( attributeName: string ): XrmInterface.Page.Attribute;
+
+        /**
+         * Gets an attribute by index.
+         *
+         * @param   {number}    index   The attribute index.
+         *
+         * @return  The attribute.
+         */
+        getAttribute( index: number ): XrmInterface.Page.Attribute;
+
+        /**
+         * Gets an attribute.
+         *
+         * @param   {Collection.MatchingDelegate{Attribute}}    delegateFunction    A matching delegate function
+         *
+         * @return  An array of attribute.
+         */
+        getAttribute( delegateFunction: XrmInterface.Collection.MatchingDelegate<XrmInterface.Page.Attribute> ): XrmInterface.Page.Attribute[];
+
+        /**
+         * Gets all controls.
+         *
+         * @return  An array of controls.
+         */
+        getControl(): XrmInterface.Page.Control[];
+
+        /**
+         * Gets a control matching controlName.
+         *
+         * @tparam  T   A Control type
+         * @param   {string}    controlName Name of the control.
+         *
+         * @return  The control.
+         */
+        getControl<T extends XrmInterface.Page.Control>( controlName: string ): T;
+
+        /**
+         * Gets a control matching controlName.
+         *
+         * @param   {string}    controlName Name of the control.
+         *
+         * @return  The control.
+         */
+        getControl( controlName: string ): XrmInterface.Page.Control;
+
+        /**
+         * Gets a control by index.
+         *
+         * @param   {number}    index   The control index.
+         *
+         * @return  The control.
+         */
+        getControl( index: number ): XrmInterface.Page.Control;
+
+        /**
+         * Gets a control.
+         *
+         * @param   {Collection.MatchingDelegate{Control}}  delegateFunction    A matching delegate function.
+         *
+         * @return  An array of control.
+         */
+        getControl( delegateFunction: XrmInterface.Collection.MatchingDelegate<XrmInterface.Page.Control> ): XrmInterface.Page.Control[];
+    }
+    
+    /**
+     * Provides a container for useful functions not directly related to the current page.
+     */
+    Utility: {
+        /**
+         * Displays an alert dialog, with an "OK" button.
+         *
+         * @param   {string}        message         The message.
+         * @param   {function()}    onCloseCallback The "OK" callback.
+         */
+        alertDialog( message: string, onCloseCallback: () => void ): void;
+        
+        /**
+         * Displays a confirmation dialog, with "OK" and "Cancel" buttons.
+         *
+         * @param   {string}        message             The message.
+         * @param   {function()}    yesCloseCallback    The "OK" callback.
+         * @param   {function()}    noCloseCallback     The "Cancel" callback.
+         */
+        confirmDialog( message: string, yesCloseCallback: () => void, noCloseCallback: () => void ): void;
+        
+        /**
+         * Query if 'entityType' is an Activity entity.
+         *
+         * @param   {string}    entityType  Type of the entity.
+         *
+         * @return  true if the entity is an Activity, false if not.
+         */
+        isActivityType( entityType: string ): boolean;
+        
+        /**
+         * Opens quick create.
+         *
+         * @param   {Function}  callback                    The function that will be called when a record is created. This
+         *                                                  function is passed a LookupValue object as a parameter.
+         * @param   {string}    entityLogicalName           The logical name of the entity to create.
+         * @param   {Page.LookupValue}  createFromEntity    (Optional) Designates a record that will provide default values
+         *                                                  based on mapped attribute values.
+         * @param   {OpenParameters}    parameters          (Optional) A dictionary object that passes extra query string
+         *                                                  parameters to the form. Invalid query string parameters will cause an
+         *                                                  error.
+         */
+        openQuickCreate(
+            callback: ( recordReference: XrmInterface.Page.LookupValue ) => void,
+            entityLogicalName: string,
+            createFromEntity?: XrmInterface.Page.LookupValue,
+            parameters?: XrmInterface.Utility.OpenParameters ): void;
+        
+        /**
+         * Opens an entity form.
+         *
+         * @param   {string}    name                The entity's logical name.
+         * @param   {string}    id                  (Optional) The unique identifier for the record.
+         * @param   {FormParameters}    parameters  (Optional) A dictionary object that passes extra query string parameters to the form.
+         * @param   {WindowOptions} windowOptions   (Optional) Options for controlling the window.
+         */
+        openEntityForm( name: string, id?: string, parameters?: XrmInterface.Utility.FormOpenParameters, windowOptions?: XrmInterface.Utility.WindowOptions ): void;
+
+        /**
+         * Opens an HTML Web Resource in a new browser window.
+         *
+         * @param   {string}    webResourceName Name of the HTML web resource. Can be used to pass URL
+         *                                      parameters.  See Remarks.
+         * @param   {string}    webResourceData (Optional) Data to pass into the Web Resource's data parameter.
+         *                                                 It is advised to use encodeURIcomponent() to encode the value.
+         * @param   {number}    width           (Optional) The width of the new window.
+         * @param   {number}    height          (Optional) The height of the new window.
+         *
+         * @return  A Window reference, containing the opened Web Resource.
+         *
+         * @remarks This function will not work with Microsoft Dynamics CRM for tablets.
+         *          Valid WebResource URL Parameters:   typename
+         *                                              type
+         *                                              id
+         *                                              orgname
+         *                                              userlcid
+         *                                              data (identical to this method's webResourceData parameter)
+         *                                              formid
+         */
+        openWebResource( webResourceName: string, webResourceData?: string, width?: number, height?: number ): Window;
+    }   
+}
+
+/**
+ * Ghost module for the Xrm interfaces.
+ */
+declare module XrmInterface
 {
     /**
      * Interface for the client context.
@@ -137,6 +363,170 @@ declare module Xrm
          * @remarks Format: "/"+ OrgName + sPath
          */
         prependOrgName( sPath: string ): string;
+    }
+
+    /**
+     * Interface for the Xrm.Page.data object.
+     */
+    export interface Data
+    {
+        /**
+         * Asynchronously refreshes data on the form, without reloading the page.
+         *
+         * @param   {boolean}   save    true to save the record, after the refresh.
+         *
+         * @return  An Async.XrmPromise.
+         */
+        refresh( save: boolean ): XrmInterface.Async.XrmPromise;
+
+        /**
+         * Asynchronously saves the record.
+         *
+         * @return  An Async.XrmPromise.
+         */
+        save(): XrmInterface.Async.XrmPromise;
+        
+        /**
+         * The record context of the form.
+         */
+        entity: XrmInterface.Page.Entity;
+
+        /**
+         * The process API for Xrm.Page.data.
+         *
+         * @remarks This member may be undefined when Process Flows are not used by the current entity.
+         */
+        process: XrmInterface.Page.data.ProcessManager;
+    }
+
+    /**
+     * Interface for the Xrm.Page.ui object.
+     */
+    export interface Ui
+    {
+        /**
+         * Clears the form notification described by uniqueId.
+         *
+         * @param   {string}    uniqueId    Unique identifier.
+         *
+         * @return  true if it succeeds, otherwise false.
+         */
+        clearFormNotification( uniqueId: string ): boolean;
+
+        /**
+         * Closes the form.
+         */
+        close(): void;
+
+        /**
+         * Gets form type.
+         *
+         * @return  The form type.
+         *
+         * @remarks     Values returned are: 0  Undefined
+         *                                   1  Create
+         *                                   2  Update
+         *                                   3  Read Only
+         *                                   4  Disabled
+         *                                   6  Bulk Edit
+         *              Deprecated values are 5 (Quick Create), and 11 (Read Optimized)
+         */
+        getFormType(): XrmInterface.Page.FormType;
+
+        /**
+         * Gets view port height.
+         *
+         * @return  The view port height, in pixels.
+         *
+         * @remarks This method does not work with Microsoft Dynamics CRM for tablets.
+         */
+        getViewPortHeight(): number;
+
+        /**
+         * Gets view port width.
+         *
+         * @return  The view port width, in pixels.
+         *
+         * @remarks This method does not work with Microsoft Dynamics CRM for tablets.
+         */
+        getViewPortWidth(): number;
+
+        /**
+         * Re-evaluates the ribbon's configured EnableRules
+         *
+         * @remarks This method does not work with Microsoft Dynamics CRM for tablets.
+         */
+        refreshRibbon(): void;
+
+        /**
+         * Sets a form-level notification.
+         *
+         * @param   {string}    message     The message.
+         * @param   {"ERROR"}   level       An error message.
+         * @param   {string}    uniqueId    A unique identifier for the message.
+         *
+         * @return  true if it succeeds, false if it fails.
+         */
+        setFormNotification( message: string, level: "ERROR", uniqueId: string ): boolean;
+
+        /**
+         * Sets a form-level notification.
+         *
+         * @param   {string}    message     The message.
+         * @param   {"WARNING"} level       A warning message.
+         * @param   {string}    uniqueId    A unique identifier for the message.
+         *
+         * @return  true if it succeeds, false if it fails.
+         */
+        setFormNotification( message: string, level: "WARNING", uniqueId: string ): boolean;
+
+        /**
+         * Sets a form-level notification.
+         *
+         * @param   {string}    message     The message.
+         * @param   {"INFO"}    level       An informational message.
+         * @param   {string}    uniqueId    A unique identifier for the message.
+         *
+         * @return  true if it succeeds, false if it fails.
+         */
+        setFormNotification( message: string, level: "INFO", uniqueId: string ): boolean;
+
+        /**
+         * Sets a form-level notification.
+         *
+         * @param   {string}    message     The message.
+         * @param   {string}    level       The level, as either "ERROR", "WARNING", or "INFO".
+         * @param   {string}    uniqueId    A unique identifier for the message.
+         *
+         * @return  true if it succeeds, otherwise false.
+         */
+        setFormNotification( message: string, level: string, uniqueId: string ): boolean;
+
+        process: XrmInterface.Page.data.ProcessManager;
+
+        /**
+         * A reference to the collection of controls on the form.
+         */
+        controls: XrmInterface.Collection.ItemCollection<XrmInterface.Page.Control>;
+
+        /**
+         * The form selector API.
+         *
+         * @remarks This API does not exist with Microsoft Dynamics CRM for tablets.
+         */
+        formSelector: XrmInterface.Page.FormSelector;
+
+        /**
+         * The navigation API.
+         *
+         * @remarks This API does not exist with Microsoft Dynamics CRM for tablets.
+         */
+        navigation: XrmInterface.Page.Navigation;
+
+        /**
+         * A reference to the collection of tabs on the form.
+         */
+        tabs: XrmInterface.Collection.ItemCollection<XrmInterface.Page.Tab>;
     }
 
     /**
@@ -486,7 +876,7 @@ declare module Xrm
              *
              * @return  The event source.
              */
-            getEventSource(): Xrm.Page.Attribute | Xrm.Page.Entity;
+            getEventSource(): XrmInterface.Page.Attribute | XrmInterface.Page.Entity;
 
             /**
              * Gets the shared variable with the specified key.
@@ -1302,34 +1692,6 @@ declare module Xrm
              * Represents a key-value pair, where the key is the Process Flow's ID, and the value is the name thereof.
              */
             export type ProcessDictionary = { [index: string]: string };
-
-            /**
-             * Asynchronously refreshes data on the form, without reloading the page.
-             *
-             * @param   {boolean}   save    true to save the record, after the refresh.
-             *
-             * @return  An Async.XrmPromise.
-             */
-            export function refresh( save: boolean ): Async.XrmPromise;
-
-            /**
-             * Asynchronously saves the record.
-             *
-             * @return  An Async.XrmPromise.
-             */
-            export function save(): Async.XrmPromise;
-
-            /**
-             * The record context of the form.
-             */
-            export var entity: Entity;
-
-            /**
-             * The process API for Xrm.Page.data.
-             *
-             * @remarks This member may be undefined when Process Flows are not used by the current entity.
-             */
-            export var process: ProcessManager;
         }
 
         /**
@@ -1767,7 +2129,7 @@ declare module Xrm
              *
              * @return  The parent.
              */
-            getParent(): typeof ui;
+            getParent(): XrmInterface.Ui;
 
             /**
              * Sets display state of the tab.
@@ -1996,130 +2358,6 @@ declare module Xrm
                  */
                 getEntityReference(): LookupValue;
             }
-
-            /**
-             * Clears the form notification described by uniqueId.
-             *
-             * @param   {string}    uniqueId    Unique identifier.
-             *
-             * @return  true if it succeeds, otherwise false.
-             */
-            export function clearFormNotification( uniqueId: string ): boolean;
-
-            /**
-             * Closes the form.
-             */
-            export function close(): void;
-
-            /**
-             * Gets form type.
-             *
-             * @return  The form type.
-             *
-             * @remarks     Values returned are: 0  Undefined
-             *                                   1  Create
-             *                                   2  Update
-             *                                   3  Read Only
-             *                                   4  Disabled
-             *                                   6  Bulk Edit
-             *              Deprecated values are 5 (Quick Create), and 11 (Read Optimized)
-             */
-            export function getFormType(): FormType;
-
-            /**
-             * Gets view port height.
-             *
-             * @return  The view port height, in pixels.
-             *
-             * @remarks This method does not work with Microsoft Dynamics CRM for tablets.
-             */
-            export function getViewPortHeight(): number;
-
-            /**
-             * Gets view port width.
-             *
-             * @return  The view port width, in pixels.
-             *
-             * @remarks This method does not work with Microsoft Dynamics CRM for tablets.
-             */
-            export function getViewPortWidth(): number;
-
-            /**
-             * Re-evaluates the ribbon's configured EnableRules
-             *
-             * @remarks This method does not work with Microsoft Dynamics CRM for tablets.
-             */
-            export function refreshRibbon(): void;
-
-            /**
-             * Sets a form-level notification.
-             *
-             * @param   {string}    message     The message.
-             * @param   {"ERROR"}   level       An error message.
-             * @param   {string}    uniqueId    A unique identifier for the message.
-             *
-             * @return  true if it succeeds, false if it fails.
-             */
-            export function setFormNotification( message: string, level: "ERROR", uniqueId: string ): boolean;
-
-            /**
-             * Sets a form-level notification.
-             *
-             * @param   {string}    message     The message.
-             * @param   {"WARNING"} level       A warning message.
-             * @param   {string}    uniqueId    A unique identifier for the message.
-             *
-             * @return  true if it succeeds, false if it fails.
-             */
-            export function setFormNotification( message: string, level: "WARNING", uniqueId: string ): boolean;
-
-            /**
-             * Sets a form-level notification.
-             *
-             * @param   {string}    message     The message.
-             * @param   {"INFO"}    level       An informational message.
-             * @param   {string}    uniqueId    A unique identifier for the message.
-             *
-             * @return  true if it succeeds, false if it fails.
-             */
-            export function setFormNotification( message: string, level: "INFO", uniqueId: string ): boolean;
-
-            /**
-             * Sets a form-level notification.
-             *
-             * @param   {string}    message     The message.
-             * @param   {string}    level       The level, as either "ERROR", "WARNING", or "INFO".
-             * @param   {string}    uniqueId    A unique identifier for the message.
-             *
-             * @return  true if it succeeds, otherwise false.
-             */
-            export function setFormNotification( message: string, level: string, uniqueId: string ): boolean;
-
-            export var process: ProcessManager;
-
-            /**
-             * A reference to the collection of controls on the form.
-             */
-            export var controls: Collection.ItemCollection<Control>;
-
-            /**
-             * The form selector API.
-             *
-             * @remarks This API does not exist with Microsoft Dynamics CRM for tablets.
-             */
-            export var formSelector: FormSelector;
-
-            /**
-             * The navigation API.
-             *
-             * @remarks This API does not exist with Microsoft Dynamics CRM for tablets.
-             */
-            export var navigation: Navigation;
-
-            /**
-             * A reference to the collection of tabs on the form.
-             */
-            export var tabs: Collection.ItemCollection<Tab>;
         }
 
         /**
@@ -2193,99 +2431,6 @@ declare module Xrm
              */
             items: Collection.ItemCollection<FormItem>;
         }
-
-        /**
-         * A reference to the xRM application context.
-         */
-        export var context: Context;
-
-        /**
-         * Gets all attributes.
-         *
-         * @return  An array of attributes.
-         */
-        export function getAttribute(): Attribute[];
-
-        /**
-         * Gets an attribute matching attributeName.
-         *
-         * @tparam  T   An Attribute type.
-         * @param   {string}    attributeName   Name of the attribute.
-         *
-         * @return  The attribute.
-         */
-        export function getAttribute<T extends Attribute>( attributeName: string ): T;
-
-        /**
-         * Gets an attribute matching attributeName.
-         *
-         * @param   {string}    attributeName   Name of the attribute.
-         *
-         * @return  The attribute.
-         */
-        export function getAttribute( attributeName: string ): Attribute;
-
-        /**
-         * Gets an attribute by index.
-         *
-         * @param   {number}    index   The attribute index.
-         *
-         * @return  The attribute.
-         */
-        export function getAttribute( index: number ): Attribute;
-
-        /**
-         * Gets an attribute.
-         *
-         * @param   {Collection.MatchingDelegate{Attribute}}    delegateFunction    A matching delegate function
-         *
-         * @return  An array of attribute.
-         */
-        export function getAttribute( delegateFunction: Collection.MatchingDelegate<Attribute> ): Attribute[];
-
-        /**
-         * Gets all controls.
-         *
-         * @return  An array of controls.
-         */
-        export function getControl(): Control[];
-
-        /**
-         * Gets a control matching controlName.
-         *
-         * @tparam  T   A Control type
-         * @param   {string}    controlName Name of the control.
-         *
-         * @return  The control.
-         */
-        export function getControl<T extends Control>( controlName: string ): T;
-
-        /**
-         * Gets a control matching controlName.
-         *
-         * @param   {string}    controlName Name of the control.
-         *
-         * @return  The control.
-         */
-        export function getControl( controlName: string ): Control;
-
-        /**
-         * Gets a control by index.
-         *
-         * @param   {number}    index   The control index.
-         *
-         * @return  The control.
-         */
-        export function getControl( index: number ): Control;
-
-        /**
-         * Gets a control.
-         *
-         * @param   {Collection.MatchingDelegate{Control}}  delegateFunction    A matching delegate function.
-         *
-         * @return  An array of control.
-         */
-        export function getControl( delegateFunction: Collection.MatchingDelegate<Control> ): Control[];
     }
 
     /**
@@ -2506,89 +2651,5 @@ declare module Xrm
              */
             openInNewWindow: boolean;
         }
-
-        /**
-         * Displays an alert dialog, with an "OK" button.
-         *
-         * @param   {string}        message         The message.
-         * @param   {function()}    onCloseCallback The "OK" callback.
-         */
-        export function alertDialog( message: string, onCloseCallback: () => void ): void;
-
-        /**
-         * Displays a confirmation dialog, with "OK" and "Cancel" buttons.
-         *
-         * @param   {string}        message             The message.
-         * @param   {function()}    yesCloseCallback    The "OK" callback.
-         * @param   {function()}    noCloseCallback     The "Cancel" callback.
-         */
-        export function confirmDialog( message: string, yesCloseCallback: () => void, noCloseCallback: () => void ): void;
-
-        /**
-         * Query if 'entityType' is an Activity entity.
-         *
-         * @param   {string}    entityType  Type of the entity.
-         *
-         * @return  true if the entity is an Activity, false if not.
-         */
-        export function isActivityType( entityType: string ): boolean;
-
-        /**
-         * Opens an entity form.
-         *
-         * @param   {string}    name                The entity's logical name.
-         * @param   {string}    id                  (Optional) The unique identifier for the record.
-         * @param   {FormParameters}    parameters  (Optional) A dictionary object that passes extra query string parameters to the form.
-         * @param   {WindowOptions} windowOptions   (Optional) Options for controlling the window.
-         */
-        export function openEntityForm( name: string, id?: string, parameters?: FormOpenParameters, windowOptions?: WindowOptions ): void;
-
-        /**
-         * Opens quick create.
-         *
-         * @param   {Function}  callback                    The function that will be called when a record is created. This
-         *                                                  function is passed a LookupValue object as a parameter.
-         * @param   {string}    entityLogicalName           The logical name of the entity to create.
-         * @param   {Page.LookupValue}  createFromEntity    (Optional) Designates a record that will provide default values
-         *                                                  based on mapped attribute values.
-         * @param   {OpenParameters}    parameters          (Optional) A dictionary object that passes extra query string
-         *                                                  parameters to the form. Invalid query string parameters will cause an
-         *                                                  error.
-         */
-        export function openQuickCreate( callback: ( recordReference: Page.LookupValue ) => void,
-            entityLogicalName: string,
-            createFromEntity?: Page.LookupValue,
-            parameters?: OpenParameters ): void;
-
-        /**
-         * Opens an HTML Web Resource in a new browser window.
-         *
-         * @param   {string}    webResourceName Name of the HTML web resource. Can be used to pass URL
-         *                                      parameters.  See Remarks.
-         * @param   {string}    webResourceData (Optional) Data to pass into the Web Resource's data parameter.
-         *                                                 It is advised to use encodeURIcomponent() to encode the value.
-         * @param   {number}    width           (Optional) The width of the new window.
-         * @param   {number}    height          (Optional) The height of the new window.
-         *
-         * @return  A Window reference, containing the opened Web Resource.
-         *
-         * @remarks This function will not work with Microsoft Dynamics CRM for tablets.
-         *          Valid WebResource URL Parameters:   typename
-         *                                              type
-         *                                              id
-         *                                              orgname
-         *                                              userlcid
-         *                                              data (identical to this method's webResourceData parameter)
-         *                                              formid
-         */
-        export function openWebResource( webResourceName: string, webResourceData?: string, width?: number, height?: number ): Window;
     }
 }
-
-/**
- * Gets the xRM application context, for HTML web resources, included by ClientGlobalContext.js.aspx
- * @returns {Xrm.Context}   The application context for the user's current session.
- * @remarks The ClientGlobalContext.js.aspx page will include some global event handlers. These event handlers will
- *          cancel the onselectstart, contextmenu, and ondragstart events.
- */
-declare function GetGlobalContext(): Xrm.Context;

--- a/xrm/xrm.d.ts
+++ b/xrm/xrm.d.ts
@@ -3,232 +3,213 @@
 // Definitions by: David Berry <https://github.com/6ix4our/>, Matt Ngan <https://github.com/mattngan/>, Markus Mauch <https://github.com/markusmauch/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-/**
- * Injects the Xrm object and GetGlobalContext function into the global namespace.
- */
-declare var Xrm: XrmStatic;
-declare function GetGlobalContext(): XrmInterface.Context;
+declare var Xrm: Xrm.XrmStatic;
+declare function GetGlobalContext(): Xrm.Context; 
 
-/**
- * Extends the Window interface defined in lib.d.ts and makes the Xrm object and GetGlobalContext function accessible from any window object (window, parent, top, etc.).
- */
 interface Window
 {
-    /**
-     * A reference to the xRM global object.
-     */
-    Xrm: XrmStatic;
-        
-    /**
-     * Gets the xRM application context, for HTML web resources, included by ClientGlobalContext.js.aspx
-     * @returns {Xrm.Context}   The application context for the user's current session.
-     * @remarks The ClientGlobalContext.js.aspx page will include some global event handlers. These event handlers will
-     *          cancel the onselectstart, contextmenu, and ondragstart events.
-     */
-    GetGlobalContext(): XrmInterface.Context;
+    Xrm: Xrm.XrmStatic;
+    GetGlobalContext(): Xrm.Context;
 }
 
-/**
- * Static xRM object.
- */
-interface XrmStatic
+declare module Xrm
 {
     /**
-     * Provides a namespace container for the context, data and ui objects.
+     * Static xRM object.
      */
-    Page: {
+    export interface XrmStatic
+    {
         /**
-         * Provides methods to retrieve information specific to an organization, a user, or parameters passed to a page.
+         * Provides a namespace container for the context, data and ui objects.
          */
-        context: XrmInterface.Context;
-        
-        /**
-         * Provides methods to work with the form.
-         */
-        data: XrmInterface.Data;
-        
-        /**
-         * Contains properties and methods to retrieve information about the user interface as well as collections for several subcomponents of the form.
-         */
-        ui: XrmInterface.Ui;
-        
-        /**
-         * Gets all attributes.
-         *
-         * @return  An array of attributes.
-         */
-        getAttribute(): XrmInterface.Page.Attribute[];
+        Page: {
+            /**
+             * Provides methods to retrieve information specific to an organization, a user, or parameters passed to a page.
+             */
+            context: Context;
+
+            /**
+             * Provides methods to work with the form.
+             */
+            data: Data;
+
+            /**
+             * Contains properties and methods to retrieve information about the user interface as well as collections for several subcomponents of the form.
+             */
+            ui: Ui;
+
+            /**
+             * Gets all attributes.
+             *
+             * @return  An array of attributes.
+             */
+            getAttribute(): Page.Attribute[];
+
+            /**
+             * Gets an attribute matching attributeName.
+             *
+             * @tparam  T   An Attribute type.
+             * @param   {string}    attributeName   Name of the attribute.
+             *
+             * @return  The attribute.
+             */
+            getAttribute<T extends Page.Attribute>( attributeName: string ): T;
+
+            /**
+             * Gets an attribute matching attributeName.
+             *
+             * @param   {string}    attributeName   Name of the attribute.
+             *
+             * @return  The attribute.
+             */
+            getAttribute( attributeName: string ): Page.Attribute;
+
+            /**
+             * Gets an attribute by index.
+             *
+             * @param   {number}    index   The attribute index.
+             *
+             * @return  The attribute.
+             */
+            getAttribute( index: number ): Page.Attribute;
+
+            /**
+             * Gets an attribute.
+             *
+             * @param   {Collection.MatchingDelegate{Attribute}}    delegateFunction    A matching delegate function
+             *
+             * @return  An array of attribute.
+             */
+            getAttribute( delegateFunction: Collection.MatchingDelegate<Page.Attribute> ): Page.Attribute[];
+
+            /**
+             * Gets all controls.
+             *
+             * @return  An array of controls.
+             */
+            getControl(): Page.Control[];
+
+            /**
+             * Gets a control matching controlName.
+             *
+             * @tparam  T   A Control type
+             * @param   {string}    controlName Name of the control.
+             *
+             * @return  The control.
+             */
+            getControl<T extends Page.Control>( controlName: string ): T;
+
+            /**
+             * Gets a control matching controlName.
+             *
+             * @param   {string}    controlName Name of the control.
+             *
+             * @return  The control.
+             */
+            getControl( controlName: string ): Page.Control;
+
+            /**
+             * Gets a control by index.
+             *
+             * @param   {number}    index   The control index.
+             *
+             * @return  The control.
+             */
+            getControl( index: number ): Page.Control;
+
+            /**
+             * Gets a control.
+             *
+             * @param   {Collection.MatchingDelegate{Control}}  delegateFunction    A matching delegate function.
+             *
+             * @return  An array of control.
+             */
+            getControl( delegateFunction: Collection.MatchingDelegate<Page.Control> ): Page.Control[];
+        }
 
         /**
-         * Gets an attribute matching attributeName.
-         *
-         * @tparam  T   An Attribute type.
-         * @param   {string}    attributeName   Name of the attribute.
-         *
-         * @return  The attribute.
+         * Provides a container for useful functions not directly related to the current page.
          */
-        getAttribute<T extends XrmInterface.Page.Attribute>( attributeName: string ): T;
+        Utility: {
+            /**
+             * Displays an alert dialog, with an "OK" button.
+             *
+             * @param   {string}        message         The message.
+             * @param   {function()}    onCloseCallback The "OK" callback.
+             */
+            alertDialog( message: string, onCloseCallback: () => void ): void;
 
-        /**
-         * Gets an attribute matching attributeName.
-         *
-         * @param   {string}    attributeName   Name of the attribute.
-         *
-         * @return  The attribute.
-         */
-        getAttribute( attributeName: string ): XrmInterface.Page.Attribute;
+            /**
+             * Displays a confirmation dialog, with "OK" and "Cancel" buttons.
+             *
+             * @param   {string}        message             The message.
+             * @param   {function()}    yesCloseCallback    The "OK" callback.
+             * @param   {function()}    noCloseCallback     The "Cancel" callback.
+             */
+            confirmDialog( message: string, yesCloseCallback: () => void, noCloseCallback: () => void ): void;
 
-        /**
-         * Gets an attribute by index.
-         *
-         * @param   {number}    index   The attribute index.
-         *
-         * @return  The attribute.
-         */
-        getAttribute( index: number ): XrmInterface.Page.Attribute;
+            /**
+             * Query if 'entityType' is an Activity entity.
+             *
+             * @param   {string}    entityType  Type of the entity.
+             *
+             * @return  true if the entity is an Activity, false if not.
+             */
+            isActivityType( entityType: string ): boolean;
 
-        /**
-         * Gets an attribute.
-         *
-         * @param   {Collection.MatchingDelegate{Attribute}}    delegateFunction    A matching delegate function
-         *
-         * @return  An array of attribute.
-         */
-        getAttribute( delegateFunction: XrmInterface.Collection.MatchingDelegate<XrmInterface.Page.Attribute> ): XrmInterface.Page.Attribute[];
+            /**
+             * Opens quick create.
+             *
+             * @param   {Function}  callback                    The function that will be called when a record is created. This
+             *                                                  function is passed a LookupValue object as a parameter.
+             * @param   {string}    entityLogicalName           The logical name of the entity to create.
+             * @param   {Page.LookupValue}  createFromEntity    (Optional) Designates a record that will provide default values
+             *                                                  based on mapped attribute values.
+             * @param   {OpenParameters}    parameters          (Optional) A dictionary object that passes extra query string
+             *                                                  parameters to the form. Invalid query string parameters will cause an
+             *                                                  error.
+             */
+            openQuickCreate(
+                callback: ( recordReference: Page.LookupValue ) => void,
+                entityLogicalName: string,
+                createFromEntity?: Page.LookupValue,
+                parameters?: Utility.OpenParameters ): void;
 
-        /**
-         * Gets all controls.
-         *
-         * @return  An array of controls.
-         */
-        getControl(): XrmInterface.Page.Control[];
+            /**
+             * Opens an entity form.
+             *
+             * @param   {string}    name                The entity's logical name.
+             * @param   {string}    id                  (Optional) The unique identifier for the record.
+             * @param   {FormParameters}    parameters  (Optional) A dictionary object that passes extra query string parameters to the form.
+             * @param   {WindowOptions} windowOptions   (Optional) Options for controlling the window.
+             */
+            openEntityForm( name: string, id?: string, parameters?: Utility.FormOpenParameters, windowOptions?: Utility.WindowOptions ): void;
 
-        /**
-         * Gets a control matching controlName.
-         *
-         * @tparam  T   A Control type
-         * @param   {string}    controlName Name of the control.
-         *
-         * @return  The control.
-         */
-        getControl<T extends XrmInterface.Page.Control>( controlName: string ): T;
-
-        /**
-         * Gets a control matching controlName.
-         *
-         * @param   {string}    controlName Name of the control.
-         *
-         * @return  The control.
-         */
-        getControl( controlName: string ): XrmInterface.Page.Control;
-
-        /**
-         * Gets a control by index.
-         *
-         * @param   {number}    index   The control index.
-         *
-         * @return  The control.
-         */
-        getControl( index: number ): XrmInterface.Page.Control;
-
-        /**
-         * Gets a control.
-         *
-         * @param   {Collection.MatchingDelegate{Control}}  delegateFunction    A matching delegate function.
-         *
-         * @return  An array of control.
-         */
-        getControl( delegateFunction: XrmInterface.Collection.MatchingDelegate<XrmInterface.Page.Control> ): XrmInterface.Page.Control[];
+            /**
+             * Opens an HTML Web Resource in a new browser window.
+             *
+             * @param   {string}    webResourceName Name of the HTML web resource. Can be used to pass URL
+             *                                      parameters.  See Remarks.
+             * @param   {string}    webResourceData (Optional) Data to pass into the Web Resource's data parameter.
+             *                                                 It is advised to use encodeURIcomponent() to encode the value.
+             * @param   {number}    width           (Optional) The width of the new window.
+             * @param   {number}    height          (Optional) The height of the new window.
+             *
+             * @return  A Window reference, containing the opened Web Resource.
+             *
+             * @remarks This function will not work with Microsoft Dynamics CRM for tablets.
+             *          Valid WebResource URL Parameters:   typename
+             *                                              type
+             *                                              id
+             *                                              orgname
+             *                                              userlcid
+             *                                              data (identical to this method's webResourceData parameter)
+             *                                              formid
+             */
+            openWebResource( webResourceName: string, webResourceData?: string, width?: number, height?: number ): Window;
+        }
     }
-    
-    /**
-     * Provides a container for useful functions not directly related to the current page.
-     */
-    Utility: {
-        /**
-         * Displays an alert dialog, with an "OK" button.
-         *
-         * @param   {string}        message         The message.
-         * @param   {function()}    onCloseCallback The "OK" callback.
-         */
-        alertDialog( message: string, onCloseCallback: () => void ): void;
-        
-        /**
-         * Displays a confirmation dialog, with "OK" and "Cancel" buttons.
-         *
-         * @param   {string}        message             The message.
-         * @param   {function()}    yesCloseCallback    The "OK" callback.
-         * @param   {function()}    noCloseCallback     The "Cancel" callback.
-         */
-        confirmDialog( message: string, yesCloseCallback: () => void, noCloseCallback: () => void ): void;
-        
-        /**
-         * Query if 'entityType' is an Activity entity.
-         *
-         * @param   {string}    entityType  Type of the entity.
-         *
-         * @return  true if the entity is an Activity, false if not.
-         */
-        isActivityType( entityType: string ): boolean;
-        
-        /**
-         * Opens quick create.
-         *
-         * @param   {Function}  callback                    The function that will be called when a record is created. This
-         *                                                  function is passed a LookupValue object as a parameter.
-         * @param   {string}    entityLogicalName           The logical name of the entity to create.
-         * @param   {Page.LookupValue}  createFromEntity    (Optional) Designates a record that will provide default values
-         *                                                  based on mapped attribute values.
-         * @param   {OpenParameters}    parameters          (Optional) A dictionary object that passes extra query string
-         *                                                  parameters to the form. Invalid query string parameters will cause an
-         *                                                  error.
-         */
-        openQuickCreate(
-            callback: ( recordReference: XrmInterface.Page.LookupValue ) => void,
-            entityLogicalName: string,
-            createFromEntity?: XrmInterface.Page.LookupValue,
-            parameters?: XrmInterface.Utility.OpenParameters ): void;
-        
-        /**
-         * Opens an entity form.
-         *
-         * @param   {string}    name                The entity's logical name.
-         * @param   {string}    id                  (Optional) The unique identifier for the record.
-         * @param   {FormParameters}    parameters  (Optional) A dictionary object that passes extra query string parameters to the form.
-         * @param   {WindowOptions} windowOptions   (Optional) Options for controlling the window.
-         */
-        openEntityForm( name: string, id?: string, parameters?: XrmInterface.Utility.FormOpenParameters, windowOptions?: XrmInterface.Utility.WindowOptions ): void;
 
-        /**
-         * Opens an HTML Web Resource in a new browser window.
-         *
-         * @param   {string}    webResourceName Name of the HTML web resource. Can be used to pass URL
-         *                                      parameters.  See Remarks.
-         * @param   {string}    webResourceData (Optional) Data to pass into the Web Resource's data parameter.
-         *                                                 It is advised to use encodeURIcomponent() to encode the value.
-         * @param   {number}    width           (Optional) The width of the new window.
-         * @param   {number}    height          (Optional) The height of the new window.
-         *
-         * @return  A Window reference, containing the opened Web Resource.
-         *
-         * @remarks This function will not work with Microsoft Dynamics CRM for tablets.
-         *          Valid WebResource URL Parameters:   typename
-         *                                              type
-         *                                              id
-         *                                              orgname
-         *                                              userlcid
-         *                                              data (identical to this method's webResourceData parameter)
-         *                                              formid
-         */
-        openWebResource( webResourceName: string, webResourceData?: string, width?: number, height?: number ): Window;
-    }   
-}
-
-/**
- * Ghost module for the Xrm interfaces.
- */
-declare module XrmInterface
-{
     /**
      * Interface for the client context.
      */
@@ -252,7 +233,7 @@ declare module XrmInterface
     /**
      * Interface for the xRM application context.
      */
-    export interface Context
+    interface Context
     {
         /**
          * The client's context instance.
@@ -375,26 +356,26 @@ declare module XrmInterface
          *
          * @return  An Async.XrmPromise.
          */
-        refresh( save: boolean ): XrmInterface.Async.XrmPromise;
+        refresh( save: boolean ): Async.XrmPromise;
 
         /**
          * Asynchronously saves the record.
          *
          * @return  An Async.XrmPromise.
          */
-        save(): XrmInterface.Async.XrmPromise;
-        
+        save(): Async.XrmPromise;
+
         /**
          * The record context of the form.
          */
-        entity: XrmInterface.Page.Entity;
+        entity: Page.Entity;
 
         /**
          * The process API for Xrm.Page.data.
          *
          * @remarks This member may be undefined when Process Flows are not used by the current entity.
          */
-        process: XrmInterface.Page.data.ProcessManager;
+        process: Page.data.ProcessManager;
     }
 
     /**
@@ -429,7 +410,7 @@ declare module XrmInterface
          *                                   6  Bulk Edit
          *              Deprecated values are 5 (Quick Create), and 11 (Read Optimized)
          */
-        getFormType(): XrmInterface.Page.FormType;
+        getFormType(): XrmEnum.FormType;
 
         /**
          * Gets view port height.
@@ -500,31 +481,31 @@ declare module XrmInterface
          */
         setFormNotification( message: string, level: string, uniqueId: string ): boolean;
 
-        process: XrmInterface.Page.data.ProcessManager;
+        process: Page.data.ProcessManager;
 
         /**
          * A reference to the collection of controls on the form.
          */
-        controls: XrmInterface.Collection.ItemCollection<XrmInterface.Page.Control>;
+        controls: Collection.ItemCollection<Page.Control>;
 
         /**
          * The form selector API.
          *
          * @remarks This API does not exist with Microsoft Dynamics CRM for tablets.
          */
-        formSelector: XrmInterface.Page.FormSelector;
+        formSelector: Page.FormSelector;
 
         /**
          * The navigation API.
          *
          * @remarks This API does not exist with Microsoft Dynamics CRM for tablets.
          */
-        navigation: XrmInterface.Page.Navigation;
+        navigation: Page.Navigation;
 
         /**
          * A reference to the collection of tabs on the form.
          */
-        tabs: XrmInterface.Collection.ItemCollection<XrmInterface.Page.Tab>;
+        tabs: Collection.ItemCollection<Page.Tab>;
     }
 
     /**
@@ -666,63 +647,6 @@ declare module XrmInterface
     export module Page
     {
         /**
-         * Enumeration of entity form states/types.
-         */
-        export const enum FormType
-        {
-            Undefined = 0,
-            Create = 1,
-            Update = 2,
-            ReadOnly = 3,
-            Disabled = 4,
-            BulkEdit = 6
-        }
-
-        /**
-         * Enumeration of entity form save modes.
-         */
-        export const enum SaveMode
-        {
-            Save = 1,
-            SaveAndClose = 2,
-            SaveAndNew = 59,
-            AutoSave = 70,
-            SaveAsCompleted = 58,
-            Deactivate = 5,
-            Reactivate = 6,
-            Assign = 47,
-            Send = 7,
-            Qualify = 16,
-            Disqualify = 15
-        }
-
-        /**
-         * Enumeration of stage categories.
-         */
-        export const enum StageCategory
-        {
-            Qualify = 0,
-            Develop = 1,
-            Propose = 2,
-            Close = 3,
-            Identify = 4,
-            Research = 5,
-            Resolve = 6
-        }
-
-        /**
-         * Enumeration of grid control context resolutions.
-         */
-        export const enum GridControlContext
-        {
-            Unknown = 0,
-            RibbonContextForm = 1,
-            RibbonContextListing = 2,
-            FormContextUnrelated = 3,
-            FormContextRelated = 4
-        }
-
-        /**
          * Interface for a CRM Business Process Flow instance.
          */
         export interface Process
@@ -769,7 +693,7 @@ declare module XrmInterface
              *
              * @return  The stage category.
              */
-            getCategory(): { getValue(): StageCategory };
+            getCategory(): { getValue(): XrmEnum.StageCategory };
 
             /**
              * Returns the logical name of the entity associated with the stage.
@@ -874,7 +798,7 @@ declare module XrmInterface
              *
              * @return  The event source.
              */
-            getEventSource(): XrmInterface.Page.Attribute | XrmInterface.Page.Entity;
+            getEventSource(): Page.Attribute | Page.Entity;
 
             /**
              * Gets the shared variable with the specified key.
@@ -1552,7 +1476,7 @@ declare module XrmInterface
              *                               16     Qualify (Lead)
              *                               15     Disqualify (Lead)
              */
-            getSaveMode(): SaveMode;
+            getSaveMode(): XrmEnum.SaveMode;
 
             /**
              * Returns a boolean value to indicate if the record's save has been prevented.
@@ -1972,7 +1896,7 @@ declare module XrmInterface
              *
              * @return  The context type.
              */
-            getContextType(): GridControlContext;
+            getContextType(): XrmEnum.GridControlContext;
 
             /**
              * Use this method to get the logical name of the entity data displayed in the grid.
@@ -2127,7 +2051,7 @@ declare module XrmInterface
              *
              * @return  The parent.
              */
-            getParent(): XrmInterface.Ui;
+            getParent(): Ui;
 
             /**
              * Sets display state of the tab.
@@ -2439,15 +2363,6 @@ declare module XrmInterface
     export module Url
     {
         /**
-         * An enumeration for view types.
-         */
-        export const enum ViewType
-        {
-            SystemView = 1039,
-            UserView = 4230
-        }
-
-        /**
          * Interface for defining parameters on a request to open a form with main.aspx (as with
          * window.open). Useful for parsing the keys and values into a string of the format:
          * "&key=value".
@@ -2519,7 +2434,7 @@ declare module XrmInterface
              * @remarks  Accepted values are:    1039    System View
              *                                   4230    User View.
              */
-            viewtype: ViewType;
+            viewtype: XrmEnum.ViewType;
 
             /**
              * Controls whether the command bar is displayed.
@@ -2649,5 +2564,74 @@ declare module XrmInterface
              */
             openInNewWindow: boolean;
         }
+    }
+}
+
+declare module XrmEnum
+{
+    /**
+     * Enumeration of entity form states/types.
+     */
+    export const enum FormType
+    {
+        Undefined = 0,
+        Create = 1,
+        Update = 2,
+        ReadOnly = 3,
+        Disabled = 4,
+        BulkEdit = 6
+    }
+
+    /**
+     * Enumeration of entity form save modes.
+     */
+    export const enum SaveMode
+    {
+        Save = 1,
+        SaveAndClose = 2,
+        SaveAndNew = 59,
+        AutoSave = 70,
+        SaveAsCompleted = 58,
+        Deactivate = 5,
+        Reactivate = 6,
+        Assign = 47,
+        Send = 7,
+        Qualify = 16,
+        Disqualify = 15
+    }
+
+    /**
+     * Enumeration of stage categories.
+     */
+    export const enum StageCategory
+    {
+        Qualify = 0,
+        Develop = 1,
+        Propose = 2,
+        Close = 3,
+        Identify = 4,
+        Research = 5,
+        Resolve = 6
+    }
+
+    /**
+     * Enumeration of grid control context resolutions.
+     */
+    export const enum GridControlContext
+    {
+        Unknown = 0,
+        RibbonContextForm = 1,
+        RibbonContextListing = 2,
+        FormContextUnrelated = 3,
+        FormContextRelated = 4
+    }
+
+    /**
+     * An enumeration for view types.
+     */
+    export const enum ViewType
+    {
+        SystemView = 1039,
+        UserView = 4230
     }
 }


### PR DESCRIPTION
Makes the Xrm `object` available in the browser's `window` object (`window`, `parent`, `top`, etc.) by introducing a dedicated interface `XrmStatic` and extending the `Window` interface specified in `lib.d.ts`:

```
interface Window {
    Xrm: Xrm.XrmStatic;
}
```

The `XrmStatic` interface is added to the already existing `Xrm` module:

```
declare module Xrm {
    interface XrmStatic {
        Page: Page;
        Utiltiy: Utiltiy;
    }
    module Page {...}
    module Utility {...}
}
```

To make the `Xrm` object globally available (not as a property of `window`) the following declaration is best practice:

```
declare var Xrm: Xrm.XrmStatic;
```

Declaring a variable and a module with the same name works only if the module is a so-called non-instantiated module (see section 2.3 of the TypeScript 1.5 language specification for more details). The current implementation of the `Xrm` module contains enums and is therefore introduced to the declaration space.

In order to solve this problem, the present proposal extracts the enums `FormType`, `SaveMode`, `StageCategory`, `GridControlContext`, `ViewType` into a separate `XrmEnum` module, allowing the `Xrm` module to be non-instanciated:

```
module XrmEnums {
    export const enum FormType {...}
    export const enum ViewType {...}
}
```

This allows to keep almost the entire Library within the `Xrm` root and also having a type (`Xrm.XrmStatic`) that can be referenced.
