### PR TITLE
Improve jQuery triggerHandler()

### DIFF
--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -932,6 +932,46 @@ function test_trigger() {
     });
 }
 
+function test_triggerHandler() {
+    $('input').triggerHandler('focus');
+
+    $('input').triggerHandler('outsideChange', this);
+
+    $('playlist').triggerHandler({type: 'load'});
+
+    $('input').triggerHandler('input').triggerHandler('change');
+
+    $('input').triggerHandler($.Event('keydown', {which: 13}));
+
+    $('input').triggerHandler(jQuery.Event('change', {
+        target: {
+            files: [
+                new Blob(['data0']),
+                new Blob(['data1'])
+            ]
+        }
+    }));
+
+    $('input').triggerHandler($.Event('change', {
+        target: {
+            files: [
+                new Blob(['data0']),
+                new Blob(['data1'])
+            ]
+        }
+    }));
+
+    $('input').triggerHandler({
+        type: 'change',
+        target: {
+            files: [
+                new Blob(['data0']),
+                new Blob(['data1'])
+            ]
+        }
+    });
+}
+
 function test_clone() {
     $('.hello').clone().appendTo('.goodbye');
     var $elem = $('#elem').data({ "arr": [1] }),

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -2504,15 +2504,15 @@ interface JQuery {
      * @param eventType A string containing a JavaScript event type, such as click or submit.
      * @param extraParameters An array of additional parameters to pass along to the event handler.
      */
-    triggerHandler(eventType: string, ...extraParameters: any[]): Object;
-
+    triggerHandler(eventType: string, ...extraParameters: any[]): JQuery;
     /**
      * Execute all handlers attached to an element for an event.
      * 
      * @param event A jQuery.Event object.
      * @param extraParameters An array of additional parameters to pass along to the event handler.
      */
-    triggerHandler(event: JQueryEventObject, ...extraParameters: any[]): Object;
+    triggerHandler(event: JQueryEventObject, ...extraParameters: any[]): JQuery;
+    triggerHandler(event: any): JQuery;
 
     /**
      * Remove a previously-attached event handler from the elements.
@@ -2531,9 +2531,9 @@ interface JQuery {
     /**
      * Remove a previously-attached event handler from the elements.
      * 
-     * @param evt A JavaScript event object as passed to an event handler.
+     * @param event A JavaScript event object as passed to an event handler.
      */
-    unbind(evt: any): JQuery;
+    unbind(event: any): JQuery;
 
     /**
      * Remove a handler from the event for all elements which match the current selector, based upon a specific set of root elements.


### PR DESCRIPTION
See #4094

It should be possible to call:

``` JavaScript
$('playlist').triggerHandler({type: 'load'});

$('input').triggerHandler({
    type: 'change',
    target: {
        files: [
            new Blob(['data0']),
            new Blob(['data1'])
        ]
    }
});
```

Definition: `triggerHandler(event: any): Object`
I could not find a way with TypeScript to force `event` to have at least property `type` :/

And also:

``` JavaScript
$('input').triggerHandler('input').triggerHandler('change');
```

`triggerHandler()` should return ~~`JQuery`~~ Object.
