### PR TITLE
Updated pasteHTML(...) interface definitions and bumped version to v1.0.3

### DIFF
--- a/quill/quill-tests.ts
+++ b/quill/quill-tests.ts
@@ -172,3 +172,15 @@ function test_on_EventType1(){
     });
 
 }
+
+function test_PasteHTML()
+{
+    var quillEditor = new Quill('#editor');
+    quillEditor.pasteHTML('<h1>Quill Rocks</h1>');
+}
+
+function test_PasteHTML2()
+{
+    var quillEditor = new Quill('#editor');
+    quillEditor.pasteHTML(5, '<h1>Quill Rocks</h1>');
+}

--- a/quill/quill.d.ts
+++ b/quill/quill.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Quill v1.0.0
+// Type definitions for Quill v1.0.3
 // Project: http://quilljs.com
 // Definitions by: Sumit <https://github.com/sumitkm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -49,7 +49,8 @@ declare namespace QuillJS {
         insertText(index: number, text: string, source?: sourceType): void;
         insertText(index: number, text: string, format: string, value: string, source?: sourceType): void;
         insertText(index: number, text: string, formats: formatsType, source?: sourceType): void;
-        pasteHTML(): string;
+        pasteHTML(index: number, html: string, source?:sourceType): string;
+        pasteHTML(html:string, source?: sourceType): string;
         setContents(delta: DeltaStatic, source?: sourceType): void;
         setText(text: string, source?: sourceType): void;
         update(source?: string): void;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://quilljs.com/docs/api/.

The `pasteHTML` interface definition was incorrect when compare to the API docs for Quill. This PR fixes the issue https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11152
- it has been reviewed by a DefinitelyTyped member - NO
