### PR TITLE
Add uri-templates constructor

### DIFF
--- a/uri-templates/uri-templates-tests.ts
+++ b/uri-templates/uri-templates-tests.ts
@@ -8,6 +8,7 @@ var u: URITemplate;
 var obj: Object;
 
 u = utmpl(str);
+u = new URITemplate(str);
 
 str = u.fillFromObject(obj);
 str = u.fill((key) => {

--- a/uri-templates/uri-templates.d.ts
+++ b/uri-templates/uri-templates.d.ts
@@ -8,6 +8,7 @@ declare module 'uri-templates' {
 
 	namespace utpl {
 		export interface URITemplate {
+			new(template: string): URITemplate;
 			fillFromObject(vars: Object): string;
 			fill(callback: (varName: string) => string): string;
 			fromUri(uri: string): Object;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

ex: `new UriTemplate("/prefix/{?params*}");`
from https://github.com/geraintluff/uri-templates

CC @geraintluff
