### PR TITLE
Improvement to existing type definition (mongoose): Fixed discriminator signature to match documentation

### DIFF
--- a/mongoose/index.d.ts
+++ b/mongoose/index.d.ts
@@ -2225,7 +2225,7 @@ declare module "mongoose" {
        * @param name discriminator model name
        * @param schema discriminator model schema
        */
-      discriminator(name: string, schema: Schema): Model<T>;
+      discriminator<U extends T>(name: string, schema: Schema): ModelConstructor<U>;
 
       /** Creates a Query for a distinct operation. Passing a callback immediately executes the query. */
       distinct(field: string, callback?: (err: any, res: any[]) => void): Query<any[]>;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- [x] documentation or source code reference which provides context for the suggested changes:
  [Mongoose documentation example](http://mongoosejs.com/docs/discriminators.html) shows that desciminator models should act exactly as model.
  which means, ModelConstructor should be returned.
- [x] it has been reviewed by a DefinitelyTyped member.
