### PR TITLE
$animate.enabled() is also callable w/o params

### DIFF
--- a/angularjs/angular-animate.d.ts
+++ b/angularjs/angular-animate.d.ts
@@ -69,8 +69,9 @@ declare namespace angular.animate {
         * @param value If provided then set the animation on or off.
         * @returns current animation state
         */
-        enabled(element: JQuery, value?: boolean): boolean;
+        enabled(): boolean;
         enabled(value: boolean): boolean;
+        enabled(element: JQuery, value?: boolean): boolean;
 
         /**
          * Cancels the provided animation.

--- a/angularjs/angular-animate.d.ts
+++ b/angularjs/angular-animate.d.ts
@@ -69,8 +69,7 @@ declare namespace angular.animate {
         * @param value If provided then set the animation on or off.
         * @returns current animation state
         */
-        enabled(): boolean;
-        enabled(value: boolean): boolean;
+        enabled(value?: boolean): boolean;
         enabled(element: JQuery, value?: boolean): boolean;
 
         /**


### PR DESCRIPTION
It is actually supported to call $animate.enabled() without parameters.
url: https://docs.angularjs.org/api/ng/service/$animate
