### PR TITLE
(backbone) Correct model defaults type

### DIFF
--- a/backbone/backbone-global.d.ts
+++ b/backbone/backbone-global.d.ts
@@ -115,7 +115,7 @@ declare namespace Backbone {
         * Default attributes for the model. It can be an object hash or a method returning an object hash.
         * That works only if you set it in the constructor or the initialize method.
         **/
-        defaults: () => ObjectHash | ObjectHash;
+        defaults: (() => ObjectHash) | ObjectHash;
         id: any;
         idAttribute: string;
         validationError: any;

--- a/backbone/backbone-global.d.ts
+++ b/backbone/backbone-global.d.ts
@@ -113,10 +113,9 @@ declare namespace Backbone {
 
         /**
         * Default attributes for the model. It can be an object hash or a method returning an object hash.
-        * For assigning an object hash, do it like this: this.defaults = <any>{ attribute: value, ... };
         * That works only if you set it in the constructor or the initialize method.
         **/
-        defaults(): ObjectHash;
+        defaults: () => ObjectHash | ObjectHash;
         id: any;
         idAttribute: string;
         validationError: any;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
defaults can be an object or a function http://backbonejs.org/#Model-defaults
