### PR TITLE
Change type from jquery to (correctly) d3 selection

### DIFF
--- a/dagre-d3/dagre-d3-tests.ts
+++ b/dagre-d3/dagre-d3-tests.ts
@@ -14,6 +14,6 @@ namespace DagreD3Tests {
 
     const render = new dagreD3.render();
     const svg = d3.select("svg");
-    render.arrows()["arrowType"] = (parent: JQuery, id: string, edge: Dagre.Edge, type: string) => {};
+    render.arrows()["arrowType"] = (parent: d3.Selection<any>, id: string, edge: Dagre.Edge, type: string) => {};
     render(svg, graph);
 }

--- a/dagre-d3/dagre-d3.d.ts
+++ b/dagre-d3/dagre-d3.d.ts
@@ -5,7 +5,6 @@
 
 /// <reference path="../d3/d3.d.ts"/>
 /// <reference path="../dagre/dagre.d.ts"/>
-/// <reference path="../jquery/jquery.d.ts" />
 
 declare namespace Dagre {
 
@@ -25,7 +24,7 @@ declare namespace Dagre {
 
     interface Render {
         // see http://cpettitt.github.io/project/dagre-d3/latest/demo/user-defined.html for example usage
-        arrows (): { [arrowStyleName: string]: (parent: JQuery, id: string, edge: Dagre.Edge, type: string) => void };
+        arrows (): { [arrowStyleName: string]: (parent: d3.Selection<any>, id: string, edge: Dagre.Edge, type: string) => void };
         new (): Render;
         (selection: d3.Selection<any>, g: Dagre.Graph): void;
     }


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
