### PR TITLE
add node-fetch based on whatwg-fetch (#8931)

### DIFF
--- a/node-fetch/node-fetch-tests.ts
+++ b/node-fetch/node-fetch-tests.ts
@@ -1,0 +1,60 @@
+﻿/// <reference path="node-fetch.d.ts" />
+
+import fetch = require('node-fetch');
+
+function test_fetchUrlWithOptions() {
+	var headers = new Headers();
+	headers.append("Content-Type", "application/json");
+	var requestOptions: RequestInit = {
+		method: "POST",
+		headers: headers,
+		mode: 'same-origin',
+		credentials: 'omit',
+		cache: 'default',
+		redirect: 'manual'
+	};
+	handlePromise(fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions));
+}
+
+function test_fetchUrlWithHeadersObject() {
+	var requestOptions: RequestInit = {
+		method: "POST",
+		headers: {
+			'Content-Type': 'application/json'
+		}
+	};
+	handlePromise(fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions));
+}
+
+function test_fetchUrl() {
+	handlePromise(fetch("http://www.andlabs.net/html5/uCOR.php"));
+}
+
+function test_fetchUrlWithRequestObject() {
+	var requestOptions: RequestInit = {
+		method: "POST",
+		headers: {
+			'Content-Type': 'application/json'
+		}
+	};
+	var request: Request = new Request("http://www.andlabs.net/html5/uCOR.php", requestOptions);
+	handlePromise(fetch(request));
+}
+
+function test_globalFetchVar() {
+	fetch('http://test.com', {})
+		.then(response => {
+			// for test only
+		});
+}
+
+function handlePromise(promise: Promise<Response>) {
+	promise.then((response) => {
+		if (response.type === 'basic') {
+			// for test only
+		}
+		return response.text();
+	}).then((text) => {
+		console.log(text);
+	});
+}

--- a/node-fetch/node-fetch-tests.ts
+++ b/node-fetch/node-fetch-tests.ts
@@ -3,9 +3,9 @@
 import fetch = require('node-fetch');
 
 function test_fetchUrlWithOptions() {
-	var headers = new Headers();
+	var headers = new _fetch.Headers();
 	headers.append("Content-Type", "application/json");
-	var requestOptions: RequestInit = {
+	var requestOptions: _fetch.RequestInit = {
 		method: "POST",
 		headers: headers,
 		mode: 'same-origin',
@@ -17,7 +17,7 @@ function test_fetchUrlWithOptions() {
 }
 
 function test_fetchUrlWithHeadersObject() {
-	var requestOptions: RequestInit = {
+	var requestOptions: _fetch.RequestInit = {
 		method: "POST",
 		headers: {
 			'Content-Type': 'application/json'
@@ -31,13 +31,13 @@ function test_fetchUrl() {
 }
 
 function test_fetchUrlWithRequestObject() {
-	var requestOptions: RequestInit = {
+	var requestOptions: _fetch.RequestInit = {
 		method: "POST",
 		headers: {
 			'Content-Type': 'application/json'
 		}
 	};
-	var request: Request = new Request("http://www.andlabs.net/html5/uCOR.php", requestOptions);
+	var request: _fetch.Request = new _fetch.Request("http://www.andlabs.net/html5/uCOR.php", requestOptions);
 	handlePromise(fetch(request));
 }
 
@@ -48,7 +48,7 @@ function test_globalFetchVar() {
 		});
 }
 
-function handlePromise(promise: Promise<Response>) {
+function handlePromise(promise: Promise<_fetch.Response>) {
 	promise.then((response) => {
 		if (response.type === 'basic') {
 			// for test only

--- a/node-fetch/node-fetch.d.ts
+++ b/node-fetch/node-fetch.d.ts
@@ -1,7 +1,6 @@
-﻿// Type definitions for fetch API
-// Project: https://github.com/github/fetch
-// Definitions by: Torsten Werner <https://github.com/torstenwerner> based on whatwg-fetch
-// that was created by: Ryan Graham <https://github.com/ryan-codingintrigue>
+﻿// Type definitions for node-fetch based on whatwg-fetch
+// Project: https://github.com/bitinn/node-fetch
+// Definitions by: Torsten Werner <https://github.com/torstenwerner>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare class Request extends Body {

--- a/node-fetch/node-fetch.d.ts
+++ b/node-fetch/node-fetch.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Torsten Werner <https://github.com/torstenwerner>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'node-fetch' {
+declare module _fetch {
 
 	class Request extends Body {
 		constructor(input: string | Request, init?: RequestInit);
@@ -88,5 +88,8 @@ declare module 'node-fetch' {
 	type RequestInfo = Request | string;
 
     function fetch(url: string | Request, init?: RequestInit): Promise<Response>;
-    export = fetch;
+}
+
+declare module "node-fetch" {
+	export = _fetch.fetch;
 }

--- a/node-fetch/node-fetch.d.ts
+++ b/node-fetch/node-fetch.d.ts
@@ -3,89 +3,90 @@
 // Definitions by: Torsten Werner <https://github.com/torstenwerner>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare class Request extends Body {
-	constructor(input: string|Request, init?:RequestInit);
-	method: string;
-	url: string;
-	headers: Headers;
-	context: RequestContext;
-	referrer: string;
-	mode: RequestMode;
-	redirect: RequestRedirect;
-	credentials: RequestCredentials;
-	cache: RequestCache;
-}
-
-interface RequestInit {
-	method?: string;
-	headers?: HeaderInit|{ [index: string]: string };
-	body?: BodyInit;
-	mode?: RequestMode;
-	redirect?: RequestRedirect;
-	credentials?: RequestCredentials;
-	cache?: RequestCache;
-}
-
-type RequestContext =
-	"audio" | "beacon" | "cspreport" | "download" | "embed" |
-	"eventsource" | "favicon" | "fetch" | "font" | "form" | "frame" |
-	"hyperlink" | "iframe" | "image" | "imageset" | "import" |
-	"internal" | "location" | "manifest" | "object" | "ping" | "plugin" |
-	"prefetch" | "script" | "serviceworker" | "sharedworker" |
-	"subresource" | "style" | "track" | "video" | "worker" |
-	"xmlhttprequest" | "xslt";
-type RequestMode = "same-origin" | "no-cors" | "cors";
-type RequestRedirect = "follow" | "error" | "manual";
-type RequestCredentials = "omit" | "same-origin" | "include";
-type RequestCache =
-	"default" | "no-store" | "reload" | "no-cache" |
-	"force-cache" | "only-if-cached";
-
-declare class Headers {
-	append(name: string, value: string): void;
-	delete(name: string):void;
-	get(name: string): string;
-	getAll(name: string): Array<string>;
-	has(name: string): boolean;
-	set(name: string, value: string): void;
-	forEach(callback: (value: string, name: string) => void): void;
-}
-
-declare class Body {
-	bodyUsed: boolean;
-	arrayBuffer(): Promise<ArrayBuffer>;
-	blob(): Promise<Blob>;
-	formData(): Promise<FormData>;
-	json(): Promise<any>;
-	json<T>(): Promise<T>;
-	text(): Promise<string>;
-}
-declare class Response extends Body {
-	constructor(body?: BodyInit, init?: ResponseInit);
-	static error(): Response;
-	static redirect(url: string, status: number): Response;
-	type: ResponseType;
-	url: string;
-	status: number;
-	ok: boolean;
-	statusText: string;
-	headers: Headers;
-	clone(): Response;
-}
-
-type ResponseType = "basic" | "cors" | "default" | "error" | "opaque" | "opaqueredirect";
-
-interface ResponseInit {
-	status: number;
-	statusText?: string;
-	headers?: HeaderInit;
-}
-
-declare type HeaderInit = Headers|Array<string>;
-declare type BodyInit = ArrayBuffer|ArrayBufferView|Blob|FormData|string;
-declare type RequestInfo = Request|string;
-
 declare module 'node-fetch' {
+
+	class Request extends Body {
+		constructor(input: string | Request, init?: RequestInit);
+		method: string;
+		url: string;
+		headers: Headers;
+		context: RequestContext;
+		referrer: string;
+		mode: RequestMode;
+		redirect: RequestRedirect;
+		credentials: RequestCredentials;
+		cache: RequestCache;
+	}
+
+	interface RequestInit {
+		method?: string;
+		headers?: HeaderInit | { [index: string]: string };
+		body?: BodyInit;
+		mode?: RequestMode;
+		redirect?: RequestRedirect;
+		credentials?: RequestCredentials;
+		cache?: RequestCache;
+	}
+
+	type RequestContext =
+		"audio" | "beacon" | "cspreport" | "download" | "embed" |
+		"eventsource" | "favicon" | "fetch" | "font" | "form" | "frame" |
+		"hyperlink" | "iframe" | "image" | "imageset" | "import" |
+		"internal" | "location" | "manifest" | "object" | "ping" | "plugin" |
+		"prefetch" | "script" | "serviceworker" | "sharedworker" |
+		"subresource" | "style" | "track" | "video" | "worker" |
+		"xmlhttprequest" | "xslt";
+	type RequestMode = "same-origin" | "no-cors" | "cors";
+	type RequestRedirect = "follow" | "error" | "manual";
+	type RequestCredentials = "omit" | "same-origin" | "include";
+	type RequestCache =
+		"default" | "no-store" | "reload" | "no-cache" |
+		"force-cache" | "only-if-cached";
+
+	class Headers {
+		append(name: string, value: string): void;
+		delete(name: string): void;
+		get(name: string): string;
+		getAll(name: string): Array<string>;
+		has(name: string): boolean;
+		set(name: string, value: string): void;
+		forEach(callback: (value: string, name: string) => void): void;
+	}
+
+	class Body {
+		bodyUsed: boolean;
+		arrayBuffer(): Promise<ArrayBuffer>;
+		blob(): Promise<Blob>;
+		formData(): Promise<FormData>;
+		json(): Promise<any>;
+		json<T>(): Promise<T>;
+		text(): Promise<string>;
+	}
+	class Response extends Body {
+		constructor(body?: BodyInit, init?: ResponseInit);
+		static error(): Response;
+		static redirect(url: string, status: number): Response;
+		type: ResponseType;
+		url: string;
+		status: number;
+		ok: boolean;
+		statusText: string;
+		headers: Headers;
+		clone(): Response;
+	}
+
+	type ResponseType = "basic" | "cors" | "default" | "error" | "opaque" | "opaqueredirect";
+
+	interface ResponseInit {
+		status: number;
+		statusText?: string;
+		headers?: HeaderInit;
+	}
+
+	type HeaderInit = Headers | Array<string>;
+	type BodyInit = ArrayBuffer | ArrayBufferView | Blob | FormData | string;
+	type RequestInfo = Request | string;
+
     function fetch(url: string | Request, init?: RequestInit): Promise<Response>;
     export = fetch;
 }

--- a/node-fetch/node-fetch.d.ts
+++ b/node-fetch/node-fetch.d.ts
@@ -1,0 +1,91 @@
+﻿// Type definitions for fetch API
+// Project: https://github.com/github/fetch
+// Definitions by: Ryan Graham <https://github.com/ryan-codingintrigue>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare class Request extends Body {
+	constructor(input: string|Request, init?:RequestInit);
+	method: string;
+	url: string;
+	headers: Headers;
+	context: RequestContext;
+	referrer: string;
+	mode: RequestMode;
+	redirect: RequestRedirect;
+	credentials: RequestCredentials;
+	cache: RequestCache;
+}
+
+interface RequestInit {
+	method?: string;
+	headers?: HeaderInit|{ [index: string]: string };
+	body?: BodyInit;
+	mode?: RequestMode;
+	redirect?: RequestRedirect;
+	credentials?: RequestCredentials;
+	cache?: RequestCache;
+}
+
+type RequestContext =
+	"audio" | "beacon" | "cspreport" | "download" | "embed" |
+	"eventsource" | "favicon" | "fetch" | "font" | "form" | "frame" |
+	"hyperlink" | "iframe" | "image" | "imageset" | "import" |
+	"internal" | "location" | "manifest" | "object" | "ping" | "plugin" |
+	"prefetch" | "script" | "serviceworker" | "sharedworker" |
+	"subresource" | "style" | "track" | "video" | "worker" |
+	"xmlhttprequest" | "xslt";
+type RequestMode = "same-origin" | "no-cors" | "cors";
+type RequestRedirect = "follow" | "error" | "manual";
+type RequestCredentials = "omit" | "same-origin" | "include";
+type RequestCache =
+	"default" | "no-store" | "reload" | "no-cache" |
+	"force-cache" | "only-if-cached";
+
+declare class Headers {
+	append(name: string, value: string): void;
+	delete(name: string):void;
+	get(name: string): string;
+	getAll(name: string): Array<string>;
+	has(name: string): boolean;
+	set(name: string, value: string): void;
+	forEach(callback: (value: string, name: string) => void): void;
+}
+
+declare class Body {
+	bodyUsed: boolean;
+	arrayBuffer(): Promise<ArrayBuffer>;
+	blob(): Promise<Blob>;
+	formData(): Promise<FormData>;
+	json(): Promise<any>;
+	json<T>(): Promise<T>;
+	text(): Promise<string>;
+}
+declare class Response extends Body {
+	constructor(body?: BodyInit, init?: ResponseInit);
+	static error(): Response;
+	static redirect(url: string, status: number): Response;
+	type: ResponseType;
+	url: string;
+	status: number;
+	ok: boolean;
+	statusText: string;
+	headers: Headers;
+	clone(): Response;
+}
+
+type ResponseType = "basic" | "cors" | "default" | "error" | "opaque" | "opaqueredirect";
+
+interface ResponseInit {
+	status: number;
+	statusText?: string;
+	headers?: HeaderInit;
+}
+
+declare type HeaderInit = Headers|Array<string>;
+declare type BodyInit = ArrayBuffer|ArrayBufferView|Blob|FormData|string;
+declare type RequestInfo = Request|string;
+
+declare module 'node-fetch' {
+    function fetch(url: string | Request, init?: RequestInit): Promise<Response>;
+    export = fetch;
+}

--- a/node-fetch/node-fetch.d.ts
+++ b/node-fetch/node-fetch.d.ts
@@ -1,6 +1,7 @@
 ﻿// Type definitions for fetch API
 // Project: https://github.com/github/fetch
-// Definitions by: Ryan Graham <https://github.com/ryan-codingintrigue>
+// Definitions by: Torsten Werner <https://github.com/torstenwerner> based on whatwg-fetch
+// that was created by: Ryan Graham <https://github.com/ryan-codingintrigue>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare class Request extends Body {


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

It is primarily a copy of whatwg-fetch with the idea from #8931 applied.
