### PR TITLE
.html allows for both string and DOM element

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -1287,12 +1287,14 @@ interface JQuery {
      * Get the HTML contents of the first element in the set of matched elements.
      */
     html(): string;
+    
     /**
      * Set the HTML contents of each element in the set of matched elements.
      *
-     * @param htmlString A string of HTML to set as the content of each matched element.
+     * @param content DOM element or HTML string to set as the content of each matched element.
      */
-    html(htmlString: string): JQuery;
+    html(content: string|JQuery): JQuery;
+    
     /**
      * Set the HTML contents of each element in the set of matched elements.
      *


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
