### PR TITLE
React-Native: Added ActivityIndicator

### DIFF
--- a/react-native/react-native.d.ts
+++ b/react-native/react-native.d.ts
@@ -1742,6 +1742,41 @@ declare namespace  __React {
 
 
     /**
+     * @see https://facebook.github.io/react-native/docs/activityindicator.html#props
+     */
+    export interface ActivityIndicatorProperties extends React.Props<ActivityIndicatorStatic> {
+
+        /**
+         * Whether to show the indicator (true, the default) or hide it (false).
+         */
+        animating?: boolean
+
+        /**
+         * The foreground color of the spinner (default is gray).
+         */
+        color?: string
+
+        /**
+         * Whether the indicator should hide when not animating (true by default).
+         */
+        hidesWhenStopped?: boolean
+
+        /**
+         * Size of the indicator.
+         * Small has a height of 20, large has a height of 36.
+         *
+         * enum('small', 'large')
+         */
+        size?: string
+
+        style?: ViewStyle
+    }
+
+    export interface ActivityIndicatorStatic extends React.ComponentClass<ActivityIndicatorProperties> {
+    }
+
+
+    /**
      * @see https://facebook.github.io/react-native/docs/activityindicatorios.html#props
      */
     export interface ActivityIndicatorIOSProperties extends React.Props<ActivityIndicatorIOSStatic> {
@@ -5585,6 +5620,8 @@ declare namespace  __React {
 
     // export var AppRegistry: AppRegistryStatic;
 
+    export var ActivityIndicator: ActivityIndicatorStatic
+    export type ActivityIndicator = ActivityIndicatorStatic
 
     export var ActivityIndicatorIOS: ActivityIndicatorIOSStatic
     export type ActivityIndicatorIOS = ActivityIndicatorIOSStatic

--- a/react-native/react-native.d.ts
+++ b/react-native/react-native.d.ts
@@ -1767,7 +1767,7 @@ declare namespace  __React {
          *
          * enum('small', 'large')
          */
-        size?: string
+        size?: 'small' | 'large'
 
         style?: ViewStyle
     }
@@ -1807,11 +1807,14 @@ declare namespace  __React {
          *
          * enum('small', 'large')
          */
-        size?: string
+        size?: 'small' | 'large'
 
         style?: ViewStyle
     }
 
+    /**
+     * @Deprecated since version 0.28.0
+     */ 
     export interface ActivityIndicatorIOSStatic extends React.ComponentClass<ActivityIndicatorIOSProperties> {
     }
 


### PR DESCRIPTION
`ActivityIndicatorIOS` was removed in version `0.28.0` and replaced with the generic `ActivityIndicator`. I have added the new version, but I also left the IOS specific version as I'm not sure what the policy on this is. I'd be happy to remove it if a maintainer feels it's needed.
