### PR TITLE
PDFKit: Add layout property and fix margin/margins

### DIFF
--- a/pdfkit/pdfkit-tests.ts
+++ b/pdfkit/pdfkit-tests.ts
@@ -24,12 +24,16 @@ doc.addPage({
 });
 
 doc.addPage({
-  margin: {
+  margins: {
     top: 50,
     bottom: 50,
     left: 72,
     right: 72
   }
+});
+
+doc.addPage({
+  layout: "landscape"
 });
 
 doc.info.Title = "Sample";

--- a/pdfkit/pdfkit.d.ts
+++ b/pdfkit/pdfkit.d.ts
@@ -233,7 +233,7 @@ declare namespace PDFKit {
         size?: number[];
         margin?: number;
         margins?: { top: number; left: number; bottom: number; right: number };
-        layout?: "portrait" | "landscape"
+        layout?: "portrait" | "landscape";
 
         bufferPages?: boolean;
     }

--- a/pdfkit/pdfkit.d.ts
+++ b/pdfkit/pdfkit.d.ts
@@ -231,7 +231,9 @@ declare namespace PDFKit {
         info?: DocumentInfo;
         autoFirstPage?: boolean;
         size?: number[];
-        margin?: { top: number; left: number; bottom: number; right: number }|number;
+        margin?: number;
+        margins?: { top: number; left: number; bottom: number; right: number };
+        layout?: "portrait" | "landscape"
 
         bufferPages?: boolean;
     }


### PR DESCRIPTION
Documentation: http://pdfkit.org/docs/getting_started.html#adding_pages

1) Page options uses `margins` property for specifying different margins for each side (`margin` is used to set margin on all sides)
2) Prioperty `layout` in page options was missing
