### PR TITLE
[Material UI] Fixed button labels

### DIFF
--- a/material-ui/material-ui-tests.tsx
+++ b/material-ui/material-ui-tests.tsx
@@ -680,7 +680,7 @@ const FlatButtonExampleComplex = () => (
     </FlatButton>
 
     <FlatButton
-      label="Label before"
+      label={<span>Label before</span>}
       labelPosition="before"
       primary={true}
       style={styles.button}
@@ -741,7 +741,7 @@ const RaisedButtonExampleComplex = () => (
       <input type="file" style={styles.exampleImageInput} />
     </RaisedButton>
     <RaisedButton
-      label="Label before"
+      label={<span>Label before</span>}
       labelPosition="before"
       primary={true}
       icon={<ActionAndroid />}

--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -662,7 +662,7 @@ declare namespace __MaterialUI {
         hoverColor?: string;
         href?: string;
         icon?: React.ReactNode;
-        label?: string;
+        label?: React.ReactNode;
         labelPosition?: "before" | "after";
         labelStyle?: React.CSSProperties;
         linkButton?: boolean;
@@ -688,7 +688,7 @@ declare namespace __MaterialUI {
         fullWidth?: boolean;
         href?: string;
         icon?: React.ReactNode;
-        label?: string;
+        label?: React.ReactNode;
         labelColor?: string;
         labelPosition?: "before" | "after";
         labelStyle?: React.CSSProperties;


### PR DESCRIPTION
Fixes incorrectly defined button labels. They are actually ReactNodes not strings.
https://github.com/callemall/material-ui/blob/master/src/FlatButton/FlatButton.js#L240
https://github.com/callemall/material-ui/blob/master/src/FlatButton/FlatButtonLabel.js#L18

@ngbrown
