### PR TITLE
github-electron: Added findInPage(), stopFindInPage() and insertText() for WebContents

### DIFF
--- a/github-electron/github-electron-main-tests.ts
+++ b/github-electron/github-electron-main-tests.ts
@@ -109,6 +109,15 @@ app.on('ready', () => {
 	mainWindow.webContents.executeJavaScript('return true;');
 	mainWindow.webContents.executeJavaScript('return true;', true);
 	mainWindow.webContents.executeJavaScript('return true;', true, (result: boolean) => console.log(result));
+	mainWindow.webContents.insertText('blah, blah, blah');
+	mainWindow.webContents.findInPage('blah');
+	mainWindow.webContents.findInPage('blah', {
+		forward: true,
+		matchCase: false,
+	});
+	mainWindow.webContents.stopFindInPage('clearSelection');
+	mainWindow.webContents.stopFindInPage('keepSelection');
+	mainWindow.webContents.stopFindInPage('activateSelection');
 });
 
 // Locale

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -537,6 +537,14 @@ declare module Electron {
 		height?: number;
 	}
 
+	interface FindInPageOptions {
+		forward?: boolean;
+		findNext?: boolean;
+		matchCase?: boolean;
+		wordStart?: boolean;
+		medialCapitalAsWordStart?: boolean;
+	}
+
 	/**
 	 * A WebContents is responsible for rendering and controlling a web page.
 	 */
@@ -677,6 +685,26 @@ declare module Electron {
 		 * Executes Edit -> Replace Misspelling command in page.
 		 */
 		replaceMisspelling(text: string): void;
+		/**
+		 * Inserts text to the focused element.
+		 */
+		insertText(text: string): void;
+		/**
+		 * Starts a request to find all matches for the text in the web page and
+		 * returns an Integer representing the request id used for the request.
+		 * The result of the request can be obtained by subscribing to
+		 * found-in-page event.
+		 */
+		findInPage(text: string, options?: FindInPageOptions): void;
+		/**
+		 * Stops any findInPage request for the webContents with the provided
+		 * action.
+		 * @param action Specifies the action to take place when ending webContents.findInPage request.
+		 *   'clearSelection' - Translate the selection into a normal selection.
+		 *   'keepSelection' - Clear the selection.
+		 *   'activateSelection' - Focus and click the selection node.
+		 */
+		stopFindInPage(action: 'clearSelection' | 'keepSelection' | 'activateSelection'): void;
 		/**
 		 * Checks if any serviceworker is registered.
 		 */


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

…APIs for WebContents

https://github.com/atom/electron/blob/73a5f323e78cc15ca0c72ce7da5a6bea2ee56b63/docs/api/web-contents.md#webcontentsfindinpagetext-options
