### PR TITLE
Winston: Add remove(transport: string)

### DIFF
--- a/winston/winston.d.ts
+++ b/winston/winston.d.ts
@@ -38,6 +38,7 @@ declare module "winston" {
   export function unhandleExceptions(...transports: TransportInstance[]): void;
   export function add(transport: TransportInstance, options?: TransportOptions, created?: boolean): LoggerInstance;
   export function clear(): void;
+  export function remove(transport: string): LoggerInstance;
   export function remove(transport: TransportInstance): LoggerInstance;
   export function startTimer(): ProfileHandler;
   export function profile(id: string, msg?: string, meta?: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
line 512 in https://github.com/winstonjs/winston/blob/master/lib/winston/logger.js
`Logger.prototype.remove = function (transport) {
  var name = typeof transport !== 'string'
    ? transport.name || transport.prototype.name
    : transport;`

So, Logger.remove should support both string and transport parameter type.
