### PR TITLE
Moved fs constants under constants as per documentation

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -165,6 +165,22 @@ fs.watch('/tmp/foo-', {
   console.log(event, filename);
 });
 
+fs.access('/path/to/folder', (err) => {});
+
+fs.access(Buffer.from(''), (err) => {});
+
+fs.access('/path/to/folder', fs.constants.F_OK | fs.constants.R_OK, (err) => {});
+
+fs.access(Buffer.from(''), fs.constants.F_OK | fs.constants.R_OK, (err) => {});
+
+fs.accessSync('/path/to/folder');
+
+fs.accessSync(Buffer.from(''));
+
+fs.accessSync('path/to/folder', fs.constants.W_OK | fs.constants.X_OK);
+
+fs.accessSync(Buffer.from(''), fs.constants.W_OK | fs.constants.X_OK);
+
 ///////////////////////////////////////////////////////
 /// Buffer tests : https://nodejs.org/api/buffer.html
 ///////////////////////////////////////////////////////

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1717,14 +1717,23 @@ declare module "fs" {
     export function watch(filename: string, options: { persistent?: boolean; recursive?: boolean; encoding?: string }, listener?: (event: string, filename: string | Buffer) => any): FSWatcher;
     export function exists(path: string | Buffer, callback?: (exists: boolean) => void): void;
     export function existsSync(path: string | Buffer): boolean;
-    /** Constant for fs.access(). File is visible to the calling process. */
-    export var F_OK: number;
-    /** Constant for fs.access(). File can be read by the calling process. */
-    export var R_OK: number;
-    /** Constant for fs.access(). File can be written by the calling process. */
-    export var W_OK: number;
-    /** Constant for fs.access(). File can be executed by the calling process. */
-    export var X_OK: number;
+
+    interface Constants {
+        /** Constant for fs.access(). File is visible to the calling process. */
+        F_OK: number;
+
+        /** Constant for fs.access(). File can be read by the calling process. */
+        R_OK: number;
+
+        /** Constant for fs.access(). File can be written by the calling process. */
+        W_OK: number;
+
+        /** Constant for fs.access(). File can be executed by the calling process. */
+        X_OK: number;
+    }
+
+    export const constants: Constants;
+    
     /** Tests a user's permissions for the file specified by path. */
     export function access(path: string | Buffer, callback: (err: NodeJS.ErrnoException) => void): void;
     export function access(path: string | Buffer, mode: number, callback: (err: NodeJS.ErrnoException) => void): void;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- moved fs constants to `fs.constants` https://nodejs.org/api/fs.html#fs_fs_access_path_mode_callback
- added tests for `access` https://nodejs.org/api/fs.html#fs_fs_access_path_mode_callback
- added tests for `accessSync` https://nodejs.org/api/fs.html#fs_fs_accesssync_path_mode
