### PR TITLE
Create ssh2-sftp-client.d.ts

### DIFF
--- a/ssh2-sftp-client/ssh2-sftp-client-tests.ts
+++ b/ssh2-sftp-client/ssh2-sftp-client-tests.ts
@@ -1,0 +1,27 @@
+/// <reference path="ssh2-sftp-client.d.ts"/>
+
+import * as Client from 'ssh2-sftp-client';
+var client = new Client();
+
+client.connect({
+    host: 'asdb',
+    port: 1234,
+    privateKey: 'my private key rsa in openssh format',
+    readyTimeout: 1000,
+}).then(() => null);
+
+client.list('/remote/path').then(() => null);
+
+client.get('/remote/path').then(stream => stream.read(0));
+
+client.put('/local/path', '/remote/path').then(() => null);
+
+client.put(new Buffer('content'), '/remote/path').then(() => null);
+
+client.mkdir('/remote/path/dir', true).then(() => null);
+
+client.delete('remote/path').then(() => null);
+
+client.remove('/remote/from', '/remote/to').then(() => null);
+
+client.end().then(() => null);

--- a/ssh2-sftp-client/ssh2-sftp-client.d.ts
+++ b/ssh2-sftp-client/ssh2-sftp-client.d.ts
@@ -1,0 +1,47 @@
+// Type definitions for ssh2-sftp-client v1.0.5
+// Project: https://www.npmjs.com/package/ssh2-sftp-client
+// Definitions by: igrayson <https://github.com/igrayson>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../ssh2/ssh2.d.ts"/>
+
+declare module "ssh2-sftp-client" {
+  import * as ssh2 from 'ssh2';
+
+  namespace sftp {
+
+    interface FileInfo {
+      type:string;
+      name:string;
+      size:number;
+      modifyTime:number;
+      accessTime:number;
+      rights:{
+        user:string;
+        group:string;
+        other:string;
+      };
+      owner:number;
+      group:number;
+    }
+
+    interface Client {
+      new():Client;
+      connect(options:ssh2.ConnectConfig):Promise<void>;
+      list(remoteFilePath:string):Promise<Array<FileInfo>>;
+      get(remoteFilePath:string, useCompression?:boolean):Promise<NodeJS.ReadableStream>;
+      put(localFilePath:string, remoteFilePath:string, useCompression?:boolean):Promise<void>;
+      put(buffer:Buffer, remoteFilePath:string, useCompression?:boolean):Promise<void>;
+      put(stream:NodeJS.ReadableStream, remoteFilePath:string, useCompression?:boolean):Promise<void>;
+      mkdir(remoteFilePath:string, recursive?:boolean):Promise<void>;
+      delete(remoteFilePath:string):Promise<void>;
+      remove(remoteSourcePath:string, remoteDestPath:string):Promise<void>;
+      end():Promise<void>;
+    }
+  }
+
+  var sftp:sftp.Client;
+
+  export = sftp;
+}
+


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
