### PR TITLE
Mark param as optional

### DIFF
--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -399,7 +399,7 @@ declare namespace uiGrid {
          * ALL
          * @returns {Function} deregister function - a function that can be called to deregister this callback
          */
-        registerDataChangeCallback(callback: (grid: IGridInstanceOf<TEntity>) => void, types: Array<string>): Function;
+        registerDataChangeCallback(callback: (grid: IGridInstanceOf<TEntity>) => void, types?: Array<string>): Function;
         /**
          * When the build creates rows from gridOptions.data, the rowBuilders will be called to add
          * additional properties to the row.


### PR DESCRIPTION
Mark param `types` as optional in method `registerDataChangeCallback` for `IGridOptions<TEntity>`
