### PR TITLE
Added interface for Angular Material Prompt Dialog added in 1.1.0-rc1…

### DIFF
--- a/angular-material/angular-material-tests.ts
+++ b/angular-material/angular-material-tests.ts
@@ -55,6 +55,18 @@ myApp.controller('DialogController', ($scope: ng.IScope, $mdDialog: ng.material.
     $scope['confirmDialog'] = () => {
         $mdDialog.show($mdDialog.confirm().htmlContent('<span>Confirm!</span>'));
     };
+    $scope['promptDialog'] = () => {
+        $mdDialog.show($mdDialog.prompt().textContent('Prompt!'));
+    };
+    $scope['promptDialog'] = () => {
+        $mdDialog.show($mdDialog.prompt().htmlContent('<span>Prompt!</span>'));
+    };
+    $scope['promptDialog'] = () => {
+        $mdDialog.show($mdDialog.prompt().cancel('Prompt "Cancel" button text'));
+    };
+    $scope['promptDialog'] = () => {
+        $mdDialog.show($mdDialog.prompt().placeholder('Prompt input placeholder text'));
+    };
     $scope['hideDialog'] = $mdDialog.hide.bind($mdDialog, 'hide');
     $scope['cancelDialog'] = $mdDialog.cancel.bind($mdDialog, 'cancel');
 });

--- a/angular-material/angular-material.d.ts
+++ b/angular-material/angular-material.d.ts
@@ -59,6 +59,11 @@ declare namespace angular.material {
     interface IConfirmDialog extends IPresetDialog<IConfirmDialog> {
         cancel(cancel: string): IConfirmDialog;
     }
+    
+    interface IPromptDialog extends IPresetDialog<IPromptDialog> {
+        cancel(cancel: string): IPromptDialog;
+        placeholder(placeholder: string): IPromptDialog;        
+    }
 
     interface IDialogOptions {
         templateUrl?: string;
@@ -90,6 +95,7 @@ declare namespace angular.material {
         show(dialog: IDialogOptions|IAlertDialog|IConfirmDialog): angular.IPromise<any>;
         confirm(): IConfirmDialog;
         alert(): IAlertDialog;
+        prompt(): IPromptDialog;
         hide(response?: any): angular.IPromise<any>;
         cancel(response?: any): void;
     }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- Added interface for Angular Material Prompt Dialog added in [1.1.0-rc1 (2016-03-09)](https://github.com/angular/material/blob/master/CHANGELOG.md#110-rc1-2016-03-09) - [source](https://github.com/angular/material/blob/master/src/components/dialog/dialog.js#L374).Extends IPresetDialog<T> and includes cancel(cancel: string) and placeholder(placeholder: string) methods. Added typings tests for these methods.

Thanks!
