### PR TITLE
Added definitions for csv-parse

### DIFF
--- a/csv-parse/csv-parse-tests.ts
+++ b/csv-parse/csv-parse-tests.ts
@@ -1,0 +1,64 @@
+/// <reference path="csv-parse.d.ts" />
+
+import parse = require('csv-parse');
+
+function callbackAPITest() {
+    var input = '#Welcome\n"1","2","3","4"\n"a","b","c","d"';
+    parse(input, {comment: '#'}, function(err, output){
+    output.should.eql([ [ '1', '2', '3', '4' ], [ 'a', 'b', 'c', 'd' ] ]);
+    });
+}
+
+function streamAPITest() {
+    var output:any = [];
+    // Create the parser
+    var parser = parse({delimiter: ':'});
+    var record: any;
+    // Use the writable stream api
+    parser.on('readable', function(){
+    while(record = parser.read()){
+        output.push(record);
+    }
+    });
+    // Catch any error
+    parser.on('error', function(err: any){
+    console.log(err.message);
+    });
+    // When we are done, test that the parsed output matched what expected
+    parser.on('finish', function(){
+    output.should.eql([
+        [ 'root','x','0','0','root','/root','/bin/bash' ],
+        [ 'someone','x','1022','1022','a funny cat','/home/someone','/bin/bash' ]
+    ]);
+    });
+    // Now that setup is done, write data to the stream
+    parser.write("root:x:0:0:root:/root:/bin/bash\n");
+    parser.write("someone:x:1022:1022:a funny cat:/home/someone:/bin/bash\n");
+    // Close the readable stream
+    parser.end();
+}
+
+import fs = require('fs');
+
+function pipeFunctionTest() {
+    var transform = require('stream-transform');
+    
+    var output:any = [];
+    var parser = parse({delimiter: ':'})
+    var input = fs.createReadStream('/etc/passwd');
+    var transformer = transform(function(record: any[], callback: any){
+    setTimeout(function(){
+        callback(null, record.join(' ')+'\n');
+    }, 500);
+    }, {parallel: 10});
+    input.pipe(parser).pipe(transformer).pipe(process.stdout);
+}
+
+import parseSync = require('csv-parse/lib/sync');
+
+function syncApiTest() {
+    var input = '"key_1","key_2"\n"value 1","value 2"';
+    var records = parseSync(input, {columns: true});
+    records.should.eql([{ key_1: 'value 1', key_2: 'value 2' }]);
+}
+

--- a/csv-parse/csv-parse.d.ts
+++ b/csv-parse/csv-parse.d.ts
@@ -1,0 +1,132 @@
+// Type definitions for csv-parse 1.1.0
+// Project: https://github.com/wdavidw/node-csv-parse
+// Definitions by: David Muller <https://github.com/davidm77>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module "csv-parse/types" {
+    interface callbackFn {
+        (err: any, output: any): void
+    }
+    
+    interface nameCallback {
+        (line1: any[]): boolean | string[]
+    }   
+    
+    interface options {
+        /***
+         *  Set the field delimiter. One character only, defaults to comma. 
+         */
+        delimiter?: string;
+
+        /***
+         *  String used to delimit record rows or a special value; special constants are 'auto', 'unix', 'mac', 'windows', 'unicode'; defaults to 'auto' (discovered in source or 'unix' if no source is specified).
+         */ 
+        rowDelimiter?:  string;
+        /***
+         *  Optional character surrounding a field, one character only, defaults to double quotes. 
+         */
+        quote?: string
+        
+        /***
+         *  Set the escape character, one character only, defaults to double quotes. 
+         */ 
+        escape?: string
+
+        /***
+         *  List of fields as an array, a user defined callback accepting the first line and returning the column names or true if autodiscovered in the first CSV line, default to null, affect the result data set in the sense that records will be objects instead of arrays. 
+         */
+        columns?: any[]|boolean|nameCallback;
+
+        /***
+         *  Treat all the characters after this one as a comment, default to '' (disabled). 
+         */
+        comment?: string
+
+        /***
+         *  Name of header-record title to name objects by.
+         */
+        objname?: string
+
+        /***
+         *  Preserve quotes inside unquoted field.
+         */
+        relax?: boolean
+
+        /***
+         *  Discard inconsistent columns count, default to false.
+         */
+        relax_column_count?: boolean
+
+        /***
+         *  Dont generate empty values for empty lines.
+         */
+        skip_empty_lines?: boolean
+
+        /***
+         *  Maximum numer of characters to be contained in the field and line buffers before an exception is raised, used to guard against a wrong delimiter or rowDelimiter, default to 128000 characters.
+         */
+        max_limit_on_data_read?: number
+
+        /***
+         *  If true, ignore whitespace immediately around the delimiter, defaults to false. Does not remove whitespace in a quoted field.
+         */
+        trim?: boolean
+
+        /***
+         *  If true, ignore whitespace immediately following the delimiter (i.e. left-trim all fields), defaults to false. Does not remove whitespace in a quoted field.
+         */
+        ltrim?: boolean
+
+        /***
+         *  If true, ignore whitespace immediately preceding the delimiter (i.e. right-trim all fields), defaults to false. Does not remove whitespace in a quoted field.
+         */
+        rtrim?: boolean
+
+        /***
+         *  If true, the parser will attempt to convert read data types to native types.
+         */
+        auto_parse?: boolean
+        
+        /***
+         *  If true, the parser will attempt to convert read data types to dates. It requires the "auto_parse" option.
+         */
+        auto_parse_date?: boolean
+    }
+    
+    import * as stream from "stream"; 
+    
+    interface Parser extends stream.Transform {
+        __push(line: any): any ;
+        __write(chars: any, end: any, callback: any): any; 
+    }
+    
+    interface ParserConstructor {
+       new (options: options): Parser;
+    }
+    
+    interface parse {
+        (input: string, options?: options, callback?: callbackFn): any;
+        (options: options, callback: callbackFn): any;
+        (callback: callbackFn): any;
+        (options?: options): NodeJS.ReadWriteStream;
+        Parser: ParserConstructor;
+    }
+}
+
+declare module "csv-parse" {
+    import { parse as parseIntf } from "csv-parse/types";
+    
+    let parse: parseIntf;
+    
+    export = parse;
+}
+
+declare module "csv-parse/lib/sync" {
+   import { options } from "csv-parse/types"; 
+   
+   function parse (input: string, options?: options): any;
+ 
+   export = parse;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [ X ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ X ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ X ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
