### PR TITLE
Add EventEmitter APIs introduced in Node 6

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -55,6 +55,8 @@ namespace events_tests {
         result = emitter.addListener(event, listener);
         result = emitter.on(event, listener);
         result = emitter.once(event, listener);
+        result = emitter.prependListener(event, listener);
+        result = emitter.prependOnceListener(event, listener);
         result = emitter.removeListener(event, listener);
         result = emitter.removeAllListeners();
         result = emitter.removeAllListeners(event);
@@ -84,6 +86,12 @@ namespace events_tests {
         result = emitter.emit(event, any);
         result = emitter.emit(event, any, any);
         result = emitter.emit(event, any, any, any);
+    }
+
+    {
+        let result: string[];
+
+        result = emitter.eventNames();
     }
 }
 

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -536,12 +536,15 @@ declare module "events" {
         addListener(event: string, listener: Function): this;
         on(event: string, listener: Function): this;
         once(event: string, listener: Function): this;
+        prependListener(event: string, listener: Function): this;
+        prependOnceListener(event: string, listener: Function): this;
         removeListener(event: string, listener: Function): this;
         removeAllListeners(event?: string): this;
         setMaxListeners(n: number): this;
         getMaxListeners(): number;
         listeners(event: string): Function[];
         emit(event: string, ...args: any[]): boolean;
+        eventNames(): string[];
         listenerCount(type: string): number;
     }
 }


### PR DESCRIPTION
Added a few Event APIs introduced in Node 6:

`emitter.prependListener(eventName, listener)` ==> https://nodejs.org/dist/latest-v6.x/docs/api/events.html#events_emitter_prependlistener_eventname_listener

`emitter.prependOnceListener(eventName, listener)` ==>  https://nodejs.org/dist/latest-v6.x/docs/api/events.html#events_emitter_prependoncelistener_eventname_listener

`emitter.eventNames()` ==> https://nodejs.org/dist/latest-v6.x/docs/api/events.html#events_emitter_eventnames
