### PR TITLE
Fixing favIconUrl property name typo for TabChangeInfo class

### DIFF
--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -6210,7 +6210,7 @@ declare namespace chrome.tabs {
 		 * The tab's new favicon URL.
 		 * @since Chrome 27.
 		 */
-		faviconUrl?: string;
+		favIconUrl?: string;
 		/**
 		 * The tab's new title.
 		 * @since Chrome 48.


### PR DESCRIPTION
Please compare with correct property name (favIconUrl) in official documentation: https://developer.chrome.com/extensions/tabs#event-onUpdated

Also tested in my own Chrome extension.
