### PR TITLE
Added `complete` boolean to progress definition

### DIFF
--- a/progress/progress.d.ts
+++ b/progress/progress.d.ts
@@ -114,6 +114,11 @@ declare module "progress"
          * Terminates a progress bar.
          */
         terminate():void;
+        
+        /**
+         * Completed status of progress (Boolean)
+         */
+        complete:boolean;
     }
     namespace ProgressBar { }
 


### PR DESCRIPTION
The `complete` variable is described as (true|false) if the status is completed.

Quickstart instructions has `complete` in the example.

``` javascript
var ProgressBar = require('progress');

var bar = new ProgressBar(':bar', { total: 10 });
var timer = setInterval(function () {
  bar.tick();
  if (bar.complete) {
    console.log('\ncomplete\n');
    clearInterval(timer);
  }
}, 100);
```
