### PR TITLE
Add default export to angular-ui-router.

### DIFF
--- a/angular-ui-router/angular-ui-router-tests.ts
+++ b/angular-ui-router/angular-ui-router-tests.ts
@@ -1,6 +1,7 @@
 /// <reference path="angular-ui-router.d.ts" />
 
-var myApp = angular.module('testModule');
+import uiRouterModule from "angular-ui-router";
+var myApp = angular.module("testModule", [uiRouterModule]);
 
 interface MyAppScope extends ng.IScope {
 	items: string[];
@@ -141,7 +142,7 @@ class UrlLocatorTestService implements IUrlLocatorTestService {
         private $state: ng.ui.IStateService
     ) {
         $rootScope.$on("$locationChangeSuccess", (event: ng.IAngularEvent) => this.onLocationChangeSuccess(event));
-        $rootScope.$on('$stateNotFound', (event: ng.IAngularEvent, unfoundState: ng.ui.IUnfoundState, fromState: ng.ui.IState, fromParams: {}) => 
+        $rootScope.$on('$stateNotFound', (event: ng.IAngularEvent, unfoundState: ng.ui.IUnfoundState, fromState: ng.ui.IState, fromParams: {}) =>
                                               this.onStateNotFound(event, unfoundState, fromState, fromParams));
     }
 
@@ -164,14 +165,14 @@ class UrlLocatorTestService implements IUrlLocatorTestService {
             });
         }
     }
-    
+
      private onStateNotFound(event: ng.IAngularEvent,
                              unfoundState: ng.ui.IUnfoundState,
                              fromState: ng.ui.IState,
                              fromParams: {}) {
         var unfoundTo: string = unfoundState.to;
         var unfoundToParams: {} = unfoundState.toParams;
-        var unfoundOptions: ng.ui.IStateOptions = unfoundState.options 
+        var unfoundOptions: ng.ui.IStateOptions = unfoundState.options
     }
 
     private stateServiceTest() {

--- a/angular-ui-router/angular-ui-router.d.ts
+++ b/angular-ui-router/angular-ui-router.d.ts
@@ -7,13 +7,7 @@
 
 // Support for AMD require and CommonJS
 declare module 'angular-ui-router' {
-    // Since angular-ui-router adds providers for a bunch of
-    // injectable dependencies, it doesn't really return any
-    // actual data except the plain string 'ui.router'.
-    //
-    // As such, I don't think anybody will ever use the actual
-    // default value of the module.  So I've only included the
-    // the types. (@xogeny)
+    export default "ui.router";
     export type IState = angular.ui.IState;
     export type IStateProvider = angular.ui.IStateProvider;
     export type IUrlMatcher = angular.ui.IUrlMatcher;
@@ -109,7 +103,7 @@ declare namespace angular.ui {
         toParams: {},
         options: IStateOptions
     }
-    
+
     interface IStateProvider extends angular.IServiceProvider {
         state(name:string, config:IState): IStateProvider;
         state(config:IState): IStateProvider;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url https://github.com/angular-ui/ui-router/blob/a65c58f9edabff1e1097afe0da4b7c06868f32e2/src/ng1.ts#L18 .
  - it has been reviewed by a DefinitelyTyped member.

Add default symbol to enable angular module name import.
