### PR TITLE
Add useRouterHistory to react-router type definitions

### DIFF
--- a/react-router/react-router.d.ts
+++ b/react-router/react-router.d.ts
@@ -395,6 +395,14 @@ declare module "react-router/lib/match" {
 
 }
 
+declare module "react-router/lib/useRouterHistory" {
+    interface CreateRouterHistory {
+        (options?: HistoryModule.HistoryOptions): HistoryModule.History & HistoryModule.HistoryQueries;
+    }
+
+    export default function useRouterHistory<T>(createHistory: HistoryModule.CreateHistory<T>): CreateRouterHistory;
+}
+
 
 declare module "react-router" {
 
@@ -434,6 +442,8 @@ declare module "react-router" {
 
     import match from "react-router/lib/match"
 
+    import useRouterHistory from "react-router/lib/useRouterHistory";
+
     // PlainRoute is defined in the API documented at:
     // https://github.com/rackt/react-router/blob/master/docs/API.md
     // but not included in any of the .../lib modules above.
@@ -472,7 +482,8 @@ declare module "react-router" {
         formatPattern,
         RouterContext,
         PropTypes,
-        match
+        match,
+        useRouterHistory
     }
 
     export default Router


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

**case 2. Improvement to existing type definition.**
- documentation or source code reference which provides context for the suggested changes: https://github.com/reactjs/react-router/blob/v2.0.0/modules/useRouterHistory.js
  - it has been reviewed by a DefinitelyTyped member.
