### PR TITLE
Create typings for is-plain-object

### DIFF
--- a/is-plain-object/is-plain-object-tests.ts
+++ b/is-plain-object/is-plain-object-tests.ts
@@ -1,0 +1,25 @@
+/// <reference path="is-plain-object.d.ts" />
+
+import * as isPlainObject from 'is-plain-object';
+
+isPlainObject(Object.create({}));
+//=> true
+isPlainObject(Object.create(Object.prototype));
+//=> true
+isPlainObject({foo: 'bar'});
+//=> true
+isPlainObject({});
+
+isPlainObject(1);
+//=> false
+isPlainObject(['foo', 'bar']);
+//=> false
+isPlainObject([]);
+//=> false
+class Foo {}
+isPlainObject(new Foo);
+//=> false
+isPlainObject(null);
+//=> false
+isPlainObject(Object.create(null));
+//=> false

--- a/is-plain-object/is-plain-object.d.ts
+++ b/is-plain-object/is-plain-object.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for is-plain-object
+// Project: https://github.com/jonschlinkert/is-plain-object
+// Definitions by: Kevin Zeng <https://github.com/zengfenfei/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "is-plain-object" {
+    namespace isPlainObject {}
+    function isPlainObject(obj: any): boolean;
+    export = isPlainObject;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
