### PR TITLE
add types of devtools-detect

### DIFF
--- a/devtools-detect/devtools-detect-tests.ts
+++ b/devtools-detect/devtools-detect-tests.ts
@@ -1,0 +1,12 @@
+/// <reference path="devtools-detect.d.ts" />
+
+// check if it's open
+console.log('is DevTools open?', window.devtools.open);
+// check it's orientation, null if not open
+console.log('and DevTools orientation?', window.devtools.orientation);
+
+// get notified when it's opened/closed or orientation changes
+window.addEventListener('devtoolschange', function (e) {
+    console.log('is DevTools open?', e.detail.open);
+    console.log('and DevTools orientation?', e.detail.orientation);
+});

--- a/devtools-detect/devtools-detect.d.ts
+++ b/devtools-detect/devtools-detect.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for ajv
+// Project: https://github.com/sindresorhus/devtools-detect
+// Definitions by: York Yao <https://github.com/plantain-00/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type DevTools = {
+    open: boolean;
+    orientation: "vertical" | "horizontal";
+}
+interface DevToolsEvent extends Event {
+    detail: DevTools;
+}
+interface Window {
+    devtools: DevTools;
+    addEventListener(type: "devtoolschange", listener: (ev: DevToolsEvent) => any, useCapture?: boolean): void;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
