### PR TITLE
Add webpack-validator v2.2.6

### DIFF
--- a/webpack-validator/webpack-validator-tests.ts
+++ b/webpack-validator/webpack-validator-tests.ts
@@ -1,0 +1,17 @@
+///<reference path="webpack-validator.d.ts" />
+
+import {Configuration} from "webpack";
+import validate = require("webpack-validator");
+
+const a: Configuration = {
+    entry: "test"
+}
+
+const b = validate(a);
+const c = validate(b, {
+    "no-root-files-node-modules-nameclash": true
+});
+const d = validate(b, {
+    "loader-enforce-include-or-exclude": false,
+    "loader-prefer-include": true
+});

--- a/webpack-validator/webpack-validator.d.ts
+++ b/webpack-validator/webpack-validator.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for webpack-validator v2.2.6
+// Project: https://github.com/js-dxtools/webpack-validator
+// Definitions by: Simon Hartcher <https://github.com/deevus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+///<reference path="../webpack/webpack.d.ts" />
+
+declare module "webpack-validator" {
+    import {Configuration} from "webpack";
+
+    interface ValidationOptions {
+        "no-root-files-node-modules-nameclash"?: boolean;
+        "loader-enforce-include-or-exclude"?: boolean;
+        "loader-prefer-include"?: boolean;
+    }
+
+    /**
+     * Validate your webpack configs with joi
+     */
+    function Validate(config: Configuration): Configuration;
+    /**
+     * Validate your webpack configs with joi
+     */
+    function Validate(config: Configuration, options: ValidationOptions): Configuration;
+
+    export = Validate;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
