### PR TITLE
Remove @deprecated from non-deprecated functions

### DIFF
--- a/fabricjs/fabricjs.d.ts
+++ b/fabricjs/fabricjs.d.ts
@@ -333,7 +333,6 @@ declare namespace fabric {
     on(eventName: {[key:string] : Function}): T;
     /**
      * Fires event with an optional options object
-     * @deprecated `fire` deprecated since 1.0.7 (use `trigger` instead)
      * @param {String} eventName Event name to fire
      * @param {Object} [options] Options object
      */
@@ -341,7 +340,6 @@ declare namespace fabric {
     /**
      * Stops event observing for a particular event handler. Calling this method
      * without arguments removes all handlers for all events
-     * @deprecated `stopObserving` deprecated since 0.8.34 (use `off` instead)
      * @param eventName Event name (eg. 'after:render') or object with key/value pairs (eg. {'after:render': handler, 'selection:cleared': handler})
      * @param handler Function to be deleted from EventListeners
      */


### PR DESCRIPTION
These API changes were made:

`fire` became `trigger`
`stopObserving` became `off`

But the typings have the _latter_ as `@deprecated`. The diff should be enough of a source, but [here](http://fabricjs.com/docs/fabric.Observable.html) is the original documentation which supports this as well.
