### PR TITLE
Add scriptjs type defs

### DIFF
--- a/scriptjs/scriptjs-tests.ts
+++ b/scriptjs/scriptjs-tests.ts
@@ -17,17 +17,7 @@ function main(): void {
   $script.ready('foo', callback);
   $script.ready('bundle', callback);
 
-  const deps = {
-    foo: 'foo.js',
-    bar: 'bar.js',
-    thunk: ['thunkor.js', 'thunky.js'],
-  };
-
-  $script.ready(['foo', 'bar', 'thunk'], callback, (missing: string[]): void => {
-    missing.forEach((dep: string): void => {
-      $script(deps[dep], dep);
-    });
-  });
+  $script.ready(['foo', 'bar', 'thunk'], callback, (missing: string[]): void => console.log('missing deps:', missing));
 
   $script.path('/js/modules/');
 

--- a/scriptjs/scriptjs-tests.ts
+++ b/scriptjs/scriptjs-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="scriptjs.d.ts" />
 
-import $script = require("scriptjs");
+import * as $script from 'scriptjs';
 
 const callback = (): void => console.log('done');
 

--- a/scriptjs/scriptjs-tests.ts
+++ b/scriptjs/scriptjs-tests.ts
@@ -1,0 +1,39 @@
+/// <reference path="scriptjs.d.ts" />
+
+import $script = require("scriptjs");
+
+const callback = () => console.log('done');
+
+function main(): void {
+  $script('foo.js', callback);
+  $script(['foo.js', 'bar.js'], callback);
+
+  $script('foo.js', 'foo', callback);
+  $script(['foo.js', 'bar.js'], 'bundle', callback);
+
+  $script('foo', callback);
+  $script('bundle', callback);
+
+  $script.ready('foo', callback);
+  $script.ready('bundle', callback);
+
+  const deps = {
+    foo: 'foo.js',
+    bar: 'bar.js',
+    thunk: ['thunkor.js', 'thunky.js'],
+  };
+
+  $script.ready(['foo', 'bar', 'thunk'], callback, (missing: string[]) => {
+    missing.forEach((dep: string) => {
+      $script(deps[dep], dep);
+    });
+  });
+
+  $script.path('/js/modules/');
+
+  $script.get('http://example.com/base.js', callback);
+
+  $script.urlArgs('key=value&foo=bar');
+
+  $script.order(['foo.js', 'bar.js'], 'bundle', callback);
+}

--- a/scriptjs/scriptjs-tests.ts
+++ b/scriptjs/scriptjs-tests.ts
@@ -2,7 +2,7 @@
 
 import $script = require("scriptjs");
 
-const callback = () => console.log('done');
+const callback = (): void => console.log('done');
 
 function main(): void {
   $script('foo.js', callback);
@@ -23,8 +23,8 @@ function main(): void {
     thunk: ['thunkor.js', 'thunky.js'],
   };
 
-  $script.ready(['foo', 'bar', 'thunk'], callback, (missing: string[]) => {
-    missing.forEach((dep: string) => {
+  $script.ready(['foo', 'bar', 'thunk'], callback, (missing: string[]): void => {
+    missing.forEach((dep: string): void => {
       $script(deps[dep], dep);
     });
   });

--- a/scriptjs/scriptjs.d.ts
+++ b/scriptjs/scriptjs.d.ts
@@ -1,0 +1,12 @@
+interface $script {
+  (paths:string | string[], idOrDone:string | (() => void), optDone?:() => void): $script;
+  get(path:string, fn:() => void);
+  order(scripts:string[], id:string, done:() => void);
+  path(p:string);
+  urlArts(str:string);
+  ready(deps:string | string[], ready:() => void, req?:(missing:string[]) => void): $script;
+}
+
+declare var $script: $script;
+
+export = $script;

--- a/scriptjs/scriptjs.d.ts
+++ b/scriptjs/scriptjs.d.ts
@@ -3,7 +3,7 @@ interface $script {
   get(path:string, fn:() => void): void;
   order(scripts:string[], id:string, done:() => void): void;
   path(p:string): void;
-  urlArts(str:string): void;
+  urlArgs(str:string): void;
   ready(deps:string | string[], ready:() => void, req?:(missing:string[]) => void): $script;
 }
 

--- a/scriptjs/scriptjs.d.ts
+++ b/scriptjs/scriptjs.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for scriptjs
 // Project: https://github.com/ded/script.js
-// Definitions by: ssttevee
+// Definitions by: Steve Lam <http://ssttevee.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface $script {

--- a/scriptjs/scriptjs.d.ts
+++ b/scriptjs/scriptjs.d.ts
@@ -1,3 +1,8 @@
+// Type definitions for scriptjs
+// Project: https://github.com/ded/script.js
+// Definitions by: ssttevee
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
 interface $script {
   (paths:string | string[], idOrDone:string | (() => void), optDone?:() => void): $script;
   get(path:string, fn:() => void): void;

--- a/scriptjs/scriptjs.d.ts
+++ b/scriptjs/scriptjs.d.ts
@@ -1,9 +1,9 @@
 interface $script {
   (paths:string | string[], idOrDone:string | (() => void), optDone?:() => void): $script;
-  get(path:string, fn:() => void);
-  order(scripts:string[], id:string, done:() => void);
-  path(p:string);
-  urlArts(str:string);
+  get(path:string, fn:() => void): void;
+  order(scripts:string[], id:string, done:() => void): void;
+  path(p:string): void;
+  urlArts(str:string): void;
   ready(deps:string | string[], ready:() => void, req?:(missing:string[]) => void): $script;
 }
 

--- a/scriptjs/scriptjs.d.ts
+++ b/scriptjs/scriptjs.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for scriptjs
 // Project: https://github.com/ded/script.js
-// Definitions by: Steve Lam <http://ssttevee.com>
+// Definitions by: Steve Lam <https://github.com/ssttevee>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface $script {
@@ -12,6 +12,7 @@ interface $script {
   ready(deps:string | string[], ready:() => void, req?:(missing:string[]) => void): $script;
 }
 
-declare var $script: $script;
-
-export = $script;
+declare module 'scriptjs'{ 
+    var $script: $script; 
+    export = $script; 
+}


### PR DESCRIPTION
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

for https://www.npmjs.com/package/scriptjs
