### PR TITLE
Add webpack-fail-plugin v1.0.5

### DIFF
--- a/webpack-fail-plugin/webpack-fail-plugin-tests.ts
+++ b/webpack-fail-plugin/webpack-fail-plugin-tests.ts
@@ -1,0 +1,9 @@
+///<reference path="webpack-fail-plugin.d.ts" />
+import * as Webpack from "webpack";
+import FailPlugin = require("webpack-fail-plugin");
+
+const config: Webpack.Configuration = {
+    plugins: [
+        FailPlugin
+    ]
+}

--- a/webpack-fail-plugin/webpack-fail-plugin.d.ts
+++ b/webpack-fail-plugin/webpack-fail-plugin.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for webpack-fail-plugin v1.0.5
+// Project: https://github.com/TiddoLangerak/webpack-fail-plugin
+// Definitions by: Simon Hartcher <https://github.com/deevus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+///<reference path="./../webpack/webpack.d.ts" />
+
+declare module "webpack-fail-plugin" {
+    import {Plugin} from "webpack";
+
+    /**
+     * Webpack plugin that will make the process return status code 1 when it finishes with errors in single-run mode.
+    */
+    function WebpackFailPlugin(): Plugin;
+
+    export = WebpackFailPlugin;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
## Notes

Compiles with `--noImplicitAny` but the module isn't an es6 module, so `import * as FailPlugin from "webpack-fail-plugin";` doesn't work. Is there a common fix for this?
