### PR TITLE
[adal-angular]: add the new field postLogoutRedirectUri & appropriate tests & code style fix

### DIFF
--- a/adal-angular/adal-tests.ts
+++ b/adal-angular/adal-tests.ts
@@ -21,3 +21,5 @@ Logging.level = 4;
 auth.info("Logging message");
 
 var userName: string = auth.getCachedUser().userName;
+var postLogoutRedirectUrl = auth.config.postLogoutRedirectUri;
+var isValidRequest = auth.getRequestInfo('hash').valid;

--- a/adal-angular/adal.d.ts
+++ b/adal-angular/adal.d.ts
@@ -13,29 +13,30 @@ declare module 'adal' {
 declare namespace adal {
 
     interface Config {
-        tenant?: string,
-        clientId: string,
-        redirectUri?: string,
-        cacheLocation?: string,
-        displayCall?: (urlNavigate: string) => any,
-        correlationId?: string,
-        loginResource?: string,
-        resource?: string
-        endpoints?: any  // If you need to send CORS api requests.
-        extraQueryParameter?: string
+        tenant?: string;
+        clientId: string;
+        redirectUri?: string;
+        cacheLocation?: string;
+        displayCall?: (urlNavigate: string) => any;
+        correlationId?: string;
+        loginResource?: string;
+        resource?: string;
+        endpoints?: any;  // If you need to send CORS api requests.
+        extraQueryParameter?: string;
+        postLogoutRedirectUri?: string; // redirect url after succesful logout operation
     }
 
     interface User {
-        userName: string,
-        profile: any
+        userName: string;
+        profile: any;
     }
 
     interface RequestInfo {
-        valid: boolean,
-        parameters: any,
-        stateMatch: boolean,
-        stateResponse: string,
-        requestType: string
+        valid: boolean;
+        parameters: any;
+        stateMatch: boolean;
+        stateResponse: string;
+        requestType: string;
     }
     
     interface Logging {
@@ -64,6 +65,10 @@ declare namespace adal {
          * Saves the resulting Idtoken in localStorage.
          */
         login(): void;
+
+        /**
+         * Indicates whether login is in progress now or not.
+         */
         loginInProgress(): boolean;
 
         /**
@@ -147,6 +152,11 @@ declare namespace adal {
          */
         getResourceForEndpoint(endpoint: string): string;
 
+        /**
+         * Handles redirection after login operation. 
+         * Gets access token from url and saves token to the (local/session) storage
+         * or saves error in case unsuccessful login.
+         */
         handleWindowCallback(): void;
 
         log(level: number, message: string, error: any): void;


### PR DESCRIPTION
It's improvement to existing type definition.
Based on adal.js source code, Config type definition should contain the `postLogoutRedirectUri` field. See [source (line 457)](https://github.com/AzureAD/azure-activedirectory-library-for-js/blob/master/lib/adal.js#L457) as a proof.
