### PR TITLE
Issue 10185

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -2223,6 +2223,10 @@ declare module "stream" {
 
     // Note: Duplex extends both Readable and Writable.
     export class Duplex extends Readable implements NodeJS.ReadWriteStream {
+        // Readable
+        pause(): Duplex;
+        resume(): Duplex;
+        // Writeable
         writable: boolean;
         constructor(opts?: DuplexOptions);
         _write(chunk: any, encoding: string, callback: Function): void;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -2187,8 +2187,8 @@ declare module "stream" {
         _read(size: number): void;
         read(size?: number): any;
         setEncoding(encoding: string): void;
-        pause(): void;
-        resume(): void;
+        pause(): Readable;
+        resume(): Readable;
         pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
         unpipe<T extends NodeJS.WritableStream>(destination?: T): void;
         unshift(chunk: any): void;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -2251,8 +2251,8 @@ declare module "stream" {
         _flush(callback: Function): void;
         read(size?: number): any;
         setEncoding(encoding: string): void;
-        pause(): void;
-        resume(): void;
+        pause(): Transform;
+        resume(): Transform;
         pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
         unpipe<T extends NodeJS.WritableStream>(destination?: T): void;
         unshift(chunk: any): void;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -257,8 +257,8 @@ declare namespace NodeJS {
         readable: boolean;
         read(size?: number): string | Buffer;
         setEncoding(encoding: string): void;
-        pause(): void;
-        resume(): void;
+        pause(): ReadableStream;
+        resume(): ReadableStream;
         pipe<T extends WritableStream>(destination: T, options?: { end?: boolean; }): T;
         unpipe<T extends WritableStream>(destination?: T): void;
         unshift(chunk: string): void;
@@ -276,7 +276,10 @@ declare namespace NodeJS {
         end(str: string, encoding?: string, cb?: Function): void;
     }
 
-    export interface ReadWriteStream extends ReadableStream, WritableStream { }
+    export interface ReadWriteStream extends ReadableStream, WritableStream {
+      pause(): ReadWriteStream;
+      resume(): ReadWriteStream;
+    }
 
     export interface Events extends EventEmitter { }
 

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1284,8 +1284,8 @@ declare module "net" {
         setEncoding(encoding?: string): void;
         write(data: any, encoding?: string, callback?: Function): void;
         destroy(): void;
-        pause(): void;
-        resume(): void;
+        pause(): Socket;
+        resume(): Socket;
         setTimeout(timeout: number, callback?: Function): void;
         setNoDelay(noDelay?: boolean): void;
         setKeepAlive(enable?: boolean, initialDelay?: number): void;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- [x] documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

The current type definitions of ReadableStream's pause and resume method return void. This is not the case in versions 6.x of NodeJS (I have not looked into older version). pause and resume return a this reference, which is of the type implementing the Readable interface.

See here for ReadableStream type definition - https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/node/node.d.ts#L260-L261

See here for the NodeJS doc corresponding to these methods :

pause https://nodejs.org/api/stream.html#stream_readable_pause
resume https://nodejs.org/api/stream.html#stream_readable_resume
