### PR TITLE
Changing dojo/_base/lang mixin signature to match documentation

### DIFF
--- a/dojo/dojo.d.ts
+++ b/dojo/dojo.d.ts
@@ -5686,6 +5686,7 @@ declare namespace dojo {
              * @param dest The object to which to copy/add all properties contained in source. If dest is falsy, thena new object is manufactured before copying/adding properties begins.
              * @param sources One of more objects from which to draw all properties to copy into dest. sources are processedleft-to-right and if more than one of these objects contain the same property name, the right-mostvalue "wins".
              */
+            mixin<T>(dest: T): T;
             mixin<T, U>(
                 dest: T,
                 source: U
@@ -5701,7 +5702,7 @@ declare namespace dojo {
                 source2: V,
                 source3: W
             ): T & U & V & W;
-            mixin<T>(dest: Object, source: Object, sources?: Object[]): T;
+            mixin<T>(dest: Object, ...sources: Object[]): T;
             /**
              * similar to hitch() except that the scope object is left to be
              * whatever the execution context eventually becomes.

--- a/dojo/dojo.d.ts
+++ b/dojo/dojo.d.ts
@@ -5686,7 +5686,22 @@ declare namespace dojo {
              * @param dest The object to which to copy/add all properties contained in source. If dest is falsy, thena new object is manufactured before copying/adding properties begins.
              * @param sources One of more objects from which to draw all properties to copy into dest. sources are processedleft-to-right and if more than one of these objects contain the same property name, the right-mostvalue "wins".
              */
-            mixin(dest: Object, source: Object, sources?: Object[]): Object;
+            mixin<T, U>(
+                dest: T,
+                source: U
+            ): T & U;
+            mixin<T, U, V>(
+                dest: T,
+                source1: U,
+                source2: V
+            ): T & U & V;
+            mixin<T, U, V, W>(
+                dest: T,
+                source1: U,
+                source2: V,
+                source3: W
+            ): T & U & V & W;
+            mixin<T>(dest: Object, source: Object, sources?: Object[]): T;
             /**
              * similar to hitch() except that the scope object is left to be
              * whatever the execution context eventually becomes.


### PR DESCRIPTION
I revisited the changes I made on [https://github.com/DefinitelyTyped/DefinitelyTyped/pull/10275](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/10275) and it turns out I made a huge mistake regarding the`source` and `sources` parameters. I also decided to take a cue from the lodash definition of [_.assign](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/lodash/lodash.d.ts#L13822) and create multiple function signatures to give the user better type information for the returned object.
