### PR TITLE
Update orientation type from number to string

### DIFF
--- a/bootstrap-slider/bootstrap-slider.d.ts
+++ b/bootstrap-slider/bootstrap-slider.d.ts
@@ -35,7 +35,7 @@ interface SliderOptions {
      * Default: 'horizontal'
      * set the orientation. Accepts 'vertical' or 'horizontal'
      */
-    orientation?: number;
+    orientation?: string;
     /**
      * Default: 5
      * initial value. Use array to have a range slider.


### PR DESCRIPTION
Case 2. Improvement to existing type definition.

When using this d.ts file in a project I was getting a TS2345 error in SliderOptions orientation: Type 'string' is not assignable to type 'number'. 

Looks it should be a string, but the d.ts file defines it as a number. The docs say that it should be a string (orientation, string. Accepts 'vertical' or 'horizontal'). 

Docs: https://github.com/seiyria/bootstrap-slider
