### PR TITLE
s3-upload-stream typing [types-2.0]

### DIFF
--- a/s3-upload-stream/index.d.ts
+++ b/s3-upload-stream/index.d.ts
@@ -4,23 +4,19 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
-/// <reference path="../aws-sdk/index.d.ts" />
+/// <reference types="aws-sdk" />
 
 import * as stream from 'stream';
 import * as AWS from 'aws-sdk';
 
-interface IS3Stream {
-    (client: AWS.S3): IS3StreamUploader
+interface S3StreamUploader {
+    upload(destinationDetails: AWS.s3.PutObjectRequest, sessionDetails?: any): S3WriteStream;
 }
 
-interface IS3StreamUploader {
-    upload(destinationDetails: AWS.s3.PutObjectRequest, sessionDetails?: any): IS3WriteStream;
-}
-
-interface IS3WriteStream extends stream.Writable {
+interface S3WriteStream extends stream.Writable {
     maxPartSize(sizeInBytes: number): void;
     concurrentParts(numberOfParts: number): void;
 }
 
-declare var s3Stream: IS3Stream;
+declare function s3Stream(client: AWS.S3): S3StreamUploader;
 export = s3Stream;

--- a/s3-upload-stream/index.d.ts
+++ b/s3-upload-stream/index.d.ts
@@ -9,14 +9,16 @@
 import * as stream from 'stream';
 import * as AWS from 'aws-sdk';
 
-interface S3StreamUploader {
-    upload(destinationDetails: AWS.s3.PutObjectRequest, sessionDetails?: any): S3WriteStream;
+declare namespace s3Stream {
+    export interface S3StreamUploader {
+        upload(destinationDetails: AWS.s3.PutObjectRequest, sessionDetails?: any): S3WriteStream;
+    }
+
+    export interface S3WriteStream extends stream.Writable {
+        maxPartSize(sizeInBytes: number): void;
+        concurrentParts(numberOfParts: number): void;
+    }
 }
 
-interface S3WriteStream extends stream.Writable {
-    maxPartSize(sizeInBytes: number): void;
-    concurrentParts(numberOfParts: number): void;
-}
-
-declare function s3Stream(client: AWS.S3): S3StreamUploader;
+declare function s3Stream(client: AWS.S3): s3Stream.S3StreamUploader;
 export = s3Stream;

--- a/s3-upload-stream/index.d.ts
+++ b/s3-upload-stream/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for s3-upload-stream
+// Project: https://github.com/nathanpeck/s3-upload-stream
+// Definitions by: Joshua DeVinney <https://github.com/geoffreak>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+/// <reference path="../aws-sdk/index.d.ts" />
+
+import * as stream from 'stream';
+import * as AWS from 'aws-sdk';
+
+interface IS3Stream {
+    (client: AWS.S3): IS3StreamUploader
+}
+
+interface IS3StreamUploader {
+    upload(destinationDetails: AWS.s3.PutObjectRequest, sessionDetails?: any): IS3WriteStream;
+}
+
+interface IS3WriteStream extends stream.Writable {
+    maxPartSize(sizeInBytes: number): void;
+    concurrentParts(numberOfParts: number): void;
+}
+
+declare var s3Stream: IS3Stream;
+export = s3Stream;

--- a/s3-upload-stream/s3-upload-stream-tests.ts
+++ b/s3-upload-stream/s3-upload-stream-tests.ts
@@ -1,0 +1,21 @@
+/// <reference types="node" />
+/// <reference path="../aws-sdk/index.d.ts" />
+
+import * as fs from 'fs';
+import * as S3Stream from 's3-upload-stream';
+import * as AWS from 'aws-sdk';
+
+var s3Stream = S3Stream(new AWS.S3());
+
+var read = fs.createReadStream('/path/to/a/file');
+var upload = s3Stream.upload({
+  Bucket: "bucket-name",
+  Key: "key-name",
+  ACL: "public-read",
+  StorageClass: "REDUCED_REDUNDANCY",
+  ContentType: "binary/octet-stream"
+});
+
+upload.concurrentParts(5);
+
+read.pipe(upload);

--- a/s3-upload-stream/tsconfig.json
+++ b/s3-upload-stream/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "s3-upload-stream-tests.ts"
+    ]
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

---

Typing for [`s3-upload-stream`](https://github.com/nathanpeck/s3-upload-stream)
