### PR TITLE
angular.d.ts: add isObject<T>

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -125,6 +125,7 @@ declare namespace angular {
         isFunction(value: any): value is Function;
         isNumber(value: any): value is number;
         isObject(value: any): value is Object;
+        isObject<T>(value: any): value is T;
         isString(value: any): value is string;
         isUndefined(value: any): boolean;
         lowercase(str: string): string;


### PR DESCRIPTION
This allows user-defined type guards for specific objects.

Example code illustrating the issue:

```
interface MyInterface {
  property: number;
}

function logProperty(value: MyInterface) {
  if(angular.isObject(value) {
    console.log(value.property);
  }
}
```

Without generics value is cast to `Object` and type check fails.
