### PR TITLE
MailParser: Added missing "stream" attribute on Attachment

### DIFF
--- a/mailparser/mailparser-tests.ts
+++ b/mailparser/mailparser-tests.ts
@@ -3,7 +3,7 @@
 import mailparser_mod = require("mailparser");
 import MailParser = mailparser_mod.MailParser;
 import ParsedMail = mailparser_mod.ParsedMail;
-
+import Attachment = mailparser_mod.Attachment;
 
 
 var mailparser = new MailParser();
@@ -61,7 +61,7 @@ var mp = new MailParser({
     streamAttachments: true
 })
 
-mp.on("attachment", function(attachment, mail){
+mp.on("attachment", function(attachment : Attachment, mail : ParsedMail){
     var output = fs.createWriteStream(attachment.generatedFileName);
     attachment.stream.pipe(output);
 });

--- a/mailparser/mailparser.d.ts
+++ b/mailparser/mailparser.d.ts
@@ -8,6 +8,8 @@
 
 
 declare module 'mailparser' {
+    import StreamModule = require("stream");
+    import Stream = StreamModule.Stream;
     import WritableStream = NodeJS.WritableStream;
     import EventEmitter = NodeJS.EventEmitter;
 
@@ -36,6 +38,7 @@ declare module 'mailparser' {
         generatedFileName: string;   // e.g. 'image.png'
         checksum: string;  // the md5 hash of the file, e.g. 'e4cef4c6e26037bcf8166905207ea09b'
         content: Buffer;   // possibly a SlowBuffer
+        stream: Stream; // a stream to read the attachment if streamAttachments is set to true 
     }
     
     // emitted with the 'end' event


### PR DESCRIPTION
Test was already present but not using typed parameters, hence allowing loose types verification.

See documentation at https://github.com/andris9/mailparser#attachment-streaming
