### PR TITLE
allow tooltip prop of IconButton to be a ReactNode | string

### DIFF
--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -536,7 +536,7 @@ declare namespace __MaterialUI {
         type horizontal = 'left' | 'middle' | 'right';
         type vertical = 'top' | 'center' | 'bottom';
         type direction = 'left' | 'right' | 'up' | 'down';
-        
+
         interface origin {
             horizontal: horizontal;
             vertical: vertical;
@@ -745,7 +745,7 @@ declare namespace __MaterialUI {
         onMouseLeave?: React.MouseEventHandler;
         onMouseOut?: React.MouseEventHandler;
         style?: React.CSSProperties;
-        tooltip?: string;
+        tooltip?: React.ReactNode | string;
         tooltipPosition?: propTypes.cornersAndCenter;
         tooltipStyles?: React.CSSProperties;
         touch?: boolean;


### PR DESCRIPTION
I am proposing an update to the type definition of the React Material-UI library.

The IconButton component currently has a type `string` for the prop `tooltip`. However, The documentation says that the `tooltip` prop has a type `node`: `http://www.material-ui.com/#/components/icon-button` (go to the bottom of the page where it says `Properties`).

Though, in the examples they use a `string` when they create a IconButton with a tooltip. Therefor I changed the type to `React.ReactNode | string`
