### PR TITLE
Update jsonwebtoken typings for 6.2.0

### DIFF
--- a/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/jsonwebtoken/jsonwebtoken-tests.ts
@@ -25,7 +25,7 @@ cert = fs.readFileSync('private.key');  // get private key
 token = jwt.sign({ foo: 'bar' }, cert, { algorithm: 'RS256'});
 
 // sign asynchronously
-jwt.sign({ foo: 'bar' }, cert, { algorithm: 'RS256' }, function(token: string) {
+jwt.sign({ foo: 'bar' }, cert, { algorithm: 'RS256' }, function(err, token: string) {
   console.log(token);
 });
 

--- a/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/jsonwebtoken/jsonwebtoken-tests.ts
@@ -25,7 +25,7 @@ cert = fs.readFileSync('private.key');  // get private key
 token = jwt.sign({ foo: 'bar' }, cert, { algorithm: 'RS256'});
 
 // sign asynchronously
-jwt.sign({ foo: 'bar' }, cert, { algorithm: 'RS256' }, function(err, token: string) {
+jwt.sign({ foo: 'bar' }, cert, { algorithm: 'RS256' }, function(err: Error, token: string) {
   console.log(token);
 });
 

--- a/jsonwebtoken/jsonwebtoken.d.ts
+++ b/jsonwebtoken/jsonwebtoken.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for jsonwebtoken 5.7.0
+﻿// Type definitions for jsonwebtoken 6.2.0
 // Project: https://github.com/auth0/node-jsonwebtoken
 // Definitions by: Maxime LUCE <https://github.com/SomaticIT>, Daniel Heim <https://github.com/danielheim>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -22,11 +22,6 @@ declare module "jsonwebtoken" {
          * - none:     No digital signature or MAC value included
          */
         algorithm?: string;
-        /**
-         *@deprecated - see expiresIn
-         *@member {number} - Lifetime for the token in minutes
-         */
-        expiresInMinutes?: number;
         /** @member {string} - Lifetime for the token expressed in a string describing a time span [rauchg/ms](https://github.com/rauchg/ms.js). Eg: `60`, `"2 days"`, `"10h"`, `"7d"` */
         expiresIn?: string;
         notBefore?: string;
@@ -35,7 +30,7 @@ declare module "jsonwebtoken" {
         issuer?: string;
         jwtid?: string;
         noTimestamp?: boolean;
-        headers?: Object;
+        header?: Object;
     }
 
     export interface VerifyOptions {

--- a/jsonwebtoken/jsonwebtoken.d.ts
+++ b/jsonwebtoken/jsonwebtoken.d.ts
@@ -62,7 +62,7 @@ declare module "jsonwebtoken" {
     }
 
     export interface SignCallback {
-        (encoded: string): void;
+        (err: Error, encoded: string): void;
     }
 
     /**


### PR DESCRIPTION
According to the jsonwebtoken [changelog](https://github.com/auth0/node-jsonwebtoken/blob/master/CHANGELOG.md), there were quite a few changes that need to be reflected in the type definition of the module.

For example, the callback for `jwt.sign()` now is a standard node callback with an `err, result` signature. In addition to that, some keys were renamed or removed after having been deprecated before.
