### PR TITLE
Add sourceType to esprima Options (#10890)

### DIFF
--- a/esprima/esprima-tests.ts
+++ b/esprima/esprima-tests.ts
@@ -12,6 +12,7 @@ var string: string;
 string = esprima.version;
 program = esprima.parse('code');
 program = esprima.parse('code', {range: true});
+program = esprima.parse('import * as code from "code"', {sourceType: 'module'})
 token = esprima.tokenize('code')[0];
 token = esprima.tokenize('code', {range: true})[0];
 

--- a/esprima/esprima.d.ts
+++ b/esprima/esprima.d.ts
@@ -30,6 +30,7 @@ declare namespace esprima {
         attachComment?: boolean;
         tolerant?: boolean;
         source?: boolean;
+        sourceType?: 'script' | 'module';
     }
 
     const Syntax: {


### PR DESCRIPTION
See the following for the addition of sourceType to esprima:  https://github.com/jquery/esprima/pull/290

And some documentation of its use here: http://esprima.org/doc/index.html  (bottom of "Parsing Interface" section)
