### PR TITLE
Support union types in mousetrap .bind and .bindGlobal

### DIFF
--- a/mousetrap/mousetrap-global-bind-tests.ts
+++ b/mousetrap/mousetrap-global-bind-tests.ts
@@ -25,6 +25,11 @@ Mousetrap.bindGlobal('up up down down left right left right b a enter', function
     console.log('konami code');
 });
 
+// Test that union types are accepted.
+const unionTypeKeys: string | string[] = ['a', 'b', 'c'];
+Mousetrap.bindGlobal(unionTypeKeys, function() { console.log('Union type test') });
+
+
 Mousetrap.bindGlobal(['ctrl+s', 'meta+s'], (e, combo) => {
     if (e.preventDefault) {
         e.preventDefault();

--- a/mousetrap/mousetrap-global-bind.d.ts
+++ b/mousetrap/mousetrap-global-bind.d.ts
@@ -6,6 +6,5 @@
 /// <reference path="./mousetrap.d.ts" />
 
 interface MousetrapStatic {
-    bindGlobal(keys: string, callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
-    bindGlobal(keyArray: string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
+    bindGlobal(keyArray: string|string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
 }

--- a/mousetrap/mousetrap-tests.ts
+++ b/mousetrap/mousetrap-tests.ts
@@ -51,6 +51,10 @@ instance.bind('mod+s', function(){ console.log('Instance Saved'); });
 // Test that the factory method works as well.
 Mousetrap(element).bind('mod+s', function(){ console.log('Factory Saved'); });
 
+// Test that union types are accepted.
+const unionTypeKeys: string | string[] = ['a', 'b', 'c'];
+Mousetrap(element).bind(unionTypeKeys, function() { console.log('Union type test') });
+
 // Test that Mousetrap can be loaded as an external module.
 // Assume that if the externally-loaded module can be assigned to a variable with the type of global Mousetrap,
 // then everything is working correctly.

--- a/mousetrap/mousetrap.d.ts
+++ b/mousetrap/mousetrap.d.ts
@@ -11,20 +11,16 @@ interface MousetrapStatic {
     (el: Element): MousetrapInstance;
     new (el: Element): MousetrapInstance;
     stopCallback: (e: ExtendedKeyboardEvent, element: Element, combo: string) => boolean;
-    bind(keys: string, callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
-    bind(keyArray: string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
-    unbind(keys: string, action?: string): void;
-    unbind(keyArray: string[], action?: string): void;
+    bind(keys: string|string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
+    unbind(keys: string|string[], action?: string): void;
     trigger(keys: string, action?: string): void;
     reset(): void;
 }
 
 interface MousetrapInstance {
     stopCallback: (e: ExtendedKeyboardEvent, element: Element, combo: string) => boolean;
-    bind(keys: string, callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
-    bind(keyArray: string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
-    unbind(keys: string, action?: string): void;
-    unbind(keyArray: string[], action?: string): void;
+    bind(keys: string|string[], callback: (e: ExtendedKeyboardEvent, combo: string) => any, action?: string): void;
+    unbind(keys: string|string[], action?: string): void;
     trigger(keys: string, action?: string): void;
     reset(): void;
 }


### PR DESCRIPTION
This pull request makes is such that `.bind` and `.bindGlobal` accepts variables with union type of `string | string[]`. This is good for the following reasons:
- Simplifies the definition file
- Accepts variables that can be either `string` or `string[]` -- for example, if a react component accepts a prop that can be either `string` or `string[]`, the current definitions require the user to cast it to either type, although the method accepts either type.
