### PR TITLE
PDFJS.Util and viewport.convert... definitions

### DIFF
--- a/pdf/pdf.d.ts
+++ b/pdf/pdf.d.ts
@@ -156,9 +156,9 @@ interface PDFPageViewport {
 	transforms: number[];
 
 	clone(options: PDFPageViewportOptions): PDFPageViewport;
-	convertToViewportPoint(): number[]; // [x, y]
-	convertToViewportRectangle(): number[]; // [x1, y1, x2, y2]
-	convertToPdfPoint(): number[]; // [x, y]
+	convertToViewportPoint(x: number, y: number): number[]; // [x, y]
+	convertToViewportRectangle(rect: number[]): number[]; // [x1, y1, x2, y2]
+	convertToPdfPoint(x: number, y: number): number[]; // [x, y]
 }
 
 interface PDFAnnotationData {
@@ -300,6 +300,92 @@ interface PDFObjects {
 	clear(): void;
 }
 
+interface PDFJSUtilStatic {
+	/**
+	 * create a css color string rgb(r,g,b)
+	 **/
+	makeCssRgb(r: number, g: number, b: number): string;
+
+	/**
+	 * Concatenates two transformation matrices together and returns the result.
+	 **/
+	transform(m1: number[], m2: number[]): number[];
+
+	/**
+	 * apply transform matrix m to a point p[x,y]
+	 **/
+	applyTransform(p: number[], m: number[]): number[];
+
+	/**
+	 * apply inverse transform matrix m to a point p[x,y]
+	 **/
+	applyInverseTransform(p: number[], m: number[]): number[]; // [xt, yt]
+
+	/**
+	 * Applies the transform to the rectangle and finds the minimum axially
+	 * aligned bounding box.
+	 **/
+	getAxialAlignedBoundingBox(r: number[], m: number[])
+
+	/**
+	 * inverse transform
+	 **/
+	inverseTransform(m: number[]): number[];
+
+	/**
+	 * apply transform matrix m to a vector v[x,y,z]
+	 **/
+	apply3dTransform(m: number[], v: number[]): number[]; // [xt, yt, zt]
+
+	/**
+	 * This calculation uses Singular Value Decomposition.
+	 * The SVD can be represented with formula A = USV. We are interested in the
+	 * matrix S here because it represents the scale values.
+	 **/
+	singularValueDecompose2dScale(m: number[]): number[];
+
+	/**
+	 * Normalize rectangle rect=[x1, y1, x2, y2] so that (x1,y1) < (x2,y2)
+	 * For coordinate systems whose origin lies in the bottom-left, this
+	 * means normalization to (BL,TR) ordering. For systems with origin in the
+	 * top-left, this means (TL,BR) ordering.
+	 **/
+	normalizeRect(rect: number[]): number[];
+
+	/**
+	 * Returns a rectangle [x1, y1, x2, y2] corresponding to the
+	 * intersection of rect1 and rect2. If no intersection, returns 'false'
+	 * The rectangle coordinates of rect1, rect2 should be [x1, y1, x2, y2]
+	 **/
+	intersect(rect1: number[], rect2: number[])
+
+	/**
+	 * get signedness of number
+	 */
+	sign(): number;
+
+	/**
+	 * Converts positive integers to (upper case) Roman numerals.
+	 * @param {integer} number - The number that should be converted.
+	 * @param {boolean} lowerCase - Indicates if the result should be converted
+	 *   to lower case letters. The default is false.
+	 * @return {string} The resulting Roman number.
+	 **/
+	toRoman(number: number, lowerCase: boolean): string;
+
+	appendToArray(arr1: any[], arr2: any[]): any[];
+
+	prependToArray(arr1: any[], arr2: any[]): any[];
+
+	extendObj(obj1: any, obj2: any): any;
+
+	getInheritableProperty(dict: any, name: string): any;
+
+	inherit(sub: any, base: any, prototype: any);
+
+	loadScript(src: string, callback: any);
+}
+
 interface PDFJSStatic {
 
 	/**
@@ -337,7 +423,7 @@ interface PDFJSStatic {
 	disableWorker: boolean;
 
 	/**
-	 * Path and filename of the worker file. Required when the worker is enabled in
+	 * Path and filename of the worker file. Required when the worker is enabled inn
 	 * development mode. If unspecified in the production build, the worker will be
 	 * loaded based on the location of the pdf.js file.
 	 */
@@ -422,7 +508,9 @@ interface PDFJSStatic {
 	 * Determines if we can eval strings as JS. Primarily used to improve
 	 * performance for font rendering.
 	 */
-	isEvalSupported: boolean;
+    isEvalSupported: boolean;
+
+    Util: PDFJSUtilStatic;
 
 	/**
 	 * This is the main entry point for loading a PDF and interacting with it.

--- a/pdf/pdf.d.ts
+++ b/pdf/pdf.d.ts
@@ -325,7 +325,7 @@ interface PDFJSUtilStatic {
 	 * Applies the transform to the rectangle and finds the minimum axially
 	 * aligned bounding box.
 	 **/
-	getAxialAlignedBoundingBox(r: number[], m: number[])
+	getAxialAlignedBoundingBox(r: number[], m: number[]): number[];
 
 	/**
 	 * inverse transform
@@ -357,7 +357,7 @@ interface PDFJSUtilStatic {
 	 * intersection of rect1 and rect2. If no intersection, returns 'false'
 	 * The rectangle coordinates of rect1, rect2 should be [x1, y1, x2, y2]
 	 **/
-	intersect(rect1: number[], rect2: number[])
+	intersect(rect1: number[], rect2: number[]): number[];
 
 	/**
 	 * get signedness of number
@@ -377,13 +377,13 @@ interface PDFJSUtilStatic {
 
 	prependToArray(arr1: any[], arr2: any[]): any[];
 
-	extendObj(obj1: any, obj2: any): any;
+	extendObj(obj1: any, obj2: any): void;
 
 	getInheritableProperty(dict: any, name: string): any;
 
-	inherit(sub: any, base: any, prototype: any);
+	inherit(sub: any, base: any, prototype: any): void;
 
-	loadScript(src: string, callback: any);
+	loadScript(src: string, callback: any): void;
 }
 
 interface PDFJSStatic {


### PR DESCRIPTION
### Improvement to existing type definition.

I'd like to make Mozilla's acroforms example work with TypesScript:
https://github.com/mozilla/pdf.js/blob/master/examples/acroforms/forms.js

To make it work, some additions to the type definitions are necessary.
#### Interface `PDFPageViewport`
- `convertToViewportRectangle` requires a parameter `rect:number[]`
- `convertToViewportPoint` requires 2 parameters `x: number, y: number`
- `convertToPdfPoint` requires 2 parameters `x: number, y: number`

For reference, see: https://github.com/mozilla/pdf.js/blob/master/src/shared/util.js#L985
#### Interface `PDFJS.Util` (static)
- Added missing type definitions for `PDFJS.Util`

For reference, see: https://github.com/mozilla/pdf.js/blob/master/src/shared/util.js#L643
