### PR TITLE
Fix ReadableStream methods

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -189,13 +189,12 @@ declare module NodeJS {
     export interface ReadableStream extends EventEmitter {
         readable: boolean;
         read(size?: number): string|Buffer;
-        setEncoding(encoding: string): void;
-        pause(): void;
-        resume(): void;
+        setEncoding(encoding: string|void): this;
+        pause(): this;
+        resume(): this;
         pipe<T extends WritableStream>(destination: T, options?: { end?: boolean; }): T;
         unpipe<T extends WritableStream>(destination?: T): void;
-        unshift(chunk: string): void;
-        unshift(chunk: Buffer): void;
+        unshift(chunk: string|Buffer): void;
         wrap(oldStream: ReadableStream): ReadableStream;
     }
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.
https://nodejs.org/api/stream.html#stream_class_stream_readable

ReadableStream is chainable, and setEncoding accepts null as an argument
