### PR TITLE
Updating Quill JS definitions to v1.0.0

### DIFF
--- a/quill/quill-tests.ts
+++ b/quill/quill-tests.ts
@@ -69,9 +69,22 @@ function test_formatText2() {
     });
 }
 
-function test_formatLine() {
+function test_formatLine1() {
+    var quillEditor = new Quill('#editor');
+    quillEditor.formatLine(1, 3, 'api');
+}
+
+function test_formatLine2() {
     var quillEditor = new Quill('#editor');
     quillEditor.formatLine(1, 3, 'align', 'right');
+}
+
+function test_formatLine3() {
+    var quillEditor = new Quill('#editor');
+    quillEditor.formatLine(1, 3, {
+            'align': 'right',
+            'bold': false,
+        });
 }
 
 function test_insertEmbed() {
@@ -150,4 +163,12 @@ function test_addContainer()
 {
     var quillEditor = new Quill('#editor');
     quillEditor.addContainer('ql-custom');
+}
+
+function test_on_EventType1(){
+    var quillEditor = new Quill('#editor');
+    quillEditor.on('text-change', (newDelta, oldDelta, source)=>{
+        // happened
+    });
+
 }

--- a/quill/quill-tests.ts
+++ b/quill/quill-tests.ts
@@ -1,10 +1,6 @@
 /// <reference path="quill.d.ts" />
-/// <reference path="../requirejs/require.d.ts"/>
-
-//export var Quill = require("quill");
 
 function test_quill() {
-
     var quillEditor = new Quill('#editor', {
         modules:
         {
@@ -12,6 +8,31 @@ function test_quill() {
         },
         theme: 'snow'
     });
+}
+
+function test_deleteText() {
+    var quillEditor = new Quill('#editor');
+    quillEditor.deleteText(0, 10);
+}
+
+function test_disable() {
+    let quillEditor = new Quill('#Editor');
+    quillEditor.disable();
+}
+
+function test_enable() {
+    let quillEditor = new Quill('#Editor');
+    quillEditor.enable();
+}
+
+function test_getContents() {
+    var quillEditor = new Quill('#editor');
+    var delta: QuillJS.DeltaStatic = quillEditor.getContents();
+}
+
+function test_getLength() {
+    var quillEditor = new Quill('#editor');
+    var num: number = quillEditor.getLength();
 }
 
 function test_getText() {
@@ -29,24 +50,9 @@ function test_getText_substring() {
     var strValue: string = quillEditor.getText(0, 10);
 }
 
-function test_getLength() {
-    var quillEditor = new Quill('#editor');
-    var num: number = quillEditor.getLength();
-}
-
-function test_getContents() {
-    var quillEditor = new Quill('#editor');
-    var delta: DeltaStatic = quillEditor.getContents();
-}
-
 function test_insertText() {
     var quillEditor = new Quill('#editor');
     quillEditor.insertText(0, "Hello World");
-}
-
-function test_deleteText() {
-    var quillEditor = new Quill('#editor');
-    quillEditor.deleteText(0, 10);
 }
 
 function test_formatText() {
@@ -71,7 +77,7 @@ function test_formatLine() {
 function test_insertEmbed() {
     var quillEditor = new Quill('#editor');
 
-    quillEditor.insertEmbed(10, 'image', 'http://quilljs.com/images/cloud.png');
+    quillEditor.insertEmbed(10, 'image', 'http://com/images/cloud.png');
 }
 
 function test_updateContents() {
@@ -96,12 +102,6 @@ function test_setContents() {
     ]);
 }
 
-function test_setHTML() {
-    var quillEditor = new Quill('#editor');
-
-    quillEditor.setHTML('<div>Hello</div>');
-}
-
 function test_setText() {
     var quillEditor = new Quill('#editor');
     quillEditor.setText('Hello\n');
@@ -113,10 +113,10 @@ function test_getSelection() {
 
     var range = quillEditor.getSelection();
     if (range) {
-        if (range.start == range.end) {
-            console.log('User cursor is at index', range.start);
+        if (range.index == range.length) {
+            console.log('User cursor is at index', range.index);
         } else {
-            var text = quillEditor.getText(range.start, range.end);
+            var text = quillEditor.getText(range.index, range.length);
             console.log('User has highlighted: ', text);
         }
     } else {
@@ -129,11 +129,6 @@ function test_setSelection() {
     quillEditor.setSelection(0, 5);
 }
 
-function test_prepareFormat() {
-    var quillEditor = new Quill('#editor');
-    quillEditor.prepareFormat('bold', true);
-}
-
 function test_focus() {
     var quillEditor = new Quill('#editor');
     quillEditor.focus();
@@ -144,26 +139,11 @@ function test_getBounds() {
     quillEditor.setText('Hello\nWorld\n');
 }
 
-function test_addModule() {
-    var quillEditor = new Quill('#editor');
-
-    var toolbar = quillEditor.addModule('toolbar', {
-        container: '#toolbar-container'
-    });
-}
-
 function test_getModule()
 {
     var quillEditor = new Quill('#editor');
 
     var toolbar = quillEditor.getModule('toolbar');
-}
-
-
-function test_addFormat()
-{
-    var quillEditor = new Quill('#editor');
-    quillEditor.addFormat('strike', { tag: 'S', prepare: 'strikeThrough' });
 }
 
 function test_addContainer()

--- a/quill/quill.d.ts
+++ b/quill/quill.d.ts
@@ -5,6 +5,13 @@
 
 declare namespace QuillJS {
 
+    export interface QuillOptionsStatic {
+        debug?: string,
+        modules?: {[key: string]: any},
+        placeholder?: string,
+        readOnly?: boolean,
+        theme?: string
+    }
 
     export interface BoundsStatic {
         left: number,
@@ -28,52 +35,52 @@ declare namespace QuillJS {
     }
 
     export interface QuillStatic {
-        new (selector: string, options?: Object): QuillStatic;
+        new (selector: string, options?: QuillOptionsStatic): QuillStatic;
 
-        deleteText(start: number, end: number, source?: string): void;
+        deleteText(start: number, end: number, source?: "api"|"user"|"silent"): void;
         disable(): void;
         enable(enabled?: boolean): void;
         getContents(start?: number, end?: number): DeltaStatic;
         getLength(): number;
         getText(start?: number, end?: number): string;
-        insertEmbed(index: number, type: string, url: string, source?: string): void;
-        insertText(index: number, text: string, source?: string): void;
-        insertText(index: number, text: string, format: string, value: string, source?: string): void;
-        insertText(index: number, text: string, formats: any, source?: string): void;
+        insertEmbed(index: number, type: string, url: string, source?: "api"|"user"|"silent"): void;
+        insertText(index: number, text: string, source?: "api"|"user"|"silent"): void;
+        insertText(index: number, text: string, format: string, value: string, source?: "api"|"user"|"silent"): void;
+        insertText(index: number, text: string, formats: { [key: string] : any  }, source?: "api"|"user"|"silent"): void;
         pasteHTML(): string;
-        setContents(delta: DeltaStatic, source?: string): void;
-        setText(text: string, source?: string): void;
+        setContents(delta: DeltaStatic, source?: "api"|"user"|"silent"): void;
+        setText(text: string, source?: "api"|"user"|"silent"): void;
         update(source?: string): void;
-        updateContents(delta: DeltaStatic, source?: string): void;
+        updateContents(delta: DeltaStatic, source?: "api"|"user"|"silent"): void;
 
-        format(name: string, value: any, source?: string): void;
-        formatLine(index: number, length: number, source?: string): void;
-        formatLine(index: number, length: number, format: string, value: any, source?: string): void;
-        formatLine(index: number, length: number, formats: any, source?: string): void;
-        formatText(index: number, length: number, source?: string): void;
-        formatText(index: number, length: number, format: string, value: any, source?: string): void;
-        formatText(index: number, length: number, formats: any, source?: string): void;
-        getFormat(range?: RangeStatic): any;
-        getFormat(index: number, length?: number): any;
-        removeFormat(index: Number, length: Number, source?: String): void;
+        format(name: string, value: any, source?: "api"|"user"|"silent"): void;
+        formatLine(index: number, length: number, source?: "api"|"user"|"silent"): void;
+        formatLine(index: number, length: number, format: string, value: any, source?: "api"|"user"|"silent"): void;
+        formatLine(index: number, length: number, formats: { [key: string] : any  }, source?: "api"|"user"|"silent"): void;
+        formatText(index: number, length: number, source?: "api"|"user"|"silent"): void;
+        formatText(index: number, length: number, format: string, value: any, source?: "api"|"user"|"silent"): void;
+        formatText(index: number, length: number, formats: { [key: string] : any  }, source?: "api"|"user"|"silent"): void;
+        getFormat(range?: RangeStatic): {[key: string]: any};
+        getFormat(index: number, length?: number): {[key: string]: any};
+        removeFormat(index: Number, length: Number, source?: "api"|"user"|"silent"): void;
 
         blur(): void;
         focus(): void;
         getBounds(index: number, length?: number): BoundsStatic;
         getSelection(focus?: boolean): RangeStatic;
         hasFocus(): boolean;
-        setSelection(index: number, length: number, source?: string): void;
-        setSelection(range: RangeStatic, source?: string): void;
+        setSelection(index: number, length: number, source?: "api"|"user"|"silent"): void;
+        setSelection(range: RangeStatic, source?: "api"|"user"|"silent"): void;
 
-        on(eventName: string, callback: (delta: DeltaStatic, oldContents: DeltaStatic, source: String) => void): QuillStatic;
-        on(eventName: string, callback: (range: RangeStatic, oldRange: RangeStatic, source: String) => void): QuillStatic;
+        on(eventName: string, callback: (<T>(delta: T, oldContents: T, source: string) => void) |
+                                            ((name: string, ...args) => void )): QuillStatic;
         once(eventName: string, callback: (delta: DeltaStatic, source: string) => void): QuillStatic;
         off(eventName: string, callback: (delta: DeltaStatic, source: string) => void): QuillStatic;
 
         debug(level: string): void;
         import(path: string): any;
         register(path: string, def: any, suppressWarning?: boolean): void;
-        register(defs: any, suppressWarning?: boolean): void;
+        register(defs: { [key: string] : any  }, suppressWarning?: boolean): void;
         addContainer(className: string, refNode?: any): any;
         getModule(name: string): any
     }

--- a/quill/quill.d.ts
+++ b/quill/quill.d.ts
@@ -73,7 +73,7 @@ declare namespace QuillJS {
         setSelection(range: RangeStatic, source?: "api"|"user"|"silent"): void;
 
         on(eventName: string, callback: (<T>(delta: T, oldContents: T, source: string) => void) |
-                                            ((name: string, ...args) => void )): QuillStatic;
+                                            ((name: string, ...args:any[]) => void )): QuillStatic;
         once(eventName: string, callback: (delta: DeltaStatic, source: string) => void): QuillStatic;
         off(eventName: string, callback: (delta: DeltaStatic, source: string) => void): QuillStatic;
 

--- a/quill/quill.d.ts
+++ b/quill/quill.d.ts
@@ -1,118 +1,85 @@
-// Type definitions for Quill
+// Type definitions for Quill v1.0.0
 // Project: http://quilljs.com
 // Definitions by: Sumit <https://github.com/sumitkm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-///<reference path="../eventemitter2/eventemitter2.d.ts" />
+declare namespace QuillJS {
 
-declare interface  DeltaStatic{
-	ops? : Array<any>;
-	retain?: any,
-	delete?: any,
-	insert?: any,
-	attributes?: any
+
+    export interface BoundsStatic {
+        left: number,
+        top: number,
+        height: number,
+        width: number
+    }
+
+    export interface DeltaStatic {
+        ops?: Array<any>;
+        retain?: any,
+        delete?: any,
+        insert?: any,
+        attributes?: any
+    }
+
+    export interface RangeStatic {
+        new (): RangeStatic;
+        index: number;
+        length: number;
+    }
+
+    export interface QuillStatic {
+        new (selector: string, options?: Object): QuillStatic;
+
+        deleteText(start: number, end: number, source?: string): void;
+        disable(): void;
+        enable(enabled?: boolean): void;
+        getContents(start?: number, end?: number): DeltaStatic;
+        getLength(): number;
+        getText(start?: number, end?: number): string;
+        insertEmbed(index: number, type: string, url: string, source?: string): void;
+        insertText(index: number, text: string, source?: string): void;
+        insertText(index: number, text: string, format: string, value: string, source?: string): void;
+        insertText(index: number, text: string, formats: any, source?: string): void;
+        pasteHTML(): string;
+        setContents(delta: DeltaStatic, source?: string): void;
+        setText(text: string, source?: string): void;
+        update(source?: string): void;
+        updateContents(delta: DeltaStatic, source?: string): void;
+
+        format(name: string, value: any, source?: string): void;
+        formatLine(index: number, length: number, source?: string): void;
+        formatLine(index: number, length: number, format: string, value: any, source?: string): void;
+        formatLine(index: number, length: number, formats: any, source?: string): void;
+        formatText(index: number, length: number, source?: string): void;
+        formatText(index: number, length: number, format: string, value: any, source?: string): void;
+        formatText(index: number, length: number, formats: any, source?: string): void;
+        getFormat(range?: RangeStatic): any;
+        getFormat(index: number, length?: number): any;
+        removeFormat(index: Number, length: Number, source?: String): void;
+
+        blur(): void;
+        focus(): void;
+        getBounds(index: number, length?: number): BoundsStatic;
+        getSelection(focus?: boolean): RangeStatic;
+        hasFocus(): boolean;
+        setSelection(index: number, length: number, source?: string): void;
+        setSelection(range: RangeStatic, source?: string): void;
+
+        on(eventName: string, callback: (delta: DeltaStatic, oldContents: DeltaStatic, source: String) => void): QuillStatic;
+        on(eventName: string, callback: (range: RangeStatic, oldRange: RangeStatic, source: String) => void): QuillStatic;
+        once(eventName: string, callback: (delta: DeltaStatic, source: string) => void): QuillStatic;
+        off(eventName: string, callback: (delta: DeltaStatic, source: string) => void): QuillStatic;
+
+        debug(level: string): void;
+        import(path: string): any;
+        register(path: string, def: any, suppressWarning?: boolean): void;
+        register(defs: any, suppressWarning?: boolean): void;
+        addContainer(className: string, refNode?: any): any;
+        getModule(name: string): any
+    }
 }
 
-declare interface RangeStatic{
-	new(): RangeStatic;
-	start: number;
-	end: number;
-}
-
-declare interface QuillStatic {
-	new(selector: string, options?: Object):QuillStatic;
-
-    on(eventName: string, callback: (delta: DeltaStatic, source: string) => void): EventEmitter2;
-    addModule(id: string, options: any) : Object;
-
-    getText(): string;
-    getText(start: number): string;
-    getText(start: number, end: number): string;
-
-    getLength(): number;
-
-    getContents(): DeltaStatic;
-    getContents(start: number): DeltaStatic;
-    getContents(start: number, end: number): DeltaStatic;
-
-    getHTML(): string;
-
-    insertText(index: number, text: string): void;
-    insertText(index: number, text: string, name: string, value: string): void;
-    insertText(index: number, text: string, formats: any): void;
-    insertText(index: number, text: string, source: string) : void;
-    insertText(index: number, text: string, name: string, value: string, source: string): void;
-    insertText(index: number, text: string, formats: any, source: string): void;
-
-    deleteText(start: number, end: number): void;
-    deleteText(start: number, end: number, source: string): void;
-
-    formatText(start: number, end: number): void;
-    formatText(start: number, end: number, name: string, value: boolean): void;
-    formatText(start: number, end: number, formats: any): void;
-    formatText(start: number, end: number, source: string): void;
-    formatText(start: number, end: number, name: string, value: string, source: string): void;
-    formatText(start: number, end: number, formats: string, source: string): void;
-
-
-    formatLine(start: number, end: number): void;
-    formatLine(start: number, end: number, name: string, value: boolean): void;
-    formatLine(start: number, end: number, formats: any): void;
-    formatLine(start: number, end: number, source: string): void;
-    formatLine(start: number, end: number, name: string, value: string, source: string): void;
-    formatLine(start: number, end: number, formats: any, source: string): void;
-
-
-    insertEmbed(index: number, type: string, url: string): void;
-    insertEmbed(index: number, type: string, url: string, source: string): void;
-
-    updateContents(delta: DeltaStatic): void;
-
-    setContents(delta: DeltaStatic): void;
-
-    setHTML(html: string): void;
-
-    setText(text: string): void;
-
-    getSelection(): RangeStatic;
-
-    setSelection(start: number, end: number): void;
-    setSelection(start: number, end: number, source: string): void;
-    setSelection(range: RangeStatic): void;
-    setSelection(range: RangeStatic, source: string): void;
-
-    prepareFormat(format: string, value: boolean): void;
-
-    focus(): void;
-
-    getBounds(index: number): any;
-
-    registerModule(name: string, callback: (quill: QuillStatic, options: any) => {}): any;
-
-    addModule(name: string, options: any): any;
-
-    getModule(name: string): any;
-
-    onModuleLoad(name: string, callback: (input: any) => {}): void;
-
-    addFormat(name: string, config: any): void;
-
-    addContainer(cssClass: string, before?: number): HTMLDivElement;
-}
-
-declare module "Range"
-{
-	var Range: RangeStatic;
-	export = Range;
-}
-
-declare var Delta: DeltaStatic;
-
-declare module "Delta"{
-	export = Delta;
-}
-
-declare var Quill: QuillStatic;
+declare var Quill: QuillJS.QuillStatic;
 
 declare module "Quill" {
     export = Quill;

--- a/quill/quill.d.ts
+++ b/quill/quill.d.ts
@@ -7,7 +7,7 @@ declare namespace QuillJS {
 
     export interface QuillOptionsStatic {
         debug?: string,
-        modules?: {[key: string]: any},
+        modules?: { [key: string]: any },
         placeholder?: string,
         readOnly?: boolean,
         theme?: string
@@ -34,53 +34,55 @@ declare namespace QuillJS {
         length: number;
     }
 
+    type sourceType = "api" | "user" | "silent";
+    type formatsType = { [key: string]: any };
+
     export interface QuillStatic {
         new (selector: string, options?: QuillOptionsStatic): QuillStatic;
-
-        deleteText(start: number, end: number, source?: "api"|"user"|"silent"): void;
+        deleteText(start: number, end: number, source?: sourceType): void;
         disable(): void;
         enable(enabled?: boolean): void;
         getContents(start?: number, end?: number): DeltaStatic;
         getLength(): number;
         getText(start?: number, end?: number): string;
-        insertEmbed(index: number, type: string, url: string, source?: "api"|"user"|"silent"): void;
-        insertText(index: number, text: string, source?: "api"|"user"|"silent"): void;
-        insertText(index: number, text: string, format: string, value: string, source?: "api"|"user"|"silent"): void;
-        insertText(index: number, text: string, formats: { [key: string] : any  }, source?: "api"|"user"|"silent"): void;
+        insertEmbed(index: number, type: string, url: string, source?: sourceType): void;
+        insertText(index: number, text: string, source?: sourceType): void;
+        insertText(index: number, text: string, format: string, value: string, source?: sourceType): void;
+        insertText(index: number, text: string, formats: formatsType, source?: sourceType): void;
         pasteHTML(): string;
-        setContents(delta: DeltaStatic, source?: "api"|"user"|"silent"): void;
-        setText(text: string, source?: "api"|"user"|"silent"): void;
+        setContents(delta: DeltaStatic, source?: sourceType): void;
+        setText(text: string, source?: sourceType): void;
         update(source?: string): void;
-        updateContents(delta: DeltaStatic, source?: "api"|"user"|"silent"): void;
+        updateContents(delta: DeltaStatic, source?: sourceType): void;
 
-        format(name: string, value: any, source?: "api"|"user"|"silent"): void;
-        formatLine(index: number, length: number, source?: "api"|"user"|"silent"): void;
-        formatLine(index: number, length: number, format: string, value: any, source?: "api"|"user"|"silent"): void;
-        formatLine(index: number, length: number, formats: { [key: string] : any  }, source?: "api"|"user"|"silent"): void;
-        formatText(index: number, length: number, source?: "api"|"user"|"silent"): void;
-        formatText(index: number, length: number, format: string, value: any, source?: "api"|"user"|"silent"): void;
-        formatText(index: number, length: number, formats: { [key: string] : any  }, source?: "api"|"user"|"silent"): void;
-        getFormat(range?: RangeStatic): {[key: string]: any};
-        getFormat(index: number, length?: number): {[key: string]: any};
-        removeFormat(index: Number, length: Number, source?: "api"|"user"|"silent"): void;
+        format(name: string, value: any, source?: sourceType): void;
+        formatLine(index: number, length: number, source?: sourceType): void;
+        formatLine(index: number, length: number, format: string, value: any, source?: sourceType): void;
+        formatLine(index: number, length: number, formats: formatsType, source?: sourceType): void;
+        formatText(index: number, length: number, source?: sourceType): void;
+        formatText(index: number, length: number, format: string, value: any, source?: sourceType): void;
+        formatText(index: number, length: number, formats: formatsType, source?: sourceType): void;
+        getFormat(range?: RangeStatic): formatsType;
+        getFormat(index: number, length?: number): formatsType;
+        removeFormat(index: Number, length: Number, source?: sourceType): void;
 
         blur(): void;
         focus(): void;
         getBounds(index: number, length?: number): BoundsStatic;
         getSelection(focus?: boolean): RangeStatic;
         hasFocus(): boolean;
-        setSelection(index: number, length: number, source?: "api"|"user"|"silent"): void;
-        setSelection(range: RangeStatic, source?: "api"|"user"|"silent"): void;
+        setSelection(index: number, length: number, source?: sourceType): void;
+        setSelection(range: RangeStatic, source?: sourceType): void;
 
         on(eventName: string, callback: (<T>(delta: T, oldContents: T, source: string) => void) |
-                                            ((name: string, ...args:any[]) => void )): QuillStatic;
+            ((name: string, ...args: any[]) => void)): QuillStatic;
         once(eventName: string, callback: (delta: DeltaStatic, source: string) => void): QuillStatic;
         off(eventName: string, callback: (delta: DeltaStatic, source: string) => void): QuillStatic;
 
         debug(level: string): void;
         import(path: string): any;
         register(path: string, def: any, suppressWarning?: boolean): void;
-        register(defs: { [key: string] : any  }, suppressWarning?: boolean): void;
+        register(defs: formatsType, suppressWarning?: boolean): void;
         addContainer(className: string, refNode?: any): any;
         getModule(name: string): any
     }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://quilljs.com/docs/quickstart/ and http://quilljs.com/guides/upgrading-to-1-0/.
  - it has been reviewed by a DefinitelyTyped member.

Refactoring definitions as per latest guidelines/best-practices
Built using Typescript 1.8
