### PR TITLE
Mongoose paginate

### DIFF
--- a/mongoose-paginate/mongoose-paginate-tests.ts
+++ b/mongoose-paginate/mongoose-paginate-tests.ts
@@ -1,0 +1,75 @@
+/// <reference path="./mongoose-paginate.d.ts" />
+/// <reference path="../mongoose/mongoose.d.ts" />
+/// <reference path="../express/express.d.ts" />
+
+/**
+ * Created by Linus Brolin <https://github.com/linusbrolin/>.
+ */
+
+import {
+    Schema,
+    model,
+    PaginateModel,
+    PaginateOptions,
+    PaginateResult
+} from 'mongoose';
+import * as mongoosePaginate from 'mongoose-paginate';
+import { Router, Request, Response } from 'express';
+
+
+//#region Test Models
+interface User {
+  email: string;
+  username: string;
+  password: string;
+}
+
+const UserSchema: Schema = new Schema({
+  email: String,
+  username: String,
+  password: String
+});
+
+UserSchema.plugin(mongoosePaginate);
+
+type UserModel<T> = _UserModel<T> & PaginateModel<T>;
+interface _UserModel<T> {}
+
+let UserModel: UserModel<User> = model<User>('User', UserSchema) as UserModel<User>;
+//#endregion
+
+
+//#region Test Paginate
+let router: Router = Router();
+
+router.get('/users.json', function(req: Request, res: Response) {
+    let descending: boolean = true;
+    let options: PaginateOptions = <PaginateOptions>{};
+    options.select = 'email username';
+    options.sort = { 'username': (descending ? -1 : 1) };
+    options.populate = '';
+    options.lean = true;
+    options.leanWithId = false;
+    options.offset = 0;
+    options.page = 1;
+    options.limit = 10;
+
+    UserModel
+    .paginate({}, options, (err: any, value: PaginateResult<User>) => {
+        if (err) {
+            console.log(err);
+            return res.status(500).send(err);
+        }
+
+        console.log('total: ' + value.total);
+        console.log('limit: ' + value.limit);
+        console.log('page: ' + value.page);
+        console.log('pages: ' + value.pages);
+        console.log('offset: ' + value.offset);
+        console.log('docs: ');
+        console.dir(value.docs);
+        return res.json(value);
+    });
+
+});
+//#endregion

--- a/mongoose-paginate/mongoose-paginate.d.ts
+++ b/mongoose-paginate/mongoose-paginate.d.ts
@@ -1,3 +1,7 @@
+// Type definitions for mongoose-paginate 5.0.0
+// Project: https://github.com/edwardhotchkiss/mongoose-paginate
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
 /// <reference path="../mongoose/mongoose.d.ts" />
 
 declare module 'mongoose' {

--- a/mongoose-paginate/mongoose-paginate.d.ts
+++ b/mongoose-paginate/mongoose-paginate.d.ts
@@ -1,0 +1,40 @@
+/// <reference path="../mongoose/mongoose.d.ts" />
+
+declare module 'mongoose' {
+  export interface PaginateOptions {
+    select?: Object | string;
+    sort?: Object | string;
+    populate?: Array<Object> | Array<string> | Object | string;
+    lean?: boolean;
+    leanWithId?: boolean;
+    offset?: number;
+    page?: number;
+    limit?: number;
+  }
+
+  export interface PaginateResult<T> {
+    docs: Array<T>;
+    total: number;
+    limit: number;
+    page?: number;
+    pages?: number;
+    offset?: number;
+  }
+
+  export type PaginateModel<T> = _PaginateModel<T> & Model<T>;
+  interface _PaginateModel<T> {
+    paginate(query?: Object, options?: PaginateOptions, callback?: (err: any, result: PaginateResult<T>) => void): Promise<PaginateResult<T>>;
+  }
+
+  export function model<T extends Document, Statics>(
+    name: string,
+    schema?: Schema,
+    collection?: string,
+    skipInit?: boolean): Statics & PaginateModel<T>;
+}
+
+declare module 'mongoose-paginate' {
+  import mongoose = require('mongoose');
+  var _: (schema: mongoose.Schema) => void;
+  export = _;
+}

--- a/mongoose-paginate/mongoose-paginate.d.ts
+++ b/mongoose-paginate/mongoose-paginate.d.ts
@@ -1,5 +1,6 @@
 // Type definitions for mongoose-paginate 5.0.0
 // Project: https://github.com/edwardhotchkiss/mongoose-paginate
+// Definitions by: Linus Brolin <https://github.com/linusbrolin/>, simonxca <https://github.com/simonxca/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../mongoose/mongoose.d.ts" />


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

This will add type definitions for the mongoose-paginate plugin:
https://github.com/edwardhotchkiss/mongoose-paginate
