### PR TITLE
Fixing a few API set annotations in Office-js.d.ts

### DIFF
--- a/office-js/office-js.d.ts
+++ b/office-js/office-js.d.ts
@@ -2142,7 +2142,7 @@ declare namespace Excel {
          *
          * @param across Set true to merge cells in each row of the specified range as separate merged cells. The default value is false.
          *
-         * [Api set: ExcelApi 1.1]
+         * [Api set: ExcelApi 1.2]
          */
         merge(across?: boolean): void;
         /**
@@ -2156,7 +2156,7 @@ declare namespace Excel {
          *
          * Unmerge the range cells into separate cells.
          *
-         * [Api set: ExcelApi 1.1]
+         * [Api set: ExcelApi 1.2]
          */
         unmerge(): void;
         /**
@@ -2473,14 +2473,14 @@ declare namespace Excel {
          *
          * Clears all the filters currently applied on the table.
          *
-         * [Api set: ExcelApi 1.1]
+         * [Api set: ExcelApi 1.2]
          */
         clearFilters(): void;
         /**
          *
          * Converts the table into a normal range of cells. All data is preserved.
          *
-         * [Api set: ExcelApi 1.1]
+         * [Api set: ExcelApi 1.2]
          */
         convertToRange(): Excel.Range;
         /**
@@ -2522,7 +2522,7 @@ declare namespace Excel {
          *
          * Reapplies all the filters currently on the table.
          *
-         * [Api set: ExcelApi 1.1]
+         * [Api set: ExcelApi 1.2]
          */
         reapplyFilters(): void;
         /**
@@ -2835,14 +2835,14 @@ declare namespace Excel {
          *
          * Changes the width of the columns of the current range to achieve the best fit, based on the current data in the columns.
          *
-         * [Api set: ExcelApi 1.1]
+         * [Api set: ExcelApi 1.2]
          */
         autofitColumns(): void;
         /**
          *
          * Changes the height of the rows of the current range to achieve the best fit, based on the current data in the columns.
          *
-         * [Api set: ExcelApi 1.1]
+         * [Api set: ExcelApi 1.2]
          */
         autofitRows(): void;
         /**
@@ -3221,7 +3221,7 @@ declare namespace Excel {
          * @param width (Optional) The desired width of the resulting image.
          * @param fittingMode (Optional) The method used to scale the chart to the specified to the specified dimensions (if both height and width are set)."
          *
-         * [Api set: ExcelApi 1.1]
+         * [Api set: ExcelApi 1.2]
          */
         getImage(width?: number, height?: number, fittingMode?: string): OfficeExtension.ClientResult<string>;
         /**


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Fixed api set annotations on half-a-dozen methods that were erroneously labeled as 1.1, whereas they really belong the the 1.2 set.
