### PR TITLE
Adding a couple missing highcharts properites

### DIFF
--- a/highcharts/highcharts-tests.ts
+++ b/highcharts/highcharts-tests.ts
@@ -2258,6 +2258,7 @@ function test_PointObject() {
     var point = <HighchartsPointObject>$('#container').highcharts().get('point1');
     var category = point.category;
     var percentage = point.percentage;
+	point.index;
     point.remove();
     point.remove(false);
     point.remove(false, {duration: 50});

--- a/highcharts/highcharts-tests.ts
+++ b/highcharts/highcharts-tests.ts
@@ -2258,7 +2258,7 @@ function test_PointObject() {
     var point = <HighchartsPointObject>$('#container').highcharts().get('point1');
     var category = point.category;
     var percentage = point.percentage;
-	point.index;
+    point.index;
     point.remove();
     point.remove(false);
     point.remove(false, {duration: 50});

--- a/highcharts/highcharts.d.ts
+++ b/highcharts/highcharts.d.ts
@@ -6114,7 +6114,7 @@ interface HighchartsPointObject {
      */
     category: string | number;
     name: string;
-	index: number;
+    index: number;
     /**
      * The percentage for points in a stacked series or pies.
      * @since 1.2.0

--- a/highcharts/highcharts.d.ts
+++ b/highcharts/highcharts.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Highcharts 4.1.9
+// Type definitions for Highcharts 4.2.5
 // Project: http://www.highcharts.com/
 // Definitions by: Damiano Gambarotto <http://github.com/damianog>, Dan Lewi Harkestad <http://github.com/baltie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -4817,6 +4817,17 @@ interface HighchartsPlotOptions {
  */
 interface HighchartsIndividualSeriesOptions {
     type?: string;
+ 	/**
+ 	 * The main color or the series. In line type series it applies to the line and the point markers unless otherwise
+	 *     specified. In bar type series it applies to the bars unless a color is specified per point. The default
+	 *     value is pulled from the options.colors array.
+ 	 */
+ 	color?: string;
+ 	/**
+ 	 * You can set the cursor to "pointer" if you have click events attached to the series, to signal to the user
+	 *     that the points and lines can be clicked.
+ 	 */
+ 	cursor?: string;
     /**
      * An array of data points for the series. For the area series type, points can be given in the following ways:
      *
@@ -4867,6 +4878,11 @@ interface HighchartsIndividualSeriesOptions {
      * The name of the series as shown in the legend, tooltip etc.
      */
     name?: string;
+ 	/**
+ 	 * A pixel value specifying a fixed width for each column or bar. When null, the width is calculated from
+	 * the pointPadding and groupPadding.
+ 	 */
+ 	pointWidth?: number;
     /**
      * This option allows grouping series in a stacked chart. The stack option can be a string or a number or anything
      * else, as long as the grouped series' stack options match each other.
@@ -5472,12 +5488,12 @@ interface HighchartsOptions {
      * The X axis or category axis. Normally this is the horizontal axis, though if the chart is inverted this is the
      * vertical axis. In case of multiple axes, the xAxis node is an array of configuration objects.
      */
-    xAxis?: HighchartsAxisOptions | HighchartsAxisOptions[];
+    xAxis?: HighchartsAxisOptions[] | HighchartsAxisOptions;
     /**
      * The Y axis or value axis. Normally this is the vertical axis, though if the chart is inverted this is the
      * horizontal axis. In case of multiple axes, the yAxis node is an array of configuration objects.
      */
-    yAxis?: HighchartsAxisOptions | HighchartsAxisOptions[];
+    yAxis?: HighchartsAxisOptions[] | HighchartsAxisOptions;
 }
 
 interface HighchartsGlobalOptions extends HighchartsOptions {
@@ -6098,6 +6114,7 @@ interface HighchartsPointObject {
      */
     category: string | number;
     name: string;
+	index: number;
     /**
      * The percentage for points in a stacked series or pies.
      * @since 1.2.0

--- a/highcharts/highcharts.d.ts
+++ b/highcharts/highcharts.d.ts
@@ -4817,17 +4817,17 @@ interface HighchartsPlotOptions {
  */
 interface HighchartsIndividualSeriesOptions {
     type?: string;
- 	/**
- 	 * The main color or the series. In line type series it applies to the line and the point markers unless otherwise
-	 *     specified. In bar type series it applies to the bars unless a color is specified per point. The default
-	 *     value is pulled from the options.colors array.
- 	 */
- 	color?: string;
- 	/**
- 	 * You can set the cursor to "pointer" if you have click events attached to the series, to signal to the user
-	 *     that the points and lines can be clicked.
- 	 */
- 	cursor?: string;
+    /**
+     * The main color or the series. In line type series it applies to the line and the point markers unless otherwise
+     *     specified. In bar type series it applies to the bars unless a color is specified per point. The default
+     *     value is pulled from the options.colors array.
+     */
+    color?: string;
+    /**
+     * You can set the cursor to "pointer" if you have click events attached to the series, to signal to the user
+     *     that the points and lines can be clicked.
+     */
+    cursor?: string;
     /**
      * An array of data points for the series. For the area series type, points can be given in the following ways:
      *
@@ -4878,11 +4878,11 @@ interface HighchartsIndividualSeriesOptions {
      * The name of the series as shown in the legend, tooltip etc.
      */
     name?: string;
- 	/**
- 	 * A pixel value specifying a fixed width for each column or bar. When null, the width is calculated from
-	 * the pointPadding and groupPadding.
- 	 */
- 	pointWidth?: number;
+    /**
+     * A pixel value specifying a fixed width for each column or bar. When null, the width is calculated from
+     * the pointPadding and groupPadding.
+     */
+    pointWidth?: number;
     /**
      * This option allows grouping series in a stacked chart. The stack option can be a string or a number or anything
      * else, as long as the grouped series' stack options match each other.


### PR DESCRIPTION
We are just moving over to TS, so there will likely be more PRs or additions to this one as we continue the transition. I re-ordered the axis options and axis options array to provide a better type error. As originally written, the error was about the value not having length (because it wasn't an array) instead of complaining about the properties of the axis options object.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
