### PR TITLE
Added onFocus prop

### DIFF
--- a/react-input-calendar/react-input-calendar.d.ts
+++ b/react-input-calendar/react-input-calendar.d.ts
@@ -50,6 +50,10 @@ declare namespace reactInputCalendar {
         */
         onBlur?: (event: __React.SyntheticEvent, computableDate: string) => void;
         /**
+        * Set a function that will be triggered when the input field is focused.
+        */
+        onFocus?: (event: __React.SyntheticEvent) => void;
+        /**
         * Define state when date picker would close once the user has clicked on a date.
         */
         closeOnSelect?: boolean;


### PR DESCRIPTION
Improved typing to comply to latest version 0.3.7 of react-input-calendar.

onFocus prop [was added](https://github.com/Rudeg/react-input-calendar/commit/98c6bbfc97adecaf49d76e713425fb3fc3e9f6c1) in [version 0.3.7](https://github.com/Rudeg/react-input-calendar#propsonfocus)
