### PR TITLE
Add export of propTypes and defaultProps

### DIFF
--- a/redux-form/redux-form.d.ts
+++ b/redux-form/redux-form.d.ts
@@ -15,6 +15,9 @@ declare module 'redux-form' {
 
   export type FormData = {[fieldName:string]: FieldValue};
 
+  export const propTypes: { [key: string]: any };
+  export const defaultProps: { [key: string]: any };
+
   export interface FieldProp {
     /**
      * true if this field currently has focus. It will only work if you are


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

To simplify integration. I use Object.assign since object spread does not work in TypeScript (yet).

```
import { reduxForm, propTypes, defaultProps, ReduxFormProps } from 'redux-form';

interface IComponentProps extends ReduxFormProps {
    /*foo: Immutable.List<any>;
    bar: number;*/
}

public static propsTypes = Object.assign(propTypes, {
    /*foo: React.PropTypes.object.isRequired,
    bar: React.PropTypes.number.isRequired*/
});

public static defaultProps = Object.assign(defaultProps, {
    /*foo: null,
    bar: null*/
});
```
