### PR TITLE
Suggestion type for suggestion selected event.

### DIFF
--- a/react-autosuggest/react-autosuggest-tests.tsx
+++ b/react-autosuggest/react-autosuggest-tests.tsx
@@ -69,7 +69,7 @@ export class ReactAutosuggestBasicTest extends React.Component<any, any> {
                             inputProps={inputProps}/>;
     }
 
-    protected onSuggestionsSelected(event: React.FormEvent, data: ReactAutosuggest.SuggestionSelectedEventData<Language>) {
+    protected onSuggestionsSelected(event: React.FormEvent, data: ReactAutosuggest.SuggestionSelectedEventData<Language>): void {
         alert(`Selected language is ${data.suggestion.name} (${data.suggestion.year}).`);
     }
 
@@ -186,11 +186,18 @@ export class ReactAutosuggestMultipleTest extends React.Component<any, any> {
         return <Autosuggest multiSection={true}
                             suggestions={suggestions}
                             onSuggestionsUpdateRequested={this.onSuggestionsUpdateRequested.bind(this)}
+                            onSuggestionSelected={this.onSuggestionSelected}
                             getSuggestionValue={this.getSuggestionValue}
                             renderSuggestion={this.renderSuggestion}
                             renderSectionTitle={this.renderSectionTitle}
                             getSectionSuggestions={this.getSectionSuggestions}
                             inputProps={inputProps} />;
+    }
+
+    protected onSuggestionSelected(event: React.FormEvent, data: ReactAutosuggest.ImplicitSuggestionSelectedEventData): void {
+        const language = data.suggestion as Language;
+
+        alert(`Selected language is ${language.name} (${language.year}).`);
     }
 
     protected renderSuggestion(suggestion: Language): JSX.Element {

--- a/react-autosuggest/react-autosuggest-tests.tsx
+++ b/react-autosuggest/react-autosuggest-tests.tsx
@@ -69,7 +69,7 @@ export class ReactAutosuggestBasicTest extends React.Component<any, any> {
                             inputProps={inputProps}/>;
     }
 
-    protected onSuggestionsSelected(event: React.FormEvent, data: ReactAutosuggest.SuggestionSelectedEventData<Language>): void {
+    protected onSuggestionsSelected(event: React.FormEvent, data: ReactAutosuggest.ExplicitSuggestionSelectedEventData<Language>): void {
         alert(`Selected language is ${data.suggestion.name} (${data.suggestion.year}).`);
     }
 
@@ -194,7 +194,7 @@ export class ReactAutosuggestMultipleTest extends React.Component<any, any> {
                             inputProps={inputProps} />;
     }
 
-    protected onSuggestionSelected(event: React.FormEvent, data: ReactAutosuggest.ImplicitSuggestionSelectedEventData): void {
+    protected onSuggestionSelected(event: React.FormEvent, data: ReactAutosuggest.SuggestionSelectedEventData): void {
         const language = data.suggestion as Language;
 
         alert(`Selected language is ${language.name} (${language.year}).`);

--- a/react-autosuggest/react-autosuggest-tests.tsx
+++ b/react-autosuggest/react-autosuggest-tests.tsx
@@ -65,7 +65,12 @@ export class ReactAutosuggestBasicTest extends React.Component<any, any> {
                             onSuggestionsUpdateRequested={this.onSuggestionsUpdateRequested.bind(this)}
                             getSuggestionValue={this.getSuggestionValue}
                             renderSuggestion={this.renderSuggestion}
+                            onSuggestionSelected={this.onSuggestionsSelected}
                             inputProps={inputProps}/>;
+    }
+
+    protected onSuggestionsSelected(event: React.FormEvent, data: ReactAutosuggest.SuggestionSelectedEventData<Language>) {
+        alert(`Selected language is ${data.suggestion.name} (${data.suggestion.year}).`);
     }
 
     protected renderSuggestion(suggestion: Language): JSX.Element {

--- a/react-autosuggest/react-autosuggest.d.ts
+++ b/react-autosuggest/react-autosuggest.d.ts
@@ -30,6 +30,9 @@ declare namespace ReactAutosuggest {
     suggestionValue: string;
   }
 
+  interface ImplicitSuggestionSelectedEventData extends SuggestionSelectedEventData<any> {
+  }
+
   interface Theme {
     container: string;
     containerOpen: string;
@@ -52,7 +55,7 @@ declare namespace ReactAutosuggest {
     multiSection?: boolean;
     renderSectionTitle?: (section: any, inputValues: InputValues) => JSX.Element;
     getSectionSuggestions?: (section: any) => any[];
-    onSuggestionSelected?: (event: React.FormEvent, data: SuggestionSelectedEventData<any>) => void;
+    onSuggestionSelected?: (event: React.FormEvent, data: ImplicitSuggestionSelectedEventData | SuggestionSelectedEventData<any>) => void;
     focusInputOnSuggestionClick?: boolean;
     theme?: Theme;
     id?: string;

--- a/react-autosuggest/react-autosuggest.d.ts
+++ b/react-autosuggest/react-autosuggest.d.ts
@@ -23,10 +23,10 @@ declare namespace ReactAutosuggest {
     onChange: (event: React.FormEvent, params?: {newValue: string, method: string}) => void;
   }
 
-  interface SuggestionSelectedEventData {
+  interface SuggestionSelectedEventData<TSuggestion> {
     method: string;
     sectionIndex: number;
-    suggestion: any;
+    suggestion: TSuggestion;
     suggestionValue: string;
   }
 
@@ -52,7 +52,7 @@ declare namespace ReactAutosuggest {
     multiSection?: boolean;
     renderSectionTitle?: (section: any, inputValues: InputValues) => JSX.Element;
     getSectionSuggestions?: (section: any) => any[];
-    onSuggestionSelected?: (event: React.FormEvent, data: SuggestionSelectedEventData) => void;
+    onSuggestionSelected?: (event: React.FormEvent, data: SuggestionSelectedEventData<any>) => void;
     focusInputOnSuggestionClick?: boolean;
     theme?: Theme;
     id?: string;

--- a/react-autosuggest/react-autosuggest.d.ts
+++ b/react-autosuggest/react-autosuggest.d.ts
@@ -23,14 +23,14 @@ declare namespace ReactAutosuggest {
     onChange: (event: React.FormEvent, params?: {newValue: string, method: string}) => void;
   }
 
-  interface SuggestionSelectedEventData<TSuggestion> {
+  interface ExplicitSuggestionSelectedEventData<TSuggestion> {
     method: string;
     sectionIndex: number;
     suggestion: TSuggestion;
     suggestionValue: string;
   }
 
-  interface ImplicitSuggestionSelectedEventData extends SuggestionSelectedEventData<any> {
+  interface SuggestionSelectedEventData extends ExplicitSuggestionSelectedEventData<any> {
   }
 
   interface Theme {
@@ -55,7 +55,7 @@ declare namespace ReactAutosuggest {
     multiSection?: boolean;
     renderSectionTitle?: (section: any, inputValues: InputValues) => JSX.Element;
     getSectionSuggestions?: (section: any) => any[];
-    onSuggestionSelected?: (event: React.FormEvent, data: ImplicitSuggestionSelectedEventData | SuggestionSelectedEventData<any>) => void;
+    onSuggestionSelected?: (event: React.FormEvent, data: SuggestionSelectedEventData | ExplicitSuggestionSelectedEventData<any>) => void;
     focusInputOnSuggestionClick?: boolean;
     theme?: Theme;
     id?: string;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
SuggestionSelectedEventData converted to be a generic interface, so type of the suggestion property can be defined by the consumer.

It's useful because I don't have to cast the suggestion to the appropriate type in the event handler:

```
    protected onSuggestionsSelected(event: React.FormEvent, data: ReactAutosuggest.SuggestionSelectedEventData<Language>) {
        alert(`Selected language is ${data.suggestion.name} (${data.suggestion.year}).`);
    }
```
