### PR TITLE
request.files property is not correctly mapped.

### DIFF
--- a/multer/multer.d.ts
+++ b/multer/multer.d.ts
@@ -9,7 +9,7 @@ declare namespace Express {
     export interface Request {
         file: Multer.File;
         files: {
-            [fieldname: string]: Multer.File
+            [fieldname: string]: Multer.File[]
         };
     }
 


### PR DESCRIPTION
As is documented on multer project (https://github.com/expressjs/multer):

// req.files is an object (String -> Array) where fieldname is the key, and the value is array of files
  //
  // e.g.
  //  req.files['avatar'][0] -> File
  //  req.files['gallery'] -> Array
  //
  // req.body will contain the text fields, if there were any
