### PR TITLE
Methods are missing on kendo.Observable

### DIFF
--- a/kendo-ui/kendo-ui.d.ts
+++ b/kendo-ui/kendo-ui.d.ts
@@ -262,8 +262,10 @@ declare namespace kendo {
         static fn: Observable;
         static extend(prototype: Object): Observable;
 
+        init(...args: any[]): void
         bind(eventName: string, handler: Function): Observable;
         one(eventName: string, handler: Function): Observable;
+        first(eventName: string, handler: Function): Observable;
         trigger(eventName: string, e?: any): boolean;
         unbind(eventName: string, handler?: any): Observable;
     }


### PR DESCRIPTION
According to the source code found at [https://github.com/telerik/kendo-ui-core/blob/master/src/kendo.core.js](https://github.com/telerik/kendo-ui-core/blob/master/src/kendo.core.js) the `Observable` class has two methods which are missing from the definition file: [init](https://github.com/telerik/kendo-ui-core/blob/master/src/kendo.core.js#L87) and [first](https://github.com/telerik/kendo-ui-core/blob/master/src/kendo.core.js#L134).

Even though the [API documentation](http://docs.telerik.com/kendo-ui/api/javascript/observable) for `Observable` does not mention them, these methods still exist and if I attempt to extend the `Observable` class and call the `init` function of `Observable` I will get a type error.
