### PR TITLE
Fix WebSocketRequest.reject + update gh url

### DIFF
--- a/websocket/websocket.d.ts
+++ b/websocket/websocket.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for websocket
-// Project: https://github.com/Worlize/WebSocket-Node
+// Project: https://github.com/theturtle32/WebSocket-Node
 // Definitions by: Paul Loyd <https://github.com/loyd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
@@ -236,8 +236,9 @@ declare module "websocket" {
          * You may optionally pass in an HTTP Status code (such as 404) and a textual
          * description that will be sent to the client in the form of an
          * `X-WebSocket-Reject-Reason` header.
+         * Optional extra http headers can be added via Object key/values on extraHeaders.
          */
-        reject(httpStatus?: number, reason?: string): void;
+        reject(httpStatus?: number, reason?: string, extraHeaders?: Object): void;
 
         // Events
         on(event: string, listener: () => void): this;


### PR DESCRIPTION
reject method supports a useful undocumented 3rd parameter, see https://github.com/theturtle32/WebSocket-Node/blob/v1.0.23/lib/WebSocketRequest.js#L465

https://github.com/Worlize/WebSocket-Node redirects to https://github.com/theturtle32/WebSocket-Node. Fixing it here will help avoid ambiguity about whether these are the right typings.
