### PR TITLE
Reflux

### DIFF
--- a/reflux/reflux-tests.ts
+++ b/reflux/reflux-tests.ts
@@ -43,6 +43,7 @@ Reflux.createAction({
     children: ["progressed", "completed", "failed"]
 });
 
+var action = Reflux.createAction();
 
 var actions = Reflux.createActions(["fireBall", "magicMissile"]);
 

--- a/reflux/reflux-tests.ts
+++ b/reflux/reflux-tests.ts
@@ -57,3 +57,7 @@ var Store = Reflux.createStore({
         // bzzzzapp!
     }
 });
+
+var ReactComponent = {
+    mixins: [Reflux.ListenerMixin]
+};

--- a/reflux/reflux.d.ts
+++ b/reflux/reflux.d.ts
@@ -47,7 +47,7 @@ declare module  RefluxCore {
 
     function createStore(definition: StoreDefinition): Store;
 
-    function createAction(definition: ActionsDefinition): any;
+    function createAction(definition?: ActionsDefinition): any;
 
     function createActions(definition: ActionsDefinition): any;
     function createActions(definitions: string[]): any;

--- a/reflux/reflux.d.ts
+++ b/reflux/reflux.d.ts
@@ -55,6 +55,8 @@ declare module  RefluxCore {
     function connect(store: Store, key?: string):void;
     function listenTo(store: Store, handler: string):void;
     function setState(state: any):void;
+
+    function ListenerMixin(): any;
 }
 
 declare module "reflux" {


### PR DESCRIPTION
Case 2. Improvement to existing type definition.
## ListenerMixin

There's `ListenerMixin` for React which was not included:

```
var Status = React.createClass({
    mixins: [Reflux.ListenerMixin],
    onStatusChange: function(status) {
        this.setState({
            currentStatus: status
        });
    },
    componentDidMount: function() {
        this.listenTo(statusStore, this.onStatusChange);
    },
    render: function() {
        // render specifics
    }
});
```
## createAction

> Create an action by calling Reflux.createAction with an optional options object.

`options` in `createAction()` is optional. So it should be possible to do:

```
var myAction = Reflux.createAction();
```

Source: https://github.com/reflux/refluxjs/blob/master/README.md
