### PR TITLE
add overload for html function to allow a JQuery object

### DIFF
--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -2189,6 +2189,8 @@ function test_html() {
     $("div").html("<b>Wow!</b> Such excitement...");
     $("div b").append(document.createTextNode("!!!"))
               .css("color", "red");
+    var testObject = $(".test");
+    $('div.demo-container').html(testObject);
 }
 
 function test_inArray() {

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -1282,6 +1282,12 @@ interface JQuery {
      * @param htmlString A string of HTML to set as the content of each matched element.
      */
     html(htmlString: string): JQuery;
+     /**
+     * Set the HTML contents of each element in the set of matched elements.
+     *
+     * @param jQueryObject A JQuery Object to set as the content of each matched element.
+     */
+    html(jQueryObject: JQuery): JQuery;
     /**
      * Set the HTML contents of each element in the set of matched elements.
      *


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

This pull request adds an overload for the html() function to allow a JQuery object. tested with jQuery 1.12.4 and 2.2.4
