### PR TITLE
Add bluebird's cancelation method.

### DIFF
--- a/request-promise/request-promise.d.ts
+++ b/request-promise/request-promise.d.ts
@@ -23,6 +23,7 @@ declare module 'request-promise' {
             finally<TResult>(handler: () => PromiseLike<TResult>): Promise<any>;
             finally<TResult>(handler: () => TResult): Promise<any>;
             promise(): Promise<any>;
+            cancel(): void;
         }
 
         interface RequestPromiseOptions extends request.CoreOptions {


### PR DESCRIPTION
From request-promise v4.1.0 (2016-07-30), Bluebird `cancel()` is exposed.

https://github.com/request/request-promise/pull/123
http://bluebirdjs.com/docs/api/cancellation.html
