### PR TITLE
Added definitions for react-tabs

### DIFF
--- a/react-tabs/react-tabs-tests.ts
+++ b/react-tabs/react-tabs-tests.ts
@@ -1,0 +1,27 @@
+/// <reference path="react-tabs.d.ts" />
+/// <reference path="../react/react.d.ts" />
+/// <reference path="../react/react-dom.d.ts" />
+
+import React = require("react");
+import ReactDOM = require("react-dom");
+import { Tabs, TabList, Tab, TabPanel } from "react-tabs";
+
+class TestApp extends React.Component<{}, {}> {
+    onSelect = (index: number, last: number) => {
+        console.log("selected tab: " + index.toString());
+        console.log("last tab: " + last.toString());
+    }
+
+    render() {
+        return React.createElement(Tabs, {onSelect: this.onSelect, selectedIndex: 1},
+                   React.createElement(TabList, {className: "test-class"},
+                       React.createElement(Tab, {}, "Tab1"),
+                       React.createElement(Tab, {}, "Tab2"),
+                       React.createElement(Tab, {}, "Tab3")),
+                   React.createElement(TabPanel, {}, React.createElement("h2", {}, "Content1")),
+                   React.createElement(TabPanel, {}, React.createElement("h2", {}, "Content2")),
+                   React.createElement(TabPanel, {}, React.createElement("h2", {}, "Content3")));
+    }
+}
+
+ReactDOM.render(React.createElement(TestApp, {}), document.getElementById("test-app"));

--- a/react-tabs/react-tabs.d.ts
+++ b/react-tabs/react-tabs.d.ts
@@ -1,0 +1,61 @@
+// Type definitions for react-tabs 0.5.3
+// Project: https://github.com/reactjs/react-tabs/
+// Definitions by: Yuu Igarashi <https://github.com/yu-i9/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../react/react.d.ts" />
+
+declare namespace ReactTabs {
+
+    interface TabsProps {
+        className?: string;
+        selectedIndex?: number;
+        focus?: boolean;
+        forceRenderTabPanel?: boolean;
+        onSelect?: (index: number, last: number) => void;
+    }
+
+    interface Tabs extends __React.ComponentClass<TabsProps> {}
+
+    interface TabListProps {
+        className?: string;
+    }
+
+    interface TabList extends __React.ComponentClass<TabListProps> {}
+
+    interface TabProps {
+        className?: string;
+        focus?: boolean;
+        selected?: boolean;
+        id?: string;
+        panelId?: string;
+    }
+
+    interface Tab extends __React.ComponentClass<TabProps> {}
+
+    interface TabPanelProps {
+        className?: string;
+        selected?: boolean;
+        id?: string;
+        tabId?: string;
+    }
+
+    interface TabPanel extends __React.ComponentClass<TabPanelProps> {}
+}
+
+
+declare module "react-tabs" {
+
+    var Tabs: ReactTabs.Tabs;
+    var TabList: ReactTabs.TabList;
+    var Tab: ReactTabs.Tab;
+    var TabPanel: ReactTabs.TabPanel;
+
+    export {
+        Tabs,
+        TabList,
+        Tab,
+        TabPanel
+    }
+
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
