### PR TITLE
add tinycopy type definitions

### DIFF
--- a/tinycopy/tinycopy-tests.ts
+++ b/tinycopy/tinycopy-tests.ts
@@ -1,0 +1,17 @@
+/// <reference path="tinycopy.d.ts" />
+
+import TinyCopy from 'tinycopy';
+
+TinyCopy.exec('test', (err, data) => {});
+
+var trigger_1 = document.getElementById('trigger_1');
+var target_1 = document.getElementById('target');
+new TinyCopy(trigger_1, target_1)
+  .on('success', function(data) {})
+  .on('error', function(err) {});
+
+var trigger_2 = document.getElementById('trigger_2');
+var target_2 = 'test';
+new TinyCopy(trigger_2, target_2)
+  .on('success', function(data) {})
+  .on('error', function(err) {});

--- a/tinycopy/tinycopy.d.ts
+++ b/tinycopy/tinycopy.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for tinycopy 2.1.2
+// Project: https://github.com/vvatanabe/tinycopy
+// Definitions by: Yuichi Watanabe <https://github.com/vvatanabe>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "tinycopy" {
+  export default class TinyCopy {
+    constructor(trigger: Element, target: (string | Element | NodeListOf<Element>));
+    on(type: "success", action: (data: string) => void): this;
+    on(type: "error", action: (err: Error) => void): this;
+    on(type: string, action: (e: (string | Error)) => void): this;
+    static exec(value: string, callback: (err?: Error, data?: string) => void): void;
+  }
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
