### PR TITLE
add typings for pouchdb-upsert. resolves #10596

### DIFF
--- a/pouchdb-core/pouchdb-core-tests.ts
+++ b/pouchdb-core/pouchdb-core-tests.ts
@@ -86,31 +86,4 @@ namespace PouchDBCoreTests {
       // Options with a callback
       db.compact({interval: 300},  (res: PouchDB.Core.Response) => {});
     }
-
-    function testRemove() {
-      type MyModel = { rev: 'rev', property: 'someProperty '};
-      let model: PouchDB.Core.Document<MyModel>;
-      const id = 'model';
-      const rev = 'rev';
-
-      const db = new PouchDB<MyModel>();
-
-      // Promise version with doc
-      db.remove(model).then( (res: PouchDB.Core.Response) => {});
-
-      // Promise version with doc and options
-      db.remove(model, {}).then( (res: PouchDB.Core.Response) => {});
-
-      // Promise version with docId and rev
-      db.remove(id, rev).then( (res: PouchDB.Core.Response) => {});
-
-      // Promise version with docId and rev and options
-      db.remove(id, rev, {}).then( (res: PouchDB.Core.Response) => {});
-
-      // Callback version with doc
-      db.remove(model, {}, (res: PouchDB.Core.Response) => {});
-
-      // Callback version with docId and rev
-      db.remove(id, rev, {}, (res: PouchDB.Core.Response) => {});
-    }
 }

--- a/pouchdb-core/pouchdb-core-tests.ts
+++ b/pouchdb-core/pouchdb-core-tests.ts
@@ -86,4 +86,31 @@ namespace PouchDBCoreTests {
       // Options with a callback
       db.compact({interval: 300},  (res: PouchDB.Core.Response) => {});
     }
+
+    function testRemove() {
+      type MyModel = { rev: 'rev', property: 'someProperty '};
+      let model: PouchDB.Core.Document<MyModel>;
+      const id = 'model';
+      const rev = 'rev';
+
+      const db = new PouchDB<MyModel>();
+
+      // Promise version with doc
+      db.remove(model).then( (res: PouchDB.Core.Response) => {});
+
+      // Promise version with doc and options
+      db.remove(model, {}).then( (res: PouchDB.Core.Response) => {});
+
+      // Promise version with docId and rev
+      db.remove(id, rev).then( (res: PouchDB.Core.Response) => {});
+
+      // Promise version with docId and rev and options
+      db.remove(id, rev, {}).then( (res: PouchDB.Core.Response) => {});
+
+      // Callback version with doc
+      db.remove(model, {}, (res: PouchDB.Core.Response) => {});
+
+      // Callback version with docId and rev
+      db.remove(id, rev, {}, (res: PouchDB.Core.Response) => {});
+    }
 }

--- a/pouchdb-core/pouchdb-core-tests.ts
+++ b/pouchdb-core/pouchdb-core-tests.ts
@@ -75,4 +75,15 @@ namespace PouchDBCoreTests {
         db.info({ ajax: { cache: true }}, (error, result) => {
         });
     }
+  
+    function testCompact() {
+      const db = new PouchDB<{}>();
+
+      // Promise version
+      db.compact().then( (res: PouchDB.Core.Response) => {});
+      // Promise version with optional options
+      db.compact({interval: 300}).then( (res: PouchDB.Core.Response) => {});
+      // Options with a callback
+      db.compact({interval: 300},  (res: PouchDB.Core.Response) => {});
+    }
 }

--- a/pouchdb-core/pouchdb-core.d.ts
+++ b/pouchdb-core/pouchdb-core.d.ts
@@ -328,20 +328,6 @@ declare namespace PouchDB {
             revision?: Core.RevisionId,
             options?: Core.PutOptions): Promise<Core.Response>;
 
-        /** Remove a doc from the database */
-        remove(doc: Core.Document<Content>,
-               options: Core.Options,
-               callback: Core.Callback<Core.Error, Core.Response>): void;
-        remove(docId: Core.DocumentId,
-               revision: Core.RevisionId,
-               options: Core.Options,
-               callback: Core.Callback<Core.Error, Core.Response>): void;
-        remove(doc: Core.Document<Content>,
-               options?: Core.Options): Promise<Core.Response>;
-        remove(docId: Core.DocumentId,
-               revision: Core.RevisionId,
-               options?: Core.Options): Promise<Core.Response>;
-
         /** Get database information */
         info(options: Core.InfoOptions | void,
             callback: Core.Callback<any, Core.DatabaseInfo>): void;

--- a/pouchdb-core/pouchdb-core.d.ts
+++ b/pouchdb-core/pouchdb-core.d.ts
@@ -250,6 +250,10 @@ declare namespace PouchDB {
             options?: Configuration.DatabaseConfiguration): Database<Content>;
     }
 
+    interface CompactOptions extends Core.Options {
+      interval?: number;
+    }
+
     interface Database<Content extends Core.Encodable>  {
         /** Fetch all documents matching the given key. */
         allDocs(options: Core.AllDocsWithKeyOptions):
@@ -263,6 +267,11 @@ declare namespace PouchDB {
         /** Fetch all documents. */
         allDocs(options?: Core.AllDocsOptions):
             Promise<Core.AllDocsResponse<Content>>;
+
+        /** Compact the database */
+        compact(options?: CompactOptions): Promise<Core.Response>;
+        compact(options: CompactOptions,
+                callback: Core.Callback<Core.Error, Core.Response>): void;
 
         /** Destroy the database */
         destroy(options: Core.DestroyOptions | void,

--- a/pouchdb-core/pouchdb-core.d.ts
+++ b/pouchdb-core/pouchdb-core.d.ts
@@ -328,6 +328,20 @@ declare namespace PouchDB {
             revision?: Core.RevisionId,
             options?: Core.PutOptions): Promise<Core.Response>;
 
+        /** Remove a doc from the database */
+        remove(doc: Core.Document<Content>,
+               options: Core.Options,
+               callback: Core.Callback<Core.Error, Core.Response>): void;
+        remove(docId: Core.DocumentId,
+               revision: Core.RevisionId,
+               options: Core.Options,
+               callback: Core.Callback<Core.Error, Core.Response>): void;
+        remove(doc: Core.Document<Content>,
+               options?: Core.Options): Promise<Core.Response>;
+        remove(docId: Core.DocumentId,
+               revision: Core.RevisionId,
+               options?: Core.Options): Promise<Core.Response>;
+
         /** Get database information */
         info(options: Core.InfoOptions | void,
             callback: Core.Callback<any, Core.DatabaseInfo>): void;

--- a/pouchdb-upsert/pouchdb-upsert-tests.ts
+++ b/pouchdb-upsert/pouchdb-upsert-tests.ts
@@ -1,0 +1,49 @@
+/// <reference path="./pouchdb-upsert.d.ts" />
+
+import * as pouchdbUpsert from 'pouchdb-upsert';
+PouchDB.plugin(pouchdbUpsert);
+
+namespace PouchDBUpsertTests {
+  type UpsertDocModel = { _id: 'test-doc1', name: 'test' };
+  let docToUpsert: PouchDB.Core.Document<UpsertDocModel>;
+  const db = new PouchDB<UpsertDocModel>();
+
+  function testUpsert_WithPromise_AndReturnDoc() {
+    db.upsert(docToUpsert._id, (doc: PouchDB.Core.Document<UpsertDocModel>) => {
+      // Make some updates....
+      return doc;
+    }).then((res: PouchDB.Core.Response) => {
+    });
+  }
+
+  function testUpsert_WithPromise_AndReturnBoolean() {
+    db.upsert(docToUpsert._id, (doc: PouchDB.Core.Document<UpsertDocModel>) => {
+      // Make some updates....
+      return false;
+    }).then((res: PouchDB.Core.Response) => {
+    });
+  }
+
+  function testUpsert_WithCallback_AndReturnDoc() {
+    db.upsert(docToUpsert._id, (doc: PouchDB.Core.Document<UpsertDocModel>) => {
+      // Make some updates....
+      return doc;
+    }, (res: PouchDB.Core.Response) => {});
+  }
+
+  function testUpsert_WithCallback_AndReturnBoolean() {
+    // callback return boolean
+    db.upsert(docToUpsert._id, (doc: PouchDB.Core.Document<UpsertDocModel>) => {
+      // Make some updates....
+      return false;
+    }, (res: PouchDB.Core.Response) => {});
+  }
+
+  function testPutIfNotExists_WithPromise() {
+    db.putIfNotExists(docToUpsert).then( (res: PouchDB.Core.Response) => {});
+  }
+
+  function testPutIfNotExists_WithCallback() {
+    db.putIfNotExists(docToUpsert, (res: PouchDB.Core.Response) => {});
+  }
+}

--- a/pouchdb-upsert/pouchdb-upsert.d.ts
+++ b/pouchdb-upsert/pouchdb-upsert.d.ts
@@ -1,0 +1,66 @@
+// Type definitions for pouchdb-upsert v2.0.1
+// Project: https://github.com/pouchdb/upsert
+// Definitions by: Keith D. Moore <https://github.com/keithdmoore>, Andrew Mitchell <https://github.com/hotforfeature>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../pouchdb-core/pouchdb-core.d.ts" />
+
+declare namespace PouchDB {
+
+  interface Database<Content extends Core.Encodable> {
+    /**
+     * Perform an upsert (update or insert) operation. Returns a Promise.
+     *
+     * @param docId - the _id of the document.
+     * @param diffFun - function that takes the existing doc as input and returns an updated doc.
+     * If this diffFunc returns falsey, then the update won't be performed (as an optimization).
+     * If the document does not already exist, then {} will be the input to diffFunc.
+     *
+     */
+    upsert(docId: Core.DocumentId, diffFun: UpsertDiffCallback<Content>): Promise<Core.Response>;
+
+    /**
+     * Perform an upsert (update or insert) operation. If a callback is not provided, the Promise based version
+     * of this function will be called.
+     *
+     * @param docId - the _id of the document.
+     * @param diffFun - function that takes the existing doc as input and returns an updated doc.
+     * If this diffFunc returns falsey, then the update won't be performed (as an optimization).
+     * If the document does not already exist, then {} will be the input to diffFunc.
+     * @param callback - called with the results after operation is completed.
+     */
+    upsert(docId: Core.DocumentId, diffFun: UpsertDiffCallback<Content>,
+           callback: Core.Callback<Core.Error, Core.Response>): void;
+
+    /**
+     * Put a new document with the given docId, if it doesn't already exist. Returns a Promise.
+     *
+     * @param doc - the document to insert. Should contain an _id if docId is not specified
+     * If the document already exists, then the Promise will just resolve immediately.
+     */
+    putIfNotExists(doc: Core.Document<Content>): Promise<Core.Response>;
+
+    //
+    /**
+     * Put a new document with the given docId, if it doesn't already exist.  If a callback is not provided,
+     * the Promise based version of this function will be called.
+     *
+     * @param doc - the document to insert. Should contain an _id if docId is not specified
+     * If the document already exists, then the Promise will just resolve immediately.
+     * @param callback - called with the results after operation is completed.
+     * If you don't specify a callback, then the Promise version of this function will be invoked and it
+     * will return a Promise.
+     */
+    putIfNotExists(doc: Core.Document<Content>,
+                   callback: Core.Callback<Core.Error, Core.Response>): void;
+  }
+
+  interface UpsertDiffCallback<Content extends Core.Encodable> {
+    (doc: Core.Document<Content>): Core.Document<Content>|boolean;
+  }
+}
+
+declare module 'pouchdb-upsert' {
+  const plugin: PouchDB.Plugin;
+  export = plugin;
+}


### PR DESCRIPTION
case 1. Add a new type definition for pouchdb-upsert
- [ x ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ x ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ x ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
