### PR TITLE
Added koLite DefaultOptions for the Binding Handler

### DIFF
--- a/kolite/knockout.activity.d.ts
+++ b/kolite/knockout.activity.d.ts
@@ -28,8 +28,18 @@ interface KoLiteActivity {
     getOpacity(options: { steps?: number; segments?: number; opacity?: number; }, i: number): number;
 }
 
+interface KoLiteActivityDefaultOptions {
+    activityClass?: string,
+    container?: string,
+    inactiveClass?: string
+}
+
+interface KoLiteActivityBindingHandler extends KnockoutBindingHandler {
+    defaultOptions: KoLiteActivityDefaultOptions
+}
+
 interface KnockoutBindingHandlers {
-    activity: KnockoutBindingHandler;
+    activity: KoLiteActivityBindingHandler;
 }
 
 interface JQuery {

--- a/kolite/kolite-tests.ts
+++ b/kolite/kolite-tests.ts
@@ -2,6 +2,20 @@
 /// <reference path="../knockout/knockout.d.ts" />
 /// <reference path="kolite.d.ts" />
 
+function test_activityDefaults() {
+    ko.bindingHandlers.activity.defaultOptions = {
+        activityClass: 'fa fa-spinner fa-spin',
+        container: 'i',
+        inactiveClass: ''
+    };
+    
+    ko.bindingHandlers.activity.defaultOptions = {
+        activityClass: 'some Value'
+    };
+    
+    ko.bindingHandlers.activity.defaultOptions = {
+    };
+}
 function test_asyncCommand() {
     var saveCmd = ko.asyncCommand({
         execute: function (complete) {


### PR DESCRIPTION
Improvement to existing type definition of "kolite"
Library: https://github.com/CodeSeven/KoLite/blob/master/knockout.activity.js

The `ko.bindingHandlers.activity.defaultOptions` was missing and you had to cast it to `any`before you could change those in your typescript code.
