### PR TITLE
Fix geojson type values.

### DIFF
--- a/geojson/geojson.d.ts
+++ b/geojson/geojson.d.ts
@@ -33,7 +33,6 @@ declare namespace GeoJSON {
     */
     export interface Point extends GeometryObject
     {
-        type: 'Point'
         coordinates: Position
     }
 
@@ -42,7 +41,6 @@ declare namespace GeoJSON {
     */
     export interface MultiPoint extends GeometryObject
     {
-        type: 'MultiPoint'
         coordinates: Position[]
     }
 
@@ -51,7 +49,6 @@ declare namespace GeoJSON {
     */
     export interface LineString extends GeometryObject
     {
-        type: 'LineString'
         coordinates: Position[]
     }
 
@@ -60,7 +57,6 @@ declare namespace GeoJSON {
     */
     export interface MultiLineString extends GeometryObject
     {
-        type: 'MultiLineString'
         coordinates: Position[][]
     }
 
@@ -69,7 +65,6 @@ declare namespace GeoJSON {
     */
     export interface Polygon extends GeometryObject
     {
-        type: 'Polygon'
         coordinates: Position[][]
     }
 
@@ -78,7 +73,6 @@ declare namespace GeoJSON {
     */
     export interface MultiPolygon extends GeometryObject
     {
-        type: 'MultiPolygon'
         coordinates: Position[][][]
     }
 
@@ -87,7 +81,6 @@ declare namespace GeoJSON {
     */
     export interface GeometryCollection extends GeoJsonObject
     {
-        type: 'GeometryCollection'
         geometries: GeometryObject[];
     }
 
@@ -96,7 +89,6 @@ declare namespace GeoJSON {
     */
     export interface Feature<T extends GeometryObject> extends GeoJsonObject
     {
-        type: 'Feature'
         geometry: T;
         properties: any;
         id?: string;
@@ -107,7 +99,6 @@ declare namespace GeoJSON {
     */
     export interface FeatureCollection<T extends GeometryObject> extends GeoJsonObject
     {
-        type: 'FeatureCollection'
         features: Feature<T>[];
     }
 


### PR DESCRIPTION
Hello, 

at the moment geojson tests fails with output:

``` bash
$ tsc --noImplicitAny --target es6 geojson/geojson-tests.ts 
geojson/geojson.d.ts(36,15): error TS1110: Type expected.
geojson/geojson.d.ts(45,15): error TS1110: Type expected.
geojson/geojson.d.ts(54,15): error TS1110: Type expected.
geojson/geojson.d.ts(63,15): error TS1110: Type expected.
geojson/geojson.d.ts(72,15): error TS1110: Type expected.
geojson/geojson.d.ts(81,15): error TS1110: Type expected.
geojson/geojson.d.ts(90,15): error TS1110: Type expected.
geojson/geojson.d.ts(99,15): error TS1110: Type expected.
geojson/geojson.d.ts(110,15): error TS1110: Type expected.
```

As tsc's error says, the reason is using string literal when type expected.

I've fixed this failures. `type` field has been defined in `GeoJsonObject`
