### PR TITLE
[material-ui] Add `containerElement` to buttons

### DIFF
--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -641,6 +641,7 @@ declare namespace __MaterialUI {
         touchRippleColor?: string;
         touchRippleOpacity?: number;
         type?: string;
+        containerElement?: React.ReactNode | string;
     }
 
     interface EnhancedButtonProps extends React.HTMLAttributes, SharedEnhancedButtonProps<EnhancedButton> {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url https://github.com/callemall/material-ui/issues/850#issuecomment-112662943

All buttons have the `containerElement` prop available to them to embed other React elements inside them — for instance, the `<Link />` from `react-router`.
