### PR TITLE
added typings for ecmarkup

### DIFF
--- a/ecmarkup/ecmarkup-tests.ts
+++ b/ecmarkup/ecmarkup-tests.ts
@@ -1,0 +1,21 @@
+/// <reference types="ecmarkup" />
+
+import * as emu from "ecmarkup";
+
+emu.build("string", (path: string) => Promise.resolve("string"), {
+    contributors: "string",
+    copyright: true,
+    date: new Date(),
+    location: "string",
+    oldToc: true,
+    toc: true,
+    shortname: "string",
+    stage: "string",
+    status: "proposal",
+    title: "string",
+    version: "string",
+    verbose: true
+}).then((spec: emu.Spec) => {
+    const output = spec.toHTML();
+    const biblio = spec.exportBiblio();
+});

--- a/ecmarkup/index.d.ts
+++ b/ecmarkup/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for emarkup v3.3.2
+// Project: http://github.com/bterlson/ecmarkup
+// Definitions by: Ron Buckton <https://github.com/rbuckton>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface Spec {
+    spec: this;
+    location: string;
+    opts: Options;
+    rootPath: string;
+    rootDir: string;
+    namespace: string;
+    toHTML(): string;
+    exportBiblio(): any;
+}
+
+export interface Options {
+    status?: "proposal" | "draft" | "standard";
+    version?: string;
+    title?: string;
+    shortname?: string;
+    stage?: string | null;
+    copyright?: boolean;
+    date?: Date;
+    location?: string;
+    contributors?: string;
+    toc?: boolean;
+    oldToc?: boolean;
+    verbose?: boolean;
+}
+
+export function build(path: string, fetch: (path: string) => PromiseLike<string>, opts?: Options): PromiseLike<Spec | undefined>;

--- a/ecmarkup/tsconfig.json
+++ b/ecmarkup/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ecmarkup-tests.ts"
+    ]
+}


### PR DESCRIPTION
Adds typings for ecmarkup:
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
