### PR TITLE
Fix for issue #10315 

### DIFF
--- a/jasmine-ajax/jasmine-ajax.d.ts
+++ b/jasmine-ajax/jasmine-ajax.d.ts
@@ -73,6 +73,9 @@ declare class MockAjax {
 
 	stubRequest(url: RegExp, data?: string, method?: string): JasmineAjaxRequestStub;
 	stubRequest(url: string, data?: string, method?: string): JasmineAjaxRequestStub;
+    
+	stubRequest(url: RegExp, data?: RegExp, method?: string): JasmineAjaxRequestStub;
+	stubRequest(url: string, data?: RegExp, method?: string): JasmineAjaxRequestStub;
 
 	requests: JasmineAjaxRequestTracker;
 	stubs: JasmineAjaxStubTracker;


### PR DESCRIPTION
jasmine-ajax stubRequest data can be a RegExp as well 

@vvakame 
