### PR TITLE
fix(WebRTC): fix RTCMediaConstraints error.

### DIFF
--- a/webrtc/RTCPeerConnection-tests.ts
+++ b/webrtc/RTCPeerConnection-tests.ts
@@ -26,7 +26,7 @@ var config: RTCConfiguration = {
     iceCandidatePoolSize: 5
 };
 var constraints: RTCMediaConstraints =
-    { mandatory: { offerToReceiveAudio: true, offerToReceiveVideo: true } };
+    { mandatory: { OfferToReceiveAudio: true, OfferToReceiveVideo: true } };
 
 var peerConnection: RTCPeerConnection =
     new RTCPeerConnection(config, constraints);

--- a/webrtc/RTCPeerConnection.d.ts
+++ b/webrtc/RTCPeerConnection.d.ts
@@ -94,8 +94,8 @@ interface RTCMediaConstraints {
 }
 
 interface RTCMediaOfferConstraints {
-  offerToReceiveAudio: boolean;
-  offerToReceiveVideo: boolean;
+  OfferToReceiveAudio: boolean;
+  OfferToReceiveVideo: boolean;
 }
 
 interface RTCSessionDescriptionInit {


### PR DESCRIPTION
WebRTC 1.0 RTCMediaConstraints has attributes `OfferToReceiveVideo` and `OfferToReceiveAudio`, but not `offerToReceiveVideo` and `offerToReceiveAudio`.
visit https://www.w3.org/TR/2013/WD-webrtc-20130910/.
