### PR TITLE
Fix ajax-field 'quietMillis' to 'delay'.

### DIFF
--- a/select2/select2-tests.ts
+++ b/select2/select2-tests.ts
@@ -99,7 +99,7 @@ $("#e7").select2({
     ajax: {
         url: "http://api.rottentomatoes.com/api/public/v1.0/movies.json",
         dataType: 'jsonp',
-        quietMillis: 100,
+        delay: 100,
         data: function (term, page) {
             return {
                 q: term,

--- a/select2/select2.d.ts
+++ b/select2/select2.d.ts
@@ -25,7 +25,7 @@ interface Select2AjaxOptions {
     */
     url?: any;
     dataType?: string;
-    quietMillis?: number;
+    delay?: number;
     cache?: boolean;
     data?: (term: string, page: number, context: any) => any;
     results?: (term: any, page: number, context: any) => any;


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

See select2 documentation at https://select2.github.io/options.html#ajax
