### PR TITLE
Add missing acquireConnectionTimeout parameter to "knex.d.ts"

### DIFF
--- a/knex/knex-tests.ts
+++ b/knex/knex-tests.ts
@@ -57,6 +57,19 @@ var knex = Knex({
   }
 });
 
+// acquireConnectionTimeout
+var knex = Knex({
+  debug: true,
+  client: 'mysql',
+  connection: {
+    socketPath     : '/path/to/socket.sock',
+    user     : 'your_database_user',
+    password : 'your_database_password',
+    database : 'myapp_test'
+  },
+  acquireConnectionTimeout: 60000,
+});
+
 // Pure Query Builder without a connection
 var knex = Knex({});
 

--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -453,6 +453,7 @@ declare module "knex" {
         Sqlite3ConnectionConfig|SocketConnectionConfig;
       pool?: PoolConfig;
       migrations?: MigratorConfig;
+      acquireConnectionTimeout?: number;
     }
 
     interface ConnectionConfig {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes

Adds a single parameter to the configuration object (acquireConnectionTimeout) as documented by [this section of the documentation](http://knexjs.org/#Installation-acquireConnectionTimeout)
- it has been reviewed by a DefinitelyTyped member.

I still need review by a member / the author.
