### PR TITLE
normalizr - fixed entites typo

### DIFF
--- a/normalizr/normalizr.d.ts
+++ b/normalizr/normalizr.d.ts
@@ -105,7 +105,7 @@ declare namespace Normalizr {
          */
         mergeIntoEntity?: (stored: any, normalized: any, entityKey: string) => any;
     }): {
-            entites: any;
+            entities: any;
             result: any;
         };
 }


### PR DESCRIPTION
There is a simple typo in the normalizr.d.ts file.
It should be named `entities` instead of `entites`
