### PR TITLE
Update aws-sdk.d.ts

### DIFF
--- a/aws-sdk/aws-sdk.d.ts
+++ b/aws-sdk/aws-sdk.d.ts
@@ -226,7 +226,7 @@ declare module "aws-sdk" {
     constructor(options?: any);
     endpoint: Endpoint;
 
-    getObject(params: s3.GetObjectRequest, callback: (err: Error, data: any) => void): void;
+    getObject(params: s3.GetObjectRequest, callback?: (err: Error, data: any) => void): any;
     putObject(params: s3.PutObjectRequest, callback: (err: Error, data: any) => void): void;
     deleteObject(params: s3.DeleteObjectRequest, callback: (err: Error, data: any) => void): void;
     headObject(params: s3.HeadObjectRequest, callback: (err: Error, data: any) => void): void;


### PR DESCRIPTION
Callback is not required for getObject method.

When you need to create a read stream from a response, you can easily create it without a callback, example:

`const fileStream = storage.getObject(params).createReadStream();`
