### PR TITLE
Add missing bootstrap transition support

### DIFF
--- a/bootstrap/bootstrap-tests.ts
+++ b/bootstrap/bootstrap-tests.ts
@@ -44,3 +44,8 @@ $('.typeahead').typeahead({
 });
 
 $('#navbar').affix();
+
+$('.item').emulateTransitionEnd(2000);
+
+$.support.transition = false;
+console.log(($.support.transition as TransitionEventNames).end === "transitionend");

--- a/bootstrap/bootstrap.d.ts
+++ b/bootstrap/bootstrap.d.ts
@@ -53,7 +53,7 @@ interface PopoverOptions {
 }
 
 interface CollapseOptions {
-    parent?: any;    
+    parent?: any;
     toggle?: boolean;
 }
 
@@ -77,6 +77,10 @@ interface TypeaheadOptions {
 interface AffixOptions {
     offset?: number | Function | Object;
     target?: any;
+}
+
+interface TransitionEventNames {
+    end: string;
 }
 
 interface JQuery {
@@ -114,6 +118,12 @@ interface JQuery {
     typeahead(options?: TypeaheadOptions): JQuery;
 
     affix(options?: AffixOptions): JQuery;
+
+    emulateTransitionEnd(duration: number): JQuery;
+}
+
+interface JQuerySupport {
+    transition: boolean | TransitionEventNames;
 }
 
 declare module "bootstrap" {


### PR DESCRIPTION
I needed these while working with the alert plugin and adding support to hide them instead of dismiss them.

Docs: http://getbootstrap.com/javascript/#transitions
