### PR TITLE
updated redux createStore definition to reflect the current 3.3.1 def…

### DIFF
--- a/redux/redux.d.ts
+++ b/redux/redux.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Redux v1.0.0
+// Type definitions for Redux v3.3.1
 // Project: https://github.com/rackt/redux
 // Definitions by: William Buchwalter <https://github.com/wbuchwalter/>, Vincent Prouillet <https://github.com/Keats/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -40,7 +40,7 @@ declare namespace Redux {
         subscribe(listener: Function): Function;
     }
 
-    function createStore(reducer: Reducer, initialState?: any, enhancer?: ()=>any): Store;
+    function createStore(reducer: Reducer, initialState?: any, enhancer?: Function): Store;
     function bindActionCreators<T>(actionCreators: T, dispatch: Dispatch): T;
     function combineReducers(reducers: any): Reducer;
     function applyMiddleware(...middlewares: Middleware[]): Function;


### PR DESCRIPTION
updated redux createStore definition to reflect the current 3.3.1 definition:

[https://github.com/reactjs/redux/blob/master/src/createStore.js](https://github.com/reactjs/redux/blob/master/src/createStore.js)

@param {Function} enhancer
