### PR TITLE
Added UglifyCSS typings

### DIFF
--- a/uglifycss/uglifycss-tests.ts
+++ b/uglifycss/uglifycss-tests.ts
@@ -1,0 +1,19 @@
+/// <reference path="uglifycss.d.ts" />
+
+import * as UglifyCSS from 'uglifycss';
+
+var test1 = UglifyCSS.processString('some css string');
+
+var test2 = UglifyCSS.processString('some css string', {
+    maxLineLen: 0,
+    expandVars: true,
+    uglyComments: true,
+    cuteComments: true
+});
+
+var test3 = UglifyCSS.processFiles(['/path/to/file']);
+
+var test4 = UglifyCSS.processFiles(['/path/to/file'], {
+    maxLineLen: 0,
+    cuteComments: true
+});

--- a/uglifycss/uglifycss.d.ts
+++ b/uglifycss/uglifycss.d.ts
@@ -1,0 +1,47 @@
+// Type definitions for UglifyCSS v0.0.20
+// Project: https://github.com/fmarcia/UglifyCSS
+// Definitions by: gevik Babakhani <https://github.com/blendsdk>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "uglifycss" {
+
+    namespace UglifyCSS {
+
+        interface UglifyCSSOptions {
+
+            /**
+             * Adds a newline (approx.) every n characters; 0 means no newline and is the default value
+             */
+            maxLineLen?: number
+
+            /**
+             * eEpands variables; by default, @variables blocks are preserved and var(x)s are not expanded
+             */
+            expandVars?: boolean
+
+            /**
+             * Removes newlines within preserved comments; by default, newlines are preserved
+             */
+            uglyComments?: boolean
+
+            /**
+             * Preserves newlines within and around preserved comments
+             */
+            cuteComments?: boolean
+        }
+
+        /**
+         * Uglify a string
+         */
+        function processString(content: string, options?: UglifyCSSOptions);
+
+        /**
+         * Uglify one or more files
+         */
+        function processFiles(filenames: Array<string>, options?: UglifyCSSOptions);
+
+    }
+
+    export = UglifyCSS;
+
+}

--- a/uglifycss/uglifycss.d.ts
+++ b/uglifycss/uglifycss.d.ts
@@ -33,12 +33,12 @@ declare module "uglifycss" {
         /**
          * Uglify a string
          */
-        function processString(content: string, options?: UglifyCSSOptions);
+        function processString(content: string, options?: UglifyCSSOptions): string;
 
         /**
          * Uglify one or more files
          */
-        function processFiles(filenames: Array<string>, options?: UglifyCSSOptions);
+        function processFiles(filenames: Array<string>, options?: UglifyCSSOptions): string;
 
     }
 


### PR DESCRIPTION
case 1. Add a new type definition.
- [OK] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [OK] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [OK] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
