### PR TITLE
Add type definitions for solution-center-communicator

### DIFF
--- a/solution-center-communicator/solution-center-communicator-tests.ts
+++ b/solution-center-communicator/solution-center-communicator-tests.ts
@@ -1,0 +1,22 @@
+/// <reference path="solution-center-communicator.d.ts" />
+
+import * as ScCommunicator from 'solution-center-communicator';
+
+var environment: ScCommunicator.Environment = {
+  NAME: 'TEST',
+  URL: 'https://norris.test.zalan.do',
+  DOMAIN: '.zalan.do',
+  PORT: '',
+  USER_SERVICE: 'https://um.norris.test.zalan.do',
+  TOKEN_SERVICE: 'https://tm.norris.test.zalan.do',
+  MODULE_SERVICE: 'https://ms.norris.test.zalan.do'
+};
+
+var environments: ScCommunicator.Environments;
+environments.TESTING = environment;
+
+var environmentsProvider: ScCommunicator.ScEnvironmentsProvider;
+
+environmentsProvider.setCurrentEnvironment(environment);
+environmentsProvider.getCurrentEnvironment();
+environmentsProvider.getSpecificEnvironment('TESTING');

--- a/solution-center-communicator/solution-center-communicator.d.ts
+++ b/solution-center-communicator/solution-center-communicator.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Solution Center Communicator 2.3.0
+// Type definitions for Solution Center Communicator 2.2.0
 // Project: https://github.com/zalando-incubator/solution-center-communicator
 // Definitions by: Damián García <https://github.com/dami-gg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -111,7 +111,7 @@ declare namespace ScCommunicator {
      * @param {string|Object} env - Environment name or custom environment object
      * @returns {Object} Named or custom environment
      */
-    setCurrentEnvironment(environment: Environment): Environment;
+    setCurrentEnvironment(env: any): Environment;
 
     /**
      * Access to the public methods of the service

--- a/solution-center-communicator/solution-center-communicator.d.ts
+++ b/solution-center-communicator/solution-center-communicator.d.ts
@@ -1,0 +1,125 @@
+// Type definitions for Solution Center Communicator 2.3.0
+// Project: https://github.com/zalando-incubator/solution-center-communicator
+// Definitions by: Damián García <https://github.com/dami-gg>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace ScCommunicator {
+
+  interface Environment {
+    /**
+     * Name of the environment
+     */
+    NAME: string;
+
+    /**
+     * URL where to reach the frontend of the environment
+     */
+    URL: string;
+
+    /**
+     * Domain where to set a cookie in case it's needed for that environment
+     */
+    DOMAIN: string;
+
+    /**
+     * In case that the domain is localhost, a port can be also specified
+     */
+    PORT?: string;
+
+    /**
+     * URL where to reach the user management service API
+     */
+    USER_SERVICE?: string;
+
+    /**
+     * URL where to reach the token management service API
+     */
+    TOKEN_SERVICE?: string;
+
+    /**
+     * URL where to reach the merchant management service API
+     */
+    MERCHANT_SERVICE?: string;
+
+    /**
+     * URL where to reach the GoodData service API
+     */
+    GOODDATA_SERVICE?: string;
+
+    /**
+     * URL where to reach the module service API
+     */
+    MODULE_SERVICE?: string;
+  }
+
+  interface Environments {
+    /**
+     * Production environment
+     */
+    PRODUCTION: Environment;
+
+    /**
+     * Stage environment
+     */
+    STAGE: Environment;
+
+    /**
+     * Integration environment
+     */
+    INTEGRATION: Environment;
+
+    /**
+     * Development environment
+     */
+    DEVELOPMENT: Environment;
+
+    /**
+     * Local environment
+     */
+    LOCAL: Environment;
+
+    /**
+     * Testing environment
+     */
+    TESTING: Environment;
+  }
+
+  interface ScEnvironmentsProvider {
+
+    /**
+     * Get current environment
+     * If environment was not previously configured, use default environment
+     *
+     * @public
+     * @returns {Object} Current or default environment
+     */
+    getCurrentEnvironment(): Environment;
+
+    /**
+     * Get specific environment
+     *
+     * @public
+     * @param {string} name - Environment name
+     * @returns {Object} Specific or default environment
+     */
+    getSpecificEnvironment(name: string): Environment;
+
+    /**
+     * Set current environment
+     *
+     * @public
+     * @param {string|Object} env - Environment name or custom environment object
+     * @returns {Object} Named or custom environment
+     */
+    setCurrentEnvironment(environment: Environment): Environment;
+
+    /**
+     * Access to the public methods of the service
+     */
+    $get(): any;
+  }
+}
+
+declare module "solution-center-communicator" {
+  export = ScCommunicator;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
