### PR TITLE
Rename name property from ng.IDirective

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1825,7 +1825,7 @@ declare namespace angular {
         bindToController?: boolean | Object;
         link?: IDirectiveLinkFn | IDirectivePrePost;
         multiElement?: boolean;
-        name?: string;
+        directiveName?: string;
         priority?: number;
         /**
          * @deprecated


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Rename name property from ng.IDirective as there is no mention of this property in the official API documentation (https://docs.angularjs.org/api/ng/service/$compile) and it was causing issues with directives made as classes like so:

```
class MyDirective implements ng.IDirective {
    public template = "<div>{{ test }}</div>";
    public scope = {
        test: "="
    };

    public static name = "myDirective";
    public static $inject: string[] = ["$http"];

    constructor(private $http: ng.IHttpService) {
    }

    public link(scope: ng.IScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) {
    }
}

angular.module("app")
    .directive(MyDirective.name, DirectiveFactory.getFactoryFor(MyDirective));
```

See http://stackoverflow.com/questions/38853868/typeerror-when-class-has-static-member-name for more details.

Changing it to another non-reserved name fixes the issue.
