### PR TITLE
update typings for React Select 1.0.0

### DIFF
--- a/react-select/react-select-0.9.10-tests.tsx
+++ b/react-select/react-select-0.9.10-tests.tsx
@@ -1,19 +1,18 @@
 
 /// <reference path="../react/react.d.ts" />
 /// <reference path="../react/react-dom.d.ts" />
-/// <reference path="./react-select.d.ts" />
+/// <reference path="./react-select-0.9.10.d.ts" />
 
 import * as React from "react"
 import * as ReactDOM from "react-dom"
 
-import * as Select from "react-select"
+import Select from "react-select"
 
 class SelectTest extends React.Component<React.Props<{}>, {}> {
 
     render() {
-        const options: ReactSelect.Option[] = [{ label: "Foo", value: "bar" }]
         return <div>
-           <Select options={options} />
+           <Select />
         </div>
     }
 

--- a/react-select/react-select-0.9.10.d.ts
+++ b/react-select/react-select-0.9.10.d.ts
@@ -1,0 +1,80 @@
+// Type definitions for react-select v0.9.10
+// Project: https://github.com/JedWatson/react-select
+// Definitions by: ESQUIBET Hugo <https://github.com/Hesquibet/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+///<reference path="../react/react.d.ts"/>
+
+// Typings for https://github.com/JedWatson/react-select
+//***Usage***
+// import ReactSelect = require('react-select');
+//  <ReactSelect options={this.options} name="form-field-name" onChange={this._onSelect} value={this.state.Type} />
+
+declare module "react-select" {
+    // Import React
+    import React = require("react");
+
+    interface Option{
+        label : string;
+        value : string;
+    }
+
+    interface ReactSelectProps extends React.Props<ReactSelectClass>{
+        addLabelText? : string;
+        allowCreate? : boolean;
+        autoload? : boolean;
+        backspaceRemoves? : boolean;
+        cacheAsyncResults? : boolean;
+        className? : string;
+        clearable? : boolean;
+        clearAllText? : string;
+        clearValueText? : string;
+        delimiter? : string;
+        disabled? : boolean;
+        filterOption? : (option : Option,filterString : string)=>Option;
+        filterOptions? : (options:Array<Option>,filterString : string,values : Array<Object>)=>Array<Option>;
+        ignoreCase? : boolean; // default true	whether to perform case-insensitive filtering
+        inputProps? : Object;
+        isLoading? : boolean;
+        labelKey? : string;
+        matchPos? : string;
+        matchProp? : string;
+        multi? : boolean;
+        name? : string;
+        newOptionCreator? : ()=>Option;
+        noResultsText? : string;
+        onBlur? : (event : Event)=>void;
+        onChange? : (newValue : string)=>void;
+        onFocus? : (event : Event)=>void;
+        onInputChange? : (inputValue : string)=>void;
+        onOptionLabelClick? : (value : string, event : Event)=>void;
+        optionRenderer? : ()=>void;
+        options? : Array<Option>;
+        placeholder? : string;
+        searchable? : boolean;
+        searchingText? : string;
+        searchPromptText? : string;
+        value? : Option;
+        valueKey? : string;
+        valueRenderer? : ()=>void;
+    }
+
+    interface ReactAsyncSelectProps extends React.Props<ReactSelectClass>{
+        cache? : any;
+        loadOptions? : ()=>void;
+        ignoreAccents? : boolean;
+        isLoading? : boolean;
+        loadingPlaceholder? : string;
+    }
+
+    interface ReactSelect extends  React.ReactElement<ReactSelectProps> { }
+    interface ReactSelectClass extends React.ComponentClass<ReactSelectProps>{}
+
+    interface SelectWithAsync extends ReactSelectClass {
+        Async? : ReactAsyncSelectProps;
+    }
+
+    var ReactSelect: SelectWithAsync;
+
+    export default ReactSelect;
+}

--- a/react-select/react-select.d.ts
+++ b/react-select/react-select.d.ts
@@ -1,80 +1,221 @@
-// Type definitions for react-select v0.9.10
+// Type definitions for react-select v1.0.0
 // Project: https://github.com/JedWatson/react-select
-// Definitions by: ESQUIBET Hugo <https://github.com/Hesquibet/>
+// Definitions by: ESQUIBET Hugo <https://github.com/Hesquibet/>, Gilad Gray <https://github.com/giladgray/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-///<reference path="../react/react.d.ts"/>
+/// <reference path="../react/react.d.ts"/>
 
-// Typings for https://github.com/JedWatson/react-select
-//***Usage***
-// import ReactSelect = require('react-select');
-//  <ReactSelect options={this.options} name="form-field-name" onChange={this._onSelect} value={this.state.Type} />
+declare namespace ReactSelect {
+    interface Option {
+        /** Text for rendering */
+        label: string;
+        /** Value for searching */
+        value: string | number;
+        /**
+         * Allow this option to be cleared
+         * @default true
+         */
+        clearableValue?: boolean;
+    }
+
+    interface ReactSelectProps extends __React.Props<ReactSelect> {
+        /**
+         * text to display when `allowCreate` is true.
+         * @default 'Add "{label}"?'
+         */
+        addLabelText?: string;
+        /**
+         * blurs the input element after a selection has been made. Handy for lowering the keyboard on mobile devices.
+         * @default false
+         */
+        autoBlur?: boolean;
+        /**
+         * allow new options to be created in multi mode (displays an "Add <option> ?" item
+         * when a value not already in the options array is entered)
+         * @default false
+         */
+        allowCreate?: boolean;
+        /**
+         * whether to auto-load the default async options set
+         * @default true
+         */
+        autoload?: boolean;
+        /**
+         * whether pressing backspace removes the last item when there is no input value
+         * @default true
+         */
+        backspaceRemoves?: boolean;
+        /**
+         * enables the options cache for `asyncOptions`
+         * @default true
+         */
+        cacheAsyncResults?: boolean;
+        /**
+         * CSS className for the outer element
+         */
+        className?: string;
+        /**
+         * whether it is possible to reset value. if enabled, an X button will appear at the right side.
+         * @default true
+         */
+        clearable?: boolean;
+        /**
+         * title for the "clear" control when `multi` is true
+         * @default "Clear all"
+         */
+        clearAllText?: string;
+        /**
+         * title for the "clear" control
+         * @default "Clear value"
+         */
+        clearValueText?: string;
+        /**
+         * delimiter to use to join multiple values
+         * @default ","
+         */
+        delimiter?: string;
+        /**
+         * whether the Select is disabled or not
+         * @default false
+         */
+        disabled?: boolean;
+        /**
+         * method to filter a single option
+         */
+        filterOption?: (option: Option, filter: string) => Option;
+        /**
+         * method to filter the options array
+         */
+        filterOptions?: (options: Array<Option>, filter: string, currentValues: (string | number)[]) => Array<Option>;
+        /**
+         * whether to perform case-insensitive filtering
+         * @default true
+         */
+        ignoreCase?: boolean;
+        /**
+         * custom attributes for the Input (in the Select-control) e.g: {'data-foo': 'bar'}
+         * @default {}
+         */
+        inputProps?: Object;
+        /**
+         * whether the Select is loading externally or not (such as options being loaded).
+         * if true, a loading spinner will be shown at the right side.
+         * @default false
+         */
+        isLoading?: boolean;
+        /**
+         * the option property to use for the label
+         * @default "label"
+         */
+        labelKey?: string;
+        /**
+         * function that calls a callback with the options
+         */
+        loadOptions?: (input: string, callback: (options: Option[]) => any) => any;
+        /**
+         * (any, start) match the start or entire string when filtering
+         * @default "any"
+         */
+        matchPos?: string;
+        /**
+         * (any, label, value) which option property to filter on
+         * @default "any"
+         */
+        matchProp?: string;
+        /**
+         * buffer of px between the base of the dropdown and the viewport to shift if menu doesnt fit in viewport
+         * @default 0
+         */
+        menuBuffer?: number;
+        /**
+         * multi-value input
+         * @default false
+         */
+        multi?: boolean;
+        /**
+         * field name, for hidden `<input>` tag
+         */
+        name?: string;
+        /**
+         * factory to create new options when `allowCreate` is true
+         * @default false
+         */
+        newOptionCreator?: (input: string) => Option;
+        /**
+         * placeholder displayed when there are no matching search results or a falsy value to hide it
+         * @default "No results found"
+         */
+        noResultsText?: string;
+        onBlur?: __React.FocusEventHandler;
+        /**
+         * whether to clear input on blur or not
+         * @default true
+         */
+        onBlurResetsInput?: boolean;
+        onChange?: (newValue: Option | Option[]) => void;
+        onFocus?: __React.FocusEventHandler;
+        onInputChange?: (inputValue: string) => void;
+        onOptionLabelClick?: (value: string, event: Event) => void;
+        /**
+         * function which returns a custom way to render the options in the menu
+         */
+        optionRenderer?: () => void;
+        /**
+         * array of Select options
+         * @default false
+         */
+        options?: Array<Option>;
+        /**
+         * field placeholder, displayed when there's no value
+         * @default "Select..."
+         */
+        placeholder?: string;
+        /**
+         * whether to enable searching feature or not
+         * @default true;
+         */
+        searchable?: boolean;
+        /**
+         * message to display whilst options are loading via asyncOptions, or when `isLoading` is true
+         * @default "Searching..."
+         */
+        searchingText?: string;
+        /**
+         * label to prompt for search input
+         * @default "Type to search"
+         */
+        searchPromptText?: string;
+        /**
+         * initial field value
+         */
+        value?: Option | Option[];
+        /**
+         * the option property to use for the value
+         * @default "value"
+         */
+        valueKey?: string;
+        /**
+         * function which returns a custom way to render the value selected
+         * @default false
+         */
+        valueRenderer?: () => void;
+    }
+
+    interface ReactAsyncSelectProps extends __React.Props<ReactSelect> {
+        cache?: any;
+        loadOptions?: () => void;
+        ignoreAccents?: boolean;
+        isLoading?: boolean;
+        loadingPlaceholder?: string;
+    }
+
+    interface ReactSelect extends  __React.ReactElement<ReactSelectProps> { }
+    interface ReactSelectClass extends __React.ComponentClass<ReactSelectProps> {
+        Async: __React.ComponentClass<ReactAsyncSelectProps>;
+    }
+}
 
 declare module "react-select" {
-    // Import React
-    import React = require("react");
-
-    interface Option{
-        label : string;
-        value : string;
-    }
-
-    interface ReactSelectProps extends React.Props<ReactSelectClass>{
-        addLabelText? : string;
-        allowCreate? : boolean;
-        autoload? : boolean;
-        backspaceRemoves? : boolean;
-        cacheAsyncResults? : boolean;
-        className? : string;
-        clearable? : boolean;
-        clearAllText? : string;
-        clearValueText? : string;
-        delimiter? : string;
-        disabled? : boolean;
-        filterOption? : (option : Option,filterString : string)=>Option;
-        filterOptions? : (options:Array<Option>,filterString : string,values : Array<Object>)=>Array<Option>;
-        ignoreCase? : boolean; // default true	whether to perform case-insensitive filtering
-        inputProps? : Object;
-        isLoading? : boolean;
-        labelKey? : string;
-        matchPos? : string;
-        matchProp? : string;
-        multi? : boolean;
-        name? : string;
-        newOptionCreator? : ()=>Option;
-        noResultsText? : string;
-        onBlur? : (event : Event)=>void;
-        onChange? : (newValue : string)=>void;
-        onFocus? : (event : Event)=>void;
-        onInputChange? : (inputValue : string)=>void;
-        onOptionLabelClick? : (value : string, event : Event)=>void;
-        optionRenderer? : ()=>void;
-        options? : Array<Option>;
-        placeholder? : string;
-        searchable? : boolean;
-        searchingText? : string;
-        searchPromptText? : string;
-        value? : Option;
-        valueKey? : string;
-        valueRenderer? : ()=>void;
-    }
-
-    interface ReactAsyncSelectProps extends React.Props<ReactSelectClass>{
-        cache? : any;
-        loadOptions? : ()=>void;
-        ignoreAccents? : boolean;
-        isLoading? : boolean;
-        loadingPlaceholder? : string;
-    }
-
-    interface ReactSelect extends  React.ReactElement<ReactSelectProps> { }
-    interface ReactSelectClass extends React.ComponentClass<ReactSelectProps>{}
-
-    interface SelectWithAsync extends ReactSelectClass {
-        Async? : ReactAsyncSelectProps;
-    }
-
-    var ReactSelect: SelectWithAsync;
-
-    export default ReactSelect;
+    var select: ReactSelect.ReactSelectClass;
+    export = select;
 }


### PR DESCRIPTION
- use `export = var` syntax so it works as a global library
- put interfaces in ghost module so they don't pollute global namespace
- add JSDoc comments for each prop
