### PR TITLE
Missing dialogData

### DIFF
--- a/umbraco/umbraco-services.d.ts
+++ b/umbraco/umbraco-services.d.ts
@@ -494,11 +494,10 @@ declare namespace umbraco.services {
         width?: number;
         /*strips the modal from any animation and wrappers, used when you want to inject a dialog into an existing container*/
         inline?: boolean;
-        
         /** 
          * It will set this value as a property on the dialog controller's scope as $scope.dialogData
          */
-	dialogData: any;
+	dialogData?: any;
     }
 
     /**

--- a/umbraco/umbraco-services.d.ts
+++ b/umbraco/umbraco-services.d.ts
@@ -494,6 +494,11 @@ declare namespace umbraco.services {
         width?: number;
         /*strips the modal from any animation and wrappers, used when you want to inject a dialog into an existing container*/
         inline?: boolean;
+        
+        /** 
+         * It will set this value as a property on the dialog controller's scope as $scope.dialogData
+         */
+	dialogData: any;
     }
 
     /**


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

As mentioned here:
https://www.proworks.com/blog/archive/how-to-pass-data-to-the-umbraco-7-dialogservice-on-open/

And shown in the core here:
https://github.com/umbraco/Umbraco-CMS/blob/dev-v7/src/Umbraco.Web.UI.Client/src/common/services/dialog.service.js#L92
