### PR TITLE
Made fragmentOverride parameter for loadUrl optional

### DIFF
--- a/backbone/backbone-global.d.ts
+++ b/backbone/backbone-global.d.ts
@@ -316,7 +316,7 @@ declare namespace Backbone {
         stop(): void;
         route(route: string, callback: Function): number;
         checkUrl(e?: any): void;
-        loadUrl(fragmentOverride: string): boolean;
+        loadUrl(fragmentOverride?: string): boolean;
         navigate(fragment: string, options?: any): boolean;
         static started: boolean;
         options: any;

--- a/backbone/backbone-tests.ts
+++ b/backbone/backbone-tests.ts
@@ -166,6 +166,9 @@ function test_collection() {
 //////////
 
 Backbone.history.start();
+Backbone.History.started;
+Backbone.history.loadUrl();
+Backbone.history.loadUrl('12345');
 
 namespace v1Changes {
     namespace events {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url e.g. examples in the backbone.js where it is called without that parameter https://github.com/jashkenas/backbone/blob/master/backbone.js#L1778 .
  - it has been reviewed by a DefinitelyTyped member.
