### PR TITLE
export interfaces

### DIFF
--- a/agenda/agenda.d.ts
+++ b/agenda/agenda.d.ts
@@ -19,277 +19,6 @@ declare module "agenda" {
         (err?: Error, result?: T): void;
     }
 
-    /**
-     * Agenda Configuration.
-     */
-    interface AgendaConfiguration {
-
-        /**
-         * Sets the interval with which the queue is checked. A number in milliseconds or a frequency string.
-         */
-        processEvery?: string | number;
-
-        /**
-         * Takes a number which specifies the default number of a specific job that can be running at any given moment.
-         * By default it is 5.
-         */
-        defaultConcurrency?: number;
-
-        /**
-         * Takes a number which specifies the max number of jobs that can be running at any given moment. By default it
-         * is 20.
-         */
-        maxConcurrency?: number;
-
-        /**
-         * Takes a number which specifies the default number of a specific job that can be locked at any given moment.
-         * By default it is 0 for no max.
-         */
-        defaultLockLimit?: number;
-
-        /**
-         * Takes a number shich specifies the max number jobs that can be locked at any given moment. By default it is
-         * 0 for no max.
-         */
-        lockLimit?: number;
-
-        /**
-         * Takes a number which specifies the default lock lifetime in milliseconds. By default it is 10 minutes. This
-         * can be overridden by specifying the lockLifetime option to a defined job.
-         */
-        defaultLockLifetime?: number;
-
-        /**
-         * Specifies that Agenda should be initialized using and existing MongoDB connection.
-         */
-        mongo?: {
-            /**
-             * The MongoDB database connection to use.
-             */
-            db: Db;
-
-            /**
-             * The name of the collection to use.
-             */
-            collection?: string;
-        }
-
-        /**
-         * Specifies that Agenda should connect to MongoDB.
-         */
-        db?: {
-            /**
-             * The connection URL.
-             */
-            address: string;
-
-            /**
-             * The name of the collection to use.
-             */
-            collection?: string;
-
-            /**
-             * Connection options to pass to MongoDB.
-             */
-            options?: any;
-        }
-    }
-
-    /**
-     * The database record associated with a job.
-     */
-    interface JobAttributes {
-        /**
-         * The record identity.
-         */
-        _id: ObjectID;
-
-        /**
-         * The name of the job.
-         */
-        name: string;
-
-        /**
-         * The type of the job (single|normal).
-         */
-        type: string;
-
-        /**
-         * The job details.
-         */
-        data: { [name: string]: any };
-
-        /**
-         * The priority of the job.
-         */
-        priority: number;
-
-        /**
-         * How often the job is repeated using a human-readable or cron format.
-         */
-        repeatInterval: string | number;
-
-        /**
-         * The timezone that conforms to [moment-timezone](http://momentjs.com/timezone/).
-         */
-        repeatTimezone: string;
-
-        /**
-         * Date/time the job was las modified.
-         */
-        lastModifiedBy: string;
-
-        /**
-         * Date/time the job will run next.
-         */
-        nextRunAt: Date;
-
-        /**
-         * Date/time the job was locked.
-         */
-        lockedAt: Date;
-
-        /**
-         * Date/time the job was last run.
-         */
-        lastRunAt: Date;
-
-        /**
-         * Date/time the job last finished running.
-         */
-        lastFinishedAt: Date;
-
-        /**
-         * The reason the job failed.
-         */
-        failReason: string;
-
-        /**
-         * The number of times the job has failed.
-         */
-        failCount: number;
-
-        /**
-         * The date/time the job last failed.
-         */
-        failedAt: Date;
-    }
-
-    /**
-     * A scheduled job.
-     */
-    interface Job {
-
-        /**
-         * The database record associated with the job.
-         */
-        attrs: JobAttributes;
-
-        /**
-         * Specifies an interval on which the job should repeat.
-         * @param interval A human-readable format String, a cron format String, or a Number.
-         * @param options An optional argument that can include a timezone field. The timezone should be a string as
-         * accepted by moment-timezone and is considered when using an interval in the cron string format.
-         */
-        repeatEvery(interval: string | number, options?: { timezone?: string }): Job
-
-        /**
-         * Specifies a time when the job should repeat. [Possible values](https://github.com/matthewmueller/date#examples).
-         * @param time
-         */
-        repeatAt(time: string): Job
-
-        /**
-         * Disables the job.
-         */
-        disable(): Job;
-
-        /**
-         * Enables the job.
-         */
-        enable(): Job;
-
-        /**
-         * Ensure that only one instance of this job exists with the specified properties
-         * @param value The properties associated with the job that must be unqiue.
-         * @param opts
-         */
-        unique(value: any, opts?: { insertOnly?: boolean }): Job;
-
-        /**
-         * Specifies the next time at which the job should run.
-         * @param time The next time at which the job should run.
-         */
-        schedule(time: string | Date): Job;
-
-        /**
-         * Specifies the priority weighting of the job.
-         * @param value The priority of the job (lowest|low|normal|high|highest|number).
-         */
-        priority(value: string | number): Job;
-
-        /**
-         * Sets job.attrs.failedAt to now, and sets job.attrs.failReason to reason.
-         * @param reason A message or Error object that indicates why the job failed.
-         */
-        fail(reason: string | Error): Job;
-
-        /**
-         * Runs the given job and calls callback(err, job) upon completion. Normally you never need to call this manually
-         * @param cb Called when the job is completed.
-         */
-        run(cb?: ResultCallback<Job>): Job;
-
-        /**
-         * Returns true if the job is running; otherwise, returns false.
-         */
-        isRunning(): boolean;
-
-        /**
-         * Saves the job into the database.
-         * @param cb  Called when the job is saved.
-         */
-        save(cb?: ResultCallback<Job>): Job;
-
-        /**
-         * Removes the job from the database and cancels the job.
-         * @param cb Called after the job has beeb removed from the database.
-         */
-        remove(cb?: Callback): void;
-
-        /**
-         * Resets the lock on the job. Useful to indicate that the job hasn't timed out when you have very long running
-         * jobs.
-         * @param cb Called after the job has been saved to the database.
-         */
-        touch(cb?: Callback): void;
-    }
-
-    interface JobOptions {
-
-        /**
-         * Maximum number of that job that can be running at once (per instance of agenda)
-         */
-        concurrency?: number;
-
-        /**
-         * Maximum number of that job that can be locked at once (per instance of agenda)
-         */
-        lockLimit?: number;
-
-        /**
-         * Interval in ms of how long the job stays locked for (see multiple job processors for more info). A job will
-         * automatically unlock if done() is called.
-         */
-        lockLifetime?: number;
-
-        /**
-         * (lowest|low|normal|high|highest|number) specifies the priority of the job. Higher priority jobs will run
-         * first.
-         */
-        priority?: string | number;
-    }
-
     class Agenda extends EventEmitter {
 
         /**
@@ -297,7 +26,7 @@ declare module "agenda" {
          * @param config Optional configuration to initialize the Agenda.
          * @param cb Optional callback called with the MongoDB colleciton.
          */
-        constructor(config?: AgendaConfiguration, cb?: ResultCallback<Collection>);
+        constructor(config?: Agenda.AgendaConfiguration, cb?: ResultCallback<Collection>);
 
         /**
          * Connect to the specified MongoDB server and database.
@@ -360,14 +89,14 @@ declare module "agenda" {
          * @param name The name of the job.
          * @param data Data to associated with the job.
          */
-        create(name: string, data?: any): Job;
+        create(name: string, data?: any): Agenda.Job;
 
         /**
          * Find all Jobs matching `query` and pass same back in cb().
          * @param query
          * @param cb
          */
-        jobs(query: any, cb: ResultCallback<Job[]>): void;
+        jobs(query: any, cb: ResultCallback<Agenda.Job[]>): void;
 
         /**
          * Removes all jobs in the database without defined behaviors. Useful if you change a definition name and want
@@ -384,8 +113,8 @@ declare module "agenda" {
          * @param options The options for the job.
          * @param handler The handler to execute.
          */
-        define(name: string, handler: (job?: Job, done?: (err?: Error) => void) => void): void;
-        define(name: string, options: JobOptions, handler: (job?: Job, done?: (err?: Error) => void) => void): void;
+        define(name: string, handler: (job?: Agenda.Job, done?: (err?: Error) => void) => void): void;
+        define(name: string, options: Agenda.JobOptions, handler: (job?: Agenda.Job, done?: (err?: Error) => void) => void): void;
 
         /**
          * Runs job name at the given interval. Optionally, data and options can be passed in.
@@ -395,8 +124,8 @@ declare module "agenda" {
          * @param options An optional argument that will be passed to job.repeatEvery.
          * @param cb An optional callback function which will be called when the job has been persisted in the database.
          */
-        every(interval: number | string, names: string, data?: any, options?: any, cb?: ResultCallback<Job>): Job;
-        every(interval: number | string, names: string[], data?: any, options?: any, cb?: ResultCallback<Job[]>): Job[];
+        every(interval: number | string, names: string, data?: any, options?: any, cb?: ResultCallback<Agenda.Job>): Agenda.Job;
+        every(interval: number | string, names: string[], data?: any, options?: any, cb?: ResultCallback<Agenda.Job[]>): Agenda.Job[];
 
         /**
          * Schedules a job to run name once at a given time.
@@ -405,8 +134,8 @@ declare module "agenda" {
          * @param data An optional argument that will be passed to the processing function under job.attrs.data.
          * @param cb An optional callback function which will be called when the job has been persisted in the database.
          */
-        schedule(when: Date | string, names: string, data?: any, cb?: ResultCallback<Job>): Job;
-        schedule(when: Date | string, names: string[], data?: any, cb?: ResultCallback<Job[]>): Job[];
+        schedule(when: Date | string, names: string, data?: any, cb?: ResultCallback<Agenda.Job>): Agenda.Job;
+        schedule(when: Date | string, names: string[], data?: any, cb?: ResultCallback<Agenda.Job[]>): Agenda.Job[];
 
         /**
          * Schedules a job to run name once immediately.
@@ -414,7 +143,7 @@ declare module "agenda" {
          * @param data An optional argument that will be passed to the processing function under job.attrs.data.
          * @param cb An optional callback function which will be called when the job has been persisted in the database.
          */
-        now(name: string, data?: any, cb?: ResultCallback<Job>): Job;
+        now(name: string, data?: any, cb?: ResultCallback<Agenda.Job>): Agenda.Job;
 
         /**
          * Cancels any jobs matching the passed mongodb-native query, and removes them from the database.
@@ -436,7 +165,276 @@ declare module "agenda" {
     }
 
     namespace Agenda {
+        /**
+         * Agenda Configuration.
+         */
+        interface AgendaConfiguration {
 
+            /**
+             * Sets the interval with which the queue is checked. A number in milliseconds or a frequency string.
+             */
+            processEvery?: string | number;
+
+            /**
+             * Takes a number which specifies the default number of a specific job that can be running at any given moment.
+             * By default it is 5.
+             */
+            defaultConcurrency?: number;
+
+            /**
+             * Takes a number which specifies the max number of jobs that can be running at any given moment. By default it
+             * is 20.
+             */
+            maxConcurrency?: number;
+
+            /**
+             * Takes a number which specifies the default number of a specific job that can be locked at any given moment.
+             * By default it is 0 for no max.
+             */
+            defaultLockLimit?: number;
+
+            /**
+             * Takes a number shich specifies the max number jobs that can be locked at any given moment. By default it is
+             * 0 for no max.
+             */
+            lockLimit?: number;
+
+            /**
+             * Takes a number which specifies the default lock lifetime in milliseconds. By default it is 10 minutes. This
+             * can be overridden by specifying the lockLifetime option to a defined job.
+             */
+            defaultLockLifetime?: number;
+
+            /**
+             * Specifies that Agenda should be initialized using and existing MongoDB connection.
+             */
+            mongo?: {
+                /**
+                 * The MongoDB database connection to use.
+                 */
+                db: Db;
+
+                /**
+                 * The name of the collection to use.
+                 */
+                collection?: string;
+            }
+
+            /**
+             * Specifies that Agenda should connect to MongoDB.
+             */
+            db?: {
+                /**
+                 * The connection URL.
+                 */
+                address: string;
+
+                /**
+                 * The name of the collection to use.
+                 */
+                collection?: string;
+
+                /**
+                 * Connection options to pass to MongoDB.
+                 */
+                options?: any;
+            }
+        }
+
+        /**
+         * The database record associated with a job.
+         */
+        interface JobAttributes {
+            /**
+             * The record identity.
+             */
+            _id: ObjectID;
+
+            /**
+             * The name of the job.
+             */
+            name: string;
+
+            /**
+             * The type of the job (single|normal).
+             */
+            type: string;
+
+            /**
+             * The job details.
+             */
+            data: { [name: string]: any };
+
+            /**
+             * The priority of the job.
+             */
+            priority: number;
+
+            /**
+             * How often the job is repeated using a human-readable or cron format.
+             */
+            repeatInterval: string | number;
+
+            /**
+             * The timezone that conforms to [moment-timezone](http://momentjs.com/timezone/).
+             */
+            repeatTimezone: string;
+
+            /**
+             * Date/time the job was las modified.
+             */
+            lastModifiedBy: string;
+
+            /**
+             * Date/time the job will run next.
+             */
+            nextRunAt: Date;
+
+            /**
+             * Date/time the job was locked.
+             */
+            lockedAt: Date;
+
+            /**
+             * Date/time the job was last run.
+             */
+            lastRunAt: Date;
+
+            /**
+             * Date/time the job last finished running.
+             */
+            lastFinishedAt: Date;
+
+            /**
+             * The reason the job failed.
+             */
+            failReason: string;
+
+            /**
+             * The number of times the job has failed.
+             */
+            failCount: number;
+
+            /**
+             * The date/time the job last failed.
+             */
+            failedAt: Date;
+        }
+
+        /**
+         * A scheduled job.
+         */
+        interface Job {
+
+            /**
+             * The database record associated with the job.
+             */
+            attrs: JobAttributes;
+
+            /**
+             * Specifies an interval on which the job should repeat.
+             * @param interval A human-readable format String, a cron format String, or a Number.
+             * @param options An optional argument that can include a timezone field. The timezone should be a string as
+             * accepted by moment-timezone and is considered when using an interval in the cron string format.
+             */
+            repeatEvery(interval: string | number, options?: { timezone?: string }): Job
+
+            /**
+             * Specifies a time when the job should repeat. [Possible values](https://github.com/matthewmueller/date#examples).
+             * @param time
+             */
+            repeatAt(time: string): Job
+
+            /**
+             * Disables the job.
+             */
+            disable(): Job;
+
+            /**
+             * Enables the job.
+             */
+            enable(): Job;
+
+            /**
+             * Ensure that only one instance of this job exists with the specified properties
+             * @param value The properties associated with the job that must be unqiue.
+             * @param opts
+             */
+            unique(value: any, opts?: { insertOnly?: boolean }): Job;
+
+            /**
+             * Specifies the next time at which the job should run.
+             * @param time The next time at which the job should run.
+             */
+            schedule(time: string | Date): Job;
+
+            /**
+             * Specifies the priority weighting of the job.
+             * @param value The priority of the job (lowest|low|normal|high|highest|number).
+             */
+            priority(value: string | number): Job;
+
+            /**
+             * Sets job.attrs.failedAt to now, and sets job.attrs.failReason to reason.
+             * @param reason A message or Error object that indicates why the job failed.
+             */
+            fail(reason: string | Error): Job;
+
+            /**
+             * Runs the given job and calls callback(err, job) upon completion. Normally you never need to call this manually
+             * @param cb Called when the job is completed.
+             */
+            run(cb?: ResultCallback<Job>): Job;
+
+            /**
+             * Returns true if the job is running; otherwise, returns false.
+             */
+            isRunning(): boolean;
+
+            /**
+             * Saves the job into the database.
+             * @param cb  Called when the job is saved.
+             */
+            save(cb?: ResultCallback<Job>): Job;
+
+            /**
+             * Removes the job from the database and cancels the job.
+             * @param cb Called after the job has beeb removed from the database.
+             */
+            remove(cb?: Callback): void;
+
+            /**
+             * Resets the lock on the job. Useful to indicate that the job hasn't timed out when you have very long running
+             * jobs.
+             * @param cb Called after the job has been saved to the database.
+             */
+            touch(cb?: Callback): void;
+        }
+
+        interface JobOptions {
+
+            /**
+             * Maximum number of that job that can be running at once (per instance of agenda)
+             */
+            concurrency?: number;
+
+            /**
+             * Maximum number of that job that can be locked at once (per instance of agenda)
+             */
+            lockLimit?: number;
+
+            /**
+             * Interval in ms of how long the job stays locked for (see multiple job processors for more info). A job will
+             * automatically unlock if done() is called.
+             */
+            lockLifetime?: number;
+
+            /**
+             * (lowest|low|normal|high|highest|number) specifies the priority of the job. Higher priority jobs will run
+             * first.
+             */
+            priority?: string | number;
+        }
     }
 
     export = Agenda;


### PR DESCRIPTION
no changes to the api. Just exported interfaces so that it's possible to use them - for example when writing a wrapper function:

``` javascript
import * as  Agenda from 'agenda';
export function getJobByName(jobName: string) {
    return new Promise<Agenda.Job>((resolve, reject) => { 
        agenda.jobs({ name: jobName}, (err, jobs) => {
            if (err) reject(err);
            else if(jobs.length == 0) {
                reject(new Error(`Can't find job ${jobName}`));
            } else {
                resolve(jobs[0]);
            }
        });
    });
}
```

Notice how I specify the type of `Promise` returned: `Agenda.Job`. Before it was not possible.
