### PR TITLE
Add definitions for app-root-path and gulp-insert

### DIFF
--- a/app-root-path/app-root-path-tests.ts
+++ b/app-root-path/app-root-path-tests.ts
@@ -1,0 +1,10 @@
+/// <reference path="app-root-path.d.ts" />
+import * as root from 'app-root-path';
+
+let resolvedPath: string;
+resolvedPath = root.resolve('../dir');
+resolvedPath = root.path;
+resolvedPath = root.toString();
+let resolvedModule: any = root.require('app-root-path');
+root.setPath('C:\\app-root');
+

--- a/app-root-path/app-root-path.d.ts
+++ b/app-root-path/app-root-path.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for app-root-path 1.2.1
+// Project: https://github.com/inxilpro/node-app-root-path
+// Definitions by: Shant Marouti <https://github.com/shantmarouti>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'app-root-path' {
+    interface RootPath {
+        
+        /**
+         * Application root directory absolute path
+         * @type {string}
+         */
+        path: string;
+
+        /**
+         * Resolves relative path from root to absolute path
+         * @param {string} pathToModule
+         * @returns {string}
+         */
+        resolve(pathToModule: string): string;
+
+        /**
+         * Resolve module by relative addressing from root
+         * @param {string} pathToModule
+         * @returns {*}
+         */
+        require(pathToModule: string): any;
+
+        /**
+         * Explicitly set root path
+         * @param {string} explicitlySetPath
+         */
+        setPath(explicitlySetPath: string): void;
+
+        toString(): string;
+    }
+    var RootPath: RootPath;
+    export = RootPath;
+}

--- a/gulp-insert/gulp-insert-tests.ts
+++ b/gulp-insert/gulp-insert-tests.ts
@@ -1,0 +1,21 @@
+///<reference path="gulp-insert.d.ts" />
+///<reference path="../gulp/gulp.d.ts" />
+
+import * as gulp from 'gulp';
+import * as insert from 'gulp-insert';
+
+gulp.task('gulp-insert-tests', () => {
+    return gulp.src('*.js')
+        .pipe(insert.prepend('/* Inserted using gulp-insert prepend method */\n'))
+        .pipe(insert.prepend('\n/* Inserted using gulp-insert append method */'))
+        .pipe(insert.wrap(
+            '/* Inserted using gulp-insert wrap method */\n',
+            '\n/* Inserted using gulp-insert wrap method */'
+        ))
+        .pipe(insert.transform((contents, file) => {
+            var comment = '/* Local file: ' + file.path + ' */\n';
+            return comment + contents;
+        }))
+        .pipe(gulp.dest('gulp-insert'));
+});
+

--- a/gulp-insert/gulp-insert.d.ts
+++ b/gulp-insert/gulp-insert.d.ts
@@ -1,0 +1,52 @@
+// Type definitions for gulp-insert 0.5.0
+// Project: https://github.com/rschmukler/gulp-insert
+// Definitions by: Shant Marouti <https://github.com/shantmarouti>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts"/>
+/// <reference path="../vinyl/vinyl.d.ts"/>
+
+declare module 'gulp-insert' {
+
+    import File = require('vinyl');
+
+    interface Transformer {
+        (contents: string, file: File): string
+    }
+
+    namespace Insert {
+
+        /**
+         * Prepends a string onto the contents
+         * @param {string} content
+         * @returns {NodeJS.ReadWriteStream}
+         */
+        function prepend(content: string): NodeJS.ReadWriteStream;
+
+        /**
+         * Appends a string onto the contents
+         * @param {string} content
+         * @returns {NodeJS.ReadWriteStream}
+         */
+        function append(content: string): NodeJS.ReadWriteStream;
+
+        /**
+         * Wraps the contents with two strings
+         * @param {string} prepend
+         * @param {string} append
+         * @returns {NodeJS.ReadWriteStream}
+         */
+        function wrap(prepend: string, append: string): NodeJS.ReadWriteStream;
+
+        /**
+         * Calls a function with the contents of the file
+         * @param {Transformer} transformer
+         * @returns {NodeJS.ReadWriteStream}
+         */
+        function transform(transformer: Transformer): NodeJS.ReadWriteStream;
+
+    }
+
+    module Insert { }
+    export = Insert;
+}


### PR DESCRIPTION
case 1. Add a new type definitions for **app-root-path 1.2.1**
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
