### PR TITLE
update query-string definition

### DIFF
--- a/query-string/query-string-tests.ts
+++ b/query-string/query-string-tests.ts
@@ -4,6 +4,7 @@ import qs = require('query-string');
 
 qs.stringify({ foo: 'bar' });
 qs.stringify({ foo: 'bar', bar: 'baz' });
+qs.stringify({ foo: 'bar' }, {strict: false})
 
 qs.parse('?foo=bar');
 qs.parse('#foo=bar');

--- a/query-string/query-string.d.ts
+++ b/query-string/query-string.d.ts
@@ -16,7 +16,7 @@ declare module "query-string" {
      *
      * @param obj
      */
-    export function stringify(obj: any): string;
+    export function stringify(obj: any, options?: {strict: boolean}): string;
 
     /**
      * Extract a query string from a URL that can be passed into .parse().


### PR DESCRIPTION
The [stringify](https://github.com/sindresorhus/query-string#stringifyobject-options) method of [query-string](https://github.com/sindresorhus/query-string) accepts an options object with a `strict` flag.
