### PR TITLE
React-GA typing files

### DIFF
--- a/react-ga/react-ga-tests.tsx
+++ b/react-ga/react-ga-tests.tsx
@@ -1,0 +1,53 @@
+/// <reference path="react-ga.d.ts" />
+/// <reference path="../jasmine/jasmine.d.ts" />
+
+describe("Testing react-ga initialize object", () => {
+    it("Able to initialize react-ga object", () => {
+        let ga = __reactGA;
+        ga.initialize("UA-65432-1");
+    });
+    it("Able to initailize react-ga object", () => {
+        let ga = __reactGA;
+        
+        let options: __reactGA.InitializeOptions = {
+            debug: true,
+        }
+        
+        ga.initialize("UA-65432-1", options);
+    });
+});
+
+describe("Testing react-ga pageview calls", () => {
+    it("Able to make pageview calls", () => {
+        let ga = __reactGA;
+        ga.initialize("UA-65432-1");
+        
+        ga.pageview("http://telshin.com");
+    });
+});
+
+describe("Testing react-ga modal calls", () => {
+    it("Able to make modal calls", () => {
+        let ga = __reactGA;
+        ga.initialize("UA-65432-1");
+        
+        ga.modalview("Test modal");
+    });
+});
+
+describe("Testing react-ga event calls", () => {
+    it("Able to make event calls", () => {
+        let ga = __reactGA;
+        ga.initialize("UA-65432-1");
+        
+        let options: __reactGA.EventArgs = {
+            category: "Test",
+            action: "CI",
+            label: "Running Jasmine tests for react-ga typscript library",
+            value: 4,
+            nonInteraction: true,
+        }
+        
+        ga.event(options);
+    });
+});

--- a/react-ga/react-ga.d.ts
+++ b/react-ga/react-ga.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for react-fa v1.4.1
+// Project: https://github.com/react-ga/react-ga
+// Definitions by: Tim Aldridge <https://github.com/telshin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace __reactGA {
+    export interface EventArgs {
+        category: string;
+        action: string;
+        label?: string;
+        value?: number;
+        nonInteraction?: boolean;
+    }
+
+    export interface InitializeOptions {
+        debug?: boolean;
+    }
+
+    export function initialize(trackingCode: string, options?: InitializeOptions): void;
+    export function pageview(path: string): void;
+    export function modalview(name: string): void;
+    export function event(args: EventArgs): void;
+}
+
+declare module 'react-ga' {
+    export = __reactGA;
+}


### PR DESCRIPTION
Added typing file for react-ga: https://github.com/react-ga/react-ga

case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- https://www.npmjs.com/package/react-ga -> react-ga
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
