### PR TITLE
updated vue-resource

### DIFF
--- a/vue-resource/vue-resource-tests.ts
+++ b/vue-resource/vue-resource-tests.ts
@@ -29,6 +29,9 @@ class App extends Vue {
             response.headers('expires');
 
             this.$set('someData', response.data);
+            this.$set('someJsonData', response.json());
+            this.$set('someTextData', response.text());
+            this.$set('someBlobData', response.blob());
         });
 
         var resource = this.$resource('someItem/{id}');

--- a/vue-resource/vue-resource.d.ts
+++ b/vue-resource/vue-resource.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for vue-resoure 0.7.0
+// Type definitions for vue-resoure 0.9.3
 // Project: https://github.com/vuejs/vue-resource
 // Definitions by: kaorun343 <https://github.com/kaorun343>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/vue-resource/vue-resource.d.ts
+++ b/vue-resource/vue-resource.d.ts
@@ -15,7 +15,7 @@ declare namespace vuejs {
         common?: { [key: string]: string };
         custom?: { [key: string]: string };
         [key: string]: any;
-    }
+    } 
 
     interface HttpResponse {
         data: Object;
@@ -36,7 +36,7 @@ declare namespace vuejs {
         headers?: any;
         before?(request: any): any;
         progress?(event: any): any;
-        credentials:boolean;
+        credentials?:boolean;
         emulateHTTP?: boolean;
         emulateJSON?: boolean;
     }

--- a/vue-resource/vue-resource.d.ts
+++ b/vue-resource/vue-resource.d.ts
@@ -23,21 +23,22 @@ declare namespace vuejs {
         status: number;
         statusText: string;
         headers: Function;
+        text():string;
+        json():string;
+        blob():string;
     }
 
     interface HttpOptions {
         url?: string;
         method?: string;
-        data?: any;
+        body?: any;
         params?: any;
         headers?: any;
-        beforeSend?(request: any): any;
+        before?(request: any): any;
+        progress?(event: any): any;
+        credentials:boolean;
         emulateHTTP?: boolean;
         emulateJSON?: boolean;
-        xhr?: any;
-        upload?: any;
-        jsonp?: string;
-        timeout?: string;
     }
 
     interface $http {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
The current definition is for an old version, the latest release has introduced breaking changes and critical functions are missing from the definitions.

Namely:
- .json()
- .text()
- .blob()

These are essential since the old typings only had the data parameter which used to be a json object but is now only raw data, it was replace by .json().

In addition, all the types have been updated to match the latest api documentation (as of 06/29/2016) here: https://github.com/vuejs/vue-resource/blob/master/docs/http.md
