### PR TITLE
Updated method sig for logout which returns a promise (not void)

### DIFF
--- a/azure-mobile-services-client/AzureMobileServicesClient.d.ts
+++ b/azure-mobile-services-client/AzureMobileServicesClient.d.ts
@@ -17,7 +17,7 @@ declare namespace Microsoft.WindowsAzure {
         login(provider: string, token: string): asyncPromise;
         login(provider: string, callback: (error: any, user: User) => void ): void;
         login(provider: string): asyncPromise;
-        logout(): void;
+        logout(): asyncPromise;
         getTable(tableName: string): MobileServiceTable;
         withFilter(serviceFilter: (request: any, next: (request: any, callback: (error: any, response: any) => void) => void, callback: (error: any, response: any) => void) => void): MobileServiceClient;
         /**


### PR DESCRIPTION
Changed return signature of logout method to promise as the library returns a promise, not a void.

Source documentation found at https://github.com/Azure/azure-mobile-apps-js-client/tree/master/sdk/src.
