### PR TITLE
fix(xregexp): Change of xregexp.d.ts

### DIFF
--- a/xregexp/xregexp-tests.ts
+++ b/xregexp/xregexp-tests.ts
@@ -1,8 +1,7 @@
 /// <reference path="xregexp.d.ts" />
 
-import X = require('xregexp');
-import XRegExp = X.XRegExp;
-import TokenOpts = X.TokenOpts;
+import XRegExp = xregexp.OuterXRegExp;
+import TokenOpts = XRegExp.TokenOpts;
 
 // --  --  --  --  --  --  --  --  --  --  --  --  --
 
@@ -44,11 +43,11 @@ str =  XRegExp.version;
 
 // --  --  --  --  --  --  --  --  --  --  --  --  --
 
-regex = X(str);
-regex = X(str, flags);
-regex = X(regex);
+regex = XRegExp(str);
+regex = XRegExp(str, flags);
+regex = XRegExp(regex);
 
-str =  X.version;
+str =  XRegExp.version;
 
 // --  --  --  --  --  --  --  --  --  --  --  --  --
 

--- a/xregexp/xregexp.d.ts
+++ b/xregexp/xregexp.d.ts
@@ -5,7 +5,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module 'xregexp' {
+	let xRegExport: string;
+	export = xRegExport;
+}
 
+declare module xregexp {
 	function OuterXRegExp(pattern: string, flags?: string): RegExp;
 	function OuterXRegExp(pattern: RegExp): RegExp;
 
@@ -33,17 +37,17 @@ declare module 'xregexp' {
 
 		/* Since xregexp 3.0.0 can be used either via
 
-				import X = require('xregexp');
-				X();
+		 import X = require('xregexp');
+		 X();
 
-			or via
+		 or via
 
-				import XRegExp = X.XRegExp;
-				XRegExp()
+		 import XRegExp = X.XRegExp;
+		 XRegExp()
 
-			I had to duplicate the function declarations. I could simply not
-			find another way to accomplish this with TypeScript.
-		*/
+		 I had to duplicate the function declarations. I could simply not
+		 find another way to accomplish this with TypeScript.
+		 */
 
 		// begin API definitions
 		function addToken(regex: RegExp, handler: (matchArr: RegExpExecArray, scope: string) => string, options?: TokenOpts): void;
@@ -132,5 +136,4 @@ declare module 'xregexp' {
 		}
 	}
 
-	export = OuterXRegExp;
 }


### PR DESCRIPTION
I am trying to use the correct typo inside an angular module environment of the xregexp.d.ts library. I am not able to do this as this error is thrown: 'Import declarations in a namespace cannot reference a module.'. 
I propose the following change. Do you agree with this approach? 

Thanks in advance
