### PR TITLE
Adding definitions for jwt-client

### DIFF
--- a/jwt-client/jwt-client-tests.ts
+++ b/jwt-client/jwt-client-tests.ts
@@ -1,0 +1,6 @@
+/// <reference path='jwt-client.d.ts' />
+
+import JWT = require('jwt-client');
+var token = 'eyJpc3MiOiJ0b3B0YWwuY29tIiwiZXhwIjoxNDI2NDIwODAwLCJodHRwOi8vdG9wdGFsLmNvbS9qd3RfY2xhaW1zL2lzX2FkbWluIjp0cnVlLCJjb21wYW55IjoiVG9wdGFsIiwiYXdlc29tZSI6dHJ1ZX0';
+var session = JWT.read();
+console.log('session is', session);

--- a/jwt-client/jwt-client-tests.ts
+++ b/jwt-client/jwt-client-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path='jwt-client.d.ts' />
 
-import JWT = require("jwt-client");
+import * as JWT from "jwt-client";
 var token = 'eyJpc3MiOiJ0b3B0YWwuY29tIiwiZXhwIjoxNDI2NDIwODAwLCJodHRwOi8vdG9wdGFsLmNvbS9qd3RfY2xhaW1zL2lzX2FkbWluIjp0cnVlLCJjb21wYW55IjoiVG9wdGFsIiwiYXdlc29tZSI6dHJ1ZX0';
 var session = JWT.read(token);
 console.log('session is', session);

--- a/jwt-client/jwt-client-tests.ts
+++ b/jwt-client/jwt-client-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path='jwt-client.d.ts' />
 
-import JWT = require('jwt-client');
+import JWT = require("jwt-client");
 var token = 'eyJpc3MiOiJ0b3B0YWwuY29tIiwiZXhwIjoxNDI2NDIwODAwLCJodHRwOi8vdG9wdGFsLmNvbS9qd3RfY2xhaW1zL2lzX2FkbWluIjp0cnVlLCJjb21wYW55IjoiVG9wdGFsIiwiYXdlc29tZSI6dHJ1ZX0';
-var session = JWT.read();
+var session = JWT.read(token);
 console.log('session is', session);

--- a/jwt-client/jwt-client.d.ts
+++ b/jwt-client/jwt-client.d.ts
@@ -3,7 +3,8 @@
 // Definitions by: Timoteo Ponce <https://github.com/timoteoponce>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module JWT{
+
+declare module "jwt-client"{
 
   interface JWTHeader{
     typ: string;
@@ -28,14 +29,14 @@ declare module JWT{
    */ 
   function write(value:JWTObject):string;
 
-  function keep(value:JWTObject, key?:any, storate?: any);
+  function keep(value:JWTObject, key?:any, storate?: any):void;
 
-  function remember();
+  function remember():void;
 
-  function forget();
+  function forget():void;
 
   function get():string;
 
-  function validate(value:JWTObject, issuer?:any, audience?: any);
+  function validate(value:JWTObject, issuer?:any, audience?: any):boolean;
 }
 

--- a/jwt-client/jwt-client.d.ts
+++ b/jwt-client/jwt-client.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for jwt-client v0.2.1
+// Project: https://github.com/pauldijou/jwt-client
+// Definitions by: Timoteo Ponce <https://github.com/timoteoponce>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module JWT{
+
+  interface JWTHeader{
+    typ: string;
+    alg: string;
+  }
+
+  interface JWTObject{
+    header: JWTHeader;
+    claim: any;
+    signature: string;
+  }
+
+  /**
+   * Read a string value (normally an HTTP header)
+   * from JSON Web Token to an Object
+   */ 
+  function read(header:string):JWTObject;
+
+  /**
+   * Given a JWT object, stringify it back to
+   * its JWT representation.
+   */ 
+  function write(value:JWTObject):string;
+
+  function keep(value:JWTObject, key?:any, storate?: any);
+
+  function remember();
+
+  function forget();
+
+  function get():string;
+
+  function validate(value:JWTObject, issuer?:any, audience?: any);
+}
+


### PR DESCRIPTION
Adds a new type definition for jwt-client from https://github.com/pauldijou/jwt-client
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
