### PR TITLE
Add simplified constructor syntax for node streams

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -20,6 +20,7 @@ import * as cluster from "cluster";
 import * as os from "os";
 import * as vm from "vm";
 import * as string_decoder from "string_decoder";
+import * as stream from "stream";
 
 // Specifically test buffer module regression.
 import {Buffer as ImportedBuffer, SlowBuffer as ImportedSlowBuffer} from "buffer";
@@ -288,6 +289,70 @@ function stream_readable_pipe_test() {
     var w = fs.createWriteStream('file.txt.gz');
     r.pipe(z).pipe(w);
     r.close();
+}
+
+// Simplified constructors
+function simplified_stream_ctor_test() {
+    new stream.Readable({
+        read: function (size) {
+            size.toFixed();
+        }
+    });
+
+    new stream.Writable({
+        write: function (chunk, enc, cb) {
+            chunk.slice(1);
+            enc.charAt(0);
+            cb()
+        },
+        writev: function (chunks, cb) {
+            chunks[0].chunk.slice(0);
+            chunks[0].encoding.charAt(0);
+            cb();
+        }
+    });
+
+    new stream.Duplex({
+        read: function (size) {
+            size.toFixed();
+        },
+        write: function (chunk, enc, cb) {
+            chunk.slice(1);
+            enc.charAt(0);
+            cb()
+        },
+        writev: function (chunks, cb) {
+            chunks[0].chunk.slice(0);
+            chunks[0].encoding.charAt(0);
+            cb();
+        },
+        readableObjectMode: true,
+        writableObjectMode: true
+    });
+
+    new stream.Transform({
+        transform: function (chunk, enc, cb) {
+            chunk.slice(1);
+            enc.charAt(0);
+            cb();
+        },
+        flush: function (cb) {
+            cb()
+        },
+        read: function (size) {
+            size.toFixed();
+        },
+        write: function (chunk, enc, cb) {
+            chunk.slice(1);
+            enc.charAt(0);
+            cb()
+        },
+        writev: function (chunks, cb) {
+            chunks[0].chunk.slice(0);
+            chunks[0].encoding.charAt(0);
+            cb();
+        }
+    })
 }
 
 ////////////////////////////////////////////////////

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -2161,6 +2161,7 @@ declare module "stream" {
         highWaterMark?: number;
         encoding?: string;
         objectMode?: boolean;
+        read?: (size?: number) => any;
     }
 
     export class Readable extends events.EventEmitter implements NodeJS.ReadableStream {
@@ -2182,6 +2183,8 @@ declare module "stream" {
         highWaterMark?: number;
         decodeStrings?: boolean;
         objectMode?: boolean;
+        write?: (chunk: string|Buffer, encoding: string, callback: Function) => any;
+        writev?: (chunks: {chunk: string|Buffer, encoding: string}[], callback: Function) => any;
     }
 
     export class Writable extends events.EventEmitter implements NodeJS.WritableStream {
@@ -2197,6 +2200,8 @@ declare module "stream" {
 
     export interface DuplexOptions extends ReadableOptions, WritableOptions {
         allowHalfOpen?: boolean;
+        readableObjectMode?: boolean;
+        writableObjectMode?: boolean;
     }
 
     // Note: Duplex extends both Readable and Writable.
@@ -2211,7 +2216,10 @@ declare module "stream" {
         end(chunk: any, encoding?: string, cb?: Function): void;
     }
 
-    export interface TransformOptions extends ReadableOptions, WritableOptions { }
+    export interface TransformOptions extends ReadableOptions, WritableOptions {
+        transform?: (chunk: string|Buffer, encoding: string, callback: Function) => any;
+        flush?: (callback: Function) => any;
+    }
 
     // Note: Transform lacks the _read and _write methods of Readable/Writable.
     export class Transform extends events.EventEmitter implements NodeJS.ReadWriteStream {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] tests updated
- [ ] has been reviewed by a DefinitelyTyped member.

Documentation which provides context for the suggested changes: https://nodejs.org/api/stream.html#stream_simplified_construction
