### PR TITLE
Update atmosphere.d.ts

### DIFF
--- a/atmosphere/atmosphere.d.ts
+++ b/atmosphere/atmosphere.d.ts
@@ -55,7 +55,7 @@ declare namespace Atmosphere {
         connectTimeout?: number;
         reconnectInterval?: number;
         dropHeaders?: boolean;
-        uuid?: number;
+        uuid?: string;
         async?: boolean;
         shared?: boolean;
         readResponsesHeaders?: boolean;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
An AtmosphereResource has a unique identifier that can be retrieved using
 String uuid = atmosphereResource.uuid();
https://github.com/Atmosphere/atmosphere/wiki/Understanding-AtmosphereResource

UUID is actually a string containing of dashes and numbers. 
e.g. : c7d2d49e-accf-4b1a-b545-4ff6eea54091
