### PR TITLE
Added entries, includes, keys and values to Buffer

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -259,6 +259,47 @@ function bufferTests() {
         index = buffer.lastIndexOf(buffer);
     }
 
+    {
+        let buffer = new Buffer('123');
+        let val: [number, number];
+
+        for (let entry of buffer.entries()) {
+            val = entry;
+        }
+    }
+
+    {
+        let buffer = new Buffer('123');
+        let includes: boolean;
+        includes = buffer.includes("23");
+        includes = buffer.includes("23", 1);
+        includes = buffer.includes("23", 1, "utf8");
+        includes = buffer.includes(23);
+        includes = buffer.includes(23, 1);
+        includes = buffer.includes(23, 1, "utf8");
+        includes = buffer.includes(buffer);
+        includes = buffer.includes(buffer, 1);
+        includes = buffer.includes(buffer, 1, "utf8");
+    }
+
+    {
+        let buffer = new Buffer('123');
+        let val: number;
+
+        for (let key of buffer.keys()) {
+            val = key;
+        }
+    }
+
+    {
+        let buffer = new Buffer('123');
+        let val: number;
+
+        for (let value of buffer.values()) {
+            val = value;
+        }
+    }
+
     // Imported Buffer from buffer module works properly
     {
         let b = new ImportedBuffer('123');

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -505,10 +505,10 @@ interface NodeBuffer extends Uint8Array {
     fill(value: any, offset?: number, end?: number): this;
     indexOf(value: string | number | Buffer, byteOffset?: number, encoding?: string): number;
     lastIndexOf(value: string | number | Buffer, byteOffset?: number, encoding?: string): number;
-    // TODO: entries
-    // TODO: includes
-    // TODO: keys
-    // TODO: values
+    entries(): IterableIterator<[number, number]>;
+    includes(value: string | number | Buffer, byteOffset?: number, encoding?: string): boolean;
+    keys(): IterableIterator<number>;
+    values(): IterableIterator<number>;
 }
 
 /************************************************


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- Added the following method definitions to Buffer:
  - `entries` https://nodejs.org/api/buffer.html#buffer_buf_entries
  - `includes` https://nodejs.org/api/buffer.html#buffer_buf_includes_value_byteoffset_encoding
  - `keys` https://nodejs.org/api/buffer.html#buffer_buf_keys
  - `values` https://nodejs.org/api/buffer.html#buffer_buf_values
