### PR TITLE
Add all keyword to chai-as-promised

### DIFF
--- a/chai-as-promised/chai-as-promised.d.ts
+++ b/chai-as-promised/chai-as-promised.d.ts
@@ -36,6 +36,7 @@ declare namespace Chai {
         // From chai
         not: PromisedAssertion;
         deep: PromisedDeep;
+        all: PromisedKeyFilter;
         a: PromisedTypeComparison;
         an: PromisedTypeComparison;
         include: PromisedInclude;
@@ -87,7 +88,6 @@ declare namespace Chai {
         that: PromisedAssertion;
         which: PromisedAssertion;
         and: PromisedAssertion;
-        all: PromisedAssertion;
         has: PromisedAssertion;
         have: PromisedAssertion;
         with: PromisedAssertion;
@@ -130,6 +130,10 @@ declare namespace Chai {
         property: PromisedProperty;
     }
 
+    interface PromisedKeyFilter {
+        keys: PromisedKeys;
+    }
+
     interface PromisedEqual {
         (value: any, message?: string): PromisedAssertion;
     }
@@ -152,6 +156,7 @@ declare namespace Chai {
         (value: number, message?: string): PromisedAssertion;
         keys: PromisedKeys;
         members: PromisedMembers;
+        all: PromisedKeyFilter;
     }
 
     interface PromisedKeys {

--- a/chai-as-promised/chai-as-promised.d.ts
+++ b/chai-as-promised/chai-as-promised.d.ts
@@ -87,6 +87,7 @@ declare namespace Chai {
         that: PromisedAssertion;
         which: PromisedAssertion;
         and: PromisedAssertion;
+        all: PromisedAssertion;
         has: PromisedAssertion;
         have: PromisedAssertion;
         with: PromisedAssertion;


### PR DESCRIPTION
According to http://chaijs.com/api/bdd/#method_keys, there should be an 'all' chainable word which is missing from the definition.
