### PR TITLE
fs-extra: fix argument of copy and copySync function

### DIFF
--- a/fs-extra/fs-extra-tests.ts
+++ b/fs-extra/fs-extra-tests.ts
@@ -51,10 +51,41 @@ fs.copy(src, dest, errorCallback);
 fs.copy(src, dest, (src: string) => {
 	return false;
 }, errorCallback);
+fs.copy(src, dest,
+	{
+		clobber: true,
+		preserveTimestamps: true,
+		filter: (src: string) => {return false}
+	},
+	errorCallback
+);
+fs.copy(src, dest,
+	{
+		clobber: true,
+		preserveTimestamps: true,
+		filter: /.*/
+	},
+	errorCallback
+);
 fs.copySync(src, dest);
 fs.copySync(src, dest, (src: string) => {
 	return false;
 });
+fs.copySync(src, dest, /.*/);
+fs.copySync(src, dest,
+	{
+		clobber: true,
+		preserveTimestamps: true,
+		filter: (src: string) => {return false}
+	}
+);
+fs.copySync(src, dest,
+	{
+		clobber: true,
+		preserveTimestamps: true,
+		filter: /.*/
+	}
+);
 fs.createFile(file, errorCallback);
 fs.createFileSync(file);
 

--- a/fs-extra/fs-extra.d.ts
+++ b/fs-extra/fs-extra.d.ts
@@ -42,10 +42,12 @@ declare module "fs-extra" {
 
 	//extended methods
 	export function copy(src: string, dest: string, callback?: (err: Error) => void): void;
-	export function copy(src: string, dest: string, filter: (src: string) => boolean, callback?: (err: Error) => void): void;
+	export function copy(src: string, dest: string, filter: CopyFilter, callback?: (err: Error) => void): void;
+	export function copy(src: string, dest: string, options: CopyOptions, callback?: (err: Error) => void): void;
 
 	export function copySync(src: string, dest: string): void;
-	export function copySync(src: string, dest: string, filter: (src: string) => boolean): void;
+	export function copySync(src: string, dest: string, filter: CopyFilter): void;
+	export function copySync(src: string, dest: string, options: CopyOptions): void;
 
 	export function createFile(file: string, callback?: (err: Error) => void): void;
 	export function createFileSync(file: string): void;
@@ -176,6 +178,18 @@ declare module "fs-extra" {
 	export function ensureSymlinkSync(path: string): void;
     export function emptyDir(path: string, callback?: (err: Error) => void): void;
     export function emptyDirSync(path: string): boolean;
+
+	export interface CopyFilterFunction {
+		(src: string): boolean
+	}
+
+	export type CopyFilter = CopyFilterFunction | RegExp;
+
+	export interface CopyOptions {
+		clobber: boolean
+		preserveTimestamps: boolean
+		filter: CopyFilter
+	}
 
 	export interface OpenOptions {
 		encoding?: string;

--- a/fs-extra/fs-extra.d.ts
+++ b/fs-extra/fs-extra.d.ts
@@ -186,9 +186,9 @@ declare module "fs-extra" {
 	export type CopyFilter = CopyFilterFunction | RegExp;
 
 	export interface CopyOptions {
-		clobber: boolean
-		preserveTimestamps: boolean
-		filter: CopyFilter
+		clobber?: boolean
+		preserveTimestamps?: boolean
+		filter?: CopyFilter
 	}
 
 	export interface OpenOptions {


### PR DESCRIPTION
- Allow options object as 3rd argument of copy and copySync
- Allow RegExp as a filter for copy and copySync

See: https://github.com/jprichardson/node-fs-extra#copy
