### PR TITLE
Allow `any` as Cookie Value

### DIFF
--- a/hapi/hapi.d.ts
+++ b/hapi/hapi.d.ts
@@ -303,7 +303,7 @@ declare module "hapi" {
 		response(result: any): Response;
 
 		/** Sets a cookie on the response */
-		state(name: string, value: string, options?: any): void;
+		state(name: string, value: any, options?: any): void;
 
 		/** Clears a cookie on the response */
 		unstate(name: string, options?: any): void;


### PR DESCRIPTION
In the official [Hapi.js Cookie Tutorial](http://hapijs.com/tutorials/cookies), storing an object in a cookie is demonstrated. Therefore, not only `string` is allowed as value.
