### PR TITLE
Adding a new type definition for autobind-decorator

### DIFF
--- a/autobind-decorator/autobind-decorator-tests.ts
+++ b/autobind-decorator/autobind-decorator-tests.ts
@@ -28,13 +28,13 @@ Test.test(); // logs 'static'.
 
 @autobind
 class Component {
-  public constructor(private someMember: string) {
-    this.someMember = someMember;
-  }
+    public constructor(private someMember: string) {
+        this.someMember = someMember;
+    }
   
-  public somMethod(): void {
-    console.error(this.someMember);
-  }
+    public somMethod(): void {
+        console.error(this.someMember);
+    }
 }
 
 const component: Component = new Component('React vs Angular2');

--- a/autobind-decorator/autobind-decorator-tests.ts
+++ b/autobind-decorator/autobind-decorator-tests.ts
@@ -1,0 +1,43 @@
+/// <reference path="autobind-decorator.d.ts" />
+
+import autobind = require('autobind-decorator');
+
+class Test {
+    public static what: string = 'static';
+
+    @bind
+    public static test(): void {
+        console.log(this.what);
+    }
+
+    public constructor(public what: string) {
+        this.what = what;
+    }
+
+    @bind
+    public test(): void {
+        console.warn(this.what);
+    }
+}
+
+const tester: Test = new Test('bind');
+const { test } = tester;
+tester.test(); // warns 'bind'.
+test(); // warns 'bind'.
+Test.test(); // logs 'static'.
+
+@autobind
+class Component {
+  public constructor(private someMember: string) {
+    this.someMember = someMember;
+  }
+  
+  public somMethod(): void {
+    console.error(this.someMember);
+  }
+}
+
+const component: Component = new Component('React vs Angular2');
+const { somMethod } = component;
+component.someMethod(); // errors 'React vs Angular2'
+somMethod(); // errors 'React vs Angular2'

--- a/autobind-decorator/autobind-decorator-tests.ts
+++ b/autobind-decorator/autobind-decorator-tests.ts
@@ -5,7 +5,7 @@ import autobind = require('autobind-decorator');
 class Test {
     public static what: string = 'static';
 
-    @bind
+    @autobind
     public static test(): void {
         console.log(this.what);
     }
@@ -14,7 +14,7 @@ class Test {
         this.what = what;
     }
 
-    @bind
+    @autobind
     public test(): void {
         console.warn(this.what);
     }

--- a/autobind-decorator/autobind-decorator-tests.ts
+++ b/autobind-decorator/autobind-decorator-tests.ts
@@ -32,12 +32,12 @@ class Component {
         this.someMember = someMember;
     }
   
-    public somMethod(): void {
+    public someMethod(): void {
         console.error(this.someMember);
     }
 }
 
 const component: Component = new Component('React vs Angular2');
-const { somMethod } = component;
+const { someMethod } = component;
 component.someMethod(); // errors 'React vs Angular2'
-somMethod(); // errors 'React vs Angular2'
+someMethod(); // errors 'React vs Angular2'

--- a/autobind-decorator/autobind-decorator.d.ts
+++ b/autobind-decorator/autobind-decorator.d.ts
@@ -1,3 +1,8 @@
+// Type definitions for autobind-decorator v1.3.3
+// Project: https://github.com/andreypopp/autobind-decorator
+// Definitions by: Ivo Stratev <https://github.com/NoHomey/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
 declare module 'autobind-decorator' {
     function autobind<TFunction extends Function>(target: TFunction): TFunction | void;
     function autobind<T extends Function>(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> | void;

--- a/autobind-decorator/autobind-decorator.d.ts
+++ b/autobind-decorator/autobind-decorator.d.ts
@@ -1,0 +1,5 @@
+declare module 'autobind-decorator' {
+    function autobind<TFunction extends Function>(target: TFunction): TFunction | void;
+    function autobind<T extends Function>(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> | void;
+    export = autobind;
+}

--- a/autobind-decorator/autobind-decorator.ts.tscparams
+++ b/autobind-decorator/autobind-decorator.ts.tscparams
@@ -1,0 +1,1 @@
+--experimentalDecorators


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Adding a new type definition for `autobind-decorator`
