### PR TITLE
Fix uuid.js definitions.

### DIFF
--- a/uuid/UUID-tests.ts
+++ b/uuid/UUID-tests.ts
@@ -1,9 +1,5 @@
 /// <reference path="UUID.d.ts" />
 
-
-import UUID = require("UUID");
-
-
 const uuid1: string = UUID.generate()
 const uuid2: UUID.UUID = UUID.genV4()
 const uuid3: UUID.UUID = UUID.genV1()

--- a/uuid/UUID.d.ts
+++ b/uuid/UUID.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Jason Jarrett <https://github.com/staxmanade/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module "UUID" {
+declare module UUID {
 
     interface UUID {
         intFields: UUIDArray<number>;


### PR DESCRIPTION
At the moment, tests for UUID.js definitions fails with output:

``` bash
$ tsc --noImplicitAny --target es6 uuid/UUID-tests.ts 
uuid/UUID-tests.ts(4,1): error TS1202: Import assignment cannot be used when targeting ECMAScript 6 modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
```

I've fixed it.
