### PR TITLE
Enable ES6 like import syntax for nedb

### DIFF
--- a/nedb/nedb-tests.ts
+++ b/nedb/nedb-tests.ts
@@ -6,6 +6,8 @@
 /// <reference path="../node/node.d.ts" />
 /// <reference path="nedb.d.ts" />
 
+import * as es6styleimport from 'nedb';
+
 import Q = require('q');
 import nedb = require('nedb');
 

--- a/nedb/nedb-tests.ts
+++ b/nedb/nedb-tests.ts
@@ -137,7 +137,16 @@ class BaseCollection<T> {
 
         var deferred = Q.defer<T>();
 
-        this.dataStore.update(query, updateQuery, {upsert: true}, function (err:Error, numberOfUpdated:number, upsert:boolean) {
+        this.dataStore.update(query, updateQuery, {upsert: true}, function (err:Error, numberOfUpdated:number, upsert: boolean) {
+            if (err) {
+                deferred.reject(err);
+            }
+            else {
+                //deferred.resolve(newDoc);
+            }
+        });
+
+        this.dataStore.update(query, updateQuery, {upsert: true}, function (err:Error, numberOfUpdated:number, affectedDocs:any, upsert: boolean) {
             if (err) {
                 deferred.reject(err);
             }

--- a/nedb/nedb.d.ts
+++ b/nedb/nedb.d.ts
@@ -149,6 +149,7 @@ declare module "nedb" {
         remove(query:any, cb?:(err:Error, n:number)=>void):void;
     }
 
+    namespace NeDBDataStore {}
     export = NeDBDataStore;
 }
 

--- a/nedb/nedb.d.ts
+++ b/nedb/nedb.d.ts
@@ -122,18 +122,36 @@ declare module "nedb" {
         findOne<T>(query:any, callback:(err:Error, document:T)=>void):void;
 
         /**
-         * Update all docs matching query
+         * Update all docs matching query v1.7.4 and prior signature.
          * For now, very naive implementation (recalculating the whole database)
          * @param {any} query
          * @param {any} updateQuery
          * @param {Object} options Optional options
          *                 options.multi If true, can update multiple documents (defaults to false)
          *                 options.upsert If true, document is inserted if the query doesn't match anything
-         * @param {Function} cb Optional callback, signature: err, numReplaced, upsert (set to true if the update was in fact an upsert)
+         * @param {Function} cb Optional callback, signature: err,
+         *                                                    numReplaced,
+         *                                                    upsert (set to true if the update was in fact an upsert)
          *
          * @api private Use Datastore.update which has the same signature
          */
         update(query:any, updateQuery:any, options?:NeDB.UpdateOptions, cb?:(err:Error, numberOfUpdated:number, upsert:boolean)=>void):void;
+         /**
+         * Update all docs matching query v1.8 signature.
+         * For now, very naive implementation (recalculating the whole database)
+         * @param {any} query
+         * @param {any} updateQuery
+         * @param {Object} options Optional options
+         *                 options.multi If true, can update multiple documents (defaults to false)
+         *                 options.upsert If true, document is inserted if the query doesn't match anything
+         * @param {Function} cb Optional callback, signature: err,
+         *                                                    numAffected,
+         *                                                    affectedDocuments (when returnUpdatedDocs is set to true), obj or array
+         *                                                    upsert (set to true if the update was in fact an upsert)
+         *
+         * @api private Use Datastore.update which has the same signature
+         */
+        update<T>(query:any, updateQuery:any, options?:NeDB.UpdateOptions, cb?:(err:Error, numberOfUpdated:number, affectedDocuments:any, upsert:boolean)=>void):void;
 
         /**
          * Remove all docs matching the query
@@ -185,6 +203,7 @@ declare namespace NeDB {
     interface UpdateOptions {
         multi?: boolean;
         upsert?: boolean;
+        returnUpdatedDocs?: boolean
     }
 
     /**


### PR DESCRIPTION
Currently it is not possible to import nedb using ES6 like import syntax. This fixes this problem. I also  updated the test. 
