### PR TITLE
Fix isomorphic-fetch module setup

### DIFF
--- a/isomorphic-fetch/isomorphic-fetch-tests.ts
+++ b/isomorphic-fetch/isomorphic-fetch-tests.ts
@@ -1,6 +1,9 @@
 /// <reference path="isomorphic-fetch.d.ts"/>
 
-function test_isomorphicFetchTestCases() {
+import fetchImportedViaCommonJS = require('isomorphic-fetch');
+import * as fetchImportedViaES6Module from 'isomorphic-fetch';
+
+function test_isomorphicFetchTestCases_ambient() {
     expectSuccess(fetch('http://localhost:3000/good'), 'Good response');
     
     fetch('http://localhost:3000/bad')
@@ -11,7 +14,30 @@ function test_isomorphicFetchTestCases() {
         });
 }
 
-function test_whatwgTestCases() {
+function test_isomorphicFetchTestCases_commonjs() {
+    expectSuccess(fetchImportedViaCommonJS('http://localhost:3000/good'), 'Good response');
+    
+    fetchImportedViaCommonJS('http://localhost:3000/bad')
+        .then((response: IResponse) => {
+            return response.text();
+        })
+        .catch((err) => {
+        });
+}
+
+function test_isomorphicFetchTestCases_es6() {
+    expectSuccess(fetchImportedViaES6Module('http://localhost:3000/good'), 'Good response');
+    
+    fetchImportedViaES6Module('http://localhost:3000/bad')
+        .then((response: IResponse) => {
+            return response.text();
+        })
+        .catch((err) => {
+        });
+}
+
+
+function test_whatwgTestCases_ambient() {
     var headers = new Headers();
     headers.append("Content-Type", "application/json");
     var requestOptions: RequestInit = {
@@ -42,6 +68,72 @@ function test_whatwgTestCases() {
     var request: Request = new Request('http://localhost:3000/poster', requestOptions);
 
     expectSuccess(fetch(request), 'Post response:');
+}
+
+function test_whatwgTestCases_commonjs() {
+    var headers = new Headers();
+    headers.append("Content-Type", "application/json");
+    var requestOptions: RequestInit = {
+        method: "POST",
+        headers: headers,
+        mode: 'same-origin',
+        credentials: 'omit',
+        cache: 'default'
+    };
+
+    expectSuccess(fetchImportedViaCommonJS('http://localhost:3000/poster', requestOptions), 'Post response:');
+    
+    var requestOptions: RequestInit = {
+        method: "POST",
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    };
+    
+    expectSuccess(fetchImportedViaCommonJS('http://localhost:3000/poster', requestOptions), 'Post response:');
+    
+    var requestOptions: RequestInit = {
+        method: "POST",
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    };
+    var request: Request = new Request('http://localhost:3000/poster', requestOptions);
+
+    expectSuccess(fetchImportedViaCommonJS(request), 'Post response:');
+}
+
+function test_whatwgTestCases_es6() {
+    var headers = new Headers();
+    headers.append("Content-Type", "application/json");
+    var requestOptions: RequestInit = {
+        method: "POST",
+        headers: headers,
+        mode: 'same-origin',
+        credentials: 'omit',
+        cache: 'default'
+    };
+
+    expectSuccess(fetchImportedViaES6Module('http://localhost:3000/poster', requestOptions), 'Post response:');
+    
+    var requestOptions: RequestInit = {
+        method: "POST",
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    };
+    
+    expectSuccess(fetchImportedViaES6Module('http://localhost:3000/poster', requestOptions), 'Post response:');
+    
+    var requestOptions: RequestInit = {
+        method: "POST",
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    };
+    var request: Request = new Request('http://localhost:3000/poster', requestOptions);
+
+    expectSuccess(fetchImportedViaES6Module(request), 'Post response:');
 }
     
 function expectSuccess(promise: Promise<IResponse>, responseText: string) {

--- a/isomorphic-fetch/isomorphic-fetch.d.ts
+++ b/isomorphic-fetch/isomorphic-fetch.d.ts
@@ -112,8 +112,8 @@ interface IFetchStatic {
     (url: string | IRequest, init?: RequestInit): Promise<IResponse>;
 }
 
-declare module "isomorphic-fetch" {
-    export default IFetchStatic;
-}
-
 declare var fetch: IFetchStatic;
+
+declare module "isomorphic-fetch" {
+    export = fetch;
+}


### PR DESCRIPTION
The implementation of `isomorphic-fetch` exports CommonJS module, it was previously declared as exporting a ES6 modules. 

This caused it to not be importable in TypeScript. It was still accessible via `global` scope, and might have been accessible via extra layer of `babel` transpiling. 

(Ref: https://github.com/matthew-andrews/isomorphic-fetch/blob/master/fetch-npm-node.js#L4)
