### PR TITLE
Update aws-sdk.d.ts

### DIFF
--- a/aws-sdk/aws-sdk.d.ts
+++ b/aws-sdk/aws-sdk.d.ts
@@ -397,7 +397,7 @@ declare module "aws-sdk" {
 		}
 
 		export interface SendMessageParams {
-			QueueUrl: string;
+			QueueUrl?: string;
 			MessageBody: string;
 			DelaySeconds?: number;
 			MessageAttributes?: { [name:string]: MessageAttribute; }


### PR DESCRIPTION
Make QueueUrl optional, as it can have a default value that is obtained from aws.SQS constructor parameter:

```
var sqs = new aws.SQS({
    region: config.aws.region,
    accessKeyId: config.aws.accessID,
    secretAccessKey: config.aws.secretKey,

    // For every request in this demo, I'm going to be using the same QueueUrl; so,
    // rather than explicitly defining it on every request, I can set it here as the
    // default QueueUrl to be automatically appended to every request.
    params: {
        QueueUrl: config.aws.queueUrl
    }
});

var sendMessage = Q.nbind( sqs.sendMessage, sqs );


// ---------------------------------------------------------- //
// ---------------------------------------------------------- //


// Now that we have a Q-ified method, we can send the message.
sendMessage({
    MessageBody: "This is my first ever SQS request... evar!"  // QueueUrl is not required here
})

```

Based on:
http://www.bennadel.com/blog/2792-shedding-the-monolithic-application-with-aws-simple-queue-service-sqs-and-node-js.htm
