### PR TITLE
add getCurrentLocation

### DIFF
--- a/history/index.d.ts
+++ b/history/index.d.ts
@@ -25,6 +25,7 @@ export interface History {
     createPath(path: LocationDescriptor): Path;
     createHref(path: LocationDescriptor): Href;
     createLocation(path?: LocationDescriptor, action?: Action, key?: LocationKey): Location;
+    getCurrentLocation(): Location;
 
     /** @deprecated use a location descriptor instead */
     createLocation(path?: Path, state?: LocationState, action?: Action, key?: LocationKey): Location;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Added `getCurrentLocation` available since history@3. See https://github.com/mjackson/history/blob/master/CHANGES.md#300-0.
