### PR TITLE
react-select: use export default to match library

### DIFF
--- a/react-select/react-select-tests.tsx
+++ b/react-select/react-select-tests.tsx
@@ -5,7 +5,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import * as Select from "react-select";
+import Select from "react-select";
 
 class SelectTest extends React.Component<React.Props<{}>, {}> {
 

--- a/react-select/react-select.d.ts
+++ b/react-select/react-select.d.ts
@@ -302,5 +302,5 @@ declare namespace ReactSelect {
 
 declare module "react-select" {
     const select: ReactSelect.ReactSelectClass;
-    export = select;
+    export default select;
 }


### PR DESCRIPTION
In the `react-select` library (the latest one, 1.0.0-beta12), Select.js uses `export default`. When I tried using

``` js
import * as Select from 'react-select';
```

React would throw an Invariant Violation: Element type is invalid, saying that the type was object. Changing the type definitions to use `export default`, and changing the import statement above to

``` js
import Select from 'react-select';
```

fixes the issue.
