### PR TITLE
Add the options argument to openlayers custom control

### DIFF
--- a/openlayers/openlayers-3.14.2.d.ts
+++ b/openlayers/openlayers-3.14.2.d.ts
@@ -1070,6 +1070,25 @@ declare namespace olx {
             rightHanded?: boolean;
         }
     }
+
+    namespace control {
+        interface ControlOptions {
+            /**
+             * The element is the control's container element. This only needs to be specified if you're developing a custom control.
+             */
+            element?: Element;
+
+            /**
+             * Function called when the control should be re-rendered. This is called in a requestAnimationFrame callback.
+             */
+            render?: any;
+
+            /**
+             * Specify a target if you want the control to be rendered outside of the map's viewport.
+             */
+            target?: Element | string;
+        }
+    }
 }
 
 /**
@@ -2388,6 +2407,7 @@ declare namespace ol {
         }
 
         class Control {
+            constructor(options: olx.control.ControlOptions);
         }
 
         class FullScreen {


### PR DESCRIPTION
As it can be seen in the openlayers' documentation, the ol.control.Control's constructor has an options argument. This PR adds this argument with the associated type (olx.control.ControlOptions).
The openlayers' documentation does not say it but this argument has to be set. If not, an error occurs: TypeError: Cannot read property 'element' of undefined.

The same modification has been done for openlayers 3.6.0 with PR #10099.
