### PR TITLE
HammerJS: Hammer instance is not a function

### DIFF
--- a/hammerjs/hammerjs.d.ts
+++ b/hammerjs/hammerjs.d.ts
@@ -97,8 +97,6 @@ interface HammerOptions extends HammerDefaults
 
 interface HammerManager
 {
-  new( element:HTMLElement, options?:any ):HammerManager;
-
   add( recogniser:Recognizer ):Recognizer;
   add( recogniser:Recognizer ):HammerManager;
   add( recogniser:Recognizer[] ):Recognizer;

--- a/hammerjs/hammerjs.d.ts
+++ b/hammerjs/hammerjs.d.ts
@@ -39,7 +39,7 @@ interface HammerStatic
   DIRECTION_VERTICAL:   number;
   DIRECTION_ALL:        number;
 
-  Manager:     HammerManager;
+  Manager:     HammerManagerConstructor;
   Input:       HammerInput;
   TouchAction: TouchAction;
 
@@ -93,6 +93,10 @@ interface CssProps
 interface HammerOptions extends HammerDefaults
 {
 
+}
+
+interface HammerManagerConstructor {
+  new( element:HTMLElement, options?:any ):HammerManager;
 }
 
 interface HammerManager


### PR DESCRIPTION
Calling new Hammer(...) returns an instance of HammerManager, which the declaration file reflects. 

But that HammerManager is just an instance, it is not something which can be called with "new", because it is not a function. 

You can test this to be the case just by the following, you can run it on the HammerJS Site: http://hammerjs.github.io/. It fails with "test is not a function". 

```
var test = new Hammer(document)
test()
```

This removes that "new" call. 
