### PR TITLE
lodash: changed signatures of _.clone family methods

### DIFF
--- a/lodash/lodash-3.10.d.ts
+++ b/lodash/lodash-3.10.d.ts
@@ -10124,132 +10124,516 @@ declare module _ {
      ********/
 
     //_.clone
+    interface CloneCustomizer<TValue, TResult> {
+        (value: TValue): TResult;
+    }
+
     interface LoDashStatic {
         /**
          * Creates a clone of value. If isDeep is true nested objects are cloned, otherwise they are assigned by
-         * reference. If customizer is provided it’s invoked to produce the cloned values. If customizer returns
-         * undefined cloning is handled by the method instead. The customizer is bound to thisArg and invoked with up
-         * to three argument; (value [, index|key, object]).
-         * Note: This method is loosely based on the structured clone algorithm. The enumerable properties of arguments
-         * objects and objects created by constructors other than Object are cloned to plain Object objects. An empty
-         * object is returned for uncloneable values such as functions, DOM nodes, Maps, Sets, and WeakMaps.
+         * reference. If customizer is provided it's invoked to produce the cloned values. If customizer returns
+         * undefined cloning is handled by the method instead. The customizer is bound to thisArg and invoked with
+         * up to three argument; (value [, index|key, object]).
+         *
+         * Note: This method is loosely based on the structured clone algorithm. The enumerable properties of
+         * arguments objects and objects created by constructors other than Object are cloned to plain Object
+         * objects. An empty object is returned for uncloneable values such as functions, DOM nodes, Maps, Sets,
+         * and WeakMaps.
+         *
          * @param value The value to clone.
          * @param isDeep Specify a deep clone.
          * @param customizer The function to customize cloning values.
          * @param thisArg The this binding of customizer.
          * @return Returns the cloned value.
          */
-        clone<T>(
+        clone<TResult>(
+            value: any,
+            isDeep: boolean,
+            customizer: CloneCustomizer<any, TResult>,
+            thisArg?: any
+        ): TResult;
+
+        /**
+         * @see _.clone
+         */
+        clone<T, TResult>(
             value: T,
-            isDeep?: boolean,
-            customizer?: (value: any) => any,
-            thisArg?: any): T;
+            isDeep: boolean,
+            customizer: CloneCustomizer<T, TResult>,
+            thisArg?: any
+        ): TResult;
+
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult>(
+            value: any,
+            customizer: CloneCustomizer<any, TResult>,
+            thisArg?: any
+        ): TResult;
+
+        /**
+         * @see _.clone
+         */
+        clone<T, TResult>(
+            value: T,
+            customizer: CloneCustomizer<T, TResult>,
+            thisArg?: any
+        ): TResult;
 
         /**
          * @see _.clone
          */
         clone<T>(
             value: T,
-            customizer?: (value: any) => any,
-            thisArg?: any): T;
+            isDeep?: boolean
+        ): T;
     }
 
     interface LoDashImplicitWrapper<T> {
         /**
          * @see _.clone
          */
-        clone(
-            isDeep?: boolean,
-            customizer?: (value: any) => any,
-            thisArg?: any): T;
+        clone<TResult>(
+            isDeep: boolean,
+            customizer: CloneCustomizer<T, TResult>,
+            thisArg?: any
+        ): TResult;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult>(
+            customizer: CloneCustomizer<T, TResult>,
+            thisArg?: any
+        ): TResult;
 
         /**
          * @see _.clone
          */
         clone(
-            customizer?: (value: any) => any,
-            thisArg?: any): T;
+            isDeep?: boolean
+        ): T;
     }
 
     interface LoDashImplicitArrayWrapper<T> {
         /**
          * @see _.clone
          */
-        clone(
-            isDeep?: boolean,
-            customizer?: (value: any) => any,
-            thisArg?: any): T[];
+        clone<TResult>(
+            isDeep: boolean,
+            customizer: CloneCustomizer<T[], TResult>,
+            thisArg?: any
+        ): TResult;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult>(
+            customizer: CloneCustomizer<T[], TResult>,
+            thisArg?: any
+        ): TResult;
 
         /**
          * @see _.clone
          */
         clone(
-            customizer?: (value: any) => any,
-            thisArg?: any): T[];
+            isDeep?: boolean
+        ): T;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
         /**
          * @see _.clone
          */
-        clone(
-            isDeep?: boolean,
-            customizer?: (value: any) => any,
-            thisArg?: any): T;
+        clone<TResult>(
+            isDeep: boolean,
+            customizer: CloneCustomizer<T, TResult>,
+            thisArg?: any
+        ): TResult;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult>(
+            customizer: CloneCustomizer<T, TResult>,
+            thisArg?: any
+        ): TResult;
 
         /**
          * @see _.clone
          */
         clone(
-            customizer?: (value: any) => any,
-            thisArg?: any): T;
+            isDeep?: boolean
+        ): T;
+    }
+
+    interface LoDashExplicitWrapper<T> {
+        /**
+         * @see _.clone
+         */
+        clone<TResult extends (number|string|boolean)>(
+            isDeep: boolean,
+            customizer: CloneCustomizer<T, TResult>,
+            thisArg?: any
+        ):  LoDashExplicitWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult>(
+            isDeep: boolean,
+            customizer: CloneCustomizer<T, TResult[]>,
+            thisArg?: any
+        ):  LoDashExplicitArrayWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult extends Object>(
+            isDeep: boolean,
+            customizer: CloneCustomizer<T, TResult>,
+            thisArg?: any
+        ):  LoDashExplicitObjectWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult extends (number|string|boolean)>(
+            customizer: CloneCustomizer<T, TResult>,
+            thisArg?: any
+        ):  LoDashExplicitWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult>(
+            customizer: CloneCustomizer<T, TResult[]>,
+            thisArg?: any
+        ):  LoDashExplicitArrayWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult extends Object>(
+            customizer: CloneCustomizer<T, TResult>,
+            thisArg?: any
+        ):  LoDashExplicitObjectWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone(
+            isDeep?: boolean
+        ): LoDashExplicitWrapper<T>;
+    }
+
+    interface LoDashExplicitArrayWrapper<T> {
+        /**
+         * @see _.clone
+         */
+        clone<TResult extends (number|string|boolean)>(
+            isDeep: boolean,
+            customizer: CloneCustomizer<T[], TResult>,
+            thisArg?: any
+        ):  LoDashExplicitWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult>(
+            isDeep: boolean,
+            customizer: CloneCustomizer<T[], TResult[]>,
+            thisArg?: any
+        ):  LoDashExplicitArrayWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult extends Object>(
+            isDeep: boolean,
+            customizer: CloneCustomizer<T[], TResult>,
+            thisArg?: any
+        ):  LoDashExplicitObjectWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult extends (number|string|boolean)>(
+            customizer: CloneCustomizer<T[], TResult>,
+            thisArg?: any
+        ):  LoDashExplicitWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult>(
+            customizer: CloneCustomizer<T[], TResult[]>,
+            thisArg?: any
+        ):  LoDashExplicitArrayWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult extends Object>(
+            customizer: CloneCustomizer<T[], TResult>,
+            thisArg?: any
+        ):  LoDashExplicitObjectWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone(
+            isDeep?: boolean
+        ): LoDashExplicitArrayWrapper<T>;
+    }
+
+    interface LoDashExplicitObjectWrapper<T> {
+        /**
+         * @see _.clone
+         */
+        clone<TResult extends (number|string|boolean)>(
+            isDeep: boolean,
+            customizer: CloneCustomizer<T, TResult>,
+            thisArg?: any
+        ):  LoDashExplicitWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult>(
+            isDeep: boolean,
+            customizer: CloneCustomizer<T, TResult[]>,
+            thisArg?: any
+        ):  LoDashExplicitArrayWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult extends Object>(
+            isDeep: boolean,
+            customizer: CloneCustomizer<T, TResult>,
+            thisArg?: any
+        ):  LoDashExplicitObjectWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult extends (number|string|boolean)>(
+            customizer: CloneCustomizer<T, TResult>,
+            thisArg?: any
+        ):  LoDashExplicitWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult>(
+            customizer: CloneCustomizer<T, TResult[]>,
+            thisArg?: any
+        ):  LoDashExplicitArrayWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone<TResult extends Object>(
+            customizer: CloneCustomizer<T, TResult>,
+            thisArg?: any
+        ):  LoDashExplicitObjectWrapper<TResult>;
+
+        /**
+         * @see _.clone
+         */
+        clone(
+            isDeep?: boolean
+        ): LoDashExplicitObjectWrapper<T>;
     }
 
     //_.cloneDeep
+    interface CloneDeepCustomizer<TValue, TResult> {
+        (value: TValue): TResult;
+    }
+
     interface LoDashStatic {
         /**
-         * Creates a deep clone of value. If customizer is provided it’s invoked to produce the cloned values. If
-         * customizer returns undefined cloning is handled by the method instead. The customizer is bound to thisArg
-         * and invoked with up to three argument; (value [, index|key, object]).
-         * Note: This method is loosely based on the structured clone algorithm. The enumerable properties of arguments
-         * objects and objects created by constructors other than Object are cloned to plain Object objects. An empty
-         * object is returned for uncloneable values such as functions, DOM nodes, Maps, Sets, and WeakMaps.
+         * Creates a deep clone of value. If customizer is provided it's invoked to produce the cloned values.
+         * If customizer returns undefined cloning is handled by the method instead. The customizer is bound to
+         * thisArg and invoked with up to three argument; (value [, index|key, object]).
+         *
+         * Note: This method is loosely based on the structured clone algorithm. The enumerable properties of
+         * arguments objects and objects created by constructors other than Object are cloned to plain Object objects.
+         * An empty object is returned for uncloneable values such as functions, DOM nodes, Maps, Sets, and WeakMaps.
+         *
          * @param value The value to deep clone.
          * @param customizer The function to customize cloning values.
          * @param thisArg The this binding of customizer.
          * @return Returns the deep cloned value.
          */
-        cloneDeep<T>(
+        cloneDeep<TResult>(
+            value: any,
+            customizer: CloneDeepCustomizer<any, TResult>,
+            thisArg?: any
+        ): TResult;
+
+        /**
+         * @see _.cloneDeep
+         */
+        cloneDeep<T, TResult>(
             value: T,
-            customizer?: (value: any) => any,
-            thisArg?: any): T;
+            customizer: CloneDeepCustomizer<T, TResult>,
+            thisArg?: any
+        ): TResult;
+
+        /**
+         * @see _.cloneDeep
+         */
+        cloneDeep<T>(
+            value: T
+        ): T;
     }
 
     interface LoDashImplicitWrapper<T> {
         /**
          * @see _.cloneDeep
          */
-        cloneDeep(
-            customizer?: (value: any) => any,
-            thisArg?: any): T;
+        cloneDeep<TResult>(
+            customizer: CloneDeepCustomizer<T, TResult>,
+            thisArg?: any
+        ): TResult;
+
+        /**
+         * @see _.cloneDeep
+         */
+        cloneDeep(): T;
     }
 
     interface LoDashImplicitArrayWrapper<T> {
         /**
          * @see _.cloneDeep
          */
-        cloneDeep(
-            customizer?: (value: any) => any,
-            thisArg?: any): T[];
+        cloneDeep<TResult>(
+            customizer: CloneDeepCustomizer<T[], TResult>,
+            thisArg?: any
+        ): TResult;
+
+        /**
+         * @see _.cloneDeep
+         */
+        cloneDeep(): T;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
         /**
          * @see _.cloneDeep
          */
+        cloneDeep<TResult>(
+            customizer: CloneDeepCustomizer<T, TResult>,
+            thisArg?: any
+        ): TResult;
+
+        /**
+         * @see _.cloneDeep
+         */
+        cloneDeep(): T;
+    }
+
+    interface LoDashExplicitWrapper<T> {
+        /**
+         * @see _.cloneDeep
+         */
+        cloneDeep<TResult extends (number|string|boolean)>(
+            customizer: CloneDeepCustomizer<T, TResult>,
+            thisArg?: any
+        ):  LoDashExplicitWrapper<TResult>;
+
+        /**
+         * @see _.cloneDeep
+         */
+        cloneDeep<TResult>(
+            customizer: CloneDeepCustomizer<T, TResult[]>,
+            thisArg?: any
+        ):  LoDashExplicitArrayWrapper<TResult>;
+
+        /**
+         * @see _.cloneDeep
+         */
+        cloneDeep<TResult extends Object>(
+            customizer: CloneDeepCustomizer<T, TResult>,
+            thisArg?: any
+        ):  LoDashExplicitObjectWrapper<TResult>;
+
+        /**
+         * @see _.cloneDeep
+         */
         cloneDeep(
-            customizer?: (value: any) => any,
-            thisArg?: any): T;
+            isDeep?: boolean
+        ): LoDashExplicitWrapper<T>;
+    }
+
+    interface LoDashExplicitArrayWrapper<T> {
+        /**
+         * @see _.cloneDeep
+         */
+        cloneDeep<TResult extends (number|string|boolean)>(
+            customizer: CloneDeepCustomizer<T[], TResult>,
+            thisArg?: any
+        ):  LoDashExplicitWrapper<TResult>;
+
+        /**
+         * @see _.cloneDeep
+         */
+        cloneDeep<TResult>(
+            customizer: CloneDeepCustomizer<T[], TResult[]>,
+            thisArg?: any
+        ):  LoDashExplicitArrayWrapper<TResult>;
+
+        /**
+         * @see _.cloneDeep
+         */
+        cloneDeep<TResult extends Object>(
+            customizer: CloneDeepCustomizer<T[], TResult>,
+            thisArg?: any
+        ):  LoDashExplicitObjectWrapper<TResult>;
+
+        /**
+         * @see _.cloneDeep
+         */
+        cloneDeep(
+            isDeep?: boolean
+        ): LoDashExplicitArrayWrapper<T>;
+    }
+
+    interface LoDashExplicitObjectWrapper<T> {
+        /**
+         * @see _.cloneDeep
+         */
+        cloneDeep<TResult extends (number|string|boolean)>(
+            customizer: CloneDeepCustomizer<T, TResult>,
+            thisArg?: any
+        ):  LoDashExplicitWrapper<TResult>;
+
+        /**
+         * @see _.cloneDeep
+         */
+        cloneDeep<TResult>(
+            customizer: CloneDeepCustomizer<T, TResult[]>,
+            thisArg?: any
+        ):  LoDashExplicitArrayWrapper<TResult>;
+
+        /**
+         * @see _.cloneDeep
+         */
+        cloneDeep<TResult extends Object>(
+            customizer: CloneDeepCustomizer<T, TResult>,
+            thisArg?: any
+        ):  LoDashExplicitObjectWrapper<TResult>;
+
+        /**
+         * @see _.cloneDeep
+         */
+        cloneDeep(
+            isDeep?: boolean
+        ): LoDashExplicitObjectWrapper<T>;
     }
 
     //_.eq

--- a/lodash/lodash-tests-3.10.ts
+++ b/lodash/lodash-tests-3.10.ts
@@ -6313,87 +6313,260 @@ module TestWrap {
  ********/
 
 // _.clone
-interface TestCloneCustomizerFn {
-    (value: any): any;
-}
-var testCloneCustomizerFn: TestCloneCustomizerFn;
-{
-    let result: number;
-    result = _.clone<number>(42);
-    result = _.clone<number>(42, false);
-    result = _.clone<number>(42, false, testCloneCustomizerFn);
-    result = _.clone<number>(42, false, testCloneCustomizerFn, any);
-    result = _.clone<number>(42, testCloneCustomizerFn);
-    result = _.clone<number>(42, testCloneCustomizerFn, any);
-    result = _(42).clone();
-    result = _(42).clone(false);
-    result = _(42).clone(false, testCloneCustomizerFn);
-    result = _(42).clone(false, testCloneCustomizerFn, any);
-    result = _(42).clone(testCloneCustomizerFn);
-    result = _(42).clone(testCloneCustomizerFn, any);
-}
-{
-    let result: string[];
-    result = _.clone<string[]>([]);
-    result = _.clone<string[]>([], false);
-    result = _.clone<string[]>([], false, testCloneCustomizerFn);
-    result = _.clone<string[]>([], false, testCloneCustomizerFn, any);
-    result = _.clone<string[]>([], testCloneCustomizerFn);
-    result = _.clone<string[]>([], testCloneCustomizerFn, any);
-    result = _<string>([]).clone();
-    result = _<string>([]).clone(false);
-    result = _<string>([]).clone(false, testCloneCustomizerFn);
-    result = _<string>([]).clone(false, testCloneCustomizerFn, any);
-    result = _<string>([]).clone(testCloneCustomizerFn);
-    result = _<string>([]).clone(testCloneCustomizerFn, any);
-}
-{
-    let result: {a: {b: number;}};
-    result = _.clone<{a: {b: number;}}>({a: {b: 2}});
-    result = _.clone<{a: {b: number;}}>({a: {b: 2}}, false);
-    result = _.clone<{a: {b: number;}}>({a: {b: 2}}, false, testCloneCustomizerFn);
-    result = _.clone<{a: {b: number;}}>({a: {b: 2}}, false, testCloneCustomizerFn, any);
-    result = _.clone<{a: {b: number;}}>({a: {b: 2}}, testCloneCustomizerFn);
-    result = _.clone<{a: {b: number;}}>({a: {b: 2}}, testCloneCustomizerFn, any);
-    result = _({a: {b: 2}}).clone();
-    result = _({a: {b: 2}}).clone(false);
-    result = _({a: {b: 2}}).clone(false, testCloneCustomizerFn);
-    result = _({a: {b: 2}}).clone(false, testCloneCustomizerFn, any);
-    result = _({a: {b: 2}}).clone(testCloneCustomizerFn);
-    result = _({a: {b: 2}}).clone(testCloneCustomizerFn, any);
+namespace TestClone {
+    interface CloneCustomizer<V, R> {
+        (value: V): R;
+    }
+
+    {
+        let customizer: CloneCustomizer<number, number>;
+        let result: number;
+
+        result = _.clone(42);
+        result = _.clone(42, false);
+        result = _(42).clone();
+        result = _(42).clone(false);
+    }
+
+    {
+        let customizer: CloneCustomizer<number, number>;
+        let result: _.LoDashExplicitWrapper<number>;
+
+        result = _(42).chain().clone();
+        result = _(42).chain().clone(false);
+    }
+
+    {
+        let customizer: CloneCustomizer<number, string>;
+        let result: string;
+
+        result = _.clone<number>(42, false, customizer);
+        result = _.clone<number>(42, false, customizer, any);
+        result = _.clone<number>(42, customizer);
+        result = _.clone<number>(42, customizer, any);
+        result = _.clone<number, string>(42, false, customizer);
+        result = _.clone<number, string>(42, false, customizer, any);
+        result = _.clone<number, string>(42, customizer);
+        result = _.clone<number, string>(42, customizer, any);
+        result = _(42).clone<number>(false, customizer);
+        result = _(42).clone<number>(false, customizer, any);
+        result = _(42).clone<number>(customizer);
+        result = _(42).clone<number>(customizer, any);
+    }
+
+    {
+        let customizer: CloneCustomizer<number, string>;
+        let result: _.LoDashExplicitWrapper<string>;
+
+        result = _(42).chain().clone<number>(false, customizer);
+        result = _(42).chain().clone<number>(false, customizer, any);
+        result = _(42).chain().clone<number>(customizer);
+        result = _(42).chain().clone<number>(customizer, any);
+    }
+
+    {
+        let customizer: CloneCustomizer<number[], number[]>;
+        let result: number[];
+
+        result = _.clone([42]);
+        result = _.clone([42], false);
+        result = _([42]).clone();
+        result = _([42]).clone(false);
+    }
+
+    {
+        let customizer: CloneCustomizer<number[], number[]>;
+        let result: _.LoDashExplicitArrayWrapper<number>;
+
+        result = _([42]).chain().clone();
+        result = _([42]).chain().clone(false);
+    }
+
+    {
+        let customizer: CloneCustomizer<number[], string[]>;
+        let result: string[];
+
+        result = _.clone<number[]>([42], false, customizer);
+        result = _.clone<number[]>([42], false, customizer, any);
+        result = _.clone<number[]>([42], customizer);
+        result = _.clone<number[]>([42], customizer, any);
+        result = _.clone<number[], string[]>([42], false, customizer);
+        result = _.clone<number[], string[]>([42], false, customizer, any);
+        result = _.clone<number[], string[]>([42], customizer);
+        result = _.clone<number[], string[]>([42], customizer, any);
+        result = _([42]).clone<number[]>(false, customizer);
+        result = _([42]).clone<number[]>(false, customizer, any);
+        result = _([42]).clone<number[]>(customizer);
+        result = _([42]).clone<number[]>(customizer, any);
+    }
+
+    {
+        let customizer: CloneCustomizer<number[], string[]>;
+        let result: _.LoDashExplicitArrayWrapper<string>;
+
+        result = _([42]).chain().clone<number[]>(false, customizer);
+        result = _([42]).chain().clone<number[]>(false, customizer, any);
+        result = _([42]).chain().clone<number[]>(customizer);
+        result = _([42]).chain().clone<number[]>(customizer, any);
+    }
+
+    {
+        let customizer: CloneCustomizer<{a: {b: string;};}, {a: {b: number;};}>;
+        let result: {a: {b: number;};};
+
+        result = _.clone({a: {b: 42}});
+        result = _.clone({a: {b: 42}}, false);
+        result = _({a: {b: 42}}).clone();
+        result = _({a: {b: 42}}).clone(false);
+    }
+
+    {
+        let customizer: CloneCustomizer<{a: {b: string;};}, {a: {b: number;};}>;
+        let result: _.LoDashExplicitObjectWrapper<{a: {b: number;};}>;
+
+        result = _({a: {b: 42}}).chain().clone();
+        result = _({a: {b: 42}}).chain().clone(false);
+    }
+
+    {
+        let customizer: CloneCustomizer<{a: {b: number;};}, {a: {b: string;};}>;
+        let result: {a: {b: string;};};
+
+        result = _.clone<{a: {b: number;};}>({a: {b: 42}}, false, customizer);
+        result = _.clone<{a: {b: number;};}>({a: {b: 42}}, false, customizer, any);
+        result = _.clone<{a: {b: number;};}>({a: {b: 42}}, customizer);
+        result = _.clone<{a: {b: number;};}>({a: {b: 42}}, customizer, any);
+        result = _.clone<{a: {b: number;};}, {a: {b: string;};}>({a: {b: 42}}, false, customizer);
+        result = _.clone<{a: {b: number;};}, {a: {b: string;};}>({a: {b: 42}}, false, customizer, any);
+        result = _.clone<{a: {b: number;};}, {a: {b: string;};}>({a: {b: 42}}, customizer);
+        result = _.clone<{a: {b: number;};}, {a: {b: string;};}>({a: {b: 42}}, customizer, any);
+        result = _({a: {b: 42}}).clone<{a: {b: number;};}>(false, customizer);
+        result = _({a: {b: 42}}).clone<{a: {b: number;};}>(false, customizer, any);
+        result = _({a: {b: 42}}).clone<{a: {b: number;};}>(customizer);
+        result = _({a: {b: 42}}).clone<{a: {b: number;};}>(customizer, any);
+    }
+
+    {
+        let customizer: CloneCustomizer<{a: {b: number;};}, {a: {b: string;};}>;
+        let result: _.LoDashExplicitObjectWrapper<{a: {b: string;};}>;
+
+        result = _({a: {b: 42}}).chain().clone<{a: {b: number;};}>(false, customizer);
+        result = _({a: {b: 42}}).chain().clone<{a: {b: number;};}>(false, customizer, any);
+        result = _({a: {b: 42}}).chain().clone<{a: {b: number;};}>(customizer);
+        result = _({a: {b: 42}}).chain().clone<{a: {b: number;};}>(customizer, any);
+    }
 }
 
 // _.cloneDeep
-interface TestCloneDeepCustomizerFn {
-    (value: any): any;
-}
-var testCloneDeepCustomizerFn: TestCloneDeepCustomizerFn;
-{
-    let result: number;
-    result = _.cloneDeep<number>(42);
-    result = _.cloneDeep<number>(42, testCloneDeepCustomizerFn);
-    result = _.cloneDeep<number>(42, testCloneDeepCustomizerFn, any);
-    result = _(42).cloneDeep();
-    result = _(42).cloneDeep(testCloneDeepCustomizerFn);
-    result = _(42).cloneDeep(testCloneDeepCustomizerFn, any);
-}
-{
-    let result: string[];
-    result = _.cloneDeep<string[]>([]);
-    result = _.cloneDeep<string[]>([], testCloneDeepCustomizerFn);
-    result = _.cloneDeep<string[]>([], testCloneDeepCustomizerFn, any);
-    result = _<string>([]).cloneDeep();
-    result = _<string>([]).cloneDeep(testCloneDeepCustomizerFn);
-    result = _<string>([]).cloneDeep(testCloneDeepCustomizerFn, any);
-}
-{
-    let result: {a: {b: number;}};
-    result = _.cloneDeep<{a: {b: number;}}>({a: {b: 2}});
-    result = _.cloneDeep<{a: {b: number;}}>({a: {b: 2}}, testCloneDeepCustomizerFn);
-    result = _.cloneDeep<{a: {b: number;}}>({a: {b: 2}}, testCloneDeepCustomizerFn, any);
-    result = _({a: {b: 2}}).cloneDeep();
-    result = _({a: {b: 2}}).cloneDeep(testCloneDeepCustomizerFn);
-    result = _({a: {b: 2}}).cloneDeep(testCloneDeepCustomizerFn, any);
+namespace TestCloneDeep {
+    interface CloneDeepCustomizer<V, R> {
+        (value: V): R;
+    }
+
+    {
+        let customizer: CloneDeepCustomizer<number, number>;
+        let result: number;
+
+        result = _.cloneDeep(42);
+        result = _(42).cloneDeep();
+    }
+
+    {
+        let customizer: CloneDeepCustomizer<number, number>;
+        let result: _.LoDashExplicitWrapper<number>;
+
+        result = _(42).chain.cloneDeep();
+    }
+
+    {
+        let customizer: CloneDeepCustomizer<number, string>;
+        let result: string;
+
+        result = _.cloneDeep<number>(42, customizer);
+        result = _.cloneDeep<number>(42, customizer, any);
+        result = _.cloneDeep<number, string>(42, customizer);
+        result = _.cloneDeep<number, string>(42, customizer, any);
+        result = _(42).cloneDeep<number>(customizer);
+        result = _(42).cloneDeep<number>(customizer, any);
+    }
+
+    {
+        let customizer: CloneDeepCustomizer<number, string>;
+        let result: _.LoDashExplicitWrapper<string>;
+
+        result = _(42).chain().cloneDeep<number>(customizer);
+        result = _(42).chain().cloneDeep<number>(customizer, any);
+    }
+
+    {
+        let customizer: CloneDeepCustomizer<number[], number[]>;
+        let result: number[];
+
+        result = _.cloneDeep([42]);
+        result = _([42]).cloneDeep();
+    }
+
+    {
+        let customizer: CloneDeepCustomizer<number[], number[]>;
+        let result: _.LoDashExplicitArrayWrapper<number>;
+
+        result = _([42]).chain().cloneDeep();
+    }
+
+    {
+        let customizer: CloneDeepCustomizer<number[], string[]>;
+        let result: string[];
+
+        result = _.cloneDeep<number[]>([42], customizer);
+        result = _.cloneDeep<number[]>([42], customizer, any);
+        result = _.cloneDeep<number[], string[]>([42], customizer);
+        result = _.cloneDeep<number[], string[]>([42], customizer, any);
+        result = _([42]).cloneDeep<number[]>(customizer);
+        result = _([42]).cloneDeep<number[]>(customizer, any);
+    }
+
+    {
+        let customizer: CloneDeepCustomizer<number[], string[]>;
+        let result: _.LoDashExplicitArrayWrapper<string>;
+
+        result = _([42]).chain().cloneDeep<number[]>(customizer);
+        result = _([42]).chain().cloneDeep<number[]>(customizer, any);
+    }
+
+    {
+        let customizer: CloneDeepCustomizer<{a: {b: string;};}, {a: {b: number;};}>;
+        let result: {a: {b: number;};};
+
+        result = _.cloneDeep({a: {b: 42}});
+        result = _({a: {b: 42}}).cloneDeep();
+    }
+
+    {
+        let customizer: CloneDeepCustomizer<{a: {b: string;};}, {a: {b: number;};}>;
+        let result: _.LoDashExplicitObjectWrapper<{a: {b: number;};}>;
+
+        result = _({a: {b: 42}}).chain().cloneDeep();
+    }
+
+    {
+        let customizer: CloneDeepCustomizer<{a: {b: number;};}, {a: {b: string;};}>;
+        let result: {a: {b: string;};};
+
+        result = _.cloneDeep<{a: {b: number;};}>({a: {b: 42}}, customizer);
+        result = _.cloneDeep<{a: {b: number;};}>({a: {b: 42}}, customizer, any);
+        result = _.cloneDeep<{a: {b: number;};}, {a: {b: string;};}>({a: {b: 42}}, customizer);
+        result = _.cloneDeep<{a: {b: number;};}, {a: {b: string;};}>({a: {b: 42}}, customizer, any);
+        result = _({a: {b: 42}}).cloneDeep<{a: {b: number;};}>(customizer);
+        result = _({a: {b: 42}}).cloneDeep<{a: {b: number;};}>(customizer, any);
+    }
+
+    {
+        let customizer: CloneDeepCustomizer<{a: {b: number;};}, {a: {b: string;};}>;
+        let result: _.LoDashExplicitObjectWrapper<{a: {b: string;};}>;
+
+        result = _({a: {b: 42}}).chain().cloneDeep<{a: {b: number;};}>(customizer);
+        result = _({a: {b: 42}}).chain().cloneDeep<{a: {b: number;};}>(customizer, any);
+    }
 }
 
 // _.eq

--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -6036,79 +6036,197 @@ namespace TestCastArray {
 }
 
 // _.clone
-{
-    let result: number;
-    result = _.clone<number>(42);
-    result = _(42).clone();
-}
-{
-    let result: string[];
-    result = _.clone<string[]>([]);
-    result = _<string>([]).clone();
-}
-{
-    let result: {a: {b: number;}};
-    result = _.clone<{a: {b: number;}}>({a: {b: 2}});
-    result = _({a: {b: 2}}).clone();
+namespace TestClone {
+    {
+        let result: number;
+
+        result = _.clone<number>(42);
+        result = _(42).clone();
+    }
+
+    {
+        let result: _.LoDashExplicitWrapper<number>;
+
+        result = _(42).chain().clone();
+    }
+
+    {
+        let result: string[];
+
+        result = _.clone<string[]>(['']);
+        result = _<string>(['']).clone();
+    }
+
+    {
+        let result: _.LoDashExplicitArrayWrapper<string>;
+
+        result = _(['']).chain().clone();
+    }
+
+    {
+        let result: {a: {b: number;};};
+
+        result = _.clone<{a: {b: number;};}>({a: {b: 42}});
+        result = _({a: {b: 42}}).clone();
+    }
+
+    {
+        let result: _.LoDashExplicitObjectWrapper<{a: {b: number;};}>;
+
+        result = _({a: {b: 42}}).chain().clone();
+    }
 }
 
 // _.cloneDeep
-{
-    let result: number;
-    result = _.cloneDeep<number>(42);
-    result = _(42).cloneDeep();
-}
-{
-    let result: string[];
-    result = _.cloneDeep<string[]>([]);
-    result = _<string>([]).cloneDeep();
-}
-{
-    let result: {a: {b: number;}};
-    result = _.cloneDeep<{a: {b: number;}}>({a: {b: 2}});
-    result = _({a: {b: 2}}).cloneDeep();
-}
+namespace TestCloneDeep {
+    {
+        let result: number;
 
-// _.cloneWith
-interface TestCloneCustomizerFn {
-    (value: any): any;
-}
-var testCloneCustomizerFn: TestCloneCustomizerFn;
-{
-    let result: number;
-    result = _.clone<number>(42, testCloneCustomizerFn);
-    result = _(42).clone(testCloneCustomizerFn);
-}
-{
-    let result: string[];
-    result = _.clone<string[]>([], testCloneCustomizerFn);
-    result = _<string>([]).clone(testCloneCustomizerFn);
-}
-{
-    let result: {a: {b: number;}};
-    result = _.clone<{a: {b: number;}}>({a: {b: 2}}, testCloneCustomizerFn);
-    result = _({a: {b: 2}}).clone(testCloneCustomizerFn);
+        result = _.cloneDeep<number>(42);
+        result = _(42).cloneDeep();
+    }
+
+    {
+        let result: _.LoDashExplicitWrapper<number>;
+
+        result = _(42).chain().cloneDeep();
+    }
+
+    {
+        let result: string[];
+
+        result = _.cloneDeep<string[]>(['']);
+        result = _<string>(['']).cloneDeep();
+    }
+
+    {
+        let result: _.LoDashExplicitArrayWrapper<string>;
+
+        result = _(['']).chain().cloneDeep();
+    }
+
+    {
+        let result: {a: {b: number;};};
+
+        result = _.cloneDeep<{a: {b: number;};}>({a: {b: 42}});
+        result = _({a: {b: 42}}).cloneDeep();
+    }
+
+    {
+        let result: _.LoDashExplicitObjectWrapper<{a: {b: number;};}>;
+
+        result = _({a: {b: 42}}).chain().cloneDeep();
+    }
 }
 
 // _.cloneDeepWith
-interface TestCloneDeepCustomizerFn {
-    (value: any): any;
+namespace TestCloneDeepWith {
+    interface CloneDeepWithCustomizer<V, R> {
+        (value: V): R;
+    }
+
+    {
+        let customizer: CloneDeepWithCustomizer<number, string>;
+        let reslut: string;
+
+        result = _.cloneDeepWith<string>(42, customizer);
+        result = _.cloneDeepWith<number, string>(42, customizer);
+        result = _(42).cloneDeepWith<string>(customizer);
+    }
+
+    {
+        let customizer: CloneDeepWithCustomizer<number, string>;
+        let result: _.LoDashExplicitWrapper<string>;
+
+        result = _(42).chain().cloneDeepWith<string>(customizer);
+    }
+
+    {
+        let customizer: CloneDeepWithCustomizer<number[], string[]>;
+        let reslut: string[];
+
+        result = _.cloneDeepWith<string[]>([42], customizer);
+        result = _.cloneDeepWith<number[], string[]>([42], customizer);
+        result = _([42]).cloneDeepWith<string[]>(customizer);
+    }
+
+    {
+        let customizer: CloneDeepWithCustomizer<number[], string[]>;
+        let result: _.LoDashExplicitArrayWrapper<string>;
+
+        result = _([42]).chain().cloneDeepWith<string>(customizer);
+    }
+
+    {
+        let customizer: CloneDeepWithCustomizer<{a: {b: number;};}, {a: {b: string;};}>;
+        let reslut: {a: {b: string;};};
+
+        result = _.cloneDeepWith<{a: {b: string;};}>({a: {b: 42}}, customizer);
+        result = _.cloneDeepWith<{a: {b: number;};}, {a: {b: string;};}>({a: {b: 42}}, customizer);
+        result = _({a: {b: 42}}).cloneDeepWith<{a: {b: string;};}>(customizer);
+    }
+
+    {
+        let customizer: CloneDeepWithCustomizer<{a: {b: number;};}, {a: {b: string;};}>;
+        let result: _.LoDashExplicitObjectWrapper<{a: {b: string;};}>;
+
+        result = _({a: {b: 42}}).chain().cloneDeepWith<{a: {b: string;};}>(customizer);
+    }
 }
-var testCloneDeepCustomizerFn: TestCloneDeepCustomizerFn;
-{
-    let result: number;
-    result = _.cloneDeep<number>(42, testCloneDeepCustomizerFn);
-    result = _(42).cloneDeep(testCloneDeepCustomizerFn);
-}
-{
-    let result: string[];
-    result = _.cloneDeep<string[]>([], testCloneDeepCustomizerFn);
-    result = _<string>([]).cloneDeep(testCloneDeepCustomizerFn);
-}
-{
-    let result: {a: {b: number;}};
-    result = _.cloneDeep<{a: {b: number;}}>({a: {b: 2}}, testCloneDeepCustomizerFn);
-    result = _({a: {b: 2}}).cloneDeep(testCloneDeepCustomizerFn);
+
+// _.cloneWith
+namespace TestCloneWith {
+    interface CloneWithCustomizer<V, R> {
+        (value: V): R;
+    }
+
+    {
+        let customizer: CloneWithCustomizer<number, string>;
+        let reslut: string;
+
+        result = _.cloneWith<string>(42, customizer);
+        result = _.cloneWith<number, string>(42, customizer);
+        result = _(42).cloneWith<string>(customizer);
+    }
+
+    {
+        let customizer: CloneWithCustomizer<number, string>;
+        let result: _.LoDashExplicitWrapper<string>;
+
+        result = _(42).chain().cloneWith<string>(customizer);
+    }
+
+    {
+        let customizer: CloneWithCustomizer<number[], string[]>;
+        let reslut: string[];
+
+        result = _.cloneWith<string[]>([42], customizer);
+        result = _.cloneWith<number[], string[]>([42], customizer);
+        result = _([42]).cloneWith<string[]>(customizer);
+    }
+
+    {
+        let customizer: CloneWithCustomizer<number[], string[]>;
+        let result: _.LoDashExplicitArrayWrapper<string>;
+
+        result = _([42]).chain().cloneWith<string>(customizer);
+    }
+
+    {
+        let customizer: CloneWithCustomizer<{a: {b: number;};}, {a: {b: string;};}>;
+        let reslut: {a: {b: string;};};
+
+        result = _.cloneWith<{a: {b: string;};}>({a: {b: 42}}, customizer);
+        result = _.cloneWith<{a: {b: number;};}, {a: {b: string;};}>({a: {b: 42}}, customizer);
+        result = _({a: {b: 42}}).cloneWith<{a: {b: string;};}>(customizer);
+    }
+
+    {
+        let customizer: CloneWithCustomizer<{a: {b: number;};}, {a: {b: string;};}>;
+        let result: _.LoDashExplicitObjectWrapper<{a: {b: string;};}>;
+
+        result = _({a: {b: 42}}).chain().cloneWith<{a: {b: string;};}>(customizer);
+    }
 }
 
 // _.eq

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -10675,28 +10675,15 @@ declare module _ {
     //_.clone
     interface LoDashStatic {
         /**
-         * Creates a shallow clone of `value`.
+         * Creates a shallow clone of value.
          *
-         * **Note:** This method is loosely based on the
-         * [structured clone algorithm](https://mdn.io/Structured_clone_algorithm)
-         * and supports cloning arrays, array buffers, booleans, date objects, maps,
-         * numbers, `Object` objects, regexes, sets, strings, symbols, and typed
-         * arrays. The own enumerable properties of `arguments` objects are cloned
-         * as plain objects. An empty object is returned for uncloneable values such
-         * as error objects, functions, DOM nodes, and WeakMaps.
+         * Note: This method is loosely based on the structured clone algorithm and supports cloning arrays,
+         * array buffers, booleans, date objects, maps, numbers, Object objects, regexes, sets, strings, symbols,
+         * and typed arrays. The own enumerable properties of arguments objects are cloned as plain objects. An empty
+         * object is returned for uncloneable values such as error objects, functions, DOM nodes, and WeakMaps.
          *
-         * @static
-         * @memberOf _
-         * @category Lang
-         * @param {*} value The value to clone.
-         * @returns {*} Returns the cloned value.
-         * @example
-         *
-         * var objects = [{ 'a': 1 }, { 'b': 2 }];
-         *
-         * var shallow = _.clone(objects);
-         * console.log(shallow[0] === objects[0]);
-         * // => true
+         * @param value The value to clone.
+         * @return Returns the cloned value.
          */
         clone<T>(value: T): T;
     }
@@ -10723,23 +10710,35 @@ declare module _ {
         clone(): T;
     }
 
+    interface LoDashExplicitWrapper<T> {
+        /**
+         * @see _.clone
+         */
+        clone(): LoDashExplicitWrapper<T>;
+    }
+
+    interface LoDashExplicitArrayWrapper<T> {
+
+        /**
+         * @see _.clone
+         */
+        clone(): LoDashExplicitArrayWrapper<T>;
+    }
+
+    interface LoDashExplicitObjectWrapper<T> {
+        /**
+         * @see _.clone
+         */
+        clone(): LoDashExplicitObjectWrapper<T>;
+    }
+
     //_.cloneDeep
     interface LoDashStatic {
         /**
-         * This method is like `_.clone` except that it recursively clones `value`.
+         * This method is like _.clone except that it recursively clones value.
          *
-         * @static
-         * @memberOf _
-         * @category Lang
-         * @param {*} value The value to recursively clone.
-         * @returns {*} Returns the deep cloned value.
-         * @example
-         *
-         * var objects = [{ 'a': 1 }, { 'b': 2 }];
-         *
-         * var deep = _.cloneDeep(objects);
-         * console.log(deep[0] === objects[0]);
-         * // => false
+         * @param value The value to recursively clone.
+         * @return Returns the deep cloned value.
          */
         cloneDeep<T>(value: T): T;
     }
@@ -10765,97 +10764,272 @@ declare module _ {
         cloneDeep(): T;
     }
 
-    //_.cloneWith
-    interface LoDashStatic {
+    interface LoDashExplicitWrapper<T> {
         /**
-         * Creates a shallow clone of `value`.
-         *
-         * **Note:** This method is loosely based on the
-         * [structured clone algorithm](https://mdn.io/Structured_clone_algorithm)
-         * and supports cloning arrays, array buffers, booleans, date objects, maps,
-         * numbers, `Object` objects, regexes, sets, strings, symbols, and typed
-         * arrays. The own enumerable properties of `arguments` objects are cloned
-         * as plain objects. An empty object is returned for uncloneable values such
-         * as error objects, functions, DOM nodes, and WeakMaps.
-         *
-         * @static
-         * @memberOf _
-         * @category Lang
-         * @param {*} value The value to clone.
-         * @returns {*} Returns the cloned value.
-         * @example
-         *
-         * var objects = [{ 'a': 1 }, { 'b': 2 }];
-         *
-         * var shallow = _.clone(objects);
-         * console.log(shallow[0] === objects[0]);
-         * // => true
+         * @see _.cloneDeep
          */
-        clone<T>(
-            value: T,
-            customizer: (value: any) => any): T;
+        cloneDeep(): LoDashExplicitWrapper<T>;
     }
 
-    interface LoDashImplicitWrapper<T> {
+    interface LoDashExplicitArrayWrapper<T> {
         /**
-         * @see _.clone
+         * @see _.cloneDeep
          */
-        clone(customizer: (value: any) => any): T;
+        cloneDeep(): LoDashExplicitArrayWrapper<T>;
     }
 
-    interface LoDashImplicitArrayWrapper<T> {
-
+    interface LoDashExplicitObjectWrapper<T> {
         /**
-         * @see _.clone
+         * @see _.cloneDeep
          */
-        clone(customizer: (value: any) => any): T[];
-    }
-
-    interface LoDashImplicitObjectWrapper<T> {
-        /**
-         * @see _.clone
-         */
-        clone(customizer: (value: any) => any): T;
+        cloneDeep(): LoDashExplicitObjectWrapper<T>;
     }
 
     //_.cloneDeepWith
+    interface CloneDeepWithCustomizer<TValue, TResult> {
+        (value: TValue): TResult;
+    }
+
     interface LoDashStatic {
         /**
-         * Creates a deep clone of value. If customizer is provided it’s invoked to produce the cloned values. If
-         * customizer returns undefined cloning is handled by the method instead. The customizer is bound to thisArg
-         * and invoked with up to three argument; (value [, index|key, object]).
-         * Note: This method is loosely based on the structured clone algorithm. The enumerable properties of arguments
-         * objects and objects created by constructors other than Object are cloned to plain Object objects. An empty
-         * object is returned for uncloneable values such as functions, DOM nodes, Maps, Sets, and WeakMaps.
-         * @param value The value to deep clone.
-         * @param customizer The function to customize cloning values.
-         * @param thisArg The this binding of customizer.
+         * This method is like _.cloneWith except that it recursively clones value.
+         *
+         * @param value The value to recursively clone.
+         * @param customizer The function to customize cloning.
          * @return Returns the deep cloned value.
          */
-        cloneDeep<T>(
+        cloneDeepWith<TResult>(
+            value: any,
+            customizer?: CloneDeepWithCustomizer<any, TResult>
+        ): TResult;
+
+        /**
+         * @see _.clonDeepeWith
+         */
+        cloneDeepWith<T, TResult>(
             value: T,
-            customizer: (value: any) => any): T;
+            customizer?: CloneDeepWithCustomizer<T, TResult>
+        ): TResult;
     }
 
     interface LoDashImplicitWrapper<T> {
         /**
-         * @see _.cloneDeep
+         * @see _.cloneDeepWith
          */
-        cloneDeep(customizer: (value: any) => any): T;
+        cloneDeepWith<TResult>(
+            customizer?: CloneDeepWithCustomizer<T, TResult>
+        ): TResult;
     }
 
     interface LoDashImplicitArrayWrapper<T> {
         /**
-         * @see _.cloneDeep
+         * @see _.cloneDeepWith
          */
-        cloneDeep(customizer: (value: any) => any): T[];
+        cloneDeepWith<TResult>(
+            customizer?: CloneDeepWithCustomizer<T[], TResult>
+        ): TResult;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
         /**
-         * @see _.cloneDeep
+         * @see _.cloneDeepWith
          */
-        cloneDeep(customizer: (value: any) => any): T;
+        cloneDeepWith<TResult>(
+            customizer?: CloneDeepWithCustomizer<T, TResult>
+        ): TResult;
+    }
+
+    interface LoDashExplicitWrapper<T> {
+        /**
+         * @see _.cloneDeepWith
+         */
+        cloneDeepWith<TResult extends (number|string|boolean)>(
+            customizer?: CloneDeepWithCustomizer<T, TResult>
+        ): LoDashExplicitWrapper<TResult>;
+
+        /**
+         * @see _.cloneDeepWith
+         */
+        cloneDeepWith<TResult>(
+            customizer?: CloneDeepWithCustomizer<T, TResult[]>
+        ): LoDashExplicitArrayWrapper<TResult>;
+
+        /**
+         * @see _.cloneDeepWith
+         */
+        cloneDeepWith<TResult extends Object>(
+            customizer?: CloneDeepWithCustomizer<T, TResult>
+        ): LoDashExplicitObjectWrapper<TResult>;
+    }
+
+    interface LoDashExplicitArrayWrapper<T> {
+        /**
+         * @see _.cloneDeepWith
+         */
+        cloneDeepWith<TResult extends (number|string|boolean)>(
+            customizer?: CloneDeepWithCustomizer<T[], TResult>
+        ): LoDashExplicitWrapper<TResult>;
+
+        /**
+         * @see _.cloneDeepWith
+         */
+        cloneDeepWith<TResult>(
+            customizer?: CloneDeepWithCustomizer<T[], TResult[]>
+        ): LoDashExplicitArrayWrapper<TResult>;
+
+        /**
+         * @see _.cloneDeepWith
+         */
+        cloneDeepWith<TResult extends Object>(
+            customizer?: CloneDeepWithCustomizer<T[], TResult>
+        ): LoDashExplicitObjectWrapper<TResult>;
+    }
+
+    interface LoDashExplicitObjectWrapper<T> {
+        /**
+         * @see _.cloneDeepWith
+         */
+        cloneDeepWith<TResult extends (number|string|boolean)>(
+            customizer?: CloneDeepWithCustomizer<T, TResult>
+        ): LoDashExplicitWrapper<TResult>;
+
+        /**
+         * @see _.cloneDeepWith
+         */
+        cloneDeepWith<TResult>(
+            customizer?: CloneDeepWithCustomizer<T, TResult[]>
+        ): LoDashExplicitArrayWrapper<TResult>;
+
+        /**
+         * @see _.cloneDeepWith
+         */
+        cloneDeepWith<TResult extends Object>(
+            customizer?: CloneDeepWithCustomizer<T, TResult>
+        ): LoDashExplicitObjectWrapper<TResult>;
+    }
+
+    //_.cloneWith
+    interface CloneWithCustomizer<TValue, TResult> {
+        (value: TValue): TResult;
+    }
+
+    interface LoDashStatic {
+        /**
+         * This method is like _.clone except that it accepts customizer which is invoked to produce the cloned value.
+         * If customizer returns undefined cloning is handled by the method instead.
+         *
+         * @param value The value to clone.
+         * @param customizer The function to customize cloning.
+         * @return Returns the cloned value.
+         */
+        cloneWith<TResult>(
+            value: any,
+            customizer?: CloneWithCustomizer<any, TResult>
+        ): TResult;
+
+        /**
+         * @see _.cloneWith
+         */
+        cloneWith<T, TResult>(
+            value: T,
+            customizer?: CloneWithCustomizer<T, TResult>
+        ): TResult;
+    }
+
+    interface LoDashImplicitWrapper<T> {
+        /**
+         * @see _.cloneWith
+         */
+        cloneWith<TResult>(
+            customizer?: CloneWithCustomizer<T, TResult>
+        ): TResult;
+    }
+
+    interface LoDashImplicitArrayWrapper<T> {
+        /**
+         * @see _.cloneWith
+         */
+        cloneWith<TResult>(
+            customizer?: CloneWithCustomizer<T[], TResult>
+        ): TResult;
+    }
+
+    interface LoDashImplicitObjectWrapper<T> {
+        /**
+         * @see _.cloneWith
+         */
+        cloneWith<TResult>(
+            customizer?: CloneWithCustomizer<T, TResult>
+        ): TResult;
+    }
+
+    interface LoDashExplicitWrapper<T> {
+        /**
+         * @see _.cloneWith
+         */
+        cloneWith<TResult extends (number|string|boolean)>(
+            customizer?: CloneWithCustomizer<T, TResult>
+        ): LoDashExplicitWrapper<TResult>;
+
+        /**
+         * @see _.cloneWith
+         */
+        cloneWith<TResult>(
+            customizer?: CloneWithCustomizer<T, TResult[]>
+        ): LoDashExplicitArrayWrapper<TResult>;
+
+        /**
+         * @see _.cloneWith
+         */
+        cloneWith<TResult extends Object>(
+            customizer?: CloneWithCustomizer<T, TResult>
+        ): LoDashExplicitObjectWrapper<TResult>;
+    }
+
+    interface LoDashExplicitArrayWrapper<T> {
+        /**
+         * @see _.cloneWith
+         */
+        cloneWith<TResult extends (number|string|boolean)>(
+            customizer?: CloneWithCustomizer<T[], TResult>
+        ): LoDashExplicitWrapper<TResult>;
+
+        /**
+         * @see _.cloneWith
+         */
+        cloneWith<TResult>(
+            customizer?: CloneWithCustomizer<T[], TResult[]>
+        ): LoDashExplicitArrayWrapper<TResult>;
+
+        /**
+         * @see _.cloneWith
+         */
+        cloneWith<TResult extends Object>(
+            customizer?: CloneWithCustomizer<T[], TResult>
+        ): LoDashExplicitObjectWrapper<TResult>;
+    }
+
+    interface LoDashExplicitObjectWrapper<T> {
+        /**
+         * @see _.cloneWith
+         */
+        cloneWith<TResult extends (number|string|boolean)>(
+            customizer?: CloneWithCustomizer<T, TResult>
+        ): LoDashExplicitWrapper<TResult>;
+
+        /**
+         * @see _.cloneWith
+         */
+        cloneWith<TResult>(
+            customizer?: CloneWithCustomizer<T, TResult[]>
+        ): LoDashExplicitArrayWrapper<TResult>;
+
+        /**
+         * @see _.cloneWith
+         */
+        cloneWith<TResult extends Object>(
+            customizer?: CloneWithCustomizer<T, TResult>
+        ): LoDashExplicitObjectWrapper<TResult>;
     }
 
     //_.eq


### PR DESCRIPTION
**lodash-4.6**:
https://lodash.com/docs#clone
https://lodash.com/docs#cloneDeep
https://lodash.com/docs#cloneDeepWith
https://lodash.com/docs#cloneWith
https://lodash.com/docs#_ (description of chainable wrappers)

**lodash-3.10**:
https://github.com/lodash/lodash/blob/3.10.1/doc/README.md#_clonevalue-isdeep-customizer-thisarg
https://github.com/lodash/lodash/blob/3.10.1/doc/README.md#_clonedeepvalue-customizer-thisarg
https://github.com/lodash/lodash/blob/3.10.1/doc/README.md#_value (description of chainable wrappers)
