### PR TITLE
Node.d.ts: Update definitions for NodeBuffer interface

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -502,8 +502,6 @@ interface NodeBuffer extends Uint8Array {
     writeFloatBE(value: number, offset: number, noAssert?: boolean): number;
     writeDoubleLE(value: number, offset: number, noAssert?: boolean): number;
     writeDoubleBE(value: number, offset: number, noAssert?: boolean): number;
-    get(offset: number): any;
-    set(offset: number): any;
     utf8Slice(start?: number, end?: number): Buffer;
     binarySlice(start?: number, end?: number): Buffer;
     asciiSlice(start?: number, end?: number): Buffer;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -502,6 +502,14 @@ interface NodeBuffer extends Uint8Array {
     writeFloatBE(value: number, offset: number, noAssert?: boolean): number;
     writeDoubleLE(value: number, offset: number, noAssert?: boolean): number;
     writeDoubleBE(value: number, offset: number, noAssert?: boolean): number;
+    get(offset: number): any;
+    set(offset: number): any;
+    utf8Slice(start?: number, end?: number): Buffer;
+    binarySlice(start?: number, end?: number): Buffer;
+    asciiSlice(start?: number, end?: number): Buffer;
+    utf8write(string: string, offset?: number): Buffer;
+    binaryWrite(string: string, offset?: number): Buffer;
+    asciiWrite(string: string, offset?: number): Buffer;
     fill(value: any, offset?: number, end?: number): this;
     indexOf(value: string | number | Buffer, byteOffset?: number, encoding?: string): number;
     lastIndexOf(value: string | number | Buffer, byteOffset?: number, encoding?: string): number;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- Added the following definitions to node.d.ts' NodeBuffer interface:

```
Buffer.prototype.utf8Slice;

Buffer.prototype.binarySlice;

Buffer.prototype.asciiSlice;

Buffer.prototype.utf8Write;

Buffer.prototype.binaryWrite;

Buffer.prototype.asciiWrite;
```

The first commit in this pull request was causing compile errors due to 2 other properties I tried to add. These were get and set (see issue [10906](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/10906) ). The compile error I was given was incorrectly extending Uint8Array and I assumed at first that it was because of get/set being defined in Uint8Array, but I couldn't find anything. Then I saw the full compiler message which was awfully strange as it was regarding another property of the NodeBuffer interface:

> error TS2430: Interface 'NodeBuffer' incorrectly extends interface 'Uint8Array'.
>   Types of property 'fill' are incompatible.
>     Type '(value: any, offset?: number, end?: number) => this' is not assignable to type '(value: number, start?: number, end?: number) => Uint8Array'.
>       Type 'this' is not assignable to type 'Uint8Array'.
>         Type 'NodeBuffer' is not assignable to type 'Uint8Array'.
>           Types of property 'set' are incompatible.
>             Type '(offset: number) => any' is not assignable to type '{ (index: number, value: number): void; (array: ArrayLike<number>, offset?: number): void; }'.
>               Types of parameters 'offset' and 'array' are incompatible.
>                 Type 'ArrayLike<number>' is not assignable to type 'number'.

I removed the get and set properties and left the ones that do not break anything but just improve the definitions for the interface. 
