### PR TITLE
improved typing for bootbox modal options

### DIFF
--- a/bootbox/bootbox-tests.ts
+++ b/bootbox/bootbox-tests.ts
@@ -17,7 +17,8 @@ bootbox.confirm("Click cancel to pass test", function (result) {
 	console.log(!result);
 });
 bootbox.confirm({
-	message: "Click confirm to pass test",
+	title: "Click confirm to pass test",
+	message: "Please confirm this.",
 	callback: function (result) {
 		console.log(result);
 	}
@@ -27,13 +28,13 @@ bootbox.prompt("Enter 'ok' to pass test", function (result) {
 	console.log(result);
 });
 bootbox.prompt({
-	message: "Enter 'ok' to pass test", callback: function (result) {
+	title: "Enter 'ok' to pass test", callback: function (result) {
 		console.log(result);
 	}
 });
 bootbox.prompt({
 	size: "large",
-	message: "Enter 'ok' to pass test", callback: function (result) {
+	title: "Enter 'ok' to pass test", callback: function (result) {
 		console.log(result);
 	}
 });
@@ -42,7 +43,7 @@ bootbox.prompt({
 bootbox.dialog({
 	title: "Wassup?",
 	message: "Test Dialog",
-	callback: function (result) { }
+	callback: function () { }
 });
 
 // Testing the return object of the call. Using the pointer to disable the animation on success callback.

--- a/bootbox/bootbox.d.ts
+++ b/bootbox/bootbox.d.ts
@@ -1,25 +1,56 @@
 // Type definitions for Bootbox 4.4.0
 // Project: https://github.com/makeusabrew/bootbox
-// Definitions by: Vincent Bortone <https://github.com/vbortone/>, Kon Pik <https://github.com/konpikwastaken/>, Anup Kattel <https://github.com/kanup/>, Dominik Schroeter <https://github.com/icereed/>
+// Definitions by: Vincent Bortone <https://github.com/vbortone/>, Kon Pik <https://github.com/konpikwastaken/>, Anup Kattel <https://github.com/kanup/>, Dominik Schroeter <https://github.com/icereed/>, Troy McKinnon <https://github.com/trodi/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../jquery/jquery.d.ts" />
-interface BootboxAlertOptions {
+
+/** Bootbox options shared by all modal types */
+interface BootboxBaseOptions {
+	title?: string | Element;
+	callback?: (result: boolean | string) => any;
+	onEscape?: () => any | boolean;
+	show?: boolean;
+	backdrop?: boolean;
+	closeButton?: boolean;
+	animate?: boolean;
+	className?: string;
 	size?: string;
-	message: string;
+	buttons?: BootboxButtonMap; // complex object where each key is of type BootboxButton
+}
+
+/** Bootbox options available for custom modals */
+interface BootboxDialogOptions extends BootboxBaseOptions {
+	message: string | Element;
+}
+
+/** Bootbox options available for alert modals */
+interface BootboxAlertOptions extends BootboxDialogOptions {
 	callback?: () => any;
+	buttons?: BootboxAlertButtonMap;
 }
 
-interface BootboxConfirmOptions {
-	size?: string;
-	message: string;
+/** Bootbox options available for confirm modals */
+interface BootboxConfirmOptions extends BootboxDialogOptions {
 	callback: (result: boolean) => any;
+	buttons?: BootboxConfirmPromptButtonMap;
 }
 
-interface BootboxPromptOptions {
-	size?: string;
-	message?: string;
+/** Bootbox options available for prompt modals */
+interface BootboxPromptOptions extends BootboxBaseOptions {
+	title: string;
 	callback: (result: string) => any;
+	buttons?: BootboxConfirmPromptButtonMap;
+}
+
+/** Bootbox options available when setting defaults for modals */
+interface BootboxDefaultOptions {
+	locale?: string;
+	show?: boolean;
+	backdrop?: boolean;
+	closeButton?: boolean;
+	animate?: boolean;
+	className?: string;
 }
 
 interface BootboxButton {
@@ -32,28 +63,15 @@ interface BootboxButtonMap {
   [key: string]: BootboxButton | Function;
 }
 
-interface BootboxDialogOptions {
-	message: string | Element;
-	title?: string | Element;
-	locale?: string;
-	callback?: (result: boolean) => any;
-	onEscape?: () => any | boolean;
-	show?: boolean;
-	backdrop?: boolean;
-	closeButton?: boolean;
-	animate?: boolean;
-	className?: string;
-	size?: string;
-	buttons?: BootboxButtonMap; // complex object where each key is of type BootboxButton
+/** ButtonMap options for alerts modals */
+interface BootboxAlertButtonMap extends BootboxButtonMap {
+	ok: BootboxButton | Function;
 }
 
-interface BootboxDefaultOptions {
-	locale?: string;
-	show?: boolean;
-	backdrop?: boolean;
-	closeButton?: boolean;
-	animate?: boolean;
-	className?: string;
+/** ButtonMap options for confirm and prompt modals */
+interface BootboxConfirmPromptButtonMap extends BootboxButtonMap {
+	confirm: BootboxButton | Function;
+	cancel: BootboxButton | Function;
 }
 
 interface BootboxLocaleValues {


### PR DESCRIPTION
**case 2. Improvement to existing type definition.**
- [bootbox source code reference](https://github.com/makeusabrew/bootbox/blob/master/bootbox.js)

Improved typing of the various options that can be passed into bootbox's modal functions. There has not been an updated version of bootbox. I didn't attempt to verify all typings already in d.ts file, just improve.

**Note:** It appears that much of the official bootbox documentation is out of date with current release (which is the release this d.ts file is targeting), hence the many of changes.
