### PR TITLE
Improve GeoJSON generics

### DIFF
--- a/geojson/geojson-tests.ts
+++ b/geojson/geojson-tests.ts
@@ -54,7 +54,7 @@ var featureCollection: GeoJSON.FeatureCollection =  {
     }
 }
 
-var feature: GeoJSON.Feature = { 
+var feature: GeoJSON.Feature<GeoJSON.Polygon> = {
     type: "Feature",
     bbox: [-180.0, -90.0, 180.0, 90.0],
     geometry: {

--- a/geojson/geojson-tests.ts
+++ b/geojson/geojson-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./geojson.d.ts" />
 
-var featureCollection: GeoJSON.FeatureCollection =  { 
+var featureCollection: GeoJSON.FeatureCollection<any> =  {
     type: "FeatureCollection",
     features: [   
         { 

--- a/geojson/geojson.d.ts
+++ b/geojson/geojson.d.ts
@@ -90,9 +90,9 @@ declare namespace GeoJSON {
     /***
     * http://geojson.org/geojson-spec.html#feature-objects
     */
-    export interface Feature extends GeoJsonObject
+    export interface Feature<T extends GeometryObject> extends GeoJsonObject
     {
-        geometry: GeometryObject;
+        geometry: T;
         properties: any;
         id?: string;
     }
@@ -100,9 +100,9 @@ declare namespace GeoJSON {
     /***
     * http://geojson.org/geojson-spec.html#feature-collection-objects
     */
-    export interface FeatureCollection extends GeoJsonObject
+    export interface FeatureCollection<T extends GeometryObject> extends GeoJsonObject
     {
-        features: Feature[];
+        features: Feature<T>[];
     }
 
     /***

--- a/polyline/polyline.d.ts
+++ b/polyline/polyline.d.ts
@@ -8,7 +8,7 @@
 interface Polyline {
   decode(string: string, precision?: number): number[][];
   encode(coordinate: number[][], precision?: number): string;
-  fromGeoJSON(geojson: GeoJSON.LineString | GeoJSON.Feature, precision?: number): string;
+  fromGeoJSON(geojson: GeoJSON.LineString | GeoJSON.Feature<GeoJSON.LineString>, precision?: number): string;
 }
 
 declare var polyline: Polyline;

--- a/turf/turf-tests.ts
+++ b/turf/turf-tests.ts
@@ -441,11 +441,11 @@ var value = "oak";
 var filtered = turf.filter(features, key, value);
 
 // -- Test random --
-var points = turf.random('points', 100, {
+var randomPoints = turf.random('points', 100, {
   bbox: [-70, 40, -60, 60]
 });
 
-var points = turf.random('points', 100, {
+var randomPoints = turf.random('points', 100, {
   bbox: [-70, 40, -60, 60],
   num_vertices: 2,
   max_radial_length: 10
@@ -455,7 +455,7 @@ var points = turf.random('points', 100, {
 var filtered = turf.remove(points, 'marker-color', '#00f');
 
 // -- Test sample --
-var points = turf.random('points', 1000);
+var randomPoints = turf.random('points', 1000);
 var sample = turf.sample(points, 10);
 
 ///////////////////////////////////////////

--- a/turf/turf.d.ts
+++ b/turf/turf.d.ts
@@ -18,7 +18,7 @@ declare namespace turf {
     * @param aggregations An array of aggregation objects
     * @returns Polygons with properties listed based on outField values in aggregations
     */
-    function aggregate(polygons: GeoJSON.FeatureCollection, points: GeoJSON.FeatureCollection, aggregations: Array<{aggregation: string, inField: string, outField: string}>): GeoJSON.FeatureCollection;
+    function aggregate(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, aggregations: Array<{aggregation: string, inField: string, outField: string}>): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     /**
     * Calculates the average value of a field for a set of points within a set of polygons.
@@ -28,7 +28,7 @@ declare namespace turf {
     * @param outField The field in polygons to put results of the averages
     * @returns Polygons with the value of outField set to the calculated averages
     */
-    function average(polygons: GeoJSON.FeatureCollection, points: GeoJSON.FeatureCollection, field: string, outField: string): GeoJSON.FeatureCollection;
+    function average(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, field: string, outField: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     /**
     * Takes a set of points and a set of polygons and calculates the number of points that fall within the set of polygons.
@@ -37,7 +37,7 @@ declare namespace turf {
     * @param countField A field to append to the attributes of the Polygon features representing Point counts
     * @returns Polygons with countField appended
     */
-    function count(polygons: GeoJSON.FeatureCollection, points: GeoJSON.FeatureCollection, countField: string): GeoJSON.FeatureCollection;
+    function count(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, countField: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     /**
     * Calculates the standard deviation value of a field for a set of points within a set of polygons.
@@ -47,7 +47,7 @@ declare namespace turf {
     * @param outField The field to append to polygons representing deviation
     * @returns Polygons with appended field representing deviation
     */
-    function deviation(polygons: GeoJSON.FeatureCollection, points: GeoJSON.FeatureCollection, inField: string, outField: string): GeoJSON.FeatureCollection;
+    function deviation(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, inField: string, outField: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     /**
     * Calculates the maximum value of a field for a set of points within a set of polygons.
@@ -57,7 +57,7 @@ declare namespace turf {
     * @param outField The field in which to store results
     * @returns Polygons with properties listed as outField values
     */
-    function max(polygons: GeoJSON.FeatureCollection, points: GeoJSON.FeatureCollection, inField: string, outField: string): GeoJSON.FeatureCollection;
+    function max(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, inField: string, outField: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     /**
     * Calculates the median value of a field for a set of points within a set of polygons.
@@ -67,7 +67,7 @@ declare namespace turf {
     * @param outField The field in which to store results
     * @returns Polygons with properties listed as outField values
     */
-    function median(polygons: GeoJSON.FeatureCollection, points: GeoJSON.FeatureCollection, inField: string, outField: string): GeoJSON.FeatureCollection;
+    function median(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, inField: string, outField: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     /**
     * Calculates the minimum value of a field for a set of points within a set of polygons.
@@ -77,7 +77,7 @@ declare namespace turf {
     * @param outField The field in which to store results
     * @returns Polygons with properties listed as outField values
     */
-    function min(polygons: GeoJSON.FeatureCollection, points: GeoJSON.FeatureCollection, inField: string, outField: string): GeoJSON.FeatureCollection;
+    function min(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, inField: string, outField: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     /**
     * Calculates the sum of a field for a set of points within a set of polygons.
@@ -87,7 +87,7 @@ declare namespace turf {
     * @param outField The field in which to store results
     * @returns Polygons with properties listed as outField
     */
-    function sum(polygons: GeoJSON.FeatureCollection, points: GeoJSON.FeatureCollection, inField: string, outField: string): GeoJSON.FeatureCollection;
+    function sum(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, inField: string, outField: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     /**
     * Calculates the variance value of a field for a set of points within a set of polygons.
@@ -97,7 +97,7 @@ declare namespace turf {
     * @param outField The field in which to store results
     * @returns Polygons with properties listed as outField
     */
-    function variance(polygons: GeoJSON.FeatureCollection, points: GeoJSON.FeatureCollection, inField: string, outField: string): GeoJSON.FeatureCollection;
+    function variance(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, inField: string, outField: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     //////////////////////////////////////////////////////
     // Measurement
@@ -110,21 +110,21 @@ declare namespace turf {
     * @param [units=miles] 'miles', 'kilometers', 'radians' or 'degrees'
     * @returns Point along the line
     */
-    function along(line: GeoJSON.Feature, distance: number, units?: string): GeoJSON.Feature;
+    function along(line: GeoJSON.Feature<GeoJSON.LineString>, distance: number, units?: string): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
     * Takes one or more features and returns their area in square meters.
     * @param input Input features
     * @returns Area in square meters
     */
-    function area(input: GeoJSON.Feature | GeoJSON.FeatureCollection): number;
+    function area(input: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): number;
 
     /**
     * Takes a bbox and returns an equivalent polygon.
     * @param bbox An Array of bounding box coordinates in the form: [xLow, yLow, xHigh, yHigh]
     * @returns A Polygon representation of the bounding box
     */
-    function bboxPolygon(bbox: Array<number>): GeoJSON.Feature;
+    function bboxPolygon(bbox: Array<number>): GeoJSON.Feature<GeoJSON.Polygon>;
 
     /**
     * Takes two points and finds the geographic bearing between them.
@@ -132,14 +132,14 @@ declare namespace turf {
     * @param end Ending point
     * @returns Bearing in decimal degrees
     */
-    function bearing(start: GeoJSON.Feature, end: GeoJSON.Feature): number;
+    function bearing(start: GeoJSON.Feature<GeoJSON.Point>, end: GeoJSON.Feature<GeoJSON.Point>): number;
 
     /**
     * Takes a FeatureCollection and returns the absolute center point of all features.
     * @param features Input features
     * @returns A Point feature at the absolute center point of all input features
     */
-    function center(features: GeoJSON.FeatureCollection): GeoJSON.Feature;
+    function center(features: GeoJSON.FeatureCollection<any>): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
     * Takes one or more features and calculates the centroid using the arithmetic mean of all vertices.
@@ -147,7 +147,7 @@ declare namespace turf {
     * @param features Input features
     * @returns The centroid of the input features
     */
-    function centroid(features: GeoJSON.Feature | GeoJSON.FeatureCollection): GeoJSON.Feature;
+    function centroid(features: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
     * Takes a Point and calculates the location of a destination point given a distance in degrees, radians, miles, or kilometers; and bearing in degrees.
@@ -158,7 +158,7 @@ declare namespace turf {
     * @param units 'miles', 'kilometers', 'radians', or 'degrees'
     * @returns Destination point
     */
-    function destination(start: GeoJSON.Feature, distance: number, bearing: number, units: string): GeoJSON.Feature;
+    function destination(start: GeoJSON.Feature<GeoJSON.Point>, distance: number, bearing: number, units: string): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
     * Calculates the distance between two points in degress, radians, miles, or kilometers.
@@ -168,21 +168,21 @@ declare namespace turf {
     * @param [units=kilometers] 'miles', 'kilometers', 'radians', or 'degrees'
     * @returns Distance between the two points
     */
-    function distance(from: GeoJSON.Feature, to: GeoJSON.Feature, units?: string): number;
+    function distance(from: GeoJSON.Feature<GeoJSON.Point>, to: GeoJSON.Feature<GeoJSON.Point>, units?: string): number;
 
     /**
     * Takes any number of features and returns a rectangular Polygon that encompasses all vertices.
     * @param fc Input features
     * @returns A rectangular Polygon feature that encompasses all vertices
     */
-    function envelope(fc: GeoJSON.FeatureCollection): GeoJSON.Feature;
+    function envelope(fc: GeoJSON.FeatureCollection<any>): GeoJSON.Feature<GeoJSON.Polygon>;
 
     /**
     * Takes a set of features, calculates the extent of all input features, and returns a bounding box.
     * @param input Input features
     * @returns The bounding box of input given as an array in WSEN order (west, south, east, north)
     */
-    function extent(input: GeoJSON.Feature | GeoJSON.FeatureCollection): Array<number>;
+    function extent(input: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): Array<number>;
 
     /**
     * Takes a line and measures its length in the specified units.
@@ -190,7 +190,7 @@ declare namespace turf {
     * @param units 'miles', 'kilometers', 'radians', or 'degrees'
     * @returns Length of the input line
     */
-    function lineDistance(line: GeoJSON.Feature, units: string): number;
+    function lineDistance(line: GeoJSON.Feature<GeoJSON.LineString>, units: string): number;
 
     /**
     * Takes two points and returns a point midway between them.
@@ -198,7 +198,7 @@ declare namespace turf {
     * @param pt2 Second point
     * @returns A point midway between pt1 and pt2
     */
-    function midpoint(pt1: GeoJSON.Feature, pt2: GeoJSON.Feature): GeoJSON.Feature;
+    function midpoint(pt1: GeoJSON.Feature<GeoJSON.Point>, pt2: GeoJSON.Feature<GeoJSON.Point>): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
     * Takes a feature and returns a Point guaranteed to be on the surface of the feature. Given a Polygon, the point will be in the area of the polygon.
@@ -206,7 +206,7 @@ declare namespace turf {
     * @param input Any feature or set of features
     * @returns A point on the surface of input
     */
-    function pointOnSurface(input: GeoJSON.Feature | GeoJSON.FeatureCollection): GeoJSON.Feature;
+    function pointOnSurface(input: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): GeoJSON.Feature<any>;
 
     /**
     * Takes a bounding box and returns a new bounding box with a size expanded or contracted by a factor of X.
@@ -235,7 +235,7 @@ declare namespace turf {
     * @param [sharpness=0.85] A measure of how curvy the path should be between splines
     * @returns Curved line
     */
-    function bezier(line: GeoJSON.Feature, resolution?: number, sharpness?: number): GeoJSON.Feature;
+    function bezier(line: GeoJSON.Feature<GeoJSON.LineString>, resolution?: number, sharpness?: number): GeoJSON.Feature<GeoJSON.LineString>;
 
     /**
     * Calculates a buffer for input features for a given radius. Units supported are miles, kilometers, and degrees.
@@ -244,7 +244,7 @@ declare namespace turf {
     * @param units 'miles', 'kilometers', 'radians', or 'degrees'
     * @returns Buffered features
     */
-    function buffer(feature: GeoJSON.Feature | GeoJSON.FeatureCollection, distance: number, units: string): GeoJSON.Feature | GeoJSON.FeatureCollection;
+    function buffer(feature: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>, distance: number, units: string): GeoJSON.FeatureCollection<GeoJSON.Polygon> | GeoJSON.FeatureCollection<GeoJSON.MultiPolygon> | GeoJSON.Polygon | GeoJSON.MultiPolygon;
 
     /**
     * Takes a set of points and returns a concave hull polygon. Internally, this implements a Monotone chain algorithm.
@@ -253,14 +253,14 @@ declare namespace turf {
     * @param units Used for maxEdge distance (miles or kilometers)
     * @returns A concave hull
     */
-    function concave(points: GeoJSON.FeatureCollection, maxEdge: number, units: string): GeoJSON.Feature;
+    function concave(points: GeoJSON.FeatureCollection<GeoJSON.Point>, maxEdge: number, units: string): GeoJSON.Feature<GeoJSON.Polygon>;
 
     /**
     * Takes a set of points and returns a convex hull polygon. Internally this uses the convex-hull module that implements a monotone chain hull.
     * @param input Input points
     * @returns A convex hull
     */
-    function convex(input: GeoJSON.FeatureCollection): GeoJSON.Feature;
+    function convex(input: GeoJSON.FeatureCollection<GeoJSON.Point>): GeoJSON.Feature<GeoJSON.Polygon>;
 
     /**
     * Finds the difference between two polygons by clipping the second polygon from the first.
@@ -268,7 +268,7 @@ declare namespace turf {
     * @param poly2 Polygon feature to difference from poly1
     * @returns A Polygon feature showing the area of poly1 excluding the area of poly2
     */
-    function difference(poly1: GeoJSON.Feature, poly2: GeoJSON.Feature): GeoJSON.Feature;
+    function difference(poly1: GeoJSON.Feature<GeoJSON.Polygon>, poly2: GeoJSON.Feature<GeoJSON.Polygon>): GeoJSON.Feature<GeoJSON.Polygon>;
 
     /**
     * Takes two polygons and finds their intersection.
@@ -279,7 +279,7 @@ declare namespace turf {
     * if poly1 and poly2 do not overlap, returns undefined;
     * if poly1 and poly2 share a border, a MultiLineString of the locations where their borders are shared
     */
-    function intersect(poly1: GeoJSON.Feature, poly2: GeoJSON.Feature): GeoJSON.Feature;
+    function intersect(poly1: GeoJSON.Feature<GeoJSON.Polygon>, poly2: GeoJSON.Feature<GeoJSON.Polygon>): GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiLineString> | typeof undefined;
 
     /**
     * Takes a set of polygons and returns a single merged polygon feature.
@@ -287,7 +287,7 @@ declare namespace turf {
     * @param fc Input polygons
     * @returns Merged polygon or multipolygon
     */
-    function merge(fc: GeoJSON.FeatureCollection): GeoJSON.Feature;
+    function merge(fc: GeoJSON.FeatureCollection<GeoJSON.Polygon>): GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>;
 
     /**
     * Takes a LineString or Polygon and returns a simplified version.
@@ -297,7 +297,7 @@ declare namespace turf {
     * @param highQuality Whether or not to spend more time to create a higher-quality simplification with a different algorithm
     * @returns A simplified feature
     */
-    function simplify(feature: GeoJSON.Feature | GeoJSON.FeatureCollection | GeoJSON.GeometryCollection, tolerance: number, highQuality: boolean): GeoJSON.Feature | GeoJSON.FeatureCollection | GeoJSON.GeometryCollection;
+    function simplify(feature: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any> | GeoJSON.GeometryCollection, tolerance: number, highQuality: boolean): GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any> | GeoJSON.GeometryCollection;
 
     /**
     * Takes two polygons and returns a combined polygon.
@@ -306,7 +306,7 @@ declare namespace turf {
     * @param poly2 Another input polygon
     * @returns A combined Polygon or MultiPolygon feature
     */
-    function union(poly1: GeoJSON.Feature, poly2: GeoJSON.Feature): GeoJSON.Feature;
+    function union(poly1: GeoJSON.Feature<GeoJSON.Polygon>, poly2: GeoJSON.Feature<GeoJSON.Polygon>): GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>;
 
     //////////////////////////////////////////////////////
     // Misc
@@ -317,28 +317,28 @@ declare namespace turf {
     * @param fc A FeatureCollection of any type
     * @returns A FeatureCollection of corresponding type to input
     */
-    function combine(fc: GeoJSON.FeatureCollection): GeoJSON.FeatureCollection;
+    function combine(fc: GeoJSON.FeatureCollection<any>): GeoJSON.FeatureCollection<any>;
 
     /**
     * Takes a feature or set of features and returns all positions as points.
     * @param input Input features
     * @returns Points representing the exploded input features
     */
-    function explode(input: GeoJSON.Feature | GeoJSON.FeatureCollection): GeoJSON.FeatureCollection;
+    function explode(input: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): GeoJSON.FeatureCollection<GeoJSON.Point>;
 
     /**
     * Takes input features and flips all of their coordinates from [x, y] to [y, x].
     * @param input Input features
     * @returns A feature or set of features of the same type as input with flipped coordinates
     */
-    function flip(input: GeoJSON.Feature | GeoJSON.FeatureCollection): GeoJSON.Feature | GeoJSON.FeatureCollection;
+    function flip(input: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>;
 
     /**
     * Takes a polygon and returns points at all self-intersections.
     * @param polygon Input polygon
     * @returns Self-intersections
     */
-    function kinks(polygon: GeoJSON.Feature): GeoJSON.FeatureCollection;
+    function kinks(polygon: GeoJSON.Feature<GeoJSON.Polygon>): GeoJSON.FeatureCollection<GeoJSON.Point>;
 
     /**
     * Takes a line, a start Point, and a stop point and returns the line in between those points.
@@ -347,7 +347,7 @@ declare namespace turf {
     * @param line Line to slice
     * @returns Sliced line
     */
-    function lineSlice(point1: GeoJSON.Feature, point2: GeoJSON.Feature, line: GeoJSON.Feature): GeoJSON.Feature;
+    function lineSlice(point1: GeoJSON.Feature<GeoJSON.Point>, point2: GeoJSON.Feature<GeoJSON.Point>, line: GeoJSON.Feature<GeoJSON.LineString>): GeoJSON.Feature<GeoJSON.LineString>;
 
     /**
     * Takes a Point and a LineString and calculates the closest Point on the LineString.
@@ -355,7 +355,7 @@ declare namespace turf {
     * @param point Point to snap from
     * @returns Closest point on the line to point
     */
-    function pointOnLine(line: GeoJSON.Feature, point: GeoJSON.Feature): GeoJSON.Feature;
+    function pointOnLine(line: GeoJSON.Feature<GeoJSON.LineString>, point: GeoJSON.Feature<GeoJSON.Point>): GeoJSON.Feature<GeoJSON.Point>;
 
     //////////////////////////////////////////////////////
     // Helper
@@ -366,7 +366,7 @@ declare namespace turf {
     * @param features Input features
     * @returns A FeatureCollection of input features
     */
-    function featurecollection(features: Array<GeoJSON.Feature>): GeoJSON.FeatureCollection;
+    function featurecollection(features: Array<GeoJSON.Feature<any>>): GeoJSON.FeatureCollection<any>;
 
     /**
     * Creates a LineString based on a coordinate array. Properties can be added optionally.
@@ -374,7 +374,7 @@ declare namespace turf {
     * @param [properties] An Object of key-value pairs to add as properties
     * @returns A LineString feature
     */
-    function linestring(coordinates: Array<Array<number>>, properties?: any): GeoJSON.Feature;
+    function linestring(coordinates: Array<Array<number>>, properties?: any): GeoJSON.Feature<GeoJSON.LineString>;
 
     /**
     * Takes coordinates and properties (optional) and returns a new Point feature.
@@ -382,7 +382,7 @@ declare namespace turf {
     * @param [properties] An Object of key-value pairs to add as properties
     * @returns A Point feature
     */
-    function point(coordinates: Array<number>, properties?: any): GeoJSON.Feature;
+    function point(coordinates: Array<number>, properties?: any): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
     * Takes an array of LinearRings and optionally an Object with properties and returns a Polygon feature.
@@ -390,7 +390,7 @@ declare namespace turf {
     * @param [properties] An Object of key-value pairs to add as properties
     * @returns A Polygon feature
     */
-    function polygon(rings: Array<Array<Array<number>>>, properties?: any): GeoJSON.Feature;
+    function polygon(rings: Array<Array<Array<number>>>, properties?: any): GeoJSON.Feature<GeoJSON.Polygon>;
 
     //////////////////////////////////////////////////////
     // Data
@@ -403,7 +403,7 @@ declare namespace turf {
     * @param value The value of that property on which to filter
     * @returns A filtered collection with only features that match input key and value
     */
-    function filter(features: GeoJSON.FeatureCollection, key: string, value: string): GeoJSON.FeatureCollection;
+    function filter(features: GeoJSON.FeatureCollection<any>, key: string, value: string): GeoJSON.FeatureCollection<any>;
 
     /**
     * Generates random GeoJSON data, including Points and Polygons, for testing and experimentation.
@@ -415,7 +415,7 @@ declare namespace turf {
     *   - The total number of decimal degrees longitude or latitude that a polygon can extent outwards to from its center. Default is 10.
     * @returns Generated random features
     */
-    function random(type?: string, count?: number, options?: {bbox?: Array<number>; num_vertices?: number; max_radial_length?: number;}): GeoJSON.FeatureCollection;
+    function random(type?: string, count?: number, options?: {bbox?: Array<number>; num_vertices?: number; max_radial_length?: number;}): GeoJSON.FeatureCollection<any>;
 
     /**
     * Takes a FeatureCollection of any type, a property, and a value and returns a FeatureCollection with features matching that property-value pair removed.
@@ -424,7 +424,7 @@ declare namespace turf {
     * @param value The value to remove
     * @returns The resulting FeatureCollection without features that match the property-value pair
     */
-    function remove(features: GeoJSON.FeatureCollection, property: string, value: string): GeoJSON.FeatureCollection;
+    function remove(features: GeoJSON.FeatureCollection<any>, property: string, value: string): GeoJSON.FeatureCollection<any>;
 
     /**
     * Takes a FeatureCollection and returns a FeatureCollection with given number of features at random.
@@ -432,7 +432,7 @@ declare namespace turf {
     * @param n Number of features to select
     * @returns A FeatureCollection with n features
     */
-    function sample(features: GeoJSON.FeatureCollection, n: number): GeoJSON.FeatureCollection;
+    function sample(features: GeoJSON.FeatureCollection<any>, n: number): GeoJSON.FeatureCollection<any>;
 
     //////////////////////////////////////////////////////
     // Interpolation
@@ -445,7 +445,7 @@ declare namespace turf {
     * @param units Used in calculating cellWidth ('miles' or 'kilometers')
     * @returns A hexagonal grid
     */
-    function hexGrid(bbox: Array<number>, cellWidth: number, units: string): GeoJSON.FeatureCollection;
+    function hexGrid(bbox: Array<number>, cellWidth: number, units: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     /**
     * Takes points with z-values and an array of value breaks and generates isolines.
@@ -455,7 +455,7 @@ declare namespace turf {
     * @param breaks Where to draw contours
     * @returns Isolines
     */
-    function isolines(points: GeoJSON.FeatureCollection, z: string, resolution: number, breaks: Array<number>): GeoJSON.FeatureCollection;
+    function isolines(points: GeoJSON.FeatureCollection<GeoJSON.Point>, z: string, resolution: number, breaks: Array<number>): GeoJSON.FeatureCollection<GeoJSON.LineString>;
 
     /**
     * Takes a triangular plane as a Polygon and a Point within that triangle and returns the z-value at that point.
@@ -464,7 +464,7 @@ declare namespace turf {
     * @param triangle A Polygon feature with three vertices
     * @returns The z-value for interpolatedPoint
     */
-    function planepoint(interpolatedPoint: GeoJSON.Feature, triangle: GeoJSON.Feature): number;
+    function planepoint(interpolatedpoint: GeoJSON.Feature<GeoJSON.Point>, triangle: GeoJSON.Feature<GeoJSON.Polygon>): number;
 
     /**
     * Takes a bounding box and a cell depth and returns a set of points in a grid.
@@ -473,7 +473,7 @@ declare namespace turf {
     * @param units Used in calculating cellWidth ('miles' or 'kilometers')
     * @returns Grid of points
     */
-    function pointGrid(extent: Array<number>, cellWidth: number, units: string): GeoJSON.FeatureCollection;
+    function pointGrid(extent: Array<number>, cellWidth: number, units: string): GeoJSON.FeatureCollection<GeoJSON.Point>;
 
     /**
     * Takes a bounding box and a cell depth and returns a set of square polygons in a grid.
@@ -482,7 +482,7 @@ declare namespace turf {
     * @param units Used in calculating cellWidth ('miles' or 'kilometers')
     * @returns Grid of polygons
     */
-    function squareGrid(extent: Array<number>, cellWidth: number, units: string): GeoJSON.FeatureCollection;
+    function squareGrid(extent: Array<number>, cellWidth: number, units: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     /**
     * Takes a set of points and the name of a z-value property and creates a Triangulated Irregular Network, or a TIN for short, returned as a collection of Polygons.
@@ -492,7 +492,7 @@ declare namespace turf {
     * @param [propertyName] Name of the property from which to pull z values This is optional: if not given, then there will be no extra data added to the derived triangles.
     * @returns TIN output
     */
-    function tin(points: GeoJSON.FeatureCollection, propertyName?: string): GeoJSON.FeatureCollection;
+    function tin(points: GeoJSON.FeatureCollection<GeoJSON.Point>, propertyName?: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     /**
     * Takes a bounding box and a cell depth and returns a set of triangular polygons in a grid.
@@ -501,7 +501,7 @@ declare namespace turf {
     * @param units Used in calculating cellWidth ('miles' or 'kilometers')
     * @returns Grid of triangles
     */
-    function triangleGrid(extent: Array<number>, cellWidth: number, units: string): GeoJSON.FeatureCollection;
+    function triangleGrid(extent: Array<number>, cellWidth: number, units: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     //////////////////////////////////////////////////////
     // Joins
@@ -514,7 +514,7 @@ declare namespace turf {
     * @param polygon Input polygon or multipolygon
     * @returns true if the Point is inside the Polygon; false if the Point is not inside the Polygon
     */
-    function inside(point: GeoJSON.Feature, polygon: GeoJSON.Feature): boolean;
+    function inside(point: GeoJSON.Feature<GeoJSON.Point>, polygon: GeoJSON.Feature<GeoJSON.Polygon>): boolean;
 
     /**
     * Takes a set of points and a set of polygons and performs a spatial join.
@@ -524,7 +524,7 @@ declare namespace turf {
     * @param containingPolyId Property in points in which to store joined property from polygons
     * @returns Points with containingPolyId property containing values from polyId
     */
-    function tag(points: GeoJSON.FeatureCollection, polygons: GeoJSON.FeatureCollection, polyId: string, containingPolyId: string): GeoJSON.FeatureCollection;
+    function tag(points: GeoJSON.FeatureCollection<GeoJSON.Point>, polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, polyId: string, containingPolyId: string): GeoJSON.FeatureCollection<GeoJSON.Point>;
 
     /**
     * Takes a set of points and a set of polygons and returns the points that fall within the polygons.
@@ -532,7 +532,7 @@ declare namespace turf {
     * @param polygons Input polygons
     * @returns Points that land within at least one polygon
     */
-    function within(points: GeoJSON.FeatureCollection, polygons: GeoJSON.FeatureCollection): GeoJSON.FeatureCollection;
+    function within(points: GeoJSON.FeatureCollection<GeoJSON.Point>, polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>): GeoJSON.FeatureCollection<GeoJSON.Point>;
 
     //////////////////////////////////////////////////////
     // Classification
@@ -545,7 +545,7 @@ declare namespace turf {
     * @param numberOfBreaks Number of classes in which to group the data
     * @returns The break number for each class plus the minimum and maximum values
     */
-    function jenks(input: GeoJSON.FeatureCollection, field: string, numberOfBreaks: number): Array<number>;
+    function jenks(input: GeoJSON.FeatureCollection<any>, field: string, numberOfBreaks: number): Array<number>;
 
     /**
     * Takes a reference point and a set of points and returns the point from the set closest to the reference.
@@ -553,7 +553,7 @@ declare namespace turf {
     * @param against Input point set
     * @returns The closest point in the set to the reference point
     */
-    function nearest(point: GeoJSON.Feature, against: GeoJSON.FeatureCollection): GeoJSON.Feature;
+    function nearest(point: GeoJSON.Feature<GeoJSON.Point>, against: GeoJSON.FeatureCollection<GeoJSON.Point>): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
     * Takes a FeatureCollection, a property name, and a set of percentiles and returns a quantile array.
@@ -562,7 +562,7 @@ declare namespace turf {
     * @param percentiles An Array of percentiles on which to calculate quantile values
     * @returns An array of the break values
     */
-    function quantile(input: GeoJSON.FeatureCollection, field: string, percentiles: Array<number>): Array<number>;
+    function quantile(input: GeoJSON.FeatureCollection<any>, field: string, percentiles: Array<number>): Array<number>;
 
     /**
     * Takes a FeatureCollection, an input field, an output field, and an array of translations and outputs an identical FeatureCollection with the output field property populated.
@@ -572,5 +572,5 @@ declare namespace turf {
     * @param translations An array of translations
     * @returns A FeatureCollection with identical geometries to input but with outField populated.
     */
-    function reclass(input: GeoJSON.FeatureCollection, inField: string, outField: string, translations: Array<any>): GeoJSON.FeatureCollection;
+    function reclass(input: GeoJSON.FeatureCollection<any>, inField: string, outField: string, translations: Array<any>): GeoJSON.FeatureCollection<any>;
 }


### PR DESCRIPTION
GeoJSON has generics-friendly data structures, so I want to improve type accuracy.
### GeoJSON

The [Feature](http://geojson.org/geojson-spec.html#feature-objects) type has one of [Geometry Objects](http://geojson.org/geojson-spec.html#geometry-objects), so Feature can be expressed as generics.
### TurfJS

TurfJS documentation uses generics-like expression (ex. [turf-aggregate](http://turfjs.org/static/docs/module-turf_aggregate.html)). It should be implemented as generics.

cf. [API Documentation](http://turfjs.org/static/docs/)
### Polyline

Similar to turf, according to [document](https://github.com/mapbox/polyline/blob/master/API.md), 

> Takes a GeoJSON LineString feature and returns an encoded string.

so, `polyline.fromGeoJSON` needs `Feature<LineString>`.

cf. [library code](https://github.com/mapbox/polyline/blob/461a3843dfa4e0c50ca1b2d37049f491f3502648/src/polyline.js#L126-L130)
