### PR TITLE
add definitions for phonegap-plugin-barcodescanner

### DIFF
--- a/phonegap-plugin-barcodescanner/phonegap-plugin-barcodescanner-tests.ts
+++ b/phonegap-plugin-barcodescanner/phonegap-plugin-barcodescanner-tests.ts
@@ -1,0 +1,29 @@
+/// <reference path="../cordova/cordova.d.ts"/>
+/// <reference path="phonegap-plugin-barcodescanner.d.ts" />
+   
+cordova.plugins.barcodeScanner.scan(
+    function (result) {
+        alert("We got a barcode\n" +
+            "Result: " + result.text + "\n" +
+            "Format: " + result.format + "\n" +
+            "Cancelled: " + result.cancelled);
+    }, 
+    function (error) {
+        alert("Scanning failed: " + error);
+    },
+    {
+        "preferFrontCamera" : true, // iOS and Android
+        "showFlipCameraButton" : true, // iOS and Android
+        "prompt" : "Place a barcode inside the scan area", // supported on Android only
+        "formats" : "QR_CODE,PDF_417", // default: all but PDF_417 and RSS_EXPANDED
+        "orientation" : "landscape" // Android only (portrait|landscape), default unset so it rotates with the device
+    }
+);
+
+
+cordova.plugins.barcodeScanner.encode(cordova.plugins.barcodeScanner.Encode.TEXT_TYPE, "http://www.nytimes.com", function(success) {
+    alert("encode success: " + success);
+    }, function(fail) {
+    alert("encoding failed: " + fail);
+    }
+);

--- a/phonegap-plugin-barcodescanner/phonegap-plugin-barcodescanner.d.ts
+++ b/phonegap-plugin-barcodescanner/phonegap-plugin-barcodescanner.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for phonegap-plugin-barcodescanner
+// Project: https://github.com/phonegap/phonegap-plugin-barcodescanner
+// Definitions by: Nathan Ainslie <https://www.github.com/nainslie>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface CordovaPlugins {
+    barcodeScanner: phonegapBarcode.BarcodeScanner;
+}
+
+declare namespace phonegapBarcode {
+    interface BarcodeScanResult {
+        text: string;
+        format: string;
+        cancelled: boolean;
+    }
+    
+    interface BarcodeScanOptions {
+        preferFrontCamera?: boolean;
+        showFlipCameraButton?: boolean;
+        prompt?: string;
+        formats?: string;
+        orientation?: "landscape" | "portrait";
+    }
+
+    interface EncodingType {
+        TEXT_TYPE: any;
+        EMAIL_TYPE: any;
+        PHONE_TYPE: any;
+        SMS_TYPE: any;
+    }
+
+    interface BarcodeScanner {
+        scan: (success: ((result: BarcodeScanResult) => any), failure?: ((err: any) => any), opts?: BarcodeScanOptions) => void;
+        encode: (encodingType: EncodingType, data: string, success: ((result: any) => any), failure?: ((err: any) => any)) => void;
+        Encode: EncodingType;
+    }
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

---

Added new type definitions for cordova/phonegap plugin hosted at https://github.com/phonegap/phonegap-plugin-barcodescanner.
