### PR TITLE
Added 2 missing methods to knex.js

### DIFF
--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -301,6 +301,7 @@ declare module "knex" {
 
     interface SchemaBuilder extends Promise<any> {
       createTable(tableName: string, callback: (tableBuilder: CreateTableBuilder) => any): SchemaBuilder;
+      createTableIfNotExistsknex(tableName: string, callback: (tableBuilder: CreateTableBuilder) => any): SchemaBuilder;
       renameTable(oldTableName: string, newTableName: string): Promise<void>;
       dropTable(tableName: string): SchemaBuilder;
       hasTable(tableName: string): Promise<boolean>;
@@ -312,6 +313,7 @@ declare module "knex" {
 
     interface TableBuilder {
       increments(columnName?: string): ColumnBuilder;
+      bigIncrements(columnName?: string): ColumnBuilder;
       dropColumn(columnName: string): TableBuilder;
       dropColumns(...columnNames: string[]): TableBuilder;
       renameColumn(from: string, to: string): ColumnBuilder;

--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -301,7 +301,7 @@ declare module "knex" {
 
     interface SchemaBuilder extends Promise<any> {
       createTable(tableName: string, callback: (tableBuilder: CreateTableBuilder) => any): SchemaBuilder;
-      createTableIfNotExistsknex(tableName: string, callback: (tableBuilder: CreateTableBuilder) => any): SchemaBuilder;
+      createTableIfNotExists(tableName: string, callback: (tableBuilder: CreateTableBuilder) => any): SchemaBuilder;
       renameTable(oldTableName: string, newTableName: string): Promise<void>;
       dropTable(tableName: string): SchemaBuilder;
       hasTable(tableName: string): Promise<boolean>;


### PR DESCRIPTION
Case 2

Added `createTableIfNotExists` and `bigIncrements`. Not sure why they were omitted. http://knexjs.org/ has references to both. `bigIncrements` is not on the sidebar, but it's referenced under `increments` (and I'm using it fine).
