### PR TITLE
Add definitions for common-tags

### DIFF
--- a/common-tags/common-tags-tests.ts
+++ b/common-tags/common-tags-tests.ts
@@ -1,0 +1,156 @@
+/// <reference path="common-tags.d.ts" />
+
+import * as commonTags from 'common-tags';
+
+/* Test Built-in Tags */
+
+commonTags.commaLists `
+  I like ${['apples', 'bananas', 'watermelons']}
+  They're good!
+`;
+
+commonTags.commaListsAnd`
+  I like ${['apples', 'bananas', 'watermelons']}
+  They're good!
+`;
+
+commonTags.commaListsOr`
+  I like ${['apples', 'bananas', 'watermelons']}
+  They're good!
+`;
+
+let fruits = ['apple', 'orange', 'watermelon'];
+
+commonTags.html`
+  <div class="list">
+    <ul>
+      ${fruits.map(fruit => `<li>${fruit}</li>`)}
+      ${'<li>kiwi</li>\n<li>guava</li>'}
+    </ul>
+  </div>
+`;
+
+commonTags.codeBlock`
+  <div class="list">
+    <ul>
+      ${fruits.map(fruit => `<li>${fruit}</li>`)}
+      ${'<li>kiwi</li>\n<li>guava</li>'}
+    </ul>
+  </div>
+`;
+
+commonTags.source`
+  <div class="list">
+    <ul>
+      ${fruits.map(fruit => `<li>${fruit}</li>`)}
+      ${'<li>kiwi</li>\n<li>guava</li>'}
+    </ul>
+  </div>
+`;
+
+commonTags.oneLine`
+  foo
+  bar
+  baz
+`;
+
+commonTags.oneLineTrim`
+  https://news.com/article
+  ?utm_source=designernews.co
+`;
+
+commonTags.oneLineCommaLists`
+  I like ${['apples', 'bananas', 'watermelons']}
+  They're good!
+`;
+
+commonTags.oneLineCommaListsOr`
+  I like ${['apples', 'bananas', 'watermelons']}
+  They're good!
+`;
+
+commonTags.oneLineCommaListsAnd`
+  I like ${['apples', 'bananas', 'watermelons']}
+  They're good!
+`;
+
+commonTags.inlineLists`
+  I like ${['apples', 'bananas', 'watermelons']}
+  They're good!
+`;
+
+commonTags.oneLineInlineLists`
+  I like ${['apples', 'bananas', 'watermelons']}
+  They're good!
+`;
+
+let verb = 'notice';
+
+commonTags.stripIndent`
+  This is a multi-line string.
+  You'll ${verb} that it is indented.
+  We don't want to output this indentation.
+    But we do want to keep this line indented.
+`;
+
+commonTags.stripIndents`
+  This is a multi-line string.
+  You'll ${verb} that it is indented.
+  We don't want to output this indentation.
+    We don't want to keep this line indented either.
+`;
+
+/* Test Tag Constructor */
+
+new commonTags.TemplateTag();
+
+const substitutionReplacer = (oldValue : string, newValue : string) => ({
+    onSubstitution(substitution : string, resultSoFar : string) {
+        if (substitution === oldValue) {
+            return newValue;
+        }
+        return substitution;
+    }
+});
+
+new commonTags.TemplateTag(substitutionReplacer('fizz', 'buzz'));
+
+new commonTags.TemplateTag(
+    substitutionReplacer('fizz', 'buzz'),
+    substitutionReplacer('foo', 'bar')
+);
+
+new commonTags.TemplateTag([
+    substitutionReplacer('fizz', 'buzz'),
+    substitutionReplacer('foo', 'bar')
+]);
+
+new commonTags.TemplateTag({});
+
+new commonTags.TemplateTag({
+    onEndResult: endResult => `${endResult}!`
+});
+
+new commonTags.TemplateTag({
+    onSubstitution: substitution => `${substitution}!`,
+    onEndResult: endResult => `${endResult}!`
+});
+
+/* Tests Built-in Transformers */
+
+new commonTags.TemplateTag(commonTags.trimResultTransformer());
+new commonTags.TemplateTag(commonTags.trimResultTransformer('left'));
+new commonTags.TemplateTag(commonTags.trimResultTransformer('right'));
+
+new commonTags.TemplateTag(commonTags.stripIndentTransformer());
+new commonTags.TemplateTag(commonTags.stripIndentTransformer('initial'));
+new commonTags.TemplateTag(commonTags.stripIndentTransformer('all'));
+
+new commonTags.TemplateTag(commonTags.replaceResultTransformer('foo', 'bar'));
+
+new commonTags.TemplateTag(commonTags.inlineArrayTransformer());
+new commonTags.TemplateTag(commonTags.inlineArrayTransformer({}));
+new commonTags.TemplateTag(commonTags.inlineArrayTransformer({separator: 'foo'}));
+new commonTags.TemplateTag(commonTags.inlineArrayTransformer({conjunction: 'bar'}));
+
+new commonTags.TemplateTag(commonTags.splitStringTransformer('foo'));

--- a/common-tags/common-tags.d.ts
+++ b/common-tags/common-tags.d.ts
@@ -1,0 +1,62 @@
+// Type definitions for common-tags v1.2.1
+// Project: https://github.com/declandewet/common-tags
+// Definitions by: Viktor Zozuliak <https://github.com/zuzusik>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'common-tags' {
+    type TemplateTag = (literals: string[], ...placeholders: any[]) => string;
+
+    type TemplateTransformer = {
+        onSubstitution?: (substitution: string, resultSoFar: string) => string;
+        onEndResult?: (endResult : string) => string;
+    }
+
+    /* Built-in Tags */
+    export var commaLists: TemplateTag;
+
+    export var commaListsAnd: TemplateTag;
+
+    export var commaListsOr: TemplateTag;
+
+    export var html: TemplateTag;
+
+    export var codeBlock: TemplateTag;
+
+    export var source: TemplateTag;
+
+    export var oneLine: TemplateTag;
+
+    export var oneLineTrim: TemplateTag;
+
+    export var oneLineCommaLists: TemplateTag;
+
+    export var oneLineCommaListsOr: TemplateTag;
+
+    export var oneLineCommaListsAnd: TemplateTag;
+
+    export var inlineLists: TemplateTag;
+
+    export var oneLineInlineLists: TemplateTag;
+
+    export var stripIndent: TemplateTag;
+
+    export var stripIndents: TemplateTag;
+
+    /* New Tag Constructor */
+    export var TemplateTag: {
+        new(): TemplateTag;
+        new(...transformers: TemplateTransformer[]): TemplateTag;
+        new(transformers: TemplateTransformer[]): TemplateTag;
+    };
+
+    /* Built-in Transformers */
+    export var trimResultTransformer: (side?: 'left'|'right') => TemplateTransformer;
+
+    export var stripIndentTransformer: (type?: 'initial'|'all') => TemplateTransformer;
+
+    export var replaceResultTransformer: (replaceWhat: string, replaceWith: string) => TemplateTransformer;
+
+    export var inlineArrayTransformer: (opts?: {separator?: string, conjunction?: string}) => TemplateTransformer;
+
+    export var splitStringTransformer: (splitBy: string) => TemplateTransformer;
+}


### PR DESCRIPTION
Docs: https://github.com/declandewet/common-tags
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
