### PR TITLE
[exorcist] Added exorcist v0.4.0 definition

### DIFF
--- a/exorcist/exorcist-tests.ts
+++ b/exorcist/exorcist-tests.ts
@@ -1,0 +1,15 @@
+/// <reference path="exorcist.d.ts" />
+
+import exorcist = require("exorcist");
+
+module ExorcistTest {
+
+    function pullSourceMaps(srcPath: string, projRoot: string) {
+        exorcist(srcPath, undefined, projRoot);
+        exorcist(srcPath, null, projRoot, null, true);
+        exorcist(srcPath, null, projRoot, "./");
+    }
+
+}
+
+export = ExorcistTest;

--- a/exorcist/exorcist.d.ts
+++ b/exorcist/exorcist.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for exorcist v3.7.x
+// Type definitions for exorcist v0.4.0
 // Project: https://github.com/substack/watchify
 // Definitions by: TeamworkGuy2 <https://github.com/TeamworkGuy2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/exorcist/exorcist.d.ts
+++ b/exorcist/exorcist.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for exorcist v0.4.0
-// Project: https://github.com/substack/watchify
+// Project: https://github.com/substack/exorcist
 // Definitions by: TeamworkGuy2 <https://github.com/TeamworkGuy2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/exorcist/exorcist.d.ts
+++ b/exorcist/exorcist.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for exorcist v0.4.0
-// Project: https://github.com/substack/exorcist
+// Project: https://github.com/thlorenz/exorcist
 // Definitions by: TeamworkGuy2 <https://github.com/TeamworkGuy2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/exorcist/exorcist.d.ts
+++ b/exorcist/exorcist.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for exorcist v3.7.x
+// Project: https://github.com/substack/watchify
+// Definitions by: TeamworkGuy2 <https://github.com/TeamworkGuy2>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../through/through.d.ts" />
+
+declare module 'exorcist' {
+    import through = require("through");
+
+    /** Externalizes the source map found inside a stream to an external .map file.
+     * Works with both JavaScript and CSS input streams
+     * @param file full path to the map file to which to write the extracted source map
+     * @param [url] full URL to the map file, set as sourceMappingURL in the streaming output (default: file)
+     * @param [root] root URL for loading relative source paths, set as sourceRoot in the source map (default: "")
+     * @param [base] base path for calculating relative source paths (default: use absolute paths)
+     * @param [errorOnMissing] when truthy, causes 'error' to be emitted instead of 'missing-map' if no map was found in the stream (default: falsey)
+     */
+    function exorcist(file: string, url?: string, root?: string, base?: string, errorOnMissing?: boolean): through.ThroughStream;
+    export = exorcist;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Definition for https://github.com/thlorenz/exorcist, used by a number of projects or as a stand alone library for siphoning off source maps from a browserify bundle.
