### PR TITLE
update easeljs: Conatiner.addChild

### DIFF
--- a/easeljs/easeljs-tests.ts
+++ b/easeljs/easeljs-tests.ts
@@ -87,3 +87,17 @@ function matrixDecompose() {
     shape.skewY = transformData.skewY;
     shape.rotation = transformData.rotation;
 }
+
+function test_addChild()
+{
+    var container: createjs.Container;
+    var textChild: createjs.Text;
+    var displayObject: createjs.DisplayObject;
+
+    container.addChild(textChild).text = "abc";
+    container.addChild(displayObject, textChild).text = "abc";
+    container.addChild(displayObject, displayObject, textChild).text = "abc";
+    container.addChild(displayObject, displayObject, displayObject, displayObject, displayObject, textChild);
+    container.addChildAt(textChild, 0).text = "abc";
+    container.addChildAt(displayObject, textChild, 0).text = "abc";
+}

--- a/easeljs/easeljs.d.ts
+++ b/easeljs/easeljs.d.ts
@@ -161,9 +161,16 @@ declare module createjs {
         tickChildren: boolean;
 
         // methods
-        addChild(...child: DisplayObject[]): DisplayObject;
-        addChildAt(child: DisplayObject, index: number): DisplayObject; // add this for the common case
-        addChildAt(...childOrIndex: any[]): DisplayObject; // actually (...child: DisplayObject[], index: number)
+        addChild<T extends DisplayObject>(child: T): T;
+        addChild<T extends DisplayObject>(child0: DisplayObject, lastChild: T): T;
+		addChild<T extends DisplayObject>(child0: DisplayObject, child1: DisplayObject, lastChild: T): T;
+		addChild<T extends DisplayObject>(child0: DisplayObject, child1: DisplayObject, child2: DisplayObject, lastChild: T): T;
+		addChild(...children: DisplayObject[]): DisplayObject;
+		addChildAt<T extends DisplayObject>(child: T, index: number): T;
+		addChildAt<T extends DisplayObject>(child0: DisplayObject, lastChild: T, index: number): T;
+		addChildAt<T extends DisplayObject>(child0: DisplayObject, child1: DisplayObject, lastChild: T, index: number): T;
+        addChildAt(...childOrIndex: (DisplayObject|number)[]): DisplayObject; // actually (...child: DisplayObject[], index: number)
+
         clone(recursive?: boolean): Container;
         contains(child: DisplayObject): boolean;
         getChildAt(index: number): DisplayObject;

--- a/easeljs/easeljs.d.ts
+++ b/easeljs/easeljs.d.ts
@@ -163,12 +163,12 @@ declare module createjs {
         // methods
         addChild<T extends DisplayObject>(child: T): T;
         addChild<T extends DisplayObject>(child0: DisplayObject, lastChild: T): T;
-		addChild<T extends DisplayObject>(child0: DisplayObject, child1: DisplayObject, lastChild: T): T;
-		addChild<T extends DisplayObject>(child0: DisplayObject, child1: DisplayObject, child2: DisplayObject, lastChild: T): T;
-		addChild(...children: DisplayObject[]): DisplayObject;
-		addChildAt<T extends DisplayObject>(child: T, index: number): T;
-		addChildAt<T extends DisplayObject>(child0: DisplayObject, lastChild: T, index: number): T;
-		addChildAt<T extends DisplayObject>(child0: DisplayObject, child1: DisplayObject, lastChild: T, index: number): T;
+        addChild<T extends DisplayObject>(child0: DisplayObject, child1: DisplayObject, lastChild: T): T;
+        addChild<T extends DisplayObject>(child0: DisplayObject, child1: DisplayObject, child2: DisplayObject, lastChild: T): T;
+        addChild(...children: DisplayObject[]): DisplayObject;
+        addChildAt<T extends DisplayObject>(child: T, index: number): T;
+        addChildAt<T extends DisplayObject>(child0: DisplayObject, lastChild: T, index: number): T;
+        addChildAt<T extends DisplayObject>(child0: DisplayObject, child1: DisplayObject, lastChild: T, index: number): T;
         addChildAt(...childOrIndex: (DisplayObject|number)[]): DisplayObject; // actually (...child: DisplayObject[], index: number)
 
         clone(recursive?: boolean): Container;


### PR DESCRIPTION
document: http://www.createjs.com/docs/easeljs/classes/Container.html#method_addChildAt

`addChild` and `addChildAt` return the last added child `DisplayObject`, so make the return type more specific to the type.  Then you can write code like:

```
container.addChild(new createjs.Text()).text = "aaaaaa";
```

But beacuse typescript doesn't support function like `foo(...args:any[], lastArg:T)`, so I make some overloads to satisfy the most common cases.
