### PR TITLE
Fixed param middleware to accept url param as first middleware param

### DIFF
--- a/koa-router/koa-router-tests.ts
+++ b/koa-router/koa-router-tests.ts
@@ -1,5 +1,6 @@
 /// <reference path="../koa/koa.d.ts" />
 /// <reference path="koa-router.d.ts" />
+/// <reference path="../node_modules/typescript/lib/lib.es6.d.ts" />
 
 import * as Koa from "koa";
 import * as Router from "koa-router";
@@ -11,6 +12,9 @@ const router = new Router({
 });
 
 router
+  .param('id', function(id, ctx, next) {
+    next();
+  })
   .get('/', function (ctx, next) {
     ctx.body = 'Hello World!';
   })
@@ -23,7 +27,7 @@ router
   .del('/users/:id', function (ctx, next) {
     // ...
   });
-  
+
 router.get('user', '/users/:id', function (ctx, next) {
     ctx.body = "sdsd";
 });

--- a/koa-router/koa-router-tests.ts
+++ b/koa-router/koa-router-tests.ts
@@ -1,6 +1,5 @@
 /// <reference path="../koa/koa.d.ts" />
 /// <reference path="koa-router.d.ts" />
-/// <reference path="../node_modules/typescript/lib/lib.es6.d.ts" />
 
 import * as Koa from "koa";
 import * as Router from "koa-router";

--- a/koa-router/koa-router.d.ts
+++ b/koa-router/koa-router.d.ts
@@ -30,7 +30,7 @@ declare module "koa-router" {
 
         export interface IRouterOptions {
             /**
-             * Router prefixes 
+             * Router prefixes
              */
             prefix?: string;
             /**
@@ -50,6 +50,10 @@ declare module "koa-router" {
 
         export interface IMiddleware {
             (ctx: Router.IRouterContext, next?: () => any): any;
+        }
+
+        export interface IParamMiddleware {
+            (param: string, ctx: Router.IRouterContext, next?: () => any): any;
         }
 
         export interface IRouterAllowedMethodsOptions {
@@ -141,13 +145,13 @@ declare module "koa-router" {
          */
         get(name: string, path: string, ...middleware: Array<Router.IMiddleware>): Router;
         get(path: string, ...middleware: Array<Router.IMiddleware>): Router;
-        
+
         /**
          * HTTP post method
          */
         post(name: string, path: string, ...middleware: Array<Router.IMiddleware>): Router;
         post(path: string, ...middleware: Array<Router.IMiddleware>): Router;
-        
+
         /**
          * HTTP put method
          */
@@ -214,7 +218,7 @@ declare module "koa-router" {
 
         /**
          * Redirect `source` to `destination` URL with optional 30x status `code`.
-         * 
+         *
          * Both `source` and `destination` can be route names.
          */
         redirect(source: string, destination: string, code?: number): Router;
@@ -245,7 +249,7 @@ declare module "koa-router" {
         /**
          * Run middleware for named route parameters. Useful for auto-loading or validation.
          */
-        param(param: string, middleware: Router.IMiddleware): Router;
+        param(param: string, middleware: Router.IParamMiddleware): Router;
 
         /**
          * Generate URL from url pattern and given `params`.


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url https://github.com/alexmingoia/koa-router/tree/master/.
  - it has been reviewed by a DefinitelyTyped member.
