### PR TITLE
Add definitions for 'nunjucks-date'.

### DIFF
--- a/nunjucks-date/nunjucks-date-tests.ts
+++ b/nunjucks-date/nunjucks-date-tests.ts
@@ -1,0 +1,17 @@
+/// <reference path="nunjucks-date.d.ts"/>
+
+// Import the plugin
+import nunjucksDate = require('nunjucks-date');
+
+// Define a custom default date format. Any valid format works.
+// The date format defaults to "YYYY"
+// http://momentjs.com/docs/#/displaying/format/
+nunjucksDate.setDefaultFormat('MMMM Do YYYY, h:mm:ss a');
+
+
+let env = { };
+
+// Pass the environment to `install()`
+nunjucksDate.install(env);
+// Pass the environment & a custom filter name
+nunjucksDate.install(env, 'yourFilterName');

--- a/nunjucks-date/nunjucks-date.d.ts
+++ b/nunjucks-date/nunjucks-date.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for nunjucks-date
+// Project: https://github.com/techmsi/nunjucks-date
+// Definitions by: kruncher <https://github.com/kruncher/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module "nunjucks-date" {
+
+    export function setDefaultFormat(formatString: string): void;
+    export function install(env: any, filterName?: string): void;
+
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
