### PR TITLE
Adding logging interface to adal.d.ts

### DIFF
--- a/adal-angular/adal-tests.ts
+++ b/adal-angular/adal-tests.ts
@@ -12,4 +12,10 @@ var config : adal.Config = {
 
 var auth = new AuthenticationContext(config);
 
+Logging.log = (message: string) => {
+    console.log(message);
+}
+
+Logging.level = 4;
+
 var userName: string = auth.getCachedUser().userName;

--- a/adal-angular/adal-tests.ts
+++ b/adal-angular/adal-tests.ts
@@ -18,4 +18,6 @@ Logging.log = (message: string) => {
 
 Logging.level = 4;
 
+auth.info("Logging message");
+
 var userName: string = auth.getCachedUser().userName;

--- a/adal-angular/adal.d.ts
+++ b/adal-angular/adal.d.ts
@@ -4,9 +4,10 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var AuthenticationContext: adal.AuthenticationContextStatic;
+declare var Logging: adal.Logging;
 
 declare module 'adal' {
-    export = AuthenticationContext;
+    export = { AuthenticationContext, Logging };
 }
 
 declare namespace adal {
@@ -35,6 +36,18 @@ declare namespace adal {
         stateMatch: boolean,
         stateResponse: string,
         requestType: string
+    }
+    
+    interface Logging {
+        log: (message: string) => void;
+        level: LoggingLevel;
+    }
+    
+    enum LoggingLevel {
+        ERROR = 0,
+        WARNING = 1, 
+        INFO = 2,
+        VERBOSE = 3
     }
 
     interface AuthenticationContextStatic {


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

The current definitions have no support for exposing the adal.js log function, which is needed to see the log messages from the library. See here https://github.com/AzureAD/azure-activedirectory-library-for-js/blob/master/lib/adal.js#L22  
