### PR TITLE
added support of using custom parent function

### DIFF
--- a/angular-breadcrumb/angular-breadcrumb.d.ts
+++ b/angular-breadcrumb/angular-breadcrumb.d.ts
@@ -14,7 +14,7 @@ declare namespace angular.ui {
             /**
              * Override the parent state (only for the breadcrumb)
              **/
-            parent?: string;
+            parent?: string|Function;
             /**
             * When defined to true, the state is never included in the chain of states and never appears in the breadcrumb
             **/


### PR DESCRIPTION
For angular-breadcrumb
https://github.com/ncuillery/angular-breadcrumb/wiki/API-Reference#state-options

The parent parameter can be a string or a function at the end of this section of the docs
