### PR TITLE
adding type for move to fs-extra

### DIFF
--- a/fs-extra/fs-extra-tests.ts
+++ b/fs-extra/fs-extra-tests.ts
@@ -52,20 +52,46 @@ fs.copySync(src, dest,
 		filter: /.*/
 	}
 );
+
 fs.createFile(file, errorCallback);
 fs.createFileSync(file);
 
 fs.mkdirs(dir, errorCallback);
 fs.mkdirs(dir, {}, errorCallback);
+
 fs.mkdirsSync(dir);
 fs.mkdirsSync(dir, {});
+
 fs.mkdirp(dir, errorCallback);
 fs.mkdirp(dir, {}, errorCallback);
+
 fs.mkdirpSync(dir);
 fs.mkdirpSync(dir, {});
 
+fs.move(src, dest, errorCallback);
+fs.move(src, dest, (src: string) => {
+	return false;
+}, errorCallback);
+fs.move(src, dest,
+	{
+		clobber: true,
+		preserveTimestamps: true,
+		filter: (src: string) => {return false}
+	},
+	errorCallback
+);
+fs.move(src, dest,
+	{
+		clobber: true,
+		preserveTimestamps: true,
+		filter: /.*/
+	},
+	errorCallback
+);
+
 fs.outputFile(file, data, errorCallback);
 fs.outputFileSync(file, data);
+
 fs.outputJson(file, data, errorCallback);
 fs.outputJSON(file, data, errorCallback);
 

--- a/fs-extra/fs-extra.d.ts
+++ b/fs-extra/fs-extra.d.ts
@@ -28,6 +28,10 @@ declare module "fs-extra" {
 	export function mkdirsSync(dir: string, options?: MkdirOptions): void;
 	export function mkdirpSync(dir: string, options?: MkdirOptions): void;
 
+	export function move(src: string, dest: string, callback?: (err: Error) => void): void;
+	export function move(src: string, dest: string, filter: CopyFilter, callback?: (err: Error) => void): void;
+	export function move(src: string, dest: string, options: CopyOptions, callback?: (err: Error) => void): void;
+
 	export function outputFile(file: string, data: any, callback?: (err: Error) => void): void;
 	export function outputFileSync(file: string, data: any): void;
 


### PR DESCRIPTION
The type for "move" function is missed in fs-extra module.
It is very similar to "copy" function, so the exact same type and tests very used.

https://www.npmjs.com/package/fs-extra#movesrc-dest-options-callback

case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
