### PR TITLE
Improvement to node type definition

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -324,6 +324,7 @@ declare namespace NodeJS {
         cwd(): string;
         env: any;
         exit(code?: number): void;
+        exitCode: number
         getgid(): number;
         setgid(id: number): void;
         setgid(id: string): void;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -324,7 +324,7 @@ declare namespace NodeJS {
         cwd(): string;
         env: any;
         exit(code?: number): void;
-        exitCode: number
+        exitCode: number;
         getgid(): number;
         setgid(id: number): void;
         setgid(id: string): void;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Adding Process.exitCode as @trixlerjs pointed it's missing from Process.

From Node.js API Reference (https://nodejs.org/api/process.html#process_process_exitcode):
"A number which will be the process exit code, when the process either exits gracefully, or is exited via process.exit() without specifying a code."
