### PR TITLE
express-jwt: Add Buffer type for secret

### DIFF
--- a/express-jwt/express-jwt.d.ts
+++ b/express-jwt/express-jwt.d.ts
@@ -20,7 +20,7 @@ declare module "express-jwt" {
 
     module jwt {
         export interface Options {
-            secret: string|ICallback;
+            secret: string|Buffer|ICallback;
             userProperty?: string;
             skip?: string[];
             credentialsRequired?: boolean;


### PR DESCRIPTION
According to the express-jwt docs, a Buffer can be passed as a type for secret.

https://github.com/auth0/express-jwt#usage

Usage:

```
jwt({ secret: new Buffer(mySecret, 'base64') });
```
