### PR TITLE
Add missing urlParams to jquery-mockjax definition.

### DIFF
--- a/jquery-mockjax/jquery-mockjax.d.ts
+++ b/jquery-mockjax/jquery-mockjax.d.ts
@@ -11,6 +11,7 @@ interface MockJaxSettingsHeaders {
 
 interface MockJaxSettings {
     url?: string | RegExp;
+    urlParams?: string[];
     data?: any;
     type?: string;
     headers?: MockJaxSettingsHeaders;


### PR DESCRIPTION
PR to add missing urlParams to jquery-mockjax definition.
