### PR TITLE
Firebase: Generic Github, Twitter and Facebook authentication providers

### DIFF
--- a/firebase/firebase.d.ts
+++ b/firebase/firebase.d.ts
@@ -334,9 +334,46 @@ interface FirebaseAuthData {
 	expires: number;
 	auth: Object;
 	google?: FirebaseAuthDataGoogle;
-	github?: any;
-	twitter?: any;
-	facebook?: any;
+	twitter?: FirebaseAuthDataTwitter;
+	github?: FirebaseAuthDataGithub;
+	facebook?: FirebaseAuthDataFacebook;
+	password?: FirebaseAuthDataPassword;
+	anonymous?: any;
+}
+
+interface FirebaseAuthDataPassword{
+	email: string;
+	isTemporaryPassword: boolean;
+	profileImageURL: string;
+}
+
+interface FirebaseAuthDataTwitter{
+	id: string;
+	accessToken: string;
+	accessTokenSecret: string;
+	displayName: string;
+	username: string;
+	profileImageURL: string;
+	cachedUserProfile: any;
+}
+
+interface FirebaseAuthDataGithub{
+	id: string;
+	accessToken: string;
+	displayName: string;
+	email?: string;
+	username: string;
+	profileImageURL: string;
+	cachedUserProfile: any;
+}
+
+interface FirebaseAuthDataFacebook{
+	id: string;
+	accessToken: string;
+	displayName: string;
+	email?: string;
+	profileImageURL: string;
+	cachedUserProfile: any;
 }
 
 interface FirebaseAuthDataGoogle {

--- a/firebase/firebase.d.ts
+++ b/firebase/firebase.d.ts
@@ -334,6 +334,9 @@ interface FirebaseAuthData {
 	expires: number;
 	auth: Object;
 	google?: FirebaseAuthDataGoogle;
+	github?: any;
+	twitter?: any;
+	facebook?: any;
 }
 
 interface FirebaseAuthDataGoogle {


### PR DESCRIPTION
Added Github, Twitter and Facebook authentication providers to Firebase.

I chose to use "any" because specially the "cachedUserProfile" property may vary often as the documentation explains: https://www.firebase.com/docs/web/guide/login/github.html

I don't touched the "google?" provider because was already implemented and could mess existing projects.
