### PR TITLE
(winston) Added level to Logger

### DIFF
--- a/winston/winston.d.ts
+++ b/winston/winston.d.ts
@@ -127,6 +127,8 @@ declare module "winston" {
 
     setLevels(target: any): any;
     cli(): LoggerInstance;
+    
+    level: string;
   }
 
   export interface LoggerOptions {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes. 
  url https://github.com/winstonjs/winston/blob/master/lib/winston/logger.js#L75

This is not really documented, but the documentation of winston is quite lacking.
Here it is used to change get and set the level of the default logger
https://github.com/winstonjs/winston/blob/master/lib/winston.js#L125
