### PR TITLE
Added jQuery-contextMenu missing option

### DIFF
--- a/jquery.contextMenu/jquery.contextMenu.d.ts
+++ b/jquery.contextMenu/jquery.contextMenu.d.ts
@@ -28,6 +28,7 @@ interface JQueryContextMenuOptions {
     items: any;
     reposition?: boolean;
     className?: string;
+    itemClickEvent?: string;
 }
 
 interface JQueryStatic {


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Added missing `itemClickEvent` option. [Ref (at the end of the page)](https://swisnl.github.io/jQuery-contextMenu/docs.html#build)
