### PR TITLE
Fix StatelessComponent interface

### DIFF
--- a/react/react-tsx-tests.tsx
+++ b/react/react-tsx-tests.tsx
@@ -1,0 +1,16 @@
+/// <reference path="react.d.ts" />
+import React = require("react");
+
+interface SCProps {
+    foo?: number;
+}
+
+var StatelessComponent: React.SFC<SCProps> = ({ foo }: SCProps) => {
+    return <div>{ foo }</div>;
+};
+StatelessComponent.displayName = "StatelessComponent3";
+StatelessComponent.defaultProps = {
+    foo: 42
+};
+
+<StatelessComponent />;

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -197,7 +197,7 @@ declare namespace __React {
 
     type SFC<P> = StatelessComponent<P>;
     interface StatelessComponent<P> {
-        (props?: P, context?: any): ReactElement<any>;
+        (props: P, context?: any): ReactElement<any>;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: P;


### PR DESCRIPTION
Empty object is passed to StatelessComponent even if we pass no props.
Example:

``` js
function Test(props) {
  return <div>props: {JSON.stringify(props)}</div>
}

React.render(<Test />, document.body)
```

will render into `props: {}`
[jsfiddle](https://jsfiddle.net/LL25c28c/)

We need to fix this because otherwise we have error:
`Property 'propName' does not exist on type 'IntrinsicAttributes & (IMyInterface | undefined)'.`
for that code:

``` js
const MyComponent: React.SFC<IMyInterface> = ({ propName }: IMyInterface) => {
  // ...
}
```
