### PR TITLE
fetch-mock types-2.0 version

### DIFF
--- a/fetch-mock/fetch-mock-tests.ts
+++ b/fetch-mock/fetch-mock-tests.ts
@@ -1,0 +1,30 @@
+import * as fetchMock from 'fetch-mock';
+
+fetchMock.mock("http://test.com", 200);
+fetchMock.mock(/test\.com/, 200);
+fetchMock.mock(() => true, 200);
+fetchMock.mock((url, opts) => true, 200);
+
+fetchMock.mock(/test/, "test").mock(/test/, { a: "b" });
+fetchMock.mock(/test/, {
+    status: 200,
+    headers: {
+        "test": "test"
+    },
+    body: {
+        a: "b"
+    }
+});
+
+fetchMock.restore().reset();
+
+(fetchMock.calls().matched[0][1] as RequestInit).body;
+fetchMock.calls().unmatched[0][0].toUpperCase();
+fetchMock.calls("http://test.com")[0][0].toUpperCase();
+(fetchMock.calls("http://test.com")[0][1] as RequestInit).body;
+
+fetchMock.called("http://test.com");
+
+(fetchMock.lastCall()[1] as RequestInit).body;
+fetchMock.lastUrl();
+fetchMock.lastOptions();

--- a/fetch-mock/index.d.ts
+++ b/fetch-mock/index.d.ts
@@ -1,0 +1,205 @@
+// Type definitions for fetch-mock 5.0.0
+// Project: https://github.com/wheresrhys/fetch-mock
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>, Tamir Duberstein <https://github.com/tamird>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference path="../whatwg-fetch/index.d.ts" />
+
+type MockRequest = Request | RequestInit;
+
+/**
+ * Mock matcher function
+ * @param url
+ * @param opts
+ */
+type MockMatcherFunction = (url: string, opts: MockRequest) => boolean
+/**
+ * Mock matcher. Can be one of following:
+ * string: Either
+     * an exact url to match e.g. 'http://www.site.com/page.html'
+     * if the string begins with a `^`, the string following the `^` must
+       begin the url e.g. '^http://www.site.com' would match
+       'http://www.site.com' or 'http://www.site.com/page.html'
+     * '*' to match any url
+ * RegExp: A regular expression to test the url against
+ * Function(url, opts): A function (returning a Boolean) that is passed the
+   url and opts fetch() is called with (or, if fetch() was called with one,
+   the Request instance)
+ */
+type MockMatcher = string | RegExp | MockMatcherFunction;
+
+/**
+ * Mock response object
+ */
+interface MockResponseObject {
+    /**
+     * Set the response body
+     */
+    body?: string | {};
+    /**
+     * Set the response status
+     * @default 200
+     */
+    status?: number;
+    /**
+     * Set the response headers.
+     */
+    headers?: { [key: string]: string };
+    /**
+     * If this property is present then a Promise rejected with the value
+       of throws is returned
+     */
+    throws?: boolean;
+    /**
+     * This property determines whether or not the request body should be
+       JSON.stringified before being sent
+     * @default true
+     */
+    sendAsJson?: boolean;
+}
+/**
+ * Response: A Response instance - will be used unaltered
+ * number: Creates a response with this status
+ * string: Creates a 200 response with the string as the response body
+ * object: As long as the object is not a MockResponseObject it is
+   converted into a json string and returned as the body of a 200 response
+ * If MockResponseObject was given then it's used to configure response
+ * Function(url, opts): A function that is passed the url and opts fetch()
+   is called with and that returns any of the responses listed above
+ */
+type MockResponse = Response | Promise<Response>
+                    | number | Promise<number>
+                    | string | Promise<string>
+                    | Object | Promise<Object>
+                    | MockResponseObject | Promise<MockResponseObject>;
+/**
+ * Mock response function
+ * @param url
+ * @param opts
+ */
+type MockResponseFunction = (url: string, opts: MockRequest) => MockResponse;
+
+/**
+ * Mock options object
+ */
+interface MockOptions {
+    /**
+     * A unique string naming the route. Used to subsequently retrieve
+       references to the calls, grouped by name.
+     * @default matcher.toString()
+     *
+     * Note: If a non-unique name is provided no error will be thrown
+       (because names are optional, auto-generated ones may legitimately
+       clash)
+     */
+    name?: string;
+    /**
+     * http method to match
+     */
+    method?: string;
+    /**
+     * as specified above
+     */
+    matcher?: MockMatcher;
+    /**
+     * as specified above
+     */
+    response?: MockResponse | MockResponseFunction;
+}
+
+type MockCall = [string, MockRequest];
+
+interface MatchedRoutes {
+    matched: Array<MockCall>;
+    unmatched: Array<MockCall>;
+}
+
+interface FetchMockStatic {
+    /**
+     * Replaces fetch() with a stub which records its calls, grouped by
+       route, and optionally returns a mocked Response object or passes the
+       call through to fetch(). Calls to .mock() can be chained.
+     * @param matcher Condition for selecting which requests to mock
+     * @param response Configures the http response returned by the mock
+     */
+    mock(matcher: MockMatcher, response: MockResponse | MockResponseFunction): this;
+    /**
+     * Replaces fetch() with a stub which records its calls, grouped by
+       route, and optionally returns a mocked Response object or passes the
+       call through to fetch(). Calls to .mock() can be chained.
+     * @param matcher Condition for selecting which requests to mock
+     * @param response Configures the http response returned by the mock
+     * @param options Additional properties defining the route to mock
+     */
+    mock(matcher: MockMatcher, response: MockResponse | MockResponseFunction, options: MockOptions): this;
+    /**
+     * Replaces fetch() with a stub which records its calls, grouped by
+       route, and optionally returns a mocked Response object or passes the
+       call through to fetch(). Calls to .mock() can be chained.
+     * @param options The route to mock
+     */
+    mock(options: MockOptions): this;
+    /**
+     * Chainable method that restores fetch() to its unstubbed state and
+       clears all data recorded for its calls.
+     */
+    restore(): this;
+    /**
+     * Chainable method that clears all data recorded for fetch()'s calls
+     */
+    reset(): this;
+    /**
+     * Returns all calls to fetch, grouped by whether fetch-mock matched
+       them or not.
+     */
+    calls(): MatchedRoutes;
+    /**
+     * Returns all calls to fetch matching matcherName.
+     */
+    calls(matcherName?: string): Array<MockCall>;
+    /**
+     * Returns a Boolean indicating whether fetch was called and a route
+       was matched.
+     */
+    called(): boolean;
+    /**
+     * Returns a Boolean indicating whether fetch was called and a route
+       named matcherName was matched.
+     */
+    called(matcherName?: string): boolean;
+    /**
+     * Returns the arguments for the last matched call to fetch
+     */
+    lastCall(): MockCall;
+    /**
+     * Returns the arguments for the last call to fetch matching
+       matcherName
+     */
+    lastCall(matcherName?: string): MockCall;
+    /**
+     * Returns the url for the last matched call to fetch
+     */
+    lastUrl(): string;
+    /**
+     * Returns the url for the last call to fetch matching matcherName
+     */
+    lastUrl(matcherName?: string): string;
+    /**
+     * Returns the options for the last matched call to fetch
+     */
+    lastOptions(): MockRequest;
+    /**
+     * Returns the options for the last call to fetch matching matcherName
+     */
+    lastOptions(matcherName?: string): MockRequest;
+    /**
+     * Set some global config options, which include
+         * sendAsJson [default `true`] - by default fetchMock will
+           convert objects to JSON before sending. This is overrideable
+           for each call but for some scenarios, e.g. when dealing with a
+           lot of array buffers, it can be useful to default to `false`
+     */
+    configure(opts: Object): void;
+}
+
+declare var fetchMock: FetchMockStatic;
+export = fetchMock;

--- a/fetch-mock/tsconfig.json
+++ b/fetch-mock/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "fetch-mock-tests.ts"
+    ]
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
