### PR TITLE
Node.d.ts: Update module "vm" to define function createScript

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1058,6 +1058,7 @@ declare module "vm" {
     export function runInDebugContext(code: string): any;
     export function runInNewContext(code: string, sandbox?: Context, options?: RunningScriptOptions): any;
     export function runInThisContext(code: string, options?: RunningScriptOptions): any;
+    export function createScript(code: string, filename?: string): Script;
 }
 
 declare module "child_process" {


### PR DESCRIPTION
case 2. Improvement to existing type definition.

I've noticed that module "vm" lacks a definition for the function createScript. Even though, this function is not present in NodeJS' current documentation it could be found in previous versions like [this](https://nodejs.org/docs/v0.10.0/api/vm.html#vm_vm_createscript_code_filename). It is still possible to use it now with the newer version. That is, if you run `node` in the console and type in `require("vm")` `createScript` will appear on the list of exported functions for the module. This pull request resolves that problem and the function is now recognized by the compiler.
