### PR TITLE
Add returnValues() function to SpyAnd interface

### DIFF
--- a/jasmine/jasmine-tests.ts
+++ b/jasmine/jasmine-tests.ts
@@ -358,6 +358,40 @@ describe("A spy, when configured to fake a return value", function () {
     });
 });
 
+describe("A spy, when configured to fake a series of return values", function() {
+    var foo: any, bar: any;
+
+    beforeEach(function() {
+        foo = {
+            setBar: function(value: any) {
+                bar = value;
+            },
+            getBar: function() {
+                return bar;
+            }
+        };
+
+        spyOn(foo, "getBar").and.returnValues("fetched first", "fetched second");
+
+        foo.setBar(123);
+    });
+
+    it("tracks that the spy was called", function() {
+        foo.getBar(123);
+        expect(foo.getBar).toHaveBeenCalled();
+    });
+
+    it("should not affect other functions", function() {
+        expect(bar).toEqual(123);
+    });
+
+    it("when called multiple times returns the requested values in order", function() {
+        expect(foo.getBar()).toEqual("fetched first");
+        expect(foo.getBar()).toEqual("fetched second");
+        expect(foo.getBar()).toBeUndefined();
+    });
+});
+
 describe("A spy, when configured with an alternate implementation", function () {
     var foo: any, bar: any, fetchedBar: any;
 

--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -424,6 +424,8 @@ declare namespace jasmine {
         callThrough(): Spy;
         /** By chaining the spy with and.returnValue, all calls to the function will return a specific value. */
         returnValue(val: any): Spy;
+        /** By chaining the spy with and.returnValues, all calls to the function will return specific values in order until it reaches the end of the return values list. */
+        returnValues(...values: any[]): Spy;
         /** By chaining the spy with and.callFake, all calls to the spy will delegate to the supplied function. */
         callFake(fn: Function): Spy;
         /** By chaining the spy with and.throwError, all calls to the spy will throw the specified value. */


### PR DESCRIPTION
From jasmine [document](http://jasmine.github.io/2.4/introduction.html#section-Spies:_<code>and.returnValues</code), it has returnValues function on `SpyAnd` interface.

case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
