### PR TITLE
declare ReactHelmet namespace and fix error

### DIFF
--- a/react-helmet/react-helmet-tests.tsx
+++ b/react-helmet/react-helmet-tests.tsx
@@ -2,7 +2,7 @@
 /// <reference path="../react/react.d.ts" />
 
 import * as React from 'react';
-import Helmet from 'react-helmet';
+import * as Helmet from 'react-helmet';
 
 <Helmet title="My Title" />
 

--- a/react-helmet/react-helmet.d.ts
+++ b/react-helmet/react-helmet.d.ts
@@ -1,13 +1,13 @@
 // Type definitions for react-helmet
 // Project: https://github.com/nfl/react-helmet
-// Definitions by: Evan Bremer <https://github.com/evanbb>
+// Definitions by: Evan Bremer <https://github.com/evanbb>, Isman Usoh <https://github.com/isman-usoh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../react/react.d.ts" />
 
-declare module 'react-helmet' {
-    import { Component } from 'react';
-
+declare namespace ReactHelmet {
+    import React = __React;
+    
     interface HelmetProps {
         title?: string;
         titleTemplate?: string;
@@ -25,15 +25,20 @@ declare module 'react-helmet' {
         meta: HelmetDatum;
         script: HelmetDatum;
     }
-
+    
     interface HelmetDatum {
         toString(): string;
-        toComponent(): Component<any, any>;
+        toComponent(): React.Component<any, any>;
     }
 
-    class Helmet extends Component<HelmetProps, any> {
-        static rewind(): HelmetData
-    }
+    class HelmetComponent extends React.Component<HelmetProps, any> {}
+}
 
-    export default Helmet;
+declare module "react-helmet" {
+    var Helmet: {
+        (): ReactHelmet.HelmetComponent
+        rewind(): ReactHelmet.HelmetData
+    }
+    
+    export = Helmet;
 }


### PR DESCRIPTION
- declare ReactHelmet namespace
- fix error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined.
- fix warning: React.createElement: type should not be null, undefined, boolean, or number. It should be a string (for DOM elements) or a ReactClass (for composite components)
