### PR TITLE
Update semver definitions to support v5.3.0

### DIFF
--- a/semver/semver-tests.ts
+++ b/semver/semver-tests.ts
@@ -27,6 +27,7 @@ str = mod.inc(str, str, loose);
 num = mod.major(str, loose);
 num = mod.minor(str, loose);
 num = mod.patch(str, loose);
+strArr = mod.prerelease(str, loose);
 
 // Comparison
 bool = mod.gt(v1, v2, loose);
@@ -44,6 +45,7 @@ diff = mod.diff(v1, v2, loose);
 str = mod.validRange(str, loose);
 bool = mod.satisfies(version, str, loose);
 str = mod.maxSatisfying(versions, str, loose);
+str = mod.minSatisfying(versions, str, loose);
 bool = mod.gtr(version, str, loose);
 bool = mod.ltr(version, str, loose);
 bool = mod.outside(version, str, str, loose);

--- a/semver/semver.d.ts
+++ b/semver/semver.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for semver v4.3.4
+// Type definitions for semver v5.3.0
 // Project: https://github.com/npm/node-semver
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/semver
@@ -28,6 +28,10 @@ declare namespace SemVerModule {
      * Return the patch version number.
      */
     function patch(v: string, loose?: boolean): number;
+    /**
+     * Returns an array of prerelease components, or null if none exist.
+     */
+    function prerelease(v: string, loose?: boolean): string[];
 
     // Comparison
     /**
@@ -84,6 +88,10 @@ declare namespace SemVerModule {
      * Return the highest version in the list that satisfies the range, or null if none of them do.
      */
     function maxSatisfying(versions: string[], range: string, loose?: boolean): string;
+    /**
+     * Return the lowest version in the list that satisfies the range, or null if none of them do.
+     */
+    function minSatisfying(versions: string[], range: string, loose?: boolean): string;
     /**
      * Return true if version is greater than all the versions possible in the range.
      */


### PR DESCRIPTION
This update simply adds typing support for the `minSatisfying` and `prerelease` methods which were added in v5.3.0 and v5.2.0 of semver respectively.
