### PR TITLE
support `$injector.get('$resource')`

### DIFF
--- a/angularjs/angular-resource.d.ts
+++ b/angularjs/angular-resource.d.ts
@@ -186,6 +186,12 @@ declare namespace angular {
         /** creating a resource service factory */
         factory(name: string, resourceServiceFactoryFunction: angular.resource.IResourceServiceFactoryFunction<any>): IModule;
     }
+    
+    namespace auto {
+    	interface IInjectorService {
+    		get(name: '$resource'): ng.resource.IResourceService;
+    	}
+    }
 }
 
 interface Array<T>


### PR DESCRIPTION
This provides support for `$injector.get('$resource')`, in the same way [`angular.d.ts`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/angularjs/angular.d.ts#L1882) does for its services.
