### PR TITLE
fix lokijs/lokijs.d.ts

### DIFF
--- a/lokijs/lokijs.d.ts
+++ b/lokijs/lokijs.d.ts
@@ -1539,8 +1539,6 @@ interface LokiJquerySyncAdapterError extends Error {
 /* ======== END jquery-sync-adapter.js ======== */
 
 
-
-
 declare var LokiCryptedFileAdapterConstructor: {
     new (): LokiCryptedFileAdapter;
 }
@@ -1568,14 +1566,4 @@ declare var LokiConstructor: {
 
 declare module "lokijs" {
     export = LokiConstructor;
-}
-
-
-declare var LokiIndexedAdapterConstructor: {
-    new (filename: string): LokiIndexedAdapter;
-};
-
-
-declare module "loki-indexed-adapter" {
-    export = LokiIndexedAdapterConstructor;
 }


### PR DESCRIPTION
```
=============================================================================
                    Errors in files
=============================================================================
----------------- For file:lokijs/lokijs.d.ts
lokijs/lokijs.d.ts(1558,5): error TS2300: Duplicate identifier 'export='.
lokijs/lokijs.d.ts(1580,5): error TS2300: Duplicate identifier 'export='.

=============================================================================

----------------- For file:lokijs/lokijs-tests.ts
lokijs/lokijs.d.ts(1558,5): error TS2300: Duplicate identifier 'export='.
lokijs/lokijs.d.ts(1580,5): error TS2300: Duplicate identifier 'export='.
```
