### PR TITLE
Types 2.0 ReactDom.render

### DIFF
--- a/react-dom/index.d.ts
+++ b/react-dom/index.d.ts
@@ -18,19 +18,19 @@ declare namespace ReactDOM {
 
     function render<P extends DOMAttributes<T>, T extends Element>(
         element: DOMElement<P, T>,
-        container: Element,
+        container: Element | null,
         callback?: (element: T) => any): T;
     function render<P>(
         element: SFCElement<P>,
-        container: Element,
+        container: Element | null,
         callback?: () => any): void;
     function render<P, T extends Component<P, ComponentState>>(
         element: CElement<P, T>,
-        container: Element,
+        container: Element | null,
         callback?: (component: T) => any): T;
     function render<P>(
         element: ReactElement<P>,
-        container: Element,
+        container: Element | null,
         callback?: (component?: Component<P, ComponentState> | Element) => any): Component<P, ComponentState> | Element | void;
 
     function unmountComponentAtNode(container: Element): boolean;

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -218,6 +218,8 @@ var componentElementOrNull: ModernComponent =
     ReactDOM.render(element, document.getElementById("anelement"));    
 var componentNoState: ModernComponentNoState =
     ReactDOM.render(elementNoState, container);
+var componentNoStateElementOrNull: ModernComponentNoState =
+    ReactDOM.render(elementNoState, document.getElementById("anelement"));
 var classicComponent: React.ClassicComponent<Props, any> =
     ReactDOM.render(classicElement, container);
 var domComponent: Element =

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -211,6 +211,11 @@ var clonedDOMElement: React.ReactHTMLElement<HTMLDivElement> =
 // React.render
 var component: ModernComponent =
     ReactDOM.render(element, container);
+var componentNullContainer: ModernComponent =
+    ReactDOM.render(element, null);
+
+var componentElementOrNull: ModernComponent = 
+    ReactDOM.render(element, document.getElementById("anelement"));    
 var componentNoState: ModernComponentNoState =
     ReactDOM.render(elementNoState, container);
 var classicComponent: React.ClassicComponent<Props, any> =


### PR DESCRIPTION
Update type definition for ReactDOM.render() to match document.getElementById() being Element | null.
