### PR TITLE
Removing duplicate 'require' field on IComponentOptions

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1707,10 +1707,7 @@ declare namespace angular {
          * Use the array form to define dependencies (necessary if strictDi is enabled and you require dependency injection)
          */
         templateUrl?: string | Function | (string | Function)[];
-        /**
-         * Define object mapping to other directive or component required controllers.
-         */
-        require?: any;
+
         /**
          * Define DOM attribute binding to component properties. Component properties are always bound to the component
          * controller and not to the scope.
@@ -1720,6 +1717,9 @@ declare namespace angular {
          * Whether transclusion is enabled. Enabled by default.
          */
         transclude?: boolean | string | {[slot: string]: string};
+        /**
+         * Define object mapping to other directive or component required controllers.
+         */
         require?: {[controller: string]: string};
     }
 


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

IComponentOptions already had a 'require' field, and in a merge, there are now duplicate which break the definition, and causes a build error.
