### PR TITLE
Add keyboard to CordovaPlugins

### DIFF
--- a/cordova/plugins/Keyboard.d.ts
+++ b/cordova/plugins/Keyboard.d.ts
@@ -172,3 +172,7 @@ interface Keyboard {
 }
 
 declare var Keyboard:Keyboard;
+
+interface CordovaPlugins {
+    Keyboard: Keyboard;
+}


### PR DESCRIPTION
Ionic default templates use the cordova.plugins.Keyboard object.
