### PR TITLE
Correct PackageConfig.defaultExtension type for SystemJS definition.

### DIFF
--- a/systemjs/systemjs.d.ts
+++ b/systemjs/systemjs.d.ts
@@ -119,7 +119,7 @@ declare namespace SystemJSLoader {
          * The default extension to add to modules requested within the package. Takes preference over defaultJSExtensions.
          * Can be set to defaultExtension: false to optionally opt-out of extension-adding when defaultJSExtensions is enabled.
          */
-        defaultExtension?: boolean;
+        defaultExtension?: string | boolean;
 
         /**
          * Local and relative map configurations scoped to the package. Apply for subpaths as well.


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- [x] documentation or source code reference which provides context for the suggested changes.
  - https://github.com/systemjs/systemjs/blob/master/docs/config-api.md#packages
- [ ] it has been reviewed by a DefinitelyTyped member.

Because property `defaultExtension` can take a string value such as `"js"`, this commit correct that.
