### PR TITLE
add type definition for v8-profiler

### DIFF
--- a/v8-profiler/v8-profiler-tests.ts
+++ b/v8-profiler/v8-profiler-tests.ts
@@ -1,0 +1,60 @@
+/// <reference path="v8-profiler.d.ts" />
+
+import * as fs from "fs";
+import * as profiler from "v8-profiler";
+
+{
+    var snapshot1 = profiler.takeSnapshot('1');
+    var snapshot2 = profiler.takeSnapshot();
+    profiler.deleteAllSnapshots();
+}
+{
+    profiler.startProfiling('', true);
+    setTimeout(function () {
+        var profile = profiler.stopProfiling('');
+        profiler.deleteAllProfiles();
+    }, 1000);
+}
+{
+    var snapshot1 = profiler.takeSnapshot();
+    var snapshot2 = profiler.takeSnapshot();
+
+    console.log(snapshot1.getHeader(), snapshot2.getHeader());
+
+    console.log(snapshot1.compare(snapshot2));
+
+    // Export snapshot to file file
+    snapshot1.export(function (error, result) {
+        fs.writeFileSync('snapshot1.json', result);
+        snapshot1.delete();
+    });
+
+    // Export snapshot to file stream
+    (snapshot2.export() as fs.ReadStream)
+        .pipe(fs.createWriteStream('snapshot2.json'))
+        .on('finish', snapshot2.delete);
+}
+{
+    profiler.startProfiling('1', true);
+    var profile1 = profiler.stopProfiling();
+    profiler.startProfiling('2', true);
+    var profile2 = profiler.stopProfiling();
+
+    console.log(snapshot1.getHeader(), snapshot2.getHeader());
+
+    profile1.export(function (error, result) {
+        fs.writeFileSync('profile1.json', result);
+        profile1.delete();
+    });
+
+    (profile2.export() as fs.ReadStream)
+        .pipe(fs.createWriteStream('profile2.json'))
+        .on('finish', function () {
+            profile2.delete();
+        });
+}
+{
+    var a: profiler.Profile;
+    var b: profiler.Profiler;
+    var c: profiler.Snapshot;
+}

--- a/v8-profiler/v8-profiler-tests.ts
+++ b/v8-profiler/v8-profiler-tests.ts
@@ -30,7 +30,7 @@ import * as profiler from "v8-profiler";
     });
 
     // Export snapshot to file stream
-    (snapshot2.export() as fs.ReadStream)
+    snapshot2.export()
         .pipe(fs.createWriteStream('snapshot2.json'))
         .on('finish', snapshot2.delete);
 }
@@ -47,7 +47,7 @@ import * as profiler from "v8-profiler";
         profile1.delete();
     });
 
-    (profile2.export() as fs.ReadStream)
+    profile2.export()
         .pipe(fs.createWriteStream('profile2.json'))
         .on('finish', function () {
             profile2.delete();

--- a/v8-profiler/v8-profiler.d.ts
+++ b/v8-profiler/v8-profiler.d.ts
@@ -1,0 +1,89 @@
+// Type definitions for v8-profiler
+// Project: https://github.com/node-inspector/v8-profiler
+// Definitions by: York Yao <https://github.com/plantain-00/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/* =================== USAGE ===================
+    import * as profiler from "v8-profiler";
+    profiler.startProfiling();
+ =============================================== */
+
+/// <reference path="../node/node.d.ts" />
+
+declare module "v8-profiler" {
+    import * as fs from "fs";
+
+    namespace V8Profiler {
+        type Profiler = {
+            /**
+             * returns new HEAP Snapshot instance.
+             * name is optional argument, by default snapshot name will be constructed from his uid.
+             */
+            takeSnapshot: (name?: string) => Snapshot;
+            deleteAllSnapshots: () => void;
+            /**
+             * start CPU profiling.
+             * name is optional argument, by default profile name will be constructed from his uid.
+             * recsamples is true by default.
+             */
+            startProfiling: (name?: string, recsamples?: boolean) => void;
+            /**
+             * returns new CPU Profile instance.
+             * There is no strictly described behavior for usage without name argument.
+             */
+            stopProfiling: (name?: string) => Profile;
+            /**
+             * Changes default CPU profiler sampling interval to the specified number of microseconds.
+             * Default interval is 1000us.
+             * This method must be called when there are no profiles being recorded.
+             * If called without arguments it resets interval to default.
+             */
+            setSamplingInterval: (ms?: number) => void;
+            deleteAllProfiles: () => void;
+        };
+        type Snapshot = {
+            /**
+             * provides short information about snapshot.
+             */
+            getHeader: () => any;
+            /**
+             * creates HEAP diff for two snapshots.
+             */
+            compare: (snapshot: Snapshot) => void;
+            /**
+             * removes snapshot from memory.
+             */
+            delete: () => any;
+            /**
+             * provides simple export API for snapshot.
+             * callback(error, data) receives serialized snapshot as second argument. (Serialization is not equal to JSON.stringify result).
+             * If callback will not be passed, export returns transform stream.
+             */
+            export: (callback?: (error?: Error, data?: any) => void) => fs.ReadStream | void;
+            /**
+             * low level serialization method.
+             * Look Snapshot.export source for usage example.
+             */
+            serialize: Function;
+        };
+
+        type Profile = {
+            /**
+             * provides short information about profile.
+             */
+            getHeader: () => any;
+            /**
+             * removes profile from memory.
+             */
+            delete: () => any;
+            /**
+             * provides simple export API for profile.
+             * callback(error, data) receives serialized profile as second argument. (Serialization is equal to JSON.stringify result).
+             */
+            export: (callback?: (error?: Error, data?: any) => void) => fs.ReadStream | void;
+        }
+    }
+
+    var V8Profiler: V8Profiler.Profiler;
+    export = V8Profiler;
+}

--- a/v8-profiler/v8-profiler.d.ts
+++ b/v8-profiler/v8-profiler.d.ts
@@ -59,7 +59,13 @@ declare module "v8-profiler" {
              * callback(error, data) receives serialized snapshot as second argument. (Serialization is not equal to JSON.stringify result).
              * If callback will not be passed, export returns transform stream.
              */
-            export: (callback?: (error?: Error, data?: any) => void) => fs.ReadStream | void;
+            export(callback: (error?: Error, data?: any) => void): void;
+            /**
+             * provides simple export API for snapshot.
+             * callback(error, data) receives serialized snapshot as second argument. (Serialization is not equal to JSON.stringify result).
+             * If callback will not be passed, export returns transform stream.
+             */
+            export(): fs.ReadStream;
             /**
              * low level serialization method.
              * Look Snapshot.export source for usage example.
@@ -80,7 +86,12 @@ declare module "v8-profiler" {
              * provides simple export API for profile.
              * callback(error, data) receives serialized profile as second argument. (Serialization is equal to JSON.stringify result).
              */
-            export: (callback?: (error?: Error, data?: any) => void) => fs.ReadStream | void;
+            export(callback: (error?: Error, data?: any) => void): void;
+            /**
+             * provides simple export API for profile.
+             * callback(error, data) receives serialized profile as second argument. (Serialization is equal to JSON.stringify result).
+             */
+            export(): fs.ReadStream;
         }
     }
 


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
