### PR TITLE
Fixes #10684

### DIFF
--- a/chance/chance.d.ts
+++ b/chance/chance.d.ts
@@ -114,8 +114,16 @@ declare namespace Chance {
         capitalize(str: string): string;
         mixin(desc: MixinDescriptor): any;
         pad(num: number, width: number, padChar?: string): string;
+        /**
+         * @deprecated Use pickone
+        */
         pick<T>(arr: T[]): T;
+        pickone<T>(arr: T[]): T;
+        /**
+         * @deprecated Use pickset 
+         */
         pick<T>(arr: T[], count: number): T[];
+        pickset<T>(arr: T[], count: number): T[];
         set: Setter;
         shuffle<T>(arr: T[]): T[];
 


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

I kept the deprecated `pick` declarations, but added the proposed (JSDoc-influenced) [deprecation annotation](https://github.com/Microsoft/TypeScript/issues/390) to them. The added `pickone` and `pickset` declarations have identical types to their respective `pick` flavors.
