### PR TITLE
Add jquery-backstretch definitions.

### DIFF
--- a/jquery-backstretch/jquery-backstretch-tests.ts
+++ b/jquery-backstretch/jquery-backstretch-tests.ts
@@ -1,0 +1,16 @@
+var backstretch = $.backstretch(['image.png'], {
+    centeredX: false,
+    centeredY: false,
+    duration: 'normal',
+    fade: 1000
+});
+
+backstretch.next();
+backstretch.prev();
+backstretch.pause();
+backstretch.resize();
+backstretch.resume();
+backstretch.destroy(true);
+
+jQuery('body').backstretch(['image.png']).pause();
+jQuery('body').backstretch('resume');

--- a/jquery-backstretch/jquery-backstretch-tests.ts
+++ b/jquery-backstretch/jquery-backstretch-tests.ts
@@ -1,4 +1,7 @@
-var backstretch = $.backstretch(['image.png'], {
+/// <reference path="../jquery/jquery.d.ts"/>
+/// <reference path="jquery-backstretch.d.ts"/>
+
+var backstretch = jQuery.backstretch(['image.png'], {
     centeredX: false,
     centeredY: false,
     duration: 'normal',

--- a/jquery-backstretch/jquery-backstretch.d.ts
+++ b/jquery-backstretch/jquery-backstretch.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jquery-backstretch v 2.0.4
+// Type definitions for backstretch v 2.0.4
 // Project: https://github.com/srobbin/jquery-backstretch
 // Definitions by: Dmytro Kulyk <lnkvisitor.ts@gmail.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -78,7 +78,7 @@ declare namespace JQueryBackStretch {
          *
          * @param {boolean} preserveBackground
          */
-        destroy(preserveBackground?:boolean);
+        destroy(preserveBackground?:boolean):void;
     }
 }
 

--- a/jquery-backstretch/jquery-backstretch.d.ts
+++ b/jquery-backstretch/jquery-backstretch.d.ts
@@ -1,0 +1,92 @@
+// Type definitions for jquery-backstretch v 2.0.4
+// Project: https://github.com/srobbin/jquery-backstretch
+// Definitions by: Dmytro Kulyk <lnkvisitor.ts@gmail.com>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../jquery/jquery.d.ts" />
+
+declare namespace JQueryBackStretch {
+
+    interface BackStretchOptions {
+        /**
+         * The ratio of the width/height of the image doesn't always jive with the
+         * width/height of the window. This parameter controls whether or not we
+         * center the image on the X axis to account for the discrepancy.
+         */
+        centeredX?:boolean;
+
+        /**
+         * This parameter controls whether or not we center the image on the Y axis
+         * to account for the aforementioned discrepancy.
+         */
+        centeredY?:boolean;
+
+        /**
+         * This is the speed at which the image will fade in. Integers in
+         * milliseconds are accepted, as well as standard jQuery speed strings
+         * (slow, normal, fast).
+         */
+        duration?:number | string;
+
+        /**
+         * The amount of time in between slides, when using Backstretch as a
+         * slideshow, expressed as the number of milliseconds.
+         */
+        fade?:number;
+    }
+
+    interface BackStretch {
+        /**
+         * This method is called automatically when the container (window or
+         * block-level element) is resized, however you can always call this
+         * manually if needed.
+         */
+        resize():BackStretch;
+
+        /**
+         * Jump to the slide at a given index, where n is the number of the
+         * image that you'd like to display. Slide number starts at 0.
+         *
+         * @param {number} newIndex
+         */
+        show(newIndex:number):BackStretch;
+
+        /**
+         * Advance to the next image in a slideshow.
+         */
+        next():BackStretch;
+
+        /**
+         * Display the previous image in a slideshow.
+         */
+        prev():BackStretch;
+
+        /**
+         * Pause the slideshow.
+         */
+        pause():BackStretch;
+
+        /**
+         * Resume a paused slideshow.
+         */
+        resume():BackStretch;
+
+        /**
+         * Destroy the Backstretch instance. Optionally, you can pass in a Boolean
+         * parameter, preserveBackground, to determine whether or not you'd like
+         * to keep the current image stretched as the background image.
+         *
+         * @param {boolean} preserveBackground
+         */
+        destroy(preserveBackground?:boolean);
+    }
+}
+
+interface JQueryStatic {
+    backstretch(images:string[], config?:JQueryBackStretch.BackStretchOptions):JQueryBackStretch.BackStretch;
+}
+
+interface JQuery {
+    backstretch(images:string[], config?:JQueryBackStretch.BackStretchOptions):JQueryBackStretch.BackStretch;
+    backstretch(method:string):JQuery;
+}

--- a/jquery-backstretch/jquery-backstretch.d.ts
+++ b/jquery-backstretch/jquery-backstretch.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for backstretch v 2.0.4
 // Project: https://github.com/srobbin/jquery-backstretch
-// Definitions by: Dmytro Kulyk <lnkvisitor.ts@gmail.com>
+// Definitions by: Dmytro Kulyk <https://github.com/dkulyk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../jquery/jquery.d.ts" />


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
