### PR TITLE
d3 - Adds function type to d3.layout.partition<T>

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -3064,6 +3064,8 @@ declare namespace d3 {
         }
 
         export interface Partition<T extends partition.Node> {
+            (root: T): T[];
+
             nodes(root: T): T[];
 
             links(nodes: T[]): partition.Link<T>[];


### PR DESCRIPTION
Improves existing interface definition for `Parition<T>` to match documentation at https://github.com/d3/d3/wiki/Partition-Layout#_partition. Existing definition was missing function type on interface definition 
