### PR TITLE
Create sinon-as-promised.d.ts

### DIFF
--- a/sinon-as-promised/sinon-as-promised-tests.ts
+++ b/sinon-as-promised/sinon-as-promised-tests.ts
@@ -1,0 +1,11 @@
+/// <reference path="sinon-as-promised.d.ts"/>
+function testResolve() {
+    sinon.stub().resolves('test val');
+}
+
+function testReject() {
+    sinon.stub().rejects('test val');
+}
+
+testResolve();
+testReject();

--- a/sinon-as-promised/sinon-as-promised.d.ts
+++ b/sinon-as-promised/sinon-as-promised.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for sinon-as-promised v4.0.0
+// Project: https://github.com/bendrucker/sinon-as-promised
+// Definitions by: igrayson <https://github.com/igrayson>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../sinon/sinon.d.ts"/>
+
+declare namespace Sinon {
+
+  export interface SinonStub {
+
+    /**
+     * When called, the stub will return a "thenable" object which will return a promise for the provided value. Any Promises/A+ compliant library will handle this object properly.
+     */
+    resolves(value:any):SinonStub;
+
+    /**
+     * When called, the stub will return a thenable which will return a reject promise with the provided err. If err is a string, it will be set as the message on an Error object.
+     */
+    rejects(value:any):SinonStub;
+  } 
+
+}

--- a/sinon-as-promised/sinon-as-promised.d.ts
+++ b/sinon-as-promised/sinon-as-promised.d.ts
@@ -17,7 +17,7 @@ declare namespace Sinon {
     /**
      * When called, the stub will return a thenable which will return a reject promise with the provided err. If err is a string, it will be set as the message on an Error object.
      */
-    rejects(value:any):SinonStub;
+    rejects(err:any):SinonStub;
   } 
 
 }


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
