### PR TITLE
Update index.d.ts

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -2345,7 +2345,7 @@ declare global {
     namespace JSX {
         interface Element extends React.ReactElement<any> { }
         interface ElementClass extends React.Component<any, any> {
-            render(): JSX.Element;
+            render(): JSX.Element|null;
         }
         interface ElementAttributesProperty { props: {}; }
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Fixes 

``` bash
client/components/controllers/Notes.tsx(199,13): error TS2605: JSX element type 'Component<OwnProps, {} | void>' is not a constructor function for JSX elements.
  Types of property 'render' are incompatible.
    Type '() => Element | null' is not assignable to type '() => Element'.
      Type 'Element | null' is not assignable to type 'Element'.
        Type 'null' is not assignable to type 'Element'.
```

rendering `null` is acceptable and should be accepted.

See https://github.com/Microsoft/TypeScript/issues/10259
