### PR TITLE
updated ts definition for v2.4.0 of 'bytes' package with missing options

### DIFF
--- a/bytes/bytes-tests.ts
+++ b/bytes/bytes-tests.ts
@@ -8,7 +8,9 @@ console.log(bytes(104857, { thousandsSeparator: ' ' }));
 
 console.log(bytes.format(104857));
 console.log(bytes.format(104857, { thousandsSeparator: ' ' }));
-
+console.log(bytes.format(104857, { decimalPlaces: 2 }));
+console.log(bytes.format(104857, { fixedDecimals: true }));
+console.log(bytes.format(104857, { unitSeparator: '-' }));
 console.log(bytes('1024kb'));
 console.log(bytes(1024));
 

--- a/bytes/bytes.d.ts
+++ b/bytes/bytes.d.ts
@@ -1,10 +1,15 @@
-﻿// Type definitions for bytes v2.1.0
+﻿// Type definitions for bytes v2.4.0
 // Project: https://github.com/visionmedia/bytes.js
 // Definitions by: Zhiyuan Wang <https://github.com/danny8002/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module 'bytes' {
-
+    interface BytesOptions {
+      decimalPlaces?: number,
+      thousandsSeparator?: string,
+      unitSeparator?: string,
+      fixedDecimals?: boolean
+    }
     /**
      *Convert the given value in bytes into a string.
      *
@@ -15,7 +20,7 @@ declare module 'bytes' {
      *
      * @returns {string}
      */
-    function bytes(value: number, options?: { thousandsSeparator: string }): string;
+    function bytes(value: number, options?: BytesOptions): string;
 
     /**
      *Parse string to an integer in bytes.
@@ -37,7 +42,7 @@ declare module 'bytes' {
          * @param {BytesFormatOptions} [options]
          */
 
-        function format(value: number, options?: { thousandsSeparator: string }): string;
+        function format(value: number, options?: BytesOptions): string;
 
         /**
          * Just return the input number value.


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- updated definition to v2.4.0 of the library (https://www.npmjs.com/package/bytes)
