### PR TITLE
Adding actual GeoJSON types to getGeoJSON fns

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Vladimir Zotov <https://github.com/rgripper>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference path='../geojson/geojson.d.ts' />
+
 declare namespace L {
     type LatLngExpression = LatLng | number[] | ({ lat: number; lng: number })
     type LatLngBoundsExpression = LatLngBounds | LatLngExpression[];
@@ -219,7 +221,7 @@ declare namespace L {
         /**
           * Returns a GeoJSON representation of the circle (GeoJSON Point Feature).
           */
-        toGeoJSON(): any;
+        toGeoJSON(): GeoJSON.Feature<GeoJSON.Point>;
 
     }
 }
@@ -254,11 +256,6 @@ declare namespace L {
           * Sets the radius of a circle marker. Units are in pixels.
           */
         setRadius(radius: number): CircleMarker;
-
-        /**
-          * Returns a GeoJSON representation of the circle marker (GeoJSON Point Feature).
-          */
-        toGeoJSON(): any;
     }
 }
 
@@ -1709,8 +1706,9 @@ declare namespace L {
 
         /**
           * Returns a GeoJSON representation of the layer group (GeoJSON FeatureCollection).
+          * Note: Descendent classes MultiPolygon & MultiPolyLine return `Feature`s, not `FeatureCollection`s
           */
-        toGeoJSON(): any;
+        toGeoJSON(): GeoJSON.FeatureCollection<GeoJSON.GeometryObject>|GeoJSON.Feature<GeoJSON.MultiLineString|GeoJSON.MultiPolygon>;
 
         ////////////
         ////////////
@@ -2000,7 +1998,7 @@ declare namespace L {
         export function closestPointOnSegment(p: Point, p1: Point, p2: Point): Point;
 
         /**
-          * Clips the segment a to b by rectangular bounds. Used by Leaflet to only show 
+          * Clips the segment a to b by rectangular bounds. Used by Leaflet to only show
           * polyline points that are on the screen or near, increasing performance. Returns
           * either false or a length-2 array of clipped points.
           */
@@ -2921,7 +2919,7 @@ declare namespace L {
         /**
           * Returns a GeoJSON representation of the marker (GeoJSON Point Feature).
           */
-        toGeoJSON(): any;
+        toGeoJSON(): GeoJSON.Feature<GeoJSON.Point>;
 
         /**
           * Marker dragging handler (by both mouse and touch).
@@ -3081,7 +3079,7 @@ declare namespace L {
         /**
           * Returns a GeoJSON representation of the multipolygon (GeoJSON MultiPolygon Feature).
           */
-        toGeoJSON(): any;
+        toGeoJSON(): GeoJSON.Feature<GeoJSON.MultiPolygon>;
     }
 }
 
@@ -3122,7 +3120,7 @@ declare namespace L {
         /**
           * Returns a GeoJSON representation of the multipolyline (GeoJSON MultiLineString Feature).
           */
-        toGeoJSON(): any;
+        toGeoJSON(): GeoJSON.Feature<GeoJSON.MultiLineString>;
     }
 }
 
@@ -3384,7 +3382,7 @@ declare namespace L {
         className?: string;
 
 	/**
-	 * Sets the radius of a circle marker. 
+	 * Sets the radius of a circle marker.
 	 */
 	radius?: number;
 
@@ -3543,7 +3541,7 @@ declare namespace L {
         /**
           * Returns a GeoJSON representation of the polyline (GeoJSON LineString Feature).
           */
-        toGeoJSON(): any;
+        toGeoJSON(): GeoJSON.Feature<GeoJSON.LineString>;
     }
 }
 


### PR DESCRIPTION
Previously returned `any` which was not accurate

Definitions of `toGeoJSON` begin [here](https://github.com/Leaflet/Leaflet/blob/v0.7.7/src/layer/GeoJSON.js#L195)

There are two cases where descendent classes actually return a _different type_ from parent. I noted these cases, I know this is not good but I'm merely documenting the behavior not authoring it.

/cc @horiuchi @vvakame (previous leaflet typings committers)
