### PR TITLE
Use features from typescript 2.0 in ESTree

### DIFF
--- a/estree/estree-tests.ts
+++ b/estree/estree-tests.ts
@@ -1,34 +1,112 @@
+import * as ESTree from './index';
 
+declare var node: ESTree.Node;
+declare var program: ESTree.Program;
+declare var functionAst: ESTree.Function;
+declare var statement: ESTree.Statement;
+declare var emptyStatement: ESTree.EmptyStatement;
+declare var blockStatement: ESTree.BlockStatement;
+declare var expressionStatement: ESTree.ExpressionStatement;
+declare var ifStatement: ESTree.IfStatement;
+declare var labeledStatement: ESTree.LabeledStatement;
+declare var breakStatement: ESTree.BreakStatement;
+declare var continueStatement: ESTree.ContinueStatement;
+declare var withStatement: ESTree.WithStatement;
+declare var switchStatement: ESTree.SwitchStatement;
+declare var returnStatement: ESTree.ReturnStatement;
+declare var throwStatement: ESTree.ThrowStatement;
+declare var tryStatement: ESTree.TryStatement;
+declare var whileStatement: ESTree.WhileStatement;
+declare var doWhileStatement: ESTree.DoWhileStatement;
+declare var forStatement: ESTree.ForStatement;
+declare var forInStatement: ESTree.ForInStatement;
+declare var debuggerStatement: ESTree.DebuggerStatement;
+declare var declaration: ESTree.Declaration;
+declare var functionDeclaration: ESTree.FunctionDeclaration;
+declare var variableDeclaration: ESTree.VariableDeclaration;
+declare var variableDeclarator: ESTree.VariableDeclarator;
+declare var expression: ESTree.Expression;
+declare var baseExpression: ESTree.BaseExpression;
+declare var thisExpression: ESTree.ThisExpression;
+declare var arrayExpression: ESTree.ArrayExpression;
+declare var objectExpression: ESTree.ObjectExpression;
+declare var property: ESTree.Property;
+declare var functionExpression: ESTree.FunctionExpression;
+declare var sequenceExpression: ESTree.SequenceExpression;
+declare var unaryExpression: ESTree.UnaryExpression;
+declare var binaryExpression: ESTree.BinaryExpression;
+declare var assignmentExpression: ESTree.AssignmentExpression;
+declare var updateExpression: ESTree.UpdateExpression;
+declare var logicalExpression: ESTree.LogicalExpression;
+declare var conditionalExpression: ESTree.ConditionalExpression;
+declare var callExpression: ESTree.CallExpression;
+declare var simpleCallExpression: ESTree.SimpleCallExpression;
+declare var newExpression: ESTree.NewExpression;
+declare var memberExpression: ESTree.MemberExpression;
+declare var pattern: ESTree.Pattern;
+declare var switchCase: ESTree.SwitchCase;
+declare var catchClause: ESTree.CatchClause;
+declare var identifier: ESTree.Identifier;
+declare var literal: ESTree.Literal;
+declare var simpleLiteral: ESTree.SimpleLiteral;
+declare var regExpLiteral: ESTree.RegExpLiteral;
+declare var unaryOperator: ESTree.UnaryOperator;
+declare var binaryOperator: ESTree.BinaryOperator;
+declare var logicalOperator: ESTree.LogicalOperator;
+declare var assignmentOperator: ESTree.AssignmentOperator;
+declare var updateOperator: ESTree.UpdateOperator;
+declare var forOfStatement: ESTree.ForOfStatement;
+declare var superAst: ESTree.Super;
+declare var spreadElement: ESTree.SpreadElement;
+declare var arrowFunctionExpression: ESTree.ArrowFunctionExpression;
+declare var yieldExpression: ESTree.YieldExpression;
+declare var templateLiteral: ESTree.TemplateLiteral;
+declare var taggedTemplateExpression: ESTree.TaggedTemplateExpression;
+declare var templateElement: ESTree.TemplateElement;
+declare var assignmentProperty: ESTree.AssignmentProperty;
+declare var objectPattern: ESTree.ObjectPattern;
+declare var arrayPattern: ESTree.ArrayPattern;
+declare var restElement: ESTree.RestElement;
+declare var assignmentPattern: ESTree.AssignmentPattern;
+declare var classAst: ESTree.Class;
+declare var classBody: ESTree.ClassBody;
+declare var methodDefinition: ESTree.MethodDefinition;
+declare var classDeclaration: ESTree.ClassDeclaration;
+declare var classExpression: ESTree.ClassExpression;
+declare var metaProperty: ESTree.MetaProperty;
+declare var moduleDeclaration: ESTree.ModuleDeclaration;
+declare var moduleSpecifier: ESTree.ModuleSpecifier;
+declare var importDeclaration: ESTree.ImportDeclaration;
+declare var importSpecifier: ESTree.ImportSpecifier;
+declare var importDefaultSpecifier: ESTree.ImportDefaultSpecifier;
+declare var importNamespaceSpecifier: ESTree.ImportNamespaceSpecifier;
+declare var exportNamedDeclaration: ESTree.ExportNamedDeclaration;
+declare var exportSpecifier: ESTree.ExportSpecifier;
+declare var exportDefaultDeclaration: ESTree.ExportDefaultDeclaration;
+declare var exportAllDeclaration: ESTree.ExportAllDeclaration;
 
-var program: ESTree.Program;
-var statement: ESTree.Statement;
-var expression: ESTree.Expression;
-var property: ESTree.Property;
-var identifier: ESTree.Identifier;
-var literal: ESTree.Literal;
-var switchCase: ESTree.SwitchCase;
-var catchClause: ESTree.CatchClause;
-var pattern: ESTree.Pattern;
-var assignmentPattern: ESTree.AssignmentPattern;
-var variableDeclaratorOrExpression: ESTree.VariableDeclaration | ESTree.Expression;
-var literalOrIdentifier: ESTree.Literal | ESTree.Identifier;
-var blockStatementOrExpression: ESTree.BlockStatement | ESTree.Expression;
-var identifierOrExpression: ESTree.Expression;
-var any: any;
-var string: string;
-var boolean: boolean;
-var number: number;
+declare var toplevelStatement: ESTree.Statement | ESTree.ModuleDeclaration;
+declare var expressionOrPattern: ESTree.Expression | ESTree.Pattern;
+declare var variableDeclaratorOrExpression: ESTree.VariableDeclaration | ESTree.Expression;
+declare var literalOrIdentifier: ESTree.Literal | ESTree.Identifier;
+declare var blockStatementOrExpression: ESTree.BlockStatement | ESTree.Expression;
+declare var identifierOrExpression: ESTree.Identifier | ESTree.Expression;
+declare var any: any;
+declare var string: string;
+declare var boolean: boolean;
+declare var number: number;
+declare var never: never;
 
 // Program
 string = program.type;
-statement = program.body[0];
+toplevelStatement = program.body[0];
 
 // Location
-number = program.loc.start.line;
-number = program.loc.start.column;
-number = program.loc.end.line;
-number = program.loc.end.column;
-number = program.range[0];
+number = program.loc!.start.line;
+number = program.loc!.start.column;
+number = program.loc!.end.line;
+number = program.loc!.end.column;
+number = program!.range![0];
 
 // Statement
 // BlockStatement
@@ -44,7 +122,7 @@ expression = expressionStatement.expression;
 var ifStatement: ESTree.IfStatement;
 expression = ifStatement.test;
 statement = ifStatement.consequent;
-statement = ifStatement.alternate;
+var statementOrNull: ESTree.Statement | undefined = ifStatement.alternate;
 
 // LabeledStatement
 var labeledStatement: ESTree.LabeledStatement;
@@ -62,18 +140,18 @@ switchCase = switchStatement.cases[0];
 
 // ReturnStatement
 var returnStatement: ESTree.ReturnStatement;
-expression = returnStatement.argument;
+var expressionMaybe: ESTree.Expression | undefined = returnStatement.argument;
 
 // TryStatement
 var tryStatement: ESTree.TryStatement;
 blockStatement = tryStatement.block;
-catchClause = tryStatement.handler;
-blockStatement = tryStatement.finalizer;
+var catchClauseMaybe: ESTree.CatchClause | undefined = tryStatement.handler;
+var blockStatementMaybe: ESTree.BlockStatement | undefined = tryStatement.finalizer;
 
 // ForStatement
 var forStatement: ESTree.ForStatement;
-variableDeclaratorOrExpression = forStatement.init;
-expression = forStatement.update;
+var variableDeclaratorOrExpressionMaybe: typeof variableDeclaratorOrExpression | undefined = forStatement.init;
+var expressionMaybe: ESTree.Expression | undefined = forStatement.update;
 
 // ForInStatement
 var forInStatement: ESTree.ForInStatement;
@@ -84,24 +162,25 @@ expression = forInStatement.right;
 // ArrayExpression
 var arrayExpression: ESTree.ArrayExpression;
 string = arrayExpression.type;
-expression = arrayExpression.elements[0];
+var expressionOrSpread: ESTree.Expression | ESTree.SpreadElement
+    = arrayExpression.elements[0];
 
 // ObjectExpression
 var objectExpression: ESTree.ObjectExpression;
 property = objectExpression.properties[0];
 string = property.type;
 expression = property.key;
-expression = property.value;
+expressionOrPattern = property.value;
 string = property.kind;
 
 // FunctionExpression
 var functionExpression: ESTree.FunctionExpression;
-identifier = functionExpression.id;
-assignmentPattern = <ESTree.AssignmentPattern>functionExpression.params[0];
+var identifierMaybe: ESTree.Identifier | undefined = functionExpression.id;
+pattern = functionExpression.params[0];
 pattern = assignmentPattern.left;
 expression = assignmentPattern.right;
-blockStatementOrExpression = functionExpression.body;
-boolean = functionExpression.generator;
+blockStatement = functionExpression.body;
+var booleanMaybe: boolean | undefined = functionExpression.generator;
 
 // SequenceExpression
 var sequenceExpression: ESTree.SequenceExpression;
@@ -125,17 +204,17 @@ expression = conditionalExpression.consequent;
 
 // NewExpression
 var newExpression: ESTree.NewExpression;
-expression = newExpression.callee;
-expression = newExpression.arguments[0];
+var expressionOrSuper: ESTree.Expression | ESTree.Super = newExpression.callee;
+expressionOrSpread = newExpression.arguments[0];
 
 // CallExpression
 var callExpression: ESTree.CallExpression;
-expression = callExpression.callee;
-expression = callExpression.arguments[0];
+expressionOrSuper = callExpression.callee;
+expressionOrSpread = callExpression.arguments[0];
 
 // MemberExpression
 var memberExpression: ESTree.MemberExpression;
-expression = memberExpression.object;
+expressionOrSuper = memberExpression.object;
 identifierOrExpression = memberExpression.property;
 boolean = memberExpression.computed;
 
@@ -143,8 +222,8 @@ boolean = memberExpression.computed;
 var functionDeclaration: ESTree.FunctionDeclaration;
 identifier = functionDeclaration.id;
 var params:ESTree.Pattern[] = functionDeclaration.params;
-var body:ESTree.BlockStatement | ESTree.Expression = functionDeclaration.body;
-boolean = functionDeclaration.generator;
+blockStatement = functionDeclaration.body;
+booleanMaybe = functionDeclaration.generator;
 
 var variableDeclaration: ESTree.VariableDeclaration;
 var declarations:ESTree.VariableDeclarator[] = variableDeclaration.declarations;
@@ -152,12 +231,12 @@ string = variableDeclaration.kind; // "var" | "let" | "const"
 
 var variableDeclarator: ESTree.VariableDeclarator;
 pattern = variableDeclarator.id; // Pattern
-expression = variableDeclarator.init;
+expressionMaybe = variableDeclarator.init;
 
 // Clauses
 // SwitchCase
 string = switchCase.type;
-expression = switchCase.test;
+expressionMaybe = switchCase.test;
 statement = switchCase.consequent[0];
 
 // CatchClause
@@ -173,3 +252,462 @@ string = identifier.name;
 // Literal
 string = literal.type;
 any = literal.value;
+
+
+// Test narrowing
+
+switch (node.type) {
+  case 'Identifier':
+    identifier = node;
+    break;
+  case 'Literal':
+    literal = node;
+    break;
+  case 'Program':
+    program = node;
+    break;
+  case 'FunctionDeclaration':
+    functionDeclaration = node
+    break;
+  case 'FunctionExpression':
+    functionExpression = node
+    break;
+  case 'SwitchCase':
+    switchCase = node
+    break;
+  case 'CatchClause':
+    catchClause = node
+    break;
+  case 'VariableDeclarator':
+    variableDeclarator = node
+    break;
+  // Narrowing of Statement
+  case 'ExpressionStatement':
+    expressionStatement = node;
+    break;
+  case 'BlockStatement':
+    blockStatement = node;
+    break;
+  case 'EmptyStatement':
+    emptyStatement = node;
+    break;
+  case 'DebuggerStatement':
+    debuggerStatement = node;
+    break;
+  case 'WithStatement':
+    withStatement = node;
+    break;
+  case 'ReturnStatement':
+    returnStatement = node;
+    break;
+  case 'LabeledStatement':
+    labeledStatement = node;
+    break;
+  case 'BreakStatement':
+    breakStatement = node;
+    break;
+  case 'ContinueStatement':
+    continueStatement = node;
+    break;
+  case 'IfStatement':
+    ifStatement = node;
+    break;
+  case 'SwitchStatement':
+    switchStatement = node;
+    break;
+  case 'ThrowStatement':
+    throwStatement = node;
+    break;
+  case 'TryStatement':
+    tryStatement = node;
+    break;
+  case 'WhileStatement':
+    whileStatement = node;
+    break;
+  case 'DoWhileStatement':
+    doWhileStatement = node;
+    break;
+  case 'ForStatement':
+    forStatement = node;
+    break;
+  case 'ForInStatement':
+    forInStatement = node;
+    break;
+  case 'ForOfStatement':
+    forOfStatement = node;
+    break;
+  // end narrowing of Statement
+
+  // narrowing of Declaration
+  case 'FunctionDeclaration':
+    functionDeclaration = node;
+    break;
+  case 'VariableDeclaration':
+    variableDeclaration = node;
+    break;
+  case 'ClassDeclaration':
+    classDeclaration = node;
+    break;
+  // end narrowing of Declaration
+
+  // narrowing of Expression
+  case 'ThisExpression':
+    thisExpression = node;
+    break;
+  case 'ArrayExpression':
+    arrayExpression = node;
+    break;
+  case 'ObjectExpression':
+    objectExpression = node;
+    break;
+  case 'FunctionExpression':
+    functionExpression = node;
+    break;
+  case 'ArrowFunctionExpression':
+    arrowFunctionExpression = node;
+    break;
+  case 'YieldExpression':
+    yieldExpression = node;
+    break;
+  case 'Literal':
+    literal = node;
+    break;
+  case 'UnaryExpression':
+    unaryExpression = node;
+    break;
+  case 'UpdateExpression':
+    updateExpression = node;
+    break;
+  case 'BinaryExpression':
+    binaryExpression = node;
+    break;
+  case 'AssignmentExpression':
+    assignmentExpression = node;
+    break;
+  case 'LogicalExpression':
+    logicalExpression = node;
+    break;
+  case 'MemberExpression':
+    memberExpression = node;
+    break;
+  case 'ConditionalExpression':
+    conditionalExpression = node;
+    break;
+  case 'CallExpression':
+    callExpression = node;
+    break;
+  case 'NewExpression':
+    newExpression = node;
+    break;
+  case 'SequenceExpression':
+    sequenceExpression = node;
+    break;
+  case 'TemplateLiteral':
+    templateLiteral = node;
+    break;
+  case 'TaggedTemplateExpression':
+    taggedTemplateExpression = node;
+    break;
+  case 'ClassExpression':
+    classExpression = node;
+    break;
+  case 'MetaProperty':
+    metaProperty = node;
+    break;
+  case 'Identifier':
+    identifier = node;
+    break;
+  // end narrowing of Expression
+
+  case 'Property':
+    property = node
+    break;
+  case 'Super':
+    superAst = node
+    break;
+  case 'TemplateElement':
+    templateElement = node
+    break;
+  case 'SpreadElement':
+    spreadElement = node
+    break;
+
+  // narrowing of Pattern
+  case 'Identifier':
+    identifier = node;
+    break;
+  case 'ObjectPattern':
+    objectPattern = node;
+    break;
+  case 'ArrayPattern':
+    arrayPattern = node;
+    break;
+  case 'RestElement':
+    restElement = node;
+    break;
+  case 'AssignmentPattern':
+    assignmentPattern = node;
+    break;
+  case 'MemberExpression':
+    memberExpression = node;
+    break;
+  // end narrowing of Pattern
+
+  case 'ClassBody':
+    classBody = node
+    break;
+  case 'ClassDeclaration':
+    classDeclaration = node
+    break;
+  case 'ClassExpression':
+    classExpression = node
+    break;
+  case 'MethodDefinition':
+    methodDefinition = node
+    break;
+
+  // narrowing of ModuleDeclaration
+  case 'ImportDeclaration':
+    importDeclaration = node;
+    break;
+  case 'ExportNamedDeclaration':
+    exportNamedDeclaration = node;
+    break;
+  case 'ExportDefaultDeclaration':
+    exportDefaultDeclaration = node;
+    break;
+  case 'ExportAllDeclaration':
+    exportAllDeclaration = node;
+    break;
+  // end narrowing of ModuleDeclaration
+
+  // narrowing of ModuleSpecifier
+  case 'ImportSpecifier':
+    importSpecifier = node;
+    break;
+  case 'ImportDefaultSpecifier':
+    importDefaultSpecifier = node;
+    break;
+  case 'ImportNamespaceSpecifier':
+    importNamespaceSpecifier = node;
+    break;
+  case 'ExportSpecifier':
+    exportSpecifier = node;
+    break;
+  // end narrowing of ModuleSpecifier
+
+  default:
+    never = node;
+}
+
+switch (statement.type) {
+  case 'ExpressionStatement':
+    expressionStatement = statement;
+    break;
+  case 'BlockStatement':
+    blockStatement = statement;
+    break;
+  case 'EmptyStatement':
+    emptyStatement = statement;
+    break;
+  case 'DebuggerStatement':
+    debuggerStatement = statement;
+    break;
+  case 'WithStatement':
+    withStatement = statement;
+    break;
+  case 'ReturnStatement':
+    returnStatement = statement;
+    break;
+  case 'LabeledStatement':
+    labeledStatement = statement;
+    break;
+  case 'BreakStatement':
+    breakStatement = statement;
+    break;
+  case 'ContinueStatement':
+    continueStatement = statement;
+    break;
+  case 'IfStatement':
+    ifStatement = statement;
+    break;
+  case 'SwitchStatement':
+    switchStatement = statement;
+    break;
+  case 'ThrowStatement':
+    throwStatement = statement;
+    break;
+  case 'TryStatement':
+    tryStatement = statement;
+    break;
+  case 'WhileStatement':
+    whileStatement = statement;
+    break;
+  case 'DoWhileStatement':
+    doWhileStatement = statement;
+    break;
+  case 'ForStatement':
+    forStatement = statement;
+    break;
+  case 'ForInStatement':
+    forInStatement = statement;
+    break;
+  case 'ForOfStatement':
+    forOfStatement = statement;
+    break;
+  // narrowing of Declaration
+  case 'FunctionDeclaration':
+    functionDeclaration = statement;
+    break;
+  case 'VariableDeclaration':
+    variableDeclaration = statement;
+    break;
+  case 'ClassDeclaration':
+    classDeclaration = statement;
+    break;
+  // end narrowing of Declaration
+  default:
+    never = statement;
+}
+
+switch (expression.type) {
+  case 'ThisExpression':
+    thisExpression = expression;
+    break;
+  case 'ArrayExpression':
+    arrayExpression = expression;
+    break;
+  case 'ObjectExpression':
+    objectExpression = expression;
+    break;
+  case 'FunctionExpression':
+    functionExpression = expression;
+    break;
+  case 'ArrowFunctionExpression':
+    arrowFunctionExpression = expression;
+    break;
+  case 'YieldExpression':
+    yieldExpression = expression;
+    break;
+  case 'Literal':
+    literal = expression;
+    break;
+  case 'UnaryExpression':
+    unaryExpression = expression;
+    break;
+  case 'UpdateExpression':
+    updateExpression = expression;
+    break;
+  case 'BinaryExpression':
+    binaryExpression = expression;
+    break;
+  case 'AssignmentExpression':
+    assignmentExpression = expression;
+    break;
+  case 'LogicalExpression':
+    logicalExpression = expression;
+    break;
+  case 'MemberExpression':
+    memberExpression = expression;
+    break;
+  case 'ConditionalExpression':
+    conditionalExpression = expression;
+    break;
+  case 'CallExpression':
+    callExpression = expression;
+    break;
+  case 'NewExpression':
+    newExpression = expression;
+    break;
+  case 'SequenceExpression':
+    sequenceExpression = expression;
+    break;
+  case 'TemplateLiteral':
+    templateLiteral = expression;
+    break;
+  case 'TaggedTemplateExpression':
+    taggedTemplateExpression = expression;
+    break;
+  case 'ClassExpression':
+    classExpression = expression;
+    break;
+  case 'MetaProperty':
+    metaProperty = expression;
+    break;
+  case 'Identifier':
+    identifier = expression;
+    break;
+  default:
+    never = expression;
+}
+
+switch (declaration.type) {
+  case 'FunctionDeclaration':
+    functionDeclaration = declaration;
+    break;
+  case 'VariableDeclaration':
+    variableDeclaration = declaration;
+    break;
+  case 'ClassDeclaration':
+    classDeclaration = declaration;
+    break;
+  default:
+    never = declaration;
+}
+
+switch (pattern.type) {
+  case 'Identifier':
+    identifier = pattern;
+    break;
+  case 'ObjectPattern':
+    objectPattern = pattern;
+    break;
+  case 'ArrayPattern':
+    arrayPattern = pattern;
+    break;
+  case 'RestElement':
+    restElement = pattern;
+    break;
+  case 'AssignmentPattern':
+    assignmentPattern = pattern;
+    break;
+  case 'MemberExpression':
+    memberExpression = pattern;
+    break;
+  default:
+    never = pattern;
+}
+
+switch (moduleDeclaration.type) {
+  case 'ImportDeclaration':
+    importDeclaration = moduleDeclaration;
+    break;
+  case 'ExportNamedDeclaration':
+    exportNamedDeclaration = moduleDeclaration;
+    break;
+  case 'ExportDefaultDeclaration':
+    exportDefaultDeclaration = moduleDeclaration;
+    break;
+  case 'ExportAllDeclaration':
+    exportAllDeclaration = moduleDeclaration;
+    break;
+  default:
+    never = moduleDeclaration;
+}
+
+switch (moduleSpecifier.type) {
+  case 'ImportSpecifier':
+    importSpecifier = moduleSpecifier;
+    break;
+  case 'ImportDefaultSpecifier':
+    importDefaultSpecifier = moduleSpecifier;
+    break;
+  case 'ImportNamespaceSpecifier':
+    importNamespaceSpecifier = moduleSpecifier;
+    break;
+  case 'ExportSpecifier':
+    exportSpecifier = moduleSpecifier;
+    break;
+  default:
+    never = moduleSpecifier;
+}

--- a/estree/estree-tests.ts
+++ b/estree/estree-tests.ts
@@ -221,12 +221,12 @@ boolean = memberExpression.computed;
 // Declarations
 var functionDeclaration: ESTree.FunctionDeclaration;
 identifier = functionDeclaration.id;
-var params:ESTree.Pattern[] = functionDeclaration.params;
+var params: Array<ESTree.Pattern> = functionDeclaration.params;
 blockStatement = functionDeclaration.body;
 booleanMaybe = functionDeclaration.generator;
 
 var variableDeclaration: ESTree.VariableDeclaration;
-var declarations:ESTree.VariableDeclarator[] = variableDeclaration.declarations;
+var declarations: Array<ESTree.VariableDeclarator> = variableDeclaration.declarations;
 string = variableDeclaration.kind; // "var" | "let" | "const"
 
 var variableDeclarator: ESTree.VariableDeclarator;

--- a/estree/index.d.ts
+++ b/estree/index.d.ts
@@ -488,8 +488,7 @@ interface BaseModuleSpecifier extends BaseNode {
 
 export interface ImportDeclaration extends BaseModuleDeclaration {
   type: "ImportDeclaration";
-  specifiers: Array<
-      ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>;
+  specifiers: Array<ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>;
   source: Literal;
 }
 

--- a/estree/index.d.ts
+++ b/estree/index.d.ts
@@ -26,8 +26,8 @@ interface BaseNode {
   // The type property should be a string literal. For example, Identifier
   // has: `type: "Identifier"`
 
-  leadingComments?: Comment[];
-  trailingComments?: Comment[];
+  leadingComments?: Array<Comment>;
+  trailingComments?: Array<Comment>;
   loc?: SourceLocation;
   range?: [number, number];
 }
@@ -222,7 +222,7 @@ export interface ArrayExpression extends BaseExpression {
 
 export interface ObjectExpression extends BaseExpression {
   type: "ObjectExpression";
-  properties: Property[];
+  properties: Array<Property>;
 }
 
 export interface Property extends BaseNode {
@@ -488,7 +488,8 @@ interface BaseModuleSpecifier extends BaseNode {
 
 export interface ImportDeclaration extends BaseModuleDeclaration {
   type: "ImportDeclaration";
-  specifiers: (ImportSpecifier|ImportDefaultSpecifier|ImportNamespaceSpecifier)[];
+  specifiers: Array<
+      ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>;
   source: Literal;
 }
 

--- a/estree/index.d.ts
+++ b/estree/index.d.ts
@@ -3,366 +3,526 @@
 // Definitions by: RReverser <https://github.com/RReverser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace ESTree {
-  interface Node {
-    type: string;
-    loc?: SourceLocation;
-    range?: [number, number];
-  }
-
-  interface SourceLocation {
-    source?: string;
-    start: Position;
-    end: Position;
-  }
-
-  interface Position {
-    line: number;
-    column: number;
-  }
-
-  interface Program extends Node {
-    body: Array<Statement | ModuleDeclaration>;
-    sourceType: string;
-  }
-
-  interface Function extends Node {
-    id?: Identifier;
-    params: Array<Pattern>;
-    body: BlockStatement | Expression;
-    generator: boolean;
-  }
-
-  interface Statement extends Node {}
-
-  interface EmptyStatement extends Statement {}
-
-  interface BlockStatement extends Statement {
-    body: Array<Statement>;
-  }
-
-  interface ExpressionStatement extends Statement {
-    expression: Expression;
-  }
-
-  interface IfStatement extends Statement {
-    test: Expression;
-    consequent: Statement;
-    alternate?: Statement;
-  }
-
-  interface LabeledStatement extends Statement {
-    label: Identifier;
-    body: Statement;
-  }
-
-  interface BreakStatement extends Statement {
-    label?: Identifier;
-  }
-
-  interface ContinueStatement extends Statement {
-    label?: Identifier;
-  }
-
-  interface WithStatement extends Statement {
-    object: Expression;
-    body: Statement;
-  }
-
-  interface SwitchStatement extends Statement {
-    discriminant: Expression;
-    cases: Array<SwitchCase>;
-  }
-
-  interface ReturnStatement extends Statement {
-    argument?: Expression;
-  }
-
-  interface ThrowStatement extends Statement {
-    argument: Expression;
-  }
-
-  interface TryStatement extends Statement {
-    block: BlockStatement;
-    handler?: CatchClause;
-    finalizer?: BlockStatement;
-  }
-
-  interface WhileStatement extends Statement {
-    test: Expression;
-    body: Statement;
-  }
-
-  interface DoWhileStatement extends Statement {
-    body: Statement;
-    test: Expression;
-  }
-
-  interface ForStatement extends Statement {
-    init?: VariableDeclaration | Expression;
-    test?: Expression;
-    update?: Expression;
-    body: Statement;
-  }
-
-  interface ForInStatement extends Statement {
-    left: VariableDeclaration | Expression;
-    right: Expression;
-    body: Statement;
-  }
-
-  interface DebuggerStatement extends Statement {}
-
-  interface Declaration extends Statement {}
-
-  interface FunctionDeclaration extends Function, Declaration {
-    id: Identifier;
-  }
-
-  interface VariableDeclaration extends Declaration {
-    declarations: Array<VariableDeclarator>;
-    kind: string;
-  }
-
-  interface VariableDeclarator extends Node {
-    id: Pattern;
-    init?: Expression;
-  }
-
-  interface Expression extends Node {}
-
-  interface ThisExpression extends Expression {}
-
-  interface ArrayExpression extends Expression {
-    elements: Array<Expression | SpreadElement>;
-  }
-
-  interface ObjectExpression extends Expression {
-    properties: Array<Property>;
-  }
-
-  interface Property extends Node {
-    key: Expression;
-    value: Expression;
-    kind: string;
-    method: boolean;
-    shorthand: boolean;
-    computed: boolean;
-  }
-
-  interface FunctionExpression extends Function, Expression {}
-
-  interface SequenceExpression extends Expression {
-    expressions: Array<Expression>;
-  }
-
-  interface UnaryExpression extends Expression {
-    operator: UnaryOperator;
-    prefix: boolean;
-    argument: Expression;
-  }
-
-  interface BinaryExpression extends Expression {
-    operator: BinaryOperator;
-    left: Expression;
-    right: Expression;
-  }
-
-  interface AssignmentExpression extends Expression {
-    operator: AssignmentOperator;
-    left: Pattern | MemberExpression;
-    right: Expression;
-  }
-
-  interface UpdateExpression extends Expression {
-    operator: UpdateOperator;
-    argument: Expression;
-    prefix: boolean;
-  }
-
-  interface LogicalExpression extends Expression {
-    operator: LogicalOperator;
-    left: Expression;
-    right: Expression;
-  }
-
-  interface ConditionalExpression extends Expression {
-    test: Expression;
-    alternate: Expression;
-    consequent: Expression;
-  }
-
-  interface CallExpression extends Expression {
-    callee: Expression | Super;
-    arguments: Array<Expression | SpreadElement>;
-  }
-
-  interface NewExpression extends CallExpression {}
-
-  interface MemberExpression extends Expression, Pattern {
-    object: Expression | Super;
-    property: Expression;
-    computed: boolean;
-  }
-
-  interface Pattern extends Node {}
-
-  interface SwitchCase extends Node {
-    test?: Expression;
-    consequent: Array<Statement>;
-  }
-
-  interface CatchClause extends Node {
-    param: Pattern;
-    body: BlockStatement;
-  }
-
-  interface Identifier extends Node, Expression, Pattern {
-    name: string;
-  }
-
-  interface Literal extends Node, Expression {
-    value?: string | boolean | number | RegExp;
-  }
-
-  interface RegExpLiteral extends Literal {
-    regex: {
-      pattern: string;
-      flags: string;
-    };
-  }
-
-  type UnaryOperator = string;
-
-  type BinaryOperator = string;
-
-  type LogicalOperator = string;
-
-  type AssignmentOperator = string;
-
-  type UpdateOperator = string;
-
-  interface ForOfStatement extends ForInStatement {}
-
-  interface Super extends Node {}
-
-  interface SpreadElement extends Node {
-    argument: Expression;
-  }
-
-  interface ArrowFunctionExpression extends Function, Expression {
-    expression: boolean;
-  }
-
-  interface YieldExpression extends Expression {
-    argument?: Expression;
-    delegate: boolean;
-  }
-
-  interface TemplateLiteral extends Expression {
-    quasis: Array<TemplateElement>;
-    expressions: Array<Expression>;
-  }
-
-  interface TaggedTemplateExpression extends Expression {
-    tag: Expression;
-    quasi: TemplateLiteral;
-  }
-
-  interface TemplateElement extends Node {
-    tail: boolean;
-    value: {
-      cooked: string;
-      raw: string;
-    };
-  }
-
-  interface AssignmentProperty extends Property {
-    value: Pattern;
-    kind: string;
-    method: boolean;
-  }
-
-  interface ObjectPattern extends Pattern {
-    properties: Array<AssignmentProperty>;
-  }
-
-  interface ArrayPattern extends Pattern {
-    elements: Array<Pattern>;
-  }
-
-  interface RestElement extends Pattern {
-    argument: Pattern;
-  }
-
-  interface AssignmentPattern extends Pattern {
-    left: Pattern;
-    right: Expression;
-  }
-
-  interface Class extends Node {
-    id?: Identifier;
-    superClass: Expression;
-    body: ClassBody;
-  }
-
-  interface ClassBody extends Node {
-    body: Array<MethodDefinition>;
-  }
-
-  interface MethodDefinition extends Node {
-    key: Expression;
-    value: FunctionExpression;
-    kind: string;
-    computed: boolean;
-    static: boolean;
-  }
-
-  interface ClassDeclaration extends Class, Declaration {
-    id: Identifier;
-  }
-
-  interface ClassExpression extends Class, Expression {}
-
-  interface MetaProperty extends Expression {
-    meta: Identifier;
-    property: Identifier;
-  }
-
-  interface ModuleDeclaration extends Node {}
-
-  interface ModuleSpecifier extends Node {
-    local: Identifier;
-  }
-
-  interface ImportDeclaration extends ModuleDeclaration {
-    specifiers: Array<ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>;
-    source: Literal;
-  }
-
-  interface ImportSpecifier extends ModuleSpecifier {
-    imported: Identifier;
-  }
-
-  interface ImportDefaultSpecifier extends ModuleSpecifier {}
-
-  interface ImportNamespaceSpecifier extends ModuleSpecifier {}
-
-  interface ExportNamedDeclaration extends ModuleDeclaration {
-    declaration?: Declaration;
-    specifiers: Array<ExportSpecifier>;
-    source?: Literal;
-  }
-
-  interface ExportSpecifier extends ModuleSpecifier {
-    exported: Identifier;
-  }
-
-  interface ExportDefaultDeclaration extends ModuleDeclaration {
-    declaration: Declaration | Expression;
-  }
-
-  interface ExportAllDeclaration extends ModuleDeclaration {
-    source: Literal;
-  }
+// This definition file follows a somewhat unusual format. ESTree allows
+// runtime type checks based on the `type` parameter. In order to explain this
+// to typescript we want to use discriminated union types:
+// https://github.com/Microsoft/TypeScript/pull/9163
+//
+// For ESTree this is a bit tricky because the high level interfaces like
+// Node or Function are pulling double duty. We want to pass common fields down
+// to the interfaces that extend them (like Identifier or
+// ArrowFunctionExpression), but you can't extend a type union or enforce
+// common fields on them. So we've split the high level interfaces into two
+// types, a base type which passes down inhereted fields, and a type union of
+// all types which extend the base type. Only the type union is exported, and
+// the union is how other types refer to the collection of inheriting types.
+//
+// This makes the definitions file here somewhat more difficult to maintain,
+// but it has the notable advantage of making ESTree much easier to use as
+// an end user.
+
+interface BaseNode {
+  // Every leaf interface that extends BaseNode must specify a type property.
+  // The type property should be a string literal. For example, Identifier
+  // has: `type: "Identifier"`
+
+  leadingComments?: Comment[];
+  trailingComments?: Comment[];
+  loc?: SourceLocation;
+  range?: [number, number];
+}
+export type Node =
+    Identifier | Literal | Program | Function | SwitchCase | CatchClause |
+    VariableDeclarator | Statement | Expression | Property |
+    AssignmentProperty | Super | TemplateElement | SpreadElement | Pattern |
+    ClassBody | Class | MethodDefinition | ModuleDeclaration | ModuleSpecifier;
+
+export interface Comment {
+  value: string;
+}
+
+interface SourceLocation {
+  source?: string;
+  start: Position;
+  end: Position;
+}
+
+export interface Position {
+  /** >= 1 */
+  line: number;
+  /** >= 0 */
+  column: number;
+}
+
+export interface Program extends BaseNode {
+  type: "Program";
+  sourceType: "script" | "module";
+  body: Array<Statement | ModuleDeclaration>;
+}
+
+interface BaseFunction extends BaseNode {
+  params: Array<Pattern>;
+  generator?: boolean;
+  // The body is either BlockStatement or Expression because arrow functions
+  // can have a body that's either. FunctionDeclarations and
+  // FunctionExpressions nave only BlockStatement bodies.
+  body: BlockStatement | Expression;
+}
+export type Function =
+    FunctionDeclaration | FunctionExpression | ArrowFunctionExpression;
+
+
+export type Statement =
+    ExpressionStatement | BlockStatement | EmptyStatement |
+    DebuggerStatement | WithStatement | ReturnStatement | LabeledStatement |
+    BreakStatement | ContinueStatement | IfStatement | SwitchStatement |
+    ThrowStatement | TryStatement | WhileStatement | DoWhileStatement |
+    ForStatement | ForInStatement | ForOfStatement | Declaration;
+interface BaseStatement extends BaseNode { }
+
+export interface EmptyStatement extends BaseStatement {
+  type: "EmptyStatement";
+}
+
+export interface BlockStatement extends BaseStatement {
+  type: "BlockStatement";
+  body: Array<Statement>;
+}
+
+export interface ExpressionStatement extends BaseStatement {
+  type: "ExpressionStatement";
+  expression: Expression;
+}
+
+export interface IfStatement extends BaseStatement {
+  type: "IfStatement";
+  test: Expression;
+  consequent: Statement;
+  alternate?: Statement;
+}
+
+export interface LabeledStatement extends BaseStatement {
+  type: "LabeledStatement";
+  label: Identifier;
+  body: Statement;
+}
+
+export interface BreakStatement extends BaseStatement {
+  type: "BreakStatement";
+  label?: Identifier;
+}
+
+export interface ContinueStatement extends BaseStatement {
+  type: "ContinueStatement";
+  label?: Identifier;
+}
+
+export interface WithStatement extends BaseStatement {
+  type: "WithStatement";
+  object: Expression;
+  body: Statement;
+}
+
+export interface SwitchStatement extends BaseStatement {
+  type: "SwitchStatement";
+  discriminant: Expression;
+  cases: Array<SwitchCase>;
+}
+
+export interface ReturnStatement extends BaseStatement {
+  type: "ReturnStatement";
+  argument?: Expression;
+}
+
+export interface ThrowStatement extends BaseStatement {
+  type: "ThrowStatement";
+  argument: Expression;
+}
+
+export interface TryStatement extends BaseStatement {
+  type: "TryStatement";
+  block: BlockStatement;
+  handler?: CatchClause;
+  finalizer?: BlockStatement;
+}
+
+export interface WhileStatement extends BaseStatement {
+  type: "WhileStatement";
+  test: Expression;
+  body: Statement;
+}
+
+export interface DoWhileStatement extends BaseStatement {
+  type: "DoWhileStatement";
+  body: Statement;
+  test: Expression;
+}
+
+export interface ForStatement extends BaseStatement {
+  type: "ForStatement";
+  init?: VariableDeclaration | Expression;
+  test?: Expression;
+  update?: Expression;
+  body: Statement;
+}
+
+interface BaseForXStatement extends BaseStatement {
+  left: VariableDeclaration |  Expression;
+  right: Expression;
+  body: Statement;
+}
+
+export interface ForInStatement extends BaseForXStatement {
+  type: "ForInStatement";
+}
+
+export interface DebuggerStatement extends BaseStatement {
+  type: "DebuggerStatement";
+}
+
+export type Declaration =
+      FunctionDeclaration | VariableDeclaration | ClassDeclaration;
+interface BaseDeclaration extends BaseStatement { }
+
+export interface FunctionDeclaration extends BaseFunction, BaseDeclaration {
+  type: "FunctionDeclaration";
+  id: Identifier;
+  body: BlockStatement;
+}
+
+export interface VariableDeclaration extends BaseDeclaration {
+  type: "VariableDeclaration";
+  declarations: Array<VariableDeclarator>;
+  kind: "var" | "let" | "const";
+}
+
+export interface VariableDeclarator extends BaseNode {
+  type: "VariableDeclarator";
+  id: Pattern;
+  init?: Expression;
+}
+
+type Expression =
+    ThisExpression | ArrayExpression | ObjectExpression | FunctionExpression |
+    ArrowFunctionExpression | YieldExpression | Literal | UnaryExpression |
+    UpdateExpression | BinaryExpression | AssignmentExpression |
+    LogicalExpression | MemberExpression | ConditionalExpression |
+    CallExpression | NewExpression | SequenceExpression | TemplateLiteral |
+    TaggedTemplateExpression | ClassExpression | MetaProperty | Identifier;
+export interface BaseExpression extends BaseNode { }
+
+export interface ThisExpression extends BaseExpression {
+  type: "ThisExpression";
+}
+
+export interface ArrayExpression extends BaseExpression {
+  type: "ArrayExpression";
+  elements: Array<Expression | SpreadElement>;
+}
+
+export interface ObjectExpression extends BaseExpression {
+  type: "ObjectExpression";
+  properties: Property[];
+}
+
+export interface Property extends BaseNode {
+  type: "Property";
+  key: Expression;
+  value: Expression | Pattern; // Could be an AssignmentProperty
+  kind: "init" | "get" | "set";
+  method: boolean;
+  shorthand: boolean;
+  computed: boolean;
+}
+
+export interface FunctionExpression extends BaseFunction, BaseExpression {
+  id?: Identifier;
+  type: "FunctionExpression";
+  body: BlockStatement;
+}
+
+export interface SequenceExpression extends BaseExpression {
+  type: "SequenceExpression";
+  expressions: Array<Expression>;
+}
+
+export interface UnaryExpression extends BaseExpression {
+  type: "UnaryExpression";
+  operator: UnaryOperator;
+  prefix: boolean;
+  argument: Expression;
+}
+
+export interface BinaryExpression extends BaseExpression {
+  type: "BinaryExpression";
+  operator: BinaryOperator;
+  left: Expression;
+  right: Expression;
+}
+
+export interface AssignmentExpression extends BaseExpression {
+  type: "AssignmentExpression";
+  operator: AssignmentOperator;
+  left: Pattern | MemberExpression;
+  right: Expression;
+}
+
+export interface UpdateExpression extends BaseExpression {
+  type: "UpdateExpression";
+  operator: UpdateOperator;
+  argument: Expression;
+  prefix: boolean;
+}
+
+export interface LogicalExpression extends BaseExpression {
+  type: "LogicalExpression";
+  operator: LogicalOperator;
+  left: Expression;
+  right: Expression;
+}
+
+export interface ConditionalExpression extends BaseExpression {
+  type: "ConditionalExpression";
+  test: Expression;
+  alternate: Expression;
+  consequent: Expression;
+}
+
+interface BaseCallExpression extends BaseExpression {
+  callee: Expression | Super;
+  arguments: Array<Expression | SpreadElement>;
+}
+export type CallExpression = SimpleCallExpression | NewExpression;
+
+export interface SimpleCallExpression extends BaseCallExpression {
+  type: "CallExpression";
+}
+
+export interface NewExpression extends BaseCallExpression {
+  type: "NewExpression";
+}
+
+export interface MemberExpression extends BaseExpression, BasePattern {
+  type: "MemberExpression";
+  object: Expression | Super;
+  property: Expression;
+  computed: boolean;
+}
+
+export type Pattern =
+    Identifier | ObjectPattern | ArrayPattern | RestElement |
+    AssignmentPattern | MemberExpression;
+interface BasePattern extends BaseNode { }
+
+export interface SwitchCase extends BaseNode {
+  type: "SwitchCase";
+  test?: Expression;
+  consequent: Array<Statement>;
+}
+
+export interface CatchClause extends BaseNode {
+  type: "CatchClause";
+  param: Pattern;
+  body: BlockStatement;
+}
+
+export interface Identifier extends BaseNode, BaseExpression, BasePattern {
+  type: "Identifier";
+  name: string;
+}
+
+export type Literal = SimpleLiteral | RegExpLiteral;
+
+export interface SimpleLiteral extends BaseNode, BaseExpression {
+  type: "Literal";
+  value: string | boolean | number | null;
+  raw: string;
+}
+
+export interface RegExpLiteral extends BaseNode, BaseExpression {
+  type: "Literal";
+  value: RegExp;
+  regex: {
+    pattern: string;
+    flags: string;
+  };
+  raw: string;
+}
+
+export type UnaryOperator =
+    "-" | "+" | "!" | "~" | "typeof" | "void" | "delete";
+
+export type BinaryOperator =
+    "==" | "!=" | "===" | "!==" | "<" | "<=" | ">" | ">=" | "<<" |
+    ">>" | ">>>" | "+" | "-" | "*" | "/" | "%" | "**" | "|" | "^" | "&" | "in" |
+    "instanceof";
+
+export type LogicalOperator = "||" | "&&";
+
+export type AssignmentOperator =
+    "=" | "+=" | "-=" | "*=" | "/=" | "%=" | "**=" | "<<=" | ">>=" | ">>>=" |
+    "|=" | "^=" | "&=";
+
+export type UpdateOperator = "++" | "--";
+
+export interface ForOfStatement extends BaseForXStatement {
+  type: "ForOfStatement";
+}
+
+export interface Super extends BaseNode {
+  type: "Super";
+}
+
+export interface SpreadElement extends BaseNode {
+  type: "SpreadElement";
+  argument: Expression;
+}
+
+export interface ArrowFunctionExpression extends BaseExpression, BaseFunction {
+  type: "ArrowFunctionExpression";
+  expression: boolean;
+  body: BlockStatement | Expression;
+}
+
+export interface YieldExpression extends BaseExpression {
+  type: "YieldExpression";
+  argument?: Expression;
+  delegate: boolean;
+}
+
+export interface TemplateLiteral extends BaseExpression {
+  type: "TemplateLiteral";
+  quasis: Array<TemplateElement>;
+  expressions: Array<Expression>;
+}
+
+export interface TaggedTemplateExpression extends BaseExpression {
+  type: "TaggedTemplateExpression";
+  tag: Expression;
+  quasi: TemplateLiteral;
+}
+
+export interface TemplateElement extends BaseNode {
+  type: "TemplateElement";
+  tail: boolean;
+  value: {
+    cooked: string;
+    raw: string;
+  };
+}
+
+export interface AssignmentProperty extends Property {
+  value: Pattern;
+  kind: "init";
+  method: boolean; // false
+}
+
+export interface ObjectPattern extends BasePattern {
+  type: "ObjectPattern";
+  properties: Array<AssignmentProperty>;
+}
+
+export interface ArrayPattern extends BasePattern {
+  type: "ArrayPattern";
+  elements: Array<Pattern>;
+}
+
+export interface RestElement extends BasePattern {
+  type: "RestElement";
+  argument: Pattern;
+}
+
+export interface AssignmentPattern extends BasePattern {
+  type: "AssignmentPattern";
+  left: Pattern;
+  right: Expression;
+}
+
+export type Class = ClassDeclaration | ClassExpression;
+interface BaseClass extends BaseNode {
+  superClass?: Expression;
+  body: ClassBody;
+}
+
+export interface ClassBody extends BaseNode {
+  type: "ClassBody";
+  body: Array<MethodDefinition>;
+}
+
+export interface MethodDefinition extends BaseNode {
+  type: "MethodDefinition";
+  key: Expression;
+  value: FunctionExpression;
+  kind: "constructor" | "method" | "get" | "set";
+  computed: boolean;
+  static: boolean;
+}
+
+export interface ClassDeclaration extends BaseClass, BaseDeclaration {
+  type: "ClassDeclaration";
+  id: Identifier;
+}
+
+export interface ClassExpression extends BaseClass, BaseExpression {
+  type: "ClassExpression";
+  id?: Identifier;
+}
+
+export interface MetaProperty extends BaseExpression {
+  type: "MetaProperty";
+  meta: Identifier;
+  property: Identifier;
+}
+
+export type ModuleDeclaration =
+    ImportDeclaration | ExportNamedDeclaration | ExportDefaultDeclaration |
+    ExportAllDeclaration;
+interface BaseModuleDeclaration extends BaseNode { }
+
+export type ModuleSpecifier =
+    ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier |
+    ExportSpecifier;
+interface BaseModuleSpecifier extends BaseNode {
+  local: Identifier;
+}
+
+export interface ImportDeclaration extends BaseModuleDeclaration {
+  type: "ImportDeclaration";
+  specifiers: (ImportSpecifier|ImportDefaultSpecifier|ImportNamespaceSpecifier)[];
+  source: Literal;
+}
+
+export interface ImportSpecifier extends BaseModuleSpecifier {
+  type: "ImportSpecifier";
+  imported: Identifier;
+}
+
+export interface ImportDefaultSpecifier extends BaseModuleSpecifier {
+  type: "ImportDefaultSpecifier";
+}
+
+export interface ImportNamespaceSpecifier extends BaseModuleSpecifier {
+  type: "ImportNamespaceSpecifier";
+}
+
+export interface ExportNamedDeclaration extends BaseModuleDeclaration {
+  type: "ExportNamedDeclaration";
+  declaration?: Declaration;
+  specifiers: Array<ExportSpecifier>;
+  source?: Literal;
+}
+
+export interface ExportSpecifier extends BaseModuleSpecifier {
+  type: "ExportSpecifier";
+  exported: Identifier;
+}
+
+export interface ExportDefaultDeclaration extends BaseModuleDeclaration {
+  type: "ExportDefaultDeclaration";
+  declaration: Declaration | Expression;
+}
+
+export interface ExportAllDeclaration extends BaseModuleDeclaration {
+  type: "ExportAllDeclaration";
+  source: Literal;
 }

--- a/estree/tsconfig.json
+++ b/estree/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "noImplicitAny": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- [ ] documentation or source code reference which provides context for the suggested changes.  url: https://github.com/estree/estree
  - [ ] it has been reviewed by a DefinitelyTyped member.

Uses [discriminated union types](https://github.com/Microsoft/TypeScript/pull/9163) to allow type narrowing based on string literal comparisons on the `type` field. This makes ESTree much more natural to use, with fewer casts needed.

For example:

``` typescript
let node: ESTree.Node;
let identifier: ESTree.Identifier;
if (node.type === 'Identifier') {
  identifier = node;  // succeeds with this PR!
}
```
