### PR TITLE
Add allowHTML NotificationSystem property

### DIFF
--- a/react-notification-system/react-notification-system.d.ts
+++ b/react-notification-system/react-notification-system.d.ts
@@ -74,6 +74,7 @@ declare namespace NotificationSystem {
         noAnimation?: boolean;
         ref?: string;
         style?: Style | boolean;
+        allowHTML?: boolean;
     }
 }
 


### PR DESCRIPTION
Added missing allowHTML property to NotificationSystem.Attributes interface

Corresponding source code reference: Line 90 of https://github.com/igorprado/react-notification-system/blob/master/src/NotificationSystem.jsx
