### PR TITLE
Make `getColHeader` parameter optional in handsOnTable

### DIFF
--- a/handsontable/handsontable.d.ts
+++ b/handsontable/handsontable.d.ts
@@ -232,7 +232,7 @@ declare namespace ht {
     getCellMeta(row: number, col: number): Object;
     getCellRenderer(row: number, col: number): Function;
     getCellValidator(row: number, col: number): any;
-    getColHeader(col: number): any[]|string;
+    getColHeader(col?: number): any[]|string;
     getColWidth(col: number): number;
     getCoords(elem: Element): Object;
     getCopyableData(row: number, column: number): string;


### PR DESCRIPTION
Improvement to existing type definition - see http://docs.handsontable.com/0.23.0/Core.html#getColHeader
