### PR TITLE
Html2canvas 0.5

### DIFF
--- a/html2canvas/html2canvas.d.ts
+++ b/html2canvas/html2canvas.d.ts
@@ -36,7 +36,7 @@ declare namespace Html2Canvas {
 
         /** Whether to attempt to load cross-origin images as CORS served, before reverting back to proxy. */
         useCORS?: boolean;
-        
+
         /** Use svg powered rendering where available (FF11+). */
         svgRendering?: boolean;
     }

--- a/html2canvas/html2canvas.d.ts
+++ b/html2canvas/html2canvas.d.ts
@@ -69,6 +69,9 @@ interface Html2CanvasPromise<R> extends Html2CanvasThenable<R> {
     then<U>(onFulfilled?: (value: R) => U | Html2CanvasThenable<U>, onRejected?: (error: any) => void): Html2CanvasPromise<U>;
     catch<U>(onRejected?: (error: any) => U | Html2CanvasThenable<U>): Html2CanvasPromise<U>;
 }
+
+declare module 'html2canvas' {
+    export = html2canvas;
 }
 
 declare var html2canvas: Html2CanvasStatic;

--- a/html2canvas/html2canvas.d.ts
+++ b/html2canvas/html2canvas.d.ts
@@ -1,7 +1,6 @@
-﻿// Type definitions for html2canvas.js v0.5.0
+﻿// Type definitions for html2canvas.js v0.5.0-bata.4
 // Project: https://github.com/niklasvh/html2canvas
-// Definitions by: Richard Hepburn <https://github.com/rwhepburn/>
-// Definitions by: Pei-Tang Huang <https://github.com/tan9/>
+// Definitions by: Richard Hepburn <https://github.com/rwhepburn/>, Pei-Tang Huang <https://github.com/tan9/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../jquery/jquery.d.ts"/>

--- a/html2canvas/html2canvas.d.ts
+++ b/html2canvas/html2canvas.d.ts
@@ -39,9 +39,6 @@ declare namespace Html2Canvas {
         
         /** Use svg powered rendering where available (FF11+). */
         svgRendering?: boolean;
-
-        /** Callback providing the rendered canvas element after rendering */
-        onrendered?(canvas: HTMLCanvasElement): void;
     }
 }
 
@@ -56,7 +53,22 @@ interface Html2CanvasStatic {
       * @param {HTMLElement} element The HTML element which will be rendered to the canvas. Use the root element to render the entire window.
       * @param {Html2CanvasOptions} options The options object that controls how the element will be rendered.
       */
-    (element: HTMLElement, options?: Html2Canvas.Html2CanvasOptions): void;
+    (element: HTMLElement, options?: Html2Canvas.Html2CanvasOptions): Html2CanvasPromise<HTMLCanvasElement>;
+}
+
+// FIXME:
+// Find out a way to dependent on real Promise interface.
+// And remove following custome Promise interface.
+interface Html2CanvasThenable<R> {
+    then<U>(onFulfilled?: (value: R) => U | Html2CanvasThenable<U>, onRejected?: (error: any) => U | Html2CanvasThenable<U>): Html2CanvasThenable<U>;
+    then<U>(onFulfilled?: (value: R) => U | Html2CanvasThenable<U>, onRejected?: (error: any) => void): Html2CanvasThenable<U>;
+}
+
+interface Html2CanvasPromise<R> extends Html2CanvasThenable<R> {
+    then<U>(onFulfilled?: (value: R) => U | Html2CanvasThenable<U>, onRejected?: (error: any) => U | Html2CanvasThenable<U>): Html2CanvasPromise<U>;
+    then<U>(onFulfilled?: (value: R) => U | Html2CanvasThenable<U>, onRejected?: (error: any) => void): Html2CanvasPromise<U>;
+    catch<U>(onRejected?: (error: any) => U | Html2CanvasThenable<U>): Html2CanvasPromise<U>;
+}
 }
 
 declare var html2canvas: Html2CanvasStatic;

--- a/html2canvas/html2canvas.d.ts
+++ b/html2canvas/html2canvas.d.ts
@@ -54,21 +54,7 @@ interface Html2CanvasStatic {
       * @param {HTMLElement} element The HTML element which will be rendered to the canvas. Use the root element to render the entire window.
       * @param {Html2CanvasOptions} options The options object that controls how the element will be rendered.
       */
-    (element: HTMLElement, options?: Html2Canvas.Html2CanvasOptions): Html2CanvasPromise<HTMLCanvasElement>;
-}
-
-// FIXME:
-// Find out a way to dependent on real Promise interface.
-// And remove following custome Promise interface.
-interface Html2CanvasThenable<R> {
-    then<U>(onFulfilled?: (value: R) => U | Html2CanvasThenable<U>, onRejected?: (error: any) => U | Html2CanvasThenable<U>): Html2CanvasThenable<U>;
-    then<U>(onFulfilled?: (value: R) => U | Html2CanvasThenable<U>, onRejected?: (error: any) => void): Html2CanvasThenable<U>;
-}
-
-interface Html2CanvasPromise<R> extends Html2CanvasThenable<R> {
-    then<U>(onFulfilled?: (value: R) => U | Html2CanvasThenable<U>, onRejected?: (error: any) => U | Html2CanvasThenable<U>): Html2CanvasPromise<U>;
-    then<U>(onFulfilled?: (value: R) => U | Html2CanvasThenable<U>, onRejected?: (error: any) => void): Html2CanvasPromise<U>;
-    catch<U>(onRejected?: (error: any) => U | Html2CanvasThenable<U>): Html2CanvasPromise<U>;
+    (element: HTMLElement, options?: Html2Canvas.Html2CanvasOptions): Promise<HTMLCanvasElement>;
 }
 
 declare module 'html2canvas' {

--- a/html2canvas/html2canvas.d.ts
+++ b/html2canvas/html2canvas.d.ts
@@ -54,18 +54,9 @@ interface Html2CanvasStatic {
       * but builds the screenshot based on the information available on the page.
       *
       * @param {HTMLElement} element The HTML element which will be rendered to the canvas. Use the root element to render the entire window.
-      */
-    (element: HTMLElement): void;
-    /**
-      * Renders an HTML element to a canvas so that a screenshot can be generated.
-      *
-      * The screenshot is based on the DOM and as such may not be 100% accurate to the real representation as it does not make an actual screenshot,
-      * but builds the screenshot based on the information available on the page.
-      *
-      * @param {HTMLElement} element The HTML element which will be rendered to the canvas. Use the root element to render the entire window.
       * @param {Html2CanvasOptions} options The options object that controls how the element will be rendered.
       */
-    (element: HTMLElement, options: Html2Canvas.Html2CanvasOptions): void;
+    (element: HTMLElement, options?: Html2Canvas.Html2CanvasOptions): void;
 }
 
 declare var html2canvas: Html2CanvasStatic;

--- a/html2canvas/html2canvas.d.ts
+++ b/html2canvas/html2canvas.d.ts
@@ -54,7 +54,21 @@ interface Html2CanvasStatic {
       * @param {HTMLElement} element The HTML element which will be rendered to the canvas. Use the root element to render the entire window.
       * @param {Html2CanvasOptions} options The options object that controls how the element will be rendered.
       */
-    (element: HTMLElement, options?: Html2Canvas.Html2CanvasOptions): Promise<HTMLCanvasElement>;
+    (element: HTMLElement, options?: Html2Canvas.Html2CanvasOptions): Html2CanvasPromise<HTMLCanvasElement>;
+}
+
+// FIXME:
+// Find out a way to dependent on real Promise interface.
+// And remove following custome Promise interface.
+interface Html2CanvasThenable<R> {
+    then<U>(onFulfilled?: (value: R) => U | Html2CanvasThenable<U>, onRejected?: (error: any) => U | Html2CanvasThenable<U>): Html2CanvasThenable<U>;
+    then<U>(onFulfilled?: (value: R) => U | Html2CanvasThenable<U>, onRejected?: (error: any) => void): Html2CanvasThenable<U>;
+}
+
+interface Html2CanvasPromise<R> extends Html2CanvasThenable<R> {
+    then<U>(onFulfilled?: (value: R) => U | Html2CanvasThenable<U>, onRejected?: (error: any) => U | Html2CanvasThenable<U>): Html2CanvasPromise<U>;
+    then<U>(onFulfilled?: (value: R) => U | Html2CanvasThenable<U>, onRejected?: (error: any) => void): Html2CanvasPromise<U>;
+    catch<U>(onRejected?: (error: any) => U | Html2CanvasThenable<U>): Html2CanvasPromise<U>;
 }
 
 declare module 'html2canvas' {

--- a/html2canvas/html2canvas.d.ts
+++ b/html2canvas/html2canvas.d.ts
@@ -1,6 +1,7 @@
-﻿// Type definitions for html2canvas.js v0.4.1
+﻿// Type definitions for html2canvas.js v0.5.0
 // Project: https://github.com/niklasvh/html2canvas
 // Definitions by: Richard Hepburn <https://github.com/rwhepburn/>
+// Definitions by: Pei-Tang Huang <https://github.com/tan9/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../jquery/jquery.d.ts"/>


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url https://github.com/niklasvh/html2canvas/releases/tag/0.5.0-alpha1 .
  - it has been reviewed by a DefinitelyTyped member.
