### PR TITLE
Made node Buffer's lastIndexOf and indexOf conformant to node API

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -244,8 +244,19 @@ function bufferTests() {
         let index: number;
         index = buffer.indexOf("23");
         index = buffer.indexOf("23", 1);
+        index = buffer.indexOf("23", 1, "utf8");
         index = buffer.indexOf(23);
         index = buffer.indexOf(buffer);
+    }
+
+    {
+        let buffer = new Buffer('123');
+        let index: number;
+        index = buffer.lastIndexOf("23");
+        index = buffer.lastIndexOf("23", 1);
+        index = buffer.lastIndexOf("23", 1, "utf8");
+        index = buffer.lastIndexOf(23);
+        index = buffer.lastIndexOf(buffer);
     }
 
     // Imported Buffer from buffer module works properly

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -503,8 +503,8 @@ interface NodeBuffer extends Uint8Array {
     writeDoubleLE(value: number, offset: number, noAssert?: boolean): number;
     writeDoubleBE(value: number, offset: number, noAssert?: boolean): number;
     fill(value: any, offset?: number, end?: number): this;
-    // TODO: encoding param
-    indexOf(value: string | number | Buffer, byteOffset?: number): number;
+    indexOf(value: string | number | Buffer, byteOffset?: number, encoding?: string): number;
+    lastIndexOf(value: string | number | Buffer, byteOffset?: number, encoding?: string): number;
     // TODO: entries
     // TODO: includes
     // TODO: keys


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- indexOf definition was missing encoding optional parameter.  https://nodejs.org/api/buffer.html#buffer_buf_indexof_value_byteoffset_encoding 
- lastIndexOf definition was not being overridden to conform to node's API. https://nodejs.org/api/buffer.html#buffer_buf_lastindexof_value_byteoffset_encoding 
