### PR TITLE
Update README.md to point to Typings instead of tsd

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Please see the [contribution guide](http://definitelytyped.org/guides/contributi
 
 * Directly from the GitHub repos
 * [NuGet packages](http://nuget.org/packages?q=DefinitelyTyped)
-* [TypeScript Definition manager](https://github.com/DefinitelyTyped/tsd)
+* [Typings - TypeScript Definition Manager](https://github.com/typings/typings)
 
 ## List of definitions
 


### PR DESCRIPTION
Based on the note on the `tsd` page and the issue DefinitelyTyped/tsd#269, it would make sense to point people to Typings instead.
