### PR TITLE
protractor-http-mock: Add runtime mocks and plugin support.

### DIFF
--- a/protractor-http-mock/protractor-http-mock-tests.ts
+++ b/protractor-http-mock/protractor-http-mock-tests.ts
@@ -8,15 +8,10 @@ function TestConfig() {
 }
 
 function TestCtorOverloads() {
-    let noParam: mock.ProtractorHttpMock = mock();
-    let emptyArray: mock.ProtractorHttpMock = mock([]);
-    let mockFiles: mock.ProtractorHttpMock = mock(["mock1", "mock2"]);
-    let skipDefaults: mock.ProtractorHttpMock = mock([], true);
-
     let del: mock.requests.Delete<number> = {
         request: {
-            path: "path",
-            method: "DELETE"
+            path: 'path',
+            method: 'DELETE'
         },
         response: {
             status: 400,
@@ -25,15 +20,36 @@ function TestCtorOverloads() {
     };
     let put: mock.requests.Put<number> = {
         request: {
-            path: "path",
-            method: "PUT"
+            path: 'path',
+            method: 'PUT'
         },
         response: {
             status: 400,
             data: 1
         }
     };
+    let plugin: mock.Plugin = {
+        match: (mockRequest: mock.requests.Delete<number>, requestConfig: mock.requests.AllRequests<number, number>) => {
+            if (requestConfig.request.method && mockRequest.request.method) {
+                return true;
+            }
+
+            return false;
+        }
+    };
+
+    let noParam: mock.ProtractorHttpMock = mock();
+    let emptyArray: mock.ProtractorHttpMock = mock([]);
+    let mockFiles: mock.ProtractorHttpMock = mock(['mock1', 'mock2']);
     let mocks: mock.ProtractorHttpMock = mock([del, put]);
+
+    let mockFilesNpmPlugins: mock.ProtractorHttpMock = mock(['mock1'], ['plugin']);
+    let mocksWithNpmPlugins: mock.ProtractorHttpMock = mock([del, put], ['plugin']);
+
+    let pluginMocks: mock.ProtractorHttpMock = mock([del, put], [plugin]);
+
+    let mockFilesNpmPluginsSkipDefaults: mock.ProtractorHttpMock = mock(['mock1'], ['plugin'], true);
+    let skipDefaults: mock.ProtractorHttpMock = mock([del, put], [plugin], true);
 }
 
 function TestTeardown() {
@@ -85,8 +101,9 @@ function TestDyanmicRemove() {
 function TestGetRequestDefinitions() {
     let getMinium: mock.requests.Get<number> = {
         request: {
-            path: "path",
-            method: "GET"
+            path: 'path',
+            method: 'GET',
+            regex: true
         },
         response: {
             data: 1,
@@ -96,10 +113,11 @@ function TestGetRequestDefinitions() {
 
     let getParams: mock.requests.Get<number> = {
         request: {
-            path: "path",
-            method: "GET",
+            path: 'path',
+            method: 'GET',
+            regex: true,
             params: {
-                param1: "param1",
+                param1: 'param1',
                 param2: 2
             }
         },
@@ -111,8 +129,9 @@ function TestGetRequestDefinitions() {
 
     let post: mock.requests.Post<number> = {
         request: {
-            path: "path",
-            method: "POST"
+            path: 'path',
+            method: 'POST',
+            regex: true
         },
         response: {
             data: 1,
@@ -122,10 +141,11 @@ function TestGetRequestDefinitions() {
 
     let getQueryString: mock.requests.Get<number> = {
         request: {
-            path: "path",
-            method: "GET",
+            path: 'path',
+            method: 'GET',
+            regex: true,
             queryString: {
-                query1: "query1",
+                query1: 'query1',
                 query2: 2
             }
         },
@@ -137,11 +157,12 @@ function TestGetRequestDefinitions() {
 
     let getHeaders: mock.requests.Get<number> = {
         request: {
-            path: "path",
-            method: "GET",
+            path: 'path',
+            method: 'GET',
+            regex: true,
             headers: {
-                head1: "head1",
-                head2: "head2"
+                head1: 'head1',
+                head2: 'head2'
             }
         },
         response: {
@@ -154,8 +175,9 @@ function TestGetRequestDefinitions() {
 function TestPostRequestDefinitions() {
     let post: mock.requests.Post<number> = {
         request: {
-            path: "path",
-            method: "POST"
+            path: 'path',
+            method: 'POST',
+            regex: true
         },
         response: {
             data: 1,
@@ -165,9 +187,10 @@ function TestPostRequestDefinitions() {
 
     let postData: mock.requests.PostData<number, string> = {
         request: {
-            path: "path",
-            method: "POST",
-            data: "data"
+            path: 'path',
+            method: 'POST',
+            data: 'data',
+            regex: true
         },
         response: {
             data: 1,
@@ -179,8 +202,9 @@ function TestPostRequestDefinitions() {
 function TestHeadRequestDefinitions() {
     let head: mock.requests.Head<number> = {
         request: {
-            path: "path",
-            method: "HEAD"
+            path: 'path',
+            method: 'HEAD',
+            regex: true
         },
         response: {
             status: 500,
@@ -192,8 +216,9 @@ function TestHeadRequestDefinitions() {
 function TestDeleteRequestDefinitions() {
     let del: mock.requests.Delete<number> = {
         request: {
-            path: "path",
-            method: "DELETE"
+            path: 'path',
+            method: 'DELETE',
+            regex: true
         },
         response: {
             status: 500,
@@ -205,8 +230,9 @@ function TestDeleteRequestDefinitions() {
 function TestPutRequestDefinitions() {
     let put: mock.requests.Put<number> = {
         request: {
-            path: "path",
-            method: "PUT"
+            path: 'path',
+            method: 'PUT',
+            regex: true
         },
         response: {
             status: 500,
@@ -218,8 +244,9 @@ function TestPutRequestDefinitions() {
 function TestPatchRequestDefinitions() {
     let patch: mock.requests.Patch<number> = {
         request: {
-            path: "path",
-            method: "PATCH"
+            path: 'path',
+            method: 'PATCH',
+            regex: true
         },
         response: {
             status: 500,
@@ -231,12 +258,45 @@ function TestPatchRequestDefinitions() {
 function TestJsonpRequestDefinitions() {
     let jsonp: mock.requests.Jsonp<number> = {
         request: {
-            path: "path",
-            method: "JSONP"
+            path: 'path',
+            method: 'JSONP',
+            regex: true
         },
         response: {
             status: 500,
             data: 1
         }
     };
+}
+
+function TestRuntimeMocks() {
+    mock.add([{
+        request: {
+            path: '/users',
+            method: 'GET',
+            params: {
+                name: 'Charlie'
+            }
+        },
+        response: {
+            data: {
+                name: 'Override'
+            }
+        }
+    }]);
+
+    mock.remove([{
+        request: {
+            path: '/users',
+            method: 'GET',
+            params: {
+                name: 'Charlie'
+            }
+        },
+        response: {
+            data: {
+                name: 'Override'
+            }
+        }
+    }]);
 }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url https://github.com/atecarlos/protractor-http-mock#runtime-mocks .
  - it has been reviewed by a DefinitelyTyped member.
