### PR TITLE
Fix #10919 - Added IterableIterator forward declaration to enable compilation on targets lower than es2015

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -452,6 +452,8 @@ declare namespace NodeJS {
     }
 }
 
+interface IterableIterator<T> {}
+
 /**
  * @deprecated
  */

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -452,7 +452,7 @@ declare namespace NodeJS {
     }
 }
 
-interface IterableIterator<T> {}
+interface IterableIterator<T> extends Array<T> {}
 
 /**
  * @deprecated

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -452,7 +452,7 @@ declare namespace NodeJS {
     }
 }
 
-interface IterableIterator<T> extends Array<T> {}
+interface IterableIterator<T> {}
 
 /**
  * @deprecated


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- Added forward declaration for `IterableIterator`
