### PR TITLE
Add width to IDialogOptions

### DIFF
--- a/ng-dialog/ng-dialog.d.ts
+++ b/ng-dialog/ng-dialog.d.ts
@@ -222,6 +222,11 @@ declare namespace angular.dialog {
 		 * If specified, the first matching element is used.
 		 */
 		ariaDescribedBySelector?: string;
+
+		/**
+		 * Specifies the width of the dialog content element. Default value is null (unspecified)
+		 */
+		width?: string|number;
 	}
 
 	/**


### PR DESCRIPTION
The latest version of ngDialog (v0.6.2) also allows for a `width` property to be present in `IDialogOptions`. As can be seen in the [source code](https://github.com/likeastore/ngDialog/blob/0.6.2/js/ngDialog.js#L65).

It specifies the width that should be given to the '.ngdialog-content' element, as can be seen in the [source code](https://github.com/likeastore/ngDialog/blob/0.6.2/js/ngDialog.js#L546).
