### PR TITLE
add load-json-file

### DIFF
--- a/load-json-file/load-json-file-tests.ts
+++ b/load-json-file/load-json-file-tests.ts
@@ -1,0 +1,15 @@
+/// <reference path="load-json-file.d.ts" />
+import * as loadJsonFile from 'load-json-file';
+
+function assert(actual: string, expected: string): void {
+	if (actual !== expected) {
+		throw new Error(`${JSON.stringify(actual)} !== ${JSON.stringify(expected)}`);
+	}
+}
+
+loadJsonFile('../package.json').then(pkg => {
+	assert(pkg.name, 'definitely-typed');
+});
+
+const pkg = loadJsonFile.sync('../package.json');
+assert(pkg.name, 'definitely-typed');

--- a/load-json-file/load-json-file.d.ts
+++ b/load-json-file/load-json-file.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for load-json-file v2.0.0
+// Project: https://github.com/sindresorhus/load-json-file
+// Definitions by: Sam Verschueren <https://github.com/SamVerschueren>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "load-json-file" {
+
+	interface LoadJsonFile {
+		/**
+		 * Returns a promise for the parsed JSON.
+		 *
+		 * @param filepath
+		 */
+		(filepath: string): Promise<any>;
+		/**
+		 * Returns the parsed JSON.
+		 *
+		 * @param filepath
+		 */
+		sync(filepath: string): any;
+	}
+
+	const loadJsonFile: LoadJsonFile;
+
+	export = loadJsonFile;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Added type definitions for [load-json-file](https://github.com/sindresorhus/load-json-file)
