### PR TITLE
bytebuffer: remove superfluous namespace

### DIFF
--- a/bytebuffer/bytebuffer.d.ts
+++ b/bytebuffer/bytebuffer.d.ts
@@ -91,7 +91,7 @@ declare class ByteBuffer
     /**
      * Data view to manipulate the backing buffer. Becomes null if the backing buffer has a capacity of 0.
      */
-    view: DataView;    
+    view: DataView;
 
     /**
      * Allocates a new ByteBuffer backed by a buffer of the specified capacity.
@@ -424,7 +424,7 @@ declare class ByteBuffer
 
     /**
      * Resizes this ByteBuffer to be backed by a buffer of at least the given capacity. Will do nothing if already that large or larger.
-     */ 
+     */
     resize( capacity: number ): ByteBuffer;
 
     /**

--- a/bytebuffer/bytebuffer.d.ts
+++ b/bytebuffer/bytebuffer.d.ts
@@ -611,6 +611,5 @@ declare class ByteBuffer
 }
 
 declare module 'bytebuffer' {
-    namespace ByteBuffer {}
     export = ByteBuffer;
 }


### PR DESCRIPTION
This prevents `import ByteBuffer = require("bytebuffer");` from
generating the javascript require call.
