### PR TITLE
[tether-drop] Remove 'element' property

### DIFF
--- a/tether-drop/tether-drop-tests.ts
+++ b/tether-drop/tether-drop-tests.ts
@@ -24,7 +24,7 @@ d.remove();
 d.toggle();
 d.position();
 d.destroy();
-d.drop.appendChild(document.createElement("div"));
+d.content.appendChild(document.createElement("div"));
 d.tether.position();
 
 d.on("open", () => false);

--- a/tether-drop/tether-drop-tests.ts
+++ b/tether-drop/tether-drop-tests.ts
@@ -24,7 +24,7 @@ d.remove();
 d.toggle();
 d.position();
 d.destroy();
-d.element.appendChild(document.createElement("div"));
+d.drop.appendChild(document.createElement("div"));
 d.tether.position();
 
 d.on("open", () => false);

--- a/tether-drop/tether-drop.d.ts
+++ b/tether-drop/tether-drop.d.ts
@@ -10,7 +10,7 @@ declare class Drop {
     constructor(options: Drop.IDropOptions);
 
     public content: HTMLElement;
-    public element: HTMLElement;
+    public drop: HTMLElement;
     public tether: Tether;
     public open(): void;
     public close(): void;

--- a/tether-drop/tether-drop.d.ts
+++ b/tether-drop/tether-drop.d.ts
@@ -10,7 +10,6 @@ declare class Drop {
     constructor(options: Drop.IDropOptions);
 
     public content: HTMLElement;
-    public drop: HTMLElement;
     public tether: Tether;
     public open(): void;
     public close(): void;


### PR DESCRIPTION
Drop objects do not have an 'element' property, rather the root element of the drop DOM subtree is stored in a 'drop' property.
For this reason I renamed 'element' property to 'drop'.
