### PR TITLE
Fix `NodeBuffer.fill` definition

### DIFF
--- a/node/node-0.11-tests.ts
+++ b/node/node-0.11-tests.ts
@@ -24,7 +24,8 @@ assert.notStrictEqual(2, "2", "uses === comparator");
 assert.throws(() => { throw "a hammer at your face"; }, undefined, "DODGED IT");
 
 assert.doesNotThrow(() => {
-    if (false) { throw "a hammer at your face"; }
+    const b = false;
+    if (b) { throw "a hammer at your face"; }
 }, undefined, "What the...*crunch*");
 
 ////////////////////////////////////////////////////

--- a/node/node-0.12-tests.ts
+++ b/node/node-0.12-tests.ts
@@ -26,7 +26,8 @@ assert.notStrictEqual(2, "2", "uses === comparator");
 assert.throws(() => { throw "a hammer at your face"; }, undefined, "DODGED IT");
 
 assert.doesNotThrow(() => {
-    if (false) { throw "a hammer at your face"; }
+    const b = false;
+    if (b) { throw "a hammer at your face"; }
 }, undefined, "What the...*crunch*");
 
 ////////////////////////////////////////////////////

--- a/node/node-4.d.ts
+++ b/node/node-4.d.ts
@@ -465,7 +465,7 @@ interface NodeBuffer extends Uint8Array {
     writeFloatBE(value: number, offset: number, noAssert?: boolean): number;
     writeDoubleLE(value: number, offset: number, noAssert?: boolean): number;
     writeDoubleBE(value: number, offset: number, noAssert?: boolean): number;
-    fill(value: any, offset?: number, end?: number): Buffer;
+    fill(value: any, offset?: number, end?: number): this;
     // TODO: encoding param
     indexOf(value: string | number | Buffer, byteOffset?: number): number;
     // TODO: entries

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -465,7 +465,7 @@ interface NodeBuffer extends Uint8Array {
     writeFloatBE(value: number, offset: number, noAssert?: boolean): number;
     writeDoubleLE(value: number, offset: number, noAssert?: boolean): number;
     writeDoubleBE(value: number, offset: number, noAssert?: boolean): number;
-    fill(value: any, offset?: number, end?: number): Buffer;
+    fill(value: any, offset?: number, end?: number): this;
     // TODO: encoding param
     indexOf(value: string | number | Buffer, byteOffset?: number): number;
     // TODO: entries


### PR DESCRIPTION
With change Microsoft/TypeScript#8515, `Uint8Array.fill` method now returns `this`.
Fixing definition of `NodeBuffer` to maintain extends relationship with `Uint8Array`
