### PR TITLE
Add declaration for freeport

### DIFF
--- a/freeport/freeport-tests.ts
+++ b/freeport/freeport-tests.ts
@@ -1,0 +1,9 @@
+/// <reference path="freeport.d.ts" />
+
+import freeport = require('freeport');
+
+var num: number;
+
+freeport((err, made) => {
+	num = made;
+});

--- a/freeport/freeport.d.ts
+++ b/freeport/freeport.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for freeport 1.0.5
+// Project: https://github.com/daaku/nodejs-freeport
+// Definitions by: Arne Schubert <https://github.com/atd-schubert>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'freeport' {
+	function freeport(cb: (err: Error, port: number) => void): void;
+	
+	export = freeport;
+}


### PR DESCRIPTION
case 1. Add a new type definition for npm-module freeport.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
