### PR TITLE
D3 enter

### DIFF
--- a/d3/d3-tests.ts
+++ b/d3/d3-tests.ts
@@ -2706,3 +2706,17 @@ function testMultiUtcFormat() {
         ["%Y", function() { return true; }]
     ]);
 }
+
+function testEnterSizeEmpty() {
+    
+    var selectionSize: number,
+        emptyStatus: boolean;
+        
+    var newNodes = d3.selectAll('.test')
+                .data(['1', '2', '3'])
+                .enter();
+                
+    emptyStatus = newNodes.empty();
+    selectionSize = newNodes.size();
+
+}

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -415,6 +415,9 @@ declare namespace d3 {
 
             select(name: (datum: Datum, index: number, outerIndex: number) => EventTarget): Selection<Datum>;
             call(func: (selection: Enter<Datum>, ...args: any[]) => any, ...args: any[]): Enter<Datum>;
+            
+            empty(): boolean;
+            size(): number;
         }
     }
 


### PR DESCRIPTION
Please review this pull request with minor changes to the interface for enter selections. It adds the size() and empty() methods referenced in the API documentation:

https://github.com/mbostock/d3/wiki/Selections#enter

A minimal test function testEnterSizeEmpty() is suggested for addition to the test file.

@gustavderdrache @borisyankov @vvakame 

Thanks in advance for reviewing!
