### PR TITLE
Allowing usage as decorators for react-sortable-hoc

### DIFF
--- a/react-sortable-hoc/react-sortable-hoc-tests.tsx
+++ b/react-sortable-hoc/react-sortable-hoc-tests.tsx
@@ -1,29 +1,23 @@
 /// <reference path="../react/react-dom.d.ts" />
 /// <reference path="./react-sortable-hoc.d.ts" />
 
-import React = require('react');
-import ReactDOM = require('react-dom');
-import ReactSortableHOC = require('react-sortable-hoc');
-
-interface SortableItemOwnProps {
+interface SortableItemProps {
     value: string;
 }
 
-interface SortableListOwnProps {
+interface SortableListProps {
     items: Array<string>;
 }
 
-type SortableComponentState = SortableListOwnProps;
+type SortableComponentState = SortableListProps;
 
-type SortableListDecoratedProps = ReactSortableHOC.SortableContainerProps<SortableListOwnProps>;
-
-const SortableItem = ReactSortableHOC.SortableElement((props: SortableItemOwnProps): JSX.Element => {
+const SortableItem = ReactSortableHOC.SortableElement((props: SortableItemProps): JSX.Element => {
     return <li>{props.value}</li>;
 });
 
-const SortableListFunCall = ReactSortableHOC.SortableContainer<SortableListOwnProps>(
-    class extends React.Component<SortableListOwnProps, void> {
-        public constructor(props: SortableListOwnProps) {
+const SortableListFunCall = ReactSortableHOC.SortableContainer<SortableListProps>(
+    class extends React.Component<SortableListProps, void> {
+        public constructor(props: SortableListProps) {
             super(props);
         }
 
@@ -36,9 +30,13 @@ const SortableListFunCall = ReactSortableHOC.SortableContainer<SortableListOwnPr
     }
 );
 
+// Generic decorators can't be used in TSX:
+// [ts] Cannot find name ''. [ts] JSX element '' has no corresponding closing tag.
+// ReactSortableHOC.SortableContainerProps<Props> is required in order to avoid compilation errors:
+// [ts] Property '{prop}' dose not exist on type ...
 @ReactSortableHOC.SortableContainer
-class SortableListDecorated extends React.Component<SortableListDecoratedProps, void> {
-    public constructor(props: SortableListDecoratedProps) {
+class SortableListDecorated extends React.Component<ReactSortableHOC.SortableContainerProps<SortableListProps>, void> {
+    public constructor(props: SortableListProps) {
         super(props);
     }
 
@@ -49,7 +47,6 @@ class SortableListDecorated extends React.Component<SortableListDecoratedProps, 
         return <ul>{items}</ul>;
     }
 }
-
 
 class SortableComponent extends React.Component<void, SortableComponentState> {
     private _onSortEnd: ReactSortableHOC.SortEndHandler;

--- a/react-sortable-hoc/react-sortable-hoc-tests.tsx
+++ b/react-sortable-hoc/react-sortable-hoc-tests.tsx
@@ -5,34 +5,51 @@ import React = require('react');
 import ReactDOM = require('react-dom');
 import ReactSortableHOC = require('react-sortable-hoc');
 
-interface SortableItemProps {
+interface SortableItemOwnProps {
     value: string;
 }
 
-interface SortableListProps {
+interface SortableListOwnProps {
     items: Array<string>;
 }
 
-type SortableComponentState = SortableListProps;
+type SortableComponentState = SortableListOwnProps;
 
-class Item extends React.Component<SortableItemProps, void> {
-    public constructor(props: SortableItemProps) {
+type SortableListDecoratedProps = ReactSortableHOC.SortableContainerProps<SortableListOwnProps>;
+
+const SortableItem = ReactSortableHOC.SortableElement((props: SortableItemOwnProps): JSX.Element => {
+    return <li>{props.value}</li>;
+});
+
+const SortableListFunCall = ReactSortableHOC.SortableContainer<SortableListOwnProps>(
+    class extends React.Component<SortableListOwnProps, void> {
+        public constructor(props: SortableListOwnProps) {
+            super(props);
+        }
+
+        public render(): JSX.Element {
+            const items: Array<JSX.Element> = this.props.items.map((value: string, index: number): JSX.Element => {
+                return <SortableItem key={`item-${index}`} index={index} value={value} />;
+            });
+            return <ul>{items}</ul>;
+        }
+    }
+);
+
+@ReactSortableHOC.SortableContainer
+class SortableListDecorated extends React.Component<SortableListDecoratedProps, void> {
+    public constructor(props: SortableListDecoratedProps) {
         super(props);
     }
 
     public render(): JSX.Element {
-        return <li>{this.props.value}</li>;
+        const items: Array<JSX.Element> = this.props.items.map((value: string, index: number): JSX.Element => {
+            return <SortableItem key={`item-${index}`} index={index} value={value} />;
+        });
+        return <ul>{items}</ul>;
     }
 }
 
-const SortableItem = ReactSortableHOC.SortableElement(Item);
-
-const SortableList = ReactSortableHOC.SortableContainer((props: SortableListProps): JSX.Element => {
-    const items: Array<JSX.Element> = props.items.map((value: string, index: number): JSX.Element => {
-        return <SortableItem key={`item-${index}`} index={index} value={value} />;
-    });
-    return <ul>{items}</ul>;
-});
 
 class SortableComponent extends React.Component<void, SortableComponentState> {
     private _onSortEnd: ReactSortableHOC.SortEndHandler;
@@ -48,7 +65,12 @@ class SortableComponent extends React.Component<void, SortableComponentState> {
     }
 
     public render(): JSX.Element {
-        return <SortableList items={this.state.items} onSortEnd={this._onSortEnd} />;
+        return (
+            <div>
+                <SortableListFunCall items={this.state.items} onSortEnd={this._onSortEnd} />
+                <SortableListDecorated items={this.state.items} onSortEnd={this._onSortEnd} />
+            </div>
+        );
     }
 }
 

--- a/react-sortable-hoc/react-sortable-hoc-tests.tsx
+++ b/react-sortable-hoc/react-sortable-hoc-tests.tsx
@@ -1,6 +1,10 @@
 /// <reference path="../react/react-dom.d.ts" />
 /// <reference path="./react-sortable-hoc.d.ts" />
 
+import React = require('react');
+import ReactDOM = require('react-dom');
+import ReactSortableHOC = require('react-sortable-hoc');
+
 interface SortableItemProps {
     value: string;
 }

--- a/react-sortable-hoc/react-sortable-hoc-tests.tsx.tscparams
+++ b/react-sortable-hoc/react-sortable-hoc-tests.tsx.tscparams
@@ -1,0 +1,1 @@
+--experimentalDecorators

--- a/react-sortable-hoc/react-sortable-hoc.d.ts
+++ b/react-sortable-hoc/react-sortable-hoc.d.ts
@@ -34,7 +34,7 @@ declare module 'react-sortable-hoc' {
 
     export type ContainerGetter = (element: React.ReactElement<any>) => HTMLElement;
 
-    export interface SortableContainerProps {
+    export interface SortableContainerHOCProps {
         axis?: Axis;
         lockAxis?: Axis;
         helperClass?: string;
@@ -51,7 +51,7 @@ declare module 'react-sortable-hoc' {
         getContainer?: ContainerGetter;
     }
 
-    export interface SortableElementProps {
+    export interface SortableElementHOCProps {
         index: number;
         collection?: Offset;
         disabled?: boolean;
@@ -61,13 +61,21 @@ declare module 'react-sortable-hoc' {
         withRef: boolean;
     }
 
-    export type WrappedComponentFactory<P> = (props: P) => JSX.Element;
+    export type WrappedComponentFactory<P> = (props: P) => JSX.Element; 
 
     export type WrappedComponent<P> = React.ComponentClass<P> | WrappedComponentFactory<P>;
 
-    export function SortableContainer<P>(wrappedComponent: WrappedComponent<P>, config?: Config): React.ComponentClass<P & SortableContainerProps>;
+    export type SortableContainerProps<P> = P & SortableContainerHOCProps;
 
-    export function SortableElement<P>(wrappedComponent: WrappedComponent<P>, config?: Config): React.ComponentClass<P & SortableElementProps>;
+    export type SortableElementProps<P> = P & SortableElementHOCProps;
+
+    export function SortableContainer<P>(wrappedComponent: WrappedComponent<P>, config?: Config): React.ComponentClass<SortableContainerProps<P>>;
+
+    export function SortableContainer<TFunction extends Function>(wrappedComponent: TFunction, config?: Config): TFunction | void;
+
+    export function SortableElement<P>(wrappedComponent: WrappedComponent<P>, config?: Config): React.ComponentClass<SortableElementProps<P>>;
+
+    export function SortableElement<TFunction extends Function>(wrappedComponent: TFunction, config?: Config): TFunction | void;
 
     export function SortableHandle<P>(wrappedComponent: WrappedComponent<P>, config?: Config): React.ComponentClass<P>;
 

--- a/react-sortable-hoc/react-sortable-hoc.d.ts
+++ b/react-sortable-hoc/react-sortable-hoc.d.ts
@@ -68,6 +68,11 @@ declare module 'react-sortable-hoc' {
     export type SortableContainerProps<P> = P & SortableContainerHOCProps;
 
     export type SortableElementProps<P> = P & SortableElementHOCProps;
+    
+    // Generic decorators can't be used in TSX:
+    // [ts] Cannot find name ''. [ts] JSX element '' has no corresponding closing tag.
+    // Sortable{Wrapper}Props<Props> is required in order to avoid compilation errors:
+    // [ts] Property '{prop}' dose not exist on type ...
 
     export function SortableContainer<P>(wrappedComponent: WrappedComponent<P>, config?: Config): React.ComponentClass<SortableContainerProps<P>>;
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Allowing `SortableContainer` & `SortableElement` to be used as `class decorator`s.
