### PR TITLE
adding 'delay' definition to redux-saga DT

### DIFF
--- a/redux-saga/redux-saga.d.ts
+++ b/redux-saga/redux-saga.d.ts
@@ -45,6 +45,10 @@ declare module 'redux-saga' {
 
   export function takeLatest(pattern: Pattern, saga: Saga, ...args: any[]): { [Symbol.iterator](): IterableIterator<any> };
 
+  export function delay(ms: number): Promise<boolean>;
+
+  export function delay<T>(ms: number, val: T): Promise<T>;
+
   export function isCancelError(e: any): boolean;
 }
 


### PR DESCRIPTION
case 2: Improvement to existing type definition.
- Adding the delay definitions enables importing 'delay' from redux-saga, as shown in the redux-saga tutorial: https://yelouafi.github.io/redux-saga/docs/introduction/BeginnerTutorial.html (about halfway down the page under heading 'Making Asynchronous calls' - third gray box of example code). This way 'delay' can be imported in a .tsx file the same way it can in javascript.
