### PR TITLE
[types 2.0] Migrate connect-redis

### DIFF
--- a/connect-redis/connect-redis-tests.ts
+++ b/connect-redis/connect-redis-tests.ts
@@ -1,5 +1,4 @@
-/// <reference path="./connect-redis.d.ts" />
-/// <reference path="../express-session/express-session.d.ts" />
+/// <reference path="./index.d.ts" />
 
 import * as connectRedis from "connect-redis";
 import * as session from "express-session";

--- a/connect-redis/index.d.ts
+++ b/connect-redis/index.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: Xavier Stouder <https://github.com/xstoudi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../express/express.d.ts" />
-/// <reference path="../express-session/express-session.d.ts" />
-/// <reference path="../redis/redis.d.ts" />
+/// <reference types="express" />
+/// <reference types="express-session" />
+/// <reference types="redis" />
 
 declare module "connect-redis" {
     import * as express from "express";

--- a/connect-redis/tsconfig.json
+++ b/connect-redis/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "connect-redis-tests.ts"
+    ]
+}


### PR DESCRIPTION
`connect-redis` dependencies were not recognized, leading to missing `redis` typings error. I have migrated the file to use the `types` attribute of reference to fix the dependencies. 
