### PR TITLE
Using $._data() to retrieve event handlers

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -848,6 +848,10 @@ interface JQueryStatic {
      */
     data(element: Element, key: string): any;
     /**
+     * jQuery more than v1.8. Example.. jQuery._data(window, "events")
+     */
+    _data(element: Element, key: string): any;
+    /**
      * Returns value at named data store for the element, as set by jQuery.data(element, name, value), or the full data store for the element.
      *
      * @param element The DOM element to associate with the data.


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

http://slavchoslavchev.com/quick-tips/using-_data-to-retrieve-event-handlers/
