### PR TITLE
Fix for duplicate USB event

### DIFF
--- a/chrome/chrome-app.d.ts
+++ b/chrome/chrome-app.d.ts
@@ -685,7 +685,7 @@ declare namespace chrome.usb {
 	interface DeviceEvent extends chrome.events.Event<(device: Device) => void> {}
 
 	export var onDeviceAdded: DeviceEvent;
-	export var onDeviceAdded: DeviceEvent;
+	export var onDeviceRemoved: DeviceEvent;
 
 	export function getDevices(options: { vendorId?: number, productId?: number, filters?: DeviceFilter[] }, callback: (devices: Device[]) => void): void;
 	export function getUserSelectedDevices(options: { multiple?: boolean, filters?: DeviceFilter[] }, callback: (devices: Device[]) => void): void;


### PR DESCRIPTION
Please find a minor correction to the chrome-app definition where the author has two duplicate definitions for `onDeviceAdded`. I've replaced the duplicate with `onDeviceRemoved`, which was probably the authors intention

Please below for reference
https://developer.chrome.com/apps/usb#event-onDeviceRemoved

Thanks
