### PR TITLE
Add the options argument to openlayers custom control

### DIFF
--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -2395,6 +2395,8 @@ declare namespace ol {
         }
 
         class Control {
+            //TODO: Replace with olx.control.ControlOptions
+            constructor(options?: any);
         }
 
         class FullScreen {

--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -1079,6 +1079,25 @@ declare namespace olx {
             rightHanded?: boolean;
         }
     }
+
+    namespace control {
+        interface ControlOptions {
+            /**
+             * The element is the control's container element. This only needs to be specified if you're developing a custom control.
+             */
+            element?: Element;
+
+            /**
+             * Function called when the control should be re-rendered. This is called in a requestAnimationFrame callback.
+             */
+            render?: any;
+
+            /**
+             * Specify a target if you want the control to be rendered outside of the map's viewport.
+             */
+            target?: Element | string;
+        }
+    }
 }
 
 /**
@@ -2395,8 +2414,7 @@ declare namespace ol {
         }
 
         class Control {
-            //TODO: Replace with olx.control.ControlOptions
-            constructor(options?: any);
+            constructor(options: olx.control.ControlOptions);
         }
 
         class FullScreen {


### PR DESCRIPTION
As it can be seen in the openlayers' [documentation](http://openlayers.org/en/v3.6.0/apidoc/ol.control.Control.html), the `ol.control.Control`'s constructor has an `options` argument. This PR adds this argument with the associated type (`olx.control.ControlOptions`).
The openlayers' documentation does not say it but this argument has to be set. If not, an error occurs: `TypeError: Cannot read property 'element' of undefined`.
