### PR TITLE
Return typed definition from toJSON method

### DIFF
--- a/angularjs/angular-resource-tests.ts
+++ b/angularjs/angular-resource-tests.ts
@@ -98,9 +98,7 @@ resource = resourceClass.save({ key: 'value' }, { key: 'value' }, function () { 
 
 var promise : angular.IPromise<IMyResource>;
 var arrayPromise : angular.IPromise<IMyResource[]>;
-var json: {
-  [index: string]: any;
-};
+var json: IMyResource;
 
 promise = resource.$delete();
 promise = resource.$delete({ key: 'value' });

--- a/angularjs/angular-resource.d.ts
+++ b/angularjs/angular-resource.d.ts
@@ -153,9 +153,7 @@ declare namespace angular.resource {
         /** the promise of the original server interaction that created this instance. **/
         $promise : angular.IPromise<T>;
         $resolved : boolean;
-        toJSON: () => {
-          [index: string]: any;
-        }
+        toJSON(): T;
     }
 
     /**


### PR DESCRIPTION
This fixes the case when calling `toJSON()` on a resource would not provide a typed definition of the resource.
