### PR TITLE
Durandal - Fixes to DialogContext. See below:

### DIFF
--- a/durandal/durandal.d.ts
+++ b/durandal/durandal.d.ts
@@ -690,6 +690,11 @@ declare module 'plugins/dialog' {
          * @param {object} context The composition context.
         */
         compositionComplete(child: HTMLElement, parent: HTMLElement, context: composition.CompositionContext): void;
+
+        /**
+         * Opacity of the blockout. The default is 0.6.
+         */
+        blockoutOpacity?: number;
     }
 
     interface Dialog {
@@ -728,7 +733,7 @@ declare module 'plugins/dialog' {
      * @param {string} [name] The name of the context to retrieve.
      * @returns {DialogContext} True context.
     */
-    export function getContext(name: string): DialogContext;
+    export function getContext(name?: string): DialogContext;
 
     /**
      * Adds (or replaces) a dialog context.


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
- Add blockoutOpacity to DialogContext
- Mark name of getContext as optional

All as per docs here:
http://durandaljs.com/documentation/Showing-Message-Boxes-And-Modals.html#dialog-contexts
