### PR TITLE
Rxjs, concatAll using inner observer must return observer with value.

### DIFF
--- a/rx/rx-lite.d.ts
+++ b/rx/rx-lite.d.ts
@@ -245,8 +245,8 @@ declare namespace Rx {
 		withLatestFrom<TOther, TResult>(souces: (Observable<TOther>|IPromise<TOther>)[], resultSelector: (firstValue: T, ...otherValues: TOther[]) => TResult): Observable<TResult>;
 		concat(...sources: (Observable<T>|IPromise<T>)[]): Observable<T>;
 		concat(sources: (Observable<T>|IPromise<T>)[]): Observable<T>;
-		concatAll(): Observable<T>;
-		concatObservable(): Observable<T>;	// alias for concatAll
+		concatAll(): T;
+		concatObservable(): T;	// alias for concatAll
 		concatMap<T2, R>(selector: (value: T, index: number) => Observable<T2>, resultSelector: (value1: T, value2: T2, index: number) => R): Observable<R>;	// alias for selectConcat
 		concatMap<T2, R>(selector: (value: T, index: number) => IPromise<T2>, resultSelector: (value1: T, value2: T2, index: number) => R): Observable<R>;	// alias for selectConcat
 		concatMap<R>(selector: (value: T, index: number) => Observable<R>): Observable<R>;	// alias for selectConcat
@@ -257,8 +257,8 @@ declare namespace Rx {
 		merge(maxConcurrent: number): T;
 		merge(other: Observable<T>): Observable<T>;
 		merge(other: IPromise<T>): Observable<T>;
-		mergeAll(): Observable<T>;
-		mergeObservable(): Observable<T>;	// alias for mergeAll
+		mergeAll(): T;
+		mergeObservable(): T;	// alias for mergeAll
 		skipUntil<T2>(other: Observable<T2>): Observable<T>;
 		skipUntil<T2>(other: IPromise<T2>): Observable<T>;
 		switch(): Observable<T>;
@@ -524,6 +524,7 @@ declare namespace Rx {
 		range(start: number, count: number, scheduler?: IScheduler): Observable<number>;
 		repeat<T>(value: T, repeatCount?: number, scheduler?: IScheduler): Observable<T>;
 		return<T>(value: T, scheduler?: IScheduler): Observable<T>;
+		replay<T>(selector?, bufferSize?, window?, scheduler?:IScheduler): Observable<T>
 		/**
 		 * @since 2.2.28
 		 */


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

The All methods creates an uplift version of an Observable,
so Observable<T> => T
