### PR TITLE
Node: Fix child_process exec() and execFile() definitions

### DIFF
--- a/node/node-0.10.d.ts
+++ b/node/node-0.10.d.ts
@@ -703,16 +703,37 @@ declare module "child_process" {
         stdio?: any;
         customFds?: any;
         env?: any;
-        encoding?: string;
+        encoding: void;
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
     }, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
-    export function exec(command: string, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    export function exec(command: string, options: {
+        cwd?: string;
+        stdio?: any;
+        customFds?: any;
+        env?: any;
+        encoding?: string;
+        timeout?: number;
+        maxBuffer?: number;
+        killSignal?: string;
+    }, callback: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
+    export function exec(command: string,
+        callback: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
     export function execFile(file: string,
-        callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+        callback?: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
     export function execFile(file: string, args?: string[],
-        callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+        callback?: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
+    export function execFile(file: string, args?: string[], options?: {
+        cwd?: string;
+        stdio?: any;
+        customFds?: any;
+        env?: any;
+        encoding: void;
+        timeout?: number;
+        maxBuffer?: number;
+        killSignal?: string;
+    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
     export function execFile(file: string, args?: string[], options?: {
         cwd?: string;
         stdio?: any;
@@ -722,7 +743,7 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback?: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
     export function fork(modulePath: string, args?: string[], options?: {
         cwd?: string;
         env?: any;

--- a/node/node-0.11.d.ts
+++ b/node/node-0.11.d.ts
@@ -626,12 +626,33 @@ declare module "child_process" {
         stdio?: any;
         customFds?: any;
         env?: any;
-        encoding?: string;
+        encoding: void;
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
     }, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
-    export function exec(command: string, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    export function exec(command: string, options: {
+        cwd?: string;
+        stdio?: any;
+        customFds?: any;
+        env?: any;
+        encoding?: string;
+        timeout?: number;
+        maxBuffer?: number;
+        killSignal?: string;
+    }, callback: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
+    export function exec(command: string,
+        callback: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
+    export function execFile(file: string, args: string[], options: {
+        cwd?: string;
+        stdio?: any;
+        customFds?: any;
+        env?: any;
+        encoding: void;
+        timeout?: number;
+        maxBuffer?: number;
+        killSignal?: string;
+    }, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
     export function execFile(file: string, args: string[], options: {
         cwd?: string;
         stdio?: any;
@@ -641,7 +662,7 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
     export function fork(modulePath: string, args?: string[], options?: {
         cwd?: string;
         env?: any;

--- a/node/node-0.12.d.ts
+++ b/node/node-0.12.d.ts
@@ -844,16 +844,37 @@ declare module "child_process" {
         stdio?: any;
         customFds?: any;
         env?: any;
-        encoding?: string;
+        encoding: void;
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
     }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
-    export function exec(command: string, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    export function exec(command: string, options: {
+        cwd?: string;
+        stdio?: any;
+        customFds?: any;
+        env?: any;
+        encoding?: string;
+        timeout?: number;
+        maxBuffer?: number;
+        killSignal?: string;
+    }, callback?: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
+    export function exec(command: string,
+        callback?: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
     export function execFile(file: string,
-        callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+        callback?: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
     export function execFile(file: string, args?: string[],
-        callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+        callback?: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
+    export function execFile(file: string, args?: string[], options?: {
+        cwd?: string;
+        stdio?: any;
+        customFds?: any;
+        env?: any;
+        encoding: void;
+        timeout?: number;
+        maxBuffer?: number;
+        killSignal?: string;
+    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
     export function execFile(file: string, args?: string[], options?: {
         cwd?: string;
         stdio?: any;
@@ -863,7 +884,7 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback?: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
     export function fork(modulePath: string, args?: string[], options?: {
         cwd?: string;
         env?: any;

--- a/node/node-0.8.8.d.ts
+++ b/node/node-0.8.8.d.ts
@@ -560,12 +560,33 @@ declare module "child_process" {
         stdio?: any;
         customFds?: any;
         env?: any;
-        encoding?: string;
+        encoding: void;
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
     }, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
-    export function exec(command: string, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    export function exec(command: string, options: {
+        cwd?: string;
+        stdio?: any;
+        customFds?: any;
+        env?: any;
+        encoding?: string;
+        timeout?: number;
+        maxBuffer?: number;
+        killSignal?: string;
+    }, callback: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
+    export function exec(command: string,
+        callback: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
+    export function execFile(file: string, args: string[], options: {
+        cwd?: string;
+        stdio?: any;
+        customFds?: any;
+        env?: any;
+        encoding: void;
+        timeout?: number;
+        maxBuffer?: number;
+        killSignal?: string;
+    }, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
     export function execFile(file: string, args: string[], options: {
         cwd?: string;
         stdio?: any;
@@ -575,7 +596,7 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback: (error: Error, stdout: string, stderr: string) =>void ): ChildProcess;
     export function fork(modulePath: string, args?: string[], options?: {
         cwd?: string;
         env?: any;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -227,8 +227,8 @@ declare module NodeJS {
         removeListener(event: string, listener: Function): this;
         removeAllListeners(event?: string): this;
     }
-    
-    export interface MemoryUsage { 
+
+    export interface MemoryUsage {
         rss: number;
         heapTotal: number;
         heapUsed: number;
@@ -965,16 +965,37 @@ declare module "child_process" {
         stdio?: any;
         customFds?: any;
         env?: any;
+        encoding: void;
+        timeout?: number;
+        maxBuffer?: number;
+        killSignal?: string;
+    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
+    export function exec(command: string, options: {
+        cwd?: string;
+        stdio?: any;
+        customFds?: any;
+        env?: any;
         encoding?: string;
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
-    export function exec(command: string, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback?: (error: Error, stdout: string, stderr: string) => void): ChildProcess;
+    export function exec(command: string,
+        callback?: (error: Error, stdout: string, stderr: string) => void): ChildProcess;
     export function execFile(file: string,
-        callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+        callback?: (error: Error, stdout: string, stderr: string) => void): ChildProcess;
     export function execFile(file: string, args?: string[],
-        callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+        callback?: (error: Error, stdout: string, stderr: string) => void): ChildProcess;
+    export function execFile(file: string, args?: string[], options?: {
+        cwd?: string;
+        stdio?: any;
+        customFds?: any;
+        env?: any;
+        encoding: void;
+        timeout?: number;
+        maxBuffer?: number;
+        killSignal?: string;
+    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
     export function execFile(file: string, args?: string[], options?: {
         cwd?: string;
         stdio?: any;
@@ -984,7 +1005,7 @@ declare module "child_process" {
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
-    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    }, callback?: (error: Error, stdout: string, stderr: string) => void): ChildProcess;
     export function fork(modulePath: string, args?: string[], options?: {
         cwd?: string;
         env?: any;

--- a/tabtab/tabtab-tests.ts
+++ b/tabtab/tabtab-tests.ts
@@ -13,7 +13,7 @@ if (process.argv.slice(2)[0] === 'completion') {
         if (/^-\w?/.test(data.last)) return tabtab.log(['n', 'o', 'd', 'e'], data, '-');
         tabtab.log(['list', 'of', 'commands'], data);
 
-        child_process.exec('rake -H', function(err, stdout, stderr) {
+        child_process.exec('rake -H', {encoding: null}, function(err, stdout, stderr) {
             if (err) return;
             var decoder = new string_decoder.StringDecoder('utf8');
             var parsed = tabtab.parseOut(decoder.write(stdout));
@@ -21,7 +21,7 @@ if (process.argv.slice(2)[0] === 'completion') {
             if (/^-\w?/.test(data.last)) return tabtab.log(parsed.shorts, data, '-');
         });
 
-        child_process.exec('cake', function(err, stdout, stderr) {
+        child_process.exec('cake', {encoding: null}, function(err, stdout, stderr) {
             if (err) return;
             var decoder = new string_decoder.StringDecoder('utf8');
             var tasks = tabtab.parseTasks(decoder.write(stdout), 'cake');


### PR DESCRIPTION
Corrected the definitions for `child_process.exec()` and `child_process.execFile()`. The `stdout` and `stderr` parameters for the callback are now of type `string`, unless options.encoding is explicitly set to `null`, in which case the type is `Buffer`.

Apparently following Node's documentation, the type for the `stdout` and `stderr` callback parameters had been declared simply as `Buffer`. However, this is only true if the encoding option is explicitly set to `null`. Since the encoding option is set to `'utf8'` by default, the callback will typically be invoked with strings rather than Buffers. While this is true of all Node versions since at least v0.8, only the [documentation for v0.12](https://nodejs.org/docs/v0.12.11/api/child_process.html#child_process_child_process_exec_command_options_callback) makes this clear for whatever reason.

In light of these changes to the definition files under the `node/` directory, the [tests for tabtab](https://github.com/akim-mcmath/DefinitelyTyped/blob/1ce00deb8232577a2e5774672db5fd477fea98d8/tabtab/tabtab-tests.ts) had to be updated as well.
