### PR TITLE
Fix withWidth return type signature to be a HOC

### DIFF
--- a/material-ui/material-ui-tests.tsx
+++ b/material-ui/material-ui-tests.tsx
@@ -112,6 +112,8 @@ import {cyan500, cyan700,
 } from 'material-ui/styles/colors';
 import {fade} from 'material-ui/utils/colorManipulator';
 
+import {SMALL, MEDIUM, LARGE, default as withWidth} from 'material-ui/utils/withWidth';
+
 
 import injectTapEventPlugin = require('react-tap-event-plugin');
 
@@ -4925,6 +4927,8 @@ class ToolbarExamplesSimple extends React.Component<{}, {value?: number}> {
     );
   }
 }
+
+const componentWithWidth = withWidth()(ToolbarExamplesSimple);
 
 
 interface MaterialUiTestsState {

--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -7228,7 +7228,7 @@ declare module 'material-ui/utils/withWidth' {
       mediumWidth?: number;
       resizeInterval?: number;
   }
-  export default function withWidth(options?: Options): __React.ComponentClass<any>
+  export default function withWidth<C extends Function>(options?: Options): (component: C) => C;
 }
 
 declare namespace __MaterialUI.Styles {


### PR DESCRIPTION
`withWidth` is a function that returns a high order component wrapper function. More info here: https://github.com/callemall/material-ui/blob/master/src/utils/withWidth.js#L15

This comes as a successor of #10235
