### PR TITLE
Introducing combokeys typings.

### DIFF
--- a/combokeys/combokeys-tests.ts
+++ b/combokeys/combokeys-tests.ts
@@ -1,0 +1,33 @@
+
+///<reference path="combokeys.d.ts" />
+
+import Combokeys = require("combokeys");
+
+const combokeys1: Combokeys.Combokeys = new Combokeys(document.createElement('div'));
+const combokeys2: Combokeys.Combokeys = new Combokeys(document.createElement('div'));
+
+combokeys1.bind('ctrl+a', () => {});
+combokeys1.bind('ctrl+z', () => {}, 'keydown');
+combokeys1.bind(['ctrl+a', 'ctrl+shift+a'], () => {});
+combokeys1.bind(['ctrl+a', 'ctrl+shift+a'], () => {}, 'keyup');
+
+combokeys1.bindMultiple(['ctrl+a', 'ctrl+shift+a'], () => {});
+combokeys1.bindMultiple(['ctrl+a', 'ctrl+shift+a'], () => {}, 'keyup');
+
+const result: boolean = combokeys1.stopCallback(new Event(null), document.createElement('div'));
+
+combokeys1.unbind('ctrl+a');
+combokeys1.unbind('ctrl+a', 'keydown');
+combokeys1.unbind(['ctrl+a', 'ctrl+shift+a']);
+combokeys1.unbind(['ctrl+a', 'ctrl+shift+a'], 'keydown');
+
+combokeys1.trigger('ctrl+a');
+combokeys1.trigger('ctrl+a', 'keypress');
+
+combokeys1.reset();
+
+combokeys1.detach();
+
+Combokeys.reset();
+
+Combokeys.instances.forEach((combokeys: Combokeys.Combokeys) => combokeys.reset() );

--- a/combokeys/combokeys.d.ts
+++ b/combokeys/combokeys.d.ts
@@ -30,9 +30,9 @@ declare namespace Combokeys {
      * be sure to list the modifier keys first to make sure that the
      * correct key ends up getting bound (the last key in the pattern)
      *
-     * @param {keys} keys
-     * @param {callback} callback
-     * @param {handler} action - "keypress", "keydown", or "keyup"
+     * @param {keys} key combination or combinations
+     * @param {callback} callback function
+     * @param {handler} optional - one of "keypress", "keydown", or "keyup"
      * @returns void
      */
     bind(keys: string | string[], callback: () => void, action?: string): void;
@@ -41,9 +41,9 @@ declare namespace Combokeys {
     /**
      * binds multiple combinations to the same callback
      *
-     * @param {keys} combinations
-     * @param {callback} callback
-     * @param {handler} action
+     * @param {keys} key combinations
+     * @param {callback} callback function
+     * @param {handler} optional - one of "keypress", "keydown", or "keyup"
      * @returns void
      */
     bindMultiple(keys: string[], callback: () => void, action?: string): void;
@@ -58,8 +58,8 @@ declare namespace Combokeys {
      * the keycombo+action has to be exactly the same as
      * it was defined in the bind method
      *
-     * @param {keys} keys
-     * @param {action} action
+     * @param {keys} key combination or combinations
+     * @param {action} optional - one of "keypress", "keydown", or "keyup"
      * @returns void
      */
     unbind(keys: string | string[], action?: string): void;
@@ -67,8 +67,8 @@ declare namespace Combokeys {
     /**
      * triggers an event that has already been bound
      *
-     * @param {keys} keys
-     * @param {action} action
+     * @param {keys} key combination
+     * @param {action} optional - one of "keypress", "keydown", or "keyup"
      * @returns void
      */
     trigger(keys: string, action?: string): void;
@@ -86,7 +86,7 @@ declare namespace Combokeys {
      * should we stop this event before firing off callbacks
      *
      * @param {e} event
-     * @param {element} element
+     * @param {element} bound element
      * @return {boolean}
      */
     stopCallback(e: Event, element: Element): boolean;

--- a/combokeys/combokeys.d.ts
+++ b/combokeys/combokeys.d.ts
@@ -1,0 +1,107 @@
+// Type definitions for Combokeys v2.4.6
+// Project: https://github.com/PolicyStat/combokeys
+// Definitions by: Ian Clanton-Thuon <https://github.com/iclanton>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace Combokeys {
+  interface CombokeysStatic {
+    new (element: Element): Combokeys;
+
+    /**
+     * all instances of Combokeys
+     */
+    instances: Combokeys[];
+
+    /**
+     * reset all instances
+     */
+    reset(): void;
+  }
+
+  interface Combokeys {
+    element: Element;
+
+    /**
+     * binds an event to Combokeys
+     *
+     * can be a single key, a combination of keys separated with +,
+     * an array of keys, or a sequence of keys separated by spaces
+     *
+     * be sure to list the modifier keys first to make sure that the
+     * correct key ends up getting bound (the last key in the pattern)
+     *
+     * @param {keys} keys
+     * @param {callback} callback
+     * @param {handler} action - "keypress", "keydown", or "keyup"
+     * @returns void
+     */
+    bind(keys: string | string[], callback: () => void, action?: string): void;
+
+
+    /**
+     * binds multiple combinations to the same callback
+     *
+     * @param {keys} combinations
+     * @param {callback} callback
+     * @param {handler} action
+     * @returns void
+     */
+    bindMultiple(keys: string[], callback: () => void, action?: string): void;
+
+    /**
+     * unbinds an event to Combokeys
+     *
+     * the unbinding sets the callback function of the specified key combo
+     * to an empty function and deletes the corresponding key in the
+     * directMap dict.
+     *
+     * the keycombo+action has to be exactly the same as
+     * it was defined in the bind method
+     *
+     * @param {keys} keys
+     * @param {action} action
+     * @returns void
+     */
+    unbind(keys: string | string[], action?: string): void;
+
+    /**
+     * triggers an event that has already been bound
+     *
+     * @param {keys} keys
+     * @param {action} action
+     * @returns void
+     */
+    trigger(keys: string, action?: string): void;
+
+    /**
+     * resets the library back to its initial state. This is useful
+     * if you want to clear out the current keyboard shortcuts and bind
+     * new ones - for example if you switch to another page
+     *
+     * @returns void
+     */
+    reset(): void;
+
+    /**
+     * should we stop this event before firing off callbacks
+     *
+     * @param {e} event
+     * @param {element} element
+     * @return {boolean}
+     */
+    stopCallback(e: Event, element: Element): boolean;
+
+    /**
+     * detach all listners from the bound element
+     *
+     * @return {void}
+     */
+    detach(): void;
+  }
+}
+
+declare var combokeys: Combokeys.CombokeysStatic;
+
+declare module "combokeys" {
+  export = combokeys;
+}

--- a/combokeys/combokeys.d.ts
+++ b/combokeys/combokeys.d.ts
@@ -4,104 +4,104 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace Combokeys {
-  interface CombokeysStatic {
-    new (element: Element): Combokeys;
+    interface CombokeysStatic {
+        new (element: Element): Combokeys;
 
-    /**
-     * all instances of Combokeys
-     */
-    instances: Combokeys[];
+        /**
+         * all instances of Combokeys
+         */
+        instances: Combokeys[];
 
-    /**
-     * reset all instances
-     */
-    reset(): void;
-  }
+        /**
+         * reset all instances
+         */
+        reset(): void;
+    }
 
-  interface Combokeys {
-    element: Element;
+    interface Combokeys {
+        element: Element;
 
-    /**
-     * binds an event to Combokeys
-     *
-     * can be a single key, a combination of keys separated with +,
-     * an array of keys, or a sequence of keys separated by spaces
-     *
-     * be sure to list the modifier keys first to make sure that the
-     * correct key ends up getting bound (the last key in the pattern)
-     *
-     * @param {keys} key combination or combinations
-     * @param {callback} callback function
-     * @param {handler} optional - one of "keypress", "keydown", or "keyup"
-     * @returns void
-     */
-    bind(keys: string | string[], callback: () => void, action?: string): void;
+        /**
+         * binds an event to Combokeys
+         *
+         * can be a single key, a combination of keys separated with +,
+         * an array of keys, or a sequence of keys separated by spaces
+         *
+         * be sure to list the modifier keys first to make sure that the
+         * correct key ends up getting bound (the last key in the pattern)
+         *
+         * @param {keys} key combination or combinations
+         * @param {callback} callback function
+         * @param {handler} optional - one of "keypress", "keydown", or "keyup"
+         * @returns void
+         */
+        bind(keys: string | string[], callback: () => void, action?: string): void;
 
 
-    /**
-     * binds multiple combinations to the same callback
-     *
-     * @param {keys} key combinations
-     * @param {callback} callback function
-     * @param {handler} optional - one of "keypress", "keydown", or "keyup"
-     * @returns void
-     */
-    bindMultiple(keys: string[], callback: () => void, action?: string): void;
+        /**
+         * binds multiple combinations to the same callback
+         *
+         * @param {keys} key combinations
+         * @param {callback} callback function
+         * @param {handler} optional - one of "keypress", "keydown", or "keyup"
+         * @returns void
+         */
+        bindMultiple(keys: string[], callback: () => void, action?: string): void;
 
-    /**
-     * unbinds an event to Combokeys
-     *
-     * the unbinding sets the callback function of the specified key combo
-     * to an empty function and deletes the corresponding key in the
-     * directMap dict.
-     *
-     * the keycombo+action has to be exactly the same as
-     * it was defined in the bind method
-     *
-     * @param {keys} key combination or combinations
-     * @param {action} optional - one of "keypress", "keydown", or "keyup"
-     * @returns void
-     */
-    unbind(keys: string | string[], action?: string): void;
+        /**
+         * unbinds an event to Combokeys
+         *
+         * the unbinding sets the callback function of the specified key combo
+         * to an empty function and deletes the corresponding key in the
+         * directMap dict.
+         *
+         * the keycombo+action has to be exactly the same as
+         * it was defined in the bind method
+         *
+         * @param {keys} key combination or combinations
+         * @param {action} optional - one of "keypress", "keydown", or "keyup"
+         * @returns void
+         */
+        unbind(keys: string | string[], action?: string): void;
 
-    /**
-     * triggers an event that has already been bound
-     *
-     * @param {keys} key combination
-     * @param {action} optional - one of "keypress", "keydown", or "keyup"
-     * @returns void
-     */
-    trigger(keys: string, action?: string): void;
+        /**
+         * triggers an event that has already been bound
+         *
+         * @param {keys} key combination
+         * @param {action} optional - one of "keypress", "keydown", or "keyup"
+         * @returns void
+         */
+        trigger(keys: string, action?: string): void;
 
-    /**
-     * resets the library back to its initial state. This is useful
-     * if you want to clear out the current keyboard shortcuts and bind
-     * new ones - for example if you switch to another page
-     *
-     * @returns void
-     */
-    reset(): void;
+        /**
+         * resets the library back to its initial state. This is useful
+         * if you want to clear out the current keyboard shortcuts and bind
+         * new ones - for example if you switch to another page
+         *
+         * @returns void
+         */
+        reset(): void;
 
-    /**
-     * should we stop this event before firing off callbacks
-     *
-     * @param {e} event
-     * @param {element} bound element
-     * @return {boolean}
-     */
-    stopCallback(e: Event, element: Element): boolean;
+        /**
+         * should we stop this event before firing off callbacks
+         *
+         * @param {e} event
+         * @param {element} bound element
+         * @return {boolean}
+         */
+        stopCallback(e: Event, element: Element): boolean;
 
-    /**
-     * detach all listners from the bound element
-     *
-     * @return {void}
-     */
-    detach(): void;
-  }
+        /**
+         * detach all listners from the bound element
+         *
+         * @return {void}
+         */
+        detach(): void;
+    }
 }
 
 declare var combokeys: Combokeys.CombokeysStatic;
 
 declare module "combokeys" {
-  export = combokeys;
+    export = combokeys;
 }


### PR DESCRIPTION
- [X] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [X] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
