### PR TITLE
GridOptions does not contain the correct definition of the toolbar property

### DIFF
--- a/kendo-ui/kendo-ui.d.ts
+++ b/kendo-ui/kendo-ui.d.ts
@@ -4438,7 +4438,7 @@ declare module kendo.ui {
         scrollable?: GridScrollable;
         selectable?: boolean|string;
         sortable?: GridSortable;
-        toolbar?: GridToolbarItem[];
+        toolbar?: string | ((...args) => string) | GridToolbarItem[];
         cancel?(e: GridCancelEvent): void;
         change?(e: GridChangeEvent): void;
         columnHide?(e: GridColumnHideEvent): void;

--- a/kendo-ui/kendo-ui.d.ts
+++ b/kendo-ui/kendo-ui.d.ts
@@ -4438,7 +4438,7 @@ declare module kendo.ui {
         scrollable?: GridScrollable;
         selectable?: boolean|string;
         sortable?: GridSortable;
-        toolbar?: string | ((...args) => string) | GridToolbarItem[];
+        toolbar?: string | ((...args:any[]) => string) | GridToolbarItem[];
         cancel?(e: GridCancelEvent): void;
         change?(e: GridChangeEvent): void;
         columnHide?(e: GridColumnHideEvent): void;


### PR DESCRIPTION
According to the documentation, the toolbar property can take a string, function, or array of GridToolbarItem as it's value. The current definition file only allows for an array of GridToolbarItem.

see: [http://docs.telerik.com/kendo-ui/api/javascript/ui/grid#configuration-toolbar](http://docs.telerik.com/kendo-ui/api/javascript/ui/grid#configuration-toolbar)
