### PR TITLE
PreloadJS.AbstractLoader » made GET and POST variables static (#6140)

### DIFF
--- a/preloadjs/preloadjs.d.ts
+++ b/preloadjs/preloadjs.d.ts
@@ -20,14 +20,14 @@ declare namespace createjs {
         static BINARY: string;
         canceled: boolean;
         static CSS: string;
-        GET: string;
+        static GET: string;
         static IMAGE: string;
         static JAVASCRIPT: string;
         static JSON: string;
         static JSONP: string;
         loaded: boolean;
         static MANIFEST: string;
-        POST: string;
+        static POST: string;
         progress: number;
         resultFormatter: () => any;
         static SOUND: string;


### PR DESCRIPTION
Updated AbstractLoader's definition so the `POST` and `GET` variables are static.
See http://www.createjs.com/docs/preloadjs/classes/AbstractLoader.html for docs.

Resolves https://github.com/DefinitelyTyped/DefinitelyTyped/issues/6140
