### PR TITLE
Update datatable-buttons definitions

### DIFF
--- a/datatables-buttons/datatables-buttons-tests.ts
+++ b/datatables-buttons/datatables-buttons-tests.ts
@@ -29,5 +29,148 @@ $(document).ready(function () {
                 }
             ],
         }
+        
+    $('#myTable').DataTable( {
+        buttons: {
+            name: 'primary'
+        }
+    });
 
+    $('#myTable').DataTable( {
+        buttons: [ 'copy', 'csv', 'print' ]
+    });
+
+    $('#myTable').DataTable( {
+        buttons: {
+            buttons: [
+                'copy',
+                { extend: 'excel', text: 'Save as Excel' }
+            ]
+        }
+    });
+
+    $('#myTable').DataTable({
+        buttons: {
+            dom: {
+                buttons: {
+                    tag: 'button'
+                },
+                buttonLiner: {
+                    tag: null
+                }
+            },
+            buttons: [
+                'copy',
+                { extend: 'excel', text: 'Save as Excel' }
+            ]
+        }
+    });
+
+    $('#myTable').DataTable( {
+        buttons: {
+            dom: {
+                container: {
+                    tag: 'aside'
+                }
+            }
+        }
+    });
+
+    $('#myTable').DataTable( {
+        buttons: {
+            dom: {
+                button: {
+                    tag: 'input',
+                    className: 'btn',
+                }
+            }
+        }
+    });
+
+    $('#myTable').DataTable( {
+        buttons: {
+            dom: {
+                container: {
+                    tag: 'ul'
+                },
+                buttonContainer: {
+                    tag: 'li'
+                },
+                button: {
+                    tag: 'a'
+                }
+            }
+        }
+    });
+
+    $('#myTable').DataTable( {
+        buttons: {
+            dom: {
+                collection: {
+                    tag: 'aside'
+                }
+            }
+        }
+    });
+
+    $('#myTable').DataTable( {
+        buttons: [
+            {
+                extend:    'copyHtml5',
+                text:      '<i class="fa fa-files-o"></i>',
+                titleAttr: 'Copy'
+            }
+        ]
+    });
+
+    $('#myTable').DataTable( {
+        buttons: {
+            buttons: [
+                {
+                    text: '',
+                    init: function ( e, dt, node:JQuery, config ) {
+                        node.on( 'mouseenter'+config.namespace, function () {
+                            console.log( 'Mouse enter' );
+                        } );
+
+                        node.on( 'mouseleave'+config.namespace, function () {
+                            console.log( 'Mouse leave' );
+                        } );
+                    },
+                    destroy: function ( dt, node, config ) {
+                        node.off( 'mouseenter'+config.namespace );
+                        node.off( 'mouseleave'+config.namespace );
+                    }
+                }
+            ]
+        }
+    });
+
+    $('#myTable').DataTable( {
+        buttons: [
+            { extend: 'print', key: 'p' }
+        ]
+    });
+
+    $('#myTable').DataTable( {
+        buttons: {
+            buttons: [
+                {
+                    text: 'FileReader available',
+                    available: function ( dt, config ) {
+                        return true;
+                    }
+                }
+            ]
+        }
+    });
+
+    $('#myTable').DataTable( {
+        buttons: {
+            buttons: [
+                'copy',
+                { extend: 'excel', disable: false }
+            ]
+        }
+    });
 });

--- a/datatables-buttons/datatables-buttons-tests.ts
+++ b/datatables-buttons/datatables-buttons-tests.ts
@@ -128,7 +128,7 @@ $(document).ready(function () {
             buttons: [
                 {
                     text: '',
-                    init: function ( e, dt, node:JQuery, config ) {
+                    init: function ( dt, node, config ) {
                         node.on( 'mouseenter'+config.namespace, function () {
                             console.log( 'Mouse enter' );
                         } );
@@ -140,6 +140,20 @@ $(document).ready(function () {
                     destroy: function ( dt, node, config ) {
                         node.off( 'mouseenter'+config.namespace );
                         node.off( 'mouseleave'+config.namespace );
+                    }
+                }
+            ]
+        }
+    });
+
+    $('#myTable').DataTable( {
+        buttons: {
+            buttons: [
+                {
+                    text: 'Alert',
+                    action: function ( e, dt, node, config ) {
+                        alert( 'Activated!' );
+                        this.disable(); // disable button
                     }
                 }
             ]

--- a/datatables-buttons/datatables-buttons.d.ts
+++ b/datatables-buttons/datatables-buttons.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for JQuery DataTables Buttons extension 1.1.0
 // Project: http://datatables.net/extensions/buttons/
-// Definitions by: Sam Germano <https://github.com/SammyG4Free>
+// Definitions by: Sam Germano <https://github.com/SammyG4Free>, Kiarash Ghiaseddin <https://github.com/Silver-Connection/DefinitelyTyped>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../jquery/jquery.d.ts" />
@@ -11,9 +11,86 @@ declare module DataTables {
         /**
          * Buttons extension options
          */
-        buttons?: boolean | string[] | ButtonSettings[];
+        buttons?: boolean | ButtonsSettings | Array<string | ButtonSettings>;
     }
 	
+    //#region "buttons-general-settings"
+    
+    export interface ButtonsSettings {
+        /**
+        * As multiple Buttons instances can be attached to a single DataTable, it can be useful to be able to select each instance individually. Since: Buttons 1.0.0
+        */
+        name?: string;
+        
+        /**
+        * Options to control the DOM structure Buttons creates. Since: Buttons 1.0.0
+        */
+        dom?: ButtonsDomSettings;
+        
+        /**
+        * List of buttons to be created. Since: Buttons 1.0.0
+        */
+        buttons?: ButtonSettings | Array<string | ButtonSettings>;
+    }
+    
+    //#region "buttons-general-settings"
+    
+    //#region "buttons-dom-settings"
+    
+     export interface ButtonsDomSettings {
+        /**
+        * As multiple Buttons instances can be attached to a single DataTable, it can be useful to be able to select each instance individually. Since: Buttons 1.0.0
+        */
+        container?: ButtonsDomContainerSettings;
+        
+        /**
+        * DOM configuration for individual button elements.
+        */
+        button?: ButtonsDomButtonSettings;
+        buttons?: ButtonsDomButtonSettings;
+        
+        /**
+        * DOM configuration of a button container element.
+        */
+        buttonContainer?: ButtonsDomContainerSettings;
+        
+        /**
+        * DOM configuration of a button liner element.
+        */
+        buttonLiner?: ButtonsDomContainerSettings;
+        
+        /**
+        * DOM configuration of the collection display.
+        */
+        collection?: ButtonsDomContainerSettings;
+    }
+    
+    export interface ButtonsDomContainerSettings {
+        /**
+        * Value which defines the element's class name. Multiple classes can be given using space separation.
+        */
+        className?: string;
+        
+        /**
+        * Value which defines the HTML tag to use. There should be no spaces or any other formatting - e.g. it should simply be div, aside, etc.
+        */
+        tag?: string;
+    }
+        
+    export interface ButtonsDomButtonSettings extends ButtonsDomContainerSettings {
+        /**
+        * The class name to assign to the button when the button is in the disabled state.
+        */
+        active?: string;
+        
+        /**
+        * The class name to assign to the button when the button is in the active state.
+        */
+        disabled?: string;
+    }
+    
+    //#endregion "buttons-dom-settings"
+    
     //#region "button-settings"
     
     /**
@@ -44,6 +121,7 @@ declare module DataTables {
         * Set a button's initial enabled state
         */
         enabled?: boolean;
+        disable?: boolean;
 
         /**
         * Define which button type the button should be based on
@@ -73,7 +151,7 @@ declare module DataTables {
         /**
         * The text to show in the button
         */
-        text?: string | ButtonText;
+        text?: string | FunctionButtonText;
 
         /**
         * Button 'title' attribute text
@@ -84,30 +162,51 @@ declare module DataTables {
         autoPrint?: boolean;
     }
 
-    export interface FunctionButtonAvailable {
-        (dt: DataTables.DataTable, config: any): boolean
-    }
     export interface ButtonExportOptions {
         columns?: string;
     }
 
     export interface ButtonKey {
+        /**
+        * The character to listen for. The character is case insensitive.
+        */
         key?: string;
+        
+        /**
+        * When set to true activation will only occur if the shift key is also being held.
+        */
         shiftKey?: boolean;
+        
+        /**
+        * When set to true activation will only occur if the alt key is also being held.
+        */
         altKey?: boolean;
+        
+        /**
+        * When set to true activation will only occur if the ctrl key is also being held.
+        */
         ctrlKey?: boolean;
+        
+        /**
+        * When set to true activation will only occur if the cmd key (Mac) or Windows key (Windows) is also being held.
+        */
         metaKey?: boolean;
     }
 
-    export interface ButtonText {
-        (dt: DataTables.DataTable, node: JQuery, config: any): string
+    export interface FunctionButtonAvailable {
+        (dt: DataTables.DataTable, config: ButtonSettings): boolean
     }
+
+    export interface FunctionButtonText {
+        (dt: DataTables.DataTable, node: JQuery, config: ButtonSettings): string
+    }
+    
     export interface FunctionButtonInit {
-        (dt: DataTables.DataTable, node: JQuery, config: any): void
+        (dt: DataTables.DataTable, node: JQuery, config: ButtonSettings): void
     }
-    // api object?
+    
     export interface FunctionButtonAction {
-        (e: any, dt: DataTables.DataTable, node: JQuery, config: any): void
+        (e: any, dt: DataTables.DataTable, node: JQuery, config: ButtonSettings): void
     }
     //#endregion "button-settings
 }


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Comment:
Update correct d.ts file for dataTabel buttons plugin and add more functionalities.
- DOM Settings
- Update function parameter types.
- Rename function type 'ButtonText' -> 'FunctionButtonText', to match other function names.
- Add some examples from project page for better testing.
