### PR TITLE
source5 type should be generic R

### DIFF
--- a/simple-assign/simple-assign-tests.ts
+++ b/simple-assign/simple-assign-tests.ts
@@ -1,15 +1,78 @@
-
 /// <reference path="simple-assign.d.ts" />
-import assign = require("simple-assign");
+import simpleAssign = require("simple-assign");
 
-function assign1() {
-  return assign({hello: "world"});
+interface Target {
+  hellow: string;
 }
 
-function assign2() {
-  return assign({hello: "world"}, {hello: "worlds", second: "extra"});
+interface Source1 {
+  source1: string;
 }
 
-function assign3() {
-  return assign({hello: "world"}, {hello: "worlds", second: "extra"}, {hello: "stop", the: "spinning"});
+interface Result extends Target, Source1 {
+  
+}
+
+interface Source2 {
+  source2: string;
+}
+
+interface Result2 extends Result, Source2 {
+  
+}
+
+interface Source3 {
+  source3: string;
+}
+
+interface Result3 extends Result2, Source3 {
+  
+}
+
+interface Source4 {
+  source4: string;
+}
+
+interface Result4 extends Result3, Source4 {
+  
+}
+
+interface Source5 {
+  source5: string;
+}
+
+interface Result5 extends Result4, Source5 {
+  
+}
+
+function assign1(): Result {
+  return simpleAssign({hellow: "world"}, {source1: "U"});
+}
+
+function assign2(): Result2 {
+  return simpleAssign({hellow: "world"}, {source1: "U"}, {source2: "V"});
+}
+
+function assign3(): Result3 {
+  return simpleAssign({hellow: "world"}, {source1: "U"}, {source2: "V"}, {source3: "W"});
+}
+
+function assign4(): Result4 {
+  return simpleAssign({hellow: "world"}, {source1: "U"}, {source2: "V"}, {source3: "W"}, {source4: "Q"});
+}
+
+function assign5(): Result5 {
+  return simpleAssign({hellow: "world"}, {source1: "U"}, {source2: "V"}, {source3: "W"}, {source4: "Q"}, {source5: "R"});
+}
+
+function assign() {
+  return simpleAssign({hellow: "world"}, {source1: "U"}, {source2: "V"}, {source3: "W"}, {source4: "Q"}, {source5: "R"}, {
+    hellow: "hellow",
+    source1: "source1",
+    source2: "source2",
+    source3: "source3",
+    source4: "source4",
+    source5: "source5",
+    generic: "any"
+  });
 }

--- a/simple-assign/simple-assign.d.ts
+++ b/simple-assign/simple-assign.d.ts
@@ -8,7 +8,7 @@ declare module "simple-assign" {
   function simpleAssign<T, U, V>(target: T, source1: U, source2: V): T & U & V;
   function simpleAssign<T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
   function simpleAssign<T, U, V, W, Q>(target: T, source1: U, source2: V, source3: W, source4: Q): T & U & V & W & Q;
-  function simpleAssign<T, U, V, W, Q, R>(target: T, source1: U, source2: V, source3: W, source4: Q, source5: T): T & U & V & W & Q & R;
+  function simpleAssign<T, U, V, W, Q, R>(target: T, source1: U, source2: V, source3: W, source4: Q, source5: R): T & U & V & W & Q & R;
   function simpleAssign(target: any, ...sources: any[]): any;
   export = simpleAssign;
 }


### PR DESCRIPTION
case 2. Improvement to existing type definition.

source5 type should be generic `R` instead of `T` as @chbrown pointed out in #10703. Also updating tests to match new generic definition.
