### PR TITLE
React TestUtils SyntheticEventData extends browser Event

### DIFF
--- a/react/react-addons-test-utils.d.ts
+++ b/react/react-addons-test-utils.d.ts
@@ -6,7 +6,7 @@
 /// <reference path="react.d.ts" />
 
 declare namespace __React {
-    interface SyntheticEventData {
+    interface SyntheticEventData extends Event {
         altKey?: boolean;
         button?: number;
         buttons?: number;
@@ -41,8 +41,7 @@ declare namespace __React {
     }
 
     interface EventSimulator {
-        (element: Element, eventData?: SyntheticEventData): void;
-        (component: Component<any, any>, eventData?: SyntheticEventData): void;
+        (element: Element | Component<any, any>, eventData?: SyntheticEventData): void;
     }
 
     interface MockedComponentClass {

--- a/react/react-addons-test-utils.d.ts
+++ b/react/react-addons-test-utils.d.ts
@@ -6,7 +6,22 @@
 /// <reference path="react.d.ts" />
 
 declare namespace __React {
-    interface SyntheticEventData extends Event {
+    interface OptionalEventProperties {
+        bubbles?: boolean;
+        cancelable?: boolean;
+        currentTarget?: EventTarget;
+        defaultPrevented?: boolean;
+        eventPhase?: number;
+        isTrusted?: boolean;
+        nativeEvent?: Event;
+        preventDefault?(): void;
+        stopPropagation?(): void;
+        target?: EventTarget;
+        timeStamp?: Date;
+        type?: string;
+    }
+
+    interface SyntheticEventData extends OptionalEventProperties {
         altKey?: boolean;
         button?: number;
         buttons?: number;

--- a/react/react-global-tests.ts
+++ b/react/react-global-tests.ts
@@ -418,14 +418,10 @@ React.createClass({
 // TestUtils addon
 // --------------------------------------------------------------------------
 var node: Element;
-var eventData = {} as React.SyntheticEventData;
-
-eventData.key = "Enter";
-eventData.cancelable = false;
 
 React.addons.TestUtils.Simulate.click(node);
 React.addons.TestUtils.Simulate.change(node);
-React.addons.TestUtils.Simulate.keyDown(node, eventData);
+React.addons.TestUtils.Simulate.keyDown(node, { key: "Enter", cancelable: false });
 
 var renderer: React.ShallowRenderer =
     React.addons.TestUtils.createRenderer();

--- a/react/react-global-tests.ts
+++ b/react/react-global-tests.ts
@@ -418,9 +418,14 @@ React.createClass({
 // TestUtils addon
 // --------------------------------------------------------------------------
 var node: Element;
+var eventData = {} as React.SyntheticEventData;
+
+eventData.key = "Enter";
+eventData.cancelable = false;
+
 React.addons.TestUtils.Simulate.click(node);
 React.addons.TestUtils.Simulate.change(node);
-React.addons.TestUtils.Simulate.keyDown(node, { key: "Enter" });
+React.addons.TestUtils.Simulate.keyDown(node, eventData);
 
 var renderer: React.ShallowRenderer =
     React.addons.TestUtils.createRenderer();

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -550,10 +550,14 @@ React.createClass({
 
 var inst: ModernComponent = TestUtils.renderIntoDocument<ModernComponent>(element);
 var node: Element = TestUtils.renderIntoDocument(React.DOM.div());
+var eventData = {} as React.SyntheticEventData;
+
+eventData.key = "Enter";
+eventData.cancelable = false;
 
 TestUtils.Simulate.click(node);
 TestUtils.Simulate.change(node);
-TestUtils.Simulate.keyDown(node, { key: "Enter" });
+TestUtils.Simulate.keyDown(node, eventData);
 
 var renderer: React.ShallowRenderer =
     TestUtils.createRenderer();

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -550,14 +550,10 @@ React.createClass({
 
 var inst: ModernComponent = TestUtils.renderIntoDocument<ModernComponent>(element);
 var node: Element = TestUtils.renderIntoDocument(React.DOM.div());
-var eventData = {} as React.SyntheticEventData;
-
-eventData.key = "Enter";
-eventData.cancelable = false;
 
 TestUtils.Simulate.click(node);
 TestUtils.Simulate.change(node);
-TestUtils.Simulate.keyDown(node, eventData);
+TestUtils.Simulate.keyDown(node, { key: "Enter", cancelable: false });
 
 var renderer: React.ShallowRenderer =
     TestUtils.createRenderer();


### PR DESCRIPTION
From https://facebook.github.io/react/docs/events.html

Your event handlers will be passed instances of SyntheticEvent, a
cross-browser wrapper around the browser's native event. It has the same
interface as the browser's native event, including stopPropagation() and
preventDefault(), except the events work identically across all
browsers.
