### PR TITLE
The DragEvent should inherit from MouseEvent.

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -287,7 +287,7 @@ declare namespace __React {
         data: string;
     }
 
-    interface DragEvent extends SyntheticEvent {
+    interface DragEvent extends MouseEvent {
         dataTransfer: DataTransfer;
     }
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- Reference: https://developer.mozilla.org/en-US/docs/Web/API/DragEvent

---

There are many useful properties in `MouseEvent`:

``` ts
interface MouseEvent extends SyntheticEvent {
   altKey: boolean;
   button: number;
   buttons: number;
   clientX: number;
   clientY: number;
   ctrlKey: boolean;
   getModifierState(key: string): boolean;
   metaKey: boolean;
   pageX: number;
   pageY: number;
   relatedTarget: EventTarget;
   screenX: number;
   screenY: number;
   shiftKey: boolean;
}
```
