### PR TITLE
[types 2.0] Add moment-jalaali types

### DIFF
--- a/moment-jalaali/index.d.ts
+++ b/moment-jalaali/index.d.ts
@@ -23,25 +23,22 @@ declare module 'moment' {
         startOf(jUnitOfTime: JUnitOfTime): Moment;
         endOf(jUnitOfTime: JUnitOfTime): Moment;
 
-        add(amount: number, jUnitOfTime: JUnitOfTime): Moment;
-        add(amount: string, jUnitOfTime: JUnitOfTime): Moment;
+        add(amount: string | number, jUnitOfTime: JUnitOfTime): Moment;
 
-        subtract(amount: number, jUnitOfTime: JUnitOfTime): Moment;
-        subtract(amount: string, jUnitOfTime: JUnitOfTime): Moment;
+        subtract(amount: string | number, jUnitOfTime: JUnitOfTime): Moment;
 
         jYear(y: number): Moment;
         jYear(): number;
-        jMonth(M: number): Moment;
-        jMonth(M: string): Moment;
+        jMonth(M: number | string): Moment;
         jMonth(): number;
         jDate(d: number): Moment;
         jDate(): number;
-        jWeek(): number;
         jWeek(d: number): Moment;
-        jWeekYear(): number;
+        jWeek(): number;
         jWeekYear(d: number): Moment;
-        jDayOfYear(): number;
+        jWeekYear(): number;
         jDayOfYear(d: number): Moment;
+        jDayOfYear(): number;
     }
 
 }

--- a/moment-jalaali/index.d.ts
+++ b/moment-jalaali/index.d.ts
@@ -1,0 +1,47 @@
+// Type definitions for moment-jalaali 0.5.0
+// Project: https://github.com/jalaali/moment-jalaali
+// Definitions by: Ali Taheri Moghaddar <https://github.com/alitaheri>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as moment from 'moment';
+
+export = moment;
+
+declare module 'moment' {
+    type JUnitOfTime = 'jYear' | 'jMonth';
+
+    /**
+     * Add persian language.
+     */
+    function loadPersian(): void;
+
+    function jIsLeapYear(year: number): boolean;
+    function jDaysInMonth(year: number, month: number): number;
+
+    interface Moment {
+
+        startOf(jUnitOfTime: JUnitOfTime): Moment;
+        endOf(jUnitOfTime: JUnitOfTime): Moment;
+
+        add(amount: number, jUnitOfTime: JUnitOfTime): Moment;
+        add(amount: string, jUnitOfTime: JUnitOfTime): Moment;
+
+        subtract(amount: number, jUnitOfTime: JUnitOfTime): Moment;
+        subtract(amount: string, jUnitOfTime: JUnitOfTime): Moment;
+
+        jYear(y: number): Moment;
+        jYear(): number;
+        jMonth(M: number): Moment;
+        jMonth(M: string): Moment;
+        jMonth(): number;
+        jDate(d: number): Moment;
+        jDate(): number;
+        jWeek(): number;
+        jWeek(d: number): Moment;
+        jWeekYear(): number;
+        jWeekYear(d: number): Moment;
+        jDayOfYear(): number;
+        jDayOfYear(d: number): Moment;
+    }
+
+}

--- a/moment-jalaali/moment-jalaali-tests.ts
+++ b/moment-jalaali/moment-jalaali-tests.ts
@@ -1,0 +1,45 @@
+import * as moment from 'moment-jalaali';
+
+moment.loadPersian();
+
+moment.jIsLeapYear(1391);
+
+moment.jDaysInMonth(1395, 11);
+
+const m = moment();
+
+m.jYear();
+m.jMonth();
+m.jDate();
+m.jDayOfYear();
+m.jWeek();
+m.jWeekYear();
+
+m.jYear(1);
+m.jMonth(1);
+m.jDate(1);
+m.jDayOfYear(1);
+m.jWeek(1);
+m.jWeekYear(1);
+
+m.startOf('jYear');
+m.startOf('jMonth');
+
+m.endOf('jMonth');
+m.endOf('jYear');
+
+m.add(1, 'jYear');
+m.add(2, 'jMonth');
+m.add(3, 'day');
+
+m.add('1', 'jYear');
+m.add('2', 'jMonth');
+m.add('3', 'day');
+
+m.subtract(1, 'jYear');
+m.subtract(2, 'jMonth');
+m.subtract(3, 'day');
+
+m.subtract('1', 'jYear');
+m.subtract('2', 'jMonth');
+m.subtract('3', 'day');

--- a/moment-jalaali/package.json
+++ b/moment-jalaali/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "moment": "2.14.*"
+    }
+}

--- a/moment-jalaali/tsconfig.json
+++ b/moment-jalaali/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "moment-jalaali-tests.ts"
+    ]
+}


### PR DESCRIPTION
Typings for [moment-jalaali](https://github.com/jalaali/moment-jalaali)
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
