### PR TITLE
[node] Clean up testcase of assert 

### DIFF
--- a/node/node-4-tests.ts
+++ b/node/node-4-tests.ts
@@ -24,22 +24,44 @@ import * as string_decoder from "string_decoder";
 // Specifically test buffer module regression.
 import {Buffer as ImportedBuffer, SlowBuffer as ImportedSlowBuffer} from "buffer";
 
-assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
+//////////////////////////////////////////////////////////
+/// Assert Tests : https://nodejs.org/api/assert.html ///
+//////////////////////////////////////////////////////////
 
-assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");
+namespace assert_tests{
+    {
+        assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
+        
+        assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");
+        
+        // TODO: assert.deepStrictEqual
+        
+        assert.doesNotThrow(() => {
+            const b = false;
+            if (b) { throw "a hammer at your face"; }
+        }, undefined, "What the...*crunch*");
+        
+        assert.equal(3, "3", "uses == comparator");
 
-assert.equal(3, "3", "uses == comparator");
-
-assert.notStrictEqual(2, "2", "uses === comparator");
-
-assert.notDeepStrictEqual({ x: { y: "3" } }, { x: { y: 3 } }, "uses === comparator");
-
-assert.throws(() => { throw "a hammer at your face"; }, undefined, "DODGED IT");
-
-assert.doesNotThrow(() => {
-    const b = false;
-    if (b) { throw "a hammer at your face"; }
-}, undefined, "What the...*crunch*");
+        // TODO: assert.fail
+        
+        // TODO: assert.ifError
+        
+        assert.notDeepStrictEqual({ x: { y: "3" } }, { x: { y: 3 } }, "uses === comparator");
+        
+        // TODO: assert.notDeepStrictEqual
+        
+        // TODO: assert.notEqual
+        
+        assert.notStrictEqual(2, "2", "uses === comparator");
+        
+        // TODO: assert.ok
+        
+        // TODO: assert.strictEqual
+        
+        assert.throws(() => { throw "a hammer at your face"; }, undefined, "DODGED IT");
+    }
+}
 
 ////////////////////////////////////////////////////
 /// Events tests : http://nodejs.org/api/events.html

--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -26,22 +26,44 @@ import * as timers from "timers";
 // Specifically test buffer module regression.
 import {Buffer as ImportedBuffer, SlowBuffer as ImportedSlowBuffer} from "buffer";
 
-assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
+//////////////////////////////////////////////////////////
+/// Assert Tests : https://nodejs.org/api/assert.html ///
+//////////////////////////////////////////////////////////
 
-assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");
+namespace assert_tests{
+    {
+        assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
+        
+        assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");
+        
+        // TODO: assert.deepStrictEqual
+        
+        assert.doesNotThrow(() => {
+            const b = false;
+            if (b) { throw "a hammer at your face"; }
+        }, undefined, "What the...*crunch*");
+        
+        assert.equal(3, "3", "uses == comparator");
 
-assert.equal(3, "3", "uses == comparator");
-
-assert.notStrictEqual(2, "2", "uses === comparator");
-
-assert.notDeepStrictEqual({ x: { y: "3" } }, { x: { y: 3 } }, "uses === comparator");
-
-assert.throws(() => { throw "a hammer at your face"; }, undefined, "DODGED IT");
-
-assert.doesNotThrow(() => {
-    const b = false;
-    if (b) { throw "a hammer at your face"; }
-}, undefined, "What the...*crunch*");
+        // TODO: assert.fail
+        
+        // TODO: assert.ifError
+        
+        assert.notDeepStrictEqual({ x: { y: "3" } }, { x: { y: 3 } }, "uses === comparator");
+        
+        // TODO: assert.notDeepStrictEqual
+        
+        // TODO: assert.notEqual
+        
+        assert.notStrictEqual(2, "2", "uses === comparator");
+        
+        // TODO: assert.ok
+        
+        // TODO: assert.strictEqual
+        
+        assert.throws(() => { throw "a hammer at your face"; }, undefined, "DODGED IT");
+    }
+}
 
 ////////////////////////////////////////////////////
 /// Events tests : http://nodejs.org/api/events.html


### PR DESCRIPTION
The purposes of PR:
- Clean up all test cases of assert module and wrap in `assert_tests` namespace
- To be consistent with order of contents of [assert](https://nodejs.org/api/assert.html), I rearrange the order.
- Note that it hadn't tested API as `TODO`
