### PR TITLE
Add missing MetaProperty property to esprima

### DIFF
--- a/esprima/esprima.d.ts
+++ b/esprima/esprima.d.ts
@@ -71,6 +71,7 @@ declare namespace esprima {
         LabeledStatement: string,
         LogicalExpression: string,
         MemberExpression: string,
+        MetaProperty: string,
         MethodDefinition: string,
         NewExpression: string,
         ObjectExpression: string,


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- The MetaProperty which is defined [here](https://github.com/jquery/esprima/blob/master/src/syntax.ts#L40) was missing
