### PR TITLE
Fix SAXParser startTag attrs type.

### DIFF
--- a/parse5/parse5-tests.ts
+++ b/parse5/parse5-tests.ts
@@ -1,6 +1,6 @@
 // Type definitions for parse5 2.1.5
 // Project: https://github.com/inikulin/parse5
-// Definitions by: Nico Jansen <https://github.com/nicojs>
+// Definitions by: Nico Jansen <https://github.com/nicojs>, Meirion Hughes <https://github.com/MeirionHughes>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="./parse5.d.ts" />
@@ -9,33 +9,56 @@ import * as parse5 from 'parse5';
 
 // parse5.SAXParser()
 var parser = new parse5.SAXParser({ locationInfo: true });
+
+var _wasCalled = false;
+
 parser.on('startTag', (name, attrs, selfClosing, location) => {
     console.log(name, attrs, selfClosing, location);
+    console.log(attrs[0].name);
+    console.log(attrs[0].prefix);
+    console.log(attrs[0].value);
+
+    if(name == "use")
+        if(attrs[0].prefix === undefined)
+            throw "prefix wasn't defined on known attr"
+
+    _wasCalled = true;
 });
+
 parser.on('text', (text, location)  => {
     console.log(text, location);
 });
 
+parser.write('some text');
+parser.write('<svg class="icon"><use xlink:href="icons.svg#some_selector"></use></svg>');
+
+if(!_wasCalled)
+    throw "parser.on 'startTag' wasn't called";
+
 // parse5.parse()
-parse5.parse('html', { locationInfo: true, treeAdapter: parse5.treeAdapters.default });
+parse5.parse('<html></html>', { locationInfo: true, treeAdapter: parse5.treeAdapters.default });
 parse5.parse('html', {});
-parse5.parse('html');
+parse5.parse('');
 
 // parse5.ParserStream()
 var parserStream = new parse5.ParserStream({ locationInfo: true, treeAdapter: parse5.treeAdapters.htmlparser2 });
 parserStream = new parse5.ParserStream({ });
 parserStream = new parse5.ParserStream();
+
+parserStream.write("<html></html>");
+
 var node = parserStream.document.childNodes[0];
+
 node.parentNode.attrs = [{name: '', value: ''}];
 
 // parse5.parseFragment()
-var fragment = parse5.parseFragment('');
-fragment = parse5.parseFragment('', {locationInfo: true});
+var fragment = parse5.parseFragment('<div></div>');
+fragment = parse5.parseFragment('<div></div>', {locationInfo: true});
 
 // parse5.ASTNode
 fragment.quirksMode = true;
 fragment.namespaceURI = '';
 fragment.nodeName = '';
 fragment.value = '';
-fragment = fragment.parentNode;
 fragment = fragment.childNodes[0];
+fragment = fragment.parentNode;

--- a/parse5/parse5-tests.ts
+++ b/parse5/parse5-tests.ts
@@ -1,4 +1,4 @@
-// Type definitions for parse5 2.1.5
+// Type definitions for parse5 2.2.0
 // Project: https://github.com/inikulin/parse5
 // Definitions by: Nico Jansen <https://github.com/nicojs>, Meirion Hughes <https://github.com/MeirionHughes>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/parse5/parse5.d.ts
+++ b/parse5/parse5.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for parse5 2.1.5
+// Type definitions for parse5 2.2.0
 // Project: https://github.com/inikulin/parse5
-// Definitions by: Nico Jansen <https://github.com/nicojs>
+// Definitions by: Nico Jansen <https://github.com/nicojs>, Meirion Hughes <https://github.com/MeirionHughes>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../node/node.d.ts" />
@@ -45,6 +45,7 @@ declare module 'parse5' {
     export interface ASTAttribute {
         name: string;
         value: string;
+        prefix?: string;
     }
 
     export interface Attribute {
@@ -126,10 +127,10 @@ declare module 'parse5' {
         /**
          * Raised when the parser encounters a start tag.
          * Listener function has 4 parameters:
-         * Tag name, List of attributes in the { key: String, value: String } form, selfClosing boolean 
+         * Tag name, List of attributes in the { name: String, value: String, prefix?: String } form, selfClosing boolean 
          * and start tag source code location info. Available if location info is enabled in SAXParserOptions.
          */
-        on(event: 'startTag', listener: (name: string, attrs: Attribute[], selfClosing: boolean, location?: StartTagLocationInfo) => void): this;
+        on(event: 'startTag', listener: (name: string, attrs: ASTAttribute[], selfClosing: boolean, location?: StartTagLocationInfo) => void): this;
         /**
          * Raised when parser encounters an end tag.
          * Listener function has 2 parameters:


### PR DESCRIPTION
case 2. Improvement to existing type definition.
Fix typing bug, see: https://github.com/inikulin/parse5/issues/147

update ASTAttribute to include optional prefix field
