### PR TITLE
fix the type of google-closure-compiler CompileOptions

### DIFF
--- a/google-closure-compiler/google-closure-compiler-tests.ts
+++ b/google-closure-compiler/google-closure-compiler-tests.ts
@@ -26,3 +26,12 @@ let jsonStream: GoogleClosureCompiler.JSONStreamFile[] = [
         src: 'var x = "hello, world";',
     },
 ];
+
+// Test the various options formats -- see
+//   https://github.com/ChadKillingsworth/closure-compiler-npm#specifying-options
+let optionsFormats: GoogleClosureCompiler.CompileOptions = {
+    js: ['/file-one.js', '/file-two.js'],
+    compilation_level: 'ADVANCED',
+    js_output_file: 'out.js',
+    debug: true
+};

--- a/google-closure-compiler/google-closure-compiler.d.ts
+++ b/google-closure-compiler/google-closure-compiler.d.ts
@@ -5,6 +5,10 @@
 
 /// <reference path="../node/node.d.ts" />
 
+// Note: the types seen in the JSDoc are wrong:
+//   https://github.com/ChadKillingsworth/closure-compiler-npm/issues/21
+// Be careful to read the code when choosing types.
+
 declare module 'google-closure-compiler' {
     import * as child_process from 'child_process';
 
@@ -26,7 +30,8 @@ declare module 'google-closure-compiler' {
         
         getFullCommand(): string;
     }
-    type CompileOptions = {[key: string]: string};
+    type CompileOption = string | boolean;
+    type CompileOptions = string[] | {[key: string]: (CompileOption|CompileOption[])};
     var compiler: {
         new (opts: (CompileOptions|string[]),
              extraCommandArgs?: string[]): Compiler;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- [x] documentation or source code reference which provides context for the suggested changes
- [] it has been reviewed by a DefinitelyTyped member.

The type shown in the JSDoc is wrong.  This patch copies the sample
code from the README into the test to verify that the type is right.
