### PR TITLE
Improve types for supertest and supertest-as-promised

### DIFF
--- a/supertest-as-promised/supertest-as-promised-tests.ts
+++ b/supertest-as-promised/supertest-as-promised-tests.ts
@@ -66,7 +66,7 @@ request(app)
 
 // Constructor with custom promises
 let customPromiseRequest = request(Promise);
-customPromiseRequest('')
+customPromiseRequest(app)
   .get("/kittens")
   .expect(201)
   .then(function (res) { /* ... */ })

--- a/supertest-as-promised/supertest-as-promised-tests.ts
+++ b/supertest-as-promised/supertest-as-promised-tests.ts
@@ -4,6 +4,7 @@
 
 import * as request from 'supertest-as-promised';
 import * as express from 'express';
+import * as http from 'http';
 
 var app = express();
 
@@ -62,3 +63,30 @@ request(app)
   // I'm a real promise now!
   .delay(10)
   .then(function (res) { /* ... */ })
+
+// Constructor with custom promises
+let customPromiseRequest = request(Promise);
+customPromiseRequest('')
+  .get("/kittens")
+  .expect(201)
+  .then(function (res) { /* ... */ })
+  // I'm a real promise now!
+  .catch(function (err) { /* ... */ })
+
+
+// Constructor overload
+// String constructor
+request('localhost')
+    .get('/')
+    .expect(200)
+    .then(function (res) {
+      // ...
+    });
+// RequestListener constructor
+let requestListener = (request: http.IncomingMessage, response: http.ServerResponse): void => {};
+request(requestListener)
+    .get('/')
+    .expect(200)
+    .then(function (res) {
+      // ...
+    });

--- a/supertest-as-promised/supertest-as-promised.d.ts
+++ b/supertest-as-promised/supertest-as-promised.d.ts
@@ -10,7 +10,7 @@
 declare module "supertest-as-promised" {
   import * as supertest from "supertest";
   import * as superagent from "superagent";
-  import * as PromiseBlurbird from "bluebird";
+  import * as PromiseBluebird from "bluebird";
 
   function supertestAsPromised(app: supertest.App): supertest.SuperTest<supertestAsPromised.Test>;
   function supertestAsPromised(promiseConstructor: { resolve: Function, reject: Function }): (app: supertest.App) => supertest.SuperTest<supertestAsPromised.Test>;
@@ -23,7 +23,7 @@ declare module "supertest-as-promised" {
     }
 
     interface Test extends supertest.Test, superagent.Request {
-      toPromise(): PromiseBlurbird<Response>;
+      toPromise(): PromiseBluebird<Response>;
     }
 
     function agent(app?: any): supertest.SuperTest<Test>;

--- a/supertest-as-promised/supertest-as-promised.d.ts
+++ b/supertest-as-promised/supertest-as-promised.d.ts
@@ -9,11 +9,11 @@
 
 declare module "supertest-as-promised" {
   import * as supertest from "supertest";
-  import * as supersgent from "superagent";
-  import { SuperTest, Response } from "supertest";
+  import * as superagent from "superagent";
   import * as PromiseBlurbird from "bluebird";
 
-  function supertestAsPromised(app: any): SuperTest<supertestAsPromised.Test>;
+  function supertestAsPromised(app: supertest.App): supertest.SuperTest<supertestAsPromised.Test>;
+  function supertestAsPromised(promiseConstructor: { resolve: Function, reject: Function }): (app: supertest.App) => supertest.SuperTest<supertestAsPromised.Test>;
 
   namespace supertestAsPromised {
     interface Request extends supertest.Request {
@@ -22,15 +22,14 @@ declare module "supertest-as-promised" {
     interface Response extends supertest.Response {
     }
 
-    interface Test extends supertest.Test, supersgent.Request {
+    interface Test extends supertest.Test, superagent.Request {
       toPromise(): PromiseBlurbird<Response>;
     }
 
-    function agent(app?: any): SuperTest<Test>;
+    function agent(app?: any): supertest.SuperTest<Test>;
 
     interface SuperTest<T> extends supertest.SuperTest<T> {
     }
   }
-  export = supertestAsPromised
-
+  export = supertestAsPromised;
 }

--- a/supertest/supertest-tests.ts
+++ b/supertest/supertest-tests.ts
@@ -3,6 +3,7 @@
 
 import * as supertest from 'supertest';
 import * as express from 'express';
+import * as http from 'http';
 
 var app = express();
 
@@ -56,3 +57,12 @@ function hasPreviousAndNextKeys(res: supertest.Response) {
   if (!('next' in res.body)) return "missing next key";
   if (!('prev' in res.body)) throw new Error("missing prev key");
 }
+
+// constructor overload
+// String constructor
+supertest('localhost')
+  .get('/');
+// RequestListener constructor
+let requestListener = (request: http.IncomingMessage, response: http.ServerResponse): void => {};
+supertest(requestListener)
+  .get('/');

--- a/supertest/supertest.d.ts
+++ b/supertest/supertest.d.ts
@@ -7,10 +7,22 @@
 
 declare module "supertest" {
   import * as superagent from "superagent"
+  import * as http from 'http';
 
-  function supertest(app: any): supertest.SuperTest<supertest.Test>;
+  function supertest(app: supertest.App): supertest.SuperTest<supertest.Test>;
 
   namespace supertest {
+    interface ServerLike {
+      address: { port: number; family: string; address: string; };
+      listen(port: number): http.Server;
+    }
+
+    interface RequestListener { // Like the `requestListener` argument for http.createServer()
+      (request: http.IncomingMessage, response: http.ServerResponse): void;
+    }
+
+    type App = string | supertest.RequestListener | supertest.ServerLike;
+
     interface Response extends superagent.Response {
     }
 
@@ -33,13 +45,12 @@ declare module "supertest" {
       end(callback?: CallbackHandler): this;
     }
 
-    function agent(app?: any): SuperTest<Test>;
+    function agent(app?: App): SuperTest<Test>;
 
     interface SuperTest<T> extends superagent.SuperAgent<T> {
     }
 
   }
-
 
   export = supertest;
 }


### PR DESCRIPTION
The existing definition for `supertest-as-promised` did not allow for wiring in other Promise types:
https://github.com/WhoopInc/supertest-as-promised#byop-bring-your-own-promise

To fix this, I added an overloaded function to `supertestAsPromised`. However, because the original definition for the function used the `any` type, this did not work, so I had to narrow the definition for the original function to its usages:
https://github.com/visionmedia/supertest/blob/master/lib/agent.js#L27
https://github.com/visionmedia/supertest/blob/master/lib/test.js#L34
https://github.com/visionmedia/supertest/blob/master/lib/test.js#L55
https://github.com/visionmedia/supertest/blob/master/lib/test.js#L59

This means that `supertest.App` is now narrower but should still match all existing cases, and `supertestAsPromised` can be overloaded with the Promise constructor (definition taken from https://github.com/WhoopInc/supertest-as-promised/blob/master/index.js#L80 and following lines.)
