### PR TITLE
Change types of request.params and request.pre to any

### DIFF
--- a/hapi/hapi.d.ts
+++ b/hapi/hapi.d.ts
@@ -1190,7 +1190,7 @@ declare module "hapi" {
 		/**  plugin-specific state. Provides a place to store and pass request-level plugin data. The plugins is an object where each key is a plugin name and the value is the state.*/
 		plugins: any;
 		/** an object where each key is the name assigned by a route prerequisites function. The values are the raw values provided to the continuation function as argument. For the wrapped response object, use responses.*/
-		pre: IDictionary<any>;
+		pre: any;
 		/** the response object when set. The object can be modified but must not be assigned another object. To replace the response with another from within an extension point, use reply(response) to override with a different response. Contains null when no response has been set (e.g. when a request terminates prematurely when the client disconnects).*/
 		response: Response;
 		/**preResponses - same as pre but represented as the response object created by the pre method.*/

--- a/hapi/hapi.d.ts
+++ b/hapi/hapi.d.ts
@@ -1180,7 +1180,7 @@ declare module "hapi" {
 			payload: any;
 		};
 		/**  an object where each key is a path parameter name with matching value as described in Path parameters.*/
-		params: IDictionary<string>;
+		params: any;
 		/** an array containing all the path params values in the order they appeared in the path.*/
 		paramsArray: string[];
 		/**  the request URI's path component. */


### PR DESCRIPTION
The current definition only allows `request.params["someParam"]`. The [documentation](http://hapijs.com/api#path-parameters) is clear that `request.params.someParam` is to be allowed, just as `request.query.someQuery` is already allowed.
