### PR TITLE
Added missing optional member to passport

### DIFF
--- a/passport/passport.d.ts
+++ b/passport/passport.d.ts
@@ -8,6 +8,7 @@
 declare namespace Express {
     export interface Request {
         authInfo?: any;
+        user?: any;
 
         // These declarations are merged into express's Request type
         login(user: any, done: (err: any) => void): void;
@@ -89,4 +90,3 @@ declare module 'passport' {
         }[];
     }
 }
-


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes
  - The documentation for Passport explains the use of "req.user": http://passportjs.org/docs/authenticate
  - The following test from the Passport repo demonstrates that an optional "user" member is used in some cases on the "Request" object: https://github.com/jaredhanson/passport/blob/33075756a626999c6e2efc872b055e45ae434053/test/strategies/session.test.js
- it has been reviewed by a DefinitelyTyped member.
