### PR TITLE
webcomponents.js: mark ShadowRootPolyfill.host and Element.shadowRoot readonly

### DIFF
--- a/webcomponents.js/index.d.ts
+++ b/webcomponents.js/index.d.ts
@@ -31,6 +31,11 @@ declare namespace webcomponents {
         whenReady(callback: () => void): void;
     }
 
+    export interface ShadowRootPolyfill extends DocumentFragment {
+        innerHTML: string;
+        readonly host: Element;
+    }
+
     export interface Polyfill {
         flags: any;
     }
@@ -39,6 +44,11 @@ declare namespace webcomponents {
 
 declare module "webcomponents.js" {
     export = webcomponents;
+}
+
+interface Element {
+    createShadowRoot(): webcomponents.ShadowRootPolyfill;
+    readonly shadowRoot?: webcomponents.ShadowRootPolyfill;
 }
 
 interface Document {

--- a/webcomponents.js/webcomponents.js-tests.ts
+++ b/webcomponents.js/webcomponents.js-tests.ts
@@ -37,6 +37,15 @@ window.HTMLImports.whenReady(() => {
 document.querySelectorAll(`link[type=${window.HTMLImports.IMPORT_LINK_TYPE}`);
 
 /*
+ * Shadow DOM
+ */
+
+var shadow = xFoo.createShadowRoot();
+xFoo.shadowRoot;
+shadow.innerHTML;
+shadow.host;
+
+/*
  * Web Components
  */
 window.WebComponents.flags;


### PR DESCRIPTION
This is pretty much the same change as https://github.com/DefinitelyTyped/DefinitelyTyped/pull/10330, except that we can use the readonly annotation for ShadowRootPolyfill.host and Element.shadowRoot.

case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
