### PR TITLE
Added "identifier" property to PIXI.interaction.InteractionData.

### DIFF
--- a/pixi.js/pixi.js.d.ts
+++ b/pixi.js/pixi.js.d.ts
@@ -1456,6 +1456,7 @@ declare namespace PIXI {
             global: Point;
             target: DisplayObject;
             originalEvent: Event;
+            identifier: number;
 
             getLocalPosition(displayObject: DisplayObject, point?: Point, globalPos?: Point): Point;
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- [x] documentation or source code reference which provides context for the suggested changes. http://pixijs.github.io/docs/interaction_InteractionManager.js.html
- [ ] it has been reviewed by a DefinitelyTyped member.

---

The current InteractionData type lacks an "identifier" property. This property identifies individual touches when using a touchscreen device and is necessary for making use of multi-touch functionality.

It was probably overlooked because 
1. The property is not defined during instantiation and is only defined on InteractionData instances that are created to populate the InteractionManager.interactiveDataPool (i.e. it is defined on instances used to track touch events, but not on the instance used to track mouse events.) See line 1038 in the "getTouchData" method in the above linked source code.
2.  Earlier versions of Pixi.js used a different method of uniquely identifying touches.
