### PR TITLE
webcomponents.js: Add typings for Element.createShadowRoot

### DIFF
--- a/webcomponents.js/webcomponents.js-tests.ts
+++ b/webcomponents.js/webcomponents.js-tests.ts
@@ -41,6 +41,7 @@ document.querySelectorAll(`link[type=${window.HTMLImports.IMPORT_LINK_TYPE}`);
  */
 
 var shadow = xFoo.createShadowRoot();
+xFoo.shadowRoot;
 shadow.innerHTML;
 shadow.host;
 

--- a/webcomponents.js/webcomponents.js-tests.ts
+++ b/webcomponents.js/webcomponents.js-tests.ts
@@ -37,6 +37,14 @@ window.HTMLImports.whenReady(() => {
 document.querySelectorAll(`link[type=${window.HTMLImports.IMPORT_LINK_TYPE}`);
 
 /*
+ * Shadow DOM
+ */
+
+var shadow = xFoo.createShadowRoot();
+shadow.innerHTML;
+shadow.host;
+
+/*
  * Web Components
  */
 window.WebComponents.flags;

--- a/webcomponents.js/webcomponents.js.d.ts
+++ b/webcomponents.js/webcomponents.js.d.ts
@@ -33,7 +33,7 @@ declare namespace webcomponents {
 
     export interface ShadowRootPolyfill extends DocumentFragment {
         innerHTML: string;
-        readonly host: Element;
+        host: Element;
     }
 
     export interface Polyfill {

--- a/webcomponents.js/webcomponents.js.d.ts
+++ b/webcomponents.js/webcomponents.js.d.ts
@@ -48,6 +48,7 @@ declare module "webcomponents.js" {
 
 interface Element {
     createShadowRoot(): webcomponents.ShadowRootPolyfill;
+    shadowRoot?: webcomponents.ShadowRootPolyfill;
 }
 
 interface Document {

--- a/webcomponents.js/webcomponents.js.d.ts
+++ b/webcomponents.js/webcomponents.js.d.ts
@@ -40,7 +40,6 @@ declare namespace webcomponents {
         flags: any;
     }
 
-
 }
 
 declare module "webcomponents.js" {

--- a/webcomponents.js/webcomponents.js.d.ts
+++ b/webcomponents.js/webcomponents.js.d.ts
@@ -31,14 +31,24 @@ declare namespace webcomponents {
         whenReady(callback: () => void): void;
     }
 
+    export interface ShadowRootPolyfill extends DocumentFragment {
+        innerHTML: string;
+        readonly host: Element;
+    }
+
     export interface Polyfill {
         flags: any;
     }
+
 
 }
 
 declare module "webcomponents.js" {
     export = webcomponents;
+}
+
+interface Element {
+    createShadowRoot(): webcomponents.ShadowRootPolyfill;
 }
 
 interface Document {


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

See https://github.com/webcomponents/webcomponentsjs/blob/master/src/ShadowDOM/wrappers/Element.js

createShadowRoot is deprecated in the official Shadow DOM spec,
but is the way to attach a shadow root in the current released
version of webcomponents.js.
