### PR TITLE
Add type definitions for https://www.npmjs.com/package/cli

### DIFF
--- a/cli/cli-tests.ts
+++ b/cli/cli-tests.ts
@@ -1,0 +1,181 @@
+/// <reference path="./cli.d.ts" />
+
+import * as cli from "cli";
+
+// ========================================================================
+// Example: https://github.com/node-js-libs/cli/blob/master/examples/cat.js
+// ========================================================================
+
+var output_file = function(file: string) {
+    cli.withInput(file, function (line, sep, eof) {
+        if (!eof) {
+            cli.output(line + sep);
+        } else if (cli.args.length) {
+            output_file(cli.args.shift());
+        }
+    });
+};
+
+if (cli.args.length) {
+    output_file(cli.args.shift());
+}
+
+// ============================================================================
+// Example: https://github.com/node-js-libs/cli/blob/master/examples/command.js
+// ============================================================================
+
+cli.parse(null, ['install', 'test', 'edit', 'remove', 'uninstall', 'ls']);
+
+console.log('Command is: ' + cli.command);
+
+
+// ============================================================================
+// Example: https://github.com/node-js-libs/cli/blob/master/examples/echo.js
+// ============================================================================
+
+cli.parse({
+    newline:   ['n', 'Do not output the trailing newline'],
+    escape:    ['e', 'Enable interpretation of backslash escapes'],
+    separator: ['s', 'Separate arguments using this value', 'string', ' '],
+    output:    [false, 'Write to FILE rather than the console', 'file']
+});
+
+cli.main(function (args, options) {
+    var output = '', i: any, j: any, l: number, output_stream: NodeJS.WritableStream;
+
+    if (this.argc) {
+        if (options.escape) {
+            var replace: any = {'\\n':'\n','\\r':'\r','\\t':'\t','\\e':'\e','\\v':'\v','\\f':'\f','\\c':'\c','\\b':'\b','\\a':'\a','\\\\':'\\'};
+            var escape = function (str: string) {
+                str += '';
+                for (j in replace) {
+                    str = str.replace(i, replace[i]);
+                }
+                return str;
+            }
+            for (i = 0, l = this.argc; i < l; i++) {
+                args[i] = escape(args[i]);
+            }
+            options.separator = escape(options.separator);
+        }
+        output += args.join(options.separator);
+    }
+
+    if (!options.newline) {
+        output += '\n';
+    }
+
+    try {
+        if (options.output) {
+            output_stream = this.native.fs.createWriteStream(options.output)
+        } else {
+            output_stream = process.stdout;
+        }
+        output_stream.write(output);
+    } catch (e) {
+        this.fatal('Could not write to output stream');
+    }
+});
+
+
+// =========================================================================
+// Example: https://github.com/node-js-libs/cli/blob/master/examples/glob.js
+// =========================================================================
+
+cli.enable('glob');
+
+//Running `./glob.js *.js` will output a list of .js files in this directory
+console.log(cli.args);
+
+
+// ==============================================================================
+// Example: https://github.com/node-js-libs/cli/blob/master/examples/long_desc.js
+// ==============================================================================
+
+//You can (optionally) boost the width of output with:
+cli.width = 120;
+
+//You can also adjust the width of the options/command definitions
+cli.option_width = 25;
+
+var long_desc = 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s '
+              + 'standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make'
+              + ' a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, '
+              + 'remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing '
+              + 'Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions'
+              + ' of Lorem Ipsum.';
+
+cli.parse({
+    foo: ['f', long_desc]
+});
+
+
+// =============================================================================
+// Example: https://github.com/node-js-libs/cli/blob/master/examples/progress.js
+// =============================================================================
+
+var i = 0, interval = setInterval(function () {
+    cli.progress(++i / 100);
+    if (i === 100) {
+        clearInterval(interval);
+        cli.ok('Finished!');
+    }
+}, 50);
+
+
+// =========================================================================
+// Example: https://github.com/node-js-libs/cli/blob/master/examples/sort.js
+// =========================================================================
+
+var options = cli.parse({
+    numeric: ['n', 'Compare using a numeric sort'],
+    reverse: ['r', 'Reverse the results']
+});
+
+cli.withStdinLines(function (lines, newline) {
+    lines.sort(!options.numeric ? null : function (a, b) {
+        return parseInt(a) - parseInt(b);
+    });
+    if (options.reverse) {
+        lines.reverse();
+    }
+    this.output(lines.join(newline));
+});
+
+
+// ============================================================================
+// Example: https://github.com/node-js-libs/cli/blob/master/examples/spinner.js
+// ============================================================================
+
+cli.spinner('Working..');
+
+setTimeout(function () {
+    cli.spinner('Working.. done!', true); //End the spinner
+}, 3000);
+
+
+// ===========================================================================
+// Example: https://github.com/node-js-libs/cli/blob/master/examples/static.js
+// ===========================================================================
+
+cli.parse({
+    log:   ['l', 'Enable logging'],
+    port:  ['p', 'Listen on this port', 'number', 8080],
+    serve: [false, 'Serve static files from PATH', 'path', './public']
+});
+
+cli.main(function (args, options) {
+    var server: any, middleware: any = [];
+
+    if (options.log) {
+        this.debug('Enabling logging');
+        middleware.push(require('creationix/log')());
+    }
+
+    this.debug('Serving files from ' + options.serve);
+    middleware.push(require('creationix/static')('/', options.serve, 'index.html'));
+
+    server = this.createServer(middleware).listen(options.port);
+
+    this.ok('Listening on port ' + options.port);
+});

--- a/cli/cli.d.ts
+++ b/cli/cli.d.ts
@@ -1,0 +1,66 @@
+// Type definitions for cli v0.11.2
+// Project: https://www.npmjs.com/package/cli
+// Definitions by: Klaus Reimer <https://github.com/kayahr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module "cli" {
+    interface CLI {
+        app: string;
+        version: string;
+        argv: string[];
+        argc: number;
+        options: any;
+        args: string[];
+        command: string;
+        width: number;
+        option_width: number;
+        native: any;
+        output(message?: any, ...optionalParams: any[]): void;
+        exit(code: number): void;
+        no_color: boolean;
+        enable(...plugins: string[]): CLI;
+        disable(...plugins: string[]): CLI;
+        setArgv(argv: string | Array<any>, keepArg0?: boolean): void;
+        next(): string;
+        parse(opts?: { [long: string]: { 0: string | boolean, 1: string, 2?: string, 3?: any } },
+              commands?: { [name: string]: string } | string[]): any;
+        autocompleteCommand(command: string): string;
+        info(msg: string): void;
+        error(msg: string): void;
+        ok(msg: string): void;
+        debug(msg: string): void;
+        fatal(msg: string): void;
+        setApp(appName: string, version: string): CLI;
+        setApp(packageJson: string): CLI;
+        parsePackageJson(path?: string): void;
+        setUsage(usage: string): CLI;
+        getUsage(code?: number): void;
+        getOptError(expects: string, type: string): string;
+        getValue(defaultVal: string, validateFunc: (value: any) => any, errMsg: string): void;
+        getInt(defaultVal: number): number;
+        getDate(defaultVal: Date): Date;
+        getFloat(defaultVal: number): number;
+        getUrl(defautltVal: string, identifier?: string): string;
+        getEmail(defaultVal: string): string;
+        getIp(defaultVal: string): string;
+        getPath(defaultVal: string, identifier?: string): string;
+        getArrayValue<T>(arr: T[], defaultVal: T): T;
+        withStdin(callback: (data: string) => void): void;
+        withStdin(encoding: string, callback: (text: string) => void): void;
+        withStdinLines(callback: (lines: string[], newline: string) => void): void;
+        withInput(file: string, encoding: string, callback: (line: string, newline: string, eof: boolean) => void): void;
+        withInput(file: string, callback: (line: string, newline: string, eof: boolean) => void): void;
+        withInput(callback: (line: string, newline: string, eof: boolean) => void): void;
+        toType(object: any): string;
+        daemon(arg: string, callback: () => void): void;
+        main(callback: (args: string[], options: any) => void): void;
+        createServer(...args: any[]): any;
+        exec(cmd: string, callback?: (lines: string[]) => void, errback?: (err: any, stdout: string) => void): void;
+        progress(progress: number, decimals?: number, stream?: NodeJS.WritableStream): void;
+        spinner(prefix?: string | boolean, end?: boolean, stream?: NodeJS.WritableStream): void;
+    }
+    const cli: CLI;
+    export = cli;
+}


### PR DESCRIPTION
This pull requests adds type definitions for the [cli](https://www.npmjs.com/package/cli) library. The tests are created from the [official example programs](https://github.com/node-js-libs/cli/tree/master/examples)
