### PR TITLE
Add ArrayBuffer to list of supported BodyInit types

### DIFF
--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -79,7 +79,7 @@ interface ResponseInit {
 }
 
 declare type HeaderInit = Headers|Array<string>;
-declare type BodyInit = Blob|FormData|string;
+declare type BodyInit = ArrayBuffer|Blob|FormData|string;
 declare type RequestInfo = Request|string;
 
 interface Window {


### PR DESCRIPTION
Addresses https://github.com/DefinitelyTyped/DefinitelyTyped/issues/9378 from `whatwg-fetch` point of view 

`BodyInit` definition of the spec: https://fetch.spec.whatwg.org/#bodyinit
