### PR TITLE
Add explicit string types to GeoJson definition

### DIFF
--- a/geojson/geojson.d.ts
+++ b/geojson/geojson.d.ts
@@ -36,6 +36,7 @@ declare namespace GeoJSON {
     */
     export interface Point extends GeometryObject
     {
+        type: 'Point'
         coordinates: Position
     }
 
@@ -44,6 +45,7 @@ declare namespace GeoJSON {
     */
     export interface MultiPoint extends GeometryObject
     {
+        type: 'MultiPoint'
         coordinates: Position[]
     }
 
@@ -52,6 +54,7 @@ declare namespace GeoJSON {
     */
     export interface LineString extends GeometryObject
     {
+        type: 'LineString'
         coordinates: Position[]
     }
 
@@ -60,6 +63,7 @@ declare namespace GeoJSON {
     */
     export interface MultiLineString extends GeometryObject
     {
+        type: 'MultiLineString'
         coordinates: Position[][]
     }
 
@@ -68,6 +72,7 @@ declare namespace GeoJSON {
     */
     export interface Polygon extends GeometryObject
     {
+        type: 'Polygon'
         coordinates: Position[][]
     }
 
@@ -76,6 +81,7 @@ declare namespace GeoJSON {
     */
     export interface MultiPolygon extends GeometryObject
     {
+        type: 'MultiPolygon'
         coordinates: Position[][][]
     }
 
@@ -84,6 +90,7 @@ declare namespace GeoJSON {
     */
     export interface GeometryCollection extends GeoJsonObject
     {
+        type: 'GeometryCollection'
         geometries: GeometryObject[];
     }
 
@@ -92,6 +99,7 @@ declare namespace GeoJSON {
     */
     export interface Feature<T extends GeometryObject> extends GeoJsonObject
     {
+        type: 'Feature'
         geometry: T;
         properties: any;
         id?: string;
@@ -102,6 +110,7 @@ declare namespace GeoJSON {
     */
     export interface FeatureCollection<T extends GeometryObject> extends GeoJsonObject
     {
+        type: 'FeatureCollection'
         features: Feature<T>[];
     }
 

--- a/turf/turf-tests.ts
+++ b/turf/turf-tests.ts
@@ -4,7 +4,7 @@
 // Tests data initialisation
 ///////////////////////////////////////////
 
-var point1 = {
+var point1: GeoJSON.Feature<GeoJSON.Point> = {
   "type": "Feature",
   "properties": {},
   "geometry": {
@@ -13,7 +13,7 @@ var point1 = {
   }
 };
 
-var point2 = {
+var point2: GeoJSON.Feature<GeoJSON.Point> = {
   "type": "Feature",
   "properties": {},
   "geometry": {
@@ -22,7 +22,7 @@ var point2 = {
     }
 };
 
-var line = {
+var line: GeoJSON.Feature<GeoJSON.LineString> = {
   "type": "Feature",
   "properties": {},
   "geometry": {
@@ -38,7 +38,7 @@ var line = {
   }
 };
 
-var polygons = {
+var polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon> = {
   "type": "FeatureCollection",
   "features": [
     {
@@ -71,7 +71,7 @@ var polygons = {
   ]
 };
 
-var polygon1 = {
+var polygon1: GeoJSON.Feature<GeoJSON.Polygon> = {
   "type": "Feature",
   "properties": {},
   "geometry": {
@@ -86,7 +86,7 @@ var polygon1 = {
   }
 };
 
-var polygon2 = {
+var polygon2: GeoJSON.Feature<GeoJSON.Polygon> = {
   "type": "Feature",
   "properties": {
     "fill": "#00f"
@@ -106,7 +106,7 @@ var polygon2 = {
   }
 }
 
-var features = {
+var features: GeoJSON.FeatureCollection<GeoJSON.Point> = {
   "type": "FeatureCollection",
   "features": [
     {
@@ -197,7 +197,7 @@ var features = {
   ]
 };
 
-var triangle = {
+var triangle: GeoJSON.Feature<GeoJSON.Polygon> = {
   "type": "Feature",
   "properties": {
     "a": 11,


### PR DESCRIPTION
Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

The type names for each interface are explicit in the [GeoJson spec](http://geojson.org/geojson-spec.html) and this uses recent TypeScript support for string valued types to make this much more obvious and to check this for us.
