### PR TITLE
Exposing dropdown popup

### DIFF
--- a/kendo-ui/kendo-ui.d.ts
+++ b/kendo-ui/kendo-ui.d.ts
@@ -3335,6 +3335,7 @@ declare namespace kendo.ui {
         static fn: DropDownList;
 
         options: DropDownListOptions;
+        popup: kendo.ui.Popup;
 
         dataSource: kendo.data.DataSource;
         span: JQuery;


### PR DESCRIPTION
The dropdown list inherits from list. During construction, list constructs a popup and makes it public according to naming convention (_ prefixes are private).

https://github.com/telerik/kendo-ui-core/blob/master/src/kendo.list.js#L614
