### PR TITLE
normalised interfaces names (module contains local and session storag…

### DIFF
--- a/ngstorage/ngstorage-tests.ts
+++ b/ngstorage/ngstorage-tests.ts
@@ -24,21 +24,21 @@ app.controller('LocalCtrl', function ($localStorage: angular.storage.IStorageSer
 
 app.controller('SessionCtrl', function ($sessionStorage: angular.storage.IStorageService) {
 
-    $localStorage.set('MyKey', 'value');
+    $sessionStorage.set('MyKey', 'value');
 
-    $localStorage.get('MyKey');
+    $sessionStorage.get('MyKey');
 
-    $localStorage.$default({
+    $sessionStorage.$default({
         counter: 1
     });
 
-    $localStorage.$reset({
+    $sessionStorage.$reset({
         counter: 1
     });
     
-    $localStorage.$reset();
+    $sessionStorage.$reset();
 
-    $localStorage.$apply();
+    $sessionStorage.$apply();
 });
 
 app.config(['$localStorageProvider', function ($localStorageProvider: angular.storage.IStorageProvider) {

--- a/ngstorage/ngstorage-tests.ts
+++ b/ngstorage/ngstorage-tests.ts
@@ -3,7 +3,7 @@
 
 var app: any;
 
-app.controller('MainCtrl', function ($localStorage: angular.storage.ILocalStorageService) {
+app.controller('LocalCtrl', function ($localStorage: angular.storage.IStorageService) {
 
     $localStorage.set('MyKey', 'value');
 
@@ -16,12 +16,32 @@ app.controller('MainCtrl', function ($localStorage: angular.storage.ILocalStorag
     $localStorage.$reset({
         counter: 1
     });
+    
+    $localStorage.$reset();
 
     $localStorage.$apply();
 });
 
-app.config(['$localStorageProvider',
-    function ($localStorageProvider: angular.storage.ILocalStorageProvider) {
+app.controller('SessionCtrl', function ($sessionStorage: angular.storage.IStorageService) {
+
+    $localStorage.set('MyKey', 'value');
+
+    $localStorage.get('MyKey');
+
+    $localStorage.$default({
+        counter: 1
+    });
+
+    $localStorage.$reset({
+        counter: 1
+    });
+    
+    $localStorage.$reset();
+
+    $localStorage.$apply();
+});
+
+app.config(['$localStorageProvider', function ($localStorageProvider: angular.storage.IStorageProvider) {
         $localStorageProvider.setKeyPrefix('NewPrefix');
 
         $localStorageProvider.get('MyKey');
@@ -38,5 +58,24 @@ app.config(['$localStorageProvider',
 
         $localStorageProvider.setSerializer(mySerializer);
         $localStorageProvider.setDeserializer(myDeserializer);
+    }
+]).config(['$sessionStorageProvider', function ($sessionStorageProvider: angular.storage.IStorageProvider) {
+
+        $sessionStorageProvider.setKeyPrefix('NewPrefix');
+
+        $sessionStorageProvider.get('MyKey');
+
+        $sessionStorageProvider.set('MyKey', { counter: 'value' });
+
+        var mySerializer = function (value:any):string {
+            return value.toString();
+        };
+
+        var myDeserializer = function (value:string):any {
+            return value;
+        };
+
+        $sessionStorageProvider.setSerializer(mySerializer);
+        $sessionStorageProvider.setDeserializer(myDeserializer);
     }
 ]);

--- a/ngstorage/ngstorage.d.ts
+++ b/ngstorage/ngstorage.d.ts
@@ -7,22 +7,22 @@
 
 declare namespace angular.storage {
 
-    export interface ILocalStorageService {
-        $default(items: any):ILocalStorageService;
-        $reset(items: any):ILocalStorageService;
-        $apply():void;
+    export interface IStorageService {
+        $default(items: {}): IStorageService;
+        $reset(items?: {}): IStorageService;
+        $apply(): void;
 
         get<T>(key: string): T;
         set<T>(key: string, value: T): T;
     }
 
-    export interface ILocalStorageProvider extends angular.IServiceProvider {
+    export interface IStorageProvider extends angular.IServiceProvider {
 
         get<T>(key:string): T;
         set<T>(key:string, value:T): T;
 
-        setKeyPrefix(prefix: string):void;
-        setSerializer(serializer: (value: any)=>string):void;
-        setDeserializer(deserializer: (value: string)=>any):void;
+        setKeyPrefix(prefix: string): void;
+        setSerializer(serializer: (value: any)=>string): void;
+        setDeserializer(deserializer: (value: string)=>any): void;
     }
 }


### PR DESCRIPTION
case 2. Improvement to existing type definition.

The [readme.md](https://github.com/gsklee/ngStorage/blob/master/README.md) at the module's [repository](https://github.com/gsklee/ngStorage), clearly shows that the `.$reset()` argument is optional, so updated the definition to reflect that.

Furthermore, given that the module deals with both Session and Local storage, and given that they both share the same interface, it made sense that the interfaces names would be made agnostic to the storage medium.
