### PR TITLE
Add nodir to SrcOptions

### DIFF
--- a/gulp/gulp.d.ts
+++ b/gulp/gulp.d.ts
@@ -149,6 +149,11 @@ declare module "gulp" {
              * Note that an explicit dot in a portion of the pattern will always match dot files.
              */
             dot?: boolean;
+            
+            /**
+             * Set to match only fles, not directories. Set this flag to prevent copying empty directories
+             */
+            nodir?: boolean;
 
             /**
              * By default, a pattern starting with a forward-slash will be "mounted" onto the root setting, so that a valid


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url 

According to the gulp API
https://github.com/gulpjs/gulp/blob/5944c1b4d4c0a9dea804bc426b936aa742792cd4/docs/API.md

> gulp supports all options supported by node-glob and glob-stream except ignore.

node-glob
https://github.com/isaacs/node-glob/blob/68f2509d237babec64cf03adf72531127fd80339/README.md#L264

> `nodir` Do not match directories, only files. (Note: to match only directories, simply put a / at the end of the pattern.)
