### PR TITLE
Adding in the three types of Verify Error classes

### DIFF
--- a/jsonwebtoken/jsonwebtoken.d.ts
+++ b/jsonwebtoken/jsonwebtoken.d.ts
@@ -7,6 +7,24 @@
 
 declare module "jsonwebtoken" {
 
+    export class JsonWebTokenError extends Error {
+        inner: Error;
+
+        constructor(message: string, error?: Error);
+    }
+
+    export class TokenExpiredError extends JsonWebTokenError {
+        expiredAt: number;
+
+        constructor(message: string, expiredAt: number);
+    }
+
+    export class NotBeforeError extends JsonWebTokenError {
+        date: Date;
+
+        constructor(message: string, date: Date);
+    }
+
     export interface SignOptions {
         /**
          * Signature algorithm. Could be one of these values :
@@ -53,7 +71,7 @@ declare module "jsonwebtoken" {
     }
 
     export interface VerifyCallback {
-        (err: Error, decoded: any): void;
+        (err: JsonWebTokenError | TokenExpiredError | NotBeforeError, decoded: any): void;
     }
 
     export interface SignCallback {


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Added in the custom error classes that are used for the verify tokens.
You can find these files [here](https://github.com/auth0/node-jsonwebtoken/tree/master/lib)
These were already available in the 6.2.0 release so no need to bump DT version of this file.
