### PR TITLE
fix: Physijs.d.ts Scene.setGravity() accepts Vector3

### DIFF
--- a/physijs/physijs.d.ts
+++ b/physijs/physijs.d.ts
@@ -147,7 +147,7 @@ declare namespace Physijs {
         add(object:THREE.Object3D):void;
         remove(object:THREE.Object3D):void;
         setFixedTimeStep(fixedTimeStep:number):void;
-        setGravity(gravity:number):void;
+        setGravity(gravity:THREE.Vector3):void;
         simulate(timeStep?:number, maxSubSteps?:number):boolean;
 
 


### PR DESCRIPTION
Method Physijs.Scene.setGravity(gravity:number) is mistyped.
It is supposed to take a THREE.Vector3 argument as per:
[https://github.com/chandlerprall/Physijs/blob/master/physijs_worker.js#L320](https://github.com/chandlerprall/Physijs/blob/master/physijs_worker.js#L320)

```
public_functions.setGravity = function( description ) {
    _vec3_1.setX(description.x);
    _vec3_1.setY(description.y);
    _vec3_1.setZ(description.z);
    world.setGravity(_vec3_1);
};
```
