### PR TITLE
Add createInstance() method

### DIFF
--- a/localForage/localForage.d.ts
+++ b/localForage/localForage.d.ts
@@ -86,6 +86,13 @@ interface LocalForage {
     iterate(iteratee: (value: any, key: string, iterationNumber: number) => any): Promise<any>;
     iterate(iteratee: (value: any, key: string, iterationNumber: number) => any,
             callback: (err: any, result: any) => void): void;
+    
+    /**
+     * Create a new instance of localForage to point to a different store.
+     * All the configuration options used by config are supported.
+     * @param {LocalForageOptions} options
+     */
+    createInstance(options: LocalForageOptions): LocalForage;
 }
 
 declare module "localforage" {


### PR DESCRIPTION
Adds the missing createInstance() method:

You can create multiple instances of localForage that point to different stores using createInstance. All the configuration options used by config are supported.

```
var store = localforage.createInstance({
  name: "nameHere"
});

var otherStore = localforage.createInstance({
  name: "otherName"
});

// Setting the key on one of these doesn't affect the other.
store.setItem("key", "value");
otherStore.setItem("key", "value2");
```
