### PR TITLE
Improvement to node type definition

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -25,6 +25,11 @@ import * as stream from "stream";
 // Specifically test buffer module regression.
 import {Buffer as ImportedBuffer, SlowBuffer as ImportedSlowBuffer} from "buffer";
 
+
+global['simpleTest'] = true;
+
+assert(true === (global['simpleTest'] as boolean), "This should compile");
+
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
 assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");

--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -25,11 +25,6 @@ import * as stream from "stream";
 // Specifically test buffer module regression.
 import {Buffer as ImportedBuffer, SlowBuffer as ImportedSlowBuffer} from "buffer";
 
-
-global['simpleTest'] = true;
-
-assert(true === (global['simpleTest'] as boolean), "This should compile");
-
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
 assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -313,6 +313,7 @@ declare namespace NodeJS {
         cwd(): string;
         env: any;
         exit(code?: number): void;
+        exitCode: number;
         getgid(): number;
         setgid(id: number): void;
         setgid(id: string): void;
@@ -438,7 +439,6 @@ declare namespace NodeJS {
         unescape: (str: string) => string;
         gc: () => void;
         v8debug?: any;
-        [propName: string]: any;
     }
 
     export interface Timer {

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -438,6 +438,7 @@ declare namespace NodeJS {
         unescape: (str: string) => string;
         gc: () => void;
         v8debug?: any;
+        [propName: string]: any;
     }
 
     export interface Timer {


### PR DESCRIPTION
case 2. Improvement to existing type definition.

From Node.js API Reference (https://nodejs.org/dist/latest-v6.x/docs/api/globals.html):
These objects are available in all modules. Some of these objects aren't actually in the global scope but in the module scope - this will be noted.
And From Electron Docs (http://electron.atom.io/docs/api/process/#event-loaded):
Emitted when Electron has loaded its internal initialization script and is beginning to load the web page or the main script.

It can be used by the preload script to add removed Node global symbols back to the global scope when node integration is turned off:

In rear cases the Global object can be used to share code across environments such as between Electron and TypeScript Cross platform Web App.
