### PR TITLE
protobufjs: allow to use protobuf-light version

### DIFF
--- a/protobufjs/protobufjs.d.ts
+++ b/protobufjs/protobufjs.d.ts
@@ -387,3 +387,7 @@ declare namespace ProtoBuf {
 declare module "protobufjs" {
     export = ProtoBuf;
 }
+
+declare module "protobufjs/dist/protobuf-light" {
+    export = ProtoBuf;
+}


### PR DESCRIPTION
Allow to require `protobufjs/dist/protobuf-light` version. See: https://www.npmjs.com/package/proto-loader

As the light version has fewer methods available, it might be a good idea to export a diferent object though.

Cheers
