### PR TITLE
rails-actioncable: Support import + fix ambicious datatype

### DIFF
--- a/rails-actioncable/rails-actioncable-tests.ts
+++ b/rails-actioncable/rails-actioncable-tests.ts
@@ -1,4 +1,24 @@
 /// <reference path="./rails-actioncable.d.ts" />
+
+interface HelloChannel extends ActionCable.Channel {
+  hello(world: string, name?: string): void;
+}
+
 App = {};
 App.cable = ActionCable.createConsumer();
-App.cable.subscriptions.create("NetworkChannel", {});
+const helloChannel = App.cable.subscriptions.create('NetworkChannel', {
+  connected(): void {
+    console.log('connected');
+  },
+  disconnected(): void {
+    console.log('disconnected');
+  },
+  received(obj: Object): void {
+    console.log(obj);
+  },
+  hello(world: string, name: string = 'John Doe'): void {
+    console.log(`Hello, ${world}! name[${name}]`);
+  }
+}) as HelloChannel;
+
+helloChannel.hello('World');

--- a/rails-actioncable/rails-actioncable.d.ts
+++ b/rails-actioncable/rails-actioncable.d.ts
@@ -10,11 +10,18 @@ declare module ActionCable {
   }
 
   interface Subscriptions {
-    create(chan_name: string, obj: {}): Channel;
+    create(chan_name: string, obj: CreateMixin): Channel;
   }
 
   interface Cable {
     subscriptions: Subscriptions;
+  }
+
+  interface CreateMixin {
+    connected(): void;
+    disconnected(): void;
+    received(obj: Object): void;
+    [key: string]: Function;
   }
 
   function createConsumer(): Cable;

--- a/rails-actioncable/rails-actioncable.d.ts
+++ b/rails-actioncable/rails-actioncable.d.ts
@@ -8,24 +8,26 @@ declare module ActionCable {
     unsubscribe(): void;
     perform(action: string, data: {}): void;
   }
+
   interface Subscriptions {
     create(chan_name: string, obj: {}): Channel;
   }
+
   interface Cable {
     subscriptions: Subscriptions;
   }
+
   function createConsumer(): Cable;
   function createConsumer(url: string): Cable;
 }
 
 declare interface AppInterface {
   cable?: ActionCable.Cable;
-  network?: ActionCable.Channel; 
+  network?: ActionCable.Channel;
 }
 
 declare var App: AppInterface;
 
-
-
-
-
+declare module 'actioncable' {
+  export = ActionCable;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

sorry for my last awful PR 😄 
