### PR TITLE
Added typing definitions for jsoneditor project

### DIFF
--- a/jsoneditor/jsoneditor-tests.ts
+++ b/jsoneditor/jsoneditor-tests.ts
@@ -1,0 +1,50 @@
+/// <reference path="jsoneditor.d.ts" />
+
+import JSONEditor, {JSONEditorMode, JSONEditorNode, JSONEditorOptions} from 'jsoneditor';
+
+let options: JSONEditorOptions;
+options = {
+    ace: ace,
+    //ajv: Ajv({allErrors: true, verbose: true})
+    onChange() {},
+    onEditable(node: JSONEditorNode) {
+        return true;
+    },
+    onError(error: Error) {},
+    onModeChange(newMode: JSONEditorMode, oldMode: JSONEditorMode) {},
+    escapeUnicode: false,
+    sortObjectKeys: true,
+    history: true,
+    mode: 'tree',
+    modes: ['tree', 'view', 'form', 'code', 'text'],
+    name: 'foo',
+    schema: {},
+    search: false,
+    indentation: 2,
+    theme: 'default'
+};
+options = {
+    onEditable(node: JSONEditorNode) {
+        return {field: true, value: false};
+    }
+};
+
+let jsonEditor: JSONEditor;
+jsonEditor = new JSONEditor(document.body);
+jsonEditor = new JSONEditor(document.body, {});
+jsonEditor = new JSONEditor(document.body, options, {foo: 'bar'});
+
+jsonEditor.collapseAll();
+jsonEditor.destroy();
+jsonEditor.expandAll();
+jsonEditor.focus();
+jsonEditor.set({foo: 'bar'});
+jsonEditor.setMode('text');
+jsonEditor.setName('foo');
+jsonEditor.setName();
+jsonEditor.setSchema({});
+jsonEditor.setText('{foo: 1}');
+
+const json: any = jsonEditor.get();
+const name: string = jsonEditor.getName();
+const jsonString: string = jsonEditor.getText();

--- a/jsoneditor/jsoneditor.d.ts
+++ b/jsoneditor/jsoneditor.d.ts
@@ -1,0 +1,52 @@
+// Type definitions for jsoneditor v5.5.7
+// Project: https://github.com/josdejong/jsoneditor
+// Definitions by: Alejandro Sánchez <https://github.com/alejo90>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../ace/ace.d.ts" />
+
+declare module 'jsoneditor' {
+    export interface JSONEditorNode {
+        field: string;
+        value: string;
+        path: Array<string>;
+    }
+
+    export type JSONEditorMode = 'tree' | 'view' | 'form' | 'code' | 'text';
+
+    export interface JSONEditorOptions {
+        ace?: AceAjax.Ace;
+        ajv?: any; // Any for now, since ajv typings aren't A-Ok
+        onChange?: () => void;
+        onEditable?: (node: JSONEditorNode) => boolean | {field: boolean, value: boolean};
+        onError?: (error: Error) => void;
+        onModeChange?: (newMode: JSONEditorMode, oldMode: JSONEditorMode) => void;
+        escapeUnicode?: boolean;
+        sortObjectKeys?: boolean;
+        history?: boolean;
+        mode?: JSONEditorMode;
+        modes?: Array<JSONEditorMode>;
+        name?: string;
+        schema?: Object;
+        search?: boolean;
+        indentation?: number;
+        theme?: string;
+    }
+
+    export default class JSONEditor {
+        constructor(container: HTMLElement, options?: JSONEditorOptions, json?: Object);
+        collapseAll(): void;
+        destroy(): void;
+        expandAll(): void;
+        focus(): void;
+        set(json: Object): void;
+        setMode(mode: JSONEditorMode): void;
+        setName(name?: string): void;
+        setSchema(schema: Object): void;
+        setText(jsonString: string): void;
+        get(): any;
+        getMode(): JSONEditorMode;
+        getName(): string;
+        getText(): string;
+    }
+}


### PR DESCRIPTION
Project: https://github.com/josdejong/jsoneditor
Api: https://github.com/josdejong/jsoneditor/blob/master/docs/api.md

case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
