### PR TITLE
[pino]: Fix constructor argument stream typing

### DIFF
--- a/pino/pino-tests.ts
+++ b/pino/pino-tests.ts
@@ -26,6 +26,12 @@ var instance = PINO({
   }
 })
 
+var pretty = PINO.pretty()
+var instance2 = PINO({
+  name: 'app',
+  safe: true
+}, pretty)
+
 
 var logger = instance
 logger.child({ a: 'property' }).info('hello child!')

--- a/pino/pino.d.ts
+++ b/pino/pino.d.ts
@@ -41,8 +41,8 @@ declare module 'pino' {
     }
 
     interface Pino {
-        (optionsOrStream?: LoggerOptions | stream.Writable): Logger
-        (options: LoggerOptions, stream: stream.Writable): Logger
+        (optionsOrStream?: LoggerOptions | stream.Writable | stream.Readable): Logger
+        (options: LoggerOptions, stream: stream.Writable | stream.Readable): Logger
         levels: {
             values: LevelLabelsToValues
             labels: LevelValuesToLabels


### PR DESCRIPTION
[An example in the documentation wasn't compiling correctly](https://www.npmjs.com/package/pino#pinoprettyopts) because:
- pino.pretty() returns a _stream.Readable_
- pino: accepts a _stream.Writable_ as an optional second argument

``` bash
Argument of type 'Readable' is not assignable to parameter of type 'Writable'.
```
