### PR TITLE
Use properly modular estree in downstream typings

### DIFF
--- a/acorn/acorn-tests.ts
+++ b/acorn/acorn-tests.ts
@@ -1,6 +1,7 @@
 /// <reference types="estree" />
 
 import acorn = require('acorn');
+import * as ESTree from 'estree';
 
 declare var token: acorn.Token;
 declare var tokens: acorn.Token[];

--- a/acorn/index.d.ts
+++ b/acorn/index.d.ts
@@ -7,6 +7,7 @@
 
 export as namespace acorn;
 export = acorn;
+import * as ESTree from 'estree';
 
 declare namespace acorn {
     var version: string;

--- a/esprima/esprima-tests.ts
+++ b/esprima/esprima-tests.ts
@@ -2,6 +2,7 @@
 
 
 import esprima = require('esprima');
+import * as ESTree from 'estree';
 
 var token: esprima.Token;
 var comment: esprima.Comment;

--- a/esprima/index.d.ts
+++ b/esprima/index.d.ts
@@ -7,6 +7,7 @@
 
 export = esprima;
 export as namespace esprima;
+import * as ESTree from 'estree';
 
 declare namespace esprima {
 
@@ -20,7 +21,7 @@ declare namespace esprima {
         value: string;
     }
 
-    interface Comment extends ESTree.Node {
+    interface Comment extends ESTree.BaseNode {
         value: string;
     }
 

--- a/static-eval/index.d.ts
+++ b/static-eval/index.d.ts
@@ -5,6 +5,7 @@
 
 /// <reference types="esprima" />
 
+import * as ESTree from 'estree';
 
 /**
 * Evaluates the given ESTree.Expression, with the given named variables in place.

--- a/static-eval/static-eval-tests.ts
+++ b/static-eval/static-eval-tests.ts
@@ -2,6 +2,8 @@
 
 import evaluate = require('static-eval');
 import esprima = require('esprima');
+import * as ESTree from 'estree';
+
 var parse = esprima.parse;
 
 


### PR DESCRIPTION
PR #10305 switched ESTree from exposing a global namespace of types to exposing its types in an importable module. This PR fixes other typings that used that global namespace.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
