### PR TITLE
Morris.js typings miss the module declaration

### DIFF
--- a/morris.js/morris.js.d.ts
+++ b/morris.js/morris.js.d.ts
@@ -1,6 +1,6 @@
 ﻿// Type definitions for morris.js 0.5.1
 // Project: http://morrisjs.github.io/morris.js/
-// Definitions by: Matthieu Mourisson <https://github.com/mareek> 
+// Definitions by: Matthieu Mourisson <https://github.com/mareek>, Matanel Sindilevich <https://github.com/sindilevich>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace morris {
@@ -141,6 +141,10 @@ declare namespace morris {
         /** Create a Donut chart. */
         Donut: (options: IDonutOptions) => DonutChart;
     }
+}
+
+declare module "morris" {
+    export = Morris;
 }
 
 declare var Morris: morris.MorrisStatic;


### PR DESCRIPTION
Fixes issue https://github.com/DefinitelyTyped/DefinitelyTyped/issues/10865.

The DefinitelyTyped/morris.js/morris.js.d.ts file lacks module declaration. Something like the following:

``` typescript
declare module "morris" {
    export = Morris;
}
```

Without these lines, the code like the following in Visual Studio would produce a TS2307 error: `Cannot find module 'morris'`:

``` typescript
import Morris = require("morris");
```

For example the typings for jQuery do define a module: towards the end of the DefinitelyTyped/jquery/jquery.d.ts file.
