### PR TITLE
add _.invoke to existing lodash definition

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -4366,9 +4366,12 @@ namespace TestKeyBy {
 
 //_.invoke
 namespace TestInvoke {
+    let boolArray: boolean[] = [true, false];
+
     let nestedDict: _.Dictionary<Array<number>> = {
         a: [0, 1, 2]
     }
+
     let numDict: _.Dictionary<number> = {
         a: 1,
         b: 2,
@@ -4376,33 +4379,71 @@ namespace TestInvoke {
         d: 4
     }
 
-    let result: any;
-    result = _.invoke<number>(numDict, "a.toString");
-    result = _.invoke<number>(numDict, "a.toString", 2);
-    result = _.invoke<number>(numDict, ["a", "toString"]);
-    result = _.invoke<number>(numDict, ["a", "toString"], 2);
-    result = _.invoke<Array<number>>(nestedDict, ["a[0].toString"]);
-    result = _.invoke<Array<number>>(nestedDict, ["a[0].toString"], 2);
-    result = _.invoke<Array<number>>(nestedDict, ["a", 0, "toString"]);
-    result = _.invoke<Array<number>>(nestedDict, ["a", 0, "toString"], 2);
+    let result: string;
 
-    result = _(numDict).invoke("a.toString");
-    result = _(numDict).invoke("a.toString", 2);
-    result = _(numDict).invoke(["a", "toString"]);
-    result = _(numDict).invoke(["a", "toString"], 2);
-    result = _(nestedDict).invoke("a[0].toString");
-    result = _(nestedDict).invoke("a[0].toString", 2);
-    result = _(nestedDict).invoke(["a", 0, "toString"]);
-    result = _(nestedDict).invoke(["a", 0, "toString"], 2);
+    result = _.invoke<string>(boolArray, "[1]");
+    result = _.invoke<string>(boolArray, "[1]", 2);
+    result = _.invoke<string>(boolArray, [1, "toString"]);
+    result = _.invoke<string>(boolArray, [1, "toString"], 2);
 
-    result = _(numDict).chain().invoke("a.toString");
-    result = _(numDict).chain().invoke("a.toString", 2);
-    result = _(numDict).chain().invoke(["a", "toString"]);
-    result = _(numDict).chain().invoke(["a", "toString"], 2);
-    result = _(nestedDict).chain().invoke("a[0].toString");
-    result = _(nestedDict).chain().invoke("a[0].toString", 2);
-    result = _(nestedDict).chain().invoke(["a", 0, "toString"]);
-    result = _(nestedDict).chain().invoke(["a", 0, "toString"], 2);
+    result = _.invoke<boolean, string>(boolArray, "[1]");
+    result = _.invoke<boolean, string>(boolArray, "[1]", 2);
+    result = _.invoke<boolean, string>(boolArray, [1, "toString"]);
+    result = _.invoke<boolean, string>(boolArray, [1, "toString"], 2);
+
+    result = _.invoke<string>(numDict, "a.toString");
+    result = _.invoke<string>(numDict, "a.toString", 2);
+    result = _.invoke<string>(numDict, ["a", "toString"]);
+    result = _.invoke<string>(numDict, ["a", "toString"], 2);
+
+    result = _.invoke<number, string>(numDict, "a.toString");
+    result = _.invoke<number, string>(numDict, "a.toString", 2);
+    result = _.invoke<number, string>(numDict, ["a", "toString"]);
+    result = _.invoke<number, string>(numDict, ["a", "toString"], 2);
+
+    result = _.invoke<string>(nestedDict, ["a[0].toString"]);
+    result = _.invoke<string>(nestedDict, ["a[0].toString"], 2);
+    result = _.invoke<string>(nestedDict, ["a", 0, "toString"]);
+    result = _.invoke<string>(nestedDict, ["a", 0, "toString"], 2);
+
+    result = _.invoke<Array<number>, string>(nestedDict, ["a[0].toString"]);
+    result = _.invoke<Array<number>, string>(nestedDict, ["a[0].toString"], 2);
+    result = _.invoke<Array<number>, string>(nestedDict, ["a", 0, "toString"]);
+    result = _.invoke<Array<number>, string>(nestedDict, ["a", 0, "toString"], 2);
+
+    result = _(boolArray).invoke<string>("[1]");
+    result = _(boolArray).invoke<string>("[1]", 2);
+    result = _(boolArray).invoke<string>([1, "toString"]);
+    result = _(boolArray).invoke<string>([1, "toString"], 2);
+
+    result = _(numDict).invoke<string>("a.toString");
+    result = _(numDict).invoke<string>("a.toString", 2);
+    result = _(numDict).invoke<string>(["a", "toString"]);
+    result = _(numDict).invoke<string>(["a", "toString"], 2);
+
+    result = _(nestedDict).invoke<string>("a[0].toString");
+    result = _(nestedDict).invoke<string>("a[0].toString", 2);
+    result = _(nestedDict).invoke<string>(["a", 0, "toString"]);
+    result = _(nestedDict).invoke<string>(["a", 0, "toString"], 2);
+
+    {
+        let result: _.LoDashExplicitWrapper<string>;
+
+        result = _(boolArray).chain().invoke<_.LoDashExplicitWrapper<string>>("[1]");
+        result = _(boolArray).chain().invoke<_.LoDashExplicitWrapper<string>>("[1]", 2);
+        result = _(boolArray).chain().invoke<_.LoDashExplicitWrapper<string>>([1, "toString"]);
+        result = _(boolArray).chain().invoke<_.LoDashExplicitWrapper<string>>([1, "toString"], 2);
+
+        result = _(numDict).chain().invoke<_.LoDashExplicitWrapper<string>>("a.toString");
+        result = _(numDict).chain().invoke<_.LoDashExplicitWrapper<string>>("a.toString", 2);
+        result = _(numDict).chain().invoke<_.LoDashExplicitWrapper<string>>(["a", "toString"]);
+        result = _(numDict).chain().invoke<_.LoDashExplicitWrapper<string>>(["a", "toString"], 2);
+
+        result = _(nestedDict).chain().invoke<_.LoDashExplicitWrapper<string>>("a[0].toString");
+        result = _(nestedDict).chain().invoke<_.LoDashExplicitWrapper<string>>("a[0].toString", 2);
+        result = _(nestedDict).chain().invoke<_.LoDashExplicitWrapper<string>>(["a", 0, "toString"]);
+        result = _(nestedDict).chain().invoke<_.LoDashExplicitWrapper<string>>(["a", 0, "toString"], 2);
+    }
 }
 
 //_.invokeMap

--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -4364,6 +4364,47 @@ namespace TestKeyBy {
     }
 }
 
+//_.invoke
+namespace TestInvoke {
+    let nestedDict: _.Dictionary<Array<number>> = {
+        a: [0, 1, 2]
+    }
+    let numDict: _.Dictionary<number> = {
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4
+    }
+
+    let result: any;
+    result = _.invoke<number>(numDict, "a.toString");
+    result = _.invoke<number>(numDict, "a.toString", 2);
+    result = _.invoke<number>(numDict, ["a", "toString"]);
+    result = _.invoke<number>(numDict, ["a", "toString"], 2);
+    result = _.invoke<Array<number>>(nestedDict, ["a[0].toString"]);
+    result = _.invoke<Array<number>>(nestedDict, ["a[0].toString"], 2);
+    result = _.invoke<Array<number>>(nestedDict, ["a", 0, "toString"]);
+    result = _.invoke<Array<number>>(nestedDict, ["a", 0, "toString"], 2);
+
+    result = _(numDict).invoke("a.toString");
+    result = _(numDict).invoke("a.toString", 2);
+    result = _(numDict).invoke(["a", "toString"]);
+    result = _(numDict).invoke(["a", "toString"], 2);
+    result = _(nestedDict).invoke("a[0].toString");
+    result = _(nestedDict).invoke("a[0].toString", 2);
+    result = _(nestedDict).invoke(["a", 0, "toString"]);
+    result = _(nestedDict).invoke(["a", 0, "toString"], 2);
+
+    result = _(numDict).chain().invoke("a.toString");
+    result = _(numDict).chain().invoke("a.toString", 2);
+    result = _(numDict).chain().invoke(["a", "toString"]);
+    result = _(numDict).chain().invoke(["a", "toString"], 2);
+    result = _(nestedDict).chain().invoke("a[0].toString");
+    result = _(nestedDict).chain().invoke("a[0].toString", 2);
+    result = _(nestedDict).chain().invoke(["a", 0, "toString"]);
+    result = _(nestedDict).chain().invoke(["a", 0, "toString"], 2);
+}
+
 //_.invokeMap
 namespace TestInvokeMap {
     let numArray = [4, 2, 1, 3]

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -7831,6 +7831,38 @@ declare module _ {
         ): LoDashExplicitObjectWrapper<Dictionary<T>>;
     }
 
+    //_.invoke
+    interface LoDashStatic {
+        /**
+        * Invokes the method at path of object.
+        * @param object The object to query.
+        * @param path The path of the method to invoke.
+        * @param args The arguments to invoke the method with.
+        **/
+        invoke<TValue>(
+            object: Dictionary<TValue>,
+            path: string | Array<string | number>,
+            ...args: any[]): any;
+    }
+
+    interface LoDashImplicitObjectWrapper<T> {
+        /**
+        * @see _.invoke
+        **/
+        invoke(
+            path: string | Array<string | number>,
+            ...args: any[]): any;
+    }
+
+    interface LoDashExplicitObjectWrapper<T> {
+        /**
+        * @see _.invoke
+        **/
+        invoke(
+            path: string | Array<string | number>,
+            ...args: any[]): any;
+    }
+
     //_.invokeMap
     interface LoDashStatic {
         /**

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -7839,28 +7839,62 @@ declare module _ {
         * @param path The path of the method to invoke.
         * @param args The arguments to invoke the method with.
         **/
-        invoke<TValue>(
-            object: Dictionary<TValue>,
-            path: string | Array<string | number>,
-            ...args: any[]): any;
+        invoke<TObject extends Object, TResult>(
+            object: TObject,
+            path: StringRepresentable|StringRepresentable[],
+            ...args: any[]): TResult;
+
+        /**
+        * @see _.invoke
+        **/
+        invoke<TValue, TResult>(
+            object: Dictionary<TValue>|TValue[],
+            path: StringRepresentable|StringRepresentable[],
+            ...args: any[]): TResult;
+
+        /**
+        * @see _.invoke
+        **/
+        invoke<TResult>(
+            object: any,
+            path: StringRepresentable|StringRepresentable[],
+            ...args: any[]): TResult;
+    }
+
+    interface LoDashImplicitArrayWrapper<T> {
+        /**
+        * @see _.invoke
+        **/
+        invoke<TResult>(
+            path: StringRepresentable|StringRepresentable[],
+            ...args: any[]): TResult;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
         /**
         * @see _.invoke
         **/
-        invoke(
-            path: string | Array<string | number>,
-            ...args: any[]): any;
+        invoke<TResult>(
+            path: StringRepresentable|StringRepresentable[],
+            ...args: any[]): TResult;
+    }
+
+    interface LoDashExplicitArrayWrapper<T> {
+        /**
+        * @see _.invoke
+        **/
+        invoke<TResult>(
+            path: StringRepresentable|StringRepresentable[],
+            ...args: any[]): TResult;
     }
 
     interface LoDashExplicitObjectWrapper<T> {
         /**
         * @see _.invoke
         **/
-        invoke(
-            path: string | Array<string | number>,
-            ...args: any[]): any;
+        invoke<TResult>(
+            path: StringRepresentable|StringRepresentable[],
+            ...args: any[]): TResult;
     }
 
     //_.invokeMap


### PR DESCRIPTION
Prior to lodash 4.0.0, a method existed named _.invoke, which has now been renamed to _.invokeMap and a new _.invoke method created.

Users upgrading from lodash <4.0.0 definitions may find it surprising that the _.invoke method has been "removed" from the type definitions, especially as [the documentation](https://lodash.com/docs#invoke) indicates that the method still exists.
