### PR TITLE
Add opentok, fill-pdf, html-pdf, and phone-formatter typings with tests.

### DIFF
--- a/fill-pdf/fill-pdf-tests.ts
+++ b/fill-pdf/fill-pdf-tests.ts
@@ -1,0 +1,15 @@
+import * as fillPdf from 'fill-pdf';
+
+var formData: fillPdf.FormData = { FieldName: 'Text to put into form field' };
+var pdfTemplatePath = 'templates.pdf';
+var extendArgs: string[] = [];
+
+fillPdf.generatePdf(formData, pdfTemplatePath, extendArgs, (err: Error, output: Buffer) => {
+  if ( !err ) {
+    console.log('Success!');
+    // output is a buffer
+  }
+});
+
+var result = fillPdf.generateFdf(formData);
+// result is a buffer

--- a/fill-pdf/fill-pdf-tests.ts
+++ b/fill-pdf/fill-pdf-tests.ts
@@ -1,3 +1,5 @@
+/// <reference path='fill-pdf.d.ts' />
+
 import * as fillPdf from 'fill-pdf';
 
 var formData: fillPdf.FormData = { FieldName: 'Text to put into form field' };

--- a/fill-pdf/fill-pdf.d.ts
+++ b/fill-pdf/fill-pdf.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for fill-pdf v0.5.0
+// Project: https://github.com/dommmel/fill-pdf
+// Definitions by: Seth Westphal <https://github.com/westy92>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module 'fill-pdf' {
+
+  export interface FormData {
+    [name: string]: string;
+  }
+
+  export function generatePdf(data: FormData, templatePath: string, extendArgs: string[], callback?: (err: Error, output: Buffer) => void): void;
+  export function generateFdf(data: FormData): Buffer;
+}

--- a/html-pdf/html-pdf-tests.ts
+++ b/html-pdf/html-pdf-tests.ts
@@ -1,0 +1,10 @@
+import * as fs from 'fs';
+import * as pdf from 'html-pdf';
+
+var html = fs.readFileSync('./test/businesscard.html', 'utf8');
+var options: pdf.CreateOptions = { format: 'Letter' };
+
+pdf.create(html, options).toFile('./businesscard.pdf', (err: Error, res: pdf.FileInfo) => {
+  if (err) return console.log(err);
+  console.log(res); // { filename: '/app/businesscard.pdf' }
+});

--- a/html-pdf/html-pdf-tests.ts
+++ b/html-pdf/html-pdf-tests.ts
@@ -1,3 +1,6 @@
+/// <reference path='html-pdf.d.ts' />
+/// <reference path='../node/node.d.ts' />
+
 import * as fs from 'fs';
 import * as pdf from 'html-pdf';
 

--- a/html-pdf/html-pdf.d.ts
+++ b/html-pdf/html-pdf.d.ts
@@ -1,0 +1,80 @@
+// Type definitions for html-pdf v2.1.0
+// Project: https://github.com/marcbachmann/node-html-pdf
+// Definitions by: Seth Westphal <https://github.com/westy92>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path='../node/node.d.ts' />
+
+declare module 'html-pdf' {
+
+  import * as fs from 'fs';
+
+  export interface CreateOptions {
+
+    // Export options
+    directory?: string;
+
+    // Papersize Options: http://phantomjs.org/api/webpage/property/paper-size.html
+    height?: string;
+    width?: string;
+    format?: 'A3' | 'A4' | 'A5' | 'Legal' | 'Letter' | 'Tabloid';
+    orientation?: 'portrait' | 'landscape';
+
+    // Page options
+    border?: string | {
+      top?: string;
+      right?: string;
+      bottom?: string;
+      left?: string;
+    };
+
+    header?: {
+      height?: string;
+      contents?: string;
+    };
+    footer?: {
+      height?: string;
+      contents?: {
+        first?: string;
+        [page: number]: string;
+        default?: string;
+        last?: string;
+      };
+    };
+
+    // Rendering options
+    base?: string;
+
+    // Zooming option, can be used to scale images if `options.type` is not pdf
+    zoomFactor?: string;
+
+    // File options
+    type?: 'png' | 'jpeg' | 'pdf';
+    quality?: string;
+
+    // Script options
+    phantomPath?: string;
+    phantomArgs?: string[];
+    script?: string;
+    timeout?: number;
+
+    // HTTP Headers that are used for requests
+    httpHeaders?: {
+      [header: string]: string;
+    };
+
+  }
+
+  export interface FileInfo {
+    filename: string;
+  }
+
+  export interface CreateResult {
+    toBuffer(callback: (err: Error, buffer: Buffer) => void): void;
+    toFile(callback: (err: Error, res: FileInfo) => void): void;
+    toFile(filename?: string, callback?: (err: Error, res: FileInfo) => void): void;
+    toStream(callback: (err: Error, stream: fs.ReadStream) => void): void;
+  }
+
+  export function create(html: string, options?: CreateOptions): CreateResult;
+}

--- a/opentok/opentok-tests.ts
+++ b/opentok/opentok-tests.ts
@@ -1,0 +1,63 @@
+import * as OpenTok from 'opentok';
+
+const client = new OpenTok('API_KEY', 'API_SECRET');
+
+const sessionOptions: OpenTok.SessionOptions = {
+  mediaMode: 'routed',
+  archiveMode: 'manual',
+  location: '12.34.56.78',
+};
+
+client.createSession(sessionOptions, (err: Error, session: OpenTok.Session) => {
+  if (err) return console.log(err);
+  console.log(session.sessionId);
+});
+
+const tokenOptions: OpenTok.TokenOptions = {
+  role: 'subscriber',
+  data: 'name=Seth',
+  expireTime: 123456,
+};
+
+const token = client.generateToken('SESSION_ID', tokenOptions);
+
+const archiveOptions: OpenTok.ArchiveOptions = {
+  name: 'name',
+  hasAudio: true,
+  hasVideo: true,
+  outputMode: 'individual',
+};
+
+client.startArchive('SESSION_ID', archiveOptions, (err: Error, archive: OpenTok.Archive) => {
+  if (err) return console.log(err);
+  console.log(archive.id);
+});
+
+client.stopArchive('ARCHIVE_ID', (err: Error, archive: OpenTok.Archive) => {
+  if (err) return console.log(err);
+  console.log('Stopped archive:' + archive.id);
+});
+
+client.getArchive('ARCHIVE_ID', (err: Error, archive: OpenTok.Archive) => {
+  if (err) return console.log(err);
+  console.log(archive);
+});
+
+client.deleteArchive('ARCHIVE_ID', (err: Error) => {
+  if (err) return console.log(err);
+  console.log('success');
+});
+
+const listArchivesOptions: OpenTok.ListArchivesOptions = {
+  count: 10,
+  offset: 5,
+}
+
+client.listArchives(listArchivesOptions, (err: Error, archives: OpenTok.Archive[], totalCount: number) => {
+  if (err) return console.log(err);
+
+  console.log(totalCount + ' archives');
+  for (var i = 0; i < archives.length; i++) {
+    console.log(archives[i].id);
+  }
+});

--- a/opentok/opentok-tests.ts
+++ b/opentok/opentok-tests.ts
@@ -1,3 +1,5 @@
+/// <reference path='opentok.d.ts'' />
+
 import * as OpenTok from 'opentok';
 
 const client = new OpenTok('API_KEY', 'API_SECRET');

--- a/opentok/opentok.d.ts
+++ b/opentok/opentok.d.ts
@@ -1,0 +1,80 @@
+// Type definitions for opentok v2.3.2
+// Project: https://github.com/opentok/opentok-node
+// Definitions by: Seth Westphal <https://github.com/westy92>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'opentok' {
+
+  namespace OpenTok {
+
+    export type OutputMode = 'composed' | 'individual';
+
+    export type ArchiveStatus = 'available' | 'expired' | 'failed' | 'paused' | 'started' | 'stopped' | 'uploaded';
+
+    export interface Archive {
+      createdAt: number;
+      duration: string;
+      id: string;
+      name: string;
+      partnerId: string;
+      reason: string;
+      sessionId: string;
+      size: number;
+      status: ArchiveStatus;
+      hasAudio: boolean;
+      hasVideo: boolean;
+      outputMode: OutputMode;
+      url: string;
+    }
+
+    export interface ArchiveOptions {
+      name?: string;
+      hasAudio?: boolean;
+      hasVideo?: boolean;
+      outputMode?: OutputMode;
+    }
+
+    export type MediaMode = 'relayed' | 'routed';
+
+    export type ArchiveMode = 'manual' | 'always';
+
+    export interface SessionOptions {
+      mediaMode?: MediaMode;
+      archiveMode?: ArchiveMode;
+      location?: string;
+    }
+
+    export interface Session {
+      sessionId: string;
+    }
+
+    export type Token = string;
+
+    export type Role = 'subscriber' | 'publisher' | 'moderator';
+
+    export interface TokenOptions {
+      role?: Role;
+      data?: string;
+      expireTime?: number;
+    }
+
+    export interface ListArchivesOptions {
+      count?: number;
+      offset?: number;
+    }
+  }
+
+  class OpenTok {
+    constructor(apiKey: string, apiSecret: string);
+
+    public createSession(options: OpenTok.SessionOptions, callback: (err: Error, session: OpenTok.Session) => void): void;
+    public generateToken(sessionId: string, options: OpenTok.TokenOptions): OpenTok.Token;
+    public startArchive(sessionId: string, options: OpenTok.ArchiveOptions, callback: (err: Error, archive: OpenTok.Archive) => void): void;
+    public stopArchive(archiveId: string, callback: (err: Error, archive: OpenTok.Archive) => void): void;
+    public getArchive(archiveId: string, callback: (err: Error, archive: OpenTok.Archive) => void): void;
+    public deleteArchive(archiveId: string, callback: (err: Error) => void): void;
+    public listArchives(options: OpenTok.ListArchivesOptions, callback: (err: Error, archives: OpenTok.Archive[], totalCount: number) => void): void;
+  }
+
+  export = OpenTok;
+}

--- a/phone-formatter/phone-formatter-tests.ts
+++ b/phone-formatter/phone-formatter-tests.ts
@@ -1,0 +1,7 @@
+import * as phoneFormatter from 'phone-formatter';
+
+phoneFormatter.normalize('212.555.1212');
+phoneFormatter.normalize('+1 (212) 555-1212');
+
+phoneFormatter.format('(212) 555-1212', 'NNN.NNN.NNNN');
+phoneFormatter.format('(212) 555-1212', 'NNN.NNN.NNNN', {normalize: false});

--- a/phone-formatter/phone-formatter-tests.ts
+++ b/phone-formatter/phone-formatter-tests.ts
@@ -1,3 +1,5 @@
+/// <reference path='phone-formatter.d.ts' />
+
 import * as phoneFormatter from 'phone-formatter';
 
 phoneFormatter.normalize('212.555.1212');

--- a/phone-formatter/phone-formatter.d.ts
+++ b/phone-formatter/phone-formatter.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for phone-formatter v0.0.2
+// Project: https://github.com/stevekinney/node-phone-formatter
+// Definitions by: Seth Westphal <https://github.com/westy92>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'phone-formatter' {
+
+  export interface FormatOptions {
+    normalize: boolean;
+  }
+
+  export function normalize(digits: string): string;
+  export function format(digits: string, format: string, options?: FormatOptions): string;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
