### PR TITLE
bowser: update bowser for global variable closes #10813

### DIFF
--- a/bowser/bowser-tests.ts
+++ b/bowser/bowser-tests.ts
@@ -13,3 +13,7 @@ bowser.test(['msie']) === true;
 bowser.a === bowser.c;
 bowser.osversion > 10;
 bowser.osversion === '10.1A';
+bowser.compareVersions(['9.0', '10']);
+bowser() === <BowserModule.IBowserDetection>{android: true, x: true};
+bowser.check({msie: "11"}, window.navigator.userAgent);
+bowser.isUnsupportedBrowser({msie: "10"}, window.navigator.userAgent);

--- a/bowser/bowser-tests.ts
+++ b/bowser/bowser-tests.ts
@@ -7,3 +7,9 @@ Bowser.test(['msie']) === true;
 Bowser.a === Bowser.c;
 Bowser.osversion > 10;
 Bowser.osversion === '10.1A';
+
+bowser.msedge === true;
+bowser.test(['msie']) === true;
+bowser.a === bowser.c;
+bowser.osversion > 10;
+bowser.osversion === '10.1A';

--- a/bowser/bowser.d.ts
+++ b/bowser/bowser.d.ts
@@ -3,9 +3,10 @@
 // Definitions by: Paulo Cesar <https://github.com/pocesar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+declare var bowser: BowserModule.IBowser;
+
 declare module 'bowser' {
-    var def: BowserModule.IBowser;
-    export = def;
+    export = bowser;
 }
 
 declare namespace BowserModule {

--- a/bowser/bowser.d.ts
+++ b/bowser/bowser.d.ts
@@ -11,45 +11,96 @@ declare module 'bowser' {
 
 declare namespace BowserModule {
 
-    export interface IBowserUA {
-        msie: boolean;
+    export interface IBowserOS {
+        mac: boolean;
+        /**other than Windows Phone */
+        windows: boolean;
+        windowsphone: boolean;
+        /**other than android, chromeos, webos, tizen, and sailfish */
+        linux: boolean;
+        chromeos: boolean;
+        android: boolean;
+        /** also sets one of iphone/ipad/ipod */
+        ios: boolean;
+        blackberry: boolean;
+        firefoxos: boolean;
+        /** may also set touchpad */
+        webos: boolean;
+        bada: boolean;
+        tizen: boolean;
+        sailfish: boolean;
+    }
+
+    export interface IBowserVersions {
         chrome: boolean;
-        webkit: boolean;
-        phantom: boolean;
-        opera: boolean;
+        firefox: boolean;
+        msie: boolean;
+        msedge: boolean;
         safari: boolean;
         android: boolean;
         ios: boolean;
-        webos: boolean;
-        msedge: boolean;
-        seamonkey: boolean;
-        firefox: boolean;
-        yandexbrowser: boolean;
+        opera: boolean;
+        phantom: boolean;
         blackberry: boolean;
-        tablet: boolean;
-        mobile: boolean;
+        webos: boolean;
         silk: boolean;
         bada: boolean;
         tizen: boolean;
-        windowsphone: boolean;
-        firefoxos: boolean;
-        gecko: boolean;
+        seamonkey: boolean;
         sailfish: boolean;
-        chromeBook: boolean;
+        ucbrowser: boolean;
+        qupzilla: boolean;
+        vivaldi: boolean;
+        sleipnir: boolean;
+        kMeleon: boolean;
+    }
+
+    export interface IBowserEngines {
+        /** IE <= 11 */
+        msie: boolean;
+        /**Chrome 0-27, Android <4.4, iOs, BB, etc. */
+        webkit: boolean;
+        /**Chrome >=28, Android >=4.4, Opera, etc. */
+        blink: boolean;
+        /**Firefox, etc. */
+        gecko: boolean;
+        /** IE > 11 */
+        msedge: boolean;
+        /** If a tablet device is detected, the flag tablet is set instead of mobile. */
+        tablet: boolean;
+        /** All detected mobile OSes are additionally flagged mobile, unless it's a tablet */
+        mobile: boolean;
+
+    }
+
+    export interface IBowserGrade {
         /** Grade A browser */
         a: boolean;
         /** Grade C browser */
         c: boolean;
         /** Grade X browser */
         x: boolean;
+        /**A human readable name for this browser. E.g. 'Chrome', '' */
         name: string;
+        /**Version number for the browser. E.g. '32.0' */
         version: string|number;
         osversion: string|number;
     }
 
-    export interface IBowser extends IBowserUA {
+    export interface IBowserDetection extends IBowserGrade, IBowserEngines, IBowserOS, IBowserVersions { }
+
+    export interface IBowserMinVersions {
+        // { msie: "11", "firefox": "4" }
+        [index: string]: string;
+    }
+
+    export interface IBowser extends IBowserDetection {
+        (): IBowserDetection;
         test(browserList: string[]): boolean;
         _detect(ua: string): IBowser;
+        compareVersions(versions: string[]): number;
+        check(minVersions: IBowserMinVersions, strictMode?: boolean|string, ua?: string): Boolean;
+        isUnsupportedBrowser(minVersions: IBowserMinVersions, strictMode?: boolean|string, ua?: string): boolean;
     }
 
 }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changeshttps://github.com/ded/bowser#api.

was missing browser global declaration, closes #10813 
