### PR TITLE
Fix react-select definition for valueRenderer and clean up tests

### DIFF
--- a/react-select/react-select-tests.tsx
+++ b/react-select/react-select-tests.tsx
@@ -132,6 +132,7 @@ class SelectTest extends React.Component<React.Props<{}>, {}> {
             onChange: onChange,
             value: options,
             valueComponent: CustomValue,
+            valueRenderer: optionRenderer
         };
 
         return <div>

--- a/react-select/react-select-tests.tsx
+++ b/react-select/react-select-tests.tsx
@@ -1,9 +1,7 @@
-/// <reference path="../lodash/lodash.d.ts" />
 /// <reference path="../react/react.d.ts" />
 /// <reference path="../react/react-dom.d.ts" />
 /// <reference path="./react-select.d.ts" />
 
-import * as _ from "lodash";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
@@ -65,19 +63,15 @@ const CustomValue = React.createClass({
 
 const filterOptions = (options: Array<Option>, filter: string, values: Array<Option>) => {
     // Filter already selected values
-    let filteredOptions = options.filter(option => {
-        return !(_.includes(values, option));
-    });
+    let filteredOptions = options.filter(option => values.indexOf(option) < 0);
 
     // Filter by label
-    if (filter !== undefined && filter != null && filter.length > 0) {
-        filteredOptions = filteredOptions.filter(option => {
-            return RegExp(filter, 'ig').test(option.label);
-        });
+    if (filter != null && filter.length > 0) {
+        filteredOptions = filteredOptions.filter(option => RegExp(filter, 'ig').test(option.label));
     }
 
     // Append Addition option
-    if (filteredOptions.length == 0) {
+    if (filteredOptions.length === 0) {
         filteredOptions.push({
             label:  `Create: ${filter}`,
             value:  filter

--- a/react-select/react-select.d.ts
+++ b/react-select/react-select.d.ts
@@ -313,7 +313,7 @@ declare namespace ReactSelect {
          * function which returns a custom way to render the value selected
          * @default false
          */
-        valueRenderer?: () => void;
+        valueRenderer?: (option: Option) => JSX.Element;
         /**
          *  optional style to apply to the control
          */


### PR DESCRIPTION
Source code reference: https://github.com/JedWatson/react-select/blob/1e4de671f651eec0e25a22593079b937bf25f939/examples/src/components/CustomRender.js#L40

Additionally, cleaning up react-select tests to address suggestions from #10109 
