### PR TITLE
Added initial typings for remote-redux-devtools

### DIFF
--- a/remote-redux-devtools/remote-redux-devtools-tests.ts
+++ b/remote-redux-devtools/remote-redux-devtools-tests.ts
@@ -1,0 +1,13 @@
+/// <reference path="remote-redux-devtools.d.ts" />
+
+import * as devTools from "remote-redux-devtools";
+
+// example configuration from: https://github.com/zalmoxisus/remote-redux-devtools
+devTools({
+  name: 'Android app',
+  realtime: true,
+  hostname: 'localhost',
+  port: 8000,
+  maxAge: 30,
+  filters: { blacklist: ['EFFECT_RESOLVED'] }
+});

--- a/remote-redux-devtools/remote-redux-devtools.d.ts
+++ b/remote-redux-devtools/remote-redux-devtools.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for remote-redux-devtools v0.3.2
+// Project: https://github.com/zalmoxisus/remote-redux-devtools
+// Definitions by: Colin Eberhardt <https://github.com/ColinEberhardt>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "remote-redux-devtools" {
+
+    type StringOrArray = string | string[];
+
+    interface Config {
+      name?: string;
+      realtime?: boolean;
+      hostname?: string;
+      port?: number;
+      secure?: boolean;
+      filters?: {[key: string]: string[]};
+      maxAge?: number;
+      startOn?: StringOrArray;
+      stopOn?: StringOrArray;
+      sendOn?: StringOrArray;
+      sendOnError?: number;
+      sendTo?: string;
+      id?: string;
+    }
+
+    function devTools(config?: Config): Function;
+
+    namespace devTools {}
+
+    export = devTools;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
