### PR TITLE
Q: Deferred#resolve can take a promise or value

### DIFF
--- a/q/Q-tests.ts
+++ b/q/Q-tests.ts
@@ -16,6 +16,10 @@ Q.when(delay(1000), function (val: void) {
     return;
 });
 
+// Note from Q documentation: a deferred can be resolved with a value or a promise.
+var otherPromise = Q.defer<string>().promise;
+Q.defer<string>().resolve(otherPromise);
+
 Q.timeout(Q(new Date()), 1000, "My dates never arrived. :(").then(d => d.toJSON());
 
 Q.delay(Q(8), 1000).then(x => x.toExponential());

--- a/q/Q.d.ts
+++ b/q/Q.d.ts
@@ -21,6 +21,7 @@ declare namespace Q {
     interface Deferred<T> {
         promise: Promise<T>;
         resolve(value?: T): void;
+        resolve(value?: IPromise<T>): void;
         reject(reason: any): void;
         notify(value: any): void;
         makeNodeResolver(): (reason: any, value: T) => void;


### PR DESCRIPTION
According to the documentation of Q, `deferred`s can be `resolve`d with either a value, or a promise. (https://github.com/kriskowal/q#using-deferreds)

> Note that a deferred can be resolved with a value or a promise.

This adds an overloaded definition of the `resolve` method on the `Deferred` interface, such that `resolve` can either take an optional value of type `T` or `IPromise<T>`
