### PR TITLE
[page] Adding the missing func page.replace() to type def

### DIFF
--- a/page/page.d.ts
+++ b/page/page.d.ts
@@ -87,6 +87,11 @@ declare namespace PageJS {
          */
         redirect(page: string): void;
         /**
+         * Replace `path` with optional `state` object.
+         *
+         */
+        replace(path: string, state?: any, init?: boolean, dispatch?: boolean): Context;
+        /**
          *  Navigate to the given path.
          *
          *      $('.view').click(function(e){


### PR DESCRIPTION
According to the source code for `page.js`, this replace function exists but it is missing from our type definition. Please promptly merge. I've tested this on my local machine.
https://github.com/visionmedia/page.js/blob/master/page.js#L272

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
