### PR TITLE
Removed get/set (not present in the object) and added $sync function()

### DIFF
--- a/ngstorage/ngstorage-tests.ts
+++ b/ngstorage/ngstorage-tests.ts
@@ -5,10 +5,6 @@ var app: any;
 
 app.controller('LocalCtrl', function ($localStorage: angular.storage.IStorageService) {
 
-    $localStorage.set('MyKey', 'value');
-
-    $localStorage.get('MyKey');
-
     $localStorage.$default({
         counter: 1
     });
@@ -20,13 +16,11 @@ app.controller('LocalCtrl', function ($localStorage: angular.storage.IStorageSer
     $localStorage.$reset();
 
     $localStorage.$apply();
+    
+    $localStorage.$sync();
 });
 
 app.controller('SessionCtrl', function ($sessionStorage: angular.storage.IStorageService) {
-
-    $sessionStorage.set('MyKey', 'value');
-
-    $sessionStorage.get('MyKey');
 
     $sessionStorage.$default({
         counter: 1
@@ -39,9 +33,12 @@ app.controller('SessionCtrl', function ($sessionStorage: angular.storage.IStorag
     $sessionStorage.$reset();
 
     $sessionStorage.$apply();
+    
+    $sessionStorage.$sync();
 });
 
 app.config(['$localStorageProvider', function ($localStorageProvider: angular.storage.IStorageProvider) {
+
         $localStorageProvider.setKeyPrefix('NewPrefix');
 
         $localStorageProvider.get('MyKey');

--- a/ngstorage/ngstorage.d.ts
+++ b/ngstorage/ngstorage.d.ts
@@ -11,9 +11,7 @@ declare namespace angular.storage {
         $default(items: {}): IStorageService;
         $reset(items?: {}): IStorageService;
         $apply(): void;
-
-        get<T>(key: string): T;
-        set<T>(key: string, value: T): T;
+        $sync(): void;
     }
 
     export interface IStorageProvider extends angular.IServiceProvider {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation: https://github.com/gsklee/ngStorage/blob/0.3.10/ngStorage.js
- it has been reviewed by a DefinitelyTyped member;
