### PR TITLE
fix(localforage): fix driver() method to return string

### DIFF
--- a/localForage/localForage.d.ts
+++ b/localForage/localForage.d.ts
@@ -52,7 +52,7 @@ interface LocalForage {
     config(options: LocalForageOptions): boolean;
     createInstance(options: LocalForageOptions): LocalForage;
 
-    driver(): string | null;
+    driver(): string;
     /**
     * Force usage of a particular driver or drivers, if available.
     * @param {string} driver

--- a/localForage/localForage.d.ts
+++ b/localForage/localForage.d.ts
@@ -52,7 +52,7 @@ interface LocalForage {
     config(options: LocalForageOptions): boolean;
     createInstance(options: LocalForageOptions): LocalForage;
 
-    driver(): LocalForageDriver;
+    driver(): string | null;
     /**
     * Force usage of a particular driver or drivers, if available.
     * @param {string} driver


### PR DESCRIPTION
There seems to be a misunderstanding to what [the `driver()` method returns](https://github.com/mozilla/localForage/blob/master/src/localforage.js#L218-L220). Since it returns `LocalForageDriver._driver` it should be a string.
