### PR TITLE
Update setErrorInterceptor method signature to be compatible with Restangular 1.5

### DIFF
--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Restangular v1.4.0
+// Type definitions for Restangular v1.5.0
 // Project: https://github.com/mgonto/restangular
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -56,7 +56,7 @@ declare namespace restangular {
     addRequestInterceptor(requestInterceptor: (element: any, operation: string, what: string, url: string) => any): void;
     setFullRequestInterceptor(fullRequestInterceptor: (element: any, operation: string, what: string, url: string, headers: any, params: any, httpConfig: angular.IRequestShortcutConfig) => {element: any; headers: any; params: any}): void;
     addFullRequestInterceptor(requestInterceptor: (element: any, operation: string, what: string, url: string, headers: any, params: any, httpConfig: angular.IRequestShortcutConfig) => {headers: any; params: any; element: any; httpConfig: angular.IRequestShortcutConfig}): void;
-    setErrorInterceptor(errorInterceptor: (response: IResponse, deferred: angular.IDeferred<any>) => any): void;
+    setErrorInterceptor(errorInterceptor: (response: IResponse, deferred: angular.IDeferred<any>, responseHandler: (response: restangular.IResponse) => any) => any): void;
     setRestangularFields(fields: {[fieldName: string]: string}): void;
     setMethodOverriders(overriders: string[]): void;
     setJsonp(jsonp: boolean): void;


### PR DESCRIPTION
Improvement to existing Restangular type definition.

Documentation and source code reference which provides context for the suggested changes:
https://github.com/mgonto/restangular#seterrorinterceptor
https://github.com/mgonto/restangular/blob/1.5.0/src/restangular.js#L1196
https://github.com/mgonto/restangular/blob/1.5.0/src/restangular.js#L1158-L1191
