### PR TITLE
Add definition for iconv

### DIFF
--- a/iconv/iconv-tests.ts
+++ b/iconv/iconv-tests.ts
@@ -1,0 +1,28 @@
+///<reference path="./iconv.d.ts" />
+
+import {Iconv} from "iconv";
+import {Writable} from "stream";
+
+const iconv: Iconv.Iconv = new Iconv("utf-8", "cp932");
+const iconvFromFunction: Iconv.Iconv = Iconv("utf-8", "cp932");
+
+iconv.writable = true;
+
+let buffer: Buffer;
+
+buffer = iconv.convert("hoge");
+buffer = iconv.convert("hoge", "utf-8");
+buffer = iconv.convert(new Buffer("hoge"), "utf-8");
+
+let result: boolean;
+
+result = iconv.write("hoge");
+result = iconv.write("hoge", "utf-8");
+result = iconv.write(new Buffer("hoge"), "utf-8");
+
+iconv.end();
+iconv.end("hoge");
+iconv.end("hoge", "utf-8");
+iconv.end(new Buffer("hoge"), "utf-8");
+
+const st: Writable = iconv.pipe(new Writable, {end: true});

--- a/iconv/iconv.d.ts
+++ b/iconv/iconv.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for iconv 2.1.11
+// Project: https://github.com/bnoordhuis/node-iconv
+// Definitions by: delphinus <https://github.com/delphinus35/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+///<reference path="../node/node.d.ts" />
+
+declare namespace Iconv {
+
+    interface Static {
+
+        new(fromEncoding: string, toEncoding: string): Iconv;
+        (fromEncoding: string, toEncoding: string): Iconv;
+    }
+
+    interface Iconv extends NodeJS.WritableStream {
+
+        writable: boolean;
+        convert(input: string | Buffer, encoding?: string): Buffer;
+        write(input: string | Buffer, encoding?: string): boolean;
+        end(input?: string | Buffer, encoding?: string): void;
+
+        // copy from NodeJS.WritableStream for compatibility
+        write(buffer: Buffer|string, cb?: Function): boolean;
+        write(str: string, encoding?: string, cb?: Function): boolean;
+        end(): void;
+        end(buffer: Buffer, cb?: Function): void;
+        end(str: string, cb?: Function): void;
+        end(str: string, encoding?: string, cb?: Function): void;
+
+        // copy from stream.Stream
+        pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
+    }
+}
+
+declare module "iconv" {
+
+    var Iconv: Iconv.Static;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
