### PR TITLE
added an empty namespace in koa-bodyparser.d.ts

### DIFF
--- a/koa-bodyparser/koa-bodyparser.d.ts
+++ b/koa-bodyparser/koa-bodyparser.d.ts
@@ -60,5 +60,6 @@ declare module "koa-bodyparser" {
         onerror?: (err: Error, ctx: Koa.Context) => void;
     }): { (ctx: Koa.Context, next?: () => any): any };
 
+    namespace bodyParser {}
     export = bodyParser;
 }


### PR DESCRIPTION
Without this, there will be `Module '"koa-bodyparser"' resolves to a non-module entity and cannot be imported using this construct. (2497)` error
This solution is found (here)[https://github.com/Microsoft/TypeScript/issues/5073].
koa-json's `.d.ts` file, which is not in this repo, has such namespace.
