### PR TITLE
add resolve module

### DIFF
--- a/resolve/resolve-tests.ts
+++ b/resolve/resolve-tests.ts
@@ -1,0 +1,83 @@
+/// <reference path="resolve.d.ts" />
+
+import * as fs from 'fs';
+import * as resolve from 'resolve';
+
+function test_basic_async() {
+  resolve('typescript', function(error, resolved) {
+    if (error) {
+      console.error(error.message);
+      return;
+    }
+    console.log(resolved);
+  });
+}
+
+function test_basic_sync() {
+  var resolved = resolve.sync('typescript');
+  console.log(resolved);
+}
+
+function test_options_async() {
+  resolve('typescript', {
+    basedir: process.cwd(),
+    package: {},
+    extensions: ['.js'],
+    packageFilter: function(pkg, pkgfile) {
+      return pkg;
+    },
+    pathFilter: function(pkg, path, relativePath) {
+      return path
+    },
+    paths: [process.cwd()],
+    moduleDirectory: 'node_modules',
+    readFile: fs.readFile,
+    isFile: function(file, cb) {
+      fs.stat(file, function(error, stat) {
+        if (error && error.code === 'ENOENT') {
+          return cb(null, false);
+        } else if (error) {
+          return cb(error);
+        } else {
+          return cb(null, stat.isFile());
+        }
+      });
+    }
+  }, function(error, resolved) {
+    if (error) {
+      console.error(error.message);
+      return;
+    }
+    console.log(resolved);
+  });
+}
+
+function test_options_sync() {
+  var resolved = resolve.sync('typescript', {
+    basedir: process.cwd(),
+    package: {},
+    extensions: ['.js'],
+    packageFilter: function(pkg, pkgfile) {
+      return pkg;
+    },
+    pathFilter: function(pkg, path, relativePath) {
+      return path
+    },
+    paths: [process.cwd()],
+    moduleDirectory: 'node_modules',
+    readFileSync: fs.readFileSync,
+    isFile: function(file) {
+      try {
+        return fs.statSync(file).isFile();
+      } catch (error) {
+        return false;
+      }
+    }
+  });
+  console.log(resolved);
+}
+
+function test_is_core() {
+  var fsIsCore = resolve.isCore('fs');
+  var typescriptIsCore = resolve.isCore('typescript');
+}

--- a/resolve/resolve.d.ts
+++ b/resolve/resolve.d.ts
@@ -1,0 +1,102 @@
+// Type definitions for resolve
+// Project: https://github.com/substack/node-resolve
+// Definitions by: Mario Nebl <https://github.com/marionebl>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module 'resolve' {
+  /**
+   * Callback invoked when resolving asynchronously
+   *
+   * @param error
+   * @param resolved Absolute path to resolved identifier
+   */
+  type resolveCallback = (err: Error, resolved?: string) => void;
+
+  /**
+   * Callback invoked when checking if a file exists
+   *
+   * @param error
+   * @param isFile If the given file exists
+   */
+  type isFileCallback = (err: Error, isFile?: boolean) => void;
+
+  /**
+   * Callback invoked when reading a file
+   *
+   * @param error
+   * @param isFile If the given file exists
+   */
+  type readFileCallback = (err: Error, file?: Buffer) => void;
+
+  /**
+   * Asynchronously resolve the module path string id into cb(err, res [, pkg]), where pkg (if defined) is the data from package.json
+   *
+   * @param id Identifier to resolve
+   * @param callback
+   */
+  function resolve(id: string, cb: resolveCallback): void;
+
+  /**
+   * Asynchronously resolve the module path string id into cb(err, res [, pkg]), where pkg (if defined) is the data from package.json
+   *
+   * @param id Identifier to resolve
+   * @param options Options to use for resolving, optional.
+   * @param callback
+   */
+  function resolve(id: string, opts: resolve.AsyncOpts, cb: resolveCallback): void;
+
+  /**
+   * Synchronously resolve the module path string id, returning the result and throwing an error when id can't be resolved.
+   *
+   * @param id Identifier to resolve
+   * @param options Options to use for resolving, optional.
+   */
+  function resolveSync(id: string, opts?: resolve.SyncOpts): string;
+
+  /**
+   * Return whether a package is in core
+   *
+   * @param id
+   */
+  function resolveIsCore(id: string): boolean;
+
+  namespace resolve {
+    interface Opts {
+      // directory to begin resolving from (defaults to __dirname)
+      basedir?: string;
+      // package.json data applicable to the module being loaded
+      package?: any;
+      // array of file extensions to search in order (defaults to ['.js'])
+      extensions?: string|string[];
+      // transform the parsed package.json contents before looking at the "main" field
+      packageFilter?: (pkg: any, pkgfile: string) => any;
+      // transform a path within a package
+      pathFilter?: (pkg: any, path: string, relativePath: string) => string;
+      // require.paths array to use if nothing is found on the normal node_modules recursive walk (probably don't use this)
+      paths?: string|string[];
+      // directory (or directories) in which to recursively look for modules. (default to 'node_modules')
+      moduleDirectory?: string|string[]
+    }
+    
+    export interface AsyncOpts extends Opts {
+      // how to read files asynchronously (defaults to fs.readFile)
+      readFile?: (file: string, cb: readFileCallback) => void;
+      // function to asynchronously test whether a file exists
+      isFile?: (file: string, cb: isFileCallback) => void;
+    }
+
+    export interface SyncOpts extends Opts {
+      // how to read files synchronously (defaults to fs.readFileSync)
+      readFileSync?: (file: string) => Buffer;
+      // function to synchronously test whether a file exists
+      isFile?: (file: string) => boolean;
+    }
+
+    export var sync: typeof resolveSync;
+    export var isCore: typeof resolveIsCore;
+  }
+  
+  export = resolve;
+}


### PR DESCRIPTION
Adds typings for [resolve](https://github.com/substack/node-resolve)
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
