### PR TITLE
Allow `Object` type as argument to `Stringifier.write`

### DIFF
--- a/csv-stringify/csv-stringify.d.ts
+++ b/csv-stringify/csv-stringify.d.ts
@@ -58,7 +58,7 @@ declare module "csv-stringify" {
 
 		interface Stringifier extends NodeJS.ReadWriteStream {
 
-			// Stringifier stream takes array of strings
+			// Stringifier stream takes array of strings or Object
 			write(line: string[] | Object): boolean;
 
 			// repeat declarations from NodeJS.WritableStream to avoid compile error

--- a/csv-stringify/csv-stringify.d.ts
+++ b/csv-stringify/csv-stringify.d.ts
@@ -59,7 +59,7 @@ declare module "csv-stringify" {
 		interface Stringifier extends NodeJS.ReadWriteStream {
 
 			// Stringifier stream takes array of strings
-			write(line: string[]): boolean;
+			write(line: string[] | Object): boolean;
 
 			// repeat declarations from NodeJS.WritableStream to avoid compile error
 			write(buffer: Buffer, cb?: Function): boolean;


### PR DESCRIPTION
Pretty self explanatory, `Stringifier.write` can take an object for its argument or a string array.
