### PR TITLE
Fixed Pusher interface property name

### DIFF
--- a/pusher-js/pusher-js.d.ts
+++ b/pusher-js/pusher-js.d.ts
@@ -23,7 +23,7 @@ declare module "pusher-js" {
             config: Config; //TODO: add GlobalConfig typings
             channels: any; //TODO: Type this
             global_emitter: EventsDispatcher;
-            sessionId: number;
+            sessionID: number;
             timeline: any; //TODO: Type this
             connection: ConnectionManager;
         }

--- a/react-notification-system/react-notification-system.d.ts
+++ b/react-notification-system/react-notification-system.d.ts
@@ -74,6 +74,7 @@ declare namespace NotificationSystem {
         noAnimation?: boolean;
         ref?: string;
         style?: Style | boolean;
+        allowHTML?: boolean;
     }
 }
 


### PR DESCRIPTION
Pusher interface property name should be sessionID, not sessionId

Code reference: Line 61 of https://github.com/pusher/pusher-js/blob/master/src/core/pusher.ts
