### PR TITLE
PDFJS: Add typedefs for viewport conversion methods

### DIFF
--- a/pdf/pdf-tests.ts
+++ b/pdf/pdf-tests.ts
@@ -25,6 +25,16 @@ function renderPage(pageNum: number) {
 		var context = canvas.getContext('2d');
 		canvas.height = viewport.height;
 		canvas.width = viewport.width;
+		
+		//
+		// test viewport conversion methods
+		// convertToViewportRectangle and normalizeRect are used in the acroforms example:
+		// https://github.com/mozilla/pdf.js/blob/master/examples/acroforms/forms.js
+		//
+		const rect = viewport.convertToViewportRectangle([100,100,0,0]);
+		const normalizedRect = PDFJS.Util.normalizeRect(rect);
+		const point = viewport.convertToViewportPoint(100, 100);
+		const pdfPoint = viewport.convertToPdfPoint(100, 100);
 
 		//
 		// Render PDF page into canvas context

--- a/pdf/pdf.d.ts
+++ b/pdf/pdf.d.ts
@@ -156,9 +156,9 @@ interface PDFPageViewport {
 	transforms: number[];
 
 	clone(options: PDFPageViewportOptions): PDFPageViewport;
-	convertToViewportPoint(): number[]; // [x, y]
-	convertToViewportRectangle(): number[]; // [x1, y1, x2, y2]
-	convertToPdfPoint(): number[]; // [x, y]
+	convertToViewportPoint(x: number, y: number): number[]; // [x, y]
+	convertToViewportRectangle(rect: number[]): number[]; // [x1, y1, x2, y2]
+	convertToPdfPoint(x: number, y: number): number[]; // [x, y]
 }
 
 interface PDFAnnotationData {
@@ -300,6 +300,19 @@ interface PDFObjects {
 	clear(): void;
 }
 
+interface PDFJSUtilStatic {
+	/**
+	 * Normalize rectangle so that (x1,y1) < (x2,y2)
+	 * @param {number[]} rect - the rectangle with [x1,y1,x2,y2]
+	 *
+	 * For coordinate systems whose origin lies in the bottom-left, this
+	 * means normalization to (BL,TR) ordering. For systems with origin in the
+	 * top-left, this means (TL,BR) ordering.
+	 **/
+	normalizeRect(rect:number[]): number[];
+}
+
+
 interface PDFJSStatic {
 
 	/**
@@ -423,6 +436,8 @@ interface PDFJSStatic {
 	 * performance for font rendering.
 	 */
 	isEvalSupported: boolean;
+
+	Util: PDFJSUtilStatic;
 
 	/**
 	 * This is the main entry point for loading a PDF and interacting with it.


### PR DESCRIPTION
## Improvement to existing type definition.

I'd like to make Mozilla's acroforms example work with TypesScript:
https://github.com/mozilla/pdf.js/blob/master/examples/acroforms/forms.js#L33

A type error occurs on the marked line.
### Proposed fixes
#### Interface `PDFPageViewport`
- `convertToViewportRectangle` requires a parameter `rect:number[]`
- `convertToViewportPoint` requires 2 parameters `x: number, y: number`
- `convertToPdfPoint` requires 2 parameters `x: number, y: number`

I couldn't find an API documentation for these methods. 
For reference, look at the implementation: 

https://github.com/mozilla/pdf.js/blob/master/src/shared/util.js#L985
#### Interface `PDFJS`
- Added new interface `Util: PDFJSUtilStatic` to the `PDFJS` interface
#### Interface `PDFJSUtilStatic` (static)
- Added missing type definition for `PDFJS.Util.normalizeRect`

For reference: https://github.com/mozilla/pdf.js/blob/master/src/shared/util.js#L748
