### PR TITLE
Fix body-parser json options object

### DIFF
--- a/body-parser/body-parser.d.ts
+++ b/body-parser/body-parser.d.ts
@@ -33,7 +33,7 @@ declare module "body-parser" {
         /**
          * passed to JSON.parse().
          */
-        receiver?: (key: string, value: any) => any;
+        reviver?: (key: string, value: any) => any;
         /**
          * parse extended syntax with the qs module. (default: true)
          */
@@ -65,7 +65,7 @@ declare module "body-parser" {
             /**
              * passed to JSON.parse().
              */
-            receiver?: (key: string, value: any) => any;
+            reviver?: (key: string, value: any) => any;
         }): express.RequestHandler;
 
         export function raw(options?: {


### PR DESCRIPTION
This is an improvement to the existing `body-parser` type definition.
Source: https://github.com/expressjs/body-parser#reviver
