### PR TITLE
caolan/async: add missing optional type to 'retry'

### DIFF
--- a/async/async-tests.ts
+++ b/async/async-tests.ts
@@ -378,6 +378,7 @@ async.auto({
 
 async.retry(3, function (callback, results) { }, function (err, result) { });
 async.retry({ times: 3, interval: 200 }, function (callback, results) { }, function (err, result) { });
+async.retry({ times: 3, interval: (retryCount) => { return 200 * retryCount; } }, function (callback, results) { }, function (err, result) { });
 
 
 async.parallel([

--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -136,7 +136,7 @@ interface Async {
     cargo(worker : (tasks: any[], callback : ErrorCallback) => void, payload? : number) : AsyncCargo;
     auto(tasks: any, callback?: (error: Error, results: any) => void): void;
     retry<T>(opts: number, task: (callback : AsyncResultCallback<T>, results: any) => void, callback: (error: Error, results: any) => void): void;
-    retry<T>(opts: { times: number, interval: number|((retryCount: number) => void) }, task: (callback: AsyncResultCallback<T>, results : any) => void, callback: (error: Error, results: any) => void): void;
+    retry<T>(opts: { times: number, interval: number|((retryCount: number) => number) }, task: (callback: AsyncResultCallback<T>, results : any) => void, callback: (error: Error, results: any) => void): void;
     iterator(tasks: Function[]): Function;
     apply(fn: Function, ...arguments: any[]): AsyncFunction<any>;
     nextTick(callback: Function): void;

--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -136,7 +136,7 @@ interface Async {
     cargo(worker : (tasks: any[], callback : ErrorCallback) => void, payload? : number) : AsyncCargo;
     auto(tasks: any, callback?: (error: Error, results: any) => void): void;
     retry<T>(opts: number, task: (callback : AsyncResultCallback<T>, results: any) => void, callback: (error: Error, results: any) => void): void;
-    retry<T>(opts: { times: number, interval: number }, task: (callback: AsyncResultCallback<T>, results : any) => void, callback: (error: Error, results: any) => void): void;
+    retry<T>(opts: { times: number, interval: number|((retryCount: number) => void) }, task: (callback: AsyncResultCallback<T>, results : any) => void, callback: (error: Error, results: any) => void): void;
     iterator(tasks: Function[]): Function;
     apply(fn: Function, ...arguments: any[]): AsyncFunction<any>;
     nextTick(callback: Function): void;


### PR DESCRIPTION
The [caolan/async retry](https://github.com/caolan/async#retry) function can have an interval with type `(retryCount: number) => number`

> The interval may also be specified as a function of the retry count

``` typescript
async.retry({
  times: 10,
  interval: function(retryCount) {
    return 50 * Math.pow(2, retryCount);
  }
}, apiMethod, function(err, result) {
    // do something with the result
});
```
