### PR TITLE
angularjs: Support HttpParamSerializer interface

### DIFF
--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -1110,3 +1110,10 @@ function doBootstrap(element: Element | JQuery, mode: string): ng.auto.IInjector
         debugInfoEnabled: false
     });
 }
+
+function testIHttpParamSerializerJQLikeProvider() {
+    let serializer: angular.IHttpParamSerializer;
+    serializer({
+        a: "b"
+    });
+}

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1916,4 +1916,12 @@ declare namespace angular {
         }
 
     }
+
+    /**
+     * $http params serializer that converts objects to strings
+     * see https://docs.angularjs.org/api/ng/service/$httpParamSerializer
+     */
+    interface IHttpParamSerializer {
+        (obj: Object): string;
+    }
 }


### PR DESCRIPTION
Hi, I added support `HttpParamSerializer` provider such as $httpParamSerializer, $httpParamSerializerJQLike or custom Serializer.
