### PR TITLE
$translatePartialLoader methods are made to be chainable

### DIFF
--- a/angular-translate/angular-translate.d.ts
+++ b/angular-translate/angular-translate.d.ts
@@ -31,9 +31,9 @@ declare module angular.translate {
         key?: string;
     }
 
-    interface IPartialLoader<T> {
-        addPart(name : string, priority? : number) : T;
-        deletePart(name : string) : T;
+    interface IPartialLoader {
+        addPart(name : string, priority? : number) : IPartialLoader;
+        deletePart(name : string) : IPartialLoader;
         isPartAvailable(name : string) : boolean;
     }
 


### PR DESCRIPTION
Based on [the official documentation for $translatePartialLoader](http://angular-translate.github.io/docs/#/api/pascalprecht.translate.$translatePartialLoader), the addPart and deletePart methods should return the `this` instance and not a different generic type.
