### PR TITLE
mark Response.error() and Response.redirect() as static

### DIFF
--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -59,8 +59,8 @@ declare class Body {
 }
 declare class Response extends Body {
 	constructor(body?: BodyInit, init?: ResponseInit);
-	error(): Response;
-	redirect(url: string, status: number): Response;
+	static error(): Response;
+	static redirect(url: string, status: number): Response;
 	type: ResponseType;
 	url: string;
 	status: number;


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Response

Fixes #7777
