### PR TITLE
Add new type definition for xmlpoke

### DIFF
--- a/xmlpoke/xmlpoke-tests.ts
+++ b/xmlpoke/xmlpoke-tests.ts
@@ -1,0 +1,83 @@
+/// <reference path="xmlpoke.d.ts" />
+/// <reference path="../node/node.d.ts" />
+
+// tsc xmlpoke-tests.ts && node xmlpoke-tests.js
+
+import * as xmlpoke from 'xmlpoke';
+import * as assert from 'assert';
+
+let result: string;
+
+// add with xpath, value
+result = xmlpoke('<a/>', xml => xml.add('/a/b', 'c'));
+assert.equal(result, '<a><b>c</b></a>');
+
+// add with xpath, Transform
+const addfn: XmlPoke.Transform = (node, value) => 'c'; 
+result = xmlpoke('<a/>', xml => xml.add('/a/b', addfn));
+assert.equal(result, '<a><b>c</b></a>');
+
+// add with xpath, CDataValue
+const cdataval: XmlPoke.CDataValue = new xmlpoke.CDataValue('c');
+result = xmlpoke('<a/>', xml => xml.add('/a/b', cdataval));
+assert.equal(result, '<a><b><![CDATA[c]]></b></a>');
+
+// add with xpath, XMLVal
+const xmlval = new xmlpoke.XmlString('<c/>');
+result = xmlpoke('<a/>', xml => xml.add('/a/b', xmlval));
+assert.equal(result, '<a><b><c/></b></a>');
+
+// add with map
+result = xmlpoke('<a/>', xml => xml.add({
+    '/a/b': 'c'
+}));
+assert.equal(result, '<a><b>c</b></a>');
+
+// set with xpath, value
+result = xmlpoke('<a>b</a>', xml => xml.set('/a', 'c'));
+assert.equal(result, '<a>c</a>');
+
+// set with map
+result = xmlpoke('<a>b</a>', xml => xml.set({
+    '/a': 'c'
+}));
+assert.equal(result, '<a>c</a>');
+
+// set with xpath that doesn't exist (no-op)
+result = xmlpoke('<a><b>bval</b></a>', xml => xml.set('/a/c', 'cval'));
+assert.equal(result, '<a><b>bval</b></a>');
+
+// setOrAdd with xpath, value
+result = xmlpoke('<a/>', xml => xml.setOrAdd('/a/b', 'c'));
+assert.equal(result, '<a><b>c</b></a>');
+
+// setOrAdd with map
+result = xmlpoke('<a/>', xml => xml.setOrAdd({
+    '/a/b': 'c'
+}));
+assert.equal(result, '<a><b>c</b></a>');
+
+// setOrAdd with xpath that doesn't exist: add
+result = xmlpoke('<a><b>bval</b></a>', xml => xml.setOrAdd('/a/c', 'cval'));
+assert.equal(result, '<a><b>bval</b><c>cval</c></a>');
+
+// remove
+result = xmlpoke('<a><b/></a>', xml => xml.remove('//b'));
+assert.equal(result, '<a/>');
+
+// clear
+result = xmlpoke('<a><b/></a>', xml => xml.clear('/a'));
+assert.equal(result, '<a/>');
+
+// withBasePath, addNamespace, errorOnNoMatches
+result = xmlpoke('<test><x><![CDATA[hello]]></x></test>', xml =>
+    xml.withBasePath('/test')
+       .addNamespace('x', 'http://example.com/x')
+       .errorOnNoMatches()
+       .set('/x', (node, value) => {
+            assert.equal(typeof node, 'object');
+            assert.equal((node.constructor as any).name, 'Element');
+            assert.equal(value, 'hello');
+            return 'y';   
+       }));
+assert.equal(result, '<test><x>y</x></test>');

--- a/xmlpoke/xmlpoke.d.ts
+++ b/xmlpoke/xmlpoke.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for xmlpoke 0.1.12
+// Project: https://github.com/mikeobrien/node-xmlpoke
+// Definitions by: Garth Kidd <https://github.com/garthk/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../xpath/xpath.d.ts" />
+
+declare module XmlPoke { // ghost module
+	interface Transform {
+		(node: Node, value: string): Value;
+	}
+	type Value = string | boolean | number | XmlValue | CDataValue | PathToValueMap | Transform;
+	type PathToValueMap = {
+		[xpath: string]: Value;
+	}
+	interface API {
+		add(xpath: string, value: Value): API;
+		add(map: PathToValueMap): API;
+		set(xpath: string, value: Value): API;
+		set(map: PathToValueMap): API;
+		setOrAdd(xpath: string, value: Value): API;
+		setOrAdd(map: PathToValueMap): API;
+		remove(xpath: string): API;
+		clear(xpath: string): API;
+		withBasePath(xpath: string): API;
+		addNamespace(prefix: string, uri: string): API;
+		errorOnNoMatches(): API;
+	}
+	interface CDataValue {
+		value: string;
+	}
+	interface XmlValue {
+		value: string;
+	}
+}
+
+declare module 'xmlpoke' {
+	const xmlpoke: {
+		(xml: string, modify: (api: XmlPoke.API) => void): string;
+		CDataValue: new (value: string) => XmlPoke.CDataValue;
+		XmlString: new (value: string) => XmlPoke.XmlValue;
+	};
+	namespace xmlpoke {}
+	export = xmlpoke;
+}


### PR DESCRIPTION
`tsc` check:

```
$ tsc --noImplicitAny xmlpoke-tests.ts && echo $? && node xmlpoke-tests.js
0
```

`tsc` check for ES6:

```
$ tsc --target es6 --noImplicitAny --module commonjs xmlpoke-tests.ts && echo $? && node xmlpoke-tests.js
0
```

`npm test` result:

```
…
-----------------------------------------------------------------------------
 Queued for testing
-----------------------------------------------------------------------------
xmlpoke/xmlpoke-tests.ts
xmlpoke/xmlpoke.d.ts
=============================================================================
                    DefinitelyTyped Test Runner 0.5.0
=============================================================================
 Typescript version: 1.8.7

…
 Total
-----------------------------------------------------------------------------
 Elapsed time    : ~3.85 seconds (3.85s)
 Syntax error    : 0.00% (0/1)
 Failed tests    : 0.00% (0/1)
 Invalid header  : 0.00% (0/1)
 Without tests   : 0.00% (0/1)
-----------------------------------------------------------------------------
```

Header check:

```
$ head -n 5 xmlpoke.d.ts 
// Type definitions for xmlpoke 0.1.12
// Project: https://github.com/mikeobrien/node-xmlpoke
// Definitions by: Garth Kidd <https://github.com/garthk/>
// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

```
