### PR TITLE
Lodash: Remove thisArg from everything except _.bind.

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -527,16 +527,12 @@ namespace TestDropRightWhile {
 
         result = _.dropRightWhile<TResult>(array);
         result = _.dropRightWhile<TResult>(array, predicateFn);
-        result = _.dropRightWhile<TResult>(array, predicateFn, any);
         result = _.dropRightWhile<TResult>(array, '');
-        result = _.dropRightWhile<TResult>(array, '', any);
         result = _.dropRightWhile<{a: number;}, TResult>(array, {a: 42});
 
         result = _.dropRightWhile<TResult>(list);
         result = _.dropRightWhile<TResult>(list, predicateFn);
-        result = _.dropRightWhile<TResult>(list, predicateFn, any);
         result = _.dropRightWhile<TResult>(list, '');
-        result = _.dropRightWhile<TResult>(list, '', any);
         result = _.dropRightWhile<{a: number;}, TResult>(list, {a: 42});
     }
 
@@ -545,16 +541,12 @@ namespace TestDropRightWhile {
 
         result = _(array).dropRightWhile();
         result = _(array).dropRightWhile(predicateFn);
-        result = _(array).dropRightWhile(predicateFn, any);
         result = _(array).dropRightWhile('');
-        result = _(array).dropRightWhile('', any);
         result = _(array).dropRightWhile<{a: number;}>({a: 42});
 
         result = _(list).dropRightWhile<TResult>();
         result = _(list).dropRightWhile<TResult>(predicateFn);
-        result = _(list).dropRightWhile<TResult>(predicateFn, any);
         result = _(list).dropRightWhile<TResult>('');
-        result = _(list).dropRightWhile<TResult>('', any);
         result = _(list).dropRightWhile<{a: number;}, TResult>({a: 42});
     }
 
@@ -563,16 +555,12 @@ namespace TestDropRightWhile {
 
         result = _(array).chain().dropRightWhile();
         result = _(array).chain().dropRightWhile(predicateFn);
-        result = _(array).chain().dropRightWhile(predicateFn, any);
         result = _(array).chain().dropRightWhile('');
-        result = _(array).chain().dropRightWhile('', any);
         result = _(array).chain().dropRightWhile<{a: number;}>({a: 42});
 
         result = _(list).chain().dropRightWhile<TResult>();
         result = _(list).chain().dropRightWhile<TResult>(predicateFn);
-        result = _(list).chain().dropRightWhile<TResult>(predicateFn, any);
         result = _(list).chain().dropRightWhile<TResult>('');
-        result = _(list).chain().dropRightWhile<TResult>('', any);
         result = _(list).chain().dropRightWhile<{a: number;}, TResult>({a: 42});
     }
 }
@@ -588,16 +576,12 @@ namespace TestDropWhile {
 
         result = _.dropWhile<TResult>(array);
         result = _.dropWhile<TResult>(array, predicateFn);
-        result = _.dropWhile<TResult>(array, predicateFn, any);
         result = _.dropWhile<TResult>(array, '');
-        result = _.dropWhile<TResult>(array, '', any);
         result = _.dropWhile<{a: number;}, TResult>(array, {a: 42});
 
         result = _.dropWhile<TResult>(list);
         result = _.dropWhile<TResult>(list, predicateFn);
-        result = _.dropWhile<TResult>(list, predicateFn, any);
         result = _.dropWhile<TResult>(list, '');
-        result = _.dropWhile<TResult>(list, '', any);
         result = _.dropWhile<{a: number;}, TResult>(list, {a: 42});
     }
 
@@ -606,16 +590,12 @@ namespace TestDropWhile {
 
         result = _(array).dropWhile();
         result = _(array).dropWhile(predicateFn);
-        result = _(array).dropWhile(predicateFn, any);
         result = _(array).dropWhile('');
-        result = _(array).dropWhile('', any);
         result = _(array).dropWhile<{a: number;}>({a: 42});
 
         result = _(list).dropWhile<TResult>();
         result = _(list).dropWhile<TResult>(predicateFn);
-        result = _(list).dropWhile<TResult>(predicateFn, any);
         result = _(list).dropWhile<TResult>('');
-        result = _(list).dropWhile<TResult>('', any);
         result = _(list).dropWhile<{a: number;}, TResult>({a: 42});
     }
 
@@ -624,16 +604,12 @@ namespace TestDropWhile {
 
         result = _(array).chain().dropWhile();
         result = _(array).chain().dropWhile(predicateFn);
-        result = _(array).chain().dropWhile(predicateFn, any);
         result = _(array).chain().dropWhile('');
-        result = _(array).chain().dropWhile('', any);
         result = _(array).chain().dropWhile<{a: number;}>({a: 42});
 
         result = _(list).chain().dropWhile<TResult>();
         result = _(list).chain().dropWhile<TResult>(predicateFn);
-        result = _(list).chain().dropWhile<TResult>(predicateFn, any);
         result = _(list).chain().dropWhile<TResult>('');
-        result = _(list).chain().dropWhile<TResult>('', any);
         result = _(list).chain().dropWhile<{a: number;}, TResult>({a: 42});
     }
 }
@@ -703,30 +679,22 @@ namespace TestFindIndex {
 
         result = _.findIndex<TResult>(array);
         result = _.findIndex<TResult>(array, predicateFn);
-        result = _.findIndex<TResult>(array, predicateFn, any);
         result = _.findIndex<TResult>(array, '');
-        result = _.findIndex<TResult>(array, '', any);
         result = _.findIndex<{a: number}, TResult>(array, {a: 42});
 
         result = _.findIndex<TResult>(list);
         result = _.findIndex<TResult>(list, predicateFn);
-        result = _.findIndex<TResult>(list, predicateFn, any);
         result = _.findIndex<TResult>(list, '');
-        result = _.findIndex<TResult>(list, '', any);
         result = _.findIndex<{a: number}, TResult>(list, {a: 42});
 
         result = _<TResult>(array).findIndex();
         result = _<TResult>(array).findIndex(predicateFn);
-        result = _<TResult>(array).findIndex(predicateFn, any);
         result = _<TResult>(array).findIndex('');
-        result = _<TResult>(array).findIndex('', any);
         result = _<TResult>(array).findIndex<{a: number}>({a: 42});
 
         result = _(list).findIndex();
         result = _(list).findIndex<TResult>(predicateFn);
-        result = _(list).findIndex<TResult>(predicateFn, any);
         result = _(list).findIndex('');
-        result = _(list).findIndex('', any);
         result = _(list).findIndex<{a: number}>({a: 42});
     }
 
@@ -735,16 +703,12 @@ namespace TestFindIndex {
 
         result = _<TResult>(array).chain().findIndex();
         result = _<TResult>(array).chain().findIndex(predicateFn);
-        result = _<TResult>(array).chain().findIndex(predicateFn, any);
         result = _<TResult>(array).chain().findIndex('');
-        result = _<TResult>(array).chain().findIndex('', any);
         result = _<TResult>(array).chain().findIndex<{a: number}>({a: 42});
 
         result = _(list).chain().findIndex();
         result = _(list).chain().findIndex<TResult>(predicateFn);
-        result = _(list).chain().findIndex<TResult>(predicateFn, any);
         result = _(list).chain().findIndex('');
-        result = _(list).chain().findIndex('', any);
         result = _(list).chain().findIndex<{a: number}>({a: 42});
     }
 }
@@ -761,30 +725,22 @@ namespace TestFindLastIndex {
 
         result = _.findLastIndex<TResult>(array);
         result = _.findLastIndex<TResult>(array, predicateFn);
-        result = _.findLastIndex<TResult>(array, predicateFn, any);
         result = _.findLastIndex<TResult>(array, '');
-        result = _.findLastIndex<TResult>(array, '', any);
         result = _.findLastIndex<{a: number}, TResult>(array, {a: 42});
 
         result = _.findLastIndex<TResult>(list);
         result = _.findLastIndex<TResult>(list, predicateFn);
-        result = _.findLastIndex<TResult>(list, predicateFn, any);
         result = _.findLastIndex<TResult>(list, '');
-        result = _.findLastIndex<TResult>(list, '', any);
         result = _.findLastIndex<{a: number}, TResult>(list, {a: 42});
 
         result = _<TResult>(array).findLastIndex();
         result = _<TResult>(array).findLastIndex(predicateFn);
-        result = _<TResult>(array).findLastIndex(predicateFn, any);
         result = _<TResult>(array).findLastIndex('');
-        result = _<TResult>(array).findLastIndex('', any);
         result = _<TResult>(array).findLastIndex<{a: number}>({a: 42});
 
         result = _(list).findLastIndex();
         result = _(list).findLastIndex<TResult>(predicateFn);
-        result = _(list).findLastIndex<TResult>(predicateFn, any);
         result = _(list).findLastIndex('');
-        result = _(list).findLastIndex('', any);
         result = _(list).findLastIndex<{a: number}>({a: 42});
     }
 
@@ -793,16 +749,12 @@ namespace TestFindLastIndex {
 
         result = _<TResult>(array).chain().findLastIndex();
         result = _<TResult>(array).chain().findLastIndex(predicateFn);
-        result = _<TResult>(array).chain().findLastIndex(predicateFn, any);
         result = _<TResult>(array).chain().findLastIndex('');
-        result = _<TResult>(array).chain().findLastIndex('', any);
         result = _<TResult>(array).chain().findLastIndex<{a: number}>({a: 42});
 
         result = _(list).chain().findLastIndex();
         result = _(list).chain().findLastIndex<TResult>(predicateFn);
-        result = _(list).chain().findLastIndex<TResult>(predicateFn, any);
         result = _(list).chain().findLastIndex('');
-        result = _(list).chain().findLastIndex('', any);
         result = _(list).chain().findLastIndex<{a: number}>({a: 42});
     }
 }
@@ -1412,16 +1364,12 @@ namespace TestRemove {
 
         result = _.remove<TResult>(array);
         result = _.remove<TResult>(array, predicateFn);
-        result = _.remove<TResult>(array, predicateFn, any);
         result = _.remove<TResult>(array, '');
-        result = _.remove<TResult>(array, '', any);
         result = _.remove<{a: number}, TResult>(array, {a: 42});
 
         result = _.remove<TResult>(list);
         result = _.remove<TResult>(list, predicateFn);
-        result = _.remove<TResult>(list, predicateFn, any);
         result = _.remove<TResult>(list, '');
-        result = _.remove<TResult>(list, '', any);
         result = _.remove<{a: number}, TResult>(list, {a: 42});
     }
 
@@ -1430,16 +1378,12 @@ namespace TestRemove {
 
         result = _<TResult>(array).remove();
         result = _<TResult>(array).remove(predicateFn);
-        result = _<TResult>(array).remove(predicateFn, any);
         result = _<TResult>(array).remove('');
-        result = _<TResult>(array).remove('', any);
         result = _<TResult>(array).remove<{a: number}>({a: 42});
 
         result = _(list).remove<TResult>();
         result = _(list).remove<TResult>(predicateFn);
-        result = _(list).remove<TResult>(predicateFn, any);
         result = _(list).remove<TResult>('');
-        result = _(list).remove<TResult>('', any);
         result = _(list).remove<{a: number}, TResult>({a: 42});
     }
 
@@ -1448,16 +1392,12 @@ namespace TestRemove {
 
         result = _<TResult>(array).chain().remove();
         result = _<TResult>(array).chain().remove(predicateFn);
-        result = _<TResult>(array).chain().remove(predicateFn, any);
         result = _<TResult>(array).chain().remove('');
-        result = _<TResult>(array).chain().remove('', any);
         result = _<TResult>(array).chain().remove<{a: number}>({a: 42});
 
         result = _(list).chain().remove<TResult>();
         result = _(list).chain().remove<TResult>(predicateFn);
-        result = _(list).chain().remove<TResult>(predicateFn, any);
         result = _(list).chain().remove<TResult>('');
-        result = _(list).chain().remove<TResult>('', any);
         result = _(list).chain().remove<{a: number}, TResult>({a: 42});
     }
 }
@@ -1834,16 +1774,12 @@ namespace TestTakeRightWhile {
 
         result = _.takeRightWhile<TResult>(array);
         result = _.takeRightWhile<TResult>(array, predicateFn);
-        result = _.takeRightWhile<TResult>(array, predicateFn, any);
         result = _.takeRightWhile<TResult>(array, '');
-        result = _.takeRightWhile<TResult>(array, '', any);
         result = _.takeRightWhile<{a: number;}, TResult>(array, {a: 42});
 
         result = _.takeRightWhile<TResult>(list);
         result = _.takeRightWhile<TResult>(list, predicateFn);
-        result = _.takeRightWhile<TResult>(list, predicateFn, any);
         result = _.takeRightWhile<TResult>(list, '');
-        result = _.takeRightWhile<TResult>(list, '', any);
         result = _.takeRightWhile<{a: number;}, TResult>(list, {a: 42});
     }
 
@@ -1852,16 +1788,12 @@ namespace TestTakeRightWhile {
 
         result = _(array).takeRightWhile();
         result = _(array).takeRightWhile(predicateFn);
-        result = _(array).takeRightWhile(predicateFn, any);
         result = _(array).takeRightWhile('');
-        result = _(array).takeRightWhile('', any);
         result = _(array).takeRightWhile<{a: number;}>({a: 42});
 
         result = _(list).takeRightWhile<TResult>();
         result = _(list).takeRightWhile<TResult>(predicateFn);
-        result = _(list).takeRightWhile<TResult>(predicateFn, any);
         result = _(list).takeRightWhile<TResult>('');
-        result = _(list).takeRightWhile<TResult>('', any);
         result = _(list).takeRightWhile<{a: number;}, TResult>({a: 42});
     }
 
@@ -1870,16 +1802,12 @@ namespace TestTakeRightWhile {
 
         result = _(array).chain().takeRightWhile();
         result = _(array).chain().takeRightWhile(predicateFn);
-        result = _(array).chain().takeRightWhile(predicateFn, any);
         result = _(array).chain().takeRightWhile('');
-        result = _(array).chain().takeRightWhile('', any);
         result = _(array).chain().takeRightWhile<{a: number;}>({a: 42});
 
         result = _(list).chain().takeRightWhile<TResult>();
         result = _(list).chain().takeRightWhile<TResult>(predicateFn);
-        result = _(list).chain().takeRightWhile<TResult>(predicateFn, any);
         result = _(list).chain().takeRightWhile<TResult>('');
-        result = _(list).chain().takeRightWhile<TResult>('', any);
         result = _(list).chain().takeRightWhile<{a: number;}, TResult>({a: 42});
     }
 }
@@ -1895,16 +1823,12 @@ namespace TestTakeWhile {
 
         result = _.takeWhile<TResult>(array);
         result = _.takeWhile<TResult>(array, predicateFn);
-        result = _.takeWhile<TResult>(array, predicateFn, any);
         result = _.takeWhile<TResult>(array, '');
-        result = _.takeWhile<TResult>(array, '', any);
         result = _.takeWhile<{a: number;}, TResult>(array, {a: 42});
 
         result = _.takeWhile<TResult>(list);
         result = _.takeWhile<TResult>(list, predicateFn);
-        result = _.takeWhile<TResult>(list, predicateFn, any);
         result = _.takeWhile<TResult>(list, '');
-        result = _.takeWhile<TResult>(list, '', any);
         result = _.takeWhile<{a: number;}, TResult>(list, {a: 42});
     }
 
@@ -1913,16 +1837,12 @@ namespace TestTakeWhile {
 
         result = _(array).takeWhile();
         result = _(array).takeWhile(predicateFn);
-        result = _(array).takeWhile(predicateFn, any);
         result = _(array).takeWhile('');
-        result = _(array).takeWhile('', any);
         result = _(array).takeWhile<{a: number;}>({a: 42});
 
         result = _(list).takeWhile<TResult>();
         result = _(list).takeWhile<TResult>(predicateFn);
-        result = _(list).takeWhile<TResult>(predicateFn, any);
         result = _(list).takeWhile<TResult>('');
-        result = _(list).takeWhile<TResult>('', any);
         result = _(list).takeWhile<{a: number;}, TResult>({a: 42});
     }
 
@@ -1931,16 +1851,12 @@ namespace TestTakeWhile {
 
         result = _(array).chain().takeWhile();
         result = _(array).chain().takeWhile(predicateFn);
-        result = _(array).chain().takeWhile(predicateFn, any);
         result = _(array).chain().takeWhile('');
-        result = _(array).chain().takeWhile('', any);
         result = _(array).chain().takeWhile<{a: number;}>({a: 42});
 
         result = _(list).chain().takeWhile<TResult>();
         result = _(list).chain().takeWhile<TResult>(predicateFn);
-        result = _(list).chain().takeWhile<TResult>(predicateFn, any);
         result = _(list).chain().takeWhile<TResult>('');
-        result = _(list).chain().takeWhile<TResult>('', any);
         result = _(list).chain().takeWhile<{a: number;}, TResult>({a: 42});
     }
 }
@@ -2443,14 +2359,10 @@ namespace TestUnzip {
     let result: TResult[];
     result = _.unzipWith<number, TResult>(testUnzipWithArray);
     result = _.unzipWith<number, TResult>(testUnzipWithArray, testUnzipWithIterator);
-    result = _.unzipWith<number, TResult>(testUnzipWithArray, testUnzipWithIterator, any);
     result = _.unzipWith<number, TResult>(testUnzipWithList);
     result = _.unzipWith<number, TResult>(testUnzipWithList, testUnzipWithIterator);
-    result = _.unzipWith<number, TResult>(testUnzipWithList, testUnzipWithIterator, any);
     result = _(testUnzipWithArray).unzipWith<number, TResult>(testUnzipWithIterator).value();
-    result = _(testUnzipWithArray).unzipWith<number, TResult>(testUnzipWithIterator, any).value();
     result = _(testUnzipWithList).unzipWith<number, TResult>(testUnzipWithIterator).value();
-    result = _(testUnzipWithList).unzipWith<number, TResult>(testUnzipWithIterator, any).value();
 }
 
 // _.without
@@ -2717,14 +2629,12 @@ interface TestZipWithFn {
 var testZipWithFn: TestZipWithFn;
 result = <number[]>_.zipWith<number>([1, 2]);
 result = <number[]>_.zipWith<number>([1, 2], testZipWithFn);
-result = <number[]>_.zipWith<number>([1, 2], testZipWithFn, any);
-result = <number[]>_.zipWith<number>([1, 2], [1, 2], testZipWithFn, any);
-result = <number[]>_.zipWith<number>([1, 2], [1, 2], [1, 2], [1, 2], [1, 2], [1, 2], testZipWithFn, any);
+result = <number[]>_.zipWith<number>([1, 2], [1, 2], testZipWithFn);
+result = <number[]>_.zipWith<number>([1, 2], [1, 2], [1, 2], [1, 2], [1, 2], [1, 2], testZipWithFn);
 result = <number[]>_([1, 2]).zipWith<number>().value();
 result = <number[]>_([1, 2]).zipWith<number>(testZipWithFn).value();
-result = <number[]>_([1, 2]).zipWith<number>(testZipWithFn, any).value();
-result = <number[]>_([1, 2]).zipWith<number>([1, 2], testZipWithFn, any).value();
-result = <number[]>_([1, 2]).zipWith<number>([1, 2], [1, 2], [1, 2], [1, 2], [1, 2], testZipWithFn, any).value();
+result = <number[]>_([1, 2]).zipWith<number>([1, 2], testZipWithFn).value();
+result = <number[]>_([1, 2]).zipWith<number>([1, 2], [1, 2], [1, 2], [1, 2], [1, 2], testZipWithFn).value();
 
 /*********
  * Chain *
@@ -2778,7 +2688,6 @@ namespace TestTap {
         let result: string;
 
         _.tap('', interceptor);
-        _.tap('', interceptor, any);
     }
 
     {
@@ -2786,7 +2695,6 @@ namespace TestTap {
         let result: _.LoDashImplicitArrayWrapper<string>;
 
         _.tap([''], interceptor);
-        _.tap([''], interceptor, any);
     }
 
     {
@@ -2794,18 +2702,15 @@ namespace TestTap {
         let result: _.LoDashImplicitObjectWrapper<{a: string}>;
 
         _.tap({a: ''}, interceptor);
-        _.tap({a: ''}, interceptor, any);
     }
 
     {
         let interceptor: (value: string) => void;
         let result: _.LoDashImplicitWrapper<string>;
 
-        _.chain('').tap(interceptor, any);
-        _.chain('').tap(interceptor, any);
+        _.chain('').tap(interceptor);
 
         _('').tap(interceptor);
-        _('').tap(interceptor, any);
     }
 
     {
@@ -2813,10 +2718,8 @@ namespace TestTap {
         let result: _.LoDashImplicitArrayWrapper<string>;
 
         _.chain(['']).tap(interceptor);
-        _.chain(['']).tap(interceptor, any);
 
         _(['']).tap(interceptor);
-        _(['']).tap(interceptor, any);
     }
 
     {
@@ -2824,21 +2727,17 @@ namespace TestTap {
         let result: _.LoDashImplicitObjectWrapper<{a: string}>;
 
         _.chain({a: ''}).tap(interceptor);
-        _.chain({a: ''}).tap(interceptor, any);
 
         _({a: ''}).tap(interceptor);
-        _({a: ''}).tap(interceptor, any);
     }
 
     {
         let interceptor: (value: string) => void;
         let result: _.LoDashExplicitWrapper<string>;
 
-        _.chain('').tap(interceptor, any);
-        _.chain('').tap(interceptor, any);
+        _.chain('').tap(interceptor);
 
         _('').chain().tap(interceptor);
-        _('').chain().tap(interceptor, any);
     }
 
     {
@@ -2846,10 +2745,8 @@ namespace TestTap {
         let result: _.LoDashExplicitArrayWrapper<string>;
 
         _.chain(['']).tap(interceptor);
-        _.chain(['']).tap(interceptor, any);
 
         _(['']).chain().tap(interceptor);
-        _(['']).chain().tap(interceptor, any);
     }
 
     {
@@ -2857,10 +2754,8 @@ namespace TestTap {
         let result: _.LoDashExplicitObjectWrapper<{a: string}>;
 
         _.chain({a: ''}).tap(interceptor);
-        _.chain({a: ''}).tap(interceptor, any);
 
         _({a: ''}).chain().tap(interceptor);
-        _({a: ''}).chain().tap(interceptor, any);
     }
 }
 
@@ -2875,7 +2770,6 @@ namespace TestThru {
         let result: number;
 
         result = _.thru<number, number>(1, interceptor);
-        result = _.thru<number, number>(1, interceptor, any);
     }
 
     {
@@ -2883,7 +2777,6 @@ namespace TestThru {
         let result: _.LoDashImplicitWrapper<number>;
 
         result = _(1).thru<number>(interceptor);
-        result = _(1).thru<number>(interceptor, any);
     }
 
     {
@@ -2891,7 +2784,6 @@ namespace TestThru {
         let result: _.LoDashImplicitWrapper<string>;
 
         result = _('').thru<string>(interceptor);
-        result = _('').thru<string>(interceptor, any);
     }
 
     {
@@ -2899,7 +2791,6 @@ namespace TestThru {
         let result: _.LoDashImplicitWrapper<boolean>;
 
         result = _(true).thru<boolean>(interceptor);
-        result = _(true).thru<boolean>(interceptor, any);
     }
 
     {
@@ -2907,7 +2798,6 @@ namespace TestThru {
         let result: _.LoDashImplicitObjectWrapper<{a: string}>;
 
         result = _({a: ''}).thru<{a: string}>(interceptor);
-        result = _({a: ''}).thru<{a: string}>(interceptor, any);
     }
 
     {
@@ -2915,7 +2805,6 @@ namespace TestThru {
         let result: _.LoDashImplicitArrayWrapper<number>;
 
         result = _([1, 2, 3]).thru<number>(interceptor);
-        result = _([1, 2, 3]).thru<number>(interceptor, any);
     }
 
     {
@@ -2923,7 +2812,6 @@ namespace TestThru {
         let result: _.LoDashExplicitWrapper<number>;
 
         result = _(1).chain().thru<number>(interceptor);
-        result = _(1).chain().thru<number>(interceptor, any);
     }
 
     {
@@ -2931,7 +2819,6 @@ namespace TestThru {
         let result: _.LoDashExplicitWrapper<string>;
 
         result = _('').chain().thru<string>(interceptor);
-        result = _('').chain().thru<string>(interceptor, any);
     }
 
     {
@@ -2939,7 +2826,6 @@ namespace TestThru {
         let result: _.LoDashExplicitWrapper<boolean>;
 
         result = _(true).chain().thru<boolean>(interceptor);
-        result = _(true).chain().thru<boolean>(interceptor, any);
     }
 
     {
@@ -2947,7 +2833,6 @@ namespace TestThru {
         let result: _.LoDashExplicitObjectWrapper<{a: string}>;
 
         result = _({a: ''}).chain().thru<{a: string}>(interceptor);
-        result = _({a: ''}).chain().thru<{a: string}>(interceptor, any);
     }
 
     {
@@ -2955,7 +2840,6 @@ namespace TestThru {
         let result: _.LoDashExplicitArrayWrapper<number>;
 
         result = _([1, 2, 3]).chain().thru<number>(interceptor);
-        result = _([1, 2, 3]).chain().thru<number>(interceptor, any);
     }
 }
 
@@ -3134,12 +3018,12 @@ namespace TestPlant {
 namespace TestReverse {
     {
         let result: _.LoDashImplicitArrayWrapper<number>;
-        result: _([42]).reverse();
+        result = _([42]).reverse();
     }
 
     {
         let result: _.LoDashExplicitArrayWrapper<number>;
-        result: _([42]).chain().reverse();
+        result = _([42]).chain().reverse();
     }
 }
 
@@ -3326,37 +3210,28 @@ namespace TestCountBy {
 
         result = _.countBy<string>('');
         result = _.countBy<string>('', stringIterator);
-        result = _.countBy<string>('', stringIterator, any);
 
         result = _.countBy<TResult>(array);
         result = _.countBy<TResult>(array, listIterator);
-        result = _.countBy<TResult>(array, listIterator, any);
         result = _.countBy<TResult>(array, '');
-        result = _.countBy<TResult>(array, '', any);
         result = _.countBy<{a: number}, TResult>(array, {a: 42});
         result = _.countBy<TResult>(array, {a: 42});
 
         result = _.countBy<TResult>(list);
         result = _.countBy<TResult>(list, listIterator);
-        result = _.countBy<TResult>(list, listIterator, any);
         result = _.countBy<TResult>(list, '');
-        result = _.countBy<TResult>(list, '', any);
         result = _.countBy<{a: number}, TResult>(list, {a: 42});
         result = _.countBy<TResult>(list, {a: 42});
 
         result = _.countBy<TResult>(dictionary);
         result = _.countBy<TResult>(dictionary, dictionaryIterator);
-        result = _.countBy<TResult>(dictionary, dictionaryIterator, any);
         result = _.countBy<TResult>(dictionary, '');
-        result = _.countBy<TResult>(dictionary, '', any);
         result = _.countBy<{a: number}, TResult>(dictionary, {a: 42});
         result = _.countBy<TResult>(dictionary, {a: 42});
 
         result = _.countBy<TResult>(numericDictionary);
         result = _.countBy<TResult>(numericDictionary, numericDictionaryIterator);
-        result = _.countBy<TResult>(numericDictionary, numericDictionaryIterator, any);
         result = _.countBy<TResult>(numericDictionary, '');
-        result = _.countBy<TResult>(numericDictionary, '', any);
         result = _.countBy<{a: number}, TResult>(numericDictionary, {a: 42});
         result = _.countBy<TResult>(numericDictionary, {a: 42});
     }
@@ -3366,37 +3241,28 @@ namespace TestCountBy {
 
         result = _('').countBy();
         result = _('').countBy(stringIterator);
-        result = _('').countBy(stringIterator, any);
 
         result = _(array).countBy();
         result = _(array).countBy(listIterator);
-        result = _(array).countBy(listIterator, any);
         result = _(array).countBy('');
-        result = _(array).countBy('', any);
         result = _(array).countBy<{a: number}>({a: 42});
         result = _(array).countBy({a: 42});
 
         result = _(list).countBy();
         result = _(list).countBy<TResult>(listIterator);
-        result = _(list).countBy<TResult>(listIterator, any);
         result = _(list).countBy('');
-        result = _(list).countBy('', any);
         result = _(list).countBy<{a: number}>({a: 42});
         result = _(list).countBy({a: 42});
 
         result = _(dictionary).countBy();
         result = _(dictionary).countBy<TResult>(dictionaryIterator);
-        result = _(dictionary).countBy<TResult>(dictionaryIterator, any);
         result = _(dictionary).countBy('');
-        result = _(dictionary).countBy('', any);
         result = _(dictionary).countBy<{a: number}>({a: 42});
         result = _(dictionary).countBy({a: 42});
 
         result = _(numericDictionary).countBy();
         result = _(numericDictionary).countBy<TResult>(numericDictionaryIterator);
-        result = _(numericDictionary).countBy<TResult>(numericDictionaryIterator, any);
         result = _(numericDictionary).countBy('');
-        result = _(numericDictionary).countBy('', any);
         result = _(numericDictionary).countBy<{a: number}>({a: 42});
         result = _(numericDictionary).countBy({a: 42});
     }
@@ -3406,37 +3272,28 @@ namespace TestCountBy {
 
         result = _('').chain().countBy();
         result = _('').chain().countBy(stringIterator);
-        result = _('').chain().countBy(stringIterator, any);
 
         result = _(array).chain().countBy();
         result = _(array).chain().countBy(listIterator);
-        result = _(array).chain().countBy(listIterator, any);
         result = _(array).chain().countBy('');
-        result = _(array).chain().countBy('', any);
         result = _(array).chain().countBy<{a: number}>({a: 42});
         result = _(array).chain().countBy({a: 42});
 
         result = _(list).chain().countBy();
         result = _(list).chain().countBy<TResult>(listIterator);
-        result = _(list).chain().countBy<TResult>(listIterator, any);
         result = _(list).chain().countBy('');
-        result = _(list).chain().countBy('', any);
         result = _(list).chain().countBy<{a: number}>({a: 42});
         result = _(list).chain().countBy({a: 42});
 
         result = _(dictionary).chain().countBy();
         result = _(dictionary).chain().countBy<TResult>(dictionaryIterator);
-        result = _(dictionary).chain().countBy<TResult>(dictionaryIterator, any);
         result = _(dictionary).chain().countBy('');
-        result = _(dictionary).chain().countBy('', any);
         result = _(dictionary).chain().countBy<{a: number}>({a: 42});
         result = _(dictionary).chain().countBy({a: 42});
 
         result = _(numericDictionary).chain().countBy();
         result = _(numericDictionary).chain().countBy<TResult>(numericDictionaryIterator);
-        result = _(numericDictionary).chain().countBy<TResult>(numericDictionaryIterator, any);
         result = _(numericDictionary).chain().countBy('');
-        result = _(numericDictionary).chain().countBy('', any);
         result = _(numericDictionary).chain().countBy<{a: number}>({a: 42});
         result = _(numericDictionary).chain().countBy({a: 42});
     }
@@ -3456,84 +3313,72 @@ namespace TestEach {
         let result: string;
 
         _.each('', stringIterator);
-        _.each('', stringIterator, any);
     }
 
     {
         let result: TResult[];
 
         _.each<TResult>(array, listIterator);
-        _.each<TResult>(array, listIterator, any);
     }
 
     {
         let result: _.List<TResult>;
 
         _.each<TResult>(list, listIterator);
-        _.each<TResult>(list, listIterator, any);
     }
 
     {
         let result: _.Dictionary<TResult>;
 
         _.each<TResult>(dictionary, dictionaryIterator);
-        _.each<TResult>(dictionary, dictionaryIterator, any);
     }
 
     {
         let result: _.LoDashImplicitWrapper<string>;
 
         _('').each(stringIterator);
-        _('').each(stringIterator, any);
     }
 
     {
         let result: _.LoDashImplicitArrayWrapper<TResult>;
 
         _(array).each(listIterator);
-        _(array).each(listIterator, any);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<_.List<TResult>>;
 
         _(list).each<TResult>(listIterator);
-        _(list).each<TResult>(listIterator, any);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<_.Dictionary<TResult>>;
 
         _(dictionary).each<TResult>(dictionaryIterator);
-        _(dictionary).each<TResult>(dictionaryIterator, any);
     }
 
     {
         let result: _.LoDashExplicitWrapper<string>;
 
         _('').chain().each(stringIterator);
-        _('').chain().each(stringIterator, any);
     }
 
     {
         let result: _.LoDashExplicitArrayWrapper<TResult>;
 
         _(array).chain().each(listIterator);
-        _(array).chain().each(listIterator, any);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<_.List<TResult>>;
 
         _(list).chain().each<TResult>(listIterator);
-        _(list).chain().each<TResult>(listIterator, any);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<_.Dictionary<TResult>>;
 
         _(dictionary).chain().each<TResult>(dictionaryIterator);
-        _(dictionary).chain().each<TResult>(dictionaryIterator, any);
     }
 }
 
@@ -3551,84 +3396,72 @@ namespace TestEachRight {
         let result: string;
 
         _.eachRight('', stringIterator);
-        _.eachRight('', stringIterator, any);
     }
 
     {
         let result: TResult[];
 
         _.eachRight<TResult>(array, listIterator);
-        _.eachRight<TResult>(array, listIterator, any);
     }
 
     {
         let result: _.List<TResult>;
 
         _.eachRight<TResult>(list, listIterator);
-        _.eachRight<TResult>(list, listIterator, any);
     }
 
     {
         let result: _.Dictionary<TResult>;
 
         _.eachRight<TResult>(dictionary, dictionaryIterator);
-        _.eachRight<TResult>(dictionary, dictionaryIterator, any);
     }
 
     {
         let result: _.LoDashImplicitWrapper<string>;
 
         _('').eachRight(stringIterator);
-        _('').eachRight(stringIterator, any);
     }
 
     {
         let result: _.LoDashImplicitArrayWrapper<TResult>;
 
         _(array).eachRight(listIterator);
-        _(array).eachRight(listIterator, any);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<_.List<TResult>>;
 
         _(list).eachRight<TResult>(listIterator);
-        _(list).eachRight<TResult>(listIterator, any);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<_.Dictionary<TResult>>;
 
         _(dictionary).eachRight<TResult>(dictionaryIterator);
-        _(dictionary).eachRight<TResult>(dictionaryIterator, any);
     }
 
     {
         let result: _.LoDashExplicitWrapper<string>;
 
         _('').chain().eachRight(stringIterator);
-        _('').chain().eachRight(stringIterator, any);
     }
 
     {
         let result: _.LoDashExplicitArrayWrapper<TResult>;
 
         _(array).chain().eachRight(listIterator);
-        _(array).chain().eachRight(listIterator, any);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<_.List<TResult>>;
 
         _(list).chain().eachRight<TResult>(listIterator);
-        _(list).chain().eachRight<TResult>(listIterator, any);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<_.Dictionary<TResult>>;
 
         _(dictionary).chain().eachRight<TResult>(dictionaryIterator);
-        _(dictionary).chain().eachRight<TResult>(dictionaryIterator, any);
     }
 }
 
@@ -3740,28 +3573,21 @@ namespace TestFilter {
         let result: string[];
 
         result = _.filter('', stringIterator);
-        result = _.filter('', stringIterator, any);
     }
 
     {
         let result: TResult[];
 
         result = _.filter<TResult>(array, listIterator);
-        result = _.filter<TResult>(array, listIterator, any);
         result = _.filter<TResult>(array, '');
-        result = _.filter<TResult>(array, '', any);
         result = _.filter<{a: number}, TResult>(array, {a: 42});
 
         result = _.filter<TResult>(list, listIterator);
-        result = _.filter<TResult>(list, listIterator, any);
         result = _.filter<TResult>(list, '');
-        result = _.filter<TResult>(list, '', any);
         result = _.filter<{a: number}, TResult>(list, {a: 42});
 
         result = _.filter<TResult>(dictionary, dictionaryIterator);
-        result = _.filter<TResult>(dictionary, dictionaryIterator, any);
         result = _.filter<TResult>(dictionary, '');
-        result = _.filter<TResult>(dictionary, '', any);
         result = _.filter<{a: number}, TResult>(dictionary, {a: 42});
     }
 
@@ -3769,28 +3595,21 @@ namespace TestFilter {
         let result: _.LoDashImplicitArrayWrapper<string>;
 
         result = _('').filter(stringIterator);
-        result = _('').filter(stringIterator, any);
     }
 
     {
         let result: _.LoDashImplicitArrayWrapper<TResult>;
 
         result = _(array).filter(listIterator);
-        result = _(array).filter(listIterator, any);
         result = _(array).filter('');
-        result = _(array).filter('', any);
         result = _(array).filter<{a: number}>({a: 42});
 
         result = _(list).filter<TResult>(listIterator);
-        result = _(list).filter<TResult>(listIterator, any);
         result = _(list).filter<TResult>('');
-        result = _(list).filter<TResult>('', any);
         result = _(list).filter<{a: number}, TResult>({a: 42});
 
         result = _(dictionary).filter<TResult>(dictionaryIterator);
-        result = _(dictionary).filter<TResult>(dictionaryIterator, any);
         result = _(dictionary).filter<TResult>('');
-        result = _(dictionary).filter<TResult>('', any);
         result = _(dictionary).filter<{a: number}, TResult>({a: 42});
     }
 
@@ -3798,28 +3617,21 @@ namespace TestFilter {
         let result: _.LoDashExplicitArrayWrapper<string>;
 
         result = _('').chain().filter(stringIterator);
-        result = _('').chain().filter(stringIterator, any);
     }
 
     {
         let result: _.LoDashExplicitArrayWrapper<TResult>;
 
         result = _(array).chain().filter(listIterator);
-        result = _(array).chain().filter(listIterator, any);
         result = _(array).chain().filter('');
-        result = _(array).chain().filter('', any);
         result = _(array).chain().filter<{a: number}>({a: 42});
 
         result = _(list).chain().filter<TResult>(listIterator);
-        result = _(list).chain().filter<TResult>(listIterator, any);
         result = _(list).chain().filter<TResult>('');
-        result = _(list).chain().filter<TResult>('', any);
         result = _(list).chain().filter<{a: number}, TResult>({a: 42});
 
         result = _(dictionary).chain().filter<TResult>(dictionaryIterator);
-        result = _(dictionary).chain().filter<TResult>(dictionaryIterator, any);
         result = _(dictionary).chain().filter<TResult>('');
-        result = _(dictionary).chain().filter<TResult>('', any);
         result = _(dictionary).chain().filter<{a: number}, TResult>({a: 42});
     }
 }
@@ -3837,37 +3649,31 @@ namespace TestFind {
 
     result = _.find<TResult>(array);
     result = _.find<TResult>(array, listIterator);
-    result = _.find<TResult>(array, listIterator, any);
     result = _.find<TResult>(array, '');
     result = _.find<{a: number}, TResult>(array, {a: 42});
 
     result = _.find<TResult>(list);
     result = _.find<TResult>(list, listIterator);
-    result = _.find<TResult>(list, listIterator, any);
     result = _.find<TResult>(list, '');
     result = _.find<{a: number}, TResult>(list, {a: 42});
 
     result = _.find<TResult>(dictionary);
     result = _.find<TResult>(dictionary, dictionaryIterator);
-    result = _.find<TResult>(dictionary, dictionaryIterator, any);
     result = _.find<TResult>(dictionary, '');
     result = _.find<{a: number}, TResult>(dictionary, {a: 42});
 
     result = _(array).find();
     result = _(array).find(listIterator);
-    result = _(array).find(listIterator, any);
     result = _(array).find('');
     result = _(array).find<{a: number}>({a: 42});
 
     result = _(list).find<TResult>();
     result = _(list).find<TResult>(listIterator);
-    result = _(list).find<TResult>(listIterator, any);
     result = _(list).find<TResult>('');
     result = _(list).find<{a: number}, TResult>({a: 42});
 
     result = _(dictionary).find<TResult>();
     result = _(dictionary).find<TResult>(dictionaryIterator);
-    result = _(dictionary).find<TResult>(dictionaryIterator, any);
     result = _(dictionary).find<TResult>('');
     result = _(dictionary).find<{a: number}, TResult>({a: 42});
 }
@@ -4089,84 +3895,72 @@ namespace TestForEach {
         let result: string;
 
         _.forEach('', stringIterator);
-        _.forEach('', stringIterator, any);
     }
 
     {
         let result: TResult[];
 
         _.forEach<TResult>(array, listIterator);
-        _.forEach<TResult>(array, listIterator, any);
     }
 
     {
         let result: _.List<TResult>;
 
         _.forEach<TResult>(list, listIterator);
-        _.forEach<TResult>(list, listIterator, any);
     }
 
     {
         let result: _.Dictionary<TResult>;
 
         _.forEach<TResult>(dictionary, dictionaryIterator);
-        _.forEach<TResult>(dictionary, dictionaryIterator, any);
     }
 
     {
         let result: _.LoDashImplicitWrapper<string>;
 
         _('').forEach(stringIterator);
-        _('').forEach(stringIterator, any);
     }
 
     {
         let result: _.LoDashImplicitArrayWrapper<TResult>;
 
         _(array).forEach(listIterator);
-        _(array).forEach(listIterator, any);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<_.List<TResult>>;
 
         _(list).forEach<TResult>(listIterator);
-        _(list).forEach<TResult>(listIterator, any);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<_.Dictionary<TResult>>;
 
         _(dictionary).forEach<TResult>(dictionaryIterator);
-        _(dictionary).forEach<TResult>(dictionaryIterator, any);
     }
 
     {
         let result: _.LoDashExplicitWrapper<string>;
 
         _('').chain().forEach(stringIterator);
-        _('').chain().forEach(stringIterator, any);
     }
 
     {
         let result: _.LoDashExplicitArrayWrapper<TResult>;
 
         _(array).chain().forEach(listIterator);
-        _(array).chain().forEach(listIterator, any);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<_.List<TResult>>;
 
         _(list).chain().forEach<TResult>(listIterator);
-        _(list).chain().forEach<TResult>(listIterator, any);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<_.Dictionary<TResult>>;
 
         _(dictionary).chain().forEach<TResult>(dictionaryIterator);
-        _(dictionary).chain().forEach<TResult>(dictionaryIterator, any);
     }
 }
 
@@ -4184,84 +3978,72 @@ namespace TestForEachRight {
         let result: string;
 
         _.forEachRight('', stringIterator);
-        _.forEachRight('', stringIterator, any);
     }
 
     {
         let result: TResult[];
 
         _.forEachRight<TResult>(array, listIterator);
-        _.forEachRight<TResult>(array, listIterator, any);
     }
 
     {
         let result: _.List<TResult>;
 
         _.forEachRight<TResult>(list, listIterator);
-        _.forEachRight<TResult>(list, listIterator, any);
     }
 
     {
         let result: _.Dictionary<TResult>;
 
         _.forEachRight<TResult>(dictionary, dictionaryIterator);
-        _.forEachRight<TResult>(dictionary, dictionaryIterator, any);
     }
 
     {
         let result: _.LoDashImplicitWrapper<string>;
 
         _('').forEachRight(stringIterator);
-        _('').forEachRight(stringIterator, any);
     }
 
     {
         let result: _.LoDashImplicitArrayWrapper<TResult>;
 
         _(array).forEachRight(listIterator);
-        _(array).forEachRight(listIterator, any);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<_.List<TResult>>;
 
         _(list).forEachRight<TResult>(listIterator);
-        _(list).forEachRight<TResult>(listIterator, any);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<_.Dictionary<TResult>>;
 
         _(dictionary).forEachRight<TResult>(dictionaryIterator);
-        _(dictionary).forEachRight<TResult>(dictionaryIterator, any);
     }
 
     {
         let result: _.LoDashExplicitWrapper<string>;
 
         _('').chain().forEachRight(stringIterator);
-        _('').chain().forEachRight(stringIterator, any);
     }
 
     {
         let result: _.LoDashExplicitArrayWrapper<TResult>;
 
         _(array).chain().forEachRight(listIterator);
-        _(array).chain().forEachRight(listIterator, any);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<_.List<TResult>>;
 
         _(list).chain().forEachRight<TResult>(listIterator);
-        _(list).chain().forEachRight<TResult>(listIterator, any);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<_.Dictionary<TResult>>;
 
         _(dictionary).chain().forEachRight<TResult>(dictionaryIterator);
-        _(dictionary).chain().forEachRight<TResult>(dictionaryIterator, any);
     }
 }
 
@@ -4282,9 +4064,7 @@ namespace TestGroupBy {
 
         result = _.groupBy<string>('');
         result = _.groupBy<string>('', stringIterator);
-        result = _.groupBy<string>('', stringIterator, any);
         result = _.groupBy<string, number>('', stringIterator);
-        result = _.groupBy<string, number>('', stringIterator, any);
     }
 
     {
@@ -4292,38 +4072,29 @@ namespace TestGroupBy {
 
         result = _.groupBy<SampleType>(array);
         result = _.groupBy<SampleType>(array, listIterator);
-        result = _.groupBy<SampleType>(array, listIterator, any);
         result = _.groupBy<SampleType>(array, '');
-        result = _.groupBy<SampleType>(array, '', any);
         result = _.groupBy<SampleType>(array, {a: 42});
 
         result = _.groupBy<SampleType, number>(array, listIterator);
-        result = _.groupBy<SampleType, number>(array, listIterator, any);
-        result = _.groupBy<SampleType, boolean>(array, '', true);
+        result = _.groupBy<SampleType, boolean>(array, '');
         result = _.groupBy<{a: number}, SampleType>(array, {a: 42});
 
         result = _.groupBy<SampleType>(list);
         result = _.groupBy<SampleType>(list, listIterator);
-        result = _.groupBy<SampleType>(list, listIterator, any);
         result = _.groupBy<SampleType>(list, '');
-        result = _.groupBy<SampleType>(list, '', any);
         result = _.groupBy<SampleType>(list, {a: 42});
 
         result = _.groupBy<SampleType, number>(list, listIterator);
-        result = _.groupBy<SampleType, number>(list, listIterator, any);
-        result = _.groupBy<SampleType, boolean>(list, '', true);
+        result = _.groupBy<SampleType, boolean>(list, '');
         result = _.groupBy<{a: number}, SampleType>(list, {a: 42});
 
         result = _.groupBy<SampleType>(dictionary);
         result = _.groupBy<SampleType>(dictionary, dictionaryIterator);
-        result = _.groupBy<SampleType>(dictionary, dictionaryIterator, any);
         result = _.groupBy<SampleType>(dictionary, '');
-        result = _.groupBy<SampleType>(dictionary, '', any);
         result = _.groupBy<SampleType>(dictionary, {a: 42});
 
         result = _.groupBy<SampleType, number>(dictionary, dictionaryIterator);
-        result = _.groupBy<SampleType, number>(dictionary, dictionaryIterator, any);
-        result = _.groupBy<SampleType, boolean>(dictionary, '', true);
+        result = _.groupBy<SampleType, boolean>(dictionary, '');
         result = _.groupBy<{a: number}, SampleType>(dictionary, {a: 42});
     }
 
@@ -4332,7 +4103,6 @@ namespace TestGroupBy {
 
         result = _('').groupBy();
         result = _('').groupBy<number>(stringIterator);
-        result = _('').groupBy<number>(stringIterator, any);
     }
 
     {
@@ -4340,33 +4110,26 @@ namespace TestGroupBy {
 
         result = _(array).groupBy();
         result = _(array).groupBy<number>(listIterator);
-        result = _(array).groupBy<number>(listIterator, any);
         result = _(array).groupBy('');
-        result = _(array).groupBy<boolean>('', true);
+        result = _(array).groupBy<boolean>('');
         result = _(array).groupBy<{a: number}>({a: 42});
 
         result = _(list).groupBy<SampleType>();
         result = _(list).groupBy<SampleType>(listIterator);
-        result = _(list).groupBy<SampleType>(listIterator, any);
         result = _(list).groupBy<SampleType>('');
-        result = _(list).groupBy<SampleType>('', any);
         result = _(list).groupBy<SampleType>({a: 42});
 
         result = _(list).groupBy<SampleType, number>(listIterator);
-        result = _(list).groupBy<SampleType, number>(listIterator, any);
-        result = _(list).groupBy<SampleType, boolean>('', true);
+        result = _(list).groupBy<SampleType, boolean>('');
         result = _(list).groupBy<{a: number}, SampleType>({a: 42});
 
         result = _(dictionary).groupBy<SampleType>();
         result = _(dictionary).groupBy<SampleType>(dictionaryIterator);
-        result = _(dictionary).groupBy<SampleType>(dictionaryIterator, any);
         result = _(dictionary).groupBy<SampleType>('');
-        result = _(dictionary).groupBy<SampleType>('', any);
         result = _(dictionary).groupBy<SampleType>({a: 42});
 
         result = _(dictionary).groupBy<SampleType, number>(dictionaryIterator);
-        result = _(dictionary).groupBy<SampleType, number>(dictionaryIterator, any);
-        result = _(dictionary).groupBy<SampleType, boolean>('', true);
+        result = _(dictionary).groupBy<SampleType, boolean>('');
         result = _(dictionary).groupBy<{a: number}, SampleType>({a: 42});
     }
 
@@ -4375,7 +4138,6 @@ namespace TestGroupBy {
 
         result = _('').chain().groupBy();
         result = _('').chain().groupBy<number>(stringIterator);
-        result = _('').chain().groupBy<number>(stringIterator, any);
     }
 
     {
@@ -4383,33 +4145,26 @@ namespace TestGroupBy {
 
         result = _(array).chain().groupBy();
         result = _(array).chain().groupBy<number>(listIterator);
-        result = _(array).chain().groupBy<number>(listIterator, any);
         result = _(array).chain().groupBy('');
-        result = _(array).chain().groupBy<boolean>('', true);
+        result = _(array).chain().groupBy<boolean>('');
         result = _(array).chain().groupBy<{a: number}>({a: 42});
 
         result = _(list).chain().groupBy<SampleType>();
         result = _(list).chain().groupBy<SampleType>(listIterator);
-        result = _(list).chain().groupBy<SampleType>(listIterator, any);
         result = _(list).chain().groupBy<SampleType>('');
-        result = _(list).chain().groupBy<SampleType>('', any);
         result = _(list).chain().groupBy<SampleType>({a: 42});
 
         result = _(list).chain().groupBy<SampleType, number>(listIterator);
-        result = _(list).chain().groupBy<SampleType, number>(listIterator, any);
-        result = _(list).chain().groupBy<SampleType, boolean>('', true);
+        result = _(list).chain().groupBy<SampleType, boolean>('');
         result = _(list).chain().groupBy<{a: number}, SampleType>({a: 42});
 
         result = _(dictionary).chain().groupBy<SampleType>();
         result = _(dictionary).chain().groupBy<SampleType>(dictionaryIterator);
-        result = _(dictionary).chain().groupBy<SampleType>(dictionaryIterator, any);
         result = _(dictionary).chain().groupBy<SampleType>('');
-        result = _(dictionary).chain().groupBy<SampleType>('', any);
         result = _(dictionary).chain().groupBy<SampleType>({a: 42});
 
         result = _(dictionary).chain().groupBy<SampleType, number>(dictionaryIterator);
-        result = _(dictionary).chain().groupBy<SampleType, number>(dictionaryIterator, any);
-        result = _(dictionary).chain().groupBy<SampleType, boolean>('', true);
+        result = _(dictionary).chain().groupBy<SampleType, boolean>('');
         result = _(dictionary).chain().groupBy<{a: number}, SampleType>({a: 42});
     }
 }
@@ -4479,7 +4234,6 @@ namespace TestKeyBy {
 
         result = _.keyBy<string>('abcd');
         result = _.keyBy<string>('abcd', stringIterator);
-        result = _.keyBy<string>('abcd', stringIterator, any);
     }
 
     {
@@ -4487,33 +4241,25 @@ namespace TestKeyBy {
 
         result = _.keyBy<SampleObject>(array);
         result = _.keyBy<SampleObject>(array, listIterator);
-        result = _.keyBy<SampleObject>(array, listIterator, any);
         result = _.keyBy<SampleObject>(array, 'a');
-        result = _.keyBy<SampleObject>(array, 'a', any);
         result = _.keyBy<{a: number}, SampleObject>(array, {a: 42});
         result = _.keyBy<SampleObject>(array, {a: 42});
 
         result = _.keyBy<SampleObject>(list);
         result = _.keyBy<SampleObject>(list, listIterator);
-        result = _.keyBy<SampleObject>(list, listIterator, any);
         result = _.keyBy<SampleObject>(list, 'a');
-        result = _.keyBy<SampleObject>(list, 'a', any);
         result = _.keyBy<{a: number}, SampleObject>(list, {a: 42});
         result = _.keyBy<SampleObject>(list, {a: 42});
 
         result = _.keyBy<SampleObject>(numericDictionary);
         result = _.keyBy<SampleObject>(numericDictionary, numericDictionaryIterator);
-        result = _.keyBy<SampleObject>(numericDictionary, numericDictionaryIterator, any);
         result = _.keyBy<SampleObject>(numericDictionary, 'a');
-        result = _.keyBy<SampleObject>(numericDictionary, 'a', any);
         result = _.keyBy<{a: number}, SampleObject>(numericDictionary, {a: 42});
         result = _.keyBy<SampleObject>(numericDictionary, {a: 42});
 
         result = _.keyBy<SampleObject>(dictionary);
         result = _.keyBy<SampleObject>(dictionary, dictionaryIterator);
-        result = _.keyBy<SampleObject>(dictionary, dictionaryIterator, any);
         result = _.keyBy<SampleObject>(dictionary, 'a');
-        result = _.keyBy<SampleObject>(dictionary, 'a', any);
         result = _.keyBy<{a: number}, SampleObject>(dictionary, {a: 42});
         result = _.keyBy<SampleObject>(dictionary, {a: 42});
     }
@@ -4523,7 +4269,6 @@ namespace TestKeyBy {
 
         result = _('abcd').keyBy();
         result = _('abcd').keyBy(stringIterator);
-        result = _('abcd').keyBy(stringIterator, any);
     }
 
     {
@@ -4531,32 +4276,24 @@ namespace TestKeyBy {
 
         result = _(array).keyBy();
         result = _(array).keyBy(listIterator);
-        result = _(array).keyBy(listIterator, any);
         result = _(array).keyBy('a');
-        result = _(array).keyBy('a', any);
         result = _(array).keyBy<{a: number}>({a: 42});
 
         result = _(list).keyBy<SampleObject>();
         result = _(list).keyBy<SampleObject>(listIterator);
-        result = _(list).keyBy<SampleObject>(listIterator, any);
         result = _(list).keyBy<SampleObject>('a');
-        result = _(list).keyBy<SampleObject>('a', any);
         result = _(list).keyBy<{a: number}, SampleObject>({a: 42});
         result = _(list).keyBy<SampleObject>({a: 42});
 
         result = _(numericDictionary).keyBy<SampleObject>();
         result = _(numericDictionary).keyBy<SampleObject>(numericDictionaryIterator);
-        result = _(numericDictionary).keyBy<SampleObject>(numericDictionaryIterator, any);
         result = _(numericDictionary).keyBy<SampleObject>('a');
-        result = _(numericDictionary).keyBy<SampleObject>('a', any);
         result = _(numericDictionary).keyBy<{a: number}, SampleObject>({a: 42});
         result = _(numericDictionary).keyBy<SampleObject>({a: 42});
 
         result = _(dictionary).keyBy<SampleObject>();
         result = _(dictionary).keyBy<SampleObject>(dictionaryIterator);
-        result = _(dictionary).keyBy<SampleObject>(dictionaryIterator, any);
         result = _(dictionary).keyBy<SampleObject>('a');
-        result = _(dictionary).keyBy<SampleObject>('a', any);
         result = _(dictionary).keyBy<{a: number}, SampleObject>({a: 42});
         result = _(dictionary).keyBy<SampleObject>({a: 42});
     }
@@ -4566,7 +4303,6 @@ namespace TestKeyBy {
 
         result = _('abcd').chain().keyBy();
         result = _('abcd').chain().keyBy(stringIterator);
-        result = _('abcd').chain().keyBy(stringIterator, any);
     }
 
     {
@@ -4574,32 +4310,24 @@ namespace TestKeyBy {
 
         result = _(array).chain().keyBy();
         result = _(array).chain().keyBy(listIterator);
-        result = _(array).chain().keyBy(listIterator, any);
         result = _(array).chain().keyBy('a');
-        result = _(array).chain().keyBy('a', any);
         result = _(array).chain().keyBy<{a: number}>({a: 42});
 
         result = _(list).chain().keyBy<SampleObject>();
         result = _(list).chain().keyBy<SampleObject>(listIterator);
-        result = _(list).chain().keyBy<SampleObject>(listIterator, any);
         result = _(list).chain().keyBy<SampleObject>('a');
-        result = _(list).chain().keyBy<SampleObject>('a', any);
         result = _(list).chain().keyBy<{a: number}, SampleObject>({a: 42});
         result = _(list).chain().keyBy<SampleObject>({a: 42});
 
         result = _(numericDictionary).chain().keyBy<SampleObject>();
         result = _(numericDictionary).chain().keyBy<SampleObject>(numericDictionaryIterator);
-        result = _(numericDictionary).chain().keyBy<SampleObject>(numericDictionaryIterator, any);
         result = _(numericDictionary).chain().keyBy<SampleObject>('a');
-        result = _(numericDictionary).chain().keyBy<SampleObject>('a', any);
         result = _(numericDictionary).chain().keyBy<{a: number}, SampleObject>({a: 42});
         result = _(numericDictionary).chain().keyBy<SampleObject>({a: 42});
 
         result = _(dictionary).chain().keyBy<SampleObject>();
         result = _(dictionary).chain().keyBy<SampleObject>(dictionaryIterator);
-        result = _(dictionary).chain().keyBy<SampleObject>(dictionaryIterator, any);
         result = _(dictionary).chain().keyBy<SampleObject>('a');
-        result = _(dictionary).chain().keyBy<SampleObject>('a', any);
         result = _(dictionary).chain().keyBy<{a: number}, SampleObject>({a: 42});
         result = _(dictionary).chain().keyBy<SampleObject>({a: 42});
     }
@@ -4749,17 +4477,14 @@ namespace TestMap {
 
         result = _.map<number, TResult>(array);
         result = _.map<number, TResult>(array, listIterator);
-        result = _.map<number, TResult>(array, listIterator, any);
         result = _.map<number, TResult>(array, '');
 
         result = _.map<number, TResult>(list);
         result = _.map<number, TResult>(list, listIterator);
-        result = _.map<number, TResult>(list, listIterator, any);
         result = _.map<number, TResult>(list, '');
 
         result = _.map<number, TResult>(dictionary);
         result = _.map<number, TResult>(dictionary, dictionaryIterator);
-        result = _.map<number, TResult>(dictionary, dictionaryIterator, any);
         result = _.map<number, TResult>(dictionary, '');
     }
 
@@ -4776,17 +4501,14 @@ namespace TestMap {
 
         result = _<number>(array).map<TResult>();
         result = _<number>(array).map<TResult>(listIterator);
-        result = _<number>(array).map<TResult>(listIterator, any);
         result = _<number>(array).map<TResult>('');
 
         result = _(list).map<number, TResult>();
         result = _(list).map<number, TResult>(listIterator);
-        result = _(list).map<number, TResult>(listIterator, any);
         result = _(list).map<number, TResult>('');
 
         result = _(dictionary).map<number, TResult>();
         result = _(dictionary).map<number, TResult>(dictionaryIterator);
-        result = _(dictionary).map<number, TResult>(dictionaryIterator, any);
         result = _(dictionary).map<number, TResult>('');
     }
 
@@ -4803,17 +4525,14 @@ namespace TestMap {
 
         result = _<number>(array).chain().map<TResult>();
         result = _<number>(array).chain().map<TResult>(listIterator);
-        result = _<number>(array).chain().map<TResult>(listIterator, any);
         result = _<number>(array).chain().map<TResult>('');
 
         result = _(list).chain().map<number, TResult>();
         result = _(list).chain().map<number, TResult>(listIterator);
-        result = _(list).chain().map<number, TResult>(listIterator, any);
         result = _(list).chain().map<number, TResult>('');
 
         result = _(dictionary).chain().map<number, TResult>();
         result = _(dictionary).chain().map<number, TResult>(dictionaryIterator);
-        result = _(dictionary).chain().map<number, TResult>(dictionaryIterator, any);
         result = _(dictionary).chain().map<number, TResult>('');
     }
 
@@ -4957,28 +4676,21 @@ namespace TestReject {
         let result: string[];
 
         result = _.reject('', stringIterator);
-        result = _.reject('', stringIterator, any);
     }
 
     {
         let result: TResult[];
 
         result = _.reject<TResult>(array, listIterator);
-        result = _.reject<TResult>(array, listIterator, any);
         result = _.reject<TResult>(array, '');
-        result = _.reject<TResult>(array, '', any);
         result = _.reject<{a: number}, TResult>(array, {a: 42});
 
         result = _.reject<TResult>(list, listIterator);
-        result = _.reject<TResult>(list, listIterator, any);
         result = _.reject<TResult>(list, '');
-        result = _.reject<TResult>(list, '', any);
         result = _.reject<{a: number}, TResult>(list, {a: 42});
 
         result = _.reject<TResult>(dictionary, dictionaryIterator);
-        result = _.reject<TResult>(dictionary, dictionaryIterator, any);
         result = _.reject<TResult>(dictionary, '');
-        result = _.reject<TResult>(dictionary, '', any);
         result = _.reject<{a: number}, TResult>(dictionary, {a: 42});
     }
 
@@ -4986,28 +4698,21 @@ namespace TestReject {
         let result: _.LoDashImplicitArrayWrapper<string>;
 
         result = _('').reject(stringIterator);
-        result = _('').reject(stringIterator, any);
     }
 
     {
         let result: _.LoDashImplicitArrayWrapper<TResult>;
 
         result = _(array).reject(listIterator);
-        result = _(array).reject(listIterator, any);
         result = _(array).reject('');
-        result = _(array).reject('', any);
         result = _(array).reject<{a: number}>({a: 42});
 
         result = _(list).reject<TResult>(listIterator);
-        result = _(list).reject<TResult>(listIterator, any);
         result = _(list).reject<TResult>('');
-        result = _(list).reject<TResult>('', any);
         result = _(list).reject<{a: number}, TResult>({a: 42});
 
         result = _(dictionary).reject<TResult>(dictionaryIterator);
-        result = _(dictionary).reject<TResult>(dictionaryIterator, any);
         result = _(dictionary).reject<TResult>('');
-        result = _(dictionary).reject<TResult>('', any);
         result = _(dictionary).reject<{a: number}, TResult>({a: 42});
     }
 
@@ -5015,28 +4720,21 @@ namespace TestReject {
         let result: _.LoDashExplicitArrayWrapper<string>;
 
         result = _('').chain().reject(stringIterator);
-        result = _('').chain().reject(stringIterator, any);
     }
 
     {
         let result: _.LoDashExplicitArrayWrapper<TResult>;
 
         result = _(array).chain().reject(listIterator);
-        result = _(array).chain().reject(listIterator, any);
         result = _(array).chain().reject('');
-        result = _(array).chain().reject('', any);
         result = _(array).chain().reject<{a: number}>({a: 42});
 
         result = _(list).chain().reject<TResult>(listIterator);
-        result = _(list).chain().reject<TResult>(listIterator, any);
         result = _(list).chain().reject<TResult>('');
-        result = _(list).chain().reject<TResult>('', any);
         result = _(list).chain().reject<{a: number}, TResult>({a: 42});
 
         result = _(dictionary).chain().reject<TResult>(dictionaryIterator);
-        result = _(dictionary).chain().reject<TResult>(dictionaryIterator, any);
         result = _(dictionary).chain().reject<TResult>('');
-        result = _(dictionary).chain().reject<TResult>('', any);
         result = _(dictionary).chain().reject<{a: number}, TResult>({a: 42});
     }
 }
@@ -8970,7 +8668,6 @@ namespace TestExtend {
 
         result = _.extend<Obj, S1, Obj & S1>(obj, s1);
         result = _.extend<Obj, S1, Obj & S1>(obj, s1, customizer);
-        result = _.extend<Obj, S1, Obj & S1>(obj, s1, customizer, any);
     }
 
     {
@@ -8978,7 +8675,6 @@ namespace TestExtend {
 
         result = _.extend<Obj, S1, S2, Obj & S1 & S2>(obj, s1, s2);
         result = _.extend<Obj, S1, S2, Obj & S1 & S2>(obj, s1, s2, customizer);
-        result = _.extend<Obj, S1, S2, Obj & S1 & S2>(obj, s1, s2, customizer, any);
     }
 
     {
@@ -8986,7 +8682,6 @@ namespace TestExtend {
 
         result = _.extend<Obj, S1, S2, S3, Obj & S1 & S2 & S3>(obj, s1, s2, s3);
         result = _.extend<Obj, S1, S2, S3, Obj & S1 & S2 & S3>(obj, s1, s2, s3, customizer);
-        result = _.extend<Obj, S1, S2, S3, Obj & S1 & S2 & S3>(obj, s1, s2, s3, customizer, any);
     }
 
     {
@@ -8994,7 +8689,6 @@ namespace TestExtend {
 
         result = _.extend<Obj, S1, S2, S3, S4, Obj & S1 & S2 & S3 & S4>(obj, s1, s2, s3, s4);
         result = _.extend<Obj, S1, S2, S3, S4, Obj & S1 & S2 & S3 & S4>(obj, s1, s2, s3, s4, customizer);
-        result = _.extend<Obj, S1, S2, S3, S4, Obj & S1 & S2 & S3 & S4>(obj, s1, s2, s3, s4, customizer, any);
     }
 
     {
@@ -9002,7 +8696,6 @@ namespace TestExtend {
 
         result = _.extend<Obj, Obj & S1 & S2 & S3 & S4 & S5>(obj, s1, s2, s3, s4, s5);
         result = _.extend<Obj, Obj & S1 & S2 & S3 & S4 & S5>(obj, s1, s2, s3, s4, s5, customizer);
-        result = _.extend<Obj, Obj & S1 & S2 & S3 & S4 & S5>(obj, s1, s2, s3, s4, s5, customizer, any);
     }
 
     {
@@ -9016,7 +8709,6 @@ namespace TestExtend {
 
         result = _(obj).extend<S1, Obj & S1>(s1);
         result = _(obj).extend<S1, Obj & S1>(s1, customizer);
-        result = _(obj).extend<S1, Obj & S1>(s1, customizer, any);
     }
 
     {
@@ -9024,7 +8716,6 @@ namespace TestExtend {
 
         result = _(obj).extend<S1, S2, Obj & S1 & S2>(s1, s2);
         result = _(obj).extend<S1, S2, Obj & S1 & S2>(s1, s2, customizer);
-        result = _(obj).extend<S1, S2, Obj & S1 & S2>(s1, s2, customizer, any);
     }
 
     {
@@ -9032,7 +8723,6 @@ namespace TestExtend {
 
         result = _(obj).extend<S1, S2, S3, Obj & S1 & S2 & S3>(s1, s2, s3);
         result = _(obj).extend<S1, S2, S3, Obj & S1 & S2 & S3>(s1, s2, s3, customizer);
-        result = _(obj).extend<S1, S2, S3, Obj & S1 & S2 & S3>(s1, s2, s3, customizer, any);
     }
 
     {
@@ -9040,7 +8730,6 @@ namespace TestExtend {
 
         result = _(obj).extend<S1, S2, S3, S4, Obj & S1 & S2 & S3 & S4>(s1, s2, s3, s4);
         result = _(obj).extend<S1, S2, S3, S4, Obj & S1 & S2 & S3 & S4>(s1, s2, s3, s4, customizer);
-        result = _(obj).extend<S1, S2, S3, S4, Obj & S1 & S2 & S3 & S4>(s1, s2, s3, s4, customizer, any);
     }
 
     {
@@ -9048,7 +8737,6 @@ namespace TestExtend {
 
         result = _(obj).extend<Obj & S1 & S2 & S3 & S4 & S5>(s1, s2, s3, s4, s5);
         result = _(obj).extend<Obj & S1 & S2 & S3 & S4 & S5>(s1, s2, s3, s4, s5, customizer);
-        result = _(obj).extend<Obj & S1 & S2 & S3 & S4 & S5>(s1, s2, s3, s4, s5, customizer, any);
     }
 
     {
@@ -9062,7 +8750,6 @@ namespace TestExtend {
 
         result = _(obj).chain().extend<S1, Obj & S1>(s1);
         result = _(obj).chain().extend<S1, Obj & S1>(s1, customizer);
-        result = _(obj).chain().extend<S1, Obj & S1>(s1, customizer, any);
     }
 
     {
@@ -9070,7 +8757,6 @@ namespace TestExtend {
 
         result = _(obj).chain().extend<S1, S2, Obj & S1 & S2>(s1, s2);
         result = _(obj).chain().extend<S1, S2, Obj & S1 & S2>(s1, s2, customizer);
-        result = _(obj).chain().extend<S1, S2, Obj & S1 & S2>(s1, s2, customizer, any);
     }
 
     {
@@ -9078,7 +8764,6 @@ namespace TestExtend {
 
         result = _(obj).chain().extend<S1, S2, S3, Obj & S1 & S2 & S3>(s1, s2, s3);
         result = _(obj).chain().extend<S1, S2, S3, Obj & S1 & S2 & S3>(s1, s2, s3, customizer);
-        result = _(obj).chain().extend<S1, S2, S3, Obj & S1 & S2 & S3>(s1, s2, s3, customizer, any);
     }
 
     {
@@ -9086,7 +8771,6 @@ namespace TestExtend {
 
         result = _(obj).chain().extend<S1, S2, S3, S4, Obj & S1 & S2 & S3 & S4>(s1, s2, s3, s4);
         result = _(obj).chain().extend<S1, S2, S3, S4, Obj & S1 & S2 & S3 & S4>(s1, s2, s3, s4, customizer);
-        result = _(obj).chain().extend<S1, S2, S3, S4, Obj & S1 & S2 & S3 & S4>(s1, s2, s3, s4, customizer, any);
     }
 
     {
@@ -9094,7 +8778,6 @@ namespace TestExtend {
 
         result = _(obj).chain().extend<Obj & S1 & S2 & S3 & S4 & S5>(s1, s2, s3, s4, s5);
         result = _(obj).chain().extend<Obj & S1 & S2 & S3 & S4 & S5>(s1, s2, s3, s4, s5, customizer);
-        result = _(obj).chain().extend<Obj & S1 & S2 & S3 & S4 & S5>(s1, s2, s3, s4, s5, customizer, any);
     }
 }
 
@@ -9107,22 +8790,18 @@ namespace TestFindKey {
         result = _.findKey<{a: string;}>({a: ''});
 
         result = _.findKey<{a: string;}>({a: ''}, predicateFn);
-        result = _.findKey<{a: string;}>({a: ''}, predicateFn, any);
 
 
         result = _.findKey<{a: string;}>({a: ''}, '');
-        result = _.findKey<{a: string;}>({a: ''}, '', any);
 
         result = _.findKey<{a: number;}, {a: string;}>({a: ''}, {a: 42});
 
         result = _<{a: string;}>({a: ''}).findKey();
 
         result = _<{a: string;}>({a: ''}).findKey(predicateFn);
-        result = _<{a: string;}>({a: ''}).findKey(predicateFn, any);
 
 
         result = _<{a: string;}>({a: ''}).findKey('');
-        result = _<{a: string;}>({a: ''}).findKey('', any);
 
         result = _<{a: string;}>({a: ''}).findKey<{a: number;}>({a: 42});
     }
@@ -9132,10 +8811,8 @@ namespace TestFindKey {
         let result: string;
 
         result = _.findKey<string, {a: string;}>({a: ''}, predicateFn);
-        result = _.findKey<string, {a: string;}>({a: ''}, predicateFn, any);
 
         result = _<{a: string;}>({a: ''}).findKey<string>(predicateFn);
-        result = _<{a: string;}>({a: ''}).findKey<string>(predicateFn, any);
     }
 
     {
@@ -9145,11 +8822,9 @@ namespace TestFindKey {
         result = _<{a: string;}>({a: ''}).chain().findKey();
 
         result = _<{a: string;}>({a: ''}).chain().findKey(predicateFn);
-        result = _<{a: string;}>({a: ''}).chain().findKey(predicateFn, any);
 
 
         result = _<{a: string;}>({a: ''}).chain().findKey('');
-        result = _<{a: string;}>({a: ''}).chain().findKey('', any);
 
         result = _<{a: string;}>({a: ''}).chain().findKey<{a: number;}>({a: 42});
     }
@@ -9159,7 +8834,6 @@ namespace TestFindKey {
         let result: _.LoDashExplicitWrapper<string>;
 
         result = _<{a: string;}>({a: ''}).chain().findKey<string>(predicateFn);
-        result = _<{a: string;}>({a: ''}).chain().findKey<string>(predicateFn, any);
     }
 }
 
@@ -9172,22 +8846,18 @@ namespace TestFindLastKey {
         result = _.findLastKey<{a: string;}>({a: ''});
 
         result = _.findLastKey<{a: string;}>({a: ''}, predicateFn);
-        result = _.findLastKey<{a: string;}>({a: ''}, predicateFn, any);
 
 
         result = _.findLastKey<{a: string;}>({a: ''}, '');
-        result = _.findLastKey<{a: string;}>({a: ''}, '', any);
 
         result = _.findLastKey<{a: number;}, {a: string;}>({a: ''}, {a: 42});
 
         result = _<{a: string;}>({a: ''}).findLastKey();
 
         result = _<{a: string;}>({a: ''}).findLastKey(predicateFn);
-        result = _<{a: string;}>({a: ''}).findLastKey(predicateFn, any);
 
 
         result = _<{a: string;}>({a: ''}).findLastKey('');
-        result = _<{a: string;}>({a: ''}).findLastKey('', any);
 
         result = _<{a: string;}>({a: ''}).findLastKey<{a: number;}>({a: 42});
     }
@@ -9197,10 +8867,8 @@ namespace TestFindLastKey {
         let result: string;
 
         result = _.findLastKey<string, {a: string;}>({a: ''}, predicateFn);
-        result = _.findLastKey<string, {a: string;}>({a: ''}, predicateFn, any);
 
         result = _<{a: string;}>({a: ''}).findLastKey<string>(predicateFn);
-        result = _<{a: string;}>({a: ''}).findLastKey<string>(predicateFn, any);
     }
 
     {
@@ -9210,11 +8878,9 @@ namespace TestFindLastKey {
         result = _<{a: string;}>({a: ''}).chain().findLastKey();
 
         result = _<{a: string;}>({a: ''}).chain().findLastKey(predicateFn);
-        result = _<{a: string;}>({a: ''}).chain().findLastKey(predicateFn, any);
 
 
         result = _<{a: string;}>({a: ''}).chain().findLastKey('');
-        result = _<{a: string;}>({a: ''}).chain().findLastKey('', any);
 
         result = _<{a: string;}>({a: ''}).chain().findLastKey<{a: number;}>({a: 42});
     }
@@ -9224,7 +8890,6 @@ namespace TestFindLastKey {
         let result: _.LoDashExplicitWrapper<string>;
 
         result = _<{a: string;}>({a: ''}).chain().findLastKey<string>(predicateFn);
-        result = _<{a: string;}>({a: ''}).chain().findLastKey<string>(predicateFn, any);
     }
 }
 
@@ -9243,7 +8908,6 @@ namespace TestForIn {
 
         result = _.forIn<number>(dictionary);
         result = _.forIn<number>(dictionary, dictionaryIterator);
-        result = _.forIn<number>(dictionary, dictionaryIterator, any);
     }
 
     {
@@ -9251,7 +8915,6 @@ namespace TestForIn {
 
         result = _.forIn<SampleObject>(object);
         result = _.forIn<SampleObject>(object, objectIterator);
-        result = _.forIn<SampleObject>(object, objectIterator, any);
     }
 
     {
@@ -9259,7 +8922,6 @@ namespace TestForIn {
 
         result = _(dictionary).forIn<number>();
         result = _(dictionary).forIn<number>(dictionaryIterator);
-        result = _(dictionary).forIn<number>(dictionaryIterator, any);
     }
 
     {
@@ -9267,7 +8929,6 @@ namespace TestForIn {
 
         result = _(dictionary).chain().forIn<number>();
         result = _(dictionary).chain().forIn<number>(dictionaryIterator);
-        result = _(dictionary).chain().forIn<number>(dictionaryIterator, any);
     }
 }
 
@@ -9286,7 +8947,6 @@ namespace TestForInRight {
 
         result = _.forInRight<number>(dictionary);
         result = _.forInRight<number>(dictionary, dictionaryIterator);
-        result = _.forInRight<number>(dictionary, dictionaryIterator, any);
     }
 
     {
@@ -9294,7 +8954,6 @@ namespace TestForInRight {
 
         result = _.forInRight<SampleObject>(object);
         result = _.forInRight<SampleObject>(object, objectIterator);
-        result = _.forInRight<SampleObject>(object, objectIterator, any);
     }
 
     {
@@ -9302,7 +8961,6 @@ namespace TestForInRight {
 
         result = _(dictionary).forInRight<number>();
         result = _(dictionary).forInRight<number>(dictionaryIterator);
-        result = _(dictionary).forInRight<number>(dictionaryIterator, any);
     }
 
     {
@@ -9310,7 +8968,6 @@ namespace TestForInRight {
 
         result = _(dictionary).chain().forInRight<number>();
         result = _(dictionary).chain().forInRight<number>(dictionaryIterator);
-        result = _(dictionary).chain().forInRight<number>(dictionaryIterator, any);
     }
 }
 
@@ -9329,7 +8986,6 @@ namespace TestForOwn {
 
         result = _.forOwn<number>(dictionary);
         result = _.forOwn<number>(dictionary, dictionaryIterator);
-        result = _.forOwn<number>(dictionary, dictionaryIterator, any);
     }
 
     {
@@ -9337,7 +8993,6 @@ namespace TestForOwn {
 
         result = _.forOwn<SampleObject>(object);
         result = _.forOwn<SampleObject>(object, objectIterator);
-        result = _.forOwn<SampleObject>(object, objectIterator, any);
     }
 
     {
@@ -9345,7 +9000,6 @@ namespace TestForOwn {
 
         result = _(dictionary).forOwn<number>();
         result = _(dictionary).forOwn<number>(dictionaryIterator);
-        result = _(dictionary).forOwn<number>(dictionaryIterator, any);
     }
 
     {
@@ -9353,7 +9007,6 @@ namespace TestForOwn {
 
         result = _(dictionary).chain().forOwn<number>();
         result = _(dictionary).chain().forOwn<number>(dictionaryIterator);
-        result = _(dictionary).chain().forOwn<number>(dictionaryIterator, any);
     }
 }
 
@@ -9372,7 +9025,6 @@ namespace TestForOwnRight {
 
         result = _.forOwnRight<number>(dictionary);
         result = _.forOwnRight<number>(dictionary, dictionaryIterator);
-        result = _.forOwnRight<number>(dictionary, dictionaryIterator, any);
     }
 
     {
@@ -9380,7 +9032,6 @@ namespace TestForOwnRight {
 
         result = _.forOwnRight<SampleObject>(object);
         result = _.forOwnRight<SampleObject>(object, objectIterator);
-        result = _.forOwnRight<SampleObject>(object, objectIterator, any);
     }
 
     {
@@ -9388,7 +9039,6 @@ namespace TestForOwnRight {
 
         result = _(dictionary).forOwnRight<number>();
         result = _(dictionary).forOwnRight<number>(dictionaryIterator);
-        result = _(dictionary).forOwnRight<number>(dictionaryIterator, any);
     }
 
     {
@@ -9396,7 +9046,6 @@ namespace TestForOwnRight {
 
         result = _(dictionary).chain().forOwnRight<number>();
         result = _(dictionary).chain().forOwnRight<number>(dictionaryIterator);
-        result = _(dictionary).chain().forOwnRight<number>(dictionaryIterator, any);
     }
 }
 
@@ -9779,23 +9428,17 @@ namespace TestMapKeys {
 
         result = _.mapKeys<TResult, string>(array);
         result = _.mapKeys<TResult, string>(array, listIterator);
-        result = _.mapKeys<TResult, string>(array, listIterator, any);
         result = _.mapKeys<TResult>(array, '');
-        result = _.mapKeys<TResult>(array, '', any);
         result = _.mapKeys<TResult, {}>(array, {});
 
         result = _.mapKeys<TResult, string>(list);
         result = _.mapKeys<TResult, string>(list, listIterator);
-        result = _.mapKeys<TResult, string>(list, listIterator, any);
         result = _.mapKeys<TResult>(list, '');
-        result = _.mapKeys<TResult>(list, '', any);
         result = _.mapKeys<TResult, {}>(list, {});
 
         result = _.mapKeys<TResult, string>(dictionary);
         result = _.mapKeys<TResult, string>(dictionary, dictionaryIterator);
-        result = _.mapKeys<TResult, string>(dictionary, dictionaryIterator, any);
         result = _.mapKeys<TResult>(dictionary, '');
-        result = _.mapKeys<TResult>(dictionary, '', any);
         result = _.mapKeys<TResult, {}>(dictionary, {});
     }
 
@@ -9804,23 +9447,17 @@ namespace TestMapKeys {
 
         result = _(array).mapKeys<string>();
         result = _(array).mapKeys<string>(listIterator);
-        result = _(array).mapKeys<string>(listIterator, any);
         result = _(array).mapKeys('');
-        result = _(array).mapKeys('', any);
         result = _(array).mapKeys<{}>({});
 
         result = _(list).mapKeys<TResult, string>();
         result = _(list).mapKeys<TResult, string>(listIterator);
-        result = _(list).mapKeys<TResult, string>(listIterator, any);
         result = _(list).mapKeys<TResult>('');
-        result = _(list).mapKeys<TResult>('', any);
         result = _(list).mapKeys<TResult, {}>({});
 
         result = _(dictionary).mapKeys<TResult, string>();
         result = _(dictionary).mapKeys<TResult, string>(dictionaryIterator);
-        result = _(dictionary).mapKeys<TResult, string>(dictionaryIterator, any);
         result = _(dictionary).mapKeys<TResult>('');
-        result = _(dictionary).mapKeys<TResult>('', any);
         result = _(dictionary).mapKeys<TResult, {}>({});
     }
 
@@ -9829,23 +9466,17 @@ namespace TestMapKeys {
 
         result = _(array).chain().mapKeys<string>();
         result = _(array).chain().mapKeys<string>(listIterator);
-        result = _(array).chain().mapKeys<string>(listIterator, any);
         result = _(array).chain().mapKeys('');
-        result = _(array).chain().mapKeys('', any);
         result = _(array).chain().mapKeys<{}>({});
 
         result = _(list).chain().mapKeys<TResult, string>();
         result = _(list).chain().mapKeys<TResult, string>(listIterator);
-        result = _(list).chain().mapKeys<TResult, string>(listIterator, any);
         result = _(list).chain().mapKeys<TResult>('');
-        result = _(list).chain().mapKeys<TResult>('', any);
         result = _(list).chain().mapKeys<TResult, {}>({});
 
         result = _(dictionary).chain().mapKeys<TResult, string>();
         result = _(dictionary).chain().mapKeys<TResult, string>(dictionaryIterator);
-        result = _(dictionary).chain().mapKeys<TResult, string>(dictionaryIterator, any);
         result = _(dictionary).chain().mapKeys<TResult>('');
-        result = _(dictionary).chain().mapKeys<TResult>('', any);
         result = _(dictionary).chain().mapKeys<TResult, {}>({});
     }
 }
@@ -10388,12 +10019,10 @@ namespace TestTransform {
         result = _.transform<number, TResult>(array);
         result = _.transform<number, TResult>(array, iterator);
         result = _.transform<number, TResult>(array, iterator, accumulator);
-        result = _.transform<number, TResult>(array, iterator, accumulator, any);
 
         result = _<number>(array).transform<TResult>().value();
         result = _<number>(array).transform<TResult>(iterator).value();
         result = _<number>(array).transform<TResult>(iterator, accumulator).value();
-        result = _<number>(array).transform<TResult>(iterator, accumulator, any).value();
     }
 
     {
@@ -10403,11 +10032,9 @@ namespace TestTransform {
 
         result = _.transform<number, TResult>(array, iterator);
         result = _.transform<number, TResult>(array, iterator, accumulator);
-        result = _.transform<number, TResult>(array, iterator, accumulator, any);
 
         result = _<number>(array).transform<TResult>(iterator).value();
         result = _<number>(array).transform<TResult>(iterator, accumulator).value();
-        result = _<number>(array).transform<TResult>(iterator, accumulator, any).value();
     }
 
     {
@@ -10418,12 +10045,10 @@ namespace TestTransform {
         result = _.transform<number, TResult>(dictionary);
         result = _.transform<number, TResult>(dictionary, iterator);
         result = _.transform<number, TResult>(dictionary, iterator, accumulator);
-        result = _.transform<number, TResult>(dictionary, iterator, accumulator, any);
 
         result = _(dictionary).transform<number, TResult>().value();
         result = _(dictionary).transform<number, TResult>(iterator).value();
         result = _(dictionary).transform<number, TResult>(iterator, accumulator).value();
-        result = _(dictionary).transform<number, TResult>(iterator, accumulator, any).value();
     }
 
     {
@@ -10433,11 +10058,9 @@ namespace TestTransform {
 
         result = _.transform<number, TResult>(dictionary, iterator);
         result = _.transform<number, TResult>(dictionary, iterator, accumulator);
-        result = _.transform<number, TResult>(dictionary, iterator, accumulator, any);
 
         result = _(dictionary).transform<number, TResult>(iterator).value();
         result = _(dictionary).transform<number, TResult>(iterator, accumulator).value();
-        result = _(dictionary).transform<number, TResult>(iterator, accumulator, any).value();
     }
 }
 
@@ -11207,77 +10830,77 @@ namespace TestAttempt {
 namespace TestConstant {
     {
         let result: () => number;
-        result: _.constant<number>(42);
+        result = _.constant<number>(42);
     }
 
     {
         let result: () => string;
-        result: _.constant<string>('a');
+        result = _.constant<string>('a');
     }
 
     {
         let result: () => boolean;
-        result: _.constant<boolean>(true);
+        result = _.constant<boolean>(true);
     }
 
     {
         let result: () => string[];
-        result: _.constant<string[]>(['a']);
+        result = _.constant<string[]>(['a']);
     }
 
     {
         let result: () => {a: string};
-        result: _.constant<{a: string}>({a: 'a'});
+        result = _.constant<{a: string}>({a: 'a'});
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<() => number>;
-        result: _(42).constant<number>();
+        result = _(42).constant<number>();
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<() => string>;
-        result: _('a').constant<string>();
+        result = _('a').constant<string>();
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<() => boolean>;
-        result: _(true).constant<boolean>();
+        result = _(true).constant<boolean>();
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<() => string[]>;
-        result: _(['a']).constant<string[]>();
+        result = _(['a']).constant<string[]>();
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<() => {a: string}>;
-        result: _({a: 'a'}).constant<{a: string}>();
+        result = _({a: 'a'}).constant<{a: string}>();
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<() => number>;
-        result: _(42).chain().constant<number>();
+        result = _(42).chain().constant<number>();
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<() => string>;
-        result: _('a').chain().constant<string>();
+        result = _('a').chain().constant<string>();
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<() => boolean>;
-        result: _(true).chain().constant<boolean>();
+        result = _(true).chain().constant<boolean>();
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<() => string[]>;
-        result: _(['a']).chain().constant<string[]>();
+        result = _(['a']).chain().constant<string[]>();
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<() => {a: string}>;
-        result: _({a: 'a'}).chain().constant<{a: string}>();
+        result = _({a: 'a'}).chain().constant<{a: string}>();
     }
 }
 
@@ -11329,63 +10952,54 @@ namespace TestIteratee {
         let result: (...args: any[]) => TResult;
 
         result = _.iteratee<TResult>(Function);
-        result = _.iteratee<TResult>(Function, any);
     }
 
     {
         let result: (object: any) => TResult;
 
         result = _.iteratee<TResult>('');
-        result = _.iteratee<TResult>('', any);
     }
 
     {
         let result: (object: any) => boolean;
 
         result = _.iteratee({});
-        result = _.iteratee({}, any);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<(...args: any[]) => TResult>;
 
         result = _(Function).iteratee<TResult>();
-        result = _(Function).iteratee<TResult>(any);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<(object: any) => TResult>;
 
         result = _('').iteratee<TResult>();
-        result = _('').iteratee<TResult>(any);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<(object: any) => boolean>;
 
         result = _({}).iteratee();
-        result = _({}).iteratee(any);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<(...args: any[]) => TResult>;
 
         result = _(Function).chain().iteratee<TResult>();
-        result = _(Function).chain().iteratee<TResult>(any);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<(object: any) => TResult>;
 
         result = _('').chain().iteratee<TResult>();
-        result = _('').chain().iteratee<TResult>(any);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<(object: any) => boolean>;
 
         result = _({}).chain().iteratee();
-        result = _({}).chain().iteratee(any);
     }
 }
 
@@ -11462,7 +11076,6 @@ namespace TestMethod {
         let result: (object: any) => {a: string};
 
         result = _.method<{a: string}>('a.0');
-        result = _.method<{a: string}>('a.0', any);
         result = _.method<{a: string}>('a.0', any, any);
         result = _.method<{a: string}>('a.0', any, any, any);
 
@@ -11476,7 +11089,6 @@ namespace TestMethod {
         let result: (object: {a: string}) => {b: string};
 
         result = _.method<{a: string}, {b: string}>('a.0');
-        result = _.method<{a: string}, {b: string}>('a.0', any);
         result = _.method<{a: string}, {b: string}>('a.0', any, any);
         result = _.method<{a: string}, {b: string}>('a.0', any, any, any);
 

--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -4658,7 +4658,7 @@ result = <number>_([1, 2, 3]).reduce<number>(function (sum: number, num: number)
 result = <ABC>_({ 'a': 1, 'b': 2, 'c': 3 }).reduce<number, ABC>(function (r: ABC, num: number, key: string) {
     r[key] = num * 3;
     return r;
-}, {});
+}, <ABC> {});
 
 result = <number[]>_.reduceRight([[0, 1], [2, 3], [4, 5]], function (a: number[], b: number[]) { return a.concat(b); }, <number[]>[]);
 

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -1241,8 +1241,7 @@ declare module _ {
          */
         dropRightWhile<TValue>(
             array: List<TValue>,
-            predicate?: ListIterator<TValue, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TValue, boolean>
         ): TValue[];
 
         /**
@@ -1250,8 +1249,7 @@ declare module _ {
          */
         dropRightWhile<TValue>(
             array: List<TValue>,
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): TValue[];
 
         /**
@@ -1268,16 +1266,14 @@ declare module _ {
          * @see _.dropRightWhile
          */
         dropRightWhile(
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
          * @see _.dropRightWhile
          */
         dropRightWhile(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
@@ -1293,16 +1289,14 @@ declare module _ {
          * @see _.dropRightWhile
          */
         dropRightWhile<TValue>(
-            predicate?: ListIterator<TValue, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TValue, boolean>
         ): LoDashImplicitArrayWrapper<TValue>;
 
         /**
          * @see _.dropRightWhile
          */
         dropRightWhile<TValue>(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashImplicitArrayWrapper<TValue>;
 
         /**
@@ -1318,16 +1312,14 @@ declare module _ {
          * @see _.dropRightWhile
          */
         dropRightWhile(
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
          * @see _.dropRightWhile
          */
         dropRightWhile(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
@@ -1343,16 +1335,14 @@ declare module _ {
          * @see _.dropRightWhile
          */
         dropRightWhile<TValue>(
-            predicate?: ListIterator<TValue, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TValue, boolean>
         ): LoDashExplicitArrayWrapper<TValue>;
 
         /**
          * @see _.dropRightWhile
          */
         dropRightWhile<TValue>(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashExplicitArrayWrapper<TValue>;
 
         /**
@@ -1385,8 +1375,7 @@ declare module _ {
          */
         dropWhile<TValue>(
             array: List<TValue>,
-            predicate?: ListIterator<TValue, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TValue, boolean>
         ): TValue[];
 
         /**
@@ -1394,8 +1383,7 @@ declare module _ {
          */
         dropWhile<TValue>(
             array: List<TValue>,
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): TValue[];
 
         /**
@@ -1412,16 +1400,14 @@ declare module _ {
          * @see _.dropWhile
          */
         dropWhile(
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
          * @see _.dropWhile
          */
         dropWhile(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
@@ -1437,16 +1423,14 @@ declare module _ {
          * @see _.dropWhile
          */
         dropWhile<TValue>(
-            predicate?: ListIterator<TValue, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TValue, boolean>
         ): LoDashImplicitArrayWrapper<TValue>;
 
         /**
          * @see _.dropWhile
          */
         dropWhile<TValue>(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashImplicitArrayWrapper<TValue>;
 
         /**
@@ -1462,16 +1446,14 @@ declare module _ {
          * @see _.dropWhile
          */
         dropWhile(
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
          * @see _.dropWhile
          */
         dropWhile(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
@@ -1487,16 +1469,14 @@ declare module _ {
          * @see _.dropWhile
          */
         dropWhile<TValue>(
-            predicate?: ListIterator<TValue, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TValue, boolean>
         ): LoDashExplicitArrayWrapper<TValue>;
 
         /**
          * @see _.dropWhile
          */
         dropWhile<TValue>(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashExplicitArrayWrapper<TValue>;
 
         /**
@@ -1604,8 +1584,7 @@ declare module _ {
          */
         findIndex<T>(
             array: List<T>,
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): number;
 
         /**
@@ -1613,8 +1592,7 @@ declare module _ {
          */
         findIndex<T>(
             array: List<T>,
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): number;
 
         /**
@@ -1631,16 +1609,14 @@ declare module _ {
          * @see _.findIndex
          */
         findIndex(
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): number;
 
         /**
          * @see _.findIndex
          */
         findIndex(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): number;
 
         /**
@@ -1656,16 +1632,14 @@ declare module _ {
          * @see _.findIndex
          */
         findIndex<TResult>(
-            predicate?: ListIterator<TResult, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TResult, boolean>
         ): number;
 
         /**
          * @see _.findIndex
          */
         findIndex(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): number;
 
         /**
@@ -1681,16 +1655,14 @@ declare module _ {
          * @see _.findIndex
          */
         findIndex(
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): LoDashExplicitWrapper<number>;
 
         /**
          * @see _.findIndex
          */
         findIndex(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashExplicitWrapper<number>;
 
         /**
@@ -1706,16 +1678,14 @@ declare module _ {
          * @see _.findIndex
          */
         findIndex<TResult>(
-            predicate?: ListIterator<TResult, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TResult, boolean>
         ): LoDashExplicitWrapper<number>;
 
         /**
          * @see _.findIndex
          */
         findIndex(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashExplicitWrapper<number>;
 
         /**
@@ -1747,8 +1717,7 @@ declare module _ {
          */
         findLastIndex<T>(
             array: List<T>,
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): number;
 
         /**
@@ -1756,8 +1725,7 @@ declare module _ {
          */
         findLastIndex<T>(
             array: List<T>,
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): number;
 
         /**
@@ -1774,16 +1742,14 @@ declare module _ {
          * @see _.findLastIndex
          */
         findLastIndex(
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): number;
 
         /**
          * @see _.findLastIndex
          */
         findLastIndex(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): number;
 
         /**
@@ -1799,16 +1765,14 @@ declare module _ {
          * @see _.findLastIndex
          */
         findLastIndex<TResult>(
-            predicate?: ListIterator<TResult, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TResult, boolean>
         ): number;
 
         /**
          * @see _.findLastIndex
          */
         findLastIndex(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): number;
 
         /**
@@ -1824,16 +1788,14 @@ declare module _ {
          * @see _.findLastIndex
          */
         findLastIndex(
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): LoDashExplicitWrapper<number>;
 
         /**
          * @see _.findLastIndex
          */
         findLastIndex(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashExplicitWrapper<number>;
 
         /**
@@ -1849,16 +1811,14 @@ declare module _ {
          * @see _.findLastIndex
          */
         findLastIndex<TResult>(
-            predicate?: ListIterator<TResult, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TResult, boolean>
         ): LoDashExplicitWrapper<number>;
 
         /**
          * @see _.findLastIndex
          */
         findLastIndex(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashExplicitWrapper<number>;
 
         /**
@@ -2756,8 +2716,7 @@ declare module _ {
          */
         remove<T>(
             array: List<T>,
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): T[];
 
         /**
@@ -2765,8 +2724,7 @@ declare module _ {
          */
         remove<T>(
             array: List<T>,
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): T[];
 
         /**
@@ -2783,16 +2741,14 @@ declare module _ {
          * @see _.remove
          */
         remove(
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
          * @see _.remove
          */
         remove(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
@@ -2808,16 +2764,14 @@ declare module _ {
          * @see _.remove
          */
         remove<TResult>(
-            predicate?: ListIterator<TResult, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TResult, boolean>
         ): LoDashImplicitArrayWrapper<TResult>;
 
         /**
          * @see _.remove
          */
         remove<TResult>(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashImplicitArrayWrapper<TResult>;
 
         /**
@@ -2833,16 +2787,14 @@ declare module _ {
          * @see _.remove
          */
         remove(
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
          * @see _.remove
          */
         remove(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
@@ -2858,16 +2810,14 @@ declare module _ {
          * @see _.remove
          */
         remove<TResult>(
-            predicate?: ListIterator<TResult, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TResult, boolean>
         ): LoDashExplicitArrayWrapper<TResult>;
 
         /**
          * @see _.remove
          */
         remove<TResult>(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashExplicitArrayWrapper<TResult>;
 
         /**
@@ -3888,8 +3838,7 @@ declare module _ {
          */
         takeRightWhile<TValue>(
             array: List<TValue>,
-            predicate?: ListIterator<TValue, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TValue, boolean>
         ): TValue[];
 
         /**
@@ -3897,8 +3846,7 @@ declare module _ {
          */
         takeRightWhile<TValue>(
             array: List<TValue>,
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): TValue[];
 
         /**
@@ -3915,16 +3863,14 @@ declare module _ {
          * @see _.takeRightWhile
          */
         takeRightWhile(
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
          * @see _.takeRightWhile
          */
         takeRightWhile(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
@@ -3940,16 +3886,14 @@ declare module _ {
          * @see _.takeRightWhile
          */
         takeRightWhile<TValue>(
-            predicate?: ListIterator<TValue, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TValue, boolean>
         ): LoDashImplicitArrayWrapper<TValue>;
 
         /**
          * @see _.takeRightWhile
          */
         takeRightWhile<TValue>(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashImplicitArrayWrapper<TValue>;
 
         /**
@@ -3965,16 +3909,14 @@ declare module _ {
          * @see _.takeRightWhile
          */
         takeRightWhile(
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
          * @see _.takeRightWhile
          */
         takeRightWhile(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
@@ -3990,16 +3932,14 @@ declare module _ {
          * @see _.takeRightWhile
          */
         takeRightWhile<TValue>(
-            predicate?: ListIterator<TValue, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TValue, boolean>
         ): LoDashExplicitArrayWrapper<TValue>;
 
         /**
          * @see _.takeRightWhile
          */
         takeRightWhile<TValue>(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashExplicitArrayWrapper<TValue>;
 
         /**
@@ -4032,8 +3972,7 @@ declare module _ {
          */
         takeWhile<TValue>(
             array: List<TValue>,
-            predicate?: ListIterator<TValue, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TValue, boolean>
         ): TValue[];
 
         /**
@@ -4041,8 +3980,7 @@ declare module _ {
          */
         takeWhile<TValue>(
             array: List<TValue>,
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): TValue[];
 
         /**
@@ -4059,16 +3997,14 @@ declare module _ {
          * @see _.takeWhile
          */
         takeWhile(
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
          * @see _.takeWhile
          */
         takeWhile(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
@@ -4084,16 +4020,14 @@ declare module _ {
          * @see _.takeWhile
          */
         takeWhile<TValue>(
-            predicate?: ListIterator<TValue, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TValue, boolean>
         ): LoDashImplicitArrayWrapper<TValue>;
 
         /**
          * @see _.takeWhile
          */
         takeWhile<TValue>(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashImplicitArrayWrapper<TValue>;
 
         /**
@@ -4109,16 +4043,14 @@ declare module _ {
          * @see _.takeWhile
          */
         takeWhile(
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
          * @see _.takeWhile
          */
         takeWhile(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
@@ -4134,16 +4066,14 @@ declare module _ {
          * @see _.takeWhile
          */
         takeWhile<TValue>(
-            predicate?: ListIterator<TValue, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TValue, boolean>
         ): LoDashExplicitArrayWrapper<TValue>;
 
         /**
          * @see _.takeWhile
          */
         takeWhile<TValue>(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashExplicitArrayWrapper<TValue>;
 
         /**
@@ -5391,8 +5321,7 @@ declare module _ {
          */
         unzipWith<TArray, TResult>(
             array: List<List<TArray>>,
-            iteratee?: MemoIterator<TArray, TResult>,
-            thisArg?: any
+            iteratee?: MemoIterator<TArray, TResult>
         ): TResult[];
     }
 
@@ -5401,8 +5330,7 @@ declare module _ {
          * @see _.unzipWith
          */
         unzipWith<TArr, TResult>(
-            iteratee?: MemoIterator<TArr, TResult>,
-            thisArg?: any
+            iteratee?: MemoIterator<TArr, TResult>
         ): LoDashImplicitArrayWrapper<TResult>;
     }
 
@@ -5411,8 +5339,7 @@ declare module _ {
          * @see _.unzipWith
          */
         unzipWith<TArr, TResult>(
-            iteratee?: MemoIterator<TArr, TResult>,
-            thisArg?: any
+            iteratee?: MemoIterator<TArr, TResult>
         ): LoDashImplicitArrayWrapper<TResult>;
     }
 
@@ -5801,8 +5728,7 @@ declare module _ {
          **/
         tap<T>(
             value: T,
-            interceptor: (value: T) => void,
-            thisArg?: any
+            interceptor: (value: T) => void
         ): T;
     }
 
@@ -5811,8 +5737,7 @@ declare module _ {
          * @see _.tap
          */
         tap(
-            interceptor: (value: T) => void,
-            thisArg?: any
+            interceptor: (value: T) => void
         ): TWrapper;
     }
 
@@ -5821,8 +5746,7 @@ declare module _ {
          * @see _.tap
          */
         tap(
-            interceptor: (value: T) => void,
-            thisArg?: any
+            interceptor: (value: T) => void
         ): TWrapper;
     }
 
@@ -5838,8 +5762,7 @@ declare module _ {
          */
         thru<T, TResult>(
             value: T,
-            interceptor: (value: T) => TResult,
-            thisArg?: any
+            interceptor: (value: T) => TResult
         ): TResult;
     }
 
@@ -5848,36 +5771,31 @@ declare module _ {
          * @see _.thru
          */
         thru<TResult extends number>(
-            interceptor: (value: T) => TResult,
-            thisArg?: any): LoDashImplicitWrapper<TResult>;
+            interceptor: (value: T) => TResult): LoDashImplicitWrapper<TResult>;
 
         /**
          * @see _.thru
          */
         thru<TResult extends string>(
-            interceptor: (value: T) => TResult,
-            thisArg?: any): LoDashImplicitWrapper<TResult>;
+            interceptor: (value: T) => TResult): LoDashImplicitWrapper<TResult>;
 
         /**
          * @see _.thru
          */
         thru<TResult extends boolean>(
-            interceptor: (value: T) => TResult,
-            thisArg?: any): LoDashImplicitWrapper<TResult>;
+            interceptor: (value: T) => TResult): LoDashImplicitWrapper<TResult>;
 
         /**
          * @see _.thru
          */
         thru<TResult extends {}>(
-            interceptor: (value: T) => TResult,
-            thisArg?: any): LoDashImplicitObjectWrapper<TResult>;
+            interceptor: (value: T) => TResult): LoDashImplicitObjectWrapper<TResult>;
 
         /**
          * @see _.thru
          */
         thru<TResult>(
-            interceptor: (value: T) => TResult[],
-            thisArg?: any): LoDashImplicitArrayWrapper<TResult>;
+            interceptor: (value: T) => TResult[]): LoDashImplicitArrayWrapper<TResult>;
     }
 
     interface LoDashExplicitWrapperBase<T, TWrapper> {
@@ -5885,40 +5803,35 @@ declare module _ {
          * @see _.thru
          */
         thru<TResult extends number>(
-            interceptor: (value: T) => TResult,
-            thisArg?: any
+            interceptor: (value: T) => TResult
         ): LoDashExplicitWrapper<TResult>;
 
         /**
          * @see _.thru
          */
         thru<TResult extends string>(
-            interceptor: (value: T) => TResult,
-            thisArg?: any
+            interceptor: (value: T) => TResult
         ): LoDashExplicitWrapper<TResult>;
 
         /**
          * @see _.thru
          */
         thru<TResult extends boolean>(
-            interceptor: (value: T) => TResult,
-            thisArg?: any
+            interceptor: (value: T) => TResult
         ): LoDashExplicitWrapper<TResult>;
 
         /**
          * @see _.thru
          */
         thru<TResult extends {}>(
-            interceptor: (value: T) => TResult,
-            thisArg?: any
+            interceptor: (value: T) => TResult
         ): LoDashExplicitObjectWrapper<TResult>;
 
         /**
          * @see _.thru
          */
         thru<TResult>(
-            interceptor: (value: T) => TResult[],
-            thisArg?: any
+            interceptor: (value: T) => TResult[]
         ): LoDashExplicitArrayWrapper<TResult>;
     }
 
@@ -6174,8 +6087,7 @@ declare module _ {
          */
         countBy<T>(
             collection: List<T>,
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): Dictionary<number>;
 
         /**
@@ -6183,8 +6095,7 @@ declare module _ {
          */
         countBy<T>(
             collection: Dictionary<T>,
-            iteratee?: DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<T, any>
         ): Dictionary<number>;
 
         /**
@@ -6192,8 +6103,7 @@ declare module _ {
          */
         countBy<T>(
             collection: NumericDictionary<T>,
-            iteratee?: NumericDictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: NumericDictionaryIterator<T, any>
         ): Dictionary<number>;
 
         /**
@@ -6201,8 +6111,7 @@ declare module _ {
          */
         countBy<T>(
             collection: List<T>|Dictionary<T>|NumericDictionary<T>,
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): Dictionary<number>;
 
         /**
@@ -6227,8 +6136,7 @@ declare module _ {
          * @see _.countBy
          */
         countBy(
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): LoDashImplicitObjectWrapper<Dictionary<number>>;
     }
 
@@ -6237,16 +6145,14 @@ declare module _ {
          * @see _.countBy
          */
         countBy(
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): LoDashImplicitObjectWrapper<Dictionary<number>>;
 
         /**
          * @see _.countBy
          */
         countBy(
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): LoDashImplicitObjectWrapper<Dictionary<number>>;
 
         /**
@@ -6262,16 +6168,14 @@ declare module _ {
          * @see _.countBy
          */
         countBy<T>(
-            iteratee?: ListIterator<T, any>|DictionaryIterator<T, any>|NumericDictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>|DictionaryIterator<T, any>|NumericDictionaryIterator<T, any>
         ): LoDashImplicitObjectWrapper<Dictionary<number>>;
 
         /**
          * @see _.countBy
          */
         countBy(
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): LoDashImplicitObjectWrapper<Dictionary<number>>;
 
         /**
@@ -6287,8 +6191,7 @@ declare module _ {
          * @see _.countBy
          */
         countBy(
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): LoDashExplicitObjectWrapper<Dictionary<number>>;
     }
 
@@ -6297,16 +6200,14 @@ declare module _ {
          * @see _.countBy
          */
         countBy(
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): LoDashExplicitObjectWrapper<Dictionary<number>>;
 
         /**
          * @see _.countBy
          */
         countBy(
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): LoDashExplicitObjectWrapper<Dictionary<number>>;
 
         /**
@@ -6322,16 +6223,14 @@ declare module _ {
          * @see _.countBy
          */
         countBy<T>(
-            iteratee?: ListIterator<T, any>|DictionaryIterator<T, any>|NumericDictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>|DictionaryIterator<T, any>|NumericDictionaryIterator<T, any>
         ): LoDashExplicitObjectWrapper<Dictionary<number>>;
 
         /**
          * @see _.countBy
          */
         countBy(
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): LoDashExplicitObjectWrapper<Dictionary<number>>;
 
         /**
@@ -6349,8 +6248,7 @@ declare module _ {
          */
         each<T>(
             collection: T[],
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): T[];
 
         /**
@@ -6358,8 +6256,7 @@ declare module _ {
          */
         each<T>(
             collection: List<T>,
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): List<T>;
 
         /**
@@ -6367,8 +6264,7 @@ declare module _ {
          */
         each<T>(
             collection: Dictionary<T>,
-            iteratee?: DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<T, any>
         ): Dictionary<T>;
 
         /**
@@ -6376,8 +6272,7 @@ declare module _ {
          */
         each<T extends {}>(
             collection: T,
-            iteratee?: ObjectIterator<any, any>,
-            thisArgs?: any
+            iteratee?: ObjectIterator<any, any>
         ): T;
 
         /**
@@ -6385,8 +6280,7 @@ declare module _ {
          */
         each<T extends {}, TValue>(
             collection: T,
-            iteratee?: ObjectIterator<TValue, any>,
-            thisArgs?: any
+            iteratee?: ObjectIterator<TValue, any>
         ): T;
     }
 
@@ -6395,8 +6289,7 @@ declare module _ {
          * @see _.forEach
          */
         each(
-            iteratee: ListIterator<string, any>,
-            thisArg?: any
+            iteratee: ListIterator<string, any>
         ): LoDashImplicitWrapper<string>;
     }
 
@@ -6405,8 +6298,7 @@ declare module _ {
          * @see _.forEach
          */
         each(
-            iteratee: ListIterator<T, any>,
-            thisArg?: any
+            iteratee: ListIterator<T, any>
         ): LoDashImplicitArrayWrapper<T>;
     }
 
@@ -6415,8 +6307,7 @@ declare module _ {
          * @see _.forEach
          */
         each<TValue>(
-            iteratee?: ListIterator<TValue, any>|DictionaryIterator<TValue, any>,
-            thisArg?: any
+            iteratee?: ListIterator<TValue, any>|DictionaryIterator<TValue, any>
         ): LoDashImplicitObjectWrapper<T>;
     }
 
@@ -6425,8 +6316,7 @@ declare module _ {
          * @see _.forEach
          */
         each(
-            iteratee: ListIterator<string, any>,
-            thisArg?: any
+            iteratee: ListIterator<string, any>
         ): LoDashExplicitWrapper<string>;
     }
 
@@ -6435,8 +6325,7 @@ declare module _ {
          * @see _.forEach
          */
         each(
-            iteratee: ListIterator<T, any>,
-            thisArg?: any
+            iteratee: ListIterator<T, any>
         ): LoDashExplicitArrayWrapper<T>;
     }
 
@@ -6445,8 +6334,7 @@ declare module _ {
          * @see _.forEach
          */
         each<TValue>(
-            iteratee?: ListIterator<TValue, any>|DictionaryIterator<TValue, any>,
-            thisArg?: any
+            iteratee?: ListIterator<TValue, any>|DictionaryIterator<TValue, any>
         ): LoDashExplicitObjectWrapper<T>;
     }
 
@@ -6457,8 +6345,7 @@ declare module _ {
          */
         eachRight<T>(
             collection: T[],
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): T[];
 
         /**
@@ -6466,8 +6353,7 @@ declare module _ {
          */
         eachRight<T>(
             collection: List<T>,
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): List<T>;
 
         /**
@@ -6475,8 +6361,7 @@ declare module _ {
          */
         eachRight<T>(
             collection: Dictionary<T>,
-            iteratee?: DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<T, any>
         ): Dictionary<T>;
 
         /**
@@ -6484,8 +6369,7 @@ declare module _ {
          */
         eachRight<T extends {}>(
             collection: T,
-            iteratee?: ObjectIterator<any, any>,
-            thisArgs?: any
+            iteratee?: ObjectIterator<any, any>
         ): T;
 
         /**
@@ -6493,8 +6377,7 @@ declare module _ {
          */
         eachRight<T extends {}, TValue>(
             collection: T,
-            iteratee?: ObjectIterator<TValue, any>,
-            thisArgs?: any
+            iteratee?: ObjectIterator<TValue, any>
         ): T;
     }
 
@@ -6503,8 +6386,7 @@ declare module _ {
          * @see _.forEachRight
          */
         eachRight(
-            iteratee: ListIterator<string, any>,
-            thisArg?: any
+            iteratee: ListIterator<string, any>
         ): LoDashImplicitWrapper<string>;
     }
 
@@ -6513,8 +6395,7 @@ declare module _ {
          * @see _.forEachRight
          */
         eachRight(
-            iteratee: ListIterator<T, any>,
-            thisArg?: any
+            iteratee: ListIterator<T, any>
         ): LoDashImplicitArrayWrapper<T>;
     }
 
@@ -6523,8 +6404,7 @@ declare module _ {
          * @see _.forEachRight
          */
         eachRight<TValue>(
-            iteratee?: ListIterator<TValue, any>|DictionaryIterator<TValue, any>,
-            thisArg?: any
+            iteratee?: ListIterator<TValue, any>|DictionaryIterator<TValue, any>
         ): LoDashImplicitObjectWrapper<T>;
     }
 
@@ -6533,8 +6413,7 @@ declare module _ {
          * @see _.forEachRight
          */
         eachRight(
-            iteratee: ListIterator<string, any>,
-            thisArg?: any
+            iteratee: ListIterator<string, any>
         ): LoDashExplicitWrapper<string>;
     }
 
@@ -6543,8 +6422,7 @@ declare module _ {
          * @see _.forEachRight
          */
         eachRight(
-            iteratee: ListIterator<T, any>,
-            thisArg?: any
+            iteratee: ListIterator<T, any>
         ): LoDashExplicitArrayWrapper<T>;
     }
 
@@ -6553,8 +6431,7 @@ declare module _ {
          * @see _.forEachRight
          */
         eachRight<TValue>(
-            iteratee?: ListIterator<TValue, any>|DictionaryIterator<TValue, any>,
-            thisArg?: any
+            iteratee?: ListIterator<TValue, any>|DictionaryIterator<TValue, any>
         ): LoDashExplicitObjectWrapper<T>;
     }
 
@@ -6720,8 +6597,7 @@ declare module _ {
          */
         filter<T>(
             collection: List<T>,
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): T[];
 
         /**
@@ -6729,8 +6605,7 @@ declare module _ {
          */
         filter<T>(
             collection: Dictionary<T>,
-            predicate?: DictionaryIterator<T, boolean>,
-            thisArg?: any
+            predicate?: DictionaryIterator<T, boolean>
         ): T[];
 
         /**
@@ -6738,8 +6613,7 @@ declare module _ {
          */
         filter(
             collection: string,
-            predicate?: StringIterator<boolean>,
-            thisArg?: any
+            predicate?: StringIterator<boolean>
         ): string[];
 
         /**
@@ -6747,8 +6621,7 @@ declare module _ {
          */
         filter<T>(
             collection: List<T>|Dictionary<T>,
-            predicate: string,
-            thisArg?: any
+            predicate: string
         ): T[];
 
         /**
@@ -6765,8 +6638,7 @@ declare module _ {
          * @see _.filter
          */
         filter(
-            predicate?: StringIterator<boolean>,
-            thisArg?: any
+            predicate?: StringIterator<boolean>
         ): LoDashImplicitArrayWrapper<string>;
     }
 
@@ -6775,16 +6647,14 @@ declare module _ {
          * @see _.filter
          */
         filter(
-            predicate: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate: ListIterator<T, boolean>
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
          * @see _.filter
          */
         filter(
-            predicate: string,
-            thisArg?: any
+            predicate: string
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
@@ -6798,16 +6668,14 @@ declare module _ {
          * @see _.filter
          */
         filter<T>(
-            predicate: ListIterator<T, boolean>|DictionaryIterator<T, boolean>,
-            thisArg?: any
+            predicate: ListIterator<T, boolean>|DictionaryIterator<T, boolean>
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
          * @see _.filter
          */
         filter<T>(
-            predicate: string,
-            thisArg?: any
+            predicate: string
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
@@ -6821,8 +6689,7 @@ declare module _ {
          * @see _.filter
          */
         filter(
-            predicate?: StringIterator<boolean>,
-            thisArg?: any
+            predicate?: StringIterator<boolean>
         ): LoDashExplicitArrayWrapper<string>;
     }
 
@@ -6831,16 +6698,14 @@ declare module _ {
          * @see _.filter
          */
         filter(
-            predicate: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate: ListIterator<T, boolean>
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
          * @see _.filter
          */
         filter(
-            predicate: string,
-            thisArg?: any
+            predicate: string
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
@@ -6854,16 +6719,14 @@ declare module _ {
          * @see _.filter
          */
         filter<T>(
-            predicate: ListIterator<T, boolean>|DictionaryIterator<T, boolean>,
-            thisArg?: any
+            predicate: ListIterator<T, boolean>|DictionaryIterator<T, boolean>
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
          * @see _.filter
          */
         filter<T>(
-            predicate: string,
-            thisArg?: any
+            predicate: string
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
@@ -6894,8 +6757,7 @@ declare module _ {
          */
         find<T>(
             collection: List<T>,
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): T;
 
         /**
@@ -6903,8 +6765,7 @@ declare module _ {
          */
         find<T>(
             collection: Dictionary<T>,
-            predicate?: DictionaryIterator<T, boolean>,
-            thisArg?: any
+            predicate?: DictionaryIterator<T, boolean>
         ): T;
 
         /**
@@ -6912,8 +6773,7 @@ declare module _ {
          */
         find<T>(
             collection: List<T>|Dictionary<T>,
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): T;
 
         /**
@@ -6930,16 +6790,14 @@ declare module _ {
          * @see _.find
          */
         find(
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): T;
 
         /**
          * @see _.find
          */
         find(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): T;
 
         /**
@@ -6955,16 +6813,14 @@ declare module _ {
          * @see _.find
          */
         find<TResult>(
-            predicate?: ListIterator<TResult, boolean>|DictionaryIterator<TResult, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<TResult, boolean>|DictionaryIterator<TResult, boolean>
         ): TResult;
 
         /**
          * @see _.find
          */
         find<TResult>(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): TResult;
 
         /**
@@ -6987,24 +6843,21 @@ declare module _ {
         **/
         findLast<T>(
             collection: Array<T>,
-            callback: ListIterator<T, boolean>,
-            thisArg?: any): T;
+            callback: ListIterator<T, boolean>): T;
 
         /**
         * @see _.find
         **/
         findLast<T>(
             collection: List<T>,
-            callback: ListIterator<T, boolean>,
-            thisArg?: any): T;
+            callback: ListIterator<T, boolean>): T;
 
         /**
         * @see _.find
         **/
         findLast<T>(
             collection: Dictionary<T>,
-            callback: DictionaryIterator<T, boolean>,
-            thisArg?: any): T;
+            callback: DictionaryIterator<T, boolean>): T;
 
         /**
         * @see _.find
@@ -7060,8 +6913,7 @@ declare module _ {
         * @see _.findLast
         */
         findLast(
-            callback: ListIterator<T, boolean>,
-            thisArg?: any): T;
+            callback: ListIterator<T, boolean>): T;
         /**
         * @see _.findLast
         * @param _.where style callback
@@ -7361,8 +7213,7 @@ declare module _ {
          */
         forEach<T>(
             collection: T[],
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): T[];
 
         /**
@@ -7370,8 +7221,7 @@ declare module _ {
          */
         forEach<T>(
             collection: List<T>,
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): List<T>;
 
         /**
@@ -7379,8 +7229,7 @@ declare module _ {
          */
         forEach<T>(
             collection: Dictionary<T>,
-            iteratee?: DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<T, any>
         ): Dictionary<T>;
 
         /**
@@ -7388,8 +7237,7 @@ declare module _ {
          */
         forEach<T extends {}>(
             collection: T,
-            iteratee?: ObjectIterator<any, any>,
-            thisArgs?: any
+            iteratee?: ObjectIterator<any, any>
         ): T;
 
         /**
@@ -7397,8 +7245,7 @@ declare module _ {
          */
         forEach<T extends {}, TValue>(
             collection: T,
-            iteratee?: ObjectIterator<TValue, any>,
-            thisArgs?: any
+            iteratee?: ObjectIterator<TValue, any>
         ): T;
     }
 
@@ -7407,8 +7254,7 @@ declare module _ {
          * @see _.forEach
          */
         forEach(
-            iteratee: ListIterator<string, any>,
-            thisArg?: any
+            iteratee: ListIterator<string, any>
         ): LoDashImplicitWrapper<string>;
     }
 
@@ -7417,8 +7263,7 @@ declare module _ {
          * @see _.forEach
          */
         forEach(
-            iteratee: ListIterator<T, any>,
-            thisArg?: any
+            iteratee: ListIterator<T, any>
         ): LoDashImplicitArrayWrapper<T>;
     }
 
@@ -7427,8 +7272,7 @@ declare module _ {
          * @see _.forEach
          */
         forEach<TValue>(
-            iteratee?: ListIterator<TValue, any>|DictionaryIterator<TValue, any>,
-            thisArg?: any
+            iteratee?: ListIterator<TValue, any>|DictionaryIterator<TValue, any>
         ): LoDashImplicitObjectWrapper<T>;
     }
 
@@ -7437,8 +7281,7 @@ declare module _ {
          * @see _.forEach
          */
         forEach(
-            iteratee: ListIterator<string, any>,
-            thisArg?: any
+            iteratee: ListIterator<string, any>
         ): LoDashExplicitWrapper<string>;
     }
 
@@ -7447,8 +7290,7 @@ declare module _ {
          * @see _.forEach
          */
         forEach(
-            iteratee: ListIterator<T, any>,
-            thisArg?: any
+            iteratee: ListIterator<T, any>
         ): LoDashExplicitArrayWrapper<T>;
     }
 
@@ -7457,8 +7299,7 @@ declare module _ {
          * @see _.forEach
          */
         forEach<TValue>(
-            iteratee?: ListIterator<TValue, any>|DictionaryIterator<TValue, any>,
-            thisArg?: any
+            iteratee?: ListIterator<TValue, any>|DictionaryIterator<TValue, any>
         ): LoDashExplicitObjectWrapper<T>;
     }
 
@@ -7475,8 +7316,7 @@ declare module _ {
          */
         forEachRight<T>(
             collection: T[],
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): T[];
 
         /**
@@ -7484,8 +7324,7 @@ declare module _ {
          */
         forEachRight<T>(
             collection: List<T>,
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): List<T>;
 
         /**
@@ -7493,8 +7332,7 @@ declare module _ {
          */
         forEachRight<T>(
             collection: Dictionary<T>,
-            iteratee?: DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<T, any>
         ): Dictionary<T>;
 
         /**
@@ -7502,8 +7340,7 @@ declare module _ {
          */
         forEachRight<T extends {}>(
             collection: T,
-            iteratee?: ObjectIterator<any, any>,
-            thisArgs?: any
+            iteratee?: ObjectIterator<any, any>
         ): T;
 
         /**
@@ -7511,8 +7348,7 @@ declare module _ {
          */
         forEachRight<T extends {}, TValue>(
             collection: T,
-            iteratee?: ObjectIterator<TValue, any>,
-            thisArgs?: any
+            iteratee?: ObjectIterator<TValue, any>
         ): T;
     }
 
@@ -7521,8 +7357,7 @@ declare module _ {
          * @see _.forEachRight
          */
         forEachRight(
-            iteratee: ListIterator<string, any>,
-            thisArg?: any
+            iteratee: ListIterator<string, any>
         ): LoDashImplicitWrapper<string>;
     }
 
@@ -7531,8 +7366,7 @@ declare module _ {
          * @see _.forEachRight
          */
         forEachRight(
-            iteratee: ListIterator<T, any>,
-            thisArg?: any
+            iteratee: ListIterator<T, any>
         ): LoDashImplicitArrayWrapper<T>;
     }
 
@@ -7541,8 +7375,7 @@ declare module _ {
          * @see _.forEachRight
          */
         forEachRight<TValue>(
-            iteratee?: ListIterator<TValue, any>|DictionaryIterator<TValue, any>,
-            thisArg?: any
+            iteratee?: ListIterator<TValue, any>|DictionaryIterator<TValue, any>
         ): LoDashImplicitObjectWrapper<T>;
     }
 
@@ -7551,8 +7384,7 @@ declare module _ {
          * @see _.forEachRight
          */
         forEachRight(
-            iteratee: ListIterator<string, any>,
-            thisArg?: any
+            iteratee: ListIterator<string, any>
         ): LoDashExplicitWrapper<string>;
     }
 
@@ -7561,8 +7393,7 @@ declare module _ {
          * @see _.forEachRight
          */
         forEachRight(
-            iteratee: ListIterator<T, any>,
-            thisArg?: any
+            iteratee: ListIterator<T, any>
         ): LoDashExplicitArrayWrapper<T>;
     }
 
@@ -7571,8 +7402,7 @@ declare module _ {
          * @see _.forEachRight
          */
         forEachRight<TValue>(
-            iteratee?: ListIterator<TValue, any>|DictionaryIterator<TValue, any>,
-            thisArg?: any
+            iteratee?: ListIterator<TValue, any>|DictionaryIterator<TValue, any>
         ): LoDashExplicitObjectWrapper<T>;
     }
 
@@ -7600,8 +7430,7 @@ declare module _ {
          */
         groupBy<T, TKey>(
             collection: List<T>,
-            iteratee?: ListIterator<T, TKey>,
-            thisArg?: any
+            iteratee?: ListIterator<T, TKey>
         ): Dictionary<T[]>;
 
         /**
@@ -7609,8 +7438,7 @@ declare module _ {
          */
         groupBy<T>(
             collection: List<any>,
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): Dictionary<T[]>;
 
         /**
@@ -7618,8 +7446,7 @@ declare module _ {
          */
         groupBy<T, TKey>(
             collection: Dictionary<T>,
-            iteratee?: DictionaryIterator<T, TKey>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<T, TKey>
         ): Dictionary<T[]>;
 
         /**
@@ -7627,8 +7454,7 @@ declare module _ {
          */
         groupBy<T>(
             collection: Dictionary<any>,
-            iteratee?: DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<T, any>
         ): Dictionary<T[]>;
 
         /**
@@ -7636,8 +7462,7 @@ declare module _ {
          */
         groupBy<T, TValue>(
             collection: List<T>|Dictionary<T>,
-            iteratee?: string,
-            thisArg?: TValue
+            iteratee?: string
         ): Dictionary<T[]>;
 
         /**
@@ -7645,8 +7470,7 @@ declare module _ {
          */
         groupBy<T>(
             collection: List<T>|Dictionary<T>,
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): Dictionary<T[]>;
 
         /**
@@ -7671,8 +7495,7 @@ declare module _ {
          * @see _.groupBy
          */
         groupBy<TKey>(
-            iteratee?: ListIterator<T, TKey>,
-            thisArg?: any
+            iteratee?: ListIterator<T, TKey>
         ): LoDashImplicitObjectWrapper<Dictionary<T[]>>;
     }
 
@@ -7681,16 +7504,14 @@ declare module _ {
          * @see _.groupBy
          */
         groupBy<TKey>(
-            iteratee?: ListIterator<T, TKey>,
-            thisArg?: any
+            iteratee?: ListIterator<T, TKey>
         ): LoDashImplicitObjectWrapper<Dictionary<T[]>>;
 
         /**
          * @see _.groupBy
          */
         groupBy<TValue>(
-            iteratee?: string,
-            thisArg?: TValue
+            iteratee?: string
         ): LoDashImplicitObjectWrapper<Dictionary<T[]>>;
 
         /**
@@ -7706,32 +7527,28 @@ declare module _ {
          * @see _.groupBy
          */
         groupBy<T, TKey>(
-            iteratee?: ListIterator<T, TKey>|DictionaryIterator<T, TKey>,
-            thisArg?: any
+            iteratee?: ListIterator<T, TKey>|DictionaryIterator<T, TKey>
         ): LoDashImplicitObjectWrapper<Dictionary<T[]>>;
 
         /**
          * @see _.groupBy
          */
         groupBy<T>(
-            iteratee?: ListIterator<T, any>|DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>|DictionaryIterator<T, any>
         ): LoDashImplicitObjectWrapper<Dictionary<T[]>>;
 
         /**
          * @see _.groupBy
          */
         groupBy<T, TValue>(
-            iteratee?: string,
-            thisArg?: TValue
+            iteratee?: string
         ): LoDashImplicitObjectWrapper<Dictionary<T[]>>;
 
         /**
          * @see _.groupBy
          */
         groupBy<T>(
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): LoDashImplicitObjectWrapper<Dictionary<T[]>>;
 
         /**
@@ -7754,8 +7571,7 @@ declare module _ {
          * @see _.groupBy
          */
         groupBy<TKey>(
-            iteratee?: ListIterator<T, TKey>,
-            thisArg?: any
+            iteratee?: ListIterator<T, TKey>
         ): LoDashExplicitObjectWrapper<Dictionary<T[]>>;
     }
 
@@ -7764,16 +7580,14 @@ declare module _ {
          * @see _.groupBy
          */
         groupBy<TKey>(
-            iteratee?: ListIterator<T, TKey>,
-            thisArg?: any
+            iteratee?: ListIterator<T, TKey>
         ): LoDashExplicitObjectWrapper<Dictionary<T[]>>;
 
         /**
          * @see _.groupBy
          */
         groupBy<TValue>(
-            iteratee?: string,
-            thisArg?: TValue
+            iteratee?: string
         ): LoDashExplicitObjectWrapper<Dictionary<T[]>>;
 
         /**
@@ -7789,32 +7603,28 @@ declare module _ {
          * @see _.groupBy
          */
         groupBy<T, TKey>(
-            iteratee?: ListIterator<T, TKey>|DictionaryIterator<T, TKey>,
-            thisArg?: any
+            iteratee?: ListIterator<T, TKey>|DictionaryIterator<T, TKey>
         ): LoDashExplicitObjectWrapper<Dictionary<T[]>>;
 
         /**
          * @see _.groupBy
          */
         groupBy<T>(
-            iteratee?: ListIterator<T, any>|DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>|DictionaryIterator<T, any>
         ): LoDashExplicitObjectWrapper<Dictionary<T[]>>;
 
         /**
          * @see _.groupBy
          */
         groupBy<T, TValue>(
-            iteratee?: string,
-            thisArg?: TValue
+            iteratee?: string
         ): LoDashExplicitObjectWrapper<Dictionary<T[]>>;
 
         /**
          * @see _.groupBy
          */
         groupBy<T>(
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): LoDashExplicitObjectWrapper<Dictionary<T[]>>;
 
         /**
@@ -7943,8 +7753,7 @@ declare module _ {
          */
         keyBy<T>(
             collection: List<T>,
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): Dictionary<T>;
 
         /**
@@ -7952,8 +7761,7 @@ declare module _ {
          */
         keyBy<T>(
             collection: NumericDictionary<T>,
-            iteratee?: NumericDictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: NumericDictionaryIterator<T, any>
         ): Dictionary<T>;
 
         /**
@@ -7961,8 +7769,7 @@ declare module _ {
          */
         keyBy<T>(
             collection: Dictionary<T>,
-            iteratee?: DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<T, any>
         ): Dictionary<T>;
 
         /**
@@ -7970,8 +7777,7 @@ declare module _ {
          */
         keyBy<T>(
             collection: List<T>|NumericDictionary<T>|Dictionary<T>,
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): Dictionary<T>;
 
         /**
@@ -7996,8 +7802,7 @@ declare module _ {
          * @see _.keyBy
          */
         keyBy(
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): LoDashImplicitObjectWrapper<Dictionary<T>>;
     }
 
@@ -8006,16 +7811,14 @@ declare module _ {
          * @see _.keyBy
          */
         keyBy(
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): LoDashImplicitObjectWrapper<Dictionary<T>>;
 
         /**
          * @see _.keyBy
          */
         keyBy(
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): LoDashImplicitObjectWrapper<Dictionary<T>>;
 
         /**
@@ -8031,16 +7834,14 @@ declare module _ {
          * @see _.keyBy
          */
         keyBy<T>(
-            iteratee?: ListIterator<T, any>|NumericDictionaryIterator<T, any>|DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>|NumericDictionaryIterator<T, any>|DictionaryIterator<T, any>
         ): LoDashImplicitObjectWrapper<Dictionary<T>>;
 
         /**
          * @see _.keyBy
          */
         keyBy<T>(
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): LoDashImplicitObjectWrapper<Dictionary<T>>;
 
         /**
@@ -8063,8 +7864,7 @@ declare module _ {
          * @see _.keyBy
          */
         keyBy(
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): LoDashExplicitObjectWrapper<Dictionary<T>>;
     }
 
@@ -8073,16 +7873,14 @@ declare module _ {
          * @see _.keyBy
          */
         keyBy(
-            iteratee?: ListIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>
         ): LoDashExplicitObjectWrapper<Dictionary<T>>;
 
         /**
          * @see _.keyBy
          */
         keyBy(
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): LoDashExplicitObjectWrapper<Dictionary<T>>;
 
         /**
@@ -8098,16 +7896,14 @@ declare module _ {
          * @see _.keyBy
          */
         keyBy<T>(
-            iteratee?: ListIterator<T, any>|NumericDictionaryIterator<T, any>|DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>|NumericDictionaryIterator<T, any>|DictionaryIterator<T, any>
         ): LoDashExplicitObjectWrapper<Dictionary<T>>;
 
         /**
          * @see _.keyBy
          */
         keyBy<T>(
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): LoDashExplicitObjectWrapper<Dictionary<T>>;
 
         /**
@@ -8358,8 +8154,7 @@ declare module _ {
          */
         map<T, TResult>(
             collection: List<T>,
-            iteratee?: ListIterator<T, TResult>,
-            thisArg?: any
+            iteratee?: ListIterator<T, TResult>
         ): TResult[];
 
         /**
@@ -8367,14 +8162,12 @@ declare module _ {
          */
         map<T extends {}, TResult>(
             collection: Dictionary<T>,
-            iteratee?: DictionaryIterator<T, TResult>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<T, TResult>
         ): TResult[];
 
         map<T extends {}, TResult>(
             collection: NumericDictionary<T>,
-            iteratee?: NumericDictionaryIterator<T, TResult>,
-            thisArg?: any
+            iteratee?: NumericDictionaryIterator<T, TResult>
         ): TResult[];
 
         /**
@@ -8399,8 +8192,7 @@ declare module _ {
          * @see _.map
          */
         map<TResult>(
-            iteratee?: ListIterator<T, TResult>,
-            thisArg?: any
+            iteratee?: ListIterator<T, TResult>
         ): LoDashImplicitArrayWrapper<TResult>;
 
         /**
@@ -8423,8 +8215,7 @@ declare module _ {
          * @see _.map
          */
         map<TValue, TResult>(
-            iteratee?: ListIterator<TValue, TResult>|DictionaryIterator<TValue, TResult>,
-            thisArg?: any
+            iteratee?: ListIterator<TValue, TResult>|DictionaryIterator<TValue, TResult>
         ): LoDashImplicitArrayWrapper<TResult>;
 
         /**
@@ -8447,8 +8238,7 @@ declare module _ {
          * @see _.map
          */
         map<TResult>(
-            iteratee?: ListIterator<T, TResult>,
-            thisArg?: any
+            iteratee?: ListIterator<T, TResult>
         ): LoDashExplicitArrayWrapper<TResult>;
 
         /**
@@ -8471,8 +8261,7 @@ declare module _ {
          * @see _.map
          */
         map<TValue, TResult>(
-            iteratee?: ListIterator<TValue, TResult>|DictionaryIterator<TValue, TResult>,
-            thisArg?: any
+            iteratee?: ListIterator<TValue, TResult>|DictionaryIterator<TValue, TResult>
         ): LoDashExplicitArrayWrapper<TResult>;
 
         /**
@@ -8513,16 +8302,14 @@ declare module _ {
         **/
         partition<T>(
             collection: List<T>,
-            callback: ListIterator<T, boolean>,
-            thisArg?: any): T[][];
+            callback: ListIterator<T, boolean>): T[][];
 
         /**
          * @see _.partition
          **/
         partition<T>(
             collection: Dictionary<T>,
-            callback: DictionaryIterator<T, boolean>,
-            thisArg?: any): T[][];
+            callback: DictionaryIterator<T, boolean>): T[][];
 
         /**
          * @see _.partition
@@ -8574,8 +8361,7 @@ declare module _ {
          * @see _.partition
          */
         partition(
-            callback: ListIterator<string, boolean>,
-            thisArg?: any): LoDashImplicitArrayWrapper<string[]>;
+            callback: ListIterator<string, boolean>): LoDashImplicitArrayWrapper<string[]>;
     }
 
     interface LoDashImplicitArrayWrapper<T> {
@@ -8583,8 +8369,7 @@ declare module _ {
          * @see _.partition
          */
         partition(
-            callback: ListIterator<T, boolean>,
-            thisArg?: any): LoDashImplicitArrayWrapper<T[]>;
+            callback: ListIterator<T, boolean>): LoDashImplicitArrayWrapper<T[]>;
         /**
          * @see _.partition
          */
@@ -8608,15 +8393,13 @@ declare module _ {
          * @see _.partition
          */
         partition<TResult>(
-            callback: ListIterator<TResult, boolean>,
-            thisArg?: any): LoDashImplicitArrayWrapper<TResult[]>;
+            callback: ListIterator<TResult, boolean>): LoDashImplicitArrayWrapper<TResult[]>;
 
         /**
          * @see _.partition
          */
         partition<TResult>(
-            callback: DictionaryIterator<TResult, boolean>,
-            thisArg?: any): LoDashImplicitArrayWrapper<TResult[]>;
+            callback: DictionaryIterator<TResult, boolean>): LoDashImplicitArrayWrapper<TResult[]>;
 
         /**
          * @see _.partition
@@ -8655,8 +8438,7 @@ declare module _ {
         reduce<T, TResult>(
             collection: Array<T>,
             callback: MemoIterator<T, TResult>,
-            accumulator: TResult,
-            thisArg?: any): TResult;
+            accumulator: TResult): TResult;
 
         /**
         * @see _.reduce
@@ -8664,8 +8446,7 @@ declare module _ {
         reduce<T, TResult>(
             collection: List<T>,
             callback: MemoIterator<T, TResult>,
-            accumulator: TResult,
-            thisArg?: any): TResult;
+            accumulator: TResult): TResult;
 
         /**
         * @see _.reduce
@@ -8673,8 +8454,7 @@ declare module _ {
         reduce<T, TResult>(
             collection: Dictionary<T>,
             callback: MemoIterator<T, TResult>,
-            accumulator: TResult,
-            thisArg?: any): TResult;
+            accumulator: TResult): TResult;
 
         /**
         * @see _.reduce
@@ -8682,40 +8462,35 @@ declare module _ {
         reduce<T, TResult>(
             collection: NumericDictionary<T>,
             callback: MemoIterator<T, TResult>,
-            accumulator: TResult,
-            thisArg?: any): TResult;
+            accumulator: TResult): TResult;
 
         /**
         * @see _.reduce
         **/
         reduce<T, TResult>(
             collection: Array<T>,
-            callback: MemoIterator<T, TResult>,
-            thisArg?: any): TResult;
+            callback: MemoIterator<T, TResult>): TResult;
 
         /**
         * @see _.reduce
         **/
         reduce<T, TResult>(
             collection: List<T>,
-            callback: MemoIterator<T, TResult>,
-            thisArg?: any): TResult;
+            callback: MemoIterator<T, TResult>): TResult;
 
         /**
         * @see _.reduce
         **/
         reduce<T, TResult>(
             collection: Dictionary<T>,
-            callback: MemoIterator<T, TResult>,
-            thisArg?: any): TResult;
+            callback: MemoIterator<T, TResult>): TResult;
 
         /**
         * @see _.reduce
         **/
         reduce<T, TResult>(
             collection: NumericDictionary<T>,
-            callback: MemoIterator<T, TResult>,
-            thisArg?: any): TResult;
+            callback: MemoIterator<T, TResult>): TResult;
 
     }
 
@@ -8725,15 +8500,13 @@ declare module _ {
         **/
         reduce<TResult>(
             callback: MemoIterator<T, TResult>,
-            accumulator: TResult,
-            thisArg?: any): TResult;
+            accumulator: TResult): TResult;
 
         /**
         * @see _.reduce
         **/
         reduce<TResult>(
-            callback: MemoIterator<T, TResult>,
-            thisArg?: any): TResult;
+            callback: MemoIterator<T, TResult>): TResult;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
@@ -8742,15 +8515,13 @@ declare module _ {
         **/
         reduce<TValue, TResult>(
             callback: MemoIterator<TValue, TResult>,
-            accumulator: TResult,
-            thisArg?: any): TResult;
+            accumulator: TResult): TResult;
 
         /**
         * @see _.reduce
         **/
         reduce<TValue, TResult>(
-            callback: MemoIterator<TValue, TResult>,
-            thisArg?: any): TResult;
+            callback: MemoIterator<TValue, TResult>): TResult;
     }
 
     //_.reduceRight
@@ -8767,8 +8538,7 @@ declare module _ {
         reduceRight<T, TResult>(
             collection: Array<T>,
             callback: MemoIterator<T, TResult>,
-            accumulator: TResult,
-            thisArg?: any): TResult;
+            accumulator: TResult): TResult;
 
         /**
         * @see _.reduceRight
@@ -8776,8 +8546,7 @@ declare module _ {
         reduceRight<T, TResult>(
             collection: List<T>,
             callback: MemoIterator<T, TResult>,
-            accumulator: TResult,
-            thisArg?: any): TResult;
+            accumulator: TResult): TResult;
 
         /**
         * @see _.reduceRight
@@ -8785,32 +8554,28 @@ declare module _ {
         reduceRight<T, TResult>(
             collection: Dictionary<T>,
             callback: MemoIterator<T, TResult>,
-            accumulator: TResult,
-            thisArg?: any): TResult;
+            accumulator: TResult): TResult;
 
         /**
         * @see _.reduceRight
         **/
         reduceRight<T, TResult>(
             collection: Array<T>,
-            callback: MemoIterator<T, TResult>,
-            thisArg?: any): TResult;
+            callback: MemoIterator<T, TResult>): TResult;
 
         /**
         * @see _.reduceRight
         **/
         reduceRight<T, TResult>(
             collection: List<T>,
-            callback: MemoIterator<T, TResult>,
-            thisArg?: any): TResult;
+            callback: MemoIterator<T, TResult>): TResult;
 
         /**
         * @see _.reduceRight
         **/
         reduceRight<T, TResult>(
             collection: Dictionary<T>,
-            callback: MemoIterator<T, TResult>,
-            thisArg?: any): TResult;
+            callback: MemoIterator<T, TResult>): TResult;
     }
 
     //_.reject
@@ -8826,8 +8591,7 @@ declare module _ {
          */
         reject<T>(
             collection: List<T>,
-            predicate?: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate?: ListIterator<T, boolean>
         ): T[];
 
         /**
@@ -8835,8 +8599,7 @@ declare module _ {
          */
         reject<T>(
             collection: Dictionary<T>,
-            predicate?: DictionaryIterator<T, boolean>,
-            thisArg?: any
+            predicate?: DictionaryIterator<T, boolean>
         ): T[];
 
         /**
@@ -8844,8 +8607,7 @@ declare module _ {
          */
         reject(
             collection: string,
-            predicate?: StringIterator<boolean>,
-            thisArg?: any
+            predicate?: StringIterator<boolean>
         ): string[];
 
         /**
@@ -8853,8 +8615,7 @@ declare module _ {
          */
         reject<T>(
             collection: List<T>|Dictionary<T>,
-            predicate: string,
-            thisArg?: any
+            predicate: string
         ): T[];
 
         /**
@@ -8871,8 +8632,7 @@ declare module _ {
          * @see _.reject
          */
         reject(
-            predicate?: StringIterator<boolean>,
-            thisArg?: any
+            predicate?: StringIterator<boolean>
         ): LoDashImplicitArrayWrapper<string>;
     }
 
@@ -8881,16 +8641,14 @@ declare module _ {
          * @see _.reject
          */
         reject(
-            predicate: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate: ListIterator<T, boolean>
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
          * @see _.reject
          */
         reject(
-            predicate: string,
-            thisArg?: any
+            predicate: string
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
@@ -8904,16 +8662,14 @@ declare module _ {
          * @see _.reject
          */
         reject<T>(
-            predicate: ListIterator<T, boolean>|DictionaryIterator<T, boolean>,
-            thisArg?: any
+            predicate: ListIterator<T, boolean>|DictionaryIterator<T, boolean>
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
          * @see _.reject
          */
         reject<T>(
-            predicate: string,
-            thisArg?: any
+            predicate: string
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
@@ -8927,8 +8683,7 @@ declare module _ {
          * @see _.reject
          */
         reject(
-            predicate?: StringIterator<boolean>,
-            thisArg?: any
+            predicate?: StringIterator<boolean>
         ): LoDashExplicitArrayWrapper<string>;
     }
 
@@ -8937,16 +8692,14 @@ declare module _ {
          * @see _.reject
          */
         reject(
-            predicate: ListIterator<T, boolean>,
-            thisArg?: any
+            predicate: ListIterator<T, boolean>
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
          * @see _.reject
          */
         reject(
-            predicate: string,
-            thisArg?: any
+            predicate: string
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
@@ -8960,16 +8713,14 @@ declare module _ {
          * @see _.reject
          */
         reject<T>(
-            predicate: ListIterator<T, boolean>|DictionaryIterator<T, boolean>,
-            thisArg?: any
+            predicate: ListIterator<T, boolean>|DictionaryIterator<T, boolean>
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
          * @see _.reject
          */
         reject<T>(
-            predicate: string,
-            thisArg?: any
+            predicate: string
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
@@ -10120,7 +9871,6 @@ declare module _ {
         **/
         createCallback(
             func: string,
-            thisArg?: any,
             argCount?: number): () => any;
 
         /**
@@ -10128,7 +9878,6 @@ declare module _ {
         **/
         createCallback(
             func: Dictionary<any>,
-            thisArg?: any,
             argCount?: number): () => boolean;
     }
 
@@ -10137,7 +9886,6 @@ declare module _ {
         * @see _.createCallback
         **/
         createCallback(
-            thisArg?: any,
             argCount?: number): LoDashImplicitObjectWrapper<() => any>;
     }
 
@@ -10146,7 +9894,6 @@ declare module _ {
         * @see _.createCallback
         **/
         createCallback(
-            thisArg?: any,
             argCount?: number): LoDashImplicitObjectWrapper<() => any>;
     }
 
@@ -13349,16 +13096,14 @@ declare module _ {
          * @see _.maxBy
          */
         maxBy<T>(
-            iteratee?: ListIterator<T, any>|DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>|DictionaryIterator<T, any>
         ): T;
 
         /**
          * @see _.maxBy
          */
         maxBy<T>(
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): T;
 
         /**
@@ -13514,16 +13259,14 @@ declare module _ {
          * @see _.minBy
          */
         minBy<T>(
-            iteratee?: ListIterator<T, any>|DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: ListIterator<T, any>|DictionaryIterator<T, any>
         ): T;
 
         /**
          * @see _.minBy
          */
         minBy<T>(
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): T;
 
         /**
@@ -14917,8 +14660,7 @@ declare module _ {
         extend<TObject extends {}, TSource extends {}, TResult extends {}>(
             object: TObject,
             source: TSource,
-            customizer?: AssignCustomizer,
-            thisArg?: any
+            customizer?: AssignCustomizer
         ): TResult;
 
         /**
@@ -14928,8 +14670,7 @@ declare module _ {
             object: TObject,
             source1: TSource1,
             source2: TSource2,
-            customizer?: AssignCustomizer,
-            thisArg?: any
+            customizer?: AssignCustomizer
         ): TResult;
 
         /**
@@ -14940,8 +14681,7 @@ declare module _ {
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
-            customizer?: AssignCustomizer,
-            thisArg?: any
+            customizer?: AssignCustomizer
         ): TResult;
 
         /**
@@ -14955,8 +14695,7 @@ declare module _ {
                 source2: TSource2,
                 source3: TSource3,
                 source4: TSource4,
-                customizer?: AssignCustomizer,
-                thisArg?: any
+                customizer?: AssignCustomizer
             ): TResult;
 
         /**
@@ -14978,8 +14717,7 @@ declare module _ {
          */
         extend<TSource extends {}, TResult extends {}>(
             source: TSource,
-            customizer?: AssignCustomizer,
-            thisArg?: any
+            customizer?: AssignCustomizer
         ): LoDashImplicitObjectWrapper<TResult>;
 
         /**
@@ -14988,8 +14726,7 @@ declare module _ {
         extend<TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
             source1: TSource1,
             source2: TSource2,
-            customizer?: AssignCustomizer,
-            thisArg?: any
+            customizer?: AssignCustomizer
         ): LoDashImplicitObjectWrapper<TResult>;
 
         /**
@@ -14999,8 +14736,7 @@ declare module _ {
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
-            customizer?: AssignCustomizer,
-            thisArg?: any
+            customizer?: AssignCustomizer
         ): LoDashImplicitObjectWrapper<TResult>;
 
         /**
@@ -15011,8 +14747,7 @@ declare module _ {
             source2: TSource2,
             source3: TSource3,
             source4: TSource4,
-            customizer?: AssignCustomizer,
-            thisArg?: any
+            customizer?: AssignCustomizer
         ): LoDashImplicitObjectWrapper<TResult>;
 
         /**
@@ -15032,8 +14767,7 @@ declare module _ {
          */
         extend<TSource extends {}, TResult extends {}>(
             source: TSource,
-            customizer?: AssignCustomizer,
-            thisArg?: any
+            customizer?: AssignCustomizer
         ): LoDashExplicitObjectWrapper<TResult>;
 
         /**
@@ -15042,8 +14776,7 @@ declare module _ {
         extend<TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
             source1: TSource1,
             source2: TSource2,
-            customizer?: AssignCustomizer,
-            thisArg?: any
+            customizer?: AssignCustomizer
         ): LoDashExplicitObjectWrapper<TResult>;
 
         /**
@@ -15053,8 +14786,7 @@ declare module _ {
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
-            customizer?: AssignCustomizer,
-            thisArg?: any
+            customizer?: AssignCustomizer
         ): LoDashExplicitObjectWrapper<TResult>;
 
         /**
@@ -15065,8 +14797,7 @@ declare module _ {
             source2: TSource2,
             source3: TSource3,
             source4: TSource4,
-            customizer?: AssignCustomizer,
-            thisArg?: any
+            customizer?: AssignCustomizer
         ): LoDashExplicitObjectWrapper<TResult>;
 
         /**
@@ -15102,8 +14833,7 @@ declare module _ {
          */
         findKey<TValues, TObject>(
             object: TObject,
-            predicate?: DictionaryIterator<TValues, boolean>,
-            thisArg?: any
+            predicate?: DictionaryIterator<TValues, boolean>
         ): string;
 
         /**
@@ -15111,8 +14841,7 @@ declare module _ {
          */
         findKey<TObject>(
             object: TObject,
-            predicate?: ObjectIterator<any, boolean>,
-            thisArg?: any
+            predicate?: ObjectIterator<any, boolean>
         ): string;
 
         /**
@@ -15120,8 +14849,7 @@ declare module _ {
          */
         findKey<TObject>(
             object: TObject,
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): string;
 
         /**
@@ -15138,24 +14866,21 @@ declare module _ {
          * @see _.findKey
          */
         findKey<TValues>(
-            predicate?: DictionaryIterator<TValues, boolean>,
-            thisArg?: any
+            predicate?: DictionaryIterator<TValues, boolean>
         ): string;
 
         /**
          * @see _.findKey
          */
         findKey(
-            predicate?: ObjectIterator<any, boolean>,
-            thisArg?: any
+            predicate?: ObjectIterator<any, boolean>
         ): string;
 
         /**
          * @see _.findKey
          */
         findKey(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): string;
 
         /**
@@ -15171,24 +14896,21 @@ declare module _ {
          * @see _.findKey
          */
         findKey<TValues>(
-            predicate?: DictionaryIterator<TValues, boolean>,
-            thisArg?: any
+            predicate?: DictionaryIterator<TValues, boolean>
         ): LoDashExplicitWrapper<string>;
 
         /**
          * @see _.findKey
          */
         findKey(
-            predicate?: ObjectIterator<any, boolean>,
-            thisArg?: any
+            predicate?: ObjectIterator<any, boolean>
         ): LoDashExplicitWrapper<string>;
 
         /**
          * @see _.findKey
          */
         findKey(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashExplicitWrapper<string>;
 
         /**
@@ -15220,8 +14942,7 @@ declare module _ {
          */
         findLastKey<TValues, TObject>(
             object: TObject,
-            predicate?: DictionaryIterator<TValues, boolean>,
-            thisArg?: any
+            predicate?: DictionaryIterator<TValues, boolean>
         ): string;
 
         /**
@@ -15229,8 +14950,7 @@ declare module _ {
          */
         findLastKey<TObject>(
             object: TObject,
-            predicate?: ObjectIterator<any, boolean>,
-            thisArg?: any
+            predicate?: ObjectIterator<any, boolean>
         ): string;
 
         /**
@@ -15238,8 +14958,7 @@ declare module _ {
          */
         findLastKey<TObject>(
             object: TObject,
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): string;
 
         /**
@@ -15256,24 +14975,21 @@ declare module _ {
          * @see _.findLastKey
          */
         findLastKey<TValues>(
-            predicate?: DictionaryIterator<TValues, boolean>,
-            thisArg?: any
+            predicate?: DictionaryIterator<TValues, boolean>
         ): string;
 
         /**
          * @see _.findLastKey
          */
         findLastKey(
-            predicate?: ObjectIterator<any, boolean>,
-            thisArg?: any
+            predicate?: ObjectIterator<any, boolean>
         ): string;
 
         /**
          * @see _.findLastKey
          */
         findLastKey(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): string;
 
         /**
@@ -15289,24 +15005,21 @@ declare module _ {
          * @see _.findLastKey
          */
         findLastKey<TValues>(
-            predicate?: DictionaryIterator<TValues, boolean>,
-            thisArg?: any
+            predicate?: DictionaryIterator<TValues, boolean>
         ): LoDashExplicitWrapper<string>;
 
         /**
          * @see _.findLastKey
          */
         findLastKey(
-            predicate?: ObjectIterator<any, boolean>,
-            thisArg?: any
+            predicate?: ObjectIterator<any, boolean>
         ): LoDashExplicitWrapper<string>;
 
         /**
          * @see _.findLastKey
          */
         findLastKey(
-            predicate?: string,
-            thisArg?: any
+            predicate?: string
         ): LoDashExplicitWrapper<string>;
 
         /**
@@ -15331,8 +15044,7 @@ declare module _ {
          */
         forIn<T>(
             object: Dictionary<T>,
-            iteratee?: DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<T, any>
         ): Dictionary<T>;
 
         /**
@@ -15340,8 +15052,7 @@ declare module _ {
          */
         forIn<T extends {}>(
             object: T,
-            iteratee?: ObjectIterator<any, any>,
-            thisArg?: any
+            iteratee?: ObjectIterator<any, any>
         ): T;
     }
 
@@ -15350,8 +15061,7 @@ declare module _ {
          * @see _.forIn
          */
         forIn<TValue>(
-            iteratee?: DictionaryIterator<TValue, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<TValue, any>
         ): _.LoDashImplicitObjectWrapper<T>;
     }
 
@@ -15360,8 +15070,7 @@ declare module _ {
          * @see _.forIn
          */
         forIn<TValue>(
-            iteratee?: DictionaryIterator<TValue, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<TValue, any>
         ): _.LoDashExplicitObjectWrapper<T>;
     }
 
@@ -15377,8 +15086,7 @@ declare module _ {
          */
         forInRight<T>(
             object: Dictionary<T>,
-            iteratee?: DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<T, any>
         ): Dictionary<T>;
 
         /**
@@ -15386,8 +15094,7 @@ declare module _ {
          */
         forInRight<T extends {}>(
             object: T,
-            iteratee?: ObjectIterator<any, any>,
-            thisArg?: any
+            iteratee?: ObjectIterator<any, any>
         ): T;
     }
 
@@ -15396,8 +15103,7 @@ declare module _ {
          * @see _.forInRight
          */
         forInRight<TValue>(
-            iteratee?: DictionaryIterator<TValue, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<TValue, any>
         ): _.LoDashImplicitObjectWrapper<T>;
     }
 
@@ -15406,8 +15112,7 @@ declare module _ {
          * @see _.forInRight
          */
         forInRight<TValue>(
-            iteratee?: DictionaryIterator<TValue, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<TValue, any>
         ): _.LoDashExplicitObjectWrapper<T>;
     }
 
@@ -15425,8 +15130,7 @@ declare module _ {
          */
         forOwn<T>(
             object: Dictionary<T>,
-            iteratee?: DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<T, any>
         ): Dictionary<T>;
 
         /**
@@ -15434,8 +15138,7 @@ declare module _ {
          */
         forOwn<T extends {}>(
             object: T,
-            iteratee?: ObjectIterator<any, any>,
-            thisArg?: any
+            iteratee?: ObjectIterator<any, any>
         ): T;
     }
 
@@ -15444,8 +15147,7 @@ declare module _ {
          * @see _.forOwn
          */
         forOwn<TValue>(
-            iteratee?: DictionaryIterator<TValue, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<TValue, any>
         ): _.LoDashImplicitObjectWrapper<T>;
     }
 
@@ -15454,8 +15156,7 @@ declare module _ {
          * @see _.forOwn
          */
         forOwn<TValue>(
-            iteratee?: DictionaryIterator<TValue, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<TValue, any>
         ): _.LoDashExplicitObjectWrapper<T>;
     }
 
@@ -15471,8 +15172,7 @@ declare module _ {
          */
         forOwnRight<T>(
             object: Dictionary<T>,
-            iteratee?: DictionaryIterator<T, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<T, any>
         ): Dictionary<T>;
 
         /**
@@ -15480,8 +15180,7 @@ declare module _ {
          */
         forOwnRight<T extends {}>(
             object: T,
-            iteratee?: ObjectIterator<any, any>,
-            thisArg?: any
+            iteratee?: ObjectIterator<any, any>
         ): T;
     }
 
@@ -15490,8 +15189,7 @@ declare module _ {
          * @see _.forOwnRight
          */
         forOwnRight<TValue>(
-            iteratee?: DictionaryIterator<TValue, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<TValue, any>
         ): _.LoDashImplicitObjectWrapper<T>;
     }
 
@@ -15500,8 +15198,7 @@ declare module _ {
          * @see _.forOwnRight
          */
         forOwnRight<TValue>(
-            iteratee?: DictionaryIterator<TValue, any>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<TValue, any>
         ): _.LoDashExplicitObjectWrapper<T>;
     }
 
@@ -15999,8 +15696,7 @@ declare module _ {
          */
         mapKeys<T, TKey>(
             object: List<T>,
-            iteratee?: ListIterator<T, TKey>,
-            thisArg?: any
+            iteratee?: ListIterator<T, TKey>
         ): Dictionary<T>;
 
         /**
@@ -16008,8 +15704,7 @@ declare module _ {
          */
         mapKeys<T, TKey>(
             object: Dictionary<T>,
-            iteratee?: DictionaryIterator<T, TKey>,
-            thisArg?: any
+            iteratee?: DictionaryIterator<T, TKey>
         ): Dictionary<T>;
 
         /**
@@ -16025,8 +15720,7 @@ declare module _ {
          */
         mapKeys<T>(
             object: List<T>|Dictionary<T>,
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): Dictionary<T>;
     }
 
@@ -16035,8 +15729,7 @@ declare module _ {
          * @see _.mapKeys
          */
         mapKeys<TKey>(
-            iteratee?: ListIterator<T, TKey>,
-            thisArg?: any
+            iteratee?: ListIterator<T, TKey>
         ): LoDashImplicitObjectWrapper<Dictionary<T>>;
 
         /**
@@ -16050,8 +15743,7 @@ declare module _ {
          * @see _.mapKeys
          */
         mapKeys(
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): LoDashImplicitObjectWrapper<Dictionary<T>>;
     }
 
@@ -16060,8 +15752,7 @@ declare module _ {
          * @see _.mapKeys
          */
         mapKeys<TResult, TKey>(
-            iteratee?: ListIterator<TResult, TKey>|DictionaryIterator<TResult, TKey>,
-            thisArg?: any
+            iteratee?: ListIterator<TResult, TKey>|DictionaryIterator<TResult, TKey>
         ): LoDashImplicitObjectWrapper<Dictionary<TResult>>;
 
         /**
@@ -16075,8 +15766,7 @@ declare module _ {
          * @see _.mapKeys
          */
         mapKeys<TResult>(
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): LoDashImplicitObjectWrapper<Dictionary<TResult>>;
     }
 
@@ -16085,8 +15775,7 @@ declare module _ {
          * @see _.mapKeys
          */
         mapKeys<TKey>(
-            iteratee?: ListIterator<T, TKey>,
-            thisArg?: any
+            iteratee?: ListIterator<T, TKey>
         ): LoDashExplicitObjectWrapper<Dictionary<T>>;
 
         /**
@@ -16100,8 +15789,7 @@ declare module _ {
          * @see _.mapKeys
          */
         mapKeys(
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): LoDashExplicitObjectWrapper<Dictionary<T>>;
     }
 
@@ -16110,8 +15798,7 @@ declare module _ {
          * @see _.mapKeys
          */
         mapKeys<TResult, TKey>(
-            iteratee?: ListIterator<TResult, TKey>|DictionaryIterator<TResult, TKey>,
-            thisArg?: any
+            iteratee?: ListIterator<TResult, TKey>|DictionaryIterator<TResult, TKey>
         ): LoDashExplicitObjectWrapper<Dictionary<TResult>>;
 
         /**
@@ -16125,8 +15812,7 @@ declare module _ {
          * @see _.mapKeys
          */
         mapKeys<TResult>(
-            iteratee?: string,
-            thisArg?: any
+            iteratee?: string
         ): LoDashExplicitObjectWrapper<Dictionary<TResult>>;
     }
 
@@ -16151,10 +15837,10 @@ declare module _ {
         * @param {Object} [thisArg] The `this` binding of `iteratee`.
         * @return {Object} Returns the new mapped object.
         */
-        mapValues<T, TResult>(obj: Dictionary<T>, callback: ObjectIterator<T, TResult>, thisArg?: any): Dictionary<TResult>;
+        mapValues<T, TResult>(obj: Dictionary<T>, callback: ObjectIterator<T, TResult>): Dictionary<TResult>;
         mapValues<T>(obj: Dictionary<T>, where: Dictionary<T>): Dictionary<boolean>;
         mapValues<T, TMapped>(obj: T, pluck: string): TMapped;
-        mapValues<T>(obj: T, callback: ObjectIterator<any, any>, thisArg?: any): T;
+        mapValues<T>(obj: T, callback: ObjectIterator<any, any>): T;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
@@ -16163,7 +15849,7 @@ declare module _ {
          * TValue is the type of the property values of T.
          * TResult is the type output by the ObjectIterator function
          */
-        mapValues<TValue, TResult>(callback: ObjectIterator<TValue, TResult>, thisArg?: any): LoDashImplicitObjectWrapper<Dictionary<TResult>>;
+        mapValues<TValue, TResult>(callback: ObjectIterator<TValue, TResult>): LoDashImplicitObjectWrapper<Dictionary<TResult>>;
 
         /**
          * @see _.mapValues
@@ -16973,8 +16659,7 @@ declare module _ {
         transform<T, TResult>(
             object: T[],
             iteratee?: MemoVoidArrayIterator<T, TResult[]>,
-            accumulator?: TResult[],
-            thisArg?: any
+            accumulator?: TResult[]
         ): TResult[];
 
         /**
@@ -16983,8 +16668,7 @@ declare module _ {
         transform<T, TResult>(
             object: T[],
             iteratee?: MemoVoidArrayIterator<T, Dictionary<TResult>>,
-            accumulator?: Dictionary<TResult>,
-            thisArg?: any
+            accumulator?: Dictionary<TResult>
         ): Dictionary<TResult>;
 
         /**
@@ -16993,8 +16677,7 @@ declare module _ {
         transform<T, TResult>(
             object: Dictionary<T>,
             iteratee?: MemoVoidDictionaryIterator<T, Dictionary<TResult>>,
-            accumulator?: Dictionary<TResult>,
-            thisArg?: any
+            accumulator?: Dictionary<TResult>
         ): Dictionary<TResult>;
 
         /**
@@ -17003,8 +16686,7 @@ declare module _ {
         transform<T, TResult>(
             object: Dictionary<T>,
             iteratee?: MemoVoidDictionaryIterator<T, TResult[]>,
-            accumulator?: TResult[],
-            thisArg?: any
+            accumulator?: TResult[]
         ): TResult[];
     }
 
@@ -17014,8 +16696,7 @@ declare module _ {
          */
         transform<TResult>(
             iteratee?: MemoVoidArrayIterator<T, TResult[]>,
-            accumulator?: TResult[],
-            thisArg?: any
+            accumulator?: TResult[]
         ): LoDashImplicitArrayWrapper<TResult>;
 
         /**
@@ -17023,8 +16704,7 @@ declare module _ {
          */
         transform<TResult>(
             iteratee?: MemoVoidArrayIterator<T, Dictionary<TResult>>,
-            accumulator?: Dictionary<TResult>,
-            thisArg?: any
+            accumulator?: Dictionary<TResult>
         ): LoDashImplicitObjectWrapper<Dictionary<TResult>>;
     }
 
@@ -17034,8 +16714,7 @@ declare module _ {
          */
         transform<T, TResult>(
             iteratee?: MemoVoidDictionaryIterator<T, Dictionary<TResult>>,
-            accumulator?: Dictionary<TResult>,
-            thisArg?: any
+            accumulator?: Dictionary<TResult>
         ): LoDashImplicitObjectWrapper<Dictionary<TResult>>;
 
         /**
@@ -17043,8 +16722,7 @@ declare module _ {
          */
         transform<T, TResult>(
             iteratee?: MemoVoidDictionaryIterator<T, TResult[]>,
-            accumulator?: TResult[],
-            thisArg?: any
+            accumulator?: TResult[]
         ): LoDashImplicitArrayWrapper<TResult>;
     }
 
@@ -18344,24 +18022,21 @@ declare module _ {
          * // => [{ 'user': 'fred', 'age': 40 }]
          */
         iteratee<TResult>(
-            func: Function,
-            thisArg?: any
+            func: Function
         ): (...args: any[]) => TResult;
 
         /**
          * @see _.iteratee
          */
         iteratee<TResult>(
-            func: string,
-            thisArg?: any
+            func: string
         ): (object: any) => TResult;
 
         /**
          * @see _.iteratee
          */
         iteratee(
-            func: Object,
-            thisArg?: any
+            func: Object
         ): (object: any) => boolean;
 
         /**
@@ -18374,38 +18049,38 @@ declare module _ {
         /**
          * @see _.iteratee
          */
-        iteratee<TResult>(thisArg?: any): LoDashImplicitObjectWrapper<(object: any) => TResult>;
+        iteratee<TResult>(): LoDashImplicitObjectWrapper<(object: any) => TResult>;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
         /**
          * @see _.iteratee
          */
-        iteratee(thisArg?: any): LoDashImplicitObjectWrapper<(object: any) => boolean>;
+        iteratee(): LoDashImplicitObjectWrapper<(object: any) => boolean>;
 
         /**
          * @see _.iteratee
          */
-        iteratee<TResult>(thisArg?: any): LoDashImplicitObjectWrapper<(...args: any[]) => TResult>;
+        iteratee<TResult>(): LoDashImplicitObjectWrapper<(...args: any[]) => TResult>;
     }
 
     interface LoDashExplicitWrapper<T> {
         /**
          * @see _.iteratee
          */
-        iteratee<TResult>(thisArg?: any): LoDashExplicitObjectWrapper<(object: any) => TResult>;
+        iteratee<TResult>(): LoDashExplicitObjectWrapper<(object: any) => TResult>;
     }
 
     interface LoDashExplicitObjectWrapper<T> {
         /**
          * @see _.iteratee
          */
-        iteratee(thisArg?: any): LoDashExplicitObjectWrapper<(object: any) => boolean>;
+        iteratee(): LoDashExplicitObjectWrapper<(object: any) => boolean>;
 
         /**
          * @see _.iteratee
          */
-        iteratee<TResult>(thisArg?: any): LoDashExplicitObjectWrapper<(...args: any[]) => TResult>;
+        iteratee<TResult>(): LoDashExplicitObjectWrapper<(...args: any[]) => TResult>;
     }
 
     //_.matches


### PR DESCRIPTION
Lodash 4 [removed almost all instances of the `thisArg` argument](https://github.com/lodash/lodash/wiki/Changelog#v400).

Relatedly: the doc comments were already out of date, but now they're extra out-of-date. Is there a good programmatic way to update them all?
