### PR TITLE
add compact function typings to pouchdb-core

### DIFF
--- a/pouchdb-core/pouchdb-core-tests.ts
+++ b/pouchdb-core/pouchdb-core-tests.ts
@@ -38,6 +38,16 @@ namespace PouchDBCoreTests {
         });
     }
 
+    function testCompact() {
+      const db = new PouchDB<{}>();
+      // Promise version
+      db.compact().then( (res: PouchDB.Core.Response) => {});
+      // Promise version with optional options
+      db.compact({interval: 300}).then( (res: PouchDB.Core.Response) => {});
+      // Options with a callback
+      db.compact({interval: 300},  (res: PouchDB.Core.Response) => {});
+    }
+
     function testDestroy() {
         const db = new PouchDB<{}>();
 

--- a/pouchdb-core/pouchdb-core.d.ts
+++ b/pouchdb-core/pouchdb-core.d.ts
@@ -164,6 +164,10 @@ declare namespace PouchDB {
         interface PostOptions extends PutOptions {
         }
 
+        interface CompactOptions extends Core.Options {
+          interval?: number;
+        }
+
         interface InfoOptions extends Options {
         }
     }
@@ -263,6 +267,11 @@ declare namespace PouchDB {
         /** Fetch all documents. */
         allDocs(options?: Core.AllDocsOptions):
             Promise<Core.AllDocsResponse<Content>>;
+
+        /** Compact the database */
+        compact(options?: Core.CompactOptions): Promise<Core.Response>;
+        compact(options: Core.CompactOptions,
+                callback: Core.Callback<Core.Error, Core.Response>): void;
 
         /** Destroy the database */
         destroy(options: Core.DestroyOptions | void,


### PR DESCRIPTION
Improvement to existing pouchdb-core definition. Add compact function typings
- documentation or source code reference which provides context for the suggested changes.  url https://pouchdb.com/api.html#compaction.
  - it has been reviewed by a DefinitelyTyped member.
