### PR TITLE
Node.d.ts: Update definitions for module "os"

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -890,6 +890,7 @@ declare module "os" {
     export function freemem(): number;
     export function cpus(): CpuInfo[];
     export function networkInterfaces(): { [index: string]: NetworkInterfaceInfo[] };
+    export function userInfo(options?: {encoding: string}): { username: string, uid: number, gid: number, shell: any, homedir: string }
     export var EOL: string;
 }
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.

This pull request adds the function userInfo to the module "os" as described in node's [documentation](https://nodejs.org/dist/latest-v6.x/docs/api/os.html#os_os_userinfo_options).

Please do comment on the types as I couldn't find much more info about the properties of the returned object and some of their types are assumptions made by their defaults. 
