### PR TITLE
slickgrid: Add CheckboxSelectColumn and ColumnPicker

### DIFF
--- a/slickgrid/slick.checkboxselectcolumn-tests.ts
+++ b/slickgrid/slick.checkboxselectcolumn-tests.ts
@@ -1,0 +1,42 @@
+/// <reference path="slick.checkboxselectcolumn.d.ts" />
+/// <reference path="slick.columnpicker.d.ts" />
+/// <reference path="slick.rowselectionmodel.d.ts" />
+
+/**
+ * Extracted from https://github.com/mleibman/SlickGrid/blob/master/examples/example-checkbox-row-select.html
+ */
+
+var grid: Slick.Grid<Slick.SlickData>;
+var data: any[] = [];
+var options = {
+    editable: true,
+    enableCellNavigation: true,
+    asyncEditorLoading: false,
+    autoEdit: false
+};
+var columns: Slick.SlickData[] = [];
+$(function () {
+    for (var i = 0; i < 100; i++) {
+        // I'm not actually sure what this is supposed to be doing, but
+        // this is verbatim the example :/
+        var d: any = (data[i] = {});
+        d[0] = "Row " + i;
+    }
+    var checkboxSelector = new Slick.CheckboxSelectColumn({
+        cssClass: "slick-cell-checkboxsel"
+    });
+    columns.push(checkboxSelector.getColumnDefinition());
+    for (var i = 0; i < 5; i++) {
+        columns.push({
+            id: i,
+            name: String.fromCharCode("A".charCodeAt(0) + i),
+            field: i,
+            width: 100,
+            editor: Slick.Editors.Text
+        });
+    }
+    grid = new Slick.Grid("#myGrid", data, columns, options);
+    grid.setSelectionModel(new Slick.RowSelectionModel({ selectActiveRow: false }));
+    grid.registerPlugin(checkboxSelector);
+    var columnpicker = new Slick.Controls.ColumnPicker(columns, grid, options);
+})

--- a/slickgrid/slick.checkboxselectcolumn.d.ts
+++ b/slickgrid/slick.checkboxselectcolumn.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for SlickGrid CheckboxSelectColumn Plugin 2.1.0
+// Project: https://github.com/mleibman/SlickGrid
+// Definitions by: berwyn <https://github.com/berwyn>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="SlickGrid.d.ts" />
+
+declare namespace Slick {
+    export interface SlickGridCheckBoxSelectColumnOptions extends PluginOptions {
+        /**
+         * Column to add the checkbox to
+         * @default "_checkbox_selector"
+         */
+        columnId?: string;
+
+        /**
+         * CSS class to be added to cells in this column
+         * @default null
+         */
+        cssClass?: string;
+
+        /**
+         * Tooltip text to display for this column
+         * @default "Select/Deselect All"
+         */
+        toolTip?: string;
+
+        /**
+         * Width of the column
+         * @default 30
+         */
+        width?: number;
+    }
+
+    export class CheckboxSelectColumn<T extends Slick.SlickData> extends Plugin<T> {
+        constructor(options?: SlickGridCheckBoxSelectColumnOptions);
+        init(grid: Slick.Grid<T>): void;
+        destroy(): void;
+        getColumnDefinition(): Slick.ColumnMetadata<T>;
+    }
+}

--- a/slickgrid/slick.columnpicker.d.ts
+++ b/slickgrid/slick.columnpicker.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for SlickGrid ColumnPicker Control 2.1.0
+// Project: https://github.com/mleibman/SlickGrid
+// Definitions by: berwyn <https://github.com/berwyn>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="SlickGrid.d.ts" />
+
+declare namespace Slick {
+    export namespace Controls {
+        export interface SlickColumnPickerOptions {
+            fadeSpeed?: number;
+        }
+
+        export class ColumnPicker<T extends Slick.SlickData> {
+            constructor(columns: Slick.Column<T>[], grid: Slick.Grid<T>, options: SlickColumnPickerOptions);
+            getAllColumns(): Slick.Column<T>[];
+            destroy(): void;
+        }
+    }
+}


### PR DESCRIPTION
Adds slickgrid/slick.checkboxselectioncolumn and slickgrid/slick.columnpicker
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
