### PR TITLE
Fix gulp.dest overload parameter type to be Vinyl File

### DIFF
--- a/gulp/gulp.d.ts
+++ b/gulp/gulp.d.ts
@@ -5,9 +5,11 @@
 
 /// <reference path="../node/node.d.ts" />
 /// <reference path="../orchestrator/orchestrator.d.ts" />
+/// <reference path="../vinyl/vinyl.d.ts" />
 
 declare module "gulp" {
     import Orchestrator = require("orchestrator");
+    import VinylFile = require("vinyl");
 
     namespace gulp {
         interface Gulp extends Orchestrator {
@@ -92,7 +94,7 @@ declare module "gulp" {
              * @param outFolder The path (output folder) to write files to. Or a function that returns it, the function will be provided a vinyl File instance.
              * @param opt
              */
-            (outFolder: string|((file: string) => string), opt?: DestOptions): NodeJS.ReadWriteStream;
+            (outFolder: string|((file: VinylFile) => string), opt?: DestOptions): NodeJS.ReadWriteStream;
         }
 
         interface SrcMethod {
@@ -149,7 +151,7 @@ declare module "gulp" {
              * Note that an explicit dot in a portion of the pattern will always match dot files.
              */
             dot?: boolean;
-            
+
             /**
              * Set to match only fles, not directories. Set this flag to prevent copying empty directories
              */

--- a/gulp/gulp.d.ts
+++ b/gulp/gulp.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference path="../node/node.d.ts" />
 /// <reference path="../orchestrator/orchestrator.d.ts" />
-/// <reference path="../vinyl/vinyl.d.ts" />
+/// <reference path="../vinyl/vinyl-0.4.3.d.ts" />
 
 declare module "gulp" {
     import Orchestrator = require("orchestrator");

--- a/gulp/gulp.d.ts
+++ b/gulp/gulp.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference path="../node/node.d.ts" />
 /// <reference path="../orchestrator/orchestrator.d.ts" />
-/// <reference path="../vinyl/vinyl-0.4.3.d.ts" />
+/// <reference path="../vinyl/vinyl.d.ts" />
 
 declare module "gulp" {
     import Orchestrator = require("orchestrator");


### PR DESCRIPTION
According to the [Gulp API](https://github.com/gulpjs/gulp/blob/master/docs/API.md#gulpdestpath-options), `gulp.dest` can be a `string` or a `function`.

In the case of a `function`, the passed parameter will be a Vinyl File instance, and not a `string`.
