### PR TITLE
Handle mutating promise return types in PDF.js.

### DIFF
--- a/pdf/pdf-tests.ts
+++ b/pdf/pdf-tests.ts
@@ -43,3 +43,10 @@ function goNext() {
         renderPage(pageNum);
     }
 }
+
+//
+// Test PDFPromise allows return value mutation
+//
+var promise: PDFPromise<string> = PDFJS.getDocument('helloworld.pdf').then(pdf => {
+	return "arbitrary string";
+});

--- a/pdf/pdf.d.ts
+++ b/pdf/pdf.d.ts
@@ -32,7 +32,7 @@ interface PDFPromise<T> {
 	isRejected(): boolean;
 	resolve(value: T): void;
 	reject(reason: string): void;
-	then(onResolve: (promise: T) => void, onReject?: (reason: string) => void): PDFPromise<T>;
+	then<U>(onResolve: (promise: T) => U, onReject?: (reason: string) => void): PDFPromise<U>;
 }
 
 interface PDFTreeNode {


### PR DESCRIPTION
The definition for the promise object returned in PDF.js does not handle return type changes. This pull request fixes that. The promise object returned by PDF.js does support this, see https://github.com/mozilla/pdf.js/blob/9c95d089dea692f2ab4cd4c8b188555d2550b27f/src/shared/util.js#L1120-L1129
