### PR TITLE
Add parse function definition to set-cookie-parse

### DIFF
--- a/set-cookie-parser/set-cookie-parser-tests.ts
+++ b/set-cookie-parser/set-cookie-parser-tests.ts
@@ -1,13 +1,20 @@
 /// <reference path="./set-cookie-parser.d.ts" />
 /// <reference path="../node/node.d.ts" />
 
-import assert = require("assert");
-import http = require("http");
-import setCookie = require("set-cookie-parser");
+import * as assert from "assert";
+import * as http from "http";
+import * as setCookie from "set-cookie-parser";
+
+// Call parse function on imported object
+var input = "foo=bar;";
+var cookies = setCookie.parse(input);
+assert.equal(cookies.length, 1);
+assert.equal(cookies[0].name, "foo");
+assert.equal(cookies[0].value, "bar");
 
 // Required properties only test
 var requiredOnly = "foo=bar;";
-var cookies = setCookie(requiredOnly);
+cookies = setCookie(requiredOnly);
 assert.equal(cookies.length, 1);
 assert.equal(cookies[0].name, "foo");
 assert.equal(cookies[0].value, "bar");
@@ -43,3 +50,21 @@ assert.equal(cookies[0].name, "bam");
 assert.equal(cookies[0].value, "baz");
 assert.equal(cookies[1].name, "foo");
 assert.equal(cookies[1].value, "bar");
+
+// Create new cookie with only required properties
+var requiredOnlyCookie: setCookie.Cookie = {
+    name: "Foo",
+    value: "Bar"
+}
+
+// Create new cookie with all properties included optional ones
+var optionalIncludedCookie: setCookie.Cookie = {
+    name: "Bam",
+    value: "Baz",
+    domain: ".example.com",
+    path: "/",
+    expires:  new Date("Tue Jul 01 2025 06:01:11 GMT-0400 (EDT)"),
+    maxAge: 1000,
+    httpOnly: true,
+    secure: true
+};

--- a/set-cookie-parser/set-cookie-parser.d.ts
+++ b/set-cookie-parser/set-cookie-parser.d.ts
@@ -6,22 +6,24 @@
 /// <reference path="../node/node.d.ts" />
 
 declare module "set-cookie-parser" {
-	import http = require("http");
+    import http = require("http");
 
-	function SetCookieParser(input: string | string[] | http.IncomingMessage): SetCookieParser.Cookie[];
+    function SetCookieParser(input: string | string[] | http.IncomingMessage): SetCookieParser.Cookie[];
 
-	namespace SetCookieParser {
-		interface Cookie {
-			name: string;
-			value: string;
-			path?: string;
-			expires?: Date;
-			maxAge?: number;
-			domain?: string;
-			secure?: boolean;
-			httpOnly?: boolean;
-		}
-	}
+    namespace SetCookieParser {
+        function parse(input: string | string[] | http.IncomingMessage): Cookie[];
 
-	export = SetCookieParser;
+        interface Cookie {
+            name: string;
+            value: string;
+            path?: string;
+            expires?: Date;
+            maxAge?: number;
+            domain?: string;
+            secure?: boolean;
+            httpOnly?: boolean;
+        }
+    }
+
+    export = SetCookieParser;
 }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- [x] documentation or source code reference which provides context for the suggested changes. https://github.com/nfriedly/set-cookie-parser/blob/master/lib/set-cookie.js
- [ ] it has been reviewed by a DefinitelyTyped member.

The library is exported twice, once as the main export and once as a parse property. This change adds the parse property that is being exported to the definitions along with a corresponding test.
