### PR TITLE
Mongoose - improve Schema type information

### DIFF
--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -369,7 +369,7 @@ schema.path('name');
 schema.path('name', Number);
 schema.pathType('name');
 schema.plugin(function() {});
-schema.post('save', function(doc: IActor) {});
+schema.post('save', function(next: () => void, doc: IActor) {});
 schema.pre('save', function(next: () => void) {});
 schema.requiredPaths();
 schema.static('findByName', function(name: string, callback: () => void) {});

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -274,14 +274,10 @@ declare module "mongoose" {
     pathType(path: string): string;
     plugin(plugin: (schema: Schema, options?: Object) => void, options?: Object): Schema;
 
-    pre(method: string, fn: HookSyncCallback): Schema;
-    pre(method: string, fn: HookSyncCallback, errorCb: HookErrorCallback): Schema;
-    pre(method: string, isAsync: boolean, fn: HookAsyncCallback): Schema;
-    pre(method: string, isAsync: boolean, fn: HookAsyncCallback, errorCb: HookErrorCallback): Schema;
-    post(method: string, fn: HookSyncCallback): Schema;
-    post(method: string, fn: HookSyncCallback, errorCb: HookErrorCallback): Schema;
-    post(method: string, isAsync: boolean, fn: HookAsyncCallback): Schema;
-    post(method: string, isAsync: boolean, fn: HookAsyncCallback, errorCb: HookErrorCallback): Schema;
+    pre(method: string, fn: HookSyncCallback, errorCb?: HookErrorCallback): Schema;
+    pre(method: string, isAsync: boolean, fn: HookAsyncCallback, errorCb?: HookErrorCallback): Schema;
+    post(method: string, fn: HookSyncCallback, errorCb?: HookErrorCallback): Schema;
+    post(method: string, isAsync: boolean, fn: HookAsyncCallback, errorCb?: HookErrorCallback): Schema;
 
     requiredPaths(): string[];
     set(key: string, value: any): void;

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -289,25 +289,25 @@ declare module "mongoose" {
 
   // hook functions: https://github.com/vkarpov15/hooks-fixed
   export interface HookSyncCallback {
-      (next: HookNextFunction, ...hookArgs:any[]): any;
+    (next: HookNextFunction, ...hookArgs:any[]): any;
   }
 
   export interface HookAsyncCallback {
-      (next: HookNextFunction, done: HookDoneFunction, ...hookArgs:any[]): any;
+    (next: HookNextFunction, done: HookDoneFunction, ...hookArgs:any[]): any;
   }
 
   export interface HookErrorCallback {
-      (error: Error): any;
+    (error: Error): any;
   }
 
   export interface HookNextFunction {
-      (...hookArgs:any[]): any;
-      (error: Error): any;
+    (error: Error): any;
+    (...hookArgs:any[]): any;
   }
 
   export interface HookDoneFunction {
-      (...hookArgs:any[]): any;
-      (error: Error): any;
+    (error: Error): any;
+    (...hookArgs:any[]): any;
   }
 
   export interface SchemaOption {

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -256,6 +256,10 @@ declare module "mongoose" {
       OId: Types.ObjectId;
       Mixed: any;
     };
+
+    methods: any;
+    statics: any;
+
     constructor(schema?: Object, options?: Object);
 
     add(obj: Object, prefix?: string): void;
@@ -284,6 +288,7 @@ declare module "mongoose" {
     static(name: string, fn: Function): Schema;
     virtual(name: string, options?: Object): VirtualType;
     virtualpath(name: string): VirtualType;
+
   }
 
   // hook functions: https://github.com/vkarpov15/hooks-fixed

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -289,11 +289,11 @@ declare module "mongoose" {
 
   // hook functions: https://github.com/vkarpov15/hooks-fixed
   export interface HookSyncCallback {
-      (next: Function, ...hookArgs:any[]): any;
+      (next: HookNextFunction, ...hookArgs:any[]): any;
   }
 
   export interface HookAsyncCallback {
-      (next: Function, done: Function, ...hookArgs:any[]): any;
+      (next: HookNextFunction, done: HookDoneFunction, ...hookArgs:any[]): any;
   }
 
   export interface HookErrorCallback {
@@ -301,6 +301,11 @@ declare module "mongoose" {
   }
 
   export interface HookNextFunction {
+      (...hookArgs:any[]): any;
+      (error: Error): any;
+  }
+
+    export interface HookDoneFunction {
       (...hookArgs:any[]): any;
       (error: Error): any;
   }

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -305,7 +305,7 @@ declare module "mongoose" {
       (error: Error): any;
   }
 
-    export interface HookDoneFunction {
+  export interface HookDoneFunction {
       (...hookArgs:any[]): any;
       (error: Error): any;
   }

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -269,14 +269,41 @@ declare module "mongoose" {
     path(path: string, constructor: any): Schema;
     pathType(path: string): string;
     plugin(plugin: (schema: Schema, options?: Object) => void, options?: Object): Schema;
-    post(method: string, fn: Function): Schema;
-    pre(method: string, callback: Function): Schema;
+
+    pre(method: string, fn: HookSyncCallback): Schema;
+    pre(method: string, fn: HookSyncCallback, errorCb: HookErrorCallback): Schema;
+    pre(method: string, isAsync: boolean, fn: HookAsyncCallback): Schema;
+    pre(method: string, isAsync: boolean, fn: HookAsyncCallback, errorCb: HookErrorCallback): Schema;
+    post(method: string, fn: HookSyncCallback): Schema;
+    post(method: string, fn: HookSyncCallback, errorCb: HookErrorCallback): Schema;
+    post(method: string, isAsync: boolean, fn: HookAsyncCallback): Schema;
+    post(method: string, isAsync: boolean, fn: HookAsyncCallback, errorCb: HookErrorCallback): Schema;
+
     requiredPaths(): string[];
     set(key: string, value: any): void;
     static(name: string, fn: Function): Schema;
     virtual(name: string, options?: Object): VirtualType;
     virtualpath(name: string): VirtualType;
   }
+
+  // hook functions: https://github.com/vkarpov15/hooks-fixed
+  export interface HookSyncCallback {
+      (next: Function, ...hookArgs:any[]): any;
+  }
+
+  export interface HookAsyncCallback {
+      (next: Function, done: Function, ...hookArgs:any[]): any;
+  }
+
+  export interface HookErrorCallback {
+      (error: Error): any;
+  }
+
+  export interface HookNextFunction {
+      (...hookArgs:any[]): any;
+      (error: Error): any;
+  }
+
   export interface SchemaOption {
     autoIndex?: boolean;
     bufferCommands?: boolean;


### PR DESCRIPTION
1. Add details on `pre` and `post` on Schema
   Mongoose use `hooks-fixed` package to add hook methods, and should be added some detailed callback information.
   See https://github.com/vkarpov15/hooks-fixed
2. Add `static` and `methods` on Schema
   See http://mongoosejs.com/docs/2.7.x/docs/methods-statics.html
