### PR TITLE
Fix bisectLeft function declaration

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1111,8 +1111,7 @@ declare namespace d3 {
     export function deviation(array: number[]): number;
     export function deviation<T>(array: T[], accessor: (datum: T, index: number) => number): number;
 
-    export function bisectLeft(array: number[], x: number, lo?: number, hi?: number): number;
-    export function bisectLeft(array: string[], x: string, lo?: number, hi?: number): number;
+    export function bisectLeft<T>(array: T[], x: T, lo?: number, hi?: number): number;
 
     export var bisect: typeof bisectRight;
 


### PR DESCRIPTION
It should match the type signature of `bisectRight()`, as implied by the [API documentation](https://github.com/d3/d3/wiki/Arrays#d3_bisectRight) and as implied by their nearly identical [source code](https://github.com/d3/d3-array/blob/master/src/bisector.js#L6-L25).

Note that the assumption of `number` and `string` type is reasonable since [the comparator](https://github.com/d3/d3-array/blob/master/src/ascending.js#L1-L3) uses the `<`, `>`, and `>=` operators to compare its operands. However, according to [the standard](http://www.ecma-international.org/ecma-262/6.0/#sec-abstract-relational-comparison), any type that can be coerced `ToPrimitive()` will work. In fact, there is a special case for strings, however objects, such as `Date()` objects will usually use `.valueOf()` to try to coerce the value into a number.

A more verbose type union explaining T would look something like this:

``` typescript
T = number | string | { valueOf(): number; } | { toString(): string } 
```
