### PR TITLE
Changing hitch signature to match documentation

### DIFF
--- a/dojo/dojo.d.ts
+++ b/dojo/dojo.d.ts
@@ -5686,7 +5686,7 @@ declare namespace dojo {
              * @param dest The object to which to copy/add all properties contained in source. If dest is falsy, thena new object is manufactured before copying/adding properties begins.
              * @param sources One of more objects from which to draw all properties to copy into dest. sources are processedleft-to-right and if more than one of these objects contain the same property name, the right-mostvalue "wins".
              */
-            mixin(dest: Object, ...sources: Object[]): Object;
+            mixin(dest: Object, sources: Object[]): Object;
             /**
              * similar to hitch() except that the scope object is left to be
              * whatever the execution context eventually becomes.

--- a/dojo/dojo.d.ts
+++ b/dojo/dojo.d.ts
@@ -5617,7 +5617,7 @@ declare namespace dojo {
              * @param scope The scope to use when method executes. If method is a string,scope is also the object containing method.
              * @param method A function to be hitched to scope, or the name of the method inscope to be hitched.
              */
-            hitch(scope: Object, method: (...args: any[]) => any): any;
+            hitch(scope: Object, method: (...args: any[]) => any, ...args: any[]): any;
             /**
              * Returns a function that will only ever execute in the a given scope.
              * This allows for easy use of object member functions
@@ -5631,7 +5631,7 @@ declare namespace dojo {
              * @param scope The scope to use when method executes. If method is a string,scope is also the object containing method.
              * @param method A function to be hitched to scope, or the name of the method inscope to be hitched.
              */
-            hitch(scope: Object, method: string): any;
+            hitch(scope: Object, method: string, ...args: any[]): any;
             /**
              * Returns true if it is a built-in function or some other kind of
              * oddball that should report as a function but doesn't

--- a/dojo/dojo.d.ts
+++ b/dojo/dojo.d.ts
@@ -5686,7 +5686,7 @@ declare namespace dojo {
              * @param dest The object to which to copy/add all properties contained in source. If dest is falsy, thena new object is manufactured before copying/adding properties begins.
              * @param sources One of more objects from which to draw all properties to copy into dest. sources are processedleft-to-right and if more than one of these objects contain the same property name, the right-mostvalue "wins".
              */
-            mixin(dest: Object, sources: Object[]): Object;
+            mixin(dest: Object, ...sources: Object[]): Object;
             /**
              * similar to hitch() except that the scope object is left to be
              * whatever the execution context eventually becomes.

--- a/dojo/dojo.d.ts
+++ b/dojo/dojo.d.ts
@@ -5617,7 +5617,7 @@ declare namespace dojo {
              * @param scope The scope to use when method executes. If method is a string,scope is also the object containing method.
              * @param method A function to be hitched to scope, or the name of the method inscope to be hitched.
              */
-            hitch(scope: Object, method: Function): any;
+            hitch(scope: Object, method: (...args: any[]) => any): any;
             /**
              * Returns a function that will only ever execute in the a given scope.
              * This allows for easy use of object member functions
@@ -5631,7 +5631,7 @@ declare namespace dojo {
              * @param scope The scope to use when method executes. If method is a string,scope is also the object containing method.
              * @param method A function to be hitched to scope, or the name of the method inscope to be hitched.
              */
-            hitch(scope: Object, method: String[]): any;
+            hitch(scope: Object, method: string): any;
             /**
              * Returns true if it is a built-in function or some other kind of
              * oddball that should report as a function but doesn't


### PR DESCRIPTION
According to [http://dojotoolkit.org/api/#1_10dojo__base_lang_hitch](http://dojotoolkit.org/api/#1_10dojo__base_lang_hitch), the hitch function takes a function or string as it's second parameter. The current definition says that the second parameter is an array of strings, which is not correct.

The changes I have made also reflect the fact that an arbitrary number of arguments can also be bound to the hitched function. See examples for usage details [http://dojotoolkit.org/reference-guide/1.10/dojo/_base/lang.html#hitch](http://dojotoolkit.org/reference-guide/1.10/dojo/_base/lang.html#hitch)
