### PR TITLE
added definitions for windows-1251

### DIFF
--- a/windows-1251/windows-1251-tests.ts
+++ b/windows-1251/windows-1251-tests.ts
@@ -1,0 +1,21 @@
+/// <reference path='windows-1251.d.ts' />
+
+import * as windows1251 from 'windows-1251';
+
+var text:string = "some text", byteString:string, decodedText:string;
+
+var version:string = windows1251.version;
+
+var labels:string[] = windows1251.labels;
+ 
+byteString = windows1251.encode(text);
+byteString = windows1251.encode(text, { mode: 'html' });
+byteString = windows1251.encode(text, { mode: 'fatal' });
+
+decodedText = windows1251.decode(byteString);
+decodedText = windows1251.decode(byteString, { mode: 'fatal' });
+decodedText = windows1251.decode(byteString, { mode: 'replacement' });
+
+
+
+

--- a/windows-1251/windows-1251-tests.ts
+++ b/windows-1251/windows-1251-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path='windows-1251.d.ts' />
 
-import windows1251 from 'windows-1251';
+import * as windows1251 from 'windows-1251';
 
 var text:string = "some text", byteString:string, decodedText:string;
 

--- a/windows-1251/windows-1251-tests.ts
+++ b/windows-1251/windows-1251-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path='windows-1251.d.ts' />
 
-import * as windows1251 from 'windows-1251';
+import windows1251 from 'windows-1251';
 
 var text:string = "some text", byteString:string, decodedText:string;
 

--- a/windows-1251/windows-1251.d.ts
+++ b/windows-1251/windows-1251.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for windows-1251 v0.1.2
+// Project: https://github.com/mathiasbynens/windows-1251
+// Definitions by: RomanGolovanov <https://github.com/RomanGolovanov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+declare namespace windows1251 {
+
+    type EncoderMode = 'fatal' | 'html';
+    type DecoderMode = 'replacement' | 'fatal';
+
+    interface windows1251 {
+        encode(input:string, options?:{ mode?: EncoderMode }):string;
+        decode(text: string, options?:{ mode?: DecoderMode }): string;
+    }
+
+}
+
+declare module 'windows-1251' {
+    var windows1251: {
+        encode(input:string, options?:{ mode?: windows1251.EncoderMode }):string;
+        decode(text: string, options?:{ mode?: windows1251.DecoderMode }): string;
+        version: string;
+        labels: string[];
+    }
+
+    export = windows1251;
+}

--- a/windows-1251/windows-1251.d.ts
+++ b/windows-1251/windows-1251.d.ts
@@ -22,5 +22,5 @@ declare module 'windows-1251' {
         labels: string[];
     }
 
-    export default windows1251;
+    export = windows1251;
 }

--- a/windows-1251/windows-1251.d.ts
+++ b/windows-1251/windows-1251.d.ts
@@ -22,5 +22,5 @@ declare module 'windows-1251' {
         labels: string[];
     }
 
-    export = windows1251;
+    export default windows1251;
 }


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
