### PR TITLE
better type for negate

### DIFF
--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -3511,10 +3511,10 @@ interface UnderscoreStatic {
 
 	/**
 	* Returns a negated version of the pass-in predicate.
-	* @param Function predicate
-	* @return boolean
+	* @param (...args: any[]) => boolean predicate
+	* @return (...args: any[]) => boolean
 	**/
-	negate(predicate: Function): boolean;
+	negate(predicate: (...args: any[]) => boolean): (...args: any[]) => boolean;
 
 	/**
 	* Returns the composition of a list of functions, where each function consumes the return value of the


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Negate is a function that takes a function that returns a boolean and returns a function that returns a boolean. The current typing has negate taking a function and itself returning a boolean, which is incorrect.
