### PR TITLE
Added declaration of module 'mathjs'

### DIFF
--- a/mathjs/mathjs.d.ts
+++ b/mathjs/mathjs.d.ts
@@ -2208,3 +2208,8 @@ declare namespace mathjs {
 		toString(): string;
 	}
 }
+
+declare module 'mathjs'{
+	export = math;
+}
+


### PR DESCRIPTION
case 2. Improvement to existing type definition.
Mathjs can now be correctly used in nodejs, importing it in typescript with 

``` ts
import * as mathjs from 'mathjs';
```
