### PR TITLE
add length for io.sockets.adapter.rooms['foo']

### DIFF
--- a/socket.io/socket.io.d.ts
+++ b/socket.io/socket.io.d.ts
@@ -752,7 +752,7 @@ declare namespace SocketIO {
 		 * A dictionary of all the rooms that we have in this namespace
 		 * The rooms are made of a `sockets` key which is the dictionary of sockets per ID
 		 */
-		rooms: {[room: string]: {sockets: {[id: string]: boolean }}};
+		rooms: {[room: string]: {sockets: {[id: string]: boolean }, length: number }};
 
 		/**
 		 * A dictionary of all the socket ids that we're dealing with, and all


### PR DESCRIPTION
case 2. Improvement to existing type definition.

---

Check [kdbanman's answer](http://stackoverflow.com/questions/9352549/getting-how-many-people-are-in-a-chat-room-in-socket-io) (NOT sntran's) for socket.io 1.4.x:

When we get size of the room, we use like this:

``` ts
const room = io.sockets.adapter.rooms['foo'];
console.log(room.length);
```

Right now the `length` is missing.

Before fixing:
![image](https://cloud.githubusercontent.com/assets/3375461/18227769/9bf30906-71fd-11e6-9712-1697c301deba.png)

After fixing:
![image](https://cloud.githubusercontent.com/assets/3375461/18227766/897115ca-71fd-11e6-919e-3e0aad532cfd.png)
