### PR TITLE
'text=auto' changes crlf automatically in local repository and pollutes work tree

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
-# Auto detect text files and perform LF normalization
-* text=auto
 
 # Custom for Visual Studio
 *.cs     diff=csharp


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

---

This commit is none of the above cases.
I fixed the option because it polluted work tree and caused an error on merging upstream to my fork and emitted so many 'CRLF will be replaced...' warnings.
My environment is OS X 10.11.3.
