### PR TITLE
Add definitions for react-jsonschema-form 0.30.1

### DIFF
--- a/react-jsonschema-form/react-jsonschema-form-test.tsx
+++ b/react-jsonschema-form/react-jsonschema-form-test.tsx
@@ -1,0 +1,84 @@
+/// <reference path="react-jsonschema-form.d.ts" />
+/// <reference path="../react/react.d.ts" />
+
+import * as React from "react";
+import Form from "react-jsonschema-form";
+
+// example taken from the react-jsonschema-form playground:
+// https://github.com/mozilla-services/react-jsonschema-form/blob/fedd830294417969d88e38fb9f6b3a85e6ad105e/playground/samples/simple.js
+
+const schema =  {
+    "title": "A registration form",
+    "type": "object",
+    "required": [
+        "firstName",
+        "lastName"
+    ],
+    "properties": {
+        "firstName": {
+            "type": "string",
+            "title": "First name"
+        },
+        "lastName": {
+            "type": "string",
+            "title": "Last name"
+        },
+        "age": {
+            "type": "integer",
+            "title": "Age"
+        },
+        "bio": {
+            "type": "string",
+            "title": "Bio"
+        },
+        "password": {
+            "type": "string",
+            "title": "Password",
+            "minLength": 3
+        }
+    }
+};
+
+const uiSchema = {
+    age: {
+        "ui:widget": "updown"
+    },
+    bio: {
+        "ui:widget": "textarea"
+    },
+    password: {
+        "ui:widget": "password",
+        "ui:help": "Hint: Make it strong!"
+    },
+    date: {
+        "ui:widget": "alt-datetime"
+    }
+};
+
+interface IExampleState {
+    formData: any;
+}
+
+export class Example extends React.Component<any, IExampleState> {
+    constructor(props: any) {
+        super(props);
+        this.state.formData = {
+            firstName: "Chuck",
+            lastName: "Norris",
+            age: 75,
+            bio: "Roundhouse kicking asses since 1940",
+            password: "noneed"
+        };
+    }
+
+    public render() {
+      return (
+          <div className="react-jsonschema-form-example">
+              {   <Form schema={schema}
+                        uiSchema={uiSchema}
+                        formData={this.state}
+                        onChange={(formData) => this.setState({formData})} /> }
+          </div>
+      );
+    }
+}

--- a/react-jsonschema-form/react-jsonschema-form.d.ts
+++ b/react-jsonschema-form/react-jsonschema-form.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for react-jsonschema-form 0.30.1
+// Project: https://github.com/mozilla-services/react-jsonschema-form
+// Definitions by: Dan Fox <https://github.com/iamdanfox>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../react/react.d.ts" />
+
+declare module "react-jsonschema-form" {
+    import * as React from "react";
+
+    export interface FormProps {
+        schema: {};
+        uiSchema?: {};
+        formData?: any;
+        widgets?: {};
+        fields?: {};
+        validate?: (formData: any, errors: any) => any;
+        onChange?: (e: IChangeEvent) => any;
+        onError?: (e: any) => any;
+        onSubmit?: (e: any) => any;
+        liveValidate?: boolean;
+        safeRenderCompletion?: boolean;
+    }
+
+    export interface IChangeEvent {
+        edit: boolean;
+        formData: any;
+        errors: any[];
+        errorSchema: any;
+        idSchema: any;
+        status: string;
+    }
+
+    export default class Form extends React.Component<FormProps, any> {}
+}


### PR DESCRIPTION
[React JSONSchema Form](https://github.com/mozilla-services/react-jsonschema-form) is a React component for building Web forms from JSONSchema, built by mozilla.

This PR brings very barebones typings, intended to serve as a baseline for improvement.

> case 1. Add a new type definition.
> - [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
>   
>   ```
>   ./node_modules/.bin/tsc --jsx react react-jsonschema-form/react-jsonschema-form-test.tsx --noImplicitAny --target es6
>   ```
> - [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
> - [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
