### PR TITLE
Created typings for angular-match-queries module

### DIFF
--- a/angular-media-queries/match-media-tests.ts
+++ b/angular-media-queries/match-media-tests.ts
@@ -1,0 +1,55 @@
+﻿/// <reference path="match-media.d.ts" />
+
+var myApp = angular.module('testModule', ['matchMedia']);
+
+myApp.controller('TestController', ($log: angular.ILogService,
+    $scope: angular.IScope,
+    screenSize: angular.matchmedia.IScreenSize) => {
+
+    var fnCallback = (result: boolean) => {
+        $log.info(`Result: ${result}`);
+    }
+    
+    // '.is(...)' examples
+    var res = screenSize.is(["xs", "sm"]);
+    fnCallback(res);
+
+    res = screenSize.is("xs, lg")
+    fnCallback(res);
+    
+    // '.on(...)' examples
+    
+    res = screenSize.on(["xs", "sm"], fnCallback);
+    fnCallback(res);
+
+    res = screenSize.on("xs, lg", fnCallback);
+    fnCallback(res);
+
+    res = screenSize.on(["xs", "sm"], fnCallback, $scope);
+    fnCallback(res);
+
+    res = screenSize.on("xs, lg", fnCallback, $scope);
+    fnCallback(res);
+    
+    // '.onChange(...)' examples
+
+    res = screenSize.onChange($scope, ["xs", "sm"], fnCallback);
+    fnCallback(res);
+
+    res = screenSize.onChange($scope, "xs, lg", fnCallback);
+    fnCallback(res);
+    
+    // '.when(...)' examples
+    
+    res = screenSize.when(["xs", "sm"], fnCallback);
+    fnCallback(res);
+
+    res = screenSize.when("xs, lg", fnCallback);
+    fnCallback(res);
+
+    res = screenSize.when(["xs", "sm"], fnCallback, $scope);
+    fnCallback(res);
+
+    res = screenSize.when("xs, lg", fnCallback, $scope);
+    fnCallback(res);
+});

--- a/angular-media-queries/match-media-tests.ts
+++ b/angular-media-queries/match-media-tests.ts
@@ -10,6 +10,11 @@ myApp.controller('TestController', ($log: angular.ILogService,
         $log.info(`Result: ${result}`);
     }
     
+    // '.isRetina' examples
+    if(screenSize.isRetina) {
+        $log.info("Retina screen detected")
+    }
+    
     // '.is(...)' examples
     var res = screenSize.is(["xs", "sm"]);
     fnCallback(res);

--- a/angular-media-queries/match-media.d.ts
+++ b/angular-media-queries/match-media.d.ts
@@ -8,6 +8,9 @@ declare namespace angular.matchmedia {
 
     interface IScreenSize {
 
+        // Returns a value indicating if the current device has a retina screen
+        isRetina: boolean;
+    
         is(list: Array<string> | string): boolean;
 
         // Executes the callback function on window resize with the match truthiness as the first argument.

--- a/angular-media-queries/match-media.d.ts
+++ b/angular-media-queries/match-media.d.ts
@@ -1,0 +1,27 @@
+﻿// Type definitions for Angular matchMedia 0.6.0 (angular.matchMedia module)
+// Project: https://github.com/jacopotarantino/angular-match-media
+// Definitions by: Joao Monteiro <https://github.com/jpmnteiro>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../angularjs/angular.d.ts" />
+declare namespace angular.matchmedia {
+
+    interface IScreenSize {
+
+        is(list: Array<string> | string): boolean;
+
+        // Executes the callback function on window resize with the match truthiness as the first argument.
+        // Returns the current match truthiness.
+        // The 'scope' parameter is optional. If it's not passed in, '$rootScope' is used.
+        on(list: Array<string> | string, callback: (result: boolean) => void, scope?: angular.IScope): boolean;
+
+        // Executes the callback function ONLY when the match differs from previous match.
+        // Returns the current match truthiness.
+        // The 'scope' parameter is required for cleanup reasons (destroy event).
+        onChange(scope: angular.IScope, list: Array<string> | string, callback: (result: boolean) => void): boolean;
+
+        // Executes the callback only when inside of the particular screensize.
+        // The 'scope' parameter is optional. If it's not passed in, '$rootScope' is used.  
+        when(list: Array<string> | string, callback: (result: boolean) => void, scope?: angular.IScope): boolean;
+    }
+}


### PR DESCRIPTION
Typings for [angular-match-media module](https://github.com/jacopotarantino/angular-match-media) (known in bower as angular-media-queries).

case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [X] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [X] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
