### PR TITLE
Fixed codemirror gutterMarkers. Was gutterMarks, should have been gut…

### DIFF
--- a/codemirror/codemirror.d.ts
+++ b/codemirror/codemirror.d.ts
@@ -181,7 +181,7 @@ declare namespace CodeMirror {
             handle: any;
             text: string;
             /** Object mapping gutter IDs to marker elements. */
-            gutterMarks: any;
+            gutterMarkers: any;
             textClass: string;
             bgClass: string;
             wrapClass: string;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

The gutterMarkers attribute of CodeMirror's lineinfo type was mis-named. The typings file had it as "gutterMarks", while the actual field is named "gutterMarkers".
