### PR TITLE
Fixed connect decorator.

### DIFF
--- a/react-redux/react-redux-tests.tsx
+++ b/react-redux/react-redux-tests.tsx
@@ -85,13 +85,20 @@ connect<ICounterStateProps, ICounterDispatchProps, {}>(
     { pure: true }
 )(Counter);
 
-@connect<ICounterStateProps, ICounterDispatchProps, any>(mapStateToProps, mapDispatchToProps)
-class AnotherCounter extends React.Component<any, any> {
+interface AnotherCounterProps {
+    mustHaveValue: number;
+}
+
+@connect<ICounterStateProps, ICounterDispatchProps, AnotherCounterProps>(mapStateToProps, mapDispatchToProps)
+class AnotherCounter extends React.Component<ICounterStateProps & ICounterDispatchProps, any> {
     doSomething(): void {
     }
 }
 
-let doSomethingCounterContainer: React.ComponentClass<any> = connect<ICounterStateProps, ICounterDispatchProps, any>(mapStateToProps, mapDispatchToProps)(AnotherCounter);
+let AnotherCounterContainer: React.ComponentClass<AnotherCounterProps> = connect<ICounterStateProps, ICounterDispatchProps, AnotherCounterProps>(mapStateToProps, mapDispatchToProps)(AnotherCounter);
+let anotherCounterContainerInstance = new AnotherCounterContainer();
+anotherCounterContainerInstance.props.mustHaveValue = 1;
+anotherCounterContainerInstance.render();
 
 class App extends Component<any, any> {
     render(): JSX.Element {

--- a/react-redux/react-redux-tests.tsx
+++ b/react-redux/react-redux-tests.tsx
@@ -55,7 +55,7 @@ connect(
 
 @connect(mapStateToProps)
 class CounterContainer extends Component<any, any> {
-
+    private myProperty: string;
 }
 
 // Ensure connect's first two arguments can be replaced by wrapper functions

--- a/react-redux/react-redux-tests.tsx
+++ b/react-redux/react-redux-tests.tsx
@@ -52,10 +52,8 @@ connect(
     mapDispatchToProps
 )(Counter);
 
-
 @connect(mapStateToProps)
 class CounterContainer extends Component<any, any> {
-    private myProperty: string;
 }
 
 // Ensure connect's first two arguments can be replaced by wrapper functions
@@ -87,6 +85,13 @@ connect<ICounterStateProps, ICounterDispatchProps, {}>(
     { pure: true }
 )(Counter);
 
+@connect<ICounterStateProps, ICounterDispatchProps, any>(mapStateToProps, mapDispatchToProps)
+class AnotherCounter extends React.Component<any, any> {
+    doSomething(): void {
+    }
+}
+
+let doSomethingCounterContainer: React.ComponentClass<any> = connect<ICounterStateProps, ICounterDispatchProps, any>(mapStateToProps, mapDispatchToProps)(AnotherCounter);
 
 class App extends Component<any, any> {
     render(): JSX.Element {

--- a/react-redux/react-redux.d.ts
+++ b/react-redux/react-redux.d.ts
@@ -15,7 +15,7 @@ declare namespace ReactRedux {
   type ActionCreator<A> = Redux.ActionCreator<A>;
 
   interface ComponentDecorator<TOriginalProps, TOwnProps> {
-    (component: ComponentClass<TOriginalProps>|StatelessComponent<TOriginalProps>): ComponentClass<TOwnProps>;
+    (component: ComponentClass<TOriginalProps>|StatelessComponent<TOriginalProps>): ComponentClass<TOwnProps> | any;
   }
 
   /**
@@ -24,7 +24,7 @@ declare namespace ReactRedux {
    * Can't use the above decorator because it would default the type to {}
    */
   export interface InferableComponentDecorator {
-    <P, TComponentConstruct extends (ComponentClass<P>|StatelessComponent<P>)>(component: TComponentConstruct): TComponentConstruct;
+    <P, TComponentConstruct extends (ComponentClass<P>|StatelessComponent<P>)>(component: TComponentConstruct): TComponentConstruct | any;
   }
 
   /**
@@ -88,7 +88,7 @@ declare namespace ReactRedux {
      */
     pure?: boolean;
     /**
-    * If true, stores a ref to the wrapped component instance and makes it available via 
+    * If true, stores a ref to the wrapped component instance and makes it available via
     * getWrappedInstance() method. Defaults to false.
     */
     withRef?: boolean;

--- a/react-redux/react-redux.d.ts
+++ b/react-redux/react-redux.d.ts
@@ -15,7 +15,7 @@ declare namespace ReactRedux {
   type ActionCreator<A> = Redux.ActionCreator<A>;
 
   interface ComponentDecorator<TOriginalProps, TOwnProps> {
-    (component: ComponentClass<TOriginalProps>|StatelessComponent<TOriginalProps>): ComponentClass<TOwnProps> | any;
+    (component: ComponentClass<TOriginalProps>|StatelessComponent<TOriginalProps>): ComponentClass<TOwnProps> & void;
   }
 
   /**
@@ -24,7 +24,7 @@ declare namespace ReactRedux {
    * Can't use the above decorator because it would default the type to {}
    */
   export interface InferableComponentDecorator {
-    <P, TComponentConstruct extends (ComponentClass<P>|StatelessComponent<P>)>(component: TComponentConstruct): TComponentConstruct | any;
+    <P, TComponentConstruct extends (ComponentClass<P>|StatelessComponent<P>)>(component: TComponentConstruct): TComponentConstruct;
   }
 
   /**


### PR DESCRIPTION
case 2. Improvement to existing type definition.
Now it can be applied on components that has custom properties or functions.

Reason:
When using connect on a class that has custom behavior like custom properties or function than the TypeScript compiler gives back the following error:
Unable to resolve signature of class decorator when called as an expression. Type 'ComponentClass<{}>' is not assignable to type 'void'.

I modified the test to contain my issue:
@connect(mapStateToProps)
class CounterContainer extends Component<any, any> {
    private myProperty: string; // custom "behavior"
}

According to TypeScript documentation:
"If the class decorator returns a value, it will replace the class declaration with the provided constructor function.

NOTE  Should you chose to return a new constructor function, you must take care to maintain the original prototype. The logic that applies decorators at runtime will not do this for you."

https://www.typescriptlang.org/docs/handbook/decorators.html
