### PR TITLE
react-select: Export the Option interface

### DIFF
--- a/react-select/react-select-tests.tsx
+++ b/react-select/react-select-tests.tsx
@@ -5,16 +5,16 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import Select from "react-select";
+import Select, { Option } from "react-select";
 
 class SelectTest extends React.Component<React.Props<{}>, {}> {
 
     render() {
-        const options: ReactSelect.Option[] = [{ label: "Foo", value: "bar" }];
+        const options: Option[] = [{ label: "Foo", value: "bar" }];
         const onChange = (value: any) => console.log(value);
         const onOpen = () => { return; };
         const onClose = () => { return; };
-        const optionRenderer = (option: ReactSelect.Option) => <span>{option.label}</span>
+        const optionRenderer = (option: Option) => <span>{option.label}</span>
         return <div>
             <Select
                 name="test-select"
@@ -46,7 +46,7 @@ class SelectAsyncTest extends React.Component<React.Props<{}>, {}> {
                 callback(null, options);
             }, 500);
         };
-        const options: ReactSelect.Option[] = [{ label: "Foo", value: "bar" }];
+        const options: Option[] = [{ label: "Foo", value: "bar" }];
         const onChange = (value: any) => console.log(value);
         return <div>
             <Select.Async

--- a/react-select/react-select.d.ts
+++ b/react-select/react-select.d.ts
@@ -302,5 +302,8 @@ declare namespace ReactSelect {
 
 declare module "react-select" {
     const select: ReactSelect.ReactSelectClass;
+    interface Option extends ReactSelect.Option {}
+    
     export default select;
+    export { Option };
 }


### PR DESCRIPTION
Exporting the Option interface allows `react-select` users to define types for methods that might take or return Options for the Select component.

For example,

``` js
import Select, { Option } from 'react-select';

// ...

<Select
    options={myOptions}
    name="myPicker"
    onChange={ (option) => { this.changeOption(dispatch, option as Option) } }
    placeholder="Show the data as"
    />

// ...

changeOption(dispatch: any, option: Option) {
    dispatch(myAction(option.value.toString()));
}

```
