### PR TITLE
Adds type parameter back to mongoose.Model class fixes #10110

### DIFF
--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -167,7 +167,7 @@ mongoose.Error.Messages.hasOwnProperty('');
  * section querycursor.js
  * http://mongoosejs.com/docs/api.html#querycursor-js
  */
-var querycursor: mongoose.QueryCursor;
+var querycursor: mongoose.QueryCursor<any>;
 querycursor.close(function (error, result) {
   result.execPopulate();
 }).catch(cb);
@@ -1212,3 +1212,45 @@ MongoModel.find({
   options: { limit: 5 }
 })
 .exec();
+/* practical example */
+interface Location extends mongoose.Document {
+  name: string;
+  address: string;
+  rating: number;
+  facilities: string[];
+  coords: number[];
+  openingTimes: any[];
+  reviews: any[];
+};
+const locationSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  address: String,
+  rating: { type: Number, "default": 0, min: 0, max: 5 },
+  facilities: [String],
+  coords: { type: [Number], index: "2dsphere" },
+  openingTimes: [mongoose.Schema.Types.Mixed],
+  reviews: [mongoose.SchemaTypes.Mixed]
+});
+var LocModel = mongoose.model<Location>("Location", locationSchema);
+LocModel.findById(999)
+  .select("-reviews -rating")
+  .exec(function (err, location) {
+    location.name = 'blah';
+    location.address = 'blah';
+    location.reviews.forEach(review => {});
+    location.facilities.forEach(facility => {
+      facility.toLowerCase();
+    });
+  });
+LocModel.find()
+  .select('-reviews -rating')
+  .exec(function (err, locations) {
+    locations.forEach(location => {
+      location.name = 'blah';
+      location.address = 'blah';
+      location.reviews.forEach(review => {});
+      location.facilities.forEach(facility => {
+        facility.toLowerCase();
+      });
+    });
+  });

--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -1254,3 +1254,36 @@ LocModel.find()
       });
     });
   });
+LocModel.$where('')
+  .exec(function (err, locations) {
+    locations[0].name;
+    locations[1].openingTimes;
+  });
+LocModel.count({})
+  .exec(function (err, count) {
+    count.toFixed();
+  });
+LocModel.distinct('')
+  .select('-review')
+  .exec(function (err, distinct) {
+    distinct.concat;
+  })
+  .then(cb).catch(cb);
+LocModel.findByIdAndRemove()
+  .exec(function (err, doc) {
+    doc.addListener;
+    doc.openingTimes;
+  });
+LocModel.findByIdAndUpdate()
+  .select({})
+  .exec(function (err, location) {
+    location.reviews;
+  });
+LocModel.findOne({}, function (err, doc) { doc.openingTimes; });
+LocModel.findOneAndRemove()
+  .exec(function (err, location) { location.name; });
+LocModel.findOneAndUpdate().exec().then(function (arg) { arg.openingTimes; });
+LocModel.geoSearch({}, {
+  near: [1, 2],
+  maxDistance: 22
+}, function (err, res) { res[0].openingTimes; });

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -1262,6 +1262,11 @@ declare module "mongoose" {
      * http://mongoosejs.com/docs/api.html#query-js
      */
     type Query<T> = ModelQuery<T, any>;
+
+    /*
+     * Query.find() will return Query<Model<T>[]> however we need the
+     * type T to create this so we save T in another parameter.
+     */
     class ModelQuery<T, ModelType> extends mquery {
       /**
        * Specifies a javascript function or expression to pass to MongoDBs query system.

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -1067,7 +1067,7 @@ declare module "mongoose" {
         $shift(): T;
 
         /** Alias of pull */
-        remove(...args: any[]): Array<T>;
+        remove(...args: any[]): this;
 
         /**
          * Pops the array atomically at most one time per document save().
@@ -1113,7 +1113,7 @@ declare module "mongoose" {
          * the provided value to an embedded document and comparing using
          * the Document.equals() function.
          */
-        pull(...args: any[]): Array<T>;
+        pull(...args: any[]): this;
 
         /**
          * Wraps Array#push with proper change tracking.
@@ -1122,7 +1122,7 @@ declare module "mongoose" {
         push(...args: any[]): number;
 
         /** Sets the casted val at index i and marks the array modified. */
-        set(i: number, val: any): Array<T>;
+        set(i: number, val: any): this;
 
         /**
          * Wraps Array#shift with proper change tracking.


### PR DESCRIPTION
Added back type parameters for mongoose.Model<T> from the previous definitions so that:

```
interface Example { names: string[] }
var M = mongoose.model<Example>(...);
M.findOne({}, function (err, doc) {
  doc.names.forEach(...);
});
```

provides correct type-checking.
