### PR TITLE
Update JSZip definitions for version 3

### DIFF
--- a/jszip/jszip-tests.ts
+++ b/jszip/jszip-tests.ts
@@ -8,112 +8,121 @@ var SEVERITY = {
 	FATAL: 4
 }
 
-function testJSZip() {
-	var newJszip = new JSZip();
+function createTestZip(): JSZip {
+	var zip = new JSZip();
+	zip.file("test.txt", "test string");
+	zip.file("test/test.txt", "test string");
+	return zip
+}
 
-	newJszip.file("test.txt", "test string");
-	newJszip.file("test/test.txt", "test string");
-
-	var serializedZip = newJszip.generate({compression: "DEFLATE", type: "base64"});
-
-	newJszip = new JSZip();
-	newJszip.load(serializedZip, {base64: true, checkCRC32: true});
-
-    if (newJszip.file("test.txt").asText() === "test string") {
-		log(SEVERITY.INFO, "all ok");
-	} else {
-		log(SEVERITY.ERROR, "no matching file found");
-	}
-    if (newJszip.file("test/test.txt").asText() === "test string") {
-		log(SEVERITY.INFO, "all ok");
-	} else {
-		log(SEVERITY.ERROR, "no matching file found");
-	}
-
-	var folder = newJszip.folder("test");
-	if(folder.file("test.txt").asText() == "test string") {
-		log(SEVERITY.INFO, "all ok");
-	}
-	else {
-		log(SEVERITY.ERROR, "wrong file");
-	}
-
-	var folders = newJszip.folder(new RegExp("^test"));
-
-	if(folders.length == 1) {
-		log(SEVERITY.INFO, "all ok");
-		if(folders[0].dir == true) {
-			log(SEVERITY.INFO, "all ok");
-		}
-		else {
-			log(SEVERITY.ERROR, "wrong file");
-		}
-	} else {
-		log(SEVERITY.ERROR, "wrong number of folder");
-	}
-
-	var files = newJszip.file(new RegExp("^test"));
-	if(files.length == 2) {
-		log(SEVERITY.INFO, "all ok");
-        if (files[0].asText() == "test string" && files[1].asText() == "test string") {
-			log(SEVERITY.INFO, "all ok");
-		}
-		else {
-			log(SEVERITY.ERROR, "wrong data in files");
-		}
-	}
-	else {
-		log(SEVERITY.ERROR, "wrong number of files");
-	}
-
-	var filterFiles = newJszip.filter((relativePath: string, file: JSZipObject) => {
-        if (file.asText() == "test string") {
-			return true;
-		}
-		return false;
+function filterWithFileAsync(zip: JSZip, as: Serialization,
+                             cb: (relativePath: string, file: JSZipObject, value: any) => boolean)
+  : Promise<JSZipObject[]> {
+	var promises: Promise<any>[] = [];
+	var promiseIndices: {[key: string]: number} = {};
+	zip.forEach((relativePath: string, file: JSZipObject) => {
+		var promise = file.async(as);
+		promiseIndices[file.name] = promises.length;
+		promises.push(promise);
 	});
+	return Promise.all(promises).then(function(values: any[]) {
+		var filtered = zip.filter((relativePath: string, file: JSZipObject) => {
+			var index = promiseIndices[file.name];
+			return cb(relativePath, file, values[index]);
+		});
+		return Promise.resolve(filtered);
+	});
+}
 
-	if(filterFiles.length == 2) {
-		log(SEVERITY.INFO, "all ok");
-	}
-	else {
-		log(SEVERITY.ERROR, "wrong number of files");
-	}
+function testJSZip() {
+	var zip = createTestZip();
+	zip.generateAsync({compression: "DEFLATE", type: "base64"}).then(function(serializedZip: any) {
+		var newJszip = new JSZip();
+		return newJszip.loadAsync(serializedZip, {base64: true/*, checkCRC32: true*/});
+	}).then(function(newJszip: JSZip) {
+		newJszip.file("test.txt").async('text').then(function(text: string) {
+			if (text === "test string") {
+				log(SEVERITY.INFO, "all ok");
+			} else {
+				log(SEVERITY.ERROR, "no matching file found");
+			}
+		}).catch((e: any) => log(SEVERITY.ERROR, e));
 
+		newJszip.file("test/test.txt").async('text').then(function(text: string) {
+			if (text === "test string") {
+				log(SEVERITY.INFO, "all ok");
+			} else {
+				log(SEVERITY.ERROR, "no matching file found");
+			}
+		}).catch((e: any) => log(SEVERITY.ERROR, e));
+
+		var folder = newJszip.folder("test");
+		folder.file("test.txt").async('text').then(function(text: string) {
+			if (text == "test string") {
+				log(SEVERITY.INFO, "all ok");
+			} else {
+				log(SEVERITY.ERROR, "wrong file");
+			}
+		}).catch((e: any) => log(SEVERITY.ERROR, e));
+
+		var folders = newJszip.folder(new RegExp("^test"));
+
+		if (folders.length == 1) {
+			log(SEVERITY.INFO, "all ok");
+			if (folders[0].dir == true) {
+				log(SEVERITY.INFO, "all ok");
+			} else {
+				log(SEVERITY.ERROR, "wrong file");
+			}
+		} else {
+			log(SEVERITY.ERROR, "wrong number of folder");
+		}
+
+		var files = newJszip.file(new RegExp("^test"));
+		if (files.length == 2) {
+			log(SEVERITY.INFO, "all ok");
+			Promise.all([files[0].async('text'), files[1].async('text')]).then(function(texts: string[]) {
+				if (texts[0] == "test string" && texts[1] == 'test string') {
+					log(SEVERITY.INFO, "all ok");
+				} else {
+					log(SEVERITY.ERROR, "wrong data in files");
+				}
+			});
+		} else {
+			log(SEVERITY.ERROR, "wrong number of files");
+		}
+
+		filterWithFileAsync(newJszip, 'text', (relativePath: string, file: JSZipObject, text: string) => {
+			if (text == "test string") {
+				return true;
+			}
+			return false;
+		}).then(function(filterFiles: JSZipObject[]) {
+			if (filterFiles.length == 2) {
+				log(SEVERITY.INFO, "all ok");
+			} else {
+				log(SEVERITY.ERROR, "wrong number of files");
+			}
+		}).catch((e: any) => log(SEVERITY.ERROR, e));
+	}).catch((e: any)=> { console.error(e) });
+}
+
+function testJSZipRemove() {
+	var newJszip = createTestZip();
 	newJszip.remove("test/test.txt");
 
-	filterFiles = newJszip.filter((relativePath: string, file: JSZipObject) => {
-        if (file.asText() == "test string") {
+	filterWithFileAsync(newJszip, 'text', (relativePath: string, file: JSZipObject, text: string) => {
+		if (text == "test string") {
 			return true;
 		}
 		return false;
-	});
-
-	if(filterFiles.length == 1) {
-		log(SEVERITY.INFO, "all ok");
-	}
-	else {
-		log(SEVERITY.ERROR, "wrong number of files");
-	}
-
-	var uncompressedStr = JSZip.compressions.DEFLATE.uncompress(
-		JSZip.compressions.DEFLATE.compress("\0\1\2\3\4\5\6\7",{level:9}));
-	var uncompressedArr = JSZip.compressions.DEFLATE.uncompress(
-		JSZip.compressions.DEFLATE.compress([0,1,2,3,4,5,6,7],{level:9}));
-	var uncompressedUint8Arr = JSZip.compressions.DEFLATE.uncompress(
-		JSZip.compressions.DEFLATE.compress(new Uint8Array([0,1,2,3,4,5,6,7]),{level:9}));
-
-	var every_match = [0,1,2,3,4,5,6,7].every(function(val, i){
-		return uncompressedStr[i] === val &&
-					 uncompressedArr[i] === val &&
-					 uncompressedUint8Arr[i] === val;
-	});
-	if(every_match) {
-		log(SEVERITY.INFO, "compress and uncompress ok.");
-	}else{
-		log(SEVERITY.ERROR, "compress or uncompress failed.");
-	}
-
+	}).then(function(filterFiles: JSZipObject[]) {
+		if (filterFiles.length == 1) {
+			log(SEVERITY.INFO, "all ok");
+		} else {
+			log(SEVERITY.ERROR, "wrong number of files");
+		}
+	}).catch((e: any) => log(SEVERITY.ERROR, e));
 }
 
 function log(severity:number, message: any) {
@@ -142,3 +151,4 @@ function log(severity:number, message: any) {
 }
 
 testJSZip();
+testJSZipRemove();

--- a/jszip/jszip.d.ts
+++ b/jszip/jszip.d.ts
@@ -4,6 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface JSZip {
+    files: {[key: string]: JSZipObject};
+
     /**
      * Get a file from the archive
      *
@@ -47,6 +49,13 @@ interface JSZip {
     folder(name: RegExp): JSZipObject[];
 
     /**
+     * Call a callback function for each entry at this folder level.
+     *
+     * @param callback function
+     */
+    forEach(callback: (relativePath: string, file: JSZipObject) => void): void;
+
+    /**
      * Get all files wchich match the given filter function
      *
      * @param predicate Filter function
@@ -63,22 +72,39 @@ interface JSZip {
     remove(path: string): JSZip;
 
     /**
-     * Generates a new archive
-     *
-     * @param options Optional options for the generator
-     * @return The serialized archive
+     * @deprecated since version 3.0
+     * @see {@link generateAsync}
+     * http://stuk.github.io/jszip/documentation/upgrade_guide.html
      */
     generate(options?: JSZipGeneratorOptions): any;
 
     /**
-     * Deserialize zip file
+     * Generates a new archive asynchronously
+     *
+     * @param options Optional options for the generator
+     * @return The serialized archive
+     */
+    generateAsync(options?: JSZipGeneratorOptions, onUpdate?: Function): Promise<any>;
+
+    /**
+     * @deprecated since version 3.0
+     * @see {@link loadAsync}
+     * http://stuk.github.io/jszip/documentation/upgrade_guide.html
+     */
+    load(): void;
+
+    /**
+     * Deserialize zip file asynchronously
      *
      * @param data Serialized zip file
      * @param options Options for deserializing
-     * @return Returns the JSZip instance
+     * @return Returns promise
      */
-    load(data: any, options: JSZipLoadOptions): JSZip;
+    loadAsync(data: any, options?: JSZipLoadOptions): Promise<JSZip>;
 }
+
+type Serialization = ("string" | "text" | "base64" | "binarystring" | "uint8array" |
+                      "arraybuffer" | "blob" | "nodebuffer");
 
 interface JSZipObject {
     name: string;
@@ -87,11 +113,31 @@ interface JSZipObject {
     comment: string;
     options: JSZipObjectOptions;
 
-    asText(): string;
-    asBinary(): string;
-    asArrayBuffer(): ArrayBuffer;
-    asUint8Array(): Uint8Array;
-    //asNodeBuffer(): Buffer;
+    /**
+     * Prepare the content in the asked type.
+     * @param {String} type the type of the result.
+     * @param {Function} onUpdate a function to call on each internal update.
+     * @return Promise the promise of the result.
+     */
+    async(type: Serialization, onUpdate?: Function): Promise<any>;
+
+    /**
+     * @deprecated since version 3.0
+     */
+    asText(): void;
+    /**
+     * @deprecated since version 3.0
+     */
+    asBinary(): void;
+    /**
+     * @deprecated since version 3.0
+     */
+    asArrayBuffer(): void;
+    /**
+     * @deprecated since version 3.0
+     */
+    asUint8Array(): void;
+    //asNodeBuffer(): void;
 }
 
 interface JSZipFileOptions {
@@ -140,18 +186,6 @@ interface JSZipSupport {
     nodebuffer: boolean;
 }
 
-interface DEFLATE {
-    /** pako.deflateRaw, level:0-9 */
-    compress(input: string, compressionOptions: {level:number}): Uint8Array;
-    compress(input: number[], compressionOptions: {level:number}): Uint8Array;
-    compress(input: Uint8Array, compressionOptions: {level:number}): Uint8Array;
-
-    /** pako.inflateRaw */
-    uncompress(input: string): Uint8Array;
-    uncompress(input: number[]): Uint8Array;
-    uncompress(input: Uint8Array): Uint8Array;
-}
-
 declare var JSZip: {
     /**
      * Create JSZip instance
@@ -181,9 +215,6 @@ declare var JSZip: {
 
     prototype: JSZip;
     support: JSZipSupport;
-    compressions: {
-      DEFLATE: DEFLATE;
-    }
 }
 
 declare module "jszip" {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

JSZip has changed its APIs asynchronously in version 3.0:

http://stuk.github.io/jszip/documentation/upgrade_guide.html

Replace to async method definitions:
- `load` => `loadAsync`
- `generate` => `generateAsync`
- `asXXXX` => `async('XXXX')`

> JSZip.compressions has been removed.

So related tests are removed.
