### PR TITLE
soap.d.ts: Add optional parameter extraHeaders to soap method.

### DIFF
--- a/soap/soap.d.ts
+++ b/soap/soap.d.ts
@@ -13,7 +13,7 @@ declare module 'soap' {
     }
     interface Client extends events.EventEmitter {
         setSecurity(s: WSSecurity): void;
-        [method: string]: (args: any, fn: (err: any, result: any) => void, options?: any) => void;
+        [method: string]: (args: any, fn: (err: any, result: any) => void, options?: any, extraHeaders?: any) => void;
         addSoapHeader(headJSON: any): void;
     }
     function createClient(wsdlPath: string, options: any, fn: (err: any, client: Client) => void): void;


### PR DESCRIPTION
Soap client method has an optional parameter `extraHeaders`.

Reference:
https://github.com/vpulim/node-soap#clientserviceportmethodargs-callback-options-extraheaders---call-a-method-using-a-specific-service-and-port
