### PR TITLE
Added type definition for react-flexr

### DIFF
--- a/react-flexr/react-flexr-tests.tsx
+++ b/react-flexr/react-flexr-tests.tsx
@@ -76,7 +76,7 @@ class App1 extends React.Component<any, any> {
 }
 
 const isMobile = /iP(hone|od)|Mobile/;
-function textFxn(req, res) {
+function textFxn(req: any, res: any): void {
     if ( isMobile.test( req.headers['user-agent'] ) ) {
         setBreakpoints(['palm', 'portable'])
     }

--- a/react-flexr/react-flexr-tests.tsx
+++ b/react-flexr/react-flexr-tests.tsx
@@ -1,9 +1,9 @@
 /// <reference path="react-flexr.d.ts"/>
 /// <reference path="../react/react-dom.d.ts"/>
 
-import * as React from 'react';
+import * as React from "react";
 import * as ReactDOMServer from "react-dom/server";
-import { Grid, Cell, findMatch, setBreakpoints, findBreakpoints, getCurrentBreakpoints, optimizedResize, palm, lap, portable, desk } from 'react-flexr';
+import { Grid, Cell, findMatch, setBreakpoints, findBreakpoints, getCurrentBreakpoints, optimizedResize, palm, lap, portable, desk } from "react-flexr";
 
 class Example extends React.Component<any, any> {
     render() {
@@ -21,7 +21,7 @@ class Example2 extends React.Component<any, any> {
     render() {
         return (
             <Grid>
-                <Cell size='6/12'>
+                <Cell size="6/12">
                     Fills Half
                 </Cell>
 
@@ -37,15 +37,15 @@ class Example2 extends React.Component<any, any> {
                     Fills a quarter on lap and half everywhere else
                 </Cell>
 
-                <Cell size='3/12'>
+                <Cell size="3/12">
                     Fills a quarter
                 </Cell>
 
-                <Cell palm='3/12' lap='1/2'>
+                <Cell palm="3/12" lap="1/2">
                     Fills a quarter on palm (mobile), half on lap and dynamicly sized everywhere else
                 </Cell>
 
-                <Cell palm='hidden' size='1/2'>
+                <Cell palm="hidden" size="1/2">
                     Hidden on palm, half width otherwise
                 </Cell>
             </Grid>
@@ -55,9 +55,9 @@ class Example2 extends React.Component<any, any> {
 
 class App1 extends React.Component<any, any> {
     render() {
-        const isPalm = findMatch('palm');
+        const isPalm = findMatch("palm");
 
-        if (isPalm) console.log( 'only logged in palm' );
+        if (isPalm) console.log( "only logged in palm" );
 
         return (
             <div>
@@ -67,7 +67,7 @@ class App1 extends React.Component<any, any> {
                     : null }
 
                 <h1>Allows Multiple Matches</h1>
-                { findMatch('desk', 'lap')
+                { findMatch("desk", "lap")
                     ? <h2>Lap or Desk</h2>
                     : null }
             </div>
@@ -77,15 +77,15 @@ class App1 extends React.Component<any, any> {
 
 const isMobile = /iP(hone|od)|Mobile/;
 function textFxn(req: any, res: any): void {
-    if ( isMobile.test( req.headers['user-agent'] ) ) {
-        setBreakpoints(['palm', 'portable'])
+    if ( isMobile.test( req.headers["user-agent"] ) ) {
+        setBreakpoints(["palm", "portable"])
     }
     else {
-        setBreakpoints(['desk'])
+        setBreakpoints(["desk"])
     }
     const html = ReactDOMServer.renderToString( <App1 />);
 
-    res.send( '<!doctype html>' + html );
+    res.send( "<!doctype html>" + html );
 }
 
 const breakpoints: string[] | boolean = findBreakpoints();
@@ -94,7 +94,7 @@ class App2 extends React.Component<any, any> {
     componentDidMount() {
         optimizedResize.init( () => {
             if ( findBreakpoints() ) {
-                console.log('New Breakpoints');
+                console.log("New Breakpoints");
                 this.forceUpdate();
             }
         });

--- a/react-flexr/react-flexr-tests.tsx
+++ b/react-flexr/react-flexr-tests.tsx
@@ -1,0 +1,106 @@
+/// <reference path="react-flexr.d.ts"/>
+/// <reference path="../react/react-dom.d.ts"/>
+
+import * as React from 'react';
+import * as ReactDOMServer from "react-dom/server";
+import { Grid, Cell, findMatch, setBreakpoints, findBreakpoints, getCurrentBreakpoints, optimizedResize, palm, lap, portable, desk } from 'react-flexr';
+
+class Example extends React.Component<any, any> {
+    render() {
+        return (
+            <Grid>
+                <Cell>1/3</Cell>
+                <Cell>1/3</Cell>
+                <Cell>1/3</Cell>
+            </Grid>
+        );
+    }
+}
+
+class Example2 extends React.Component<any, any> {
+    render() {
+        return (
+            <Grid>
+                <Cell size='6/12'>
+                    Fills Half
+                </Cell>
+
+                <Cell>
+                    Fills Rest.. (Yay for Flexbox)
+                </Cell>
+
+                <Cell size={200} lap={150}>
+                    Fills 150px on lap and 200px everywhere else
+                </Cell>
+
+                <Cell size={0.5} lap={0.25}>
+                    Fills a quarter on lap and half everywhere else
+                </Cell>
+
+                <Cell size='3/12'>
+                    Fills a quarter
+                </Cell>
+
+                <Cell palm='3/12' lap='1/2'>
+                    Fills a quarter on palm (mobile), half on lap and dynamicly sized everywhere else
+                </Cell>
+
+                <Cell palm='hidden' size='1/2'>
+                    Hidden on palm, half width otherwise
+                </Cell>
+            </Grid>
+        );
+    }
+}
+
+class App1 extends React.Component<any, any> {
+    render() {
+        const isPalm = findMatch('palm');
+
+        if (isPalm) console.log( 'only logged in palm' );
+
+        return (
+            <div>
+                <h1>Only visible in palm:</h1>
+                { isPalm
+                    ? <h2>Palm</h2>
+                    : null }
+
+                <h1>Allows Multiple Matches</h1>
+                { findMatch('desk', 'lap')
+                    ? <h2>Lap or Desk</h2>
+                    : null }
+            </div>
+        );
+    }
+}
+
+const isMobile = /iP(hone|od)|Mobile/;
+function textFxn(req, res) {
+    if ( isMobile.test( req.headers['user-agent'] ) ) {
+        setBreakpoints(['palm', 'portable'])
+    }
+    else {
+        setBreakpoints(['desk'])
+    }
+    const html = ReactDOMServer.renderToString( <App1 />);
+
+    res.send( '<!doctype html>' + html );
+}
+
+const breakpoints: string[] | boolean = findBreakpoints();
+
+class App2 extends React.Component<any, any> {
+    componentDidMount() {
+        optimizedResize.init( () => {
+            if ( findBreakpoints() ) {
+                console.log('New Breakpoints');
+                this.forceUpdate();
+            }
+        });
+    }
+}
+
+const breakpoints2: string[] = getCurrentBreakpoints();
+
+const someStrings: string[] = [palm, lap, portable, desk];

--- a/react-flexr/react-flexr.d.ts
+++ b/react-flexr/react-flexr.d.ts
@@ -1,0 +1,59 @@
+// Type definitions for react-flexr v2.0.2
+// Project: https://github.com/kodyl/react-flexr
+// Definitions by: Jeffery Grajkowski <https://github.com/pushplay>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../react/react.d.ts" />
+
+declare namespace __ReactFlexr {
+    export import React = __React;
+
+    interface GridProps extends React.Props<Grid> {
+        align?: "top" | "center" | "bottom";
+        hAlign?: "left" | "center" | "right";
+        gutter?: string;
+        flexCells?: boolean;
+    }
+
+    export class Grid extends React.Component<GridProps, {}> {
+    }
+
+    interface CellProps extends React.Props<Cell> {
+        align?: "top" | "center" | "bottom";
+        gutter?: string;
+        flex?: boolean;
+        size?: string | number;
+        palm?: string | number;
+        lap?: string | number;
+        portable?: string | number;
+        desk?: string | number;
+    }
+
+    export class Cell extends React.Component<CellProps, {}> {
+    }
+
+    interface OptimizedResize {
+        init: (callback: () => void) => void;
+    }
+
+    export const optimizedResize: OptimizedResize;
+
+    export type ErgonomicType = "palm" | "lap" | "portable" | "desk";
+
+    export const findMatch: (...arguments: ErgonomicType[]) => boolean;
+
+    export const setBreakpoints: (breakpoints: ErgonomicType[]) => void;
+
+    export const findBreakpoints: () => ErgonomicType[] | boolean;
+
+    export const getCurrentBreakpoints: () => ErgonomicType[];
+
+    export const palm: string;
+    export const lap: string;
+    export const portable: string;
+    export const desk: string;
+}
+
+declare module "react-flexr" {
+    export = __ReactFlexr;
+}

--- a/react-flexr/react-flexr.d.ts
+++ b/react-flexr/react-flexr.d.ts
@@ -9,9 +9,26 @@ declare namespace __ReactFlexr {
     export import React = __React;
 
     interface GridProps extends React.Props<Grid> {
+        /**
+         * Vertical Align Sub Cells: top, center, bottom
+         */
         align?: "top" | "center" | "bottom";
+
+        /**
+         * Horizontal Align Sub Cells: left, center, right
+         */
         hAlign?: "left" | "center" | "right";
+
+        /**
+         * Override default gutter: '1em', '5%', '10px', etc.
+         * Propagates downwards. Cells inside this Grid component
+         * will use the same gutter.
+         */
         gutter?: string;
+
+        /**
+         * All sub cells will be full height.
+         */
         flexCells?: boolean;
     }
 
@@ -19,19 +36,59 @@ declare namespace __ReactFlexr {
     }
 
     interface CellProps extends React.Props<Cell> {
+        /**
+         * Vertical Align This Cell: top, center, bottom
+         */
         align?: "top" | "center" | "bottom";
+
+        /**
+         * Override default gutter: '1em', '5%', '10px', etc.
+         */
         gutter?: string;
+
+        /**
+         * Cell will be full height.
+         */
         flex?: boolean;
+
+        /**
+         * Takes a fraction. e.g. 1/6
+         */
         size?: string | number;
+
+        /**
+         * Like size, but only for palm devices.
+         * Accepts 'hidden' as well.
+         */
         palm?: string | number;
+
+        /**
+         * Like size, but only for lap devices.
+         * Accepts 'hidden' as well.
+         */
         lap?: string | number;
+
+        /**
+         * Like size, but only for ( palm + lap ) devices.
+         * Accepts 'hidden' as well.
+         */
         portable?: string | number;
+
+        /**
+         * Like size, but only for desk devices.
+         * Accepts 'hidden' as well.
+         */
         desk?: string | number;
     }
 
     export class Cell extends React.Component<CellProps, {}> {
     }
 
+    /**
+     * Simple resize event throttler. Usefull for force updating when the
+     * app have been resized. For best performance, use it in your main
+     * app component in the componentDidMount life cycle.
+     */
     interface OptimizedResize {
         init: (callback: () => void) => void;
     }
@@ -40,17 +97,53 @@ declare namespace __ReactFlexr {
 
     export type ErgonomicType = "palm" | "lap" | "portable" | "desk";
 
+    /**
+     * The internal function that Flexr uses to check which ergonomic
+     * state it's currently in. It's really useful if you have components
+     * outside the grid, that you want to show/hide/manipulate passed properties
+     * or stuff in your lifecycle hooks.
+     */
     export const findMatch: (...arguments: ErgonomicType[]) => boolean;
 
+    /**
+     * It's posible to force flexr to be in a specific ergonomic state. This is
+     * primarily usefull when rendering on the server. E.g. looking at the user
+     * agent string on rendering the app in palm/portable if it's an iOS/iPhone
+     * or lap/portable if iOS/iPad.
+     */
     export const setBreakpoints: (breakpoints: ErgonomicType[]) => void;
 
+    /**
+     * Force flexr to find the current breakpoints. Returns an array of the
+     * current breakpoints that flexr matches in. If they haven't changed since
+     * the last time findBreakpoints() was called, false will be returned. Use
+     * in combination with optimizedResize.
+     */
     export const findBreakpoints: () => ErgonomicType[] | boolean;
 
+    /**
+     * Returns an array of current breakpoints.
+     */
     export const getCurrentBreakpoints: () => ErgonomicType[];
 
+    /**
+     * The ergonomic breakpoint media query that flexr uses internally.
+     */
     export const palm: string;
+
+    /**
+     * The ergonomic breakpoint media query that flexr uses internally.
+     */
     export const lap: string;
+
+    /**
+     * The ergonomic breakpoint media query that flexr uses internally.
+     */
     export const portable: string;
+
+    /**
+     * The ergonomic breakpoint media query that flexr uses internally.
+     */
     export const desk: string;
 }
 


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
