### PR TITLE
[watchify] Added watchify definition

### DIFF
--- a/watchify/watchify-tests.ts
+++ b/watchify/watchify-tests.ts
@@ -1,0 +1,33 @@
+/// <reference path="watchify.d.ts" />
+
+import browserify = require("browserify");
+import watchify = require("watchify");
+
+module WatchifyTest {
+
+    export function setupWatchify(srcPath: string, opts?: watchify.Options) {
+        // new syntax
+        var bfyWatched = browserify(srcPath, {
+            cache: watchify.args.cache,
+            packageCache: watchify.args.packageCache,
+            plugin: [watchify],
+        });
+
+        var stream: NodeJS.ReadWriteStream;
+        bfyWatched.pipeline.get("deps").push(stream);
+
+        // old syntax
+        var bfy = browserify(srcPath);
+
+        var bfyWatched = watchify(bfy, {
+            delay: opts.delay || 100,
+            ignoreWatch: opts.ignoreWatch || false,
+            poll: opts.poll || 0,
+        });
+
+        bfy.pipeline.get('wrap').on("error", function () { });
+    }
+
+}
+
+export = WatchifyTest;

--- a/watchify/watchify.d.ts
+++ b/watchify/watchify.d.ts
@@ -1,0 +1,51 @@
+// Type definitions for watchify v3.7.0
+// Project: https://github.com/substack/watchify
+// Definitions by: TeamworkGuy2 <https://github.com/TeamworkGuy2>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../browserify/browserify.d.ts" />
+
+declare module 'watchify' {
+
+    var Watchify: Watchify.Constructor;
+
+    /** Watch mode for browserify builds.
+     * Update any source file and your browserify bundle will be recompiled on the spot
+     */
+    module Watchify {
+
+        /** Watch mode for browserify builds.
+         * Update any source file and your browserify bundle will be recompiled on the spot
+         */
+        export interface Constructor {
+            args: { cache: any; packageCache: any; };
+
+            <T extends Browserify.BrowserifyObject>(b: T, opts?: Watchify.Options): T;
+            (b: Browserify.BrowserifyObject, opts?: Watchify.Options): Browserify.BrowserifyObject;
+        }
+
+
+        export interface Options {
+            /** The amount of time in milliseconds to wait before emitting an "update" event after a change.
+             * Default: 100
+             */
+            delay?: number;
+
+            /** Ignores monitoring files for changes. If set to true, then ** /node_modules/ ** will be ignored. For other possible values see Chokidar's documentation on "ignored"
+             * Also see anymatch package: https://github.com/es128/anymatch#usage
+             */
+            ignoreWatch?: boolean | (string | RegExp | ((...values: any[]) => boolean) | (string | RegExp | ((...values: any[]) => boolean))[]);
+
+            /** Enables polling to monitor for changes. If set to true, then a polling interval of 100 ms is used.
+             * If set to a number, then that amount of milliseconds will be the polling interval. For more info see
+             * Chokidar's documentation on "usePolling" and "interval".
+             * This option is useful if you're watching an NFS volume
+             * Also see chokidar package: https://github.com/paulmillr/chokidar#path-filtering
+             */
+            poll?: number;
+        }
+
+    }
+
+    export = Watchify;
+}


### PR DESCRIPTION
Adding new type definition for [watchify](https://github.com/substack/watchify).
- [x] checked compilation succeeds with `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
