### PR TITLE
Fixed intreactjs's module name

### DIFF
--- a/interactjs/interact-tests.ts
+++ b/interactjs/interact-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./interact.d.ts" />
 
-import interact = require("interact");
+import interact = require("interact.js");
 
 var button: HTMLElement = document.createElement("BUTTON");
 var rectangle: ClientRect = {

--- a/interactjs/interact.d.ts
+++ b/interactjs/interact.d.ts
@@ -242,6 +242,6 @@ declare namespace Interact {
 
 declare var interact: Interact.InteractStatic;
 
-declare module "interact" {
+declare module "interact.js" {
     export = interact;
 }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
The module name should be equal to the name of the package in interactjs's package.json file (https://github.com/taye/interact.js/blob/master/package.json)
