### PR TITLE
Allow _.min(object) and _.max(object).

### DIFF
--- a/underscore/underscore-tests.ts
+++ b/underscore/underscore-tests.ts
@@ -173,6 +173,10 @@ _.pluck(stooges, 'name');
 
 _.max(stooges, (stooge) => stooge.age);
 _.min(stooges, (stooge) => stooge.age);
+_.max({ a: 1, b: 2 });
+_.max({ a: 'a', b: 'bb' }, (v, k) => v.length);
+_.min({ a: 1, b: 2 });
+_.min({ a: 'a', b: 'bb' }, (v, k) => v.length);
 
 var numbers = [10, 5, 100, 2, 1000];
 _.max(numbers);

--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -537,6 +537,11 @@ interface UnderscoreStatic {
 	max(list: _.List<number>): number;
 
 	/**
+	* @see _.max
+	*/
+	max(object: _.Dictionary<number>): number;
+
+	/**
 	* Returns the maximum value in list. If iterator is passed, it will be used on each value to generate
 	* the criterion by which the value is ranked.
 	* @param list Finds the maximum value in this list.
@@ -550,11 +555,24 @@ interface UnderscoreStatic {
 		context?: any): T;
 
 	/**
+	* @see _.max
+	*/
+	max<T>(
+		list: _.Dictionary<T>,
+		iterator?: _.ObjectIterator<T, any>,
+		context?: any): T;
+
+	/**
 	* Returns the minimum value in list.
 	* @param list Finds the minimum value in this list.
 	* @return Minimum value in `list`.
 	**/
 	min(list: _.List<number>): number;
+
+	/**
+	 * @see _.min
+	 */
+	min(o: _.Dictionary<number>): number;
 
 	/**
 	* Returns the minimum value in list. If iterator is passed, it will be used on each value to generate
@@ -567,6 +585,14 @@ interface UnderscoreStatic {
 	min<T>(
 		list: _.List<T>,
 		iterator?: _.ListIterator<T, any>,
+		context?: any): T;
+
+	/**
+	* @see _.min
+	*/
+	min<T>(
+		list: _.Dictionary<T>,
+		iterator?: _.ObjectIterator<T, any>,
 		context?: any): T;
 
 	/**


### PR DESCRIPTION
case 2. Improvement to existing type definition.

> - documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .

See #8961
- it has been reviewed by a DefinitelyTyped member.

@vvakame asked for a PR in #8961 

Fixes #8961
