### PR TITLE
Added Filesize definitions

### DIFF
--- a/filesize/filesize-tests.ts
+++ b/filesize/filesize-tests.ts
@@ -1,3 +1,5 @@
+/// <reference path="filesize.d.ts" />
+
 import filesize = require("filesize");
 
 filesize(500);                        // "500 B" 

--- a/filesize/filesize-tests.ts
+++ b/filesize/filesize-tests.ts
@@ -1,0 +1,13 @@
+import filesize = require("filesize");
+
+filesize(500);                        // "500 B" 
+filesize(500, { bits: true });          // "4 Kb" 
+filesize(265318, { base: 10 });         // "265.32 kB" 
+filesize(265318);                     // "259.1 KB" 
+filesize(265318, { round: 0 });         // "259 KB" 
+filesize(265318, { output: "array" });  // [259.1, "KB"] 
+filesize(265318, { output: "object" }); // {value: 259.1, suffix: "KB", symbol: "KB"} 
+filesize(1, { symbols: { B: "Б" } });    // "1 Б" 
+filesize(1024);                       // "1 KB" 
+filesize(1024, { exponent: 0 });        // "1024 B" 
+filesize(1024, { output: "exponent" }); // 1 

--- a/filesize/filesize.d.ts
+++ b/filesize/filesize.d.ts
@@ -52,7 +52,7 @@ declare namespace Filesize {
         * Dictionary of SI/JEDEC symbols to replace for localization, defaults to english if no match is found
         * @deprecated: use 'symbols'
         */
-        suffixes?: { [name: string]: string };
+        suffixes?: SiJedec;
         /**
         * Dictionary of SI/JEDEC symbols to replace for localization, defaults to english if no match is found
         */

--- a/filesize/filesize.d.ts
+++ b/filesize/filesize.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for filesize 3.2.1
+// Project: https://github.com/avoidwork/filesize.js
+// Definitions by: Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace Filesize {
+
+    export interface Options {
+        bits?: boolean;
+        base?: number;
+        round?: number;
+        output?: string;
+        suffixes?: { [name: string]: string };
+        exponent?: number;
+    }
+
+    export interface IFileSize {
+        (bytes: number): string;
+        (bytes: number, options: Options): string;
+    }
+}
+
+
+declare module "filesize" {
+    let fileSize: Filesize.IFileSize;
+    export = fileSize;
+}

--- a/filesize/filesize.d.ts
+++ b/filesize/filesize.d.ts
@@ -5,16 +5,73 @@
 
 declare namespace Filesize {
 
-    export interface Options {
-        bits?: boolean;
-        base?: number;
-        round?: number;
-        output?: string;
-        suffixes?: { [name: string]: string };
-        exponent?: number;
+    export interface SiJedecBits {
+        b?: string;
+        Kb?: string;
+        Mb?: string;
+        Gb?: string;
+        Tb?: string;
+        Pb?: string;
+        Eb?: string;
+        Zb?: string;
+        Yb?: string;
     }
 
-    export interface IFileSize {
+    export interface SiJedecBytes {
+        B?: string;
+        KB?: string;
+        MB?: string;
+        GB?: string;
+        TB?: string;
+        PB?: string;
+        EB?: string;
+        ZB?: string;
+        YB?: string;
+    }
+
+    type SiJedec = SiJedecBits & SiJedecBytes & { [name: string]: string };
+
+    export interface Options {
+        /**
+        * Enables bit sizes, default is false
+        */
+        bits?: boolean;
+        /**
+        * Number base, default is 2
+        */
+        base?: number;
+        /**
+        * Decimal place, default is 2
+        */
+        round?: number;
+        /**
+        * Output of function (array, exponent, object, or string), default is string
+        */
+        output?: string;
+        /**
+        * Dictionary of SI/JEDEC symbols to replace for localization, defaults to english if no match is found
+        * @deprecated: use 'symbols'
+        */
+        suffixes?: { [name: string]: string };
+        /**
+        * Dictionary of SI/JEDEC symbols to replace for localization, defaults to english if no match is found
+        */
+        symbols?: SiJedec;
+        /**
+        * Specifies the SI suffix via exponent, e.g. 2 is MB for bytes, default is -1
+        */
+        exponent?: number;
+        /**
+        *  Enables unix style human readable output, e.g ls -lh, default is false
+        */
+        unix?: boolean;
+        /**
+        * Character between the result and suffix, default is " "
+        */
+        spacer?: string;
+    }
+
+    export interface IFilesize {
         (bytes: number): string;
         (bytes: number, options: Options): string;
     }
@@ -22,6 +79,6 @@ declare namespace Filesize {
 
 
 declare module "filesize" {
-    let fileSize: Filesize.IFileSize;
+    let fileSize: Filesize.IFilesize;
     export = fileSize;
 }


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Docs: https://www.npmjs.com/package/filesize
