### PR TITLE
react.d.ts: make nullable arguments of `React.Children.map` and etc

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -151,7 +151,7 @@ declare namespace __React {
     var PropTypes: ReactPropTypes;
     var Children: ReactChildren;
     var version: string;
-    
+
     //
     // Component API
     // ----------------------------------------------------------------------
@@ -359,7 +359,7 @@ declare namespace __React {
         pseudoElement: string;
         elapsedTime: number;
     }
-    
+
     interface TransitionEvent extends SyntheticEvent {
         propertyName: string;
         pseudoElement: string;
@@ -2302,11 +2302,11 @@ declare namespace __React {
     // ----------------------------------------------------------------------
 
     interface ReactChildren {
-        map<T>(children: ReactNode, fn: (child: ReactChild, index: number) => T): T[];
-        forEach(children: ReactNode, fn: (child: ReactChild, index: number) => any): void;
+        map<T>(children: ReactNode, fn: (child: ReactChild | null, index: number) => T): T[];
+        forEach(children: ReactNode, fn: (child: ReactChild | null, index: number) => any): void;
         count(children: ReactNode): number;
         only(children: ReactNode): ReactElement<any>;
-        toArray(children: ReactNode): ReactChild[];
+        toArray(children: ReactNode): Array<ReactChild | null>;
     }
 
     //


### PR DESCRIPTION
I've made arguments of `React.Children.map`, `React.Children.map` callbacks and result of `React.Children.toArray` nullables.

This PR addressed to typescript 1.9 and it's awesome `strictNullChecks` feature.
Seems, that it should be postponed until TS 1.9 released.
