### PR TITLE
Add public Knex APIs: TableBuilder.bigIncrements, SchemaBuilder.createTableIfNotExists, QueryBuilder.on()

### DIFF
--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -301,6 +301,7 @@ declare module "knex" {
 
     interface SchemaBuilder extends Promise<any> {
       createTable(tableName: string, callback: (tableBuilder: CreateTableBuilder) => any): SchemaBuilder;
+      createTableIfNotExists(tableName: string, callback: (tableBuilder: CreateTableBuilder) => any): SchemaBuilder;
       renameTable(oldTableName: string, newTableName: string): Promise<void>;
       dropTable(tableName: string): SchemaBuilder;
       hasTable(tableName: string): Promise<boolean>;

--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -312,6 +312,7 @@ declare module "knex" {
 
     interface TableBuilder {
       increments(columnName?: string): ColumnBuilder;
+      bigIncrements(columnName?: string): ColumnBuilder;
       dropColumn(columnName: string): TableBuilder;
       dropColumns(...columnNames: string[]): TableBuilder;
       renameColumn(from: string, to: string): ColumnBuilder;

--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -31,6 +31,7 @@ declare module "knex" {
     migrate: Knex.Migrator;
     seed: any;
     fn: any;
+    on(eventName: string, callback: Function): Knex.QueryBuilder;
   }
 
   function Knex(config: Knex.Config) : Knex;


### PR DESCRIPTION
Improvement to existing type definitions for Knex:

url: http://knexjs.org/#Schema-increments

> "...also available is a `bigIncrements`"

and

url: http://knexjs.org/#Schema-createTableIfNotExists

and

url: http://knexjs.org/#Interfaces-Events
