### PR TITLE
Add namespace to gulp-rename to make export work

### DIFF
--- a/gulp-rename/gulp-rename-tests.ts
+++ b/gulp-rename/gulp-rename-tests.ts
@@ -3,6 +3,9 @@
 import gulp = require("gulp");
 import rename = require("gulp-rename");
 
+// Test that new import syntax works
+import * as newRename from 'gulp-rename';
+
 // rename via string
 gulp.src("./src/main/text/hello.txt")
     .pipe(rename("main/text/ciao/goodbye.md"))

--- a/gulp-rename/gulp-rename.d.ts
+++ b/gulp-rename/gulp-rename.d.ts
@@ -20,5 +20,12 @@ declare module "gulp-rename" {
     function rename(name: string): NodeJS.ReadWriteStream;
     function rename(callback: (path: ParsedPath) => any): NodeJS.ReadWriteStream;
     function rename(opts: Options): NodeJS.ReadWriteStream;
+
+    /**
+     * This is required as per:
+     * https://github.com/Microsoft/TypeScript/issues/5073
+     */
+    namespace rename {}
+
     export = rename;
 }


### PR DESCRIPTION
Because of an issue with how TypeScript handles module exports of functions, `gulp-rename` currently doesn't work in an ES6 Modules `import` statement.

``` javascript
import * as rename from 'gulp-rename'; // <-- Fails because 'gulp-rename' is a non-module entity
```

We work around this, by adding a namespace with the same name as the exported function.

Please see microsoft/typescript#5073
