### PR TITLE
flashvars should be flashVars

### DIFF
--- a/react-swf/index.d.ts
+++ b/react-swf/index.d.ts
@@ -108,7 +108,7 @@ declare namespace rswf {
         * Browsers support string sizes of up to 64 KB (65535 bytes) in length.
         * For more information on using flashvars, see Using FlashVars to pass variables to a SWF (tn_16417).
         */
-        flashvars?: Object | string
+        flashVars?: Object | string
     }
     export class ReactSWF extends React.Component<Props, State>{
         /**


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url https://github.com/syranide/react-swf .

`flashvars` should be `flashVars`, see first example here: https://github.com/syranide/react-swf
Also I can confirm that it works only this way.
