### PR TITLE
slickgrid: fixed getCellFromEvent signature, using DOMEvent in subscribe

### DIFF
--- a/slickgrid/SlickGrid-tests.ts
+++ b/slickgrid/SlickGrid-tests.ts
@@ -209,7 +209,7 @@ grid.onSort.subscribe((e, args) => {
     var sortCol:string = args.sortCols[0].sortCol.field;
 });
 
-grid.onMouseEnter.subscribe((e: DOMEvent, args) => {
+grid.onMouseEnter.subscribe((e: DOMEvent, args: Slick.OnMouseEnterEventArgs<MyData>) => {
 	let cell: Slick.Cell = args.grid.getCellFromEvent(e);
 	if (!cell) { return; }
 });

--- a/slickgrid/SlickGrid-tests.ts
+++ b/slickgrid/SlickGrid-tests.ts
@@ -155,8 +155,6 @@ grid.getCellCssStyles("test")[0]["number_column"];
 
 grid.getCellEditor();
 
-grid.getCellFromEvent(new Slick.Event());
-
 grid.getCellFromPoint(5, 10);
 
 grid.getCellNode(5, 10);
@@ -209,4 +207,9 @@ columns.forEach(column => {
 
 grid.onSort.subscribe((e, args) => {
     var sortCol:string = args.sortCols[0].sortCol.field;
+});
+
+grid.onMouseEnter.subscribe((e: DOMEvent, args) => {
+	let cell: Slick.Cell = args.grid.getCellFromEvent(e);
+	if (!cell) { return; }
 });

--- a/slickgrid/SlickGrid.d.ts
+++ b/slickgrid/SlickGrid.d.ts
@@ -92,14 +92,16 @@ declare namespace Slick {
 		* @method subscribe
 		* @param fn {Function} Event handler.
 		*/
-		public subscribe(fn: (eventData: EventData, data: T) => any ): void;
+		public subscribe(fn: (e: EventData, data: T) => any): void;
+		public subscribe(fn: (e: DOMEvent, data: T) => any): void;
 
 		/***
 		* Removes an event handler added with <code>subscribe(fn)</code>.
 		* @method unsubscribe
 		* @param fn {Function} Event handler to be removed.
 		*/
-		public unsubscribe(fn: (eventData: EventData, data: T) => any ): void;
+		public unsubscribe(fn: (e: EventData, data: T) => any): void;
+		public unsubscribe(fn: (e: DOMEvent, data: T) => any): void;
 
 		/***
 		* Fires an event notifying all subscribers.
@@ -1037,7 +1039,7 @@ declare namespace Slick {
 		* @param e A standard W3C/jQuery event.
 		* @return
 		**/
-		public getCellFromEvent<T>(e: Event<T>): Cell; // todo: !! Unsure on return type !!
+		public getCellFromEvent(e: DOMEvent): Cell;
 
 		/**
 		* Returns a hash containing row and cell indexes. Coordinates are relative to the top left corner of the grid beginning with the first row (not including the column headers).
@@ -1045,7 +1047,7 @@ declare namespace Slick {
 		* @param y A y coordinate.
 		* @return
 		**/
-		public getCellFromPoint(x: number, y: number): Cell; // todo: !! Unsure on return type !!
+		public getCellFromPoint(x: number, y: number): Cell;
 
 		/**
 		* Returns a DOM element containing a cell at a given row and cell.


### PR DESCRIPTION
The argument of `getCellFromEvent` must be of type `DOMEvent`. From https://github.com/mleibman/SlickGrid/wiki/Slick.Grid#getCellFromEvent :

> e - A standard W3C/jQuery event.

To use this method in event handlers we also need another signature of `Event.subscribe` method:

``` ts
        public subscribe(fn: (e: EventData, data: T) => any): void; // old signature
        public subscribe(fn: (e: DOMEvent, data: T) => any): void; // new signature
```

New signature can be used to subscribe to DOM-based events. See a comment to `Event.notify` method:

> For DOM events, an existing W3C/jQuery event object can be passed in.

By the way, `notify` method also has two signatures with `EventData` and `DOMEvent`.
