### PR TITLE
Exposed angular.mock.module.sharedInjector method for jasmine and moc…

### DIFF
--- a/angularjs/angular-mocks-tests.ts
+++ b/angularjs/angular-mocks-tests.ts
@@ -36,6 +36,7 @@ mock.module(
     function () { return 2; }
     );
 mock.module({ module1: function () { return 1; } });
+mock.module.sharedInjector();
 
 date = mock.TzDate(-7, '2013-1-1T15:00:00Z');
 date = mock.TzDate(-8, 12345678);

--- a/angularjs/angular-mocks.d.ts
+++ b/angularjs/angular-mocks.d.ts
@@ -47,7 +47,10 @@ declare namespace angular {
         inject: IInjectStatic
 
         // see https://docs.angularjs.org/api/ngMock/function/angular.mock.module
-        module(...modules: any[]): any;
+        module: {
+          (...modules: any[]): any;
+          sharedInjector(): void;
+        }
 
         // see https://docs.angularjs.org/api/ngMock/type/angular.mock.TzDate
         TzDate(offset: number, timestamp: number): Date;


### PR DESCRIPTION
**case 2. Improvement to existing type definition.**

Exposed [angular.mock.module.sharedInjector](https://docs.angularjs.org/api/ngMock/function/angular.mock.module.sharedInjector) method that can be used with Jasmine or Mocha testing to take advantage of Jasmine's beforeAll() or Mocha's before() method for test setup.

sharedInjector() [source](https://github.com/angular/angular.js/blob/master/src/ngMock/angular-mocks.js#L2779)
