### PR TITLE
webrtc: Fix type of ondatachannel event

### DIFF
--- a/webrtc/RTCPeerConnection-tests.ts
+++ b/webrtc/RTCPeerConnection-tests.ts
@@ -41,7 +41,7 @@ navigator.getUserMedia({ audio: true, video: true },
   });
 
 peerConnection.onaddstream = ev => console.log(ev.type);
-peerConnection.ondatachannel = ev => console.log(ev.type);
+peerConnection.ondatachannel = ev => console.log(ev.channel);
 peerConnection.oniceconnectionstatechange = ev => console.log(ev.type);
 peerConnection.onnegotiationneeded = ev => console.log(ev.type);
 peerConnection.onopen = ev => console.log(ev.type);

--- a/webrtc/RTCPeerConnection.d.ts
+++ b/webrtc/RTCPeerConnection.d.ts
@@ -191,6 +191,7 @@ declare var RTCDataChannel: {
   new (): RTCDataChannel;
 };
 
+// https://www.w3.org/TR/webrtc/#rtcdatachannelevent
 interface RTCDataChannelEvent extends Event {
   channel: RTCDataChannel;
 }
@@ -309,7 +310,7 @@ interface RTCPeerConnection {
   getRemoteStreams(): MediaStream[];
   createDataChannel(label?: string,
                     dataChannelDict?: RTCDataChannelInit): RTCDataChannel;
-  ondatachannel: (event: Event) => void;
+  ondatachannel: (event: RTCDataChannelEvent) => void;
   addStream(stream: MediaStream, constraints?: RTCMediaConstraints): void;
   removeStream(stream: MediaStream): void;
   close(): void;


### PR DESCRIPTION
Improvement to existing type definition.
- [x] documentation or source code reference which provides context for the suggested changes
- [ ] it has been reviewed by a DefinitelyTyped member

Source for change: https://www.w3.org/TR/webrtc/#event-datachannel and https://www.w3.org/TR/webrtc/#rtcdatachannelevent
