### PR TITLE
Add colors enabled property

### DIFF
--- a/colors/colors-tests.ts
+++ b/colors/colors-tests.ts
@@ -3,9 +3,15 @@
 
 import colors = require("colors");
 
+colors.enabled = true;
+
 console.log(colors.black.underline('test'));
 console.log(colors.rainbow.black.blue.gray('test'));
 console.log(colors.random.reset.bgWhite.dim('test'));
 console.log('test'.black.underline);
 console.log('test'.rainbow.black.blue.gray);
 console.log('test'.random.reset.bgWhite.dim);
+
+colors.enabled = false;
+
+console.log(colors.black.underline('test'));

--- a/colors/colors.d.ts
+++ b/colors/colors.d.ts
@@ -47,6 +47,8 @@ declare module "colors" {
     namespace e {
         export function setTheme(theme:any): void;
 
+        export var enabled: boolean;
+
         export var black: Color;
         export var red: Color;
         export var green: Color;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

This PR add the `enabled` property on colors that allow to turn on/off colors.
As you can see [here](https://github.com/Marak/colors.js/blob/master/lib/colors.js#L39) as result of [that](https://github.com/Marak/colors.js/blob/master/lib/system/supports-colors.js#L28) and [here](https://github.com/Marak/colors.js/blob/master/lib/colors.js#L51), this property is a boolean.
It has been here since [1.0.0](https://github.com/Marak/colors.js/commit/dfb15b55382772ba4fd34fc21922a2d83e9d34d3#diff-97b2ad20b5254cedc6d5589dd680d3e5R41).
