### PR TITLE
IRaygunOptions parameter type change

### DIFF
--- a/raygun4js/raygun4js.d.ts
+++ b/raygun4js/raygun4js.d.ts
@@ -62,8 +62,8 @@ declare namespace raygun {
         ignoreAjaxAbort?: boolean;
         ignoreAjaxError?: boolean;
         disableAnonymousUserTracking?: boolean;
-        excludedHostnames?: boolean;
-        excludedUserAgents?: boolean;
+        excludedHostnames?: boolean | string[];
+        excludedUserAgents?: boolean | string[];
         wrapAsynchronousCallbacks?: boolean;
         debugMode?: boolean;
         ignore3rdPartyErrors?: boolean;

--- a/raygun4js/raygun4js.d.ts
+++ b/raygun4js/raygun4js.d.ts
@@ -62,8 +62,8 @@ declare namespace raygun {
         ignoreAjaxAbort?: boolean;
         ignoreAjaxError?: boolean;
         disableAnonymousUserTracking?: boolean;
-        excludedHostnames?: boolean | string[];
-        excludedUserAgents?: boolean | string[];
+        excludedHostnames?: (string|Regex)[];
+        excludedUserAgents?: (string|Regex)[];
         wrapAsynchronousCallbacks?: boolean;
         debugMode?: boolean;
         ignore3rdPartyErrors?: boolean;

--- a/raygun4js/raygun4js.d.ts
+++ b/raygun4js/raygun4js.d.ts
@@ -62,8 +62,8 @@ declare namespace raygun {
         ignoreAjaxAbort?: boolean;
         ignoreAjaxError?: boolean;
         disableAnonymousUserTracking?: boolean;
-        excludedHostnames?: (string|Regex)[];
-        excludedUserAgents?: (string|Regex)[];
+        excludedHostnames?: (string|RegExp)[];
+        excludedUserAgents?: (string|RegExp)[];
         wrapAsynchronousCallbacks?: boolean;
         debugMode?: boolean;
         ignore3rdPartyErrors?: boolean;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

By looking at the https://github.com/MindscapeHQ/raygun4js/blob/c7d8880045214ab6d403d5cc613c207f696a3cdd/src/raygun.js#L507-529 it looks like the `excludedHostnames` and `excludedUserAgents` can be an array of strings as well.
