### PR TITLE
angularjs: Revert "Add missing definition"

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -238,7 +238,6 @@ declare namespace angular {
          * @param directiveFactory An injectable directive factory function.
          */
         directive(name: string, inlineAnnotatedFunction: any[]): IModule;
-        directive(name: string, injectionFunction: Function): IModule;
         directive(object: Object): IModule;
         /**
          * Register a service factory, which will be called to return the service instance. This is short for registering a service where its provider consists of only a $get property, which is the given service factory function. You should use $provide.factory(getFn) if you do not need to configure your service in a provider.


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#10720

It fixes something that wasn't broken. There had already been more strongly-typed type definitions for that case, and they are broken now because of this change.

Overall, the recent changes to the definitions for Angular 1.x look pretty questionable. Can I become a reviewer so that I would be notified of any proposed changes to these definitions?
