### PR TITLE
Fix declaration for 'denodeify' method in npm module 'promise'

### DIFF
--- a/promise/promise-tests.ts
+++ b/promise/promise-tests.ts
@@ -19,3 +19,9 @@ var prom3 = Promise.all([prom, prom2]);
 prom3.then((resolve: Array<any>) => {
 
 });
+
+function withCallback(arg: any, cb: (e: Error, result: any) => void): void {
+	cb(null, arg);
+}
+var prom4 = Promise.denodeify(withCallback);
+prom4('test').then(result => result);

--- a/promise/promise.d.ts
+++ b/promise/promise.d.ts
@@ -18,7 +18,7 @@ declare namespace Promise {
 		resolve: <T>(value: T) => IThenable<T>;
 		reject: <T>(value: T) => IThenable<T>;
 		all: (array: Array<IThenable<any>>) => IThenable<Array<any>>;
-		denodeify: (fn: Function) => IThenable<any>;
+		denodeify: (fn: Function) => (...args: any[]) => IThenable<any>;
 		nodeify: (fn: Function) => Function;
 	}
 


### PR DESCRIPTION
Documentation for the fixed method: https://github.com/then/promise#promisedenodeifyfn

Current declaration is missing the fact that the result is not directly a Promise, _but_ a Function that will return a Promise.

Also added a test for the fixed method.
