### PR TITLE
Add some missing typings to js-data-http

### DIFF
--- a/js-data-http/js-data-http-tests.ts
+++ b/js-data-http/js-data-http-tests.ts
@@ -1,8 +1,14 @@
+/// <reference path="./../axios/axios.d.ts" />
 /// <reference path="js-data-http.d.ts" />
+
+import * as axios from 'axios';
 
 var adapter = new DSHttpAdapter();
 var store = new JSData.DS();
 store.registerAdapter('http', adapter, { default: true });
+
+adapter.defaults.basePath = '/api';
+adapter.http = axios;
 
 var ADocument:JSData.DSResourceDefinition<any> = store.defineResource<any>('document');
 

--- a/js-data-http/js-data-http.d.ts
+++ b/js-data-http/js-data-http.d.ts
@@ -15,6 +15,8 @@ declare namespace JSData {
         forceTrailingSlash?: boolean;
         log?: boolean | ((message?:any, ...optionalParams:any[])=> void);
         error?: boolean | ((message?:any, ...optionalParams:any[])=> void);
+        basePath?: string;
+        verbsUseBasePath?: string;
     }
 
     interface DSHttpAdapterPromiseResolveType {
@@ -27,6 +29,9 @@ declare namespace JSData {
     interface DSHttpAdapter extends IDSAdapter {
 
         new(options?:DSHttpAdapterOptions):DSHttpAdapter;
+
+        defaults: DSHttpAdapterOptions;
+        http: any;
 
         // DSHttpAdapter uses axios so options are axios config objects.
         HTTP(options?:Object):JSDataPromise<DSHttpAdapterPromiseResolveType>;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
