### PR TITLE
Fix ua-parser-js definitions.

### DIFF
--- a/ua-parser-js/ua-parser-js.d.ts
+++ b/ua-parser-js/ua-parser-js.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Viktor Miroshnikov <https://github.com/superduper>, Lucas Woo <https://github.com/legendecas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace UAParser {
+declare namespace IUAParser {
 
     export interface IBrowser {
         /**
@@ -18,31 +18,31 @@ declare namespace UAParser {
          * Tizen, UCBrowser, Vivaldi, w3m, Yandex
          *
          */
-        name:string;
+        name: string;
 
         /**
          * Determined dynamically
          */
-        version:string;
+        version: string;
 
         /**
          * Determined dynamically
          * @deprecated
          */
-        major:string;
+        major: string;
     }
 
     export interface IDevice {
         /**
          * Determined dynamically
          */
-        model:string;
+        model: string;
 
         /**
          * Possible type:
          * console, mobile, tablet, smarttv, wearable, embedded
          */
-        type:string;
+        type: string;
 
         /**
          * Possible vendor:
@@ -51,7 +51,7 @@ declare namespace UAParser {
          * Nintendo, Nokia, Nvidia, Ouya, Palm, Panasonic, Polytron, RIM, Samsung, Sharp,
          * Siemens, Sony-Ericsson, Sprint, Xbox, ZTE
          */
-        vendor:string;
+        vendor: string;
     }
 
     export interface IEngine {
@@ -60,11 +60,11 @@ declare namespace UAParser {
          * Amaya, EdgeHTML, Gecko, iCab, KHTML, Links, Lynx, NetFront, NetSurf, Presto,
          * Tasman, Trident, w3m, WebKit
          */
-        name:string;
+        name: string;
         /**
          * Determined dynamically
          */
-        version:string;
+        version: string;
     }
 
     export interface IOS {
@@ -77,11 +77,11 @@ declare namespace UAParser {
          * RIM Tablet OS, RISC OS, Sailfish, Series40, Slackware, Solaris, SUSE, Symbian, Tizen,
          * Ubuntu, UNIX, VectorLinux, WebOS, Windows [Phone/Mobile], Zenwalk
          */
-        name:string;
+        name: string;
         /**
          * Determined dynamically
          */
-        version:string;
+        version: string;
     }
 
     export interface ICPU {
@@ -90,120 +90,107 @@ declare namespace UAParser {
          *  68k, amd64, arm, arm64, avr, ia32, ia64, irix, irix64, mips, mips64, pa-risc,
          *  ppc, sparc, sparc64
          */
-        architecture:string;
+        architecture: string;
     }
 
     export interface IResult {
-        ua:string;
-        browser:IBrowser;
-        device:IDevice;
-        engine:IEngine;
-        os:IOS;
-        cpu:ICPU;
+        ua: string;
+        browser: IBrowser;
+        device: IDevice;
+        engine: IEngine;
+        os: IOS;
+        cpu: ICPU;
     }
 
     export interface BROWSER {
-        NAME:string;
+        NAME: string;
         /**
          * @deprecated
          */
-        MAJOR:string;
-        VERSION:string;
+        MAJOR: string;
+        VERSION: string;
     }
 
     export interface CPU {
-        ARCHITECTURE:string;
+        ARCHITECTURE: string;
     }
 
     export interface DEVICE {
-        MODEL:string;
-        VENDOR:string;
-        TYPE:string;
-        CONSOLE:string;
-        MOBILE:string;
-        SMARTTV:string;
-        TABLET:string;
-        WEARABLE:string;
-        EMBEDDED:string;
+        MODEL: string;
+        VENDOR: string;
+        TYPE: string;
+        CONSOLE: string;
+        MOBILE: string;
+        SMARTTV: string;
+        TABLET: string;
+        WEARABLE: string;
+        EMBEDDED: string;
     }
 
     export interface ENGINE {
-        NAME:string;
-        VERSION:string;
+        NAME: string;
+        VERSION: string;
     }
 
     export interface OS {
-        NAME:string;
-        VERSION:string;
+        NAME: string;
+        VERSION: string;
     }
 }
 
 declare module "ua-parser-js" {
-    import BROWSER = UAParser.BROWSER;
-    import CPU = UAParser.CPU;
-    import DEVICE = UAParser.DEVICE;
-    import ENGINE = UAParser.ENGINE;
-    import OS = UAParser.OS;
-    import IBrowser = UAParser.IBrowser;
-    import IOS = UAParser.IOS;
-    import IEngine = UAParser.IEngine;
-    import IDevice = UAParser.IDevice;
-    import ICPU = UAParser.ICPU;
-    import IResult = UAParser.IResult;
-
     export class UAParser {
-        static VERSION:string;
-        static BROWSER:BROWSER;
-        static CPU:CPU;
-        static DEVICE:DEVICE;
-        static ENGINE:ENGINE;
-        static OS:OS;
+        static VERSION: string;
+        static BROWSER: IUAParser.BROWSER;
+        static CPU: IUAParser.CPU;
+        static DEVICE: IUAParser.DEVICE;
+        static ENGINE: IUAParser.ENGINE;
+        static OS: IUAParser.OS;
 
         /**
          * Create a new parser with UA prepopulated and extensions extended
          */
-        constructor(uastring?:string, extensions?:any);
+        constructor(uastring?: string, extensions?: any);
 
         /**
          *  Returns browser information
          */
-        getBrowser():IBrowser;
+        getBrowser(): IUAParser.IBrowser;
 
         /**
          *  Returns OS information
          */
-        getOS():IOS;
+        getOS(): IUAParser.IOS;
 
         /**
          *  Returns browsers engine information
          */
-        getEngine():IEngine;
+        getEngine(): IUAParser.IEngine;
 
         /**
          *  Returns device information
          */
-        getDevice():IDevice;
+        getDevice(): IUAParser.IDevice;
 
         /**
          *  Returns parsed CPU information
          */
-        getCPU():ICPU;
+        getCPU(): IUAParser.ICPU;
 
         /**
          *  Returns UA string of current instance
          */
-        getUA():string;
+        getUA(): string;
 
         /**
          *  Set & parse UA string
          */
-        setUA(uastring:string):UAParser;
+        setUA(uastring: string): UAParser;
 
         /**
          *  Returns parse result
          */
-        getResult():IResult;
+        getResult(): IUAParser.IResult;
     }
-
 }
 

--- a/ua-parser-js/ua-parser-js.d.ts
+++ b/ua-parser-js/ua-parser-js.d.ts
@@ -3,79 +3,79 @@
 // Definitions by: Viktor Miroshnikov <https://github.com/superduper>, Lucas Woo <https://github.com/legendecas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace UAParser {
+declare namespace IUAParser {
 
     export interface IBrowser {
         /**
-        * Possible values :
-        * Amaya, Android Browser, Arora, Avant, Baidu, Blazer, Bolt, Camino, Chimera, Chrome,
-        * Chromium, Comodo Dragon, Conkeror, Dillo, Dolphin, Doris, Edge, Epiphany, Fennec,
-        * Firebird, Firefox, Flock, GoBrowser, iCab, ICE Browser, IceApe, IceCat, IceDragon,
-        * Iceweasel, IE [Mobile], Iron, Jasmine, K-Meleon, Konqueror, Kindle, Links,
-        * Lunascape, Lynx, Maemo, Maxthon, Midori, Minimo, MIUI Browser, [Mobile] Safari,
-        * Mosaic, Mozilla, Netfront, Netscape, NetSurf, Nokia, OmniWeb, Opera [Mini/Mobi/Tablet],
-        * Phoenix, Polaris, QQBrowser, RockMelt, Silk, Skyfire, SeaMonkey, SlimBrowser, Swiftfox,
-        * Tizen, UCBrowser, Vivaldi, w3m, Yandex
-        *
-        */
-        name: string;
+         * Possible values :
+         * Amaya, Android Browser, Arora, Avant, Baidu, Blazer, Bolt, Camino, Chimera, Chrome,
+         * Chromium, Comodo Dragon, Conkeror, Dillo, Dolphin, Doris, Edge, Epiphany, Fennec,
+         * Firebird, Firefox, Flock, GoBrowser, iCab, ICE Browser, IceApe, IceCat, IceDragon,
+         * Iceweasel, IE [Mobile], Iron, Jasmine, K-Meleon, Konqueror, Kindle, Links,
+         * Lunascape, Lynx, Maemo, Maxthon, Midori, Minimo, MIUI Browser, [Mobile] Safari,
+         * Mosaic, Mozilla, Netfront, Netscape, NetSurf, Nokia, OmniWeb, Opera [Mini/Mobi/Tablet],
+         * Phoenix, Polaris, QQBrowser, RockMelt, Silk, Skyfire, SeaMonkey, SlimBrowser, Swiftfox,
+         * Tizen, UCBrowser, Vivaldi, w3m, Yandex
+         *
+         */
+        name:string;
 
         /**
-        * Determined dynamically
-        */
-        version: string;
+         * Determined dynamically
+         */
+        version:string;
     }
 
     export interface IDevice {
         /**
-        * Determined dynamically
-        */
-        model: string;
+         * Determined dynamically
+         */
+        model:string;
 
         /**
-        * Possible type:
-        * console, mobile, tablet, smarttv, wearable, embedded
-        */
-        type: string;
+         * Possible type:
+         * console, mobile, tablet, smarttv, wearable, embedded
+         */
+            type:string;
 
         /**
-        * Possible vendor:
-        * Acer, Alcatel, Amazon, Apple, Archos, Asus, BenQ, BlackBerry, Dell, GeeksPhone,
-        * Google, HP, HTC, Huawei, Jolla, Lenovo, LG, Meizu, Microsoft, Motorola, Nexian,
-        * Nintendo, Nokia, Nvidia, Ouya, Palm, Panasonic, Polytron, RIM, Samsung, Sharp,
-        * Siemens, Sony-Ericsson, Sprint, Xbox, ZTE
-        */
-        vendor: string;
+         * Possible vendor:
+         * Acer, Alcatel, Amazon, Apple, Archos, Asus, BenQ, BlackBerry, Dell, GeeksPhone,
+         * Google, HP, HTC, Huawei, Jolla, Lenovo, LG, Meizu, Microsoft, Motorola, Nexian,
+         * Nintendo, Nokia, Nvidia, Ouya, Palm, Panasonic, Polytron, RIM, Samsung, Sharp,
+         * Siemens, Sony-Ericsson, Sprint, Xbox, ZTE
+         */
+        vendor:string;
     }
 
     export interface IEngine {
         /**
-        * Possible name:
-        * Amaya, EdgeHTML, Gecko, iCab, KHTML, Links, Lynx, NetFront, NetSurf, Presto,
-        * Tasman, Trident, w3m, WebKit
-        */
-        name: string;
+         * Possible name:
+         * Amaya, EdgeHTML, Gecko, iCab, KHTML, Links, Lynx, NetFront, NetSurf, Presto,
+         * Tasman, Trident, w3m, WebKit
+         */
+        name:string;
         /**
-        * Determined dynamically
-        */
-        version: string;
+         * Determined dynamically
+         */
+        version:string;
     }
 
     export interface IOS {
         /**
-        * Possible 'os.name'
-        * AIX, Amiga OS, Android, Arch, Bada, BeOS, BlackBerry, CentOS, Chromium OS, Contiki,
-        * Fedora, Firefox OS, FreeBSD, Debian, DragonFly, Gentoo, GNU, Haiku, Hurd, iOS,
-        * Joli, Linpus, Linux, Mac OS, Mageia, Mandriva, MeeGo, Minix, Mint, Morph OS, NetBSD,
-        * Nintendo, OpenBSD, OpenVMS, OS/2, Palm, PCLinuxOS, Plan9, Playstation, QNX, RedHat,
-        * RIM Tablet OS, RISC OS, Sailfish, Series40, Slackware, Solaris, SUSE, Symbian, Tizen,
-        * Ubuntu, UNIX, VectorLinux, WebOS, Windows [Phone/Mobile], Zenwalk
-        */
-        name: string;
+         * Possible 'os.name'
+         * AIX, Amiga OS, Android, Arch, Bada, BeOS, BlackBerry, CentOS, Chromium OS, Contiki,
+         * Fedora, Firefox OS, FreeBSD, Debian, DragonFly, Gentoo, GNU, Haiku, Hurd, iOS,
+         * Joli, Linpus, Linux, Mac OS, Mageia, Mandriva, MeeGo, Minix, Mint, Morph OS, NetBSD,
+         * Nintendo, OpenBSD, OpenVMS, OS/2, Palm, PCLinuxOS, Plan9, Playstation, QNX, RedHat,
+         * RIM Tablet OS, RISC OS, Sailfish, Series40, Slackware, Solaris, SUSE, Symbian, Tizen,
+         * Ubuntu, UNIX, VectorLinux, WebOS, Windows [Phone/Mobile], Zenwalk
+         */
+        name:string;
         /**
-        * Determined dynamically
-        */
-        version: string;
+         * Determined dynamically
+         */
+        version:string;
     }
 
     export interface ICPU {
@@ -84,50 +84,50 @@ declare namespace UAParser {
          *  68k, amd64, arm, arm64, avr, ia32, ia64, irix, irix64, mips, mips64, pa-risc,
          *  ppc, sparc, sparc64
          */
-        architecture: string;
+        architecture:string;
     }
 
     export interface IResult {
-        ua: string;
-        browser: IBrowser;
-        device: IDevice;
-        engine: IEngine;
-        os: IOS;
-        cpu: ICPU;
+        ua:string;
+        browser:IBrowser;
+        device:IDevice;
+        engine:IEngine;
+        os:IOS;
+        cpu:ICPU;
     }
 
     export interface BROWSER {
-        NAME: string,
+        NAME:string;
 
         // Deprecated
-        MAJOR: string,
-        VERSION: string
+        MAJOR:string;
+        VERSION:string;
     }
 
     export interface CPU {
-        ARCHITECTURE: string
+        ARCHITECTURE:string;
     }
 
     export interface DEVICE {
-        MODEL: string,
-        VENDOR: string,
-        TYPE: string,
-        CONSOLE: string,
-        MOBILE: string,
-        SMARTTV: string,
-        TABLET: string,
-        WEARABLE: string,
-        EMBEDDED: string
+        MODEL:string;
+        VENDOR:string;
+        TYPE:string;
+        CONSOLE:string;
+        MOBILE:string;
+        SMARTTV:string;
+        TABLET:string;
+        WEARABLE:string;
+        EMBEDDED:string;
     }
 
     export interface ENGINE {
-        NAME: string,
-        VERSION: string
+        NAME:string;
+        VERSION:string;
     }
 
     export interface OS {
-        NAME: string,
-        VERSION: string
+        NAME:string;
+        VERSION:string;
     }
 
 }
@@ -135,56 +135,58 @@ declare namespace UAParser {
 declare module "ua-parser-js" {
 
     export class UAParser {
-        static VERSION: string;
-        static BROWSER: UAParser.BROWSER;
-        static CPU: UAParser.CPU;
-        static DEVICE: UAParser.DEVICE;
-        static ENGINE: UAParser.ENGINE;
-        static OS: UAParser.OS;
-
-        /**
-        *  Returns browser information
-        */
-        getBrowser(): UAParser.IBrowser;
-        /**
-        *  Returns OS information
-        */
-        getOS(): UAParser.IOS;
-
-        /**
-        *  Returns browsers engine information
-        */
-        getEngine(): UAParser.IEngine;
-
-        /**
-        *  Returns device information
-        */
-        getDevice(): UAParser.IDevice;
-
-        /**
-        *  Returns parsed CPU information
-        */
-        getCPU(): UAParser.ICPU;
-
-        /**
-        *  Returns UA string of current instance
-        */
-        getUA(): string;
-
-        /**
-        *  Set & parse UA string
-        */
-        setUA(uastring: string): UAParser;
-
-        /**
-        *  Returns parse result
-        */
-        getResult(): UAParser.IResult;
+        static VERSION:string;
+        static BROWSER:IUAParser.BROWSER;
+        static CPU:IUAParser.CPU;
+        static DEVICE:IUAParser.DEVICE;
+        static ENGINE:IUAParser.ENGINE;
+        static OS:IUAParser.OS;
 
         /**
          * Create a new parser with UA prepopulated and extensions extended
          */
-        constructor(uastring?: string, extensions?: any);
+        constructor(uastring?:string, extensions?:any);
+
+        /**
+         *  Returns browser information
+         */
+        getBrowser():IUAParser.IBrowser;
+
+        /**
+         *  Returns OS information
+         */
+        getOS():IUAParser.IOS;
+
+        /**
+         *  Returns browsers engine information
+         */
+        getEngine():IUAParser.IEngine;
+
+        /**
+         *  Returns device information
+         */
+        getDevice():IUAParser.IDevice;
+
+        /**
+         *  Returns parsed CPU information
+         */
+        getCPU():IUAParser.ICPU;
+
+        /**
+         *  Returns UA string of current instance
+         */
+        getUA():string;
+
+        /**
+         *  Set & parse UA string
+         */
+        setUA(uastring:string):UAParser;
+
+        /**
+         *  Returns parse result
+         */
+        getResult():IUAParser.IResult;
     }
 
 }
+

--- a/ua-parser-js/ua-parser-js.d.ts
+++ b/ua-parser-js/ua-parser-js.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Viktor Miroshnikov <https://github.com/superduper>, Lucas Woo <https://github.com/legendecas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace IUAParser {
+declare namespace UAParser {
 
     export interface IBrowser {
         /**
@@ -24,6 +24,12 @@ declare namespace IUAParser {
          * Determined dynamically
          */
         version:string;
+
+        /**
+         * Determined dynamically
+         * @deprecated
+         */
+        major:string;
     }
 
     export interface IDevice {
@@ -36,7 +42,7 @@ declare namespace IUAParser {
          * Possible type:
          * console, mobile, tablet, smarttv, wearable, embedded
          */
-            type:string;
+        type:string;
 
         /**
          * Possible vendor:
@@ -98,8 +104,9 @@ declare namespace IUAParser {
 
     export interface BROWSER {
         NAME:string;
-
-        // Deprecated
+        /**
+         * @deprecated
+         */
         MAJOR:string;
         VERSION:string;
     }
@@ -129,18 +136,28 @@ declare namespace IUAParser {
         NAME:string;
         VERSION:string;
     }
-
 }
 
 declare module "ua-parser-js" {
+    import BROWSER = UAParser.BROWSER;
+    import CPU = UAParser.CPU;
+    import DEVICE = UAParser.DEVICE;
+    import ENGINE = UAParser.ENGINE;
+    import OS = UAParser.OS;
+    import IBrowser = UAParser.IBrowser;
+    import IOS = UAParser.IOS;
+    import IEngine = UAParser.IEngine;
+    import IDevice = UAParser.IDevice;
+    import ICPU = UAParser.ICPU;
+    import IResult = UAParser.IResult;
 
     export class UAParser {
         static VERSION:string;
-        static BROWSER:IUAParser.BROWSER;
-        static CPU:IUAParser.CPU;
-        static DEVICE:IUAParser.DEVICE;
-        static ENGINE:IUAParser.ENGINE;
-        static OS:IUAParser.OS;
+        static BROWSER:BROWSER;
+        static CPU:CPU;
+        static DEVICE:DEVICE;
+        static ENGINE:ENGINE;
+        static OS:OS;
 
         /**
          * Create a new parser with UA prepopulated and extensions extended
@@ -150,27 +167,27 @@ declare module "ua-parser-js" {
         /**
          *  Returns browser information
          */
-        getBrowser():IUAParser.IBrowser;
+        getBrowser():IBrowser;
 
         /**
          *  Returns OS information
          */
-        getOS():IUAParser.IOS;
+        getOS():IOS;
 
         /**
          *  Returns browsers engine information
          */
-        getEngine():IUAParser.IEngine;
+        getEngine():IEngine;
 
         /**
          *  Returns device information
          */
-        getDevice():IUAParser.IDevice;
+        getDevice():IDevice;
 
         /**
          *  Returns parsed CPU information
          */
-        getCPU():IUAParser.ICPU;
+        getCPU():ICPU;
 
         /**
          *  Returns UA string of current instance
@@ -185,7 +202,7 @@ declare module "ua-parser-js" {
         /**
          *  Returns parse result
          */
-        getResult():IUAParser.IResult;
+        getResult():IResult;
     }
 
 }


### PR DESCRIPTION
URL to library: https://github.com/faisalman/ua-parser-js

Currently ua-parser-js.d.ts broken. I fixed it. Webstorm's auto-reformat used for consistent code-style in file.
