### PR TITLE
github-electron: add missing remote.getCurrentWebContents()

### DIFF
--- a/github-electron/github-electron-renderer-tests.ts
+++ b/github-electron/github-electron-renderer-tests.ts
@@ -38,6 +38,8 @@ remote.getCurrentWindow().capturePage(buf => {
 	});
 });
 
+remote.getCurrentWebContents().print();
+
 remote.getCurrentWindow().capturePage(buf => {
 	remote.require('fs').writeFile('/tmp/screenshot.png', buf, (err: Error) => {
 		console.log(err);

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -1542,6 +1542,10 @@ declare module Electron {
 		 */
 		getCurrentWindow(): BrowserWindow;
 		/**
+		 * @returns The WebContents object of this web page.
+		 */
+		getCurrentWebContents(): WebContents;
+		/**
 		 * @returns The global variable of name (e.g. global[name]) in the main process.
 		 */
 		getGlobal(name: string): any;


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

---

API document is here:
https://github.com/atom/electron/blob/master/docs/api/remote.md#remotegetcurrentwebcontents
