### PR TITLE
making Connection.close() get optional arguments

### DIFF
--- a/autobahn/autobahn.d.ts
+++ b/autobahn/autobahn.d.ts
@@ -181,7 +181,7 @@ declare namespace autobahn {
 
         open(): void;
 
-        close(reason: string, message: string): void;
+        close(reason?: string, message?: string): void;
 
         onopen: (session: Session, details: any) => void;
         onclose: (reason: string, details: any) => boolean;


### PR DESCRIPTION
Improvement to existing type definition.
as written by the Autobahn API Reference:
[http://autobahn.ws/js/reference.html#connection-methods]
