### PR TITLE
Add fromIndex parameter to find

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -3674,33 +3674,51 @@ namespace TestFind {
 
     result = _.find<TResult>(array);
     result = _.find<TResult>(array, listIterator);
+    result = _.find<TResult>(array, listIterator, 1);
     result = _.find<TResult>(array, '');
+    result = _.find<TResult>(array, '', 1);
     result = _.find<{a: number}, TResult>(array, {a: 42});
+    result = _.find<{a: number}, TResult>(array, {a: 42}, 1);
 
     result = _.find<TResult>(list);
     result = _.find<TResult>(list, listIterator);
+    result = _.find<TResult>(list, listIterator, 1);
     result = _.find<TResult>(list, '');
+    result = _.find<TResult>(list, '', 1);
     result = _.find<{a: number}, TResult>(list, {a: 42});
+    result = _.find<{a: number}, TResult>(list, {a: 42}, 1);
 
     result = _.find<TResult>(dictionary);
     result = _.find<TResult>(dictionary, dictionaryIterator);
+    result = _.find<TResult>(dictionary, dictionaryIterator, 1);
     result = _.find<TResult>(dictionary, '');
+    result = _.find<TResult>(dictionary, '', 1);
     result = _.find<{a: number}, TResult>(dictionary, {a: 42});
+    result = _.find<{a: number}, TResult>(dictionary, {a: 42}, 1);
 
     result = _(array).find();
     result = _(array).find(listIterator);
+    result = _(array).find(listIterator, 1);
     result = _(array).find('');
+    result = _(array).find('', 1);
     result = _(array).find<{a: number}>({a: 42});
+    result = _(array).find<{a: number}>({a: 42}, 1);
 
     result = _(list).find<TResult>();
     result = _(list).find<TResult>(listIterator);
+    result = _(list).find<TResult>(listIterator, 1);
     result = _(list).find<TResult>('');
+    result = _(list).find<TResult>('', 1);
     result = _(list).find<{a: number}, TResult>({a: 42});
+    result = _(list).find<{a: number}, TResult>({a: 42}, 1);
 
     result = _(dictionary).find<TResult>();
     result = _(dictionary).find<TResult>(dictionaryIterator);
+    result = _(dictionary).find<TResult>(dictionaryIterator, 1);
     result = _(dictionary).find<TResult>('');
+    result = _(dictionary).find<TResult>('', 1);
     result = _(dictionary).find<{a: number}, TResult>({a: 42});
+    result = _(dictionary).find<{a: number}, TResult>({a: 42}, 1);
 }
 
 result = <number>_.findLast([1, 2, 3, 4], function (num) {
@@ -5733,11 +5751,11 @@ namespace TestFlow {
     let Fn2: (m: number, n: number) => number;
     let Fn3: (a: number) => string;
     let Fn4: (a: string) => number;
-    
+
     {
         // type infer test
         let result: (m: number, n: number) => number;
-        
+
         result = _.flow(Fn2, Fn1);
         result = _.flow(Fn2, Fn1, Fn1);
         result = _.flow(Fn2, Fn1, Fn1, Fn1);

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -6787,12 +6787,13 @@ declare module _ {
          *
          * @param collection The collection to search.
          * @param predicate The function invoked per iteration.
-         * @param thisArg The this binding of predicate.
+         * @param fromIndex The index to search from.
          * @return Returns the matched element, else undefined.
          */
         find<T>(
             collection: List<T>,
-            predicate?: ListIterator<T, boolean>
+            predicate?: ListIterator<T, boolean>,
+            fromIndex?: number
         ): T;
 
         /**
@@ -6800,7 +6801,8 @@ declare module _ {
          */
         find<T>(
             collection: Dictionary<T>,
-            predicate?: DictionaryIterator<T, boolean>
+            predicate?: DictionaryIterator<T, boolean>,
+            fromIndex?: number
         ): T;
 
         /**
@@ -6808,7 +6810,8 @@ declare module _ {
          */
         find<T>(
             collection: List<T>|Dictionary<T>,
-            predicate?: string
+            predicate?: string,
+            fromIndex?: number
         ): T;
 
         /**
@@ -6816,7 +6819,8 @@ declare module _ {
          */
         find<TObject extends {}, T>(
             collection: List<T>|Dictionary<T>,
-            predicate?: TObject
+            predicate?: TObject,
+            fromIndex?: number
         ): T;
     }
 
@@ -6825,21 +6829,24 @@ declare module _ {
          * @see _.find
          */
         find(
-            predicate?: ListIterator<T, boolean>
+            predicate?: ListIterator<T, boolean>,
+            fromIndex?: number
         ): T;
 
         /**
          * @see _.find
          */
         find(
-            predicate?: string
+            predicate?: string,
+            fromIndex?: number
         ): T;
 
         /**
          * @see _.find
          */
         find<TObject extends {}>(
-            predicate?: TObject
+            predicate?: TObject,
+            fromIndex?: number
         ): T;
     }
 
@@ -6848,21 +6855,24 @@ declare module _ {
          * @see _.find
          */
         find<TResult>(
-            predicate?: ListIterator<TResult, boolean>|DictionaryIterator<TResult, boolean>
+            predicate?: ListIterator<TResult, boolean>|DictionaryIterator<TResult, boolean>,
+            fromIndex?: number
         ): TResult;
 
         /**
          * @see _.find
          */
         find<TResult>(
-            predicate?: string
+            predicate?: string,
+            fromIndex?: number
         ): TResult;
 
         /**
          * @see _.find
          */
         find<TObject extends {}, TResult>(
-            predicate?: TObject
+            predicate?: TObject,
+            fromIndex?: number
         ): TResult;
     }
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- Added missing optional parameter `fromIndex` to `find`.  https://lodash.com/docs#find
