### PR TITLE
getInputNode should return HTMLInputElement

### DIFF
--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -1712,7 +1712,7 @@ declare namespace __MaterialUI {
         focus(): void;
         select(): void;
         getValue(): string;
-        getInputNode(): Element;
+        getInputNode(): HTMLInputElement;
     }
 
     interface TimePickerProps extends React.Props<TimePicker> {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.
  Looking at [source of TextField](https://github.com/callemall/material-ui/blob/master/src/TextField/TextField.js):

``` js
  blur() {
    if (this.input) this.getInputNode().blur();
  }

  focus() {
    if (this.input) this.getInputNode().focus();
  }

  select() {
    if (this.input) this.getInputNode().select();
  }

  getValue() {
    return this.input ? this.getInputNode().value : undefined;
  }

  getInputNode() {
    return (this.props.children || this.props.multiLine) ?
      this.input.getInputNode() : ReactDOM.findDOMNode(this.input);
  }
```

Reviews that `getInputNode` should return type that has methods `focus`, `blur`, `select` and property `value` .
And than cheking [MDN](https://developer.mozilla.org/en-US/) says that [HTMLInputElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement) defines them and has the following inheritance chain: `Element ->  HTMLElement -> HTMLInputElement` so it's the correct return type.
