### PR TITLE
add missing methods of documentDb QueryIterator interface

### DIFF
--- a/documentdb/documentdb.d.ts
+++ b/documentdb/documentdb.d.ts
@@ -93,7 +93,12 @@ declare module 'documentdb' {
 
     /** Represents the result returned from a query. */
     interface QueryIterator<TResultRow> {
-
+        current(): TResultRow;
+        executeNext(callback: (error: QueryError, result: TResultRow[]) => void): void;
+        forEach(iteratorFunction : (error: QueryError, element: TResultRow) => void): void;
+        hasMoreResults(): boolean;
+        nextItem(callback: (error : QueryError, item : TResultRow) => void): void;
+        reset() : void;
         toArray(callback: (error: QueryError, result: TResultRow[]) => void): void;
     }
 


### PR DESCRIPTION
This is an improvement for an existing type definition. 

The documentation of the respective methods can be found [here](http://dl.windowsazure.com/documentDB/jsclientdocs/QueryIterator.html).
