### PR TITLE
Added to Set definition the property '_es6-shim iterator_'.

### DIFF
--- a/es6-shim/es6-shim.d.ts
+++ b/es6-shim/es6-shim.d.ts
@@ -582,6 +582,7 @@ interface Set<T> {
     entries(): IterableIteratorShim<[T, T]>;
     keys(): IterableIteratorShim<T>;
     values(): IterableIteratorShim<T>;
+    '_es6-shim iterator_'(): IterableIteratorShim<T>;
 }
 
 interface SetConstructor {


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
