### PR TITLE
[node] http.IncomingMessage no destroy

### DIFF
--- a/node/node-4.d.ts
+++ b/node/node-4.d.ts
@@ -632,6 +632,7 @@ declare module "http" {
          */
         statusMessage?: string;
         socket: net.Socket;
+        destroy(error?: Error): void;
     }
     /**
      * @deprecated Use IncomingMessage


### PR DESCRIPTION
# Improvement to existing type definition
- **Brief**:
  
  http.IncomingMessage no destroy
- **Detail**:
  
  This is [Node v4.x document about http_message_destroy_error](https://nodejs.org/dist/latest-v4.x/docs/api/http.html#http_message_destroy_error), please refer this link.
