### PR TITLE
Add colors strip and stripColors methods

### DIFF
--- a/colors/colors-tests.ts
+++ b/colors/colors-tests.ts
@@ -8,9 +8,11 @@ colors.enabled = true;
 console.log(colors.black.underline('test'));
 console.log(colors.rainbow.black.blue.gray('test'));
 console.log(colors.random.reset.bgWhite.dim('test'));
+console.log(colors.random.reset.bgWhite.strip('test'));
 console.log('test'.black.underline);
 console.log('test'.rainbow.black.blue.gray);
 console.log('test'.random.reset.bgWhite.dim);
+console.log('test'.random.reset.bgWhite.dim.stripColors);
 
 colors.enabled = false;
 

--- a/colors/colors.d.ts
+++ b/colors/colors.d.ts
@@ -7,6 +7,9 @@ declare module "colors" {
     interface Color {
         (text: string): string;
 
+        strip: Color;
+        stripColors: Color;
+
         black: Color;
         red: Color;
         green: Color;
@@ -49,6 +52,9 @@ declare module "colors" {
 
         export var enabled: boolean;
 
+        export var strip: Color;
+        export var stripColors: Color;
+
         export var black: Color;
         export var red: Color;
         export var green: Color;
@@ -90,6 +96,9 @@ declare module "colors" {
 }
 
 interface String {
+    strip: string;
+    stripColors: string;
+
     black: string;
     red: string;
     green: string;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

This PR add `strip` and `stripColors` methods on colors that remove all previously applied colors.
Methods are declared [here](https://github.com/Marak/colors.js/blob/master/lib/colors.js#L45) and String prototype is extended [here](https://github.com/Marak/colors.js/blob/master/lib/extendStringPrototype.js#L20) with [this method](https://github.com/Marak/colors.js/blob/master/lib/extendStringPrototype.js#L8).
