### PR TITLE
Fix broken Q import

### DIFF
--- a/twilio/twilio.d.ts
+++ b/twilio/twilio.d.ts
@@ -5,12 +5,12 @@
 
 /// <reference path="../express/express.d.ts" />
 /// <reference path="../node/node.d.ts" />
-/// <reference path="../q/Q.d.ts" />
+/// <reference path="../q/index.d.ts" />
 
 import * as express from 'express';
 import * as Http from 'http';
 
-import q = require('q');
+import Q = require('q');
 
 export interface twilio {
   (sid?: string, tkn?: string, options?: twilio.ClientOptions): twilio.RestClient;


### PR DESCRIPTION
Trying to compile code that references the current version of this definition was erroring, saying that the `<reference`d file couldn't be found and, once that was fixed, that the identifier `Q` needed to be imported. 

Looking in the DefinitelyTyped repo, it does seem like there isn't a `Q.d.ts` file, while there is an [index.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/types-2.0/q/index.d.ts). So this PR just updates the `<reference>` to point to that. Then, it renames the import to `Q`, to match the declarations later in the file.
