### PR TITLE
getComponent/getComponents now takes state parameter instead of location

### DIFF
--- a/react-router/react-router.d.ts
+++ b/react-router/react-router.d.ts
@@ -144,8 +144,8 @@ declare namespace ReactRouter {
         path?: RoutePattern
         component?: RouteComponent
         components?: RouteComponents
-        getComponent?: (location: H.Location, cb: (error: any, component?: RouteComponent) => void) => void
-        getComponents?: (location: H.Location, cb: (error: any, components?: RouteComponents) => void) => void
+        getComponent?: (nextState: RouterState, cb: (error: any, component?: RouteComponent) => void) => void
+        getComponents?: (nextState: RouterState, cb: (error: any, components?: RouteComponents) => void) => void
         onEnter?: EnterHook
         onLeave?: LeaveHook
         onChange?: ChangeHook


### PR DESCRIPTION
See
https://github.com/reactjs/react-router/commit/0cdee03a54aeb79f7c7e35628e3ba58bde54e2bd
