### PR TITLE
change typings for aggregate

### DIFF
--- a/sequelize/sequelize.d.ts
+++ b/sequelize/sequelize.d.ts
@@ -3727,7 +3727,7 @@ declare module "sequelize" {
              * @return Returns the aggregate result cast to `options.dataType`, unless `options.plain` is false, in
              *     which case the complete data result is returned.
              */
-            aggregate( field : string, aggregateFunction : Function, options? : AggregateOptions ) : Promise<Object>;
+            aggregate( field : string, aggregateFunction : string, options? : AggregateOptions ) : Promise<Object>;
 
             /**
              * Count the number of records matching the provided where clause.


### PR DESCRIPTION
Improvement to existing type definition of Model.aggregate.
- in the aggregate method for the model, aggregateFunction is of type string, and not a function, in source code: https://github.com/sequelize/sequelize/blob/3e5b8772ef75169685fc96024366bca9958fee63/lib/model.js#L1525
