### PR TITLE
serializeToString is in XMLSerializer and NOT in DOMParser

### DIFF
--- a/xmldom/xmldom-tests.ts
+++ b/xmldom/xmldom-tests.ts
@@ -34,3 +34,7 @@ new xmldom.DOMParser({
   //errorHandler:function(level,msg){console.log(level,msg)}
 });
 
+
+// XMLSerializer provides serializeToString method
+new xmldom.XMLSerializer().serializeToString(doc) == "string";
+new xmldom.XMLSerializer().serializeToString(doc.documentElement) == "string";

--- a/xmldom/xmldom.d.ts
+++ b/xmldom/xmldom.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for xmldom 0.1.16
+// Type definitions for xmldom 0.1.22
 // Project: https://github.com/jindw/xmldom.git
 // Definitions by: Qubo <https://github.com/tkqubo>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -6,14 +6,22 @@
 declare module "xmldom" {
   namespace xmldom {
     var DOMParser: DOMParserStatic;
+    var XMLSerializer: XMLSerializerStatic;
 
     interface DOMParserStatic {
       new(): DOMParser;
       new(options: Options): DOMParser;
     }
 
+    interface XMLSerializerStatic {
+      new(): XMLSerializer;
+    }
+
     interface DOMParser {
       parseFromString(xmlsource: string, mimeType?: string): Document;
+    }
+
+    interface XMLSerializer {
       serializeToString(node: Node): string;
     }
 


### PR DESCRIPTION
This pull requests moves the `serializeToString` method from the `DOMParser` class to the newly exported `XMLSerializer` class because that's where the method is really located in xmldom (And browser DOM implementations)
