### PR TITLE
Node.d.ts: Update definitions for module "repl"

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -963,7 +963,7 @@ declare module "punycode" {
 
 declare module "repl" {
     import * as stream from "stream";
-    import * as events from "events";
+    import * as readline from "readline";
 
     export interface ReplOptions {
         prompt?: string;
@@ -975,8 +975,17 @@ declare module "repl" {
         useGlobal?: boolean;
         ignoreUndefined?: boolean;
         writer?: Function;
+        completer?: Function;
+        replMode?: any;
+        breakEvalOnSigint?: any;
     }
-    export function start(options: ReplOptions): events.EventEmitter;
+
+    export interface REPLServer extends readline.ReadLine {
+        defineCommand(keyword: string, cmd: Function | { help: string, action: Function }): void;
+        displayPrompt(preserveCursor?: boolean): void
+    }
+
+    export function start(options: ReplOptions): REPLServer;
 }
 
 declare module "readline" {


### PR DESCRIPTION
case 2. Improvement to existing type definition.

This pull request introduces updates to node's [REPL](https://nodejs.org/dist/latest-v6.x/docs/api/repl.html) module. The changes are:
- Add more properties to the`ReplOptions` interface - [documentation](https://nodejs.org/dist/latest-v6.x/docs/api/repl.html#repl_repl_start_options)
- Introduce the `REPLServer` interface - [documentation](https://nodejs.org/dist/latest-v6.x/docs/api/repl.html#repl_class_replserver)
- Change the return type of function `start`\- [documentation](https://nodejs.org/dist/latest-v6.x/docs/api/repl.html#repl_repl_start_options)
