### PR TITLE
D3.diagonal's index is optional

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -2488,7 +2488,7 @@ declare module d3 {
         }
 
         interface Diagonal<Link, Node> {
-            (d: Link, i: number): string;
+            (d: Link, i?: number): string;
 
             source(): (d: Link, i: number) => Node;
             source(source: Node): Diagonal<Link, Node>;


### PR DESCRIPTION
cf. https://github.com/mbostock/d3/wiki/SVG-Shapes#_diagonal
