### PR TITLE
Fix for material-ui typings: added "& EnhancedButtonProps" to Tab Component

### DIFF
--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -1598,7 +1598,7 @@ declare namespace __MaterialUI {
             value?: any;
             width?: string;
         }
-        export class Tab extends React.Component<TabProps, {}> {
+        export class Tab extends React.Component<TabProps & EnhancedButtonProps, {}> {
         }
     }
 


### PR DESCRIPTION
EnhancedButtonProps are legal props for Tab because they are passed down to EnhancedButton inside Tab component (e.g. disabled={true})
