### PR TITLE
Add path to fs.WriteStream

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1418,6 +1418,7 @@ declare module "fs" {
     export interface WriteStream extends stream.Writable {
         close(): void;
         bytesWritten: number;
+        path: string;
     }
 
     /**

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1418,7 +1418,7 @@ declare module "fs" {
     export interface WriteStream extends stream.Writable {
         close(): void;
         bytesWritten: number;
-        path: string;
+        path: string | Buffer;
     }
 
     /**


### PR DESCRIPTION
case 2. Improvement to existing type definition.
According to docs [`fs.WriteStream`](https://nodejs.org/api/fs.html#fs_class_fs_writestream) has had a `path`-member since `v0.1.93`:
https://nodejs.org/api/fs.html#fs_writestream_path
