### PR TITLE
Add exportChartLocal function for HighCharts

### DIFF
--- a/highcharts/highcharts-tests.ts
+++ b/highcharts/highcharts-tests.ts
@@ -2187,6 +2187,7 @@ function test_ChartObject() {
     chart.destroy();
     chart.drillUp();
     chart.exportChart(<HighchartsExportingOptions>{}, <HighchartsOptions>{});
+    chart.exportChartLocal(<HighchartsExportingOptions>{}, <HighchartsOptions>{});
     var object = chart.get('axisIdOrSeriesIdOrPointId');
     var svg1 = chart.getSVG();
     var svg2 = chart.getSVG(<HighchartsOptions>{});

--- a/highcharts/highcharts.d.ts
+++ b/highcharts/highcharts.d.ts
@@ -5682,6 +5682,30 @@ interface HighchartsChartObject {
      */
     exportChart(options: HighchartsExportingOptions, chartOptions: HighchartsOptions): void;
     /**
+     * Export the chart to a PNG or SVG without sending it to a server. Requires
+     * modules/exporting.js and modules/offline-exporting.js.
+     * @since 2.0
+     */
+    exportChartLocal(): void;
+    /**
+     * Export the chart to a PNG or SVG without sending it to a server. Requires
+     * modules/exporting.js and modules/offline-exporting.js.
+     * @param {HighchartsExportingOptions} options Exporting options. Same as
+     * the exportChart params.
+     * @since 2.0
+     */
+    exportChartLocal(options: HighchartsExportingOptions): void;
+    /**
+     * Export the chart to a PNG or SVG without sending it to a server.
+     * Requires modules/exporting.js and modules/offline-exporting.js.
+     * @param {HighchartsExportingOptions} options Exporting options. Same as
+     * the exportChart params.
+     * @param {HighchartsOptions} chartOptions Additional chart options for the
+     * exported chart. Same as the exportChart params.
+     * @since 2.0
+     */
+    exportChartLocal(options: HighchartsExportingOptions, chartOptions: HighchartsOptions): void;
+    /**
      * Get an axis, series or point by its id as given in the configuration options.
      * @param  {string} id The id of the axis, series or point to get.
      * @return {HighchartsAxisObject|HighchartsSeriesObject|HighchartsPointObject}


### PR DESCRIPTION
Function is documented here (http://api.highcharts.com/highcharts#Chart.exportChartLocal). It's signature is identical to the `exportChart` function already in the type definition.
