### PR TITLE
Fixed interface gulp-uglify Options

### DIFF
--- a/gulp-uglify/gulp-uglify-tests.ts
+++ b/gulp-uglify/gulp-uglify-tests.ts
@@ -14,7 +14,7 @@ gulp.task('compress2', function() {
     var tsResult = gulp.src('lib/*.ts')
         .pipe(uglify({
             mangle: false,
-            preserverComments: "some",
+            preserveComments: "some",
             compress: false,
             output: {
                 max_line_len: 300

--- a/gulp-uglify/gulp-uglify.d.ts
+++ b/gulp-uglify/gulp-uglify.d.ts
@@ -32,7 +32,7 @@ declare module "gulp-uglify" {
              * some - Preserve comments that start with a bang (!) or include a Closure Compiler directive (@preserve, @license, @cc_on)
              * function - Specify your own comment preservation function. You will be passed the current node and the current comment and are expected to return either true or false.
              */
-            preserverComments?: string|((node: any, comment: UglifyJS.Tokenizer) => boolean);
+            preserveComments?: string|((node: any, comment: UglifyJS.Tokenizer) => boolean);
         }
     }
 


### PR DESCRIPTION
Fix typo `preserverComments` to `preserveComments` 
- refs: https://github.com/terinjokes/gulp-uglify/blob/master/minifier.js#L38-L47

case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
