### PR TITLE
Add parameter types for assert() in Koa.

### DIFF
--- a/base64-js/base64-js-tests.ts
+++ b/base64-js/base64-js-tests.ts
@@ -1,0 +1,6 @@
+/// <reference path="base64-js.d.ts" />
+
+import base64js = require('base64-js');
+
+const bytes: Uint8Array = base64js.toByteArray('shemp');
+const decoded: string = base64js.fromByteArray(new Uint8Array(0));

--- a/base64-js/base64-js.d.ts
+++ b/base64-js/base64-js.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for base64-js v1.1.2
+// Project: https://github.com/beatgammit/base64-js
+// Definitions by: Peter Safranek <https://github.com/pe8ter>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'base64-js' {
+
+    export function toByteArray(encoded: string): Uint8Array;
+    export function fromByteArray(bytes: Uint8Array): string;
+}

--- a/koa/koa.d.ts
+++ b/koa/koa.d.ts
@@ -38,7 +38,7 @@ declare module "koa" {
         toJSON(): any;
         inspect(): any;
         throw(code?: any, message?: any): void;
-        assert(): void;
+        assert(test: any, status: number, message: string): void;
     }
 
     export interface Request {


### PR DESCRIPTION
Relevant source file showing what parameters Koa needs for `assert()`:

https://github.com/koajs/koa/blob/v2.x/lib/context.js#L55
