### PR TITLE
Update/Add Inversify type definitions

### DIFF
--- a/inversify-binding-decorators/inversify-binding-decorators-tests.ts
+++ b/inversify-binding-decorators/inversify-binding-decorators-tests.ts
@@ -4,51 +4,52 @@ import { inject, Kernel } from "inversify";
 import { autoProvide, makeProvideDecorator, makeFluentProvideDecorator } from "inversify-binding-decorators";
 
 module decorator {
+
     let kernel = new Kernel();
     let provide = makeProvideDecorator(kernel);
 
-    interface INinja {
+    interface Warrior {
         fight(): string;
         sneak(): string;
     }
 
-    interface IKatana {
+    interface Weapon {
         hit(): string;
     }
 
-    interface IShuriken {
+    interface ThrowableWeapon {
         throw(): string;
     }
 
     let TYPE = {
-        IKatana: "IKatana",
-        INinja: "INinja",
-        IShuriken: "IShuriken"
+        ThrowableWeapon: "ThrowableWeapon",
+        Warrior: "Warrior",
+        Weapon: "Weapon"
     };
 
-    @provide(TYPE.IKatana)
-    class Katana implements IKatana {
+    @provide(TYPE.Weapon)
+    class Katana implements Weapon {
         public hit() {
             return "cut!";
         }
     }
 
-    @provide(TYPE.IShuriken)
-    class Shuriken implements IShuriken {
+    @provide(TYPE.ThrowableWeapon)
+    class Shuriken implements ThrowableWeapon {
         public throw() {
             return "hit!";
         }
     }
 
-    @provide(TYPE.INinja)
-    class Ninja implements INinja {
+    @provide(TYPE.Warrior)
+    class Ninja implements Warrior {
 
-        private _katana: IKatana;
-        private _shuriken: IShuriken;
+        private _katana: Weapon;
+        private _shuriken: ThrowableWeapon;
 
         public constructor(
-            @inject("IKatana") katana: IKatana,
-            @inject("IShuriken") shuriken: IShuriken
+            @inject(TYPE.Weapon) katana: Weapon,
+            @inject(TYPE.ThrowableWeapon) shuriken: ThrowableWeapon
         ) {
             this._katana = katana;
             this._shuriken = shuriken;
@@ -59,12 +60,13 @@ module decorator {
 
     }
 
-    let ninja = kernel.get<INinja>(TYPE.INinja);
+    let ninja = kernel.get<Warrior>(TYPE.Warrior);
     console.log(ninja);
 
 }
 
 module fluent_decorator {
+
     let kernel = new Kernel();
     let provide = makeFluentProvideDecorator(kernel);
 
@@ -76,27 +78,27 @@ module fluent_decorator {
         return provide(identifier).done();
     };
 
-    interface INinja {
+    interface Warrior {
         fight(): string;
         sneak(): string;
     }
 
-    interface IKatana {
+    interface Weapon {
         hit(): string;
     }
 
-    interface IShuriken {
+    interface ThrowableWeapon {
         throw(): string;
     }
 
     let TYPE = {
-        IKatana: "IKatana",
-        INinja: "INinja",
-        IShuriken: "IShuriken"
+        ThrowableWeapon: "ThrowableWeapon",
+        Warrior: "Warrior",
+        Weapon: "Weapon"
     };
 
-    @provideSingleton(TYPE.IKatana)
-    class Katana implements IKatana {
+    @provideSingleton(TYPE.Weapon)
+    class Katana implements Weapon {
         private _mark: any;
         public constructor() {
             this._mark = Math.random();
@@ -106,8 +108,8 @@ module fluent_decorator {
         }
     }
 
-    @provideTransient(TYPE.IShuriken)
-    class Shuriken implements IShuriken {
+    @provideTransient(TYPE.ThrowableWeapon)
+    class Shuriken implements ThrowableWeapon {
         private _mark: any;
         public constructor() {
             this._mark = Math.random();
@@ -117,15 +119,15 @@ module fluent_decorator {
         }
     }
 
-    @provideTransient(TYPE.INinja)
-    class Ninja implements INinja {
+    @provideTransient(TYPE.Warrior)
+    class Ninja implements Warrior {
 
-        private _katana: IKatana;
-        private _shuriken: IShuriken;
+        private _katana: Weapon;
+        private _shuriken: ThrowableWeapon;
 
         public constructor(
-            @inject("IKatana") katana: IKatana,
-            @inject("IShuriken") shuriken: IShuriken
+            @inject(TYPE.Weapon) katana: Weapon,
+            @inject(TYPE.ThrowableWeapon) shuriken: ThrowableWeapon
         ) {
             this._katana = katana;
             this._shuriken = shuriken;
@@ -136,7 +138,7 @@ module fluent_decorator {
 
     }
 
-    let ninja = kernel.get<INinja>(TYPE.INinja);
+    let ninja = kernel.get<Warrior>(TYPE.Warrior);
     console.log(ninja);
 
 }

--- a/inversify-binding-decorators/inversify-binding-decorators.d.ts
+++ b/inversify-binding-decorators/inversify-binding-decorators.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for inversify 1.0.0-beta.5
+// Type definitions for inversify-binding-decorators 1.0.0
 // Project: https://github.com/inversify/inversify-binding-decorators
 // Definitions by: inversify <https://github.com/inversify/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -7,37 +7,41 @@
 
 declare namespace inversifyBindingDecorators {
 
-    interface IProvideInSyntax<T> extends IProvideDoneSyntax<T> {
-        inSingletonScope(): IProvideWhenOnSyntax<T>;
-    }
+    namespace interfaces {
 
-    interface IProvideDoneSyntax<T> {
-        done(): (target: any) => any;
-    }
+        export interface ProvideInSyntax<T> extends ProvideDoneSyntax<T> {
+            inSingletonScope(): ProvideWhenOnSyntax<T>;
+        }
 
-    interface IProvideOnSyntax<T> extends IProvideDoneSyntax<T> {
-        onActivation(fn: (context: inversify.interfaces.Context, injectable: T) => T): IProvideWhenSyntax<T>;
-    }
+        export interface ProvideDoneSyntax<T> {
+            done(): (target: any) => any;
+        }
 
-    interface IProvideInWhenOnSyntax<T> extends IProvideInSyntax<T>, IProvideWhenSyntax<T>, IProvideOnSyntax<T> {}
+        export interface ProvideOnSyntax<T> extends ProvideDoneSyntax<T> {
+            onActivation(fn: (context: inversify.interfaces.Context, injectable: T) => T): ProvideWhenSyntax<T>;
+        }
 
-    interface IProvideWhenOnSyntax<T> extends IProvideWhenSyntax<T>, IProvideOnSyntax<T> {}
+        export interface ProvideInWhenOnSyntax<T> extends ProvideInSyntax<T>, ProvideWhenSyntax<T>, ProvideOnSyntax<T> {}
 
-    interface IProvideWhenSyntax<T> extends IProvideDoneSyntax<T> {
-        when(constraint: (request: inversify.interfaces.Request) => boolean): IProvideOnSyntax<T>;
-        whenTargetNamed(name: string): IProvideOnSyntax<T>;
-        whenTargetTagged(tag: string, value: any): IProvideOnSyntax<T>;
-        whenInjectedInto(parent: (Function|string)): IProvideOnSyntax<T>;
-        whenParentNamed(name: string): IProvideOnSyntax<T>;
-        whenParentTagged(tag: string, value: any): IProvideOnSyntax<T>;
-        whenAnyAncestorIs(ancestor: (Function|string)): IProvideOnSyntax<T>;
-        whenNoAncestorIs(ancestor: (Function|string)): IProvideOnSyntax<T>;
-        whenAnyAncestorNamed(name: string): IProvideOnSyntax<T>;
-        whenAnyAncestorTagged(tag: string, value: any): IProvideOnSyntax<T>;
-        whenNoAncestorNamed(name: string): IProvideOnSyntax<T>;
-        whenNoAncestorTagged(tag: string, value: any): IProvideOnSyntax<T>;
-        whenAnyAncestorMatches(constraint: (request: inversify.interfaces.Request) => boolean): IProvideOnSyntax<T>;
-        whenNoAncestorMatches(constraint: (request: inversify.interfaces.Request) => boolean): IProvideOnSyntax<T>;
+        export interface ProvideWhenOnSyntax<T> extends ProvideWhenSyntax<T>, ProvideOnSyntax<T> {}
+
+        export interface ProvideWhenSyntax<T> extends ProvideDoneSyntax<T> {
+            when(constraint: (request: inversify.interfaces.Request) => boolean): ProvideOnSyntax<T>;
+            whenTargetNamed(name: string): ProvideOnSyntax<T>;
+            whenTargetTagged(tag: string, value: any): ProvideOnSyntax<T>;
+            whenInjectedInto(parent: (Function|string)): ProvideOnSyntax<T>;
+            whenParentNamed(name: string): ProvideOnSyntax<T>;
+            whenParentTagged(tag: string, value: any): ProvideOnSyntax<T>;
+            whenAnyAncestorIs(ancestor: (Function|string)): ProvideOnSyntax<T>;
+            whenNoAncestorIs(ancestor: (Function|string)): ProvideOnSyntax<T>;
+            whenAnyAncestorNamed(name: string): ProvideOnSyntax<T>;
+            whenAnyAncestorTagged(tag: string, value: any): ProvideOnSyntax<T>;
+            whenNoAncestorNamed(name: string): ProvideOnSyntax<T>;
+            whenNoAncestorTagged(tag: string, value: any): ProvideOnSyntax<T>;
+            whenAnyAncestorMatches(constraint: (request: inversify.interfaces.Request) => boolean): ProvideOnSyntax<T>;
+            whenNoAncestorMatches(constraint: (request: inversify.interfaces.Request) => boolean): ProvideOnSyntax<T>;
+        }
+
     }
 
     export function autoProvide(kernel: inversify.interfaces.Kernel, ...modules: any[]): void;
@@ -46,7 +50,7 @@ declare namespace inversifyBindingDecorators {
         (serviceIdentifier: (string|Symbol|inversify.interfaces.Newable<any>)) => (target: any) => any;
 
     export function makeFluentProvideDecorator(kernel: inversify.interfaces.Kernel):
-        (serviceIdentifier: (string|Symbol|inversify.interfaces.Newable<any>)) => IProvideInWhenOnSyntax<any>;
+        (serviceIdentifier: (string|Symbol|inversify.interfaces.Newable<any>)) => interfaces.ProvideInWhenOnSyntax<any>;
 
 }
 

--- a/inversify-binding-decorators/inversify-binding-decorators.d.ts
+++ b/inversify-binding-decorators/inversify-binding-decorators.d.ts
@@ -47,10 +47,10 @@ declare namespace inversifyBindingDecorators {
     export function autoProvide(kernel: inversify.interfaces.Kernel, ...modules: any[]): void;
 
     export function makeProvideDecorator(kernel: inversify.interfaces.Kernel):
-        (serviceIdentifier: (string|Symbol|inversify.interfaces.Newable<any>)) => (target: any) => any;
+        (serviceIdentifier: inversify.interfaces.ServiceIdentifier<any>) => (target: any) => any;
 
     export function makeFluentProvideDecorator(kernel: inversify.interfaces.Kernel):
-        (serviceIdentifier: (string|Symbol|inversify.interfaces.Newable<any>)) => interfaces.ProvideInWhenOnSyntax<any>;
+        (serviceIdentifier: inversify.interfaces.ServiceIdentifier<any>) => interfaces.ProvideInWhenOnSyntax<any>;
 
 }
 

--- a/inversify-devtools/inversify-devtools-test.ts
+++ b/inversify-devtools/inversify-devtools-test.ts
@@ -1,0 +1,6 @@
+import render from "inversify-devtools";
+import { Kernel } from "inversify";
+
+let connectKernel = render("root");
+let kernel = new Kernel();
+connectKernel(kernel);

--- a/inversify-devtools/inversify-devtools-test.ts
+++ b/inversify-devtools/inversify-devtools-test.ts
@@ -1,3 +1,5 @@
+/// <reference path="./inversify-devtools.d.ts" />
+
 import render from "inversify-devtools";
 import { Kernel } from "inversify";
 

--- a/inversify-devtools/inversify-devtools.d.ts
+++ b/inversify-devtools/inversify-devtools.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for inversify-devtools 1.0.0
+// Project: https://github.com/inversify/inversify-devtools
+// Definitions by: inversify <https://github.com/inversify/>
+
+/// <reference path="../inversify/inversify.d.ts" />
+
+interface ConnectKernel extends Function {
+  (kernel: inversify.interfaces.Kernel): void;
+}
+
+declare module "inversify-devtools" {
+  let render: (container: string) => ConnectKernel;
+  export default render;
+}

--- a/inversify-devtools/inversify-devtools.d.ts
+++ b/inversify-devtools/inversify-devtools.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for inversify-devtools 1.0.0
 // Project: https://github.com/inversify/inversify-devtools
 // Definitions by: inversify <https://github.com/inversify/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../inversify/inversify.d.ts" />
 

--- a/inversify-express-utils/inversify-express-utils-tests.ts
+++ b/inversify-express-utils/inversify-express-utils-tests.ts
@@ -1,21 +1,23 @@
 /// <reference path="./inversify-express-utils.d.ts" />
 
-import { InversifyExpressServer, Controller, Get, All, Delete, Head, Put, Patch, Post, Method } from "inversify-express-utils";
+import { InversifyExpressServer, Controller, Get, All, Delete, Head, Put, Patch, Post, Method, TYPE } from "inversify-express-utils";
 import * as express from "express";
 import { Kernel } from "inversify";
 
+let kernel = new Kernel();
+
 module server {
-    let kernel = new Kernel();
+
     let server = new InversifyExpressServer(kernel);
 
     server
-        .setConfig((app) => {
+        .setConfig((app: express.Application) => {
             app.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
                 console.log("hello world");
                 next();
             });
         })
-        .setErrorConfig((app) => {
+        .setErrorConfig((app: express.Application) => {
             app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
                 console.error(err.stack);
                 res.status(500).send("Something broke!");
@@ -54,6 +56,8 @@ module decorators {
         @Method("foo", "/")
         public testMethod() { return "METHOD:FOO"; }
     }
+
+    kernel.bind<Controller>(TYPE.Controller).to(TestController);
 
     function m1(req: express.Request, res: express.Response, next: express.NextFunction) { next(); }
     function m2(req: express.Request, res: express.Response, next: express.NextFunction) { next(); }

--- a/inversify-express-utils/inversify-express-utils.d.ts
+++ b/inversify-express-utils/inversify-express-utils.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for inversify 1.0.0-alpha.4
+// Type definitions for inversify-express-utils 1.0.0
 // Project: https://github.com/inversify/inversify-express-utils
 // Definitions by: inversify <https://github.com/inversify/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -11,40 +11,50 @@ declare module "inversify-express-utils" {
     import * as express from "express";
     import * as inversify from "inversify";
 
-    interface IInversifyExpressServerConstructor {
-        new(kernel: inversify.interfaces.Kernel): IInversifyExpressServer;
+    export namespace interfaces {
+
+        export interface InversifyExpressServerConstructor {
+            new(kernel: inversify.interfaces.Kernel): InversifyExpressServer;
+        }
+
+        export interface InversifyExpressServer {
+            setConfig(fn: ConfigFunction): InversifyExpressServer;
+            setErrorConfig(fn: ConfigFunction): InversifyExpressServer;
+            build(): express.Application;
+        }
+
+        export interface ConfigFunction {
+            (app: express.Application): void;
+        }
+
+        export interface HandlerDecoratorFactory {
+            (path: string, ...middleware: express.RequestHandler[]): HandlerDecorator;
+        }
+
+        export interface HandlerDecorator {
+            (target: any, key: string, value: any): void;
+        }
+
     }
 
-    interface IInversifyExpressServer {
-        setConfig(fn: IConfigFunction): IInversifyExpressServer;
-        setErrorConfig(fn: IConfigFunction): IInversifyExpressServer;
-        build(): express.Application;
+    export interface Controller {}
+
+    interface ServiceIdentifiers {
+        Controller: Symbol;
     }
 
-    interface IConfigFunction {
-        (app: express.Application): void;
-    }
-
-    interface IHandlerDecoratorFactory {
-        (path: string, ...middleware: express.RequestHandler[]): IHandlerDecorator;
-    }
-
-    interface IHandlerDecorator {
-        (target: any, key: string, value: any): void;
-    }
-
-    export interface IController {}
-
-    export var InversifyExpressServer: IInversifyExpressServerConstructor;
+    export var InversifyExpressServer: interfaces.InversifyExpressServerConstructor;
 
     export var Controller: (path: string, ...middleware: express.RequestHandler[]) => (target: any) => void;
 
-    export var All: IHandlerDecoratorFactory;
-    export var Get: IHandlerDecoratorFactory;
-    export var Post: IHandlerDecoratorFactory;
-    export var Put: IHandlerDecoratorFactory;
-    export var Patch: IHandlerDecoratorFactory;
-    export var Head: IHandlerDecoratorFactory;
-    export var Delete: IHandlerDecoratorFactory;
-    export var Method: (method: string, path: string, ...middleware: express.RequestHandler[]) => IHandlerDecorator;
+    export var All: interfaces.HandlerDecoratorFactory;
+    export var Get: interfaces.HandlerDecoratorFactory;
+    export var Post: interfaces.HandlerDecoratorFactory;
+    export var Put: interfaces.HandlerDecoratorFactory;
+    export var Patch: interfaces.HandlerDecoratorFactory;
+    export var Head: interfaces.HandlerDecoratorFactory;
+    export var Delete: interfaces.HandlerDecoratorFactory;
+    export var Method: (method: string, path: string, ...middleware: express.RequestHandler[]) => interfaces.HandlerDecorator;
+    export var TYPE: ServiceIdentifiers;
+
 }

--- a/inversify-inject-decorators/inversify-inject-decorators.d.ts
+++ b/inversify-inject-decorators/inversify-inject-decorators.d.ts
@@ -23,10 +23,11 @@ declare namespace inversifyInjectDecorators {
 
   }
 
-  export default function getDecorators(kernel: inversify.interfaces.Kernel): InjectDecorators;
+  export function getDecorators(kernel: inversify.interfaces.Kernel): InjectDecorators;
 
 }
 
 declare module "inversify-inject-decorators" {
-  export default inversifyInjectDecorators;
+  let getDecorators: inversifyInjectDecorators.getDecorators;
+  export default getDecorators;
 }

--- a/inversify-inject-decorators/inversify-inject-decorators.d.ts
+++ b/inversify-inject-decorators/inversify-inject-decorators.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for inversify-inject-decorators 1.0.0-beta.1
+// Type definitions for inversify-inject-decorators 1.0.0
 // Project: https://github.com/inversify/inversify-inject-decorators
 // Definitions by: inversify <https://github.com/inversify/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -9,24 +9,24 @@ declare namespace inversifyInjectDecorators {
 
   interface InjectDecorators {
 
-    lazyInject: (serviceIdentifier: (string|Symbol|inversify.interfaces.Newable<any>)) =>
+    lazyInject: (serviceIdentifier: inversify.interfaces.ServiceIdentifier<any>) =>
                 (proto: any, key: string) => void;
 
-    lazyInjectNamed: (serviceIdentifier: (string|Symbol|inversify.interfaces.Newable<any>), named: string) =>
+    lazyInjectNamed: (serviceIdentifier: inversify.interfaces.ServiceIdentifier<any>, named: string) =>
                      (proto: any, key: string) => void;
 
-    lazyInjectTagged: (serviceIdentifier: (string|Symbol|inversify.interfaces.Newable<any>), key: string, value: any) =>
+    lazyInjectTagged: (serviceIdentifier: inversify.interfaces.ServiceIdentifier<any>, key: string, value: any) =>
                       (proto: any, propertyName: string) => void;
 
-    lazyMultiInject: (serviceIdentifier: (string|Symbol|inversify.interfaces.Newable<any>)) =>
+    lazyMultiInject: (serviceIdentifier: inversify.interfaces.ServiceIdentifier<any>) =>
                      (proto: any, key: string) => void;
 
   }
 
-  export function getDecorators(kernel: inversify.interfaces.Kernel): InjectDecorators;
+  export default function getDecorators(kernel: inversify.interfaces.Kernel): InjectDecorators;
 
 }
 
 declare module "inversify-inject-decorators" {
-  export default inversifyInjectDecorators.getDecorators;
+  export = inversifyInjectDecorators;
 }

--- a/inversify-inject-decorators/inversify-inject-decorators.d.ts
+++ b/inversify-inject-decorators/inversify-inject-decorators.d.ts
@@ -26,6 +26,6 @@ declare namespace inversifyInjectDecorators {
 }
 
 declare module "inversify-inject-decorators" {
-  let getDecorators: (kernel: inversify.interfaces.Kernel): => inversifyInjectDecorators.InjectDecorators;
+  let getDecorators: (kernel: inversify.interfaces.Kernel) => inversifyInjectDecorators.InjectDecorators;
   export default getDecorators;
 }

--- a/inversify-inject-decorators/inversify-inject-decorators.d.ts
+++ b/inversify-inject-decorators/inversify-inject-decorators.d.ts
@@ -7,7 +7,7 @@
 
 declare namespace inversifyInjectDecorators {
 
-  interface InjectDecorators {
+  export interface InjectDecorators {
 
     lazyInject: (serviceIdentifier: inversify.interfaces.ServiceIdentifier<any>) =>
                 (proto: any, key: string) => void;
@@ -23,11 +23,9 @@ declare namespace inversifyInjectDecorators {
 
   }
 
-  export function getDecorators(kernel: inversify.interfaces.Kernel): InjectDecorators;
-
 }
 
 declare module "inversify-inject-decorators" {
-  let getDecorators: inversifyInjectDecorators.getDecorators;
+  let getDecorators: (kernel: inversify.interfaces.Kernel): => inversifyInjectDecorators.InjectDecorators;
   export default getDecorators;
 }

--- a/inversify-inject-decorators/inversify-inject-decorators.d.ts
+++ b/inversify-inject-decorators/inversify-inject-decorators.d.ts
@@ -28,5 +28,5 @@ declare namespace inversifyInjectDecorators {
 }
 
 declare module "inversify-inject-decorators" {
-  export = inversifyInjectDecorators;
+  export default inversifyInjectDecorators;
 }

--- a/inversify-logger-middleware/inversify-logger-middleware-tests.ts
+++ b/inversify-logger-middleware/inversify-logger-middleware-tests.ts
@@ -4,23 +4,23 @@ declare var kernel: inversify.interfaces.Kernel;
 
 import { makeLoggerMiddleware, textSerializer } from "inversify-logger-middleware";
 
-interface ILoggerOutput<T> {
+interface LoggerOutput<T> {
     entry: T;
 }
 
-let makeStringRenderer = function (loggerOutput: ILoggerOutput<string>) {
-    return function (entry: inversifyLoggerMiddleware.ILogEntry) {
+let makeStringRenderer = function (loggerOutput: LoggerOutput<string>) {
+    return function (entry: inversifyLoggerMiddleware.interfaces.LogEntry) {
         loggerOutput.entry = textSerializer(entry);
     };
 };
 
-let makeObjRenderer = function (loggerOutput: ILoggerOutput<any>) {
-    return function (entry: inversifyLoggerMiddleware.ILogEntry) {
+let makeObjRenderer = function (loggerOutput: LoggerOutput<any>) {
+    return function (entry: inversifyLoggerMiddleware.interfaces.LogEntry) {
         loggerOutput.entry = entry;
     };
 };
 
-let options: inversifyLoggerMiddleware.ILoggerSettings = {
+let options: inversifyLoggerMiddleware.interfaces.LoggerSettings = {
     request: {
         bindings: {
             activated: true,
@@ -48,12 +48,12 @@ let options: inversifyLoggerMiddleware.ILoggerSettings = {
 let logger = makeLoggerMiddleware();
 kernel.applyMiddleware(logger);
 
-let loggerOutput1: ILoggerOutput<string> = { entry: null };
+let loggerOutput1: LoggerOutput<string> = { entry: null };
 let stringRenderer1 = makeStringRenderer(loggerOutput1);
 let logger1 = makeLoggerMiddleware(options, stringRenderer1);
 kernel.applyMiddleware(logger1);
 
-let loggerOutput2: ILoggerOutput<inversifyLoggerMiddleware.ILogEntry> = { entry: null };
+let loggerOutput2: LoggerOutput<inversifyLoggerMiddleware.interfaces.LogEntry> = { entry: null };
 let objRenderer2 = makeObjRenderer(loggerOutput2);
 let logger2 = makeLoggerMiddleware(options, objRenderer2);
 kernel.applyMiddleware(logger2);

--- a/inversify-logger-middleware/inversify-logger-middleware.d.ts
+++ b/inversify-logger-middleware/inversify-logger-middleware.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for inversify 1.0.0-beta.6
+// Type definitions for inversify-logger-middleware 1.0.0
 // Project: https://github.com/inversify/inversify-logger-middleware
 // Definitions by: inversify <https://github.com/inversify/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -7,50 +7,61 @@
 
 declare namespace inversifyLoggerMiddleware {
 
-    export interface ILoggerSettings {
-        request?: IRequestLoggerSettings;
-        time?: boolean;
+    export namespace interfaces {
+
+        export interface LoggerSettings {
+            request?: RequestLoggerSettings;
+            time?: boolean;
+        }
+
+        export interface RequestLoggerSettings {
+            serviceIdentifier?: boolean;
+            bindings?: BindingLoggerSettings;
+            target?: TargetLoggerSettings;
+        }
+
+        export interface BindingLoggerSettings {
+            activated?: boolean;
+            serviceIdentifier?: boolean;
+            implementationType?: boolean;
+            factory?: boolean;
+            provider?: boolean;
+            constraint?: boolean;
+            onActivation?: boolean;
+            cache?: boolean;
+            dynamicValue?: boolean;
+            scope?: boolean;
+            type?: boolean;
+        }
+
+        export interface TargetLoggerSettings {
+            serviceIdentifier?: boolean;
+            name?: boolean;
+            metadata?: boolean;
+        }
+
+        export interface LogEntry {
+            error: boolean;
+            exception: any;
+            guid: string;
+            multiInject: boolean;
+            results: any[];
+            rootRequest: inversify.interfaces.Request;
+            serviceIdentifier: any;
+            target: any;
+            time: string;
+        }
+
     }
 
-    export interface IRequestLoggerSettings {
-        serviceIdentifier?: boolean;
-        bindings?: IBindingLoggerSettings;
-        target?: ITargetLoggerSettings;
-    }
+    export function makeLoggerMiddleware(
+        settings?: interfaces.LoggerSettings,
+        renderer?: (out: interfaces.LogEntry) => void
+    ): inversify.interfaces.Middleware;
 
-    export interface IBindingLoggerSettings {
-        activated?: boolean;
-        serviceIdentifier?: boolean;
-        implementationType?: boolean;
-        factory?: boolean;
-        provider?: boolean;
-        constraint?: boolean;
-        onActivation?: boolean;
-        cache?: boolean;
-        dynamicValue?: boolean;
-        scope?: boolean;
-        type?: boolean;
-    }
-
-    export interface ITargetLoggerSettings {
-        serviceIdentifier?: boolean;
-        name?: boolean;
-        metadata?: boolean;
-    }
-
-    export interface ILogEntry {
-        error: boolean;
-        exception: any;
-        multiInject: boolean;
-        results: any[];
-        rootRequest: inversify.interfaces.Request;
-        serviceIdentifier: any;
-        target: any;
-        time: string;
-    }
-
-    export function makeLoggerMiddleware(settings?: ILoggerSettings, renderer?: (out: ILogEntry) => void): inversify.interfaces.Middleware;
-    export function textSerializer(entry: ILogEntry): string;
+    export function textSerializer(entry: interfaces.LogEntry): string;
+    export function bindingTypeFormatter(type: number): string;
+    export function scopeFormatter(scope: number): string;
 
 }
 

--- a/inversify-restify-utils/inversify-restify-utils-tests.ts
+++ b/inversify-restify-utils/inversify-restify-utils-tests.ts
@@ -1,0 +1,91 @@
+/// <reference path="./inversify-restify-utils.d.ts" />
+
+import {
+    InversifyRestifyServer, Controller, Get, Options,
+    Delete, Head, Put, Patch, Post, Method, TYPE
+} from "inversify-restify-utils";
+
+import * as restify from "restify";
+import { Kernel } from "inversify";
+
+let kernel = new Kernel();
+
+module server {
+
+    let server = new InversifyRestifyServer(kernel);
+
+    server
+        .setConfig((app: restify.Server) => {
+            app.use((req: restify.Request, res: restify.Response, next: restify.Next) => {
+                console.log("hello world");
+                next();
+            });
+        })
+        .build()
+        .listen(3000, "localhost");
+}
+
+module decorators {
+
+    @Controller("/")
+    class TestController {
+
+        @Get("/")
+        public testGet() { return "GET"; }
+
+        @Options("/")
+        public testAll() { return "OPTIONS"; }
+
+        @Delete("/")
+        public testDelete() { return "DELETE"; }
+
+        @Head("/")
+        public testHead() { return "HEAD"; }
+
+        @Put("/")
+        public testPut() { return "PUT"; }
+
+        @Patch("/")
+        public testPatch() { return "PATCH"; }
+
+        @Post("/")
+        public testPost() { return "POST"; }
+
+        @Method("opts", "/")
+        public testMethod() { return "METHOD:OPTS"; }
+    }
+
+    kernel.bind<Controller>(TYPE.Controller).to(TestController);
+
+    function m1(req: restify.Request, res: restify.Response, next: restify.Next) { next(); }
+    function m2(req: restify.Request, res: restify.Response, next: restify.Next) { next(); }
+    function m3(req: restify.Request, res: restify.Response, next: restify.Next) { next(); }
+
+    @Controller("/", m1, m2, m3)
+    class TestMiddlewareController {
+
+        @Get("/", m1, m2, m3)
+        public testGet() { return "GET"; }
+
+        @Options("/", m1, m2, m3)
+        public testAll() { return "OPTIONS"; }
+
+        @Delete("/", m1, m2, m3)
+        public testDelete() { return "DELETE"; }
+
+        @Head("/", m1, m2, m3)
+        public testHead() { return "HEAD"; }
+
+        @Put("/", m1, m2, m3)
+        public testPut() { return "PUT"; }
+
+        @Patch("/", m1, m2, m3)
+        public testPatch() { return "PATCH"; }
+
+        @Post("/", m1, m2, m3)
+        public testPost() { return "POST"; }
+
+        @Method("opts", "/", m1, m2, m3)
+        public testMethod() { return "METHOD:OPTS"; }
+    }
+}

--- a/inversify-restify-utils/inversify-restify-utils.d.ts
+++ b/inversify-restify-utils/inversify-restify-utils.d.ts
@@ -1,0 +1,57 @@
+// Type definitions for inversify-restify-utils 1.0.0
+// Project: https://github.com/inversify/inversify-restify-utils
+// Definitions by: inversify <https://github.com/inversify/>
+
+/// <reference path="../inversify/inversify.d.ts" />
+
+declare module "inversify-restify-utils" {
+
+    import * as restify from "restify";
+    import * as inversify from "inversify";
+
+    export namespace interfaces {
+
+        export interface InversifyRestifyServerConstructor {
+            new(kernel: inversify.interfaces.Kernel): InversifyRestifyServer;
+        }
+
+        export interface InversifyRestifyServer {
+            setConfig(fn: ConfigFunction): InversifyRestifyServer;
+            build(): restify.Server;
+        }
+
+        export interface ConfigFunction {
+            (app: restify.Server): void;
+        }
+
+        export interface HandlerDecoratorFactory {
+            (path: string, ...middleware: restify.RequestHandler[]): HandlerDecorator;
+        }
+
+        export interface HandlerDecorator {
+            (target: any, key: string, value: any): void;
+        }
+
+    }
+
+    export interface Controller {}
+
+    interface ServiceIdentifiers {
+        Controller: Symbol;
+    }
+
+    export var InversifyRestifyServer: interfaces.InversifyRestifyServerConstructor;
+
+    export var Controller: (path: string, ...middleware: restify.RequestHandler[]) => (target: any) => void;
+
+    export var Options: interfaces.HandlerDecoratorFactory;
+    export var Get: interfaces.HandlerDecoratorFactory;
+    export var Post: interfaces.HandlerDecoratorFactory;
+    export var Put: interfaces.HandlerDecoratorFactory;
+    export var Patch: interfaces.HandlerDecoratorFactory;
+    export var Head: interfaces.HandlerDecoratorFactory;
+    export var Delete: interfaces.HandlerDecoratorFactory;
+    export var Method: (method: string, path: string, ...middleware: restify.RequestHandler[]) => interfaces.HandlerDecorator;
+    export var TYPE: ServiceIdentifiers;
+
+}

--- a/inversify-restify-utils/inversify-restify-utils.d.ts
+++ b/inversify-restify-utils/inversify-restify-utils.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: inversify <https://github.com/inversify/>
 
 /// <reference path="../inversify/inversify.d.ts" />
+/// <reference path="restify/restify.d.ts" />
 
 declare module "inversify-restify-utils" {
 

--- a/inversify-restify-utils/inversify-restify-utils.d.ts
+++ b/inversify-restify-utils/inversify-restify-utils.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for inversify-restify-utils 1.0.0
 // Project: https://github.com/inversify/inversify-restify-utils
 // Definitions by: inversify <https://github.com/inversify/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../inversify/inversify.d.ts" />
 /// <reference path="restify/restify.d.ts" />

--- a/inversify-restify-utils/inversify-restify-utils.d.ts
+++ b/inversify-restify-utils/inversify-restify-utils.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference path="../inversify/inversify.d.ts" />
-/// <reference path="restify/restify.d.ts" />
+/// <reference path="../restify/restify.d.ts" />
 
 declare module "inversify-restify-utils" {
 

--- a/inversify/inversify-global-tests.ts
+++ b/inversify/inversify-global-tests.ts
@@ -111,7 +111,7 @@ module external_module_test {
     // binding types
     kernel.bind<Weapon>("Weapon").to(Katana);
     kernel.bind<Weapon>("Weapon").toConstantValue(new Katana());
-    kernel.bind<Weapon>("Weapon").toDynamicValue(() => { return new Katana(); });
+    kernel.bind<Weapon>("Weapon").toDynamicValue((context: inversify.interfaces.Context) => { return new Katana(); });
 
     kernel.bind<inversify.interfaces.Newable<Weapon>>("Weapon").toConstructor<Weapon>(Katana);
 

--- a/inversify/inversify-global-tests.ts
+++ b/inversify/inversify-global-tests.ts
@@ -1,6 +1,8 @@
 /// <reference path="./inversify.d.ts" />
 /// <reference path="../harmony-proxy/harmony-proxy.d.ts" />
 
+import * as Proxy from "harmony-proxy";
+
 let injectable = inversify.injectable;
 let inject = inversify.inject;
 let tagged = inversify.tagged;
@@ -13,10 +15,7 @@ let traverseAncerstors = inversify.traverseAncerstors;
 let taggedConstraint = inversify.taggedConstraint;
 let namedConstraint = inversify.namedConstraint;
 let typeConstraint = inversify.typeConstraint;
-let makePropertyMultiInjectDecorator = inversify.makePropertyMultiInjectDecorator;
-let makePropertyInjectTaggedDecorator = inversify.makePropertyInjectTaggedDecorator;
-let makePropertyInjectNamedDecorator = inversify.makePropertyInjectNamedDecorator;
-let makePropertyInjectDecorator = inversify.makePropertyInjectDecorator;
+let unmanaged = inversify.unmanaged;
 
 module external_module_test {
 
@@ -145,6 +144,7 @@ module external_module_test {
         return new Proxy(katanaToBeInjected, handler);
     });
 
+
     @injectable()
     class Samurai implements Warrior {
         public katana: Weapon;
@@ -161,8 +161,9 @@ module external_module_test {
     }
 
     kernel.bind<Samurai>("Samurai").to(Samurai);
-    kernel.bind<Weapon>("IWeapon").to(Katana).whenTargetTagged("canThrow", false);
+    kernel.bind<Weapon>("Weapon").to(Katana).whenTargetTagged("canThrow", false);
     kernel.bind<ThrowableWeapon>("ThrowableWeapon").to(Shuriken).whenTargetTagged("canThrow", true);
+    kernel.getAllTagged<Weapon>("Weapon", "canThrow", false);
 
     let throwable = tagged("canThrow", true);
     let notThrowable = tagged("canThrow", false);
@@ -200,6 +201,7 @@ module external_module_test {
     kernel.bind<Warrior>("Warrior").to(Samurai3);
     kernel.bind<Weapon>("Weapon").to(Katana).whenTargetNamed("strong");
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenTargetNamed("weak");
+    kernel.getAllNamed<Weapon>("Weapon", "weak");
 
     @injectable()
     class Samurai4 implements Samurai {
@@ -245,18 +247,18 @@ module external_module_test {
 
     // Constraint helpers
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenInjectedInto(Ninja);
-    kernel.bind<Weapon>("Weapon").to(Shuriken).whenInjectedInto("INinja");
+    kernel.bind<Weapon>("Weapon").to(Shuriken).whenInjectedInto("Ninja");
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenParentNamed("chinese");
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenParentTagged("canThrow", true);
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenTargetNamed("strong");
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenTargetTagged("canThrow", true);
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenAnyAncestorIs(Ninja);
-    kernel.bind<Weapon>("Weapon").to(Shuriken).whenAnyAncestorIs("INinja");
+    kernel.bind<Weapon>("Weapon").to(Shuriken).whenAnyAncestorIs("Ninja");
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenAnyAncestorNamed("strong");
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenAnyAncestorTagged("canThrow", true);
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenAnyAncestorMatches(whenParentNamedCanThrowConstraint);
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenNoAncestorIs(Ninja);
-    kernel.bind<Weapon>("Weapon").to(Shuriken).whenNoAncestorIs("INinja");
+    kernel.bind<Weapon>("Weapon").to(Shuriken).whenNoAncestorIs("Ninja");
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenNoAncestorNamed("strong");
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenNoAncestorTagged("canThrow", true);
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenNoAncestorMatches(whenParentNamedCanThrowConstraint);
@@ -341,103 +343,42 @@ module external_module_test {
 
 }
 
-module property_injection {
+module snapshot {
 
     let kernel = new Kernel();
 
-    let TYPES = { Weapon: "Weapon" };
-
-    interface Weapon {
-        durability: number;
-        use(): void;
-    }
-
-    @injectable()
-    class Sword implements Weapon {
-        public durability: number;
-        public constructor() {
-            this.durability = 100;
-        }
-        public use() {
-            this.durability = this.durability - 10;
-        }
-    }
-
-    @injectable()
-    class WarHammer implements Weapon {
-        public durability: number;
-        public constructor() {
-            this.durability = 100;
-        }
-        public use() {
-            this.durability = this.durability - 10;
-        }
-    }
-
-    let propertyMultiInject = makePropertyMultiInjectDecorator(kernel);
-
-    class Warrior1 {
-        @propertyMultiInject(TYPES.Weapon)
-        public weapons: Weapon[];
-    }
-
-    let propertyInject = makePropertyInjectDecorator(kernel);
-
-    interface Service {
-        count: number;
-        increment(): void;
-    }
-
-    @injectable()
-    class SomeService implements Service {
-        public count: number;
-        public constructor() {
-            this.count = 0;
-        }
-        public increment() {
-            this.count = this.count + 1;
-        }
-    }
-
-    class SomeWebComponent {
-        @propertyInject("Service")
-        private _service: Service;
-        public doSomething() {
-            let count =  this._service.count;
-            this._service.increment();
-            return count;
-        }
-    }
-
-    let propertyInjectNammed = makePropertyInjectNamedDecorator(kernel);
-
-    class Warrior2 {
-
-        @propertyInjectNammed(TYPES.Weapon, "not-throwwable")
-        @named("not-throwwable")
-        public primaryWeapon: Weapon;
-
-        @propertyInjectNammed(TYPES.Weapon, "throwwable")
-        @named("throwwable")
-        public secondaryWeapon: Weapon;
-
-    }
-
-    let propertyInjectTagged = makePropertyInjectTaggedDecorator(kernel);
-
-    class Warrior3 {
-
-        @propertyInjectTagged(TYPES.Weapon, "throwwable", false)
-        @tagged("throwwable", false)
-        public primaryWeapon: Weapon;
-
-        @propertyInjectTagged(TYPES.Weapon, "throwwable", true)
-        @tagged("throwwable", true)
-        public secondaryWeapon: Weapon;
-
-    }
-
     kernel.snapshot();
     kernel.restore();
+
+    @injectable()
+    class Test { }
+
+    kernel.bind<Test>(Test).toSelf();
+    kernel.bind<Test>(Test).toSelf().inSingletonScope();
+}
+
+module unmanaged_injection {
+
+    let kernel = new Kernel();
+
+    const BaseId = "Base";
+
+    @injectable()
+    class Base {
+        public prop: string;
+        public constructor(@unmanaged() arg: string) { // injected by user
+            this.prop = arg;
+        }
+    }
+
+    @injectable()
+    class Derived extends Base {
+        public constructor() {
+            super("unmanaged-injected-value"); // user injection
+        }
+    }
+
+    kernel.bind<Base>(BaseId).to(Derived);
+    console.log(kernel.get(BaseId) instanceof Base); // true
 
 }

--- a/inversify/inversify-tests.ts
+++ b/inversify/inversify-tests.ts
@@ -6,11 +6,7 @@ import {
     injectable, tagged, named, targetName,
     inject, multiInject, traverseAncerstors,
     taggedConstraint, namedConstraint, typeConstraint,
-    makePropertyMultiInjectDecorator,
-    makePropertyInjectTaggedDecorator,
-    makePropertyInjectNamedDecorator,
-    makePropertyInjectDecorator,
-    KernelModule, interfaces
+    KernelModule, interfaces, unmanaged
 } from "inversify";
 
 import * as Proxy from "harmony-proxy";
@@ -159,8 +155,9 @@ module external_module_test {
     }
 
     kernel.bind<Samurai>("Samurai").to(Samurai);
-    kernel.bind<Weapon>("IWeapon").to(Katana).whenTargetTagged("canThrow", false);
+    kernel.bind<Weapon>("Weapon").to(Katana).whenTargetTagged("canThrow", false);
     kernel.bind<ThrowableWeapon>("ThrowableWeapon").to(Shuriken).whenTargetTagged("canThrow", true);
+    kernel.getAllTagged<Weapon>("Weapon", "canThrow", false);
 
     let throwable = tagged("canThrow", true);
     let notThrowable = tagged("canThrow", false);
@@ -198,6 +195,7 @@ module external_module_test {
     kernel.bind<Warrior>("Warrior").to(Samurai3);
     kernel.bind<Weapon>("Weapon").to(Katana).whenTargetNamed("strong");
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenTargetNamed("weak");
+    kernel.getAllNamed<Weapon>("Weapon", "weak");
 
     @injectable()
     class Samurai4 implements Samurai {
@@ -243,18 +241,18 @@ module external_module_test {
 
     // Constraint helpers
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenInjectedInto(Ninja);
-    kernel.bind<Weapon>("Weapon").to(Shuriken).whenInjectedInto("INinja");
+    kernel.bind<Weapon>("Weapon").to(Shuriken).whenInjectedInto("Ninja");
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenParentNamed("chinese");
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenParentTagged("canThrow", true);
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenTargetNamed("strong");
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenTargetTagged("canThrow", true);
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenAnyAncestorIs(Ninja);
-    kernel.bind<Weapon>("Weapon").to(Shuriken).whenAnyAncestorIs("INinja");
+    kernel.bind<Weapon>("Weapon").to(Shuriken).whenAnyAncestorIs("Ninja");
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenAnyAncestorNamed("strong");
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenAnyAncestorTagged("canThrow", true);
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenAnyAncestorMatches(whenParentNamedCanThrowConstraint);
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenNoAncestorIs(Ninja);
-    kernel.bind<Weapon>("Weapon").to(Shuriken).whenNoAncestorIs("INinja");
+    kernel.bind<Weapon>("Weapon").to(Shuriken).whenNoAncestorIs("Ninja");
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenNoAncestorNamed("strong");
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenNoAncestorTagged("canThrow", true);
     kernel.bind<Weapon>("Weapon").to(Shuriken).whenNoAncestorMatches(whenParentNamedCanThrowConstraint);
@@ -339,103 +337,42 @@ module external_module_test {
 
 }
 
-module property_injection {
+module snapshot {
 
     let kernel = new Kernel();
 
-    let TYPES = { Weapon: "Weapon" };
-
-    interface Weapon {
-        durability: number;
-        use(): void;
-    }
-
-    @injectable()
-    class Sword implements Weapon {
-        public durability: number;
-        public constructor() {
-            this.durability = 100;
-        }
-        public use() {
-            this.durability = this.durability - 10;
-        }
-    }
-
-    @injectable()
-    class WarHammer implements Weapon {
-        public durability: number;
-        public constructor() {
-            this.durability = 100;
-        }
-        public use() {
-            this.durability = this.durability - 10;
-        }
-    }
-
-    let propertyMultiInject = makePropertyMultiInjectDecorator(kernel);
-
-    class Warrior1 {
-        @propertyMultiInject(TYPES.Weapon)
-        public weapons: Weapon[];
-    }
-
-    let propertyInject = makePropertyInjectDecorator(kernel);
-
-    interface Service {
-        count: number;
-        increment(): void;
-    }
-
-    @injectable()
-    class SomeService implements Service {
-        public count: number;
-        public constructor() {
-            this.count = 0;
-        }
-        public increment() {
-            this.count = this.count + 1;
-        }
-    }
-
-    class SomeWebComponent {
-        @propertyInject("Service")
-        private _service: Service;
-        public doSomething() {
-            let count =  this._service.count;
-            this._service.increment();
-            return count;
-        }
-    }
-
-    let propertyInjectNammed = makePropertyInjectNamedDecorator(kernel);
-
-    class Warrior2 {
-
-        @propertyInjectNammed(TYPES.Weapon, "not-throwwable")
-        @named("not-throwwable")
-        public primaryWeapon: Weapon;
-
-        @propertyInjectNammed(TYPES.Weapon, "throwwable")
-        @named("throwwable")
-        public secondaryWeapon: Weapon;
-
-    }
-
-    let propertyInjectTagged = makePropertyInjectTaggedDecorator(kernel);
-
-    class Warrior3 {
-
-        @propertyInjectTagged(TYPES.Weapon, "throwwable", false)
-        @tagged("throwwable", false)
-        public primaryWeapon: Weapon;
-
-        @propertyInjectTagged(TYPES.Weapon, "throwwable", true)
-        @tagged("throwwable", true)
-        public secondaryWeapon: Weapon;
-
-    }
-
     kernel.snapshot();
     kernel.restore();
+
+    @injectable()
+    class Test { }
+
+    kernel.bind<Test>(Test).toSelf();
+    kernel.bind<Test>(Test).toSelf().inSingletonScope();
+}
+
+module unmanaged_injection {
+
+    let kernel = new Kernel();
+
+    const BaseId = "Base";
+
+    @injectable()
+    class Base {
+        public prop: string;
+        public constructor(@unmanaged() arg: string) { // injected by user
+            this.prop = arg;
+        }
+    }
+
+    @injectable()
+    class Derived extends Base {
+        public constructor() {
+            super("unmanaged-injected-value"); // user injection
+        }
+    }
+
+    kernel.bind<Base>(BaseId).to(Derived);
+    console.log(kernel.get(BaseId) instanceof Base); // true
 
 }

--- a/inversify/inversify-tests.ts
+++ b/inversify/inversify-tests.ts
@@ -105,7 +105,7 @@ module external_module_test {
     // binding types
     kernel.bind<Weapon>("Weapon").to(Katana);
     kernel.bind<Weapon>("Weapon").toConstantValue(new Katana());
-    kernel.bind<Weapon>("Weapon").toDynamicValue(() => { return new Katana(); });
+    kernel.bind<Weapon>("Weapon").toDynamicValue((context: interfaces.Context) => { return new Katana(); });
 
     kernel.bind<interfaces.Newable<Weapon>>("Weapon").toConstructor<Weapon>(Katana);
 

--- a/inversify/inversify.d.ts
+++ b/inversify/inversify.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for inversify 2.0.0-beta.9
+// Type definitions for inversify 2.0.0-rc.12
 // Project: https://github.com/inversify/InversifyJS
 // Definitions by: inversify <https://github.com/inversify>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/inversify/inversify.d.ts
+++ b/inversify/inversify.d.ts
@@ -135,6 +135,7 @@ declare namespace inversify {
         export interface Target {
             guid: string;
             serviceIdentifier: ServiceIdentifier<any>;
+            type: number; // TargetType
             name: QueryableString;
             metadata: Array<Metadata>;
             hasTag(key: string): boolean;
@@ -152,6 +153,7 @@ declare namespace inversify {
 
         export interface Kernel {
             guid: string;
+            parent: Kernel;
             bind<T>(serviceIdentifier: ServiceIdentifier<T>): BindingToSyntax<T>;
             unbind(serviceIdentifier: ServiceIdentifier<any>): void;
             unbindAll(): void;
@@ -160,6 +162,8 @@ declare namespace inversify {
             getNamed<T>(serviceIdentifier: ServiceIdentifier<T>, named: string): T;
             getTagged<T>(serviceIdentifier: ServiceIdentifier<T>, key: string, value: any): T;
             getAll<T>(serviceIdentifier: ServiceIdentifier<T>): T[];
+            getAllNamed<T>(serviceIdentifier: ServiceIdentifier<T>, named: string): T[];
+            getAllTagged<T>(serviceIdentifier: ServiceIdentifier<T>, key: string, value: any): T[];
             load(...modules: KernelModule[]): void;
             unload(...modules: KernelModule[]): void;
             applyMiddleware(...middleware: Middleware[]): void;
@@ -197,10 +201,12 @@ declare namespace inversify {
         export interface KeyValuePair<T> {
             serviceIdentifier: ServiceIdentifier<any>;
             value: Array<T>;
+            guid: string;
         }
 
         export interface BindingInSyntax<T> {
             inSingletonScope(): BindingWhenOnSyntax<T>;
+            inTransientScope(): BindingWhenOnSyntax<T>;
         }
 
         export interface BindingInWhenOnSyntax<T> extends BindingInSyntax<T>, BindingWhenOnSyntax<T> {}
@@ -211,6 +217,7 @@ declare namespace inversify {
 
         export interface BindingToSyntax<T> {
             to(constructor: { new(...args: any[]): T; }): BindingInWhenOnSyntax<T>;
+            toSelf(): BindingInWhenOnSyntax<T>;
             toConstantValue(value: T): BindingWhenOnSyntax<T>;
             toDynamicValue(func: () => T): BindingWhenOnSyntax<T>;
             toConstructor<T2>(constructor: Newable<T2>): BindingWhenOnSyntax<T>;
@@ -248,30 +255,19 @@ declare namespace inversify {
     export function tagged(metadataKey: string, metadataValue: any): (target: any, targetKey: string, index?: number) => any;
     export function named(name: string): (target: any, targetKey: string, index?: number) => any;
     export function targetName(name: string): (target: any, targetKey: string, index: number) => any;
+    export function unmanaged(): (target: any, targetKey: string, index: number) => any;
     export function inject(serviceIdentifier: interfaces.ServiceIdentifier<any>): (target: any, targetKey: string, index?: number) => any;
+    export function guid(): string;
 
     export function multiInject(
         serviceIdentifier: interfaces.ServiceIdentifier<any>
     ): (target: any, targetKey: string, index?: number) => any;
-
-    export function makePropertyInjectDecorator(kernel: interfaces.Kernel):
-        (serviceIdentifier: (string|Symbol|interfaces.Newable<any>)) => (proto: any, key: string) => void;
-
-    export function makePropertyInjectNamedDecorator(kernel: interfaces.Kernel):
-        (serviceIdentifier: (string|Symbol|interfaces.Newable<any>), named: string) => (proto: any, key: string) => void;
-
-    export function makePropertyInjectTaggedDecorator(kernel: interfaces.Kernel):
-        (serviceIdentifier: (string|Symbol|interfaces.Newable<any>), key: string, value: any) => (proto: any, propertyName: string) => void;
-
-    export function makePropertyMultiInjectDecorator(kernel: interfaces.Kernel):
-        (serviceIdentifier: (string|Symbol|interfaces.Newable<any>)) => (proto: any, key: string) => void;
 
     // constraint helpers
     export var traverseAncerstors: (request: interfaces.Request, constraint: (request: interfaces.Request) => boolean) => boolean;
     export var taggedConstraint: (tag: string) => (value: any) => (request: interfaces.Request) => boolean;
     export var namedConstraint: (value: any) => (request: interfaces.Request) => boolean;
     export var typeConstraint: (type: (Function|string)) => (request: interfaces.Request) => boolean;
-
 }
 
 declare module "inversify" {

--- a/inversify/inversify.d.ts
+++ b/inversify/inversify.d.ts
@@ -45,7 +45,7 @@ declare namespace inversify {
             constraint: (request: Request) => boolean;
             onActivation: (context: Context, injectable: T) => T;
             cache: T;
-            dynamicValue: () => T;
+            dynamicValue: (context: Context) => T;
             scope: number; // BindingScope
             type: number; // BindingType
         }
@@ -219,7 +219,7 @@ declare namespace inversify {
             to(constructor: { new(...args: any[]): T; }): BindingInWhenOnSyntax<T>;
             toSelf(): BindingInWhenOnSyntax<T>;
             toConstantValue(value: T): BindingWhenOnSyntax<T>;
-            toDynamicValue(func: () => T): BindingWhenOnSyntax<T>;
+            toDynamicValue(func: (context: Context) => T): BindingWhenOnSyntax<T>;
             toConstructor<T2>(constructor: Newable<T2>): BindingWhenOnSyntax<T>;
             toFactory<T2>(factory: FactoryCreator<T2>): BindingWhenOnSyntax<T>;
             toFunction(func: T): BindingWhenOnSyntax<T>;


### PR DESCRIPTION
I manage type definitions for all the inversify repos via [inversify/inversify-dts](https://github.com/inversify/inversify-dts) I try to keep DefinitelyTyped and inversify-dts in sync.

This PR updates all the type definitions to match latest releases of multiple modules:
- inversify-binding-decorators
- inversify-devtools (NEW)
- inversify-express-utils
- inversify-inject-decorators
- inversify-logger-middleware
- inversify-restify-utils (NEW)
- inversify
