### PR TITLE
support for req.session.cookie.expires and cookieOptions.expires to be false (cookie only valid until Browser closes)

### DIFF
--- a/express-serve-static-core/express-serve-static-core.d.ts
+++ b/express-serve-static-core/express-serve-static-core.d.ts
@@ -117,7 +117,7 @@ declare module "express-serve-static-core" {
     interface CookieOptions {
         maxAge?: number;
         signed?: boolean;
-        expires?: Date;
+        expires?: Date | boolean;
         httpOnly?: boolean;
         path?: string;
         domain?: string;

--- a/express-session/express-session.d.ts
+++ b/express-session/express-session.d.ts
@@ -30,7 +30,7 @@ declare namespace Express {
     secure?: boolean;
     httpOnly: boolean;
     domain?: string;
-    expires: Date;
+    expires: Date | boolean;
     serialize: (name: string, value: string) => string;
   }
 }


### PR DESCRIPTION
see: https://github.com/expressjs/session#reqsessioncookie
added support for expires to be false (valid until Browser closes).
