### PR TITLE
Add setNonce to $mdThemeProvider to allow the user to define a nonce …

### DIFF
--- a/angular-material/angular-material.d.ts
+++ b/angular-material/angular-material.d.ts
@@ -247,6 +247,7 @@ declare namespace angular.material {
         extendPalette(name: string, palette: IPalette): IPalette;
         setDefaultTheme(theme: string): void;
         alwaysWatchTheme(alwaysWatch: boolean): void;
+        setNonce(nonce: string): void;
     }
 
     interface IDateLocaleProvider {


### PR DESCRIPTION
Allow the user to define a nonce attribute for generated theme style tags. Really important if you want to use Angular Material and be compliant with CSP.

See https://github.com/angular/material/issues/7780 and https://material.angularjs.org/1.1.0-rc.5/api/service/$mdThemingProvider
