### PR TITLE
Change log4javascript.Level from enum to class with static fields

### DIFF
--- a/log4javascript/log4javascript-tests.ts
+++ b/log4javascript/log4javascript-tests.ts
@@ -2,7 +2,14 @@
 
 function aSimpleLoggingMessageString() {
 	var log = log4javascript.getDefaultLogger();
-	log.info("Hello World");
+    log.info("Hello World");
+}
+
+function compareLogLevelsAndLog() {
+    var log = log4javascript.getDefaultLogger();
+    if (log4javascript.Level.INFO.isGreaterOrEqual(log.getLevel())) {
+        log.log(log4javascript.Level.INFO, ["Info"]);
+    }
 }
 
 function loggingAnErrorWithAMessage() {

--- a/log4javascript/log4javascript.d.ts
+++ b/log4javascript/log4javascript.d.ts
@@ -89,7 +89,22 @@ declare namespace log4javascript {
 	/**
 	 * Levels are available as static properties of the log4javascript.Level object.
 	 */
-	export enum Level { ALL, TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF }
+	export class Level {
+		static ALL: Level;
+		static TRACE: Level;
+		static DEBUG: Level;
+		static INFO: Level;
+		static WARN: Level;
+		static ERROR: Level;
+		static FATAL: Level;
+		static OFF: Level;
+
+		constructor(level: number, name: string);
+
+		toString(): string;
+		equals(level: Level): boolean;
+		isGreaterOrEqual(level: Level): boolean;
+	}
 
 	// #endregion
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.
  - [x] the latest 1.4.13 source code isn't readily available without downloading from sourceforge, the closest I could find available online is 1.2 source: http://log4javascript.cvs.sourceforge.net/viewvc/log4javascript/log4javascript/log4javascript.js?view=markup&pathrev=MAIN, see line 560 - 581
  - [ ] it has been reviewed by a DefinitelyTyped member.
