### PR TITLE
Add missing currentTarget event property

### DIFF
--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -1525,6 +1525,9 @@ function test_eventParams() {
     $(window).on('mousewheel', (e) => {
         var delta = (<WheelEvent>e.originalEvent).deltaY;
     });
+    $( "p" ).click(function( event ) {
+      alert( event.currentTarget === this ); // true
+    });
 }
 
 function test_extend() {

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -442,6 +442,7 @@ interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
  * Interface of the JQuery extension of the W3C event object
  */
 interface BaseJQueryEventObject extends Event {
+    currentTarget: Element;
     data: any;
     delegateTarget: Element;
     isDefaultPrevented(): boolean;


### PR DESCRIPTION
Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes: https://api.jquery.com/event.currentTarget/
- it has been reviewed by a DefinitelyTyped member: @johnnyreilly on https://github.com/DefinitelyTyped/DefinitelyTyped/issues/9899#issuecomment-229868515

Closes #9899
