### PR TITLE
Add ListenerMixin to reflux module

### DIFF
--- a/reflux/reflux.d.ts
+++ b/reflux/reflux.d.ts
@@ -45,6 +45,8 @@ declare module  RefluxCore {
         [index: string]: Listenable
     }
 
+    class ListenerMixin {}
+
     function createStore(definition: StoreDefinition): Store;
 
     function createAction(definition: ActionsDefinition): any;


### PR DESCRIPTION
This allows to use `Reflux.ListenerMixin` without TS compiler complaining about unknown property on `RefluxCore`.

There should be no changes regarding the documentation as `ListenerMixin` has already been a part of refluxjs ([source](https://github.com/reflux/refluxjs/blob/master/src/ListenerMixin.js)).
