### PR TITLE
fix(localforage): use `export =` since it's a UMD module

### DIFF
--- a/localForage/localForage.d.ts
+++ b/localForage/localForage.d.ts
@@ -96,6 +96,6 @@ interface LocalForage {
 }
 
 declare module "localforage" {
-    export var localforage: LocalForage;
-	export default localforage;
+    var localforage: LocalForage;
+    export = localforage;
 }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- [source code reference](https://github.com/localForage/localForage/blob/master/dist/localforage.nopromises.js)
- [test project](https://github.com/thgreasi/localForage-cordovaSQLiteDriver-TestIonic2App)
