### PR TITLE
Use same type for next function in middleware as koa main project

### DIFF
--- a/koa-router/koa-router-tests.ts
+++ b/koa-router/koa-router-tests.ts
@@ -23,11 +23,11 @@ router
   .put('/users/:id', function (ctx, next) {
     ctx.body = ctx.params.id;
   })
-  .del('/users/:id', function (ctx, next) {
+  .del('/users/:id', function () {
     // ...
   });
 
-router.get('user', '/users/:id', function (ctx, next) {
+router.get('user', '/users/:id', function (ctx) {
     ctx.body = "sdsd";
 });
 

--- a/koa-router/koa-router.d.ts
+++ b/koa-router/koa-router.d.ts
@@ -49,11 +49,11 @@ declare module "koa-router" {
         }
 
         export interface IMiddleware {
-            (ctx: Router.IRouterContext, next?: () => any): any;
+            (ctx: Router.IRouterContext, next: () => Promise<any>): any;
         }
 
         export interface IParamMiddleware {
-            (param: string, ctx: Router.IRouterContext, next?: () => any): any;
+            (param: string, ctx: Router.IRouterContext, next: () => Promise<any>): any;
         }
 
         export interface IRouterAllowedMethodsOptions {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- Use same type for next function in middleware as the main koa typing for consistency and because the next function in IMiddleware doesn't need to be marked as nullable. 
- I also tested this in typescript 2 with --strictNullChecks and when next is nullable, compilation fails. With this fix, compilation works both in 1.8.x and 2 with --strictNullChecks.
