### PR TITLE
Added definition for react-motion-slider

### DIFF
--- a/react-motion-slider/react-motion-slider-tests.tsx
+++ b/react-motion-slider/react-motion-slider-tests.tsx
@@ -1,0 +1,28 @@
+/// <reference path="../react/react.d.ts" />
+/// <reference path="./react-motion-slider.d.ts" />
+
+import * as React from "react";
+import Slider from "react-motion-slider";
+
+class Test extends React.Component<{}, {}> {
+    protected slider: Slider;
+
+    public render() {
+        return (
+            <div onMouseEnter={this.onMouseEnter.bind(this) }>
+                <Slider currentIndex={1}
+                    autoHeight
+                    align="center"
+                    ref={ref => this.slider = ref}
+                    >
+                    <div key="slide1"/>
+                    <div key="slide2"/>
+                </Slider>
+            </div>
+        );
+    }
+
+    protected onMouseEnter(): void {
+        this.slider.next();
+    }
+}

--- a/react-motion-slider/react-motion-slider.d.ts
+++ b/react-motion-slider/react-motion-slider.d.ts
@@ -4,9 +4,12 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../react/react.d.ts" />
+/// <reference path="../react-motion/react-motion.d.ts" />
+
 
 declare module "react-motion-slider" {
     import * as React from "react";
+    import { OpaqueConfig } from "react-motion";
 
     export interface SliderProps {
         /**
@@ -54,7 +57,7 @@ declare module "react-motion-slider" {
         /**
          * Accepts a React Motion spring config.
          */
-        springConfig?: Object;
+        springConfig?: OpaqueConfig;
         /**
          * Prop callback fired before slide change.
          * @param currentIndex

--- a/react-motion-slider/react-motion-slider.d.ts
+++ b/react-motion-slider/react-motion-slider.d.ts
@@ -1,0 +1,82 @@
+// Type definitions for react-motion-slider 0.4.1
+// Project: https://github.com/souporserious/react-motion-slider
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../react/react.d.ts" />
+
+declare module "react-motion-slider" {
+    import * as React from "react";
+
+    export interface SliderProps {
+        /**
+         * Move to a slide by its key.
+         */
+        currentKey?: string | number;
+        /**
+         * Move to a slide by its index.
+         */
+        currentIndex?: number;
+        /**
+         * The amount of slides shown in view
+         * @default 1
+         */
+        slidesToShow?: number;
+        /**
+         * The amount of slides to move upon using prev and next methods.
+         * @default 1
+         */
+        slidesToMove?: number;
+        /**
+         * Animates the wrapper height to fit the current slide.
+         * @default false
+         */
+        autoHeight?: boolean;
+        /**
+         * Offsets the slide to align either left, center, or right.
+         * @default "left"
+         */
+        align?: "left" | "center" | "right";
+        /**
+         * Enable touch and/or mouse dragging
+         * @default true
+         */
+        swipe?: boolean | "touch" | "mouse";
+        /**
+         * The amount the user must swipe to advance slides. (sliderWidth * swipeThreshold)
+         * @default 0.5
+         */
+        swipeThreshold?: number;
+        /**
+         * The amount of time in milliseconds that determines if a swipe was a flick or not.
+         */
+        flickTimeout?: number;
+        /**
+         * Accepts a React Motion spring config.
+         */
+        springConfig?: Object;
+        /**
+         * Prop callback fired before slide change.
+         * @param currentIndex
+         * @param nextIndex
+         */
+        beforeSlide?: (currentIndex: number, nextIndex: number) => void;
+        /**
+         * Prop callback fired after slide change.
+         * @param currentIndex
+         */
+        afterSlide?: (currentIndex: number) => void;
+    }
+
+    export default class Slider extends React.Component<SliderProps, {}> {
+        /**
+         * Moves to next slide
+         */
+        public next(): void;
+
+        /**
+         * Move to previous slide
+         */
+        public prev(): void;
+    }
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
