### PR TITLE
`new` on a `IResourceClass` will return a `IResource`

### DIFF
--- a/angularjs/angular-resource.d.ts
+++ b/angularjs/angular-resource.d.ts
@@ -113,7 +113,7 @@ declare namespace angular.resource {
     // Also, static calls always return the IResource (or IResourceArray) retrieved
     // https://github.com/angular/angular.js/blob/v1.2.0/src/ngResource/resource.js#L538-L549
     interface IResourceClass<T> {
-        new(dataOrParams? : any) : T;
+        new(dataOrParams? : any) : T & IResource<T>;
         get: IResourceMethod<T>;
 
         query: IResourceArrayMethod<T>;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

---

note: that means you can do `new Res({title: 'a'}).$save..` works – which is as intended.
