### PR TITLE
oracledb.d.ts : access object property in result rows

### DIFF
--- a/oracledb/oracledb-tests.ts
+++ b/oracledb/oracledb-tests.ts
@@ -23,6 +23,7 @@ OracleDB.getConnection(
 					console.error(err.message); return;
 				}
 				console.log(result.rows);
+                console.log(result.rows[0].department_id); // when outFormet is OBJECT
 			}
 		);
 	}

--- a/oracledb/oracledb.d.ts
+++ b/oracledb/oracledb.d.ts
@@ -93,7 +93,7 @@ declare module 'oracledb' {
 		/** Metadata information - just columns names for now. */
 		metaData?: Array<IMetaData>;
 		/** When not using ResultSet, query results comes here. */
-		rows?: Array<Array<any>> | Array<Object>;
+		rows?: Array<Array<any>> | Array<any>;
 		/** When using ResultSet, query results comes here. */
 		resultSet?: IResultSet;
 	}


### PR DESCRIPTION
When `outFormat` is set to OBJECT, the properties of rows in result object should be accessible.

``` js
connection.execute(
    "SELECT department_id, department_name FROM departments",
    function(err, result) {
        if (err) {
            console.error(err.message); return;
        }
        console.log(result.rows[0].department_id);   // access property of object in rows array
    }
);
```

https://github.com/oracle/node-oracledb/blob/master/doc/api.md#resultobject
