### PR TITLE
add initial typing for react-datepicker

### DIFF
--- a/react-datepicker/react-datepicker-tests.tsx
+++ b/react-datepicker/react-datepicker-tests.tsx
@@ -1,0 +1,34 @@
+/// <reference path="../react/react.d.ts" />
+/// <reference path="../moment/moment.d.ts" />
+/// <reference path="./react-datepicker.d.ts"/>
+
+import * as React from "react";
+import * as moment from 'moment';
+import * as DatePicker from 'react-datepicker';
+
+class ReactDatePicker extends React.Component<{}, {startDate:any,displayName:string}> { 
+     constructor(props) {
+        super();
+        this.state = { 
+          startDate: moment(),
+          displayName: 'Example' 
+        }
+        this.handleChange = this.handleChange.bind(this);
+     }
+          
+     handleChange = function(date?:any) {
+        this.setState({
+          startDate: date
+        });
+     }
+     
+     render(){
+         return (
+           <div>
+             <DatePicker
+                 selected={this.state.startDate}
+                 onChange={this.handleChange} />
+           </div>        
+         );
+    }      
+};

--- a/react-datepicker/react-datepicker-tests.tsx
+++ b/react-datepicker/react-datepicker-tests.tsx
@@ -7,7 +7,7 @@ import * as moment from 'moment';
 import * as DatePicker from 'react-datepicker';
 
 class ReactDatePicker extends React.Component<{}, {startDate:any,displayName:string}> { 
-     constructor(props) {
+     constructor(props:any) {
         super();
         this.state = { 
           startDate: moment(),

--- a/react-datepicker/react-datepicker.d.ts
+++ b/react-datepicker/react-datepicker.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for react-datepicker v0.27.0
+// Project: https://github.com/Hacker0x01/react-datepicker
+// Definitions by: Rajab Shakirov <https://github.com/radziksh>, Andrey Balokha <https://github.com/andrewBalekha>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../react/react.d.ts"/>
+
+declare module "react-datepicker" {
+    interface ReactDatePicker {
+        className?: string;
+        dateFormat?: string;
+        dateFormatCalendar?: string;
+        disabled?: boolean;
+        endDate?: {};
+        excludeDates?: any[];
+        filterDate?():any;
+        id?: string;
+        includeDates?: any[];
+        isClearable?: boolean;
+        locale?: string;
+        maxDate?: {};
+        minDate?: {};
+        name?: string;
+        onBlur?():any;
+        onChange():any;
+        onChange(date?:any):any;
+        onFocus?():any;
+        placeholderText?: string;
+        popoverAttachment?: string;
+        popoverTargetAttachment?: string;
+        popoverTargetOffset?: string;
+        readOnly?: boolean;
+        renderCalendarTo?: any;
+        required?: boolean;
+        selected?: {};
+        showYearDropdown?: boolean;
+        startDate?: {};
+        tabIndex?: number;
+        tetherConstraints?: any[];
+        title?: string;
+        todayButton?:  string;
+    }
+    let ReactDatePicker: __React.ClassicComponentClass<ReactDatePicker>;
+    export = ReactDatePicker;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
