### PR TITLE
Fix ExpressionAttributeNames.

### DIFF
--- a/aws-sdk/aws-sdk.d.ts
+++ b/aws-sdk/aws-sdk.d.ts
@@ -329,7 +329,7 @@ declare module "aws-sdk" {
 
     interface _DDBDC_Generic {
       TableName: string;
-      ExpressionAttributeNames?: string[];
+      ExpressionAttributeNames?: { [someKey: string]: string };
       ReturnConsumedCapacity?: "INDEXES" | "TOTAL" | "NONE";
     }
 


### PR DESCRIPTION
See: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#query-property

``` javascript
ExpressionAttributeNames: {
  someKey: 'STRING_VALUE',
  /* anotherKey: ... */
},
```
