### PR TITLE
Add type definition for koa-json-error

### DIFF
--- a/koa-json-error/koa-json-error-tests.ts
+++ b/koa-json-error/koa-json-error-tests.ts
@@ -9,5 +9,5 @@ import { assign } from "lodash";
 const app = new Koa();
 
 app.use(error({
-    preFormat: err => _.assign({}, err)
+    preFormat: err => assign({}, err)
 }));

--- a/koa-json-error/koa-json-error-tests.ts
+++ b/koa-json-error/koa-json-error-tests.ts
@@ -1,0 +1,13 @@
+/// <reference path="../koa/koa.d.ts" />
+/// <reference path="koa-json-error.d.ts" />
+/// <reference path="../lodash/lodash.d.ts" />
+
+import * as Koa from "koa";
+import * as error from "koa-json-error";
+import { assign } from "lodash";
+
+const app = new Koa();
+
+app.use(error({
+    preFormat: err => _.assign({}, err)
+}));

--- a/koa-json-error/koa-json-error.d.ts
+++ b/koa-json-error/koa-json-error.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for koa-json-error v3.x
+// Project: https://github.com/koajs/json-error
+// Definitions by: Mudkip <https://github.com/mudkipme>
+// Definitions: https://github.com/mudkipme/DefinitelyTyped
+
+/// <reference path="../koa/koa.d.ts" />
+
+declare module "koa-json-error" {
+
+    import * as Koa from "koa";
+
+    interface JSONErrorOptions {
+        /**
+         * Perform some task before calling `options.format`. Must be a function with the original err as its only argument.
+         */
+        preFormat?: { (err: Error): any };
+
+        /**
+         * Runs inmediatly after `options.preFormat`. It receives two arguments: the original `err` and the output of     `options.preFormat`. It should `return` a newly formatted error.
+         */
+        format?: { (err: Error, obj: any): any };
+
+        /**
+         * Runs inmediatly after `options.format`. It receives two arguments: the original `err` and the output of   `options.format`.   It should `return` a newly formatted error.
+         */
+        postFormat?: { (err: Error, obj: any): any };
+    }
+
+    /**
+     * Error handler for pure Koa 2.0.0+ JSON apps
+     */
+    function jsonError(options?: JSONErrorOptions) : { (ctx: Koa.Context, next?: () => any): any };
+  
+    namespace jsonError {}
+    export = jsonError;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
