### PR TITLE
d3-selection enhancements and D3 module version numbers.

### DIFF
--- a/d3-array/index.d.ts
+++ b/d3-array/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-array module 1.0.0
+// Type definitions for D3JS d3-array module v1.0.1
 // Project: https://github.com/d3/d3-array
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-axis/index.d.ts
+++ b/d3-axis/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-axis module 1.0.0
+// Type definitions for D3JS d3-axis module v1.0.3
 // Project: https://github.com/d3/d3-axis/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-brush/index.d.ts
+++ b/d3-brush/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-brush module 1.0.1
+// Type definitions for D3JS d3-brush module v1.0.2
 // Project: https://github.com/d3/d3-brush/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-chord/index.d.ts
+++ b/d3-chord/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-chord module 1.0.0
+// Type definitions for D3JS d3-chord module v1.0.2
 // Project: https://github.com/d3/d3-chord/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-collection/index.d.ts
+++ b/d3-collection/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-collection module 1.0.0
+// Type definitions for D3JS d3-collection module v1.0.1
 // Project: https://github.com/d3/d3-collection/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-color/index.d.ts
+++ b/d3-color/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-color module 1.0.0
+// Type definitions for D3JS d3-color module v1.0.1
 // Project: https://github.com/d3/d3-color/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-dispatch/index.d.ts
+++ b/d3-dispatch/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-dispatch module 1.0.0
+// Type definitions for D3JS d3-dispatch module v1.0.1
 // Project: https://github.com/d3/d3-dispatch/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-drag/index.d.ts
+++ b/d3-drag/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-drag module 1.0.0
+// Type definitions for D3JS d3-drag module v1.0.1
 // Project: https://github.com/d3/d3-drag/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-ease/index.d.ts
+++ b/d3-ease/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-ease module 1.0.0
+// Type definitions for D3JS d3-ease module v1.0.1
 // Project: https://github.com/d3/d3-ease/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-force/index.d.ts
+++ b/d3-force/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-force module 1.0.0
+// Type definitions for D3JS d3-force module v1.0.2
 // Project: https://github.com/d3/d3-force/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-format/index.d.ts
+++ b/d3-format/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-format module 1.0.0
+// Type definitions for D3JS d3-format module v1.0.2
 // Project: https://github.com/d3/d3-format/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-geo/index.d.ts
+++ b/d3-geo/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-geo module 1.2.0
+// Type definitions for D3JS d3-geo module v1.2.4
 // Project: https://github.com/d3/d3-geo/
 // Definitions by: Hugues Stefanski <https://github.com/Ledragon>, Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-hierarchy/index.d.ts
+++ b/d3-hierarchy/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-hierarchy module 1.0.0
+// Type definitions for D3JS d3-hierarchy module v1.0.2
 // Project: https://github.com/d3/d3-hierarchy/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-hsv/index.d.ts
+++ b/d3-hsv/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-hsv module 0.0.3
+// Type definitions for D3JS d3-hsv module v0.0.3
 // Project: https://github.com/d3/d3-hsv/
 // Definitions by: Yuri Feldman <https://github.com/arrayjam>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-interpolate/index.d.ts
+++ b/d3-interpolate/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-interpolate module 1.1.0
+// Type definitions for D3JS d3-interpolate module v1.1.1
 // Project: https://github.com/d3/d3-interpolate/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-path/index.d.ts
+++ b/d3-path/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-path module 1.0.0
+// Type definitions for D3JS d3-path module v1.0.1
 // Project: https://github.com/d3/d3-path/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-polygon/index.d.ts
+++ b/d3-polygon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-polygon module 1.0.0
+// Type definitions for D3JS d3-polygon module v1.0.1
 // Project: https://github.com/d3/d3-polygon/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-quadtree/index.d.ts
+++ b/d3-quadtree/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-quadtree module 1.0.0
+// Type definitions for D3JS d3-quadtree module v1.0.1
 // Project: https://github.com/d3/d3-quadtree/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-queue/index.d.ts
+++ b/d3-queue/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-queue module 3.0.1
+// Type definitions for D3JS d3-queue module v3.0.2
 // Project: https://github.com/d3/d3-queue/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-random/index.d.ts
+++ b/d3-random/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-random module 1.0.0
+// Type definitions for D3JS d3-random module v1.0.1
 // Project: https://github.com/d3/d3-random/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-scale/index.d.ts
+++ b/d3-scale/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-scale module 1.0.1
+// Type definitions for D3JS d3-scale module v1.0.3
 // Project: https://github.com/d3/d3-scale/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-selection-multi/index.d.ts
+++ b/d3-selection-multi/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-selection-multi module 1.0.0
+// Type definitions for D3JS d3-selection-multi module v1.0.0
 // Project: https://github.com/d3/d3-selection-multi/
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-selection/d3-selection-tests.ts
+++ b/d3-selection/d3-selection-tests.ts
@@ -894,14 +894,20 @@ positions = d3Selection.touches(h, changedTouches);
 // ---------------------------------------------------------------------------------------
 
 let xElement: Element;
-let foo: d3Selection.Local = d3Selection.local();
+let foo: d3Selection.Local<number[]> = d3Selection.local<number[]>();
 let propName: string = foo.toString();
 
-console.log('Local Property Name: %s', propName);
+// direct set & get on Local<T> object
+xElement = foo.set(xElement, [1, 2, 3]);
+let array: number[] = foo.get(xElement);
 
-xElement = foo.set(xElement, 'test');
+// test read & write of .property() access to locals
+array = d3Selection.select(xElement)
+  .property(foo, [3, 2, 1])
+  .property(foo, () => [999])
+  .property(foo);
 
-// TODO: complete remaing tests for Local
+foo.remove(xElement);
 
 // ---------------------------------------------------------------------------------------
 // Tests of Namespace

--- a/d3-selection/index.d.ts
+++ b/d3-selection/index.d.ts
@@ -288,7 +288,9 @@ export interface Local<T> {
      */
     get(node: Element): T | undefined;
     /**
+     * Deletes the value associated with the given node. Values stored on ancestors are not affected, meaning that child nodes will still see inherited values.
      *
+     * This function returns true if there was a value stored directly on the node, and false otherwise.
      */
     remove(node: Element): boolean;
     /**

--- a/d3-selection/index.d.ts
+++ b/d3-selection/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-selection module 1.0.0
+// Type definitions for D3JS d3-selection module v1.0.2
 // Project: https://github.com/d3/d3-selection/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -129,9 +129,29 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
     style(name: string, value: ValueFn<GElement, Datum, string | number | boolean>, priority?: null | 'important'): this;
 
     property(name: string): any;
+    /**
+     * Look up a local variable on the first node of this selection. Note that this is not equivalent to `local.get(selection.node())` in that it will not look up locals set on the parent node(s).
+     *
+     * @param name The `d3.local` variable to look up.
+     */
+    property<T>(name: Local<T>): T | undefined;
     property(name: string, value: ValueFn<GElement, Datum, any>): this;
     property(name: string, value: null): this;
     property(name: string, value: any): this;
+    /**
+     * Store a value in a `d3.local` variable. This is equivalent to `selection.each(function (d, i, g) { name.set(this, value.call(this, d, i, g)); })` but more concise.
+     *
+     * @param name A `d3.local` variable
+     * @param value A callback that returns the value to store
+     */
+    property<T>(name: Local<T>, value: ValueFn<GElement, Datum, T>): this;
+    /**
+     * Store a value in a `d3.local` variable for each node in the selection. This is equivalent to `selection.each(function () { name.set(this, value); })` but more concise.
+     *
+     * @param name A `d3.local` variable
+     * @param value A callback that returns the value to store
+     */
+    property<T>(name: Local<T>, value: T): this;
 
     text(): string;
     text(value: string | number | boolean): this;
@@ -262,10 +282,19 @@ export function touches(container: ContainerElement, touches?: TouchList): Array
 // ---------------------------------------------------------------------------
 
 
-export interface Local {
-    get(node: Element): any;
+export interface Local<T> {
+    /**
+     * Retrieves a local variable stored on the node (or one of its parents).
+     */
+    get(node: Element): T | undefined;
+    /**
+     *
+     */
     remove(node: Element): boolean;
-    set(node: Element, value: any): Element;
+    /**
+     * Store a value for this local variable. Calling `.get()` on children of this node will also retrieve the variable's value.
+     */
+    set(node: Element, value: T): Element;
     /**
      * Obtain a string with the internally assigned property name for the local
      * which is used to store the value on a node
@@ -276,7 +305,7 @@ export interface Local {
 /**
  * Obtain a new local variable
  */
-export function local(): Local;
+export function local<T>(): Local<T>;
 
 // ---------------------------------------------------------------------------
 // namespace.js related

--- a/d3-shape/index.d.ts
+++ b/d3-shape/index.d.ts
@@ -326,10 +326,12 @@ export var symbolWye: SymbolType;
 // -----------------------------------------------------------------------------------
 
 
-// HACK: SeriesPoint is a [number, number] two-element Array with added
+// SeriesPoint is a [number, number] two-element Array with added
 // data and index properties related to the data element which formed the basis for the
 // SeriesPoint
 export interface SeriesPoint<Datum> extends Array<number> {
+    0: number;
+    1: number;
     index: number;
     data: Datum;
 }

--- a/d3-shape/index.d.ts
+++ b/d3-shape/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-shape module 1.0.0
+// Type definitions for D3JS d3-shape module v1.0.3
 // Project: https://github.com/d3/d3-shape/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-time-format/index.d.ts
+++ b/d3-time-format/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for d3JS d3-time-format module 2.0.0
+// Type definitions for d3JS d3-time-format module v2.0.2
 // Project: https://github.com/d3/d3-time-format/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-time/index.d.ts
+++ b/d3-time/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-time module 1.0.0
+// Type definitions for D3JS d3-time module v1.0.2
 // Project: https://github.com/d3/d3-time/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-timer/index.d.ts
+++ b/d3-timer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for d3JS d3-timer module 1.0.1
+// Type definitions for d3JS d3-timer module v1.0.2
 // Project: https://github.com/d3/d3-timer/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-transition/d3-transition-tests.ts
+++ b/d3-transition/d3-transition-tests.ts
@@ -103,12 +103,13 @@ exitTransition = exitCircles.transition('exit');
 let newEnterTransition: d3Transition.Transition<SVGCircleElement, CircleDatum, SVGSVGElement, SVGDatum>;
 newEnterTransition = enterCircles.transition(enterTransition);
 
-let wrongElementTypeTransition: d3Transition.Transition<HTMLDivElement, CircleDatum, HTMLBodyElement, any>;
-let wrongDatumTypeTransition: d3Transition.Transition<SVGCircleElement, { wrong: string }, SVGSVGElement, any>;
+let differentElementTypeTransition: d3Transition.Transition<SVGSVGElement, CircleDatum, HTMLBodyElement, any>;
+let differentDatumTypeTransition: d3Transition.Transition<SVGCircleElement, { differrent: string }, SVGSVGElement, any>;
 
-newEnterTransition = enterCircles.transition(enterTransition);
-// newEnterTransition = enterCircles.transition(wrongElementTypeTransition);// fails, wrong group element type
-// newEnterTransition = enterCircles.transition(wrongDatumTypeTransition);// fails, wrong datum type
+// Comparable use cases arise e.g. when using an existing transition to generate a new transition
+// on a different selection to synchronize them (see e.g. Mike Bostock's Brush & Zoom II Example https://bl.ocks.org/mbostock/f48fcdb929a620ed97877e4678ab15e6)
+newEnterTransition = enterCircles.transition(differentElementTypeTransition);
+newEnterTransition = enterCircles.transition(differentDatumTypeTransition);
 
 // --------------------------------------------------------------------------
 // Test Transition Configuration (Timing)

--- a/d3-transition/index.d.ts
+++ b/d3-transition/index.d.ts
@@ -12,7 +12,7 @@ declare module 'd3-selection' {
     export interface Selection<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {
         interrupt(name?: string): Transition<GElement, Datum, PElement, PDatum>;
         transition(name?: string): Transition<GElement, Datum, PElement, PDatum>;
-        transition(transition: Transition<GElement, Datum, PElement, PDatum>): Transition<GElement, Datum, PElement, PDatum>;
+        transition(transition: Transition<BaseType, any, any, any>): Transition<GElement, Datum, PElement, PDatum>;
     }
 }
 

--- a/d3-transition/index.d.ts
+++ b/d3-transition/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-transition module 1.0.0
+// Type definitions for D3JS d3-transition module v1.0.1
 // Project: https://github.com/d3/d3-transition/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-voronoi/d3-voronoi-tests.ts
+++ b/d3-voronoi/d3-voronoi-tests.ts
@@ -65,6 +65,9 @@ let point: d3Voronoi.VoronoiPoint;
 point[0] = 10; // x-coordinate
 point[1] = 10; // y-coordinate
 
+point = [10, 10];
+// point = [10]; // fails, second element for y-coordinate missing
+// point = ['a', 'b']; // fails, wrong element type
 
 // VoronoiPointPair ---------------------------------------------------
 
@@ -74,6 +77,13 @@ pointPair[0][0] = 10; // x-coordinate of first point
 pointPair[0][1] = 10; // y-coordinate of first point
 pointPair[1][0] = 20; // x-coordinate of second point
 pointPair[1][1] = 10; // y-coordinate of second point
+
+pointPair = [[10, 10], [50, 50]];
+
+// pointPair = [[10, 10]]; // fails, second point coordinates missing
+// pointPair = [[10, 10], [50]]; // fails, one element is not of type [number, number]
+// pointPair = [[10], [50, 50]]; // fails, one element is not of type [number, number]
+// pointPair = [['a', 10], [50, 50]]; // fails, one element is not of type [number, number]
 
 // VoronoiPolygon -------------------------------------------------------
 

--- a/d3-voronoi/index.d.ts
+++ b/d3-voronoi/index.d.ts
@@ -9,18 +9,24 @@
 
 
 /**
- * The Point type is defined as a cue that the array is strictly of type [number, number] with two elements
+ * The VoronoiPoint interface is defined as a cue that the array is strictly of type [number, number] with two elements
  * for x and y coordinates. However, it is used as a base for interface definitions, and [number, number]
  * cannot be extended.
  */
-export type VoronoiPoint = Array<number>;
+export interface VoronoiPoint extends Array<number> {
+    0: number;
+    1: number;
+}
 
 /**
- * The PointPair type is defined as a cue that the array is strictly of type [[number, number], [number, number]] with two elements, one
+ * The VoronoiPointPair interface is defined as a cue that the array is strictly of type [[number, number], [number, number]] with two elements, one
  * for each point containing the respective x and y coordinates. However, it is used as a base for interface definitions, and
- * [[number, number], [number, number]]cannot be extended.
+ * [[number, number], [number, number]] cannot be extended.
  */
-export type VoronoiPointPair = Array<[number, number]> // [Point, Point];
+export interface VoronoiPointPair extends Array<[number, number]> {
+    0: [number, number];
+    1: [number, number];
+}
 
 export interface VoronoiPolygon<T> extends Array<[number, number]> {
     data: T;

--- a/d3-voronoi/index.d.ts
+++ b/d3-voronoi/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-voronoi module 1.0.1
+// Type definitions for D3JS d3-voronoi module v1.0.2
 // Project: https://github.com/d3/d3-voronoi/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-zoom/index.d.ts
+++ b/d3-zoom/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for d3JS d3-zoom module 1.0.2
+// Type definitions for d3JS d3-zoom module v1.0.3
 // Project: https://github.com/d3/d3-zoom/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3/index.d.ts
+++ b/d3/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for d3JS
+// Type definitions for d3JS v3.5.17
 // Project: http://d3js.org/
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -418,7 +418,7 @@ declare namespace d3 {
 
             select(name: (datum: Datum, index: number, outerIndex: number) => EventTarget): Selection<Datum>;
             call(func: (selection: Enter<Datum>, ...args: any[]) => any, ...args: any[]): Enter<Datum>;
-            
+
             empty(): boolean;
             size(): number;
         }


### PR DESCRIPTION
This PR contains the following enhancements and chores:
- **d3-selection**: `Local` is now templated to accept a datum type parameter. Overload signatures for `Selection.property(...)` added to accept `Local` as first argument. (Thanks to @gustavderdrache for this enhancement)
- **d3-voronoi**: Changed `VoronoiPoint` and `VoronoiPointPair` from type alias to interface with mandatory first and second elements
- **d3-shape**: Added mandatory first and second element to SeriesPoint interface.
- **d3-transition**: Relaxed type constraint on existing transitions which can be passed into `Selection.transition(transition)` to create a new transition from a selection.
- Updated header comments for various D3 modules to reflect latest version.

@gustavderdrache changes as discussed.

EDIT: Included enhancements to d3-voronoi and d3-shape as per above.
EDIT: Included change to d3-transition
