### PR TITLE
Fix Openlayers StyleFunction returned type

### DIFF
--- a/openlayers/index.d.ts
+++ b/openlayers/index.d.ts
@@ -4495,7 +4495,7 @@ declare namespace ol {
         /**
          * A function that takes an ol.Feature and a {number} representing the view's resolution. The function should return an array of ol.style.Style. This way e.g. a vector layer can be styled.
          */
-        interface StyleFunction { (feature: ol.Feature, resolution: number): ol.style.Style }
+        interface StyleFunction { (feature: ol.Feature, resolution: number): ol.style.Style | ol.style.Style[] }
     }
 
     namespace tilegrid {

--- a/openlayers/openlayers-3.14.2-tests.ts
+++ b/openlayers/openlayers-3.14.2-tests.ts
@@ -685,6 +685,16 @@ draw = new ol.interaction.Draw({
     type: "Point",
     style: styleFunction
 });
+var styleFunctionAsStyle = function(feature: ol.Feature, resolution: number): ol.style.Style { return style; }
+draw = new ol.interaction.Draw({
+    type: "Point",
+    style: styleFunctionAsStyle
+});
+var styleFunctionAsArray = function(feature: ol.Feature, resolution: number): ol.style.Style[] { return styleArray; }
+draw = new ol.interaction.Draw({
+    type: "Point",
+    style: styleFunctionAsArray
+});
 
 var dragbox: ol.interaction.DragBox = new ol.interaction.DragBox({
     className: stringValue,

--- a/openlayers/openlayers-3.14.2.d.ts
+++ b/openlayers/openlayers-3.14.2.d.ts
@@ -4651,7 +4651,7 @@ declare namespace ol {
         /**
          * A function that takes an ol.Feature and a {number} representing the view's resolution. The function should return an array of ol.style.Style. This way e.g. a vector layer can be styled.
          */
-        interface StyleFunction { (feature: ol.Feature, resolution: number): ol.style.Style }
+        interface StyleFunction { (feature: ol.Feature, resolution: number): ol.style.Style | ol.style.Style[] }
     }
 
     namespace tilegrid {


### PR DESCRIPTION
According to documentation for [3.6.0](http://openlayers.org/en/v3.6.0/apidoc/ol.style.html#StyleFunction) and [latest version](http://openlayers.org/en/master/apidoc/ol.html#.StyleFunction), `StyleFunction` returns a `Style` or an array of `Style`.

In 3.6.0, the documentation says the `StyleFunction` should returns an array but for compatibility reason, I made it to return both.
