### PR TITLE
add two interface:ClientSSLSecurity and setEndpoint

### DIFF
--- a/soap/soap-tests.ts
+++ b/soap/soap-tests.ts
@@ -11,7 +11,10 @@ const wsdlOptions = { name: 'value' };
 soap.createClient(url, wsdlOptions, function(err: any, client: soap.Client) {
     let securityOptions = { 'hasTimeStamp': false };
     client.setSecurity(new soap.WSSecurity('user', 'password', securityOptions));
+    let defaults = {'rejectUnauthorized': false};
+    client.setSecurity(new soap.ClientSSLSecurity('/path/to/key', '/path/to/cert', '/path/to/ca',defaults));
     client.addSoapHeader({});
+    client.setEndpoint('http://localhost');
     client['create']({ name: 'value' }, function(err, result) {
         // result is an object
     });

--- a/soap/soap.d.ts
+++ b/soap/soap.d.ts
@@ -8,12 +8,12 @@
 declare module 'soap' {
     import * as events from 'events';
 
-    class Security {
+    interface Security {
     }
-    class WSSecurity extends Security {
+    class WSSecurity implements   Security {
         constructor(username: string, password: string, options: any);
     }
-    class ClientSSLSecurity extends Security {
+    class ClientSSLSecurity implements   Security {
         constructor(key: string, cert: string, ca: string, defaults: any);
     }
     interface Client extends events.EventEmitter {

--- a/soap/soap.d.ts
+++ b/soap/soap.d.ts
@@ -8,13 +8,19 @@
 declare module 'soap' {
     import * as events from 'events';
 
-    class WSSecurity {
+    class Security {
+    }
+    class WSSecurity extends Security {
         constructor(username: string, password: string, options: any);
     }
+    class ClientSSLSecurity extends Security {
+        constructor(key: string, cert: string, ca: string, defaults: any);
+    }
     interface Client extends events.EventEmitter {
-        setSecurity(s: WSSecurity): void;
+        setSecurity(s: Security): void;
         [method: string]: (args: any, fn: (err: any, result: any) => void, options?: any, extraHeaders?: any) => void;
         addSoapHeader(headJSON: any): void;
+        setEndpoint(endpoint: string): void;
     }
     function createClient(wsdlPath: string, options: any, fn: (err: any, client: Client) => void): void;
 


### PR DESCRIPTION
 soap/soap.d.ts Improvement to existing type definition.
- add interface setEndpoint .  url https://github.com/vpulim/node-soap#clientsetendpointurl---overwrite-the-soap-service-endpoint-address.
  -add interface ClientSSLSecurity. url:https://github.com/vpulim/node-soap#clientsslsecurity
