### PR TITLE
SlickGrid: Add RowMoveManager

### DIFF
--- a/jquery.event.drag/jquery.event.drag-tests.ts
+++ b/jquery.event.drag/jquery.event.drag-tests.ts
@@ -1,0 +1,61 @@
+/// <reference path="../jquery/jquery.d.ts" />
+/// <reference path="jquery.event.drag.d.ts" />
+
+$('.drag').drag(function (ev, dd) {
+    $(this).css({
+        top: dd.offsetY,
+        left: dd.offsetX
+    });
+});
+
+$('.drag')
+    .drag(function (ev, dd) {
+        $(this).css({
+            top: dd.offsetY,
+            left: dd.offsetX
+        });
+    }, { relative: true });
+
+$('.drag').drag(function (ev, dd) {
+    $(this).css({ left: dd.offsetX });
+});
+
+$('.drag').drag(function (ev, dd) {
+    $(this).css({
+        top: Math.round(dd.offsetY / 20) * 20,
+        left: Math.round(dd.offsetX / 20) * 20
+    });
+});
+
+var $div = $('#container');
+$('.drag')
+    .drag("start", function (ev, dd: any) {
+        dd.limit = $div.offset();
+        dd.limit.bottom = dd.limit.top + $div.outerHeight() - $(this).outerHeight();
+        dd.limit.right = dd.limit.left + $div.outerWidth() - $(this).outerWidth();
+    })
+    .drag(function (ev, dd: any) {
+        $(this).css({
+            top: Math.min(dd.limit.bottom, Math.max(dd.limit.top, dd.offsetY)),
+            left: Math.min(dd.limit.right, Math.max(dd.limit.left, dd.offsetX))
+        });
+    });
+
+$('.drag').drag(function (ev, dd) {
+    $(this).css({
+        top: dd.offsetY,
+        left: dd.offsetX
+    });
+}, { handle: ".handle" });
+
+var z = 1;
+$('.drag')
+    .drag("start", function () {
+        $(this).css('zIndex', z++);
+    })
+    .drag(function (ev, dd) {
+        $(this).css({
+            top: dd.offsetY,
+            left: dd.offsetX
+        });
+    });

--- a/jquery.event.drag/jquery.event.drag.d.ts
+++ b/jquery.event.drag/jquery.event.drag.d.ts
@@ -1,0 +1,149 @@
+// Type definitions for jquery.events.drag v2.2
+// Project: http://threedubmedia.com/code/event/drag
+// Definitions by: berwyn <https://github.com/berwyn>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../jquery/jquery.d.ts" />
+
+interface JQueryDragOptions {
+
+    /**
+     * A number that matches the "which" event property
+     * to indicate the mousebutton that is pressed.
+     * (0 = Any Button, 1 = Left Button, 2 = Middle Button, 3 = Right Button)
+     * @default 1
+     */
+    which?: number;
+
+    /**
+     * A number representing the length of pixels that the mouse must move
+     * before the "dragstart" event may fire.
+     * @default 0
+     */
+    distance?: number;
+
+    /**
+     * A jquery selector expression that matches elements where dragging is
+     * not allowed to begin.
+     * @default ':input'
+     */
+    not?: string;
+
+    /**
+     * A jquery selector expression that matches elements where dragging is
+     * allowed to begin.
+     * @default null
+     */
+    handle?: string;
+
+    /**
+     * A boolean to indicate whether to use element position relative to the
+     * document or the offset parent. This setting affects the values offsetX,
+     * offsetY, originalX, and originalY. (FALSE = Position Relative to the Document)
+     * @default false
+     */
+    relative?: boolean;
+
+    /**
+     * A boolean to indicate whether or not "click" events are allowed to fire after
+     * the "dragend" event. (FALSE = No Click)
+     * @default false
+     */
+    click?: boolean;
+
+    /**
+     * A boolean to indicate whether or not "drag" events are considered in the drag
+     * interaction, or a jquery selector expression that should filter and match a subset
+     * of the registered drop targets. (FALSE = No Dropping, TRUE = Drop Anywhere,
+     * ":expr" = Drop in targets that match this expression)
+     * @default true
+     */
+    drop?: boolean | string;
+}
+
+interface JQueryDragCallbackObject {
+
+    /**
+     * The drag element, or the drop element, to which the event
+     * handler has been bound. (Always the same as "this" within
+     * an event handler)
+     */
+    target: Element;
+
+    /**
+     * The dragged element for the given interaction to which the
+     * drag event has been bound.
+     */
+    drag: Element;
+
+    /**
+     * The dragged element, or any element returned by the "dragstart"
+     * handler. The proxy element is used to determine the drop target
+     * tolerance.
+     */
+    proxy: Element;
+
+    /**
+     * Contains all of the active drop targets for the current interaction.
+     */
+    drop: any[]; // TODO: Array elements aren't described in the docs :/
+
+    /**
+     * Contains all of the available drop targets for the current interaction.
+     */
+    available: any[];
+
+    /**
+     * A helper function which updates the locations of all of the available
+     * drop targets for the current interaction.
+     */
+    update: () => void;
+
+    /**
+     * The horizontal location of the "mousedown" event.
+     */
+    startX: number;
+
+    /**
+     * The vertical location of the "mousedown" event.
+     */
+    startY: number;
+
+    /**
+     * The horizontal distance moved from "startX".
+     */
+    deltaX: number;
+
+    /**
+     * The horizontal distance moved from "startY".
+     */
+    deltaY: number;
+
+    /**
+     * The starting horizontal position of the drag "target" element.
+     */
+    originalX: number;
+
+    /**
+     * The starting vertical position of the drag "target" element.
+     */
+    originalY: number;
+
+    /**
+     * The the moved horizontal position of the drag "target" element.
+     */
+    offsetX: number;
+
+    /**
+     * The the moved vertical position of the drag "target" element.
+     */
+    offsetY: number;
+
+}
+
+declare interface JQuery {
+    drag(): JQuery;
+    drag(type: string): JQuery;
+    drag(handler: (evt?: JQueryEventObject, callback?: JQueryDragCallbackObject) => void, options?: JQueryDragOptions): JQuery;
+    drag(type: string, handler: (evt?: JQueryEventObject, callback?: JQueryDragCallbackObject) => void, options?: JQueryDragOptions): JQuery;
+}

--- a/jquery.event.drop/jquery.event.drop-tests.ts
+++ b/jquery.event.drop/jquery.event.drop-tests.ts
@@ -1,0 +1,63 @@
+/// <reference path="../jquery/jquery.d.ts" />
+/// <reference path="jquery.event.drop.d.ts" />
+
+$('.drop').drop(function () {
+    $(this).toggleClass('dropped');
+});
+
+$('.drop')
+    .drop("start", function () {
+        $(this).addClass("active");
+    })
+    .drop("end", function () {
+        $(this).removeClass("active");
+    });
+
+$('.drop td')
+    .drop("start", function () {
+        $(this).addClass("active");
+    })
+    .drop(function (ev, dd) {
+        $(this).toggleClass("dropped");
+    })
+    .drop("end", function () {
+        $(this).removeClass("active");
+    });
+$.drop({ mode: "overlap" });
+
+$('.drop td')
+    .drop("start", function () {
+        $(this).addClass("active");
+    })
+    .drop(function (ev, dd) {
+        $(this).toggleClass("dropped");
+    })
+    .drop("end", function () {
+        $(this).removeClass("active");
+    })
+$.drop({ mode: "intersect" });
+
+$('.drop')
+    .drop("start", function () {
+        $(this).addClass("active");
+    })
+    .drop(function (ev, dd) {
+        $(this).toggleClass("dropped");
+    })
+    .drop("end", function () {
+        $(this).removeClass("active");
+    });
+$.drop({
+    multi: true,
+    tolerance: function (event, proxy, target) {
+        var r = target.width / 2, x = target.left + r, y = target.top + r,
+            h = Math.min(Math.abs(x - proxy.left), Math.abs(x - proxy.right)),
+            v = Math.min(Math.abs(y - proxy.top), Math.abs(y - proxy.bottom));
+        if (proxy.top < y && proxy.bottom > y)
+            return h <= r ? 1 : 0;
+        else if (proxy.left < x && proxy.right > x)
+            return v <= r ? 1 : 0;
+        else
+            return Math.sqrt(h * h + v * v) <= r ? 1 : 0;
+    }
+});

--- a/jquery.event.drop/jquery.event.drop.d.ts
+++ b/jquery.event.drop/jquery.event.drop.d.ts
@@ -1,0 +1,134 @@
+// Type definitions for jquery.events.drop v2.2
+// Project: http://threedubmedia.com/code/event/drop
+// Definitions by: berwyn <https://github.com/berwyn>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../jquery/jquery.d.ts" />
+
+interface JQueryDropOptions {
+    /**
+     * A string which matches any one of the configured tolerance
+     * modes (fit, intersect, middle, overlap) If a mode is not found,
+     * the plugin will use the mouse position as a fallback.
+     * @default 'overlap'
+     */
+    mode?: 'fit' | 'intersect' | 'middle' | 'overlap' | string;
+
+    // TODO: There's not a strong type for proxy/target on the docs.
+    // It's implied that it's an Element, but it doesn't use Element properties
+
+    /**
+     * An optional function to use instead of a configured tolerance
+     * mode. The function has the same signature as any tolerance
+     * mode function.
+     * @default null
+     */
+    tolerance?: (event: JQueryEventObject, proxy: any, target: any) => number;
+
+    /**
+     * A number which indicates the frequency to check drop target
+     * tolerances during "drag" events. This can be used to tune
+     * performance when dealing with many elements.
+     * @default 20
+     */
+    delay?: number;
+
+    /**
+     * A value which indicates how many drop targets are allowed to
+     * be win per interaction for each dragged element.
+     * (true = unlimited, false = none)
+     * @default 1
+     */
+    multi?: boolean | number;
+}
+
+interface JQueryDropCallbackObject {
+
+    /**
+     * The drag element, or the drop element, to which the event
+     * handler has been bound. (Always the same as "this" within
+     * an event handler)
+     */
+    target: Element;
+
+    /**
+     * The dragged element for the given interaction to which the
+     * drag event has been bound.
+     */
+    drag: Element;
+
+    /**
+     * The dragged element, or any element returned by the "dragstart"
+     * handler. The proxy element is used to determine the drop target
+     * tolerance.
+     */
+    proxy: Element;
+
+    /**
+     * Contains all of the active drop targets for the current interaction.
+     */
+    drop: any[]; // TODO: Array elements aren't described in the docs :/
+
+    /**
+     * Contains all of the available drop targets for the current interaction.
+     */
+    available: any[];
+
+    /**
+     * A helper function which updates the locations of all of the available
+     * drop targets for the current interaction.
+     */
+    update: () => void;
+
+    /**
+     * The horizontal location of the "mousedown" event.
+     */
+    startX: number;
+
+    /**
+     * The vertical location of the "mousedown" event.
+     */
+    startY: number;
+
+    /**
+     * The horizontal distance moved from "startX".
+     */
+    deltaX: number;
+
+    /**
+     * The horizontal distance moved from "startY".
+     */
+    deltaY: number;
+
+    /**
+     * The starting horizontal position of the drag "target" element.
+     */
+    originalX: number;
+
+    /**
+     * The starting vertical position of the drag "target" element.
+     */
+    originalY: number;
+
+    /**
+     * The the moved horizontal position of the drag "target" element.
+     */
+    offsetX: number;
+
+    /**
+     * The the moved vertical position of the drag "target" element.
+     */
+    offsetY: number;
+
+}
+
+declare interface JQuery {
+    drop(): JQuery;
+    drop(type: string): JQuery;
+    drop(handler: (evt?: JQueryEventObject, callback?: JQueryDropCallbackObject) => void): JQuery;
+    drop(type: string, handler: (evt?: JQueryEventObject, callback?: JQueryDropCallbackObject) => void): JQuery;
+}
+
+declare interface JQueryStatic {
+    drop(options: JQueryDropOptions): void;
+}

--- a/jqueryui/jqueryui.d.ts
+++ b/jqueryui/jqueryui.d.ts
@@ -87,7 +87,7 @@ declare namespace JQueryUI {
         disabled?: boolean;
         icons?: any;
         label?: string;
-        text?: string|boolean;
+        text?: string | boolean;
         click?: (event?: Event) => void;
     }
 
@@ -365,7 +365,7 @@ declare namespace JQueryUI {
         width?: any; // number or string
         zIndex?: number;
 
-		open?: DialogEvent;
+        open?: DialogEvent;
         close?: DialogEvent;
     }
 
@@ -614,12 +614,12 @@ declare namespace JQueryUI {
     }
 
     interface SelectableEvents {
-        selected? (event: Event, ui: { selected?: Element; }): void;
-        selecting? (event: Event, ui: { selecting?: Element; }): void;
-        start? (event: Event, ui: any): void;
-        stop? (event: Event, ui: any): void;
-        unselected? (event: Event, ui: { unselected: Element; }): void;
-        unselecting? (event: Event, ui: { unselecting: Element; }): void;
+        selected?(event: Event, ui: { selected?: Element; }): void;
+        selecting?(event: Event, ui: { selecting?: Element; }): void;
+        start?(event: Event, ui: any): void;
+        stop?(event: Event, ui: any): void;
+        unselected?(event: Event, ui: { unselected: Element; }): void;
+        unselecting?(event: Event, ui: { unselecting: Element; }): void;
     }
 
     interface Selectable extends Widget, SelectableOptions {
@@ -679,7 +679,7 @@ declare namespace JQueryUI {
         forceHelperSize?: boolean;
         forcePlaceholderSize?: boolean;
         grid?: number[];
-        helper?: string | ((event: Event, element: Sortable) => Element);
+        helper?: string | ((event: Event, element: JQuery) => Element | JQuery);
         handle?: any; // Selector or Element
         items?: any; // Selector
         opacity?: number;

--- a/slickgrid/SlickGrid.d.ts
+++ b/slickgrid/SlickGrid.d.ts
@@ -336,7 +336,7 @@ declare namespace Slick {
 		* @param editController {EditController}
 		* @return {Boolean}
 		*/
-		public isActive(editController: Editors.Editor<T>): boolean;
+		public isActive(editController?: Editors.Editor<T>): boolean;
 
 		/***
 		* Sets the specified edit controller as the active edit controller (acquire edit lock).
@@ -839,14 +839,14 @@ declare namespace Slick {
 		* @param newData New databinding source using a regular JavaScript array..
 		* @param scrollToTop If true, the grid will reset the vertical scroll position to the top of the grid.
 		**/
-		public setData(newData: T[], scrollToTop: boolean): void;
+		public setData(newData: T[], scrollToTop?: boolean): void;
 
 		/**
 		* Sets a new source for databinding and removes all rendered rows. Note that this doesn't render the new rows - you can follow it with a call to render() to do that.
 		* @param newData New databinding source using a custom object exposing getItem(index) and getLength() functions.
 		* @param scrollToTop If true, the grid will reset the vertical scroll position to the top of the grid.
 		**/
-		public setData(newData: DataProvider<T>, scrollToTop: boolean): void;
+		public setData(newData: DataProvider<T>, scrollToTop?: boolean): void;
 
 		/**
 		* Returns the size of the databinding source.
@@ -1037,7 +1037,7 @@ declare namespace Slick {
 		* @param e A standard W3C/jQuery event.
 		* @return
 		**/
-		public getCellFromEvent<T>(e: Event<T>): Cell; // todo: !! Unsure on return type !!
+		public getCellFromEvent<T>(e: Event<T> | EventData): Cell; // todo: !! Unsure on return type !!
 
 		/**
 		* Returns a hash containing row and cell indexes. Coordinates are relative to the top left corner of the grid beginning with the first row (not including the column headers).

--- a/slickgrid/slick.rowmovemanager-tests.ts
+++ b/slickgrid/slick.rowmovemanager-tests.ts
@@ -1,0 +1,195 @@
+/// <reference path="SlickGrid.d.ts" />
+/// <reference path="slick.rowmovemanager.d.ts" />
+/// <reference path="slick.rowselectionmodel.d.ts" />
+/// <reference path="../jquery/jquery.d.ts" />
+/// <reference path="../jquery.event.drop/jquery.event.drop.d.ts" />
+
+/**
+ * Extracted from https://github.com/mleibman/SlickGrid/blob/master/examples/example9-row-reordering.html
+ */
+var grid: Slick.Grid<any>;
+var data: any[] = [];
+var columns = [
+    {
+        id: "#",
+        name: "",
+        width: 40,
+        behavior: "selectAndMove",
+        selectable: false,
+        resizable: false,
+        cssClass: "cell-reorder dnd"
+    },
+    {
+        id: "name",
+        name: "Name",
+        field: "name",
+        width: 500,
+        cssClass: "cell-title",
+        editor: Slick.Editors.Text,
+        validator: requiredFieldValidator
+    },
+    {
+        id: "complete",
+        name: "Complete",
+        width: 60,
+        cssClass: "cell-effort-driven",
+        field: "complete",
+        cannotTriggerInsert: true,
+        formatter: Slick.Formatters.Checkmark,
+        editor: Slick.Editors.Checkbox
+    }
+];
+var options = {
+    editable: true,
+    enableAddRow: true,
+    enableCellNavigation: true,
+    forceFitColumns: true,
+    autoEdit: false
+};
+function requiredFieldValidator(value: any) {
+    if (value == null || value == undefined || !value.length) {
+        return { valid: false, msg: "This is a required field" };
+    } else {
+        return { valid: true, msg: null };
+    }
+}
+$(function () {
+    data = [
+        { name: "Make a list", complete: true },
+        { name: "Check it twice", complete: false },
+        { name: "Find out who's naughty", complete: false },
+        { name: "Find out who's nice", complete: false }
+    ];
+    grid = new Slick.Grid("#myGrid", data, columns, options);
+    grid.setSelectionModel(new Slick.RowSelectionModel());
+    var moveRowsPlugin = new Slick.RowMoveManager<any>({
+        cancelEditOnDrag: true
+    });
+    moveRowsPlugin.onBeforeMoveRows.subscribe(function (e, data) {
+        for (var i = 0; i < data.rows.length; i++) {
+            // no point in moving before or after itself
+            if (data.rows[i] == data.insertBefore || data.rows[i] == data.insertBefore - 1) {
+                e.stopPropagation();
+                return false;
+            }
+        }
+        return true;
+    });
+    moveRowsPlugin.onMoveRows.subscribe(function (e, args) {
+        var extractedRows: any[] = [], left: any, right: any;
+        var rows = args.rows;
+        var insertBefore = args.insertBefore;
+        left = data.slice(0, insertBefore);
+        right = data.slice(insertBefore, data.length);
+        rows.sort(function (a: any, b: any) { return a - b; });
+        for (var i = 0; i < rows.length; i++) {
+            extractedRows.push(data[rows[i]]);
+        }
+        rows.reverse();
+        for (var i = 0; i < rows.length; i++) {
+            var row = rows[i];
+            if (row < insertBefore) {
+                left.splice(row, 1);
+            } else {
+                right.splice(row - insertBefore, 1);
+            }
+        }
+        data = left.concat(extractedRows.concat(right));
+        var selectedRows: any[] = [];
+        for (var i = 0; i < rows.length; i++)
+            selectedRows.push(left.length + i);
+        grid.resetActiveCell();
+        grid.setData(data);
+        grid.setSelectedRows(selectedRows);
+        grid.render();
+    });
+    grid.registerPlugin(moveRowsPlugin);
+    grid.onDragInit.subscribe(function (e, dd) {
+        // prevent the grid from cancelling drag'n'drop by default
+        e.stopImmediatePropagation();
+    });
+    grid.onDragStart.subscribe(function (e: JQueryEventObject, dd: any) {
+        var cell = grid.getCellFromEvent(e);
+        if (!cell) {
+            return;
+        }
+        dd.row = cell.row;
+        if (!data[dd.row]) {
+            return;
+        }
+        if (Slick.GlobalEditorLock.isActive()) {
+            return;
+        }
+        e.stopImmediatePropagation();
+        dd.mode = "recycle";
+        var selectedRows = grid.getSelectedRows();
+        if (!selectedRows.length || $.inArray(dd.row, selectedRows) == -1) {
+            selectedRows = [dd.row];
+            grid.setSelectedRows(selectedRows);
+        }
+        dd.rows = selectedRows;
+        dd.count = selectedRows.length;
+        var proxy = $("<span></span>")
+            .css({
+                position: "absolute",
+                display: "inline-block",
+                padding: "4px 10px",
+                background: "#e0e0e0",
+                border: "1px solid gray",
+                "z-index": 99999,
+                "-moz-border-radius": "8px",
+                "-moz-box-shadow": "2px 2px 6px silver"
+            })
+            .text("Drag to Recycle Bin to delete " + dd.count + " selected row(s)")
+            .appendTo("body");
+        dd.helper = proxy;
+        $(dd.available).css("background", "pink");
+        return proxy;
+    });
+    grid.onDrag.subscribe(function (e: JQueryEventObject, dd: any) {
+        if (dd.mode != "recycle") {
+            return;
+        }
+        dd.helper.css({ top: e.pageY + 5, left: e.pageX + 5 });
+    });
+    grid.onDragEnd.subscribe(function (e: JQueryEventObject, dd: any) {
+        if (dd.mode != "recycle") {
+            return;
+        }
+        dd.helper.remove();
+        $(dd.available).css("background", "beige");
+    });
+    $.drop({ mode: "mouse" });
+    $("#dropzone")
+        .bind("dropstart", function (e, dd) {
+            if (dd.mode != "recycle") {
+                return;
+            }
+            $(this).css("background", "yellow");
+        } as (evt?: JQueryEventObject) => void)
+        .bind("dropend", function (e, dd) {
+            if (dd.mode != "recycle") {
+                return;
+            }
+            $(dd.available).css("background", "pink");
+        } as (evt?: JQueryEventObject) => void)
+        .bind("drop", function (e, dd) {
+            if (dd.mode != "recycle") {
+                return;
+            }
+            var rowsToDelete = dd.rows.sort().reverse();
+            for (var i = 0; i < rowsToDelete.length; i++) {
+                data.splice(rowsToDelete[i], 1);
+            }
+            grid.invalidate();
+            grid.setSelectedRows([]);
+        } as (evt?: JQueryEventObject) => void);
+    grid.onAddNewRow.subscribe(function (e, args) {
+        var item = { name: "New task", complete: false };
+        $.extend(item, args.item);
+        data.push(item);
+        grid.invalidateRows([data.length - 1]);
+        grid.updateRowCount();
+        grid.render();
+    });
+})

--- a/slickgrid/slick.rowmovemanager.d.ts
+++ b/slickgrid/slick.rowmovemanager.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for SlickGrid RowMoveManager Plugin 2.1.0
+// Project: https://github.com/mleibman/SlickGrid
+// Definitions by: berwyn <https://github.com/berwyn>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="SlickGrid.d.ts" />
+
+declare namespace Slick {
+    export interface SlickGridRowMoveManagerOptions extends PluginOptions {
+
+    }
+
+    export class RowMoveManager<T extends SlickData> extends Plugin<T> {
+        constructor(options?: SlickGridRowMoveManagerOptions);
+        init(grid: Grid<T>): void;
+        destroy(): void;
+
+        onBeforeMoveRows: Event<T>;
+        onMoveRows: Event<T>
+    }
+}


### PR DESCRIPTION
case 1. Add a new type definition (jquery.event.drag, jquery.event.drop, slick.rowmovemanager)
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
