### PR TITLE
Added definitions for the react-file-reader-input react component.

### DIFF
--- a/react-file-reader-input/react-file-reader-input-tests.tsx
+++ b/react-file-reader-input/react-file-reader-input-tests.tsx
@@ -1,0 +1,25 @@
+///<reference path="../react/react.d.ts" />
+///<reference path="./react-file-reader-input.d.ts" />
+
+import * as React from "react";
+import FileReaderInput = require("react-file-reader-input");
+
+class MyComponent extends React.Component<{}, {}> {
+  handleChange = (event: React.SyntheticEvent, results: any) => {
+    results.forEach((result: any) => {
+      const [event, file] = result;
+      console.log(`Selected file ${file.name}!`);
+    });
+  }
+
+  render(): React.ReactElement<{}> {
+    return (
+      <form>
+        <label htmlFor="my-file-input">Upload a File: </label>
+        <FileReaderInput as="binary" onChange={this.handleChange} >
+          <button>Select a file!</button>
+        </FileReaderInput>
+      </form>
+    );
+  }
+}

--- a/react-file-reader-input/react-file-reader-input.d.ts
+++ b/react-file-reader-input/react-file-reader-input.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for react-file-reader-input
+// Project: https://www.npmjs.com/package/react-file-reader-input
+// Definitions by: Dmitry Rogozhny <https://github.com/dmitryrogozhny>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+///<reference path="../react/react.d.ts" />
+
+declare module "react-file-reader-input" {
+    import React = __React;
+
+    interface FileInputProps {
+        as?: string;
+        onChange?: (event: React.SyntheticEvent, results: any) => void;
+    }
+
+    class FileInput extends React.Component<FileInputProps, {}> {
+    }
+
+    export = FileInput;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
