### PR TITLE
Added typings for react-css-modules

### DIFF
--- a/react-css-modules/react-css-modules-tests.tsx
+++ b/react-css-modules/react-css-modules-tests.tsx
@@ -1,0 +1,47 @@
+///<reference path="../react/react.d.ts" />
+///<reference path="./react-css-modules.d.ts" />
+
+
+import * as React from 'react';
+import * as CSSModules from 'react-css-modules';
+
+const styles = {};
+
+interface TableProps extends CSSModules.InjectedCSSModuleProps {
+
+}
+
+class Table extends React.Component<TableProps, {}> {
+    render () {
+        const { styles } = this.props;
+
+        return <div styleName='table'>
+            <div styleName='row'>
+                <div styleName='cell'>A0</div>
+                <div styleName='cell'>B0</div>
+            </div>
+        </div>;
+    }
+}
+
+const TableHOC = CSSModules(Table, styles);
+
+
+
+interface TableDecoratedProps extends CSSModules.InjectedCSSModuleProps {
+
+}
+
+@CSSModules(styles)
+class TableDecorated extends React.Component<TableDecoratedProps, {}> {
+    render () {
+        const { styles } = this.props;
+
+        return <div styleName='table'>
+            <div styleName='row'>
+                <div styleName='cell'>A0</div>
+                <div styleName='cell'>B0</div>
+            </div>
+        </div>;
+    }
+}

--- a/react-css-modules/react-css-modules.d.ts
+++ b/react-css-modules/react-css-modules.d.ts
@@ -19,8 +19,11 @@ declare module 'react-css-modules' {
     }
 
     module CSSModules {
+        // Extend your component's Prop interface with this one to get access to `this.props.styles`
+        //
+        // interface MyComponentProps extends CSSModules.InjectedCSSModuleProps {}
         interface InjectedCSSModuleProps {
-            styles: StylesObject;
+            styles?: StylesObject;
         }
     }
 

--- a/react-css-modules/react-css-modules.d.ts
+++ b/react-css-modules/react-css-modules.d.ts
@@ -1,0 +1,30 @@
+// Type definitions for react-css-modules 3.7.9
+// Project: https://github.com/gajus/react-css-modules
+// Definitions by: Kostya Esmukov <https://github.com/KostyaEsmukov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+
+declare module 'react-css-modules' {
+
+    interface TypeOptions {
+        allowMultiple?: boolean;
+        errorWhenNotFound?: boolean;
+    }
+
+    type StylesObject = any;
+
+    interface CSSModules {
+        (defaultStyles: StylesObject, options?: TypeOptions): <C extends Function>(Component: C) => C;
+        <C extends Function>(Component: C, defaultStyles: StylesObject, options?: TypeOptions): C;
+    }
+
+    module CSSModules {
+        interface InjectedCSSModuleProps {
+            styles: StylesObject;
+        }
+    }
+
+    let CSSModules: CSSModules;
+
+    export = CSSModules;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
