### PR TITLE
Add missing method definitions for StackedAreaChart

### DIFF
--- a/nvd3/nvd3.d.ts
+++ b/nvd3/nvd3.d.ts
@@ -1204,6 +1204,10 @@ id(value: number|string): this;
         style(offset: 'expand'): this;
         style(offset: 'stack_percent'): this;
         style(offset: string): this;
+        width(): number;
+        width(value: number): this;
+        height(): number;
+        height(value: number): this;
     }
 
     interface Sunburst extends Nvd3Element {
@@ -3270,6 +3274,15 @@ id(value: number|string): this;
         useInteractiveGuideline(): boolean;
         /*Sets the chart to use a guideline and floating tooltip instead of requiring the user to hover over specific hotspots. Turning this on will set the 'interactive' and 'useVoronoi' options to false to avoid conflicting.*/
         useInteractiveGuideline(value: boolean): this;
+
+        focusEnable(): boolean;
+        focusEnable(value: boolean): this;
+        focusHeight(): number;
+        focusHeight(value: number): this;
+        showControls(): boolean;
+        showControls(value: boolean): this;
+        brushExtent(): [number, number] | [[number, number], [number, number]];
+        brushExtent(value: [number, number] | [[number, number], [number, number]]) : this;
     }
 
     interface SunburstChart extends Sunburst, Chart {

--- a/nvd3/nvd3.d.ts
+++ b/nvd3/nvd3.d.ts
@@ -3234,7 +3234,9 @@ id(value: number|string): this;
         legend: Legend;
         controls: Legend;
         xAxis: Nvd3Axis;
+        x2Axis: Nvd3Axis;
         yAxis: Nvd3Axis;
+        y2Axis: Nvd3Axis;
         tooltip: Tooltip;
 
         controlLabels(): any;


### PR DESCRIPTION
add missing method definitions in StackedAreaChart:
width, height, focusEnable, focusHeight, showControls, brushExtent
