### PR TITLE
Added optional $el to Region

### DIFF
--- a/marionette/marionette.d.ts
+++ b/marionette/marionette.d.ts
@@ -314,6 +314,11 @@ declare namespace Marionette {
         el: any;
 
         /**
+         * Contains the element that this region should manage as a jQuery selector.
+         */
+        $el?: JQuery;
+
+        /**
          * Renders and displays the specified view in this region.
          * @param view the view to display.
          */


### PR DESCRIPTION
Region has a $el property which it maintains.

`this.$el = this.getEl(this.el);`

I have made it optional as it is deleted in the reset() method.

https://github.com/marionettejs/backbone.marionette/blob/master/src/region.js
