### PR TITLE
allow objects for hapi's request.log

### DIFF
--- a/hapi/hapi-tests.ts
+++ b/hapi/hapi-tests.ts
@@ -79,6 +79,7 @@ server.route({
 	method: 'GET',
 	path: '/hello',
 	handler: function (request: Hapi.Request, reply: Function) {
+		request.log('info', { route: '/hello' }, Date.now());
 		reply('hello world');
 	}
 });

--- a/hapi/hapi.d.ts
+++ b/hapi/hapi.d.ts
@@ -1301,7 +1301,7 @@ declare module "hapi" {
 		log(/** a string or an array of strings (e.g. ['error', 'database', 'read']) used to identify the event. Tags are used instead of log levels and provide a much more expressive mechanism for describing and filtering events.*/
 			tags: string | string[],
 			/** an optional message string or object with the application data being logged.*/
-			data?: string,
+			data?: any,
 			/**  an optional timestamp expressed in milliseconds. Defaults to Date.now() (now).*/
 			timestamp?: number): void;
 


### PR DESCRIPTION
Fixes #6961

Allow strings and objects as the `data` argument, as specified by [the docs](http://hapijs.com/api#requestlogtags-data-timestamp).
