### PR TITLE
Typing Location.Query to K,V dictionary

### DIFF
--- a/react-router/history.d.ts
+++ b/react-router/history.d.ts
@@ -90,7 +90,7 @@ declare namespace HistoryModule {
 
     type Pathname = string
 
-    type Query = Object
+    type Query = { [key: string]: string; }
 
     type QueryString = string
 

--- a/react-router/history.d.ts
+++ b/react-router/history.d.ts
@@ -90,7 +90,7 @@ declare namespace HistoryModule {
 
     type Pathname = string
 
-    type Query = { [key: string]: string; }
+    type Query = { [key: string]: any; }
 
     type QueryString = string
 


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Location.Query is actually typed as 'Object', which forces to cast it to 'any' anytime you need to access one of your own query string parameter.

```
const clientId = (this.props.location.query as any).clientId;
```

It should be typed as '{ [key: string]: string; }' since it's a dictionary where you can get your arbitrary named query string parameters.
