### PR TITLE
Change the IHttpInterceptorService.response() method to match angular documentation

### DIFF
--- a/angular-ui-router/angular-ui-router.d.ts
+++ b/angular-ui-router/angular-ui-router.d.ts
@@ -7,13 +7,8 @@
 
 // Support for AMD require and CommonJS
 declare module 'angular-ui-router' {
-    // Since angular-ui-router adds providers for a bunch of
-    // injectable dependencies, it doesn't really return any
-    // actual data except the plain string 'ui.router'.
-    //
-    // As such, I don't think anybody will ever use the actual
-    // default value of the module.  So I've only included the
-    // the types. (@xogeny)
+    export default 'ui.router';
+
     export type IState = angular.ui.IState;
     export type IStateProvider = angular.ui.IStateProvider;
     export type IUrlMatcher = angular.ui.IUrlMatcher;

--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -1077,3 +1077,21 @@ function doBootstrap(element: Element | JQuery, mode: string): ng.auto.IInjector
         debugInfoEnabled: false
     });
 }
+
+// IHttpInterceptor implementation test
+class MyHttpInterceptor implements ng.IHttpInterceptor {
+    public request(config: ng.IRequestConfig): ng.IRequestConfig | ng.IPromise<ng.IRequestConfig> {
+        if (config.withCredentials) {
+            // Include OAuth2 token in headers
+        }
+        
+        return config;
+    }
+
+    public response<T>(response: ng.IHttpPromiseCallbackArg<T>): ng.IPromise<ng.IHttpPromiseCallbackArg<T>> | ng.IHttpPromiseCallbackArg<T> {
+        if (response.status === 500) {
+            // Unwrap error message
+        }
+        return response;
+    }
+}

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1491,7 +1491,7 @@ declare module angular {
     interface IHttpInterceptor {
         request?: (config: IRequestConfig) => IRequestConfig|IPromise<IRequestConfig>;
         requestError?: (rejection: any) => any;
-        response?: <T>(response: IHttpPromiseCallbackArg<T>) => IPromise<T>|T;
+        response?: <T>(response: IHttpPromiseCallbackArg<T>) => IPromise<IHttpPromiseCallbackArg<T>>|IHttpPromiseCallbackArg<T>;
         responseError?: (rejection: any) => any;
     }
 


### PR DESCRIPTION
As per the [$http angular docs on writing interceptors](https://docs.angularjs.org/api/ng/service/$http), I have updated the `IHttpInterceptorService` type to match the following definition:

> response: interceptors get called with http response object. The function is free to modify the response object or create a new one. The function needs to return the response object directly, or as a promise containing the response or a new response object.

The previous definition would require returning the data that was passed through the response object instead.

I also added a basic test for the the service since none was previously provided.

This fixes #7736 

As a note, maybe we should consider renaming `IHttpPromiseCallbackArg` to `IHttpResponse` or something similar since it is not always used in  the context of a promise (like in this case) and that the name does not really represent the content of the interface very well.
