### PR TITLE
Add 'jsx-chai' module

### DIFF
--- a/jsx-chai/jsx-chai-tests.ts
+++ b/jsx-chai/jsx-chai-tests.ts
@@ -1,0 +1,9 @@
+/// <reference path="../chai/chai.d.ts"/>
+/// <reference path="jsx-chai.d.ts"/>
+
+import chai = require('chai');
+import jsxChai = require('jsx-chai');
+
+function testUseJsxChai() {
+	chai.use(jsxChai.jsxChai);
+}

--- a/jsx-chai/jsx-chai.d.ts
+++ b/jsx-chai/jsx-chai.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for jsx-chai 3.0.0
+// Project: https://github.com/bkonkle/jsx-chai
+// Definitions by: Philipp Holzer <https://github.com/nupplaphil/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../chai/chai.d.ts" />
+
+declare module 'jsx-chai' {
+    interface JsxChaiStatic {
+        jsxChai: jsxChaiFunction;
+    }
+
+    interface jsxChaiFunction {
+        (chai: any, utils: any): void;
+    }
+
+    var jsxChai: JsxChaiStatic;
+
+    export = jsxChai;
+}

--- a/radium/radium-tests.tsx
+++ b/radium/radium-tests.tsx
@@ -1,0 +1,17 @@
+/// <reference path="radium.d.ts" />
+/// <reference path="../react/react.d.ts" />
+
+import * as React from "react";
+import * as Radium from 'radium';
+
+@Radium
+export default class TestComponent extends React.Component<any, any> {
+
+	render() {
+		return (
+			<div >
+				Test with Radium
+			</div>
+		);
+	}
+}

--- a/radium/radium.d.ts
+++ b/radium/radium.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for radium 0.17.1
+// Project: https://github.com/formidablelabs/radium
+// Definitions by: Alex Gorbatchev <https://github.com/alexgorbatchev/>, Philipp Holzer <https://github.com/nupplaphil/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../react/react.d.ts"/>
+
+declare module 'radium' {
+    import React = require('react');
+
+    interface ReactComponent<P, S> {
+        new (p: P): React.Component<P, S>;
+    }
+
+    var Radium: {
+        <T extends ReactComponent<any, any>>(comp: T): T;
+    };
+
+    export = Radium;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [X] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [X] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [X] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
