### PR TITLE
AutoComplete accepts React.Node as floatingLabelText

### DIFF
--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -556,7 +556,7 @@ declare namespace __MaterialUI {
         errorStyle?: React.CSSProperties;
         errorText?: string;
         filter?: (searchText: string, key: string, item: AutoCompleteDataItem) => boolean;
-        floatingLabelText?: string;
+        floatingLabelText?: React.ReactNode;
         fullWidth?: boolean;
         hintText?: string;
         listStyle?: React.CSSProperties;


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

http://www.material-ui.com/#/components/auto-complete
