### PR TITLE
Update bootbox.d.ts for vs 2015

### DIFF
--- a/bootbox/bootbox.d.ts
+++ b/bootbox/bootbox.d.ts
@@ -9,7 +9,7 @@
 interface BootboxBaseOptions {
 	title?: string | Element;
 	callback?: (result: boolean | string) => any;
-	onEscape?: () => any | boolean;
+	onEscape?: (() => any) | boolean;
 	show?: boolean;
 	backdrop?: boolean;
 	closeButton?: boolean;


### PR DESCRIPTION
vs 2015 & typescript 1.8 has error for  "onEscape?: (() => any) | boolean" when I set onEscape = boolean , then I added brackets it works.
