### PR TITLE
Rewrite sanitize-html typings.

### DIFF
--- a/sanitize-html/sanitize-html-tests.ts
+++ b/sanitize-html/sanitize-html-tests.ts
@@ -1,33 +1,19 @@
 /// <reference path="sanitize-html.d.ts" />
 
-import sanitizeHtml = require('sanitize-html');
+import sanitize = require('sanitize-html');
 
-var s: string;
-var t: string;
+let options: sanitize.IOptions = {
+  allowedTags: sanitize.defaults.allowedTags.concat('h1', 'h2', 'img'),
+  allowedAttributes: {
+    'a': sanitize.defaults.allowedAttributes['a'].concat('rel'),
+    'img': ['src', 'height', 'width', 'alt']
+  },
+  transformTags: {
+    'a': sanitize.simpleTransform('a', { 'rel': 'nofollow' }),
+    'img': 'canvas'
+  }
+};
 
-t = sanitizeHtml(s);
-t = sanitizeHtml(s, {
-});
-t = sanitizeHtml(s, {
-	allowedTags: ["a", "br"],
-	allowedSchemes: ["http"],
-	allowedAttributes: { "a": ["href"] },
-	allowedClasses: { "a": ["someclass"] },
-	transformTags: { 
-		"a": "b", 
-		"br": function(tagName: string, attributes: {[index: string]: string}): { tagName: string; attributes: {[index: string]: string};} {
-			return { tagName: tagName, attributes: attributes };
-		}
-	},
-	exclusiveFilter: {
-		"a": function(frame: {
-			tag: string;
-			attribs: { [index: string]: string };
-			text: string;
-			tagPosition: number;
-		}): boolean {
-			return false;
-		}
-	}
-});
+let unsafe = '<div><script>alert("hello");</script></div>';
 
+let safe = sanitize(unsafe, options);

--- a/sanitize-html/sanitize-html.d.ts
+++ b/sanitize-html/sanitize-html.d.ts
@@ -1,27 +1,65 @@
-﻿// Type definitions for sanitize-html 1.6.0
+﻿// Type definitions for sanitize-html 1.12.0
 // Project: https://github.com/punkave/sanitize-html
-// Definitions by: Rogier Schouten <https://github.com/rogierschouten>
+// Definitions by: Afshin Darian <https://github.com/afshin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 
-declare module "sanitize-html" {
+declare function sanitize(dirty: string, options?: sanitize.IOptions): string;
 
-	function sanitizeHtml(s: string, opts?: {
-		allowedTags?: string[];
-		allowedSchemes?: string[];
-		allowedAttributes?: { [index: string]: string[] };
-		allowedClasses?: { [index: string]: string[] };
-		transformTags?: { [index: string]: any };
-		exclusiveFilter?: {
-			[index: string]: (frame: {
-				tag: string;
-				attribs: { [index: string]: string };
-				text: string;
-				tagPosition: number;
-			}) => boolean
-		};
 
-	}): string;
+declare namespace sanitize {
+  export
+  type Attributes = { [attr: string]: string };
 
-	export = sanitizeHtml;
+
+  export
+  type Tag = { tagName: string; attributes: Attributes; };
+
+
+  export
+  type Transformer = (tagName: string, attributes: Attributes) => Tag;
+
+
+  export
+  interface IDefaults {
+    allowedAttributes: { [index: string]: string[] };
+    allowedSchemes: string[];
+    allowedSchemesByTag: { [index: string]: string[] };
+    allowedTags: string[];
+    selfClosing: string[];
+  }
+
+
+  export
+  interface IFrame {
+    tag: string;
+    attributes: { [index: string]: string };
+    text: string;
+    tagPosition: number;
+  }
+
+
+  export
+  interface IOptions {
+    allowedAttributes?: { [index: string]: string[] };
+    allowedClasses?: { [index: string]: string[] };
+    allowedSchemes?: string[];
+    allowedTags?: string[];
+    exclusiveFilter?: (frame: IFrame) => boolean;
+    selfClosing?: string[];
+    transformTags?: { [tagName: string]: string | Transformer };
+  }
+
+
+  export
+  var defaults: IDefaults;
+
+
+  export
+  function simpleTransform(tagName: string, attributes: Attributes, merge?: boolean): Transformer;
+}
+
+
+declare module 'sanitize-html' {
+  export = sanitize;
 }


### PR DESCRIPTION
Case 2. Improvement to existing type definition.

Full API is here: https://github.com/punkave/sanitize-html

This definition is currently in production inside [JupyterLab](https://github.com/jupyter/jupyterlab): https://github.com/jupyter/jupyterlab/blob/master/typings/sanitize-html/sanitize-html.d.ts
- [x] New types (`Attributes`, `Tag`, and `Transformer`)
- [x] `defaults` attribute added as an attribute to the main exported function
- [x] `simpleTransform` function added as an attribute to the main exported function
- [x] New interfaces (`IDefaults`, `IFrame`, and `IOptions`)

Import statements look like this:

``` typescript
import * as sanitize from 'sanitize-html';
```

or:

``` typescript
import * as sanitizeHTML from 'sanitize-html';
```

or:

``` typescript
import * as sanitizeHtml from 'sanitize-html';
```
