### PR TITLE
react: Add all remaining SVG elements except deprecated ones.

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -2478,6 +2478,7 @@ declare namespace JSX {
         circle: React.SVGProps;
         clipPath: React.SVGProps;
         defs: React.SVGProps;
+        desc: React.SVGProps;
         ellipse: React.SVGProps;
         feBlend: React.SVGProps;
         feColorMatrix: React.SVGProps;
@@ -2486,15 +2487,21 @@ declare namespace JSX {
         feConvolveMatrix: React.SVGProps;
         feDiffuseLighting: React.SVGProps;
         feDisplacementMap: React.SVGProps;
+        feDistantLight: React.SVGProps;
         feFlood: React.SVGProps;
         feFuncA: React.SVGProps;
+        feFuncB: React.SVGProps;
+        feFuncG: React.SVGProps;
+        feFuncR: React.SVGProps;
         feGaussianBlur: React.SVGProps;
         feImage: React.SVGProps;
         feMerge: React.SVGProps;
         feMergeNode: React.SVGProps;
         feMorphology: React.SVGProps;
         feOffset: React.SVGProps;
+        fePointLight: React.SVGProps;
         feSpecularLighting: React.SVGProps;
+        feSpotLight: React.SVGProps;
         feTile: React.SVGProps;
         feTurbulence: React.SVGProps;
         filter: React.SVGProps;
@@ -2505,6 +2512,7 @@ declare namespace JSX {
         linearGradient: React.SVGProps;
         marker: React.SVGProps;
         mask: React.SVGProps;
+        metadata: React.SVGProps;
         path: React.SVGProps;
         pattern: React.SVGProps;
         polygon: React.SVGProps;
@@ -2512,10 +2520,12 @@ declare namespace JSX {
         radialGradient: React.SVGProps;
         rect: React.SVGProps;
         stop: React.SVGProps;
+        switch: React.SVGProps;
         symbol: React.SVGProps;
         text: React.SVGProps;
         textPath: React.SVGProps;
         tspan: React.SVGProps;
         use: React.SVGProps;
+        view: React.SVGProps;
     }
 }


### PR DESCRIPTION
My last PR only added the SVG elements I needed immediately. I realized that was a bit shortsighted, so this PR adds the rest. I deliberately omitted elements that are either deprecated in the documentation or that React warns are deprecated (such as SMIL elements). I also omitted elements such as `<a>` and `<title>` since there is already TSX support for these via the HTML elements of the same name.
