### PR TITLE
added moment type for goToDate

### DIFF
--- a/fullCalendar/fullCalendar.d.ts
+++ b/fullCalendar/fullCalendar.d.ts
@@ -318,7 +318,7 @@ interface JQuery {
     /**
      * Moves the calendar to an arbitrary date.
      */
-    fullCalendar(method: 'gotoDate', date: Date | string): void;
+    fullCalendar(method: 'gotoDate', moment.Moment | Date | string): void;
 
     /**
      * Moves the calendar forward/backward an arbitrary amount of time.

--- a/fullCalendar/fullCalendar.d.ts
+++ b/fullCalendar/fullCalendar.d.ts
@@ -318,7 +318,7 @@ interface JQuery {
     /**
      * Moves the calendar to an arbitrary date.
      */
-    fullCalendar(method: 'gotoDate', moment.Moment | Date | string): void;
+    fullCalendar(method: 'gotoDate', date: moment.Moment | Date | string): void;
 
     /**
      * Moves the calendar forward/backward an arbitrary amount of time.


### PR DESCRIPTION
Improvement to existing type definition:
https://fullcalendar.io/docs/current_date/gotoDate/
