### PR TITLE
Export type RouteProps

### DIFF
--- a/react-router/react-router.d.ts
+++ b/react-router/react-router.d.ts
@@ -484,6 +484,7 @@ declare module "react-router" {
     export type RouterState = ReactRouter.RouterState
     export type HistoryBase = ReactRouter.HistoryBase
     export type RouterOnContext = ReactRouter.RouterOnContext
+    export type RouteProps = ReactRouter.RouteProps
 
     export {
         Router,


### PR DESCRIPTION
I tried using the latest `react-router/react-router.d.ts` file in this repo and had problems.
Type of Route is not exported, we need that type when using [Dynamic Routing](https://github.com/reactjs/react-router/blob/master/docs/guides/DynamicRouting.md#dynamic-routing)
