### PR TITLE
add pify

### DIFF
--- a/pify/pify-tests.ts
+++ b/pify/pify-tests.ts
@@ -1,0 +1,31 @@
+/// <reference path="pify.d.ts" />
+/// <reference path="../bluebird/bluebird.d.ts" />
+
+import * as pify from 'pify';
+import * as Bluebird from 'bluebird';
+
+function assert(actual: string, expected: string): void {
+    if (actual !== expected) {
+        throw new Error(`${JSON.stringify(actual)} !== ${JSON.stringify(expected)}`);
+    }
+}
+
+const fs = {
+    readFile: (file: string, callback: Function) => {
+        let result: any = undefined;
+
+        if (file === 'foo.txt') {
+            result = 'foo';
+        } else if (file === 'bar.txt') {
+            result = 'bar';
+        }
+
+        callback(undefined, result);
+    }
+};
+
+const fsP = pify(fs);
+fsP.readFile('foo.txt').then((result: string) => assert(result, 'foo'));
+
+pify(fs.readFile)('foo.txt').then((result: string) => assert(result, 'foo'));
+pify(fs.readFile, Bluebird)('bar.txt').then((result: string) => assert(result, 'bar'));

--- a/pify/pify.d.ts
+++ b/pify/pify.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for pify
+// Project: https://github.com/sindresorhus/pify
+// Definitions by: Sam Verschueren <https://github.com/samverschueren>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module "pify" {
+    interface PifyOptions {
+        multiArgs?: boolean,
+        include?: [string | RegExp],
+        exclude?: [string | RegExp],
+        excludeMain?: boolean
+    }
+
+    function pify(input: Function, promiseModule?: Function, options?: PifyOptions): (...args:any[]) => Promise<any>;
+    function pify(input: any, promiseModule?: Function, options?: PifyOptions): any;
+    function pify(input: Function, options?: PifyOptions): (...args:any[]) => Promise<any>;
+    function pify(input: any, options?: PifyOptions): any;
+
+	namespace pify {}
+	export = pify;
+}


### PR DESCRIPTION
Added [pify](https://github.com/sindresorhus/pify)

case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
