### PR TITLE
fetch-mock: update to v5

### DIFF
--- a/fetch-mock/fetch-mock-tests.ts
+++ b/fetch-mock/fetch-mock-tests.ts
@@ -18,17 +18,15 @@ fetchMock.mock(/test/, {
     }
 });
 
-fetchMock.reMock();
-
 fetchMock.restore().reset();
 
-fetchMock.calls().matched[0][1].body;
+(fetchMock.calls().matched[0][1] as RequestInit).body;
 fetchMock.calls().unmatched[0][0].toUpperCase();
 fetchMock.calls("http://test.com")[0][0].toUpperCase();
-fetchMock.calls("http://test.com")[0][1].body;
+(fetchMock.calls("http://test.com")[0][1] as RequestInit).body;
 
 fetchMock.called("http://test.com");
 
-fetchMock.lastCall()[1].body;
+(fetchMock.lastCall()[1] as RequestInit).body;
 fetchMock.lastUrl();
 fetchMock.lastOptions();

--- a/fetch-mock/fetch-mock.d.ts
+++ b/fetch-mock/fetch-mock.d.ts
@@ -1,40 +1,32 @@
-// Type definitions for fetch-mock 4.6.0
+// Type definitions for fetch-mock 5.0.0
 // Project: https://github.com/wheresrhys/fetch-mock
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>, Tamir Duberstein <https://github.com/tamird>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference path="../whatwg-fetch/whatwg-fetch.d.ts" />
 
-
 declare module "fetch-mock" {
+    type MockRequest = Request | RequestInit;
+
     /**
      * Mock matcher function
      * @param url
      * @param opts
      */
-    type MockMatcherFunction = (url: string, opts: any) => boolean;
+    type MockMatcherFunction = (url: string, opts: MockRequest) => boolean
     /**
      * Mock matcher. Can be one of following:
-     * string: Either an exact url to match e.g. 'http://www.site.com/page.html' or, if the string begins with a ^, the string following the ^ must begin the url
-     * e.g. '^http://www.site.com' would match 'http://www.site.com' or 'http://www.site.com/page.html'
+     * string: Either
+         * an exact url to match e.g. 'http://www.site.com/page.html'
+         * if the string begins with a `^`, the string following the `^` must
+           begin the url e.g. '^http://www.site.com' would match
+           'http://www.site.com' or 'http://www.site.com/page.html'
+         * '*' to match any url
      * RegExp: A regular expression to test the url against
-     * Function(url, opts): A function (returning a Boolean) that is passed the url and opts fetch() is called with (or, if fetch() was called with one, the Request instance)
+     * Function(url, opts): A function (returning a Boolean) that is passed the
+       url and opts fetch() is called with (or, if fetch() was called with one,
+       the Request instance)
      */
-    type MockMatcher = string | RegExp | Function | MockMatcherFunction;
-
-    /**
-     * Mock response function
-     * @param url
-     * @param opts
-     */
-    type MockResponseFunction = (url: string, opts: any) => MockResponse;
-    /**
-     * number: Creates a response with this status
-     * string: Creates a 200 response with the string as the response body
-     * object: As long as the object does not contain any of the properties below it is converted into a json string and returned as the body of a 200 response.
-     * If MockResponseObject was given then it's used to configure response
-     */
-    type MockResponse = number | string | MockResponseObject | {};
-
+    type MockMatcher = string | RegExp | MockMatcherFunction;
 
     /**
      * Mock response object
@@ -52,93 +44,164 @@ declare module "fetch-mock" {
         /**
          * Set the response headers.
          */
-        headers?: { [key: string]: any };
+        headers?: { [key: string]: string };
         /**
-         * If this property is present then a Promise rejected with the value of throws is returned
+         * If this property is present then a Promise rejected with the value
+           of throws is returned
          */
         throws?: boolean;
         /**
-         * This property determines whether or not the request body should be JSON.stringified before being sent
+         * This property determines whether or not the request body should be
+           JSON.stringified before being sent
          * @default true
          */
         sendAsJson?: boolean;
     }
+    /**
+     * Response: A Response instance - will be used unaltered
+     * number: Creates a response with this status
+     * string: Creates a 200 response with the string as the response body
+     * object: As long as the object is not a MockResponseObject it is
+       converted into a json string and returned as the body of a 200 response
+     * If MockResponseObject was given then it's used to configure response
+     * Function(url, opts): A function that is passed the url and opts fetch()
+       is called with and that returns any of the responses listed above
+     */
+    type MockResponse = Response | Promise<Response>
+                        | number | Promise<number>
+                        | string | Promise<string>
+                        | Object | Promise<Object>
+                        | MockResponseObject | Promise<MockResponseObject>;
+    /**
+     * Mock response function
+     * @param url
+     * @param opts
+     */
+    type MockResponseFunction = (url: string, opts: MockRequest) => MockResponse;
 
-    interface MockCallOptions {
-        [key: string]: any;
+    /**
+     * Mock options object
+     */
+    interface MockOptions {
+        /**
+         * A unique string naming the route. Used to subsequently retrieve
+           references to the calls, grouped by name.
+         * @default matcher.toString()
+         *
+         * Note: If a non-unique name is provided no error will be thrown
+           (because names are optional, auto-generated ones may legitimately
+           clash)
+         */
+        name?: string;
+        /**
+         * http method to match
+         */
+        method?: string;
+        /**
+         * as specified above
+         */
+        matcher?: MockMatcher;
+        /**
+         * as specified above
+         */
+        response?: MockResponse | MockResponseFunction;
     }
 
-    type MockCall = [string, RequestInit];
+    type MockCall = [string, MockRequest];
 
     interface MatchedRoutes {
-        matched: MockCall[];
-        unmatched: MockCall[];
+        matched: Array<MockCall>;
+        unmatched: Array<MockCall>;
     }
 
     interface FetchMockStatic {
         /**
-         * When using isomorphic-fetch or node-fetch ideally fetch should be added as a global.
-         * If not possible to do so you can still use fetch-mock in combination with mockery or similar in nodejs.
-         * To use fetch-mock with with mockery you may use this function to prevent fetch-mock trying to mock the function globally.
-         * @deprecated
-         */
-        useNonGlobalFetch(func?: any): void;
-        /**
-         * Replaces fetch() with a stub which records its calls, grouped by route, and optionally returns a mocked
-         * Response object or passes the call through to fetch(). Calls to .mock() can be chained.
+         * Replaces fetch() with a stub which records its calls, grouped by
+           route, and optionally returns a mocked Response object or passes the
+           call through to fetch(). Calls to .mock() can be chained.
          * @param matcher Condition for selecting which requests to mock
          * @param response Configures the http response returned by the mock
          */
-        mock(matcher: MockMatcher, response?: MockResponse | MockResponseFunction): this;
+        mock(matcher: MockMatcher, response: MockResponse | MockResponseFunction): this;
         /**
-         * Replaces fetch() with a stub which records its calls, grouped by route, and optionally returns a mocked
-         * Response object or passes the call through to fetch(). Calls to .mock() can be chained.
+         * Replaces fetch() with a stub which records its calls, grouped by
+           route, and optionally returns a mocked Response object or passes the
+           call through to fetch(). Calls to .mock() can be chained.
          * @param matcher Condition for selecting which requests to mock
-         * @param method Only matches requests using this http method
          * @param response Configures the http response returned by the mock
+         * @param options Additional properties defining the route to mock
          */
-        mock(matcher: MockMatcher, method?: string, response?: MockResponse | MockMatcherFunction): this;
+        mock(matcher: MockMatcher, response: MockResponse | MockResponseFunction, options: MockOptions): this;
         /**
-         * Restores fetch() to its unstubbed state and clears all data recorded for its calls
+         * Replaces fetch() with a stub which records its calls, grouped by
+           route, and optionally returns a mocked Response object or passes the
+           call through to fetch(). Calls to .mock() can be chained.
+         * @param options The route to mock
+         */
+        mock(options: MockOptions): this;
+        /**
+         * Chainable method that restores fetch() to its unstubbed state and
+           clears all data recorded for its calls.
          */
         restore(): this;
         /**
-         * Clears all data recorded for fetch()'s calls
+         * Chainable method that clears all data recorded for fetch()'s calls
          */
         reset(): this;
         /**
-         * Calls restore() internally then calls mock(). This allows you to put some generic calls to mock() in a
-         * beforeEach() while retaining the flexibility to vary the responses for some tests. reMock() can be chained.
+         * Returns all calls to fetch, grouped by whether fetch-mock matched
+           them or not.
          */
-        reMock(matcher?: MockMatcher, response?: MockResponse | MockResponseFunction): this;
-        reMock(matcher?: MockMatcher, method?: string, response?: MockResponse | MockMatcherFunction): this;
-
-        /**
-         * Returns an object {matched: [], unmatched: []} containing arrays of all calls to fetch, grouped by whether fetch-mock matched them or not.
-         * If matcherName is specified then only calls to fetch matching that route are returned.
-         */
-        calls(matcher: string): MockCall[];
         calls(): MatchedRoutes;
         /**
-         * Returns a Boolean indicating whether fetch was called and a route was matched. If matcherName is specified it only returns true if that particular route was matched.
+         * Returns all calls to fetch matching matcherName.
          */
-        called(matcher?: string): boolean;
+        calls(matcherName?: string): Array<MockCall>;
+        /**
+         * Returns a Boolean indicating whether fetch was called and a route
+           was matched.
+         */
+        called(): boolean;
+        /**
+         * Returns a Boolean indicating whether fetch was called and a route
+           named matcherName was matched.
+         */
+        called(matcherName?: string): boolean;
         /**
          * Returns the arguments for the last matched call to fetch
          */
-        lastCall(matcher?: string): MockCall;
+        lastCall(): MockCall;
+        /**
+         * Returns the arguments for the last call to fetch matching
+           matcherName
+         */
+        lastCall(matcherName?: string): MockCall;
         /**
          * Returns the url for the last matched call to fetch
          */
-        lastUrl(matcher?: string): string;
+        lastUrl(): string;
+        /**
+         * Returns the url for the last call to fetch matching matcherName
+         */
+        lastUrl(matcherName?: string): string;
         /**
          * Returns the options for the last matched call to fetch
          */
-        lastOptions(matcher?: string): MockCallOptions;
-
+        lastOptions(): MockRequest;
+        /**
+         * Returns the options for the last call to fetch matching matcherName
+         */
+        lastOptions(matcherName?: string): MockRequest;
+        /**
+         * Set some global config options, which include
+             * sendAsJson [default `true`] - by default fetchMock will
+               convert objects to JSON before sending. This is overrideable
+               for each call but for some scenarios, e.g. when dealing with a
+               lot of array buffers, it can be useful to default to `false`
+         */
+        configure(opts: Object): void;
     }
 
     var fetchMock: FetchMockStatic;
     export = fetchMock;
-
 }


### PR DESCRIPTION
Pretty much a full rewrite guided by https://github.com/wheresrhys/fetch-mock/blob/master/src/fetch-mock.js.
