### PR TITLE
Indexing the IDocumentService should return Document

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -985,7 +985,9 @@ declare namespace angular {
     // DocumentService
     // see http://docs.angularjs.org/api/ng.$document
     ///////////////////////////////////////////////////////////////////////////
-    interface IDocumentService extends JQuery {}
+    interface IDocumentService extends JQuery {
+        [index: number]: Document;
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     // ExceptionHandlerService


### PR DESCRIPTION
JQ(lite)-unwrapping `$document[0]` should be of type Document instead of
the default HTMLElement. Otherwise important methods like
getElementById are missing.
