### PR TITLE
d3.Selection<Datum>.node() returns Datum

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -297,7 +297,7 @@ declare namespace d3 {
              * @param value the function to compute data for each node
              */
             datum<NewDatum>(value: (datum: Datum, index: number, outerIndex: number) => NewDatum): Update<NewDatum>;
-            
+
             /**
              * Set the data item for each node in the selection.
              * @param value the constant element to use for each node
@@ -415,7 +415,7 @@ declare namespace d3 {
 
             select(name: (datum: Datum, index: number, outerIndex: number) => EventTarget): Selection<Datum>;
             call(func: (selection: Enter<Datum>, ...args: any[]) => any, ...args: any[]): Enter<Datum>;
-            
+
             empty(): boolean;
             size(): number;
         }
@@ -794,7 +794,7 @@ declare namespace d3 {
         /**
          * Returns the first non-null element in the selection, or null otherwise.
          */
-        node(): Node;
+        node(): Datum;
 
         /**
          * Returns the total number of elements in the selection.
@@ -857,7 +857,7 @@ declare namespace d3 {
         call(func: (transition: Transition<Datum>, ...args: any[]) => any, ...args: any[]): Transition<Datum>;
 
         empty(): boolean;
-        node(): Node;
+        node(): Datum;
         size(): number;
     }
 
@@ -1078,7 +1078,7 @@ declare namespace d3 {
      * Return the min and max simultaneously.
      */
     export function extent<T>(array: T[], accessor: (datum: T, index: number) => string): [string, string];
-    
+
     /**
      * Return the min and max simultaneously.
      */


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes. https://github.com/mbostock/d3/wiki/Selections#node .
  - it has been reviewed by a DefinitelyTyped member.

See discussion in last four comments here: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/7014#issuecomment-233207998
