### PR TITLE
eventemitter2: Namespaces allow string[] for on()

### DIFF
--- a/eventemitter2/eventemitter2.d.ts
+++ b/eventemitter2/eventemitter2.d.ts
@@ -43,7 +43,7 @@ declare class EventEmitter2 {
      * @param event
      * @param listener
      */
-    on(event: string, listener: Function): EventEmitter2;
+    on(event: string | string[], listener: Function): EventEmitter2;
 
     /**
      * Adds a listener that will be fired when any event is emitted.
@@ -128,7 +128,7 @@ declare class EventEmitter2 {
      * @param event
      * @param args
      */
-    emit(event: string, ...args: any[]): boolean;
+    emit(event: string | string[], ...args: any[]): boolean;
 
     /**
      * Execute each of the listeners that may be listening for the specified event name in order with the list of arguments.
@@ -156,7 +156,7 @@ declare module "eventemitter2" {
          * @param event
          * @param listener
          */
-        on(event: string, listener: Function): EventEmitter2;
+        on(event: string | string[], listener: Function): EventEmitter2;
 
         /**
          * Adds a listener that will be fired when any event is emitted.
@@ -241,7 +241,7 @@ declare module "eventemitter2" {
          * @param event
          * @param args
          */
-        emit(event: string, ...args: any[]): boolean;
+        emit(event: string | string[], ...args: any[]): boolean;
 
         /**
          * Execute each of the listeners that may be listening for the specified event name in order with the list of arguments.


### PR DESCRIPTION
The `on`/`emit` methods in eventemitter2 allows namespacing via arrays thus the type for the `events` arg should be `string | string[]`.

See this quote from the docs:

> Namespaces with Wildcards To use namespaces/wildcards, pass the wildcard option into the EventEmitter constructor. When namespaces/wildcards are enabled, **events can either be strings (foo.bar) separated by a delimiter or arrays (['foo', 'bar'])**. The delimiter is also configurable as a constructor option.

https://github.com/asyncly/EventEmitter2#api
