### PR TITLE
lodash: changed _.noConflict

### DIFF
--- a/lodash/lodash-3.10-tests.ts
+++ b/lodash/lodash-3.10-tests.ts
@@ -10270,12 +10270,23 @@ namespace TestMixin {
 }
 
 // _.noConflict
-{
-    let result: typeof _;
-    result = _.noConflict();
-    result = _(42).noConflict();
-    result = _<any>([]).noConflict();
-    result = _({}).noConflict();
+namespace TestNoConflict {
+    {
+        let result: typeof _;
+
+        result = _.noConflict();
+        result = _(42).noConflict();
+        result = _<any>([]).noConflict();
+        result = _({}).noConflict();
+    }
+
+    {
+        let result: _.LoDashExplicitObjectWrapper<typeof _>;
+
+        result = _(42).chain().noConflict();
+        result = _<any>([]).chain().noConflict();
+        result = _({}).chain().noConflict();
+    }
 }
 
 // _.noop

--- a/lodash/lodash-3.10.d.ts
+++ b/lodash/lodash-3.10.d.ts
@@ -15430,6 +15430,13 @@ declare module _ {
         noConflict(): typeof _;
     }
 
+    interface LoDashExplicitWrapperBase<T, TWrapper> {
+        /**
+         * @see _.noConflict
+         */
+        noConflict(): LoDashExplicitObjectWrapper<typeof _>;
+    }
+
     //_.noop
     interface LoDashStatic {
         /**

--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -11506,12 +11506,23 @@ namespace TestMixin {
 }
 
 // _.noConflict
-{
-    let result: typeof _;
-    result = _.noConflict();
-    result = _(42).noConflict();
-    result = _<any>([]).noConflict();
-    result = _({}).noConflict();
+namespace TestNoConflict {
+    {
+        let result: typeof _;
+
+        result = _.noConflict();
+        result = _(42).noConflict();
+        result = _<any>([]).noConflict();
+        result = _({}).noConflict();
+    }
+
+    {
+        let result: _.LoDashExplicitObjectWrapper<typeof _>;
+
+        result = _(42).chain().noConflict();
+        result = _<any>([]).chain().noConflict();
+        result = _({}).chain().noConflict();
+    }
 }
 
 // _.noop

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -18614,6 +18614,13 @@ declare module _ {
         noConflict(): typeof _;
     }
 
+    interface LoDashExplicitWrapperBase<T, TWrapper> {
+        /**
+         * @see _.noConflict
+         */
+        noConflict(): LoDashExplicitObjectWrapper<typeof _>;
+    }
+
     //_.noop
     interface LoDashStatic {
         /**


### PR DESCRIPTION
lodash-4:
https://lodash.com/docs#noConflict
https://lodash.com/docs#_ (chainable wrapper)

lodash-3:
https://github.com/lodash/lodash/blob/3.10.1/doc/README.md#_noconflict
https://github.com/lodash/lodash/blob/3.10.1/doc/README.md#_value (chainable wrapper)
