### PR TITLE
Fix error TS2497 on import * as X from 'koa-static

### DIFF
--- a/koa-static/koa-static.d.ts
+++ b/koa-static/koa-static.d.ts
@@ -46,6 +46,6 @@ declare module "koa-static" {
          */
         gzip?: boolean;
     }): { (ctx: Koa.Context, next?: () => any): any };
-
+    namespace serve{}
     export = serve;
 }


### PR DESCRIPTION
Fixes Microsoft/TypeScript#5073 error on koa-static.
