### PR TITLE
PathJS: Spelling mistake

### DIFF
--- a/pathjs/pathjs.d.ts
+++ b/pathjs/pathjs.d.ts
@@ -35,7 +35,7 @@ interface IPath {
 	
 	root(path: string): void;
 	
-	rescure(fn: Function): void;
+	rescue(fn: Function): void;
 	
 	history: IPathHistory;
 	


### PR DESCRIPTION
rescue is not spelled rescure. 

Relevant JS source: 

```
'rescue': function (fn) {
   Path.routes.rescue = fn;
},
```
