### PR TITLE
Update lru-cache to v4.1.0

### DIFF
--- a/lru-cache/lru-cache.d.ts
+++ b/lru-cache/lru-cache.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for lru-cache v2.5.0
+// Type definitions for lru-cache v4.0.1
 // Project: https://github.com/isaacs/node-lru-cache
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -12,20 +12,22 @@ declare module 'lru-cache' {
 			max?: number;
 			maxAge?: number;
 			length?: (value: T) => number;
-			dispose?: (key: string, value: T) => void;
+			dispose?: (key: any, value: T) => void;
 			stale?: boolean;
 		}
 
 		interface Cache<T> {
-			set(key: string, value: T): void;
-			get(key: string): T;
-			peek(key: string): T;
-			has(key: string): boolean
-			del(key: string): void;
+			set(key: any, value: T): void;
+			get(key: any): T;
+			peek(key: any): T;
+			has(key: any): boolean
+			del(key: any): void;
 			reset(): void;
-			forEach(iter: (value: T, key: string, cache: Cache<T>) => void, thisp?: any): void;
-
-			keys(): string[];
+			prune(): void;
+			forEach(iter: (value: T, key: any, cache: Cache<T>) => void, thisp?: any): void;
+			itemCount: number;
+			length: number
+			keys(): any[];
 			values(): T[];
 		}
 	}


### PR DESCRIPTION
New version of lru-cache accepts any type for the key. I added missing methods too
