### PR TITLE
Improved aws-lambda type definitions

### DIFF
--- a/aws-lambda/aws-lambda-tests.ts
+++ b/aws-lambda/aws-lambda-tests.ts
@@ -9,6 +9,8 @@ var kinesis: lambda.Kinesis;
 var recordsList: lambda.Record[];
 var anyObj: any;
 var num: number;
+var identity: lambda.Identity;
+var error: Error;
 
 /* Records */
 var records: lambda.Records;
@@ -47,3 +49,18 @@ context.succeed(anyObj);
 context.succeed(str, anyObj);
 str = context.awsRequestId;
 num = context.getRemainingTimeInMillis();
+identity = context.identity;
+
+/* Identity */
+var identity: lambda.Identity;
+
+str = identity.cognitoIdentityId;
+str = identity.cognitoIdentityPoolId;
+
+/* Callback */
+function callback(cb: lambda.Callback) {
+    cb();
+    cb(null);
+    cb(error);
+    cb(null, anyObj);
+}

--- a/aws-lambda/aws-lambda.d.ts
+++ b/aws-lambda/aws-lambda.d.ts
@@ -36,8 +36,20 @@ declare module "aws-lambda" {
         succeed(message: string, object: any): void;
         awsRequestId: string;
         getRemainingTimeInMillis(): number;
+        /** Information about the Amazon Cognito identity provider when invoked through the AWS Mobile SDK. It can be null. */
+        identity?: Identity;
     }
 
+    interface Identity {
+        cognitoIdentityId: string;
+        cognitoIdentityPoolId: string;
+    }
 
-    export type Callback = (error?: Error, message?: string) => void;
+    /**
+     * Optional callback parameter.
+     *
+     *  @param error – an optional parameter that you can use to provide results of the failed Lambda function execution.
+     *  @param result – an optional parameter that you can use to provide the result of a successful function execution. The result provided must be JSON.stringify compatible.
+     */
+    export type Callback = (error?: Error, result?: any) => void;
 }


### PR DESCRIPTION
- documentation or source code reference which provides context for the suggested changes:
  - http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html#nodejs-prog-model-handler-callback
  - http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-context.html

Adjusted the `Context` object with the `identity` and fixed `Callback` parameters as result accepts any object, not only a string.
Added tests for new objects and for `Callback`.
