### PR TITLE
Added $el to Region

### DIFF
--- a/marionette/marionette.d.ts
+++ b/marionette/marionette.d.ts
@@ -314,6 +314,11 @@ declare namespace Marionette {
         el: any;
 
         /**
+         * Contains the element that this region should manage as a jQuery selector.
+         */
+        $el: JQuery;
+
+        /**
          * Renders and displays the specified view in this region.
          * @param view the view to display.
          */


### PR DESCRIPTION
$el is always assigned in the constructor:

`this.$el = this.getEl(this.el);`

https://github.com/marionettejs/backbone.marionette/blob/master/src/region.js @ line 27
