### PR TITLE
backbone.radio: add module definition

### DIFF
--- a/backbone.radio/backbone.radio-tests.ts
+++ b/backbone.radio/backbone.radio-tests.ts
@@ -102,3 +102,9 @@ function TestGlobalApiAndChannels() {
     Backbone.Radio.reply('auth', 'authenticate', onStart);
     Backbone.Radio.request('auth', 'authenticate', 'pelle', 42);
 }
+
+import Radio = require('backbone.radio');
+function TestImport() {
+    var channel: Backbone.Radio.Channel = Radio.channel('channel-name');
+    channel.command('show:view');
+}

--- a/backbone.radio/backbone.radio.d.ts
+++ b/backbone.radio/backbone.radio.d.ts
@@ -90,3 +90,9 @@ declare namespace Backbone {
         }
     }
 }
+
+declare module 'backbone.radio' {
+    import Backbone = require('backbone');
+
+    export = Backbone.Radio;
+}


### PR DESCRIPTION
This exports the `backbone.radio` module definition, which is used when Backbone.Radio is packaged using browserify.

Documentation for the `backbone.radio` npm package name: https://github.com/marionettejs/backbone.radio#installation

The new code follows the structure in the marionette type definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/marionette/marionette.d.ts#L1508

Please let me know if I can do anything else to get this merged!

Thank you very much for maintaining all these definitions! ❤️ 
