### PR TITLE
angular-material: fix declarations to properly augment angular namespace when importing the types via npm

### DIFF
--- a/angular-material/angular-material-0.8.3.d.ts
+++ b/angular-material/angular-material-0.8.3.d.ts
@@ -4,192 +4,194 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="angular" />
-declare namespace angular.material {
+declare namespace angular {
+    export namespace material {
 
-    interface MDBottomSheetOptions {
-        templateUrl?: string;
-        template?: string;
-        controller?: any;
-        locals?: {[index: string]: any};
-        targetEvent?: any;
-        resolve?: {[index: string]: angular.IPromise<any>}
-        controllerAs?: string;
-        parent?: Element;
-        disableParentScroll?: boolean;
-    }
+        interface MDBottomSheetOptions {
+            templateUrl?: string;
+            template?: string;
+            controller?: any;
+            locals?: { [index: string]: any };
+            targetEvent?: any;
+            resolve?: { [index: string]: angular.IPromise<any> }
+            controllerAs?: string;
+            parent?: Element;
+            disableParentScroll?: boolean;
+        }
 
-    interface MDBottomSheetService {
-        show(options: MDBottomSheetOptions): angular.IPromise<any>;
-        hide(response?: any): void;
-        cancel(response?: any): void;
-    }
+        interface MDBottomSheetService {
+            show(options: MDBottomSheetOptions): angular.IPromise<any>;
+            hide(response?: any): void;
+            cancel(response?: any): void;
+        }
 
-    interface MDPresetDialog<T> {
-        title(title: string): T;
-        content(content: string): T;
-        ok(content: string): T;
-        theme(theme: string): T;
-    }
+        interface MDPresetDialog<T> {
+            title(title: string): T;
+            content(content: string): T;
+            ok(content: string): T;
+            theme(theme: string): T;
+        }
 
-    interface MDAlertDialog extends MDPresetDialog<MDAlertDialog> {
-    }
+        interface MDAlertDialog extends MDPresetDialog<MDAlertDialog> {
+        }
 
-    interface MDConfirmDialog extends MDPresetDialog<MDConfirmDialog> {
-        cancel(reason?: string): MDConfirmDialog;
-    }
+        interface MDConfirmDialog extends MDPresetDialog<MDConfirmDialog> {
+            cancel(reason?: string): MDConfirmDialog;
+        }
 
-    interface MDDialogOptions {
-        templateUrl?: string;
-        template?: string;
-        domClickEvent?: any;
-        disableParentScroll?: boolean;
-        clickOutsideToClose?: boolean;
-        hasBackdrop?: boolean;
-        escapeToClose?: boolean;
-        controller?: any;
-        locals?: {[index: string]: any};
-        bindToController?: boolean;
-        resolve?: {[index: string]: angular.IPromise<any>}
-        controllerAs?: string;
-        parent?: Element;
-        onComplete?: Function;
-    }
+        interface MDDialogOptions {
+            templateUrl?: string;
+            template?: string;
+            domClickEvent?: any;
+            disableParentScroll?: boolean;
+            clickOutsideToClose?: boolean;
+            hasBackdrop?: boolean;
+            escapeToClose?: boolean;
+            controller?: any;
+            locals?: { [index: string]: any };
+            bindToController?: boolean;
+            resolve?: { [index: string]: angular.IPromise<any> }
+            controllerAs?: string;
+            parent?: Element;
+            onComplete?: Function;
+        }
 
-    interface MDDialogService {
-        show(dialog: MDDialogOptions|MDPresetDialog<any>): angular.IPromise<any>;
-        confirm(): MDConfirmDialog;
-        alert(): MDAlertDialog;
-        hide(response?: any): angular.IPromise<any>;
-        cancel(response?: any): void;
-    }
+        interface MDDialogService {
+            show(dialog: MDDialogOptions | MDPresetDialog<any>): angular.IPromise<any>;
+            confirm(): MDConfirmDialog;
+            alert(): MDAlertDialog;
+            hide(response?: any): angular.IPromise<any>;
+            cancel(response?: any): void;
+        }
 
-    interface MDIcon {
-        (path: string): angular.IPromise<Element>;
-    }
+        interface MDIcon {
+            (path: string): angular.IPromise<Element>;
+        }
 
-    interface MDIconProvider {
-        icon(id: string, url: string, iconSize?: string): MDIconProvider;
-        iconSet(id: string, url: string, iconSize?: string): MDIconProvider;
-        defaultIconSet(url: string, iconSize?: string): MDIconProvider;
-        defaultIconSize(iconSize: string): MDIconProvider;
-    }
+        interface MDIconProvider {
+            icon(id: string, url: string, iconSize?: string): MDIconProvider;
+            iconSet(id: string, url: string, iconSize?: string): MDIconProvider;
+            defaultIconSet(url: string, iconSize?: string): MDIconProvider;
+            defaultIconSize(iconSize: string): MDIconProvider;
+        }
 
-    interface MDMedia {
-        (media: string): boolean;
-    }
+        interface MDMedia {
+            (media: string): boolean;
+        }
 
-    interface MDSidenavObject {
-        toggle(): void;
-        open(): void;
-        close(): void;
-        isOpen(): boolean;
-        isLockedOpen(): boolean;
-    }
+        interface MDSidenavObject {
+            toggle(): void;
+            open(): void;
+            close(): void;
+            isOpen(): boolean;
+            isLockedOpen(): boolean;
+        }
 
-    interface MDSidenavService {
-        (component: string): MDSidenavObject;
-    }
+        interface MDSidenavService {
+            (component: string): MDSidenavObject;
+        }
 
-    interface MDToastPreset<T> {
-        content(content: string): T;
-        action(action: string): T;
-        highlightAction(highlightAction: boolean): T;
-        capsule(capsule: boolean): T;
-        theme(theme: string): T;
-        hideDelay(delay: number): T;
-    }
+        interface MDToastPreset<T> {
+            content(content: string): T;
+            action(action: string): T;
+            highlightAction(highlightAction: boolean): T;
+            capsule(capsule: boolean): T;
+            theme(theme: string): T;
+            hideDelay(delay: number): T;
+        }
 
-    interface MDSimpleToastPreset extends MDToastPreset<MDSimpleToastPreset> {
-    }
+        interface MDSimpleToastPreset extends MDToastPreset<MDSimpleToastPreset> {
+        }
 
-    interface MDToastOptions {
-        templateUrl?: string;
-        template?: string;
-        hideDelay?: number;
-        position?: string;
-        controller?: any;
-        locals?: {[index: string]: any};
-        bindToController?: boolean;
-        resolve?: {[index: string]: angular.IPromise<any>}
-        controllerAs?: string;
-        parent?: Element;
-    }
+        interface MDToastOptions {
+            templateUrl?: string;
+            template?: string;
+            hideDelay?: number;
+            position?: string;
+            controller?: any;
+            locals?: { [index: string]: any };
+            bindToController?: boolean;
+            resolve?: { [index: string]: angular.IPromise<any> }
+            controllerAs?: string;
+            parent?: Element;
+        }
 
-    interface MDToastService {
-        show(optionsOrPreset: MDToastOptions|MDToastPreset<any>): angular.IPromise<any>;
-        showSimple(): angular.IPromise<any>;
-        simple(): MDSimpleToastPreset;
-        build(): MDToastPreset<any>;
-        updateContent(): void;
-        hide(response?: any): void;
-        cancel(response?: any): void;
-    }
+        interface MDToastService {
+            show(optionsOrPreset: MDToastOptions | MDToastPreset<any>): angular.IPromise<any>;
+            showSimple(): angular.IPromise<any>;
+            simple(): MDSimpleToastPreset;
+            build(): MDToastPreset<any>;
+            updateContent(): void;
+            hide(response?: any): void;
+            cancel(response?: any): void;
+        }
 
-    interface MDPalette {
-        0?: string;
-        50?: string;
-        100?: string;
-        200?: string;
-        300?: string;
-        400?: string;
-        500?: string;
-        600?: string;
-        700?: string;
-        800?: string;
-        900?: string;
-        A100?: string;
-        A200?: string;
-        A400?: string;
-        A700?: string;
-        contrastDefaultColor?: string;
-        contrastDarkColors?: string;
-        contrastStrongLightColors?: string;
-    }
+        interface MDPalette {
+            0?: string;
+            50?: string;
+            100?: string;
+            200?: string;
+            300?: string;
+            400?: string;
+            500?: string;
+            600?: string;
+            700?: string;
+            800?: string;
+            900?: string;
+            A100?: string;
+            A200?: string;
+            A400?: string;
+            A700?: string;
+            contrastDefaultColor?: string;
+            contrastDarkColors?: string;
+            contrastStrongLightColors?: string;
+        }
 
-    interface MDThemeHues {
-        default?: string;
-        'hue-1'?: string;
-        'hue-2'?: string;
-        'hue-3'?: string;
-    }
+        interface MDThemeHues {
+            default?: string;
+            'hue-1'?: string;
+            'hue-2'?: string;
+            'hue-3'?: string;
+        }
 
-    interface MDThemePalette {
-        name: string;
-        hues: MDThemeHues;
-    }
+        interface MDThemePalette {
+            name: string;
+            hues: MDThemeHues;
+        }
 
-    interface MDThemeColors {
-        accent: MDThemePalette;
-        background: MDThemePalette;
-        primary: MDThemePalette;
-        warn: MDThemePalette;
-    }
+        interface MDThemeColors {
+            accent: MDThemePalette;
+            background: MDThemePalette;
+            primary: MDThemePalette;
+            warn: MDThemePalette;
+        }
 
-    interface MDThemeGrayScalePalette {
-        1: string;
-        2: string;
-        3: string;
-        4: string;
-        name: string;
-    }
+        interface MDThemeGrayScalePalette {
+            1: string;
+            2: string;
+            3: string;
+            4: string;
+            name: string;
+        }
 
-    interface MDTheme {
-        name: string;
-        colors: MDThemeColors;
-        foregroundPalette: MDThemeGrayScalePalette;
-        foregroundShadow: string;
-        accentPalette(name: string, hues?: MDThemeHues): MDTheme;
-        primaryPalette(name: string, hues?: MDThemeHues): MDTheme;
-        warnPalette(name: string, hues?: MDThemeHues): MDTheme;
-        backgroundPalette(name: string, hues?: MDThemeHues): MDTheme;
-        dark(isDark?: boolean): MDTheme;
-    }
+        interface MDTheme {
+            name: string;
+            colors: MDThemeColors;
+            foregroundPalette: MDThemeGrayScalePalette;
+            foregroundShadow: string;
+            accentPalette(name: string, hues?: MDThemeHues): MDTheme;
+            primaryPalette(name: string, hues?: MDThemeHues): MDTheme;
+            warnPalette(name: string, hues?: MDThemeHues): MDTheme;
+            backgroundPalette(name: string, hues?: MDThemeHues): MDTheme;
+            dark(isDark?: boolean): MDTheme;
+        }
 
-    interface MDThemingProvider {
-        theme(name: string, inheritFrom?: string): MDTheme;
-        definePalette(name: string, palette: MDPalette): MDThemingProvider;
-        extendPalette(name: string, palette: MDPalette): MDPalette;
-        setDefaultTheme(theme: string): void;
-        alwaysWatchTheme(alwaysWatch: boolean): void;
+        interface MDThemingProvider {
+            theme(name: string, inheritFrom?: string): MDTheme;
+            definePalette(name: string, palette: MDPalette): MDThemingProvider;
+            extendPalette(name: string, palette: MDPalette): MDPalette;
+            setDefaultTheme(theme: string): void;
+            alwaysWatchTheme(alwaysWatch: boolean): void;
+        }
     }
 }

--- a/angular-material/angular-material-0.9.0.d.ts
+++ b/angular-material/angular-material-0.9.0.d.ts
@@ -4,201 +4,202 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="angular" />
-declare namespace angular.material {
+declare namespace angular {
+    export namespace material {
+        interface MDBottomSheetOptions {
+            templateUrl?: string;
+            template?: string;
+            scope?: angular.IScope; // default: new child scope
+            preserveScope?: boolean; // default: false
+            controller?: string | Function;
+            locals?: { [index: string]: any };
+            targetEvent?: MouseEvent;
+            resolve?: { [index: string]: angular.IPromise<any> }
+            controllerAs?: string;
+            parent?: string | Element | JQuery; // default: root node
+            disableParentScroll?: boolean; // default: true
+        }
 
-    interface MDBottomSheetOptions {
-        templateUrl?: string;
-        template?: string;
-        scope?: angular.IScope; // default: new child scope
-        preserveScope?: boolean; // default: false
-        controller?: string|Function;
-        locals?: {[index: string]: any};
-        targetEvent?: MouseEvent;
-        resolve?: {[index: string]: angular.IPromise<any>}
-        controllerAs?: string;
-        parent?: string|Element|JQuery; // default: root node
-        disableParentScroll?: boolean; // default: true
-    }
+        interface MDBottomSheetService {
+            show(options: MDBottomSheetOptions): angular.IPromise<any>;
+            hide(response?: any): void;
+            cancel(response?: any): void;
+        }
 
-    interface MDBottomSheetService {
-        show(options: MDBottomSheetOptions): angular.IPromise<any>;
-        hide(response?: any): void;
-        cancel(response?: any): void;
-    }
+        interface MDPresetDialog<T> {
+            title(title: string): T;
+            content(content: string): T;
+            ok(ok: string): T;
+            theme(theme: string): T;
+        }
 
-    interface MDPresetDialog<T> {
-        title(title: string): T;
-        content(content: string): T;
-        ok(ok: string): T;
-        theme(theme: string): T;
-    }
+        interface MDAlertDialog extends MDPresetDialog<MDAlertDialog> {
+        }
 
-    interface MDAlertDialog extends MDPresetDialog<MDAlertDialog> {
-    }
+        interface MDConfirmDialog extends MDPresetDialog<MDConfirmDialog> {
+            cancel(cancel: string): MDConfirmDialog;
+        }
 
-    interface MDConfirmDialog extends MDPresetDialog<MDConfirmDialog> {
-        cancel(cancel: string): MDConfirmDialog;
-    }
+        interface MDDialogOptions {
+            templateUrl?: string;
+            template?: string;
+            targetEvent?: MouseEvent;
+            scope?: angular.IScope; // default: new child scope
+            preserveScope?: boolean; // default: false
+            disableParentScroll?: boolean; // default: true
+            hasBackdrop?: boolean // default: true
+            clickOutsideToClose?: boolean; // default: false
+            escapeToClose?: boolean; // default: true
+            focusOnOpen?: boolean; // default: true
+            controller?: string | Function;
+            locals?: { [index: string]: any };
+            bindToController?: boolean; // default: false
+            resolve?: { [index: string]: angular.IPromise<any> }
+            controllerAs?: string;
+            parent?: string | Element | JQuery; // default: root node
+            onComplete?: Function;
+        }
 
-    interface MDDialogOptions {
-        templateUrl?: string;
-        template?: string;
-        targetEvent?: MouseEvent;
-        scope?: angular.IScope; // default: new child scope
-        preserveScope?: boolean; // default: false
-        disableParentScroll?: boolean; // default: true
-        hasBackdrop?: boolean // default: true
-        clickOutsideToClose?: boolean; // default: false
-        escapeToClose?: boolean; // default: true
-        focusOnOpen?: boolean; // default: true
-        controller?: string|Function;
-        locals?: {[index: string]: any};
-        bindToController?: boolean; // default: false
-        resolve?: {[index: string]: angular.IPromise<any>}
-        controllerAs?: string;
-        parent?: string|Element|JQuery; // default: root node
-        onComplete?: Function;
-    }
+        interface MDDialogService {
+            show(dialog: MDDialogOptions | MDAlertDialog | MDConfirmDialog): angular.IPromise<any>;
+            confirm(): MDConfirmDialog;
+            alert(): MDAlertDialog;
+            hide(response?: any): angular.IPromise<any>;
+            cancel(response?: any): void;
+        }
 
-    interface MDDialogService {
-        show(dialog: MDDialogOptions|MDAlertDialog|MDConfirmDialog): angular.IPromise<any>;
-        confirm(): MDConfirmDialog;
-        alert(): MDAlertDialog;
-        hide(response?: any): angular.IPromise<any>;
-        cancel(response?: any): void;
-    }
+        interface MDIcon {
+            (id: string): angular.IPromise<Element>; // id is a unique ID or URL
+        }
 
-    interface MDIcon {
-        (id: string): angular.IPromise<Element>; // id is a unique ID or URL
-    }
+        interface MDIconProvider {
+            icon(id: string, url: string, iconSize?: string): MDIconProvider; // iconSize default: '24px'
+            iconSet(id: string, url: string, iconSize?: string): MDIconProvider; // iconSize default: '24px'
+            defaultIconSet(url: string, iconSize?: string): MDIconProvider; // iconSize default: '24px'
+            defaultIconSize(iconSize: string): MDIconProvider; // default: '24px'
+        }
 
-    interface MDIconProvider {
-        icon(id: string, url: string, iconSize?: string): MDIconProvider; // iconSize default: '24px'
-        iconSet(id: string, url: string, iconSize?: string): MDIconProvider; // iconSize default: '24px'
-        defaultIconSet(url: string, iconSize?: string): MDIconProvider; // iconSize default: '24px'
-        defaultIconSize(iconSize: string): MDIconProvider; // default: '24px'
-    }
+        interface MDMedia {
+            (media: string): boolean;
+        }
 
-    interface MDMedia {
-        (media: string): boolean;
-    }
+        interface MDSidenavObject {
+            toggle(): angular.IPromise<void>;
+            open(): angular.IPromise<void>;
+            close(): angular.IPromise<void>;
+            isOpen(): boolean;
+            isLockedOpen(): boolean;
+        }
 
-    interface MDSidenavObject {
-        toggle(): angular.IPromise<void>;
-        open(): angular.IPromise<void>;
-        close(): angular.IPromise<void>;
-        isOpen(): boolean;
-        isLockedOpen(): boolean;
-    }
+        interface MDSidenavService {
+            (component: string): MDSidenavObject;
+        }
 
-    interface MDSidenavService {
-        (component: string): MDSidenavObject;
-    }
+        interface MDToastPreset<T> {
+            content(content: string): T;
+            action(action: string): T;
+            highlightAction(highlightAction: boolean): T;
+            capsule(capsule: boolean): T;
+            theme(theme: string): T;
+            hideDelay(delay: number): T;
+            position(position: string): T;
+        }
 
-    interface MDToastPreset<T> {
-        content(content: string): T;
-        action(action: string): T;
-        highlightAction(highlightAction: boolean): T;
-        capsule(capsule: boolean): T;
-        theme(theme: string): T;
-        hideDelay(delay: number): T;
-        position(position: string): T;
-    }
+        interface MDSimpleToastPreset extends MDToastPreset<MDSimpleToastPreset> {
+        }
 
-    interface MDSimpleToastPreset extends MDToastPreset<MDSimpleToastPreset> {
-    }
+        interface MDToastOptions {
+            templateUrl?: string;
+            template?: string;
+            scope?: angular.IScope; // default: new child scope
+            preserveScope?: boolean; // default: false
+            hideDelay?: number; // default (ms): 3000
+            position?: string; // any combination of 'bottom'/'left'/'top'/'right'/'fit'; default: 'bottom left'
+            controller?: string | Function;
+            locals?: { [index: string]: any };
+            bindToController?: boolean; // default: false
+            resolve?: { [index: string]: angular.IPromise<any> }
+            controllerAs?: string;
+            parent?: string | Element | JQuery; // default: root node
+        }
 
-    interface MDToastOptions {
-        templateUrl?: string;
-        template?: string;
-        scope?: angular.IScope; // default: new child scope
-        preserveScope?: boolean; // default: false
-        hideDelay?: number; // default (ms): 3000
-        position?: string; // any combination of 'bottom'/'left'/'top'/'right'/'fit'; default: 'bottom left'
-        controller?: string|Function;
-        locals?: {[index: string]: any};
-        bindToController?: boolean; // default: false
-        resolve?: {[index: string]: angular.IPromise<any>}
-        controllerAs?: string;
-        parent?: string|Element|JQuery; // default: root node
-    }
+        interface MDToastService {
+            show(optionsOrPreset: MDToastOptions | MDToastPreset<any>): angular.IPromise<any>;
+            showSimple(): angular.IPromise<any>;
+            simple(): MDSimpleToastPreset;
+            build(): MDToastPreset<any>;
+            updateContent(): void;
+            hide(response?: any): void;
+            cancel(response?: any): void;
+        }
 
-    interface MDToastService {
-        show(optionsOrPreset: MDToastOptions|MDToastPreset<any>): angular.IPromise<any>;
-        showSimple(): angular.IPromise<any>;
-        simple(): MDSimpleToastPreset;
-        build(): MDToastPreset<any>;
-        updateContent(): void;
-        hide(response?: any): void;
-        cancel(response?: any): void;
-    }
+        interface MDPalette {
+            0?: string;
+            50?: string;
+            100?: string;
+            200?: string;
+            300?: string;
+            400?: string;
+            500?: string;
+            600?: string;
+            700?: string;
+            800?: string;
+            900?: string;
+            A100?: string;
+            A200?: string;
+            A400?: string;
+            A700?: string;
+            contrastDefaultColor?: string;
+            contrastDarkColors?: string | string[];
+            contrastLightColors?: string | string[];
+        }
 
-    interface MDPalette {
-        0?: string;
-        50?: string;
-        100?: string;
-        200?: string;
-        300?: string;
-        400?: string;
-        500?: string;
-        600?: string;
-        700?: string;
-        800?: string;
-        900?: string;
-        A100?: string;
-        A200?: string;
-        A400?: string;
-        A700?: string;
-        contrastDefaultColor?: string;
-        contrastDarkColors?: string|string[];
-        contrastLightColors?: string|string[];
-    }
+        interface MDThemeHues {
+            default?: string;
+            'hue-1'?: string;
+            'hue-2'?: string;
+            'hue-3'?: string;
+        }
 
-    interface MDThemeHues {
-        default?: string;
-        'hue-1'?: string;
-        'hue-2'?: string;
-        'hue-3'?: string;
-    }
+        interface MDThemePalette {
+            name: string;
+            hues: MDThemeHues;
+        }
 
-    interface MDThemePalette {
-        name: string;
-        hues: MDThemeHues;
-    }
+        interface MDThemeColors {
+            accent: MDThemePalette;
+            background: MDThemePalette;
+            primary: MDThemePalette;
+            warn: MDThemePalette;
+        }
 
-    interface MDThemeColors {
-        accent: MDThemePalette;
-        background: MDThemePalette;
-        primary: MDThemePalette;
-        warn: MDThemePalette;
-    }
+        interface MDThemeGrayScalePalette {
+            1: string;
+            2: string;
+            3: string;
+            4: string;
+            name: string;
+        }
 
-    interface MDThemeGrayScalePalette {
-        1: string;
-        2: string;
-        3: string;
-        4: string;
-        name: string;
-    }
+        interface MDTheme {
+            name: string;
+            isDark: boolean;
+            colors: MDThemeColors;
+            foregroundPalette: MDThemeGrayScalePalette;
+            foregroundShadow: string;
+            accentPalette(name: string, hues?: MDThemeHues): MDTheme;
+            primaryPalette(name: string, hues?: MDThemeHues): MDTheme;
+            warnPalette(name: string, hues?: MDThemeHues): MDTheme;
+            backgroundPalette(name: string, hues?: MDThemeHues): MDTheme;
+            dark(isDark?: boolean): MDTheme;
+        }
 
-    interface MDTheme {
-        name: string;
-        isDark: boolean;
-        colors: MDThemeColors;
-        foregroundPalette: MDThemeGrayScalePalette;
-        foregroundShadow: string;
-        accentPalette(name: string, hues?: MDThemeHues): MDTheme;
-        primaryPalette(name: string, hues?: MDThemeHues): MDTheme;
-        warnPalette(name: string, hues?: MDThemeHues): MDTheme;
-        backgroundPalette(name: string, hues?: MDThemeHues): MDTheme;
-        dark(isDark?: boolean): MDTheme;
-    }
-
-    interface MDThemingProvider {
-        theme(name: string, inheritFrom?: string): MDTheme;
-        definePalette(name: string, palette: MDPalette): MDThemingProvider;
-        extendPalette(name: string, palette: MDPalette): MDPalette;
-        setDefaultTheme(theme: string): void;
-        alwaysWatchTheme(alwaysWatch: boolean): void;
+        interface MDThemingProvider {
+            theme(name: string, inheritFrom?: string): MDTheme;
+            definePalette(name: string, palette: MDPalette): MDThemingProvider;
+            extendPalette(name: string, palette: MDPalette): MDPalette;
+            setDefaultTheme(theme: string): void;
+            alwaysWatchTheme(alwaysWatch: boolean): void;
+        }
     }
 }

--- a/angular-material/index.d.ts
+++ b/angular-material/index.d.ts
@@ -5,9 +5,7 @@
 
 /// <reference types="angular" />
 
-import * as angular from 'angular';
-
-declare module 'angular' {
+declare namespace angular {
     export namespace material {
 
         interface IBottomSheetOptions {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes. 
  - it has been reviewed by a DefinitelyTyped member.

I couldn't get the `angular-material` typings to work with `angular` when using TS 2.0 with the `@types` typings.  My code was able to see `angular`, but not `angular.material`.  I reviewed the new documents in the TypeScript Handbook regarding Definition files and came to the conclusion that since the angular-material library modifies the global `angular`, the typings for it should follow the pattern of a global plugin (see https://github.com/Microsoft/TypeScript-Handbook/blob/release-2.0/pages/declaration%20files/Library%20Structures.md#global-plugin).  After making these changes to the types in my project, I was finally able to get types off of both `angular` and `angular.material`.
I haven't been able to verify that the build passes since the Travis build for this branch is broken right now, but I would be happy to verify in any way I can that these changes are valid.

I'm not sure if I'm going about this the right way, but any direction at this point would be helpful :)

P.S. In the DT repo when I am editing the files it doesn't seem to know how to resolve `/// <reference types="..." />` references.  Is there any way to make that work? (I have my VSCode pointing to my local installation of TS 2.0.)
