### PR TITLE
add types of json-editor

### DIFF
--- a/json-editor/json-editor-tests.ts
+++ b/json-editor/json-editor-tests.ts
@@ -1,0 +1,146 @@
+/// <reference path="json-editor.d.ts" />
+
+var element = document.getElementById('editor_holder');
+var editor = new JSONEditor(element, {});
+
+// Set an option globally
+JSONEditor.defaults.options.theme = 'bootstrap2';
+// Set an option during instantiation
+editor = new JSONEditor(element, {
+    theme: 'bootstrap2'
+});
+editor.on('ready', function () {
+    // Now the api methods will be available
+    editor.validate();
+});
+
+var editor2 = new JSONEditor<{ name: string; }>(element, {});
+editor2.setValue({ name: "John Smith" });
+var value = editor2.getValue();
+console.log(value.name) // Will log "John Smith"
+
+// Get a reference to a node within the editor
+var name2 = editor.getEditor('root.name');
+
+// `getEditor` will return null if the path is invalid
+if (name2) {
+    name2.setValue("John Smith");
+
+    console.log(name2.getValue());
+}
+
+var errors = editor.validate();
+
+if (errors.length) {
+    // errors is an array of objects, each with a `path`, `property`, and `message` parameter
+    // `property` is the schema keyword that triggered the validation error (e.g. "minLength")
+    // `path` is a dot separated path into the JSON object (e.g. "root.path.to.field")
+    console.log(errors);
+}
+else {
+    // It's valid!
+}
+
+// Validate an arbitrary value against the editor's schema
+var errors = editor.validate({
+    value: {
+        to: "test"
+    }
+});
+
+editor.on('change', function () {
+    // Do something
+});
+
+editor.off('change', function () {
+    // Do something
+});
+
+editor.watch('path.to.field', function () {
+    // Do something
+});
+
+editor.unwatch('path.to.field', function () {
+    // Do something
+});
+
+// Disable entire form
+editor.disable();
+
+// Disable part of the form
+editor.getEditor('root.location').disable();
+
+// Enable entire form
+editor.enable();
+
+// Enable part of the form
+editor.getEditor('root.location').enable();
+
+// Check if form is currently enabled
+if (editor.isEnabled()) alert("It's editable!");
+
+editor.destroy();
+
+JSONEditor.defaults.options.theme = 'foundation5';
+
+JSONEditor.plugins.sceditor.emoticonsEnabled = false;
+
+JSONEditor.plugins.epiceditor.basePath = 'epiceditor';
+
+JSONEditor.plugins.ace.theme = 'twilight';
+
+JSONEditor.defaults.editors.object.options.collapsed = true;
+
+JSONEditor.defaults.options.template = 'handlebars';
+
+var myengine = {
+    compile: function (template: any) {
+        // Compile should return a render function
+        return function (vars: any) {
+            // A real template engine would render the template here
+            var result = template;
+            return result;
+        }
+    }
+};
+
+// Set globally
+JSONEditor.defaults.options.template = myengine;
+
+// Override a specific translation
+JSONEditor.defaults.languages.en.error_minLength =
+    "This better be at least {{0}} characters long or else!";
+
+
+// Create your own language mapping
+// Any keys not defined here will fall back to the "en" language
+JSONEditor.defaults.languages.es = {
+    error_notset: "propiedad debe existir"
+};
+
+JSONEditor.defaults.language = "es";
+
+JSONEditor.defaults.resolvers.unshift(function (schema) {
+    if (schema.type === "object" && schema.format === "location") {
+        return "location";
+    }
+
+    // If no valid editor is returned, the next resolver function will be used
+});
+
+JSONEditor.plugins.selectize.enable = true;
+
+JSONEditor.defaults.custom_validators.push(function (schema, value, path) {
+    var errors: JSONEditorError[] = [];
+    if (schema.format === "date") {
+        if (!/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(value)) {
+            // Errors must be an object with `path`, `property`, and `message`
+            errors.push({
+                path: path,
+                property: 'format',
+                message: 'Dates must be in the format "YYYY-MM-DD"'
+            });
+        }
+    }
+    return errors;
+});

--- a/json-editor/json-editor.d.ts
+++ b/json-editor/json-editor.d.ts
@@ -1,0 +1,184 @@
+// Type definitions for json-editor
+// Project: https://github.com/jdorn/json-editor
+// Definitions by: York Yao <https://github.com/plantain-00/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type JSONEditorOptions<TValue> = {
+    /**
+     * If true, JSON Editor will load external URLs in $ref via ajax.
+     */
+    ajax?: boolean;
+    /**
+     * If true, remove all "add row" buttons from arrays.
+     */
+    disable_array_add?: boolean;
+    /**
+     * If true, remove all "delete row" buttons from arrays.
+     */
+    disable_array_delete?: boolean;
+    /**
+     * If true, remove all "move up" and "move down" buttons from arrays.
+     */
+    disable_array_reorder?: boolean;
+    /**
+     * If true, remove all collapse buttons from objects and arrays.
+     */
+    disable_collapse?: boolean;
+    /**
+     * If true, remove all Edit JSON buttons from objects.
+     */
+    disable_edit_json?: boolean;
+    /**
+     * If true, remove all Edit Properties buttons from objects.
+     */
+    disable_properties?: boolean;
+    /**
+     * The first part of the `name` attribute of form inputs in the editor. An full example name is `root[person][name]` where "root" is the form_name_root.
+     */
+    form_name_root?: string;
+    /**
+     * The icon library to use for the editor.
+     */
+    iconlib?: boolean;
+    /**
+     * If true, objects can only contain properties defined with the properties keyword.
+     */
+    no_additional_properties?: boolean;
+    /**
+     * An object containing schema definitions for URLs. Allows you to pre-define external schemas.
+     */
+    refs?: any;
+    /**
+     * If true, all schemas that don't explicitly set the required property will be required.
+     */
+    required_by_default?: boolean;
+    /**
+     * If true, makes oneOf copy properties over when switching.
+     */
+    keep_oneof_values?: boolean;
+    /**
+     * A valid JSON Schema to use for the editor. Version 3 and Version 4 of the draft specification are supported.
+     */
+    schema?: any;
+    /**
+     * When to show validation errors in the UI. Valid values are interaction, change, always, and never.
+     */
+    show_errors?: "interaction" | "change" | "always" | "never";
+    /**
+     * Seed the editor with an initial value. This should be valid against the editor's schema.
+     */
+    startval?: TValue;
+    /**
+     * The JS template engine to use.
+     */
+    template?: string | { compile: (template: string) => (vars: any) => string };
+    /**
+     * The CSS theme to use.
+     */
+    theme?: string;
+    /**
+     * If true, only required properties will be included by default.
+     */
+    display_required_only?: boolean;
+}
+type JSONEditorError = {
+    path: string;
+    property: string;
+    message: string;
+}
+type JSONEditorObjectOptions = {
+    /**
+     * If set to true, the editor will start collapsed
+     */
+    collapsed?: boolean;
+    /**
+     * If set to true, the collapse button will be hidden
+     */
+    disable_collapse?: boolean;
+    /**
+     * If set to true, the Edit JSON button will be hidden
+     */
+    disable_edit_json?: boolean;
+    /**
+     * If set to true, the Edit Properties button will be hidden
+     */
+    disable_properties?: boolean;
+}
+type JSONEditorArrayOptions = {
+    /**
+     * If set to true, the editor will start collapsed
+     */
+    collapsed?: boolean;
+    /**
+     * If set to true, the "add row" button will be hidden
+     */
+    disable_array_add?: boolean;
+    /**
+     * If set to true, all of the "delete" buttons will be hidden
+     */
+    disable_array_delete?: boolean;
+    /**
+     * If set to true, just the "delete all rows" button will be hidden
+     */
+    disable_array_delete_all_rows?: boolean;
+    /**
+     * If set to true, just the "delete last row" buttons will be hidden
+     */
+    disable_array_delete_last_row?: boolean;
+    /**
+     * If set to true, the "move up/down" buttons will be hidden
+     */
+    disable_array_reorder?: boolean;
+    /**
+     * If set to true, the collapse button will be hidden
+     */
+    disable_collapse?: boolean;
+}
+declare class JSONEditor<TValue> {
+    public static defaults: {
+        options: JSONEditorOptions<any>;
+        editors: {
+            object: {
+                options: JSONEditorObjectOptions;
+            };
+            array: {
+                options: JSONEditorArrayOptions;
+            }
+        };
+        languages: any;
+        language: string;
+        resolvers: ((schema: any) => string)[];
+        custom_validators: (((schema: any, value: string, path: string) => JSONEditorError[]))[];
+    };
+    public static plugins: {
+        sceditor: {
+            emoticonsEnabled: boolean;
+        };
+        epiceditor: {
+            basePath: string;
+        };
+        ace: {
+            theme: string;
+        };
+        selectize: {
+            enable: boolean;
+        };
+    };
+    constructor(element: HTMLElement, options: JSONEditorOptions<TValue>);
+    public on(event: string, fn: Function): JSONEditor<TValue>;
+    public off(event: string, fn: Function): JSONEditor<TValue>;
+    public watch(event: string, fn: Function): JSONEditor<TValue>;
+    public unwatch(event: string, fn: Function): JSONEditor<TValue>;
+    public validate(value?: TValue): JSONEditorError[];
+    public setValue(value: TValue): void;
+    public getValue(): TValue;
+    public getEditor(name: string): JSONEditor<TValue>;
+    public disable(): void;
+    public enable(): void;
+    public isEnabled(): boolean;
+    public destroy(): void;
+}
+
+declare module "json-editor" {
+    export = JSONEditor;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
