### PR TITLE
Define Turf 3.5.2 definition

### DIFF
--- a/turf/turf-2.0-tests.ts
+++ b/turf/turf-2.0-tests.ts
@@ -1,53 +1,28 @@
-/// <reference path="turf.d.ts"/>
-import * as turf from 'turf'
+/// <reference path="turf-2.0.d.ts"/>
 
 ///////////////////////////////////////////
 // Tests data initialisation
 ///////////////////////////////////////////
 
-const resolution = 15
-const cellWidth = 50
-const count = 100
-const bbox = [0, 0, 10, 10]
-const distance = 50
-const bearing = 90
-const tolerance = 0.01
-const maxEdge = 1
-const units = 'miles'
-const properties = {foo: 'bar'}
-const highQuality = false
-const breaks = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-const point: GeoJSON.Feature<GeoJSON.Point> = {
+var point1: GeoJSON.Feature<GeoJSON.Point> = {
   "type": "Feature",
   "properties": {},
   "geometry": {
     "type": "Point",
     "coordinates": [-75.343, 39.984]
   }
-}
+};
 
-const point1 = point
-
-const point2: GeoJSON.Feature<GeoJSON.Point> = {
+var point2: GeoJSON.Feature<GeoJSON.Point> = {
   "type": "Feature",
   "properties": {},
   "geometry": {
     "type": "Point",
-    "coordinates": [-75.401, 39.884]
-  }
-}
+    "coordinates": [-75.534, 39.123]
+    }
+};
 
-const multiPoint: GeoJSON.Feature<GeoJSON.MultiPoint> = {
-  "type": "Feature",
-  "properties": {},
-  "geometry": {
-    "type": "MultiPoint",
-    "coordinates": [ [100.0, 0.0], [101.0, 1.0] ]
-  }
-}
-
-const line: GeoJSON.Feature<GeoJSON.LineString> = {
+var line: GeoJSON.Feature<GeoJSON.LineString> = {
   "type": "Feature",
   "properties": {},
   "geometry": {
@@ -61,21 +36,9 @@ const line: GeoJSON.Feature<GeoJSON.LineString> = {
       [-77.019824, 38.892368]
     ]
   }
-}
+};
 
-const multiLine: GeoJSON.Feature<GeoJSON.MultiLineString> = {
-  "type": "Feature",
-  "properties": {},
-  "geometry": {
-    "type": "MultiLineString",
-    "coordinates": [
-        [ [100.0, 0.0], [101.0, 1.0] ],
-        [ [102.0, 2.0], [103.0, 3.0] ]
-      ]
-  }
-}
-
-const polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon> = {
+var polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon> = {
   "type": "FeatureCollection",
   "features": [
     {
@@ -106,9 +69,9 @@ const polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon> = {
       }
     }
   ]
-}
+};
 
-const polygon: GeoJSON.Feature<GeoJSON.Polygon> = {
+var polygon1: GeoJSON.Feature<GeoJSON.Polygon> = {
   "type": "Feature",
   "properties": {},
   "geometry": {
@@ -121,11 +84,9 @@ const polygon: GeoJSON.Feature<GeoJSON.Polygon> = {
       [105.818939,21.004714]
     ]]
   }
-}
+};
 
-const polygon1 = polygon
-
-const polygon2: GeoJSON.Feature<GeoJSON.Polygon> = {
+var polygon2: GeoJSON.Feature<GeoJSON.Polygon> = {
   "type": "Feature",
   "properties": {
     "fill": "#00f"
@@ -145,20 +106,7 @@ const polygon2: GeoJSON.Feature<GeoJSON.Polygon> = {
   }
 }
 
-const multiPolygon: GeoJSON.Feature<GeoJSON.MultiPolygon> = {
-  "type": "Feature",
-  "properties": {},
-  "geometry": {
-    "type": "MultiPolygon",
-    "coordinates": [
-      [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0]]],
-      [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],
-       [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]
-      ]
-  }
-}
-
-const points: GeoJSON.FeatureCollection<GeoJSON.Point> = {
+var features: GeoJSON.FeatureCollection<GeoJSON.Point> = {
   "type": "FeatureCollection",
   "features": [
     {
@@ -247,9 +195,9 @@ const points: GeoJSON.FeatureCollection<GeoJSON.Point> = {
       }
     }
   ]
-}
+};
 
-const triangle: GeoJSON.Feature<GeoJSON.Polygon> = {
+var triangle: GeoJSON.Feature<GeoJSON.Polygon> = {
   "type": "Feature",
   "properties": {
     "a": 11,
@@ -265,205 +213,310 @@ const triangle: GeoJSON.Feature<GeoJSON.Polygon> = {
       [-75.1221, 39.57]
     ]]
   }
-}
+};
+
+var aggregations = [
+  {
+    aggregation: 'sum',
+    inField: 'population',
+    outField: 'pop_sum'
+  },
+  {
+    aggregation: 'average',
+    inField: 'population',
+    outField: 'pop_avg'
+  },
+  {
+    aggregation: 'median',
+    inField: 'population',
+    outField: 'pop_median'
+  },
+  {
+    aggregation: 'min',
+    inField: 'population',
+    outField: 'pop_min'
+  },
+  {
+    aggregation: 'max',
+    inField: 'population',
+    outField: 'pop_max'
+  },
+  {
+    aggregation: 'deviation',
+    inField: 'population',
+    outField: 'pop_deviation'
+  },
+  {
+    aggregation: 'variance',
+    inField: 'population',
+    outField: 'pop_variance'
+  },
+  {
+    aggregation: 'count',
+    inField: '',
+    outField: 'point_count'
+  }
+];
+
+///////////////////////////////////////////
+// Tests Aggregation
+///////////////////////////////////////////
+
+// -- Test aggregate --
+var aggregated = turf.aggregate(polygons, points, aggregations);
+
+// -- Test average --
+var averaged = turf.average(polygons, points, 'population', 'pop_avg');
+
+// -- Test count --
+var counted = turf.count(polygons, points, 'pt_count');
+
+// -- Test deviation --
+var deviated = turf.deviation(polygons, points, 'population', 'pop_deviation');
+
+// -- Test max --
+var aggregated = turf.max(polygons, points, 'population', 'max');
+
+// -- Test median --
+var medians = turf.median(polygons, points, 'population', 'median');
+
+// -- Test min --
+var minimums = turf.min(polygons, points, 'population', 'min');
+
+// -- Test sum --
+var summed = turf.sum(polygons, points, 'population', 'sum');
+
+// -- Test variance --
+var varianced = turf.variance(polygons, points, 'population', 'variance');
 
 ///////////////////////////////////////////
 // Tests Measurement
 ///////////////////////////////////////////
 
 // -- Test along --
-turf.along(line, distance, units)
-turf.along(line, distance)
+var along = turf.along(line, 1, 'miles');
 
 // -- Test area --
-turf.area(polygons)
+var area = turf.area(polygons);
 
 // -- Test bboxPolygon --
-turf.bboxPolygon(bbox)
+var bbox = [0, 0, 10, 10];
+var poly = turf.bboxPolygon(bbox);
 
 // -- Test bearing --
-turf.bearing(point1, point2)
+var bearing = turf.bearing(point1, point2);
 
 // -- Test center
-turf.center(points)
+var centerPt = turf.center(features);
 
 // -- Test centroid --
-turf.centroid(polygon1)
+var centroidPt = turf.centroid(polygon1);
 
 // -- Test destination --
-turf.destination(point1, distance, bearing, units)
+var distance = 50;
+var bearing = 90;
+var units = 'miles';
+var destination = turf.destination(point1, distance, bearing, units);
 
 // -- Test distance --
-turf.distance(point1, point2, units)
+var units = "miles";
+var distance = turf.distance(point1, point2, units);
 
 // -- Test envelope --
-turf.envelope(polygons)
+var enveloped = turf.envelope(polygons);
+
+// -- Test extent --
+var bbox = turf.extent(polygons);
 
 // -- Test lineDistance
-turf.lineDistance(line, units)
+var length = turf.lineDistance(line, 'miles');
 
 // -- Test midpoint --
-turf.midpoint(point1, point2)
+var midpointed = turf.midpoint(point1, point2);
 
 // -- Test pointOnSurface --
-turf.pointOnSurface(polygon1)
+var pointOnPolygon = turf.pointOnSurface(polygon1);
+
+// -- Test size --
+var resized = turf.size(bbox, 2);
 
 // -- Test square --
-turf.square(bbox)
+var squared = turf.square(bbox);
 
 ///////////////////////////////////////////
 // Tests Transformation
 ///////////////////////////////////////////
 
 // -- Test bezier --
-turf.bezier(line)
+var curved = turf.bezier(line);
 
 // -- Test buffer --
-turf.buffer(point1, distance, units)
+var buffered = turf.buffer(point1, 500, units);
 
 // -- Test concave --
-turf.concave(points, maxEdge, units)
+var hull = turf.concave(features, 1, 'miles');
 
 // -- Test convex --
-turf.convex(points)
+var hull = turf.convex(features);
 
 // -- Test difference --
-turf.difference(polygon1, polygon2)
+var differenced = turf.difference(polygon1, polygon2);
 
 // -- Test intersect --
-turf.intersect(polygon1, polygon2)
+var intersection = turf.intersect(polygon1, polygon2);
+
+// -- Test merge --
+var merged = turf.merge(polygons);
 
 // -- Test simplify --
-
-turf.simplify(polygon1, tolerance, highQuality)
+var tolerance = 0.01;
+var simplified = turf.simplify(polygon1, tolerance, false);
 
 // -- Test union --
-turf.union(polygon1, polygon2)
+var union = turf.union(polygon1, polygon2);
 
 ///////////////////////////////////////////
 // Tests Misc
 ///////////////////////////////////////////
 
 // -- Test combine --
-turf.combine(points)
+var combined = turf.combine(features);
 
 // -- Test explode --
-turf.explode(polygon1)
+var points = turf.explode(polygon1);
 
 // -- Test flip --
-turf.flip(point1)
+var flipedPoint = turf.flip(point1);
 
 // -- Test kinks --
-turf.kinks(polygon1)
+var kinks = turf.kinks(polygon1);
 
 // -- Test lineSlice --
-turf.lineSlice(point1, point2, line)
+var sliced = turf.lineSlice(point1, point2, line);
 
 // -- Test pointOnLine --
-turf.pointOnLine(line, point1)
+var snapped = turf.pointOnLine(line, point1);
 
 ///////////////////////////////////////////
 // Tests Helper
 ///////////////////////////////////////////
 
 // -- Test featurecollection --
-turf.featureCollection([point1, point2])
-turf.featureCollection([point, polygon])
-turf.featureCollection([polygon1, polygon2])
-turf.featureCollection([line, polygon])
-turf.featureCollection([line, point])
+var fc = turf.featurecollection([point1, point2]);
 
-// -- Test feature --
-turf.feature(point)
-turf.feature(polygon)
-turf.feature(line)
-
-// -- Test lineString --
-turf.lineString(line.geometry.coordinates)
-turf.lineString(line.geometry.coordinates, properties)
-
-// -- Test multiLineString --
-turf.multiLineString(multiLine.geometry.coordinates)
+// -- Test linestring --
+var linestring1 = turf.linestring([
+	[-21.964416, 64.148203],
+	[-21.956176, 64.141316],
+	[-21.93901, 64.135924],
+	[-21.927337, 64.136673]
+]);
+var linestring2 = turf.linestring([
+	[-21.929054, 64.127985],
+	[-21.912918, 64.134726],
+	[-21.916007, 64.141016],
+	[-21.930084, 64.14446]
+], {name: 'line 1', distance: 145});
 
 // -- Test point --
-turf.point(point.geometry.coordinates)
-turf.point(point.geometry.coordinates, properties)
-
-// -- Test multiPoint --
-turf.multiPoint(multiPoint.geometry.coordinates)
+var pt1 = turf.point([-75.343, 39.984]);
+var pt2 = turf.point([-75.343, 39.984], {name: 'point 1', distance: 145});
 
 // -- Test polygon --
-turf.polygon(polygon.geometry.coordinates, properties)
-
-// -- Test multiPolygon --
-turf.multiPolygon(multiPolygon.geometry.coordinates, properties)
-
-// -- Test geometryCollection --
-turf.geometryCollection([point.geometry, line.geometry]);
+var polygon = turf.polygon([[
+ [-2.275543, 53.464547],
+ [-2.275543, 53.489271],
+ [-2.215118, 53.489271],
+ [-2.215118, 53.464547],
+ [-2.275543, 53.464547]
+]], { name: 'poly1', population: 400});
 
 ///////////////////////////////////////////
 // Tests Data
 ///////////////////////////////////////////
 
+// -- Test filter --
+var key = "species";
+var value = "oak";
+var filtered = turf.filter(features, key, value);
+
 // -- Test random --
-turf.random('points', 100)
-turf.random('points', 100, { bbox })
-turf.random('polygons', 4, {
-  bbox,
-  num_vertices: 10,
+var randomPoints = turf.random('points', 100, {
+  bbox: [-70, 40, -60, 60]
+});
+
+var randomPoints = turf.random('points', 100, {
+  bbox: [-70, 40, -60, 60],
+  num_vertices: 2,
   max_radial_length: 10
-})
+});
+
+// -- Test remove --
+var filtered = turf.remove(points, 'marker-color', '#00f');
 
 // -- Test sample --
-turf.random('points', 1000)
-turf.sample(points, 10)
+var randomPoints = turf.random('points', 1000);
+var sample = turf.sample(points, 10);
 
 ///////////////////////////////////////////
 // Tests Interpolation
 ///////////////////////////////////////////
 
 // -- Test hexGrid --
-turf.hexGrid(bbox, cellWidth, units)
+var cellWidth = 50;
+var hexgrid = turf.hexGrid(bbox, cellWidth, units);
 
 // -- Test isolines --
-turf.isolines(points, 'z', resolution, breaks)
+var breaks = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+var isolined = turf.isolines(points, 'z', 15, breaks);
 
 // -- Test planepoint --
-turf.planepoint(point1, triangle)
+var zValue = turf.planepoint(point1, triangle);
 
 // -- Test pointGrid --
-turf.pointGrid(bbox, cellWidth, units)
+var extent = [-70.823364, -33.553984, -70.473175, -33.302986];
+var cellWidth = 3;
+var grid = turf.pointGrid(extent, cellWidth, units);
 
 // -- Test squareGrid --
-turf.squareGrid(bbox, cellWidth, units)
+var squareGrid = turf.squareGrid(extent, cellWidth, units);
 
 // -- Test tin --
-turf.tin(points, 'z')
+var tin = turf.tin(points, 'z');
 
 // -- Test triangleGrid --
-turf.triangleGrid(bbox, cellWidth, units)
+var triangleGrid = turf.triangleGrid(extent, cellWidth, units);
 
 ///////////////////////////////////////////
 // Tests Joins
 ///////////////////////////////////////////
 
 // -- Test inside --
-turf.inside(point, polygon)
+var isInside1 = turf.inside(point1, polygon);
 
 // -- Test tag --
-turf.tag(points, polygons, 'fill', 'marker-color')
+var tagged = turf.tag(points, triangleGrid, 'fill', 'marker-color');
 
 // -- Test within --
-turf.within(points, polygons)
+var ptsWithin = turf.within(points, polygons);
 
 ///////////////////////////////////////////
 // Tests Classification
 ///////////////////////////////////////////
 
-// -- Test nearest --
-turf.nearest(point1, points)
+// -- Test jenks --
+var breaks = turf.jenks(points, 'population', 3);
 
-///////////////////////////////////////////
-// Tests Aggregation
-///////////////////////////////////////////
-turf.collect(polygons, points, 'population', 'values')
+// -- Test nearest --
+var nearest = turf.nearest(point1, points);
+
+// -- Test quantile --
+var breaks = turf.quantile(points, 'population', [25, 50, 75, 99]);
+
+// -- Test reclass --
+var translations = [
+  [0, 200, "small"],
+  [200, 400, "medium"],
+  [400, 600, "large"]
+];
+var reclassed = turf.reclass(points, 'population', 'size', translations);

--- a/turf/turf-2.0.d.ts
+++ b/turf/turf-2.0.d.ts
@@ -1,91 +1,9 @@
-// Type definitions for Turf 3.5.2
+// Type definitions for Turf 2.0
 // Project: http://turfjs.org/
-// Definitions by: Denis Carriere <https://github.com/DenisCarriere>
+// Definitions by: Guillaume Croteau <https://github.com/gcroteau>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../geojson/geojson.d.ts" />
-
-/**
-#### TODO:
-
-Update all methods with newest JSDocs & tests based on the latest TurfJS library.
-
-AGGREGATION
-- [x] collect
-MEASUREMENT
-- [ ] along
-- [ ] area
-- [ ] bboxPolygon
-- [ ] bearing
-- [ ] center
-- [ ] centroid
-- [ ] destination
-- [ ] distance
-- [ ] envelope
-- [ ] lineDistance
-- [ ] midpoint
-- [ ] pointOnSurface
-- [ ] square
-TRANSFORMATION
-- [ ] bezier
-- [ ] buffer
-- [ ] concave
-- [ ] convex
-- [ ] difference
-- [ ] intersect
-- [ ] simplify
-- [ ] union
-MISC
-- [ ] combine
-- [ ] explode
-- [ ] flip
-- [ ] kinks
-- [ ] lineSlice
-- [ ] pointOnLine
-HELPER
-- [x] featureCollection
-- [x] feature
-- [x] lineString
-- [x] multiLineString
-- [x] point
-- [x] multiPoint
-- [x] polygon
-- [x] multiPolygon
-- [x] geometryCollection
-DATA
-- [x] random
-- [x] sample
-INTERPOLATION
-- [ ] isolines
-- [ ] planepoint
-- [ ] tin
-JOINS
-- [ ] inside
-- [ ] tag
-GRIDS
-- [ ] hexGrid
-- [ ] pointGrid
-- [ ] squareGrid
-- [ ] triangleGrid
-- [ ] within
-CLASSIFICATION
-- [ ] nearest
-META
-- [ ] propEach
-- [ ] coordEach
-- [ ] coordReduce
-- [ ] featureEach
-- [ ] getCoord
-ASSERTIONS
-- [ ] featureOf
-- [ ] collectionOf
-- [ ] bbox
-- [ ] circle
-- [ ] geojsonType
-- [ ] propReduce
-- [ ] coordAll
-- [ ] tesselate
- */
 
 declare module turf {
     //////////////////////////////////////////////////////
@@ -93,37 +11,93 @@ declare module turf {
     //////////////////////////////////////////////////////
 
     /**
-     * Merges a specified property from a FeatureCollection of points into a
-     * FeatureCollection of polygons. Given an `inProperty` on points and an `outProperty`
-     * for polygons, this finds every point that lies within each polygon, collects the
-     * `inProperty` values from those points, and adds them as an array to `outProperty`
-     * on the polygon.
-     *
-     * @name collect
-     * @param {FeatureCollection<Polygon>} polygons polygons with values on which to aggregate
-     * @param {FeatureCollection<Point>} points points to be aggregated
-     * @param {string} inProperty property to be nested from
-     * @param {string} outProperty property to be nested into
-     * @return {FeatureCollection<Polygon>} polygons with properties listed based on `outField`
-     * @example
-     * const poly1 = polygon([[[0,0],[10,0],[10,10],[0,10],[0,0]]])
-     * const poly2 = polygon([[[10,0],[20,10],[20,20],[20,0],[10,0]]])
-     * const polyFC = featurecollection([poly1, poly2])
-     * const pt1 = point([5,5], {population: 200})
-     * const pt2 = point([1,3], {population: 600})
-     * const pt3 = point([14,2], {population: 100})
-     * const pt4 = point([13,1], {population: 200})
-     * const pt5 = point([19,7], {population: 300})
-     * const ptFC = featurecollection([pt1, pt2, pt3, pt4, pt5])
-     * const aggregated = aggregate(polyFC, ptFC, 'population', 'values')
-     *
-     * aggregated.features[0].properties.values // => [200, 600])
-     */
-    function collect(
-      polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>,
-      points: GeoJSON.FeatureCollection<GeoJSON.Point>,
-      inProperty: string,
-      outProperty: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+    * Calculates a series of aggregations for a set of points within a set of polygons.
+    * Sum, average, count, min, max, and deviation are supported.
+    * @param polygons Polygons with values on which to aggregate
+    * @param points Points to be aggregated
+    * @param aggregations An array of aggregation objects
+    * @returns Polygons with properties listed based on outField values in aggregations
+    */
+    function aggregate(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, aggregations: Array<{aggregation: string, inField: string, outField: string}>): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+
+    /**
+    * Calculates the average value of a field for a set of points within a set of polygons.
+    * @param polygons Polygons with values on which to average
+    * @param points Points from which to calculate the average
+    * @param field The field in the points features from which to pull values to average
+    * @param outField The field in polygons to put results of the averages
+    * @returns Polygons with the value of outField set to the calculated averages
+    */
+    function average(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, field: string, outField: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+
+    /**
+    * Takes a set of points and a set of polygons and calculates the number of points that fall within the set of polygons.
+    * @param polygons Input polygons
+    * @param points Input points
+    * @param countField A field to append to the attributes of the Polygon features representing Point counts
+    * @returns Polygons with countField appended
+    */
+    function count(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, countField: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+
+    /**
+    * Calculates the standard deviation value of a field for a set of points within a set of polygons.
+    * @param polygons Input polygons
+    * @param points Input points
+    * @param inField The field in points from which to aggregate
+    * @param outField The field to append to polygons representing deviation
+    * @returns Polygons with appended field representing deviation
+    */
+    function deviation(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, inField: string, outField: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+
+    /**
+    * Calculates the maximum value of a field for a set of points within a set of polygons.
+    * @param polygons Input polygons
+    * @param points Input points
+    * @param inField The field in input data to analyze
+    * @param outField The field in which to store results
+    * @returns Polygons with properties listed as outField values
+    */
+    function max(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, inField: string, outField: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+
+    /**
+    * Calculates the median value of a field for a set of points within a set of polygons.
+    * @param polygons Input polygons
+    * @param points Input points
+    * @param inField The field in input data to analyze
+    * @param outField The field in which to store results
+    * @returns Polygons with properties listed as outField values
+    */
+    function median(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, inField: string, outField: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+
+    /**
+    * Calculates the minimum value of a field for a set of points within a set of polygons.
+    * @param polygons Input polygons
+    * @param points Input points
+    * @param inField The field in input data to analyze
+    * @param outField The field in which to store results
+    * @returns Polygons with properties listed as outField values
+    */
+    function min(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, inField: string, outField: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+
+    /**
+    * Calculates the sum of a field for a set of points within a set of polygons.
+    * @param polygons Input polygons
+    * @param points Input points
+    * @param inField The field in input data to analyze
+    * @param outField The field in which to store results
+    * @returns Polygons with properties listed as outField
+    */
+    function sum(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, inField: string, outField: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+
+    /**
+    * Calculates the variance value of a field for a set of points within a set of polygons.
+    * @param polygons Input polygons
+    * @param points Input points
+    * @param inField The field in input data to analyze
+    * @param outField The field in which to store results
+    * @returns Polygons with properties listed as outField
+    */
+    function variance(polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, points: GeoJSON.FeatureCollection<GeoJSON.Point>, inField: string, outField: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     //////////////////////////////////////////////////////
     // Measurement
@@ -176,7 +150,7 @@ declare module turf {
     function centroid(features: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
-    * Takes a Point and calculates the location of a destination point given a distance in degrees, radians, miles, or kilometers and bearing in degrees.
+    * Takes a Point and calculates the location of a destination point given a distance in degrees, radians, miles, or kilometers; and bearing in degrees.
     * This uses the Haversine formula to account for global curvature.
     * @param start Starting point
     * @param distance Distance from the starting point
@@ -204,6 +178,13 @@ declare module turf {
     function envelope(fc: GeoJSON.FeatureCollection<any>): GeoJSON.Feature<GeoJSON.Polygon>;
 
     /**
+    * Takes a set of features, calculates the extent of all input features, and returns a bounding box.
+    * @param input Input features
+    * @returns The bounding box of input given as an array in WSEN order (west, south, east, north)
+    */
+    function extent(input: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): Array<number>;
+
+    /**
     * Takes a line and measures its length in the specified units.
     * @param line Line to measure
     * @param units 'miles', 'kilometers', 'radians', or 'degrees'
@@ -226,6 +207,14 @@ declare module turf {
     * @returns A point on the surface of input
     */
     function pointOnSurface(input: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): GeoJSON.Feature<any>;
+
+    /**
+    * Takes a bounding box and returns a new bounding box with a size expanded or contracted by a factor of X.
+    * @param bbox A bounding box
+    * @param factor The ratio of the new bbox to the input bbox
+    * @returns The resized bbox
+    */
+    function size(bbox: Array<number>, factor: number): Array<number>;
 
     /**
     * Takes a bounding box and calculates the minimum square bounding box that would contain the input.
@@ -283,14 +272,22 @@ declare module turf {
 
     /**
     * Takes two polygons and finds their intersection.
-    *  If they share a border, returns the border if they don't intersect, returns undefined.
+    *  If they share a border, returns the border; if they don't intersect, returns undefined.
     * @param poly1 The first polygon
     * @param poly2 The second polygon
-    * @returns If poly1 and poly2 overlap, returns a Polygon feature representing the area they overlap
-    * if poly1 and poly2 do not overlap, returns undefined
+    * @returns If poly1 and poly2 overlap, returns a Polygon feature representing the area they overlap;
+    * if poly1 and poly2 do not overlap, returns undefined;
     * if poly1 and poly2 share a border, a MultiLineString of the locations where their borders are shared
     */
     function intersect(poly1: GeoJSON.Feature<GeoJSON.Polygon>, poly2: GeoJSON.Feature<GeoJSON.Polygon>): GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiLineString> | typeof undefined;
+
+    /**
+    * Takes a set of polygons and returns a single merged polygon feature.
+    * If the input polygon features are not contiguous, this function returns a MultiPolygon feature.
+    * @param fc Input polygons
+    * @returns Merged polygon or multipolygon
+    */
+    function merge(fc: GeoJSON.FeatureCollection<GeoJSON.Polygon>): GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>;
 
     /**
     * Takes a LineString or Polygon and returns a simplified version.
@@ -304,7 +301,7 @@ declare module turf {
 
     /**
     * Takes two polygons and returns a combined polygon.
-    * If the input polygons are not contiguous, this function returns a MultiPolygon feature.;
+    * If the input polygons are not contiguous, this function returns a MultiPolygon feature.
     * @param poly1 Input polygon
     * @param poly2 Another input polygon
     * @returns A combined Polygon or MultiPolygon feature
@@ -365,252 +362,77 @@ declare module turf {
     //////////////////////////////////////////////////////
 
     /**
-     * Takes one or more {@link Feature|Features} and creates a {@link FeatureCollection}.
-     * http://turfjs.org/docs/#featurecollection
-     * 
-     * @name featureCollection
-     * @param {Feature[]} features input features
-     * @returns {FeatureCollection} a FeatureCollection of input features
-     * @example
-     * var features = [
-     *  turf.point([-75.343, 39.984], {name: 'Location A'}),
-     *  turf.point([-75.833, 39.284], {name: 'Location B'}),
-     *  turf.point([-75.534, 39.123], {name: 'Location C'})
-     * ]
-     *
-     * var fc = turf.featureCollection(features)
-     *
-     * //=fc
-     */
-    function featureCollection(features: Array<GeoJSON.Feature<any>>): GeoJSON.FeatureCollection<any>;
+    * Takes one or more Features and creates a FeatureCollection.
+    * @param features Input features
+    * @returns A FeatureCollection of input features
+    */
+    function featurecollection(features: Array<GeoJSON.Feature<any>>): GeoJSON.FeatureCollection<any>;
 
     /**
-     * Wraps a GeoJSON {@link Geometry} in a GeoJSON {@link Feature}.
-     * http://turfjs.org/docs/#feature
-     *
-     * @name feature
-     * @param {Geometry} geometry input geometry
-     * @param {Object} properties properties
-     * @returns {FeatureCollection} a FeatureCollection of input features
-     * @example
-     * var geometry = {
-     *      "type": "Point",
-     *      "coordinates": [
-     *        67.5,
-     *        32.84267363195431
-     *      ]
-     *    }
-     *
-     * var feature = turf.feature(geometry)
-     *
-     * //=feature
-     */
-    function feature(geometry:GeoJSON.Feature<any>, properties?: any): GeoJSON.Feature<any>;
+    * Creates a LineString based on a coordinate array. Properties can be added optionally.
+    * @param coordinates An array of Positions
+    * @param [properties] An Object of key-value pairs to add as properties
+    * @returns A LineString feature
+    */
+    function linestring(coordinates: Array<Array<number>>, properties?: any): GeoJSON.Feature<GeoJSON.LineString>;
 
     /**
-     * Creates a {@link LineString} based on a coordinate array. Properties can be added optionally.
-     * http://turfjs.org/docs/#linestring
-     * 
-     * @name lineString
-     * @param {Array<Array<number>>} coordinates an array of Positions
-     * @param {Object=} properties an Object of key-value pairs to add as properties
-     * @returns {Feature<LineString>} a LineString feature
-     * @throws {Error} if no coordinates are passed
-     * @example
-     * var linestring1 = turf.lineString([
-     *	  [-21.964416, 64.148203],
-     *	  [-21.956176, 64.141316],
-     *	  [-21.93901, 64.135924],
-     *	  [-21.927337, 64.136673]
-     * ])
-     * var linestring2 = turf.lineString([
-     *	  [-21.929054, 64.127985],
-     *	  [-21.912918, 64.134726],
-     *	  [-21.916007, 64.141016],
-     * 	[-21.930084, 64.14446]
-     * ], {name: 'line 1', distance: 145})
-     *
-     * //=linestring1
-     *
-     * //=linestring2
-     */
-    function lineString(coordinates: Array<Array<number>>, properties?: any): GeoJSON.Feature<GeoJSON.LineString>;
-
-    /**
-     * Creates a {@link Feature<MultiLineString>} based on a coordinate array. Properties can be added optionally.
-     * http://turfjs.org/docs/#multilinestring
-     * 
-     * @name multiLineString
-     * @param {Array<Array<Array<number>>>} coordinates an array of LineStrings
-     * @param {Object=} properties an Object of key-value pairs to add as properties
-     * @returns {Feature<MultiLineString>} a MultiLineString feature
-     * @throws {Error} if no coordinates are passed
-     * @example
-     * var multiLine = turf.multiLineString([[[0,0],[10,10]]])
-     *
-     * //=multiLine
-     *
-     */
-    function multiLineString(coordinates: Array<Array<Array<number>>>, properties?: any): GeoJSON.Feature<GeoJSON.MultiLineString>;
-
-    /**
-     * Takes coordinates and properties (optional) and returns a new {@link Point} feature.
-     * http://turfjs.org/docs/#point
-     * 
-     * @name point
-     * @param {Array<number>} coordinates longitude, latitude position (each in decimal degrees)
-     * @param {Object=} properties an Object that is used as the {@link Feature}'s
-     * properties
-     * @returns {Feature<Point>} a Point feature
-     * @example
-     * var pt1 = turf.point([-75.343, 39.984]);
-     *
-     * //=pt1
-     */
+    * Takes coordinates and properties (optional) and returns a new Point feature.
+    * @param coordinates Longitude, latitude position (each in decimal degrees)
+    * @param [properties] An Object of key-value pairs to add as properties
+    * @returns A Point feature
+    */
     function point(coordinates: Array<number>, properties?: any): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
-     * Creates a {@link Feature<MultiPoint>} based on a coordinate array. Properties can be added optionally.
-     * http://turfjs.org/docs/#multipoint
-     * 
-     * @name multiPoint
-     * @param {Array<Array<number>>} coordinates an array of Positions
-     * @param {Object=} properties an Object of key-value pairs to add as properties
-     * @returns {Feature<MultiPoint>} a MultiPoint feature
-     * @throws {Error} if no coordinates are passed
-     * @example
-     * var multiPt = turf.multiPoint([[0,0],[10,10]])
-     *
-     * //=multiPt
-     *
-     */
-    function multiPoint(coordinates: Array<Array<number>>, properties?: any): GeoJSON.Feature<GeoJSON.MultiPoint>;
-
-    /**
-     * Takes an array of LinearRings and optionally an {@link Object} with properties and returns a {@link Polygon} feature.
-     * http://turfjs.org/docs/#polygon
-     * 
-     * @name polygon
-     * @param {Array<Array<Array<number>>>} coordinates an array of LinearRings
-     * @param {Object=} properties a properties object
-     * @returns {Feature<Polygon>} a Polygon feature
-     * @throws {Error} throw an error if a LinearRing of the polygon has too few positions
-     * or if a LinearRing of the Polygon does not have matching Positions at the
-     * beginning & end.
-     * @example
-     * var polygon = turf.polygon([[
-     *  [-2.275543, 53.464547],
-     *  [-2.275543, 53.489271],
-     *  [-2.215118, 53.489271],
-     *  [-2.215118, 53.464547],
-     *  [-2.275543, 53.464547]
-     * ]], { name: 'poly1', population: 400});
-     *
-     * //=polygon
-     */
-    function polygon(coordinates: Array<Array<Array<number>>>, properties?: any): GeoJSON.Feature<GeoJSON.Polygon>;
-
-    /**
-     * Creates a {@link Feature<MultiPolygon>} based on a coordinate array. Properties can be added optionally.
-     * http://turfjs.org/docs/#multipolygon
-     * 
-     * @name multiPolygon
-     * @param {Array<Array<Array<Array<number>>>>} coordinates an array of Polygons
-     * @param {Object=} properties an Object of key-value pairs to add as properties
-     * @returns {Feature<MultiPolygon>} a multipolygon feature
-     * @throws {Error} if no coordinates are passed
-     * @example
-     * var multiPoly = turf.multiPolygon([[[[0,0],[0,10],[10,10],[10,0],[0,0]]]);
-     *
-     * //=multiPoly
-     *
-     */
-    function multiPolygon(coordinates: Array<Array<Array<Array<number>>>>, properties?: any): GeoJSON.Feature<GeoJSON.MultiPolygon>;
-
-    /**
-     * Creates a {@link Feature<GeometryCollection>} based on acoordinate array. Properties can be added optionally.
-     * http://turfjs.org/docs/#geometrycollection
-     *
-     * @name geometryCollection
-     * @param {Array<{Geometry}>} geometries an array of GeoJSON Geometries
-     * @param {Object=} properties an Object of key-value pairs to add as properties
-     * @returns {Feature<GeometryCollection>} a GeoJSON GeometryCollection Feature
-     * @example
-     * var point = {
-     *     "type": "Point",
-     *       "coordinates": [100, 0]
-     *     };
-     * var line = {
-     *     "type": "LineString",
-     *     "coordinates": [ [101, 0], [102, 1] ]
-     *   };
-     * var collection = turf.geometryCollection([point, line]);
-     *
-     * //=collection
-     */
-    function geometryCollection(geometries: Array<GeoJSON.GeometryObject>, properties?: any): GeoJSON.GeometryCollection;
+    * Takes an array of LinearRings and optionally an Object with properties and returns a Polygon feature.
+    * @param rings An array of LinearRings
+    * @param [properties] An Object of key-value pairs to add as properties
+    * @returns A Polygon feature
+    */
+    function polygon(rings: Array<Array<Array<number>>>, properties?: any): GeoJSON.Feature<GeoJSON.Polygon>;
 
     //////////////////////////////////////////////////////
     // Data
     //////////////////////////////////////////////////////
 
     /**
-     * Generates random {@link GeoJSON} data, including {@link Point|Points} and {@link Polygon|Polygons}, for testing
-     * and experimentation.
-     *
-     * @name random
-     * @param {String} [type='point'] type of features desired: 'points' or 'polygons'
-     * @param {Number} [count=1] how many geometries should be generated.
-     * @param {Object} options options relevant to the feature desired. Can include:
-     * @param {Array<number>} options.bbox a bounding box inside of which geometries
-     * are placed. In the case of {@link Point} features, they are guaranteed to be within this bounds,
-     * while {@link Polygon} features have their centroid within the bounds.
-     * @param {Number} [options.num_vertices=10] options.vertices the number of vertices added
-     * to polygon features.
-     * @param {Number} [options.max_radial_length=10] the total number of decimal
-     * degrees longitude or latitude that a polygon can extent outwards to
-     * from its center.
-     * @return {FeatureCollection} generated random features
-     * @example
-     * const points = turf.random('points', 100, {
-     *   bbox: [-70, 40, -60, 60]
-     * })
-     *
-     * //=points
-     *
-     * const polygons = turf.random('polygons', 4, {
-     *   bbox: [-70, 40, -60, 60]
-     * })
-     *
-     * //=polygons
-     */
-    function random(
-      type?: 'points' | 'polygons',
-      count?: number,
-      options?: {
-        bbox?: Array<number>
-        num_vertices?: number
-        max_radial_length?: number
-    }): GeoJSON.FeatureCollection<any>;
+    * Takes a FeatureCollection and filters it by a given property and value.
+    * @param features Input features
+    * @param key The property on which to filter
+    * @param value The value of that property on which to filter
+    * @returns A filtered collection with only features that match input key and value
+    */
+    function filter(features: GeoJSON.FeatureCollection<any>, key: string, value: string): GeoJSON.FeatureCollection<any>;
 
     /**
-     * Takes a {@link FeatureCollection} and returns a FeatureCollection with given number of {@link Feature|features} at random.
-     * http://turfjs.org/docs/#sample
-     * 
-     * @name sample
-     * @param {FeatureCollection} featurecollection set of input features
-     * @param {number} num number of features to select
-     * @return {FeatureCollection} a FeatureCollection with `n` features
-     * @example
-     * var points = turf.random('points', 1000);
-     *
-     * //=points
-     *
-     * var sample = turf.sample(points, 10);
-     *
-     * //=sample
-     */
-    function sample(featurecollection: GeoJSON.FeatureCollection<any>, num: number): GeoJSON.FeatureCollection<any>;
+    * Generates random GeoJSON data, including Points and Polygons, for testing and experimentation.
+    * @param [type='point'] Type of features desired: 'points' or 'polygons'
+    * @param [count=1] How many geometries should be generated.
+    * @param [options] Options relevant to the feature desired. Can include:
+    *   - A bounding box inside of which geometries are placed. In the case of Point features, they are guaranteed to be within this bounds, while Polygon features have their centroid within the bounds.
+    *   - The number of vertices added to polygon features. Default is 10;
+    *   - The total number of decimal degrees longitude or latitude that a polygon can extent outwards to from its center. Default is 10.
+    * @returns Generated random features
+    */
+    function random(type?: string, count?: number, options?: {bbox?: Array<number>; num_vertices?: number; max_radial_length?: number;}): GeoJSON.FeatureCollection<any>;
+
+    /**
+    * Takes a FeatureCollection of any type, a property, and a value and returns a FeatureCollection with features matching that property-value pair removed.
+    * @param features Set of input features
+    * @param property The property to remove
+    * @param value The value to remove
+    * @returns The resulting FeatureCollection without features that match the property-value pair
+    */
+    function remove(features: GeoJSON.FeatureCollection<any>, property: string, value: string): GeoJSON.FeatureCollection<any>;
+
+    /**
+    * Takes a FeatureCollection and returns a FeatureCollection with given number of features at random.
+    * @param features Set of input features
+    * @param n Number of features to select
+    * @returns A FeatureCollection with n features
+    */
+    function sample(features: GeoJSON.FeatureCollection<any>, n: number): GeoJSON.FeatureCollection<any>;
 
     //////////////////////////////////////////////////////
     // Interpolation
@@ -645,42 +467,22 @@ declare module turf {
     function planepoint(interpolatedpoint: GeoJSON.Feature<GeoJSON.Point>, triangle: GeoJSON.Feature<GeoJSON.Polygon>): number;
 
     /**
-     * Takes a bounding box and a cell depth and returns a set of {@link Point|points} in a grid.
-     *
-     * @name pointGrid
-     * @param {Array<number>} bbox extent in [minX, minY, maxX, maxY] order
-     * @param {number} cellSize the distance across each cell
-     * @param {string} [units=kilometers] used in calculating cellWidth, can be degrees, radians, miles, or kilometers
-     * @return {FeatureCollection<Point>} grid of points
-     * @example
-     * const extent = [-70.823364, -33.553984, -70.473175, -33.302986]
-     * const cellSize = 3
-     * const units = 'miles'
-     *
-     * const grid = turf.pointGrid(extent, cellSize, units)
-     *
-     * //=grid
-     */
-    function pointGrid(bbox: Array<number>, cellSize: number, units: string): GeoJSON.FeatureCollection<GeoJSON.Point>;
+    * Takes a bounding box and a cell depth and returns a set of points in a grid.
+    * @param extent Extent in [minX, minY, maxX, maxY] order
+    * @param cellWidth The distance across each cell
+    * @param units Used in calculating cellWidth ('miles' or 'kilometers')
+    * @returns Grid of points
+    */
+    function pointGrid(extent: Array<number>, cellWidth: number, units: string): GeoJSON.FeatureCollection<GeoJSON.Point>;
 
     /**
-     * Takes a bounding box and a cell depth and returns a set of square {@link Polygon|polygons} in a grid.
-     *
-     * @name squareGrid
-     * @param {Array<number>} bbox extent in [minX, minY, maxX, maxY] order
-     * @param {number} cellSize width of each cell
-     * @param {string} units units to use for cellSize
-     * @return {FeatureCollection<Polygon>} grid a grid of polygons
-     * @example
-     * const extent = [-77.3876953125,38.71980474264239,-76.9482421875,39.027718840211605]
-     * const cellSize = 10
-     * const units = 'miles'
-     *
-     * const squareGrid = turf.squareGrid(extent, cellSize, units)
-     *
-     * //=squareGrid
-     */
-    function squareGrid(extent: Array<number>, cellSize: number, units: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+    * Takes a bounding box and a cell depth and returns a set of square polygons in a grid.
+    * @param extent Extent in [minX, minY, maxX, maxY] order
+    * @param cellWidth Width of each cell
+    * @param units Used in calculating cellWidth ('miles' or 'kilometers')
+    * @returns Grid of polygons
+    */
+    function squareGrid(extent: Array<number>, cellWidth: number, units: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     /**
     * Takes a set of points and the name of a z-value property and creates a Triangulated Irregular Network, or a TIN for short, returned as a collection of Polygons.
@@ -707,10 +509,10 @@ declare module turf {
 
     /**
     * Takes a Point and a Polygon or MultiPolygon and determines if the point resides inside the polygon.
-    * The polygon can be convex or concave. The function accounts for holes.;
+    * The polygon can be convex or concave. The function accounts for holes.
     * @param point Input point
     * @param polygon Input polygon or multipolygon
-    * @returns true if the Point is inside the Polygon false if the Point is not inside the Polygon
+    * @returns true if the Point is inside the Polygon; false if the Point is not inside the Polygon
     */
     function inside(point: GeoJSON.Feature<GeoJSON.Point>, polygon: GeoJSON.Feature<GeoJSON.Polygon>): boolean;
 
@@ -737,14 +539,42 @@ declare module turf {
     //////////////////////////////////////////////////////
 
     /**
+    * Takes a set of features and returns an array of the Jenks Natural breaks for a given property.
+    * @param input Input features
+    * @param field The property in input on which to calculate Jenks natural breaks
+    * @param numberOfBreaks Number of classes in which to group the data
+    * @returns The break number for each class plus the minimum and maximum values
+    */
+    function jenks(input: GeoJSON.FeatureCollection<any>, field: string, numberOfBreaks: number): Array<number>;
+
+    /**
     * Takes a reference point and a set of points and returns the point from the set closest to the reference.
     * @param point The reference point
     * @param against Input point set
     * @returns The closest point in the set to the reference point
     */
     function nearest(point: GeoJSON.Feature<GeoJSON.Point>, against: GeoJSON.FeatureCollection<GeoJSON.Point>): GeoJSON.Feature<GeoJSON.Point>;
+
+    /**
+    * Takes a FeatureCollection, a property name, and a set of percentiles and returns a quantile array.
+    * @param input Set of features
+    * @param field The property in input from which to retrieve quantile values
+    * @param percentiles An Array of percentiles on which to calculate quantile values
+    * @returns An array of the break values
+    */
+    function quantile(input: GeoJSON.FeatureCollection<any>, field: string, percentiles: Array<number>): Array<number>;
+
+    /**
+    * Takes a FeatureCollection, an input field, an output field, and an array of translations and outputs an identical FeatureCollection with the output field property populated.
+    * @param input Set of input features
+    * @param inField The field to translate
+    * @param outField The field in which to store translated results
+    * @param translations An array of translations
+    * @returns A FeatureCollection with identical geometries to input but with outField populated.
+    */
+    function reclass(input: GeoJSON.FeatureCollection<any>, inField: string, outField: string, translations: Array<any>): GeoJSON.FeatureCollection<any>;
 }
 
 declare module 'turf' {
-  export= turf
+  export= turf;
 }

--- a/turf/turf-tests.ts
+++ b/turf/turf-tests.ts
@@ -69,7 +69,7 @@ import * as nearest from '@turf/nearest'
 // // ASSERTIONS
 // import * as featureOf from '@turf/featureOf'
 // import * as collectionOf from '@turf/collectionOf'
-// import * as bbox from '@turf/bbox'
+import * as bboxAssertions from '@turf/bbox'
 // import * as circle from '@turf/circle'
 // import * as geojsonType from '@turf/geojsonType'
 // import * as propReduce from '@turf/propReduce'
@@ -108,7 +108,7 @@ const multiPoint1: GeoJSON.Feature<GeoJSON.MultiPoint> = {
   }
 }
 
-const line1: GeoJSON.Feature<GeoJSON.LineString> = {
+const lineString1: GeoJSON.Feature<GeoJSON.LineString> = {
   "type": "Feature",
   "properties": {},
   "geometry": {
@@ -124,7 +124,7 @@ const line1: GeoJSON.Feature<GeoJSON.LineString> = {
   }
 }
 
-const multiLine1: GeoJSON.Feature<GeoJSON.MultiLineString> = {
+const multiLineString1: GeoJSON.Feature<GeoJSON.MultiLineString> = {
   "type": "Feature",
   "properties": {},
   "geometry": {
@@ -283,8 +283,8 @@ const triangle: GeoJSON.Feature<GeoJSON.Polygon> = {
 ///////////////////////////////////////////
 
 // -- Test along --
-turf.along(line1, 50)
-turf.along(line1, 50, 'miles')
+turf.along(lineString1, 50)
+turf.along(lineString1, 50, 'miles')
 
 // -- Test area --
 turf.area(polygons)
@@ -313,8 +313,8 @@ turf.distance(point1, point2, 'miles')
 turf.envelope(polygons)
 
 // -- Test lineDistance
-turf.lineDistance(line1)
-turf.lineDistance(line1, 'miles')
+turf.lineDistance(lineString1)
+turf.lineDistance(lineString1, 'miles')
 
 // -- Test midpoint --
 turf.midpoint(point1, point2)
@@ -330,7 +330,7 @@ turf.square(bbox)
 ///////////////////////////////////////////
 
 // -- Test bezier --
-turf.bezier(line1)
+turf.bezier(lineString1)
 
 // -- Test buffer --
 turf.buffer(point1, 50)
@@ -350,8 +350,8 @@ turf.intersect(polygon1, polygon2)
 turf.intersect(point1, polygon1)
 turf.intersect(point1, point1)
 turf.intersect(polygon1, point1)
-turf.intersect(polygon1, line1)
-turf.intersect(line1, point1)
+turf.intersect(polygon1, lineString1)
+turf.intersect(lineString1, point1)
 
 // -- Test simplify --
 
@@ -377,10 +377,10 @@ turf.flip(point1)
 turf.kinks(polygon1)
 
 // -- Test lineSlice --
-turf.lineSlice(point1, point2, line1)
+turf.lineSlice(point1, point2, lineString1)
 
 // -- Test pointOnLine --
-turf.pointOnLine(line1, point1)
+turf.pointOnLine(lineString1, point1)
 
 ///////////////////////////////////////////
 // Tests Helper
@@ -390,20 +390,20 @@ turf.pointOnLine(line1, point1)
 turf.featureCollection([point1, point2])
 turf.featureCollection([point1, polygon1])
 turf.featureCollection([polygon1, polygon2])
-turf.featureCollection([line1, polygon1])
-turf.featureCollection([line1, point1])
+turf.featureCollection([lineString1, polygon1])
+turf.featureCollection([lineString1, point1])
 
 // -- Test feature --
 turf.feature(point1)
 turf.feature(polygon1)
-turf.feature(line1)
+turf.feature(lineString1)
 
 // -- Test lineString --
-turf.lineString(line1.geometry.coordinates)
-turf.lineString(line1.geometry.coordinates, properties)
+turf.lineString(lineString1.geometry.coordinates)
+turf.lineString(lineString1.geometry.coordinates, properties)
 
 // -- Test multiLineString --
-turf.multiLineString(multiLine1.geometry.coordinates)
+turf.multiLineString(multiLineString1.geometry.coordinates)
 
 // -- Test point --
 turf.point(point1.geometry.coordinates)
@@ -419,7 +419,7 @@ turf.polygon(polygon1.geometry.coordinates, properties)
 turf.multiPolygon(multiPolygon1.geometry.coordinates, properties)
 
 // -- Test geometryCollection --
-turf.geometryCollection([point1.geometry, line1.geometry]);
+turf.geometryCollection([point1.geometry, lineString1.geometry]);
 
 ///////////////////////////////////////////
 // Tests Data
@@ -495,3 +495,12 @@ turf.nearest(point1, points)
 // Tests Aggregation
 ///////////////////////////////////////////
 turf.collect(polygons, points, 'population', 'values')
+
+///////////////////////////////////////////
+// Tests Assertions
+///////////////////////////////////////////
+turf.bbox(polygon1)
+turf.bbox(point1)
+turf.bbox(lineString1)
+turf.bbox(multiLineString1)
+turf.bbox(multiPolygon1)

--- a/turf/turf-tests.ts
+++ b/turf/turf-tests.ts
@@ -1,5 +1,14 @@
 /// <reference path="turf.d.ts"/>
-import * as turf from 'turf'
+import * as turf from '@turf/turf'
+import {
+  collect,
+  random,
+  sample,
+  hexGrid,
+  pointGrid,
+  squareGrid,
+  triangleGrid
+} from '@turf/turf'
 
 ///////////////////////////////////////////
 // Tests data initialisation

--- a/turf/turf-tests.ts
+++ b/turf/turf-tests.ts
@@ -13,23 +13,8 @@ import {
 ///////////////////////////////////////////
 // Tests data initialisation
 ///////////////////////////////////////////
-
-const resolution = 15
-const cellWidth = 50
-const count = 100
 const bbox = [0, 0, 10, 10]
-const distance = 50
-const bearing = 90
-const tolerance = 0.01
-const maxEdge = 1
-const units = 'miles'
 const properties = {foo: 'bar'}
-const highQuality = false
-const breaks = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-const num_vertices = 10
-const max_radial_length = 10
-const num = 10
-
 const point: GeoJSON.Feature<GeoJSON.Point> = {
   "type": "Feature",
   "properties": {},
@@ -176,14 +161,42 @@ const points: GeoJSON.FeatureCollection<GeoJSON.Point> = {
       "properties": {},
       "geometry": {
         "type": "Point",
-        "coordinates": [-97.522259, 35.4691]
+        "coordinates": [-63.601226, 44.642643]
       }
     }, {
       "type": "Feature",
       "properties": {},
       "geometry": {
         "type": "Point",
-        "coordinates": [-97.502754, 35.463455]
+        "coordinates": [-63.591442, 44.651436]
+      }
+    }, {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-63.580799, 44.648749]
+      }
+    }, {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-63.573589, 44.641788]
+      }
+    }, {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-63.587665, 44.64533]
+      }
+    }, {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-63.595218, 44.64765]
       }
     }
   ]
@@ -208,8 +221,8 @@ const triangle: GeoJSON.Feature<GeoJSON.Polygon> = {
 ///////////////////////////////////////////
 
 // -- Test along --
-turf.along(line, distance, units)
-turf.along(line, distance)
+turf.along(line, 50)
+turf.along(line, 50, 'miles')
 
 // -- Test area --
 turf.area(polygons)
@@ -227,16 +240,19 @@ turf.center(points)
 turf.centroid(polygon1)
 
 // -- Test destination --
-turf.destination(point1, distance, bearing, units)
+turf.destination(point1, 50, 90)
+turf.destination(point1, 50, 90, 'miles')
 
 // -- Test distance --
-turf.distance(point1, point2, units)
+turf.distance(point1, point2)
+turf.distance(point1, point2, 'miles')
 
 // -- Test envelope --
 turf.envelope(polygons)
 
 // -- Test lineDistance
-turf.lineDistance(line, units)
+turf.lineDistance(line)
+turf.lineDistance(line, 'miles')
 
 // -- Test midpoint --
 turf.midpoint(point1, point2)
@@ -255,10 +271,11 @@ turf.square(bbox)
 turf.bezier(line)
 
 // -- Test buffer --
-turf.buffer(point1, distance, units)
+turf.buffer(point1, 50)
+turf.buffer(point1, 50, 'miles')
 
 // -- Test concave --
-turf.concave(points, maxEdge, units)
+turf.concave(points, 1, 'miles')
 
 // -- Test convex --
 turf.convex(points)
@@ -271,7 +288,7 @@ turf.intersect(polygon1, polygon2)
 
 // -- Test simplify --
 
-turf.simplify(polygon1, tolerance, highQuality)
+turf.simplify(polygon1, 0.01, false)
 
 // -- Test union --
 turf.union(polygon1, polygon2)
@@ -342,44 +359,44 @@ turf.geometryCollection([point.geometry, line.geometry]);
 ///////////////////////////////////////////
 
 // -- Test random --
-turf.random('points', count)
-turf.random('points', count, { bbox })
-turf.random('polygons', count, {
+turf.random('points', 100)
+turf.random('points', 100, { bbox })
+turf.random('polygons', 100, {
   bbox,
-  num_vertices,
-  max_radial_length
+  num_vertices: 10,
+  max_radial_length: 10
 })
 
 // -- Test sample --
-turf.random('points', count)
-turf.sample(points, num)
+turf.random('points', 100)
+turf.sample(points, 10)
 
 ///////////////////////////////////////////
 // Tests Interpolation
 ///////////////////////////////////////////
 
 // -- Test hexGrid --
-turf.hexGrid(bbox, cellWidth)
-turf.hexGrid(bbox, cellWidth, 'miles')
+turf.hexGrid(bbox, 50)
+turf.hexGrid(bbox, 50, 'miles')
 
 // -- Test pointGrid --
-turf.pointGrid(bbox, cellWidth)
-turf.pointGrid(bbox, cellWidth, 'kilometres')
+turf.pointGrid(bbox, 50)
+turf.pointGrid(bbox, 50, 'miles')
 
 // -- Test squareGrid --
-turf.squareGrid(bbox, cellWidth)
-turf.squareGrid(bbox, cellWidth, 'inches')
+turf.squareGrid(bbox, 50)
+turf.squareGrid(bbox, 50, 'miles')
 
 // -- Test triangleGrid --
-turf.triangleGrid(bbox, cellWidth)
-turf.triangleGrid(bbox, cellWidth, units)
+turf.triangleGrid(bbox, 50)
+turf.triangleGrid(bbox, 50, 'miles')
 
 ///////////////////////////////////////////
 // Tests Interpolation
 ///////////////////////////////////////////
 
 // -- Test isolines --
-turf.isolines(points, 'z', resolution, breaks)
+turf.isolines(points, 'z', 15, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
 // -- Test planepoint --
 turf.planepoint(point1, triangle)

--- a/turf/turf-tests.ts
+++ b/turf/turf-tests.ts
@@ -7,15 +7,16 @@ import {
   hexGrid,
   pointGrid,
   squareGrid,
-  triangleGrid
+  triangleGrid,
+  featureCollection
 } from '@turf/turf'
 
 ///////////////////////////////////////////
 // Tests data initialisation
 ///////////////////////////////////////////
 const bbox = [0, 0, 10, 10]
-const properties = {foo: 'bar'}
-const point: GeoJSON.Feature<GeoJSON.Point> = {
+const properties = {pop: 3000}
+const point1: GeoJSON.Feature<GeoJSON.Point> = {
   "type": "Feature",
   "properties": {},
   "geometry": {
@@ -23,8 +24,6 @@ const point: GeoJSON.Feature<GeoJSON.Point> = {
     "coordinates": [-75.343, 39.984]
   }
 }
-
-const point1 = point
 
 const point2: GeoJSON.Feature<GeoJSON.Point> = {
   "type": "Feature",
@@ -34,6 +33,7 @@ const point2: GeoJSON.Feature<GeoJSON.Point> = {
     "coordinates": [-75.401, 39.884]
   }
 }
+const point = point1
 
 const multiPoint: GeoJSON.Feature<GeoJSON.MultiPoint> = {
   "type": "Feature",
@@ -412,7 +412,7 @@ turf.tin(points, 'z')
 turf.inside(point, polygon)
 
 // -- Test tag --
-turf.tag(points, polygons, 'fill', 'marker-color')
+turf.tag(points, polygons, 'pop', 'population')
 
 // -- Test within --
 turf.within(points, polygons)

--- a/turf/turf-tests.ts
+++ b/turf/turf-tests.ts
@@ -17,6 +17,9 @@ const units = 'miles'
 const properties = {foo: 'bar'}
 const highQuality = false
 const breaks = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+const num_vertices = 10
+const max_radial_length = 10
+const num = 10
 
 const point: GeoJSON.Feature<GeoJSON.Point> = {
   "type": "Feature",
@@ -127,9 +130,7 @@ const polygon1 = polygon
 
 const polygon2: GeoJSON.Feature<GeoJSON.Polygon> = {
   "type": "Feature",
-  "properties": {
-    "fill": "#00f"
-  },
+  "properties": {},
   "geometry": {
     "type": "Polygon",
     "coordinates": [[
@@ -175,87 +176,13 @@ const points: GeoJSON.FeatureCollection<GeoJSON.Point> = {
         "type": "Point",
         "coordinates": [-97.502754, 35.463455]
       }
-    }, {
-      "type": "Feature",
-      "properties": {},
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-97.508269, 35.463245]
-      }
-    }, {
-      "type": "Feature",
-      "properties": {},
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-97.516809, 35.465779]
-      }
-    }, {
-      "type": "Feature",
-      "properties": {},
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-97.515372, 35.467072]
-      }
-    }, {
-      "type": "Feature",
-      "properties": {},
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-97.509363, 35.463053]
-      }
-    }, {
-      "type": "Feature",
-      "properties": {},
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-97.511123, 35.466601]
-      }
-    }, {
-      "type": "Feature",
-      "properties": {},
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-97.518547, 35.469327]
-      }
-    }, {
-      "type": "Feature",
-      "properties": {},
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-97.519706, 35.469659]
-      }
-    }, {
-      "type": "Feature",
-      "properties": {},
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-97.517839, 35.466998]
-      }
-    }, {
-      "type": "Feature",
-      "properties": {},
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-97.508678, 35.464942]
-      }
-    }, {
-      "type": "Feature",
-      "properties": {},
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-97.514914, 35.463453]
-      }
     }
   ]
 }
 
 const triangle: GeoJSON.Feature<GeoJSON.Polygon> = {
   "type": "Feature",
-  "properties": {
-    "a": 11,
-    "b": 122,
-    "c": 44
-  },
+  "properties": {},
   "geometry": {
     "type": "Polygon",
     "coordinates": [[
@@ -406,24 +333,41 @@ turf.geometryCollection([point.geometry, line.geometry]);
 ///////////////////////////////////////////
 
 // -- Test random --
-turf.random('points', 100)
-turf.random('points', 100, { bbox })
-turf.random('polygons', 4, {
+turf.random('points', count)
+turf.random('points', count, { bbox })
+turf.random('polygons', count, {
   bbox,
-  num_vertices: 10,
-  max_radial_length: 10
+  num_vertices,
+  max_radial_length
 })
 
 // -- Test sample --
-turf.random('points', 1000)
-turf.sample(points, 10)
+turf.random('points', count)
+turf.sample(points, num)
 
 ///////////////////////////////////////////
 // Tests Interpolation
 ///////////////////////////////////////////
 
 // -- Test hexGrid --
-turf.hexGrid(bbox, cellWidth, units)
+turf.hexGrid(bbox, cellWidth)
+turf.hexGrid(bbox, cellWidth, 'miles')
+
+// -- Test pointGrid --
+turf.pointGrid(bbox, cellWidth)
+turf.pointGrid(bbox, cellWidth, 'kilometres')
+
+// -- Test squareGrid --
+turf.squareGrid(bbox, cellWidth)
+turf.squareGrid(bbox, cellWidth, 'inches')
+
+// -- Test triangleGrid --
+turf.triangleGrid(bbox, cellWidth)
+turf.triangleGrid(bbox, cellWidth, units)
+
+///////////////////////////////////////////
+// Tests Interpolation
+///////////////////////////////////////////
 
 // -- Test isolines --
 turf.isolines(points, 'z', resolution, breaks)
@@ -431,17 +375,8 @@ turf.isolines(points, 'z', resolution, breaks)
 // -- Test planepoint --
 turf.planepoint(point1, triangle)
 
-// -- Test pointGrid --
-turf.pointGrid(bbox, cellWidth, units)
-
-// -- Test squareGrid --
-turf.squareGrid(bbox, cellWidth, units)
-
 // -- Test tin --
 turf.tin(points, 'z')
-
-// -- Test triangleGrid --
-turf.triangleGrid(bbox, cellWidth, units)
 
 ///////////////////////////////////////////
 // Tests Joins

--- a/turf/turf-tests.ts
+++ b/turf/turf-tests.ts
@@ -1,15 +1,80 @@
 /// <reference path="turf.d.ts"/>
 import * as turf from '@turf/turf'
+// AGGREGATION
+import * as collect from '@turf/collect'
+// MEASUREMENT
+import * as along from '@turf/along'
+import * as area from '@turf/area'
+import * as bboxPolygon from '@turf/bbox-polygon'
+import * as bearing from '@turf/bearing'
+import * as center from '@turf/center'
+import * as centroid from '@turf/centroid'
+import * as destination from '@turf/destination'
+import * as envelope from '@turf/envelope'
+import * as lineDistance from '@turf/line-distance'
+import * as midpoint from '@turf/midpoint'
+import * as pointOnSurce from '@turf/point-on-surface'
+import * as square from '@turf/square'
+// TRANSFORMATION
+import * as bezier from '@turf/bezier'
+import * as buffer from '@turf/buffer'
+import * as concave from '@turf/concave'
+import * as convex from '@turf/convex'
+import * as difference from '@turf/difference'
+import * as intersect from '@turf/intersect'
+import * as simplify from '@turf/simplify'
+import * as union from '@turf/union'
+// MISC
+import * as combine from '@turf/combine'
+import * as explode from '@turf/explode'
+import * as flip from '@turf/flip'
+import * as kinks from '@turf/kinks'
+import * as lineSlice from '@turf/line-slice'
+import * as pointOnLine from '@turf/point-on-line'
+// HELPER
 import {
-  collect,
-  random,
-  sample,
-  hexGrid,
-  pointGrid,
-  squareGrid,
-  triangleGrid,
-  featureCollection
-} from '@turf/turf'
+  featureCollection,
+  feature,
+  lineString,
+  multiLineString,
+  point,
+  multiPoint,
+  polygon,
+  multiPolygon,
+  geometryCollection } from '@turf/helpers'
+// DATA
+import * as random from '@turf/random'
+import * as sample from '@turf/sample'
+// INTERPOLATION
+import * as isolines from '@turf/isolines'
+import * as planepoint from '@turf/planepoint'
+import * as tin from '@turf/tin'
+// JOINS
+import * as inside from '@turf/inside'
+import * as tag from '@turf/tag'
+import * as within from '@turf/within'
+// GRIDS
+import * as hexGrid from '@turf/hex-grid'
+import * as pointGrid from '@turf/point-grid'
+import * as squareGrid from '@turf/square-grid'
+import * as triangleGrid from '@turf/triangle-grid'
+// CLASSIFICATION
+import * as nearest from '@turf/nearest'
+// // META
+// import * as propEach from '@turf/propEach'
+// import * as coordEach from '@turf/coordEach'
+// import * as coordReduce from '@turf/coordReduce'
+// import * as featureEach from '@turf/featureEach'
+// import * as getCoord from '@turf/getCoord'
+// // ASSERTIONS
+// import * as featureOf from '@turf/featureOf'
+// import * as collectionOf from '@turf/collectionOf'
+// import * as bbox from '@turf/bbox'
+// import * as circle from '@turf/circle'
+// import * as geojsonType from '@turf/geojsonType'
+// import * as propReduce from '@turf/propReduce'
+// import * as coordAll from '@turf/coordAll'
+// import * as tesselate from '@turf/tesselate'
 
 ///////////////////////////////////////////
 // Tests data initialisation
@@ -33,9 +98,8 @@ const point2: GeoJSON.Feature<GeoJSON.Point> = {
     "coordinates": [-75.401, 39.884]
   }
 }
-const point = point1
 
-const multiPoint: GeoJSON.Feature<GeoJSON.MultiPoint> = {
+const multiPoint1: GeoJSON.Feature<GeoJSON.MultiPoint> = {
   "type": "Feature",
   "properties": {},
   "geometry": {
@@ -44,7 +108,7 @@ const multiPoint: GeoJSON.Feature<GeoJSON.MultiPoint> = {
   }
 }
 
-const line: GeoJSON.Feature<GeoJSON.LineString> = {
+const line1: GeoJSON.Feature<GeoJSON.LineString> = {
   "type": "Feature",
   "properties": {},
   "geometry": {
@@ -60,7 +124,7 @@ const line: GeoJSON.Feature<GeoJSON.LineString> = {
   }
 }
 
-const multiLine: GeoJSON.Feature<GeoJSON.MultiLineString> = {
+const multiLine1: GeoJSON.Feature<GeoJSON.MultiLineString> = {
   "type": "Feature",
   "properties": {},
   "geometry": {
@@ -105,7 +169,7 @@ const polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon> = {
   ]
 }
 
-const polygon: GeoJSON.Feature<GeoJSON.Polygon> = {
+const polygon1: GeoJSON.Feature<GeoJSON.Polygon> = {
   "type": "Feature",
   "properties": {},
   "geometry": {
@@ -119,8 +183,6 @@ const polygon: GeoJSON.Feature<GeoJSON.Polygon> = {
     ]]
   }
 }
-
-const polygon1 = polygon
 
 const polygon2: GeoJSON.Feature<GeoJSON.Polygon> = {
   "type": "Feature",
@@ -140,7 +202,7 @@ const polygon2: GeoJSON.Feature<GeoJSON.Polygon> = {
   }
 }
 
-const multiPolygon: GeoJSON.Feature<GeoJSON.MultiPolygon> = {
+const multiPolygon1: GeoJSON.Feature<GeoJSON.MultiPolygon> = {
   "type": "Feature",
   "properties": {},
   "geometry": {
@@ -221,8 +283,8 @@ const triangle: GeoJSON.Feature<GeoJSON.Polygon> = {
 ///////////////////////////////////////////
 
 // -- Test along --
-turf.along(line, 50)
-turf.along(line, 50, 'miles')
+turf.along(line1, 50)
+turf.along(line1, 50, 'miles')
 
 // -- Test area --
 turf.area(polygons)
@@ -251,8 +313,8 @@ turf.distance(point1, point2, 'miles')
 turf.envelope(polygons)
 
 // -- Test lineDistance
-turf.lineDistance(line)
-turf.lineDistance(line, 'miles')
+turf.lineDistance(line1)
+turf.lineDistance(line1, 'miles')
 
 // -- Test midpoint --
 turf.midpoint(point1, point2)
@@ -268,7 +330,7 @@ turf.square(bbox)
 ///////////////////////////////////////////
 
 // -- Test bezier --
-turf.bezier(line)
+turf.bezier(line1)
 
 // -- Test buffer --
 turf.buffer(point1, 50)
@@ -310,10 +372,10 @@ turf.flip(point1)
 turf.kinks(polygon1)
 
 // -- Test lineSlice --
-turf.lineSlice(point1, point2, line)
+turf.lineSlice(point1, point2, line1)
 
 // -- Test pointOnLine --
-turf.pointOnLine(line, point1)
+turf.pointOnLine(line1, point1)
 
 ///////////////////////////////////////////
 // Tests Helper
@@ -321,38 +383,38 @@ turf.pointOnLine(line, point1)
 
 // -- Test featurecollection --
 turf.featureCollection([point1, point2])
-turf.featureCollection([point, polygon])
+turf.featureCollection([point1, polygon1])
 turf.featureCollection([polygon1, polygon2])
-turf.featureCollection([line, polygon])
-turf.featureCollection([line, point])
+turf.featureCollection([line1, polygon1])
+turf.featureCollection([line1, point1])
 
 // -- Test feature --
-turf.feature(point)
-turf.feature(polygon)
-turf.feature(line)
+turf.feature(point1)
+turf.feature(polygon1)
+turf.feature(line1)
 
 // -- Test lineString --
-turf.lineString(line.geometry.coordinates)
-turf.lineString(line.geometry.coordinates, properties)
+turf.lineString(line1.geometry.coordinates)
+turf.lineString(line1.geometry.coordinates, properties)
 
 // -- Test multiLineString --
-turf.multiLineString(multiLine.geometry.coordinates)
+turf.multiLineString(multiLine1.geometry.coordinates)
 
 // -- Test point --
-turf.point(point.geometry.coordinates)
-turf.point(point.geometry.coordinates, properties)
+turf.point(point1.geometry.coordinates)
+turf.point(point1.geometry.coordinates, properties)
 
 // -- Test multiPoint --
-turf.multiPoint(multiPoint.geometry.coordinates)
+turf.multiPoint(multiPoint1.geometry.coordinates)
 
 // -- Test polygon --
-turf.polygon(polygon.geometry.coordinates, properties)
+turf.polygon(polygon1.geometry.coordinates, properties)
 
 // -- Test multiPolygon --
-turf.multiPolygon(multiPolygon.geometry.coordinates, properties)
+turf.multiPolygon(multiPolygon1.geometry.coordinates, properties)
 
 // -- Test geometryCollection --
-turf.geometryCollection([point.geometry, line.geometry]);
+turf.geometryCollection([point1.geometry, line1.geometry]);
 
 ///////////////////////////////////////////
 // Tests Data
@@ -409,7 +471,7 @@ turf.tin(points, 'z')
 ///////////////////////////////////////////
 
 // -- Test inside --
-turf.inside(point, polygon)
+turf.inside(point1, polygon1)
 
 // -- Test tag --
 turf.tag(points, polygons, 'pop', 'population')

--- a/turf/turf-tests.ts
+++ b/turf/turf-tests.ts
@@ -347,6 +347,11 @@ turf.difference(polygon1, polygon2)
 
 // -- Test intersect --
 turf.intersect(polygon1, polygon2)
+turf.intersect(point1, polygon1)
+turf.intersect(point1, point1)
+turf.intersect(polygon1, point1)
+turf.intersect(polygon1, line1)
+turf.intersect(line1, point1)
 
 // -- Test simplify --
 

--- a/turf/turf.d.ts
+++ b/turf/turf.d.ts
@@ -63,12 +63,12 @@ JOINS
 - [ ] inside
 - [ ] tag
 GRIDS
-- [ ] hexGrid
-- [ ] pointGrid
-- [ ] squareGrid
-- [ ] triangleGrid
-- [ ] within
+- [x] hexGrid
+- [x] pointGrid
+- [x] squareGrid
+- [x] triangleGrid
 CLASSIFICATION
+- [ ] within
 - [ ] nearest
 META
 - [ ] propEach
@@ -93,13 +93,9 @@ declare module turf {
     //////////////////////////////////////////////////////
 
     /**
-     * Merges a specified property from a FeatureCollection of points into a
-     * FeatureCollection of polygons. Given an `inProperty` on points and an `outProperty`
-     * for polygons, this finds every point that lies within each polygon, collects the
-     * `inProperty` values from those points, and adds them as an array to `outProperty`
-     * on the polygon.
+     * Merges a specified property from a FeatureCollection of points into a FeatureCollection of polygons. Given an `inProperty` on points and an `outProperty` for polygons, this finds every point that lies within each polygon, collects the `inProperty` values from those points, and adds them as an array to `outProperty` on the polygon.
      *
-     * @name collect
+     * @name [collect](http://turfjs.org/docs/#collect)
      * @param {FeatureCollection<Polygon>} polygons polygons with values on which to aggregate
      * @param {FeatureCollection<Point>} points points to be aggregated
      * @param {string} inProperty property to be nested from
@@ -366,9 +362,8 @@ declare module turf {
 
     /**
      * Takes one or more {@link Feature|Features} and creates a {@link FeatureCollection}.
-     * http://turfjs.org/docs/#featurecollection
      * 
-     * @name featureCollection
+     * @name [featureCollection](http://turfjs.org/docs/#featurecollection)
      * @param {Feature[]} features input features
      * @returns {FeatureCollection} a FeatureCollection of input features
      * @example
@@ -386,9 +381,8 @@ declare module turf {
 
     /**
      * Wraps a GeoJSON {@link Geometry} in a GeoJSON {@link Feature}.
-     * http://turfjs.org/docs/#feature
      *
-     * @name feature
+     * @name [feature](http://turfjs.org/docs/#feature)
      * @param {Geometry} geometry input geometry
      * @param {Object} properties properties
      * @returns {FeatureCollection} a FeatureCollection of input features
@@ -409,9 +403,8 @@ declare module turf {
 
     /**
      * Creates a {@link LineString} based on a coordinate array. Properties can be added optionally.
-     * http://turfjs.org/docs/#linestring
      * 
-     * @name lineString
+     * @name [lineString](http://turfjs.org/docs/#linestring)
      * @param {Array<Array<number>>} coordinates an array of Positions
      * @param {Object=} properties an Object of key-value pairs to add as properties
      * @returns {Feature<LineString>} a LineString feature
@@ -438,9 +431,8 @@ declare module turf {
 
     /**
      * Creates a {@link Feature<MultiLineString>} based on a coordinate array. Properties can be added optionally.
-     * http://turfjs.org/docs/#multilinestring
      * 
-     * @name multiLineString
+     * @name [multiLineString](http://turfjs.org/docs/#multilinestring)
      * @param {Array<Array<Array<number>>>} coordinates an array of LineStrings
      * @param {Object=} properties an Object of key-value pairs to add as properties
      * @returns {Feature<MultiLineString>} a MultiLineString feature
@@ -455,9 +447,8 @@ declare module turf {
 
     /**
      * Takes coordinates and properties (optional) and returns a new {@link Point} feature.
-     * http://turfjs.org/docs/#point
      * 
-     * @name point
+     * @name [point](http://turfjs.org/docs/#point)
      * @param {Array<number>} coordinates longitude, latitude position (each in decimal degrees)
      * @param {Object=} properties an Object that is used as the {@link Feature}'s
      * properties
@@ -471,9 +462,8 @@ declare module turf {
 
     /**
      * Creates a {@link Feature<MultiPoint>} based on a coordinate array. Properties can be added optionally.
-     * http://turfjs.org/docs/#multipoint
      * 
-     * @name multiPoint
+     * @name [multiPoint](http://turfjs.org/docs/#multipoint)
      * @param {Array<Array<number>>} coordinates an array of Positions
      * @param {Object=} properties an Object of key-value pairs to add as properties
      * @returns {Feature<MultiPoint>} a MultiPoint feature
@@ -488,9 +478,8 @@ declare module turf {
 
     /**
      * Takes an array of LinearRings and optionally an {@link Object} with properties and returns a {@link Polygon} feature.
-     * http://turfjs.org/docs/#polygon
      * 
-     * @name polygon
+     * @name [polygon](http://turfjs.org/docs/#polygon)
      * @param {Array<Array<Array<number>>>} coordinates an array of LinearRings
      * @param {Object=} properties a properties object
      * @returns {Feature<Polygon>} a Polygon feature
@@ -512,9 +501,8 @@ declare module turf {
 
     /**
      * Creates a {@link Feature<MultiPolygon>} based on a coordinate array. Properties can be added optionally.
-     * http://turfjs.org/docs/#multipolygon
      * 
-     * @name multiPolygon
+     * @name [multiPolygon](http://turfjs.org/docs/#multipolygon)
      * @param {Array<Array<Array<Array<number>>>>} coordinates an array of Polygons
      * @param {Object=} properties an Object of key-value pairs to add as properties
      * @returns {Feature<MultiPolygon>} a multipolygon feature
@@ -529,9 +517,8 @@ declare module turf {
 
     /**
      * Creates a {@link Feature<GeometryCollection>} based on acoordinate array. Properties can be added optionally.
-     * http://turfjs.org/docs/#geometrycollection
      *
-     * @name geometryCollection
+     * @name [geometryCollection](http://turfjs.org/docs/#geometrycollection)
      * @param {Array<{Geometry}>} geometries an array of GeoJSON Geometries
      * @param {Object=} properties an Object of key-value pairs to add as properties
      * @returns {Feature<GeometryCollection>} a GeoJSON GeometryCollection Feature
@@ -555,10 +542,9 @@ declare module turf {
     //////////////////////////////////////////////////////
 
     /**
-     * Generates random {@link GeoJSON} data, including {@link Point|Points} and {@link Polygon|Polygons}, for testing
-     * and experimentation.
+     * Generates random {@link GeoJSON} data, including {@link Point|Points} and {@link Polygon|Polygons}, for testing and experimentation.
      *
-     * @name random
+     * @name [random](http://turfjs.org/docs/#random)
      * @param {String} [type='point'] type of features desired: 'points' or 'polygons'
      * @param {Number} [count=1] how many geometries should be generated.
      * @param {Object} options options relevant to the feature desired. Can include:
@@ -595,9 +581,8 @@ declare module turf {
 
     /**
      * Takes a {@link FeatureCollection} and returns a FeatureCollection with given number of {@link Feature|features} at random.
-     * http://turfjs.org/docs/#sample
      * 
-     * @name sample
+     * @name [sample](http://turfjs.org/docs/#sample)
      * @param {FeatureCollection} featurecollection set of input features
      * @param {number} num number of features to select
      * @return {FeatureCollection} a FeatureCollection with `n` features
@@ -613,17 +598,106 @@ declare module turf {
     function sample(featurecollection: GeoJSON.FeatureCollection<any>, num: number): GeoJSON.FeatureCollection<any>;
 
     //////////////////////////////////////////////////////
-    // Interpolation
+    // GRIDS
     //////////////////////////////////////////////////////
 
     /**
-    * Takes a bounding box and a cell size in degrees and returns a FeatureCollection of flat-topped hexagons (Polygon features) aligned in an "odd-q" vertical grid as described in Hexagonal Grids.
-    * @param bbox Bounding box in [minX, minY, maxX, maxY] order
-    * @param cellWidth Width of cell in specified units
-    * @param units Used in calculating cellWidth ('miles' or 'kilometers')
-    * @returns A hexagonal grid
-    */
-    function hexGrid(bbox: Array<number>, cellWidth: number, units: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+     * Takes a bounding box and a cell size in degrees and returns a {@link FeatureCollection} of flat-topped hexagons ({@link Polygon} features) aligned in an "odd-q" vertical grid as described in [Hexagonal Grids](http://www.redblobgames.com/grids/hexagons/).
+     * 
+     * @name [hexGrid](http://turfjs.org/docs/#hexgrid)
+     * @param {Array<number>} bbox bounding box in [minX, minY, maxX, maxY] order
+     * @param {number} cellSize dimension of cell in specified units
+     * @param {string} units used in calculating cellSize ('miles' or 'kilometers')
+     * @param {boolean} triangles whether to return as triangles instead of hexagons
+     * @return {FeatureCollection<Polygon>} a hexagonal grid
+     * @example
+     * var bbox = [-96,31,-84,40];
+     * var cellSize = 50;
+     * var units = 'miles';
+     *
+     * var hexgrid = turf.hexGrid(bbox, cellSize, units);
+     *
+     * //=hexgrid
+     */
+    function hexGrid(
+      bbox: Array<number>,
+      cellSize: number,
+      units?: string | 'miles' | 'nauticalmiles' | 'degrees' | 'radians' | 'inches' | 'yards' | 'meters' | 'metres' | 'kilometers' | 'kilometres',
+      triangles?: boolean
+    ): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+
+    /**
+     * Takes a bounding box and a cell depth and returns a set of {@link Point|points} in a grid.
+     *
+     * @name [pointGrid](http://turfjs.org/docs/#pointgrid)
+     * @param {Array<number>} bbox extent in [minX, minY, maxX, maxY] order
+     * @param {number} cellSize the distance across each cell
+     * @param {string} [units=kilometers] used in calculating cellSize, can be degrees, radians, miles, or kilometers
+     * @return {FeatureCollection<Point>} grid of points
+     * @example
+     * var extent = [-70.823364, -33.553984, -70.473175, -33.302986];
+     * var cellSize = 3;
+     * var units = 'miles';
+     *
+     * var grid = turf.pointGrid(extent, cellSize, units);
+     *
+     * //=grid
+     */
+    function pointGrid(
+      bbox: Array<number>,
+      cellSize: number,
+      units?: string | 'miles' | 'nauticalmiles' | 'degrees' | 'radians' | 'inches' | 'yards' | 'meters' | 'metres' | 'kilometers' | 'kilometres' 
+    ): GeoJSON.FeatureCollection<GeoJSON.Point>;
+
+    /**
+     * Takes a bounding box and a cell depth and returns a set of square {@link Polygon|polygons} in a grid.
+     *
+     * @name [squareGrid](http://turfjs.org/docs/#squaregrid)
+     * @param {Array<number>} bbox extent in [minX, minY, maxX, maxY] order
+     * @param {number} cellSize width of each cell
+     * @param {string} [units=kilometers] used in calculating cellSize, can be degrees, radians, miles, or kilometers
+     * @return {FeatureCollection<Polygon>} grid a grid of polygons
+     * @example
+     * var bbox = [-96,31,-84,40]
+     * var cellSize = 10
+     * var units = 'miles'
+     *
+     * var squareGrid = turf.squareGrid(bbox, cellSize, units)
+     *
+     * //=squareGrid
+     */
+    function squareGrid(
+      bbox: Array<number>,
+      cellSize: number,
+      units?: string | 'miles' | 'nauticalmiles' | 'degrees' | 'radians' | 'inches' | 'yards' | 'meters' | 'metres' | 'kilometers' | 'kilometres'
+    ): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+
+    /**
+     * Takes a bounding box and a cell depth and returns a set of triangular {@link Polygon|polygons} in a grid.
+     *
+     * @name [triangleGrid](http://turfjs.org/docs/#trianglegrid))
+     * @param {Array<number>} bbox extent in [minX, minY, maxX, maxY] order
+     * @param {number} cellSize dimension of each cell
+     * @param {string} [units=kilometers] used in calculating cellSize, can be degrees, radians, miles, or kilometers
+     * @return {FeatureCollection<Polygon>} grid of polygons
+     * @example
+     * var bbox = [-96,31,-84,40]
+     * var cellSize = 10;
+     * var units = 'miles';
+     *
+     * var triangleGrid = turf.triangleGrid(extent, cellSize, units);
+     *
+     * //=triangleGrid
+     */
+    function triangleGrid(
+      bbox: Array<number>,
+      cellSize: number,
+      units?: string | 'miles' | 'nauticalmiles' | 'degrees' | 'radians' | 'inches' | 'yards' | 'meters' | 'metres' | 'kilometers' | 'kilometres'
+    ): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+
+    //////////////////////////////////////////////////////
+    // Interpolation
+    //////////////////////////////////////////////////////
 
     /**
     * Takes points with z-values and an array of value breaks and generates isolines.
@@ -645,44 +719,6 @@ declare module turf {
     function planepoint(interpolatedpoint: GeoJSON.Feature<GeoJSON.Point>, triangle: GeoJSON.Feature<GeoJSON.Polygon>): number;
 
     /**
-     * Takes a bounding box and a cell depth and returns a set of {@link Point|points} in a grid.
-     *
-     * @name pointGrid
-     * @param {Array<number>} bbox extent in [minX, minY, maxX, maxY] order
-     * @param {number} cellSize the distance across each cell
-     * @param {string} [units=kilometers] used in calculating cellWidth, can be degrees, radians, miles, or kilometers
-     * @return {FeatureCollection<Point>} grid of points
-     * @example
-     * const extent = [-70.823364, -33.553984, -70.473175, -33.302986]
-     * const cellSize = 3
-     * const units = 'miles'
-     *
-     * const grid = turf.pointGrid(extent, cellSize, units)
-     *
-     * //=grid
-     */
-    function pointGrid(bbox: Array<number>, cellSize: number, units: string): GeoJSON.FeatureCollection<GeoJSON.Point>;
-
-    /**
-     * Takes a bounding box and a cell depth and returns a set of square {@link Polygon|polygons} in a grid.
-     *
-     * @name squareGrid
-     * @param {Array<number>} bbox extent in [minX, minY, maxX, maxY] order
-     * @param {number} cellSize width of each cell
-     * @param {string} units units to use for cellSize
-     * @return {FeatureCollection<Polygon>} grid a grid of polygons
-     * @example
-     * const extent = [-77.3876953125,38.71980474264239,-76.9482421875,39.027718840211605]
-     * const cellSize = 10
-     * const units = 'miles'
-     *
-     * const squareGrid = turf.squareGrid(extent, cellSize, units)
-     *
-     * //=squareGrid
-     */
-    function squareGrid(extent: Array<number>, cellSize: number, units: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
-
-    /**
     * Takes a set of points and the name of a z-value property and creates a Triangulated Irregular Network, or a TIN for short, returned as a collection of Polygons.
     * These are often used for developing elevation contour maps or stepped heat visualizations.
     * This triangulates the points, as well as adds properties called a, b, and c representing the value of the given propertyName at each of the points that represent the corners of the triangle.
@@ -691,15 +727,6 @@ declare module turf {
     * @returns TIN output
     */
     function tin(points: GeoJSON.FeatureCollection<GeoJSON.Point>, propertyName?: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
-
-    /**
-    * Takes a bounding box and a cell depth and returns a set of triangular polygons in a grid.
-    * @param extent Extent in [minX, minY, maxX, maxY] order
-    * @param cellWidth Width of each cell
-    * @param units Used in calculating cellWidth ('miles' or 'kilometers')
-    * @returns Grid of triangles
-    */
-    function triangleGrid(extent: Array<number>, cellWidth: number, units: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     //////////////////////////////////////////////////////
     // Joins
@@ -742,9 +769,12 @@ declare module turf {
     * @param against Input point set
     * @returns The closest point in the set to the reference point
     */
-    function nearest(point: GeoJSON.Feature<GeoJSON.Point>, against: GeoJSON.FeatureCollection<GeoJSON.Point>): GeoJSON.Feature<GeoJSON.Point>;
+    function nearest(
+      point: GeoJSON.Feature<GeoJSON.Point>,
+      against: GeoJSON.FeatureCollection<GeoJSON.Point>
+    ): GeoJSON.Feature<GeoJSON.Point>;
 }
 
 declare module 'turf' {
-  export= turf
+  export = turf
 }

--- a/turf/turf.d.ts
+++ b/turf/turf.d.ts
@@ -882,7 +882,7 @@ declare module "turf" {
 
 // Latest version of Turf
 declare module "@turf/turf" {
-  export default turf
+  export = turf
 }
 
 // AGGREGATION

--- a/turf/turf.d.ts
+++ b/turf/turf.d.ts
@@ -87,8 +87,8 @@ ASSERTIONS
 - [ ] tesselate
  */
 
-declare var turf: turf.TurfStatic;
-
+declare const turf: turf.TurfStatic;
+declare const TemplateUnits: 'miles' | 'nauticalmiles' | 'degrees' | 'radians' | 'inches' | 'yards' | 'meters' | 'metres' | 'kilometers' | 'kilometres'
 declare module turf {
   interface TurfStatic {
     //////////////////////////////////////////////////////
@@ -135,7 +135,11 @@ declare module turf {
     * @param [units=miles] 'miles', 'kilometers', 'radians' or 'degrees'
     * @returns Point along the line
     */
-    along(line: GeoJSON.Feature<GeoJSON.LineString>, distance: number, units?: string): GeoJSON.Feature<GeoJSON.Point>;
+    along(
+      line: GeoJSON.Feature<GeoJSON.LineString>,
+      distance: number,
+      units?: typeof TemplateUnits
+    ): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
     * Takes one or more features and returns their area in square meters.
@@ -183,7 +187,12 @@ declare module turf {
     * @param units 'miles', 'kilometers', 'radians', or 'degrees'
     * @returns Destination point
     */
-    destination(start: GeoJSON.Feature<GeoJSON.Point>, distance: number, bearing: number, units: string): GeoJSON.Feature<GeoJSON.Point>;
+    destination(
+      start: GeoJSON.Feature<GeoJSON.Point>,
+      distance: number,
+      bearing: number,
+      units?: typeof TemplateUnits
+    ): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
     * Calculates the distance between two points in degress, radians, miles, or kilometers.
@@ -193,7 +202,11 @@ declare module turf {
     * @param [units=kilometers] 'miles', 'kilometers', 'radians', or 'degrees'
     * @returns Distance between the two points
     */
-    distance(from: GeoJSON.Feature<GeoJSON.Point>, to: GeoJSON.Feature<GeoJSON.Point>, units?: string): number;
+    distance(
+      from: GeoJSON.Feature<GeoJSON.Point>,
+      to: GeoJSON.Feature<GeoJSON.Point>,
+      units?: typeof TemplateUnits
+    ): number;
 
     /**
     * Takes any number of features and returns a rectangular Polygon that encompasses all vertices.
@@ -208,7 +221,10 @@ declare module turf {
     * @param units 'miles', 'kilometers', 'radians', or 'degrees'
     * @returns Length of the input line
     */
-    lineDistance(line: GeoJSON.Feature<GeoJSON.LineString>, units: string): number;
+    lineDistance(
+      line: GeoJSON.Feature<GeoJSON.LineString>,
+      units?: typeof TemplateUnits
+    ): number;
 
     /**
     * Takes two points and returns a point midway between them.
@@ -254,7 +270,14 @@ declare module turf {
     * @param units 'miles', 'kilometers', 'radians', or 'degrees'
     * @returns Buffered features
     */
-    buffer(feature: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>, distance: number, units: string): GeoJSON.FeatureCollection<GeoJSON.Polygon> | GeoJSON.FeatureCollection<GeoJSON.MultiPolygon> | GeoJSON.Polygon | GeoJSON.MultiPolygon;
+    buffer(feature: GeoJSON.Feature<GeoJSON.Polygon>, distance: number, units?: typeof TemplateUnits): GeoJSON.Feature<GeoJSON.Polygon>;
+    buffer(feature: GeoJSON.Feature<GeoJSON.MultiPolygon>, distance: number, units?: typeof TemplateUnits): GeoJSON.Feature<GeoJSON.MultiPolygon>;
+    buffer(feature: GeoJSON.Feature<GeoJSON.Point>, distance: number, units?: typeof TemplateUnits): GeoJSON.Feature<GeoJSON.Point>;        
+    buffer(feature: GeoJSON.Feature<any>, distance: number, units?: typeof TemplateUnits): GeoJSON.Feature<any>;
+    buffer(feature: GeoJSON.FeatureCollection<GeoJSON.Polygon>, distance: number, units?: typeof TemplateUnits): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+    buffer(feature: GeoJSON.FeatureCollection<GeoJSON.MultiPolygon>, distance: number, units?: typeof TemplateUnits): GeoJSON.FeatureCollection<GeoJSON.MultiPolygon>;
+    buffer(feature: GeoJSON.FeatureCollection<GeoJSON.Point>, distance: number, units?: typeof TemplateUnits): GeoJSON.FeatureCollection<GeoJSON.Point>;
+    buffer(feature: GeoJSON.FeatureCollection<any>, distance: number, units?: typeof TemplateUnits): GeoJSON.FeatureCollection<any>;
 
     /**
     * Takes a set of points and returns a concave hull polygon. Internally, this implements a Monotone chain algorithm.
@@ -263,14 +286,20 @@ declare module turf {
     * @param units Used for maxEdge distance (miles or kilometers)
     * @returns A concave hull
     */
-    concave(points: GeoJSON.FeatureCollection<GeoJSON.Point>, maxEdge: number, units: string): GeoJSON.Feature<GeoJSON.Polygon>;
+    concave(
+      points: GeoJSON.FeatureCollection<GeoJSON.Point>,
+      maxEdge: number,
+      units?: typeof TemplateUnits
+    ): GeoJSON.Feature<GeoJSON.Polygon>;
 
     /**
     * Takes a set of points and returns a convex hull polygon. Internally this uses the convex-hull module that implements a monotone chain hull.
     * @param input Input points
     * @returns A convex hull
     */
-    convex(input: GeoJSON.FeatureCollection<GeoJSON.Point>): GeoJSON.Feature<GeoJSON.Polygon>;
+    convex(
+      input: GeoJSON.FeatureCollection<GeoJSON.Point>
+    ): GeoJSON.Feature<GeoJSON.Polygon>;
 
     /**
     * Finds the difference between two polygons by clipping the second polygon from the first.
@@ -278,18 +307,65 @@ declare module turf {
     * @param poly2 Polygon feature to difference from poly1
     * @returns A Polygon feature showing the area of poly1 excluding the area of poly2
     */
-    difference(poly1: GeoJSON.Feature<GeoJSON.Polygon>, poly2: GeoJSON.Feature<GeoJSON.Polygon>): GeoJSON.Feature<GeoJSON.Polygon>;
+    difference(
+      poly1: GeoJSON.Feature<GeoJSON.Polygon>,
+      poly2: GeoJSON.Feature<GeoJSON.Polygon>
+    ): GeoJSON.Feature<GeoJSON.Polygon>;
 
     /**
-    * Takes two polygons and finds their intersection.
-    *  If they share a border, returns the border if they don't intersect, returns undefined.
-    * @param poly1 The first polygon
-    * @param poly2 The second polygon
-    * @returns If poly1 and poly2 overlap, returns a Polygon feature representing the area they overlap
-    * if poly1 and poly2 do not overlap, returns undefined
-    * if poly1 and poly2 share a border, a MultiLineString of the locations where their borders are shared
+    * Takes two Features and finds their intersection.
+    * If they share a border, returns the border if they don't intersect, returns undefined.
+    *
+    * @name [intersect](http://turfjs.org/docs/#intersect)
+    * @param {Feature} feature1 
+    * @param {Feature} feature2
+    * @returns {Feature} If feature1 and feature2 overlap, returns a Feature representing the area they overlap
+    * if feature1 and feature2 do not overlap, returns undefined
     */
-    intersect(poly1: GeoJSON.Feature<GeoJSON.Polygon>, poly2: GeoJSON.Feature<GeoJSON.Polygon>): GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiLineString> | typeof undefined;
+    intersect(
+      feature1: GeoJSON.Feature<GeoJSON.Point>,
+      feature2: GeoJSON.Feature<GeoJSON.Point>
+    ): GeoJSON.Feature<GeoJSON.Point>;
+    intersect(
+      feature1: GeoJSON.Feature<GeoJSON.LineString>,
+      feature2: GeoJSON.Feature<GeoJSON.LineString>
+    ): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString>;
+    intersect(
+      feature1: GeoJSON.Feature<GeoJSON.Polygon>,
+      feature2: GeoJSON.Feature<GeoJSON.Polygon>
+    ): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.Polygon>;
+    intersect(
+      feature1: GeoJSON.Feature<GeoJSON.MultiPoint>,
+      feature2: GeoJSON.Feature<GeoJSON.MultiPoint>
+    ): GeoJSON.Feature<GeoJSON.Point | GeoJSON.MultiPoint>;
+    intersect(
+      feature1: GeoJSON.Feature<GeoJSON.MultiLineString>,
+      feature2: GeoJSON.Feature<GeoJSON.MultiLineString>
+    ): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.MultiLineString>;
+        intersect(
+      feature1: GeoJSON.Feature<GeoJSON.MultiPolygon>,
+      feature2: GeoJSON.Feature<GeoJSON.MultiPolygon>
+    ): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.Polygon | GeoJSON.MultiPolygon>;
+    intersect(
+      feature1: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.Point>,
+      feature2: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.Point>
+    ): GeoJSON.Feature<GeoJSON.Point>;
+    intersect(
+      feature1: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.LineString>,
+      feature2: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.LineString>
+    ): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString>;
+    intersect(
+      feature1: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiLineString>,
+      feature2: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiLineString>
+    ): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.MultiLineString>;
+    intersect(
+      feature1: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>,
+      feature2: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>
+    ): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.Polygon | GeoJSON.MultiLineString | GeoJSON.MultiPolygon>;
+    intersect(
+      feature1: GeoJSON.Feature<any>,
+      feature2: GeoJSON.Feature<any>
+    ): GeoJSON.Feature<any>;
 
     /**
     * Takes a LineString or Polygon and returns a simplified version.
@@ -573,13 +649,10 @@ declare module turf {
      *
      * //=polygons
      */
-    random(
-      type?: 'points' | 'polygons',
-      count?: number,
-      options?: {
-        bbox?: Array<number>
-        num_vertices?: number
-        max_radial_length?: number
+    random(type?: 'points' | 'polygons', count?: number, options?: {
+      bbox?: Array<number>
+      num_vertices?: number
+      max_radial_length?: number
     }): GeoJSON.FeatureCollection<any>;
 
     /**
@@ -625,7 +698,7 @@ declare module turf {
     hexGrid(
       bbox: Array<number>,
       cellSize: number,
-      units?: string | 'miles' | 'nauticalmiles' | 'degrees' | 'radians' | 'inches' | 'yards' | 'meters' | 'metres' | 'kilometers' | 'kilometres',
+      units?: typeof TemplateUnits,
       triangles?: boolean
     ): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
@@ -649,7 +722,7 @@ declare module turf {
     pointGrid(
       bbox: Array<number>,
       cellSize: number,
-      units?: string | 'miles' | 'nauticalmiles' | 'degrees' | 'radians' | 'inches' | 'yards' | 'meters' | 'metres' | 'kilometers' | 'kilometres' 
+      units?: typeof TemplateUnits 
     ): GeoJSON.FeatureCollection<GeoJSON.Point>;
 
     /**
@@ -672,7 +745,7 @@ declare module turf {
     squareGrid(
       bbox: Array<number>,
       cellSize: number,
-      units?: string | 'miles' | 'nauticalmiles' | 'degrees' | 'radians' | 'inches' | 'yards' | 'meters' | 'metres' | 'kilometers' | 'kilometres'
+      units?: typeof TemplateUnits
     ): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     /**
@@ -695,7 +768,7 @@ declare module turf {
     triangleGrid(
       bbox: Array<number>,
       cellSize: number,
-      units?: string | 'miles' | 'nauticalmiles' | 'degrees' | 'radians' | 'inches' | 'yards' | 'meters' | 'metres' | 'kilometers' | 'kilometres'
+      units?: typeof TemplateUnits
     ): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     //////////////////////////////////////////////////////

--- a/turf/turf.d.ts
+++ b/turf/turf.d.ts
@@ -886,7 +886,7 @@ declare module turf {
   }
 }
 
-// Stable version of Turf
+// NPM Stable version of Turf
 declare module "turf" {
   export = turf
 }
@@ -895,3 +895,300 @@ declare module "turf" {
 declare module "@turf/turf" {
   export = turf
 }
+
+// AGGREGATION
+declare module "@turf/collect" {
+   const collect: typeof turf.collect;
+   export = collect;
+}
+
+// MEASUREMENT
+declare module "@turf/along" {
+   const along: typeof turf.along;
+   export = along;
+}
+
+declare module "@turf/area" {
+   const area: typeof turf.area;
+   export = area;
+}
+
+declare module "@turf/bbox-polygon" {
+   const bboxPolygon: typeof turf.bboxPolygon;
+   export = bboxPolygon;
+}
+
+declare module "@turf/bearing" {
+   const bearing: typeof turf.bearing;
+   export = bearing;
+}
+
+declare module "@turf/center" {
+   const center: typeof turf.center;
+   export = center;
+}
+
+declare module "@turf/centroid" {
+   const centroid: typeof turf.centroid;
+   export = centroid;
+}
+
+declare module "@turf/destination" {
+   const destination: typeof turf.destination;
+   export = destination;
+}
+
+declare module "@turf/distance" {
+   const distance: typeof turf.distance;
+   export = distance;
+}
+
+declare module "@turf/envelope" {
+   const envelope: typeof turf.envelope;
+   export = envelope;
+}
+
+declare module "@turf/line-distance" {
+   const lineDistance: typeof turf.lineDistance;
+   export = lineDistance;
+}
+
+declare module "@turf/midpoint" {
+   const midpoint: typeof turf.midpoint;
+   export = midpoint;
+}
+
+declare module "@turf/point-on-surface" {
+   const pointOnSurface: typeof turf.pointOnSurface;
+   export = pointOnSurface;
+}
+
+declare module "@turf/square" {
+   const square: typeof turf.square;
+   export = square;
+}
+
+// TRANSFORMATION
+declare module "@turf/bezier" {
+   const bezier: typeof turf.bezier;
+   export = bezier;
+}
+
+declare module "@turf/buffer" {
+   const buffer: typeof turf.buffer;
+   export = buffer;
+}
+
+declare module "@turf/concave" {
+   const concave: typeof turf.concave;
+   export = concave;
+}
+
+declare module "@turf/convex" {
+   const convex: typeof turf.convex;
+   export = convex;
+}
+
+declare module "@turf/difference" {
+   const difference: typeof turf.difference;
+   export = difference;
+}
+
+declare module "@turf/intersect" {
+   const intersect: typeof turf.intersect;
+   export = intersect;
+}
+
+declare module "@turf/simplify" {
+   const simplify: typeof turf.simplify;
+   export = simplify;
+}
+
+declare module "@turf/union" {
+   const union: typeof turf.union;
+   export = union;
+}
+
+// MISC
+declare module "@turf/combine" {
+   const combine: typeof turf.combine;
+   export = combine;
+}
+
+declare module "@turf/explode" {
+   const explode: typeof turf.explode;
+   export = explode;
+}
+
+declare module "@turf/flip" {
+   const flip: typeof turf.flip;
+   export = flip;
+}
+
+declare module "@turf/kinks" {
+   const kinks: typeof turf.kinks;
+   export = kinks;
+}
+
+declare module "@turf/line-slice" {
+   const lineSlice: typeof turf.lineSlice;
+   export = lineSlice;
+}
+
+declare module "@turf/point-on-line" {
+   const pointOnLine: typeof turf.pointOnLine;
+   export = pointOnLine;
+}
+
+// HELPER
+declare module "@turf/helpers" {
+   const helpers: {
+     featureCollection: typeof turf.featureCollection,
+     feature: typeof turf.feature,
+     lineString: typeof turf.lineString,
+     multiLineString: typeof turf.multiLineString,
+     point: typeof turf.point,
+     multiPoint: typeof turf.multiPoint,
+     polygon: typeof turf.polygon,
+     multiPolygon: typeof turf.multiPolygon,
+     geometryCollection: typeof turf.geometryCollection,
+   };
+   export = helpers;
+}
+
+// DATA
+declare module "@turf/random" {
+   const random: typeof turf.random;
+   export = random;
+}
+
+declare module "@turf/sample" {
+   const sample: typeof turf.sample;
+   export = sample;
+}
+
+// INTERPOLATION
+declare module "@turf/isolines" {
+   const isolines: typeof turf.isolines;
+   export = isolines;
+}
+
+declare module "@turf/planepoint" {
+   const planepoint: typeof turf.planepoint;
+   export = planepoint;
+}
+
+declare module "@turf/tin" {
+   const tin: typeof turf.tin;
+   export = tin;
+}
+
+// JOINS
+declare module "@turf/inside" {
+   const inside: typeof turf.inside;
+   export = inside;
+}
+
+declare module "@turf/tag" {
+   const tag: typeof turf.tag;
+   export = tag;
+}
+
+declare module "@turf/within" {
+   const within: typeof turf.within;
+   export = within;
+}
+
+// GRIDS
+declare module "@turf/hex-grid" {
+   const hexGrid: typeof turf.hexGrid;
+   export = hexGrid;
+}
+
+declare module "@turf/point-grid" {
+   const pointGrid: typeof turf.pointGrid;
+   export = pointGrid;
+}
+
+declare module "@turf/square-grid" {
+   const squareGrid: typeof turf.squareGrid;
+   export = squareGrid;
+}
+
+declare module "@turf/triangle-grid" {
+   const triangleGrid: typeof turf.triangleGrid;
+   export = triangleGrid;
+}
+
+// CLASSIFICATION
+declare module "@turf/nearest" {
+   const nearest: typeof turf.nearest;
+   export = nearest;
+}
+
+// // META
+// declare module "@turf/propEach" {
+//    const propEach: typeof turf.propEach;
+//    export = propEach;
+// }
+
+// declare module "@turf/coordEach" {
+//    const coordEach: typeof turf.coordEach;
+//    export = coordEach;
+// }
+
+// declare module "@turf/coordReduce" {
+//    const coordReduce: typeof turf.coordReduce;
+//    export = coordReduce;
+// }
+
+// declare module "@turf/featureEach" {
+//    const featureEach: typeof turf.featureEach;
+//    export = featureEach;
+// }
+
+// declare module "@turf/getCoord" {
+//    const getCoord: typeof turf.getCoord;
+//    export = getCoord;
+// }
+
+// // ASSERTIONS
+// declare module "@turf/featureOf" {
+//    const featureOf: typeof turf.featureOf;
+//    export = featureOf;
+// }
+
+// declare module "@turf/collectionOf" {
+//    const collectionOf: typeof turf.collectionOf;
+//    export = collectionOf;
+// }
+
+// declare module "@turf/bbox" {
+//    const bbox: typeof turf.bbox;
+//    export = bbox;
+// }
+
+// declare module "@turf/circle" {
+//    const circle: typeof turf.circle;
+//    export = circle;
+// }
+
+// declare module "@turf/geojsonType" {
+//    const geojsonType: typeof turf.geojsonType;
+//    export = geojsonType;
+// }
+
+// declare module "@turf/propReduce" {
+//    const propReduce: typeof turf.propReduce;
+//    export = propReduce;
+// }
+
+// declare module "@turf/coordAll" {
+//    const coordAll: typeof turf.coordAll;
+//    export = coordAll;
+// }
+
+// declare module "@turf/tesselate" {
+//    const tesselate: typeof turf.tesselate;
+//    export = tesselate;
+// }

--- a/turf/turf.d.ts
+++ b/turf/turf.d.ts
@@ -60,15 +60,15 @@ INTERPOLATION
 - [ ] planepoint
 - [ ] tin
 JOINS
-- [ ] inside
-- [ ] tag
+- [x] inside
+- [x] tag
+- [ ] within
 GRIDS
 - [x] hexGrid
 - [x] pointGrid
 - [x] squareGrid
 - [x] triangleGrid
 CLASSIFICATION
-- [ ] within
 - [ ] nearest
 META
 - [ ] propEach
@@ -89,6 +89,7 @@ ASSERTIONS
 
 declare const turf: turf.TurfStatic;
 declare const TemplateUnits: 'miles' | 'nauticalmiles' | 'degrees' | 'radians' | 'inches' | 'yards' | 'meters' | 'metres' | 'kilometers' | 'kilometres'
+declare const TemplateType: 'point'| 'points' | 'polygon' | 'polygons'
 declare module turf {
   interface TurfStatic {
     //////////////////////////////////////////////////////
@@ -105,16 +106,16 @@ declare module turf {
      * @param {string} outProperty property to be nested into
      * @return {FeatureCollection<Polygon>} polygons with properties listed based on `outField`
      * @example
-     * const poly1 = polygon([[[0,0],[10,0],[10,10],[0,10],[0,0]]])
-     * const poly2 = polygon([[[10,0],[20,10],[20,20],[20,0],[10,0]]])
-     * const polyFC = featurecollection([poly1, poly2])
-     * const pt1 = point([5,5], {population: 200})
-     * const pt2 = point([1,3], {population: 600})
-     * const pt3 = point([14,2], {population: 100})
-     * const pt4 = point([13,1], {population: 200})
-     * const pt5 = point([19,7], {population: 300})
-     * const ptFC = featurecollection([pt1, pt2, pt3, pt4, pt5])
-     * const aggregated = aggregate(polyFC, ptFC, 'population', 'values')
+     * var poly1 = polygon([[[0,0],[10,0],[10,10],[0,10],[0,0]]])
+     * var poly2 = polygon([[[10,0],[20,10],[20,20],[20,0],[10,0]]])
+     * var polyFC = featurecollection([poly1, poly2])
+     * var pt1 = point([5,5], {population: 200})
+     * var pt2 = point([1,3], {population: 600})
+     * var pt3 = point([14,2], {population: 100})
+     * var pt4 = point([13,1], {population: 200})
+     * var pt5 = point([19,7], {population: 300})
+     * var ptFC = featurecollection([pt1, pt2, pt3, pt4, pt5])
+     * var aggregated = aggregate(polyFC, ptFC, 'population', 'values')
      *
      * aggregated.features[0].properties.values // => [200, 600])
      */
@@ -122,7 +123,8 @@ declare module turf {
       polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>,
       points: GeoJSON.FeatureCollection<GeoJSON.Point>,
       inProperty: string,
-      outProperty: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+      outProperty: string
+    ): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     //////////////////////////////////////////////////////
     // Measurement
@@ -637,19 +639,19 @@ declare module turf {
      * from its center.
      * @return {FeatureCollection} generated random features
      * @example
-     * const points = turf.random('points', 100, {
+     * var points = turf.random('points', 100, {
      *   bbox: [-70, 40, -60, 60]
      * })
      *
      * //=points
      *
-     * const polygons = turf.random('polygons', 4, {
+     * var polygons = turf.random('polygons', 4, {
      *   bbox: [-70, 40, -60, 60]
      * })
      *
      * //=polygons
      */
-    random(type?: 'points' | 'polygons', count?: number, options?: {
+    random(type?: typeof TemplateType, count?: number, options?: {
       bbox?: Array<number>
       num_vertices?: number
       max_radial_length?: number
@@ -809,23 +811,52 @@ declare module turf {
     //////////////////////////////////////////////////////
 
     /**
-    * Takes a Point and a Polygon or MultiPolygon and determines if the point resides inside the polygon.
-    * The polygon can be convex or concave. The function accounts for holes.;
-    * @param point Input point
-    * @param polygon Input polygon or multipolygon
-    * @returns true if the Point is inside the Polygon false if the Point is not inside the Polygon
-    */
-    inside(point: GeoJSON.Feature<GeoJSON.Point>, polygon: GeoJSON.Feature<GeoJSON.Polygon>): boolean;
+     * Takes a {<Point>} and a {<Polygon>} or {<MultiPolygon>} and determines if the point resides inside the polygon. The polygon can be convex or concave. The function accounts for holes.
+     *
+     * @name [inside](http://turfjs.org/docs/#inside)
+     * @param {Feature<Point>} point input point
+     * @param {Feature<(Polygon|MultiPolygon)>} polygon input polygon or multipolygon
+     * @return {Boolean} `true` if the Point is inside the Polygon; `false` if the Point is not inside the Polygon
+     * @example
+     * var pt = point([-77, 44])
+     * var poly = polygon([[[-81, 41], [-81, 47], [-72, 47], [-72, 41], [-81, 41]]])
+     *
+     * var isInside = turf.inside(pt, poly)
+     * 
+     * //=isInside
+     */
+    inside(
+      point: GeoJSON.Feature<GeoJSON.Point>,
+      polygon: GeoJSON.Feature<GeoJSON.Polygon>
+    ): boolean;
 
     /**
-    * Takes a set of points and a set of polygons and performs a spatial join.
-    * @param points Input points
-    * @param polygons Input polygons
-    * @param polyId Property in polygons to add to joined Point features
-    * @param containingPolyId Property in points in which to store joined property from polygons
-    * @returns Points with containingPolyId property containing values from polyId
-    */
-    tag(points: GeoJSON.FeatureCollection<GeoJSON.Point>, polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, polyId: string, containingPolyId: string): GeoJSON.FeatureCollection<GeoJSON.Point>;
+     * Takes a {FeatureCollection<Point>} and a {FeatureCollection<Polygon>} and performs a spatial join.
+     *
+     * @name [tag](http://turfjs.org/docs/#inside)
+     * @param {FeatureCollection<Point>} points input points
+     * @param {FeatureCollection<Polygon>} polygons input polygons
+     * @param {string} field property in `polygons` to add to joined {<Point>} features
+     * @param {string} outField property in `points` in which to store joined property from `polygons`
+     * @return {FeatureCollection<Point>} points with `containingPolyId` property containing values from `polyId`
+     * @example
+     * var pt1 = point([-77, 44])
+     * var pt2 = point([-77, 38])
+     * var poly1 = polygon([[[-81, 41], [-81, 47], [-72, 47], [-72, 41], [-81, 41]]], {pop: 1000})
+     * var poly2 = polygon([[[-81, 35], [-81, 41], [-72, 41], [-72, 35], [-81, 35]]], {pop: 3000})
+     * 
+     * var points = featureCollection([pt1, pt2])
+     * var polygons = featureCollection([poly1, poly2])
+     * 
+     * var tagged = turf.tag(points, polygons, 'pop', 'population')
+     * //=tagged
+     */
+    tag(
+      points: GeoJSON.FeatureCollection<GeoJSON.Point>,
+      polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>,
+      field: string,
+      outField: string
+    ): GeoJSON.FeatureCollection<GeoJSON.Point>;
 
     /**
     * Takes a set of points and a set of polygons and returns the points that fall within the polygons.
@@ -833,7 +864,10 @@ declare module turf {
     * @param polygons Input polygons
     * @returns Points that land within at least one polygon
     */
-    within(points: GeoJSON.FeatureCollection<GeoJSON.Point>, polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>): GeoJSON.FeatureCollection<GeoJSON.Point>;
+    within(
+      points: GeoJSON.FeatureCollection<GeoJSON.Point>,
+      polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>
+    ): GeoJSON.FeatureCollection<GeoJSON.Point>;
 
     //////////////////////////////////////////////////////
     // Classification

--- a/turf/turf.d.ts
+++ b/turf/turf.d.ts
@@ -315,55 +315,44 @@ declare module turf {
     ): GeoJSON.Feature<GeoJSON.Polygon>;
 
     /**
-    * Takes two Features and finds their intersection.
-    * If they share a border, returns the border if they don't intersect, returns undefined.
-    *
-    * @name [intersect](http://turfjs.org/docs/#intersect)
-    * @param {Feature} feature1 
-    * @param {Feature} feature2
-    * @returns {Feature} If feature1 and feature2 overlap, returns a Feature representing the area they overlap
-    * if feature1 and feature2 do not overlap, returns undefined
-    */
-    intersect(
-      feature1: GeoJSON.Feature<GeoJSON.Point>,
-      feature2: GeoJSON.Feature<GeoJSON.Point>
-    ): GeoJSON.Feature<GeoJSON.Point>;
-    intersect(
-      feature1: GeoJSON.Feature<GeoJSON.LineString>,
-      feature2: GeoJSON.Feature<GeoJSON.LineString>
-    ): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString>;
+     * Takes two Features and finds their intersection.
+     * If they share a border, returns the border if they don't intersect, returns undefined.
+     *
+     * @name [intersect](http://turfjs.org/docs/#intersect)
+     * @param {Feature<Polygon>} poly1 
+     * @param {Feature<Polygon>} poly2
+     * @returns {Feature|undefined} A feature representing the point(s) they share (in case of a {Point}  or {MultiPoint}), the borders they share (in case of a {LineString} or a {MultiLineString}), the area they share (in case of {Polygon} or {MultiPolygon}). If they do not share any point, returns `undefined`.
+     * @example
+     * var poly1 = polygon([[
+     *   [-122.801742, 45.48565],
+     *   [-122.801742, 45.60491],
+     *   [-122.584762, 45.60491],
+     *   [-122.584762, 45.48565],
+     *   [-122.801742, 45.48565]
+     * ]]);
+     *
+     * var poly2 = polygon([[
+     *   [-122.520217, 45.535693],
+     *   [-122.64038, 45.553967],
+     *   [-122.720031, 45.526554],
+     *   [-122.669906, 45.507309],
+     *   [-122.723464, 45.446643],
+     *   [-122.532577, 45.408574],
+     *   [-122.487258, 45.477466],
+     *   [-122.520217, 45.535693]
+     * ]]);
+     * var polygons = featureCollection([poly1, poly2]);
+     *
+     * var intersection = turf.intersect(poly1, poly2);
+     *
+     * //=polygons
+     *
+     * //=intersection
+     */
     intersect(
       feature1: GeoJSON.Feature<GeoJSON.Polygon>,
       feature2: GeoJSON.Feature<GeoJSON.Polygon>
     ): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.Polygon>;
-    intersect(
-      feature1: GeoJSON.Feature<GeoJSON.MultiPoint>,
-      feature2: GeoJSON.Feature<GeoJSON.MultiPoint>
-    ): GeoJSON.Feature<GeoJSON.Point | GeoJSON.MultiPoint>;
-    intersect(
-      feature1: GeoJSON.Feature<GeoJSON.MultiLineString>,
-      feature2: GeoJSON.Feature<GeoJSON.MultiLineString>
-    ): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.MultiLineString>;
-        intersect(
-      feature1: GeoJSON.Feature<GeoJSON.MultiPolygon>,
-      feature2: GeoJSON.Feature<GeoJSON.MultiPolygon>
-    ): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.Polygon | GeoJSON.MultiPolygon>;
-    intersect(
-      feature1: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.Point>,
-      feature2: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.Point>
-    ): GeoJSON.Feature<GeoJSON.Point>;
-    intersect(
-      feature1: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.LineString>,
-      feature2: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.LineString>
-    ): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString>;
-    intersect(
-      feature1: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiLineString>,
-      feature2: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiLineString>
-    ): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.MultiLineString>;
-    intersect(
-      feature1: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>,
-      feature2: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>
-    ): GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.Polygon | GeoJSON.MultiLineString | GeoJSON.MultiPolygon>;
     intersect(
       feature1: GeoJSON.Feature<any>,
       feature2: GeoJSON.Feature<any>

--- a/turf/turf.d.ts
+++ b/turf/turf.d.ts
@@ -79,7 +79,7 @@ META
 ASSERTIONS
 - [ ] featureOf
 - [ ] collectionOf
-- [ ] bbox
+- [x] bbox
 - [ ] circle
 - [ ] geojsonType
 - [ ] propReduce
@@ -149,6 +149,30 @@ declare module turf {
     * @returns Area in square meters
     */
     area(input: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): number;
+
+    /**
+     * Takes a set of features, calculates the bbox of all input features, and returns a bounding box.
+     *
+     * @name bbox
+     * @param {(Feature|FeatureCollection)} geojson input features
+     * @return {Array<number>} bbox extent in [minX, minY, maxX, maxY] order
+     * @example
+     * var pt1 = point([114.175329, 22.2524])
+     * var pt2 = point([114.170007, 22.267969])
+     * var pt3 = point([114.200649, 22.274641])
+     * var pt4 = point([114.200649, 22.274641])
+     * var pt5 = point([114.186744, 22.265745])
+     * var features = featureCollection([pt1, pt2, pt3, pt4, pt5])
+     *
+     * var bbox = turf.bbox(features);
+     *
+     * var bboxPolygon = turf.bboxPolygon(bbox);
+     *
+     * //=bbox
+     * 
+     * //=bboxPolygon
+     */
+    bbox(bbox: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): Array<number>;
 
     /**
     * Takes a bbox and returns an equivalent polygon.
@@ -1152,10 +1176,10 @@ declare module "@turf/nearest" {
 //    export = collectionOf;
 // }
 
-// declare module "@turf/bbox" {
-//    const bbox: typeof turf.bbox;
-//    export = bbox;
-// }
+declare module "@turf/bbox" {
+   const bbox: typeof turf.bbox;
+   export = bbox;
+}
 
 // declare module "@turf/circle" {
 //    const circle: typeof turf.circle;

--- a/turf/turf.d.ts
+++ b/turf/turf.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Turf 3.5.2
 // Project: http://turfjs.org/
-// Definitions by: Denis Carriere <https://github.com/DenisCarriere>
+// Definitions by: Guillaume Croteau <https://github.com/gcroteau>, Denis Carriere <https://github.com/DenisCarriere>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../geojson/geojson.d.ts" />

--- a/turf/turf.d.ts
+++ b/turf/turf.d.ts
@@ -411,16 +411,16 @@ declare module turf {
      * @throws {Error} if no coordinates are passed
      * @example
      * var linestring1 = turf.lineString([
-     *	  [-21.964416, 64.148203],
-     *	  [-21.956176, 64.141316],
-     *	  [-21.93901, 64.135924],
-     *	  [-21.927337, 64.136673]
+     *    [-21.964416, 64.148203],
+     *    [-21.956176, 64.141316],
+     *    [-21.93901, 64.135924],
+     *    [-21.927337, 64.136673]
      * ])
      * var linestring2 = turf.lineString([
-     *	  [-21.929054, 64.127985],
-     *	  [-21.912918, 64.134726],
-     *	  [-21.916007, 64.141016],
-     * 	[-21.930084, 64.14446]
+     *    [-21.929054, 64.127985],
+     *    [-21.912918, 64.134726],
+     *    [-21.916007, 64.141016],
+     *   [-21.930084, 64.14446]
      * ], {name: 'line 1', distance: 145})
      *
      * //=linestring1
@@ -775,6 +775,12 @@ declare module turf {
     ): GeoJSON.Feature<GeoJSON.Point>;
 }
 
+// Stable version of Turf
 declare module 'turf' {
+  export = turf
+}
+
+// Latest version of Turf
+declare module '@turf/turf' {
   export = turf
 }

--- a/turf/turf.d.ts
+++ b/turf/turf.d.ts
@@ -882,7 +882,7 @@ declare module "turf" {
 
 // Latest version of Turf
 declare module "@turf/turf" {
-  export = turf
+  export default turf
 }
 
 // AGGREGATION

--- a/turf/turf.d.ts
+++ b/turf/turf.d.ts
@@ -87,7 +87,10 @@ ASSERTIONS
 - [ ] tesselate
  */
 
+declare var turf: turf.TurfStatic;
+
 declare module turf {
+  interface TurfStatic {
     //////////////////////////////////////////////////////
     // Aggregation
     //////////////////////////////////////////////////////
@@ -115,7 +118,7 @@ declare module turf {
      *
      * aggregated.features[0].properties.values // => [200, 600])
      */
-    function collect(
+    collect(
       polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>,
       points: GeoJSON.FeatureCollection<GeoJSON.Point>,
       inProperty: string,
@@ -132,21 +135,21 @@ declare module turf {
     * @param [units=miles] 'miles', 'kilometers', 'radians' or 'degrees'
     * @returns Point along the line
     */
-    function along(line: GeoJSON.Feature<GeoJSON.LineString>, distance: number, units?: string): GeoJSON.Feature<GeoJSON.Point>;
+    along(line: GeoJSON.Feature<GeoJSON.LineString>, distance: number, units?: string): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
     * Takes one or more features and returns their area in square meters.
     * @param input Input features
     * @returns Area in square meters
     */
-    function area(input: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): number;
+    area(input: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): number;
 
     /**
     * Takes a bbox and returns an equivalent polygon.
     * @param bbox An Array of bounding box coordinates in the form: [xLow, yLow, xHigh, yHigh]
     * @returns A Polygon representation of the bounding box
     */
-    function bboxPolygon(bbox: Array<number>): GeoJSON.Feature<GeoJSON.Polygon>;
+    bboxPolygon(bbox: Array<number>): GeoJSON.Feature<GeoJSON.Polygon>;
 
     /**
     * Takes two points and finds the geographic bearing between them.
@@ -154,14 +157,14 @@ declare module turf {
     * @param end Ending point
     * @returns Bearing in decimal degrees
     */
-    function bearing(start: GeoJSON.Feature<GeoJSON.Point>, end: GeoJSON.Feature<GeoJSON.Point>): number;
+    bearing(start: GeoJSON.Feature<GeoJSON.Point>, end: GeoJSON.Feature<GeoJSON.Point>): number;
 
     /**
     * Takes a FeatureCollection and returns the absolute center point of all features.
     * @param features Input features
     * @returns A Point feature at the absolute center point of all input features
     */
-    function center(features: GeoJSON.FeatureCollection<any>): GeoJSON.Feature<GeoJSON.Point>;
+    center(features: GeoJSON.FeatureCollection<any>): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
     * Takes one or more features and calculates the centroid using the arithmetic mean of all vertices.
@@ -169,7 +172,7 @@ declare module turf {
     * @param features Input features
     * @returns The centroid of the input features
     */
-    function centroid(features: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): GeoJSON.Feature<GeoJSON.Point>;
+    centroid(features: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
     * Takes a Point and calculates the location of a destination point given a distance in degrees, radians, miles, or kilometers and bearing in degrees.
@@ -180,7 +183,7 @@ declare module turf {
     * @param units 'miles', 'kilometers', 'radians', or 'degrees'
     * @returns Destination point
     */
-    function destination(start: GeoJSON.Feature<GeoJSON.Point>, distance: number, bearing: number, units: string): GeoJSON.Feature<GeoJSON.Point>;
+    destination(start: GeoJSON.Feature<GeoJSON.Point>, distance: number, bearing: number, units: string): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
     * Calculates the distance between two points in degress, radians, miles, or kilometers.
@@ -190,14 +193,14 @@ declare module turf {
     * @param [units=kilometers] 'miles', 'kilometers', 'radians', or 'degrees'
     * @returns Distance between the two points
     */
-    function distance(from: GeoJSON.Feature<GeoJSON.Point>, to: GeoJSON.Feature<GeoJSON.Point>, units?: string): number;
+    distance(from: GeoJSON.Feature<GeoJSON.Point>, to: GeoJSON.Feature<GeoJSON.Point>, units?: string): number;
 
     /**
     * Takes any number of features and returns a rectangular Polygon that encompasses all vertices.
     * @param fc Input features
     * @returns A rectangular Polygon feature that encompasses all vertices
     */
-    function envelope(fc: GeoJSON.FeatureCollection<any>): GeoJSON.Feature<GeoJSON.Polygon>;
+    envelope(fc: GeoJSON.FeatureCollection<any>): GeoJSON.Feature<GeoJSON.Polygon>;
 
     /**
     * Takes a line and measures its length in the specified units.
@@ -205,7 +208,7 @@ declare module turf {
     * @param units 'miles', 'kilometers', 'radians', or 'degrees'
     * @returns Length of the input line
     */
-    function lineDistance(line: GeoJSON.Feature<GeoJSON.LineString>, units: string): number;
+    lineDistance(line: GeoJSON.Feature<GeoJSON.LineString>, units: string): number;
 
     /**
     * Takes two points and returns a point midway between them.
@@ -213,7 +216,7 @@ declare module turf {
     * @param pt2 Second point
     * @returns A point midway between pt1 and pt2
     */
-    function midpoint(pt1: GeoJSON.Feature<GeoJSON.Point>, pt2: GeoJSON.Feature<GeoJSON.Point>): GeoJSON.Feature<GeoJSON.Point>;
+    midpoint(pt1: GeoJSON.Feature<GeoJSON.Point>, pt2: GeoJSON.Feature<GeoJSON.Point>): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
     * Takes a feature and returns a Point guaranteed to be on the surface of the feature. Given a Polygon, the point will be in the area of the polygon.
@@ -221,14 +224,14 @@ declare module turf {
     * @param input Any feature or set of features
     * @returns A point on the surface of input
     */
-    function pointOnSurface(input: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): GeoJSON.Feature<any>;
+    pointOnSurface(input: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): GeoJSON.Feature<any>;
 
     /**
     * Takes a bounding box and calculates the minimum square bounding box that would contain the input.
     * @param bbox A bounding box
     * @returns A square surrounding bbox
     */
-    function square(bbox: Array<number>): Array<number>;
+    square(bbox: Array<number>): Array<number>;
 
     //////////////////////////////////////////////////////
     // Transformation
@@ -242,7 +245,7 @@ declare module turf {
     * @param [sharpness=0.85] A measure of how curvy the path should be between splines
     * @returns Curved line
     */
-    function bezier(line: GeoJSON.Feature<GeoJSON.LineString>, resolution?: number, sharpness?: number): GeoJSON.Feature<GeoJSON.LineString>;
+    bezier(line: GeoJSON.Feature<GeoJSON.LineString>, resolution?: number, sharpness?: number): GeoJSON.Feature<GeoJSON.LineString>;
 
     /**
     * Calculates a buffer for input features for a given radius. Units supported are miles, kilometers, and degrees.
@@ -251,7 +254,7 @@ declare module turf {
     * @param units 'miles', 'kilometers', 'radians', or 'degrees'
     * @returns Buffered features
     */
-    function buffer(feature: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>, distance: number, units: string): GeoJSON.FeatureCollection<GeoJSON.Polygon> | GeoJSON.FeatureCollection<GeoJSON.MultiPolygon> | GeoJSON.Polygon | GeoJSON.MultiPolygon;
+    buffer(feature: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>, distance: number, units: string): GeoJSON.FeatureCollection<GeoJSON.Polygon> | GeoJSON.FeatureCollection<GeoJSON.MultiPolygon> | GeoJSON.Polygon | GeoJSON.MultiPolygon;
 
     /**
     * Takes a set of points and returns a concave hull polygon. Internally, this implements a Monotone chain algorithm.
@@ -260,14 +263,14 @@ declare module turf {
     * @param units Used for maxEdge distance (miles or kilometers)
     * @returns A concave hull
     */
-    function concave(points: GeoJSON.FeatureCollection<GeoJSON.Point>, maxEdge: number, units: string): GeoJSON.Feature<GeoJSON.Polygon>;
+    concave(points: GeoJSON.FeatureCollection<GeoJSON.Point>, maxEdge: number, units: string): GeoJSON.Feature<GeoJSON.Polygon>;
 
     /**
     * Takes a set of points and returns a convex hull polygon. Internally this uses the convex-hull module that implements a monotone chain hull.
     * @param input Input points
     * @returns A convex hull
     */
-    function convex(input: GeoJSON.FeatureCollection<GeoJSON.Point>): GeoJSON.Feature<GeoJSON.Polygon>;
+    convex(input: GeoJSON.FeatureCollection<GeoJSON.Point>): GeoJSON.Feature<GeoJSON.Polygon>;
 
     /**
     * Finds the difference between two polygons by clipping the second polygon from the first.
@@ -275,7 +278,7 @@ declare module turf {
     * @param poly2 Polygon feature to difference from poly1
     * @returns A Polygon feature showing the area of poly1 excluding the area of poly2
     */
-    function difference(poly1: GeoJSON.Feature<GeoJSON.Polygon>, poly2: GeoJSON.Feature<GeoJSON.Polygon>): GeoJSON.Feature<GeoJSON.Polygon>;
+    difference(poly1: GeoJSON.Feature<GeoJSON.Polygon>, poly2: GeoJSON.Feature<GeoJSON.Polygon>): GeoJSON.Feature<GeoJSON.Polygon>;
 
     /**
     * Takes two polygons and finds their intersection.
@@ -286,7 +289,7 @@ declare module turf {
     * if poly1 and poly2 do not overlap, returns undefined
     * if poly1 and poly2 share a border, a MultiLineString of the locations where their borders are shared
     */
-    function intersect(poly1: GeoJSON.Feature<GeoJSON.Polygon>, poly2: GeoJSON.Feature<GeoJSON.Polygon>): GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiLineString> | typeof undefined;
+    intersect(poly1: GeoJSON.Feature<GeoJSON.Polygon>, poly2: GeoJSON.Feature<GeoJSON.Polygon>): GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiLineString> | typeof undefined;
 
     /**
     * Takes a LineString or Polygon and returns a simplified version.
@@ -296,7 +299,7 @@ declare module turf {
     * @param highQuality Whether or not to spend more time to create a higher-quality simplification with a different algorithm
     * @returns A simplified feature
     */
-    function simplify(feature: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any> | GeoJSON.GeometryCollection, tolerance: number, highQuality: boolean): GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any> | GeoJSON.GeometryCollection;
+    simplify(feature: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any> | GeoJSON.GeometryCollection, tolerance: number, highQuality: boolean): GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any> | GeoJSON.GeometryCollection;
 
     /**
     * Takes two polygons and returns a combined polygon.
@@ -305,7 +308,7 @@ declare module turf {
     * @param poly2 Another input polygon
     * @returns A combined Polygon or MultiPolygon feature
     */
-    function union(poly1: GeoJSON.Feature<GeoJSON.Polygon>, poly2: GeoJSON.Feature<GeoJSON.Polygon>): GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>;
+    union(poly1: GeoJSON.Feature<GeoJSON.Polygon>, poly2: GeoJSON.Feature<GeoJSON.Polygon>): GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>;
 
     //////////////////////////////////////////////////////
     // Misc
@@ -316,28 +319,28 @@ declare module turf {
     * @param fc A FeatureCollection of any type
     * @returns A FeatureCollection of corresponding type to input
     */
-    function combine(fc: GeoJSON.FeatureCollection<any>): GeoJSON.FeatureCollection<any>;
+    combine(fc: GeoJSON.FeatureCollection<any>): GeoJSON.FeatureCollection<any>;
 
     /**
     * Takes a feature or set of features and returns all positions as points.
     * @param input Input features
     * @returns Points representing the exploded input features
     */
-    function explode(input: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): GeoJSON.FeatureCollection<GeoJSON.Point>;
+    explode(input: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): GeoJSON.FeatureCollection<GeoJSON.Point>;
 
     /**
     * Takes input features and flips all of their coordinates from [x, y] to [y, x].
     * @param input Input features
     * @returns A feature or set of features of the same type as input with flipped coordinates
     */
-    function flip(input: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>;
+    flip(input: GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>): GeoJSON.Feature<any> | GeoJSON.FeatureCollection<any>;
 
     /**
     * Takes a polygon and returns points at all self-intersections.
     * @param polygon Input polygon
     * @returns Self-intersections
     */
-    function kinks(polygon: GeoJSON.Feature<GeoJSON.Polygon>): GeoJSON.FeatureCollection<GeoJSON.Point>;
+    kinks(polygon: GeoJSON.Feature<GeoJSON.Polygon>): GeoJSON.FeatureCollection<GeoJSON.Point>;
 
     /**
     * Takes a line, a start Point, and a stop point and returns the line in between those points.
@@ -346,7 +349,7 @@ declare module turf {
     * @param line Line to slice
     * @returns Sliced line
     */
-    function lineSlice(point1: GeoJSON.Feature<GeoJSON.Point>, point2: GeoJSON.Feature<GeoJSON.Point>, line: GeoJSON.Feature<GeoJSON.LineString>): GeoJSON.Feature<GeoJSON.LineString>;
+    lineSlice(point1: GeoJSON.Feature<GeoJSON.Point>, point2: GeoJSON.Feature<GeoJSON.Point>, line: GeoJSON.Feature<GeoJSON.LineString>): GeoJSON.Feature<GeoJSON.LineString>;
 
     /**
     * Takes a Point and a LineString and calculates the closest Point on the LineString.
@@ -354,7 +357,7 @@ declare module turf {
     * @param point Point to snap from
     * @returns Closest point on the line to point
     */
-    function pointOnLine(line: GeoJSON.Feature<GeoJSON.LineString>, point: GeoJSON.Feature<GeoJSON.Point>): GeoJSON.Feature<GeoJSON.Point>;
+    pointOnLine(line: GeoJSON.Feature<GeoJSON.LineString>, point: GeoJSON.Feature<GeoJSON.Point>): GeoJSON.Feature<GeoJSON.Point>;
 
     //////////////////////////////////////////////////////
     // Helper
@@ -377,7 +380,7 @@ declare module turf {
      *
      * //=fc
      */
-    function featureCollection(features: Array<GeoJSON.Feature<any>>): GeoJSON.FeatureCollection<any>;
+    featureCollection(features: Array<GeoJSON.Feature<any>>): GeoJSON.FeatureCollection<any>;
 
     /**
      * Wraps a GeoJSON {@link Geometry} in a GeoJSON {@link Feature}.
@@ -399,7 +402,7 @@ declare module turf {
      *
      * //=feature
      */
-    function feature(geometry:GeoJSON.Feature<any>, properties?: any): GeoJSON.Feature<any>;
+    feature(geometry:GeoJSON.Feature<any>, properties?: any): GeoJSON.Feature<any>;
 
     /**
      * Creates a {@link LineString} based on a coordinate array. Properties can be added optionally.
@@ -427,7 +430,7 @@ declare module turf {
      *
      * //=linestring2
      */
-    function lineString(coordinates: Array<Array<number>>, properties?: any): GeoJSON.Feature<GeoJSON.LineString>;
+    lineString(coordinates: Array<Array<number>>, properties?: any): GeoJSON.Feature<GeoJSON.LineString>;
 
     /**
      * Creates a {@link Feature<MultiLineString>} based on a coordinate array. Properties can be added optionally.
@@ -443,7 +446,7 @@ declare module turf {
      * //=multiLine
      *
      */
-    function multiLineString(coordinates: Array<Array<Array<number>>>, properties?: any): GeoJSON.Feature<GeoJSON.MultiLineString>;
+    multiLineString(coordinates: Array<Array<Array<number>>>, properties?: any): GeoJSON.Feature<GeoJSON.MultiLineString>;
 
     /**
      * Takes coordinates and properties (optional) and returns a new {@link Point} feature.
@@ -458,7 +461,7 @@ declare module turf {
      *
      * //=pt1
      */
-    function point(coordinates: Array<number>, properties?: any): GeoJSON.Feature<GeoJSON.Point>;
+    point(coordinates: Array<number>, properties?: any): GeoJSON.Feature<GeoJSON.Point>;
 
     /**
      * Creates a {@link Feature<MultiPoint>} based on a coordinate array. Properties can be added optionally.
@@ -474,7 +477,7 @@ declare module turf {
      * //=multiPt
      *
      */
-    function multiPoint(coordinates: Array<Array<number>>, properties?: any): GeoJSON.Feature<GeoJSON.MultiPoint>;
+    multiPoint(coordinates: Array<Array<number>>, properties?: any): GeoJSON.Feature<GeoJSON.MultiPoint>;
 
     /**
      * Takes an array of LinearRings and optionally an {@link Object} with properties and returns a {@link Polygon} feature.
@@ -497,7 +500,7 @@ declare module turf {
      *
      * //=polygon
      */
-    function polygon(coordinates: Array<Array<Array<number>>>, properties?: any): GeoJSON.Feature<GeoJSON.Polygon>;
+    polygon(coordinates: Array<Array<Array<number>>>, properties?: any): GeoJSON.Feature<GeoJSON.Polygon>;
 
     /**
      * Creates a {@link Feature<MultiPolygon>} based on a coordinate array. Properties can be added optionally.
@@ -513,7 +516,7 @@ declare module turf {
      * //=multiPoly
      *
      */
-    function multiPolygon(coordinates: Array<Array<Array<Array<number>>>>, properties?: any): GeoJSON.Feature<GeoJSON.MultiPolygon>;
+    multiPolygon(coordinates: Array<Array<Array<Array<number>>>>, properties?: any): GeoJSON.Feature<GeoJSON.MultiPolygon>;
 
     /**
      * Creates a {@link Feature<GeometryCollection>} based on acoordinate array. Properties can be added optionally.
@@ -535,7 +538,7 @@ declare module turf {
      *
      * //=collection
      */
-    function geometryCollection(geometries: Array<GeoJSON.GeometryObject>, properties?: any): GeoJSON.GeometryCollection;
+    geometryCollection(geometries: Array<GeoJSON.GeometryObject>, properties?: any): GeoJSON.GeometryCollection;
 
     //////////////////////////////////////////////////////
     // Data
@@ -570,7 +573,7 @@ declare module turf {
      *
      * //=polygons
      */
-    function random(
+    random(
       type?: 'points' | 'polygons',
       count?: number,
       options?: {
@@ -595,7 +598,7 @@ declare module turf {
      *
      * //=sample
      */
-    function sample(featurecollection: GeoJSON.FeatureCollection<any>, num: number): GeoJSON.FeatureCollection<any>;
+    sample(featurecollection: GeoJSON.FeatureCollection<any>, num: number): GeoJSON.FeatureCollection<any>;
 
     //////////////////////////////////////////////////////
     // GRIDS
@@ -619,7 +622,7 @@ declare module turf {
      *
      * //=hexgrid
      */
-    function hexGrid(
+    hexGrid(
       bbox: Array<number>,
       cellSize: number,
       units?: string | 'miles' | 'nauticalmiles' | 'degrees' | 'radians' | 'inches' | 'yards' | 'meters' | 'metres' | 'kilometers' | 'kilometres',
@@ -643,7 +646,7 @@ declare module turf {
      *
      * //=grid
      */
-    function pointGrid(
+    pointGrid(
       bbox: Array<number>,
       cellSize: number,
       units?: string | 'miles' | 'nauticalmiles' | 'degrees' | 'radians' | 'inches' | 'yards' | 'meters' | 'metres' | 'kilometers' | 'kilometres' 
@@ -666,7 +669,7 @@ declare module turf {
      *
      * //=squareGrid
      */
-    function squareGrid(
+    squareGrid(
       bbox: Array<number>,
       cellSize: number,
       units?: string | 'miles' | 'nauticalmiles' | 'degrees' | 'radians' | 'inches' | 'yards' | 'meters' | 'metres' | 'kilometers' | 'kilometres'
@@ -689,7 +692,7 @@ declare module turf {
      *
      * //=triangleGrid
      */
-    function triangleGrid(
+    triangleGrid(
       bbox: Array<number>,
       cellSize: number,
       units?: string | 'miles' | 'nauticalmiles' | 'degrees' | 'radians' | 'inches' | 'yards' | 'meters' | 'metres' | 'kilometers' | 'kilometres'
@@ -707,7 +710,7 @@ declare module turf {
     * @param breaks Where to draw contours
     * @returns Isolines
     */
-    function isolines(points: GeoJSON.FeatureCollection<GeoJSON.Point>, z: string, resolution: number, breaks: Array<number>): GeoJSON.FeatureCollection<GeoJSON.LineString>;
+    isolines(points: GeoJSON.FeatureCollection<GeoJSON.Point>, z: string, resolution: number, breaks: Array<number>): GeoJSON.FeatureCollection<GeoJSON.LineString>;
 
     /**
     * Takes a triangular plane as a Polygon and a Point within that triangle and returns the z-value at that point.
@@ -716,7 +719,7 @@ declare module turf {
     * @param triangle A Polygon feature with three vertices
     * @returns The z-value for interpolatedPoint
     */
-    function planepoint(interpolatedpoint: GeoJSON.Feature<GeoJSON.Point>, triangle: GeoJSON.Feature<GeoJSON.Polygon>): number;
+    planepoint(interpolatedpoint: GeoJSON.Feature<GeoJSON.Point>, triangle: GeoJSON.Feature<GeoJSON.Polygon>): number;
 
     /**
     * Takes a set of points and the name of a z-value property and creates a Triangulated Irregular Network, or a TIN for short, returned as a collection of Polygons.
@@ -726,7 +729,7 @@ declare module turf {
     * @param [propertyName] Name of the property from which to pull z values This is optional: if not given, then there will be no extra data added to the derived triangles.
     * @returns TIN output
     */
-    function tin(points: GeoJSON.FeatureCollection<GeoJSON.Point>, propertyName?: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+    tin(points: GeoJSON.FeatureCollection<GeoJSON.Point>, propertyName?: string): GeoJSON.FeatureCollection<GeoJSON.Polygon>;
 
     //////////////////////////////////////////////////////
     // Joins
@@ -739,7 +742,7 @@ declare module turf {
     * @param polygon Input polygon or multipolygon
     * @returns true if the Point is inside the Polygon false if the Point is not inside the Polygon
     */
-    function inside(point: GeoJSON.Feature<GeoJSON.Point>, polygon: GeoJSON.Feature<GeoJSON.Polygon>): boolean;
+    inside(point: GeoJSON.Feature<GeoJSON.Point>, polygon: GeoJSON.Feature<GeoJSON.Polygon>): boolean;
 
     /**
     * Takes a set of points and a set of polygons and performs a spatial join.
@@ -749,7 +752,7 @@ declare module turf {
     * @param containingPolyId Property in points in which to store joined property from polygons
     * @returns Points with containingPolyId property containing values from polyId
     */
-    function tag(points: GeoJSON.FeatureCollection<GeoJSON.Point>, polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, polyId: string, containingPolyId: string): GeoJSON.FeatureCollection<GeoJSON.Point>;
+    tag(points: GeoJSON.FeatureCollection<GeoJSON.Point>, polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>, polyId: string, containingPolyId: string): GeoJSON.FeatureCollection<GeoJSON.Point>;
 
     /**
     * Takes a set of points and a set of polygons and returns the points that fall within the polygons.
@@ -757,7 +760,7 @@ declare module turf {
     * @param polygons Input polygons
     * @returns Points that land within at least one polygon
     */
-    function within(points: GeoJSON.FeatureCollection<GeoJSON.Point>, polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>): GeoJSON.FeatureCollection<GeoJSON.Point>;
+    within(points: GeoJSON.FeatureCollection<GeoJSON.Point>, polygons: GeoJSON.FeatureCollection<GeoJSON.Polygon>): GeoJSON.FeatureCollection<GeoJSON.Point>;
 
     //////////////////////////////////////////////////////
     // Classification
@@ -769,18 +772,19 @@ declare module turf {
     * @param against Input point set
     * @returns The closest point in the set to the reference point
     */
-    function nearest(
+    nearest(
       point: GeoJSON.Feature<GeoJSON.Point>,
       against: GeoJSON.FeatureCollection<GeoJSON.Point>
     ): GeoJSON.Feature<GeoJSON.Point>;
+  }
 }
 
 // Stable version of Turf
-declare module 'turf' {
+declare module "turf" {
   export = turf
 }
 
 // Latest version of Turf
-declare module '@turf/turf' {
+declare module "@turf/turf" {
   export = turf
 }


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Kept old definition for Turf 2.0 backwards compatibility.

Update all methods with newest JSDocs & tests based on the latest TurfJS library.

**AGGREGATION**
- [x] collect

**MEASUREMENT**
- [ ] along
- [ ] area
- [ ] bboxPolygon
- [ ] bearing
- [ ] center
- [ ] centroid
- [ ] destination
- [ ] distance
- [ ] envelope
- [ ] lineDistance
- [ ] midpoint
- [ ] pointOnSurface
- [ ] square

**TRANSFORMATION**
- [ ] bezier
- [ ] buffer
- [ ] concave
- [ ] convex
- [ ] difference
- [ ] intersect
- [ ] simplify
- [ ] union

**MISC**
- [ ] combine
- [ ] explode
- [ ] flip
- [ ] kinks
- [ ] lineSlice
- [ ] pointOnLine

**HELPER**
- [x] featureCollection
- [x] feature
- [x] lineString
- [x] multiLineString
- [x] point
- [x] multiPoint
- [x] polygon
- [x] multiPolygon
- [x] geometryCollection

**DATA**
- [x] random
- [x] sample

**INTERPOLATION**
- [ ] isolines
- [ ] planepoint
- [ ] tin

**JOINS**
- [x] inside
- [x] tag

**GRIDS**
- [x] hexGrid
- [x] pointGrid
- [x] squareGrid
- [x] triangleGrid

**CLASSIFICATION**
- [ ] within
- [ ] nearest

**META**
- [ ] propEach
- [ ] coordEach
- [ ] coordReduce
- [ ] featureEach
- [ ] getCoord

**ASSERTIONS**
- [ ] featureOf
- [ ] collectionOf
- [ ] bbox
- [ ] circle
- [ ] geojsonType
- [ ] propReduce
- [ ] coordAll
- [ ] tesselate
