### PR TITLE
Added react-native requireNativeComponent function

### DIFF
--- a/react-native/react-native.d.ts
+++ b/react-native/react-native.d.ts
@@ -5977,6 +5977,19 @@ declare namespace  __React {
     export var NativeModules: any
     export var NativeAppEventEmitter: NativeAppEventEmitterStatic
 
+
+    //////////// Plugins //////////////
+    export type ComponentInterface = ReactClass<any, any, any> | {
+        name?: string;
+        displayName?: string;
+        propTypes: Object
+    };
+
+    export function requireNativeComponent(
+        viewName: string,
+        componentInterface?: ComponentInterface,
+        extraConfig?: {nativeOnly: Object}): React.ComponentClass<any>;
+
     //
     // /TODO: BGR: These are leftovers of the initial port that must be revisited
     //

--- a/react-native/react-native.d.ts
+++ b/react-native/react-native.d.ts
@@ -5979,16 +5979,17 @@ declare namespace  __React {
 
 
     //////////// Plugins //////////////
-    export type ComponentInterface = ReactClass<any, any, any> | {
+    export interface ComponentInterface<P> {
         name?: string;
         displayName?: string;
-        propTypes: Object
-    };
+        propTypes: P
+    }
 
-    export function requireNativeComponent(
+    export function requireNativeComponent<P>(
         viewName: string,
-        componentInterface?: ComponentInterface,
-        extraConfig?: {nativeOnly: Object}): React.ComponentClass<any>;
+        componentInterface?: ComponentInterface<P>,
+        extraConfig?: {nativeOnly: Object}
+    ): React.ComponentClass<P>;
 
     //
     // /TODO: BGR: These are leftovers of the initial port that must be revisited


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- added definition for requireNativeComponent function which enables developers to require native (e.g. Android) components from TypeScript

Example of using native Android module exposed from Java as `"RCTMapView"`:

```
interface MapViewPropTypes {
   ...
}

export const MapView: React.ComponentClass<MapViewPropTypes> =
    requireNativeComponent("RCTMapView");
```

Then just import MapView and use it in JSX as usual: `<MapView />`
