### PR TITLE
Initial typings for babel v6

### DIFF
--- a/babel-core/babel-core-tests.ts
+++ b/babel-core/babel-core-tests.ts
@@ -1,0 +1,32 @@
+/// <reference path="babel-core.d.ts" />
+import * as babel from "babel-core";
+
+
+// Example from https://github.com/babel/babel/tree/master/packages/babel-core
+const code = `class Example {}`;
+const result = babel.transform(code, { /* options */ });
+result.code; // Generated code
+result.map; // Sourcemap
+result.ast; // AST
+
+
+// Examples from http://babeljs.io/docs/usage/api/
+let options: babel.TransformOptions = {
+    plugins: [
+        "es2015-arrow-functions",
+        "es2015-block-scoped-functions",
+        "es2015-block-scoping",
+        "es2015-classes",
+    ],
+    only: /.*\.js/,
+    ast: false,
+    sourceMaps: true
+};
+
+babel.transformFile("filename.js", options, function (err, result) {
+    result.code;
+    result.map;
+    result.ast;
+});
+
+babel.transformFileSync("filename.js", options).code;

--- a/babel-core/babel-core.d.ts
+++ b/babel-core/babel-core.d.ts
@@ -21,7 +21,7 @@ declare module "babel-core" {
     export function transform(code: string, opts?: TransformOptions): BabelFileResult;
 
     /** Asynchronously transforms the entire contents of a file. */
-    export function transformFile(filename: string, opts: TransformOptions | undefined, callback: (err, result: BabelFileResult) => void): void;
+    export function transformFile(filename: string, opts: TransformOptions, callback: (err: any, result: BabelFileResult) => void): void;
 
     /** Synchronous version of `babel.transformFile`. Returns the transformed contents of the `filename`. */
     export function transformFileSync(filename: string, opts?: TransformOptions): BabelFileResult;
@@ -139,6 +139,6 @@ declare module "babel-core" {
     export interface BabelFileResult {
         ast?: Node;
         code?: string;
-        map?: Object | null;
+        map?: Object;
     }
 }

--- a/babel-core/babel-core.d.ts
+++ b/babel-core/babel-core.d.ts
@@ -1,0 +1,144 @@
+// Type definitions for babel-core v6.7
+// Project: https://github.com/babel/babel/tree/master/packages/babel-core
+// Definitions by: Troy Gerwien <https://github.com/yortus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../babel-template/babel-template.d.ts" />
+/// <reference path="../babel-traverse/babel-traverse.d.ts" />
+/// <reference path="../babel-types/babel-types.d.ts" />
+
+declare module "babel-core" {
+    import * as t from 'babel-types';
+    export {t as types};
+    type Node = t.Node;
+    export import template = require('babel-template');
+    export var version: string;
+    import traverse, {Visitor} from "babel-traverse";
+    export {traverse, Visitor};
+
+
+    /** Transforms the passed in `code`. Returning an object with the generated code, source map, and AST. */
+    export function transform(code: string, opts?: TransformOptions): BabelFileResult;
+
+    /** Asynchronously transforms the entire contents of a file. */
+    export function transformFile(filename: string, opts: TransformOptions | undefined, callback: (err, result: BabelFileResult) => void): void;
+
+    /** Synchronous version of `babel.transformFile`. Returns the transformed contents of the `filename`. */
+    export function transformFileSync(filename: string, opts?: TransformOptions): BabelFileResult;
+
+    export function transformFromAst(ast: Node, code?: string, opts?: TransformOptions): BabelFileResult;
+
+    export interface TransformOptions {
+
+        /** Filename to use when reading from stdin - this will be used in source-maps, errors etc. Default: "unknown". */
+        filename?: string;
+
+        /** Filename relative to `sourceRoot`. */
+        filenameRelative?: string;
+
+        /** A source map object that the output source map will be based on. */
+        inputSourceMap?: Object;
+
+        /**
+         * This is an object of keys that represent different environments. For example, you may have:
+         * `{ env: { production: { / * specific options * / } } }`
+         * which will use those options when the enviroment variable `BABEL_ENV` is set to `"production"`.
+         * If `BABEL_ENV` isn't set then `NODE_ENV` will be used, if it's not set then it defaults to `"development"`.
+         */
+        env?: Object;
+
+        /** Retain line numbers - will result in really ugly code. Default: `false` */
+        retainLines?: boolean;
+
+        /** Enable/disable ANSI syntax highlighting of code frames. Default: `true`. */
+        highlightCode?: boolean;
+
+        /** List of presets (a set of plugins) to load and use. */
+        presets?: any[];
+
+        /** List of plugins to load and use. */
+        plugins?: any[];
+
+        /** list of glob paths to **not** compile. Opposite to the `only` option. */
+        ignore?: string[];
+
+        /**
+         * A glob, regex, or mixed array of both, matching paths to only compile. Can also be an array of arrays containing
+         * paths to explicitly match. When attempting to compile a non-matching file it's returned verbatim.
+         */
+        only?: string | RegExp | Array<string | RegExp>;
+
+        /** Enable code generation. Default: `true`. */
+        code?: boolean;
+
+        /** Include the AST in the returned object. Default: `true`. */
+        ast?: boolean;
+
+        /** A path to an .babelrc file to extend. */
+        extends?: string;
+
+        /** write comments to generated output. Default: `true`. */
+        comments?: boolean;
+
+        /**
+         * An optional callback that controls whether a comment should be output or not. Called as
+         * `shouldPrintComment(commentContents)`. **NOTE**: This overrides the `comments` option when used.
+         */
+        shouldPrintComment?: (comment: string) => boolean;
+
+        /**
+         * Do not include superfluous whitespace characters and line terminators. When set to `"auto"`, `compact` is set to
+         * `true` on input sizes of >100KB.
+         */
+        compact?: boolean | "auto";
+
+        /**
+         * If truthy, adds a `map` property to returned output. If set to `"inline"`, a comment with a `sourceMappingURL`
+         * directive is added to the bottom of the returned code. If set to `"both"` then a map property is returned as well
+         * as a source map comment appended.
+         */
+        sourceMaps?: boolean | "inline" | "both";
+
+        /** Set `file` on returned source map. */
+        sourceMapTarget?: string;
+
+        /** Set `sources[0]` on returned source map. */
+        sourceFileName?: string;
+
+        /** The root from which all sources are relative. */
+        sourceRoot?: string;
+
+        /** Specify whether or not to use `.babelrc` and `.babelignore` files. Default: `true`. */
+        babelrc?: boolean;
+
+        /** Attach a comment before all non-user injected code. */
+        auxiliaryCommentBefore?: string;
+
+        /** Attach a comment after all non-user injected code. */
+        auxiliaryCommentAfter?: string;
+
+        /**
+         * Specify a custom callback to generate a module id with. Called as `getModuleId(moduleName)`.
+         * If falsy value is returned then the generated module id is used.
+         */
+        getModuleId?: (moduleName: string) => string;
+
+        /** Optional prefix for the AMD module formatter that will be prepend to the filename on module definitions. */
+        moduleRoot?: string;
+
+        /**
+         * If truthy, insert an explicit id for modules. By default, all modules are anonymous.
+         * (Not available for `common` modules).
+         */
+        moduleIds?: boolean;
+
+        /** Specify a custom name for module ids. */
+        moduleId?: string;
+    }
+
+    export interface BabelFileResult {
+        ast?: Node;
+        code?: string;
+        map?: Object | null;
+    }
+}

--- a/babel-generator/babel-generator-tests.ts
+++ b/babel-generator/babel-generator-tests.ts
@@ -1,0 +1,27 @@
+/// <reference path="../babylon/babylon.d.ts" />
+/// <reference path="babel-generator.d.ts" />
+
+
+// Example from https://github.com/babel/babel/tree/master/packages/babel-generator
+import {parse} from 'babylon';
+import generate from 'babel-generator';
+
+const code = 'class Example {}';
+const ast = parse(code);
+
+ast.type;
+ast.loc.start;
+
+const output = generate(ast, { /* options */ }, code);
+
+
+// Example from https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#babel-generator
+let result = generate(ast, {
+    retainLines: false,
+    compact: "auto",
+    concise: false,
+    quotes: "double",
+    // ...
+}, code);
+result.code;
+result.map;

--- a/babel-generator/babel-generator.d.ts
+++ b/babel-generator/babel-generator.d.ts
@@ -96,7 +96,7 @@ declare module "babel-generator" {
     }
 
     export interface GeneratorResult {
-        map: Object | null | undefined;
+        map: Object;
         code: string;
     }
 }

--- a/babel-generator/babel-generator.d.ts
+++ b/babel-generator/babel-generator.d.ts
@@ -1,0 +1,102 @@
+// Type definitions for babel-generator v6.7
+// Project: https://github.com/babel/babel/tree/master/packages/babel-generator
+// Definitions by: Troy Gerwien <https://github.com/yortus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../babel-types/babel-types.d.ts" />
+
+declare module "babel-generator" {
+    import * as t from 'babel-types';
+    type Node = t.Node;
+
+    /**
+     * Turns an AST into code, maintaining sourcemaps, user preferences, and valid output.
+     * @param ast - the abstract syntax tree from which to generate output code.
+     * @param opts - used for specifying options for code generation.
+     * @param code - the original source code, used for source maps.
+     * @returns - an object containing the output code and source map.
+     */
+    export default function generate(ast: Node, opts?: GeneratorOptions, code?: string | {[filename: string]: string}): GeneratorResult;
+
+    export interface GeneratorOptions {
+
+        /**
+         * Optional string to add as a block comment at the start of the output file.
+        */
+        auxiliaryCommentBefore?: string;
+
+        /**
+         * Optional string to add as a block comment at the end of the output file.
+        */
+        auxiliaryCommentAfter?: string;
+
+        /**
+         * Function that takes a comment (as a string) and returns true if the comment should be included in the output.
+         * By default, comments are included if `opts.comments` is `true` or if `opts.minifed` is `false` and the comment
+         * contains `@preserve` or `@license`.
+         */
+        shouldPrintComment?: (comment: string) => boolean;
+
+        /**
+         * Attempt to use the same line numbers in the output code as in the source code (helps preserve stack traces).
+         * Defaults to `false`.
+         */
+        retainLines?: boolean;
+
+        /**
+         * Should comments be included in output? Defaults to `true`.
+         */
+        comments?: boolean;
+
+        /**
+         * Set to true to avoid adding whitespace for formatting. Defaults to the value of `opts.minified`.
+         */
+        compact?: boolean | 'auto';
+
+        /**
+         * Should the output be minified. Defaults to `false`.
+         */
+        minified?: boolean;
+
+        /**
+         * Set to true to reduce whitespace (but not as much as opts.compact). Defaults to `false`.
+         */
+        concise?: boolean;        
+
+        /**
+         * The type of quote to use in the output. If omitted, autodetects based on `ast.tokens`.
+         */
+        quotes?: 'single' | 'double';
+
+        /**
+         * Used in warning messages
+         */
+        filename?: string;        
+
+        /**
+         * Enable generating source maps. Defaults to `false`.
+         */
+        sourceMaps?: boolean;
+
+        /**
+         * The filename of the generated code that the source map will be associated with.
+         */
+        sourceMapTarget?: string;
+
+        /**
+         * A root for all relative URLs in the source map.
+         */
+        sourceRoot?: string;
+
+        /**
+         * The filename for the source code (i.e. the code in the `code` argument).
+         * This will only be used if `code` is a string.
+         */
+        sourceFileName?: string;
+    }
+
+    export interface GeneratorResult {
+        map: Object | null | undefined;
+        code: string;
+    }
+}

--- a/babel-template/babel-template-tests.ts
+++ b/babel-template/babel-template-tests.ts
@@ -1,0 +1,21 @@
+/// <reference path="babel-template.d.ts" />
+/// <reference path="../babel-generator/babel-generator.d.ts" />
+/// <reference path="../babel-types/babel-types.d.ts" />
+
+
+// Example from https://github.com/babel/babel/tree/master/packages/babel-template
+import template = require('babel-template');
+import generate from 'babel-generator';
+import * as t from 'babel-types';
+
+const buildRequire = template(`
+    var IMPORT_NAME = require(SOURCE);
+`);
+
+const ast = buildRequire({
+    IMPORT_NAME: t.identifier('myModule'),
+    SOURCE: t.stringLiteral('my-module')
+});
+
+console.log(generate(ast).code);
+// var myModule = require('my-module');

--- a/babel-template/babel-template.d.ts
+++ b/babel-template/babel-template.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for babel-template v6.7
+// Project: https://github.com/babel/babel/tree/master/packages/babel-template
+// Definitions by: Troy Gerwien <https://github.com/yortus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../babylon/babylon.d.ts" />
+/// <reference path="../babel-types/babel-types.d.ts" />
+
+declare module "babel-template" {
+    import {BabylonOptions} from 'babylon';
+    import * as t from 'babel-types';
+    type Node = t.Node;
+
+    // NB: This export doesn't match the handbook example, where `template` is the default export.
+    // But it does match the runtime behaviour (at least at the time of this writing). For some reason,
+    // babel-template/lib/index.js has this line at the bottom: module.exports = exports["default"];
+    export = template;
+    function template(code: string, opts?: BabylonOptions): UseTemplate;
+
+    type UseTemplate = (nodes?: {[placeholder: string]: Node}) => Node;
+}

--- a/babel-traverse/babel-traverse-tests.ts
+++ b/babel-traverse/babel-traverse-tests.ts
@@ -1,0 +1,111 @@
+/// <reference path="babel-traverse.d.ts" />
+/// <reference path="../babel-types/babel-types.d.ts" />
+/// <reference path="../babylon/babylon.d.ts" />
+
+
+import * as babylon from "babylon";
+import traverse, {Visitor} from 'babel-traverse';
+import * as t from 'babel-types';
+
+
+// Examples from: https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md
+const MyVisitor: Visitor = {
+    Identifier: {
+        enter() {
+            console.log("Entered!");
+        },
+        exit() {
+            console.log("Exited!");
+        }
+    }
+};
+
+const MyVisitor2: Visitor = {
+    Identifier(path) {
+        console.log("Visiting: " + path.node.name);
+    }
+};
+
+
+// Example from https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#babel-traverse
+const code = `function square(n) {
+    return n * n;
+}`;
+
+const ast = babylon.parse(code);
+
+traverse(ast, {
+    enter(path) {
+        let node = path.node;
+        if (t.isIdentifier(node) && node.name === "n") {
+            node.name = "x";
+        }
+    }
+});
+
+
+// Examples from https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#writing-your-first-babel-plugin
+
+const v1: Visitor = {
+
+    BinaryExpression(path) {
+        if (t.isIdentifier(path.node.left)) {
+            // ...
+        }
+        path.replaceWith(
+            t.binaryExpression("**", path.node.left, t.numericLiteral(2))
+        );
+        path.parentPath.replaceWith(
+            t.expressionStatement(t.stringLiteral("Anyway the wind blows, doesn't really matter to me, to me."))
+        );
+        path.parentPath.remove();
+    },
+
+    Identifier(path) {
+        if (path.isReferencedIdentifier()) {
+            // ...
+        }
+        if (t.isReferenced(path.node, path.parent)) {
+            // ...
+        }
+    },
+
+    ReturnStatement(path) {
+        path.replaceWithMultiple([
+            t.expressionStatement(t.stringLiteral("Is this the real life?")),
+            t.expressionStatement(t.stringLiteral("Is this just fantasy?")),
+            t.expressionStatement(t.stringLiteral("(Enjoy singing the rest of the song in your head)")),
+        ]);
+    },
+
+    FunctionDeclaration(path, state) {
+        path.replaceWithSourceString(`function add(a, b) {
+            return a + b;
+        }`);
+
+        path.insertBefore(t.expressionStatement(t.stringLiteral("Because I'm easy come, easy go.")));
+        path.insertAfter(t.expressionStatement(t.stringLiteral("A little high, little low.")));
+        path.remove();
+
+        if (path.scope.hasBinding("n")) {
+            // ...
+        }
+        if (path.scope.hasOwnBinding("n")) {
+            // ...
+        }
+
+        let id1 = path.scope.generateUidIdentifier("uid");
+        id1.type;
+        id1.name;
+        let id2 = path.scope.generateUidIdentifier("uid");
+        id2.type;
+        id2.name;
+
+        const id = path.scope.generateUidIdentifierBasedOnNode(path.node.id);
+        path.remove();
+        path.scope.parent.push({ id, init: path.node });
+
+        path.scope.rename("n", "x");
+        path.scope.rename("n");
+    }
+};

--- a/babel-traverse/babel-traverse.d.ts
+++ b/babel-traverse/babel-traverse.d.ts
@@ -70,7 +70,7 @@ declare module "babel-traverse" {
 
         registerBinding(kind: string, path: NodePath<Node>, bindingPath?: NodePath<Node>): void;
 
-        addGlobal(node: Node);
+        addGlobal(node: Node): void;
 
         hasUid(name: string): boolean;
 
@@ -326,19 +326,19 @@ declare module "babel-traverse" {
         shouldStop: boolean;
         removed: boolean;
         state: any;
-        opts: Object | null | undefined;
-        skipKeys: Object | null | undefined;
-        parentPath: NodePath<Node> | null | undefined;
+        opts: Object;
+        skipKeys: Object;
+        parentPath: NodePath<Node>;
         context: TraversalContext;
-        container: Object | Object[] | null | undefined;
-        listKey: string | null | undefined;
+        container: Object | Object[];
+        listKey: string;
         inList: boolean;
-        parentKey: string | null | undefined;
-        key: string | null | undefined;
-        node: T | null | undefined;
+        parentKey: string;
+        key: string;
+        node: T;
         scope: Scope;
-        type: string | null | undefined;
-        typeAnnotation: Object | null | undefined;
+        type: string;
+        typeAnnotation: Object;
 
         getScope(scope: Scope): Scope;
 
@@ -354,7 +354,7 @@ declare module "babel-traverse" {
 
         getPathLocation(): string;
 
-        debug(buildMessage: Function);
+        debug(buildMessage: Function): void;
 
         // ------------------------- ancestry -------------------------
         /**
@@ -400,7 +400,7 @@ declare module "babel-traverse" {
 
         couldBeBaseType(name: string): boolean;
 
-        baseTypeStrictlyMatches(right: NodePath<Node>);
+        baseTypeStrictlyMatches(right: NodePath<Node>): boolean;
 
         isGenericType(genericName: string): boolean;
 
@@ -952,7 +952,7 @@ declare module "babel-traverse" {
     }
 
     export class Hub {
-        constructor(file, options);
+        constructor(file: any, options: any);
         file: any;
         options: any;
     }

--- a/babel-traverse/babel-traverse.d.ts
+++ b/babel-traverse/babel-traverse.d.ts
@@ -1,0 +1,966 @@
+// Type definitions for babel-traverse v6.7
+// Project: https://github.com/babel/babel/tree/master/packages/babel-traverse
+// Definitions by: Troy Gerwien <https://github.com/yortus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../babel-types/babel-types.d.ts" />
+
+declare module "babel-traverse" {
+    import * as t from 'babel-types';
+    type Node = t.Node;
+
+    export default function traverse(parent: Node | Node[], opts?: TraverseOptions, scope?: Scope, state?: any, parentPath?: NodePath<Node>): void;
+
+    export interface TraverseOptions extends Visitor {
+        scope?: Scope;
+        noScope?: boolean;
+    }
+
+    export class Scope {
+        constructor(path: NodePath<Node>, parentScope?: Scope);
+        path: NodePath<Node>;
+        block: Node;
+        parentBlock: Node;
+        parent: Scope;
+        hub: Hub;
+        bindings: { [name: string]: Binding; };
+
+        /** Traverse node with current scope and path. */
+        traverse(node: Node | Node[], opts?: TraverseOptions, state?: any): void;
+
+        /** Generate a unique identifier and add it to the current scope. */
+        generateDeclaredUidIdentifier(name?: string): t.Identifier;
+
+        /** Generate a unique identifier. */
+        generateUidIdentifier(name?: string): t.Identifier;
+
+        /** Generate a unique `_id1` binding. */
+        generateUid(name?: string): string;
+
+        /** Generate a unique identifier based on a node. */
+        generateUidIdentifierBasedOnNode(parent: Node, defaultName?: string): t.Identifier;
+
+        /**
+         * Determine whether evaluating the specific input `node` is a consequenceless reference. ie.
+         * evaluating it wont result in potentially arbitrary code from being ran. The following are
+         * whitelisted and determined not to cause side effects:
+         *
+         *  - `this` expressions
+         *  - `super` expressions
+         *  - Bound identifiers
+         */
+        isStatic(node: Node): boolean;
+
+        /** Possibly generate a memoised identifier if it is not static and has consequences. */
+        maybeGenerateMemoised(node: Node, dontPush?: boolean): t.Identifier;
+
+        checkBlockScopedCollisions(local: Node, kind: string, name: string, id: Object): void;
+
+        rename(oldName: string, newName?: string, block?: Node): void;
+
+        dump(): void;
+
+        toArray(node: Node, i?: number): Node;
+
+        registerDeclaration(path: NodePath<Node>): void;
+
+        buildUndefinedNode(): Node;
+
+        registerConstantViolation(path: NodePath<Node>): void;
+
+        registerBinding(kind: string, path: NodePath<Node>, bindingPath?: NodePath<Node>): void;
+
+        addGlobal(node: Node);
+
+        hasUid(name: string): boolean;
+
+        hasGlobal(name: string): boolean;
+
+        hasReference(name: string): boolean;
+
+        isPure(node: Node, constantsOnly?: boolean): boolean;
+
+        setData(key: string, val: any): any;
+
+        getData(key: string): any;
+
+        removeData(key: string): void;
+
+        push(opts: any): void;
+
+        getProgramParent(): Scope;
+
+        getFunctionParent(): Scope;
+
+        getBlockParent(): Scope;
+
+        /** Walks the scope tree and gathers **all** bindings. */
+        getAllBindings(...kinds: string[]): Object;
+
+        bindingIdentifierEquals(name: string, node: Node): boolean;
+
+        getBinding(name: string): Binding;
+
+        getOwnBinding(name: string): Binding;
+
+        getBindingIdentifier(name: string): t.Identifier;
+
+        getOwnBindingIdentifier(name: string): t.Identifier;
+
+        hasOwnBinding(name: string): boolean;
+
+        hasBinding(name: string, noGlobals?: boolean): boolean;
+
+        parentHasBinding(name: string, noGlobals?: boolean): boolean;
+
+        /** Move a binding of `name` to another `scope`. */
+        moveBindingTo(name: string, scope: Scope): void;
+
+        removeOwnBinding(name: string): void;
+
+        removeBinding(name: string): void;
+    }
+
+    export class Binding {
+        constructor(opts: { existing: Binding; identifier: t.Identifier; scope: Scope; path: NodePath<Node>; kind: 'var' | 'let' | 'const'; });
+        identifier: t.Identifier;
+        scope: Scope;
+        path: NodePath<Node>;
+        kind: 'var' | 'let' | 'const';
+        referenced: boolean;
+        references: number;
+        referencePaths: NodePath<Node>[];
+        constant: boolean;
+        constantViolations: NodePath<Node>[];
+    }
+
+    export interface Visitor extends VisitNodeObject<Node> {
+        ArrayExpression?: VisitNode<t.ArrayExpression>;
+        AssignmentExpression?: VisitNode<t.AssignmentExpression>;
+        LVal?: VisitNode<t.LVal>;
+        Expression?: VisitNode<t.Expression>;
+        BinaryExpression?: VisitNode<t.BinaryExpression>;
+        Directive?: VisitNode<t.Directive>;
+        DirectiveLiteral?: VisitNode<t.DirectiveLiteral>;
+        BlockStatement?: VisitNode<t.BlockStatement>;
+        BreakStatement?: VisitNode<t.BreakStatement>;
+        Identifier?: VisitNode<t.Identifier>;
+        CallExpression?: VisitNode<t.CallExpression>;
+        CatchClause?: VisitNode<t.CatchClause>;
+        ConditionalExpression?: VisitNode<t.ConditionalExpression>;
+        ContinueStatement?: VisitNode<t.ContinueStatement>;
+        DebuggerStatement?: VisitNode<t.DebuggerStatement>;
+        DoWhileStatement?: VisitNode<t.DoWhileStatement>;
+        Statement?: VisitNode<t.Statement>;
+        EmptyStatement?: VisitNode<t.EmptyStatement>;
+        ExpressionStatement?: VisitNode<t.ExpressionStatement>;
+        File?: VisitNode<t.File>;
+        Program?: VisitNode<t.Program>;
+        ForInStatement?: VisitNode<t.ForInStatement>;
+        VariableDeclaration?: VisitNode<t.VariableDeclaration>;
+        ForStatement?: VisitNode<t.ForStatement>;
+        FunctionDeclaration?: VisitNode<t.FunctionDeclaration>;
+        FunctionExpression?: VisitNode<t.FunctionExpression>;
+        IfStatement?: VisitNode<t.IfStatement>;
+        LabeledStatement?: VisitNode<t.LabeledStatement>;
+        StringLiteral?: VisitNode<t.StringLiteral>;
+        NumericLiteral?: VisitNode<t.NumericLiteral>;
+        NullLiteral?: VisitNode<t.NullLiteral>;
+        BooleanLiteral?: VisitNode<t.BooleanLiteral>;
+        RegExpLiteral?: VisitNode<t.RegExpLiteral>;
+        LogicalExpression?: VisitNode<t.LogicalExpression>;
+        MemberExpression?: VisitNode<t.MemberExpression>;
+        NewExpression?: VisitNode<t.NewExpression>;
+        ObjectExpression?: VisitNode<t.ObjectExpression>;
+        ObjectMethod?: VisitNode<t.ObjectMethod>;
+        ObjectProperty?: VisitNode<t.ObjectProperty>;
+        RestElement?: VisitNode<t.RestElement>;
+        ReturnStatement?: VisitNode<t.ReturnStatement>;
+        SequenceExpression?: VisitNode<t.SequenceExpression>;
+        SwitchCase?: VisitNode<t.SwitchCase>;
+        SwitchStatement?: VisitNode<t.SwitchStatement>;
+        ThisExpression?: VisitNode<t.ThisExpression>;
+        ThrowStatement?: VisitNode<t.ThrowStatement>;
+        TryStatement?: VisitNode<t.TryStatement>;
+        UnaryExpression?: VisitNode<t.UnaryExpression>;
+        UpdateExpression?: VisitNode<t.UpdateExpression>;
+        VariableDeclarator?: VisitNode<t.VariableDeclarator>;
+        WhileStatement?: VisitNode<t.WhileStatement>;
+        WithStatement?: VisitNode<t.WithStatement>;
+        AssignmentPattern?: VisitNode<t.AssignmentPattern>;
+        ArrayPattern?: VisitNode<t.ArrayPattern>;
+        ArrowFunctionExpression?: VisitNode<t.ArrowFunctionExpression>;
+        ClassBody?: VisitNode<t.ClassBody>;
+        ClassDeclaration?: VisitNode<t.ClassDeclaration>;
+        ClassExpression?: VisitNode<t.ClassExpression>;
+        ExportAllDeclaration?: VisitNode<t.ExportAllDeclaration>;
+        ExportDefaultDeclaration?: VisitNode<t.ExportDefaultDeclaration>;
+        ExportNamedDeclaration?: VisitNode<t.ExportNamedDeclaration>;
+        Declaration?: VisitNode<t.Declaration>;
+        ExportSpecifier?: VisitNode<t.ExportSpecifier>;
+        ForOfStatement?: VisitNode<t.ForOfStatement>;
+        ImportDeclaration?: VisitNode<t.ImportDeclaration>;
+        ImportDefaultSpecifier?: VisitNode<t.ImportDefaultSpecifier>;
+        ImportNamespaceSpecifier?: VisitNode<t.ImportNamespaceSpecifier>;
+        ImportSpecifier?: VisitNode<t.ImportSpecifier>;
+        MetaProperty?: VisitNode<t.MetaProperty>;
+        ClassMethod?: VisitNode<t.ClassMethod>;
+        ObjectPattern?: VisitNode<t.ObjectPattern>;
+        SpreadElement?: VisitNode<t.SpreadElement>;
+        Super?: VisitNode<t.Super>;
+        TaggedTemplateExpression?: VisitNode<t.TaggedTemplateExpression>;
+        TemplateLiteral?: VisitNode<t.TemplateLiteral>;
+        TemplateElement?: VisitNode<t.TemplateElement>;
+        YieldExpression?: VisitNode<t.YieldExpression>;
+        AnyTypeAnnotation?: VisitNode<t.AnyTypeAnnotation>;
+        ArrayTypeAnnotation?: VisitNode<t.ArrayTypeAnnotation>;
+        BooleanTypeAnnotation?: VisitNode<t.BooleanTypeAnnotation>;
+        BooleanLiteralTypeAnnotation?: VisitNode<t.BooleanLiteralTypeAnnotation>;
+        NullLiteralTypeAnnotation?: VisitNode<t.NullLiteralTypeAnnotation>;
+        ClassImplements?: VisitNode<t.ClassImplements>;
+        ClassProperty?: VisitNode<t.ClassProperty>;
+        DeclareClass?: VisitNode<t.DeclareClass>;
+        DeclareFunction?: VisitNode<t.DeclareFunction>;
+        DeclareInterface?: VisitNode<t.DeclareInterface>;
+        DeclareModule?: VisitNode<t.DeclareModule>;
+        DeclareTypeAlias?: VisitNode<t.DeclareTypeAlias>;
+        DeclareVariable?: VisitNode<t.DeclareVariable>;
+        ExistentialTypeParam?: VisitNode<t.ExistentialTypeParam>;
+        FunctionTypeAnnotation?: VisitNode<t.FunctionTypeAnnotation>;
+        FunctionTypeParam?: VisitNode<t.FunctionTypeParam>;
+        GenericTypeAnnotation?: VisitNode<t.GenericTypeAnnotation>;
+        InterfaceExtends?: VisitNode<t.InterfaceExtends>;
+        InterfaceDeclaration?: VisitNode<t.InterfaceDeclaration>;
+        IntersectionTypeAnnotation?: VisitNode<t.IntersectionTypeAnnotation>;
+        MixedTypeAnnotation?: VisitNode<t.MixedTypeAnnotation>;
+        NullableTypeAnnotation?: VisitNode<t.NullableTypeAnnotation>;
+        NumericLiteralTypeAnnotation?: VisitNode<t.NumericLiteralTypeAnnotation>;
+        NumberTypeAnnotation?: VisitNode<t.NumberTypeAnnotation>;
+        StringLiteralTypeAnnotation?: VisitNode<t.StringLiteralTypeAnnotation>;
+        StringTypeAnnotation?: VisitNode<t.StringTypeAnnotation>;
+        ThisTypeAnnotation?: VisitNode<t.ThisTypeAnnotation>;
+        TupleTypeAnnotation?: VisitNode<t.TupleTypeAnnotation>;
+        TypeofTypeAnnotation?: VisitNode<t.TypeofTypeAnnotation>;
+        TypeAlias?: VisitNode<t.TypeAlias>;
+        TypeAnnotation?: VisitNode<t.TypeAnnotation>;
+        TypeCastExpression?: VisitNode<t.TypeCastExpression>;
+        TypeParameterDeclaration?: VisitNode<t.TypeParameterDeclaration>;
+        TypeParameterInstantiation?: VisitNode<t.TypeParameterInstantiation>;
+        ObjectTypeAnnotation?: VisitNode<t.ObjectTypeAnnotation>;
+        ObjectTypeCallProperty?: VisitNode<t.ObjectTypeCallProperty>;
+        ObjectTypeIndexer?: VisitNode<t.ObjectTypeIndexer>;
+        ObjectTypeProperty?: VisitNode<t.ObjectTypeProperty>;
+        QualifiedTypeIdentifier?: VisitNode<t.QualifiedTypeIdentifier>;
+        UnionTypeAnnotation?: VisitNode<t.UnionTypeAnnotation>;
+        VoidTypeAnnotation?: VisitNode<t.VoidTypeAnnotation>;
+        JSXAttribute?: VisitNode<t.JSXAttribute>;
+        JSXIdentifier?: VisitNode<t.JSXIdentifier>;
+        JSXNamespacedName?: VisitNode<t.JSXNamespacedName>;
+        JSXElement?: VisitNode<t.JSXElement>;
+        JSXExpressionContainer?: VisitNode<t.JSXExpressionContainer>;
+        JSXClosingElement?: VisitNode<t.JSXClosingElement>;
+        JSXMemberExpression?: VisitNode<t.JSXMemberExpression>;
+        JSXOpeningElement?: VisitNode<t.JSXOpeningElement>;
+        JSXEmptyExpression?: VisitNode<t.JSXEmptyExpression>;
+        JSXSpreadAttribute?: VisitNode<t.JSXSpreadAttribute>;
+        JSXText?: VisitNode<t.JSXText>;
+        Noop?: VisitNode<t.Noop>;
+        ParenthesizedExpression?: VisitNode<t.ParenthesizedExpression>;
+        AwaitExpression?: VisitNode<t.AwaitExpression>;
+        BindExpression?: VisitNode<t.BindExpression>;
+        Decorator?: VisitNode<t.Decorator>;
+        DoExpression?: VisitNode<t.DoExpression>;
+        ExportDefaultSpecifier?: VisitNode<t.ExportDefaultSpecifier>;
+        ExportNamespaceSpecifier?: VisitNode<t.ExportNamespaceSpecifier>;
+        RestProperty?: VisitNode<t.RestProperty>;
+        SpreadProperty?: VisitNode<t.SpreadProperty>;
+        Binary?: VisitNode<t.Binary>;
+        Scopable?: VisitNode<t.Scopable>;
+        BlockParent?: VisitNode<t.BlockParent>;
+        Block?: VisitNode<t.Block>;
+        Terminatorless?: VisitNode<t.Terminatorless>;
+        CompletionStatement?: VisitNode<t.CompletionStatement>;
+        Conditional?: VisitNode<t.Conditional>;
+        Loop?: VisitNode<t.Loop>;
+        While?: VisitNode<t.While>;
+        ExpressionWrapper?: VisitNode<t.ExpressionWrapper>;
+        For?: VisitNode<t.For>;
+        ForXStatement?: VisitNode<t.ForXStatement>;
+        Function?: VisitNode<t.Function>;
+        FunctionParent?: VisitNode<t.FunctionParent>;
+        Pureish?: VisitNode<t.Pureish>;
+        Literal?: VisitNode<t.Literal>;
+        Immutable?: VisitNode<t.Immutable>;
+        UserWhitespacable?: VisitNode<t.UserWhitespacable>;
+        Method?: VisitNode<t.Method>;
+        ObjectMember?: VisitNode<t.ObjectMember>;
+        Property?: VisitNode<t.Property>;
+        UnaryLike?: VisitNode<t.UnaryLike>;
+        Pattern?: VisitNode<t.Pattern>;
+        Class?: VisitNode<t.Class>;
+        ModuleDeclaration?: VisitNode<t.ModuleDeclaration>;
+        ExportDeclaration?: VisitNode<t.ExportDeclaration>;
+        ModuleSpecifier?: VisitNode<t.ModuleSpecifier>;
+        Flow?: VisitNode<t.Flow>;
+        FlowBaseAnnotation?: VisitNode<t.FlowBaseAnnotation>;
+        FlowDeclaration?: VisitNode<t.FlowDeclaration>;
+        JSX?: VisitNode<t.JSX>;
+    }
+
+    export type VisitNode<T> = VisitNodeFunction<T> | VisitNodeObject<T>;
+
+    export type VisitNodeFunction<T> = (path: NodePath<T>, state: any) => void;
+
+    export interface VisitNodeObject<T> {
+        enter?(path: NodePath<T>, state: any): void;
+        exit?(path: NodePath<T>, state: any): void;
+    }
+
+    export class NodePath<T> {
+        constructor(hub: Hub, parent: Node);
+        parent: Node;
+        hub: Hub;
+        contexts: TraversalContext[];
+        data: Object;
+        shouldSkip: boolean;
+        shouldStop: boolean;
+        removed: boolean;
+        state: any;
+        opts: Object | null | undefined;
+        skipKeys: Object | null | undefined;
+        parentPath: NodePath<Node> | null | undefined;
+        context: TraversalContext;
+        container: Object | Object[] | null | undefined;
+        listKey: string | null | undefined;
+        inList: boolean;
+        parentKey: string | null | undefined;
+        key: string | null | undefined;
+        node: T | null | undefined;
+        scope: Scope;
+        type: string | null | undefined;
+        typeAnnotation: Object | null | undefined;
+
+        getScope(scope: Scope): Scope;
+
+        setData(key: string, val: any): any;
+
+        getData(key: string, def?: any): any;
+
+        buildCodeFrameError(msg: string, Error: Error): Error;
+
+        traverse(visitor: Visitor, state?: any): void;
+
+        set(key: string, node: Node): void;
+
+        getPathLocation(): string;
+
+        debug(buildMessage: Function);
+
+        // ------------------------- ancestry -------------------------
+        /**
+         * Call the provided `callback` with the `NodePath`s of all the parents.
+         * When the `callback` returns a truthy value, we return that node path.
+         */
+        findParent(callback: (path: NodePath<Node>) => boolean): NodePath<Node>;
+
+        find(callback: (path: NodePath<Node>) => boolean): NodePath<Node>;
+
+        /** Get the parent function of the current path. */
+        getFunctionParent(): NodePath<Node>;
+
+        /** Walk up the tree until we hit a parent node path in a list. */
+        getStatementParent(): NodePath<Node>;
+
+        /**
+         * Get the deepest common ancestor and then from it, get the earliest relationship path
+         * to that ancestor.
+         *
+         * Earliest is defined as being "before" all the other nodes in terms of list container
+         * position and visiting key.
+         */
+        getEarliestCommonAncestorFrom(paths: NodePath<Node>[]): NodePath<Node>;
+
+        /** Get the earliest path in the tree where the provided `paths` intersect. */
+        getDeepestCommonAncestorFrom(paths: NodePath<Node>[], filter?: Function): NodePath<Node>;        
+
+        /**
+         * Build an array of node paths containing the entire ancestry of the current node path.
+         *
+         * NOTE: The current node path is included in this.
+         */
+        getAncestry(): NodePath<Node>[];
+
+        inType(...candidateTypes: string[]): boolean;
+
+        // ------------------------- inference -------------------------
+        /** Infer the type of the current `NodePath`. */
+        getTypeAnnotation(): t.FlowTypeAnnotation;
+
+        isBaseType(baseName: string, soft?: boolean): boolean;
+
+        couldBeBaseType(name: string): boolean;
+
+        baseTypeStrictlyMatches(right: NodePath<Node>);
+
+        isGenericType(genericName: string): boolean;
+
+        // ------------------------- replacement -------------------------
+        /**
+         * Replace a node with an array of multiple. This method performs the following steps:
+         *
+         *  - Inherit the comments of first provided node with that of the current node.
+         *  - Insert the provided nodes after the current node.
+         *  - Remove the current node.
+         */
+        replaceWithMultiple(nodes: Node[]): void;
+
+        /**
+         * Parse a string as an expression and replace the current node with the result.
+         *
+         * NOTE: This is typically not a good idea to use. Building source strings when
+         * transforming ASTs is an antipattern and SHOULD NOT be encouraged. Even if it's
+         * easier to use, your transforms will be extremely brittle.
+         */
+        replaceWithSourceString(replacement: any): void;
+
+        /** Replace the current node with another. */
+        replaceWith(replacement: Node | NodePath<Node>): void;
+
+        /**
+         * This method takes an array of statements nodes and then explodes it
+         * into expressions. This method retains completion records which is
+         * extremely important to retain original semantics.
+         */
+        replaceExpressionWithStatements(nodes: Node[]): Node;
+
+        replaceInline(nodes: Node | Node[]): void;
+
+        // ------------------------- evaluation -------------------------
+        /**
+         * Walk the input `node` and statically evaluate if it's truthy.
+         *
+         * Returning `true` when we're sure that the expression will evaluate to a
+         * truthy value, `false` if we're sure that it will evaluate to a falsy
+         * value and `undefined` if we aren't sure. Because of this please do not
+         * rely on coercion when using this method and check with === if it's false.
+         */
+        evaluateTruthy(): boolean;
+
+        /**
+         * Walk the input `node` and statically evaluate it.
+         *
+         * Returns an object in the form `{ confident, value }`. `confident` indicates
+         * whether or not we had to drop out of evaluating the expression because of
+         * hitting an unknown node that we couldn't confidently find the value of.
+         *
+         * Example:
+         *
+         *   t.evaluate(parse("5 + 5")) // { confident: true, value: 10 }
+         *   t.evaluate(parse("!true")) // { confident: true, value: false }
+         *   t.evaluate(parse("foo + foo")) // { confident: false, value: undefined }
+         */
+        evaluate(): { confident: boolean; value: any };
+
+        // ------------------------- introspection -------------------------
+        /**
+         * Match the current node if it matches the provided `pattern`.
+         *
+         * For example, given the match `React.createClass` it would match the
+         * parsed nodes of `React.createClass` and `React["createClass"]`.
+         */
+        matchesPattern(pattern: string, allowPartial?: boolean): boolean;
+
+        /**
+         * Check whether we have the input `key`. If the `key` references an array then we check
+         * if the array has any items, otherwise we just check if it's falsy.
+         */
+        has(key: string): boolean;
+
+        isStatic(): boolean;
+
+        /** Alias of `has`. */
+        is(key: string): boolean;
+
+        /** Opposite of `has`. */
+        isnt(key: string): boolean;
+
+        /** Check whether the path node `key` strict equals `value`. */
+        equals(key: string, value: any): boolean;
+
+        /**
+         * Check the type against our stored internal type of the node. This is handy when a node has
+         * been removed yet we still internally know the type and need it to calculate node replacement.
+         */
+        isNodeType(type: string): boolean;
+
+        /**
+         * This checks whether or not we're in one of the following positions:
+         *
+         *   for (KEY in right);
+         *   for (KEY;;);
+         *
+         * This is because these spots allow VariableDeclarations AND normal expressions so we need
+         * to tell the path replacement that it's ok to replace this with an expression.
+         */
+        canHaveVariableDeclarationOrExpression(): boolean;
+
+        /**
+         * This checks whether we are swapping an arrow function's body between an
+         * expression and a block statement (or vice versa).
+         *
+         * This is because arrow functions may implicitly return an expression, which
+         * is the same as containing a block statement.
+         */
+        canSwapBetweenExpressionAndStatement(replacement: Node): boolean;
+
+        /** Check whether the current path references a completion record */
+        isCompletionRecord(allowInsideFunction?: boolean): boolean;
+
+        /**
+         * Check whether or not the current `key` allows either a single statement or block statement
+         * so we can explode it if necessary.
+         */
+        isStatementOrBlock(): boolean;
+
+        /** Check if the currently assigned path references the `importName` of `moduleSource`. */
+        referencesImport(moduleSource: string, importName: string): boolean;
+
+        /** Get the source code associated with this node. */
+        getSource(): string;
+
+        // ------------------------- context -------------------------
+        call(key: string): boolean;
+
+        isBlacklisted(): boolean;
+
+        visit(): boolean;
+
+        skip(): void;
+
+        skipKey(key: string): void;
+
+        stop(): void;
+
+        setScope(): void;
+
+        setContext(context: TraversalContext): NodePath<T>;
+
+        popContext(): void;
+
+        pushContext(context: TraversalContext): void;
+
+        // ------------------------- removal -------------------------
+        remove(): void;
+
+        // ------------------------- modification -------------------------
+        /** Insert the provided nodes before the current one. */
+        insertBefore(nodes: Node | Node[]): any;
+
+        /**
+         * Insert the provided nodes after the current one. When inserting nodes after an
+         * expression, ensure that the completion record is correct by pushing the current node.
+         */
+        insertAfter(nodes: Node | Node[]): any;
+
+        /** Update all sibling node paths after `fromIndex` by `incrementBy`. */
+        updateSiblingKeys(fromIndex: number, incrementBy: number): void;
+
+        /** Hoist the current node to the highest scope possible and return a UID referencing it. */
+        hoist(scope: Scope): void;
+
+        // ------------------------- family -------------------------
+        getStatementParent(): NodePath<Node>;
+
+        getOpposite(): NodePath<Node>;
+
+        getCompletionRecords(): NodePath<Node>[];
+
+        getSibling(key: string): NodePath<Node>;
+
+        get(key: string, context?: boolean | TraversalContext): NodePath<Node>;
+
+        getBindingIdentifiers(duplicates?: boolean): Node[];
+
+        getOuterBindingIdentifiers(duplicates?: boolean): Node[];
+
+        // ------------------------- comments -------------------------
+        /** Share comments amongst siblings. */
+        shareCommentsWithSiblings(): void;
+
+        addComment(type: string, content: string, line?: boolean): void;
+
+        /** Give node `comments` of the specified `type`. */
+        addComments(type: string, comments: any[]): void;
+
+        // ------------------------- isXXX -------------------------
+        isArrayExpression(opts?: Object): boolean;
+        isAssignmentExpression(opts?: Object): boolean;
+        isBinaryExpression(opts?: Object): boolean;
+        isDirective(opts?: Object): boolean;
+        isDirectiveLiteral(opts?: Object): boolean;
+        isBlockStatement(opts?: Object): boolean;
+        isBreakStatement(opts?: Object): boolean;
+        isCallExpression(opts?: Object): boolean;
+        isCatchClause(opts?: Object): boolean;
+        isConditionalExpression(opts?: Object): boolean;
+        isContinueStatement(opts?: Object): boolean;
+        isDebuggerStatement(opts?: Object): boolean;
+        isDoWhileStatement(opts?: Object): boolean;
+        isEmptyStatement(opts?: Object): boolean;
+        isExpressionStatement(opts?: Object): boolean;
+        isFile(opts?: Object): boolean;
+        isForInStatement(opts?: Object): boolean;
+        isForStatement(opts?: Object): boolean;
+        isFunctionDeclaration(opts?: Object): boolean;
+        isFunctionExpression(opts?: Object): boolean;
+        isIdentifier(opts?: Object): boolean;
+        isIfStatement(opts?: Object): boolean;
+        isLabeledStatement(opts?: Object): boolean;
+        isStringLiteral(opts?: Object): boolean;
+        isNumericLiteral(opts?: Object): boolean;
+        isNullLiteral(opts?: Object): boolean;
+        isBooleanLiteral(opts?: Object): boolean;
+        isRegExpLiteral(opts?: Object): boolean;
+        isLogicalExpression(opts?: Object): boolean;
+        isMemberExpression(opts?: Object): boolean;
+        isNewExpression(opts?: Object): boolean;
+        isProgram(opts?: Object): boolean;
+        isObjectExpression(opts?: Object): boolean;
+        isObjectMethod(opts?: Object): boolean;
+        isObjectProperty(opts?: Object): boolean;
+        isRestElement(opts?: Object): boolean;
+        isReturnStatement(opts?: Object): boolean;
+        isSequenceExpression(opts?: Object): boolean;
+        isSwitchCase(opts?: Object): boolean;
+        isSwitchStatement(opts?: Object): boolean;
+        isThisExpression(opts?: Object): boolean;
+        isThrowStatement(opts?: Object): boolean;
+        isTryStatement(opts?: Object): boolean;
+        isUnaryExpression(opts?: Object): boolean;
+        isUpdateExpression(opts?: Object): boolean;
+        isVariableDeclaration(opts?: Object): boolean;
+        isVariableDeclarator(opts?: Object): boolean;
+        isWhileStatement(opts?: Object): boolean;
+        isWithStatement(opts?: Object): boolean;
+        isAssignmentPattern(opts?: Object): boolean;
+        isArrayPattern(opts?: Object): boolean;
+        isArrowFunctionExpression(opts?: Object): boolean;
+        isClassBody(opts?: Object): boolean;
+        isClassDeclaration(opts?: Object): boolean;
+        isClassExpression(opts?: Object): boolean;
+        isExportAllDeclaration(opts?: Object): boolean;
+        isExportDefaultDeclaration(opts?: Object): boolean;
+        isExportNamedDeclaration(opts?: Object): boolean;
+        isExportSpecifier(opts?: Object): boolean;
+        isForOfStatement(opts?: Object): boolean;
+        isImportDeclaration(opts?: Object): boolean;
+        isImportDefaultSpecifier(opts?: Object): boolean;
+        isImportNamespaceSpecifier(opts?: Object): boolean;
+        isImportSpecifier(opts?: Object): boolean;
+        isMetaProperty(opts?: Object): boolean;
+        isClassMethod(opts?: Object): boolean;
+        isObjectPattern(opts?: Object): boolean;
+        isSpreadElement(opts?: Object): boolean;
+        isSuper(opts?: Object): boolean;
+        isTaggedTemplateExpression(opts?: Object): boolean;
+        isTemplateElement(opts?: Object): boolean;
+        isTemplateLiteral(opts?: Object): boolean;
+        isYieldExpression(opts?: Object): boolean;
+        isAnyTypeAnnotation(opts?: Object): boolean;
+        isArrayTypeAnnotation(opts?: Object): boolean;
+        isBooleanTypeAnnotation(opts?: Object): boolean;
+        isBooleanLiteralTypeAnnotation(opts?: Object): boolean;
+        isNullLiteralTypeAnnotation(opts?: Object): boolean;
+        isClassImplements(opts?: Object): boolean;
+        isClassProperty(opts?: Object): boolean;
+        isDeclareClass(opts?: Object): boolean;
+        isDeclareFunction(opts?: Object): boolean;
+        isDeclareInterface(opts?: Object): boolean;
+        isDeclareModule(opts?: Object): boolean;
+        isDeclareTypeAlias(opts?: Object): boolean;
+        isDeclareVariable(opts?: Object): boolean;
+        isExistentialTypeParam(opts?: Object): boolean;
+        isFunctionTypeAnnotation(opts?: Object): boolean;
+        isFunctionTypeParam(opts?: Object): boolean;
+        isGenericTypeAnnotation(opts?: Object): boolean;
+        isInterfaceExtends(opts?: Object): boolean;
+        isInterfaceDeclaration(opts?: Object): boolean;
+        isIntersectionTypeAnnotation(opts?: Object): boolean;
+        isMixedTypeAnnotation(opts?: Object): boolean;
+        isNullableTypeAnnotation(opts?: Object): boolean;
+        isNumericLiteralTypeAnnotation(opts?: Object): boolean;
+        isNumberTypeAnnotation(opts?: Object): boolean;
+        isStringLiteralTypeAnnotation(opts?: Object): boolean;
+        isStringTypeAnnotation(opts?: Object): boolean;
+        isThisTypeAnnotation(opts?: Object): boolean;
+        isTupleTypeAnnotation(opts?: Object): boolean;
+        isTypeofTypeAnnotation(opts?: Object): boolean;
+        isTypeAlias(opts?: Object): boolean;
+        isTypeAnnotation(opts?: Object): boolean;
+        isTypeCastExpression(opts?: Object): boolean;
+        isTypeParameterDeclaration(opts?: Object): boolean;
+        isTypeParameterInstantiation(opts?: Object): boolean;
+        isObjectTypeAnnotation(opts?: Object): boolean;
+        isObjectTypeCallProperty(opts?: Object): boolean;
+        isObjectTypeIndexer(opts?: Object): boolean;
+        isObjectTypeProperty(opts?: Object): boolean;
+        isQualifiedTypeIdentifier(opts?: Object): boolean;
+        isUnionTypeAnnotation(opts?: Object): boolean;
+        isVoidTypeAnnotation(opts?: Object): boolean;
+        isJSXAttribute(opts?: Object): boolean;
+        isJSXClosingElement(opts?: Object): boolean;
+        isJSXElement(opts?: Object): boolean;
+        isJSXEmptyExpression(opts?: Object): boolean;
+        isJSXExpressionContainer(opts?: Object): boolean;
+        isJSXIdentifier(opts?: Object): boolean;
+        isJSXMemberExpression(opts?: Object): boolean;
+        isJSXNamespacedName(opts?: Object): boolean;
+        isJSXOpeningElement(opts?: Object): boolean;
+        isJSXSpreadAttribute(opts?: Object): boolean;
+        isJSXText(opts?: Object): boolean;
+        isNoop(opts?: Object): boolean;
+        isParenthesizedExpression(opts?: Object): boolean;
+        isAwaitExpression(opts?: Object): boolean;
+        isBindExpression(opts?: Object): boolean;
+        isDecorator(opts?: Object): boolean;
+        isDoExpression(opts?: Object): boolean;
+        isExportDefaultSpecifier(opts?: Object): boolean;
+        isExportNamespaceSpecifier(opts?: Object): boolean;
+        isRestProperty(opts?: Object): boolean;
+        isSpreadProperty(opts?: Object): boolean;
+        isExpression(opts?: Object): boolean;
+        isBinary(opts?: Object): boolean;
+        isScopable(opts?: Object): boolean;
+        isBlockParent(opts?: Object): boolean;
+        isBlock(opts?: Object): boolean;
+        isStatement(opts?: Object): boolean;
+        isTerminatorless(opts?: Object): boolean;
+        isCompletionStatement(opts?: Object): boolean;
+        isConditional(opts?: Object): boolean;
+        isLoop(opts?: Object): boolean;
+        isWhile(opts?: Object): boolean;
+        isExpressionWrapper(opts?: Object): boolean;
+        isFor(opts?: Object): boolean;
+        isForXStatement(opts?: Object): boolean;
+        isFunction(opts?: Object): boolean;
+        isFunctionParent(opts?: Object): boolean;
+        isPureish(opts?: Object): boolean;
+        isDeclaration(opts?: Object): boolean;
+        isLVal(opts?: Object): boolean;
+        isLiteral(opts?: Object): boolean;
+        isImmutable(opts?: Object): boolean;
+        isUserWhitespacable(opts?: Object): boolean;
+        isMethod(opts?: Object): boolean;
+        isObjectMember(opts?: Object): boolean;
+        isProperty(opts?: Object): boolean;
+        isUnaryLike(opts?: Object): boolean;
+        isPattern(opts?: Object): boolean;
+        isClass(opts?: Object): boolean;
+        isModuleDeclaration(opts?: Object): boolean;
+        isExportDeclaration(opts?: Object): boolean;
+        isModuleSpecifier(opts?: Object): boolean;
+        isFlow(opts?: Object): boolean;
+        isFlowBaseAnnotation(opts?: Object): boolean;
+        isFlowDeclaration(opts?: Object): boolean;
+        isJSX(opts?: Object): boolean;
+        isNumberLiteral(opts?: Object): boolean;
+        isRegexLiteral(opts?: Object): boolean;
+        isReferencedIdentifier(opts?: Object): boolean;
+        isReferencedMemberExpression(opts?: Object): boolean;
+        isBindingIdentifier(opts?: Object): boolean;
+        isScope(opts?: Object): boolean;
+        isReferenced(opts?: Object): boolean;
+        isBlockScoped(opts?: Object): boolean;
+        isVar(opts?: Object): boolean;
+        isUser(opts?: Object): boolean;
+        isGenerated(opts?: Object): boolean;
+        isPure(opts?: Object): boolean;
+
+        // ------------------------- assertXXX -------------------------
+        assertArrayExpression(opts?: Object): void;
+        assertAssignmentExpression(opts?: Object): void;
+        assertBinaryExpression(opts?: Object): void;
+        assertDirective(opts?: Object): void;
+        assertDirectiveLiteral(opts?: Object): void;
+        assertBlockStatement(opts?: Object): void;
+        assertBreakStatement(opts?: Object): void;
+        assertCallExpression(opts?: Object): void;
+        assertCatchClause(opts?: Object): void;
+        assertConditionalExpression(opts?: Object): void;
+        assertContinueStatement(opts?: Object): void;
+        assertDebuggerStatement(opts?: Object): void;
+        assertDoWhileStatement(opts?: Object): void;
+        assertEmptyStatement(opts?: Object): void;
+        assertExpressionStatement(opts?: Object): void;
+        assertFile(opts?: Object): void;
+        assertForInStatement(opts?: Object): void;
+        assertForStatement(opts?: Object): void;
+        assertFunctionDeclaration(opts?: Object): void;
+        assertFunctionExpression(opts?: Object): void;
+        assertIdentifier(opts?: Object): void;
+        assertIfStatement(opts?: Object): void;
+        assertLabeledStatement(opts?: Object): void;
+        assertStringLiteral(opts?: Object): void;
+        assertNumericLiteral(opts?: Object): void;
+        assertNullLiteral(opts?: Object): void;
+        assertBooleanLiteral(opts?: Object): void;
+        assertRegExpLiteral(opts?: Object): void;
+        assertLogicalExpression(opts?: Object): void;
+        assertMemberExpression(opts?: Object): void;
+        assertNewExpression(opts?: Object): void;
+        assertProgram(opts?: Object): void;
+        assertObjectExpression(opts?: Object): void;
+        assertObjectMethod(opts?: Object): void;
+        assertObjectProperty(opts?: Object): void;
+        assertRestElement(opts?: Object): void;
+        assertReturnStatement(opts?: Object): void;
+        assertSequenceExpression(opts?: Object): void;
+        assertSwitchCase(opts?: Object): void;
+        assertSwitchStatement(opts?: Object): void;
+        assertThisExpression(opts?: Object): void;
+        assertThrowStatement(opts?: Object): void;
+        assertTryStatement(opts?: Object): void;
+        assertUnaryExpression(opts?: Object): void;
+        assertUpdateExpression(opts?: Object): void;
+        assertVariableDeclaration(opts?: Object): void;
+        assertVariableDeclarator(opts?: Object): void;
+        assertWhileStatement(opts?: Object): void;
+        assertWithStatement(opts?: Object): void;
+        assertAssignmentPattern(opts?: Object): void;
+        assertArrayPattern(opts?: Object): void;
+        assertArrowFunctionExpression(opts?: Object): void;
+        assertClassBody(opts?: Object): void;
+        assertClassDeclaration(opts?: Object): void;
+        assertClassExpression(opts?: Object): void;
+        assertExportAllDeclaration(opts?: Object): void;
+        assertExportDefaultDeclaration(opts?: Object): void;
+        assertExportNamedDeclaration(opts?: Object): void;
+        assertExportSpecifier(opts?: Object): void;
+        assertForOfStatement(opts?: Object): void;
+        assertImportDeclaration(opts?: Object): void;
+        assertImportDefaultSpecifier(opts?: Object): void;
+        assertImportNamespaceSpecifier(opts?: Object): void;
+        assertImportSpecifier(opts?: Object): void;
+        assertMetaProperty(opts?: Object): void;
+        assertClassMethod(opts?: Object): void;
+        assertObjectPattern(opts?: Object): void;
+        assertSpreadElement(opts?: Object): void;
+        assertSuper(opts?: Object): void;
+        assertTaggedTemplateExpression(opts?: Object): void;
+        assertTemplateElement(opts?: Object): void;
+        assertTemplateLiteral(opts?: Object): void;
+        assertYieldExpression(opts?: Object): void;
+        assertAnyTypeAnnotation(opts?: Object): void;
+        assertArrayTypeAnnotation(opts?: Object): void;
+        assertBooleanTypeAnnotation(opts?: Object): void;
+        assertBooleanLiteralTypeAnnotation(opts?: Object): void;
+        assertNullLiteralTypeAnnotation(opts?: Object): void;
+        assertClassImplements(opts?: Object): void;
+        assertClassProperty(opts?: Object): void;
+        assertDeclareClass(opts?: Object): void;
+        assertDeclareFunction(opts?: Object): void;
+        assertDeclareInterface(opts?: Object): void;
+        assertDeclareModule(opts?: Object): void;
+        assertDeclareTypeAlias(opts?: Object): void;
+        assertDeclareVariable(opts?: Object): void;
+        assertExistentialTypeParam(opts?: Object): void;
+        assertFunctionTypeAnnotation(opts?: Object): void;
+        assertFunctionTypeParam(opts?: Object): void;
+        assertGenericTypeAnnotation(opts?: Object): void;
+        assertInterfaceExtends(opts?: Object): void;
+        assertInterfaceDeclaration(opts?: Object): void;
+        assertIntersectionTypeAnnotation(opts?: Object): void;
+        assertMixedTypeAnnotation(opts?: Object): void;
+        assertNullableTypeAnnotation(opts?: Object): void;
+        assertNumericLiteralTypeAnnotation(opts?: Object): void;
+        assertNumberTypeAnnotation(opts?: Object): void;
+        assertStringLiteralTypeAnnotation(opts?: Object): void;
+        assertStringTypeAnnotation(opts?: Object): void;
+        assertThisTypeAnnotation(opts?: Object): void;
+        assertTupleTypeAnnotation(opts?: Object): void;
+        assertTypeofTypeAnnotation(opts?: Object): void;
+        assertTypeAlias(opts?: Object): void;
+        assertTypeAnnotation(opts?: Object): void;
+        assertTypeCastExpression(opts?: Object): void;
+        assertTypeParameterDeclaration(opts?: Object): void;
+        assertTypeParameterInstantiation(opts?: Object): void;
+        assertObjectTypeAnnotation(opts?: Object): void;
+        assertObjectTypeCallProperty(opts?: Object): void;
+        assertObjectTypeIndexer(opts?: Object): void;
+        assertObjectTypeProperty(opts?: Object): void;
+        assertQualifiedTypeIdentifier(opts?: Object): void;
+        assertUnionTypeAnnotation(opts?: Object): void;
+        assertVoidTypeAnnotation(opts?: Object): void;
+        assertJSXAttribute(opts?: Object): void;
+        assertJSXClosingElement(opts?: Object): void;
+        assertJSXElement(opts?: Object): void;
+        assertJSXEmptyExpression(opts?: Object): void;
+        assertJSXExpressionContainer(opts?: Object): void;
+        assertJSXIdentifier(opts?: Object): void;
+        assertJSXMemberExpression(opts?: Object): void;
+        assertJSXNamespacedName(opts?: Object): void;
+        assertJSXOpeningElement(opts?: Object): void;
+        assertJSXSpreadAttribute(opts?: Object): void;
+        assertJSXText(opts?: Object): void;
+        assertNoop(opts?: Object): void;
+        assertParenthesizedExpression(opts?: Object): void;
+        assertAwaitExpression(opts?: Object): void;
+        assertBindExpression(opts?: Object): void;
+        assertDecorator(opts?: Object): void;
+        assertDoExpression(opts?: Object): void;
+        assertExportDefaultSpecifier(opts?: Object): void;
+        assertExportNamespaceSpecifier(opts?: Object): void;
+        assertRestProperty(opts?: Object): void;
+        assertSpreadProperty(opts?: Object): void;
+        assertExpression(opts?: Object): void;
+        assertBinary(opts?: Object): void;
+        assertScopable(opts?: Object): void;
+        assertBlockParent(opts?: Object): void;
+        assertBlock(opts?: Object): void;
+        assertStatement(opts?: Object): void;
+        assertTerminatorless(opts?: Object): void;
+        assertCompletionStatement(opts?: Object): void;
+        assertConditional(opts?: Object): void;
+        assertLoop(opts?: Object): void;
+        assertWhile(opts?: Object): void;
+        assertExpressionWrapper(opts?: Object): void;
+        assertFor(opts?: Object): void;
+        assertForXStatement(opts?: Object): void;
+        assertFunction(opts?: Object): void;
+        assertFunctionParent(opts?: Object): void;
+        assertPureish(opts?: Object): void;
+        assertDeclaration(opts?: Object): void;
+        assertLVal(opts?: Object): void;
+        assertLiteral(opts?: Object): void;
+        assertImmutable(opts?: Object): void;
+        assertUserWhitespacable(opts?: Object): void;
+        assertMethod(opts?: Object): void;
+        assertObjectMember(opts?: Object): void;
+        assertProperty(opts?: Object): void;
+        assertUnaryLike(opts?: Object): void;
+        assertPattern(opts?: Object): void;
+        assertClass(opts?: Object): void;
+        assertModuleDeclaration(opts?: Object): void;
+        assertExportDeclaration(opts?: Object): void;
+        assertModuleSpecifier(opts?: Object): void;
+        assertFlow(opts?: Object): void;
+        assertFlowBaseAnnotation(opts?: Object): void;
+        assertFlowDeclaration(opts?: Object): void;
+        assertJSX(opts?: Object): void;
+        assertNumberLiteral(opts?: Object): void;
+        assertRegexLiteral(opts?: Object): void;
+    }
+
+    export class Hub {
+        constructor(file, options);
+        file: any;
+        options: any;
+    }
+
+    interface TraversalContext {
+        parentPath: NodePath<Node>;
+        scope: Scope;
+        state: any;
+        opts: any;
+    }
+}

--- a/babel-types/babel-types-tests.ts
+++ b/babel-types/babel-types-tests.ts
@@ -10,8 +10,9 @@ let ast: t.Node;
 
 traverse(ast, {
     enter(path) {
-        if (t.isIdentifier(path.node, { name: "n" })) {
-            path.node.name = "x";
+        let node = path.node;
+        if (t.isIdentifier(node, { name: "n" })) {
+            node.name = "x";
         }
     }
 });

--- a/babel-types/babel-types-tests.ts
+++ b/babel-types/babel-types-tests.ts
@@ -1,0 +1,25 @@
+/// <reference path="babel-types.d.ts" />
+/// <reference path="../babel-traverse/babel-traverse.d.ts" />
+
+
+// Examples from https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#babel-types
+import traverse from "babel-traverse";
+import * as t from "babel-types";
+
+let ast: t.Node;
+
+traverse(ast, {
+    enter(path) {
+        if (t.isIdentifier(path.node, { name: "n" })) {
+            path.node.name = "x";
+        }
+    }
+});
+
+if (t.isBinaryExpression(ast)) {
+    ast.left;
+    ast.right;
+    ast.operator;
+}
+t.assertBinaryExpression(ast);
+t.assertBinaryExpression(ast, { operator: "*" });

--- a/babel-types/babel-types.d.ts
+++ b/babel-types/babel-types.d.ts
@@ -7,9 +7,9 @@ declare module "babel-types" {
 
     export interface Comment {
         value: string;
-        start: number | null;
-        end: number | null;
-        loc: SourceLocation | null;
+        start: number;
+        end: number;
+        loc: SourceLocation;
     }
 
     export interface CommentBlock extends Comment {
@@ -37,14 +37,14 @@ declare module "babel-types" {
         leadingComments?: Array<Comment>;
         innerComments?: Array<Comment>;
         trailingComments?: Array<Comment>;
-        start: number | null;
-        end: number | null;
-        loc: SourceLocation | null;
+        start: number;
+        end: number;
+        loc: SourceLocation;
     }
 
     export interface ArrayExpression extends Node {
         type: "ArrayExpression";
-        elements: Array<Expression | SpreadElement | null>;
+        elements: Array<Expression | SpreadElement>;
     }
 
     export interface AssignmentExpression extends Node {
@@ -79,7 +79,7 @@ declare module "babel-types" {
 
     export interface BreakStatement extends Node {
         type: "BreakStatement";
-        label: Identifier | null;
+        label: Identifier;
     }
 
     export interface CallExpression extends Node {
@@ -103,7 +103,7 @@ declare module "babel-types" {
 
     export interface ContinueStatement extends Node {
         type: "ContinueStatement";
-        label: Identifier | null;
+        label: Identifier;
     }
 
     export interface DebuggerStatement extends Node {
@@ -141,9 +141,9 @@ declare module "babel-types" {
 
     export interface ForStatement extends Node {
         type: "ForStatement";
-        init: VariableDeclaration | Expression | null;
-        test: Expression | null;
-        update: Expression | null;
+        init: VariableDeclaration | Expression;
+        test: Expression;
+        update: Expression;
         body: Statement;
     }
 
@@ -160,7 +160,7 @@ declare module "babel-types" {
 
     export interface FunctionExpression extends Node {
         type: "FunctionExpression";
-        id: Identifier | null;
+        id: Identifier;
         params: Pattern[];
         body: BlockStatement;
         generator: boolean;
@@ -179,7 +179,7 @@ declare module "babel-types" {
         type: "IfStatement";
         test: Expression;
         consequent: Statement;
-        alternate: Statement | null;
+        alternate: Statement;
     }
 
     export interface LabeledStatement extends Node {
@@ -253,7 +253,7 @@ declare module "babel-types" {
         computed: boolean;
         value: Expression;
         decorators?: Decorator[];
-        id: Identifier | null;
+        id: Identifier;
         params: Pattern[];
         body: BlockStatement;
         generator: boolean;
@@ -279,7 +279,7 @@ declare module "babel-types" {
 
     export interface ReturnStatement extends Node {
         type: "ReturnStatement";
-        argument: Expression | null;
+        argument: Expression;
     }
 
     export interface SequenceExpression extends Node {
@@ -289,7 +289,7 @@ declare module "babel-types" {
 
     export interface SwitchCase extends Node {
         type: "SwitchCase";
-        test: Expression | null;
+        test: Expression;
         consequent: Statement[];
     }
 
@@ -311,8 +311,8 @@ declare module "babel-types" {
     export interface TryStatement extends Node {
         type: "TryStatement";
         block: BlockStatement;
-        handler: CatchClause | null;
-        finalizer: BlockStatement | null;
+        handler: CatchClause;
+        finalizer: BlockStatement;
     }
 
     export interface UnaryExpression extends Node {
@@ -338,7 +338,7 @@ declare module "babel-types" {
     export interface VariableDeclarator extends Node {
         type: "VariableDeclarator";
         id: LVal;
-        init: Expression | null;
+        init: Expression;
     }
 
     export interface WhileStatement extends Node {
@@ -361,13 +361,13 @@ declare module "babel-types" {
 
     export interface ArrayPattern extends Node {
         type: "ArrayPattern";
-        elements: Array<Pattern | null>;
+        elements: Array<Pattern>;
         typeAnnotation?: TypeAnnotation;
     }
 
     export interface ArrowFunctionExpression extends Node {
         type: "ArrowFunctionExpression";
-        id: Identifier | null;
+        id: Identifier;
         params: Pattern[];
         body: BlockStatement | Expression;
         generator: boolean;
@@ -385,7 +385,7 @@ declare module "babel-types" {
     export interface ClassDeclaration extends Node {
         type: "ClassDeclaration";
         id: Identifier;
-        superClass: Expression | null;
+        superClass: Expression;
         body: ClassBody;
         decorators?: Decorator[];
         implements?: ClassImplements[];
@@ -396,8 +396,8 @@ declare module "babel-types" {
 
     export interface ClassExpression extends Node {
         type: "ClassExpression";
-        id: Identifier | null;
-        superClass: Expression | null;
+        id: Identifier;
+        superClass: Expression;
         body: ClassBody;
         decorators?: Decorator[];
         implements?: ClassImplements[];
@@ -418,9 +418,9 @@ declare module "babel-types" {
 
     export interface ExportNamedDeclaration extends Node {
         type: "ExportNamedDeclaration";
-        declaration: Declaration | null;
+        declaration: Declaration;
         specifiers: ExportSpecifier[];
-        source: StringLiteral | null;
+        source: StringLiteral;
     }
 
     export interface ExportSpecifier extends Node {
@@ -473,7 +473,7 @@ declare module "babel-types" {
         computed: boolean;
         static: boolean;
         decorators?: Decorator[];
-        id: Identifier | null;
+        id: Identifier;
         params: Pattern[];
         body: BlockStatement;
         generator: boolean;
@@ -531,7 +531,7 @@ declare module "babel-types" {
 
     export interface YieldExpression extends Node {
         type: "YieldExpression";
-        argument: Expression | null;
+        argument: Expression;
         delegate: boolean;
     }
 
@@ -559,7 +559,7 @@ declare module "babel-types" {
     export interface ClassImplements extends Node {
         type: "ClassImplements";
         id: Identifier;
-        typeParameters: TypeParameterInstantiation | null;
+        typeParameters: TypeParameterInstantiation;
     }
 
     export interface ClassProperty extends Node {
@@ -573,7 +573,7 @@ declare module "babel-types" {
     export interface DeclareClass extends Node {
         type: "DeclareClass";
         id: Identifier;
-        typeParameters: TypeParameterDeclaration | null;
+        typeParameters: TypeParameterDeclaration;
         extends: InterfaceExtends[];
         body: ObjectTypeAnnotation;
     }
@@ -586,7 +586,7 @@ declare module "babel-types" {
     export interface DeclareInterface extends Node {
         type: "DeclareInterface";
         id: Identifier;
-        typeParameters: TypeParameterDeclaration | null;
+        typeParameters: TypeParameterDeclaration;
         extends: InterfaceExtends[];
         body: ObjectTypeAnnotation;
     }
@@ -600,7 +600,7 @@ declare module "babel-types" {
     export interface DeclareTypeAlias extends Node {
         type: "DeclareTypeAlias";
         id: Identifier;
-        typeParameters: TypeParameterDeclaration | null;
+        typeParameters: TypeParameterDeclaration;
         right: FlowTypeAnnotation;
     }
 
@@ -617,7 +617,7 @@ declare module "babel-types" {
         type: "FunctionTypeAnnotation";
         typeParameters: TypeParameterDeclaration;
         params: FunctionTypeParam[];
-        rest: FunctionTypeParam | null;
+        rest: FunctionTypeParam;
         returnType: FlowTypeAnnotation;
     }
 
@@ -630,19 +630,19 @@ declare module "babel-types" {
     export interface GenericTypeAnnotation extends Node {
         type: "GenericTypeAnnotation";
         id: Identifier;
-        typeParameters: TypeParameterInstantiation | null;
+        typeParameters: TypeParameterInstantiation;
     }
 
     export interface InterfaceExtends extends Node {
         type: "InterfaceExtends";
         id: Identifier;
-        typeParameters: TypeParameterInstantiation | null;
+        typeParameters: TypeParameterInstantiation;
     }
 
     export interface InterfaceDeclaration extends Node {
         type: "InterfaceDeclaration";
         id: Identifier;
-        typeParameters: TypeParameterDeclaration | null;
+        typeParameters: TypeParameterDeclaration;
         extends: InterfaceExtends[];
         mixins?: any[];
         body: ObjectTypeAnnotation;
@@ -695,7 +695,7 @@ declare module "babel-types" {
     export interface TypeAlias extends Node {
         type: "TypeAlias";
         id: Identifier;
-        typeParameters: TypeParameterDeclaration | null;
+        typeParameters: TypeParameterDeclaration;
         right: FlowTypeAnnotation;
     }
 
@@ -763,7 +763,7 @@ declare module "babel-types" {
     export interface JSXAttribute extends Node {
         type: "JSXAttribute";
         name: JSXIdentifier | JSXNamespacedName;
-        value: JSXElement | StringLiteral | JSXExpressionContainer | null;
+        value: JSXElement | StringLiteral | JSXExpressionContainer;
     }
 
     export interface JSXClosingElement extends Node {
@@ -774,7 +774,7 @@ declare module "babel-types" {
     export interface JSXElement extends Node {
         type: "JSXElement";
         openingElement: JSXOpeningElement;
-        closingElement: JSXClosingElement | null;
+        closingElement: JSXClosingElement;
         children: Array<JSXElement | JSXExpressionContainer | JSXText>;
         selfClosing?: boolean;
     }
@@ -833,12 +833,12 @@ declare module "babel-types" {
 
     export interface AwaitExpression extends Node {
         type: "AwaitExpression";
-        argument: Expression | null;
+        argument: Expression;
     }
 
     export interface BindExpression extends Node {
         type: "BindExpression";
-        object: Expression | null;
+        object: Expression;
         callee: Expression;
     }
 
@@ -872,7 +872,7 @@ declare module "babel-types" {
         argument: Expression;
     }
 
-    export type Expression = ArrayExpression | AssignmentExpression | BinaryExpression | CallExpression | ConditionalExpression | FunctionExpression | Identifier | StringLiteral | NumericLiteral | NullLiteral | BooleanLiteral | RegExpLiteral | LogicalExpression | MemberExpression | NewExpression | ObjectExpression | SequenceExpression | ThisExpression | UnaryExpression | UpdateExpression | ArrowFunctionExpression | ClassExpression | MetaProperty | Super | TaggedTemplateExpression | TemplateLiteral | YieldExpression | TypeCastExpression | JSXElement | JSXEmptyExpression | JSXIdentifier | JSXMemberExpression | ParenthesizedExpression | AwaitExpression | BindExpression | DoExpression;
+    export type Expression = ArrayExpression | AssignmentExpression | BinaryExpression | CallExpression | ConditionalExpression | FunctionExpression | Identifier | StringLiteral | NumericLiteral | BooleanLiteral | RegExpLiteral | LogicalExpression | MemberExpression | NewExpression | ObjectExpression | SequenceExpression | ThisExpression | UnaryExpression | UpdateExpression | ArrowFunctionExpression | ClassExpression | MetaProperty | Super | TaggedTemplateExpression | TemplateLiteral | YieldExpression | TypeCastExpression | JSXElement | JSXEmptyExpression | JSXIdentifier | JSXMemberExpression | ParenthesizedExpression | AwaitExpression | BindExpression | DoExpression;
     export type Binary = BinaryExpression | LogicalExpression;
     export type Scopable = BlockStatement | CatchClause | DoWhileStatement | ForInStatement | ForStatement | FunctionDeclaration | FunctionExpression | Program | ObjectMethod | SwitchStatement | WhileStatement | ArrowFunctionExpression | ClassDeclaration | ClassExpression | ForOfStatement | ClassMethod;
     export type BlockParent = BlockStatement | DoWhileStatement | ForInStatement | ForStatement | FunctionDeclaration | FunctionExpression | Program | ObjectMethod | SwitchStatement | WhileStatement | ArrowFunctionExpression | ForOfStatement | ClassMethod;
@@ -888,11 +888,11 @@ declare module "babel-types" {
     export type ForXStatement = ForInStatement | ForOfStatement;
     export type Function = FunctionDeclaration | FunctionExpression | ObjectMethod | ArrowFunctionExpression | ClassMethod;
     export type FunctionParent = FunctionDeclaration | FunctionExpression | Program | ObjectMethod | ArrowFunctionExpression | ClassMethod;
-    export type Pureish = FunctionDeclaration | FunctionExpression | StringLiteral | NumericLiteral | NullLiteral | BooleanLiteral | ArrowFunctionExpression | ClassDeclaration | ClassExpression;
+    export type Pureish = FunctionDeclaration | FunctionExpression | StringLiteral | NumericLiteral | BooleanLiteral | ArrowFunctionExpression | ClassDeclaration | ClassExpression;
     export type Declaration = FunctionDeclaration | VariableDeclaration | ClassDeclaration | ExportAllDeclaration | ExportDefaultDeclaration | ExportNamedDeclaration | ImportDeclaration | DeclareClass | DeclareFunction | DeclareInterface | DeclareModule | DeclareTypeAlias | DeclareVariable | InterfaceDeclaration | TypeAlias;
     export type LVal = Identifier | MemberExpression | RestElement | AssignmentPattern | ArrayPattern | ObjectPattern;
-    export type Literal = StringLiteral | NumericLiteral | NullLiteral | BooleanLiteral | RegExpLiteral | TemplateLiteral;
-    export type Immutable = StringLiteral | NumericLiteral | NullLiteral | BooleanLiteral | JSXAttribute | JSXClosingElement | JSXElement | JSXExpressionContainer | JSXOpeningElement;
+    export type Literal = StringLiteral | NumericLiteral | BooleanLiteral | RegExpLiteral | TemplateLiteral;
+    export type Immutable = StringLiteral | NumericLiteral | BooleanLiteral | JSXAttribute | JSXClosingElement | JSXElement | JSXExpressionContainer | JSXOpeningElement;
     export type UserWhitespacable = ObjectMethod | ObjectProperty | ObjectTypeCallProperty | ObjectTypeIndexer | ObjectTypeProperty;
     export type Method = ObjectMethod | ClassMethod;
     export type ObjectMember = ObjectMethod | ObjectProperty;
@@ -903,34 +903,34 @@ declare module "babel-types" {
     export type ModuleDeclaration = ExportAllDeclaration | ExportDefaultDeclaration | ExportNamedDeclaration | ImportDeclaration;
     export type ExportDeclaration = ExportAllDeclaration | ExportDefaultDeclaration | ExportNamedDeclaration;
     export type ModuleSpecifier = ExportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier | ImportSpecifier | ExportDefaultSpecifier | ExportNamespaceSpecifier;
-    export type Flow = AnyTypeAnnotation | ArrayTypeAnnotation | BooleanTypeAnnotation | BooleanLiteralTypeAnnotation | NullLiteralTypeAnnotation | ClassImplements | ClassProperty | DeclareClass | DeclareFunction | DeclareInterface | DeclareModule | DeclareTypeAlias | DeclareVariable | ExistentialTypeParam | FunctionTypeAnnotation | FunctionTypeParam | GenericTypeAnnotation | InterfaceExtends | InterfaceDeclaration | IntersectionTypeAnnotation | MixedTypeAnnotation | NullableTypeAnnotation | NumericLiteralTypeAnnotation | NumberTypeAnnotation | StringLiteralTypeAnnotation | StringTypeAnnotation | ThisTypeAnnotation | TupleTypeAnnotation | TypeofTypeAnnotation | TypeAlias | TypeAnnotation | TypeCastExpression | TypeParameterDeclaration | TypeParameterInstantiation | ObjectTypeAnnotation | ObjectTypeCallProperty | ObjectTypeIndexer | ObjectTypeProperty | QualifiedTypeIdentifier | UnionTypeAnnotation | VoidTypeAnnotation;
-    export type FlowTypeAnnotation = AnyTypeAnnotation | ArrayTypeAnnotation | BooleanTypeAnnotation | BooleanLiteralTypeAnnotation | NullLiteralTypeAnnotation | FunctionTypeAnnotation | GenericTypeAnnotation | IntersectionTypeAnnotation | MixedTypeAnnotation | NullableTypeAnnotation | NumericLiteralTypeAnnotation | NumberTypeAnnotation | StringLiteralTypeAnnotation | StringTypeAnnotation | ThisTypeAnnotation | TupleTypeAnnotation | TypeofTypeAnnotation | TypeAnnotation | ObjectTypeAnnotation | UnionTypeAnnotation | VoidTypeAnnotation;
-    export type FlowBaseAnnotation = AnyTypeAnnotation | BooleanTypeAnnotation | NullLiteralTypeAnnotation | MixedTypeAnnotation | NumberTypeAnnotation | StringTypeAnnotation | ThisTypeAnnotation | VoidTypeAnnotation;
+    export type Flow = AnyTypeAnnotation | ArrayTypeAnnotation | BooleanTypeAnnotation | BooleanLiteralTypeAnnotation | ClassImplements | ClassProperty | DeclareClass | DeclareFunction | DeclareInterface | DeclareModule | DeclareTypeAlias | DeclareVariable | ExistentialTypeParam | FunctionTypeAnnotation | FunctionTypeParam | GenericTypeAnnotation | InterfaceExtends | InterfaceDeclaration | IntersectionTypeAnnotation | MixedTypeAnnotation | NullableTypeAnnotation | NumericLiteralTypeAnnotation | NumberTypeAnnotation | StringLiteralTypeAnnotation | StringTypeAnnotation | ThisTypeAnnotation | TupleTypeAnnotation | TypeofTypeAnnotation | TypeAlias | TypeAnnotation | TypeCastExpression | TypeParameterDeclaration | TypeParameterInstantiation | ObjectTypeAnnotation | ObjectTypeCallProperty | ObjectTypeIndexer | ObjectTypeProperty | QualifiedTypeIdentifier | UnionTypeAnnotation | VoidTypeAnnotation;
+    export type FlowTypeAnnotation = AnyTypeAnnotation | ArrayTypeAnnotation | BooleanTypeAnnotation | BooleanLiteralTypeAnnotation | FunctionTypeAnnotation | GenericTypeAnnotation | IntersectionTypeAnnotation | MixedTypeAnnotation | NullableTypeAnnotation | NumericLiteralTypeAnnotation | NumberTypeAnnotation | StringLiteralTypeAnnotation | StringTypeAnnotation | ThisTypeAnnotation | TupleTypeAnnotation | TypeofTypeAnnotation | TypeAnnotation | ObjectTypeAnnotation | UnionTypeAnnotation | VoidTypeAnnotation;
+    export type FlowBaseAnnotation = AnyTypeAnnotation | BooleanTypeAnnotation | MixedTypeAnnotation | NumberTypeAnnotation | StringTypeAnnotation | ThisTypeAnnotation | VoidTypeAnnotation;
     export type FlowDeclaration = DeclareClass | DeclareFunction | DeclareInterface | DeclareModule | DeclareTypeAlias | DeclareVariable | InterfaceDeclaration | TypeAlias;
     export type JSX = JSXAttribute | JSXClosingElement | JSXElement | JSXEmptyExpression | JSXExpressionContainer | JSXIdentifier | JSXMemberExpression | JSXNamespacedName | JSXOpeningElement | JSXSpreadAttribute | JSXText;
 
-    export function arrayExpression(elements?: Array<Expression | SpreadElement | null>): ArrayExpression;
+    export function arrayExpression(elements?: Array<Expression | SpreadElement>): ArrayExpression;
     export function assignmentExpression(operator?: string, left?: LVal, right?: Expression): AssignmentExpression;
     export function binaryExpression(operator?: "+" | "-" | "/" | "%" | "*" | "**" | "&" | "|" | ">>" | ">>>" | "<<" | "^" | "==" | "===" | "!=" | "!==" | "in" | "instanceof" | ">" | "<" | ">=" | "<=", left?: Expression, right?: Expression): BinaryExpression;
     export function directive(value?: DirectiveLiteral): Directive;
     export function directiveLiteral(value?: string): DirectiveLiteral;
     export function blockStatement(body?: Statement[], directives?: Directive[]): BlockStatement;
-    export function breakStatement(label?: Identifier | null): BreakStatement;
+    export function breakStatement(label?: Identifier): BreakStatement;
     export function callExpression(callee?: Expression, _arguments?: Array<Expression | SpreadElement>): CallExpression;
     export function catchClause(param?: Identifier, body?: BlockStatement): CatchClause;
     export function conditionalExpression(test?: Expression, consequent?: Expression, alternate?: Expression): ConditionalExpression;
-    export function continueStatement(label?: Identifier | null): ContinueStatement;
+    export function continueStatement(label?: Identifier): ContinueStatement;
     export function debuggerStatement(): DebuggerStatement;
     export function doWhileStatement(test?: Expression, body?: Statement): DoWhileStatement;
     export function emptyStatement(): EmptyStatement;
     export function expressionStatement(expression?: Expression): ExpressionStatement;
     export function file(program?: Program, comments?: Comment[], tokens?: any[]): File;
     export function forInStatement(left?: VariableDeclaration | LVal, right?: Expression, body?: Statement): ForInStatement;
-    export function forStatement(init?: VariableDeclaration | Expression | null, test?: Expression | null, update?: Expression | null, body?: Statement): ForStatement;
+    export function forStatement(init?: VariableDeclaration | Expression, test?: Expression, update?: Expression, body?: Statement): ForStatement;
     export function functionDeclaration(id?: Identifier, params?: Pattern[], body?: BlockStatement, generator?: boolean, async?: boolean): FunctionDeclaration;
-    export function functionExpression(id?: Identifier | null, params?: Pattern[], body?: BlockStatement, generator?: boolean, async?: boolean): FunctionExpression;
+    export function functionExpression(id?: Identifier, params?: Pattern[], body?: BlockStatement, generator?: boolean, async?: boolean): FunctionExpression;
     export function identifier(name?: string): Identifier;
-    export function ifStatement(test?: Expression, consequent?: Statement, alternate?: Statement | null): IfStatement;
+    export function ifStatement(test?: Expression, consequent?: Statement, alternate?: Statement): IfStatement;
     export function labeledStatement(label?: Identifier, body?: Statement): LabeledStatement;
     export function stringLiteral(value?: string): StringLiteral;
     export function numericLiteral(value?: number): NumericLiteral;
@@ -945,28 +945,28 @@ declare module "babel-types" {
     export function objectMethod(kind?: "get" | "set" | "method", key?: Expression, params?: Pattern[], body?: BlockStatement, computed?: boolean): ObjectMethod;
     export function objectProperty(key?: Expression, value?: Expression, computed?: boolean, shorthand?: boolean, decorators?: Decorator[]): ObjectProperty;
     export function restElement(argument?: LVal, typeAnnotation?: TypeAnnotation): RestElement;
-    export function returnStatement(argument?: Expression | null): ReturnStatement;
+    export function returnStatement(argument?: Expression): ReturnStatement;
     export function sequenceExpression(expressions?: Expression[]): SequenceExpression;
-    export function switchCase(test?: Expression | null, consequent?: Statement[]): SwitchCase;
+    export function switchCase(test?: Expression, consequent?: Statement[]): SwitchCase;
     export function switchStatement(discriminant?: Expression, cases?: SwitchCase[]): SwitchStatement;
     export function thisExpression(): ThisExpression;
     export function throwStatement(argument?: Expression): ThrowStatement;
-    export function tryStatement(block?: BlockStatement, handler?: CatchClause | null, finalizer?: BlockStatement | null): TryStatement;
+    export function tryStatement(block?: BlockStatement, handler?: CatchClause, finalizer?: BlockStatement): TryStatement;
     export function unaryExpression(operator?: "void" | "delete" | "!" | "+" | "-" | "++" | "--" | "~" | "typeof", argument?: Expression, prefix?: boolean): UnaryExpression;
     export function updateExpression(operator?: "++" | "--", argument?: Expression, prefix?: boolean): UpdateExpression;
     export function variableDeclaration(kind?: "var" | "let" | "const", declarations?: VariableDeclarator[]): VariableDeclaration;
-    export function variableDeclarator(id?: LVal, init?: Expression | null): VariableDeclarator;
+    export function variableDeclarator(id?: LVal, init?: Expression): VariableDeclarator;
     export function whileStatement(test?: Expression, body?: BlockStatement | Statement): WhileStatement;
     export function withStatement(object?: Expression, body?: BlockStatement | Statement): WithStatement;
     export function assignmentPattern(left?: Identifier, right?: Expression): AssignmentPattern;
-    export function arrayPattern(elements?: Array<Pattern | null>, typeAnnotation?: TypeAnnotation): ArrayPattern;
+    export function arrayPattern(elements?: Array<Pattern>, typeAnnotation?: TypeAnnotation): ArrayPattern;
     export function arrowFunctionExpression(params?: Pattern[], body?: BlockStatement | Expression, async?: boolean): ArrowFunctionExpression;
     export function classBody(body?: Array<ClassMethod | ClassProperty>): ClassBody;
-    export function classDeclaration(id?: Identifier, superClass?: Expression | null, body?: ClassBody, decorators?: Decorator[]): ClassDeclaration;
-    export function classExpression(id?: Identifier, superClass?: Expression | null, body?: ClassBody, decorators?: Decorator[]): ClassExpression;
+    export function classDeclaration(id?: Identifier, superClass?: Expression, body?: ClassBody, decorators?: Decorator[]): ClassDeclaration;
+    export function classExpression(id?: Identifier, superClass?: Expression, body?: ClassBody, decorators?: Decorator[]): ClassExpression;
     export function exportAllDeclaration(source?: StringLiteral): ExportAllDeclaration;
     export function exportDefaultDeclaration(declaration?: FunctionDeclaration | ClassDeclaration | Expression): ExportDefaultDeclaration;
-    export function exportNamedDeclaration(declaration?: Declaration | null, specifiers?: ExportSpecifier[], source?: StringLiteral | null): ExportNamedDeclaration;
+    export function exportNamedDeclaration(declaration?: Declaration, specifiers?: ExportSpecifier[], source?: StringLiteral): ExportNamedDeclaration;
     export function exportSpecifier(local?: Identifier, exported?: Identifier): ExportSpecifier;
     export function forOfStatement(left?: VariableDeclaration | LVal, right?: Expression, body?: Statement): ForOfStatement;
     export function importDeclaration(specifiers?: Array<ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>, source?: StringLiteral): ImportDeclaration;
@@ -980,26 +980,26 @@ declare module "babel-types" {
     export function taggedTemplateExpression(tag?: Expression, quasi?: TemplateLiteral): TaggedTemplateExpression;
     export function templateElement(value?: {cooked?: string; raw?: string;}, tail?: boolean): TemplateElement;
     export function templateLiteral(quasis?: TemplateElement[], expressions?: Expression[]): TemplateLiteral;
-    export function yieldExpression(argument?: Expression | null, delegate?: boolean): YieldExpression;
+    export function yieldExpression(argument?: Expression, delegate?: boolean): YieldExpression;
     export function anyTypeAnnotation(): AnyTypeAnnotation;
     export function arrayTypeAnnotation(elementType?: FlowTypeAnnotation): ArrayTypeAnnotation;
     export function booleanTypeAnnotation(): BooleanTypeAnnotation;
     export function booleanLiteralTypeAnnotation(): BooleanLiteralTypeAnnotation;
     export function nullLiteralTypeAnnotation(): NullLiteralTypeAnnotation;
-    export function classImplements(id?: Identifier, typeParameters?: TypeParameterInstantiation | null): ClassImplements;
+    export function classImplements(id?: Identifier, typeParameters?: TypeParameterInstantiation): ClassImplements;
     export function classProperty(key?: Identifier, value?: Expression, typeAnnotation?: TypeAnnotation, decorators?: Decorator[]): ClassProperty;
-    export function declareClass(id?: Identifier, typeParameters?: TypeParameterDeclaration | null, _extends?: InterfaceExtends[], body?: ObjectTypeAnnotation): DeclareClass;
+    export function declareClass(id?: Identifier, typeParameters?: TypeParameterDeclaration, _extends?: InterfaceExtends[], body?: ObjectTypeAnnotation): DeclareClass;
     export function declareFunction(id?: Identifier): DeclareFunction;
-    export function declareInterface(id?: Identifier, typeParameters?: TypeParameterDeclaration | null, _extends?: InterfaceExtends[], body?: ObjectTypeAnnotation): DeclareInterface;
+    export function declareInterface(id?: Identifier, typeParameters?: TypeParameterDeclaration, _extends?: InterfaceExtends[], body?: ObjectTypeAnnotation): DeclareInterface;
     export function declareModule(id?: StringLiteral | Identifier, body?: BlockStatement): DeclareModule;
-    export function declareTypeAlias(id?: Identifier, typeParameters?: TypeParameterDeclaration | null, right?: FlowTypeAnnotation): DeclareTypeAlias;
+    export function declareTypeAlias(id?: Identifier, typeParameters?: TypeParameterDeclaration, right?: FlowTypeAnnotation): DeclareTypeAlias;
     export function declareVariable(id?: Identifier): DeclareVariable;
     export function existentialTypeParam(): ExistentialTypeParam;
-    export function functionTypeAnnotation(typeParameters?: TypeParameterDeclaration, params?: FunctionTypeParam[], rest?: FunctionTypeParam | null, returnType?: FlowTypeAnnotation): FunctionTypeAnnotation;
+    export function functionTypeAnnotation(typeParameters?: TypeParameterDeclaration, params?: FunctionTypeParam[], rest?: FunctionTypeParam, returnType?: FlowTypeAnnotation): FunctionTypeAnnotation;
     export function functionTypeParam(name?: Identifier, typeAnnotation?: FlowTypeAnnotation): FunctionTypeParam;
-    export function genericTypeAnnotation(id?: Identifier, typeParameters?: TypeParameterInstantiation | null): GenericTypeAnnotation;
-    export function interfaceExtends(id?: Identifier, typeParameters?: TypeParameterInstantiation | null): InterfaceExtends;
-    export function interfaceDeclaration(id?: Identifier, typeParameters?: TypeParameterDeclaration | null, _extends?: InterfaceExtends[], body?: ObjectTypeAnnotation): InterfaceDeclaration;
+    export function genericTypeAnnotation(id?: Identifier, typeParameters?: TypeParameterInstantiation): GenericTypeAnnotation;
+    export function interfaceExtends(id?: Identifier, typeParameters?: TypeParameterInstantiation): InterfaceExtends;
+    export function interfaceDeclaration(id?: Identifier, typeParameters?: TypeParameterDeclaration, _extends?: InterfaceExtends[], body?: ObjectTypeAnnotation): InterfaceDeclaration;
     export function intersectionTypeAnnotation(types?: FlowTypeAnnotation[]): IntersectionTypeAnnotation;
     export function mixedTypeAnnotation(): MixedTypeAnnotation;
     export function nullableTypeAnnotation(typeAnnotation?: FlowTypeAnnotation): NullableTypeAnnotation;
@@ -1010,7 +1010,7 @@ declare module "babel-types" {
     export function thisTypeAnnotation(): ThisTypeAnnotation;
     export function tupleTypeAnnotation(types?: FlowTypeAnnotation[]): TupleTypeAnnotation;
     export function typeofTypeAnnotation(argument?: FlowTypeAnnotation): TypeofTypeAnnotation;
-    export function typeAlias(id?: Identifier, typeParameters?: TypeParameterDeclaration | null, right?: FlowTypeAnnotation): TypeAlias;
+    export function typeAlias(id?: Identifier, typeParameters?: TypeParameterDeclaration, right?: FlowTypeAnnotation): TypeAlias;
     export function typeAnnotation(typeAnnotation?: FlowTypeAnnotation): TypeAnnotation;
     export function typeCastExpression(expression?: Expression, typeAnnotation?: FlowTypeAnnotation): TypeCastExpression;
     export function typeParameterDeclaration(params?: Identifier[]): TypeParameterDeclaration;
@@ -1022,9 +1022,9 @@ declare module "babel-types" {
     export function qualifiedTypeIdentifier(id?: Identifier, qualification?: Identifier | QualifiedTypeIdentifier): QualifiedTypeIdentifier;
     export function unionTypeAnnotation(types?: FlowTypeAnnotation[]): UnionTypeAnnotation;
     export function voidTypeAnnotation(): VoidTypeAnnotation;
-    export function jSXAttribute(name?: JSXIdentifier | JSXNamespacedName, value?: JSXElement | StringLiteral | JSXExpressionContainer | null): JSXAttribute;
+    export function jSXAttribute(name?: JSXIdentifier | JSXNamespacedName, value?: JSXElement | StringLiteral | JSXExpressionContainer): JSXAttribute;
     export function jSXClosingElement(name?: JSXIdentifier | JSXMemberExpression): JSXClosingElement;
-    export function jSXElement(openingElement?: JSXOpeningElement, closingElement?: JSXClosingElement | null, children?: Array<JSXElement | JSXExpressionContainer | JSXText>, selfClosing?: boolean): JSXElement;
+    export function jSXElement(openingElement?: JSXOpeningElement, closingElement?: JSXClosingElement, children?: Array<JSXElement | JSXExpressionContainer | JSXText>, selfClosing?: boolean): JSXElement;
     export function jSXEmptyExpression(): JSXEmptyExpression;
     export function jSXExpressionContainer(expression?: Expression): JSXExpressionContainer;
     export function jSXIdentifier(name?: string): JSXIdentifier;
@@ -1036,7 +1036,7 @@ declare module "babel-types" {
     export function noop(): Noop;
     export function parenthesizedExpression(expression?: Expression): ParenthesizedExpression;
     export function awaitExpression(argument?: Expression): AwaitExpression;
-    export function bindExpression(object?: Expression | null, callee?: Expression): BindExpression;
+    export function bindExpression(object?: Expression, callee?: Expression): BindExpression;
     export function decorator(expression?: Expression): Decorator;
     export function doExpression(body?: BlockStatement): DoExpression;
     export function exportDefaultSpecifier(exported?: Identifier): ExportDefaultSpecifier;

--- a/babel-types/babel-types.d.ts
+++ b/babel-types/babel-types.d.ts
@@ -1,0 +1,1403 @@
+// Type definitions for babel-types v6.7
+// Project: https://github.com/babel/babel/tree/master/packages/babel-types
+// Definitions by: Troy Gerwien <https://github.com/yortus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "babel-types" {
+
+    export interface Comment {
+        value: string;
+        start: number | null;
+        end: number | null;
+        loc: SourceLocation | null;
+    }
+
+    export interface CommentBlock extends Comment {
+        type: "CommentBlock";
+    }
+
+    export interface CommentLine extends Comment {
+        type: "CommentLine";
+    }
+
+    export interface SourceLocation {
+        start: {
+            line: number;
+            column: number;
+        };
+
+        end: {
+            line: number;
+            column: number;
+        };
+    }
+
+    export interface Node {
+        type: string;
+        leadingComments?: Array<Comment>;
+        innerComments?: Array<Comment>;
+        trailingComments?: Array<Comment>;
+        start: number | null;
+        end: number | null;
+        loc: SourceLocation | null;
+    }
+
+    export interface ArrayExpression extends Node {
+        type: "ArrayExpression";
+        elements: Array<Expression | SpreadElement | null>;
+    }
+
+    export interface AssignmentExpression extends Node {
+        type: "AssignmentExpression";
+        operator: "=" | "+=" | "-=" | "*=" | "/=" | "%=" | "<<=" | ">>=" | ">>>=" | "|=" | "^=" | "&=";
+        left: LVal;
+        right: Expression;
+    }
+
+    export interface BinaryExpression extends Node {
+        type: "BinaryExpression";
+        operator: "+" | "-" | "/" | "%" | "*" | "**" | "&" | "|" | ">>" | ">>>" | "<<" | "^" | "==" | "===" | "!=" | "!==" | "in" | "instanceof" | ">" | "<" | ">=" | "<=";
+        left: Expression;
+        right: Expression;
+    }
+
+    export interface Directive extends Node {
+        type: "Directive";
+        value: DirectiveLiteral;
+    }
+
+    export interface DirectiveLiteral extends Node {
+        type: "DirectiveLiteral";
+        value: string;
+    }
+
+    export interface BlockStatement extends Node {
+        type: "BlockStatement";
+        directives?: Directive[];
+        body: Statement[];
+    }
+
+    export interface BreakStatement extends Node {
+        type: "BreakStatement";
+        label: Identifier | null;
+    }
+
+    export interface CallExpression extends Node {
+        type: "CallExpression";
+        callee: Expression | Super;
+        arguments: Array<Expression | SpreadElement>;
+    }
+
+    export interface CatchClause extends Node {
+        type: "CatchClause";
+        param: Pattern;
+        body: BlockStatement;
+    }
+
+    export interface ConditionalExpression extends Node {
+        type: "ConditionalExpression";
+        test: Expression;
+        consequent: Expression;
+        alternate: Expression;
+    }
+
+    export interface ContinueStatement extends Node {
+        type: "ContinueStatement";
+        label: Identifier | null;
+    }
+
+    export interface DebuggerStatement extends Node {
+        type: "DebuggerStatement";
+    }
+
+    export interface DoWhileStatement extends Node {
+        type: "DoWhileStatement";
+        test: Expression;
+        body: Statement;
+    }
+
+    export interface EmptyStatement extends Node {
+        type: "EmptyStatement";
+    }
+
+    export interface ExpressionStatement extends Node {
+        type: "ExpressionStatement";
+        expression: Expression;
+    }
+
+    export interface File extends Node {
+        type: "File";
+        program: Program;
+        comments: Comment[];
+        tokens: any[];
+    }
+
+    export interface ForInStatement extends Node {
+        type: "ForInStatement";
+        left: VariableDeclaration | LVal;
+        right: Expression;
+        body: Statement;
+    }
+
+    export interface ForStatement extends Node {
+        type: "ForStatement";
+        init: VariableDeclaration | Expression | null;
+        test: Expression | null;
+        update: Expression | null;
+        body: Statement;
+    }
+
+    export interface FunctionDeclaration extends Node {
+        type: "FunctionDeclaration";
+        id: Identifier;
+        params: Pattern[];
+        body: BlockStatement;
+        generator: boolean;
+        async: boolean;
+        returnType?: TypeAnnotation;
+        typeParameters?: TypeParameterDeclaration;
+    }
+
+    export interface FunctionExpression extends Node {
+        type: "FunctionExpression";
+        id: Identifier | null;
+        params: Pattern[];
+        body: BlockStatement;
+        generator: boolean;
+        async: boolean;
+        returnType?: TypeAnnotation;
+        typeParameters?: TypeParameterDeclaration;
+    }
+
+    export interface Identifier extends Node {
+        type: "Identifier";
+        name: string;
+        typeAnnotation?: TypeAnnotation;
+    }
+
+    export interface IfStatement extends Node {
+        type: "IfStatement";
+        test: Expression;
+        consequent: Statement;
+        alternate: Statement | null;
+    }
+
+    export interface LabeledStatement extends Node {
+        type: "LabeledStatement";
+        label: Identifier;
+        body: Statement;
+    }
+
+    export interface StringLiteral extends Node {
+        type: "StringLiteral";
+        value: string;
+    }
+
+    export interface NumericLiteral extends Node {
+        type: "NumericLiteral";
+        value: number;
+    }
+
+    export interface NullLiteral extends Node {
+        type: "NullLiteral";
+    }
+
+    export interface BooleanLiteral extends Node {
+        type: "BooleanLiteral";
+        value: boolean;
+    }
+
+    export interface RegExpLiteral extends Node {
+        type: "RegExpLiteral";
+        pattern: string;
+        flags?: string;
+    }
+
+    export interface LogicalExpression extends Node {
+        type: "LogicalExpression";
+        operator: "||" | "&&";
+        left: Expression;
+        right: Expression;
+    }
+
+    export interface MemberExpression extends Node {
+        type: "MemberExpression";
+        object: Expression | Super;
+        property: Expression;
+        computed: boolean;
+    }
+
+    export interface NewExpression extends Node {
+        type: "NewExpression";
+        callee: Expression | Super;
+        arguments: Array<Expression | SpreadElement>;
+    }
+
+    export interface Program extends Node {
+        type: "Program";
+        sourceType: "script" | "module";
+        directives?: Directive[];
+        body: Array<Statement | ModuleDeclaration>;
+    }
+
+    export interface ObjectExpression extends Node {
+        type: "ObjectExpression";
+        properties: Array<ObjectProperty | ObjectMethod | SpreadProperty>;
+    }
+
+    export interface ObjectMethod extends Node {
+        type: "ObjectMethod";
+        key: Expression;
+        kind: "get" | "set" | "method";
+        shorthand: boolean;
+        computed: boolean;
+        value: Expression;
+        decorators?: Decorator[];
+        id: Identifier | null;
+        params: Pattern[];
+        body: BlockStatement;
+        generator: boolean;
+        async: boolean;
+        returnType?: TypeAnnotation;
+        typeParameters?: TypeParameterDeclaration;
+    }
+
+    export interface ObjectProperty extends Node {
+        type: "ObjectProperty";
+        key: Expression;
+        computed: boolean;
+        value: Expression;
+        decorators?: Decorator[];
+        shorthand: boolean;
+    }
+
+    export interface RestElement extends Node {
+        type: "RestElement";
+        argument: LVal;
+        typeAnnotation?: TypeAnnotation;
+    }
+
+    export interface ReturnStatement extends Node {
+        type: "ReturnStatement";
+        argument: Expression | null;
+    }
+
+    export interface SequenceExpression extends Node {
+        type: "SequenceExpression";
+        expressions: Expression[];
+    }
+
+    export interface SwitchCase extends Node {
+        type: "SwitchCase";
+        test: Expression | null;
+        consequent: Statement[];
+    }
+
+    export interface SwitchStatement extends Node {
+        type: "SwitchStatement";
+        discriminant: Expression;
+        cases: SwitchCase[];
+    }
+
+    export interface ThisExpression extends Node {
+        type: "ThisExpression";
+    }
+
+    export interface ThrowStatement extends Node {
+        type: "ThrowStatement";
+        argument: Expression;
+    }
+
+    export interface TryStatement extends Node {
+        type: "TryStatement";
+        block: BlockStatement;
+        handler: CatchClause | null;
+        finalizer: BlockStatement | null;
+    }
+
+    export interface UnaryExpression extends Node {
+        type: "UnaryExpression";
+        operator: "-" | "+" | "!" | "~" | "typeof" | "void" | "delete";
+        prefix: boolean;
+        argument: Expression;
+    }
+
+    export interface UpdateExpression extends Node {
+        type: "UpdateExpression";
+        operator: "++" | "--";
+        prefix: boolean;
+        argument: Expression;
+    }
+
+    export interface VariableDeclaration extends Node {
+        type: "VariableDeclaration";
+        declarations: VariableDeclarator[];
+        kind: "var" | "let" | "const";
+    }
+
+    export interface VariableDeclarator extends Node {
+        type: "VariableDeclarator";
+        id: LVal;
+        init: Expression | null;
+    }
+
+    export interface WhileStatement extends Node {
+        type: "WhileStatement";
+        test: Expression;
+        body: Statement;
+    }
+
+    export interface WithStatement extends Node {
+        type: "WithStatement";
+        object: Expression;
+        body: BlockStatement | Statement;
+    }
+
+    export interface AssignmentPattern extends Node {
+        type: "AssignmentPattern";
+        left: Pattern;
+        right: Expression;
+    }
+
+    export interface ArrayPattern extends Node {
+        type: "ArrayPattern";
+        elements: Array<Pattern | null>;
+        typeAnnotation?: TypeAnnotation;
+    }
+
+    export interface ArrowFunctionExpression extends Node {
+        type: "ArrowFunctionExpression";
+        id: Identifier | null;
+        params: Pattern[];
+        body: BlockStatement | Expression;
+        generator: boolean;
+        async: boolean;
+        expression: boolean;
+        returnType?: TypeAnnotation;
+        typeParameters?: TypeParameterDeclaration;
+    }
+
+    export interface ClassBody extends Node {
+        type: "ClassBody";
+        body: Array<ClassMethod | ClassProperty>;
+    }
+
+    export interface ClassDeclaration extends Node {
+        type: "ClassDeclaration";
+        id: Identifier;
+        superClass: Expression | null;
+        body: ClassBody;
+        decorators?: Decorator[];
+        implements?: ClassImplements[];
+        mixins?: any[];
+        typeParameters?: TypeParameterDeclaration;
+        superTypeParameters?: TypeParameterInstantiation;
+    }
+
+    export interface ClassExpression extends Node {
+        type: "ClassExpression";
+        id: Identifier | null;
+        superClass: Expression | null;
+        body: ClassBody;
+        decorators?: Decorator[];
+        implements?: ClassImplements[];
+        mixins?: any[];
+        typeParameters?: TypeParameterDeclaration;
+        superTypeParameters?: TypeParameterInstantiation;
+    }
+
+    export interface ExportAllDeclaration extends Node {
+        type: "ExportAllDeclaration";
+        source: StringLiteral;
+    }
+
+    export interface ExportDefaultDeclaration extends Node {
+        type: "ExportDefaultDeclaration";
+        declaration: Declaration | Expression;
+    }
+
+    export interface ExportNamedDeclaration extends Node {
+        type: "ExportNamedDeclaration";
+        declaration: Declaration | null;
+        specifiers: ExportSpecifier[];
+        source: StringLiteral | null;
+    }
+
+    export interface ExportSpecifier extends Node {
+        type: "ExportSpecifier";
+        local: Identifier;
+        imported: Identifier;
+        exported: Identifier;
+    }
+
+    export interface ForOfStatement extends Node {
+        type: "ForOfStatement";
+        left: VariableDeclaration | LVal;
+        right: Expression;
+        body: Statement;
+    }
+
+    export interface ImportDeclaration extends Node {
+        type: "ImportDeclaration";
+        specifiers: Array<ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>;
+        source: StringLiteral;
+    }
+
+    export interface ImportDefaultSpecifier extends Node {
+        type: "ImportDefaultSpecifier";
+        local: Identifier;
+    }
+
+    export interface ImportNamespaceSpecifier extends Node {
+        type: "ImportNamespaceSpecifier";
+        local: Identifier;
+    }
+
+    export interface ImportSpecifier extends Node {
+        type: "ImportSpecifier";
+        local: Identifier;
+        imported: Identifier;
+    }
+
+    export interface MetaProperty extends Node {
+        type: "MetaProperty";
+        meta: Identifier;
+        property: Identifier;
+    }
+
+    export interface ClassMethod extends Node {
+        type: "ClassMethod";
+        key: Expression;
+        value?: FunctionExpression;
+        kind: "constructor" | "method" | "get" | "set";
+        computed: boolean;
+        static: boolean;
+        decorators?: Decorator[];
+        id: Identifier | null;
+        params: Pattern[];
+        body: BlockStatement;
+        generator: boolean;
+        async: boolean;
+        expression: boolean;
+        returnType?: TypeAnnotation;
+        typeParameters?: TypeParameterDeclaration;
+    }
+
+    // See: https://github.com/babel/babel/blob/master/doc/ast/spec.md#objectpattern
+    export interface AssignmentProperty extends Node {
+        type: "ObjectProperty";
+        key: Expression;
+        computed: boolean;
+        value: Pattern;
+        decorators?: Decorator[];
+        shorthand: boolean;
+    }
+
+    export interface ObjectPattern extends Node {
+        type: "ObjectPattern";
+        properties: Array<AssignmentProperty | RestProperty>;
+        typeAnnotation?: TypeAnnotation;
+    }
+
+    export interface SpreadElement extends Node {
+        type: "SpreadElement";
+        argument: Expression;
+    }
+
+    export interface Super extends Node {
+        type: "Super";
+    }
+
+    export interface TaggedTemplateExpression extends Node {
+        type: "TaggedTemplateExpression";
+        tag: Expression;
+        quasi: TemplateLiteral;
+    }
+
+    export interface TemplateElement extends Node {
+        type: "TemplateElement";
+        tail: boolean;
+        value: {
+            cooked: string;
+            raw: string;
+        };
+    }
+
+    export interface TemplateLiteral extends Node {
+        type: "TemplateLiteral";
+        quasis: TemplateElement[];
+        expressions: Expression[];
+    }
+
+    export interface YieldExpression extends Node {
+        type: "YieldExpression";
+        argument: Expression | null;
+        delegate: boolean;
+    }
+
+    export interface AnyTypeAnnotation extends Node {
+        type: "AnyTypeAnnotation";
+    }
+
+    export interface ArrayTypeAnnotation extends Node {
+        type: "ArrayTypeAnnotation";
+        elementType: FlowTypeAnnotation;
+    }
+
+    export interface BooleanTypeAnnotation extends Node {
+        type: "BooleanTypeAnnotation";
+    }
+
+    export interface BooleanLiteralTypeAnnotation extends Node {
+        type: "BooleanLiteralTypeAnnotation";
+    }
+
+    export interface NullLiteralTypeAnnotation extends Node {
+        type: "NullLiteralTypeAnnotation";
+    }
+
+    export interface ClassImplements extends Node {
+        type: "ClassImplements";
+        id: Identifier;
+        typeParameters: TypeParameterInstantiation | null;
+    }
+
+    export interface ClassProperty extends Node {
+        type: "ClassProperty";
+        key: Identifier;
+        value: Expression;
+        decorators?: Decorator[];
+        typeAnnotation?: TypeAnnotation;
+    }
+
+    export interface DeclareClass extends Node {
+        type: "DeclareClass";
+        id: Identifier;
+        typeParameters: TypeParameterDeclaration | null;
+        extends: InterfaceExtends[];
+        body: ObjectTypeAnnotation;
+    }
+
+    export interface DeclareFunction extends Node {
+        type: "DeclareFunction";
+        id: Identifier;
+    }
+
+    export interface DeclareInterface extends Node {
+        type: "DeclareInterface";
+        id: Identifier;
+        typeParameters: TypeParameterDeclaration | null;
+        extends: InterfaceExtends[];
+        body: ObjectTypeAnnotation;
+    }
+
+    export interface DeclareModule extends Node {
+        type: "DeclareModule";
+        id: StringLiteral | Identifier;
+        body: BlockStatement;
+    }
+
+    export interface DeclareTypeAlias extends Node {
+        type: "DeclareTypeAlias";
+        id: Identifier;
+        typeParameters: TypeParameterDeclaration | null;
+        right: FlowTypeAnnotation;
+    }
+
+    export interface DeclareVariable extends Node {
+        type: "DeclareVariable";
+        id: Identifier;
+    }
+
+    export interface ExistentialTypeParam extends Node {
+        type: "ExistentialTypeParam";
+    }
+
+    export interface FunctionTypeAnnotation extends Node {
+        type: "FunctionTypeAnnotation";
+        typeParameters: TypeParameterDeclaration;
+        params: FunctionTypeParam[];
+        rest: FunctionTypeParam | null;
+        returnType: FlowTypeAnnotation;
+    }
+
+    export interface FunctionTypeParam extends Node {
+        type: "FunctionTypeParam";
+        name: Identifier;
+        typeAnnotation: FlowTypeAnnotation;
+    }
+
+    export interface GenericTypeAnnotation extends Node {
+        type: "GenericTypeAnnotation";
+        id: Identifier;
+        typeParameters: TypeParameterInstantiation | null;
+    }
+
+    export interface InterfaceExtends extends Node {
+        type: "InterfaceExtends";
+        id: Identifier;
+        typeParameters: TypeParameterInstantiation | null;
+    }
+
+    export interface InterfaceDeclaration extends Node {
+        type: "InterfaceDeclaration";
+        id: Identifier;
+        typeParameters: TypeParameterDeclaration | null;
+        extends: InterfaceExtends[];
+        mixins?: any[];
+        body: ObjectTypeAnnotation;
+    }
+
+    export interface IntersectionTypeAnnotation extends Node {
+        type: "IntersectionTypeAnnotation";
+        types: FlowTypeAnnotation[];
+    }
+
+    export interface MixedTypeAnnotation extends Node {
+        type: "MixedTypeAnnotation";
+    }
+
+    export interface NullableTypeAnnotation extends Node {
+        type: "NullableTypeAnnotation";
+        typeAnnotation: FlowTypeAnnotation;
+    }
+
+    export interface NumericLiteralTypeAnnotation extends Node {
+        type: "NumericLiteralTypeAnnotation";
+    }
+
+    export interface NumberTypeAnnotation extends Node {
+        type: "NumberTypeAnnotation";
+    }
+
+    export interface StringLiteralTypeAnnotation extends Node {
+        type: "StringLiteralTypeAnnotation";
+    }
+
+    export interface StringTypeAnnotation extends Node {
+        type: "StringTypeAnnotation";
+    }
+
+    export interface ThisTypeAnnotation extends Node {
+        type: "ThisTypeAnnotation";
+    }
+
+    export interface TupleTypeAnnotation extends Node {
+        type: "TupleTypeAnnotation";
+        types: FlowTypeAnnotation[];
+    }
+
+    export interface TypeofTypeAnnotation extends Node {
+        type: "TypeofTypeAnnotation";
+        argument: FlowTypeAnnotation;
+    }
+
+    export interface TypeAlias extends Node {
+        type: "TypeAlias";
+        id: Identifier;
+        typeParameters: TypeParameterDeclaration | null;
+        right: FlowTypeAnnotation;
+    }
+
+    export interface TypeAnnotation extends Node {
+        type: "TypeAnnotation";
+        typeAnnotation: FlowTypeAnnotation;
+    }
+
+    export interface TypeCastExpression extends Node {
+        type: "TypeCastExpression";
+        expression: Expression;
+        typeAnnotation: FlowTypeAnnotation;
+    }
+
+    export interface TypeParameterDeclaration extends Node {
+        type: "TypeParameterDeclaration";
+        params: Identifier[];
+    }
+
+    export interface TypeParameterInstantiation extends Node {
+        type: "TypeParameterInstantiation";
+        params: FlowTypeAnnotation[];
+    }
+
+    export interface ObjectTypeAnnotation extends Node {
+        type: "ObjectTypeAnnotation";
+        properties: ObjectTypeProperty[];
+        indexers: ObjectTypeIndexer[];
+        callProperties: ObjectTypeCallProperty[];
+    }
+
+    export interface ObjectTypeCallProperty extends Node {
+        type: "ObjectTypeCallProperty";
+        value: FlowTypeAnnotation;
+    }
+
+    export interface ObjectTypeIndexer extends Node {
+        type: "ObjectTypeIndexer";
+        id: Expression;
+        key: FlowTypeAnnotation;
+        value: FlowTypeAnnotation;
+    }
+
+    export interface ObjectTypeProperty extends Node {
+        type: "ObjectTypeProperty";
+        key: Expression;
+        value: FlowTypeAnnotation;
+    }
+
+    export interface QualifiedTypeIdentifier extends Node {
+        type: "QualifiedTypeIdentifier";
+        id: Identifier;
+        qualification: Identifier | QualifiedTypeIdentifier;
+    }
+
+    export interface UnionTypeAnnotation extends Node {
+        type: "UnionTypeAnnotation";
+        types: FlowTypeAnnotation[];
+    }
+
+    export interface VoidTypeAnnotation extends Node {
+        type: "VoidTypeAnnotation";
+    }
+
+    export interface JSXAttribute extends Node {
+        type: "JSXAttribute";
+        name: JSXIdentifier | JSXNamespacedName;
+        value: JSXElement | StringLiteral | JSXExpressionContainer | null;
+    }
+
+    export interface JSXClosingElement extends Node {
+        type: "JSXClosingElement";
+        name: JSXIdentifier | JSXMemberExpression;
+    }
+
+    export interface JSXElement extends Node {
+        type: "JSXElement";
+        openingElement: JSXOpeningElement;
+        closingElement: JSXClosingElement | null;
+        children: Array<JSXElement | JSXExpressionContainer | JSXText>;
+        selfClosing?: boolean;
+    }
+
+    export interface JSXEmptyExpression extends Node {
+        type: "JSXEmptyExpression";
+    }
+
+    export interface JSXExpressionContainer extends Node {
+        type: "JSXExpressionContainer";
+        expression: Expression;
+    }
+
+    export interface JSXIdentifier extends Node {
+        type: "JSXIdentifier";
+        name: string;
+    }
+
+    export interface JSXMemberExpression extends Node {
+        type: "JSXMemberExpression";
+        object: JSXMemberExpression | JSXIdentifier;
+        property: JSXIdentifier;
+    }
+
+    export interface JSXNamespacedName extends Node {
+        type: "JSXNamespacedName";
+        namespace: JSXIdentifier;
+        name: JSXIdentifier;
+    }
+
+    export interface JSXOpeningElement extends Node {
+        type: "JSXOpeningElement";
+        name: JSXIdentifier | JSXMemberExpression;
+        selfClosing: boolean;
+        attributes: JSXAttribute[];
+    }
+
+    export interface JSXSpreadAttribute extends Node {
+        type: "JSXSpreadAttribute";
+        argument: Expression;
+    }
+
+    export interface JSXText extends Node {
+        type: "JSXText";
+        value: string;
+    }
+
+    export interface Noop extends Node {
+        type: "Noop";
+    }
+
+    export interface ParenthesizedExpression extends Node {
+        type: "ParenthesizedExpression";
+        expression: Expression;
+    }
+
+    export interface AwaitExpression extends Node {
+        type: "AwaitExpression";
+        argument: Expression | null;
+    }
+
+    export interface BindExpression extends Node {
+        type: "BindExpression";
+        object: Expression | null;
+        callee: Expression;
+    }
+
+    export interface Decorator extends Node {
+        type: "Decorator";
+        expression: Expression;
+    }
+
+    export interface DoExpression extends Node {
+        type: "DoExpression";
+        body: BlockStatement;
+    }
+
+    export interface ExportDefaultSpecifier extends Node {
+        type: "ExportDefaultSpecifier";
+        exported: Identifier;
+    }
+
+    export interface ExportNamespaceSpecifier extends Node {
+        type: "ExportNamespaceSpecifier";
+        exported: Identifier;
+    }
+
+    export interface RestProperty extends Node {
+        type: "RestProperty";
+        argument: LVal;
+    }
+
+    export interface SpreadProperty extends Node {
+        type: "SpreadProperty";
+        argument: Expression;
+    }
+
+    export type Expression = ArrayExpression | AssignmentExpression | BinaryExpression | CallExpression | ConditionalExpression | FunctionExpression | Identifier | StringLiteral | NumericLiteral | NullLiteral | BooleanLiteral | RegExpLiteral | LogicalExpression | MemberExpression | NewExpression | ObjectExpression | SequenceExpression | ThisExpression | UnaryExpression | UpdateExpression | ArrowFunctionExpression | ClassExpression | MetaProperty | Super | TaggedTemplateExpression | TemplateLiteral | YieldExpression | TypeCastExpression | JSXElement | JSXEmptyExpression | JSXIdentifier | JSXMemberExpression | ParenthesizedExpression | AwaitExpression | BindExpression | DoExpression;
+    export type Binary = BinaryExpression | LogicalExpression;
+    export type Scopable = BlockStatement | CatchClause | DoWhileStatement | ForInStatement | ForStatement | FunctionDeclaration | FunctionExpression | Program | ObjectMethod | SwitchStatement | WhileStatement | ArrowFunctionExpression | ClassDeclaration | ClassExpression | ForOfStatement | ClassMethod;
+    export type BlockParent = BlockStatement | DoWhileStatement | ForInStatement | ForStatement | FunctionDeclaration | FunctionExpression | Program | ObjectMethod | SwitchStatement | WhileStatement | ArrowFunctionExpression | ForOfStatement | ClassMethod;
+    export type Block = BlockStatement | Program;
+    export type Statement = BlockStatement | BreakStatement | ContinueStatement | DebuggerStatement | DoWhileStatement | EmptyStatement | ExpressionStatement | ForInStatement | ForStatement | FunctionDeclaration | IfStatement | LabeledStatement | ReturnStatement | SwitchStatement | ThrowStatement | TryStatement | VariableDeclaration | WhileStatement | WithStatement | ClassDeclaration | ExportAllDeclaration | ExportDefaultDeclaration | ExportNamedDeclaration | ForOfStatement | ImportDeclaration | DeclareClass | DeclareFunction | DeclareInterface | DeclareModule | DeclareTypeAlias | DeclareVariable | InterfaceDeclaration | TypeAlias;
+    export type Terminatorless = BreakStatement | ContinueStatement | ReturnStatement | ThrowStatement | YieldExpression | AwaitExpression;
+    export type CompletionStatement = BreakStatement | ContinueStatement | ReturnStatement | ThrowStatement;
+    export type Conditional = ConditionalExpression | IfStatement;
+    export type Loop = DoWhileStatement | ForInStatement | ForStatement | WhileStatement | ForOfStatement;
+    export type While = DoWhileStatement | WhileStatement;
+    export type ExpressionWrapper = ExpressionStatement | TypeCastExpression | ParenthesizedExpression;
+    export type For = ForInStatement | ForStatement | ForOfStatement;
+    export type ForXStatement = ForInStatement | ForOfStatement;
+    export type Function = FunctionDeclaration | FunctionExpression | ObjectMethod | ArrowFunctionExpression | ClassMethod;
+    export type FunctionParent = FunctionDeclaration | FunctionExpression | Program | ObjectMethod | ArrowFunctionExpression | ClassMethod;
+    export type Pureish = FunctionDeclaration | FunctionExpression | StringLiteral | NumericLiteral | NullLiteral | BooleanLiteral | ArrowFunctionExpression | ClassDeclaration | ClassExpression;
+    export type Declaration = FunctionDeclaration | VariableDeclaration | ClassDeclaration | ExportAllDeclaration | ExportDefaultDeclaration | ExportNamedDeclaration | ImportDeclaration | DeclareClass | DeclareFunction | DeclareInterface | DeclareModule | DeclareTypeAlias | DeclareVariable | InterfaceDeclaration | TypeAlias;
+    export type LVal = Identifier | MemberExpression | RestElement | AssignmentPattern | ArrayPattern | ObjectPattern;
+    export type Literal = StringLiteral | NumericLiteral | NullLiteral | BooleanLiteral | RegExpLiteral | TemplateLiteral;
+    export type Immutable = StringLiteral | NumericLiteral | NullLiteral | BooleanLiteral | JSXAttribute | JSXClosingElement | JSXElement | JSXExpressionContainer | JSXOpeningElement;
+    export type UserWhitespacable = ObjectMethod | ObjectProperty | ObjectTypeCallProperty | ObjectTypeIndexer | ObjectTypeProperty;
+    export type Method = ObjectMethod | ClassMethod;
+    export type ObjectMember = ObjectMethod | ObjectProperty;
+    export type Property = ObjectProperty | ClassProperty;
+    export type UnaryLike = UnaryExpression | SpreadElement | RestProperty | SpreadProperty;
+    export type Pattern = AssignmentPattern | ArrayPattern | ObjectPattern;
+    export type Class = ClassDeclaration | ClassExpression;
+    export type ModuleDeclaration = ExportAllDeclaration | ExportDefaultDeclaration | ExportNamedDeclaration | ImportDeclaration;
+    export type ExportDeclaration = ExportAllDeclaration | ExportDefaultDeclaration | ExportNamedDeclaration;
+    export type ModuleSpecifier = ExportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier | ImportSpecifier | ExportDefaultSpecifier | ExportNamespaceSpecifier;
+    export type Flow = AnyTypeAnnotation | ArrayTypeAnnotation | BooleanTypeAnnotation | BooleanLiteralTypeAnnotation | NullLiteralTypeAnnotation | ClassImplements | ClassProperty | DeclareClass | DeclareFunction | DeclareInterface | DeclareModule | DeclareTypeAlias | DeclareVariable | ExistentialTypeParam | FunctionTypeAnnotation | FunctionTypeParam | GenericTypeAnnotation | InterfaceExtends | InterfaceDeclaration | IntersectionTypeAnnotation | MixedTypeAnnotation | NullableTypeAnnotation | NumericLiteralTypeAnnotation | NumberTypeAnnotation | StringLiteralTypeAnnotation | StringTypeAnnotation | ThisTypeAnnotation | TupleTypeAnnotation | TypeofTypeAnnotation | TypeAlias | TypeAnnotation | TypeCastExpression | TypeParameterDeclaration | TypeParameterInstantiation | ObjectTypeAnnotation | ObjectTypeCallProperty | ObjectTypeIndexer | ObjectTypeProperty | QualifiedTypeIdentifier | UnionTypeAnnotation | VoidTypeAnnotation;
+    export type FlowTypeAnnotation = AnyTypeAnnotation | ArrayTypeAnnotation | BooleanTypeAnnotation | BooleanLiteralTypeAnnotation | NullLiteralTypeAnnotation | FunctionTypeAnnotation | GenericTypeAnnotation | IntersectionTypeAnnotation | MixedTypeAnnotation | NullableTypeAnnotation | NumericLiteralTypeAnnotation | NumberTypeAnnotation | StringLiteralTypeAnnotation | StringTypeAnnotation | ThisTypeAnnotation | TupleTypeAnnotation | TypeofTypeAnnotation | TypeAnnotation | ObjectTypeAnnotation | UnionTypeAnnotation | VoidTypeAnnotation;
+    export type FlowBaseAnnotation = AnyTypeAnnotation | BooleanTypeAnnotation | NullLiteralTypeAnnotation | MixedTypeAnnotation | NumberTypeAnnotation | StringTypeAnnotation | ThisTypeAnnotation | VoidTypeAnnotation;
+    export type FlowDeclaration = DeclareClass | DeclareFunction | DeclareInterface | DeclareModule | DeclareTypeAlias | DeclareVariable | InterfaceDeclaration | TypeAlias;
+    export type JSX = JSXAttribute | JSXClosingElement | JSXElement | JSXEmptyExpression | JSXExpressionContainer | JSXIdentifier | JSXMemberExpression | JSXNamespacedName | JSXOpeningElement | JSXSpreadAttribute | JSXText;
+
+    export function arrayExpression(elements?: Array<Expression | SpreadElement | null>): ArrayExpression;
+    export function assignmentExpression(operator?: string, left?: LVal, right?: Expression): AssignmentExpression;
+    export function binaryExpression(operator?: "+" | "-" | "/" | "%" | "*" | "**" | "&" | "|" | ">>" | ">>>" | "<<" | "^" | "==" | "===" | "!=" | "!==" | "in" | "instanceof" | ">" | "<" | ">=" | "<=", left?: Expression, right?: Expression): BinaryExpression;
+    export function directive(value?: DirectiveLiteral): Directive;
+    export function directiveLiteral(value?: string): DirectiveLiteral;
+    export function blockStatement(body?: Statement[], directives?: Directive[]): BlockStatement;
+    export function breakStatement(label?: Identifier | null): BreakStatement;
+    export function callExpression(callee?: Expression, _arguments?: Array<Expression | SpreadElement>): CallExpression;
+    export function catchClause(param?: Identifier, body?: BlockStatement): CatchClause;
+    export function conditionalExpression(test?: Expression, consequent?: Expression, alternate?: Expression): ConditionalExpression;
+    export function continueStatement(label?: Identifier | null): ContinueStatement;
+    export function debuggerStatement(): DebuggerStatement;
+    export function doWhileStatement(test?: Expression, body?: Statement): DoWhileStatement;
+    export function emptyStatement(): EmptyStatement;
+    export function expressionStatement(expression?: Expression): ExpressionStatement;
+    export function file(program?: Program, comments?: Comment[], tokens?: any[]): File;
+    export function forInStatement(left?: VariableDeclaration | LVal, right?: Expression, body?: Statement): ForInStatement;
+    export function forStatement(init?: VariableDeclaration | Expression | null, test?: Expression | null, update?: Expression | null, body?: Statement): ForStatement;
+    export function functionDeclaration(id?: Identifier, params?: Pattern[], body?: BlockStatement, generator?: boolean, async?: boolean): FunctionDeclaration;
+    export function functionExpression(id?: Identifier | null, params?: Pattern[], body?: BlockStatement, generator?: boolean, async?: boolean): FunctionExpression;
+    export function identifier(name?: string): Identifier;
+    export function ifStatement(test?: Expression, consequent?: Statement, alternate?: Statement | null): IfStatement;
+    export function labeledStatement(label?: Identifier, body?: Statement): LabeledStatement;
+    export function stringLiteral(value?: string): StringLiteral;
+    export function numericLiteral(value?: number): NumericLiteral;
+    export function nullLiteral(): NullLiteral;
+    export function booleanLiteral(value?: boolean): BooleanLiteral;
+    export function regExpLiteral(pattern?: string, flags?: string): RegExpLiteral;
+    export function logicalExpression(operator?: "||" | "&&", left?: Expression, right?: Expression): LogicalExpression;
+    export function memberExpression(object?: Expression | Super, property?: Expression, computed?: boolean): MemberExpression;
+    export function newExpression(callee?: Expression | Super, _arguments?: Array<Expression | SpreadElement>): NewExpression;
+    export function program(body?: Array<Statement | ModuleDeclaration>, directives?: Directive[]): Program;
+    export function objectExpression(properties?: Array<ObjectProperty | ObjectMethod | SpreadProperty>): ObjectExpression;
+    export function objectMethod(kind?: "get" | "set" | "method", key?: Expression, params?: Pattern[], body?: BlockStatement, computed?: boolean): ObjectMethod;
+    export function objectProperty(key?: Expression, value?: Expression, computed?: boolean, shorthand?: boolean, decorators?: Decorator[]): ObjectProperty;
+    export function restElement(argument?: LVal, typeAnnotation?: TypeAnnotation): RestElement;
+    export function returnStatement(argument?: Expression | null): ReturnStatement;
+    export function sequenceExpression(expressions?: Expression[]): SequenceExpression;
+    export function switchCase(test?: Expression | null, consequent?: Statement[]): SwitchCase;
+    export function switchStatement(discriminant?: Expression, cases?: SwitchCase[]): SwitchStatement;
+    export function thisExpression(): ThisExpression;
+    export function throwStatement(argument?: Expression): ThrowStatement;
+    export function tryStatement(block?: BlockStatement, handler?: CatchClause | null, finalizer?: BlockStatement | null): TryStatement;
+    export function unaryExpression(operator?: "void" | "delete" | "!" | "+" | "-" | "++" | "--" | "~" | "typeof", argument?: Expression, prefix?: boolean): UnaryExpression;
+    export function updateExpression(operator?: "++" | "--", argument?: Expression, prefix?: boolean): UpdateExpression;
+    export function variableDeclaration(kind?: "var" | "let" | "const", declarations?: VariableDeclarator[]): VariableDeclaration;
+    export function variableDeclarator(id?: LVal, init?: Expression | null): VariableDeclarator;
+    export function whileStatement(test?: Expression, body?: BlockStatement | Statement): WhileStatement;
+    export function withStatement(object?: Expression, body?: BlockStatement | Statement): WithStatement;
+    export function assignmentPattern(left?: Identifier, right?: Expression): AssignmentPattern;
+    export function arrayPattern(elements?: Array<Pattern | null>, typeAnnotation?: TypeAnnotation): ArrayPattern;
+    export function arrowFunctionExpression(params?: Pattern[], body?: BlockStatement | Expression, async?: boolean): ArrowFunctionExpression;
+    export function classBody(body?: Array<ClassMethod | ClassProperty>): ClassBody;
+    export function classDeclaration(id?: Identifier, superClass?: Expression | null, body?: ClassBody, decorators?: Decorator[]): ClassDeclaration;
+    export function classExpression(id?: Identifier, superClass?: Expression | null, body?: ClassBody, decorators?: Decorator[]): ClassExpression;
+    export function exportAllDeclaration(source?: StringLiteral): ExportAllDeclaration;
+    export function exportDefaultDeclaration(declaration?: FunctionDeclaration | ClassDeclaration | Expression): ExportDefaultDeclaration;
+    export function exportNamedDeclaration(declaration?: Declaration | null, specifiers?: ExportSpecifier[], source?: StringLiteral | null): ExportNamedDeclaration;
+    export function exportSpecifier(local?: Identifier, exported?: Identifier): ExportSpecifier;
+    export function forOfStatement(left?: VariableDeclaration | LVal, right?: Expression, body?: Statement): ForOfStatement;
+    export function importDeclaration(specifiers?: Array<ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>, source?: StringLiteral): ImportDeclaration;
+    export function importDefaultSpecifier(local?: Identifier): ImportDefaultSpecifier;
+    export function importNamespaceSpecifier(local?: Identifier): ImportNamespaceSpecifier;
+    export function importSpecifier(local?: Identifier, imported?: Identifier): ImportSpecifier;
+    export function metaProperty(meta?: string, property?: string): MetaProperty;
+    export function classMethod(kind?: "constructor" | "method" | "get" | "set", key?: Expression, params?: Pattern[], body?: BlockStatement, computed?: boolean, _static?: boolean): ClassMethod;
+    export function objectPattern(properties?: Array<AssignmentProperty | RestProperty>, typeAnnotation?: TypeAnnotation): ObjectPattern;
+    export function spreadElement(argument?: Expression): SpreadElement;
+    export function taggedTemplateExpression(tag?: Expression, quasi?: TemplateLiteral): TaggedTemplateExpression;
+    export function templateElement(value?: {cooked?: string; raw?: string;}, tail?: boolean): TemplateElement;
+    export function templateLiteral(quasis?: TemplateElement[], expressions?: Expression[]): TemplateLiteral;
+    export function yieldExpression(argument?: Expression | null, delegate?: boolean): YieldExpression;
+    export function anyTypeAnnotation(): AnyTypeAnnotation;
+    export function arrayTypeAnnotation(elementType?: FlowTypeAnnotation): ArrayTypeAnnotation;
+    export function booleanTypeAnnotation(): BooleanTypeAnnotation;
+    export function booleanLiteralTypeAnnotation(): BooleanLiteralTypeAnnotation;
+    export function nullLiteralTypeAnnotation(): NullLiteralTypeAnnotation;
+    export function classImplements(id?: Identifier, typeParameters?: TypeParameterInstantiation | null): ClassImplements;
+    export function classProperty(key?: Identifier, value?: Expression, typeAnnotation?: TypeAnnotation, decorators?: Decorator[]): ClassProperty;
+    export function declareClass(id?: Identifier, typeParameters?: TypeParameterDeclaration | null, _extends?: InterfaceExtends[], body?: ObjectTypeAnnotation): DeclareClass;
+    export function declareFunction(id?: Identifier): DeclareFunction;
+    export function declareInterface(id?: Identifier, typeParameters?: TypeParameterDeclaration | null, _extends?: InterfaceExtends[], body?: ObjectTypeAnnotation): DeclareInterface;
+    export function declareModule(id?: StringLiteral | Identifier, body?: BlockStatement): DeclareModule;
+    export function declareTypeAlias(id?: Identifier, typeParameters?: TypeParameterDeclaration | null, right?: FlowTypeAnnotation): DeclareTypeAlias;
+    export function declareVariable(id?: Identifier): DeclareVariable;
+    export function existentialTypeParam(): ExistentialTypeParam;
+    export function functionTypeAnnotation(typeParameters?: TypeParameterDeclaration, params?: FunctionTypeParam[], rest?: FunctionTypeParam | null, returnType?: FlowTypeAnnotation): FunctionTypeAnnotation;
+    export function functionTypeParam(name?: Identifier, typeAnnotation?: FlowTypeAnnotation): FunctionTypeParam;
+    export function genericTypeAnnotation(id?: Identifier, typeParameters?: TypeParameterInstantiation | null): GenericTypeAnnotation;
+    export function interfaceExtends(id?: Identifier, typeParameters?: TypeParameterInstantiation | null): InterfaceExtends;
+    export function interfaceDeclaration(id?: Identifier, typeParameters?: TypeParameterDeclaration | null, _extends?: InterfaceExtends[], body?: ObjectTypeAnnotation): InterfaceDeclaration;
+    export function intersectionTypeAnnotation(types?: FlowTypeAnnotation[]): IntersectionTypeAnnotation;
+    export function mixedTypeAnnotation(): MixedTypeAnnotation;
+    export function nullableTypeAnnotation(typeAnnotation?: FlowTypeAnnotation): NullableTypeAnnotation;
+    export function numericLiteralTypeAnnotation(): NumericLiteralTypeAnnotation;
+    export function numberTypeAnnotation(): NumberTypeAnnotation;
+    export function stringLiteralTypeAnnotation(): StringLiteralTypeAnnotation;
+    export function stringTypeAnnotation(): StringTypeAnnotation;
+    export function thisTypeAnnotation(): ThisTypeAnnotation;
+    export function tupleTypeAnnotation(types?: FlowTypeAnnotation[]): TupleTypeAnnotation;
+    export function typeofTypeAnnotation(argument?: FlowTypeAnnotation): TypeofTypeAnnotation;
+    export function typeAlias(id?: Identifier, typeParameters?: TypeParameterDeclaration | null, right?: FlowTypeAnnotation): TypeAlias;
+    export function typeAnnotation(typeAnnotation?: FlowTypeAnnotation): TypeAnnotation;
+    export function typeCastExpression(expression?: Expression, typeAnnotation?: FlowTypeAnnotation): TypeCastExpression;
+    export function typeParameterDeclaration(params?: Identifier[]): TypeParameterDeclaration;
+    export function typeParameterInstantiation(params?: FlowTypeAnnotation[]): TypeParameterInstantiation;
+    export function objectTypeAnnotation(properties?: ObjectTypeProperty[], indexers?: ObjectTypeIndexer[], callProperties?: ObjectTypeCallProperty[]): ObjectTypeAnnotation;
+    export function objectTypeCallProperty(value?: FlowTypeAnnotation): ObjectTypeCallProperty;
+    export function objectTypeIndexer(id?: Expression, key?: FlowTypeAnnotation, value?: FlowTypeAnnotation): ObjectTypeIndexer;
+    export function objectTypeProperty(key?: Expression, value?: FlowTypeAnnotation): ObjectTypeProperty;
+    export function qualifiedTypeIdentifier(id?: Identifier, qualification?: Identifier | QualifiedTypeIdentifier): QualifiedTypeIdentifier;
+    export function unionTypeAnnotation(types?: FlowTypeAnnotation[]): UnionTypeAnnotation;
+    export function voidTypeAnnotation(): VoidTypeAnnotation;
+    export function jSXAttribute(name?: JSXIdentifier | JSXNamespacedName, value?: JSXElement | StringLiteral | JSXExpressionContainer | null): JSXAttribute;
+    export function jSXClosingElement(name?: JSXIdentifier | JSXMemberExpression): JSXClosingElement;
+    export function jSXElement(openingElement?: JSXOpeningElement, closingElement?: JSXClosingElement | null, children?: Array<JSXElement | JSXExpressionContainer | JSXText>, selfClosing?: boolean): JSXElement;
+    export function jSXEmptyExpression(): JSXEmptyExpression;
+    export function jSXExpressionContainer(expression?: Expression): JSXExpressionContainer;
+    export function jSXIdentifier(name?: string): JSXIdentifier;
+    export function jSXMemberExpression(object?: JSXMemberExpression | JSXIdentifier, property?: JSXIdentifier): JSXMemberExpression;
+    export function jSXNamespacedName(namespace?: JSXIdentifier, name?: JSXIdentifier): JSXNamespacedName;
+    export function jSXOpeningElement(name?: JSXIdentifier | JSXMemberExpression, attributes?: JSXAttribute[], selfClosing?: boolean): JSXOpeningElement;
+    export function jSXSpreadAttribute(argument?: Expression): JSXSpreadAttribute;
+    export function jSXText(value?: string): JSXText;
+    export function noop(): Noop;
+    export function parenthesizedExpression(expression?: Expression): ParenthesizedExpression;
+    export function awaitExpression(argument?: Expression): AwaitExpression;
+    export function bindExpression(object?: Expression | null, callee?: Expression): BindExpression;
+    export function decorator(expression?: Expression): Decorator;
+    export function doExpression(body?: BlockStatement): DoExpression;
+    export function exportDefaultSpecifier(exported?: Identifier): ExportDefaultSpecifier;
+    export function exportNamespaceSpecifier(exported?: Identifier): ExportNamespaceSpecifier;
+    export function restProperty(argument?: LVal): RestProperty;
+    export function spreadProperty(argument?: Expression): SpreadProperty;
+
+    export function isArrayExpression(node: Object, opts?: Object): node is ArrayExpression;
+    export function isAssignmentExpression(node: Object, opts?: Object): node is AssignmentExpression;
+    export function isBinaryExpression(node: Object, opts?: Object): node is BinaryExpression;
+    export function isDirective(node: Object, opts?: Object): node is Directive;
+    export function isDirectiveLiteral(node: Object, opts?: Object): node is DirectiveLiteral;
+    export function isBlockStatement(node: Object, opts?: Object): node is BlockStatement;
+    export function isBreakStatement(node: Object, opts?: Object): node is BreakStatement;
+    export function isCallExpression(node: Object, opts?: Object): node is CallExpression;
+    export function isCatchClause(node: Object, opts?: Object): node is CatchClause;
+    export function isConditionalExpression(node: Object, opts?: Object): node is ConditionalExpression;
+    export function isContinueStatement(node: Object, opts?: Object): node is ContinueStatement;
+    export function isDebuggerStatement(node: Object, opts?: Object): node is DebuggerStatement;
+    export function isDoWhileStatement(node: Object, opts?: Object): node is DoWhileStatement;
+    export function isEmptyStatement(node: Object, opts?: Object): node is EmptyStatement;
+    export function isExpressionStatement(node: Object, opts?: Object): node is ExpressionStatement;
+    export function isFile(node: Object, opts?: Object): node is File;
+    export function isForInStatement(node: Object, opts?: Object): node is ForInStatement;
+    export function isForStatement(node: Object, opts?: Object): node is ForStatement;
+    export function isFunctionDeclaration(node: Object, opts?: Object): node is FunctionDeclaration;
+    export function isFunctionExpression(node: Object, opts?: Object): node is FunctionExpression;
+    export function isIdentifier(node: Object, opts?: Object): node is Identifier;
+    export function isIfStatement(node: Object, opts?: Object): node is IfStatement;
+    export function isLabeledStatement(node: Object, opts?: Object): node is LabeledStatement;
+    export function isStringLiteral(node: Object, opts?: Object): node is StringLiteral;
+    export function isNumericLiteral(node: Object, opts?: Object): node is NumericLiteral;
+    export function isNullLiteral(node: Object, opts?: Object): node is NullLiteral;
+    export function isBooleanLiteral(node: Object, opts?: Object): node is BooleanLiteral;
+    export function isRegExpLiteral(node: Object, opts?: Object): node is RegExpLiteral;
+    export function isLogicalExpression(node: Object, opts?: Object): node is LogicalExpression;
+    export function isMemberExpression(node: Object, opts?: Object): node is MemberExpression;
+    export function isNewExpression(node: Object, opts?: Object): node is NewExpression;
+    export function isProgram(node: Object, opts?: Object): node is Program;
+    export function isObjectExpression(node: Object, opts?: Object): node is ObjectExpression;
+    export function isObjectMethod(node: Object, opts?: Object): node is ObjectMethod;
+    export function isObjectProperty(node: Object, opts?: Object): node is ObjectProperty;
+    export function isRestElement(node: Object, opts?: Object): node is RestElement;
+    export function isReturnStatement(node: Object, opts?: Object): node is ReturnStatement;
+    export function isSequenceExpression(node: Object, opts?: Object): node is SequenceExpression;
+    export function isSwitchCase(node: Object, opts?: Object): node is SwitchCase;
+    export function isSwitchStatement(node: Object, opts?: Object): node is SwitchStatement;
+    export function isThisExpression(node: Object, opts?: Object): node is ThisExpression;
+    export function isThrowStatement(node: Object, opts?: Object): node is ThrowStatement;
+    export function isTryStatement(node: Object, opts?: Object): node is TryStatement;
+    export function isUnaryExpression(node: Object, opts?: Object): node is UnaryExpression;
+    export function isUpdateExpression(node: Object, opts?: Object): node is UpdateExpression;
+    export function isVariableDeclaration(node: Object, opts?: Object): node is VariableDeclaration;
+    export function isVariableDeclarator(node: Object, opts?: Object): node is VariableDeclarator;
+    export function isWhileStatement(node: Object, opts?: Object): node is WhileStatement;
+    export function isWithStatement(node: Object, opts?: Object): node is WithStatement;
+    export function isAssignmentPattern(node: Object, opts?: Object): node is AssignmentPattern;
+    export function isArrayPattern(node: Object, opts?: Object): node is ArrayPattern;
+    export function isArrowFunctionExpression(node: Object, opts?: Object): node is ArrowFunctionExpression;
+    export function isClassBody(node: Object, opts?: Object): node is ClassBody;
+    export function isClassDeclaration(node: Object, opts?: Object): node is ClassDeclaration;
+    export function isClassExpression(node: Object, opts?: Object): node is ClassExpression;
+    export function isExportAllDeclaration(node: Object, opts?: Object): node is ExportAllDeclaration;
+    export function isExportDefaultDeclaration(node: Object, opts?: Object): node is ExportDefaultDeclaration;
+    export function isExportNamedDeclaration(node: Object, opts?: Object): node is ExportNamedDeclaration;
+    export function isExportSpecifier(node: Object, opts?: Object): node is ExportSpecifier;
+    export function isForOfStatement(node: Object, opts?: Object): node is ForOfStatement;
+    export function isImportDeclaration(node: Object, opts?: Object): node is ImportDeclaration;
+    export function isImportDefaultSpecifier(node: Object, opts?: Object): node is ImportDefaultSpecifier;
+    export function isImportNamespaceSpecifier(node: Object, opts?: Object): node is ImportNamespaceSpecifier;
+    export function isImportSpecifier(node: Object, opts?: Object): node is ImportSpecifier;
+    export function isMetaProperty(node: Object, opts?: Object): node is MetaProperty;
+    export function isClassMethod(node: Object, opts?: Object): node is ClassMethod;
+    export function isObjectPattern(node: Object, opts?: Object): node is ObjectPattern;
+    export function isSpreadElement(node: Object, opts?: Object): node is SpreadElement;
+    export function isSuper(node: Object, opts?: Object): node is Super;
+    export function isTaggedTemplateExpression(node: Object, opts?: Object): node is TaggedTemplateExpression;
+    export function isTemplateElement(node: Object, opts?: Object): node is TemplateElement;
+    export function isTemplateLiteral(node: Object, opts?: Object): node is TemplateLiteral;
+    export function isYieldExpression(node: Object, opts?: Object): node is YieldExpression;
+    export function isAnyTypeAnnotation(node: Object, opts?: Object): node is AnyTypeAnnotation;
+    export function isArrayTypeAnnotation(node: Object, opts?: Object): node is ArrayTypeAnnotation;
+    export function isBooleanTypeAnnotation(node: Object, opts?: Object): node is BooleanTypeAnnotation;
+    export function isBooleanLiteralTypeAnnotation(node: Object, opts?: Object): node is BooleanLiteralTypeAnnotation;
+    export function isNullLiteralTypeAnnotation(node: Object, opts?: Object): node is NullLiteralTypeAnnotation;
+    export function isClassImplements(node: Object, opts?: Object): node is ClassImplements;
+    export function isClassProperty(node: Object, opts?: Object): node is ClassProperty;
+    export function isDeclareClass(node: Object, opts?: Object): node is DeclareClass;
+    export function isDeclareFunction(node: Object, opts?: Object): node is DeclareFunction;
+    export function isDeclareInterface(node: Object, opts?: Object): node is DeclareInterface;
+    export function isDeclareModule(node: Object, opts?: Object): node is DeclareModule;
+    export function isDeclareTypeAlias(node: Object, opts?: Object): node is DeclareTypeAlias;
+    export function isDeclareVariable(node: Object, opts?: Object): node is DeclareVariable;
+    export function isExistentialTypeParam(node: Object, opts?: Object): node is ExistentialTypeParam;
+    export function isFunctionTypeAnnotation(node: Object, opts?: Object): node is FunctionTypeAnnotation;
+    export function isFunctionTypeParam(node: Object, opts?: Object): node is FunctionTypeParam;
+    export function isGenericTypeAnnotation(node: Object, opts?: Object): node is GenericTypeAnnotation;
+    export function isInterfaceExtends(node: Object, opts?: Object): node is InterfaceExtends;
+    export function isInterfaceDeclaration(node: Object, opts?: Object): node is InterfaceDeclaration;
+    export function isIntersectionTypeAnnotation(node: Object, opts?: Object): node is IntersectionTypeAnnotation;
+    export function isMixedTypeAnnotation(node: Object, opts?: Object): node is MixedTypeAnnotation;
+    export function isNullableTypeAnnotation(node: Object, opts?: Object): node is NullableTypeAnnotation;
+    export function isNumericLiteralTypeAnnotation(node: Object, opts?: Object): node is NumericLiteralTypeAnnotation;
+    export function isNumberTypeAnnotation(node: Object, opts?: Object): node is NumberTypeAnnotation;
+    export function isStringLiteralTypeAnnotation(node: Object, opts?: Object): node is StringLiteralTypeAnnotation;
+    export function isStringTypeAnnotation(node: Object, opts?: Object): node is StringTypeAnnotation;
+    export function isThisTypeAnnotation(node: Object, opts?: Object): node is ThisTypeAnnotation;
+    export function isTupleTypeAnnotation(node: Object, opts?: Object): node is TupleTypeAnnotation;
+    export function isTypeofTypeAnnotation(node: Object, opts?: Object): node is TypeofTypeAnnotation;
+    export function isTypeAlias(node: Object, opts?: Object): node is TypeAlias;
+    export function isTypeAnnotation(node: Object, opts?: Object): node is TypeAnnotation;
+    export function isTypeCastExpression(node: Object, opts?: Object): node is TypeCastExpression;
+    export function isTypeParameterDeclaration(node: Object, opts?: Object): node is TypeParameterDeclaration;
+    export function isTypeParameterInstantiation(node: Object, opts?: Object): node is TypeParameterInstantiation;
+    export function isObjectTypeAnnotation(node: Object, opts?: Object): node is ObjectTypeAnnotation;
+    export function isObjectTypeCallProperty(node: Object, opts?: Object): node is ObjectTypeCallProperty;
+    export function isObjectTypeIndexer(node: Object, opts?: Object): node is ObjectTypeIndexer;
+    export function isObjectTypeProperty(node: Object, opts?: Object): node is ObjectTypeProperty;
+    export function isQualifiedTypeIdentifier(node: Object, opts?: Object): node is QualifiedTypeIdentifier;
+    export function isUnionTypeAnnotation(node: Object, opts?: Object): node is UnionTypeAnnotation;
+    export function isVoidTypeAnnotation(node: Object, opts?: Object): node is VoidTypeAnnotation;
+    export function isJSXAttribute(node: Object, opts?: Object): node is JSXAttribute;
+    export function isJSXClosingElement(node: Object, opts?: Object): node is JSXClosingElement;
+    export function isJSXElement(node: Object, opts?: Object): node is JSXElement;
+    export function isJSXEmptyExpression(node: Object, opts?: Object): node is JSXEmptyExpression;
+    export function isJSXExpressionContainer(node: Object, opts?: Object): node is JSXExpressionContainer;
+    export function isJSXIdentifier(node: Object, opts?: Object): node is JSXIdentifier;
+    export function isJSXMemberExpression(node: Object, opts?: Object): node is JSXMemberExpression;
+    export function isJSXNamespacedName(node: Object, opts?: Object): node is JSXNamespacedName;
+    export function isJSXOpeningElement(node: Object, opts?: Object): node is JSXOpeningElement;
+    export function isJSXSpreadAttribute(node: Object, opts?: Object): node is JSXSpreadAttribute;
+    export function isJSXText(node: Object, opts?: Object): node is JSXText;
+    export function isNoop(node: Object, opts?: Object): node is Noop;
+    export function isParenthesizedExpression(node: Object, opts?: Object): node is ParenthesizedExpression;
+    export function isAwaitExpression(node: Object, opts?: Object): node is AwaitExpression;
+    export function isBindExpression(node: Object, opts?: Object): node is BindExpression;
+    export function isDecorator(node: Object, opts?: Object): node is Decorator;
+    export function isDoExpression(node: Object, opts?: Object): node is DoExpression;
+    export function isExportDefaultSpecifier(node: Object, opts?: Object): node is ExportDefaultSpecifier;
+    export function isExportNamespaceSpecifier(node: Object, opts?: Object): node is ExportNamespaceSpecifier;
+    export function isRestProperty(node: Object, opts?: Object): node is RestProperty;
+    export function isSpreadProperty(node: Object, opts?: Object): node is SpreadProperty;
+    export function isExpression(node: Object, opts?: Object): node is Expression;
+    export function isBinary(node: Object, opts?: Object): node is Binary;
+    export function isScopable(node: Object, opts?: Object): node is Scopable;
+    export function isBlockParent(node: Object, opts?: Object): node is BlockParent;
+    export function isBlock(node: Object, opts?: Object): node is Block;
+    export function isStatement(node: Object, opts?: Object): node is Statement;
+    export function isTerminatorless(node: Object, opts?: Object): node is Terminatorless;
+    export function isCompletionStatement(node: Object, opts?: Object): node is CompletionStatement;
+    export function isConditional(node: Object, opts?: Object): node is Conditional;
+    export function isLoop(node: Object, opts?: Object): node is Loop;
+    export function isWhile(node: Object, opts?: Object): node is While;
+    export function isExpressionWrapper(node: Object, opts?: Object): node is ExpressionWrapper;
+    export function isFor(node: Object, opts?: Object): node is For;
+    export function isForXStatement(node: Object, opts?: Object): node is ForXStatement;
+    export function isFunction(node: Object, opts?: Object): node is Function;
+    export function isFunctionParent(node: Object, opts?: Object): node is FunctionParent;
+    export function isPureish(node: Object, opts?: Object): node is Pureish;
+    export function isDeclaration(node: Object, opts?: Object): node is Declaration;
+    export function isLVal(node: Object, opts?: Object): node is LVal;
+    export function isLiteral(node: Object, opts?: Object): node is Literal;
+    export function isImmutable(node: Object, opts?: Object): node is Immutable;
+    export function isUserWhitespacable(node: Object, opts?: Object): node is UserWhitespacable;
+    export function isMethod(node: Object, opts?: Object): node is Method;
+    export function isObjectMember(node: Object, opts?: Object): node is ObjectMember;
+    export function isProperty(node: Object, opts?: Object): node is Property;
+    export function isUnaryLike(node: Object, opts?: Object): node is UnaryLike;
+    export function isPattern(node: Object, opts?: Object): node is Pattern;
+    export function isClass(node: Object, opts?: Object): node is Class;
+    export function isModuleDeclaration(node: Object, opts?: Object): node is ModuleDeclaration;
+    export function isExportDeclaration(node: Object, opts?: Object): node is ExportDeclaration;
+    export function isModuleSpecifier(node: Object, opts?: Object): node is ModuleSpecifier;
+    export function isFlow(node: Object, opts?: Object): node is Flow;
+    export function isFlowBaseAnnotation(node: Object, opts?: Object): node is FlowBaseAnnotation;
+    export function isFlowDeclaration(node: Object, opts?: Object): node is FlowDeclaration;
+    export function isJSX(node: Object, opts?: Object): node is JSX;
+    export function isNumberLiteral(node: Object, opts?: Object): node is NumericLiteral;
+    export function isRegexLiteral(node: Object, opts?: Object): node is RegExpLiteral;
+
+    export function isReferencedIdentifier(node: Object, opts?: Object): boolean;
+    export function isReferencedMemberExpression(node: Object, opts?: Object): boolean;
+    export function isBindingIdentifier(node: Object, opts?: Object): boolean;
+    export function isScope(node: Object, opts?: Object): boolean;
+    export function isReferenced(node: Object, opts?: Object): boolean;
+    export function isBlockScoped(node: Object, opts?: Object): boolean;
+    export function isVar(node: Object, opts?: Object): boolean;
+    export function isUser(node: Object, opts?: Object): boolean;
+    export function isGenerated(node: Object, opts?: Object): boolean;
+    export function isPure(node: Object, opts?: Object): boolean;
+
+    export function assertArrayExpression(node: Object, opts?: Object): void;
+    export function assertAssignmentExpression(node: Object, opts?: Object): void;
+    export function assertBinaryExpression(node: Object, opts?: Object): void;
+    export function assertDirective(node: Object, opts?: Object): void;
+    export function assertDirectiveLiteral(node: Object, opts?: Object): void;
+    export function assertBlockStatement(node: Object, opts?: Object): void;
+    export function assertBreakStatement(node: Object, opts?: Object): void;
+    export function assertCallExpression(node: Object, opts?: Object): void;
+    export function assertCatchClause(node: Object, opts?: Object): void;
+    export function assertConditionalExpression(node: Object, opts?: Object): void;
+    export function assertContinueStatement(node: Object, opts?: Object): void;
+    export function assertDebuggerStatement(node: Object, opts?: Object): void;
+    export function assertDoWhileStatement(node: Object, opts?: Object): void;
+    export function assertEmptyStatement(node: Object, opts?: Object): void;
+    export function assertExpressionStatement(node: Object, opts?: Object): void;
+    export function assertFile(node: Object, opts?: Object): void;
+    export function assertForInStatement(node: Object, opts?: Object): void;
+    export function assertForStatement(node: Object, opts?: Object): void;
+    export function assertFunctionDeclaration(node: Object, opts?: Object): void;
+    export function assertFunctionExpression(node: Object, opts?: Object): void;
+    export function assertIdentifier(node: Object, opts?: Object): void;
+    export function assertIfStatement(node: Object, opts?: Object): void;
+    export function assertLabeledStatement(node: Object, opts?: Object): void;
+    export function assertStringLiteral(node: Object, opts?: Object): void;
+    export function assertNumericLiteral(node: Object, opts?: Object): void;
+    export function assertNullLiteral(node: Object, opts?: Object): void;
+    export function assertBooleanLiteral(node: Object, opts?: Object): void;
+    export function assertRegExpLiteral(node: Object, opts?: Object): void;
+    export function assertLogicalExpression(node: Object, opts?: Object): void;
+    export function assertMemberExpression(node: Object, opts?: Object): void;
+    export function assertNewExpression(node: Object, opts?: Object): void;
+    export function assertProgram(node: Object, opts?: Object): void;
+    export function assertObjectExpression(node: Object, opts?: Object): void;
+    export function assertObjectMethod(node: Object, opts?: Object): void;
+    export function assertObjectProperty(node: Object, opts?: Object): void;
+    export function assertRestElement(node: Object, opts?: Object): void;
+    export function assertReturnStatement(node: Object, opts?: Object): void;
+    export function assertSequenceExpression(node: Object, opts?: Object): void;
+    export function assertSwitchCase(node: Object, opts?: Object): void;
+    export function assertSwitchStatement(node: Object, opts?: Object): void;
+    export function assertThisExpression(node: Object, opts?: Object): void;
+    export function assertThrowStatement(node: Object, opts?: Object): void;
+    export function assertTryStatement(node: Object, opts?: Object): void;
+    export function assertUnaryExpression(node: Object, opts?: Object): void;
+    export function assertUpdateExpression(node: Object, opts?: Object): void;
+    export function assertVariableDeclaration(node: Object, opts?: Object): void;
+    export function assertVariableDeclarator(node: Object, opts?: Object): void;
+    export function assertWhileStatement(node: Object, opts?: Object): void;
+    export function assertWithStatement(node: Object, opts?: Object): void;
+    export function assertAssignmentPattern(node: Object, opts?: Object): void;
+    export function assertArrayPattern(node: Object, opts?: Object): void;
+    export function assertArrowFunctionExpression(node: Object, opts?: Object): void;
+    export function assertClassBody(node: Object, opts?: Object): void;
+    export function assertClassDeclaration(node: Object, opts?: Object): void;
+    export function assertClassExpression(node: Object, opts?: Object): void;
+    export function assertExportAllDeclaration(node: Object, opts?: Object): void;
+    export function assertExportDefaultDeclaration(node: Object, opts?: Object): void;
+    export function assertExportNamedDeclaration(node: Object, opts?: Object): void;
+    export function assertExportSpecifier(node: Object, opts?: Object): void;
+    export function assertForOfStatement(node: Object, opts?: Object): void;
+    export function assertImportDeclaration(node: Object, opts?: Object): void;
+    export function assertImportDefaultSpecifier(node: Object, opts?: Object): void;
+    export function assertImportNamespaceSpecifier(node: Object, opts?: Object): void;
+    export function assertImportSpecifier(node: Object, opts?: Object): void;
+    export function assertMetaProperty(node: Object, opts?: Object): void;
+    export function assertClassMethod(node: Object, opts?: Object): void;
+    export function assertObjectPattern(node: Object, opts?: Object): void;
+    export function assertSpreadElement(node: Object, opts?: Object): void;
+    export function assertSuper(node: Object, opts?: Object): void;
+    export function assertTaggedTemplateExpression(node: Object, opts?: Object): void;
+    export function assertTemplateElement(node: Object, opts?: Object): void;
+    export function assertTemplateLiteral(node: Object, opts?: Object): void;
+    export function assertYieldExpression(node: Object, opts?: Object): void;
+    export function assertAnyTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertArrayTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertBooleanTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertBooleanLiteralTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertNullLiteralTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertClassImplements(node: Object, opts?: Object): void;
+    export function assertClassProperty(node: Object, opts?: Object): void;
+    export function assertDeclareClass(node: Object, opts?: Object): void;
+    export function assertDeclareFunction(node: Object, opts?: Object): void;
+    export function assertDeclareInterface(node: Object, opts?: Object): void;
+    export function assertDeclareModule(node: Object, opts?: Object): void;
+    export function assertDeclareTypeAlias(node: Object, opts?: Object): void;
+    export function assertDeclareVariable(node: Object, opts?: Object): void;
+    export function assertExistentialTypeParam(node: Object, opts?: Object): void;
+    export function assertFunctionTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertFunctionTypeParam(node: Object, opts?: Object): void;
+    export function assertGenericTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertInterfaceExtends(node: Object, opts?: Object): void;
+    export function assertInterfaceDeclaration(node: Object, opts?: Object): void;
+    export function assertIntersectionTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertMixedTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertNullableTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertNumericLiteralTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertNumberTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertStringLiteralTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertStringTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertThisTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertTupleTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertTypeofTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertTypeAlias(node: Object, opts?: Object): void;
+    export function assertTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertTypeCastExpression(node: Object, opts?: Object): void;
+    export function assertTypeParameterDeclaration(node: Object, opts?: Object): void;
+    export function assertTypeParameterInstantiation(node: Object, opts?: Object): void;
+    export function assertObjectTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertObjectTypeCallProperty(node: Object, opts?: Object): void;
+    export function assertObjectTypeIndexer(node: Object, opts?: Object): void;
+    export function assertObjectTypeProperty(node: Object, opts?: Object): void;
+    export function assertQualifiedTypeIdentifier(node: Object, opts?: Object): void;
+    export function assertUnionTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertVoidTypeAnnotation(node: Object, opts?: Object): void;
+    export function assertJSXAttribute(node: Object, opts?: Object): void;
+    export function assertJSXClosingElement(node: Object, opts?: Object): void;
+    export function assertJSXElement(node: Object, opts?: Object): void;
+    export function assertJSXEmptyExpression(node: Object, opts?: Object): void;
+    export function assertJSXExpressionContainer(node: Object, opts?: Object): void;
+    export function assertJSXIdentifier(node: Object, opts?: Object): void;
+    export function assertJSXMemberExpression(node: Object, opts?: Object): void;
+    export function assertJSXNamespacedName(node: Object, opts?: Object): void;
+    export function assertJSXOpeningElement(node: Object, opts?: Object): void;
+    export function assertJSXSpreadAttribute(node: Object, opts?: Object): void;
+    export function assertJSXText(node: Object, opts?: Object): void;
+    export function assertNoop(node: Object, opts?: Object): void;
+    export function assertParenthesizedExpression(node: Object, opts?: Object): void;
+    export function assertAwaitExpression(node: Object, opts?: Object): void;
+    export function assertBindExpression(node: Object, opts?: Object): void;
+    export function assertDecorator(node: Object, opts?: Object): void;
+    export function assertDoExpression(node: Object, opts?: Object): void;
+    export function assertExportDefaultSpecifier(node: Object, opts?: Object): void;
+    export function assertExportNamespaceSpecifier(node: Object, opts?: Object): void;
+    export function assertRestProperty(node: Object, opts?: Object): void;
+    export function assertSpreadProperty(node: Object, opts?: Object): void;
+    export function assertExpression(node: Object, opts?: Object): void;
+    export function assertBinary(node: Object, opts?: Object): void;
+    export function assertScopable(node: Object, opts?: Object): void;
+    export function assertBlockParent(node: Object, opts?: Object): void;
+    export function assertBlock(node: Object, opts?: Object): void;
+    export function assertStatement(node: Object, opts?: Object): void;
+    export function assertTerminatorless(node: Object, opts?: Object): void;
+    export function assertCompletionStatement(node: Object, opts?: Object): void;
+    export function assertConditional(node: Object, opts?: Object): void;
+    export function assertLoop(node: Object, opts?: Object): void;
+    export function assertWhile(node: Object, opts?: Object): void;
+    export function assertExpressionWrapper(node: Object, opts?: Object): void;
+    export function assertFor(node: Object, opts?: Object): void;
+    export function assertForXStatement(node: Object, opts?: Object): void;
+    export function assertFunction(node: Object, opts?: Object): void;
+    export function assertFunctionParent(node: Object, opts?: Object): void;
+    export function assertPureish(node: Object, opts?: Object): void;
+    export function assertDeclaration(node: Object, opts?: Object): void;
+    export function assertLVal(node: Object, opts?: Object): void;
+    export function assertLiteral(node: Object, opts?: Object): void;
+    export function assertImmutable(node: Object, opts?: Object): void;
+    export function assertUserWhitespacable(node: Object, opts?: Object): void;
+    export function assertMethod(node: Object, opts?: Object): void;
+    export function assertObjectMember(node: Object, opts?: Object): void;
+    export function assertProperty(node: Object, opts?: Object): void;
+    export function assertUnaryLike(node: Object, opts?: Object): void;
+    export function assertPattern(node: Object, opts?: Object): void;
+    export function assertClass(node: Object, opts?: Object): void;
+    export function assertModuleDeclaration(node: Object, opts?: Object): void;
+    export function assertExportDeclaration(node: Object, opts?: Object): void;
+    export function assertModuleSpecifier(node: Object, opts?: Object): void;
+    export function assertFlow(node: Object, opts?: Object): void;
+    export function assertFlowBaseAnnotation(node: Object, opts?: Object): void;
+    export function assertFlowDeclaration(node: Object, opts?: Object): void;
+    export function assertJSX(node: Object, opts?: Object): void;
+    export function assertNumberLiteral(node: Object, opts?: Object): void;
+    export function assertRegexLiteral(node: Object, opts?: Object): void;
+}

--- a/babylon/babylon-tests.ts
+++ b/babylon/babylon-tests.ts
@@ -1,0 +1,24 @@
+/// <reference path="babylon.d.ts" />
+/// <reference path="../babel-types/babel-types.d.ts" />
+/// <reference path="../babel-types/babel-types.d.ts" />
+
+
+// Example from https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#babylon
+import * as babylon from "babylon";
+declare function assert(expr: boolean): void;
+
+const code = `function square(n) {
+  return n * n;
+}`;
+
+let node = babylon.parse(code);
+assert(node.type === "File");
+assert(node.start === 0);
+assert(node.end === 38);
+assert(node.loc.start > node.loc.end);
+
+
+babylon.parse(code, {
+  sourceType: "module", // default: "script"
+  plugins: ["jsx"] // default: []
+});

--- a/babylon/babylon.d.ts
+++ b/babylon/babylon.d.ts
@@ -1,0 +1,48 @@
+// Type definitions for babylon v6.7
+// Project: https://github.com/babel/babylon
+// Definitions by: Troy Gerwien <https://github.com/yortus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../babel-types/babel-types.d.ts" />
+
+declare module "babylon" {
+    import * as t from 'babel-types';
+    type Node = t.Node;
+
+    export function parse(code: string, opts?: BabylonOptions): Node;
+
+    export interface BabylonOptions {
+        /**
+         * By default, import and export declarations can only appear at a program's top level.
+         * Setting this option to true allows them anywhere where a statement is allowed.
+         */
+        allowImportExportEverywhere?: boolean;
+
+        /**
+         * By default, a return statement at the top level raises an error. Set this to true to accept such code.
+         */
+        allowReturnOutsideFunction?: boolean;
+
+        allowSuperOutsideMethod?: boolean;
+
+        /**
+         * Indicate the mode the code should be parsed in. Can be either "script" or "module".
+         */
+        sourceType?: 'script' | 'module';
+
+        /**
+         * Correlate output AST nodes with their source filename. Useful when
+         * generating code and source maps from the ASTs of multiple input files.
+         */
+        sourceFilename?: string;
+
+        /**
+         * Array containing the plugins that you want to enable.
+         */
+        plugins?: PluginName[];
+    }
+
+    export type PluginName = 'jsx' | 'flow' | 'asyncFunctions' | 'classConstructorCall' | 'doExpressions'
+        | 'trailingFunctionCommas' | 'objectRestSpread' | 'decorators' | 'classProperties' | 'exportExtensions'
+        | 'exponentiationOperator' | 'asyncGenerators' | 'functionBind' | 'functionSent';
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
### Notes

This PR adds typings for six modules that are commonly used together to author babel plugins:
- `babel-core`
- `babel-generator`
- `babel-template`
- `babel-traverse`
- `babel-types`
- `babylon`

All typings have accompanying test files, and all tests pass with Travis CI.

Babel documentation is patchy, so I've compiled typing information from several sources, basically wherever I could find details:
- the README.md of each module
- the [babel plugin handbook](https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md)
- the source code of each module, if no other documentation was available

I've added JSDoc comments where I could find them from any of the above-mentioned locations. Therefore not all exports have JSDoc comments, only those that are documented in babel source/READMEs.

For test files, I've used sample code from the modules' README files and from the babel plugin handbook. As such the tests do not provide complete API coverage, but they are a start.
