### PR TITLE
Add redirect option to whatwg-fetch

### DIFF
--- a/whatwg-fetch/whatwg-fetch-tests.ts
+++ b/whatwg-fetch/whatwg-fetch-tests.ts
@@ -8,7 +8,8 @@ function test_fetchUrlWithOptions() {
 		headers: headers,
 		mode: 'same-origin',
 		credentials: 'omit',
-		cache: 'default'
+		cache: 'default',
+		redirect: 'manual'
 	};
 	handlePromise(window.fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions));
 }

--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -11,6 +11,7 @@ declare class Request extends Body {
 	context: RequestContext;
 	referrer: string;
 	mode: RequestMode;
+	redirect: RequestRedirect;
 	credentials: RequestCredentials;
 	cache: RequestCache;
 }
@@ -20,6 +21,7 @@ interface RequestInit {
 	headers?: HeaderInit|{ [index: string]: string };
 	body?: BodyInit;
 	mode?: RequestMode;
+	redirect?: RequestRedirect;
 	credentials?: RequestCredentials;
 	cache?: RequestCache;
 }
@@ -33,6 +35,7 @@ type RequestContext =
 	"subresource" | "style" | "track" | "video" | "worker" |
 	"xmlhttprequest" | "xslt";
 type RequestMode = "same-origin" | "no-cors" | "cors";
+type RequestRedirect = "follow" | "error" | "manual";
 type RequestCredentials = "omit" | "same-origin" | "include";
 type RequestCache =
 	"default" | "no-store" | "reload" | "no-cache" |
@@ -70,7 +73,7 @@ declare class Response extends Body {
 	clone(): Response;
 }
 
-type ResponseType = "basic" | "cors" | "default" | "error" | "opaque";
+type ResponseType = "basic" | "cors" | "default" | "error" | "opaque" | "opaqueredirect";
 
 interface ResponseInit {
 	status: number;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

The spec says [Request and RequestInit have `redirect` property](https://fetch.spec.whatwg.org/#requestredirect), and [ResponseType has `opaqueredirect`](https://fetch.spec.whatwg.org/#responsetype).
