### PR TITLE
Fix #10093: Expose the Commander interfaces on the `exported=`

### DIFF
--- a/commander/index.d.ts
+++ b/commander/index.d.ts
@@ -5,8 +5,8 @@
 
 /// <reference types="node" />
 
-declare var _tmp: commander.IExportedCommand;
-export = _tmp;
+declare var commander: commander.IExportedCommand;
+export = commander;
 
 declare namespace commander {
     interface ICommandStatic {


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/10093
