### PR TITLE
react-bootstrap: add missing function props to Modal

### DIFF
--- a/react-bootstrap/react-bootstrap-tests.tsx
+++ b/react-bootstrap/react-bootstrap-tests.tsx
@@ -281,7 +281,7 @@ export class ReactBootstrapTest extends Component<any, any> {
 
                 <div style={style}>
                   <div className='static-modal'>
-                    <Modal.Dialog>
+                    <Modal.Dialog onHide={this.callback} onEnter={this.callback} onEntered={this.callback} onEntering={this.callback} onExit={this.callback} onExited={this.callback} onExiting={this.callback}>
                       <Modal.Header>
                         <Modal.Title>Modal title</Modal.Title>
                       </Modal.Header>

--- a/react-bootstrap/react-bootstrap.d.ts
+++ b/react-bootstrap/react-bootstrap.d.ts
@@ -190,6 +190,12 @@ declare module "react-bootstrap" {
         dialogComponent?: any; // TODO: Add more specific type
         enforceFocus?: boolean;
         keyboard?: boolean;
+        onEnter?: Function;
+        onEntered?: Function;
+        onEntering?: Function;
+        onExit?: Function;
+        onExited?: Function;
+        onExiting?: Function;
         show?: boolean;
     }
     interface ModalClass extends React.ClassicComponentClass<ModalProps> {

--- a/react-bootstrap/react-bootstrap.d.ts
+++ b/react-bootstrap/react-bootstrap.d.ts
@@ -190,12 +190,12 @@ declare module "react-bootstrap" {
         dialogComponent?: any; // TODO: Add more specific type
         enforceFocus?: boolean;
         keyboard?: boolean;
-        onEnter?: Function;
-        onEntered?: Function;
-        onEntering?: Function;
-        onExit?: Function;
-        onExited?: Function;
-        onExiting?: Function;
+        onEnter?: (node: HTMLElement) => any;
+        onEntered?: (node: HTMLElement) => any;
+        onEntering?: (node: HTMLElement) => any;
+        onExit?: (node: HTMLElement) => any;
+        onExited?: (node: HTMLElement) => any;
+        onExiting?: (node: HTMLElement) => any;
         show?: boolean;
     }
     interface ModalClass extends React.ClassicComponentClass<ModalProps> {


### PR DESCRIPTION
Added the missing event props to Modal for onEnter, onEntered, onEntering, onExit, onExited, onExiting

see: https://react-bootstrap.github.io/components.html#modals-props
