### PR TITLE
added minSize and maxSide to React-Dropzone

### DIFF
--- a/react-dropzone/react-dropzone-tests.tsx
+++ b/react-dropzone/react-dropzone-tests.tsx
@@ -19,8 +19,8 @@ class Test extends React.Component<any, any> {
         style={{ borderStyle: "dashed" }}
         activeStyle={{ borderStyle: "dotted" }}
         className="regular"
-        minSize={Infinity}
-        maxSize={2000}
+        minSize={2000}
+        maxSize={Infinity}
         activeClassName="active"
         rejectClassName="reject"
         disableClick={true}

--- a/react-dropzone/react-dropzone-tests.tsx
+++ b/react-dropzone/react-dropzone-tests.tsx
@@ -19,6 +19,8 @@ class Test extends React.Component<any, any> {
         style={{ borderStyle: "dashed" }}
         activeStyle={{ borderStyle: "dotted" }}
         className="regular"
+        minSize={Infinity}
+        maxSize={2000}
         activeClassName="active"
         rejectClassName="reject"
         disableClick={true}

--- a/react-dropzone/react-dropzone.d.ts
+++ b/react-dropzone/react-dropzone.d.ts
@@ -25,6 +25,8 @@ declare namespace ReactDropzone {
         /**
         * To accept only a single file, set this to false.
         */
+        maxSize?: number;
+        minSize?: number;
         multiple?: boolean;
         /**
         * Filters the file types that are valid. It should have a valid MIME type according to input element, for example:

--- a/react-dropzone/react-dropzone.d.ts
+++ b/react-dropzone/react-dropzone.d.ts
@@ -23,10 +23,16 @@ declare namespace ReactDropzone {
         */
         disableClick?: boolean;
         /**
-        * To accept only a single file, set this to false.
+         * Min file size accepted
+         */
+        minSize?: number;
+        /** 
+        * Max file size accepted
         */
         maxSize?: number;
-        minSize?: number;
+        /**
+        * To accept only a single file, set this to false.
+        */
         multiple?: boolean;
         /**
         * Filters the file types that are valid. It should have a valid MIME type according to input element, for example:


### PR DESCRIPTION
Added minSize and maxSize props to definitions to React-Dropzone.  
Although they are not documented in the README, they are present in the [component propTypes](https://github.com/okonet/react-dropzone/blob/master/src/index.js)
