### PR TITLE
Add extra static members to the Node v4 Error class

### DIFF
--- a/node/node-4-tests.ts
+++ b/node/node-4-tests.ts
@@ -826,3 +826,17 @@ namespace vm_tests {
         Debug.scripts().forEach(function(script: any) { console.log(script.name); });
     }
 }
+
+///////////////////////////////////////////////////////////////////////////////
+/// Errors Tests : https://nodejs.org/dist/latest-v4.x/docs/api/errors.html ///
+///////////////////////////////////////////////////////////////////////////////
+
+namespace errors_tests {
+    {
+        Error.stackTraceLimit = Infinity;
+    }
+    {
+        const myObject = {};
+        Error.captureStackTrace(myObject);
+    }
+}

--- a/node/node-4.d.ts
+++ b/node/node-4.d.ts
@@ -13,6 +13,10 @@ interface Error {
     stack?: string;
 }
 
+interface ErrorConstructor {
+    captureStackTrace(targetObject: Object, constructorOpt?: Function): void;
+    stackTraceLimit: number;
+}
 
 // compat for TypeScript 1.8
 // if you use with --target es3 or --target es5 and use below definitions,


### PR DESCRIPTION
case 2. Improvement to existing type definition.

@vvakame The fix in #9618 applies to node version 4.\* as well. [Related docs](https://nodejs.org/dist/latest-v4.x/docs/api/errors.html#errors_error_capturestacktrace_targetobject_constructoropt)

Defines `stackTraceLimit` and `captureStackTrace` as static members for
the Error class in Node v4 so their usage can be recognized.
