### PR TITLE
[ReactDnd] Module reorganization and typing updates

### DIFF
--- a/react-dnd-html5-backend/react-dnd-html5-backend-tests.ts
+++ b/react-dnd-html5-backend/react-dnd-html5-backend-tests.ts
@@ -14,8 +14,6 @@ import DropTarget = ReactDnd.DropTarget;
 import DragLayer = ReactDnd.DragLayer;
 import DragDropContext = ReactDnd.DragDropContext;
 import HTML5Backend, { getEmptyImage } from 'react-dnd-html5-backend';
-import TestBackend = require('react-dnd/modules/backends/Test');
-
 // Game Component
 // ----------------------------------------------------------------------
 
@@ -285,17 +283,11 @@ namespace Board {
     }
 
     export var createWithHTMLBackend = React.createFactory(DragDropContext(HTML5Backend)(Board));
-    export var createWithTestBackend = React.createFactory(DragDropContext(TestBackend)(Board));
 }
 
 // Render the Board Component
 // ----------------------------------------------------------------------
 
 Board.createWithHTMLBackend({
-    knightPosition: [0, 0]
-});
-
-
-Board.createWithTestBackend({
     knightPosition: [0, 0]
 });

--- a/react-dnd/react-dnd-html5-backend.d.ts
+++ b/react-dnd/react-dnd-html5-backend.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for React DnD HTML 5 Backend v2.0.0
+// Project: https://github.com/gaearon/react-dnd
+// Definitions by: Asana <https://asana.com>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+///<reference path='./react-dnd.d.ts' />
+
+declare module "react-dnd-html5-backend" {
+  export enum NativeTypes { FILE, URL, TEXT }
+  export function getEmptyImage(): any; // Image
+  export default class HTML5Backend implements __ReactDnd.Backend { }
+}

--- a/react-dnd/react-dnd-html5-backend.d.ts
+++ b/react-dnd/react-dnd-html5-backend.d.ts
@@ -6,7 +6,11 @@
 ///<reference path='./react-dnd.d.ts' />
 
 declare module "react-dnd-html5-backend" {
-  export enum NativeTypes { FILE, URL, TEXT }
-  export function getEmptyImage(): any; // Image
-  export default class HTML5Backend implements __ReactDnd.Backend { }
+    export namespace NativeTypes {
+        export const FILE: string;
+        export const URL: string;
+        export const TEXT: string;
+    }
+    export function getEmptyImage(): any; // Image
+    export default class HTML5Backend implements __ReactDnd.Backend { }
 }

--- a/react-dnd/react-dnd-test-backend.d.ts
+++ b/react-dnd/react-dnd-test-backend.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for React DnD HTML 5 Backend v2.0.0
+// Project: https://github.com/gaearon/react-dnd
+// Definitions by: Asana <https://asana.com>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+///<reference path='./react-dnd.d.ts' />
+
+declare module "react-dnd-test-backend" {
+  class TestBackend {
+    setup(): void;
+    teardown(): void;
+    connectDragSource(): void;
+    connectDropTarget(): void;
+    simulateBeginDrag(sourceIds: __ReactDnd.Identifier[], options?: {}): void;
+    simulatePublishDragSource(): void;
+    simulateHover(targetIds: __ReactDnd.Identifier[], options?: {}): void;
+    simulateDrop(): void;
+    simulateEndDrag(): void;
+  }
+
+  export { TestBackend as default };
+}

--- a/react-dnd/react-dnd-test-backend.d.ts
+++ b/react-dnd/react-dnd-test-backend.d.ts
@@ -6,17 +6,17 @@
 ///<reference path='./react-dnd.d.ts' />
 
 declare module "react-dnd-test-backend" {
-  class TestBackend {
-    setup(): void;
-    teardown(): void;
-    connectDragSource(): void;
-    connectDropTarget(): void;
-    simulateBeginDrag(sourceIds: __ReactDnd.Identifier[], options?: {}): void;
-    simulatePublishDragSource(): void;
-    simulateHover(targetIds: __ReactDnd.Identifier[], options?: {}): void;
-    simulateDrop(): void;
-    simulateEndDrag(): void;
-  }
+    class TestBackend {
+        setup(): void;
+        teardown(): void;
+        connectDragSource(): void;
+        connectDropTarget(): void;
+        simulateBeginDrag(sourceIds: __ReactDnd.Identifier[], options?: {}): void;
+        simulatePublishDragSource(): void;
+        simulateHover(targetIds: __ReactDnd.Identifier[], options?: {}): void;
+        simulateDrop(): void;
+        simulateEndDrag(): void;
+    }
 
-  export { TestBackend as default };
+    export { TestBackend as default };
 }

--- a/react-dnd/react-dnd-tests.ts
+++ b/react-dnd/react-dnd-tests.ts
@@ -13,8 +13,8 @@ import DragSource = ReactDnd.DragSource;
 import DropTarget = ReactDnd.DropTarget;
 import DragLayer = ReactDnd.DragLayer;
 import DragDropContext = ReactDnd.DragDropContext;
-import HTML5Backend, { getEmptyImage } from 'react-dnd/modules/backends/HTML5';
-import TestBackend = require('react-dnd/modules/backends/Test');
+import HTML5Backend, { getEmptyImage } from "react-dnd-html5-backend";
+import TestBackend from "react-dnd-test-backend";
 
 // Game Component
 // ----------------------------------------------------------------------

--- a/react-dnd/react-dnd-tests.ts
+++ b/react-dnd/react-dnd-tests.ts
@@ -1,4 +1,6 @@
 ///<reference path="react-dnd.d.ts" />
+///<reference path="react-dnd-html5-backend.d.ts" />
+///<reference path="react-dnd-test-backend.d.ts" />
 "use strict";
 
 // Test adapted from the ReactDnD chess game tutorial:

--- a/react-dnd/react-dnd-tests.ts
+++ b/react-dnd/react-dnd-tests.ts
@@ -15,7 +15,7 @@ import DragSource = ReactDnd.DragSource;
 import DropTarget = ReactDnd.DropTarget;
 import DragLayer = ReactDnd.DragLayer;
 import DragDropContext = ReactDnd.DragDropContext;
-import HTML5Backend, { getEmptyImage } from "react-dnd-html5-backend";
+import HTML5Backend, { getEmptyImage, NativeTypes } from "react-dnd-html5-backend";
 import TestBackend from "react-dnd-test-backend";
 
 // Game Component
@@ -201,6 +201,7 @@ namespace BoardSquare {
     }
 
     export var DndBoardSquare = DropTarget(ItemTypes.KNIGHT, boardSquareTarget, boardSquareCollect)(BoardSquare);
+    export var fileDropTarget = DropTarget(NativeTypes.FILE, boardSquareTarget, boardSquareCollect)(BoardSquare);
     export var create = React.createFactory(DndBoardSquare);
 }
 

--- a/react-dnd/react-dnd.d.ts
+++ b/react-dnd/react-dnd.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for React DnD v1.1.4
+// Type definitions for React DnD v2.0.2
 // Project: https://github.com/gaearon/react-dnd
 // Definitions by: Asana <https://asana.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -177,26 +177,4 @@ declare module __ReactDnd {
 
 declare module "react-dnd" {
     export = __ReactDnd;
-}
-
-declare module "react-dnd-html5-backend" {
-    export enum NativeTypes { FILE, URL, TEXT }
-    export function getEmptyImage(): any; // Image
-    export default class HTML5Backend implements __ReactDnd.Backend {}
-}
-
-declare module "react-dnd-test-backend" {
-    class TestBackend {
-        setup(): void;
-        teardown(): void;
-        connectDragSource(): void;
-        connectDropTarget(): void;
-        simulateBeginDrag(sourceIds: __ReactDnd.Identifier[], options?: {}): void;
-        simulatePublishDragSource(): void;
-        simulateHover(targetIds: __ReactDnd.Identifier[], options?: {}): void;
-        simulateDrop(): void;
-        simulateEndDrag(): void;
-    }
-
-    export { TestBackend as default };
 }

--- a/react-dnd/react-dnd.d.ts
+++ b/react-dnd/react-dnd.d.ts
@@ -179,13 +179,13 @@ declare module "react-dnd" {
     export = __ReactDnd;
 }
 
-declare module "react-dnd/modules/backends/HTML5" {
+declare module "react-dnd-html5-backend" {
     export enum NativeTypes { FILE, URL, TEXT }
     export function getEmptyImage(): any; // Image
     export default class HTML5Backend implements __ReactDnd.Backend {}
 }
 
-declare module "react-dnd/modules/backends/Test" {
+declare module "react-dnd-test-backend" {
     class TestBackend {
         setup(): void;
         teardown(): void;
@@ -198,5 +198,5 @@ declare module "react-dnd/modules/backends/Test" {
         simulateEndDrag(): void;
     }
 
-    export = TestBackend;
+    export { TestBackend as default };
 }


### PR DESCRIPTION
- Moves the HTML5 backend and test backend into separate files for better readability
- Changes the typing of NativeTypes from an enum integer type to a string type to match the usage in functions like DragSource() and DropTarget()
