### PR TITLE
Added ecdhBob() to freedom.d.ts.

### DIFF
--- a/freedom/freedom.d.ts
+++ b/freedom/freedom.d.ts
@@ -423,7 +423,7 @@ declare namespace freedom.PgpProvider {
         clear(): Promise<void>;
         exportKey(): Promise<PublicKey>;
         getFingerprint(publicKey: string): Promise<KeyFingerprint>;
-        ecdhBob(curve:string, pubKey:string) :Promise<ArrayBuffer>;
+        ecdhBob(curve: string, pubKey: string): Promise<ArrayBuffer>;
         signEncrypt(data: ArrayBuffer, encryptKey?: string,
                     sign?: boolean): Promise<ArrayBuffer>;
         verifyDecrypt(data: ArrayBuffer,

--- a/freedom/freedom.d.ts
+++ b/freedom/freedom.d.ts
@@ -423,6 +423,7 @@ declare namespace freedom.PgpProvider {
         clear(): Promise<void>;
         exportKey(): Promise<PublicKey>;
         getFingerprint(publicKey: string): Promise<KeyFingerprint>;
+        ecdhBob(curve:string, pubKey:string) :Promise<ArrayBuffer>;
         signEncrypt(data: ArrayBuffer, encryptKey?: string,
                     sign?: boolean): Promise<ArrayBuffer>;
         verifyDecrypt(data: ArrayBuffer,

--- a/freedom/freedom.d.ts
+++ b/freedom/freedom.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for freedom v0.6.26
+// Type definitions for freedom v0.6.29
 // Project: https://github.com/freedomjs/freedom
 // Definitions by: Jonathan Pevarnek <https://github.com/jpevarnek/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
case 2. Improvement to existing type definition.

The module freedom-pgp-e2e has added a new method (this will be under `freedom.PgpProvider`) called `ecdhBob`. [method implementation here](https://github.com/freedomjs/freedom-pgp-e2e/blob/master/src/e2e.js#L228)

@jpevarnek is willing to review.
