### PR TITLE
React Native Definition: Module '__React' has no exported member 'ScaledSize'.

### DIFF
--- a/react-native/react-native.d.ts
+++ b/react-native/react-native.d.ts
@@ -2621,7 +2621,7 @@ declare module "react-native" {
      * @see https://facebook.github.io/react-native/docs/dimensions.html#content
      */
     export interface Dimensions {
-      get( what: "window" | "screen" ): React.ScaledSize;
+        get( what: "window" | "screen" ): ScaledSize;
     }
 
     export interface InteractionManagerStatic {


### PR DESCRIPTION
Fix #9155 of issue.

It's for `react-native/react-native.d.ts`.

to author (@bgrieder). Could you review this PR?
:+1: or :-1:?
