### PR TITLE
Added less-common fields to search result.

### DIFF
--- a/elasticsearch/elasticsearch.d.ts
+++ b/elasticsearch/elasticsearch.d.ts
@@ -79,6 +79,12 @@ declare module Elasticsearch {
         createNodeAgent?: any;
     }
 
+    export interface Explanation {
+        value: number,
+        description: string,
+        details: Explanation[]
+    }
+
     export interface GenericParams {
         requestTimeout?: number;
         maxRetries?: number;
@@ -222,6 +228,7 @@ declare module Elasticsearch {
     export interface SearchResponse<T> {
         took: number,
         timed_out: boolean,
+        _scroll_id?: string,
         _shards: {
             total: number,
             successful: number,
@@ -235,10 +242,15 @@ declare module Elasticsearch {
                 _type: string,
                 _id: string,
                 _score: number,
-                _source: T
+                _source: T,
+                _version: number,
+                _explanation?: Explanation,
+                fields?: any,
+                highlight?: any,
+                inner_hits?: any
             }[]
         },
-        aggregations: any
+        aggregations?: any
     } 
 
     export interface MSearchParams extends GenericParams {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Well, this is embarrassing. 

I retroactively applied the SearchResponse I created to some older services I had written, and I found that I was using a less-often-used search option that added a new field to the response.

I added the field, and in addition, double checked for other less-common fields that appear in the results when specific search options are invoked.

A couple of fields, such as "highlight" and "inner_hits" can be further defined, but that will require a lot more work and experimentation to determine the full set of fields.
