### PR TITLE
Node.d.ts: Introduce module "timers"

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -2629,3 +2629,12 @@ declare module "constants" {
 declare module "process" {
     export = process;
 }
+
+declare module "timers" {
+    export function setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
+    export function clearTimeout(timeoutId: NodeJS.Timer): void;
+    export function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
+    export function clearInterval(intervalId: NodeJS.Timer): void;
+    export function setImmediate(callback: (...args: any[]) => void, ...args: any[]): any;
+    export function clearImmediate(immediateId: any): void;
+}


### PR DESCRIPTION
case 2. Improvement to existing type definition.

This pull request adds the module `"timers"` to node.d.ts - [documentation](https://nodejs.org/dist/latest-v6.x/docs/api/timers.html). 

Even though the functions described in the module can be used globally they can be accessed in node by using require("timers") as well and node.d.ts should make that possible in TypeScript, too.
