### PR TITLE
node.d.ts: added http.ServerResponse.setTimeout signature

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -599,6 +599,7 @@ declare module "http" {
         statusMessage: string;
         headersSent: boolean;
         setHeader(name: string, value: string | string[]): void;
+        setTimeout(msecs: number, callback: Function): ServerResponse;
         sendDate: boolean;
         getHeader(name: string): string;
         removeHeader(name: string): void;


### PR DESCRIPTION
Added missing `http.ServerResponse.setTimeout` signature. The `setTimeout` method was added in node v0.9.12, see https://nodejs.org/api/http.html#http_response_settimeout_msecs_callback
