### PR TITLE
adding typing for scroll-into-view

### DIFF
--- a/scroll-into-view/scroll-into-view-tests.ts
+++ b/scroll-into-view/scroll-into-view-tests.ts
@@ -1,0 +1,24 @@
+/// <reference path="scroll-into-view.d.ts" />
+import * as scrollIntoView from "scroll-into-view"
+
+var someElement: HTMLElement
+scrollIntoView(someElement);
+
+scrollIntoView(someElement, {
+    time: 500, // half a second
+    ease: function(value){
+        return Math.pow(value,2) - value); // Do something weird.
+    },
+    validTarget: function(target, parentsScrolled){
+        return parentsScrolled < 2 && !target.matches('.dontScroll');
+    },
+    align:{
+        top: 0,
+        left: 1
+    }
+});
+
+scrollIntoView(someElement, function(type){
+    // Scrolling done.
+    // type will be 'complete' if the scroll completed or 'canceled' if the current scroll was canceled by a new scroll
+})

--- a/scroll-into-view/scroll-into-view.d.ts
+++ b/scroll-into-view/scroll-into-view.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for scroll-into-view 1.6.0
+// Project: https://github.com/KoryNunn/scroll-into-view
+// Definitions by: zivni https://github.com/zivni
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module __ScrollIntoView {
+
+    interface Settings {
+        time?: number
+        ease?: (value: number) => number
+        validTarget?: (target: HTMLElement, parentsScrolled: number) => boolean
+        align?: Alignment
+    }
+
+    interface Alignment {
+        /** 0 to 1, default 0.5 (center) */
+        top?: number
+        /** 0 to 1, default 0.5 (center) */
+        left?: number
+    }
+
+    /** type will be 'complete' if the scroll completed or 'canceled' if the current scroll was canceled by a new scroll */
+    type callbackParamterType = "complete" | "canceled"
+    type Callback = (type: callbackParamterType) => void
+
+    interface ScrollIntoView {
+        (target: HTMLElement, callback?: __ScrollIntoView.Callback) : void
+        (target: HTMLElement, settings: __ScrollIntoView.Settings, callback?: __ScrollIntoView.Callback) :  void
+    }
+
+}
+
+declare module "scroll-into-view" {
+    var scrollIntoView: __ScrollIntoView.ScrollIntoView
+    export = scrollIntoView;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
