### PR TITLE
Fixing broken tests due to object-assign type definition change

### DIFF
--- a/react-redux/react-redux-2.1.2-tests.tsx
+++ b/react-redux/react-redux-2.1.2-tests.tsx
@@ -233,8 +233,8 @@ connect(mapStateToProps3)(TodoApp);
 //    return { todos: state.todos };
 //}
 
-function mergeProps(stateProps: TodoState, dispatchProps: DispatchProps, ownProps: TodoProps): DispatchProps & TodoState {
-    return objectAssign({}, ownProps, {
+function mergeProps(stateProps: TodoState, dispatchProps: DispatchProps, ownProps: TodoProps): DispatchProps & TodoState & TodoProps {
+    return objectAssign({}, ownProps, dispatchProps, {
         todos: stateProps.todos[ownProps.userId],
         addTodo: (text: string) => dispatchProps.addTodo(ownProps.userId, text)
     });

--- a/react-redux/react-redux-tests.tsx
+++ b/react-redux/react-redux-tests.tsx
@@ -268,8 +268,8 @@ connect(mapStateToProps3)(TodoApp);
 //    return { todos: state.todos };
 //}
 
-function mergeProps(stateProps: TodoState, dispatchProps: DispatchProps, ownProps: TodoProps): DispatchProps & TodoState {
-    return objectAssign({}, ownProps, {
+function mergeProps(stateProps: TodoState, dispatchProps: DispatchProps, ownProps: TodoProps): DispatchProps & TodoState & TodoProps {
+    return objectAssign({}, ownProps, dispatchProps, {
         todos: stateProps.todos[ownProps.userId],
         addTodo: (text: string) => dispatchProps.addTodo(ownProps.userId, text)
     });


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Not familiar with redux but merging and `dispatchProps` in `mergeProps` seems valid since `action` is required property of `DispatchProps`  and  there is no other source from which to come from.
