### PR TITLE
Changed return type of `toArray` to `HTMLElement[]`

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -2782,7 +2782,7 @@ interface JQuery {
      * Retrieve all the elements contained in the jQuery set, as an array.
      * @name toArray
      */
-    toArray(): Element[];
+    toArray(): (Element|HTMLElement)[];
 
     /**
      * Remove the parents of the set of matched elements from the DOM, leaving the matched elements in their place.
@@ -2840,7 +2840,7 @@ interface JQuery {
      * Retrieve the elements matched by the jQuery object.
      * @alias toArray
      */
-    get(): Element[];
+    get(): (Element|HTMLElement)[];
 
     /**
      * Search for a given element from among the matched elements.

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -2780,8 +2780,9 @@ interface JQuery {
 
     /**
      * Retrieve all the elements contained in the jQuery set, as an array.
+     * @name toArray
      */
-    toArray(): any[];
+    toArray(): Element[];
 
     /**
      * Remove the parents of the set of matched elements from the DOM, leaving the matched elements in their place.
@@ -2837,8 +2838,9 @@ interface JQuery {
     get(index: number): HTMLElement;
     /**
      * Retrieve the elements matched by the jQuery object.
+     * @alias toArray
      */
-    get(): any[];
+    get(): Element[];
 
     /**
      * Search for a given element from among the matched elements.

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -2782,7 +2782,7 @@ interface JQuery {
      * Retrieve all the elements contained in the jQuery set, as an array.
      * @name toArray
      */
-    toArray(): (Element|HTMLElement)[];
+    toArray(): HTMLElement[];
 
     /**
      * Remove the parents of the set of matched elements from the DOM, leaving the matched elements in their place.
@@ -2840,7 +2840,7 @@ interface JQuery {
      * Retrieve the elements matched by the jQuery object.
      * @alias toArray
      */
-    get(): (Element|HTMLElement)[];
+    get(): HTMLElement[];
 
     /**
      * Search for a given element from among the matched elements.


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

**NOTE** Also changed the return type for `get(void)` and added a JSDoc [`@alias`](http://usejsdoc.org/tags-alias.html) annotation.

**Documentation** See [`toArray()`](https://api.jquery.com/toArray/) and [`get(void)`](https://api.jquery.com/get/#get).

Due to [legacy support](https://forum.jquery.com/topic/get-vs-toarray-get-index-vs-index), these functions are [practically aliases](https://github.com/jquery/jquery/blob/6acf4a79467a5aea5bc1eb7d552d72366718635d/src/core.js#L60).
