### PR TITLE
Fix for Sequelize.FindOptions

### DIFF
--- a/sequelize/sequelize-tests.ts
+++ b/sequelize/sequelize-tests.ts
@@ -884,6 +884,10 @@ User.findAll( { include : [User], order : [['id', 'ASC NULLS LAST'], [User, 'id'
 User.findAll( { include : [{ model : User, where : { title : 'DoDat' }, include : [{ model : User }] }] } );
 User.findAll( { attributes: ['username', 'data']});
 User.findAll( { attributes: {include: ['username', 'data']} });
+User.findAll( { attributes: [['username', 'UNM'], ['email', 'EML']] });
+User.findAll( { attributes: [s.fn('count', Sequelize.col('*'))] });
+User.findAll( { attributes: [[s.fn('count', Sequelize.col('*')), 'count']] });
+User.findAll( { attributes: [[s.fn('count', Sequelize.col('*')), 'count']], group: ['sex'] });
 
 User.findById( 'a string' );
 

--- a/sequelize/sequelize.d.ts
+++ b/sequelize/sequelize.d.ts
@@ -3121,7 +3121,7 @@ declare module "sequelize" {
              * `Sequelize.literal`, `Sequelize.fn` and so on), and the second is the name you want the attribute to
              * have in the returned instance
              */
-            attributes? :  Array<string> | { include?: Array<string>, exclude?: Array<string> };
+            attributes?: Array<string | fn | [string, string] | [fn, string]> | { include?: Array<string>, exclude?: Array<string> };
 
             /**
              * If true, only non-deleted records will be returned. If false, both deleted and non-deleted records will
@@ -3181,6 +3181,12 @@ declare module "sequelize" {
              * having ?!?
              */
             having? : WhereOptions;
+
+            /**
+             * Group by. It is not mentioned in sequelize's JSDoc, but mentioned in docs.
+             * https://github.com/sequelize/sequelize/blob/master/docs/docs/models-usage.md#user-content-manipulating-the-dataset-with-limit-offset-order-and-group
+             */
+            group?: string | string[] | Object;
 
         }
 


### PR DESCRIPTION
Improvement to existing type definition.

Sequelize.FindOptions actually have `group` attribute. See https://github.com/sequelize/sequelize/blob/master/test/unit/dialects/sqlite/query-generator.test.js#L221

Sequelize.FindOptions.attributes supports SQL-functions. See https://github.com/sequelize/sequelize/blob/master/test/unit/dialects/sqlite/query-generator.test.js#L260

Some more evidences:
https://github.com/sequelize/sequelize/blob/master/docs/docs/models-usage.md#user-content-manipulating-the-dataset-with-limit-offset-order-and-group
