### PR TITLE
Node.d.ts Decompose  class EventEmitter w/ _static

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -240,7 +240,7 @@ declare namespace NodeJS {
         stack?: string;
     }
 
-    export interface EventEmitter {
+    export class EventEmitter {
         addListener(event: string, listener: Function): this;
         on(event: string, listener: Function): this;
         once(event: string, listener: Function): this;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -240,7 +240,7 @@ declare namespace NodeJS {
         stack?: string;
     }
 
-    export class EventEmitter {
+    export interface EventEmitter {
         addListener(event: string, listener: Function): this;
         on(event: string, listener: Function): this;
         once(event: string, listener: Function): this;
@@ -256,6 +256,13 @@ declare namespace NodeJS {
         prependOnceListener(event: string, listener: Function): this;
         eventNames(): string[];
     }
+
+    interface EventEmitter_Static {
+        new() : EventEmitter;
+        EventEmitter: EventEmitter_Static;
+        listenerCount(emitter: EventEmitter, event: string): number; // deprecated
+        defaultMaxListeners: number;
+     } 
 
     export interface ReadableStream extends EventEmitter {
         readable: boolean;
@@ -547,25 +554,11 @@ declare module "querystring" {
 }
 
 declare module "events" {
-    export class EventEmitter extends NodeJS.EventEmitter {
-        static EventEmitter: EventEmitter;
-        static listenerCount(emitter: EventEmitter, event: string): number; // deprecated
-        static defaultMaxListeners: number;
-
-        addListener(event: string, listener: Function): this;
-        on(event: string, listener: Function): this;
-        once(event: string, listener: Function): this;
-        prependListener(event: string, listener: Function): this;
-        prependOnceListener(event: string, listener: Function): this;
-        removeListener(event: string, listener: Function): this;
-        removeAllListeners(event?: string): this;
-        setMaxListeners(n: number): this;
-        getMaxListeners(): number;
-        listeners(event: string): Function[];
-        emit(event: string, ...args: any[]): boolean;
-        eventNames(): string[];
-        listenerCount(type: string): number;
+       namespace EventEmitter {
+        type  EventEmitter= NodeJS.EventEmitter;
     }
+    const EventEmitter: NodeJS.EventEmitter_Static;
+    export = EventEmitter;
 }
 
 declare module "http" {


### PR DESCRIPTION
This decomposition is to allow declaration of circular definition of EventEmitter in module events, per docs at https://nodejs.org/dist/latest-v6.x/docs/api/events.html#events_class_eventemitter,.   

See issue #10968 for related discussion.
