### PR TITLE
fix express.NextFunction

### DIFF
--- a/express-serve-static-core/express-serve-static-core.d.ts
+++ b/express-serve-static-core/express-serve-static-core.d.ts
@@ -783,8 +783,7 @@ declare module "express-serve-static-core" {
     }
 
     interface NextFunction {
-        (): void;
-        (err: any): void;
+        (err?: any): void;
     }
 
     interface ErrorRequestHandler {

--- a/express/express-tests.ts
+++ b/express/express-tests.ts
@@ -68,3 +68,6 @@ app.use((req, res, next) => {
 app.use(router);
 
 app.listen(3000);
+
+const next: express.NextFunction = () => {};
+const nextWithArgument: express.NextFunction = (err: any) => {};


### PR DESCRIPTION
With the current definition of `express.NextFunction`, we cannot assign a function with any argument (see the below link).

<del>case 1. Add a new type definition.</del>


case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.
  - http://www.typescriptlang.org/Playground#src=interface%20NextFunction%20%7B%0D%0A%20%20%20%20()%3A%20void%3B%0D%0A%20%20%20%20(err%3A%20any)%3A%20void%3B%0D%0A%7D%0D%0A%0D%0Aconst%20next%3A%20NextFunction%20%3D%20(err%3A%20any)%20%3D%3E%20%7B%7D%3B%0D%0A%0D%0Ainterface%20NewNextFunction%20%7B%0D%0A%20%20%20%20(err%3F%3A%20any)%3A%20void%3B%0D%0A%7D%0D%0A%0D%0Aconst%20newNext%3A%20NewNextFunction%20%3D%20(err%3A%20any)%20%3D%3E%20%7B%7D%3B
