### PR TITLE
Fixed Joi attempt return type

### DIFF
--- a/joi/joi.d.ts
+++ b/joi/joi.d.ts
@@ -844,7 +844,7 @@ declare module 'joi' {
 	 * @param schema - the schema object.
 	 * @param message - optional message string prefix added in front of the error message. may also be an Error object.
 	 */
-	export function attempt(value: any, schema: Schema, message?: string | Error): void;
+	export function attempt<T>(value: T, schema: Schema, message?: string | Error): T;
 
 
 	/**


### PR DESCRIPTION
The Joi attempt function should not have a void return type as it returns the passed value if validation succeeds, as documented at https://github.com/hapijs/joi/blob/v9.0.0-2/API.md#attemptvalue-schema-message
