### PR TITLE
Update jest type definitions to 0.9.0

### DIFF
--- a/jest/jest-tests.ts
+++ b/jest/jest-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="jest.d.ts" />
 
 // Tests based on the Jest website
-jest.dontMock('../sum');
+jest.unmock('../sum');
 
 describe('sum', function() {
     it('adds 1 + 2 to equal 3', function() {
@@ -16,7 +16,7 @@ describe('fetchCurrentUser', function() {
         var fetchCurrentUser = require('../fetchCurrentUser');
 
         // Create a mock function for our callback
-        var callback = jest.genMockFunction();
+        var callback = jest.fn();
         fetchCurrentUser(callback);
 
         // Now we emulate the process by which `$.ajax` would execute its own
@@ -35,7 +35,9 @@ describe('fetchCurrentUser', function() {
     });
 });
 
-jest.dontMock('../displayUser.js')
+// unmock is the recommended approach for unmocking...
+jest.unmock('../displayUser.js')
+// ...but dontMock also still works.
 jest.dontMock('jquery');
 
 describe('displayUser', function() {
@@ -70,7 +72,7 @@ describe('displayUser', function() {
     });
 });
 
-jest.dontMock('../CheckboxWithLabel.js');
+jest.unmock('../CheckboxWithLabel.js');
 describe('CheckboxWithLabel', function() {
     it('changes the text after click', function() {
         var React = require('react/addons');
@@ -99,7 +101,7 @@ describe('CheckboxWithLabel', function() {
 });
 
 function testInstances() {
-    var mockFn = jest.genMockFunction<Function>();
+    var mockFn = jest.fn<Function>();
     var a = new mockFn();
     var b = new mockFn();
 
@@ -108,7 +110,7 @@ function testInstances() {
 }
 
 function testMockImplementation() {
-    var mockFn = jest.genMockFunction<Function>().mockImplementation(function (scalar:number):number {
+    var mockFn = jest.fn<Function>().mockImplementation(function (scalar:number):number {
         return 42 + scalar;
     });
 

--- a/jest/jest.d.ts
+++ b/jest/jest.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jest 0.1.18
+// Type definitions for Jest 0.9.0
 // Project: http://facebook.github.io/jest/
 // Definitions by: Asana <https://asana.com>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -26,15 +26,15 @@ declare module jest {
     function autoMockOn(): void;
     function clearAllTimers(): void;
     function currentTestPath(): string;
+    function fn<T>(implementation?: Function): Mock<T>;
     function dontMock(moduleName: string): void;
     function genMockFromModule<T>(moduleName: string): Mock<T>;
-    function genMockFunction<T>(): Mock<T>;
-    function genMockFn<T>(): Mock<T>;
     function mock(moduleName: string): void;
     function runAllTicks(): void;
     function runAllTimers(): void;
     function runOnlyPendingTimers(): void;
     function setMock<T>(moduleName: string, moduleExports: T): void;
+    function unmock(moduleName: string): void;
 
     interface EmptyFunction {
         (): void;


### PR DESCRIPTION
There have been multiple changes in the api so it is not possible to point out jest commits that these changes relate to. However, the official api reference was used as a source of what the api looks like at version 0.9.0: https://github.com/facebook/jest/blob/0.9.0/docs/API.md

I do not claim these typings to be perfectly aligned with jest 0.9.0 but consider this commit to be a significant improvement on previous state.
