### PR TITLE
react-redux: Allow wrapper function for connect arguments

### DIFF
--- a/react-redux/react-redux-tests.tsx
+++ b/react-redux/react-redux-tests.tsx
@@ -58,6 +58,36 @@ class CounterContainer extends Component<any, any> {
 
 }
 
+// Ensure connect's first two arguments can be replaced by wrapper functions
+interface ICounterStateProps {
+    value: number
+}
+interface ICounterDispatchProps {
+    onIncrement: () => void
+}
+connect<ICounterStateProps, ICounterDispatchProps, {}>(
+    () => mapStateToProps,
+    () => mapDispatchToProps
+)(Counter);
+// only first argument
+connect<ICounterStateProps, {}, {}>(
+    () => mapStateToProps
+)(Counter);
+// wrap only one argument
+connect<ICounterStateProps, ICounterDispatchProps, {}>(
+    mapStateToProps,
+    () => mapDispatchToProps
+)(Counter);
+// with extra arguments
+connect<ICounterStateProps, ICounterDispatchProps, {}>(
+    () => mapStateToProps,
+    () => mapDispatchToProps,
+    (s: ICounterStateProps, d: ICounterDispatchProps) =>
+        objectAssign({}, s, d),
+    { pure: true }
+)(Counter);
+
+
 class App extends Component<any, any> {
     render(): JSX.Element {
         // ...

--- a/react-redux/react-redux.d.ts
+++ b/react-redux/react-redux.d.ts
@@ -45,16 +45,18 @@ declare module "react-redux" {
   export function connect(): InferableComponentDecorator;
 
   export function connect<TStateProps, TDispatchProps, TOwnProps>(
-    mapStateToProps: MapStateToProps<TStateProps, TOwnProps>,
-    mapDispatchToProps?: MapDispatchToPropsFunction<TDispatchProps, TOwnProps>|MapDispatchToPropsObject
+    mapStateToProps: FuncOrSelf<MapStateToProps<TStateProps, TOwnProps>>,
+    mapDispatchToProps?: FuncOrSelf<MapDispatchToPropsFunction<TDispatchProps, TOwnProps>|MapDispatchToPropsObject>
   ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
 
   export function connect<TStateProps, TDispatchProps, TOwnProps>(
-    mapStateToProps: MapStateToProps<TStateProps, TOwnProps>,
-    mapDispatchToProps: MapDispatchToPropsFunction<TDispatchProps, TOwnProps>|MapDispatchToPropsObject,
+    mapStateToProps: FuncOrSelf<MapStateToProps<TStateProps, TOwnProps>>,
+    mapDispatchToProps: FuncOrSelf<MapDispatchToPropsFunction<TDispatchProps, TOwnProps>|MapDispatchToPropsObject>,
     mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps>,
     options?: Options
   ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
+
+  type FuncOrSelf<T> = T | (() => T);
 
   interface MapStateToProps<TStateProps, TOwnProps> {
     (state: any, ownProps?: TOwnProps): TStateProps;


### PR DESCRIPTION
The `connect` function in recent versions of `react-redux` allows its first two arguments to be wrapped in function calls to allow initialisation on a per-component-instance basis. This change just wraps those arguments in a type that allows for itself or a wrapper function.

API reference: https://github.com/reactjs/react-redux/blob/master/docs/api.md#arguments
