### PR TITLE
update phonegap-nfc's enabled() signature

### DIFF
--- a/phonegap-nfc/phonegap-nfc-tests.ts
+++ b/phonegap-nfc/phonegap-nfc-tests.ts
@@ -39,7 +39,7 @@ nfc.erase();
 nfc.erase(() => {}, () => {});
 
 nfc.enabled();
-nfc.enabled(() => {}, () => {});
+nfc.enabled((status: String) => {}, () => {});
 
 nfc.removeTagDiscoveredListener(() => {});
 nfc.removeTagDiscoveredListener(() => {},() => {},() => {});

--- a/phonegap-nfc/phonegap-nfc-tests.ts
+++ b/phonegap-nfc/phonegap-nfc-tests.ts
@@ -3,6 +3,8 @@
 import nfc = require('nfc');
 import ndef = require('ndef');
 import NdefRecord = PhoneGapNfc.NdefRecord;
+import NdefTag = PhoneGapNfc.NdefTag;
+import NdefTagEvent = PhoneGapNfc.NdefTagEvent;
 
 nfc.addTagDiscoveredListener(() => {});
 nfc.addTagDiscoveredListener(() => {},() => {}, () => {});
@@ -78,3 +80,45 @@ let obj:any = ndef.decodeTnf(bytes[0]);
 let tnfByte:number = ndef.encodeTnf(bytes[0],bytes[1],bytes[2],bytes[3],bytes[4],bytes[5]);
 
 let tnfString:string = ndef.tnfToString(tnfByte);
+
+let ndefTag: NdefTag = {
+    id: [4, 12, 109, 98, 8, 41, -127],
+    techTypes: ["android.nfc.tech.MifareUltralight", "android.nfc.tech.NfcA", "android.nfc.tech.Ndef"],
+    type: "NFC Forum Type 2",
+    date: "1394448136236",
+
+    canMakeReadOnly: true,
+    isWritable: true,
+    maxSize: 137,
+    ndefMessage: records
+};
+
+let eventTarget: EventTarget = {
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean) { return; },
+    dispatchEvent(evt: Event) { return true; },
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean) { return; }
+}
+
+let ndefTagEvent: NdefTagEvent = {
+    bubbles: false,
+    cancelBubble: false,
+    cancelable: false,
+    currentTarget: eventTarget,
+    defaultPrevented: false,
+    eventPhase: 2,
+    isTrusted: true,
+    returnValue: true,
+    srcElement: new Element(),
+    target: eventTarget,
+    timeStamp: 1394448136236,
+    type: "ndef",
+    initEvent(eventTypeArg: string, canBubbleArg: boolean, cancelableArg: boolean) { return; },
+    preventDefault() { return; },
+    stopImmediatePropagation() { return; },
+    stopPropagation() { return; },
+    AT_TARGET: 0,
+    BUBBLING_PHASE: 0,
+    CAPTURING_PHASE: 0,
+
+    tag: ndefTag
+};

--- a/phonegap-nfc/phonegap-nfc-tests.ts
+++ b/phonegap-nfc/phonegap-nfc-tests.ts
@@ -39,7 +39,7 @@ nfc.erase();
 nfc.erase(() => {}, () => {});
 
 nfc.enabled();
-nfc.enabled((status: String) => {}, () => {});
+nfc.enabled((status: String) => {}, (status: String) => {});
 
 nfc.removeTagDiscoveredListener(() => {});
 nfc.removeTagDiscoveredListener(() => {},() => {},() => {});

--- a/phonegap-nfc/phonegap-nfc.d.ts
+++ b/phonegap-nfc/phonegap-nfc.d.ts
@@ -406,7 +406,7 @@ declare namespace PhoneGapNfc {
          * @param win The callback that is called when NFC is enabled.
          * @param fail The callback that is called when NFC is disabled or missing.
          */
-        enabled(win?:(status:String) => void, fail?:() => void):void;
+        enabled(win?:(status:String) => void, fail?:(status:String) => void):void;
 
         /**
          * Removes the previously registered event listener added via nfc.addTagDiscoveredListener

--- a/phonegap-nfc/phonegap-nfc.d.ts
+++ b/phonegap-nfc/phonegap-nfc.d.ts
@@ -406,7 +406,7 @@ declare namespace PhoneGapNfc {
          * @param win The callback that is called when NFC is enabled.
          * @param fail The callback that is called when NFC is disabled or missing.
          */
-        enabled(win?:() => void, fail?:() => void):void;
+        enabled(win?:(status:String) => void, fail?:() => void):void;
 
         /**
          * Removes the previously registered event listener added via nfc.addTagDiscoveredListener

--- a/phonegap-nfc/phonegap-nfc.d.ts
+++ b/phonegap-nfc/phonegap-nfc.d.ts
@@ -49,7 +49,7 @@ declare namespace PhoneGapNfc {
         canMakeReadOnly:boolean;
         isWritable:boolean;
         maxSize:number;
-        records:Array<NdefRecord>;
+        ndefMessage:Array<NdefRecord>;
     }
 
     interface TagEvent extends Event {


### PR DESCRIPTION
the documentation (method comments) tells that there is a parameter in the callbacks, but until now it was not implemented
the native plugin code implements different statuses:

```
STATUS_NFC_OK = "NFC_OK";
STATUS_NO_NFC = "NO_NFC";
STATUS_NFC_DISABLED = "NFC_DISABLED";
STATUS_NDEF_PUSH_DISABLED = "NDEF_PUSH_DISABLED";
```

from the signature of the native code a String is returned in the error callback,
see: https://github.com/chariotsolutions/phonegap-nfc/blob/master/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java#L88

and later on in the success ballback,
see: https://github.com/chariotsolutions/phonegap-nfc/blob/master/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java#L142
