### PR TITLE
add types of get-port

### DIFF
--- a/get-port/get-port-tests.ts
+++ b/get-port/get-port-tests.ts
@@ -1,0 +1,7 @@
+/// <reference path="get-port.d.ts" />
+
+import * as getPort from "get-port";
+
+getPort().then(port => {
+    console.log(port);
+});

--- a/get-port/get-port.d.ts
+++ b/get-port/get-port.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for ajv
+// Project: https://github.com/sindresorhus/get-port
+// Definitions by: York Yao <https://github.com/plantain-00/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "get-port" {
+    var getPort: () => PromiseLike<number>
+    export = getPort;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
