### PR TITLE
oracledb.d.ts: fix IMetaData to match real data structure.

### DIFF
--- a/oracledb/oracledb-tests.ts
+++ b/oracledb/oracledb-tests.ts
@@ -24,6 +24,7 @@ OracleDB.getConnection(
 				}
 				console.log(result.rows);
                 console.log(result.rows[0].department_id); // when outFormet is OBJECT
+                console.log(result.metaData[0].name);
 			}
 		);
 	}

--- a/oracledb/oracledb.d.ts
+++ b/oracledb/oracledb.d.ts
@@ -100,7 +100,7 @@ declare module 'oracledb' {
 
 	export interface IMetaData {
 		/** Column name */
-		columnName: string;
+		name: string;
 	}
 
 	export interface IResultSet {


### PR DESCRIPTION
I print out the result object by `console.log(result)`. It shows that the property name inside `metaData` is `name`, not `columnName`.

```
result:
{ rows: [ [ 'fisrt', 'fox' ] ],
  resultSet: undefined,
  outBinds: undefined,
  rowsAffected: undefined,
  metaData: [ { name: 'KEY' }, { name: 'VALUE' } ] }
```

Test on oracledb 1.8.0.
