### PR TITLE
Add promise.prototype.finally definition file

### DIFF
--- a/promise.prototype.finally/promise.prototype.finally-tests.ts
+++ b/promise.prototype.finally/promise.prototype.finally-tests.ts
@@ -1,0 +1,12 @@
+/// <reference path="./promise.prototype.finally.d.ts"/>
+
+var promise = new Promise<Boolean>((resolve, reject) => {
+	resolve(true);
+});
+
+promise.finally(() => {});
+promise.then(() => {}, () => {}).finally(() => {});
+promise.catch(() => {}).finally(() => {});
+
+var allPromise = Promise.all([promise]);
+allPromise.finally(() => {});

--- a/promise.prototype.finally/promise.prototype.finally.d.ts
+++ b/promise.prototype.finally/promise.prototype.finally.d.ts
@@ -1,0 +1,5 @@
+declare module 'es6-promise/dist/es6-promise' {
+    export interface Promise <R> {
+      finally?<U>(onFinally?: () => U | Promise<U>): Promise<U>;
+    }
+}

--- a/promise.prototype.finally/promise.prototype.finally.d.ts
+++ b/promise.prototype.finally/promise.prototype.finally.d.ts
@@ -1,5 +1,8 @@
-declare module 'es6-promise/dist/es6-promise' {
-    export interface Promise <R> {
-      finally?<U>(onFinally?: () => U | Promise<U>): Promise<U>;
-    }
+// Type definitions for promise.prototype.finally v1.0.1
+// Project: https://github.com/matthew-andrews/Promise.prototype.finally
+// Definitions by: Slava Shpitalny <https://github.com/slavik57>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare interface Promise<T> {
+    finally<U>(onFinally?: () => U | Promise<U>): Promise<U>;
 }


### PR DESCRIPTION
case 1. Add a new type definition.
- [ x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
