### PR TITLE
SignalR Updated: Added source param in ConnectionError

### DIFF
--- a/signalr/signalr.d.ts
+++ b/signalr/signalr.d.ts
@@ -180,6 +180,7 @@ declare namespace SignalR {
     interface ConnectionError extends Error {
         context: ConnectionErrorContext;
         transport?: string;
+        source?: string;
     }
 
     interface Connection {


### PR DESCRIPTION
Source: [jquery.signalR.core.js#L181](https://github.com/SignalR/SignalR/blob/dev/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js#L181)
