### PR TITLE
Adding some form components in react-bootstrap

### DIFF
--- a/react-bootstrap/react-bootstrap-tests.tsx
+++ b/react-bootstrap/react-bootstrap-tests.tsx
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------------
 import * as React from 'react';
 import { Component, CSSProperties } from 'react';
-import { Button, ButtonToolbar, Modal, Well, ButtonGroup, DropdownButton, MenuItem, Panel, ListGroup, ListGroupItem, Accordion, Tooltip, OverlayTrigger, Popover, ProgressBar, Nav, NavItem, Navbar, NavDropdown, Tabs, Tab, Pager, PageItem, Pagination, Alert, Carousel, CarouselItem, Grid, Row, Col, Thumbnail, Label, Badge, Jumbotron, PageHeader, Glyphicon, Table, Input, ButtonInput, FormControls } from 'react-bootstrap';
+import { Button, ButtonToolbar, Modal, Well, ButtonGroup, DropdownButton, MenuItem, Panel, ListGroup, ListGroupItem, Accordion, Tooltip, OverlayTrigger, Popover, ProgressBar, Nav, NavItem, Navbar, NavDropdown, Tabs, Tab, Pager, PageItem, Pagination, Alert, Carousel, CarouselItem, Grid, Row, Col, Thumbnail, Label, Badge, Jumbotron, PageHeader, Glyphicon, Table, Input, ButtonInput, FormControls, Form, FormGroup, ControlLabel, FormControl, HelpBlock, Radio, Checkbox } from 'react-bootstrap';
 
 
 export class ReactBootstrapTest extends Component<any, any> {
@@ -910,6 +910,37 @@ export class ReactBootstrapTest extends Component<any, any> {
                       </Col>
                     </Row>
                   </Input>
+                </div>
+                
+                <div style={style}>
+                  <Form>
+                    <FormGroup
+                      controlId="formBasicText"
+                    >
+                      <ControlLabel>Control Label</ControlLabel>
+                      <FormControl
+                        type="text"                        
+                        placeholder="Enter text"
+                      />
+                      <FormControl.Feedback />
+                      <HelpBlock>Help block message.</HelpBlock>
+                    </FormGroup>
+                    
+                    <FormGroup>
+                      <Checkbox name="checkbox" inline>1</Checkbox>
+                      {' '}
+                      <Checkbox name="checkbox" inline>2</Checkbox>
+                      {' '}
+                      <Checkbox name="checkbox" inline>3</Checkbox>
+                    </FormGroup>
+                    <FormGroup>
+                      <Radio name="radio" inline>1</Radio>
+                      {' '}
+                      <Radio name="radio" inline>2</Radio>
+                      {' '}
+                      <Radio name="radio" inline>3</Radio>
+                    </FormGroup>
+                  </Form>
                 </div>
             </div>
         );

--- a/react-bootstrap/react-bootstrap.d.ts
+++ b/react-bootstrap/react-bootstrap.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-bootstrap
 // Project: https://github.com/react-bootstrap/react-bootstrap
-// Definitions by: Walker Burgin <https://github.com/walkerburgin>, Vincent Siao <https://github.com/vsiao>
+// Definitions by: Walker Burgin <https://github.com/walkerburgin>, Vincent Siao <https://github.com/vsiao>, Danilo Barros <https://github.com/danilojrr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 ///<reference path="../react/react.d.ts"/>
@@ -704,6 +704,88 @@ declare module "react-bootstrap" {
     }
     var FormControls: FormControlsClass;
 
+    // <Form />
+    // ----------------------------------------
+    interface FormProps extends React.HTMLAttributes {
+        bsClass?: string;
+        componentClass?: string;
+        horizontal?: boolean;
+        inline?: boolean;
+    }
+    type Form = React.ClassicComponent<FormProps, {}>;
+    var Form: React.ClassicComponentClass<FormProps>;
+
+    // <FormGroup />
+    // ----------------------------------------
+    interface FormGroupProps extends React.HTMLAttributes {
+        bsClass?: string;
+        bsSize?: 'sm' | 'small' | 'lg' | 'large';
+        controlId?: string;
+        validationState?: 'success' | 'warning' | 'error';
+    }
+    type FormGroup = React.ClassicComponent<FormGroupProps, {}>;
+    var FormGroup: React.ClassicComponentClass<FormGroupProps>;
+    
+    // <ControlLabel />
+    // ----------------------------------------
+    interface ControlLabelProps extends React.HTMLAttributes {
+        bsClass?: string;
+        htmlFor?: string;
+        srOnly?: boolean;
+    }
+    type ControlLabel = React.ClassicComponent<ControlLabelProps, {}>;
+    var ControlLabel: React.ClassicComponentClass<ControlLabelProps>;
+    
+    // <FormControl.Feedback />
+    // ----------------------------------------
+    interface FormControlFeedbackProps extends React.HTMLAttributes {
+    }
+    class FormControlFeedback extends React.Component<FormControlFeedbackProps, {}> {
+    }
+    
+    // <FormControl />
+    // ----------------------------------------
+    interface FormControlProps extends React.HTMLAttributes {
+        bsClass?: string;
+        componentClass?: string;
+        id?: string;
+        type?: string;
+    }
+    interface FormControlClass extends React.ClassicComponentClass<FormControlProps> {
+        Feedback: typeof FormControlFeedback;
+    }
+    type FormControl = React.ClassicComponent<FormControlProps, {}>;
+    var FormControl: FormControlClass;
+    
+    // <HelpBlock />
+    // ----------------------------------------
+    interface HelpBlockProps extends React.HTMLAttributes {
+        bsClass?: string;
+    }
+    type HelpBlock = React.ClassicComponent<HelpBlockProps, {}>;
+    var HelpBlock: React.ClassicComponentClass<HelpBlockProps>;
+    
+    // <Checkbox />
+    // ----------------------------------------
+    interface CheckboxProps extends React.HTMLAttributes {
+        bsClass?: string;
+        disabled?: boolean;
+        inline?: boolean;
+        validationState?: 'success' | 'warning' | 'error';
+    }
+    type Checkbox = React.ClassicComponent<CheckboxProps, {}>;
+    var Checkbox: React.ClassicComponentClass<CheckboxProps>;
+    
+    // <Radio />
+    // ----------------------------------------
+    interface RadioProps extends React.HTMLAttributes {
+        bsClass?: string;
+        disabled?: boolean;
+        inline?: boolean;
+        validationState?: 'success' | 'warning' | 'error';
+    }
+    type Radio = React.ClassicComponent<RadioProps, {}>;
+    var Radio: React.ClassicComponentClass<RadioProps>;
 
     // <Portal />
     // ----------------------------------------

--- a/react-bootstrap/react-bootstrap.d.ts
+++ b/react-bootstrap/react-bootstrap.d.ts
@@ -21,7 +21,7 @@ declare module "react-bootstrap" {
         bsSize?: string;
         navItem?: boolean;
         navDropdown?: boolean;
-        componentClass?: string;
+        componentClass?: React.ReactType;
     }
     type Button = React.ClassicComponent<ButtonProps, {}>;
     var Button: React.ClassicComponentClass<ButtonProps>;
@@ -329,7 +329,7 @@ declare module "react-bootstrap" {
         brand?: any; // TODO: Add more specific type
         bsSize?: string;
         bsStyle?: string;
-        componentClass?: any; // TODO: Add more specific type
+        componentClass?: React.ReactType;
         defaultNavExpanded?: boolean;
         eventKey?: any;
         fixedBottom?: boolean;
@@ -380,7 +380,7 @@ declare module "react-bootstrap" {
         brand?: any; // TODO: Add more specific type
         bsSize?: string;
         bsStyle?: string;
-        componentClass?: any; // TODO: Add more specific type
+        componentClass?: React.ReactType;
         defaultNavExpanded?: boolean;
         fixedBottom?: boolean;
         fixedTop?: boolean;
@@ -455,7 +455,7 @@ declare module "react-bootstrap" {
         activePage?: number;
         bsSize?: string;
         bsStyle?: string;
-        buttonComponentClass?: any; // TODO: Add more specific type
+        buttonComponentClass?: React.ReactType;
         ellipsis?: boolean;
         first?: boolean;
         items?: number;
@@ -516,7 +516,7 @@ declare module "react-bootstrap" {
     // <Grid />
     // ----------------------------------------
     interface GridProps extends React.HTMLAttributes {
-        componentClass?: any; // TODO: Add more specific type
+        componentClass?: React.ReactType;
         fluid?: boolean;
     }
     type Grid = React.ClassicComponent<GridProps, {}>;
@@ -525,7 +525,7 @@ declare module "react-bootstrap" {
     // <Row />
     // ----------------------------------------
     interface RowProps extends React.HTMLAttributes {
-        componentClass?: any; // TODO: Add more specific type
+        componentClass?: React.ReactType; 
     }
     type Row = React.ClassicComponent<RowProps, {}>;
     var Row: React.ClassicComponentClass<RowProps>;
@@ -533,7 +533,7 @@ declare module "react-bootstrap" {
     // <Col />
     // ----------------------------------------
     interface ColProps extends React.HTMLAttributes {
-        componentClass?: any; // TODO: Add more specific type
+        componentClass?: React.ReactType;
         lg?: number;
         lgHidden?: boolean;
         lgOffset?: number;
@@ -609,7 +609,7 @@ declare module "react-bootstrap" {
     // <Jumbotron />
     // ----------------------------------------
     interface JumbotronProps extends React.HTMLAttributes {
-        componentClass?: any; // TODO: Add more specific type
+        componentClass?: React.ReactType;
     }
     type Jumbotron = React.ClassicComponent<JumbotronProps, {}>;
     var Jumbotron: React.ClassicComponentClass<JumbotronProps>;
@@ -708,23 +708,21 @@ declare module "react-bootstrap" {
     // ----------------------------------------
     interface FormProps extends React.HTMLAttributes {
         bsClass?: string;
-        componentClass?: string;
+        componentClass?: React.ReactType;
         horizontal?: boolean;
         inline?: boolean;
     }
-    type Form = React.ClassicComponent<FormProps, {}>;
-    var Form: React.ClassicComponentClass<FormProps>;
+    class Form extends React.Component<FormProps, {}> {}
 
     // <FormGroup />
     // ----------------------------------------
     interface FormGroupProps extends React.HTMLAttributes {
         bsClass?: string;
-        bsSize?: 'sm' | 'small' | 'lg' | 'large';
+        bsSize?: "sm" | "small" | "lg" | "large";
         controlId?: string;
-        validationState?: 'success' | 'warning' | 'error';
+        validationState?: "success" | "warning" | "error";
     }
-    type FormGroup = React.ClassicComponent<FormGroupProps, {}>;
-    var FormGroup: React.ClassicComponentClass<FormGroupProps>;
+    class FormGroup extends React.Component<FormGroupProps, {}> {}
     
     // <ControlLabel />
     // ----------------------------------------
@@ -733,8 +731,7 @@ declare module "react-bootstrap" {
         htmlFor?: string;
         srOnly?: boolean;
     }
-    type ControlLabel = React.ClassicComponent<ControlLabelProps, {}>;
-    var ControlLabel: React.ClassicComponentClass<ControlLabelProps>;
+    class ControlLabel extends React.Component<ControlLabelProps, {}> {}
     
     // <FormControl.Feedback />
     // ----------------------------------------
@@ -747,14 +744,14 @@ declare module "react-bootstrap" {
     // ----------------------------------------
     interface FormControlProps extends React.HTMLAttributes {
         bsClass?: string;
-        componentClass?: string;
+        componentClass?: React.ReactType;
         id?: string;
         type?: string;
     }
     interface FormControlClass extends React.ClassicComponentClass<FormControlProps> {
         Feedback: typeof FormControlFeedback;
     }
-    type FormControl = React.ClassicComponent<FormControlProps, {}>;
+    type FormControl = React.Component<FormControlProps, {}>;
     var FormControl: FormControlClass;
     
     // <HelpBlock />
@@ -762,8 +759,7 @@ declare module "react-bootstrap" {
     interface HelpBlockProps extends React.HTMLAttributes {
         bsClass?: string;
     }
-    type HelpBlock = React.ClassicComponent<HelpBlockProps, {}>;
-    var HelpBlock: React.ClassicComponentClass<HelpBlockProps>;
+    class HelpBlock extends React.Component<HelpBlockProps, {}> {}
     
     // <Checkbox />
     // ----------------------------------------
@@ -771,10 +767,9 @@ declare module "react-bootstrap" {
         bsClass?: string;
         disabled?: boolean;
         inline?: boolean;
-        validationState?: 'success' | 'warning' | 'error';
+        validationState?: "success" | "warning" | "error";
     }
-    type Checkbox = React.ClassicComponent<CheckboxProps, {}>;
-    var Checkbox: React.ClassicComponentClass<CheckboxProps>;
+    class Checkbox extends React.Component<CheckboxProps, {}> {}
     
     // <Radio />
     // ----------------------------------------
@@ -782,10 +777,9 @@ declare module "react-bootstrap" {
         bsClass?: string;
         disabled?: boolean;
         inline?: boolean;
-        validationState?: 'success' | 'warning' | 'error';
+        validationState?: "success" | "warning" | "error";
     }
-    type Radio = React.ClassicComponent<RadioProps, {}>;
-    var Radio: React.ClassicComponentClass<RadioProps>;
+    class Radio extends React.Component<RadioProps, {}> {}
 
     // <Portal />
     // ----------------------------------------


### PR DESCRIPTION
Some components are missing in react-bootstrap.
So I added some of them like you see here: https://github.com/danilojrr/DefinitelyTyped/commit/a6a476190ce2197f04f541c360fdccc543f0005d

The new components was created based on react-bootstrap documentation. Topics: [Forms](https://react-bootstrap.github.io/components.html#forms) and [Supported Controls](https://react-bootstrap.github.io/components.html#forms-controls).

cc @walkerburgin @vsiao 
