### PR TITLE
angular-ui-router - update $state.go reload option to support v0.2.5+

### DIFF
--- a/angular-ui-router/angular-ui-router.d.ts
+++ b/angular-ui-router/angular-ui-router.d.ts
@@ -229,9 +229,9 @@ declare namespace angular.ui {
          */
         notify?: boolean;
         /**
-         * {boolean=false}, If true will force transition even if the state or params have not changed, aka a reload of the same state. It differs from reloadOnSearch because you'd use this when you want to force a reload when everything is the same, including search params.
+         *  {boolean=false|string|object}, If true will force transition even if no state or params have changed. It will reload the resolves and views of the current state and parent states. If reload is a string (or state object), the state object is fetched (by name, or object reference); and \ the transition reloads the resolves and views for that matched state, and all its children states.
          */
-        reload?: boolean;
+        reload?: boolean | string | IState;
     }
 
     interface IHrefOptions {


### PR DESCRIPTION
Improvement to existing type definition.

Update the IStateOptions interface to be inline with the reload option in $state.go of ui router v0.2.5+

Documentation for ui rotuer (see go options).
http://angular-ui.github.io/ui-router/site/#/api/ui.router.state.$state
