### PR TITLE
Adding missing methods from SyntheticEvent

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -276,10 +276,10 @@ declare namespace __React {
         isTrusted: boolean;
         nativeEvent: Event;
         preventDefault(): void;
-        stopPropagation(): void;
-        persist(): void;
         isDefaultPrevented(): boolean;
+        stopPropagation(): void;
         isPropagationStopped(): boolean;
+        persist(): void;
         target: EventTarget;
         timeStamp: Date;
         type: string;

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -278,6 +278,8 @@ declare namespace __React {
         preventDefault(): void;
         stopPropagation(): void;
         persist(): void;
+        isDefaultPrevented(): boolean;
+        isPropagationStopped(): boolean;
         target: EventTarget;
         timeStamp: Date;
         type: string;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Referencing [**Event System**](https://facebook.github.io/react/docs/events.html): Synthetic Event has methods `boolean isDefaultPrevented()` and `boolean isPropagationStopped()` which currently are missing from it's interface.
