### PR TITLE
Return intersection type when indexing IDocumentService

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -986,7 +986,8 @@ declare namespace angular {
     // see http://docs.angularjs.org/api/ng.$document
     ///////////////////////////////////////////////////////////////////////////
     interface IDocumentService extends JQuery {
-        [index: number]: Document;
+        // Must return intersection type for index signature compatibility with JQuery
+        [index: number]: HTMLElement & Document;
     }
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Typescript 2.0 starts checking the compatibility of the index
signature with the base JQuery interface; Hence we are forced to
return Document & HTMLElement to be compatible with the base.

Fixes regression introduced in #10237 
