### PR TITLE
fix type of iconlib

### DIFF
--- a/json-editor/json-editor.d.ts
+++ b/json-editor/json-editor.d.ts
@@ -39,7 +39,7 @@ type JSONEditorOptions<TValue> = {
     /**
      * The icon library to use for the editor.
      */
-    iconlib?: string;
+    iconlib?: "bootstrap2" | "bootstrap3" | "foundation2" | "foundation3" | "jqueryui" | "fontawesome3" | "fontawesome4";
     /**
      * If true, objects can only contain properties defined with the properties keyword.
      */
@@ -75,7 +75,7 @@ type JSONEditorOptions<TValue> = {
     /**
      * The CSS theme to use.
      */
-    theme?: string;
+    theme?: "barebones" | "html" | "bootstrap2" | "bootstrap3" | "foundation3" | "foundation4" | "foundation5" | "foundation6" | "jqueryui";
     /**
      * If true, only required properties will be included by default.
      */

--- a/json-editor/json-editor.d.ts
+++ b/json-editor/json-editor.d.ts
@@ -39,7 +39,7 @@ type JSONEditorOptions<TValue> = {
     /**
      * The icon library to use for the editor.
      */
-    iconlib?: boolean;
+    iconlib?: string;
     /**
      * If true, objects can only contain properties defined with the properties keyword.
      */


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url https://github.com/jdorn/json-editor#icon-libraries .
  - it has been reviewed by a DefinitelyTyped member.

here is the code example from the document:

``` ts
// Set the global default
JSONEditor.defaults.options.iconlib = "bootstrap2";

// Set the icon lib during initialization
var editor = new JSONEditor(element,{
  schema: schema,
  iconlib: "fontawesome4"
});
```
