### PR TITLE
Update heatmap.js typings - valueField is not required

### DIFF
--- a/heatmap.js/heatmap.d.ts
+++ b/heatmap.js/heatmap.d.ts
@@ -77,8 +77,9 @@ interface HeatmapConfiguration {
 
     /*
      * The property name of the value/weight in a datapoint
+     * Default value: 'value'
      */
-    valueField: string;
+    valueField?: string;
 }
 
 /*


### PR DESCRIPTION
> case 2. Improvement to existing type definition.
> - documentation or source code reference which provides context for the suggested changes.
> - it has been reviewed by a DefinitelyTyped member.

reference URL: https://www.patrick-wied.at/static/heatmapjs/docs.html#h337-create
