### PR TITLE
added missing `target` member

### DIFF
--- a/threejs/three-orthographictrackballcontrols.d.ts
+++ b/threejs/three-orthographictrackballcontrols.d.ts
@@ -27,6 +27,8 @@ declare module THREE {
 		dynamicDampingFactor:number;
 		keys:number[];
 
+		target: THREE.Vector3;
+
 		position0: THREE.Vector3;
 		target0: THREE.Vector3;
 		up0: THREE.Vector3;


### PR DESCRIPTION
See https://github.com/mrdoob/three.js/blob/master/examples/js/controls/OrthographicTrackballControls.js#L39
