### PR TITLE
Adding typings for fs-extra-promise-es6 (sourced from fs-extra-promise) [types-2.0]

### DIFF
--- a/fs-extra-promise-es6/fs-extra-promise-es6-tests.ts
+++ b/fs-extra-promise-es6/fs-extra-promise-es6-tests.ts
@@ -217,12 +217,10 @@ readStreeam = fs.createReadStream(path, {
 	flags: str,
 	encoding: str,
 	fd: num,
-	mode: num,
-	bufferSize: num
+	mode: num
 });
 writeStream = fs.createWriteStream(path);
 writeStream = fs.createWriteStream(path, {
 	flags: str,
-	encoding: str,
-	string: str
+	encoding: str
 });

--- a/fs-extra-promise-es6/fs-extra-promise-es6-tests.ts
+++ b/fs-extra-promise-es6/fs-extra-promise-es6-tests.ts
@@ -1,0 +1,228 @@
+/// <reference types="node" />
+
+import fs = require('fs-extra-promise-es6');
+import stream = require('stream');
+
+var stats: fs.Stats;
+var str: string;
+var strArr: string[];
+var bool: boolean;
+var num: number;
+var src: string;
+var dest: string;
+var file: string;
+var filename: string;
+var dir: string;
+var path: string;
+var data: any;
+var object: Object;
+var buffer: NodeBuffer;
+var modeNum: number;
+var modeStr: string;
+var encoding: string;
+var type: string;
+var flags: string;
+var srcpath: string;
+var dstpath: string;
+var oldPath: string;
+var newPath: string;
+var cache: string;
+var offset: number;
+var length: number;
+var position: number;
+var cacheBool: boolean;
+var cacheStr: string;
+var fd: number;
+var len: number;
+var uid: number;
+var gid: number;
+var atime: number;
+var mtime: number;
+var statsCallback: (err: Error, stats: fs.Stats) => void;
+var errorCallback: (err: Error) => void;
+var openOpts: fs.OpenOptions;
+var watcher: fs.FSWatcher;
+var readStreeam: stream.Readable;
+var writeStream: stream.Writable;
+
+fs.copy(src, dest, errorCallback);
+fs.copy(src, dest, (src: string) => {
+	return false;
+}, errorCallback);
+fs.copySync(src, dest);
+fs.copySync(src, dest, (src: string) => {
+	return false;
+});
+fs.createFile(file, errorCallback);
+fs.createFileSync(file);
+
+fs.mkdirs(dir, errorCallback);
+fs.mkdirsSync(dir);
+fs.mkdirp(dir, errorCallback);
+fs.mkdirpSync(dir);
+
+fs.outputFile(file, data, errorCallback);
+fs.outputFileSync(file, data);
+fs.outputJson(file, data, errorCallback);
+fs.outputJSON(file, data, errorCallback);
+
+fs.outputJsonSync(file, data);
+fs.outputJSONSync(file, data);
+
+fs.readJson(file, errorCallback);
+fs.readJson(file, openOpts, errorCallback);
+fs.readJSON(file, errorCallback);
+fs.readJSON(file, openOpts, errorCallback);
+
+fs.readJsonSync(file, openOpts);
+fs.readJSONSync(file, openOpts);
+
+fs.remove(dir, errorCallback);
+fs.removeSync(dir);
+
+fs.writeJson(file, object, errorCallback);
+fs.writeJson(file, object, openOpts, errorCallback);
+fs.writeJSON(file, object, errorCallback);
+fs.writeJSON(file, object, openOpts, errorCallback);
+
+fs.writeJsonSync(file, object, openOpts);
+fs.writeJSONSync(file, object, openOpts);
+
+fs.rename(oldPath, newPath, errorCallback);
+fs.renameSync(oldPath, newPath);
+fs.truncate(fd, len, errorCallback);
+fs.truncateSync(fd, len);
+fs.chown(path, uid, gid, errorCallback);
+fs.chownSync(path, uid, gid);
+fs.fchown(fd, uid, gid, errorCallback);
+fs.fchownSync(fd, uid, gid);
+fs.lchown(path, uid, gid, errorCallback);
+fs.lchownSync(path, uid, gid);
+fs.chmod(path, modeNum, errorCallback);
+fs.chmod(path, modeStr, errorCallback);
+fs.chmodSync(path, modeNum);
+fs.chmodSync(path, modeStr);
+fs.fchmod(fd, modeNum, errorCallback);
+fs.fchmod(fd, modeStr, errorCallback);
+fs.fchmodSync(fd, modeNum);
+fs.fchmodSync(fd, modeStr);
+fs.lchmod(path, modeStr, errorCallback);
+fs.lchmod(path, modeNum, errorCallback);
+fs.lchmodSync(path, modeNum);
+fs.lchmodSync(path, modeStr);
+fs.stat(path, statsCallback);
+fs.lstat(path, statsCallback);
+fs.fstat(fd, statsCallback);
+stats = fs.statSync(path);
+stats = fs.lstatSync(path);
+stats = fs.fstatSync(fd);
+fs.link(srcpath, dstpath, errorCallback);
+fs.linkSync(srcpath, dstpath);
+fs.symlink(srcpath, dstpath, type, errorCallback);
+fs.symlinkSync(srcpath, dstpath, type);
+fs.readlink(path, (err: Error, linkString: string) => {
+
+});
+fs.realpath(path, (err: Error, resolvedPath: string) => {
+
+});
+fs.realpath(path, cache, (err: Error, resolvedPath: string) => {
+
+});
+str = fs.realpathSync(path, cacheBool);
+fs.unlink(path, errorCallback);
+fs.unlinkSync(path);
+fs.rmdir(path, errorCallback);
+fs.rmdirSync(path);
+fs.mkdir(path, modeNum, errorCallback);
+fs.mkdir(path, modeStr, errorCallback);
+fs.mkdirSync(path, modeNum);
+fs.mkdirSync(path, modeStr);
+fs.readdir(path, (err: Error, files: string[]) => {
+
+});
+strArr = fs.readdirSync(path);
+fs.close(fd, errorCallback);
+fs.closeSync(fd);
+fs.open(path, flags, modeStr, (err: Error, fd: number) => {
+    
+});
+num = fs.openSync(path, flags, modeStr);
+fs.utimes(path, atime, mtime, errorCallback);
+fs.utimesSync(path, atime, mtime);
+fs.futimes(fd, atime, mtime, errorCallback);
+fs.futimesSync(fd, atime, mtime);
+fs.fsync(fd, errorCallback);
+fs.fsyncSync(fd);
+fs.write(fd, buffer, offset, length, position, (err: Error, written: number, buffer: NodeBuffer) => {
+
+});
+num = fs.writeSync(fd, buffer, offset, length, position);
+fs.read(fd, buffer, offset, length, position, (err: Error, bytesRead: number, buffer: NodeBuffer) => {
+
+});
+num = fs.readSync(fd, buffer, offset, length, position);
+fs.readFile(filename, (err: Error, data: NodeBuffer) => {
+
+});
+fs.readFile(filename, encoding, (err: Error, data: string) => {
+
+});
+fs.readFile(filename, openOpts, (err: Error, data: string) => {
+
+});
+fs.readFile(filename, (err: Error, data: NodeBuffer) => {
+
+});
+buffer = fs.readFileSync(filename);
+str = fs.readFileSync(filename, encoding);
+str = fs.readFileSync(filename, openOpts);
+
+fs.writeFile(filename, data, errorCallback);
+fs.writeFile(filename, data, encoding, errorCallback);
+fs.writeFile(filename, data, openOpts, errorCallback);
+fs.writeFileSync(filename, data);
+fs.writeFileSync(filename, data, encoding);
+fs.writeFileSync(filename, data, openOpts);
+
+fs.appendFile(filename, data, errorCallback);
+fs.appendFile(filename, data, encoding, errorCallback);
+fs.appendFile(filename, data, openOpts, errorCallback);
+fs.appendFileSync(filename, data);
+fs.appendFileSync(filename, data, encoding);
+fs.appendFileSync(filename, data, openOpts);
+
+fs.watchFile(filename, {
+	curr: stats,
+	prev: stats
+});
+fs.watchFile(filename, {
+	persistent: bool,
+	interval: num
+}, {
+	curr: stats,
+	prev: stats
+});
+fs.unwatchFile(filename);
+watcher = fs.watch(filename, { persistent: bool }, (event: string, filename: string) => {
+
+});
+fs.exists(path, (exists: boolean) => {
+
+});
+bool = fs.existsSync(path);
+
+readStreeam = fs.createReadStream(path);
+readStreeam = fs.createReadStream(path, {
+	flags: str,
+	encoding: str,
+	fd: num,
+	mode: num,
+	bufferSize: num
+});
+writeStream = fs.createWriteStream(path);
+writeStream = fs.createWriteStream(path, {
+	flags: str,
+	encoding: str,
+	string: str
+});

--- a/fs-extra-promise-es6/index.d.ts
+++ b/fs-extra-promise-es6/index.d.ts
@@ -9,29 +9,7 @@
 
 
 import stream = require("stream");
-
-export interface Stats {
-    isFile(): boolean;
-    isDirectory(): boolean;
-    isBlockDevice(): boolean;
-    isCharacterDevice(): boolean;
-    isSymbolicLink(): boolean;
-    isFIFO(): boolean;
-    isSocket(): boolean;
-    dev: number;
-    ino: number;
-    mode: number;
-    nlink: number;
-    uid: number;
-    gid: number;
-    rdev: number;
-    size: number;
-    blksize: number;
-    blocks: number;
-    atime: Date;
-    mtime: Date;
-    ctime: Date;
-}
+import fs = require("fs");
 
 export interface FSWatcher {
     close(): void;
@@ -106,12 +84,12 @@ export declare function lchmod(path: string, mode: string, callback?: (err: Erro
 export declare function lchmod(path: string, mode: number, callback?: (err: Error) => void): void;
 export declare function lchmodSync(path: string, mode: number): void;
 export declare function lchmodSync(path: string, mode: string): void;
-export declare function stat(path: string, callback?: (err: Error, stats: Stats) => void): void;
-export declare function lstat(path: string, callback?: (err: Error, stats: Stats) => void): void;
-export declare function fstat(fd: number, callback?: (err: Error, stats: Stats) => void): void;
-export declare function statSync(path: string): Stats;
-export declare function lstatSync(path: string): Stats;
-export declare function fstatSync(fd: number): Stats;
+export declare function stat(path: string, callback?: (err: Error, stats: fs.Stats) => void): void;
+export declare function lstat(path: string, callback?: (err: Error, stats: fs.Stats) => void): void;
+export declare function fstat(fd: number, callback?: (err: Error, stats: fs.Stats) => void): void;
+export declare function statSync(path: string): fs.Stats;
+export declare function lstatSync(path: string): fs.Stats;
+export declare function fstatSync(fd: number): fs.Stats;
 export declare function link(srcpath: string, dstpath: string, callback?: (err: Error) => void): void;
 export declare function linkSync(srcpath: string, dstpath: string): void;
 export declare function symlink(srcpath: string, dstpath: string, type?: string, callback?: (err: Error) => void): void;
@@ -158,9 +136,9 @@ export declare function appendFile(filename: string, data: any, encoding?: strin
 export declare function appendFile(filename: string, data: any, option?: OpenOptions, callback?: (err: Error) => void): void;
 export declare function appendFileSync(filename: string, data: any, encoding?: string): void;
 export declare function appendFileSync(filename: string, data: any, option?: OpenOptions): void;
-export declare function watchFile(filename: string, listener: { curr: Stats; prev: Stats; }): void;
-export declare function watchFile(filename: string, options: { persistent?: boolean; interval?: number; }, listener: { curr: Stats; prev: Stats; }): void;
-export declare function unwatchFile(filename: string, listener?: Stats): void;
+export declare function watchFile(filename: string, listener: { curr: fs.Stats; prev: fs.Stats; }): void;
+export declare function watchFile(filename: string, options: { persistent?: boolean; interval?: number; }, listener: { curr: fs.Stats; prev: fs.Stats; }): void;
+export declare function unwatchFile(filename: string, listener?: fs.Stats): void;
 export declare function watch(filename: string, options?: { persistent?: boolean; }, listener?: (event: string, filename: string) => any): FSWatcher;
 export declare function exists(path: string, callback?: (exists: boolean) => void): void;
 export declare function existsSync(path: string): boolean;
@@ -172,20 +150,21 @@ export interface OpenOptions {
     flag?: string;
 }
 
-export interface ReadStreamOptions {
+export declare function createReadStream(path: string | Buffer, options?: {
     flags?: string;
     encoding?: string;
     fd?: number;
     mode?: number;
-    bufferSize?: number;
-}
-export interface WriteStreamOptions {
+    autoClose?: boolean;
+    start?: number;
+    end?: number;
+}): ReadStream;
+export declare function createWriteStream(path: string | Buffer, options?: {
     flags?: string;
     encoding?: string;
-    string?: string;
-}
-export declare function createReadStream(path: string, options?: ReadStreamOptions): ReadStream;
-export declare function createWriteStream(path: string, options?: WriteStreamOptions): WriteStream;
+    fd?: number;
+    mode?: number;
+}): WriteStream;
 
 
 
@@ -228,9 +207,9 @@ export declare function fchmodAsync(fd: number, mode: number): Promise<void>;
 export declare function fchmodAsync(fd: number, mode: string): Promise<void>;
 export declare function lchmodAsync(path: string, mode: string): Promise<void>;
 export declare function lchmodAsync(path: string, mode: number): Promise<void>;
-export declare function statAsync(path: string): Promise<Stats>;
-export declare function lstatAsync(path: string): Promise<Stats>;
-export declare function fstatAsync(fd: number): Promise<Stats>;
+export declare function statAsync(path: string): Promise<fs.Stats>;
+export declare function lstatAsync(path: string): Promise<fs.Stats>;
+export declare function fstatAsync(fd: number): Promise<fs.Stats>;
 export declare function linkAsync(srcpath: string, dstpath: string): Promise<void>;
 export declare function symlinkAsync(srcpath: string, dstpath: string, type?: string): Promise<void>;
 export declare function readlinkAsync(path: string): Promise<string>;

--- a/fs-extra-promise-es6/index.d.ts
+++ b/fs-extra-promise-es6/index.d.ts
@@ -1,0 +1,260 @@
+// Type definitions for fs-extra-promise-es6
+// Project: https://github.com/vinsonchuong/fs-extra-promise-es6
+// Definitions by: midknight41 <https://github.com/midknight41>, Jason Swearingen <https://github.com/jasonswearingen>, Joshua DeVinney <https://github.com/geoffreak>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Imported from: fs-extra-promise typings (minus Bluebird)
+
+///<reference types="node"/>
+
+
+import stream = require("stream");
+
+export interface Stats {
+    isFile(): boolean;
+    isDirectory(): boolean;
+    isBlockDevice(): boolean;
+    isCharacterDevice(): boolean;
+    isSymbolicLink(): boolean;
+    isFIFO(): boolean;
+    isSocket(): boolean;
+    dev: number;
+    ino: number;
+    mode: number;
+    nlink: number;
+    uid: number;
+    gid: number;
+    rdev: number;
+    size: number;
+    blksize: number;
+    blocks: number;
+    atime: Date;
+    mtime: Date;
+    ctime: Date;
+}
+
+export interface FSWatcher {
+    close(): void;
+}
+
+export declare class ReadStream extends stream.Readable { }
+export declare class WriteStream extends stream.Writable { }
+
+//extended methods
+export declare function copy(src: string, dest: string, callback?: (err: Error) => void): void;
+export declare function copy(src: string, dest: string, filter: (src: string) => boolean, callback?: (err: Error) => void): void;
+
+export declare function copySync(src: string, dest: string): void;
+export declare function copySync(src: string, dest: string, filter: (src: string) => boolean): void;
+
+export declare function createFile(file: string, callback?: (err: Error) => void): void;
+export declare function createFileSync(file: string): void;
+
+export declare function mkdirs(dir: string, callback?: (err: Error) => void): void;
+export declare function mkdirp(dir: string, callback?: (err: Error) => void): void;
+export declare function mkdirsSync(dir: string): void;
+export declare function mkdirpSync(dir: string): void;
+
+export declare function outputFile(file: string, data: any, callback?: (err: Error) => void): void;
+export declare function outputFileSync(file: string, data: any): void;
+
+export declare function outputJson(file: string, data: any, callback?: (err: Error) => void): void;
+export declare function outputJSON(file: string, data: any, callback?: (err: Error) => void): void;
+export declare function outputJsonSync(file: string, data: any): void;
+export declare function outputJSONSync(file: string, data: any): void;
+
+export declare function readJson(file: string, callback?: (err: Error) => void): void;
+export declare function readJson(file: string, options?: OpenOptions, callback?: (err: Error) => void): void;
+export declare function readJSON(file: string, callback?: (err: Error) => void): void;
+export declare function readJSON(file: string, options?: OpenOptions, callback?: (err: Error) => void): void;
+
+export declare function readJsonSync(file: string, options?: OpenOptions): void;
+export declare function readJSONSync(file: string, options?: OpenOptions): void;
+
+export declare function remove(dir: string, callback?: (err: Error) => void): void;
+export declare function removeSync(dir: string): void;
+// export function delete(dir: string, callback?: (err: Error) => void): void;
+// export function deleteSync(dir: string): void;
+
+export declare function writeJson(file: string, object: any, callback?: (err: Error) => void): void;
+export declare function writeJson(file: string, object: any, options?: OpenOptions, callback?: (err: Error) => void): void;
+export declare function writeJSON(file: string, object: any, callback?: (err: Error) => void): void;
+export declare function writeJSON(file: string, object: any, options?: OpenOptions, callback?: (err: Error) => void): void;
+
+export declare function writeJsonSync(file: string, object: any, options?: OpenOptions): void;
+export declare function writeJSONSync(file: string, object: any, options?: OpenOptions): void;
+
+export declare function rename(oldPath: string, newPath: string, callback?: (err: Error) => void): void;
+export declare function renameSync(oldPath: string, newPath: string): void;
+export declare function truncate(fd: number, len: number, callback?: (err: Error) => void): void;
+export declare function truncateSync(fd: number, len: number): void;
+export declare function chown(path: string, uid: number, gid: number, callback?: (err: Error) => void): void;
+export declare function chownSync(path: string, uid: number, gid: number): void;
+export declare function fchown(fd: number, uid: number, gid: number, callback?: (err: Error) => void): void;
+export declare function fchownSync(fd: number, uid: number, gid: number): void;
+export declare function lchown(path: string, uid: number, gid: number, callback?: (err: Error) => void): void;
+export declare function lchownSync(path: string, uid: number, gid: number): void;
+export declare function chmod(path: string, mode: number, callback?: (err: Error) => void): void;
+export declare function chmod(path: string, mode: string, callback?: (err: Error) => void): void;
+export declare function chmodSync(path: string, mode: number): void;
+export declare function chmodSync(path: string, mode: string): void;
+export declare function fchmod(fd: number, mode: number, callback?: (err: Error) => void): void;
+export declare function fchmod(fd: number, mode: string, callback?: (err: Error) => void): void;
+export declare function fchmodSync(fd: number, mode: number): void;
+export declare function fchmodSync(fd: number, mode: string): void;
+export declare function lchmod(path: string, mode: string, callback?: (err: Error) => void): void;
+export declare function lchmod(path: string, mode: number, callback?: (err: Error) => void): void;
+export declare function lchmodSync(path: string, mode: number): void;
+export declare function lchmodSync(path: string, mode: string): void;
+export declare function stat(path: string, callback?: (err: Error, stats: Stats) => void): void;
+export declare function lstat(path: string, callback?: (err: Error, stats: Stats) => void): void;
+export declare function fstat(fd: number, callback?: (err: Error, stats: Stats) => void): void;
+export declare function statSync(path: string): Stats;
+export declare function lstatSync(path: string): Stats;
+export declare function fstatSync(fd: number): Stats;
+export declare function link(srcpath: string, dstpath: string, callback?: (err: Error) => void): void;
+export declare function linkSync(srcpath: string, dstpath: string): void;
+export declare function symlink(srcpath: string, dstpath: string, type?: string, callback?: (err: Error) => void): void;
+export declare function symlinkSync(srcpath: string, dstpath: string, type?: string): void;
+export declare function readlink(path: string, callback?: (err: Error, linkString: string) => void): void;
+export declare function realpath(path: string, callback?: (err: Error, resolvedPath: string) => void): void;
+export declare function realpath(path: string, cache: string, callback: (err: Error, resolvedPath: string) => void): void;
+export declare function realpathSync(path: string, cache?: boolean): string;
+export declare function unlink(path: string, callback?: (err: Error) => void): void;
+export declare function unlinkSync(path: string): void;
+export declare function rmdir(path: string, callback?: (err: Error) => void): void;
+export declare function rmdirSync(path: string): void;
+export declare function mkdir(path: string, mode?: number, callback?: (err: Error) => void): void;
+export declare function mkdir(path: string, mode?: string, callback?: (err: Error) => void): void;
+export declare function mkdirSync(path: string, mode?: number): void;
+export declare function mkdirSync(path: string, mode?: string): void;
+export declare function readdir(path: string, callback?: (err: Error, files: string[]) => void): void;
+export declare function readdirSync(path: string): string[];
+export declare function close(fd: number, callback?: (err: Error) => void): void;
+export declare function closeSync(fd: number): void;
+export declare function open(path: string, flags: string, mode?: string, callback?: (err: Error, fs: number) => void): void;
+export declare function openSync(path: string, flags: string, mode?: string): number;
+export declare function utimes(path: string, atime: number, mtime: number, callback?: (err: Error) => void): void;
+export declare function utimesSync(path: string, atime: number, mtime: number): void;
+export declare function futimes(fd: number, atime: number, mtime: number, callback?: (err: Error) => void): void;
+export declare function futimesSync(fd: number, atime: number, mtime: number): void;
+export declare function fsync(fd: number, callback?: (err: Error) => void): void;
+export declare function fsyncSync(fd: number): void;
+export declare function write(fd: number, buffer: NodeBuffer, offset: number, length: number, position: number, callback?: (err: Error, written: number, buffer: NodeBuffer) => void): void;
+export declare function writeSync(fd: number, buffer: NodeBuffer, offset: number, length: number, position: number): number;
+export declare function read(fd: number, buffer: NodeBuffer, offset: number, length: number, position: number, callback?: (err: Error, bytesRead: number, buffer: NodeBuffer) => void): void;
+export declare function readSync(fd: number, buffer: NodeBuffer, offset: number, length: number, position: number): number;
+export declare function readFile(filename: string, encoding: string, callback: (err: Error, data: string) => void): void;
+export declare function readFile(filename: string, options: OpenOptions, callback: (err: Error, data: string) => void): void;
+export declare function readFile(filename: string, callback: (err: Error, data: NodeBuffer) => void): void;
+export declare function readFileSync(filename: string): NodeBuffer;
+export declare function readFileSync(filename: string, encoding: string): string;
+export declare function readFileSync(filename: string, options: OpenOptions): string;
+export declare function writeFile(filename: string, data: any, encoding?: string, callback?: (err: Error) => void): void;
+export declare function writeFile(filename: string, data: any, options?: OpenOptions, callback?: (err: Error) => void): void;
+export declare function writeFileSync(filename: string, data: any, encoding?: string): void;
+export declare function writeFileSync(filename: string, data: any, option?: OpenOptions): void;
+export declare function appendFile(filename: string, data: any, encoding?: string, callback?: (err: Error) => void): void;
+export declare function appendFile(filename: string, data: any, option?: OpenOptions, callback?: (err: Error) => void): void;
+export declare function appendFileSync(filename: string, data: any, encoding?: string): void;
+export declare function appendFileSync(filename: string, data: any, option?: OpenOptions): void;
+export declare function watchFile(filename: string, listener: { curr: Stats; prev: Stats; }): void;
+export declare function watchFile(filename: string, options: { persistent?: boolean; interval?: number; }, listener: { curr: Stats; prev: Stats; }): void;
+export declare function unwatchFile(filename: string, listener?: Stats): void;
+export declare function watch(filename: string, options?: { persistent?: boolean; }, listener?: (event: string, filename: string) => any): FSWatcher;
+export declare function exists(path: string, callback?: (exists: boolean) => void): void;
+export declare function existsSync(path: string): boolean;
+export declare function ensureDir(path: string, cb: (err: Error) => void): void;
+export declare function ensureDirSync(path: string): void;
+
+export interface OpenOptions {
+    encoding?: string;
+    flag?: string;
+}
+
+export interface ReadStreamOptions {
+    flags?: string;
+    encoding?: string;
+    fd?: number;
+    mode?: number;
+    bufferSize?: number;
+}
+export interface WriteStreamOptions {
+    flags?: string;
+    encoding?: string;
+    string?: string;
+}
+export declare function createReadStream(path: string, options?: ReadStreamOptions): ReadStream;
+export declare function createWriteStream(path: string, options?: WriteStreamOptions): WriteStream;
+
+
+
+//promisified versions
+export declare function copyAsync(src: string, dest: string): Promise<void>;
+export declare function copyAsync(src: string, dest: string, filter: (src: string) => boolean): Promise<void>;
+
+export declare function createFileAsync(file: string): Promise<void>;
+
+export declare function mkdirsAsync(dir: string): Promise<void>;
+export declare function mkdirpAsync(dir: string): Promise<void>;
+
+export declare function outputFileAsync(file: string, data: any): Promise<void>;
+
+export declare function outputJsonAsync(file: string, data: any): Promise<void>;
+export declare function outputJSONAsync(file: string, data: any): Promise<void>;
+
+export declare function readJsonAsync(file: string): Promise<void>;
+export declare function readJsonAsync(file: string, options?: OpenOptions): Promise<void>;
+export declare function readJSONAsync(file: string): Promise<void>;
+export declare function readJSONAsync(file: string, options?: OpenOptions): Promise<void>;
+
+
+export declare function removeAsync(dir: string): Promise<void>;
+// export function deleteAsync(dir: string):Promise<void>;
+
+export declare function writeJsonAsync(file: string, object: any): Promise<void>;
+export declare function writeJsonAsync(file: string, object: any, options?: OpenOptions): Promise<void>;
+export declare function writeJSONAsync(file: string, object: any): Promise<void>;
+export declare function writeJSONAsync(file: string, object: any, options?: OpenOptions): Promise<void>;
+
+export declare function renameAsync(oldPath: string, newPath: string): Promise<void>;
+export declare function truncateAsync(fd: number, len: number): Promise<void>;
+export declare function chownAsync(path: string, uid: number, gid: number): Promise<void>;
+export declare function fchownAsync(fd: number, uid: number, gid: number): Promise<void>;
+export declare function lchownAsync(path: string, uid: number, gid: number): Promise<void>;
+export declare function chmodAsync(path: string, mode: number): Promise<void>;
+export declare function chmodAsync(path: string, mode: string): Promise<void>;
+export declare function fchmodAsync(fd: number, mode: number): Promise<void>;
+export declare function fchmodAsync(fd: number, mode: string): Promise<void>;
+export declare function lchmodAsync(path: string, mode: string): Promise<void>;
+export declare function lchmodAsync(path: string, mode: number): Promise<void>;
+export declare function statAsync(path: string): Promise<Stats>;
+export declare function lstatAsync(path: string): Promise<Stats>;
+export declare function fstatAsync(fd: number): Promise<Stats>;
+export declare function linkAsync(srcpath: string, dstpath: string): Promise<void>;
+export declare function symlinkAsync(srcpath: string, dstpath: string, type?: string): Promise<void>;
+export declare function readlinkAsync(path: string): Promise<string>;
+export declare function realpathAsync(path: string): Promise<string>;
+export declare function realpathAsync(path: string, cache: string): Promise<string>;
+export declare function unlinkAsync(path: string): Promise<void>;
+export declare function rmdirAsync(path: string): Promise<void>;
+export declare function mkdirAsync(path: string, mode?: number): Promise<void>;
+export declare function mkdirAsync(path: string, mode?: string): Promise<void>;
+export declare function readdirAsync(path: string): Promise<string[]>;
+export declare function closeAsync(fd: number): Promise<void>;
+export declare function openAsync(path: string, flags: string, mode?: string): Promise<number>;
+export declare function utimesAsync(path: string, atime: number, mtime: number): Promise<void>;
+export declare function futimesAsync(fd: number, atime: number, mtime: number): Promise<void>;
+export declare function fsyncAsync(fd: number): Promise<void>;
+export declare function writeAsync(fd: number, buffer: NodeBuffer, offset: number, length: number, position: number): Promise<[number, NodeBuffer]>;
+export declare function readAsync(fd: number, buffer: NodeBuffer, offset: number, length: number, position: number): Promise<[number, NodeBuffer]>;
+export declare function readFileAsync(filename: string, encoding: string): Promise<string>;
+export declare function readFileAsync(filename: string, options: OpenOptions): Promise<string>;
+export declare function readFileAsync(filename: string): Promise<NodeBuffer>;
+export declare function writeFileAsync(filename: string, data: any, encoding?: string): Promise<void>;
+export declare function writeFileAsync(filename: string, data: any, options?: OpenOptions): Promise<void>;
+export declare function appendFileAsync(filename: string, data: any, encoding?: string): Promise<void>;
+export declare function appendFileAsync(filename: string, data: any, option?: OpenOptions): Promise<void>;
+
+export declare function existsAsync(path: string): Promise<boolean>;
+export declare function ensureDirAsync(path: string): Promise<void>;

--- a/fs-extra-promise-es6/index.d.ts
+++ b/fs-extra-promise-es6/index.d.ts
@@ -11,8 +11,7 @@
 import stream = require("stream");
 import fs = require("fs");
 
-export interface Stats extends fs.Stats {
-}
+export type Stats = fs.Stats
 
 export interface FSWatcher {
     close(): void;

--- a/fs-extra-promise-es6/index.d.ts
+++ b/fs-extra-promise-es6/index.d.ts
@@ -11,6 +11,9 @@
 import stream = require("stream");
 import fs = require("fs");
 
+export interface Stats extends fs.Stats {
+}
+
 export interface FSWatcher {
     close(): void;
 }
@@ -84,12 +87,12 @@ export declare function lchmod(path: string, mode: string, callback?: (err: Erro
 export declare function lchmod(path: string, mode: number, callback?: (err: Error) => void): void;
 export declare function lchmodSync(path: string, mode: number): void;
 export declare function lchmodSync(path: string, mode: string): void;
-export declare function stat(path: string, callback?: (err: Error, stats: fs.Stats) => void): void;
-export declare function lstat(path: string, callback?: (err: Error, stats: fs.Stats) => void): void;
-export declare function fstat(fd: number, callback?: (err: Error, stats: fs.Stats) => void): void;
-export declare function statSync(path: string): fs.Stats;
-export declare function lstatSync(path: string): fs.Stats;
-export declare function fstatSync(fd: number): fs.Stats;
+export declare function stat(path: string, callback?: (err: Error, stats: Stats) => void): void;
+export declare function lstat(path: string, callback?: (err: Error, stats: Stats) => void): void;
+export declare function fstat(fd: number, callback?: (err: Error, stats: Stats) => void): void;
+export declare function statSync(path: string): Stats;
+export declare function lstatSync(path: string): Stats;
+export declare function fstatSync(fd: number): Stats;
 export declare function link(srcpath: string, dstpath: string, callback?: (err: Error) => void): void;
 export declare function linkSync(srcpath: string, dstpath: string): void;
 export declare function symlink(srcpath: string, dstpath: string, type?: string, callback?: (err: Error) => void): void;
@@ -136,9 +139,9 @@ export declare function appendFile(filename: string, data: any, encoding?: strin
 export declare function appendFile(filename: string, data: any, option?: OpenOptions, callback?: (err: Error) => void): void;
 export declare function appendFileSync(filename: string, data: any, encoding?: string): void;
 export declare function appendFileSync(filename: string, data: any, option?: OpenOptions): void;
-export declare function watchFile(filename: string, listener: { curr: fs.Stats; prev: fs.Stats; }): void;
-export declare function watchFile(filename: string, options: { persistent?: boolean; interval?: number; }, listener: { curr: fs.Stats; prev: fs.Stats; }): void;
-export declare function unwatchFile(filename: string, listener?: fs.Stats): void;
+export declare function watchFile(filename: string, listener: { curr: Stats; prev: Stats; }): void;
+export declare function watchFile(filename: string, options: { persistent?: boolean; interval?: number; }, listener: { curr: Stats; prev: Stats; }): void;
+export declare function unwatchFile(filename: string, listener?: Stats): void;
 export declare function watch(filename: string, options?: { persistent?: boolean; }, listener?: (event: string, filename: string) => any): FSWatcher;
 export declare function exists(path: string, callback?: (exists: boolean) => void): void;
 export declare function existsSync(path: string): boolean;
@@ -207,9 +210,9 @@ export declare function fchmodAsync(fd: number, mode: number): Promise<void>;
 export declare function fchmodAsync(fd: number, mode: string): Promise<void>;
 export declare function lchmodAsync(path: string, mode: string): Promise<void>;
 export declare function lchmodAsync(path: string, mode: number): Promise<void>;
-export declare function statAsync(path: string): Promise<fs.Stats>;
-export declare function lstatAsync(path: string): Promise<fs.Stats>;
-export declare function fstatAsync(fd: number): Promise<fs.Stats>;
+export declare function statAsync(path: string): Promise<Stats>;
+export declare function lstatAsync(path: string): Promise<Stats>;
+export declare function fstatAsync(fd: number): Promise<Stats>;
 export declare function linkAsync(srcpath: string, dstpath: string): Promise<void>;
 export declare function symlinkAsync(srcpath: string, dstpath: string, type?: string): Promise<void>;
 export declare function readlinkAsync(path: string): Promise<string>;

--- a/fs-extra-promise-es6/tsconfig.json
+++ b/fs-extra-promise-es6/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "fs-extra-promise-es6-tests.ts"
+    ]
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

---

Definitions for [`fs-extra-promise-es6`](https://github.com/vinsonchuong/fs-extra-promise-es6). Typings borrowed and tweaked from `fs-extra-promise`, which has the same API, but uses Bluebird instead of native promises.
