### PR TITLE
Request Promise: Fixed capitalization on the Promise import.

### DIFF
--- a/request-promise/index.d.ts
+++ b/request-promise/index.d.ts
@@ -7,7 +7,7 @@ declare module 'request-promise' {
     import request = require('request');
     import http = require('http');
     import errors = require('request-promise/errors');
-    import promise = require('bluebird');
+    import Promise = require('bluebird');
 
     namespace requestPromise {
         interface RequestPromise extends request.Request {


### PR DESCRIPTION
Using the latest build of TypeScript (2.0.0) is causing TS errors as the Promise being returned is not referencing the Bluebird one which it should be doing so. Due the capitalization being wrong this fixes that and enables the correct Promise being returned to allow the usage of Bluebird method / changes w/o TS errors.
