### PR TITLE
Improve Vue.js directive types

### DIFF
--- a/vue/vue-tests.ts
+++ b/vue/vue-tests.ts
@@ -30,9 +30,20 @@ namespace TestGlobalAPI {
     twoWay: true,
     acceptStatement: true,
     priority: 1,
+    terminal: true,
     count: 30
   });
-  Vue.directive("my-directive", () => {});
+  Vue.directive("my-directive", function() {
+    const d = this as vuejs.Directive;
+    d.el;
+    d.vm;
+    d.expression;
+    d.arg;
+    d.name;
+    d.modifiers;
+    d.descriptor;
+    d.params;
+  });
   var myDirective = Vue.directive("my-directive");
   var elementDirective = Vue.elementDirective("element-directive");
   Vue.elementDirective("element-directive", elementDirective);

--- a/vue/vue.d.ts
+++ b/vue/vue.d.ts
@@ -43,6 +43,17 @@ declare namespace vuejs {
         [key: string]: any;
     }
 
+    interface Directive {
+        el: HTMLElement;
+        vm: Vue;
+        expression: string;
+        arg?: string;
+        name: string;
+        modifiers: { [key: string]: boolean };
+        descriptor: any;
+        params?: { [key: string]: any };
+    }
+
     interface FilterOption {
         read?: Function;
         write?: Function;

--- a/vue/vue.d.ts
+++ b/vue/vue.d.ts
@@ -38,6 +38,7 @@ declare namespace vuejs {
         deep?: boolean;
         twoWay?: boolean;
         acceptStatement?: boolean;
+        terminal?: boolean;
         priority?: number;
         [key: string]: any;
     }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- Add `terminal` option for DirectiveOption
  - ref: https://vuejs.org/guide/custom-directive.html#terminal
- Add instance type of directive
  - ref: https://vuejs.org/guide/custom-directive.html#Directive-Instance-Properties
