### PR TITLE
Parse fixes

### DIFF
--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -714,8 +714,6 @@ declare namespace Parse {
 
         signUp<T>(attrs: any, options?: SuccessFailureOptions): Promise<T>;
         logIn<T>(options?: SuccessFailureOptions): Promise<T>;
-        fetch<T extends User>(options?: SuccessFailureOptions): Promise<T>;
-        save<T extends User>(options?: Object.SaveOptions, arg2?: any, arg3?: any): Promise<T>;
         authenticated(): boolean;
         isCurrent(): boolean;
 

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -320,7 +320,7 @@ declare namespace Parse {
         static fetchAll<T>(list: Object[], options: SuccessFailureOptions): Promise<T>;
         static fetchAllIfNeeded<T>(list: Object[], options: SuccessFailureOptions): Promise<T>;
         static destroyAll<T>(list: Object[], options?: Object.DestroyAllOptions): Promise<T>;
-        static saveAll<T>(list: Object[], options?: Object.SaveAllOptions): Promise<T>;
+        static saveAll<T extends Object>(list: T[], options?: Object.SaveAllOptions): Promise<T[]>;
 
         initialize(): void;
         add(attr: string, item: any): Object;
@@ -346,7 +346,7 @@ declare namespace Parse {
         previousAttributes(): any;
         relation(attr: string): Relation;
         remove(attr: string, item: any): any;
-        save<T>(options?: Object.SaveOptions, arg2?: any, arg3?: any): Promise<T>;
+        save<T extends Object>(options?: Object.SaveOptions, arg2?: any, arg3?: any): Promise<T>;
         set(key: string, value: any, options?: Object.SetOptions): boolean;
         setACL(acl: ACL, options?: SuccessFailureOptions): boolean;
         unset(attr: string, options?: any): any;
@@ -712,7 +712,7 @@ declare namespace Parse {
         signUp<T>(attrs: any, options?: SuccessFailureOptions): Promise<T>;
         logIn<T>(options?: SuccessFailureOptions): Promise<T>;
         fetch<T>(options?: SuccessFailureOptions): Promise<T>;
-        save<T>(arg1: any, arg2: any, arg3: any): Promise<T>;
+        save<T extends User>(options?: Object.SaveOptions, arg2?: any, arg3?: any): Promise<T>;
         authenticated(): boolean;
         isCurrent(): boolean;
 

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -1065,10 +1065,10 @@ declare namespace Parse {
      * Call this method first to set up your authentication tokens for Parse.
      * You can get your keys from the Data Browser on parse.com.
      * @param {String} applicationId Your Parse Application ID.
-     * @param {String} javaScriptKey Your Parse JavaScript Key.
+     * @param {String} javaScriptKey (optional) Your Parse JavaScript Key (Not needed for parse-server)
      * @param {String} masterKey (optional) Your Parse Master Key. (Node.js only!)
      */
-    function initialize(applicationId: string, javaScriptKey: string, masterKey?: string): void;
+    function initialize(applicationId: string, javaScriptKey?: string, masterKey?: string): void;
 
 }
 

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -845,8 +845,8 @@ declare namespace Parse {
         }
 
         interface FunctionResponse {
-            success?: (response: HttpResponse) => void;
-            error?: (response: HttpResponse) => void;
+            success?: (response: any) => void;
+            error?: (response: any) => void;
         }
 
         interface Cookie {

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -698,6 +698,7 @@ declare namespace Parse {
         static allowCustomUserClass(isAllowed: boolean): void;
         static become<T>(sessionToken: string, options?: SuccessFailureOptions): Promise<T>;
         static requestPasswordReset<T>(email: string, options?: SuccessFailureOptions): Promise<T>;
+        static extend(protoProps?: any, classProps?: any): any;
 
         signUp<T>(attrs: any, options?: SuccessFailureOptions): Promise<T>;
         logIn<T>(options?: SuccessFailureOptions): Promise<T>;

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -77,8 +77,8 @@ declare namespace Parse {
         static as<U>(resolvedValue: U): Promise<U>;
         static error<U>(error: U): Promise<U>;
         static is(possiblePromise: any): Boolean;
-        static when(promises: Promise<any>[]): Promise<any>;
-        static when(...promises: Promise<any>[]): Promise<any>;
+        static when(promises: IPromise<any>[]): Promise<any>;
+        static when(...promises: IPromise<any>[]): Promise<any>;
 
         always(callback: Function): Promise<T>;
         done(callback: Function): Promise<T>;

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -588,7 +588,7 @@ declare namespace Parse {
         endsWith(key: string, suffix: string): Query;
         equalTo(key: string, value: any): Query;
         exists(key: string): Query;
-        find<T>(options?: Query.FindOptions): Promise<T>;
+        find<T extends Object>(options?: Query.FindOptions): Promise<T[]>;
         first<T>(options?: Query.FirstOptions): Promise<T>;
         get(objectId: string, options?: Query.GetOptions): Promise<any>;
         greaterThan(key: string, value: any): Query;

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -927,7 +927,10 @@ declare namespace Parse {
 
     }
 
-    enum ErrorCode {
+    /*
+     * We need to inline the codes in order to make compilation work without this type definition as dependency.
+     */
+    const enum ErrorCode {
 
         OTHER_CAUSE = -1,
         INTERNAL_SERVER_ERROR = 1,

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -348,7 +348,8 @@ declare namespace Parse {
         previousAttributes(): any;
         relation(attr: string): Relation;
         remove(attr: string, item: any): any;
-        save<T extends Object>(options?: Object.SaveOptions, arg2?: any, arg3?: any): Promise<T>;
+        save<T extends Object>(attrs?: { [key: string]: any }, options?: Object.SaveOptions): Promise<T>;
+        save<T extends Object>(key: string, value: any, options?: Object.SaveOptions): Promise<T>;
         set(key: string, value: any, options?: Object.SetOptions): boolean;
         setACL(acl: ACL, options?: SuccessFailureOptions): boolean;
         unset(attr: string, options?: any): any;

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -322,6 +322,8 @@ declare namespace Parse {
         static destroyAll<T>(list: Object[], options?: Object.DestroyAllOptions): Promise<T>;
         static saveAll<T extends Object>(list: T[], options?: Object.SaveAllOptions): Promise<T[]>;
 
+        static registerSubclass<T extends Object>(className: string, clazz: new (options?: any) => T): void;
+
         initialize(): void;
         add(attr: string, item: any): Object;
         addUnique(attr: string, item: any): any;

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -656,6 +656,13 @@ declare namespace Parse {
         escape(attr: string): any;
     }
 
+    class Session extends Object {
+        static current(): Promise<Session>;
+
+        getSessionToken(): string;
+        isCurrentSessionRevocable(): boolean;
+    }
+
     /**
      * Routers map faux-URLs to actions, and fire events when routes are
      * matched. Creating a new one sets its `routes` hash, if not set statically.

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -643,6 +643,14 @@ declare namespace Parse {
         setName(name: string, options?: SuccessFailureOptions): any;
     }
 
+    class Config extends Object {
+        static get(options?: SuccessFailureOptions): Promise<Config>;
+        static current(): Config;
+
+        get(attr: string): any;
+        escape(attr: string): any;
+    }
+
     /**
      * Routers map faux-URLs to actions, and fire events when routes are
      * matched. Creating a new one sets its `routes` hash, if not set statically.

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -832,9 +832,9 @@ declare namespace Parse {
         }
 
         interface JobStatus {
-            error?: Function;
-            message?: Function;
-            success?: Function;
+            error?: (response: any) => void;
+            message?: (response: any) => void;
+            success?: (response: any) => void;
         }
 
         interface FunctionRequest {

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -859,7 +859,9 @@ declare namespace Parse {
         interface AfterDeleteRequest extends FunctionRequest {}
         interface BeforeDeleteRequest extends FunctionRequest {}
         interface BeforeDeleteResponse extends FunctionResponse {}
-        interface BeforeSaveRequest extends FunctionRequest {}
+        interface BeforeSaveRequest extends FunctionRequest {
+            object: Object;
+        }
         interface BeforeSaveResponse extends FunctionResponse {}
 
         function afterDelete(arg1: any, func?: (request: AfterDeleteRequest) => void): void;

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -307,7 +307,9 @@ declare namespace Parse {
      */
     class Object extends BaseObject {
 
-        id: any;
+        id: string;
+        createdAt: Date;
+        updatedAt: Date;
         attributes: any;
         cid: string;
         changed: boolean;

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -72,7 +72,7 @@ declare namespace Parse {
         then<U>(resolvedCallback: (...values: T[]) => U, rejectedCallback?: (reason: any) => U): IPromise<U>;
     }
 
-    class Promise<T> {
+    class Promise<T> implements IPromise<T> {
 
         static as<U>(resolvedValue: U): Promise<U>;
         static error<U>(error: U): Promise<U>;
@@ -85,8 +85,8 @@ declare namespace Parse {
         fail(callback: Function): Promise<T>;
         reject(error: any): void;
         resolve(result: any): void;
-        then<U>(resolvedCallback: (...values: T[]) => Promise<U>,
-                rejectedCallback?: (reason: any) => Promise<U>): IPromise<T>;
+        then<U>(resolvedCallback: (...values: T[]) => IPromise<U>,
+                rejectedCallback?: (reason: any) => IPromise<U>): IPromise<T>;
         then<U>(resolvedCallback: (...values: T[]) => U,
             rejectedCallback?: (reason: any) => IPromise<U>): IPromise<T>;
         then<U>(resolvedCallback: (...values: T[]) => U,

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -67,9 +67,9 @@ declare namespace Parse {
 
     interface IPromise<T> {
 
-        then<U>(resolvedCallback: (value: T) => IPromise<U>, rejectedCallback?: (reason: any) => IPromise<U>): IPromise<T>;
-        then<U>(resolvedCallback: (value: T) => U, rejectedCallback?: (reason: any) => IPromise<U>): IPromise<U>;
-        then<U>(resolvedCallback: (value: T) => U, rejectedCallback?: (reason: any) => U): IPromise<U>;
+        then<U>(resolvedCallback: (...values: T[]) => IPromise<U>, rejectedCallback?: (reason: any) => IPromise<U>): IPromise<T>;
+        then<U>(resolvedCallback: (...values: T[]) => U, rejectedCallback?: (reason: any) => IPromise<U>): IPromise<U>;
+        then<U>(resolvedCallback: (...values: T[]) => U, rejectedCallback?: (reason: any) => U): IPromise<U>;
     }
 
     class Promise<T> {
@@ -78,17 +78,18 @@ declare namespace Parse {
         static error<U>(error: U): Promise<U>;
         static is(possiblePromise: any): Boolean;
         static when(promises: Promise<any>[]): Promise<any>;
+        static when(...promises: Promise<any>[]): Promise<any>;
 
         always(callback: Function): Promise<T>;
         done(callback: Function): Promise<T>;
         fail(callback: Function): Promise<T>;
         reject(error: any): void;
         resolve(result: any): void;
-        then<U>(resolvedCallback: (value: T) => Promise<U>,
+        then<U>(resolvedCallback: (...values: T[]) => Promise<U>,
                 rejectedCallback?: (reason: any) => Promise<U>): IPromise<T>;
-        then<U>(resolvedCallback: (value: T) => U,
+        then<U>(resolvedCallback: (...values: T[]) => U,
             rejectedCallback?: (reason: any) => IPromise<U>): IPromise<T>;
-        then<U>(resolvedCallback: (value: T) => U,
+        then<U>(resolvedCallback: (...values: T[]) => U,
             rejectedCallback?: (reason: any) => U): IPromise<T>;
     }
 

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -75,7 +75,7 @@ declare namespace Parse {
     class Promise<T> implements IPromise<T> {
 
         static as<U>(resolvedValue: U): Promise<U>;
-        static error<U>(error: U): Promise<U>;
+        static error<U, V>(error: U): Promise<V>;
         static is(possiblePromise: any): Boolean;
         static when(promises: IPromise<any>[]): Promise<any>;
         static when(...promises: IPromise<any>[]): Promise<any>;

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -334,7 +334,7 @@ declare namespace Parse {
         dirtyKeys(): string[];
         escape(attr: string): string;
         existed(): boolean;
-        fetch<T>(options?: Object.FetchOptions): Promise<T>;
+        fetch<T extends Object>(options?: Object.FetchOptions): Promise<T>;
         get(attr: string): any;
         getACL(): ACL;
         has(attr: string): boolean;
@@ -711,7 +711,7 @@ declare namespace Parse {
 
         signUp<T>(attrs: any, options?: SuccessFailureOptions): Promise<T>;
         logIn<T>(options?: SuccessFailureOptions): Promise<T>;
-        fetch<T>(options?: SuccessFailureOptions): Promise<T>;
+        fetch<T extends User>(options?: SuccessFailureOptions): Promise<T>;
         save<T extends User>(options?: Object.SaveOptions, arg2?: any, arg3?: any): Promise<T>;
         authenticated(): boolean;
         isCurrent(): boolean;

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -855,14 +855,18 @@ declare namespace Parse {
             value?: string;
         }
 
-        interface AfterSaveRequest extends FunctionRequest {}
+        interface SaveRequest extends FunctionRequest {
+            object: Object;
+        }
+
+        interface AfterSaveRequest extends SaveRequest {}
         interface AfterDeleteRequest extends FunctionRequest {}
         interface BeforeDeleteRequest extends FunctionRequest {}
         interface BeforeDeleteResponse extends FunctionResponse {}
-        interface BeforeSaveRequest extends FunctionRequest {
-            object: Object;
+        interface BeforeSaveRequest extends SaveRequest {}
+        interface BeforeSaveResponse extends FunctionResponse {
+            success?: () => void;
         }
-        interface BeforeSaveResponse extends FunctionResponse {}
 
         function afterDelete(arg1: any, func?: (request: AfterDeleteRequest) => void): void;
         function afterSave(arg1: any, func?: (request: AfterSaveRequest) => void): void;

--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -67,7 +67,7 @@ declare namespace Parse {
 
     interface IPromise<T> {
 
-        then<U>(resolvedCallback: (...values: T[]) => IPromise<U>, rejectedCallback?: (reason: any) => IPromise<U>): IPromise<T>;
+        then<U>(resolvedCallback: (...values: T[]) => IPromise<U>, rejectedCallback?: (reason: any) => IPromise<U>): IPromise<U>;
         then<U>(resolvedCallback: (...values: T[]) => U, rejectedCallback?: (reason: any) => IPromise<U>): IPromise<U>;
         then<U>(resolvedCallback: (...values: T[]) => U, rejectedCallback?: (reason: any) => U): IPromise<U>;
     }
@@ -86,11 +86,11 @@ declare namespace Parse {
         reject(error: any): void;
         resolve(result: any): void;
         then<U>(resolvedCallback: (...values: T[]) => IPromise<U>,
-                rejectedCallback?: (reason: any) => IPromise<U>): IPromise<T>;
+                rejectedCallback?: (reason: any) => IPromise<U>): IPromise<U>;
         then<U>(resolvedCallback: (...values: T[]) => U,
-            rejectedCallback?: (reason: any) => IPromise<U>): IPromise<T>;
+            rejectedCallback?: (reason: any) => IPromise<U>): IPromise<U>;
         then<U>(resolvedCallback: (...values: T[]) => U,
-            rejectedCallback?: (reason: any) => U): IPromise<T>;
+            rejectedCallback?: (reason: any) => U): IPromise<U>;
     }
 
     interface IBaseObject {


### PR DESCRIPTION
case 2. Improvement to existing type definition.

All changes in close alignment to the [Parse JS SDK](https://parse.com/docs/js/api/) and the sources. All fixes were applied to make our (stable & tested) company's cloud code compile after transition to type script.

In particular this PR does the following changes:
- adds missing methods & properties (such as `Parse.Object#createdAt` or `Parse.Config`)
- fixes wrong/incomplete type signatures (such as `Parse.User#extend` or `Parse.Promise.then`)
- makes type definitions more accurate by replacing any by actual types (e.g. in `Parse.Object#fetch`)

Details in the individual commit messages.
