### PR TITLE
Added definition to chai-enzyme

### DIFF
--- a/chai-enzyme/chai-enzyme-tests.tsx
+++ b/chai-enzyme/chai-enzyme-tests.tsx
@@ -1,0 +1,45 @@
+/// <reference path="../react/react.d.ts" />
+/// <reference path="./chai-enzyme.d.ts" />
+/// <reference path="../enzyme/enzyme.d.ts" />
+/// <reference path="../chai/chai.d.ts" />
+
+import * as React from "react";
+import * as chaiEnzyme from "chai-enzyme";
+import { expect } from "chai";
+import { shallow } from "enzyme";
+
+const Test = () => <div/>;
+
+class Test2 extends React.Component<{}, {}> {
+    render() {
+        return <div/>;
+    }
+}
+
+chai.use(chaiEnzyme());
+
+const wrapper = shallow(<Test />);
+
+expect(wrapper).to.be.checked();
+expect(wrapper).to.have.className("test");
+expect(wrapper).to.have.descendants({ a: "b" });
+expect(wrapper).to.have.descendants(Test);
+expect(wrapper).to.have.exactly(1).descendants(Test2);
+expect(wrapper).to.have.descendants("div");
+expect(wrapper).to.be.disabled();
+expect(wrapper).to.be.blank();
+expect(wrapper).to.be.present();
+expect(wrapper).to.have.html("<div></div>");
+expect(wrapper).to.have.id("test");
+expect(wrapper).to.have.ref("test");
+expect(wrapper).to.be.selected();
+expect(wrapper).to.have.tagName("div");
+expect(wrapper).to.have.text("");
+expect(wrapper).to.have.value("test");
+expect(wrapper).to.have.attr("test", "test");
+expect(wrapper).to.have.data("test", "Test");
+expect(wrapper).to.have.style("background", "green");
+expect(wrapper).to.have.state("test", "test");
+expect(wrapper).to.have.prop("test", 5);
+expect(wrapper).to.contain(<Test/>);
+expect(wrapper).to.match(<Test/>);

--- a/chai-enzyme/chai-enzyme.d.ts
+++ b/chai-enzyme/chai-enzyme.d.ts
@@ -1,0 +1,153 @@
+// Type definitions for chai-enzyme 0.5.0
+// Project: https://github.com/producthunt/chai-enzyme
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+
+/// <reference path="../enzyme/enzyme.d.ts" />
+/// <reference path="../chai/chai.d.ts" />
+/// <reference path="../react/react.d.ts" />
+
+declare namespace Chai {
+    type EnzymeSelector = string | __React.StatelessComponent<any> | __React.ComponentClass<any> | { [key: string]: any };
+
+    interface Match {
+        /**
+         * Assert that the wrapper matches given selector:
+         * @param selector
+         */
+        (selector: EnzymeSelector): Assertion;
+    }
+    interface Include {
+        /**
+         * Assert that the wrapper contains a given node:
+         * @param code
+         */
+        (selector: EnzymeSelector): Assertion;
+    }
+    interface Assertion {
+        /**
+         * Assert that the given wrapper is checked:
+         */
+        checked(): Assertion;
+
+        /**
+         * Assert that the wrapper has a given class:
+         * @param name
+         */
+        className(name: string): Assertion;
+
+        /**
+         * Assert that the wrapper contains a descendant matching the given selector:
+         * @param selector
+         */
+        descendants(selector?: EnzymeSelector): Assertion;
+
+        /**
+         * Assert that the wrapper contains an exact amount of descendants matching the given selector:
+         */
+        exactly(count?: number): Assertion;
+
+        /**
+         * Assert that the given wrapper is disabled:
+         */
+        disabled(): Assertion;
+
+        /**
+         * Assert that the given wrapper is empty:
+         */
+        blank(): Assertion;
+
+        /**
+         * Assert that the given wrapper exists:
+         */
+        present(): Assertion;
+
+        /**
+         * Assert that the wrapper has given html:
+         * @param str
+         */
+        html(str?: string): Assertion;
+
+        /**
+         * Assert that the wrapper has given ID attribute:
+         * @param str
+         */
+        id(str: string): Assertion;
+
+        /**
+         * Assert that the wrapper has a given ref
+         * @param key
+         */
+        ref(key: string): Assertion;
+
+        /**
+         * Assert that the given wrapper is selected:
+         */
+        selected(): Assertion;
+
+        /**
+         * Assert that the given wrapper has the tag name:
+         * @param str
+         */
+        tagName(str: string): Assertion;
+
+        /**
+         * Assert that the given wrapper has the supplied text:
+         * @param str
+         */
+        text(str?: string): Assertion;
+
+        /**
+         * Assert that the given wrapper has given value:
+         * @param str
+         */
+        value(str: string): Assertion;
+
+        /**
+         * Assert that the wrapper has given attribute [with value]:
+         * @param key
+         * @param val
+         */
+        attr(key: string, val?: string): Assertion;
+
+        /**
+         * Assert that the wrapper has a given data attribute [with value]:
+         * @param key
+         * @param val
+         */
+        data(key: string, val?: string): Assertion;
+
+        /**
+         * Assert that the wrapper has given style:
+         * @param key
+         * @param val
+         */
+        style(key: string, val?: string): Assertion;
+
+        /**
+         * Assert that the wrapper has given state [with value]:
+         * @param key
+         * @param val
+         */
+        state(key: string, val?: any): Assertion;
+
+        /**
+         * Assert that the wrapper has given prop [with value]:
+         * @param key
+         * @param val
+         */
+        prop(key: string, val?: any): Assertion;
+    }
+}
+
+declare module "chai-enzyme" {
+    import { ShallowWrapper, ReactWrapper, CheerioWrapper } from "enzyme";
+
+    type DebugWrapper = ShallowWrapper<any,any> | CheerioWrapper<any, any> | ReactWrapper<any, any>;
+    function chaiEnzyMe(wrapper?: (debugWrapper: DebugWrapper) => string): (chai: any) => void;
+
+    module chaiEnzyMe {
+    }
+    export = chaiEnzyMe;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
