### PR TITLE
6586 FIX lodash chain split

### DIFF
--- a/lodash/lodash-3.10-tests.ts
+++ b/lodash/lodash-3.10-tests.ts
@@ -9658,6 +9658,25 @@ namespace TestSnakeCase {
     }
 }
 
+// _.split
+namespace TestSplit {
+    {
+        let result: _.LoDashImplicitArrayWrapper<string>;
+
+        result = _('a-b-c').split();
+        result = _('a-b-c').split('-');
+        result = _('a-b-c').split('-', 2);
+    }
+
+    {
+        let result: _.LoDashImplicitArrayWrapper<string>;
+
+        result = _('a-b-c').chain().split();
+        result = _('a-b-c').chain().split('-');
+        result = _('a-b-c').chain().split('-', 2);
+    }
+}
+
 // _.startCase
 namespace TestStartCase {
     {

--- a/lodash/lodash-3.10.d.ts
+++ b/lodash/lodash-3.10.d.ts
@@ -14720,6 +14720,27 @@ declare module _ {
         snakeCase(): LoDashExplicitWrapper<string>;
     }
 
+    //_.split
+    interface LoDashImplicitWrapper<T> {
+        /**
+         * Splits string by separator.
+         *
+         * Note: This method is based on String#split.
+         * 
+         * @param separator The separator pattern to split by.
+         * @param limit The length to truncate results to.
+         * @return Returns the new array with the terms splitted.
+         */
+        split(separator?: RegExp|string, limit?: number): LoDashImplicitArrayWrapper<string>;
+    }
+
+    interface LoDashExplicitWrapper<T> {
+        /**
+         * @see _.split
+         */
+        split(separator?: RegExp|string, limit?: number): LoDashImplicitArrayWrapper<string>;
+    }
+
     //_.startCase
     interface LoDashStatic {
         /**


### PR DESCRIPTION
Added support for _.chain(string).split() in v3.10.{0,1} as requested in #6586
