### PR TITLE
Add missing param for rowIdentity

### DIFF
--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -861,7 +861,7 @@ declare namespace uiGrid {
          * By default it returns the `$$hashKey` property if it exists. If it doesn't it uses gridUtil.nextUid()
          * to generate one
          */
-        rowIdentity?(): any;
+        rowIdentity?(row: IGridRowOf<TEntity>): any;
     }
     export interface IGridCoreApi<TEntity> {
         // Methods


### PR DESCRIPTION
Add missing param `row` for function `rowIdentity` in `IGridOptionsOf<TEntity>`
