### PR TITLE
Add some properties to Restangularized Elements

### DIFF
--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -116,6 +116,9 @@ declare namespace restangular {
     withHttpConfig(httpConfig: angular.IRequestShortcutConfig): IElement;
     save(queryParams?: any, headers?: any): IPromise<any>;
     getRestangularUrl(): string;
+    route?: string;
+    id?: string;
+    reqParams?: any;
   }
 
   interface ICollection extends IService, Array<any> {


### PR DESCRIPTION
When an element is restangularized it often has one to many of the properties added in this proposed code change.  Leveraging the route, id, and reqParams gives greater functionality to restangularized objects in typescript projects. 
