### PR TITLE
react-select: Fix definition of loadOptions-callback

### DIFF
--- a/react-select/react-select.d.ts
+++ b/react-select/react-select.d.ts
@@ -7,6 +7,16 @@
 
 declare namespace ReactSelect {
 
+    interface AutocompleteResult {
+        /** the search-results to be displayed  */
+        data: Option[],
+        /** Should be set to true, if and only if a longer query with the same prefix
+         * would return a subset of the results
+         * If set to true, more specific queries will not be sent to the server.
+         **/
+        complete: boolean;
+    }
+
     interface Option {
         /** Text for rendering */
         label: string;
@@ -359,7 +369,7 @@ declare namespace ReactSelect {
         /**
          *  function to call to load options asynchronously
          */
-        loadOptions: (input: string, callback: (options: Option[]) => any) => any;
+        loadOptions: (input: string, callback: (err: any, result: AutocompleteResult) => any) => any;
 
         /**
          *  replaces the placeholder while options are loading


### PR DESCRIPTION
I made two changes:
### Adding the second parameter

LoadOptions is called here with the value of the responseHandler-Variable:
https://github.com/JedWatson/react-select/blob/74e0f08/src/Async.js#L138

The implementation of that function is here:
https://github.com/JedWatson/react-select/blob/74e0f08/src/Async.js#L102

It's very obvious that this function needs two parameters.

Ironically, your test-code already [does this correctly](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a50c292dc12df1c1dab62795c2bba83a79921ee0/react-select/react-select-tests.tsx#L126), but only by throwing away type-definitions. Should I fix that too, and make it more specific?
### The data-parameter

See [their readme.md#async-options](https://github.com/JedWatson/react-select/tree/74e0f0867f1a2338070a07bcfc0bb452fa80dbc4#async-options)

The also matches the expected variables in the code.
