### PR TITLE
Radium: Bump version to 0.18.1

### DIFF
--- a/radium/radium-tests.tsx
+++ b/radium/radium-tests.tsx
@@ -43,6 +43,12 @@ class TestComponentWithConfig extends React.Component<{ a?: number }, {}> {
                         }}
                         >
                     </Style>
+                    <Style scopeSelector="test"
+                        rules={{
+                            background: "green"
+                        }}
+                        >
+                    </Style>
                 </Radium.StyleRoot>
             </div>
         )

--- a/radium/radium.d.ts
+++ b/radium/radium.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for radium 0.17.1
+// Type definitions for radium 0.18.1
 // Project: https://github.com/formidablelabs/radium
-// Definitions by: Alex Gorbatchev <https://github.com/alexgorbatchev/>, Philipp Holzer <https://github.com/nupplaphil/>, Alexey Svetliakov <https://github.com/asvetliakov/>
+// Definitions by: Alex Gorbatchev <https://github.com/alexgorbatchev/>, Philipp Holzer <https://github.com/nupplaphil/>, Alexey Svetliakov <https://github.com/asvetliakov/>, Mikael Hermansson <https://github.com/mihe/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../react/react.d.ts"/>
@@ -19,10 +19,10 @@ declare module 'radium' {
          */
         export interface StyleProps {
             /**
-             * An object of CSS rules to render. Each key of the rules object is a CSS selector and the value is an object
-             * of styles. If rules is empty, the component will render nothing.
+             * An object of styles, or an object of CSS rules to render. Each key of the rules object is a CSS
+             * selector and the value is an object of styles. If rules is empty, the component will render nothing.
              */
-            rules: StyleRules;
+            rules: React.CSSProperties | StyleRules;
             /**
              * A string that any included selectors in rules will be appended to.
              * Use to scope styles in the component to a particular element. A good use case might be to generate a unique


### PR DESCRIPTION
Improvement to existing type definition:

[As can be seen here](https://github.com/FormidableLabs/radium/tree/master/docs/api#style-component), the `rules` property of `Radium.Style` can take `React.CSSProperties` as well as an object of CSS rules, which apparently has been in [since v0.17.1](https://github.com/FormidableLabs/radium/commit/28ce30588c4be188dda61073b6e9502956802edd).

I also went ahead and bumped the version number, since there [doesn't seem to be](https://github.com/FormidableLabs/radium/blob/9c61f148d51a611af24705fee7f4d9734d336526/CHANGELOG.md) any type-related changes since v0.17.1.
