### PR TITLE
Fix Metadata definition in S3.putObject method

### DIFF
--- a/aws-sdk/aws-sdk.d.ts
+++ b/aws-sdk/aws-sdk.d.ts
@@ -1072,7 +1072,7 @@ declare module "aws-sdk" {
 			GrantReadACP?: string;
 			GrantWriteACP?: string;
 			Key: string;
-			Metadata?: any;
+			Metadata?: { [key: string]:string; };
 			ServerSideEncryption?: string;
 			StorageClass?: string;
 			WebsiteRedirectLocation?: string;

--- a/aws-sdk/aws-sdk.d.ts
+++ b/aws-sdk/aws-sdk.d.ts
@@ -1072,7 +1072,7 @@ declare module "aws-sdk" {
 			GrantReadACP?: string;
 			GrantWriteACP?: string;
 			Key: string;
-			Metadata?: string[];
+			Metadata?: any;
 			ServerSideEncryption?: string;
 			StorageClass?: string;
 			WebsiteRedirectLocation?: string;


### PR DESCRIPTION
This is a bug fix for the aws-sdk type definition.

In the `putObject` method, `Metadata` is a map of strings, not an array as it's currently stated.

Citing [the docs](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property):

``` js
var params = {
  Bucket: 'STRING_VALUE', /* required */
  Key: 'STRING_VALUE', /* required */
  …
  Metadata: {
    someKey: 'STRING_VALUE',
    /* anotherKey: ... */
  },
```
