### PR TITLE
add missing command hincrbyfloat of ioredis

### DIFF
--- a/ioredis/ioredis.d.ts
+++ b/ioredis/ioredis.d.ts
@@ -197,6 +197,8 @@ declare module IORedis {
         hmget(...args: any[]): any;
         hincrby(args: any[], callback?: ResCallbackT<any>): any;
         hincrby(...args: any[]): any;
+        hincrbyfloat(args: any[], callback?: ResCallbackT<any>): any;
+        hincrbyfloat(...args: any[]): any;
         hdel(args: any[], callback?: ResCallbackT<any>): any;
         hdel(...args: any[]): any;
         hlen(args: any[], callback?: ResCallbackT<any>): any;
@@ -478,6 +480,8 @@ declare module IORedis {
         hmget(...args: any[]): Pipeline;
         hincrby(args: any[], callback?: ResCallbackT<any>): Pipeline;
         hincrby(...args: any[]): Pipeline;
+        hincrbyfloat(args: any[], callback?: ResCallbackT<any>): Pipeline;
+        hincrbyfloat(...args: any[]): Pipeline;
         hdel(args: any[], callback?: ResCallbackT<any>): Pipeline;
         hdel(...args: any[]): Pipeline;
         hlen(args: any[], callback?: ResCallbackT<any>): Pipeline;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://redis.io/commands/hincrbyfloat .
  - it has been reviewed by a DefinitelyTyped member.
