### PR TITLE
fix for #10271 jstree

### DIFF
--- a/jstree/jstree-tests.ts
+++ b/jstree/jstree-tests.ts
@@ -109,3 +109,8 @@ var tree = $('a').jstree();
 tree.move_node('a', 'b', 0, (node: any, new_par: any, pos: any) => { }, true, true);
 tree.copy_node('a', 'b', 0, (node: any, new_par: any, pos: any) => { }, true, true);
 
+// #10271 jstree - get_path params not marked to be optional
+tree.get_path('nodeId');
+tree.get_path('nodeId', '/');
+tree.get_path('nodeId', '/', true);
+

--- a/jstree/jstree.d.ts
+++ b/jstree/jstree.d.ts
@@ -830,7 +830,7 @@ interface JSTree extends JQuery {
     * @param  {Boolean} ids if set to true build the path using ID, otherwise node text is used
     * @return {mixed}
     */
-    get_path: (obj: any, glue: string, ids: boolean) => any;
+    get_path: (obj: any, glue?: string, ids?: boolean) => any;
 
     /**
     * get the next visible node that is below the `obj` node. If `strict` is set to `true` only sibling nodes are returned.


### PR DESCRIPTION
case 1. Add a new type definition.
- [ x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

fix for #10271 jstree - get_path params not marked to be optional
