### PR TITLE
Add support for loading using `moment/moment`

### DIFF
--- a/moment/moment-node.d.ts
+++ b/moment/moment-node.d.ts
@@ -686,3 +686,8 @@ declare module 'moment' {
     var moment: moment.MomentStatic;
     export = moment;
 }
+
+declare module 'moment/moment' {
+    var moment: moment.MomentStatic;
+    export = moment;
+}


### PR DESCRIPTION
This addition allows importing moment in AMD environments where `main` hasn't been defined for the `moment` package.
