### PR TITLE
Change react-modal from export default to export =

### DIFF
--- a/react-modal/react-modal-tests.tsx
+++ b/react-modal/react-modal-tests.tsx
@@ -2,7 +2,7 @@
 /// <reference path="./react-modal.d.ts"/>
 
 import * as React from "react";
-import ReactModal from 'react-modal';
+import * as ReactModal from 'react-modal';
 
 class ExampleOfUsingReactModal extends React.Component<{}, {}> {
   render() {

--- a/react-modal/react-modal.d.ts
+++ b/react-modal/react-modal.d.ts
@@ -24,5 +24,5 @@ declare module "react-modal" {
         shouldCloseOnOverlayClick?: boolean
     }
     let ReactModal: __React.ClassicComponentClass<ReactModal>;
-    export default ReactModal;
+    export = ReactModal;
 }


### PR DESCRIPTION
case 2. Improvement to existing type definition.

React Modal assigns to `module.exports` [source](https://github.com/reactjs/react-modal/blob/master/lib/index.js#L1) so it seems like we should use `export =` as suggested in the [Typescript module docs](https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require)
