### PR TITLE
Fix for 'Express' namespace not being found for the Twilio typings.

### DIFF
--- a/twilio/twilio.d.ts
+++ b/twilio/twilio.d.ts
@@ -449,7 +449,7 @@ export module twilio {
   export function webhook(options?: string | webhookOptions): MiddlewareFunction;
 
   export function validateRequest(authToken: string, twilioHeader: string, url: string, params?: any): boolean;
-  export function validateExpressRequest(request: Express.Request, authToken: string, options?: WebhookExpressOptions): boolean;
+  export function validateExpressRequest(request: express.Request, authToken: string, options?: WebhookExpressOptions): boolean;
 
   /// resources/Accounts.js
   export interface OutgoingCallerIdInstance extends InstanceResource {


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
### Notes

While compiling my project, I noticed that my linter was giving me warnings about the 'Express' namespace not being found.

``` Bash
Using tsc v1.8.10
typings/modules/twilio/index.d.ts(452,51): error TS2503: Cannot find namespace 'Express'.
```

The solution was to refactor the reference from `Express` to `express`.
