### PR TITLE
Add support for passing in undefined or null to classnames

### DIFF
--- a/classnames/classnames-tests.ts
+++ b/classnames/classnames-tests.ts
@@ -19,6 +19,8 @@ classNames([{ foo: true, bar: false }, { baz: true }]); // => 'foo baz'
 
 classNames(["foo", ["bar", {baz: true}]]); // => 'foo bar baz'
 
-// other falsy values are just ignored
-// NOTE: We don't really want to allow this kind of thing with Typescript (otherwise what's the point!)
-//classNames(null, false, 'bar', undefined, 0, 1, { baz: null }, ''); // => 'bar 1'
+// falsey values are just ignored
+classNames(null, 'bar', undefined, 0, 1, { baz: null }, ''); // => 'bar 1'
+
+// Supporting booleans is tricky since we should only support passing in false, which is ignored
+//classNames(false, 'bar', 0, 1, { baz: null }, ''); // => 'bar 1'

--- a/classnames/classnames.d.ts
+++ b/classnames/classnames.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Dave Keen <http://www.keendevelopment.ch>, Adi Dahiya <https://github.com/adidahiya>, Jason Killian <https://github.com/JKillian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare type ClassValue = string | number | ClassDictionary | ClassArray;
+declare type ClassValue = string | number | ClassDictionary | ClassArray | undefined | null;
 
 interface ClassDictionary {
 	[id: string]: boolean;


### PR DESCRIPTION
When strictNullChecks are enabled, it is currently impossible to pass in values that might be `null` or `undefined` to classNames. This is a common usage pattern and is [documented in the README](https://github.com/JedWatson/classnames#usage).

Fix this by allowing both `null` and `undefined` to be passed in.
