### PR TITLE
declare module

### DIFF
--- a/tween.js/tween.js.d.ts
+++ b/tween.js/tween.js.d.ts
@@ -98,3 +98,7 @@ interface TweenInterpolation {
     Factorial(n:number): number;
   };
 }
+
+declare module 'tween.js' {
+  export = TWEEN;
+}


### PR DESCRIPTION
file `tween.js/index.d.ts` missing `declare module 'tween.js'{...}`, so outputs `error TS2307: Cannot find module 'tween.js'`
