### PR TITLE
request-promise added additional namespace and exports

### DIFF
--- a/request-promise/request-promise-tests.ts
+++ b/request-promise/request-promise-tests.ts
@@ -18,6 +18,14 @@ rp(options)
     .then(console.dir)
     .catch(console.error);
 
+// Test defining a request-promise options object
+
+var extendedOptions: rp.RequestPromiseOptions = {
+  simple: true,
+  resolveWithFullResponse: false,
+  transform: (body: any, response: http.IncomingMessage) => { return body;}
+};
+
 // --> Displays length of response from server after post
 
 //Defaults tests

--- a/request-promise/request-promise.d.ts
+++ b/request-promise/request-promise.d.ts
@@ -11,23 +11,23 @@
 declare module 'request-promise' {
     import request = require('request');
     import http = require('http');
-        
-    interface RequestPromise extends request.Request {
-        then<TResult>(onfulfilled?: (value: any) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>;
-        then<TResult>(onfulfilled?: (value: any) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<TResult>;
-        catch(onrejected?: (reason: any) => any | PromiseLike<any>): Promise<any>;
-        catch(onrejected?: (reason: any) => void): Promise<any>;
-        finally<TResult>(handler: () => PromiseLike<TResult>): Promise<any>;
-        finally<TResult>(handler: () => TResult): Promise<any>;
-        promise(): Promise<any>;
+    namespace requestPromise {
+        export interface RequestPromise extends request.Request {
+            then<TResult>(onfulfilled?: (value: any) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>;
+            then<TResult>(onfulfilled?: (value: any) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<TResult>;
+            catch(onrejected?: (reason: any) => any | PromiseLike<any>): Promise<any>;
+            catch(onrejected?: (reason: any) => void): Promise<any>;
+            finally<TResult>(handler: () => PromiseLike<TResult>): Promise<any>;
+            finally<TResult>(handler: () => TResult): Promise<any>;
+            promise(): Promise<any>;
+        }
+
+        export interface RequestPromiseOptions extends request.CoreOptions {
+            simple?: boolean;
+            transform?: (body: any, response: http.IncomingMessage) => any;
+            resolveWithFullResponse?: boolean;
+        }
     }
-    
-    interface RequestPromiseOptions extends request.CoreOptions {
-        simple?: boolean;
-        transform?: (body: any, response: http.IncomingMessage) => any;
-        resolveWithFullResponse?: boolean;
-    }
-    
-    var requestPromise: request.RequestAPI<RequestPromise, RequestPromiseOptions, request.RequiredUriUrl>;
-	export = requestPromise;
+    var requestPromise: request.RequestAPI<requestPromise.RequestPromise, requestPromise.RequestPromiseOptions, request.RequiredUriUrl>;
+    export = requestPromise;
 }


### PR DESCRIPTION
Please review this pull-request to the request-promise files. It adds an additional namespace and exports so that the interfaces, i.p. for RequestPromiseOptions can be explicitly used for typing.

A test was added for demonstration.
