### PR TITLE
node-dir: added types for callback params

### DIFF
--- a/node-dir/node-dir-tests.ts
+++ b/node-dir/node-dir-tests.ts
@@ -1,3 +1,4 @@
+/// <reference path="../node/node.d.ts" />
 /// <reference path="node-dir.d.ts" />
 
 import * as dir from "node-dir";

--- a/node-dir/node-dir.d.ts
+++ b/node-dir/node-dir.d.ts
@@ -4,6 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module "node-dir" {
+    import { ReadStream } from "fs";
+    
     export interface Options {
         // file encoding (defaults to 'utf8')
         encoding?: string;
@@ -37,31 +39,28 @@ declare module "node-dir" {
     }
 
     export interface FileCallback {
-        (error: any, content: string, next: () => void): void;
+        (error: any, content: string | Buffer, next: () => void): void;
     }
 
     export interface FileNamedCallback {
-        (error: any, content: string, filename: string, next: () => void): void;
+        (error: any, content: string | Buffer, filename: string, next: () => void): void;
     }
 
     export interface StreamCallback {
-        (error: any, stream: any, next: () => void): void;
+        (error: any, stream: ReadStream, next: () => void): void;
     }
 
     export interface FinishedCallback {
         (error: any, files: string[]): void;
     }
     export interface PathsResult {
-    	files: string[];
-    	dirs: string[];
+        files: string[];
+        dirs: string[];
     }
 
-    export function readFiles(dir: string, fileCallback: FileCallback, finishedCallback?: FinishedCallback): void;
-	export function readFiles(dir: string, fileCallback: FileNamedCallback, finishedCallback?: FinishedCallback): void;
-    export function readFiles(dir: string, options: Options, fileCallback: FileCallback, finishedCallback?: FinishedCallback): void;
-    export function readFiles(dir: string, options: Options, fileCallback: FileNamedCallback, finishedCallback?: FinishedCallback): void;
-    export function readFilesStream(dir: string, options: Options, streamCallback: StreamCallback,
-        finishedCallback?: FinishedCallback): void;
+    export function readFiles(dir: string, fileCallback: FileCallback | FileNamedCallback, finishedCallback?: FinishedCallback): void;
+    export function readFiles(dir: string, options: Options, fileCallback: FileCallback | FileNamedCallback, finishedCallback?: FinishedCallback): void;
+    export function readFilesStream(dir: string, options: Options, streamCallback: StreamCallback, finishedCallback?: FinishedCallback): void;
     export function files(dir: string, callback: (error: any, files: string[]) => void): void;
     export function subdirs(dir: string, callback: (error: any, subdirs: string[]) => void): void;
     export function paths(dir: string, callback: (error: any, paths: PathsResult) => void): void;

--- a/node-dir/node-dir.d.ts
+++ b/node-dir/node-dir.d.ts
@@ -59,8 +59,10 @@ declare module "node-dir" {
         dirs: string[];
     }
 
-    export function readFiles(dir: string, fileCallback: FileCallback | FileNamedCallback, finishedCallback?: FinishedCallback): void;
-    export function readFiles(dir: string, options: Options, fileCallback: FileCallback | FileNamedCallback, finishedCallback?: FinishedCallback): void;
+    export function readFiles(dir: string, fileCallback: FileCallback, finishedCallback?: FinishedCallback): void;
+    export function readFiles(dir: string, fileCallback: FileNamedCallback, finishedCallback?: FinishedCallback): void;
+    export function readFiles(dir: string, options: Options, fileCallback: FileCallback, finishedCallback?: FinishedCallback): void;
+    export function readFiles(dir: string, options: Options, fileCallback: FileNamedCallback, finishedCallback?: FinishedCallback): void;
     export function readFilesStream(dir: string, options: Options, streamCallback: StreamCallback, finishedCallback?: FinishedCallback): void;
     export function files(dir: string, callback: (error: any, files: string[]) => void): void;
     export function subdirs(dir: string, callback: (error: any, subdirs: string[]) => void): void;

--- a/node-dir/node-dir.d.ts
+++ b/node-dir/node-dir.d.ts
@@ -37,11 +37,11 @@ declare module "node-dir" {
     }
 
     export interface FileCallback {
-        (error: any, content: any, next: () => void): void;
+        (error: any, content: string, next: () => void): void;
     }
 
     export interface FileNamedCallback {
-        (error: any, content: any, filename: string, next: () => void): void;
+        (error: any, content: string, filename: string, next: () => void): void;
     }
 
     export interface StreamCallback {
@@ -49,7 +49,11 @@ declare module "node-dir" {
     }
 
     export interface FinishedCallback {
-        (error: any, files: any): void;
+        (error: any, files: string[]): void;
+    }
+    export interface PathsResult {
+    	files: string[];
+    	dirs: string[];
     }
 
     export function readFiles(dir: string, fileCallback: FileCallback, finishedCallback?: FinishedCallback): void;
@@ -58,8 +62,9 @@ declare module "node-dir" {
     export function readFiles(dir: string, options: Options, fileCallback: FileNamedCallback, finishedCallback?: FinishedCallback): void;
     export function readFilesStream(dir: string, options: Options, streamCallback: StreamCallback,
         finishedCallback?: FinishedCallback): void;
-    export function files(dir: string, callback: (error: any, files: any) => void): void;
-    export function subdirs(dir: string, callback: (error: any, subdirs: any) => void): void;
-    export function paths(dir: string, callback: (error: any, paths: any) => void): void;
-    export function paths(dir: string, combine: boolean, callback: (error: any, paths: any) => void): void;
+    export function files(dir: string, callback: (error: any, files: string[]) => void): void;
+    export function subdirs(dir: string, callback: (error: any, subdirs: string[]) => void): void;
+    export function paths(dir: string, callback: (error: any, paths: PathsResult) => void): void;
+    export function paths(dir: string, combine: true, callback: (error: any, paths: string[]) => void): void;
+    export function paths(dir: string, combine: false, callback: (error: any, paths: PathsResult) => void): void;
 }

--- a/node-dir/node-dir.d.ts
+++ b/node-dir/node-dir.d.ts
@@ -64,6 +64,5 @@ declare module "node-dir" {
     export function files(dir: string, callback: (error: any, files: string[]) => void): void;
     export function subdirs(dir: string, callback: (error: any, subdirs: string[]) => void): void;
     export function paths(dir: string, callback: (error: any, paths: PathsResult) => void): void;
-    export function paths(dir: string, combine: true, callback: (error: any, paths: string[]) => void): void;
-    export function paths(dir: string, combine: false, callback: (error: any, paths: PathsResult) => void): void;
+    export function paths(dir: string, combine: boolean, callback: (error: any, paths: string[] | PathsResult) => void): void;
 }

--- a/node-dir/node-dir.d.ts
+++ b/node-dir/node-dir.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/fshost/node-dir
 // Definitions by: Panu Horsmalahti <https://github.com/panuhorsmalahti/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+///<reference path="../node/node.d.ts"/>
 
 declare module "node-dir" {
     import { ReadStream } from "fs";


### PR DESCRIPTION
`node-dir` internally uses `fs.readFile()` in [`readFiles()`](https://github.com/fshost/node-dir/blob/master/lib/readfiles.js#L101) and passes `string[]` as an array of filenames to [finishedCallback](https://github.com/fshost/node-dir/blob/master/lib/readfiles.js#L60)

`files()` & `subdirs()` pass `string[]` to result callback.
`paths()` passes `string[]` if called with `combine == true` and `{ files: string[]; dirs: string[]; }` [otherwise](https://github.com/fshost/node-dir/blob/master/lib/paths.js#L116)
