### PR TITLE
Object like parameter in Bitmap contructor when are using preloadjs getResult

### DIFF
--- a/easeljs/easeljs.d.ts
+++ b/easeljs/easeljs.d.ts
@@ -43,7 +43,7 @@ declare namespace createjs {
 
 
     export class Bitmap extends DisplayObject {
-        constructor(imageOrUrl: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | string);
+        constructor(imageOrUrl: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | Object | string);
 
         // properties
         image: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement;

--- a/html2canvas/html2canvas.d.ts
+++ b/html2canvas/html2canvas.d.ts
@@ -36,6 +36,9 @@ declare namespace Html2Canvas {
 
         /** Whether to attempt to load cross-origin images as CORS served, before reverting back to proxy. */
         useCORS?: boolean;
+        
+        /** Use svg powered rendering where available (FF11+). */
+        svgRendering?: boolean;
 
         /** Callback providing the rendered canvas element after rendering */
         onrendered?(canvas: HTMLCanvasElement): void;


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
