### PR TITLE
Update select2 to have selectOnClose option

### DIFF
--- a/select2/select2.d.ts
+++ b/select2/select2.d.ts
@@ -79,6 +79,7 @@ interface Select2Options {
     templateSelection?: (object: Select2SelectionObject) => any;
     templateResult?: (object: Select2SelectionObject) => any;
     language?: string | string[] | {};
+    selectOnClose?: boolean;
 }
 
 interface Select2JQueryEventObject extends JQueryEventObject {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Option documented at https://select2.github.io/options.html#can-i-select-the-highlighted-result-when-the-dropdown-is-closed
