### PR TITLE
Fix type for Lovefield RawForeignKeySpec object

### DIFF
--- a/lovefield/lovefield.d.ts
+++ b/lovefield/lovefield.d.ts
@@ -188,7 +188,7 @@ declare namespace lf {
       local: string
       ref: string
       action: lf.ConstraintAction
-      timing: lf.ConstraintAction
+      timing: lf.ConstraintTiming
     }
 
     export interface TableBuilder {


### PR DESCRIPTION
Currently the `RawForeignKeySpec.timing` type is set to `ConstraintAction`. After checking the test [here](https://github.com/google/lovefield/blob/master/tests/schema/builder_test.js#L57) I confirmed that it should be `ConstraintTiming` instead.
