### PR TITLE
Added create reflect-metadata.d.ts

### DIFF
--- a/reflect-metadata/reflect-metadata-test.ts
+++ b/reflect-metadata/reflect-metadata-test.ts
@@ -1,0 +1,42 @@
+/// <reference path="reflect-metadata.d.ts" />
+
+// define metadata on an object or property
+Reflect.defineMetadata(metadataKey, metadataValue, target);
+Reflect.defineMetadata(metadataKey, metadataValue, target, propertyKey);
+ 
+// check for presence of a metadata key on the prototype chain of an object or property
+let result = Reflect.hasMetadata(metadataKey, target);
+let result = Reflect.hasMetadata(metadataKey, target, propertyKey);
+ 
+// check for presence of an own metadata key of an object or property
+let result = Reflect.hasOwnMetadata(metadataKey, target);
+let result = Reflect.hasOwnMetadata(metadataKey, target, propertyKey);
+ 
+// get metadata value of a metadata key on the prototype chain of an object or property
+let result = Reflect.getMetadata(metadataKey, target);
+let result = Reflect.getMetadata(metadataKey, target, propertyKey);
+ 
+// get metadata value of an own metadata key of an object or property
+let result = Reflect.getOwnMetadata(metadataKey, target);
+let result = Reflect.getOwnMetadata(metadataKey, target, propertyKey);
+ 
+// get all metadata keys on the prototype chain of an object or property
+let result = Reflect.getMetadataKeys(target);
+let result = Reflect.getMetadataKeys(target, propertyKey);
+ 
+// get all own metadata keys of an object or property
+let result = Reflect.getOwnMetadataKeys(target);
+let result = Reflect.getOwnMetadataKeys(target, propertyKey);
+ 
+// delete metadata from an object or property
+let result = Reflect.deleteMetadata(metadataKey, target);
+let result = Reflect.deleteMetadata(metadataKey, target, propertyKey);
+ 
+// apply metadata via a decorator to a constructor
+@Reflect.metadata(metadataKey, metadataValue)
+class C {
+  // apply metadata via a decorator to a method (property)
+  @Reflect.metadata(metadataKey, metadataValue)
+  method() {  
+  }
+}

--- a/reflect-metadata/reflect-metadata-test.ts
+++ b/reflect-metadata/reflect-metadata-test.ts
@@ -1,5 +1,15 @@
 /// <reference path="reflect-metadata.d.ts" />
 
+let target = {
+ some_property: {
+  
+ }
+}
+
+let metadataKey = "key";
+let metadataValue = "val";
+let propertyKey = "some_property";
+
 // define metadata on an object or property
 Reflect.defineMetadata(metadataKey, metadataValue, target);
 Reflect.defineMetadata(metadataKey, metadataValue, target, propertyKey);

--- a/reflect-metadata/reflect-metadata-test.ts
+++ b/reflect-metadata/reflect-metadata-test.ts
@@ -15,32 +15,32 @@ Reflect.defineMetadata(metadataKey, metadataValue, target);
 Reflect.defineMetadata(metadataKey, metadataValue, target, propertyKey);
  
 // check for presence of a metadata key on the prototype chain of an object or property
-let result = Reflect.hasMetadata(metadataKey, target);
-let result = Reflect.hasMetadata(metadataKey, target, propertyKey);
+let result1 = Reflect.hasMetadata(metadataKey, target);
+let result2 = Reflect.hasMetadata(metadataKey, target, propertyKey);
  
 // check for presence of an own metadata key of an object or property
-let result = Reflect.hasOwnMetadata(metadataKey, target);
-let result = Reflect.hasOwnMetadata(metadataKey, target, propertyKey);
+let result3 = Reflect.hasOwnMetadata(metadataKey, target);
+let result4 = Reflect.hasOwnMetadata(metadataKey, target, propertyKey);
  
 // get metadata value of a metadata key on the prototype chain of an object or property
-let result = Reflect.getMetadata(metadataKey, target);
-let result = Reflect.getMetadata(metadataKey, target, propertyKey);
+let result5 = Reflect.getMetadata(metadataKey, target);
+let result6 = Reflect.getMetadata(metadataKey, target, propertyKey);
  
 // get metadata value of an own metadata key of an object or property
-let result = Reflect.getOwnMetadata(metadataKey, target);
-let result = Reflect.getOwnMetadata(metadataKey, target, propertyKey);
+let result7 = Reflect.getOwnMetadata(metadataKey, target);
+let result8 = Reflect.getOwnMetadata(metadataKey, target, propertyKey);
  
 // get all metadata keys on the prototype chain of an object or property
-let result = Reflect.getMetadataKeys(target);
-let result = Reflect.getMetadataKeys(target, propertyKey);
+let result9 = Reflect.getMetadataKeys(target);
+let result10 = Reflect.getMetadataKeys(target, propertyKey);
  
 // get all own metadata keys of an object or property
-let result = Reflect.getOwnMetadataKeys(target);
-let result = Reflect.getOwnMetadataKeys(target, propertyKey);
+let result11 = Reflect.getOwnMetadataKeys(target);
+let result12 = Reflect.getOwnMetadataKeys(target, propertyKey);
  
 // delete metadata from an object or property
-let result = Reflect.deleteMetadata(metadataKey, target);
-let result = Reflect.deleteMetadata(metadataKey, target, propertyKey);
+let result13 = Reflect.deleteMetadata(metadataKey, target);
+let result14 = Reflect.deleteMetadata(metadataKey, target, propertyKey);
  
 // apply metadata via a decorator to a constructor
 @Reflect.metadata(metadataKey, metadataValue)

--- a/reflect-metadata/reflect-metadata.d.ts
+++ b/reflect-metadata/reflect-metadata.d.ts
@@ -1,0 +1,480 @@
+// Type definitions for reflect-metadata
+// Project: https://github.com/rbuckton/ReflectDecorators
+// Definitions by: Ron Buckton <https://github.com/rbuckton>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "reflect-metadata" {
+    // The "reflect-metadata" module has no imports or exports, but can be used by modules to load the polyfill.
+}
+
+declare namespace Reflect {
+    /**
+      * Applies a set of decorators to a target object.
+      * @param decorators An array of decorators.
+      * @param target The target object.
+      * @returns The result of applying the provided decorators.
+      * @remarks Decorators are applied in reverse order of their positions in the array.
+      * @example
+      *
+      *     class C { }
+      *
+      *     // constructor
+      *     C = Reflect.decorate(decoratorsArray, C);
+      *
+      */
+    function decorate(decorators: ClassDecorator[], target: Function): Function;
+    /**
+      * Applies a set of decorators to a property of a target object.
+      * @param decorators An array of decorators.
+      * @param target The target object.
+      * @param targetKey The property key to decorate.
+      * @param descriptor A property descriptor
+      * @remarks Decorators are applied in reverse order.
+      * @example
+      *
+      *     class C {
+      *         // property declarations are not part of ES6, though they are valid in TypeScript:
+      *         // static staticProperty;
+      *         // property;
+      *
+      *         static staticMethod() { }
+      *         method() { }
+      *     }
+      *
+      *     // property (on constructor)
+      *     Reflect.decorate(decoratorsArray, C, "staticProperty");
+      *
+      *     // property (on prototype)
+      *     Reflect.decorate(decoratorsArray, C.prototype, "property");
+      *
+      *     // method (on constructor)
+      *     Object.defineProperty(C, "staticMethod",
+      *         Reflect.decorate(decoratorsArray, C, "staticMethod",
+      *             Object.getOwnPropertyDescriptor(C, "staticMethod")));
+      *
+      *     // method (on prototype)
+      *     Object.defineProperty(C.prototype, "method",
+      *         Reflect.decorate(decoratorsArray, C.prototype, "method",
+      *             Object.getOwnPropertyDescriptor(C.prototype, "method")));
+      *
+      */
+    function decorate(decorators: (PropertyDecorator | MethodDecorator)[], target: Object, targetKey: string | symbol, descriptor?: PropertyDescriptor): PropertyDescriptor;
+    /**
+      * A default metadata decorator factory that can be used on a class, class member, or parameter.
+      * @param metadataKey The key for the metadata entry.
+      * @param metadataValue The value for the metadata entry.
+      * @returns A decorator function.
+      * @remarks
+      * If `metadataKey` is already defined for the target and target key, the
+      * metadataValue for that key will be overwritten.
+      * @example
+      *
+      *     // constructor
+      *     @Reflect.metadata(key, value)
+      *     class C {
+      *     }
+      *
+      *     // property (on constructor, TypeScript only)
+      *     class C {
+      *         @Reflect.metadata(key, value)
+      *         static staticProperty;
+      *     }
+      *
+      *     // property (on prototype, TypeScript only)
+      *     class C {
+      *         @Reflect.metadata(key, value)
+      *         property;
+      *     }
+      *
+      *     // method (on constructor)
+      *     class C {
+      *         @Reflect.metadata(key, value)
+      *         static staticMethod() { }
+      *     }
+      *
+      *     // method (on prototype)
+      *     class C {
+      *         @Reflect.metadata(key, value)
+      *         method() { }
+      *     }
+      *
+      */
+    function metadata(metadataKey: any, metadataValue: any): {
+        (target: Function): void;
+        (target: Object, propertyKey: string | symbol): void;
+    };
+    /**
+      * Define a unique metadata entry on the target.
+      * @param metadataKey A key used to store and retrieve metadata.
+      * @param metadataValue A value that contains attached metadata.
+      * @param target The target object on which to define metadata.
+      * @example
+      *
+      *     class C {
+      *     }
+      *
+      *     // constructor
+      *     Reflect.defineMetadata("custom:annotation", options, C);
+      *
+      *     // decorator factory as metadata-producing annotation.
+      *     function MyAnnotation(options): ClassDecorator {
+      *         return target => Reflect.defineMetadata("custom:annotation", options, target);
+      *     }
+      *
+      */
+    function defineMetadata(metadataKey: any, metadataValue: any, target: Object): void;
+    /**
+      * Define a unique metadata entry on the target.
+      * @param metadataKey A key used to store and retrieve metadata.
+      * @param metadataValue A value that contains attached metadata.
+      * @param target The target object on which to define metadata.
+      * @param targetKey The property key for the target.
+      * @example
+      *
+      *     class C {
+      *         // property declarations are not part of ES6, though they are valid in TypeScript:
+      *         // static staticProperty;
+      *         // property;
+      *
+      *         static staticMethod(p) { }
+      *         method(p) { }
+      *     }
+      *
+      *     // property (on constructor)
+      *     Reflect.defineMetadata("custom:annotation", Number, C, "staticProperty");
+      *
+      *     // property (on prototype)
+      *     Reflect.defineMetadata("custom:annotation", Number, C.prototype, "property");
+      *
+      *     // method (on constructor)
+      *     Reflect.defineMetadata("custom:annotation", Number, C, "staticMethod");
+      *
+      *     // method (on prototype)
+      *     Reflect.defineMetadata("custom:annotation", Number, C.prototype, "method");
+      *
+      *     // decorator factory as metadata-producing annotation.
+      *     function MyAnnotation(options): PropertyDecorator {
+      *         return (target, key) => Reflect.defineMetadata("custom:annotation", options, target, key);
+      *     }
+      *
+      */
+    function defineMetadata(metadataKey: any, metadataValue: any, target: Object, targetKey: string | symbol): void;
+    /**
+      * Gets a value indicating whether the target object or its prototype chain has the provided metadata key defined.
+      * @param metadataKey A key used to store and retrieve metadata.
+      * @param target The target object on which the metadata is defined.
+      * @returns `true` if the metadata key was defined on the target object or its prototype chain; otherwise, `false`.
+      * @example
+      *
+      *     class C {
+      *     }
+      *
+      *     // constructor
+      *     result = Reflect.hasMetadata("custom:annotation", C);
+      *
+      */
+    function hasMetadata(metadataKey: any, target: Object): boolean;
+    /**
+      * Gets a value indicating whether the target object or its prototype chain has the provided metadata key defined.
+      * @param metadataKey A key used to store and retrieve metadata.
+      * @param target The target object on which the metadata is defined.
+      * @param targetKey The property key for the target.
+      * @returns `true` if the metadata key was defined on the target object or its prototype chain; otherwise, `false`.
+      * @example
+      *
+      *     class C {
+      *         // property declarations are not part of ES6, though they are valid in TypeScript:
+      *         // static staticProperty;
+      *         // property;
+      *
+      *         static staticMethod(p) { }
+      *         method(p) { }
+      *     }
+      *
+      *     // property (on constructor)
+      *     result = Reflect.hasMetadata("custom:annotation", C, "staticProperty");
+      *
+      *     // property (on prototype)
+      *     result = Reflect.hasMetadata("custom:annotation", C.prototype, "property");
+      *
+      *     // method (on constructor)
+      *     result = Reflect.hasMetadata("custom:annotation", C, "staticMethod");
+      *
+      *     // method (on prototype)
+      *     result = Reflect.hasMetadata("custom:annotation", C.prototype, "method");
+      *
+      */
+    function hasMetadata(metadataKey: any, target: Object, targetKey: string | symbol): boolean;
+    /**
+      * Gets a value indicating whether the target object has the provided metadata key defined.
+      * @param metadataKey A key used to store and retrieve metadata.
+      * @param target The target object on which the metadata is defined.
+      * @returns `true` if the metadata key was defined on the target object; otherwise, `false`.
+      * @example
+      *
+      *     class C {
+      *     }
+      *
+      *     // constructor
+      *     result = Reflect.hasOwnMetadata("custom:annotation", C);
+      *
+      */
+    function hasOwnMetadata(metadataKey: any, target: Object): boolean;
+    /**
+      * Gets a value indicating whether the target object has the provided metadata key defined.
+      * @param metadataKey A key used to store and retrieve metadata.
+      * @param target The target object on which the metadata is defined.
+      * @param targetKey The property key for the target.
+      * @returns `true` if the metadata key was defined on the target object; otherwise, `false`.
+      * @example
+      *
+      *     class C {
+      *         // property declarations are not part of ES6, though they are valid in TypeScript:
+      *         // static staticProperty;
+      *         // property;
+      *
+      *         static staticMethod(p) { }
+      *         method(p) { }
+      *     }
+      *
+      *     // property (on constructor)
+      *     result = Reflect.hasOwnMetadata("custom:annotation", C, "staticProperty");
+      *
+      *     // property (on prototype)
+      *     result = Reflect.hasOwnMetadata("custom:annotation", C.prototype, "property");
+      *
+      *     // method (on constructor)
+      *     result = Reflect.hasOwnMetadata("custom:annotation", C, "staticMethod");
+      *
+      *     // method (on prototype)
+      *     result = Reflect.hasOwnMetadata("custom:annotation", C.prototype, "method");
+      *
+      */
+    function hasOwnMetadata(metadataKey: any, target: Object, targetKey: string | symbol): boolean;
+    /**
+      * Gets the metadata value for the provided metadata key on the target object or its prototype chain.
+      * @param metadataKey A key used to store and retrieve metadata.
+      * @param target The target object on which the metadata is defined.
+      * @returns The metadata value for the metadata key if found; otherwise, `undefined`.
+      * @example
+      *
+      *     class C {
+      *     }
+      *
+      *     // constructor
+      *     result = Reflect.getMetadata("custom:annotation", C);
+      *
+      */
+    function getMetadata(metadataKey: any, target: Object): any;
+    /**
+      * Gets the metadata value for the provided metadata key on the target object or its prototype chain.
+      * @param metadataKey A key used to store and retrieve metadata.
+      * @param target The target object on which the metadata is defined.
+      * @param targetKey The property key for the target.
+      * @returns The metadata value for the metadata key if found; otherwise, `undefined`.
+      * @example
+      *
+      *     class C {
+      *         // property declarations are not part of ES6, though they are valid in TypeScript:
+      *         // static staticProperty;
+      *         // property;
+      *
+      *         static staticMethod(p) { }
+      *         method(p) { }
+      *     }
+      *
+      *     // property (on constructor)
+      *     result = Reflect.getMetadata("custom:annotation", C, "staticProperty");
+      *
+      *     // property (on prototype)
+      *     result = Reflect.getMetadata("custom:annotation", C.prototype, "property");
+      *
+      *     // method (on constructor)
+      *     result = Reflect.getMetadata("custom:annotation", C, "staticMethod");
+      *
+      *     // method (on prototype)
+      *     result = Reflect.getMetadata("custom:annotation", C.prototype, "method");
+      *
+      */
+    function getMetadata(metadataKey: any, target: Object, targetKey: string | symbol): any;
+    /**
+      * Gets the metadata value for the provided metadata key on the target object.
+      * @param metadataKey A key used to store and retrieve metadata.
+      * @param target The target object on which the metadata is defined.
+      * @returns The metadata value for the metadata key if found; otherwise, `undefined`.
+      * @example
+      *
+      *     class C {
+      *     }
+      *
+      *     // constructor
+      *     result = Reflect.getOwnMetadata("custom:annotation", C);
+      *
+      */
+    function getOwnMetadata(metadataKey: any, target: Object): any;
+    /**
+      * Gets the metadata value for the provided metadata key on the target object.
+      * @param metadataKey A key used to store and retrieve metadata.
+      * @param target The target object on which the metadata is defined.
+      * @param targetKey The property key for the target.
+      * @returns The metadata value for the metadata key if found; otherwise, `undefined`.
+      * @example
+      *
+      *     class C {
+      *         // property declarations are not part of ES6, though they are valid in TypeScript:
+      *         // static staticProperty;
+      *         // property;
+      *
+      *         static staticMethod(p) { }
+      *         method(p) { }
+      *     }
+      *
+      *     // property (on constructor)
+      *     result = Reflect.getOwnMetadata("custom:annotation", C, "staticProperty");
+      *
+      *     // property (on prototype)
+      *     result = Reflect.getOwnMetadata("custom:annotation", C.prototype, "property");
+      *
+      *     // method (on constructor)
+      *     result = Reflect.getOwnMetadata("custom:annotation", C, "staticMethod");
+      *
+      *     // method (on prototype)
+      *     result = Reflect.getOwnMetadata("custom:annotation", C.prototype, "method");
+      *
+      */
+    function getOwnMetadata(metadataKey: any, target: Object, targetKey: string | symbol): any;
+    /**
+      * Gets the metadata keys defined on the target object or its prototype chain.
+      * @param target The target object on which the metadata is defined.
+      * @returns An array of unique metadata keys.
+      * @example
+      *
+      *     class C {
+      *     }
+      *
+      *     // constructor
+      *     result = Reflect.getMetadataKeys(C);
+      *
+      */
+    function getMetadataKeys(target: Object): any[];
+    /**
+      * Gets the metadata keys defined on the target object or its prototype chain.
+      * @param target The target object on which the metadata is defined.
+      * @param targetKey The property key for the target.
+      * @returns An array of unique metadata keys.
+      * @example
+      *
+      *     class C {
+      *         // property declarations are not part of ES6, though they are valid in TypeScript:
+      *         // static staticProperty;
+      *         // property;
+      *
+      *         static staticMethod(p) { }
+      *         method(p) { }
+      *     }
+      *
+      *     // property (on constructor)
+      *     result = Reflect.getMetadataKeys(C, "staticProperty");
+      *
+      *     // property (on prototype)
+      *     result = Reflect.getMetadataKeys(C.prototype, "property");
+      *
+      *     // method (on constructor)
+      *     result = Reflect.getMetadataKeys(C, "staticMethod");
+      *
+      *     // method (on prototype)
+      *     result = Reflect.getMetadataKeys(C.prototype, "method");
+      *
+      */
+    function getMetadataKeys(target: Object, targetKey: string | symbol): any[];
+    /**
+      * Gets the unique metadata keys defined on the target object.
+      * @param target The target object on which the metadata is defined.
+      * @returns An array of unique metadata keys.
+      * @example
+      *
+      *     class C {
+      *     }
+      *
+      *     // constructor
+      *     result = Reflect.getOwnMetadataKeys(C);
+      *
+      */
+    function getOwnMetadataKeys(target: Object): any[];
+    /**
+      * Gets the unique metadata keys defined on the target object.
+      * @param target The target object on which the metadata is defined.
+      * @param targetKey The property key for the target.
+      * @returns An array of unique metadata keys.
+      * @example
+      *
+      *     class C {
+      *         // property declarations are not part of ES6, though they are valid in TypeScript:
+      *         // static staticProperty;
+      *         // property;
+      *
+      *         static staticMethod(p) { }
+      *         method(p) { }
+      *     }
+      *
+      *     // property (on constructor)
+      *     result = Reflect.getOwnMetadataKeys(C, "staticProperty");
+      *
+      *     // property (on prototype)
+      *     result = Reflect.getOwnMetadataKeys(C.prototype, "property");
+      *
+      *     // method (on constructor)
+      *     result = Reflect.getOwnMetadataKeys(C, "staticMethod");
+      *
+      *     // method (on prototype)
+      *     result = Reflect.getOwnMetadataKeys(C.prototype, "method");
+      *
+      */
+    function getOwnMetadataKeys(target: Object, targetKey: string | symbol): any[];
+    /**
+      * Deletes the metadata entry from the target object with the provided key.
+      * @param metadataKey A key used to store and retrieve metadata.
+      * @param target The target object on which the metadata is defined.
+      * @returns `true` if the metadata entry was found and deleted; otherwise, false.
+      * @example
+      *
+      *     class C {
+      *     }
+      *
+      *     // constructor
+      *     result = Reflect.deleteMetadata("custom:annotation", C);
+      *
+      */
+    function deleteMetadata(metadataKey: any, target: Object): boolean;
+    /**
+      * Deletes the metadata entry from the target object with the provided key.
+      * @param metadataKey A key used to store and retrieve metadata.
+      * @param target The target object on which the metadata is defined.
+      * @param targetKey The property key for the target.
+      * @returns `true` if the metadata entry was found and deleted; otherwise, false.
+      * @example
+      *
+      *     class C {
+      *         // property declarations are not part of ES6, though they are valid in TypeScript:
+      *         // static staticProperty;
+      *         // property;
+      *
+      *         static staticMethod(p) { }
+      *         method(p) { }
+      *     }
+      *
+      *     // property (on constructor)
+      *     result = Reflect.deleteMetadata("custom:annotation", C, "staticProperty");
+      *
+      *     // property (on prototype)
+      *     result = Reflect.deleteMetadata("custom:annotation", C.prototype, "property");
+      *
+      *     // method (on constructor)
+      *     result = Reflect.deleteMetadata("custom:annotation", C, "staticMethod");
+      *
+      *     // method (on prototype)
+      *     result = Reflect.deleteMetadata("custom:annotation", C.prototype, "method");
+      *
+      */
+    function deleteMetadata(metadataKey: any, target: Object, targetKey: string | symbol): boolean;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

The type definitions have been copied from https://github.com/rbuckton/ReflectDecorators/blob/master/reflect-metadata.d.ts

The tests are based on https://github.com/rbuckton/ReflectDecorators#api
