### PR TITLE
Add .d.ts for weighted

### DIFF
--- a/weighted/weighted-tests.ts
+++ b/weighted/weighted-tests.ts
@@ -1,0 +1,30 @@
+/// <reference path="./weighted.d.ts" />
+import * as weighted from 'weighted';
+
+function testSet() {
+    var options = ['Wake Up', 'Snooze Alarm'];
+    var weights = [0.25, 0.75];
+
+    console.log('Decision:', weighted.select(options, weights));
+}
+
+function testObj() {
+    var options = {
+        'Wake Up': 0.25,
+        'Snooze Alarm': 0.75
+    };
+
+    console.log('Decision:', weighted.select(options));
+}
+
+function testOverrideRand() {
+    var options = ['Wake Up', 'Snooze Alarm'];
+	var weights = [0.25, 0.75];
+
+    function rand() {
+        return 4; // chosen by fair dice roll.
+                  // guaranteed to be random.  
+    }
+
+    console.log('Decision:', weighted.select(options, weights, rand));
+}

--- a/weighted/weighted.d.ts
+++ b/weighted/weighted.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for weighted
+// Project: https://github.com/Schoonology/weighted
+// Definitions by: Craig Citro <https://github.com/ccitro>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'weighted' {
+    export interface RandomFunc {
+        (): Number;
+    }  
+
+    export function select<T> (set: T[], weights: Number[], rand?: RandomFunc): T;
+    export function select<T> (obj: Object, rand?: RandomFunc): T;
+}


### PR DESCRIPTION
Adds types for current version of weighted (0.3.0)

https://www.npmjs.com/package/weighted 
https://github.com/Schoonology/weighted
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
