### PR TITLE
Update systemjs.d.ts

### DIFF
--- a/systemjs/systemjs.d.ts
+++ b/systemjs/systemjs.d.ts
@@ -119,7 +119,7 @@ declare namespace SystemJSLoader {
          * The default extension to add to modules requested within the package. Takes preference over defaultJSExtensions.
          * Can be set to defaultExtension: false to optionally opt-out of extension-adding when defaultJSExtensions is enabled.
          */
-        defaultExtension?: boolean;
+        defaultExtension?: boolean | string;
 
         /**
          * Local and relative map configurations scoped to the package. Apply for subpaths as well.


### PR DESCRIPTION
case 2. Improvement to existing type definition.

defaultExtension property also supports string type.
https://github.com/systemjs/systemjs/blob/master/docs/config-api.md#packages
