### PR TITLE
Hammerjs: eventType is a number, not a string, per the documentation

### DIFF
--- a/hammerjs/hammerjs.d.ts
+++ b/hammerjs/hammerjs.d.ts
@@ -178,7 +178,7 @@ declare class HammerInput
   pointerType:string;
 
   /** Event type, matches the INPUT constants. */
-  eventType:string;
+  eventType:number;
 
   /** true when the first input. */
   isFirst:boolean;


### PR DESCRIPTION
For hammerjs, eventType is a number, not a string.  It is compared to the following constants:

```
INPUT_START:  number;
INPUT_MOVE:   number;
INPUT_END:    number;
INPUT_CANCEL: number;
```

which are also numbers.

Please let me know what is needed to merge.

Thanks,
Dan
