### PR TITLE
add engine.ws to SocketIO.Server

### DIFF
--- a/socket.io/socket.io.d.ts
+++ b/socket.io/socket.io.d.ts
@@ -47,7 +47,7 @@ interface SocketIOStatic {
 declare namespace SocketIO {
 
 	interface Server {
-		engine: { ws: WebSocketServer };
+		engine: { ws: any };
 		
 		/**
 		 * A dictionary of all the namespaces currently on this Server

--- a/socket.io/socket.io.d.ts
+++ b/socket.io/socket.io.d.ts
@@ -47,7 +47,8 @@ interface SocketIOStatic {
 declare namespace SocketIO {
 
 	interface Server {
-
+		engine: { ws: WebSocketServer };
+		
 		/**
 		 * A dictionary of all the namespaces currently on this Server
 		 */


### PR DESCRIPTION
case 2. Improvement to existing type definition.

---

Check the demo at https://github.com/uWebSockets/uWebSockets/blob/master/README.md#socketio

``` js
var io = require('socket.io')(80);
io.engine.ws = new (require('uws').Server)({
    noServer: true,
    perMessageDeflate: false
});
```

which is the current way to change socket.io engine.
