### PR TITLE
Update threejs/three.d.ts Intersection

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -1631,7 +1631,9 @@ declare module THREE {
 
     export interface Intersection {
         distance: number;
+        distanceToRay: number;
         point: Vector3;
+        index: number;
         face: Face3;
         object: Object3D;
     }


### PR DESCRIPTION
Improvement to existing type definition:

Intersection was missing distanceToRay and index properties from three.js r73.

See https://cdnjs.cloudflare.com/ajax/libs/three.js/r73/three.js lines 18426-18435
