### PR TITLE
add resolveClientLocale() to angular-translate

### DIFF
--- a/angular-translate/angular-translate.d.ts
+++ b/angular-translate/angular-translate.d.ts
@@ -68,6 +68,7 @@ declare namespace angular.translate {
         loaderCache(): any;
         isReady(): boolean;
         onReady(): angular.IPromise<void>;
+        resolveClientLocale():string;
     }
 
     interface ITranslateProvider extends angular.IServiceProvider {
@@ -111,6 +112,7 @@ declare namespace angular.translate {
         registerAvailableLanguageKeys(): string[];
         registerAvailableLanguageKeys(languageKeys: string[], aliases?: ILanguageKeyAlias): ITranslateProvider;
         useLoaderCache(cache?: any): ITranslateProvider;
+        resolveClientLocale():string;
     }
 }
 


### PR DESCRIPTION
add missing Typing for `resolveClientLocale()` method in angular-translate
