### PR TITLE
react-flex - added optional style object to CommonFlexProps

### DIFF
--- a/react-flex/react-flex.d.ts
+++ b/react-flex/react-flex.d.ts
@@ -12,7 +12,7 @@ declare namespace __ReactFlex {
         /**
          * For custom style
          */
-        style?: Object;
+        style?: any;
 
         /**
          * For `display: inline-flex`.

--- a/react-flex/react-flex.d.ts
+++ b/react-flex/react-flex.d.ts
@@ -10,6 +10,11 @@ declare namespace __ReactFlex {
 
     interface CommonFlexProps {
         /**
+         * For custom style
+         */
+        style?: Object;
+
+        /**
          * For `display: inline-flex`.
          */
         inline?: boolean;


### PR DESCRIPTION
The style property allows to add other inline css customisations to the <Flex /> component.
Obviously it is expected not to be used for overriding the flexbox features of the component.
