### PR TITLE
Transclude On A Component Should Be An Object Like On Directive

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1741,7 +1741,7 @@ declare namespace angular {
         /**
          * Whether transclusion is enabled. Enabled by default.
          */
-        transclude?: boolean | string | {[slot: string]: string};
+        transclude?: any;
         require?: string | string[] | {[controller: string]: string};
     }
 


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

From The Source:

Here it just passes through the option.transclude 

https://github.com/angular/angular.js/blob/0780666e41938e28984a4496231008ae6066c41e/src/ng/compile.js#L859

For example: 

transclude: {
            'header': '?panelHeader',
            'content': 'panelContent'
        }
