### PR TITLE
Changed the "series" property of the HighChartsNGConfig interface to be of type HighchartsIndividualSeriesOptions[]

### DIFF
--- a/highcharts-ng/highcharts-ng-tests.ts
+++ b/highcharts-ng/highcharts-ng-tests.ts
@@ -20,9 +20,17 @@ class AppController {
             },
             plotOptions: {}
         },
-        series: [{
-            data: [10, 15, 12, 8, 7]
-        }],
+        series: [
+            {
+                data: [10, 15, 12, 8, 7]
+            },
+            {
+                data: [[0, 10], [1, 15], [2, 12], [3, 8], [4, 7]]
+            },
+            {
+                data: [{ name: "A", y: 10 }, { name: "B", y: 15 }, { name: "C", y: 12 }, { name: "D", y: 8 }, { name: "E", y: 7 }]
+            }
+        ],
         title: {
             text: 'My Awesome Chart'
         },

--- a/highcharts-ng/highcharts-ng.d.ts
+++ b/highcharts-ng/highcharts-ng.d.ts
@@ -10,7 +10,7 @@ interface HighChartsNGConfig {
     //The below properties are watched separately for changes.
 
     //Series object (optional) - a list of series using normal highcharts series options.
-    series?: number[]|[number, number][]| HighchartsDataPoint[] | {data:number[];}[];
+    series?: HighchartsIndividualSeriesOptions[];
     //Title configuration (optional)
     title?: {
         text?: string;


### PR DESCRIPTION
Hi,

I've done this because, as per the documentation of the [highcharts-ng](https://github.com/pablojim/highcharts-ng) project, the `series` object should be an array of **normal Highcharts series options**:

```
//Series object (optional) - a list of series using normal Highcharts series options.
series: [{
   data: [10, 15, 12, 8, 7]
}],
```

Using the Highcharts type definitions, "normal" Highcharts series options would be represented with the `HighchartsIndividualSeriesOptions` interface.

Currently the `HighChartsNGConfig` interface has the `series` property typed as a union of array types; it's not typed as an array of the `HighchartsIndividualSeriesOptions` interface as it should be.

Instances of the first few array types currently in the union type (that is, `number[]|[number, number][]| HighchartsDataPoint[]`) are valid for assigning to the `data` property of the `HighchartsIndividualSeriesOptions` interface, but they should not be valid for directly assigning to the `HighChartsNGConfig` interface's `series` property.

The last array type currently in the union type (that is, `{data:number[];}[]`) happens to work in practice because it is compatible with the `HighchartsIndividualSeriesOptions` interface.

I've put together a [JSFiddle](https://jsfiddle.net/tsv4t3tL/1/) using the current test file to show how code that compiles under the current type definitions doesn't actually work, and vice versa.

And here is a [JSFiddle ](https://jsfiddle.net/tsv4t3tL/2/) demonstrating that the changes I've made work.
