### PR TITLE
Correct param and return types for ShapeUtils triangulation methods.

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -5725,8 +5725,8 @@ declare namespace THREE {
 
     export namespace ShapeUtils {
         export function area(contour: number[]): number;
-        export function triangulate(contour: number[], indices: boolean): number[];
-        export function triangulateShape(contour: number[], holes: any[]): number[];
+        export function triangulate(contour: Vector2[], indices: boolean): Vector2[][] | number[][];
+        export function triangulateShape(contour: Vector2[], holes: Vector2[][]): Vector2[][];
         export function isClockWise(pts: number[]): boolean;
         export function b2(t: number, p0: number, p1: number, p2: number): number;
         export function b3(t: number, p0: number, p1: number, p2: number, p3: number): number;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

The [THREE.ShapeUtils.triangulate](https://github.com/mrdoob/three.js/blob/master/src/extras/ShapeUtils.js#L24) function [takes a parameter contour](https://github.com/mrdoob/three.js/blob/master/src/extras/ShapeUtils.js#L94) which is an array of THREE.Vector2 which can be seen here: https://github.com/mrdoob/three.js/blob/master/src/extras/ShapeUtils.js#L46. 

It returns [either an array of coordinates or indices](https://github.com/mrdoob/three.js/blob/master/src/extras/ShapeUtils.js#L185). When coordinates it is an array of arrays of THREE.Vector2 and when indices it is an array of array of number which can be seen here: https://github.com/mrdoob/three.js/blob/master/src/extras/ShapeUtils.js#L160.

The [THREE.ShapeUtils.triangulateShape](https://github.com/mrdoob/three.js/blob/master/src/extras/ShapeUtils.js#L192) function uses the triangulate function above but always returns the coordinates which can be seen here: https://github.com/mrdoob/three.js/blob/master/src/extras/ShapeUtils.js#L642.
