### PR TITLE
Nodejs definitions: Adding destroy method to ReadStream interface

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1399,6 +1399,7 @@ declare module "fs" {
 
     export interface ReadStream extends stream.Readable {
         close(): void;
+        destroy(): void;
     }
     export interface WriteStream extends stream.Writable {
         close(): void;


### PR DESCRIPTION
Just added missed method to the definition
