### PR TITLE
Added typing definitions for mitm <https://www.npmjs.com/package/mitm>

### DIFF
--- a/mitm/mitm-tests.ts
+++ b/mitm/mitm-tests.ts
@@ -1,0 +1,18 @@
+///<reference path="mitm.d.ts"/>
+
+import Mitm, {BypassableSocket, SocketOptions} from 'mitm';
+import {Socket} from 'net';
+import {IncomingMessage, ServerResponse} from 'http';
+
+const mitm = Mitm();
+mitm.disable();
+
+mitm.on('connect', (socket: BypassableSocket, opts: SocketOptions): void => {
+	socket.bypass();
+});
+
+mitm.on('connection', (socket: Socket, opts: SocketOptions): void => {
+});
+
+mitm.on('request', (request: IncomingMessage, response: ServerResponse): void => {
+});

--- a/mitm/mitm-tests.ts
+++ b/mitm/mitm-tests.ts
@@ -1,18 +1,16 @@
 ///<reference path="mitm.d.ts"/>
 
-import Mitm, {BypassableSocket, SocketOptions} from 'mitm';
-import {Socket} from 'net';
-import {IncomingMessage, ServerResponse} from 'http';
+import Mitm = require('mitm');
 
 const mitm = Mitm();
 mitm.disable();
 
-mitm.on('connect', (socket: BypassableSocket, opts: SocketOptions): void => {
-	socket.bypass();
+mitm.on('connect', (bypassableSocket, opts): void => {
+	bypassableSocket.bypass();
 });
 
-mitm.on('connection', (socket: Socket, opts: SocketOptions): void => {
+mitm.on('connection', (socket, opts): void => {
 });
 
-mitm.on('request', (request: IncomingMessage, response: ServerResponse): void => {
+mitm.on('request', (request, response): void => {
 });

--- a/mitm/mitm.d.ts
+++ b/mitm/mitm.d.ts
@@ -9,7 +9,7 @@ declare module 'mitm' {
 	import * as http from 'http';
 	import * as net from 'net';
 
-	export interface SocketOptions {
+	interface SocketOptions {
 		port: number;
 		host?: string; 
 		localAddress?: string;
@@ -18,7 +18,7 @@ declare module 'mitm' {
 		allowHalfOpen?: boolean;
 	}
 
-	export interface BypassableSocket extends net.Socket {
+	interface BypassableSocket extends net.Socket {
 		bypass(): void
 	}
 
@@ -32,7 +32,7 @@ declare module 'mitm' {
 
 	type Callback = SocketConnectCallback | SocketConnectionCallback | HttpCallback;
 
-	export interface Mitm {
+	interface Mitm {
 		disable(): void;
 		on(event: Event, callback: Callback): void;
 		on(event: 'connect', callback: SocketConnectCallback): void;
@@ -40,5 +40,6 @@ declare module 'mitm' {
 		on(event: 'request', callback: HttpCallback): void;
 	}
 
-	export default function (): Mitm;
+	function _(): Mitm;
+	export = _;
 }

--- a/mitm/mitm.d.ts
+++ b/mitm/mitm.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for mitm v1.3.0
+// Project: https://github.com/moll/node-mitm
+// Definitions by: Alejandro Sánchez <https://github.com/alejo90>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+///<reference path="../node/node.d.ts"/>
+
+declare module 'mitm' {
+	import * as http from 'http';
+	import * as net from 'net';
+
+	export interface SocketOptions {
+		port: number;
+		host?: string; 
+		localAddress?: string;
+		localPort?: string; 
+		family?: number; 
+		allowHalfOpen?: boolean;
+	}
+
+	export interface BypassableSocket extends net.Socket {
+		bypass(): void
+	}
+
+	type SocketConnectCallback = (socket: BypassableSocket, opts: SocketOptions) => void;
+
+	type SocketConnectionCallback = (socket: net.Socket, opts: SocketOptions) => void;
+	
+	type HttpCallback = (request: http.IncomingMessage, response: http.ServerResponse) => void;
+
+	type Event = 'connect' | 'connection' | 'request';
+
+	type Callback = SocketConnectCallback | SocketConnectionCallback | HttpCallback;
+
+	export interface Mitm {
+		disable(): void;
+		on(event: Event, callback: Callback): void;
+		on(event: 'connect', callback: SocketConnectCallback): void;
+		on(event: 'connection', callback: SocketConnectionCallback): void;
+		on(event: 'request', callback: HttpCallback): void;
+	}
+
+	export default function (): Mitm;
+}


### PR DESCRIPTION
Project: https://github.com/moll/node-mitm
Api: https://github.com/moll/node-mitm/blob/master/README.md

case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
