### PR TITLE
Browser now has strongly typed `on` method

### DIFF
--- a/mdns/mdns.d.ts
+++ b/mdns/mdns.d.ts
@@ -49,6 +49,9 @@ declare namespace MDNS {
     interface Browser extends NodeJS.EventEmitter {
         start():any;
         stop():any;
+        on(event:string, listener:Function):this;
+        on(event:'serviceUp', listener:(info:Service)=>void):this;
+        on(event:'serviceDown', listener:(info:Service)=>void):this;
     }
 
     interface BrowserStatic {


### PR DESCRIPTION
Function expressions are now implicitly typed, i.e.

```
browser.on('serviceUp', (service) => {
  \\ `service` is strongly typed as `mdns.Service`
});
```
