### PR TITLE
Rectify type for IState.template

### DIFF
--- a/angular-ui-router/angular-ui-router.d.ts
+++ b/angular-ui-router/angular-ui-router.d.ts
@@ -35,7 +35,7 @@ declare namespace angular.ui {
         /**
          * String HTML content, or function that returns an HTML string
          */
-        template?: string | {(): string};
+        template?: string | {(params: IStateParamsService): string};
         /**
          * String URL path to template file OR Function, returns URL path string
          */


### PR DESCRIPTION
Add `params: IStateParamsService` for IState.template function.
Documentation reference: [$stateProvider.state](http://angular-ui.github.io/ui-router/site/#/api/ui.router.state.$stateProvider#methods_state) -> stateConfig -> template
