### PR TITLE
Correct optional fields in QueryOptions

### DIFF
--- a/cassandra-driver/cassandra-driver.d.ts
+++ b/cassandra-driver/cassandra-driver.d.ts
@@ -480,10 +480,10 @@ declare module "cassandra-driver" {
   interface QueryOptions {
     autoPage?: boolean;
     captureStackTrace?: boolean;
-    consistency: number;
+    consistency?: number;
     customPayload?: any;
     fetchSize?: number;
-    hints: Array<string> | Array<Array<string>>;
+    hints?: Array<string> | Array<Array<string>>;
     logged?: boolean;
     pageState?: Buffer|string;
     prepare?: boolean;


### PR DESCRIPTION
According to documentation, these should be optional.
http://docs.datastax.com/en/latest-nodejs-driver-api/global.html#QueryOptions
