### PR TITLE
Update redux-logger typings for compatibility with Redux typings

### DIFF
--- a/redux-logger/redux-logger.d.ts
+++ b/redux-logger/redux-logger.d.ts
@@ -3,9 +3,8 @@
 // Definitions by: Alexander Rusakov <https://github.com/arusakov/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../redux/redux.d.ts" />
-
 declare module 'redux-logger' {
+  import { Middleware } from "redux";
 
   type LoggerPredicate = (getState: () => any, action: any) => boolean;
 
@@ -47,6 +46,6 @@ declare module 'redux-logger' {
   // Trickery to get TypeScript to accept that our anonymous, non-default export is a function.
   // see https://github.com/Microsoft/TypeScript/issues/3612 for more
   namespace createLogger {}
-  function createLogger(options?: ReduxLoggerOptions): Redux.Middleware;
+  function createLogger(options?: ReduxLoggerOptions): Middleware;
   export = createLogger;
 }


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

**case 2. Improvement to existing type definition.**
- documentation or source code reference which provides context for the suggested changes: https://github.com/reactjs/redux/blob/master/index.d.ts
  - it has been reviewed by a DefinitelyTyped member.

Redux now ships with its own typings, so redux-logger should import and use them.
