### PR TITLE
Webpack: Make Resolve.alias optional

### DIFF
--- a/webpack/webpack-tests.ts
+++ b/webpack/webpack-tests.ts
@@ -247,6 +247,12 @@ configuration = {
     devtool: "#inline-source-map"
 };
 
+configuration = {
+  resolve: {
+    root: __dirname
+  }
+};
+
 loader = {
     test: /\.jsx$/,
     include: [

--- a/webpack/webpack.d.ts
+++ b/webpack/webpack.d.ts
@@ -147,7 +147,7 @@ declare module "webpack" {
 
         interface Resolve {
             /** Replace modules by other modules or paths. */
-            alias: { [key: string]: string; };
+            alias?: { [key: string]: string; };
             /**
              * The directory (absolute path) that contains your modules.
              * May also be an array of directories.
@@ -536,4 +536,3 @@ declare module "webpack" {
     //export default webpack;
     export = webpack;
 }
-


### PR DESCRIPTION
The [alias](https://webpack.github.io/docs/configuration.html#resolve-alias) property on the Resolve interface was incorrectly declared
as required. This commit makes it optional.

Files changed:
- webpack/webpack.d.ts: Set Resolve.alias to optional
- webpack/webpack-tests.ts: Add new test which would have failed
  but now passes
