### PR TITLE
fix definitions of express req.accepts functions

### DIFF
--- a/express-serve-static-core/express-serve-static-core.d.ts
+++ b/express-serve-static-core/express-serve-static-core.d.ts
@@ -192,9 +192,10 @@ declare module "express-serve-static-core" {
             *     req.accepts('html, json');
             *     // => "json"
             */
-        accepts(type: string): string;
-
-        accepts(type: string[]): string;
+        accepts(): string[];
+        accepts(type: string): string | boolean;
+        accepts(type: string[]): string | boolean;
+        accepts(...type: string[]): string | boolean;
 
         /**
             * Returns the first accepted charset of the specified character sets,
@@ -204,7 +205,10 @@ declare module "express-serve-static-core" {
             * For more information, or if you have issues or concerns, see accepts.
             * @param charset
             */
-        acceptsCharsets(charset?: string | string[]): string[];
+        acceptsCharsets(): string[];
+        acceptsCharsets(charset: string): string | boolean;
+        acceptsCharsets(charset: string[]): string | boolean;
+        acceptsCharsets(...charset: string[]): string | boolean;
 
         /**
             * Returns the first accepted encoding of the specified encodings,
@@ -214,7 +218,10 @@ declare module "express-serve-static-core" {
             * For more information, or if you have issues or concerns, see accepts.
             * @param encoding
             */
-        acceptsEncodings(encoding?: string | string[]): string[];
+        acceptsEncodings(): string[];
+        acceptsEncodings(encoding: string): string | boolean;
+        acceptsEncodings(encoding: string[]): string | boolean;
+        acceptsEncodings(...encoding: string[]): string | boolean;
 
         /**
             * Returns the first accepted language of the specified languages,
@@ -225,7 +232,10 @@ declare module "express-serve-static-core" {
             *
             * @param lang
             */
-        acceptsLanguages(lang?: string | string[]): string[];
+        acceptsLanguages(): string[];
+        acceptsLanguages(lang: string): string | boolean;
+        acceptsLanguages(lang: string[]): string | boolean;
+        acceptsLanguages(...lang: string[]): string | boolean;
 
         /**
             * Parse Range header field,

--- a/express/express-tests.ts
+++ b/express/express-tests.ts
@@ -50,6 +50,26 @@ router.delete(pathRE);
 router.use((req, res, next) => { next(); })
 router.route('/users')
     .get((req, res, next) => {
+        let types: string[] = req.accepts();
+        let type: string | boolean = req.accepts('json');
+        type = req.accepts(['json', 'text']);
+        type = req.accepts('json', 'text');
+
+        let charsets: string[] = req.acceptsCharsets();
+        let charset: string | boolean = req.acceptsCharsets('utf-8');
+        charset = req.acceptsCharsets(['utf-8', 'utf-16']);
+        charset = req.acceptsCharsets('utf-8', 'utf-16');
+
+        let encodings: string[] = req.acceptsEncodings();
+        let encoding: string | boolean = req.acceptsEncodings('gzip');
+        encoding = req.acceptsEncodings(['gzip', 'deflate']);
+        encoding = req.acceptsEncodings('gzip', 'deflate');
+
+        let languages: string[] = req.acceptsLanguages();
+        let language: string | boolean = req.acceptsLanguages('en');
+        language = req.acceptsLanguages(['en', 'ja']);
+        language = req.acceptsLanguages('en', 'ja');
+
         res.send(req.query['token']);
     });
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Functions `accepts`, `acceptsCharsets`, `acceptsEncodings`, and `acceptsLanguages` of Express `Request` object internally call the corresponding functions of [accepts](https://github.com/jshttp/accepts).

https://github.com/expressjs/express/blob/master/lib/request.js#L126-L176

From the test codes of accepts, it is obvious that these functions should return an array of strings when called without arguments, while they should return string or `false` when called with an argument(s) (which should be a single string, an array of strings, or multiple strings).

https://github.com/jshttp/accepts/tree/master/test
