### PR TITLE
allow importing bootbox as a module

### DIFF
--- a/bootbox/bootbox.d.ts
+++ b/bootbox/bootbox.d.ts
@@ -98,3 +98,7 @@ interface BootboxStatic {
 }
 
 declare var bootbox: BootboxStatic;
+
+declare module "bootbox" {
+    export = bootbox;
+}


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- no new library version

Currently the definition declares a global "bootbox" assuming you'll provide the required source somehow:

```
bootbox.alert("foobar")
```

If I want to import bootbox, as seen below, I must add an additional d.ts extension to make tsc happy.

```
import * as bb from "bootbox";
```

My change allows you to import bootbox without the end user having to add additional typing files (and depending on your module loading strategy, pull in the source without need for a script tag or the like). You see this pattern in other d.ts such as [toastr](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/toastr/toastr.d.ts)

Once Typescript 2.0 comes out, [an improved solution](https://github.com/Microsoft/TypeScript/issues/7125#issue-134444635) will exist.
