### PR TITLE
fix type of port in socket.io-redis

### DIFF
--- a/socket.io-redis/socket.io-redis.d.ts
+++ b/socket.io-redis/socket.io-redis.d.ts
@@ -58,7 +58,7 @@ declare namespace SocketIORedis {
 		 * The optional port to connect to redis on
 		 * @default 6379
 		 */
-		port?: string;
+		port?: number;
 
 		/**
 		 * The optional redis client to publish events on


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url https://github.com/socketio/socket.io-redis .
  - it has been reviewed by a DefinitelyTyped member.
