### PR TITLE
Add humps definitions

### DIFF
--- a/humps/humps-tests.ts
+++ b/humps/humps-tests.ts
@@ -1,0 +1,71 @@
+/// <reference path="humps.d.ts" />
+
+// Tests evaluated from:
+// https://github.com/domchristie/humps/blob/master/README.md
+
+import * as humps from "humps";
+
+let someObject = { attr_one: 'foo', attr_two: 'bar' };
+let someArray = [{ attr_one: 'foo' }, { attr_one: 'bar' }]
+
+let someOptions: humps.HumpsOptions = {
+	separator: '-'
+};
+let someOptions2: humps.HumpsOptions = {
+	split: /^[A-Z0-9_]+$/
+};
+let someOptions3: humps.HumpsOptions = {
+	separator: '-',
+	process: function (key: string, convert: humps.HumpsProcessorParameter, options: humps.HumpsOptions) {
+		return /^[A-Z0-9_]+$/.test(key) ? key : convert(key, options);
+	}
+};
+
+
+humps.camelize('hello_world')
+
+humps.decamelize('fooBar')
+humps.decamelize('fooBarBaz', someOptions)
+
+humps.camelizeKeys(someObject);
+
+humps.camelizeKeys(someArray);
+
+humps.camelizeKeys(someObject, function (key, convert) {
+  return /^[A-Z0-9_]+$/.test(key) ? key : convert(key);
+});
+
+humps.decamelizeKeys(someObject, function (key, convert, options) {
+  return /^[A-Z0-9_]+$/.test(key) ? key : convert(key, options);
+});
+
+
+humps.camelize('hello_world-foo bar');
+
+humps.pascalize('hello_world-foo bar');
+
+humps.decamelize('helloWorldFooBar');
+humps.decamelize('helloWorldFooBar', someOptions);
+humps.decamelize('helloWorld1', { split: /(?=[A-Z0-9])/ })
+
+humps.depascalize('helloWorldFooBar');
+
+humps.camelizeKeys(someObject);
+humps.pascalizeKeys(someObject);
+humps.decamelizeKeys(someObject);
+humps.depascalizeKeys(someObject);
+
+humps.camelizeKeys(someObject, someOptions);
+humps.pascalizeKeys(someObject, someOptions);
+humps.decamelizeKeys(someObject, someOptions);
+humps.depascalizeKeys(someObject, someOptions);
+
+humps.camelizeKeys(someObject, someOptions2);
+humps.pascalizeKeys(someObject, someOptions2);
+humps.decamelizeKeys(someObject, someOptions2);
+humps.depascalizeKeys(someObject, someOptions2);
+
+humps.camelizeKeys(someObject, someOptions3);
+humps.pascalizeKeys(someObject, someOptions3);
+humps.decamelizeKeys(someObject, someOptions3);
+humps.depascalizeKeys(someObject, someOptions3);

--- a/humps/humps.d.ts
+++ b/humps/humps.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for humps v1.1.0
+// Project: https://github.com/domchristie/humps
+// Definitions by: Niklas Mollenhauer <https://github.com/nikeee>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace humps {
+
+	function camelize(value: string): string;
+	function pascalize(value: string): string;
+	function decamelize(value: string, optionsOrProcessor?: OptionOrProcessor): string;
+	function depascalize(value: string, optionsOrProcessor?: OptionOrProcessor): string;
+
+	function camelizeKeys(str: Object, optionsOrProcessor?: OptionOrProcessor): Object;
+	function pascalizeKeys(str: Object, optionsOrProcessor?: OptionOrProcessor): Object;
+	function decamelizeKeys(str: Object, optionsOrProcessor?: OptionOrProcessor): Object;
+	function depascalizeKeys(str: Object, optionsOrProcessor?: OptionOrProcessor): Object;
+
+	function camelizeKeys(str: Object[], optionsOrProcessor?: OptionOrProcessor): Object[];
+	function pascalizeKeys(str: Object[], optionsOrProcessor?: OptionOrProcessor): Object[];
+	function decamelizeKeys(str: Object[], optionsOrProcessor?: OptionOrProcessor): Object[];
+	function depascalizeKeys(str: Object[], optionsOrProcessor?: OptionOrProcessor): Object[];
+
+	interface HumpsOptions {
+		separator?: string;
+		split?: RegExp;
+		process?: HumpsProcessor;
+	}
+	interface HumpsProcessor {
+		(key: string, convert: HumpsProcessorParameter, options?: HumpsOptions): string;
+	}
+	interface HumpsProcessorParameter {
+		(key: string, options?: HumpsOptions): string;
+	}
+	type OptionOrProcessor = HumpsOptions | HumpsProcessor;
+}
+
+declare module "humps" {
+	export = humps;
+}


### PR DESCRIPTION
This PR adds definitions for humps.
Project page/docs: https://github.com/domchristie/humps
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts`.
