### PR TITLE
Add jquery-mousewheel

### DIFF
--- a/jquery-mousewheel/jquery-mousewheel-tests.ts
+++ b/jquery-mousewheel/jquery-mousewheel-tests.ts
@@ -1,0 +1,11 @@
+﻿/// <reference path="jquery-mousewheel.d.ts"/>
+
+$('#my_elem').on('mousewheel', (event: JQueryMousewheel.JQueryMousewheelEventObject) => {
+    console.log(event.deltaX, event.deltaY, event.deltaFactor, event.deltaMode, event.absDelta);
+});
+
+$('#my_elem').mousewheel(event => {
+    console.log(event.deltaX, event.deltaY, event.deltaFactor, event.deltaMode, event.absDelta);
+});
+
+$('#my_elem').unmousewheel();

--- a/jquery-mousewheel/jquery-mousewheel.d.ts
+++ b/jquery-mousewheel/jquery-mousewheel.d.ts
@@ -1,0 +1,21 @@
+﻿// Type definitions for jquery-mousewheel v3.1.13
+// Project: https://github.com/jquery/jquery-mousewheel
+// Definitions by: Brian Surowiec <https://github.com/xt0rted/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../jquery/jquery.d.ts"/>
+
+declare namespace JQueryMousewheel {
+    interface JQueryMousewheelEventObject extends JQueryEventObject {
+        deltaX: number;
+        deltaY: number;
+        deltaFactor: number;
+        deltaMode: number;
+        absDelta: number;
+    }
+}
+
+interface JQuery {
+    mousewheel(handler: (eventObject: JQueryMousewheel.JQueryMousewheelEventObject, ...args: any[]) => any): JQuery
+    unmousewheel(): JQuery;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

---

I ran the following to test the definition but it resulted in a bunch of errors in the jquery definition, as well as a couple for this one about missing semicolons, yet everything looks correct.

``` powershell
> tsc --noImplicitAny jquery-mousewheel/jquery-mousewheel-tests.ts
> tsc --target es6 jquery-mousewheel/jquery-mousewheel-tests.ts
```

Running `npm test` succeeds with no issues.

I'm already using this in a project so I don't think the issue is with the actual definition.
