### PR TITLE
[angular-adal] Fix return type for getRequestInfo method definition.

### DIFF
--- a/adal-angular/adal.d.ts
+++ b/adal-angular/adal.d.ts
@@ -133,7 +133,7 @@ declare namespace adal {
          * Gets requestInfo from given hash.
          * @returns {string} error message related to login
          */
-        getRequestInfo(hash: string): string;
+        getRequestInfo(hash: string): RequestInfo;
 
         /**
          * Saves token from hash that is received from redirect.

--- a/adal-angular/adal.d.ts
+++ b/adal-angular/adal.d.ts
@@ -131,7 +131,7 @@ declare namespace adal {
 
         /**
          * Gets requestInfo from given hash.
-         * @returns {string} error message related to login
+         * @returns {RequestInfo} for appropriate hash.
          */
         getRequestInfo(hash: string): RequestInfo;
 


### PR DESCRIPTION
It's improvement to existing type definition.
The method called `getRequestInfo` should return `RequestInfo` instead of string. There is a [source](https://github.com/AzureAD/azure-activedirectory-library-for-js/blob/master/lib/adal.js#L580) as a proof.
