### PR TITLE
Suggested fix for request.d.ts

### DIFF
--- a/request/request-tests.ts
+++ b/request/request-tests.ts
@@ -21,7 +21,7 @@ var headers: {[key: string]: string};
 var agent: http.Agent;
 var write: stream.Writable;
 var req: request.Request;
-var form1: formData.FormData;
+var form1: formData;
 
 var bodyArr: request.RequestPart[] = [{
 	body: value

--- a/request/request.d.ts
+++ b/request/request.d.ts
@@ -175,7 +175,7 @@ declare module 'request' {
 			setHeader(name: string, value: string, clobber?: boolean): Request;
 			setHeaders(headers: Headers): Request;
 			qs(q: Object, clobber?: boolean): Request;
-			form(): FormData.FormData;
+			form(): FormData;
 			form(form: any): Request;
 			multipart(multipart: RequestPart[]): Request;
 			json(val: any): Request;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Fixing error:

at line 178, file ../myProject/typings/main/ambient/request/index.d.ts

Module 'FormData' has no exported member 'FormData'.
