### PR TITLE
Add host field to Dialog interface

### DIFF
--- a/durandal/durandal.d.ts
+++ b/durandal/durandal.d.ts
@@ -693,6 +693,7 @@ declare module 'plugins/dialog' {
     }
 
     interface Dialog {
+        host: HTMLElement;
         owner: any;
         context: DialogContext;
         activator: DurandalActivator<any>;


### PR DESCRIPTION
It should be set by `DialogContext.addHost()` according to
[durandals documentation](http://durandaljs.com/documentation/Showing-Message-Boxes-And-Modals.html#custom-dialog-contexts).
