### PR TITLE
Improvement to node type definition

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1541,11 +1541,9 @@ declare module "fs" {
     export function readdirSync(path: string | Buffer): string[];
     export function close(fd: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
     export function closeSync(fd: number): void;
-    export function open(path: string | Buffer, flags: string, callback?: (err: NodeJS.ErrnoException, fd: number) => any): void;
-    export function open(path: string | Buffer, flags: number, mode: number, callback?: (err: NodeJS.ErrnoException, fd: number) => any): void;
-    export function open(path: string | Buffer, flags: string, mode: number, callback?: (err: NodeJS.ErrnoException, fd: number) => any): void;
-    export function openSync(path: string | Buffer, flags: number, mode?: number): number;
-    export function openSync(path: string | Buffer, flags: string, mode?: number): number;
+    export function open(path: string | Buffer, flags: string | number, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;
+    export function open(path: string | Buffer, flags: string | number, mode: number, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;
+    export function openSync(path: string | Buffer, flags: string | number, mode?: number): number;
     export function utimes(path: string | Buffer, atime: number, mtime: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
     export function utimes(path: string | Buffer, atime: Date, mtime: Date, callback?: (err?: NodeJS.ErrnoException) => void): void;
     export function utimesSync(path: string | Buffer, atime: number, mtime: number): void;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

From Node.js API Reference (https://nodejs.org/dist/latest-v6.x/docs/api/fs.html#fs_fs_open_path_flags_mode_callback):

fs.open(path, flags[, mode], callback)#
Added in: v0.0.2
path <String> | <Buffer>
flags <String> | <Number>
mode <Integer>
callback <Function>

Only mode is optional in open. Also instead of pure function overloads definitions can be re-written using union type annotaion for open and openSync.
