### PR TITLE
TransitionGroup spreads HTMLAttribute props onto its component

### DIFF
--- a/react/react-addons-transition-group.d.ts
+++ b/react/react-addons-transition-group.d.ts
@@ -7,7 +7,7 @@
 
 declare namespace __React {
 
-    interface TransitionGroupProps {
+    interface TransitionGroupProps extends HTMLAttributes {
         component?: ReactType;
         childFactory?: (child: ReactElement<any>) => ReactElement<any>;
     }

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -480,7 +480,9 @@ React.createFactory(CSSTransitionGroup)({
     transitionName: "transition",
     transitionAppear: false,
     transitionEnter: true,
-    transitionLeave: true
+    transitionLeave: true,
+    id: "some-id",
+    className: "some-class"
 });
 
 React.createFactory(CSSTransitionGroup)({


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes: https://facebook.github.io/react/docs/animation.html#rendering-a-different-component
- it has been reviewed by a DefinitelyTyped member.
