### PR TITLE
Add TypeDefinition for autosize plugin of jackmoore

### DIFF
--- a/autosize/autosize-tests.ts
+++ b/autosize/autosize-tests.ts
@@ -1,0 +1,10 @@
+/// <reference path="autosize.d.ts" />
+
+// from a NodeList
+autosize(document.querySelectorAll('textarea'));
+
+// from a single Node
+autosize(document.querySelector('textarea'));
+
+// from a single element
+autosize(document.getElementById('my-textarea'));

--- a/autosize/autosize.d.ts
+++ b/autosize/autosize.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for jquery.autosize 3.0.7
+// Project: http://www.jacklmoore.com/autosize/
+// Definitions by: Aaron T. King <https://github.com/kingdango>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace autosize {
+    interface AutosizeStatic {
+        (el: Element): void;
+        (el: NodeList): void;
+    }
+}
+
+declare var autosize: autosize.AutosizeStatic;
+
+declare module 'autosize' {
+    export = autosize;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

original jquery-autosize plugin requred jquery but the new version
didn't need it anymore.
So I add a new definition for the new version of the plugin
see #10023
