### PR TITLE
Angular ui bootstrap: Update IModalSettings controller and resolve properties to not be any type

### DIFF
--- a/angular-ui-bootstrap/angular-ui-bootstrap.d.ts
+++ b/angular-ui-bootstrap/angular-ui-bootstrap.d.ts
@@ -308,7 +308,7 @@ declare namespace angular.ui.bootstrap {
         /**
          * a controller for a modal instance - it can initialize scope used by modal.
          * A controller can be injected with `$modalInstance`
-         * Can use array notation for dependency injection.
+         * If value is an array, it must be in Inline Array Annotation format for injection (strings followed by factory method)
          */
         controller?: string | Function | Array<string | Function>;
 
@@ -327,6 +327,7 @@ declare namespace angular.ui.bootstrap {
 
         /**
          * members that will be resolved and passed to the controller as locals; it is equivalent of the `resolve` property for AngularJS routes
+         * If object property value is an array, it must be in Inline Array Annotation format for injection (strings followed by factory method)
          */
         resolve?: { [ key: string ]: string | Function | Array<string | Function> };
 

--- a/angular-ui-bootstrap/angular-ui-bootstrap.d.ts
+++ b/angular-ui-bootstrap/angular-ui-bootstrap.d.ts
@@ -308,8 +308,9 @@ declare namespace angular.ui.bootstrap {
         /**
          * a controller for a modal instance - it can initialize scope used by modal.
          * A controller can be injected with `$modalInstance`
+         * Can use array notation for dependency injection.
          */
-        controller?: any;
+        controller?: string | Function | Array<string | Function>;
 
         /**
          *  an alternative to the controller-as syntax, matching the API of directive definitions.
@@ -327,7 +328,7 @@ declare namespace angular.ui.bootstrap {
         /**
          * members that will be resolved and passed to the controller as locals; it is equivalent of the `resolve` property for AngularJS routes
          */
-        resolve?: any;
+        resolve?: { [ key: string ]: string | Function | Array<string | Function> };
 
         /**
          * Set to false to disable animations on new modal/backdrop. Does not toggle animations for modals/backdrops that are already displayed.

--- a/angular-ui-bootstrap/angular-ui-bootstrap.d.ts
+++ b/angular-ui-bootstrap/angular-ui-bootstrap.d.ts
@@ -327,9 +327,9 @@ declare namespace angular.ui.bootstrap {
 
         /**
          * members that will be resolved and passed to the controller as locals; it is equivalent of the `resolve` property for AngularJS routes
-         * If object property value is an array, it must be in Inline Array Annotation format for injection (strings followed by factory method)
+         * If property value is an array, it must be in Inline Array Annotation format for injection (strings followed by factory method)
          */
-        resolve?: { [ key: string ]: string | Function | Array<string | Function> };
+        resolve?: { [ key: string ]: string | Function | Array<string | Function> | Object };
 
         /**
          * Set to false to disable animations on new modal/backdrop. Does not toggle animations for modals/backdrops that are already displayed.


### PR DESCRIPTION
Improvement to existing type definition

Docs
- controller doc: https://angular-ui.github.io/bootstrap/#/modal
- resolve doc: https://github.com/angular-ui/ui-router/wiki
- invoke doc: https://docs.angularjs.org/api/auto/service/$injector
  -- angular ui bootstrap modal resolve uses the $injector to invoke function or array

Currently, in IModalSettings, controller and resolve have the type of any. Updated types to match docs.
