### PR TITLE
Added type definitions for react-calendar-timeline

### DIFF
--- a/react-calendar-timeline/react-calendar-timeline-tests.tsx
+++ b/react-calendar-timeline/react-calendar-timeline-tests.tsx
@@ -1,0 +1,33 @@
+/// <reference path="../react/react.d.ts" />
+/// <reference path="../moment/moment.d.ts" />
+/// <reference path="./react-calendar-timeline.d.ts"/>
+
+import * as React from "react";
+import * as moment from 'moment';
+import * as Timeline from 'react-calendar-timeline';
+
+const groups = [
+  {id: 1, title: 'group 1'},
+  {id: 2, title: 'group 2'}
+]
+
+const items = [
+  {id: 1, group: 1, title: 'item 1', start_time: moment(), end_time: moment().add(1, 'hour')},
+  {id: 2, group: 2, title: 'item 2', start_time: moment().add(-0.5, 'hour'), end_time: moment().add(0.5, 'hour')},
+  {id: 3, group: 1, title: 'item 3', start_time: moment().add(2, 'hour'), end_time: moment().add(3, 'hour')}
+]
+
+class ReactCalendarTimeline extends React.Component<{}, {}> {
+     render(){
+         return(
+             <div>
+                Rendered by react!
+                <Timeline groups={groups}
+                          items={items}
+                          defaultTimeStart={moment().add(-12, 'hour')}
+                          defaultTimeEnd={moment().add(12, 'hour')}
+                          />
+            </div>
+         );
+    }      
+};

--- a/react-calendar-timeline/react-calendar-timeline.d.ts
+++ b/react-calendar-timeline/react-calendar-timeline.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Rajab Shakirov <https://github.com/radziksh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference path="../react/react.d.ts"/>
+
 declare module "react-calendar-timeline" {
     interface ReactCalendarTimeline {
         groups?:any;

--- a/react-calendar-timeline/react-calendar-timeline.d.ts
+++ b/react-calendar-timeline/react-calendar-timeline.d.ts
@@ -63,6 +63,6 @@ declare module "react-calendar-timeline" {
         children?: any;
     }
 
-    let DatePicker: __React.ClassicComponentClass<ReactCalendarTimeline>;
-    export = DatePicker;
+    let ReactCalendarTimeline: __React.ClassicComponentClass<ReactCalendarTimeline>;
+    export = ReactCalendarTimeline;
 }

--- a/react-calendar-timeline/react-calendar-timeline.d.ts
+++ b/react-calendar-timeline/react-calendar-timeline.d.ts
@@ -44,20 +44,20 @@ declare module "react-calendar-timeline" {
         stackItems?: boolean;
         traditionalZoom?: boolean;
         itemTouchSendsClick?: boolean;
-        onItemMove?(itemId, dragTime, newGroupOrder): any;
-        onItemResize?(itemId, newResizeEnd): any;
-        onItemSelect?(itemId): any;
-        onItemClick?(itemId): any;
-        onCanvasClick?(groupId, time, e): any;
-        onItemDoubleClick?(itemId): any;
-        moveResizeValidator?(action, itemId, time): any;
+        onItemMove?(itemId:any, dragTime:any, newGroupOrder:any): any;
+        onItemResize?(itemId:any, newResizeEnd:any): any;
+        onItemSelect?(itemId:any): any;
+        onItemClick?(itemId:any): any;
+        onCanvasClick?(groupId:any, time:any, e:any): any;
+        onItemDoubleClick?(itemId:any): any;
+        moveResizeValidator?(action:any, itemId:any, time:any): any;
         defaultTimeStart: any;
         defaultTimeEnd: any;
         visibleTimeStart?: any;
         visibleTimeEnd?: any;
-        onTimeChange?(visibleTimeStart, visibleTimeEnd): any;
-        onTimeInit?(visibleTimeStart, visibleTimeEnd): any;
-        onBoundsChange?(canvasTimeStart, canvasTimeEnd): any;
+        onTimeChange?(visibleTimeStart:any, visibleTimeEnd:any): any;
+        onTimeInit?(visibleTimeStart:any, visibleTimeEnd:any): any;
+        onBoundsChange?(canvasTimeStart:any, canvasTimeEnd:any): any;
         children?: any;
     }
 

--- a/react-calendar-timeline/react-calendar-timeline.d.ts
+++ b/react-calendar-timeline/react-calendar-timeline.d.ts
@@ -1,0 +1,66 @@
+// Type definitions for react-calendar-timeline v0.7.9
+// Project: https://github.com/namespace-ee/react-calendar-timeline
+// Definitions by: Rajab Shakirov <https://github.com/radziksh>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "react-calendar-timeline" {
+    interface ReactCalendarTimeline {
+        groups?:any;
+        items?:{
+            id: number;
+            group: number;
+            title?: string;
+            start_time: any;
+            end_time: any;
+            canMove?: boolean;
+            canResize?: boolean;
+            canChangeGroup?: boolean;
+            className?: string;
+        }[];
+        keys?:{
+            groupIdKey: string;
+            groupTitleKey: string;
+            itemIdKey: string;
+            itemTitleKey: string;
+            itemGroupKey: string;
+            itemTimeStartKey: string;
+            itemTimeEndKey: string;
+        };
+        sidebarWidth?: number;
+        dragSnap?: number;
+        minResizeWidth?: number;
+        fixedHeader?: "fixed" | "none";
+        zIndexStart?: number;
+        lineHeight?: number;
+        headerLabelGroupHeight?: number;
+        headerLabelHeight?: number;
+        itemHeightRatio?: number;
+        minZoom?: number;
+        maxZoom?: number;
+        canMove?: boolean;
+        canChangeGroup?: boolean;
+        canResize?: boolean;
+        useResizeHandle?: boolean;
+        stackItems?: boolean;
+        traditionalZoom?: boolean;
+        itemTouchSendsClick?: boolean;
+        onItemMove?(itemId, dragTime, newGroupOrder): any;
+        onItemResize?(itemId, newResizeEnd): any;
+        onItemSelect?(itemId): any;
+        onItemClick?(itemId): any;
+        onCanvasClick?(groupId, time, e): any;
+        onItemDoubleClick?(itemId): any;
+        moveResizeValidator?(action, itemId, time): any;
+        defaultTimeStart: any;
+        defaultTimeEnd: any;
+        visibleTimeStart?: any;
+        visibleTimeEnd?: any;
+        onTimeChange?(visibleTimeStart, visibleTimeEnd): any;
+        onTimeInit?(visibleTimeStart, visibleTimeEnd): any;
+        onBoundsChange?(canvasTimeStart, canvasTimeEnd): any;
+        children?: any;
+    }
+
+    let DatePicker: __React.ClassicComponentClass<ReactCalendarTimeline>;
+    export = DatePicker;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a test file with the suffix of -tests.ts or -tests.tsx.
