### PR TITLE
Fix method .returning() and check if Promise exists before polyfilling it.

### DIFF
--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -7,7 +7,9 @@
 /// <reference path="../node/node.d.ts" />
 
 declare module "knex" {
-  import Promise = require("bluebird");
+  if (!Promise) {
+    import Promise = require("bluebird");
+  }
   import * as events from "events";
 
   type Callback = Function;
@@ -127,7 +129,7 @@ declare module "knex" {
       insert(data: any, returning?: string | string[]): QueryBuilder;
       update(data: any, returning?: string | string[]): QueryBuilder;
       update(columnName: string, value: Value, returning?: string | string[]): QueryBuilder;
-      returning(column: string): QueryBuilder;
+      returning(column: string | string[]): QueryBuilder;
 
       del(returning?: string | string[]): QueryBuilder;
       delete(returning?: string | string[]): QueryBuilder;

--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -7,9 +7,7 @@
 /// <reference path="../node/node.d.ts" />
 
 declare module "knex" {
-  if (!Promise) {
-    import Promise = require("bluebird");
-  }
+  import Promise = require("bluebird");
   import * as events from "events";
 
   type Callback = Function;


### PR DESCRIPTION
In the knexjs docs, returning can take an array of strings as well as a single string

```
// Returns [ { id: 1, title: 'Slaughterhouse Five' } ]
knex('books')
  .returning(['id','title'])
  .insert({title: 'Slaughterhouse Five'})
```

I also added a check to see if Promises are supported natively before polyfilling it. 
