### PR TITLE
Added missing preflightContinue option to cors type definition.

### DIFF
--- a/cors/cors.d.ts
+++ b/cors/cors.d.ts
@@ -16,6 +16,7 @@ declare module "cors" {
             exposedHeaders?: any;
             credentials?: boolean;
             maxAge?: number;
+            preflightContinue?: boolean;
         }
     }
 


### PR DESCRIPTION
Solve issue #10026 related to a missing option for the cors express middleware..
