### PR TITLE
Inferrable _.assign*, _.extend*, _.defaults

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -8014,12 +8014,12 @@ namespace TestRandom {
 
 // _.assign
 namespace TestAssign {
-    interface Obj {a: string};
-    interface S1 {a: number};
-    interface S2 {b: number};
-    interface S3 {c: number};
-    interface S4 {d: number};
-    interface S5 {e: number};
+    interface Obj { a: string };
+    interface S1 { a: number };
+    interface S2 { b: number };
+    interface S3 { c: number };
+    interface S4 { d: number };
+    interface S5 { e: number };
 
     let obj: Obj;
     let s1: S1;
@@ -8037,33 +8037,33 @@ namespace TestAssign {
     }
 
     {
-        let result: {a: number};
+        let result: { a: number };
 
-        result = _.assign<Obj, S1>(obj, s1);
+        result = _.assign(obj, s1);
     }
 
     {
-        let result: {a: number, b: number};
+        let result: { a: number, b: number };
 
-        result = _.assign<Obj, S1, S2>(obj, s1, s2);
+        result = _.assign(obj, s1, s2);
     }
 
     {
-        let result: {a: number, b: number, c: number};
+        let result: { a: number, b: number, c: number };
 
-        result = _.assign<Obj, S1, S2, S3>(obj, s1, s2, s3);
+        result = _.assign(obj, s1, s2, s3);
     }
 
     {
-        let result: {a: number, b: number, c: number, d: number};
+        let result: { a: number, b: number, c: number, d: number };
 
-        result = _.assign<Obj, S1, S2, S3, S4>(obj, s1, s2, s3, s4);
+        result = _.assign(obj, s1, s2, s3, s4);
     }
 
     {
-        let result: {a: number, b: number, c: number, d: number, e: number};
+        let result: { a: number, b: number, c: number, d: number, e: number };
 
-        result = _.assign<{a: number, b: number, c: number, d: number, e: number}>(obj, s1, s2, s3, s4, s5);
+        result = _.assign<{ a: number, b: number, c: number, d: number, e: number }>(obj, s1, s2, s3, s4, s5);
     }
 
     {
@@ -8073,33 +8073,33 @@ namespace TestAssign {
     }
 
     {
-        let result: _.LoDashImplicitObjectWrapper<{a: number}>;
+        let result: _.LoDashImplicitObjectWrapper<{ a: number }>;
 
-        result = _(obj).assign<S1>(s1);
+        result = _(obj).assign(s1);
     }
 
     {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number}>;
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number }>;
 
-        result = _(obj).assign<S1, S2>(s1, s2);
+        result = _(obj).assign(s1, s2);
     }
 
     {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number}>;
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number }>;
 
-        result = _(obj).assign<S1, S2, S3>(s1, s2, s3);
+        result = _(obj).assign(s1, s2, s3);
     }
 
     {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number, d: number}>;
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
 
-        result = _(obj).assign<S1, S2, S3, S4>(s1, s2, s3, s4);
+        result = _(obj).assign(s1, s2, s3, s4);
     }
 
     {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number, d: number, e: number}>;
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
 
-        result = _(obj).assign<{a: number, b: number, c: number, d: number, e: number}>(s1, s2, s3, s4, s5);
+        result = _(obj).assign<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5);
     }
 
     {
@@ -8109,385 +8109,385 @@ namespace TestAssign {
     }
 
     {
-        let result: _.LoDashExplicitObjectWrapper<{a: number}>;
+        let result: _.LoDashExplicitObjectWrapper<{ a: number }>;
 
-        result = _(obj).chain().assign<S1>(s1);
+        result = _(obj).chain().assign(s1);
     }
 
     {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number}>;
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number }>;
 
-        result = _(obj).chain().assign<S1, S2>(s1, s2);
+        result = _(obj).chain().assign(s1, s2);
     }
 
     {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number}>;
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number }>;
 
-        result = _(obj).chain().assign<S1, S2, S3>(s1, s2, s3);
+        result = _(obj).chain().assign(s1, s2, s3);
     }
 
     {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number, d: number}>;
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
 
-        result = _(obj).chain().assign<S1, S2, S3, S4>(s1, s2, s3, s4);
+        result = _(obj).chain().assign(s1, s2, s3, s4);
     }
 
     {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number, d: number, e: number}>;
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
 
-        result = _(obj).chain().assign<{a: number, b: number, c: number, d: number, e: number}>(s1, s2, s3, s4, s5);
+        result = _(obj).chain().assign<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5);
     }
 }
 
 // _.assignWith
 namespace TestAssignWith {
-  interface Obj { a: string };
-  interface S1 { a: number };
-  interface S2 { b: number };
-  interface S3 { c: number };
-  interface S4 { d: number };
-  interface S5 { e: number };
+    interface Obj { a: string };
+    interface S1 { a: number };
+    interface S2 { b: number };
+    interface S3 { c: number };
+    interface S4 { d: number };
+    interface S5 { e: number };
 
-  let obj: Obj;
-  let s1: S1;
-  let s2: S2;
-  let s3: S3;
-  let s4: S4;
-  let s5: S5;
+    let obj: Obj;
+    let s1: S1;
+    let s2: S2;
+    let s3: S3;
+    let s4: S4;
+    let s5: S5;
 
-  let customizer: (objectValue: any, sourceValue: any, key?: string, object?: {}, source?: {}) => any;
+    let customizer: (objectValue: any, sourceValue: any, key?: string, object?: {}, source?: {}) => any;
 
-  {
-    let result: Obj;
+    {
+        let result: Obj;
 
-    result = _.assignWith<Obj>(obj);
-  }
+        result = _.assignWith(obj);
+    }
 
-  {
-    let result: { a: number };
-    result = _.assignWith<Obj, S1>(obj, s1, customizer);
-  }
+    {
+        let result: { a: number };
+        result = _.assignWith(obj, s1, customizer);
+    }
 
-  {
-    let result: { a: number, b: number };
-    result = _.assignWith<Obj, S1, S2>(obj, s1, s2, customizer);
-  }
+    {
+        let result: { a: number, b: number };
+        result = _.assignWith(obj, s1, s2, customizer);
+    }
 
-  {
-    let result: { a: number, b: number, c: number };
-    result = _.assignWith<Obj, S1, S2, S3>(obj, s1, s2, s3, customizer);
-  }
+    {
+        let result: { a: number, b: number, c: number };
+        result = _.assignWith(obj, s1, s2, s3, customizer);
+    }
 
-  {
-    let result: { a: number, b: number, c: number, d: number };
-    result = _.assignWith<Obj, S1, S2, S3, S4>(obj, s1, s2, s3, s4, customizer);
-  }
+    {
+        let result: { a: number, b: number, c: number, d: number };
+        result = _.assignWith(obj, s1, s2, s3, s4, customizer);
+    }
 
-  {
-    let result: { a: number, b: number, c: number, d: number, e: number };
-    result = _.assignWith<{ a: number, b: number, c: number, d: number, e: number }>(obj, s1, s2, s3, s4, s5, customizer);
-  }
+    {
+        let result: { a: number, b: number, c: number, d: number, e: number };
+        result = _.assignWith<{ a: number, b: number, c: number, d: number, e: number }>(obj, s1, s2, s3, s4, s5, customizer);
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<Obj>;
+    {
+        let result: _.LoDashImplicitObjectWrapper<Obj>;
 
-    result = _(obj).assignWith();
-  }
+        result = _(obj).assignWith();
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<{ a: number }>;
-    result = _(obj).assignWith<S1>(s1, customizer);
-  }
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number }>;
+        result = _(obj).assignWith(s1, customizer);
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number }>;
-    result = _(obj).assignWith<S1, S2>(s1, s2, customizer);
-  }
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number }>;
+        result = _(obj).assignWith(s1, s2, customizer);
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number }>;
-    result = _(obj).assignWith<S1, S2, S3>(s1, s2, s3, customizer);
-  }
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number }>;
+        result = _(obj).assignWith(s1, s2, s3, customizer);
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
-    result = _(obj).assignWith<S1, S2, S3, S4>(s1, s2, s3, s4, customizer);
-  }
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
+        result = _(obj).assignWith(s1, s2, s3, s4, customizer);
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
-    result = _(obj).assignWith<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5, customizer);
-  }
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
+        result = _(obj).assignWith<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5, customizer);
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<Obj>;
+    {
+        let result: _.LoDashExplicitObjectWrapper<Obj>;
 
-    result = _(obj).chain().assignWith();
-  }
+        result = _(obj).chain().assignWith();
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<{ a: number }>;
-    result = _(obj).chain().assignWith<S1>(s1, customizer);
-  }
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number }>;
+        result = _(obj).chain().assignWith(s1, customizer);
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number }>;
-    result = _(obj).chain().assignWith<S1, S2>(s1, s2, customizer);
-  }
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number }>;
+        result = _(obj).chain().assignWith(s1, s2, customizer);
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number }>;
-    result = _(obj).chain().assignWith<S1, S2, S3>(s1, s2, s3, customizer);
-  }
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number }>;
+        result = _(obj).chain().assignWith(s1, s2, s3, customizer);
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
-    result = _(obj).chain().assignWith<S1, S2, S3, S4>(s1, s2, s3, s4, customizer);
-  }
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
+        result = _(obj).chain().assignWith(s1, s2, s3, s4, customizer);
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
-    result = _(obj).chain().assignWith<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5, customizer);
-  }
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
+        result = _(obj).chain().assignWith<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5, customizer);
+    }
 }
 
 // _.assignIn
 namespace TestAssignIn {
-  interface Obj { a: string };
-  interface S1 { a: number };
-  interface S2 { b: number };
-  interface S3 { c: number };
-  interface S4 { d: number };
-  interface S5 { e: number };
+    interface Obj { a: string };
+    interface S1 { a: number };
+    interface S2 { b: number };
+    interface S3 { c: number };
+    interface S4 { d: number };
+    interface S5 { e: number };
 
-  let obj: Obj;
-  let s1: S1;
-  let s2: S2;
-  let s3: S3;
-  let s4: S4;
-  let s5: S5;
+    let obj: Obj;
+    let s1: S1;
+    let s2: S2;
+    let s3: S3;
+    let s4: S4;
+    let s5: S5;
 
-  let customizer: (objectValue: any, sourceValue: any, key?: string, object?: {}, source?: {}) => any;
+    let customizer: (objectValue: any, sourceValue: any, key?: string, object?: {}, source?: {}) => any;
 
-  {
-    let result: Obj;
+    {
+        let result: Obj;
 
-    result = _.assignIn<Obj>(obj);
-  }
+        result = _.assignIn(obj);
+    }
 
-  {
-    let result: { a: number };
+    {
+        let result: { a: number };
 
-    result = _.assignIn<Obj, S1>(obj, s1);
-  }
+        result = _.assignIn(obj, s1);
+    }
 
-  {
-    let result: { a: number, b: number };
+    {
+        let result: { a: number, b: number };
 
-    result = _.assignIn<Obj, S1, S2>(obj, s1, s2);
-  }
+        result = _.assignIn(obj, s1, s2);
+    }
 
-  {
-    let result: { a: number, b: number, c: number };
+    {
+        let result: { a: number, b: number, c: number };
 
-    result = _.assignIn<Obj, S1, S2, S3>(obj, s1, s2, s3);
-  }
+        result = _.assignIn(obj, s1, s2, s3);
+    }
 
-  {
-    let result: { a: number, b: number, c: number, d: number };
+    {
+        let result: { a: number, b: number, c: number, d: number };
 
-    result = _.assignIn<Obj, S1, S2, S3, S4>(obj, s1, s2, s3, s4);
-  }
+        result = _.assignIn(obj, s1, s2, s3, s4);
+    }
 
-  {
-    let result: { a: number, b: number, c: number, d: number, e: number };
+    {
+        let result: { a: number, b: number, c: number, d: number, e: number };
 
-    result = _.assignIn<{ a: number, b: number, c: number, d: number, e: number }>(obj, s1, s2, s3, s4, s5);
-  }
+        result = _.assignIn<{ a: number, b: number, c: number, d: number, e: number }>(obj, s1, s2, s3, s4, s5);
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<Obj>;
+    {
+        let result: _.LoDashImplicitObjectWrapper<Obj>;
 
-    result = _(obj).assignIn();
-  }
+        result = _(obj).assignIn();
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<{ a: number }>;
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number }>;
 
-    result = _(obj).assignIn<S1>(s1);
-  }
+        result = _(obj).assignIn(s1);
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number }>;
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number }>;
 
-    result = _(obj).assignIn<S1, S2>(s1, s2);
-  }
+        result = _(obj).assignIn(s1, s2);
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number }>;
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number }>;
 
-    result = _(obj).assignIn<S1, S2, S3>(s1, s2, s3);
-  }
+        result = _(obj).assignIn(s1, s2, s3);
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
 
-    result = _(obj).assignIn<S1, S2, S3, S4>(s1, s2, s3, s4);
-  }
+        result = _(obj).assignIn(s1, s2, s3, s4);
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
 
-    result = _(obj).assignIn<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5);
-  }
+        result = _(obj).assignIn<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5);
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<Obj>;
+    {
+        let result: _.LoDashExplicitObjectWrapper<Obj>;
 
-    result = _(obj).chain().assignIn();
-  }
+        result = _(obj).chain().assignIn();
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<{ a: number }>;
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number }>;
 
-    result = _(obj).chain().assignIn<S1>(s1);
-  }
+        result = _(obj).chain().assignIn(s1);
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number }>;
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number }>;
 
-    result = _(obj).chain().assignIn<S1, S2>(s1, s2);
-  }
+        result = _(obj).chain().assignIn(s1, s2);
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number }>;
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number }>;
 
-    result = _(obj).chain().assignIn<S1, S2, S3>(s1, s2, s3);
-  }
+        result = _(obj).chain().assignIn(s1, s2, s3);
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
 
-    result = _(obj).chain().assignIn<S1, S2, S3, S4>(s1, s2, s3, s4);
-  }
+        result = _(obj).chain().assignIn(s1, s2, s3, s4);
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
 
-    result = _(obj).chain().assignIn<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5);
-  }
+        result = _(obj).chain().assignIn<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5);
+    }
 }
 
 // _.assignInWith
 namespace TestAssignInWith {
-  interface Obj { a: string };
-  interface S1 { a: number };
-  interface S2 { b: number };
-  interface S3 { c: number };
-  interface S4 { d: number };
-  interface S5 { e: number };
+    interface Obj { a: string };
+    interface S1 { a: number };
+    interface S2 { b: number };
+    interface S3 { c: number };
+    interface S4 { d: number };
+    interface S5 { e: number };
 
-  let obj: Obj;
-  let s1: S1;
-  let s2: S2;
-  let s3: S3;
-  let s4: S4;
-  let s5: S5;
+    let obj: Obj;
+    let s1: S1;
+    let s2: S2;
+    let s3: S3;
+    let s4: S4;
+    let s5: S5;
 
-  let customizer: (objectValue: any, sourceValue: any, key?: string, object?: {}, source?: {}) => any;
+    let customizer: (objectValue: any, sourceValue: any, key?: string, object?: {}, source?: {}) => any;
 
-  {
-    let result: Obj;
+    {
+        let result: Obj;
 
-    result = _.assignInWith<Obj>(obj);
-  }
+        result = _.assignInWith(obj);
+    }
 
-  {
-    let result: { a: number };
-    result = _.assignInWith<Obj, S1>(obj, s1, customizer);
-  }
+    {
+        let result: { a: number };
+        result = _.assignInWith(obj, s1, customizer);
+    }
 
-  {
-    let result: { a: number, b: number };
-    result = _.assignInWith<Obj, S1, S2>(obj, s1, s2, customizer);
-  }
+    {
+        let result: { a: number, b: number };
+        result = _.assignInWith(obj, s1, s2, customizer);
+    }
 
-  {
-    let result: { a: number, b: number, c: number };
-    result = _.assignInWith<Obj, S1, S2, S3>(obj, s1, s2, s3, customizer);
-  }
+    {
+        let result: { a: number, b: number, c: number };
+        result = _.assignInWith(obj, s1, s2, s3, customizer);
+    }
 
-  {
-    let result: { a: number, b: number, c: number, d: number };
-    result = _.assignInWith<Obj, S1, S2, S3, S4>(obj, s1, s2, s3, s4, customizer);
-  }
+    {
+        let result: { a: number, b: number, c: number, d: number };
+        result = _.assignInWith(obj, s1, s2, s3, s4, customizer);
+    }
 
-  {
-    let result: { a: number, b: number, c: number, d: number, e: number };
-    result = _.assignInWith<{ a: number, b: number, c: number, d: number, e: number }>(obj, s1, s2, s3, s4, s5, customizer);
-  }
+    {
+        let result: { a: number, b: number, c: number, d: number, e: number };
+        result = _.assignInWith<{ a: number, b: number, c: number, d: number, e: number }>(obj, s1, s2, s3, s4, s5, customizer);
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<Obj>;
+    {
+        let result: _.LoDashImplicitObjectWrapper<Obj>;
 
-    result = _(obj).assignInWith();
-  }
+        result = _(obj).assignInWith();
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<{ a: number }>;
-    result = _(obj).assignInWith<S1>(s1, customizer);
-  }
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number }>;
+        result = _(obj).assignInWith(s1, customizer);
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number }>;
-    result = _(obj).assignInWith<S1, S2>(s1, s2, customizer);
-  }
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number }>;
+        result = _(obj).assignInWith(s1, s2, customizer);
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number }>;
-    result = _(obj).assignInWith<S1, S2, S3>(s1, s2, s3, customizer);
-  }
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number }>;
+        result = _(obj).assignInWith(s1, s2, s3, customizer);
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
-    result = _(obj).assignInWith<S1, S2, S3, S4>(s1, s2, s3, s4, customizer);
-  }
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
+        result = _(obj).assignInWith(s1, s2, s3, s4, customizer);
+    }
 
-  {
-    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
-    result = _(obj).assignInWith<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5, customizer);
-  }
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
+        result = _(obj).assignInWith<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5, customizer);
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<Obj>;
+    {
+        let result: _.LoDashExplicitObjectWrapper<Obj>;
 
-    result = _(obj).chain().assignInWith();
-  }
+        result = _(obj).chain().assignInWith();
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<{ a: number }>;
-    result = _(obj).chain().assignInWith<S1>(s1, customizer);
-  }
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number }>;
+        result = _(obj).chain().assignInWith(s1, customizer);
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number }>;
-    result = _(obj).chain().assignInWith<S1, S2>(s1, s2, customizer);
-  }
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number }>;
+        result = _(obj).chain().assignInWith(s1, s2, customizer);
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number }>;
-    result = _(obj).chain().assignInWith<S1, S2, S3>(s1, s2, s3, customizer);
-  }
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number }>;
+        result = _(obj).chain().assignInWith(s1, s2, s3, customizer);
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
-    result = _(obj).chain().assignInWith<S1, S2, S3, S4>(s1, s2, s3, s4, customizer);
-  }
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
+        result = _(obj).chain().assignInWith(s1, s2, s3, s4, customizer);
+    }
 
-  {
-    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
-    result = _(obj).chain().assignInWith<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5, customizer);
-  }
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
+        result = _(obj).chain().assignInWith<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5, customizer);
+    }
 }
 
 // _.create
@@ -8540,31 +8540,31 @@ namespace TestDefaults {
   {
     let result: Obj;
 
-    result = _.defaults<Obj>(obj);
+    result = _.defaults(obj);
   }
 
   {
     let result: { a: string };
 
-    result = _.defaults<Obj, S1>(obj, s1);
+    result = _.defaults(obj, s1);
   }
 
   {
     let result: { a: string, b: number };
 
-    result = _.defaults<Obj, S1, S2>(obj, s1, s2);
+    result = _.defaults(obj, s1, s2);
   }
 
   {
     let result: { a: string, b: number, c: number };
 
-    result = _.defaults<Obj, S1, S2, S3>(obj, s1, s2, s3);
+    result = _.defaults(obj, s1, s2, s3);
   }
 
   {
     let result: { a: string, b: number, c: number, d: number };
 
-    result = _.defaults<Obj, S1, S2, S3, S4>(obj, s1, s2, s3, s4);
+    result = _.defaults(obj, s1, s2, s3, s4);
   }
 
   {
@@ -8582,25 +8582,25 @@ namespace TestDefaults {
   {
     let result: _.LoDashImplicitObjectWrapper<{ a: string }>;
 
-    result = _(obj).defaults<S1>(s1);
+    result = _(obj).defaults(s1);
   }
 
   {
     let result: _.LoDashImplicitObjectWrapper<{ a: string, b: number }>;
 
-    result = _(obj).defaults<S1, S2>(s1, s2);
+    result = _(obj).defaults(s1, s2);
   }
 
   {
     let result: _.LoDashImplicitObjectWrapper<{ a: string, b: number, c: number }>;
 
-    result = _(obj).defaults<S1, S2, S3>(s1, s2, s3);
+    result = _(obj).defaults(s1, s2, s3);
   }
 
   {
     let result: _.LoDashImplicitObjectWrapper<{ a: string, b: number, c: number, d: number }>;
 
-    result = _(obj).defaults<S1, S2, S3, S4>(s1, s2, s3, s4);
+    result = _(obj).defaults(s1, s2, s3, s4);
   }
 
   {
@@ -8618,25 +8618,25 @@ namespace TestDefaults {
   {
     let result: _.LoDashExplicitObjectWrapper<{ a: string }>;
 
-    result = _(obj).chain().defaults<S1>(s1);
+    result = _(obj).chain().defaults(s1);
   }
 
   {
     let result: _.LoDashExplicitObjectWrapper<{ a: string, b: number }>;
 
-    result = _(obj).chain().defaults<S1, S2>(s1, s2);
+    result = _(obj).chain().defaults(s1, s2);
   }
 
   {
     let result: _.LoDashExplicitObjectWrapper<{ a: string, b: number, c: number }>;
 
-    result = _(obj).chain().defaults<S1, S2, S3>(s1, s2, s3);
+    result = _(obj).chain().defaults(s1, s2, s3);
   }
 
   {
     let result: _.LoDashExplicitObjectWrapper<{ a: string, b: number, c: number, d: number }>;
 
-    result = _(obj).chain().defaults<S1, S2, S3, S4>(s1, s2, s3, s4);
+    result = _(obj).chain().defaults(s1, s2, s3, s4);
   }
 
   {
@@ -8680,37 +8680,37 @@ namespace TestExtend {
     {
         let result: Obj;
 
-        result = _.extend<Obj>(obj);
+        result = _.extend(obj);
     }
 
     {
         let result: { a: number };
 
-        result = _.extend<Obj, S1>(obj, s1);
+        result = _.extend(obj, s1);
     }
 
     {
         let result: { a: number, b: number };
 
-        result = _.extend<Obj, S1, S2>(obj, s1, s2);
+        result = _.extend(obj, s1, s2);
     }
 
     {
         let result: { a: number, b: number, c: number };
 
-        result = _.extend<Obj, S1, S2, S3>(obj, s1, s2, s3);
+        result = _.extend(obj, s1, s2, s3);
     }
 
     {
         let result: { a: number, b: number, c: number, d: number };
 
-        result = _.extend<Obj, S1, S2, S3, S4>(obj, s1, s2, s3, s4);
+        result = _.extend(obj, s1, s2, s3, s4);
     }
 
     {
         let result: { a: number, b: number, c: number, d: number, e: number };
 
-        result = _.extend<Obj & S1 & S2 & S3 & S4 & S5>(obj, s1, s2, s3, s4, s5);
+        result = _.extend<{ a: number, b: number, c: number, d: number, e: number }>(obj, s1, s2, s3, s4, s5);
     }
 
     {
@@ -8722,31 +8722,31 @@ namespace TestExtend {
     {
         let result: _.LoDashImplicitObjectWrapper<{ a: number }>;
 
-        result = _(obj).extend<S1>(s1);
+        result = _(obj).extend(s1);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number }>;
 
-        result = _(obj).extend<S1, S2>(s1, s2);
+        result = _(obj).extend(s1, s2);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number }>;
 
-        result = _(obj).extend<S1, S2, S3>(s1, s2, s3);
+        result = _(obj).extend(s1, s2, s3);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
 
-        result = _(obj).extend<S1, S2, S3, S4>(s1, s2, s3, s4);
+        result = _(obj).extend(s1, s2, s3, s4);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
 
-        result = _(obj).extend<Obj & S1 & S2 & S3 & S4 & S5>(s1, s2, s3, s4, s5);
+        result = _(obj).extend<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5);
     }
 
     {
@@ -8758,31 +8758,31 @@ namespace TestExtend {
     {
         let result: _.LoDashExplicitObjectWrapper<{ a: number }>;
 
-        result = _(obj).chain().extend<S1>(s1);
+        result = _(obj).chain().extend(s1);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number }>;
 
-        result = _(obj).chain().extend<S1, S2>(s1, s2);
+        result = _(obj).chain().extend(s1, s2);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number }>;
 
-        result = _(obj).chain().extend<S1, S2, S3>(s1, s2, s3);
+        result = _(obj).chain().extend(s1, s2, s3);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
 
-        result = _(obj).chain().extend<S1, S2, S3, S4>(s1, s2, s3, s4);
+        result = _(obj).chain().extend(s1, s2, s3, s4);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
 
-        result = _(obj).chain().extend<Obj & S1 & S2 & S3 & S4 & S5>(s1, s2, s3, s4, s5);
+        result = _(obj).chain().extend<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5);
     }
 }
 
@@ -8808,37 +8808,37 @@ namespace TestExtendWith {
     {
         let result: Obj;
 
-        result = _.extendWith<Obj>(obj);
+        result = _.extendWith(obj);
     }
 
     {
         let result: { a: number };
 
-        result = _.extendWith<Obj, S1>(obj, s1, customizer);
+        result = _.extendWith(obj, s1, customizer);
     }
 
     {
         let result: { a: number, b: number };
 
-        result = _.extendWith<Obj, S1, S2>(obj, s1, s2, customizer);
+        result = _.extendWith(obj, s1, s2, customizer);
     }
 
     {
         let result: { a: number, b: number, c: number };
 
-        result = _.extendWith<Obj, S1, S2, S3>(obj, s1, s2, s3, customizer);
+        result = _.extendWith(obj, s1, s2, s3, customizer);
     }
 
     {
         let result: { a: number, b: number, c: number, d: number };
 
-        result = _.extendWith<Obj, S1, S2, S3, S4>(obj, s1, s2, s3, s4, customizer);
+        result = _.extendWith(obj, s1, s2, s3, s4, customizer);
     }
 
     {
         let result: { a: number, b: number, c: number, d: number, e: number };
 
-        result = _.extendWith<Obj & S1 & S2 & S3 & S4 & S5>(obj, s1, s2, s3, s4, s5, customizer);
+        result = _.extendWith<{ a: number, b: number, c: number, d: number, e: number }>(obj, s1, s2, s3, s4, s5, customizer);
     }
 
     {
@@ -8850,31 +8850,31 @@ namespace TestExtendWith {
     {
         let result: _.LoDashImplicitObjectWrapper<{ a: number }>;
 
-        result = _(obj).extendWith<S1>(s1, customizer);
+        result = _(obj).extendWith(s1, customizer);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number }>;
 
-        result = _(obj).extendWith<S1, S2>(s1, s2, customizer);
+        result = _(obj).extendWith(s1, s2, customizer);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number }>;
 
-        result = _(obj).extendWith<S1, S2, S3>(s1, s2, s3, customizer);
+        result = _(obj).extendWith(s1, s2, s3, customizer);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
 
-        result = _(obj).extendWith<S1, S2, S3, S4>(s1, s2, s3, s4, customizer);
+        result = _(obj).extendWith(s1, s2, s3, s4, customizer);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
 
-        result = _(obj).extendWith<Obj & S1 & S2 & S3 & S4 & S5>(s1, s2, s3, s4, s5, customizer);
+        result = _(obj).extendWith<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5, customizer);
     }
 
     {
@@ -8886,31 +8886,31 @@ namespace TestExtendWith {
     {
         let result: _.LoDashExplicitObjectWrapper<{ a: number }>;
 
-        result = _(obj).chain().extendWith<S1>(s1, customizer);
+        result = _(obj).chain().extendWith(s1, customizer);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number }>;
 
-        result = _(obj).chain().extendWith<S1, S2>(s1, s2, customizer);
+        result = _(obj).chain().extendWith(s1, s2, customizer);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number }>;
 
-        result = _(obj).chain().extendWith<S1, S2, S3>(s1, s2, s3, customizer);
+        result = _(obj).chain().extendWith(s1, s2, s3, customizer);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
 
-        result = _(obj).chain().extendWith<S1, S2, S3, S4>(s1, s2, s3, s4, customizer);
+        result = _(obj).chain().extendWith(s1, s2, s3, s4, customizer);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
 
-        result = _(obj).chain().extendWith<Obj & S1 & S2 & S3 & S4 & S5>(s1, s2, s3, s4, s5, customizer);
+        result = _(obj).chain().extendWith<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5, customizer);
     }
 }
 

--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -8033,37 +8033,37 @@ namespace TestAssign {
     {
         let result: Obj;
 
-        result = _.assign<Obj>(obj);
+        result = _.assign(obj);
     }
 
     {
         let result: {a: number};
 
-        result = _.assign<Obj, S1, {a: number}>(obj, s1);
+        result = _.assign<Obj, S1>(obj, s1);
     }
 
     {
         let result: {a: number, b: number};
 
-        result = _.assign<Obj, S1, S2, {a: number, b: number}>(obj, s1, s2);
+        result = _.assign<Obj, S1, S2>(obj, s1, s2);
     }
 
     {
         let result: {a: number, b: number, c: number};
 
-        result = _.assign<Obj, S1, S2, S3, {a: number, b: number, c: number}>(obj, s1, s2, s3);
+        result = _.assign<Obj, S1, S2, S3>(obj, s1, s2, s3);
     }
 
     {
         let result: {a: number, b: number, c: number, d: number};
 
-        result = _.assign<Obj, S1, S2, S3, S4, {a: number, b: number, c: number, d: number}>(obj, s1, s2, s3, s4);
+        result = _.assign<Obj, S1, S2, S3, S4>(obj, s1, s2, s3, s4);
     }
 
     {
         let result: {a: number, b: number, c: number, d: number, e: number};
 
-        result = _.assign<Obj, {a: number, b: number, c: number, d: number, e: number}>(obj, s1, s2, s3, s4, s5);
+        result = _.assign<{a: number, b: number, c: number, d: number, e: number}>(obj, s1, s2, s3, s4, s5);
     }
 
     {
@@ -8075,25 +8075,25 @@ namespace TestAssign {
     {
         let result: _.LoDashImplicitObjectWrapper<{a: number}>;
 
-        result = _(obj).assign<S1, {a: number}>(s1);
+        result = _(obj).assign<S1>(s1);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<{a: number, b: number}>;
 
-        result = _(obj).assign<S1, S2, {a: number, b: number}>(s1, s2);
+        result = _(obj).assign<S1, S2>(s1, s2);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number}>;
 
-        result = _(obj).assign<S1, S2, S3, {a: number, b: number, c: number}>(s1, s2, s3);
+        result = _(obj).assign<S1, S2, S3>(s1, s2, s3);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number, d: number}>;
 
-        result = _(obj).assign<S1, S2, S3, S4, {a: number, b: number, c: number, d: number}>(s1, s2, s3, s4);
+        result = _(obj).assign<S1, S2, S3, S4>(s1, s2, s3, s4);
     }
 
     {
@@ -8111,25 +8111,25 @@ namespace TestAssign {
     {
         let result: _.LoDashExplicitObjectWrapper<{a: number}>;
 
-        result = _(obj).chain().assign<S1, {a: number}>(s1);
+        result = _(obj).chain().assign<S1>(s1);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<{a: number, b: number}>;
 
-        result = _(obj).chain().assign<S1, S2, {a: number, b: number}>(s1, s2);
+        result = _(obj).chain().assign<S1, S2>(s1, s2);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number}>;
 
-        result = _(obj).chain().assign<S1, S2, S3, {a: number, b: number, c: number}>(s1, s2, s3);
+        result = _(obj).chain().assign<S1, S2, S3>(s1, s2, s3);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number, d: number}>;
 
-        result = _(obj).chain().assign<S1, S2, S3, S4, {a: number, b: number, c: number, d: number}>(s1, s2, s3, s4);
+        result = _(obj).chain().assign<S1, S2, S3, S4>(s1, s2, s3, s4);
     }
 
     {
@@ -8141,353 +8141,353 @@ namespace TestAssign {
 
 // _.assignWith
 namespace TestAssignWith {
-    interface Obj {a: string};
-    interface S1 {a: number};
-    interface S2 {b: number};
-    interface S3 {c: number};
-    interface S4 {d: number};
-    interface S5 {e: number};
+  interface Obj { a: string };
+  interface S1 { a: number };
+  interface S2 { b: number };
+  interface S3 { c: number };
+  interface S4 { d: number };
+  interface S5 { e: number };
 
-    let obj: Obj;
-    let s1: S1;
-    let s2: S2;
-    let s3: S3;
-    let s4: S4;
-    let s5: S5;
+  let obj: Obj;
+  let s1: S1;
+  let s2: S2;
+  let s3: S3;
+  let s4: S4;
+  let s5: S5;
 
-    let customizer: (objectValue: any, sourceValue: any, key?: string, object?: {}, source?: {}) => any;
+  let customizer: (objectValue: any, sourceValue: any, key?: string, object?: {}, source?: {}) => any;
 
-    {
-        let result: Obj;
+  {
+    let result: Obj;
 
-        result = _.assignWith<Obj>(obj);
-    }
+    result = _.assignWith<Obj>(obj);
+  }
 
-    {
-        let result: {a: number};
-        result = _.assignWith<Obj, S1, {a: number}>(obj, s1, customizer);
-    }
+  {
+    let result: { a: number };
+    result = _.assignWith<Obj, S1>(obj, s1, customizer);
+  }
 
-    {
-        let result: {a: number, b: number};
-        result = _.assignWith<Obj, S1, S2, {a: number, b: number}>(obj, s1, s2, customizer);
-    }
+  {
+    let result: { a: number, b: number };
+    result = _.assignWith<Obj, S1, S2>(obj, s1, s2, customizer);
+  }
 
-    {
-        let result: {a: number, b: number, c: number};
-        result = _.assignWith<Obj, S1, S2, S3, {a: number, b: number, c: number}>(obj, s1, s2, s3, customizer);
-    }
+  {
+    let result: { a: number, b: number, c: number };
+    result = _.assignWith<Obj, S1, S2, S3>(obj, s1, s2, s3, customizer);
+  }
 
-    {
-        let result: {a: number, b: number, c: number, d: number};
-        result = _.assignWith<Obj, S1, S2, S3, S4, {a: number, b: number, c: number, d: number}>(obj, s1, s2, s3, s4, customizer);
-    }
+  {
+    let result: { a: number, b: number, c: number, d: number };
+    result = _.assignWith<Obj, S1, S2, S3, S4>(obj, s1, s2, s3, s4, customizer);
+  }
 
-    {
-        let result: {a: number, b: number, c: number, d: number, e: number};
-        result = _.assignWith<Obj, {a: number, b: number, c: number, d: number, e: number}>(obj, s1, s2, s3, s4, s5, customizer);
-    }
+  {
+    let result: { a: number, b: number, c: number, d: number, e: number };
+    result = _.assignWith<{ a: number, b: number, c: number, d: number, e: number }>(obj, s1, s2, s3, s4, s5, customizer);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<Obj>;
+  {
+    let result: _.LoDashImplicitObjectWrapper<Obj>;
 
-        result = _(obj).assignWith();
-    }
+    result = _(obj).assignWith();
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: number}>;
-        result = _(obj).assignWith<S1, {a: number}>(s1, customizer);
-    }
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: number }>;
+    result = _(obj).assignWith<S1>(s1, customizer);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number}>;
-        result = _(obj).assignWith<S1, S2, {a: number, b: number}>(s1, s2, customizer);
-    }
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number }>;
+    result = _(obj).assignWith<S1, S2>(s1, s2, customizer);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number}>;
-        result = _(obj).assignWith<S1, S2, S3, {a: number, b: number, c: number}>(s1, s2, s3, customizer);
-    }
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number }>;
+    result = _(obj).assignWith<S1, S2, S3>(s1, s2, s3, customizer);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number, d: number}>;
-        result = _(obj).assignWith<S1, S2, S3, S4, {a: number, b: number, c: number, d: number}>(s1, s2, s3, s4, customizer);
-    }
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
+    result = _(obj).assignWith<S1, S2, S3, S4>(s1, s2, s3, s4, customizer);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number, d: number, e: number}>;
-        result = _(obj).assignWith<{a: number, b: number, c: number, d: number, e: number}>(s1, s2, s3, s4, s5, customizer);
-    }
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
+    result = _(obj).assignWith<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5, customizer);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<Obj>;
+  {
+    let result: _.LoDashExplicitObjectWrapper<Obj>;
 
-        result = _(obj).chain().assignWith();
-    }
+    result = _(obj).chain().assignWith();
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: number}>;
-        result = _(obj).chain().assignWith<S1, {a: number}>(s1, customizer);
-    }
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: number }>;
+    result = _(obj).chain().assignWith<S1>(s1, customizer);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number}>;
-        result = _(obj).chain().assignWith<S1, S2, {a: number, b: number}>(s1, s2, customizer);
-    }
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number }>;
+    result = _(obj).chain().assignWith<S1, S2>(s1, s2, customizer);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number}>;
-        result = _(obj).chain().assignWith<S1, S2, S3, {a: number, b: number, c: number}>(s1, s2, s3, customizer);
-    }
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number }>;
+    result = _(obj).chain().assignWith<S1, S2, S3>(s1, s2, s3, customizer);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number, d: number}>;
-        result = _(obj).chain().assignWith<S1, S2, S3, S4, {a: number, b: number, c: number, d: number}>(s1, s2, s3, s4, customizer);
-    }
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
+    result = _(obj).chain().assignWith<S1, S2, S3, S4>(s1, s2, s3, s4, customizer);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number, d: number, e: number}>;
-        result = _(obj).chain().assignWith<{a: number, b: number, c: number, d: number, e: number}>(s1, s2, s3, s4, s5, customizer);
-    }
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
+    result = _(obj).chain().assignWith<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5, customizer);
+  }
 }
 
 // _.assignIn
 namespace TestAssignIn {
-    interface Obj {a: string};
-    interface S1 {a: number};
-    interface S2 {b: number};
-    interface S3 {c: number};
-    interface S4 {d: number};
-    interface S5 {e: number};
+  interface Obj { a: string };
+  interface S1 { a: number };
+  interface S2 { b: number };
+  interface S3 { c: number };
+  interface S4 { d: number };
+  interface S5 { e: number };
 
-    let obj: Obj;
-    let s1: S1;
-    let s2: S2;
-    let s3: S3;
-    let s4: S4;
-    let s5: S5;
+  let obj: Obj;
+  let s1: S1;
+  let s2: S2;
+  let s3: S3;
+  let s4: S4;
+  let s5: S5;
 
-    let customizer: (objectValue: any, sourceValue: any, key?: string, object?: {}, source?: {}) => any;
+  let customizer: (objectValue: any, sourceValue: any, key?: string, object?: {}, source?: {}) => any;
 
-    {
-        let result: Obj;
+  {
+    let result: Obj;
 
-        result = _.assignIn<Obj>(obj);
-    }
+    result = _.assignIn<Obj>(obj);
+  }
 
-    {
-        let result: {a: number};
+  {
+    let result: { a: number };
 
-        result = _.assignIn<Obj, S1, {a: number}>(obj, s1);
-    }
+    result = _.assignIn<Obj, S1>(obj, s1);
+  }
 
-    {
-        let result: {a: number, b: number};
+  {
+    let result: { a: number, b: number };
 
-        result = _.assignIn<Obj, S1, S2, {a: number, b: number}>(obj, s1, s2);
-    }
+    result = _.assignIn<Obj, S1, S2>(obj, s1, s2);
+  }
 
-    {
-        let result: {a: number, b: number, c: number};
+  {
+    let result: { a: number, b: number, c: number };
 
-        result = _.assignIn<Obj, S1, S2, S3, {a: number, b: number, c: number}>(obj, s1, s2, s3);
-    }
+    result = _.assignIn<Obj, S1, S2, S3>(obj, s1, s2, s3);
+  }
 
-    {
-        let result: {a: number, b: number, c: number, d: number};
+  {
+    let result: { a: number, b: number, c: number, d: number };
 
-        result = _.assignIn<Obj, S1, S2, S3, S4, {a: number, b: number, c: number, d: number}>(obj, s1, s2, s3, s4);
-    }
+    result = _.assignIn<Obj, S1, S2, S3, S4>(obj, s1, s2, s3, s4);
+  }
 
-    {
-        let result: {a: number, b: number, c: number, d: number, e: number};
+  {
+    let result: { a: number, b: number, c: number, d: number, e: number };
 
-        result = _.assignIn<Obj, {a: number, b: number, c: number, d: number, e: number}>(obj, s1, s2, s3, s4, s5);
-    }
+    result = _.assignIn<{ a: number, b: number, c: number, d: number, e: number }>(obj, s1, s2, s3, s4, s5);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<Obj>;
+  {
+    let result: _.LoDashImplicitObjectWrapper<Obj>;
 
-        result = _(obj).assignIn();
-    }
+    result = _(obj).assignIn();
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: number}>;
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: number }>;
 
-        result = _(obj).assignIn<S1, {a: number}>(s1);
-    }
+    result = _(obj).assignIn<S1>(s1);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number}>;
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number }>;
 
-        result = _(obj).assignIn<S1, S2, {a: number, b: number}>(s1, s2);
-    }
+    result = _(obj).assignIn<S1, S2>(s1, s2);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number}>;
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number }>;
 
-        result = _(obj).assignIn<S1, S2, S3, {a: number, b: number, c: number}>(s1, s2, s3);
-    }
+    result = _(obj).assignIn<S1, S2, S3>(s1, s2, s3);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number, d: number}>;
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
 
-        result = _(obj).assignIn<S1, S2, S3, S4, {a: number, b: number, c: number, d: number}>(s1, s2, s3, s4);
-    }
+    result = _(obj).assignIn<S1, S2, S3, S4>(s1, s2, s3, s4);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number, d: number, e: number}>;
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
 
-        result = _(obj).assignIn<{a: number, b: number, c: number, d: number, e: number}>(s1, s2, s3, s4, s5);
-    }
+    result = _(obj).assignIn<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<Obj>;
+  {
+    let result: _.LoDashExplicitObjectWrapper<Obj>;
 
-        result = _(obj).chain().assignIn();
-    }
+    result = _(obj).chain().assignIn();
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: number}>;
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: number }>;
 
-        result = _(obj).chain().assignIn<S1, {a: number}>(s1);
-    }
+    result = _(obj).chain().assignIn<S1>(s1);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number}>;
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number }>;
 
-        result = _(obj).chain().assignIn<S1, S2, {a: number, b: number}>(s1, s2);
-    }
+    result = _(obj).chain().assignIn<S1, S2>(s1, s2);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number}>;
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number }>;
 
-        result = _(obj).chain().assignIn<S1, S2, S3, {a: number, b: number, c: number}>(s1, s2, s3);
-    }
+    result = _(obj).chain().assignIn<S1, S2, S3>(s1, s2, s3);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number, d: number}>;
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
 
-        result = _(obj).chain().assignIn<S1, S2, S3, S4, {a: number, b: number, c: number, d: number}>(s1, s2, s3, s4);
-    }
+    result = _(obj).chain().assignIn<S1, S2, S3, S4>(s1, s2, s3, s4);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number, d: number, e: number}>;
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
 
-        result = _(obj).chain().assignIn<{a: number, b: number, c: number, d: number, e: number}>(s1, s2, s3, s4, s5);
-    }
+    result = _(obj).chain().assignIn<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5);
+  }
 }
 
 // _.assignInWith
 namespace TestAssignInWith {
-    interface Obj {a: string};
-    interface S1 {a: number};
-    interface S2 {b: number};
-    interface S3 {c: number};
-    interface S4 {d: number};
-    interface S5 {e: number};
+  interface Obj { a: string };
+  interface S1 { a: number };
+  interface S2 { b: number };
+  interface S3 { c: number };
+  interface S4 { d: number };
+  interface S5 { e: number };
 
-    let obj: Obj;
-    let s1: S1;
-    let s2: S2;
-    let s3: S3;
-    let s4: S4;
-    let s5: S5;
+  let obj: Obj;
+  let s1: S1;
+  let s2: S2;
+  let s3: S3;
+  let s4: S4;
+  let s5: S5;
 
-    let customizer: (objectValue: any, sourceValue: any, key?: string, object?: {}, source?: {}) => any;
+  let customizer: (objectValue: any, sourceValue: any, key?: string, object?: {}, source?: {}) => any;
 
-    {
-        let result: Obj;
+  {
+    let result: Obj;
 
-        result = _.assignInWith<Obj>(obj);
-    }
+    result = _.assignInWith<Obj>(obj);
+  }
 
-    {
-        let result: {a: number};
-        result = _.assignInWith<Obj, S1, {a: number}>(obj, s1, customizer);
-    }
+  {
+    let result: { a: number };
+    result = _.assignInWith<Obj, S1>(obj, s1, customizer);
+  }
 
-    {
-        let result: {a: number, b: number};
-        result = _.assignInWith<Obj, S1, S2, {a: number, b: number}>(obj, s1, s2, customizer);
-    }
+  {
+    let result: { a: number, b: number };
+    result = _.assignInWith<Obj, S1, S2>(obj, s1, s2, customizer);
+  }
 
-    {
-        let result: {a: number, b: number, c: number};
-        result = _.assignInWith<Obj, S1, S2, S3, {a: number, b: number, c: number}>(obj, s1, s2, s3, customizer);
-    }
+  {
+    let result: { a: number, b: number, c: number };
+    result = _.assignInWith<Obj, S1, S2, S3>(obj, s1, s2, s3, customizer);
+  }
 
-    {
-        let result: {a: number, b: number, c: number, d: number};
-        result = _.assignInWith<Obj, S1, S2, S3, S4, {a: number, b: number, c: number, d: number}>(obj, s1, s2, s3, s4, customizer);
-    }
+  {
+    let result: { a: number, b: number, c: number, d: number };
+    result = _.assignInWith<Obj, S1, S2, S3, S4>(obj, s1, s2, s3, s4, customizer);
+  }
 
-    {
-        let result: {a: number, b: number, c: number, d: number, e: number};
-        result = _.assignInWith<Obj, {a: number, b: number, c: number, d: number, e: number}>(obj, s1, s2, s3, s4, s5, customizer);
-    }
+  {
+    let result: { a: number, b: number, c: number, d: number, e: number };
+    result = _.assignInWith<{ a: number, b: number, c: number, d: number, e: number }>(obj, s1, s2, s3, s4, s5, customizer);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<Obj>;
+  {
+    let result: _.LoDashImplicitObjectWrapper<Obj>;
 
-        result = _(obj).assignInWith();
-    }
+    result = _(obj).assignInWith();
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: number}>;
-        result = _(obj).assignInWith<S1, {a: number}>(s1, customizer);
-    }
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: number }>;
+    result = _(obj).assignInWith<S1>(s1, customizer);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number}>;
-        result = _(obj).assignInWith<S1, S2, {a: number, b: number}>(s1, s2, customizer);
-    }
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number }>;
+    result = _(obj).assignInWith<S1, S2>(s1, s2, customizer);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number}>;
-        result = _(obj).assignInWith<S1, S2, S3, {a: number, b: number, c: number}>(s1, s2, s3, customizer);
-    }
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number }>;
+    result = _(obj).assignInWith<S1, S2, S3>(s1, s2, s3, customizer);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number, d: number}>;
-        result = _(obj).assignInWith<S1, S2, S3, S4, {a: number, b: number, c: number, d: number}>(s1, s2, s3, s4, customizer);
-    }
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
+    result = _(obj).assignInWith<S1, S2, S3, S4>(s1, s2, s3, s4, customizer);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number, d: number, e: number}>;
-        result = _(obj).assignInWith<{a: number, b: number, c: number, d: number, e: number}>(s1, s2, s3, s4, s5, customizer);
-    }
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
+    result = _(obj).assignInWith<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5, customizer);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<Obj>;
+  {
+    let result: _.LoDashExplicitObjectWrapper<Obj>;
 
-        result = _(obj).chain().assignInWith();
-    }
+    result = _(obj).chain().assignInWith();
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: number}>;
-        result = _(obj).chain().assignInWith<S1, {a: number}>(s1, customizer);
-    }
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: number }>;
+    result = _(obj).chain().assignInWith<S1>(s1, customizer);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number}>;
-        result = _(obj).chain().assignInWith<S1, S2, {a: number, b: number}>(s1, s2, customizer);
-    }
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number }>;
+    result = _(obj).chain().assignInWith<S1, S2>(s1, s2, customizer);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number}>;
-        result = _(obj).chain().assignInWith<S1, S2, S3, {a: number, b: number, c: number}>(s1, s2, s3, customizer);
-    }
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number }>;
+    result = _(obj).chain().assignInWith<S1, S2, S3>(s1, s2, s3, customizer);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number, d: number}>;
-        result = _(obj).chain().assignInWith<S1, S2, S3, S4, {a: number, b: number, c: number, d: number}>(s1, s2, s3, s4, customizer);
-    }
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
+    result = _(obj).chain().assignInWith<S1, S2, S3, S4>(s1, s2, s3, s4, customizer);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number, d: number, e: number}>;
-        result = _(obj).chain().assignInWith<{a: number, b: number, c: number, d: number, e: number}>(s1, s2, s3, s4, s5, customizer);
-    }
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
+    result = _(obj).chain().assignInWith<{ a: number, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5, customizer);
+  }
 }
 
 // _.create
@@ -8520,151 +8520,153 @@ namespace TestCreate {
     }
 }
 
+
 // _.defaults
 namespace TestDefaults {
-    interface Obj {a: string};
-    interface S1 {a: number};
-    interface S2 {b: number};
-    interface S3 {c: number};
-    interface S4 {d: number};
-    interface S5 {e: number};
+  interface Obj { a: string };
+  interface S1 { a: number };
+  interface S2 { b: number };
+  interface S3 { c: number };
+  interface S4 { d: number };
+  interface S5 { e: number };
 
-    let obj: Obj;
-    let s1: S1;
-    let s2: S2;
-    let s3: S3;
-    let s4: S4;
-    let s5: S5;
+  let obj: Obj;
+  let s1: S1;
+  let s2: S2;
+  let s3: S3;
+  let s4: S4;
+  let s5: S5;
 
-    {
-        let result: Obj;
+  {
+    let result: Obj;
 
-        result = _.defaults<Obj>(obj);
-    }
+    result = _.defaults<Obj>(obj);
+  }
 
-    {
-        let result: {a: string};
+  {
+    let result: { a: string };
 
-        result = _.defaults<Obj, S1, {a: string}>(obj, s1);
-    }
+    result = _.defaults<Obj, S1>(obj, s1);
+  }
 
-    {
-        let result: {a: string, b: number};
+  {
+    let result: { a: string, b: number };
 
-        result = _.defaults<Obj, S1, S2, {a: string, b: number}>(obj, s1, s2);
-    }
+    result = _.defaults<Obj, S1, S2>(obj, s1, s2);
+  }
 
-    {
-        let result: {a: string, b: number, c: number};
+  {
+    let result: { a: string, b: number, c: number };
 
-        result = _.defaults<Obj, S1, S2, S3, {a: string, b: number, c: number}>(obj, s1, s2, s3);
-    }
+    result = _.defaults<Obj, S1, S2, S3>(obj, s1, s2, s3);
+  }
 
-    {
-        let result: {a: string, b: number, c: number, d: number};
+  {
+    let result: { a: string, b: number, c: number, d: number };
 
-        result = _.defaults<Obj, S1, S2, S3, S4, {a: string, b: number, c: number, d: number}>(obj, s1, s2, s3, s4);
-    }
+    result = _.defaults<Obj, S1, S2, S3, S4>(obj, s1, s2, s3, s4);
+  }
 
-    {
-        let result: {a: string, b: number, c: number, d: number, e: number};
+  {
+    let result: { a: string, b: number, c: number, d: number, e: number };
 
-        result = _.defaults<Obj, {a: string, b: number, c: number, d: number, e: number}>(obj, s1, s2, s3, s4, s5);
-    }
+    result = _.defaults<{ a: string, b: number, c: number, d: number, e: number }>(obj, s1, s2, s3, s4, s5);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<Obj>;
+  {
+    let result: _.LoDashImplicitObjectWrapper<Obj>;
 
-        result = _(obj).defaults();
-    }
+    result = _(obj).defaults();
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: string}>;
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: string }>;
 
-        result = _(obj).defaults<S1, {a: string}>(s1);
-    }
+    result = _(obj).defaults<S1>(s1);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: string, b: number}>;
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: string, b: number }>;
 
-        result = _(obj).defaults<S1, S2, {a: string, b: number}>(s1, s2);
-    }
+    result = _(obj).defaults<S1, S2>(s1, s2);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: string, b: number, c: number}>;
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: string, b: number, c: number }>;
 
-        result = _(obj).defaults<S1, S2, S3, {a: string, b: number, c: number}>(s1, s2, s3);
-    }
+    result = _(obj).defaults<S1, S2, S3>(s1, s2, s3);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: string, b: number, c: number, d: number}>;
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: string, b: number, c: number, d: number }>;
 
-        result = _(obj).defaults<S1, S2, S3, S4, {a: string, b: number, c: number, d: number}>(s1, s2, s3, s4);
-    }
+    result = _(obj).defaults<S1, S2, S3, S4>(s1, s2, s3, s4);
+  }
 
-    {
-        let result: _.LoDashImplicitObjectWrapper<{a: string, b: number, c: number, d: number, e: number}>;
+  {
+    let result: _.LoDashImplicitObjectWrapper<{ a: string, b: number, c: number, d: number, e: number }>;
 
-        result = _(obj).defaults<{a: string, b: number, c: number, d: number, e: number}>(s1, s2, s3, s4, s5);
-    }
+    result = _(obj).defaults<{ a: string, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<Obj>;
+  {
+    let result: _.LoDashExplicitObjectWrapper<Obj>;
 
-        result = _(obj).chain().defaults();
-    }
+    result = _(obj).chain().defaults();
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: string}>;
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: string }>;
 
-        result = _(obj).chain().defaults<S1, {a: string}>(s1);
-    }
+    result = _(obj).chain().defaults<S1>(s1);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: string, b: number}>;
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: string, b: number }>;
 
-        result = _(obj).chain().defaults<S1, S2, {a: string, b: number}>(s1, s2);
-    }
+    result = _(obj).chain().defaults<S1, S2>(s1, s2);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: string, b: number, c: number}>;
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: string, b: number, c: number }>;
 
-        result = _(obj).chain().defaults<S1, S2, S3, {a: string, b: number, c: number}>(s1, s2, s3);
-    }
+    result = _(obj).chain().defaults<S1, S2, S3>(s1, s2, s3);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: string, b: number, c: number, d: number}>;
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: string, b: number, c: number, d: number }>;
 
-        result = _(obj).chain().defaults<S1, S2, S3, S4, {a: string, b: number, c: number, d: number}>(s1, s2, s3, s4);
-    }
+    result = _(obj).chain().defaults<S1, S2, S3, S4>(s1, s2, s3, s4);
+  }
 
-    {
-        let result: _.LoDashExplicitObjectWrapper<{a: string, b: number, c: number, d: number, e: number}>;
+  {
+    let result: _.LoDashExplicitObjectWrapper<{ a: string, b: number, c: number, d: number, e: number }>;
 
-        result = _(obj).chain().defaults<{a: string, b: number, c: number, d: number, e: number}>(s1, s2, s3, s4, s5);
-    }
+    result = _(obj).chain().defaults<{ a: string, b: number, c: number, d: number, e: number }>(s1, s2, s3, s4, s5);
+  }
 }
 
 //_.defaultsDeep
 interface DefaultsDeepResult {
-    user: {
-        name: string;
-        age: number;
-    }
+  user: {
+    name: string;
+    age: number;
+  }
 }
-var TestDefaultsDeepObject = {'user': {'name': 'barney'}};
-var TestDefaultsDeepSource = {'user': {'name': 'fred', 'age': 36}};
+var TestDefaultsDeepObject = { 'user': { 'name': 'barney' } };
+var TestDefaultsDeepSource = { 'user': { 'name': 'fred', 'age': 36 } };
 result = <DefaultsDeepResult>_.defaultsDeep(TestDefaultsDeepObject, TestDefaultsDeepSource);
 result = <DefaultsDeepResult>_(TestDefaultsDeepObject).defaultsDeep<DefaultsDeepResult>(TestDefaultsDeepSource).value();
 
+
 // _.extend
 namespace TestExtend {
-    type Obj = {a: string};
-    type S1 = {a: number};
-    type S2 = {b: number};
-    type S3 = {c: number};
-    type S4 = {d: number};
-    type S5 = {e: number};
+    type Obj = { a: string };
+    type S1 = { a: number };
+    type S2 = { b: number };
+    type S3 = { c: number };
+    type S4 = { d: number };
+    type S5 = { e: number };
 
     let obj: Obj;
     let s1: S1;
@@ -8682,38 +8684,33 @@ namespace TestExtend {
     }
 
     {
-        let result: {a: number};
+        let result: { a: number };
 
-        result = _.extend<Obj, S1, Obj & S1>(obj, s1);
-        result = _.extend<Obj, S1, Obj & S1>(obj, s1, customizer);
+        result = _.extend<Obj, S1>(obj, s1);
     }
 
     {
-        let result: {a: number, b: number};
+        let result: { a: number, b: number };
 
-        result = _.extend<Obj, S1, S2, Obj & S1 & S2>(obj, s1, s2);
-        result = _.extend<Obj, S1, S2, Obj & S1 & S2>(obj, s1, s2, customizer);
+        result = _.extend<Obj, S1, S2>(obj, s1, s2);
     }
 
     {
-        let result: {a: number, b: number, c: number};
+        let result: { a: number, b: number, c: number };
 
-        result = _.extend<Obj, S1, S2, S3, Obj & S1 & S2 & S3>(obj, s1, s2, s3);
-        result = _.extend<Obj, S1, S2, S3, Obj & S1 & S2 & S3>(obj, s1, s2, s3, customizer);
+        result = _.extend<Obj, S1, S2, S3>(obj, s1, s2, s3);
     }
 
     {
-        let result: {a: number, b: number, c: number, d: number};
+        let result: { a: number, b: number, c: number, d: number };
 
-        result = _.extend<Obj, S1, S2, S3, S4, Obj & S1 & S2 & S3 & S4>(obj, s1, s2, s3, s4);
-        result = _.extend<Obj, S1, S2, S3, S4, Obj & S1 & S2 & S3 & S4>(obj, s1, s2, s3, s4, customizer);
+        result = _.extend<Obj, S1, S2, S3, S4>(obj, s1, s2, s3, s4);
     }
 
     {
-        let result: {a: number, b: number, c: number, d: number, e: number};
+        let result: { a: number, b: number, c: number, d: number, e: number };
 
-        result = _.extend<Obj, Obj & S1 & S2 & S3 & S4 & S5>(obj, s1, s2, s3, s4, s5);
-        result = _.extend<Obj, Obj & S1 & S2 & S3 & S4 & S5>(obj, s1, s2, s3, s4, s5, customizer);
+        result = _.extend<Obj & S1 & S2 & S3 & S4 & S5>(obj, s1, s2, s3, s4, s5);
     }
 
     {
@@ -8723,38 +8720,33 @@ namespace TestExtend {
     }
 
     {
-        let result: _.LoDashImplicitObjectWrapper<{a: number}>;
+        let result: _.LoDashImplicitObjectWrapper<{ a: number }>;
 
-        result = _(obj).extend<S1, Obj & S1>(s1);
-        result = _(obj).extend<S1, Obj & S1>(s1, customizer);
+        result = _(obj).extend<S1>(s1);
     }
 
     {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number}>;
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number }>;
 
-        result = _(obj).extend<S1, S2, Obj & S1 & S2>(s1, s2);
-        result = _(obj).extend<S1, S2, Obj & S1 & S2>(s1, s2, customizer);
+        result = _(obj).extend<S1, S2>(s1, s2);
     }
 
     {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number}>;
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number }>;
 
-        result = _(obj).extend<S1, S2, S3, Obj & S1 & S2 & S3>(s1, s2, s3);
-        result = _(obj).extend<S1, S2, S3, Obj & S1 & S2 & S3>(s1, s2, s3, customizer);
+        result = _(obj).extend<S1, S2, S3>(s1, s2, s3);
     }
 
     {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number, d: number}>;
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
 
-        result = _(obj).extend<S1, S2, S3, S4, Obj & S1 & S2 & S3 & S4>(s1, s2, s3, s4);
-        result = _(obj).extend<S1, S2, S3, S4, Obj & S1 & S2 & S3 & S4>(s1, s2, s3, s4, customizer);
+        result = _(obj).extend<S1, S2, S3, S4>(s1, s2, s3, s4);
     }
 
     {
-        let result: _.LoDashImplicitObjectWrapper<{a: number, b: number, c: number, d: number, e: number}>;
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
 
         result = _(obj).extend<Obj & S1 & S2 & S3 & S4 & S5>(s1, s2, s3, s4, s5);
-        result = _(obj).extend<Obj & S1 & S2 & S3 & S4 & S5>(s1, s2, s3, s4, s5, customizer);
     }
 
     {
@@ -8764,38 +8756,161 @@ namespace TestExtend {
     }
 
     {
-        let result: _.LoDashExplicitObjectWrapper<{a: number}>;
+        let result: _.LoDashExplicitObjectWrapper<{ a: number }>;
 
-        result = _(obj).chain().extend<S1, Obj & S1>(s1);
-        result = _(obj).chain().extend<S1, Obj & S1>(s1, customizer);
+        result = _(obj).chain().extend<S1>(s1);
     }
 
     {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number}>;
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number }>;
 
-        result = _(obj).chain().extend<S1, S2, Obj & S1 & S2>(s1, s2);
-        result = _(obj).chain().extend<S1, S2, Obj & S1 & S2>(s1, s2, customizer);
+        result = _(obj).chain().extend<S1, S2>(s1, s2);
     }
 
     {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number}>;
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number }>;
 
-        result = _(obj).chain().extend<S1, S2, S3, Obj & S1 & S2 & S3>(s1, s2, s3);
-        result = _(obj).chain().extend<S1, S2, S3, Obj & S1 & S2 & S3>(s1, s2, s3, customizer);
+        result = _(obj).chain().extend<S1, S2, S3>(s1, s2, s3);
     }
 
     {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number, d: number}>;
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
 
-        result = _(obj).chain().extend<S1, S2, S3, S4, Obj & S1 & S2 & S3 & S4>(s1, s2, s3, s4);
-        result = _(obj).chain().extend<S1, S2, S3, S4, Obj & S1 & S2 & S3 & S4>(s1, s2, s3, s4, customizer);
+        result = _(obj).chain().extend<S1, S2, S3, S4>(s1, s2, s3, s4);
     }
 
     {
-        let result: _.LoDashExplicitObjectWrapper<{a: number, b: number, c: number, d: number, e: number}>;
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
 
         result = _(obj).chain().extend<Obj & S1 & S2 & S3 & S4 & S5>(s1, s2, s3, s4, s5);
-        result = _(obj).chain().extend<Obj & S1 & S2 & S3 & S4 & S5>(s1, s2, s3, s4, s5, customizer);
+    }
+}
+
+
+// _.extendWith
+namespace TestExtendWith {
+    type Obj = { a: string };
+    type S1 = { a: number };
+    type S2 = { b: number };
+    type S3 = { c: number };
+    type S4 = { d: number };
+    type S5 = { e: number };
+
+    let obj: Obj;
+    let s1: S1;
+    let s2: S2;
+    let s3: S3;
+    let s4: S4;
+    let s5: S5;
+
+    let customizer: (objectValue: any, sourceValue: any, key?: string, object?: {}, source?: {}) => any;
+
+    {
+        let result: Obj;
+
+        result = _.extendWith<Obj>(obj);
+    }
+
+    {
+        let result: { a: number };
+
+        result = _.extendWith<Obj, S1>(obj, s1, customizer);
+    }
+
+    {
+        let result: { a: number, b: number };
+
+        result = _.extendWith<Obj, S1, S2>(obj, s1, s2, customizer);
+    }
+
+    {
+        let result: { a: number, b: number, c: number };
+
+        result = _.extendWith<Obj, S1, S2, S3>(obj, s1, s2, s3, customizer);
+    }
+
+    {
+        let result: { a: number, b: number, c: number, d: number };
+
+        result = _.extendWith<Obj, S1, S2, S3, S4>(obj, s1, s2, s3, s4, customizer);
+    }
+
+    {
+        let result: { a: number, b: number, c: number, d: number, e: number };
+
+        result = _.extendWith<Obj & S1 & S2 & S3 & S4 & S5>(obj, s1, s2, s3, s4, s5, customizer);
+    }
+
+    {
+        let result: _.LoDashImplicitObjectWrapper<Obj>;
+
+        result = _(obj).extendWith();
+    }
+
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number }>;
+
+        result = _(obj).extendWith<S1>(s1, customizer);
+    }
+
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number }>;
+
+        result = _(obj).extendWith<S1, S2>(s1, s2, customizer);
+    }
+
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number }>;
+
+        result = _(obj).extendWith<S1, S2, S3>(s1, s2, s3, customizer);
+    }
+
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
+
+        result = _(obj).extendWith<S1, S2, S3, S4>(s1, s2, s3, s4, customizer);
+    }
+
+    {
+        let result: _.LoDashImplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
+
+        result = _(obj).extendWith<Obj & S1 & S2 & S3 & S4 & S5>(s1, s2, s3, s4, s5, customizer);
+    }
+
+    {
+        let result: _.LoDashExplicitObjectWrapper<Obj>;
+
+        result = _(obj).chain().extendWith();
+    }
+
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number }>;
+
+        result = _(obj).chain().extendWith<S1>(s1, customizer);
+    }
+
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number }>;
+
+        result = _(obj).chain().extendWith<S1, S2>(s1, s2, customizer);
+    }
+
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number }>;
+
+        result = _(obj).chain().extendWith<S1, S2, S3>(s1, s2, s3, customizer);
+    }
+
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number }>;
+
+        result = _(obj).chain().extendWith<S1, S2, S3, S4>(s1, s2, s3, s4, customizer);
+    }
+
+    {
+        let result: _.LoDashExplicitObjectWrapper<{ a: number, b: number, c: number, d: number, e: number }>;
+
+        result = _(obj).chain().extendWith<Obj & S1 & S2 & S3 & S4 & S5>(s1, s2, s3, s4, s5, customizer);
     }
 }
 

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -13788,7 +13788,7 @@ declare module _ {
         /**
          * @see assign
          */
-        assign<TObject, TSource1, TSource2, TSource3, TSource4, TResult>(
+        assign<TObject, TSource1, TSource2, TSource3, TSource4>(
             object: TObject,
             source1: TSource1,
             source2: TSource2,
@@ -14475,6 +14475,7 @@ declare module _ {
         create<U extends Object>(properties?: U): LoDashExplicitObjectWrapper<T & U>;
     }
 
+
     //_.defaults
     interface LoDashStatic {
         /**
@@ -14491,7 +14492,7 @@ declare module _ {
         defaults<TObject, TSource>(
             object: TObject,
             source: TSource
-        ): TObject & TSource;
+        ): TSource & TObject;
 
         /**
          * @see _.defaults
@@ -14500,7 +14501,7 @@ declare module _ {
             object: TObject,
             source1: TSource1,
             source2: TSource2
-        ): TObject & TSource1 & TSource2;
+        ): TSource2 & TSource1 & TObject;
 
         /**
          * @see _.defaults
@@ -14510,7 +14511,7 @@ declare module _ {
             source1: TSource1,
             source2: TSource2,
             source3: TSource3
-        ): TObject & TSource1 & TSource2;
+        ): TSource3 & TSource2 & TSource1 & TObject;
 
         /**
          * @see _.defaults
@@ -14521,7 +14522,7 @@ declare module _ {
             source2: TSource2,
             source3: TSource3,
             source4: TSource4
-        ): TObject & TSource1 & TSource2 & TSource3 & TSource4;
+        ): TSource4 & TSource3 & TSource2 & TSource1 & TObject;
 
         /**
          * @see _.defaults
@@ -14543,7 +14544,7 @@ declare module _ {
          */
         defaults<TSource>(
             source: TSource
-        ): LoDashImplicitObjectWrapper<T & TSource>;
+        ): LoDashImplicitObjectWrapper<TSource & T>;
 
         /**
          * @see _.defaults
@@ -14551,7 +14552,7 @@ declare module _ {
         defaults<TSource1, TSource2>(
             source1: TSource1,
             source2: TSource2
-        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2>;
+        ): LoDashImplicitObjectWrapper<TSource2 & TSource1 & T>;
 
         /**
          * @see _.defaults
@@ -14560,7 +14561,7 @@ declare module _ {
             source1: TSource1,
             source2: TSource2,
             source3: TSource3
-        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3>;
+        ): LoDashImplicitObjectWrapper<TSource3 & TSource2 & TSource1 & T>;
 
         /**
          * @see _.defaults
@@ -14570,7 +14571,7 @@ declare module _ {
             source2: TSource2,
             source3: TSource3,
             source4: TSource4
-        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3 & TSource4>;
+        ): LoDashImplicitObjectWrapper<TSource4 & TSource3 & TSource2 & TSource1 & T>;
 
         /**
          * @see _.defaults
@@ -14589,7 +14590,7 @@ declare module _ {
          */
         defaults<TSource>(
             source: TSource
-        ): LoDashImplicitObjectWrapper<T & TSource>;
+        ): LoDashImplicitObjectWrapper<TSource & T>;
 
         /**
          * @see _.defaults
@@ -14597,7 +14598,7 @@ declare module _ {
         defaults<TSource1, TSource2>(
             source1: TSource1,
             source2: TSource2
-        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2>;
+        ): LoDashImplicitObjectWrapper<TSource2 & TSource1 & T>;
 
         /**
          * @see _.defaults
@@ -14606,7 +14607,7 @@ declare module _ {
             source1: TSource1,
             source2: TSource2,
             source3: TSource3
-        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3>;
+        ): LoDashImplicitObjectWrapper<TSource3 & TSource2 & TSource1 & T>;
 
         /**
          * @see _.defaults
@@ -14616,7 +14617,7 @@ declare module _ {
             source2: TSource2,
             source3: TSource3,
             source4: TSource4
-        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3 & TSource4>;
+        ): LoDashImplicitObjectWrapper<TSource4 & TSource3 & TSource2 & TSource1 & T>;
 
         /**
          * @see _.defaults

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -14488,59 +14488,52 @@ declare module _ {
          * @param sources The source objects.
          * @return The destination object.
          */
-        defaults<Obj extends {}, TResult extends {}>(
-            object: Obj,
-            ...sources: {}[]
-        ): TResult;
+        defaults<TObject, TSource>(
+            object: TObject,
+            source: TSource
+        ): TObject & TSource;
 
         /**
          * @see _.defaults
          */
-        defaults<Obj extends {}, S1 extends {}, TResult extends {}>(
-            object: Obj,
-            source1: S1,
-            ...sources: {}[]
-        ): TResult;
+        defaults<TObject, TSource1, TSource2>(
+            object: TObject,
+            source1: TSource1,
+            source2: TSource2
+        ): TObject & TSource1 & TSource2;
 
         /**
          * @see _.defaults
          */
-        defaults<Obj extends {}, S1 extends {}, S2 extends {}, TResult extends {}>(
-            object: Obj,
-            source1: S1,
-            source2: S2,
-            ...sources: {}[]
-        ): TResult;
+        defaults<TObject, TSource1, TSource2, TSource3>(
+            object: TObject,
+            source1: TSource1,
+            source2: TSource2,
+            source3: TSource3
+        ): TObject & TSource1 & TSource2;
 
         /**
          * @see _.defaults
          */
-        defaults<Obj extends {}, S1 extends {}, S2 extends {}, S3 extends {}, TResult extends {}>(
-            object: Obj,
-            source1: S1,
-            source2: S2,
-            source3: S3,
-            ...sources: {}[]
-        ): TResult;
+        defaults<TObject, TSource1, TSource2, TSource3, TSource4>(
+            object: TObject,
+            source1: TSource1,
+            source2: TSource2,
+            source3: TSource3,
+            source4: TSource4
+        ): TObject & TSource1 & TSource2 & TSource3 & TSource4;
 
         /**
          * @see _.defaults
          */
-        defaults<Obj extends {}, S1 extends {}, S2 extends {}, S3 extends {}, S4 extends {}, TResult extends {}>(
-            object: Obj,
-            source1: S1,
-            source2: S2,
-            source3: S3,
-            source4: S4,
-            ...sources: {}[]
-        ): TResult;
+        defaults<TObject>(object: TObject): TObject;
 
         /**
          * @see _.defaults
          */
-        defaults<TResult extends {}>(
-            object: {},
-            ...sources: {}[]
+        defaults<TResult>(
+            object: any,
+            ...sources: any[]
         ): TResult;
     }
 
@@ -14548,40 +14541,36 @@ declare module _ {
         /**
          * @see _.defaults
          */
-        defaults<S1 extends {}, TResult extends {}>(
-            source1: S1,
-            ...sources: {}[]
-        ): LoDashImplicitObjectWrapper<TResult>;
+        defaults<TSource>(
+            source: TSource
+        ): LoDashImplicitObjectWrapper<T & TSource>;
 
         /**
          * @see _.defaults
          */
-        defaults<S1 extends {}, S2 extends {}, TResult extends {}>(
-            source1: S1,
-            source2: S2,
-            ...sources: {}[]
-        ): LoDashImplicitObjectWrapper<TResult>;
+        defaults<TSource1, TSource2>(
+            source1: TSource1,
+            source2: TSource2
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2>;
 
         /**
          * @see _.defaults
          */
-        defaults<S1 extends {}, S2 extends {}, S3 extends {}, TResult extends {}>(
-            source1: S1,
-            source2: S2,
-            source3: S3,
-            ...sources: {}[]
-        ): LoDashImplicitObjectWrapper<TResult>;
+        defaults<TSource1, TSource2, TSource3>(
+            source1: TSource1,
+            source2: TSource2,
+            source3: TSource3
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3>;
 
         /**
          * @see _.defaults
          */
-        defaults<S1 extends {}, S2 extends {}, S3 extends {}, S4 extends {}, TResult extends {}>(
-            source1: S1,
-            source2: S2,
-            source3: S3,
-            source4: S4,
-            ...sources: {}[]
-        ): LoDashImplicitObjectWrapper<TResult>;
+        defaults<TSource1, TSource2, TSource3, TSource4>(
+            source1: TSource1,
+            source2: TSource2,
+            source3: TSource3,
+            source4: TSource4
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3 & TSource4>;
 
         /**
          * @see _.defaults
@@ -14591,47 +14580,43 @@ declare module _ {
         /**
          * @see _.defaults
          */
-        defaults<TResult>(...sources: {}[]): LoDashImplicitObjectWrapper<TResult>;
+        defaults<TResult>(...sources: any[]): LoDashImplicitObjectWrapper<TResult>;
     }
 
     interface LoDashExplicitObjectWrapper<T> {
         /**
          * @see _.defaults
          */
-        defaults<S1 extends {}, TResult extends {}>(
-            source1: S1,
-            ...sources: {}[]
-        ): LoDashExplicitObjectWrapper<TResult>;
+        defaults<TSource>(
+            source: TSource
+        ): LoDashImplicitObjectWrapper<T & TSource>;
 
         /**
          * @see _.defaults
          */
-        defaults<S1 extends {}, S2 extends {}, TResult extends {}>(
-            source1: S1,
-            source2: S2,
-            ...sources: {}[]
-        ): LoDashExplicitObjectWrapper<TResult>;
+        defaults<TSource1, TSource2>(
+            source1: TSource1,
+            source2: TSource2
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2>;
 
         /**
          * @see _.defaults
          */
-        defaults<S1 extends {}, S2 extends {}, S3 extends {}, TResult extends {}>(
-            source1: S1,
-            source2: S2,
-            source3: S3,
-            ...sources: {}[]
-        ): LoDashExplicitObjectWrapper<TResult>;
+        defaults<TSource1, TSource2, TSource3>(
+            source1: TSource1,
+            source2: TSource2,
+            source3: TSource3
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3>;
 
         /**
          * @see _.defaults
          */
-        defaults<S1 extends {}, S2 extends {}, S3 extends {}, S4 extends {}, TResult extends {}>(
-            source1: S1,
-            source2: S2,
-            source3: S3,
-            source4: S4,
-            ...sources: {}[]
-        ): LoDashExplicitObjectWrapper<TResult>;
+        defaults<TSource1, TSource2, TSource3, TSource4>(
+            source1: TSource1,
+            source2: TSource2,
+            source3: TSource3,
+            source4: TSource4
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3 & TSource4>;
 
         /**
          * @see _.defaults
@@ -14641,7 +14626,7 @@ declare module _ {
         /**
          * @see _.defaults
          */
-        defaults<TResult>(...sources: {}[]): LoDashExplicitObjectWrapper<TResult>;
+        defaults<TResult>(...sources: any[]): LoDashImplicitObjectWrapper<TResult>;
     }
 
     //_.defaultsDeep

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -14590,7 +14590,7 @@ declare module _ {
          */
         defaults<TSource>(
             source: TSource
-        ): LoDashImplicitObjectWrapper<TSource & T>;
+        ): LoDashExplicitObjectWrapper<TSource & T>;
 
         /**
          * @see _.defaults
@@ -14598,7 +14598,7 @@ declare module _ {
         defaults<TSource1, TSource2>(
             source1: TSource1,
             source2: TSource2
-        ): LoDashImplicitObjectWrapper<TSource2 & TSource1 & T>;
+        ): LoDashExplicitObjectWrapper<TSource2 & TSource1 & T>;
 
         /**
          * @see _.defaults
@@ -14607,7 +14607,7 @@ declare module _ {
             source1: TSource1,
             source2: TSource2,
             source3: TSource3
-        ): LoDashImplicitObjectWrapper<TSource3 & TSource2 & TSource1 & T>;
+        ): LoDashExplicitObjectWrapper<TSource3 & TSource2 & TSource1 & T>;
 
         /**
          * @see _.defaults
@@ -14617,7 +14617,7 @@ declare module _ {
             source2: TSource2,
             source3: TSource3,
             source4: TSource4
-        ): LoDashImplicitObjectWrapper<TSource4 & TSource3 & TSource2 & TSource1 & T>;
+        ): LoDashExplicitObjectWrapper<TSource4 & TSource3 & TSource2 & TSource1 & T>;
 
         /**
          * @see _.defaults
@@ -14627,7 +14627,7 @@ declare module _ {
         /**
          * @see _.defaults
          */
-        defaults<TResult>(...sources: any[]): LoDashImplicitObjectWrapper<TResult>;
+        defaults<TResult>(...sources: any[]): LoDashExplicitObjectWrapper<TResult>;
     }
 
     //_.defaultsDeep

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -20047,15 +20047,12 @@ declare module "lodash/extend" {
    export = extend;
 }
 
-/**
-* uncoment it if definition exists
-*/
-/*
+
 declare module "lodash/extendWith" {
    const extendWith: typeof _.extendWith;
    export = extendWith;
 }
-*/
+
 
 declare module "lodash/add" {
    const add: typeof _.add;

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -14664,163 +14664,307 @@ declare module _ {
         defaultsDeep<TResult>(...sources: any[]): LoDashImplicitObjectWrapper<TResult>
     }
 
-    //_.extend
+    // _.extend
     interface LoDashStatic {
         /**
-         * @see assign
+         * @see _.assignIn
          */
-        extend<TObject extends {}, TSource extends {}, TResult extends {}>(
+        extend<TObject, TSource>(
             object: TObject,
-            source: TSource,
-            customizer?: AssignCustomizer
-        ): TResult;
+            source: TSource
+        ): TObject & TSource;
 
         /**
-         * @see assign
+         * @see _.assignIn
          */
-        extend<TObject extends {}, TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
+        extend<TObject, TSource1, TSource2>(
+            object: TObject,
+            source1: TSource1,
+            source2: TSource2
+        ): TObject & TSource1 & TSource2;
+
+        /**
+         * @see _.assignIn
+         */
+        extend<TObject, TSource1, TSource2, TSource3>(
             object: TObject,
             source1: TSource1,
             source2: TSource2,
-            customizer?: AssignCustomizer
-        ): TResult;
+            source3: TSource3
+        ): TObject & TSource1 & TSource2 & TSource3;
 
         /**
-         * @see assign
+         * @see _.assignIn
          */
-        extend<TObject extends {}, TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TResult extends {}>(
+        extend<TObject, TSource1, TSource2, TSource3, TSource4>(
             object: TObject,
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
-            customizer?: AssignCustomizer
-        ): TResult;
+            source4: TSource4
+        ): TObject & TSource1 & TSource2 & TSource3 & TSource4;
 
         /**
-         * @see assign
+         * @see _.assignIn
          */
-        extend<TObject extends {}, TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TSource4 extends {},
-            TResult extends {}>
-            (
-                object: TObject,
-                source1: TSource1,
-                source2: TSource2,
-                source3: TSource3,
-                source4: TSource4,
-                customizer?: AssignCustomizer
-            ): TResult;
+        extend<TObject>(object: TObject): TObject;
 
         /**
-         * @see _.assign
+         * @see _.assignIn
          */
-        extend<TObject extends {}>(object: TObject): TObject;
-
-        /**
-         * @see _.assign
-         */
-        extend<TObject extends {}, TResult extends {}>(
-            object: TObject, ...otherArgs: any[]
+        extend<TResult>(
+            object: any,
+            ...otherArgs: any[]
         ): TResult;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
         /**
-         * @see _.assign
+         * @see _.assignIn
          */
-        extend<TSource extends {}, TResult extends {}>(
-            source: TSource,
-            customizer?: AssignCustomizer
-        ): LoDashImplicitObjectWrapper<TResult>;
+        extend<TSource>(
+            source: TSource
+        ): LoDashImplicitObjectWrapper<T & TSource>;
 
         /**
-         * @see assign
+         * @see _.assignIn
          */
-        extend<TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
+        extend<TSource1, TSource2>(
+            source1: TSource1,
+            source2: TSource2
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2>;
+
+        /**
+         * @see _.assignIn
+         */
+        extend<TSource1, TSource2, TSource3>(
             source1: TSource1,
             source2: TSource2,
-            customizer?: AssignCustomizer
-        ): LoDashImplicitObjectWrapper<TResult>;
+            source3: TSource3
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3>;
 
         /**
-         * @see assign
+         * @see _.assignIn
          */
-        extend<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TResult extends {}>(
-            source1: TSource1,
-            source2: TSource2,
-            source3: TSource3,
-            customizer?: AssignCustomizer
-        ): LoDashImplicitObjectWrapper<TResult>;
-
-        /**
-         * @see assign
-         */
-        extend<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TSource4 extends {}, TResult extends {}>(
+        extend<TSource1, TSource2, TSource3, TSource4>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
-            source4: TSource4,
-            customizer?: AssignCustomizer
-        ): LoDashImplicitObjectWrapper<TResult>;
+            source4: TSource4
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3 & TSource4>;
 
         /**
-         * @see _.assign
+         * @see _.assignIn
          */
         extend(): LoDashImplicitObjectWrapper<T>;
 
         /**
-         * @see _.assign
+         * @see _.assignIn
          */
-        extend<TResult extends {}>(...otherArgs: any[]): LoDashImplicitObjectWrapper<TResult>;
+        extend<TResult>(...otherArgs: any[]): LoDashImplicitObjectWrapper<TResult>;
     }
 
     interface LoDashExplicitObjectWrapper<T> {
         /**
-         * @see _.assign
+         * @see _.assignIn
          */
-        extend<TSource extends {}, TResult extends {}>(
-            source: TSource,
-            customizer?: AssignCustomizer
-        ): LoDashExplicitObjectWrapper<TResult>;
+        extend<TSource>(
+            source: TSource
+        ): LoDashExplicitObjectWrapper<T & TSource>;
 
         /**
-         * @see assign
+         * @see _.assignIn
          */
-        extend<TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
+        extend<TSource1, TSource2>(
+            source1: TSource1,
+            source2: TSource2
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2>;
+
+        /**
+         * @see _.assignIn
+         */
+        extend<TSource1, TSource2, TSource3>(
             source1: TSource1,
             source2: TSource2,
-            customizer?: AssignCustomizer
-        ): LoDashExplicitObjectWrapper<TResult>;
+            source3: TSource3
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2 & TSource3>;
 
         /**
-         * @see assign
+         * @see _.assignIn
          */
-        extend<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TResult extends {}>(
-            source1: TSource1,
-            source2: TSource2,
-            source3: TSource3,
-            customizer?: AssignCustomizer
-        ): LoDashExplicitObjectWrapper<TResult>;
-
-        /**
-         * @see assign
-         */
-        extend<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TSource4 extends {}, TResult extends {}>(
+        extend<TSource1, TSource2, TSource3, TSource4>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
-            source4: TSource4,
-            customizer?: AssignCustomizer
-        ): LoDashExplicitObjectWrapper<TResult>;
+            source4: TSource4
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2 & TSource3 & TSource4>;
 
         /**
-         * @see _.assign
+         * @see _.assignIn
          */
         extend(): LoDashExplicitObjectWrapper<T>;
 
         /**
-         * @see _.assign
+         * @see _.assignIn
          */
-        extend<TResult extends {}>(...otherArgs: any[]): LoDashExplicitObjectWrapper<TResult>;
+        extend<TResult>(...otherArgs: any[]): LoDashExplicitObjectWrapper<TResult>;
+    }
+
+    interface LoDashStatic {
+        /**
+         * @see _.assignInWith
+         */
+        extendWith<TObject, TSource>(
+            object: TObject,
+            source: TSource,
+            customizer: AssignCustomizer
+        ): TObject & TSource;
+
+        /**
+         * @see _.assignInWith
+         */
+        extendWith<TObject, TSource1, TSource2>(
+            object: TObject,
+            source1: TSource1,
+            source2: TSource2,
+            customizer: AssignCustomizer
+        ): TObject & TSource1 & TSource2;
+
+        /**
+         * @see _.assignInWith
+         */
+        extendWith<TObject, TSource1, TSource2, TSource3>(
+            object: TObject,
+            source1: TSource1,
+            source2: TSource2,
+            source3: TSource3,
+            customizer: AssignCustomizer
+        ): TObject & TSource1 & TSource2 & TSource3;
+
+        /**
+         * @see _.assignInWith
+         */
+        extendWith<TObject, TSource1, TSource2, TSource3, TSource4>(
+            object: TObject,
+            source1: TSource1,
+            source2: TSource2,
+            source3: TSource3,
+            source4: TSource4,
+            customizer: AssignCustomizer
+        ): TObject & TSource1 & TSource2 & TSource3 & TSource4;
+
+        /**
+         * @see _.assignInWith
+         */
+        extendWith<TObject>(object: TObject): TObject;
+
+        /**
+         * @see _.assignInWith
+         */
+        extendWith<TResult>(
+            object: any,
+            ...otherArgs: any[]
+        ): TResult;
+    }
+
+    interface LoDashImplicitObjectWrapper<T> {
+        /**
+         * @see _.assignInWith
+         */
+        extendWith<TSource>(
+            source: TSource,
+            customizer: AssignCustomizer
+        ): LoDashImplicitObjectWrapper<T & TSource>;
+
+        /**
+         * @see _.assignInWith
+         */
+        extendWith<TSource1, TSource2>(
+            source1: TSource1,
+            source2: TSource2,
+            customizer: AssignCustomizer
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2>;
+
+        /**
+         * @see _.assignInWith
+         */
+        extendWith<TSource1, TSource2, TSource3>(
+            source1: TSource1,
+            source2: TSource2,
+            source3: TSource3,
+            customizer: AssignCustomizer
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3>;
+
+        /**
+         * @see _.assignInWith
+         */
+        extendWith<TSource1, TSource2, TSource3, TSource4>(
+            source1: TSource1,
+            source2: TSource2,
+            source3: TSource3,
+            source4: TSource4,
+            customizer: AssignCustomizer
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3 & TSource4>;
+
+        /**
+         * @see _.assignInWith
+         */
+        extendWith(): LoDashImplicitObjectWrapper<T>;
+
+        /**
+         * @see _.assignInWith
+         */
+        extendWith<TResult>(...otherArgs: any[]): LoDashImplicitObjectWrapper<TResult>;
+    }
+
+    interface LoDashExplicitObjectWrapper<T> {
+        /**
+         * @see _.assignInWith
+         */
+        extendWith<TSource>(
+            source: TSource,
+            customizer: AssignCustomizer
+        ): LoDashExplicitObjectWrapper<T & TSource>;
+
+        /**
+         * @see _.assignInWith
+         */
+        extendWith<TSource1, TSource2>(
+            source1: TSource1,
+            source2: TSource2,
+            customizer: AssignCustomizer
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2>;
+
+        /**
+         * @see _.assignInWith
+         */
+        extendWith<TSource1, TSource2, TSource3>(
+            source1: TSource1,
+            source2: TSource2,
+            source3: TSource3,
+            customizer: AssignCustomizer
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2 & TSource3>;
+
+        /**
+         * @see _.assignInWith
+         */
+        extendWith<TSource1, TSource2, TSource3, TSource4>(
+            source1: TSource1,
+            source2: TSource2,
+            source3: TSource3,
+            source4: TSource4,
+            customizer: AssignCustomizer
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2 & TSource3 & TSource4>;
+
+        /**
+         * @see _.assignInWith
+         */
+        extendWith(): LoDashExplicitObjectWrapper<T>;
+
+        /**
+         * @see _.assignInWith
+         */
+        extendWith<TResult>(...otherArgs: any[]): LoDashExplicitObjectWrapper<TResult>;
     }
 
     //_.findKey

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -13761,53 +13761,52 @@ declare module _ {
          * _.assign({ 'a': 1 }, new Foo, new Bar);
          * // => { 'a': 1, 'c': 3, 'e': 5 }
          */
-        assign<TObject extends {}, TSource extends {}, TResult extends {}>(
+        assign<TObject, TSource>(
             object: TObject,
             source: TSource
-        ): TResult;
+        ): TObject & TSource;
 
         /**
          * @see assign
          */
-        assign<TObject extends {}, TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
+        assign<TObject, TSource1, TSource2>(
             object: TObject,
             source1: TSource1,
             source2: TSource2
-        ): TResult;
+        ): TObject & TSource1 & TSource2;
 
         /**
          * @see assign
          */
-        assign<TObject extends {}, TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TResult extends {}>(
+        assign<TObject, TSource1, TSource2, TSource3>(
             object: TObject,
             source1: TSource1,
             source2: TSource2,
             source3: TSource3
-        ): TResult;
+        ): TObject & TSource1 & TSource2 & TSource3;
 
         /**
          * @see assign
          */
-        assign<TObject extends {}, TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TSource4 extends {},
-            TResult extends {}>
-        (
+        assign<TObject, TSource1, TSource2, TSource3, TSource4, TResult>(
             object: TObject,
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             source4: TSource4
-        ): TResult;
+        ): TObject & TSource1 & TSource2 & TSource3 & TSource4;
 
         /**
          * @see _.assign
          */
-        assign<TObject extends {}>(object: TObject): TObject;
+        assign<TObject>(object: TObject): TObject;
 
         /**
          * @see _.assign
          */
-        assign<TObject extends {}, TResult extends {}>(
-            object: TObject, ...otherArgs: any[]
+        assign<TResult>(
+            object: any,
+            ...otherArgs: any[]
         ): TResult;
     }
 
@@ -13815,36 +13814,36 @@ declare module _ {
         /**
          * @see _.assign
          */
-        assign<TSource extends {}, TResult extends {}>(
+        assign<TSource>(
             source: TSource
-        ): LoDashImplicitObjectWrapper<TResult>;
+        ): LoDashImplicitObjectWrapper<T & TSource>;
 
         /**
          * @see assign
          */
-        assign<TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
+        assign<TSource1, TSource2>(
             source1: TSource1,
             source2: TSource2
-        ): LoDashImplicitObjectWrapper<TResult>;
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2>;
 
         /**
          * @see assign
          */
-        assign<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TResult extends {}>(
+        assign<TSource1, TSource2, TSource3>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3
-        ): LoDashImplicitObjectWrapper<TResult>;
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3>;
 
         /**
          * @see assign
          */
-        assign<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TSource4 extends {}, TResult extends {}>(
+        assign<TSource1, TSource2, TSource3, TSource4>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             source4: TSource4
-        ): LoDashImplicitObjectWrapper<TResult>;
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3 & TSource4>;
 
         /**
          * @see _.assign
@@ -13854,43 +13853,43 @@ declare module _ {
         /**
          * @see _.assign
          */
-        assign<TResult extends {}>(...otherArgs: any[]): LoDashImplicitObjectWrapper<TResult>;
+        assign<TResult>(...otherArgs: any[]): LoDashImplicitObjectWrapper<TResult>;
     }
 
     interface LoDashExplicitObjectWrapper<T> {
         /**
          * @see _.assign
          */
-        assign<TSource extends {}, TResult extends {}>(
+        assign<TSource>(
             source: TSource
-        ): LoDashExplicitObjectWrapper<TResult>;
+        ): LoDashExplicitObjectWrapper<T & TSource>;
 
         /**
          * @see assign
          */
-        assign<TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
+        assign<TSource1, TSource2>(
             source1: TSource1,
             source2: TSource2
-        ): LoDashExplicitObjectWrapper<TResult>;
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2>;
 
         /**
          * @see assign
          */
-        assign<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TResult extends {}>(
+        assign<TSource1, TSource2, TSource3>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3
-        ): LoDashExplicitObjectWrapper<TResult>;
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2 & TSource3>;
 
         /**
          * @see assign
          */
-        assign<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TSource4 extends {}, TResult extends {}>(
+        assign<TSource1, TSource2, TSource3, TSource4>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             source4: TSource4
-        ): LoDashExplicitObjectWrapper<TResult>;
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2 & TSource3 & TSource4>;
 
         /**
          * @see _.assign
@@ -13900,7 +13899,7 @@ declare module _ {
         /**
          * @see _.assign
          */
-        assign<TResult extends {}>(...otherArgs: any[]): LoDashExplicitObjectWrapper<TResult>;
+        assign<TResult>(...otherArgs: any[]): LoDashExplicitObjectWrapper<TResult>;
     }
 
     //_.assignWith
@@ -13935,57 +13934,56 @@ declare module _ {
          * defaults({ 'a': 1 }, { 'b': 2 }, { 'a': 3 });
          * // => { 'a': 1, 'b': 2 }
          */
-        assignWith<TObject extends {}, TSource extends {}, TResult extends {}>(
+        assignWith<TObject, TSource>(
             object: TObject,
             source: TSource,
             customizer: AssignCustomizer
-        ): TResult;
+        ): TObject & TSource;
 
         /**
          * @see assignWith
          */
-        assignWith<TObject extends {}, TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
+        assignWith<TObject, TSource1, TSource2>(
             object: TObject,
             source1: TSource1,
             source2: TSource2,
             customizer: AssignCustomizer
-        ): TResult;
+        ): TObject & TSource1 & TSource2;
 
         /**
          * @see assignWith
          */
-        assignWith<TObject extends {}, TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TResult extends {}>(
+        assignWith<TObject, TSource1, TSource2, TSource3>(
             object: TObject,
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             customizer: AssignCustomizer
-        ): TResult;
+        ): TObject & TSource1 & TSource2 & TSource3;
 
         /**
          * @see assignWith
          */
-        assignWith<TObject extends {}, TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TSource4 extends {},
-            TResult extends {}>
-        (
+        assignWith<TObject, TSource1, TSource2, TSource3, TSource4>(
             object: TObject,
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             source4: TSource4,
             customizer: AssignCustomizer
-        ): TResult;
+        ): TObject & TSource1 & TSource2 & TSource3 & TSource4;
 
         /**
          * @see _.assignWith
          */
-        assignWith<TObject extends {}>(object: TObject): TObject;
+        assignWith<TObject>(object: TObject): TObject;
 
         /**
          * @see _.assignWith
          */
-        assignWith<TObject extends {}, TResult extends {}>(
-            object: TObject, ...otherArgs: any[]
+        assignWith<TResult>(
+            object: any,
+            ...otherArgs: any[]
         ): TResult;
     }
 
@@ -13993,40 +13991,40 @@ declare module _ {
         /**
          * @see _.assignWith
          */
-        assignWith<TSource extends {}, TResult extends {}>(
+        assignWith<TSource>(
             source: TSource,
             customizer: AssignCustomizer
-        ): LoDashImplicitObjectWrapper<TResult>;
+        ): LoDashImplicitObjectWrapper<T & TSource>;
 
         /**
          * @see assignWith
          */
-        assignWith<TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
+        assignWith<TSource1, TSource2>(
             source1: TSource1,
             source2: TSource2,
             customizer: AssignCustomizer
-        ): LoDashImplicitObjectWrapper<TResult>;
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2>;
 
         /**
          * @see assignWith
          */
-        assignWith<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TResult extends {}>(
+        assignWith<TSource1, TSource2, TSource3>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             customizer: AssignCustomizer
-        ): LoDashImplicitObjectWrapper<TResult>;
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3>;
 
         /**
          * @see assignWith
          */
-        assignWith<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TSource4 extends {}, TResult extends {}>(
+        assignWith<TSource1, TSource2, TSource3, TSource4>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             source4: TSource4,
             customizer: AssignCustomizer
-        ): LoDashImplicitObjectWrapper<TResult>;
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3 & TSource4>;
 
         /**
          * @see _.assignWith
@@ -14036,47 +14034,47 @@ declare module _ {
         /**
          * @see _.assignWith
          */
-        assignWith<TResult extends {}>(...otherArgs: any[]): LoDashImplicitObjectWrapper<TResult>;
+        assignWith<TResult>(...otherArgs: any[]): LoDashImplicitObjectWrapper<TResult>;
     }
 
     interface LoDashExplicitObjectWrapper<T> {
         /**
          * @see _.assignWith
          */
-        assignWith<TSource extends {}, TResult extends {}>(
+        assignWith<TSource>(
             source: TSource,
             customizer: AssignCustomizer
-        ): LoDashExplicitObjectWrapper<TResult>;
+        ): LoDashExplicitObjectWrapper<T & TSource>;
 
         /**
          * @see assignWith
          */
-        assignWith<TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
+        assignWith<TSource1, TSource2>(
             source1: TSource1,
             source2: TSource2,
             customizer: AssignCustomizer
-        ): LoDashExplicitObjectWrapper<TResult>;
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2>;
 
         /**
          * @see assignWith
          */
-        assignWith<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TResult extends {}>(
+        assignWith<TSource1, TSource2, TSource3>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             customizer: AssignCustomizer
-        ): LoDashExplicitObjectWrapper<TResult>;
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2 & TSource3>;
 
         /**
          * @see assignWith
          */
-        assignWith<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TSource4 extends {}, TResult extends {}>(
+        assignWith<TSource1, TSource2, TSource3, TSource4>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             source4: TSource4,
             customizer: AssignCustomizer
-        ): LoDashExplicitObjectWrapper<TResult>;
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2 & TSource3 & TSource4>;
 
         /**
          * @see _.assignWith
@@ -14086,7 +14084,7 @@ declare module _ {
         /**
          * @see _.assignWith
          */
-        assignWith<TResult extends {}>(...otherArgs: any[]): LoDashExplicitObjectWrapper<TResult>;
+        assignWith<TResult>(...otherArgs: any[]): LoDashExplicitObjectWrapper<TResult>;
     }
 
     //_.assignIn
@@ -14120,53 +14118,52 @@ declare module _ {
          * _.assignIn({ 'a': 1 }, new Foo, new Bar);
          * // => { 'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5 }
          */
-        assignIn<TObject extends {}, TSource extends {}, TResult extends {}>(
+        assignIn<TObject, TSource>(
             object: TObject,
             source: TSource
-        ): TResult;
+        ): TObject & TSource;
 
         /**
          * @see assignIn
          */
-        assignIn<TObject extends {}, TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
+        assignIn<TObject, TSource1, TSource2>(
             object: TObject,
             source1: TSource1,
             source2: TSource2
-        ): TResult;
+        ): TObject & TSource1 & TSource2;
 
         /**
          * @see assignIn
          */
-        assignIn<TObject extends {}, TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TResult extends {}>(
+        assignIn<TObject, TSource1, TSource2, TSource3>(
             object: TObject,
             source1: TSource1,
             source2: TSource2,
             source3: TSource3
-        ): TResult;
+        ): TObject & TSource1 & TSource2 & TSource3;
 
         /**
          * @see assignIn
          */
-        assignIn<TObject extends {}, TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TSource4 extends {},
-            TResult extends {}>
-        (
+        assignIn<TObject, TSource1, TSource2, TSource3, TSource4>(
             object: TObject,
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             source4: TSource4
-        ): TResult;
+        ): TObject & TSource1 & TSource2 & TSource3 & TSource4;
 
         /**
          * @see _.assignIn
          */
-        assignIn<TObject extends {}>(object: TObject): TObject;
+        assignIn<TObject>(object: TObject): TObject;
 
         /**
          * @see _.assignIn
          */
-        assignIn<TObject extends {}, TResult extends {}>(
-            object: TObject, ...otherArgs: any[]
+        assignIn<TResult>(
+            object: any,
+            ...otherArgs: any[]
         ): TResult;
     }
 
@@ -14174,36 +14171,36 @@ declare module _ {
         /**
          * @see _.assignIn
          */
-        assignIn<TSource extends {}, TResult extends {}>(
+        assignIn<TSource>(
             source: TSource
-        ): LoDashImplicitObjectWrapper<TResult>;
+        ): LoDashImplicitObjectWrapper<T & TSource>;
 
         /**
          * @see assignIn
          */
-        assignIn<TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
+        assignIn<TSource1, TSource2>(
             source1: TSource1,
             source2: TSource2
-        ): LoDashImplicitObjectWrapper<TResult>;
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2>;
 
         /**
          * @see assignIn
          */
-        assignIn<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TResult extends {}>(
+        assignIn<TSource1, TSource2, TSource3>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3
-        ): LoDashImplicitObjectWrapper<TResult>;
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3>;
 
         /**
          * @see assignIn
          */
-        assignIn<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TSource4 extends {}, TResult extends {}>(
+        assignIn<TSource1, TSource2, TSource3, TSource4>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             source4: TSource4
-        ): LoDashImplicitObjectWrapper<TResult>;
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3 & TSource4>;
 
         /**
          * @see _.assignIn
@@ -14213,43 +14210,43 @@ declare module _ {
         /**
          * @see _.assignIn
          */
-        assignIn<TResult extends {}>(...otherArgs: any[]): LoDashImplicitObjectWrapper<TResult>;
+        assignIn<TResult>(...otherArgs: any[]): LoDashImplicitObjectWrapper<TResult>;
     }
 
     interface LoDashExplicitObjectWrapper<T> {
         /**
          * @see _.assignIn
          */
-        assignIn<TSource extends {}, TResult extends {}>(
+        assignIn<TSource>(
             source: TSource
-        ): LoDashExplicitObjectWrapper<TResult>;
+        ): LoDashExplicitObjectWrapper<T & TSource>;
 
         /**
          * @see assignIn
          */
-        assignIn<TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
+        assignIn<TSource1, TSource2>(
             source1: TSource1,
             source2: TSource2
-        ): LoDashExplicitObjectWrapper<TResult>;
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2>;
 
         /**
          * @see assignIn
          */
-        assignIn<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TResult extends {}>(
+        assignIn<TSource1, TSource2, TSource3>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3
-        ): LoDashExplicitObjectWrapper<TResult>;
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2 & TSource3>;
 
         /**
          * @see assignIn
          */
-        assignIn<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TSource4 extends {}, TResult extends {}>(
+        assignIn<TSource1, TSource2, TSource3, TSource4>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             source4: TSource4
-        ): LoDashExplicitObjectWrapper<TResult>;
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2 & TSource3 & TSource4>;
 
         /**
          * @see _.assignIn
@@ -14259,7 +14256,7 @@ declare module _ {
         /**
          * @see _.assignIn
          */
-        assignIn<TResult extends {}>(...otherArgs: any[]): LoDashExplicitObjectWrapper<TResult>;
+        assignIn<TResult>(...otherArgs: any[]): LoDashExplicitObjectWrapper<TResult>;
     }
 
     //_.assignInWith
@@ -14295,57 +14292,56 @@ declare module _ {
          * defaults({ 'a': 1 }, { 'b': 2 }, { 'a': 3 });
          * // => { 'a': 1, 'b': 2 }
          */
-        assignInWith<TObject extends {}, TSource extends {}, TResult extends {}>(
+        assignInWith<TObject, TSource>(
             object: TObject,
             source: TSource,
             customizer: AssignCustomizer
-        ): TResult;
+        ): TObject & TSource;
 
         /**
          * @see assignInWith
          */
-        assignInWith<TObject extends {}, TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
+        assignInWith<TObject, TSource1, TSource2>(
             object: TObject,
             source1: TSource1,
             source2: TSource2,
             customizer: AssignCustomizer
-        ): TResult;
+        ): TObject & TSource1 & TSource2;
 
         /**
          * @see assignInWith
          */
-        assignInWith<TObject extends {}, TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TResult extends {}>(
+        assignInWith<TObject, TSource1, TSource2, TSource3>(
             object: TObject,
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             customizer: AssignCustomizer
-        ): TResult;
+        ): TObject & TSource1 & TSource2 & TSource3;
 
         /**
          * @see assignInWith
          */
-        assignInWith<TObject extends {}, TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TSource4 extends {},
-            TResult extends {}>
-        (
+        assignInWith<TObject, TSource1, TSource2, TSource3, TSource4>(
             object: TObject,
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             source4: TSource4,
             customizer: AssignCustomizer
-        ): TResult;
+        ): TObject & TSource1 & TSource2 & TSource3 & TSource4;
 
         /**
          * @see _.assignInWith
          */
-        assignInWith<TObject extends {}>(object: TObject): TObject;
+        assignInWith<TObject>(object: TObject): TObject;
 
         /**
          * @see _.assignInWith
          */
-        assignInWith<TObject extends {}, TResult extends {}>(
-            object: TObject, ...otherArgs: any[]
+        assignInWith<TResult>(
+            object: any,
+            ...otherArgs: any[]
         ): TResult;
     }
 
@@ -14353,40 +14349,40 @@ declare module _ {
         /**
          * @see _.assignInWith
          */
-        assignInWith<TSource extends {}, TResult extends {}>(
+        assignInWith<TSource>(
             source: TSource,
             customizer: AssignCustomizer
-        ): LoDashImplicitObjectWrapper<TResult>;
+        ): LoDashImplicitObjectWrapper<T & TSource>;
 
         /**
          * @see assignInWith
          */
-        assignInWith<TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
+        assignInWith<TSource1, TSource2>(
             source1: TSource1,
             source2: TSource2,
             customizer: AssignCustomizer
-        ): LoDashImplicitObjectWrapper<TResult>;
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2>;
 
         /**
          * @see assignInWith
          */
-        assignInWith<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TResult extends {}>(
+        assignInWith<TSource1, TSource2, TSource3>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             customizer: AssignCustomizer
-        ): LoDashImplicitObjectWrapper<TResult>;
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3>;
 
         /**
          * @see assignInWith
          */
-        assignInWith<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TSource4 extends {}, TResult extends {}>(
+        assignInWith<TSource1, TSource2, TSource3, TSource4>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             source4: TSource4,
             customizer: AssignCustomizer
-        ): LoDashImplicitObjectWrapper<TResult>;
+        ): LoDashImplicitObjectWrapper<T & TSource1 & TSource2 & TSource3 & TSource4>;
 
         /**
          * @see _.assignInWith
@@ -14396,47 +14392,47 @@ declare module _ {
         /**
          * @see _.assignInWith
          */
-        assignInWith<TResult extends {}>(...otherArgs: any[]): LoDashImplicitObjectWrapper<TResult>;
+        assignInWith<TResult>(...otherArgs: any[]): LoDashImplicitObjectWrapper<TResult>;
     }
 
     interface LoDashExplicitObjectWrapper<T> {
         /**
          * @see _.assignInWith
          */
-        assignInWith<TSource extends {}, TResult extends {}>(
+        assignInWith<TSource>(
             source: TSource,
             customizer: AssignCustomizer
-        ): LoDashExplicitObjectWrapper<TResult>;
+        ): LoDashExplicitObjectWrapper<T & TSource>;
 
         /**
          * @see assignInWith
          */
-        assignInWith<TSource1 extends {}, TSource2 extends {}, TResult extends {}>(
+        assignInWith<TSource1, TSource2>(
             source1: TSource1,
             source2: TSource2,
             customizer: AssignCustomizer
-        ): LoDashExplicitObjectWrapper<TResult>;
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2>;
 
         /**
          * @see assignInWith
          */
-        assignInWith<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TResult extends {}>(
+        assignInWith<TSource1, TSource2, TSource3>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             customizer: AssignCustomizer
-        ): LoDashExplicitObjectWrapper<TResult>;
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2 & TSource3>;
 
         /**
          * @see assignInWith
          */
-        assignInWith<TSource1 extends {}, TSource2 extends {}, TSource3 extends {}, TSource4 extends {}, TResult extends {}>(
+        assignInWith<TSource1, TSource2, TSource3, TSource4>(
             source1: TSource1,
             source2: TSource2,
             source3: TSource3,
             source4: TSource4,
             customizer: AssignCustomizer
-        ): LoDashExplicitObjectWrapper<TResult>;
+        ): LoDashExplicitObjectWrapper<T & TSource1 & TSource2 & TSource3 & TSource4>;
 
         /**
          * @see _.assignInWith
@@ -14446,7 +14442,7 @@ declare module _ {
         /**
          * @see _.assignInWith
          */
-        assignInWith<TResult extends {}>(...otherArgs: any[]): LoDashExplicitObjectWrapper<TResult>;
+        assignInWith<TResult>(...otherArgs: any[]): LoDashExplicitObjectWrapper<TResult>;
     }
 
     //_.create


### PR DESCRIPTION
Following the pattern that 4e4ffc7e used for `_.merge`, redefine `_.assign*`, `_.extend*` and `_.defaults` to use intersection types. This means that almost all normal usages are able to infer much more informative types than just `{}`.

A few random notes about these changes: 
- Split tests for `_.extend` into a suite just for `_.extendWith`.
- I wasn't able to find a clever method for aliasing `extend` as `assignIn` without just copy-pasting it it (I tried playing around with `typeof`, etc).
- `_.defaults`'s return types' ordering is backwards from that in the parameter list because it appears that Typescript uses "latest wins" to resolve an intersection of types that define the same field name. Doing it backwards ensures that earlier parameters, which are later in the type expression, take precedence.
- Uncommented the `lodash/extendWith` module export since it exists now.
