### PR TITLE
Update Xrm.Page object

### DIFF
--- a/xrm/xrm.d.ts
+++ b/xrm/xrm.d.ts
@@ -786,7 +786,7 @@ declare namespace Xrm
              *
              * @return  The event source.
              */
-            getEventSource(): Attribute | Entity;
+            getEventSource(): Attribute | Control | Entity;
 
             /**
              * Gets the shared variable with the specified key.
@@ -1726,7 +1726,7 @@ declare namespace Xrm
              *
              * @param   {Function}  handler The handler.
              */
-            addPreSearch( handler: () => void ): void;
+            addPreSearch( handler: ContextSensitiveHandler ): void;
 
             /**
              * Adds an additional custom filter to the lookup, with the "AND" filter operator.


### PR DESCRIPTION
Verified that addPreSearch returns a ContextSensitiveHandler, and since the handler is added against a control, the getEventSource can return a Control as well.  

https://msdn.microsoft.com/en-us/library/gg328130.aspx?f=255&MSPPError=-2147217396#BKMK_getEventSource states: This method returns the object from the Xrm.Page object model that is the source of the event.  Since the addPreSearch is a Control, the control gets returned in this case...
