### PR TITLE
[knex] allow object for .raw parameters

### DIFF
--- a/knex/knex-tests.ts
+++ b/knex/knex-tests.ts
@@ -162,6 +162,8 @@ knex.select('*').from('users').join('accounts', function() {
 
 knex.select('*').from('users').join('accounts', 'accounts.type', knex.raw('?', ['admin']));
 
+knex.raw('select * from users where id = :user_id', { user_id: 1 });
+
 knex.from('users').innerJoin('accounts', 'users.id', 'accounts.user_id');
 
 knex.table('users').innerJoin('accounts', 'users.id', '=', 'accounts.user_id');

--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -249,6 +249,7 @@ declare module "knex" {
       (value: Value): Raw;
       (sql: string, ...bindings: Value[]): Raw;
       (sql: string, bindings: Value[]): Raw;
+      (sql: string, bindings: Object): Raw;
     }
 
     //


### PR DESCRIPTION
As per http://knexjs.org/#Raw-Bindings
knexjs allows one to pass an Object to bind named parameters to raw sql. This PR enables that functionality.
