### PR TITLE
countdown - fix namespace

### DIFF
--- a/countdown/countdown-tests.ts
+++ b/countdown/countdown-tests.ts
@@ -1,15 +1,15 @@
 /// <reference path="countdown.d.ts" />
 
-import { countdown, Timespan, CountdownStatic, Format } from 'countdown';
+import * as countdown from 'countdown';
 
-let ts: Timespan;
+let ts: countdown.Timespan;
 let interval: number;
 
-ts = <Timespan>countdown(new Date());
-ts = <Timespan>countdown(150);
+ts = <countdown.Timespan>countdown(new Date());
+ts = <countdown.Timespan>countdown(150);
 
 interval = <number>countdown(new Date(),
-    function (ts: Timespan) {
+    function (ts: countdown.Timespan) {
         document.getElementById('pageTimer').innerHTML = ts.toHTML('strong');
     },
     countdown.HOURS | countdown.MINUTES | countdown.SECONDS,

--- a/countdown/countdown-tests.ts
+++ b/countdown/countdown-tests.ts
@@ -1,0 +1,47 @@
+// Type definitions for countdown.js
+// Project: http://countdownjs.org/
+// Definitions by: Gabriel Juchault https://github.com/gjuchault
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="countdown.d.ts" />
+
+import { countdown, Timespan, CountdownStatic, Format } from 'countdown';
+
+let ts: Timespan;
+let interval: number;
+
+ts = <Timespan>countdown(new Date());
+ts = <Timespan>countdown(150);
+
+interval = <number>countdown(new Date(),
+    function (ts: Timespan) {
+        document.getElementById('pageTimer').innerHTML = ts.toHTML('strong');
+    },
+    countdown.HOURS | countdown.MINUTES | countdown.SECONDS,
+    2,
+    2
+);
+
+clearInterval(interval);
+
+ts.toString('foo');
+ts.toHTML('em', 'foo');
+
+countdown.resetFormat();
+countdown.setLabels('a', 'b', 'c', 'd', 'e');
+
+countdown.setLabels('a', 'b', 'c', 'd', 'e', function (value: number): string {
+    return 'ok';
+}, function (value: number, unit: number): string {
+    return 'ok';
+});
+
+countdown.setLabels(null, null, null, null, 'Now.');
+
+countdown.setLabels(
+    ' millisecond| second| minute| hour| day| week| month| year| decade| century| millennium',
+    ' milliseconds| seconds| minutes| hours| days| weeks| months| years| decades| centuries| millennia',
+    ' and ',
+    ', ',
+    '',
+    n => n.toString());

--- a/countdown/countdown-tests.ts
+++ b/countdown/countdown-tests.ts
@@ -1,8 +1,3 @@
-// Type definitions for countdown.js
-// Project: http://countdownjs.org/
-// Definitions by: Gabriel Juchault https://github.com/gjuchault
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /// <reference path="countdown.d.ts" />
 
 import { countdown, Timespan, CountdownStatic, Format } from 'countdown';

--- a/countdown/countdown.d.ts
+++ b/countdown/countdown.d.ts
@@ -3,11 +3,11 @@
 // Definitions by: Gabriel Juchault <https://github.com/gjuchault>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'countdown' {
-  export type DateFunction = (timespan: Timespan) => void;
-  export type DateTime = number | Date | DateFunction;
+declare namespace countdown {
+  type DateFunction = (timespan: Timespan) => void;
+  type DateTime = number | Date | DateFunction;
 
-  export interface Timespan {
+  interface Timespan {
       start?: Date;
       end?: Date;
       units?: number;
@@ -26,7 +26,7 @@ declare module 'countdown' {
       toHTML(tagName?: string, label?: string): string;
   }
 
-  export interface Format {
+  interface Format {
     singular?: string | Array<string>;
     plural?: string | Array<string>;
     last?: string;
@@ -36,7 +36,7 @@ declare module 'countdown' {
     formatter?(value: number, unit: number): string;
   }
 
-  export interface CountdownStatic {
+  interface CountdownStatic {
       (start: DateTime, end?: DateTime, units?: number, max?: number, digits?: number): Timespan | number;
       MILLENNIA: number;
       CENTURIES: number;
@@ -64,6 +64,9 @@ declare module 'countdown' {
       resetFormat(): void;
       setFormat(format: Format): void;
   }
+}
 
-  export let countdown: CountdownStatic;
+declare module 'countdown' {
+  let countdown: countdown.CountdownStatic;
+  export = countdown;
 }

--- a/countdown/countdown.d.ts
+++ b/countdown/countdown.d.ts
@@ -65,5 +65,5 @@ declare module 'countdown' {
       setFormat(format: Format): void;
   }
 
-  export var countdown: CountdownStatic;
+  export let countdown: CountdownStatic;
 }

--- a/countdown/countdown.d.ts
+++ b/countdown/countdown.d.ts
@@ -1,0 +1,69 @@
+// Type definitions for countdown.js
+// Project: http://countdownjs.org/
+// Definitions by: Gabriel Juchault <https://github.com/gjuchault>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'countdown' {
+  export type DateFunction = (timespan: Timespan) => void;
+  export type DateTime = number | Date | DateFunction;
+
+  export interface Timespan {
+      start?: Date;
+      end?: Date;
+      units?: number;
+      value?: number;
+      millennia?: number;
+      centuries?: number;
+      decades?: number;
+      years?: number;
+      months?: number;
+      days?: number;
+      hours?: number;
+      minutes?: number;
+      seconds?: number;
+      milliseconds?: number;
+      toString(label?: string): string;
+      toHTML(tagName?: string, label?: string): string;
+  }
+
+  export interface Format {
+    singular?: string | Array<string>;
+    plural?: string | Array<string>;
+    last?: string;
+    delim?: string;
+    empty?: string;
+    formatNumber?(value: number): string;
+    formatter?(value: number, unit: number): string;
+  }
+
+  export interface CountdownStatic {
+      (start: DateTime, end?: DateTime, units?: number, max?: number, digits?: number): Timespan | number;
+      MILLENNIA: number;
+      CENTURIES: number;
+      DECADES: number;
+      YEARS: number;
+      MONTHS: number;
+      WEEKS: number;
+      DAYS: number;
+      HOURS: number;
+      MINUTES: number;
+      SECONDS: number;
+      MILLISECONDS: number;
+      ALL: number;
+      DEFAULTS: number;
+      resetLabels(): void;
+      setLabels(
+        singular?: string,
+        plural?: string,
+        last?: string,
+        delim?: string,
+        empty?: string,
+        formatNumber?: (value: number) => string,
+        formatter?: (value: number, unit: number) => string
+      ): void;
+      resetFormat(): void;
+      setFormat(format: Format): void;
+  }
+
+  export var countdown: CountdownStatic;
+}


### PR DESCRIPTION
I made previous definitions for `countdown` but actually, I didn't realize that the import should be made like that: `import * as countdown from 'countdown';`. So I created a namespace as seen in other libraries
