### PR TITLE
Reflect the latest Fetch API spec

### DIFF
--- a/whatwg-fetch/whatwg-fetch-tests.ts
+++ b/whatwg-fetch/whatwg-fetch-tests.ts
@@ -7,7 +7,7 @@ function test_HeadersCopiedFromHeaders() {
 }
 
 function test_HeadersCopiedFromHash() {
-	var source:HeadersMap = {
+	var source: DOMStringMap = {
 		'Content-Type': 'application/json'
 	};
 	return new Headers(source);

--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -93,7 +93,7 @@ interface Response extends Body {
 }
 interface ResponseInit {
     status?: number;
-    statusText?: number;
+    statusText?: string;
     headers?: HeadersInit;
 }
 interface ResponseConstructor {

--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -42,8 +42,8 @@ interface Request extends Body {
     url: string;
     headers: Headers;
 
-    type: "" | "audio" | "font" | "image" | "script" | "style" | "track" | "video";
-    destination: "" | "document" | "embed" | "font" | "image" | "manifest" | "media" | "object" | "report" | "script" | "serviceworker" | "sharedworker" | "style" | "worker" | "xslt";
+    type: RequestType
+    destination: RequestDestination;
     referrer: string;
     referrerPolicy: ReferrerPolicy;
     mode: RequestMode;
@@ -72,6 +72,8 @@ interface RequestConstructor {
 }
 declare var Request: RequestConstructor;
 
+type RequestType = "" | "audio" | "font" | "image" | "script" | "style" | "track" | "video";
+type RequestDestination = "" | "document" | "embed" | "font" | "image" | "manifest" | "media" | "object" | "report" | "script" | "serviceworker" | "sharedworker" | "style" | "worker" | "xslt";
 type RequestMode = "navigate" | "same-origin" | "no-cors" | "cors";
 type RequestCredentials = "omit" | "same-origin" | "include";
 type RequestCache = "default" | "no-store" | "reload" | "no-cache" | "force-cache" | "only-if-cached";
@@ -79,7 +81,7 @@ type RequestRedirect = "follow" | "error" | "manual";
 type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url";
 
 interface Response extends Body {
-    type: "basic" | "cors" | "default" | "error" | "opaque" | "opaqueredirect";
+    type: ResponseType;
     url: string;
     redirected: boolean;
     status: number;
@@ -103,3 +105,5 @@ interface ResponseConstructor {
     redirect(url: string, status?: number): Response;
 }
 declare var Response: ResponseConstructor;
+
+type ResponseType = "basic" | "cors" | "default" | "error" | "opaque" | "opaqueredirect";

--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -1,98 +1,105 @@
-﻿// Type definitions for fetch API
+// Type definitions for Fetch API
 // Project: https://github.com/github/fetch
-// Definitions by: Ryan Graham <https://github.com/ryan-codingintrigue>
+// Definitions by: Ryan Graham <https://github.com/ryan-codingintrigue>, Kagami Sascha Rosylight <https://github.com/saschanaz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare class Request extends Body {
-	constructor(input: string|Request, init?:RequestInit);
-	method: string;
-	url: string;
-	headers: Headers;
-	context: RequestContext;
-	referrer: string;
-	mode: RequestMode;
-	redirect: RequestRedirect;
-	credentials: RequestCredentials;
-	cache: RequestCache;
-}
-
-interface RequestInit {
-	method?: string;
-	headers?: HeaderInit|{ [index: string]: string };
-	body?: BodyInit;
-	mode?: RequestMode;
-	redirect?: RequestRedirect;
-	credentials?: RequestCredentials;
-	cache?: RequestCache;
-}
-
-type RequestContext =
-	"audio" | "beacon" | "cspreport" | "download" | "embed" |
-	"eventsource" | "favicon" | "fetch" | "font" | "form" | "frame" |
-	"hyperlink" | "iframe" | "image" | "imageset" | "import" |
-	"internal" | "location" | "manifest" | "object" | "ping" | "plugin" |
-	"prefetch" | "script" | "serviceworker" | "sharedworker" |
-	"subresource" | "style" | "track" | "video" | "worker" |
-	"xmlhttprequest" | "xslt";
-type RequestMode = "same-origin" | "no-cors" | "cors";
-type RequestRedirect = "follow" | "error" | "manual";
-type RequestCredentials = "omit" | "same-origin" | "include";
-type RequestCache =
-	"default" | "no-store" | "reload" | "no-cache" |
-	"force-cache" | "only-if-cached";
-
-declare interface HeadersMap {
-	[index: string]: string;
-}
-
-declare class Headers {
-	constructor(headers?:Headers|HeadersMap)
-	append(name: string, value: string): void;
-	delete(name: string):void;
-	get(name: string): string;
-	getAll(name: string): Array<string>;
-	has(name: string): boolean;
-	set(name: string, value: string): void;
-	forEach(callback: (value: string, name: string) => void): void;
-}
-
-declare class Body {
-	bodyUsed: boolean;
-	arrayBuffer(): Promise<ArrayBuffer>;
-	blob(): Promise<Blob>;
-	formData(): Promise<FormData>;
-	json(): Promise<any>;
-	json<T>(): Promise<T>;
-	text(): Promise<string>;
-}
-
-declare class Response extends Body {
-	constructor(body?: BodyInit, init?: ResponseInit);
-	static error(): Response;
-	static redirect(url: string, status: number): Response;
-	type: ResponseType;
-	url: string;
-	status: number;
-	ok: boolean;
-	statusText: string;
-	headers: Headers;
-	clone(): Response;
-}
-
-type ResponseType = "basic" | "cors" | "default" | "error" | "opaque" | "opaqueredirect";
-
-interface ResponseInit {
-	status: number;
-	statusText?: string;
-	headers?: HeaderInit;
-}
-
-declare type HeaderInit = Headers|Array<string>;
-declare type BodyInit = ArrayBuffer|ArrayBufferView|Blob|FormData|string;
-declare type RequestInfo = Request|string;
-
 interface Window {
-	fetch(url: string|Request, init?: RequestInit): Promise<Response>;
+    fetch(url: RequestInfo, init?: RequestInit): Promise<Response>;
+}
+declare var fetch: typeof window.fetch;
+
+declare type HeadersInit = Headers | string[][] | { [key: string]: string };
+declare class Headers {
+    constructor(init?: HeadersInit);
+
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    get(name: string): string | null;
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+
+    // WebIDL pair iterator: iterable<ByteString, ByteString>
+    entries(): IterableIterator<[string, string]>;
+    forEach(callback: (value: string, index: number, headers: Headers) => void, thisArg?: any): void;
+    keys(): IterableIterator<string>;
+    values(): IterableIterator<string>;
+    [Symbol.iterator](): IterableIterator<[string, string]>;
 }
 
-declare var fetch: typeof window.fetch;
+declare type BodyInit = Blob | ArrayBufferView | ArrayBuffer | FormData /* | URLSearchParams */ | string;
+interface Body {
+    bodyUsed: boolean;
+    arrayBuffer(): Promise<ArrayBuffer>;
+    blob(): Promise<Blob>;
+    formData(): Promise<FormData>;
+    json(): Promise<any>;
+    text(): Promise<string>;
+}
+
+declare type RequestInfo = Request | string;
+interface Request extends Body {
+    method: string;
+    url: string;
+    headers: Headers;
+
+    type: "" | "audio" | "font" | "image" | "script" | "style" | "track" | "video";
+    destination: "" | "document" | "embed" | "font" | "image" | "manifest" | "media" | "object" | "report" | "script" | "serviceworker" | "sharedworker" | "style" | "worker" | "xslt";
+    referrer: string;
+    referrerPolicy: ReferrerPolicy;
+    mode: RequestMode;
+    credentials: RequestCredentials;
+    cache: RequestCache;
+    redirect: RequestRedirect;
+    integrity: string;
+
+    clone(): Request;
+}
+interface RequestInit {
+    method?: string;
+    headers?: HeadersInit;
+    body?: BodyInit;
+    referrer?: string;
+    referrerPolicy?: ReferrerPolicy;
+    mode?: RequestMode;
+    credentials?: RequestCredentials;
+    cache?: RequestCache;
+    redirect?: RequestRedirect;
+    integrity?: string;
+    window?: any;
+}
+interface RequestConstructor {
+    new (input: RequestInfo, init?: RequestInit): Request;
+}
+declare var Request: RequestConstructor;
+
+type RequestMode = "same-origin" | "no-cors" | "cors";
+type RequestCredentials = "omit" | "same-origin" | "include";
+type RequestCache = "default" | "no-store" | "reload" | "no-cache" | "force-cache";
+type RequestRedirect = "follow" | "error" | "manual";
+type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | "origin" | "origin-when-cross-origin" | "unsafe-url";
+
+interface Response extends Body {
+    type: "basic" | "cors" | "default" | "error" | "opaque" | "opaqueredirect";
+    url: string;
+    redirected: boolean;
+    status: number;
+    ok: boolean;
+    statusText: string;
+    headers: Headers;
+    body: any /*ReadableStream | null*/;
+    trailer: Promise<Headers>;
+
+    clone(): Response;
+}
+interface ResponseInit {
+    status?: number;
+    statusText?: number;
+    headers?: HeadersInit;
+}
+interface ResponseConstructor {
+    new (body?: BodyInit, init?: ResponseInit): Response;
+
+    error(): Response;
+    redirect(url: string, status?: number): Response;
+}
+declare var Response: ResponseConstructor;

--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -14,7 +14,7 @@ declare class Headers {
 
     append(name: string, value: string): void;
     delete(name: string): void;
-    get(name: string): string | null;
+    get(name: string): string; // | null; (TS 2.0 strict null check)
     has(name: string): boolean;
     set(name: string, value: string): void;
 

--- a/whatwg-fetch/whatwg-fetch.d.ts
+++ b/whatwg-fetch/whatwg-fetch.d.ts
@@ -72,11 +72,11 @@ interface RequestConstructor {
 }
 declare var Request: RequestConstructor;
 
-type RequestMode = "same-origin" | "no-cors" | "cors";
+type RequestMode = "navigate" | "same-origin" | "no-cors" | "cors";
 type RequestCredentials = "omit" | "same-origin" | "include";
-type RequestCache = "default" | "no-store" | "reload" | "no-cache" | "force-cache";
+type RequestCache = "default" | "no-store" | "reload" | "no-cache" | "force-cache" | "only-if-cached";
 type RequestRedirect = "follow" | "error" | "manual";
-type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | "origin" | "origin-when-cross-origin" | "unsafe-url";
+type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url";
 
 interface Response extends Body {
     type: "basic" | "cors" | "default" | "error" | "opaque" | "opaqueredirect";


### PR DESCRIPTION
Spec: https://fetch.spec.whatwg.org/
1. Change `Body` to an interface as it is a mixin interface without any class object
2. Change `Request` and `Response` to interfaces as implementing `Body` interface will require duplicated members. :( https://github.com/Microsoft/TypeScript/issues/5468
3. Remove `getAll` method on `Headers` as it is removed from the spec and Microsoft Edge does not have it
4. Add WebIDL pair iterator members to `Headers`
5. Replace `context` property by `type` and `destination` on `Request` class as the spec says + MSEdge does
6. Add missing enum items
7. Add `redirected`, `body` and `trailer` property on `Response`
