### PR TITLE
Fix IFormController methods in angular.d.ts

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -389,9 +389,9 @@ declare namespace angular {
         $submitted: boolean;
         $error: any;
         $pending: any;
-        $addControl(control: INgModelController): void;
-        $removeControl(control: INgModelController): void;
-        $setValidity(validationErrorKey: string, isValid: boolean, control: INgModelController): void;
+        $addControl(control: INgModelController | IFormController): void;
+        $removeControl(control: INgModelController | IFormController): void;
+        $setValidity(validationErrorKey: string, isValid: boolean, control: INgModelController | IFormController): void;
         $setDirty(): void;
         $setPristine(): void;
         $commitViewValue(): void;


### PR DESCRIPTION
Improvement of angular's IFormController.$addControl, $removeControl and $setValidity, to allow FormController as "control" argument
- angular documentation about this [form.FormController#$addControl](https://docs.angularjs.org/api/ng/type/form.FormController#$addControl):
  
  > $addControl(control);
  > control object, either a form.FormController or an ngModel.NgModelController

TODO: 
- [x] not yet reviewed by a DefinitelyTyped member
