### PR TITLE
Including typings for globalize-compiler.

### DIFF
--- a/globalize-compiler/globalize-compiler-tests.ts
+++ b/globalize-compiler/globalize-compiler-tests.ts
@@ -20,7 +20,9 @@ compileOutput = globalizeCompiler.compile({ x: () => "test", y: (x: string) => x
 
 let extractOutput: GlobalizeCompiler.ExtractFunction;
 extractOutput = globalizeCompiler.extract("path");
-extractOutput = globalizeCompiler.extract({});
+
+const ast: ESTree.Program = undefined;
+extractOutput = globalizeCompiler.extract(ast);
 
 extractsArray = extractOutput(globalize);
 

--- a/globalize-compiler/globalize-compiler-tests.ts
+++ b/globalize-compiler/globalize-compiler-tests.ts
@@ -1,0 +1,34 @@
+///<reference path="globalize-compiler.d.ts" />
+
+import globalizeCompiler = require("globalize-compiler");
+const globalize: GlobalizeStatic = null;
+
+let extractsArray: GlobalizeCompiler.FormatterOrParserFunction[];
+
+const templateFunction: (options: GlobalizeCompiler.CompileTemplateOptions) => string =
+  (options: GlobalizeCompiler.CompileTemplateOptions): string => {
+    const deps: string[] = options.dependencies;
+    const code: string = options.code;
+    return `${deps.join(';')}${code}`;
+  };
+
+let compileOutput: string;
+compileOutput = globalizeCompiler.compile(extractsArray);
+compileOutput = globalizeCompiler.compile({ x: () => "test", y: (x: string) => x });
+compileOutput = globalizeCompiler.compile(extractsArray, { template: templateFunction });
+compileOutput = globalizeCompiler.compile({ x: () => "test", y: (x: string) => x }, { template: templateFunction });
+
+let extractOutput: GlobalizeCompiler.ExtractFunction;
+extractOutput = globalizeCompiler.extract("path");
+extractOutput = globalizeCompiler.extract({});
+
+extractsArray = extractOutput(globalize);
+
+compileOutput = globalizeCompiler.compileExtracts({ extracts: extractOutput, defaultLocale: "en" });
+compileOutput = globalizeCompiler.compileExtracts({ extracts: extractOutput, defaultLocale: "en", messages: {} });
+compileOutput = globalizeCompiler.compileExtracts({ extracts: extractOutput, defaultLocale: "en", template: templateFunction });
+compileOutput = globalizeCompiler.compileExtracts({ extracts: extractOutput, defaultLocale: "en", messages: {}, template: templateFunction });
+compileOutput = globalizeCompiler.compileExtracts({ extracts: extractOutput, defaultLocale: "en", cldr: {} });
+compileOutput = globalizeCompiler.compileExtracts({ extracts: extractOutput, defaultLocale: "en", cldr: {}, messages: {} });
+compileOutput = globalizeCompiler.compileExtracts({ extracts: extractOutput, defaultLocale: "en", cldr: {}, template: templateFunction });
+compileOutput = globalizeCompiler.compileExtracts({ extracts: extractOutput, defaultLocale: "en", cldr: {}, messages: {}, template: templateFunction });

--- a/globalize-compiler/globalize-compiler.d.ts
+++ b/globalize-compiler/globalize-compiler.d.ts
@@ -1,0 +1,105 @@
+// Type definitions for globalize-compiler v0.2.0
+// Project: https://github.com/jquery-support/globalize-compiler
+// Definitions by: Ian Clanton-Thuon <https://github.com/iclanton>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="./../globalize/globalize.d.ts" />
+
+declare namespace GlobalizeCompiler {
+  interface CompileTemplateOptions {
+    /**
+     * the source of the compiled formatters and parsers.
+     */
+    code: string;
+
+    /**
+     * a list of globalize runtime modules that the compiled code depends on, e.g. globalize-runtime/number.
+     */
+    dependencies: string[];
+  }
+
+  interface CompileOptions {
+    /**
+     * A function that replaces the default template.
+     */
+    template?: (options: CompileTemplateOptions) => string;
+  }
+  
+  interface FormatterOrParserFunction {
+    (...arguments: any[]): any;
+  }
+
+  interface ExtractFunction {
+    /**
+     * @param {globalize} the globalize object.
+     * 
+     * @returns an Array with the formatters and parsers created using the passed Globalize.
+     */
+    (globalize: GlobalizeStatic): FormatterOrParserFunction[];
+  }
+
+  interface CompileExtractsAttributes extends CompileOptions {
+    /**
+     * an Array of extracts obtained by @see{GlobalizeCompilerStatic.extract}
+     */
+    extracts: ExtractFunction;
+
+    /**
+     * a locale to be used as Globalize.locale(defaultLocale) when generating the extracted formatters and parsers.
+     */
+    defaultLocale: string;
+
+    /**
+     * an Object with CLDR data (in the JSON format) or a Function taking one argument: locale, a String; returning
+     *  an Object with the CLDR data for the passed locale. Defaults to the entire supplemental data plus the entire
+     *  main data for the defaultLocale.
+     */
+    cldr?: Object | ((locale: string) => Object);
+
+    /**
+     * an Object with messages data (in the JSON format) or a Function taking one argument: locale, a String; returning
+     *  an Object with the messages data for the passed locale. Defaults to {}.
+     */
+    messages?: Object | ((locale: string) => Object);
+  }
+
+  interface GlobalizeCompilerStatic {
+    /**
+     * Generates a JavaScript bundle containing the specified globalize formatters and parsers.
+     * 
+     * @param {formattersAndParsers} an Array or an Object containing formatters and/or parsers.
+     * @param {options} compiler options.
+     * 
+     * @returns a String with the generated JavaScript bundle (UMD wrapped) including the compiled formatters and
+     *  parsers.
+     */
+    compile(formattersAndParsers: FormatterOrParserFunction[] | { [key: string]: FormatterOrParserFunction },
+            options?: CompileOptions): string;
+
+    /**
+     * Creates an extract function from a source file.
+     * 
+     * @param {input} a String with a filename, or a String with the file content, or an AST Object.
+     * 
+     * @returns an extract. An extract is a Function taking one argument: Globalize, the Globalize Object;
+     *  and returning an Array with the formatters and parsers created using the passed Globalize.
+     */
+    extract(input: string | Object): ExtractFunction;
+
+    /**
+     * Generates a JavaScript bundle containing the specified globalize formatters and parsers.
+     * 
+     * @param {options} compiler attributes.
+     * 
+     * @returns a String with the generated JavaScript bundle (UMD wrapped) including the compiled formatters and
+     *  parsers.
+     */
+    compileExtracts(attributes: CompileExtractsAttributes): string;
+  }
+}
+
+declare module "globalize-compiler" {
+  var globalizeCompiler: GlobalizeCompiler.GlobalizeCompilerStatic;
+
+  export = globalizeCompiler;
+}

--- a/globalize-compiler/globalize-compiler.d.ts
+++ b/globalize-compiler/globalize-compiler.d.ts
@@ -4,6 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="./../globalize/globalize.d.ts" />
+/// <reference path="../estree/estree.d.ts" />
 
 declare namespace GlobalizeCompiler {
   interface CompileTemplateOptions {
@@ -84,7 +85,7 @@ declare namespace GlobalizeCompiler {
      * @returns an extract. An extract is a Function taking one argument: Globalize, the Globalize Object;
      *  and returning an Array with the formatters and parsers created using the passed Globalize.
      */
-    extract(input: string | Object): ExtractFunction;
+    extract(input: string | ESTree.Program): ExtractFunction;
 
     /**
      * Generates a JavaScript bundle containing the specified globalize formatters and parsers.


### PR DESCRIPTION
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
