### PR TITLE
Added a trailing semicolon for consistency.

### DIFF
--- a/moment/moment-node.d.ts
+++ b/moment/moment-node.d.ts
@@ -379,7 +379,7 @@ declare module moment {
         meridiem?: (hour: number, minute: number, isLowercase: boolean) => string;
         calendar?: MomentCalendar;
         ordinal?: (num: number) => string;
-        week?: MomentLanguageWeek
+        week?: MomentLanguageWeek;
     }
 
     interface MomentLanguage extends BaseMomentLanguage {


### PR DESCRIPTION
As per suggestion of @adidahiya, forgot the trailing semicolon!
