### PR TITLE
Fixed an issue with linq/linq.3.0.4-Beta5.d.ts/groupBy compareSelector, it should be based on TKey not T

### DIFF
--- a/linq/linq.3.0.4-Beta5.d.ts
+++ b/linq/linq.3.0.4-Beta5.d.ts
@@ -157,7 +157,7 @@ declare module linqjs {
         groupBy<TKey>(keySelector: (element: T) => TKey): IEnumerable<IGrouping<TKey, any>>;
         groupBy<TKey, TElement>(keySelector: (element: T) => TKey, elementSelector: (element: T) => TElement): IEnumerable<IGrouping<TKey, TElement>>;
         groupBy<TKey, TElement, TResult>(keySelector: (element: T) => TKey, elementSelector: (element: T) => TElement, resultSelector: (key: TKey, element: IEnumerable<TElement>) => TResult): IEnumerable<TResult>;
-        groupBy<TKey, TElement, TResult, TCompare>(keySelector: (element: T) => TKey, elementSelector: (element: T) => TElement, resultSelector: (key: TKey, element: IEnumerable<TElement>) => TResult, compareSelector: (element: T) => TCompare): IEnumerable<TResult>;
+        groupBy<TKey, TElement, TResult, TCompare>(keySelector: (element: T) => TKey, elementSelector: (element: T) => TElement, resultSelector: (key: TKey, element: IEnumerable<TElement>) => TResult, compareSelector: (element: TKey) => TCompare): IEnumerable<TResult>;
         // :IEnumerable<IGrouping<TKey, T>>
         partitionBy<TKey>(keySelector: (element: T) => TKey): IEnumerable<IGrouping<TKey, any>>;
         // :IEnumerable<IGrouping<TKey, TElement>>


### PR DESCRIPTION
Found a bug in the linq/linq.3.0.4-Beta5.d.ts/groupBy method signature.  Should be using TKey not T as type on groupBy's compareSelector.
