### PR TITLE
Updated ServerRequest to IncomingMessage

### DIFF
--- a/ws/ws.d.ts
+++ b/ws/ws.d.ts
@@ -21,7 +21,7 @@ declare module "ws" {
         protocolVersion: string;
         url: string;
         supports: any;
-        upgradeReq: http.ServerRequest;
+        upgradeReq: http.IncomingMessage;
         protocol: string;
 
         CONNECTING: number;
@@ -76,8 +76,8 @@ declare module "ws" {
 
     namespace WebSocket {
                 
-        type VerifyClientCallbackSync = (info: {origin: string; secure: boolean; req: http.ServerRequest}) => boolean;
-        type VerifyClientCallbackAsync = (info: {origin: string; secure: boolean; req: http.ServerRequest}
+        type VerifyClientCallbackSync = (info: {origin: string; secure: boolean; req: http.IncomingMessage}) => boolean;
+        type VerifyClientCallbackAsync = (info: {origin: string; secure: boolean; req: http.IncomingMessage}
                                             , callback: (res: boolean) => void) => void;
         
         export interface IClientOptions {
@@ -116,7 +116,7 @@ declare module "ws" {
             constructor(options?: IServerOptions, callback?: Function);
 
             close(cb?: () => {}): void;
-            handleUpgrade(request: http.ServerRequest, socket: net.Socket,
+            handleUpgrade(request: http.IncomingMessage, socket: net.Socket,
                           upgradeHead: Buffer, callback: (client: WebSocket) => void): void;
 
             // Events


### PR DESCRIPTION
```
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
```

ServerRequest has been deprecated in favor of IncomingMessage for a while [1][2] and it's finally starting to cause trouble in some places [2]. (Still passes tests)
[1] https://nodejs.org/docs/v0.10.35/api/http.html#http_class_http_serverresponse
[2] https://nodejs.org/dist/latest-v4.x/docs/api/http.html#http_class_http_incomingmessage
[3] https://github.com/types/env-node/pull/35
