### PR TITLE
Improvement to github-electron: Add AutoUpdater.getFeedURL()

### DIFF
--- a/github-electron/github-electron.d.ts
+++ b/github-electron/github-electron.d.ts
@@ -504,6 +504,8 @@ declare namespace Electron {
 		 * Set the url and initialize the auto updater.
 		 */
 		setFeedURL(url: string, requestHeaders?: Headers): void;
+		/** Returns the current update feed URL. */
+		getFeedURL():string;
 		/**
 		 * Ask the server whether there is an update, you have to call setFeedURL
 		 * before using this API


### PR DESCRIPTION
Improvement to existing type definition.
See https://github.com/electron/electron/blob/master/docs/api/auto-updater.md#autoupdatergetfeedurl
