### PR TITLE
Made ErrnoException.errno a string as per NodeJS API documentation

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -134,7 +134,7 @@ class Networker extends events.EventEmitter {
     }
 }
 
-var errno: number;
+var errno: string;
 fs.readFile('testfile', (err, data) => {
     if (err && err.errno) {
         errno = err.errno;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -233,7 +233,7 @@ declare var Buffer: {
 ************************************************/
 declare namespace NodeJS {
     export interface ErrnoException extends Error {
-        errno?: number;
+        errno?: string;
         code?: string;
         path?: string;
         syscall?: string;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- Strangely, `errno` is actually a `string` https://nodejs.org/api/errors.html#errors_error_errno
