### PR TITLE
The click event handler for the title action of Infobox entities need…

### DIFF
--- a/bingmaps/Microsoft.Maps.d.ts
+++ b/bingmaps/Microsoft.Maps.d.ts
@@ -301,7 +301,7 @@ declare namespace Microsoft.Maps {
         getShowPointer(): boolean;
         getTitle(): string;
         getTitleAction(): any;
-        getTitleClickHandler(): () => void;
+        getTitleClickHandler(): (mouseEvent?: MouseEvent) => void;
         getVisible(): boolean;
         getWidth(): number;
         getZIndex(): number;
@@ -329,8 +329,8 @@ declare namespace Microsoft.Maps {
         showPointer?: boolean;
         pushpin?: Pushpin;
         title?: string;
-        titleAction?: { label?: string; eventHandler: () => void; };
-        titleClickHandler?: () => void;
+        titleAction?: { label?: string; eventHandler: (mouseEvent?: MouseEvent) => void; };
+        titleClickHandler?: (mouseEvent?: MouseEvent) => void;
         typeName?: InfoboxType;
         visible?: boolean;
         width?: number;


### PR DESCRIPTION
Because the Infobox title click handler is attached to an anchor tag with a hash as its destination (&lt;a href="#"&gt;), the hash can cause problems in frameworks like Angular when used in conjunction with a &lt;base href="/"&gt; tag.  To get around this, the MouseEvent object needs to be available inside the event handler so that we can call the "preventDefault()" method to prevent navigation to "{baseHref}/#".
