### PR TITLE
Backbone: View#make doesn't exists anymore

### DIFF
--- a/backbone/backbone-global.d.ts
+++ b/backbone/backbone-global.d.ts
@@ -368,7 +368,6 @@ declare namespace Backbone {
         $(selector: any): JQuery;
         render(): View<TModel>;
         remove(): View<TModel>;
-        make(tagName: any, attributes?: any, content?: any): any;
         delegateEvents(events?: EventsHash): any;
         delegate(eventName: string, selector: string, listener: Function): View<TModel>;
         undelegateEvents(): any;

--- a/backbone/backbone-global.d.ts
+++ b/backbone/backbone-global.d.ts
@@ -146,7 +146,6 @@ declare namespace Backbone {
         /*private*/ set(attributeName: string, value: any, options?: ModelSetOptions): Model;
         set(obj: any, options?: ModelSetOptions): Model;
 
-        change(): any;
         changedAttributes(attributes?: any): any[];
         clear(options?: Silenceable): any;
         clone(): Model;


### PR DESCRIPTION
View#make hasn't existed in Backbone since January 2013. 

See changelog from for version 0.9.10: (View#make has been removed. You'll need to use $ directly to construct DOM elements now.)

Given how long it has been gone from Backbone, I think it should be removed. 
