### PR TITLE
superagent: req.responseType, res.xhr

### DIFF
--- a/superagent/superagent-tests.ts
+++ b/superagent/superagent-tests.ts
@@ -5,6 +5,7 @@
 
 import * as request from 'superagent';
 import * as fs from 'fs';
+import * as assert from 'assert';
 
 // Examples taken from https://github.com/visionmedia/superagent/blob/gh-pages/docs/index.md
 // and https://github.com/visionmedia/superagent/blob/master/Readme.md
@@ -302,4 +303,13 @@ request
 request
   .get('/search')
   .then((response) => {})
-  .catch((error) => {}); 
+  .catch((error) => {});
+
+// Requesting binary data.
+// adapted from: https://github.com/visionmedia/superagent/blob/v2.0.0/test/client/request.js#L110
+request
+  .get('/blob')
+  .responseType('blob')
+  .end(function(err, res){
+    assert.deepEqual(res.xhr.response instanceof Blob, true);
+  });

--- a/superagent/superagent-tests.ts
+++ b/superagent/superagent-tests.ts
@@ -310,6 +310,7 @@ request
 request
   .get('/blob')
   .responseType('blob')
-  .end(function(err, res){
-    assert.deepEqual(res.xhr.response instanceof Blob, true);
+  .end(function (err, res) {
+    assert(res.xhr instanceof XMLHttpRequest)
+    assert(res.xhr.response instanceof Blob);
   });

--- a/superagent/superagent.d.ts
+++ b/superagent/superagent.d.ts
@@ -77,6 +77,7 @@ declare module "superagent" {
       notAcceptable: boolean;
       notFound: boolean;
       forbidden: boolean;
+      xhr: XMLHttpRequest;
       get(header: string): string;
     }
 
@@ -96,6 +97,7 @@ declare module "superagent" {
       pipe(stream: NodeJS.WritableStream, options?: Object): stream.Writable;
       query(val: Object): this;
       redirects(n: number): this;
+      responseType(type: string): this;
       send(data: string): this;
       send(data: Object): this;
       send(): this;


### PR DESCRIPTION
Added:
- `SuperAgentRequest.responseType` setter method
- `SuperAgentResponse.xhr` field definition

Source reference from tests at 2.0.0 tag: https://github.com/visionmedia/superagent/blob/v2.0.0/test/client/request.js#L110 (included URL in superagent-tests.ts)

Since this test existed at 2.0.0 tag, I believe this could be published as the next patch version of the 2.0.x typing.

Needs review by a DefinitelyTyped member, per PR template.
