### PR TITLE
Isomorphic fetch update

### DIFF
--- a/isomorphic-fetch/isomorphic-fetch-tests.ts
+++ b/isomorphic-fetch/isomorphic-fetch-tests.ts
@@ -1,4 +1,5 @@
 /// <reference path="isomorphic-fetch.d.ts"/>
+/// <reference path="../bluebird/bluebird-2.0.d.ts" />
 
 import fetchImportedViaCommonJS = require('isomorphic-fetch');
 import * as fetchImportedViaES6Module from 'isomorphic-fetch';

--- a/isomorphic-fetch/isomorphic-fetch.d.ts
+++ b/isomorphic-fetch/isomorphic-fetch.d.ts
@@ -129,9 +129,6 @@ declare class Request extends Body implements IRequest {
 }
 
 interface IResponse extends IBody {
-    redirect(url: string, status?: number): IResponse;
-    error(): IResponse;
-
     type: ResponseType;
 
     url: string;
@@ -159,8 +156,8 @@ interface ResponseInit {
 declare class Response extends Body implements IResponse {
     constructor(body?: ResponseBodyInit, init?: ResponseInit);
 
-    redirect(url: string, status?: number): IResponse;
-    error(): IResponse;
+    static redirect(url: string, status?: number): IResponse;
+    static error(): IResponse;
 
     type: ResponseType
 

--- a/isomorphic-fetch/isomorphic-fetch.d.ts
+++ b/isomorphic-fetch/isomorphic-fetch.d.ts
@@ -3,21 +3,21 @@
 // Definitions by: Todd Lucas <https://github.com/toddlucas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare enum RequestContext {
-    "audio", "beacon", "cspreport", "download", "embed", "eventsource",
-    "favicon", "fetch", "font", "form", "frame", "hyperlink", "iframe",
-    "image", "imageset", "import", "internal", "location", "manifest",
-    "object", "ping", "plugin", "prefetch", "script", "serviceworker",
-    "sharedworker", "subresource", "style", "track", "video", "worker",
-    "xmlhttprequest", "xslt"
-}
-declare enum RequestMode { "same-origin", "no-cors", "cors" }
-declare enum RequestCredentials { "omit", "same-origin", "include" }
-declare enum RequestCache {
-    "default", "no-store", "reload", "no-cache", "force-cache",
-    "only-if-cached"
-}
-declare enum ResponseType { "basic", "cors", "default", "error", "opaque" }
+type RequestContext =
+    "audio" | "beacon" | "cspreport" | "download" | "embed" | "eventsource" |
+    "favicon" | "fetch" | "font" | "form" | "frame" | "hyperlink" | "iframe" |
+    "image" | "imageset" | "import" | "internal" | "location" | "manifest" |
+    "object" | "ping" | "plugin" | "prefetch" | "script" | "serviceworker" |
+    "sharedworker" | "subresource" | "style" | "track" | "video" | "worker" |
+    "xmlhttprequest" | "xslt";
+
+type RequestMode = "same-origin" | "no-cors" | "cors";
+type RequestCredentials = "omit" | "same-origin" | "include";
+type RequestCache =
+    "default" | "no-store" | "reload" | "no-cache" | "force-cache" |
+    "only-if-cached";
+
+type ResponseType = "basic" | "cors" | "default" | "error" | "opaque";
 
 declare type HeaderInit = Headers | Array<string>;
 declare type BodyInit = ArrayBuffer | ArrayBufferView | Blob | FormData | string;
@@ -27,9 +27,9 @@ interface RequestInit {
     method?: string;
     headers?: HeaderInit | { [index: string]: string };
     body?: BodyInit;
-    mode?: string | RequestMode;
-    credentials?: string | RequestCredentials;
-    cache?: string | RequestCache;
+    mode?: RequestMode;
+    credentials?: RequestCredentials;
+    cache?: RequestCache;
 }
 
 interface IHeaders {
@@ -71,11 +71,11 @@ interface IRequest extends IBody {
     method: string;
     url: string;
     headers: Headers;
-    context: string | RequestContext;
+    context: RequestContext;
     referrer: string;
-    mode: string | RequestMode;
-    credentials: string | RequestCredentials;
-    cache: string | RequestCache;
+    mode: RequestMode;
+    credentials: RequestCredentials;
+    cache: RequestCache;
 }
 
 declare class Request extends Body implements IRequest {
@@ -83,11 +83,11 @@ declare class Request extends Body implements IRequest {
     method: string;
     url: string;
     headers: Headers;
-    context: string | RequestContext;
+    context: RequestContext;
     referrer: string;
-    mode: string | RequestMode;
-    credentials: string | RequestCredentials;
-    cache: string | RequestCache;
+    mode: RequestMode;
+    credentials: RequestCredentials;
+    cache: RequestCache;
 }
 
 interface IResponse extends IBody {
@@ -96,7 +96,7 @@ interface IResponse extends IBody {
     statusText: string;
     ok: boolean;
     headers: IHeaders;
-    type: string | ResponseType;
+    type: ResponseType;
     size: number;
     timeout: number;
     redirect(url: string, status: number): IResponse;

--- a/isomorphic-fetch/isomorphic-fetch.d.ts
+++ b/isomorphic-fetch/isomorphic-fetch.d.ts
@@ -3,13 +3,6 @@
 // Definitions by: Todd Lucas <https://github.com/toddlucas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-type RequestContext = // Deprecated
-    "audio" | "beacon" | "cspreport" | "download" | "embed" | "eventsource" |
-    "favicon" | "fetch" | "font" | "form" | "frame" | "hyperlink" | "iframe" |
-    "image" | "imageset" | "import" | "internal" | "location" | "manifest" |
-    "object" | "ping" | "plugin" | "prefetch" | "script" | "serviceworker" |
-    "sharedworker" | "subresource" | "style" | "track" | "video" | "worker" |
-    "xmlhttprequest" | "xslt";
 type RequestType = "" | "audio" | "font" | "image" | "script" | "style" | 
     "track" | "video";
 type RequestDestination = "" | "document" | "embed" | "font" | "image" | 
@@ -25,27 +18,9 @@ type RequestRedirect = "follow" | "error" | "manual";
 type ResponseType = "basic" | "cors" | "default" | "error" | "opaque" | 
     "opaqueredirect";
 
-type HeadersInit = Headers | Array<string> | { [index: string]: string };
-type BodyInit = Blob | ArrayBufferView | ArrayBuffer | FormData /* | URLSearchParams */ | string;
-type ResponseBodyInit = BodyInit;
-
 type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | 
     "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | 
     "strict-origin-when-cross-origin" | "unsafe-url";
-
-interface RequestInit {
-    method?: string;
-    headers?: HeadersInit;
-    body?: BodyInit;
-    referrer?: string;
-    referrerPolicy?: ReferrerPolicy;    
-    mode?: RequestMode;
-    credentials?: RequestCredentials;
-    cache?: RequestCache;
-    redirect?: RequestRedirect;
-    integrity?: string;
-    window?: any; // can only be set to null
-}
 
 interface IHeaders {
     append(name: string, value: string): void;
@@ -62,6 +37,8 @@ interface IHeaders {
     // keys(): IterableIterator<string>;
     // values(): IterableIterator<string>;    
 }
+
+type HeadersInit = Headers | Array<string> | { [index: string]: string };
 
 declare class Headers implements IHeaders {
     constructor(init?: HeadersInit);
@@ -99,8 +76,8 @@ interface IRequest extends IBody {
     method: string;
     url: string;
     headers: IHeaders;
+
     type: RequestType;
-    context: RequestContext; // Deprecated
     destination: RequestDestination;
     referrer?: string;
     referrerPolicy?: ReferrerPolicy;    
@@ -109,18 +86,36 @@ interface IRequest extends IBody {
     cache: RequestCache;
     redirect?: RequestRedirect;
     integrity?: string;
+    
     clone(): IRequest;
+}
+
+type BodyInit = Blob | ArrayBufferView | ArrayBuffer | FormData /* | URLSearchParams */ | string;
+
+interface RequestInit {
+    method?: string;
+    headers?: HeadersInit;
+    body?: BodyInit;
+    referrer?: string;
+    referrerPolicy?: ReferrerPolicy;    
+    mode?: RequestMode;
+    credentials?: RequestCredentials;
+    cache?: RequestCache;
+    redirect?: RequestRedirect;
+    integrity?: string;
+    window?: any; // can only be set to null
 }
 
 type RequestInfo = IRequest | string;
 
 declare class Request extends Body implements IRequest {
     constructor(input: RequestInfo, init?: RequestInit);
+    
     method: string;
     url: string;
     headers: IHeaders;
+
     type: RequestType
-    context: RequestContext;
     destination: RequestDestination;
     referrer: string;
     referrerPolicy: ReferrerPolicy;    
@@ -129,17 +124,16 @@ declare class Request extends Body implements IRequest {
     cache: RequestCache;
     redirect: RequestRedirect;
     integrity: string;
+
     clone(): IRequest;
 }
 
-interface ResponseInit {
-    status?: number;
-    statusText?: string;
-    headers?: HeadersInit;
-}
-
 interface IResponse extends IBody {
+    redirect(url: string, status?: number): IResponse;
+    error(): IResponse;
+
     type: ResponseType;
+
     url: string;
     redirected: boolean;
     status: number;
@@ -150,14 +144,26 @@ interface IResponse extends IBody {
     // timeout: number;
     body: any;
     trailer: Promise<IHeaders>;
-    redirect(url: string, status?: number): IResponse;
-    error(): IResponse;
+
     clone(): IResponse;
+}
+
+type ResponseBodyInit = BodyInit;
+
+interface ResponseInit {
+    status?: number;
+    statusText?: string;
+    headers?: HeadersInit;
 }
 
 declare class Response extends Body implements IResponse {
     constructor(body?: ResponseBodyInit, init?: ResponseInit);
+
+    redirect(url: string, status?: number): IResponse;
+    error(): IResponse;
+
     type: ResponseType
+
     url: string;
     redirected: boolean;
     status: number;
@@ -166,8 +172,7 @@ declare class Response extends Body implements IResponse {
     headers: IHeaders;
     body: any;
     trailer: Promise<IHeaders>;
-    redirect(url: string, status?: number): IResponse;
-    error(): IResponse;
+
     clone(): IResponse;
 }
 

--- a/isomorphic-fetch/isomorphic-fetch.d.ts
+++ b/isomorphic-fetch/isomorphic-fetch.d.ts
@@ -3,48 +3,76 @@
 // Definitions by: Todd Lucas <https://github.com/toddlucas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-type RequestContext =
+type RequestContext = // Deprecated
     "audio" | "beacon" | "cspreport" | "download" | "embed" | "eventsource" |
     "favicon" | "fetch" | "font" | "form" | "frame" | "hyperlink" | "iframe" |
     "image" | "imageset" | "import" | "internal" | "location" | "manifest" |
     "object" | "ping" | "plugin" | "prefetch" | "script" | "serviceworker" |
     "sharedworker" | "subresource" | "style" | "track" | "video" | "worker" |
     "xmlhttprequest" | "xslt";
-
-type RequestMode = "same-origin" | "no-cors" | "cors";
+type RequestType = "" | "audio" | "font" | "image" | "script" | "style" | 
+    "track" | "video";
+type RequestDestination = "" | "document" | "embed" | "font" | "image" | 
+    "manifest" | "media" | "object" | "report" | "script" | "serviceworker" | 
+    "sharedworker" | "style" | "worker" | "xslt";
+type RequestMode = "navigate" | "same-origin" | "no-cors" | "cors";
 type RequestCredentials = "omit" | "same-origin" | "include";
 type RequestCache =
     "default" | "no-store" | "reload" | "no-cache" | "force-cache" |
     "only-if-cached";
+type RequestRedirect = "follow" | "error" | "manual";
 
-type ResponseType = "basic" | "cors" | "default" | "error" | "opaque";
+type ResponseType = "basic" | "cors" | "default" | "error" | "opaque" | 
+    "opaqueredirect";
 
-declare type HeaderInit = Headers | Array<string>;
-declare type BodyInit = ArrayBuffer | ArrayBufferView | Blob | FormData | string;
-declare type RequestInfo = Request | string;
+type HeadersInit = Headers | Array<string> | { [index: string]: string };
+type BodyInit = Blob | ArrayBufferView | ArrayBuffer | FormData /* | URLSearchParams */ | string;
+type ResponseBodyInit = BodyInit;
+
+type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | 
+    "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | 
+    "strict-origin-when-cross-origin" | "unsafe-url";
 
 interface RequestInit {
     method?: string;
-    headers?: HeaderInit | { [index: string]: string };
+    headers?: HeadersInit;
     body?: BodyInit;
+    referrer?: string;
+    referrerPolicy?: ReferrerPolicy;    
     mode?: RequestMode;
     credentials?: RequestCredentials;
     cache?: RequestCache;
+    redirect?: RequestRedirect;
+    integrity?: string;
+    window?: any; // can only be set to null
 }
 
 interface IHeaders {
-    get(name: string): string;
-    getAll(name: string): Array<string>;
-    has(name: string): boolean;
-}
-
-declare class Headers implements IHeaders {
     append(name: string, value: string): void;
-    delete(name: string):void;
+    delete(name: string): void;
     get(name: string): string;
     getAll(name: string): Array<string>;
     has(name: string): boolean;
     set(name: string, value: string): void;
+
+    // TODO: iterable<string, string>;
+    forEach(callback: (value: string, index: number, headers: IHeaders) => void, thisArg?: any): void;
+    // NOTE: The following are supported by whatwg-fetch but not node-fetch.
+    // entries(): IterableIterator<[string, string]>;
+    // keys(): IterableIterator<string>;
+    // values(): IterableIterator<string>;    
+}
+
+declare class Headers implements IHeaders {
+    constructor(init?: HeadersInit);
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    get(name: string): string;
+    getAll(name: string): Array<string>;
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+
+    forEach(callback: (value: string, index: number, headers: IHeaders) => void, thisArg?: any): void;
 }
 
 interface IBody {
@@ -70,49 +98,84 @@ declare class Body implements IBody {
 interface IRequest extends IBody {
     method: string;
     url: string;
-    headers: Headers;
-    context: RequestContext;
-    referrer: string;
+    headers: IHeaders;
+    type: RequestType;
+    context: RequestContext; // Deprecated
+    destination: RequestDestination;
+    referrer?: string;
+    referrerPolicy?: ReferrerPolicy;    
     mode: RequestMode;
     credentials: RequestCredentials;
     cache: RequestCache;
+    redirect?: RequestRedirect;
+    integrity?: string;
+    clone(): IRequest;
 }
 
+type RequestInfo = IRequest | string;
+
 declare class Request extends Body implements IRequest {
-    constructor(input: string | Request, init?: RequestInit);
+    constructor(input: RequestInfo, init?: RequestInit);
     method: string;
     url: string;
-    headers: Headers;
+    headers: IHeaders;
+    type: RequestType
     context: RequestContext;
+    destination: RequestDestination;
     referrer: string;
+    referrerPolicy: ReferrerPolicy;    
     mode: RequestMode;
     credentials: RequestCredentials;
     cache: RequestCache;
+    redirect: RequestRedirect;
+    integrity: string;
+    clone(): IRequest;
+}
+
+interface ResponseInit {
+    status?: number;
+    statusText?: string;
+    headers?: HeadersInit;
 }
 
 interface IResponse extends IBody {
+    type: ResponseType;
     url: string;
+    redirected: boolean;
     status: number;
     statusText: string;
     ok: boolean;
     headers: IHeaders;
-    type: ResponseType;
-    size: number;
-    timeout: number;
-    redirect(url: string, status: number): IResponse;
+    // size: number;
+    // timeout: number;
+    body: any;
+    trailer: Promise<IHeaders>;
+    redirect(url: string, status?: number): IResponse;
     error(): IResponse;
     clone(): IResponse;
 }
 
-interface IFetchStatic {
-    Promise: any;
-    Headers: IHeaders
-    Request: IRequest;
-    Response: IResponse;
-    (url: string | IRequest, init?: RequestInit): Promise<IResponse>;
+declare class Response extends Body implements IResponse {
+    constructor(body?: ResponseBodyInit, init?: ResponseInit);
+    type: ResponseType
+    url: string;
+    redirected: boolean;
+    status: number;
+    statusText: string;
+    ok: boolean;
+    headers: IHeaders;
+    body: any;
+    trailer: Promise<IHeaders>;
+    redirect(url: string, status?: number): IResponse;
+    error(): IResponse;
+    clone(): IResponse;
 }
 
-declare var fetch: IFetchStatic;
+interface Window {
+    fetch(url: RequestInfo, init?: RequestInit): Promise<IResponse>;
+}
+
+declare var fetch: typeof window.fetch;
 
 declare module "isomorphic-fetch" {
     export = fetch;


### PR DESCRIPTION
This is an update to add new properties suggested by @zengfenfei in a related PR. It also includes changes suggested by @SaschaNaz, incorporating some improvements made in the related whatwg-fetch type definitions.

We may eventually merge these. However, there are two considerations. First, isomorphic-fetch must also represent the node-fetch interface--ideally, the common subset of whatwg-fetch and node-fetch. Second, this definitions file is structured differently, and we should maintain compatibility for anyone with established code. In particular, it distinguishes between interfaces and classes.
