### PR TITLE
Updated typings for fullcalendar

### DIFF
--- a/fullCalendar/fullCalendar-tests.ts
+++ b/fullCalendar/fullCalendar-tests.ts
@@ -781,16 +781,16 @@ $(document).ready(function () {
     /* initialize the external events
     -----------------------------------------------------------------*/
     $('#external-events div.external-event').each(function () {
-        
+
         // create an Event Object (http://arshaw.com/fullcalendar/docs/event_data/Event_Object/)
         // it doesn't need to have a start or end
         var eventObject = {
             title: $.trim($(this).text()) // use the element's text as the event title
         };
-        
+
         // store the Event Object in the DOM element so we can get to it later
         $(this).data('eventObject', eventObject);
-        
+
         // make the event draggable using jQuery UI
         $(this).draggable({
             zIndex: 999,
@@ -811,21 +811,21 @@ $(document).ready(function () {
         editable: true,
         droppable: true, // this allows things to be dropped onto the calendar !!!
         drop: function (date, allDay) { // this function is called when something is dropped
-            
+
             // retrieve the dropped element's stored Event Object
             var originalEventObject = $(this).data('eventObject');
-            
+
             // we need to copy it, so that multiple events don't have a reference to the same object
             var copiedEventObject: any = $.extend({}, originalEventObject);
-            
+
             // assign it the date that was reported
             copiedEventObject.start = date;
             copiedEventObject.allDay = allDay;
-            
+
             // render the event on the calendar
             // the last `true` argument determines if the event "sticks" (http://arshaw.com/fullcalendar/docs/event_rendering/renderEvent/)
             $('#calendar').fullCalendar('renderEvent', copiedEventObject, true);
-            
+
             // is the "remove after drop" checkbox checked?
             if ($('#drop-remove').is(':checked')) {
                 // if so, remove the element from the "Draggable Events" list
@@ -833,6 +833,77 @@ $(document).ready(function () {
             }
         }
     });
+});
+
+$(document).ready(() => {
+    var date = new Date();
+    var d = date.getDate();
+    var m = date.getMonth();
+    var y = date.getFullYear();
+
+    $('#calendar').fullCalendar({
+        theme: true,
+        header: {
+            left: 'prev,next today',
+            center: 'title',
+            right: 'month,agendaWeek,agendaDay'
+        },
+        editable: true,
+        events: [{
+            id: 'test1',
+            title: 'event full of features',
+            start: new Date(y, m, 1),
+            startEditable: true,
+            allDay: false,
+            url: 'http://www.google.com',
+            className: 'gcal-event',
+            editable: false,
+            durationEditable: false,
+            rendering: 'background',
+            overlap: false,
+            constraint: {
+                start: '10:00',
+                end: '18:00',
+                dow: [ 1, 2 ],
+                // days of week. an array of zero-based day of week integers (0=Sunday)
+                // (Monday-Tuesday in this example)
+            },
+            color: 'white',
+            backgroundColor: 'black',
+            borderColor: 'grey',
+            textColor: 'white',
+        }],
+    });
+
+    $('#calendar').fullCalendar({
+        theme: true,
+        header: {
+            left: 'prev,next today',
+            center: 'title',
+            right: 'month,agendaWeek,agendaDay'
+        },
+        editable: true,
+        events: [{
+            id: 'test2',
+            title: 'just an event',
+            start: new Date(y, m, 1),
+        }],
+        eventConstraint: 'businessHours',
+        eventLimit: true,
+        businessHours: [{
+            start: '10:00',
+            end: '18:00',
+            dow: [ 1, 2 ],
+            // days of week. an array of zero-based day of week integers (0=Sunday)
+            // (Monday-Tuesday in this example)
+        }, {
+            start: '09:00',
+            end: '19:00',
+            dow: [ 3, 4 ],
+        }],
+    });
+
+    $('#calendar').fullCalendar('refetchEventSources', 'http://www.google.com/your_feed_url1/');
 });
 
 $('#calendar').fullCalendar('refetchEvents');

--- a/fullCalendar/index.d.ts
+++ b/fullCalendar/index.d.ts
@@ -18,14 +18,14 @@ export interface Calendar {
 }
 
 export interface BusinessHours {
-    start: moment.Duration;
-    end: moment.Duration;
+    start: moment.Duration | string | Date;
+    end: moment.Duration | string | Date;
     dow: Array<number>;
 }
 
 export interface Timespan {
-    start: moment.Moment;
-    end: moment.Moment;
+    start: moment.Moment | string | Date;
+    end?: moment.Moment | string | Date;
 }
 
 export interface Options extends AgendaOptions, EventDraggingResizingOptions, DroppingExternalElementsOptions, SelectionOptions {
@@ -35,12 +35,12 @@ export interface Options extends AgendaOptions, EventDraggingResizingOptions, Dr
         left: string;
         center: string;
         right: string;
-    }
-    theme?: boolean
+    };
+    theme?: boolean;
     buttonIcons?: {
         prev: string;
         next: string;
-    }
+    };
     firstDay?: number;
     isRTL?: boolean;
     weekends?: boolean;
@@ -48,7 +48,7 @@ export interface Options extends AgendaOptions, EventDraggingResizingOptions, Dr
     weekMode?: string;
     weekNumbers?: boolean;
     weekNumberCalculation?: any; // String/Function
-    businessHours?: boolean | BusinessHours;
+    businessHours?: boolean | BusinessHours | Array<BusinessHours>;
     height?: number;
     contentHeight?: number;
     aspectRatio?: number;
@@ -61,7 +61,7 @@ export interface Options extends AgendaOptions, EventDraggingResizingOptions, Dr
 
     // Timezone
     timezone?: string | boolean;
-    now?: moment.Moment | Date | string | (() => moment.Moment)
+    now?: moment.Moment | Date | string | (() => moment.Moment);
 
     // Views - http://fullcalendar.io/docs/views/
 
@@ -117,10 +117,11 @@ export interface Options extends AgendaOptions, EventDraggingResizingOptions, Dr
 
     allDayDefault?: boolean;
     startParam?: string;
-    endParam?: string
+    endParam?: string;
     lazyFetching?: boolean;
     eventDataTransform?: (eventData: any) => EventObject;
     loading?: (isLoading: boolean, view: ViewObject) => void;
+    eventLimit?: boolean;
 
     // Event Rendering - http://fullcalendar.io/docs/event_rendering/
 
@@ -161,7 +162,7 @@ export interface EventDraggingResizingOptions {
     dragOpacity?: number; // float
     dragScroll?: boolean;
     eventOverlap?: boolean | ((stillEvent: EventObject, movingEvent: EventObject) => boolean);
-    eventConstraint?: BusinessHours | Timespan;
+    eventConstraint?: "businessHours" | BusinessHours | Timespan;
     eventDragStart?: (event: EventObject, jsEvent: MouseEvent, ui: any, view: ViewObject) => void;
     eventDragStop?: (event: EventObject, jsEvent: MouseEvent, ui: any, view: ViewObject) => void;
     eventDrop?: (event: EventObject, delta: moment.Duration, revertFunc: Function, jsEvent: Event, ui: any, view: ViewObject) => void;
@@ -187,7 +188,7 @@ export interface DroppingExternalElementsOptions {
     droppable?: boolean;
     dropAccept?: string | ((draggable: any) => boolean);
     drop?: (date: moment.Moment, jsEvent: MouseEvent, ui: any) => void;
-    eventReceive?: (event: EventObject) => void
+    eventReceive?: (event: EventObject) => void;
 }
 
 export interface ButtonTextObject {
@@ -201,19 +202,24 @@ export interface ButtonTextObject {
     day?: string;
 }
 
+/* Refer to http://fullcalendar.io/docs/event_data/Event_Object/ */
 export interface EventObject extends Timespan {
-    id?: any // String/number
+    id?: any; // String/number
     title: string;
     allDay?: boolean;
     url?: string;
-    className?: any; // string/Array<string>
+    className?: string | Array<string>;
     editable?: boolean;
+    startEditable?: boolean;
+    durationEditable?: boolean;
+    rendering?: string;
+    overlap?: boolean;
+    constraint?: Timespan | BusinessHours;
     source?: EventSource;
     color?: string;
     backgroundColor?: string;
     borderColor?: string;
     textColor?: string;
-    rendering?: string;
 }
 
 export interface ViewObject extends Timespan {
@@ -243,7 +249,7 @@ export interface EventSource extends JQueryAjaxSettings {
     ignoreTimezone?: boolean;
     eventTransform?: any;
     startParam?: string;
-    endParam?: string
+    endParam?: string;
 }
 
 /*
@@ -391,6 +397,11 @@ declare global {
          * Rerenders all events on the calendar.
          */
         fullCalendar(method: 'rerenderEvents'): void;
+
+        /**
+         * Refetches one or more specific event sources.
+         */
+        fullCalendar(method: 'refetchEventSources', source: any): void;
 
         /**
          * Create calendar object


### PR DESCRIPTION
Hi,
i've aligned abit fullCalendar typings,
it's still not perfect, but much closer to the documentation.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  
  [BusinessHours](http://fullcalendar.io/docs/display/businessHours/)
  [eventLimit](http://fullcalendar.io/docs/display/eventLimit/)
  [eventConstraint](http://fullcalendar.io/docs/event_ui/eventConstraint/)
  [EventObject](http://fullcalendar.io/docs/event_data/Event_Object/)
  [refetchEventSources](http://fullcalendar.io/docs/event_data/refetchEventSources/)
- it has been reviewed by a DefinitelyTyped member.
