### PR TITLE
sequelize: fix FindOptions

### DIFF
--- a/sequelize/sequelize-tests.ts
+++ b/sequelize/sequelize-tests.ts
@@ -882,6 +882,8 @@ User.findAll( { order : [['id', ';DELETE YOLO INJECTIONS']] } );
 User.findAll( { include : [User], order : [[User, 'id', ';DELETE YOLO INJECTIONS']] } );
 User.findAll( { include : [User], order : [['id', 'ASC NULLS LAST'], [User, 'id', 'DESC NULLS FIRST']] } );
 User.findAll( { include : [{ model : User, where : { title : 'DoDat' }, include : [{ model : User }] }] } );
+User.findAll( { attributes: ['username', 'data']});
+User.findAll( { attributes: {include: ['username', 'data']} });
 
 User.findById( 'a string' );
 

--- a/sequelize/sequelize.d.ts
+++ b/sequelize/sequelize.d.ts
@@ -3121,7 +3121,7 @@ declare module "sequelize" {
              * `Sequelize.literal`, `Sequelize.fn` and so on), and the second is the name you want the attribute to
              * have in the returned instance
              */
-            attributes? : Array<string | [string, string]>;
+            attributes? :  Array<string> | { include?: Array<string>, exclude?: Array<string> };
 
             /**
              * If true, only non-deleted records will be returned. If false, both deleted and non-deleted records will


### PR DESCRIPTION
Fix FindOptions.attributes. Now allows a object having include and/or exclude properties.
See the params table in 
http://sequelize.readthedocs.org/en/latest/api/model/#findalloptions-promisearrayinstance
