### PR TITLE
Update gapi.d.ts

### DIFF
--- a/gapi/gapi.d.ts
+++ b/gapi/gapi.d.ts
@@ -140,8 +140,9 @@ declare namespace gapi.client {
     * @param name The name of the API to load.
     * @param version The version of the API to load
     * @param callback the function that is called once the API interface is loaded
+    * @param url optional, the url of your app - if using Google's APIs, don't set it
     */
-    export function load(name: string, version: string, callback: () => any): void;
+    export function load(name: string, version: string, callback: () => any, url?: string): void;
     /**
     * Creates a HTTP request for making RESTful requests.
     * An object encapsulating the various arguments for this method.


### PR DESCRIPTION
Adding the optional url param to gapi.client.load. It's used if you are using a custom endpoint server.
It's not on the official documentation, but you can see it here (steps 3 and 4):
https://cloud.google.com/appengine/docs/java/endpoints/consume_js
Here too:
http://stackoverflow.com/questions/18260815/use-gapi-client-javascript-to-execute-my-custom-google-api
I don't know how that param would work in the 
`load(name: string, version: string): Promise<void>`
method
