### PR TITLE
antd: Fix notification typings.

### DIFF
--- a/antd/antd-tests.tsx
+++ b/antd/antd-tests.tsx
@@ -23,7 +23,7 @@ import React = __React
     Menu,
     message,
     Modal,
-    Notification,
+    notification,
     Pagination,
     Popconfirm,
     Popover,
@@ -71,7 +71,7 @@ import Col from 'antd/lib/Col'
 import Menu from 'antd/lib/Menu'
 import message from 'antd/lib/message'
 import Modal from 'antd/lib/Modal'
-import Notification from 'antd/lib/Notification'
+import notification from 'antd/lib/notification'
 import Pagination from 'antd/lib/Pagination'
 import Popconfirm from 'antd/lib/Popconfirm'
 import Popover from 'antd/lib/Popover'
@@ -229,7 +229,7 @@ class App extends React.Component<any, any>{
 
         Modal.info({ title: 'hello' });
         Modal.success({ cancelText: 'No' })
-        Notification.success({
+        notification.success({
             message: 'hello',
             description: 'test'
         })

--- a/antd/antd.d.ts
+++ b/antd/antd.d.ts
@@ -871,7 +871,7 @@ declare namespace Antd {
             duration?: number
         }) => void
     /**
-     * #Notification
+     * #notification
     全局展示通知提醒信息。
 
     ## 何时使用
@@ -881,7 +881,7 @@ declare namespace Antd {
     - 较为复杂的通知内容。
     - 带有交互的通知，给出用户下一步的行动点。
     - 系统主动推送。*/
-    export const Notification: {
+    export const notification: {
         success: NotificationFunc
         error: NotificationFunc
         info: NotificationFunc
@@ -1911,8 +1911,8 @@ declare module 'antd/lib/message' {
 declare module 'antd/lib/Modal' {
     export default Antd.Modal
 }
-declare module 'antd/lib/Notification' {
-    export default Antd.Notification
+declare module 'antd/lib/notification' {
+    export default Antd.notification
 }
 declare module 'antd/lib/Pagination' {
     export default Antd.Pagination


### PR DESCRIPTION
These are exported as 'notification' rather than 'Notification'
so we need to use the correct case when providing the typings.

This is documented at http://ant.design/components/notification/
