### PR TITLE
Updated mathjs

### DIFF
--- a/mathjs/mathjs.d.ts
+++ b/mathjs/mathjs.d.ts
@@ -1334,6 +1334,10 @@ declare namespace mathjs {
 	export interface MathNode {
                 isNode: boolean;
                 isSymbolNode: boolean;
+                isConstantNode: boolean;
+                isOperatorNode: boolean;
+                op: string;
+                fn: string;
                 type: string;
                 name: string;
                 value: any;

--- a/mathjs/mathjs.d.ts
+++ b/mathjs/mathjs.d.ts
@@ -1333,14 +1333,15 @@ declare namespace mathjs {
 
 	export interface MathNode {
                 isNode: boolean;
-                isSymbolNode: boolean;
-                isConstantNode: boolean;
-                isOperatorNode: boolean;
-                op: string;
-                fn: string;
+                isSymbolNode?: boolean;
+                isConstantNode?: boolean;
+                isOperatorNode?: boolean;
+                op?: string;
+                fn?: string;
+                args?: MathNode[];
                 type: string;
-                name: string;
-                value: any;
+                name?: string;
+                value?: any;
 
                 compile(): EvalFunction;
                 eval(): any;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
http://mathjs.org/docs/expressions/expression_trees.html#properties
http://mathjs.org/docs/expressions/expression_trees.html#operatornode

Added additional properties to interface `MathNode` for ConstantNode and OperatorNode
