### PR TITLE
Allow Url type to be passed into setUrl()

### DIFF
--- a/hapi/hapi.d.ts
+++ b/hapi/hapi.d.ts
@@ -12,6 +12,7 @@ declare module "hapi" {
 	import http = require("http");
 	import stream = require("stream");
 	import Events = require("events");
+	import url = require("url");
 
 	interface IDictionary<T> {
 		[key: string]: T;
@@ -1250,8 +1251,7 @@ declare module "hapi" {
 		request.setUrl('/test');
 		return reply.continue();
 		});*/
-		setUrl(url: string): void;
-
+		setUrl(url: string | url.Url): void;
 		/** request.setMethod(method)
 
 		 Available only in 'onRequest' extension methods.


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Hapi allows you to [pass an already parsed Url](https://github.com/hapijs/hapi/blob/af9591356114f64485546cac0aa6b540a010c7da/lib/request.js#L199) into `request.setUrl()`.
