### PR TITLE
Created definitions for promise-pg

### DIFF
--- a/promise-pg/promise-pg-tests.ts
+++ b/promise-pg/promise-pg-tests.ts
@@ -1,0 +1,37 @@
+/// <reference path="promise-pg.d.ts" />
+
+import * as pg from 'promise-pg';
+
+var conString = "postgres://username:password@localhost/database";
+
+// https://github.com/brianc/node-pg-types
+pg.raw.types.setTypeParser(20, (val) => Number(val));
+
+// Client pooling
+pg.connect(conString)
+  .then(function (client) {
+    client.query("SELECT $1::int AS number", ["1"]).promise
+      .then(function (result) {
+        // done
+      }, function (err) {
+        console.error("Error running query", err);
+      });
+  }, function (err) {
+    return console.error("Error fetching client from pool", err);
+  });
+
+// Simple
+var client = new pg.Client(conString);
+client.connect()
+  .then(function () {
+    client.query("SELECT NOW() AS 'theTime'").promise
+      .then(function (result) {
+        console.log(result.rows[0]["theTime"]);
+        client.end();
+        return null;
+      }, function (err) {
+        return console.error("Error running query", err);
+      });
+  }, function (err) {
+    return console.error("Could not connect to postgres", err);
+  });

--- a/promise-pg/promise-pg-tests.ts
+++ b/promise-pg/promise-pg-tests.ts
@@ -1,4 +1,5 @@
 /// <reference path="promise-pg.d.ts" />
+/// <reference path="../q/Q.d.ts" />
 
 import * as pg from 'promise-pg';
 
@@ -35,4 +36,60 @@ client.connect()
       });
   }, function (err) {
     return console.error("Could not connect to postgres", err);
+  }).done();
+
+// Using buffer query option
+pg.connect(conString)
+  .spread(function (client: pg.Client, done: () => void) {
+    client.query({
+      text: "SELECT * FROM users",
+      buffer: true
+    }).promise.then(
+      function (result) { console.log(result.rows.length + " rows returned"); },
+      function (err) { console.error("Error running query", err); throw err; },
+      function (user: any) {} // called for each returned row
+    ).finally(done);
+  }).done();
+
+// Transactions
+pg.connect(conString)
+  .spread(function (client: pg.Client, done: () => void) {
+    var INSERT = "INSERT INTO users(name, t_birth, country) VALUES ($1, $2, $3)";
+
+    console.log("Transaction I:");
+    var trans = client.transaction(function () {
+      return Q.all([{
+          text: INSERT,
+          values: ["Jake1", "now()", "Oo"]
+        }, {
+          text: INSERT,
+          values: ["Cake2", null, "Küche"]
+        }, {
+          text: INSERT,
+          values: ["Mike3", "now()", null]
+        }].map(function (q) { return client.query(q).promise; }));
+    }).then(function() {
+      console.log("Good - Committed Transaction I.");
+    }, function (err) {
+      console.log("Bad  - Rolled back Transaction I.", err);
+    });
+
+    trans.finally(function () {
+      client.transaction(function () {
+        return Q.all([{
+          text: INSERT,
+          values: ["Jake", "now()", "Oo"]
+        }, {
+          text: INSERT, // Bad, name is NOT NULL
+          values: [null, null, "Küche"]
+        }, {
+          text: INSERT,
+          values: ["Mike", "now()", null]
+        }].map(function (q) { return client.query(q).promise; }));
+      }).then(function () {
+        console.log("Bad  - Committed Transaction II.");
+      }, function (err) {
+        console.log("Good - Rolled back Transaction II.", err.message);
+      }).finally(done).done();
+    });
   }).done();

--- a/promise-pg/promise-pg-tests.ts
+++ b/promise-pg/promise-pg-tests.ts
@@ -9,21 +9,22 @@ pg.raw.types.setTypeParser(20, (val) => Number(val));
 
 // Client pooling
 pg.connect(conString)
-  .then(function (client) {
+  .spread(function (client: pg.Client, done: () => void) {
     client.query("SELECT $1::int AS number", ["1"]).promise
       .then(function (result) {
         // done
       }, function (err) {
         console.error("Error running query", err);
-      });
+      })
+      .finally(done);
   }, function (err) {
     return console.error("Error fetching client from pool", err);
-  });
+  }).done();
 
 // Simple
 var client = new pg.Client(conString);
 client.connect()
-  .then(function () {
+  .spread(function (client: pg.Client, done: () => void) {
     client.query("SELECT NOW() AS 'theTime'").promise
       .then(function (result) {
         console.log(result.rows[0]["theTime"]);
@@ -34,4 +35,4 @@ client.connect()
       });
   }, function (err) {
     return console.error("Could not connect to postgres", err);
-  });
+  }).done();

--- a/promise-pg/promise-pg.d.ts
+++ b/promise-pg/promise-pg.d.ts
@@ -21,7 +21,7 @@ declare module "promise-pg" {
   export function end(): Q.Promise<void>;
 
   export interface QueryConfig extends pg.QueryConfig {
-    buffer: boolean;
+    buffer?: boolean;
   }
 
   export class Client {

--- a/promise-pg/promise-pg.d.ts
+++ b/promise-pg/promise-pg.d.ts
@@ -1,0 +1,61 @@
+// Type definitions for promise-pg
+// Project: https://bitbucket.org/lplabs/promise-pg
+// Definitions by: Chris Charabaruk <http://github.com/coldacid>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+/// <reference path="../q/Q.d.ts" />
+/// <reference path="../pg/pg.d.ts" />
+
+declare module "promise-pg" {
+  import * as stream from 'stream';
+  import * as pg from 'pg';
+
+  export {pg as raw};
+
+  export interface ClientConfig extends pg.ClientConfig {}
+
+  export function connect(connection: string): Q.Promise<Client>;
+  export function connect(connection: pg.ClientConfig): Q.Promise<Client>;
+
+  export function end(): Q.Promise<void>;
+
+  export interface QueryConfig extends pg.QueryConfig {
+    buffer: boolean;
+  }
+
+  export class Client {
+    constructor(connection: string);
+    constructor(config: ClientConfig);
+
+    raw: pg.Client;
+
+    connect(): Q.Promise<void>;
+    end(): Q.Promise<void>;
+
+    query(queryText: string): Query;
+    query(config: QueryConfig): Query;
+    query(queryText: string, values: any[]): Query;
+
+    copyFrom(queryText: string): stream.Writable;
+    copyTo(queryText: string): stream.Readable;
+
+    pauseDrain(): void;
+    resumeDrain(): void;
+
+    public on(event: "drain", listener: () => void): Client;
+    public on(event: "error", listener: (err: Error) => void): Client;
+    public on(event: "notification", listener: (message: any) => void): Client;
+    public on(event: "notice", listener: (message: any) => void): Client;
+    public on(event: string, listener: Function): Client;
+
+    transaction(task: () => Q.Promise<any>): Q.Promise<any>;
+  }
+
+  export interface QueryResult extends pg.QueryResult {}
+  export interface ResultBuilder extends pg.ResultBuilder {}
+
+  export class Query extends pg.Query {
+    promise: Q.Promise<QueryResult>;
+  }
+}


### PR DESCRIPTION
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Dependencies:
- node
- Q
- pg

Tests script is cribbed from pg typings and modified for promise-pg.

'promise-pg'.Client does not inherit from 'pg'.Client because the
functions redefined to return promises completely replace the originals
from 'pg'.
