### PR TITLE
Add typings for chai-dom

### DIFF
--- a/chai-dom/chai-dom-tests.ts
+++ b/chai-dom/chai-dom-tests.ts
@@ -1,0 +1,27 @@
+/// <reference path="chai-dom.d.ts" />
+
+import * as chai from 'chai';
+import * as chaiDom from 'chai-dom';
+
+chai.use(chaiDom);
+var expect = chai.expect;
+
+function test() {
+
+    var testElement = '<div></div>';
+    expect(testElement).to.have.attribute('foo', 'bar');
+    expect(testElement).to.have.attr('foo').match(/bar/);
+    expect(testElement).to.have.class('foo');
+    expect(testElement).to.have.id('id');
+    expect(testElement).to.have.html('foo');
+    expect(testElement).to.have.text('foo');
+    expect(testElement).to.have.text(['foo', 'bar']);
+    expect(testElement).to.have.value('foo');
+    expect(testElement).to.be.empty;
+    expect(testElement).to.have.length(2);
+    expect(testElement).to.exist;
+    expect(testElement).to.match('foo');
+    expect(testElement).to.contain('foo');
+    expect(testElement).to.contain(document.body);
+
+}

--- a/chai-dom/chai-dom.d.ts
+++ b/chai-dom/chai-dom.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for chai-dom
+// Project: https://github.com/nathanboktae/chai-dom
+// Definitions by: Matt Lewis <https://github.com/mattlewis92>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../chai/chai.d.ts" />
+
+declare namespace Chai {
+
+    interface Assertion {
+
+        attr(name: string, value?: string): Assertion;
+
+        attribute(name: string, value?: string): Assertion;
+
+        class(className: string): Assertion;
+
+        id(id: string): Assertion;
+
+        html(html: string): Assertion;
+
+        text(text: string|string[]): Assertion;
+
+        value(text: string): Assertion;
+
+    }
+
+}
+
+declare module "chai-dom" {
+
+    function chaiDom(chai: any, utils: any): void;
+
+    namespace chaiDom {
+    }
+
+    export = chaiDom;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
