### PR TITLE
Update react-bootstrap to allow for both module-based and namespace-b…

### DIFF
--- a/react-bootstrap/react-bootstrap.d.ts
+++ b/react-bootstrap/react-bootstrap.d.ts
@@ -1,18 +1,15 @@
 // Type definitions for react-bootstrap
 // Project: https://github.com/react-bootstrap/react-bootstrap
 // Definitions by: Walker Burgin <https://github.com/walkerburgin>, Vincent Siao <https://github.com/vsiao>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-///<reference path="../react/react.d.ts"/>
+///<reference path="../react/react-global.d.ts"/>
 
-declare module "react-bootstrap" {
-    // Import React
-    import React = require("react");
-
+declare namespace ReactBootstrap {
 
     // <Button />
     // ----------------------------------------
-    interface ButtonProps extends React.Props<Button>{
+    export interface ButtonProps extends React.Props<Button> {
 
         // Optional
         active?: boolean;
@@ -29,12 +26,12 @@ declare module "react-bootstrap" {
         target?: string;
         type?: string;
     }
-    type Button = React.ClassicComponent<ButtonProps, {}>;
-    var Button: React.ClassicComponentClass<ButtonProps>;
+    export type Button = React.ClassicComponent<ButtonProps, {}>;
+    export var Button: React.ClassicComponentClass<ButtonProps>;
 
     // <ButtonToolbar />
     // ----------------------------------------
-    interface ButtonToolbarProps extends React.Props<ButtonToolbar> {
+    export interface ButtonToolbarProps extends React.Props<ButtonToolbar> {
 
         // Optional
         block?: boolean;
@@ -44,12 +41,12 @@ declare module "react-bootstrap" {
         justified?: boolean;
         vertical?: boolean;
     }
-    type ButtonToolbar = React.ClassicComponent<ButtonToolbarProps, {}>;
-    var ButtonToolbar: React.ClassicComponentClass<ButtonToolbarProps>;
+    export type ButtonToolbar = React.ClassicComponent<ButtonToolbarProps, {}>;
+    export var ButtonToolbar: React.ClassicComponentClass<ButtonToolbarProps>;
 
     // <ButtonGroup />
     // ----------------------------------------
-    interface ButtonGroupProps extends React.Props<ButtonGroup> {
+    export interface ButtonGroupProps extends React.Props<ButtonGroup> {
         // Optional
         block?: boolean;
         bsSize?: string;
@@ -58,12 +55,12 @@ declare module "react-bootstrap" {
         justified?: boolean;
         vertical?: boolean;
     }
-    type ButtonGroup = React.ClassicComponent<ButtonGroupProps, {}>;
-    var ButtonGroup: React.ClassicComponentClass<ButtonGroupProps>;
+    export type ButtonGroup = React.ClassicComponent<ButtonGroupProps, {}>;
+    export var ButtonGroup: React.ClassicComponentClass<ButtonGroupProps>;
 
     // <DropdownButton />
     // ----------------------------------------
-    interface DropdownButtonProps extends React.Props<DropdownButton> {
+    export interface DropdownButtonProps extends React.Props<DropdownButton> {
         bsStyle?: string;
         bsSize?: string;
         buttonClassName?: string;
@@ -78,12 +75,12 @@ declare module "react-bootstrap" {
         pullRight?: boolean;
         title?: any; // TODO: Add more specific type
     }
-    class DropdownButton extends React.Component<DropdownButtonProps, {}> {
+    export class DropdownButton extends React.Component<DropdownButtonProps, {}> {
     }
 
     // <SplitButton />
     // ----------------------------------------
-    interface SplitButtonProps extends React.Props<SplitButton>{
+    export interface SplitButtonProps extends React.Props<SplitButton> {
         bsStyle?: string;
         bsSize?: string;
         className?: string;
@@ -98,12 +95,12 @@ declare module "react-bootstrap" {
         target?: string;
         title?: any; // TODO: Add more specific type
     }
-    class SplitButton extends React.Component<SplitButtonProps, {}> {
+    export class SplitButton extends React.Component<SplitButtonProps, {}> {
     }
 
     // <MenuItem />
     // ----------------------------------------
-    interface MenuItemProps extends React.Props<MenuItem> {
+    export interface MenuItemProps extends React.Props<MenuItem> {
         active?: boolean;
         className?: string;
         disabled?: boolean;
@@ -117,12 +114,12 @@ declare module "react-bootstrap" {
         target?: string;
         title?: string;
     }
-    class MenuItem extends React.Component<MenuItemProps, {}> {
+    export class MenuItem extends React.Component<MenuItemProps, {}> {
     }
 
     // <Panel />
     // ----------------------------------------
-    interface PanelProps extends React.Props<Panel> {
+    export interface PanelProps extends React.Props<Panel> {
         className?: string;
         bsSize?: string;
         bsStyle?: string;
@@ -136,12 +133,12 @@ declare module "react-bootstrap" {
         onSelect?: Function; // TODO: Add more specific type
         onClick?: Function; // TODO: Add more specific type
     }
-    type Panel = React.ClassicComponent<PanelProps, {}>;
-    var Panel: React.ClassicComponentClass<PanelProps>;
+    export type Panel = React.ClassicComponent<PanelProps, {}>;
+    export var Panel: React.ClassicComponentClass<PanelProps>;
 
     // <Accordion />
     // ----------------------------------------
-    interface AccordionProps extends React.Props<Accordion> {
+    export interface AccordionProps extends React.Props<Accordion> {
         bsSize?: string;
         bsStyle?: string;
         collapsible?: boolean;
@@ -153,12 +150,12 @@ declare module "react-bootstrap" {
         id?: string;
         onSelect?: Function; // TODO: Add more specific type
     }
-    type Accordion = React.ClassicComponent<AccordionProps, {}>;
-    var Accordion: React.ClassicComponentClass<AccordionProps>;
+    export type Accordion = React.ClassicComponent<AccordionProps, {}>;
+    export var Accordion: React.ClassicComponentClass<AccordionProps>;
 
     // <PanelGroup />
     // ----------------------------------------
-    interface PanelGroupProps extends React.Props<PanelGroup> {
+    export interface PanelGroupProps extends React.Props<PanelGroup> {
         accordion?: boolean;
         activeKey?: any;
         bsSize?: string;
@@ -167,66 +164,66 @@ declare module "react-bootstrap" {
         defaultActiveKey?: any;
         onSelect?: Function;
     }
-    type PanelGroup = React.ClassicComponent<PanelGroupProps, {}>;
-    var PanelGroup: React.ClassicComponentClass<PanelGroupProps>;
+    export type PanelGroup = React.ClassicComponent<PanelGroupProps, {}>;
+    export var PanelGroup: React.ClassicComponentClass<PanelGroupProps>;
 
     // <Modal.Dialog />
     // ----------------------------------------
-    interface ModalDialogProps extends React.Props<ModalDialog> {
+    export interface ModalDialogProps extends React.Props<ModalDialog> {
         // TODO: Add more specific type
     }
-    type ModalDialog = React.ClassicComponent<ModalDialogProps, {}>;
-    var ModalDialog: React.ClassicComponentClass<ModalDialogProps>;
+    export type ModalDialog = React.ClassicComponent<ModalDialogProps, {}>;
+    export var ModalDialog: React.ClassicComponentClass<ModalDialogProps>;
 
     // <Modal.Header />
     // ----------------------------------------
-  interface ModalHeaderProps extends React.Props<ModalHeader> {
+    export interface ModalHeaderProps extends React.Props<ModalHeader> {
         className?: string;
         closeButton?: boolean;
         modalClassName?: string;
         onHide?: Function;
         // undefined?: string;
     }
-    class ModalHeader extends React.Component<ModalHeaderProps, {}> {
+    export class ModalHeader extends React.Component<ModalHeaderProps, {}> {
     }
 
     // <Modal.Title/>
     // ----------------------------------------
-    interface ModalTitleProps extends React.Props<ModalTitle> {
+    export interface ModalTitleProps extends React.Props<ModalTitle> {
         className?: string;
         modalClassName?: string;
     }
-    class ModalTitle extends React.Component<ModalTitleProps, {}> {
+    export class ModalTitle extends React.Component<ModalTitleProps, {}> {
     }
 
     // <Modal.Body />
     // ----------------------------------------
-    interface ModalBodyProps extends React.Props<ModalBody> {
+    export interface ModalBodyProps extends React.Props<ModalBody> {
         className?: string;
         modalClassName?: string;
     }
-    class ModalBody extends React.Component<ModalBodyProps, {}> {
+    export class ModalBody extends React.Component<ModalBodyProps, {}> {
     }
 
     // <Modal.Footer />
     // ----------------------------------------
-    interface ModalFooterProps extends React.Props<ModalFooter> {
+    export interface ModalFooterProps extends React.Props<ModalFooter> {
         className?: string;
         modalClassName?: string;
     }
-    class ModalFooter extends React.Component<ModalFooterProps, {}> {
+    export class ModalFooter extends React.Component<ModalFooterProps, {}> {
     }
 
     // <Modal />
     // ----------------------------------------
-    interface ModalProps extends React.Props<Modal> {
+    export interface ModalProps extends React.Props<Modal> {
         // Required
         onHide: Function;
 
         // Optional
         animation?: boolean;
         autoFocus?: boolean;
-        backdrop?: boolean|string;
+        backdrop?: boolean | string;
         bsSize?: string;
         container?: any; // TODO: Add more specific type
         dialogClassName?: string;
@@ -235,20 +232,19 @@ declare module "react-bootstrap" {
         keyboard?: boolean;
         show?: boolean;
     }
-    interface ModalClass extends React.ClassicComponentClass<ModalProps> {
+    export interface ModalClass extends React.ClassicComponentClass<ModalProps> {
         Body: typeof ModalBody;
         Header: typeof ModalHeader;
         Title: typeof ModalTitle;
         Footer: typeof ModalFooter;
         Dialog: typeof ModalDialog;
     }
-    type Modal = React.ClassicComponent<ModalProps, {}>;
-    var Modal: ModalClass;
-
+    export type Modal = React.ClassicComponent<ModalProps, {}>;
+    export var Modal: ModalClass;
 
     // <OverlayTrigger />
     // ----------------------------------------
-    interface OverlayTriggerProps extends React.Props<OverlayTrigger> {
+    export interface OverlayTriggerProps extends React.Props<OverlayTrigger> {
         // Required
         overlay: any; // TODO: Add more specific type
 
@@ -270,12 +266,12 @@ declare module "react-bootstrap" {
         rootClose?: boolean;
         trigger?: string | string[];
     }
-    type OverlayTrigger = React.ClassicComponent<OverlayTriggerProps, {}>;
-    var OverlayTrigger: React.ClassicComponentClass<OverlayTriggerProps>;
+    export type OverlayTrigger = React.ClassicComponent<OverlayTriggerProps, {}>;
+    export var OverlayTrigger: React.ClassicComponentClass<OverlayTriggerProps>;
 
     // <Tooltip />
     // ----------------------------------------
-    interface TooltipProps extends React.Props<Tooltip> {
+    export interface TooltipProps extends React.Props<Tooltip> {
         // Optional
         arrowOffsetLeft?: number | string;
         arrowOffsetTop?: number | string;
@@ -288,12 +284,12 @@ declare module "react-bootstrap" {
         positionTop?: number;
         title?: any; // TODO: Add more specific type
     }
-    type Tooltip = React.ClassicComponent<TooltipProps, {}>;
-    var Tooltip: React.ClassicComponentClass<TooltipProps>;
+    export type Tooltip = React.ClassicComponent<TooltipProps, {}>;
+    export var Tooltip: React.ClassicComponentClass<TooltipProps>;
 
     // <Popover/>
     // ----------------------------------------
-    interface PopoverProps  extends React.Props<Popover> {
+    export interface PopoverProps extends React.Props<Popover> {
         // Optional
         arrowOffsetLeft?: number | string;
         arrowOffsetTop?: number | string;
@@ -306,12 +302,12 @@ declare module "react-bootstrap" {
         positionTop?: number;
         title?: any; // TODO: Add more specific type
     }
-    type Popover = React.ClassicComponent<PopoverProps, {}>;
-    var Popover: React.ClassicComponentClass<PopoverProps>;
+    export type Popover = React.ClassicComponent<PopoverProps, {}>;
+    export var Popover: React.ClassicComponentClass<PopoverProps>;
 
     // <Overlay />
     // ----------------------------------------
-    interface OverlayProps extends React.Props<Overlay> {
+    export interface OverlayProps extends React.Props<Overlay> {
         // Optional
         animation?: any; // TODO: Add more specific type
         container?: any; // TODO: Add more specific type
@@ -328,12 +324,12 @@ declare module "react-bootstrap" {
         show?: boolean;
         target?: Function;
     }
-    class Overlay extends React.Component<OverlayProps, {}> {
+    export class Overlay extends React.Component<OverlayProps, {}> {
     }
 
     // <ProgressBar />
     // ----------------------------------------
-    interface ProgressBarProps extends React.Props<ProgressBar> {
+    export interface ProgressBarProps extends React.Props<ProgressBar> {
         // Optional
         active?: boolean;
         bsSize?: string;
@@ -347,13 +343,13 @@ declare module "react-bootstrap" {
         srOnly?: boolean;
         striped?: boolean;
     }
-    class ProgressBar extends React.Component<ProgressBarProps, {}> {
+    export class ProgressBar extends React.Component<ProgressBarProps, {}> {
     }
 
     // <Nav />
     // ----------------------------------------
     // TODO: This one turned into a union of two different types
-    interface NavProps extends React.Props<Nav> {
+    export interface NavProps extends React.Props<Nav> {
         // Optional
         activeHref?: string;
         activeKey?: any;
@@ -373,12 +369,12 @@ declare module "react-bootstrap" {
         ulClassName?: string;
         ulId?: string;
     }
-    class Nav extends React.Component<NavProps, {}> {
+    export class Nav extends React.Component<NavProps, {}> {
     }
 
     // <NavItem />
     // ----------------------------------------
-    interface NavItemProps extends React.Props<NavItem> {
+    export interface NavItemProps extends React.Props<NavItem> {
         active?: boolean;
         brand?: any; // TODO: Add more specific type
         bsSize?: string;
@@ -405,40 +401,40 @@ declare module "react-bootstrap" {
         toggleButton?: any; // TODO: Add more specific type
         toggleNavKey?: string | number;
     }
-    type NavItem = React.ClassicComponent<NavItemProps, {}>;
-    var NavItem: React.ClassicComponentClass<NavItemProps>;
+    export type NavItem = React.ClassicComponent<NavItemProps, {}>;
+    export var NavItem: React.ClassicComponentClass<NavItemProps>;
 
     // <Navbar.Brand />
     // ----------------------------------------
-    interface NavbarBrandProps extends React.Props<NavbarBrand> {
+    export interface NavbarBrandProps extends React.Props<NavbarBrand> {
     }
-    class NavbarBrand extends React.Component<NavbarBrandProps, {}> {
+    export class NavbarBrand extends React.Component<NavbarBrandProps, {}> {
     }
 
     // <Navbar.Collapse />
     // ----------------------------------------
-    interface NavbarCollapseProps extends React.Props<NavbarCollapse> {
+    export interface NavbarCollapseProps extends React.Props<NavbarCollapse> {
     }
-    type NavbarCollapse = React.ClassicComponent<NavbarCollapseProps, {}>;
-    var NavbarCollapse: React.ClassicComponentClass<NavbarCollapseProps>;
+    export type NavbarCollapse = React.ClassicComponent<NavbarCollapseProps, {}>;
+    export var NavbarCollapse: React.ClassicComponentClass<NavbarCollapseProps>;
 
     // <Navbar.Header />
     // ----------------------------------------
-    interface NavbarHeaderProps extends React.Props<NavbarHeader> {
+    export interface NavbarHeaderProps extends React.Props<NavbarHeader> {
     }
-    type NavbarHeader = React.ClassicComponent<NavbarHeaderProps, {}>;
-    var NavbarHeader: React.ClassicComponentClass<NavbarHeaderProps>;
+    export type NavbarHeader = React.ClassicComponent<NavbarHeaderProps, {}>;
+    export var NavbarHeader: React.ClassicComponentClass<NavbarHeaderProps>;
 
     // <Navbar.Toggle />
     // ----------------------------------------
-    interface NavbarToggleProps extends React.Props<NavbarToggle> {
+    export interface NavbarToggleProps extends React.Props<NavbarToggle> {
     }
-    type NavbarToggle = React.ClassicComponent<NavbarToggleProps, {}>;
-    var NavbarToggle: React.ClassicComponentClass<NavbarToggleProps>;
+    export type NavbarToggle = React.ClassicComponent<NavbarToggleProps, {}>;
+    export var NavbarToggle: React.ClassicComponentClass<NavbarToggleProps>;
 
     // <Navbar />
     // ----------------------------------------
-    interface NavbarProps extends React.Props<Navbar> {
+    export interface NavbarProps extends React.Props<Navbar> {
         brand?: any; // TODO: Add more specific type
         bsSize?: string;
         bsStyle?: string;
@@ -456,29 +452,29 @@ declare module "react-bootstrap" {
         toggleButton?: any; // TODO: Add more specific type
         toggleNavKey?: string | number;
     }
-    interface NavbarClass extends React.ClassicComponentClass<NavbarProps> {
+    export interface NavbarClass extends React.ClassicComponentClass<NavbarProps> {
         Brand: typeof NavbarBrand;
         Collapse: typeof NavbarCollapse;
         Header: typeof NavbarHeader;
         Toggle: typeof NavbarToggle;
     }
-    type Navbar = React.ClassicComponent<NavbarProps, {}>;
-    var Navbar: NavbarClass;
+    export type Navbar = React.ClassicComponent<NavbarProps, {}>;
+    export var Navbar: NavbarClass;
 
     // <NavDropdown />
     // ----------------------------------------
-    interface NavDropdownProps extends React.Props<NavDropdown> {
+    export interface NavDropdownProps extends React.Props<NavDropdown> {
         className?: string;
         eventKey?: any;
         title?: string;
         id?: string;
     }
-    class NavDropdown extends React.Component<NavDropdownProps, {}> {
+    export class NavDropdown extends React.Component<NavDropdownProps, {}> {
     }
 
     // <Tabs />
     // ----------------------------------------
-    interface TabsProps extends React.Props<Tabs> {
+    export interface TabsProps extends React.Props<Tabs> {
         activeKey?: any;
         animation?: boolean;
         bsStyle?: string;
@@ -489,33 +485,33 @@ declare module "react-bootstrap" {
         position?: string;
         tabWidth?: any; // TODO: Add more specific type
     }
-    type Tabs = React.ClassicComponent<TabsProps, {}>;
-    var Tabs: React.ClassicComponentClass<TabsProps>;
+    export type Tabs = React.ClassicComponent<TabsProps, {}>;
+    export var Tabs: React.ClassicComponentClass<TabsProps>;
 
     // <Tab />
     // ----------------------------------------
-    interface TabProps extends React.Props<Tab> {
+    export interface TabProps extends React.Props<Tab> {
         animation?: boolean;
         className?: string;
         disabled?: boolean;
         eventKey?: any; // TODO: Add more specific type
         title?: any; // TODO: Add more specific type
     }
-    type Tab = React.ClassicComponent<TabProps, {}>;
-    var Tab: React.ClassicComponentClass<TabProps>;
+    export type Tab = React.ClassicComponent<TabProps, {}>;
+    export var Tab: React.ClassicComponentClass<TabProps>;
 
     // <Pager />
     // ----------------------------------------
-    interface PagerProps extends React.Props<Pager> {
+    export interface PagerProps extends React.Props<Pager> {
         className?: string;
         onSelect?: Function;
     }
-    type Pager = React.ClassicComponent<PagerProps, {}>;
-    var Pager: React.ClassicComponentClass<PagerProps>;
+    export type Pager = React.ClassicComponent<PagerProps, {}>;
+    export var Pager: React.ClassicComponentClass<PagerProps>;
 
     // <PageItem />
     // ----------------------------------------
-    interface PageItemProps extends React.Props<PageItem> {
+    export interface PageItemProps extends React.Props<PageItem> {
         className?: string;
         disabled?: boolean;
         eventKey?: any;
@@ -526,12 +522,12 @@ declare module "react-bootstrap" {
         target?: string;
         title?: string;
     }
-    type PageItem = React.ClassicComponent<PageItemProps, {}>;
-    var PageItem: React.ClassicComponentClass<PageItemProps>;
+    export type PageItem = React.ClassicComponent<PageItemProps, {}>;
+    export var PageItem: React.ClassicComponentClass<PageItemProps>;
 
     // <Pagination />
     // ----------------------------------------
-    interface PaginationProps extends React.Props<Pagination> {
+    export interface PaginationProps extends React.Props<Pagination> {
         activePage?: number;
         bsSize?: string;
         bsStyle?: string;
@@ -546,12 +542,12 @@ declare module "react-bootstrap" {
         onSelect?: Function;
         prev?: boolean;
     }
-    type Pagination = React.ClassicComponent<PaginationProps, {}>;
-    var Pagination: React.ClassicComponentClass<PaginationProps>;
+    export type Pagination = React.ClassicComponent<PaginationProps, {}>;
+    export var Pagination: React.ClassicComponentClass<PaginationProps>;
 
     // <Alert />
     // ----------------------------------------
-    interface AlertProps extends React.Props<Alert> {
+    export interface AlertProps extends React.Props<Alert> {
         bsSize?: string;
         bsStyle?: string;
         className?: string;
@@ -559,12 +555,12 @@ declare module "react-bootstrap" {
         dismissAfter?: number;
         onDismiss?: Function;
     }
-    type Alert = React.ClassicComponent<AlertProps, {}>;
-    var Alert: React.ClassicComponentClass<AlertProps>;
+    export type Alert = React.ClassicComponent<AlertProps, {}>;
+    export var Alert: React.ClassicComponentClass<AlertProps>;
 
     // <Carousel />
     // ----------------------------------------
-    interface CarouselProps extends React.Props<Carousel> {
+    export interface CarouselProps extends React.Props<Carousel> {
         activeIndex?: number;
         bsSize?: string;
         bsStyle?: string;
@@ -582,12 +578,12 @@ declare module "react-bootstrap" {
         slide?: boolean;
         wrap?: boolean;
     }
-    type Carousel = React.ClassicComponent<CarouselProps, {}>;
-    var Carousel: React.ClassicComponentClass<CarouselProps>;
+    export type Carousel = React.ClassicComponent<CarouselProps, {}>;
+    export var Carousel: React.ClassicComponentClass<CarouselProps>;
 
     // <CarouselItem />
     // ----------------------------------------
-    interface CarouselItemProps extends React.Props<CarouselItem> {
+    export interface CarouselItemProps extends React.Props<CarouselItem> {
         active?: boolean;
         animtateIn?: boolean;
         animateOut?: boolean;
@@ -597,31 +593,31 @@ declare module "react-bootstrap" {
         index?: number;
         onAnimateOutEnd?: Function;
     }
-    type CarouselItem = React.ClassicComponent<CarouselItemProps, {}>;
-    var CarouselItem: React.ClassicComponentClass<CarouselItemProps>;
+    export type CarouselItem = React.ClassicComponent<CarouselItemProps, {}>;
+    export var CarouselItem: React.ClassicComponentClass<CarouselItemProps>;
 
     // <Grid />
     // ----------------------------------------
-    interface GridProps extends React.Props<Grid> {
+    export interface GridProps extends React.Props<Grid> {
         className?: string;
         componentClass?: any; // TODO: Add more specific type
         fluid?: boolean;
     }
-    type Grid = React.ClassicComponent<GridProps, {}>;
-    var Grid: React.ClassicComponentClass<GridProps>;
+    export type Grid = React.ClassicComponent<GridProps, {}>;
+    export var Grid: React.ClassicComponentClass<GridProps>;
 
     // <Row />
     // ----------------------------------------
-    interface RowProps extends React.Props<Row> {
+    export interface RowProps extends React.Props<Row> {
         className?: string;
         componentClass?: any; // TODO: Add more specific type
     }
-    type Row = React.ClassicComponent<RowProps, {}>;
-    var Row: React.ClassicComponentClass<RowProps>;
+    export type Row = React.ClassicComponent<RowProps, {}>;
+    export var Row: React.ClassicComponentClass<RowProps>;
 
     // <Col />
     // ----------------------------------------
-    interface ColProps extends React.Props<Col> {
+    export interface ColProps extends React.Props<Col> {
         className?: string;
         componentClass?: any; // TODO: Add more specific type
         lg?: number;
@@ -645,12 +641,12 @@ declare module "react-bootstrap" {
         xsPull?: number;
         xsPush?: number;
     }
-    type Col = React.ClassicComponent<ColProps, {}>;
-    var Col: React.ClassicComponentClass<ColProps>;
+    export type Col = React.ClassicComponent<ColProps, {}>;
+    export var Col: React.ClassicComponentClass<ColProps>;
 
     // <Thumbnail />
     // ----------------------------------------
-    interface ThumbnailProps extends React.Props<Thumbnail> {
+    export interface ThumbnailProps extends React.Props<Thumbnail> {
         alt?: string;
         bsSize?: string;
         bsStyle?: string;
@@ -658,22 +654,22 @@ declare module "react-bootstrap" {
         href?: string;
         src?: string;
     }
-    type Thumbnail = React.ClassicComponent<ThumbnailProps, {}>;
-    var Thumbnail: React.ClassicComponentClass<ThumbnailProps>;
+    export type Thumbnail = React.ClassicComponent<ThumbnailProps, {}>;
+    export var Thumbnail: React.ClassicComponentClass<ThumbnailProps>;
 
     // <ListGroup />
     // ----------------------------------------
-    interface ListGroupProps extends React.Props<ListGroup> {
+    export interface ListGroupProps extends React.Props<ListGroup> {
         className?: string;
         id?: string | number;
         fill?: boolean; // TODO: Add more specific type
     }
-    class ListGroup extends React.Component<ListGroupProps, {}> {
+    export class ListGroup extends React.Component<ListGroupProps, {}> {
     }
 
     // <ListGroupItem />
     // ----------------------------------------
-    interface ListGroupItemProps extends React.Props<ListGroupItem> {
+    export interface ListGroupItemProps extends React.Props<ListGroupItem> {
         active?: any;
         bsSize?: string;
         bsStyle?: string;
@@ -687,68 +683,68 @@ declare module "react-bootstrap" {
         onClick?: Function; // TODO: Add more specific type
         target?: string;
     }
-    class ListGroupItem extends React.Component<ListGroupItemProps, {}> {
+    export class ListGroupItem extends React.Component<ListGroupItemProps, {}> {
     }
 
     // <Label />
     // ----------------------------------------
-    interface LabelProps extends React.Props<Label> {
+    export interface LabelProps extends React.Props<Label> {
         bsSize?: string;
         bsStyle?: string;
         className?: string;
     }
-    class Label extends React.Component<LabelProps, {}> {
+    export class Label extends React.Component<LabelProps, {}> {
     }
 
     // <Badge />
     // ----------------------------------------
-    interface BadgeProps extends React.Props<Badge> {
+    export interface BadgeProps extends React.Props<Badge> {
         className?: string;
         pullRight?: boolean;
     }
-    type Badge = React.ClassicComponent<BadgeProps, {}>;
-    var Badge: React.ClassicComponentClass<BadgeProps>;
+    export type Badge = React.ClassicComponent<BadgeProps, {}>;
+    export var Badge: React.ClassicComponentClass<BadgeProps>;
 
     // <Jumbotron />
     // ----------------------------------------
-    interface JumbotronProps extends React.Props<Jumbotron> {
+    export interface JumbotronProps extends React.Props<Jumbotron> {
         className?: string;
         componentClass?: any; // TODO: Add more specific type
     }
-    type Jumbotron = React.ClassicComponent<JumbotronProps, {}>;
-    var Jumbotron: React.ClassicComponentClass<JumbotronProps>;
+    export type Jumbotron = React.ClassicComponent<JumbotronProps, {}>;
+    export var Jumbotron: React.ClassicComponentClass<JumbotronProps>;
 
     // <PageHeader />
     // ----------------------------------------
-    interface PageHeaderProps extends React.Props<PageHeader> {
+    export interface PageHeaderProps extends React.Props<PageHeader> {
         className?: string;
     }
-    class PageHeader extends React.Component<PageHeaderProps, {}> {
+    export class PageHeader extends React.Component<PageHeaderProps, {}> {
     }
 
     // <Well />
     // ----------------------------------------
-    interface WellProps extends React.Props<Well> {
+    export interface WellProps extends React.Props<Well> {
         bsSize?: string;
         bsStyle?: string;
         className?: string;
     }
-    class Well extends React.Component<WellProps, {}> {
+    export class Well extends React.Component<WellProps, {}> {
     }
 
     // <Glyphicon />
     // ----------------------------------------
-    interface GlyphiconProps extends React.Props<Glyphicon> {
+    export interface GlyphiconProps extends React.Props<Glyphicon> {
         className?: string;
         // Required
         glyph: string;
     }
-    type Glyphicon = React.ClassicComponent<GlyphiconProps, {}>;
-    var Glyphicon: React.ClassicComponentClass<GlyphiconProps>;
+    export type Glyphicon = React.ClassicComponent<GlyphiconProps, {}>;
+    export var Glyphicon: React.ClassicComponentClass<GlyphiconProps>;
 
     // <Table />
     // ----------------------------------------
-    interface TableProps extends React.Props<Table> {
+    export interface TableProps extends React.Props<Table> {
         bordered?: boolean;
         className?: string;
         condensed?: boolean;
@@ -756,13 +752,13 @@ declare module "react-bootstrap" {
         responsive?: boolean;
         striped?: boolean;
     }
-    type Table = React.ClassicComponent<TableProps, {}>;
-    var Table: React.ClassicComponentClass<TableProps>;
+    export type Table = React.ClassicComponent<TableProps, {}>;
+    export var Table: React.ClassicComponentClass<TableProps>;
 
     // <Input />
     // ----------------------------------------
-    interface InputProps extends React.Props<Input> {
-        defaultValue?:string;
+    export interface InputProps extends React.Props<Input> {
+        defaultValue?: string;
         addonAfter?: any; // TODO: Add more specific type
         addonBefore?: any; // TODO: Add more specific type
         bsSize?: string;
@@ -791,12 +787,12 @@ declare module "react-bootstrap" {
         wrapperClassName?: string;
     }
     // TODO: extends InputBase
-    class Input extends React.Component<InputProps, {}> {
+    export class Input extends React.Component<InputProps, {}> {
     }
 
     // <ButtonInput />
     // ----------------------------------------
-    interface ButtonInputProps extends React.Props<ButtonInput> {
+    export interface ButtonInputProps extends React.Props<ButtonInput> {
         addonAfter?: any; // TODO: Add more specific type
         addonBefore?: any; // TODO: Add more specific type
         bsSize?: string;
@@ -819,25 +815,25 @@ declare module "react-bootstrap" {
         wrapperClassName?: string;
     }
     // TODO: extends InputBase
-    class ButtonInput extends React.Component<ButtonInputProps, {}> {
+    export class ButtonInput extends React.Component<ButtonInputProps, {}> {
     }
 
 
     // <FormControls.Static />
     // ----------------------------------------
 
-    interface StaticProps extends React.Props<StaticClass> { }
-    interface Static extends React.ReactElement<StaticProps> { }
-    interface StaticClass extends React.ComponentClass<StaticProps> { }
-    interface FormControlsClass {
-      Static: StaticClass;
+    export interface StaticProps extends React.Props<StaticClass> { }
+    export interface Static extends React.ReactElement<StaticProps> { }
+    export interface StaticClass extends React.ComponentClass<StaticProps> { }
+    export interface FormControlsClass {
+        Static: StaticClass;
     }
-    var FormControls: FormControlsClass;
+    export var FormControls: FormControlsClass;
 
 
     // <Portal />
     // ----------------------------------------
-    interface PortalProps extends React.Props<Portal> {
+    export interface PortalProps extends React.Props<Portal> {
         dimension?: string | Function;
         getDimensionValue?: Function;
         in?: boolean;
@@ -852,12 +848,12 @@ declare module "react-bootstrap" {
         transitionAppear?: boolean;
         unmountOnExit?: boolean;
     }
-    type Portal = React.ClassicComponent<PortalProps, {}>;
-    var Portal: React.ClassicComponentClass<PortalProps>;
+    export type Portal = React.ClassicComponent<PortalProps, {}>;
+    export var Portal: React.ClassicComponentClass<PortalProps>;
 
     // <Position />
     // ----------------------------------------
-    interface PositionProps extends React.Props<Position> {
+    export interface PositionProps extends React.Props<Position> {
         dimension?: string | Function;
         getDimensionValue?: Function;
         in?: boolean;
@@ -872,12 +868,12 @@ declare module "react-bootstrap" {
         transitionAppear?: boolean;
         unmountOnExit?: boolean;
     }
-    class Position extends React.Component<PositionProps, {}> {
+    export class Position extends React.Component<PositionProps, {}> {
     }
 
     // <Fade />
     // ----------------------------------------
-    interface FadeProps extends React.Props<Fade> {
+    export interface FadeProps extends React.Props<Fade> {
         in?: boolean;
         onEnter?: Function;
         onEntered?: Function;
@@ -889,6 +885,10 @@ declare module "react-bootstrap" {
         transitionAppear?: boolean;
         unmountOnExit?: boolean;
     }
-    class Fade extends React.Component<FadeProps, {}> {
+    export class Fade extends React.Component<FadeProps, {}> {
     }
+}
+
+declare module "react-bootstrap" {
+    export = ReactBootstrap;
 }


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
- it has been reviewed by a DefinitelyTyped member.

Notes:
Previously, the react-bootstrap definitions only allowed for module-based loading. However, react-bootstrap itself can be loaded either via a module (AMD/CommonJS, etc.), or it can be loaded "globally" onto a web page. The react.d.ts definitions allow for both sorts of loading; so this set of definitions probably should as well.
