### PR TITLE
changed serializers as per package author

### DIFF
--- a/pino/pino.d.ts
+++ b/pino/pino.d.ts
@@ -14,50 +14,10 @@ declare module 'pino' {
     type LevelLabelsToValues = {[level: string]: number}
     type LevelValuesToLabels = {[level: number]: string}
 
-    interface RequestSummary {
-        pid: number
-        hostname: string
-        level: number
-        msg: string
-        time: string
-        v: number
-        req: {
-            method: string
-            url: string
-            headers: Headers
-            remoteAddress: string
-            remotePort: number
-        }
-    }
-
-    interface ResponseSummary {
-        pid: number
-        hostname: string
-        level: number
-        msg: string
-        time: string
-        v: number
-        res: {
-            statusCode: number
-            header: string
-        }
-    }
-
-    interface ErrorSummary {
-        pid: number
-        hostname: string
-        level: number
-        msg: string
-        time: number
-        v: number
-        type: string
-        stack: string
-    }
-
     interface Serializers {
-        req?: (req: any) => RequestSummary
-        res?: (res: any) => ResponseSummary
-        err?: (error: Error) => ErrorSummary
+        req?: (req: any) => any
+        res?: (res: any) => any
+        err?: (error: Error) => any
     }
 
     interface LoggerOptions {


### PR DESCRIPTION
case 2. Improvement to existing type definition for **pino**

The package author gave me feedback that the Serializers are meant to be open for users to customize as they want, and that there is no requirement for the return value.
See 3rd comment: https://github.com/mcollina/pino/issues/62 
