### PR TITLE
react.d.ts: add <foreignObject/> to JSX

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -2455,6 +2455,7 @@ declare namespace JSX {
         clipPath: React.SVGProps;
         defs: React.SVGProps;
         ellipse: React.SVGProps;
+        foreignObject: React.SVGProps;
         g: React.SVGProps;
         image: React.SVGProps;
         line: React.SVGProps;


### PR DESCRIPTION
case 2. Improvement to existing type definition. fixes #9481
- https://github.com/facebook/react/issues/1657
