### PR TITLE
Fix FilterEvent interface in keymaster.d.ts

### DIFF
--- a/keymaster/keymaster.d.ts
+++ b/keymaster/keymaster.d.ts
@@ -17,13 +17,8 @@ interface KeyHandler {
     (keyboardEvent: KeyboardEvent, keymasterEvent: KeymasterEvent) : void;
 }
 
-interface FilterEvent {
-    target?: {
-        tagName?: string;
-    }
-    srcElement?: {
-        tagName?: string;
-    }
+interface FilterEvent extends KeyboardEvent {
+    target: Element
 }
 
 interface Keymaster {


### PR DESCRIPTION
N.B. I'm new to TypeScript. This change made my code compile, but there may be some subtlety here that I'm missing.

The issue is that FilterEvent previously defined only a very small subset of the Event interface. Clients of the library who wanted to use, say `ev.keyCode` would hit an error, because FilterEvent did not extend KeyboardEvent. I ran into a further error when trying to access `ev.target.tagName`, so I overrode the `target` property here to make it an Element. I wonder if that's a change that should be made on the lib d.ts?
