### PR TITLE
Update isBetween method to support inclusivity

### DIFF
--- a/moment/moment-node.d.ts
+++ b/moment/moment-node.d.ts
@@ -307,7 +307,7 @@ declare namespace moment {
         isAfter(b: MomentComparable, granularity?: string): boolean;
 
         isSame(b: MomentComparable, granularity?: string): boolean;
-        isBetween(a: MomentComparable, b: MomentComparable, granularity?: string): boolean;
+        isBetween(a: MomentComparable, b: MomentComparable, granularity?: string, inclusivity?: string): boolean;
 
         /**
          * @since 2.10.7+


### PR DESCRIPTION
Updated the isBetween method declaration to support the inclusivity parameter introduced in MomentJS 2.13.0 as per http://momentjs.com/docs/#/query/is-between/ 
