### PR TITLE
google.maps: Allow LatLngLiteral for MarkerOptions.position

### DIFF
--- a/googlemaps/google.maps.d.ts
+++ b/googlemaps/google.maps.d.ts
@@ -427,7 +427,7 @@ declare namespace google.maps {
         /**
          * Marker position. Required.
          */
-        position: LatLng;
+        position: LatLng|LatLngLiteral;
         /** Image map region definition used for drag/click. */
         shape?: MarkerShape;
         /** Rollover text. */


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

LatLngLiteral is an acceptable type for MarkerOptions.position

See https://developers.google.com/maps/documentation/javascript/3.exp/reference#MarkerOptions and https://developers.google.com/maps/documentation/javascript/3.exp/reference#LatLng
