### PR TITLE
Revert Thenable.catch from #7653

### DIFF
--- a/es6-promise/es6-promise.d.ts
+++ b/es6-promise/es6-promise.d.ts
@@ -6,7 +6,6 @@
 interface Thenable<T> {
     then<U>(onFulfilled?: (value: T) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
     then<U>(onFulfilled?: (value: T) => U | Thenable<U>, onRejected?: (error: any) => void): Thenable<U>;
-    catch<U>(onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
 }
 
 declare class Promise<T> implements Thenable<T> {


### PR DESCRIPTION
Does not match the definition of `PromiseLike` from upstream TypeScript, and not required by the spec, which mentions only a `then` method:
http://www.ecma-international.org/ecma-262/6.0/#sec-promiseresolvethenablejob

See discussion in #4400
