### PR TITLE
Added type definitions for scrollreveal

### DIFF
--- a/scrollreveal/scrollreveal-tests.ts
+++ b/scrollreveal/scrollreveal-tests.ts
@@ -45,13 +45,12 @@ sr.reveal('.foo', { container: fooContainer });
 sr.reveal('.bar', { container: '#barContainer' });
 
 //3.5
-var content, xmlhttp;
 
 fooContainer = document.getElementById('fooContainer');
 
 sr = ScrollReveal();
 sr.reveal('.foo', { container: fooContainer });
-xmlhttp = new XMLHttpRequest();
+var xmlhttp = new XMLHttpRequest();
 xmlhttp.onreadystatechange = function() {
   if (xmlhttp.readyState == XMLHttpRequest.DONE) {
     if (xmlhttp.status == 200) {

--- a/scrollreveal/scrollreveal-tests.ts
+++ b/scrollreveal/scrollreveal-tests.ts
@@ -1,0 +1,75 @@
+/// <reference path="scrollreveal.d.ts" />
+
+//Tests from https://github.com/jlmakes/scrollreveal.js
+
+//1.2
+var sr = ScrollReveal();
+sr.reveal('.foo');
+sr.reveal('.bar');
+
+//1.3
+sr = ScrollReveal().reveal('.foo, .bar');
+
+//2.1
+sr = ScrollReveal({ reset: true });
+sr.reveal('.foo', { duration: 200 });
+
+//3.1
+sr = ScrollReveal({ duration: 2000 });
+sr.reveal('.box', 50);
+
+sr = ScrollReveal();
+sr.reveal('.box', { duration: 2000 }, 50);
+
+//3.2
+var fooReveal  = {
+  delay    : 200,
+  distance : '90px',
+  easing   : 'ease-in-out',
+  rotate   : { z: 10 },
+  scale    : 1.1
+};
+
+sr = ScrollReveal();
+sr.reveal('.foo', fooReveal);
+sr.reveal('#chocolate', { delay: 500, scale: 0.9 });
+
+//3.3
+sr.reveal(document.getElementById('foo'));
+sr.reveal(document.querySelectorAll('.bar'));
+
+//3.4
+sr = ScrollReveal();
+var fooContainer = document.getElementById('fooContainer');
+sr.reveal('.foo', { container: fooContainer });
+sr.reveal('.bar', { container: '#barContainer' });
+
+//3.5
+var content, xmlhttp;
+
+fooContainer = document.getElementById('fooContainer');
+
+sr = ScrollReveal();
+sr.reveal('.foo', { container: fooContainer });
+xmlhttp = new XMLHttpRequest();
+xmlhttp.onreadystatechange = function() {
+  if (xmlhttp.readyState == XMLHttpRequest.DONE) {
+    if (xmlhttp.status == 200) {
+
+      // Turn our response into HTML...
+      var content = document.createElement('div');
+      content.innerHTML = xmlhttp.responseText;
+
+      // Add each element to the DOM...
+      for (var i = 0; i < content.childNodes.length; i++) {
+        fooContainer.appendChild(content.childNodes[ i ]);
+      };
+
+      // Finally!
+      sr.sync();
+    }
+  }
+}
+
+xmlhttp.open('GET', 'ajax.html', true);
+xmlhttp.send();

--- a/scrollreveal/scrollreveal.d.ts
+++ b/scrollreveal/scrollreveal.d.ts
@@ -4,25 +4,25 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace scrollReveal {
-    interface IScrollRevealRotateObject {
+    interface ScrollRevealRotateObject {
         x?: number;
         y?: number;
         z?: number;
     }
 
-    interface IScrollRevealPositionObject {
+    interface ScrollRevealPositionObject {
         top?: number;
         right?: number;
         bottom?: number;
         left?: number;
     }
 
-    interface IScrollRevealOptions {
+    interface ScrollRevealObjectOptions {
         origin ? : string;
         distance ? : string;
         duration ? : number;
         delay ? : number;
-        rotate ? : IScrollRevealRotateObject;
+        rotate ? : ScrollRevealRotateObject;
         opacity ? : number;
         scale ? : number;
         easing ? : string;
@@ -31,7 +31,7 @@ declare namespace scrollReveal {
         reset ? : boolean;
         useDelay ? : string;
         viewFactor ? : number;
-        viewOffset ? : IScrollRevealPositionObject;
+        viewOffset ? : ScrollRevealPositionObject;
         beforeReveal ? (domEl: HTMLElement): void;
         afterReveal ? (domEl: HTMLElement): void;
         beforeReset ? (domEl: HTMLElement): void;
@@ -43,26 +43,26 @@ declare namespace scrollReveal {
     }
 
 
-    interface IScrollReveal {
-        (): IScrollReveal;
-        (options: IScrollRevealOptions): IScrollReveal;
-        reveal(selector: string): IScrollReveal;
-        reveal(selector: string, interval: number): IScrollReveal;
-        reveal(selector: string, options: IScrollRevealOptions): IScrollReveal;
-        reveal(selector: string, options: IScrollRevealOptions, interval: number): IScrollReveal;
+    interface ScrollRevealObject {
+        (): ScrollRevealObject;
+        (options: ScrollRevealObjectOptions): ScrollRevealObject;
+        reveal(selector: string): ScrollRevealObject;
+        reveal(selector: string, interval: number): ScrollRevealObject;
+        reveal(selector: string, options: ScrollRevealObjectOptions): ScrollRevealObject;
+        reveal(selector: string, options: ScrollRevealObjectOptions, interval: number): ScrollRevealObject;
         
-        reveal(selector: HTMLElement): IScrollReveal;
-        reveal(selector: HTMLElement, interval: number): IScrollReveal;
-        reveal(selector: HTMLElement, options: IScrollRevealOptions): IScrollReveal;
-        reveal(selector: HTMLElement, options: IScrollRevealOptions, interval: number): IScrollReveal;
+        reveal(selector: HTMLElement): ScrollRevealObject;
+        reveal(selector: HTMLElement, interval: number): ScrollRevealObject;
+        reveal(selector: HTMLElement, options: ScrollRevealObjectOptions): ScrollRevealObject;
+        reveal(selector: HTMLElement, options: ScrollRevealObjectOptions, interval: number): ScrollRevealObject;
 
-        reveal(selector: NodeListOf<Element>): IScrollReveal;
-        reveal(selector: NodeListOf<Element>, interval: number): IScrollReveal;
-        reveal(selector: NodeListOf<Element>, options: IScrollRevealOptions): IScrollReveal;
-        reveal(selector: NodeListOf<Element>, options: IScrollRevealOptions, interval: number): IScrollReveal;
+        reveal(selector: NodeListOf<Element>): ScrollRevealObject;
+        reveal(selector: NodeListOf<Element>, interval: number): ScrollRevealObject;
+        reveal(selector: NodeListOf<Element>, options: ScrollRevealObjectOptions): ScrollRevealObject;
+        reveal(selector: NodeListOf<Element>, options: ScrollRevealObjectOptions, interval: number): ScrollRevealObject;
 
         sync(): void;
     }
 }
 
-declare var ScrollReveal: scrollReveal.IScrollReveal;
+declare var ScrollReveal: scrollReveal.ScrollRevealObject;

--- a/scrollreveal/scrollreveal.d.ts
+++ b/scrollreveal/scrollreveal.d.ts
@@ -32,14 +32,14 @@ declare namespace scrollReveal {
         useDelay ? : string;
         viewFactor ? : number;
         viewOffset ? : IScrollRevealPositionObject;
-        beforeReveal ? (domEl: HTMLElement);
-        afterReveal ? (domEl: HTMLElement);
-        beforeReset ? (domEl: HTMLElement);
-        afterReset ? (domEl: HTMLElement);
-        beforeReveal ? (domEl: NodeListOf<Element>);
-        afterReveal ? (domEl: NodeListOf<Element>);
-        beforeReset ? (domEl: NodeListOf<Element>);
-        afterReset ? (domEl: NodeListOf<Element>);
+        beforeReveal ? (domEl: HTMLElement): void;
+        afterReveal ? (domEl: HTMLElement): void;
+        beforeReset ? (domEl: HTMLElement): void;
+        afterReset ? (domEl: HTMLElement): void;
+        beforeReveal ? (domEl: NodeListOf<Element>): void;
+        afterReveal ? (domEl: NodeListOf<Element>): void;
+        beforeReset ? (domEl: NodeListOf<Element>): void;
+        afterReset ? (domEl: NodeListOf<Element>): void;
     }
 
 
@@ -61,7 +61,7 @@ declare namespace scrollReveal {
         reveal(selector: NodeListOf<Element>, options: IScrollRevealOptions): IScrollReveal;
         reveal(selector: NodeListOf<Element>, options: IScrollRevealOptions, interval: number): IScrollReveal;
 
-        sync();
+        sync(): void;
     }
 }
 

--- a/scrollreveal/scrollreveal.d.ts
+++ b/scrollreveal/scrollreveal.d.ts
@@ -1,0 +1,68 @@
+﻿// Type definitions for ScrollReveal
+// Project: https://github.com/jlmakes/scrollreveal.js
+// Definitions by: David Pires <https://github.com/Davidblkx>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace scrollReveal {
+    interface IScrollRevealRotateObject {
+        x?: number;
+        y?: number;
+        z?: number;
+    }
+
+    interface IScrollRevealPositionObject {
+        top?: number;
+        right?: number;
+        bottom?: number;
+        left?: number;
+    }
+
+    interface IScrollRevealOptions {
+        origin ? : string;
+        distance ? : string;
+        duration ? : number;
+        delay ? : number;
+        rotate ? : IScrollRevealRotateObject;
+        opacity ? : number;
+        scale ? : number;
+        easing ? : string;
+        container ? : any;
+        mobile ? : boolean;
+        reset ? : boolean;
+        useDelay ? : string;
+        viewFactor ? : number;
+        viewOffset ? : IScrollRevealPositionObject;
+        beforeReveal ? (domEl: HTMLElement);
+        afterReveal ? (domEl: HTMLElement);
+        beforeReset ? (domEl: HTMLElement);
+        afterReset ? (domEl: HTMLElement);
+        beforeReveal ? (domEl: NodeListOf<Element>);
+        afterReveal ? (domEl: NodeListOf<Element>);
+        beforeReset ? (domEl: NodeListOf<Element>);
+        afterReset ? (domEl: NodeListOf<Element>);
+    }
+
+
+    interface IScrollReveal {
+        (): IScrollReveal;
+        (options: IScrollRevealOptions): IScrollReveal;
+        reveal(selector: string): IScrollReveal;
+        reveal(selector: string, interval: number): IScrollReveal;
+        reveal(selector: string, options: IScrollRevealOptions): IScrollReveal;
+        reveal(selector: string, options: IScrollRevealOptions, interval: number): IScrollReveal;
+        
+        reveal(selector: HTMLElement): IScrollReveal;
+        reveal(selector: HTMLElement, interval: number): IScrollReveal;
+        reveal(selector: HTMLElement, options: IScrollRevealOptions): IScrollReveal;
+        reveal(selector: HTMLElement, options: IScrollRevealOptions, interval: number): IScrollReveal;
+
+        reveal(selector: NodeListOf<Element>): IScrollReveal;
+        reveal(selector: NodeListOf<Element>, interval: number): IScrollReveal;
+        reveal(selector: NodeListOf<Element>, options: IScrollRevealOptions): IScrollReveal;
+        reveal(selector: NodeListOf<Element>, options: IScrollRevealOptions, interval: number): IScrollReveal;
+
+        sync();
+    }
+}
+
+declare var ScrollReveal: scrollReveal.IScrollReveal;


### PR DESCRIPTION
see https://github.com/jlmakes/scrollreveal.js

case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
