### PR TITLE
Add diff2html typings and tests

### DIFF
--- a/diff2html/diff2html-tests.ts
+++ b/diff2html/diff2html-tests.ts
@@ -1,0 +1,26 @@
+/// <reference path="./diff2html.d.ts" />
+
+import Diff2Html = require('diff2html');
+
+let d2h = Diff2Html.Diff2Html;
+
+class Diff2HtmlOptionsImpl implements Diff2Html.Options {  
+    constructor (public inputFormat: string) {
+    }
+} 
+
+let strInput = 
+        'diff --git a/sample b/sample\n' +
+        'index 0000001..0ddf2ba\n' +
+        '--- a/sample\n' +
+        '+++ b/sample\n' +
+        '@@ -1 +1 @@\n' +
+        '-test\n' +
+        '+test1r\n';
+
+let strConfiguration = new Diff2HtmlOptionsImpl('diff');
+let diffInput = d2h.getJsonFromDiff(strInput, strConfiguration);
+
+let diffConfiguration = new Diff2HtmlOptionsImpl('json');
+let htmlString = d2h.getPrettyHtml(diffInput, diffConfiguration);
+console.log(htmlString);

--- a/diff2html/diff2html.d.ts
+++ b/diff2html/diff2html.d.ts
@@ -1,0 +1,66 @@
+// Type definitions for diff2html
+// Project: https://github.com/rtfpessoa/diff2html
+// Definitions by: rtfpessoa <https://github.com/rtfpessoa/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace Diff2Html {
+    
+    export interface Options {
+        inputFormat?: string;
+        outputFormat?: string;
+        showFiles?: boolean;
+        matching?: string;
+        synchronisedScroll?: boolean;
+        matchWordsThreshold?: number;
+        matchingMaxComparisons?: number;
+    }
+
+    export interface Line {
+        content: string;
+        type: string;
+        oldNumber: number;
+        newNumber: number;
+    }
+
+    export interface Block {
+        oldStartLine: number;
+        oldStartLine2?: number;
+        newStartLine: number;
+        header: string;
+        lines: Line[];
+    }
+
+    export interface Result {
+        addedLines: number;
+        deletedLines: number;
+        isCombined: boolean;
+        isGitDiff: boolean;
+        oldName: string;
+        newName: string;
+        language: string;
+        blocks: Block[];
+        oldMode?: string;
+        newMode?: string;
+        deletedFileMode?: string;
+        newFileMode?: string;
+        isDeleted?: boolean;
+        isNew?: boolean;
+        isCopy?: boolean;
+        isRename?: boolean;
+        unchangedPercentage?: number;
+        changedPercentage?: number;
+        checksumBefore?: string;
+        checksumAfter?: string;
+        mode?: string;
+    }
+    
+    export interface Diff2Html {
+        getJsonFromDiff(input: string, configuration?: Options): Result;
+        getPrettyHtml(input: any, configuration?: Options): string;
+    }
+}
+
+declare module "diff2html" {
+    var d2h: { "Diff2Html": Diff2Html.Diff2Html };
+    export = d2h;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [X] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [X] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [X] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
