### PR TITLE
Add definitions for angular-permission

### DIFF
--- a/angular-permission/angular-permission-tests.ts
+++ b/angular-permission/angular-permission-tests.ts
@@ -1,0 +1,92 @@
+/// <reference path="./angular-permission.d.ts" />
+
+import * as permission from 'angular-permission';
+
+angular
+  .module('fooModule', ['permission', 'user'])
+  .run(function (PermissionStore: permission.PermissionStore, User: any) {
+    // Define anonymous permission
+    PermissionStore
+      .definePermission('anonymous', function (stateParams) {
+        // If the returned value is *truthy* then the user has the permission, otherwise they don't
+        if (!User) {
+          return true; // Is anonymous
+        }
+        return false;
+      });
+  });
+
+  interface BackendUserService {
+    checkSession(): angular.IPromise<any>;
+    getAccessLevel(): angular.IPromise<{accessLevel: string}>;
+    hasPermissionDefinition(permission: string) : angular.IPromise<any>;
+  }
+
+  angular.module('barModule', ['permission', 'user'])
+  .run(function (PermissionStore: permission.PermissionStore, User: BackendUserService, $q: angular.IQService) {
+    PermissionStore
+      // Define user permission calling back-end
+      .definePermission('user', function (stateParams) {
+        // This time we will return a promise
+        // If the promise *resolves* then the user has the permission, if it *rejects* (you guessed it)
+
+        // Let's assume this returns a promise that resolves or rejects if session is active
+        return User.checkSession();
+      });
+
+    PermissionStore
+      // A different example for admin
+      .definePermission('admin', function (stateParams) {
+        var deferred = $q.defer();
+
+        User.getAccessLevel()
+          .then(function (data) {
+            if (data.accessLevel === 'admin') {
+              deferred.resolve();
+            } else {
+              deferred.reject();
+            }
+          })
+          .catch(function () {
+            // Error with request
+            deferred.reject();
+          });
+
+        return deferred.promise;
+      });
+
+    let arrayOfPermissionNames = ['p1', 'p2'];
+    PermissionStore.defineManyPermissions(arrayOfPermissionNames, function (stateParams: angular.ui.IStateParamsService, permissionName: string) {
+      return User.hasPermissionDefinition(permissionName);
+    });
+
+    PermissionStore.clearStore();
+
+    PermissionStore.removePermissionDefinition('user');
+
+    let permissions: Array<permission.Permission> = PermissionStore.getStore();
+
+
+  });
+
+angular
+  .module('fooModule', ['permission', 'user'])
+  .run(function (RoleStore: permission.RoleStore, User: any) {
+    RoleStore
+      // Permission array validated role
+      // Library will internally validate if 'user' and 'editor' permissions are valid when checking if role is valid
+      .defineRole('admin', ['user', 'editor']);
+
+    RoleStore
+      // Server side validated role
+      .defineRole('accountant', [], function (stateParams) {
+        // Let's assume that we are making a request to server here and return response as promise
+        return User.hasRole('accountant');
+      });
+
+    RoleStore.clearStore();
+
+    RoleStore.removeRoleDefinition('user');
+
+    let roles: Array<permission.Role> = RoleStore.getStore();
+  });

--- a/angular-permission/angular-permission.d.ts
+++ b/angular-permission/angular-permission.d.ts
@@ -1,0 +1,164 @@
+// Type definitions for angular-permission 2.3.1
+// Project: https://github.com/Narzerus/angular-permission
+// Definitions by: Voislav Mishevski <https://github.com/vmishevski>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../angularjs/angular.d.ts" />
+/// <reference path="../angular-ui-router/angular-ui-router.d.ts" />
+
+declare module 'angular-permission' {
+  export interface PermissionStore {
+    /**
+     * Allows to define permission on application configuration
+     * @method
+     *
+     * @param permissionName {String} Name of defined permission
+     * @param validationFunction {Function} Function used to validate if permission is valid
+     */
+    definePermission(
+      name: string,
+      validationFunction: (stateParams?: angular.ui.IStateParamsService, permission?: string) => boolean | angular.IPromise<any>
+    ): void;
+
+    /**
+     * Allows to define set of permissionNames with shared validation function on application configuration
+     * @method
+     * @throws {TypeError}
+     *
+     * @param permissionNames {Array} Set of permission names
+     * @param validationFunction {Function} Function used to validate if permission is valid
+     */
+    defineManyPermissions(
+      permissions: string[],
+      validationFunction: (stateParams?: angular.ui.IStateParamsService, permission?: string) => boolean | angular.IPromise<any>
+    ): void;
+
+    clearStore(): void;
+
+    /**
+     * Deletes permission
+     * @method
+     *
+     * @param permissionName {String} Name of defined permission
+     */
+    removePermissionDefinition(permission: string): void;
+
+    /**
+     * Checks if permission exists
+     * @method
+     *
+     * @param permissionName {String} Name of defined permission
+     * @returns {Boolean}
+     */
+    hasPermissionDefinition(permissionName: string): boolean;
+
+    /**
+     * Returns all permissions
+     * @method
+     *
+     * @returns {Object} Permissions collection
+     */
+    getStore(): Permission[];
+  }
+
+  export interface RoleStore {
+    /**
+     * Allows to define role
+     * @method
+     *
+     * @param roleName {String} Name of defined role
+     * @param permissions {Array} Set of permission names
+     * @param [validationFunction] {Function} Function used to validate if permissions in role are valid
+     */
+    defineRole(
+      role: string,
+      permissions: Array<string>,
+      validationFunction: RoleValidationFunction
+    ): void;
+
+    /**
+     * Allows to define role
+     * @method
+     *
+     * @param roleName {String} Name of defined role
+     * @param permissions {Array} Set of permission names
+     */
+    defineRole(role: string, permissions: Array<string>): void;
+
+    /**
+     * Checks if role is defined in store
+     * @method
+     *
+     * @param roleName {String} Name of role
+     * @returns {Boolean}
+     */
+    hasRoleDefinition(role: string): boolean;
+
+    /**
+     * Returns role definition object by it's name
+     * @method
+     *
+     * @returns {permission.Role} Role definition object
+     */
+    getRoleDefinition(roleName: string): Role;
+
+    /**
+     * Removes all role definitions
+     * @method
+     */
+    clearStore(): void;
+
+    /**
+     * Deletes role from store
+     * @method
+     *
+     * @param roleName {String} Name of defined permission
+     */
+    removeRoleDefinition(roleName: string): void;
+
+    /**
+     * Returns all role definitions
+     * @method
+     *
+     * @returns {Object} Defined roles collection
+     */
+    getStore(): Role[];
+  }
+
+  export interface Role {
+    roleName: string;
+    permissionNames: string[];
+    validationFunction?: RoleValidationFunction;
+  }
+
+  export interface Permission {
+    permissionName: string;
+    validationFunction?: PermissionValidationFunction;
+  }
+
+  interface RoleValidationFunction {
+    (stateParams?: angular.ui.IStateParamsService, permission?: string): boolean | angular.IPromise<any>;
+  }
+
+  interface PermissionValidationFunction {
+    (stateParams?: angular.ui.IStateParamsService, permission?: string): boolean | angular.IPromise<any>;
+  }
+
+  export interface IPermissionState extends angular.ui.IState {
+    data?: any | DataWithPermissions;
+  }
+
+  export interface DataWithPermissions {
+    permissions?: {
+      only?: (() => void) | Array<string> | angular.IPromise<any>;
+      except?: (() => void) | Array<string> | angular.IPromise<any>;
+      redirectTo: string | (() => string) | (() => PermissionRedirectConfigation) | {[index: string]: PermissionRedirectConfigation}
+    };
+  }
+
+  export interface PermissionRedirectConfigation {
+    state: string;
+    params?: {};
+    options?: angular.ui.IStateOptions;
+  }
+}


### PR DESCRIPTION
Definitions for angular-permission library [https://github.com/Narzerus/angular-permission](url).
Npm module for the library: [https://www.npmjs.com/package/angular-permission](url)
Includes definitions for RoleStore, PermissionStore, Roles and Permissions objects.
Test file contains the examples from the library.
