### PR TITLE
Missing definition for _.any

### DIFF
--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -458,6 +458,10 @@ interface UnderscoreStatic {
 		object: _.Dictionary<T>,
 		iterator?: _.ObjectIterator<T, boolean>,
 		context?: any): boolean;
+		
+	any<T>(
+		list: _.List<T>,
+		value: T): boolean;		
 
 	/**
 	* Returns true if the value is present in the list. Uses indexOf internally,


### PR DESCRIPTION
Added missing definition for _.any
