### PR TITLE
Added SearchResponse for search methods.

### DIFF
--- a/elasticsearch/elasticsearch.d.ts
+++ b/elasticsearch/elasticsearch.d.ts
@@ -23,8 +23,8 @@ declare module Elasticsearch {
         ping(params: PingParams, callback: (err: any, response: any, status: any) => void): void;
         scroll(params: ScrollParams): PromiseLike<any>;
         scroll(params: ScrollParams, callback: (error: any, response: any) => void): void;
-        search(params: SearchParams): PromiseLike<any>;
-        search(params: SearchParams, callback: (error: any, response: any) => void): void;
+        search<T>(params: SearchParams): PromiseLike<SearchResponse<T>>;
+        search<T>(params: SearchParams, callback: (error: any, response: SearchResponse<T>) => void): void;
         suggest(params: SuggestParams): PromiseLike<any>;
         suggest(params: SuggestParams, callback: (error: any, response: any) => void): void;
         update(params: UpdateDocumentParams): PromiseLike<any>;
@@ -218,6 +218,28 @@ declare module Elasticsearch {
         suggestText?: string;
         timeout?: Date | number;
     }
+
+    export interface SearchResponse<T> {
+        took: number,
+        timed_out: boolean,
+        _shards: {
+            total: number,
+            successful: number,
+            failed: number
+        },
+        hits: {
+            total: number,
+            max_score: number,
+            hits: {
+                _index: string,
+                _type: string,
+                _id: string,
+                _score: number,
+                _source: T
+            }[]
+        },
+        aggregations: any
+    } 
 
     export interface MSearchParams extends GenericParams {
         index?: string | string[] | Boolean;


### PR DESCRIPTION
The DT definition for elasticsearch.d.ts is missing the model for search results. 

Elasticsearch's documentation is notoriously bad when it comes to examples or any actual documentation of the return types (see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html and https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#api-search)

However, there's an almost complete example in their e-book here:
https://www.elastic.co/guide/en/elasticsearch/guide/current/empty-search.html
