### PR TITLE
[Drop] Fix issue where createContext did not return constructable type

### DIFF
--- a/drop/drop-tests.ts
+++ b/drop/drop-tests.ts
@@ -36,3 +36,11 @@ var e = new Drop({
     content: () => greenBox
 });
 
+var Tooltip = Drop.createContext({
+    classPrefix: 'tooltip'
+});
+
+var t = new Tooltip({
+    target: yellowBox,
+    content: () => greenBox
+});

--- a/drop/drop.d.ts
+++ b/drop/drop.d.ts
@@ -27,7 +27,7 @@ declare class Drop {
     public once(event: string, handler: Function, context?: any): void;
     public off(event: string, handler?: Function): void;
 
-    public static createContext(options: Drop.IDropContextOptions): Drop.IDropConstructor;
+    public static createContext(options: Drop.IDropContextOptions): typeof Drop;
 }
 
 declare namespace Drop {
@@ -53,10 +53,6 @@ declare namespace Drop {
         hoverOpenDelay?: number;
         hoverCloseDelay?: number;
         tetherOptions?: Tether.ITetherOptions;
-    }
-
-    interface IDropConstructor {
-        new (options: Drop.IDropOptions): Drop;
     }
 }
 

--- a/drop/drop.d.ts
+++ b/drop/drop.d.ts
@@ -63,4 +63,3 @@ declare namespace Drop {
 declare module "drop" {
     export = Drop;
 }
-

--- a/drop/drop.d.ts
+++ b/drop/drop.d.ts
@@ -27,7 +27,7 @@ declare class Drop {
     public once(event: string, handler: Function, context?: any): void;
     public off(event: string, handler?: Function): void;
 
-    public static createContext(options: Drop.IDropContextOptions): Drop;
+    public static createContext(options: Drop.IDropContextOptions): Drop.IDropConstructor;
 }
 
 declare namespace Drop {
@@ -53,6 +53,10 @@ declare namespace Drop {
         hoverOpenDelay?: number;
         hoverCloseDelay?: number;
         tetherOptions?: Tether.ITetherOptions;
+    }
+
+    interface IDropConstructor {
+        new (options: Drop.IDropOptions): Drop;
     }
 }
 


### PR DESCRIPTION
createContext function is a factory for a constructor function.
This means that it should return a type where we can construct a new Drop object with the new keyword.
This however was not the case, as it returned a Drop typed object which is not instantiable.
I changed the return type so that instead of returning a Drop object, this function returns a constructor interface that can be instantiated, and constructs a Drop object.
