### PR TITLE
Joi.alternatives bugfixes

### DIFF
--- a/joi/joi-tests.ts
+++ b/joi/joi-tests.ts
@@ -734,6 +734,7 @@ namespace common {
 
 schema = Joi.alternatives();
 schema = Joi.alternatives().try(schemaArr);
+schema = Joi.alternatives().try(schema, schema);
 
 schema = Joi.alternatives(schemaArr);
 schema = Joi.alternatives(schema, anySchema, boolSchema);

--- a/joi/joi-tests.ts
+++ b/joi/joi-tests.ts
@@ -732,6 +732,9 @@ namespace common {
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
+schema = Joi.alternatives();
+schema = Joi.alternatives().try(schemaArr);
+
 schema = Joi.alternatives(schemaArr);
 schema = Joi.alternatives(schema, anySchema, boolSchema);
 

--- a/joi/joi.d.ts
+++ b/joi/joi.d.ts
@@ -691,6 +691,7 @@ declare module 'joi' {
 
 	export interface AlternativesSchema extends AnySchema<FunctionSchema> {
 		try(schemas: Schema[]): AlternativesSchema;
+		try(type1: Schema, type2: Schema, ...types: Schema[]): AlternativesSchema;
 		when<T>(ref: string, options: WhenOptions<T>): AlternativesSchema;
 		when<T>(ref: Reference, options: WhenOptions<T>): AlternativesSchema;
 	}

--- a/joi/joi.d.ts
+++ b/joi/joi.d.ts
@@ -747,8 +747,9 @@ declare module 'joi' {
 	/**
 	 * Generates a type that will match one of the provided alternative schemas
 	 */
-	export function alternatives(types: Schema[]): Schema;
-	export function alternatives(type1: Schema, type2: Schema, ...types: Schema[]): Schema;
+	export function alternatives(): AlternativesSchema;
+	export function alternatives(types: Schema[]): AlternativesSchema;
+	export function alternatives(type1: Schema, type2: Schema, ...types: Schema[]): AlternativesSchema;
 
 	/**
 	 * Validates a value using the given schema and options.


### PR DESCRIPTION
The Joi documentation uses `Joi.alternatives()` (no parameters), but the TS declaration demanded parameters. The Joi docs don't contain an example that includes parameters, but I'm calling Chesterton's Fence here.

The TS declaration also failed to return an interface supporting the `.try()` and `.when()` members - the whole point of `alternatives()`.

`.try()` member did not support the non-array variant of function signature.

---

case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

…t returning interface with try() member.
