### PR TITLE
Missing locale functions and types

### DIFF
--- a/html2canvas/html2canvas.d.ts
+++ b/html2canvas/html2canvas.d.ts
@@ -36,6 +36,9 @@ declare namespace Html2Canvas {
 
         /** Whether to attempt to load cross-origin images as CORS served, before reverting back to proxy. */
         useCORS?: boolean;
+        
+        /** Use svg powered rendering where available (FF11+). */
+        svgRendering?: boolean;
 
         /** Callback providing the rendered canvas element after rendering */
         onrendered?(canvas: HTMLCanvasElement): void;

--- a/knockout.validation/knockout.validation.d.ts
+++ b/knockout.validation/knockout.validation.d.ts
@@ -106,6 +106,10 @@ interface KnockoutValidationGroup {
     isAnyMessageShown?: () => boolean;
 }
 
+interface KnockoutValidationLocalizationDictionary {
+    [key: string]: string;
+}
+
 interface KnockoutValidationStatic {
     init(options?: KnockoutValidationConfiguration, force?: boolean): void;
     reset(): void;
@@ -127,7 +131,9 @@ interface KnockoutValidationStatic {
     registerExtenders(): void;
     utils: KnockoutValidationUtils;
 
-    localize(msgTranslations: any): void;
+    localize(msgTranslations: KnockoutValidationLocalizationDictionary): void;
+    defineLocale(newLocale: string, msgTranslations: KnockoutValidationLocalizationDictionary): KnockoutValidationLocalizationDictionary;
+    locale(newLocale: string): string;
     validateObservable(observable: KnockoutObservable<any>): boolean;
 }
 

--- a/koa-bodyparser/koa-bodyparser.d.ts
+++ b/koa-bodyparser/koa-bodyparser.d.ts
@@ -60,5 +60,6 @@ declare module "koa-bodyparser" {
         onerror?: (err: Error, ctx: Koa.Context) => void;
     }): { (ctx: Koa.Context, next?: () => any): any };
 
+    namespace bodyParser {}
     export = bodyParser;
 }


### PR DESCRIPTION
Missing 2.0.x locale functions, plus proper typing for the existing functions
