### PR TITLE
second argument of `EventEmitter#off` is optional

### DIFF
--- a/pixi.js/pixi.js.d.ts
+++ b/pixi.js/pixi.js.d.ts
@@ -87,8 +87,8 @@ declare namespace PIXI {
         emit(event: string, ...args: any[]): boolean;
         on(event: string, fn: Function, context?: any): EventEmitter;
         once(event: string, fn: Function, context?: any): EventEmitter;
-        removeListener(event: string, fn: Function, context?: any, once?: boolean): EventEmitter;
-        removeAllListeners(event: string): EventEmitter;
+        removeListener(event: string, fn?: Function, context?: any, once?: boolean): EventEmitter;
+        removeAllListeners(event?: string): EventEmitter;
 
         off(event: string, fn?: Function, context?: any, once?: boolean): EventEmitter;
         addListener(event: string, fn: Function, context?: any): EventEmitter;

--- a/pixi.js/pixi.js.d.ts
+++ b/pixi.js/pixi.js.d.ts
@@ -90,7 +90,7 @@ declare namespace PIXI {
         removeListener(event: string, fn: Function, context?: any, once?: boolean): EventEmitter;
         removeAllListeners(event: string): EventEmitter;
 
-        off(event: string, fn: Function, context?: any, once?: boolean): EventEmitter;
+        off(event: string, fn?: Function, context?: any, once?: boolean): EventEmitter;
         addListener(event: string, fn: Function, context?: any): EventEmitter;
 
     }


### PR DESCRIPTION
Updated `EventEmitter#off` to be the same as its dependency: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/eventemitter3/eventemitter3.d.ts#L97
