### PR TITLE
long: remove superfluous namespace

### DIFF
--- a/long/long.d.ts
+++ b/long/long.d.ts
@@ -348,6 +348,5 @@ declare class Long
 }
 
 declare module 'long' {
-    namespace Long {}
     export = Long;
 }


### PR DESCRIPTION
This prevents `import Long = require("long");` from generating the
javascript require call.
