### PR TITLE
rename drop to tether-drop to adhere to npm registry

### DIFF
--- a/tether-drop/tether-drop-tests.ts
+++ b/tether-drop/tether-drop-tests.ts
@@ -1,5 +1,7 @@
 ///<reference path="../tether/tether.d.ts" />
-///<reference path="drop.d.ts" />
+///<reference path="tether-drop.d.ts" />
+
+import 'tether-drop';
 
 var yellowBox = document.querySelector(".yellow");
 var greenBox = document.querySelector(".green");

--- a/tether-drop/tether-drop.d.ts
+++ b/tether-drop/tether-drop.d.ts
@@ -56,6 +56,6 @@ declare namespace Drop {
     }
 }
 
-declare module "drop" {
+declare module "tether-drop" {
     export = Drop;
 }


### PR DESCRIPTION
Due to the policy of using npm registry to name typings, this PR is for https://www.npmjs.com/package/tether-drop.

cc: @adidahiya 
