### PR TITLE
Fix ComponentDecorator interface for StatelessComponents that pass args to connect().

### DIFF
--- a/react-redux/react-redux-tests.tsx
+++ b/react-redux/react-redux-tests.tsx
@@ -285,6 +285,37 @@ let ConnectedHelloMessage = connect()(HelloMessage);
 ReactDOM.render(<HelloMessage name="Sebastian" />, document.getElementById('content'));
 ReactDOM.render(<ConnectedHelloMessage name="Sebastian" />, document.getElementById('content'));
 
+// stateless functions that uses mapStateToProps and mapDispatchToProps
+namespace TestStatelessFunctionWithMapArguments {
+    interface GreetingProps {
+        name: string;
+        onClick: () => void;
+    }
+
+    function Greeting(props: GreetingProps) {
+        return <div>Hello {props.name}</div>;
+    }
+
+    const mapStateToProps = (state: any, ownProps: GreetingProps) => {
+        return {
+            name: 'Connected! ' + ownProps.name
+        };
+    };
+
+    const mapDispatchToProps = (dispatch: Dispatch, ownProps: GreetingProps) => {
+        return {
+            onClick: () => {
+                dispatch({ type: 'GREETING', name: ownProps.name });
+            }
+        };
+    };
+
+    const ConnectedGreeting = connect(
+        mapStateToProps,
+        mapDispatchToProps
+    )(Greeting);
+}
+
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/8787
 namespace TestTOwnPropsInference {
     interface OwnProps {

--- a/react-redux/react-redux.d.ts
+++ b/react-redux/react-redux.d.ts
@@ -11,7 +11,7 @@ declare module "react-redux" {
   import { Store, Dispatch, ActionCreator } from 'redux';
 
   interface ComponentDecorator<TOriginalProps, TOwnProps> {
-    (component: ComponentClass<TOriginalProps>): ComponentClass<TOwnProps>;
+    (component: ComponentClass<TOriginalProps>|StatelessComponent<TOriginalProps>): ComponentClass<TOwnProps>;
   }
 
   /**


### PR DESCRIPTION
Without any changes to react-redux.d.ts, the TestStatelessFunctionWithMapArguments additions to the tests will generate the following compiler errors:

react-redux/react-redux-tests.tsx(316,7): error TS2345: Argument of type '(props: GreetingProps) => Element' is not assignable to parameter of type 'ComponentClass<{ name: string; } & { onClick: () => void; }>'.
  Type '(props: GreetingProps) => Element' provides no match for the signature 'new (props?: { name: string; } & { onClick: () => void; }, context?: any): Component<{ name: string; } & { onClick: () => void; }, {}>'

By adding StatelessComponent<TOriginalProps> as a union type to the ComponentDecorator method signature, it removes the compiler errors and allows stateless functions to use mapStateToProps and mapDispatchToProps functions as arguments to connect().
