### PR TITLE
Add definition for split2

### DIFF
--- a/split2/split2-tests.ts
+++ b/split2/split2-tests.ts
@@ -1,0 +1,31 @@
+/// <reference path="./split2.d.ts" />
+/// <reference path="../node/node.d.ts" />
+import * as split from 'split2';
+import * as fs from 'fs';
+import { Transform, TransformOptions } from 'stream';
+
+let stream: Transform;
+let options: split.Options = {};
+let matcherString = '\t';
+let matcherRegex = /\r?\n/;
+
+stream = split();
+stream = split(JSON.parse);
+stream = split(options);
+stream = split(JSON.parse, options);
+stream = split(matcherString);
+stream = split(matcherString, JSON.parse);
+stream = split(matcherString, options);
+stream = split(matcherString, JSON.parse, options);
+stream = split(matcherRegex);
+stream = split(matcherRegex, JSON.parse);
+stream = split(matcherRegex, options);
+stream = split(matcherRegex, JSON.parse, options);
+
+options = {
+  maxLength: 1000,
+  objectMode: true,
+  highWaterMark: 16,
+  encoding: 'utf8'
+};
+

--- a/split2/split2.d.ts
+++ b/split2/split2.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for split2 2.1.0
+// Project: https://github.com/mcollina/split2
+// Definitions by: TANAKA Koichi <https://github.com/mugeso/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+declare module "split2" {
+    import { Transform, TransformOptions } from 'stream';
+
+    type Matcher = string|RegExp;
+    type Mapper = split.Mapper;
+    type Options = split.Options;
+
+    function split(): Transform;
+    function split(matcher: Matcher): Transform;
+    function split(mapper: Mapper): Transform;
+    function split(options: Options): Transform;
+    function split(matcher: Matcher, mapper: Mapper): Transform;
+    function split(matcher: Matcher, options: Options): Transform;
+    function split(mapper: Mapper, options: Options): Transform;
+    function split(matcher: Matcher, mapper: Mapper, options: Options): Transform;
+
+    namespace split {
+        export interface Mapper {
+            (line: string): any;
+        }
+
+        export interface Options extends TransformOptions {
+           maxLength?: number;
+        }
+    }
+
+    export = split;
+}


### PR DESCRIPTION
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

npm: https://www.npmjs.com/package/split2
project: https://github.com/mcollina/split2
