### PR TITLE
Added basic type definitions for react-relay

### DIFF
--- a/react-relay/react-relay-test.tsx
+++ b/react-relay/react-relay-test.tsx
@@ -4,4 +4,43 @@
 import * as React from "react"
 import * as Relay from "react-relay"
 
-// TODO write test cases
+interface Props {
+    text: string
+    userId: string
+}
+
+interface Response {
+}
+
+export default class AddTweetMutation extends Relay.Mutation<Props, Response> {
+
+    getMutation () {
+        return Relay.QL`mutation{addTweet}`
+    }
+
+    getFatQuery () {
+        return Relay.QL`
+            fragment on AddTweetPayload {
+                tweetEdge
+                user
+            }
+        `
+    }
+
+    getConfigs () {
+        return [{
+            type: "RANGE_ADD",
+            parentName: "user",
+            parentID: this.props.userId,
+            connectionName: "tweets",
+            edgeName: "tweetEdge",
+            rangeBehaviors: {
+                "": "append",
+            },
+        }]
+    }
+
+    getVariables () {
+        return this.props
+    }
+}

--- a/react-relay/react-relay-test.tsx
+++ b/react-relay/react-relay-test.tsx
@@ -1,0 +1,7 @@
+/// <reference path="../react/react.d.ts" />
+/// <reference path="./react-relay.d.ts" />
+
+import * as React from "react"
+import * as Relay from "react-relay"
+
+// TODO write test cases

--- a/react-relay/react-relay.d.ts
+++ b/react-relay/react-relay.d.ts
@@ -8,7 +8,7 @@
 declare module "react-relay" {
     import * as React from "react";
 
-    // fragments are a hash of functions
+    /** Fragments are a hash of functions */
     interface Fragments {
         [query: string]: ((variables?: RelayVariables) => string)
     }
@@ -23,7 +23,7 @@ declare module "react-relay" {
         [name: string]: any
     }
 
-    // add static getFragment method to the component constructor
+    /** add static getFragment method to the component constructor */
     interface RelayContainerClass<T> extends React.ComponentClass<T> {
         getFragment: ((q: string) => string)
     }
@@ -67,9 +67,11 @@ declare module "react-relay" {
         constructor(params?: RelayVariables)
     }
 
-    // Relay Mutation class, where T are the props it takes and S is the returned payload from Relay.Store.update.
-    // S is typically dynamic as it depends on the data the app is currently using, but it's possible to always
-    // return some data in the payload using REQUIRED_CHILDREN which is where specifying S is the most useful.
+    /**
+     * Relay Mutation class, where T are the props it takes and S is the returned payload from Relay.Store.update.
+     * S is typically dynamic as it depends on the data the app is currently using, but it's possible to always
+     * return some data in the payload using REQUIRED_CHILDREN which is where specifying S is the most useful.
+     */
     class Mutation<T,S> {
         props: T
 

--- a/react-relay/react-relay.d.ts
+++ b/react-relay/react-relay.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-relay
+// Type definitions for react-relay 0.9.2
 // Project: https://github.com/facebook/relay
 // Definitions by: Johannes Schickling <https://github.com/graphcool>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -6,104 +6,105 @@
 /// <reference path="../react/react.d.ts"/>
 
 declare module "react-relay" {
+    import * as React from "react";
 
-  // fragments are a hash of functions
-  interface Fragments {
-    [query: string]: ((variables?: RelayVariables) => string)
-  }
+    // fragments are a hash of functions
+    interface Fragments {
+        [query: string]: ((variables?: RelayVariables) => string)
+    }
 
-  interface CreateContainerOpts {
-    initialVariables?: Object
-    fragments: Fragments
-    prepareVariables?(prevVariables: RelayVariables): RelayVariables
-  }
+    interface CreateContainerOpts {
+        initialVariables?: Object
+        fragments: Fragments
+        prepareVariables?(prevVariables: RelayVariables): RelayVariables
+    }
 
-  interface RelayVariables {
-    [name: string]: any
-  }
+    interface RelayVariables {
+        [name: string]: any
+    }
 
-  // add static getFragment method to the component constructor
-  interface RelayContainerClass<T> extends React.ComponentClass<T> {
-    getFragment: ((q: string) => string)
-  }
+    // add static getFragment method to the component constructor
+    interface RelayContainerClass<T> extends React.ComponentClass<T> {
+        getFragment: ((q: string) => string)
+    }
 
-  interface RelayQueryRequestResolve {
-    response: any
-  }
+    interface RelayQueryRequestResolve {
+        response: any
+    }
 
-  interface RelayMutationRequest {
-    getQueryString(): string
-    getVariables(): RelayVariables
-    resolve(result: RelayQueryRequestResolve)
-    reject(errors: any)
-  }
+    interface RelayMutationRequest {
+        getQueryString(): string
+        getVariables(): RelayVariables
+        resolve(result: RelayQueryRequestResolve): any
+        reject(errors: any): any
+    }
 
-  interface RelayQueryRequest {
-    resolve(result: RelayQueryRequestResolve)
-    reject(errors: any)
+    interface RelayQueryRequest {
+        resolve(result: RelayQueryRequestResolve): any
+        reject(errors: any): any
 
-    getQueryString(): string
-    getVariables(): RelayVariables
-    getID(): string
-    getDebugName(): string
-  }
+        getQueryString(): string
+        getVariables(): RelayVariables
+        getID(): string
+        getDebugName(): string
+    }
 
-  interface RelayNetworkLayer {
-    supports(...options: string[]): boolean
-  }
+    interface RelayNetworkLayer {
+        supports(...options: string[]): boolean
+    }
 
-  class DefaultNetworkLayer implements RelayNetworkLayer {
-    constructor(host: string, options: any)
-    supports(...options: string[]): boolean
-  }
+    class DefaultNetworkLayer implements RelayNetworkLayer {
+        constructor(host: string, options: any)
+        supports(...options: string[]): boolean
+    }
 
-  function createContainer<T>(component: React.ComponentClass<T>, params?: CreateContainerOpts): RelayContainerClass<any>
-  function injectNetworkLayer(networkLayer: RelayNetworkLayer)
-  function isContainer(component: React.ComponentClass<any>): boolean
-  function QL(...args: any[]): string
+    function createContainer<T>(component: React.ComponentClass<T>, params?: CreateContainerOpts): RelayContainerClass<any>
+    function injectNetworkLayer(networkLayer: RelayNetworkLayer): any
+    function isContainer(component: React.ComponentClass<any>): boolean
+    function QL(...args: any[]): string
 
-  class Route {
-    constructor(params?: RelayVariables)
-  }
+    class Route {
+        constructor(params?: RelayVariables)
+    }
 
-  // Relay Mutation class, where T are the props it takes and S is the returned payload from Relay.Store.update.
-  // S is typically dynamic as it depends on the data the app is currently using, but it's possible to always
-  // return some data in the payload using REQUIRED_CHILDREN which is where specifying S is the most useful.
-  class Mutation<T,S> {
-    props: T
+    // Relay Mutation class, where T are the props it takes and S is the returned payload from Relay.Store.update.
+    // S is typically dynamic as it depends on the data the app is currently using, but it's possible to always
+    // return some data in the payload using REQUIRED_CHILDREN which is where specifying S is the most useful.
+    class Mutation<T,S> {
+        props: T
 
-    constructor(props: T)
-    static getFragment(q: string): string
-  }
+        constructor(props: T)
+        static getFragment(q: string): string
+    }
 
-  interface Transaction {
-    getError(): Error
-    Status(): number
-  }
+    interface Transaction {
+        getError(): Error
+        Status(): number
+    }
 
-  interface StoreUpdateCallbacks<T> {
-    onFailure?(transaction: Transaction)
-    onSuccess?(response: T)
-  }
+    interface StoreUpdateCallbacks<T> {
+        onFailure?(transaction: Transaction): any
+        onSuccess?(response: T): any
+    }
 
-  interface Store {
-    commitUpdate(mutation: Mutation<any,any>, callbacks?: StoreUpdateCallbacks<any>)
-  }
+    interface Store {
+        commitUpdate(mutation: Mutation<any,any>, callbacks?: StoreUpdateCallbacks<any>): any
+    }
 
-  var Store: Store
+    var Store: Store
 
-  class RootContainer extends React.Component<RootContainerProps,any> {}
+    class RootContainer extends React.Component<RootContainerProps,any> {}
 
-  interface RootContainerProps extends React.Props<RootContainer>{
-    Component: RelayContainerClass<any>
-    route: Route
-    renderLoading?(): JSX.Element
-    renderFetched?(data: any): JSX.Element
-    renderFailure?(error: Error, retry: Function): JSX.Element
-  }
+    interface RootContainerProps extends React.Props<RootContainer>{
+        Component: RelayContainerClass<any>
+        route: Route
+        renderLoading?(): JSX.Element
+        renderFetched?(data: any): JSX.Element
+        renderFailure?(error: Error, retry: Function): JSX.Element
+    }
 
-  interface RelayProp {
-    variables: any
-    setVariables(variables: Object)
-  }
+    interface RelayProp {
+      variables: any
+      setVariables(variables: Object): void
+    }
 }

--- a/react-relay/react-relay.d.ts
+++ b/react-relay/react-relay.d.ts
@@ -1,0 +1,109 @@
+// Type definitions for react-relay
+// Project: https://github.com/facebook/relay
+// Definitions by: Johannes Schickling <https://github.com/graphcool>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../react/react.d.ts"/>
+
+declare module "react-relay" {
+
+  // fragments are a hash of functions
+  interface Fragments {
+    [query: string]: ((variables?: RelayVariables) => string)
+  }
+
+  interface CreateContainerOpts {
+    initialVariables?: Object
+    fragments: Fragments
+    prepareVariables?(prevVariables: RelayVariables): RelayVariables
+  }
+
+  interface RelayVariables {
+    [name: string]: any
+  }
+
+  // add static getFragment method to the component constructor
+  interface RelayContainerClass<T> extends React.ComponentClass<T> {
+    getFragment: ((q: string) => string)
+  }
+
+  interface RelayQueryRequestResolve {
+    response: any
+  }
+
+  interface RelayMutationRequest {
+    getQueryString(): string
+    getVariables(): RelayVariables
+    resolve(result: RelayQueryRequestResolve)
+    reject(errors: any)
+  }
+
+  interface RelayQueryRequest {
+    resolve(result: RelayQueryRequestResolve)
+    reject(errors: any)
+
+    getQueryString(): string
+    getVariables(): RelayVariables
+    getID(): string
+    getDebugName(): string
+  }
+
+  interface RelayNetworkLayer {
+    supports(...options: string[]): boolean
+  }
+
+  class DefaultNetworkLayer implements RelayNetworkLayer {
+    constructor(host: string, options: any)
+    supports(...options: string[]): boolean
+  }
+
+  function createContainer<T>(component: React.ComponentClass<T>, params?: CreateContainerOpts): RelayContainerClass<any>
+  function injectNetworkLayer(networkLayer: RelayNetworkLayer)
+  function isContainer(component: React.ComponentClass<any>): boolean
+  function QL(...args: any[]): string
+
+  class Route {
+    constructor(params?: RelayVariables)
+  }
+
+  // Relay Mutation class, where T are the props it takes and S is the returned payload from Relay.Store.update.
+  // S is typically dynamic as it depends on the data the app is currently using, but it's possible to always
+  // return some data in the payload using REQUIRED_CHILDREN which is where specifying S is the most useful.
+  class Mutation<T,S> {
+    props: T
+
+    constructor(props: T)
+    static getFragment(q: string): string
+  }
+
+  interface Transaction {
+    getError(): Error
+    Status(): number
+  }
+
+  interface StoreUpdateCallbacks<T> {
+    onFailure?(transaction: Transaction)
+    onSuccess?(response: T)
+  }
+
+  interface Store {
+    commitUpdate(mutation: Mutation<any,any>, callbacks?: StoreUpdateCallbacks<any>)
+  }
+
+  var Store: Store
+
+  class RootContainer extends React.Component<RootContainerProps,any> {}
+
+  interface RootContainerProps extends React.Props<RootContainer>{
+    Component: RelayContainerClass<any>
+    route: Route
+    renderLoading?(): JSX.Element
+    renderFetched?(data: any): JSX.Element
+    renderFailure?(error: Error, retry: Function): JSX.Element
+  }
+
+  interface RelayProp {
+    variables: any
+    setVariables(variables: Object)
+  }
+}


### PR DESCRIPTION
1. Add a new type definition.
2. [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
3. [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
4. [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
   ]
