### PR TITLE
Add typings for immutability-helper.

### DIFF
--- a/immutability-helper/immutability-helper-tests.ts
+++ b/immutability-helper/immutability-helper-tests.ts
@@ -1,0 +1,50 @@
+/// <reference path="immutability-helper.d.ts"/>
+
+import * as update from 'immutability-helper';
+import { newContext } from 'immutability-helper';
+
+namespace TestObjectUpdate {
+  update({}, {
+    foo: {
+      bar: { $set: 'baz' }
+    }
+  });
+}
+
+namespace TestArrayUpdate {
+  update([], {
+    foo: {
+      bar: { $set: 'baz' }
+    }
+  });
+}
+
+namespace TestExtend {
+  update.extend('$command', (specValue, originalValue) => originalValue);
+}
+
+namespace TestNewContext {
+  update.newContext().extend('$command', (specValue, originalValue) => originalValue);
+  newContext().extend('$command', (specValue, originalValue) => originalValue);
+
+  // This shouldn't compile, but we can't test negatives.
+  // newContext().newContext();
+}
+
+namespace TestFromReactDocs {
+  // These are copied from https://facebook.github.io/react/docs/update.html
+  let initialArray = [1, 2, 3];
+  let newArray = update(initialArray, { $push: [4] }); // => [1, 2, 3, 4]
+
+  let collection = [1, 2, { a: [12, 17, 15] }];
+  let newCollection = update(collection, { 2: { a: { $splice: [[1, 1, 13, 14]] } } });
+  // => [1, 2, {a: [12, 13, 14, 15]}]
+
+  let obj = { a: 5, b: 3 };
+  let newObj = update(obj, { b: { $apply: function(x: number) { return x * 2; } } });
+  // => {a: 5, b: 6}
+  let newObj2 = update(obj, { b: { $set: obj.b * 2 } });
+
+  let objShallow = { a: 5, b: 3 };
+  let newObjShallow = update(obj, { $merge: { b: 6, c: 7 } }); // => {a: 5, b: 6, c: 7}
+}

--- a/immutability-helper/immutability-helper.d.ts
+++ b/immutability-helper/immutability-helper.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for immutability-helper v2.0.0
+// Project: https://github.com/kolodny/immutability-helper
+// Definitions by: Sean Kelley <https://github.com/seansfkelley>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "immutability-helper" {
+  interface UpdateSpecCommand {
+    $set?: any;
+    $merge?: {};
+    $apply?(value: any): any;
+    [customCommand: string]: any;
+  }
+
+  interface UpdateSpecPath {
+    [pathPart: string]: UpdateSpec;
+  }
+
+  type UpdateSpec = UpdateSpecCommand | UpdateSpecPath;
+
+  interface UpdateArraySpec extends UpdateSpecCommand {
+    $push?: any[];
+    $unshift?: any[];
+    $splice?: any[][];
+    [customCommand: string]: any;
+  }
+
+  type CommandHandler = (specValue: any, originalValue: any) => any;
+
+  interface UpdateFunction {
+    (value: any[], spec: UpdateArraySpec): any[];
+    (value: {}, spec: UpdateSpec): any;
+    extend: (commandName: string, handler: CommandHandler) => any;
+  }
+
+  interface Update extends UpdateFunction {
+    newContext(): UpdateFunction;
+  }
+
+  const update: Update;
+  export = update;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

These typings are mostly copy-pasted from react-addons-update. Because this library
strives to be a drop-in replacement for react-addons-update, that seems appropriate.
I did not define it in terms of react-addons-update (i.e., didn't import
react-addons-update and then re-export it) because it won't necessarily track React,
so it should remain separate. Plus, it adds a couple functions.
