### PR TITLE
added _doc member to mongoose Document interface

### DIFF
--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -428,6 +428,8 @@ declare module "mongoose" {
     id?: string;
     _id: any;
 
+    _doc?: Document;
+
     equals(doc: Document): boolean;
     get(path: string, type?: new(...args: any[]) => any): any;
     inspect(options?: Object): string;


### PR DESCRIPTION
Added `_doc` member to Document interface, as the `result` of some `collection.find().limit(a).offset(b).exec((err: any, result?: T[]) => { ...` encapsulates the actual document in `_doc` for some reason.
