### PR TITLE
add another name which is usually use in project

### DIFF
--- a/avoscloud-sdk/avoscloud-sdk.d.ts
+++ b/avoscloud-sdk/avoscloud-sdk.d.ts
@@ -797,3 +797,8 @@ declare module "avoscloud-sdk" {
 
   export = AV;
 }
+
+declare module 'leanengine' {
+    import alias = require('avoscloud-sdk');
+    export = alias;
+}


### PR DESCRIPTION
add another name which is usually use in project

in real peoject, always like this

```
var AV = require("leanengine");
```
