### PR TITLE
Fixes conflict with Node.d.ts on the Error object.

### DIFF
--- a/microsoft-ajax/microsoft.ajax.d.ts
+++ b/microsoft-ajax/microsoft.ajax.d.ts
@@ -257,14 +257,6 @@ interface ErrorConstructor {
     //#endregion
 }
 
-interface Error {
-    /**
-    * Updates the fileName and lineNumber properties of an Error instance to indicate where the error was thrown instead of where the error was created. Use this function if you are creating custom error types.
-    */
-    popStackFrame(): void;
-}
-
-
 
 interface String {
 


### PR DESCRIPTION
Fixes the following error caused by adding custom method to the global Error object  

Conflicts with node.d.ts

```
 error TS2420: Class 'AssertionError' incorrectly implements interface 'Error'.
  Property 'popStackFrame' is missing in type 'AssertionError'.
```
