### PR TITLE
Fix type defenition for canActivate function

### DIFF
--- a/angularjs/angular-component-router.d.ts
+++ b/angularjs/angular-component-router.d.ts
@@ -476,7 +476,7 @@ declare namespace angular {
     // Supplement IComponentOptions from angular.d.ts with router-specific
     // fields.
     interface IComponentOptions {
-      $canActivate?: () => boolean;
+      $canActivate?: (...args: any[]) => boolean | angular.IPromise<boolean>;
       $routeConfig?: RouteDefinition[];
     }
 }


### PR DESCRIPTION
As described in angular Component Router [documentation](https://docs.angularjs.org/guide/component-router), `$canActivate` function can return `boolean` or promise that resolves to `boolean`.

Also `$canActivate` function is injectable function and it can receive multiple services as arguments.
