### PR TITLE
Added RegExp typing to 'path' argument descriptions

### DIFF
--- a/nock/nock.d.ts
+++ b/nock/nock.d.ts
@@ -22,28 +22,45 @@ declare module "nock" {
 
 		export interface Scope {
 			get(path: string, data?: string): Scope;
+			get(path: RegExp, data?: string): Scope;
 
 			post(path: string, data?: string): Scope;
 			post(path: string, data?: Object): Scope;
 			post(path: string, regex?: RegExp): Scope;
+			post(path: RegExp, data?: string): Scope;
+			post(path: RegExp, data?: Object): Scope;
+			post(path: RegExp, regex?: RegExp): Scope;
 
 			patch(path: string, data?: string): Scope;
 			patch(path: string, data?: Object): Scope;
 			patch(path: string, regex?: RegExp): Scope;
+			patch(path: RegExp, data?: string): Scope;
+			patch(path: RegExp, data?: Object): Scope;
+			patch(path: RegExp, regex?: RegExp): Scope;
 
 			put(path: string, data?: string): Scope;
 			put(path: string, data?: Object): Scope;
 			put(path: string, regex?: RegExp): Scope;
+			put(path: RegExp, data?: string): Scope;
+			put(path: RegExp, data?: Object): Scope;
+			put(path: RegExp, regex?: RegExp): Scope;
 
 			head(path: string): Scope;
+			head(path: RegExp): Scope;
 
 			delete(path: string, data?: string): Scope;
 			delete(path: string, data?: Object): Scope;
 			delete(path: string, regex?: RegExp): Scope;
+			delete(path: RegExp, data?: string): Scope;
+			delete(path: RegExp, data?: Object): Scope;
+			delete(path: RegExp, regex?: RegExp): Scope;
 
 			merge(path: string, data?: string): Scope;
 			merge(path: string, data?: Object): Scope;
 			merge(path: string, regex?: RegExp): Scope;
+			merge(path: RegExp, data?: string): Scope;
+			merge(path: RegExp, data?: Object): Scope;
+			merge(path: RegExp, regex?: RegExp): Scope;
 
 			query(params: any): Scope;
 			query(acceptAnyParams: boolean): Scope;
@@ -51,6 +68,9 @@ declare module "nock" {
 			intercept(path: string, verb: string, body?: string, options?: any): Scope;
 			intercept(path: string, verb: string, body?: Object, options?: any): Scope;
 			intercept(path: string, verb: string, body?: RegExp, options?: any): Scope;
+			intercept(path: RegExp, verb: string, body?: string, options?: any): Scope;
+			intercept(path: RegExp, verb: string, body?: Object, options?: any): Scope;
+			intercept(path: RegExp, verb: string, body?: RegExp, options?: any): Scope;
 
 			reply(responseCode: number, body?: string, headers?: Object): Scope;
 			reply(responseCode: number, body?: Object, headers?: Object): Scope;


### PR DESCRIPTION
Improvement to existing type definition.

nock allows the use of a regular expression as path so I've added that to the type definition.
See https://www.npmjs.com/package/nock#specifying-path
