### PR TITLE
Node.d.ts: Update module "querystring" to support unescapeBuffer function

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -538,6 +538,7 @@ declare module "querystring" {
     export function parse<T extends {}>(str: string, sep?: string, eq?: string, options?: ParseOptions): T;
     export function escape(str: string): string;
     export function unescape(str: string): string;
+    export function unescapeBuffer(s: Buffer, decodeSpaces: boolean): void;
 }
 
 declare module "events" {


### PR DESCRIPTION
case 2. Improvement to existing type definition.

This pull request adds the unescapeBuffer function to the querystring module. Running node in the console and typing `require("querystring")` lists that unescapeBuffer is a member of the module and can be accessed so it might be needed to add it to node.d.ts so that the compiler does not complain. On the other hand, I couldn't find documentation about it so it might not be meant to be on the public API (I saw it closure-compiler's extern declarations) The types I've used come from [closure-compiler](https://github.com/google/closure-compiler/blob/master/contrib/nodejs/querystring.js#L64).
