### PR TITLE
Fix `request.raw.req` type

### DIFF
--- a/hapi/hapi.d.ts
+++ b/hapi/hapi.d.ts
@@ -964,7 +964,7 @@ declare module "hapi" {
 		payload: string;
 		rawPayload: Buffer;
 		raw: {
-			req: http.ClientRequest;
+			req: http.IncomingMessage;
 			res: http.ServerResponse
 		};
 		result: string;
@@ -1199,7 +1199,7 @@ declare module "hapi" {
 		query: any;
 		/**  an object containing the Node HTTP server objects. Direct interaction with these raw objects is not recommended.*/
 		raw: {
-			req: http.ClientRequest;
+			req: http.IncomingMessage;
 			res: http.ServerResponse;
 		};
 		/** the route public interface.*/


### PR DESCRIPTION
Per the hapi [code](https://github.com/hapijs/hapi/blob/master/lib/request.js) and [documentation](http://hapijs.com/api#request-object) the correct type for the raw http request object `request.raw.req` is actually `http.IncomingMessage` and not `http.ClientRequest`.
