### PR TITLE
[FullCalendar]: header option accepts boolean value

### DIFF
--- a/fullCalendar/fullCalendar.d.ts
+++ b/fullCalendar/fullCalendar.d.ts
@@ -25,15 +25,17 @@ declare namespace FullCalendar {
         end: moment.Moment;
     }
 
+    export interface Header {
+        left: string;
+        center: string;
+        right: string;
+    }
+
     export interface Options extends AgendaOptions, EventDraggingResizingOptions, DroppingExternalElementsOptions, SelectionOptions {
         // General display - http://fullcalendar.io/docs/display/
 
-        header?: {
-            left: string;
-            center: string;
-            right: string;
-        }
-        theme?: boolean
+        header?: boolean | Header;
+        theme?: boolean;
         buttonIcons?: {
             prev: string;
             next: string;
@@ -50,7 +52,7 @@ declare namespace FullCalendar {
         contentHeight?: number;
         aspectRatio?: number;
         handleWindowResize?: boolean;
-		views?: ViewSpecificOptions;
+        views?: ViewSpecificOptions;
         viewRender?: (view: ViewObject, element: JQuery) => void;
         viewDestroy?: (view: ViewObject, element: JQuery) => void;
         dayRender?: (date: Date, cell: HTMLTableDataCellElement) => void;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- [FullCalendar header docs](https://fullcalendar.io/docs/display/header/)

> Setting the header options to false will display no header. An object can be supplied with properties left, center, and right.
