### PR TITLE
add `setExtent` to ol.proj.Projection and make transform `ol.geom.Point` accept `ol.proj.Projection`

### DIFF
--- a/openlayers/openlayers-tests.ts
+++ b/openlayers/openlayers-tests.ts
@@ -136,6 +136,7 @@ coordinate = geometryResult.getClosestPoint(coordinate);
 geometryResult.getClosestPoint(coordinate, coordinate);
 extent = geometryResult.getExtent();
 geometryResult.getExtent(extent);
+geometryResult.transform(projection, projection);
 
 //
 //

--- a/openlayers/openlayers-tests.ts
+++ b/openlayers/openlayers-tests.ts
@@ -338,6 +338,7 @@ var tileLayer: ol.layer.Tile = new ol.layer.Tile({
 projection = new ol.proj.Projection({
     code:stringValue,    
 });
+projection.setExtent(projection.getExtent());
 
 //
 // ol.Map 

--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -4054,6 +4054,12 @@ declare namespace ol {
             constructor(options: olx.Projection);
 
             getExtent(): Extent;
+
+            /**
+             * Set the validity extent for this projection.
+             * @param extent The new extent of the projection.
+             */
+            setExtent(extent: Extent): void;
         }
     }
 

--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -2936,7 +2936,7 @@ declare namespace ol {
              * @param destination The desired projection. Can be a string identifier or a ol.proj.Projection object.
              * @return This geometry. Note that original geometry is modified in place.
              */
-            transform(source: ol.proj.ProjectionLike, destination: ol.proj.ProjectionLike): ol.geom.Geometry;
+            transform(source: ol.proj.ProjectionLike | ol.proj.Projection, destination: ol.proj.ProjectionLike | ol.proj.Projection): ol.geom.Geometry;
         }
 
         /**


### PR DESCRIPTION
- setExtent is described here: http://openlayers.org/en/v3.0.0/apidoc/ol.proj.Projection.html#setExtent
  - "Type `ol.Extent`"
- transform is described here: http://openlayers.org/en/v3.0.0/apidoc/ol.geom.Point.html#transform
  - "Can be a string identifier or a ol.proj.Projection object."

Reject https://github.com/DefinitelyTyped/DefinitelyTyped/pull/8986 and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/8973 in favor of this pull request.
