### PR TITLE
fix angular-material import as module

### DIFF
--- a/angular-material/angular-material.d.ts
+++ b/angular-material/angular-material.d.ts
@@ -4,6 +4,12 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../angularjs/angular.d.ts" />
+
+declare module 'angular-material' {
+    var _: string;
+    export = _;
+}
+
 declare namespace angular.material {
 
     interface IBottomSheetOptions {


### PR DESCRIPTION
case 2. Improvement to existing type definition.

import \* as ngMaterial from 'angular-material';
gave me the following error:
[TypeScript error: xxx.ts(xx,xx): Error TS2307: Cannot find module 'angular-material'.]

The previous version declared only a namespace, my change adds the module declaration.
