### PR TITLE
Augment the sortingAlgorithm type with all its documented arguments.

### DIFF
--- a/ui-grid/ui-grid-tests.ts
+++ b/ui-grid/ui-grid-tests.ts
@@ -44,6 +44,10 @@ columnDef.filter = {
 columnDef.filter.condition = (searchTerm: string, cellValue: any, row: uiGrid.IGridRow, column: uiGrid.IGridColumn): boolean => {
     return true;
 };
+// the condition function does not need to declare all the parameters
+columnDef.filter.condition = (searchTerm: string, cellValue: any): boolean => {
+    return false;
+};
 columnDef.filterCellFiltered = false;
 columnDef.filterHeaderTemplate = '<div blah="test"></div>';
 columnDef.filters = [columnDef.filter];

--- a/ui-grid/ui-grid-tests.ts
+++ b/ui-grid/ui-grid-tests.ts
@@ -88,7 +88,7 @@ columnDef.sort = {
     priority: 1
 };
 columnDef.sortCellFiltered = false;
-columnDef.sortingAlgorithm = (a: any, b: any, rowA: IMyEntity, rowB: IMyEntity, direction: string) => {
+columnDef.sortingAlgorithm = (a: any, b: any, rowA: uiGrid.IGridRowOf<IMyEntity>, rowB: uiGrid.IGridRowOf<IMyEntity>, direction: string) => {
     return -1;
 };
 columnDef.suppressRemoveSort = false;

--- a/ui-grid/ui-grid-tests.ts
+++ b/ui-grid/ui-grid-tests.ts
@@ -88,7 +88,7 @@ columnDef.sort = {
     priority: 1
 };
 columnDef.sortCellFiltered = false;
-columnDef.sortingAlgorithm = (a: any, b: any) => {
+columnDef.sortingAlgorithm = (a: any, b: any, rowA: IMyEntity, rowB: IMyEntity, direction: string) => {
     return -1;
 };
 columnDef.suppressRemoveSort = false;

--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -3548,8 +3548,13 @@ declare namespace uiGrid {
         name?: string;
         /** Sort on this column */
         sort?: ISortInfo;
-        /** Algorithm to use for sorting this column. Takes 'a' and 'b' parameters like any normal sorting function. */
-        sortingAlgorithm?: (a: any, b: any) => number;
+        /**
+         * Algorithm to use for sorting this column. Takes 'a' and 'b' parameters
+         * like any normal sorting function with additional 'rowA', 'rowB', and 'direction'
+         * parameters that are the row objects and the current direction of the sort
+         * respectively. 
+         */
+        sortingAlgorithm?: (a: any, b: any, rowA: TEntity, rowB: TEntity, direction: string) => number;
         /** Column width */
         width: number;
         /**
@@ -3778,8 +3783,13 @@ declare namespace uiGrid {
          * not appear in the list more than once (e.g. [ASC, DESC, DESC] is not allowed), and the list may not be empty.*
          */
         sortDirectionCycle?: Array<IUiGridConstants>;
-        /** Algorithm to use for sorting this column */
-        sortingAlgorithm?: (a: any, b: any) => number;
+        /**
+         * Algorithm to use for sorting this column. Takes 'a' and 'b' parameters
+         * like any normal sorting function with additional 'rowA', 'rowB', and 'direction'
+         * parameters that are the row objects and the current direction of the sort
+         * respectively. 
+         */
+        sortingAlgorithm?: (a: any, b: any, rowA: TEntity, rowB: TEntity, direction: string) => number;
         /**
          * When enabled, this setting hides the removeSort option in the menu,
          * and prevents users from manually removing the sort

--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -3554,7 +3554,7 @@ declare namespace uiGrid {
          * parameters that are the row objects and the current direction of the sort
          * respectively. 
          */
-        sortingAlgorithm?: (a: any, b: any, rowA: TEntity, rowB: TEntity, direction: string) => number;
+        sortingAlgorithm?: (a: any, b: any, rowA: IGridRowOf<TEntity>, rowB: IGridRowOf<TEntity>, direction: string) => number;
         /** Column width */
         width: number;
         /**
@@ -3789,7 +3789,7 @@ declare namespace uiGrid {
          * parameters that are the row objects and the current direction of the sort
          * respectively. 
          */
-        sortingAlgorithm?: (a: any, b: any, rowA: TEntity, rowB: TEntity, direction: string) => number;
+        sortingAlgorithm?: (a: any, b: any, rowA: IGridRowOf<TEntity>, rowB: IGridRowOf<TEntity>, direction: string) => number;
         /**
          * When enabled, this setting hides the removeSort option in the menu,
          * and prevents users from manually removing the sort


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- The documentation for `sortingAlgorithm` (http://ui-grid.info/docs/#/api/ui.grid.class:GridOptions.columnDef) mentions some arguments that don't currently exist in the type definition. This pull request adds the missing arguments.
