### PR TITLE
Added Headers constructor options to whatwg-fetch

### DIFF
--- a/whatwg-fetch/whatwg-fetch-tests.ts
+++ b/whatwg-fetch/whatwg-fetch-tests.ts
@@ -1,5 +1,18 @@
 ﻿/// <reference path="whatwg-fetch.d.ts" />
 
+function test_HeadersCopiedFromHeaders() {
+	var source = new Headers();
+	source.append('Content-Type', 'application/json');
+	return new Headers(source);
+}
+
+function test_HeadersCopiedFromHash() {
+	var source:HeadersMap = {
+		'Content-Type': 'application/json'
+	};
+	return new Headers(source);
+}
+
 function test_fetchUrlWithOptions() {
 	var headers = new Headers();
 	headers.append("Content-Type", "application/json");

--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -41,7 +41,12 @@ type RequestCache =
 	"default" | "no-store" | "reload" | "no-cache" |
 	"force-cache" | "only-if-cached";
 
+declare interface HeadersMap {
+	[index: string]: string;
+}
+
 declare class Headers {
+	constructor(headers?:Headers|HeadersMap)
 	append(name: string, value: string): void;
 	delete(name: string):void;
 	get(name: string): string;
@@ -60,6 +65,7 @@ declare class Body {
 	json<T>(): Promise<T>;
 	text(): Promise<string>;
 }
+
 declare class Response extends Body {
 	constructor(body?: BodyInit, init?: ResponseInit);
 	static error(): Response;


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url https://github.com/github/fetch/blob/v1.0.0/fetch.js#L58
