### PR TITLE
fix: wrong type using in express-serve-static-core

### DIFF
--- a/express-serve-static-core/express-serve-static-core.d.ts
+++ b/express-serve-static-core/express-serve-static-core.d.ts
@@ -126,7 +126,7 @@ declare module "express-serve-static-core" {
 
     interface Errback { (err: Error): void; }
 
-    interface Request extends http.ServerRequest, Express.Request {
+    interface Request extends http.IncomingMessage, Express.Request {
 
         /**
             * Return request header.


### PR DESCRIPTION
http.ServerRequest removed in node6 and express actually using IncomingMessage

`"express": "^4.14.0"` source code in express/lib/request.js

```
/**
 * Request prototype.
 */

var req = exports = module.exports = {
  __proto__: http.IncomingMessage.prototype
};
```
