### PR TITLE
Jquery mockjax settings response callback

### DIFF
--- a/jquery-mockjax/jquery-mockjax-tests.ts
+++ b/jquery-mockjax/jquery-mockjax-tests.ts
@@ -171,10 +171,10 @@ class Tests {
 
             let settings: MockJaxSettings = {
                 url: '/async-response-callback',
-                response: (settings, callback) => {
+                response: (settings, completed) => {
                     setTimeout(() => {
                         settings.responseText = settings.data.response + ' 3';
-                        callback();
+                        completed();
                     }, 10);
                 }
             };

--- a/jquery-mockjax/jquery-mockjax-tests.ts
+++ b/jquery-mockjax/jquery-mockjax-tests.ts
@@ -9,7 +9,7 @@ class Tests {
     run(): void {
         const self = this;
 
-        var t = QUnit.test;
+        let t = QUnit.test;
 
         QUnit.begin(() => {
 
@@ -36,7 +36,7 @@ class Tests {
                 responseText: 'Hello Word'
             });
 
-            var xhr = $.ajax({
+            let xhr = $.ajax({
                 url: '/xmlhttprequest',
                 complete: () => { }
             });
@@ -67,7 +67,7 @@ class Tests {
         });
 
         t('Intercept asynchronized proxy calls', (assert) => {
-            var done = assert.async();
+            let done = assert.async();
             $.mockjax({
                 url: '/proxy',
                 proxy: 'test_proxy.json'
@@ -85,7 +85,7 @@ class Tests {
         });
 
         t('Intercept and proxy (sub-ajax request)', (assert) => {
-            var done = assert.async();
+            let done = assert.async();
 
             $.mockjax({
                 url: '/proxy',
@@ -104,7 +104,7 @@ class Tests {
         });
 
         t('Proxy type specification', (assert) => {
-            var done = assert.async();
+            let done = assert.async();
 
             $.mockjax({
                 url: '/proxy',
@@ -124,7 +124,7 @@ class Tests {
         });
 
         t('Support 1.5 $.ajax(url, settings) signature.', (assert) => {
-            var done = assert.async();
+            let done = assert.async();
 
             $.mockjax({
                 url: '/resource',
@@ -141,9 +141,9 @@ class Tests {
         });
 
         t('Dynamic response callback', (assert) => {
-            var done = assert.async();
+            let done = assert.async();
 
-            var settings: MockJaxSettings = {
+            let settings: MockJaxSettings = {
                 url: '/response-callback',
                 response: (settings) => {
                     settings.responseText = settings.data.response + ' 2';
@@ -165,8 +165,36 @@ class Tests {
                 }
             });
         });
+
+        t('Asyncronous response callback', (assert) => {
+            let done = assert.async();
+
+            let settings: MockJaxSettings = {
+                url: '/async-response-callback',
+                response: (settings, callback) => {
+                    setTimeout(() => {
+                        settings.responseText = settings.data.response + ' 3';
+                        callback();
+                    }, 10);
+                }
+            };
+
+            $.mockjax(settings);
+
+            $.ajax({
+                url: '/async-response-callback',
+                dataType: 'text',
+                data: {
+                    response: 'Hello world'
+                },
+                error: self._noErrorCallbackExpected,
+                complete: (xhr) => {
+                    assert.equal(xhr.responseText, 'Hello world 3', 'Response Text matches');
+                    done();
+                }
+            });
+        });
     }
 }
 
-var tests = new Tests();
-tests.run();
+new Tests().run();

--- a/jquery-mockjax/jquery-mockjax.d.ts
+++ b/jquery-mockjax/jquery-mockjax.d.ts
@@ -22,7 +22,7 @@ interface MockJaxSettings {
     isTimeout?: boolean;
     dataType?: string;
     contentType?: string;
-    response?: (settings: any, callback?: Function) => void;
+    response?: (settings: any, done?: Function) => void;
     responseText?: string | Object;
     responseXml?: string;
     proxy?: string;

--- a/jquery-mockjax/jquery-mockjax.d.ts
+++ b/jquery-mockjax/jquery-mockjax.d.ts
@@ -22,7 +22,7 @@ interface MockJaxSettings {
     isTimeout?: boolean;
     dataType?: string;
     contentType?: string;
-    response?: (settings: any) => void;
+    response?: (settings: any, callback?: Function) => void;
     responseText?: string | Object;
     responseXml?: string;
     proxy?: string;


### PR DESCRIPTION
The MockJaxSettings.response function can have two parameters. The second one is an optional callback in case the response function is doing asynchronous stuff. See https://github.com/jakerella/jquery-mockjax/#callback for an example.

So, I simply added the optional `done?: Function`, I added a dum test and I updated the code a little.
