### PR TITLE
D3 - extent does not work with dates

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1078,6 +1078,11 @@ declare namespace d3 {
      * Return the min and max simultaneously.
      */
     export function extent<T>(array: T[], accessor: (datum: T, index: number) => string): [string, string];
+    
+    /**
+     * Return the min and max simultaneously.
+     */
+    export function extent<T>(array: T[], accessor: (datum: T, index: number) => Date): [Date, Date];
 
     /**
      * Return the min and max simultaneously.

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -1087,7 +1087,7 @@ declare namespace d3 {
     /**
      * Return the min and max simultaneously.
      */
-    export function extent<T, U extends Numeric>(array: U[], accessor: (datum: T, index: number) => U): [U | Primitive, U | Primitive];
+    export function extent<T, U extends Numeric>(array: T[], accessor: (datum: T, index: number) => U): [U | Primitive, U | Primitive];
 
     /**
      * Compute the sum of an array of numbers.


### PR DESCRIPTION
The extent method can be used together with a time scale. But there was no definition for that type.

There was also a typo in another extent method, where the output type was used instead of the input type.
