### PR TITLE
add definitions for koa-static

### DIFF
--- a/koa-static/koa-static-tests.ts
+++ b/koa-static/koa-static-tests.ts
@@ -1,0 +1,11 @@
+/// <reference path="../koa/koa.d.ts" />
+/// <reference path="koa-static.d.ts" />
+
+import * as Koa from "koa";
+import serve = require("koa-static");
+
+const app = new Koa();
+
+app.use(serve('.',{index:false,defer:false}));
+
+app.listen(80)

--- a/koa-static/koa-static.d.ts
+++ b/koa-static/koa-static.d.ts
@@ -1,0 +1,51 @@
+// Type definitions for koa-static v2.x
+// Project: https://github.com/koajs/static
+// Definitions by: Jerry Chin <https://github.com/hellopao/>
+// Definitions: https://github.com/hellopao/DefinitelyTyped
+
+/* =================== USAGE ===================
+
+    import serve = require("koa-static");
+    var Koa = require('koa');
+
+    var app = new Koa();
+    app.use(serve("."));
+
+ =============================================== */
+
+/// <reference path="../koa/koa.d.ts" />
+
+declare module "koa-static" {
+
+    import * as Koa from "koa";
+
+    function serve(root: string, opts?: {
+        
+        /**
+         * Default file name, defaults to 'index.html'
+         */
+        index?: boolean | string;
+        
+        /**
+         * If true, serves after return next(),allowing any downstream middleware to respond first.
+         */
+        defer?: boolean;
+        
+        /**
+         * Browser cache max-age in milliseconds. defaults to 0
+         */
+        maxage?: number;
+        
+        /**
+         * Allow transfer of hidden files. defaults to false
+         */
+        hidden?: boolean;
+        
+        /**
+         * Try to serve the gzipped version of a file automatically when gzip is supported by a client and if the requested file with .gz extension exists. defaults to true.
+         */
+        gzip?: boolean;
+    }): { (ctx: Koa.Context, next?: () => any): any };
+
+    export = serve;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
