### PR TITLE
Make connection optional for knex Config

### DIFF
--- a/knex/knex-tests.ts
+++ b/knex/knex-tests.ts
@@ -55,6 +55,16 @@ var knex = Knex({
   }
 });
 
+// Pure Query Builder without a connection
+var knex = Knex({});
+
+// Pure Query Builder without a connection, using a specific flavour of SQL
+var knex = Knex({
+  client: 'pg'
+});
+
+knex('books').insert({title: 'Test'}).returning('*').toString();
+
 // Migrations
 var knex = Knex({
   client: 'mysql',

--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -409,7 +409,7 @@ declare module "knex" {
       debug?: boolean;
       client?: string;
       dialect?: string;
-      connection: string|ConnectionConfig|MariaSqlConnectionConfig|
+      connection?: string|ConnectionConfig|MariaSqlConnectionConfig|
         Sqlite3ConnectionConfig|SocketConnectionConfig;
       pool?: PoolConfig;
       migrations?: MigrationConfig;


### PR DESCRIPTION
It is possible to use knex as a pure query builder without any database
connection. This is specified in the knex documentation.

Quoting http://knexjs.org/#Installation-client:

> You can even use knex without a connection, just for its query building features. Just pass in an empty object when initializing the library. Specify a client if you are interested in a particular flavour of SQL.
