### PR TITLE
javascript-obfuscator definitions

### DIFF
--- a/javascript-obfuscator/javascript-obfuscator-tests.ts
+++ b/javascript-obfuscator/javascript-obfuscator-tests.ts
@@ -5,6 +5,7 @@ import { JavaScriptObfuscator } from 'javascript-obfuscator';
 let sourceCode1: string = JavaScriptObfuscator.obfuscate('var foo = 1;');
 let sourceCode2: string = JavaScriptObfuscator.obfuscate('var foo = 1;', {
   compact: true,
+  encodeUnicodeArray: true,
   debugProtection: false,
   debugProtectionInterval: false,
   disableConsoleOutput: true,

--- a/javascript-obfuscator/javascript-obfuscator-tests.ts
+++ b/javascript-obfuscator/javascript-obfuscator-tests.ts
@@ -5,10 +5,11 @@ import { JavaScriptObfuscator } from 'javascript-obfuscator';
 let sourceCode1: string = JavaScriptObfuscator.obfuscate('var foo = 1;');
 let sourceCode2: string = JavaScriptObfuscator.obfuscate('var foo = 1;', {
   compact: true,
-  encodeUnicodeArray: true,
   debugProtection: false,
   debugProtectionInterval: false,
   disableConsoleOutput: true,
+  encodeUnicodeLiterals: true,
   rotateUnicodeArray: true,
+  unicodeArray: true,
   wrapUnicodeArrayCalls: true
 });

--- a/javascript-obfuscator/javascript-obfuscator-tests.ts
+++ b/javascript-obfuscator/javascript-obfuscator-tests.ts
@@ -1,0 +1,8 @@
+/// <reference path="javascript-obfuscator" />
+
+import { JavaScriptObfuscator } from 'javascript-obfuscator';
+
+let sourceCode1: string = JavaScriptObfuscator.obfuscate('var foo = 1;');
+let sourceCode2: string = JavaScriptObfuscator.obfuscate('var foo = 1;', {
+  rotateUnicodeArray: false
+});

--- a/javascript-obfuscator/javascript-obfuscator-tests.ts
+++ b/javascript-obfuscator/javascript-obfuscator-tests.ts
@@ -4,5 +4,10 @@ import { JavaScriptObfuscator } from 'javascript-obfuscator';
 
 let sourceCode1: string = JavaScriptObfuscator.obfuscate('var foo = 1;');
 let sourceCode2: string = JavaScriptObfuscator.obfuscate('var foo = 1;', {
-  rotateUnicodeArray: false
+  compact: true,
+  debugProtection: false,
+  debugProtectionInterval: false,
+  disableConsoleOutput: true,
+  rotateUnicodeArray: true,
+  wrapUnicodeArrayCalls: true
 });

--- a/javascript-obfuscator/javascript-obfuscator.d.ts
+++ b/javascript-obfuscator/javascript-obfuscator.d.ts
@@ -6,12 +6,14 @@
 declare module 'javascript-obfuscator' {
   export interface IOptions {
     compact?: boolean;
-    encodeUnicodeArray?: boolean;
     debugProtection?: boolean;
     debugProtectionInterval?: boolean;
     disableConsoleOutput?: boolean;
+    encodeUnicodeLiterals?: boolean;
     rotateUnicodeArray?: boolean;
+    unicodeArray?: boolean;
     wrapUnicodeArrayCalls?: boolean;
+    [id: string]: any;
   }
 
   export class JavaScriptObfuscator {

--- a/javascript-obfuscator/javascript-obfuscator.d.ts
+++ b/javascript-obfuscator/javascript-obfuscator.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for javascript-obfuscator
+// Project: https://github.com/sanex3339/javascript-obfuscator
+// Definitions by: sanex3339 <https://github.com/sanex3339>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'javascript-obfuscator' {
+  export class JavaScriptObfuscator {
+    public static obfuscate (sourceCode: string, customOptions?: any): string;
+  }
+}

--- a/javascript-obfuscator/javascript-obfuscator.d.ts
+++ b/javascript-obfuscator/javascript-obfuscator.d.ts
@@ -4,7 +4,16 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module 'javascript-obfuscator' {
+  export interface IOptions {
+    compact?: boolean;
+    debugProtection?: boolean;
+    debugProtectionInterval?: boolean;
+    disableConsoleOutput?: boolean;
+    rotateUnicodeArray?: boolean;
+    wrapUnicodeArrayCalls?: boolean;
+  }
+
   export class JavaScriptObfuscator {
-    public static obfuscate (sourceCode: string, customOptions?: any): string;
+    public static obfuscate (sourceCode: string, customOptions?: IOptions): string;
   }
 }

--- a/javascript-obfuscator/javascript-obfuscator.d.ts
+++ b/javascript-obfuscator/javascript-obfuscator.d.ts
@@ -6,6 +6,7 @@
 declare module 'javascript-obfuscator' {
   export interface IOptions {
     compact?: boolean;
+    encodeUnicodeArray?: boolean;
     debugProtection?: boolean;
     debugProtectionInterval?: boolean;
     disableConsoleOutput?: boolean;


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
