### PR TITLE
Node.js Buffer should be useable as a Uint8Array and is missing a constructor

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -181,6 +181,12 @@ function bufferTests() {
         let sb = new ImportedSlowBuffer(43);
         b.writeUInt8(0, 6);
     }
+
+    // Buffer has Uint8Array's buffer field (an ArrayBuffer).
+    {
+      let buffer = new Buffer('123');
+      let octets = new Uint8Array(buffer.buffer);
+    }
 }
 
 

--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -138,6 +138,7 @@ function bufferTests() {
     var base64Buffer = new Buffer('','base64');
     var octets: Uint8Array = null;
     var octetBuffer = new Buffer(octets);
+    var sharedBuffer = new Buffer(octets.buffer);
     var copiedBuffer = new Buffer(utf8Buffer);
     console.log(Buffer.isBuffer(octetBuffer));
     console.log(Buffer.isEncoding('utf8'));

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -435,7 +435,12 @@ interface NodeBuffer extends Uint8Array {
     writeDoubleLE(value: number, offset: number, noAssert?: boolean): number;
     writeDoubleBE(value: number, offset: number, noAssert?: boolean): number;
     fill(value: any, offset?: number, end?: number): Buffer;
+    // TODO: encoding param
     indexOf(value: string | number | Buffer, byteOffset?: number): number;
+    // TODO: entries
+    // TODO: includes
+    // TODO: keys
+    // TODO: values
 }
 
 /************************************************

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -109,6 +109,14 @@ declare var Buffer: {
      */
     new (array: Uint8Array): Buffer;
     /**
+     * Produces a Buffer backed by the same allocated memory as
+     * the given {ArrayBuffer}.
+     * 
+     *
+     * @param arrayBuffer The ArrayBuffer with which to share memory.
+     */
+    new (arrayBuffer: ArrayBuffer): Buffer;
+    /**
      * Allocates a new buffer containing the given {array} of octets.
      *
      * @param array The octets to store.

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -382,12 +382,10 @@ declare namespace NodeJS {
 /**
  * @deprecated
  */
-interface NodeBuffer {
-    [index: number]: number;
+interface NodeBuffer extends Uint8Array {
     write(string: string, offset?: number, length?: number, encoding?: string): number;
     toString(encoding?: string, start?: number, end?: number): string;
     toJSON(): any;
-    length: number;
     equals(otherBuffer: Buffer): boolean;
     compare(otherBuffer: Buffer): number;
     copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;


### PR DESCRIPTION
This is an improvement to an existing type definition.

I work on a browserified project that uses some Node.js libraries - so converting between `ArrayBuffer` and `Buffer` crops up again and again. I was looking into the performance of this - specifically, eliminating byte copying - when I realised two things are missing from the current definition:
1. `Buffer` is also a `Uint8Array`: https://nodejs.org/dist/latest-v4.x/docs/api/buffer.html#buffer_buffers_and_typedarray
2. `Buffer` has a constructor which accepts an `ArrayBuffer` and which causes the resulting `Buffer` to share the same memory as the `ArrayBuffer`: https://nodejs.org/dist/latest-v4.x/docs/api/buffer.html#buffer_new_buffer_arraybuffer

My solution is to make `NodeBuffer` extend `Uint8Array` and add that missing constructor to `Buffer` - also, remove a couple of methods from `Buffer` which are already defined in `Uint8Array` and a few which are missing.
