### PR TITLE
changed reduce, inject, foldl, reduceRight, foldr

### DIFF
--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -4987,28 +4987,106 @@ interface _Chain<T> {
 	* Wrapped type `any[]`.
 	* @see _.reduce
 	**/
-	reduce<TResult>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
+	reduce<TResult>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _Chain<TResult>;
+	
+	/**
+	* Wrapped type `any[]`.
+	* @see _.reduce
+	**/
+	reduce<TResult extends number>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
+	
+	/**
+	* Wrapped type `any[]`.
+	* @see _.reduce
+	**/
+	reduce<TResult extends string>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
+	
+	/**
+	* Wrapped type `any[]`.
+	* @see _.reduce
+	**/
+	reduce<TResult extends boolean>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
 
 	/**
 	* @see _.reduce
 	**/
-	inject<TResult>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
-
+	inject<TResult>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _Chain<TResult>;
+	
 	/**
 	* @see _.reduce
 	**/
-	foldl<TResult>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
+	inject<TResult extends number>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
+	
+	/**
+	* @see _.reduce
+	**/
+	inject<TResult extends string>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
+	
+	/**
+	* @see _.reduce
+	**/
+	inject<TResult extends boolean>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
+	
+	/**
+	* @see _.reduce
+	**/
+	foldl<TResult>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _Chain<TResult>;
+	
+	/**
+	* @see _.reduce
+	**/
+	foldl<TResult extends number>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
+	
+	/**
+	* @see _.reduce
+	**/
+	foldl<TResult extends string>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
+	
+	/**
+	* @see _.reduce
+	**/
+	foldl<TResult extends boolean>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
 
 	/**
 	* Wrapped type `any[]`.
 	* @see _.reduceRight
 	**/
-	reduceRight<TResult>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
+	reduceRight<TResult>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _Chain<TResult>;
+
+	/**
+	* @see _.reduce
+	**/
+	reduceRight<TResult extends number>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
+	
+	/**
+	* @see _.reduce
+	**/
+	reduceRight<TResult extends string>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
+	
+	/**
+	* @see _.reduce
+	**/
+	reduceRight<TResult extends boolean>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
 
 	/**
 	* @see _.reduceRight
 	**/
-	foldr<TResult>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
+	foldr<TResult>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _Chain<TResult>;
+
+	/**
+	* @see _.reduce
+	**/
+	foldr<TResult extends number>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
+	
+	/**
+	* @see _.reduce
+	**/
+	foldr<TResult extends string>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
+	
+	/**
+	* @see _.reduce
+	**/
+	foldr<TResult extends boolean>(iterator: _.MemoIterator<T, TResult>, memo?: TResult, context?: any): _ChainSingle<TResult>;
 
 	/**
 	* Wrapped type `any[]`.


### PR DESCRIPTION
changed reduce, inject, foldl, reduceRight, foldr to return _Chain<TResult> except if the Generic Type extends "number, string, boolean" (primitive values) then return _ChainSingle<TResult>

what do you think? 
#7931
