### PR TITLE
Added typings for node-libxslt

### DIFF
--- a/libxslt/libxslt-tests.ts
+++ b/libxslt/libxslt-tests.ts
@@ -1,0 +1,102 @@
+/// <reference path="libxslt.d.ts" />
+/// <reference path="../libxmljs/libxmljs.d.ts" />
+
+import * as libxslt from 'libxslt';
+import * as libxmljs from 'libxmljs';
+
+const document: libxmljs.XMLDocument = libxslt.libxmljs.parseXmlString('<xml></xml>');
+
+let stylesheet: libxslt.Stylesheet;
+
+stylesheet = libxslt.parse('<xslt></xslt>');
+
+stylesheet = libxslt.parse(document);
+
+libxslt.parse('<xslt></xslt>', (err, result) => {
+	if (err == null) {
+		stylesheet = result;
+	}
+});
+
+libxslt.parse(document, (err, result) => {
+	if (err == null) {
+		stylesheet = result;
+	}
+});
+
+libxslt.parseFile('/path/to/file', (err, result) => {
+	if (err == null) {
+		stylesheet = result;
+	}
+});
+
+let applyOptions: libxslt.ApplyOptions = {};
+
+applyOptions = {
+	outputFormat: 'string',
+	noWrapParams: true
+};
+
+let transformedString: string;
+
+let transformedDocument: libxmljs.XMLDocument;
+
+transformedString = stylesheet.apply('<xml></xml>');
+
+transformedString = stylesheet.apply('<xml></xml>', {});
+
+let applyResult = stylesheet.apply('<xml></xml>', {}, applyOptions);
+
+if (typeof applyResult === 'string') {
+	transformedString = applyResult;
+} else {
+	transformedDocument = applyResult;
+}
+
+stylesheet.apply('<xml></xml>', {}, applyOptions, (err, result) => {
+	if (err != null) {
+		return;
+	}
+
+	if (typeof result === 'string') {
+		transformedString = result;
+	} else {
+		transformedDocument = result;
+	}
+});
+
+transformedDocument = stylesheet.apply(document);
+
+transformedDocument = stylesheet.apply(document, {});
+
+applyResult = stylesheet.apply(document, {}, applyOptions);
+
+if (typeof applyResult === 'string') {
+	transformedString = applyResult;
+} else {
+	transformedDocument = applyResult;
+}
+
+stylesheet.apply(document, {}, applyOptions, (err, result) => {
+	if (err != null) {
+		return;
+	}
+
+	if (typeof result === 'string') {
+		transformedString = result;
+	} else {
+		transformedDocument = result;
+	}
+});
+
+stylesheet.applyToFile('/path/to/file', {}, applyOptions, (err, result) => {
+	if (err == null) {
+		transformedString = result;
+	}
+});
+
+stylesheet.applyToFile('/path/to/file', (err, result) => {
+	if (err == null) {
+		transformedString = result;
+	}
+});

--- a/libxslt/libxslt.d.ts
+++ b/libxslt/libxslt.d.ts
@@ -1,0 +1,61 @@
+// Type definitions for node-libxslt
+// Project: https://github.com/albanm/node-libxslt
+// Definitions by: Alejandro Sánchez <https://github.com/alejo90>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../libxmljs/libxmljs.d.ts" />
+
+declare module 'libxslt' {
+	import * as xmljs from 'libxmljs';
+
+	export const libxmljs: typeof xmljs;
+
+	type OutputFormat = 'document' | 'string';
+
+	export interface ApplyOptions {
+		outputFormat?: OutputFormat;
+		noWrapParams?: boolean;
+	}
+
+	type ApplyResult = string | xmljs.XMLDocument;
+
+	type ApplyCallback = (err: Error, result: ApplyResult) => void;
+
+	type ApplyStringCallback = (err: Error, result: string) => void;
+
+	type ApplyDocumentCallback = (err: Error, result: xmljs.XMLDocument) => void;
+
+	export interface Stylesheet {
+		apply(source: string, params?: Object): string;
+
+		apply(source: string, params: Object, options: ApplyOptions): ApplyResult;
+
+		apply(source: string, params: Object, options: ApplyOptions, callback: ApplyCallback): void;
+
+		apply(source: string, callback: ApplyStringCallback): void;
+
+		apply(source: xmljs.XMLDocument, params?: Object): xmljs.XMLDocument;
+
+		apply(source: xmljs.XMLDocument, params: Object, options: ApplyOptions): ApplyResult;
+
+		apply(source: xmljs.XMLDocument, params: Object, options: ApplyOptions, callback: ApplyCallback): void;
+
+		apply(source: xmljs.XMLDocument, callback: ApplyDocumentCallback): void;
+
+		applyToFile(sourcePath: string, params: Object, options: ApplyOptions, callback: ApplyStringCallback): void;
+
+		applyToFile(sourcePath: string, callback: ApplyStringCallback): void;
+	}
+
+	type ParseCallback = (err: Error, stylesheet: Stylesheet) => void;
+
+	export function parse(source: string): Stylesheet;
+
+	export function parse(source: string, callback: ParseCallback): void;
+
+	export function parse(source: xmljs.XMLDocument): Stylesheet;
+
+	export function parse(source: xmljs.XMLDocument, callback: ParseCallback): void;
+
+	export function parseFile(sourcePath: string, callback: ParseCallback): void;
+}


### PR DESCRIPTION
Project https://github.com/albanm/node-libxslt
API https://github.com/albanm/node-libxslt/blob/master/README.md

case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
