### PR TITLE
replace moment.MomentFormatSpecification with string

### DIFF
--- a/moment-timezone/index.d.ts
+++ b/moment-timezone/index.d.ts
@@ -28,10 +28,10 @@ declare namespace MomentTimezone {
         (date: number, timezone: string): moment.Moment;
         (date: number[], timezone: string): moment.Moment;
         (date: string, timezone: string): moment.Moment;
-        (date: string, format: moment.MomentFormatSpecification, timezone: string): moment.Moment;
-        (date: string, format: moment.MomentFormatSpecification, strict: boolean, timezone: string): moment.Moment;
-        (date: string, format: moment.MomentFormatSpecification, language: string, timezone: string): moment.Moment;
-        (date: string, format: moment.MomentFormatSpecification, language: string, strict: boolean, timezone: string): moment.Moment;
+        (date: string, format: string, timezone: string): moment.Moment;
+        (date: string, format: string, strict: boolean, timezone: string): moment.Moment;
+        (date: string, format: string, language: string, timezone: string): moment.Moment;
+        (date: string, format: string, language: string, strict: boolean, timezone: string): moment.Moment;
         (date: Date, timezone: string): moment.Moment;
         (date: moment.Moment, timezone: string): moment.Moment;
         (date: Object, timezone: string): moment.Moment;


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

type moment.MomentFormatSpecification doesn't exist (any more - moment@2.14.1). 
Using string instead seems to work OK.
