### PR TITLE
[d3] Added missing histogram.range() method signature

### DIFF
--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -2990,7 +2990,6 @@ declare namespace d3 {
             range(range: (values: T[], index: number) => [number, number]): Histogram<T>;
             range(range: [number, number]): Histogram<T>;
 
-
             bins(): (range: [number, number], values: T[], index: number) => number[];
             bins(count: number): Histogram<T>;
             bins(thresholds: number[]): Histogram<T>;

--- a/d3/d3.d.ts
+++ b/d3/d3.d.ts
@@ -2988,6 +2988,8 @@ declare namespace d3 {
 
             range(): (values: T[], index: number) => [number, number];
             range(range: (values: T[], index: number) => [number, number]): Histogram<T>;
+            range(range: [number, number]): Histogram<T>;
+
 
             bins(): (range: [number, number], values: T[], index: number) => number[];
             bins(count: number): Histogram<T>;


### PR DESCRIPTION
histogram.range([range]) accepts a two element number array representing the minimum and maximum of the range as well as a function that returns a two element array.

See: https://github.com/d3/d3-3.x-api-reference/blob/master/Histogram-Layout.md 

I have added the method signature to the histogram typing.
