### PR TITLE
 Improvement to node type definition

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1542,10 +1542,10 @@ declare module "fs" {
     export function close(fd: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
     export function closeSync(fd: number): void;
     export function open(path: string | Buffer, flags: string, callback?: (err: NodeJS.ErrnoException, fd: number) => any): void;
+    export function open(path: string | Buffer, flags: number, mode: number, callback?: (err: NodeJS.ErrnoException, fd: number) => any): void;
     export function open(path: string | Buffer, flags: string, mode: number, callback?: (err: NodeJS.ErrnoException, fd: number) => any): void;
-    export function open(path: string | Buffer, flags: string, mode: string, callback?: (err: NodeJS.ErrnoException, fd: number) => any): void;
+    export function openSync(path: string | Buffer, flags: number, mode?: number): number;
     export function openSync(path: string | Buffer, flags: string, mode?: number): number;
-    export function openSync(path: string | Buffer, flags: string, mode?: string): number;
     export function utimes(path: string | Buffer, atime: number, mtime: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
     export function utimes(path: string | Buffer, atime: Date, mtime: Date, callback?: (err?: NodeJS.ErrnoException) => void): void;
     export function utimesSync(path: string | Buffer, atime: number, mtime: number): void;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

From Node.js API Reference (https://nodejs.org/dist/latest-v6.x/docs/api/fs.html#fs_fs_open_path_flags_mode_callback):

fs.open(path, flags[, mode], callback)#
Added in: v0.0.2
path <String> | <Buffer>
flags <String> | <Number>
mode <Integer>
callback <Function>

fs.openSync(path, flags[, mode])#
Added in: v0.1.21
path <String> | <Buffer>
flags <String> | <Number>
mode <Integer>
