### PR TITLE
Support Array as Value type

### DIFF
--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -12,7 +12,7 @@ declare module "knex" {
 
   type Callback = Function;
   type Client = Function;
-  type Value = string|number|boolean|Date;
+  type Value = string|number|boolean|Date|Array<string>|Array<number>|Array<Date>|Array<boolean>;
   type ColumnName = string|Knex.Raw|Knex.QueryBuilder;
 
   interface Knex extends Knex.QueryInterface {


### PR DESCRIPTION
knex sql binding support value type, where knex.d.ts didn't support.
