### PR TITLE
ES2015 module support for koa-compress and koa-favicon

### DIFF
--- a/koa-compress/koa-compress.d.ts
+++ b/koa-compress/koa-compress.d.ts
@@ -37,5 +37,6 @@ declare module "koa-compress" {
      */
     function compress(options?: CompressOptions): { (ctx: Koa.Context, next?: () => any): any };
 
+    namespace compress {}
     export = compress;
 }

--- a/koa-favicon/koa-favicon.d.ts
+++ b/koa-favicon/koa-favicon.d.ts
@@ -31,5 +31,6 @@ declare module "koa-favicon" {
 
     }): { (ctx: Koa.Context, next?: () => any): any };
 
+    namespace favicon {}
     export = favicon;
 }


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Add namespace declaration to koa-compress and koa-favicon so we can use ES2015 module syntax like this:

``` javascript
import * as compress from 'koa-compress';
import * as favicon from 'koa-favicon';
```
