### PR TITLE
fix(ui-grid): fix isRowSelectable typing

### DIFF
--- a/ui-grid/ui-grid-tests.ts
+++ b/ui-grid/ui-grid-tests.ts
@@ -107,7 +107,7 @@ gridApi.core.clearAllFilters(true);
 gridApi.core.addToGridMenu(gridInstance, [menuItem]);
 gridApi.core.getVisibleRows(gridInstance);
 gridApi.core.handleWindowResize();
-gridApi.core.queueGridRefresh()
+gridApi.core.queueGridRefresh();
 gridApi.core.queueRefresh();
 gridApi.core.registerColumnsProcessor(colProcessor, 100);
 
@@ -118,7 +118,9 @@ var gridOptions: uiGrid.IGridOptionsOf<IMyEntity> = {
             console.log(row.entity.name);
         })
     }
-}
+};
+gridOptions.isRowSelectable = () => true;
+
 interface IAnotherEntity {
     anObject: string
 }

--- a/ui-grid/ui-grid.d.ts
+++ b/ui-grid/ui-grid.d.ts
@@ -2825,7 +2825,7 @@ declare namespace uiGrid {
              * Makes it possible to specify a method that evaluates for each row and sets its "enableSelection"
              * property.
              */
-            isRowSelectable?: boolean;
+            isRowSelectable?: (row: IGridRow) => boolean;
             /**
              * Enable multiple row selection only when using the ctrlKey or shiftKey. Requires multiSelect to be true.
              * Defaults to false


### PR DESCRIPTION
- per [the ui-grid documentation](http://ui-grid.info/docs/#/tutorial/210_selection), `isRowSelectable` is a function that takes a `IGridRow` as an argument and returns a boolean, rather than a straight boolean property.
