### PR TITLE
Add addMethod overload in support of message as a function

### DIFF
--- a/jquery.validation/jquery.validation.d.ts
+++ b/jquery.validation/jquery.validation.d.ts
@@ -188,6 +188,14 @@ declare namespace JQueryValidation
          * @param method The actual method implementation, returning true if an element is valid. First argument: Current value. Second argument: Validated element. Third argument: Parameters.
          */
         addMethod(name: string, method: (value: any, element: HTMLElement, params: any) => boolean, message?: string): void;
+         /**
+         * Add a custom validation method. It must consist of a name (must be a legal javascript identifier), a predicate function and a message generating function.
+         *
+         * @param name The name of the method used to identify it and referencing it; this must be a valid JavaScript identifier
+         * @param method The actual method implementation, returning true if an element is valid. First argument: Current value. Second argument: Validated element. Third argument: Parameters.
+         * @param message Message generator. First argument: Parameters. Second argument: Validated element.
+         */
+        addMethod(name: string, method: (value: any, element: HTMLElement, params: any) => boolean, message?: (params: any, element: HTMLElement) => string): void;
         /**
          * Replaces {n} placeholders with arguments.
          *


### PR DESCRIPTION
Propose adding overload to addMethod to support parameter based messages, e.g.

```
$.validator.addMethod("sameAs",
    (val, el, params) => val == $(params).val(),
    (params, el) => "You put " + $(el).val() + " but should be " + $(params).val()
); 
```
