### PR TITLE
Overload for custom scope interfaces

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1845,6 +1845,11 @@ declare namespace angular {
         controller(name: string): any;
         injector(): any;
         scope(): IScope;
+        
+        /**
+        *   Overload for custom scope interfaces
+        */
+        scope<T extends IScope>(): T;
         isolateScope(): IScope;
 
         inheritedData(key: string, value: any): JQuery;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

I recently came up with this solution so I could leverage my custom scope when grabbing the scope from a controller using angular.element.  It works well and with the <T extends IScope> it ensures that you can only set it to an interface that extends IScope.

Let me know if there's anything else you need for the commit as this is the first time I've tried this. Here's an example of how this improves things:

```
var $scope = angular.element($('[ng-controller]')).scope<ICustomScope>();
$scope.vm.setName();
```
