### PR TITLE
knockout.validation.d.ts: add missing config options and some doc com…

### DIFF
--- a/knockout.validation/knockout.validation.d.ts
+++ b/knockout.validation/knockout.validation.d.ts
@@ -23,6 +23,10 @@ interface KnockoutValidationGroupingOptions {
     live?: boolean;
 }
 
+interface KnockoutValidationValidateOptions {
+    throttle?: number;
+}
+
 interface KnockoutValidationConfiguration {
     /**
      * Allows HTML in validation messages
@@ -85,6 +89,7 @@ interface KnockoutValidationConfiguration {
      * Register custom validation rules defined via ko.validation.rules
      */
     registerExtenders?: boolean;
+    validate?: KnockoutValidationValidateOptions;
     /**
      * Add HTML5 input validation attributes to form elements
      * that ko observable's are bound to

--- a/knockout.validation/knockout.validation.d.ts
+++ b/knockout.validation/knockout.validation.d.ts
@@ -6,22 +6,90 @@
 /// <reference path="../knockout/knockout.d.ts" />
 
 interface KnockoutValidationGroupingOptions {
+    /**
+     * indicates whether to walk the ViewModel (or object)
+     * recursively, or only walk first-level properties.
+     */
     deep?: boolean;
+    /**
+     * indicates whether the returned errors object
+     * is a ko.computed or a simple function
+     */
     observable?: boolean;
+    /**
+     * indicates whether changes to observableArrays inside
+     * the model should cause the validator to re-run
+     */
+    live?: boolean;
 }
 
 interface KnockoutValidationConfiguration {
-    registerExtenders?: boolean;
-    messagesOnModified?: boolean;
-    messageTemplate?: string;
-    insertMessages?: boolean;
-    parseInputAttributes?: boolean;
-    writeInputAttributes?: boolean;
+    /**
+     * Allows HTML in validation messages
+     */
+    allowHtmlMessages?: boolean;
+    /**
+     * Indicates whether css error classes are added only
+     * when properties are modified or at all times
+     * @type {[type]}
+     */
+    decorateElementOnModified?: boolean;
+    /**
+     * Indicates whether to assign an error class to the <input> tag
+     * when your property is invalid
+     */
     decorateInputElement?: boolean;
+    /**
+     * If defined, the CSS class assigned to both <input> and validation message elements
+     */
     errorClass?: string;
+    /**
+     * The CSS class assigned to validation error <input> elements, must have decorateInputElement set to true
+     */
     errorElementClass?: string;
+    /**
+     * The CSS class assigned to validation error messages
+     */
     errorMessageClass?: string;
+    /**
+     * Shows tooltips using input 'title' attribute. False hides them
+     */
+    errorsAsTitle?: boolean;
+    /**
+     * Shows the error when hovering the input field (decorateElement must be true)
+     */
+    errorsAsTitleOnModified?: boolean;
     grouping?: KnockoutValidationGroupingOptions;
+    /**
+     * If true validation will insert either a <span> element or the template
+     * specified by messageTemplate after any element (e.g. <input>)
+     * that uses a KO value binding with a validated field
+     */
+    insertMessages?: boolean;
+    /**
+     * Indicates whether validation messages are triggered only
+     * when properties are modified or at all times
+     */
+    messagesOnModified?: boolean;
+    /**
+     * The id of the <script type="text/html"></script>
+     * that you want to use for all your validation messages
+     */
+    messageTemplate?: string;
+    /**
+     * Indicates whether to assign validation rules to your ViewModel
+     * using HTML5 validation attributes
+     */
+    parseInputAttributes?: boolean;
+    /**
+     * Register custom validation rules defined via ko.validation.rules
+     */
+    registerExtenders?: boolean;
+    /**
+     * Add HTML5 input validation attributes to form elements
+     * that ko observable's are bound to
+     */
+    writeInputAttributes?: boolean;
 }
 
 interface KnockoutValidationUtils {
@@ -154,7 +222,7 @@ interface KnockoutSubscribableFunctions<T> {
 }
 
 declare module "knockout.validation" {
-	export = validation;
+    export = validation;
 }
 
-declare var validation: KnockoutValidationStatic 
+declare var validation: KnockoutValidationStatic


### PR DESCRIPTION
Documentation is taken from [projects wiki](https://github.com/Knockout-Contrib/Knockout-Validation/wiki/Configuration)
