### PR TITLE
Adds declarations for the `node-usb` library

### DIFF
--- a/node-usb/node-usb-tests.ts
+++ b/node-usb/node-usb-tests.ts
@@ -1,0 +1,202 @@
+/// <reference path="node-usb.d.ts"/>
+
+import * as usb from "usb";
+
+const device = new usb.Device();
+
+device.timeout = 1;
+device.busNumber = 1;
+device.deviceAddress = 1;
+device.portNumbers = [1, 2, 3];
+
+device.open(true);
+device.close();
+const xferDevice: usb.Device = device.controlTransfer(1, 1, 1, 1, 1, (error: string, buf: Buffer): usb.Device => new usb.Device());
+device.getStringDescriptor(1, (error: string, buf: Buffer) => null);
+device.setConfiguration(1, (error: string) => null);
+device.reset((error: string) => null);
+
+const deviceDesc: usb.DeviceDescriptor = new usb.DeviceDescriptor();
+
+deviceDesc.bLength = 1;
+deviceDesc.bDescriptorType = 1;
+deviceDesc.bcdUSB = 1;
+deviceDesc.bDeviceClass = 1;
+deviceDesc.bDeviceSubClass = 1;
+deviceDesc.bDeviceProtocol = 1;
+deviceDesc.bMaxPacketSize = 1;
+deviceDesc.idVendor = 1;
+deviceDesc.idProduct = 1;
+deviceDesc.bcdDevice = 1;
+deviceDesc.iManufacturer = 1;
+deviceDesc.iProduct = 1;
+deviceDesc.iSerialNumber = 1;
+deviceDesc.bNumConfigurations = 1;
+
+device.deviceDescriptor = deviceDesc;
+
+const configDesc: usb.ConfigDescriptor = new usb.ConfigDescriptor();
+
+configDesc.bLength = 1;
+configDesc.bDescriptorType = 1;
+configDesc.wTotalLength = 1;
+configDesc.bNumInterfaces = 1;
+configDesc.bConfigurationValue = 1;
+configDesc.iConfiguration = 1;
+configDesc.bmAttributes = 1;
+configDesc.bMaxPower = 1;
+configDesc.extra = new Buffer([]);
+
+const deviceInterface: usb.Interface = device.interface(1);
+
+device.interfaces = [deviceInterface];
+
+const iface = new usb.Interface(device, 1);
+
+iface.claim();
+iface.release((error: string) => null, (error: string) => null);
+const kernelActive: boolean = iface.isKernelDriverActive();
+const detachKernel: number = iface.detachKernelDriver();
+const attachKernel: number = iface.attachKernelDriver();
+iface.setAltSetting(1, (error: string) => null);
+
+const endpointDesc: usb.EndpointDescriptor = new usb.EndpointDescriptor();
+
+endpointDesc.bLength = 1;
+endpointDesc.bDescriptorType = 1;
+endpointDesc.bEndpointAddress = 1;
+endpointDesc.bmAttributes = 1;
+endpointDesc.wMaxPacketSize = 1;
+endpointDesc.bInterval = 1;
+endpointDesc.bRefresh = 1;
+endpointDesc.bSynchAddress = 1;
+
+const ifaceInEndpoint: usb.IEndpoint = iface.endpoint(1) as usb.InEndpoint;
+const ifaceOutEndpoint: usb.IEndpoint = iface.endpoint(1) as usb.OutEndpoint;
+
+const inEndpoint: usb.InEndpoint = new usb.InEndpoint(device, endpointDesc);
+
+inEndpoint.direction = "in";
+inEndpoint.transferType = 1;
+inEndpoint.timeout = 1;
+inEndpoint.descriptor = endpointDesc;
+const xferInEndpoint: usb.InEndpoint = inEndpoint.transfer(1, (error: string, data: Buffer) => { return inEndpoint; });
+inEndpoint.startPoll(1, 1);
+inEndpoint.stopPoll(() => null);
+
+const outEndpoint: usb.OutEndpoint = new usb.OutEndpoint(device, endpointDesc);
+outEndpoint.direction = "out";
+outEndpoint.transferType = 1;
+outEndpoint.timeout = 1;
+outEndpoint.descriptor = endpointDesc;
+const xferOutEndpoint: usb.OutEndpoint = outEndpoint.transfer(new Buffer([]), (error: string) => null);
+outEndpoint.transferWithZLP(new Buffer([]), (error: string) => null);
+
+const findByDevice: usb.Device = usb.findByIds(1, 1);
+usb.on("hey", (device: usb.Device) => null);
+const deviceList: Array<usb.Device> = usb.getDeviceList();
+usb.setDebugLevel(1);
+
+const CHECK_LIBUSB_CLASS_PER_INTERFACE: number = usb.LIBUSB_CLASS_PER_INTERFACE;
+const CHECK_LIBUSB_CLASS_AUDIO: number = usb.LIBUSB_CLASS_AUDIO;
+const CHECK_LIBUSB_CLASS_COMM: number = usb.LIBUSB_CLASS_COMM;
+const CHECK_LIBUSB_CLASS_HID: number = usb.LIBUSB_CLASS_HID;
+const CHECK_LIBUSB_CLASS_PRINTER: number = usb.LIBUSB_CLASS_PRINTER;
+const CHECK_LIBUSB_CLASS_PTP: number = usb.LIBUSB_CLASS_PTP;
+const CHECK_LIBUSB_CLASS_MASS_STORAGE: number = usb.LIBUSB_CLASS_MASS_STORAGE;
+const CHECK_LIBUSB_CLASS_HUB: number = usb.LIBUSB_CLASS_HUB;
+const CHECK_LIBUSB_CLASS_DATA: number = usb.LIBUSB_CLASS_DATA;
+const CHECK_LIBUSB_CLASS_WIRELESS: number = usb.LIBUSB_CLASS_WIRELESS;
+const CHECK_LIBUSB_CLASS_APPLICATION: number = usb.LIBUSB_CLASS_APPLICATION;
+const CHECK_LIBUSB_CLASS_VENDOR_SPEC: number = usb.LIBUSB_CLASS_VENDOR_SPEC;
+// libusb_standard_request
+const CHECK_LIBUSB_REQUEST_GET_STATUS: number = usb.LIBUSB_REQUEST_GET_STATUS;
+const CHECK_LIBUSB_REQUEST_CLEAR_FEATURE: number = usb.LIBUSB_REQUEST_CLEAR_FEATURE;
+const CHECK_LIBUSB_REQUEST_SET_FEATURE: number = usb.LIBUSB_REQUEST_SET_FEATURE;
+const CHECK_LIBUSB_REQUEST_SET_ADDRESS: number = usb.LIBUSB_REQUEST_SET_ADDRESS;
+const CHECK_LIBUSB_REQUEST_GET_DESCRIPTOR: number = usb.LIBUSB_REQUEST_GET_DESCRIPTOR;
+const CHECK_LIBUSB_REQUEST_SET_DESCRIPTOR: number = usb.LIBUSB_REQUEST_SET_DESCRIPTOR;
+const CHECK_LIBUSB_REQUEST_GET_CONFIGURATION: number = usb.LIBUSB_REQUEST_GET_CONFIGURATION;
+const CHECK_LIBUSB_REQUEST_SET_CONFIGURATION: number = usb.LIBUSB_REQUEST_SET_CONFIGURATION;
+const CHECK_LIBUSB_REQUEST_GET_INTERFACE: number = usb.LIBUSB_REQUEST_GET_INTERFACE;
+const CHECK_LIBUSB_REQUEST_SET_INTERFACE: number = usb.LIBUSB_REQUEST_SET_INTERFACE;
+const CHECK_LIBUSB_REQUEST_SYNCH_FRAME: number = usb.LIBUSB_REQUEST_SYNCH_FRAME;
+// libusb_descriptor_type
+const CHECK_LIBUSB_DT_DEVICE: number = usb.LIBUSB_DT_DEVICE;
+const CHECK_LIBUSB_DT_CONFIG: number = usb.LIBUSB_DT_CONFIG;
+const CHECK_LIBUSB_DT_STRING: number = usb.LIBUSB_DT_STRING;
+const CHECK_LIBUSB_DT_INTERFACE: number = usb.LIBUSB_DT_INTERFACE;
+const CHECK_LIBUSB_DT_ENDPOINT: number = usb.LIBUSB_DT_ENDPOINT;
+const CHECK_LIBUSB_DT_HID: number = usb.LIBUSB_DT_HID;
+const CHECK_LIBUSB_DT_REPORT: number = usb.LIBUSB_DT_REPORT;
+const CHECK_LIBUSB_DT_PHYSICAL: number = usb.LIBUSB_DT_PHYSICAL;
+const CHECK_LIBUSB_DT_HUB: number = usb.LIBUSB_DT_HUB;
+// libusb_endpoint_direction
+const CHECK_LIBUSB_ENDPOINT_IN: number = usb.LIBUSB_ENDPOINT_IN;
+const CHECK_LIBUSB_ENDPOINT_OUT: number = usb.LIBUSB_ENDPOINT_OUT;
+// libusb_transfer_type
+const CHECK_LIBUSB_TRANSFER_TYPE_CONTROL: number = usb.LIBUSB_TRANSFER_TYPE_CONTROL;
+const CHECK_LIBUSB_TRANSFER_TYPE_ISOCHRONOUS: number = usb.LIBUSB_TRANSFER_TYPE_ISOCHRONOUS;
+const CHECK_LIBUSB_TRANSFER_TYPE_BULK: number = usb.LIBUSB_TRANSFER_TYPE_BULK;
+const CHECK_LIBUSB_TRANSFER_TYPE_INTERRUPT: number = usb.LIBUSB_TRANSFER_TYPE_INTERRUPT;
+// libusb_iso_sync_type
+const CHECK_LIBUSB_ISO_SYNC_TYPE_NONE: number = usb.LIBUSB_ISO_SYNC_TYPE_NONE;
+const CHECK_LIBUSB_ISO_SYNC_TYPE_ASYNC: number = usb.LIBUSB_ISO_SYNC_TYPE_ASYNC;
+const CHECK_LIBUSB_ISO_SYNC_TYPE_ADAPTIVE: number = usb.LIBUSB_ISO_SYNC_TYPE_ADAPTIVE;
+const CHECK_LIBUSB_ISO_SYNC_TYPE_SYNC: number = usb.LIBUSB_ISO_SYNC_TYPE_SYNC;
+// libusb_iso_usage_type
+const CHECK_LIBUSB_ISO_USAGE_TYPE_DATA: number = usb.LIBUSB_ISO_USAGE_TYPE_DATA;
+const CHECK_LIBUSB_ISO_USAGE_TYPE_FEEDBACK: number = usb.LIBUSB_ISO_USAGE_TYPE_FEEDBACK;
+const CHECK_LIBUSB_ISO_USAGE_TYPE_IMPLICIT: number = usb.LIBUSB_ISO_USAGE_TYPE_IMPLICIT;
+// libusb_transfer_status
+const CHECK_LIBUSB_TRANSFER_COMPLETED: number = usb.LIBUSB_TRANSFER_COMPLETED;
+const CHECK_LIBUSB_TRANSFER_ERROR: number = usb.LIBUSB_TRANSFER_ERROR;
+const CHECK_LIBUSB_TRANSFER_TIMED_OUT: number = usb.LIBUSB_TRANSFER_TIMED_OUT;
+const CHECK_LIBUSB_TRANSFER_CANCELLED: number = usb.LIBUSB_TRANSFER_CANCELLED;
+const CHECK_LIBUSB_TRANSFER_STALL: number = usb.LIBUSB_TRANSFER_STALL;
+const CHECK_LIBUSB_TRANSFER_NO_DEVICE: number = usb.LIBUSB_TRANSFER_NO_DEVICE;
+const CHECK_LIBUSB_TRANSFER_OVERFLOW: number = usb.LIBUSB_TRANSFER_OVERFLOW;
+// libusb_transfer_flags
+const CHECK_LIBUSB_TRANSFER_SHORT_NOT_OK: number = usb.LIBUSB_TRANSFER_SHORT_NOT_OK;
+const CHECK_LIBUSB_TRANSFER_FREE_BUFFER: number = usb.LIBUSB_TRANSFER_FREE_BUFFER;
+const CHECK_LIBUSB_TRANSFER_FREE_TRANSFER: number = usb.LIBUSB_TRANSFER_FREE_TRANSFER;
+// libusb_request_type
+const CHECK_LIBUSB_REQUEST_TYPE_STANDARD: number = usb.LIBUSB_REQUEST_TYPE_STANDARD;
+const CHECK_LIBUSB_REQUEST_TYPE_CLASS: number = usb.LIBUSB_REQUEST_TYPE_CLASS;
+const CHECK_LIBUSB_REQUEST_TYPE_VENDOR: number = usb.LIBUSB_REQUEST_TYPE_VENDOR;
+const CHECK_LIBUSB_REQUEST_TYPE_RESERVED: number = usb.LIBUSB_REQUEST_TYPE_RESERVED;
+// libusb_request_recipient
+const CHECK_LIBUSB_RECIPIENT_DEVICE: number = usb.LIBUSB_RECIPIENT_DEVICE;
+const CHECK_LIBUSB_RECIPIENT_INTERFACE: number = usb.LIBUSB_RECIPIENT_INTERFACE;
+const CHECK_LIBUSB_RECIPIENT_ENDPOINT: number = usb.LIBUSB_RECIPIENT_ENDPOINT;
+const CHECK_LIBUSB_RECIPIENT_OTHER: number = usb.LIBUSB_RECIPIENT_OTHER;
+
+const CHECK_LIBUSB_CONTROL_SETUP_SIZE: number = usb.LIBUSB_CONTROL_SETUP_SIZE;
+
+// libusb_error
+// Input/output error
+const CHECK_LIBUSB_ERROR_IO: number = usb.LIBUSB_ERROR_IO;
+// Invalid parameter
+const CHECK_LIBUSB_ERROR_INVALID_PARAM: number = usb.LIBUSB_ERROR_INVALID_PARAM;
+// Access denied (insufficient permissions)
+const CHECK_LIBUSB_ERROR_ACCESS: number = usb.LIBUSB_ERROR_ACCESS;
+// No such device (it may have been disconnected)
+const CHECK_LIBUSB_ERROR_NO_DEVICE: number = usb.LIBUSB_ERROR_NO_DEVICE;
+// Entity not found
+const CHECK_LIBUSB_ERROR_NOT_FOUND: number = usb.LIBUSB_ERROR_NOT_FOUND;
+// Resource busy
+const CHECK_LIBUSB_ERROR_BUSY: number = usb.LIBUSB_ERROR_BUSY;
+// Operation timed out
+const CHECK_LIBUSB_ERROR_TIMEOUT: number = usb.LIBUSB_ERROR_TIMEOUT;
+// Overflow
+const CHECK_LIBUSB_ERROR_OVERFLOW: number = usb.LIBUSB_ERROR_OVERFLOW;
+// Pipe error
+const CHECK_LIBUSB_ERROR_PIPE: number = usb.LIBUSB_ERROR_PIPE;
+// System call interrupted (perhaps due to signal)
+const CHECK_LIBUSB_ERROR_INTERRUPTED: number = usb.LIBUSB_ERROR_INTERRUPTED;
+// Insufficient memory
+const CHECK_LIBUSB_ERROR_NO_MEM: number = usb.LIBUSB_ERROR_NO_MEM;
+// Operation not supported or unimplemented on this platform
+const CHECK_LIBUSB_ERROR_NOT_SUPPORTED: number = usb.LIBUSB_ERROR_NOT_SUPPORTED;
+// Other error
+const CHECK_LIBUSB_ERROR_OTHER: number = usb.LIBUSB_ERROR_OTHER;

--- a/node-usb/node-usb.d.ts
+++ b/node-usb/node-usb.d.ts
@@ -1,0 +1,230 @@
+// Type definitions for node-usb 1.1.2
+// Project: https://github.com/nonolith/node-usb
+// Definitions by: Eric Brody <https://github.com/underscorebrody>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module "usb" {
+
+  class Device {
+    public timeout: number;
+    public busNumber: number;
+    public deviceAddress: number;
+    public portNumbers: Array<number>;
+    public deviceDescriptor: DeviceDescriptor;
+    public configDescriptor: ConfigDescriptor;
+    public interfaces: Array<Interface>;
+
+    open(defaultConfig?: boolean): void;
+    close(): void;
+    interface(addr: number): Interface;
+    controlTransfer(bmRequestType: number, bRequest: number, wValue: number, wIndex: number, data_or_length: any, callback: (error?: string, buf?: Buffer) => void): Device;
+    getStringDescriptor(desc_index: number, callback: (error?: string, buf?: Buffer) => void): void;
+    setConfiguration(desired: number, cb: (err?: string) => void): void;
+    reset(callback: (err?: string) => void): void;
+  }
+
+  class DeviceDescriptor {
+    public bLength: number;
+    public bDescriptorType: number;
+    public bcdUSB: number;
+    public bDeviceClass: number;
+    public bDeviceSubClass: number;
+    public bDeviceProtocol: number;
+    public bMaxPacketSize: number;
+    public idVendor: number;
+    public idProduct: number;
+    public bcdDevice: number;
+    public iManufacturer: number;
+    public iProduct: number;
+    public iSerialNumber: number;
+    public bNumConfigurations: number;
+  }
+
+  class ConfigDescriptor {
+    public bLength: number;
+    public bDescriptorType: number;
+    public wTotalLength: number;
+    public bNumInterfaces: number;
+    public bConfigurationValue: number;
+    public iConfiguration: number;
+    public bmAttributes: number;
+    public bMaxPower: number;
+    public extra: Buffer;
+  }
+
+  class Interface {
+    public descriptor: InterfaceDescriptor;
+    public endpoints: Array<IEndpoint>;
+    constructor(device: Device, id: number);
+    claim(): void;
+    release(closeEndpoints?: (err?: string) => void, cb?: (err?: string) => void): void;
+    isKernelDriverActive(): boolean;
+    detachKernelDriver(): number;
+    attachKernelDriver(): number;
+    setAltSetting(altSetting: number, cb: (err?: string) => void): void;
+    endpoint(addr: number): IEndpoint;
+  }
+
+  class InterfaceDescriptor {
+    public bLength: number;
+    public bDescriptorType: number;
+    public bInterfaceNumber: number;
+    public bAlternateSetting: number;
+    public bNumEndpoints: number;
+    public bInterfaceClass: number;
+    public bInterfaceSubClass: number;
+    public bInterfaceProtocol: number;
+    public iInterface: number;
+    public extra: Buffer;
+  }
+
+  interface IEndpoint {
+    direction: string;
+    transferType: number;
+    timeout: number;
+    descriptor: EndpointDescriptor;
+  }
+
+  class InEndpoint implements IEndpoint {
+    public direction: string;
+    public transferType: number;
+    public timeout: number;
+    public descriptor: EndpointDescriptor;
+    constructor(device: Device, descriptor: EndpointDescriptor);
+    transfer(length: number, callback: (error: string, data: Buffer) => void): InEndpoint;
+    startPoll(nTransfers: number, transferSize: number): void;
+    stopPoll(cb: () => void): void;
+  }
+
+  class OutEndpoint implements IEndpoint {
+    public direction: string;
+    public transferType: number;
+    public timeout: number;
+    public descriptor: EndpointDescriptor;
+    constructor(device: Device, descriptor: EndpointDescriptor);
+    transfer(buffer: Buffer, cb: (err?: string) => void): OutEndpoint;
+    transferWithZLP(buf: Buffer, cb: (err?: string) => void): void;
+  }
+
+  class EndpointDescriptor {
+    public bLength: number;
+    public bDescriptorType: number;
+    public bEndpointAddress: number;
+    public bmAttributes: number;
+    public wMaxPacketSize: number;
+    public bInterval: number;
+    public bRefresh: number;
+    public bSynchAddress: number;
+  }
+
+  function findByIds(vid: number, pid: number): Device;
+  function on(event: string, callback: (device: Device) => void): void;
+  function getDeviceList(): Array<Device>;
+  function setDebugLevel(level: number): void;
+
+  const LIBUSB_CLASS_PER_INTERFACE: number;
+  const LIBUSB_CLASS_AUDIO: number;
+  const LIBUSB_CLASS_COMM: number;
+  const LIBUSB_CLASS_HID: number;
+  const LIBUSB_CLASS_PRINTER: number;
+  const LIBUSB_CLASS_PTP: number;
+  const LIBUSB_CLASS_MASS_STORAGE: number;
+  const LIBUSB_CLASS_HUB: number;
+  const LIBUSB_CLASS_DATA: number;
+  const LIBUSB_CLASS_WIRELESS: number;
+  const LIBUSB_CLASS_APPLICATION: number;
+  const LIBUSB_CLASS_VENDOR_SPEC: number;
+  // libusb_standard_request
+  const LIBUSB_REQUEST_GET_STATUS: number;
+  const LIBUSB_REQUEST_CLEAR_FEATURE: number;
+  const LIBUSB_REQUEST_SET_FEATURE: number;
+  const LIBUSB_REQUEST_SET_ADDRESS: number;
+  const LIBUSB_REQUEST_GET_DESCRIPTOR: number;
+  const LIBUSB_REQUEST_SET_DESCRIPTOR: number;
+  const LIBUSB_REQUEST_GET_CONFIGURATION: number;
+  const LIBUSB_REQUEST_SET_CONFIGURATION: number;
+  const LIBUSB_REQUEST_GET_INTERFACE: number;
+  const LIBUSB_REQUEST_SET_INTERFACE: number;
+  const LIBUSB_REQUEST_SYNCH_FRAME: number;
+  // libusb_descriptor_type
+  const LIBUSB_DT_DEVICE: number;
+  const LIBUSB_DT_CONFIG: number;
+  const LIBUSB_DT_STRING: number;
+  const LIBUSB_DT_INTERFACE: number;
+  const LIBUSB_DT_ENDPOINT: number;
+  const LIBUSB_DT_HID: number;
+  const LIBUSB_DT_REPORT: number;
+  const LIBUSB_DT_PHYSICAL: number;
+  const LIBUSB_DT_HUB: number;
+  // libusb_endpoint_direction
+  const LIBUSB_ENDPOINT_IN: number;
+  const LIBUSB_ENDPOINT_OUT: number;
+  // libusb_transfer_type
+  const LIBUSB_TRANSFER_TYPE_CONTROL: number;
+  const LIBUSB_TRANSFER_TYPE_ISOCHRONOUS: number;
+  const LIBUSB_TRANSFER_TYPE_BULK: number;
+  const LIBUSB_TRANSFER_TYPE_INTERRUPT: number;
+  // libusb_iso_sync_type
+  const LIBUSB_ISO_SYNC_TYPE_NONE: number;
+  const LIBUSB_ISO_SYNC_TYPE_ASYNC: number;
+  const LIBUSB_ISO_SYNC_TYPE_ADAPTIVE: number;
+  const LIBUSB_ISO_SYNC_TYPE_SYNC: number;
+  // libusb_iso_usage_type
+  const LIBUSB_ISO_USAGE_TYPE_DATA: number;
+  const LIBUSB_ISO_USAGE_TYPE_FEEDBACK: number;
+  const LIBUSB_ISO_USAGE_TYPE_IMPLICIT: number;
+  // libusb_transfer_status
+  const LIBUSB_TRANSFER_COMPLETED: number;
+  const LIBUSB_TRANSFER_ERROR: number;
+  const LIBUSB_TRANSFER_TIMED_OUT: number;
+  const LIBUSB_TRANSFER_CANCELLED: number;
+  const LIBUSB_TRANSFER_STALL: number;
+  const LIBUSB_TRANSFER_NO_DEVICE: number;
+  const LIBUSB_TRANSFER_OVERFLOW: number;
+  // libusb_transfer_flags
+  const LIBUSB_TRANSFER_SHORT_NOT_OK: number;
+  const LIBUSB_TRANSFER_FREE_BUFFER: number;
+  const LIBUSB_TRANSFER_FREE_TRANSFER: number;
+  // libusb_request_type
+  const LIBUSB_REQUEST_TYPE_STANDARD: number;
+  const LIBUSB_REQUEST_TYPE_CLASS: number;
+  const LIBUSB_REQUEST_TYPE_VENDOR: number;
+  const LIBUSB_REQUEST_TYPE_RESERVED: number;
+  // libusb_request_recipient
+  const LIBUSB_RECIPIENT_DEVICE: number;
+  const LIBUSB_RECIPIENT_INTERFACE: number;
+  const LIBUSB_RECIPIENT_ENDPOINT: number;
+  const LIBUSB_RECIPIENT_OTHER: number;
+
+  const LIBUSB_CONTROL_SETUP_SIZE: number;
+
+  // libusb_error
+  // Input/output error
+  const LIBUSB_ERROR_IO: number;
+  // Invalid parameter
+  const LIBUSB_ERROR_INVALID_PARAM: number;
+  // Access denied (insufficient permissions)
+  const LIBUSB_ERROR_ACCESS: number;
+  // No such device (it may have been disconnected)
+  const LIBUSB_ERROR_NO_DEVICE: number;
+  // Entity not found
+  const LIBUSB_ERROR_NOT_FOUND: number;
+  // Resource busy
+  const LIBUSB_ERROR_BUSY: number;
+  // Operation timed out
+  const LIBUSB_ERROR_TIMEOUT: number;
+  // Overflow
+  const LIBUSB_ERROR_OVERFLOW: number;
+  // Pipe error
+  const LIBUSB_ERROR_PIPE: number;
+  // System call interrupted (perhaps due to signal)
+  const LIBUSB_ERROR_INTERRUPTED: number;
+  // Insufficient memory
+  const LIBUSB_ERROR_NO_MEM: number;
+  // Operation not supported or unimplemented on this platform
+  const LIBUSB_ERROR_NOT_SUPPORTED: number;
+  // Other error
+  const LIBUSB_ERROR_OTHER: number;
+}


### PR DESCRIPTION
Adds a new type definition for https://github.com/nonolith/node-usb
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Travis build linked here, not sure why the web hook didn't pick it up: https://travis-ci.org/kitcheck/DefinitelyTyped/builds/141140864

Resolves https://github.com/DefinitelyTyped/DefinitelyTyped/issues/9866
