### PR TITLE
find and findLast return undefined on failure

### DIFF
--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -6781,7 +6781,7 @@ declare module _ {
         find<T>(
             collection: List<T>,
             predicate?: ListIterator<T, boolean>
-        ): T;
+        ): T | undefined;
 
         /**
          * @see _.find
@@ -6789,7 +6789,7 @@ declare module _ {
         find<T>(
             collection: Dictionary<T>,
             predicate?: DictionaryIterator<T, boolean>
-        ): T;
+        ): T | undefined;
 
         /**
          * @see _.find
@@ -6797,7 +6797,7 @@ declare module _ {
         find<T>(
             collection: List<T>|Dictionary<T>,
             predicate?: string
-        ): T;
+        ): T | undefined;
 
         /**
          * @see _.find
@@ -6805,7 +6805,7 @@ declare module _ {
         find<TObject extends {}, T>(
             collection: List<T>|Dictionary<T>,
             predicate?: TObject
-        ): T;
+        ): T | undefined;
     }
 
     interface LoDashImplicitArrayWrapper<T> {
@@ -6814,21 +6814,21 @@ declare module _ {
          */
         find(
             predicate?: ListIterator<T, boolean>
-        ): T;
+        ): T | undefined;
 
         /**
          * @see _.find
          */
         find(
             predicate?: string
-        ): T;
+        ): T | undefined;
 
         /**
          * @see _.find
          */
         find<TObject extends {}>(
             predicate?: TObject
-        ): T;
+        ): T | undefined;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
@@ -6837,21 +6837,21 @@ declare module _ {
          */
         find<TResult>(
             predicate?: ListIterator<TResult, boolean>|DictionaryIterator<TResult, boolean>
-        ): TResult;
+        ): TResult | undefined;
 
         /**
          * @see _.find
          */
         find<TResult>(
             predicate?: string
-        ): TResult;
+        ): TResult | undefined;
 
         /**
          * @see _.find
          */
         find<TObject extends {}, TResult>(
             predicate?: TObject
-        ): TResult;
+        ): TResult | undefined;
     }
 
     //_.findLast
@@ -6866,21 +6866,21 @@ declare module _ {
         **/
         findLast<T>(
             collection: Array<T>,
-            callback: ListIterator<T, boolean>): T;
+            callback: ListIterator<T, boolean>): T | undefined;
 
         /**
         * @see _.find
         **/
         findLast<T>(
             collection: List<T>,
-            callback: ListIterator<T, boolean>): T;
+            callback: ListIterator<T, boolean>): T | undefined;
 
         /**
         * @see _.find
         **/
         findLast<T>(
             collection: Dictionary<T>,
-            callback: DictionaryIterator<T, boolean>): T;
+            callback: DictionaryIterator<T, boolean>): T | undefined;
 
         /**
         * @see _.find
@@ -6888,7 +6888,7 @@ declare module _ {
         **/
         findLast<W, T>(
             collection: Array<T>,
-            whereValue: W): T;
+            whereValue: W): T | undefined;
 
         /**
         * @see _.find
@@ -6896,7 +6896,7 @@ declare module _ {
         **/
         findLast<W, T>(
             collection: List<T>,
-            whereValue: W): T;
+            whereValue: W): T | undefined;
 
         /**
         * @see _.find
@@ -6904,7 +6904,7 @@ declare module _ {
         **/
         findLast<W, T>(
             collection: Dictionary<T>,
-            whereValue: W): T;
+            whereValue: W): T | undefined;
 
         /**
         * @see _.find
@@ -6912,7 +6912,7 @@ declare module _ {
         **/
         findLast<T>(
             collection: Array<T>,
-            pluckValue: string): T;
+            pluckValue: string): T | undefined;
 
         /**
         * @see _.find
@@ -6920,7 +6920,7 @@ declare module _ {
         **/
         findLast<T>(
             collection: List<T>,
-            pluckValue: string): T;
+            pluckValue: string): T | undefined;
 
         /**
         * @see _.find
@@ -6928,7 +6928,7 @@ declare module _ {
         **/
         findLast<T>(
             collection: Dictionary<T>,
-            pluckValue: string): T;
+            pluckValue: string): T | undefined;
     }
 
     interface LoDashImplicitArrayWrapper<T> {
@@ -6936,20 +6936,20 @@ declare module _ {
         * @see _.findLast
         */
         findLast(
-            callback: ListIterator<T, boolean>): T;
+            callback: ListIterator<T, boolean>): T | undefined;
         /**
         * @see _.findLast
         * @param _.where style callback
         */
         findLast<W>(
-            whereValue: W): T;
+            whereValue: W): T | undefined;
 
         /**
         * @see _.findLast
         * @param _.where style callback
         */
         findLast(
-            pluckValue: string): T;
+            pluckValue: string): T | undefined;
     }
 
     //_.flatMap


### PR DESCRIPTION
TypeScript now has a strict null checking option. When it is turned on, types that can be `undefined` or `null` must explicitly say so.

This fixes the find/findLast methods so that they declare their potential to return `undefined`.
