### PR TITLE
Add typings for react-is-deprecated.

### DIFF
--- a/react-is-deprecated/react-is-deprecated-tests.ts
+++ b/react-is-deprecated/react-is-deprecated-tests.ts
@@ -1,0 +1,17 @@
+/// <reference path="../react/react.d.ts" />
+/// <reference path="./react-is-deprecated.d.ts"/>
+
+import { PropTypes } from 'react';
+import { deprecate, addIsDeprecated } from 'react-is-deprecated';
+
+// test: one-off deprecation
+deprecate(PropTypes.string, 'message');
+
+// test: one-off deprecated with isRequired
+deprecate(PropTypes.string.isRequired, 'message');
+
+// test: isDeprecated is added to a proptype
+addIsDeprecated(PropTypes).string.isDeprecated('message');
+
+// test: isRequired is still present on that proptype
+addIsDeprecated(PropTypes).string.isRequired;

--- a/react-is-deprecated/react-is-deprecated.d.ts
+++ b/react-is-deprecated/react-is-deprecated.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for react-is-deprecated v0.1.2
+// Project: https://github.com/Aweary/react-is-deprecated
+// Definitions by: Sean Kelley <https://github.com/seansfkelley>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../react/react.d.ts" />
+
+declare module 'react-is-deprecated' {
+  import { Validator, Requireable, ValidationMap, ReactPropTypes } from 'react';
+
+  export function deprecate<T>(validator: Validator<T>, message: string): Validator<T>;
+
+  interface Deprecatable<T> {
+    isDeprecated: (message: string) => Validator<T>;
+  }
+
+  // Unfortunately this copy-paste must happen -- I can't just take PropTypes and programmatically
+  // define a version that intersects in the Deprecatable interface into the keys.
+  interface DeprecatablePropTypes {
+    any: Requireable<any> & Deprecatable<any>;
+    array: Requireable<any> & Deprecatable<any>;
+    bool: Requireable<any> & Deprecatable<any>;
+    func: Requireable<any> & Deprecatable<any>;
+    number: Requireable<any> & Deprecatable<any>;
+    object: Requireable<any> & Deprecatable<any>;
+    string: Requireable<any> & Deprecatable<any>;
+    node: Requireable<any> & Deprecatable<any>;
+    element: Requireable<any> & Deprecatable<any>;
+    instanceOf(expectedClass: {}): Requireable<any> & Deprecatable<any>;
+    oneOf(types: any[]): Requireable<any> & Deprecatable<any>;
+    oneOfType(types: Validator<any>[]): Requireable<any> & Deprecatable<any>;
+    arrayOf(type: Validator<any>): Requireable<any> & Deprecatable<any>;
+    objectOf(type: Validator<any>): Requireable<any> & Deprecatable<any>;
+    shape(type: ValidationMap<any>): Requireable<any> & Deprecatable<any>;
+  }
+
+  export function addIsDeprecated(propTypes: ReactPropTypes): DeprecatablePropTypes;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
