### PR TITLE
add browser resolve module

### DIFF
--- a/browser-resolve/browser-resolve-tests.ts
+++ b/browser-resolve/browser-resolve-tests.ts
@@ -1,0 +1,39 @@
+/// <reference path="./browser-resolve.d.ts" />
+
+import * as browserResolve from 'browser-resolve';
+
+function basic_test_async(callback: (err?: Error, resolved?: string) => void) {
+  browserResolve('typescript', function(error, resolved) {
+    if (error) {
+      return callback(error);
+    }
+    callback(null, resolved);
+  });
+}
+
+function basic_test_sync() {
+  var resolved = browserResolve.sync('typescript');
+}
+
+function options_test_async() {
+  browserResolve('typescript', {
+    browser: 'jsnext:main',
+    filename: './browser-resolve/browser-resolve.js',
+    modules: {
+      fs: './fs-shim.js'
+    }
+  }, function(error, resolved) {
+    if (error) {
+      console.error(error);
+      return;
+    }
+    console.log(resolved);
+  });
+}
+
+function options_test_sync() {
+  var resolved = browserResolve.sync('typescript', {
+    filename: './browser-resolve/browser-resolve.js',
+    modules: {}
+  });
+}

--- a/browser-resolve/browser-resolve.d.ts
+++ b/browser-resolve/browser-resolve.d.ts
@@ -1,0 +1,61 @@
+// Type definitions for browser-resolve
+// Project: https://github.com/defunctzombie/node-browser-resolve
+// Definitions by: Mario Nebl <https://github.com/marionebl/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../resolve/resolve.d.ts" />
+
+declare module 'browser-resolve' {
+  import * as resolve from 'resolve';
+
+  /**
+   * Callback invoked when resolving asynchronously
+   *
+   * @param error
+   * @param resolved Absolute path to resolved identifier
+   */
+  type resolveCallback = (err?: Error, resolved?: string) => void;
+
+  /**
+   * Resolve a module path and call cb(err, path [, pkg])
+   *
+   * @param id Identifier to resolve
+   * @param callback
+   */
+  function browserResolve(id: string, cb: resolveCallback): void;
+
+  /**
+   * Resolve a module path and call cb(err, path [, pkg])
+   *
+   * @param id Identifier to resolve
+   * @param options Options to use for resolving, optional.
+   * @param callback
+   */
+  function browserResolve(id: string, opts: browserResolve.AsyncOpts, cb: resolveCallback): void;
+
+  /**
+   * Returns a module path
+   *
+   * @param id Identifier to resolve
+   * @param options Options to use for resolving, optional.
+   */
+  function browserResolveSync(id: string, opts?: browserResolve.SyncOpts): string;
+
+  namespace browserResolve {
+    interface Opts {
+      // the 'browser' property to use from package.json (defaults to 'browser')
+      browser?: string;
+      // the calling filename where the require() call originated (in the source)
+      filename?: string;
+      // modules object with id to path mappings to consult before doing manual resolution (use to provide core modules)
+      modules?: any;
+    }
+
+    export interface AsyncOpts extends resolve.AsyncOpts, Opts {}
+    export interface SyncOpts extends resolve.SyncOpts, Opts {}
+
+    export var sync: typeof browserResolveSync;
+  }
+
+  export = browserResolve
+}


### PR DESCRIPTION
**Checklist**
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Depends on #9734 
