### PR TITLE
D3 - add "median" to array methods

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1097,6 +1097,12 @@ declare namespace d3 {
     export function mean(array: number[]): number;
     export function mean<T>(array: T[], accessor: (datum: T, index: number) => number): number;
 
+    /**
+     * Compute the median of an array of numbers (the 0.5-quantile).
+     */
+    export function median(array: number[]): number;
+    export function median<T>(datum: T[], accessor: (datum: T, index: number) => number): number;
+
     export function quantile(array: number[], p: number): number;
 
     export function variance(array: number[]): number;


### PR DESCRIPTION
This method was lost during one of the latest refactorings.

Docs: https://github.com/d3/d3/wiki/Arrays#d3_median
