### PR TITLE
Use `string | RegExp` for path in koa-router

### DIFF
--- a/koa-router/koa-router.d.ts
+++ b/koa-router/koa-router.d.ts
@@ -83,10 +83,8 @@ declare module "koa-router" {
         regexp: RegExp;
         path: string;
 
-        constructor(path: string, methods: string[], middleware: Router.IMiddleware, opts?: Layer.ILayerOptions);
-        constructor(path: string, methods: string[], middleware: Array<Router.IMiddleware>, opts?: Layer.ILayerOptions);
-        constructor(path: RegExp, methods: string[], middleware: Router.IMiddleware, opts?: Layer.ILayerOptions);
-        constructor(path: RegExp, methods: string[], middleware: Array<Router.IMiddleware>, opts?: Layer.ILayerOptions);
+        constructor(path: string | RegExp, methods: string[], middleware: Router.IMiddleware, opts?: Layer.ILayerOptions);
+        constructor(path: string | RegExp, methods: string[], middleware: Array<Router.IMiddleware>, opts?: Layer.ILayerOptions);
 
         /**
          * Returns whether request `path` matches route.
@@ -96,7 +94,7 @@ declare module "koa-router" {
         /**
          * Returns map of URL parameters for given `path` and `paramNames`.
          */
-        params(path: string, captures: string[], existingParams?: Object): Object;
+        params(path: string | RegExp, captures: string[], existingParams?: Object): Object;
 
         /**
          * Returns array of regexp url path captures.
@@ -138,61 +136,61 @@ declare module "koa-router" {
          * "down" the middleware stack.
          */
         use(...middleware: Array<Router.IMiddleware>): Router;
-        use(path: string, ...middleware: Array<Router.IMiddleware>): Router;
+        use(path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
 
         /**
          * HTTP get method
          */
-        get(name: string, path: string, ...middleware: Array<Router.IMiddleware>): Router;
-        get(path: string, ...middleware: Array<Router.IMiddleware>): Router;
+        get(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
+        get(path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
 
         /**
          * HTTP post method
          */
-        post(name: string, path: string, ...middleware: Array<Router.IMiddleware>): Router;
-        post(path: string, ...middleware: Array<Router.IMiddleware>): Router;
+        post(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
+        post(path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
 
         /**
          * HTTP put method
          */
-        put(name: string, path: string, ...middleware: Array<Router.IMiddleware>): Router;
-        put(path: string, ...middleware: Array<Router.IMiddleware>): Router;
+        put(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
+        put(path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
 
         /**
          * HTTP delete method
          */
-        delete(name: string, path: string, ...middleware: Array<Router.IMiddleware>): Router;
-        delete(path: string, ...middleware: Array<Router.IMiddleware>): Router;
+        delete(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
+        delete(path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
 
         /**
          * Alias for `router.delete()` because delete is a reserved word
          */
-        del(name: string, path: string, ...middleware: Array<Router.IMiddleware>): Router;
-        del(path: string, ...middleware: Array<Router.IMiddleware>): Router;
+        del(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
+        del(path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
 
         /**
          * HTTP head method
          */
-        head(name: string, path: string, ...middleware: Array<Router.IMiddleware>): Router;
-        head(path: string, ...middleware: Array<Router.IMiddleware>): Router;
+        head(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
+        head(path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
 
         /**
          * HTTP options method
          */
-        options(name: string, path: string, ...middleware: Array<Router.IMiddleware>): Router;
-        options(path: string, ...middleware: Array<Router.IMiddleware>): Router;
+        options(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
+        options(path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
 
         /**
          * HTTP path method
          */
-        patch(name: string, path: string, ...middleware: Array<Router.IMiddleware>): Router;
-        patch(path: string, ...middleware: Array<Router.IMiddleware>): Router;
+        patch(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
+        patch(path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
 
         /**
          * Register route with all methods.
          */
-        all(name: string, path: string, ...middleware: Array<Router.IMiddleware>): Router;
-        all(path: string, ...middleware: Array<Router.IMiddleware>): Router;
+        all(name: string, path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
+        all(path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
 
         /**
          * Set the path prefix for a Router instance that was already initialized.
@@ -226,7 +224,7 @@ declare module "koa-router" {
         /**
          * Create and register a route.
          */
-        register(path: string, methods: string[], middleware: Router.IMiddleware, opts?: Object): Layer;
+        register(path: string | RegExp, methods: string[], middleware: Router.IMiddleware, opts?: Object): Layer;
 
         /**
          * Lookup route with given `name`.
@@ -254,7 +252,7 @@ declare module "koa-router" {
         /**
          * Generate URL from url pattern and given `params`.
          */
-        static url(path: string, params: Object): string;
+        static url(path: string | RegExp, params: Object): string;
     }
 
     export = Router;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
According to the [source code](https://github.com/alexmingoia/koa-router/blob/master/lib/layer.js) of koa-router, `path` parameter is converted by [path-to-regexp](https://github.com/pillarjs/path-to-regexp), which supports both strings and regular expressions.

This enables RegExp path usage like:

``` javascript
router.get(/(^\/$|^\/(?!api))/, async (ctx, next) => {
  ctx.body = 'Hello world';
});
```
