### PR TITLE
I18next: reverting default export

### DIFF
--- a/i18next-sprintf-postprocessor/i18next-sprintf-postprocessor-tests.ts
+++ b/i18next-sprintf-postprocessor/i18next-sprintf-postprocessor-tests.ts
@@ -1,6 +1,6 @@
 ///<reference path="./i18next-sprintf-postprocessor.d.ts"/>
 
-import i18next from "i18next";
+import * as i18next from "i18next";
 import * as sprintfA from "i18next-sprintf-postprocessor";
 import sprintfB from "i18next-sprintf-postprocessor/dist/commonjs";
 

--- a/i18next/i18next-tests.ts
+++ b/i18next/i18next-tests.ts
@@ -5,7 +5,7 @@
 /// <reference path="../jquery/jquery.d.ts" />
 /// <reference path="i18next.d.ts" />
 
-import i18n from 'i18next';
+import * as i18n from 'i18next';
 
 i18n.init({
     debug: true,

--- a/i18next/i18next.d.ts
+++ b/i18next/i18next.d.ts
@@ -125,5 +125,5 @@ declare namespace I18next {
 declare module 'i18next' {
     var i18n:I18next.I18n;
 
-    export default i18n;
+    export = i18n;
 }


### PR DESCRIPTION
We should revert https://github.com/DefinitelyTyped/DefinitelyTyped/pull/9884 because:
1. i18next [index.js](https://github.com/i18next/i18next/blob/master/index.js) does not have default export.
2. For those who use 

```
"target": "es2015", // or "es6"
"module": "commonjs"
```

typescript compiler options and babel with `es2015` preset current definitions are broken.

1 is the main reason.

I migrated my project to `"target": "es2015", "module": "es2015", "allowSyntheticDefaultImports": true` options and now I can `import i18next from 'i18next'` though I have `export = i18n` in type definitions because babel do some magic and wraps default imports with

```
function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
```

like

```
var _i18next = require('i18next');
var _i18next2 = _interopRequireDefault(_i18next);
```

I suggest @zakjan to do the same.

Also it may be useful to read following links:
- https://github.com/Microsoft/TypeScript/pull/5577
- https://matthewrwilton.wordpress.com/2016/03/18/typescript-to-es2015-es6-to-es5-via-babel-6/
- https://github.com/Microsoft/TypeScript/issues/4337
