### PR TITLE
Add missing dataType to jquery-mockjax definition.

### DIFF
--- a/jquery-mockjax/jquery-mockjax.d.ts
+++ b/jquery-mockjax/jquery-mockjax.d.ts
@@ -20,6 +20,7 @@ interface MockJaxSettings {
     statusText?: string;
     responseTime?: number;
     isTimeout?: boolean;
+    dataType?: string;
     contentType?: string;
     response?: (settings: any) => void;
     responseText?: string | Object;


### PR DESCRIPTION
PR to add missing dataType to jquery-mockjax definition.
