### PR TITLE
added definitions for phone library

### DIFF
--- a/phone/index.d.ts
+++ b/phone/index.d.ts
@@ -1,0 +1,6 @@
+// Type definitions for phone 1.0.8
+// Project: https://github.com/aftership/phone
+// Definitions by: Hagai Cohen <https://github.com/DxCx>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export default function phone(phoneNumber: string, countryCode?: string): Array<string>;

--- a/phone/phone-tests.ts
+++ b/phone/phone-tests.ts
@@ -1,0 +1,12 @@
+import phone from 'phone';
+
+phone('+852 6569-8900'); // return ['+85265698900', 'HKG']
+phone('(817) 569-8900'); // return ['+18175698900, 'USA']
+phone('(817) 569-8900', ''); // return ['+18175698900, 'USA']
+phone('(817) 569-8900', 'USA'); // return ['+18175698900', 'USA']
+phone('(817) 569-8900', 'HKG'); // return []
+phone('+1(817) 569-8900', 'HKG'); // return [], as it is not a valid HKG mobile phone number
+phone('+1(817) 569-8900', ''); // return ['+18175698900', 'USA']
+phone('(817) 569-8900', ''); // return ['+18175698900', 'USA']
+phone('6123-6123', ''); // return [], as default country is USA
+phone('6123-6123', 'HKG'); // return ['+85261236123', 'HKG']

--- a/phone/tsconfig.json
+++ b/phone/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "phone-tests.ts"
+    ]
+}


### PR DESCRIPTION
## Add a new type definition for 'phone' library
- [V] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [V] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [V] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
- [V] Run dt --changes successfully.
