### PR TITLE
Add createMemoryHistory to react-router.

### DIFF
--- a/react-router/react-router-tests.tsx
+++ b/react-router/react-router-tests.tsx
@@ -8,7 +8,7 @@
 import * as React from "react"
 import * as ReactDOM from "react-dom"
 
-import { browserHistory, hashHistory, Router, Route, IndexRoute, Link } from "react-router"
+import { browserHistory, hashHistory, createMemoryHistory, Router, Route, IndexRoute, Link } from "react-router"
 
 interface MasterContext {
 	router: ReactRouter.RouterOnContext;

--- a/react-router/react-router.d.ts
+++ b/react-router/react-router.d.ts
@@ -78,6 +78,8 @@ declare namespace ReactRouter {
     const browserHistory: History;
     const hashHistory: History;
 
+    function createMemoryHistory(options?: H.HistoryOptions): H.History
+
     /* components */
 
     interface RouterProps extends React.Props<Router> {
@@ -403,6 +405,9 @@ declare module "react-router/lib/useRouterHistory" {
     export default function useRouterHistory<T>(createHistory: HistoryModule.CreateHistory<T>): CreateRouterHistory;
 }
 
+declare module "react-router/lib/createMemoryHistory" {
+  export default ReactRouter.createMemoryHistory;
+}
 
 declare module "react-router" {
 
@@ -444,6 +449,8 @@ declare module "react-router" {
 
     import useRouterHistory from "react-router/lib/useRouterHistory";
 
+    import createMemoryHistory from "react-router/lib/createMemoryHistory";
+
     // PlainRoute is defined in the API documented at:
     // https://github.com/rackt/react-router/blob/master/docs/API.md
     // but not included in any of the .../lib modules above.
@@ -483,7 +490,8 @@ declare module "react-router" {
         RouterContext,
         PropTypes,
         match,
-        useRouterHistory
+        useRouterHistory,
+        createMemoryHistory
     }
 
     export default Router


### PR DESCRIPTION
Since the version 2.0.0, react-router exports createMemoryHistory.

Sources:
[createMemoryHistory](https://github.com/reactjs/react-router/blob/a759887f6096426c9f9023ea3a201c8560c74810/modules/createMemoryHistory.js)
[export](https://github.com/reactjs/react-router/blob/6bddfccd4d52dd0ab33298e91b13ed21f68e1135/modules/index.js#L30)
