### PR TITLE
Make LatLng.wrap function arguments optional

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -1504,7 +1504,7 @@ declare namespace L {
           * Returns a new LatLng object with the longitude wrapped around left and right
           * boundaries (-180 to 180 by default).
           */
-        wrap(left: number, right: number): LatLng;
+        wrap(left?: number, right?: number): LatLng;
 
         /**
           * Latitude in degrees.


### PR DESCRIPTION
It appears that LatLng.wrap arguments are optional and default values are used when they are not given: http://leafletjs.com/reference.html#latlng-wrap
