### PR TITLE
Added Redis retry_strategy

### DIFF
--- a/redis/redis-tests.ts
+++ b/redis/redis-tests.ts
@@ -27,6 +27,28 @@ redis.print(err, value);
 
 client = redis.createClient(num, str, options);
 
+// Test the `retry_strategy` property
+// ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
+interface RedisRetryStrategyOptions {
+  error: Error;
+  total_retry_time: number;
+  times_connected: number;
+  attempt: number;
+}
+function retryStrategyNumber(options: RedisRetryStrategyOptions): number {
+  return 5000;
+}
+function retryStrategyError(options: RedisRetryStrategyOptions): Error {
+  return new Error('Foo');
+}
+redis.createClient({
+  retry_strategy: retryStrategyNumber
+});
+redis.createClient({
+  retry_strategy: retryStrategyError
+});
+// ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
+
 bool = client.connected;
 num = client.retry_delay;
 num = client.retry_backoff;

--- a/redis/redis-tests.ts
+++ b/redis/redis-tests.ts
@@ -30,6 +30,12 @@ client = redis.createClient(num, str, options);
 // Test the `retry_strategy` property
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 function retryStrategyNumber(options: redis.RetryStrategyOptions): number {
+  // Ensure that the properties of RetryStrategyOptions are resilient to breaking change.
+  // If the properties of the interface changes, the variables below will also need to be adapted.
+  var error:            Error  = options.error;
+  var total_retry_time: number = options.total_retry_time;
+  var times_connected:  number = options.times_connected;
+  var attempt:          number = options.attempt;
   return 5000;
 }
 function retryStrategyError(options: redis.RetryStrategyOptions): Error {

--- a/redis/redis-tests.ts
+++ b/redis/redis-tests.ts
@@ -29,22 +29,16 @@ client = redis.createClient(num, str, options);
 
 // Test the `retry_strategy` property
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
-interface RedisRetryStrategyOptions {
-  error: Error;
-  total_retry_time: number;
-  times_connected: number;
-  attempt: number;
-}
-function retryStrategyNumber(options: RedisRetryStrategyOptions): number {
+function retryStrategyNumber(options: redis.RetryStrategyOptions): number {
   return 5000;
 }
-function retryStrategyError(options: RedisRetryStrategyOptions): Error {
+function retryStrategyError(options: redis.RetryStrategyOptions): Error {
   return new Error('Foo');
 }
-redis.createClient({
+client = redis.createClient({
   retry_strategy: retryStrategyNumber
 });
-redis.createClient({
+client = redis.createClient({
   retry_strategy: retryStrategyError
 });
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----

--- a/redis/redis.d.ts
+++ b/redis/redis.d.ts
@@ -34,6 +34,10 @@ declare module "redis" {
         versions: number[];
     }
 
+    interface RetryStrategy {
+      (options: {error: Error, total_retry_time: number, times_connected: number, attempt: number}): number;
+    }
+
     export interface ClientOpts {
         parser?: string;
         return_buffers?: boolean;
@@ -50,6 +54,7 @@ declare module "redis" {
         family?: string;
         command_queue_high_water?: number;
         command_queue_low_water?: number;
+        retry_strategy?: RetryStrategy;
     }
 
     export interface RedisClient extends NodeJS.EventEmitter {

--- a/redis/redis.d.ts
+++ b/redis/redis.d.ts
@@ -34,15 +34,15 @@ declare module "redis" {
         versions: number[];
     }
 
-    interface RedisRetryStrategyOptions {
-      error: Error;
-      total_retry_time: number;
-      times_connected: number;
-      attempt: number;
+    export interface RetryStrategyOptions {
+        error: Error;
+        total_retry_time: number;
+        times_connected: number;
+        attempt: number;
     }
 
-    interface RetryStrategy {
-      (options: RedisRetryStrategyOptions): number | Error;
+    export interface RetryStrategy {
+        (options: RetryStrategyOptions): number | Error;
     }
 
     export interface ClientOpts {

--- a/redis/redis.d.ts
+++ b/redis/redis.d.ts
@@ -34,8 +34,15 @@ declare module "redis" {
         versions: number[];
     }
 
+    interface RedisRetryStrategyOptions {
+      error: Error;
+      total_retry_time: number;
+      times_connected: number;
+      attempt: number;
+    }
+
     interface RetryStrategy {
-      (options: {error: Error, total_retry_time: number, times_connected: number, attempt: number}): number;
+      (options: RedisRetryStrategyOptions): number | Error;
     }
 
     export interface ClientOpts {


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

**case 2. Improvement to existing type definition.**
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Most of the ClientOpts that have to do with reconnecting have been
deprecated in favor of the `retry_strategy` property. The
DefinitelyTyped repo is outdated and is missing the retry_strategy
property. See the docs at https://github.com/NodeRedis/node_redis.

The following options of ClientOpts are deprecated in favor of
retry_strategy:
- retry_max_delay
- connect_timeout
- max_attempts
