### PR TITLE
Update Vue v1.0.16 -> v1.0.21

### DIFF
--- a/vue/vue-tests.ts
+++ b/vue/vue-tests.ts
@@ -8,7 +8,7 @@ namespace TestConfig {
   Vue.config.unsafeDelimiters = ['{!!', '!!}'];
   Vue.config.silent = true;
   Vue.config.async = false;
-  Vue.config.convertAllProperties = true;
+  Vue.config.devtools = true;
 }
 
 namespace TestGlobalAPI {
@@ -66,6 +66,16 @@ namespace TestGlobalAPI {
         set: function(val: number) { this.d = val; }
       }
     }
+  });
+  Vue.component("component", {
+    props: {
+      a: [String, Number],
+      b: {
+        type: [Number, Function],
+        required: true
+      }
+    },
+    init: function() {}
   });
   var transition = Vue.transition("transition");
   Vue.transition("transition", transition);

--- a/vue/vue.d.ts
+++ b/vue/vue.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for vuejs 1.0.16
+// Type definitions for vuejs 1.0.21
 // Project: https://github.com/vuejs/vue
 // Definitions by: odangosan <https://github.com/odangosan>, kaorun343 <https://github.com/kaorun343>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -11,7 +11,7 @@ interface Array<T> {
 declare namespace vuejs {
 
     interface PropOption {
-        type?: { new (...args: any[]): any; };
+        type?: { new (...args: any[]): any; } | { new (...args: any[]): any; }[];
         required?: boolean;
         default?: any;
         twoWay?: boolean;
@@ -68,13 +68,14 @@ declare namespace vuejs {
 
     interface ComponentOption {
         data?: { [key: string]: any } | Function;
-        props?: string[] | { [key: string]: (PropOption | { new (...args: any[]): any; }) };
+        props?: string[] | { [key: string]: (PropOption | { new (...args: any[]): any; } | { new (...args: any[]): any; }[]) };
         computed?: { [key: string]: (Function | ComputedOption) };
         methods?: { [key: string]: Function };
         watch?: { [key: string]: ((val: any, oldVal: any) => void) | string | WatchOption };
         el?: string | HTMLElement | (() => HTMLElement);
         template?: string;
         replace?: boolean;
+        init?(): void;
         created?(): void;
         beforeCompile?(): void;
         compiled?(): void;
@@ -143,7 +144,7 @@ declare namespace vuejs {
         unsafeDelimiters: [string, string];
         silent: boolean;
         async: boolean;
-        convertAllProperties: boolean;
+        devtools: boolean;
     }
 
     interface VueUtil {


### PR DESCRIPTION
Improvement to existing type definition.
- `Vue.config.devtools` is added on v1.0.18
  - https://vuejs.org/api/#devtools
  - https://github.com/vuejs/vue/releases/tag/v1.0.18
- `Vue.config.convertAllProperties` has been removed on v1.0.17
  - https://github.com/vuejs/vue/releases/tag/v1.0.17
- Component prop type can be array of type from v1.0.21
  - https://github.com/vuejs/vue/releases/tag/v1.0.21
- Component init callback is documented but is not defined. I have added its definition.
  - https://vuejs.org/api/#init
