### PR TITLE
Updates redux-actions to allow payload and meta typing.

### DIFF
--- a/redux-actions/redux-actions.d.ts
+++ b/redux-actions/redux-actions.d.ts
@@ -1,32 +1,70 @@
 // Type definitions for redux-actions v0.8.0
 // Project: https://github.com/acdlite/redux-actions
-// Definitions by: Jack Hsu <https://github.com/jaysoo>
+// Definitions by: Jack Hsu <https://github.com/jaysoo>, Alex Gorbatchev <https://github.com/alexgorbatchev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace ReduxActions {
     // FSA-compliant action.
     // See: https://github.com/acdlite/flux-standard-action
-    type Action = {
+    interface BaseAction {
         type: string
-        payload?: any
+    }
+
+    interface Action<Payload> extends BaseAction {
+        payload?: Payload
         error?: boolean
         meta?: any
+    }
+
+    interface ActionMeta<Payload, Meta> extends Action<Payload> {
+        meta: Meta
+    }
+
+    type PayloadCreator<Input, Payload> = (...args: Input[]) => Payload;
+
+    type MetaCreator<Input, Payload> = (...args: Input[]) => Payload;
+
+    type Reducer<Payload> = (state: Payload, action: Action<Payload>) => Payload;
+
+    type ReducerMeta<Payload, Meta> = (state: Payload, action: ActionMeta<Payload, Meta>) => Payload;
+
+    type ReducerMap<Payload> = {
+        [actionType: string]: Reducer<Payload>
     };
 
-    type PayloadCreator<T> = (...args: any[]) => T;
-    type MetaCreator = (...args: any[]) => any;
+    export function createAction(
+        actionType: string,
+        payloadCreator?: PayloadCreator<any, any>,
+        metaCreator?: MetaCreator<any, any>
+    ): (...args: any[]) => Action<any>;
 
-    type Reducer<T> = (state: T, action: Action) => T;
+    export function createAction<InputAndPayload>(
+        actionType: string,
+        payloadCreator?: PayloadCreator<InputAndPayload, InputAndPayload>
+    ): (...args: InputAndPayload[]) => Action<InputAndPayload>;
 
-    type ReducerMap<T> = {
-        [actionType: string]: Reducer<T>
-    };
+    export function createAction<Input, Payload>(
+        actionType: string,
+        payloadCreator?: PayloadCreator<Input, Payload>
+    ): (...args: Input[]) => Action<Payload>;
 
-    export function createAction<T>(actionType: string, payloadCreator?: PayloadCreator<T>, metaCreator?: MetaCreator): (...args: any[]) => Action;
+    export function createAction<Input, Payload, Meta>(
+        actionType: string,
+        payloadCreator: PayloadCreator<Input, Payload>,
+        metaCreator: MetaCreator<Input, Meta>
+    ): (...args: Input[]) => ActionMeta<Payload, Meta>;
 
-    export function handleAction<T>(actionType: string, reducer: Reducer<T> | ReducerMap<T>): Reducer<T>;
+    export function handleAction<Payload>(
+        actionType: string,
+        reducer: Reducer<Payload> | ReducerMap<Payload>
+    ): Reducer<Payload>;
 
-    export function handleActions<T>(reducerMap: ReducerMap<T>, initialState?: T): Reducer<T>;
+    export function handleAction<Payload, Meta>(
+        actionType: string,
+        reducer: ReducerMeta<Payload, Meta> | ReducerMap<Payload>
+    ): Reducer<Payload>;
+
+    export function handleActions<Payload>(reducerMap: ReducerMap<Payload>, initialState?: Payload): Reducer<Payload>;
 }
 
 declare module 'redux-actions' {


### PR DESCRIPTION
This update allows typing information to be applied to the `payload` and `meta` properties of the Flux Action object. This helps payload type to flow through all the handlers.

This also allows for cases when input type isn't the same as payload type, for example:

```
action(10) => { type: 'ACTION', payload: { value: 10 } }
```

and alternatively, input being the same type as payload:

```
action({ value: 10 }) => { type: 'ACTION', payload: { value: 10 } }
```
