### PR TITLE
Another fix for mongoose Promises

### DIFF
--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -1024,6 +1024,31 @@ mongoose.model('')
     arg.b.toFixed;
   });
 
+mongoose.model('').findOne({})
+  .then(function (arg) {
+    arg.save;
+    return 2;
+  }).then(function (num) {
+    num.toFixed;
+    return new Promise<string>((resolve, reject) => {
+      resolve('str');
+    });
+  }).then(function (str) {
+    str.toLowerCase;
+  });
+
+mongoose.model('').aggregate()
+  .then(function (arg) {
+    return 2;
+  }).then(function (num) {
+    num.toFixed;
+    return new Promise<string>((resolve, reject) => {
+      resolve('str');
+    });
+  }).then(function (str) {
+    str.toLowerCase;
+  });
+
 /* pluggable promise */
 mongoose.Promise = Promise;
 mongoose.Promise.race;

--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -28,7 +28,7 @@ mongoose.connect(connectUri, {
     autoIndex: true
   },
   mongos: true
-}).then(cb);
+}).then(cb).onReject;
 mongoose.connect(connectUri, function (error) {
   error.stack;
 });
@@ -46,7 +46,7 @@ mongoose.createConnection('localhost', 'database', 3000, {
     autoIndex: false
   }
 }).open('');
-mongoose.disconnect(cb).then(cb);
+mongoose.disconnect(cb).then(cb).fulfill;
 mongoose.get('test');
 mongoose.model('Actor', new mongoose.Schema({
   name: String

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -309,13 +309,14 @@ declare module "mongoose" {
        * Ability to use mongoose object as a pseudo-promise so .connect().then()
        * and .disconnect().then() are viable.
        */
-      static then(onFulfill?: () => void, onRejected?: (err: mongodb.MongoError) => void): typeof MongooseThenable;
+      static then<TRes>(onFulfill?: () => void | TRes | PromiseLike<TRes>,
+        onRejected?: (err: mongodb.MongoError) => void | TRes | PromiseLike<TRes>): Promise<TRes>;
 
       /**
        * Ability to use mongoose object as a pseudo-promise so .connect().then()
        * and .disconnect().then() are viable.
        */
-      static catch(onRejected?: (err: mongodb.MongoError) => void): typeof MongooseThenable;
+      static catch<TRes>(onRejected?: (err: mongodb.MongoError) => void | TRes | PromiseLike<TRes>): Promise<TRes>;
     }
 
     class CastError extends _mongoose.Error {

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -1307,7 +1307,7 @@ declare module "mongoose" {
        * resolved with either the doc(s) or rejected with the error.
        * Like .then(), but only takes a rejection handler.
        */
-      catch(reject?: (err: any) => void): Promise<T>;
+      catch<TRes>(reject?: (err: any) =>  void | TRes | PromiseLike<TRes>): Promise<TRes>;
 
       /**
        * DEPRECATED Alias for circle
@@ -1651,7 +1651,8 @@ declare module "mongoose" {
       }): this;
 
       /** Executes this query and returns a promise */
-      then(resolve?: (res: T) => void, reject?: (err: any) => void): Promise<T>;
+      then<TRes>(resolve?: (res: T) => void | TRes | PromiseLike<TRes>,
+        reject?: (err: any) =>  void | TRes | PromiseLike<TRes>): Promise<TRes>;
 
       /**
        * Converts this query to a customized, reusable query
@@ -2071,7 +2072,8 @@ declare module "mongoose" {
       sort(arg: string | Object): this;
 
       /** Provides promise for aggregate. */
-      then(resolve?: (val: T) => void, reject?: (err: any) => void): Promise<T>
+      then<TRes>(resolve?: (val: T) =>  void | TRes | PromiseLike<TRes>,
+        reject?: (err: any) =>  void | TRes | PromiseLike<TRes>): Promise<TRes>
 
       /**
        * Appends new custom $unwind operator(s) to this aggregate pipeline.


### PR DESCRIPTION
Forgot to add type parameters for a few `then()` and `catch()` methods.
Double-checked and corrected the return type of MongooseThenable `.then()` and `.catch()`.
