### PR TITLE
Backbone: sortedIndex isn't added to collection through mixins

### DIFF
--- a/backbone/backbone-global.d.ts
+++ b/backbone/backbone-global.d.ts
@@ -265,7 +265,6 @@ declare namespace Backbone {
         some(iterator: (element: TModel, index: number) => boolean, context?: any): boolean;
         sortBy(iterator: (element: TModel, index: number) => number, context?: any): TModel[];
         sortBy(attribute: string, context?: any): TModel[];
-        sortedIndex(element: TModel, iterator?: (element: TModel, index: number) => number): number;
         reduceRight(iterator: (memo: any, element: TModel, index: number) => any, initialMemo: any, context?: any): any[];
         reject(iterator: (element: TModel, index: number) => boolean, context?: any): TModel[];
         rest(): TModel;


### PR DESCRIPTION
According to the declaration file, sortedIndex was added as a mixin to the collection class. 

This is however not the case, if one looks at the "collectionMethods" variable in the Backbone.js source code, one will see that sortedIndex isn't one of the methods that is added trough a mixin. 
