### PR TITLE
Add property `mapObject` on type `_ChainOfArrays<T>`

### DIFF
--- a/underscore/underscore-tests.ts
+++ b/underscore/underscore-tests.ts
@@ -506,16 +506,11 @@ function chain_tests() {
 		.first()
 		.value();
 
-    interface NumberObject {
-        property: string;
-        value: number;
-    }
-    let numberObjects: NumberObject[] = [{property: 'odd', value: 1}, {property: 'even', value: 2}, {property: 'even', value: 0}];
-    let evenNumbers: NumberObject[][] = _.chain(numberObjects)
+    let numberObjects = [{property: 'odd', value: 1}, {property: 'even', value: 2}, {property: 'even', value: 0}];
+    let evenAndOddGroupedNumbers = _.chain(numberObjects)
         .groupBy('property')
-        .mapObject((objects: any) => _.sortBy(objects, (object: NumberObject) => object.value))
-        .values()
-        .value();
+        .mapObject((objects: any) => _.pluck(objects, 'value'))
+        .value(); // { odd: [1], even: [0, 2] }
 }
 
 var obj: { [k: string] : number } = {

--- a/underscore/underscore-tests.ts
+++ b/underscore/underscore-tests.ts
@@ -505,6 +505,17 @@ function chain_tests() {
 	var firstVal: number = _.chain([1, 2, 3])
 		.first()
 		.value();
+
+    interface NumberObject {
+        property: string;
+        value: number;
+    }
+    let numberObjects: NumberObject[] = [{property: 'odd', value: 1}, {property: 'even', value: 2}, {property: 'even', value: 0}];
+    let evenNumbers: NumberObject[][] = _.chain(numberObjects)
+        .groupBy('property')
+        .mapObject((objects: any) => _.sortBy(objects, (object: NumberObject) => object.value))
+        .values()
+        .value();
 }
 
 var obj: { [k: string] : number } = {

--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -5924,6 +5924,7 @@ interface _ChainSingle<T> {
 }
 interface _ChainOfArrays<T> extends _Chain<T[]> {
 	flatten(shallow?: boolean): _Chain<T>;
+	mapObject(fn: _.ListIterator<T, any>): _ChainOfArrays<T>;
 }
 
 declare var _: UnderscoreStatic;


### PR DESCRIPTION
 Improvement to existing type definition.

Error without my modification to the _ChainOfArrays interface:
`Error:(512, 10) TS2339: Property 'mapObject' does not exist on type '_ChainOfArrays<{ property: string; value: number; }>'.`

Since it's supported in pure JS, it should be supported when using TypeScript.

After my modification, this is compiling as expected:

```
    let numberObjects = [{property: 'odd', value: 1}, {property: 'even', value: 2}, {property: 'even', value: 0}];
    let evenAndOddGroupedNumbers = _.chain(numberObjects)
        .groupBy('property')
        .mapObject((objects: any) => _.pluck(objects, 'value'))
        .value(); // { odd: [1], even: [0, 2] }
```
