### PR TITLE
Allow es6 import for addons-create-fragment/addons-shallow-compare

### DIFF
--- a/react/react-addons-create-fragment.d.ts
+++ b/react/react-addons-create-fragment.d.ts
@@ -12,5 +12,6 @@ declare namespace __React {
 }
 
 declare module "react-addons-create-fragment" {
-    export = __React.__Addons.createFragment;
+    var createFragment: typeof __React.__Addons.createFragment;
+    export = createFragment;
 }

--- a/react/react-addons-shallow-compare.d.ts
+++ b/react/react-addons-shallow-compare.d.ts
@@ -15,5 +15,6 @@ declare namespace __React {
 }
 
 declare module "react-addons-shallow-compare" {
-    export = __React.__Addons.shallowCompare;
+    var shallowCompare: typeof __React.__Addons.shallowCompare;
+    export = shallowCompare;
 }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- Allow es6 import all for createFragment/shallowCompare

``` ts
import * as shallowCompare from "react-addons-shallow-compare";
import * as createFragment from "react-addons-create-fragment";
```

Current way of importing:

``` ts
import shallowCompare = require("react-addons-shallow-compare");
```

should work too
