### PR TITLE
Backbone: History.getFragment, removing the second argument

### DIFF
--- a/backbone/backbone-global.d.ts
+++ b/backbone/backbone-global.d.ts
@@ -311,7 +311,7 @@ declare namespace Backbone {
         start(options?: HistoryOptions): boolean;
 
         getHash(window?: Window): string;
-        getFragment(fragment?: string, forcePushState?: boolean): string;
+        getFragment(fragment?: string): string;
         stop(): void;
         route(route: string, callback: Function): number;
         checkUrl(e?: any): void;


### PR DESCRIPTION
The declaration file mentioned 2 arguments, but the source: http://backbonejs.org/docs/backbone.html#section-214 doesn't mention the second argument in any way. 

I therefore removed it. 
