### PR TITLE
mobx & mobx-react typings update (formerly known as mobservable / mobservable-react)

### DIFF
--- a/mobx-react/mobx-react-tests.ts
+++ b/mobx-react/mobx-react-tests.ts
@@ -1,0 +1,61 @@
+/// <reference path="./mobx-react.d.ts"/>
+/// <reference path="../react/react-global.d.ts" />
+
+import {observer} from 'mobx-react';
+
+{
+    let c1 = observer(React.createClass({
+        getDefaultProps() {
+            return {
+                test: "hi"
+            };
+        },
+
+        render: function() {
+            return React.createElement("div");
+        }
+    }));
+
+    let c1Factory = React.createFactory(c1);
+    ReactDOM.render(c1Factory({
+        test: "hello"
+    }), null);
+}
+
+@observer
+class TestComponent extends React.Component<{ test: string },{}> {
+    render() {
+        return React.createElement("div");
+    }
+}
+
+{
+    let c2Factory = React.createFactory(TestComponent);
+    ReactDOM.render(c2Factory({
+        test: "hello" 
+    }) , null);
+}
+
+{
+    var c3 = observer((props: { test: string }) => React.createElement("div"));
+    var c3Factory = React.createFactory(c3); //without JSX
+    ReactDOM.render(c3Factory({
+        test: "hello"
+    }), null);
+}
+
+
+class TestComponent2 extends React.Component<{ test: string },{}> {
+    render() {
+        return React.createElement("div");
+    }
+}
+{
+    // Does not work properly in typescript 1.6.2 without cast :'(
+    // Argument of type 'typeof TestComponent2 | void' is not assignable to parameter of type 'ComponentClass<{ test: string; }>'.
+    // Type 'void' is not assignable to type 'ComponentClass<{ test: string; }>'.
+    let c4Factory = React.createFactory(<React.ClassicComponentClass<{test:string}>><any> observer(TestComponent2));
+    ReactDOM.render(c4Factory({
+        test: "hello" 
+    }) , null);
+}

--- a/mobx-react/mobx-react.d.ts
+++ b/mobx-react/mobx-react.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for mobx v1.0.0
+// Project: https://github.com/mweststrate/mobx-react
+// Definitions by: Michel Weststrate <https://github.com/mweststrate/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../react/react-global.d.ts" />
+
+declare module "mobx-react" {
+    /**
+     * Turns a React component or stateless render function into a reactive component.
+     */
+    export function observer<P>(clazz: React.ClassicComponentClass<P>): React.ClassicComponentClass<P>;
+    export function observer<TFunction extends React.ComponentClass<any>>(target: TFunction): void; // decorator signature
+    export function observer<P>(clazz: React.ComponentClass<P>): React.ComponentClass<P>;
+    export function observer<P>(renderFunction: (props: P) => React.ReactElement<any>): React.ClassicComponentClass<P>;
+}

--- a/mobx/mobx-tests.ts
+++ b/mobx/mobx-tests.ts
@@ -1,0 +1,56 @@
+/// <reference path="./mobx.d.ts"/>
+import {observable, autorun} from "mobx";
+
+var v = observable(3);
+v.autorun(() => {});
+
+var a = observable([1,2,3]);
+
+class Order {
+    @observable price:number = 3;
+    @observable amount:number = 2;
+    @observable orders:string[] = [];
+
+    @observable get total() {
+        return this.amount * this.price * (1 + this.orders.length);
+    }
+}
+
+export function testObservable() {
+    var a = observable(3);
+    var b = autorun(() => a() * 2);
+}
+
+export function testAnnotations() {
+    var order1totals:number[] = [];
+    var order1 = new Order();
+    var order2 = new Order();
+
+    var disposer = autorun(() => {
+        order1totals.push(order1.total)
+    });
+
+    order2.price = 4;
+    order1.amount = 1;
+
+    order2.orders.push('bla');
+
+    order1.orders.splice(0,0,'boe', 'hoi');
+
+    disposer();
+    order1.orders.pop();
+};
+
+export function testTyping() {
+    var ar:Mobx.IObservableArray<number> = observable([1,2]);
+    ar.autorun((d:Mobx.IArrayChange<number>|Mobx.IArraySplice<number>) => {
+        console.log(d.type);
+    });
+
+    var ar2:Mobx.IObservableArray<number> = observable([1,2]);
+    ar2.autorun((d:Mobx.IArrayChange<number>|Mobx.IArraySplice<number>) => {
+        console.log(d.type);
+    });
+
+    var x:Mobx.IObservableValue<Object> = observable(3);
+}

--- a/mobx/mobx.d.ts
+++ b/mobx/mobx.d.ts
@@ -1,0 +1,259 @@
+// Type definitions for mobx v1.0.0
+// Project: https://mweststrate.github.io/mobservable
+// Definitions by: Michel Weststrate <https://github.com/mweststrate/>
+// Updated by: Ryan Megidov <https://github.com/nightwolfz/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+
+interface _IMobxStatic {
+    /**
+     * Extends an object with reactive capabilities.
+     * @param target the object to which reactive properties should be added
+     * @param properties the properties that should be added and made reactive
+     * @returns targer
+     */
+    extendObservable(target: Object, properties: Object): Object;
+
+    /**
+     * Returns true if the provided value is reactive.
+     * @param value object, function or array
+     * @param propertyName if propertyName is specified, checkes whether value.propertyName is reactive.
+     */
+    isObservable(value: any, propertyName?:string): boolean;
+
+    /**
+     * Returns true if the provided value is reactive.
+     * @param value map
+     * @param propertyName if propertyName is specified, checkes whether value.propertyName is reactive.
+     */
+    isObservableMap(value: Map<string, any>, propertyName?:string): boolean;
+
+    /**
+     * Returns true if the provided value is reactive.
+     * @param value array
+     * @param propertyName if propertyName is specified, checkes whether value.propertyName is reactive.
+     */
+    isObservableArray(value: Array<any>, propertyName?:string): boolean;
+
+    /**
+     * Returns true if the provided value is reactive.
+     * @param value object
+     * @param propertyName if propertyName is specified, checkes whether value.propertyName is reactive.
+     */
+    isObservableObject(value: Object, propertyName?:string): boolean;
+
+    /**
+     * Can be used in combination with makeReactive / extendReactive.
+     * Enforces that a reference to 'value' is stored as property,
+     * but that 'value' itself is not turned into something reactive.
+     * Future assignments to the same property will inherit this behavior.
+     * @param value initial value of the reactive property that is being defined.
+     */
+    asReference<T>(value: any): {value:T};
+
+    /**
+     * ES6 / Typescript decorator which can to make class properties and getter functions reactive.
+     */
+    observable(target: Object, key?: string): any; // decorator / annotation
+
+    /**
+     * Technically the same as @observable but for getter properties.
+     * @param expression or object {asStructure: true}
+     */
+    computed(expression: Mobx.Lambda|{asStructure: boolean}): any; // decorator / annotation
+
+    /**
+     * Similar to Mobx.observe() but much faster when adding items but doesn't support enumerability
+     * @param target The array to make observable
+     */
+    fastArray(target: Array<any>):any;
+
+    /**
+     * ES6 / Typescript decorator to help you to structure your code better.
+     * It is advised to use them on any function that modifies observables or has side effects.
+     */
+    action(value: string|Mobx.Lambda, fn?: Mobx.Lambda): any; // decorator / annotation
+
+    /**
+     * Observes an observable for changes.
+     * @param target The observable to observe
+     * @param listener func callback that will be invoked for each change that is made to the observable
+     * @param invokeImmediately (optional) boolean
+     * @returns disposer function, which can be used to stop the view from being updated in the future
+     */
+    observe(target: Mobx.IObservable, listener: Mobx.Lambda, invokeImmediately?: boolean): Mobx.Lambda;
+
+    /**
+     * Creates a reactive view and keeps it alive, so that the view is always
+     * updated if one of the dependencies changes, even when the view is not further used by something else.
+     * @param func The reactive view
+     * @param scope (optional)
+     * @returns disposer function, which can be used to stop the view from being updated in the future.
+     */
+    autorun(func: Mobx.Lambda, scope?: any): Mobx.Lambda;
+
+    /**
+     * Deprecated, use mobservable.observe instead.
+     */
+    sideEffect(func: Mobx.Lambda, scope?: any): Mobx.Lambda;
+
+    /**
+     * Similar to 'observer', observes the given predicate until it returns true.
+     * Once it returns true, the 'effect' function is invoked an the observation is cancelled.
+     * @param predicate
+     * @param effect
+     * @param scope (optional)
+     * @returns disposer function to prematurely end the observer.
+     */
+    autorunUntil(predicate: ()=>boolean, effect: Mobx.Lambda, scope?: any): Mobx.Lambda;
+
+    /**
+     * Just like autorun except that the action won't be invoked synchronously
+     * but asynchronously after the minimum amount of milliseconds has passed
+     * @param action a function that updates some reactive state
+     * @param minimumDelay (optional) awaited before re-executing the action again.
+     * @param scope (optional)
+     * @returns disposer function, which can be used to cancel the autorun.
+     */
+    autorunAsync(action: ()=>void, minimumDelay?: number, scope?: any): Mobx.Lambda;
+
+    /**
+     * During a transaction no views are updated until the end of the transaction.
+     * The transaction will be run synchronously nonetheless.
+     * @param action a function that updates some reactive state
+     * @returns any value that was returned by the 'action' parameter.
+     */
+    transaction<T>(action: ()=>T): T;
+
+    /**
+     * Converts a reactive structure into a non-reactive structure.
+     * Basically a deep-clone.
+     * @param value any type accepted by Mobx
+     * @param supportCycles (optional) enabled by default
+     */
+    toJS<T>(value: T, supportCycles?: boolean): T;
+
+    /**
+     * (DEPRECATED! Use toJS() instead)
+     * @param value any type accepted by Mobx
+     * @param supportCycles (optional) enabled by default
+     */
+    toJSON<T>(value: T, supportCycles?: boolean): T;
+
+    /**
+     * Sets the reporting level Defaults to 1. Use 0 for production or 2 for increased verbosity.
+     */
+    logLevel:  number;  // 0 = production, 1 = development, 2 = debugging
+
+    extras: {
+        getDependencyTree(thing:any, property?:string): Mobx.IDependencyTree;
+
+        getObserverTree(thing:any, property?:string): Mobx.IObserverTree;
+
+        trackTransitions(extensive?:boolean, onReport?:(lines:Mobx.ITransitionEvent) => void) : Mobx.Lambda;
+    }
+}
+
+interface IObservable {
+    <T>(value: string|number|boolean|Date|RegExp|Function|void, opts?: Mobx.IObservableOptions): Mobx.IObservableValue<T>;
+    <T>(value: T[], opts?: Mobx.IObservableOptions): Mobx.IObservableArray<T>;
+    <T>(value: ()=>T, opts?: Mobx.IObservableOptions): Mobx.IObservableValue<T>;
+    <T>(value: Map<string, any>, opts?: Mobx.IObservableOptions): Mobx.IObservableMap<T>;
+    <T extends Object>(value: Object, opts?: Mobx.IObservableOptions): T;
+}
+
+interface IMobservableStatic extends _IMobxStatic, IObservable {
+}
+
+declare namespace Mobx {
+    interface IObservableOptions {
+        as?:  string /* "auto" | "reference" | TODO:  see #8 "structure" */
+        scope?:  Object,
+        context?: Object,
+        recurse?:  boolean;
+        name?: string;
+        // protected:  boolean TODO:  see #9
+    }
+
+    export interface IContextInfoStruct {
+        object: Object;
+        name: string;
+    }
+
+    export type IContextInfo = IContextInfoStruct | string;
+
+    interface Lambda {
+        (): void;
+        name?: string;
+    }
+
+    interface IObservable {
+        autorun(callback: (...args: any[])=>void, fireImmediately?: boolean): Lambda;
+    }
+
+    interface IObservableValue<T> extends IObservable {
+        (): T;
+        (value: T):void;
+        observe(callback: (newValue: T, oldValue: T)=>void, fireImmediately?: boolean): Lambda;
+    }
+
+    interface IObservableArray<T> extends IObservable, Array<T> {
+        spliceWithArray(index: number, deleteCount?: number, newItems?: T[]): T[];
+        autorun(listener: (changeData: IArrayChange<T>|IArraySplice<T>)=>void, fireImmediately?: boolean): Lambda;
+        clear(): T[];
+        peek(): T[];
+        replace(newItems: T[]): T[];
+        find(predicate: (item: T,index: number,array: IObservableArray<T>)=>boolean,thisArg?: any,fromIndex?: number): T;
+        remove(value: T): boolean;
+    }
+    interface IObservableMap<T> extends IObservable, Map<string, any> {
+        toJS(): Object;
+        intercept(interceptor: Lambda): Lambda;
+        observe(listener: Lambda, fireImmediately?: boolean): Lambda;
+        merge(target: Object|Map<string, any>): void;
+    }
+
+    interface IArrayChange<T> {
+        type:  string; // Always:  'update'
+        object:  IObservableArray<T>;
+        index:  number;
+        oldValue:  T;
+    }
+
+    interface IArraySplice<T> {
+        type:  string; // Always:  'splice'
+        object:  IObservableArray<T>;
+        index:  number;
+        removed:  T[];
+        addedCount:  number;
+    }
+
+    interface IDependencyTree {
+        id: number;
+        name: string;
+        context: any;
+        dependencies?: IDependencyTree[];
+    }
+
+    interface IObserverTree {
+        id: number;
+        name: string;
+        context: any;
+        observers?: IObserverTree[];
+        listeners?: number; // amount of functions manually attached using an .observe method
+    }
+
+    interface ITransitionEvent {
+        id: number;
+        name: string;
+        context: Object;
+        state: string;
+        changed: boolean;
+        newValue: string;
+    }
+}
+
+declare module "mobx" {
+	var m : IMobservableStatic;
+	export = m;
+}

--- a/mobx/mobx.d.ts
+++ b/mobx/mobx.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for mobx v1.0.0
 // Project: https://mweststrate.github.io/mobservable
 // Definitions by: Michel Weststrate <https://github.com/mweststrate/>
-// Updated by: Ryan Megidov <https://github.com/nightwolfz/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 

--- a/mobx/tsconfig.json
+++ b/mobx/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "moduleResolution": "node",
+        "noImplicitAny": true,
+        "experimentalDecorators": true
+    }
+}


### PR DESCRIPTION
I don't usually typescript, so bear with me please.

case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6 --noImplicitAny --experimentalDecorators` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
