### PR TITLE
no jQuery dependecy for jquery.autosize

### DIFF
--- a/jquery.autosize/jquery.autosize.d.ts
+++ b/jquery.autosize/jquery.autosize.d.ts
@@ -8,7 +8,6 @@ declare namespace autosize {
     interface AutosizeStatic {
         (el: Element): void;
         (el: NodeList): void;
-        (el: JQuery): void;
     }
 }
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

The autosize plugin have break his dependency with jQuery since the version 2.

reference:
https://github.com/jackmoore/autosize
The summary say it's a "stand-alone script"
If you take a look to packe.json and bower.json you can see that they are no dependency to jQuery.
If you see the source code (only 218 line) https://github.com/jackmoore/autosize/blob/master/src/autosize.js
You can see that they are no reference to jQuery.
