### PR TITLE
Add possible null response from find one style functions for TS 2.0 (Sequelize) [types-2.0]

### DIFF
--- a/sequelize/index.d.ts
+++ b/sequelize/index.d.ts
@@ -56,7 +56,7 @@ declare namespace sequelize {
          * Get the associated instance.
          * @param options The options to use when getting the association.
          */
-        (options?: BelongsToGetAssociationMixinOptions): Promise<TInstance>;
+        (options?: BelongsToGetAssociationMixinOptions): Promise<TInstance | null>;
     }
 
     /**
@@ -170,7 +170,7 @@ declare namespace sequelize {
          * Get the associated instance.
          * @param options The options to use when getting the association.
          */
-        (options?: HasOneGetAssociationMixinOptions): Promise<TInstance>;
+        (options?: HasOneGetAssociationMixinOptions): Promise<TInstance | null>;
     }
 
     /**
@@ -3718,15 +3718,15 @@ declare namespace sequelize {
          * Search for a single instance by its primary key. This applies LIMIT 1, so the listener will
          * always be called with a single instance.
          */
-        findById(identifier?: number | string, options?: FindOptions): Promise<TInstance>;
-        findByPrimary(identifier?: number | string, options?: FindOptions): Promise<TInstance>;
+        findById(identifier?: number | string, options?: FindOptions): Promise<TInstance | null>;
+        findByPrimary(identifier?: number | string, options?: FindOptions): Promise<TInstance | null>;
 
         /**
          * Search for a single instance. This applies LIMIT 1, so the listener will always be called with a single
          * instance.
          */
-        findOne(options?: FindOptions): Promise<TInstance>;
-        find(options?: FindOptions): Promise<TInstance>;
+        findOne(options?: FindOptions): Promise<TInstance | null>;
+        find(options?: FindOptions): Promise<TInstance | null>;
 
         /**
          * Run an aggregation method on the specified field

--- a/sequelize/index.d.ts
+++ b/sequelize/index.d.ts
@@ -3052,7 +3052,7 @@ declare namespace sequelize {
      * typesafety, but there is no way to pass the tests if we just remove it.
      */
     interface WhereOptions {
-        [field: string]: string | number | WhereLogic | WhereOptions | col | and | or | WhereGeometryOptions | Array<string | number> | Object;
+        [field: string]: string | number | WhereLogic | WhereOptions | col | and | or | WhereGeometryOptions | Array<string | number> | Object | null;
     }
 
     /**


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

---

_Info from #10999_

When using TypeScript 2.0 with the latest `@types/sequelize` (3.4.32) there's an issue with return types. Find queries and mixins only show that there is a return type of `TInstance`, when there can be a `null` return from these methods. This can cause oversights when using `strictNullChecks`.

As an example, consider the following (incomplete) definition.

``` typescript
interface IUserInstance extends Sequelize.Instance<IUserAttributes>, IUserAttributes {
  getSomething: Sequelize.HasOneGetAssociationMixin<ISomethingInstance>;
}
```

If I were to try and use the model later, the typing is incorrect.

``` typescript
let something = await user.getSomething();
```

`something` will be of type `ISomethingInstance` instead of the expected `ISomethingInstance | null` as Sequelize will return `null` if there isn't actually a relation to anything.

The same is true with `findOne`/`find` queries.

``` typescript
let user = await UserModel.findOne();
```

The typing doesn't show this can return `null`.

All single return `Promise<TInstance>` querying functions have this issue and can return null.
Multi return `Promise<TInstance[]>` don't have any issue as they will return empty arrays when nothing is found, which is permissible per the typing.
