### PR TITLE
Allow SVGElement as the first param for the constructor function.

### DIFF
--- a/hammerjs/hammerjs.d.ts
+++ b/hammerjs/hammerjs.d.ts
@@ -11,7 +11,7 @@ declare module "hammerjs" {
 
 interface HammerStatic
 {
-  new( element:HTMLElement, options?:any ): HammerManager;
+  new( element:HTMLElement | SVGElement, options?:any ): HammerManager;
 
   defaults:HammerDefaults;
 


### PR DESCRIPTION
Hammer.new(element) works for SVG elements as well, not just for HTML elements.
