### PR TITLE
Node.d.ts: It's compatible for **express.Application**

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -715,6 +715,7 @@ declare module "http" {
         [errorCode: number]: string;
         [errorCode: string]: string;
     };
+    export function createServer(requestListener?: Function): Server;
     export function createServer(requestListener?: (request: IncomingMessage, response: ServerResponse) => void): Server;
     export function createClient(port?: number, host?: string): any;
     export function request(options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -715,8 +715,8 @@ declare module "http" {
         [errorCode: number]: string;
         [errorCode: string]: string;
     };
-    export function createServer(requestListener?: Function): Server;
     export function createServer(requestListener?: (request: IncomingMessage, response: ServerResponse) => void): Server;
+    export function createServer(requestListener?: Function): Server;
     export function createClient(port?: number, host?: string): any;
     export function request(options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
     export function get(options: any, callback?: (res: IncomingMessage) => void): ClientRequest;


### PR DESCRIPTION
Refer to #10507 , @mahald had a issue when he/she assigned a assigned a **express.Application** object to **http.createServer**, it happended error.

According to his/her situation, I simplify the code and show the point:

``` ts
import * as http from 'http';
import * as express from 'express';

const app: express.Application = express();

http.createServer(app).listen(5678);  // there is hinted error by definition
```

In order to be compatible for **express**, this is my solution, please refer this commit.

If anyone has any questions, please let me know.
