### PR TITLE
[node] http.IncomingMessage: destroy not found

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -670,6 +670,7 @@ declare module "http" {
          */
         statusMessage?: string;
         socket: net.Socket;
+        destroy(error: Error): void;
     }
     /**
      * @deprecated Use IncomingMessage

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -670,7 +670,7 @@ declare module "http" {
          */
         statusMessage?: string;
         socket: net.Socket;
-        destroy(error: Error): void;
+        destroy(error?: Error): void;
     }
     /**
      * @deprecated Use IncomingMessage


### PR DESCRIPTION
According to [official document](https://nodejs.org/api/http.html#http_message_destroy_error), the interface **IncomingMessage** should add **destroy**.

Why does it be defined as `destroy(error?: Error): void;`?
- The official document explains that function should be assigned a value of **Error** type.
- Refer to the [source code](https://github.com/nodejs/node/blob/6510eb5ddc802dcd25713c2b3cbb82711c94d075/lib/net.js#L516), when this function is invoked, it won't return anything. Therefore, the return should be defined as **void**.
