### PR TITLE
Add additional patch methods in jsdiff

### DIFF
--- a/diff/diff.d.ts
+++ b/diff/diff.d.ts
@@ -16,6 +16,22 @@ declare namespace JsDiff {
         componenets: IDiffResult[];
     }
 
+    interface IHunk {
+        oldStart: number;
+        oldLines: number;
+        newStart: number;
+        newLines: number;
+        lines: string[];
+    }
+
+    interface IUniDiff {
+        oldFileName: string;
+        newFileName: string;
+        oldHeader: string;
+        newHeader: string;
+        hunks: IHunk[];
+    }
+
     class Diff {
         ignoreWhitespace:boolean;
 
@@ -46,9 +62,21 @@ declare namespace JsDiff {
 
     function diffCss(oldStr:string, newStr:string):IDiffResult[];
 
-    function createPatch(fileName:string, oldStr:string, newStr:string, oldHeader:string, newHeader:string):string;
+    function createPatch(fileName: string, oldStr: string, newStr: string, oldHeader: string, newHeader: string, options?: {context: number}): string;
 
-    function applyPatch(oldStr:string, uniDiff:string):string;
+    function createTwoFilesPatch(oldFileName: string, newFileName: string, oldStr: string, newStr: string, oldHeader: string, newHeader: string, options?: {context: number}): string;
+
+    function structuredPatch(oldFileName: string, newFileName: string, oldStr: string, newStr: string, oldHeader: string, newHeader: string, options?: {context: number}): IUniDiff;
+
+    function applyPatch(oldStr: string, uniDiff: string | IUniDiff | IUniDiff[]): string;
+
+    function applyPatches(uniDiff: IUniDiff[], options: {
+        loadFile: (index: number, callback: (err: Error, data: string) => void) => void,
+        patched: (index: number, content: string) => void,
+        complete: (err?: Error) => void
+    }): void;
+
+    function parsePatch(diffStr: string, options?: {strict: boolean}): IUniDiff[];
 
     function convertChangesToXML(changes:IDiffResult[]):string;
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Sources:
- https://www.npmjs.com/package/diff
- https://github.com/kpdecker/jsdiff
  - [src/patch/apply.js](/kpdecker/jsdiff/blob/master/src/patch/apply.js)
  - [src/patch/create.js](/kpdecker/jsdiff/blob/master/src/patch/create.js)
  - [src/patch/parse.js](/kpdecker/jsdiff/blob/master/src/patch/parse.js)

Changes:
- Add `IUniDiff` struct, representing a unified patch
- Add `IHunk` struct, representing a section of modified lines and context
- Fix `createPatch` optional `options` argument
- Fix `applyPatch` to accept either a patch string, IUniDiff or IUniDiff array
- Add `createTwoFilesPatch`, `structuredPatch` and `applyPatches`
- Add test code for these new functions
