### PR TITLE
Update THREE.js definitions to r79

### DIFF
--- a/threejs/tests/webgl/webgl_animation_cloth.ts
+++ b/threejs/tests/webgl/webgl_animation_cloth.ts
@@ -114,7 +114,7 @@
         clothGeometry.dynamic = true;
         clothGeometry.computeFaceNormals();
 
-        var uniforms = { texture: { type: "t", value: clothTexture } };
+        var uniforms = { texture: { value: clothTexture } };
         var vertexShader = document.getElementById('vertexShaderDepth').textContent;
         var fragmentShader = document.getElementById('fragmentShaderDepth').textContent;
 

--- a/threejs/tests/webgl/webgl_animation_skinning_morph.ts
+++ b/threejs/tests/webgl/webgl_animation_skinning_morph.ts
@@ -182,7 +182,7 @@
         scene.add( helper );
 
 
-        var clipMorpher = THREE.AnimationClip.CreateFromMorphTargetSequence( 'facialExpressions', mesh.geometry.morphTargets, 3 );
+        var clipMorpher = THREE.AnimationClip.CreateFromMorphTargetSequence( 'facialExpressions', mesh.geometry.morphTargets, 3, true );
         var clipBones = geometry.animations[0];
 
         mixer = new THREE.AnimationMixer( mesh );

--- a/threejs/tests/webgl/webgl_lights_hemisphere.ts
+++ b/threejs/tests/webgl/webgl_lights_hemisphere.ts
@@ -95,10 +95,10 @@
         var vertexShader = document.getElementById( 'vertexShader' ).textContent;
         var fragmentShader = document.getElementById( 'fragmentShader' ).textContent;
         var uniforms = {
-            topColor: 	 { type: "c", value: new THREE.Color( 0x0077ff ) },
-            bottomColor: { type: "c", value: new THREE.Color( 0xffffff ) },
-            offset:		 { type: "f", value: 33 },
-            exponent:	 { type: "f", value: 0.6 }
+            topColor: 	 { value: new THREE.Color( 0x0077ff ) },
+            bottomColor: { value: new THREE.Color( 0xffffff ) },
+            offset:		 { value: 33 },
+            exponent:	 { value: 0.6 }
         };
         uniforms.topColor.value.copy( hemiLight.color );
 

--- a/threejs/three-trackballcontrols.d.ts
+++ b/threejs/three-trackballcontrols.d.ts
@@ -28,6 +28,7 @@ declare namespace THREE {
         maxDistance:number;
         keys:number[];
 
+        target: THREE.Vector3;
         position0: THREE.Vector3;
         target0: THREE.Vector3;
         up0: THREE.Vector3;

--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -593,7 +593,7 @@ declare namespace THREE {
             height: number
         };
         filmGauge: number;
-        filmAcces: number;
+        filmOffset: number;
 
         setFocalLength(focalLength: number): void;
         getFocalLength(): number;

--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for three.js r75
+// Type definitions for three.js r79
 // Project: http://mrdoob.github.com/three.js/
 // Definitions by: Kon <http://phyzkit.net/>, Satoru Kimura <https://github.com/gyohk>, Florent Poujol <https://github.com/florentpoujol>, SereznoKot <https://github.com/SereznoKot>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -158,6 +158,7 @@ declare namespace THREE {
     export const LuminanceFormat: PixelFormat;
     export const LuminanceAlphaFormat: PixelFormat;
     export const RGBEFormat: PixelFormat;
+    export const DepthFormat: PixelFormat;
 
     // Compressed texture formats
     // DDS / ST3C Compressed texture formats
@@ -211,6 +212,11 @@ declare namespace THREE {
     export const RGBM16Encoding: TextureEncoding;
     export const RGBDEncoding: TextureEncoding;
 
+    // Depth packing strategies
+    export enum DepthPackingStrategies { }
+    export const BasicDepthPacking: DepthPackingStrategies;
+    export const RGBADepthPacking: DepthPackingStrategies;
+
     // log handlers
     export function warn(message?: any, ...optionalParams: any[]): void;
     export function error(message?: any, ...optionalParams: any[]): void;
@@ -218,40 +224,78 @@ declare namespace THREE {
 
     // Animation ////////////////////////////////////////////////////////////////////////////////////////
 
+    export class AnimationAction {
+        loop: boolean;
+        time: number;
+        timeScale: number;
+        weight: number;
+        repetitions: number;
+        paused: boolean;
+        enabled: boolean;
+        clampWhenFinished: boolean;
+        zeroSlopeAtStart: boolean;
+        zeroSlopeAtEnd: boolean;
+
+        play(): AnimationAction;
+        stop(): AnimationAction;
+        reset(): AnimationAction;
+        isRunning(): boolean;
+        startAt(time: number): AnimationAction;
+        setLoop(mode: boolean, repetitions: number): AnimationAction;
+        setEffectiveWeight(weight: number): AnimationAction;
+        getEffectiveWeight(): number;
+        fadeIn(duration: number): AnimationAction;
+        fadeOut(duration: number): AnimationAction;
+        crossFadeFrom(fadeOutAction: AnimationAction,duration: number, warp: boolean): AnimationAction;
+        crossFadeTo(fadeInAction: AnimationAction,duration: number, warp: boolean): AnimationAction;
+        stopFading(): AnimationAction;
+        setEffectiveTimeScale(timeScale: number): AnimationAction;
+        getEffectiveTimeScale(): number;
+        setDuration(duration: number): AnimationAction;
+        syncWith(action: AnimationAction): AnimationAction;
+        halt(duration: number): AnimationAction;
+        warp(statTimeScale: number, endTimeScale: number, duration: number): AnimationAction;
+        stopWarping(): AnimationAction;
+        getMixer(): AnimationMixer;
+        getClip(): AnimationClip;
+        getRoot(): any;
+    }
+
     export class AnimationClip {
         constructor( name?: string, duration?: number, tracks?: KeyframeTrack[] );
 
         name: string;
         tracks: KeyframeTrack[];
         duration: number;
+        uuid: string;
         results: any[];
 
         resetDuration(): void;
         trim(): AnimationClip;
         optimize(): AnimationClip;
 
-        static CreateFromMorphTargetSequence( name: string, morphTargetSequence: MorphTarget[], fps: number ): AnimationClip;
+        static CreateFromMorphTargetSequence( name: string, morphTargetSequence: MorphTarget[], fps: number, noLoop: boolean ): AnimationClip;
         static findByName( clipArray: AnimationClip, name: string ): AnimationClip;
-        static CreateClipsFromMorphTargetSequences( morphTargets: MorphTarget[], fps: number ): AnimationClip[];
+        static CreateClipsFromMorphTargetSequences( morphTargets: MorphTarget[], fps: number, noLoop: boolean ): AnimationClip[];
         static parse( json: any ): AnimationClip;
         static parseAnimation( animation: any, bones: Bone[], nodeName: string ): AnimationClip;
         static toJSON(): any;
     }
 
-    export class AnimationMixer {
+    export class AnimationMixer extends EventDispatcher {
         constructor(root: any);
 
         time: number;
         timeScale: number;
 
-        clipAction(clip: AnimationClip, root?: any): any; // returns THREE.AnimationMixer._Action
-        existingAction(clip: AnimationClip, root?: any): any; /// returns THREE.AnimationMixer._Action
+        clipAction(clip: AnimationClip, root?: any): AnimationAction;
+        existingAction(clip: AnimationClip, root?: any): AnimationAction;
         stopAllAction(clip: AnimationClip, root?: any): AnimationMixer;
         update(deltaTime: number): AnimationMixer;
         getRoot(): any;
         uncacheClip(clip: AnimationClip): void;
         uncacheRoot(root: any): void;
-        uncazcheAction(clip: AnimationClip, root?: any): void;
+        uncacheAction(clip: AnimationClip, root?: any): void;
     }
 
     export class AnimationObjectGroup {
@@ -367,6 +411,10 @@ declare namespace THREE {
         constructor(name: string, times: any[], values: any[]);
     }
 
+    export class ColorKeyframeTrack extends KeyframeTrack {
+        constructor(name: string, times: any[], values: any[], interpolation: InterpolationModes);
+    }
+
     export class NumberKeyframeTrack extends KeyframeTrack {
         constructor(name: string, times: any[], values: any[], interpolation: InterpolationModes);
     }
@@ -445,6 +493,14 @@ declare namespace THREE {
         constructor(left: number, right: number, top: number, bottom: number, near?: number, far?: number);
 
         zoom: number;
+        view: {
+          fullWidth: number,
+          fullHeight: number,
+          offsetX: number,
+          offsetY: number,
+          width: number,
+          height: number
+        };
 
         /**
          * Camera frustum left plane.
@@ -480,6 +536,8 @@ declare namespace THREE {
          * Updates the camera projection matrix. Must be called after change of parameters.
          */
         updateProjectionMatrix(): void;
+        setViewOffset(fullWidth: number, fullHeight: number, offsetX: number, offsetY: number, width: number, height: number): void;
+        clearViewOffset(): void;
         clone(): OrthographicCamera;
         copy(source: OrthographicCamera): OrthographicCamera;
         toJSON(meta?: any): any;
@@ -503,7 +561,6 @@ declare namespace THREE {
          */
         constructor(fov?: number, aspect?: number, near?: number, far?: number);
 
-        focalLength: number;
         zoom: number;
 
         /**
@@ -526,14 +583,23 @@ declare namespace THREE {
          */
         far: number;
 
-        /**
-         * Uses focal length (in mm) to estimate and set FOV 35mm (fullframe) camera is used if frame size is not specified.
-         * Formula based on http://www.bobatkins.com/photography/technical/field_of_view.html
-         * @param focalLength focal length
-         * @param frameHeight frame size. Default value is 24.
-         */
-        setLens(focalLength: number, frameHeight?: number): void;
+        focus: number;
+        view: {
+            fullWidth: number,
+            fullHeight: number,
+            offsetX: number,
+            offsetY: number,
+            width: number,
+            height: number
+        };
+        filmGauge: number;
+        filmAcces: number;
 
+        setFocalLength(focalLength: number): void;
+        getFocalLength(): number;
+        getEffectiveFOV(): number;
+        getFilmWidth(): number;
+        getFilmHeight(): number;
         /**
          * Sets an offset in a larger frustum. This is useful for multi-window or multi-monitor/multi-machine setups.
          * For example, if you have 3x2 monitors and each monitor is 1920x1080 and the monitors are in grid like this:
@@ -572,14 +638,17 @@ declare namespace THREE {
          * @param height height of subcamera
          */
         setViewOffset(fullWidth: number, fullHeight: number, x: number, y: number, width: number, height: number): void;
+        clearViewOffset(): void;
 
         /**
          * Updates the camera projection matrix. Must be called after change of parameters.
          */
         updateProjectionMatrix(): void;
         clone(): PerspectiveCamera;
-        copy(source: PerspectiveCamera): PerspectiveCamera;
         toJSON(meta?: any): any;
+
+        // deprecated
+        setLens(focalLength: number, frameHeight?: number): void;
     }
 
     export class StereoCamera extends Camera {
@@ -598,7 +667,7 @@ declare namespace THREE {
      * @see <a href="https://github.com/mrdoob/three.js/blob/master/src/core/BufferAttribute.js">src/core/BufferAttribute.js</a>
      */
     export class BufferAttribute {
-        constructor(array: ArrayLike<number>, itemSize: number); // array parameter should be TypedArray.
+        constructor(array: ArrayLike<number>, itemSize: number, normalized?: boolean); // array parameter should be TypedArray.
 
         uuid: string;
         array: ArrayLike<number>;
@@ -606,6 +675,7 @@ declare namespace THREE {
         dynamic: boolean;
         updateRange: {offset:number, count:number};
         version: number;
+        normalized: boolean;
         needsUpdate: boolean;
         count: number;
 
@@ -682,7 +752,7 @@ declare namespace THREE {
      *
      * @see <a href="https://github.com/mrdoob/three.js/blob/master/src/core/BufferGeometry.js">src/core/BufferGeometry.js</a>
      */
-    export class BufferGeometry {
+    export class BufferGeometry extends EventDispatcher {
         /**
          * This creates a new BufferGeometry. It also sets several properties to an default value.
          */
@@ -700,8 +770,6 @@ declare namespace THREE {
         index: BufferAttribute;
         attributes: BufferAttribute|InterleavedBufferAttribute[];
         morphAttributes: any;
-        drawcalls: any; // deprecated, use groups
-        offsets: any; // deprecated, use groups
         groups: {start: number, count: number, materialIndex?: number}[];
         boundingBox: Box3;
         boundingSphere: BoundingSphere;
@@ -773,17 +841,14 @@ declare namespace THREE {
          */
         dispose(): void;
 
-        // EventDispatcher mixins
-        addEventListener(type: string, listener: (event: Event) => void ): void;
-        hasEventListener(type: string, listener: (event: Event) => void): void;
-        removeEventListener(type: string, listener: (event: Event) => void): void;
-        dispatchEvent(event: { type: string; [attachment: string]: any; }): void;
+        // deprecated
+        drawcalls: any;
+        offsets: any;
 
-        addIndex(index: any): void; // deprecated, use setIndex()
-        addAttribute(name: any, array: any, itemSize: any): any; // deprecated
-        addDrawCall(start: any, count: any, indexOffset?: any): void; // deprecated, use addGroup()
-        clearDrawCalls(): void; // deprecated, use clearGroups()
-        computeFaceNormals(): void; // deprecated
+        addIndex(index: any): void;
+        addDrawCall(start: any, count: any, indexOffset?: any): void;
+        clearDrawCalls(): void;
+        addAttribute(name: any, array: any, itemSize: any): any;
     }
 
     /**
@@ -849,7 +914,7 @@ declare namespace THREE {
     /**
      * @see <a href="https://github.com/mrdoob/three.js/blob/master/src/core/DirectGeometry.js">src/core/DirectGeometry.js</a>
      */
-    export class DirectGeometry {
+    export class DirectGeometry extends EventDispatcher {
         constructor();
 
         id: number;
@@ -919,8 +984,6 @@ declare namespace THREE {
          */
         constructor();
 
-        apply(object: any): void;
-
         /**
          * Adds a listener to an event type.
          * @param type The type of the listener that gets removed.
@@ -947,6 +1010,9 @@ declare namespace THREE {
          * @param type The type of event that gets fired.
          */
         dispatchEvent(event: { type: string; [attachment: string]: any; }): void;
+
+        // deprecated
+        apply(target: any): void;
     }
 
     export interface Event {
@@ -1058,7 +1124,7 @@ declare namespace THREE {
      *
      * @see https://github.com/mrdoob/three.js/blob/master/src/core/Geometry.js
      */
-    export class Geometry {
+    export class Geometry extends EventDispatcher {
         constructor();
 
         /**
@@ -1277,7 +1343,7 @@ declare namespace THREE {
      */
     export class InstancedBufferAttribute extends BufferAttribute {
         constructor(data: ArrayLike<number>, itemSize: number, meshPerAttribute?: number);
-
+        
         meshPerAttribute: number;
 
         clone(): InstancedBufferAttribute;
@@ -1292,7 +1358,7 @@ declare namespace THREE {
 
         groups: {start:number, count:number, instances:number}[];
         maxInstancedCount: number;
-
+        
         addGroup(start: number, count: number, instances: number): void;
         clone(): InstancedBufferGeometry;
         copy(source: InstancedBufferGeometry): InstancedBufferGeometry;
@@ -1326,7 +1392,7 @@ declare namespace THREE {
      */
     export class InstancedInterleavedBuffer extends InterleavedBuffer {
         constructor(array: ArrayLike<number>, stride: number, meshPerAttribute?: number);
-
+        
         meshPerAttribute: number;
 
         clone(): InstancedInterleavedBuffer;
@@ -1337,13 +1403,15 @@ declare namespace THREE {
      * @see <a href="https://github.com/mrdoob/three.js/blob/master/src/core/InterleavedBufferAttribute.js">src/core/InterleavedBufferAttribute.js</a>
      */
     export class InterleavedBufferAttribute {
-        constructor(interleavedBuffer: InterleavedBuffer, itemSize: number, offset: number);
+        constructor(interleavedBuffer: InterleavedBuffer, itemSize: number, offset: number, normalized: boolean);
 
         uuid: string;
         data: InterleavedBuffer;
         itemSize: number;
         offset: number;
         count: number;
+        normalized: boolean;
+        array: any[];
 
         getX(index: number): number;
         setX(index: number, x: number): InterleavedBufferAttribute;
@@ -1365,7 +1433,7 @@ declare namespace THREE {
     /**
      * Base class for scene graph objects
      */
-    export class Object3D {
+    export class Object3D extends EventDispatcher {
         constructor();
 
         /**
@@ -1409,7 +1477,6 @@ declare namespace THREE {
          * Object's local rotation (Euler angles), in radians.
          */
         rotation: Euler;
-        eulerOrder: string; // deprecated, use rotation.order
 
         /**
          * Global rotation.
@@ -1424,11 +1491,6 @@ declare namespace THREE {
         modelViewMatrix: Matrix4;
 
         normalMatrix: Matrix3;
-
-        /**
-         * When this is set, then the rotationMatrix gets calculated every frame.
-         */
-        rotationAutoUpdate: boolean;
 
         /**
          * Local transform.
@@ -1539,7 +1601,6 @@ declare namespace THREE {
          * @param distance  The distance to translate.
          */
         translateOnAxis(axis: Vector3, distance: number): Object3D;
-        translate(distance: number, axis: Vector3): Object3D; // deprecated, use translateOnAxis(axis, distance)
 
         /**
          * Translates object along x axis by distance.
@@ -1636,13 +1697,10 @@ declare namespace THREE {
          */
         copy(source: Object3D, recursive?: boolean): Object3D;
 
-        // EventDispatcher mixins
-        addEventListener(type: string, listener: (event: Event) => void ): void;
-        hasEventListener(type: string, listener: (event: Event) => void): void;
-        removeEventListener(type: string, listener: (event: Event) => void): void;
-        dispatchEvent(event: { type: string; [attachment: string]: any; }): void;
-
-        getChildByName(name: string): Object3D; // deprecated, use getObjectByName()
+        // deprecated
+        eulerOrder: string;
+        getChildByName(name: string): Object3D;
+        translate(distance: number, axis: Vector3): Object3D;
     }
 
     export interface Intersection {
@@ -1672,7 +1730,7 @@ declare namespace THREE {
         params: RaycasterParameters;
         precision: number;
         linePrecision: number;
-
+        
         set(origin: Vector3, direction: Vector3): void;
         setFromCamera(coords: { x: number; y: number;}, camera: Camera ): void;
         intersectObject(object: Object3D, recursive?: boolean): Intersection[];
@@ -1692,9 +1750,9 @@ declare namespace THREE {
     }
 
     export class Font {
-        constructor(data: any);
+        constructor(jsondata: string);
 
-        data: any;
+        data: string;
 
         generateShapes(text: string, size: number, divisions: number): any[];
     }
@@ -1793,6 +1851,8 @@ declare namespace THREE {
         clone(recursive?: boolean): HemisphereLight;
     }
 
+    export class DirectionalLightShadow extends LightShadow {}
+
     export class HemisphereLight extends Light {
         constructor(skyColorHex?: number|string, groundColorHex?: number|string, intensity?: number);
 
@@ -1871,11 +1931,16 @@ declare namespace THREE {
         exponent: number;
 
         decay: number;
-        shadow: LightShadow;
+        shadow: SpotLightShadow;
         power: number;
+        penumbra: number;
 
         clone(recursive?: boolean): SpotLight;
         copy(source: PointLight): SpotLight;
+    }
+
+    export class SpotLightShadow extends LightShadow {
+        update(light: Light): void;
     }
 
     // Loaders //////////////////////////////////////////////////////////////////////////////////
@@ -1943,9 +2008,9 @@ declare namespace THREE {
         withCredentials: boolean;
 
         load(url: string, onLoad?: (responseText: string) => void, onProgress?: (event: any) => void, onError?: (event: any) => void): any;
-        setPath(path: string): void;
-        setResponseType(responseType: string): void;
-        setWithCredentials(withCredentials: boolean): void;
+        setPath(path: string): XHRLoader;
+        setResponseType(responseType: string): XHRLoader;
+        setWithCredentials(withCredentials: boolean): XHRLoader;
     }
 
     export class FontLoader {
@@ -1954,6 +2019,7 @@ declare namespace THREE {
         manager: LoadingManager;
 
         load(url: string, onLoad?: (responseText: string) => void, onProgress?: (event: any) => void, onError?: (event: any) => void): void;
+        parse(json: string): Font;
     }
 
     /**
@@ -1972,8 +2038,8 @@ declare namespace THREE {
          * @param url
          */
         load(url: string, onLoad?: (image: HTMLImageElement) => void, onProgress?: (event: any) => void, onError?: (event: any) => void): HTMLImageElement;
-        setCrossOrigin(crossOrigin: string): void;
-        setPath(value: any): void;
+        setCrossOrigin(crossOrigin: string): ImageLoader;
+        setPath(value: any): ImageLoader;
     }
 
     /**
@@ -1984,7 +2050,6 @@ declare namespace THREE {
 
         manager: LoadingManager;
         withCredentials: boolean;
-        statusDomElement: HTMLElement; // readonly and deprecated
 
         load(url: string, onLoad?: (geometry: Geometry, materials: Material[]) => void, onProgress?: (event: any) => void, onError?: (event: any) => void): void;
         setTexturePath( value: string ): void;
@@ -2081,8 +2146,8 @@ declare namespace THREE {
          * @param url
          */
         load(url: string, onLoad?: (texture: Texture) => void): Texture;
-        setCrossOrigin(crossOrigin: string): void;
-        setPath(path: string): void;
+        setCrossOrigin(crossOrigin: string): TextureLoader;
+        setPath(path: string): TextureLoader;
     }
 
     export class CubeTextureLoader {
@@ -2093,8 +2158,8 @@ declare namespace THREE {
         path: string;
 
         load(urls: Array<string>, onLoad?: (texture: CubeTexture) => void, onProgress?: (event: any) => void, onError?: (event: any) => void): void;
-        setCrossOrigin(crossOrigin: string): void;
-        setPath(path: string): void;
+        setCrossOrigin(crossOrigin: string): CubeTextureLoader;
+        setPath(path: string): CubeTextureLoader;
     }
 
     export class BinaryTextureLoader {
@@ -2113,7 +2178,13 @@ declare namespace THREE {
         path: string;
 
         load(url: string, onLoad: (texture: CompressedTexture) => void, onProgress?: (event: any) => void, onError?: (event: any) => void): void;
-        setPath(path: string): void;
+        setPath(path: string): CompressedTextureLoader;
+    }
+
+    export class AudioLoader {
+        constructor(manager?: LoadingManager);
+
+        load(url: string, onLoad: Function, onPrgress: Function, onError: Function): void;
     }
 
     export namespace Cache {
@@ -2153,12 +2224,16 @@ declare namespace THREE {
         premultipliedAlpha?: boolean;
         overdraw?: number;
         visible?: boolean;
+        fog?: boolean;
+        lights?: boolean;
+        shading?: Shading;
+        vertexColors?: Colors;
     }
 
     /**
      * Materials describe the appearance of objects. They are defined in a (mostly) renderer-independent way, so you don't have to rewrite materials if you decide to use a different renderer.
      */
-    export class Material {
+    export class Material extends EventDispatcher {
         constructor();
 
         /**
@@ -2229,6 +2304,9 @@ declare namespace THREE {
          */
         depthWrite: boolean;
 
+        clippingPlanes: any;
+        clipShadows: boolean;
+
         colorWrite: boolean;
 
         precision: any;
@@ -2271,7 +2349,10 @@ declare namespace THREE {
          */
         needsUpdate: boolean;
 
-        warpRGB: Color; // deprecated, returns a new Color intance
+        fog: boolean;
+        lights: boolean;
+        shading: Shading;
+        vertexColors: Colors;
 
         setValues(parameters: MaterialParameters): void;
         toJSON(meta?: any): any;
@@ -2280,11 +2361,8 @@ declare namespace THREE {
         update(): void;
         dispose(): void;
 
-        // EventDispatcher mixins
-        addEventListener(type: string, listener: (event: Event) => void ): void;
-        hasEventListener(type: string, listener: (event: Event) => void): void;
-        removeEventListener(type: string, listener: (event: Event) => void): void;
-        dispatchEvent(event: { type: string; [attachment: string]: any; }): void;
+        // deprecated
+        warpRGB: Color;
     }
 
     export interface LineBasicMaterialParameters extends MaterialParameters {
@@ -2292,9 +2370,6 @@ declare namespace THREE {
         linewidth?: number;
         linecap?: string;
         linejoin?: string;
-        blending?: Blending;
-        vertexColors?: Colors;
-        fog?: boolean;
     }
 
     export class LineBasicMaterial extends Material {
@@ -2304,9 +2379,6 @@ declare namespace THREE {
         linewidth: number;
         linecap: string;
         linejoin: string;
-        blending: Blending;
-        vertexColors: Colors;
-        fog: boolean;
 
         setValues(parameters: LineBasicMaterialParameters): void;
         clone(): LineBasicMaterial;
@@ -2319,9 +2391,6 @@ declare namespace THREE {
         scale?: number;
         dashSize?: number;
         gapSize?: number;
-        blending?: Blending;
-        vertexColors?: Colors;
-        fog?: boolean;
     }
 
     export class LineDashedMaterial extends Material {
@@ -2332,9 +2401,6 @@ declare namespace THREE {
         scale: number;
         dashSize: number;
         gapSize: number;
-        blending: Blending;
-        vertexColors: Colors;
-        fog: boolean;
 
         setValues(parameters: LineDashedMaterialParameters): void;
         clone(): LineDashedMaterial;
@@ -2357,15 +2423,12 @@ declare namespace THREE {
         reflectivity?: number;
         refractionRatio?: number;
         shading?: Shading;
-        blending?: Blending;
         wireframe?: boolean;
         wireframeLinewidth?: number;
         wireframeLinecap?: string;
         wireframeLinejoin?: string;
-        vertexColors?: Colors;
         skinning?: boolean;
         morphTargets?: boolean;
-        fog?: boolean;
     }
 
     export class MeshBasicMaterial extends Material {
@@ -2381,14 +2444,11 @@ declare namespace THREE {
         combine: Combine;
         reflectivity: number;
         refractionRatio: number;
-        fog: boolean;
         shading: Shading;
-        blending: Blending;
         wireframe: boolean;
         wireframeLinewidth: number;
         wireframeLinecap: string;
         wireframeLinejoin: string;
-        vertexColors: Colors;
         skinning: boolean;
         morphTargets: boolean;
 
@@ -2429,13 +2489,10 @@ declare namespace THREE {
         combine?: Combine;
         reflectivity?: number;
         refractionRatio?: number;
-        fog?: boolean;
-        blending?: Blending;
         wireframe?: boolean;
         wireframeLinewidth?: number;
         wireframeLinecap?: string;
         wireframeLinejoin?: string;
-        vertexColors?: Colors;
         skinning?: boolean;
         morphTargets?: boolean;
         morphNormals?: boolean;
@@ -2445,7 +2502,7 @@ declare namespace THREE {
         constructor(parameters?: MeshLambertMaterialParameters);
 
         color: Color;
-        emissive: Color;
+        emissive: number|string;
         emissiveIntensity: number;
         emissiveMap: Texture;
         map: Texture;
@@ -2459,13 +2516,10 @@ declare namespace THREE {
         combine: Combine;
         reflectivity: number;
         refractionRatio: number;
-        fog: boolean;
-        blending: Blending;
         wireframe: boolean;
         wireframeLinewidth: number;
         wireframeLinecap: string;
         wireframeLinejoin: string;
-        vertexColors: Colors;
         skinning: boolean;
         morphTargets: boolean;
         morphNormals: boolean;
@@ -2500,20 +2554,17 @@ declare namespace THREE {
         envMap?: Texture;
         envMapIntensity?: number;
         refractionRatio?: number;
-        shading?: Shading;
-        blending?: Blending;
         wireframe?: boolean;
         wireframeLinewidth?: number;
-        vertexColors?: Colors;
         skinning?: boolean;
         morphTargets?: boolean;
         morphNormals?: boolean;
-        fog?: boolean;
     }
 
     export class MeshStandardMaterial extends Material {
         constructor(parameters?: MeshStandardMaterialParameters);
 
+        defines: any;
         color: Color;
         roughness: number;
         metalness: number;
@@ -2538,38 +2589,15 @@ declare namespace THREE {
         envMap: Texture;
         envMapIntensity: number;
         refractionRatio: number;
-        shading: Shading;
-        blending: Blending;
         wireframe: boolean;
         wireframeLinewidth: number;
-        vertexColors: Colors;
         skinning: boolean;
         morphTargets: boolean;
         morphNormals: boolean;
-        fog: boolean;
 
         setValues(parameters: MeshStandardMaterialParameters): void;
         clone(): MeshStandardMaterial;
         copy(source: MeshStandardMaterial): MeshStandardMaterial;
-    }
-
-    export interface MeshPhysicalMaterialParameters extends MeshStandardMaterialParameters {
-        reflectivity?: number;
-        clearCoat?: number;
-        clearCoatRoughness?: number;
-    }
-
-    export class MeshPhysicalMaterial extends MeshStandardMaterial {
-        constructor(parameters?: MeshPhysicalMaterialParameters);
-
-        defines: any;
-        reflectivity: number;
-        clearCoat: number;
-        clearCoatRoughness: number;
-
-        setValues(parameters: MeshPhysicalMaterialParameters): void;
-        clone(): MeshPhysicalMaterial;
-        copy(source: MeshPhysicalMaterial): MeshPhysicalMaterial;
     }
 
     export interface MeshNormalMaterialParameters extends MaterialParameters {
@@ -2619,17 +2647,13 @@ declare namespace THREE {
         combine?: Combine;
         reflectivity?: number;
         refractionRatio?: number;
-        shading?: Shading;
-        blending?: Blending;
         wireframe?: boolean;
         wireframeLinewidth?: number;
         wireframeLinecap?: string;
         wireframeLinejoin?: string;
-        vertexColors?: Colors;
         skinning?: boolean;
         morphTargets?: boolean;
         morphNormals?: boolean;
-        fog?: boolean;
     }
 
     export class MeshPhongMaterial extends Material {
@@ -2659,14 +2683,10 @@ declare namespace THREE {
         combine: Combine;
         reflectivity: number;
         refractionRatio: number;
-        fog: boolean;
-        shading: Shading;
-        blending: Blending;
         wireframe: boolean;
         wireframeLinewidth: number;
         wireframeLinecap: string;
         wireframeLinejoin: string;
-        vertexColors: Colors;
         skinning: boolean;
         morphTargets: boolean;
         morphNormals: boolean;
@@ -2675,6 +2695,21 @@ declare namespace THREE {
         setValues(parameters: MeshPhongMaterialParameters): void;
         clone(): MeshPhongMaterial;
         copy(source: MeshPhongMaterial): MeshPhongMaterial;
+    }
+
+    export interface MeshPhysicalMaterialParameters extends MeshStandardMaterialParameters {
+        reflectivity?: number;
+        clearCoat?: number;
+        clearCoatRoughness?: number;
+    }
+
+    export class MeshPhysicalMaterial extends MeshStandardMaterial {
+        constructor(parameters: MeshPhysicalMaterialParameters);
+
+        defines: any;
+        reflectivity: number;
+        clearCoat: number;
+        clearCoatRoughness: number;
     }
 
     // MultiMaterial does not inherit the Material class in the original code. However, it should treat as Material class.
@@ -2695,9 +2730,6 @@ declare namespace THREE {
         map?: Texture;
         size?: number;
         sizeAttenuation?: boolean;
-        blending?: Blending;
-        vertexColors?: Colors;
-        fog?: boolean;
     }
 
     export class PointsMaterial extends Material {
@@ -2707,31 +2739,26 @@ declare namespace THREE {
         map: Texture;
         size: number;
         sizeAttenuation: boolean;
-        blending: Blending;
-        vertexColors: boolean;
-        fog: boolean;
 
         setValues(parameters: PointsMaterialParameters): void;
         clone(): PointsMaterial;
         copy(source: PointsMaterial): PointsMaterial;
     }
 
-    export class PointCloudMaterial extends PointsMaterial {} // deprecated, use PointsMaterial
-    export class ParticleBasicMaterial extends PointsMaterial {} // deprecated, use PointsMaterial
-    export class ParticleSystemMaterial extends PointsMaterial {} // deprecated, use PointsMaterial
+    export class PointCloudMaterial extends PointsMaterial {} // deprecated
+    export class ParticleBasicMaterial extends PointsMaterial {} // deprecated
+    export class ParticleSystemMaterial extends PointsMaterial {} // deprecated
 
     export interface ShaderMaterialParameters extends MaterialParameters {
         defines?: any;
-        uniforms?: any;
+        uniforms?: any; 
         vertexShader?: string;
         fragmentShader?: string;
-        shading?: Shading;
         lineWidth?: number;
         wireframe?: boolean;
         wireframeLinewidth?: number;
-        fog?: boolean;
         lights?: boolean;
-        vertexColors?: Colors;
+        clipping?: boolean;
         skinning?: boolean;
         morphTargets?: boolean;
         morphNormals?: boolean;
@@ -2741,16 +2768,14 @@ declare namespace THREE {
         constructor(parameters?: ShaderMaterialParameters);
 
         defines: any;
-        uniforms: any;
+        uniforms: any; // type should be  { [uniform: string]: { value: any }; };    but gives "Index signature is missing in type" error during compilation
         vertexShader: string;
         fragmentShader: string;
-        shading: Shading;
         linewidth: number;
         wireframe: boolean;
         wireframeLinewidth: number;
-        fog: boolean;
         lights: boolean;
-        vertexColors: Colors;
+        clipping: boolean;
         skinning: boolean;
         morphTargets: boolean;
         morphNormals: boolean;
@@ -2773,7 +2798,6 @@ declare namespace THREE {
         color?: number|string;
         map?: Texture;
         rotation?: number;
-        fog?: boolean;
     }
 
     export class SpriteMaterial extends Material {
@@ -2782,11 +2806,14 @@ declare namespace THREE {
         color: Color;
         map: Texture;
         rotation: number;
-        fog: boolean;
 
         setValues(parameters: SpriteMaterialParameters): void;
         clone(): SpriteMaterial;
         copy(source: SpriteMaterial): SpriteMaterial;
+    }
+
+    export class ShadowMaterial extends ShaderMaterial {
+        constructor(parameters?: ShaderMaterialParameters);
     }
 
     // Math //////////////////////////////////////////////////////////////////////////////////
@@ -2803,7 +2830,6 @@ declare namespace THREE {
         clone(): Box2;
         copy(box: Box2): Box2;
         makeEmpty(): Box2;
-        empty(): any; // deprecated, use isEmpty()
         isEmpty(): boolean;
         center(optionalTarget?: Vector2): Vector2;
         size(optionalTarget?: Vector2): Vector2;
@@ -2821,6 +2847,7 @@ declare namespace THREE {
         translate(offset: Vector2): Box2;
         equals(box: Box2): boolean;
 
+        empty(): any; // deprecated, use isEmpty()
         isIntersectionBox(b: any): any; // deprecated, use intersectsBox()
     }
 
@@ -2858,7 +2885,7 @@ declare namespace THREE {
         applyMatrix4(matrix: Matrix4): Box3;
         translate(offset: Vector3): Box3;
         equals(box: Box3): boolean;
-
+        
         empty(): any; // deprecated, use isEmpty()
         isIntersectionBox(b: any): any; // deprecated, use intersectsBox()
         isIntersectionSphere(s: any): any; // deprecated, use intersectsSphere()
@@ -2985,6 +3012,7 @@ declare namespace THREE {
         add(color: Color): Color;
         addColors(color1: Color, color2: Color): Color;
         addScalar(s: number): Color;
+        sub(color: Color): Color;
         multiply(color: Color): Color;
         multiplyScalar(s: number): Color;
         lerp(color: Color, alpha: number): Color;
@@ -3145,7 +3173,7 @@ declare namespace THREE {
 
     export class Euler {
         constructor(x?: number, y?: number, z?: number, order?: string);
-
+        
         x: number;
         y: number;
         z: number;
@@ -3185,6 +3213,7 @@ declare namespace THREE {
         copy(frustum: Frustum): Frustum;
         setFromMatrix(m: Matrix4): Frustum;
         intersectsObject(object: Object3D): boolean;
+        intersectsObject(sprite: Sprite): boolean;
         intersectsSphere(sphere: Sphere): boolean;
         intersectsBox(box: Box3): boolean;
         containsPoint(point: Vector3): boolean;
@@ -3215,6 +3244,9 @@ declare namespace THREE {
      * @see <a href="https://github.com/mrdoob/three.js/blob/master/src/math/Math.js">src/math/Math.js</a>
      */
     export namespace Math {
+        export const DEG2RAD: number;
+        export const RAD2DEG: number;
+
         export function generateUUID(): string;
 
         /**
@@ -3335,11 +3367,6 @@ declare namespace THREE {
         clone(): Matrix3;
         copy(m: Matrix3): Matrix3;
         setFromMatix4(m: Matrix4): Matrix3;
-
-        /**
-         * @deprecated Use applyToVector3Array()
-         */
-        multiplyVector3Array(a: any): any;
         applyToVector3Array(array: number[], offset?: number, length?: number): number[];
         applyToBuffer(buffer: BufferAttribute, offset?: number, length?: number): BufferAttribute;
         multiplyScalar(s: number): Matrix3;
@@ -3347,15 +3374,9 @@ declare namespace THREE {
         getInverse(matrix: Matrix3, throwOnDegenerate?: boolean): Matrix3;
 
         /**
-         * @deprecated No longer takes a Matrix4 argument.
-         */
-        getInverse(matrix: Matrix4, throwOnDegenerate?: boolean): Matrix3;
-
-        /**
          * Transposes this matrix in place.
          */
         transpose(): Matrix3;
-        flattenToArrayOffset(array: number[], offset: number): number[];
         getNormalMatrix(matrix4: Matrix4): Matrix3;
 
         /**
@@ -3365,10 +3386,11 @@ declare namespace THREE {
         fromArray(array: number[]): Matrix3;
         toArray(): number[];
 
-        /**
-         * @deprecated Use vector.applyMatrix3( matrix )
-         */
+        // deprecated
         multiplyVector3(vector: Vector3): any;
+        multiplyVector3Array(a: any): any;
+        getInverse(matrix: Matrix4, throwOnDegenerate?: boolean): Matrix3;
+        flattenToArrayOffset(array: number[], offset: number): number[];
     }
 
     /**
@@ -3408,7 +3430,6 @@ declare namespace THREE {
         identity(): Matrix4;
         clone(): Matrix4;
         copy(m: Matrix4): Matrix4;
-        extractPosition(m: Matrix4): Matrix4; // deprecated, use copyPosition()
         copyPosition(m: Matrix4): Matrix4;
         extractBasis( xAxis: Vector3, yAxis: Vector3, zAxis: Vector3): Matrix4;
         makeBasis( xAxis: Vector3, yAxis: Vector3, zAxis: Vector3): Matrix4;
@@ -3418,7 +3439,6 @@ declare namespace THREE {
          */
         extractRotation(m: Matrix4): Matrix4;
         makeRotationFromEuler(euler: Euler): Matrix4;
-        setRotationFromQuaternion(q: Quaternion): Matrix4; // deprecated, use makeRotationFromQuaternion()
         makeRotationFromQuaternion(q: Quaternion): Matrix4;
         /**
          * Constructs a rotation matrix, looking from eye towards center with defined up vector.
@@ -3429,6 +3449,8 @@ declare namespace THREE {
          * Multiplies this matrix by m.
          */
         multiply(m: Matrix4): Matrix4;
+
+        premultiply(m: Matrix4): Matrix4;
 
         /**
          * Sets this matrix to a x b.
@@ -3445,7 +3467,6 @@ declare namespace THREE {
          * Multiplies this matrix by s.
          */
         multiplyScalar(s: number): Matrix4;
-        multiplyVector3Array(array: number[]): number[]; // deprecated, use applyToVector3Array()
         applyToVector3Array(array: number[], offset?: number, length?: number): number[];
         applyToBuffer( buffer: BufferAttribute, offset?: number, length?: number): BufferAttribute;
         /**
@@ -3459,16 +3480,13 @@ declare namespace THREE {
          */
         transpose(): Matrix4;
 
-        /**
-         * Flattens this matrix into supplied flat array starting from offset position in the array.
-         */
-        flattenToArrayOffset(array: number[], offset: number): number[];
+
 
         /**
          * Sets the position component for this matrix from vector v.
          */
         setPosition(v: Vector3): Matrix4;
-
+        
 
         /**
          * Sets this matrix to the inverse of matrix m.
@@ -3551,26 +3569,15 @@ declare namespace THREE {
         fromArray(array: number[]): Matrix4;
         toArray(): number[];
 
-        /**
-         * @deprecated Use Vector3.setFromMatrixPosition( matrix )
-         */
-        getPosition(): any;
-        /**
-         * @deprecated Use Vector3.applyMatrix4( matrix ) or Vector3.applyProjection( matrix )
-         */
+        // deprecated
+        extractPosition(m: Matrix4): Matrix4;
+        setRotationFromQuaternion(q: Quaternion): Matrix4;
         multiplyVector3(v: any): any;
-        /**
-         * @deprecated Use Vector3.applyMatrix4( matrix )
-         */
         multiplyVector4(v: any): any;
-        /**
-         * @deprecated Use Vector3.transformDirection( matrix )
-         */
+        multiplyVector3Array(array: number[]): number[];
         rotateAxis(v: any): void;
-        /**
-         * @deprecated Use Vector3.applyMatrix( matrix )
-         */
         crossVector(v: any): void;
+        flattenToArrayOffset(array: number[], offset: number): number[];
     }
 
     export class Plane {
@@ -3599,13 +3606,14 @@ declare namespace THREE {
         translate(offset: Vector3): Plane;
         equals(plane: Plane): boolean;
 
-        isIntersectionLine(l: any): any; // deprecated, use instersectsLine()
+        // deprecated
+        isIntersectionLine(l: any): any;
     }
 
     export class Spherical {
         constructor(radius?: number, phi?: number, theta?: number);
 
-        set(radius: number, phi: number, theta: number): void;
+        set(radius: number, phi: number, theta: number): Spherical;
         clone(): Spherical;
         copy(other: Spherical): Spherical;
         makeSafe(): void;
@@ -3690,6 +3698,7 @@ declare namespace THREE {
          * Multiplies this quaternion by b.
          */
         multiply(q: Quaternion): Quaternion;
+        premultiply(q: Quaternion): Quaternion;
 
         /**
          * Sets this quaternion to a x b
@@ -3697,7 +3706,6 @@ declare namespace THREE {
          */
         multiplyQuaternions(a: Quaternion, b: Quaternion): Quaternion;
 
-        multiplyVector3(v: any): any; // deprecated, use vector.applyQuaternion( quaternion )
 
         slerp(qb: Quaternion, t: number): Quaternion;
         equals(v: Quaternion): boolean;
@@ -3714,8 +3722,11 @@ declare namespace THREE {
          * Adapted from http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/slerp/.
          */
         static slerp(qa: Quaternion, qb: Quaternion, qm: Quaternion, t: number): Quaternion;
-
+        
         static slerpFlat(dst: number[], dstOffset: number, src0: number[], srcOffset: number, src1: number[], stcOffset1: number, t: number): Quaternion;
+
+        // deprecated
+        multiplyVector3(v: any): any;
     }
 
     export class Ray {
@@ -3744,10 +3755,11 @@ declare namespace THREE {
         intersectTriangle(a: Vector3, b: Vector3, c: Vector3, backfaceCulling: boolean, optionalTarget?: Vector3): Vector3;
         applyMatrix4(matrix4: Matrix4): Ray;
         equals(ray: Ray): boolean;
-
-        isIntersectionSphere(s: any): any; // deprecated, use intersectsSphere()
-        isIntersectionPlane(p: any): any; // deprecated, use intersectsPlane()
-        isIntersectionBox(b: any): any; // deprecated, use intersectsBox()
+        
+        // deprecated
+        isIntersectionBox(b: any): any;
+        isIntersectionPlane(p: any): any;
+        isIntersectionSphere(s: any): any;
     }
 
     export class Sphere {
@@ -3843,6 +3855,7 @@ declare namespace THREE {
         plane(optionalTarget?: Vector3): Plane;
         barycoordFromPoint(point: Vector3, optionalTarget?: Vector3): Vector3;
         containsPoint(point: Vector3): boolean;
+        closestPointToPoint(): Vector3;
         equals(triangle: Triangle): boolean;
 
         static normal(a: Vector3, b: Vector3, c: Vector3, optionalTarget?: Vector3): Vector3;
@@ -4094,6 +4107,7 @@ declare namespace THREE {
          * Computes squared distance of this vector to v.
          */
         distanceToSquared(v: Vector2): number;
+        distanceToManhattan(v: Vector2): number;
 
         /**
          * Normalizes this vector and multiplies it by l.
@@ -4210,7 +4224,7 @@ declare namespace THREE {
         applyMatrix4(m: Matrix4): Vector3;
         applyProjection(m: Matrix4): Vector3;
         applyQuaternion(q: Quaternion): Vector3;
-        project(camera: Camera): Vector3;
+        project(camrea: Camera): Vector3;
         unproject(camera: Camera): Vector3;
         transformDirection(m: Matrix4): Vector3;
         divide(v: Vector3): Vector3;
@@ -4292,15 +4306,12 @@ declare namespace THREE {
          * Computes squared distance of this vector to v.
          */
         distanceToSquared(v: Vector3): number;
+        distanceToManhattan(v: Vector3): number;
 
         setFromSpherical(s: Spherical): Matrix3;
-        getPositionFromMatrix(m: Matrix4): Vector3; // deprecated, use setFromMatrixPosition()
         setFromMatrixPosition(m: Matrix4): Vector3;
-        getScaleFromMatrix(m: Matrix4): Vector3; // deprecated, use setFromMatrixScale()
         setFromMatrixScale(m: Matrix4): Vector3;
-        getColumnFromMatrixColumn(index: number, matrix: Matrix4): Vector3; // deprecated, use setFromMatrixColumn()
         setFromMatrixColumn(matrix: Matrix4, index: number): Vector3;
-        setFromMatrixColumn(index: number, matrix: Matrix4): Vector3; // deprecated, now expects ( matrix, index )
 
         /**
          * Checks for strict equality of this vector and v.
@@ -4308,13 +4319,16 @@ declare namespace THREE {
         equals(v: Vector3): boolean;
 
         fromArray(xyz: number[], offset?: number): Vector3;
-
         toArray(xyz?: number[], offset?: number): number[];
-
         fromAttribute( attribute: BufferAttribute, index: number, offset?: number): Vector3;
+
+        // deprecated
+        getPositionFromMatrix(m: Matrix4): Vector3;
+        getScaleFromMatrix(m: Matrix4): Vector3;
+        getColumnFromMatrix(index: number, matrix: Matrix4): Vector3;
     }
 
-    export class Vertex extends Vector3 {} // deprecated, use Vector3
+    export class Vertex extends Vector3 {} // deprecated
 
     /**
      * 4D vector.
@@ -4338,7 +4352,7 @@ declare namespace THREE {
          * Sets all values of this vector.
          */
         setScalar(scalar: number): Vector4;
-
+        
         /**
          * Sets X component of this vector.
          */
@@ -4491,7 +4505,7 @@ declare namespace THREE {
 
         interpolate_(i1: number, t0: number, t: number, t1: number): any;
     }
-
+    
     export class DiscreteInterpolant extends Interpolant {
         constructor(parameterPositions: any, samplesValues: any, sampleSize: number, resultBuffer?: any);
 
@@ -4529,16 +4543,17 @@ declare namespace THREE {
         constructor();
 
         levels: any[];
-        objects: any[]; // deprecated, use .levels
 
         addLevel(object: Object3D, distance?: number): void;
         getObjectForDistance(distance: number): Object3D;
         raycast(raycaster: Raycaster, intersects: any): void;
         update(camera: Camera): void;
-
         clone(): LOD;
         copy(source: LOD): LOD;
         toJSON(meta: any): any;
+
+        // deprecated
+        objects: any[];
     }
 
     export interface LensFlareProperty {
@@ -4584,6 +4599,9 @@ declare namespace THREE {
         copy(source: Line): Line;
     }
 
+    export const LineStrip: number; // deprecated
+    export const LinePieces: number; // deprecated
+
     export class LineSegments extends Line {
         constructor(
             geometry?: Geometry | BufferGeometry,
@@ -4596,8 +4614,6 @@ declare namespace THREE {
     }
 
     enum LineMode {}
-    var LineStrip: LineMode; // deprecated
-    var LinePieces: LineMode; // deprecated
 
     export class Mesh extends Object3D {
         constructor(geometry?: Geometry, material?: Material);
@@ -4646,8 +4662,8 @@ declare namespace THREE {
         copy(source: Points): Points;
     }
 
-    export class PointCloud extends Points {} // deprecated, use Points
-    export class ParticleSystem extends Points {} // deprecated, use Points
+    export class PointCloud extends Points {} // deprecated
+    export class ParticleSystem extends Points {} // deprecated
 
     export class Skeleton {
         constructor(bones: Bone[], boneInverses?: Matrix4[], useVertexTexture?: boolean);
@@ -4700,15 +4716,16 @@ declare namespace THREE {
         copy(source: Sprite): Sprite;
     }
 
-    export class Particle extends Sprite {} // deprecated, use Sprite
+    export class Particle extends Sprite {} // deprecated
 
 
     // Renderers //////////////////////////////////////////////////////////////////////////////////
 
     export interface Renderer {
+        domElement: HTMLCanvasElement;
+
         render(scene: Scene, camera: Camera): void;
         setSize(width:number, height:number, updateStyle?:boolean): void;
-        domElement: HTMLCanvasElement;
     }
 
     export interface WebGLRendererParameters {
@@ -4814,9 +4831,10 @@ declare namespace THREE {
          */
         sortObjects: boolean;
 
-        extensions: WebGLExtensions;
+        clippingPlanes: any[];
+        localClippingEnabled: boolean;
 
-        gammaFactor: number; // deprecated
+        extensions: WebGLExtensions;
 
         /**
          * Default is false.
@@ -4849,11 +4867,6 @@ declare namespace THREE {
         maxMorphNormals: number;
 
         /**
-         * Default is true.
-         */
-        autoScaleCubemaps: boolean;
-
-        /**
          * An object with a series of statistical information about the graphics board memory and the rendering process. Useful for debugging or just for the sake of curiosity. The object contains the following fields:
          */
         info: {
@@ -4871,15 +4884,13 @@ declare namespace THREE {
         };
 
         shadowMap: WebGLShadowMap;
-        shadowMapType: ShadowMapType; // deprecated, use shadowMap.type
-        shadowMapEnabled: boolean; // deprecated, use shadowMap.enabled
-        shadowMapCullFace: CullFace; // deprecated, use shadowMap.cullFace
 
         pixelRation: number;
 
         capabilities: WebGLCapabilities;
         properties: WebGLProperties;
         state: WebGLState;
+        allocTextureUnit: any;
 
         /**
          * Return the WebGL context.
@@ -4892,7 +4903,7 @@ declare namespace THREE {
         getPrecision(): string;
         getPixelRatio(): number;
         setPixelRatio(value: number): void;
-
+        
         getSize(): { width: number; height: number; };
 
         /**
@@ -4926,12 +4937,12 @@ declare namespace THREE {
         setClearColor(color: Color, alpha?: number): void;
         setClearColor(color: string, alpha?: number): void;
         setClearColor(color: number, alpha?: number): void;
-
+        
         /**
          * Returns a float with the current clear alpha. Ranges from 0 to 1.
          */
         getClearAlpha(): number;
-
+        
         setClearAlpha(alpha: number): void;
 
         /**
@@ -4971,24 +4982,31 @@ declare namespace THREE {
          * @param frontFace "ccw" or "cw
          */
         setFaceCulling(cullFace?: CullFace, frontFace?: FrontFaceDirection): void;
-        setTexture(texture: Texture, slot: number): void;
+        setTexture(texture: Texture, slot: number): void; // deprecated
+        setTexture2D(texture: Texture, slot: number): void;
+        setTextureCube(texture: Texture, slot: number): void;
         getCurrentRenderTarget(): RenderTarget;
         setRenderTarget(renderTarget: RenderTarget): void;
         readRenderTargetPixels( renderTarget: RenderTarget, x: number, y: number, width: number, height: number, buffer: any ): void;
 
-        supportsFloatTextures(): any; // deprecated
-        supportsHalfFloatTextures(): any; // deprecated
-        supportsStandardDerivatives(): any; // deprecated
-        supportsCompressedTextureS3TC(): any; // deprecated
-        supportsCompressedTexturePVRTC(): any; // deprecated
-        supportsBlendMinMax(): any; // deprecated
-        supportsVertexTextures(): any; // deprecated
-        supportsInstancedArrays(): any; // deprecated
-        enableScissorTest(boolean: any): any; // deprecated
+        // deprecated
+        gammaFactor: number;
+        shadowMapEnabled: boolean;
+        shadowMapType: ShadowMapType;
+        shadowMapCullFace: CullFace;
+
+        supportsFloatTextures(): any;
+        supportsHalfFloatTextures(): any;
+        supportsStandardDerivatives(): any;
+        supportsCompressedTextureS3TC(): any;
+        supportsCompressedTexturePVRTC(): any;
+        supportsBlendMinMax(): any;
+        supportsVertexTextures(): any;
+        supportsInstancedArrays(): any;
+        enableScissorTest(boolean: any): any;
     }
 
-    export interface RenderTarget {
-    }
+    export interface RenderTarget {} // not defined in the code, used in LightShadow and WebGRenderer classes
 
     export interface WebGLRenderTargetOptions {
         wrapS?: Wrapping;
@@ -5002,7 +5020,7 @@ declare namespace THREE {
         stencilBuffer?: boolean; // true;
     }
 
-    export class WebGLRenderTarget implements RenderTarget {
+    export class WebGLRenderTarget extends EventDispatcher {
         constructor(width: number, height: number, options?: WebGLRenderTargetOptions);
 
         uuid: string;
@@ -5014,6 +5032,7 @@ declare namespace THREE {
         texture: Texture;
         depthBuffer: boolean;
         stencilBuffer: boolean;
+        depthTexture: Texture;
         wrapS: any; // deprecated, use texture.wrapS
         wrapT: any; // deprecated, use texture.wrapT
         magFilter: any; // deprecated, use texture.magFilter
@@ -5029,12 +5048,6 @@ declare namespace THREE {
         clone(): WebGLRenderTarget;
         copy(source: WebGLRenderTarget): WebGLRenderTarget;
         dispose(): void;
-
-        // EventDispatcher mixins
-        addEventListener(type: string, listener: (event: Event) => void ): void;
-        hasEventListener(type: string, listener: (event: Event) => void): void;
-        removeEventListener(type: string, listener: (event: Event) => void): void;
-        dispatchEvent(event: { type: string; [attachment: string]: any; }): void;
     }
 
     export class WebGLRenderTargetCube extends WebGLRenderTarget {
@@ -5057,6 +5070,10 @@ declare namespace THREE {
         beginnormal_vertex: string;
         bsdfs: string;
         bumpmap_pars_fragment: string;
+        clipping_planes_fragment: string;
+        clipping_planes_pars_fragment: string;
+        clipping_planes_pars_vertex: string;
+        clipping_planes_vertex: string;
         color_fragment: string;
         color_pars_fragment: string;
         color_pars_vertex: string;
@@ -5068,8 +5085,6 @@ declare namespace THREE {
         defaultnormal_vertex: string;
         depth_frag: string;
         depth_vert: string;
-        depthRGBA_frag: string;
-        depthRGBA_vert: string;
         distanceRGBA_frag: string;
         distanceRGBA_vert: string;
         displacementmap_vertex: string;
@@ -5094,10 +5109,8 @@ declare namespace THREE {
         lights_pars: string;
         lights_phong_fragment: string;
         lights_phong_pars_fragment: string;
-        lights_phong_pars_vertex: string;
-        lights_phong_vertex: string;
-        lights_standard_fragment: string;
-        lights_standard_pars_fragment: string;
+        lights_physical_fragment: string;
+        lights_physical_pars_fragment: string;
         lights_template: string;
         logdepthbuf_fragment: string;
         logdepthbuf_pars_fragment: string;
@@ -5113,19 +5126,24 @@ declare namespace THREE {
         meshlambert_vert: string;
         meshphong_frag: string;
         meshphong_vert: string;
-        meshstandard_frag: string;
-        meshstandard_vert: string;
+        meshphysical_frag: string;
+        meshphysical_vert: string;
         metalnessmap_fragment: string;
         metalnessmap_pars_fragment: string;
         morphnormal_vertex: string;
         morphtarget_pars_vertex: string;
         morphtarget_vertex: string;
+        normal_flip: string;
         normal_frag: string;
         normal_fragment: string;
         normal_vert: string;
         normalmap_pars_fragment: string;
+        packing: string;
         points_frag: string;
         points_vert: string;
+        shadow_frag: string;
+        shadow_vert: string;
+
         premultiplied_alpha_fragment: string;
         project_vertex: string;
         roughnessmap_fragment: string;
@@ -5152,7 +5170,7 @@ declare namespace THREE {
     }
 
     export interface Shader {
-        uniforms: any;
+        uniforms: IUniform;
         vertexShader: string;
         fragmentShader: string;
     }
@@ -5171,10 +5189,10 @@ declare namespace THREE {
         equirect: Shader;
         depthRGBA: Shader;
         distanceRGBA: Shader;
+        physical: Shader;
     };
 
     export interface IUniform {
-        type: string;
         value: any;
     }
 
@@ -5224,61 +5242,57 @@ declare namespace THREE {
         lights: {
             ambientLightColor: IUniform
             directionalLights: {
-                type: string;
                 value: any[];
                 properties: {
-                    direction: { type: string };
-                    color: { type: string };
-                    shadow: { type: string };
-                    shadowBias: { type: string };
-                    shadowRadius: { type: string };
-                    shadowMapSize: { type: string };
+                    direction: {};
+                    color: {};
+                    shadow: {};
+                    shadowBias: {};
+                    shadowRadius: {};
+                    shadowMapSize: {};
                 };
             };
             directionalShadowMap: IUniform;
             directionalShadowMatrix: IUniform;
             spotLights: {
-                type: string;
                 value: any[];
                 properties: {
-                    color: { type: string };
-                    position: { type: string };
-                    direction: { type: string };
-                    distance: { type: string };
-                    coneCos: { type: string };
-                    penumbraCos: { type: string };
-                    decay: { type: string };
-                    shadow: { type: string };
-                    shadowBias: { type: string };
-                    shadowRadius: { type: string };
-                    shadowMapSize: { type: string };
+                    color: {};
+                    position: {};
+                    direction: {};
+                    distance: {};
+                    coneCos: {};
+                    penumbraCos: {};
+                    decay: {};
+                    shadow: {};
+                    shadowBias: {};
+                    shadowRadius: {};
+                    shadowMapSize: {};
                 };
             };
             spotShadowMap: IUniform;
             spotShadowMatrix: IUniform;
             pointLights: {
-                type: string;
                 value: any[];
                 properties: {
-                    color: { type: string };
-                    position: { type: string };
-                    decay: { type: string };
-                    distance: { type: string };
-                    shadow: { type: string };
-                    shadowBias: { type: string };
-                    shadowRadius: { type: string };
-                    shadowMapSize: { type: string };
+                    color: {};
+                    position: {};
+                    decay: {};
+                    distance: {};
+                    shadow: {};
+                    shadowBias: {};
+                    shadowRadius: {};
+                    shadowMapSize: {};
                 };
             };
             pointShadowMap: IUniform;
             pointShadowMatrix: IUniform;
             hemisphereLigtts: {
-                type: string;
                 value: any[];
                 properties: {
-                    direction: { type: string };
-                    skycolor: { type: string };
-                    groundColor: { type: string };
+                    direction: {};
+                    skycolor: {};
+                    groundColor: {};
                 };
             };
         };
@@ -5297,11 +5311,12 @@ declare namespace THREE {
         export function clone(uniforms_src: any): any;
     }
 
-    export class Uniform {
-        constructor(type: string, value: string);
+    export class Uniform { 
+        constructor(value: any);
+        constructor(type: string, value: any); // deprecated
 
-        type: string;
-        value: string;
+        type: string; // deprecated
+        value: any;
         dynamic: boolean;
         onUpdateCallback: Function;
 
@@ -5313,8 +5328,18 @@ declare namespace THREE {
         constructor(_gl: WebGLRenderingContext, extensions: any, _infoRender: any);
 
         setMode(value: any): void;
-        render(start: any, count: any): void;
+        render(start: any, count: number): void;
         renderInstances(geometry: any): void;
+    }
+
+    export class WebGLClipping {
+        uniform: { value: any, needsUpdate: boolean };
+        numPlanes: number;
+
+        init(planes: any[], enableLocalClipping: boolean, camera: Camera): boolean;
+        beginShadows(): void;
+        endShadows(): void;
+        setState(planes: any[], clipShadows: boolean, camera: Camera, cache: boolean, fromCache: boolean): void; 
     }
 
     export interface WebGLCapabilitiesParameters {
@@ -5339,7 +5364,8 @@ declare namespace THREE {
         floatFragmentTextures: any;
         floatVertexTextures: any;
 
-        getMaxPrecision(precision: any): any;
+        getMaxAnisotropy(): number;
+        getMaxPrecision(precision: string): string;
     }
 
     export class WebGLExtensions {
@@ -5356,7 +5382,7 @@ declare namespace THREE {
 
     export class WebGLLights {
         constructor(gl: WebGLRenderingContext, properties: any, info: any);
-
+        
         get(light: any): any;
     }
 
@@ -5368,7 +5394,7 @@ declare namespace THREE {
         render(start: any, count: number): void;
         renderInstances(geometry: any, start: any, count: number): void;
     }
-
+    
     export class WebGLObjects {
         constructor(gl: WebGLRenderingContext, properties: any, info: any);
 
@@ -5379,7 +5405,7 @@ declare namespace THREE {
 
     export class WebGLProgram {
         constructor(renderer: WebGLRenderer, code: string, material: ShaderMaterial, parameters: WebGLRendererParameters);
-
+        
         id: number;
         code: string;
         usedTimes: number;
@@ -5389,7 +5415,7 @@ declare namespace THREE {
         uniforms: any; // deprecated, use getUniforms()
         attributes: any; // deprecated, use getAttributes()
 
-        getUniforms(): any;
+        getUniforms(): WebGLUniforms;
         getAttributes(): any;
         destroy(): void;
     }
@@ -5399,12 +5425,37 @@ declare namespace THREE {
 
         programs: any[];
 
-        getParameters(material: ShaderMaterial, lights: any, fog: any, object: any): any[];
+        getParameters(material: ShaderMaterial, lights: any, fog: any, nClipPlanes: number, object: any): any;
         getProgramCode(material: ShaderMaterial, parameters: any): string;
         acquireProgram(material: ShaderMaterial, parameters: any, code: string): WebGLProgram;
         releaseProgram(program: WebGLProgram): void;
     }
 
+    export class WebGLTextures {
+        constructor(gl: any, extensions: any, state: any, properties:any, capabilities: any, paramThreeToGL: Function, info: any);
+
+        setTexture2D(texture: any, slot: number): void;
+        setTextureCube(texture: any, slot: number): void;
+        setTextureCubeDynamic(texture: any, slot: number): void;
+        setupRenderTarget(renderTarget: any): void;
+        updateRenderTargetMipmap(renderTarget: any): void;
+    }
+
+    export class WebGLUniforms {
+        constructor(gl: any, program: WebGLProgram, renderer: WebGLRenderer);
+
+        renderer: WebGLRenderer;
+
+        setValue(gl: any, value: any, renderer?: any): void;
+        set(gl: any, object: any, name: string): void;
+        setOptional(gl: any, object: any, name: string): void;
+
+        static upload(gl: any, seq: any, values: any[], renderer: any): void;
+        static seqWithValue(seq: any, values: any[]): any[];
+        static splitDynamic(seq: any, values: any[]): any[];
+        static evalDynamic(seq: any, values: any[], object: any, camera: any): any[];
+    }
+    
     export class WebGLProperties {
         constructor();
 
@@ -5418,19 +5469,29 @@ declare namespace THREE {
     }
 
     export class WebGLShadowMap {
-        constructor(_renderer: Renderer, _lights: any[], _objects: any[]);
+        constructor(_renderer: Renderer, _lights: any[], _objects: any[], capabilities: any);
 
         enabled: boolean;
         autoUpdate: boolean;
         needsUpdate: boolean;
         type: ShadowMapType;
-        cullFace: CullFace;
+        renderReverseSided: boolean;
+        renderSingleSided: boolean;
 
         render(scene: Scene, camera: Camera): void;
-    }
 
+        // deprecated
+        cullFace: any;
+    }
+    
     export class WebGLState {
         constructor(gl: any, extensions: any, paramThreeToGL: Function);
+
+        buffers: {
+            color: WebGLColorBuffer,
+            depth: WebGLDepthBuffer,
+            stencil: WebGLStencilBuffer,
+        };
 
         init(): void;
         initAttributes(): void;
@@ -5441,15 +5502,16 @@ declare namespace THREE {
         disable(id: string): void;
         getCompressedTextureFormats(): any[];
         setBlending(blending: number, blendEquation: number, blendSrc: number, blendDst: number, blendEquationAlpha: number, blendSrcAlpha: number, blendDstAlpha: number): void;
-        setDepthFunc(func: Function): void;
+        setColorWrite(colorWrite: number): void;
         setDepthTest(depthTest: number): void;
         setDepthWrite(depthWrite: number): void;
-        setColorWrite(colorWrite: number): void;
-        setStencilFunc(stencilFunc: Function, stencilRef: any, stencilMask: any): void;
-        setStencilOp(stencilFail: any, stencilZFail: any, stencilZPass: any): void;
+        setDepthFunc(depthFunc: Function): void;
         setStencilTest(stencilTest: boolean): void;
         setStencilWrite(stencilWrite: any): void;
+        setStencilFunc(stencilFunc: Function, stencilRef: any, stencilMask: number): void;
+        setStencilOp(stencilFail: any, stencilZFail: any, stencilZPass: any): void;
         setFlipSided(flipSided: number): void;
+        setCullFace(cullFace: CullFace): void;
         setLineWidth(width: number): void;
         setPolygonOffset(polygonoffset: number, factor: number, units: number): void;
         setScissorTest(scissorTest: boolean): void;
@@ -5466,10 +5528,42 @@ declare namespace THREE {
         reset(): void;
     }
 
+    export class WebGLColorBuffer {
+        constructor(gl: any, state: any);
+
+        setMask(colorMask: number): void;
+        setLocked(lock: boolean): void;
+        setClear(r: number, g: number, b: number, a: number): void;
+        reset(): void;
+    }
+
+    export class WebGLDepthBuffer {
+        constructor(gl: any, state: any);
+
+        setTest(depthTest: boolean): void;
+        sertMask(depthMask: number): void;
+        setFunc(depthFunc: Function): void;
+        setLocked(lock: boolean): void;
+        setClear(depth: any): void;
+        reset(): void;
+    }
+
+    export class WebGLStencilBuffer {
+        constructor(gl: any, state: any);
+
+        setTest(stencilTest: boolean): void;
+        sertMask(stencilMask: number): void;
+        setFunc(stencilFunc: Function, stencilRef: any, stencilMask: number): void;
+        setOp(stencilFail: any, stencilZFail: any, stencilZPass: any): void;
+        setLocked(lock: boolean): void;
+        setClear(stencil: any): void;
+        reset(): void;
+    }
+
     // Renderers / WebGL / Plugins /////////////////////////////////////////////////////////////////////
     export class LensFlarePlugin {
         constructor(renderer: WebGLRenderer, flares: any[]);
-
+        
         render(scene: Scene, camera: Camera, viewportWidth: number, viewportHeight: number): void;
     }
 
@@ -5480,7 +5574,7 @@ declare namespace THREE {
     }
 
     // Scenes /////////////////////////////////////////////////////////////////////
-
+    
     /**
      * Scenes allow you to set up what and where is to be rendered by three.js. This is where you place objects, lights and cameras.
      */
@@ -5497,6 +5591,7 @@ declare namespace THREE {
          */
         overrideMaterial: Material;
         autoUpdate: boolean;
+        background: any;
 
         copy(source: Scene, recursive?: boolean): Scene;
     }
@@ -5555,7 +5650,7 @@ declare namespace THREE {
     // Textures /////////////////////////////////////////////////////////////////////
     export let TextureIdCount: number;
 
-    export class Texture {
+    export class Texture extends EventDispatcher {
         constructor(
             image: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement,
             mapping?: Mapping,
@@ -5565,14 +5660,15 @@ declare namespace THREE {
             minFilter?: TextureFilter,
             format?: PixelFormat,
             type?: TextureDataType,
-            anisotropy?: number
+            anisotropy?: number,
+            encoding?: TextureEncoding
             );
 
         id: number;
         uuid: string;
         name: string;
         sourceFile: string;
-        image: any; // HTMLImageElement or ImageData ;
+        image: any; // HTMLImageElement or ImageData or { width: number, height: number } in some children;
         mipmaps: ImageData[];
         mapping: Mapping;
         wrapS: Wrapping;
@@ -5600,12 +5696,22 @@ declare namespace THREE {
         toJSON(meta: any): any;
         dispose(): void;
         transformUv(uv: Vector): void;
+    }
 
-        // EventDispatcher mixins
-        addEventListener(type: string, listener: (event: Event) => void ): void;
-        hasEventListener(type: string, listener: (event: Event) => void): void;
-        removeEventListener(type: string, listener: (event: Event) => void): void;
-        dispatchEvent(event: { type: string; [attachment: string]: any; }): void;
+    export class DepthTexture extends Texture {
+        constructor(
+            width: number,
+            heighht: number,
+            type?: TextureDataType,
+            mapping?: Mapping,
+            wrapS?: Wrapping,
+            wrapT?: Wrapping,
+            magFilter?: TextureFilter,
+            minFilter?: TextureFilter,
+            anisotropy?: number
+        );
+
+        image: { width: number, height: number };
     }
 
     export class CanvasTexture extends Texture {
@@ -5635,7 +5741,8 @@ declare namespace THREE {
             minFilter?: TextureFilter,
             format?: PixelFormat,
             type?: TextureDataType,
-            anisotropy?: number
+            anisotropy?: number,
+            encoding?: TextureEncoding
         );
 
         images: any; // returns and sets the value of Texture.image in the codde ?
@@ -5655,7 +5762,8 @@ declare namespace THREE {
             wrapT?: Wrapping,
             magFilter?: TextureFilter,
             minFilter?: TextureFilter,
-            anisotropy?: number
+            anisotropy?: number,
+            encoding?: TextureEncoding
         );
 
         image: { width: number; height: number; };
@@ -5676,7 +5784,8 @@ declare namespace THREE {
             wrapT: Wrapping,
             magFilter: TextureFilter,
             minFilter: TextureFilter,
-            anisotropy?: number
+            anisotropy?: number,
+            encoding?: TextureEncoding
         );
 
         image: { data: ImageData; width: number; height: number; };
@@ -5725,8 +5834,8 @@ declare namespace THREE {
 
     export namespace ShapeUtils {
         export function area(contour: number[]): number;
-        export function triangulate(contour: Vector2[], indices: boolean): Vector2[][] | number[][];
-        export function triangulateShape(contour: Vector2[], holes: Vector2[][]): Vector2[][];
+        export function triangulate(contour: number[], indices: boolean): number[];
+        export function triangulateShape(contour: number[], holes: any[]): number[];
         export function isClockWise(pts: number[]): boolean;
         export function b2(t: number, p0: number, p1: number, p2: number): number;
         export function b3(t: number, p0: number, p1: number, p2: number, p3: number): number;
@@ -5747,26 +5856,28 @@ declare namespace THREE {
         hasPlaybackControl: boolean;
         isPlaying: boolean;
         sourceType: string;
-        filter: any;
+        filters: any[];
 
         getOutput(): GainNode;
-        load(file: string): Audio;
         setNodeSource(audioNode: AudioBufferSourceNode): Audio;
         setBuffer(audioBuffer: AudioBuffer): Audio;
-        play(): void;
-        pause(): void;
-        stop(): void;
-        connect(): void;
-        disconnect(): void;
-        setFilter(value: any): void;
+        play(): Audio;
+        pause(): Audio;
+        stop(): Audio;
+        connect(): Audio;
+        disconnect(): Audio;
+        getFilters(): any[];
+        setFilter(value: any[]): Audio;
         getFilter(): any;
-        setPlaybackRate(value: number): void;
+        setFilter(filter: any): Audio;
+        setPlaybackRate(value: number): Audio;
         getPlaybackRate(): number;
         onEnded(): void;
-        setLoop(value: boolean): void;
         getLoop(): boolean;
-        setVolume(value: number): void;
+        setLoop(value: boolean): void;
         getVolume(): number;
+        setVolume(value: number): Audio;
+        load(file: string): Audio; // deprecated, use the AudioLoader class
     }
 
     export class AudioAnalyser {
@@ -5775,8 +5886,14 @@ declare namespace THREE {
         analyser: any;
         data: Uint8Array;
 
-        getData(): Uint8Array;
+        getFrequencyData(): Uint8Array;
+        getAverageFrequency(): number;
+
+        // deprecated
+        getData(file: any): any;
     }
+
+    export const AudioContext: AudioContext;
 
     export class AudioBuffer {
         constructor(context: any);
@@ -5896,7 +6013,10 @@ declare namespace THREE {
         closePath(): void;
         getPoint(t: number): T;
         getLength(): number;
+        updateArcLengths(): void;
         getCurveLengths(): number[];
+        getSpacedPoints(divisions?: number): T[];
+        getPoints(divisions?: number): T[];
         createPointsGeometry(divisions: number): Geometry;
         createSpacedPointsGeometry(divisions: number): Geometry;
         createGeometry(points: T[]): Geometry;
@@ -5923,7 +6043,7 @@ declare namespace THREE {
     export class Path extends CurvePath<Vector2> {
         constructor(points?: Vector2[]);
 
-        actions: PathAction[];
+        currentPoint: Vector2;
 
         fromPoints(vectors: Vector2[]): void;
         moveTo(x: number, y: number): void;
@@ -5935,8 +6055,19 @@ declare namespace THREE {
         absarc(aX: number, aY: number, aRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean): void;
         ellipse(aX: number, aY: number, xRadius: number, yRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean, aRotation: number): void;
         absellipse(aX: number, aY: number, xRadius: number, yRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean, aRotation: number): void;
-        getSpacedPoints(divisions?: number): Vector2[];
-        getPoints(divisions?: number, closedPath?: boolean): Vector2[];
+    }
+
+    export class ShapePath {
+        constructor();
+
+        subPaths: any[];
+        currentPath: any;
+
+        moveTo(x: number, y: number): void;
+        lineTo(x: number, y: number): void;
+        quadraticCurveTo(aCPx: number, aCPy: number, aX: number, aY: number): void;
+        bezierCurveTo(aCP1x: number, aCP1y: number, aCP2x: number, aCP2y: number, aX: number, aY: number): void;
+        splineThru(pts: Vector2[]): void;
         toShapes(isCCW: boolean, noHoles: any): Shape[];
     }
 
@@ -5969,7 +6100,7 @@ declare namespace THREE {
 
     export class ClosedSplineCurve3 extends CatmullRomCurve3 {} // deprecated, use CatmullRomCurve3
     export class SplineCurve3 extends CatmullRomCurve3 {} // will be deprecated, use CatmullRomCurve3
-
+        
     export class CubicBezierCurve extends Curve<Vector2> {
         constructor(v0: Vector2, v1: Vector2, v2: Vector2, v3: Vector2);
 
@@ -5989,7 +6120,7 @@ declare namespace THREE {
 
         getPoint(t: number): Vector3;
     }
-
+    
     export class EllipseCurve extends Curve<Vector2> {
         constructor(aX: number, aY: number, xRadius: number, yRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean, aRotation: number);
 
@@ -6021,7 +6152,7 @@ declare namespace THREE {
 
         getPoint(t: number): Vector3;
     }
-
+    
     export class QuadraticBezierCurve extends Curve<Vector2> {
         constructor( v0: Vector2, v1: Vector2, v2: Vector2 );
 
@@ -6045,7 +6176,7 @@ declare namespace THREE {
 
         points: Vector2[];
     }
-
+    
 
     // Extras / Geometries /////////////////////////////////////////////////////////////////////
     export class BoxBufferGeometry extends BufferGeometry {
@@ -6147,6 +6278,14 @@ declare namespace THREE {
             thetaStart: number;
             thetaLength: number;
         };
+    }
+
+    export class ConeBufferGeometry extends BufferGeometry {
+        constructor(radius?: number, height?: number, radialSegment?: number, heightSegment?: number, openEnded?: boolean, thetaStart?: number, thetaLength?: number);
+    }
+
+    export class ConeGeometry extends CylinderGeometry {
+        constructor(radius?: number, height?: number, radialSegment?: number, heightSegment?: number, openEnded?: boolean, thetaStart?: number, thetaLength?: number);
     }
 
     export class DodecahedronGeometry extends Geometry {
@@ -6458,7 +6597,7 @@ declare namespace THREE {
     }
 
     export class BoxHelper extends LineSegments {
-        constructor(object?: Object3D);
+        constructor(object?: Object3D, color?: Color);
 
         update(object?: Object3D): void;
     }
@@ -6477,7 +6616,6 @@ declare namespace THREE {
 
         light: Light;
         lightPlane: Line;
-        targetLine: Line;
 
         dispose(): void;
         update(): void;
@@ -6497,12 +6635,9 @@ declare namespace THREE {
     }
 
     export class GridHelper extends LineSegments {
-        constructor(size: number, step: number);
+        constructor(size: number, divisions: number, color1?: Color|number, color2?: Color|number);
 
-        color1: Color;
-        color2: Color;
-
-        setColors(colorCenterLine: number, colorGrid: number): void;
+        setColors(color1?: Color|number, color2?: Color|number): void; // deprecated
     }
 
     export class HemisphereLightHelper extends Object3D {
@@ -6536,10 +6671,9 @@ declare namespace THREE {
     }
 
     export class SpotLightHelper extends Object3D {
-        constructor(light: Light, sphereSize: number, arrowLength: number);
+        constructor(light: Light);
 
         light: Light;
-        cone: Mesh;
 
         dispose(): void;
         update(): void;

--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for three.js r75
+// Type definitions for three.js r79
 // Project: http://mrdoob.github.com/three.js/
 // Definitions by: Kon <http://phyzkit.net/>, Satoru Kimura <https://github.com/gyohk>, Florent Poujol <https://github.com/florentpoujol>, SereznoKot <https://github.com/SereznoKot>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -158,6 +158,7 @@ declare namespace THREE {
     export const LuminanceFormat: PixelFormat;
     export const LuminanceAlphaFormat: PixelFormat;
     export const RGBEFormat: PixelFormat;
+    export const DepthFormat: PixelFormat;
 
     // Compressed texture formats
     // DDS / ST3C Compressed texture formats
@@ -211,6 +212,11 @@ declare namespace THREE {
     export const RGBM16Encoding: TextureEncoding;
     export const RGBDEncoding: TextureEncoding;
 
+    // Depth packing strategies
+    export enum DepthPackingStrategies { }
+    export const BasicDepthPacking: DepthPackingStrategies;
+    export const RGBADepthPacking: DepthPackingStrategies;
+
     // log handlers
     export function warn(message?: any, ...optionalParams: any[]): void;
     export function error(message?: any, ...optionalParams: any[]): void;
@@ -218,40 +224,78 @@ declare namespace THREE {
 
     // Animation ////////////////////////////////////////////////////////////////////////////////////////
 
+    export class AnimationAction {
+        loop: boolean;
+        time: number;
+        timeScale: number;
+        weight: number;
+        repetitions: number;
+        paused: boolean;
+        enabled: boolean;
+        clampWhenFinished: boolean;
+        zeroSlopeAtStart: boolean;
+        zeroSlopeAtEnd: boolean;
+
+        play(): AnimationAction;
+        stop(): AnimationAction;
+        reset(): AnimationAction;
+        isRunning(): boolean;
+        startAt(time: number): AnimationAction;
+        setLoop(mode: boolean, repetitions: number): AnimationAction;
+        setEffectiveWeight(weight: number): AnimationAction;
+        getEffectiveWeight(): number;
+        fadeIn(duration: number): AnimationAction;
+        fadeOut(duration: number): AnimationAction;
+        crossFadeFrom(fadeOutAction: AnimationAction,duration: number, warp: boolean): AnimationAction;
+        crossFadeTo(fadeInAction: AnimationAction,duration: number, warp: boolean): AnimationAction;
+        stopFading(): AnimationAction;
+        setEffectiveTimeScale(timeScale: number): AnimationAction;
+        getEffectiveTimeScale(): number;
+        setDuration(duration: number): AnimationAction;
+        syncWith(action: AnimationAction): AnimationAction;
+        halt(duration: number): AnimationAction;
+        warp(statTimeScale: number, endTimeScale: number, duration: number): AnimationAction;
+        stopWarping(): AnimationAction;
+        getMixer(): AnimationMixer;
+        getClip(): AnimationClip;
+        getRoot(): any;
+    }
+
     export class AnimationClip {
         constructor( name?: string, duration?: number, tracks?: KeyframeTrack[] );
 
         name: string;
         tracks: KeyframeTrack[];
         duration: number;
+        uuid: string;
         results: any[];
 
         resetDuration(): void;
         trim(): AnimationClip;
         optimize(): AnimationClip;
 
-        static CreateFromMorphTargetSequence( name: string, morphTargetSequence: MorphTarget[], fps: number ): AnimationClip;
+        static CreateFromMorphTargetSequence( name: string, morphTargetSequence: MorphTarget[], fps: number, noLoop: boolean ): AnimationClip;
         static findByName( clipArray: AnimationClip, name: string ): AnimationClip;
-        static CreateClipsFromMorphTargetSequences( morphTargets: MorphTarget[], fps: number ): AnimationClip[];
+        static CreateClipsFromMorphTargetSequences( morphTargets: MorphTarget[], fps: number, noLoop: boolean ): AnimationClip[];
         static parse( json: any ): AnimationClip;
         static parseAnimation( animation: any, bones: Bone[], nodeName: string ): AnimationClip;
         static toJSON(): any;
     }
 
-    export class AnimationMixer {
+    export class AnimationMixer extends EventDispatcher {
         constructor(root: any);
 
         time: number;
         timeScale: number;
 
-        clipAction(clip: AnimationClip, root?: any): any; // returns THREE.AnimationMixer._Action
-        existingAction(clip: AnimationClip, root?: any): any; /// returns THREE.AnimationMixer._Action
+        clipAction(clip: AnimationClip, root?: any): AnimationAction;
+        existingAction(clip: AnimationClip, root?: any): AnimationAction;
         stopAllAction(clip: AnimationClip, root?: any): AnimationMixer;
         update(deltaTime: number): AnimationMixer;
         getRoot(): any;
         uncacheClip(clip: AnimationClip): void;
         uncacheRoot(root: any): void;
-        uncazcheAction(clip: AnimationClip, root?: any): void;
+        uncacheAction(clip: AnimationClip, root?: any): void;
     }
 
     export class AnimationObjectGroup {
@@ -367,6 +411,10 @@ declare namespace THREE {
         constructor(name: string, times: any[], values: any[]);
     }
 
+    export class ColorKeyframeTrack extends KeyframeTrack {
+        constructor(name: string, times: any[], values: any[], interpolation: InterpolationModes);
+    }
+
     export class NumberKeyframeTrack extends KeyframeTrack {
         constructor(name: string, times: any[], values: any[], interpolation: InterpolationModes);
     }
@@ -445,6 +493,14 @@ declare namespace THREE {
         constructor(left: number, right: number, top: number, bottom: number, near?: number, far?: number);
 
         zoom: number;
+        view: {
+          fullWidth: number,
+          fullHeight: number,
+          offsetX: number,
+          offsetY: number,
+          width: number,
+          height: number
+        };
 
         /**
          * Camera frustum left plane.
@@ -480,6 +536,8 @@ declare namespace THREE {
          * Updates the camera projection matrix. Must be called after change of parameters.
          */
         updateProjectionMatrix(): void;
+        setViewOffset(fullWidth: number, fullHeight: number, offsetX: number, offsetY: number, width: number, height: number): void;
+        clearViewOffset(): void;
         clone(): OrthographicCamera;
         copy(source: OrthographicCamera): OrthographicCamera;
         toJSON(meta?: any): any;
@@ -503,7 +561,6 @@ declare namespace THREE {
          */
         constructor(fov?: number, aspect?: number, near?: number, far?: number);
 
-        focalLength: number;
         zoom: number;
 
         /**
@@ -526,14 +583,23 @@ declare namespace THREE {
          */
         far: number;
 
-        /**
-         * Uses focal length (in mm) to estimate and set FOV 35mm (fullframe) camera is used if frame size is not specified.
-         * Formula based on http://www.bobatkins.com/photography/technical/field_of_view.html
-         * @param focalLength focal length
-         * @param frameHeight frame size. Default value is 24.
-         */
-        setLens(focalLength: number, frameHeight?: number): void;
+        focus: number;
+        view: {
+            fullWidth: number,
+            fullHeight: number,
+            offsetX: number,
+            offsetY: number,
+            width: number,
+            height: number
+        };
+        filmGauge: number;
+        filmAcces: number;
 
+        setFocalLength(focalLength: number): void;
+        getFocalLength(): number;
+        getEffectiveFOV(): number;
+        getFilmWidth(): number;
+        getFilmHeight(): number;
         /**
          * Sets an offset in a larger frustum. This is useful for multi-window or multi-monitor/multi-machine setups.
          * For example, if you have 3x2 monitors and each monitor is 1920x1080 and the monitors are in grid like this:
@@ -572,14 +638,17 @@ declare namespace THREE {
          * @param height height of subcamera
          */
         setViewOffset(fullWidth: number, fullHeight: number, x: number, y: number, width: number, height: number): void;
+        clearViewOffset(): void;
 
         /**
          * Updates the camera projection matrix. Must be called after change of parameters.
          */
         updateProjectionMatrix(): void;
         clone(): PerspectiveCamera;
-        copy(source: PerspectiveCamera): PerspectiveCamera;
         toJSON(meta?: any): any;
+
+        // deprecated
+        setLens(focalLength: number, frameHeight?: number): void;
     }
 
     export class StereoCamera extends Camera {
@@ -598,7 +667,7 @@ declare namespace THREE {
      * @see <a href="https://github.com/mrdoob/three.js/blob/master/src/core/BufferAttribute.js">src/core/BufferAttribute.js</a>
      */
     export class BufferAttribute {
-        constructor(array: ArrayLike<number>, itemSize: number); // array parameter should be TypedArray.
+        constructor(array: ArrayLike<number>, itemSize: number, normalized?: boolean); // array parameter should be TypedArray.
 
         uuid: string;
         array: ArrayLike<number>;
@@ -606,6 +675,7 @@ declare namespace THREE {
         dynamic: boolean;
         updateRange: {offset:number, count:number};
         version: number;
+        normalized: boolean;
         needsUpdate: boolean;
         count: number;
 
@@ -682,7 +752,7 @@ declare namespace THREE {
      *
      * @see <a href="https://github.com/mrdoob/three.js/blob/master/src/core/BufferGeometry.js">src/core/BufferGeometry.js</a>
      */
-    export class BufferGeometry {
+    export class BufferGeometry extends EventDispatcher {
         /**
          * This creates a new BufferGeometry. It also sets several properties to an default value.
          */
@@ -700,8 +770,6 @@ declare namespace THREE {
         index: BufferAttribute;
         attributes: BufferAttribute|InterleavedBufferAttribute[];
         morphAttributes: any;
-        drawcalls: any; // deprecated, use groups
-        offsets: any; // deprecated, use groups
         groups: {start: number, count: number, materialIndex?: number}[];
         boundingBox: Box3;
         boundingSphere: BoundingSphere;
@@ -773,17 +841,14 @@ declare namespace THREE {
          */
         dispose(): void;
 
-        // EventDispatcher mixins
-        addEventListener(type: string, listener: (event: Event) => void ): void;
-        hasEventListener(type: string, listener: (event: Event) => void): void;
-        removeEventListener(type: string, listener: (event: Event) => void): void;
-        dispatchEvent(event: { type: string; [attachment: string]: any; }): void;
+        // deprecated
+        drawcalls: any;
+        offsets: any;
 
-        addIndex(index: any): void; // deprecated, use setIndex()
-        addAttribute(name: any, array: any, itemSize: any): any; // deprecated
-        addDrawCall(start: any, count: any, indexOffset?: any): void; // deprecated, use addGroup()
-        clearDrawCalls(): void; // deprecated, use clearGroups()
-        computeFaceNormals(): void; // deprecated
+        addIndex(index: any): void;
+        addDrawCall(start: any, count: any, indexOffset?: any): void;
+        clearDrawCalls(): void;
+        addAttribute(name: any, array: any, itemSize: any): any;
     }
 
     /**
@@ -849,7 +914,7 @@ declare namespace THREE {
     /**
      * @see <a href="https://github.com/mrdoob/three.js/blob/master/src/core/DirectGeometry.js">src/core/DirectGeometry.js</a>
      */
-    export class DirectGeometry {
+    export class DirectGeometry extends EventDispatcher {
         constructor();
 
         id: number;
@@ -919,8 +984,6 @@ declare namespace THREE {
          */
         constructor();
 
-        apply(object: any): void;
-
         /**
          * Adds a listener to an event type.
          * @param type The type of the listener that gets removed.
@@ -947,6 +1010,9 @@ declare namespace THREE {
          * @param type The type of event that gets fired.
          */
         dispatchEvent(event: { type: string; [attachment: string]: any; }): void;
+
+        // deprecated
+        apply(target: any): void;
     }
 
     export interface Event {
@@ -1058,7 +1124,7 @@ declare namespace THREE {
      *
      * @see https://github.com/mrdoob/three.js/blob/master/src/core/Geometry.js
      */
-    export class Geometry {
+    export class Geometry extends EventDispatcher {
         constructor();
 
         /**
@@ -1277,7 +1343,7 @@ declare namespace THREE {
      */
     export class InstancedBufferAttribute extends BufferAttribute {
         constructor(data: ArrayLike<number>, itemSize: number, meshPerAttribute?: number);
-
+        
         meshPerAttribute: number;
 
         clone(): InstancedBufferAttribute;
@@ -1292,7 +1358,7 @@ declare namespace THREE {
 
         groups: {start:number, count:number, instances:number}[];
         maxInstancedCount: number;
-
+        
         addGroup(start: number, count: number, instances: number): void;
         clone(): InstancedBufferGeometry;
         copy(source: InstancedBufferGeometry): InstancedBufferGeometry;
@@ -1326,7 +1392,7 @@ declare namespace THREE {
      */
     export class InstancedInterleavedBuffer extends InterleavedBuffer {
         constructor(array: ArrayLike<number>, stride: number, meshPerAttribute?: number);
-
+        
         meshPerAttribute: number;
 
         clone(): InstancedInterleavedBuffer;
@@ -1337,13 +1403,15 @@ declare namespace THREE {
      * @see <a href="https://github.com/mrdoob/three.js/blob/master/src/core/InterleavedBufferAttribute.js">src/core/InterleavedBufferAttribute.js</a>
      */
     export class InterleavedBufferAttribute {
-        constructor(interleavedBuffer: InterleavedBuffer, itemSize: number, offset: number);
+        constructor(interleavedBuffer: InterleavedBuffer, itemSize: number, offset: number, normalized: boolean);
 
         uuid: string;
         data: InterleavedBuffer;
         itemSize: number;
         offset: number;
         count: number;
+        normalized: boolean;
+        array: any[];
 
         getX(index: number): number;
         setX(index: number, x: number): InterleavedBufferAttribute;
@@ -1365,7 +1433,7 @@ declare namespace THREE {
     /**
      * Base class for scene graph objects
      */
-    export class Object3D {
+    export class Object3D extends EventDispatcher {
         constructor();
 
         /**
@@ -1409,7 +1477,6 @@ declare namespace THREE {
          * Object's local rotation (Euler angles), in radians.
          */
         rotation: Euler;
-        eulerOrder: string; // deprecated, use rotation.order
 
         /**
          * Global rotation.
@@ -1424,11 +1491,6 @@ declare namespace THREE {
         modelViewMatrix: Matrix4;
 
         normalMatrix: Matrix3;
-
-        /**
-         * When this is set, then the rotationMatrix gets calculated every frame.
-         */
-        rotationAutoUpdate: boolean;
 
         /**
          * Local transform.
@@ -1539,7 +1601,6 @@ declare namespace THREE {
          * @param distance  The distance to translate.
          */
         translateOnAxis(axis: Vector3, distance: number): Object3D;
-        translate(distance: number, axis: Vector3): Object3D; // deprecated, use translateOnAxis(axis, distance)
 
         /**
          * Translates object along x axis by distance.
@@ -1636,13 +1697,10 @@ declare namespace THREE {
          */
         copy(source: Object3D, recursive?: boolean): Object3D;
 
-        // EventDispatcher mixins
-        addEventListener(type: string, listener: (event: Event) => void ): void;
-        hasEventListener(type: string, listener: (event: Event) => void): void;
-        removeEventListener(type: string, listener: (event: Event) => void): void;
-        dispatchEvent(event: { type: string; [attachment: string]: any; }): void;
-
-        getChildByName(name: string): Object3D; // deprecated, use getObjectByName()
+        // deprecated
+        eulerOrder: string;
+        getChildByName(name: string): Object3D;
+        translate(distance: number, axis: Vector3): Object3D;
     }
 
     export interface Intersection {
@@ -1672,7 +1730,7 @@ declare namespace THREE {
         params: RaycasterParameters;
         precision: number;
         linePrecision: number;
-
+        
         set(origin: Vector3, direction: Vector3): void;
         setFromCamera(coords: { x: number; y: number;}, camera: Camera ): void;
         intersectObject(object: Object3D, recursive?: boolean): Intersection[];
@@ -1692,9 +1750,9 @@ declare namespace THREE {
     }
 
     export class Font {
-        constructor(data: any);
+        constructor(jsondata: string);
 
-        data: any;
+        data: string;
 
         generateShapes(text: string, size: number, divisions: number): any[];
     }
@@ -1793,6 +1851,8 @@ declare namespace THREE {
         clone(recursive?: boolean): HemisphereLight;
     }
 
+    export class DirectionalLightShadow extends LightShadow {}
+
     export class HemisphereLight extends Light {
         constructor(skyColorHex?: number|string, groundColorHex?: number|string, intensity?: number);
 
@@ -1871,11 +1931,16 @@ declare namespace THREE {
         exponent: number;
 
         decay: number;
-        shadow: LightShadow;
+        shadow: SpotLightShadow;
         power: number;
+        penumbra: number;
 
         clone(recursive?: boolean): SpotLight;
         copy(source: PointLight): SpotLight;
+    }
+
+    export class SpotLightShadow extends LightShadow {
+        update(light: Light): void;
     }
 
     // Loaders //////////////////////////////////////////////////////////////////////////////////
@@ -1943,17 +2008,18 @@ declare namespace THREE {
         withCredentials: boolean;
 
         load(url: string, onLoad?: (responseText: string) => void, onProgress?: (event: any) => void, onError?: (event: any) => void): any;
-        setPath(path: string): void;
-        setResponseType(responseType: string): void;
-        setWithCredentials(withCredentials: boolean): void;
+        setPath(path: string): XHRLoader;
+        setResponseType(responseType: string): XHRLoader;
+        setWithCredentials(withCredentials: boolean): XHRLoader;
     }
 
     export class FontLoader {
-        constructor(manager?: LoadingManager);
+        constructor(manager?: LoadingManager);F
 
         manager: LoadingManager;
 
         load(url: string, onLoad?: (responseText: string) => void, onProgress?: (event: any) => void, onError?: (event: any) => void): void;
+        parse(json: string): Font;
     }
 
     /**
@@ -1972,8 +2038,8 @@ declare namespace THREE {
          * @param url
          */
         load(url: string, onLoad?: (image: HTMLImageElement) => void, onProgress?: (event: any) => void, onError?: (event: any) => void): HTMLImageElement;
-        setCrossOrigin(crossOrigin: string): void;
-        setPath(value: any): void;
+        setCrossOrigin(crossOrigin: string): ImageLoader;
+        setPath(value: any): ImageLoader;
     }
 
     /**
@@ -1984,7 +2050,6 @@ declare namespace THREE {
 
         manager: LoadingManager;
         withCredentials: boolean;
-        statusDomElement: HTMLElement; // readonly and deprecated
 
         load(url: string, onLoad?: (geometry: Geometry, materials: Material[]) => void, onProgress?: (event: any) => void, onError?: (event: any) => void): void;
         setTexturePath( value: string ): void;
@@ -2081,8 +2146,8 @@ declare namespace THREE {
          * @param url
          */
         load(url: string, onLoad?: (texture: Texture) => void): Texture;
-        setCrossOrigin(crossOrigin: string): void;
-        setPath(path: string): void;
+        setCrossOrigin(crossOrigin: string): TextureLoader;
+        setPath(path: string): TextureLoader;
     }
 
     export class CubeTextureLoader {
@@ -2093,8 +2158,8 @@ declare namespace THREE {
         path: string;
 
         load(urls: Array<string>, onLoad?: (texture: CubeTexture) => void, onProgress?: (event: any) => void, onError?: (event: any) => void): void;
-        setCrossOrigin(crossOrigin: string): void;
-        setPath(path: string): void;
+        setCrossOrigin(crossOrigin: string): CubeTextureLoader;
+        setPath(path: string): CubeTextureLoader;
     }
 
     export class BinaryTextureLoader {
@@ -2113,7 +2178,13 @@ declare namespace THREE {
         path: string;
 
         load(url: string, onLoad: (texture: CompressedTexture) => void, onProgress?: (event: any) => void, onError?: (event: any) => void): void;
-        setPath(path: string): void;
+        setPath(path: string): CompressedTextureLoader;
+    }
+
+    export class AudioLoader {
+        constructor(manager?: LoadingManager);
+
+        load(url: string, onLoad: Function, onPrgress: Function, onError: Function): void;
     }
 
     export namespace Cache {
@@ -2153,12 +2224,16 @@ declare namespace THREE {
         premultipliedAlpha?: boolean;
         overdraw?: number;
         visible?: boolean;
+        fog?: boolean;
+        lights?: boolean;
+        shading?: Shading;
+        vertexColors?: Colors;
     }
 
     /**
      * Materials describe the appearance of objects. They are defined in a (mostly) renderer-independent way, so you don't have to rewrite materials if you decide to use a different renderer.
      */
-    export class Material {
+    export class Material extends EventDispatcher {
         constructor();
 
         /**
@@ -2229,6 +2304,9 @@ declare namespace THREE {
          */
         depthWrite: boolean;
 
+        clippingPlanes: any;
+        clipShadows: boolean;
+
         colorWrite: boolean;
 
         precision: any;
@@ -2271,7 +2349,10 @@ declare namespace THREE {
          */
         needsUpdate: boolean;
 
-        warpRGB: Color; // deprecated, returns a new Color intance
+        fog: boolean;
+        lights: boolean;
+        shading: Shading;
+        vertexColors: Colors;
 
         setValues(parameters: MaterialParameters): void;
         toJSON(meta?: any): any;
@@ -2280,11 +2361,8 @@ declare namespace THREE {
         update(): void;
         dispose(): void;
 
-        // EventDispatcher mixins
-        addEventListener(type: string, listener: (event: Event) => void ): void;
-        hasEventListener(type: string, listener: (event: Event) => void): void;
-        removeEventListener(type: string, listener: (event: Event) => void): void;
-        dispatchEvent(event: { type: string; [attachment: string]: any; }): void;
+        // deprecated
+        warpRGB: Color;
     }
 
     export interface LineBasicMaterialParameters extends MaterialParameters {
@@ -2292,9 +2370,6 @@ declare namespace THREE {
         linewidth?: number;
         linecap?: string;
         linejoin?: string;
-        blending?: Blending;
-        vertexColors?: Colors;
-        fog?: boolean;
     }
 
     export class LineBasicMaterial extends Material {
@@ -2304,9 +2379,6 @@ declare namespace THREE {
         linewidth: number;
         linecap: string;
         linejoin: string;
-        blending: Blending;
-        vertexColors: Colors;
-        fog: boolean;
 
         setValues(parameters: LineBasicMaterialParameters): void;
         clone(): LineBasicMaterial;
@@ -2319,9 +2391,6 @@ declare namespace THREE {
         scale?: number;
         dashSize?: number;
         gapSize?: number;
-        blending?: Blending;
-        vertexColors?: Colors;
-        fog?: boolean;
     }
 
     export class LineDashedMaterial extends Material {
@@ -2332,9 +2401,6 @@ declare namespace THREE {
         scale: number;
         dashSize: number;
         gapSize: number;
-        blending: Blending;
-        vertexColors: Colors;
-        fog: boolean;
 
         setValues(parameters: LineDashedMaterialParameters): void;
         clone(): LineDashedMaterial;
@@ -2357,15 +2423,12 @@ declare namespace THREE {
         reflectivity?: number;
         refractionRatio?: number;
         shading?: Shading;
-        blending?: Blending;
         wireframe?: boolean;
         wireframeLinewidth?: number;
         wireframeLinecap?: string;
         wireframeLinejoin?: string;
-        vertexColors?: Colors;
         skinning?: boolean;
         morphTargets?: boolean;
-        fog?: boolean;
     }
 
     export class MeshBasicMaterial extends Material {
@@ -2381,14 +2444,11 @@ declare namespace THREE {
         combine: Combine;
         reflectivity: number;
         refractionRatio: number;
-        fog: boolean;
         shading: Shading;
-        blending: Blending;
         wireframe: boolean;
         wireframeLinewidth: number;
         wireframeLinecap: string;
         wireframeLinejoin: string;
-        vertexColors: Colors;
         skinning: boolean;
         morphTargets: boolean;
 
@@ -2429,13 +2489,10 @@ declare namespace THREE {
         combine?: Combine;
         reflectivity?: number;
         refractionRatio?: number;
-        fog?: boolean;
-        blending?: Blending;
         wireframe?: boolean;
         wireframeLinewidth?: number;
         wireframeLinecap?: string;
         wireframeLinejoin?: string;
-        vertexColors?: Colors;
         skinning?: boolean;
         morphTargets?: boolean;
         morphNormals?: boolean;
@@ -2445,7 +2502,7 @@ declare namespace THREE {
         constructor(parameters?: MeshLambertMaterialParameters);
 
         color: Color;
-        emissive: Color;
+        emissive: number|string;
         emissiveIntensity: number;
         emissiveMap: Texture;
         map: Texture;
@@ -2459,13 +2516,10 @@ declare namespace THREE {
         combine: Combine;
         reflectivity: number;
         refractionRatio: number;
-        fog: boolean;
-        blending: Blending;
         wireframe: boolean;
         wireframeLinewidth: number;
         wireframeLinecap: string;
         wireframeLinejoin: string;
-        vertexColors: Colors;
         skinning: boolean;
         morphTargets: boolean;
         morphNormals: boolean;
@@ -2500,20 +2554,17 @@ declare namespace THREE {
         envMap?: Texture;
         envMapIntensity?: number;
         refractionRatio?: number;
-        shading?: Shading;
-        blending?: Blending;
         wireframe?: boolean;
         wireframeLinewidth?: number;
-        vertexColors?: Colors;
         skinning?: boolean;
         morphTargets?: boolean;
         morphNormals?: boolean;
-        fog?: boolean;
     }
 
     export class MeshStandardMaterial extends Material {
         constructor(parameters?: MeshStandardMaterialParameters);
 
+        defines: any;
         color: Color;
         roughness: number;
         metalness: number;
@@ -2538,38 +2589,15 @@ declare namespace THREE {
         envMap: Texture;
         envMapIntensity: number;
         refractionRatio: number;
-        shading: Shading;
-        blending: Blending;
         wireframe: boolean;
         wireframeLinewidth: number;
-        vertexColors: Colors;
         skinning: boolean;
         morphTargets: boolean;
         morphNormals: boolean;
-        fog: boolean;
 
         setValues(parameters: MeshStandardMaterialParameters): void;
         clone(): MeshStandardMaterial;
         copy(source: MeshStandardMaterial): MeshStandardMaterial;
-    }
-
-    export interface MeshPhysicalMaterialParameters extends MeshStandardMaterialParameters {
-        reflectivity?: number;
-        clearCoat?: number;
-        clearCoatRoughness?: number;
-    }
-
-    export class MeshPhysicalMaterial extends MeshStandardMaterial {
-        constructor(parameters?: MeshPhysicalMaterialParameters);
-
-        defines: any;
-        reflectivity: number;
-        clearCoat: number;
-        clearCoatRoughness: number;
-
-        setValues(parameters: MeshPhysicalMaterialParameters): void;
-        clone(): MeshPhysicalMaterial;
-        copy(source: MeshPhysicalMaterial): MeshPhysicalMaterial;
     }
 
     export interface MeshNormalMaterialParameters extends MaterialParameters {
@@ -2619,17 +2647,13 @@ declare namespace THREE {
         combine?: Combine;
         reflectivity?: number;
         refractionRatio?: number;
-        shading?: Shading;
-        blending?: Blending;
         wireframe?: boolean;
         wireframeLinewidth?: number;
         wireframeLinecap?: string;
         wireframeLinejoin?: string;
-        vertexColors?: Colors;
         skinning?: boolean;
         morphTargets?: boolean;
         morphNormals?: boolean;
-        fog?: boolean;
     }
 
     export class MeshPhongMaterial extends Material {
@@ -2659,14 +2683,10 @@ declare namespace THREE {
         combine: Combine;
         reflectivity: number;
         refractionRatio: number;
-        fog: boolean;
-        shading: Shading;
-        blending: Blending;
         wireframe: boolean;
         wireframeLinewidth: number;
         wireframeLinecap: string;
         wireframeLinejoin: string;
-        vertexColors: Colors;
         skinning: boolean;
         morphTargets: boolean;
         morphNormals: boolean;
@@ -2675,6 +2695,21 @@ declare namespace THREE {
         setValues(parameters: MeshPhongMaterialParameters): void;
         clone(): MeshPhongMaterial;
         copy(source: MeshPhongMaterial): MeshPhongMaterial;
+    }
+
+    export interface MeshPhysicalMaterialParameters extends MeshStandardMaterialParameters {
+        reflectivity?: number;
+        clearCoat?: number;
+        clearCoatRoughness?: number;
+    }
+
+    export class MeshPhysicalMaterial extends MeshStandardMaterial {
+        constructors(parameters: MeshPhysicalMaterialParameters);
+
+        defines: any;
+        reflectivity: number;
+        clearCoat: number;
+        clearCoatRoughness: number;
     }
 
     // MultiMaterial does not inherit the Material class in the original code. However, it should treat as Material class.
@@ -2695,9 +2730,6 @@ declare namespace THREE {
         map?: Texture;
         size?: number;
         sizeAttenuation?: boolean;
-        blending?: Blending;
-        vertexColors?: Colors;
-        fog?: boolean;
     }
 
     export class PointsMaterial extends Material {
@@ -2707,31 +2739,26 @@ declare namespace THREE {
         map: Texture;
         size: number;
         sizeAttenuation: boolean;
-        blending: Blending;
-        vertexColors: boolean;
-        fog: boolean;
 
         setValues(parameters: PointsMaterialParameters): void;
         clone(): PointsMaterial;
         copy(source: PointsMaterial): PointsMaterial;
     }
 
-    export class PointCloudMaterial extends PointsMaterial {} // deprecated, use PointsMaterial
-    export class ParticleBasicMaterial extends PointsMaterial {} // deprecated, use PointsMaterial
-    export class ParticleSystemMaterial extends PointsMaterial {} // deprecated, use PointsMaterial
+    export class PointCloudMaterial extends PointsMaterial {} // deprecated
+    export class ParticleBasicMaterial extends PointsMaterial {} // deprecated
+    export class ParticleSystemMaterial extends PointsMaterial {} // deprecated
 
     export interface ShaderMaterialParameters extends MaterialParameters {
         defines?: any;
-        uniforms?: any;
+        uniforms?: any; 
         vertexShader?: string;
         fragmentShader?: string;
-        shading?: Shading;
         lineWidth?: number;
         wireframe?: boolean;
         wireframeLinewidth?: number;
-        fog?: boolean;
         lights?: boolean;
-        vertexColors?: Colors;
+        clipping?: boolean;
         skinning?: boolean;
         morphTargets?: boolean;
         morphNormals?: boolean;
@@ -2741,16 +2768,14 @@ declare namespace THREE {
         constructor(parameters?: ShaderMaterialParameters);
 
         defines: any;
-        uniforms: any;
+        uniforms: any; // type should be  { [uniform: string]: { value: any }; };    but gives "Index signature is missing in type" error during compilation
         vertexShader: string;
         fragmentShader: string;
-        shading: Shading;
         linewidth: number;
         wireframe: boolean;
         wireframeLinewidth: number;
-        fog: boolean;
         lights: boolean;
-        vertexColors: Colors;
+        clipping: boolean;
         skinning: boolean;
         morphTargets: boolean;
         morphNormals: boolean;
@@ -2773,7 +2798,6 @@ declare namespace THREE {
         color?: number|string;
         map?: Texture;
         rotation?: number;
-        fog?: boolean;
     }
 
     export class SpriteMaterial extends Material {
@@ -2782,11 +2806,14 @@ declare namespace THREE {
         color: Color;
         map: Texture;
         rotation: number;
-        fog: boolean;
 
         setValues(parameters: SpriteMaterialParameters): void;
         clone(): SpriteMaterial;
         copy(source: SpriteMaterial): SpriteMaterial;
+    }
+
+    export class ShadowMaterial extends ShaderMaterial {
+        constructor(parameters?: ShaderMaterialParameters);
     }
 
     // Math //////////////////////////////////////////////////////////////////////////////////
@@ -2803,7 +2830,6 @@ declare namespace THREE {
         clone(): Box2;
         copy(box: Box2): Box2;
         makeEmpty(): Box2;
-        empty(): any; // deprecated, use isEmpty()
         isEmpty(): boolean;
         center(optionalTarget?: Vector2): Vector2;
         size(optionalTarget?: Vector2): Vector2;
@@ -2821,6 +2847,7 @@ declare namespace THREE {
         translate(offset: Vector2): Box2;
         equals(box: Box2): boolean;
 
+        empty(): any; // deprecated, use isEmpty()
         isIntersectionBox(b: any): any; // deprecated, use intersectsBox()
     }
 
@@ -2858,7 +2885,7 @@ declare namespace THREE {
         applyMatrix4(matrix: Matrix4): Box3;
         translate(offset: Vector3): Box3;
         equals(box: Box3): boolean;
-
+        
         empty(): any; // deprecated, use isEmpty()
         isIntersectionBox(b: any): any; // deprecated, use intersectsBox()
         isIntersectionSphere(s: any): any; // deprecated, use intersectsSphere()
@@ -2985,6 +3012,7 @@ declare namespace THREE {
         add(color: Color): Color;
         addColors(color1: Color, color2: Color): Color;
         addScalar(s: number): Color;
+        sub(color: Color): Color;
         multiply(color: Color): Color;
         multiplyScalar(s: number): Color;
         lerp(color: Color, alpha: number): Color;
@@ -3145,7 +3173,7 @@ declare namespace THREE {
 
     export class Euler {
         constructor(x?: number, y?: number, z?: number, order?: string);
-
+        
         x: number;
         y: number;
         z: number;
@@ -3185,6 +3213,7 @@ declare namespace THREE {
         copy(frustum: Frustum): Frustum;
         setFromMatrix(m: Matrix4): Frustum;
         intersectsObject(object: Object3D): boolean;
+        intersectsObject(sprite: Sprite): boolean;
         intersectsSphere(sphere: Sphere): boolean;
         intersectsBox(box: Box3): boolean;
         containsPoint(point: Vector3): boolean;
@@ -3215,6 +3244,9 @@ declare namespace THREE {
      * @see <a href="https://github.com/mrdoob/three.js/blob/master/src/math/Math.js">src/math/Math.js</a>
      */
     export namespace Math {
+        export const DEG2RAD: number;
+        export const RAD2DEG: number;
+
         export function generateUUID(): string;
 
         /**
@@ -3335,11 +3367,6 @@ declare namespace THREE {
         clone(): Matrix3;
         copy(m: Matrix3): Matrix3;
         setFromMatix4(m: Matrix4): Matrix3;
-
-        /**
-         * @deprecated Use applyToVector3Array()
-         */
-        multiplyVector3Array(a: any): any;
         applyToVector3Array(array: number[], offset?: number, length?: number): number[];
         applyToBuffer(buffer: BufferAttribute, offset?: number, length?: number): BufferAttribute;
         multiplyScalar(s: number): Matrix3;
@@ -3347,15 +3374,9 @@ declare namespace THREE {
         getInverse(matrix: Matrix3, throwOnDegenerate?: boolean): Matrix3;
 
         /**
-         * @deprecated No longer takes a Matrix4 argument.
-         */
-        getInverse(matrix: Matrix4, throwOnDegenerate?: boolean): Matrix3;
-
-        /**
          * Transposes this matrix in place.
          */
         transpose(): Matrix3;
-        flattenToArrayOffset(array: number[], offset: number): number[];
         getNormalMatrix(matrix4: Matrix4): Matrix3;
 
         /**
@@ -3365,10 +3386,11 @@ declare namespace THREE {
         fromArray(array: number[]): Matrix3;
         toArray(): number[];
 
-        /**
-         * @deprecated Use vector.applyMatrix3( matrix )
-         */
+        // deprecated
         multiplyVector3(vector: Vector3): any;
+        multiplyVector3Array(a: any): any;
+        getInverse(matrix: Matrix4, throwOnDegenerate?: boolean): Matrix3;
+        flattenToArrayOffset(array: number[], offset: number): number[];
     }
 
     /**
@@ -3408,7 +3430,6 @@ declare namespace THREE {
         identity(): Matrix4;
         clone(): Matrix4;
         copy(m: Matrix4): Matrix4;
-        extractPosition(m: Matrix4): Matrix4; // deprecated, use copyPosition()
         copyPosition(m: Matrix4): Matrix4;
         extractBasis( xAxis: Vector3, yAxis: Vector3, zAxis: Vector3): Matrix4;
         makeBasis( xAxis: Vector3, yAxis: Vector3, zAxis: Vector3): Matrix4;
@@ -3418,7 +3439,6 @@ declare namespace THREE {
          */
         extractRotation(m: Matrix4): Matrix4;
         makeRotationFromEuler(euler: Euler): Matrix4;
-        setRotationFromQuaternion(q: Quaternion): Matrix4; // deprecated, use makeRotationFromQuaternion()
         makeRotationFromQuaternion(q: Quaternion): Matrix4;
         /**
          * Constructs a rotation matrix, looking from eye towards center with defined up vector.
@@ -3429,6 +3449,8 @@ declare namespace THREE {
          * Multiplies this matrix by m.
          */
         multiply(m: Matrix4): Matrix4;
+
+        premultiply(m: Matrix4): Matrix4;
 
         /**
          * Sets this matrix to a x b.
@@ -3445,7 +3467,6 @@ declare namespace THREE {
          * Multiplies this matrix by s.
          */
         multiplyScalar(s: number): Matrix4;
-        multiplyVector3Array(array: number[]): number[]; // deprecated, use applyToVector3Array()
         applyToVector3Array(array: number[], offset?: number, length?: number): number[];
         applyToBuffer( buffer: BufferAttribute, offset?: number, length?: number): BufferAttribute;
         /**
@@ -3459,16 +3480,13 @@ declare namespace THREE {
          */
         transpose(): Matrix4;
 
-        /**
-         * Flattens this matrix into supplied flat array starting from offset position in the array.
-         */
-        flattenToArrayOffset(array: number[], offset: number): number[];
+
 
         /**
          * Sets the position component for this matrix from vector v.
          */
         setPosition(v: Vector3): Matrix4;
-
+        
 
         /**
          * Sets this matrix to the inverse of matrix m.
@@ -3551,26 +3569,15 @@ declare namespace THREE {
         fromArray(array: number[]): Matrix4;
         toArray(): number[];
 
-        /**
-         * @deprecated Use Vector3.setFromMatrixPosition( matrix )
-         */
-        getPosition(): any;
-        /**
-         * @deprecated Use Vector3.applyMatrix4( matrix ) or Vector3.applyProjection( matrix )
-         */
+        // deprecated
+        extractPosition(m: Matrix4): Matrix4;
+        setRotationFromQuaternion(q: Quaternion): Matrix4;
         multiplyVector3(v: any): any;
-        /**
-         * @deprecated Use Vector3.applyMatrix4( matrix )
-         */
         multiplyVector4(v: any): any;
-        /**
-         * @deprecated Use Vector3.transformDirection( matrix )
-         */
+        multiplyVector3Array(array: number[]): number[];
         rotateAxis(v: any): void;
-        /**
-         * @deprecated Use Vector3.applyMatrix( matrix )
-         */
         crossVector(v: any): void;
+        flattenToArrayOffset(array: number[], offset: number): number[];
     }
 
     export class Plane {
@@ -3599,13 +3606,14 @@ declare namespace THREE {
         translate(offset: Vector3): Plane;
         equals(plane: Plane): boolean;
 
-        isIntersectionLine(l: any): any; // deprecated, use instersectsLine()
+        // deprecated
+        isIntersectionLine(l: any): any;
     }
 
     export class Spherical {
         constructor(radius?: number, phi?: number, theta?: number);
 
-        set(radius: number, phi: number, theta: number): void;
+        set(radius: number, phi: number, theta: number): Spherical;
         clone(): Spherical;
         copy(other: Spherical): Spherical;
         makeSafe(): void;
@@ -3690,6 +3698,7 @@ declare namespace THREE {
          * Multiplies this quaternion by b.
          */
         multiply(q: Quaternion): Quaternion;
+        premultiply(q: Quaternion): Quaternion;
 
         /**
          * Sets this quaternion to a x b
@@ -3697,7 +3706,6 @@ declare namespace THREE {
          */
         multiplyQuaternions(a: Quaternion, b: Quaternion): Quaternion;
 
-        multiplyVector3(v: any): any; // deprecated, use vector.applyQuaternion( quaternion )
 
         slerp(qb: Quaternion, t: number): Quaternion;
         equals(v: Quaternion): boolean;
@@ -3714,8 +3722,11 @@ declare namespace THREE {
          * Adapted from http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/slerp/.
          */
         static slerp(qa: Quaternion, qb: Quaternion, qm: Quaternion, t: number): Quaternion;
-
+        
         static slerpFlat(dst: number[], dstOffset: number, src0: number[], srcOffset: number, src1: number[], stcOffset1: number, t: number): Quaternion;
+
+        // deprecated
+        multiplyVector3(v: any): any;
     }
 
     export class Ray {
@@ -3744,10 +3755,11 @@ declare namespace THREE {
         intersectTriangle(a: Vector3, b: Vector3, c: Vector3, backfaceCulling: boolean, optionalTarget?: Vector3): Vector3;
         applyMatrix4(matrix4: Matrix4): Ray;
         equals(ray: Ray): boolean;
-
-        isIntersectionSphere(s: any): any; // deprecated, use intersectsSphere()
-        isIntersectionPlane(p: any): any; // deprecated, use intersectsPlane()
-        isIntersectionBox(b: any): any; // deprecated, use intersectsBox()
+        
+        // deprecated
+        isIntersectionBox(b: any): any;
+        isIntersectionPlane(p: any): any;
+        isIntersectionSphere(s: any): any;
     }
 
     export class Sphere {
@@ -3843,6 +3855,7 @@ declare namespace THREE {
         plane(optionalTarget?: Vector3): Plane;
         barycoordFromPoint(point: Vector3, optionalTarget?: Vector3): Vector3;
         containsPoint(point: Vector3): boolean;
+        closestPointToPoint(): Vector3;
         equals(triangle: Triangle): boolean;
 
         static normal(a: Vector3, b: Vector3, c: Vector3, optionalTarget?: Vector3): Vector3;
@@ -4094,6 +4107,7 @@ declare namespace THREE {
          * Computes squared distance of this vector to v.
          */
         distanceToSquared(v: Vector2): number;
+        distanceToManhattan(v: Vector2): number;
 
         /**
          * Normalizes this vector and multiplies it by l.
@@ -4210,7 +4224,7 @@ declare namespace THREE {
         applyMatrix4(m: Matrix4): Vector3;
         applyProjection(m: Matrix4): Vector3;
         applyQuaternion(q: Quaternion): Vector3;
-        project(camera: Camera): Vector3;
+        project(camrea: Camera): Vector3;
         unproject(camera: Camera): Vector3;
         transformDirection(m: Matrix4): Vector3;
         divide(v: Vector3): Vector3;
@@ -4292,15 +4306,12 @@ declare namespace THREE {
          * Computes squared distance of this vector to v.
          */
         distanceToSquared(v: Vector3): number;
+        distanceToManhattan(v: Vector3): number;
 
         setFromSpherical(s: Spherical): Matrix3;
-        getPositionFromMatrix(m: Matrix4): Vector3; // deprecated, use setFromMatrixPosition()
         setFromMatrixPosition(m: Matrix4): Vector3;
-        getScaleFromMatrix(m: Matrix4): Vector3; // deprecated, use setFromMatrixScale()
         setFromMatrixScale(m: Matrix4): Vector3;
-        getColumnFromMatrixColumn(index: number, matrix: Matrix4): Vector3; // deprecated, use setFromMatrixColumn()
         setFromMatrixColumn(matrix: Matrix4, index: number): Vector3;
-        setFromMatrixColumn(index: number, matrix: Matrix4): Vector3; // deprecated, now expects ( matrix, index )
 
         /**
          * Checks for strict equality of this vector and v.
@@ -4308,13 +4319,16 @@ declare namespace THREE {
         equals(v: Vector3): boolean;
 
         fromArray(xyz: number[], offset?: number): Vector3;
-
         toArray(xyz?: number[], offset?: number): number[];
-
         fromAttribute( attribute: BufferAttribute, index: number, offset?: number): Vector3;
+
+        // deprecated
+        getPositionFromMatrix(m: Matrix4): Vector3;
+        getScaleFromMatrix(m: Matrix4): Vector3;
+        getColumnFromMatrix(index: number, matrix: Matrix4): Vector3;
     }
 
-    export class Vertex extends Vector3 {} // deprecated, use Vector3
+    export class Vertex extends Vector3 {} // deprecated
 
     /**
      * 4D vector.
@@ -4338,7 +4352,7 @@ declare namespace THREE {
          * Sets all values of this vector.
          */
         setScalar(scalar: number): Vector4;
-
+        
         /**
          * Sets X component of this vector.
          */
@@ -4491,7 +4505,7 @@ declare namespace THREE {
 
         interpolate_(i1: number, t0: number, t: number, t1: number): any;
     }
-
+    
     export class DiscreteInterpolant extends Interpolant {
         constructor(parameterPositions: any, samplesValues: any, sampleSize: number, resultBuffer?: any);
 
@@ -4529,16 +4543,17 @@ declare namespace THREE {
         constructor();
 
         levels: any[];
-        objects: any[]; // deprecated, use .levels
 
         addLevel(object: Object3D, distance?: number): void;
         getObjectForDistance(distance: number): Object3D;
         raycast(raycaster: Raycaster, intersects: any): void;
         update(camera: Camera): void;
-
         clone(): LOD;
         copy(source: LOD): LOD;
         toJSON(meta: any): any;
+
+        // deprecated
+        objects: any[];
     }
 
     export interface LensFlareProperty {
@@ -4584,6 +4599,9 @@ declare namespace THREE {
         copy(source: Line): Line;
     }
 
+    export const LineStrip: number; // deprecated
+    export const LinePieces: number; // deprecated
+
     export class LineSegments extends Line {
         constructor(
             geometry?: Geometry | BufferGeometry,
@@ -4596,8 +4614,6 @@ declare namespace THREE {
     }
 
     enum LineMode {}
-    var LineStrip: LineMode; // deprecated
-    var LinePieces: LineMode; // deprecated
 
     export class Mesh extends Object3D {
         constructor(geometry?: Geometry, material?: Material);
@@ -4646,8 +4662,8 @@ declare namespace THREE {
         copy(source: Points): Points;
     }
 
-    export class PointCloud extends Points {} // deprecated, use Points
-    export class ParticleSystem extends Points {} // deprecated, use Points
+    export class PointCloud extends Points {} // deprecated
+    export class ParticleSystem extends Points {} // deprecated
 
     export class Skeleton {
         constructor(bones: Bone[], boneInverses?: Matrix4[], useVertexTexture?: boolean);
@@ -4700,15 +4716,16 @@ declare namespace THREE {
         copy(source: Sprite): Sprite;
     }
 
-    export class Particle extends Sprite {} // deprecated, use Sprite
+    export class Particle extends Sprite {} // deprecated
 
 
     // Renderers //////////////////////////////////////////////////////////////////////////////////
 
     export interface Renderer {
+        domElement: HTMLCanvasElement;
+
         render(scene: Scene, camera: Camera): void;
         setSize(width:number, height:number, updateStyle?:boolean): void;
-        domElement: HTMLCanvasElement;
     }
 
     export interface WebGLRendererParameters {
@@ -4814,9 +4831,10 @@ declare namespace THREE {
          */
         sortObjects: boolean;
 
-        extensions: WebGLExtensions;
+        clippingPlanes: any[];
+        localClippingEnabled: boolean;
 
-        gammaFactor: number; // deprecated
+        extensions: WebGLExtensions;
 
         /**
          * Default is false.
@@ -4849,11 +4867,6 @@ declare namespace THREE {
         maxMorphNormals: number;
 
         /**
-         * Default is true.
-         */
-        autoScaleCubemaps: boolean;
-
-        /**
          * An object with a series of statistical information about the graphics board memory and the rendering process. Useful for debugging or just for the sake of curiosity. The object contains the following fields:
          */
         info: {
@@ -4871,15 +4884,13 @@ declare namespace THREE {
         };
 
         shadowMap: WebGLShadowMap;
-        shadowMapType: ShadowMapType; // deprecated, use shadowMap.type
-        shadowMapEnabled: boolean; // deprecated, use shadowMap.enabled
-        shadowMapCullFace: CullFace; // deprecated, use shadowMap.cullFace
 
         pixelRation: number;
 
         capabilities: WebGLCapabilities;
         properties: WebGLProperties;
         state: WebGLState;
+        allocTextureUnit: any;
 
         /**
          * Return the WebGL context.
@@ -4892,7 +4903,7 @@ declare namespace THREE {
         getPrecision(): string;
         getPixelRatio(): number;
         setPixelRatio(value: number): void;
-
+        
         getSize(): { width: number; height: number; };
 
         /**
@@ -4926,12 +4937,12 @@ declare namespace THREE {
         setClearColor(color: Color, alpha?: number): void;
         setClearColor(color: string, alpha?: number): void;
         setClearColor(color: number, alpha?: number): void;
-
+        
         /**
          * Returns a float with the current clear alpha. Ranges from 0 to 1.
          */
         getClearAlpha(): number;
-
+        
         setClearAlpha(alpha: number): void;
 
         /**
@@ -4971,24 +4982,31 @@ declare namespace THREE {
          * @param frontFace "ccw" or "cw
          */
         setFaceCulling(cullFace?: CullFace, frontFace?: FrontFaceDirection): void;
-        setTexture(texture: Texture, slot: number): void;
+        setTexture(texture: Texture, slot: number): void; // deprecated
+        setTexture2D(texture: Texture, slot: number): void;
+        setTextureCube(texture: Texture, slot: number): void;
         getCurrentRenderTarget(): RenderTarget;
         setRenderTarget(renderTarget: RenderTarget): void;
         readRenderTargetPixels( renderTarget: RenderTarget, x: number, y: number, width: number, height: number, buffer: any ): void;
 
-        supportsFloatTextures(): any; // deprecated
-        supportsHalfFloatTextures(): any; // deprecated
-        supportsStandardDerivatives(): any; // deprecated
-        supportsCompressedTextureS3TC(): any; // deprecated
-        supportsCompressedTexturePVRTC(): any; // deprecated
-        supportsBlendMinMax(): any; // deprecated
-        supportsVertexTextures(): any; // deprecated
-        supportsInstancedArrays(): any; // deprecated
-        enableScissorTest(boolean: any): any; // deprecated
+        // deprecated
+        gammaFactor: number;
+        shadowMapEnabled: boolean;
+        shadowMapType: ShadowMapType;
+        shadowMapCullFace: CullFace;
+
+        supportsFloatTextures(): any;
+        supportsHalfFloatTextures(): any;
+        supportsStandardDerivatives(): any;
+        supportsCompressedTextureS3TC(): any;
+        supportsCompressedTexturePVRTC(): any;
+        supportsBlendMinMax(): any;
+        supportsVertexTextures(): any;
+        supportsInstancedArrays(): any;
+        enableScissorTest(boolean: any): any;
     }
 
-    export interface RenderTarget {
-    }
+    export interface RenderTarget {} // not defined in the code, used in LightShadow and WebGRenderer classes
 
     export interface WebGLRenderTargetOptions {
         wrapS?: Wrapping;
@@ -5002,7 +5020,7 @@ declare namespace THREE {
         stencilBuffer?: boolean; // true;
     }
 
-    export class WebGLRenderTarget implements RenderTarget {
+    export class WebGLRenderTarget extends EventDispatcher {
         constructor(width: number, height: number, options?: WebGLRenderTargetOptions);
 
         uuid: string;
@@ -5014,6 +5032,7 @@ declare namespace THREE {
         texture: Texture;
         depthBuffer: boolean;
         stencilBuffer: boolean;
+        depthTexture: Texture;
         wrapS: any; // deprecated, use texture.wrapS
         wrapT: any; // deprecated, use texture.wrapT
         magFilter: any; // deprecated, use texture.magFilter
@@ -5029,12 +5048,6 @@ declare namespace THREE {
         clone(): WebGLRenderTarget;
         copy(source: WebGLRenderTarget): WebGLRenderTarget;
         dispose(): void;
-
-        // EventDispatcher mixins
-        addEventListener(type: string, listener: (event: Event) => void ): void;
-        hasEventListener(type: string, listener: (event: Event) => void): void;
-        removeEventListener(type: string, listener: (event: Event) => void): void;
-        dispatchEvent(event: { type: string; [attachment: string]: any; }): void;
     }
 
     export class WebGLRenderTargetCube extends WebGLRenderTarget {
@@ -5057,6 +5070,10 @@ declare namespace THREE {
         beginnormal_vertex: string;
         bsdfs: string;
         bumpmap_pars_fragment: string;
+        clipping_planes_fragment: string;
+        clipping_planes_pars_fragment: string;
+        clipping_planes_pars_vertex: string;
+        clipping_planes_vertex: string;
         color_fragment: string;
         color_pars_fragment: string;
         color_pars_vertex: string;
@@ -5068,8 +5085,6 @@ declare namespace THREE {
         defaultnormal_vertex: string;
         depth_frag: string;
         depth_vert: string;
-        depthRGBA_frag: string;
-        depthRGBA_vert: string;
         distanceRGBA_frag: string;
         distanceRGBA_vert: string;
         displacementmap_vertex: string;
@@ -5094,10 +5109,8 @@ declare namespace THREE {
         lights_pars: string;
         lights_phong_fragment: string;
         lights_phong_pars_fragment: string;
-        lights_phong_pars_vertex: string;
-        lights_phong_vertex: string;
-        lights_standard_fragment: string;
-        lights_standard_pars_fragment: string;
+        lights_physical_fragment: string;
+        lights_physical_pars_fragment: string;
         lights_template: string;
         logdepthbuf_fragment: string;
         logdepthbuf_pars_fragment: string;
@@ -5113,19 +5126,24 @@ declare namespace THREE {
         meshlambert_vert: string;
         meshphong_frag: string;
         meshphong_vert: string;
-        meshstandard_frag: string;
-        meshstandard_vert: string;
+        meshphysical_frag: string;
+        meshphysical_vert: string;
         metalnessmap_fragment: string;
         metalnessmap_pars_fragment: string;
         morphnormal_vertex: string;
         morphtarget_pars_vertex: string;
         morphtarget_vertex: string;
+        normal_flip: string;
         normal_frag: string;
         normal_fragment: string;
         normal_vert: string;
         normalmap_pars_fragment: string;
+        packing: string;
         points_frag: string;
         points_vert: string;
+        shadow_frag: string;
+        shadow_vert: string;
+
         premultiplied_alpha_fragment: string;
         project_vertex: string;
         roughnessmap_fragment: string;
@@ -5152,7 +5170,7 @@ declare namespace THREE {
     }
 
     export interface Shader {
-        uniforms: any;
+        uniforms: IUniform;
         vertexShader: string;
         fragmentShader: string;
     }
@@ -5171,10 +5189,10 @@ declare namespace THREE {
         equirect: Shader;
         depthRGBA: Shader;
         distanceRGBA: Shader;
+        physical: Shader;
     };
 
     export interface IUniform {
-        type: string;
         value: any;
     }
 
@@ -5224,61 +5242,57 @@ declare namespace THREE {
         lights: {
             ambientLightColor: IUniform
             directionalLights: {
-                type: string;
                 value: any[];
                 properties: {
-                    direction: { type: string };
-                    color: { type: string };
-                    shadow: { type: string };
-                    shadowBias: { type: string };
-                    shadowRadius: { type: string };
-                    shadowMapSize: { type: string };
+                    direction: {};
+                    color: {};
+                    shadow: {};
+                    shadowBias: {};
+                    shadowRadius: {};
+                    shadowMapSize: {};
                 };
             };
             directionalShadowMap: IUniform;
             directionalShadowMatrix: IUniform;
             spotLights: {
-                type: string;
                 value: any[];
                 properties: {
-                    color: { type: string };
-                    position: { type: string };
-                    direction: { type: string };
-                    distance: { type: string };
-                    coneCos: { type: string };
-                    penumbraCos: { type: string };
-                    decay: { type: string };
-                    shadow: { type: string };
-                    shadowBias: { type: string };
-                    shadowRadius: { type: string };
-                    shadowMapSize: { type: string };
+                    color: {};
+                    position: {};
+                    direction: {};
+                    distance: {};
+                    coneCos: {};
+                    penumbraCos: {};
+                    decay: {};
+                    shadow: {};
+                    shadowBias: {};
+                    shadowRadius: {};
+                    shadowMapSize: {};
                 };
             };
             spotShadowMap: IUniform;
             spotShadowMatrix: IUniform;
             pointLights: {
-                type: string;
                 value: any[];
                 properties: {
-                    color: { type: string };
-                    position: { type: string };
-                    decay: { type: string };
-                    distance: { type: string };
-                    shadow: { type: string };
-                    shadowBias: { type: string };
-                    shadowRadius: { type: string };
-                    shadowMapSize: { type: string };
+                    color: {};
+                    position: {};
+                    decay: {};
+                    distance: {};
+                    shadow: {};
+                    shadowBias: {};
+                    shadowRadius: {};
+                    shadowMapSize: {};
                 };
             };
             pointShadowMap: IUniform;
             pointShadowMatrix: IUniform;
             hemisphereLigtts: {
-                type: string;
                 value: any[];
                 properties: {
-                    direction: { type: string };
-                    skycolor: { type: string };
-                    groundColor: { type: string };
+                    direction: {};
+                    skycolor: {};
+                    groundColor: {};
                 };
             };
         };
@@ -5297,11 +5311,12 @@ declare namespace THREE {
         export function clone(uniforms_src: any): any;
     }
 
-    export class Uniform {
-        constructor(type: string, value: string);
+    export class Uniform { 
+        constructor(value: any);
+        constructor(type: string, value: any); // deprecated
 
-        type: string;
-        value: string;
+        type: string; // deprecated
+        value: any;
         dynamic: boolean;
         onUpdateCallback: Function;
 
@@ -5313,8 +5328,18 @@ declare namespace THREE {
         constructor(_gl: WebGLRenderingContext, extensions: any, _infoRender: any);
 
         setMode(value: any): void;
-        render(start: any, count: any): void;
+        render(start: any, count: number): void;
         renderInstances(geometry: any): void;
+    }
+
+    export class WebGLClipping {
+        uniform: { value: any, needsUpdate: boolean };
+        numPlanes: number;
+
+        init(planes: any[], enableLocalClipping: boolean, camera: Camera): boolean;
+        beginShadows(): void;
+        endShadows(): void;
+        setState(planes: any[], clipShadows: boolean, camera: Camera, cache: boolean, fromCache: boolean): void; 
     }
 
     export interface WebGLCapabilitiesParameters {
@@ -5339,7 +5364,8 @@ declare namespace THREE {
         floatFragmentTextures: any;
         floatVertexTextures: any;
 
-        getMaxPrecision(precision: any): any;
+        getMaxAnisotropy(): number;
+        getMaxPrecision(precision: string): string;
     }
 
     export class WebGLExtensions {
@@ -5356,7 +5382,7 @@ declare namespace THREE {
 
     export class WebGLLights {
         constructor(gl: WebGLRenderingContext, properties: any, info: any);
-
+        
         get(light: any): any;
     }
 
@@ -5368,7 +5394,7 @@ declare namespace THREE {
         render(start: any, count: number): void;
         renderInstances(geometry: any, start: any, count: number): void;
     }
-
+    
     export class WebGLObjects {
         constructor(gl: WebGLRenderingContext, properties: any, info: any);
 
@@ -5379,7 +5405,7 @@ declare namespace THREE {
 
     export class WebGLProgram {
         constructor(renderer: WebGLRenderer, code: string, material: ShaderMaterial, parameters: WebGLRendererParameters);
-
+        
         id: number;
         code: string;
         usedTimes: number;
@@ -5389,7 +5415,7 @@ declare namespace THREE {
         uniforms: any; // deprecated, use getUniforms()
         attributes: any; // deprecated, use getAttributes()
 
-        getUniforms(): any;
+        getUniforms(): WebGLUniforms;
         getAttributes(): any;
         destroy(): void;
     }
@@ -5399,12 +5425,37 @@ declare namespace THREE {
 
         programs: any[];
 
-        getParameters(material: ShaderMaterial, lights: any, fog: any, object: any): any[];
+        getParameters(material: ShaderMaterial, lights: any, fog: any, nClipPlanes: number, object: any): any;
         getProgramCode(material: ShaderMaterial, parameters: any): string;
         acquireProgram(material: ShaderMaterial, parameters: any, code: string): WebGLProgram;
         releaseProgram(program: WebGLProgram): void;
     }
 
+    export class WebGLTextures {
+        constructor(gl: any, extensions: any, state: any, properties:any, capabilities: any, paramThreeToGL: Function, info: any);
+
+        setTexture2D(texture: any, slot: number): void;
+        setTextureCube(texture: any, slot: number): void;
+        setTextureCubeDynamic(texture: any, slot: number): void;
+        setupRenderTarget(renderTarget: any): void;
+        updateRenderTargetMipmap(renderTarget: any): void;
+    }
+
+    export class WebGLUniforms {
+        constructor(gl: any, program: WebGLProgram, renderer: WebGLRenderer);
+
+        renderer: WebGLRenderer;
+
+        setValue(gl: any, value: any, renderer?: any): void;
+        set(gl: any, object: any, name: string): void;
+        setOptional(gl: any, object: any, name: string): void;
+
+        static upload(gl: any, seq: any, values: any[], renderer: any): void;
+        static seqWithValue(seq: any, values: any[]): any[];
+        static splitDynamic(seq: any, values: any[]): any[];
+        static evalDynamic(seq: any, values: any[], object: any, camera: any): any[];
+    }
+    
     export class WebGLProperties {
         constructor();
 
@@ -5418,19 +5469,29 @@ declare namespace THREE {
     }
 
     export class WebGLShadowMap {
-        constructor(_renderer: Renderer, _lights: any[], _objects: any[]);
+        constructor(_renderer: Renderer, _lights: any[], _objects: any[], capabilities: any);
 
         enabled: boolean;
         autoUpdate: boolean;
         needsUpdate: boolean;
         type: ShadowMapType;
-        cullFace: CullFace;
+        renderReverseSided: boolean;
+        renderSingleSided: boolean;
 
         render(scene: Scene, camera: Camera): void;
-    }
 
+        // deprecated
+        cullFace: any;
+    }
+    
     export class WebGLState {
         constructor(gl: any, extensions: any, paramThreeToGL: Function);
+
+        buffers: {
+            color: WebGLColorBuffer,
+            depth: WebGLDepthBuffer,
+            stencil: WebGLStencilBuffer,
+        };
 
         init(): void;
         initAttributes(): void;
@@ -5441,15 +5502,16 @@ declare namespace THREE {
         disable(id: string): void;
         getCompressedTextureFormats(): any[];
         setBlending(blending: number, blendEquation: number, blendSrc: number, blendDst: number, blendEquationAlpha: number, blendSrcAlpha: number, blendDstAlpha: number): void;
-        setDepthFunc(func: Function): void;
+        setColorWrite(colorWrite: number): void;
         setDepthTest(depthTest: number): void;
         setDepthWrite(depthWrite: number): void;
-        setColorWrite(colorWrite: number): void;
-        setStencilFunc(stencilFunc: Function, stencilRef: any, stencilMask: any): void;
-        setStencilOp(stencilFail: any, stencilZFail: any, stencilZPass: any): void;
+        setDepthFunc(depthFunc: Function): void;
         setStencilTest(stencilTest: boolean): void;
         setStencilWrite(stencilWrite: any): void;
+        setStencilFunc(stencilFunc: Function, stencilRef: any, stencilMask: number): void;
+        setStencilOp(stencilFail: any, stencilZFail: any, stencilZPass: any): void;
         setFlipSided(flipSided: number): void;
+        setCullFace(cullFace: CullFace)
         setLineWidth(width: number): void;
         setPolygonOffset(polygonoffset: number, factor: number, units: number): void;
         setScissorTest(scissorTest: boolean): void;
@@ -5466,10 +5528,42 @@ declare namespace THREE {
         reset(): void;
     }
 
+    export class WebGLColorBuffer {
+        constructor(gl: any, state: any);
+
+        setMask(colorMask: number): void;
+        setLocked(lock: boolean): void;
+        setClear(r: number, g: number, b: number, a: number): void;
+        reset(): void;
+    }
+
+    export class WebGLDepthBuffer {
+        constructor(gl: any, state: any);
+
+        setTest(depthTest: boolean): void;
+        sertMask(depthMask: number): void;
+        setFunc(depthFunc: Function): void;
+        setLocked(lock: boolean): void;
+        setClear(depth: any): void;
+        reset(): void;
+    }
+
+    export class WebGLStencilBuffer {
+        constructor(gl: any, state: any);
+
+        setTest(stencilTest: boolean): void;
+        sertMask(stencilMask: number): void;
+        setFunc(stencilFunc: Function, stencilRef: any, stencilMask: number): void;
+        setOp(stencilFail: any, stencilZFail: any, stencilZPass: any): void;
+        setLocked(lock: boolean): void;
+        setClear(stencil: any): void;
+        reset(): void;
+    }
+
     // Renderers / WebGL / Plugins /////////////////////////////////////////////////////////////////////
     export class LensFlarePlugin {
         constructor(renderer: WebGLRenderer, flares: any[]);
-
+        
         render(scene: Scene, camera: Camera, viewportWidth: number, viewportHeight: number): void;
     }
 
@@ -5480,7 +5574,7 @@ declare namespace THREE {
     }
 
     // Scenes /////////////////////////////////////////////////////////////////////
-
+    
     /**
      * Scenes allow you to set up what and where is to be rendered by three.js. This is where you place objects, lights and cameras.
      */
@@ -5497,6 +5591,7 @@ declare namespace THREE {
          */
         overrideMaterial: Material;
         autoUpdate: boolean;
+        background: any;
 
         copy(source: Scene, recursive?: boolean): Scene;
     }
@@ -5555,7 +5650,7 @@ declare namespace THREE {
     // Textures /////////////////////////////////////////////////////////////////////
     export let TextureIdCount: number;
 
-    export class Texture {
+    export class Texture extends EventDispatcher {
         constructor(
             image: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement,
             mapping?: Mapping,
@@ -5565,14 +5660,15 @@ declare namespace THREE {
             minFilter?: TextureFilter,
             format?: PixelFormat,
             type?: TextureDataType,
-            anisotropy?: number
+            anisotropy?: number,
+            encoding?: TextureEncoding
             );
 
         id: number;
         uuid: string;
         name: string;
         sourceFile: string;
-        image: any; // HTMLImageElement or ImageData ;
+        image: any; // HTMLImageElement or ImageData or { width: number, height: number } in some children;
         mipmaps: ImageData[];
         mapping: Mapping;
         wrapS: Wrapping;
@@ -5600,12 +5696,22 @@ declare namespace THREE {
         toJSON(meta: any): any;
         dispose(): void;
         transformUv(uv: Vector): void;
+    }
 
-        // EventDispatcher mixins
-        addEventListener(type: string, listener: (event: Event) => void ): void;
-        hasEventListener(type: string, listener: (event: Event) => void): void;
-        removeEventListener(type: string, listener: (event: Event) => void): void;
-        dispatchEvent(event: { type: string; [attachment: string]: any; }): void;
+    export class DepthTexture extends Texture {
+        constructor(
+            width: number,
+            heighht: number,
+            type?: TextureDataType,
+            mapping?: Mapping,
+            wrapS?: Wrapping,
+            wrapT?: Wrapping,
+            magFilter?: TextureFilter,
+            minFilter?: TextureFilter,
+            anisotropy?: number
+        );
+
+        image: { width: number, height: number };
     }
 
     export class CanvasTexture extends Texture {
@@ -5635,7 +5741,8 @@ declare namespace THREE {
             minFilter?: TextureFilter,
             format?: PixelFormat,
             type?: TextureDataType,
-            anisotropy?: number
+            anisotropy?: number,
+            encoding?: TextureEncoding
         );
 
         images: any; // returns and sets the value of Texture.image in the codde ?
@@ -5655,7 +5762,8 @@ declare namespace THREE {
             wrapT?: Wrapping,
             magFilter?: TextureFilter,
             minFilter?: TextureFilter,
-            anisotropy?: number
+            anisotropy?: number,
+            encoding?: TextureEncoding
         );
 
         image: { width: number; height: number; };
@@ -5676,7 +5784,8 @@ declare namespace THREE {
             wrapT: Wrapping,
             magFilter: TextureFilter,
             minFilter: TextureFilter,
-            anisotropy?: number
+            anisotropy?: number,
+            encoding?: TextureEncoding
         );
 
         image: { data: ImageData; width: number; height: number; };
@@ -5725,8 +5834,8 @@ declare namespace THREE {
 
     export namespace ShapeUtils {
         export function area(contour: number[]): number;
-        export function triangulate(contour: Vector2[], indices: boolean): Vector2[][] | number[][];
-        export function triangulateShape(contour: Vector2[], holes: Vector2[][]): Vector2[][];
+        export function triangulate(contour: number[], indices: boolean): number[];
+        export function triangulateShape(contour: number[], holes: any[]): number[];
         export function isClockWise(pts: number[]): boolean;
         export function b2(t: number, p0: number, p1: number, p2: number): number;
         export function b3(t: number, p0: number, p1: number, p2: number, p3: number): number;
@@ -5747,26 +5856,28 @@ declare namespace THREE {
         hasPlaybackControl: boolean;
         isPlaying: boolean;
         sourceType: string;
-        filter: any;
+        filters: any[];
 
         getOutput(): GainNode;
-        load(file: string): Audio;
         setNodeSource(audioNode: AudioBufferSourceNode): Audio;
         setBuffer(audioBuffer: AudioBuffer): Audio;
-        play(): void;
-        pause(): void;
-        stop(): void;
-        connect(): void;
-        disconnect(): void;
-        setFilter(value: any): void;
+        play(): Audio;
+        pause(): Audio;
+        stop(): Audio;
+        connect(): Audio;
+        disconnect(): Audio;
+        getFilters(): any[];
+        setFilter(value: any[]): Audio;
         getFilter(): any;
-        setPlaybackRate(value: number): void;
+        setFilter(filter: any): Audio;
+        setPlaybackRate(value: number): Audio;
         getPlaybackRate(): number;
         onEnded(): void;
-        setLoop(value: boolean): void;
         getLoop(): boolean;
-        setVolume(value: number): void;
+        setLoop(value: boolean): void;
         getVolume(): number;
+        setVolume(value: number): Audio;
+        load(file: string): Audio; // deprecated, use the AudioLoader class
     }
 
     export class AudioAnalyser {
@@ -5775,8 +5886,14 @@ declare namespace THREE {
         analyser: any;
         data: Uint8Array;
 
-        getData(): Uint8Array;
+        getFrequencyData(): Uint8Array;
+        getAverageFrequency(): number;
+
+        // deprecated
+        getData(file: any): any;
     }
+
+    export const AudioContext: AudioContext;
 
     export class AudioBuffer {
         constructor(context: any);
@@ -5896,7 +6013,10 @@ declare namespace THREE {
         closePath(): void;
         getPoint(t: number): T;
         getLength(): number;
+        updateArcLengths(): void;
         getCurveLengths(): number[];
+        getSpacedPoints(divisions?: number): T[];
+        getPoints(divisions?: number): T[];
         createPointsGeometry(divisions: number): Geometry;
         createSpacedPointsGeometry(divisions: number): Geometry;
         createGeometry(points: T[]): Geometry;
@@ -5923,7 +6043,7 @@ declare namespace THREE {
     export class Path extends CurvePath<Vector2> {
         constructor(points?: Vector2[]);
 
-        actions: PathAction[];
+        currentPoint: Vector2;
 
         fromPoints(vectors: Vector2[]): void;
         moveTo(x: number, y: number): void;
@@ -5935,8 +6055,19 @@ declare namespace THREE {
         absarc(aX: number, aY: number, aRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean): void;
         ellipse(aX: number, aY: number, xRadius: number, yRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean, aRotation: number): void;
         absellipse(aX: number, aY: number, xRadius: number, yRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean, aRotation: number): void;
-        getSpacedPoints(divisions?: number): Vector2[];
-        getPoints(divisions?: number, closedPath?: boolean): Vector2[];
+    }
+
+    export class ShapePath {
+        constructor();
+
+        subPaths: any[];
+        currentPath: any;
+
+        moveTo(x: number, y: number): void;
+        lineTo(x: number, y: number): void;
+        quadraticCurveTo(aCPx: number, aCPy: number, aX: number, aY: number): void;
+        bezierCurveTo(aCP1x: number, aCP1y: number, aCP2x: number, aCP2y: number, aX: number, aY: number): void;
+        splineThru(pts: Vector2[]): void;
         toShapes(isCCW: boolean, noHoles: any): Shape[];
     }
 
@@ -5969,7 +6100,7 @@ declare namespace THREE {
 
     export class ClosedSplineCurve3 extends CatmullRomCurve3 {} // deprecated, use CatmullRomCurve3
     export class SplineCurve3 extends CatmullRomCurve3 {} // will be deprecated, use CatmullRomCurve3
-
+        
     export class CubicBezierCurve extends Curve<Vector2> {
         constructor(v0: Vector2, v1: Vector2, v2: Vector2, v3: Vector2);
 
@@ -5989,7 +6120,7 @@ declare namespace THREE {
 
         getPoint(t: number): Vector3;
     }
-
+    
     export class EllipseCurve extends Curve<Vector2> {
         constructor(aX: number, aY: number, xRadius: number, yRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean, aRotation: number);
 
@@ -6021,7 +6152,7 @@ declare namespace THREE {
 
         getPoint(t: number): Vector3;
     }
-
+    
     export class QuadraticBezierCurve extends Curve<Vector2> {
         constructor( v0: Vector2, v1: Vector2, v2: Vector2 );
 
@@ -6045,7 +6176,7 @@ declare namespace THREE {
 
         points: Vector2[];
     }
-
+    
 
     // Extras / Geometries /////////////////////////////////////////////////////////////////////
     export class BoxBufferGeometry extends BufferGeometry {
@@ -6147,6 +6278,14 @@ declare namespace THREE {
             thetaStart: number;
             thetaLength: number;
         };
+    }
+
+    export class ConeBufferGeometry extends BufferGeometry {
+        constructor(radius?: number, height?: number, radialSegment?: number, heightSegment?: number, openEnded?: boolean, thetaStart?: number, thetaLength?: number);
+    }
+
+    export class ConeGeometry extends CylinderGeometry {
+        constructor(radius?: number, height?: number, radialSegment?: number, heightSegment?: number, openEnded?: boolean, thetaStart?: number, thetaLength?: number);
     }
 
     export class DodecahedronGeometry extends Geometry {
@@ -6458,7 +6597,7 @@ declare namespace THREE {
     }
 
     export class BoxHelper extends LineSegments {
-        constructor(object?: Object3D);
+        constructor(object?: Object3D, color?: Color);
 
         update(object?: Object3D): void;
     }
@@ -6477,7 +6616,6 @@ declare namespace THREE {
 
         light: Light;
         lightPlane: Line;
-        targetLine: Line;
 
         dispose(): void;
         update(): void;
@@ -6497,12 +6635,9 @@ declare namespace THREE {
     }
 
     export class GridHelper extends LineSegments {
-        constructor(size: number, step: number);
+        constructor(size: number, divisions: number, color1?: Color|number, color2?: Color|number);
 
-        color1: Color;
-        color2: Color;
-
-        setColors(colorCenterLine: number, colorGrid: number): void;
+        setColors(color1?: Color|number, color2?: Color|number): void; // deprecated
     }
 
     export class HemisphereLightHelper extends Object3D {
@@ -6536,10 +6671,9 @@ declare namespace THREE {
     }
 
     export class SpotLightHelper extends Object3D {
-        constructor(light: Light, sphereSize: number, arrowLength: number);
+        constructor(light: Light);
 
         light: Light;
-        cone: Mesh;
 
         dispose(): void;
         update(): void;

--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -1334,7 +1334,7 @@ declare namespace THREE {
     }
 
     export namespace GeometryUtils { // deprecated
-        export function merge(goemetry1: any, goemetry2: any, materialIndexOffset?: any): any; // deprecated, use geometry.merge( geometry2, matrix, materialIndexOffset )
+        export function merge(geometry1: any, geometry2: any, materialIndexOffset?: any): any; // deprecated, use geometry.merge( geometry2, matrix, materialIndexOffset )
         export function center(geometry: any): any; // deprecated, use geometry.center()
     }
 


### PR DESCRIPTION
Update from r75 to r79.

Note about the definition for `ShaderMaterial.uniforms` : 
It should ideally be `{ [uniform: string]: { value: any; }; };` but I left them as `any` because it breaks the compilation for two of the examples :

```
tests/webgl/webgl_animation_cloth.ts(129,63): error TS2345: Argument of type '{ uniforms: { texture: { value: Texture; }; }; vertexShader: string;
fragmentShader: string; }' is not assignable to parameter of type 'ShaderMaterialParameters'.
  Types of property 'uniforms' are incompatible.
    Type '{ texture: { value: Texture; }; }' is not assignable to type '{ [uniform: string]: { value: any; }; }'.
      Index signature is missing in type '{ texture: { value: Texture; }; }'.
```

It seems to be a Typescript "bug" in some cases, there are several closed issues about it, one of them marked as "fixed"... (I compiled with TS 1.8.10)
Not sure what to do about that, but I guess it's OK if we left the definition as `any`.
