### PR TITLE
Revert "Missing "require" property on IComponentOptions"

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1708,10 +1708,6 @@ declare namespace angular {
          */
         templateUrl?: string | Function | (string | Function)[];
         /**
-         * Define object mapping to other directive or component required controllers.
-         */
-        require?: any;
-        /**
          * Define DOM attribute binding to component properties. Component properties are always bound to the component
          * controller and not to the scope.
          */


### PR DESCRIPTION
This reverts commit 824761509fb46114aa55036829452941f135a543.

Please refer to https://github.com/DefinitelyTyped/DefinitelyTyped/commit/1a10e340827add3af660ff7400cb0c841cf18be7#commitcomment-18022034
