### PR TITLE
Fixed IScroll preventDefaultException

### DIFF
--- a/iscroll/iscroll-5-tests.ts
+++ b/iscroll/iscroll-5-tests.ts
@@ -34,3 +34,7 @@ myScroll2.on('scrollStart', function () { console.log('scroll started'); });
 
 var myScroll9 = new IScroll(document.getElementById('wrapper'));
 var myScroll10 = new IScroll(document.getElementById('wrapper'), { scrollbarClass: 'myScrollbar' });
+
+
+var myScroll11 = new IScroll(document.getElementById('wrapper'), { preventDefaultException: [ /^(INPUT|TEXTAREA|BUTTON|SELECT)$/ ] });
+var myScroll12 = new IScroll(document.getElementById('wrapper'), { preventDefaultException: { tagName: /^(INPUT|TEXTAREA|BUTTON|SELECT)$/ } });

--- a/iscroll/iscroll-5.d.ts
+++ b/iscroll/iscroll-5.d.ts
@@ -54,7 +54,7 @@ interface IScrollOptions {
 	bounceEasing?: any;
 	
 	preventDefault?: boolean;
-	preventDefaultException?: Object;
+	preventDefaultException?: Array<RegExp>|Object;
 
 	HWCompositing?: boolean;
 

--- a/iscroll/iscroll-5.d.ts
+++ b/iscroll/iscroll-5.d.ts
@@ -54,7 +54,7 @@ interface IScrollOptions {
 	bounceEasing?: any;
 	
 	preventDefault?: boolean;
-	preventDefaultException?: boolean;
+	preventDefaultException?: Object;
 
 	HWCompositing?: boolean;
 


### PR DESCRIPTION
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

IScroll's preventDefaultException option is not a boolean value, but instead a collection of regular expressions.
Typings have been updated to now require an array, or an object (as per the [original source code](https://github.com/cubiq/iscroll/blob/master/build/iscroll.js#L311)), and added a new test case for this option.
