### PR TITLE
Add redis-scripto, redis-rate-limiter, and replacement auth0 typings with tests.  Renamed original auth0 -> auth0-js.

### DIFF
--- a/auth0-js/auth0-js-tests.ts
+++ b/auth0-js/auth0-js-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path="../auth0/auth0.d.ts" />
+/// <reference path="auth0-js.d.ts" />
 
 var auth0 = new Auth0({
     domain: 'mine.auth0.com',

--- a/auth0-js/auth0-js.d.ts
+++ b/auth0-js/auth0-js.d.ts
@@ -1,5 +1,5 @@
 ﻿// Type definitions for Auth0.js
-// Project: http://auth0.com
+// Project: https://github.com/auth0/auth0.js
 // Definitions by: Robert McLaws <https://github.com/advancedrei>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/auth0.lock/auth0.lock-tests.ts
+++ b/auth0.lock/auth0.lock-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path="../auth0/auth0.d.ts" />
+/// <reference path="../auth0-js/auth0-js.d.ts" />
 /// <reference path="auth0.lock.d.ts" />
 
 const CLIENT_ID = "YOUR_AUTH0_APP_CLIENTID";

--- a/auth0.lock/auth0.lock.d.ts
+++ b/auth0.lock/auth0.lock.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Brian Caruso <https://github.com/carusology>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../auth0/auth0.d.ts" />
+/// <reference path="../auth0-js/auth0-js.d.ts" />
 
 interface Auth0LockAdditionalSignUpFieldOption {
   value: string;

--- a/auth0.widget/auth0.widget-tests.ts
+++ b/auth0.widget/auth0.widget-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path="../auth0/auth0.d.ts" />
+/// <reference path="../auth0-js/auth0-js.d.ts" />
 /// <reference path="auth0.widget.d.ts" />
 
 var widget: Auth0WidgetStatic = new Auth0Widget({

--- a/auth0.widget/auth0.widget.d.ts
+++ b/auth0.widget/auth0.widget.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Robert McLaws <https://github.com/advancedrei>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../auth0/auth0.d.ts" />
+/// <reference path="../auth0-js/auth0-js.d.ts" />
 
 
 interface Auth0WidgetStatic {

--- a/auth0/auth0-tests.ts
+++ b/auth0/auth0-tests.ts
@@ -1,0 +1,51 @@
+/// <reference path="auth0.d.ts" />
+
+import * as auth0 from 'auth0';
+
+const management = new auth0.ManagementClient({
+  token: '{YOUR_API_V2_TOKEN}',
+  domain: '{YOUR_ACCOUNT}.auth0.com'
+});
+
+const auth = new auth0.AuthenticationClient({
+  domain: '{YOUR_ACCOUNT}.auth0.com',
+  clientId: '{OPTIONAL_CLIENT_ID}'
+});
+
+// Using a callback.
+management.getUsers((err: Error, users: auth0.User[]) => {
+  if (err) {
+    // Handle error.
+  }
+  console.log(users);
+});
+
+// Using a Promise.
+management
+  .getUsers()
+  .then((users) => {
+    console.log(users);
+  })
+  .catch((err) => {
+    // Handle the error.
+  });
+
+management
+  .createUser({
+    connection: 'My-Connection',
+    email: 'hi@me.co',
+  }).then((user) => {
+    console.log(user);
+  }).catch((err) => {
+    // Handle the error.
+  });
+
+auth
+  .requestChangePasswordEmail({
+    connection: 'My-Connection',
+    email: 'hi@me.co',
+  }).then((response) => {
+    console.log(response);
+  }).catch((err) => {
+    // Handle the error.
+  });

--- a/auth0/auth0.d.ts
+++ b/auth0/auth0.d.ts
@@ -1,0 +1,95 @@
+﻿// Type definitions for auth0 v2.3.1
+// Project: https://github.com/auth0/node-auth0
+// Definitions by: Seth Westphal <https://github.com/westy92>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../bluebird/bluebird.d.ts" />
+
+declare module "auth0" {
+
+  import * as Promise from 'bluebird';
+
+  export interface ManagementClientOptions {
+    token: string;
+    domain?: string;
+  }
+
+  export interface UserData {
+    connection: string;
+    email?: string;
+    username?: string;
+    password?: string;
+    phone_number?: string;
+    user_metadata?: {};
+    email_verified?: boolean;
+    app_metadata?: {};
+  }
+
+  export interface GetUsersData {
+    per_page?: number;
+    page?: number;
+    include_totals?: boolean;
+    sort?: string;
+    connection?: string;
+    fields?: string;
+    include_fields?: boolean;
+    q?: string;
+    search_engine?: string;
+  }
+
+  export interface User {
+    email?: string;
+    email_verified?: boolean;
+    username?: string;
+    phone_number?: string;
+    phone_verified?: boolean;
+    user_id?: string;
+    created_at?: string;
+    updated_at?: string;
+    identities?: Identity[];
+    app_metadata?: {};
+    user_metadata?: {};
+    picture?: string;
+    name?: string;
+    nickname?: string;
+    multifactor?: string[];
+    last_ip?: string;
+    last_login?: string;
+    logins_count?: number;
+    blocked?: boolean;
+  }
+
+  export interface Identity {
+    connection: string;
+    user_id: string;
+    provider: string;
+    isSocial: boolean;
+  }
+
+  export class ManagementClient {
+    constructor(options: ManagementClientOptions);
+
+    getUsers(params?: GetUsersData): Promise<User[]>;
+    getUsers(params?: GetUsersData, cb?: (err: Error, users: User[]) => void): void;
+    createUser(data: UserData): Promise<User>;
+    createUser(data: UserData, cb: (err: Error, data: User) => void): void;
+  }
+
+  export interface AuthenticationClientOptions {
+    clientId?: string;
+    domain: string;
+  }
+
+  export interface RequestChangePasswordEmailData {
+    connection: string;
+    email: string;
+  }
+
+  export class AuthenticationClient {
+    constructor(options: AuthenticationClientOptions);
+
+    requestChangePasswordEmail(data: RequestChangePasswordEmailData): Promise<string>;
+    requestChangePasswordEmail(data: RequestChangePasswordEmailData, cb: (err: Error, message: string) => void): void;
+  }
+
+}

--- a/redis-rate-limiter/redis-rate-limiter-tests.ts
+++ b/redis-rate-limiter/redis-rate-limiter-tests.ts
@@ -1,0 +1,41 @@
+/// <reference path="../express/express.d.ts" />
+/// <reference path="../redis/redis.d.ts" />
+/// <reference path="redis-rate-limiter.d.ts" />
+
+import * as express from 'express';
+import * as redis from 'redis';
+import * as rateLimiter from 'redis-rate-limiter';
+
+var num: number;
+var str: string;
+var options: redis.ClientOpts;
+var redisClient = redis.createClient(num, str, options);
+
+var limit = rateLimiter.create({
+  redis: redisClient,
+  key: function(x) { return x.ip },
+  rate: '100/minute'
+});
+
+var request = {} as express.Request;
+limit(request, function(err, rate) {
+  if (err) {
+    console.warn('Rate limiting not available');
+  } else {
+    console.log('Rate window: '  + rate.window);  // 60
+    console.log('Rate limit: '   + rate.limit);   // 100
+    console.log('Rate current: ' + rate.current); // 74
+    if (rate.over) {
+      console.error('Over the limit!');
+    }
+  }
+});
+
+var middleware = rateLimiter.middleware({
+  redis: redisClient,
+  key: 'ip',
+  rate: '100/minute'
+});
+
+var app = express();
+app.use(middleware);

--- a/redis-rate-limiter/redis-rate-limiter.d.ts
+++ b/redis-rate-limiter/redis-rate-limiter.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for redis-rate-limiter 1.0.3
+// Project: https://github.com/TabDigital/redis-rate-limiter
+// Definitions by: Seth Westphal <https://github.com/westy92>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../express/express.d.ts" />
+/// <reference path="../redis/redis.d.ts" />
+
+declare module "redis-rate-limiter" {
+
+  import * as express from 'express';
+  import * as redis from 'redis';
+
+  class RedisRateLimiter {
+
+    public static create(options: RedisRateLimiter.Options): 
+      (req: express.Request, callback: (err: Error, res: RedisRateLimiter.Response) => void) => void;
+    public static middleware(options: RedisRateLimiter.Options): express.RequestHandler;
+
+  }
+
+  namespace RedisRateLimiter {
+
+    export interface Options {
+      redis: redis.RedisClient;
+      key: 'ip' | ((req: express.Request) => string);
+      window?: number;
+      limit?: number;
+      rate?: string;
+    }
+
+    export interface Response {
+      key: string;
+      current: number;
+      limit: number;
+      window: number;
+      over: boolean;
+    }
+    
+  }
+
+  export = RedisRateLimiter;
+
+}

--- a/redis-scripto/redis-scripto-tests.ts
+++ b/redis-scripto/redis-scripto-tests.ts
@@ -1,0 +1,37 @@
+/// <reference path="../redis/redis.d.ts" />
+/// <reference path="redis-scripto.d.ts" />
+
+import * as redis from 'redis';
+import * as Scripto from 'redis-scripto';
+
+var num: number;
+var str: string;
+var options: redis.ClientOpts;
+var redisClient = redis.createClient(num, str, options);
+
+var scriptManager = new Scripto(redisClient);
+scriptManager.loadFromDir('/path/to/lua/scripts');
+
+var keys    = ['keyOne', 'keyTwo'];
+var values  = [10, 20];
+scriptManager.run('your-script', keys, values, function(err, result) {
+
+});
+
+scriptManager.eval('your-script', keys, values, function(err, result) {
+
+});
+
+scriptManager.loadFromFile('script-one', '/path/to/the/file');
+scriptManager.run('script-one', [], [], function(err, result) {
+
+});
+
+var scripts: Scripto.Scripts = {
+  'script-two': 'return 1000'
+};
+
+scriptManager.load(scripts);
+scriptManager.run('script-two', [], [], function(err, result) {
+
+});

--- a/redis-scripto/redis-scripto.d.ts
+++ b/redis-scripto/redis-scripto.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for redis-scripto 0.1.3
+// Project: https://github.com/arunoda/node-redis-scripto
+// Definitions by: Seth Westphal <https://github.com/westy92>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../redis/redis.d.ts" />
+
+declare module "redis-scripto" {
+
+  import * as redis from 'redis';
+
+  class Scripto {
+
+    constructor(redisClient: redis.RedisClient);
+
+    eval(scriptName: string, keys: string[], args: any[], callback: (err: Error, result: any) => void): void;
+    evalSha(scriptName: string, keys: string[], args: any[], callback: (err: Error, result: any) => void): void;
+
+    load(scripts: Scripto.Scripts): void;
+    loadFromDir(scriptsDir: string): void;
+    loadFromFile(name: string, filepath: string): void;
+
+    run(scriptName: string, keys: string[], args: any[], callback: (err: Error, result: any) => void): void;
+
+  }
+
+  namespace Scripto {
+
+    export type Script = string;
+
+    export interface Scripts {
+      [scriptName: string]: Script;
+    }
+    
+  }
+
+  export = Scripto;
+
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

> Added redis-scripto, redis-rate-limiter, and a replacement auth0.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

> Fixed auth0 by renaming it to auth0-js.  See https://github.com/auth0/auth0.js/issues/136
