### PR TITLE
Added @deprecated on request.param

### DIFF
--- a/express-serve-static-core/express-serve-static-core.d.ts
+++ b/express-serve-static-core/express-serve-static-core.d.ts
@@ -241,6 +241,8 @@ declare module "express-serve-static-core" {
         accepted: MediaType[];
 
         /**
+            * @deprecated Use either req.params, req.body or req.query, as applicable.
+            *
             * Return the value of param `name` when present or `defaultValue`.
             *
             *  - Checks route placeholders, ex: _/user/:id_


### PR DESCRIPTION
Added `@deprecated` to `Request.param(name, defaultValue?)` as noted in the [express docs](http://expressjs.com/de/api.html#req.param).

fixes #9754 
