### PR TITLE
Added missing function config() to Pikaday class

### DIFF
--- a/pikaday/pikaday.d.ts
+++ b/pikaday/pikaday.d.ts
@@ -11,6 +11,14 @@ declare class Pikaday {
     constructor(options: Pikaday.PikadayOptions);
 
     /**
+     * Extends the existing configuration options for Pikaday object with the options provided.
+     * Can be used to change/extend the configurations on runtime.
+     * @param options full/partial configuration options.
+     * @returns {} extended configurations.
+     */
+    config(options: Pikaday.PikadayOptions): Pikaday.PikadayOptions;
+
+    /**
      * Returns the selected date in a string format. If Moment.js exists
      * (recommended) then Pikaday can return any format that Moment
      * understands, otherwise you're stuck with JavaScript's default.


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

This function was missing from the type definitions that can be used at
runtime to change/extend configuration options.

Can be very useful to change various configurations, such as i18n
(culture information), format, firstDay etc. on runtime.
