### PR TITLE
Update chai-jquery.d.ts

### DIFF
--- a/chai-jquery/chai-jquery.d.ts
+++ b/chai-jquery/chai-jquery.d.ts
@@ -17,7 +17,7 @@ declare namespace Chai {
         html(html: string): Assertion;
         text(text: string): Assertion;
         value(text: string): Assertion;
-        (selector: string): Assertion;
+        descendants(selector: string): Assertion;
         visible: Assertion;
         hidden: Assertion;
         selected: Assertion;


### PR DESCRIPTION
The `descendants` function was missing, and it looks like it was meant to go right here.  Notice in the source that it is between `value` and `visible`: https://github.com/chaijs/chai-jquery/blob/master/chai-jquery.js#L148

Unless I'm missing something, `chai-jquery` should not define the behavior of `Chai.Assertion()`, but only add matchers to it. :)
