### PR TITLE
First commit. Type definition for node-serialport.

### DIFF
--- a/serialport/serialport-tests.ts
+++ b/serialport/serialport-tests.ts
@@ -1,0 +1,15 @@
+/// <reference path="serialport.d.ts" />
+/// <reference path="../requirejs/require.d.ts"/>
+
+function test_serialport_on()
+{
+    var com = require("serialport");
+    var serialport : SerialPortStatic = new com.SerialPort("/dev/ttyAMA0",
+    {
+        parser: com.parsers.readline('\n')
+    });
+
+    serialport.on('data', (data: any) => {
+      console.log('Data: ' + data);
+    });
+}

--- a/serialport/serialport.d.ts
+++ b/serialport/serialport.d.ts
@@ -1,0 +1,47 @@
+// Type definitions for serialport
+// Project: https://github.com/voodootikigod/node-serialport
+// Definitions by: Sumit <https://github.com/sumitkm>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare interface SerialPort
+{
+    SerialPort: SerialPortStatic;
+    parsers: any;
+}
+
+declare var SerialPort: SerialPort;
+
+declare module "serialport" {
+    export = SerialPort;
+}
+
+declare interface SerialPortStatic
+{
+    new(path: string, options?: OptionsStatic, openImmediately?: boolean, callback?: () => void): SerialPortStatic;
+    open(callback?: (error: any)=>void): void;
+    isOpen(): boolean;
+    write(buffer: any, callback: (error: any) => void): void;
+    pause() : void;
+    resume() : void;
+    flush(callback: (error: any)=>void) : void;
+    drain(callback: (error: any)=>void) : void;
+    close(callback: (error: any)=>void) : void;
+    set(options: any, callback: (error: any, results: any)=>void) : void;
+    on(eventName: string, callback : (data: any)=> void) : void;
+}
+
+declare interface OptionsStatic
+{
+    baudRate?: number;
+    dataBits?: number;
+    stopBits?: number;
+    parity?: string;
+    rtscts?: boolean;
+    xon?: boolean;
+    xoff?: boolean;
+    xany?: boolean;
+    flowControl?: any;
+    bufferSize?: number;
+    parser? : any;
+    platformOptions?: any;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [ y] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ y] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ y] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
