### PR TITLE
[react-swipeable]: add optional string prop nodeName

### DIFF
--- a/react-autosuggest/react-autosuggest.d.ts
+++ b/react-autosuggest/react-autosuggest.d.ts
@@ -31,15 +31,15 @@ declare namespace ReactAutosuggest {
   }
 
   interface Theme {
-    container: string;
-    containerOpen: string;
-    input: string;
-    sectionContainer: string;
-    sectionSuggestionsContainer: string;
-    sectionTitle: string;
-    suggestion: string;
-    suggestionFocused: string;
-    suggestionsContainer: string;
+    container?: string;
+    containerOpen?: string;
+    input?: string;
+    sectionContainer?: string;
+    sectionSuggestionsContainer?: string;
+    sectionTitle?: string;
+    suggestion?: string;
+    suggestionFocused?: string;
+    suggestionsContainer?: string;
   }
 
   interface AutosuggestProps extends React.Props<Autosuggest> {

--- a/react-autosuggest/react-autosuggest.d.ts
+++ b/react-autosuggest/react-autosuggest.d.ts
@@ -31,15 +31,15 @@ declare namespace ReactAutosuggest {
   }
 
   interface Theme {
-    container?: string;
-    containerOpen?: string;
-    input?: string;
-    sectionContainer?: string;
-    sectionSuggestionsContainer?: string;
-    sectionTitle?: string;
-    suggestion?: string;
-    suggestionFocused?: string;
-    suggestionsContainer?: string;
+    container: string;
+    containerOpen: string;
+    input: string;
+    sectionContainer: string;
+    sectionSuggestionsContainer: string;
+    sectionTitle: string;
+    suggestion: string;
+    suggestionFocused: string;
+    suggestionsContainer: string;
   }
 
   interface AutosuggestProps extends React.Props<Autosuggest> {

--- a/react-swipeable/react-swipeable-tests.tsx
+++ b/react-swipeable/react-swipeable-tests.tsx
@@ -3,7 +3,7 @@
 
 import Swipeable = require('react-swipeable');
 import React = require('react');
- 
+
 var SampleComponent = React.createClass({
   render: function () {
     return (
@@ -18,7 +18,8 @@ var SampleComponent = React.createClass({
         onSwipedDown={this.swipedDown}
         onSwipedLeft={this.swipedLeft}
         onSwiped={this.handleSwipeAction}
-        preventDefaultTouchmoveEvent={false}>
+        preventDefaultTouchmoveEvent={false}
+        nodeName={"swipe"}>
         <div>
           This element can be swiped
         </div>

--- a/react-swipeable/react-swipeable.d.ts
+++ b/react-swipeable/react-swipeable.d.ts
@@ -39,6 +39,7 @@ declare namespace ReactSwipeableModule {
         flickThreshold?: number;
         delta?: number;
         preventDefaultTouchmoveEvent?: boolean;
+        nodeName?: string;
     }
 
     interface ReactSwipeable extends React.ComponentClass<Props> { }


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

here is the commit where nodeName is added:

https://github.com/dogfessional/react-swipeable/commit/0614970388c1d93320c09fe08cf284e5cceaa530
