### PR TITLE
add path parse definitions

### DIFF
--- a/path-parse/path-parse-tests.ts
+++ b/path-parse/path-parse-tests.ts
@@ -1,0 +1,6 @@
+/// <reference path="./path-parse.d.ts"/>
+
+import * as parse from "path-parse";
+
+const parsed = parse("/foo/bar.img");
+const { root, dir, base, ext, name } = parsed;

--- a/path-parse/path-parse.d.ts
+++ b/path-parse/path-parse.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for path-parse v1.0.5
 // Project: https://github.com/jbgutierrez/path-parse
-// Definitions by: Dan Chao <http://dchao.co
+// Definitions by: Dan Chao <http://dchao.co>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../node/node.d.ts"/>

--- a/path-parse/path-parse.d.ts
+++ b/path-parse/path-parse.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for path-parse v1.0.5
+// Project: https://github.com/jbgutierrez/path-parse
+// Definitions by: Dan Chao <http://dchao.co
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts"/>
+
+declare module "path-parse" {
+  import { ParsedPath } from "path";
+  const parse: (src: string) => ParsedPath;
+  export = parse;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
