### PR TITLE
Fix `LoaderHandler.add` signature.

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -1928,9 +1928,9 @@ declare namespace THREE {
     }
 
     export interface LoaderHandler{
-        handlers: any[];
+        handlers: (RegExp | Loader)[];
 
-        add(regex: string, loader: Loader): void;
+        add(regex: RegExp, loader: Loader): void;
         get(file: string): Loader;
     }
 


### PR DESCRIPTION
Also specify `LoaderHandler.handlers` element type.

See [Loader.js](https://github.com/mrdoob/three.js/blob/master/src/loaders/Loader.js) (search for `THREE.Loader.Handlers =`).
