### PR TITLE
github-electron: Fix callback's return type of app.makeSingleInstance()

### DIFF
--- a/github-electron/github-electron-main-tests.ts
+++ b/github-electron/github-electron-main-tests.ts
@@ -45,7 +45,6 @@ var shouldQuit = app.makeSingleInstance(function(commandLine, workingDirectory) 
 	if (mainWindow.isMinimized()) mainWindow.restore();
 	mainWindow.focus();
   }
-  return true;
 });
 
 if (shouldQuit) {

--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -280,7 +280,7 @@ declare namespace Electron {
 		 * multiple instances of your app to run, this will ensure that only a single instance
 		 * of your app is running, and other instances signal this instance and exit.
 		 */
-		makeSingleInstance(callback: (args: string[], workingDirectory: string) => boolean): boolean;
+		makeSingleInstance(callback: (args: string[], workingDirectory: string) => void): boolean;
 		/**
 		 * Changes the Application User Model ID to id.
 		 */


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url https://github.com/electron/electron/blob/master/docs/api/app.md#appmakesingleinstancecallback .
  - it has been reviewed by a DefinitelyTyped member.

---

The callback should return `void`, not `boolean`.

https://github.com/electron/electron/blob/master/docs/api/app.md#appmakesingleinstancecallback
