### PR TITLE
Allow ES6 import syntax for wolfy87-eventemitter.d.ts

### DIFF
--- a/redux-bootstrap/redux-bootstrap.d.ts
+++ b/redux-bootstrap/redux-bootstrap.d.ts
@@ -9,7 +9,7 @@
 
 declare module "redux-bootstrap" {
 
-    interface BoostrapOptions {
+    interface BootstrapOptions {
         routes: JSX.Element;
         reducers: ReducersOption;
         middlewares?: Redux.Middleware[];
@@ -27,5 +27,5 @@ declare module "redux-bootstrap" {
         [index: string]: Redux.Reducer;
     }
 
-    export default function bootstrap(options: BoostrapOptions): BootstrapResult;
+    export default function bootstrap(options: BootstrapOptions): BootstrapResult;
 }

--- a/wolfy87-eventemitter/wolfy87-eventemitter-tests.ts
+++ b/wolfy87-eventemitter/wolfy87-eventemitter-tests.ts
@@ -1,6 +1,6 @@
-///<reference path="wolfy87-eventemitter.d.ts"/>
+/// <reference path="./wolfy87-eventemitter.d.ts" />
 
-import EventEmitter = require("wolfy87-eventemitter");
+import * as EventEmitter from 'wolfy87-eventemitter';
 
 var emitter = new EventEmitter();
 
@@ -108,4 +108,3 @@ function testNoConflict() {
     var NoConflictEventEmitter = EventEmitter.noConflict();
     var e: Wolfy87EventEmitter.EventEmitter = new NoConflictEventEmitter();
 }
-

--- a/wolfy87-eventemitter/wolfy87-eventemitter.d.ts
+++ b/wolfy87-eventemitter/wolfy87-eventemitter.d.ts
@@ -9,7 +9,7 @@ declare namespace Wolfy87EventEmitter {
      * Hash Object for manipulating multiple events.
      */
     interface MultipleEvents {
-        [event:string]: any //Function | Function[]
+        [event: string]: any //Function | Function[]
     }
 
     /**
@@ -506,6 +506,7 @@ declare namespace Wolfy87EventEmitter {
 
 declare module "wolfy87-eventemitter" {
     class EventEmitter extends Wolfy87EventEmitter.EventEmitter {}
+    namespace EventEmitter {}
     export = EventEmitter;
 }
 


### PR DESCRIPTION
See Microsoft/TypeScript#5073 and #6697

(First commit is not related, just a rename from `Boostrap` to `Bootstrap`: a common naming mistake)
