### PR TITLE
Fix errors in SerialPort definition

### DIFF
--- a/serialport/serialport-tests.ts
+++ b/serialport/serialport-tests.ts
@@ -8,8 +8,31 @@
 
 import * as serialport from 'serialport';
 
-this.port = new serialport.SerialPort("", {
-    baudrate: 0,
-    disconnectedCallback: function () { },
-    parser: serialport.parsers.readline("\n")
-});
+function test_basic_connect() {
+    let port = new serialport.SerialPort("");
+}
+
+function test_connect_config() {
+    let port = new serialport.SerialPort("", {
+        baudrate: 0,
+        disconnectedCallback: function () { },
+        parser: serialport.parsers.readline("\n")
+    });
+}
+
+function test_write() {
+    let port = new serialport.SerialPort("");
+    port.write('main screen turn on', (err, bytesWritten) => {
+    });
+}
+
+function test_events() {
+    let port = new serialport.SerialPort("");
+    port.on('open', function () { });
+}
+
+function test_list_ports() {
+    serialport.list( (err:string, ports:serialport.portConfig[]) => {
+
+    });
+}

--- a/serialport/serialport.d.ts
+++ b/serialport/serialport.d.ts
@@ -1,19 +1,20 @@
 // Type definitions for serialport
 // Project: https://github.com/EmergingTechnologyAdvisors/node-serialport 
-// Definitions by: Jeremy Foster <https://github.com/codefoster> 
+// Definitions by: Jeremy Foster <https://github.com/codefoster>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped 
 
 declare module 'serialport' {
     module parsers {
         function readline(delimiter: string):void;
+        function raw(emitter:any, buffer:string):void
     }
 
     export class SerialPort {
-        constructor(path: string, options?: Object, openImmediately?: boolean, callback?: () => {})
+        constructor(path: string, options?: Object, openImmediately?: boolean, callback?: (err:string) => void)
         isOpen: boolean;
         on(event: string, callback?: (data?:any) => void):void;
         open(callback?: () => void):void;
-        write(buffer: any, callback?: () => void):void
+        write(buffer: any, callback?: (err:string, bytesWritten:number) => void):void
         pause():void;
         resume():void;
         disconnected(err: Error):void;
@@ -22,7 +23,18 @@ declare module 'serialport' {
         set(options: setOptions, callback: () => void):void;
         drain(callback?: () => void):void;
         update(options: updateOptions, callback?: () => void):void;
-        list(callback?: () => void):void;
+    }
+
+    export function list(callback: (err: string, ports:portConfig[]) => void): void;
+
+    interface portConfig {
+        comName: string,
+        manufacturer: string,
+        serialNumber: string,
+        pnpId: string,
+        locationId: string,
+        vendorId: string,
+        productId: string
     }
 
     interface setOptions {


### PR DESCRIPTION
The existing SerialPort definition was not entirely correct. I have made a few adjustments based on the [SerialPort documentation](https://github.com/EmergingTechnologyAdvisors/node-serialport/blob/3.1.2/README.md).

---

case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
