### PR TITLE
Add xmlToJson definitions

### DIFF
--- a/xmltojson/xmltojson-tests.ts
+++ b/xmltojson/xmltojson-tests.ts
@@ -1,0 +1,36 @@
+/// <reference path='xmltojson.d.ts' />
+
+import * as xmltojson from 'xmltojson';
+
+//Set options
+var options: xmltojson.Options = {
+    mergeCDATA: true,
+    grokAttr: true,
+    grokText: true,
+    normalize: true,
+    xmlns: true,
+    namespaceKey: '_ns',
+    textKey: '_text',
+    valueKey: '_value',
+    attrKey: '_attr',
+    cdataKey: '_cdata',
+    attrsAsObject: true,
+    stripAttrPrefix: true,
+    stripElemPrefix: true,
+    childrenAsArray: true
+}
+
+//Validate parseString(xmlString, opt)
+var xmlString: string = '<xml><a>It Works!</a></xml>';
+var parsedXmlString: Object = xmltojson.parseString(xmlString, options);
+
+console.log(JSON.stringify(parsedXmlString));
+
+//Validate stringToXml(xmlString) and parseXml(oXMLParent, opt)
+var oXMLParent: Document = xmltojson.stringToXml(xmlString);
+
+console.log(oXMLParent.getElementsByName('a').item(0).textContent);
+
+var parsedXmlString2: Object = xmltojson.parseXml(oXMLParent, options);
+
+console.log(JSON.stringify(parsedXmlString2));

--- a/xmltojson/xmltojson.d.ts
+++ b/xmltojson/xmltojson.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for xmltojson
 // Project: https://github.com/metatribal/xmlToJSON
-// Definitions by: Travis Crowe http://github.com/traviscrowe
+// Definitions by: Travis Crowe <https://github.com/traviscrowe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module 'xmltojson' {

--- a/xmltojson/xmltojson.d.ts
+++ b/xmltojson/xmltojson.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for xmltojson
+// Project: https://github.com/metatribal/xmlToJSON
+// Definitions by: Travis Crowe http://github.com/traviscrowe
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'xmltojson' {
+    
+    export = xmltojson;
+    
+    module xmltojson {
+        function grokType(sValue: any): any;
+        function parseString(xmlString: string, opt: Options): Object;
+        function parseXml(oXMLParent: Document, opt: Options): Object;
+        function xmlToString(xmlDoc: Document): string;
+        function stringToXml(xmlString: string): Document;
+        
+        interface Options {
+            mergeCDATA?: boolean,
+            grokAttr?: boolean,
+            grokText?: boolean,
+            normalize?: boolean,
+            xmlns?: boolean,
+            namespaceKey?: string,
+            textKey?: string,
+            valueKey?: string,
+            attrKey?: string,
+            cdataKey?: string,
+            attrsAsObject?: boolean,
+            stripAttrPrefix?: boolean,
+            stripElemPrefix?: boolean,
+            childrenAsArray?: boolean
+        }
+    }    
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [X] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [X] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
