### PR TITLE
Update bookshelf.d.ts

### DIFF
--- a/bookshelf/bookshelf-tests.ts
+++ b/bookshelf/bookshelf-tests.ts
@@ -15,6 +15,9 @@ var knex = Knex({
 
 var bookshelf = Bookshelf(knex);
 
+bookshelf.plugin('registry');
+bookshelf.plugin(['virtuals']);
+
 class User extends bookshelf.Model<User> {
 	get tableName() { return 'users'; }
 	messages() : Bookshelf.Collection<Posts> {

--- a/bookshelf/bookshelf.d.ts
+++ b/bookshelf/bookshelf.d.ts
@@ -18,7 +18,7 @@ declare module 'bookshelf' {
 		Model : typeof Bookshelf.Model;
 		Collection : typeof Bookshelf.Collection;
 
-		plugin(name: string) : Bookshelf;
+		plugin(name: string | string[] | Function, options?: any) : Bookshelf;
 		transaction<T>(callback : (transaction : knex.Transaction) => T) : Promise<T>;
 	}
 


### PR DESCRIPTION
Improve the existing type definition for [Bookshelf.js](https://github.com/tgriesser/bookshelf).

The `plugin` function can either take [a string](https://github.com/tgriesser/bookshelf/blob/master/src/bookshelf.js#L246), [an array](https://github.com/tgriesser/bookshelf/blob/master/src/bookshelf.js#L257), or [a custom function](https://github.com/tgriesser/bookshelf/blob/master/src/bookshelf.js#L262), and it also takes optional `options`.
