### PR TITLE
Add typings for react-split-pane

### DIFF
--- a/react-split-pane/react-split-pane-tests.tsx
+++ b/react-split-pane/react-split-pane-tests.tsx
@@ -1,0 +1,24 @@
+/// <reference path="../react/react.d.ts" />
+/// <reference path="./react-split-pane.d.ts"/>
+
+import * as React from "react";
+import * as SplitPane from "react-split-pane";
+
+class SplitPaneTest extends React.Component<React.Props<{}>, {}> {
+
+    render() {
+        return (
+            <SplitPane
+                allowResize={true}
+                className="pane"
+                defaultSize={30}
+                maxSize={50}
+                minSize={20}
+                split="vertical"
+            >
+                <div />
+                <div />
+            </SplitPane>
+        );
+    }
+}

--- a/react-split-pane/react-split-pane.d.ts
+++ b/react-split-pane/react-split-pane.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for react-split-pane v0.1.38
+// Project: https://github.com/tomkp/react-split-pane
+// Definitions by: Roger Chen <https://github.com/rcchen>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../react/react.d.ts"/>
+
+declare namespace ReactSplitPane {
+    interface ReactSplitPaneProps {
+        allowResize?: boolean;
+        className?: string;
+        /**
+         * Either a number (in pixels) or string (percentage)
+         */
+        defaultSize?: number | string;
+        /**
+         * Either a number (in pixels) or string (percentage)
+         */
+        maxSize?: number | string;
+        /**
+         * Either a number (in pixels) or string (percentage)
+         */
+        minSize?: number | string;
+        onChange?: Function;
+        onDragFinished?: Function;
+        onDragStarted?: Function;
+        primary?: string;
+        /**
+         * Either a number (in pixels) or string (percentage)
+         */
+        size?: number | string;
+        split?: string;
+    }
+
+    interface ReactSplitPaneClass extends __React.ComponentClass<ReactSplitPaneProps> { }
+}
+
+declare module "react-split-pane" {
+    var split: ReactSplitPane.ReactSplitPaneClass;
+    export = split;
+}


### PR DESCRIPTION
Basically hand translated from the source: https://github.com/tomkp/react-split-pane

case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
