### PR TITLE
Support ES6 import of jsts

### DIFF
--- a/jsts/jsts-tests.ts
+++ b/jsts/jsts-tests.ts
@@ -1,4 +1,7 @@
 ﻿/// <reference path="jsts.d.ts" />
+
+import * as jsts from 'jsts';
+
 var str: string;
 var n: number;
 var bool: boolean;

--- a/jsts/jsts.d.ts
+++ b/jsts/jsts.d.ts
@@ -1664,3 +1664,7 @@ declare namespace jsts {
         }
     }
 }
+
+declare module "jsts" {
+    export = jsts;
+}


### PR DESCRIPTION
Before:

``` ts
import * as jsts from 'jsts';  // error: cannot find module 'jsts'
```

after:

``` ts
import * as jsts from 'jsts';  // 🎉
```

cc @vvakame @dalie
