### PR TITLE
add props.children to StatelessComponent

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -200,7 +200,7 @@ declare namespace React {
 
     type SFC<P> = StatelessComponent<P>;
     interface StatelessComponent<P> {
-        (props?: P, context?: any): ReactElement<any>;
+        (props?: P & { children?: ReactNode }, context?: any): ReactElement<any>;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: P;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Handles `props.children` in `StatelessComponent` as in `Component`. Treats `<Foo children={Bar} />` in the same way as `<Foo><Bar /></Foo>` with `const Foo: StatelessComponent = (props) => <div>{props.children}</div>`.
