### PR TITLE
[browser-pack] Added browser-pack definition

### DIFF
--- a/browser-pack/browser-pack-tests.ts
+++ b/browser-pack/browser-pack-tests.ts
@@ -1,0 +1,33 @@
+/// <reference path="browser-pack.d.ts" />
+
+import browserPack = require("browser-pack");
+
+module BrowserPackTest {
+
+    export function packIt(opts?: BrowserPack.Options) {
+        var packOpts: BrowserPack.Options = {
+            basedir: opts.basedir || "./",
+            externalRequireName: opts.externalRequireName || "require",
+            hasExports: opts.hasExports || false,
+            prelude: opts.prelude || undefined,
+            preludePath: opts.preludePath || undefined,
+            raw: opts.raw || false,
+            sourceMapPrefix: opts.sourceMapPrefix || '//#',
+            standalone: opts.standalone || undefined,
+            standaloneModule: opts.standaloneModule || undefined,
+        };
+
+        var res = browserPack(); // 'opts' are optional
+        var res2 = browserPack(packOpts);
+
+        // ensure return value is a stream
+        var res3 = res.pipe(res2);
+
+        res.on("error", function (err: any) {
+            console.error("browser-pack error: ", err);
+        });
+    }
+
+}
+
+export = BrowserPackTest;

--- a/browser-pack/browser-pack.d.ts
+++ b/browser-pack/browser-pack.d.ts
@@ -1,0 +1,63 @@
+// Type definitions for browser-pack v6.0.1
+// Project: https://github.com/substack/browser-pack
+// Definitions by: TeamworkGuy2 <https://github.com/TeamworkGuy2>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+/** pack node-style source files from a json stream into a browser bundle
+ */
+declare module BrowserPack {
+
+    export interface Options {
+        /** Whether the bundle should include require= (or the opts.externalRequireName) so that
+         * require() is available outside the bundle
+         */
+        hasExports?: boolean;
+
+        /** A string to use in place of 'require' if opts.hasExports is specified, default is 'require'
+         */
+        externalRequireName?: string;
+
+        /** Specify a custom prelude, but know what you're doing first. See the prelude.js file in
+         * this repo for the default prelude. If you specify a custom prelude, you must also specify
+         * a valid opts.preludePath to the prelude source file for sourcemaps to work
+         */
+        prelude?: string;
+
+        /** prelude.js path if a custom opts.prelude is specified
+         */
+        preludePath?: string;
+
+        /** Used if opts.preludePath is undefined, this is used to resolve the prelude.js file location, default: 'process.cwd()'
+         */
+        basedir?: string;
+
+        /** if given, the writable end of the stream will expect objects to be written to
+         * it instead of expecting a stream of json text it will need to parse, default false
+         */
+        raw?: boolean;
+
+        /** External string name to use for UMD, if not provided, UMD declaration is not wrapped around output
+         */
+        standalone?: string;
+
+        /** Sets the internal module name to export for standalone
+         */
+        standaloneModule?: string;
+
+        /** If given and source maps are computed, the opts.sourceMapPrefix string will be used instead of default: '//#'
+         */
+        sourceMapPrefix?: string;
+    }
+
+}
+
+declare module "browser-pack" {
+    import stream = require("stream");
+
+    /** pack node-style source files from a json stream into a browser bundle
+     */
+    function browserPack(opts?: BrowserPack.Options): NodeJS.ReadWriteStream;
+    export = browserPack;
+}

--- a/browser-pack/browser-pack.d.ts
+++ b/browser-pack/browser-pack.d.ts
@@ -54,8 +54,6 @@ declare module BrowserPack {
 }
 
 declare module "browser-pack" {
-    import stream = require("stream");
-
     /** pack node-style source files from a json stream into a browser bundle
      */
     function browserPack(opts?: BrowserPack.Options): NodeJS.ReadWriteStream;


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Definition for https://www.npmjs.com/package/browser-pack, used by browserify and many other libraries.
