### PR TITLE
Add missing CryptoJS.mode.CBC according to doc

### DIFF
--- a/crypto-js/crypto-js.d.ts
+++ b/crypto-js/crypto-js.d.ts
@@ -93,6 +93,7 @@ declare namespace CryptoJS {
 			Base64: Encoder;
 		};
 		mode: {
+			CBC: Mode;
 			CFB: Mode;
 			CTR: Mode;
 			CTRGladman: Mode;


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

According to the doc: https://github.com/brix/crypto-js/blob/develop/docs/QuickStartGuide.wiki#block-modes-and-padding
