### PR TITLE
Add definition for password-hash

### DIFF
--- a/password-hash/password-hash-tests.ts
+++ b/password-hash/password-hash-tests.ts
@@ -1,0 +1,18 @@
+/// <reference path="password-hash.d.ts" />
+'use strict';
+
+import {generate, verify, isHashed} from 'password-hash';
+
+let password = 'raw-password';
+let hashed: string;
+
+hashed = generate(password);
+hashed = generate(password, {algorithm: 'sha256'});
+hashed = generate(password, {saltLength: 10});
+hashed = generate(password, {iterations: 11});
+hashed = generate(password, {algorithm: 'sha512', saltLength: 9, iterations: 11});
+
+let isOk: boolean;
+
+isOk = verify(password, hashed);
+isOk = isHashed(password);

--- a/password-hash/password-hash.d.ts
+++ b/password-hash/password-hash.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for password-hash 1.2.x
+// Project: https://github.com/davidwood/node-password-hash
+// Definitions by: TANAKA Koichi <https://github.com/mugeso/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'password-hash' {
+    export function generate(password: string, options?: Options): string;
+    export function verify(password: string, hashedPassword: string): boolean;
+    export function isHashed(password: string): boolean;
+
+    export interface Options {
+        algorithm?: string;
+        saltLength?: number;
+        iterations?: number;
+    }
+}


### PR DESCRIPTION
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

npm: https://www.npmjs.com/package/password-hash
project: https://github.com/davidwood/node-password-hash
