### PR TITLE
nock: Added missing delay functions

### DIFF
--- a/nock/nock-tests.ts
+++ b/nock/nock-tests.ts
@@ -97,6 +97,12 @@ inst = inst.log(() => {
 
 });
 
+inst = inst.delay(2000);
+inst = inst.delayBody(2000);
+inst = inst.delayConnection(2000);
+inst.getTotalDelay();
+inst = inst.socketDelay(2000);
+
 inst.done();
 bool = inst.isDone();
 inst.restore();

--- a/nock/nock.d.ts
+++ b/nock/nock.d.ts
@@ -96,7 +96,10 @@ declare module "nock" {
 			log(out: () => void): Scope;
 
 			delay(timeMs: number): Scope;
+			delayBody(timeMs: number): Scope;
 			delayConnection(timeMs: number): Scope;
+			getTotalDelay(): number;
+			socketDelay(timeMs: number): Scope;
 
 			times(repeats: number): Scope;
 			once(): Scope;


### PR DESCRIPTION
Added missing delay functions, see docs & code:

https://github.com/node-nock/nock#delay-the-response-body
https://github.com/node-nock/nock/blob/master/lib/interceptor.js#L506
