### PR TITLE
adds Notification interface to node-webkit typings

### DIFF
--- a/faker/faker-tests.ts
+++ b/faker/faker-tests.ts
@@ -123,6 +123,7 @@ resultStr = faker.internet.mac();
 resultStr = faker.internet.password();
 resultStr = faker.internet.password(0, false, '#', 'foo');
 
+resultStr = faker.lorem.word();
 resultStr = faker.lorem.words();
 resultStr = faker.lorem.words(0);
 resultStr = faker.lorem.sentence();

--- a/faker/faker.d.ts
+++ b/faker/faker.d.ts
@@ -135,6 +135,7 @@ declare namespace Faker {
 		};
 
 		lorem: {
+			word(): string;
 			words(num?: number): string;
 			sentence(wordCount?: number, range?: number): string;
 			sentences(sentenceCount?: number): string;

--- a/node-webkit/node-webkit-tests.ts
+++ b/node-webkit/node-webkit-tests.ts
@@ -3,7 +3,7 @@
 
 // Load native UI library
 // See docs: https://github.com/rogerwang/node-webkit/wiki/Shell
-import gui = require("nw.gui");
+import * as gui from "nw.gui";
 
 
 /* WINDOW */

--- a/node-webkit/node-webkit-tests.ts
+++ b/node-webkit/node-webkit-tests.ts
@@ -203,3 +203,28 @@ import gui = require("nw.gui");
 
     // Open a file in file explorer.
     gui.Shell.showItemInFolder('test.txt');
+
+
+/* Notification */
+
+    let options = {
+        icon: "http://yourimage.jpg",
+        body: "Here is the notification text"
+    };
+
+    let notification = new Notification( "Notification Title", options );
+    console.log( notification.body );
+    console.log( notification.dir );
+    console.log( notification.icon );
+    console.log( notification.lang );
+    console.log( notification.title );
+
+    notification.onclick = function () {
+        console.log( "Notification: onclick" )
+    };
+    notification.onerror = function ( err:Error ) {
+        console.log( "Notification: error", err )
+    };
+    notification.onshow = function () {
+        notification.close();
+    };

--- a/node-webkit/node-webkit.d.ts
+++ b/node-webkit/node-webkit.d.ts
@@ -219,3 +219,23 @@ declare module "nw.gui" {
     export var Shell: Shell;
 
 }
+
+interface Notification {
+    body:string;
+    icon:string;
+
+    new( title:string, options:NotificationOptions ):Notification;
+    close():void;
+
+    onclick:() => void;
+    onshow:() => void;
+    onerror:( error:Error ) => void;
+    onclose:() => void;
+}
+
+declare var Notification: Notification;
+
+declare interface NotificationOptions {
+    body:string;
+    icon:string;
+}

--- a/node-webkit/node-webkit.d.ts
+++ b/node-webkit/node-webkit.d.ts
@@ -220,9 +220,36 @@ declare module "nw.gui" {
 
 }
 
-interface Notification {
+interface Notification extends EventTarget {
+    /**
+     * The text displayed in the notification body
+     * @readonly
+     */
     body:string;
+
+    /**
+     * The direction the popup will sho
+     * @readonly
+     */
+    dir:"auto"|"ltr"|"rtl";
+
+    /**
+     * The icon shown in the notification
+     * @readonly
+     */
     icon:string;
+
+    /**
+     * The title shown in the notification
+     * @readonly
+     */
+    title:string;
+
+    /**
+     * The notification language
+     * @readonly
+     */
+    lang:string;
 
     new( title:string, options:NotificationOptions ):Notification;
     close():void;
@@ -236,6 +263,10 @@ interface Notification {
 declare var Notification: Notification;
 
 declare interface NotificationOptions {
-    body:string;
-    icon:string;
+    title?:string;
+    body?:string;
+    icon?:string;
+    tag?:string;
+    lang?:string;
+    dir?:"auto"|"ltr"|"rtl";
 }


### PR DESCRIPTION
Node-webkit supports desktop notifications. See here:

https://github.com/nwjs/nw.js/wiki/Notification

The documentation however is very lacking so i debugged the Notification object and it appears to be compatible with w3c web notification standards: https://www.w3.org/TR/notifications/

Here is what the debugger showed:

```
<return>: Notification
    body: "..."
    dir: "auto"
    icon: "file:///C:/..."
    lang: ""
    onclick: null
    onclose: null
    onerror: null
    onshow: null
    tag: ""
    title: "..."
    __proto__: Notification
        close: function close() { [native code] }
        constructor: function Notification() { [native code] }
        __proto__: EventTarget
```
