### PR TITLE
Add definitions for popper.js

### DIFF
--- a/popper.js/popper-tests.ts
+++ b/popper.js/popper-tests.ts
@@ -1,0 +1,39 @@
+/// <reference path="./popper.d.ts" />
+
+import * as Popper from 'popper.js';
+
+var reference = document.querySelector('.my-button');
+var thePopper = new Popper(
+    reference, {
+        content: 'My awesome popper!'
+    }
+);
+thePopper.update();
+thePopper.destroy();
+
+var options = {
+        placement: 'bottom',
+        offset: 0,
+        arrowElement: document.querySelector('.arrow'),
+        modifiersIgnored: ['applyStyle'],
+    } as Popper.PopperOptions;
+
+var thePopperWithOptions = new Popper(
+    reference, {
+        content: 'My awesome popper!',
+    }, options);
+
+var popper = document.querySelector('.my-popper');
+var anotherPopper = new Popper(
+    reference,
+    popper
+);
+
+var reference = document.querySelector('.my-button');
+var popper = document.querySelector('.my-popper');
+var anotherPopper = new Popper(reference, popper).onCreate(function(instance) {
+    console.log(instance.offsets);
+}).onUpdate(function(data) {
+    var p = data.offsets.popper;
+    console.log(`top: ${p.top}, left: ${p.left}`);
+});

--- a/popper.js/popper.d.ts
+++ b/popper.js/popper.d.ts
@@ -1,0 +1,58 @@
+// Type definitions for popper.js v0.4.0
+// Project: https://github.com/FezVrasta/popper.js/
+// Definitions by: rhysd <https://rhysd.github.io>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace Popper {
+	export interface PopperOptions {
+		placement?: string;
+		gpuAcceleration?: boolean;
+		offset?: number;
+		boundariesElement?: string | Element;
+		boundariesPadding?: number;
+		preventOverflowOrder?: ("left" | "right" | "top" | "bottom")[];
+		flipBehavior?: string | string[];
+		modifiers?: string[];
+		modifiersIgnored?: string[];
+		removeOnDestroy?: boolean;
+		arrowElement?: string | Element;
+	}
+	export class Modifiers {
+		applyStyle(data: Object): Object;
+		shift(data: Object): Object;
+		preventOverflow(data: Object): Object;
+		keepTogether(data: Object): Object;
+		flip(data: Object): Object;
+		offset(data: Object): Object;
+		arrow(data: Object): Object;
+	}
+	export interface Data {
+		placement: string;
+		offsets: {
+			popper: {
+				position: string;
+				top: number;
+				left: number;
+			};
+		};
+	}
+}
+
+declare class Popper {
+	public modifiers: Popper.Modifiers;
+	public placement: string;
+
+	constructor(reference: Element, popper: Element | Object, options?: Popper.PopperOptions);
+
+	destroy(): void;
+	update(): void;
+	onCreate(cb: (data: Popper.Data) => void): this;
+	onUpdate(cb: (data: Popper.Data) => void): this;
+	parse(config: Object): Element;
+	runModifiers(data: Object, modifiers: string[], ends: Function): void;
+	isModifierRequired(): boolean;
+}
+
+declare module "popper.js" {
+	export = Popper;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Project URL: https://github.com/FezVrasta/popper.js/
