### PR TITLE
Fix nodejs StringDecoder definition

### DIFF
--- a/node/node-0.10.d.ts
+++ b/node/node-0.10.d.ts
@@ -1032,10 +1032,10 @@ declare module "path" {
 declare module "string_decoder" {
     export interface NodeStringDecoder {
         write(buffer: Buffer): string;
-        detectIncompleteChar(buffer: Buffer): number;
+        end(): string;
     }
     export var StringDecoder: {
-        new (encoding: string): NodeStringDecoder;
+        new (encoding?: string): NodeStringDecoder;
     };
 }
 

--- a/node/node-0.11-tests.ts
+++ b/node/node-0.11-tests.ts
@@ -12,6 +12,7 @@ import net = require("net");
 import dgram = require("dgram");
 import querystring = require('querystring');
 import readline = require('readline');
+import string_decoder = require('string_decoder');
 
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
@@ -120,6 +121,18 @@ namespace http_tests {
     var code = 100;
     var codeMessage = http.STATUS_CODES['400'];
     var codeMessage = http.STATUS_CODES[400];
+}
+
+////////////////////////////////////////////////////
+/// string_decoder tests : https://nodejs.org/api/string_decoder.html
+////////////////////////////////////////////////////
+
+namespace string_decoder_tests {
+    var StringDecoder = string_decoder.StringDecoder;
+    var buffer = new Buffer('test');
+    var decoder = new StringDecoder('utf8');
+    var part: string = decoder.write(new Buffer('test'));
+    var end: string = decoder.end();
 }
 
 ////////////////////////////////////////////////////

--- a/node/node-0.11.d.ts
+++ b/node/node-0.11.d.ts
@@ -943,10 +943,10 @@ declare module "path" {
 declare module "string_decoder" {
     export interface NodeStringDecoder {
         write(buffer: Buffer): string;
-        detectIncompleteChar(buffer: Buffer): number;
+        end(): string;
     }
     export var StringDecoder: {
-        new (encoding: string): NodeStringDecoder;
+        new (encoding?: string): NodeStringDecoder;
     };
 }
 

--- a/node/node-0.12-tests.ts
+++ b/node/node-0.12-tests.ts
@@ -14,6 +14,7 @@ import * as querystring from "querystring";
 import * as path from "path";
 import * as readline from "readline";
 import * as childProcess from "child_process";
+import * as string_decoder from "string_decoder";
 
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
@@ -403,6 +404,18 @@ rl.prompt(true);
 rl.question("do you like typescript?", function(answer: string) {
   rl.close();
 });
+
+////////////////////////////////////////////////////
+/// string_decoder tests : https://nodejs.org/api/string_decoder.html
+////////////////////////////////////////////////////
+
+namespace string_decoder_tests {
+    var StringDecoder = string_decoder.StringDecoder;
+    var buffer = new Buffer('test');
+    var decoder = new StringDecoder('utf8');
+    var part: string = decoder.write(new Buffer('test'));
+    var end: string = decoder.end();
+}
 
 //////////////////////////////////////////////////////////////////////
 /// Child Process tests: https://nodejs.org/api/child_process.html ///

--- a/node/node-0.12.d.ts
+++ b/node/node-0.12.d.ts
@@ -1480,10 +1480,10 @@ declare module "path" {
 declare module "string_decoder" {
     export interface NodeStringDecoder {
         write(buffer: Buffer): string;
-        detectIncompleteChar(buffer: Buffer): number;
+        end(): string;
     }
     export var StringDecoder: {
-        new (encoding: string): NodeStringDecoder;
+        new (encoding?: string): NodeStringDecoder;
     };
 }
 

--- a/node/node-4-tests.ts
+++ b/node/node-4-tests.ts
@@ -19,6 +19,8 @@ import * as childProcess from "child_process";
 import * as cluster from "cluster";
 import * as os from "os";
 import * as vm from "vm";
+import * as string_decoder from "string_decoder";
+
 // Specifically test buffer module regression.
 import {Buffer as ImportedBuffer, SlowBuffer as ImportedSlowBuffer} from "buffer";
 
@@ -697,6 +699,18 @@ namespace readline_tests {
 
         readline.clearScreenDown(stream);
     }
+}
+
+////////////////////////////////////////////////////
+/// string_decoder tests : https://nodejs.org/api/string_decoder.html
+////////////////////////////////////////////////////
+
+namespace string_decoder_tests {
+    const StringDecoder = string_decoder.StringDecoder;
+    const buffer = new Buffer('test');
+    const decoder = new StringDecoder('utf8');
+    const part: string = decoder.write(new Buffer('test'));
+    const end: string = decoder.end();
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/node/node-4.d.ts
+++ b/node/node-4.d.ts
@@ -1779,10 +1779,10 @@ declare module "path" {
 declare module "string_decoder" {
     export interface NodeStringDecoder {
         write(buffer: Buffer): string;
-        detectIncompleteChar(buffer: Buffer): number;
+        end(): string;
     }
     export var StringDecoder: {
-        new (encoding: string): NodeStringDecoder;
+        new (encoding?: string): NodeStringDecoder;
     };
 }
 

--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -19,6 +19,8 @@ import * as childProcess from "child_process";
 import * as cluster from "cluster";
 import * as os from "os";
 import * as vm from "vm";
+import * as string_decoder from "string_decoder";
+
 // Specifically test buffer module regression.
 import {Buffer as ImportedBuffer, SlowBuffer as ImportedSlowBuffer} from "buffer";
 
@@ -721,6 +723,21 @@ namespace readline_tests {
 
         readline.clearScreenDown(stream);
     }
+}
+
+////////////////////////////////////////////////////
+/// string_decoder tests : https://nodejs.org/api/string_decoder.html
+////////////////////////////////////////////////////
+
+namespace string_decoder_tests {
+    const StringDecoder = string_decoder.StringDecoder;
+    const buffer = new Buffer('test');
+    const decoder1 = new StringDecoder();
+    const decoder2 = new StringDecoder('utf8');
+    const part1: string = decoder1.write(new Buffer('test'));
+    const end1: string = decoder1.end();
+    const part2: string = decoder2.write(new Buffer('test'));
+    const end2: string = decoder1.end(new Buffer('test'));
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1812,10 +1812,10 @@ declare module "path" {
 declare module "string_decoder" {
     export interface NodeStringDecoder {
         write(buffer: Buffer): string;
-        detectIncompleteChar(buffer: Buffer): number;
+        end(buffer?: Buffer): string;
     }
     export var StringDecoder: {
-        new (encoding: string): NodeStringDecoder;
+        new (encoding?: string): NodeStringDecoder;
     };
 }
 
@@ -1826,7 +1826,7 @@ declare module "tls" {
 
     var CLIENT_RENEG_LIMIT: number;
     var CLIENT_RENEG_WINDOW: number;
-    
+
     export interface Certificate {
         /**
          * Country code.
@@ -1868,7 +1868,7 @@ declare module "tls" {
     export class TLSSocket extends stream.Duplex {
         /**
          * Returns the bound address, the address family name and port of the underlying socket as reported by
-         * the operating system. 
+         * the operating system.
          * @returns {any} - An object with three properties, e.g. { port: 12346, family: 'IPv4', address: '127.0.0.1' }.
          */
         address(): { port: number; family: string; address: string };
@@ -1945,7 +1945,7 @@ declare module "tls" {
         remotePort: number;
         /**
          * Initiate TLS renegotiation process.
-         *  
+         *
          * NOTE: Can be used to request peer's certificate after the secure connection has been established.
          * ANOTHER NOTE: When running as the server, socket will be destroyed with an error after handshakeTimeout timeout.
          * @param {TlsOptions} options - The options may contain the following fields: rejectUnauthorized,
@@ -1966,7 +1966,7 @@ declare module "tls" {
          */
         setMaxSendFragment(size: number): boolean;
     }
-    
+
     export interface TlsOptions {
         host?: string;
         port?: number;


### PR DESCRIPTION
According to nodejs documentation the current definition of nodejs StringDecoder is invalid.

Reference: 
- latest: https://nodejs.org/api/string_decoder.html
- v4: https://nodejs.org/dist/latest-v4.x/docs/api/string_decoder.html
- v0.12: https://nodejs.org/docs/latest-v0.12.x/api/string_decoder.html
- v0.10: https://nodejs.org/docs/latest-v0.10.x/api/string_decoder.html

The only change in the documentation between the 4 versions occurs between version 4 and 6 (latest).
