### PR TITLE
Add missing jsonb column type to knex TableBuilder

### DIFF
--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -370,6 +370,7 @@ declare module "knex" {
       enum(columnName: string, values: Value[]): ColumnBuilder;
       enu(columnName: string, values: Value[]): ColumnBuilder;
       json(columnName: string): ColumnBuilder;
+      jsonb(columnName: string): ColumnBuilder;
       uuid(columnName: string): ColumnBuilder;
       comment(val: string): TableBuilder;
       specificType(columnName: string, type: string): ColumnBuilder;


### PR DESCRIPTION
Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes:

http://knexjs.org/#Schema-jsonb
