### PR TITLE
Lodash: update mapvalues, frompairs, pickby

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -1019,6 +1019,24 @@ namespace TestFlattenDeep {
     }
 }
 
+// _.fromPairs
+namespace TestFromPairs {
+    let array: string[][];
+    let result: _.Dictionary<any>;
+
+    {
+        result = _.fromPairs(array);
+    }
+
+    {
+        result = _(array).fromPairs().value();
+    }
+
+    {
+        result = _.chain(array).fromPairs().value();
+    }
+}
+
 // _.head
 namespace TestHead {
     let array: TResult[];

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -16101,6 +16101,36 @@ declare module _ {
         mapValues<TResult>(where: Dictionary<TResult>): LoDashImplicitArrayWrapper<boolean>;
     }
 
+    interface LoDashExplicitObjectWrapper<T> {
+        /**
+         * @see _.mapValues
+         * TValue is the type of the property values of T.
+         * TResult is the type output by the ObjectIterator function
+         */
+        mapValues<TValue, TResult>(callback: ObjectIterator<TValue, TResult>, thisArg?: any): LoDashExplicitObjectWrapper<Dictionary<TResult>>;
+
+        /**
+         * @see _.mapValues
+         * TResult is the type of the property specified by pluck.
+         * T should be a Dictionary<Dictionary<TResult>>
+         */
+        mapValues<TResult>(pluck: string): LoDashExplicitObjectWrapper<Dictionary<TResult>>;
+
+        /**
+         * @see _.mapValues
+         * TResult is the type of the properties on the object specified by pluck.
+         * T should be a Dictionary<Dictionary<Dictionary<TResult>>>
+         */
+        mapValues<TResult>(pluck: string, where: Dictionary<TResult>): LoDashExplicitObjectWrapper<Dictionary<boolean>>;
+
+        /**
+         * @see _.mapValues
+         * TResult is the type of the properties of each object in the values of T
+         * T should be a Dictionary<Dictionary<TResult>>
+         */
+        mapValues<TResult>(where: Dictionary<TResult>): LoDashExplicitObjectWrapper<boolean>;
+    }
+
     //_.merge
     interface LoDashStatic {
         /**

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -16104,13 +16104,6 @@ declare module _ {
 
         /**
          * @see _.mapValues
-         * TResult is the type of the properties on the object specified by pluck.
-         * T should be a Dictionary<Dictionary<Dictionary<TResult>>>
-         */
-        mapValues<TResult>(pluck: string, where: Dictionary<TResult>): LoDashImplicitArrayWrapper<Dictionary<boolean>>;
-
-        /**
-         * @see _.mapValues
          * TResult is the type of the properties of each object in the values of T
          * T should be a Dictionary<Dictionary<TResult>>
          */
@@ -16131,13 +16124,6 @@ declare module _ {
          * T should be a Dictionary<Dictionary<TResult>>
          */
         mapValues<TResult>(pluck: string): LoDashExplicitObjectWrapper<Dictionary<TResult>>;
-
-        /**
-         * @see _.mapValues
-         * TResult is the type of the properties on the object specified by pluck.
-         * T should be a Dictionary<Dictionary<Dictionary<TResult>>>
-         */
-        mapValues<TResult>(pluck: string, where: Dictionary<TResult>): LoDashExplicitObjectWrapper<Dictionary<boolean>>;
 
         /**
          * @see _.mapValues

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -16116,7 +16116,7 @@ declare module _ {
          * TValue is the type of the property values of T.
          * TResult is the type output by the ObjectIterator function
          */
-        mapValues<TValue, TResult>(callback: ObjectIterator<TValue, TResult>, thisArg?: any): LoDashExplicitObjectWrapper<Dictionary<TResult>>;
+        mapValues<TValue, TResult>(callback: ObjectIterator<TValue, TResult>): LoDashExplicitObjectWrapper<Dictionary<TResult>>;
 
         /**
          * @see _.mapValues

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -2058,7 +2058,23 @@ declare module _ {
          */
         fromPairs(
             array: any[]|List<any>
-        ): any[];
+        ): Dictionary<any>;
+    }
+
+    //_.fromPairs DUMMY
+    interface LoDashImplicitArrayWrapper<T> {
+        /**
+         * @see _.fromPairs
+         */
+        fromPairs(): LoDashImplicitObjectWrapper<any>;
+    }
+
+    //_.fromPairs DUMMY
+    interface LoDashExplicitArrayWrapper<T> {
+        /**
+         * @see _.fromPairs
+         */
+        fromPairs(): LoDashExplicitObjectWrapper<any>;
     }
 
     //_.head

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -16549,7 +16549,7 @@ declare module _ {
          */
         pickBy<TResult extends {}, T extends {}>(
             object: T,
-            predicate: ObjectIterator<any, boolean>
+            predicate?: ObjectIterator<any, boolean>
         ): TResult;
     }
 
@@ -16558,7 +16558,7 @@ declare module _ {
          * @see _.pickBy
          */
         pickBy<TResult extends {}>(
-            predicate: ObjectIterator<any, boolean>
+            predicate?: ObjectIterator<any, boolean>
         ): LoDashImplicitObjectWrapper<TResult>;
     }
 
@@ -16567,7 +16567,7 @@ declare module _ {
          * @see _.pickBy
          */
         pickBy<TResult extends {}>(
-            predicate: ObjectIterator<any, boolean>
+            predicate?: ObjectIterator<any, boolean>
         ): LoDashExplicitObjectWrapper<TResult>;
     }
 


### PR DESCRIPTION
Originally from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/8768; this subset of changes seems ready to go so I pulled it out separately.
- `fromPairs`: fixed the dummy to at least return an object; added implicit and explicit wrapper types (they still use `any`)
- `mapValues`: added to the explicit wrapper
- `pickBy`: make predicate optional as specified in the docs
