### PR TITLE
Fixing return values for Observable functions

### DIFF
--- a/rx/rx-lite-tests.ts
+++ b/rx/rx-lite-tests.ts
@@ -9,5 +9,38 @@ function test_scan() {
 	const source2: Rx.Observable<string> = Rx.Observable.range(1, 3)
 		.scan((acc, x, i, source) => acc + x, '...');
 
+
+	/* concatAll Example */
+	var source = Rx.Observable.range(0, 3)
+		.map(function (x) { return Rx.Observable.range(x, 3); })
+		.concatAll();
+
+	var subscription = source.subscribe(
+		function (x) {
+			console.log('Next: %s', x);
+		},
+		function (err) {
+			console.log('Error: %s', err);
+		},
+		function () {
+			console.log('Completed');
+		});
+
+	/* mergeAll example */
+	var source = Rx.Observable.range(0, 3)
+		.map(function (x) { return Rx.Observable.range(x, 3); })
+		.mergeAll();
+
+	var subscription = source.subscribe(
+		function (x) {
+			console.log('Next: %s', x);
+		},
+		function (err) {
+			console.log('Error: %s', err);
+		},
+		function () {
+			console.log('Completed');
+		});
+
 }
 

--- a/rx/rx-lite.d.ts
+++ b/rx/rx-lite.d.ts
@@ -245,8 +245,8 @@ declare namespace Rx {
 		withLatestFrom<TOther, TResult>(souces: (Observable<TOther>|IPromise<TOther>)[], resultSelector: (firstValue: T, ...otherValues: TOther[]) => TResult): Observable<TResult>;
 		concat(...sources: (Observable<T>|IPromise<T>)[]): Observable<T>;
 		concat(sources: (Observable<T>|IPromise<T>)[]): Observable<T>;
-		concatAll(): T;
-		concatObservable(): T;	// alias for concatAll
+		concatAll(): Observable<T>;
+		concatObservable(): Observable<T>;	// alias for concatAll
 		concatMap<T2, R>(selector: (value: T, index: number) => Observable<T2>, resultSelector: (value1: T, value2: T2, index: number) => R): Observable<R>;	// alias for selectConcat
 		concatMap<T2, R>(selector: (value: T, index: number) => IPromise<T2>, resultSelector: (value1: T, value2: T2, index: number) => R): Observable<R>;	// alias for selectConcat
 		concatMap<R>(selector: (value: T, index: number) => Observable<R>): Observable<R>;	// alias for selectConcat
@@ -257,12 +257,12 @@ declare namespace Rx {
 		merge(maxConcurrent: number): T;
 		merge(other: Observable<T>): Observable<T>;
 		merge(other: IPromise<T>): Observable<T>;
-		mergeAll(): T;
-		mergeObservable(): T;	// alias for mergeAll
+		mergeAll(): Observable<T>;
+		mergeObservable(): Observable<T>;	// alias for mergeAll
 		skipUntil<T2>(other: Observable<T2>): Observable<T>;
 		skipUntil<T2>(other: IPromise<T2>): Observable<T>;
-		switch(): T;
-		switchLatest(): T;	// alias for switch
+		switch(): Observable<T>;
+		switchLatest(): Observable<T>;	// alias for switch
 		takeUntil<T2>(other: Observable<T2>): Observable<T>;
 		takeUntil<T2>(other: IPromise<T2>): Observable<T>;
 		zip<T2>(second: Observable<T2>|IPromise<T2>): Observable<[T, T2]>;


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

All Observable functions return an Observable<T> instead of T. So I
fixed this in the rx-lite.d.ts
