### PR TITLE
add optional responseHeaders parameter to documentdb QueryIterator ca…

### DIFF
--- a/documentdb/documentdb.d.ts
+++ b/documentdb/documentdb.d.ts
@@ -94,12 +94,12 @@ declare module 'documentdb' {
     /** Represents the result returned from a query. */
     interface QueryIterator<TResultRow> {
         current(): TResultRow;
-        executeNext(callback: (error: QueryError, result: TResultRow[]) => void): void;
-        forEach(iteratorFunction : (error: QueryError, element: TResultRow) => void): void;
+        executeNext(callback: (error: QueryError, result: TResultRow[], responseHeaders? : any) => void): void;
+        forEach(iteratorFunction : (error: QueryError, element: TResultRow, responseHeaders? : any) => void): void;
         hasMoreResults(): boolean;
-        nextItem(callback: (error : QueryError, item : TResultRow) => void): void;
+        nextItem(callback: (error : QueryError, item : TResultRow, responseHeaders? : any) => void): void;
         reset() : void;
-        toArray(callback: (error: QueryError, result: TResultRow[]) => void): void;
+        toArray(callback: (error: QueryError, result: TResultRow[], responseHeaders? : any) => void): void;
     }
 
     /** Reprents an object with a unique identifier. */


### PR DESCRIPTION
extends documentdb typings.

This third optional parameter is not documented here: http://dl.windowsazure.com/documentDB/jsclientdocs/QueryIterator.html

but is clearly implemented, as can be seen here: 
http://dl.windowsazure.com/documentDB/jsclientdocs/queryIterator.js.html
