### PR TITLE
Adding scrollTo to react-native's ScrollViewStatic

### DIFF
--- a/react-native/react-native.d.ts
+++ b/react-native/react-native.d.ts
@@ -2768,7 +2768,21 @@ declare namespace  __React {
     }
 
     interface ScrollViewStatic extends React.ComponentClass<ScrollViewProps> {
-
+        /**
+         * Scrolls to a given x, y offset, either immediately or with a smooth animation.
+         * Syntax:
+         *
+         * scrollTo(options: {x: number = 0; y: number = 0; animated: boolean = true})
+         *
+         * Note: The weird argument signature is due to the fact that, for historical reasons,
+         * the function also accepts separate arguments as as alternative to the options object.
+         * This is deprecated due to ambiguity (y before x), and SHOULD NOT BE USED.
+         */
+        scrollTo(
+            y?: number | { x?: number, y?: number, animated?: boolean },
+            x?: number,
+            animated?: boolean
+        ): void;
     }
 
 


### PR DESCRIPTION
Adding `scrollTo` API as defined at react-native's [ScrollView.js](https://github.com/facebook/react-native/blob/master/Libraries/Components/ScrollView/ScrollView.js#L367-L381)

Needs review by @bgrieder.
