### PR TITLE
Make sure createLogger is a default export.

### DIFF
--- a/redux-logger/redux-logger.d.ts
+++ b/redux-logger/redux-logger.d.ts
@@ -44,9 +44,5 @@ declare module 'redux-logger' {
     diffPredicate?: LoggerPredicate;
   }
 
-  // Trickery to get TypeScript to accept that our anonymous, non-default export is a function.
-  // see https://github.com/Microsoft/TypeScript/issues/3612 for more
-  namespace createLogger {}
-  function createLogger(options?: ReduxLoggerOptions): Redux.Middleware;
-  export = createLogger;
+  export default function createLogger(options?: ReduxLoggerOptions): Redux.Middleware;
 }


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Using Typescript 1.8+ the definition requires a "real" default export and should work as expected without the trickery previously used.
