### PR TITLE
Adds extend to QUnit typings

### DIFF
--- a/qunit/qunit-tests.ts
+++ b/qunit/qunit-tests.ts
@@ -1637,3 +1637,34 @@ function testAfterDone() {
         }
     });
 }
+
+// Example QUnit.extend call taken from: http://api.qunitjs.com/QUnit.extend/
+QUnit.test( "QUnit.extend", function( assert ) {
+  var base = {
+    a: 1,
+    b: 2,
+    z: 3
+  };
+  QUnit.extend( base, {
+    b: 2.5,
+    c: 3,
+    z: undefined
+  } );
+  
+  // Change from documentation example to satisfy tsc:
+  var newBase = <any> base;
+ 
+  assert.equal( newBase.a, 1, "Unspecified values are not modified" );
+  assert.equal( newBase.b, 2.5, "Existing values are updated" );
+  assert.equal( newBase.c, 3, "New values are defined" );
+  assert.ok( !( "z" in newBase ), "Values specified as `undefined` are removed" );
+});
+
+// Example QUnit.extend usage taken from: http://stackoverflow.com/a/33439774/419956
+QUnit.extend(QUnit.assert, {
+    matches: function (actual, regex, message) {
+        var success = !!regex && !!actual && (new RegExp(regex)).test(actual);
+        var expected = "String matching /" + regex.toString() + "/";
+        this.push(success, actual, expected, message);
+    }
+});

--- a/qunit/qunit.d.ts
+++ b/qunit/qunit.d.ts
@@ -469,6 +469,18 @@ interface QUnitStatic extends QUnitAssert {
     * @depricated since version 1.16
     */
     expect(amount: number): any;
+    
+    /**
+    * Copy the properties defined by the mixin object into the target object.
+    * 
+    * This method will modify the target object to contain the "own" properties defined 
+    * by the mixin. If the mixin object specifies the value of any attribute as undefined, 
+    * this property will instead be removed from the target object.
+    *
+    * @param target An object whose properties are to be modified
+    * @param mixin An object describing which properties should be modified
+    */
+    extend(target: any, mixin: any): any;
 
     /**
     * Group related tests under a single label.


### PR DESCRIPTION
This is a pull request of type "_case 2: Improvement to existing type definition._"
- "_documentation or source code reference which provides context for the suggested changes_"
  - Documentation: http://api.qunitjs.com/QUnit.extend/
  - Source code: https://github.com/jquery/qunit/blob/master/src/core/utilities.js#L55 (note that the third argument is undocumented (see first link) and possibly not intended for public use, thus it's been left out of the typing)
- "_it has been reviewed by a DefinitelyTyped member._"

Commit message:

Adds extend to QUnit typings

Note that the second parameter (mixin) of this method is documented on
the website as being of type string, but both the qunit source code and
examples on the same documentation page tell us it's actually of type
any.
