### PR TITLE
Fix https://github.com/Microsoft/TypeScript/issues/9629

### DIFF
--- a/ioredis/index.d.ts
+++ b/ioredis/index.d.ts
@@ -22,8 +22,8 @@ interface RedisStatic {
     Cluster: IORedis.Cluster;
 }
 
-declare var redis: RedisStatic;
-export = redis;
+declare var IORedis: RedisStatic;
+export = IORedis;
 
 declare module IORedis {
     interface Commander {


### PR DESCRIPTION
Fix https://github.com/Microsoft/TypeScript/issues/9629

Expose `IORedis` namespace along with the value.
