### PR TITLE
Node.d.ts: Update definitions for module "dgram"

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1371,19 +1371,35 @@ declare module "dgram" {
         port: number;
     }
 
+    interface BindOptions {
+        port: number;
+        address?: string;
+        exclusive?: boolean;
+    }
+
+    interface SocketOptions {
+        type: string;
+        reuseAddr?: boolean;
+    }
+
     export function createSocket(type: string, callback?: (msg: Buffer, rinfo: RemoteInfo) => void): Socket;
+    export function createSocket(options: SocketOptions, callback?: (msg: Buffer, rinfo: RemoteInfo) => void): Socket;
 
     interface Socket extends events.EventEmitter {
-        send(buf: Buffer, port: number, address: string, callback?: (error: Error, bytes: number) => void): void;
-        send(buf: Buffer, offset: number, length: number, port: number, address: string, callback?: (error: Error, bytes: number) => void): void;
+        send(msg: Buffer | String | any[], port: number, address: string, callback?: (error: Error, bytes: number) => void): void;
+        send(msg: Buffer | String | any[], offset: number, length: number, port: number, address: string, callback?: (error: Error, bytes: number) => void): void;
         bind(port?: number, address?: string, callback?: () => void): void;
-        close(): void;
+        bind(options: BindOptions, callback?: Function): void;
+        close(callback?: any): void;
         address(): AddressInfo;
         setBroadcast(flag: boolean): void;
+        setTTL(ttl: number): void;
         setMulticastTTL(ttl: number): void;
         setMulticastLoopback(flag: boolean): void;
         addMembership(multicastAddress: string, multicastInterface?: string): void;
         dropMembership(multicastAddress: string, multicastInterface?: string): void;
+        ref(): void;
+        unref(): void;
     }
 }
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.

This pull requests updates the definitions for the node's [dgram module](https://nodejs.org/dist/latest-v6.x/docs/api/dgram.html) : 
- Changes to `interface Socket`:
  - bind(...) - an additional declaration as function is overloaded([documentation](https://nodejs.org/dist/latest-v6.x/docs/api/dgram.html#dgram_socket_bind_options_callback))
  - close() - add an optional parameter([documentation](https://nodejs.org/dist/latest-v6.x/docs/api/dgram.html#dgram_socket_close_callback))
  - send(...) - change `buf` parameter to `msg` and its type([documentation](https://nodejs.org/dist/latest-v6.x/docs))
  - add setTTL(ttl) method ([documentation](https://nodejs.org/dist/latest-v6.x/docs/api/dgram.html#dgram_socket_setttl_ttl))
  - add ref() method ([documentation](https://nodejs.org/dist/latest-v6.x/docs/api/dgram.html#dgram_socket_ref))
  - add unref() method ([documentation](https://nodejs.org/dist/latest-v6.x/docs/api/dgram.html#dgram_socket_unref))
- Changes to module functions:
  - createSocket(...) - add an new declaration([documentation](https://nodejs.org/dist/latest-v6.x/docs/api/dgram.html#dgram_dgram_createsocket_options_callback))
- Created two local interfaces to model types used in the update
