### PR TITLE
Add more Openlayers functionality (ol.interaction.Select + ol.source.*)

### DIFF
--- a/openlayers/openlayers-tests.ts
+++ b/openlayers/openlayers-tests.ts
@@ -358,6 +358,14 @@ var imageWMS: ol.source.ImageWMS = new ol.source.ImageWMS({
     serverType: stringValue,
     url:stringValue
 });
+
+//
+// ol.source.Source
+//
+const source = imageWMS as ol.source.Source;
+voidValue = source.refresh();
+projectionValue = source.getProjection();
+
 //
 // ol.source.TileWMS
 //
@@ -366,6 +374,9 @@ var tileWMS: ol.source.TileWMS = new ol.source.TileWMS({
     serverType: stringValue,
     url:stringValue
 });
+
+tileWMS.updateParams(tileWMS.getParams());
+stringValue = tileWMS.getGetFeatureInfoUrl();
 
 //
 // ol.source.WMTS

--- a/openlayers/openlayers-tests.ts
+++ b/openlayers/openlayers-tests.ts
@@ -364,7 +364,7 @@ var imageWMS: ol.source.ImageWMS = new ol.source.ImageWMS({
 //
 const source = imageWMS as ol.source.Source;
 voidValue = source.refresh();
-projectionValue = source.getProjection();
+projection = source.getProjection();
 
 //
 // ol.source.TileWMS
@@ -376,7 +376,7 @@ var tileWMS: ol.source.TileWMS = new ol.source.TileWMS({
 });
 
 tileWMS.updateParams(tileWMS.getParams());
-stringValue = tileWMS.getGetFeatureInfoUrl();
+stringValue = tileWMS.getGetFeatureInfoUrl([0, 0], 1, "EPSG:4326", {});
 
 //
 // ol.source.WMTS
@@ -559,5 +559,5 @@ var draw: ol.interaction.Draw = new ol.interaction.Draw({
 })
 
 const select: ol.interaction.Select = new ol.interaction.Select({
-    layers: (layer: ol.layer.Layer) => true;
+    layers: (layer: ol.layer.Layer) => true,
 });

--- a/openlayers/openlayers-tests.ts
+++ b/openlayers/openlayers-tests.ts
@@ -546,3 +546,7 @@ var modify: ol.interaction.Modify = new ol.interaction.Modify({
 var draw: ol.interaction.Draw = new ol.interaction.Draw({
     type: "Point"
 })
+
+const select: ol.interaction.Select = new ol.interaction.Select({
+    layers: (layer: ol.layer.Layer) => true;
+});

--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -4126,7 +4126,7 @@ declare namespace ol {
         class OSM extends XYZ {
         }
 
-        class Source extends Object {
+        class Source extends ol.Object {
             /**
              * Get the projection of the source.
              * @return Projection.
@@ -4169,12 +4169,12 @@ declare namespace ol {
             /**
              * Update the user-provided (WMS request) parameters.
              */
-            updateParams(params: {}): void;
+            updateParams(params: any): void;
 
             /**
              * Get the user-provided (WMS request) params, i.e. those passed to the constructor through the "params" option, and possibly updated using the updateParams method.
              */
-            getParams(): {};
+            getParams(): any;
 
             /**
              * Return the GetFeatureInfo URL for the passed coordinate, resolution, and

--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -4121,6 +4121,16 @@ declare namespace ol {
         }
 
         class Source {
+            /**
+             * Get the projection of the source.
+             * @return Projection.
+             */
+            getProjection(): ol.proj.Projection;
+
+            /**
+             * Refreshes the source and finally dispatches a 'change' event.
+             */
+            refresh(): void;
         }
 
         class Stamen {

--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -4152,6 +4152,31 @@ declare namespace ol {
 
         class TileWMS {
             constructor(options: olx.TileWMSOptions);
+
+            /**
+             * Update the user-provided (WMS request) parameters.
+             */
+            updateParams(params: Object);
+
+            /**
+             * Get the user-provided (WMS request) params, i.e. those passed to the constructor through the "params" option, and possibly updated using the updateParams method.
+             */
+            getParams(): Object;
+
+            /**
+             * Return the GetFeatureInfo URL for the passed coordinate, resolution, and
+             * projection. Return `undefined` if the GetFeatureInfo URL cannot be
+             * constructed.
+             * @param coordinate Coordinate.
+             * @param resolution Resolution.
+             * @param rojection Projection.
+             * @param params GetFeatureInfo params. `INFO_FORMAT` at least should
+             *     be provided. If `QUERY_LAYERS` is not provided then the layers specified
+             *     in the `LAYERS` parameter will be used. `VERSION` should not be
+             *     specified here.
+             * @return GetFeatureInfo URL.
+             */
+            getGetFeatureInfoUrl(coordinate: ol.Coordinate, resolution: number, projection: ol.proj.ProjectionLike, params: Object): string;
         }
 
         class Vector {

--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -4169,12 +4169,12 @@ declare namespace ol {
             /**
              * Update the user-provided (WMS request) parameters.
              */
-            updateParams(params: Object): void;
+            updateParams(params: {}): void;
 
             /**
              * Get the user-provided (WMS request) params, i.e. those passed to the constructor through the "params" option, and possibly updated using the updateParams method.
              */
-            getParams(): Object;
+            getParams(): {};
 
             /**
              * Return the GetFeatureInfo URL for the passed coordinate, resolution, and

--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -552,12 +552,12 @@ declare namespace olx {
         interface SelectOptions {
             addCondition?: ol.events.ConditionType;
             condition?: ol.events.ConditionType;
-            layers?: Array<ol.layer.Layer>;
+            layers?: Array<ol.layer.Layer> | ((layer: ol.layer.Layer) => boolean);
             style?: ol.style.Style | Array<ol.style.Style> | ol.style.StyleFunction;
             removeCondition?: ol.events.ConditionType;
             toggleCondition?: ol.events.ConditionType;
             multi?: boolean;
-            features?: ol.Collection<ol.Feature>
+            features?: ol.Collection<ol.Feature>;
             filter?: ol.interaction.SelectFilterFunction;
             wrapX?: boolean;
         }

--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -4085,42 +4085,48 @@ declare namespace ol {
 
     namespace source {
 
-        class BingMaps {
+        class BingMaps extends TileImage {
         }
 
-        class Cluster {
+        class CartoDB extends XYZ {
         }
 
-        class Image {
+        class Cluster extends Vector {
         }
 
-        class ImageCanvas {
+        class Image extends Source {
+        }
+
+        class ImageArcGISRest extends Image {
+        }
+
+        class ImageCanvas extends Image {
         }
 
         class ImageEvent {
         }
 
-        class ImageMapGuide {
+        class ImageMapGuide extends Image {
         }
 
-        class ImageStatic {
+        class ImageStatic extends Image {
         }
 
-        class ImageVector {
+        class ImageVector extends ImageCanvas {
         }
 
-        class ImageWMS {
+        class ImageWMS extends Image {
             constructor(options: olx.ImageWMSOptions);
         }
 
-        class MapQuest {
+        class MapQuest extends XYZ {
             constructor(options: any);
         }
 
-        class OSM {
+        class OSM extends XYZ {
         }
 
-        class Source {
+        class Source extends Object {
             /**
              * Get the projection of the source.
              * @return Projection.
@@ -4133,40 +4139,37 @@ declare namespace ol {
             refresh(): void;
         }
 
-        class Stamen {
+        class Stamen extends XYZ {
         }
 
-        class Tile {
+        class Tile extends Source {
         }
 
-        class TileArcGISRest {
+        class TileArcGISRest extends TileImage {
         }
 
-        class TileDebug {
+        class TileDebug extends Tile {
         }
 
         class TileEvent {
         }
 
-        class TileImage {
+        class TileImage extends UrlTile {
         }
 
-        class TileJSON {
+        class TileJSON extends TileImage {
         }
 
-        class TileUTFGrid {
+        class TileUTFGrid extends Tile {
         }
 
-        class TileVector {
-        }
-
-        class TileWMS {
+        class TileWMS extends TileImage {
             constructor(options: olx.TileWMSOptions);
 
             /**
              * Update the user-provided (WMS request) parameters.
              */
-            updateParams(params: Object);
+            updateParams(params: Object): void;
 
             /**
              * Get the user-provided (WMS request) params, i.e. those passed to the constructor through the "params" option, and possibly updated using the updateParams method.
@@ -4186,10 +4189,13 @@ declare namespace ol {
              *     specified here.
              * @return GetFeatureInfo URL.
              */
-            getGetFeatureInfoUrl(coordinate: ol.Coordinate, resolution: number, projection: ol.proj.ProjectionLike, params: Object): string;
+            getGetFeatureInfoUrl(coordinate: ol.Coordinate, resolution: number, projection: ol.proj.ProjectionLike, params: {}): string;
         }
 
-        class Vector {
+        class UrlTile extends Tile {
+        }
+
+        class Vector extends Source {
             constructor(opts?: olx.source.VectorOptions)
             /**
              * Add a single feature to the source. If you want to add a batch of features at once,
@@ -4233,14 +4239,17 @@ declare namespace ol {
         class VectorEvent {
         }
 
-        class WMTS {
+        class VectorTile extends UrlTile {
+        }
+
+        class WMTS extends TileImage {
             constructor(options: olx.source.WMTSOptions);
         }
 
-        class XYZ {
+        class XYZ extends TileImage {
         }
 
-        class Zoomify {
+        class Zoomify extends TileImage {
         }
 
         // Namespaces


### PR DESCRIPTION
case 2. Improvement to existing type definition.

ol.interaction.Select: Allow to use a filter function as `layers` option: [Reference](http://openlayers.org/en/latest/apidoc/ol.interaction.Select.html) + [Source](https://github.com/openlayers/ol3/blob/v3.16.0/src/ol/interaction/selectinteraction.js#L160)

ol.source: Added [source inheritance](http://openlayers.org/en/latest/apidoc/ol.source.html)  + functions for [Source](http://openlayers.org/en/latest/apidoc/ol.source.Source.html) and [TileWMS](http://openlayers.org/en/latest/apidoc/ol.source.TileWMS.html)
