### PR TITLE
Added missing deprecated method Collection remove

### DIFF
--- a/mongodb/mongodb.d.ts
+++ b/mongodb/mongodb.d.ts
@@ -697,6 +697,13 @@ declare module "mongodb" {
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#reIndex
     reIndex(): Promise<any>;
     reIndex(callback: MongoCallback<any>): void;
+    //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#remove
+    /** @deprecated Use use deleteOne, deleteMany or bulkWrite */
+    remove(selector: Object, callback: MongoCallback<WriteOpResult>): void;
+    /** @deprecated Use use deleteOne, deleteMany or bulkWrite */
+    remove(selector: Object, options?: CollectionOptions & { single?: boolean }): Promise<WriteOpResult>;
+    /** @deprecated Use use deleteOne, deleteMany or bulkWrite */
+    remove(selector: Object, options?: CollectionOptions & { single?: boolean }, callback?: MongoCallback<WriteOpResult>): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#rename
     rename(newName: string, callback: MongoCallback<Collection>): void;
     rename(newName: string, options?: { dropTarget?: boolean }): Promise<Collection>;
@@ -708,7 +715,9 @@ declare module "mongodb" {
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#save
     /** @deprecated Use insertOne, insertMany, updateOne or updateMany */
     save(doc: Object, callback: MongoCallback<WriteOpResult>): void;
+    /** @deprecated Use insertOne, insertMany, updateOne or updateMany */
     save(doc: Object, options?: CollectionOptions): Promise<WriteOpResult>;
+    /** @deprecated Use insertOne, insertMany, updateOne or updateMany */
     save(doc: Object, options: CollectionOptions, callback: MongoCallback<WriteOpResult>): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#stats
     stats(callback: MongoCallback<CollStats>): void;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url [Collection remove}(http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#remove).

Thanks to @NickLydon for finding the missing method.
Replaces https://github.com/DefinitelyTyped/DefinitelyTyped/pull/9475 that had problems
