### PR TITLE
revalidator: fix and update

### DIFF
--- a/revalidator/revalidator-tests.ts
+++ b/revalidator/revalidator-tests.ts
@@ -1,3 +1,32 @@
 /// <reference path="./revalidator.d.ts" />
+import revalidator = require('revalidator');
 
-revalidator.validate(null, null, null);
+let someObject: any = {};
+
+revalidator.validate(someObject, {
+  properties: {
+    url: {
+      description: 'the url the object should be stored at',
+      type: 'string',
+      pattern: '^/[^#%&*{}\\:<>?\/+]+$',
+      required: true
+    },
+    challenge: {
+      description: 'a means of protecting data (insufficient for production, used as example)',
+      type: 'string',
+      minLength: 5
+    },
+    body: {
+      description: 'what to store at the url',
+      type: 'any',
+      default: null
+    }
+  }
+}, {
+  validateFormats: true,
+  validateFormatsStrict: false,
+  validateFormatExtensions: true,
+  additionalProperties: false,
+  cast: false
+}).valid === true;
+

--- a/revalidator/revalidator-tests.ts
+++ b/revalidator/revalidator-tests.ts
@@ -1,7 +1,14 @@
 /// <reference path="./revalidator.d.ts" />
 import revalidator = require('revalidator');
 
-let someObject: any = {};
+let someObject = {
+  hello: true,
+  there: 'string'
+};
+
+let schema: Revalidator.JSONSchema<typeof someObject> = {
+
+};
 
 revalidator.validate(someObject, {
   properties: {
@@ -24,17 +31,65 @@ revalidator.validate(someObject, {
     obj: {
       type: 'object',
       properties: {
-        body: {
-          type: 'any'
+        items: {
+          type: 'object',
+          properties: {
+            title: {
+              type: 'string',
+              maxLength: 140,
+              conditions: {
+                optional: function () {
+                  return !this.published;
+                }
+              }
+            },
+            date: { type: 'string', format: 'date', messages: { format: "must be a valid %{expected} and nothing else" } },
+            body: { type: 'string' },
+            tags: {
+              type: 'array',
+              uniqueItems: true,
+              minItems: 2,
+              items: {
+                type: 'string',
+                pattern: /[a-z ]+/
+              }
+            },
+            tuple: {
+              type: 'array',
+              minItems: 2,
+              maxItems: 2,
+              items: {
+                type: ['string', 'number']
+              }
+            },
+            author: { type: 'string', pattern: /^[\w ]+$/i, required: true, messages: { required: "is essential for survival" } },
+            published: { type: 'boolean', 'default': false },
+            category: { type: 'string' },
+            palindrome: {
+              type: 'string', conform: function (val) {
+                return val == val.split("").reverse().join("");
+              }
+            },
+            name: {
+              type: 'string', default: '', conform: function (val, data) {
+                return (val === data.hello);
+              }
+            }
+          },
+          patternProperties: {
+            '^_': {
+              type: 'boolean', default: false
+            }
+          }
         }
       }
     }
   }
 }, {
-  validateFormats: true,
-  validateFormatsStrict: false,
-  validateFormatExtensions: true,
-  additionalProperties: false,
-  cast: false
-}).valid === true;
+    validateFormats: true,
+    validateFormatsStrict: false,
+    validateFormatExtensions: true,
+    additionalProperties: false,
+    cast: false
+  }).valid === true;
 

--- a/revalidator/revalidator-tests.ts
+++ b/revalidator/revalidator-tests.ts
@@ -20,6 +20,14 @@ revalidator.validate(someObject, {
       description: 'what to store at the url',
       type: 'any',
       default: null
+    },
+    obj: {
+      type: 'object',
+      properties: {
+        body: {
+          type: 'any'
+        }
+      }
     }
   }
 }, {

--- a/revalidator/revalidator.d.ts
+++ b/revalidator/revalidator.d.ts
@@ -5,7 +5,7 @@
 
 declare module Revalidator {
 
-    interface Options {
+    interface IOptions {
         /** Enforce format constraints (default true) */
         validateFormats?: boolean;
         /** When validateFormats is true treat unrecognized formats as validation errors (default false) */
@@ -19,7 +19,7 @@ declare module Revalidator {
     }
 
     interface RevalidatorStatic {
-        validate(object: any, schema: JSONSchema, options?: Options): IReturnMessage;
+        validate(object: any, schema: JSONSchema, options?: IOptions): IReturnMessage;
     }
 
     type Types = 'string' | 'number' | 'integer' | 'array' | 'boolean' | 'object' | 'null' | 'any';
@@ -35,9 +35,11 @@ declare module Revalidator {
     }
 
     interface JSONSchema {
-        properties: {
-            [index: string]: ISchema;
-        }
+        properties: ISchemas;
+    }
+
+    interface ISchemas {
+        [index: string]: ISchema;
     }
 
     interface ISchema {

--- a/revalidator/revalidator.d.ts
+++ b/revalidator/revalidator.d.ts
@@ -4,9 +4,25 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module Revalidator {
-    interface RevalidatorStatic {
-        validate(object: any, schema: ISchema, options: any): IReturnMessage;
+
+    interface Options {
+        /** Enforce format constraints (default true) */
+        validateFormats?: boolean;
+        /** When validateFormats is true treat unrecognized formats as validation errors (default false) */
+        validateFormatsStrict?: boolean;
+        /** When validateFormats is true also validate formats defined in validate.formatExtensions (default true) */
+        validateFormatExtensions?: boolean;
+        /** When additionalProperties is true allow additional unvisited properties on the object. (default true) */
+        additionalProperties?: boolean;
+        /** Enforce casting of some types (for integers/numbers are only supported) when it's possible, e.g. "42" => 42, but "forty2" => "forty2" for the integer type. */
+        cast?: boolean;
     }
+
+    interface RevalidatorStatic {
+        validate(object: any, schema: JSONSchema, options?: Options): IReturnMessage;
+    }
+
+    type Types = 'string' | 'number' | 'integer' | 'array' | 'boolean' | 'object' | 'null' | 'any';
 
     interface IErrrorProperty {
         property: string;
@@ -18,26 +34,35 @@ declare module Revalidator {
         errors: IErrrorProperty[];
     }
 
+    interface JSONSchema {
+        properties: {
+            [index: string]: ISchema;
+        }
+    }
+
     interface ISchema {
+        type: Types|Types[];
         required?: boolean;
-        type: string;
         pattern?: any;
         maxLength?: number;
+        description?: string;
         minLength?: number;
         minimum?: number;
         maximum?: number;
-        allowEmpty: boolean;
-        exclusiveMinimum: number;
+        allowEmpty?: boolean;
+        exclusiveMinimum?: number;
         exclusiveMaximum?: number;
         divisibleBy?: number;
         minItems?: number;
         maxItems?: number;
         uniqueItems?: boolean;
         enum?: any;
+        message?: string;
+        messages?: {[index: string]: string};
+        default?: any;
         format?: string;
         conform?: (data:any) => boolean;
-        depdendencies?: string;
-
+        dependencies?: string;
     }
 }
 

--- a/revalidator/revalidator.d.ts
+++ b/revalidator/revalidator.d.ts
@@ -19,10 +19,11 @@ declare module Revalidator {
     }
 
     interface RevalidatorStatic {
-        validate(object: any, schema: JSONSchema, options?: IOptions): IReturnMessage;
+        validate<T>(object: T, schema: JSONSchema<T>, options?: IOptions): IReturnMessage;
     }
 
     type Types = 'string' | 'number' | 'integer' | 'array' | 'boolean' | 'object' | 'null' | 'any';
+    type Formats = 'url' | 'email' | 'ip-address' | 'ipv6' | 'date-time' | 'date' | 'time' | 'color' | 'host-name' | 'utc-millisec' | 'regex';
 
     interface IErrrorProperty {
         property: string;
@@ -34,36 +35,58 @@ declare module Revalidator {
         errors: IErrrorProperty[];
     }
 
-    interface JSONSchema {
-        properties?: ISchemas;
+    interface JSONSchema<T> {
+        properties?: ISchemas<T>;
     }
 
-    interface ISchemas {
-        [index: string]: ISchema|JSONSchema;
+    interface ISchemas<T> {
+        [index: string]: ISchema<T>|JSONSchema<T>;
     }
 
-    interface ISchema {
+    interface ISchema<T> {
+        /**The type of value should be equal to the expected value */
         type: Types|Types[];
+        /**If true, the value should not be undefined */
         required?: boolean;
-        pattern?: any;
+        /**The expected value regex needs to be satisfied by the value */
+        pattern?: RegExp|string;
+        /**The length of value must be greater than or equal to expected value */
         maxLength?: number;
+        /**Description for this object */
         description?: string;
+        /**The length of value must be lesser than or equal to expected value */
         minLength?: number;
+        /**Value must be greater than or equal to the expected value */
         minimum?: number;
+        /**Value must be lesser than or equal to the expected value */
         maximum?: number;
+        /**If false, the value must not be an empty string */
         allowEmpty?: boolean;
+        /**Value must be greater than expected value */
         exclusiveMinimum?: number;
+        /**Value must be lesser than expected value */
         exclusiveMaximum?: number;
+        /**Value must be divisible by expected value */
         divisibleBy?: number;
+        /**Value must contain more than expected number of items */
         minItems?: number;
+        /**Value must contain fewer than expected number of items */
         maxItems?: number;
+        /**Value must hold a unique set of values */
         uniqueItems?: boolean;
-        enum?: any;
+        /**Value must be present in the array of expected values */
+        enum?: any[];
+        /**Custom messages for different constraints */
         message?: string;
+        /**Custom messages for different constraints */
         messages?: {[index: string]: string};
+        /**Default value */
         default?: any;
-        format?: string;
-        conform?: (data:any) => boolean;
+        /**Value must be a valid format */
+        format?: Formats;
+        /**Value must conform to constraint denoted by expected value */
+        conform?: (value: any, data?: T) => boolean;
+        /**Value is valid only if the dependent value is valid */
         dependencies?: string;
     }
 }

--- a/revalidator/revalidator.d.ts
+++ b/revalidator/revalidator.d.ts
@@ -35,11 +35,11 @@ declare module Revalidator {
     }
 
     interface JSONSchema {
-        properties: ISchemas;
+        properties?: ISchemas;
     }
 
     interface ISchemas {
-        [index: string]: ISchema;
+        [index: string]: ISchema|JSONSchema;
     }
 
     interface ISchema {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  https://github.com/flatiron/revalidator .
  - it has been reviewed by a DefinitelyTyped member. 

there wasn't any real tests, depdendencies was mispelled, missing description, options are optional, schema was wrong (and fails in real code because of no tests)

split ISchema and ISchemas, so you can do things like: 

``` ts
    let schema: Revalidator.JSONSchema<any> = {
       properties: {
          field2: { 
          }
       }
     }
     _.merge<Revalidator.ISchemas<any>, Revalidator.ISchemas<any>>(schema.properties, {
         field: {
         }
      })
```

since Schema is a model, it should be strongly typed against the validated object
