### PR TITLE
include enum values used in the contactfindoptions

### DIFF
--- a/cordova/plugins/Contacts.d.ts
+++ b/cordova/plugins/Contacts.d.ts
@@ -42,6 +42,40 @@ interface Contacts {
      */
     pickContact(onSuccess: (contact: Contact) => void,
         onError: (error: ContactError) => void): void
+
+    /**
+     * This allows us to use an enumeration when setting the desired fields for the ContactFindOptions.
+     * The values will correspond to the type of string literals in ContactFieldType.
+     */
+    fieldType: {
+        addresses: "addresses",
+        birthday: "birthday",
+        categories: "categories",
+        country: "country",
+        department: "department",
+        displayName: "displayName",
+        emails: "emails",
+        familyName: "familyName",
+        formatted: "formatted",
+        givenName: "givenName",
+        honorificPrefix: "honorificPrefix",
+        honorificSuffix: "honorificSuffix",
+        id: "id",
+        ims: "ims",
+        locality: "locality",
+        middleName: "middleName",
+        name: "name",
+        nickname: "nickname",
+        note: "note",
+        organizations: "organizations",
+        phoneNumbers: "phoneNumbers",
+        photos: "photos",
+        postalCode: "postalCode",
+        region: "region",
+        streetAddress: "streetAddress",
+        title: "title",
+        urls: "urls"
+    }
 }
 
 interface ContactProperties {
@@ -105,7 +139,7 @@ interface Contact extends ContactProperties {
 
 declare var Contact: {
     /** Constructor of Contact object */
-    new(id?: string,
+    new (id?: string,
         displayName?: string,
         name?: ContactName,
         nickname?: string,
@@ -130,7 +164,7 @@ interface ContactError {
 }
 
 declare var ContactError: {
-    new(code: number): ContactError;
+    new (code: number): ContactError;
     UNKNOWN_ERROR: number;
     INVALID_ARGUMENT_ERROR: number;
     TIMEOUT_ERROR: number;
@@ -158,7 +192,7 @@ interface ContactName {
 
 declare var ContactName: {
     /** Constructor for ContactName object */
-    new(formatted?: string,
+    new (formatted?: string,
         familyName?: string,
         givenName?: string,
         middleName?: string,
@@ -189,7 +223,7 @@ interface ContactField {
 
 declare var ContactField: {
     /** Constructor for ContactField object */
-    new(type?: string,
+    new (type?: string,
         value?: string,
         pref?: boolean): ContactField
 };
@@ -219,7 +253,7 @@ interface ContactAddress {
 
 declare var ContactAddress: {
     /** Constructor of ContactAddress object */
-    new(pref?: boolean,
+    new (pref?: boolean,
         type?: string,
         formatted?: string,
         streetAddress?: string,
@@ -248,7 +282,7 @@ interface ContactOrganization {
 
 declare var ContactOrganization: {
     /** Constructor for ContactOrganization object */
-    new(pref?: boolean,
+    new (pref?: boolean,
         type?: string,
         name?: string,
         department?: string,
@@ -262,12 +296,42 @@ interface ContactFindOptions {
     /** Determines if the find operation returns multiple navigator.contacts. */
     multiple?: boolean;
     /* Contact fields to be returned back. If specified, the resulting Contact object only features values for these fields. */
-    desiredFields?: string[];
+    desiredFields?: ContactFieldType[];
 }
+
+/** these are the string values that are valid for the desired fields in ContactFindOptions */
+declare type ContactFieldType =
+    "addresses"
+    | "birthday"
+    | "categories"
+    | "country"
+    | "department"
+    | "displayName"
+    | "emails"
+    | "familyName"
+    | "formatted"
+    | "givenName"
+    | "honorificPrefix"
+    | "honorificSuffix"
+    | "id"
+    | "ims"
+    | "locality"
+    | "middleName"
+    | "name"
+    | "nickname"
+    | "note"
+    | "organizations"
+    | "phoneNumbers"
+    | "photos"
+    | "postalCode"
+    | "region"
+    | "streetAddress"
+    | "title"
+    | "urls";
 
 declare var ContactFindOptions: {
     /** Constructor for ContactFindOptions object */
-    new(filter?: string,
+    new (filter?: string,
         multiple?: boolean,
-        desiredFields?: string[]): ContactFindOptions
+        desiredFields?: ContactFieldType[]): ContactFindOptions
 };


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

There is no true way to do a string literal enumeration in type script, but the proposed changes above provide type safety and intellisense.
