### PR TITLE
Add a default export for angular-ui-router to match the actual source.

### DIFF
--- a/angular-ui-router/angular-ui-router.d.ts
+++ b/angular-ui-router/angular-ui-router.d.ts
@@ -7,13 +7,8 @@
 
 // Support for AMD require and CommonJS
 declare module 'angular-ui-router' {
-    // Since angular-ui-router adds providers for a bunch of
-    // injectable dependencies, it doesn't really return any
-    // actual data except the plain string 'ui.router'.
-    //
-    // As such, I don't think anybody will ever use the actual
-    // default value of the module.  So I've only included the
-    // the types. (@xogeny)
+    export default 'ui.router';
+
     export type IState = angular.ui.IState;
     export type IStateProvider = angular.ui.IStateProvider;
     export type IUrlMatcher = angular.ui.IUrlMatcher;


### PR DESCRIPTION
This makes it possible to import the module with the es6 syntax without typescript optimizing it away automatically when it is only used for module dependencies. For instance, doing something like the following will cause 'angular-ui-router' to not be included in the final js file:

```
import * as angular from 'angular';
import router from 'angular-ui-router';

export default angular.module('app', ['ui.router', ...]);
```

This PR enables us to write it like this instead which will not be optimized away.

```
import * as angular from 'angular';
import router from 'angular-ui-router';

export default angular.module('app', [router, ...]);
```
