### PR TITLE
Fix o.js type dependency to @types/q

### DIFF
--- a/o.js/o.js.d.ts
+++ b/o.js/o.js.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Matteo Antony Mistretta <https://github.com/IceOnFire>, Brad Zacher <https://github.com/bradzacher>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../q/Q.d.ts" />
+/// <reference path="../q/index.d.ts" />
 
 declare module 'o.js' {
     interface Options {


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Currently, o.d.ts requires type dependency for Q. However, q types
reference dependency is defined as q/index.d.ts, not q/Q.d.ts
