### PR TITLE
Knex.js: Added TableName type and changed join bindings

### DIFF
--- a/knex/knex-tests.ts
+++ b/knex/knex-tests.ts
@@ -156,6 +156,10 @@ knex('users')
   .join('contacts', 'users.id', 'contacts.user_id')
   .select('users.id', 'contacts.phone');
 
+knex('users')
+  .join(knex('contacts').select('user_id', 'phone').as('contacts'), 'users.id', 'contacts.user_id')
+  .select('users.id', 'contacts.phone');
+
 knex.select('*').from('users').join('accounts', function() {
   this.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
 });

--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -14,6 +14,7 @@ declare module "knex" {
   type Client = Function;
   type Value = string|number|boolean|Date|Array<string>|Array<number>|Array<Date>|Array<boolean>;
   type ColumnName = string|Knex.Raw|Knex.QueryBuilder;
+  type TableName = string|Knex.Raw|Knex.QueryBuilder;
 
   interface Knex extends Knex.QueryInterface {
     (tableName?: string): Knex.QueryBuilder;
@@ -164,12 +165,12 @@ declare module "knex" {
 
     interface Join {
       (raw: Raw): QueryBuilder;
-      (tableName: string, callback: (joinClause: JoinClause) => any): QueryBuilder;
-      (tableName: string, columns: {[key: string]: string|Raw}): QueryBuilder;
-      (tableName: string, raw: Raw): QueryBuilder;
-      (tableName: string, column1: string, column2: string): QueryBuilder;
-      (tableName: string, column1: string, raw: Raw): QueryBuilder;
-      (tableName: string, column1: string, operator: string, column2: string): QueryBuilder;
+      (tableName: TableName, callback: (joinClause: JoinClause) => any): QueryBuilder;
+      (tableName: TableName, columns: {[key: string]: string|Raw}): QueryBuilder;
+      (tableName: TableName, raw: Raw): QueryBuilder;
+      (tableName: TableName, column1: string, column2: string): QueryBuilder;
+      (tableName: TableName, column1: string, raw: Raw): QueryBuilder;
+      (tableName: TableName, column1: string, operator: string, column2: string): QueryBuilder;
     }
 
     interface JoinClause {


### PR DESCRIPTION
Knex allows you to use subqueries in a lot of places. I've added them to Joins because they're the only ones I've tested, but it might be worth checking where else they are allowed.
