### PR TITLE
User defined type guards in Knockout

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -417,12 +417,12 @@ interface KnockoutStatic {
     observableArray: KnockoutObservableArrayStatic;
 
     contextFor(node: any): any;
-    isSubscribable(instance: any): boolean;
+    isSubscribable(instance: any): instance is KnockoutSubscribable<any>;
     toJSON(viewModel: any, replacer?: Function, space?: any): string;
     toJS(viewModel: any): any;
-    isObservable(instance: any): boolean;
-    isWriteableObservable(instance: any): boolean;
-    isComputed(instance: any): boolean;
+    isObservable(instance: any): instance is KnockoutObservable<any>;
+    isWriteableObservable(instance: any): instance is KnockoutObservable<any>;
+    isComputed(instance: any): instance is KnockoutComputed<any>;
     dataFor(node: any): any;
     removeNode(node: Element): void;
     cleanNode(node: Element): Element;


### PR DESCRIPTION
[User defined type guards](http://www.typescriptlang.org/docs/handbook/advanced-types.html) (introduced in TS 1.6) allow union types to include Knockout interfaces while allowing for strong typing, such as:

``` typescript
incrementAge(age: KnockoutObservable<number> | number) {
    if (ko.isObservable(age)) {
        age(age() + 1);
        return age();
    else {
        return age + 1;
    }
}
```

Type guards still return `boolean`, so existing usages of these functions won't be affected.
