### PR TITLE
nconf: allow nconf.get() without a key

### DIFF
--- a/nconf/nconf.d.ts
+++ b/nconf/nconf.d.ts
@@ -11,7 +11,7 @@ declare module "nconf" {
 	export var sources: any[];
 
 	export function clear(key: string, callback?: ICallbackFunction): any;
-	export function get (key: string, callback?: ICallbackFunction): any;
+	export function get (key?: string, callback?: ICallbackFunction): any;
 	export function merge(key: string, value: any, callback?: ICallbackFunction): any;
 	export function set (key: string, value: any, callback?: ICallbackFunction): any;
 	export function reset(callback?: ICallbackFunction): any;


### PR DESCRIPTION
It's not evident from the documentation, but you can call `nconf.get` without a key to get the whole configuration object.

There's a comment in the code that makes it clearer:

``` javascript
// Retrieves the value for the specified key (if any).
```

From: https://github.com/indexzero/nconf/blob/master/lib/nconf/provider.js#L210
