### PR TITLE
Add overloading to `get` method

### DIFF
--- a/cheerio/cheerio.d.ts
+++ b/cheerio/cheerio.d.ts
@@ -106,6 +106,7 @@ interface Cheerio {
 
     eq(index: number): Cheerio;
 
+    get(): string[];
     get(): CheerioElement[];
     get(index: number): CheerioElement;
 


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

e.g.

``` ts
$("a[href]").map((index, element) => $(element).attr("href")).get();
```

it returns an array of strings
