### PR TITLE
navDrawer instead of drawer in v0.15.0.

### DIFF
--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -248,7 +248,7 @@ declare namespace __MaterialUI {
             inkBar?: {
                 backgroundColor?: string;
             };
-            drawer?: {
+            navDrawer?: {
                 width?: number;
                 color?: string;
             };
@@ -427,7 +427,7 @@ declare namespace __MaterialUI {
             menu: number;
             appBar: number;
             drawerOverlay: number;
-            drawer: number;
+            navDrawer: number;
             dialogOverlay: number;
             dialog: number;
             layer: number;


### PR DESCRIPTION
v0.15.0 has `navDrawer` property (not `drawer`) in:
- https://github.com/callemall/material-ui/blob/v0.15.0/src/styles/getMuiTheme.js
- https://github.com/callemall/material-ui/blob/v0.15.0/src/styles/zIndex.js
