### PR TITLE
react-select: Allow placeholder to be an Element

### DIFF
--- a/react-select/react-select.d.ts
+++ b/react-select/react-select.d.ts
@@ -173,7 +173,7 @@ declare namespace ReactSelect {
          * field placeholder, displayed when there's no value
          * @default "Select..."
          */
-        placeholder?: string;
+        placeholder?: string | __React.ReactElement<any>;
         /**
          * whether to enable searching feature or not
          * @default true;


### PR DESCRIPTION
As per the documentation at https://github.com/JedWatson/react-select
