### PR TITLE
Update and correct Web MIDI API typings

### DIFF
--- a/webmidi/webmidi-tests.ts
+++ b/webmidi/webmidi-tests.ts
@@ -20,38 +20,17 @@ var onSuccessCallback = (item: WebMidi.MIDIAccess)=>{
     console.log("sysexenabled");
     console.log(item.sysexEnabled);
 
-    /*
-     console.log(item.inputs.get("701435409"));
-     console.log(item.inputs.has("701435409"));
-     console.log(item.inputs.keys());
-     console.log(item.inputs.keys().next());
-     console.log(item.inputs.values());
-     var inputs = this._midiPort.inputs.values();
-     console.log(this._midiPort.inputs.entries().next());
-     console.log(this._midiPort.inputs.entries().next().done);
-     */
-
     var inputs = this._midiPort.inputs.values();
 
-    /*
-     console.log(item.outputs.get("384570428"));
-     console.log(item.outputs.has("384570428"));
-     console.log(item.outputs.keys());
-     console.log(item.outputs.keys().next());
-     console.log(item.outputs.values());
-     console.log(this._midiPort.outputs.entries().next());
-     console.log(this._midiPort.outputs.entries().next().done);
-     */
-
-    for(var o = inputs.next(); !o.done; o = inputs.next()){
-        this._inputs.push(o.value);
-        console.log(o.value);
+    for(const o of inputs){
+        this._inputs.push(o);
+        console.log(o);
     }
 
     var outputs = item.outputs.values();
-    for(var op = outputs.next(); !op.done; op = outputs.next()){
-        this._outputs.push(op.value);
-        op.value.send([ 0x90, 0x45, 0x7f ] );
+    for(const op of outputs){
+        this._outputs.push(op);
+        op.send([ 0x90, 0x45, 0x7f ] );
     }
 
     for(var cnt = 0; cnt < this._inputs.length; cnt++){

--- a/webmidi/webmidi-tests.ts
+++ b/webmidi/webmidi-tests.ts
@@ -1,19 +1,10 @@
 /// <reference path="webmidi.d.ts" />
 
-if (navigator.requestMIDIAccess !== undefined) {
-    navigator.requestMIDIAccess().then(onSuccessCallback, onErrorCallback);
-}
-
-var onSuccessCallback = (item: WebMidi.MIDIAccess)=>{
+var onFulfilled = (item: WebMidi.MIDIAccess) => {
     this._midiPort = item;
 
-    item.onconnect = (event: WebMidi.MIDIConnectionEvent)=>{
-        console.log("onconnect");
-        console.log(event);
-    };
-
-    item.ondisconnect = (event: WebMidi.MIDIConnectionEvent)=>{
-        console.log("ondisconnect");
+    item.onstatechange = (event : WebMidi.MIDIConnectionEvent) => {
+        console.log("onstatechange");
         console.log(event);
     };
 
@@ -40,8 +31,8 @@ var onSuccessCallback = (item: WebMidi.MIDIAccess)=>{
     }
 };
 
-var onErrorCallback = (access: Error)=>{ };
+var onRejected = (e: Error)=>{ console.error(e) };
 
-var onMidiMessage = (event: Uint8Array)=>{
-    console.log(event);
-};
+if (navigator.requestMIDIAccess !== undefined) {
+    navigator.requestMIDIAccess().then(onFulfilled, onRejected);
+}

--- a/webmidi/webmidi.d.ts
+++ b/webmidi/webmidi.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Web MIDI API
 // Project: http://www.w3.org/TR/webmidi/
-// Definitions by: Toshiya Nakakura <https://github.com/nakakura>
+// Definitions by: six a <https://github.com/lostfictions>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface Navigator {
@@ -19,28 +19,14 @@ declare namespace WebMidi{
         sysex: boolean;
     }
 
-    export interface IteratorItem<S>{
-        value: S;
-        done: boolean;
-    }
-
-    export interface Iterator<S>{
-        next(): IteratorItem<S>;
-    }
-
-    interface Tuple2<A,B> {
-        fst: A
-        snd: B
-    }
-
     /**
      * This type is used to represent all the currently available MIDI input ports as a MapClass-like interface
      */
     export interface MIDIInputMap{
         size: number;
-        keys: ()=>Iterator<string>;
-        entries: ()=>Iterator<Tuple2<string, MIDIInput>>;
-        values(): Iterator<MIDIInput>;
+        keys(): Iterable<string>;
+        values(): Iterable<MIDIInput>;
+        entries(): Iterable<[string, MIDIInput]>;
         get(key: string): MIDIInput;
         has(key: string): boolean;
     }
@@ -50,9 +36,9 @@ declare namespace WebMidi{
      */
     export interface MIDIOutputMap{
         size: number;
-        keys: ()=>Iterator<string>;
-        entries: ()=>Iterator<Tuple2<string, MIDIOutput>>;
-        values(): Iterator<MIDIOutput>;
+        keys(): Iterable<string>;
+        values(): Iterable<MIDIOutput>;
+        entries(): Iterable<[string, MIDIOutput]>;
         get(key: string): MIDIOutput;
         has(key: string): boolean;
     }

--- a/webmidi/webmidi.d.ts
+++ b/webmidi/webmidi.d.ts
@@ -4,111 +4,193 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface Navigator {
-    /**
-     * When invoked, returns a Promise object representing a request for access to MIDI devices on the user's system.
-     * @param options settings that may be provided to the requestMIDIAccess request.
-     */
-    requestMIDIAccess (options?: WebMidi.MidiOptions): Promise<WebMidi.MIDIAccess>;
+  /**
+   * When invoked, returns a Promise object representing a request for access to MIDI
+   * devices on the user's system.
+   */
+  requestMIDIAccess(options?: WebMidi.MIDIOptions) : Promise<WebMidi.MIDIAccess>;
 }
 
-declare namespace WebMidi{
+declare namespace WebMidi {
+  export interface MIDIOptions {
     /**
-     * optional settings that may be provided to the requestMIDIAccess request.
+     * This member informs the system whether the ability to send and receive system
+     * exclusive messages is requested or allowed on a given MIDIAccess object.
      */
-    export interface MidiOptions{
-        sysex: boolean;
-    }
+    sysex : boolean;
+  }
 
-    /**
-     * This type is used to represent all the currently available MIDI input ports as a MapClass-like interface
-     */
-    export interface MIDIInputMap{
-        size: number;
-        keys(): Iterable<string>;
-        values(): Iterable<MIDIInput>;
-        entries(): Iterable<[string, MIDIInput]>;
-        get(key: string): MIDIInput;
-        has(key: string): boolean;
-    }
+  /**
+   * This is a maplike interface whose value is a MIDIInput instance and key is its
+   * ID.
+   */
+  export type MIDIInputMap = Map<string, MIDIInput>;
 
+  /**
+   * This is a maplike interface whose value is a MIDIOutput instance and key is its
+   * ID.
+   */
+  export type MIDIOutputMap = Map<string, MIDIOutput>;
+
+  export interface MIDIAccess extends EventTarget {
     /**
-     * This type is used to represent all the currently available MIDI output ports as a MapClass-like interface.
+     * The MIDI input ports available to the system.
      */
-    export interface MIDIOutputMap{
-        size: number;
-        keys(): Iterable<string>;
-        values(): Iterable<MIDIOutput>;
-        entries(): Iterable<[string, MIDIOutput]>;
-        get(key: string): MIDIOutput;
-        has(key: string): boolean;
-    }
+    inputs : MIDIInputMap;
 
     /**
-     * This interface provides the methods to list MIDI input and output devices, and obtain access to an individual device.
+     * The MIDI output ports available to the system.
      */
-    export interface MIDIAccess extends EventTarget{
-        inputs: MIDIInputMap;
-        outputs: MIDIOutputMap;
-        onconnect: (event: MIDIConnectionEvent)=>void;
-        ondisconnect: (event: MIDIConnectionEvent)=>void;
-        sysexEnabled: boolean;
-    }
+    outputs : MIDIOutputMap;
 
     /**
-     * This interface represents a MIDI input or output port.
+     * The handler called when a new port is connected or an existing port changes the
+     * state attribute.
      */
-    export enum MIDIPortType{
-        input,
-        output
-    }
+    onstatechange : (e : MIDIConnectionEvent) => void;
 
     /**
-     * This interface represents a MIDI input or output port.
+     * This attribute informs the user whether system exclusive support is enabled on
+     * this MIDIAccess.
      */
-    export interface MIDIPort extends EventTarget {
-        id: string;
-        manufacture?: string;
-        name?: string;
-        type: MIDIPortType;
-        version?: string;
-        ondisconnect: Function;
-    }
+    sysexEnabled : boolean;
+  }
+
+  export type MIDIPortType = "input" | "output";
+
+  export type MIDIPortDeviceState = "disconnected" | "connected";
+
+  export type MIDIPortConnectionState = "open" | "closed" | "pending";
+
+  export interface MIDIPort extends EventTarget {
+    /**
+     * A unique ID of the port. This can be used by developers to remember ports the
+     * user has chosen for their application.
+     */
+    id : string;
 
     /**
-     * Interface for midi inputs
+     * The manufacturer of the port.
      */
-    export interface MIDIInput{
-        onmidimessage: (event: MIDIMessageEvent)=>void;
-    }
+    manufacturer? : string;
 
     /**
-     * Interface for midi outputs
+     * The system name of the port.
      */
-    export interface MIDIOutput{
-        send(data: Array<number>, timestamp?: number): void;
-    }
+    name? : string;
 
     /**
-     * An event object implementing this interface is passed to a MIDIInput's onmidimessage handler when MIDI messages are received.
+     * A descriptor property to distinguish whether the port is an input or an output
+     * port.
      */
-    export interface MIDIMessageEvent extends Event{
-        receivedTime: number;
-        data: Uint8Array;
-    }
-
-    export interface MIDIMessageEventInit{
-        receivedTime: number;
-        data: Uint8Array;
-    }
+    type : MIDIPortType;
 
     /**
-     * An event object implementing this interface is passed to a MIDIAccess' ondisconnect handler
+     * The version of the port.
      */
-    export interface MIDIConnectionEvent extends Event{
-        port: MIDIPort;
-    }
+    version? : string;
 
-    export interface MIDIConnectionEventInit{
-        port: MIDIPort;
-    }
+    /**
+     * The state of the device.
+     */
+    state : MIDIPortDeviceState;
+
+    /**
+     * The state of the connection to the device.
+     */
+    connection : MIDIPortConnectionState;
+
+    /**
+     * The handler called when an existing port changes its state or connection
+     * attributes.
+     */
+    onstatechange : (e : MIDIConnectionEvent) => void;
+
+    /**
+     * Makes the MIDI device corresponding to the MIDIPort explicitly available. Note
+     * that this call is NOT required in order to use the MIDIPort - calling send() on
+     * a MIDIOutput or attaching a MIDIMessageEvent handler on a MIDIInputPort will
+     * cause an implicit open().
+     *
+     * When invoked, this method returns a Promise object representing a request for
+     * access to the given MIDI port on the user's system.
+     */
+    open() : Promise<MIDIPort>;
+
+    /**
+     * Makes the MIDI device corresponding to the MIDIPort
+     * explicitly unavailable (subsequently changing the state from "open" to
+     * "connected"). Note that successful invocation of this method will result in MIDI
+     * messages no longer being delivered to MIDIMessageEvent handlers on a
+     * MIDIInputPort (although setting a new handler will cause an implicit open()).
+     *
+     * When invoked, this method returns a Promise object representing a request for
+     * access to the given MIDI port on the user's system. When the port has been
+     * closed (and therefore, in exclusive access systems, the port is available to
+     * other applications), the vended Promise is resolved. If the port is
+     * disconnected, the Promise is rejected.
+     */
+    close() : Promise<MIDIPort>;
+  }
+
+  export interface MIDIInput extends MIDIPort {
+    onmidimessage : (e : MIDIMessageEvent) => void;
+  }
+
+  export interface MIDIOutput extends MIDIPort {
+    /**
+     * Enqueues the message to be sent to the corresponding MIDI port.
+     * @param data The data to be enqueued, with each sequence entry representing a single byte of data.
+     * @param timestamp The time at which to begin sending the data to the port. If timestamp is set
+     * to zero (or another time in the past), the data is to be sent as soon as
+     * possible.
+     */
+    send(data : number[], timestamp? : number) : void;
+
+    /**
+     * Clears any pending send data that has not yet been sent from the MIDIOutput 's
+     * queue. The implementation will need to ensure the MIDI stream is left in a good
+     * state, so if the output port is in the middle of a sysex message, a sysex
+     * termination byte (0xf7) should be sent.
+     */
+    clear() : void;
+  }
+
+  export interface MIDIMessageEvent extends Event {
+    /**
+     * A timestamp specifying when the event occurred.
+     */
+    receivedTime : number;
+
+    /**
+     * A Uint8Array containing the MIDI data bytes of a single MIDI message.
+     */
+    data : Uint8Array;
+  }
+
+  export interface MIDIMessageEventInit extends EventInit {
+    /**
+     * A timestamp specifying when the event occurred.
+     */
+    receivedTime : number;
+
+    /**
+     * A Uint8Array containing the MIDI data bytes of a single MIDI message.
+     */
+    data : Uint8Array;
+  }
+
+  export interface MIDIConnectionEvent extends Event {
+    /**
+     * The port that has been connected or disconnected.
+     */
+    port : MIDIPort;
+  }
+
+  export interface MIDIConnectionEventInit extends EventInit {
+    /**
+     * The port that has been connected or disconnected.
+     */
+    port : MIDIPort;
+  }
 }


### PR DESCRIPTION
This PR updates and corrects type declarations for the Web MIDI API.

Custom iterator and iterable interfaces that prevented return values from being iterated with `for...of` or spread with the ES6 `...` spread operator were removed in favour of TypeScript's built-ins. A custom tuple interface with erroneous accessors was also removed and replaced with the correct tuple type. In addition, some of the interfaces in the typings were missing `extends` statements, preventing full use of the API.

Commented-out dead code in the test file was also removed.

Definitions and docstrings were rewritten based on the WebIDL from the latest working draft of the Web MIDI API, found here: https://webaudio.github.io/web-midi-api/
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
