### PR TITLE
Update listCollections to use filter objects

### DIFF
--- a/mongodb/mongodb.d.ts
+++ b/mongodb/mongodb.d.ts
@@ -219,7 +219,7 @@ declare module "mongodb" {
     indexInformation(name: string, options?: { full?: boolean, readPreference?: ReadPreference | string }): Promise<any>;
     indexInformation(name: string, options: { full?: boolean, readPreference?: ReadPreference | string }, callback: MongoCallback<any>): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Db.html#listCollections
-    listCollections(filter: { name?: string }, options?: { batchSize?: number, readPreference?: ReadPreference | string }): CommandCursor;
+    listCollections(filter: Object, options?: { batchSize?: number, readPreference?: ReadPreference | string }): CommandCursor;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Db.html#logout
     logout(callback: MongoCallback<any>): void;
     logout(options?: { dbName?: string }): Promise<any>;


### PR DESCRIPTION
Updated db.listCollections to accept an Object for the filter parameter instead of only {name?: string}
Documentation: http://mongodb.github.io/node-mongodb-native/2.1/api/Db.html#listCollections
