### PR TITLE
Update react-intl locale data location

### DIFF
--- a/react-intl/react-intl-tests.tsx
+++ b/react-intl/react-intl-tests.tsx
@@ -26,7 +26,7 @@ FormattedPlural,
 FormattedDate,
 FormattedTime
 } from "react-intl"
-import reactIntlEn = require("react-intl/lib/locale-data/en");
+import reactIntlEn = require("react-intl/locale-data/en");
 
 addLocaleData(reactIntlEn);
 console.log(hasLocaleData("en"));

--- a/react-intl/react-intl.d.ts
+++ b/react-intl/react-intl.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-intl 2.0.0-beta1
+// Type definitions for react-intl 2.0.0
 // Project: http://formatjs.io/react/
 // Definitions by: Bruno Grieder <https://github.com/bgrieder>, Christian Droulers <https://github.com/cdroulers>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -233,7 +233,1167 @@ declare module "react-intl" {
     export = ReactIntl
 }
 
-declare module "react-intl/lib/locale-data/en" {
+declare module "react-intl/locale-data/af" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/agq" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ak" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/am" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ar" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/as" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/asa" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ast" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/az" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/bas" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/be" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/bem" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/bez" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/bg" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/bh" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/bm" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/bn" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/bo" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/br" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/brx" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/bs" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ca" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ce" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/cgg" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/chr" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ckb" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/cs" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/cu" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/cy" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/da" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/dav" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/de" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/dje" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/dsb" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/dua" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/dv" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/dyo" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/dz" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ebu" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ee" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/el" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/en" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/eo" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/es" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/et" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/eu" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ewo" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/fa" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ff" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/fi" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/fil" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/fo" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/fr" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/fur" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/fy" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ga" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/gd" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/gl" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/gsw" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/gu" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/guw" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/guz" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/gv" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ha" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/haw" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/he" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/hi" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/hr" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/hsb" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/hu" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/hy" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/id" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ig" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ii" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/in" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/is" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/it" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/iu" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/iw" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ja" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/jbo" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/jgo" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ji" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/jmc" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/jv" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/jw" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ka" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/kab" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/kaj" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/kam" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/kcg" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/kde" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/kea" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/khq" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ki" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/kk" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/kkj" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/kl" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/kln" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/km" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/kn" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ko" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/kok" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ks" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ksb" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ksf" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ksh" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ku" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/kw" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ky" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/lag" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/lb" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/lg" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/lkt" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ln" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/lo" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/lrc" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/lt" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/lu" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/luo" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/luy" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/lv" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/mas" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/mer" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/mfe" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/mg" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/mgh" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/mgo" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/mk" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ml" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/mn" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/mo" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/mr" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ms" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/mt" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/mua" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/my" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/mzn" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/nah" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/naq" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/nb" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/nd" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ne" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/nl" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/nmg" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/nn" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/nnh" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/no" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/nqo" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/nr" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/nso" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/nus" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ny" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/nyn" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/om" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/or" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/os" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/pa" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/pap" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/pl" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/prg" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ps" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/pt" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/qu" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/rm" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/rn" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ro" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/rof" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ru" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/rw" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/rwk" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/sah" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/saq" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/sbp" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/sdh" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/se" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/seh" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ses" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/sg" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/sh" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/shi" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/si" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/sk" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/sl" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/sma" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/smi" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/smj" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/smn" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/sms" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/sn" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/so" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/sq" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/sr" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ss" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ssy" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/st" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/sv" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/sw" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/syr" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ta" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/te" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/teo" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/th" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ti" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/tig" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/tk" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/tl" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/tn" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/to" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/tr" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ts" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/twq" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/tzm" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ug" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/uk" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ur" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/uz" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/vai" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/ve" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/vi" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/vo" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/vun" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/wa" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/wae" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/wo" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/xh" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/xog" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/yav" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/yi" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/yo" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/zgh" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/zh" {
+    var data: ReactIntl.LocaleData;
+    export = data;
+}
+
+declare module "react-intl/locale-data/zu" {
     var data: ReactIntl.LocaleData;
     export = data;
 }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
react-intl v2.0.0-rc-1 has following text in release notes:

> Refactored Builds and Package Layout
> React Intl's build and npm package layout have been refactored. While these changes have simplified the build and package layout, the location of the locale data has changed, so paths to it need to be updated.
> Locale data is now package-relative and can more easily be loaded:
> `import enLocaleData from 'react-intl/locale-data/en';`

So I updated location of locale-data.
