### PR TITLE
Add type definition and tests for EvaporateJS

### DIFF
--- a/evaporate/evaporate-tests.ts
+++ b/evaporate/evaporate-tests.ts
@@ -1,0 +1,7 @@
+/// <reference path="./evaporate.d.ts" />
+
+function test_upload() {
+  var evaporate = new Evaporate({});
+  var uploadId = evaporate.add({});
+  evaporate.cancel(uploadId);
+}

--- a/evaporate/evaporate.d.ts
+++ b/evaporate/evaporate.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for EvaporateJS
 // Project: https://github.com/TTLabs/EvaporateJS
-// Definitions by: Andrew Kuklewicz <https://github.com/kookster/>
+// Definitions by: Andrew Kuklewicz <https://github.com/kookster/>, Chris Rhoden <https://github.com/chrisrhoden>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 declare class Evaporate {
   cancel(id:string): boolean;

--- a/evaporate/evaporate.d.ts
+++ b/evaporate/evaporate.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for EvaporateJS
+// Project: https://github.com/TTLabs/EvaporateJS
+// Definitions by: Andrew Kuklewicz <https://github.com/kookster/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+declare class Evaporate {
+  cancel(id:string): boolean;
+  constructor(config:any);
+  add(config:any): string;
+}
+
+declare module 'evaporate' {
+  export = Evaporate;
+}


### PR DESCRIPTION
For EvaporateJS

npm: https://www.npmjs.com/package/evaporate
github: https://github.com/TTLabs/EvaporateJS

case 1. Add a new type definition.
- [X] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [X] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [X] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
