### PR TITLE
Update resolve type in angular-material.d.ts.

### DIFF
--- a/angular-material/angular-material.d.ts
+++ b/angular-material/angular-material.d.ts
@@ -22,7 +22,7 @@ declare namespace angular.material {
         clickOutsideToClose?: boolean;
         disableBackdrop?: boolean;
         escapeToClose?: boolean;
-        resolve?: {[index: string]: angular.IPromise<any>};
+        resolve?: {[index: string]: () => angular.IPromise<any>};
         controllerAs?: string;
         parent?: Function|string|Object; // default: root node
         disableParentScroll?: boolean; // default: true
@@ -53,7 +53,7 @@ declare namespace angular.material {
         controller(controller?: string|Function): T;
         locals(locals?: {[index: string]: any}): T;
         bindToController(bindToController?: boolean): T; // default: false
-        resolve(resolve?: {[index: string]: angular.IPromise<any>}): T;
+        resolve(resolve?: {[index: string]: () => angular.IPromise<any>}): T;
         controllerAs(controllerAs?: string): T;
         parent(parent?: string|Element|JQuery): T; // default: root node
         onComplete(onComplete?: Function): T;
@@ -91,7 +91,7 @@ declare namespace angular.material {
         controller?: string|Function;
         locals?: {[index: string]: any};
         bindToController?: boolean; // default: false
-        resolve?: {[index: string]: angular.IPromise<any>}
+        resolve?: {[index: string]: () => angular.IPromise<any>}
         controllerAs?: string;
         parent?: string|Element|JQuery; // default: root node
         onShowing?: Function;
@@ -165,7 +165,7 @@ declare namespace angular.material {
         controller?: string|Function;
         locals?: {[index: string]: any};
         bindToController?: boolean; // default: false
-        resolve?: {[index: string]: angular.IPromise<any>}
+        resolve?: {[index: string]: () => angular.IPromise<any>}
         controllerAs?: string;
         parent?: string|Element|JQuery; // default: root node
     }
@@ -297,7 +297,7 @@ declare namespace angular.material {
         controllerAs?: string;
         bindToController?: boolean; // default: true
         locals?: {[index: string]: any};
-        resolve?: {[index: string]: angular.IPromise<any>}
+        resolve?: {[index: string]: () => angular.IPromise<any>}
         attachTo?: string|JQuery|Element;
         propagateContainerEvents?: boolean;
         panelClass?: string;


### PR DESCRIPTION
Resolve is using the [mdCompileService](https://github.com/angular/material/blob/18afebe15e431e8413dcc7ebdb1c00c80c15b7f0/src/core/services/compiler/compiler.js#L47), which requires an object of functions that return promises, not promises.
