### PR TITLE
Fix value type for react-select

### DIFF
--- a/react-select/react-select-tests.tsx
+++ b/react-select/react-select-tests.tsx
@@ -141,6 +141,25 @@ class SelectTest extends React.Component<React.Props<{}>, {}> {
     }
 }
 
+class SelectWithStringValueTest extends React.Component<React.Props<{}>, {}> {
+
+    render() {
+        const options: Option[] = [{ label: "Foo", value: "bar" }];
+        const onChange = (value: any) => console.log(value);
+
+        const selectProps: ReactSelectProps = {
+            name: "test-select-with-string-value",
+            value: "bar",
+            options: options,
+            onChange: onChange
+        };
+
+        return <div>
+            <Select {...selectProps} />
+        </div>;
+    }
+}
+
 class SelectAsyncTest extends React.Component<React.Props<{}>, {}> {
 
     render() {

--- a/react-select/react-select.d.ts
+++ b/react-select/react-select.d.ts
@@ -303,7 +303,7 @@ declare namespace ReactSelect {
         /**
          * initial field value
          */
-        value?: Option | Option[];
+        value?: Option | Option[] | string | string[] | number | number[];
         /**
          * the option property to use for the value
          * @default "value"


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes. 
- https://github.com/JedWatson/react-select#further-options - type for "value" is given as "any"
- https://github.com/JedWatson/react-select#usage - example using string for "value"
- https://github.com/JedWatson/react-select/blob/master/dist/react-select.js#L862 - source code where it uses `expandValue` to turn string / number values into Option type
