### PR TITLE
fix Sequelize.FindOptions to be able to use Sequelize.cast in arguments

### DIFF
--- a/sequelize/sequelize-tests.ts
+++ b/sequelize/sequelize-tests.ts
@@ -888,10 +888,12 @@ User.findAll( { include : [User], order : [['id', 'ASC NULLS LAST'], [User, 'id'
 User.findAll( { include : [{ model : User, where : { title : 'DoDat' }, include : [{ model : User }] }] } );
 User.findAll( { attributes: ['username', 'data']});
 User.findAll( { attributes: {include: ['username', 'data']} });
-User.findAll( { attributes: [['username', 'UNM'], ['email', 'EML']] });
+User.findAll( { attributes: [['username', 'user_name'], ['email', 'user_email']] });
 User.findAll( { attributes: [s.fn('count', Sequelize.col('*'))] });
 User.findAll( { attributes: [[s.fn('count', Sequelize.col('*')), 'count']] });
 User.findAll( { attributes: [[s.fn('count', Sequelize.col('*')), 'count']], group: ['sex'] });
+User.findAll( { attributes: [s.cast(s.fn('count', Sequelize.col('*')), 'INTEGER')] });
+User.findAll( { attributes: [[s.cast(s.fn('count', Sequelize.col('*')), 'INTEGER'), 'count']] });
 
 User.findById( 'a string' );
 

--- a/sequelize/sequelize.d.ts
+++ b/sequelize/sequelize.d.ts
@@ -3116,16 +3116,21 @@ declare module "sequelize" {
         }
 
         /**
+         * Shortcut for types used in FindOptions.attributes
+         */
+		type FindOptionsAttriburesArray = Array<string | [string, string] | fn | [fn, string] | cast | [cast, string]>;
+
+        /**
          * Options that are passed to any model creating a SELECT query
          *
          * A hash of options to describe the scope of the search
          */
-        interface FindOptions {
+		interface FindOptions {
 
             /**
              * A hash of attributes to describe your search. See above for examples.
              */
-            where? : WhereOptions | Array<col | and | or | string>;
+            where?: WhereOptions | Array<col | and | or | string>;
 
             /**
              * A list of the attributes that you want to select. To rename an attribute, you can pass an array, with
@@ -3133,7 +3138,7 @@ declare module "sequelize" {
              * `Sequelize.literal`, `Sequelize.fn` and so on), and the second is the name you want the attribute to
              * have in the returned instance
              */
-            attributes?: Array<string | fn | [string, string] | [fn, string]> | { include?: Array<string>, exclude?: Array<string> };
+            attributes?: FindOptionsAttriburesArray | { include?: FindOptionsAttriburesArray, exclude?: Array<string> };
 
             /**
              * If true, only non-deleted records will be returned. If false, both deleted and non-deleted records will


### PR DESCRIPTION
Improvement to existing type definition.

Sequelize.FindOptions.attributes supports Sequelize.cast as arguments
