### PR TITLE
Fix compile errors

### DIFF
--- a/winjs/winjs.d.ts
+++ b/winjs/winjs.d.ts
@@ -9774,7 +9774,7 @@ declare namespace WinJS.Utilities {
     /**
      * Represents the result of a query selector, and provides various operations that perform actions over the elements of the collection.
     **/
-    class QueryCollection<T> implements Array<T> {
+    class QueryCollection<T> extends Array<T> {
         //#region Methods
 
         /**


### PR DESCRIPTION
Change line 9779 from 

``` ts
class QueryCollection<T> implements Array<T> {
```

to

``` ts
class QueryCollection<T> extends Array<T> {
```

Because I getting the **_error TS2420: Class 'QueryCollection<T>' incorrectly implements interface 'T[]'.**_
**_Property 'find' is missing in type 'QueryCollection<T>'.**_

After implementing find in .d.ts I was getting next the error about method findIndex and so on.

Simplest way to fix it, was let QueryCollection  extends Array and not implement it.

**_Typescript version**_
1.8.7
