### PR TITLE
fixes some type parameters

### DIFF
--- a/knockout.es5/knockout.es5.d.ts
+++ b/knockout.es5/knockout.es5.d.ts
@@ -6,10 +6,10 @@
 /// <reference path="../knockout/knockout.d.ts" />
 
 interface KnockoutStatic {
-    track(obj: any, propertyNames?: Array<string>): any;
-    untrack(obj: any, propertyNames?: Array<string>): any;
-    defineProperty(obj: any, propertyName: string, evaluator: Function): any;
-    defineProperty(obj: any, propertyName: string, options: KnockoutDefinePropertyOptions): any;
+    track<T>(obj: T, propertyNames?: Array<string>): T;
+    untrack(obj: any, propertyNames?: Array<string>): void;
+    defineProperty<T>(obj: T, propertyName: string, evaluator: Function): T;
+    defineProperty<T>(obj: T, propertyName: string, options: KnockoutDefinePropertyOptions): T;
     getObservable(obj: any, propertyName: string): KnockoutObservable<any>;
     valueHasMutated(obj: any, propertyName: string): void;
 }


### PR DESCRIPTION
track and defineproperty now use generic types instead of any
fixed untrack, doesn't return anything

Looked up the behaviour directly from the source: https://github.com/SteveSanderson/knockout-es5/blob/master/src/knockout-es5.js
