### PR TITLE
Allow react Component.render() to return null.

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -164,7 +164,7 @@ declare namespace __React {
         setState(f: (prevState: S, props: P) => S, callback?: () => any): void;
         setState(state: S, callback?: () => any): void;
         forceUpdate(callback?: () => any): void;
-        render(): JSX.Element;
+        render(): JSX.Element | null;
 
         // React.Props<T> is now deprecated, which means that the `children`
         // property is not available on `P` by default, even though you can
@@ -256,7 +256,7 @@ declare namespace __React {
     }
 
     interface ComponentSpec<P, S> extends Mixin<P, S> {
-        render(): ReactElement<any>;
+        render(): ReactElement<any> | null;
 
         [propertyName: string]: any;
     }
@@ -2347,7 +2347,7 @@ declare namespace JSX {
 
     interface Element extends React.ReactElement<any> { }
     interface ElementClass extends React.Component<any, any> {
-        render(): JSX.Element;
+        render(): JSX.Element | null;
     }
     interface ElementAttributesProperty { props: {}; }
 


### PR DESCRIPTION
So one can return `null` from a Component's `render` method when compiling using `--strictNullChecks`.

As per the documentation https://facebook.github.io/react/docs/component-specs.html#render
