### PR TITLE
Jasmine: Document `Env.throwOnExpectationFailure`

### DIFF
--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -179,6 +179,7 @@ declare namespace jasmine {
         addCustomEqualityTester(equalityTester: CustomEqualityTester): void;
         addMatchers(matchers: CustomMatcherFactories): void;
         specFilter(spec: Spec): boolean;
+        throwOnExpectationFailure(value: boolean): void;
     }
 
     interface FakeTimer {


### PR DESCRIPTION
The definitions for the `Env` interface in Jasmine are quite incomplete. `throwOnExpectationFailure` stood out immediately.

See current source code: https://github.com/jasmine/jasmine/blob/v2.4.1/src/core/Env.js

Once I identify all missing methods I'll create a new PR for adding them, but for now I just need `throwOnExpectationFailure` in my own code and would love to see it being added to the definitions list.
