### PR TITLE
Add mocha's `specify` function

### DIFF
--- a/mocha/mocha-tests.ts
+++ b/mocha/mocha-tests.ts
@@ -66,6 +66,21 @@ function test_test() {
     });
 }
 
+function test_specify() {
+
+    specify('does something', () => { });
+
+    specify('does something', (done) => { done(); });
+
+    specify.only('does something', () => { });
+
+    specify.skip('does something', () => { });
+
+    specify('does something', function () {
+        this.timeout(2000);
+    });
+}
+
 function test_before() {
     before(() => { });
 

--- a/mocha/mocha.d.ts
+++ b/mocha/mocha.d.ts
@@ -44,6 +44,7 @@ declare var it: Mocha.ITestDefinition;
 declare var xit: Mocha.ITestDefinition;
 // alias for `it`
 declare var test: Mocha.ITestDefinition;
+declare var specify: Mocha.ITestDefinition;
 
 declare function before(action: () => void): void;
 


### PR DESCRIPTION
I also added the appropriate tests.

From [https://mochajs.org](mochajs.org):

> The BDD interface provides describe(), context(), it(), **specify()**, before(), after(), beforeEach(), and afterEach().
> 
> context() is just an alias for describe(), and behaves the same way; it just provides a way to keep tests easier to read and organized. Similarly, **specify() is an alias for it()**.
