### PR TITLE
[redux-logger] Fix export

### DIFF
--- a/redux-logger/redux-logger.d.ts
+++ b/redux-logger/redux-logger.d.ts
@@ -6,6 +6,7 @@
 /// <reference path="../redux/redux.d.ts" />
 
 declare module 'redux-logger' {
+  import { Middleware } from "redux";
 
   type LoggerPredicate = (getState: () => any, action: any) => boolean;
 
@@ -44,9 +45,9 @@ declare module 'redux-logger' {
     diffPredicate?: LoggerPredicate;
   }
 
-  // Trickery to get TypeScript to accept that our anonymous, non-default export is a function.
-  // see https://github.com/Microsoft/TypeScript/issues/3612 for more
-  namespace createLogger {}
-  function createLogger(options?: ReduxLoggerOptions): Redux.Middleware;
-  export = createLogger;
+  const createLogger: Middleware & {
+    withExtraArgument(extraArgument: any): Middleware;
+  };
+
+  export default createLogger;
 }

--- a/sequelize/sequelize.d.ts
+++ b/sequelize/sequelize.d.ts
@@ -10,8 +10,6 @@
 /// <reference path="../validator/validator.d.ts" />
 
 declare module "sequelize" {
-    import * as _ from "lodash";
-
     namespace sequelize {
 
         //

--- a/sequelize/sequelize.d.ts
+++ b/sequelize/sequelize.d.ts
@@ -10,6 +10,7 @@
 /// <reference path="../validator/validator.d.ts" />
 
 declare module "sequelize" {
+
     namespace sequelize {
 
         //

--- a/sequelize/sequelize.d.ts
+++ b/sequelize/sequelize.d.ts
@@ -10,6 +10,7 @@
 /// <reference path="../validator/validator.d.ts" />
 
 declare module "sequelize" {
+    import * as _ from "lodash";
 
     namespace sequelize {
 


### PR DESCRIPTION
When I was trying to use this middleware, I was getting the error

```
error TS2345: Argument of type 'Middleware' is not assignable to parameter of type '(() => (next: any) => (action: any) => any) | (Middleware & { withExtraArgument(extraArgument: an...'.
  Type 'Middleware' is not assignable to type 'Middleware & { withExtraArgument(extraArgument: any): Middleware; }'.
    Type 'Middleware' is not assignable to type '{ withExtraArgument(extraArgument: any): Middleware; }'.
      Property 'withExtraArgument' is missing in type 'Middleware'.
```

So I took the code from the [redux-thunk](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/redux-thunk/redux-thunk.d.ts) middleware definition, which was working fine
