### PR TITLE
Add new type definition for serialport

### DIFF
--- a/serialport/serialport-tests.ts
+++ b/serialport/serialport-tests.ts
@@ -6,7 +6,7 @@
 
 /// <reference path="serialport.d.ts" />
 
-import serialport = require('serialport');
+import * as serialport from 'serialport';
 
 this.port = new serialport.SerialPort("", {
     baudrate: 0,

--- a/serialport/serialport-tests.ts
+++ b/serialport/serialport-tests.ts
@@ -1,0 +1,15 @@
+// Tests for serialport.d.ts
+// Project: https://github.com/EmergingTechnologyAdvisors/node-serialport 
+// Definitions by: Jeremy Foster <https://github.com/codefoster>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Tests taken from documentation samples.
+
+/// <reference path="serialport.d.ts" />
+
+import serialport = require('serialport');
+
+this.port = new serialport.SerialPort("", {
+    baudrate: 0,
+    disconnectedCallback: function () { },
+    parser: serialport.parsers.readline("\n")
+});

--- a/serialport/serialport.d.ts
+++ b/serialport/serialport.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for serialport
+// Project: https://github.com/EmergingTechnologyAdvisors/node-serialport 
+// Definitions by: Jeremy Foster <https://github.com/codefoster> 
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped 
+
+declare module 'serialport' {
+    module parsers {
+        function readline(delimiter: string);
+    }
+
+    export class SerialPort {
+        constructor(path: string, options?: Object, openImmediately?: boolean, callback?: () => {})
+        isOpen: boolean;
+        on(event: string, callback?: (data?:any) => void);
+        open(callback?: () => void);
+        write(buffer: any, callback?: () => void)
+        pause();
+        resume();
+        disconnected(err: Error);
+        close(callback?: () => void);
+        flush(callback?: () => void);
+        set(options: setOptions, callback: () => void);
+        drain(callback?: () => void);
+        update(options: updateOptions, callback?: () => void);
+        list(callback?: () => void);
+    }
+
+    interface setOptions {
+        brk?: boolean;
+        cts?: boolean;
+        dsr?: boolean;
+        dtr?: boolean;
+        rts?: boolean;
+    }
+    
+    interface updateOptions {
+        baudRate?: number
+    }
+}

--- a/serialport/serialport.d.ts
+++ b/serialport/serialport.d.ts
@@ -5,24 +5,24 @@
 
 declare module 'serialport' {
     module parsers {
-        function readline(delimiter: string);
+        function readline(delimiter: string):void;
     }
 
     export class SerialPort {
         constructor(path: string, options?: Object, openImmediately?: boolean, callback?: () => {})
         isOpen: boolean;
-        on(event: string, callback?: (data?:any) => void);
-        open(callback?: () => void);
-        write(buffer: any, callback?: () => void)
-        pause();
-        resume();
-        disconnected(err: Error);
-        close(callback?: () => void);
-        flush(callback?: () => void);
-        set(options: setOptions, callback: () => void);
-        drain(callback?: () => void);
-        update(options: updateOptions, callback?: () => void);
-        list(callback?: () => void);
+        on(event: string, callback?: (data?:any) => void):void;
+        open(callback?: () => void):void;
+        write(buffer: any, callback?: () => void):void
+        pause():void;
+        resume():void;
+        disconnected(err: Error):void;
+        close(callback?: () => void):void;
+        flush(callback?: () => void):void;
+        set(options: setOptions, callback: () => void):void;
+        drain(callback?: () => void):void;
+        update(options: updateOptions, callback?: () => void):void;
+        list(callback?: () => void):void;
     }
 
     interface setOptions {


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
