### PR TITLE
fix: Enable the use of the parse() method for superagent

### DIFF
--- a/superagent/superagent-tests.ts
+++ b/superagent/superagent-tests.ts
@@ -193,6 +193,24 @@ request('/search')
     var charset: string = res.charset;
   });
 
+// Custom parsers
+request
+  .post('/search')
+  .parse((res, callback) => {
+    res.setEncoding("binary");
+    let data = "";
+    res.on("data", (chunk: string) => {
+      data += chunk;
+    });
+
+    res.on("end", () => {
+      callback(null, new Buffer(data, "base64"));
+    });
+  })
+  .end((res: request.Response) => {
+    res.body.toString("hex");
+  });
+
 var req = request.get('/hoge');
 // Aborting requests
 req.abort();

--- a/superagent/superagent.d.ts
+++ b/superagent/superagent.d.ts
@@ -50,7 +50,7 @@ declare module "superagent" {
       search(url: string, callback?: CallbackHandler): Req;
       connect(url: string, callback?: CallbackHandler): Req;
 
-      parse(fn: Function): Req;
+      parse(fn: (res: Response, callback: (err: Error, body: any) => void) => void): this;
       saveCookies(res: Response): void;
       attachCookies(req: Req): void;
     }
@@ -107,6 +107,7 @@ declare module "superagent" {
       withCredentials(): this;
       write(data: string, encoding?: string): this;
       write(data: Buffer, encoding?: string): this;
+      parse(fn: (res: Response, callback: (err: Error, body: any) => void) => void): this;
     }
 
   }


### PR DESCRIPTION
This PR fixes the `parse()` method to ensure it works as expected, as well as adding additional type information for the parse callback. It includes tests to ensure it doesn't regress again.
