### PR TITLE
New: Add type definitions for 'rc-tooltip' module

### DIFF
--- a/rc-tooltip/rc-tooltip-tests.tsx
+++ b/rc-tooltip/rc-tooltip-tests.tsx
@@ -1,0 +1,37 @@
+/// <reference path="./rc-tooltip.d.ts" />
+/// <reference path="../react/react-dom.d.ts" />
+
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import * as Tooltip from 'rc-tooltip';
+
+ReactDOM.render(
+    <Tooltip placement="left" trigger={['click']} overlay={<span>tooltip</span>}>
+        <a href='#'>hover</a>
+    </Tooltip>,
+    document.querySelector('.app')
+);
+
+ReactDOM.render(
+    <Tooltip
+        placement="bottomRight"
+        trigger={['click', 'focus']}
+        overlay={<span>tooltip</span>}
+        overlayClassName="overlay"
+        mouseEnterDelay={0}
+        mouseLeaveDelay={0.1}
+        overlayStyle={{color: 'red'}}
+        prefixCls="my-"
+        transitionName="cool-transition"
+        onVisibleChange={() => console.log('visible changed')}
+        visible
+        defaultVisible
+        onPopupAlign={(popup, align) => console.log('aligned:', popup, align)}
+        arrowContent={<div className="arrow"/>}
+        getTooltipContainer={() => document.querySelector('.foo')}
+        destroyTooltipOnHide
+    >
+        <a href='#'>hover</a>
+    </Tooltip>,
+    document.querySelector('.another-app')
+);

--- a/rc-tooltip/rc-tooltip.d.ts
+++ b/rc-tooltip/rc-tooltip.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for rc-tooltip v3.3.2
+// Project: https://github.com/react-component/tooltip
+// Definitions by: rhysd <https://rhysd.github.io>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../react/react.d.ts" />
+
+declare namespace Tooltip {
+	import React = __React;
+
+	export type Trigger = "hover" | "click" | "focus";
+	export type Placement =
+		"left" | "right" | "top" | "bottom" |
+		"topLeft" | "topRight" | "bottomLeft" | "bottomRight";
+
+	export interface Props extends React.Props<any> {
+		overlayClassName?: string;
+		trigger?: Trigger[];
+		mouseEnterDelay?: number;
+		mouseLeaveDelay?: number;
+		overlayStyle?: React.CSSProperties;
+		prefixCls?: string;
+		transitionName?: string;
+		onVisibleChange?: () => void;
+		visible?: boolean;
+		defaultVisible?: boolean;
+		placement?: Placement | Object;
+		align?: Object;
+		onPopupAlign?: (popupDomNode: Element, align: Object) => void;
+		overlay: React.ReactElement<any>;
+		arrowContent?: React.ReactNode;
+		getTooltipContainer?: () => Element;
+		destroyTooltipOnHide?: boolean;
+	}
+}
+
+declare class Tooltip extends __React.Component<Tooltip.Props, {}> {}
+
+declare module "rc-tooltip" {
+	export = Tooltip
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Project URL: https://github.com/react-component/tooltip
