### PR TITLE
Added the listen function.

### DIFF
--- a/reflux/reflux.d.ts
+++ b/reflux/reflux.d.ts
@@ -35,7 +35,7 @@ declare module  RefluxCore {
         stopListeningToAll(): void,
         fetchInitialState(listenable: Listenable, defaultCallback: Function): void,
         trigger(state: any):void;
-        listen(callback: Function, bindContext: any) : Function;
+        listen(callback: Function, bindContext: any): Function;
     }
 
     interface ActionsDefinition {

--- a/reflux/reflux.d.ts
+++ b/reflux/reflux.d.ts
@@ -35,6 +35,7 @@ declare module  RefluxCore {
         stopListeningToAll(): void,
         fetchInitialState(listenable: Listenable, defaultCallback: Function): void,
         trigger(state: any):void;
+        listen(callback: Function, bindContext: any) : Function;
     }
 
     interface ActionsDefinition {


### PR DESCRIPTION
Added the listen function to Store interface so that people can use Reflux the non-mixin way.

Specifically, I was having great difficulty figuring out how to use the Mixin method of connecting Components to Stores when using React and Reflux with TypeScript. Having the "listen" function available in the type definition allows me to register and un-register the listening during component mount/unmount.

This is a "case 2" PR.

The "listen" function is defined on [line 560 of reflux.js](https://github.com/reflux/refluxjs/blob/0283703188d8475292d81b5d2e1c6a43e912e889/dist/reflux.js#L560).
