### PR TITLE
Add parameter types for assert() to Koa.

### DIFF
--- a/koa/koa-tests.ts
+++ b/koa/koa-tests.ts
@@ -9,6 +9,7 @@ app.use((ctx, next) => {
     const end: any = new Date();
     const ms = end - start;
     console.log(`${ctx.method} ${ctx.url} - ${ms}ms`);
+    ctx.assert(true, 404, 'Yep!');
   });
 });
 

--- a/koa/koa.d.ts
+++ b/koa/koa.d.ts
@@ -38,7 +38,7 @@ declare module "koa" {
         toJSON(): any;
         inspect(): any;
         throw(code?: any, message?: any): void;
-        assert(): void;
+        assert(test: any, status: number, message: string): void;
     }
 
     export interface Request {


### PR DESCRIPTION
Relevant source file showing what parameters Koa needs for `assert()`:

https://github.com/koajs/koa/blob/v2.x/lib/context.js#L55
