### PR TITLE
Q: Add overloads for `all` to support typed arrays

### DIFF
--- a/q/Q-tests.ts
+++ b/q/Q-tests.ts
@@ -30,7 +30,7 @@ Q.delay("asdf", 1000).then(x => x.length);
 var eventualAdd = Q.promised((a?: number, b?: number) => a + b);
 eventualAdd(Q(1), Q(2)).then(x => x.toExponential());
 
-var eventually = function (eventually: any) {
+function eventually<T>(eventually: T) {
     return Q.delay(eventually, 1000);
 };
 
@@ -42,7 +42,15 @@ Q.when(x, function (x) {
 Q.all([
     eventually(10),
     eventually(20)
-]).spread(function (x: any, y: any) {
+]).spread(function (x: number, y: number) {
+    console.log(x, y);
+});
+
+Q.all([
+    eventually(10),
+    eventually(20)
+]).then(function (results) {
+    let [x, y] = results;
     console.log(x, y);
 });
 

--- a/q/Q.d.ts
+++ b/q/Q.d.ts
@@ -206,6 +206,26 @@ declare namespace Q {
     /**
      * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
      */
+    export function all<A, B, C, D, E, F>(promises: [IPromise<A>, IPromise<B>, IPromise<C>, IPromise<D>, IPromise<E>, IPromise<F>]): Promise<[A, B, C, D, E, F]>;
+    /**
+     * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
+     */
+    export function all<A, B, C, D, E>(promises: [IPromise<A>, IPromise<B>, IPromise<C>, IPromise<D>, IPromise<E>]): Promise<[A, B, C, D, E]>;
+    /**
+     * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
+     */
+    export function all<A, B, C, D>(promises: [IPromise<A>, IPromise<B>, IPromise<C>, IPromise<D>]): Promise<[A, B, C, D]>;
+    /**
+     * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
+     */
+    export function all<A, B, C>(promises: [IPromise<A>, IPromise<B>, IPromise<C>]): Promise<[A, B, C]>;
+    /**
+     * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
+     */
+    export function all<A, B>(promises: [IPromise<A>, IPromise<B>]): Promise<[A, B]>;
+    /**
+     * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
+     */
     export function all<T>(promises: IPromise<T>[]): Promise<T[]>;
 
     /**


### PR DESCRIPTION
This is to support a common pattern of using `all` to await the completion of multiple promises of potentially different types, without requiring the developer to manually define the types in the callback handler. For example:

``` typescript
function getFoos(): IPromise<Foo> { /* ... */ }
function getBars(): IPromise<Bar> { /* ... */ }

Q.all([
    getFoos(),
    getBars()
]).then(results => {
    let [a, b] = results;
    // here `a` is of type `Foo`, and `b` is of type `Bar`
    a.foo();
    b.bar();
});
```

The additional typings support typed arrays of up to 6 elements, before falling back to old behavior.
