### PR TITLE
Add Buffer.swap16, Buffer.swap32 and Buffer.swap64 functions

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -183,6 +183,14 @@ function bufferTests() {
     var result1 = Buffer.concat([utf8Buffer, base64Buffer]);
     var result2 = Buffer.concat([utf8Buffer, base64Buffer], 9999999);
 
+    // Class Methods: Buffer.swap16(), Buffer.swa32(), Buffer.swap64()
+    {
+        const buf = Buffer.from([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8]);
+        buf.swap16();
+        buf.swap32();
+        buf.swap64();
+    }
+
     // Class Method: Buffer.from(array)
     {
         const buf: Buffer = Buffer.from([0x62,0x75,0x66,0x66,0x65,0x72]);

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -485,6 +485,9 @@ interface NodeBuffer extends Uint8Array {
     readFloatBE(offset: number, noAssert?: boolean): number;
     readDoubleLE(offset: number, noAssert?: boolean): number;
     readDoubleBE(offset: number, noAssert?: boolean): number;
+    swap16(): Buffer;
+    swap32(): Buffer;
+    swap64(): Buffer;
     writeUInt8(value: number, offset: number, noAssert?: boolean): number;
     writeUInt16LE(value: number, offset: number, noAssert?: boolean): number;
     writeUInt16BE(value: number, offset: number, noAssert?: boolean): number;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Just added missing functions on the Buffer class.
Followed the same style of already existing functions, API reference link was already there
