### PR TITLE
[sequelize] import lodash dependency

### DIFF
--- a/sequelize/sequelize.d.ts
+++ b/sequelize/sequelize.d.ts
@@ -10,6 +10,7 @@
 /// <reference path="../validator/validator.d.ts" />
 
 declare module "sequelize" {
+    import * as _ from "lodash";
 
     namespace sequelize {
 


### PR DESCRIPTION
I needed to import lodash because in my project:
- sequelize ts definitions is a global dependency (from dt)
- lodash ts definitions is NOT a global dependency (from npm)

so they were in different namespaces
