### PR TITLE
async.d.ts AsyncForEachOfIterator key type fix

### DIFF
--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -12,7 +12,7 @@ interface AsyncResultObjectCallback<T> { (err: Error, results: Dictionary<T>): v
 
 interface AsyncFunction<T> { (callback: (err?: Error, result?: T) => void): void; }
 interface AsyncIterator<T> { (item: T, callback: ErrorCallback): void; }
-interface AsyncForEachOfIterator<T> { (item: T, key: number, callback: ErrorCallback): void; }
+interface AsyncForEachOfIterator<T> { (item: T, key: number|string, callback: ErrorCallback): void; }
 interface AsyncResultIterator<T, R> { (item: T, callback: AsyncResultCallback<R>): void; }
 interface AsyncMemoIterator<T, R> { (memo: R, item: T, callback: AsyncResultCallback<R>): void; }
 interface AsyncBooleanIterator<T> { (item: T, callback: (err: string, truthValue: boolean) => void): void; }


### PR DESCRIPTION
Hi,

> case 2. Improvement to existing type definition.
> - documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
>   - it has been reviewed by a DefinitelyTyped member.

the key can be either a string (in case of objects) or a number (in case of arrays). See the example in https://github.com/caolan/async#forEachOf 
