### PR TITLE
fixed react-redux connect decorators "Type is not assignable to type 'void'"

### DIFF
--- a/react-redux/react-redux-tests.tsx
+++ b/react-redux/react-redux-tests.tsx
@@ -58,6 +58,31 @@ class CounterContainer extends Component<any, any> {
 
 }
 
+interface TSP {
+    value: number
+}
+
+function mstp (state: CounterState, own: TOP): TSP {
+    return {
+        value: 0
+    }
+}
+
+interface TDP {
+    fun: () => any
+}
+
+type TOP = TSP & TDP
+
+function mdtp (dispatch: Dispatch<CounterState>): TDP {
+    return {
+        fun: () => {}
+    }
+}
+
+@connect(mstp, mdtp)
+class CounterContainer2 extends Component<TOP, {}> {}
+
 class App extends Component<any, any> {
     render(): JSX.Element {
         // ...

--- a/react-redux/react-redux.d.ts
+++ b/react-redux/react-redux.d.ts
@@ -11,7 +11,7 @@ declare module "react-redux" {
   import { Store, Dispatch, ActionCreator } from 'redux';
 
   interface ComponentDecorator<TOriginalProps, TOwnProps> {
-    (component: ComponentClass<TOriginalProps>|StatelessComponent<TOriginalProps>): ComponentClass<TOwnProps>;
+    <T extends ComponentClass<TOriginalProps>|StatelessComponent<TOriginalProps>>(component: T): T
   }
 
   /**


### PR DESCRIPTION
fixed react-redux connect decorators "Type is not assignable to type 'void'"
