### PR TITLE
Add exported middleware handler to request-ip declaration

### DIFF
--- a/request-ip/request-ip-tests.ts
+++ b/request-ip/request-ip-tests.ts
@@ -4,6 +4,10 @@
 import express = require('express');
 import requestIp = require('request-ip');
 
+var app = express();
+
+app.use(requestIp.mw());
+
 var ipMiddleware = function(req:express.Request, res:express.Response, next:Function) {
     var clientIp = requestIp.getClientIp(req);
     next();

--- a/request-ip/request-ip.d.ts
+++ b/request-ip/request-ip.d.ts
@@ -28,5 +28,11 @@ declare module "request-ip" {
         };
     }
 
+    interface Options {
+        attributeName: string;
+    }
+
     export function getClientIp(req:Request):string;
+
+    export function mw(options?: Options): (req: Request, res: any, next: any) => any;
 }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- [Link to documentation of mw() method](https://github.com/pbojinov/request-ip#as-connect-middleware).
