### PR TITLE
electron-prebuilt was renamed to electron

### DIFF
--- a/github-electron/electron-tests.ts
+++ b/github-electron/electron-tests.ts
@@ -1,7 +1,7 @@
-/// <reference path="electron-prebuilt.d.ts" />
+/// <reference path="electron.d.ts" />
 /// <reference path="../node/node.d.ts" />
 
-import electron = require('electron-prebuilt');
+import electron = require('electron');
 import child_process = require('child_process');
 
 child_process.spawn(electron);

--- a/github-electron/electron.d.ts
+++ b/github-electron/electron.d.ts
@@ -1,9 +1,9 @@
-// Type definitions for electron-prebuilt 0.30.1
-// Project: https://github.com/mafintosh/electron-prebuilt
+// Type definitions for electron 1.3.3
+// Project: https://github.com/electron-userland/electron-prebuilt
 // Definitions by: rhysd <https://github.com/rhysd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'electron-prebuilt' {
+declare module 'electron' {
 	var electron: string;
 	export = electron;
 }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url https://github.com/electron-userland/electron-prebuilt .
  - it has been reviewed by a DefinitelyTyped member.

http://electron.atom.io/blog/2016/08/16/npm-install-electron

`electron-prebuilt` package was renamed to `electron`.  Following the change, I renamed corresponding type definition file name.
