### PR TITLE
Parse push on new parse-server need the useMasterKey flag

### DIFF
--- a/parse/parse.d.ts
+++ b/parse/parse.d.ts
@@ -1072,7 +1072,7 @@ declare namespace Parse {
             title?: string;
         }
 
-        interface SendOptions {
+        interface SendOptions extends UseMasterKeyOption {
             success?: () => void;
             error?: (error: Error) => void;
         }


### PR DESCRIPTION
case 2. Improvement to existing type definition.

To send push notifications from the new parse-server the `useMasterKey` option has to be passed. This is the correct typing as you can see in the [original source of the `send` method or the parse js sdk](https://github.com/ParsePlatform/Parse-SDK-JS/blob/master/src/Push.js):

``` javascript
options?: { useMasterKey?: boolean, success?: any, error?: any }
```

(from line 56)

This PR adds this typing detail.

PS: as we are working with parse a lot and the original maintainer of the parse typing is gone I would offer to maintain the parse typing (i.e. review PRs etc). If this is desired, how would I add myself as a maintainer so I get notified of new PRs concerning parse?
