### PR TITLE
autobahn: updated IPublishOptions

### DIFF
--- a/autobahn/autobahn.d.ts
+++ b/autobahn/autobahn.d.ts
@@ -163,6 +163,7 @@ declare namespace autobahn {
     }
 
     interface IPublishOptions {
+        acknowledge?: boolean;
         exclude?: number[];
         eligible?: number[];
         disclose_me?: Boolean;


### PR DESCRIPTION
Hi,
I've added missing acknowledge option to IPublishOptions interface.
- documentation or source code reference which provides context for the suggested changes:
  1. [Autobahn offical documentation](http://autobahn.ws/js/reference.html#acknowledgement)
  2. [Auobahn code (same version for the typings: 0.9.6)](https://github.com/crossbario/autobahn-js/blob/v0.9.6/package/lib/session.js#L1115)
