### PR TITLE
Added typings for react-i18next

### DIFF
--- a/react-i18next/react-i18next-tests.tsx
+++ b/react-i18next/react-i18next-tests.tsx
@@ -1,0 +1,95 @@
+///<reference path="../react/react.d.ts" />
+///<reference path="../react/react-dom.d.ts" />
+///<reference path="../i18next/i18next.d.ts" />
+///<reference path="./react-i18next.d.ts" />
+
+
+import * as ReactDOM from 'react-dom';
+import * as React from 'react';
+import * as i18n from 'i18next';
+import { translate, I18nextProvider, Interpolate, InjectedTranslateProps } from 'react-i18next';
+
+
+i18n
+    .init({
+        fallbackLng: 'en',
+
+        // have a common namespace used around the full app
+        ns: ['common'],
+        defaultNS: 'common',
+
+        debug: true,
+
+        interpolation: {
+            escapeValue: false // not needed for react!!
+        }
+    });
+
+
+interface InnerAnotherComponentProps extends InjectedTranslateProps {
+}
+
+class InnerAnotherComponent extends React.Component<InnerAnotherComponentProps, {}> {
+    render() {
+        const { t } = this.props;
+
+        return <p>{t('content.text', { /* options t options */ })}</p>;
+    }
+}
+
+const AnotherComponent = translate('view', { wait: true })(InnerAnotherComponent);
+
+
+
+interface InnerYetAnotherComponentProps extends InjectedTranslateProps {
+}
+
+class InnerYetAnotherComponent extends React.Component<InnerYetAnotherComponentProps, {}> {
+    render() {
+        const { t } = this.props;
+
+        return <p>{t('usingDefaultNS', { /* options t options */ })}</p>;
+    }
+}
+const YetAnotherComponent = translate()(InnerYetAnotherComponent);
+
+
+interface TranslatableViewProps extends InjectedTranslateProps {
+}
+
+@translate(['view', 'nav'], { wait: true })
+class TranslatableView extends React.Component<TranslatableViewProps, {}> {
+    render() {
+        const { t } = this.props;
+
+        let interpolateComponent = <strong>"a interpolated component"</strong>;
+
+        return (
+            <div>
+                <h1>{t('common:appName')}</h1>
+                <AnotherComponent />
+                <YetAnotherComponent />
+                <Interpolate parent='p' i18nKey='common:interpolateSample' value='"some value in props"' component={interpolateComponent} />
+                <a href='https://github.com/i18next/react-i18next' target='_blank'>{t('nav:link1')}</a>
+            </div>
+        )
+    }
+}
+
+class App extends React.Component<{}, {}> {
+    render() {
+        return (
+            <div className='main'>
+                <main>
+                    <TranslatableView />
+                </main>
+            </div>
+        );
+    }
+}
+
+
+ReactDOM.render(
+    <I18nextProvider i18n={ i18n }><App /></I18nextProvider>,
+    document.getElementById('app')
+);

--- a/react-i18next/react-i18next.d.ts
+++ b/react-i18next/react-i18next.d.ts
@@ -1,0 +1,56 @@
+// Type definitions for react-i18next 1.6.3
+// Project: https://github.com/i18next/react-i18next
+// Definitions by: Kostya Esmukov <https://github.com/KostyaEsmukov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+///<reference path="../react/react.d.ts"/>
+///<reference path="../react-router/react-router.d.ts"/>
+///<reference path="../i18next/i18next.d.ts" />
+
+
+declare namespace ReactI18next {
+    import React = __React;
+
+    // Extend your component's Prop interface with this one to get access to `this.props.t`
+    //
+    // interface MyComponentProps extends ReactI18next.InjectedTranslateProps {}
+    export interface InjectedTranslateProps {
+        t?: I18next.TranslationFunction;
+    }
+
+    interface I18nextProviderProps {
+        i18n: I18next.I18n;
+        children?: React.ReactElement<any>;
+    }
+
+    export class I18nextProvider extends React.Component<I18nextProviderProps, {}> { }
+
+
+    type InterpolateValue = string | JSX.Element;
+
+    interface InterpolateProps {
+        i18nKey: string;
+
+        parent?: string;
+        regexp?: RegExp;
+        options?: I18next.TranslationOptions;
+
+        [regexKey: string]: InterpolateValue | RegExp | I18next.TranslationOptions;
+    }
+
+    export class Interpolate extends React.Component<InterpolateProps, {}> { }
+
+    interface TranslateOptions {
+        withRef?: boolean;
+        wait?: boolean;
+    }
+
+    export function translate(namespaces?: string[] | string, options?: TranslateOptions): <C extends Function>(WrappedComponent: C) => C;
+
+    export function loadNamespaces({ components, i18n }: { components: ReactRouter.RouteComponent[], i18n: I18next.I18n }): Promise<void>;
+
+}
+
+declare module 'react-i18next' {
+    export = ReactI18next;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

---

Please note that compilation with `--module commonjs` fails (just like the react-native right now #10264)

```
$ tsc --noImplicitAny --jsx react --experimentalDecorators --module commonjs react-i18next/react-i18next-tests.tsx
react-i18next/react-i18next.d.ts(50,118): error TS2304: Cannot find name 'Promise'.
```
