### PR TITLE
[Drop] Add delay time properties for options interface

### DIFF
--- a/drop/drop.d.ts
+++ b/drop/drop.d.ts
@@ -46,6 +46,12 @@ declare namespace Drop {
         constrainToScrollParent?: boolean;
         remove?: boolean;
         beforeClose?: () => boolean;
+        openDelay?: number;
+        closeDelay?: number;
+        focusDelay?: number;
+        blurDelay?: number;
+        hoverOpenDelay?: number;
+        hoverCloseDelay?: number;
         tetherOptions?: Tether.ITetherOptions;
     }
 }


### PR DESCRIPTION
Improvement to Tether Drop type definitions.
- Delay time properties from Drop.IDropOptions interface were missing.
  - See http://github.hubspot.com/drop/ for the full documentation on Drop's option object.
- This change adds all delay time properties to the interface
