### PR TITLE
nunjucks.configure first arguments: path can be array

### DIFF
--- a/nunjucks/nunjucks.d.ts
+++ b/nunjucks/nunjucks.d.ts
@@ -34,6 +34,7 @@ declare namespace nunjucks {
 
 	export function configure(options: ConfigureOptions): Environment;
 	export function configure(path: string, options?: ConfigureOptions): Environment;
+	export function configure(path: string[], options?: ConfigureOptions): Environment;
 
 	export interface ConfigureOptions {
 		autoescape?: boolean;


### PR DESCRIPTION
[nunjucks](https://mozilla.github.io/nunjucks/) **configure** function first arguments can be array.  

can reference by [https://github.com/mozilla/nunjucks/blob/master/src/node-loaders.js#L28](https://github.com/mozilla/nunjucks/blob/master/src/node-loaders.js#L28)
