### PR TITLE
fix angularjs IComponentOptions require

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1739,7 +1739,7 @@ declare namespace angular {
          * Whether transclusion is enabled. Enabled by default.
          */
         transclude?: boolean | string | {[slot: string]: string};
-        require?: string | string[] | {[controller: string]: string};
+        require?: string | string[] | {[controller: string]: string} | {[controller: string]: string[]};
     }
 
     interface IComponentTemplateFn {


### PR DESCRIPTION
case 2. Improvement to existing type definition.

This fixes the "require" property for the interface IComponentOptions, it was missing a type. Since with a directive you can require `string[]`, you can also require an object with an array of string for each property.
