### PR TITLE
implement `samlp` type definition

### DIFF
--- a/samlp/samlp-tests.ts
+++ b/samlp/samlp-tests.ts
@@ -1,0 +1,34 @@
+/// <reference path="samlp.d.ts" />
+/// <reference path="../node/node.d.ts" />
+/// <reference path="../express/express.d.ts" />
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as express from 'express';
+import * as samlp from 'samlp';
+
+
+// Example
+const app = express();
+
+app.get('/samlp', samlp.auth({
+  issuer:     'the-issuer',
+  cert:       fs.readFileSync(path.join(__dirname, 'some-cert.pem')),
+  key:        fs.readFileSync(path.join(__dirname, 'some-cert.key')),
+  getPostURL: function (wtrealm, wreply, req, cb) {
+                return cb( null, 'http://someurl.com')
+              }
+}));
+
+app.get('/samlp/FederationMetadata/2007-06/FederationMetadata.xml', samlp.metadata({
+  issuer:   'the-issuer',
+  cert:     fs.readFileSync(path.join(__dirname, 'some-cert.pem')),
+}));
+
+
+app.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
+  samlp.parseRequest(req, (err: any, data: any) => {
+    next();
+  });
+});
+

--- a/samlp/samlp.d.ts
+++ b/samlp/samlp.d.ts
@@ -1,0 +1,67 @@
+// Type definitions for SAMLP 1.0.0
+// Project: https://github.com/auth0/node-samlp
+// Definitions by: horiuchi <https://github.com/horiuchi/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../express/express.d.ts" />
+/// <reference path="../passport/passport.d.ts" />
+
+declare module "samlp" {
+
+    import * as express from 'express';
+    import * as passport from 'passport';
+
+    export function auth(options: IdPOptions): express.Handler;
+    export function logout(options: IdPOptions): express.Handler;
+    export function parseRequest(req: express.Request, callback: (err: any, data: any) => void): void;
+    export function getSamlResponse(options: IdPOptions, user: any, callback: (err: any, samlResponse: any) => void): void;
+    export function sendError(options: IdPOptions): express.Handler;
+    export function metadata(options: IdPMetadataOptions): express.Handler;
+
+    export interface IdPOptions {
+        issuer: string;
+        cert: string | Buffer;
+        key: string | Buffer;
+        audience?: string;
+        recipient?: string;
+        destination?: string;
+        RelayState?: string;
+        digestAlgorithm?: 'sha1' | 'sha256';
+        signatureAlgorithm?: 'rsa-sha1' | 'rsa-sha256';
+        signResponse?: boolean;
+        encryptionCert?: string | Buffer;
+        encryptionPublicKey?: string | Buffer;
+        encryptionAlgorithm?: string;
+        keyEncryptionAlgorighm?: string;
+        lifetimeInSeconds?: number;
+        authnContextClassRef?: string;
+        profileMapper?: PassportProfileMapper;
+        getUserFromRequest?: (req: express.Request) => any;
+        getPostURL: (audience: string, authnRequestDom: any, req: express.Request, callback: (err: any, url: string) => void) => void;
+    }
+    export interface IdPMetadataOptions {
+        issuer: string;
+        cert: string | Buffer;
+        profileMapper?: PassportProfileMapper;
+        redirectEndpointPath?: string;
+        postEndpointPath?: string;
+        logoutEndpointPaths?: {
+            redirect?: string;
+            post?: string;
+        };
+    }
+
+    export class PassportProfileMapper {
+        constructor(pu: passport.Profile);
+        metadata: MetadataItem[];
+        getClaims(): any;
+        getNameIdentifier(): any;
+    }
+    export interface MetadataItem {
+        id: string;
+        optional: boolean;
+        displayName: string;
+        description: string;
+    }
+
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
