### PR TITLE
Adding S3.waitFor command to aws-sdk

### DIFF
--- a/aws-sdk/aws-sdk.d.ts
+++ b/aws-sdk/aws-sdk.d.ts
@@ -235,6 +235,7 @@ declare module "aws-sdk" {
     upload(params?: s3.PutObjectRequest, options?: s3.UploadOptions, callback?: (err: Error, data: any) => void): void;
     listObjects(params: s3.ListObjectRequest, callback: (err: Error, data: s3.ListObjectResponse) => void): void;
     listObjectsV2(params: s3.ListObjectV2Request, callback: (err: Error, data: s3.ListObjectV2Response) => void): void;
+    waitFor(state: string, params: s3.HeadObjectRequest, callback: (err: Error, data: any) => void): void;
   }
 
   export class STS {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

---

This PR adds a missing `waitFor` command to the `S3` interface under `aws-sdk`. [The associated documentation of this function can be found here.](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#waitFor-property)
