### PR TITLE
fix cordova file-transfer plugin - upload method

### DIFF
--- a/cordova/cordova-tests.ts
+++ b/cordova/cordova-tests.ts
@@ -192,7 +192,7 @@ file.upload('cdvfile://localhost/persistent/path/to/downloads/',
             console.error('Failed with exception ' + err.exception);
         }
     },
-    { headers: null, httpMethod: "PUT" },
+    { headers: {"X-Email": "user@mail.com", 'X-Token': "asdf3w234"}, httpMethod: "PUT" },
     true);
 
 file.abort();

--- a/cordova/plugins/FileTransfer.d.ts
+++ b/cordova/plugins/FileTransfer.d.ts
@@ -93,7 +93,7 @@ interface FileUploadOptions {
     /** Whether to upload the data in chunked streaming mode. Defaults to true. */
     chunkedMode?: boolean;
     /** A map of header name/header values. Use an array to specify more than one value. */
-    headers?: Object[];
+    headers?: Object;
 }
 
 /** Optional parameters for download method. */


### PR DESCRIPTION
same as in issue #5435 for download method, options header parameters can't be an array, has to be an object

Typings of the upload method, parameter FileUploadOptions, of the cordova file-transfer plugin doesn't match with the implementation
see: https://github.com/apache/cordova-plugin-file-transfer/blob/2b8c1a6101c57198000a8d9ab6d48d239c1c5014/www/FileTransfer.js#L103

Header is initialized with object instead of array:
options.headers = options.headers || {};
