### PR TITLE
pg.d.ts: Update type of result in Client.query() callback

### DIFF
--- a/pg/pg-tests.ts
+++ b/pg/pg-tests.ts
@@ -35,6 +35,7 @@ client.connect((err) => {
         if (err) {
             return console.error("Error running query", err);
         }
+        console.log(result.rowCount);
         console.log(result.rows[0]["theTime"]);
         client.end();
         return null;

--- a/pg/pg.d.ts
+++ b/pg/pg.d.ts
@@ -40,13 +40,13 @@ declare module "pg" {
     }
 
     export interface QueryResult {
+        command: string;
+        rowCount: number;
+        oid: number;
         rows: any[];
     }
 
     export interface ResultBuilder extends QueryResult {
-        command: string;
-        rowCount: number;
-        oid: number;
         addRow(row: any): void;
     }
 


### PR DESCRIPTION
`result` parameter in Client.query() callback has the same type with `result` object in `Query`'s `end` event.

https://github.com/brianc/node-postgres/wiki/Client#method-query-simple
