### PR TITLE
keep bluebird promise type-compatible with the lib.es6.d.ts promise

### DIFF
--- a/bluebird/bluebird.d.ts
+++ b/bluebird/bluebird.d.ts
@@ -620,6 +620,8 @@ class Bluebird<R> implements Bluebird.Thenable<R>, Bluebird.Inspection<R> {
     /** Enable monitoring */
     monitoring?: boolean;
   }): void;
+
+  [Symbol.toStringTag]: "Promise";
 }
 
 namespace Bluebird {

--- a/bluebird/bluebird.d.ts
+++ b/bluebird/bluebird.d.ts
@@ -38,6 +38,8 @@ declare module 'bluebird' {
 // Project: http://bluebirdjs.com
 
 class Bluebird<R> implements Bluebird.Thenable<R>, Bluebird.Inspection<R> {
+  [Symbol.toStringTag]: "Promise";
+
   /**
    * Create a new promise. The passed in function will receive functions `resolve` and `reject` as its arguments which can be called to seal the fate of the created promise.
    * If promise cancellation is enabled, passed in function will receive one more function argument `onCancel` that allows to register an optional cancellation callback.
@@ -620,8 +622,6 @@ class Bluebird<R> implements Bluebird.Thenable<R>, Bluebird.Inspection<R> {
     /** Enable monitoring */
     monitoring?: boolean;
   }): void;
-
-  [Symbol.toStringTag]: "Promise";
 }
 
 namespace Bluebird {


### PR DESCRIPTION
This change keeps the Bluebird promise type-compatible with the ES6 promise definition found here: https://github.com/Microsoft/TypeScript/blob/master/lib/lib.es6.d.ts#L5505

I ran into this issue with WebStorm's version of those ES6 typings, but without the Symbol.toStringTag you get an error about the property being missing on Bluebird's promise interface when trying to mix the two.  Once it's added the issue is resolved.
