### PR TITLE
Add ref to ChildProcess

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1055,6 +1055,7 @@ declare module "child_process" {
         connected: boolean;
         disconnect(): void;
         unref(): void;
+        ref(): void;
     }
 
     export interface SpawnOptions {


### PR DESCRIPTION
It is the opposite of `unref` - it allows you to regain the reference that `unref` releases.
