### PR TITLE
Fix initializeAdapterInstance return type

### DIFF
--- a/breeze/breeze.d.ts
+++ b/breeze/breeze.d.ts
@@ -1043,6 +1043,10 @@ declare namespace breeze.config {
     @return {an instance of the specified adapter}
     **/
     export function getAdapterInstance(interfaceName: string, adapterName?: string): Object;
+
+    export interface Adapter {
+        getRoutePrefix: Function
+    }
     /**
     Initializes a single adapter implementation. Initialization means either newing a instance of the 
     specified interface and then calling "initialize" on it or simply calling "initialize" on the instance
@@ -1052,7 +1056,7 @@ declare namespace breeze.config {
     @param isDefault=true {Boolean} - Whether to make this the default "adapter" for this interface. 
     @return {an instance of the specified adapter}
     **/
-    export function initializeAdapterInstance(interfaceName: string, adapterName: string, isDefault?: boolean): void;
+    export function initializeAdapterInstance(interfaceName: string, adapterName: string, isDefault?: boolean): Adapter;
 
     export interface AdapterInstancesConfig {
         /** the name of a previously registered "ajax" adapter */

--- a/breeze/breeze.d.ts
+++ b/breeze/breeze.d.ts
@@ -12,6 +12,7 @@
 // Updated Jan 20 2015 for Breeze 1.5.2 and merging changes from DefinitelyTyped
 // Updated Feb 28 2015 add any/all clause on Predicate
 // Updated Jun 27 2016 - Marcel Good (www.ideablade.com)
+// Updated Jul 28 2016 - Serkan "coni2k" Holat
 
 declare namespace breeze.core {
 


### PR DESCRIPTION
As mentioned in its comments section, initializeAdapterInstance function should actually return an instance of an adapter. Currently it returns void.

. Adapter interface was defined, with getRoutePrefix function
. initializeAdapterInstance return type was changed from "void" to "Adapter"
