### PR TITLE
Fixes #9609

### DIFF
--- a/redlock/redlock-tests.ts
+++ b/redlock/redlock-tests.ts
@@ -1,103 +1,49 @@
 /// <reference path="./redlock.d.ts" />
 
-import Redlock = require('redlock');
+import * as Redlock from 'redlock';
+import * as Promise from 'bluebird';
+import {RedisClient} from 'redis';
 
-import NodeifyCallback = RedlockTypes.NodeifyCallback;
-import Lock = RedlockTypes.Lock;
-import RedlockOptions = RedlockTypes.RedlockOptions;
+import Lock = Redlock.Lock;
 
 namespace RedlockTest {
-	// constructor
-	{
-		let redlock: Redlock;
-		let client: any;
-		let options: RedlockOptions;
-		redlock = new Redlock([client]);
-		redlock = new Redlock([client], options);
-	}
+	
+	let redlock: Redlock;
+	let client: RedisClient;
+	let lock: Lock;
+	
+	redlock = new Redlock([client]);
+	redlock = new Redlock([client], {
+		driftFactor: 0.1,
+		retryCount: 2,
+		retryDelay: 3
+	});
+	
+	redlock.acquire('resource', 30).then((lock: Lock) => {});
+	redlock.acquire('resource', 30, (err: any, lock: Lock) => {});
+	redlock.lock('resource', 30).then((lock: Lock) => {});
+	redlock.lock('resource', 30, (err: any, lock: Lock) => {});
 
-	// acquire, lock
-	{
-		let redlock: Redlock;
-		let resource: string;
-		let ttl: number;
-		let callback: NodeifyCallback<Lock>;
-		let result: Promise<Lock>;
-		result = redlock.acquire(resource, ttl);
-		result = redlock.acquire(resource, ttl, callback);
-		result = redlock.lock(resource, ttl);
-		result = redlock.lock(resource, ttl, callback);
-	}
+	// There is currently no way to test the disposer as the bluebird typings does not
+	//	expose the .using method.
+	// promise.using(redlock.disposer('resource', 30), (lock: Lock) => {});
+	
+	redlock.release(lock);
+	redlock.release(lock, (err: any) => {});
+	redlock.unlock(lock);
+	redlock.unlock(lock, (err: any) => {});
 
-	// disposer
-	{
-		let redlock: Redlock;
-		let resource: string;
-		let ttl: number;
-		let result: any;
-		result = redlock.acquire(resource, ttl);
-	}
-
-	// release, unlock
-	{
-		let redlock: Redlock;
-		let lock: Lock;
-		let callback: NodeifyCallback<void>;
-		let result: Promise<void>;
-		result = redlock.release(lock);
-		result = redlock.release(lock, callback);
-		result = redlock.unlock(lock);
-		result = redlock.unlock(lock, callback);
-	}
-
-	// extend
-	{
-		let redlock: Redlock;
-		let lock: Lock;
-		let ttl: number;
-		let callback: NodeifyCallback<Lock>;
-		let result: Promise<Lock>;
-		result = redlock.extend(lock, ttl);
-		result = redlock.extend(lock, ttl, callback);
-	}
-
-	// _lock
-	{
-		let redlock: Redlock;
-		let resource: string;
-		let value: string;
-		let ttl: number;
-		let callback: NodeifyCallback<Lock>;
-		let result: Promise<Lock>;
-		result = redlock._lock(resource, value, ttl);
-		result = redlock._lock(resource, value, ttl, callback);
-	}
-
-	// _random
-	{
-		let redlock: Redlock;
-		let result: string;
-		result = redlock._random();
-	}
+	redlock.extend(lock, 30).then((lock: Lock) => {});
+	redlock.extend(lock, 30, (err: any, lock: Lock) => {});
 }
 
 namespace LockTest {
-	// unlock
-	{
-		let lock: Lock;
-		let callback: NodeifyCallback<void>;
-		let result: Promise<void>;
-		result = lock.unlock();
-		result = lock.unlock(callback);
-	}
-
-	// extend
-	{
-		let lock: Lock;
-		let ttl: number;
-		let callback: NodeifyCallback<Lock>;
-		let result: Promise<Lock>;
-		result = lock.extend(ttl);
-		result = lock.extend(ttl, callback);
-	}
+	
+	let lock: Lock;
+	
+	lock.unlock();
+	lock.unlock((err) => {});
+	
+	lock.extend(30).then((lock: Lock) => {});
+	lock.extend(30, (err: any, lock: Lock) => {});
 }

--- a/redlock/redlock.d.ts
+++ b/redlock/redlock.d.ts
@@ -4,59 +4,61 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../bluebird/bluebird.d.ts" />
+/// <reference path="../redis/redis.d.ts" />
 
-declare namespace RedlockTypes {
-	interface LockError extends Error {}
 
-	interface NodeifyCallback<T> {
-		(err: any, value?: T): void;
+declare module "redlock" {
+
+	import * as redis from 'redis';
+	import * as Promise from 'bluebird';	
+		
+	namespace Redlock {
+		
+		interface Callback<T> {
+			(err: any, value?: T): void;
+		}
+
+		interface Lock {
+			
+			redlock: Redlock;
+			resource: string;
+			value: any;
+			expiration: number;
+
+			unlock(callback?: Callback<void>): Promise<void>;
+
+			extend(ttl: number, callback?: Callback<Lock>): Promise<Lock>;
+		}
+
+		interface Options {
+			driftFactor?: number;
+			retryCount?: number;
+			retryDelay?: number;
+		}
+
+		interface LockError extends Error {}
 	}
-
-	interface Lock {
-		redlock: Redlock;
-		resource: string;
-		value: any;
-		expiration: number;
-
-		unlock(callback?: NodeifyCallback<void>): Promise<void>;
-
-		extend(ttl: number, callback?: NodeifyCallback<Lock>): Promise<Lock>;
-	}
-
-	interface RedlockOptions {
-		driftFactor?: number;
-		retryCount?: number;
-		retryDelay?: number;
-	}
-
+	
 	class Redlock {
-		LockError: LockError;
 
 		driftFactor: number;
 		retryCount: number;
 		retryDelay: number;
 
-		servers: any[]; // array of redis.RedisClient
+		servers: redis.RedisClient[];
 
-		constructor(clients: any[], options?: RedlockOptions);
+		constructor(clients: any[], options?: Redlock.Options);
 
-		acquire(resource: string, ttl: number, callback?: NodeifyCallback<Lock>): Promise<Lock>;
-		lock(resource: string, ttl: number, callback?: NodeifyCallback<Lock>): Promise<Lock>;
+		acquire(resource: string, ttl: number, callback?: Redlock.Callback<Redlock.Lock>): Promise<Redlock.Lock>;
+		lock(resource: string, ttl: number, callback?: Redlock.Callback<Redlock.Lock>): Promise<Redlock.Lock>;
 
-		disposer(resource: string, ttl: number): any; // return bluebird.Disposer
+		disposer(resource: string, ttl: number, errorHandler?: Redlock.Callback<void>): any; // bluebird Disposer
 
-		release(lock: Lock, callback?: NodeifyCallback<void>): Promise<void>;
-		unlock(lock: Lock, callback?: NodeifyCallback<void>): Promise<void>;
+		release(lock:  Redlock.Lock, callback?: Redlock.Callback<void>): Promise<void>;
+		unlock(lock:  Redlock.Lock, callback?: Redlock.Callback<void>): Promise<void>;
 
-		extend(lock: Lock, ttl: number, callback?: NodeifyCallback<Lock>): Promise<Lock>;
-
-		_lock(resource: string, value: string, ttl: number, callback?: NodeifyCallback<Lock>): Promise<Lock>;
-
-		_random(): string;
+		extend(lock:  Redlock.Lock, ttl: number, callback?: Redlock.Callback<Redlock.Lock>): Promise<Redlock.Lock>;
 	}
-}
-
-declare module "redlock" {
-	import Redlock = RedlockTypes.Redlock;
+	
 	export = Redlock;
 }


### PR DESCRIPTION
Refactored the definition to work in current versions of TSC.
Also, the internal types (ie. Lock) are now accessible on the default export allowing other TS code to reference them (ex. "(lock: Redlock.Lock)") instead of just using type hinting.
