### PR TITLE
Updated IDialogOptions to include contentElement property for prerend…

### DIFF
--- a/angular-material/angular-material-tests.ts
+++ b/angular-material/angular-material-tests.ts
@@ -67,6 +67,16 @@ myApp.controller('DialogController', ($scope: ng.IScope, $mdDialog: ng.material.
     $scope['promptDialog'] = () => {
         $mdDialog.show($mdDialog.prompt().placeholder('Prompt input placeholder text'));
     };
+    $scope['promptDialog'] = () => {
+        $mdDialog.show($mdDialog.prompt().initialValue('Buddy'));
+    };
+    $scope['prerenderedDialog'] = () => {
+        $mdDialog.show({
+            template: '<md-dialog>Hello!</md-dialog>',
+            contentElement: '#myDialog',
+            clickOutsideToClose: true
+        });
+    };
     $scope['hideDialog'] = $mdDialog.hide.bind($mdDialog, 'hide');
     $scope['cancelDialog'] = $mdDialog.cancel.bind($mdDialog, 'cancel');
 });

--- a/angular-material/angular-material.d.ts
+++ b/angular-material/angular-material.d.ts
@@ -62,12 +62,14 @@ declare namespace angular.material {
     
     interface IPromptDialog extends IPresetDialog<IPromptDialog> {
         cancel(cancel: string): IPromptDialog;
-        placeholder(placeholder: string): IPromptDialog;        
+        placeholder(placeholder: string): IPromptDialog;    
+        initialValue(initialValue: string): IPromptDialog;    
     }
 
     interface IDialogOptions {
         templateUrl?: string;
         template?: string;
+        contentElement?: string|Element;
         autoWrap?: boolean; // default: true
         targetEvent?: MouseEvent;
         openFrom?: any;
@@ -88,7 +90,7 @@ declare namespace angular.material {
         onShowing?: Function;
         onComplete?: Function;
         onRemoving?: Function;
-        fullscreen?: boolean;
+        fullscreen?: boolean; // default: false
     }
 
     interface IDialogService {
@@ -296,7 +298,7 @@ declare namespace angular.material {
         focusOnOpen?: boolean; // default: true
         fullscreen?: boolean; // default: false
         animation?: IPanelAnimation;
-        hasBackdrop?: boolean // default: false
+        hasBackdrop?: boolean; // default: false
         disableParentScroll?: boolean; // default: false
         onDomAdded?: Function;
         onOpenComplete?: Function;

--- a/angular-material/angular-material.d.ts
+++ b/angular-material/angular-material.d.ts
@@ -68,12 +68,14 @@ declare namespace angular.material {
     
     interface IPromptDialog extends IPresetDialog<IPromptDialog> {
         cancel(cancel: string): IPromptDialog;
-        placeholder(placeholder: string): IPromptDialog;        
+        placeholder(placeholder: string): IPromptDialog;    
+        initialValue(initialValue: string): IPromptDialog;    
     }
 
     interface IDialogOptions {
         templateUrl?: string;
         template?: string;
+        contentElement?: string|Element;
         autoWrap?: boolean; // default: true
         targetEvent?: MouseEvent;
         openFrom?: any;
@@ -94,8 +96,12 @@ declare namespace angular.material {
         onShowing?: Function;
         onComplete?: Function;
         onRemoving?: Function;
+<<<<<<< 3baa34499f7a3549b484081bbb081ba22f0596eb
         fullscreen?: boolean;
         skipHide?: boolean;
+=======
+        fullscreen?: boolean; // default: false
+>>>>>>> Updated IDialogOptions to include contentElement property for prerendered dialogs. Updated IPromptDialog to add initialValue method. Adding missing semicolon to IPanelConfig.
     }
 
     interface IDialogService {
@@ -303,7 +309,7 @@ declare namespace angular.material {
         focusOnOpen?: boolean; // default: true
         fullscreen?: boolean; // default: false
         animation?: IPanelAnimation;
-        hasBackdrop?: boolean // default: false
+        hasBackdrop?: boolean; // default: false
         disableParentScroll?: boolean; // default: false
         onDomAdded?: Function;
         onOpenComplete?: Function;


### PR DESCRIPTION
**case 2. Improvement to existing type definition.**

Updates in response to changes made in [1.1.0-rc.5 (2016-06-03)](https://github.com/angular/material/blob/master/CHANGELOG.md#110-rc5-2016-06-03). 

Updated IDialogOptions to include [contentelement](https://github.com/angular/material/commit/b49ebcf5) property for prerendered dialogs. Updated IPromptDialog to add [initialValue](https://github.com/angular/material/commit/135cb3a2) method. Adding missing semicolon to IPanelConfig property.

Thanks!
