### PR TITLE
Partial revert of 1f3e28f - remove duplicate svgRendering identifier

### DIFF
--- a/html2canvas/html2canvas.d.ts
+++ b/html2canvas/html2canvas.d.ts
@@ -39,9 +39,6 @@ declare namespace Html2Canvas {
         
         /** Use svg powered rendering where available (FF11+). */
         svgRendering?: boolean;
-
-        /** Use svg powered rendering where available (FF11+). */
-        svgRendering?: boolean;
     }
 }
 


### PR DESCRIPTION
Commit 1f3e28f introduced a duplicate identifier in `html2canvas/html2canvas.d.ts`.

This PR removes this duplicate identifier.

@mhegazy Please review.
