### PR TITLE
Union & Intersection should return a Twix object

### DIFF
--- a/twix/twix.d.ts
+++ b/twix/twix.d.ts
@@ -104,8 +104,8 @@ declare namespace moment {
         overlaps(other: Twix): boolean;
         engulfs(other: Twix): boolean;
         equals(other: Twix): boolean;
-        union(other: Twix): string;
-        intersection(other: Twix): string;
+        union(other: Twix): Twix;
+        intersection(other: Twix): Twix;
 
         xor(other: Twix): Twix[];
         difference(other: Twix): Twix[];


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Union & Intersection functions currently return a string type, this should be a single Twix object.

See docs: http://isaaccambron.com/twix.js/docs.html
