### PR TITLE
angular-protractor.d.ts - fix for waitForAngular

### DIFF
--- a/angular-protractor/angular-protractor.d.ts
+++ b/angular-protractor/angular-protractor.d.ts
@@ -1683,7 +1683,7 @@ declare namespace protractor {
          * @return {!webdriver.promise.Promise} A promise that will resolve to the
          *    scripts return value.
          */
-        waitForAngular(): webdriver.promise.Promise<void>;
+        waitForAngular(): webdriver.promise.Promise<any>;
 
         /**
          * Add a module to load before Angular whenever Protractor.get is called.


### PR DESCRIPTION
Citing inline apidoc:

```
* @return {!webdriver.promise.Promise} A promise that will resolve to the
*    scripts return value.
*/
```

and this is not `Promise<void>`. This is `Promise<any>`.
