### PR TITLE
Remove string index signature in React's HTMLAttributes

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -2037,9 +2037,6 @@ declare namespace React {
         results?: number;
         security?: string;
         unselectable?: boolean;
-
-        // Allows aria- and data- Attributes
-        [key: string]: any;
     }
 
     interface SVGAttributes<T> extends HTMLAttributes<T> {


### PR DESCRIPTION
With this string index signature, _any_ property can be valid, which is typically undesirable behavior. Users can always add the signature back with an augmentation if they need.

CC @RyanCavanaugh 
