### PR TITLE
react-router: History.Location missed prop "hash"

### DIFF
--- a/react-router/history.d.ts
+++ b/react-router/history.d.ts
@@ -68,6 +68,7 @@ declare namespace HistoryModule {
         state: LocationState
         action: Action
         key: LocationKey
+        hash: Hash
         basename?: string
     }
 
@@ -97,6 +98,8 @@ declare namespace HistoryModule {
     type Search = string
 
     type TransitionHook = (location: Location, callback: (result: any) => void) => any
+
+    type Hash = string
 
 
     interface HistoryBeforeUnload {


### PR DESCRIPTION
As stated at https://github.com/ReactJSTraining/history/blob/6a92da86cdd1e3311a1fb1e8f9598a1f718820db/modules/LocationUtils.js#L19
