### PR TITLE
Add promise based API to RTCPeerConnection

### DIFF
--- a/webrtc/RTCPeerConnection-tests.ts
+++ b/webrtc/RTCPeerConnection-tests.ts
@@ -1,6 +1,8 @@
 /// <reference path="MediaStream.d.ts" />
 /// <reference path="RTCPeerConnection.d.ts" />
 
+let voidpromise: Promise<void>;
+
 var config: RTCConfiguration =
     { iceServers: [{ urls: "stun.l.google.com:19302" }] };
 var constraints: RTCMediaConstraints =
@@ -27,34 +29,27 @@ peerConnection.onicecandidate = ev => console.log(ev.type);
 peerConnection.onremovestream = ev => console.log(ev.type);
 peerConnection.onstatechange = ev => console.log(ev.type);
 
-peerConnection.createOffer(
-  offer => {
-    peerConnection.setLocalDescription(offer,
-      () => console.log("set local description"),
-      error => console.log("Error setting local description: " + error));
-  },
-  error => console.log("Error creating offer: " + error));
+peerConnection.createOffer();
+let offer2: Promise<RTCSessionDescription> = peerConnection.createOffer({
+    voiceActivityDetection: true,
+    iceRestart: false
+});
 
 var type: string = RTCSdpType[RTCSdpType.offer];
 var offer: RTCSessionDescriptionInit = { type: type, sdp: "some sdp" };
 var sessionDescription = new RTCSessionDescription(offer);
 
-peerConnection.setRemoteDescription(sessionDescription, () => {
-  peerConnection.createAnswer(
-    answer => {
-      peerConnection.setLocalDescription(answer,
-        () => console.log('Set local description'),
-      error => console.log(
-          "Error setting local description from created answer: " + error +
-          "; answer.sdp=" + answer.sdp));
-    },
-  error => console.log("Error creating answer: " + error));
-},
-error => console.log('Error setting remote description: ' + error +
-    "; offer.sdp=" + offer.sdp));
+peerConnection.setRemoteDescription(sessionDescription).then(
+    () => peerConnection.createAnswer(),
+    error => console.log('Error setting remote description: ' + error + "; offer.sdp=" + offer.sdp)
+);
 
 var webkitSessionDescription = new webkitRTCSessionDescription(offer);
 
+// New syntax
+voidpromise = peerConnection.setLocalDescription(webkitSessionDescription);
+
+// Legacy syntax
 peerConnection.setRemoteDescription(webkitSessionDescription, () => {
   peerConnection.createAnswer(
     answer => {
@@ -71,20 +66,10 @@ error => console.log('Error setting remote description: ' + error +
 
 var mozSessionDescription = new mozRTCSessionDescription(offer);
 
-peerConnection.setRemoteDescription(mozSessionDescription, () => {
-  peerConnection.createAnswer(
-    answer => {
-      peerConnection.setLocalDescription(answer,
-        () => console.log('Set local description'),
-      error => console.log(
-         "Error setting local description from created answer: " + error +
-         "; answer.sdp=" + answer.sdp));
-    },
-  error => console.log("Error creating answer: " + error));
-},
-error => console.log('Error setting remote description: ' + error +
-    "; offer.sdp=" + offer.sdp));
+peerConnection.setRemoteDescription(mozSessionDescription);
 
 var wkPeerConnection: webkitRTCPeerConnection =
     new webkitRTCPeerConnection(config, constraints);
 
+let candidate: RTCIceCandidate = {'candidate': 'foobar'};
+voidpromise = peerConnection.addIceCandidate(candidate);

--- a/webrtc/RTCPeerConnection.d.ts
+++ b/webrtc/RTCPeerConnection.d.ts
@@ -243,24 +243,40 @@ interface RTCStatsCallback {
   (report: RTCStatsReport): void;
 }
 
+interface RTCOfferAnswerOptions {
+    voiceActivityDetection ?: boolean; // default = true
+}
+
+interface RTCOfferOptions extends RTCOfferAnswerOptions {
+    iceRestart ?: boolean; // default = false
+}
+
+interface RTCAnswerOptions extends RTCOfferAnswerOptions { }
+
 interface RTCPeerConnection {
+
+  createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescription>;
   createOffer(successCallback: RTCSessionDescriptionCallback,
               failureCallback?: RTCPeerConnectionErrorCallback,
-              constraints?: RTCMediaConstraints): void;
+              constraints?: RTCMediaConstraints): void; // Deprecated
+  createAnswer(options?: RTCAnswerOptions): Promise<RTCSessionDescription>;
   createAnswer(successCallback: RTCSessionDescriptionCallback,
                failureCallback?: RTCPeerConnectionErrorCallback,
-               constraints?: RTCMediaConstraints): void;
+               constraints?: RTCMediaConstraints): void; // Deprecated
+  setLocalDescription(description: RTCSessionDescription | RTCSessionDescriptionInit): Promise<void>;
   setLocalDescription(description: RTCSessionDescription,
                       successCallback?: RTCVoidCallback,
-                      failureCallback?: RTCPeerConnectionErrorCallback): void;
-  localDescription: RTCSessionDescription;
+                      failureCallback?: RTCPeerConnectionErrorCallback): void; // Deprecated
+  setRemoteDescription(description: RTCSessionDescription | RTCSessionDescriptionInit): Promise<void>;
   setRemoteDescription(description: RTCSessionDescription,
                         successCallback?: RTCVoidCallback,
                         failureCallback?: RTCPeerConnectionErrorCallback): void;
+  localDescription: RTCSessionDescription;
   remoteDescription: RTCSessionDescription;
   signalingState: string; // RTCSignalingState; see TODO(1)
   updateIce(configuration?: RTCConfiguration,
             constraints?: RTCMediaConstraints): void;
+  addIceCandidate(candidate: RTCIceCandidate): Promise<void>;
   addIceCandidate(candidate:RTCIceCandidate,
                   successCallback:() => void,
                   failureCallback:RTCPeerConnectionErrorCallback): void;
@@ -284,8 +300,10 @@ interface RTCPeerConnection {
   onicecandidate: (event: RTCIceCandidateEvent) => void;
   onidentityresult: (event: Event) => void;
   onsignalingstatechange: (event: Event) => void;
-  getStats: (successCallback: RTCStatsCallback,
-             failureCallback: RTCPeerConnectionErrorCallback) => void;
+  getStats(selector: MediaStreamTrack): Promise<RTCStatsReport>;
+  getStats(selector: MediaStreamTrack, // nullable
+           successCallback: RTCStatsCallback,
+           failureCallback: RTCPeerConnectionErrorCallback): void;
 }
 declare var RTCPeerConnection: {
   prototype: RTCPeerConnection;
@@ -294,7 +312,7 @@ declare var RTCPeerConnection: {
 };
 
 interface RTCIceCandidate {
-  candidate?: string;
+  candidate: string;
   sdpMid?: string;
   sdpMLineIndex?: number;
 }
@@ -304,7 +322,7 @@ declare var RTCIceCandidate: {
 };
 
 interface webkitRTCIceCandidate extends RTCIceCandidate {
-  candidate?: string;
+  candidate: string;
   sdpMid?: string;
   sdpMLineIndex?: number;
 }
@@ -314,7 +332,7 @@ declare var webkitRTCIceCandidate: {
 };
 
 interface mozRTCIceCandidate extends RTCIceCandidate {
-  candidate?: string;
+  candidate: string;
   sdpMid?: string;
   sdpMLineIndex?: number;
 }
@@ -325,8 +343,8 @@ declare var mozRTCIceCandidate: {
 
 interface RTCIceCandidateInit {
   candidate: string;
-  sdpMid: string;
-  sdpMLineIndex: number;
+  sdpMid?: string;
+  sdpMLineIndex?: number;
 }
 declare var RTCIceCandidateInit:{
   prototype: RTCIceCandidateInit;


### PR DESCRIPTION
This is an improvement to existing type definition. Source: https://www.w3.org/TR/webrtc/
- Added new promise based API to `RTCPeerConnection`
- The old API is kept for legacy purposes (https://www.w3.org/TR/webrtc/#h-legacy-interface-extensions)

So far, it has not yet been reviewed by a DefinitelyTyped member. Could one (or two) of @smithkl42 @nestalk @akonwi @iislucas @nakakura @martinduparc @Garciat @groege @lgrahl maybe review?
