### PR TITLE
Rename Pako namespace to pako to allow use with browserifyed library

### DIFF
--- a/pako/pako.d.ts
+++ b/pako/pako.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Denis Cappellin <http://github.com/cappellin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace Pako {
+declare namespace pako {
 
 	/**
 	 * Compress data with deflate algorithm and options.
@@ -59,5 +59,5 @@ declare namespace Pako {
 }
 
 declare module 'pako' {
-	export = Pako;
+	export = pako;
 }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
    https://github.com/nodeca/pako/blob/master/dist/pako.js#L1
