### PR TITLE
Node.d.ts: Update definitions for module "domain"

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -2374,6 +2374,10 @@ declare module "domain" {
         bind(cb: (err: Error, data: any) => any): any;
         intercept(cb: (data: any) => any): any;
         dispose(): void;
+        members: any[];
+        enter(): void;
+        exit(): void;
+
     }
 
     export function create(): Domain;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -2377,7 +2377,6 @@ declare module "domain" {
         members: any[];
         enter(): void;
         exit(): void;
-
     }
 
     export function create(): Domain;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
This pull request adds 3 new properties to the class `Domain` of module `"domain"` in node.d.ts:
- `members` - [documentation](https://nodejs.org/dist/latest-v6.x/docs/api/domain.html#domain_domain_members)
- `enter()` - [documentation](https://nodejs.org/dist/latest-v6.x/docs/api/domain.html#domain_domain_enter)
- `exit()` - [documentation](https://nodejs.org/dist/latest-v6.x/docs/api/domain.html#domain_domain_exit)
