### PR TITLE
Fix signature for _.sum/sumBy when summing properties from object arrays in Lodash

### DIFF
--- a/lodash/lodash-3.10-tests.ts
+++ b/lodash/lodash-3.10-tests.ts
@@ -7700,8 +7700,13 @@ namespace TestRound {
 // _.sum
 namespace TestSum {
     let array: number[];
+    let objectArray: { 'age': number }[];
+
     let list: _.List<number>;
+    let objectList: _.List<{ 'age': number }>;
+
     let dictionary: _.Dictionary<number>;
+    let objectDictionary: _.Dictionary<{ 'age': number }>;
 
     let listIterator: (value: number, index: number, collection: _.List<number>) => number;
     let dictionaryIterator: (value: number, key: string, collection: _.Dictionary<number>) => number;
@@ -7713,36 +7718,36 @@ namespace TestSum {
         result = _.sum<number>(array);
         result = _.sum<number>(array, listIterator);
         result = _.sum<number>(array, listIterator, any);
-        result = _.sum<number>(array, '');
+        result = _.sum(objectArray, 'age');
 
 
         result = _.sum(list);
         result = _.sum<number>(list);
         result = _.sum<number>(list, listIterator);
         result = _.sum<number>(list, listIterator, any);
-        result = _.sum<number>(list, '');
+        result = _.sum(objectList, 'age');
 
         result = _.sum(dictionary);
         result = _.sum<number>(dictionary);
         result = _.sum<number>(dictionary, dictionaryIterator);
         result = _.sum<number>(dictionary, dictionaryIterator, any);
-        result = _.sum<number>(dictionary, '');
+        result = _.sum(objectDictionary, 'age');
 
         result = _(array).sum();
         result = _(array).sum(listIterator);
         result = _(array).sum(listIterator, any);
-        result = _(array).sum('');
+        result = _(objectArray).sum('age');
 
 
         result = _(list).sum();
         result = _(list).sum<number>(listIterator);
         result = _(list).sum<number>(listIterator, any);
-        result = _(list).sum('');
+        result = _(objectList).sum('age');
 
         result = _(dictionary).sum();
         result = _(dictionary).sum<number>(dictionaryIterator);
         result = _(dictionary).sum<number>(dictionaryIterator, any);
-        result = _(dictionary).sum('');
+        result = _(objectDictionary).sum('age');
     }
 
     {
@@ -7751,18 +7756,18 @@ namespace TestSum {
         result = _(array).chain().sum();
         result = _(array).chain().sum(listIterator);
         result = _(array).chain().sum(listIterator, any);
-        result = _(array).chain().sum('');
+        result = _(objectArray).chain().sum('');
 
 
         result = _(list).chain().sum();
         result = _(list).chain().sum<number>(listIterator);
         result = _(list).chain().sum<number>(listIterator, any);
-        result = _(list).chain().sum('');
+        result = _(objectList).chain().sum('age');
 
         result = _(dictionary).chain().sum();
         result = _(dictionary).chain().sum<number>(dictionaryIterator);
         result = _(dictionary).chain().sum<number>(dictionaryIterator, any);
-        result = _(dictionary).chain().sum('');
+        result = _(objectDictionary).chain().sum('age');
     }
 }
 

--- a/lodash/lodash-3.10.d.ts
+++ b/lodash/lodash-3.10.d.ts
@@ -12065,8 +12065,8 @@ declare module _ {
         /**
          * @see _.sum
          */
-        sum<T>(
-            collection: List<number>|Dictionary<number>,
+        sum(
+            collection: List<{}>|Dictionary<{}>,
             iteratee: string
         ): number;
 

--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -7896,49 +7896,41 @@ namespace TestSum {
 // _.sumBy
 namespace TestSumBy {
     let array: number[];
+    let objectArray: { 'age': number }[];
+
     let list: _.List<number>;
-    let dictionary: _.Dictionary<number>;
+    let objectList: _.List<{ 'age': number }>;
 
     let listIterator: (value: number, index: number, collection: _.List<number>) => number;
-    let dictionaryIterator: (value: number, key: string, collection: _.Dictionary<number>) => number;
 
     {
         let result: number;
 
-        result = _.sumBy<number>(array);
-        result = _.sumBy<number>(array, listIterator);
-        result = _.sumBy<number>(array, '');
+        result = _.sumBy(array);
+        result = _.sumBy(array, listIterator);
+        result = _.sumBy(objectArray, 'age');
+        result = _.sumBy(objectArray, { 'age': 30 });
 
-
-        result = _.sumBy<number>(list);
-        result = _.sumBy<number>(list, listIterator);
-        result = _.sumBy<number>(list, '');
-
-        result = _.sumBy<number>(dictionary);
-        result = _.sumBy<number>(dictionary, dictionaryIterator);
-        result = _.sumBy<number>(dictionary, '');
+        result = _.sumBy(list);
+        result = _.sumBy(list, listIterator);
+        result = _.sumBy(objectList, 'age');
+        result = _.sumBy(objectList, { 'age': 30 });
 
         result = _(array).sumBy(listIterator);
-        result = _(array).sumBy('');
+        result = _(objectArray).sumBy('age');
 
-        result = _(list).sumBy<number>(listIterator);
-        result = _(list).sumBy('');
-
-        result = _(dictionary).sumBy<number>(dictionaryIterator);
-        result = _(dictionary).sumBy('');
+        result = _(list).sumBy(listIterator);
+        result = _(objectList).sumBy('age');
     }
 
     {
         let result: _.LoDashExplicitWrapper<number>;
 
         result = _(array).chain().sumBy(listIterator);
-        result = _(array).chain().sumBy('');
+        result = _(objectArray).chain().sumBy('age');
 
-        result = _(list).chain().sumBy<number>(listIterator);
-        result = _(list).chain().sumBy('');
-
-        result = _(dictionary).chain().sumBy<number>(dictionaryIterator);
-        result = _(dictionary).chain().sumBy('');
+        result = _(list).chain().sumBy(listIterator);
+        result = _(objectList).chain().sumBy('age');
     }
 }
 

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -13477,29 +13477,26 @@ declare module _ {
 
         /**
          * @see _.sumBy
-         **/
-        sumBy<T>(
-            collection: Dictionary<T>,
-            iteratee: DictionaryIterator<T, number>
-        ): number;
-
-        /**
-         * @see _.sumBy
          */
-        sumBy<T>(
-            collection: List<number>|Dictionary<number>,
+        sumBy(
+            collection: List<{}>,
             iteratee: string
         ): number;
 
         /**
          * @see _.sumBy
          */
-        sumBy<T>(collection: List<T>|Dictionary<T>): number;
+        sumBy(
+            collection: List<number>
+        ): number;
 
         /**
          * @see _.sumBy
          */
-        sumBy(collection: List<number>|Dictionary<number>): number;
+        sumBy(
+            collection: List<{}>,
+            iteratee: Dictionary<{}>
+        ): number;
     }
 
     interface LoDashImplicitArrayWrapper<T> {
@@ -13518,15 +13515,15 @@ declare module _ {
         /**
          * @see _.sumBy
          */
-        sumBy(): number;
+        sumBy(iteratee: Dictionary<{}>): number;
     }
 
     interface LoDashImplicitObjectWrapper<T> {
         /**
          * @see _.sumBy
-         **/
-        sumBy<TValue>(
-            iteratee: ListIterator<TValue, number>|DictionaryIterator<TValue, number>
+         */
+        sumBy(
+            iteratee: ListIterator<{}, number>
         ): number;
 
         /**
@@ -13537,7 +13534,7 @@ declare module _ {
         /**
          * @see _.sumBy
          */
-        sumBy(): number;
+        sumBy(iteratee: Dictionary<{}>): number;
     }
 
     interface LoDashExplicitArrayWrapper<T> {
@@ -13557,14 +13554,19 @@ declare module _ {
          * @see _.sumBy
          */
         sumBy(): LoDashExplicitWrapper<number>;
+
+        /**
+         * @see _.sumBy
+         */
+        sumBy(iteratee: Dictionary<{}>): LoDashExplicitWrapper<number>;
     }
 
     interface LoDashExplicitObjectWrapper<T> {
         /**
          * @see _.sumBy
          */
-        sumBy<TValue>(
-            iteratee: ListIterator<TValue, number>|DictionaryIterator<TValue, number>
+        sumBy(
+            iteratee: ListIterator<{}, number>
         ): LoDashExplicitWrapper<number>;
 
         /**
@@ -13575,7 +13577,7 @@ declare module _ {
         /**
          * @see _.sumBy
          */
-        sumBy(): LoDashExplicitWrapper<number>;
+        sumBy(iteratee: Dictionary<{}>): LoDashExplicitWrapper<number>;
     }
 
     /**********


### PR DESCRIPTION
Fixes _.sum in Lodash 3.10 and _.sumBy in Lodash 4.

This is a recreation and update of a recent automatically closed PR: #7066

Without this change you could only sum over lists of numbers, which rejected the (working) code below:

``` javascript
_.sum([{age: 20}, {age: 30}], 'age'); // Lodash 3.10
_.sumBy([{age: 20}, {age: 30}], 'age'); // Lodash 4
```

See the documentation for [3.10](https://github.com/lodash/lodash/blob/3.10.1/doc/README.md#_sumcollection-iteratee-thisarg) and [4](https://lodash.com/docs#sumBy) for more details.

For Lodash 4 this fixes both this issue and also tidies up a little and removes various invalid sumBy signatures (in the current Lodash version you can no longer sum over dictionaries of objects or numbers - it's now lists or numbers or objects only).

I'd quite like to make the chained API (`_([1,2,3]).sumBy...`) valid only for arrays as well, to disallow invalid dictionary usage there, but currently all the Lodash v4 types required `_.List` to be a LoDashImplicit**Object**Wrapper, not an LoDashImplicit**Array**Wrapper, so you can't easily distinguish between lists (e.g. JQuery arrays) and actual dictionaries. Not desperately important, and it works for now (it's just more lax than it could be) but it might be worth thinking about in future.
