### PR TITLE
react-bootstrap-table: add cols and rows options to Editable

### DIFF
--- a/react-bootstrap-table/react-bootstrap-table-tests.tsx
+++ b/react-bootstrap-table/react-bootstrap-table-tests.tsx
@@ -23,7 +23,7 @@ function priceFormatter(cell: any, row: any) {
 render(
   <BootstrapTable data={products} striped={true} hover={true}>
       <TableHeaderColumn dataField="id" isKey={true} dataAlign="center" dataSort={true}>Product ID</TableHeaderColumn>
-      <TableHeaderColumn dataField="name" dataSort={true}>Product Name</TableHeaderColumn>
+      <TableHeaderColumn dataField="name" dataSort={true} editable={{ type: 'textarea', rows: 10 }}>Product Name</TableHeaderColumn>
       <TableHeaderColumn dataField="price" dataFormat={priceFormatter}>Product Price</TableHeaderColumn>
     </BootstrapTable>,
   document.getElementById("app")

--- a/react-bootstrap-table/react-bootstrap-table.d.ts
+++ b/react-bootstrap-table/react-bootstrap-table.d.ts
@@ -556,6 +556,12 @@ declare module "react-bootstrap-table" {
 
 		 */
 		options?: any;
+
+		/**
+		 Configuration for the textarea editable type
+		 */
+		cols?: number;
+		rows?: number;
 	}
 	
 	export type FilterType = 'TextFilter' | 'RegexFilter' | 'SelectFilter' | 'NumberFilter' | 'DateFilter' | 'CustomFilter';

--- a/react-bootstrap-table/react-bootstrap-table.d.ts
+++ b/react-bootstrap-table/react-bootstrap-table.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-bootstrap-table v2.3.0
 // Project: https://github.com/AllenFang/react-bootstrap-table
-// Definitions by: Frank Laub <https://github.com/flaub>, Michael Scharf <https://github.com/scharf>
+// Definitions by: Frank Laub <https://github.com/flaub>, Michael Scharf <https://github.com/scharf>, Ian Ker-Seymer <https://github.com/ianks>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../react/react.d.ts" />


### PR DESCRIPTION
These changes relate to the options shown here: https://github.com/AllenFang/react-bootstrap-table/blob/2152b49cb99a34124b07b0aaa43d753383725eb6/src/Editor.js#L55

@flaub @scharf 
