### PR TITLE
fixing a typo in cache-manager/cache-manager.d.ts

### DIFF
--- a/cache-manager/cache-manager.d.ts
+++ b/cache-manager/cache-manager.d.ts
@@ -28,7 +28,7 @@ declare module 'cache-manager' {
 
 
     module cacheManager {
-        function caching(ICongig: StoreConfig): Cache;
+        function caching(IConfig: StoreConfig): Cache;
         function multiCaching(Caches: Cache[]): Cache;
     }
 


### PR DESCRIPTION
Just a minor typo fix that was driving me crazy whenever I was using auto complete.
