### PR TITLE
add possibility to make html tooltips via column descriptions

### DIFF
--- a/google.visualization/google.visualization.d.ts
+++ b/google.visualization/google.visualization.d.ts
@@ -141,6 +141,7 @@ declare namespace google {
             id?: string;
             role?: string;
             pattern?: string;
+            p?: any;
         }
 
         export interface DataObject {


### PR DESCRIPTION
Resolves #10178: allow html tooltips to be configured via addColumn (as described in https://developers.google.com/chart/interactive/docs/customizing_tooltip_content#customizing-html-content)
