### PR TITLE
sqlite3: add overloads with params and callback

### DIFF
--- a/sqlite3/sqlite3-tests.ts
+++ b/sqlite3/sqlite3-tests.ts
@@ -32,8 +32,15 @@ function readAllRows() {
         rows.forEach(function (row) {
             console.log(row.id + ": " + row.info);
         });
-        closeDb();
+        readSomeRows();
     });
+}
+
+function readSomeRows() {
+    console.log("readAllRows lorem");
+    db.each("SELECT rowid AS id, info FROM lorem WHERE rowid < ? ", 5, function(err, row) {
+        console.log(row.id + ": " + row.info);
+    }, closeDb);
 }
 
 function closeDb() {
@@ -64,7 +71,7 @@ db.serialize(function() {
 db.serialize(function() {
   // These two queries will run sequentially.
   db.run("CREATE TABLE foo (num)");
-  db.run("INSERT INTO foo VALUES (?)", 1, function() {
+  db.run("INSERT INTO foo VALUES (?)", 1, function(err) {
     // These queries will run in parallel and the second query will probably
     // fail because the table might not exist yet.
     db.run("CREATE TABLE bar (num)");
@@ -83,6 +90,9 @@ db.run("UPDATE tbl SET name = $name WHERE id = $id", {
   $id: 2,
   $name: "bar"
 });
+db.run("UPDATE tbl SET name = $name WHERE id = $id", { $id: 2, $name: "bar" },
+  function(err) { }
+);
 
 db.run("UPDATE tbl SET name = ?5 WHERE id = ?", {
   1: 2,

--- a/sqlite3/sqlite3.d.ts
+++ b/sqlite3/sqlite3.d.ts
@@ -31,15 +31,19 @@ declare module "sqlite3" {
         public finalize(callback?: (err: Error) => void): Statement;
         
         public run(callback?: (err: Error) => void): Statement;
+        public run(params: any, callback?: (err: Error) => void): Statement;
         public run(...params: any[]): Statement;
         
         public get(callback?: (err: Error, row: any) => void): Statement;
+        public get(params: any, callback?: (err: Error, row: any) => void): Statement;
         public get(...params: any[]): Statement;
         
         public all(callback?: (err: Error, rows: any[]) => void): Statement;
+        public all(params: any, callback?: (err: Error, rows: any[]) => void): Statement;
         public all(...params: any[]): Statement;
         
         public each(callback?: (err: Error, row: any) => void, complete?: (err: Error, count: number) => void): Statement;
+        public each(params: any, callback?: (err: Error, row: any) => void, complete?: (err: Error, count: number) => void): Statement;
         public each(...params: any[]): Statement;
     }
     
@@ -50,20 +54,25 @@ declare module "sqlite3" {
         public close(callback?: (err: Error) => void): void;
         
         public run(sql: string, callback?: (err: Error) => void): Database;
+        public run(sql: string, params: any, callback?: (err: Error) => void): Database;
         public run(sql: string, ...params: any[]): Database;
         
         public get(sql: string, callback?: (err: Error, row: any) => void): Database;
+        public get(sql: string, params: any, callback?: (err: Error, row: any) => void): Database;
         public get(sql: string, ...params: any[]): Database;
         
         public all(sql: string, callback?: (err: Error, rows: any[]) => void): Database;
+        public all(sql: string, params: any, callback?: (err: Error, rows: any[]) => void): Database;
         public all(sql: string, ...params: any[]): Database;
         
         public each(sql: string, callback?: (err: Error, row: any) => void, complete?: (err: Error, count: number) => void): Database;
+        public each(sql: string, params: any, callback?: (err: Error, row: any) => void, complete?: (err: Error, count: number) => void): Database;
         public each(sql: string, ...params: any[]): Database;
         
         public exec(sql: string, callback?: (err: Error) => void): Database;
         
         public prepare(sql: string, callback?: (err: Error) => void): Statement;
+        public prepare(sql: string, params: any, callback?: (err: Error) => void): Statement;
         public prepare(sql: string, ...params: any[]): Statement;
         
         public serialize(callback?: () => void): void;


### PR DESCRIPTION
from: https://github.com/mapbox/node-sqlite3/wiki/API

> Database#run(sql, [param, ...], [callback])
> ... There are three ways of passing bind parameters: directly in the
> function's arguments, as an array, and as an object for named
> parameters. ...

We can support the last two parameter passing options even if a callback
is given.
