### PR TITLE
Remove copy() from Camera

### DIFF
--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -413,7 +413,6 @@ declare namespace THREE {
         lookAt(vector: Vector3): void;
 
         clone(): Camera;
-        copy(camera?: Camera): Camera;
     }
 
     export class CubeCamera extends Object3D {


### PR DESCRIPTION
This function doesn't appear in the [API docs](http://threejs.org/docs/#Reference/Cameras/Camera) and breaks compilation on TypeScript 2.0.
