### PR TITLE
Joi: change any.when options - is: attribute to type any

### DIFF
--- a/joi/joi-tests.ts
+++ b/joi/joi-tests.ts
@@ -97,7 +97,7 @@ uriOpts = {scheme: expArr};
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-var whenOpts: Joi.WhenOptions = null;
+var whenOpts: Joi.WhenOptions<any> = null;
 
 whenOpts = {is: x};
 whenOpts = {is: schema, then: schema};

--- a/joi/joi-tests.ts
+++ b/joi/joi-tests.ts
@@ -99,7 +99,7 @@ uriOpts = {scheme: expArr};
 
 var whenOpts: Joi.WhenOptions = null;
 
-whenOpts = {is: schema};
+whenOpts = {is: x};
 whenOpts = {is: schema, then: schema};
 whenOpts = {is: schema, otherwise: schema};
 

--- a/joi/joi.d.ts
+++ b/joi/joi.d.ts
@@ -99,7 +99,7 @@ declare module 'joi' {
 		/**
 		 * the required condition joi type.
 		 */
-		is: Schema;
+		is: any;
 		/**
 		 * the alternative schema type if the condition is true. Required if otherwise is missing.
 		 */

--- a/joi/joi.d.ts
+++ b/joi/joi.d.ts
@@ -95,11 +95,11 @@ declare module 'joi' {
 		scheme ?: string | RegExp | Array<string | RegExp>;
 	}
 
-	export interface WhenOptions {
+	export interface WhenOptions<T> {
 		/**
 		 * the required condition joi type.
 		 */
-		is: any;
+		is: T;
 		/**
 		 * the alternative schema type if the condition is true. Required if otherwise is missing.
 		 */
@@ -269,8 +269,8 @@ declare module 'joi' {
 		/**
 		 * Converts the type into an alternatives type where the conditions are merged into the type definition where:
 		 */
-		when(ref: string, options: WhenOptions): AlternativesSchema;
-		when(ref: Reference, options: WhenOptions): AlternativesSchema;
+		when<U>(ref: string, options: WhenOptions<U>): AlternativesSchema;
+		when<U>(ref: Reference, options: WhenOptions<U>): AlternativesSchema;
 
 		/**
 		 * Overrides the key name in error messages.
@@ -691,8 +691,8 @@ declare module 'joi' {
 
 	export interface AlternativesSchema extends AnySchema<FunctionSchema> {
 		try(schemas: Schema[]): AlternativesSchema;
-		when(ref: string, options: WhenOptions): AlternativesSchema;
-		when(ref: Reference, options: WhenOptions): AlternativesSchema;
+		when<T>(ref: string, options: WhenOptions<T>): AlternativesSchema;
+		when<T>(ref: Reference, options: WhenOptions<T>): AlternativesSchema;
 	}
 
 	// --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---


### PR DESCRIPTION
My understanding from the API documentation for the `any.when()` function is that the `is:` attribute should be of the type of the calling object rather than a schema object:
https://github.com/hapijs/joi/blob/v8.0.5/API.md#anywhenref-options

eg from the example in the API documentation:

```
const schema = {
    a: Joi.any().valid('x').when('b', { is: 5, then: Joi.valid('y'), otherwise: Joi.valid('z') }),
    b: Joi.any()
};
```

here `is:` is of type `number`

or in my case I have a `boolean` so want `is: true`
