### PR TITLE
[types-02] Sequelize - Import Promise for target < es6

### DIFF
--- a/sequelize/index.d.ts
+++ b/sequelize/index.d.ts
@@ -11,6 +11,7 @@
 
 
 import * as _ from "lodash";
+import * as Promise from "bluebird";
 
 declare namespace sequelize {
 

--- a/sequelize/sequelize-tests.ts
+++ b/sequelize/sequelize-tests.ts
@@ -1,4 +1,5 @@
 import Sequelize = require("sequelize");
+import Promise = require('bluebird');
 
 //
 //  Fixtures


### PR DESCRIPTION
When installed with `@types/sequelize` typescript complains that it cannot find Promise, although `bluebird` is referenced, it isn't imported. This tends to fix this for es5 that is because es6 already has Promise, making it compile.
