### PR TITLE
Update to sanitize-html v1.13.0 and a bug fix.

### DIFF
--- a/sanitize-html/sanitize-html-tests.ts
+++ b/sanitize-html/sanitize-html-tests.ts
@@ -10,11 +10,15 @@ let options: sanitize.IOptions = {
   },
   transformTags: {
     'a': sanitize.simpleTransform('a', { 'rel': 'nofollow' }),
-    'img': 'canvas'
+    'img': (tagName: string, attribs: sanitize.Attributes) => {
+      let img = { tagName, attribs };
+      img.attribs['alt'] = 'transformed' ;
+      return img;
+    }
   },
   exclusiveFilter: function(frame: sanitize.IFrame) {
-		return frame.tag === 'a' && !frame.text.trim();
-	}
+    return frame.tag === 'a' && !frame.text.trim();
+  }
 };
 
 let unsafe = '<div><script>alert("hello");</script></div>';

--- a/sanitize-html/sanitize-html.d.ts
+++ b/sanitize-html/sanitize-html.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for sanitize-html 1.12.0
+﻿// Type definitions for sanitize-html 1.13.0
 // Project: https://github.com/punkave/sanitize-html
 // Definitions by: Rogier Schouten <https://github.com/rogierschouten>, Afshin Darian <https://github.com/afshin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -11,10 +11,10 @@ declare namespace sanitize {
   type Attributes = { [attr: string]: string };
 
 
-  type Tag = { tagName: string; attributes: Attributes; };
+  type Tag = { tagName: string; attribs: Attributes; text?: string; };
 
 
-  type Transformer = (tagName: string, attributes: Attributes) => Tag;
+  type Transformer = (tagName: string, attribs: Attributes) => Tag;
 
 
   interface IDefaults {
@@ -28,7 +28,7 @@ declare namespace sanitize {
 
   interface IFrame {
     tag: string;
-    attributes: { [index: string]: string };
+    attribs: { [index: string]: string };
     text: string;
     tagPosition: number;
   }
@@ -40,6 +40,7 @@ declare namespace sanitize {
     allowedSchemes?: string[];
     allowedTags?: string[];
     exclusiveFilter?: (frame: IFrame) => boolean;
+    nonTextTags?: string[];
     selfClosing?: string[];
     transformTags?: { [tagName: string]: string | Transformer };
   }
@@ -48,7 +49,7 @@ declare namespace sanitize {
   var defaults: IDefaults;
 
 
-  function simpleTransform(tagName: string, attributes: Attributes, merge?: boolean): Transformer;
+  function simpleTransform(tagName: string, attribs: Attributes, merge?: boolean): Transformer;
 }
 
 


### PR DESCRIPTION
Updated the type definitions to v1.13.0.

Bug fix: sanitize-html expects tag attributes to be called attribs, which can be seen in this line from the library source:
https://github.com/punkave/sanitize-html/blob/master/index.js#L126

I introduced the original bug. Sorry about that!
