### PR TITLE
Agenda missing props/methods

### DIFF
--- a/agenda/agenda.d.ts
+++ b/agenda/agenda.d.ts
@@ -319,6 +319,11 @@ declare module "agenda" {
              * The date/time the job last failed.
              */
             failedAt: Date;
+
+            /**
+             * Job's state
+             */
+            disabled: boolean
         }
 
         /**
@@ -409,6 +414,11 @@ declare module "agenda" {
              * @param cb Called after the job has been saved to the database.
              */
             touch(cb?: Callback): void;
+
+            /**
+             * Calculates next time the job should run
+             */
+            computeNextRunAt(): Job;
         }
 
         interface JobOptions {


### PR DESCRIPTION
Improvement to existing type definition.
- [Agenda Project URL](https://github.com/rschmukler/agenda)
- Docs don't show the missing method `computeNextRunAt`. However, it exist. See [this](https://github.com/rschmukler/agenda/issues/344)
- Same for property `disabled`: See [this](https://github.com/rschmukler/agenda/blob/13b4260c6789e78badf488c073f9faac4770825b/test/agenda.js#L784)
