### PR TITLE
Adds the vary method to the Response interface

### DIFF
--- a/express-serve-static-core/express-serve-static-core.d.ts
+++ b/express-serve-static-core/express-serve-static-core.d.ts
@@ -782,6 +782,15 @@ declare module "express-serve-static-core" {
         locals: any;
 
         charset: string;
+        
+        /**
+         * Adds the field to the Vary response header, if it is not there already.
+         * Examples:
+         * 
+         *     res.vary('User-Agent').render('docs');
+         *
+         */
+        vary(field: string): Response;
     }
 
     interface NextFunction {


### PR DESCRIPTION
Adds the vary method to the Response interface. This methods exists and is missing on this definition file

http://expressjs.com/en/4x/api.html#res.vary
