### PR TITLE
webpack: Add OccurrenceOrderPlugin as Webpack optimizer

### DIFF
--- a/webpack/webpack-tests.ts
+++ b/webpack/webpack-tests.ts
@@ -333,6 +333,7 @@ plugin = new webpack.optimize.DedupePlugin();
 plugin = new webpack.optimize.LimitChunkCountPlugin(options);
 plugin = new webpack.optimize.MinChunkSizePlugin(options);
 plugin = new webpack.optimize.OccurenceOrderPlugin(preferEntry);
+plugin = new webpack.optimize.OccurrenceOrderPlugin(preferEntry);
 plugin = new webpack.optimize.UglifyJsPlugin(options);
 plugin = new webpack.optimize.UglifyJsPlugin();
 plugin = new webpack.optimize.UglifyJsPlugin({

--- a/webpack/webpack.d.ts
+++ b/webpack/webpack.d.ts
@@ -328,6 +328,7 @@ declare module "webpack" {
              * This make ids predictable, reduces to total file size and is recommended.
              */
             OccurenceOrderPlugin: optimize.OccurenceOrderPluginStatic;
+            OccurrenceOrderPlugin: optimize.OccurenceOrderPluginStatic;
             /**
              * Minimize all JavaScript output of chunks. Loaders are switched into minimizing mode.
              * You can pass an object containing UglifyJs options.

--- a/webpack/webpack.d.ts
+++ b/webpack/webpack.d.ts
@@ -327,6 +327,7 @@ declare module "webpack" {
              * Assign the module and chunk ids by occurrence count. Ids that are used often get lower (shorter) ids.
              * This make ids predictable, reduces to total file size and is recommended.
              */
+            // TODO: This is a typo, and will be removed in Webpack 2.
             OccurenceOrderPlugin: optimize.OccurenceOrderPluginStatic;
             OccurrenceOrderPlugin: optimize.OccurenceOrderPluginStatic;
             /**


### PR DESCRIPTION
`OccurenceOrderPlugin` is a typo, the webpack team already aware of this fact and it will be removed in Webpack 2 in favor of `OccurrenceOrderPlugin`.

Currently Webpack [supports both](https://github.com/webpack/webpack/blob/ee1b8c43b474b22a20bfc25daf0ee153dfb2ef9f/lib/webpack.js). This pull requests add `OccurrenceOrderPlugin` which is missing.
