### PR TITLE
react-native: let a few following interfaces extend `ViewProperties`

### DIFF
--- a/react-native/react-native.d.ts
+++ b/react-native/react-native.d.ts
@@ -918,7 +918,7 @@ declare namespace  __React {
         showWithText?: boolean
     }
 
-    export interface ToolbarAndroidProperties extends React.Props<ToolbarAndroidStatic> {
+    export interface ToolbarAndroidProperties extends ViewProperties, React.Props<ToolbarAndroidStatic> {
         actions?: ToolbarAndroidAction[]
 
         /**
@@ -1000,6 +1000,8 @@ declare namespace  __React {
          * Sets the toolbar title color.
          */
         titleColor?: string
+
+        ref?: Ref<ToolbarAndroidStatic>
     }
 
     export interface ToolbarAndroidStatic extends React.ComponentClass<ToolbarAndroidProperties> {
@@ -1479,7 +1481,7 @@ declare namespace  __React {
     /**
      * @see https://facebook.github.io/react-native/docs/webview.html#props
      */
-    export interface WebViewProperties extends WebViewPropertiesAndroid, WebViewPropertiesIOS, React.Props<WebViewStatic> {
+    export interface WebViewProperties extends ViewProperties, WebViewPropertiesAndroid, WebViewPropertiesIOS, React.Props<WebViewStatic> {
 
         automaticallyAdjustContentInsets?: boolean
 
@@ -1553,6 +1555,8 @@ declare namespace  __React {
          * sets whether the webpage scales to fit the view and the user can change the scale
          */
         scalesPageToFit?: boolean
+        
+        ref?: Ref<WebViewStatic & ViewStatic>
     }
 
 
@@ -1590,7 +1594,7 @@ declare namespace  __React {
          target: number
      }
 
-     export interface SegmentedControlIOSProperties extends React.Props<SegmentedControlIOSStatic> {
+     export interface SegmentedControlIOSProperties extends ViewProperties, React.Props<SegmentedControlIOSStatic> {
 
          /**
           * If false the user won't be able to interact with the control. Default value is true.
@@ -1630,6 +1634,8 @@ declare namespace  __React {
           * The labels for the control's segment buttons, in order.
           */
          values?: string[]
+
+         ref?: Ref<SegmentedControlIOSStatic>
      }
 
     export interface SegmentedControlIOSStatic extends React.ComponentClass<SegmentedControlIOSProperties> {
@@ -1744,7 +1750,7 @@ declare namespace  __React {
     /**
      * @see https://facebook.github.io/react-native/docs/activityindicator.html#props
      */
-    export interface ActivityIndicatorProperties extends React.Props<ActivityIndicatorStatic> {
+    export interface ActivityIndicatorProperties extends ViewProperties, React.Props<ActivityIndicatorStatic> {
 
         /**
          * Whether to show the indicator (true, the default) or hide it (false).
@@ -1770,6 +1776,8 @@ declare namespace  __React {
         size?: 'small' | 'large'
 
         style?: ViewStyle
+
+        ref?: Ref<ActivityIndicatorStatic>
     }
 
     export interface ActivityIndicatorStatic extends React.ComponentClass<ActivityIndicatorProperties> {
@@ -1779,7 +1787,7 @@ declare namespace  __React {
     /**
      * @see https://facebook.github.io/react-native/docs/activityindicatorios.html#props
      */
-    export interface ActivityIndicatorIOSProperties extends React.Props<ActivityIndicatorIOSStatic> {
+    export interface ActivityIndicatorIOSProperties extends ViewProperties, React.Props<ActivityIndicatorIOSStatic> {
 
         /**
          * Whether to show the indicator (true, the default) or hide it (false).
@@ -1810,6 +1818,8 @@ declare namespace  __React {
         size?: 'small' | 'large'
 
         style?: ViewStyle
+
+        ref?: Ref<ActivityIndicatorIOSStatic>
     }
 
     /**
@@ -1819,7 +1829,7 @@ declare namespace  __React {
     }
 
 
-    export interface DatePickerIOSProperties extends React.Props<DatePickerIOSStatic> {
+    export interface DatePickerIOSProperties extends ViewProperties, React.Props<DatePickerIOSStatic> {
 
         /**
          * The currently selected date.
@@ -1865,6 +1875,7 @@ declare namespace  __React {
          */
         timeZoneOffsetInMinutes?: number
 
+        ref?: Ref<DatePickerIOSStatic>
     }
 
     export interface DatePickerIOSStatic extends React.ComponentClass<DatePickerIOSProperties> {
@@ -1876,7 +1887,7 @@ declare namespace  __React {
     /**
      * @see DrawerLayoutAndroid.android.js
      */
-    export interface DrawerLayoutAndroidProperties extends React.Props<DrawerLayoutAndroidStatic> {
+    export interface DrawerLayoutAndroidProperties extends ViewProperties, React.Props<DrawerLayoutAndroidStatic> {
 
         /**
          * Specifies the background color of the drawer. The default value
@@ -1967,6 +1978,7 @@ declare namespace  __React {
          */
         statusBarBackgroundColor?: any
 
+        ref?: Ref<DrawerLayoutAndroidStatic & ViewStatic>
     }
 
     export interface DrawerLayoutAndroidStatic extends React.ComponentClass<DrawerLayoutAndroidProperties> {
@@ -2010,18 +2022,22 @@ declare namespace  __React {
     export interface PickerItemStatic extends React.ComponentClass<PickerItemProperties> {
     }
 
-    export interface PickerPropertiesIOS extends React.Props<PickerStatic> {
+    export interface PickerPropertiesIOS extends ViewProperties, React.Props<PickerStatic> {
 
         itemStyle?: ViewStyle
+
+        ref?: Ref<PickerStatic & ViewStatic>
     }
 
-    export interface PickerPropertiesAndroid extends React.Props<PickerStatic> {
+    export interface PickerPropertiesAndroid extends ViewProperties, React.Props<PickerStatic> {
 
         enabled?: boolean
 
         mode?: "dialog" | "dropdown"
 
         prompt?: string
+
+        ref?: Ref<PickerStatic & ViewStatic>
     }
 
     /**
@@ -2052,6 +2068,8 @@ declare namespace  __React {
          * Used to locate this view in end-to-end tests.
          */
         testId?: string
+
+        ref?: Ref<PickerStatic>
     }
 
     /**
@@ -2086,7 +2104,7 @@ declare namespace  __React {
      * @see https://facebook.github.io/react-native/docs/progressbarandroid.html
      * @see ProgressBarAndroid.android.js
      */
-    export interface ProgressBarAndroidProperties extends React.Props<ProgressBarAndroidStatic> {
+    export interface ProgressBarAndroidProperties extends ViewProperties, React.Props<ProgressBarAndroidStatic> {
 
         style?: ViewStyle
 
@@ -2122,6 +2140,8 @@ declare namespace  __React {
          * Used to locate this view in end-to-end tests.
          */
         testID?: string
+
+        ref?: Ref<ProgressBarAndroidStatic>
     }
     export interface ProgressBarAndroidStatic extends React.ComponentClass<ProgressBarAndroidProperties> {
     }
@@ -2130,7 +2150,7 @@ declare namespace  __React {
      * @see https://facebook.github.io/react-native/docs/progressviewios.html
      * @see ProgressViewIOS.ios.js
      */
-    export interface ProgressViewIOSProperties extends React.Props<ProgressViewIOSStatic> {
+    export interface ProgressViewIOSProperties extends ViewProperties, React.Props<ProgressViewIOSStatic> {
 
         style?: ViewStyle
 
@@ -2163,11 +2183,13 @@ declare namespace  __React {
          * A stretchable image to display behind the progress bar.
          */
         trackImage?: any
+
+        ref?: Ref<ProgressViewIOSStatic>
     }
     export interface ProgressViewIOSStatic extends React.ComponentClass<ProgressViewIOSProperties> {
     }
 
-    export interface RefreshControlPropertiesIOS extends React.Props<RefreshControlStatic> {
+    export interface RefreshControlPropertiesIOS extends ViewProperties, React.Props<RefreshControlStatic> {
 
         /**
          * The color of the refresh indicator.
@@ -2183,9 +2205,11 @@ declare namespace  __React {
          * Title color.
          */
         titleColor?: string
+
+        ref?: Ref<RefreshControlStatic & ViewStatic>
     }
 
-    export interface RefreshControlPropertiesAndroid extends React.Props<RefreshControlStatic> {
+    export interface RefreshControlPropertiesAndroid extends ViewProperties, React.Props<RefreshControlStatic> {
 
         /**
          * The colors (at least one) that will be used to draw the refresh indicator.
@@ -2212,6 +2236,8 @@ declare namespace  __React {
          * @platform android
          */
         progressViewOffset?: number
+
+        ref?: Ref<RefreshControlStatic & ViewStatic>
     }
 
     export interface RefreshControlProperties extends RefreshControlPropertiesIOS, RefreshControlPropertiesAndroid, React.Props<RefreshControl> {
@@ -2225,13 +2251,15 @@ declare namespace  __React {
          * Whether the view should be indicating an active refresh.
          */
         refreshing?: boolean
+        
+        ref?: Ref<RefreshControlStatic>
     }
 
     export interface RefreshControlStatic extends React.ComponentClass<RefreshControlProperties> {
         SIZE: Object // Undocumented
     }
 
-    export interface SliderPropertiesIOS extends React.Props<SliderStatic> {
+    export interface SliderPropertiesIOS extends ViewProperties, React.Props<SliderStatic> {
 
         /**
          * Assigns a maximum track image. Only static images are supported.
@@ -2268,6 +2296,8 @@ declare namespace  __React {
          * to fill the track.
          */
         trackImage?: any
+
+        ref?: Ref<SliderStatic>
     }
 
     export interface SliderProperties extends SliderPropertiesIOS, React.Props<SliderStatic> {
@@ -2333,7 +2363,7 @@ declare namespace  __React {
     /**
      * @see https://facebook.github.io/react-native/docs/sliderios.html
      */
-    export interface SliderIOSProperties extends React.Props<SliderIOSStatic> {
+    export interface SliderIOSProperties extends ViewProperties, React.Props<SliderIOSStatic> {
 
         /**
          * If true the user won't be able to move the slider. Default value is false.
@@ -2393,6 +2423,8 @@ declare namespace  __React {
          * This is not a controlled component, e.g. if you don't update the value, the component won't be reset to its inital value.
          */
         value?: number
+
+        ref?: Ref<SliderIOSStatic>
     }
 
     export interface SliderIOSStatic extends React.ComponentClass<SliderIOSProperties> {
@@ -2721,6 +2753,8 @@ declare namespace  __React {
          * pixels.
          */
         scrollRenderAheadDistance?: number
+
+        ref?: Ref<ListViewStatic & ScrollViewStatic & ViewStatic>
     }
 
     export interface ListViewStatic extends React.ComponentClass<ListViewProperties> {
@@ -2815,7 +2849,7 @@ declare namespace  __React {
         active?: boolean
     }
 
-    export interface MapViewProperties extends MapViewPropertiesIOS, MapViewPropertiesAndroid, Touchable, React.Props<MapViewStatic> {
+    export interface MapViewProperties extends MapViewPropertiesIOS, MapViewPropertiesAndroid, Touchable, ViewProperties, React.Props<MapViewStatic> {
 
 
 
@@ -2884,6 +2918,8 @@ declare namespace  __React {
          * Default value is true.
          */
         zoomEnabled?: boolean
+
+        ref?: Ref<MapViewStatic & ViewStatic>
     }
 
     /**
@@ -3502,7 +3538,7 @@ declare namespace  __React {
     /**
      * @see https://facebook.github.io/react-native/docs/tabbarios-item.html#props
      */
-    export interface TabBarItemProperties extends React.Props<TabBarItemStatic> {
+    export interface TabBarItemProperties extends ViewProperties, React.Props<TabBarItemStatic> {
 
         /**
          * Little red bubble that sits at the top right of the icon.
@@ -3549,6 +3585,7 @@ declare namespace  __React {
          */
         title?: string
 
+        ref?: Ref<TabBarItemStatic & ViewStatic>
     }
 
     export interface TabBarItemStatic extends React.ComponentClass<TabBarItemProperties> {
@@ -3557,7 +3594,7 @@ declare namespace  __React {
     /**
      * @see https://facebook.github.io/react-native/docs/tabbarios.html#props
      */
-    export interface TabBarIOSProperties extends React.Props<TabBarIOSStatic> {
+    export interface TabBarIOSProperties extends ViewProperties, React.Props<TabBarIOSStatic> {
 
         /**
          * Background color of the tab bar
@@ -3580,6 +3617,8 @@ declare namespace  __React {
          * Color of text on unselected tabs
          */
         unselectedTintColor?: string
+        
+        ref?: Ref<TabBarIOSStatic & ViewStatic>
     }
 
     export interface TabBarIOSStatic extends React.ComponentClass<TabBarIOSProperties> {
@@ -3959,7 +3998,7 @@ declare namespace  __React {
 
     }
 
-    export interface ScrollViewProperties extends ScrollViewPropertiesIOS, ScrollViewPropertiesAndroid, Touchable {
+    export interface ScrollViewProperties extends ViewProperties, ScrollViewPropertiesIOS, ScrollViewPropertiesAndroid, Touchable, React.Props<ScrollViewStatic> {
 
         /**
          * These styles will be applied to the scroll view content container which
@@ -4043,10 +4082,12 @@ declare namespace  __React {
          * functionality for the ScrollView.
          */
         refreshControl?: RefreshControl
+
+        ref?: Ref<ScrollViewStatic & ViewStatic>
     }
 
     export interface ScrollViewProps extends ScrollViewProperties, React.Props<ScrollViewStatic> {
-
+        ref?: Ref<ScrollViewStatic>
     }
 
     interface ScrollViewStatic extends React.ComponentClass<ScrollViewProps> {
@@ -5084,7 +5125,7 @@ declare namespace  __React {
         LONG: number
     }
 
-    export interface SwitchPropertiesIOS extends React.Props<SwitchStatic> {
+    export interface SwitchPropertiesIOS extends ViewProperties, React.Props<SwitchStatic> {
 
         /**
          * Background color when the switch is turned on.
@@ -5100,9 +5141,11 @@ declare namespace  __React {
          * Background color when the switch is turned off.
          */
         tintColor?: string
+
+        ref?: Ref<SwitchStatic>
     }
 
-    export interface SwitchProperties extends React.Props<SwitchStatic> {
+    export interface SwitchProperties extends ViewProperties, React.Props<SwitchStatic> {
 
         /**
          * If true the user won't be able to toggle the switch.
@@ -5126,7 +5169,9 @@ declare namespace  __React {
          */
         value?: boolean
 	
-	style?: ViewStyle
+	    style?: ViewStyle
+
+        ref?: Ref<SwitchStatic>
     }
 
     export interface SwitchStatic extends React.ComponentClass<SwitchProperties> {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

This fix was discussed in issue #10053 .

cc @bgrieder: would you like to have a look at this?
