### PR TITLE
New definition for universal-router

### DIFF
--- a/universal-router/universal-router-tests.ts
+++ b/universal-router/universal-router-tests.ts
@@ -1,0 +1,99 @@
+/// <reference path="universal-router.d.ts" />
+
+import {ActionContext, Params, resolve } from "universal-router";
+
+// Test 1
+const routes1 = [
+  {
+    path: "/one",
+    action: () => "Page One"
+  },
+  {
+    path: "/two",
+    action: () => "Page Two"
+  }
+];
+
+resolve(routes1, { path: "/one" })
+  .then(result => console.log(result));
+
+// Test 2
+const routes2 = [
+  {
+    path: "/hello/:username",
+    action: (context: ActionContext) => `Welcome, ${context.params["username"]}!`
+  }
+];
+
+resolve(routes2, { path: "/hello/john" })
+  .then(result => console.log(result));
+
+
+// Test 3
+const routes3 = [
+  {
+    path: "/hello/:username",
+    action: (ctx: ActionContext, { username }: Params) => `Welcome, ${username}!`
+  }
+];
+
+resolve(routes3, { path: "/hello/john" })
+  .then(result => console.log(result));
+
+
+// Test 4
+const routes4 = [
+  {
+    path: "/hello",
+    action: () => new Promise(resolve => {
+      setTimeout(() => resolve("Welcome!"), 1000);
+    })
+  }
+];
+
+resolve(routes4, { path: "/hello" })
+  .then(result => console.log(result));
+
+// Test 5
+const routes5 = [
+  {
+    path: "/hello/:username",
+    async action(ctx: ActionContext, { username }: Params) {
+      const waitable = async (name: string) => {
+        console.log(`Welcome ${name}`);
+      }
+      await waitable(username);
+    }
+  }
+];
+
+resolve(routes5, { path: "/hello/john" })
+  .then(result => console.log(result));
+
+// Test 6
+const routes6 = [
+  { path: "/one", action: () => "<h1>Page One</h1>" },
+  { path: "/two", action: () => "<h1>Page Two</h1>" }
+];
+
+resolve(routes6, { path: "/one" }).then(result => {
+  document.body.innerHTML = result || "<h1>Not Found</h1>";
+});
+
+// Test 7
+interface Render {
+  render: typeof render;
+}
+
+const routes7 = [
+  { path: "/one", action: ({ render: func }: ActionContext & Render) => func("<h1>Page One</h1>") },
+  { path: "/two", action: ({ render: func }: ActionContext & Render) => func("<h1>Page Two</h1>") }
+];
+
+function render(component: string) {
+  return new Promise(resolve => {
+    console.log(`Rendering... ${component}`);
+  });
+}
+
+resolve<Render, Promise<{}>>(routes7, { path: "/one", render });

--- a/universal-router/universal-router.d.ts
+++ b/universal-router/universal-router.d.ts
@@ -39,9 +39,9 @@ declare module "universal-router" {
    *  returns a Promise, R can be the type the Promise resolves to.
    */
   export interface Route<C, R> {
-    path: string,
-    action: (ctx: ActionContext & C, params: Params) => R | Promise<R> | undefined,
-    children?: Routes<C, R>
+    path: string;
+    action: (ctx: ActionContext & C, params: Params) => R | Promise<R> | void;
+    children?: Routes<C, R>;
   }
 
   /**

--- a/universal-router/universal-router.d.ts
+++ b/universal-router/universal-router.d.ts
@@ -1,0 +1,70 @@
+// Type definitions for universal-router
+// Project: https://github.com/kriasoft/universal-router
+// Definitions by: Jack Moore <https://github.com/jtmthf> 
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "universal-router" {
+  /**
+   * Params is a key/value object that represents extracted URL paramters. Each
+   * URL parameter resolves to a string.
+   */
+  export interface Params {
+    [key: string]: string;
+  }
+
+  /**
+   * Context represents the context that is passed as the second argument
+   * passed to resolve. By default, it only is require to contain a path, but
+   * can be extended by the way of generics.
+   */
+  export interface Context {
+    path: string;
+  }
+
+  /**
+   * ActionContext is similar to Context, with the exception of an added params
+   * object. ActionContext is passed as the first argument to the action
+   * function.
+   */
+  export interface ActionContext extends Context {
+    params: Params;
+  }
+
+  /**
+   * A Route is a singular route in your application. It contains a path, an
+   * action function, and optional children which are an array of Route.
+   * 
+   * @template C User context that is made union with ActionContext.
+   * @template R Result that every action function resolves to. If the action
+   *  returns a Promise, R can be the type the Promise resolves to.
+   */
+  export interface Route<C, R> {
+    path: string,
+    action: (ctx: ActionContext & C, params: Params) => R | Promise<R> | undefined,
+    children?: Routes<C, R>
+  }
+
+  /**
+   * Routes in an array of type Route.
+   * @template C User context that is made union with ActionContext.
+   * @template R Result that every action function resolves to. If the action
+   *  returns a Promise, R can be the type the Promise resolves to.
+   */
+  export type Routes<C, R> = Route<C, R>[];
+
+  /**
+   * Resolve function that is given routes and a path or context object.
+   * Returns a Promise that resolves to result of the action function of the
+   * matched route.
+   * 
+   * @template C User context that is made union with Context.
+   * @template R Result that every action function resolves to. If the action
+   *  returns a Promise, R can be the type the Promise resolves to.
+   * 
+   * @param {Routes<C, R> | Route<C, R>} routes - Single route or array of routes.
+   * @param {string | String | Context & C}  pathOrContext - path to resolve or
+   *  context object that contains the path along with other data.
+   * @return {Promise<R>} - Result of matched action function wrapped in a Promsie.
+   */
+  export function resolve<C, R>(routes: Routes<C, R> | Route<C, R>, pathOrContext: string | String | Context & C): Promise<R>
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

@koistya Can you please check the test file for correct API usage?
