### PR TITLE
Node: Fixed child_process.exec() callback param types

### DIFF
--- a/node/node-0.10.d.ts
+++ b/node/node-0.10.d.ts
@@ -707,12 +707,13 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
-    export function exec(command: string, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback: (error: Error, stdout: string|Buffer, stderr: string|Buffer) =>void ): ChildProcess;
+    export function exec(command: string,
+        callback: (error: Error, stdout: string|Buffer, stderr: string|Buffer) =>void ): ChildProcess;
     export function execFile(file: string,
-        callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+        callback?: (error: Error, stdout: string|Buffer, stderr: string|Buffer) =>void ): ChildProcess;
     export function execFile(file: string, args?: string[],
-        callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+        callback?: (error: Error, stdout: string|Buffer, stderr: string|Buffer) =>void ): ChildProcess;
     export function execFile(file: string, args?: string[], options?: {
         cwd?: string;
         stdio?: any;
@@ -722,7 +723,7 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback?: (error: Error, stdout: string|Buffer, stderr: string|Buffer) =>void ): ChildProcess;
     export function fork(modulePath: string, args?: string[], options?: {
         cwd?: string;
         env?: any;

--- a/node/node-0.11.d.ts
+++ b/node/node-0.11.d.ts
@@ -630,8 +630,9 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
-    export function exec(command: string, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback: (error: Error, stdout: string|Buffer, stderr: string|Buffer) =>void ): ChildProcess;
+    export function exec(command: string,
+        callback: (error: Error, stdout: string|Buffer, stderr: string|Buffer) =>void ): ChildProcess;
     export function execFile(file: string, args: string[], options: {
         cwd?: string;
         stdio?: any;
@@ -641,7 +642,7 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback: (error: Error, stdout: string|Buffer, stderr: string|Buffer) =>void ): ChildProcess;
     export function fork(modulePath: string, args?: string[], options?: {
         cwd?: string;
         env?: any;

--- a/node/node-0.12.d.ts
+++ b/node/node-0.12.d.ts
@@ -848,12 +848,13 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
-    export function exec(command: string, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback?: (error: Error, stdout: string|Buffer, stderr: string|Buffer) =>void ): ChildProcess;
+    export function exec(command: string,
+        callback?: (error: Error, stdout: string|Buffer, stderr: string|Buffer) =>void ): ChildProcess;
     export function execFile(file: string,
-        callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+        callback?: (error: Error, stdout: string|Buffer, stderr: string|Buffer) =>void ): ChildProcess;
     export function execFile(file: string, args?: string[],
-        callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+        callback?: (error: Error, stdout: string|Buffer, stderr: string|Buffer) =>void ): ChildProcess;
     export function execFile(file: string, args?: string[], options?: {
         cwd?: string;
         stdio?: any;
@@ -863,7 +864,7 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback?: (error: Error, stdout: string|Buffer, stderr: string|Buffer) =>void ): ChildProcess;
     export function fork(modulePath: string, args?: string[], options?: {
         cwd?: string;
         env?: any;

--- a/node/node-0.8.8.d.ts
+++ b/node/node-0.8.8.d.ts
@@ -564,8 +564,9 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
-    export function exec(command: string, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback: (error: Error, stdout: string|Buffer, stderr: string|Buffer) =>void ): ChildProcess;
+    export function exec(command: string,
+        callback: (error: Error, stdout: string|Buffer, stderr: string|Buffer) =>void ): ChildProcess;
     export function execFile(file: string, args: string[], options: {
         cwd?: string;
         stdio?: any;
@@ -575,7 +576,7 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback: (error: Error, stdout: string|Buffer, stderr: string|Buffer) =>void ): ChildProcess;
     export function fork(modulePath: string, args?: string[], options?: {
         cwd?: string;
         env?: any;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -227,8 +227,8 @@ declare module NodeJS {
         removeListener(event: string, listener: Function): this;
         removeAllListeners(event?: string): this;
     }
-    
-    export interface MemoryUsage { 
+
+    export interface MemoryUsage {
         rss: number;
         heapTotal: number;
         heapUsed: number;
@@ -969,12 +969,13 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
-    export function exec(command: string, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback?: (error: Error, stdout: string|Buffer, stderr: string|Buffer) => void): ChildProcess;
+    export function exec(command: string,
+        callback?: (error: Error, stdout: string|Buffer, stderr: string|Buffer) => void): ChildProcess;
     export function execFile(file: string,
-        callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+        callback?: (error: Error, stdout: string|Buffer, stderr: string|Buffer) => void): ChildProcess;
     export function execFile(file: string, args?: string[],
-        callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+        callback?: (error: Error, stdout: string|Buffer, stderr: string|Buffer) => void): ChildProcess;
     export function execFile(file: string, args?: string[], options?: {
         cwd?: string;
         stdio?: any;
@@ -984,7 +985,7 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback?: (error: Error, stdout: string|Buffer, stderr: string|Buffer) => void): ChildProcess;
     export function fork(modulePath: string, args?: string[], options?: {
         cwd?: string;
         env?: any;


### PR DESCRIPTION
Corrected the definitions for `child_process.exec()` and `child_process.execFile()`. The `stdout` and `stderr` parameters for the callback are now of type `string`, unless options.encoding is explicitly set to `null`, in which case the type is `Buffer`.

Apparently following Node's documentation, the type for the `stdout` and `stderr` callback parameters had been declared simply as `Buffer`. However, this is only true if the encoding option is explicitly set to `null`. Since the encoding option is set to `'utf8'` by default, the callback will typically be invoked with strings rather than Buffers. While this is true of all Node versions since at lease v0.8, only the [documentation for v0.12](https://nodejs.org/docs/v0.12.11/api/child_process.html#child_process_child_process_exec_command_options_callback) makes this clear for whatever reason.
