### PR TITLE
PathJS: "route" should be called with new.

### DIFF
--- a/pathjs/pathjs-tests.ts
+++ b/pathjs/pathjs-tests.ts
@@ -13,7 +13,7 @@ Path.history.listen(() =>{
 var initial = Path.history.initial;
 
 //Core
-var route = Path.core.route("/test/:id");
+var route = new Path.core.route("/test/:id");
 
 function test1() {
 	

--- a/pathjs/pathjs.d.ts
+++ b/pathjs/pathjs.d.ts
@@ -27,7 +27,11 @@ interface IPathRoutes{
 }
 
 interface IPathCore{
-	route(path: string): IPathRoute;
+	route: IPathRouteConstructor;
+}
+
+interface IPathRouteConstructor {
+	new (path: string): IPathRoute;
 }
 
 interface IPath {


### PR DESCRIPTION
In the declaration file, "route" was just a normal function, which had a return-type. 

However, looking at the actual code, "route" doesn't have a return-statement, and only makes sense is called with "new". (code: https://github.com/mtrpcic/pathjs/blob/master/path.js#L129)
The declaration file has been updated to reflect this. 
