### PR TITLE
Allow import statement from Typescript

### DIFF
--- a/chartist/chartist.d.ts
+++ b/chartist/chartist.d.ts
@@ -557,3 +557,7 @@ declare namespace Chartist {
 }
 
 declare var Chartist: Chartist.ChartistStatic;
+
+declare module 'chartist' {
+  export = Chartist;
+}


### PR DESCRIPTION
I've added the `declare module` statement so that you can use `import * as Chartist from 'chartist'` in Typescript.
