### PR TITLE
Update React - Adds SVG <use> & <symbol> to the JSX IntrinsicElements

### DIFF
--- a/react/react-0.13.3.d.ts
+++ b/react/react-0.13.3.d.ts
@@ -2036,9 +2036,7 @@ declare namespace JSX {
         radialGradient: React.SVGAttributes;
         rect: React.SVGAttributes;
         stop: React.SVGAttributes;
-        symbol: React.SVGAttributes;
         text: React.SVGAttributes;
         tspan: React.SVGAttributes;
-        use: React.SVGAttributes;
     }
 }

--- a/react/react-0.13.3.d.ts
+++ b/react/react-0.13.3.d.ts
@@ -730,8 +730,10 @@ declare namespace __React {
         radialGradient: SVGFactory;
         rect: SVGFactory;
         stop: SVGFactory;
+        symbol: SVGFactory;
         text: SVGFactory;
         tspan: SVGFactory;
+        use: SVGFactory;
     }
 
     //
@@ -1538,8 +1540,10 @@ declare module "react/addons" {
         radialGradient: SVGFactory;
         rect: SVGFactory;
         stop: SVGFactory;
+        symbol: SVGFactory;
         text: SVGFactory;
         tspan: SVGFactory;
+        use: SVGFactory;
     }
 
     //
@@ -2032,7 +2036,9 @@ declare namespace JSX {
         radialGradient: React.SVGAttributes;
         rect: React.SVGAttributes;
         stop: React.SVGAttributes;
+        symbol: React.SVGAttributes;
         text: React.SVGAttributes;
         tspan: React.SVGAttributes;
+        use: React.SVGAttributes;
     }
 }

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -2234,8 +2234,10 @@ declare namespace __React {
         radialGradient: SVGFactory;
         rect: SVGFactory;
         stop: SVGFactory;
+        symbol: SVGFactory;
         text: SVGFactory;
         tspan: SVGFactory;
+        use: SVGFactory;
     }
 
     //
@@ -2464,7 +2466,9 @@ declare namespace JSX {
         radialGradient: React.SVGProps;
         rect: React.SVGProps;
         stop: React.SVGProps;
+        symbol: React.SVGProps;
         text: React.SVGProps;
         tspan: React.SVGProps;
+        use: React.SVGProps;
     }
 }


### PR DESCRIPTION
<use> & <symbol> were missing from the definition.
- documentation can be found here : https://developer.mozilla.org/en-US/docs/Web/SVG/Element/symbol & https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use
