### PR TITLE
Update to ngstorage.d.ts - Add indexer to storage service

### DIFF
--- a/ngstorage/ngstorage.d.ts
+++ b/ngstorage/ngstorage.d.ts
@@ -12,6 +12,7 @@ declare namespace angular.storage {
         $reset(items?: {}): IStorageService;
         $apply(): void;
         $sync(): void;
+        [key: string]: any;
     }
 
     export interface IStorageProvider extends angular.IServiceProvider {


### PR DESCRIPTION
Adds an indexer to the storage service to allow dereferencing stored data using a dynamic key value. This allows the consumer to write custom getter/setter methods. This is not currently possible if the typescript project is configured to not allow implicit Any.
