### PR TITLE
Added NativeTypes Enum to DropTarget types

### DIFF
--- a/react-dnd/react-dnd.d.ts
+++ b/react-dnd/react-dnd.d.ts
@@ -43,7 +43,7 @@ declare module __ReactDnd {
     ): (componentClass: React.ComponentClass<P>) => DndComponentClass<P>;
 
     export function DropTarget<P>(
-        types: Identifier | Identifier[] | ((props: P) => Identifier | Identifier[]),
+        types: Identifier | Identifier[] | NativeTypes | ((props: P) => Identifier | Identifier[]),
         spec: DropTargetSpec<P>,
         collect: DropTargetCollector,
         options?: DndOptions<P>


### PR DESCRIPTION
Under the [Extras heading](https://gaearon.github.io/react-dnd/docs-html5-backend.html#extras), NativeTypes are defined as a  type that can be registered with [DropTargets](https://gaearon.github.io/react-dnd/docs-drop-target.html)
The react-dnd typings file was missing the NativeTypes enum as an allowed type.
