### PR TITLE
ssh2: some options were not optional in ConnectConfig

### DIFF
--- a/ssh2/ssh2-tests.ts
+++ b/ssh2/ssh2-tests.ts
@@ -293,6 +293,15 @@ conn.on('ready', () => {
     password: 'honk'
 });
 
+// ConnectConfig
+
+const sshconfig: ssh2.ConnectConfig = {
+    host: 'localhost',
+    port: 22,
+    username: 'ubuntu',
+    password: 'password'
+};
+
 //
 // # Server Examples
 //

--- a/ssh2/ssh2.d.ts
+++ b/ssh2/ssh2.d.ts
@@ -109,7 +109,7 @@ declare module "ssh2" {
              * @description Try keyboard-interactive user authentication if primary user authentication method fails.
              * If you set this to `true`, you need to handle the `keyboard-interactive` event.
              */
-            tryKeyboard: boolean;
+            tryKeyboard?: boolean;
             /**
              * @description How often (in milliseconds) to send SSH-level keepalive packets to the server
              * (in a similar way as OpenSSH's ServerAliveInterval config option). Set to 0 to disable.
@@ -145,7 +145,7 @@ declare module "ssh2" {
             /**
              * @description Set this to a function that receives a single string argument to get detailed (local) debug information.
              */
-            debug: (information: string) => any;
+            debug?: (information: string) => any;
         }
 
         interface ExecOption {


### PR DESCRIPTION
Case 2. Improvement to existing type definition.

It was not possible to create `ssh2.ConnectConfig` without specifying `tryKeyboard` and `debug` options which should be optional.

> tryKeyboard - boolean - Try keyboard-interactive user authentication if primary user authentication method fails. If you set this to true, you need to handle the keyboard-interactive event. Default: false
> 
> debug - function - Set this to a function that receives a single string argument to get detailed (local) debug information. Default: (none)

Source: https://github.com/mscdex/ssh2/blob/master/README.md#client-methods
