### PR TITLE
Remove the dependency on MediaStream from Chrome.

### DIFF
--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -3,7 +3,6 @@
 // Definitions by: Matthew Kimber <https://github.com/matthewkimber>, otiai10 <https://github.com/otiai10>, couven92 <https://gitbus.com/couven92>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-/// <reference path='../webrtc/MediaStream.d.ts'/>
 /// <reference path='../filesystem/filesystem.d.ts' />
 
 ////////////////////


### PR DESCRIPTION
MediaStream & Co are available in TypeScript 1.9's lib.d.ts (or
lib.dom.d.ts etc.), so there's no need to reference them anymore.

See here: https://github.com/Microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L8426
