### PR TITLE
Adding access to two semi-private node-usb methods

### DIFF
--- a/node-usb/node-usb-tests.ts
+++ b/node-usb/node-usb-tests.ts
@@ -9,6 +9,9 @@ device.busNumber = 1;
 device.deviceAddress = 1;
 device.portNumbers = [1, 2, 3];
 
+device.__open();
+device.__claimInterface(0);
+
 device.open(true);
 device.close();
 const xferDevice: usb.Device = device.controlTransfer(1, 1, 1, 1, 1, (error: string, buf: Buffer): usb.Device => new usb.Device());

--- a/node-usb/node-usb.d.ts
+++ b/node-usb/node-usb.d.ts
@@ -16,6 +16,9 @@ declare module "usb" {
     public configDescriptor: ConfigDescriptor;
     public interfaces: Array<Interface>;
 
+    __open(): void;
+    __claimInterface(addr: number): void;
+
     open(defaultConfig?: boolean): void;
     close(): void;
     interface(addr: number): Interface;


### PR DESCRIPTION
These methods are required for a workaround for interface claiming that must be run on Mac.

See https://github.com/nonolith/node-usb/issues/61#issuecomment-69195175
