### PR TITLE
Add polyfill method to es6-promise

### DIFF
--- a/es6-promise/es6-promise-commonjs-tests.ts
+++ b/es6-promise/es6-promise-commonjs-tests.ts
@@ -1,6 +1,7 @@
 /// <reference path="es6-promise.d.ts" />
 
 import rsvp = require('es6-promise');
+rsvp.polyfill(); // Test for polyfill method existence
 var Promise = rsvp.Promise;
 
 var promiseString: Promise<string>,

--- a/es6-promise/es6-promise.d.ts
+++ b/es6-promise/es6-promise.d.ts
@@ -79,6 +79,7 @@ declare module 'es6-promise' {
 	var foo: typeof Promise; // Temp variable to reference Promise in local context
 	namespace rsvp {
 		export var Promise: typeof foo;
+		export function polyfill(): void;
 	}
 	export = rsvp;
 }


### PR DESCRIPTION
The `es6-promise` library [also exports](https://github.com/stefanpenner/es6-promise/blob/448ec4d4b53dff3e6a674a72054208b08afcb13f/lib/es6-promise.umd.js#L5) a `polyfill` [method](https://github.com/stefanpenner/es6-promise/blob/448ec4d4b53dff3e6a674a72054208b08afcb13f/lib/es6-promise/polyfill.js#L4).
