### PR TITLE
Added new type definition for gulp-help-doc

### DIFF
--- a/gulp-help-doc/gulp-help-doc-tests.ts
+++ b/gulp-help-doc/gulp-help-doc-tests.ts
@@ -1,0 +1,24 @@
+/// <reference path="gulp-help-doc.d.ts" />
+/// <reference path="../node/node.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import gulp = require('gulp');
+import usage = require('gulp-help-doc');
+
+/**
+ * Demo task
+ *
+ * @task {demo}
+ * @arg {env} environment
+ */
+gulp.task('demo', function() {});
+
+var logger = {
+    output: '',
+    log: msg => logger.output += msg + '\n'
+};
+
+usage(gulp, {
+    logger: logger,
+    gulpfile: __filename
+}).then(() => console.log(logger.output));

--- a/gulp-help-doc/gulp-help-doc-tests.ts
+++ b/gulp-help-doc/gulp-help-doc-tests.ts
@@ -13,7 +13,10 @@ import usage = require('gulp-help-doc');
  */
 gulp.task('demo', function() {});
 
-var logger = {
+let logger: {
+    output: string,
+    log(msg: string)
+} = {
     output: '',
     log: msg => logger.output += msg + '\n'
 };

--- a/gulp-help-doc/gulp-help-doc-tests.ts
+++ b/gulp-help-doc/gulp-help-doc-tests.ts
@@ -15,7 +15,7 @@ gulp.task('demo', function() {});
 
 let logger: {
     output: string,
-    log(msg: string)
+    log(msg: string): any
 } = {
     output: '',
     log: msg => logger.output += msg + '\n'

--- a/gulp-help-doc/gulp-help-doc.d.ts
+++ b/gulp-help-doc/gulp-help-doc.d.ts
@@ -1,0 +1,57 @@
+// Type definitions for gulp-help-doc
+// Project: https://github.com/Mikhus/gulp-help-doc
+// Definitions by: Mikhus <https://github.com/Mikhus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+declare module "gulp-help-doc" {
+
+    import gulp = require('gulp');
+    import promise = require('es6-promise');
+
+    namespace usage {
+
+        interface UsageOptions {
+            /**
+             * Defines  max line width for the printed output lines
+             * (by default is 80 characters long)
+             */
+            lineWidth?: number,
+
+            /**
+             * Defines max width of the column width tasks or args names
+             * (by default is 20 characters long)
+             */
+            keysColumnWidth?: number,
+
+            /**
+             * Defines number of empty characters for left-padding of the output
+             */
+            padding?: number,
+
+            /**
+             * Printing engine (by default is console). Accepted any device
+             * which has log() function defined to do output.
+             */
+            logger?: { log: Function },
+
+            /**
+             * Path to a gulpfile (default is gulpfile.js)
+             * Normally, there is no need to change this option. It may be used
+             * for some special cases, like mocking gulpfile for testing.
+             */
+            gulpfile?: string
+        }
+
+        interface Usage {
+            (gulp: gulp.Gulp, options?: UsageOptions): promise.Promise
+        }
+
+    }
+
+    var usage: usage.Usage;
+
+    export = usage;
+}

--- a/gulp-help-doc/gulp-help-doc.d.ts
+++ b/gulp-help-doc/gulp-help-doc.d.ts
@@ -5,12 +5,10 @@
 
 /// <reference path="../node/node.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
-/// <reference path="../es6-promise/es6-promise.d.ts" />
 
 declare module "gulp-help-doc" {
 
     import gulp = require('gulp');
-    import promise = require('es6-promise');
 
     namespace usage {
 
@@ -47,7 +45,7 @@ declare module "gulp-help-doc" {
         }
 
         interface Usage {
-            (gulp: gulp.Gulp, options?: UsageOptions): promise.Promise
+            (gulp: gulp.Gulp, options?: UsageOptions): Promise
         }
 
     }

--- a/gulp-help-doc/gulp-help-doc.d.ts
+++ b/gulp-help-doc/gulp-help-doc.d.ts
@@ -10,7 +10,7 @@
 declare module "gulp-help-doc" {
 
     import gulp = require('gulp');
-    import Promise = require('es6-promise');
+    import promise = require('es6-promise');
 
     namespace usage {
 

--- a/gulp-help-doc/gulp-help-doc.d.ts
+++ b/gulp-help-doc/gulp-help-doc.d.ts
@@ -5,11 +5,12 @@
 
 /// <reference path="../node/node.d.ts" />
 /// <reference path="../gulp/gulp.d.ts" />
+/// <reference path="../es6-promise/es6-promise.d.ts" />
 
 declare module "gulp-help-doc" {
 
     import gulp = require('gulp');
-    import promise = require('es6-promise');
+    import Promise = require('es6-promise');
 
     namespace usage {
 

--- a/gulp-help-doc/gulp-help-doc.d.ts
+++ b/gulp-help-doc/gulp-help-doc.d.ts
@@ -45,7 +45,7 @@ declare module "gulp-help-doc" {
         }
 
         interface Usage {
-            (gulp: gulp.Gulp, options?: UsageOptions): Promise
+            (gulp: gulp.Gulp, options?: UsageOptions): Promise<any>
         }
 
     }


### PR DESCRIPTION
case 1. Add a new type definition.
- [+] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [+] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [+] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

travis-ci build passed
