### PR TITLE
Added type definition for redux-storage

### DIFF
--- a/redux-storage/redux-storage-tests.ts
+++ b/redux-storage/redux-storage-tests.ts
@@ -1,0 +1,31 @@
+/// <reference path="../redux/redux.d.ts" />
+/// <reference path="./redux-storage.d.ts" />
+
+import { Action, createStore, applyMiddleware } from "redux";
+import { reducer, createMiddleware, createLoader } from "redux-storage";
+import reduxStorageImmutableMerger from "redux-storage-merger-immutablejs";
+import filter from "redux-storage-decorator-filter";
+import createEngine from "redux-storage-engine-localstorage";
+
+interface TestState {
+    a: number;
+    b: string;
+}
+
+function rootReducer(state: TestState, action: Action): TestState {
+    return state;
+}
+
+const enhancedReducer = reducer(rootReducer, reduxStorageImmutableMerger);
+
+const storageEngine = createEngine("test");
+
+const initialStateLoader = createLoader(storageEngine);
+
+const storageMiddleware = createMiddleware(storageEngine, [], []);
+
+const store = applyMiddleware(storageMiddleware)(createStore)(enhancedReducer);
+
+initialStateLoader(store).then(() => {
+    // render app
+})

--- a/redux-storage/redux-storage.d.ts
+++ b/redux-storage/redux-storage.d.ts
@@ -1,0 +1,107 @@
+// Type definitions for redux-storage 4.0.1
+// Project: https://github.com/michaelcontento/redux-storage
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../redux/redux.d.ts" />
+
+declare module "redux-storage" {
+    import { Reducer, Store, Middleware } from "redux";
+
+    /**
+     * Action constants
+     */
+    export const LOAD: string;
+    export const SAVE: string;
+
+    /**
+     * Storage engine interface
+     */
+    export interface StorageEngine {
+        /**
+         * Load
+         */
+        load(): PromiseLike<any>;
+        /**
+         * Save
+         * @param state
+         */
+        save(state: any): PromiseLike<any>
+    }
+
+    export interface StateMerger {
+        (oldState: any, newState: any): any;
+    }
+
+    /**
+     * Storage reducer
+     * @param reducer
+     * @param merger
+     */
+    export function reducer<TState>(reducer: Reducer<TState>, merger?: StateMerger): Reducer<TState>;
+
+    /**
+     * Create storage middleware
+     * @param engine
+     * @param actionBlacklist
+     * @param actionWhitelist
+     */
+    export function createMiddleware(engine: StorageEngine, actionBlacklist?: string[], actionWhitelist?: string[]): Middleware;
+
+    /**
+     * Loader interface
+     */
+    interface Loader<TState> {
+        (store: Store<TState>): PromiseLike<any>
+    }
+
+    /**
+     * Create state loader
+     * @param engine
+     */
+    export function createLoader<TState>(engine: StorageEngine): Loader<TState>;
+
+}
+
+declare module "redux-storage-decorator-filter" {
+    import { StorageEngine } from "redux-storage";
+
+    /**
+
+     */
+    interface WhitelistArg {
+        [key: number]: string | string[];
+    }
+
+    /**
+     * Filter decorator for redux-storage to only store a subset of the whole state tree.
+     * @param engine
+     * @param whitelist
+     * @example
+     * engine = filter(engine, [
+     * 'simple-key',
+     * ['nested', 'key'],
+     * ['another', 'very', 'nested', 'key']
+     * ]);
+     */
+    export default function(engine: StorageEngine, whitelist?: WhitelistArg): StorageEngine;
+}
+
+declare module "redux-storage-engine-localstorage" {
+    import { StorageEngine } from "redux-storage";
+
+    export interface LocalStorageEngine extends StorageEngine {}
+
+    /**
+     * Create local storage
+     * @param key localstorage key
+     */
+    export default function createEngine(key: string): LocalStorageEngine;
+}
+
+declare module "redux-storage-merger-immutablejs" {
+    import { StateMerger } from "redux-storage";
+
+    const immutableStateMerger: StateMerger;
+    export default immutableStateMerger;
+}

--- a/redux-storage/redux-storage.d.ts
+++ b/redux-storage/redux-storage.d.ts
@@ -52,7 +52,7 @@ declare module "redux-storage" {
      * Loader interface
      */
     interface Loader<TState> {
-        (store: Store<TState>): PromiseLike<any>
+        (store: Store<TState>): PromiseLike<any>;
     }
 
     /**
@@ -66,9 +66,6 @@ declare module "redux-storage" {
 declare module "redux-storage-decorator-filter" {
     import { StorageEngine } from "redux-storage";
 
-    /**
-
-     */
     interface WhitelistArg {
         [key: number]: string | string[];
     }


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

There are also simple type definitions for redux-storage-decorator-filter, redux-storage-engine-localstorage, redux-storage-merger-immutablejs. Not sure where should they go so i put them into main definition file
