### PR TITLE
add d.ts for google-closure-compiler

### DIFF
--- a/google-closure-compiler/google-closure-compiler-tests.ts
+++ b/google-closure-compiler/google-closure-compiler-tests.ts
@@ -1,0 +1,28 @@
+/// <reference path="google-closure-compiler.d.ts" />
+
+import * as GoogleClosureCompiler from 'google-closure-compiler';
+
+// See
+//   https://github.com/chadkillingsworth/closure-compiler-npm#plugin-authors-and-native-node-usage
+// for the API example.  This code tries to do the exact same thing.
+
+let ClosureCompiler = GoogleClosureCompiler.compiler;
+
+console.log(ClosureCompiler.COMPILER_PATH)
+console.log(ClosureCompiler.CONTRIB_PATH)
+
+let options: GoogleClosureCompiler.CompileOptions = {
+    js: 'file-one.js',
+    compilation_level: 'ADVANCED',
+};
+let closureCompiler = new ClosureCompiler(options);
+let compilerProcess = closureCompiler.run((exitCode, stdout, stderr) => {
+    // ...
+});
+
+let jsonStream: GoogleClosureCompiler.JSONStreamFile[] = [
+    {
+        path: 'foo.js',
+        src: 'var x = "hello, world";',
+    },
+];

--- a/google-closure-compiler/google-closure-compiler.d.ts
+++ b/google-closure-compiler/google-closure-compiler.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for google-closure-compiler
+// Project: https://github.com/chadkillingsworth/closure-compiler-npm
+// Definitions by: Evan Martin <http://neugierig.org>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module 'google-closure-compiler' {
+    import * as child_process from 'child_process';
+
+    // The "json_streams" compiler flag lets the compiler accept/produce
+    // arrays of JSON objects in this shape for input/output.
+    interface JSONStreamFile {
+        path: string;
+        src: string;
+        srcmap?: string;  // TODO(evan): pass through source maps.
+    }
+
+    interface Compiler {
+        javaPath: string;
+        logger: (...args: any[]) => void;
+        spawnOptions: {[key:string]: string};
+
+        run(callback?: (exitCode: number, stdout: string, stderr: string) => void):
+        child_process.ChildProcess;
+        
+        getFullCommand(): string;
+    }
+    type CompileOptions = {[key: string]: string};
+    var compiler: {
+        new (opts: (CompileOptions|string[]),
+             extraCommandArgs?: string[]): Compiler;
+
+        JAR_PATH: string;
+        COMPILER_PATH: string;
+        CONTRIB_PATH: string;
+    };
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

The NPM google-closure-compiler library wraps the Google Closure Compiler.
This d.ts covers the Node interface to the library.
