### PR TITLE
Improvement to material-ui type definition

### DIFF
--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -452,7 +452,7 @@ declare namespace __MaterialUI {
         export function themeDecorator(muiTheme: Styles.MuiTheme): <TFunction extends Function>(Component: TFunction) => TFunction;
 
         interface MuiThemeProviderProps extends React.Props<MuiThemeProvider> {
-            muiTheme: Styles.MuiTheme;
+            muiTheme?: Styles.MuiTheme;
         }
         export class MuiThemeProvider extends React.Component<MuiThemeProviderProps, {}>{
         }


### PR DESCRIPTION
case 2. Improvement to existing type definition.

From Material-UI Reference (http://www.material-ui.com/#/customization/themes):
"The lightBaseTheme is the default so you will not need to do anything to use it other than using MuiThemeProvider as described in [Usage](http://www.material-ui.com/#/get-started/usage)"

muiTheme Property should be optional.
