### PR TITLE
Changing export so it matches Universal default export

### DIFF
--- a/object-assign/object-assign-tests.ts
+++ b/object-assign/object-assign-tests.ts
@@ -1,5 +1,5 @@
 /// <reference path="object-assign.d.ts" />
-import objectAssign = require("object-assign");
+import objectAssign from "object-assign";
 
 function assign1() {
   var result = objectAssign({hello: "world"});

--- a/object-assign/object-assign-tests.ts
+++ b/object-assign/object-assign-tests.ts
@@ -1,5 +1,5 @@
 /// <reference path="object-assign.d.ts" />
-import * as objectAssign from 'object-assign';
+import objectAssign from 'object-assign';
 
 function assign1() {
   var result = objectAssign({hello: "world"});

--- a/object-assign/object-assign-tests.ts
+++ b/object-assign/object-assign-tests.ts
@@ -1,5 +1,5 @@
 /// <reference path="object-assign.d.ts" />
-import * as ObjectAssign from 'object-assign';
+import * as objectAssign from 'object-assign';
 
 function assign1() {
   var result = objectAssign({hello: "world"});

--- a/object-assign/object-assign-tests.ts
+++ b/object-assign/object-assign-tests.ts
@@ -1,5 +1,5 @@
 /// <reference path="object-assign.d.ts" />
-import objectAssign from "object-assign";
+import * as ObjectAssign from 'object-assign';
 
 function assign1() {
   var result = objectAssign({hello: "world"});

--- a/object-assign/object-assign.d.ts
+++ b/object-assign/object-assign.d.ts
@@ -4,6 +4,5 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module "object-assign" {
-  function objectAssign(target: any, ...sources: any[]): any;
-  export = objectAssign;
+  export default function objectAssign(target: any, ...sources: any[]): any;
 }

--- a/react-redux/react-redux-2.1.2-tests.tsx
+++ b/react-redux/react-redux-2.1.2-tests.tsx
@@ -12,7 +12,7 @@ import * as Router from 'react-router';
 import { Route, RouterState } from 'react-router';
 import { Store, Dispatch, bindActionCreators } from 'redux';
 import { connect, Provider } from 'react-redux';
-import objectAssign = require('object-assign');
+import objectAssign from 'object-assign';
 
 //
 // Quick Start

--- a/react-redux/react-redux-2.1.2-tests.tsx
+++ b/react-redux/react-redux-2.1.2-tests.tsx
@@ -12,7 +12,7 @@ import * as Router from 'react-router';
 import { Route, RouterState } from 'react-router';
 import { Store, Dispatch, bindActionCreators } from 'redux';
 import { connect, Provider } from 'react-redux';
-import * as ObjectAssign from 'object-assign';
+import * as objectAssign from 'object-assign';
 
 //
 // Quick Start

--- a/react-redux/react-redux-2.1.2-tests.tsx
+++ b/react-redux/react-redux-2.1.2-tests.tsx
@@ -12,7 +12,7 @@ import * as Router from 'react-router';
 import { Route, RouterState } from 'react-router';
 import { Store, Dispatch, bindActionCreators } from 'redux';
 import { connect, Provider } from 'react-redux';
-import * as objectAssign from 'object-assign';
+import objectAssign from 'object-assign';
 
 //
 // Quick Start

--- a/react-redux/react-redux-2.1.2-tests.tsx
+++ b/react-redux/react-redux-2.1.2-tests.tsx
@@ -12,7 +12,7 @@ import * as Router from 'react-router';
 import { Route, RouterState } from 'react-router';
 import { Store, Dispatch, bindActionCreators } from 'redux';
 import { connect, Provider } from 'react-redux';
-import objectAssign from 'object-assign';
+import * as ObjectAssign from 'object-assign';
 
 //
 // Quick Start

--- a/react-redux/react-redux-tests.tsx
+++ b/react-redux/react-redux-tests.tsx
@@ -12,7 +12,7 @@ import * as ReactDOM from 'react-dom';
 import { Router, RouterState } from 'react-router';
 import { Store, Dispatch, bindActionCreators } from 'redux';
 import { connect, Provider } from 'react-redux';
-import objectAssign = require('object-assign');
+import objectAssign from 'object-assign';
 
 //
 // Quick Start

--- a/react-redux/react-redux-tests.tsx
+++ b/react-redux/react-redux-tests.tsx
@@ -12,7 +12,7 @@ import * as ReactDOM from 'react-dom';
 import { Router, RouterState } from 'react-router';
 import { Store, Dispatch, bindActionCreators } from 'redux';
 import { connect, Provider } from 'react-redux';
-import objectAssign from 'object-assign';
+import * as ObjectAssign from 'object-assign';
 
 //
 // Quick Start

--- a/react-redux/react-redux-tests.tsx
+++ b/react-redux/react-redux-tests.tsx
@@ -12,7 +12,7 @@ import * as ReactDOM from 'react-dom';
 import { Router, RouterState } from 'react-router';
 import { Store, Dispatch, bindActionCreators } from 'redux';
 import { connect, Provider } from 'react-redux';
-import * as ObjectAssign from 'object-assign';
+import * as objectAssign from 'object-assign';
 
 //
 // Quick Start

--- a/react-redux/react-redux-tests.tsx
+++ b/react-redux/react-redux-tests.tsx
@@ -12,7 +12,7 @@ import * as ReactDOM from 'react-dom';
 import { Router, RouterState } from 'react-router';
 import { Store, Dispatch, bindActionCreators } from 'redux';
 import { connect, Provider } from 'react-redux';
-import * as objectAssign from 'object-assign';
+import objectAssign from 'object-assign';
 
 //
 // Quick Start


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Using `export default` and `import from` will allow all TypeScript users to use the module and let TypeScript generate the correct code based on `moduleResolution` and `target` passed to the compiler.
