### PR TITLE
remove moment.MomentFormatSpecification (doesn't exist)

### DIFF
--- a/moment-timezone/moment-timezone.d.ts
+++ b/moment-timezone/moment-timezone.d.ts
@@ -35,10 +35,10 @@ interface MomentTimezone {
     (date: number, timezone: string): moment.Moment;
     (date: number[], timezone: string): moment.Moment;
     (date: string, timezone: string): moment.Moment;
-    (date: string, format: moment.MomentFormatSpecification, timezone: string): moment.Moment;
-    (date: string, format: moment.MomentFormatSpecification, strict: boolean, timezone: string): moment.Moment;
-    (date: string, format: moment.MomentFormatSpecification, language: string, timezone: string): moment.Moment;
-    (date: string, format: moment.MomentFormatSpecification, language: string, strict: boolean, timezone: string): moment.Moment;
+    (date: string, format: string, timezone: string): moment.Moment;
+    (date: string, format: string, strict: boolean, timezone: string): moment.Moment;
+    (date: string, format: string, language: string, timezone: string): moment.Moment;
+    (date: string, format: string, language: string, strict: boolean, timezone: string): moment.Moment;
     (date: Date, timezone: string): moment.Moment;
     (date: moment.Moment, timezone: string): moment.Moment;
     (date: Object, timezone: string): moment.Moment;


### PR DESCRIPTION
Please consider removing references to moment.MomentFormatSpecification which doesn't exist. Best, apc
