### PR TITLE
Add type definitions for 'twitter-text' module

### DIFF
--- a/twitter-text/twitter-text-tests.ts
+++ b/twitter-text/twitter-text-tests.ts
@@ -1,0 +1,44 @@
+import * as twitter from "twitter-text";
+
+const text: string = twitter.htmlEscape("@you #hello < @world > https://github.com");
+const entities = twitter.extractEntitiesWithIndices(text);
+
+for let e of entities {
+    e = modifyIndicesFromUnicodeToUTF16(e);
+    if ("hashtag" in e) {
+        console.log("hashtag: ", e.hashtag);
+    } else if ("url" in e) {
+        console.log("url: ", e.url);
+    } else if ("screenName" in e) {
+        console.log("screenName: ", e.screenName);
+    } else if ("cashtag" in e) {
+        console.log("cashtag: ", e.cashtag);
+    } else {
+        console.error("Unreachable");
+    }
+    console.log(`indices: (${e.indices[0]}, ${e.indices[1]})`);
+}
+
+let result: string;
+result = twitter.autoLink(text);
+result = twitter.autoLinkUsernamesOrLists(text);
+result = twitter.autoLinkHashtags(text);
+result = twitter.autoLinkCashtags(text);
+result = twitter.autoLinkUrlsCustom(text);
+
+const len: number = twitter.getTweetLength(text);
+
+const linked: string = twitter.autoLink("link @user, and expand url... http://t.co/0JG5Mcq", {
+    urlEntities: [
+        {
+            url: "http://t.co/0JG5Mcq",
+            display_url: "blog.twitter.com/2011/05/twitte…",
+            expanded_url: "http://blog.twitter.com/2011/05/twitter-for-mac-update.html",
+            indices: [
+                30,
+                48
+            ]
+        }
+    ]});
+
+const usernames: string[] = twttr.txt.extractMentions("Mentioning @twitter and @jack");

--- a/twitter-text/twitter-text-tests.ts
+++ b/twitter-text/twitter-text-tests.ts
@@ -3,15 +3,31 @@ import * as twitter from "twitter-text";
 const text: string = twitter.htmlEscape("@you #hello < @world > https://github.com");
 const entities = twitter.extractEntitiesWithIndices(text);
 
-for let e of entities {
-    e = modifyIndicesFromUnicodeToUTF16(e);
-    if ("hashtag" in e) {
+function isHashtagEntity(e: twitter.EntityWithIndices): e is twitter.HashtagWithIndices {
+    return "hashtag" in e;
+}
+
+function isUrlEntity(e: twitter.EntityWithIndices): e is twitter.UrlWithIndices {
+    return "url" in e;
+}
+
+function isMentionEntity(e: twitter.EntityWithIndices): e is twitter.MentionWithIndices {
+    return "screenName" in e;
+}
+
+function isCashtagEntity(e: twitter.EntityWithIndices): e is twitter.CashtagWithIndices {
+    return "cashtag" in e;
+}
+
+for (let e of entities) {
+    e = twitter.modifyIndicesFromUnicodeToUTF16(e);
+    if (isHashtagEntity(e)) {
         console.log("hashtag: ", e.hashtag);
-    } else if ("url" in e) {
+    } else if (isUrlEntity(e)) {
         console.log("url: ", e.url);
-    } else if ("screenName" in e) {
+    } else if (isMentionEntity(e)) {
         console.log("screenName: ", e.screenName);
-    } else if ("cashtag" in e) {
+    } else if (isCashtagEntity(e)) {
         console.log("cashtag: ", e.cashtag);
     } else {
         console.error("Unreachable");
@@ -41,4 +57,4 @@ const linked: string = twitter.autoLink("link @user, and expand url... http://t.
         }
     ]});
 
-const usernames: string[] = twttr.txt.extractMentions("Mentioning @twitter and @jack");
+const usernames: string[] = twitter.extractMentions("Mentioning @twitter and @jack");

--- a/twitter-text/twitter-text-tests.ts
+++ b/twitter-text/twitter-text-tests.ts
@@ -1,3 +1,5 @@
+/// <reference path="./twitter-text.d.ts" />
+
 import * as twitter from "twitter-text";
 
 const text: string = twitter.htmlEscape("@you #hello < @world > https://github.com");

--- a/twitter-text/twitter-text.d.ts
+++ b/twitter-text/twitter-text.d.ts
@@ -1,0 +1,103 @@
+// Type definitions for twitter-text v1.13.4
+// Project: https://github.com/twitter/twitter-text
+// Definitions by: rhysd <https://rhysd.github.io>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "twitter-text" {
+	export interface HashtagWithIndices {
+		hashtag: string;
+		indices: [number, number];
+	}
+	export interface UrlWithIndices {
+		url: string;
+		indices: [number, number];
+	}
+	export interface MentionWithIndices {
+		screenName: string;
+		indices: [number, number];
+	}
+	export interface MentionOrListWithIndices {
+		screenName: string;
+		listSlug: string;
+		indices: [number, number];
+	}
+	export interface CashtagWithIndices {
+		cashtag: string;
+		indices: [number, number];
+	}
+	export type EntityWithIndices =
+			HashtagWithIndices |
+			UrlWithIndices |
+			MentionWithIndices |
+			MentionOrListWithIndices |
+			CashtagWithIndices;
+
+	interface Indices {
+		indices: [number, number];
+	}
+
+	export function htmlEscape(text: string): string;
+	export function splitTags(text: string): string[];
+
+	export function extractHashtags(text: string): string[];
+	export function extractHashtagsWithIndices(text: string): HashtagWithIndices[];
+	export function extractUrls(text: string): string[];
+	export function extractUrlsWithIndices(text: string): UrlWithIndices[];
+	export function extractMentions(text: string): string[];
+	export function extractMentionsWithIndices(text: string): MentionWithIndices[];
+	export function extractMentionsOrListsWithIndices(text: string): MentionOrListWithIndices[];
+	export function extractReplies(text: string): string[];
+	export function extractCashtags(text: string): string[];
+	export function extractCashtagsWithIndices(text: string): CashtagWithIndices[];
+	export function extractEntitiesWithIndices(text: string): EntityWithIndices[];
+
+	export function modifyIndicesFromUnicodeToUTF16<I>(i: I[]): I[];
+	export function modifyIndicesFromUTF16ToUnicode<I>(i: I[]): I[];
+
+	export interface UrlEntity {
+		url: string;
+		display_url: string;
+		expanded_url: string;
+		indices: [number, number];
+	}
+	export interface AutoLinkOptions {
+		hashtagClass?: string;
+		hashtagUrlBase?: string;
+		cashtagClass?: string;
+		cashtagUrlBase?: string;
+		listClass?: string;
+		usernameClass?: string;
+		usernameUrlBase?: string;
+		listUrlBase?: string;
+		htmlAttrs?: string;
+		invisibleTagAttrs?: string;
+		htmlEscapeNonEntities?: boolean;
+		urlEntities?: UrlEntity[];
+	}
+
+	export function autoLink(text: string, options?: AutoLinkOptions): string;
+	export function autoLinkUsernamesOrLists(text: string, options?: AutoLinkOptions): string;
+	export function autoLinkHashtags(text: string, options?: AutoLinkOptions): string;
+	export function autoLinkCashtags(text: string, options?: AutoLinkOptions): string;
+	export function autoLinkUrlsCustom(text: string, options?: AutoLinkOptions): string;
+	export function autoLinkEntities(text: string, entities: EntityWithIndices[], options?: AutoLinkOptions): string;
+
+	interface TweetLengthOptions {
+		short_url_length: number;
+		short_url_length_https: number;
+	}
+	export function getTweetLength(text: string, options?: TweetLengthOptions): number;
+
+	export function isValidUsername(username: string): boolean;
+	export function isValidList(usernameList: string): boolean;
+	export function isValidHashtag(hashtag: string): boolean;
+	// Note: unicodeDomainsa and requireProtocol can be null
+	export function isValidUrl(url: string, unicodeDomains: boolean, requireProtocol: boolean): boolean;
+	export function isInvalidTweet(text: string): string;
+
+	export function getUnicodeTextLength(text: string): number;
+	// Note: This function directly modify entities" indices
+	export function convertUnicodeIndices(text: string, entities: EntityWithIndices[], indicesInUTF16?: boolean): void;
+
+	export function hitHighlight(text: string, hits?: number[][], options?: {tag: string}): string;
+}

--- a/twitter-text/twitter-text.d.ts
+++ b/twitter-text/twitter-text.d.ts
@@ -51,8 +51,8 @@ declare module "twitter-text" {
 	export function extractCashtagsWithIndices(text: string): CashtagWithIndices[];
 	export function extractEntitiesWithIndices(text: string): EntityWithIndices[];
 
-	export function modifyIndicesFromUnicodeToUTF16<I>(i: I[]): I[];
-	export function modifyIndicesFromUTF16ToUnicode<I>(i: I[]): I[];
+	export function modifyIndicesFromUnicodeToUTF16<I>(i: I): I;
+	export function modifyIndicesFromUTF16ToUnicode<I>(i: I): I;
 
 	export interface UrlEntity {
 		url: string;


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
