### PR TITLE
Fixed `dagre-d3` and extended `dagre`

### DIFF
--- a/dagre-d3/dagre-d3-tests.ts
+++ b/dagre-d3/dagre-d3-tests.ts
@@ -6,8 +6,8 @@ namespace DagreD3Tests {
     // has graph methods from dagre.d.ts
     graph.setNode("a", {});
     const num: number = 251 + graph.height + graph.width;
-    let predecessors: { [vertex: string]: string[] } = {};
-    let successors: { [vertex: string]: string[] } = {};
+    const predecessors: { [vertex: string]: string[] } = {};
+    const successors: { [vertex: string]: string[] } = {};
 
     predecessors["a"] = graph.predecessors("a");
     successors["a"] = graph.successors("a");

--- a/dagre-d3/dagre-d3-tests.ts
+++ b/dagre-d3/dagre-d3-tests.ts
@@ -1,19 +1,18 @@
 /// <reference path="dagre-d3.d.ts"/>
 namespace DagreD3Tests {
-    var gDagre = new dagreD3.graphlib.Graph();
-    var graph = gDagre.graph();
+    let gDagre = new dagreD3.graphlib.Graph();
+    let graph = gDagre.graph();
 
     // has graph methods from dagre.d.ts
     graph.setNode("a", {});
-    var num: number = 251 + graph.height + graph.width;
-    var predecessors: { [vertex:string]: string[] } = {};
-    var successors: { [vertex:string]: string[] } = {};
+    let num: number = 251 + graph.height + graph.width;
+    let predecessors: { [vertex: string]: string[] } = {};
+    let successors: { [vertex: string]: string[] } = {};
 
     predecessors["a"] = graph.predecessors("a");
     successors["a"] = graph.successors("a");
 
-    var render = new dagreD3.render();
-    var svg = d3.select("svg");
+    let render = new dagreD3.render();
+    let svg = d3.select("svg");
     render(svg, graph);
 }
-

--- a/dagre-d3/dagre-d3-tests.ts
+++ b/dagre-d3/dagre-d3-tests.ts
@@ -1,18 +1,18 @@
 /// <reference path="dagre-d3.d.ts"/>
 namespace DagreD3Tests {
-    let gDagre = new dagreD3.graphlib.Graph();
-    let graph = gDagre.graph();
+    const gDagre = new dagreD3.graphlib.Graph();
+    const graph = gDagre.graph();
 
     // has graph methods from dagre.d.ts
     graph.setNode("a", {});
-    let num: number = 251 + graph.height + graph.width;
+    const num: number = 251 + graph.height + graph.width;
     let predecessors: { [vertex: string]: string[] } = {};
     let successors: { [vertex: string]: string[] } = {};
 
     predecessors["a"] = graph.predecessors("a");
     successors["a"] = graph.successors("a");
 
-    let render = new dagreD3.render();
-    let svg = d3.select("svg");
+    const render = new dagreD3.render();
+    const svg = d3.select("svg");
     render(svg, graph);
 }

--- a/dagre-d3/dagre-d3.d.ts
+++ b/dagre-d3/dagre-d3.d.ts
@@ -29,3 +29,7 @@ declare namespace Dagre {
 }
 
 declare var dagreD3: Dagre.DagreD3Factory;
+
+declare module "dagre-d3" {
+    export = dagreD3;
+}

--- a/dagre/dagre-tests.ts
+++ b/dagre/dagre-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="dagre.d.ts"/>
 namespace DagreTests {
-  let gDagre = new dagre.graphlib.Graph();
+  const gDagre = new dagre.graphlib.Graph();
   gDagre.setGraph({})
     .setDefaultEdgeLabel(function(){ return ; })
     .setNode("a", {})

--- a/dagre/dagre-tests.ts
+++ b/dagre/dagre-tests.ts
@@ -1,10 +1,11 @@
 /// <reference path="dagre.d.ts"/>
 namespace DagreTests {
-  var gDagre = new dagre.graphlib.Graph();
+  let gDagre = new dagre.graphlib.Graph();
   gDagre.setGraph({})
     .setDefaultEdgeLabel(function(){ return ; })
     .setNode("a", {})
-    .setEdge("b", "c");
+    .setEdge("b", "c")
+    .setEdge("c", "d", {class: "class"});
 
   dagre.layout(gDagre);
 }

--- a/dagre/dagre.d.ts
+++ b/dagre/dagre.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Qinfeng Chen <https://github.com/qinfchen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace Dagre{
+declare namespace Dagre {
     interface DagreFactory {
         graphlib: GraphLib;
         layout(graph: Graph): void;
@@ -16,7 +16,7 @@ declare namespace Dagre{
         nodes(): string[];
         node(id: any): any;
         setDefaultEdgeLabel(callback: () => void): Graph;
-        setEdge(sourceId: string, targetId: string): Graph;
+        setEdge(sourceId: string, targetId: string, options?: { [key: string]: any }): Graph;
         setGraph(options: { [key: string]: any }): Graph;
         setNode(id: string, node: { [key: string]: any }): Graph;
     }


### PR DESCRIPTION
- `dagre.Graph` has a method `setExtent`. There was the (optional) option field missing.
- `dagre-d3` had no exported module so there were problems with SystemJS and Atom's TypeScript package.
