### PR TITLE
add Promisify ```sendMail``` function

### DIFF
--- a/nodemailer/nodemailer-tests.ts
+++ b/nodemailer/nodemailer-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="nodemailer.d.ts" />
 
-import nodemailer = require('nodemailer');
+import * as nodemailer from 'nodemailer'
 
 // create reusable transporter object using SMTP transport
 var transporter: nodemailer.Transporter = nodemailer.createTransport({

--- a/nodemailer/nodemailer-tests.ts
+++ b/nodemailer/nodemailer-tests.ts
@@ -38,3 +38,8 @@ var mailOptions: nodemailer.SendMailOptions = {
 transporter.sendMail(mailOptions, (error: Error, info: nodemailer.SentMessageInfo): void => {
 	// nothing
 });
+
+// promise send mail without callback
+transporter
+  .sendMail(mailOptions)
+  .then(info => info.messageId)

--- a/nodemailer/nodemailer.d.ts
+++ b/nodemailer/nodemailer.d.ts
@@ -31,7 +31,7 @@ declare module "nodemailer" {
 		/**
 		 * Send a mail with callback
 		 */
-		sendMail(mail: SendMailOptions, callback?: (error: Error, info: SentMessageInfo) => void): void;
+		sendMail(mail: SendMailOptions, callback: (error: Error, info: SentMessageInfo) => void): void;
 
 		/**
 		 * Send a mail

--- a/nodemailer/nodemailer.d.ts
+++ b/nodemailer/nodemailer.d.ts
@@ -29,9 +29,15 @@ declare module "nodemailer" {
 	 */
 	export interface Transporter {
 		/**
-		 * Send a mail
+		 * Send a mail with callback
 		 */
 		sendMail(mail: SendMailOptions, callback?: (error: Error, info: SentMessageInfo) => void): void;
+
+		/**
+		 * Send a mail
+		 * return Promise
+		 */
+		sendMail(mail: SendMailOptions): Promise<SentMessageInfo>;
 
 		/**
 		 * Attach a plugin. 'compile' and 'stream' plugins can be attached with use(plugin) method


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

https://github.com/nodemailer/nodemailer/blob/master/lib/nodemailer.js#L226
Promisify `sendMail` has added to nodemailer
