### PR TITLE
Dojo xhr

### DIFF
--- a/dojo/dojo.d.ts
+++ b/dojo/dojo.d.ts
@@ -650,7 +650,7 @@ declare namespace dojo {
          * @param options       OptionalOptions for the request.
          */
         interface xhr { (url: String, options?: dojo.request.xhr.__Options): dojo.request.__Promise }
-        interface xhr {
+        // interface xhr {
             /**
              * Send an HTTP DELETE request using XMLHttpRequest with the given URL and options.
              *
@@ -679,7 +679,7 @@ declare namespace dojo {
              * @param options               OptionalOptions for the request.
              */
             // put(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
-        }
+        // }
 
         namespace xhr {
             /**

--- a/dojo/dojo.d.ts
+++ b/dojo/dojo.d.ts
@@ -649,7 +649,7 @@ declare namespace dojo {
          * @param url URL to request
          * @param options       OptionalOptions for the request.
          */
-        interface xhr { (url: String, options?: dojo.request.xhr.__Options): void }
+        interface xhr { (url: String, options?: dojo.request.xhr.__Options): dojo.request.__Promise }
         interface xhr {
             /**
              * Send an HTTP DELETE request using XMLHttpRequest with the given URL and options.
@@ -657,28 +657,28 @@ declare namespace dojo {
              * @param url URL to request
              * @param options               OptionalOptions for the request.
              */
-            del(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
+            // del(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
             /**
              * Send an HTTP GET request using XMLHttpRequest with the given URL and options.
              *
              * @param url URL to request
              * @param options               OptionalOptions for the request.
              */
-            get(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
+            // get(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
             /**
              * Send an HTTP POST request using XMLHttpRequest with the given URL and options.
              *
              * @param url URL to request
              * @param options               OptionalOptions for the request.
              */
-            post(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
+            // post(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
             /**
              * Send an HTTP PUT request using XMLHttpRequest with the given URL and options.
              *
              * @param url URL to request
              * @param options               OptionalOptions for the request.
              */
-            put(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
+            // put(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
         }
 
         namespace xhr {

--- a/dojo/dojo.d.ts
+++ b/dojo/dojo.d.ts
@@ -650,36 +650,36 @@ declare namespace dojo {
          * @param options       OptionalOptions for the request.
          */
         interface xhr { (url: String, options?: dojo.request.xhr.__Options): dojo.request.__Promise }
-        // interface xhr {
+        interface xhr {
             /**
              * Send an HTTP DELETE request using XMLHttpRequest with the given URL and options.
              *
              * @param url URL to request
              * @param options               OptionalOptions for the request.
              */
-            // del(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
+            del(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
             /**
              * Send an HTTP GET request using XMLHttpRequest with the given URL and options.
              *
              * @param url URL to request
              * @param options               OptionalOptions for the request.
              */
-            // get(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
+            get(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
             /**
              * Send an HTTP POST request using XMLHttpRequest with the given URL and options.
              *
              * @param url URL to request
              * @param options               OptionalOptions for the request.
              */
-            // post(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
+            post(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
             /**
              * Send an HTTP PUT request using XMLHttpRequest with the given URL and options.
              *
              * @param url URL to request
              * @param options               OptionalOptions for the request.
              */
-            // put(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
-        // }
+            put(url: String, options?: dojo.request.xhr.__BaseOptions): dojo.request.__Promise;
+        }
 
         namespace xhr {
             /**


### PR DESCRIPTION
See #9338 

The current definitions for the dojo/request/xhr module don't match the source code; the helper methods (get, post, etc) are exposed in the definitions file, but commented out in the code.

In addition, the base xhr method returns either a promise or a deferred, but the definitions have it returning void, which makes using then, etc. impossible.  The default return type is a Promise, which is what I have set it to in the definitions.

See: https://github.com/dojo/dojo/blob/1.10/request/xhr.js
