### PR TITLE
Add interface to refer to the $onChanges parameter

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1746,12 +1746,12 @@ declare namespace angular {
          */
         $onInit?(): void;
         /**
-         * Called whenever one-way bindings are updated. The changesObj is a hash whose keys are the names of the bound
-         * properties that have changed, and the values are an {@link IChangesObject} object  of the form
+         * Called whenever one-way bindings are updated. The onChangesObj is a hash whose keys are the names of the bound
+         * properties that have changed, and the values are an {@link IChangesObject} object of the form
          * { currentValue, previousValue, isFirstChange() }. Use this hook to trigger updates within a component such as
          * cloning the bound value to prevent accidental mutation of the outer value.
          */
-        $onChanges?(changesObj: {[property:string]: IChangesObject}): void;
+        $onChanges?(onChangesObj: IOnChangesObject): void;
         /**
          * Called on a controller when its containing scope is destroyed. Use this hook for releasing external resources,
          * watches and event handlers.
@@ -1766,6 +1766,10 @@ declare namespace angular {
          * different in Angular 1 there is no direct mapping and care should be taken when upgrading.
          */
         $postLink?(): void;
+    }
+    
+    interface IOnChangesObject {
+        [property: string]: IChangesObject;
     }
 
     interface IChangesObject {


### PR DESCRIPTION
Improvement to existing type definition.

The $onChanges method of the IComponentController interface has the type in-lined, making it impossible to refer to it. A new interface was added to encapsulate this type, so that it can be easily used and extended.

[Link to commit](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/ac33157eb23150ae31d290b2b8bd3c68294d3475).
