### PR TITLE
Updated kafka-node's Consumer constructor signature

### DIFF
--- a/kafka-node/kafka-node.d.ts
+++ b/kafka-node/kafka-node.d.ts
@@ -28,7 +28,7 @@ declare module 'kafka-node' {
     }
 
     export class Consumer {
-        constructor(client: Client, fetchRequests: Array<Topic>, options: ConsumerOptions);
+        constructor(client: Client, fetchRequests: Array<OffsetFetchRequest>, options: ConsumerOptions);
         on(eventName: string, cb: (message: string) => any): void;
         on(eventName: string, cb: (error: any) => any): void;
         addTopics(topics: Array<string>, cb: (error: any, added: boolean) => any): void;


### PR DESCRIPTION
Improvement to the existing `kafka-node` type definition.

Changed the type of the constructor's `fetchRequests` argument from `Array<Topic>` to `Array<OffsetFetchRequest>`.

Based on the given example in node-kafka's [Consumer documentation](https://github.com/SOHU-Co/kafka-node#consumer):

```
var kafka = require('kafka-node'),
    Consumer = kafka.Consumer,
    client = new kafka.Client(),
    consumer = new Consumer(
        client,
        [
            { topic: 't', partition: 0 }, { topic: 't1', partition: 1 }
        ],
        {
            autoCommit: false
        }
    );
```

This would cause the following error as the `Topic` class does not have a `partition` field:

```
error TS2345: Argument of type '{ topic: string; partition: number; }[]' is not assignable to parameter of type 'Topic[]'.
  Type '{ topic: string; partition: number; }' is not assignable to type 'Topic'.
    Object literal may only specify known properties, and 'partition' does not exist in type 'Topic'.
```

Updating the type to `Array<OffsetFetchRequest>` resolves this issue.
