### PR TITLE
ioredis: Add some missing properties

### DIFF
--- a/ioredis/ioredis.d.ts
+++ b/ioredis/ioredis.d.ts
@@ -41,7 +41,8 @@ declare module IORedis {
     }
 
     interface Redis extends NodeJS.EventEmitter, Commander {
-        connect(callback: Function): Promise<any>;
+        status: string;
+        connect(callback?: Function): Promise<any>;
         disconnect(): void;
         duplicate(): Redis;
         monitor(calback: (error: Error, monitor: NodeJS.EventEmitter) => void): Promise<NodeJS.EventEmitter>;
@@ -59,6 +60,7 @@ declare module IORedis {
         subscribe(channel: string): any;
         get(args: any[], callback?: ResCallbackT<string>): any;
         get(...args: any[]): any;
+        getBuffer(key: string, callback?: ResCallbackT<Buffer>): any;
         set(args: any[], callback?: ResCallbackT<string>): any;
         set(...args: any[]): any;
         setnx(args: any[], callback?: ResCallbackT<any>): any;


### PR DESCRIPTION
These are minor changes:
- There's a `status` field that can be used to check if the connection to the redis server is active. (source: https://github.com/luin/ioredis/blob/master/lib/redis.js#L226)
- There's a `getBuffer` method that returns a node `Buffer` instance instead of a string (if you're saving binary data on redis, this is quite useful). It's implemented quite hackishly: https://github.com/luin/ioredis/blob/3ab4e8a67aaa27441abbd56a42bb0757284e90eb/lib/pipeline.js#L27 but it's named in the project's README: https://github.com/luin/ioredis/blob/master/README.md#handle-binary-data
- The callback on `connect` is optional (specially if you are using the promise interface)
