### PR TITLE
Add dnsPrefetchControl definition to Helmet

### DIFF
--- a/helmet/helmet-tests.ts
+++ b/helmet/helmet-tests.ts
@@ -115,3 +115,12 @@ function publicKeyPinsTest() {
         reportUri: "http://example.com"
     }));
 }
+
+/**
+ * @summary Test for {@see helmet#dnsPrefetchControl} function.
+ */
+function dnsPrefetchControlTest() {
+    app.use(helmet.dnsPrefetchControl());
+    app.use(helmet.dnsPrefetchControl({ allow: false }));
+    app.use(helmet.dnsPrefetchControl({ allow: true }));
+}

--- a/helmet/helmet.d.ts
+++ b/helmet/helmet.d.ts
@@ -44,6 +44,10 @@ declare module "helmet" {
         setOnOldIE? : boolean;
     }
 
+    interface IHelmetDnsPrefetchControlConfiguration {
+        allow? : boolean;
+    }
+
     /**
      * @summary Interface for helmet class.
      * @interface
@@ -54,6 +58,11 @@ declare module "helmet" {
          * @return {RequestHandler} The Request handler.
          */
         ():express.RequestHandler;
+
+        /**
+         * @summary Stop browsers from doing DNS prefetching.
+         */
+        dnsPrefetchControl(options ?: IHelmetDnsPrefetchControlConfiguration):express.RequestHandler;
 
         /**
          * @summary Prevent clickjacking.


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes. https://github.com/helmetjs/helmet#prevent-dns-prefetching-dnsprefetchcontrol

This adds support for the `helmet.dnsPrefetchControl` middleware.
