### PR TITLE
Add configuration options.

### DIFF
--- a/knex/knex-tests.ts
+++ b/knex/knex-tests.ts
@@ -78,6 +78,12 @@ var knex = Knex({
   client: 'pg'
 });
 
+// useNullAsDefault
+var knex = Knex({
+  client: 'sqlite',
+  useNullAsDefault: true,
+});
+
 knex('books').insert({title: 'Test'}).returning('*').toString();
 
 // Migrations

--- a/knex/knex-tests.ts
+++ b/knex/knex-tests.ts
@@ -78,6 +78,12 @@ var knex = Knex({
   client: 'pg'
 });
 
+// searchPath
+var knex = Knex({
+  client: 'pg',
+  searchPath: 'public',
+});
+
 // useNullAsDefault
 var knex = Knex({
   client: 'sqlite',

--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -455,6 +455,7 @@ declare module "knex" {
       migrations?: MigratorConfig;
       acquireConnectionTimeout?: number;
       useNullAsDefault?: boolean;
+      searchPath?: string;
     }
 
     interface ConnectionConfig {

--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -454,6 +454,7 @@ declare module "knex" {
       pool?: PoolConfig;
       migrations?: MigratorConfig;
       acquireConnectionTimeout?: number;
+      useNullAsDefault?: boolean;
     }
 
     interface ConnectionConfig {


### PR DESCRIPTION
Add the `useNullAsDefault` configuration option (this prevents a warning when using the sqlite driver), as well as the `searchPath` configuration parameter.

The former is "documented" in http://knexjs.org/#Builder-insert
The latter is only mentioned in an example in http://knexjs.org/#Installation-client
