### PR TITLE
Added toast class property to toast options/config object per commit …

### DIFF
--- a/angular-material/angular-material-tests.ts
+++ b/angular-material/angular-material-tests.ts
@@ -127,6 +127,8 @@ myApp.controller('SidenavController', ($scope: ng.IScope, $mdSidenav: ng.materia
         instance.isOpen();
         instance.isLockedOpen();
     });
+
+    $scope['onClose'] = $mdSidenav(componentId).onClose(() => {});
 });
 
 myApp.controller('ToastController', ($scope: ng.IScope, $mdToast: ng.material.IToastService) => {

--- a/angular-material/angular-material-tests.ts
+++ b/angular-material/angular-material-tests.ts
@@ -131,11 +131,24 @@ myApp.controller('SidenavController', ($scope: ng.IScope, $mdSidenav: ng.materia
 
 myApp.controller('ToastController', ($scope: ng.IScope, $mdToast: ng.material.IToastService) => {
     $scope['openToast'] = () => $mdToast.show($mdToast.simple().textContent('Hello!'));
+
+    $scope['customToast'] = () => {
+        var options = {
+            hideDelay: 3000,
+            position: 'top right',
+            controller  : 'ToastCtrl',
+            templateUrl : 'toast-template.html',
+            toastClass: 'my-class'
+        };
+
+        $mdToast.show(options);
+    }
 });
 
 myApp.controller('PanelController', ($scope: ng.IScope, $mdPanel: ng.material.IPanelService) => {
     $scope['createPanel'] = () => {
         var config = {
+            id: 'myPanel',
             template: '<h1>Hello!</h1>',
             hasBackdrop: true,
             disableParentScroll: true,

--- a/angular-material/angular-material.d.ts
+++ b/angular-material/angular-material.d.ts
@@ -132,6 +132,7 @@ declare namespace angular.material {
         close(): angular.IPromise<void>;
         isOpen(): boolean;
         isLockedOpen(): boolean;
+        onClose(onClose: Function): void;
     }
 
     interface ISidenavService {

--- a/angular-material/angular-material.d.ts
+++ b/angular-material/angular-material.d.ts
@@ -162,6 +162,7 @@ declare namespace angular.material {
         preserveScope?: boolean; // default: false
         hideDelay?: number; // default (ms): 3000
         position?: string; // any combination of 'bottom'/'left'/'top'/'right'/'fit'; default: 'bottom left'
+        toastClass?: string;
         controller?: string|Function;
         locals?: {[index: string]: any};
         bindToController?: boolean; // default: false
@@ -291,6 +292,7 @@ declare namespace angular.material {
     }
 
     interface IPanelConfig {
+        id?: string;
         template?: string;
         templateUrl?: string;
         controller?: string|Function;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- Added toastClass property to toast config/options per commit [f72c7816](https://github.com/angular/material/commit/f72c7816)
- Added id property to panel config per commit [d230aec](https://github.com/angular/material/commit/d230aec)
- Added onClose() callback to sidenav object per commit [1f01d264](https://github.com/angular/material/commit/1f01d264)
