### PR TITLE
Adding missing method persist from SyntheticEvent

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -277,6 +277,7 @@ declare namespace __React {
         nativeEvent: Event;
         preventDefault(): void;
         stopPropagation(): void;
+        persist(): void;
         target: EventTarget;
         timeStamp: Date;
         type: string;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
Adding missing method persist from SyntheticEvent
Reference: https://facebook.github.io/react/docs/events.html#event-pooling
'If you want to access the event properties in an asynchronous way, you should call `event.persist()` on the event, which will remove the synthetic event from the pool and allow references to the event to be retained by user code.'
