### PR TITLE
updated faker lorem to return words as string instead of array

### DIFF
--- a/faker/faker-tests.ts
+++ b/faker/faker-tests.ts
@@ -123,8 +123,8 @@ resultStr = faker.internet.mac();
 resultStr = faker.internet.password();
 resultStr = faker.internet.password(0, false, '#', 'foo');
 
-resultStrArr = faker.lorem.words();
-resultStrArr = faker.lorem.words(0);
+resultStr = faker.lorem.words();
+resultStr = faker.lorem.words(0);
 resultStr = faker.lorem.sentence();
 resultStr = faker.lorem.sentence(0, 0);
 resultStr = faker.lorem.sentences();

--- a/faker/faker.d.ts
+++ b/faker/faker.d.ts
@@ -135,7 +135,7 @@ declare namespace Faker {
 		};
 
 		lorem: {
-			words(num?: number): string[];
+			words(num?: number): string;
 			sentence(wordCount?: number, range?: number): string;
 			sentences(sentenceCount?: number): string;
 			paragraph(sentenceCount?: number): string;


### PR DESCRIPTION
Improvement to existing type definition.
- https://github.com/Marak/faker.js/commit/5faff98b55a6b3e51862dd3c79c5c0336bcd1953#diff-441fe51f8f345cc4f1232a93cc4cd706
