### PR TITLE
antd: Add render methods for all React.Component subclasses.

### DIFF
--- a/antd/antd.d.ts
+++ b/antd/antd.d.ts
@@ -23,7 +23,9 @@ declare namespace Antd {
      * 当内容区域比较长，需要滚动页面时，这部分内容对应的操作或者导航需要在滚动范围内始终展现。常用于侧边菜单和按钮组合。
      * 页面可视范围过小时，慎用此功能以免遮挡页面内容。
      */
-    export class Affix extends React.Component<AffixProps, {}>{ }
+    export class Affix extends React.Component<AffixProps, {}> {
+        render(): JSX.Element
+    }
 
 
     // Alert
@@ -56,7 +58,9 @@ declare namespace Antd {
      * - 当某个页面需要向用户显示警告的信息时。
      * - 非浮层的静态展现形式，始终展现，不会自动消失，用户可以点击关闭。
      * */
-    export class Alert extends React.Component<AlertProps, {}>{ }
+    export class Alert extends React.Component<AlertProps, {}> {
+        render(): JSX.Element
+    }
 
 
     // Badge
@@ -70,7 +74,9 @@ declare namespace Antd {
      * 一般出现在通知图标或头像的右上角，用于显示需要处理的消息条数，通过醒目视觉形式吸引用户处理。
      *
     */
-    export class Badge extends React.Component<BadgeProps, {}>{ }
+    export class Badge extends React.Component<BadgeProps, {}> {
+        render(): JSX.Element
+    }
     interface BadgeProps extends React.Props<Badge> {
         /** 展示的数字，大于 overflowCount 时显示为 `${overflowCount}+`，为 0 时隐藏*/
         count: number,
@@ -116,8 +122,8 @@ declare namespace Antd {
     可以将多个 `Button` 放入 `Button.Group` 的容器中。
 
     通过设置 `size` 为 `large` `small` 分别把按钮组合设为大、小尺寸。若不设置 `size`，则尺寸为中。*/
-    class ButtonGroup extends React.Component<ButtonGroupProps, {}>{
-
+    class ButtonGroup extends React.Component<ButtonGroupProps, {}> {
+        render(): JSX.Element
     }
 
     /**
@@ -127,8 +133,9 @@ declare namespace Antd {
     ## 何时使用
 
     标记了一个（或封装一组）操作命令，响应用户点击行为，触发相应的业务逻辑。*/
-    export class Button extends React.Component<ButtonProps, {}>{
+    export class Button extends React.Component<ButtonProps, {}> {
         static Group: typeof ButtonGroup
+        render(): JSX.Element
     }
 
 
@@ -139,7 +146,9 @@ declare namespace Antd {
         /** 链接，如不传则不可点击   */
         href?: string
     }
-    export class BreadcrumbItem extends React.Component<BreadcrumbItemProps, {}>{ }
+    export class BreadcrumbItem extends React.Component<BreadcrumbItemProps, {}> {
+        render(): JSX.Element
+    }
 
     interface BreadcrumbProps extends React.Props<Breadcrumb> {
         /** router 的路由栈信息 */
@@ -158,8 +167,9 @@ declare namespace Antd {
     - 当系统拥有超过两级以上的层级结构时；
     - 当需要告知用户“你在哪里”时；
     - 当需要向上导航的功能时。*/
-    export class Breadcrumb extends React.Component<BreadcrumbProps, {}>{
+    export class Breadcrumb extends React.Component<BreadcrumbProps, {}> {
         static Item: typeof BreadcrumbItem
+        render(): JSX.Element
     }
 
 
@@ -193,7 +203,9 @@ declare namespace Antd {
 
     当数据是日期或按照日期划分时，例如日程、课表、价格日历等，农历等。目前支持年/月切换。
     */
-    export class Calendar extends React.Component<CalendarProps, {}>{ }
+    export class Calendar extends React.Component<CalendarProps, {}> {
+        render(): JSX.Element
+    }
 
 
     // Carousel
@@ -223,7 +235,9 @@ declare namespace Antd {
     - 当内容空间不足时，可以用走马灯的形式进行收纳，进行轮播展现。
     - 常用于一组图片或卡片轮播。
     */
-    export class Carousel extends React.Component<CarouselProps, {}>{ }
+    export class Carousel extends React.Component<CarouselProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -267,7 +281,9 @@ declare namespace Antd {
     - 需要从一组相关联的数据集合进行选择，例如省市区，公司层级，事物分类等。
     - 从一个较大的数据集合中进行选择时，用多级分类进行分隔，方便选择。
     - 比起 Select 组件，可以在同一个浮层中完成选择，有较好的体验。*/
-    export class Cascader extends React.Component<CascaderProps, {}>{ }
+    export class Cascader extends React.Component<CascaderProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -293,7 +309,9 @@ declare namespace Antd {
         onChange?: Function
     }
     /** Checkbox 组*/
-    class CheckboxGroup extends React.Component<CheckboxGroupProps, {}>{ }
+    class CheckboxGroup extends React.Component<CheckboxGroupProps, {}> {
+        render(): JSX.Element
+    }
     /**
      * #Checkbox
     多选框。
@@ -303,8 +321,9 @@ declare namespace Antd {
     - 在一组可选项中进行多项选择时；
     - 单独使用可以表示两种状态之间的切换，和 `switch` 类似。区别在于切换 `switch` 会直接触发状态改变，而 `checkbox` 一般用于状态标记，需要和提交操作配合。
     */
-    export class Checkbox extends React.Component<CheckboxProps, {}>{
+    export class Checkbox extends React.Component<CheckboxProps, {}> {
         static Group: typeof CheckboxGroup
+        render(): JSX.Element
     }
 
 
@@ -325,7 +344,9 @@ declare namespace Antd {
         key: string,
         /** 面板头内容*/
         header: React.ReactNode | string
-    }, {}>{ }
+    }, {}> {
+        render(): JSX.Element
+    }
     /**
      * #Collapse
     可以折叠/展开的内容区域。
@@ -334,8 +355,9 @@ declare namespace Antd {
 
     - 对复杂区域进行分组和隐藏，保持页面的整洁。
     - `手风琴` 是一种特殊的折叠面板，只允许单个内容区域展开。*/
-    export class Collapse extends React.Component<CollapseProps, {}>{
+    export class Collapse extends React.Component<CollapseProps, {}> {
         static Panel: typeof CollapsePanel
+        render(): JSX.Element
     }
 
 
@@ -371,8 +393,12 @@ declare namespace Antd {
     interface RangePickProps extends DatePickerProps<RangePicker> {
 
     }
-    class RangePicker extends React.Component<RangePickProps, {}>{ }
-    class MonthPicker extends React.Component<RangePickProps, {}>{ }
+    class RangePicker extends React.Component<RangePickProps, {}> {
+        render(): JSX.Element
+    }
+    class MonthPicker extends React.Component<RangePickProps, {}> {
+        render(): JSX.Element
+    }
     /**
      * #DatePicker
     输入或选择日期的控件。
@@ -380,9 +406,10 @@ declare namespace Antd {
     ## 何时使用
 
     当用户需要输入一个日期，可以点击标准输入框，弹出日期面板进行选择。*/
-    export class DatePicker extends React.Component<DatePickerProps<any>, {}>{
+    export class DatePicker extends React.Component<DatePickerProps<any>, {}> {
         static RangePicker: typeof RangePicker
         static MonthPicker: typeof MonthPicker
+        render(): JSX.Element
     }
 
 
@@ -407,7 +434,9 @@ declare namespace Antd {
         trigger?: string,
         /** 菜单节点*/
         overlay: React.ReactNode
-    }, {}>{ }
+    }, {}> {
+        render(): JSX.Element
+    }
     /**
      * #Dropdown
     向下弹出的列表。
@@ -416,8 +445,9 @@ declare namespace Antd {
 
     当页面上的操作命令过多时，用此组件可以收纳操作元素。点击或移入触点，会出现一个下拉菜单。可在列表中进行选择，并执行相应的命令。
     */
-    export class Dropdown extends React.Component<DropdownProps, {}>{
+    export class Dropdown extends React.Component<DropdownProps, {}> {
         static Button: typeof DropdownButton
+        render(): JSX.Element
     }
 
 
@@ -448,11 +478,15 @@ declare namespace Antd {
     表单一定会包含表单域，表单域可以是输入控件，标准表单域，标签，下拉菜单，文本域等。
 
     这里我们分别封装了表单域 `<Form.Item />` 和输入控件 `<Input />`。*/
-    export class FormItem extends React.Component<FormItemProps, {}>{ }
+    export class FormItem extends React.Component<FormItemProps, {}> {
+        render(): JSX.Element
+    }
     interface FormComponentProps extends React.Props<FormComponent> {
         form: CreateFormOptions
     }
-    export class FormComponent extends React.Component<FormComponentProps, {}>{ }
+    export class FormComponent extends React.Component<FormComponentProps, {}> {
+        render(): JSX.Element
+    }
 
     // function  create
     type CreateFormOptions = {
@@ -518,7 +552,7 @@ declare namespace Antd {
     - 水平排列：可以实现 `label` 标签和表单控件的水平排列;
     - 行内排列：使其表现为 `inline-block` 级别的控件。
     */
-    export class Form extends React.Component<FormProps, {}>{
+    export class Form extends React.Component<FormProps, {}> {
         static Item: typeof FormItem
         static create(options?: {
             /**
@@ -528,6 +562,7 @@ declare namespace Antd {
             /**  把 props 转为对应的值，可用于把 Redux store 中的值读出 */
             mapPropsToFields?: (props: Object) => void
         }): ComponentDecorator
+        render(): JSX.Element
     }
 
 
@@ -564,7 +599,9 @@ declare namespace Antd {
     ```html
     <i class="anticon anticon-${type}"></i>
     ```*/
-    export class Icon extends React.Component<IconProps, {}>{ }
+    export class Icon extends React.Component<IconProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -589,7 +626,9 @@ declare namespace Antd {
         prefixCls?: string,
         placeholder?: string
     }
-    export class Input extends React.Component<InputProps, {}>{ }
+    export class Input extends React.Component<InputProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -621,7 +660,9 @@ declare namespace Antd {
     ## 何时使用
 
     当需要获取标准数值时。*/
-    export class InputNumber extends React.Component<InputNumberProps, {}>{ }
+    export class InputNumber extends React.Component<InputNumberProps, {}> {
+        render(): JSX.Element
+    }
 
 
     // Layout
@@ -632,7 +673,9 @@ declare namespace Antd {
         justify?: string,
         className?: string
     }
-    export class Row extends React.Component<RowProps, {}>{ }
+    export class Row extends React.Component<RowProps, {}> {
+        render(): JSX.Element
+    }
 
     // Col
     interface ColProps extends React.Props<Col> {
@@ -662,7 +705,9 @@ declare namespace Antd {
     我们的栅格化系统支持 Flex 布局，允许子元素在父节点内的水平对齐方式 - 居左、居中、居右、等宽排列、分散排列。子元素与子元素之间，支持顶部对齐、垂直居中对齐、底部对齐的方式。同时，支持使用 order 来定义元素的排列顺序。
 
     Flex 布局是基于 24 栅格来定义每一个“盒子”的宽度，但排版则不拘泥于栅格。*/
-    export class Col extends React.Component<ColProps, {}>{ }
+    export class Col extends React.Component<ColProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -677,7 +722,9 @@ declare namespace Antd {
         disabled?: boolean,
         key: string
     }
-    export class MenuItem extends React.Component<MenuItemProps, {}>{ }
+    export class MenuItem extends React.Component<MenuItemProps, {}> {
+        render(): JSX.Element
+    }
 
     interface MenuSubMenuProps extends React.Props<MenuSubMenu> {
         /**
@@ -693,7 +740,9 @@ declare namespace Antd {
          */
         children?: MenuItem | MenuSubMenu
     }
-    export class MenuSubMenu extends React.Component<MenuSubMenuProps, {}>{ }
+    export class MenuSubMenu extends React.Component<MenuSubMenuProps, {}> {
+        render(): JSX.Element
+    }
 
     interface MenuItemGroupProps extends React.Props<MenuItemGroup> {
         /**
@@ -709,7 +758,9 @@ declare namespace Antd {
          */
         children?: MenuItem
     }
-    export class MenuItemGroup extends React.Component<MenuItemGroupProps, {}>{ }
+    export class MenuItemGroup extends React.Component<MenuItemGroupProps, {}> {
+        render(): JSX.Element
+    }
 
 
     // enum
@@ -757,11 +808,12 @@ declare namespace Antd {
     导航菜单是一个网站的灵魂，用户依赖导航在各个页面中进行跳转。一般分为顶部导航和侧边导航，顶部导航提供全局性的类目和功能，侧边导航提供多级结构来收纳和排列网站架构。
 
     更多布局和导航的范例可以参考：[常用布局](/spec/layout)。*/
-    export class Menu extends React.Component<MenuProps, {}>{
+    export class Menu extends React.Component<MenuProps, {}> {
         static Item: typeof MenuItem
         static SubMenu: typeof MenuSubMenu
         static ItemGroup: typeof MenuItemGroup
         static Divider: typeof React.Component
+        render(): JSX.Element
     }
 
 
@@ -844,11 +896,12 @@ declare namespace Antd {
     需要用户处理事务，又不希望跳转页面以致打断工作流程时，可以使用 `Modal` 在当前页面正中打开一个浮层，承载相应的操作。
 
     另外当需要一个简洁的确认框询问用户时，可以使用精心封装好的 `ant.Modal.confirm()` 等方法。*/
-    export class Modal extends React.Component<ModalProps, {}>{
+    export class Modal extends React.Component<ModalProps, {}> {
         static info: ModalFunc
         static success: ModalFunc
         static error: ModalFunc
         static confirm: ModalFunc
+        render(): JSX.Element
     }
 
 
@@ -935,7 +988,9 @@ declare namespace Antd {
 
     - 当加载/渲染所有数据将花费很多时间时；
     - 可切换页码浏览数据。*/
-    export class Pagination extends React.Component<PaginationProps, {}>{ }
+    export class Pagination extends React.Component<PaginationProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -973,7 +1028,9 @@ declare namespace Antd {
 
     和 `confirm` 弹出的全屏居中模态对话框相比，交互形式更轻量。
     */
-    export class Popconfirm extends React.Component<PopconfirmProps, {}>{ }
+    export class Popconfirm extends React.Component<PopconfirmProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -1013,7 +1070,9 @@ declare namespace Antd {
 
     和 `Tooltip` 的区别是，用户可以对浮层上的元素进行操作，因此它可以承载更复杂的内容，比如链接或按钮等。
     */
-    export class Popover extends React.Component<PopoverProps, {}>{ }
+    export class Popover extends React.Component<PopoverProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -1037,7 +1096,9 @@ declare namespace Antd {
         /** 是否显示进度数值和状态图标*/
         showInfo?: boolean
     }
-    export class Line extends React.Component<LineProps, {}>{ }
+    export class Line extends React.Component<LineProps, {}> {
+        render(): JSX.Element
+    }
 
     interface CircleProps extends React.Props<Circle> {
         /** 百分比*/
@@ -1051,7 +1112,9 @@ declare namespace Antd {
         /** 必填，进度条画布宽度，单位px。这里没有提供height属性设置，Line型高度就是strokeWidth，Circle型高度等于width*/
         width?: number
     }
-    export class Circle extends React.Component<CircleProps, {}>{ }
+    export class Circle extends React.Component<CircleProps, {}> {
+        render(): JSX.Element
+    }
     /**
      * #Progress
     展示操作的当前进度。
@@ -1101,7 +1164,9 @@ declare namespace Antd {
 
     - 特别适合首页和需要视觉展示效果的宣传页，以及单页应用的切换页面动效。
     */
-    export class QueueAnim extends React.Component<QueueAnimProps, {}>{ }
+    export class QueueAnim extends React.Component<QueueAnimProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -1122,7 +1187,9 @@ declare namespace Antd {
         /**  大小，只对按钮样式生效*/
         size?: RadioGroupSize | string
     }
-    export class RadioGroup extends React.Component<RadioGroupProps, {}>{ }
+    export class RadioGroup extends React.Component<RadioGroupProps, {}> {
+        render(): JSX.Element
+    }
 
 
     interface RadioProps extends React.Props<Radio> {
@@ -1142,9 +1209,10 @@ declare namespace Antd {
     - 用于在多个备选项中选中单个状态。
     - 和 Select 的区别是，Radio 所有选项默认可见，方便用户在比较中选择，因此选项不宜过多。
     */
-    export class Radio extends React.Component<RadioProps, {}>{
+    export class Radio extends React.Component<RadioProps, {}> {
         static Group: typeof RadioGroup
         static Button: typeof Button
+        render(): JSX.Element
     }
 
 
@@ -1158,14 +1226,18 @@ declare namespace Antd {
         /** 默认根据此属性值进行筛选*/
         value: string
     }
-    export class SelectOption extends React.Component<SelectOptionProps, {}>{ }
+    export class SelectOption extends React.Component<SelectOptionProps, {}> {
+        render(): JSX.Element
+    }
 
     interface SelectOptGroupProps extends React.Props<SelectOptGroup> {
         /** 组名*/
         label: string | React.ReactNode,
         key?: string
     }
-    export class SelectOptGroup extends React.Component<SelectOptGroupProps, {}>{ }
+    export class SelectOptGroup extends React.Component<SelectOptGroupProps, {}> {
+        render(): JSX.Element
+    }
 
     interface SelectProps extends React.Props<Select> {
         /** 指定当前选中的条目*/
@@ -1215,9 +1287,10 @@ declare namespace Antd {
     ## 何时使用
 
     弹出一个下拉菜单给用户选择操作，用于代替原生的选择器，或者需要一个更优雅的多选器时。*/
-    export class Select extends React.Component<SelectProps, {}>{
+    export class Select extends React.Component<SelectProps, {}> {
         static Option: typeof SelectOption
         static OptGroup: typeof SelectOptGroup
+        render(): JSX.Element
     }
 
 
@@ -1257,7 +1330,9 @@ declare namespace Antd {
     ## 何时使用
 
     当用户需要在数值区间/自定义区间内进行选择时，可为连续或离散值。*/
-    export class Slider extends React.Component<SliderProps, {}>{ }
+    export class Slider extends React.Component<SliderProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -1277,7 +1352,9 @@ declare namespace Antd {
 
     页面局部处于等待异步数据或正在渲染过程时，合适的加载动效会有效缓解用户的焦虑。
     */
-    export class Spin extends React.Component<SpinProps, {}>{ }
+    export class Spin extends React.Component<SpinProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -1296,7 +1373,9 @@ declare namespace Antd {
         /** 可选参数，步骤的Icon。如果不指定，则使用默认的样式。*/
         icon?: string | React.ReactNode
     }
-    export class Step extends React.Component<StepProps, {}>{ }
+    export class Step extends React.Component<StepProps, {}> {
+        render(): JSX.Element
+    }
 
     interface StepsProps extends React.Props<Steps> {
         /** 可选参数，指定当前处理正在执行状态的步骤，从0开始记数。在子Step元素中，可以通过status属性覆盖状态。*/
@@ -1316,8 +1395,9 @@ declare namespace Antd {
     ## 何时使用
 
     当任务复杂或者存在先后关系时，将其分解成一系列步骤，从而简化任务。*/
-    export class Steps extends React.Component<StepsProps, {}>{
+    export class Steps extends React.Component<StepsProps, {}> {
         static Step: typeof Step
+        render(): JSX.Element
     }
 
 
@@ -1346,7 +1426,9 @@ declare namespace Antd {
     - 需要表示开关状态/两种状态之间的切换时；
     - 和 `checkbox `的区别是，切换 `switch` 会直接触发状态改变，而 `checkbox` 一般用于状态标记，需要和提交操作配合。
     */
-    export class Switch extends React.Component<SwitchProps, {}>{ }
+    export class Switch extends React.Component<SwitchProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -1434,7 +1516,9 @@ declare namespace Antd {
 
     - 当有大量结构化的数据需要展现时；
     - 当需要对数据进行排序、搜索、分页、自定义操作等复杂行为时。*/
-    export class Table extends React.Component<TableProps, {}>{ }
+    export class Table extends React.Component<TableProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -1443,7 +1527,9 @@ declare namespace Antd {
         /** 选项卡头显示文字*/
         tab: React.ReactNode | string
     }
-    export class TabPane extends React.Component<TabPaneProps, {}>{ }
+    export class TabPane extends React.Component<TabPaneProps, {}> {
+        render(): JSX.Element
+    }
 
     enum TabsType {
         line, card, 'editable-card'
@@ -1485,8 +1571,9 @@ declare namespace Antd {
     - 卡片式的页签，提供可关闭的样式，常用于容器顶部。
     - 标准线条式页签，用于容器内部的主功能切换，这是最常用的 Tabs。
     - [RadioButton](/components/radio/#demo-radiobutton) 可作为更次级的页签来使用。*/
-    export class Tabs extends React.Component<TabsProps, {}>{
+    export class Tabs extends React.Component<TabsProps, {}> {
         static TabPane: typeof TabPane
+        render(): JSX.Element
     }
 
 
@@ -1511,7 +1598,9 @@ declare namespace Antd {
     
     - 用于标记事物的属性和维度。
     - 进行分类。*/
-    export class Tag extends React.Component<TagProps, {}>{ }
+    export class Tag extends React.Component<TagProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -1553,7 +1642,9 @@ declare namespace Antd {
     
     当用户需要输入一个时间，可以点击标准输入框，弹出时间面板进行选择。
     */
-    export class TimePicker extends React.Component<TimePickerProps, {}>{ }
+    export class TimePicker extends React.Component<TimePickerProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -1563,7 +1654,9 @@ declare namespace Antd {
         /** 指定圆圈颜色。*/
         color?: string
     }
-    export class TimeLineItem extends React.Component<TimeLineItemProps, {}>{ }
+    export class TimeLineItem extends React.Component<TimeLineItemProps, {}> {
+        render(): JSX.Element
+    }
 
     interface TimelineProps extends React.Props<Timeline> {
         /** 指定最后一个幽灵节点是否存在或内容*/
@@ -1577,8 +1670,9 @@ declare namespace Antd {
     
     - 当有一系列信息需要从上至下按时间排列时；
     - 需要有一条时间轴进行视觉上的串联时；*/
-    export class Timeline extends React.Component<TimelineProps, {}>{
+    export class Timeline extends React.Component<TimelineProps, {}> {
         static Item: typeof TimeLineItem
+        render(): JSX.Element
     }
 
 
@@ -1600,7 +1694,9 @@ declare namespace Antd {
     鼠标移入则显示提示，移出消失，气泡浮层不承载复杂文本和操作。
     
     可用来代替系统默认的 `title` 提示，提供一个`按钮/文字/操作`的文案解释。*/
-    export class Tooltip extends React.Component<TooltipProps, {}>{ }
+    export class Tooltip extends React.Component<TooltipProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -1641,7 +1737,9 @@ declare namespace Antd {
     
     用直观的方式在两栏中移动元素，完成选择行为。
     */
-    export class Transfer extends React.Component<TransferProps, {}>{ }
+    export class Transfer extends React.Component<TransferProps, {}> {
+        render(): JSX.Element
+    }
 
 
 
@@ -1655,7 +1753,9 @@ declare namespace Antd {
         key?: string,
         isLeaf?: boolean
     }
-    export class TreeNode extends React.Component<TreeNodeProps, {}>{ }
+    export class TreeNode extends React.Component<TreeNodeProps, {}> {
+        render(): JSX.Element
+    }
 
     interface TreeProps extends React.Props<Tree> {
         showLine?: boolean,
@@ -1707,8 +1807,9 @@ declare namespace Antd {
      * #Tree
      * 文件夹、组织架构、生物分类、国家地区等等，世间万物的大多数结构都是树形结构。使用`树控件`可以完整展现其中的层级关系，并具有展开收起选择等交互功能。
     */
-    export class Tree extends React.Component<TreeProps, {}>{
+    export class Tree extends React.Component<TreeProps, {}> {
         static TreeNode: typeof TreeNode
+        render(): JSX.Element
     }
 
 
@@ -1727,7 +1828,9 @@ declare namespace Antd {
         /** 是否是叶子节点*/
         isLeaf?: boolean
     }
-    export class TreeSelectTreeNode extends React.Component<TreeSelectTreeNodeProps, {}>{ }
+    export class TreeSelectTreeNode extends React.Component<TreeSelectTreeNodeProps, {}> {
+        render(): JSX.Element
+    }
 
     type TreeData = Array<{ value: any, label: string, children: TreeData }>
     interface TreeSelectProps extends React.Props<TreeSelect> {
@@ -1787,8 +1890,9 @@ declare namespace Antd {
     
     类似 Select 的选择控件，可选择的数据结构是一个树形结构时，可以使用 TreeSelect，例如公司层级、学科系统、分类目录等等。
     */
-    export class TreeSelect extends React.Component<TreeSelectProps, {}>{
+    export class TreeSelect extends React.Component<TreeSelectProps, {}> {
         static TreeNode: typeof TreeSelectTreeNode
+        render(): JSX.Element
     }
 
 
@@ -1833,7 +1937,9 @@ declare namespace Antd {
     - 当需要上传一个或一些文件时。
     - 当需要展现上传的进度时。
     - 当需要使用拖拽交互时。*/
-    export class Upload extends React.Component<UploadProps, {}>{ }
+    export class Upload extends React.Component<UploadProps, {}> {
+        render(): JSX.Element
+    }
 
 
 


### PR DESCRIPTION
This passes the tests. And if the change suggested in #8540 happens, something like this is required. I think the change in #8540 to flag `render` as `abstract` would be good.
