### PR TITLE
Added missing className property to CardProps

### DIFF
--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -756,6 +756,7 @@ declare namespace __MaterialUI {
     namespace Card {
 
         interface CardProps extends React.Props<Card> {
+            className?: string;
             actAsExpander?: boolean;
             containerStyle?: React.CSSProperties;
             expandable?: boolean;


### PR DESCRIPTION
Improvement to existing type definition.

The className property for CardProps is missing, so using it like
<Card className={this.myClass}>...</Card>
is not possible.
