### PR TITLE
Rename bootstrap-datepicker to match npm package

### DIFF
--- a/bootstrap-datepicker/bootstrap-datepicker-tests.ts
+++ b/bootstrap-datepicker/bootstrap-datepicker-tests.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="bootstrap.datepicker.d.ts"/>
+﻿/// <reference path="bootstrap-datepicker.d.ts"/>
 
 function tests_simple() {
     $('#datepicker').datepicker();

--- a/bootstrap-datepicker/bootstrap-datepicker.d.ts
+++ b/bootstrap-datepicker/bootstrap-datepicker.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for bootstrap.datepicker
+// Type definitions for bootstrap-datepicker
 // Project: https://github.com/eternicode/bootstrap-datepicker
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Renamed the typing to match the bower & npm package name.

Fixes #10572
