### PR TITLE
Select2 - Changed placeholder to support IdTextPair

### DIFF
--- a/select2/select2-tests.ts
+++ b/select2/select2-tests.ts
@@ -9,6 +9,9 @@ $("#e2").select2({
 $("#e2_2").select2({
     placeholder: "Select a State"
 });
+$("#e2_3").select2({
+    placeholder: { id: "1", text: "Select options" }
+});
 $("#e3").select2({
     minimumInputLength: 2
 });

--- a/select2/select2.d.ts
+++ b/select2/select2.d.ts
@@ -42,7 +42,7 @@ interface Select2Options {
     minimumInputLength?: number;
     minimumResultsForSearch?: number;
     maximumSelectionSize?: number;
-    placeholder?: string;
+    placeholder?: string | IdTextPair;
     separator?: string;
     allowClear?: boolean;
     multiple?: boolean;


### PR DESCRIPTION
Added support for IdTextPair for placeholder, since it was only usable by string
https://select2.github.io/options.html#can-i-use-an-option-without-a-blank-value-as-my-placeholder
