### PR TITLE
pg.connect(...) callback done argument to signal client removal from pool

### DIFF
--- a/pg/pg-tests.ts
+++ b/pg/pg-tests.ts
@@ -12,9 +12,12 @@ pg.connect(conString, (err, client, done) => {
         return console.error("Error fetching client from pool", err);
     }
     client.query("SELECT $1::int AS number", ["1"], (err, result) => {
-        done();
         if (err) {
+            done(err);
             return console.error("Error running query", err);
+        }
+        else {
+            done();
         }
         console.log(result.rows[0]["number"]);
         return null;

--- a/pg/pg.d.ts
+++ b/pg/pg.d.ts
@@ -9,8 +9,8 @@ declare module "pg" {
     import events = require("events");
     import stream = require("stream");
 
-    export function connect(connection: string, callback: (err: Error, client: Client, done: () => void) => void): void;
-    export function connect(config: ClientConfig, callback: (err: Error, client: Client, done: () => void) => void): void;
+    export function connect(connection: string, callback: (err: Error, client: Client, done: (err?: any) => void) => void): void;
+    export function connect(config: ClientConfig, callback: (err: Error, client: Client, done: (err?: any) => void) => void): void;
     export function end(): void;
 
     export interface ConnectionConfig {


### PR DESCRIPTION
An optional argument can be supplied to `done()` to trigger removal of the client from the pool (instead of releasing it for reuse in subsequent queries). See https://github.com/brianc/node-postgres/wiki/Example for an example (documentation of this usage is scarce), or the source code: [pool.js:84](https://github.com/brianc/node-postgres/blob/master/lib/pool.js#L84).
