### PR TITLE
Allow to use `import React from 'react';`

### DIFF
--- a/react/react-dom.d.ts
+++ b/react/react-dom.d.ts
@@ -66,10 +66,10 @@ declare namespace __React {
 
 declare module "react-dom" {
     import DOM = __React.__DOM;
-    export = DOM;
+    export default DOM;
 }
 
 declare module "react-dom/server" {
     import DOMServer = __React.__DOMServer;
-    export = DOMServer;
+    export default DOMServer;
 }

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -2314,7 +2314,7 @@ declare namespace __React {
 }
 
 declare module "react" {
-    export = __React;
+    export default __React;
 }
 
 declare namespace JSX {


### PR DESCRIPTION
Improvement to existing type definition.

This is a simple fix for default React's export.
- [ ] it has been reviewed by a DefinitelyTyped member.
