### PR TITLE
Type corrections for es6 promises

### DIFF
--- a/es6-promise/es6-promise-commonjs-tests.ts
+++ b/es6-promise/es6-promise-commonjs-tests.ts
@@ -34,22 +34,22 @@ var rejectResult = Promise.reject('there is an error');
 promiseAny = rejectResult;
 
 //all test
-var allResult = Promise.all(arrayOfPromise);
+var allResult = Promise.all<string>(arrayOfPromise);
 promiseStringArr = allResult;
 
 //race test
-var raceResult = Promise.race(arrayOfPromise);
+var raceResult = Promise.race<string>(arrayOfPromise);
 promiseString = raceResult;
 
 
 //then test
-var thenWithPromiseResult = promiseString.then(word => Promise.resolve(word.length));
+var thenWithPromiseResult = promiseString.then<number>(word => Promise.resolve(word.length));
 promiseNumber = thenWithPromiseResult;
 
-var thenWithPromiseResultAndPromiseReject = promiseString.then(word => Promise.resolve(word.length), error => Promise.resolve(10));
+var thenWithPromiseResultAndPromiseReject = promiseString.then<number>(word => Promise.resolve(word.length), error => Promise.resolve(10));
 promiseNumber = thenWithPromiseResultAndPromiseReject;
 
-var thenWithPromiseResultAndSimpleReject = promiseString.then(word => Promise.resolve(word.length), error => 10);
+var thenWithPromiseResultAndSimpleReject = promiseString.then<number>(word => Promise.resolve(word.length), error => 10);
 promiseNumber = thenWithPromiseResultAndSimpleReject;
 
 var thenWithSimpleResult = promiseString.then(word => word.length);
@@ -74,7 +74,7 @@ promiseNumber = thenWithNoResultAndNoReject;
 var catchWithSimpleResult = promiseString.catch(error => 10);
 promiseNumber = catchWithSimpleResult;
 
-var catchWithPromiseResult = promiseString.catch(error => Promise.resolve(10));
+var catchWithPromiseResult = promiseString.catch<number>(error => Promise.resolve(10));
 promiseNumber = catchWithPromiseResult;
 
 

--- a/es6-promise/es6-promise-tests.ts
+++ b/es6-promise/es6-promise-tests.ts
@@ -32,22 +32,22 @@ var rejectResult = Promise.reject('there is an error');
 promiseAny = rejectResult;
 
 //all test
-var allResult = Promise.all(arrayOfPromise);
+var allResult = Promise.all<string>(arrayOfPromise);
 promiseStringArr = allResult;
 
 //race test
-var raceResult = Promise.race(arrayOfPromise);
+var raceResult = Promise.race<string>(arrayOfPromise);
 promiseString = raceResult;
 
 
 //then test
-var thenWithPromiseResult = promiseString.then(word => Promise.resolve(word.length));
+var thenWithPromiseResult = promiseString.then<number>(word => Promise.resolve(word.length));
 promiseNumber = thenWithPromiseResult;
 
-var thenWithPromiseResultAndPromiseReject = promiseString.then(word => Promise.resolve(word.length), error => Promise.resolve(10));
+var thenWithPromiseResultAndPromiseReject = promiseString.then<number>(word => Promise.resolve(word.length), error => Promise.resolve(10));
 promiseNumber = thenWithPromiseResultAndPromiseReject;
 
-var thenWithPromiseResultAndSimpleReject = promiseString.then(word => Promise.resolve(word.length), error => 10);
+var thenWithPromiseResultAndSimpleReject = promiseString.then<number>(word => Promise.resolve(word.length), error => 10);
 promiseNumber = thenWithPromiseResultAndSimpleReject;
 
 var thenWithSimpleResult = promiseString.then(word => word.length);
@@ -77,7 +77,7 @@ var voidPromise = new Promise<void>(function (resolve) { resolve(); });
 var catchWithSimpleResult = promiseString.catch(error => 10);
 promiseNumber = catchWithSimpleResult;
 
-var catchWithPromiseResult = promiseString.catch(error => Promise.resolve(10));
+var catchWithPromiseResult = promiseString.catch<number>(error => Promise.resolve(10));
 promiseNumber = catchWithPromiseResult;
 
 promiseString = promiseString.catch<string>(function () {

--- a/es6-promise/es6-promise.d.ts
+++ b/es6-promise/es6-promise.d.ts
@@ -4,8 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface Thenable<T> {
-    then<U>(onFulfilled?: (value: T) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
-    then<U>(onFulfilled?: (value: T) => U | Thenable<U>, onRejected?: (error: any) => void): Thenable<U>;
+    then<U>(onFulfilled?: (value: T | Thenable<T>) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>): Thenable<T|U>;
+    then<U>(onFulfilled?: (value: T | Thenable<T>) => U | Thenable<U>, onRejected?: (error: any) => void): Thenable<T|U>;
     catch<U>(onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
 }
 
@@ -29,8 +29,8 @@ declare class Promise<T> implements Thenable<T> {
 	 * @param onFulfilled called when/if "promise" resolves
 	 * @param onRejected called when/if "promise" rejects
 	 */
-    then<U>(onFulfilled?: (value: T) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>): Promise<U>;
-    then<U>(onFulfilled?: (value: T) => U | Thenable<U>, onRejected?: (error: any) => void): Promise<U>;
+    then<U>(onFulfilled?: (value: T) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>): Promise<T|U>;
+    then<U>(onFulfilled?: (value: T) => U | Thenable<U>, onRejected?: (error: any) => void): Promise<T|U>;
 
 	/**
 	 * Sugar for promise.then(undefined, onRejected)


### PR DESCRIPTION
The type definition for promises need to be changed in two ways in order to adhere to the [Promises A+ specification](https://promisesaplus.com/):
1. The return type of `then` must be `Thenable<T|U>` (for `Thenable`) and `Promise<T|U>` (for `Promise`), respectively. This is due to rule 2.2.7.3 in the spec: if the argument `onFulfilled` of `then` is not defined, then the promise returned by `then` must be fulfilled with the same value as the originating promise – however, this value is of type `T`.
2. The type of `value` of the argument `onFulfilled` of `then` in the interface `Thenable` must be  `T | Thenable<T>` instead of `T`. This is partially due to rule 2.3.3.3.1 of the spec: the value `y` can be of type `T | Thenable<T>` instead of `T` only. Unfortunately, rule 2.3.3.3.1 and the entire Promises A+ standard does not explicitely state that `y` is also allowed to be a `Thenable<T>`. However, the [Promises/A+ Compliance Test Suite](https://github.com/promises-aplus/promises-tests) will fail if `y` is assumed to be only of type `T` and not `T | Thenable<T>` (see test case '`y` is a thenable' in [https://github.com/promises-aplus/promises-tests/blob/master/lib/tests/2.3.3.js](https://github.com/promises-aplus/promises-tests/blob/master/lib/tests/2.3.3.js)).

Remark: the type of `value` of the argument `onFulfilled` of `then` in the class `Promise` must be only `T`, though.

For references see my [repository](https://github.com/TorstenStueber/PromiseAPlusTypeScript), an implementation of the Promises A+ spec in TypeScript.
