### PR TITLE
Renamed queryString in SignalR.Hub.Options to qs

### DIFF
--- a/signalr/signalr.d.ts
+++ b/signalr/signalr.d.ts
@@ -76,7 +76,7 @@ declare namespace SignalR {
         }
 
         interface Options {
-            queryString?: string;
+            qs?: string;
             logging?: boolean;
             useDefaultPath?: boolean;
         }


### PR DESCRIPTION
for setting query string parameter Signalr's method 'hubConnection' processes 'options.qs' parameter , not 'options.queryString'

source code: 
bower package: "signalr": "2.2.0"
file: jquery.signalR.js
line: 2733

```
// hubConnection
function hubConnection(url, options) {
    /// <summary>Creates a new hub connection.</summary>
    /// <param name="url" type="String">[Optional] The hub route url, defaults to "/signalr".</param>
    /// <param name="options" type="Object">[Optional] Settings to use when creating the hubConnection.</param>
    var settings = {
        qs: null,
        logging: false,
        useDefaultPath: true
    };

    $.extend(settings, options);

    if (!url || settings.useDefaultPath) {
        url = (url || "") + "/signalr";
    }
    return new hubConnection.fn.init(url, settings);
}
```
