### PR TITLE
Allow koa-mount to be impoted

### DIFF
--- a/koa-mount/koa-mount.d.ts
+++ b/koa-mount/koa-mount.d.ts
@@ -19,5 +19,5 @@ declare module "koa-mount" {
 
     function mount(prefix: string, app: Koa): Function;
 
-    export = mount;
+    export default mount;
 }


### PR DESCRIPTION
import \* as mount from 'koa-mount'; 
rather than
require('koa-mount');
