### PR TITLE
Improve Helmet's xssFilter options

### DIFF
--- a/helmet/helmet-tests.ts
+++ b/helmet/helmet-tests.ts
@@ -17,6 +17,8 @@ function helmetTest() {
  */
 function xssFilterTest() {
     app.use(helmet.xssFilter());
+    app.use(helmet.xssFilter({}));
+    app.use(helmet.xssFilter({ setOnOldIE: false }));
     app.use(helmet.xssFilter({ setOnOldIE: true }));
 }
 

--- a/helmet/helmet.d.ts
+++ b/helmet/helmet.d.ts
@@ -24,7 +24,11 @@ declare module "helmet" {
         disableAndroid? : boolean;
         directives? : IHelmetCspDirectives
     }
-    
+
+    interface IHelmetXssFilterConfiguration {
+        setOnOldIE? : boolean;
+    }
+
     /**
      * @summary Interface for helmet class.
      * @interface
@@ -82,11 +86,11 @@ declare module "helmet" {
         publicKeyPins(options ?: Object):express.RequestHandler;
 
         /**
-         * @summary Prevent Cross-site scripting attacks.
+         * @summary Mitigate cross-site scripting attacks with the "X-XSS-Protection" header.
          * @return {RequestHandler} The Request handler.
          * @param {Object} options The options.
          */
-        xssFilter(options ?: Object):express.RequestHandler;
+        xssFilter(options ?: IHelmetXssFilterConfiguration):express.RequestHandler;
 
         /**
          * @summary Set policy around third-party content via headers


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes: https://github.com/helmetjs/helmet#xss-filter-xssfilter.

Made two improvements here:
1. `xssFilter` takes an object with a certain interface, not just any `Object`.
2. Changed the `@summary` documentation.

I maintain Helmet, so let me know if there's anything else I can help with here!
