### PR TITLE
Added missing exports for format and compile functions to support custom named formats

### DIFF
--- a/morgan/morgan-tests.ts
+++ b/morgan/morgan-tests.ts
@@ -29,3 +29,35 @@ morgan('combined', {
     	}
     }
 });
+
+
+// a named custom format defined as string (example: extend 'tiny' format with user-agent token)
+morgan.format('tiny-extended', ':method :url :status :res[content-length] - :response-time ms :user-agent');
+
+
+// a named custom format defined using the Function signature (example: extend 'dev' format with user-agent token)
+morgan.format('dev-extended', function developmentExtendedFormatLine(tokens, req, res) {
+    
+  // get the status code if response written
+  var status = res._header
+    ? res.statusCode
+    : undefined
+
+  // get status color
+  var color = status >= 500 ? 31 // red
+    : status >= 400 ? 33 // yellow
+    : status >= 300 ? 36 // cyan
+    : status >= 200 ? 32 // green
+    : 0 // no color
+
+  // get colored function
+  var fn = developmentExtendedFormatLine[color]
+
+  if (!fn) {
+    // compile
+    fn = developmentExtendedFormatLine[color] = morgan.compile('\x1b[0m:method :url \x1b['
+      + color + 'm:status \x1b[0m:response-time ms - :res[content-length]\x1b[0m :user-agent')
+  }
+
+  return fn(tokens, req, res)
+});

--- a/morgan/morgan-tests.ts
+++ b/morgan/morgan-tests.ts
@@ -4,6 +4,7 @@
  */
 
 import morgan = require('morgan');
+import express = require('express');
 
 // a pre-defined name
 morgan('combined')
@@ -15,8 +16,8 @@ morgan('tiny')
 morgan(':remote-addr :method :url')
 
 // a custom function
-morgan(function (req, res) {
-    return req.method + ' ' + req.url
+morgan(function (tokens, req, res) {
+    return req.method + ' ' + req.url + ' ' + tokens['date'](req, res, 'iso'); // use predefined :date[iso] token with format argument
 })
 
 morgan('combined', {
@@ -31,33 +32,53 @@ morgan('combined', {
 });
 
 
+// test interface definition for morgan
+var morgan2 : morgan.Morgan = morgan;
+
 // a named custom format defined as string (example: extend 'tiny' format with user-agent token)
 morgan.format('tiny-extended', ':method :url :status :res[content-length] - :response-time ms :user-agent');
 
 
 // a named custom format defined using the Function signature (example: extend 'dev' format with user-agent token)
-morgan.format('dev-extended', function developmentExtendedFormatLine(tokens, req, res) {
+
+// extend morgan.FormatFn interface with memoizer property to avoid unnecessary re-compiling
+// of status-code range driven colorized format functions
+interface IFormatFnIndexer {
+  [memoizerName: string]: morgan.FormatFn;
+}
+
+interface IExtendedFormatFn extends morgan.FormatFn {
+  memoizer?: IFormatFnIndexer;
+}
+
+
+var developmentExtendedFormatLine : IExtendedFormatFn = function(tokens, req, res):string {
     
   // get the status code if response written
-  var status = res._header
+  var status = res.statusCode
     ? res.statusCode
-    : undefined
+    : undefined;
 
   // get status color
   var color = status >= 500 ? 31 // red
     : status >= 400 ? 33 // yellow
     : status >= 300 ? 36 // cyan
     : status >= 200 ? 32 // green
-    : 0 // no color
+    : 0; // no color
 
-  // get colored function
-  var fn = developmentExtendedFormatLine[color]
+  // get colored format function, if previously memoized, otherwise undefined
+  var fn: morgan.FormatFn = developmentExtendedFormatLine.memoizer[color];
 
   if (!fn) {
     // compile
-    fn = developmentExtendedFormatLine[color] = morgan.compile('\x1b[0m:method :url \x1b['
-      + color + 'm:status \x1b[0m:response-time ms - :res[content-length]\x1b[0m :user-agent')
+    fn = developmentExtendedFormatLine.memoizer[color] = morgan.compile('\x1b[0m:method :url \x1b['
+      + color + 'm:status \x1b[0m:response-time ms - :res[content-length]\x1b[0m :user-agent');
   }
 
-  return fn(tokens, req, res)
-});
+  return fn(tokens, req, res);
+};
+
+developmentExtendedFormatLine.memoizer = {};
+
+
+morgan.format('dev-extended', developmentExtendedFormatLine);

--- a/morgan/morgan.d.ts
+++ b/morgan/morgan.d.ts
@@ -12,6 +12,10 @@ declare module "morgan" {
 
         export function token<T>(name: string, callback: (req: express.Request, res: express.Response) => T): express.RequestHandler;
 
+        export function format(name: string, fmt: string | Function): Function;
+        
+        export function compile(format: string): Function;
+        
         export interface StreamOptions {
             /**
              * Output stream for writing log lines

--- a/morgan/morgan.d.ts
+++ b/morgan/morgan.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for morgan 1.2.2
+// Type definitions for morgan 1.7.0
 // Project: https://github.com/expressjs/morgan
 // Definitions by: James Roland Cabresos <https://github.com/staticfunction>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -10,12 +10,115 @@ declare module "morgan" {
 
     namespace morgan {
 
-        export function token<T>(name: string, callback: (req: express.Request, res: express.Response) => T): express.RequestHandler;
+        export interface FormatFn extends Function {
+            (tokens: TokenIndexer, req: express.Request, res: express.Response): string;
+        }
 
-        export function format(name: string, fmt: string | Function): Function;
-        
-        export function compile(format: string): Function;
-        
+        export interface TokenCallbackFn extends Function {
+            (req: express.Request, res: express.Response, arg?: string | number | boolean): string;
+        }
+
+        export interface TokenIndexer {
+            [tokenName: string]: TokenCallbackFn;
+        }
+
+        /**
+         * Public interface of morgan logger
+         */
+        export interface Morgan {
+            /***
+             * Create a new morgan logger middleware function using the given format and options. The format argument may be a string of a predefined name (see below for the names), 
+             * or a string of a format string containing defined tokens.
+             * @param format
+             * @param options
+             */
+            (format: string, options?: Options): express.RequestHandler;
+            /***
+             * Standard Apache combined log output.
+             * :remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"
+             * @param format
+             * @param options
+             */
+            (format: 'combined', options?: Options): express.RequestHandler;
+            /***
+             * Standard Apache common log output.
+             * :remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length]
+             * @param format
+             * @param options
+             */
+            (format: 'common', options?: Options): express.RequestHandler;
+            /**
+             * Concise output colored by response status for development use. The :status token will be colored red for server error codes, yellow for client error codes, cyan for redirection codes, and uncolored for all other codes.
+             * :method :url :status :response-time ms - :res[content-length]
+             * @param format
+             * @param options
+             */
+            (format: 'dev', options?: Options): express.RequestHandler;
+
+            /***
+             * Shorter than default, also including response time.
+             * :remote-addr :remote-user :method :url HTTP/:http-version :status :res[content-length] - :response-time ms
+             * @param format
+             * @param options
+             */
+            (format: 'short', options?: Options): express.RequestHandler;
+
+            /***
+             * The minimal output.
+             * :method :url :status :res[content-length] - :response-time ms
+             * @param format
+             * @param options
+             */
+            (format: 'tiny', options?: Options): express.RequestHandler;
+
+            /***
+             * Create a new morgan logger middleware function using the given format and options. The format argument may be a  
+             * custom format function which adheres to the signature.
+             * @param format
+             * @param options
+             */
+            (format: FormatFn, options?: Options): express.RequestHandler;
+
+            /**
+             * Define a custom token which can be used in custom morgan logging formats.
+             */
+            token(name: string, callback: TokenCallbackFn): Morgan;
+            /**
+             * Define a named custom format by specifying a format string in token notation
+             */
+            format(name: string, fmt: string): Morgan;
+
+            /**
+             * Define a named custom format by specifying a format function
+             */
+            format(name: string, fmt: FormatFn): Morgan;
+
+            /**
+             * Compile a format string in token notation into a format function
+             */
+            compile(format: string): FormatFn;
+        }
+
+        /**
+         * Define a custom token which can be used in custom morgan logging formats.
+         */
+        export function token(name: string, callback: TokenCallbackFn): Morgan;
+
+        /**
+         * Define a named custom format by specifying a format string in token notation
+         */
+        export function format(name: string, fmt: string): Morgan;
+
+        /**
+         * Define a named custom format by specifying a format function
+         */
+        export function format(name: string, fmt: FormatFn): Morgan;
+
+        /**
+         * Compile a format string in token notation into a format function
+         */
+        export function compile(format: string): FormatFn;
+
         export interface StreamOptions {
             /**
              * Output stream for writing log lines
@@ -52,7 +155,8 @@ declare module "morgan" {
     }
 
     /***
-     * Create a new morgan logger middleware function using the given format and options. The format argument may be a string of a predefined name (see below for the names), a string of a format string, or a function that will produce a log entry.
+     * Create a new morgan logger middleware function using the given format and options. The format argument may be a string of a predefined name (see below for the names), 
+     * or a string of a format string containing defined tokens.
      * @param format
      * @param options
      */
@@ -98,7 +202,13 @@ declare module "morgan" {
      */
     function morgan(format: 'tiny', options?: morgan.Options): express.RequestHandler;
 
-    function morgan(custom: (req: express.Request, res: express.Response) => string): express.RequestHandler
+    /***
+     * Create a new morgan logger middleware function using the given format and options. The format argument may be a  
+     * custom format function which adheres to the signature.
+     * @param format
+     * @param options
+     */
+    function morgan(format: morgan.FormatFn, options?: morgan.Options): express.RequestHandler
 
     export = morgan;
 }


### PR DESCRIPTION
Please consider the following pull request. The [morgan module](https://github.com/expressjs/morgan/blob/master/index.js) exports a `format` function and a `compile` function. These are exported alongside the `token`function,  but had not been included into the typescript definition file to date. Incorporating them allows the creation _named_ custom formats.

This pull request includes tests of the respective function signatures.

Thanks in advance.
