### PR TITLE
Add MediaStreamAudioDestinationNode

### DIFF
--- a/webaudioapi/waa.d.ts
+++ b/webaudioapi/waa.d.ts
@@ -188,6 +188,10 @@ interface MediaStreamAudioSourceNode extends AudioNode {
 
 }
 
+interface MediaStreamAudioDestinationNode extends AudioNode {
+    stream: MediaStream;
+}
+
 interface AudioBuffer {
     copyFromChannel(destination: Float32Array, channelNumber: number, startInChannel?: number): void;
 
@@ -202,4 +206,5 @@ interface AudioContext {
     suspend(): Promise<void>;
     resume(): Promise<void>;
     close(): Promise<void>;
+    createMediaStreamDestination(): MediaStreamAudioDestinationNode; 
 }


### PR DESCRIPTION
Added `MediaStreamAudioDestinationNode`  to the Webaudio API  as defined here: https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createMediaStreamDestination
