### PR TITLE
widen usage of promise in supertest-as-promised

### DIFF
--- a/promisify-supertest/promisify-supertest.d.ts
+++ b/promisify-supertest/promisify-supertest.d.ts
@@ -22,19 +22,18 @@ declare module 'promisify-supertest' {
     interface SuperTest extends superagent.SuperAgent<Test> {
     }
 
-    interface Test extends superagent.Request<Test> {
+    interface Test extends superagent.Request {
       url: string;
       serverAddress(app: any, path: string): string;
-      expect(status: number, callback?: CallbackHandler): Test;
-      expect(status: number, body: string, callback?: CallbackHandler): Test;
-      expect(body: string, callback?: CallbackHandler): Test;
-      expect(body: RegExp, callback?: CallbackHandler): Test;
-      expect(body: Object, callback?: CallbackHandler): Test;
-      expect(field: string, val: string, callback?: CallbackHandler): Test;
-      expect(field: string, val: RegExp, callback?: CallbackHandler): Test;
-      expect(checker: (res: Response) => any): Test;
-      end(callback: CallbackHandler): Test;
-      end(): Promise<Response>;
+      expect(status: number, callback?: CallbackHandler): this;
+      expect(status: number, body: string, callback?: CallbackHandler): this;
+      expect(body: string, callback?: CallbackHandler): this;
+      expect(body: RegExp, callback?: CallbackHandler): this;
+      expect(body: Object, callback?: CallbackHandler): this;
+      expect(field: string, val: string, callback?: CallbackHandler): this;
+      expect(field: string, val: RegExp, callback?: CallbackHandler): this;
+      expect(checker: (res: Response) => any): this;
+      end(callback?: CallbackHandler): this & Promise<Response>;
     }
 
     interface Response extends superagent.Response {

--- a/superagent/superagent.d.ts
+++ b/superagent/superagent.d.ts
@@ -13,6 +13,7 @@ declare module "superagent" {
   var request: request.SuperAgentStatic;
 
   namespace request {
+    interface SuperAgentRequest extends Request {}
     interface SuperAgentStatic extends SuperAgent<SuperAgentRequest> {
       (url: string): SuperAgentRequest;
       (method: string, url: string): SuperAgentRequest;
@@ -20,7 +21,7 @@ declare module "superagent" {
       agent(): SuperAgent<SuperAgentRequest>;
     }
 
-    interface SuperAgent<Req extends Request<any>> extends stream.Stream {
+    interface SuperAgent<Req> extends stream.Stream {
       get(url: string, callback?: CallbackHandler): Req;
       post(url: string, callback?: CallbackHandler): Req;
       put(url: string, callback?: CallbackHandler): Req;
@@ -79,38 +80,36 @@ declare module "superagent" {
       get(header: string): string;
     }
 
-    interface Request<Req extends Request<any>> /* extends NodeJS.WritableStream */ {
+    interface Request /* extends NodeJS.WritableStream */ {
       abort(): void;
-      accept(type: string): Req;
-      attach(field: string, file: string, filename?: string): Req;
-      auth(user: string, name: string): Req;
-      buffer(val: boolean): Req;
-      clearTimeout(): Req;
-      end(callback?: CallbackHandler): Req;
-      field(name: string, val: string): Req;
+      accept(type: string): this;
+      attach(field: string, file: string, filename?: string): this;
+      auth(user: string, name: string): this;
+      buffer(val: boolean): this;
+      clearTimeout(): this;
+      end(callback?: CallbackHandler): this;
+      field(name: string, val: string): this;
       get(field: string): string;
-      on(name: string, handler: Function): Req;
-      on(name: 'error', handler: (err: any) => void): Req;
-      part(): Req;
+      on(name: string, handler: Function): this;
+      on(name: 'error', handler: (err: any) => void): this;
+      part(): this;
       pipe(stream: NodeJS.WritableStream, options?: Object): stream.Writable;
-      query(val: Object): Req;
-      redirects(n: number): Req;
-      send(data: string): Req;
-      send(data: Object): Req;
-      send(): Req;
-      set(field: string, val: string): Req;
-      set(field: Object): Req;
-      timeout(ms: number): Req;
-      type(val: string): Req;
-      use(fn: Function): Req;
-      withCredentials(): Req;
-      write(data: string, encoding?: string): Req;
-      write(data: Buffer, encoding?: string): Req;
+      query(val: Object): this;
+      redirects(n: number): this;
+      send(data: string): this;
+      send(data: Object): this;
+      send(): this;
+      set(field: string, val: string): this;
+      set(field: Object): this;
+      timeout(ms: number): this;
+      type(val: string): this;
+      use(fn: Function): this;
+      withCredentials(): this;
+      write(data: string, encoding?: string): this;
+      write(data: Buffer, encoding?: string): this;
     }
-    interface SuperAgentRequest extends Request<Request<Request<Request<any>>>> {}
 
   }
 
   export = request;
 }
-

--- a/supertest-as-promised/supertest-as-promised.d.ts
+++ b/supertest-as-promised/supertest-as-promised.d.ts
@@ -4,42 +4,56 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path='../superagent/superagent.d.ts' />
-/// <reference path="../bluebird/bluebird.d.ts" />
+/// <reference path='../supertest/supertest.d.ts' />
+/// <reference path='../bluebird/bluebird.d.ts' />
 
 declare module "supertest-as-promised" {
-  // Mostly copy-pasted from supertest.d.ts
+  import * as supertest from "supertest";
+  import * as supersgent from "superagent";
+  import { SuperTest, Response } from "supertest";
+  import * as PromiseBlurbird from "bluebird";
 
-  import * as superagent from 'superagent';
-  import * as PromiseBluebird from 'bluebird';
+  function supertestAsPromised(app: any): SuperTest<supertestAsPromised.Test>;
 
-  function supertest(app: any): supertest.SuperTest;
-
-  namespace supertest {
-    function agent(app?: any): supertest.SuperTest;
-
-    interface SuperTest extends superagent.SuperAgent<Test> {
+  namespace supertestAsPromised {
+    interface Request extends supertest.Request {
     }
 
-    interface Promise<T> extends PromiseBluebird<T> {
-      toPromise(): PromiseBluebird<T>;
+    interface Response extends supertest.Response {
     }
 
-    interface Test extends superagent.Request<Test> {
-      url: string;
-      serverAddress(app: any, path: string): string;
-      expect(status: number): Promise<supertest.Response>;
-      expect(status: number, body: string): Promise<supertest.Response>;
-      expect(body: string): Promise<supertest.Response>;
-      expect(body: RegExp): Promise<supertest.Response>;
-      expect(body: Object): Promise<supertest.Response>;
-      expect(field: string, val: string): Promise<supertest.Response>;
-      expect(field: string, val: RegExp): Promise<supertest.Response>;
-      expect(checker: (res: Response) => any): Promise<supertest.Response>;
+    interface Test extends Promise<Response>, supertest.Test, supersgent.Request {
+      toPromise(): PromiseBlurbird<Response>;
     }
 
-    interface Response extends superagent.Response {
+    function agent(app?: any): SuperTest<Test>;
+
+    interface SuperTest<T> extends supertest.SuperTest<T> {
     }
   }
+  export = supertestAsPromised
 
-  export = supertest;
+  // from core-js.d.ts
+  /**
+   * Represents the completion of an asynchronous operation
+   */
+  interface Promise<T> {
+      /**
+      * Attaches callbacks for the resolution and/or rejection of the Promise.
+      * @param onfulfilled The callback to execute when the Promise is resolved.
+      * @param onrejected The callback to execute when the Promise is rejected.
+      * @returns A Promise for the completion of which ever callback is executed.
+      */
+      then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>;
+      then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<TResult>;
+
+      /**
+       * Attaches a callback for only the rejection of the Promise.
+       * @param onrejected The callback to execute when the Promise is rejected.
+       * @returns A Promise for the completion of the callback.
+       */
+      catch(onrejected?: (reason: any) => T | PromiseLike<T>): Promise<T>;
+      catch(onrejected?: (reason: any) => void): Promise<T>;
+  }
+
 }

--- a/supertest/supertest.d.ts
+++ b/supertest/supertest.d.ts
@@ -6,35 +6,40 @@
 /// <reference path='../superagent/superagent.d.ts' />
 
 declare module "supertest" {
-  import superagent = require('superagent');
+  import * as superagent from "superagent"
 
-  type CallbackHandler = (err: any, res: supertest.Response) => void;
-
-  function supertest(app: any): supertest.SuperTest;
+  function supertest(app: any): supertest.SuperTest<supertest.Test>;
 
   namespace supertest {
-    function agent(app?: any): supertest.SuperTest;
-
-    interface SuperTest extends superagent.SuperAgent<Test> {
-    }
-
-    interface Test extends superagent.Request<Test> {
-      url: string;
-      serverAddress(app: any, path: string): string;
-      expect(status: number, callback?: CallbackHandler): Test;
-      expect(status: number, body: string, callback?: CallbackHandler): Test;
-      expect(body: string, callback?: CallbackHandler): Test;
-      expect(body: RegExp, callback?: CallbackHandler): Test;
-      expect(body: Object, callback?: CallbackHandler): Test;
-      expect(field: string, val: string, callback?: CallbackHandler): Test;
-      expect(field: string, val: RegExp, callback?: CallbackHandler): Test;
-      expect(checker: (res: Response) => any): Test;
-      end(callback?: CallbackHandler): Test;
-    }
-
     interface Response extends superagent.Response {
     }
+
+    interface Request extends superagent.Request {
+    }
+
+    type CallbackHandler = (err: any, res: Response) => void;
+    interface Test extends Request {
+      app?: any;
+      url: string;
+      serverAddress(app: any, path: string): string;
+      expect(status: number, callback?: CallbackHandler): this;
+      expect(status: number, body: string, callback?: CallbackHandler): this;
+      expect(body: string, callback?: CallbackHandler): this;
+      expect(body: RegExp, callback?: CallbackHandler): this;
+      expect(body: Object, callback?: CallbackHandler): this;
+      expect(field: string, val: string, callback?: CallbackHandler): this;
+      expect(fzield: string, val: RegExp, callback?: CallbackHandler): this;
+      expect(checker: (res: Response) => any): this;
+      end(callback?: CallbackHandler): this;
+    }
+
+    function agent(app?: any): SuperTest<Test>;
+
+    interface SuperTest<T> extends superagent.SuperAgent<T> {
+    }
+
   }
+
 
   export = supertest;
 }


### PR DESCRIPTION
``` ts
    await request(app).post("/hello")
        .expect("Content-Type", /json/)
        .expect(success) // show error
        .expect(success) // show error
        .expect(success) // show error
```

originally, only accept one `expect`
now, can accept as many as possible.
