### PR TITLE
Type definition for match-media-mock

### DIFF
--- a/match-media-mock/match-media-mock-tests.ts
+++ b/match-media-mock/match-media-mock-tests.ts
@@ -1,0 +1,15 @@
+/// <reference path="./match-media-mock.d.ts" />
+
+import { create } from "match-media-mock";
+
+const matchMediaMock = create();
+matchMediaMock.setConfig({type: 'screen', width: 1200})
+
+matchMediaMock('(max-width: 991px)').matches // false
+matchMediaMock('(max-width: 1240px)').matches // true
+
+const mediaQueryList = matchMediaMock('(max-width: 991px)');
+const listener = (mql: MediaQueryList) => { };
+
+mediaQueryList.addListener(listener)
+mediaQueryList.removeListener(listener)

--- a/match-media-mock/match-media-mock.d.ts
+++ b/match-media-mock/match-media-mock.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for match-media-mock 0.1.0
+// Project: https://github.com/azazdeaz/match-media-mock
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "match-media-mock" {
+    /**
+     * Mock configuration options
+     */
+    interface ConfigOptions {
+        /**
+         * Screen type
+         */
+        type?: string;
+        /**
+         * Screen height
+         */
+        height?: number;
+        /**
+         * Screen width
+         */
+        width?: number;
+    }
+    interface MatchMediaMock {
+        /**
+         * Set configuration
+         */
+        setConfig(config: ConfigOptions): void;
+        /**
+         * Execute query based on provided configuration
+         */
+        (query: string): MediaQueryList;
+    }
+    export function create(): MatchMediaMock;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
