### PR TITLE
fix(react-redux):Fixes issue with decorator @connect

### DIFF
--- a/react-redux/react-redux.d.ts
+++ b/react-redux/react-redux.d.ts
@@ -47,25 +47,25 @@ declare module "react-redux" {
   export function connect<TStateProps, TDispatchProps, TOwnProps>(
     mapStateToProps: MapStateToProps<TStateProps, TOwnProps>,
     mapDispatchToProps?: MapDispatchToPropsFunction<TDispatchProps, TOwnProps>|MapDispatchToPropsObject
-  ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
+  ): any;
 
   export function connect<TStateProps, TDispatchProps, TOwnProps>(
     mapStateToProps: MapStateToProps<TStateProps, TOwnProps>,
     mapDispatchToProps: MapDispatchToPropsFunction<TDispatchProps, TOwnProps>|MapDispatchToPropsObject,
     mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps>,
     options?: Options
-  ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
+  ): any;
 
   interface MapStateToProps<TStateProps, TOwnProps> {
     (state: any, ownProps?: TOwnProps): TStateProps;
   }
 
   interface MapDispatchToPropsFunction<TDispatchProps, TOwnProps> {
-    (dispatch: Dispatch, ownProps?: TOwnProps): TDispatchProps;
+    (dispatch: Dispatch<any>, ownProps?: TOwnProps): TDispatchProps;
   }
 
   interface MapDispatchToPropsObject {
-    [name: string]: ActionCreator;
+    [name: string]: ActionCreator<any>;
   }
 
   interface MergeProps<TStateProps, TDispatchProps, TOwnProps> {
@@ -92,7 +92,7 @@ declare module "react-redux" {
     /**
      * The single Redux store in your application.
      */
-    store?: Store;
+    store?: Store<any>;
     children?: ReactNode;
   }
 

--- a/react-redux/react-redux.d.ts
+++ b/react-redux/react-redux.d.ts
@@ -47,14 +47,14 @@ declare module "react-redux" {
   export function connect<TStateProps, TDispatchProps, TOwnProps>(
     mapStateToProps: MapStateToProps<TStateProps, TOwnProps>,
     mapDispatchToProps?: MapDispatchToPropsFunction<TDispatchProps, TOwnProps>|MapDispatchToPropsObject
-  ): any;
+  ): ComponentClass<TStateProps & TDispatchProps & TOwnProps>;
 
   export function connect<TStateProps, TDispatchProps, TOwnProps>(
     mapStateToProps: MapStateToProps<TStateProps, TOwnProps>,
     mapDispatchToProps: MapDispatchToPropsFunction<TDispatchProps, TOwnProps>|MapDispatchToPropsObject,
     mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps>,
     options?: Options
-  ): any;
+  ): ComponentClass<TStateProps & TDispatchProps & TOwnProps>;
 
   interface MapStateToProps<TStateProps, TOwnProps> {
     (state: any, ownProps?: TOwnProps): TStateProps;

--- a/react-redux/react-redux.d.ts
+++ b/react-redux/react-redux.d.ts
@@ -61,11 +61,11 @@ declare module "react-redux" {
   }
 
   interface MapDispatchToPropsFunction<TDispatchProps, TOwnProps> {
-    (dispatch: Dispatch<any>, ownProps?: TOwnProps): TDispatchProps;
+    (dispatch: Dispatch, ownProps?: TOwnProps): TDispatchProps;
   }
 
   interface MapDispatchToPropsObject {
-    [name: string]: ActionCreator<any>;
+    [name: string]: ActionCreator;
   }
 
   interface MergeProps<TStateProps, TDispatchProps, TOwnProps> {
@@ -92,7 +92,7 @@ declare module "react-redux" {
     /**
      * The single Redux store in your application.
      */
-    store?: Store<any>;
+    store?: Store;
     children?: ReactNode;
   }
 


### PR DESCRIPTION
Fixes issue with decorator **@ connect** and also fixes generic tpyes dispatch, actioncreator and store with generic type any.

You normally use **@ connect** as a decorator. So normally **you do not care** about the **return type** of this decorator.
I decied to make the return type to any to fix the following error: 

> Unable to resolve signature of class decorator when called as an expression.  Type 'ComponentClass<{}>' is not assignable to type 'void'.`

~~Also put the generic of Dispatch, ActionCreator and Store to any. To preserve the interfaces for unnecessary complexity. Fixes following issues:~~

> ~~Generic type 'Dispatch< S >' requires 1 type argument(s).~~
> ~~Generic type 'ActionCreator< A >' requires 1 type argument(s).~~
> ~~Generic type 'Store< S >' requires 1 type argument(s)~~
