### PR TITLE
Correct method name ($postLink)

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1755,7 +1755,7 @@ declare namespace angular {
          * analogous to the ngAfterViewInit and ngAfterContentInit hooks in Angular 2. Since the compilation process is rather
          * different in Angular 1 there is no direct mapping and care should be taken when upgrading.
          */
-        $postInit?(): void;
+        $postLink?(): void;
     }
 
     interface IChangesObject {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url https://docs.angularjs.org/api/ng/service/$compile.

`$postInit` should be `$postLink`
