### PR TITLE
Fix error TS2497 on `import * as X from 'statsd-client'`:

### DIFF
--- a/statsd-client/statsd-client-import-asterisk-tests.ts
+++ b/statsd-client/statsd-client-import-asterisk-tests.ts
@@ -1,0 +1,3 @@
+/// <reference path="statsd-client.d.ts" />
+import * as StatsdClient from 'statsd-client';
+const statsd = new StatsdClient({ debug: true });

--- a/statsd-client/statsd-client.d.ts
+++ b/statsd-client/statsd-client.d.ts
@@ -99,5 +99,6 @@ declare module "statsd-client" {
 		getChildClient(name: string): StatsdClient;
 	}
 
+	namespace StatsdClient {}
 	export = StatsdClient;
 }


### PR DESCRIPTION
Per Microsoft/TypeScript#5073, closed as `By Design` by @mhegazy, we need to merge a namespace with the export when using `export =`, otherwise `import *` must fail.

Pinging @peterkooijmans and @horiuchi for review.
