### PR TITLE
Add marker to IntrinsicElements

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -2500,6 +2500,7 @@ declare namespace JSX {
         image: React.SVGProps;
         line: React.SVGProps;
         linearGradient: React.SVGProps;
+        marker: React.SVGProps;
         mask: React.SVGProps;
         path: React.SVGProps;
         pattern: React.SVGProps;


### PR DESCRIPTION
Small bug fix to add <marker> to IntrinsicElement. The attributes markerStart and markerEnd are already present, but marker itself is missing.
