### PR TITLE
Add soap module definition

### DIFF
--- a/soap/soap-tests.ts
+++ b/soap/soap-tests.ts
@@ -3,16 +3,16 @@
 import * as soap from 'soap';
 
 const url = 'http://example.com/wsdl?wsdl';
-const wsdlOptions = {name: 'value'};
+const wsdlOptions = { name: 'value' };
 
 soap.createClient(url, wsdlOptions, function(err: any, client: soap.Client) {
     let securityOptions = { 'hasTimeStamp': false };
     client.setSecurity(new soap.WSSecurity('user', 'password', securityOptions));
     client.addSoapHeader({});
-    client['create']({name: 'value'}, function(err, result) {
+    client['create']({ name: 'value' }, function(err, result) {
         // result is an object
     });
-    client['create']({name: 'value'}, function(err, result) {
+    client['create']({ name: 'value' }, function(err, result) {
         // result is an object
     }, {});
 });

--- a/soap/soap-tests.ts
+++ b/soap/soap-tests.ts
@@ -1,0 +1,19 @@
+/// <reference path="soap.d.ts" />
+
+import * as soap from 'soap';
+
+const url = 'http://example.com/wsdl?wsdl';
+const wsdlOptions = {name: 'value'};
+
+soap.createClient(url, wsdlOptions, function(err: any, client: soap.Client) {
+    let securityOptions = { 'hasTimeStamp': false };
+    client.setSecurity(new soap.WSSecurity('user', 'password', securityOptions));
+    client.addSoapHeader({});
+    client['create']({name: 'value'}, function(err, result) {
+        // result is an object
+    });
+    client['create']({name: 'value'}, function(err, result) {
+        // result is an object
+    }, {});
+});
+

--- a/soap/soap.d.ts
+++ b/soap/soap.d.ts
@@ -4,14 +4,14 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module 'soap' {
-  class WSSecurity {
-    constructor(username: string, password: string, options: any);
-  }
-  interface Client {
-    setSecurity(s: WSSecurity): void;
-    [method: string]: (args: any, fn: (err: any, result: any) => void, options?: any) => void;
-    addSoapHeader(headJSON: any): void;
-  }
-  function createClient(wsdlPath: string, options: any, fn: (err: any, client: Client) => void): void;
+    class WSSecurity {
+        constructor(username: string, password: string, options: any);
+    }
+    interface Client {
+        setSecurity(s: WSSecurity): void;
+        [method: string]: (args: any, fn: (err: any, result: any) => void, options?: any) => void;
+        addSoapHeader(headJSON: any): void;
+    }
+    function createClient(wsdlPath: string, options: any, fn: (err: any, client: Client) => void): void;
 
 }

--- a/soap/soap.d.ts
+++ b/soap/soap.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for soap
+// Project: https://www.npmjs.com/package/soap
+// Definitions by: Nicole Wang <https://github.com/nicoleWjie>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'soap' {
+  class WSSecurity {
+    constructor(username: string, password: string, options: any);
+  }
+  interface Client {
+    setSecurity(s: WSSecurity): void;
+    [method: string]: (args: any, fn: (err: any, result: any) => void, options?: any) => void;
+    addSoapHeader(headJSON: any): void;
+  }
+  function createClient(wsdlPath: string, options: any, fn: (err: any, client: Client) => void): void;
+
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
