### PR TITLE
Amended the signature of the callback function

### DIFF
--- a/cucumber/cucumber-tests.ts
+++ b/cucumber/cucumber-tests.ts
@@ -4,27 +4,27 @@ function StepSample() {
 	type Callback = cucumber.CallbackStepDefinition;
 	var step = <cucumber.StepDefinitions>this;
 	var hook = <cucumber.Hooks>this;
-	
+
 	hook.Before(function(scenario, callback){
 		scenario.isFailed() && callback.pending();
 	})
-	
+
 	hook.Around(function(scenario, runScenario)  {
 		scenario.isFailed() && runScenario(null, function(){
 			console.log('finish tasks');
 		});
 	});
-	
+
 	hook.registerHandler('AfterFeatures', function (event, callback) {
 		callback();
 	});
-	
+
 	step.Given(/^I am on the Cucumber.js GitHub repository$/, function(callback:Callback) {
 		this.visit('https://github.com/cucumber/cucumber-js', callback);
 	});
 
 	step.When(/^I go to the README file$/, function(title:string, callback:Callback) {
-		callback.pending();
+		callback(null, 'pending');
 	});
 
 	step.Then(/^I should see "(.*)" as the page title$/, { timeout:60*1000}, function(title:string, callback:Callback) {

--- a/cucumber/cucumber.d.ts
+++ b/cucumber/cucumber.d.ts
@@ -7,7 +7,7 @@ declare namespace cucumber {
 
 	export interface CallbackStepDefinition{
 		pending : () => PromiseLike<any>;
-		(errror?:any):void;
+		(errror?:any, pending?: string):void;
 	}
 
 	interface StepDefinitionCode {


### PR DESCRIPTION
The callback function no longer exposes the `.pending` method.
Instead, in order to indicate that a step is pending, one needs to invoke callback as:

```
callback(null, 'pending');
```

More info at: https://github.com/cucumber/cucumber-js#step-definitions

---

I left the `pending()` method in the `d.ts` to cater for the older versions of cucumber.js
