### PR TITLE
corrected case on showdownjs where "Converter" had been assigned the …

### DIFF
--- a/showdown/showdown-tests.ts
+++ b/showdown/showdown-tests.ts
@@ -6,9 +6,9 @@
 import Showdown = require('showdown');
 
 var exampleMarkdown = '#hello, markdown',
-    converter = new Showdown.converter(),
+    converter = new Showdown.Converter(),
     preloadedExtensions = [ 'github', 'twitter', 'prettify', 'table' ],
-    extensionsConverter = new Showdown.converter({ extensions: preloadedExtensions });
+    extensionsConverter = new Showdown.Converter({ extensions: preloadedExtensions });
 
 console.log(converter.makeHtml(exampleMarkdown));
 // should log '<h1 id="hellomarkdown">hello, markdown</h1>'

--- a/showdown/showdown.d.ts
+++ b/showdown/showdown.d.ts
@@ -18,7 +18,7 @@ declare namespace Showdown {
          * Describes what type of extension - language ext or output modifier.
          * If absent, 'output modifier' type is assumed (contrary to comments in source).
          */
-        type?: string;
+            type?: string;
     }
 
     interface LangExtension extends Extension {
@@ -53,14 +53,6 @@ declare namespace Showdown {
         extensions: any[]; // (string | Plugin)[]
     }
 
-    interface Converter {
-        /**
-         * @param text The input text (markdown)
-         * @return The output HTML
-         */
-        makeHtml(text: string): string;
-    }
-
     interface ConverterStatic {
         /**
          * @constructor
@@ -69,8 +61,19 @@ declare namespace Showdown {
         new(converter_options?: ConverterOptions): Converter;
     }
 
+    /**
+     * A converter that will use showdown to parse markdown text and return html.
+     */
+    interface Converter {
+        /**
+         * @param text The input text (markdown)
+         * @return The output HTML
+         */
+        makeHtml(text: string): string;
+    }
+
     /** Constructor function for a Converter */
-    var converter: ConverterStatic;
+    var Converter: ConverterStatic;
 
     /** Registered extensions */
     var extensions: { [name: string]: ShowdownExtension };
@@ -81,6 +84,14 @@ declare namespace Showdown {
      * @param callback Applied once to each item (signature here is from forEach in lib.d.ts)
      */
     function forEach<T>(obj: T[], callback: (value: T, index: number, array: T[]) => any): void;
+
+    /**
+     * Register an extension.
+     * @param name A name for the new extension.
+     * @param e An extension to register.
+     */
+    function extension(name: string, e: ShowdownExtension);
+
 }
 
 declare module "showdown" {


### PR DESCRIPTION
case 1. Add a new type definition.
- [X] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [X] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [X] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url https://github.com/showdownjs/showdown .
  - it has been reviewed by a DefinitelyTyped member.

The typings for `showdownjs` had an incorrect typing; the function `Converter()` was at some point changed to have uppercasing instead of being lowercase, `converter`. This was causing an issue where attempts to run code that was typed correctly would throw errors, and attempts to write code that runs correctly would throw errors with the typescript definitions.

The appropriate syntax for the `Converter` function is seen here, taken from the [project's documentation](https://github.com/showdownjs/showdown)

```
var converter = new showdown.Converter(),
    text      = '#hello, markdown!',
    html      = converter.makeHtml(text);
```

This update has resolved the identifier.
