### PR TITLE
Remove the relative path from the color import

### DIFF
--- a/d3-interpolate/index.d.ts
+++ b/d3-interpolate/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { ColorSpaceObject } from '../d3-color';
+import { ColorSpaceObject } from 'd3-color';
 
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
case 3. Bugfix

Including just `@types/d3-interpolate` in a project (and not `@types/d3-color`) results in

```
ERROR in [default] [...]\node_modules\@types\d3-interpolate\index.d.ts:6:33
Cannot find module '../d3-color'.
```
