### PR TITLE
Fix package name for sortablejs

### DIFF
--- a/sortablejs/sortablejs.d.ts
+++ b/sortablejs/sortablejs.d.ts
@@ -202,7 +202,7 @@ declare namespace Sortablejs {
 
 import Sortable = Sortablejs.Sortable;
 
-declare module 'Sortable' {
+declare module 'sortablejs' {
     import Sortable = Sortablejs.Sortable;
     export = Sortable;
 }


### PR DESCRIPTION
The [project](https://github.com/RubaXa/Sortable) and the global variable (class) is called "Sortable".
The [npm package](https://www.npmjs.com/package/sortablejs) is called "sortablejs".

While the existing definitions were fine for "window" useage, the module is written in UMD.

With this fix, the definitions match the package name and can be used with `import`:

``` js
import Sortable = require("sortablejs");
let mySortable = Sortable.create( ... );
// mySortable and Sortable.create have the correct typings
let anotherSortable: Sortablejs.Sortable; // for variable declarations / parameters
```
