### PR TITLE
fix passport google oauth types

### DIFF
--- a/passport-google-oauth/passport-google-oauth-tests.ts
+++ b/passport-google-oauth/passport-google-oauth-tests.ts
@@ -18,10 +18,11 @@ passport.use(new google.OAuthStrategy({
             consumerSecret: process.env.GOOGLE_CONSUMER_SECRET,
             callbackURL: process.env.PASSPORT_GOOGLE_CALLBACK_URL
     },
-    function(accessToken:string, refreshToken:string, profile:google.Profile, done:(error:any, user?:any) => void) {
+    function(accessToken:string, refreshToken:string, profile:google.Profile, done:(error:any, user?:any, msg?: google.VerifyOptions) => void) {
          User.findOrCreate(profile.id, profile.provider, function(err, user) {
              if (err) { return done(err); }
-             done(null, user);
+             else if(!user) return done(null, false, {message: 'not found user'});
+             return done(null, user);
          });
     })
 );

--- a/passport-google-oauth/passport-google-oauth.d.ts
+++ b/passport-google-oauth/passport-google-oauth.d.ts
@@ -28,9 +28,17 @@ declare module 'passport-google-oauth' {
         sessionKey?: string;
     }
 
+    interface VerifyOptions {
+        message: string;
+    }
+
+    interface VerifyFunction {
+        (error: any, user?: any, msg?: VerifyOptions): void;
+    }
+
     class OAuthStrategy implements passport.Strategy {
         constructor(options: IOAuthStrategyOption,
-                    verify: (accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any) => void) => void);
+                    verify: (accessToken: string, refreshToken: string, profile: Profile, done: VerifyFunction) => void);
         name: string;
         authenticate: (req: express.Request, options?: Object) => void;
     }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes. 
  See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/passport-local/passport-local.d.ts#L25.
  `passport-google-oauth` uses `passport-google-oauth20` module for OAuth2Strategy. 
  And, it uses general passport interface.
  - it has been reviewed by a DefinitelyTyped member.
