### PR TITLE
add type of socket.io-parser

### DIFF
--- a/socket.io-parser/socket.io-parser-tests.ts
+++ b/socket.io-parser/socket.io-parser-tests.ts
@@ -1,0 +1,41 @@
+/// <reference path="socket.io-parser.d.ts" />
+/// <reference path="../node/node.d.ts" />
+
+import * as parser from 'socket.io-parser';
+var encoder = new parser.Encoder();
+var packet = {
+    type: parser.EVENT,
+    data: 'test-packet',
+    id: 13
+};
+encoder.encode(packet, function (encodedPackets) {
+    var decoder = new parser.Decoder();
+    decoder.on('decoded', function (decodedPacket) {
+        decodedPacket.type == parser.EVENT
+        decodedPacket.data == 'test-packet'
+        decodedPacket.id == 13
+    });
+
+    for (var i = 0; i < encodedPackets.length; i++) {
+        decoder.add(encodedPackets[i]);
+    }
+});
+
+var packet2 = {
+    type: parser.BINARY_EVENT,
+    data: { i: new Buffer(1234), j: new Blob([new ArrayBuffer(2)]) },
+    id: 15
+};
+encoder.encode(packet2, function (encodedPackets) {
+    var decoder = new parser.Decoder();
+    decoder.on('decoded', function (decodedPacket) {
+        decodedPacket.type == parser.BINARY_EVENT
+        Buffer.isBuffer(decodedPacket.data.i) == true
+        Buffer.isBuffer(decodedPacket.data.j) == true
+        decodedPacket.id == 15
+    });
+
+    for (var i = 0; i < encodedPackets.length; i++) {
+        decoder.add(encodedPackets[i]);
+    }
+});

--- a/socket.io-parser/socket.io-parser.d.ts
+++ b/socket.io-parser/socket.io-parser.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: York Yao <https://github.com/plantain-00/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+///<reference path='../node/node.d.ts' />
+
 declare module "socket.io-parser" {
     namespace Parser {
         type Packet = {

--- a/socket.io-parser/socket.io-parser.d.ts
+++ b/socket.io-parser/socket.io-parser.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for json-editor
+// Project: https://github.com/socketio/socket.io-parser
+// Definitions by: York Yao <https://github.com/plantain-00/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "socket.io-parser" {
+    namespace Parser {
+        type Packet = {
+            type: number,
+            data: any,
+            id: number
+        }
+        type EncodedPacket = string | Buffer | ArrayBuffer | Blob;
+
+        var types: string[];
+
+        var CONNECT: number;
+        var DISCONNECT: number;
+        var EVENT: number;
+        var ACK: number;
+        var ERROR: number;
+        var BINARY_EVENT: number;
+        var BINARY_ACK: number;
+
+        class Encoder {
+            encode(packet: Packet, callback: (encodedPackets: EncodedPacket[]) => void): void;
+        }
+
+        class Decoder {
+            on(event: string, callback: (decodedPacket: Packet) => void): void;
+            add(encodedPacket: EncodedPacket): void;
+            destroy(): void;
+        }
+    }
+
+    export = Parser;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
