### PR TITLE
allow importing raphael as a module

### DIFF
--- a/raphael/raphael.d.ts
+++ b/raphael/raphael.d.ts
@@ -294,3 +294,6 @@ interface RaphaelStatic {
 }
 
 declare var Raphael: RaphaelStatic;
+declare module "raphael" {
+    export = Raphael;
+}


### PR DESCRIPTION
case 2. Improvement to existing type definition.

no new library version
Currently the definition declares a global "Raphael" assuming you'll provide the required source somehow:

If I want to import raphael, as seen below, I must add an additional d.ts extension to make tsc happy.

```
import * as raphael from "raphael";
```

My change allows you to import raphael without the end user having to add additional typing files (and depending on your module loading strategy, pull in the source without need for a script tag or the like). You see this pattern in other d.ts such as toastr.

Once Typescript 2.0 comes out, an improved solution will exist.
