### PR TITLE
Fixing issue in webpack.d.ts

### DIFF
--- a/webpack/webpack.d.ts
+++ b/webpack/webpack.d.ts
@@ -102,7 +102,7 @@ declare module "webpack" {
             /** Include comments with information about the modules. */
             pathinfo?: boolean;
             /** If set, export the bundle as library. output.library is the name. */
-            library?: boolean;
+            library?: string;
             /**
              * Which format to export the library:
              * <ul>


### PR DESCRIPTION
The type of `output.library` is incorrect. It should be `string`, and it's currently `boolean`. See [here](http://webpack.github.io/docs/configuration.html#output-library):

> ### `output.library`
> 
> If set, export the bundle as library. `output.library` is the name.
> 
> Use this, if you are writing a library and want to publish it as single file.
