### PR TITLE
[babelify] Added babelify definition

### DIFF
--- a/babelify/babelify-tests.ts
+++ b/babelify/babelify-tests.ts
@@ -1,0 +1,23 @@
+/// <reference path="babelify.d.ts" />
+
+import babelify = require("babelify");
+
+module BabelifyTest {
+
+    export function whatDidTheEs6Say(srcPath: string, opts?: babelify.BabelifyOptions) {
+        opts.extensions = opts.extensions || undefined;
+        opts.sourceMapsAbsolute = opts.sourceMapsAbsolute || false;
+        var dst: NodeJS.ReadWriteStream;
+
+        babelify(""); // 'opts' are optional
+
+        babelify(srcPath, opts).on("error", function (err: any) {
+            console.error("babelify error: ", err);
+        });
+
+        babelify.configure(opts)(srcPath).pipe(dst);
+    }
+
+}
+
+export = BabelifyTest;

--- a/babelify/babelify.d.ts
+++ b/babelify/babelify.d.ts
@@ -13,40 +13,33 @@ declare module 'babelify' {
     import babel = require("babel-core");
 
 
-    /** In addition to the various purposes documented here, all of the babelify options are passed to babel which passes them on to babel.transform() when each file is transformed */
-    interface babelifyOptions extends babel.TransformOptions {
-        /** These are passed to babel.util.canCompile() for each filename
-         * default: null (see babel.
-         */
-        extensions?: string | string[];
-
-        /** if true, a 'sourceFileName' property with a value equal to the current file being transformed is included with the options passed to babel.transform()
-         * default: false
-         */
-        sourceMapsAbsolute?: boolean;
-    }
-
-
-    class babelifyObject extends stream.Transform {
-
-        _transform(buf: string | Buffer, encoding: string, callback: () => void): void;
-
-        _flush(callback: () => void): void;
-    }
-
-
-    function Babelify(filename: string, opts?: babelifyOptions): babelifyObject;
+    function Babelify(filename: string, opts?: Babelify.BabelifyOptions): Babelify.BabelifyObject;
 
     module Babelify {
+
         export interface BabelifyConstructor {
-            (filename: string, opts: babelifyOptions): babelifyObject;
+            (filename: string, opts: Babelify.BabelifyOptions): Babelify.BabelifyObject;
         }
 
-        export interface BabelifyOptions extends babelifyOptions { }
+        /** In addition to the various purposes documented here, all of the babelify options are passed to babel which passes them on to babel.transform() when each file is transformed */
+        export interface BabelifyOptions extends babel.TransformOptions {
+            /** These are passed to babel.util.canCompile() for each filename
+             * default: null
+             */
+            extensions?: string | string[];
 
-        export class BabelifyObject extends babelifyObject { }
+            /** if true, a 'sourceFileName' property with a value equal to the current file being transformed is included with the options passed to babel.transform()
+             * default: false
+             */
+            sourceMapsAbsolute?: boolean;
+        }
 
-        export function configure(opts: babelifyOptions): (filename: string) => babelifyObject;
+        export class BabelifyObject extends stream.Transform {
+            _transform(buf: string | Buffer, encoding: string, callback: () => void): void;
+            _flush(callback: () => void): void;
+        }
+
+        export function configure(opts: Babelify.BabelifyOptions): (filename: string) => Babelify.BabelifyObject;
     }
 
     export = Babelify;

--- a/babelify/babelify.d.ts
+++ b/babelify/babelify.d.ts
@@ -1,0 +1,53 @@
+// Type definitions for babelify v7.3.0
+// Project: https://github.com/babel/babelify
+// Definitions by: TeamworkGuy2 <https://github.com/TeamworkGuy2>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+/// <reference path="../babel-core/babel-core.d.ts" />
+
+/** Browserify transform for Babel
+ */
+declare module 'babelify' {
+    import stream = require("stream");
+    import babel = require("babel-core");
+
+
+    /** In addition to the various purposes documented here, all of the babelify options are passed to babel which passes them on to babel.transform() when each file is transformed */
+    interface babelifyOptions extends babel.TransformOptions {
+        /** These are passed to babel.util.canCompile() for each filename
+         * default: null (see babel.
+         */
+        extensions?: string | string[];
+
+        /** if true, a 'sourceFileName' property with a value equal to the current file being transformed is included with the options passed to babel.transform()
+         * default: false
+         */
+        sourceMapsAbsolute?: boolean;
+    }
+
+
+    class babelifyObject extends stream.Transform {
+
+        _transform(buf: string | Buffer, encoding: string, callback: () => void): void;
+
+        _flush(callback: () => void): void;
+    }
+
+
+    function Babelify(filename: string, opts?: babelifyOptions): babelifyObject;
+
+    module Babelify {
+        export interface BabelifyConstructor {
+            (filename: string, opts: babelifyOptions): babelifyObject;
+        }
+
+        export interface BabelifyOptions extends babelifyOptions { }
+
+        export class BabelifyObject extends babelifyObject { }
+
+        export function configure(opts: babelifyOptions): (filename: string) => babelifyObject;
+    }
+
+    export = Babelify;
+}


### PR DESCRIPTION
Adding a new type definition for [babelify](https://github.com/babel/babelify/blob/master/index.js).
- [x] checked compilation succeeds with `--noImplicitAny` option.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
