### PR TITLE
add xdomain typings

### DIFF
--- a/xdomain/xdomain-tests.ts
+++ b/xdomain/xdomain-tests.ts
@@ -1,0 +1,14 @@
+/// <reference path="./xdomain.d.ts" />
+
+xdomain.masters({
+  'http://abc.example.com': '/api/*'
+});
+
+xdomain.slaves({
+  "http://xyz.example.com": "/proxy.html"
+});
+
+xdomain.debug = true;
+xdomain.on("log", (msg) => console.log(msg));
+xdomain.on("timeout", () => console.log("timeout"));
+xdomain.cookies.master = "MASTER";

--- a/xdomain/xdomain.d.ts
+++ b/xdomain/xdomain.d.ts
@@ -1,0 +1,52 @@
+// Type definitions for xdomain v0.7.5
+// Project: http://jpillora.com/xdomain/
+// Definitions by: Dan Chao <http://dchao.co/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+
+declare interface XDomainCookies {
+  master: string;
+  slave: string;
+}
+
+declare interface IXDomain {
+  /**
+   * Will initialize as a master
+   *
+   * Each of the slaves must be defined as: origin: proxy file
+   *
+   * The slaves object is used as a list slaves to force one proxy file per origin.
+   * @param slaveObj
+   */
+  slaves (slaveObj: Object): void;
+  /**
+   * Will initialize as a slave
+   *
+   * Each of the masters must be defined as: origin: path
+   *
+   * origin and path are converted to a regular expression by escaping all non-alphanumeric chars, then converting * into .* and finally wrapping it with ^ and $. path can also be a RegExp literal.
+   *
+   * Requests that do not match both the origin and the path regular expressions will be blocked.
+   * @param masterObj
+   */
+  masters(masterObj: Object): void;
+  origin: string;
+  /**
+   * When true, XDomain will log actions to console
+   */
+  debug: boolean;
+  /**
+   * event may be log, warn or timeout. When listening for log and warn events, handler with contain the message as
+   * the first parameter. The timeout event fires when an iframe exeeds the xdomain.timeout time limit.
+   * @param event
+   * @param handler
+   */
+  on(event: "log"|"warn"|"timeout", handler: (message?: string) => any): void;
+  cookies: XDomainCookies;
+}
+
+declare var xdomain: IXDomain;
+
+declare module "xdomain" {
+  export const xdomain: IXDomain;
+}

--- a/xdomain/xdomain.d.ts
+++ b/xdomain/xdomain.d.ts
@@ -29,7 +29,7 @@ declare interface IXDomain {
    * Requests that do not match both the origin and the path regular expressions will be blocked.
    * @param masterObj
    */
-  masters(masterObj: Object): void;
+  masters (masterObj: Object): void;
   origin: string;
   /**
    * When true, XDomain will log actions to console
@@ -41,7 +41,7 @@ declare interface IXDomain {
    * @param event
    * @param handler
    */
-  on(event: "log"|"warn"|"timeout", handler: (message?: string) => any): void;
+  on (event: "log"|"warn"|"timeout", handler: (message?: string) => any): void;
   cookies: XDomainCookies;
 }
 


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
