### PR TITLE
Added typings for react-breadcrumbs

### DIFF
--- a/react-breadcrumbs/react-breadcrumbs-tests.tsx
+++ b/react-breadcrumbs/react-breadcrumbs-tests.tsx
@@ -1,0 +1,25 @@
+///<reference path="../react/react.d.ts" />
+///<reference path="../react-router/react-router.d.ts"/>
+///<reference path="./react-breadcrumbs.d.ts" />
+
+
+import * as React from 'react';
+import * as Breadcrumbs from 'react-breadcrumbs';
+
+
+interface MyComponentProps extends ReactRouter.RouteComponentProps<{}, { id: number }> {
+}
+
+
+class MyComponent extends React.Component<MyComponentProps, {}> {
+    render() {
+        return (
+            <div>
+                <Breadcrumbs
+                    routes={this.props.routes}
+                    params={this.props.params}
+                />
+            </div>
+        );
+    }
+}

--- a/react-breadcrumbs/react-breadcrumbs.d.ts
+++ b/react-breadcrumbs/react-breadcrumbs.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for react-breadcrumbs 1.3.16
+// Project: https://github.com/svenanders/react-breadcrumbs
+// Definitions by: Kostya Esmukov <https://github.com/KostyaEsmukov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+///<reference path="../react/react.d.ts"/>
+///<reference path="../react-router/react-router.d.ts"/>
+
+declare namespace ReactBreadcrumbs {
+    import React = __React;
+
+
+    interface BreadcrumbsProps extends React.Props<Breadcrumbs> {
+        separator?: string | JSX.Element;
+        displayMissing?: boolean;
+        prettify?: boolean;
+        displayMissingText?: string;
+        displayName?: string;
+        breadcrumbName?: string;
+        wrapperElement?: string;
+        wrapperClass?: string;
+        itemElement?: string;
+        itemClass?: string;
+        customClass?: string;
+        activeItemClass?: string;
+        excludes?: string[];
+        hideNoPath?: boolean;
+        routes: ReactRouter.RouteConfig;
+        setDocumentTitle?: boolean;
+        params?: any;  // todo make it compatible with params of the ReactRouter.RouteComponentProps<P, R>
+    }
+
+    interface Breadcrumbs extends React.ComponentClass<BreadcrumbsProps> {}
+    const Breadcrumbs: Breadcrumbs;
+}
+
+declare module 'react-breadcrumbs' {
+    import Breadcrumbs = ReactBreadcrumbs.Breadcrumbs;
+
+    export = Breadcrumbs;
+}


### PR DESCRIPTION
Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
