### PR TITLE
Revert "Added entries, includes, keys and values to Buffer (#10809)"

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -259,47 +259,6 @@ function bufferTests() {
         index = buffer.lastIndexOf(buffer);
     }
 
-    {
-        let buffer = new Buffer('123');
-        let val: [number, number];
-
-        for (let entry of buffer.entries()) {
-            val = entry;
-        }
-    }
-
-    {
-        let buffer = new Buffer('123');
-        let includes: boolean;
-        includes = buffer.includes("23");
-        includes = buffer.includes("23", 1);
-        includes = buffer.includes("23", 1, "utf8");
-        includes = buffer.includes(23);
-        includes = buffer.includes(23, 1);
-        includes = buffer.includes(23, 1, "utf8");
-        includes = buffer.includes(buffer);
-        includes = buffer.includes(buffer, 1);
-        includes = buffer.includes(buffer, 1, "utf8");
-    }
-
-    {
-        let buffer = new Buffer('123');
-        let val: number;
-
-        for (let key of buffer.keys()) {
-            val = key;
-        }
-    }
-
-    {
-        let buffer = new Buffer('123');
-        let val: number;
-
-        for (let value of buffer.values()) {
-            val = value;
-        }
-    }
-
     // Imported Buffer from buffer module works properly
     {
         let b = new ImportedBuffer('123');

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -509,10 +509,10 @@ interface NodeBuffer extends Uint8Array {
     fill(value: any, offset?: number, end?: number): this;
     indexOf(value: string | number | Buffer, byteOffset?: number, encoding?: string): number;
     lastIndexOf(value: string | number | Buffer, byteOffset?: number, encoding?: string): number;
-    entries(): IterableIterator<[number, number]>;
-    includes(value: string | number | Buffer, byteOffset?: number, encoding?: string): boolean;
-    keys(): IterableIterator<number>;
-    values(): IterableIterator<number>;
+    // TODO: entries
+    // TODO: includes
+    // TODO: keys
+    // TODO: values
 }
 
 /************************************************


### PR DESCRIPTION
To fix #10919, this PR reverts commit 67827a1e39dc91bf66a79b04f36e9eb85e075e10, which is generating problems as documented in issue #10919.   An attempt to address these by forward-declaring `IterableIterator` in PR #10943 generated a different set of errors (in the new test cases.)   

For some reason, the existing Travis CI tests are NOT detecting the compile error generated with a plain `tsc node-tests.ts` command.   I propose reverting the original change that introduced the errors until the tests can be made more sensitive to this sort of issue.
