### PR TITLE
Updates for Mongoose

### DIFF
--- a/mongoose-paginate/mongoose-paginate-tests.ts
+++ b/mongoose-paginate/mongoose-paginate-tests.ts
@@ -11,14 +11,15 @@ import {
     model,
     PaginateModel,
     PaginateOptions,
-    PaginateResult
+    PaginateResult,
+    Document
 } from 'mongoose';
 import * as mongoosePaginate from 'mongoose-paginate';
 import { Router, Request, Response } from 'express';
 
 
 //#region Test Models
-interface User {
+interface User extends Document {
   email: string;
   username: string;
   password: string;
@@ -32,8 +33,7 @@ const UserSchema: Schema = new Schema({
 
 UserSchema.plugin(mongoosePaginate);
 
-type UserModel<T> = _UserModel<T> & PaginateModel<T>;
-interface _UserModel<T> {}
+interface UserModel<T extends Document> extends PaginateModel<T> {};
 
 let UserModel: UserModel<User> = model<User>('User', UserSchema) as UserModel<User>;
 //#endregion

--- a/mongoose-paginate/mongoose-paginate.d.ts
+++ b/mongoose-paginate/mongoose-paginate.d.ts
@@ -35,6 +35,12 @@ declare module 'mongoose' {
     schema?: Schema,
     collection?: string,
     skipInit?: boolean): PaginateModel<T>;
+
+  export function model<T extends Document, U extends PaginateModel<T>>(
+    name: string,
+    schema?: Schema,
+    collection?: string,
+    skipInit?: boolean): U;
 }
 
 declare module 'mongoose-paginate' {

--- a/mongoose-paginate/mongoose-paginate.d.ts
+++ b/mongoose-paginate/mongoose-paginate.d.ts
@@ -26,16 +26,15 @@ declare module 'mongoose' {
     offset?: number;
   }
 
-  export type PaginateModel<T> = _PaginateModel<T> & Model<T>;
-  interface _PaginateModel<T> {
+  interface PaginateModel<T extends Document> extends Model<T> {
     paginate(query?: Object, options?: PaginateOptions, callback?: (err: any, result: PaginateResult<T>) => void): Promise<PaginateResult<T>>;
   }
 
-  export function model<T extends Document, Statics>(
+  export function model<T extends Document>(
     name: string,
     schema?: Schema,
     collection?: string,
-    skipInit?: boolean): Statics & PaginateModel<T>;
+    skipInit?: boolean): PaginateModel<T>;
 }
 
 declare module 'mongoose-paginate' {

--- a/mongoose-promise/mongoose-promise-tests.ts
+++ b/mongoose-promise/mongoose-promise-tests.ts
@@ -1,8 +1,10 @@
 /// <reference path="mongoose-promise.d.ts" />
 
+import * as mongoose from 'mongoose';
+
 var cb = function () {};
 
-var mongopromise: MongoosePromise<number>;
+var mongopromise: mongoose.Promise<number>;
 mongopromise.addBack(function (err, arg) {
   err.stack;
   arg.toFixed();
@@ -40,7 +42,19 @@ mongopromise.then(function (arg) {
 });
 mongopromise.complete();
 /* static properties */
-MongoosePromise.ES6(function (complete, error) {
+mongoose.Promise.ES6(function (complete, error) {
   complete.apply(this);
   error.apply(this);
 });
+/* Practical Examples */
+interface IUser extends mongoose.Document {
+  name: string;
+  age: number;
+}
+var UserSchema = new mongoose.Schema({
+  name: String,
+  age: Number
+});
+var UserModel: mongoose.Model<IUser> = mongoose.model<IUser>('Model', UserSchema);
+UserModel.findOne({}).exec().fulfill();
+UserModel.find({}).exec().then(() => {}).catch(() => {}).reject('');

--- a/mongoose-promise/mongoose-promise-tests.ts
+++ b/mongoose-promise/mongoose-promise-tests.ts
@@ -42,7 +42,7 @@ mongopromise.then(function (arg) {
 });
 mongopromise.complete();
 /* static properties */
-mongoose.Promise.ES6(function (complete, error) {
+mongoose.Promise.ES6(function (complete: any, error: any) {
   complete.apply(this);
   error.apply(this);
 });

--- a/mongoose-promise/mongoose-promise.d.ts
+++ b/mongoose-promise/mongoose-promise.d.ts
@@ -3,126 +3,125 @@
 // Definitions by: simonxca <https://github.com/simonxca/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/*
- * These are the default promises included in the Mongoose v4.x
- * definitions. They will be deprecated beginning Mongoose V5.x
- * in favor of native ES6 Promises.
- *
- * You can switch the promise library that mongoose uses by:
- *
- * 1. Including this somewhere in your code:
- *    mongoose.Promise = YOUR_PROMISE;
- *
- * 2. Including this somewhere in your main .d.ts file:
- *    type MongoosePromise<T> = YOUR_PROMISE<T>;
- */
+/// <reference path="../mongoose/mongoose.d.ts" />
+/// <reference path="../mpromise/mpromise.d.ts" />
 
 /*
  * http://mongoosejs.com/docs/api.html#promise-js
  *
- * Callback signatures are from the mPromise type definitions.
+ * mongoose.d.ts uses global.Promise by default. This is the MongooseJS
+ * mpromise implementation (which are deprecated). If you still want to
+ * use it, install these definitions in your project.
  */
-interface MongoosePromise<T> {
-  /**
-   * Promise constructor.
-   * Promises are returned from executed queries.
-   * @param fn a function which will be called when the promise
-   *   is resolved that accepts fn(err, ...){} as signature
-   * @event err Emits when the promise is rejected
-   * @event complete Emits when the promise is fulfilled
-   * @deprecated Mongoose 5.0 will use native promises by default (or bluebird, if native
-   *   promises are not present) but still support plugging in your own ES6-compatible
-   *   promises library. Mongoose 5.0 will not support mpromise.
+declare module 'mongoose' {
+  import mpromise = require('mpromise');
+
+  type Promise<T> = MongoosePromise<T>;
+
+  /*
+   * mpromise definitions.
+   * Callback signatures are from the mPromise type definitions.
    */
-  new(fn?: (err: any, arg: T) => void): MongoosePromise<T>;
-  new(fn?: (err: any, ...args: T[]) => void): MongoosePromise<T>;
-}
+  class MongoosePromise<T> extends mpromise<T, any> {
+    /**
+     * Promise constructor.
+     * Promises are returned from executed queries.
+     * @param fn a function which will be called when the promise
+     *   is resolved that accepts fn(err, ...){} as signature
+     * @event err Emits when the promise is rejected
+     * @event complete Emits when the promise is fulfilled
+     * @deprecated Mongoose 5.0 will use native promises by default (or bluebird, if native
+     *   promises are not present) but still support plugging in your own ES6-compatible
+     *   promises library. Mongoose 5.0 will not support mpromise.
+     */
+    constructor(fn?: (err: any, arg: T) => void);
+    constructor(fn?: (err: any, ...args: T[]) => void);
 
-declare class MongoosePromise<T> {
-  /**
-   * Adds a single function as a listener to both err and complete.
-   * It will be executed with traditional node.js argument position when the promise is resolved.
-   * @deprecated Use onResolve instead.
-   */
-  addBack(listener: (err: any, arg: T) => void): this;
-  addBack(listener: (err: any, ...args: T[]) => void): this;
+      /**
+     * Adds a single function as a listener to both err and complete.
+     * It will be executed with traditional node.js argument position when the promise is resolved.
+     * @deprecated Use onResolve instead.
+     */
+    addBack(listener: (err: any, arg: T) => void): this;
+    addBack(listener: (err: any, ...args: T[]) => void): this;
 
-  /**
-   * Adds a listener to the complete (success) event.
-   * @deprecated Adds a listener to the complete (success) event.
-   */
-  addCallback(listener: (arg: T) => void): this;
-  addCallback(listener: (...args: T[]) => void): this;
+    /**
+     * Adds a listener to the complete (success) event.
+     * @deprecated Adds a listener to the complete (success) event.
+     */
+    addCallback(listener: (arg: T) => void): this;
+    addCallback(listener: (...args: T[]) => void): this;
 
-  /**
-   * Adds a listener to the err (rejected) event.
-   * @deprecated Use onReject instead.
-   */
-  addErrback(listener: (err: any) => void): this;
+    /**
+     * Adds a listener to the err (rejected) event.
+     * @deprecated Use onReject instead.
+     */
+    addErrback(listener: (err: any) => void): this;
 
-  /** ES6-style .catch() shorthand */
-  catch<TRes>(onReject?: (err: any) => void | TRes | PromiseLike<TRes>): MongoosePromise<TRes>;
+    /** ES6-style .catch() shorthand */
+    catch<TRes>(onReject?: (err: any) => void | TRes | PromiseLike<TRes>): MongoosePromise<TRes>;
 
-  /**
-   * Signifies that this promise was the last in a chain of then()s: if a handler passed
-   * to the call to then which produced this promise throws, the exception will go uncaught.
-   */
-  end(): void;
+    /**
+     * Signifies that this promise was the last in a chain of then()s: if a handler passed
+     * to the call to then which produced this promise throws, the exception will go uncaught.
+     */
+    end(): void;
 
-  /**
-   * Rejects this promise with err.
-   * If the promise has already been fulfilled or rejected, not action is taken.
-   * Differs from #reject by first casting err to an Error if it is not instanceof Error.
-   */
-  error(err: any): this;
+    /**
+     * Rejects this promise with err.
+     * If the promise has already been fulfilled or rejected, not action is taken.
+     * Differs from #reject by first casting err to an Error if it is not instanceof Error.
+     */
+    error(err: any): this;
 
-  /**
-   * Adds listener to the event.
-   * If event is either the success or failure event and the event has already been emitted,
-   * thelistener is called immediately and passed the results of the original emitted event.
-   */
-  on(event: string, listener: Function): this;
+    /**
+     * Adds listener to the event.
+     * If event is either the success or failure event and the event has already been emitted,
+     * thelistener is called immediately and passed the results of the original emitted event.
+     */
+    on(event: string, listener: Function): this;
 
-  /**
-   * Rejects this promise with reason.
-   * If the promise has already been fulfilled or rejected, not action is taken.
-   */
-  reject(reason: Object | string | Error): this;
+    /**
+     * Rejects this promise with reason.
+     * If the promise has already been fulfilled or rejected, not action is taken.
+     */
+    reject(reason: Object | string | Error): this;
 
-  /**
-   * Resolves this promise to a rejected state if err is passed or a fulfilled state if no err is passed.
-   * If the promise has already been fulfilled or rejected, not action is taken.
-   * err will be cast to an Error if not already instanceof Error.
-   * NOTE: overrides mpromise#resolve to provide error casting.
-   * @param err error or null
-   * @param val value to fulfill the promise with
-   */
-  resolve(err?: any, val?: Object): this;
+    /**
+     * Resolves this promise to a rejected state if err is passed or a fulfilled state if no err is passed.
+     * If the promise has already been fulfilled or rejected, not action is taken.
+     * err will be cast to an Error if not already instanceof Error.
+     * NOTE: overrides mpromise#resolve to provide error casting.
+     * @param err error or null
+     * @param val value to fulfill the promise with
+     */
+    resolve(err?: any, val?: Object): this;
 
-  /**
-   * Creates a new promise and returns it. If onFulfill or onReject are passed, they are added as
-   * SUCCESS/ERROR callbacks to this promise after the nextTick.
-   * Conforms to promises/A+ specification.
-   */
-  then<TRes>(onFulFill: (arg: T) => void | TRes | PromiseLike<TRes>,
-    onReject?: (err: any) => void | TRes | PromiseLike<TRes>): MongoosePromise<TRes>;
-  then<TRes>(onFulfill: (...args: T[]) => void | TRes | PromiseLike<TRes>,
-    onReject?: (err: any) => void | TRes | PromiseLike<TRes>): MongoosePromise<TRes>;
+    /**
+     * Creates a new promise and returns it. If onFulfill or onReject are passed, they are added as
+     * SUCCESS/ERROR callbacks to this promise after the nextTick.
+     * Conforms to promises/A+ specification.
+     */
+    then<TRes>(onFulFill: (arg: T) => void | TRes | PromiseLike<TRes>,
+      onReject?: (err: any) => void | TRes | PromiseLike<TRes>): MongoosePromise<TRes>;
+    then<TRes>(onFulfill: (...args: T[]) => void | TRes | PromiseLike<TRes>,
+      onReject?: (err: any) => void | TRes | PromiseLike<TRes>): MongoosePromise<TRes>;
 
-  /**
-   * Fulfills this promise with passed arguments. Alias of mpromise#fulfill.
-   * @deprecated Use fulfill instead.
-   */
-  complete(args: T): this;
-  complete(...args: T[]): this;
+    /**
+     * Fulfills this promise with passed arguments. Alias of mpromise#fulfill.
+     * @deprecated Use fulfill instead.
+     */
+    complete(args: T): this;
+    complete(...args: T[]): this;
 
-  /** Fulfills this promise with passed arguments. */
-  fulfill(...args: T[]): this;
-  fulfill(arg: T): this;
+    /** Fulfills this promise with passed arguments. */
+    fulfill(...args: T[]): this;
+    fulfill(arg: T): this;
 
-  /** ES6-style promise constructor wrapper around mpromise. */
-  static ES6<TRes>(resolver: (
-    complete: (...args: TRes[]) => void | TRes | PromiseLike<TRes>,
-    error: (e: any) => void | TRes | PromiseLike<TRes>
-  ) => void): MongoosePromise<TRes>;
+    /** ES6-style promise constructor wrapper around mpromise. */
+    static ES6<TRes>(resolver: (
+      complete: (...args: TRes[]) => void | TRes | PromiseLike<TRes>,
+      error: (e: any) => void | TRes | PromiseLike<TRes>
+    ) => void): MongoosePromise<TRes>;
+  }
 }

--- a/mongoose/README.md
+++ b/mongoose/README.md
@@ -1,0 +1,1 @@
+# TESTING

--- a/mongoose/README.md
+++ b/mongoose/README.md
@@ -25,7 +25,7 @@ import {model, Schema} from 'mongoose';
 var MyModel = model(...);
 var MySchema: Schema = new Schema(...):
 ```
-
+[top](#mongoosejs-typescript-docs)
 
 #### Creating and Saving Documents
 ```
@@ -60,6 +60,7 @@ UserModel.findOne({}, (err: any, user: IUser) => {
   user.save();     // mongoose Document methods are available
 });
 ```
+[top](#mongoosejs-typescript-docs)
 
 #### Instance Methods and Virtual Properties
 ```
@@ -94,6 +95,7 @@ UserModel.findOne({}, (err: any, user: IUser) => {
   user.nameInCaps;  // virtual properties can be used
 });
 ```
+[top](#mongoosejs-typescript-docs)
 
 #### Static Methods
 ```
@@ -110,6 +112,7 @@ interface IUserModel extends Model<IUserDocument> {
 var UserModel: IUserModel = model<IUser, IUserModel>('User', UserSchema);
 UserModel.static1();    // static methods are available
 ```
+[top](#mongoosejs-typescript-docs)
 
 #### Plugins
 To write definitions for plugins, extend the mongoose module and create a simple plugin module:
@@ -147,6 +150,7 @@ interface IUserModel<T extends PassportLocalDocument> extends PassportLocalModel
 var UserModel: IUserModel<IUser> = model<IUser>('User', UserSchema);
 ```
 Full example for [Passport Local Mongoose](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/passport-local-mongoose/passport-local-mongoose.d.ts)
+[top](#mongoosejs-typescript-docs)
 
 #### Promises
 These definitions use global.Promise by default. If you would like to use mongoose's own mpromise
@@ -180,6 +184,7 @@ Typescript does not allow assigning properties of imported modules):
 * `(<any>mongoose).Promise = YOUR_PROMISE;`
 * `require('mongoose').Promise = YOUR_PROMISE;`
 * `import mongoose = require('mongoose'); ... mongoose.Promise = YOUR_PROMISE;`
+[top](#mongoosejs-typescript-docs)
 
 #### FAQ
 Q: Why are there 2 interfaces for Documents called Document and MongooseDocument?<br>
@@ -198,3 +203,4 @@ interface IUser extends mongoose.model {
 For backwards compatibility Document is an interface for [mongoose.model](https://github.com/Automattic/mongoose/blob/master/lib/model.js#L3162)<br>
 And MongooseDocument is an interface for [mongoose.Document](https://github.com/Automattic/mongoose/blob/master/lib/model.js#L3162)<br>
 At some point in the future this may get fixed, which would require fixing your code.
+[top](#mongoosejs-typescript-docs)

--- a/mongoose/README.md
+++ b/mongoose/README.md
@@ -149,7 +149,7 @@ interface IUserModel<T extends PassportLocalDocument> extends PassportLocalModel
 
 var UserModel: IUserModel<IUser> = model<IUser>('User', UserSchema);
 ```
-Full example for [Passport Local Mongoose](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/passport-local-mongoose/passport-local-mongoose.d.ts)
+Full example for [Passport Local Mongoose](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/passport-local-mongoose/passport-local-mongoose.d.ts)<br>
 [top](#mongoosejs-typescript-docs)
 
 #### Promises
@@ -184,6 +184,7 @@ Typescript does not allow assigning properties of imported modules):
 * `(<any>mongoose).Promise = YOUR_PROMISE;`
 * `require('mongoose').Promise = YOUR_PROMISE;`
 * `import mongoose = require('mongoose'); ... mongoose.Promise = YOUR_PROMISE;`
+
 [top](#mongoosejs-typescript-docs)
 
 #### FAQ
@@ -203,4 +204,5 @@ interface IUser extends mongoose.model {
 For backwards compatibility Document is an interface for [mongoose.model](https://github.com/Automattic/mongoose/blob/master/lib/model.js#L3162)<br>
 And MongooseDocument is an interface for [mongoose.Document](https://github.com/Automattic/mongoose/blob/master/lib/model.js#L3162)<br>
 At some point in the future this may get fixed, which would require fixing your code.
+<br>
 [top](#mongoosejs-typescript-docs)

--- a/mongoose/README.md
+++ b/mongoose/README.md
@@ -1,1 +1,191 @@
-# TESTING
+## MongooseJS Typescript Docs
+Below are some examples of how to use these Definitions.<br>
+Scenarios where the Typescript code is identical to plain Javascript code are omitted.
+
+#### Mongoose Methods, Properties, Constructors
+You can call methods from the mongoose instance using:
+```
+import * as mongoose from 'mongoose';
+var MyModel = mongoose.model(...);
+var MySchema: mongoose.Schema = new mongoose.Schema(...);
+```
+
+Alternatively, you can import individual names and call them:
+```
+import {model, Schema} from 'mongoose';
+var MyModel = model(...);
+var MySchema: Schema = new Schema(...):
+```
+
+
+#### Creating and Saving Documents
+```
+import {Document, model, Model, Schema} from 'mongoose';
+
+var UserSchema: Schema = new Schema({
+  username: {
+    type: String,
+    required: true,
+    unique: true
+  },
+  age: Number,
+  friends: [String],
+  data: [Schema.Types.Mixed]
+});
+
+interface IUser extends Document {
+  username: string;
+  age: number;
+  friends: string[];
+  data: any[];
+}
+
+var UserModel: Model<IUser> = mongoose.model<IUser>('User', UserSchema);
+
+var user = new UserModel({name: 'Jane'});
+user.username;     // IUser properties are available
+user.save();       // mongoose Document methods are available
+
+UserModel.findOne({}, (err: any, user: IUser) => {
+  user.username;   // IUser properties are available
+  user.save();     // mongoose Document methods are available
+});
+```
+
+#### Instance Methods and Virtual Properties
+```
+import {Document, model, Model, Schema} from 'mongoose';
+
+var UserSchema: Schema = new Schema({
+  name: String
+});
+
+UserSchema.methods.method1 = function () { return '' };
+UserSchema.virtual('nameInCaps').get(function () {
+  return this.name.toUpperCase();
+});
+UserSchema.virtual('nameInCaps').set(function (caps) {
+  this.name = caps.toLowerCase();
+});
+
+interface IUser extends Document {
+  name: string;
+  nameInCaps: string;
+  method1: () => string;
+}
+
+var UserModel: Model<IUser> = model<IUser>('User', UserSchema);
+var user = new UserModel({name: 'Billy'});
+
+user.method1();     // IUser methods are available
+user.nameInCaps;    // virtual properties can be used
+
+UserModel.findOne({}, (err: any, user: IUser) => {
+  user.method1();   // IUser methods are available
+  user.nameInCaps;  // virtual properties can be used
+});
+```
+
+#### Static Methods
+```
+import {Document, model, Model, Schema} from 'mongoose';
+
+var UserSchema = new Schema({});
+UserSchema.statics.static1 = function () { return '' };
+
+interface IUserDocument extends Document {...}
+interface IUserModel extends Model<IUserDocument> {
+  static1: () => string;
+}
+
+var UserModel: IUserModel = model<IUser, IUserModel>('User', UserSchema);
+UserModel.static1();    // static methods are available
+```
+
+#### Plugins
+To write definitions for plugins, extend the mongoose module and create a simple plugin module:
+```
+// plugin.d.ts
+declare module 'mongoose' {
+  export interface PassportLocalDocument {...}
+  export interface PassportLocalSchema extends Schema {...}
+  export interface PassportLocalModel<T extends PassportLocalDocument> extends Model<T> {...}
+  ...
+}
+
+declare module 'passport-local-mongoose' {
+  import mongoose = require('mongoose');
+  var _: (schema: mongoose.Schema, options?: Object) => void;
+  export = _;
+}
+
+// user.ts
+import {
+  model,
+  PassportLocalDocument,
+  PassportLocalSchema,
+  PassportLocalModel
+  Schema
+} from 'mongoose';
+import * as passportLocalMongoose from 'passport-local-mongoose';
+
+var UserSchema: PassportLocalSchema = new Schema({});
+UserSchema.plugin(passportLocalMongoose, options);
+
+interface IUser extends PassportLocalDocument {...}
+interface IUserModel<T extends PassportLocalDocument> extends PassportLocalModel<T> {...}
+
+var UserModel: IUserModel<IUser> = model<IUser>('User', UserSchema);
+```
+Full example for [Passport Local Mongoose](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/passport-local-mongoose/passport-local-mongoose.d.ts)
+
+#### Promises
+These definitions use global.Promise by default. If you would like to use mongoose's own mpromise
+definition (which is deprecated), you can install definitions for [mongoose-promise](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/mongoose-promise).
+
+If you'd like to use something other than global.Promise, you'll need to create a simple .d.ts file:
+```
+// promise-bluebird.d.ts
+import * as Bluebird from 'bluebird';
+
+declare module 'mongoose' {
+  type Promise<T> = Bluebird<T>;
+}
+
+// promise-q.d.ts
+import * as Q from 'q';
+
+declare module 'mongoose' {
+  type Promise<T> = Q.Promise<T>;
+}
+
+// another-promise.d.ts
+...
+```
+To use it, you will need to `/// <reference path="promise-bluebird.d.ts" />` in one of your source code files,
+or include the `.d.ts` file in your compile.
+
+To assign the new promise library in your code, you will need to use one of the following options (since
+Typescript does not allow assigning properties of imported modules):
+
+* `(<any>mongoose).Promise = YOUR_PROMISE;`
+* `require('mongoose').Promise = YOUR_PROMISE;`
+* `import mongoose = require('mongoose'); ... mongoose.Promise = YOUR_PROMISE;`
+
+#### FAQ
+Q: Why are there 2 interfaces for Documents called Document and MongooseDocument?<br>
+A: People have been using this for a long time:
+```
+interface IUser extends mongoose.Document {
+  ...
+}
+```
+When it should really be this:
+```
+interface IUser extends mongoose.model {
+  ...
+}
+```
+For backwards compatibility Document is an interface for [mongoose.model](https://github.com/Automattic/mongoose/blob/master/lib/model.js#L3162)<br>
+And MongooseDocument is an interface for [mongoose.Document](https://github.com/Automattic/mongoose/blob/master/lib/model.js#L3162)<br>
+At some point in the future this may get fixed, which would require fixing your code.

--- a/mongoose/README.md
+++ b/mongoose/README.md
@@ -2,6 +2,15 @@
 Below are some examples of how to use these Definitions.<br>
 Scenarios where the Typescript code is identical to plain Javascript code are omitted.
 
+### Table of Contents
+* [Mongoose Methods, Properties, Constructors](#mongoose-methods-properties-constructors)
+* [Creating and Saving Documents](#creating-and-saving-documents)
+* [Instance Methods, Virtual Properties](#instance-methods-and-virtual-properties)
+* [Static Methods](#static-methods)
+* [Plugins](#plugins)
+* [Promises](#promises)
+* [FAQ](#faq)
+
 #### Mongoose Methods, Properties, Constructors
 You can call methods from the mongoose instance using:
 ```

--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -1355,9 +1355,19 @@ interface MyModel extends mongoose.Model<MyDocument> {
   staticMethod: () => void;
 }
 interface ModelStruct {
-  doc: MyDocument,
-  model: MyModel
+  doc: MyDocument;
+  model: MyModel;
+  method1: (callback: (model: MyModel, doc: MyDocument) => void) => MyModel;
 }
+var modelStruct1: ModelStruct;
+var myModel1: MyModel;
+var myDocument1: MyDocument;
+modelStruct1.method1(function (myModel1, myDocument1) {
+  myModel1.staticProp;
+  myModel1.staticMethod();
+  myDocument1.prop;
+  myDocument1.method();
+}).staticProp.toLowerCase();
 var mySchema = new mongoose.Schema({});
 export var Final: MyModel = <MyModel>mongoose.connection.model<MyDocument>('Final', mySchema);
 Final.findOne(function (err: any, doc: MyDocument) {

--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -52,7 +52,7 @@ mongoose.model('Actor', new mongoose.Schema({
 }), 'collectionName', true).find({});
 mongoose.model('Actor').find({});
 mongoose.modelNames()[0].toLowerCase();
-new (new mongoose.Mongoose()).Mongoose().connect('');
+new (new mongoose.Mongoose(9, 8, 7)).Mongoose(1, 2, 3).connect('');
 mongoose.plugin(cb, {}).connect('');
 mongoose.set('test', 'value');
 mongoose.set('debug', function(collectionName: any, methodName: any, arg1: any, arg2: any) {});
@@ -136,7 +136,6 @@ conn1.model('myModel', new mongoose.Schema({}), 'myCol').find();
 interface IStatics {
   staticMethod1: (a: number) => string;
 }
-conn1.model<{}, IStatics>('').staticMethod1;
 conn1.modelNames()[0].toLowerCase();
 conn1.config.hasOwnProperty('');
 conn1.db.bufferMaxEntries;
@@ -350,7 +349,7 @@ new mongoose.Schema({
  * section document.js
  * http://mongoosejs.com/docs/api.html#document-js
  */
-var doc: mongoose.Document;
+var doc: mongoose.MongooseDocument;
 doc.$isDefault('path').valueOf();
 doc.depopulate('path');
 doc.equals(doc).valueOf();
@@ -465,7 +464,7 @@ mongooseArray.length;
  * http://mongoosejs.com/docs/api.html#types-documentarray-js
  */
 // The constructor is private api, but we'll use it to test
-var documentArray: mongoose.Types.DocumentArray<mongoose.Document> =
+var documentArray: mongoose.Types.DocumentArray<mongoose.MongooseDocument> =
   new mongoose.Types.DocumentArray();
 documentArray.create({}).errors;
 documentArray.id(new Buffer('hi'));
@@ -500,7 +499,7 @@ var objectId: mongoose.Types.ObjectId = mongoose.Types.ObjectId.createFromHexStr
 objectId = new mongoose.Types.ObjectId(12345);
 objectId.getTimestamp();
 /* practical examples */
-export interface IManagerSchema extends mongoose.Document {
+export interface IManagerSchema extends mongoose.MongooseDocument {
   user: mongoose.Schema.Types.ObjectId;
 }
 export var ManagerSchema = new mongoose.Schema({
@@ -530,7 +529,7 @@ embeddedDocument.execPopulate();
  * section query.js
  * http://mongoosejs.com/docs/api.html#query-js
  */
-var query: mongoose.Query<mongoose.Document[]>;
+var query: mongoose.Query<mongoose.MongooseDocument[]>;
 query.$where('').$where(cb);
 query.all(99).all('path', 99);
 query.and([{ color: 'green' }, { status: 'ok' }]).and([]);
@@ -761,8 +760,9 @@ schemaArray.sparse(true);
  * section schema/string.js
  * http://mongoosejs.com/docs/api.html#schema-string-js
  */
+var MongoDocument: mongoose.Document;
 var schemastring: mongoose.Schema.Types.String = new mongoose.Schema.Types.String('hello');
-schemastring.checkRequired(234, new mongoose.Document()).valueOf();
+schemastring.checkRequired(234, MongoDocument).valueOf();
 schemastring.enum(['hi', 'a', 'b']).enum('hi').enum({});
 schemastring.lowercase().lowercase();
 schemastring.match(/re/, 'error').match(/re/);
@@ -790,7 +790,7 @@ documentarray.sparse(true);
  * http://mongoosejs.com/docs/api.html#schema-number-js
  */
 var schemanumber: mongoose.Schema.Types.Number = new mongoose.Schema.Types.Number('num', {});
-schemanumber.checkRequired(999, new mongoose.Document()).valueOf();
+schemanumber.checkRequired(999, MongoDocument).valueOf();
 schemanumber.max(999, 'error').max(999);
 schemanumber.min(999, 'error').min(999);
 /* static properties */
@@ -803,7 +803,7 @@ schemanumber.sparse(true);
  * http://mongoosejs.com/docs/api.html#schema-date-js
  */
 var schemadate: mongoose.Schema.Types.Date = new mongoose.Schema.Types.Date('99');
-schemadate.checkRequired([], new mongoose.Document()).valueOf();
+schemadate.checkRequired([], MongoDocument).valueOf();
 schemadate.expires(99).expires('now');
 schemadate.max(new Date(), 'error').max(new Date(''));
 schemadate.min(new Date(), 'error').min(new Date(''));
@@ -817,7 +817,7 @@ schemadate.sparse(true);
  * http://mongoosejs.com/docs/api.html#schema-buffer-js
  */
 var schemabuffer: mongoose.Schema.Types.Buffer = new mongoose.Schema.Types.Buffer('99');
-schemabuffer.checkRequired(999, new mongoose.Document()).valueOf();
+schemabuffer.checkRequired(999, MongoDocument).valueOf();
 /* static properties */
 mongoose.Schema.Types.Buffer.schemaName.toLowerCase();
 /* inherited properties */
@@ -840,7 +840,7 @@ schemaboolean.sparse(true);
  */
 var schemaobjectid: mongoose.Schema.Types.ObjectId = new mongoose.Schema.Types.ObjectId('99');
 schemaobjectid.auto(true).auto(false);
-schemaobjectid.checkRequired(99, new mongoose.Document()).valueOf();
+schemaobjectid.checkRequired(99, MongoDocument).valueOf();
 /* static properties */
 mongoose.Schema.Types.ObjectId.schemaName.toLowerCase();
 /* inherited properties */
@@ -1078,7 +1078,7 @@ var MongoModel = mongoose.model('MongoModel', new mongoose.Schema({
     required: true
   }
 }), 'myCollection', true);
-MongoModel.$where('indexOf("val") !== -1').exec(function (err, docs) {
+MongoModel.find({}).$where('indexOf("val") !== -1').exec(function (err, docs) {
   docs[0].save();
 });
 MongoModel.findById(999, function (err, doc) {
@@ -1310,7 +1310,7 @@ LocModel.find()
       });
     });
   });
-LocModel.$where('')
+LocModel.find({}).$where('')
   .exec(function (err, locations) {
     locations[0].name;
     locations[1].openingTimes;
@@ -1346,10 +1346,22 @@ LocModel.geoSearch({}, {
 interface IStatics {
   staticMethod2: (a: number) => string;
 }
-var StaticModel = mongoose.model<Location, IStatics>('Location');
-StaticModel.staticMethod2(9).toUpperCase();
-(new StaticModel()).save(function (err, doc) {
-  doc.openingTimes;
-  doc.model<Location, IStatics>('').staticMethod2;
+interface MyDocument extends mongoose.Document {
+  prop: string;
+  method: () => void;
+}
+interface MyModel extends mongoose.Model<MyDocument> {
+  staticProp: string;
+  staticMethod: () => void;
+}
+interface ModelStruct {
+  doc: MyDocument,
+  model: MyModel
+}
+var mySchema = new mongoose.Schema({});
+export var Final: MyModel = <MyModel>mongoose.connection.model<MyDocument>('Final', mySchema);
+Final.findOne(function (err: any, doc: MyDocument) {
+  doc.save();
+  doc.remove();
+  doc.model<null>(null, null);
 });
-StaticModel.model<Location, IStatics>('').staticMethod2;

--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -1380,3 +1380,9 @@ Final.findOne(function (err: any, doc: MyDocument) {
   doc.remove();
   doc.model('');
 });
+export var Final2: MyModel = mongoose.model<MyDocument, MyModel>('Final2', mySchema);
+Final2.staticMethod();
+Final2.staticProp;
+var final2 = new Final2();
+final2.prop;
+final2.method;

--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -1249,6 +1249,10 @@ mongoModel.discriminators;
 mongoModel.modelName.toLowerCase();
 MongoModel = mongoModel.base.model('new', mongoModel.schema);
 /* inherited properties */
+MongoModel.modelName;
+mongoModel.modelName;
+MongoModel.collection;
+mongoModel.collection;
 mongoModel._id;
 mongoModel.execPopulate();
 mongoModel.on('data', cb);

--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -27,7 +27,7 @@ mongoose.connect(connectUri, {
     autoIndex: true
   },
   mongos: true
-}).then(cb).fulfill();
+}).then(cb);
 mongoose.connect(connectUri, function (error) {
   error.stack;
 });
@@ -45,7 +45,7 @@ mongoose.createConnection('localhost', 'database', 3000, {
     autoIndex: false
   }
 }).open('');
-mongoose.disconnect(cb).then(cb).fulfill;
+mongoose.disconnect(cb).then(cb);
 mongoose.get('test');
 mongoose.model('Actor', new mongoose.Schema({
   name: String
@@ -540,7 +540,7 @@ query.where('loc').within().box(lowerLeft, upperRight)
 query.box({ ll : lowerLeft, ur : upperRight }).box({});
 var queryModel = mongoose.model('QModel')
 query.cast(new queryModel(), {}).hasOwnProperty('');
-query.catch(function (err) {}).catch();
+query.catch(cb).catch(cb);
 query.center({}).center({});
 query.centerSphere({ center: [50, 50], radius: 10 }).centerSphere('path', {});
 query.circle({ center: [50, 50], radius: 10 }).circle('path');
@@ -695,7 +695,7 @@ query.stream().on('data', function (doc: any) {
 });
 query.tailable().tailable(false);
 query.then(cb).catch(cb);
-(new (query.toConstructor())()).toConstructor();
+(new (query.toConstructor())(1, 2, 3)).toConstructor();
 query.update({}, doc, {
 
 }, cb);
@@ -1060,12 +1060,13 @@ mongoose.model('').aggregate()
   });
 
 /* pluggable promise */
-mongoose.Promise = Promise;
+(<any>mongoose).Promise = Promise;
+require('mongoose').Promise = Promise;
 mongoose.Promise.race;
 mongoose.Promise.all;
 
 mongoose.model('').findOne()
-  .exec().addErrback(cb);
+  .exec().then(cb);
 
 /*
  * section model.js
@@ -1377,5 +1378,5 @@ export var Final: MyModel = <MyModel>mongoose.connection.model<MyDocument>('Fina
 Final.findOne(function (err: any, doc: MyDocument) {
   doc.save();
   doc.remove();
-  doc.model<null>(null, null);
+  doc.model('');
 });

--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -1081,6 +1081,7 @@ var MongoModel = mongoose.model('MongoModel', new mongoose.Schema({
 }), 'myCollection', true);
 MongoModel.find({}).$where('indexOf("val") !== -1').exec(function (err, docs) {
   docs[0].save();
+  docs[0].__v;
 });
 MongoModel.findById(999, function (err, doc) {
   doc.increment();

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -2303,13 +2303,13 @@ declare module "mongoose" {
      * Returns another Model instance.
      * @param name model name
      */
-    model<T extends Document>(name: string): Model<T>;
+    model(name: string): Model<this>;
 
     /**
      * Removes this document from the db.
      * @param fn optional callback
      */
-    remove<T extends Document>(fn?: (err: any, product: T) => void): _MongoosePromise<T>;
+    remove(fn?: (err: any, product: this) => void): _MongoosePromise<this>;
 
     /**
      * Saves this document.
@@ -2318,7 +2318,7 @@ declare module "mongoose" {
      * @param options.validateBeforeSave set to false to save without validating.
      * @param fn optional callback
      */
-    save<T extends Document>(fn?: (err: any, product: T, numAffected: number) => void): _MongoosePromise<T>;
+    save(fn?: (err: any, product: this, numAffected: number) => void): _MongoosePromise<this>;
 
     /** Base Mongoose instance the model uses. */
     base: typeof mongoose;

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -27,43 +27,43 @@
  *   is just a simple heuristic to keep track of our progress.
  *
  * TODO for version 4.x [updated][tested]:
- * [x][ ] index.js
- * [x][ ] querystream.js
- * [x][ ] connection.js
- * [x][ ] utils.js
- * [x][ ] browser.js
- * [x][ ] drivers/node-mongodb-native/collection.js
- * [x][ ] drivers/node-mongodb-native/connection.js
- * [x][ ] error/messages.js
- * [x][ ] error/validation.js
- * [x][ ] error.js
- * [x][ ] querycursor.js
- * [x][ ] virtualtype.js
- * [x][ ] schema.js
- * [x][ ] document.js
- * [x][ ] types/subdocument.js
- * [x][ ] types/array.js
- * [x][ ] types/documentarray.js
- * [x][ ] types/buffer.js
- * [x][ ] types/objectid.js
- * [x][ ] types/embedded.js
- * [x][ ] query.js
- * [x][ ] schema/array.js
- * [x][ ] schema/string.js
- * [x][ ] schema/documentarray.js
- * [x][ ] schema/number.js
- * [x][ ] schema/date.js
- * [x][ ] schema/buffer.js
- * [x][ ] schema/boolean.js
- * [x][ ] schema/objectid.js
- * [x][ ] schema/mixed.js
- * [x][ ] schema/embedded.js
- * [x][ ] aggregate.js
- * [x][ ] schematype.js
- * [x][ ] promise.js
- * [x][ ] ES6Promise.js
- * [x][ ] model.js
- * [x][ ] collection.js
+ * [x][x] index.js
+ * [x][x] querystream.js
+ * [x][x] connection.js
+ * [x][x] utils.js
+ * [x][x] browser.js
+ * [x][x] drivers/node-mongodb-native/collection.js
+ * [x][x] drivers/node-mongodb-native/connection.js
+ * [x][x] error/messages.js
+ * [x][x] error/validation.js
+ * [x][x] error.js
+ * [x][x] querycursor.js
+ * [x][x] virtualtype.js
+ * [x][x] schema.js
+ * [x][x] document.js
+ * [x][x] types/subdocument.js
+ * [x][x] types/array.js
+ * [x][x] types/documentarray.js
+ * [x][x] types/buffer.js
+ * [x][x] types/objectid.js
+ * [x][x] types/embedded.js
+ * [x][x] query.js
+ * [x][x] schema/array.js
+ * [x][x] schema/string.js
+ * [x][x] schema/documentarray.js
+ * [x][x] schema/number.js
+ * [x][x] schema/date.js
+ * [x][x] schema/buffer.js
+ * [x][x] schema/boolean.js
+ * [x][x] schema/objectid.js
+ * [x][x] schema/mixed.js
+ * [x][x] schema/embedded.js
+ * [x][x] aggregate.js
+ * [x][x] schematype.js
+ * [x][x] promise.js
+ * [x][x] ES6Promise.js
+ * [x][x] model.js
+ * [x][x] collection.js
  */
 
 /*
@@ -1124,13 +1124,13 @@ declare module "mongoose" {
    * section query.js
    * http://mongoosejs.com/docs/api.html#query-js
    */
-  class Query<T> extends ModelQuery<T, any> {}
+  class Query<T> extends DocumentQuery<T, any> {}
 
   /*
    * Query.find() will return Query<Model<T>[]> however we need the
    * type T to create this so we save T in another parameter.
    */
-  class ModelQuery<T, ModelType extends Document> extends mquery {
+  class DocumentQuery<T, DocType extends Document> extends mquery {
     /**
      * Specifies a javascript function or expression to pass to MongoDBs query system.
      * Only use $where when you have a condition that cannot be met using other MongoDB
@@ -1205,7 +1205,7 @@ declare module "mongoose" {
      * Returns a wrapper around a mongodb driver cursor. A Query<T>Cursor exposes a
      * Streams3-compatible interface, as well as a .next() function.
      */
-    cursor(options?: Object): QueryCursor<ModelType>;
+    cursor(options?: Object): QueryCursor<DocType>;
 
     /** Declares or executes a distict() operation. Passing a callback executes the query. */
     distinct(callback?: (err: any, res: any[]) => void): Query<any[]>;
@@ -1235,9 +1235,9 @@ declare module "mongoose" {
      * query is executed, the result will be an array of documents.
      * @param criteria mongodb selector
      */
-    find(callback?: (err: any, res: ModelType[]) => void): ModelQuery<ModelType[], ModelType>;
+    find(callback?: (err: any, res: DocType[]) => void): DocumentQuery<DocType[], DocType>;
     find(criteria: Object,
-      callback?: (err: any, res: ModelType[]) => void): ModelQuery<ModelType[], ModelType>;
+      callback?: (err: any, res: DocType[]) => void): DocumentQuery<DocType[], DocType>;
 
     /**
      * Declares the query a findOne operation. When executed, the first found document is
@@ -1246,33 +1246,33 @@ declare module "mongoose" {
      * @param criteria mongodb selector
      * @param projection optional fields to return
      */
-    findOne(callback?: (err: any, res: ModelType) => void): ModelQuery<ModelType, ModelType>;
+    findOne(callback?: (err: any, res: DocType) => void): DocumentQuery<DocType, DocType>;
     findOne(criteria: Object,
-      callback?: (err: any, res: ModelType) => void): ModelQuery<ModelType, ModelType>;
+      callback?: (err: any, res: DocType) => void): DocumentQuery<DocType, DocType>;
 
     /**
      * Issues a mongodb findAndModify remove command.
      * Finds a matching document, removes it, passing the found document (if any) to the
      * callback. Executes immediately if callback is passed.
      */
-    findOneAndRemove(callback?: (error: any, doc: ModelType, result: any) => void): ModelQuery<ModelType, ModelType>;
+    findOneAndRemove(callback?: (error: any, doc: DocType, result: any) => void): DocumentQuery<DocType, DocType>;
     findOneAndRemove(conditions: Object,
-      callback?: (error: any, doc: ModelType, result: any) => void): ModelQuery<ModelType, ModelType>;
+      callback?: (error: any, doc: DocType, result: any) => void): DocumentQuery<DocType, DocType>;
     findOneAndRemove(conditions: Object, options: QueryFindOneAndRemoveOptions,
-      callback?: (error: any, doc: ModelType, result: any) => void): ModelQuery<ModelType, ModelType>;
+      callback?: (error: any, doc: DocType, result: any) => void): DocumentQuery<DocType, DocType>;
 
     /**
      * Issues a mongodb findAndModify update command.
      * Finds a matching document, updates it according to the update arg, passing any options, and returns
      * the found document (if any) to the callback. The query executes immediately if callback is passed.
      */
-    findOneAndUpdate(callback?: (err: any, doc: ModelType) => void): ModelQuery<ModelType, ModelType>;
+    findOneAndUpdate(callback?: (err: any, doc: DocType) => void): DocumentQuery<DocType, DocType>;
     findOneAndUpdate(update: Object,
-      callback?: (err: any, doc: ModelType) => void): ModelQuery<ModelType, ModelType>;
+      callback?: (err: any, doc: DocType) => void): DocumentQuery<DocType, DocType>;
     findOneAndUpdate(query: Object | Query<any>, update: Object,
-      callback?: (err: any, doc: ModelType) => void): ModelQuery<ModelType, ModelType>;
+      callback?: (err: any, doc: DocType) => void): DocumentQuery<DocType, DocType>;
     findOneAndUpdate(query: Object | Query<any>, update: Object, options: QueryFindOneAndUpdateOptions,
-      callback?: (err: any, doc: ModelType) => void): ModelQuery<ModelType, ModelType>;
+      callback?: (err: any, doc: DocType) => void): DocumentQuery<DocType, DocType>;
 
     /**
      * Specifies a $geometry condition. geometry() must come after either intersects() or within().
@@ -1521,7 +1521,7 @@ declare module "mongoose" {
      * Converts this query to a customized, reusable query
      * constructor with all arguments and options retained.
      */
-    toConstructor(): typeof ModelQuery;
+    toConstructor(): typeof DocumentQuery;
 
     /**
      * Declare and/or execute this query as an update() operation.
@@ -2066,11 +2066,11 @@ declare module "mongoose" {
      * @param projection optional fields to return
      */
     findById(id: Object | string | number,
-      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+      callback?: (err: any, res: T) => void): DocumentQuery<T, T>;
     findById(id: Object | string | number, projection: Object,
-      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+      callback?: (err: any, res: T) => void): DocumentQuery<T, T>;
     findById(id: Object | string | number, projection: Object, options: Object,
-      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+      callback?: (err: any, res: T) => void): DocumentQuery<T, T>;
 
     model<T extends Document>(name: string): Model<T>;
 
@@ -2078,7 +2078,7 @@ declare module "mongoose" {
      * Creates a Query and specifies a $where condition.
      * @param argument is a javascript string or anonymous function
      */
-    $where(argument: string | Function): ModelQuery<T, T>;
+    $where(argument: string | Function): DocumentQuery<T, T>;
 
     /**
      * Performs aggregations on the models collection.
@@ -2125,12 +2125,12 @@ declare module "mongoose" {
      * Finds documents.
      * @param projection optional fields to return
      */
-    find(callback?: (err: any, res: T[]) => void): ModelQuery<T[], T>;
-    find(conditions: Object, callback?: (err: any, res: T[]) => void): ModelQuery<T[], T>;
+    find(callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T>;
+    find(conditions: Object, callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T>;
     find(conditions: Object, projection: Object,
-      callback?: (err: any, res: T[]) => void): ModelQuery<T[], T>;
+      callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T>;
     find(conditions: Object, projection: Object, options: Object,
-      callback?: (err: any, res: T[]) => void): ModelQuery<T[], T>;
+      callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T>;
 
 
 
@@ -2141,27 +2141,27 @@ declare module "mongoose" {
      * Executes immediately if callback is passed, else a Query object is returned.
      * @param id value of _id to query by
      */
-    findByIdAndRemove(): ModelQuery<T, T>;
+    findByIdAndRemove(): DocumentQuery<T, T>;
     findByIdAndRemove(id: Object | number | string,
-      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+      callback?: (err: any, res: T) => void): DocumentQuery<T, T>;
     findByIdAndRemove(id: Object | number | string, options: {
       /** if multiple docs are found by the conditions, sets the sort order to choose which doc to update */
       sort?: Object;
       /** sets the document fields to return */
       select?: Object;
-    }, callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+    }, callback?: (err: any, res: T) => void): DocumentQuery<T, T>;
 
     /**
      * Issues a mongodb findAndModify update command by a document's _id field. findByIdAndUpdate(id, ...)
      * is equivalent to findOneAndUpdate({ _id: id }, ...).
      * @param id value of _id to query by
      */
-    findByIdAndUpdate(): ModelQuery<T, T>;
+    findByIdAndUpdate(): DocumentQuery<T, T>;
     findByIdAndUpdate(id: Object | number | string, update: Object,
-      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+      callback?: (err: any, res: T) => void): DocumentQuery<T, T>;
     findByIdAndUpdate(id: Object | number | string, update: Object,
       options: ModelFindByIdAndUpdateOptions,
-      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+      callback?: (err: any, res: T) => void): DocumentQuery<T, T>;
 
     /**
      * Finds one document.
@@ -2169,20 +2169,20 @@ declare module "mongoose" {
      * @param projection optional fields to return
      */
     findOne(conditions?: Object,
-      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+      callback?: (err: any, res: T) => void): DocumentQuery<T, T>;
     findOne(conditions: Object, projection: Object,
-      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+      callback?: (err: any, res: T) => void): DocumentQuery<T, T>;
     findOne(conditions: Object, projection: Object, options: Object,
-      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+      callback?: (err: any, res: T) => void): DocumentQuery<T, T>;
 
     /**
      * Issue a mongodb findAndModify remove command.
      * Finds a matching document, removes it, passing the found document (if any) to the callback.
      * Executes immediately if callback is passed else a Query object is returned.
      */
-    findOneAndRemove(): ModelQuery<T, T>;
+    findOneAndRemove(): DocumentQuery<T, T>;
     findOneAndRemove(conditions: Object,
-      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+      callback?: (err: any, res: T) => void): DocumentQuery<T, T>;
     findOneAndRemove(conditions: Object, options: {
       /**
        * if multiple docs are found by the conditions, sets the sort order to choose
@@ -2193,7 +2193,7 @@ declare module "mongoose" {
       maxTimeMS?: number;
       /** sets the document fields to return */
       select?: Object;
-    }, callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+    }, callback?: (err: any, res: T) => void): DocumentQuery<T, T>;
 
     /**
      * Issues a mongodb findAndModify update command.
@@ -2201,12 +2201,12 @@ declare module "mongoose" {
      * and returns the found document (if any) to the callback. The query executes immediately
      * if callback is passed else a Query object is returned.
      */
-    findOneAndUpdate(): ModelQuery<T, T>;
+    findOneAndUpdate(): DocumentQuery<T, T>;
     findOneAndUpdate(conditions: Object, update: Object,
-      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+      callback?: (err: any, res: T) => void): DocumentQuery<T, T>;
     findOneAndUpdate(conditions: Object, update: Object,
       options: ModelFindOneAndUpdateOptions,
-      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+      callback?: (err: any, res: T) => void): DocumentQuery<T, T>;
 
     /**
      * geoNear support for Mongoose
@@ -2221,7 +2221,7 @@ declare module "mongoose" {
       /** return the raw object */
       lean?: boolean;
       [other: string]: any;
-    }, callback?: (err: any, res: T[], stats: any) => void): ModelQuery<T[], T>;
+    }, callback?: (err: any, res: T[], stats: any) => void): DocumentQuery<T[], T>;
 
     /**
      * Implements $geoSearch functionality for Mongoose
@@ -2238,7 +2238,7 @@ declare module "mongoose" {
       limit?: number;
       /** return the raw object instead of the Mongoose Model */
       lean?: boolean;
-    }, callback?: (err: any, res: T[]) => void): ModelQuery<T[], T>;
+    }, callback?: (err: any, res: T[]) => void): DocumentQuery<T[], T>;
 
     /**
      * Shortcut for creating a new Document from existing raw data,

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -2332,6 +2332,12 @@ declare module "mongoose" {
      * @param fn optional callback
      */
     save(fn?: (err: any, product: this, numAffected: number) => void): Promise<this>;
+
+    /**
+     * Version using default version key. See http://mongoosejs.com/docs/guide.html#versionKey
+     * If you're using another key, you will have to access it using []: doc[_myVersionKey]
+     */
+    __v?: number;
   }
 
   interface ModelProperties {

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Mongoose 4.5.4
+// Type definitions for Mongoose 4.5.9
 // Project: http://mongoosejs.com/
 // Definitions by: simonxca <https://github.com/simonxca/>, horiuchi <https://github.com/horiuchi/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -6,7 +6,6 @@
 ///<reference path="../mongodb/mongodb.d.ts" />
 ///<reference path="../mpromise/mpromise.d.ts" />
 ///<reference path="../node/node.d.ts" />
-///<reference path="../mongoose-promise/mongoose-promise.d.ts" />
 
 /*
  * Guidelines for maintaining these definitions:
@@ -93,7 +92,6 @@ declare module "mongoose" {
    * http://mongoosejs.com/docs/api.html#index-js
    */
   export var DocumentProvider: any;
-  export var Model: Model<any>;
   // recursive constructor
   export var Mongoose: new(...args: any[]) => typeof mongoose;
   export var SchemaTypes: typeof Schema.Types;
@@ -107,7 +105,6 @@ declare module "mongoose" {
   /** The Mongoose version */
   export var version: string;
 
-  /* Methods */
   /**
    * Opens the default mongoose connection.
    * Options passed take precedence over options included in connection strings.
@@ -173,20 +170,19 @@ declare module "mongoose" {
   /** Sets mongoose options */
   export function set(key: string, value: any): void;
 
-  type MongooseThenable = typeof mongoose & _MongooseThenable;
-  interface _MongooseThenable {
+  type MongooseThenable = typeof mongoose & {
     /**
      * Ability to use mongoose object as a pseudo-promise so .connect().then()
      * and .disconnect().then() are viable.
      */
     then<TRes>(onFulfill?: () => void | TRes | PromiseLike<TRes>,
-      onRejected?: (err: mongodb.MongoError) => void | TRes | PromiseLike<TRes>): _MongoosePromise<TRes>;
+      onRejected?: (err: mongodb.MongoError) => void | TRes | PromiseLike<TRes>): Promise<TRes>;
 
     /**
      * Ability to use mongoose object as a pseudo-promise so .connect().then()
      * and .disconnect().then() are viable.
      */
-    catch<TRes>(onRejected?: (err: mongodb.MongoError) => void | TRes | PromiseLike<TRes>): _MongoosePromise<TRes>;
+    catch<TRes>(onRejected?: (err: mongodb.MongoError) => void | TRes | PromiseLike<TRes>): Promise<TRes>;
   }
 
   class CastError extends Error {
@@ -205,7 +201,7 @@ declare module "mongoose" {
    * http://mongoosejs.com/docs/api.html#querystream-js
    *
    * QueryStream can only be accessed using query#stream(), we only
-   *   expose its interface here to enable type-checking.
+   *   expose its interface here.
    */
   interface QueryStream extends stream.Stream {
     /**
@@ -293,7 +289,7 @@ declare module "mongoose" {
       callback?: (err: any) => void): any;
 
     /** Closes the connection */
-    close(callback?: (err: any) => void): _MongoosePromise<void>;
+    close(callback?: (err: any) => void): Promise<void>;
 
     /**
      * Retrieves a collection, creating it if not cached.
@@ -375,6 +371,10 @@ declare module "mongoose" {
     mongos?: boolean;
   }
 
+  interface ConnectOptions extends
+    ConnectionOpenOptions,
+    ConnectionOpenSetOptions {}
+
   /*
    * section drivers/node-mongodb-native/collection.js
    * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-collection-js
@@ -411,8 +411,6 @@ declare module "mongoose" {
     /** Expose the possible connection states. */
     static STATES: Object;
   }
-
-  interface ConnectOptions extends ConnectionOpenOptions, ConnectionOpenSetOptions {}
 
   /*
    * section error/validation.js
@@ -474,7 +472,7 @@ declare module "mongoose" {
     constructor(query: Query<T>, options: Object): QueryCursor<T>;
 
     /** Marks this cursor as closed. Will stop streaming and subsequent calls to next() will error. */
-    close(callback?: (error: any, result: any) => void): _MongoosePromise<any>;
+    close(callback?: (error: any, result: any) => void): Promise<any>;
 
     /**
      * Execute fn for every document in the cursor. If fn returns a promise,
@@ -482,13 +480,13 @@ declare module "mongoose" {
      * Returns a promise that resolves when done.
      * @param callback executed when all docs have been processed
      */
-    eachAsync(fn: (doc: T) => any, callback?: (err: any) => void): _MongoosePromise<T>;
+    eachAsync(fn: (doc: T) => any, callback?: (err: any) => void): Promise<T>;
 
     /**
      * Get the next document from this cursor. Will return null when there are
      * no documents left.
      */
-    next(callback?: (err: any) => void): _MongoosePromise<any>;
+    next(callback?: (err: any) => void): Promise<any>;
   }
 
   /*
@@ -729,7 +727,7 @@ declare module "mongoose" {
      * Useful for ES2015 integration.
      * @returns promise that resolves to the document when population is done
      */
-    execPopulate(): _MongoosePromise<this>;
+    execPopulate(): Promise<this>;
 
     /**
      * Returns the value of a path.
@@ -848,8 +846,8 @@ declare module "mongoose" {
      * @param optional options internal options
      * @param callback callback called after validation completes, passing an error if one occurred
      */
-    validate(callback?: (err: any) => void): _MongoosePromise<void>;
-    validate(optional: Object, callback?: (err: any) => void): _MongoosePromise<void>;
+    validate(callback?: (err: any) => void): Promise<void>;
+    validate(optional: Object, callback?: (err: any) => void): Promise<void>;
 
     /**
      * Executes registered validation rules (skipping asynchronous validators) for this document.
@@ -915,9 +913,9 @@ declare module "mongoose" {
     }
 
     /*
-      * section types/array.js
-      * http://mongoosejs.com/docs/api.html#types-array-js
-      */
+     * section types/array.js
+     * http://mongoosejs.com/docs/api.html#types-array-js
+     */
     class Array<T> extends global.Array {
       /**
        * Atomically shifts the array at most one time per document save().
@@ -1053,9 +1051,9 @@ declare module "mongoose" {
     }
 
     /*
-      * section types/buffer.js
-      * http://mongoosejs.com/docs/api.html#types-buffer-js
-      */
+     * section types/buffer.js
+     * http://mongoosejs.com/docs/api.html#types-buffer-js
+     */
     class Buffer extends global.Buffer {
       /**
        * Copies the buffer.
@@ -1082,8 +1080,7 @@ declare module "mongoose" {
       * section types/objectid.js
       * http://mongoosejs.com/docs/api.html#types-objectid-js
       */
-    var ObjectId: typeof mongodb.ObjectID;
-    interface ObjectId extends mongodb.ObjectID {}
+    class ObjectId extends mongodb.ObjectID {}
 
     /*
       * section types/embedded.js
@@ -1123,13 +1120,13 @@ declare module "mongoose" {
   /*
    * section query.js
    * http://mongoosejs.com/docs/api.html#query-js
+   *
+   * Query<T> is for backwards compatibility. Example: Query<T>.find() returns Query<T[]>.
+   * If later in the query chain a method returns Query<T>, we will need to know type T.
+   * So we save this type as the second type parameter in DocumentQuery. Since people have
+   * been using Query<T>, we set it as an alias of DocumentQuery.
    */
   class Query<T> extends DocumentQuery<T, any> {}
-
-  /*
-   * Query.find() will return Query<Model<T>[]> however we need the
-   * type T to create this so we save T in another parameter.
-   */
   class DocumentQuery<T, DocType extends Document> extends mquery {
     /**
      * Specifies a javascript function or expression to pass to MongoDBs query system.
@@ -1170,7 +1167,7 @@ declare module "mongoose" {
      * resolved with either the doc(s) or rejected with the error.
      * Like .then(), but only takes a rejection handler.
      */
-    catch<TRes>(reject?: (err: any) => void | TRes | PromiseLike<TRes>): _MongoosePromise<TRes>;
+    catch<TRes>(reject?: (err: any) => void | TRes | PromiseLike<TRes>): Promise<TRes>;
 
     /**
      * DEPRECATED Alias for circle
@@ -1223,8 +1220,8 @@ declare module "mongoose" {
     equals(val: Object): this;
 
     /** Executes the query */
-    exec(callback?: (err: any, res: T) => void): _MongoosePromise<T>;
-    exec(operation: string | Function, callback?: (err: any, res: T) => void): _MongoosePromise<T>;
+    exec(callback?: (err: any, res: T) => void): Promise<T>;
+    exec(operation: string | Function, callback?: (err: any, res: T) => void): Promise<T>;
 
     /** Specifies an $exists condition */
     exists(val?: boolean): this;
@@ -1515,13 +1512,14 @@ declare module "mongoose" {
 
     /** Executes this query and returns a promise */
     then<TRes>(resolve?: (res: T) => void | TRes | PromiseLike<TRes>,
-      reject?: (err: any) =>  void | TRes | PromiseLike<TRes>): _MongoosePromise<TRes>;
+      reject?: (err: any) =>  void | TRes | PromiseLike<TRes>): Promise<TRes>;
 
     /**
      * Converts this query to a customized, reusable query
      * constructor with all arguments and options retained.
      */
-    toConstructor(): typeof DocumentQuery;
+    toConstructor<T>(): new(...args: any[]) => Query<T>;
+    toConstructor<T, Doc extends Document>(): new(...args: any[]) => DocumentQuery<T, Doc>;
 
     /**
      * Declare and/or execute this query as an update() operation.
@@ -1858,10 +1856,10 @@ declare module "mongoose" {
 
     // If cursor option is on, could return an object
     /** Executes the aggregate pipeline on the currently bound Model. */
-    exec(callback?: (err: any, result: T) => void): _MongoosePromise<T> | any;
+    exec(callback?: (err: any, result: T) => void): Promise<T> | any;
 
     /** Execute the aggregation with explain */
-    explain(callback?: (err: any, result: T) => void): _MongoosePromise<T>;
+    explain(callback?: (err: any, result: T) => void): Promise<T>;
 
     /**
      * Appends a new custom $group operator to this aggregate pipeline.
@@ -1936,7 +1934,7 @@ declare module "mongoose" {
 
     /** Provides promise for aggregate. */
     then<TRes>(resolve?: (val: T) =>  void | TRes | PromiseLike<TRes>,
-      reject?: (err: any) =>  void | TRes | PromiseLike<TRes>): _MongoosePromise<TRes>
+      reject?: (err: any) =>  void | TRes | PromiseLike<TRes>): Promise<TRes>
 
     /**
      * Appends new custom $unwind operator(s) to this aggregate pipeline.
@@ -2004,34 +2002,37 @@ declare module "mongoose" {
       type?: string): this;
   }
 
-  /**
+  /*
    * section promise.js
    * http://mongoosejs.com/docs/api.html#promise-js
-   *
-   * You must assign a promise library:
-   *
-   * 1. To use mongoose's default promise library:
-   *    Install mongoose-promise.d.ts
-   *
-   * 2. To use native ES6 promises, add this line to your main .d.ts file:
-   *    type MongoosePromise<T> = Promise<T>;
-   *
-   * 3. To use another promise library (for example q):
-   *    Install q.d.ts
-   *    Then add this line to your main .d.ts file:
-   *    type MongoosePromise<T> = Q.Promise<T>;
    */
-  interface _MongoosePromise<T> extends MongoosePromise<T> {}
-  interface Promise<T> extends MongoosePromise<T> {}
-
   /**
    * To assign your own promise library:
    *
-   * 1. Include this somewhere in your code:
-   *    mongoose.Promise = YOUR_PROMISE;
+   * 1. Typescript does not allow assigning properties of imported modules.
+   *    To avoid compile errors use one of the options below in your code:
    *
-   * 2. Include this somewhere in your main .d.ts file:
-   *    type MongoosePromise<T> = YOUR_PROMISE<T>;
+   *    - (<any>mongoose).Promise = YOUR_PROMISE;
+   *    - require('mongoose').Promise = YOUR_PROMISE;
+   *    - import mongoose = require('mongoose');
+   *      mongoose.Promise = YOUR_PROMISE;
+   *
+   * 2. To assign type definitions for your promise library, you will need
+   *    to have a .d.ts file with the following code when you compile:
+   *
+   *    - import * as Q from 'q';
+   *      declare module 'mongoose' {
+   *        type Promise<T> = Q.promise<T>;
+   *      }
+   *
+   *    - import * as Bluebird from 'bluebird';
+   *      declare module 'mongoose' {
+   *        type Promise<T> = Bluebird<T>;
+   *      }
+   *
+   * Uses global.Promise by default. If you would like to use mongoose default
+   *   mpromise implementation (which is deprecated), you can omit step 1 and
+   *   run npm install @types/mongoose-promise
    */
   export var Promise: any;
   export var PromiseProvider: any;
@@ -2040,6 +2041,7 @@ declare module "mongoose" {
    * section model.js
    * http://mongoosejs.com/docs/api.html#model-js
    */
+  export var Model: Model<any>;
   interface Model<T extends Document> extends NodeJS.EventEmitter, ModelProperties {
     /**
      * Model constructor
@@ -2087,7 +2089,7 @@ declare module "mongoose" {
      * @param ... aggregation pipeline operator(s) or operator array
      */
     aggregate(...aggregations: Object[]): Aggregate<Object[]>;
-    aggregate(...aggregationsWithCallback: Object[]): _MongoosePromise<Object[]>;
+    aggregate(...aggregationsWithCallback: Object[]): Promise<Object[]>;
 
     /** Counts number of matching documents in a database collection. */
     count(conditions: Object, callback?: (err: any, count: number) => void): Query<number>;
@@ -2097,9 +2099,9 @@ declare module "mongoose" {
      * does new MyModel(doc).save() for every doc in docs.
      * Triggers the save() hook.
      */
-    create(docs: any[], callback?: (err: any, res: T[]) => void): _MongoosePromise<T[]>;
-    create(...docs: Object[]): _MongoosePromise<T>;
-    create(...docsWithCallback: Object[]): _MongoosePromise<T>;
+    create(docs: any[], callback?: (err: any, res: T[]) => void): Promise<T[]>;
+    create(...docs: Object[]): Promise<T>;
+    create(...docsWithCallback: Object[]): Promise<T>;
 
     /**
      * Adds a discriminator type.
@@ -2118,8 +2120,8 @@ declare module "mongoose" {
      * @param options internal options
      * @param cb optional callback
      */
-    ensureIndexes(callback?: (err: any) => void): _MongoosePromise<void>;
-    ensureIndexes(options: Object, callback?: (err: any) => void): _MongoosePromise<void>;
+    ensureIndexes(callback?: (err: any) => void): Promise<void>;
+    ensureIndexes(options: Object, callback?: (err: any) => void): Promise<void>;
 
     /**
      * Finds documents.
@@ -2254,9 +2256,9 @@ declare module "mongoose" {
      * document.
      * This function does not trigger save middleware.
      */
-    insertMany(docs: any[], callback?: (error: any, docs: T[]) => void): _MongoosePromise<T[]>;
-    insertMany(doc: any, callback?: (error: any, doc: T) => void): _MongoosePromise<T>;
-    insertMany(...docsWithCallback: Object[]): _MongoosePromise<T>;
+    insertMany(docs: any[], callback?: (error: any, docs: T[]) => void): Promise<T[]>;
+    insertMany(doc: any, callback?: (error: any, doc: T) => void): Promise<T>;
+    insertMany(...docsWithCallback: Object[]): Promise<T>;
 
     /**
      * Executes a mapReduce command.
@@ -2266,7 +2268,7 @@ declare module "mongoose" {
     mapReduce<Key, Value>(
       o: ModelMapReduceOption<T, Key, Value>,
       callback?: (err: any, res: any) => void
-    ): _MongoosePromise<any>;
+    ): Promise<any>;
 
     /**
      * Populates document references.
@@ -2275,9 +2277,9 @@ declare module "mongoose" {
      * @param callback Optional callback, executed upon completion. Receives err and the doc(s).
      */
     populate(docs: Object[], options: ModelPopulateOptions | ModelPopulateOptions[],
-      callback?: (err: any, res: T[]) => void): _MongoosePromise<T[]>;
+      callback?: (err: any, res: T[]) => void): Promise<T[]>;
     populate<T>(docs: Object, options: ModelPopulateOptions | ModelPopulateOptions[],
-      callback?: (err: any, res: T) => void): _MongoosePromise<T>;
+      callback?: (err: any, res: T) => void): Promise<T>;
 
     /** Removes documents from the collection. */
     remove(conditions: Object, callback?: (err: any) => void): Query<void>;
@@ -2309,7 +2311,7 @@ declare module "mongoose" {
      * Removes this document from the db.
      * @param fn optional callback
      */
-    remove(fn?: (err: any, product: this) => void): _MongoosePromise<this>;
+    remove(fn?: (err: any, product: this) => void): Promise<this>;
 
     /**
      * Saves this document.
@@ -2318,7 +2320,7 @@ declare module "mongoose" {
      * @param options.validateBeforeSave set to false to save without validating.
      * @param fn optional callback
      */
-    save(fn?: (err: any, product: this, numAffected: number) => void): _MongoosePromise<this>;
+    save(fn?: (err: any, product: this, numAffected: number) => void): Promise<this>;
   }
 
   interface ModelProperties {

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -4,7 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 ///<reference path="../mongodb/mongodb.d.ts" />
-///<reference path="../mpromise/mpromise.d.ts" />
 ///<reference path="../node/node.d.ts" />
 
 /*
@@ -715,7 +714,7 @@ declare module "mongoose" {
    * section document.js
    * http://mongoosejs.com/docs/api.html#document-js
    */
-  interface MongooseDocument {
+  class MongooseDocument {
     /** Checks if a path is set to its default. */
     $isDefault(path?: string): boolean;
 

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -2059,6 +2059,15 @@ declare module "mongoose" {
      */
     new(doc?: Object): T;
 
+    /** The name of the model. */
+    modelName: string;
+
+    /** Collection the model uses. */
+    collection: Collection;
+
+    /** If this is a discriminator model, `baseModelName` is the name of the base model. */
+    baseModelName: string;
+
     /**
      * Finds a single document by its _id field. findById(id) is almost*
      * equivalent to findOne({ _id: id }). findById() triggers findOne hooks.

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -2059,27 +2059,6 @@ declare module "mongoose" {
      */
     new(doc?: Object): T;
 
-    /** Base Mongoose instance the model uses. */
-    base: typeof mongoose;
-
-    /** If this is a discriminator model, `baseModelName` is the name of the base model. */
-    baseModelName: string;
-
-    /** Collection the model uses. */
-    collection: Collection;
-
-    /** Connection the model uses. */
-    db: Connection;
-
-    /** Registered discriminators for this model. */
-    discriminators: any;
-
-    /** The name of the model. */
-    modelName: string;
-
-    /** Schema the model uses. */
-    schema: Schema;
-
     /**
      * Finds a single document by its _id field. findById(id) is almost*
      * equivalent to findOne({ _id: id }). findById() triggers findOne hooks.

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -93,6 +93,7 @@ declare module "mongoose" {
   export var DocumentProvider: any;
   // recursive constructor
   export var Mongoose: new(...args: any[]) => typeof mongoose;
+  type Mongoose = typeof mongoose;
   export var SchemaTypes: typeof Schema.Types;
 
   /** Expose connection states for user-land */
@@ -110,7 +111,7 @@ declare module "mongoose" {
    * @returns pseudo-promise wrapper around this
    */
   export function connect(uris: string,
-    options?: ConnectOptions,
+    options?: ConnectionOptions,
     callback?: (err: mongodb.MongoError) => void): MongooseThenable;
   export function connect(uris: string,
     callback?: (err: mongodb.MongoError) => void): MongooseThenable;
@@ -125,10 +126,10 @@ declare module "mongoose" {
    */
   export function createConnection(): Connection;
   export function createConnection(uri: string,
-    options?: ConnectOptions
+    options?: ConnectionOptions
   ): Connection;
   export function createConnection(host: string, database_name: string, port?: number,
-    options?: ConnectOptions
+    options?: ConnectionOptions
   ): Connection;
 
   /**
@@ -381,7 +382,7 @@ declare module "mongoose" {
     mongos?: boolean;
   }
 
-  interface ConnectOptions extends
+  interface ConnectionOptions extends
     ConnectionOpenOptions,
     ConnectionOpenSetOptions {}
 

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -152,6 +152,12 @@ declare module "mongoose" {
    */
   export function model<T extends Document>(name: string, schema?: Schema, collection?: string,
     skipInit?: boolean): Model<T>;
+  export function model<T extends Document, U extends Model<T>>(
+    name: string,
+    schema?: Schema,
+    collection?: string,
+    skipInit?: boolean
+  ): U;
 
   /**
    * Returns an array of model names created on this instance of Mongoose.
@@ -311,6 +317,11 @@ declare module "mongoose" {
      * @returns The compiled model
      */
     model<T extends Document>(name: string, schema?: Schema, collection?: string): Model<T>;
+    model<T extends Document, U extends Model<T>>(
+      name: string,
+      schema?: Schema,
+      collection?: string
+    ): U;
 
     /** Returns an array of model names created on this connection. */
     modelNames(): string[];
@@ -704,7 +715,7 @@ declare module "mongoose" {
    * section document.js
    * http://mongoosejs.com/docs/api.html#document-js
    */
-  class MongooseDocument {
+  interface MongooseDocument {
     /** Checks if a path is set to its default. */
     $isDefault(path?: string): boolean;
 
@@ -2074,7 +2085,7 @@ declare module "mongoose" {
     findById(id: Object | string | number, projection: Object, options: Object,
       callback?: (err: any, res: T) => void): DocumentQuery<T, T>;
 
-    model<T extends Document>(name: string): Model<T>;
+    model(name: string): Model<T>;
 
     /**
      * Creates a Query and specifies a $where condition.

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -27,43 +27,43 @@
  *   is just a simple heuristic to keep track of our progress.
  *
  * TODO for version 4.x [updated][tested]:
- * [x][x] index.js
- * [x][x] querystream.js
- * [x][x] connection.js
- * [x][x] utils.js
- * [x][x] browser.js
- * [x][x] drivers/node-mongodb-native/collection.js
- * [x][x] drivers/node-mongodb-native/connection.js
- * [x][x] error/messages.js
- * [x][x] error/validation.js
- * [x][x] error.js
- * [x][x] querycursor.js
- * [x][x] virtualtype.js
- * [x][x] schema.js
- * [x][x] document.js
- * [x][x] types/subdocument.js
- * [x][x] types/array.js
- * [x][x] types/documentarray.js
- * [x][x] types/buffer.js
- * [x][x] types/objectid.js
- * [x][x] types/embedded.js
- * [x][x] query.js
- * [x][x] schema/array.js
- * [x][x] schema/string.js
- * [x][x] schema/documentarray.js
- * [x][x] schema/number.js
- * [x][x] schema/date.js
- * [x][x] schema/buffer.js
- * [x][x] schema/boolean.js
- * [x][x] schema/objectid.js
- * [x][x] schema/mixed.js
- * [x][x] schema/embedded.js
- * [x][x] aggregate.js
- * [x][x] schematype.js
- * [x][x] promise.js
- * [x][x] ES6Promise.js
- * [x][x] model.js
- * [x][x] collection.js
+ * [x][ ] index.js
+ * [x][ ] querystream.js
+ * [x][ ] connection.js
+ * [x][ ] utils.js
+ * [x][ ] browser.js
+ * [x][ ] drivers/node-mongodb-native/collection.js
+ * [x][ ] drivers/node-mongodb-native/connection.js
+ * [x][ ] error/messages.js
+ * [x][ ] error/validation.js
+ * [x][ ] error.js
+ * [x][ ] querycursor.js
+ * [x][ ] virtualtype.js
+ * [x][ ] schema.js
+ * [x][ ] document.js
+ * [x][ ] types/subdocument.js
+ * [x][ ] types/array.js
+ * [x][ ] types/documentarray.js
+ * [x][ ] types/buffer.js
+ * [x][ ] types/objectid.js
+ * [x][ ] types/embedded.js
+ * [x][ ] query.js
+ * [x][ ] schema/array.js
+ * [x][ ] schema/string.js
+ * [x][ ] schema/documentarray.js
+ * [x][ ] schema/number.js
+ * [x][ ] schema/date.js
+ * [x][ ] schema/buffer.js
+ * [x][ ] schema/boolean.js
+ * [x][ ] schema/objectid.js
+ * [x][ ] schema/mixed.js
+ * [x][ ] schema/embedded.js
+ * [x][ ] aggregate.js
+ * [x][ ] schematype.js
+ * [x][ ] promise.js
+ * [x][ ] ES6Promise.js
+ * [x][ ] model.js
+ * [x][ ] collection.js
  */
 
 /*
@@ -84,70 +84,26 @@ declare module "mongoose" {
    * Some mongoose classes have the same name as the native JS classes
    * Keep references to native classes using a "Native" prefix
    */
-  type NativeBuffer = Buffer;
-  type NativeDate = Date;
-  type NativeError = Error;
-
-  /*
-   * Public API
-   */
+  class NativeBuffer extends global.Buffer {}
+  class NativeDate extends global.Date {}
+  class NativeError extends global.Error {}
 
   /*
    * section index.js
    * http://mongoosejs.com/docs/api.html#index-js
    */
-
-  /* Class constructors */
-  export var Aggregate: typeof _mongoose.Aggregate;
-  export var CastError: typeof _mongoose.CastError;
-  export var Collection: _mongoose.Collection;
-  export var Connection: typeof _mongoose.Connection;
-  export var Document: typeof _mongoose.Document;
   export var DocumentProvider: any;
-  export var Error: typeof _mongoose.Error;
-  export var Model: _mongoose.ModelConstructor<{}>;
-  export var Mongoose: {
-    // recursive constructor
-    new(...args: any[]): typeof mongoose;
-  }
-
-  /**
-   * To assign your own promise library:
-   *
-   * 1. Include this somewhere in your code:
-   *    mongoose.Promise = YOUR_PROMISE;
-   *
-   * 2. Include this somewhere in your main .d.ts file:
-   *    type MongoosePromise<T> = YOUR_PROMISE<T>;
-   */
-
-  export var Promise: any;
-  export var PromiseProvider: any;
-  export var Query: typeof _mongoose.ModelQuery;
-  export var Schema: typeof _mongoose.Schema;
-  export var SchemaType: typeof _mongoose.SchemaType;
-  export var SchemaTypes: typeof _mongoose.Schema.Types;
-  export var Types: {
-    Subdocument: typeof _mongoose.Types.Subdocument;
-    Array: typeof _mongoose.Types.Array;
-    DocumentArray: typeof _mongoose.Types.DocumentArray;
-    Buffer: typeof _mongoose.Types.Buffer;
-    ObjectId: typeof _mongoose.Types.ObjectId;
-    Embedded: typeof _mongoose.Types.Embedded;
-  }
-  export var VirtualType: typeof _mongoose.VirtualType;
+  export var Model: Model<any>;
+  // recursive constructor
+  export var Mongoose: new(...args: any[]) => typeof mongoose;
+  export var SchemaTypes: typeof Schema.Types;
 
   /** Expose connection states for user-land */
   export var STATES: Object
   /** The default connection of the mongoose module. */
-  export var connection: _mongoose.Connection;
+  export var connection: Connection;
   /** The node-mongodb-native driver Mongoose uses. */
   export var mongo: typeof mongodb;
-  /**
-   * The mquery query builder Mongoose uses.
-   * Currently there is no mquery type definition.
-   */
-  export var mquery: any;
   /** The Mongoose version */
   export var version: string;
 
@@ -158,10 +114,10 @@ declare module "mongoose" {
    * @returns pseudo-promise wrapper around this
    */
   export function connect(uris: string,
-    options?: _mongoose.MongooseConnectOptions,
-    callback?: (err: mongodb.MongoError) => void): _mongoose.MongooseThenable;
+    options?: ConnectOptions,
+    callback?: (err: mongodb.MongoError) => void): MongooseThenable;
   export function connect(uris: string,
-    callback?: (err: mongodb.MongoError) => void): _mongoose.MongooseThenable;
+    callback?: (err: mongodb.MongoError) => void): MongooseThenable;
 
   /**
    * Creates a Connection instance.
@@ -171,20 +127,20 @@ declare module "mongoose" {
    * @param options options to pass to the driver
    * @returns the created Connection object
    */
-  export function createConnection(): _mongoose.Connection;
+  export function createConnection(): Connection;
   export function createConnection(uri: string,
-    options?: _mongoose.MongooseConnectOptions
-  ): _mongoose.Connection;
+    options?: ConnectOptions
+  ): Connection;
   export function createConnection(host: string, database_name: string, port?: number,
-    options?: _mongoose.MongooseConnectOptions
-  ): _mongoose.Connection;
+    options?: ConnectOptions
+  ): Connection;
 
   /**
    * Disconnects all connections.
    * @param fn called after all connection close.
    * @returns pseudo-promise wrapper around this
    */
-  export function disconnect(fn?: (error: any) => void): _mongoose.MongooseThenable;
+  export function disconnect(fn?: (error: any) => void): MongooseThenable;
 
   /** Gets mongoose options */
   export function get(key: string): any;
@@ -197,10 +153,8 @@ declare module "mongoose" {
    * @param collection (optional, induced from model name)
    * @param skipInit whether to skip initialization (defaults to false)
    */
-  export function model<T>(name: string, schema?: _mongoose.Schema, collection?: string,
-    skipInit?: boolean): _mongoose.ModelConstructor<T>;
-  export function model<T, Statics>(name: string, schema?: _mongoose.Schema, collection?: string,
-    skipInit?: boolean): Statics & _mongoose.ModelConstructor<T>;
+  export function model<T extends Document>(name: string, schema?: Schema, collection?: string,
+    skipInit?: boolean): Model<T>;
 
   /**
    * Returns an array of model names created on this instance of Mongoose.
@@ -219,2388 +173,2313 @@ declare module "mongoose" {
   /** Sets mongoose options */
   export function set(key: string, value: any): void;
 
+  type MongooseThenable = typeof mongoose & _MongooseThenable;
+  interface _MongooseThenable {
+    /**
+     * Ability to use mongoose object as a pseudo-promise so .connect().then()
+     * and .disconnect().then() are viable.
+     */
+    then<TRes>(onFulfill?: () => void | TRes | PromiseLike<TRes>,
+      onRejected?: (err: mongodb.MongoError) => void | TRes | PromiseLike<TRes>): _MongoosePromise<TRes>;
+
+    /**
+     * Ability to use mongoose object as a pseudo-promise so .connect().then()
+     * and .disconnect().then() are viable.
+     */
+    catch<TRes>(onRejected?: (err: mongodb.MongoError) => void | TRes | PromiseLike<TRes>): _MongoosePromise<TRes>;
+  }
+
+  class CastError extends Error {
+    /**
+     * The Mongoose CastError constructor
+     * @param type The name of the type
+     * @param value The value that failed to cast
+     * @param path The path a.b.c in the doc where this cast error occurred
+     * @param reason The original error that was thrown
+     */
+    constructor(type: string, value: any, path: string, reason?: NativeError);
+  }
 
   /*
-   * All the types that are exposed for type checking.
+   * section querystream.js
+   * http://mongoosejs.com/docs/api.html#querystream-js
+   *
+   * QueryStream can only be accessed using query#stream(), we only
+   *   expose its interface here to enable type-checking.
    */
-  export type Aggregate<T> = _mongoose.Aggregate<T>;
-  export type CastError = _mongoose.CastError;
-  export type Collection = _mongoose.Collection;
-  export type Connection = _mongoose.Connection;
-  export type Document = _mongoose.Document;
-  export type Error = _mongoose.Error;
-  export type ValidationError = _mongoose.ValidationError;
+  interface QueryStream extends stream.Stream {
+    /**
+     * Provides a Node.js 0.8 style ReadStream interface for Queries.
+     * @event data emits a single Mongoose document
+     * @event error emits when an error occurs during streaming. This will emit before the close event.
+     * @event close emits when the stream reaches the end of the cursor or an error occurs, or the stream
+     *   is manually destroyed. After this event, no more events are emitted.
+     */
+    constructor(query: Query<any>, options?: {
+      /**
+       * optional function which accepts a mongoose document. The return value
+       * of the function will be emitted on data.
+       */
+      transform?: Function;
+      [other: string]: any;
+    }): QueryStream;
 
-  /** Document created from model constructors. */
-  export type model<T> = _mongoose.Model<T>;
-  /** Model Constructor. */
-  export type Model<T> = _mongoose.ModelConstructor<T>;
+    /**
+     * Destroys the stream, closing the underlying cursor, which emits the close event.
+     * No more events will be emitted after the close event.
+     */
+    destroy(err?: NativeError): void;
 
-  export type Mongoose = typeof mongoose;
-  export type Promise<T> = _mongoose._MongoosePromise<T>;
-  export type Query<T> = _mongoose.Query<T>;
-  export type QueryCursor<T> = _mongoose.QueryCursor<T>;
-  export type QueryStream = _mongoose.QueryStream;
-  export type Schema = _mongoose.Schema;
-  namespace Schema {
-    namespace Types {
-      export type Array = _mongoose.Schema._Types.Array;
-      export type String = _mongoose.Schema._Types.String;
-      export type DocumentArray = _mongoose.Schema._Types.DocumentArray;
-      export type Number = _mongoose.Schema._Types.Number;
-      export type Date = _mongoose.Schema._Types.Date;
-      export type Buffer = _mongoose.Schema._Types.Buffer;
-      export type Boolean = _mongoose.Schema._Types.Boolean;
-      export type Bool = _mongoose.Schema._Types.Boolean;
-      export type ObjectId = _mongoose.Schema._Types.ObjectId;
-      export type Oid = _mongoose.Schema._Types.ObjectId;
-      export type Mixed = _mongoose.Schema._Types.Mixed;
-      export type Object = _mongoose.Schema._Types.Mixed;
-      export type Embedded = _mongoose.Schema._Types.Embedded;
-    }
+    /** Pauses this stream. */
+    pause(): void;
+    /** Pipes this query stream into another stream. This method is inherited from NodeJS Streams. */
+    pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
+    /** Resumes this stream. */
+    resume(): void;
+
+    /** Flag stating whether or not this stream is paused. */
+    paused: boolean;
+    /** Flag stating whether or not this stream is readable. */
+    readable: boolean;
   }
-  export type SchemaType = _mongoose.SchemaType;
-  namespace Types {
-    export type Subdocument = _mongoose.Types.Subdocument;
-    export type Array<T> = _mongoose.Types.Array<T>;
-    export type DocumentArray<T extends _mongoose.Document> = _mongoose.Types.DocumentArray<T>;
-    export type Buffer = _mongoose.Types.Buffer;
-    export type ObjectId = _mongoose.Types.ObjectId;
-    export type Embedded = _mongoose.Types.Embedded;
+
+  /*
+   * section connection.js
+   * http://mongoosejs.com/docs/api.html#connection-js
+   *
+   * The Connection class exposed by require('mongoose')
+   *   is actually the driver's NativeConnection class.
+   *   connection.js defines a base class that the native
+   *   versions extend. See:
+   *   http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-connection-js
+   */
+  abstract class ConnectionBase extends events.EventEmitter {
+    /**
+     * For practical reasons, a Connection equals a Db.
+     * @param base a mongoose instance
+     * @event connecting Emitted when connection.{open,openSet}() is executed on this connection.
+     * @event connected Emitted when this connection successfully connects to the db. May be emitted multiple times in reconnected scenarios.
+     * @event open Emitted after we connected and onOpen is executed on all of this connections models.
+     * @event disconnecting Emitted when connection.close() was executed.
+     * @event disconnected Emitted after getting disconnected from the db.
+     * @event close Emitted after we disconnected and onClose executed on all of this connections models.
+     * @event reconnected Emitted after we connected and subsequently disconnected, followed by successfully another successfull connection.
+     * @event error Emitted when an error occurs on this connection.
+     * @event fullsetup Emitted in a replica-set scenario, when primary and at least one seconaries specified in the connection string are connected.
+     * @event all Emitted in a replica-set scenario, when all nodes specified in the connection string are connected.
+     */
+    constructor(base: typeof mongoose);
+
+    /**
+     * Opens the connection to MongoDB.
+     * @param mongodb://uri or the host to which you are connecting
+     * @param database database name
+     * @param port database port
+     * @param options Mongoose forces the db option forceServerObjectId false and cannot be overridden.
+     *   Mongoose defaults the server auto_reconnect options to true which can be overridden.
+     *   See the node-mongodb-native driver instance for options that it understands.
+     *   Options passed take precedence over options included in connection strings.
+     */
+    open(connection_string: string, database?: string, port?: number,
+      options?: ConnectionOpenOptions, callback?: (err: any) => void): any;
+
+    /**
+     * Opens the connection to a replica set.
+     * @param uris comma-separated mongodb:// URIs
+     * @param database database name if not included in uris
+     * @param options passed to the internal driver
+     */
+    openSet(uris: string, database?: string, options?: ConnectionOpenSetOptions,
+      callback?: (err: any) => void): any;
+
+    /** Closes the connection */
+    close(callback?: (err: any) => void): _MongoosePromise<void>;
+
+    /**
+     * Retrieves a collection, creating it if not cached.
+     * Not typically needed by applications. Just talk to your collection through your model.
+     * @param name name of the collection
+     * @param options optional collection options
+     */
+    collection(name: string, options?: Object): Collection;
+
+    /**
+     * Defines or retrieves a model.
+     * When no collection argument is passed, Mongoose produces a collection name by passing
+     * the model name to the utils.toCollectionName method. This method pluralizes the name.
+     * If you don't like this behavior, either pass a collection name or set your schemas
+     * collection name option.
+     * @param name the model name
+     * @param schema a schema. necessary when defining a model
+     * @param collection name of mongodb collection (optional) if not given it will be induced from model name
+     * @returns The compiled model
+     */
+    model<T extends Document>(name: string, schema?: Schema, collection?: string): Model<T>;
+
+    /** Returns an array of model names created on this connection. */
+    modelNames(): string[];
+
+    /** A hash of the global options that are associated with this connection */
+    config: Object;
+
+    /** The mongodb.Db instance, set when the connection is opened */
+    db: mongodb.Db;
+
+    /** A hash of the collections associated with this connection */
+    collections: { [index: string]: Collection };
+
+    /**
+     * Connection ready state
+     * 0 = disconnected
+     * 1 = connected
+     * 2 = connecting
+     * 3 = disconnecting
+     * Each state change emits its associated event name.
+     */
+    readyState: number;
   }
-  export type VirtualType = _mongoose.VirtualType;
-  export type ConnectionOptions = _mongoose.MongooseConnectOptions;
 
+  interface ConnectionOptionsBase {
+    /** passed to the connection db instance */
+    db?: any;
+    /** passed to the connection server instance(s) */
+    server?: any;
+    /** passed to the connection ReplSet instance */
+    replset?: any;
+    /** username for authentication */
+    user?: string;
+    /** password for authentication */
+    pass?: string;
+    /** options for authentication (see http://mongodb.github.com/node-mongodb-native/api-generated/db.html#authenticate) */
+    auth?: any;
+  }
 
-  /** Private */
-  namespace _mongoose {
-    /*
-     * section index.js
-     * http://mongoosejs.com/docs/api.html#index-js
-     */
-    type MongooseThenable = typeof mongoose & _MongooseThenable;
-    interface _MongooseThenable {
+  /** See the node-mongodb-native driver instance for options that it understands. */
+  interface ConnectionOpenOptions extends ConnectionOptionsBase {
+    /** mongoose-specific options */
+    config?: {
       /**
-       * Ability to use mongoose object as a pseudo-promise so .connect().then()
-       * and .disconnect().then() are viable.
+       * set to false to disable automatic index creation for all
+       * models associated with this connection.
        */
-      then<TRes>(onFulfill?: () => void | TRes | PromiseLike<TRes>,
-        onRejected?: (err: mongodb.MongoError) => void | TRes | PromiseLike<TRes>): _MongoosePromise<TRes>;
-
-      /**
-       * Ability to use mongoose object as a pseudo-promise so .connect().then()
-       * and .disconnect().then() are viable.
-       */
-      catch<TRes>(onRejected?: (err: mongodb.MongoError) => void | TRes | PromiseLike<TRes>): _MongoosePromise<TRes>;
-    }
-
-    class CastError extends _mongoose.Error {
-      /**
-       * The Mongoose CastError constructor
-       * @param type The name of the type
-       * @param value The value that failed to cast
-       * @param path The path a.b.c in the doc where this cast error occurred
-       * @param reason The original error that was thrown
-       */
-      constructor(type: string, value: any, path: string, reason?: NativeError);
-    }
-
-    interface MongooseConnectOptions extends
-      ConnectionOpenOptions,
-      ConnectionOpenSetOptions {}
-
-    /*
-     * section querystream.js
-     * http://mongoosejs.com/docs/api.html#querystream-js
-     *
-     * QueryStream can only be accessed using query#stream(), we only
-     *   expose its interface here to enable type-checking.
-     */
-    interface QueryStream extends stream.Stream {
-      /**
-       * Provides a Node.js 0.8 style ReadStream interface for Queries.
-       * @event data emits a single Mongoose document
-       * @event error emits when an error occurs during streaming. This will emit before the close event.
-       * @event close emits when the stream reaches the end of the cursor or an error occurs, or the stream
-       *   is manually destroyed. After this event, no more events are emitted.
-       */
-      constructor(query: Query<any>, options?: {
-        /**
-         * optional function which accepts a mongoose document. The return value
-         * of the function will be emitted on data.
-         */
-        transform?: Function;
-        [other: string]: any;
-      }): QueryStream;
-
-      /**
-       * Destroys the stream, closing the underlying cursor, which emits the close event.
-       * No more events will be emitted after the close event.
-       */
-      destroy(err?: NativeError): void;
-
-      /** Pauses this stream. */
-      pause(): void;
-      /** Pipes this query stream into another stream. This method is inherited from NodeJS Streams. */
-      pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
-      /** Resumes this stream. */
-      resume(): void;
-
-      /** Flag stating whether or not this stream is paused. */
-      paused: boolean;
-      /** Flag stating whether or not this stream is readable. */
-      readable: boolean;
-    }
-
-    /*
-     * section connection.js
-     * http://mongoosejs.com/docs/api.html#connection-js
-     *
-     * The Connection class exposed by require('mongoose')
-     *   is actually the driver's NativeConnection class.
-     *   connection.js defines a base class that the native
-     *   versions extend. See:
-     *   http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-connection-js
-     */
-    abstract class ConnectionBase extends events.EventEmitter {
-      /**
-       * For practical reasons, a Connection equals a Db.
-       * @param base a mongoose instance
-       * @event connecting Emitted when connection.{open,openSet}() is executed on this connection.
-       * @event connected Emitted when this connection successfully connects to the db. May be emitted multiple times in reconnected scenarios.
-       * @event open Emitted after we connected and onOpen is executed on all of this connections models.
-       * @event disconnecting Emitted when connection.close() was executed.
-       * @event disconnected Emitted after getting disconnected from the db.
-       * @event close Emitted after we disconnected and onClose executed on all of this connections models.
-       * @event reconnected Emitted after we connected and subsequently disconnected, followed by successfully another successfull connection.
-       * @event error Emitted when an error occurs on this connection.
-       * @event fullsetup Emitted in a replica-set scenario, when primary and at least one seconaries specified in the connection string are connected.
-       * @event all Emitted in a replica-set scenario, when all nodes specified in the connection string are connected.
-       */
-      constructor(base: typeof mongoose);
-
-      /**
-       * Opens the connection to MongoDB.
-       * @param mongodb://uri or the host to which you are connecting
-       * @param database database name
-       * @param port database port
-       * @param options Mongoose forces the db option forceServerObjectId false and cannot be overridden.
-       *   Mongoose defaults the server auto_reconnect options to true which can be overridden.
-       *   See the node-mongodb-native driver instance for options that it understands.
-       *   Options passed take precedence over options included in connection strings.
-       */
-      open(connection_string: string, database?: string, port?: number,
-        options?: ConnectionOpenOptions, callback?: (err: any) => void): any;
-
-      /**
-       * Opens the connection to a replica set.
-       * @param uris comma-separated mongodb:// URIs
-       * @param database database name if not included in uris
-       * @param options passed to the internal driver
-       */
-      openSet(uris: string, database?: string, options?: ConnectionOpenSetOptions,
-        callback?: (err: any) => void): any;
-
-      /** Closes the connection */
-      close(callback?: (err: any) => void): _MongoosePromise<void>;
-
-      /**
-       * Retrieves a collection, creating it if not cached.
-       * Not typically needed by applications. Just talk to your collection through your model.
-       * @param name name of the collection
-       * @param options optional collection options
-       */
-      collection(name: string, options?: Object): Collection;
-
-      /**
-       * Defines or retrieves a model.
-       * When no collection argument is passed, Mongoose produces a collection name by passing
-       * the model name to the utils.toCollectionName method. This method pluralizes the name.
-       * If you don't like this behavior, either pass a collection name or set your schemas
-       * collection name option.
-       * @param name the model name
-       * @param schema a schema. necessary when defining a model
-       * @param collection name of mongodb collection (optional) if not given it will be induced from model name
-       * @returns The compiled model
-       */
-      model<T>(name: string, schema?: Schema, collection?: string): ModelConstructor<T>;
-      model<T, Statics>(name: string, schema?: Schema, collection?: string): Statics & ModelConstructor<T>;
-
-      /** Returns an array of model names created on this connection. */
-      modelNames(): string[];
-
-      /** A hash of the global options that are associated with this connection */
-      config: Object;
-
-      /** The mongodb.Db instance, set when the connection is opened */
-      db: mongodb.Db;
-
-      /** A hash of the collections associated with this connection */
-      collections: { [index: string]: Collection };
-
-      /**
-       * Connection ready state
-       * 0 = disconnected
-       * 1 = connected
-       * 2 = connecting
-       * 3 = disconnecting
-       * Each state change emits its associated event name.
-       */
-      readyState: number;
-    }
-
-    interface ConnectionOptionsBase {
-      /** passed to the connection db instance */
-      db?: any;
-      /** passed to the connection server instance(s) */
-      server?: any;
-      /** passed to the connection ReplSet instance */
-      replset?: any;
-      /** username for authentication */
-      user?: string;
-      /** password for authentication */
-      pass?: string;
-      /** options for authentication (see http://mongodb.github.com/node-mongodb-native/api-generated/db.html#authenticate) */
-      auth?: any;
-    }
-
-    /** See the node-mongodb-native driver instance for options that it understands. */
-    interface ConnectionOpenOptions extends ConnectionOptionsBase {
-      /** mongoose-specific options */
-      config?: {
-        /**
-         * set to false to disable automatic index creation for all
-         * models associated with this connection.
-         */
-        autoIndex?: boolean;
-      };
-    }
-
-    /** See the node-mongodb-native driver instance for options that it understands. */
-    interface ConnectionOpenSetOptions extends ConnectionOptionsBase {
-      /**
-       * If true, enables High Availability support for mongos
-       * If connecting to multiple mongos servers, set the mongos option to true.
-       */
-      mongos?: boolean;
-    }
-
-    /*
-     * section drivers/node-mongodb-native/collection.js
-     * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-collection-js
-     */
-    interface Collection extends CollectionBase {
-      /**
-       * Collection constructor
-       * @param name name of the collection
-       * @param conn A MongooseConnection instance
-       * @param opts optional collection options
-       */
-      new(name: string, conn: Connection, opts?: Object): Collection;
-      /** Formatter for debug print args */
-      $format(arg: any): string;
-      /** Debug print helper */
-      $print(name: any, i: any, args: any[]): void;
-      /** Retreives information about this collections indexes. */
-      getIndexes(): any;
-    }
-
-    /*
-     * section drivers/node-mongodb-native/connection.js
-     * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-connection-js
-     */
-    class Connection extends ConnectionBase {
-      /**
-       * Switches to a different database using the same connection pool.
-       * @param name The database name
-       * @returns New Connection Object
-       */
-      useDb(name: string): Connection;
-
-      /** Expose the possible connection states. */
-      static STATES: Object;
-    }
-
-    /*
-     * section error/validation.js
-     * http://mongoosejs.com/docs/api.html#error-validation-js
-     */
-    class ValidationError extends Error {
-      /** Console.log helper */
-      toString(): string;
-    }
-
-    /*
-     * section error.js
-     * http://mongoosejs.com/docs/api.html#error-js
-     */
-    class Error extends global.Error {
-      /**
-       * MongooseError constructor
-       * @param msg Error message
-       */
-      constructor(msg: string);
-
-      /**
-       * The default built-in validator error messages. These may be customized.
-       * As you might have noticed, error messages support basic templating
-       * {PATH} is replaced with the invalid document path
-       * {VALUE} is replaced with the invalid value
-       * {TYPE} is replaced with the validator type such as "regexp", "min", or "user defined"
-       * {MIN} is replaced with the declared min value for the Number.min validator
-       * {MAX} is replaced with the declared max value for the Number.max validator
-       */
-      static messages: Object;
-
-      /** For backwards compatibility. Same as mongoose.Error.messages */
-      static Messages: Object;
-    }
-
-    /*
-     * section querycursor.js
-     * http://mongoosejs.com/docs/api.html#querycursor-js
-     *
-     * Callback signatures are from: http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#close
-     * QueryCursor can only be accessed by query#cursor(), we only
-     *   expose its interface to enable type-checking.
-     */
-    interface QueryCursor<T> extends stream.Readable {
-      /**
-       * A QueryCursor is a concurrency primitive for processing query results
-       * one document at a time. A QueryCursor fulfills the Node.js streams3 API,
-       * in addition to several other mechanisms for loading documents from MongoDB
-       * one at a time.
-       * Unless you're an advanced user, do not instantiate this class directly.
-       * Use Query#cursor() instead.
-       * @param options query options passed to .find()
-       * @event cursor Emitted when the cursor is created
-       * @event error Emitted when an error occurred
-       * @event data Emitted when the stream is flowing and the next doc is ready
-       * @event end Emitted when the stream is exhausted
-       */
-      constructor(query: Query<T>, options: Object): QueryCursor<T>;
-
-      /** Marks this cursor as closed. Will stop streaming and subsequent calls to next() will error. */
-      close(callback?: (error: any, result: any) => void): _MongoosePromise<any>;
-
-      /**
-       * Execute fn for every document in the cursor. If fn returns a promise,
-       * will wait for the promise to resolve before iterating on to the next one.
-       * Returns a promise that resolves when done.
-       * @param callback executed when all docs have been processed
-       */
-      eachAsync(fn: (doc: Model<T>) => any, callback?: (err: any) => void): _MongoosePromise<Model<T>>;
-
-      /**
-       * Get the next document from this cursor. Will return null when there are
-       * no documents left.
-       */
-      next(callback?: (err: any) => void): _MongoosePromise<any>;
-    }
-
-    /*
-     * section virtualtype.js
-     * http://mongoosejs.com/docs/api.html#virtualtype-js
-     */
-    class VirtualType {
-      /** This is what mongoose uses to define virtual attributes via Schema.prototype.virtual. */
-      constructor(options: Object, name: string);
-      /** Applies getters to value using optional scope. */
-      applyGetters(value: Object, scope: Object): any;
-      /** Applies setters to value using optional scope. */
-      applySetters(value: Object, scope: Object): any;
-      /** Defines a getter. */
-      get(fn: Function): this;
-      /** Defines a setter. */
-      set(fn: Function): this;
-    }
-
-    /*
-     * section schema.js
-     * http://mongoosejs.com/docs/api.html#schema-js
-     */
-    class Schema extends events.EventEmitter {
-      /**
-       * Schema constructor.
-       * When nesting schemas, (children in the example above), always declare
-       * the child schema first before passing it into its parent.
-       * @event init Emitted after the schema is compiled into a Model.
-       */
-      constructor(definition?: Object, options?: SchemaOptions);
-
-      /** Adds key path / schema type pairs to this schema. */
-      add(obj: Object, prefix?: string): void;
-
-      /**
-       * Iterates the schemas paths similar to Array.forEach.
-       * @param fn callback function
-       * @returns this
-       */
-      eachPath(fn: (path: string, type: SchemaType) => void): this;
-
-      /**
-       * Gets a schema option.
-       * @param key option name
-       */
-      get(key: string): any;
-
-      /**
-       * Defines an index (most likely compound) for this schema.
-       * @param options Options to pass to MongoDB driver's createIndex() function
-       * @param options.expires Mongoose-specific syntactic sugar, uses ms to convert
-       *   expires option into seconds for the expireAfterSeconds in the above link.
-       */
-      index(fields: Object, options?: {
-        expires?: string;
-        [other: string]: any;
-      }): this;
-
-      /** Compiles indexes from fields and schema-level indexes */
-      indexes(): any[];
-
-      /**
-       * Adds an instance method to documents constructed from Models compiled from this schema.
-       * If a hash of name/fn pairs is passed as the only argument, each name/fn pair will be added as methods.
-       */
-      method(method: string, fn: Function): this;
-      method(methodObj: { [name: string]: Function }): this;
-
-      /**
-       * Gets/sets schema paths.
-       * Sets a path (if arity 2)
-       * Gets a path (if arity 1)
-       */
-      path(path: string): SchemaType;
-      path(path: string, constructor: any): this;
-
-      /**
-       * Returns the pathType of path for this schema.
-       * @returns whether it is a real, virtual, nested, or ad-hoc/undefined path.
-       */
-      pathType(path: string): string;
-
-      /**
-       * Registers a plugin for this schema.
-       * @param plugin callback
-       */
-      plugin(plugin: (schema: Schema, options?: Object) => void, opts?: Object): this;
-
-      /**
-       * Defines a post hook for the document
-       * Post hooks fire on the event emitted from document instances of Models compiled
-       *   from this schema.
-       * @param method name of the method to hook
-       * @param fn callback
-       */
-      post<T>(method: string, fn: (doc: Model<T>) => void, ...args: any[]): this;
-      post<T>(method: string, fn: (doc: Model<T>, next: (err?: NativeError) => void,
-        ...otherArgs: any[]) => void): this;
-
-      /**
-       * Defines a pre hook for the document.
-       */
-      pre(method: string, fn: (next: (err?: NativeError) => void) => void,
-        errorCb?: (err: Error) => void): this;
-      pre(method: string, parallel: boolean, fn: (next: (err?: NativeError) => void, done: () => void) => void,
-        errorCb?: (err: Error) => void): this;
-
-      /**
-       * Adds a method call to the queue.
-       * @param name name of the document method to call later
-       * @param args arguments to pass to the method
-       */
-      queue(name: string, args: any[]): this;
-
-      /**
-       * Removes the given path (or [paths]).
-       */
-      remove(path: string | string[]): void;
-
-      /**
-       * @param invalidate refresh the cache
-       * @returns an Array of path strings that are required by this schema.
-       */
-      requiredPaths(invalidate?: boolean): string[];
-
-      /**
-       * Sets/gets a schema option.
-       * @param key option name
-       * @param value if not passed, the current option value is returned
-       */
-      set(key: string): any;
-      set(key: string, value: any): this;
-
-      /**
-       * Adds static "class" methods to Models compiled from this schema.
-       */
-      static(name: string, fn: Function): this;
-      static(nameObj: { [name: string]: Function }): this;
-
-      /** Creates a virtual type with the given name. */
-      virtual(name: string, options?: Object): VirtualType;
-
-      /** Returns the virtual type with the given name. */
-      virtualpath(name: string): VirtualType;
-
-      /** The allowed index types */
-      static indexTypes: string[];
-
-      /**
-       * Reserved document keys.
-       * Keys in this object are names that are rejected in schema declarations
-       * b/c they conflict with mongoose functionality. Using these key name
-       * will throw an error.
-       */
-      static reserved: Object;
-
-      static Types: {
-        Array: typeof _mongoose.Schema._Types.Array;
-        String: typeof _mongoose.Schema._Types.String;
-        DocumentArray: typeof _mongoose.Schema._Types.DocumentArray;
-        Number: typeof _mongoose.Schema._Types.Number;
-        Date: typeof _mongoose.Schema._Types.Date;
-        Buffer: typeof _mongoose.Schema._Types.Buffer;
-        Boolean: typeof _mongoose.Schema._Types.Boolean;
-        Bool: typeof _mongoose.Schema._Types.Boolean;
-        ObjectId: typeof _mongoose.Schema._Types.ObjectId;
-        Oid: typeof _mongoose.Schema._Types.ObjectId;
-        Mixed: typeof _mongoose.Schema._Types.Mixed;
-        Object: typeof _mongoose.Schema._Types.Mixed;
-        Embedded: typeof _mongoose.Schema._Types.Embedded;
-      }
-
-      /** Object of currently defined methods on this schema. */
-      methods: any;
-      /** Object of currently defined statics on this schema. */
-      statics: any;
-    }
-
-    interface SchemaOptions {
-      /** defaults to null (which means use the connection's autoIndex option) */
       autoIndex?: boolean;
-      /** defaults to true */
-      bufferCommands?: boolean;
-      /** defaults to false */
-      capped?: boolean;
-      /** no default */
-      collection?: string;
-      /** defaults to false. */
-      emitIndexErrors?: boolean;
-      /** defaults to true */
-      id?: boolean;
-      /** defaults to true */
-      _id?: boolean;
-      /** controls document#toObject behavior when called manually - defaults to true */
-      minimize?: boolean;
-      read?: string;
-      /** defaults to true. */
-      safe?: boolean;
-      /** defaults to null */
-      shardKey?: boolean;
-      /** defaults to true */
-      strict?: boolean;
-      /** no default */
-      toJSON?: Object;
-      /** no default */
-      toObject?: Object;
-      /** defaults to 'type' */
-      typeKey?: string;
-      /** defaults to false */
-      useNestedStrict?: boolean;
-      /** defaults to true */
-      validateBeforeSave?: boolean;
-      /** defaults to "__v" */
-      versionKey?: boolean;
+    };
+  }
+
+  /** See the node-mongodb-native driver instance for options that it understands. */
+  interface ConnectionOpenSetOptions extends ConnectionOptionsBase {
+    /**
+     * If true, enables High Availability support for mongos
+     * If connecting to multiple mongos servers, set the mongos option to true.
+     */
+    mongos?: boolean;
+  }
+
+  /*
+   * section drivers/node-mongodb-native/collection.js
+   * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-collection-js
+   */
+  var Collection: Collection;
+  interface Collection extends CollectionBase {
+    /**
+     * Collection constructor
+     * @param name name of the collection
+     * @param conn A MongooseConnection instance
+     * @param opts optional collection options
+     */
+    new(name: string, conn: Connection, opts?: Object): Collection;
+    /** Formatter for debug print args */
+    $format(arg: any): string;
+    /** Debug print helper */
+    $print(name: any, i: any, args: any[]): void;
+    /** Retreives information about this collections indexes. */
+    getIndexes(): any;
+  }
+
+  /*
+   * section drivers/node-mongodb-native/connection.js
+   * http://mongoosejs.com/docs/api.html#drivers-node-mongodb-native-connection-js
+   */
+  class Connection extends ConnectionBase {
+    /**
+     * Switches to a different database using the same connection pool.
+     * @param name The database name
+     * @returns New Connection Object
+     */
+    useDb(name: string): Connection;
+
+    /** Expose the possible connection states. */
+    static STATES: Object;
+  }
+
+  interface ConnectOptions extends ConnectionOpenOptions, ConnectionOpenSetOptions {}
+
+  /*
+   * section error/validation.js
+   * http://mongoosejs.com/docs/api.html#error-validation-js
+   */
+  class ValidationError extends Error {
+    /** Console.log helper */
+    toString(): string;
+  }
+
+  /*
+   * section error.js
+   * http://mongoosejs.com/docs/api.html#error-js
+   */
+  class Error extends global.Error {
+    /**
+     * MongooseError constructor
+     * @param msg Error message
+     */
+    constructor(msg: string);
+
+    /**
+     * The default built-in validator error messages. These may be customized.
+     * As you might have noticed, error messages support basic templating
+     * {PATH} is replaced with the invalid document path
+     * {VALUE} is replaced with the invalid value
+     * {TYPE} is replaced with the validator type such as "regexp", "min", or "user defined"
+     * {MIN} is replaced with the declared min value for the Number.min validator
+     * {MAX} is replaced with the declared max value for the Number.max validator
+     */
+    static messages: Object;
+
+    /** For backwards compatibility. Same as mongoose.Error.messages */
+    static Messages: Object;
+  }
+
+  /*
+   * section querycursor.js
+   * http://mongoosejs.com/docs/api.html#querycursor-js
+   *
+   * Callback signatures are from: http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#close
+   * QueryCursor can only be accessed by query#cursor(), we only
+   *   expose its interface to enable type-checking.
+   */
+  interface QueryCursor<T extends Document> extends stream.Readable {
+    /**
+     * A QueryCursor is a concurrency primitive for processing query results
+     * one document at a time. A QueryCursor fulfills the Node.js streams3 API,
+     * in addition to several other mechanisms for loading documents from MongoDB
+     * one at a time.
+     * Unless you're an advanced user, do not instantiate this class directly.
+     * Use Query#cursor() instead.
+     * @param options query options passed to .find()
+     * @event cursor Emitted when the cursor is created
+     * @event error Emitted when an error occurred
+     * @event data Emitted when the stream is flowing and the next doc is ready
+     * @event end Emitted when the stream is exhausted
+     */
+    constructor(query: Query<T>, options: Object): QueryCursor<T>;
+
+    /** Marks this cursor as closed. Will stop streaming and subsequent calls to next() will error. */
+    close(callback?: (error: any, result: any) => void): _MongoosePromise<any>;
+
+    /**
+     * Execute fn for every document in the cursor. If fn returns a promise,
+     * will wait for the promise to resolve before iterating on to the next one.
+     * Returns a promise that resolves when done.
+     * @param callback executed when all docs have been processed
+     */
+    eachAsync(fn: (doc: T) => any, callback?: (err: any) => void): _MongoosePromise<T>;
+
+    /**
+     * Get the next document from this cursor. Will return null when there are
+     * no documents left.
+     */
+    next(callback?: (err: any) => void): _MongoosePromise<any>;
+  }
+
+  /*
+   * section virtualtype.js
+   * http://mongoosejs.com/docs/api.html#virtualtype-js
+   */
+  class VirtualType {
+    /** This is what mongoose uses to define virtual attributes via Schema.prototype.virtual. */
+    constructor(options: Object, name: string);
+    /** Applies getters to value using optional scope. */
+    applyGetters(value: Object, scope: Object): any;
+    /** Applies setters to value using optional scope. */
+    applySetters(value: Object, scope: Object): any;
+    /** Defines a getter. */
+    get(fn: Function): this;
+    /** Defines a setter. */
+    set(fn: Function): this;
+  }
+
+  /*
+   * section schema.js
+   * http://mongoosejs.com/docs/api.html#schema-js
+   */
+  class Schema extends events.EventEmitter {
+    /**
+     * Schema constructor.
+     * When nesting schemas, (children in the example above), always declare
+     * the child schema first before passing it into its parent.
+     * @event init Emitted after the schema is compiled into a Model.
+     */
+    constructor(definition?: Object, options?: SchemaOptions);
+
+    /** Adds key path / schema type pairs to this schema. */
+    add(obj: Object, prefix?: string): void;
+
+    /**
+     * Iterates the schemas paths similar to Array.forEach.
+     * @param fn callback function
+     * @returns this
+     */
+    eachPath(fn: (path: string, type: SchemaType) => void): this;
+
+    /**
+     * Gets a schema option.
+     * @param key option name
+     */
+    get(key: string): any;
+
+    /**
+     * Defines an index (most likely compound) for this schema.
+     * @param options Options to pass to MongoDB driver's createIndex() function
+     * @param options.expires Mongoose-specific syntactic sugar, uses ms to convert
+     *   expires option into seconds for the expireAfterSeconds in the above link.
+     */
+    index(fields: Object, options?: {
+      expires?: string;
+      [other: string]: any;
+    }): this;
+
+    /** Compiles indexes from fields and schema-level indexes */
+    indexes(): any[];
+
+    /**
+     * Adds an instance method to documents constructed from Models compiled from this schema.
+     * If a hash of name/fn pairs is passed as the only argument, each name/fn pair will be added as methods.
+     */
+    method(method: string, fn: Function): this;
+    method(methodObj: { [name: string]: Function }): this;
+
+    /**
+     * Gets/sets schema paths.
+     * Sets a path (if arity 2)
+     * Gets a path (if arity 1)
+     */
+    path(path: string): SchemaType;
+    path(path: string, constructor: any): this;
+
+    /**
+     * Returns the pathType of path for this schema.
+     * @returns whether it is a real, virtual, nested, or ad-hoc/undefined path.
+     */
+    pathType(path: string): string;
+
+    /**
+     * Registers a plugin for this schema.
+     * @param plugin callback
+     */
+    plugin(plugin: (schema: Schema, options?: Object) => void, opts?: Object): this;
+
+    /**
+     * Defines a post hook for the document
+     * Post hooks fire on the event emitted from document instances of Models compiled
+     *   from this schema.
+     * @param method name of the method to hook
+     * @param fn callback
+     */
+    post<T extends Document>(method: string, fn: (doc: T) => void, ...args: any[]): this;
+    post<T extends Document>(method: string, fn: (doc: T, next: (err?: NativeError) => void,
+      ...otherArgs: any[]) => void): this;
+
+    /**
+     * Defines a pre hook for the document.
+     */
+    pre(method: string, fn: (next: (err?: NativeError) => void) => void,
+      errorCb?: (err: Error) => void): this;
+    pre(method: string, parallel: boolean, fn: (next: (err?: NativeError) => void, done: () => void) => void,
+      errorCb?: (err: Error) => void): this;
+
+    /**
+     * Adds a method call to the queue.
+     * @param name name of the document method to call later
+     * @param args arguments to pass to the method
+     */
+    queue(name: string, args: any[]): this;
+
+    /**
+     * Removes the given path (or [paths]).
+     */
+    remove(path: string | string[]): void;
+
+    /**
+     * @param invalidate refresh the cache
+     * @returns an Array of path strings that are required by this schema.
+     */
+    requiredPaths(invalidate?: boolean): string[];
+
+    /**
+     * Sets/gets a schema option.
+     * @param key option name
+     * @param value if not passed, the current option value is returned
+     */
+    set(key: string): any;
+    set(key: string, value: any): this;
+
+    /**
+     * Adds static "class" methods to Models compiled from this schema.
+     */
+    static(name: string, fn: Function): this;
+    static(nameObj: { [name: string]: Function }): this;
+
+    /** Creates a virtual type with the given name. */
+    virtual(name: string, options?: Object): VirtualType;
+
+    /** Returns the virtual type with the given name. */
+    virtualpath(name: string): VirtualType;
+
+    /** The allowed index types */
+    static indexTypes: string[];
+
+    /**
+     * Reserved document keys.
+     * Keys in this object are names that are rejected in schema declarations
+     * b/c they conflict with mongoose functionality. Using these key name
+     * will throw an error.
+     */
+    static reserved: Object;
+
+    /** Object of currently defined methods on this schema. */
+    methods: any;
+    /** Object of currently defined statics on this schema. */
+    statics: any;
+  }
+
+  interface SchemaOptions {
+    /** defaults to null (which means use the connection's autoIndex option) */
+    autoIndex?: boolean;
+    /** defaults to true */
+    bufferCommands?: boolean;
+    /** defaults to false */
+    capped?: boolean;
+    /** no default */
+    collection?: string;
+    /** defaults to false. */
+    emitIndexErrors?: boolean;
+    /** defaults to true */
+    id?: boolean;
+    /** defaults to true */
+    _id?: boolean;
+    /** controls document#toObject behavior when called manually - defaults to true */
+    minimize?: boolean;
+    read?: string;
+    /** defaults to true. */
+    safe?: boolean;
+    /** defaults to null */
+    shardKey?: boolean;
+    /** defaults to true */
+    strict?: boolean;
+    /** no default */
+    toJSON?: Object;
+    /** no default */
+    toObject?: Object;
+    /** defaults to 'type' */
+    typeKey?: string;
+    /** defaults to false */
+    useNestedStrict?: boolean;
+    /** defaults to true */
+    validateBeforeSave?: boolean;
+    /** defaults to "__v" */
+    versionKey?: boolean;
+    /**
+     * skipVersioning allows excluding paths from
+     * versioning (the internal revision will not be
+     * incremented even if these paths are updated).
+     */
+    skipVersioning?: Object;
+    /**
+     * If set timestamps, mongoose assigns createdAt
+     * and updatedAt fields to your schema, the type
+     * assigned is Date.
+     */
+    timestamps?: Object;
+  }
+
+  /*
+   * section document.js
+   * http://mongoosejs.com/docs/api.html#document-js
+   */
+  class MongooseDocument {
+    /** Checks if a path is set to its default. */
+    $isDefault(path?: string): boolean;
+
+    /**
+     * Takes a populated field and returns it to its unpopulated state.
+     * If the path was not populated, this is a no-op.
+     */
+    depopulate(path: string): void;
+
+    /**
+     * Returns true if the Document stores the same data as doc.
+     * Documents are considered equal when they have matching _ids, unless neither document
+     * has an _id, in which case this function falls back to usin deepEqual().
+     * @param doc a document to compare
+     */
+    equals(doc: MongooseDocument): boolean;
+
+    /**
+     * Explicitly executes population and returns a promise.
+     * Useful for ES2015 integration.
+     * @returns promise that resolves to the document when population is done
+     */
+    execPopulate(): _MongoosePromise<this>;
+
+    /**
+     * Returns the value of a path.
+     * @param type optionally specify a type for on-the-fly attributes
+     */
+    get(path: string, type?: any): any;
+
+    /**
+     * Initializes the document without setters or marking anything modified.
+     * Called internally after a document is returned from mongodb.
+     * @param doc document returned by mongo
+     * @param fn callback
+     */
+    init(doc: MongooseDocument, fn?: () => void): this;
+    init(doc: MongooseDocument, opts: Object, fn?: () => void): this;
+
+    /** Helper for console.log */
+    inspect(options?: Object): any;
+
+    /**
+     * Marks a path as invalid, causing validation to fail.
+     * The errorMsg argument will become the message of the ValidationError.
+     * The value argument (if passed) will be available through the ValidationError.value property.
+     * @param path the field to invalidate
+     * @param errorMsg the error which states the reason path was invalid
+     * @param value optional invalid value
+     * @param kind optional kind property for the error
+     * @returns the current ValidationError, with all currently invalidated paths
+     */
+    invalidate(path: string, errorMsg: string | NativeError, value: any, kind?: string): ValidationError | boolean;
+
+    /** Returns true if path was directly set and modified, else false. */
+    isDirectModified(path: string): boolean;
+
+    /** Checks if path was initialized */
+    isInit(path: string): boolean;
+
+    /**
+     * Returns true if this document was modified, else false.
+     * If path is given, checks if a path or any full path containing path as part of its path
+     * chain has been modified.
+     */
+    isModified(path?: string): boolean;
+
+    /** Checks if path was selected in the source query which initialized this document. */
+    isSelected(path: string): boolean;
+
+    /**
+     * Marks the path as having pending changes to write to the db.
+     * Very helpful when using Mixed types.
+     * @param path the path to mark modified
+     */
+    markModified(path: string): void;
+
+    /** Returns the list of paths that have been modified. */
+    modifiedPaths(): string[];
+
+    /**
+     * Populates document references, executing the callback when complete.
+     * If you want to use promises instead, use this function with
+     * execPopulate()
+     * Population does not occur unless a callback is passed or you explicitly
+     * call execPopulate(). Passing the same path a second time will overwrite
+     * the previous path options. See Model.populate() for explaination of options.
+     * @param path The path to populate or an options object
+     * @param callback When passed, population is invoked
+     */
+    populate(callback: (err: any, res: this) => void): this;
+    populate(path: string, callback?: (err: any, res: this) => void): this;
+    populate(options: ModelPopulateOptions, callback?: (err: any, res: this) => void): this;
+
+    /** Gets _id(s) used during population of the given path. If the path was not populated, undefined is returned. */
+    populated(path: string): any;
+
+    /**
+     * Sets the value of a path, or many paths.
+     * @param path path or object of key/vals to set
+     * @param val the value to set
+     * @param type optionally specify a type for "on-the-fly" attributes
+     * @param options optionally specify options that modify the behavior of the set
+     */
+    set(path: string, val: any, options?: Object): void;
+    set(path: string, val: any, type: any, options?: Object): void;
+    set(value: Object): void;
+
+    /**
+     * The return value of this method is used in calls to JSON.stringify(doc).
+     * This method accepts the same options as Document#toObject. To apply the
+     * options to every document of your schema by default, set your schemas
+     * toJSON option to the same argument.
+     */
+    toJSON(options?: DocumentToObjectOptions): Object;
+
+    /**
+     * Converts this document into a plain javascript object, ready for storage in MongoDB.
+     * Buffers are converted to instances of mongodb.Binary for proper storage.
+     */
+    toObject(options?: DocumentToObjectOptions): Object;
+
+    /** Helper for console.log */
+    toString(): string;
+
+    /**
+     * Clears the modified state on the specified path.
+     * @param path the path to unmark modified
+     */
+    unmarkModified(path: string): void;
+
+    /** Sends an update command with this document _id as the query selector.  */
+    update(doc: Object, callback?: (err: any, raw: any) => void): Query<any>;
+    update(doc: Object, options: ModelUpdateOptions,
+      callback?: (err: any, raw: any) => void): Query<any>;
+
+    /**
+     * Executes registered validation rules for this document.
+     * @param optional options internal options
+     * @param callback callback called after validation completes, passing an error if one occurred
+     */
+    validate(callback?: (err: any) => void): _MongoosePromise<void>;
+    validate(optional: Object, callback?: (err: any) => void): _MongoosePromise<void>;
+
+    /**
+     * Executes registered validation rules (skipping asynchronous validators) for this document.
+     * This method is useful if you need synchronous validation.
+     * @param pathsToValidate only validate the given paths
+     * @returns MongooseError if there are errors during validation, or undefined if there is no error.
+     */
+    validateSync(pathsToValidate: string | string[]): Error;
+
+    /** Hash containing current validation errors. */
+    errors: Object;
+    /** The string version of this documents _id. */
+    id: string;
+    /** This documents _id. */
+    _id: any;
+    /** Boolean flag specifying if the document is new. */
+    isNew: boolean;
+    /** The documents schema. */
+    schema: Schema;
+  }
+
+  interface DocumentToObjectOptions {
+    /** apply all getters (path and virtual getters) */
+    getters?: boolean;
+    /** apply virtual getters (can override getters option) */
+    virtuals?: boolean;
+    /** remove empty objects (defaults to true) */
+    minimize?: boolean;
+    /**
+     * A transform function to apply to the resulting document before returning
+     * @param doc The mongoose document which is being converted
+     * @param ret The plain object representation which has been converted
+     * @param options The options in use (either schema options or the options passed inline)
+     */
+    transform?: (doc: any, ret: Object, options: Object) => any;
+    /** depopulate any populated paths, replacing them with their original refs (defaults to false) */
+    depopulate?: boolean;
+    /** whether to include the version key (defaults to true) */
+    versionKey?: boolean;
+    /**
+     * keep the order of object keys. If this is set to true,
+     * Object.keys(new Doc({ a: 1, b: 2}).toObject()) will
+     * always produce ['a', 'b'] (defaults to false)
+     */
+    retainKeyOrder?: boolean;
+  }
+
+  namespace Types {
+    /*
+      * section types/subdocument.js
+      * http://mongoosejs.com/docs/api.html#types-subdocument-js
+      */
+    class Subdocument extends MongooseDocument {
+      /** Returns the top level document of this sub-document. */
+      ownerDocument(): MongooseDocument;
+
       /**
-       * skipVersioning allows excluding paths from
-       * versioning (the internal revision will not be
-       * incremented even if these paths are updated).
+       * Null-out this subdoc
+       * @param callback optional callback for compatibility with Document.prototype.remove
        */
-      skipVersioning?: Object;
-      /**
-       * If set timestamps, mongoose assigns createdAt
-       * and updatedAt fields to your schema, the type
-       * assigned is Date.
-       */
-      timestamps?: Object;
+      remove(callback?: (err: any) => void): void;
+      remove(options: Object, callback?: (err: any) => void): void;
     }
 
     /*
-     * section document.js
-     * http://mongoosejs.com/docs/api.html#document-js
-     */
-    class Document {
-      /** Checks if a path is set to its default. */
-      $isDefault(path?: string): boolean;
+      * section types/array.js
+      * http://mongoosejs.com/docs/api.html#types-array-js
+      */
+    class Array<T> extends global.Array {
+      /**
+       * Atomically shifts the array at most one time per document save().
+       * Calling this mulitple times on an array before saving sends the same command as
+       * calling it once. This update is implemented using the MongoDB $pop method which
+       * enforces this restriction.
+       */
+      $shift(): T;
+
+      /** Alias of pull */
+      remove(...args: any[]): this;
 
       /**
-       * Takes a populated field and returns it to its unpopulated state.
-       * If the path was not populated, this is a no-op.
+       * Pops the array atomically at most one time per document save().
+       * Calling this mulitple times on an array before saving sends the same command as
+       * calling it once. This update is implemented using the MongoDB $pop method which
+       * enforces this restriction.
        */
-      depopulate(path: string): void;
+      $pop(): T;
 
       /**
-       * Returns true if the Document stores the same data as doc.
-       * Documents are considered equal when they have matching _ids, unless neither document
-       * has an _id, in which case this function falls back to usin deepEqual().
-       * @param doc a document to compare
+       * Adds values to the array if not already present.
+       * @returns the values that were added
        */
-      equals(doc: Document): boolean;
+      addToSet(...args: any[]): T[];
 
       /**
-       * Explicitly executes population and returns a promise.
-       * Useful for ES2015 integration.
-       * @returns promise that resolves to the document when population is done
+       * Return the index of obj or -1 if not found.
+       * @param obj he item to look for
        */
-      execPopulate(): _MongoosePromise<this>;
-
-      /**
-       * Returns the value of a path.
-       * @param type optionally specify a type for on-the-fly attributes
-       */
-      get(path: string, type?: any): any;
-
-      /**
-       * Initializes the document without setters or marking anything modified.
-       * Called internally after a document is returned from mongodb.
-       * @param doc document returned by mongo
-       * @param fn callback
-       */
-      init(doc: Document, fn?: () => void): this;
-      init(doc: Document, opts: Object, fn?: () => void): this;
+      indexOf(obj: any): number;
 
       /** Helper for console.log */
-      inspect(options?: Object): any;
+      inspect(): any;
+
+      /**
+       * Marks the entire array as modified, which if saved, will store it as a $set
+       * operation, potentially overwritting any changes that happen between when you
+       * retrieved the object and when you save it.
+       * @returns new length of the array
+       */
+      nonAtomicPush(...args: any[]): number;
+
+      /**
+       * Wraps Array#pop with proper change tracking.
+       * marks the entire array as modified which will pass the entire thing to $set
+       * potentially overwritting any changes that happen between when you retrieved
+       * the object and when you save it.
+       */
+      pop(): T;
+
+      /**
+       * Pulls items from the array atomically. Equality is determined by casting
+       * the provided value to an embedded document and comparing using
+       * the Document.equals() function.
+       */
+      pull(...args: any[]): this;
+
+      /**
+       * Wraps Array#push with proper change tracking.
+       * @returns new length of the array
+       */
+      push(...args: any[]): number;
+
+      /** Sets the casted val at index i and marks the array modified. */
+      set(i: number, val: any): this;
+
+      /**
+       * Wraps Array#shift with proper change tracking.
+       * Marks the entire array as modified, which if saved, will store it as a $set operation,
+       * potentially overwritting any changes that happen between when you retrieved the object
+       * and when you save it.
+       */
+      shift(): T;
+
+      /**
+       * Wraps Array#sort with proper change tracking.
+       * Marks the entire array as modified, which if saved, will store it as a $set operation,
+       * potentially overwritting any changes that happen between when you retrieved the object
+       * and when you save it.
+       */
+      // some lib.d.ts have return type "this" and others have return type "T[]"
+      // which causes errors. Let the inherited array provide the sort() method.
+      //sort(compareFn?: (a: T, b: T) => number): T[];
+
+      /**
+       * Wraps Array#splice with proper change tracking and casting.
+       * Marks the entire array as modified, which if saved, will store it as a $set operation,
+       * potentially overwritting any changes that happen between when you retrieved the object
+       * and when you save it.
+       */
+      splice(...args: any[]): T[];
+
+      /** Returns a native js Array. */
+      toObject(options?: Object): T[];
+
+      /**
+       * Wraps Array#unshift with proper change tracking.
+       * Marks the entire array as modified, which if saved, will store it as a $set operation,
+       * potentially overwritting any changes that happen between when you retrieved the object
+       * and when you save it.
+       */
+      unshift(...args: any[]): number;
+    }
+
+    /*
+      * section types/documentarray.js
+      * http://mongoosejs.com/docs/api.html#types-documentarray-js
+      */
+    class DocumentArray<T extends MongooseDocument> extends Types.Array<T> {
+      /**
+       * Creates a subdocument casted to this schema.
+       * This is the same subdocument constructor used for casting.
+       * @param obj the value to cast to this arrays SubDocument schema
+       */
+      create(obj: Object): Subdocument;
+
+      /**
+       * Searches array items for the first document with a matching _id.
+       * @returns the subdocument or null if not found.
+       */
+      id(id: ObjectId | string | number | NativeBuffer): Embedded;
+
+      /** Helper for console.log */
+      inspect(): T[];
+
+      /**
+       * Returns a native js Array of plain js objects
+       * @param options optional options to pass to each documents toObject
+       *   method call during conversion
+       */
+      toObject(options?: Object): T[];
+    }
+
+    /*
+      * section types/buffer.js
+      * http://mongoosejs.com/docs/api.html#types-buffer-js
+      */
+    class Buffer extends global.Buffer {
+      /**
+       * Copies the buffer.
+       * Buffer#copy does not mark target as modified so you must copy
+       * from a MongooseBuffer for it to work as expected. This is a
+       * work around since copy modifies the target, not this.
+       */
+      copy(target: NativeBuffer, ...nodeBufferArgs: any[]): number;
+
+      /** Determines if this buffer is equals to other buffer */
+      equals(other: NativeBuffer): boolean;
+
+      /** Sets the subtype option and marks the buffer modified. */
+      subtype(subtype: number): void;
+
+      /** Converts this buffer to its Binary type representation. */
+      toObject(subtype?: number): mongodb.Binary;
+
+      /** Writes the buffer. */
+      write(string: string, ...nodeBufferArgs: any[]): number;
+    }
+
+    /*
+      * section types/objectid.js
+      * http://mongoosejs.com/docs/api.html#types-objectid-js
+      */
+    var ObjectId: typeof mongodb.ObjectID;
+    interface ObjectId extends mongodb.ObjectID {}
+
+    /*
+      * section types/embedded.js
+      * http://mongoosejs.com/docs/api.html#types-embedded-js
+      */
+    class Embedded extends MongooseDocument {
+      /** Helper for console.log */
+      inspect(): Object;
 
       /**
        * Marks a path as invalid, causing validation to fail.
-       * The errorMsg argument will become the message of the ValidationError.
-       * The value argument (if passed) will be available through the ValidationError.value property.
        * @param path the field to invalidate
-       * @param errorMsg the error which states the reason path was invalid
-       * @param value optional invalid value
-       * @param kind optional kind property for the error
-       * @returns the current ValidationError, with all currently invalidated paths
+       * @param err error which states the reason path was invalid
        */
-      invalidate(path: string, errorMsg: string | NativeError, value: any, kind?: string): ValidationError | boolean;
+      invalidate(path: string, err: string | NativeError): boolean;
 
-      /** Returns true if path was directly set and modified, else false. */
-      isDirectModified(path: string): boolean;
+      /** Returns the top level document of this sub-document. */
+      ownerDocument(): MongooseDocument;
+      /** Returns this sub-documents parent document. */
+      parent(): MongooseDocument;
+      /** Returns this sub-documents parent array. */
+      parentArray(): DocumentArray<MongooseDocument>;
 
-      /** Checks if path was initialized */
-      isInit(path: string): boolean;
+      /** Removes the subdocument from its parent array. */
+      remove(options?: {
+        noop?: boolean;
+      }, fn?: (err: any) => void): this;
 
       /**
-       * Returns true if this document was modified, else false.
-       * If path is given, checks if a path or any full path containing path as part of its path
-       * chain has been modified.
-       */
-      isModified(path?: string): boolean;
-
-      /** Checks if path was selected in the source query which initialized this document. */
-      isSelected(path: string): boolean;
-
-      /**
-       * Marks the path as having pending changes to write to the db.
-       * Very helpful when using Mixed types.
-       * @param path the path to mark modified
+       * Marks the embedded doc modified.
+       * @param path the path which changed
        */
       markModified(path: string): void;
-
-      /** Returns the list of paths that have been modified. */
-      modifiedPaths(): string[];
-
-      /**
-       * Populates document references, executing the callback when complete.
-       * If you want to use promises instead, use this function with
-       * execPopulate()
-       * Population does not occur unless a callback is passed or you explicitly
-       * call execPopulate(). Passing the same path a second time will overwrite
-       * the previous path options. See Model.populate() for explaination of options.
-       * @param path The path to populate or an options object
-       * @param callback When passed, population is invoked
-       */
-      populate(callback: (err: any, res: this) => void): this;
-      populate(path: string, callback?: (err: any, res: this) => void): this;
-      populate(options: ModelPopulateOptions, callback?: (err: any, res: this) => void): this;
-
-      /** Gets _id(s) used during population of the given path. If the path was not populated, undefined is returned. */
-      populated(path: string): any;
-
-      /**
-       * Sets the value of a path, or many paths.
-       * @param path path or object of key/vals to set
-       * @param val the value to set
-       * @param type optionally specify a type for "on-the-fly" attributes
-       * @param options optionally specify options that modify the behavior of the set
-       */
-      set(path: string, val: any, options?: Object): void;
-      set(path: string, val: any, type: any, options?: Object): void;
-      set(value: Object): void;
-
-      /**
-       * The return value of this method is used in calls to JSON.stringify(doc).
-       * This method accepts the same options as Document#toObject. To apply the
-       * options to every document of your schema by default, set your schemas
-       * toJSON option to the same argument.
-       */
-      toJSON(options?: DocumentToObjectOptions): Object;
-
-      /**
-       * Converts this document into a plain javascript object, ready for storage in MongoDB.
-       * Buffers are converted to instances of mongodb.Binary for proper storage.
-       */
-      toObject(options?: DocumentToObjectOptions): Object;
-
-      /** Helper for console.log */
-      toString(): string;
-
-      /**
-       * Clears the modified state on the specified path.
-       * @param path the path to unmark modified
-       */
-      unmarkModified(path: string): void;
-
-      /** Sends an update command with this document _id as the query selector.  */
-      update(doc: Object, callback?: (err: any, raw: any) => void): Query<any>;
-      update(doc: Object, options: ModelUpdateOptions,
-        callback?: (err: any, raw: any) => void): Query<any>;
-
-      /**
-       * Executes registered validation rules for this document.
-       * @param optional options internal options
-       * @param callback callback called after validation completes, passing an error if one occurred
-       */
-      validate(callback?: (err: any) => void): _MongoosePromise<void>;
-      validate(optional: Object, callback?: (err: any) => void): _MongoosePromise<void>;
-
-      /**
-       * Executes registered validation rules (skipping asynchronous validators) for this document.
-       * This method is useful if you need synchronous validation.
-       * @param pathsToValidate only validate the given paths
-       * @returns MongooseError if there are errors during validation, or undefined if there is no error.
-       */
-      validateSync(pathsToValidate: string | string[]): _mongoose.Error;
-
-      /** Hash containing current validation errors. */
-      errors: Object;
-      /** The string version of this documents _id. */
-      id: string;
-      /** This documents _id. */
-      _id: any;
-      /** Boolean flag specifying if the document is new. */
-      isNew: boolean;
-      /** The documents schema. */
-      schema: Schema;
     }
+  }
 
-    interface DocumentToObjectOptions {
-      /** apply all getters (path and virtual getters) */
-      getters?: boolean;
-      /** apply virtual getters (can override getters option) */
-      virtuals?: boolean;
-      /** remove empty objects (defaults to true) */
-      minimize?: boolean;
-      /**
-       * A transform function to apply to the resulting document before returning
-       * @param doc The mongoose document which is being converted
-       * @param ret The plain object representation which has been converted
-       * @param options The options in use (either schema options or the options passed inline)
-       */
-      transform?: (doc: Model<any>, ret: Object, options: Object) => any;
-      /** depopulate any populated paths, replacing them with their original refs (defaults to false) */
-      depopulate?: boolean;
-      /** whether to include the version key (defaults to true) */
-      versionKey?: boolean;
-      /**
-       * keep the order of object keys. If this is set to true,
-       * Object.keys(new Doc({ a: 1, b: 2}).toObject()) will
-       * always produce ['a', 'b'] (defaults to false)
-       */
-      retainKeyOrder?: boolean;
-    }
+  /*
+   * section query.js
+   * http://mongoosejs.com/docs/api.html#query-js
+   */
+  class Query<T> extends ModelQuery<T, any> {}
 
-    namespace Types {
-      /*
-       * section types/subdocument.js
-       * http://mongoosejs.com/docs/api.html#types-subdocument-js
-       */
-      class Subdocument extends Document {
-        /** Returns the top level document of this sub-document. */
-        ownerDocument(): Document;
-
-        /**
-         * Null-out this subdoc
-         * @param callback optional callback for compatibility with Document.prototype.remove
-         */
-        remove(callback?: (err: any) => void): void;
-        remove(options: Object, callback?: (err: any) => void): void;
-      }
-
-      /*
-       * section types/array.js
-       * http://mongoosejs.com/docs/api.html#types-array-js
-       */
-      class Array<T> extends global.Array {
-        /**
-         * Atomically shifts the array at most one time per document save().
-         * Calling this mulitple times on an array before saving sends the same command as
-         * calling it once. This update is implemented using the MongoDB $pop method which
-         * enforces this restriction.
-         */
-        $shift(): T;
-
-        /** Alias of pull */
-        remove(...args: any[]): this;
-
-        /**
-         * Pops the array atomically at most one time per document save().
-         * Calling this mulitple times on an array before saving sends the same command as
-         * calling it once. This update is implemented using the MongoDB $pop method which
-         * enforces this restriction.
-         */
-        $pop(): T;
-
-        /**
-         * Adds values to the array if not already present.
-         * @returns the values that were added
-         */
-        addToSet(...args: any[]): T[];
-
-        /**
-         * Return the index of obj or -1 if not found.
-         * @param obj he item to look for
-         */
-        indexOf(obj: any): number;
-
-        /** Helper for console.log */
-        inspect(): any;
-
-        /**
-         * Marks the entire array as modified, which if saved, will store it as a $set
-         * operation, potentially overwritting any changes that happen between when you
-         * retrieved the object and when you save it.
-         * @returns new length of the array
-         */
-        nonAtomicPush(...args: any[]): number;
-
-        /**
-         * Wraps Array#pop with proper change tracking.
-         * marks the entire array as modified which will pass the entire thing to $set
-         * potentially overwritting any changes that happen between when you retrieved
-         * the object and when you save it.
-         */
-        pop(): T;
-
-        /**
-         * Pulls items from the array atomically. Equality is determined by casting
-         * the provided value to an embedded document and comparing using
-         * the Document.equals() function.
-         */
-        pull(...args: any[]): this;
-
-        /**
-         * Wraps Array#push with proper change tracking.
-         * @returns new length of the array
-         */
-        push(...args: any[]): number;
-
-        /** Sets the casted val at index i and marks the array modified. */
-        set(i: number, val: any): this;
-
-        /**
-         * Wraps Array#shift with proper change tracking.
-         * Marks the entire array as modified, which if saved, will store it as a $set operation,
-         * potentially overwritting any changes that happen between when you retrieved the object
-         * and when you save it.
-         */
-        shift(): T;
-
-        /**
-         * Wraps Array#sort with proper change tracking.
-         * Marks the entire array as modified, which if saved, will store it as a $set operation,
-         * potentially overwritting any changes that happen between when you retrieved the object
-         * and when you save it.
-         */
-        // some lib.d.ts have return type "this" and others have return type "T[]"
-        // which causes errors. Let the inherited array provide the sort() method.
-        //sort(compareFn?: (a: T, b: T) => number): T[];
-
-        /**
-         * Wraps Array#splice with proper change tracking and casting.
-         * Marks the entire array as modified, which if saved, will store it as a $set operation,
-         * potentially overwritting any changes that happen between when you retrieved the object
-         * and when you save it.
-         */
-        splice(...args: any[]): T[];
-
-        /** Returns a native js Array. */
-        toObject(options?: Object): T[];
-
-        /**
-         * Wraps Array#unshift with proper change tracking.
-         * Marks the entire array as modified, which if saved, will store it as a $set operation,
-         * potentially overwritting any changes that happen between when you retrieved the object
-         * and when you save it.
-         */
-        unshift(...args: any[]): number;
-      }
-
-      /*
-       * section types/documentarray.js
-       * http://mongoosejs.com/docs/api.html#types-documentarray-js
-       */
-      class DocumentArray<T extends Document> extends _mongoose.Types.Array<T> {
-        /**
-         * Creates a subdocument casted to this schema.
-         * This is the same subdocument constructor used for casting.
-         * @param obj the value to cast to this arrays SubDocument schema
-         */
-        create(obj: Object): Subdocument;
-
-        /**
-         * Searches array items for the first document with a matching _id.
-         * @returns the subdocument or null if not found.
-         */
-        id(id: ObjectId | string | number | NativeBuffer): Embedded;
-
-        /** Helper for console.log */
-        inspect(): T[];
-
-        /**
-         * Returns a native js Array of plain js objects
-         * @param options optional options to pass to each documents toObject
-         *   method call during conversion
-         */
-        toObject(options?: Object): T[];
-      }
-
-      /*
-       * section types/buffer.js
-       * http://mongoosejs.com/docs/api.html#types-buffer-js
-       */
-      class Buffer extends global.Buffer {
-        /**
-         * Copies the buffer.
-         * Buffer#copy does not mark target as modified so you must copy
-         * from a MongooseBuffer for it to work as expected. This is a
-         * work around since copy modifies the target, not this.
-         */
-        copy(target: NativeBuffer, ...nodeBufferArgs: any[]): number;
-
-        /** Determines if this buffer is equals to other buffer */
-        equals(other: NativeBuffer): boolean;
-
-        /** Sets the subtype option and marks the buffer modified. */
-        subtype(subtype: number): void;
-
-        /** Converts this buffer to its Binary type representation. */
-        toObject(subtype?: number): mongodb.Binary;
-
-        /** Writes the buffer. */
-        write(string: string, ...nodeBufferArgs: any[]): number;
-      }
-
-      /*
-       * section types/objectid.js
-       * http://mongoosejs.com/docs/api.html#types-objectid-js
-       */
-      var ObjectId: typeof mongodb.ObjectID;
-      interface ObjectId extends mongodb.ObjectID {}
-
-      /*
-       * section types/embedded.js
-       * http://mongoosejs.com/docs/api.html#types-embedded-js
-       */
-      class Embedded extends Document {
-        /** Helper for console.log */
-        inspect(): Object;
-
-        /**
-         * Marks a path as invalid, causing validation to fail.
-         * @param path the field to invalidate
-         * @param err error which states the reason path was invalid
-         */
-        invalidate(path: string, err: string | NativeError): boolean;
-
-        /** Returns the top level document of this sub-document. */
-        ownerDocument(): Document;
-        /** Returns this sub-documents parent document. */
-        parent(): Document;
-        /** Returns this sub-documents parent array. */
-        parentArray(): DocumentArray<Document>;
-
-        /** Removes the subdocument from its parent array. */
-        remove(options?: {
-          noop?: boolean;
-        }, fn?: (err: any) => void): this;
-
-        /**
-         * Marks the embedded doc modified.
-         * @param path the path which changed
-         */
-        markModified(path: string): void;
-      }
-    }
-
-    /*
-     * section query.js
-     * http://mongoosejs.com/docs/api.html#query-js
+  /*
+   * Query.find() will return Query<Model<T>[]> however we need the
+   * type T to create this so we save T in another parameter.
+   */
+  class ModelQuery<T, ModelType extends Document> extends mquery {
+    /**
+     * Specifies a javascript function or expression to pass to MongoDBs query system.
+     * Only use $where when you have a condition that cannot be met using other MongoDB
+     * operators like $lt. Be sure to read about all of its caveats before using.
+     * @param js javascript string or function
      */
-    type Query<T> = ModelQuery<T, any>;
-
-    /*
-     * Query.find() will return Query<Model<T>[]> however we need the
-     * type T to create this so we save T in another parameter.
-     */
-    class ModelQuery<T, ModelType> extends mquery {
-      /**
-       * Specifies a javascript function or expression to pass to MongoDBs query system.
-       * Only use $where when you have a condition that cannot be met using other MongoDB
-       * operators like $lt. Be sure to read about all of its caveats before using.
-       * @param js javascript string or function
-       */
-      $where(js: string | Function): this;
-
-      /**
-       * Specifies an $all query condition.
-       * When called with one argument, the most recent path passed to where() is used.
-       */
-      all(val: number): this;
-      all(path: string, val: number): this;
-
-      /**
-       * Specifies arguments for a $and condition.
-       * @param array array of conditions
-       */
-      and(array: Object[]): this;
-
-      /** Specifies the batchSize option. Cannot be used with distinct() */
-      batchSize(val: number): this;
-
-      /**
-       * Specifies a $box condition
-       * @param Upper Right Coords
-       */
-      box(val: Object): this;
-      box(lower: number[], upper: number[]): this;
-
-      /** Casts this query to the schema of model, If obj is present, it is cast instead of this query.*/
-      cast(model: Model<any> | ModelConstructor<any>, obj?: Object): Object;
-
-      /**
-       * Executes the query returning a Promise which will be
-       * resolved with either the doc(s) or rejected with the error.
-       * Like .then(), but only takes a rejection handler.
-       */
-      catch<TRes>(reject?: (err: any) => void | TRes | PromiseLike<TRes>): _MongoosePromise<TRes>;
-
-      /**
-       * DEPRECATED Alias for circle
-       * Specifies a $center or $centerSphere condition.
-       * @deprecated Use circle instead.
-       */
-      center(area: Object): this;
-      center(path: string, area: Object): this;
-
-      /**
-       * DEPRECATED Specifies a $centerSphere condition
-       * @deprecated Use circle instead.
-       */
-      centerSphere(path: string, val: Object): this;
-      centerSphere(val: Object): this;
-
-      /** Specifies a $center or $centerSphere condition. */
-      circle(area: Object): this;
-      circle(path: string, area: Object): this;
-
-      /** Specifies the comment option. Cannot be used with distinct() */
-      comment(val: string): this;
-
-      /**
-       * Specifying this query as a count query. Passing a callback executes the query.
-       * @param criteria mongodb selector
-       */
-      count(callback?: (err: any, count: number) => void): Query<number>;
-      count(criteria: Object, callback?: (err: any, count: number) => void): Query<number>;
-
-      /**
-       * Returns a wrapper around a mongodb driver cursor. A Query<T>Cursor exposes a
-       * Streams3-compatible interface, as well as a .next() function.
-       */
-      cursor(options?: Object): QueryCursor<T>;
-
-      /** Declares or executes a distict() operation. Passing a callback executes the query. */
-      distinct(callback?: (err: any, res: any[]) => void): Query<any[]>;
-      distinct(field: string, callback?: (err: any, res: any[]) => void): Query<any[]>;
-      distinct(field: string, criteria: Object | Query<any>,
-        callback?: (err: any, res: any[]) => void): Query<any[]>;
-
-      /** Specifies an $elemMatch condition */
-      elemMatch(criteria: (elem: Query<any>) => void): this;
-      elemMatch(criteria: Object): this;
-      elemMatch(path: string | Object | Function, criteria: (elem: Query<any>) => void): this;
-      elemMatch(path: string | Object | Function, criteria: Object): this;
-
-      /** Specifies the complementary comparison value for paths specified with where() */
-      equals(val: Object): this;
-
-      /** Executes the query */
-      exec(callback?: (err: any, res: T) => void): _MongoosePromise<T>;
-      exec(operation: string | Function, callback?: (err: any, res: T) => void): _MongoosePromise<T>;
-
-      /** Specifies an $exists condition */
-      exists(val?: boolean): this;
-      exists(path: string, val?: boolean): this;
-
-      /**
-       * Finds documents. When no callback is passed, the query is not executed. When the
-       * query is executed, the result will be an array of documents.
-       * @param criteria mongodb selector
-       */
-      find(callback?: (err: any, res: Model<ModelType>[]) => void): ModelQuery<Model<ModelType>[], ModelType>;
-      find(criteria: Object,
-        callback?: (err: any, res: Model<ModelType>[]) => void): ModelQuery<Model<ModelType>[], ModelType>;
-
-      /**
-       * Declares the query a findOne operation. When executed, the first found document is
-       * passed to the callback. Passing a callback executes the query. The result of the query
-       * is a single document.
-       * @param criteria mongodb selector
-       * @param projection optional fields to return
-       */
-      findOne(callback?: (err: any, res: Model<ModelType>) => void): ModelQuery<Model<ModelType>, ModelType>;
-      findOne(criteria: Object,
-        callback?: (err: any, res: Model<ModelType>) => void): ModelQuery<Model<ModelType>, ModelType>;
-
-      /**
-       * Issues a mongodb findAndModify remove command.
-       * Finds a matching document, removes it, passing the found document (if any) to the
-       * callback. Executes immediately if callback is passed.
-       */
-      findOneAndRemove(callback?: (error: any, doc: Model<ModelType>, result: any) => void): ModelQuery<Model<ModelType>, ModelType>;
-      findOneAndRemove(conditions: Object,
-        callback?: (error: any, doc: Model<ModelType>, result: any) => void): ModelQuery<Model<ModelType>, ModelType>;
-      findOneAndRemove(conditions: Object, options: QueryFindOneAndRemoveOptions,
-        callback?: (error: any, doc: Model<ModelType>, result: any) => void): ModelQuery<Model<ModelType>, ModelType>;
-
-      /**
-       * Issues a mongodb findAndModify update command.
-       * Finds a matching document, updates it according to the update arg, passing any options, and returns
-       * the found document (if any) to the callback. The query executes immediately if callback is passed.
-       */
-      findOneAndUpdate(callback?: (err: any, doc: Model<ModelType>) => void): ModelQuery<Model<ModelType>, ModelType>;
-      findOneAndUpdate(update: Object,
-        callback?: (err: any, doc: Model<ModelType>) => void): ModelQuery<Model<ModelType>, ModelType>;
-      findOneAndUpdate(query: Object | Query<any>, update: Object,
-        callback?: (err: any, doc: Model<ModelType>) => void): ModelQuery<Model<ModelType>, ModelType>;
-      findOneAndUpdate(query: Object | Query<any>, update: Object, options: QueryFindOneAndUpdateOptions,
-        callback?: (err: any, doc: Model<ModelType>) => void): ModelQuery<Model<ModelType>, ModelType>;
-
-      /**
-       * Specifies a $geometry condition. geometry() must come after either intersects() or within().
-       * @param object Must contain a type property which is a String and a coordinates property which
-       *   is an Array. See the examples.
-       */
-      geometry(object: { type: string, coordinates: any[] }): this;
-
-      /**
-       * Returns the current query conditions as a JSON object.
-       * @returns current query conditions
-       */
-      getQuery(): any;
-
-      /**
-       * Returns the current update operations as a JSON object.
-       * @returns current update operations
-       */
-      getUpdate(): any;
-
-      /**
-       * Specifies a $gt query condition.
-       * When called with one argument, the most recent path passed to where() is used.
-       */
-      gt(val: number): this;
-      gt(path: string, val: number): this;
-
-      /**
-       * Specifies a $gte query condition.
-       * When called with one argument, the most recent path passed to where() is used.
-       */
-      gte(val: number): this;
-      gte(path: string, val: number): this;
-
-      /**
-       * Sets query hints.
-       * @param val a hint object
-       */
-      hint(val: Object): this;
-
-      /**
-       * Specifies an $in query condition.
-       * When called with one argument, the most recent path passed to where() is used.
-       */
-      in(val: any[]): this;
-      in(path: string, val: any[]): this;
-
-      /** Declares an intersects query for geometry(). MUST be used after where(). */
-      intersects(arg?: Object): this;
-
-      /**
-       * Sets the lean option.
-       * Documents returned from queries with the lean option enabled are plain
-       * javascript objects, not MongooseDocuments. They have no save method,
-       * getters/setters or other Mongoose magic applied.
-       * @param bool defaults to true
-       */
-      lean(bool?: boolean): Query<Object>;
-
-      /** Specifies the maximum number of documents the query will return. Cannot be used with distinct() */
-      limit(val: number): this;
-
-      /**
-       * Specifies a $lt query condition.
-       * When called with one argument, the most recent path passed to where() is used.
-       */
-      lt(val: number): this;
-      lt(path: string, val: number): this;
-
-      /**
-       * Specifies a $lte query condition.
-       * When called with one argument, the most recent path passed to where() is used.
-       */
-      lte(val: number): this;
-      lte(path: string, val: number): this;
-
-      /**
-       * Specifies a $maxDistance query condition.
-       * When called with one argument, the most recent path passed to where() is used.
-       */
-      maxDistance(val: number): this;
-      maxDistance(path: string, val: number): this;
-
-      /** @deprecated Alias of maxScan */
-      maxscan(val: number): this;
-      /** Specifies the maxScan option. Cannot be used with distinct() */
-      maxScan(val: number): this;
-
-      /**
-       * Merges another Query or conditions object into this one.
-       * When a Query is passed, conditions, field selection and options are merged.
-       */
-      merge(source: Object | Query<any>): this;
-
-      /** Specifies a $mod condition */
-      mod(val: number[]): this;
-      mod(path: string, val: number[]): this;
-
-      /**
-       * Specifies a $ne query condition.
-       * When called with one argument, the most recent path passed to where() is used.
-       */
-      ne(val: any): this;
-      ne(path: string, val: any): this;
-
-      /** Specifies a $near or $nearSphere condition. */
-      near(val: Object): this;
-      near(path: string, val: Object): this;
-
-      /**
-       * DEPRECATED Specifies a $nearSphere condition
-       * @deprecated Use query.near() instead with the spherical option set to true.
-       */
-      nearSphere(val: Object): this;
-      nearSphere(path: string, val: Object): this;
-
-      /**
-       * Specifies a $nin query condition.
-       * When called with one argument, the most recent path passed to where() is used.
-       */
-      nin(val: any[]): this;
-      nin(path: string, val: any[]): this;
-
-      /**
-       * Specifies arguments for a $nor condition.
-       * @param array array of conditions
-       */
-      nor(array: Object[]): this;
-
-      /**
-       * Specifies arguments for an $or condition.
-       * @param array array of conditions
-       */
-      or(array: Object[]): this;
-
-      /** Specifies a $polygon condition */
-      polygon(...coordinatePairs: number[][]): this;
-      polygon(path: string, ...coordinatePairs: number[][]): this;
-
-      /**
-       * Specifies paths which should be populated with other documents.
-       * Paths are populated after the query executes and a response is received. A separate
-       * query is then executed for each path specified for population. After a response for
-       * each query has also been returned, the results are passed to the callback.
-       * @param path either the path to populate or an object specifying all parameters
-       * @param select Field selection for the population query
-       * @param model The model you wish to use for population. If not specified, populate
-       *   will look up the model by the name in the Schema's ref field.
-       * @param match Conditions for the population query
-       * @param options Options for the population query (sort, etc)
-       */
-      populate(path: string | Object, select?: string | Object, model?: string | Model<T>,
-        match?: Object, options?: Object): this;
-      populate(options: ModelPopulateOptions): this;
-
-      /**
-       * Determines the MongoDB nodes from which to read.
-       * @param pref one of the listed preference options or aliases
-       * @tags optional tags for this query
-       */
-      read(pref: string, tags?: Object[]): this;
-
-      /**
-       * Specifies a $regex query condition.
-       * When called with one argument, the most recent path passed to where() is used.
-       */
-      regex(val: RegExp): this;
-      regex(path: string, val: RegExp): this;
-
-      /**
-       * Declare and/or execute this query as a remove() operation.
-       * The operation is only executed when a callback is passed. To force execution without a callback,
-       * you must first call remove() and then execute it by using the exec() method.
-       * @param criteria mongodb selector
-       */
-      remove(callback?: (err: any) => void): Query<void>;
-      remove(criteria: Object | Query<any>, callback?: (err: any) => void): Query<void>;
-
-      /** Specifies which document fields to include or exclude (also known as the query "projection") */
-      select(arg: string | Object): this;
-      /** Determines if field selection has been made. */
-      selected(): boolean;
-      /** Determines if exclusive field selection has been made.*/
-      selectedExclusively(): boolean;
-      /** Determines if inclusive field selection has been made. */
-      selectedInclusively(): boolean;
-      /** Sets query options. */
-      setOptions(options: Object): this;
-
-      /**
-       * Specifies a $size query condition.
-       * When called with one argument, the most recent path passed to where() is used.
-       */
-      size(val: number): this;
-      size(path: string, val: number): this;
-
-      /** Specifies the number of documents to skip. Cannot be used with distinct() */
-      skip(val: number): this;
-
-      /**
-       * DEPRECATED Sets the slaveOk option.
-       * @param v defaults to true
-       * @deprecated in MongoDB 2.2 in favor of read preferences.
-       */
-      slaveOk(v?: boolean): this;
-
-      /**
-       * Specifies a $slice projection for an array.
-       * @param val number/range of elements to slice
-       */
-      slice(val: number | number[]): this;
-      slice(path: string, val: number | number[]): this;
-
-      /** Specifies this query as a snapshot query. Cannot be used with distinct() */
-      snapshot(v?: boolean): this;
-
-      /**
-       * Sets the sort order
-       * If an object is passed, values allowed are asc, desc, ascending, descending, 1, and -1.
-       * If a string is passed, it must be a space delimited list of path names. The
-       * sort order of each path is ascending unless the path name is prefixed with -
-       * which will be treated as descending.
-       */
-      sort(arg: string | Object): this;
-
-      /** Returns a Node.js 0.8 style read stream interface. */
-      stream(options?: { transform?: Function; }): QueryStream;
-
-      /**
-       * Sets the tailable option (for use with capped collections). Cannot be used with distinct()
-       * @param bool defaults to true
-       * @param opts options to set
-       * @param opts.numberOfRetries if cursor is exhausted, retry this many times before giving up
-       * @param opts.tailableRetryInterval if cursor is exhausted, wait this many milliseconds before retrying
-       */
-      tailable(bool?: boolean, opts?: {
-        numberOfRetries?: number;
-        tailableRetryInterval?: number;
-      }): this;
-
-      /** Executes this query and returns a promise */
-      then<TRes>(resolve?: (res: T) => void | TRes | PromiseLike<TRes>,
-        reject?: (err: any) =>  void | TRes | PromiseLike<TRes>): _MongoosePromise<TRes>;
-
-      /**
-       * Converts this query to a customized, reusable query
-       * constructor with all arguments and options retained.
-       */
-      toConstructor(): typeof ModelQuery;
-
-      /**
-       * Declare and/or execute this query as an update() operation.
-       * All paths passed that are not $atomic operations will become $set ops.
-       * @param doc the update command
-       */
-      update(callback?: (err: any, affectedRows: number) => void): Query<number>;
-      update(doc: Object, callback?: (err: any, affectedRows: number) => void): Query<number>;
-      update(criteria: Object, doc: Object,
-        callback?: (err: any, affectedRows: number) => void): Query<number>;
-      update(criteria: Object, doc: Object, options: QueryUpdateOptions,
-        callback?: (err: any, affectedRows: number) => void): Query<number>;
-
-      /** Specifies a path for use with chaining. */
-      where(path?: string | Object, val?: any): this;
-
-      /** Defines a $within or $geoWithin argument for geo-spatial queries. */
-      within(val?: Object): this;
-      within(coordinate: number[], ...coordinatePairs: number[][]): this;
-
-      /** Flag to opt out of using $geoWithin. */
-      static use$geoWithin: boolean;
-    }
-
-    // https://github.com/aheckmann/mquery
-    // mquery currently does not have a type definition please
-    //   replace it if one is ever created
-    class mquery {}
-
-    interface QueryFindOneAndRemoveOptions {
-      /** if multiple docs are found by the conditions, sets the sort order to choose which doc to update */
-      sort?: any;
-      /** puts a time limit on the query - requires mongodb >= 2.6.0 */
-      maxTimeMS?: number;
-      /** if true, passes the raw result from the MongoDB driver as the third callback parameter */
-      passRawResult?: boolean;
-    }
-
-    interface QueryFindOneAndUpdateOptions extends QueryFindOneAndRemoveOptions {
-      /** if true, return the modified document rather than the original. defaults to false (changed in 4.0) */
-      new?: boolean;
-      /** creates the object if it doesn't exist. defaults to false. */
-      upsert?: boolean;
-      /** Field selection. Equivalent to .select(fields).findOneAndUpdate() */
-      fields?: Object | string;
-      /** if true, runs update validators on this command. Update validators validate the update operation against the model's schema. */
-      runValidators?: boolean;
-      /**
-       * if this and upsert are true, mongoose will apply the defaults specified in the model's schema if a new document
-       * is created. This option only works on MongoDB >= 2.4 because it relies on MongoDB's $setOnInsert operator.
-       */
-      setDefaultsOnInsert?: boolean;
-      /**
-       * if set to 'query' and runValidators is on, this will refer to the query in custom validator
-       * functions that update validation runs. Does nothing if runValidators is false.
-       */
-      context?: string;
-    }
-
-    interface QueryUpdateOptions extends ModelUpdateOptions {
-      /**
-       * if set to 'query' and runValidators is on, this will refer to the query
-       * in customvalidator functions that update validation runs. Does nothing
-       * if runValidators is false.
-       */
-      context?: string;
-    }
-
-    namespace Schema {
-      namespace _Types {
-        /*
-         * section schema/array.js
-         * http://mongoosejs.com/docs/api.html#schema-array-js
-         */
-        class Array extends SchemaType {
-          /** Array SchemaType constructor */
-          constructor(key: string, cast?: SchemaType, options?: Object);
-
-          /**
-           * Check if the given value satisfies a required validator. The given value
-           * must be not null nor undefined, and have a non-zero length.
-           */
-          checkRequired<T extends { length: number }>(value: T): boolean;
-
-          /** This schema type's name, to defend against minifiers that mangle function names. */
-          static schemaName: string;
-        }
-
-        /*
-         * section schema/string.js
-         * http://mongoosejs.com/docs/api.html#schema-string-js
-         */
-        class String extends SchemaType {
-          /** String SchemaType constructor. */
-          constructor(key: string, options?: Object);
-
-          /** Check if the given value satisfies a required validator. */
-          checkRequired(value: any, doc: Document): boolean;
-
-          /**
-           * Adds an enum validator
-           * @param args enumeration values
-           */
-          enum(args: string | string[] | Object): this;
-
-          /** Adds a lowercase setter. */
-          lowercase(): this;
-
-          /**
-           * Sets a regexp validator. Any value that does not pass regExp.test(val) will fail validation.
-           * @param regExp regular expression to test against
-           * @param message optional custom error message
-           */
-          match(regExp: RegExp, message?: string): this;
-
-          /**
-           * Sets a maximum length validator.
-           * @param value maximum string length
-           * @param message optional custom error message
-           */
-          maxlength(value: number, message?: string): this;
-
-          /**
-           * Sets a minimum length validator.
-           * @param value minimum string length
-           * @param message optional custom error message
-           */
-          minlength(value: number, message?: string): this;
-
-          /** Adds a trim setter. The string value will be trimmed when set. */
-          trim(): this;
-          /** Adds an uppercase setter. */
-          uppercase(): this;
-
-          /** This schema type's name, to defend against minifiers that mangle function names. */
-          static schemaName: string;
-
-        }
-
-        /*
-         * section schema/documentarray.js
-         * http://mongoosejs.com/docs/api.html#schema-documentarray-js
-         */
-        class DocumentArray extends Array {
-          /** SubdocsArray SchemaType constructor */
-          constructor(key: string, schema: Schema, options?: Object);
-
-          /** This schema type's name, to defend against minifiers that mangle function names. */
-          static schemaName: string;
-        }
-
-        /*
-         * section schema/number.js
-         * http://mongoosejs.com/docs/api.html#schema-number-js
-         */
-        class Number extends SchemaType {
-          /** Number SchemaType constructor. */
-          constructor(key: string, options?: Object);
-
-          /** Check if the given value satisfies a required validator. */
-          checkRequired(value: any, doc: Document): boolean;
-
-          /**
-           * Sets a maximum number validator.
-           * @param maximum number
-           * @param message optional custom error message
-           */
-          max(maximum: number, message?: string): this;
-
-          /**
-           * Sets a minimum number validator.
-           * @param value minimum number
-           * @param message optional custom error message
-           */
-          min(value: number, message?: string): this;
-
-          /** This schema type's name, to defend against minifiers that mangle function names. */
-          static schemaName: string;
-        }
-
-        /*
-         * section schema/date.js
-         * http://mongoosejs.com/docs/api.html#schema-date-js
-         */
-        class Date extends SchemaType {
-          /** Date SchemaType constructor. */
-          constructor(key: string, options?: Object);
-
-          /**
-           * Check if the given value satisfies a required validator. To satisfy
-           * a required validator, the given value must be an instance of Date.
-           */
-          checkRequired(value: any, doc: Document): boolean;
-
-          /** Declares a TTL index (rounded to the nearest second) for Date types only. */
-          expires(when: number | string): this;
-
-          /**
-           * Sets a maximum date validator.
-           * @param maximum date
-           * @param message optional custom error message
-           */
-          max(maximum: NativeDate, message?: string): this;
-
-          /**
-           * Sets a minimum date validator.
-           * @param value minimum date
-           * @param message optional custom error message
-           */
-          min(value: NativeDate, message?: string): this;
-
-          /** This schema type's name, to defend against minifiers that mangle function names. */
-          static schemaName: string;
-        }
-
-        /*
-         * section schema/buffer.js
-         * http://mongoosejs.com/docs/api.html#schema-buffer-js
-         */
-        class Buffer extends SchemaType {
-          /** Buffer SchemaType constructor */
-          constructor(key: string, options?: Object);
-
-          /**
-           * Check if the given value satisfies a required validator. To satisfy a
-           * required validator, a buffer must not be null or undefined and have
-           * non-zero length.
-           */
-          checkRequired(value: any, doc: Document): boolean;
-
-          /** This schema type's name, to defend against minifiers that mangle function names. */
-          static schemaName: string;
-
-        }
-
-        /*
-         * section schema/boolean.js
-         * http://mongoosejs.com/docs/api.html#schema-boolean-js
-         */
-        class Boolean extends SchemaType {
-          /** Boolean SchemaType constructor. */
-          constructor(path: string, options?: Object);
-
-          /**
-           * Check if the given value satisfies a required validator. For a
-           * boolean to satisfy a required validator, it must be strictly
-           * equal to true or to false.
-           */
-          checkRequired(value: any): boolean;
-
-          /** This schema type's name, to defend against minifiers that mangle function names. */
-          static schemaName: string;
-        }
-
-        /*
-         * section schema/objectid.js
-         * http://mongoosejs.com/docs/api.html#schema-objectid-js
-         */
-        class ObjectId extends SchemaType {
-          /** ObjectId SchemaType constructor. */
-          constructor(key: string, options?: Object);
-
-          /**
-           * Adds an auto-generated ObjectId default if turnOn is true.
-           * @param turnOn auto generated ObjectId defaults
-           */
-          auto(turnOn: boolean): this;
-
-          /** Check if the given value satisfies a required validator. */
-          checkRequired(value: any, doc: Document): boolean;
-
-          /** This schema type's name, to defend against minifiers that mangle function names. */
-          static schemaName: string;
-        }
-
-        /*
-         * section schema/mixed.js
-         * http://mongoosejs.com/docs/api.html#schema-mixed-js
-         */
-        class Mixed extends SchemaType {
-          /** Mixed SchemaType constructor. */
-          constructor(path: string, options?: Object);
-
-          /** This schema type's name, to defend against minifiers that mangle function names. */
-          static schemaName: string;
-        }
-
-        /*
-         * section schema/embedded.js
-         * http://mongoosejs.com/docs/api.html#schema-embedded-js
-         */
-        class Embedded extends SchemaType {
-          /** Sub-schema schematype constructor */
-          constructor(schema: Schema, key: string, options?: Object);
-        }
-      }
-    }
-
-    /*
-     * section aggregate.js
-     * http://mongoosejs.com/docs/api.html#aggregate-js
-     */
-    class Aggregate<T> {
-      /**
-       * Aggregate constructor used for building aggregation pipelines.
-       * Returned when calling Model.aggregate().
-       * @param ops aggregation operator(s) or operator array
-       */
-      constructor(ops?: Object | any[], ...args: any[]);
-
-      /** Adds a cursor flag */
-      addCursorFlag(flag: string, value: boolean): this;
-
-      /**
-       * Sets the allowDiskUse option for the aggregation query (ignored for < 2.6.0)
-       * @param value Should tell server it can use hard drive to store data during aggregation.
-       * @param tags optional tags for this query
-       */
-      allowDiskUse(value: boolean, tags?: any[]): this;
-
-      /**
-       * Appends new operators to this aggregate pipeline
-       * @param ops operator(s) to append
-       */
-      append(...ops: Object[]): this;
-
-      /**
-       * Sets the cursor option option for the aggregation query (ignored for < 2.6.0).
-       * Note the different syntax below: .exec() returns a cursor object, and no callback
-       * is necessary.
-       * @param options set the cursor batch size
-       */
-      cursor(options: Object): this;
-
-      // If cursor option is on, could return an object
-      /** Executes the aggregate pipeline on the currently bound Model. */
-      exec(callback?: (err: any, result: T) => void): _MongoosePromise<T> | any;
-
-      /** Execute the aggregation with explain */
-      explain(callback?: (err: any, result: T) => void): _MongoosePromise<T>;
-
-      /**
-       * Appends a new custom $group operator to this aggregate pipeline.
-       * @param arg $group operator contents
-       */
-      group(arg: Object): this;
-
-      /**
-       * Appends a new $limit operator to this aggregate pipeline.
-       * @param num maximum number of records to pass to the next stage
-       */
-      limit(num: number): this;
-
-      /**
-       * Appends new custom $lookup operator(s) to this aggregate pipeline.
-       * @param options to $lookup as described in the above link
-       */
-      lookup(options: Object): this;
-
-      /**
-       * Appends a new custom $match operator to this aggregate pipeline.
-       * @param arg $match operator contents
-       */
-      match(arg: Object): this;
-
-      /**
-       * Binds this aggregate to a model.
-       * @param model the model to which the aggregate is to be bound
-       */
-      model(model: Model<any>): this;
-
-      /**
-       * Appends a new $geoNear operator to this aggregate pipeline.
-       * MUST be used as the first operator in the pipeline.
-       */
-      near(parameters: Object): this;
-
-      /**
-       * Appends a new $project operator to this aggregate pipeline.
-       * Mongoose query selection syntax is also supported.
-       * @param arg field specification
-       */
-      project(arg: string | Object): this;
-
-      /**
-       * Sets the readPreference option for the aggregation query.
-       * @param pref one of the listed preference options or their aliases
-       * @param tags optional tags for this query
-       */
-      read(pref: string, tags?: Object[]): this;
-
-      /**
-       * Appends new custom $sample operator(s) to this aggregate pipeline.
-       * @param size number of random documents to pick
-       */
-      sample(size: number): this;
-
-      /**
-       * Appends a new $skip operator to this aggregate pipeline.
-       * @param num number of records to skip before next stage
-       */
-      skip(num: number): this;
-
-      /**
-       * Appends a new $sort operator to this aggregate pipeline.
-       * If an object is passed, values allowed are asc, desc, ascending, descending, 1, and -1.
-       * If a string is passed, it must be a space delimited list of path names. The sort order
-       * of each path is ascending unless the path name is prefixed with - which will be treated
-       * as descending.
-       */
-      sort(arg: string | Object): this;
-
-      /** Provides promise for aggregate. */
-      then<TRes>(resolve?: (val: T) =>  void | TRes | PromiseLike<TRes>,
-        reject?: (err: any) =>  void | TRes | PromiseLike<TRes>): _MongoosePromise<TRes>
-
-      /**
-       * Appends new custom $unwind operator(s) to this aggregate pipeline.
-       * Note that the $unwind operator requires the path name to start with '$'.
-       * Mongoose will prepend '$' if the specified field doesn't start '$'.
-       * @param fields the field(s) to unwind
-       */
-      unwind(...fields: string[]): this;
-    }
-
-    /*
-     * section schematype.js
-     * http://mongoosejs.com/docs/api.html#schematype-js
-     */
-    class SchemaType {
-      /** SchemaType constructor */
-      constructor(path: string, options?: Object, instance?: string);
-
-      /**
-       * Sets a default value for this SchemaType.
-       * Defaults can be either functions which return the value to use as the
-       * default or the literal value itself. Either way, the value will be cast
-       * based on its schema type before being set during document creation.
-       * @param val the default value
-       */
-      default(val: any): any;
-
-      /** Adds a getter to this schematype. */
-      get(fn: Function): this;
-
-      /**
-       * Declares the index options for this schematype.
-       * Indexes are created in the background by default. Specify background: false to override.
-       */
-      index(options: Object | boolean | string): this;
-
-      /**
-       * Adds a required validator to this SchemaType. The validator gets added
-       * to the front of this SchemaType's validators array using unshift().
-       * @param required enable/disable the validator
-       * @param message optional custom error message
-       */
-      required(required: boolean, message?: string): this;
-
-      /** Sets default select() behavior for this path. */
-      select(val: boolean): this;
-      /** Adds a setter to this schematype. */
-      set(fn: Function): this;
-      /** Declares a sparse index. */
-      sparse(bool: boolean): this;
-      /** Declares a full text index. */
-      text(bool: boolean): this;
-      /** Declares an unique index. */
-      unique(bool: boolean): this;
-
-      /**
-       * Adds validator(s) for this document path.
-       * Validators always receive the value to validate as their first argument
-       * and must return Boolean. Returning false means validation failed.
-       * @param obj validator
-       * @param errorMsg optional error message
-       * @param type optional validator type
-       */
-      validate(obj: RegExp | Function | Object, errorMsg?: string,
-        type?: string): this;
-    }
+    $where(js: string | Function): this;
 
     /**
-     * section promise.js
-     * http://mongoosejs.com/docs/api.html#promise-js
-     *
-     * You must assign a promise library:
-     *
-     * 1. To use mongoose's default promise library:
-     *    Install mongoose-promise.d.ts
-     *
-     * 2. To use native ES6 promises, add this line to your main .d.ts file:
-     *    type MongoosePromise<T> = Promise<T>;
-     *
-     * 3. To use another promise library (for example q):
-     *    Install q.d.ts
-     *    Then add this line to your main .d.ts file:
-     *    type MongoosePromise<T> = Q.Promise<T>;
+     * Specifies an $all query condition.
+     * When called with one argument, the most recent path passed to where() is used.
      */
-    type _MongoosePromise<T> = MongoosePromise<T>;
+    all(val: number): this;
+    all(path: string, val: number): this;
 
-    /*
-     * section model.js
-     * http://mongoosejs.com/docs/api.html#model-js
-     *
-     * Mongoose Models use multiple inheritance from Document and EventEmitter.
-     * When calling methods that return a model such as mongoose.connect(),
-     * they actual return an instance of the Model constructor (think of it
-     * like a new class) which can then instantiate its own objects.
+    /**
+     * Specifies arguments for a $and condition.
+     * @param array array of conditions
      */
-    type ModelConstructor<T> = IModelConstructor<T> & events.EventEmitter;
-    type Model<T> = T & _Model<T> & events.EventEmitter;
+    and(array: Object[]): this;
 
-    interface IModelConstructor<T> {
-      /**
-       * Model constructor
-       * Provides the interface to MongoDB collections as well as creates document instances.
-       * @param doc values with which to create the document
-       * @event error If listening to this event, it is emitted when a document
-       *   was saved without passing a callback and an error occurred. If not
-       *   listening, the event bubbles to the connection used to create this Model.
-       * @event index Emitted after Model#ensureIndexes completes. If an error
-       *   occurred it is passed with the event.
-       * @event index-single-start Emitted when an individual index starts within
-       *   Model#ensureIndexes. The fields and options being used to build the index
-       *   are also passed with the event.
-       * @event index-single-done Emitted when an individual index finishes within
-       *   Model#ensureIndexes. If an error occurred it is passed with the event.
-       *   The fields, options, and index name are also passed.
-       */
-      new(doc?: Object): Model<T>;
+    /** Specifies the batchSize option. Cannot be used with distinct() */
+    batchSize(val: number): this;
 
-      /**
-       * Finds a single document by its _id field. findById(id) is almost*
-       * equivalent to findOne({ _id: id }). findById() triggers findOne hooks.
-       * @param id value of _id to query by
-       * @param projection optional fields to return
-       */
-      findById(id: Object | string | number,
-        callback?: (err: any, res: Model<T>) => void): ModelQuery<Model<T>, T>;
-      findById(id: Object | string | number, projection: Object,
-        callback?: (err: any, res: Model<T>) => void): ModelQuery<Model<T>, T>;
-      findById(id: Object | string | number, projection: Object, options: Object,
-        callback?: (err: any, res: Model<T>) => void): ModelQuery<Model<T>, T>;
+    /**
+     * Specifies a $box condition
+     * @param Upper Right Coords
+     */
+    box(val: Object): this;
+    box(lower: number[], upper: number[]): this;
 
-      model<T>(name: string): ModelConstructor<T>;
-      model<T, Statics>(name: string): Statics & ModelConstructor<T>;
+    /** Casts this query to the schema of model, If obj is present, it is cast instead of this query.*/
+    cast(model: any, obj?: Object): Object;
 
-      /**
-       * Creates a Query and specifies a $where condition.
-       * @param argument is a javascript string or anonymous function
-       */
-      $where(argument: string | Function): ModelQuery<Model<T>[], T>;
+    /**
+     * Executes the query returning a Promise which will be
+     * resolved with either the doc(s) or rejected with the error.
+     * Like .then(), but only takes a rejection handler.
+     */
+    catch<TRes>(reject?: (err: any) => void | TRes | PromiseLike<TRes>): _MongoosePromise<TRes>;
 
-      /**
-       * Performs aggregations on the models collection.
-       * If a callback is passed, the aggregate is executed and a Promise is returned.
-       * If a callback is not passed, the aggregate itself is returned.
-       * @param ... aggregation pipeline operator(s) or operator array
-       */
-      aggregate(...aggregations: Object[]): Aggregate<Object[]>;
-      aggregate(...aggregationsWithCallback: Object[]): _MongoosePromise<Object[]>;
+    /**
+     * DEPRECATED Alias for circle
+     * Specifies a $center or $centerSphere condition.
+     * @deprecated Use circle instead.
+     */
+    center(area: Object): this;
+    center(path: string, area: Object): this;
 
-      /** Counts number of matching documents in a database collection. */
-      count(conditions: Object, callback?: (err: any, count: number) => void): Query<number>;
+    /**
+     * DEPRECATED Specifies a $centerSphere condition
+     * @deprecated Use circle instead.
+     */
+    centerSphere(path: string, val: Object): this;
+    centerSphere(val: Object): this;
 
-      /**
-       * Shortcut for saving one or more documents to the database. MyModel.create(docs)
-       * does new MyModel(doc).save() for every doc in docs.
-       * Triggers the save() hook.
-       */
-      create(docs: any[], callback?: (err: any, res: Model<T>[]) => void): _MongoosePromise<Model<T>[]>;
-      create(...docs: Object[]): _MongoosePromise<Model<T>>;
-      create(...docsWithCallback: Object[]): _MongoosePromise<Model<T>>;
+    /** Specifies a $center or $centerSphere condition. */
+    circle(area: Object): this;
+    circle(path: string, area: Object): this;
 
-      /**
-       * Adds a discriminator type.
-       * @param name discriminator model name
-       * @param schema discriminator model schema
-       */
-      discriminator(name: string, schema: Schema): Model<T>;
+    /** Specifies the comment option. Cannot be used with distinct() */
+    comment(val: string): this;
 
-      /** Creates a Query for a distinct operation. Passing a callback immediately executes the query. */
-      distinct(field: string, callback?: (err: any, res: any[]) => void): Query<any[]>;
-      distinct(field: string, conditions: Object,
-        callback?: (err: any, res: any[]) => void): Query<any[]>;
+    /**
+     * Specifying this query as a count query. Passing a callback executes the query.
+     * @param criteria mongodb selector
+     */
+    count(callback?: (err: any, count: number) => void): Query<number>;
+    count(criteria: Object, callback?: (err: any, count: number) => void): Query<number>;
 
-      /**
-       * Sends ensureIndex commands to mongo for each index declared in the schema.
-       * @param options internal options
-       * @param cb optional callback
-       */
-      ensureIndexes(callback?: (err: any) => void): _MongoosePromise<void>;
-      ensureIndexes(options: Object, callback?: (err: any) => void): _MongoosePromise<void>;
+    /**
+     * Returns a wrapper around a mongodb driver cursor. A Query<T>Cursor exposes a
+     * Streams3-compatible interface, as well as a .next() function.
+     */
+    cursor(options?: Object): QueryCursor<ModelType>;
 
-      /**
-       * Finds documents.
-       * @param projection optional fields to return
-       */
-      find(callback?: (err: any, res: Model<T>[]) => void): ModelQuery<Model<T>[], T>;
-      find(conditions: Object, callback?: (err: any, res: Model<T>[]) => void): ModelQuery<Model<T>[], T>;
-      find(conditions: Object, projection: Object,
-        callback?: (err: any, res: Model<T>[]) => void): ModelQuery<Model<T>[], T>;
-      find(conditions: Object, projection: Object, options: Object,
-        callback?: (err: any, res: Model<T>[]) => void): ModelQuery<Model<T>[], T>;
+    /** Declares or executes a distict() operation. Passing a callback executes the query. */
+    distinct(callback?: (err: any, res: any[]) => void): Query<any[]>;
+    distinct(field: string, callback?: (err: any, res: any[]) => void): Query<any[]>;
+    distinct(field: string, criteria: Object | Query<any>,
+      callback?: (err: any, res: any[]) => void): Query<any[]>;
 
+    /** Specifies an $elemMatch condition */
+    elemMatch(criteria: (elem: Query<any>) => void): this;
+    elemMatch(criteria: Object): this;
+    elemMatch(path: string | Object | Function, criteria: (elem: Query<any>) => void): this;
+    elemMatch(path: string | Object | Function, criteria: Object): this;
 
+    /** Specifies the complementary comparison value for paths specified with where() */
+    equals(val: Object): this;
 
-      /**
-       * Issue a mongodb findAndModify remove command by a document's _id field.
-       * findByIdAndRemove(id, ...) is equivalent to findOneAndRemove({ _id: id }, ...).
-       * Finds a matching document, removes it, passing the found document (if any) to the callback.
-       * Executes immediately if callback is passed, else a Query object is returned.
-       * @param id value of _id to query by
-       */
-      findByIdAndRemove(): ModelQuery<Model<T>, T>;
-      findByIdAndRemove(id: Object | number | string,
-        callback?: (err: any, res: Model<T>) => void): ModelQuery<Model<T>, T>;
-      findByIdAndRemove(id: Object | number | string, options: {
-        /** if multiple docs are found by the conditions, sets the sort order to choose which doc to update */
-        sort?: Object;
-        /** sets the document fields to return */
-        select?: Object;
-      }, callback?: (err: any, res: Model<T>) => void): ModelQuery<Model<T>, T>;
+    /** Executes the query */
+    exec(callback?: (err: any, res: T) => void): _MongoosePromise<T>;
+    exec(operation: string | Function, callback?: (err: any, res: T) => void): _MongoosePromise<T>;
 
-      /**
-       * Issues a mongodb findAndModify update command by a document's _id field. findByIdAndUpdate(id, ...)
-       * is equivalent to findOneAndUpdate({ _id: id }, ...).
-       * @param id value of _id to query by
-       */
-      findByIdAndUpdate(): ModelQuery<Model<T>, T>;
-      findByIdAndUpdate(id: Object | number | string, update: Object,
-        callback?: (err: any, res: Model<T>) => void): ModelQuery<Model<T>, T>;
-      findByIdAndUpdate(id: Object | number | string, update: Object,
-        options: ModelFindByIdAndUpdateOptions,
-        callback?: (err: any, res: Model<T>) => void): ModelQuery<Model<T>, T>;
+    /** Specifies an $exists condition */
+    exists(val?: boolean): this;
+    exists(path: string, val?: boolean): this;
 
-      /**
-       * Finds one document.
-       * The conditions are cast to their respective SchemaTypes before the command is sent.
-       * @param projection optional fields to return
-       */
-      findOne(conditions?: Object,
-        callback?: (err: any, res: Model<T>) => void): ModelQuery<Model<T>, T>;
-      findOne(conditions: Object, projection: Object,
-        callback?: (err: any, res: Model<T>) => void): ModelQuery<Model<T>, T>;
-      findOne(conditions: Object, projection: Object, options: Object,
-        callback?: (err: any, res: Model<T>) => void): ModelQuery<Model<T>, T>;
+    /**
+     * Finds documents. When no callback is passed, the query is not executed. When the
+     * query is executed, the result will be an array of documents.
+     * @param criteria mongodb selector
+     */
+    find(callback?: (err: any, res: ModelType[]) => void): ModelQuery<ModelType[], ModelType>;
+    find(criteria: Object,
+      callback?: (err: any, res: ModelType[]) => void): ModelQuery<ModelType[], ModelType>;
 
-      /**
-       * Issue a mongodb findAndModify remove command.
-       * Finds a matching document, removes it, passing the found document (if any) to the callback.
-       * Executes immediately if callback is passed else a Query object is returned.
-       */
-      findOneAndRemove(): ModelQuery<Model<T>, T>;
-      findOneAndRemove(conditions: Object,
-        callback?: (err: any, res: Model<T>) => void): ModelQuery<Model<T>, T>;
-      findOneAndRemove(conditions: Object, options: {
+    /**
+     * Declares the query a findOne operation. When executed, the first found document is
+     * passed to the callback. Passing a callback executes the query. The result of the query
+     * is a single document.
+     * @param criteria mongodb selector
+     * @param projection optional fields to return
+     */
+    findOne(callback?: (err: any, res: ModelType) => void): ModelQuery<ModelType, ModelType>;
+    findOne(criteria: Object,
+      callback?: (err: any, res: ModelType) => void): ModelQuery<ModelType, ModelType>;
+
+    /**
+     * Issues a mongodb findAndModify remove command.
+     * Finds a matching document, removes it, passing the found document (if any) to the
+     * callback. Executes immediately if callback is passed.
+     */
+    findOneAndRemove(callback?: (error: any, doc: ModelType, result: any) => void): ModelQuery<ModelType, ModelType>;
+    findOneAndRemove(conditions: Object,
+      callback?: (error: any, doc: ModelType, result: any) => void): ModelQuery<ModelType, ModelType>;
+    findOneAndRemove(conditions: Object, options: QueryFindOneAndRemoveOptions,
+      callback?: (error: any, doc: ModelType, result: any) => void): ModelQuery<ModelType, ModelType>;
+
+    /**
+     * Issues a mongodb findAndModify update command.
+     * Finds a matching document, updates it according to the update arg, passing any options, and returns
+     * the found document (if any) to the callback. The query executes immediately if callback is passed.
+     */
+    findOneAndUpdate(callback?: (err: any, doc: ModelType) => void): ModelQuery<ModelType, ModelType>;
+    findOneAndUpdate(update: Object,
+      callback?: (err: any, doc: ModelType) => void): ModelQuery<ModelType, ModelType>;
+    findOneAndUpdate(query: Object | Query<any>, update: Object,
+      callback?: (err: any, doc: ModelType) => void): ModelQuery<ModelType, ModelType>;
+    findOneAndUpdate(query: Object | Query<any>, update: Object, options: QueryFindOneAndUpdateOptions,
+      callback?: (err: any, doc: ModelType) => void): ModelQuery<ModelType, ModelType>;
+
+    /**
+     * Specifies a $geometry condition. geometry() must come after either intersects() or within().
+     * @param object Must contain a type property which is a String and a coordinates property which
+     *   is an Array. See the examples.
+     */
+    geometry(object: { type: string, coordinates: any[] }): this;
+
+    /**
+     * Returns the current query conditions as a JSON object.
+     * @returns current query conditions
+     */
+    getQuery(): any;
+
+    /**
+     * Returns the current update operations as a JSON object.
+     * @returns current update operations
+     */
+    getUpdate(): any;
+
+    /**
+     * Specifies a $gt query condition.
+     * When called with one argument, the most recent path passed to where() is used.
+     */
+    gt(val: number): this;
+    gt(path: string, val: number): this;
+
+    /**
+     * Specifies a $gte query condition.
+     * When called with one argument, the most recent path passed to where() is used.
+     */
+    gte(val: number): this;
+    gte(path: string, val: number): this;
+
+    /**
+     * Sets query hints.
+     * @param val a hint object
+     */
+    hint(val: Object): this;
+
+    /**
+     * Specifies an $in query condition.
+     * When called with one argument, the most recent path passed to where() is used.
+     */
+    in(val: any[]): this;
+    in(path: string, val: any[]): this;
+
+    /** Declares an intersects query for geometry(). MUST be used after where(). */
+    intersects(arg?: Object): this;
+
+    /**
+     * Sets the lean option.
+     * Documents returned from queries with the lean option enabled are plain
+     * javascript objects, not MongooseDocuments. They have no save method,
+     * getters/setters or other Mongoose magic applied.
+     * @param bool defaults to true
+     */
+    lean(bool?: boolean): Query<Object>;
+
+    /** Specifies the maximum number of documents the query will return. Cannot be used with distinct() */
+    limit(val: number): this;
+
+    /**
+     * Specifies a $lt query condition.
+     * When called with one argument, the most recent path passed to where() is used.
+     */
+    lt(val: number): this;
+    lt(path: string, val: number): this;
+
+    /**
+     * Specifies a $lte query condition.
+     * When called with one argument, the most recent path passed to where() is used.
+     */
+    lte(val: number): this;
+    lte(path: string, val: number): this;
+
+    /**
+     * Specifies a $maxDistance query condition.
+     * When called with one argument, the most recent path passed to where() is used.
+     */
+    maxDistance(val: number): this;
+    maxDistance(path: string, val: number): this;
+
+    /** @deprecated Alias of maxScan */
+    maxscan(val: number): this;
+    /** Specifies the maxScan option. Cannot be used with distinct() */
+    maxScan(val: number): this;
+
+    /**
+     * Merges another Query or conditions object into this one.
+     * When a Query is passed, conditions, field selection and options are merged.
+     */
+    merge(source: Object | Query<any>): this;
+
+    /** Specifies a $mod condition */
+    mod(val: number[]): this;
+    mod(path: string, val: number[]): this;
+
+    /**
+     * Specifies a $ne query condition.
+     * When called with one argument, the most recent path passed to where() is used.
+     */
+    ne(val: any): this;
+    ne(path: string, val: any): this;
+
+    /** Specifies a $near or $nearSphere condition. */
+    near(val: Object): this;
+    near(path: string, val: Object): this;
+
+    /**
+     * DEPRECATED Specifies a $nearSphere condition
+     * @deprecated Use query.near() instead with the spherical option set to true.
+     */
+    nearSphere(val: Object): this;
+    nearSphere(path: string, val: Object): this;
+
+    /**
+     * Specifies a $nin query condition.
+     * When called with one argument, the most recent path passed to where() is used.
+     */
+    nin(val: any[]): this;
+    nin(path: string, val: any[]): this;
+
+    /**
+     * Specifies arguments for a $nor condition.
+     * @param array array of conditions
+     */
+    nor(array: Object[]): this;
+
+    /**
+     * Specifies arguments for an $or condition.
+     * @param array array of conditions
+     */
+    or(array: Object[]): this;
+
+    /** Specifies a $polygon condition */
+    polygon(...coordinatePairs: number[][]): this;
+    polygon(path: string, ...coordinatePairs: number[][]): this;
+
+    /**
+     * Specifies paths which should be populated with other documents.
+     * Paths are populated after the query executes and a response is received. A separate
+     * query is then executed for each path specified for population. After a response for
+     * each query has also been returned, the results are passed to the callback.
+     * @param path either the path to populate or an object specifying all parameters
+     * @param select Field selection for the population query
+     * @param model The model you wish to use for population. If not specified, populate
+     *   will look up the model by the name in the Schema's ref field.
+     * @param match Conditions for the population query
+     * @param options Options for the population query (sort, etc)
+     */
+    populate(path: string | Object, select?: string | Object, model?: any,
+      match?: Object, options?: Object): this;
+    populate(options: ModelPopulateOptions): this;
+
+    /**
+     * Determines the MongoDB nodes from which to read.
+     * @param pref one of the listed preference options or aliases
+     * @tags optional tags for this query
+     */
+    read(pref: string, tags?: Object[]): this;
+
+    /**
+     * Specifies a $regex query condition.
+     * When called with one argument, the most recent path passed to where() is used.
+     */
+    regex(val: RegExp): this;
+    regex(path: string, val: RegExp): this;
+
+    /**
+     * Declare and/or execute this query as a remove() operation.
+     * The operation is only executed when a callback is passed. To force execution without a callback,
+     * you must first call remove() and then execute it by using the exec() method.
+     * @param criteria mongodb selector
+     */
+    remove(callback?: (err: any) => void): Query<void>;
+    remove(criteria: Object | Query<any>, callback?: (err: any) => void): Query<void>;
+
+    /** Specifies which document fields to include or exclude (also known as the query "projection") */
+    select(arg: string | Object): this;
+    /** Determines if field selection has been made. */
+    selected(): boolean;
+    /** Determines if exclusive field selection has been made.*/
+    selectedExclusively(): boolean;
+    /** Determines if inclusive field selection has been made. */
+    selectedInclusively(): boolean;
+    /** Sets query options. */
+    setOptions(options: Object): this;
+
+    /**
+     * Specifies a $size query condition.
+     * When called with one argument, the most recent path passed to where() is used.
+     */
+    size(val: number): this;
+    size(path: string, val: number): this;
+
+    /** Specifies the number of documents to skip. Cannot be used with distinct() */
+    skip(val: number): this;
+
+    /**
+     * DEPRECATED Sets the slaveOk option.
+     * @param v defaults to true
+     * @deprecated in MongoDB 2.2 in favor of read preferences.
+     */
+    slaveOk(v?: boolean): this;
+
+    /**
+     * Specifies a $slice projection for an array.
+     * @param val number/range of elements to slice
+     */
+    slice(val: number | number[]): this;
+    slice(path: string, val: number | number[]): this;
+
+    /** Specifies this query as a snapshot query. Cannot be used with distinct() */
+    snapshot(v?: boolean): this;
+
+    /**
+     * Sets the sort order
+     * If an object is passed, values allowed are asc, desc, ascending, descending, 1, and -1.
+     * If a string is passed, it must be a space delimited list of path names. The
+     * sort order of each path is ascending unless the path name is prefixed with -
+     * which will be treated as descending.
+     */
+    sort(arg: string | Object): this;
+
+    /** Returns a Node.js 0.8 style read stream interface. */
+    stream(options?: { transform?: Function; }): QueryStream;
+
+    /**
+     * Sets the tailable option (for use with capped collections). Cannot be used with distinct()
+     * @param bool defaults to true
+     * @param opts options to set
+     * @param opts.numberOfRetries if cursor is exhausted, retry this many times before giving up
+     * @param opts.tailableRetryInterval if cursor is exhausted, wait this many milliseconds before retrying
+     */
+    tailable(bool?: boolean, opts?: {
+      numberOfRetries?: number;
+      tailableRetryInterval?: number;
+    }): this;
+
+    /** Executes this query and returns a promise */
+    then<TRes>(resolve?: (res: T) => void | TRes | PromiseLike<TRes>,
+      reject?: (err: any) =>  void | TRes | PromiseLike<TRes>): _MongoosePromise<TRes>;
+
+    /**
+     * Converts this query to a customized, reusable query
+     * constructor with all arguments and options retained.
+     */
+    toConstructor(): typeof ModelQuery;
+
+    /**
+     * Declare and/or execute this query as an update() operation.
+     * All paths passed that are not $atomic operations will become $set ops.
+     * @param doc the update command
+     */
+    update(callback?: (err: any, affectedRows: number) => void): Query<number>;
+    update(doc: Object, callback?: (err: any, affectedRows: number) => void): Query<number>;
+    update(criteria: Object, doc: Object,
+      callback?: (err: any, affectedRows: number) => void): Query<number>;
+    update(criteria: Object, doc: Object, options: QueryUpdateOptions,
+      callback?: (err: any, affectedRows: number) => void): Query<number>;
+
+    /** Specifies a path for use with chaining. */
+    where(path?: string | Object, val?: any): this;
+
+    /** Defines a $within or $geoWithin argument for geo-spatial queries. */
+    within(val?: Object): this;
+    within(coordinate: number[], ...coordinatePairs: number[][]): this;
+
+    /** Flag to opt out of using $geoWithin. */
+    static use$geoWithin: boolean;
+  }
+
+  // https://github.com/aheckmann/mquery
+  // mquery currently does not have a type definition please
+  //   replace it if one is ever created
+  class mquery {}
+
+  interface QueryFindOneAndRemoveOptions {
+    /** if multiple docs are found by the conditions, sets the sort order to choose which doc to update */
+    sort?: any;
+    /** puts a time limit on the query - requires mongodb >= 2.6.0 */
+    maxTimeMS?: number;
+    /** if true, passes the raw result from the MongoDB driver as the third callback parameter */
+    passRawResult?: boolean;
+  }
+
+  interface QueryFindOneAndUpdateOptions extends QueryFindOneAndRemoveOptions {
+    /** if true, return the modified document rather than the original. defaults to false (changed in 4.0) */
+    new?: boolean;
+    /** creates the object if it doesn't exist. defaults to false. */
+    upsert?: boolean;
+    /** Field selection. Equivalent to .select(fields).findOneAndUpdate() */
+    fields?: Object | string;
+    /** if true, runs update validators on this command. Update validators validate the update operation against the model's schema. */
+    runValidators?: boolean;
+    /**
+     * if this and upsert are true, mongoose will apply the defaults specified in the model's schema if a new document
+     * is created. This option only works on MongoDB >= 2.4 because it relies on MongoDB's $setOnInsert operator.
+     */
+    setDefaultsOnInsert?: boolean;
+    /**
+     * if set to 'query' and runValidators is on, this will refer to the query in custom validator
+     * functions that update validation runs. Does nothing if runValidators is false.
+     */
+    context?: string;
+  }
+
+  interface QueryUpdateOptions extends ModelUpdateOptions {
+    /**
+     * if set to 'query' and runValidators is on, this will refer to the query
+     * in customvalidator functions that update validation runs. Does nothing
+     * if runValidators is false.
+     */
+    context?: string;
+  }
+
+  namespace Schema {
+    namespace Types {
+      /*
+        * section schema/array.js
+        * http://mongoosejs.com/docs/api.html#schema-array-js
+        */
+      class Array extends SchemaType {
+        /** Array SchemaType constructor */
+        constructor(key: string, cast?: SchemaType, options?: Object);
+
         /**
-         * if multiple docs are found by the conditions, sets the sort order to choose
-         * which doc to update
+         * Check if the given value satisfies a required validator. The given value
+         * must be not null nor undefined, and have a non-zero length.
          */
-        sort?: Object;
-        /** puts a time limit on the query - requires mongodb >= 2.6.0 */
-        maxTimeMS?: number;
-        /** sets the document fields to return */
-        select?: Object;
-      }, callback?: (err: any, res: Model<T>) => void): ModelQuery<Model<T>, T>;
+        checkRequired<T extends { length: number }>(value: T): boolean;
 
-      /**
-       * Issues a mongodb findAndModify update command.
-       * Finds a matching document, updates it according to the update arg, passing any options,
-       * and returns the found document (if any) to the callback. The query executes immediately
-       * if callback is passed else a Query object is returned.
-       */
-      findOneAndUpdate(): ModelQuery<Model<T>, T>;
-      findOneAndUpdate(conditions: Object, update: Object,
-        callback?: (err: any, res: Model<T>) => void): ModelQuery<Model<T>, T>;
-      findOneAndUpdate(conditions: Object, update: Object,
-        options: ModelFindOneAndUpdateOptions,
-        callback?: (err: any, res: Model<T>) => void): ModelQuery<Model<T>, T>;
+        /** This schema type's name, to defend against minifiers that mangle function names. */
+        static schemaName: string;
+      }
 
-      /**
-       * geoNear support for Mongoose
-       * @param GeoJSON point or legacy coordinate pair [x,y] to search near
-       * @param options for the qurery
-       * @param callback optional callback for the query
-       */
-      geoNear(point: number[] | {
-        type: string;
-        coordinates: number[]
-      }, options: {
-        /** return the raw object */
-        lean?: boolean;
-        [other: string]: any;
-      }, callback?: (err: any, res: Model<T>[], stats: any) => void): ModelQuery<Model<T>[], T>;
+      /*
+        * section schema/string.js
+        * http://mongoosejs.com/docs/api.html#schema-string-js
+        */
+      class String extends SchemaType {
+        /** String SchemaType constructor. */
+        constructor(key: string, options?: Object);
 
-      /**
-       * Implements $geoSearch functionality for Mongoose
-       * @param conditions an object that specifies the match condition (required)
-       * @param options for the geoSearch, some (near, maxDistance) are required
-       * @param callback optional callback
-       */
-      geoSearch(conditions: Object, options: {
-        /** x,y point to search for */
-        near: number[];
-        /** the maximum distance from the point near that a result can be */
-        maxDistance: number;
-        /** The maximum number of results to return */
-        limit?: number;
-        /** return the raw object instead of the Mongoose Model */
-        lean?: boolean;
-      }, callback?: (err: any, res: Model<T>[]) => void): ModelQuery<Model<T>[], T>;
+        /** Check if the given value satisfies a required validator. */
+        checkRequired(value: any, doc: MongooseDocument): boolean;
 
-      /**
-       * Shortcut for creating a new Document from existing raw data,
-       * pre-saved in the DB. The document returned has no paths marked
-       * as modified initially.
-       */
-      hydrate(obj: Object): Model<T>;
+        /**
+         * Adds an enum validator
+         * @param args enumeration values
+         */
+        enum(args: string | string[] | Object): this;
 
-      /**
-       * Shortcut for validating an array of documents and inserting them into
-       * MongoDB if they're all valid. This function is faster than .create()
-       * because it only sends one operation to the server, rather than one for each
-       * document.
-       * This function does not trigger save middleware.
-       */
-      insertMany(docs: any[], callback?: (error: any, docs: Model<T>[]) => void): _MongoosePromise<Model<T>[]>;
-      insertMany(doc: any, callback?: (error: any, doc: Model<T>) => void): _MongoosePromise<Model<T>>;
-      insertMany(...docsWithCallback: Object[]): _MongoosePromise<Model<T>>;
+        /** Adds a lowercase setter. */
+        lowercase(): this;
 
-      /**
-       * Executes a mapReduce command.
-       * @param o an object specifying map-reduce options
-       * @param callbackoptional callback
-       */
-      mapReduce<Key, Value>(
-        o: ModelMapReduceOption<Model<T>, Key, Value>,
-        callback?: (err: any, res: any) => void
-      ): _MongoosePromise<any>;
+        /**
+         * Sets a regexp validator. Any value that does not pass regExp.test(val) will fail validation.
+         * @param regExp regular expression to test against
+         * @param message optional custom error message
+         */
+        match(regExp: RegExp, message?: string): this;
 
-      /**
-       * Populates document references.
-       * @param docs Either a single document or array of documents to populate.
-       * @param options A hash of key/val (path, options) used for population.
-       * @param callback Optional callback, executed upon completion. Receives err and the doc(s).
-       */
-      populate(docs: Object[], options: ModelPopulateOptions | ModelPopulateOptions[],
-        callback?: (err: any, res: Model<T>[]) => void): _MongoosePromise<Model<T>[]>;
-      populate<T>(docs: Object, options: ModelPopulateOptions | ModelPopulateOptions[],
-        callback?: (err: any, res: Model<T>) => void): _MongoosePromise<Model<T>>;
+        /**
+         * Sets a maximum length validator.
+         * @param value maximum string length
+         * @param message optional custom error message
+         */
+        maxlength(value: number, message?: string): this;
 
-      /** Removes documents from the collection. */
-      remove(conditions: Object, callback?: (err: any) => void): Query<void>;
+        /**
+         * Sets a minimum length validator.
+         * @param value minimum string length
+         * @param message optional custom error message
+         */
+        minlength(value: number, message?: string): this;
 
-      /**
-       * Updates documents in the database without returning them.
-       * All update values are cast to their appropriate SchemaTypes before being sent.
-       */
-      update(conditions: Object, doc: Object,
-        callback?: (err: any, raw: any) => void): Query<any>;
-      update(conditions: Object, doc: Object, options: ModelUpdateOptions,
-        callback?: (err: any, raw: any) => void): Query<any>;
+        /** Adds a trim setter. The string value will be trimmed when set. */
+        trim(): this;
+        /** Adds an uppercase setter. */
+        uppercase(): this;
 
-      /** Creates a Query, applies the passed conditions, and returns the Query. */
-      where(path: string, val?: Object): Query<any>;
+        /** This schema type's name, to defend against minifiers that mangle function names. */
+        static schemaName: string;
+
+      }
+
+      /*
+        * section schema/documentarray.js
+        * http://mongoosejs.com/docs/api.html#schema-documentarray-js
+        */
+      class DocumentArray extends Array {
+        /** SubdocsArray SchemaType constructor */
+        constructor(key: string, schema: Schema, options?: Object);
+
+        /** This schema type's name, to defend against minifiers that mangle function names. */
+        static schemaName: string;
+      }
+
+      /*
+        * section schema/number.js
+        * http://mongoosejs.com/docs/api.html#schema-number-js
+        */
+      class Number extends SchemaType {
+        /** Number SchemaType constructor. */
+        constructor(key: string, options?: Object);
+
+        /** Check if the given value satisfies a required validator. */
+        checkRequired(value: any, doc: MongooseDocument): boolean;
+
+        /**
+         * Sets a maximum number validator.
+         * @param maximum number
+         * @param message optional custom error message
+         */
+        max(maximum: number, message?: string): this;
+
+        /**
+         * Sets a minimum number validator.
+         * @param value minimum number
+         * @param message optional custom error message
+         */
+        min(value: number, message?: string): this;
+
+        /** This schema type's name, to defend against minifiers that mangle function names. */
+        static schemaName: string;
+      }
+
+      /*
+        * section schema/date.js
+        * http://mongoosejs.com/docs/api.html#schema-date-js
+        */
+      class Date extends SchemaType {
+        /** Date SchemaType constructor. */
+        constructor(key: string, options?: Object);
+
+        /**
+         * Check if the given value satisfies a required validator. To satisfy
+         * a required validator, the given value must be an instance of Date.
+         */
+        checkRequired(value: any, doc: MongooseDocument): boolean;
+
+        /** Declares a TTL index (rounded to the nearest second) for Date types only. */
+        expires(when: number | string): this;
+
+        /**
+         * Sets a maximum date validator.
+         * @param maximum date
+         * @param message optional custom error message
+         */
+        max(maximum: NativeDate, message?: string): this;
+
+        /**
+         * Sets a minimum date validator.
+         * @param value minimum date
+         * @param message optional custom error message
+         */
+        min(value: NativeDate, message?: string): this;
+
+        /** This schema type's name, to defend against minifiers that mangle function names. */
+        static schemaName: string;
+      }
+
+      /*
+        * section schema/buffer.js
+        * http://mongoosejs.com/docs/api.html#schema-buffer-js
+        */
+      class Buffer extends SchemaType {
+        /** Buffer SchemaType constructor */
+        constructor(key: string, options?: Object);
+
+        /**
+         * Check if the given value satisfies a required validator. To satisfy a
+         * required validator, a buffer must not be null or undefined and have
+         * non-zero length.
+         */
+        checkRequired(value: any, doc: MongooseDocument): boolean;
+
+        /** This schema type's name, to defend against minifiers that mangle function names. */
+        static schemaName: string;
+
+      }
+
+      /*
+        * section schema/boolean.js
+        * http://mongoosejs.com/docs/api.html#schema-boolean-js
+        */
+      class Boolean extends SchemaType {
+        /** Boolean SchemaType constructor. */
+        constructor(path: string, options?: Object);
+
+        /**
+         * Check if the given value satisfies a required validator. For a
+         * boolean to satisfy a required validator, it must be strictly
+         * equal to true or to false.
+         */
+        checkRequired(value: any): boolean;
+
+        /** This schema type's name, to defend against minifiers that mangle function names. */
+        static schemaName: string;
+      }
+
+      /*
+        * section schema/objectid.js
+        * http://mongoosejs.com/docs/api.html#schema-objectid-js
+        */
+      class ObjectId extends SchemaType {
+        /** ObjectId SchemaType constructor. */
+        constructor(key: string, options?: Object);
+
+        /**
+         * Adds an auto-generated ObjectId default if turnOn is true.
+         * @param turnOn auto generated ObjectId defaults
+         */
+        auto(turnOn: boolean): this;
+
+        /** Check if the given value satisfies a required validator. */
+        checkRequired(value: any, doc: MongooseDocument): boolean;
+
+        /** This schema type's name, to defend against minifiers that mangle function names. */
+        static schemaName: string;
+      }
+
+      /*
+        * section schema/mixed.js
+        * http://mongoosejs.com/docs/api.html#schema-mixed-js
+        */
+      class Mixed extends SchemaType {
+        /** Mixed SchemaType constructor. */
+        constructor(path: string, options?: Object);
+
+        /** This schema type's name, to defend against minifiers that mangle function names. */
+        static schemaName: string;
+      }
+
+      /*
+        * section schema/embedded.js
+        * http://mongoosejs.com/docs/api.html#schema-embedded-js
+        */
+      class Embedded extends SchemaType {
+        /** Sub-schema schematype constructor */
+        constructor(schema: Schema, key: string, options?: Object);
+      }
     }
+  }
 
-    class _Model<T> extends Document {
-      /** Signal that we desire an increment of this documents version. */
-      increment(): this;
+  /*
+   * section aggregate.js
+   * http://mongoosejs.com/docs/api.html#aggregate-js
+   */
+  class Aggregate<T> {
+    /**
+     * Aggregate constructor used for building aggregation pipelines.
+     * Returned when calling Model.aggregate().
+     * @param ops aggregation operator(s) or operator array
+     */
+    constructor(ops?: Object | any[], ...args: any[]);
 
-      /**
-       * Returns another Model instance.
-       * @param name model name
-       */
-      model<T>(name: string): ModelConstructor<T>;
-      model<T, Statics>(name: string): Statics & ModelConstructor<T>;
+    /** Adds a cursor flag */
+    addCursorFlag(flag: string, value: boolean): this;
 
-      /**
-       * Removes this document from the db.
-       * @param fn optional callback
-       */
-      remove(fn?: (err: any, product: Model<T>) => void): _MongoosePromise<Model<T>>;
+    /**
+     * Sets the allowDiskUse option for the aggregation query (ignored for < 2.6.0)
+     * @param value Should tell server it can use hard drive to store data during aggregation.
+     * @param tags optional tags for this query
+     */
+    allowDiskUse(value: boolean, tags?: any[]): this;
 
-      /**
-       * Saves this document.
-       * @param options options optional options
-       * @param options.safe overrides schema's safe option
-       * @param options.validateBeforeSave set to false to save without validating.
-       * @param fn optional callback
-       */
-      save(fn?: (err: any, product: Model<T>, numAffected: number) => void): _MongoosePromise<Model<T>>;
+    /**
+     * Appends new operators to this aggregate pipeline
+     * @param ops operator(s) to append
+     */
+    append(...ops: Object[]): this;
 
-      /** Base Mongoose instance the model uses. */
-      base: typeof mongoose;
-      /**
-       * If this is a discriminator model, baseModelName is the
-       * name of the base model.
-       */
-      baseModelName: String;
-      /** Collection the model uses. */
-      collection: Collection;
-      /** Connection the model uses. */
-      db: Connection;
-      /** Registered discriminators for this model. */
-      discriminators: any;
-      /** The name of the model */
-      modelName: string;
-      /** Schema the model uses. */
-      schema: Schema;
-    }
+    /**
+     * Sets the cursor option option for the aggregation query (ignored for < 2.6.0).
+     * Note the different syntax below: .exec() returns a cursor object, and no callback
+     * is necessary.
+     * @param options set the cursor batch size
+     */
+    cursor(options: Object): this;
 
-    interface ModelFindByIdAndUpdateOptions {
-      /** true to return the modified document rather than the original. defaults to false */
-      new?: boolean;
-      /** creates the object if it doesn't exist. defaults to false. */
-      upsert?: boolean;
-      /**
-       * if true, runs update validators on this command. Update validators validate the
-       * update operation against the model's schema.
-       */
-      runValidators?: boolean;
-      /**
-       * if this and upsert are true, mongoose will apply the defaults specified in the model's
-       * schema if a new document is created. This option only works on MongoDB >= 2.4 because
-       * it relies on MongoDB's $setOnInsert operator.
-       */
-      setDefaultsOnInsert?: boolean;
+    // If cursor option is on, could return an object
+    /** Executes the aggregate pipeline on the currently bound Model. */
+    exec(callback?: (err: any, result: T) => void): _MongoosePromise<T> | any;
+
+    /** Execute the aggregation with explain */
+    explain(callback?: (err: any, result: T) => void): _MongoosePromise<T>;
+
+    /**
+     * Appends a new custom $group operator to this aggregate pipeline.
+     * @param arg $group operator contents
+     */
+    group(arg: Object): this;
+
+    /**
+     * Appends a new $limit operator to this aggregate pipeline.
+     * @param num maximum number of records to pass to the next stage
+     */
+    limit(num: number): this;
+
+    /**
+     * Appends new custom $lookup operator(s) to this aggregate pipeline.
+     * @param options to $lookup as described in the above link
+     */
+    lookup(options: Object): this;
+
+    /**
+     * Appends a new custom $match operator to this aggregate pipeline.
+     * @param arg $match operator contents
+     */
+    match(arg: Object): this;
+
+    /**
+     * Binds this aggregate to a model.
+     * @param model the model to which the aggregate is to be bound
+     */
+    model(model: any): this;
+
+    /**
+     * Appends a new $geoNear operator to this aggregate pipeline.
+     * MUST be used as the first operator in the pipeline.
+     */
+    near(parameters: Object): this;
+
+    /**
+     * Appends a new $project operator to this aggregate pipeline.
+     * Mongoose query selection syntax is also supported.
+     * @param arg field specification
+     */
+    project(arg: string | Object): this;
+
+    /**
+     * Sets the readPreference option for the aggregation query.
+     * @param pref one of the listed preference options or their aliases
+     * @param tags optional tags for this query
+     */
+    read(pref: string, tags?: Object[]): this;
+
+    /**
+     * Appends new custom $sample operator(s) to this aggregate pipeline.
+     * @param size number of random documents to pick
+     */
+    sample(size: number): this;
+
+    /**
+     * Appends a new $skip operator to this aggregate pipeline.
+     * @param num number of records to skip before next stage
+     */
+    skip(num: number): this;
+
+    /**
+     * Appends a new $sort operator to this aggregate pipeline.
+     * If an object is passed, values allowed are asc, desc, ascending, descending, 1, and -1.
+     * If a string is passed, it must be a space delimited list of path names. The sort order
+     * of each path is ascending unless the path name is prefixed with - which will be treated
+     * as descending.
+     */
+    sort(arg: string | Object): this;
+
+    /** Provides promise for aggregate. */
+    then<TRes>(resolve?: (val: T) =>  void | TRes | PromiseLike<TRes>,
+      reject?: (err: any) =>  void | TRes | PromiseLike<TRes>): _MongoosePromise<TRes>
+
+    /**
+     * Appends new custom $unwind operator(s) to this aggregate pipeline.
+     * Note that the $unwind operator requires the path name to start with '$'.
+     * Mongoose will prepend '$' if the specified field doesn't start '$'.
+     * @param fields the field(s) to unwind
+     */
+    unwind(...fields: string[]): this;
+  }
+
+  /*
+   * section schematype.js
+   * http://mongoosejs.com/docs/api.html#schematype-js
+   */
+  class SchemaType {
+    /** SchemaType constructor */
+    constructor(path: string, options?: Object, instance?: string);
+
+    /**
+     * Sets a default value for this SchemaType.
+     * Defaults can be either functions which return the value to use as the
+     * default or the literal value itself. Either way, the value will be cast
+     * based on its schema type before being set during document creation.
+     * @param val the default value
+     */
+    default(val: any): any;
+
+    /** Adds a getter to this schematype. */
+    get(fn: Function): this;
+
+    /**
+     * Declares the index options for this schematype.
+     * Indexes are created in the background by default. Specify background: false to override.
+     */
+    index(options: Object | boolean | string): this;
+
+    /**
+     * Adds a required validator to this SchemaType. The validator gets added
+     * to the front of this SchemaType's validators array using unshift().
+     * @param required enable/disable the validator
+     * @param message optional custom error message
+     */
+    required(required: boolean, message?: string): this;
+
+    /** Sets default select() behavior for this path. */
+    select(val: boolean): this;
+    /** Adds a setter to this schematype. */
+    set(fn: Function): this;
+    /** Declares a sparse index. */
+    sparse(bool: boolean): this;
+    /** Declares a full text index. */
+    text(bool: boolean): this;
+    /** Declares an unique index. */
+    unique(bool: boolean): this;
+
+    /**
+     * Adds validator(s) for this document path.
+     * Validators always receive the value to validate as their first argument
+     * and must return Boolean. Returning false means validation failed.
+     * @param obj validator
+     * @param errorMsg optional error message
+     * @param type optional validator type
+     */
+    validate(obj: RegExp | Function | Object, errorMsg?: string,
+      type?: string): this;
+  }
+
+  /**
+   * section promise.js
+   * http://mongoosejs.com/docs/api.html#promise-js
+   *
+   * You must assign a promise library:
+   *
+   * 1. To use mongoose's default promise library:
+   *    Install mongoose-promise.d.ts
+   *
+   * 2. To use native ES6 promises, add this line to your main .d.ts file:
+   *    type MongoosePromise<T> = Promise<T>;
+   *
+   * 3. To use another promise library (for example q):
+   *    Install q.d.ts
+   *    Then add this line to your main .d.ts file:
+   *    type MongoosePromise<T> = Q.Promise<T>;
+   */
+  interface _MongoosePromise<T> extends MongoosePromise<T> {}
+  interface Promise<T> extends MongoosePromise<T> {}
+
+  /**
+   * To assign your own promise library:
+   *
+   * 1. Include this somewhere in your code:
+   *    mongoose.Promise = YOUR_PROMISE;
+   *
+   * 2. Include this somewhere in your main .d.ts file:
+   *    type MongoosePromise<T> = YOUR_PROMISE<T>;
+   */
+  export var Promise: any;
+  export var PromiseProvider: any;
+
+  /*
+   * section model.js
+   * http://mongoosejs.com/docs/api.html#model-js
+   */
+  interface Model<T extends Document> extends NodeJS.EventEmitter {
+    /**
+     * Model constructor
+     * Provides the interface to MongoDB collections as well as creates document instances.
+     * @param doc values with which to create the document
+     * @event error If listening to this event, it is emitted when a document
+     *   was saved without passing a callback and an error occurred. If not
+     *   listening, the event bubbles to the connection used to create this Model.
+     * @event index Emitted after Model#ensureIndexes completes. If an error
+     *   occurred it is passed with the event.
+     * @event index-single-start Emitted when an individual index starts within
+     *   Model#ensureIndexes. The fields and options being used to build the index
+     *   are also passed with the event.
+     * @event index-single-done Emitted when an individual index finishes within
+     *   Model#ensureIndexes. If an error occurred it is passed with the event.
+     *   The fields, options, and index name are also passed.
+     */
+    new(doc?: Object): T;
+
+    /**
+     * Finds a single document by its _id field. findById(id) is almost*
+     * equivalent to findOne({ _id: id }). findById() triggers findOne hooks.
+     * @param id value of _id to query by
+     * @param projection optional fields to return
+     */
+    findById(id: Object | string | number,
+      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+    findById(id: Object | string | number, projection: Object,
+      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+    findById(id: Object | string | number, projection: Object, options: Object,
+      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+
+    model<T extends Document>(name: string): Model<T>;
+
+    /**
+     * Creates a Query and specifies a $where condition.
+     * @param argument is a javascript string or anonymous function
+     */
+    $where(argument: string | Function): ModelQuery<T, T>;
+
+    /**
+     * Performs aggregations on the models collection.
+     * If a callback is passed, the aggregate is executed and a Promise is returned.
+     * If a callback is not passed, the aggregate itself is returned.
+     * @param ... aggregation pipeline operator(s) or operator array
+     */
+    aggregate(...aggregations: Object[]): Aggregate<Object[]>;
+    aggregate(...aggregationsWithCallback: Object[]): _MongoosePromise<Object[]>;
+
+    /** Counts number of matching documents in a database collection. */
+    count(conditions: Object, callback?: (err: any, count: number) => void): Query<number>;
+
+    /**
+     * Shortcut for saving one or more documents to the database. MyModel.create(docs)
+     * does new MyModel(doc).save() for every doc in docs.
+     * Triggers the save() hook.
+     */
+    create(docs: any[], callback?: (err: any, res: T[]) => void): _MongoosePromise<T[]>;
+    create(...docs: Object[]): _MongoosePromise<T>;
+    create(...docsWithCallback: Object[]): _MongoosePromise<T>;
+
+    /**
+     * Adds a discriminator type.
+     * @param name discriminator model name
+     * @param schema discriminator model schema
+     */
+    discriminator(name: string, schema: Schema): T;
+
+    /** Creates a Query for a distinct operation. Passing a callback immediately executes the query. */
+    distinct(field: string, callback?: (err: any, res: any[]) => void): Query<any[]>;
+    distinct(field: string, conditions: Object,
+      callback?: (err: any, res: any[]) => void): Query<any[]>;
+
+    /**
+     * Sends ensureIndex commands to mongo for each index declared in the schema.
+     * @param options internal options
+     * @param cb optional callback
+     */
+    ensureIndexes(callback?: (err: any) => void): _MongoosePromise<void>;
+    ensureIndexes(options: Object, callback?: (err: any) => void): _MongoosePromise<void>;
+
+    /**
+     * Finds documents.
+     * @param projection optional fields to return
+     */
+    find(callback?: (err: any, res: T[]) => void): ModelQuery<T[], T>;
+    find(conditions: Object, callback?: (err: any, res: T[]) => void): ModelQuery<T[], T>;
+    find(conditions: Object, projection: Object,
+      callback?: (err: any, res: T[]) => void): ModelQuery<T[], T>;
+    find(conditions: Object, projection: Object, options: Object,
+      callback?: (err: any, res: T[]) => void): ModelQuery<T[], T>;
+
+
+
+    /**
+     * Issue a mongodb findAndModify remove command by a document's _id field.
+     * findByIdAndRemove(id, ...) is equivalent to findOneAndRemove({ _id: id }, ...).
+     * Finds a matching document, removes it, passing the found document (if any) to the callback.
+     * Executes immediately if callback is passed, else a Query object is returned.
+     * @param id value of _id to query by
+     */
+    findByIdAndRemove(): ModelQuery<T, T>;
+    findByIdAndRemove(id: Object | number | string,
+      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+    findByIdAndRemove(id: Object | number | string, options: {
       /** if multiple docs are found by the conditions, sets the sort order to choose which doc to update */
       sort?: Object;
       /** sets the document fields to return */
       select?: Object;
-    }
+    }, callback?: (err: any, res: T) => void): ModelQuery<T, T>;
 
-    interface ModelFindOneAndUpdateOptions extends ModelFindByIdAndUpdateOptions {
-      /** Field selection. Equivalent to .select(fields).findOneAndUpdate() */
-      fields?: Object | string;
+    /**
+     * Issues a mongodb findAndModify update command by a document's _id field. findByIdAndUpdate(id, ...)
+     * is equivalent to findOneAndUpdate({ _id: id }, ...).
+     * @param id value of _id to query by
+     */
+    findByIdAndUpdate(): ModelQuery<T, T>;
+    findByIdAndUpdate(id: Object | number | string, update: Object,
+      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+    findByIdAndUpdate(id: Object | number | string, update: Object,
+      options: ModelFindByIdAndUpdateOptions,
+      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+
+    /**
+     * Finds one document.
+     * The conditions are cast to their respective SchemaTypes before the command is sent.
+     * @param projection optional fields to return
+     */
+    findOne(conditions?: Object,
+      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+    findOne(conditions: Object, projection: Object,
+      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+    findOne(conditions: Object, projection: Object, options: Object,
+      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+
+    /**
+     * Issue a mongodb findAndModify remove command.
+     * Finds a matching document, removes it, passing the found document (if any) to the callback.
+     * Executes immediately if callback is passed else a Query object is returned.
+     */
+    findOneAndRemove(): ModelQuery<T, T>;
+    findOneAndRemove(conditions: Object,
+      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+    findOneAndRemove(conditions: Object, options: {
+      /**
+       * if multiple docs are found by the conditions, sets the sort order to choose
+       * which doc to update
+       */
+      sort?: Object;
       /** puts a time limit on the query - requires mongodb >= 2.6.0 */
       maxTimeMS?: number;
-      /** if true, passes the raw result from the MongoDB driver as the third callback parameter */
-      passRawResult?: boolean;
-    }
+      /** sets the document fields to return */
+      select?: Object;
+    }, callback?: (err: any, res: T) => void): ModelQuery<T, T>;
 
-    interface ModelPopulateOptions {
-      /** space delimited path(s) to populate */
-      path: string;
-      /** optional fields to select */
-      select?: any;
-      /** optional query conditions to match */
-      match?: Object;
-      /** optional name of the model to use for population */
-      model?: string;
-      /** optional query options like sort, limit, etc */
-      options?: Object;
-    }
-
-    interface ModelUpdateOptions {
-      /** safe mode (defaults to value set in schema (true)) */
-      safe?: boolean;
-      /** whether to create the doc if it doesn't match (false) */
-      upsert?: boolean;
-      /** whether multiple documents should be updated (false) */
-      multi?: boolean;
-      /**
-       * If true, runs update validators on this command. Update validators validate
-       * the update operation against the model's schema.
-       */
-      runValidators?: boolean;
-      /**
-       * If this and upsert are true, mongoose will apply the defaults specified in the
-       * model's schema if a new document is created. This option only works on MongoDB >= 2.4
-       * because it relies on MongoDB's $setOnInsert operator.
-       */
-      setDefaultsOnInsert?: boolean;
-      /** overrides the strict option for this update */
-      strict?: boolean;
-      /** disables update-only mode, allowing you to overwrite the doc (false) */
-      overwrite?: boolean;
-      /** other options */
-      [other: string]: any;
-    }
-
-    interface ModelMapReduceOption<T, Key, Val> {
-      map: Function | string;
-      reduce: (key: Key, vals: T[]) => Val;
-      /** query filter object. */
-      query?: Object;
-      /** sort input objects using this key */
-      sort?: Object;
-      /** max number of documents */
-      limit?: number;
-      /** keep temporary data default: false */
-      keeptemp?: boolean;
-      /** finalize function */
-      finalize?: (key: Key, val: Val) => Val;
-      /** scope variables exposed to map/reduce/finalize during execution */
-      scope?: Object;
-      /** it is possible to make the execution stay in JS. Provided in MongoDB > 2.0.X default: false */
-      jsMode?: boolean;
-      /** provide statistics on job execution time. default: false */
-      verbose?: boolean;
-      readPreference?: string;
-      /** sets the output target for the map reduce job. default: {inline: 1} */
-      out?: {
-        /** the results are returned in an array */
-        inline?: number;
-        /**
-         * {replace: 'collectionName'} add the results to collectionName: the
-         * results replace the collection
-         */
-        replace?: string;
-        /**
-         * {reduce: 'collectionName'} add the results to collectionName: if
-         * dups are detected, uses the reducer / finalize functions
-         */
-        reduce?: string;
-        /**
-         * {merge: 'collectionName'} add the results to collectionName: if
-         * dups exist the new docs overwrite the old
-         */
-        merge?: string;
-      };
-    }
-
-    interface MapReduceResult<Key, Val> {
-      _id: Key;
-      value: Val;
-    }
-
-    /*
-     * section collection.js
-     * http://mongoosejs.com/docs/api.html#collection-js
+    /**
+     * Issues a mongodb findAndModify update command.
+     * Finds a matching document, updates it according to the update arg, passing any options,
+     * and returns the found document (if any) to the callback. The query executes immediately
+     * if callback is passed else a Query object is returned.
      */
-    interface CollectionBase extends mongodb.Collection {
-      /*
-       * Abstract methods. Some of these are already defined on the
-       * mongodb.Collection interface so they've been commented out.
-       */
-      ensureIndex(...args: any[]): any;
-      //find(...args: any[]): any;
-      findAndModify(...args: any[]): any;
-      //findOne(...args: any[]): any;
-      getIndexes(...args: any[]): any;
-      //insert(...args: any[]): any;
-      //mapReduce(...args: any[]): any;
-      //save(...args: any[]): any;
-      //update(...args: any[]): any;
+    findOneAndUpdate(): ModelQuery<T, T>;
+    findOneAndUpdate(conditions: Object, update: Object,
+      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
+    findOneAndUpdate(conditions: Object, update: Object,
+      options: ModelFindOneAndUpdateOptions,
+      callback?: (err: any, res: T) => void): ModelQuery<T, T>;
 
-      /** The collection name */
-      collectionName: string;
-      /** The Connection instance */
-      conn: Connection;
-      /** The collection name */
-      name: string;
-    }
+    /**
+     * geoNear support for Mongoose
+     * @param GeoJSON point or legacy coordinate pair [x,y] to search near
+     * @param options for the qurery
+     * @param callback optional callback for the query
+     */
+    geoNear(point: number[] | {
+      type: string;
+      coordinates: number[]
+    }, options: {
+      /** return the raw object */
+      lean?: boolean;
+      [other: string]: any;
+    }, callback?: (err: any, res: T[], stats: any) => void): ModelQuery<T[], T>;
+
+    /**
+     * Implements $geoSearch functionality for Mongoose
+     * @param conditions an object that specifies the match condition (required)
+     * @param options for the geoSearch, some (near, maxDistance) are required
+     * @param callback optional callback
+     */
+    geoSearch(conditions: Object, options: {
+      /** x,y point to search for */
+      near: number[];
+      /** the maximum distance from the point near that a result can be */
+      maxDistance: number;
+      /** The maximum number of results to return */
+      limit?: number;
+      /** return the raw object instead of the Mongoose Model */
+      lean?: boolean;
+    }, callback?: (err: any, res: T[]) => void): ModelQuery<T[], T>;
+
+    /**
+     * Shortcut for creating a new Document from existing raw data,
+     * pre-saved in the DB. The document returned has no paths marked
+     * as modified initially.
+     */
+    hydrate(obj: Object): T;
+
+    /**
+     * Shortcut for validating an array of documents and inserting them into
+     * MongoDB if they're all valid. This function is faster than .create()
+     * because it only sends one operation to the server, rather than one for each
+     * document.
+     * This function does not trigger save middleware.
+     */
+    insertMany(docs: any[], callback?: (error: any, docs: T[]) => void): _MongoosePromise<T[]>;
+    insertMany(doc: any, callback?: (error: any, doc: T) => void): _MongoosePromise<T>;
+    insertMany(...docsWithCallback: Object[]): _MongoosePromise<T>;
+
+    /**
+     * Executes a mapReduce command.
+     * @param o an object specifying map-reduce options
+     * @param callbackoptional callback
+     */
+    mapReduce<Key, Value>(
+      o: ModelMapReduceOption<T, Key, Value>,
+      callback?: (err: any, res: any) => void
+    ): _MongoosePromise<any>;
+
+    /**
+     * Populates document references.
+     * @param docs Either a single document or array of documents to populate.
+     * @param options A hash of key/val (path, options) used for population.
+     * @param callback Optional callback, executed upon completion. Receives err and the doc(s).
+     */
+    populate(docs: Object[], options: ModelPopulateOptions | ModelPopulateOptions[],
+      callback?: (err: any, res: T[]) => void): _MongoosePromise<T[]>;
+    populate<T>(docs: Object, options: ModelPopulateOptions | ModelPopulateOptions[],
+      callback?: (err: any, res: T) => void): _MongoosePromise<T>;
+
+    /** Removes documents from the collection. */
+    remove(conditions: Object, callback?: (err: any) => void): Query<void>;
+
+    /**
+     * Updates documents in the database without returning them.
+     * All update values are cast to their appropriate SchemaTypes before being sent.
+     */
+    update(conditions: Object, doc: Object,
+      callback?: (err: any, raw: any) => void): Query<any>;
+    update(conditions: Object, doc: Object, options: ModelUpdateOptions,
+      callback?: (err: any, raw: any) => void): Query<any>;
+
+    /** Creates a Query, applies the passed conditions, and returns the Query. */
+    where(path: string, val?: Object): Query<any>;
+  }
+
+  interface Document extends MongooseDocument, NodeJS.EventEmitter {
+    /** Signal that we desire an increment of this documents version. */
+    increment(): this;
+
+    /**
+     * Returns another Model instance.
+     * @param name model name
+     */
+    model<T extends Document>(name: string): Model<T>;
+
+    /**
+     * Removes this document from the db.
+     * @param fn optional callback
+     */
+    remove<T extends Document>(fn?: (err: any, product: T) => void): _MongoosePromise<T>;
+
+    /**
+     * Saves this document.
+     * @param options options optional options
+     * @param options.safe overrides schema's safe option
+     * @param options.validateBeforeSave set to false to save without validating.
+     * @param fn optional callback
+     */
+    save<T extends Document>(fn?: (err: any, product: T, numAffected: number) => void): _MongoosePromise<T>;
+
+    /** Base Mongoose instance the model uses. */
+    base: typeof mongoose;
+    /**
+     * If this is a discriminator model, baseModelName is the
+     * name of the base model.
+     */
+    baseModelName: String;
+    /** Collection the model uses. */
+    collection: Collection;
+    /** Connection the model uses. */
+    db: Connection;
+    /** Registered discriminators for this model. */
+    discriminators: any;
+    /** The name of the model */
+    modelName: string;
+    /** Schema the model uses. */
+    schema: Schema;
+  }
+
+  interface ModelFindByIdAndUpdateOptions {
+    /** true to return the modified document rather than the original. defaults to false */
+    new?: boolean;
+    /** creates the object if it doesn't exist. defaults to false. */
+    upsert?: boolean;
+    /**
+     * if true, runs update validators on this command. Update validators validate the
+     * update operation against the model's schema.
+     */
+    runValidators?: boolean;
+    /**
+     * if this and upsert are true, mongoose will apply the defaults specified in the model's
+     * schema if a new document is created. This option only works on MongoDB >= 2.4 because
+     * it relies on MongoDB's $setOnInsert operator.
+     */
+    setDefaultsOnInsert?: boolean;
+    /** if multiple docs are found by the conditions, sets the sort order to choose which doc to update */
+    sort?: Object;
+    /** sets the document fields to return */
+    select?: Object;
+  }
+
+  interface ModelFindOneAndUpdateOptions extends ModelFindByIdAndUpdateOptions {
+    /** Field selection. Equivalent to .select(fields).findOneAndUpdate() */
+    fields?: Object | string;
+    /** puts a time limit on the query - requires mongodb >= 2.6.0 */
+    maxTimeMS?: number;
+    /** if true, passes the raw result from the MongoDB driver as the third callback parameter */
+    passRawResult?: boolean;
+  }
+
+  interface ModelPopulateOptions {
+    /** space delimited path(s) to populate */
+    path: string;
+    /** optional fields to select */
+    select?: any;
+    /** optional query conditions to match */
+    match?: Object;
+    /** optional name of the model to use for population */
+    model?: string;
+    /** optional query options like sort, limit, etc */
+    options?: Object;
+  }
+
+  interface ModelUpdateOptions {
+    /** safe mode (defaults to value set in schema (true)) */
+    safe?: boolean;
+    /** whether to create the doc if it doesn't match (false) */
+    upsert?: boolean;
+    /** whether multiple documents should be updated (false) */
+    multi?: boolean;
+    /**
+     * If true, runs update validators on this command. Update validators validate
+     * the update operation against the model's schema.
+     */
+    runValidators?: boolean;
+    /**
+     * If this and upsert are true, mongoose will apply the defaults specified in the
+     * model's schema if a new document is created. This option only works on MongoDB >= 2.4
+     * because it relies on MongoDB's $setOnInsert operator.
+     */
+    setDefaultsOnInsert?: boolean;
+    /** overrides the strict option for this update */
+    strict?: boolean;
+    /** disables update-only mode, allowing you to overwrite the doc (false) */
+    overwrite?: boolean;
+    /** other options */
+    [other: string]: any;
+  }
+
+  interface ModelMapReduceOption<T, Key, Val> {
+    map: Function | string;
+    reduce: (key: Key, vals: T[]) => Val;
+    /** query filter object. */
+    query?: Object;
+    /** sort input objects using this key */
+    sort?: Object;
+    /** max number of documents */
+    limit?: number;
+    /** keep temporary data default: false */
+    keeptemp?: boolean;
+    /** finalize function */
+    finalize?: (key: Key, val: Val) => Val;
+    /** scope variables exposed to map/reduce/finalize during execution */
+    scope?: Object;
+    /** it is possible to make the execution stay in JS. Provided in MongoDB > 2.0.X default: false */
+    jsMode?: boolean;
+    /** provide statistics on job execution time. default: false */
+    verbose?: boolean;
+    readPreference?: string;
+    /** sets the output target for the map reduce job. default: {inline: 1} */
+    out?: {
+      /** the results are returned in an array */
+      inline?: number;
+      /**
+       * {replace: 'collectionName'} add the results to collectionName: the
+       * results replace the collection
+       */
+      replace?: string;
+      /**
+       * {reduce: 'collectionName'} add the results to collectionName: if
+       * dups are detected, uses the reducer / finalize functions
+       */
+      reduce?: string;
+      /**
+       * {merge: 'collectionName'} add the results to collectionName: if
+       * dups exist the new docs overwrite the old
+       */
+      merge?: string;
+    };
+  }
+
+  interface MapReduceResult<Key, Val> {
+    _id: Key;
+    value: Val;
+  }
+
+  /*
+   * section collection.js
+   * http://mongoosejs.com/docs/api.html#collection-js
+   */
+  interface CollectionBase extends mongodb.Collection {
+    /*
+      * Abstract methods. Some of these are already defined on the
+      * mongodb.Collection interface so they've been commented out.
+      */
+    ensureIndex(...args: any[]): any;
+    //find(...args: any[]): any;
+    findAndModify(...args: any[]): any;
+    //findOne(...args: any[]): any;
+    getIndexes(...args: any[]): any;
+    //insert(...args: any[]): any;
+    //mapReduce(...args: any[]): any;
+    //save(...args: any[]): any;
+    //update(...args: any[]): any;
+
+    /** The collection name */
+    collectionName: string;
+    /** The Connection instance */
+    conn: Connection;
+    /** The collection name */
+    name: string;
   }
 }

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -1448,8 +1448,8 @@ declare module "mongoose" {
      * you must first call remove() and then execute it by using the exec() method.
      * @param criteria mongodb selector
      */
-    remove(callback?: (err: any) => void): Query<void>;
-    remove(criteria: Object | Query<any>, callback?: (err: any) => void): Query<void>;
+    remove(callback?: (err: any) => void): Query<mongodb.WriteOpResult>;
+    remove(criteria: Object | Query<any>, callback?: (err: any) => void): Query<mongodb.WriteOpResult>;
 
     /** Specifies which document fields to include or exclude (also known as the query "projection") */
     select(arg: string | Object): this;

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -2040,7 +2040,7 @@ declare module "mongoose" {
    * section model.js
    * http://mongoosejs.com/docs/api.html#model-js
    */
-  interface Model<T extends Document> extends NodeJS.EventEmitter {
+  interface Model<T extends Document> extends NodeJS.EventEmitter, ModelProperties {
     /**
      * Model constructor
      * Provides the interface to MongoDB collections as well as creates document instances.
@@ -2059,14 +2059,26 @@ declare module "mongoose" {
      */
     new(doc?: Object): T;
 
-    /** The name of the model. */
-    modelName: string;
+    /** Base Mongoose instance the model uses. */
+    base: typeof mongoose;
+
+    /** If this is a discriminator model, `baseModelName` is the name of the base model. */
+    baseModelName: string;
 
     /** Collection the model uses. */
     collection: Collection;
 
-    /** If this is a discriminator model, `baseModelName` is the name of the base model. */
-    baseModelName: string;
+    /** Connection the model uses. */
+    db: Connection;
+
+    /** Registered discriminators for this model. */
+    discriminators: any;
+
+    /** The name of the model. */
+    modelName: string;
+
+    /** Schema the model uses. */
+    schema: Schema;
 
     /**
      * Finds a single document by its _id field. findById(id) is almost*
@@ -2304,7 +2316,7 @@ declare module "mongoose" {
     where(path: string, val?: Object): Query<any>;
   }
 
-  interface Document extends MongooseDocument, NodeJS.EventEmitter {
+  interface Document extends MongooseDocument, NodeJS.EventEmitter, ModelProperties {
     /** Signal that we desire an increment of this documents version. */
     increment(): this;
 
@@ -2328,22 +2340,30 @@ declare module "mongoose" {
      * @param fn optional callback
      */
     save(fn?: (err: any, product: this, numAffected: number) => void): _MongoosePromise<this>;
+  }
 
+  interface ModelProperties {
     /** Base Mongoose instance the model uses. */
     base: typeof mongoose;
+
     /**
      * If this is a discriminator model, baseModelName is the
      * name of the base model.
      */
     baseModelName: String;
+
     /** Collection the model uses. */
     collection: Collection;
+
     /** Connection the model uses. */
     db: Connection;
+
     /** Registered discriminators for this model. */
     discriminators: any;
+
     /** The name of the model */
     modelName: string;
+
     /** Schema the model uses. */
     schema: Schema;
   }

--- a/passport-local-mongoose/passport-local-mongoose-tests.ts
+++ b/passport-local-mongoose/passport-local-mongoose-tests.ts
@@ -77,10 +77,9 @@ options.errorMessages = errorMessages;
 
 UserSchema.plugin(passportLocalMongoose, options);
 
-type UserModel<T extends PassportLocalDocument> = _UserModel<T> & PassportLocalModel<T>;
-interface _UserModel<T extends PassportLocalDocument> {}
+interface UserModel<T extends PassportLocalDocument> extends PassportLocalModel<T> {}
 
-let UserModel: UserModel<User> = model<User>('User', UserSchema) as UserModel<User>;
+let UserModel: UserModel<User> = model<User>('User', UserSchema);
 //#endregion
 
 
@@ -96,7 +95,7 @@ passport.use('login', new LocalStrategy({
         process.nextTick(() => {
             UserModel
             .findOne({ 'username': username })
-            .exec((err: any, user: model<User>) => {
+            .exec((err: any, user: User) => {
                 if (err) {
                     console.log(err);
                     return done(err, null);

--- a/passport-local-mongoose/passport-local-mongoose-tests.ts
+++ b/passport-local-mongoose/passport-local-mongoose-tests.ts
@@ -34,7 +34,7 @@ interface User extends PassportLocalDocument {
     last: Date;
 }
 
-const UserSchema: PassportLocalSchema = <PassportLocalSchema>new Schema({
+const UserSchema: PassportLocalSchema = new Schema({
     username: String,
     hash: String,
     salt: String,

--- a/passport-local-mongoose/passport-local-mongoose-tests.ts
+++ b/passport-local-mongoose/passport-local-mongoose-tests.ts
@@ -11,6 +11,7 @@
 import {
     Schema,
     model,
+    Document,
     PassportLocalDocument,
     PassportLocalSchema,
     PassportLocalModel,
@@ -77,7 +78,7 @@ options.errorMessages = errorMessages;
 
 UserSchema.plugin(passportLocalMongoose, options);
 
-interface UserModel<T extends PassportLocalDocument> extends PassportLocalModel<T> {}
+interface UserModel<T extends Document> extends PassportLocalModel<T> {}
 
 let UserModel: UserModel<User> = model<User>('User', UserSchema);
 //#endregion

--- a/passport-local-mongoose/passport-local-mongoose.d.ts
+++ b/passport-local-mongoose/passport-local-mongoose.d.ts
@@ -76,13 +76,13 @@ declare module 'mongoose' {
     ): this;
   }
 
-  export function model<T extends PassportLocalDocument>(
+  export function model<T extends Document>(
     name: string,
     schema?: PassportLocalSchema,
     collection?: string,
     skipInit?: boolean): PassportLocalModel<T>;
 
-  export function model<T extends PassportLocalDocument, U extends PassportLocalModel<T>>(
+  export function model<T extends Document, U extends PassportLocalModel<T>>(
     name: string,
     schema?: PassportLocalSchema,
     collection?: string,

--- a/passport-local-mongoose/passport-local-mongoose.d.ts
+++ b/passport-local-mongoose/passport-local-mongoose.d.ts
@@ -10,14 +10,13 @@ declare module 'mongoose' {
   import passportLocal = require('passport-local');
 
   // methods
-  export interface PassportLocalDocument {
+  export interface PassportLocalDocument extends Document {
     setPassword(password: string, cb: (err: any, res: any) => void): void;
     authenticate(password: string, cb: (err: any, res: any, error: any) => void): void;
   }
 
   // statics
-  export type PassportLocalModel<T extends PassportLocalDocument> = _PassportLocalModel<T> & Model<T>;
-  interface _PassportLocalModel<T extends PassportLocalDocument> {
+  interface PassportLocalModel<T extends PassportLocalDocument> extends Model<T> {
     authenticate(): (username: string, password: string, cb: (err: any, res: T, error: any) => void) => void;
     serializeUser(): (user: PassportLocalModel<T>, cb: (err: any) => void) => void;
     deserializeUser(): (username: string, cb: (err: any) => void) => void;
@@ -77,11 +76,11 @@ declare module 'mongoose' {
     ): this;
   }
 
-  export function model<T extends PassportLocalDocument, Statics>(
+  export function model<T extends PassportLocalDocument>(
     name: string,
     schema?: PassportLocalSchema,
     collection?: string,
-    skipInit?: boolean): Statics & PassportLocalModel<T>;
+    skipInit?: boolean): PassportLocalModel<T>;
 }
 
 declare module 'passport-local-mongoose' {

--- a/passport-local-mongoose/passport-local-mongoose.d.ts
+++ b/passport-local-mongoose/passport-local-mongoose.d.ts
@@ -16,7 +16,7 @@ declare module 'mongoose' {
   }
 
   // statics
-  interface PassportLocalModel<T extends PassportLocalDocument> extends Model<T> {
+  interface PassportLocalModel<T extends Document> extends Model<T> {
     authenticate(): (username: string, password: string, cb: (err: any, res: T, error: any) => void) => void;
     serializeUser(): (user: PassportLocalModel<T>, cb: (err: any) => void) => void;
     deserializeUser(): (username: string, cb: (err: any) => void) => void;

--- a/passport-local-mongoose/passport-local-mongoose.d.ts
+++ b/passport-local-mongoose/passport-local-mongoose.d.ts
@@ -81,6 +81,12 @@ declare module 'mongoose' {
     schema?: PassportLocalSchema,
     collection?: string,
     skipInit?: boolean): PassportLocalModel<T>;
+
+  export function model<T extends PassportLocalDocument, U extends PassportLocalModel<T>>(
+    name: string,
+    schema?: PassportLocalSchema,
+    collection?: string,
+    skipInit?: boolean): U;
 }
 
 declare module 'passport-local-mongoose' {


### PR DESCRIPTION
1.  Definition of mongoose.Model uses interfaces again instead of type intersection since type intersections were hard to read and could not be extended by another interface.
2. Updated to mongoose 4.5.9
3. Added missing properties on mongoose.Model
4. Was some confusion about how to use the definitions so I added a README.
5. Updated mongoose.Promise to use global.Promise by default, and allowing users to manually override if necessary.
6. Updated related mongoose definitions: passport-local-mongoose, mongoose-paginate, mongoose-promise.
