### PR TITLE
Add typings for launchpad

### DIFF
--- a/launchpad/index.d.ts
+++ b/launchpad/index.d.ts
@@ -3,106 +3,104 @@
 // Definitions by: Peter Burns <https://github.com/rictic>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module "launchpad" {
-  /**
-   * For launching local browsers. The callback will be given a Launcher to
-   * perform the actual launching.
-   */
-  export function local(cb: (err: any, localBrowsers: Launcher) => void): void;
+/**
+ * For launching local browsers. The callback will be given a Launcher to
+ * perform the actual launching.
+ */
+export function local(cb: (err: any, localBrowsers: Launcher) => void): void;
 
-  export namespace local {
-    export const platform: {
-      chrome?: BrowserPlatformDetails;
-      chromium?: BrowserPlatformDetails;
-      canary?: BrowserPlatformDetails;
-      firefox?: BrowserPlatformDetails;
-      aurora?: BrowserPlatformDetails;
-      opera?: BrowserPlatformDetails;
-      ie?: BrowserPlatformDetails;
-      edge?: BrowserPlatformDetails;
-      safari?: BrowserPlatformDetails;
-      phantom?: BrowserPlatformDetails;
-      nodeWebkit?: BrowserPlatformDetails;
-    };
-  }
+export namespace local {
+  export const platform: {
+    chrome?: BrowserPlatformDetails;
+    chromium?: BrowserPlatformDetails;
+    canary?: BrowserPlatformDetails;
+    firefox?: BrowserPlatformDetails;
+    aurora?: BrowserPlatformDetails;
+    opera?: BrowserPlatformDetails;
+    ie?: BrowserPlatformDetails;
+    edge?: BrowserPlatformDetails;
+    safari?: BrowserPlatformDetails;
+    phantom?: BrowserPlatformDetails;
+    nodeWebkit?: BrowserPlatformDetails;
+  };
+}
 
-  interface BrowserstackAuth {
-    username: string;
-    password: string;
-  }
+interface BrowserstackAuth {
+  username: string;
+  password: string;
+}
 
-  export function browserstack(
-      authCreds: BrowserstackAuth,
-      cb: (err: any, browserstack: Launcher) => void): void;
+export function browserstack(
+    authCreds: BrowserstackAuth,
+    cb: (err: any, browserstack: Launcher) => void): void;
 
-  interface RemoteConnectionOptions {
-    host: string;
-    username: string;
-    password: string;
-  }
+interface RemoteConnectionOptions {
+  host: string;
+  username: string;
+  password: string;
+}
 
-  export function remote(
-      connectionOpts: RemoteConnectionOptions,
-      cb: (err: any, remoteLauncher: Launcher) => void): void;
+export function remote(
+    connectionOpts: RemoteConnectionOptions,
+    cb: (err: any, remoteLauncher: Launcher) => void): void;
 
-  interface BrowserPlatformDetails {
-    pathQuery?: string;
-    plistPath?: string;
-    command?: string;
-    process?: string;
-    versionKey?: string;
-    defaultLocation?: string;
-    args?: string[];
-    opensTab?: boolean;
-    multi?: boolean;
-    getCommand?: (browser: BrowserPlatformDetails, url: string, args: string[]) => string;
-    cwd?: string;
-    imageName?: string;
-  }
+interface BrowserPlatformDetails {
+  pathQuery?: string;
+  plistPath?: string;
+  command?: string;
+  process?: string;
+  versionKey?: string;
+  defaultLocation?: string;
+  args?: string[];
+  opensTab?: boolean;
+  multi?: boolean;
+  getCommand?: (browser: BrowserPlatformDetails, url: string, args: string[]) => string;
+  cwd?: string;
+  imageName?: string;
+}
 
-  interface LaunchOptions {
-    browser: string;
-    version?: string;
-  }
+interface LaunchOptions {
+  browser: string;
+  version?: string;
+}
 
-  interface Launcher {
-    (url: string, options: LaunchOptions, callback: (err: any, instance: Instance) => void): void;
-    browsers(cb: (error: any, browsers?: Browser[]) => void): void;
+interface Launcher {
+  (url: string, options: LaunchOptions, callback: (err: any, instance: Instance) => void): void;
+  browsers(cb: (error: any, browsers?: Browser[]) => void): void;
 
-    chrome: BrowserFunction;
-    chromium: BrowserFunction;
-    canary: BrowserFunction;
-    firefox: BrowserFunction;
-    aurora: BrowserFunction;
-    opera: BrowserFunction;
-    ie: BrowserFunction;
-    edge: BrowserFunction;
-    safari: BrowserFunction;
-    phantom: BrowserFunction;
-    nodeWebkit: BrowserFunction;
-  }
+  chrome: BrowserFunction;
+  chromium: BrowserFunction;
+  canary: BrowserFunction;
+  firefox: BrowserFunction;
+  aurora: BrowserFunction;
+  opera: BrowserFunction;
+  ie: BrowserFunction;
+  edge: BrowserFunction;
+  safari: BrowserFunction;
+  phantom: BrowserFunction;
+  nodeWebkit: BrowserFunction;
+}
 
-  interface Browser {
-    name: string;
-    version: string;
-    binPath: string;
-  }
+interface Browser {
+  name: string;
+  version: string;
+  binPath: string;
+}
 
-  interface BrowserFunction {
-    (url: string, callback: (err: any, instance: Instance) => void): void;
-  }
-  export interface Instance  {
-    id: string;
-    stop(cb: (err: any) => void): void;
-    status(cb: (err: any, status: any) => void): void;
+interface BrowserFunction {
+  (url: string, callback: (err: any, instance: Instance) => void): void;
+}
+export interface Instance  {
+  id: string;
+  stop(cb: (err: any) => void): void;
+  status(cb: (err: any, status: any) => void): void;
 
-    addListener(event: string, listener: Function): this;
-    on(event: string, listener: Function): this;
-    once(event: string, listener: Function): this;
-    removeListener(event: string, listener: Function): this;
-    removeAllListeners(event?: string): this;
-    setMaxListeners(n: number): void;
-    listeners(event: string): Function[];
-    emit(event: string, ...args: any[]): boolean;
-  }
+  addListener(event: string, listener: Function): this;
+  on(event: string, listener: Function): this;
+  once(event: string, listener: Function): this;
+  removeListener(event: string, listener: Function): this;
+  removeAllListeners(event?: string): this;
+  setMaxListeners(n: number): void;
+  listeners(event: string): Function[];
+  emit(event: string, ...args: any[]): boolean;
 }

--- a/launchpad/index.d.ts
+++ b/launchpad/index.d.ts
@@ -1,0 +1,108 @@
+// Type definitions for launchpad
+// Project: https://www.npmjs.com/package/launchpad
+// Definitions by: Peter Burns <https://github.com/rictic>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "launchpad" {
+  /**
+   * For launching local browsers. The callback will be given a Launcher to
+   * perform the actual launching.
+   */
+  export function local(cb: (err: any, localBrowsers: Launcher) => void): void;
+
+  export namespace local {
+    export const platform: {
+      chrome?: BrowserPlatformDetails;
+      chromium?: BrowserPlatformDetails;
+      canary?: BrowserPlatformDetails;
+      firefox?: BrowserPlatformDetails;
+      aurora?: BrowserPlatformDetails;
+      opera?: BrowserPlatformDetails;
+      ie?: BrowserPlatformDetails;
+      edge?: BrowserPlatformDetails;
+      safari?: BrowserPlatformDetails;
+      phantom?: BrowserPlatformDetails;
+      nodeWebkit?: BrowserPlatformDetails;
+    };
+  }
+
+  interface BrowserstackAuth {
+    username: string;
+    password: string;
+  }
+
+  export function browserstack(
+      authCreds: BrowserstackAuth,
+      cb: (err: any, browserstack: Launcher) => void): void;
+
+  interface RemoteConnectionOptions {
+    host: string;
+    username: string;
+    password: string;
+  }
+
+  export function remote(
+      connectionOpts: RemoteConnectionOptions,
+      cb: (err: any, remoteLauncher: Launcher) => void): void;
+
+  interface BrowserPlatformDetails {
+    pathQuery?: string;
+    plistPath?: string;
+    command?: string;
+    process?: string;
+    versionKey?: string;
+    defaultLocation?: string;
+    args?: string[];
+    opensTab?: boolean;
+    multi?: boolean;
+    getCommand?: (browser: BrowserPlatformDetails, url: string, args: string[]) => string;
+    cwd?: string;
+    imageName?: string;
+  }
+
+  interface LaunchOptions {
+    browser: string;
+    version?: string;
+  }
+
+  interface Launcher {
+    (url: string, options: LaunchOptions, callback: (err: any, instance: Instance) => void): void;
+    browsers(cb: (error: any, browsers?: Browser[]) => void): void;
+
+    chrome: BrowserFunction;
+    chromium: BrowserFunction;
+    canary: BrowserFunction;
+    firefox: BrowserFunction;
+    aurora: BrowserFunction;
+    opera: BrowserFunction;
+    ie: BrowserFunction;
+    edge: BrowserFunction;
+    safari: BrowserFunction;
+    phantom: BrowserFunction;
+    nodeWebkit: BrowserFunction;
+  }
+
+  interface Browser {
+    name: string;
+    version: string;
+    binPath: string;
+  }
+
+  interface BrowserFunction {
+    (url: string, callback: (err: any, instance: Instance) => void): void;
+  }
+  export interface Instance  {
+    id: string;
+    stop(cb: (err: any) => void): void;
+    status(cb: (err: any, status: any) => void): void;
+
+    addListener(event: string, listener: Function): this;
+    on(event: string, listener: Function): this;
+    once(event: string, listener: Function): this;
+    removeListener(event: string, listener: Function): this;
+    removeAllListeners(event?: string): this;
+    setMaxListeners(n: number): void;
+    listeners(event: string): Function[];
+    emit(event: string, ...args: any[]): boolean;
+  }
+}

--- a/launchpad/launchpad-tests.ts
+++ b/launchpad/launchpad-tests.ts
@@ -1,0 +1,61 @@
+import * as launch from "launchpad";
+
+launch.local(function(error, launcher) {
+  launcher.browsers(function(error, browsers) {
+    // -> List of available browsers with version
+  });
+
+  const handleInstance = function(err: any, instance: launch.Instance) {
+    instance; // -> A browser instance
+    instance.id; // -> unique instance id
+    instance.stop(() => {}); // -> Stop the instance
+    instance.status((err, status) => {}); // -> Get status information about the instance
+  };
+
+  launcher.chrome("https://example.com/", handleInstance);
+
+  launcher.firefox("http://url", function(err, instance) {
+    // An instance is an event emitter
+    instance.on("stop", function() {
+      console.log("Terminated local firefox");
+    });
+  });
+});
+
+launch.browserstack({
+    username : "user",
+    password : "password"
+  },
+  function(err, browserstack) {
+    browserstack.browsers(function(error, browsers) {
+      // -> List of all Browserstack browsers
+    });
+
+    browserstack.ie("http://url", function(err, instance) {
+      // Shut the instance down after 5 seconds
+      setTimeout(function() {
+        instance.stop(function (err) {
+          if (err) {
+            console.log(err);
+          }
+          console.log("Browser instance has stopped");
+        });
+      }, 5000);
+  });
+});
+
+launch.remote({
+  host : "ie7machine",
+  username : "launcher",
+  password : "testing"
+}, function(err, api) {
+  api.browsers(function(error, browsers) {
+    // -> List of all browsers found on ie7machine
+  });
+
+  api("http://github.com", {
+    browser : "safari",
+    version : "latest"
+  }, function(err, instance) {
+  });
+});

--- a/launchpad/tsconfig.json
+++ b/launchpad/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "launchpad-tests.ts"
+    ]
+}

--- a/launchpad/tsconfig.json
+++ b/launchpad/tsconfig.json
@@ -5,7 +5,8 @@
         "noImplicitAny": true,
         "strictNullChecks": true,
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "types": []
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

One definite known issue, and one potential issue with this PR that I'd like advice with:

This PR and its test compile correctly when I just use `tsc` on the command line, but in travis or with `npm test` the test file is unable to find the module `"launchpad"`.

I'm also sending this PR to the types-2.0 branch, as I'd like to be able to install it from npm `@types/launchpad`.
