### PR TITLE
Update serialport for 4.0 changes to the way it is exported

### DIFF
--- a/serialport/serialport-tests.ts
+++ b/serialport/serialport-tests.ts
@@ -1,38 +1,38 @@
 // Tests for serialport.d.ts
-// Project: https://github.com/EmergingTechnologyAdvisors/node-serialport 
+// Project: https://github.com/EmergingTechnologyAdvisors/node-serialport
 // Definitions by: Jeremy Foster <https://github.com/codefoster>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Tests taken from documentation samples.
 
 /// <reference path="serialport.d.ts" />
 
-import * as serialport from 'serialport';
+import * as SerialPort from 'serialport';
 
 function test_basic_connect() {
-    let port = new serialport.SerialPort("");
+    let port = new SerialPort("");
 }
 
 function test_connect_config() {
-    let port = new serialport.SerialPort("", {
+    let port = new SerialPort("", {
         baudrate: 0,
         disconnectedCallback: function () { },
-        parser: serialport.parsers.readline("\n")
+        parser: SerialPort.parsers.readline("\n")
     });
 }
 
 function test_write() {
-    let port = new serialport.SerialPort("");
-    port.write('main screen turn on', (err, bytesWritten) => {
+    let port = new SerialPort("");
+    port.write("main screen turn on", (err, bytesWritten) => {
     });
 }
 
 function test_events() {
-    let port = new serialport.SerialPort("");
-    port.on('open', function () { });
+    let port = new SerialPort("");
+    port.on("open", function () { });
 }
 
 function test_list_ports() {
-    serialport.list( (err:string, ports:serialport.portConfig[]) => {
+    SerialPort.list( (err: string, ports: SerialPort.portConfig[]) => {
 
     });
 }

--- a/serialport/serialport.d.ts
+++ b/serialport/serialport.d.ts
@@ -1,51 +1,53 @@
-// Type definitions for serialport
-// Project: https://github.com/EmergingTechnologyAdvisors/node-serialport 
+// Type definitions for serialport 4.0.1
+// Project: https://github.com/EmergingTechnologyAdvisors/node-serialport
 // Definitions by: Jeremy Foster <https://github.com/codefoster>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped 
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module 'serialport' {
-    module parsers {
-        function readline(delimiter: string):void;
-        function raw(emitter:any, buffer:string):void
-    }
-
-    export class SerialPort {
-        constructor(path: string, options?: Object, openImmediately?: boolean, callback?: (err:string) => void)
+    class SerialPort {
+        constructor(path: string, options?: Object, openImmediately?: boolean, callback?: (err: string) => void)
         isOpen: boolean;
-        on(event: string, callback?: (data?:any) => void):void;
-        open(callback?: () => void):void;
-        write(buffer: any, callback?: (err:string, bytesWritten:number) => void):void
-        pause():void;
-        resume():void;
-        disconnected(err: Error):void;
-        close(callback?: () => void):void;
-        flush(callback?: () => void):void;
-        set(options: setOptions, callback: () => void):void;
-        drain(callback?: () => void):void;
-        update(options: updateOptions, callback?: () => void):void;
+        on(event: string, callback?: (data?: any) => void): void;
+        open(callback?: () => void): void;
+        write(buffer: any, callback?: (err: string, bytesWritten: number) => void): void
+        pause(): void;
+        resume(): void;
+        disconnected(err: Error): void;
+        close(callback?: () => void): void;
+        flush(callback?: () => void): void;
+        set(options: SerialPort.setOptions, callback: () => void): void;
+        drain(callback?: () => void): void;
+        update(options: SerialPort.updateOptions, callback?: () => void): void;
+        static list(callback: (err: string, ports: SerialPort.portConfig[]) => void): void;
+        static parsers: {
+            readline: (delimiter: string) => void,
+            raw: (emitter: any, buffer: string) => void
+        };
     }
 
-    export function list(callback: (err: string, ports:portConfig[]) => void): void;
+    namespace SerialPort {
+        interface portConfig {
+            comName: string;
+            manufacturer: string;
+            serialNumber: string;
+            pnpId: string;
+            locationId: string;
+            vendorId: string;
+            productId: string;
+        }
 
-    interface portConfig {
-        comName: string,
-        manufacturer: string,
-        serialNumber: string,
-        pnpId: string,
-        locationId: string,
-        vendorId: string,
-        productId: string
+        interface setOptions {
+            brk?: boolean;
+            cts?: boolean;
+            dsr?: boolean;
+            dtr?: boolean;
+            rts?: boolean;
+        }
+
+        interface updateOptions {
+            baudRate?: number;
+        }
     }
 
-    interface setOptions {
-        brk?: boolean;
-        cts?: boolean;
-        dsr?: boolean;
-        dtr?: boolean;
-        rts?: boolean;
-    }
-    
-    interface updateOptions {
-        baudRate?: number
-    }
+    export = SerialPort
 }


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/10500

Updates based on 4.0 changes to the way the library is exported. See deprecation warning here: https://github.com/EmergingTechnologyAdvisors/node-serialport/blob/master/lib/serialport.js#L664
