### PR TITLE
Export types of redux-mock-store

### DIFF
--- a/redux-mock-store/redux-mock-store-tests.ts
+++ b/redux-mock-store/redux-mock-store-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./redux-mock-store.d.ts" />
 
-import configureStore from 'redux-mock-store';
+import configureStore, {IStore} from 'redux-mock-store';
 
 // Redux store API tests
 // The following test are taken from ../redux/redux-tests.ts
@@ -25,10 +25,11 @@ function loggingMiddleware() {
     };
 }
 
-const storeMock = configureStore([loggingMiddleware]);
+const storeMock = configureStore<number>([loggingMiddleware]);
 const initialState = 0
-let store = storeMock(initialState);
+let store: IStore<number>;
 
+store = storeMock(initialState);
 
 store.subscribe(() => {
     // ...

--- a/redux-mock-store/redux-mock-store.d.ts
+++ b/redux-mock-store/redux-mock-store.d.ts
@@ -10,9 +10,9 @@ declare module 'redux-mock-store' {
 
     function createMockStore<T>(middlewares?:Redux.Middleware[]):mockStore<T>
 
-    type mockStore<T> = (state?:T) => IStore<T>;
+    export type mockStore<T> = (state?:T) => IStore<T>;
 
-    type IStore<T> = {
+    export type IStore<T> = {
         dispatch(action: any):any
         getState():T
         getActions():Object[]


### PR DESCRIPTION
Within a test you sometimes want to declare the store first and then assign it the result of `mockStore(state)` in a `beforeEach()`. For that we need to export `IStore`.
