### PR TITLE
Node.d.ts: Update definitions for module "http"

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -651,6 +651,9 @@ declare module "http" {
     }
     export interface IncomingMessage extends events.EventEmitter, stream.Readable {
         httpVersion: string;
+        httpVersionMajor: string;
+        httpVersionMinor: string;
+        connection: any;
         headers: any;
         rawHeaders: string[];
         trailers: any;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

This pull requests adds 3 properties to the `IncomingMessage` interface of module "http". These are
- httpVersionMajor 
- httpVersionMinor 
- connection

The first two are mentioned in the documentation for httpVersion [here](https://nodejs.org/dist/latest-v6.x/docs/api/http.html#http_message_httpversion) so I've put their types as `string` (similarly to the type of httpVersion)

The `connection` property is mentioned in the documentation for [setTimeout](https://nodejs.org/dist/latest-v6.x/docs/api/http.html#http_message_settimeout_msecs_callback). It suggests that `message.setTimeout(msecs, callback)` is equivalent to `message.connection.setTimeout(msecs, callback)` . I couldn't find any other documentation for `connection`, so I've put its type as `any`. 
