### PR TITLE
core-js: add core.version

### DIFF
--- a/core-js/core-js-tests.ts
+++ b/core-js/core-js-tests.ts
@@ -500,3 +500,5 @@ s = s.unescapeHTML();
 // #############################################################################################
 
 promiseOfVoid = delay(i);
+
+console.log('core-js version number:', core.version);

--- a/core-js/core-js.d.ts
+++ b/core-js/core-js.d.ts
@@ -1266,6 +1266,8 @@ interface String {
 declare function delay(msec: number): Promise<void>;
 
 declare namespace core {
+    var version: string;
+
     namespace Reflect {
         function apply(target: Function, thisArgument: any, argumentsList: ArrayLike<any>): any;
         function construct(target: Function, argumentsList: ArrayLike<any>): any;


### PR DESCRIPTION
core-js exports a string that tells you the version number of the library

See https://github.com/zloirock/core-js/blob/v2.4.0/modules/_core.js#L1
See https://github.com/zloirock/core-js/blob/v2.4.0/library/modules/_core.js#L1
