### PR TITLE
Added definition for angular-breadcrumb

### DIFF
--- a/angular-breadcrumb/angular-breadcrumb.d.ts
+++ b/angular-breadcrumb/angular-breadcrumb.d.ts
@@ -7,11 +7,17 @@
 declare namespace angular.ui {
     export interface IState {
         ncyBreadcrumb?: {
-            // Contains the label for the step in the breadcrumb. The state name is used if not defined.
+            /**
+             * Contains the label for the step in the breadcrumb. The state name is used if not defined.
+             **/
             label?: string;
-            // Override the parent state (only for the breadcrumb)
+            /**
+             * Override the parent state (only for the breadcrumb)
+             **/
             parent?: string;
-            // When defined to true, the state is never included in the chain of states and never appears in the breadcrumb
+            /**
+            * When defined to true, the state is never included in the chain of states and never appears in the breadcrumb
+            **/
             skip?: boolean;
         },
         ncyBreadcrumbLabel?: string;
@@ -21,29 +27,53 @@ declare namespace angular.ui {
 
 declare namespace ncy {
 	
-    // Provider that returns an instance of $breadcrumb service. It contains the global configuration of the module.
+    /**
+    * Provider that returns an instance of $breadcrumb service. It contains the global configuration of the module.
+    **/
     export interface $breadcrumbProvider {
-        // Setter for options defined in a module.config block
-        setOptions(options: breadcrumbProviderOptions);
+        /**
+        * Setter for options defined in a module.config block
+        **/
+        setOptions(options: breadcrumbProviderOptions): void;
     }
 	
-    // Global configuration options for angular-breadcrumb
+    /**
+    * Global configuration options for angular-breadcrumb
+    **/
     export interface breadcrumbProviderOptions {
-        // An existing state's name to be the state is the first step of the breadcrumb
+        /**
+        * An existing state's name to be the state is the first step of the breadcrumb
+        **/
         prefixStateName?: string;
-        // Contains a predefined template's name; 'bootstrap3' (default), 'bootstrap2' or HTML for a custom template. This property is ignored if templateUrl is defined.
+
+        /**
+        * Contains a predefined template's name; 'bootstrap3' (default), 'bootstrap2' or HTML for a custom template. This property is ignored if templateUrl is defined.
+        **/
         template?: string;
-        // Contains the path to a template file. This property takes precedence over the template property.
+
+        /** 
+        * Contains the path to a template file. This property takes precedence over the template property.
+        **/
         templateUrl?: string;
-        // If true, abstract states are included in the breadcrumb. This option has a lower priority than the state-specific option skip
+
+        /**
+        * If true, abstract states are included in the breadcrumb. This option has a lower priority than the state-specific option skip
+        **/
         includeAbstract?: boolean;
     }
 
-    // Service responsible for access to $state and for directive configuration.
+    /**
+    * Service responsible for access to $state and for directive configuration.
+    **/
     export interface $breadcrumbService {
-        // Returns the state chain to the current state (i.e. all the steps of the breadcrumb). It's an array of state object enriched with the module-specific property ncyBreadcrumbLink (the href for the breadcrumb step).
+        /**
+        * Returns the state chain to the current state (i.e. all the steps of the breadcrumb). It's an array of state object enriched with the module-specific property ncyBreadcrumbLink (the href for the breadcrumb step).
+        **/
         getStatesChain(): angular.ui.IState[];
-        // Return the last step of the breadcrumb, generally the one relative to the current state, expect if it is configured as skipped (the method returns its parent). As getStatesChain, the state object is enriched with ncyBreadcrumbLink.
+
+        /**
+        * Return the last step of the breadcrumb, generally the one relative to the current state, expect if it is configured as skipped (the method returns its parent). As getStatesChain, the state object is enriched with ncyBreadcrumbLink.
+        **/
         getLastStep(): angular.ui.IState;
     }
 }

--- a/angular-breadcrumb/angular-breadcrumb.d.ts
+++ b/angular-breadcrumb/angular-breadcrumb.d.ts
@@ -1,0 +1,49 @@
+﻿// Type definitions for angular-breadcrumb 0.4.1
+// Project: https://github.com/ncuillery/angular-breadcrumb
+// Definitions by: Marc Talary <https://github.com/marctalary>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../angular-ui-router/angular-ui-router.d.ts" />
+declare namespace angular.ui {
+    export interface IState {
+        ncyBreadcrumb?: {
+            // Contains the label for the step in the breadcrumb. The state name is used if not defined.
+            label?: string;
+            // Override the parent state (only for the breadcrumb)
+            parent?: string;
+            // When defined to true, the state is never included in the chain of states and never appears in the breadcrumb
+            skip?: boolean;
+        },
+        ncyBreadcrumbLabel?: string;
+        ncyBreadcrumbLink?: string;
+    }
+}
+
+declare namespace ncy {
+	
+    // Provider that returns an instance of $breadcrumb service. It contains the global configuration of the module.
+    export interface $breadcrumbProvider {
+        // Setter for options defined in a module.config block
+        setOptions(options: breadcrumbProviderOptions);
+    }
+	
+    // Global configuration options for angular-breadcrumb
+    export interface breadcrumbProviderOptions {
+        // An existing state's name to be the state is the first step of the breadcrumb
+        prefixStateName?: string;
+        // Contains a predefined template's name; 'bootstrap3' (default), 'bootstrap2' or HTML for a custom template. This property is ignored if templateUrl is defined.
+        template?: string;
+        // Contains the path to a template file. This property takes precedence over the template property.
+        templateUrl?: string;
+        // If true, abstract states are included in the breadcrumb. This option has a lower priority than the state-specific option skip
+        includeAbstract?: boolean;
+    }
+
+    // Service responsible for access to $state and for directive configuration.
+    export interface $breadcrumbService {
+        // Returns the state chain to the current state (i.e. all the steps of the breadcrumb). It's an array of state object enriched with the module-specific property ncyBreadcrumbLink (the href for the breadcrumb step).
+        getStatesChain(): angular.ui.IState[];
+        // Return the last step of the breadcrumb, generally the one relative to the current state, expect if it is configured as skipped (the method returns its parent). As getStatesChain, the state object is enriched with ncyBreadcrumbLink.
+        getLastStep(): angular.ui.IState;
+    }
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
