### PR TITLE
Updated react-router 2.0

### DIFF
--- a/react-router/react-router.d.ts
+++ b/react-router/react-router.d.ts
@@ -18,15 +18,23 @@ declare namespace ReactRouter {
 
     type Component = React.ReactType
 
-    type EnterHook = (nextState: RouterState, replaceState: RedirectFunction, callback?: Function) => any
+    type EnterHook = (nextState: RouterState, replace: RedirectFunction, callback?: Function) => void
 
-    type LeaveHook = () => any
+    type LeaveHook = () => void
+    
+    type ChangeHook = (prevState: RouterState, nextState: RouterState, replace: RedirectFunction, callback: Function) => void;
 
-    type Params = Object
+    type Params = { [param: string]: string }
 
     type ParseQueryString = (queryString: H.QueryString) => H.Query
 
-    type RedirectFunction = (state: H.LocationState, pathname: H.Pathname | H.Path, query?: H.Query) => void
+    interface RedirectFunction {
+        (location: H.LocationDescriptor): void;
+        /**
+        * @deprecated `replaceState(state, pathname, query) is deprecated; Use `replace(location)` with a location descriptor instead. http://tiny.cc/router-isActivedeprecated
+        */
+        (state: H.LocationState, pathname: H.Pathname | H.Path, query?: H.Query): void;
+    }
 
     type RouteComponent = Component
 
@@ -98,7 +106,7 @@ declare namespace ReactRouter {
         activeStyle?: React.CSSProperties
         activeClassName?: string
         onlyActiveOnIndex?: boolean
-        to: RoutePattern
+        to: RoutePattern | H.LocationDescriptor
         query?: H.Query
         state?: H.LocationState
     }
@@ -138,6 +146,7 @@ declare namespace ReactRouter {
         getComponents?: (location: H.Location, cb: (error: any, components?: RouteComponents) => void) => void
         onEnter?: EnterHook
         onLeave?: LeaveHook
+        onChange?: ChangeHook
         getIndexRoute?: (location: H.Location, cb: (error: any, indexRoute: RouteConfig) => void) => void
         getChildRoutes?: (location: H.Location, cb: (error: any, childRoutes: RouteConfig) => void) => void
     }


### PR DESCRIPTION
- Added onchange hook. [doc](https://github.com/reactjs/react-router/blob/master/docs/API.md#onchangeprevstate-nextstate-replace-callback)
- Params from `Object` chaged to `Dictionary`.
- Updated to use location descriptor. [doc](https://github.com/reactjs/react-router/blob/master/upgrade-guides/v2.0.0.md#link-to-onenter-and-isactive-use-location-descriptors)
