### PR TITLE
Add agent property in CoreOptions request.d.ts

### DIFF
--- a/request/request-tests.ts
+++ b/request/request-tests.ts
@@ -92,7 +92,7 @@ var options: request.Options = {
 	qs: obj,
 	json: value,
 	multipart: value,
-    agent: new http.Agent(),  
+	agent: new http.Agent(),  
 	agentOptions: value,
 	agentClass: value,
 	forever: value,

--- a/request/request-tests.ts
+++ b/request/request-tests.ts
@@ -92,6 +92,7 @@ var options: request.Options = {
 	qs: obj,
 	json: value,
 	multipart: value,
+    agent: new http.Agent(),  
 	agentOptions: value,
 	agentClass: value,
 	forever: value,

--- a/request/request.d.ts
+++ b/request/request.d.ts
@@ -86,7 +86,7 @@ declare module 'request' {
 			qs?: any;
 			json?: any;
 			multipart?: RequestPart[] | Multipart;
-            agent?: http.Agent;
+			agent?: http.Agent | https.Agent;
 			agentOptions?: any;
 			agentClass?: any;
 			forever?: any;

--- a/request/request.d.ts
+++ b/request/request.d.ts
@@ -11,6 +11,7 @@
 declare module 'request' {
 	import stream = require('stream');
 	import http = require('http');
+	import https = require('https');
 	import FormData = require('form-data');
 	import url = require('url');
 	import fs = require('fs');

--- a/request/request.d.ts
+++ b/request/request.d.ts
@@ -86,6 +86,7 @@ declare module 'request' {
 			qs?: any;
 			json?: any;
 			multipart?: RequestPart[] | Multipart;
+            agent?: http.Agent;
 			agentOptions?: any;
 			agentClass?: any;
 			forever?: any;


### PR DESCRIPTION
`agent` property was missing in `CoreOptions`.

https://github.com/request/request

---

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
