### PR TITLE
Added definitions for Validate.js

### DIFF
--- a/validate.js/validate.js-tests.ts
+++ b/validate.js/validate.js-tests.ts
@@ -1,0 +1,184 @@
+///<reference path="validate.js.d.ts"/>
+import Validator = ValidateJS.Validator;
+import Field = ValidateJS.Field;
+import Constraints = ValidateJS.Constraints;
+
+let validator: Validator;
+validator = {};
+validator = {message: 'test'};
+validator = {message: (value: any, attribute: any, validatorOptions: any, attributes: any, globalOptions: any) => 'test'};
+
+let date: Validator.Date;
+date = {};
+date = {
+	earliest: 'a',
+	latest: 'b',
+	notValid: 'c',
+	tooEarly: 'd',
+	tooLate: 'e',
+	message: 'test',
+};
+
+let dateTime: Validator.DateTime;
+dateTime = {};
+dateTime = {
+	dateOnly: true,
+	earliest: 'a',
+	latest: 'b',
+	notValid: 'c',
+	tooEarly: 'd',
+	tooLate: 'e',
+	message: 'test',
+};
+
+let email: Validator.Email;
+email = {};
+email = {message: 'test'};
+
+let equality: Validator.Equality;
+equality = {};
+equality = {
+	attribute: 'a',
+	comparator: (v1: any, v2: any) => true,
+	message: 'test',
+};
+
+let exclusion: Validator.Exclusion;
+exclusion = {
+	within: ['a', 'b'],
+	message: 'test',
+};
+exclusion = {
+	within: {a: 'b', c: 'd'},
+};
+
+let format: Validator.Format;
+format = {
+	pattern: 'a',
+	message: 'test',
+};
+format = {
+	pattern: /a/g,
+};
+format = {
+	pattern: new RegExp('a'),
+};
+
+let inclusion: Validator.Inclusion;
+inclusion = {
+	within: ['a', 'b'],
+	message: 'test',
+};
+inclusion = {
+	within: {a: 'b', c: 'd'},
+};
+
+let _length: Validator.Length;
+_length = {};
+_length = {
+	is: 1,
+	notValid: 'a',
+	wrongLength: 'b',
+	message: 'test',
+	tokenizer: (value: any[]) => [1, 2],
+};
+_length = {
+	minimum: 2,
+	maximum: 4,
+	tooShort: 'a',
+	tooLong: 'b',
+	tokenizer: (value: string) => 'test',
+};
+
+let numericality: Validator.Numericality;
+numericality = {};
+numericality = {
+	onlyInteger: true,
+	strict: true,
+	equalTo: 8,
+	divisibleBy: 4,
+	even: true,
+	notValid: 'a',
+	notInteger: 'b',
+	notEqualTo: 'c',
+	notDivisibleBy: 'd',
+	notEven: 'e',
+	message: 'test',
+};
+numericality = {
+	greaterThan: 4,
+	lessThan: 10,
+	odd: true,
+	notGreaterThan: 'a',
+	notLessThan: 'b',
+	notOdd: 'c',
+};
+numericality = {
+	greaterThanOrEqualTo: 4,
+	lessThanOrEqualTo: 7,
+	notGreaterThanOrEqualTo: 'a',
+	notLessThanOrEqualTo: 'b',
+};
+
+let presence: Validator.Presence;
+presence = {};
+presence = {message: 'test'};
+
+let url: Validator.Url;
+url = {};
+url = {
+	schemes: ['a', /b/g, new RegExp('c')],
+	allowLocal: true,
+	message: 'test',
+};
+
+let field: Field;
+field = {};
+field = {
+	date: {earliest: 'a'},
+	datetime: {dateOnly: true},
+	email: {message: 'test'},
+	equality: {attribute: 'b'},
+	exclusion: {within: ['c']},
+	format: {pattern: 'd'},
+	inclusion: {within: ['e']},
+	length: {is: 4},
+	numericality: {onlyInteger: true},
+	presence: {message: 'test2'},
+	url: {schemes: ['f']},
+};
+field = {
+	date: true,
+	datetime: true,
+	email: true,
+	equality: 'a',
+	exclusion: ['b'],
+	format: 'c',
+	inclusion: ['d'],
+	numericality: true,
+	presence: true,
+	url: true,
+};
+field = {
+	format: /a/g,
+};
+field = {
+	date: (value: any, attributes: any, attributeName: any, options: any, constraints: any) => ({earliest: 'a'}),
+	datetime: (value: any, attributes: any, attributeName: any, options: any, constraints: any) => ({dateOnly: true}),
+	email: (value: any, attributes: any, attributeName: any, options: any, constraints: any) => ({message: 'test'}),
+	equality: (value: any, attributes: any, attributeName: any, options: any, constraints: any) => ({attribute: 'b'}),
+	exclusion: (value: any, attributes: any, attributeName: any, options: any, constraints: any) => ({within: ['c']}),
+	format: (value: any, attributes: any, attributeName: any, options: any, constraints: any) => ({pattern: 'd'}),
+	inclusion: (value: any, attributes: any, attributeName: any, options: any, constraints: any) => ({within: ['e']}),
+	length: (value: any, attributes: any, attributeName: any, options: any, constraints: any) => ({is: 4}),
+	numericality: (value: any, attributes: any, attributeName: any, options: any, constraints: any) => ({onlyInteger: true}),
+	presence: (value: any, attributes: any, attributeName: any, options: any, constraints: any) => ({message: 'test2'}),
+	url: (value: any, attributes: any, attributeName: any, options: any, constraints: any) => ({schemes: ['f']}),
+};
+
+let constraints: Constraints;
+constraints = {};
+constraints = {
+	a: {date: true},
+	b: (value: any, attribute: any, attributeName: any, options: any, constraints: any) => ({datetime: true}),
+};

--- a/validate.js/validate.js.d.ts
+++ b/validate.js/validate.js.d.ts
@@ -6,7 +6,7 @@
 declare namespace ValidateJS {
 
   export interface Validator {
-    message?: string | ((value: any, attribute: any, validatorOptions: any, attributes: any, globalOptions: any) => any);
+    message?: string | ((value: any, attribute: any, validatorOptions: any, attributes: any, globalOptions: any) => string);
   }
 
   namespace Validator {

--- a/validate.js/validate.js.d.ts
+++ b/validate.js/validate.js.d.ts
@@ -1,3 +1,8 @@
+// Type definitions for Validate.js
+// Project: https://github.com/ansman/validate.js
+// Definitions by: Travis Hill <https://github.com/HillTravis>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
 declare namespace ValidateJS {
 
   export interface Validator {

--- a/validate.js/validate.js.d.ts
+++ b/validate.js/validate.js.d.ts
@@ -1,0 +1,104 @@
+declare namespace ValidateJS {
+
+  export interface Validator {
+    message?: string | ((value: any, attribute: any, validatorOptions: any, attributes: any, globalOptions: any) => any);
+  }
+
+  namespace Validator {
+
+    export interface Date extends Validator {
+      earliest?: string;
+      latest?: string;
+
+      notValid?: string;
+      tooEarly?: string;
+      tooLate?: string;
+    }
+
+    export interface DateTime extends Date {
+      dateOnly?: boolean;
+    }
+
+    export interface Email extends Validator {}
+
+    export interface Equality extends Validator {
+      attribute?: string;
+      comparator?: (v1: any, v2: any) => boolean;
+    }
+
+    export interface Exclusion extends Validator {
+      within: any[] | {[key: string]: any};
+    }
+
+    export interface Format extends Validator {
+      pattern: string | RegExp;
+      flags?: string;
+    }
+
+    export interface Inclusion extends Validator {
+      within: any[] | {[key: string]: any};
+    }
+
+    export interface Length extends Validator {
+      is?: number;
+      minimum?: number;
+      maximum?: number;
+
+      notValid?: string;
+      tooLong?: string;
+      tooShort?: string;
+      wrongLength?: string;
+
+      tokenizer?: (value: string | any[]) => string | any[];
+    }
+
+    export interface Numericality extends Validator {
+      onlyInteger?: boolean;
+      strict?: boolean;
+      greaterThan?: number;
+      greaterThanOrEqualTo?: number;
+      equalTo?: number;
+      lessThanOrEqualTo?: number;
+      lessThan?: number;
+      divisibleBy?: number;
+      odd?: boolean;
+      even?: boolean;
+
+      notValid?: string;
+      notInteger?: string;
+      notGreaterThan?: string;
+      notGreaterThanOrEqualTo?: string;
+      notEqualTo?: string;
+      notLessThanOrEqualTo?: string;
+      notLessThan?: string;
+      notDivisibleBy?: string;
+      notOdd?: string;
+      notEven?: string;
+    }
+
+    export interface Presence extends Validator {}
+
+    export interface Url extends Validator {
+      schemes?: [string | RegExp];
+      allowLocal?: boolean;
+    }
+  }
+
+  export interface Field {
+    date?: Validator.Date | boolean | ((value: any, attributes: any, attributeName: any, options: any, constraints: any) => Validator.Date);
+    datetime?: Validator.DateTime | boolean | ((value: any, attributes: any, attributeName: any, options: any, constraints: any) => Validator.DateTime);
+    email?: Validator.Email | boolean | ((value: any, attributes: any, attributeName: any, options: any, constraints: any) => Validator.Email);
+    equality?: Validator.Equality | string | ((value: any, attributes: any, attributeName: any, options: any, constraints: any) => Validator.Equality);
+    exclusion?: Validator.Exclusion | any[] | {[key: string]: any} | ((value: any, attributes: any, attributeName: any, options: any, constraints: any) => Validator.Exclusion);
+    format?: Validator.Format | string | RegExp | ((value: any, attributes: any, attributeName: any, options: any, constraints: any) => Validator.Format);
+    inclusion?: Validator.Inclusion | any[] | {[key: string]: any} | ((value: any, attributes: any, attributeName: any, options: any, constraints: any) => Validator.Inclusion);
+    length?: Validator.Length | ((value: any, attributes: any, attributeName: any, options: any, constraints: any) => Validator.Length);
+    numericality?: Validator.Numericality | boolean | ((value: any, attributes: any, attributeName: any, options: any, constraints: any) => Validator.Numericality);
+    presence?: Validator.Presence | boolean | ((value: any, attributes: any, attributeName: any, options: any, constraints: any) => Validator.Presence);
+    url?: Validator.Url | boolean | ((value: any, attributes: any, attributeName: any, options: any, constraints: any) => Validator.Url);
+  }
+
+  export interface Constraints {
+    [attribute: string]: Field | ((value: any, attributes: any, attributeName: any, options: any, constraints: any) => Field);
+  }
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

This does not include tests or full functionality definitions. It is intended to be a starting point for this library's definitions. Others can improve it. This is the extent that I'm able to contribute at this moment.
