### PR TITLE
Added type definition for electron-notify and mock-require

### DIFF
--- a/electron-notify/electron-notify-tests.ts
+++ b/electron-notify/electron-notify-tests.ts
@@ -17,7 +17,10 @@ eNotify.notify({
   image: 'path/to/image.png',
   url: 'http://google.de',
   sound: 'notification.wav',
-  onClickFunc: function () { console.log('onClick') },
-  onShowFunc: function () { console.log('onShow') },
-  onCloseFunc: function () { console.log('onClose') }
+  onClickFunc: (event) => {
+    console.log('onClick ' + event.id);
+    event.closeNotification('onClick');
+  },
+  onShowFunc: (event) => { console.log('onShow ' + event.id) },
+  onCloseFunc: (event) => { console.log('onClose ' + event.id) }
 });

--- a/electron-notify/electron-notify-tests.ts
+++ b/electron-notify/electron-notify-tests.ts
@@ -1,0 +1,23 @@
+/// <reference path="./electron-notify.d.ts" />
+
+import * as eNotify from 'electron-notify';
+
+eNotify.setConfig({
+  appIcon: 'images/otherIcon.png',
+  displayTime: 6000,
+  defaultStyleText: {
+    color: '#FF0000',
+    fontWeight: 'bold'
+  }
+});
+
+eNotify.notify({
+  title: 'Title',
+  text: 'Some text',
+  image: 'path/to/image.png',
+  url: 'http://google.de',
+  sound: 'notification.wav',
+  onClickFunc: function () { console.log('onClick') },
+  onShowFunc: function () { console.log('onShow') },
+  onCloseFunc: function () { console.log('onClose') }
+});

--- a/electron-notify/electron-notify.d.ts
+++ b/electron-notify/electron-notify.d.ts
@@ -13,8 +13,8 @@ declare namespace ElectronNotify {
     image?: string,
     url?: string,
     sound?: string,
-    onClickFunc?: (event: string, id: number, closeNotification) => void,
-    onShowFunc?: (event: string, id: number, closeNotification) => void,
+    onClickFunc?: (event: string, id: number, closeNotification: any) => void,
+    onShowFunc?: (event: string, id: number, closeNotification: any) => void,
     onCloseFunc?: (event: string, id: number) => void
   }
 

--- a/electron-notify/electron-notify.d.ts
+++ b/electron-notify/electron-notify.d.ts
@@ -5,29 +5,10 @@
 
 /// <reference path="../github-electron/github-electron.d.ts" />
 
-declare namespace ElectronNotify {
+/** Nice and simple notifications for electron apps */
+declare module 'electron-notify' {
 
-  interface ICloseNotificationEvent {
-    event: 'close' | 'show' | 'click',
-    id: number
-  }
-
-  interface INotificationEvent extends ICloseNotificationEvent {
-    closeNotification: (reason: any) => void,
-  }
-
-  interface INotification {
-    title: string,
-    text?: string,
-    image?: string,
-    url?: string,
-    sound?: string,
-    onClickFunc?: (event: INotificationEvent) => void,
-    onShowFunc?: (event: INotificationEvent) => void,
-    onCloseFunc?: (event: ICloseNotificationEvent) => void
-  }
-
-  interface IConfiguration {
+  export interface ICustomConfig {
     width?: number,
     height?: number,
     padding?: number,
@@ -47,16 +28,31 @@ declare namespace ElectronNotify {
     defaultStyleText?: any
   }
 
-}
+  export interface ICloseNotificationEvent {
+    event: 'close' | 'show' | 'click',
+    id: number
+  }
 
-/** Nice and simple notifications for electron apps */
-declare module 'electron-notify' {
+  export interface INotificationEvent extends ICloseNotificationEvent {
+    closeNotification: (reason: any) => void,
+  }
+
+  export interface INotification {
+    title: string,
+    text?: string,
+    image?: string,
+    url?: string,
+    sound?: string,
+    onClickFunc?: (event: INotificationEvent) => void,
+    onShowFunc?: (event: INotificationEvent) => void,
+    onCloseFunc?: (event: ICloseNotificationEvent) => void
+  }
 
   /** Change some config options. Can be run multiple times, also between notify()-calls to change electron-notifys behaviour. */
-  export function setConfig(customConfig: ElectronNotify.IConfiguration): void;
+  export function setConfig(customConfig: ICustomConfig): void;
 
   /** Displays new notification. */
-  export function notify(notification: ElectronNotify.INotification): void;
+  export function notify(notification: INotification): void;
 
   /** Clears the animation queue and closes all windows opened by electron-notify. Call this to clean up before quiting your app. */
   export function closeAll(): void;

--- a/electron-notify/electron-notify.d.ts
+++ b/electron-notify/electron-notify.d.ts
@@ -44,16 +44,16 @@ declare namespace ElectronNotify {
 declare module 'electron-notify' {
 
   /** Change some config options. Can be run multiple times, also between notify()-calls to change electron-notifys behaviour. */
-  export function setConfig(customConfig: ElectronNotify.IConfiguration);
+  export function setConfig(customConfig: ElectronNotify.IConfiguration): void;
 
   /** Displays new notification. */
-  export function notify(notification: ElectronNotify.INotification);
+  export function notify(notification: ElectronNotify.INotification): void;
 
   /** Clears the animation queue and closes all windows opened by electron-notify. Call this to clean up before quiting your app. */
-  export function closeAll();
+  export function closeAll(): void;
 
   export function getTemplatePath(): string;
 
-  export function setTemplatePath(path: string);
+  export function setTemplatePath(path: string): void;
 
 }

--- a/electron-notify/electron-notify.d.ts
+++ b/electron-notify/electron-notify.d.ts
@@ -6,22 +6,54 @@
 /// <reference path="../github-electron/github-electron.d.ts" />
 
 declare namespace ElectronNotify {
+
+  interface INotification {
+    title: string,
+    text?: string,
+    image?: string,
+    url?: string,
+    sound?: string,
+    onClickFunc?: (event: string, id: number, closeNotification) => void,
+    onShowFunc?: (event: string, id: number, closeNotification) => void,
+    onCloseFunc?: (event: string, id: number) => void
+  }
+
+  interface IConfiguration {
+    width?: number,
+    height?: number,
+    padding?: number,
+    borderRadius?: number,
+    displayTime?: number,
+    animationSteps?: number,
+    animationStepMs?: number,
+    animateInParallel?: boolean,
+    appIcon?: string,
+    pathToModule?: string,
+    logging?: boolean,
+    defaultWindow?: Electron.BrowserWindowOptions,
+    defaultStyleContainer?: any,
+    defaultStyleAppIcon?: any,
+    defaultStyleImage?: any,
+    defaultStyleClose?: any,
+    defaultStyleText?: any
+  }
+
 }
 
 /** Nice and simple notifications for electron apps */
 declare module 'electron-notify' {
 
   /** Change some config options. Can be run multiple times, also between notify()-calls to change electron-notifys behaviour. */
-  export function setConfig(configObj);
+  export function setConfig(customConfig: ElectronNotify.IConfiguration);
 
   /** Displays new notification. */
-  export function notify(notificationObj);
+  export function notify(notification: ElectronNotify.INotification);
 
   /** Clears the animation queue and closes all windows opened by electron-notify. Call this to clean up before quiting your app. */
   export function closeAll();
 
-  export function setTemplatePath(path);
+  export function getTemplatePath(): string;
 
-  /** Returns the maximum amount of notifications that fit onto the users screen. */
-  export function calcMaxVisibleNotification(): number;
+  export function setTemplatePath(path: string);
+
 }

--- a/electron-notify/electron-notify.d.ts
+++ b/electron-notify/electron-notify.d.ts
@@ -9,7 +9,7 @@ declare namespace ElectronNotify {
 }
 
 /** Nice and simple notifications for electron apps */
-declare module 'electron-notifications' {
+declare module 'electron-notify' {
 
   /** Change some config options. Can be run multiple times, also between notify()-calls to change electron-notifys behaviour. */
   export function setConfig(configObj);

--- a/electron-notify/electron-notify.d.ts
+++ b/electron-notify/electron-notify.d.ts
@@ -7,15 +7,24 @@
 
 declare namespace ElectronNotify {
 
+  interface ICloseNotificationEvent {
+    event: 'close' | 'show' | 'click',
+    id: number
+  }
+
+  interface INotificationEvent extends ICloseNotificationEvent {
+    closeNotification: (reason: any) => void,
+  }
+
   interface INotification {
     title: string,
     text?: string,
     image?: string,
     url?: string,
     sound?: string,
-    onClickFunc?: (event: string, id: number, closeNotification: any) => void,
-    onShowFunc?: (event: string, id: number, closeNotification: any) => void,
-    onCloseFunc?: (event: string, id: number) => void
+    onClickFunc?: (event: INotificationEvent) => void,
+    onShowFunc?: (event: INotificationEvent) => void,
+    onCloseFunc?: (event: ICloseNotificationEvent) => void
   }
 
   interface IConfiguration {

--- a/electron-notify/electron-notify.d.ts
+++ b/electron-notify/electron-notify.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for electron-notify v0.1.0
+// Project: https://github.com/hankbao/electron-notify
+// Definitions by: Daniel Pereira <https://github.com/djpereira>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../github-electron/github-electron.d.ts" />
+
+declare namespace ElectronNotify {
+}
+
+/** Nice and simple notifications for electron apps */
+declare module 'electron-notifications' {
+
+  /** Change some config options. Can be run multiple times, also between notify()-calls to change electron-notifys behaviour. */
+  export function setConfig(configObj);
+
+  /** Displays new notification. */
+  export function notify(notificationObj);
+
+  /** Clears the animation queue and closes all windows opened by electron-notify. Call this to clean up before quiting your app. */
+  export function closeAll();
+
+  export function setTemplatePath(path);
+
+  /** Returns the maximum amount of notifications that fit onto the users screen. */
+  export function calcMaxVisibleNotification(): number;
+}

--- a/mock-require/mock-require-tests.ts
+++ b/mock-require/mock-require-tests.ts
@@ -1,0 +1,47 @@
+/// <reference path="mock-require.d.ts" />
+
+import mock = require('mock-require');
+
+function testMock() {
+  mock('http', {
+    request: function () {
+      console.log('http.request called');
+    }
+  });
+
+  const http = require('http');
+  http.request(); // 'http.request called'
+}
+
+function testStop() {
+  mock('fs', { mockedFS: true });
+
+  const fs1 = require('fs');
+  mock.stop('fs');
+
+  const fs2 = require('fs');
+  fs1 === fs2; // false
+}
+
+function testStopAll() {
+  mock('fs', {});
+  mock('path', {});
+
+  const fs1 = require('fs');
+  const path1 = require('path');
+
+  mock.stopAll();
+
+  const fs2 = require('fs');
+  const path2 = require('path');
+
+  fs1 === fs2; // false
+  path1 === path2; // false
+}
+
+function testReRequire() {
+  const fs = require('fs');
+  let fileToTest = require('./fileToTest');
+  mock('fs', {}); // fileToTest is still using the unmocked fs module
+  fileToTest = mock.reRequire('./fileToTest'); // fileToTest is now using your mock
+}

--- a/mock-require/mock-require.d.ts
+++ b/mock-require/mock-require.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for mock-require v1.3.0
+// Project: https://github.com/boblauer/mock-require
+// Definitions by: Daniel Pereira <https://github.com/djpereira>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+/** Simple, intuitive mocking of Node.js modules. */
+declare module 'mock-require' {
+
+  interface Mock {
+
+    /**
+     * @param {string} path The module you that you want to mock.
+     * @param {any} mockExport The function or object you want to be returned from require, instead of the path module's exports, or the module you want to be returned from require, instead of the path module's export.  
+     */
+    (path: string, mockExport: any | Function | string): void;
+
+    /**
+    * @param {string} path The module you that you want to stop mocking.
+    */
+    stop(path: string): void;
+
+    /** This function can be used to remove all registered mocks without the need to remove them individually using mock.stop(). */
+    stopAll(): void;
+
+    /**
+     * @param {string} path The file whose cache you want to refresh. 
+     */
+    reRequire(path: string): void;
+  }
+
+  const myModule: Mock;
+  export = myModule;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [X] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [X] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [X] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
