### PR TITLE
pdfkit: fix several outdated/wrong definitions

### DIFF
--- a/pdfkit/pdfkit-tests.ts
+++ b/pdfkit/pdfkit-tests.ts
@@ -16,7 +16,7 @@ import text = require("pdfkit/js/mixins/text");
 font.registerFont("Arial");
 text.widthOfString("Kila",{ellipsis:true});
 
-var doc = new PDFDocument({compress:false, sizes:[526,525],autoFirstPage:true});
+var doc = new PDFDocument({compress:false, size:[526,525],autoFirstPage:true});
 
 
 doc.addPage({
@@ -134,3 +134,9 @@ doc.image('images/test.jpeg', 320, 145, {
 doc.image('images/test.jpeg', 320, 280, {
   scale: 0.25
 }).text('Scale', 320, 265);
+
+doc.image({ /* something like a buffer */ }, {
+  scale: 0.25
+}).text('Scale', 320, 265);
+
+doc.text('Scale', {align: 'justify'});

--- a/pdfkit/pdfkit.d.ts
+++ b/pdfkit/pdfkit.d.ts
@@ -129,7 +129,7 @@ declare namespace PDFKit.Mixins {
         continued?: boolean;
 
         /** the alignment of the text (center, justify, left, right) */
-        align?: any;
+        align?: string;
     }
 
     interface PDFText<TDocument> {

--- a/pdfkit/pdfkit.d.ts
+++ b/pdfkit/pdfkit.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Pdfkit v0.7.1
+// Type definitions for Pdfkit v0.7.2
 // Project: http://pdfkit.org
 // Definitions by: Eric Hillah <https://github.com/erichillah>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -84,12 +84,12 @@ declare namespace PDFKit.Mixins {
         fit?: number[];
     }
 
-    interface PDFImage {
-    /**
-     * Draw an image in PDFKit document.
-     * No need chainning capabilities
-     */
-        image(src: any, x: number, y: number, options: ImageOption): any;
+    interface PDFImage<TDocument> {
+        /**
+         * Draw an image in PDFKit document.
+         */
+        image(src: any, x?: number, y?: number, options?: ImageOption): TDocument;
+        image(src: any, options?: ImageOption): TDocument;
     }
 
     interface TextOptions {
@@ -127,6 +127,9 @@ declare namespace PDFKit.Mixins {
         strike?: boolean;
         /**whether the text segment will be followed immediately by another segment. Useful for changing styling in the middle of a paragraph. */
         continued?: boolean;
+
+        /** the alignment of the text (center, justify, left, right) */
+        align?: any;
     }
 
     interface PDFText<TDocument> {
@@ -227,14 +230,14 @@ declare namespace PDFKit {
         compress?: boolean;
         info?: DocumentInfo;
         autoFirstPage?: boolean;
-        sizes?: number[];
+        size?: number[];
         margin?: { top: number; left: number; bottom: number; right: number }|number;
 
         bufferPages?: boolean;
     }
 
     interface PDFDocument extends NodeJS.ReadableStream,
-        Mixins.PDFAnnotation<PDFDocument>, Mixins.PDFColor<PDFDocument>, Mixins.PDFImage,
+        Mixins.PDFAnnotation<PDFDocument>, Mixins.PDFColor<PDFDocument>, Mixins.PDFImage<PDFDocument>,
         Mixins.PDFText<PDFDocument>, Mixins.PDFVector<PDFDocument>, Mixins.PDFFont<PDFDocument> {
         /**
         * PDF Version
@@ -303,7 +306,7 @@ declare namespace PDFKit {
     interface PDFPage {
         size: string;
         layout: string;
-        margin: { top: number; left: number; bottom: number; right: number }|number;
+        margins: { top: number; left: number; bottom: number; right: number };
         width: number;
         height: number;
         document: PDFDocument;
@@ -375,7 +378,7 @@ declare module "pdfkit/js/mixins/fonts" {
 }
 
 declare module "pdfkit/js/mixins/images" {
-    var PDFKitImage: PDFKit.Mixins.PDFImage;
+    var PDFKitImage: PDFKit.Mixins.PDFImage<void>;
     export = PDFKitImage;
 }
 


### PR DESCRIPTION
Improvement to existing type definition.

`size` was incorrectly defined as `sizes`, see:
http://pdfkit.org/docs/getting_started.html#adding_pages

`margin` was incorrectly defined as `margins`, see:
https://github.com/devongovett/pdfkit/blob/master/lib/page.coffee#L13

`.image()` would lose strong typing once chained and was lacking one function definition.
