### PR TITLE
added support for jasmine.getEnv().defaultTimeoutInterval

### DIFF
--- a/jasmine-node/jasmine-node.d.ts
+++ b/jasmine-node/jasmine-node.d.ts
@@ -7,6 +7,12 @@
 
 declare function it(expectation:string, assertion:(done:(err?:any) => void) => void, timeout?:number):void;
 
+declare namespace jasmine {
+	interface Env {
+		defaultTimeoutInterval: number;
+	}
+}
+
 declare module "jasmine-node" {
     interface ExecuteSpecsOptions {
         specFolders: string[],


### PR DESCRIPTION
# See:

https://github.com/mhevery/jasmine-node/blob/master/README.md#async-tests

ps: it's not the same as jasmine.DEFAULT_TIMEOUT_INTERVAL.
