### PR TITLE
Fix expect.d.ts to non-default export

### DIFF
--- a/expect/expect-tests.ts
+++ b/expect/expect-tests.ts
@@ -1,9 +1,12 @@
 /// <reference path="./expect.d.ts" />
 /// <reference path="../mocha/mocha.d.ts"" />
 
-import expect,
-      {Expectation, Extension, Spy, createSpy, isSpy, assert, spyOn, extend, restoreSpies}
-      from 'expect';
+import * as expect from 'expect';
+import Expectation from 'expect/lib/Expectation';
+import Extension from 'expect/lib/Extension';
+import Spy from 'expect/lib/Spy';
+
+const {createSpy, isSpy, assert, spyOn, extend, restoreSpies} = expect;
 
 describe('chaining assertions', function () {
   it('should allow chaining for array-like applications', function () {

--- a/expect/expect.d.ts
+++ b/expect/expect.d.ts
@@ -60,12 +60,14 @@ declare module "expect" {
 
     function expect(actual:any):Expectation;
 
-    export function createSpy(fn?:Function, restore?:Function):Spy;
-    export function spyOn(object:Object, methodName:string):Spy;
-    export function isSpy(object:any):Boolean;
-    export function restoreSpies():void;
-    export function assert(condition:any, messageFormat:string, ...extraArgs:Array<any>):void;
-    export function extend(extension:Extension):void;
+    namespace expect {
+        export function createSpy(fn?:Function, restore?:Function):Spy;
+        export function spyOn(object:Object, methodName:string):Spy;
+        export function isSpy(object:any):Boolean;
+        export function restoreSpies():void;
+        export function assert(condition:any, messageFormat:string, ...extraArgs:Array<any>):void;
+        export function extend(extension:Extension):void;
+    }
 
     export default expect;
 }

--- a/expect/expect.d.ts
+++ b/expect/expect.d.ts
@@ -3,8 +3,8 @@
 // Definitions by: Justin Reidy <https://github.com/jmreidy/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module "expect" {
-    export class Expectation {
+declare namespace expect {
+    class Expectation {
         constructor(actual:any);
         toExist(message?:string):Expectation;
         toBeTruthy(message?:string):Expectation;
@@ -37,16 +37,16 @@ declare module "expect" {
         withArgs(...args:Array<any>):Expectation;
     }
 
-    export interface Extension {
+    interface Extension {
         [name:string]:(args?:Array<any>) => void;
     }
 
-    export interface Call {
+    interface Call {
         context: Spy;
         arguments: Array<any>;
     }
 
-    export interface Spy {
+    interface Spy {
         __isSpy:Boolean;
         calls:Array<Call>;
         andCall(fn:Function):Spy;
@@ -58,16 +58,31 @@ declare module "expect" {
         destroy():void;
     }
 
-    function expect(actual:any):Expectation;
+}
 
-    namespace expect {
-        export function createSpy(fn?:Function, restore?:Function):Spy;
-        export function spyOn(object:Object, methodName:string):Spy;
+declare module "expect" {
+    function e(actual:any):expect.Expectation;
+
+    namespace e {
+        export function createSpy(fn?:Function, restore?:Function):expect.Spy;
+        export function spyOn(object:Object, methodName:string):expect.Spy;
         export function isSpy(object:any):Boolean;
         export function restoreSpies():void;
         export function assert(condition:any, messageFormat:string, ...extraArgs:Array<any>):void;
-        export function extend(extension:Extension):void;
+        export function extend(extension:expect.Extension):void;
     }
 
-    export default expect;
+    export = e;
+}
+
+declare module "expect/lib/Expectation" {
+    export default expect.Expectation;
+}
+
+declare module "expect/lib/Extension" {
+    export default expect.Extension;
+}
+
+declare module "expect/lib/Spy" {
+    export default expect.Spy;
 }

--- a/expect/expect.d.ts
+++ b/expect/expect.d.ts
@@ -5,57 +5,57 @@
 
 declare module "expect" {
     export class Expectation {
-      constructor(actual:any);
-      toExist(message?:string):Expectation;
-      toBeTruthy(message?:string):Expectation;
-      toNotExist(message?:string):Expectation;
-      toBeFalsy(message?:string):Expectation;
-      toBe(value:any, message?:string):Expectation;
-      toNotBe(value:any, message?:string):Expectation;
-      toEqual(value:any, message?:string):Expectation;
-      toNotEqual(value:any, message?:string):Expectation;
-      toThrow(value?:any, message?:string):Expectation;
-      toNotThrow(value?:any, message?:string):Expectation;
-      toBeA(value:any, message?:string):Expectation;
-      toBeAn(value:any, message?:string):Expectation;
-      toNotBeA(value:any, message?:string):Expectation;
-      toNotBeAn(value:any, message?:string):Expectation;
-      toMatch(value:any, message?:string):Expectation;
-      toNotMatch(value:any, message?:string):Expectation;
-      toBeLessThan(value:any, message?:string):Expectation;
-      toBeFewerThan(value:any, message?:string):Expectation;
-      toBeGreaterThan(value:any, message?:string):Expectation;
-      toBeMoreThan(value:any, message?:string):Expectation;
-      toInclude(value:any, compareValues?:any, message?:string):Expectation;
-      toContain(value:any, compareValues?:any, message?:string):Expectation;
-      toExclude(value:any, compareValues?:any, message?:string):Expectation;
-      toNotContain(value:any, compareValues?:any, message?:string):Expectation;
-      toHaveBeenCalled(message?:string):Expectation;
-      toHaveBeenCalledWith(...args:Array<any>):Expectation;
-      toNotHaveBeenCalled(message?:string):Expectation;
-      withContext(context:any):Expectation;
-      withArgs(...args:Array<any>):Expectation;
+        constructor(actual:any);
+        toExist(message?:string):Expectation;
+        toBeTruthy(message?:string):Expectation;
+        toNotExist(message?:string):Expectation;
+        toBeFalsy(message?:string):Expectation;
+        toBe(value:any, message?:string):Expectation;
+        toNotBe(value:any, message?:string):Expectation;
+        toEqual(value:any, message?:string):Expectation;
+        toNotEqual(value:any, message?:string):Expectation;
+        toThrow(value?:any, message?:string):Expectation;
+        toNotThrow(value?:any, message?:string):Expectation;
+        toBeA(value:any, message?:string):Expectation;
+        toBeAn(value:any, message?:string):Expectation;
+        toNotBeA(value:any, message?:string):Expectation;
+        toNotBeAn(value:any, message?:string):Expectation;
+        toMatch(value:any, message?:string):Expectation;
+        toNotMatch(value:any, message?:string):Expectation;
+        toBeLessThan(value:any, message?:string):Expectation;
+        toBeFewerThan(value:any, message?:string):Expectation;
+        toBeGreaterThan(value:any, message?:string):Expectation;
+        toBeMoreThan(value:any, message?:string):Expectation;
+        toInclude(value:any, compareValues?:any, message?:string):Expectation;
+        toContain(value:any, compareValues?:any, message?:string):Expectation;
+        toExclude(value:any, compareValues?:any, message?:string):Expectation;
+        toNotContain(value:any, compareValues?:any, message?:string):Expectation;
+        toHaveBeenCalled(message?:string):Expectation;
+        toHaveBeenCalledWith(...args:Array<any>):Expectation;
+        toNotHaveBeenCalled(message?:string):Expectation;
+        withContext(context:any):Expectation;
+        withArgs(...args:Array<any>):Expectation;
     }
 
     export interface Extension {
-      [name:string]:(args?:Array<any>) => void;
+        [name:string]:(args?:Array<any>) => void;
     }
 
     export interface Call {
-      context: Spy;
-      arguments: Array<any>;
+        context: Spy;
+        arguments: Array<any>;
     }
 
     export interface Spy {
-      __isSpy:Boolean;
-      calls:Array<Call>;
-      andCall(fn:Function):Spy;
-      andCallThrough():Spy;
-      andThrow(object:Object):Spy;
-      andReturn(value:any):Spy;
-      getLastCall():Call;
-      restore():void;
-      destroy():void;
+        __isSpy:Boolean;
+        calls:Array<Call>;
+        andCall(fn:Function):Spy;
+        andCallThrough():Spy;
+        andThrow(object:Object):Spy;
+        andReturn(value:any):Spy;
+        getLastCall():Call;
+        restore():void;
+        destroy():void;
     }
 
     function expect(actual:any):Expectation;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

[mjackson/expect](https://github.com/mjackson/expect) doesn't `export` with `default`. And exported function object implements some other methods.
- Source code: https://github.com/mjackson/expect/blob/master/modules/index.js#L6-L17
