### PR TITLE
Add option that can be set for CircleMarker

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -3383,6 +3383,11 @@ declare namespace L {
           */
         className?: string;
 
+	/**
+	 * Sets the radius of a circle marker. 
+	 */
+	radius?: number;
+
     }
 }
 


### PR DESCRIPTION
The documentation at http://leafletjs.com/reference.html#circlemarker allows the use of `radius` property in the `PathOptions`.
