### PR TITLE
lodash: add/update min, max, first, head, reduce

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -836,10 +836,10 @@ namespace TestFirst {
     }
 
     {
-        let result: _.LoDashExplicitObjectWrapper<TResult>;
+        let result: _.LoDashExplicitWrapper<TResult>;
 
-        result = _(array).chain().first<_.LoDashExplicitObjectWrapper<TResult>>();
-        result = _(list).chain().first<_.LoDashExplicitObjectWrapper<TResult>>();
+        result = _(array).chain().first<TResult>();
+        result = _(list).chain().first<TResult>();
     }
 }
 
@@ -1066,10 +1066,10 @@ namespace TestHead {
     }
 
     {
-        let result: _.LoDashExplicitObjectWrapper<TResult>;
+        let result: _.LoDashExplicitWrapper<TResult>;
 
-        result = _(array).chain().head<_.LoDashExplicitObjectWrapper<TResult>>();
-        result = _(list).chain().head<_.LoDashExplicitObjectWrapper<TResult>>();
+        result = _(array).chain().head<TResult>();
+        result = _(list).chain().head<TResult>();
     }
 }
 

--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -1019,24 +1019,6 @@ namespace TestFlattenDeep {
     }
 }
 
-// _.fromPairs
-namespace TestFromPairs {
-    let array: string[][];
-    let result: _.Dictionary<any>;
-
-    {
-        result = _.fromPairs(array);
-    }
-
-    {
-        result = _(array).fromPairs().value();
-    }
-
-    {
-        result = _.chain(array).fromPairs().value();
-    }
-}
-
 // _.head
 namespace TestHead {
     let array: TResult[];

--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -1019,6 +1019,24 @@ namespace TestFlattenDeep {
     }
 }
 
+// _.fromPairs
+namespace TestFromPairs {
+    let array: string[][];
+    let result: _.Dictionary<any>;
+
+    {
+        result = _.fromPairs(array);
+    }
+
+    {
+        result = _(array).fromPairs().value();
+    }
+
+    {
+        result = _.chain(array).fromPairs().value();
+    }
+}
+
 // _.head
 namespace TestHead {
     let array: TResult[];

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -16163,6 +16163,36 @@ declare module _ {
         mapValues<TResult>(where: Dictionary<TResult>): LoDashImplicitArrayWrapper<boolean>;
     }
 
+    interface LoDashExplicitObjectWrapper<T> {
+        /**
+         * @see _.mapValues
+         * TValue is the type of the property values of T.
+         * TResult is the type output by the ObjectIterator function
+         */
+        mapValues<TValue, TResult>(callback: ObjectIterator<TValue, TResult>, thisArg?: any): LoDashExplicitObjectWrapper<Dictionary<TResult>>;
+
+        /**
+         * @see _.mapValues
+         * TResult is the type of the property specified by pluck.
+         * T should be a Dictionary<Dictionary<TResult>>
+         */
+        mapValues<TResult>(pluck: string): LoDashExplicitObjectWrapper<Dictionary<TResult>>;
+
+        /**
+         * @see _.mapValues
+         * TResult is the type of the properties on the object specified by pluck.
+         * T should be a Dictionary<Dictionary<Dictionary<TResult>>>
+         */
+        mapValues<TResult>(pluck: string, where: Dictionary<TResult>): LoDashExplicitObjectWrapper<Dictionary<boolean>>;
+
+        /**
+         * @see _.mapValues
+         * TResult is the type of the properties of each object in the values of T
+         * T should be a Dictionary<Dictionary<TResult>>
+         */
+        mapValues<TResult>(where: Dictionary<TResult>): LoDashExplicitObjectWrapper<boolean>;
+    }
+
     //_.merge
     interface LoDashStatic {
         /**

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -16151,36 +16151,6 @@ declare module _ {
         mapValues<TResult>(where: Dictionary<TResult>): LoDashImplicitArrayWrapper<boolean>;
     }
 
-    interface LoDashExplicitObjectWrapper<T> {
-        /**
-         * @see _.mapValues
-         * TValue is the type of the property values of T.
-         * TResult is the type output by the ObjectIterator function
-         */
-        mapValues<TValue, TResult>(callback: ObjectIterator<TValue, TResult>, thisArg?: any): LoDashExplicitObjectWrapper<Dictionary<TResult>>;
-
-        /**
-         * @see _.mapValues
-         * TResult is the type of the property specified by pluck.
-         * T should be a Dictionary<Dictionary<TResult>>
-         */
-        mapValues<TResult>(pluck: string): LoDashExplicitObjectWrapper<Dictionary<TResult>>;
-
-        /**
-         * @see _.mapValues
-         * TResult is the type of the properties on the object specified by pluck.
-         * T should be a Dictionary<Dictionary<Dictionary<TResult>>>
-         */
-        mapValues<TResult>(pluck: string, where: Dictionary<TResult>): LoDashExplicitObjectWrapper<Dictionary<boolean>>;
-
-        /**
-         * @see _.mapValues
-         * TResult is the type of the properties of each object in the values of T
-         * T should be a Dictionary<Dictionary<TResult>>
-         */
-        mapValues<TResult>(where: Dictionary<TResult>): LoDashExplicitObjectWrapper<boolean>;
-    }
-
     //_.merge
     interface LoDashStatic {
         /**

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -13181,6 +13181,20 @@ declare module _ {
         max<T>(): T;
     }
 
+    interface LoDashExplicitArrayWrapper<T> {
+        /**
+         * @see _.max
+         */
+        max(): LoDashExplicitWrapper<T>;
+    }
+
+    interface LoDashExplicitObjectWrapper<T> {
+        /**
+         * @see _.max
+         */
+        max<T>(): LoDashExplicitWrapper<T>;
+    }
+
     //_.maxBy
     interface LoDashStatic {
         /**
@@ -13344,6 +13358,20 @@ declare module _ {
          * @see _.min
          */
         min<T>(): T;
+    }
+
+    interface LoDashExplicitArrayWrapper<T> {
+        /**
+         * @see _.min
+         */
+        min(): LoDashExplicitWrapper<T>;
+    }
+
+    interface LoDashExplicitObjectWrapper<T> {
+        /**
+         * @see _.min
+         */
+        min<T>(): LoDashExplicitWrapper<T>;
     }
 
     //_.minBy

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -8753,6 +8753,40 @@ declare module _ {
             thisArg?: any): TResult;
     }
 
+    interface LoDashExplicitArrayWrapper<T> {
+        /**
+       * @see _.reduce
+       **/
+        reduce<TResult>(
+            callback: MemoIterator<T, TResult>,
+            accumulator: TResult,
+            thisArg?: any): LoDashExplicitWrapper<TResult>;
+
+        /**
+        * @see _.reduce
+        **/
+        reduce<TResult>(
+            callback: MemoIterator<T, TResult>,
+            thisArg?: any): LoDashExplicitWrapper<TResult>;
+    }
+
+    interface LoDashExplicitObjectWrapper<T> {
+        /**
+       * @see _.reduce
+       **/
+        reduce<TValue, TResult>(
+            callback: MemoIterator<TValue, TResult>,
+            accumulator: TResult,
+            thisArg?: any): LoDashExplicitWrapper<TResult>;
+
+        /**
+        * @see _.reduce
+        **/
+        reduce<TValue, TResult>(
+            callback: MemoIterator<TValue, TResult>,
+            thisArg?: any): LoDashExplicitWrapper<TResult>;
+    }
+
     //_.reduceRight
     interface LoDashStatic {
         /**

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -16629,7 +16629,7 @@ declare module _ {
          */
         pickBy<TResult extends {}, T extends {}>(
             object: T,
-            predicate?: ObjectIterator<any, boolean>
+            predicate: ObjectIterator<any, boolean>
         ): TResult;
     }
 
@@ -16638,7 +16638,7 @@ declare module _ {
          * @see _.pickBy
          */
         pickBy<TResult extends {}>(
-            predicate?: ObjectIterator<any, boolean>
+            predicate: ObjectIterator<any, boolean>
         ): LoDashImplicitObjectWrapper<TResult>;
     }
 
@@ -16647,7 +16647,7 @@ declare module _ {
          * @see _.pickBy
          */
         pickBy<TResult extends {}>(
-            predicate?: ObjectIterator<any, boolean>
+            predicate: ObjectIterator<any, boolean>
         ): LoDashExplicitObjectWrapper<TResult>;
     }
 

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -1891,13 +1891,6 @@ declare module _ {
         first(): T;
     }
 
-    interface LoDashImplicitObjectWrapper<T> {
-        /**
-         * @see _.head
-         */
-        first<T>(): T;
-    }
-
     interface LoDashExplicitWrapper<T> {
         /**
          * @see _.head
@@ -1909,14 +1902,7 @@ declare module _ {
         /**
          * @see _.head
          */
-        first<T>(): T;
-    }
-
-    interface LoDashExplicitObjectWrapper<T> {
-        /**
-         * @see _.head
-         */
-        first<T>(): T;
+        first<T>(): LoDashExplicitWrapper<T>;
     }
 
     interface RecursiveArray<T> extends Array<T|RecursiveArray<T>> {}
@@ -2104,13 +2090,6 @@ declare module _ {
         head(): T;
     }
 
-    interface LoDashImplicitObjectWrapper<T> {
-        /**
-         * @see _.head
-         */
-        head<T>(): T;
-    }
-
     interface LoDashExplicitWrapper<T> {
         /**
          * @see _.head
@@ -2122,14 +2101,7 @@ declare module _ {
         /**
          * @see _.head
          */
-        head<T>(): T;
-    }
-
-    interface LoDashExplicitObjectWrapper<T> {
-        /**
-         * @see _.head
-         */
-        head<T>(): T;
+        head<T>(): LoDashExplicitWrapper<T>;
     }
 
     //_.indexOf

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -16577,7 +16577,7 @@ declare module _ {
          */
         pickBy<TResult extends {}, T extends {}>(
             object: T,
-            predicate: ObjectIterator<any, boolean>
+            predicate?: ObjectIterator<any, boolean>
         ): TResult;
     }
 
@@ -16586,7 +16586,7 @@ declare module _ {
          * @see _.pickBy
          */
         pickBy<TResult extends {}>(
-            predicate: ObjectIterator<any, boolean>
+            predicate?: ObjectIterator<any, boolean>
         ): LoDashImplicitObjectWrapper<TResult>;
     }
 
@@ -16595,7 +16595,7 @@ declare module _ {
          * @see _.pickBy
          */
         pickBy<TResult extends {}>(
-            predicate: ObjectIterator<any, boolean>
+            predicate?: ObjectIterator<any, boolean>
         ): LoDashExplicitObjectWrapper<TResult>;
     }
 

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -2044,23 +2044,7 @@ declare module _ {
          */
         fromPairs(
             array: any[]|List<any>
-        ): Dictionary<any>;
-    }
-
-    //_.fromPairs DUMMY
-    interface LoDashImplicitArrayWrapper<T> {
-        /**
-         * @see _.fromPairs
-         */
-        fromPairs(): LoDashImplicitObjectWrapper<any>;
-    }
-
-    //_.fromPairs DUMMY
-    interface LoDashExplicitArrayWrapper<T> {
-        /**
-         * @see _.fromPairs
-         */
-        fromPairs(): LoDashExplicitObjectWrapper<any>;
+        ): any[];
     }
 
     //_.head

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -1902,7 +1902,7 @@ declare module _ {
         /**
          * @see _.head
          */
-        first<T>(): LoDashExplicitWrapper<T>;
+        first(): LoDashExplicitWrapper<T>;
     }
 
     interface RecursiveArray<T> extends Array<T|RecursiveArray<T>> {}
@@ -2101,7 +2101,7 @@ declare module _ {
         /**
          * @see _.head
          */
-        head<T>(): LoDashExplicitWrapper<T>;
+        head(): LoDashExplicitWrapper<T>;
     }
 
     //_.indexOf

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -2058,7 +2058,23 @@ declare module _ {
          */
         fromPairs(
             array: any[]|List<any>
-        ): any[];
+        ): Dictionary<any>;
+    }
+
+    //_.fromPairs DUMMY
+    interface LoDashImplicitArrayWrapper<T> {
+        /**
+         * @see _.fromPairs
+         */
+        fromPairs(): LoDashImplicitObjectWrapper<any>;
+    }
+
+    //_.fromPairs DUMMY
+    interface LoDashExplicitArrayWrapper<T> {
+        /**
+         * @see _.fromPairs
+         */
+        fromPairs(): LoDashExplicitObjectWrapper<any>;
     }
 
     //_.head


### PR DESCRIPTION
This PR fixed a bunch of issues I've seen while using the typings (sorry that there's not a more specific theme).
- `min`/`max`: added to the explicit wrapper
- ~~`fromPairs`: fixed the dummy to at least return an object; added implicit and explicit wrapper types (they still use `any`)~~
- ~~`mapValues`: added to the explicit wrapper~~
- `first`/`head`: removed from explicit object wrapper; fixed return type of explicit array wrapper version
- ~~`pickBy`: make predicate optional as specified in the docs~~
- `reduce`: added to the explicit wrapper

Edit: I have since moved the less controversial changes into #8783.
