### PR TITLE
[WIP] Add type definitions for Leaflet 1.0

### DIFF
--- a/heatmap.js/heatmap.d.ts
+++ b/heatmap.js/heatmap.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Yang Guan <https://github.com/lookuptable>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../leaflet/leaflet.d.ts" />
+/// <reference path="../leaflet/leaflet-0.7.d.ts" />
 
 /*
  * Configuration object of a heatmap

--- a/leaflet-curve/leaflet-curve-tests.ts
+++ b/leaflet-curve/leaflet-curve-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path="../leaflet/leaflet.d.ts" />
+/// <reference path="../leaflet/leaflet-0.7.d.ts" />
 /// <reference path="leaflet-curve.d.ts" />
 
 

--- a/leaflet-curve/leaflet-curve.d.ts
+++ b/leaflet-curve/leaflet-curve.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Onikiienko <https://github.com/onikiienko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../leaflet/leaflet.d.ts" />
+/// <reference path="../leaflet/leaflet-0.7.d.ts" />
 
 declare namespace L {
 	/**

--- a/leaflet-draw/leaflet-draw-tests.ts
+++ b/leaflet-draw/leaflet-draw-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path="../leaflet/leaflet.d.ts" />
+/// <reference path="../leaflet/leaflet-0.7.d.ts" />
 /// <reference path="leaflet-draw.d.ts" />
 
 

--- a/leaflet-draw/leaflet-draw.d.ts
+++ b/leaflet-draw/leaflet-draw.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Matt Guest <https://github.com/matt-guest>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../leaflet/leaflet.d.ts" />
+/// <reference path="../leaflet/leaflet-0.7.d.ts" />
 
 declare namespace L {
 	export interface MapOptions {

--- a/leaflet-editable/leaflet-editable.d.ts
+++ b/leaflet-editable/leaflet-editable.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Dominic Alie <https://github.com/dalie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../leaflet/leaflet.d.ts" />
+/// <reference path="../leaflet/leaflet-0.7.d.ts" />
 
 declare namespace L {
     /**

--- a/leaflet-geocoder-mapzen/leaflet-geocoder-mapzen-tests.ts
+++ b/leaflet-geocoder-mapzen/leaflet-geocoder-mapzen-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path="../leaflet/leaflet.d.ts" />
+/// <reference path="../leaflet/leaflet-0.7.d.ts" />
 /// <reference path="leaflet-geocoder-mapzen.d.ts" />
 
 var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',

--- a/leaflet-geocoder-mapzen/leaflet-geocoder-mapzen.d.ts
+++ b/leaflet-geocoder-mapzen/leaflet-geocoder-mapzen.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 
-/// <reference path="../leaflet/leaflet.d.ts" />
+/// <reference path="../leaflet/leaflet-0.7.d.ts" />
 
 declare namespace L {
     namespace Control {

--- a/leaflet-label/leaflet-label.d.ts
+++ b/leaflet-label/leaflet-label.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Wim Looman <https://github.com/Nemo157>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../leaflet/leaflet.d.ts" />
+/// <reference path="../leaflet/leaflet-0.7.d.ts" />
 
 declare namespace L {
     export interface IconOptions {

--- a/leaflet-markercluster/leaflet-markercluster.d.ts
+++ b/leaflet-markercluster/leaflet-markercluster.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Robert Imig <https://github.com/rimig>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../leaflet/leaflet.d.ts" />
+/// <reference path="../leaflet/leaflet-0.7.d.ts" />
 
 declare namespace L {
     export interface MarkerClusterGroupOptions {
@@ -51,7 +51,7 @@ declare namespace L {
 
       /*
       * The maximum radius that a cluster will cover from the central marker (in pixels). Default 80.
-      * Decreasing will make more, smaller clusters. You can also use a function that accepts 
+      * Decreasing will make more, smaller clusters. You can also use a function that accepts
       * the current map zoom and returns the maximum cluster radius in pixels
       */
       maxClusterRadius?: number | ((zoom: number) => number);
@@ -134,9 +134,9 @@ declare namespace L {
       getAllChildMarkers(): Marker[];
 
       /*
-      * Zooms to show the given marker (spiderfying if required), 
+      * Zooms to show the given marker (spiderfying if required),
       * calls the callback when the marker is visible on the map.
-      */	  
+      */
       zoomToShowLayer(layer: any, callback: () => void): void;
     }
 }

--- a/leaflet.awesome-markers/leaflet.awesome-markers.d.ts
+++ b/leaflet.awesome-markers/leaflet.awesome-markers.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Egor Komarov <https://github.com/Odrin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../leaflet/leaflet.d.ts" />
+/// <reference path="../leaflet/leaflet-0.7.d.ts" />
 
 declare module L {
     module AwesomeMarkers {

--- a/leaflet.fullscreen/leaflet.fullscreen.d.ts
+++ b/leaflet.fullscreen/leaflet.fullscreen.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: William Comartin <https://github.com/wcomartin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../leaflet/leaflet.d.ts" />
+/// <reference path="../leaflet/leaflet-0.7.d.ts" />
 
 declare namespace L {
 

--- a/leaflet/leaflet-0.7-tests.ts
+++ b/leaflet/leaflet-0.7-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path="leaflet.d.ts" />
+/// <reference path="leaflet-0.7.d.ts" />
 
 // initialize the map on the "map" div with a given center and zoom
 

--- a/leaflet/leaflet-0.7.d.ts
+++ b/leaflet/leaflet-0.7.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Leaflet.js 1.0.0
+// Type definitions for Leaflet.js 0.7.x
 // Project: https://github.com/Leaflet/Leaflet
 // Definitions by: Vladimir Zotov <https://github.com/rgripper>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/leaflet/leaflet-tests.ts
+++ b/leaflet/leaflet-tests.ts
@@ -17,10 +17,8 @@ const latLngBoundsLiteral: L.LatLngBoundsLiteral = [[12, 13], latLngTuple];
 
 let latLngBounds: L.LatLngBounds;
 latLngBounds = L.latLngBounds(latLng, latLng);
-latLngBounds = L.latLngBounds(latLng, latLngLiteral);
-latLngBounds = L.latLngBounds(latLngLiteral, latLng);
 latLngBounds = L.latLngBounds(latLngLiteral, latLngLiteral);
-// TODO
+latLngBounds = L.latLngBounds(latLngTuple, latLngTuple);
 
 const pointTuple: L.PointTuple = [0, 0];
 

--- a/leaflet/leaflet-tests.ts
+++ b/leaflet/leaflet-tests.ts
@@ -5,11 +5,38 @@ import L = require('leaflet');
 const latLngLiteral: L.LatLngLiteral = {lat: 12, lng: 13};
 const latLngTuple: L.LatLngTuple = [12, 13];
 
+let latLng: L.LatLng;
+latLng = L.latLng(12, 13);
+latLng = L.latLng(12, 13, 0);
+latLng = L.latLng(latLngLiteral);
+latLng = L.latLng({lat: 12, lng: 13, alt: 0});
+latLng = L.latLng(latLngTuple);
+latLng = L.latLng([12, 13, 0]);
+
 const latLngBoundsLiteral: L.LatLngBoundsLiteral = [[12, 13], latLngTuple];
+
+let latLngBounds: L.LatLngBounds;
+latLngBounds = L.latLngBounds(latLng, latLng);
+latLngBounds = L.latLngBounds(latLng, latLngLiteral);
+latLngBounds = L.latLngBounds(latLngLiteral, latLng);
+latLngBounds = L.latLngBounds(latLngLiteral, latLngLiteral);
+// TODO
 
 const pointTuple: L.PointTuple = [0, 0];
 
+let point: L.Point;
+point = L.point(12, 13);
+point = L.point(12, 13, true);
+point = L.point(pointTuple);
+point = L.point({x: 12, y: 13});
+
 const boundsLiteral: L.BoundsLiteral = [[1, 1], pointTuple];
+
+let bounds: L.Bounds;
+bounds = L.bounds(point, point);
+bounds = L.bounds(pointTuple, pointTuple);
+bounds = L.bounds([point, point]);
+bounds = L.bounds(boundsLiteral);
 
 let mapOptions: L.MapOptions = {};
 mapOptions = {
@@ -49,14 +76,14 @@ mapOptions = {
 mapOptions.doubleClickZoom = true;
 mapOptions.doubleClickZoom = 'center';
 
-// assign actual latlng
+mapOptions.center = latLng;
 mapOptions.center = latLngLiteral;
 mapOptions.center = latLngTuple;
 
 mapOptions.layers = [];
 mapOptions.layers = [L.tileLayer('')]; // add layers of other types
 
-// assign actual latlngbounds
+mapOptions.maxBounds = latLngBounds;
 mapOptions.maxBounds = [];
 mapOptions.maxBounds = latLngBoundsLiteral;
 
@@ -101,13 +128,10 @@ doesItHaveLayer = map.hasLayer(L.tileLayer(''));
 // map.getRenderer
 
 let html: HTMLElement;
-
 html = map.createPane('foo');
 html = map.createPane('foo', htmlElement)
-
 html = map.getPane('foo');
 html = map.getPane(htmlElement);
-
 html = map.getContainer();
 
 const panes = map.getPanes();
@@ -127,7 +151,8 @@ let zoom: number;
 zoom = map.getZoom();
 zoom = map.getMinZoom();
 zoom = map.getMaxZoom();
-// map.getBoundsZoom with actual latlngbounds
+zoom = map.getBoundsZoom(latLngBounds);
+zoom = map.getBoundsZoom(latLngBounds, true);
 zoom = map.getBoundsZoom(latLngBoundsLiteral);
 zoom = map.getBoundsZoom(latLngBoundsLiteral, true);
 
@@ -155,11 +180,14 @@ map = map
 		layer = currentLayer;
 	}, {})
 	.openPopup(L.popup())
-	// openPopup with actual latlng
+	.openPopup('Hello World', latLng)
+	.openPopup('Hello World', latLng, popupOptions)
 	.openPopup('Hello World', latLngLiteral)
 	.openPopup('Hello World', latLngLiteral, popupOptions)
 	.openPopup('Hello World', latLngTuple)
 	.openPopup('Hello World', latLngTuple, popupOptions)
+	.openPopup(htmlElement, latLng)
+	.openPopup(htmlElement, latLng, popupOptions)
 	.openPopup(htmlElement, latLngLiteral)
 	.openPopup(htmlElement, latLngLiteral, popupOptions)
 	.openPopup(htmlElement, latLngTuple)
@@ -167,14 +195,22 @@ map = map
 	.closePopup()
 	.closePopup(L.popup())
 	.openTooltip(L.tooltip())
-	// openTooltip with actual latlng
+	.openTooltip('Hello Word', latLng)
+	.openTooltip('Hello World', latLng, tooltipOptions)
 	.openTooltip('Hello World', latLngLiteral)
-	.openTooltip('Hellow World', latLngLiteral, tooltipOptions)
+	.openTooltip('Hello World', latLngLiteral, tooltipOptions)
 	.openTooltip('Hello World', latLngTuple)
 	.openTooltip('Hello World', latLngTuple, tooltipOptions)
+	.openTooltip(htmlElement, latLng)
+	.openTooltip(htmlElement, latLng, tooltipOptions)
+	.openTooltip(htmlElement, latLngLiteral)
+	.openTooltip(htmlElement, latLngLiteral, tooltipOptions)
+	.openTooltip(htmlElement, latLngTuple)
+	.openTooltip(htmlElement, latLngTuple, tooltipOptions)
 	.closeTooltip()
 	.closeTooltip(L.tooltip())
-	// setView with actual latlng
+	.setView(latLng, 12)
+	.setView(latLng, 12, zoomPanOptions)
 	.setView(latLngLiteral, 12)
 	.setView(latLngLiteral, 12, zoomPanOptions)
 	.setView(latLngTuple, 12)
@@ -186,40 +222,45 @@ map = map
 	.zoomOut()
 	.zoomOut(1)
 	.zoomOut(1, zoomOptions)
-	// setZoomAround with actual latlng
-	.setZoomAround(latLngLiteral, 12, zoomOptions) // investigate if zoom options are really required
+	.setZoomAround(latLng, 12, zoomOptions) // investigate if zoom options are really required
+	.setZoomAround(latLngLiteral, 12, zoomOptions)
 	.setZoomAround(latLngTuple, 12, zoomOptions)
-	// setZoomAround with actual point
+	.setZoomAround(point, 12, zoomOptions)
 	.setZoomAround(pointTuple, 11, zoomOptions)
-	// fitBounds with actual latlngbounds
-	.fitBounds(latLngBoundsLiteral, fitBoundsOptions) // investigate if fit bounds options are really required
+	.fitBounds(latLngBounds, fitBoundsOptions) // investigate if fit bounds options are really required
+	.fitBounds(latLngBoundsLiteral, fitBoundsOptions)
 	.fitWorld()
 	.fitWorld(fitBoundsOptions)
-	// panTo with actual latlng
+	.panTo(latLng)
+	.panTo(latLng, panOptions)
 	.panTo(latLngLiteral)
 	.panTo(latLngLiteral, panOptions)
 	.panTo(latLngTuple)
 	.panTo(latLngTuple, panOptions)
-	// panBy with actual point
+	.panBy(point)
 	.panBy(pointTuple)
-	// setMaxBounds with actual bounds
-	.setMaxBounds(boundsLiteral) // investigate if this really receives Bounds instead of LatLngBounds
+	.setMaxBounds(bounds) // investigate if this really receives Bounds instead of LatLngBounds
+	.setMaxBounds(boundsLiteral)
 	.setMinZoom(5)
 	.setMaxZoom(10)
-	// panInsideBounds with actual latlngbounds
+	.panInsideBounds(latLngBounds)
+	.panInsideBounds(latLngBounds, panOptions)
 	.panInsideBounds(latLngBoundsLiteral)
 	.panInsideBounds(latLngBoundsLiteral, panOptions)
 	.invalidateSize(zoomPanOptions)
 	.invalidateSize(false)
 	.stop()
-	// flyTo with actual latlng
+	.flyTo(latLng)
+	.flyTo(latLng, 12)
+	.flyTo(latLng, 12, zoomOptions)
 	.flyTo(latLngLiteral)
 	.flyTo(latLngLiteral, 12)
 	.flyTo(latLngLiteral, 12, zoomPanOptions)
 	.flyTo(latLngTuple)
 	.flyTo(latLngTuple, 12)
 	.flyTo(latLngTuple, 12, zoomPanOptions)
-	// flyToBunds with actual latlngbounds
+	.flyToBounds(latLngBounds)
+	.flyToBounds(latLngBounds, fitBoundsOptions)
 	.flyToBounds(latLngBoundsLiteral)
 	.flyToBounds(latLngBoundsLiteral, fitBoundsOptions)
 	// addHandler

--- a/leaflet/leaflet-tests.ts
+++ b/leaflet/leaflet-tests.ts
@@ -1,0 +1,228 @@
+/// <reference path="leaflet.d.ts" />
+
+import L = require('leaflet');
+
+const latLngLiteral: L.LatLngLiteral = {lat: 12, lng: 13};
+const latLngTuple: L.LatLngTuple = [12, 13];
+
+const latLngBoundsLiteral: L.LatLngBoundsLiteral = [[12, 13], latLngTuple];
+
+const pointTuple: L.PointTuple = [0, 0];
+
+const boundsLiteral: L.BoundsLiteral = [[1, 1], pointTuple];
+
+let mapOptions: L.MapOptions = {};
+mapOptions = {
+	preferCanvas: true,
+	attributionControl: false,
+	zoomControl: true,
+	closePopupOnClick: false,
+	zoomSnap: 1,
+	zoomDelta: 1,
+	trackResize: false,
+	boxZoom: true,
+	dragging: true,
+	// CRS
+	zoom: 12,
+	minZoom: 10,
+	maxZoom: 14,
+	fadeAnimation: true,
+	markerZoomAnimation: false,
+	transform3DLimit: 123,
+	zoomAnimation: false,
+	zoomAnimationThreshold: 4,
+	inertia: false,
+	inertiaDeceleration: 2000,
+	inertiaMaxSpeed: 1000,
+	easeLinearity: 0.5,
+	worldCopyJump: true,
+	maxBoundsViscosity: 1.0,
+	keyboard: false,
+	keyboardPanDelta: 100,
+	wheelDebounceTime: 30,
+	wheelPxPerZoomLevel: 25,
+	tap: false,
+	tapTolerance: 10,
+	bounceAtZoomLimits: false
+};
+
+mapOptions.doubleClickZoom = true;
+mapOptions.doubleClickZoom = 'center';
+
+// assign actual latlng
+mapOptions.center = latLngLiteral;
+mapOptions.center = latLngTuple;
+
+mapOptions.layers = [];
+mapOptions.layers = [L.tileLayer('')]; // add layers of other types
+
+// assign actual latlngbounds
+mapOptions.maxBounds = [];
+mapOptions.maxBounds = latLngBoundsLiteral;
+
+// mapOptions.renderer = ?
+
+mapOptions.scrollWheelZoom = true;
+mapOptions.scrollWheelZoom = 'center';
+
+mapOptions.touchZoom = false;
+mapOptions.touchZoom = 'center';
+
+let layer: L.Layer;
+
+const htmlElement = document.getElementById('foo');
+
+let popupOptions: L.PopupOptions = {};
+
+let tooltipOptions: L.TooltipOptions = {};
+
+let zoomPanOptions: L.ZoomPanOptions = {};
+zoomPanOptions = {
+	animate: false,
+	duration: 0.5,
+	easeLinearity: 0.6,
+	noMoveStart: true
+};
+
+let zoomOptions: L.ZoomOptions = {};
+
+let panOptions: L.PanOptions = {};
+
+let fitBoundsOptions: L.FitBoundsOptions = {};
+
+let map = L.map('foo');
+map = L.map('foo', mapOptions);
+map = L.map(htmlElement);
+map = L.map(htmlElement, mapOptions);
+
+let doesItHaveLayer: boolean;
+doesItHaveLayer = map.hasLayer(L.tileLayer(''));
+
+// map.getRenderer
+
+let html: HTMLElement;
+
+html = map.createPane('foo');
+html = map.createPane('foo', htmlElement)
+
+html = map.getPane('foo');
+html = map.getPane(htmlElement);
+
+html = map.getContainer();
+
+const panes = map.getPanes();
+html = panes.mapPane;
+html = panes.tilePane;
+html = panes.overlayPane;
+html = panes.shadowPane;
+html = panes.markerPane;
+html = panes.tooltipPane;
+html = panes.popupPane;
+html = panes['foo'];
+
+let coordinates: L.LatLng;
+coordinates = map.getCenter();
+
+let zoom: number;
+zoom = map.getZoom();
+zoom = map.getMinZoom();
+zoom = map.getMaxZoom();
+// map.getBoundsZoom with actual latlngbounds
+zoom = map.getBoundsZoom(latLngBoundsLiteral);
+zoom = map.getBoundsZoom(latLngBoundsLiteral, true);
+
+let mapLatLngBounds: L.LatLngBounds;
+mapLatLngBounds = map.getBounds();
+
+let mapPoint: L.Point;
+mapPoint = map.getSize();
+mapPoint = map.getPixelOrigin();
+
+let mapPixelBounds: L.Bounds;
+mapPixelBounds = map.getPixelBounds();
+mapPixelBounds = map.getPixelWorldBounds();
+mapPixelBounds = map.getPixelWorldBounds(12);
+
+map = map
+	// addControl
+	// removeControl
+	.addLayer(L.tileLayer(''))
+	.removeLayer(L.tileLayer('')) // use a different type of layer
+	.eachLayer((currentLayer) => {
+		layer = currentLayer;
+	})
+	.eachLayer((currentLayer) => {
+		layer = currentLayer;
+	}, {})
+	.openPopup(L.popup())
+	// openPopup with actual latlng
+	.openPopup('Hello World', latLngLiteral)
+	.openPopup('Hello World', latLngLiteral, popupOptions)
+	.openPopup('Hello World', latLngTuple)
+	.openPopup('Hello World', latLngTuple, popupOptions)
+	.openPopup(htmlElement, latLngLiteral)
+	.openPopup(htmlElement, latLngLiteral, popupOptions)
+	.openPopup(htmlElement, latLngTuple)
+	.openPopup(htmlElement, latLngTuple, popupOptions)
+	.closePopup()
+	.closePopup(L.popup())
+	.openTooltip(L.tooltip())
+	// openTooltip with actual latlng
+	.openTooltip('Hello World', latLngLiteral)
+	.openTooltip('Hellow World', latLngLiteral, tooltipOptions)
+	.openTooltip('Hello World', latLngTuple)
+	.openTooltip('Hello World', latLngTuple, tooltipOptions)
+	.closeTooltip()
+	.closeTooltip(L.tooltip())
+	// setView with actual latlng
+	.setView(latLngLiteral, 12)
+	.setView(latLngLiteral, 12, zoomPanOptions)
+	.setView(latLngTuple, 12)
+	.setView(latLngTuple, 12, zoomPanOptions)
+	.setZoom(12, zoomPanOptions) // investigate if zoomPanOptions are really required
+	.zoomIn()
+	.zoomIn(1)
+	.zoomIn(1, zoomOptions)
+	.zoomOut()
+	.zoomOut(1)
+	.zoomOut(1, zoomOptions)
+	// setZoomAround with actual latlng
+	.setZoomAround(latLngLiteral, 12, zoomOptions) // investigate if zoom options are really required
+	.setZoomAround(latLngTuple, 12, zoomOptions)
+	// setZoomAround with actual point
+	.setZoomAround(pointTuple, 11, zoomOptions)
+	// fitBounds with actual latlngbounds
+	.fitBounds(latLngBoundsLiteral, fitBoundsOptions) // investigate if fit bounds options are really required
+	.fitWorld()
+	.fitWorld(fitBoundsOptions)
+	// panTo with actual latlng
+	.panTo(latLngLiteral)
+	.panTo(latLngLiteral, panOptions)
+	.panTo(latLngTuple)
+	.panTo(latLngTuple, panOptions)
+	// panBy with actual point
+	.panBy(pointTuple)
+	// setMaxBounds with actual bounds
+	.setMaxBounds(boundsLiteral) // investigate if this really receives Bounds instead of LatLngBounds
+	.setMinZoom(5)
+	.setMaxZoom(10)
+	// panInsideBounds with actual latlngbounds
+	.panInsideBounds(latLngBoundsLiteral)
+	.panInsideBounds(latLngBoundsLiteral, panOptions)
+	.invalidateSize(zoomPanOptions)
+	.invalidateSize(false)
+	.stop()
+	// flyTo with actual latlng
+	.flyTo(latLngLiteral)
+	.flyTo(latLngLiteral, 12)
+	.flyTo(latLngLiteral, 12, zoomPanOptions)
+	.flyTo(latLngTuple)
+	.flyTo(latLngTuple, 12)
+	.flyTo(latLngTuple, 12, zoomPanOptions)
+	// flyToBunds with actual latlngbounds
+	.flyToBounds(latLngBoundsLiteral)
+	.flyToBounds(latLngBoundsLiteral, fitBoundsOptions)
+	// addHandler
+	.remove()
+	.whenReady(() => {})
+	.whenReady(() => {}, {});

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -376,9 +376,114 @@ declare namespace L {
         bringToBack(): this;
     }
 
-    export interface Renderer {
-
+    export interface PolylineOptions extends PathOptions {
+        smoothFactor?: number;
+        noClip?: boolean;
     }
+
+    export interface Polyline extends Path {
+        toGeoJSON(): Object; // should import GeoJSON typings
+        getLatLngs(): Array<LatLng>;
+        setLatLngs(latlngs: Array<LatLng>): this;
+        setLatLngs(latlngs: Array<LatLngLiteral>): this;
+        setLatLngs(latlngs: Array<LatLngTuple>): this;
+        isEmpty(): boolean;
+        getCenter(): LatLng;
+        getBounds(): LatLngBounds;
+        addLatLng(latlng: LatLng): this;
+        addLatLng(latlng: LatLngLiteral): this;
+        addLatLng(latlng: LatLngTuple): this;
+        addLatLng(latlng: Array<LatLng>): this; // these three overloads aren't explicitly noted in the docs
+        addLatLng(latlng: Array<LatLngLiteral>): this;
+        addLatLng(latlng: Array<LatLngTuple>): this;
+    }
+
+    export function polyline(latlngs: Array<LatLng>, options?: PolylineOptions): Polyline;
+
+    export function polyline(latlngs: Array<LatLngLiteral>, options?: PolylineOptions): Polyline;
+
+    export function polyline(latlngs: Array<LatLngTuple>, options?: PolylineOptions): Polyline;
+
+    export function polyline(latlngs: Array<Array<LatLng>>, options?: PolylineOptions): Polyline;
+
+    export function polyline(latlngs: Array<Array<LatLngLiteral>>, options?: PolylineOptions): Polyline;
+
+    export function polyline(latlngs: Array<Array<LatLngTuple>>, options?: PolylineOptions): Polyline;
+
+    export interface Polygon extends Polyline {
+        toGeoJSON(): Object; // should import GeoJSON typings
+    }
+
+    export function polygon(latlngs: Array<LatLng>, options?: PolylineOptions): Polygon;
+
+    export function polygon(latlngs: Array<LatLngLiteral>, options?: PolylineOptions): Polygon;
+
+    export function polygon(latlngs: Array<LatLngTuple>, options?: PolylineOptions): Polygon;
+
+    export function polygon(latlngs: Array<Array<LatLng>>, options?: PolylineOptions): Polygon;
+
+    export function polygon(latlngs: Array<Array<LatLngLiteral>>, options?: PolylineOptions): Polygon;
+
+    export function polygon(latlngs: Array<Array<LatLngTuple>>, options?: PolylineOptions): Polygon;
+
+    export interface Rectangle extends Polygon {
+        setBounds(latLngBounds: LatLngBounds): this;
+        setBounds(latLngBounds: LatLngBoundsLiteral): this;
+    }
+
+    export function rectangle(latLngBounds: LatLngBounds, options?: PolylineOptions): Rectangle;
+
+    export function rectangle(latLngBounds: LatLngBoundsLiteral, options?: PolylineOptions): Rectangle;
+
+    export interface CircleMarkerOptions extends PathOptions {
+        radius?: number;
+    }
+
+    export interface CircleMarker extends Path {
+        toGeoJSON(): Object; // should import GeoJSON typings
+        setLatLng(latLng: LatLng): this;
+        setLatLng(latLng: LatLngLiteral): this;
+        setLatLng(latLng: LatLngTuple): this;
+        getLatLng(): LatLng;
+        setRadius(radius: number): this;
+        getRadius(): number;
+    }
+
+    export function circleMarker(latlng: LatLng, options?: CircleMarkerOptions): CircleMarker;
+
+    export function circleMarker(latlng: LatLngLiteral, options?: CircleMarkerOptions): CircleMarker;
+
+    export function circleMarker(latlng: LatLngLiteral, options?: CircleMarkerOptions): CircleMarker;
+
+    export interface CircleOptions extends PathOptions {
+        radius?: number;
+    }
+
+    export interface Circle extends CircleMarker {
+        setRadius(radius: number): this;
+        getRadius(): number;
+        getBounds(): LatLngBounds;
+    }
+
+    export function circle(latlng: LatLng, options?: CircleOptions): Circle;
+
+    export function circle(latlng: LatLngLiteral, options?: CircleOptions): Circle;
+
+    export function circle(latlng: LatLngTuple, options?: CircleOptions): Circle;
+
+    export function circle(latlng: LatLng, radius: number, options?: CircleOptions): Circle;
+
+    export function circle(latlng: LatLngLiteral, radius: number, options?: CircleOptions): Circle;
+
+    export function circle(latlng: LatLngTuple, radius: number, options?: CircleOptions): Circle;
+
+    export interface RendererOptions extends LayerOptions {
+        padding?: number;
+    }
+
+    export interface Renderer extends Layer {}
+
+    export interface SVG extends Renderer {}
 
     type Zoom = boolean | 'center';
 
@@ -437,10 +542,6 @@ declare namespace L {
         tapTolerance?: number;
         touchZoom?: Zoom;
         bounceAtZoomLimits?: boolean;
-    }
-
-    export interface Path {
-
     }
 
     export interface Control {
@@ -631,37 +732,58 @@ declare namespace L {
         hasLayer(layer: Layer): boolean;
         eachLayer(fn: (layer: Layer) => void, context?: Object): this;
         openPopup(popup: Popup): this;
-        openPopup(content: string, latlng: LatLngExpression, options?: PopupOptions): this;
-        openPopup(content: HTMLElement, latlng: LatLngExpression, options?: PopupOptions): this;
+        openPopup(content: string, latlng: LatLng, options?: PopupOptions): this;
+        openPopup(content: string, latlng: LatLngLiteral, options?: PopupOptions): this;
+        openPopup(content: string, latlng: LatLngTuple, options?: PopupOptions): this;
+        openPopup(content: HTMLElement, latlng: LatLng, options?: PopupOptions): this;
+        openPopup(content: HTMLElement, latlng: LatLngLiteral, options?: PopupOptions): this;
+        openPopup(content: HTMLElement, latlng: LatLngTuple, options?: PopupOptions): this;
         closePopup(popup?: Popup): this;
         openTooltip(tooltip: Tooltip): this;
-        openTooltip(content: string, latlng: LatLngExpression, options?: TooltipOptions): this;
-        openTooltip(content: HTMLElement, latlng: LatLngExpression, options?: TooltipOptions): this;
+        openTooltip(content: string, latlng: LatLng, options?: TooltipOptions): this;
+        openTooltip(content: string, latlng: LatLngLiteral, options?: TooltipOptions): this;
+        openTooltip(content: string, latlng: LatLngTuple, options?: TooltipOptions): this;
+        openTooltip(content: HTMLElement, latlng: LatLng, options?: TooltipOptions): this;
+        openTooltip(content: HTMLElement, latlng: LatLngLiteral, options?: TooltipOptions): this;
+        openTooltip(content: HTMLElement, latlng: LatLngTuple, options?: TooltipOptions): this;
         closeTooltip(tooltip?: Tooltip): this;
 
         // Methods for modifying map state
-        setView(center: LatLngExpression, zoom: number, options?: ZoomPanOptions): this;
+        setView(center: LatLng, zoom: number, options?: ZoomPanOptions): this;
+        setView(center: LatLngLiteral, zoom: number, options?: ZoomPanOptions): this;
+        setView(center: LatLngTuple, zoom: number, options?: ZoomPanOptions): this;
         setZoom(zoom: number, options: ZoomPanOptions): this;
         zoomIn(delta?: number, options?: ZoomOptions): this;
         zoomOut(delta?: number, options?: ZoomOptions): this;
-        setZoomAround(latlng: LatLngExpression, zoom: number, options: ZoomOptions): this;
+        setZoomAround(latlng: LatLng, zoom: number, options: ZoomOptions): this;
+        setZoomAround(latlng: LatLngLiteral, zoom: number, options: ZoomOptions): this;
+        setZoomAround(latlng: LatLngTuple, zoom: number, options: ZoomOptions): this; // will the latlng version using tuple take precedence or will the point tuple version?
         setZoomAround(offset: Point, zoom: number, options: ZoomOptions): this;
-        fitBounds(bounds: LatLngBoundsExpression, options: FitBoundsOptions): this;
+        fitBounds(bounds: LatLngBounds, options: FitBoundsOptions): this;
+        fitBounds(bounds: LatLngBoundsLiteral, options: FitBoundsOptions): this;
         fitWorld(options?: FitBoundsOptions): this;
-        panTo(latlng: LatLngExpression, options?: PanOptions): this;
-        panBy(offset: PointExpression): this;
-        setMaxBounds(bounds: BoundsExpression): this;
+        panTo(latlng: LatLng, options?: PanOptions): this;
+        panTo(latlng: LatLngLiteral, options?: PanOptions): this;
+        panTo(latlng: LatLngTuple, options?: PanOptions): this;
+        panBy(offset: Point): this;
+        panBy(offset: PointTuple): this;
+        setMaxBounds(bounds: Bounds): this; // is this really bounds and not lanlngbounds?
+        setMaxBounds(bounds: BoundsLiteral): this;
         setMinZoom(zoom: number): this;
         setMaxZoom(zoom: number): this;
-        panInsideBounds(bounds: LatLngBoundsExpression, options?: PanOptions): this;
+        panInsideBounds(bounds: LatLngBounds, options?: PanOptions): this;
+        panInsideBounds(bounds: LatLngBoundsLiteral, options?: PanOptions): this;
         invalidateSize(options: ZoomPanOptions): this;
         invalidateSize(animate: boolean): this;
         stop(): this;
-        flyTo(latlng: LatLngExpression, zoom?: number, options?: ZoomPanOptions): this;
-        flyToBounds(bounds: LatLngBoundsExpression, options?: FitBoundsOptions): this;
+        flyTo(latlng: LatLng, zoom?: number, options?: ZoomPanOptions): this;
+        flyTo(latlng: LatLngLiteral, zoom?: number, options?: ZoomPanOptions): this;
+        flyTo(latlng: LatLngTuple, zoom?: number, options?: ZoomPanOptions): this;
+        flyToBounds(bounds: LatLngBounds, options?: FitBoundsOptions): this;
+        flyToBounds(bounds: LatLngBoundsLiteral, options?: FitBoundsOptions): this;
 
         // Other methods
-        addHandler(name: string, HandlerClass: () => Handler): this;
+        addHandler(name: string, HandlerClass: () => Handler): this; // HandlerClass is actually a constructor function, is this the right way?
         remove(): this;
         createPane(name: string, container?: HTMLElement): HTMLElement;
         getPane(pane: string): HTMLElement;
@@ -676,7 +798,8 @@ declare namespace L {
         getBounds(): LatLngBounds;
         getMinZoom(): number;
         getMaxZoom(): number;
-        getBoundsZoom(bounds: LatLngBoundsExpression, inside?: boolean): number;
+        getBoundsZoom(bounds: LatLngBounds, inside?: boolean): number;
+        getBoundsZoom(bounds: LatLngBoundsLiteral, inside?: boolean): number;
         getSize(): Point;
         getPixelBounds(): Bounds;
         getPixelOrigin(): Point;
@@ -685,15 +808,29 @@ declare namespace L {
         // Conversion methods
         getZoomScale(toZoom: number, fromZoom: number): number;
         getScaleZoom(scale: number, fromZoom: number): number;
-        project(latlng: LatLngExpression, zoom: number): Point;
+        project(latlng: LatLng, zoom: number): Point;
+        project(latlng: LatLngLiteral, zoom: number): Point;
+        project(latlng: LatLngTuple, zoom: number): Point;
         unproject(point: Point, zoom: number): LatLng;
-        layerPointToLatLng(point: PointExpression): LatLng;
-        latLngToLayerPoint(latlng: LatLngExpression): Point;
-        wrapLatLng(latlng: LatLngExpression): LatLng;
-        distance(latlng1: LatLngExpression, latlng2: LatLngExpression): number;
-        containerPointToLayerPoint(point: PointExpression): Point;
-        layerPointToContainerPoint(point: PointExpression): Point;
-        latLngToContainerPoint(latlng: LatLngExpression): Point;
+        unproject(point: PointTuple, zoom: number): LatLng;
+        layerPointToLatLng(point: Point): LatLng;
+        layerPointToLatLng(point: PointTuple): LatLng;
+        latLngToLayerPoint(latlng: LatLng): Point;
+        latLngToLayerPoint(latlng: LatLngLiteral): Point;
+        latLngToLayerPoint(latlng: LatLngTuple): Point;
+        wrapLatLng(latlng: LatLng): LatLng;
+        wrapLatLng(latlng: LatLngLiteral): LatLng;
+        wrapLatLng(latlng: LatLngTuple): LatLng;
+        distance(latlng1: LatLng, latlng2: LatLng): number;
+        distance(latlng1: LatLngLiteral, latlng2: LatLngLiteral): number;
+        distance(latlng1: LatLngTuple, latlng2: LatLngTuple): number;
+        containerPointToLayerPoint(point: Point): Point;
+        containerPointToLayerPoint(point: PointTuple): Point;
+        layerPointToContainerPoint(point: Point): Point;
+        layerPointToContainerPoint(point: PointTuple): Point;
+        latLngToContainerPoint(latlng: LatLng): Point;
+        latLngToContainerPoint(latlng: LatLngLiteral): Point;
+        latLngToContainerPoint(latlng: LatLngTuple): Point;
         mouseEventToContainerPoint(ev: MouseEvent): Point;
         mouseEventToLayerPoint(ev: MouseEvent): Point;
         mouseEventToLatLng(ev: MouseEvent): LatLng;
@@ -767,7 +904,9 @@ declare namespace L {
 
     export interface Marker extends Layer {
         getLatLng(): LatLng;
-        setLatLng(latlng: LatLngExpression): this;
+        setLatLng(latlng: LatLng): this;
+        setLatLng(latlng: LatLngLiteral): this;
+        setLatLng(latlng: LatLngTuple): this;
         setZIndexOffset(offset: number): this;
         setIcon(icon: Icon): this;
         setOpacity(opacity: number): this;
@@ -776,7 +915,11 @@ declare namespace L {
         dragging: Handler;
     }
 
-    export function marker(latlng: LatLngExpression, options?: MarkerOptions): Marker;
+    export function marker(latlng: LatLng, options?: MarkerOptions): Marker;
+
+    export function marker(latlng: LatLngLiteral, options?: MarkerOptions): Marker;
+
+    export function marker(latlng: LatLngTuple, options?: MarkerOptions): Marker;
 }
 
 declare module 'leaflet' {

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -9,7 +9,15 @@ declare namespace L {
     }
 
     export interface LatLng {
+        equals(otherLatLng: LatLngExpression, maxMargin?: number): boolean;
+        toString(): string;
+        distanceTo(otherLatLng: LatLngExpression): number;
+        wrap(): LatLng;
+        toBounds(sizeInMeters: number): LatLngBounds;
 
+        lat: number;
+        lng: number;
+        alt: number;
     }
 
     export interface LatLngLiteral {
@@ -21,29 +29,111 @@ declare namespace L {
 
     type LatLngExpression = LatLng | LatLngLiteral | LatLngTuple;
 
-    export interface LatLngBounds {
+    export function latLng(latitude: number, longitude: number, altitude?: number): LatLng;
 
+    export function latLng(coords: LatLngTuple): LatLng;
+
+    export function latLng(coords: [number, number, number]): LatLng;
+
+    export function latLng(coords: LatLngLiteral): LatLng;
+
+    export function latLng(coords: {lat: number, lng: number, alt: number}): LatLng;
+
+    export interface LatLngBounds {
+        extend(latlng: LatLngExpression): this;
+        extend(otherBounds: LatLngExpression): this;
+        pad(bufferRatio: number): LatLngBounds; // does this modify the current instance or does it return a new one?
+        getCenter(): LatLng;
+        getSouthWest(): LatLng;
+        getNorthEast(): LatLng;
+        getNorthWest(): LatLng;
+        getSouthEast(): LatLng;
+        getWest(): number;
+        getSouth(): number;
+        getEast(): number;
+        getNorth(): number;
+        contains(otherBounds: LatLngBoundsExpression): boolean;
+        contains(latlng: LatLngExpression): boolean;
+        intersects(otherBounds: LatLngBoundsExpression): boolean;
+        overlaps(otherBounds: BoundsExpression): boolean; // investigate if this is really bounds and not latlngbounds
+        toBBoxString(): string;
+        equals(otherBounds: LatLngBoundsExpression): boolean;
+        isValid(): boolean;
     }
 
     export type LatLngBoundsLiteral = Array<LatLngTuple>;
 
     type LatLngBoundsExpression = LatLngBounds | LatLngBoundsLiteral;
 
+    export function latLngBounds(southWest: LatLngExpression, northEast: LatLngExpression): LatLngBounds;
+
+    export function latLngBounds(latlngs: Array<LatLngExpression>): LatLngBounds;
+
     export type PointTuple = [number, number];
 
     export interface Point {
-
+        clone(): Point;
+        add(otherPoint: Point): Point; // investigate if this mutates or returns a new instance
+        add(otherPoint: PointTuple): Point;
+        subtract(otherPoint: Point): Point;
+        subtract(otherPoint: PointTuple): Point;
+        divideBy(num: number): Point;
+        multiplyBy(num: number): Point;
+        scaleBy(scale: Point): Point;
+        scaleBy(scale: PointTuple): Point;
+        unscaleBy(scale: Point): Point;
+        unscaleBy(scale: PointTuple): Point;
+        round(): Point;
+        floor(): Point;
+        ceil(): Point;
+        distanceTo(otherPoint: Point): Point;
+        distanceTo(otherPoint: PointTuple): Point;
+        equals(otherPoint: Point): boolean;
+        equals(otherPoint: PointTuple): boolean;
+        contains(otherPoint: Point): boolean;
+        contains(otherPoint: PointTuple): boolean;
+        toString(): string;
     }
 
     type PointExpression = Point | PointTuple;
 
-    export interface Bounds {
+    export function point(x: number, y: number, round?: boolean): Point;
 
-    }
+    export function point(coords: PointTuple): Point;
+
+    export function point(coords: {x: number, y: number}): Point;
 
     export type BoundsLiteral = Array<PointTuple>;
 
+    export interface Bounds {
+        extend(point: Point): this;
+        extend(point: PointTuple): this;
+        getCenter(round?: boolean): Point;
+        getBottomLeft(): Point;
+        getTopRight(): Point;
+        getSize(): Point;
+        contains(otherBounds: Bounds): boolean;
+        contains(otherBounds: BoundsLiteral): boolean;
+        contains(point: Point): boolean;
+        contains(point: PointTuple): boolean;
+        intersects(otherBounds: Bounds): boolean;
+        intersects(otherBounds: BoundsLiteral): boolean;
+        overlaps(otherBounds: Bounds): boolean;
+        overlaps(otherBounds: BoundsLiteral): boolean;
+
+        min: Point;
+        max: Point;
+    }
+
     type BoundsExpression = Bounds | BoundsLiteral;
+
+    export function bounds(topLeft: Point, bottomRight: Point): Bounds;
+
+    export function bounds(topLeft: PointTuple, bottomRight: PointTuple): Bounds;
+
+    export function bounds(points: Array<Point>): Bounds;
+
+    export function bounds(points: BoundsLiteral): Bounds;
 
     export interface Evented {
 
@@ -58,7 +148,53 @@ declare namespace L {
     }
 
     export interface Layer extends Evented {
+        addTo(map: Map): this;
+        remove(): this;
+        removeFrom(map: Map): this;
+        getPane(name?: string): HTMLElement;
 
+        // Popup methods
+        bindPopup(content: string, options?: PopupOptions): this;
+        bindPopup(content: HTMLElement, options?: PopupOptions): this;
+        bindPopup(content: (layer: Layer) => Content, options?: PopupOptions): this;
+        bindPopup(content: Popup): this;
+        unbindPopup(): this;
+        openPopup(): this;
+        openPopup(latlng: LatLng): this;
+        openPopup(latlng: LatLngLiteral): this;
+        openPopup(latlng: LatLngTuple): this;
+        closePopup(): this;
+        togglePopup(): this;
+        isPopupOpen(): boolean;
+        setPopupContent(content: string): this;
+        setPopupContent(content: HTMLElement): this;
+        setPopupContent(content: Popup): this;
+        getPopup(): Popup;
+
+        // Tooltip methods
+        bindTooltip(content: string, options?: TooltipOptions): this;
+        bindTooltip(content: HTMLElement, options?: TooltipOptions): this;
+        bindTooltip(content: (layer: Layer) => Content, options?: TooltipOptions): this;
+        bindTooltip(content: Tooltip, options?: TooltipOptions): this;
+        unbindTooltip(): this;
+        openTooltip(): this;
+        openTooltip(latlng: LatLng): this;
+        openTooltip(latlng: LatLngLiteral): this;
+        openTooltip(latlng: LatLngTuple): this;
+        closeTooltip(): this;
+        toggleTooltip(): this;
+        isTooltipOpen(): boolean;
+        setTooltipContent(content: string): this;
+        setTooltipContent(content: HTMLElement): this;
+        setTooltipContent(content: Tooltip): this;
+        getTooltip(): Tooltip;
+
+        // Extension methods
+        onAdd(map: Map): this;
+        onRemove(map: Map): this;
+        getEvents(): {[name: string]: (event: Event) => void};
+        getAttribution(): string;
+        beforeAdd(map: Map): this;
     }
 
     export interface GridLayerOptions {
@@ -332,11 +468,82 @@ declare namespace L {
     }
 
     export interface Handler {
+        enable(): this;
+        disable(): this;
+        enabled(): boolean;
 
+        // Extension methods
+        addHooks(): void;
+        removeHooks(): void;
     }
 
-    export interface MouseEvent {
+    export interface Event {
+        type: string;
+        target: any; // should this be Object and have users cast?
+    }
 
+    export interface MouseEvent extends Event {
+        latlng: LatLng;
+        layerPoint: Point;
+        containerPoint: Point;
+        originalEvent: MouseEvent; // how can I reference the global MouseEvent?
+    }
+
+    export interface LocationEvent extends Event {
+        latlng: LatLng;
+        bounds: LatLngBounds;
+        accuracy: number;
+        altitude: number;
+        altitudeAccuracy: number;
+        heading: number;
+        speed: number;
+        timestamp: number;
+    }
+
+    export interface ErrorEvent extends Event {
+        message: string;
+        code: number;
+    }
+
+    export interface LayerEvent extends Event {
+        layer: Layer;
+    }
+
+    export interface LayersControlEvent extends LayerEvent {
+        name: string;
+    }
+
+    export interface TileEvent extends Event {
+        tile: HTMLImageElement;
+        coords: Point; // apparently not a normal point, since docs say it has z (zoom)
+    }
+
+    export interface TileErrorEvent extends TileEvent {
+        error: Error;
+    }
+
+    export interface ResizeEvent extends Event {
+        oldSize: Point;
+        newSize: Point;
+    }
+
+    export interface GeoJSONEvent extends Event {
+        layer: Layer;
+        properties: any; // any or Object?
+        geometryType: string;
+        id: string;
+    }
+
+    export interface PopupEvent extends Event {
+        popup: Popup;
+    }
+
+    export interface TooltipEvent extends Event {
+        tooltip: Tooltip;
+    }
+
+    export interface DragEndEvent extends Event {
+        distance: number;
     }
 
     interface DefaultMapPanes {
@@ -378,7 +585,7 @@ declare namespace L {
         fitBounds(bounds: LatLngBoundsExpression, options: FitBoundsOptions): this;
         fitWorld(options?: FitBoundsOptions): this;
         panTo(latlng: LatLngExpression, options?: PanOptions): this;
-        panBy(offset: Point): this;
+        panBy(offset: PointExpression): this;
         setMaxBounds(bounds: BoundsExpression): this;
         setMinZoom(zoom: number): this;
         setMaxZoom(zoom: number): this;
@@ -445,9 +652,40 @@ declare namespace L {
 
     export function map(el: HTMLElement, options?: MapOptions): Map;
 
-    export interface Icon {
-
+    export interface IconOptions extends LayerOptions {
+        iconUrl: string;
+        iconRetinaUrl?: string;
+        iconSize?: PointExpression;
+        iconAnchor?: PointExpression;
+        popupAnchor?: PointExpression;
+        shadowUrl?: string;
+        shadowRetinaUrl?: string;
+        shadowSize?: PointExpression;
+        shadowAnchor?: PointExpression;
+        className?: string;
     }
+
+    export interface Icon extends Layer {
+        createIcon(oldIcon?: HTMLElement): HTMLElement;
+        createShadow(oldIcon?: HTMLElement): HTMLElement;
+
+        Default: Icon;
+    }
+
+    export function icon(options: IconOptions): Icon;
+
+    export interface DivIconOptions extends LayerOptions {
+        html?: string;
+        bgPos?: PointExpression;
+        iconSize?: PointExpression;
+        iconAnchor?: PointExpression;
+        popupAnchor?: PointExpression;
+        className?: string;
+    }
+
+    export interface DivIcon extends Icon {}
+
+    export function divIcon(options: DivIconOptions): DivIcon;
 
     export interface MarkerOptions extends InteractiveLayerOptions {
         icon?: Icon;

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -5,13 +5,64 @@
 
 declare namespace L {
     export interface CRS {
+        latLngToPoint(latlng: LatLng, zoom: number): Point;
+        latLngToPoint(latlng: LatLngLiteral, zoom: number): Point;
+        latLngToPoint(latlng: LatLngTuple, zoom: number): Point;
+        pointToLatLng(point: Point): LatLng;
+        pointToLatLng(point: PointTuple): LatLng;
+        project(latlng: LatLng): Point;
+        project(latlng: LatLngLiteral): Point;
+        project(latlng: LatLngTuple): Point;
+        unproject(point: Point): LatLng;
+        unproject(point: PointTuple): LatLng;
+        scale(zoom: number): number;
+        zoom(scale: number): number;
+        getProjectedBounds(zoom: number): Bounds;
+        distance(latlng1: LatLng, latlng2: LatLng): number;
+        distance(latlng1: LatLngLiteral, latlng2: LatLngLiteral): number;
+        distance(latlng1: LatLngTuple, latlng2: LatLngTuple): number;
+        wrapLatLng(latlng: LatLng): LatLng;
+        wrapLatLng(latlng: LatLngLiteral): LatLng;
+        wrapLatLng(latlng: LatLngTuple): LatLng;
 
+        code: string;
+        wrapLng: [number, number];
+        wrapLat: [number, number];
+        infinite: boolean;
+    }
+
+    export namespace CRS {
+        export const EPSG3395: CRS;
+        export const EPSG3857: CRS;
+        export const EPSG4326: CRS;
+        export const Earth: CRS;
+        export const Simple: CRS;
+    }
+
+    export interface Projection {
+        project(latlng: LatLng): Point;
+        project(latlng: LatLngLiteral): Point;
+        project(latlng: LatLngTuple): Point;
+        unproject(point: Point): LatLng;
+        unproject(point: PointTuple): LatLng;
+
+        bounds: LatLngBounds;
+    }
+
+    export namespace Projection {
+        export const LonLat: Projection;
+        export const Mercator: Projection;
+        export const SphericalMercator: Projection;
     }
 
     export interface LatLng {
-        equals(otherLatLng: LatLngExpression, maxMargin?: number): boolean;
+        equals(otherLatLng: LatLng, maxMargin?: number): boolean;
+        equals(otherLatLng: LatLngLiteral, maxMargin?: number): boolean;
+        equals(otherLatLng: LatLngTuple, maxMargin?: number): boolean;
         toString(): string;
-        distanceTo(otherLatLng: LatLngExpression): number;
+        distanceTo(otherLatLng: LatLng): number;
+        distanceTo(otherLatLng: LatLngLiteral): number;
+        distanceTo(otherLatLng: LatLngTuple): number;
         wrap(): LatLng;
         toBounds(sizeInMeters: number): LatLngBounds;
 
@@ -40,8 +91,11 @@ declare namespace L {
     export function latLng(coords: {lat: number, lng: number, alt: number}): LatLng;
 
     export interface LatLngBounds {
-        extend(latlng: LatLngExpression): this;
-        extend(otherBounds: LatLngExpression): this;
+        extend(latlng: LatLng): this;
+        extend(latlng: LatLngLiteral): this;
+        extend(latlng: LatLngTuple): this;
+        extend(otherBounds: LatLngBounds): this;
+        extend(otherBounds: LatLngBoundsLiteral): this;
         pad(bufferRatio: number): LatLngBounds; // does this modify the current instance or does it return a new one?
         getCenter(): LatLng;
         getSouthWest(): LatLng;
@@ -52,12 +106,18 @@ declare namespace L {
         getSouth(): number;
         getEast(): number;
         getNorth(): number;
-        contains(otherBounds: LatLngBoundsExpression): boolean;
-        contains(latlng: LatLngExpression): boolean;
-        intersects(otherBounds: LatLngBoundsExpression): boolean;
-        overlaps(otherBounds: BoundsExpression): boolean; // investigate if this is really bounds and not latlngbounds
+        contains(otherBounds: LatLngBounds): boolean;
+        contains(otherBounds: LatLngBoundsLiteral): boolean;
+        contains(latlng: LatLng): boolean;
+        contains(latlng: LatLngLiteral): boolean;
+        contains(latlng: LatLngTuple): boolean;
+        intersects(otherBounds: LatLngBounds): boolean;
+        intersects(otherBounds: LatLngLiteral): boolean;
+        overlaps(otherBounds: Bounds): boolean; // investigate if this is really bounds and not latlngbounds
+        overlaps(otherBounds: BoundsLiteral): boolean;
         toBBoxString(): string;
-        equals(otherBounds: LatLngBoundsExpression): boolean;
+        equals(otherBounds: LatLngBounds): boolean;
+        equals(otherBounds: LatLngBoundsLiteral): boolean;
         isValid(): boolean;
     }
 
@@ -65,9 +125,13 @@ declare namespace L {
 
     type LatLngBoundsExpression = LatLngBounds | LatLngBoundsLiteral;
 
-    export function latLngBounds(southWest: LatLngExpression, northEast: LatLngExpression): LatLngBounds;
+    export function latLngBounds(southWest: LatLng, northEast: LatLng): LatLngBounds;
 
-    export function latLngBounds(latlngs: Array<LatLngExpression>): LatLngBounds;
+    export function latLngBounds(southWest: LatLngLiteral, northEast: LatLngLiteral): LatLngBounds;
+
+    export function latLngBounds(southWest: LatLngTuple, northEast: LatLngTuple): LatLngBounds;
+
+    export function latLngBounds(latlngs: LatLngBoundsLiteral): LatLngBounds;
 
     export type PointTuple = [number, number];
 
@@ -668,8 +732,10 @@ declare namespace L {
     export interface Icon extends Layer {
         createIcon(oldIcon?: HTMLElement): HTMLElement;
         createShadow(oldIcon?: HTMLElement): HTMLElement;
+    }
 
-        Default: Icon;
+    export namespace Icon {
+        export const Default: Icon;
     }
 
     export function icon(options: IconOptions): Icon;

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -1,0 +1,475 @@
+// Type definitions for Leaflet.js 1.0.0-rc3
+// Project: https://github.com/Leaflet/Leaflet
+// Definitions by: Alejandro Sánchez <https://github.com/alejo90>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace L {
+    export interface CRS {
+
+    }
+
+    export interface LatLng {
+
+    }
+
+    export interface LatLngObjectLiteral {
+        lat: number;
+        lng: number;
+    }
+
+    export type LatLngTupleLiteral = [number, number];
+
+    type LatLngExpression = LatLng | LatLngObjectLiteral | LatLngTupleLiteral;
+
+    export interface LatLngBounds {
+
+    }
+
+    export type LatLngBoundsLiteral = Array<LatLngTupleLiteral>;
+
+    type LatLngBoundsExpression = LatLngBounds | LatLngBoundsLiteral;
+
+    export type PointLiteral = [number, number];
+
+    export interface Point {
+
+    }
+
+    type PointExpression = Point | PointLiteral;
+
+    export interface Bounds {
+
+    }
+
+    type BoundsExpression = Bounds | Array<PointLiteral>;
+
+    export interface Evented {
+
+    }
+
+    interface LayerOptions {
+        pane?: string;
+    }
+
+    interface InteractiveLayerOptions extends LayerOptions {
+        interactive?: boolean;
+    }
+
+    export interface Layer extends Evented {
+
+    }
+
+    export interface GridLayerOptions {
+        tileSize?: number | Point;
+        opacity?: number;
+        updateWhenIdle?: boolean;
+        updateWhenZooming?: boolean;
+        updateInterval?: number;
+        attribution?: string;
+        zIndex?: number;
+        bounds?: LatLngBoundsExpression;
+        minZoom?: number;
+        maxZoom?: number;
+        noWrap?: boolean;
+        pane?: string;
+        className?: string;
+        keepBuffer?: number;
+    }
+
+    export interface GridLayer extends Layer {
+        bringToFront(): this;
+        bringToBack(): this;
+        getAttribution(): string;
+        getContainer(): HTMLElement;
+        setOpacity(opacity: number): this;
+        setZIndex(zIndex: number): this;
+        isLoading(): boolean;
+        redraw(): this;
+        getTileSize(): Point;
+    }
+
+    export function gridLayer(options?: GridLayerOptions): GridLayer;
+
+    export interface TileLayerOptions extends GridLayerOptions {
+        minZoom?: number;
+        maxZoom?: number;
+        maxNativeZoom?: number;
+        subdomains?: string | Array<string>;
+        errorTileUrl?: string;
+        zoomOffset?: number;
+        tms?: boolean;
+        zoomReverse?: boolean;
+        detectRetina?: boolean;
+        crossOrigin?: boolean;
+    }
+
+    export interface TileLayer extends GridLayer {
+        setUrl(url: string, noRedraw?: boolean): this;
+    }
+
+    export function tileLayer(urlTemplate: string, options?: TileLayerOptions): TileLayer;
+
+    export interface WMSOptions extends TileLayerOptions {
+        layers: string;
+        styles?: string;
+        format?: string;
+        transparent?: boolean;
+        version?: string;
+        crs?: CRS;
+        uppercase?: boolean;
+    }
+
+    export interface WMS extends TileLayer {
+        setParams(params: Object, noRedraw?: boolean): this;
+    }
+
+    export namespace tileLayer {
+        export function wms(baseUrl: string, options: WMSOptions): WMS;
+    }
+
+    export interface ImageOverlayOptions extends LayerOptions {
+        opacity?: number;
+        alt?: string;
+        interactive?: boolean;
+        attribution?: string;
+        crossOrigin?: boolean;
+    }
+
+    export interface ImageOverlay extends Layer {
+        setOpacity(opacity: number): this;
+        bringToFront(): this;
+        bringToBack(): this;
+        setUrl(url: string): this;
+    }
+
+    export function imageOverlay(imageUrl: string, bounds: LatLngBoundsExpression, options?: ImageOverlayOptions): ImageOverlay;
+
+    export type LineCapShape = 'butt' | 'round' | 'square' | 'inherit';
+
+    export type LineJoinShape = 'miter' | 'round' | 'bevel' | 'inherit';
+
+    export type FillRule = 'nonzero' | 'evenodd' | 'inherit';
+
+    export interface PathOptions extends InteractiveLayerOptions {
+        stroke?: boolean;
+        color?: string;
+        wight?: number;
+        opacity?: number;
+        lineCap?: LineCapShape;
+        lineJoin?: LineJoinShape;
+        dashArray?: string;
+        dashOffset?: string;
+        fill?: boolean;
+        fillColor?: string;
+        fillOpacity?: number;
+        fillRule?: FillRule;
+        renderer?: Renderer;
+        className: string;
+    }
+
+    export interface Path extends Layer {
+        redraw(): this;
+        setStyle(style: PathOptions): this;
+        bringToFront(): this;
+        bringToBack(): this;
+    }
+
+    export interface Renderer {
+
+    }
+
+    type Zoom = boolean | 'center';
+
+    export interface MapOptions {
+        preferCanvas?: boolean;
+
+        // Control options
+        attributionControl?: boolean;
+        zoomControl?: boolean;
+
+        // Interaction options
+        closePopupOnClick?: boolean;
+        zoomSnap?: number;
+        zoomDelta?: number;
+        trackResize?: boolean;
+        boxZoom?: boolean;
+        doubleClickZoom?: Zoom;
+        dragging?: boolean;
+
+        // Map state options
+        crs?: CRS;
+        center?: LatLngExpression;
+        zoom?: number;
+        minZoom?: number;
+        maxZoom?: number;
+        layers?: Array<Layer>;
+        maxBounds?: LatLngBoundsExpression;
+        renderer?: Renderer;
+
+        // Animation options
+        fadeAnimation?: boolean;
+        markerZoomAnimation?: boolean;
+        transform3DLimit?: number;
+        zoomAnimation?: boolean;
+        zoomAnimationThreshold?: number;
+
+        // Panning inertia options
+        inertia?: boolean;
+        inertiaDeceleration?: boolean;
+        inertiaMaxSpeed?: number;
+        easeLinearity?: number;
+        worldCopyJump?: boolean;
+        maxBoundsViscosity?: number;
+
+        // Keyboard navigation options
+        keyboard?: boolean;
+        keyboardPanDelta?: boolean;
+
+        // Mousewheel options
+        scrollWheelZoom?: boolean;
+        wheelDebounceTime?: number;
+        wheelPxPerZoomLevel?: number;
+
+        // Touch interaction options
+        tap?: boolean;
+        tapTolerance?: boolean;
+        touchZoom?: Zoom;
+        bounceAtZoomLimits?: boolean;
+    }
+
+    export interface Path {
+
+    }
+
+    export interface Control {
+
+    }
+
+    interface DivOverlayOptions {
+        offset?: PointExpression;
+        zoomAnimation?: boolean;
+        className?: string;
+        pane?: string;
+    }
+
+    export interface PopupOptions extends DivOverlayOptions {
+        maxWidth?: number;
+        minWidth?: number;
+        maxHeight?: number;
+        autoPan?: boolean;
+        autoPanPaddingTopLeft?: PointExpression;
+        autoPanPaddingBottomRight?: PointExpression;
+        autoPanPadding?: PointExpression;
+        keepInView?: boolean;
+        closeButton?: boolean;
+        autoClose?: boolean;
+    }
+
+    type Content = string | HTMLElement;
+
+    export interface Popup extends Layer {
+        getLatLng(): LatLng;
+        setLatLng(latlng: LatLngExpression): this;
+        getContent(): Content;
+        setContent(htmlContent: string): this;
+        setContent(htmlContent: HTMLElement): this;
+        setContent(htmlContent: (source: Layer) => Content): this;
+        getElement(): Content;
+        update(): void;
+        isOpen(): boolean;
+        bringToFront(): this;
+        bringToBack(): this;
+        openOn(map: Map): this;
+    }
+
+    export function popup(options?: PopupOptions, source?: Layer): Popup;
+
+    export type Direction = 'right' | 'left' | 'top' | 'bottom' | 'center' | 'auto';
+
+    export interface TooltipOptions extends DivOverlayOptions {
+        pane?: string;
+        offset?: PointExpression;
+        direction?: Direction;
+        permanent?: boolean;
+        sticky?: boolean;
+        interactive?: boolean;
+        opacity?: number;
+    }
+
+    export interface Tooltip extends Layer {}
+
+    export function tooltip(options?: TooltipOptions, source?: Layer): Tooltip;
+
+    export interface ZoomOptions {
+        animate?: boolean;
+    }
+
+    export interface PanOptions {
+        animate?: boolean;
+        duration?: number;
+        easeLinearity?: number;
+        noMoveStart?: boolean;
+    }
+
+    export interface ZoomPanOptions extends ZoomOptions, PanOptions {}
+
+    export interface FitBoundsOptions extends ZoomOptions, PanOptions {
+        paddingTopLeft?: PointExpression;
+        paddingBottomRight?: PointExpression;
+        padding?: PointExpression;
+        maxZoom?: number;
+    }
+
+    export interface LocateOptions {
+        watch?: boolean;
+        setView?: boolean;
+        maxZoom?: number;
+        timeout?: number;
+        maximumAge?: number;
+        enableHighAccuracy?: boolean;
+    }
+
+    export interface Handler {
+
+    }
+
+    export interface MouseEvent {
+
+    }
+
+    interface DefaultMapPanes {
+        mapPane: HTMLElement;
+        tilePane: HTMLElement;
+        overlayPane: HTMLElement;
+        shadowPane: HTMLElement;
+        markerPane: HTMLElement;
+        tooltipPane: HTMLElement;
+        popupPane: HTMLElement;
+    }
+
+    export interface Map extends Evented {
+        getRenderer(layer: Path): Renderer;
+
+        // Methods for layers and controls
+        addControl(control: Control): this;
+        removeControl(control: Control): this;
+        addLayer(layer: Layer): this;
+        removeLayer(layer: Layer): this;
+        hasLayer(layer: Layer): boolean;
+        eachLayer(fn: (layer: Layer) => void, context?: Object): this;
+        openPopup(popup: Popup): this;
+        openPopup(content: string, latlng: LatLngExpression, options?: PopupOptions): this;
+        openPopup(content: HTMLElement, latlng: LatLngExpression, options?: PopupOptions): this;
+        closePopup(popup?: Popup): this;
+        openTooltip(tooltip: Tooltip): this;
+        closeTooltip(tooltip?: Tooltip): this;
+
+        // Methods for modifying map state
+        setView(center: LatLngExpression, zoom: number, options?: ZoomPanOptions): this;
+        setZoom(zoom: number, options: ZoomPanOptions): this;
+        zoomIn(delta?: number, options?: ZoomOptions): this;
+        zoomOut(delta?: number, options?: ZoomOptions): this;
+        setZoomAround(latlng: LatLngExpression, zoom: number, options: ZoomOptions): this;
+        setZoomAround(offset: Point, zoom: number, options: ZoomOptions): this;
+        fitBounds(bounds: LatLngBoundsExpression, options: FitBoundsOptions): this;
+        fitWorld(options?: FitBoundsOptions): this;
+        panTo(latlng: LatLngExpression, options?: PanOptions): this;
+        panBy(offset: Point): this;
+        setMaxBounds(bounds: BoundsExpression): this;
+        setMinZoom(zoom: number): this;
+        setMaxZoom(zoom: number): this;
+        panInsideBounds(bounds: LatLngBoundsExpression, options?: PanOptions): this;
+        invalidateSize(animate: boolean): this;
+        stop(): this;
+        flyTo(latlng: LatLngExpression, zoom?: number, options?: ZoomPanOptions): this;
+        flyToBounds(bounds: LatLngBoundsExpression, options?: FitBoundsOptions): this;
+
+        // Other methods
+        addHandler(name: string, HandlerClass: () => Handler): this;
+        remove(): this;
+        createPane(name: string, container?: HTMLElement): HTMLElement;
+        getPane(pane: string): HTMLElement;
+        getPane(pane: HTMLElement): HTMLElement;
+        getPanes(): {[name: string]: HTMLElement} & DefaultMapPanes;
+        getContainer(): HTMLElement;
+        whenReady(fn: () => void, context?: Object): this;
+
+        // Methods for getting map state
+        getCenter(): LatLng;
+        getZoom(): number;
+        getBounds(): LatLngBounds;
+        getMinZoom(): number;
+        getMaxZoom(): number;
+        getBoundsZoom(bounds: LatLngBoundsExpression, inside?: boolean): number;
+        getSize(): Point;
+        getPixelBounds(): Bounds;
+        getPixelOrigin(): Point;
+        getPixelWorldBounds(zoom?: number): Bounds;
+
+        // Conversion methods
+        getZoomScale(toZoom: number, fromZoom: number): number;
+        getScaleZoom(scale: number, fromZoom: number): number;
+        project(latlng: LatLngExpression, zoom: number): Point;
+        unproject(point: Point, zoom: number): LatLng;
+        layerPointToLatLng(point: PointExpression): LatLng;
+        latLngToLayerPoint(latlng: LatLngExpression): Point;
+        wrapLatLng(latlng: LatLngExpression): LatLng;
+        distance(latlng1: LatLngExpression, latlng2: LatLngExpression): number;
+        containerPointToLayerPoint(point: PointExpression): Point;
+        layerPointToContainerPoint(point: PointExpression): Point;
+        latLngToContainerPoint(latlng: LatLngExpression): Point;
+        mouseEventToContainerPoint(ev: MouseEvent): Point;
+        mouseEventToLayerPoint(ev: MouseEvent): Point;
+        mouseEventToLatLng(ev: MouseEvent): LatLng;
+
+        // Geolocation methods
+        locate(options?: LocateOptions): this;
+        stopLocate(): this;
+
+        // Properties
+        boxZoom: Handler;
+        doubleClickZoom: Handler;
+        dragging: Handler;
+        keyboard: Handler;
+        scrollWheelZoom: Handler;
+        tap: Handler;
+        touchZoom: Handler;
+    }
+
+    export function map(id: string, options?: MapOptions): Map;
+
+    export function map(el: HTMLElement, options?: MapOptions): Map;
+
+    export interface Icon {
+
+    }
+
+    export interface MarkerOptions extends InteractiveLayerOptions {
+        icon?: Icon;
+        draggable?: boolean;
+        keyboard?: boolean;
+        title?: string;
+        alt?: string;
+        zIndexOffset?: number;
+        opacity?: number;
+        riseOnHover?: boolean;
+        riseOffset?: number;
+    }
+
+    export interface Marker extends Layer {
+        getLatLng(): LatLng;
+        setLatLng(latlng: LatLngExpression): this;
+        setZIndexOffset(offset: number): this;
+        setIcon(icon: Icon): this;
+        setOpacity(opacity: number): this;
+
+        // Properties
+        dragging: Handler;
+    }
+
+    export function marker(latlng: LatLngExpression, options?: MarkerOptions): Marker;
+}
+
+declare module 'leaflet' {
+    export = L;
+}

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -12,36 +12,38 @@ declare namespace L {
 
     }
 
-    export interface LatLngObjectLiteral {
+    export interface LatLngLiteral {
         lat: number;
         lng: number;
     }
 
-    export type LatLngTupleLiteral = [number, number];
+    export type LatLngTuple = [number, number];
 
-    type LatLngExpression = LatLng | LatLngObjectLiteral | LatLngTupleLiteral;
+    type LatLngExpression = LatLng | LatLngLiteral | LatLngTuple;
 
     export interface LatLngBounds {
 
     }
 
-    export type LatLngBoundsLiteral = Array<LatLngTupleLiteral>;
+    export type LatLngBoundsLiteral = Array<LatLngTuple>;
 
     type LatLngBoundsExpression = LatLngBounds | LatLngBoundsLiteral;
 
-    export type PointLiteral = [number, number];
+    export type PointTuple = [number, number];
 
     export interface Point {
 
     }
 
-    type PointExpression = Point | PointLiteral;
+    type PointExpression = Point | PointTuple;
 
     export interface Bounds {
 
     }
 
-    type BoundsExpression = Bounds | Array<PointLiteral>;
+    export type BoundsLiteral = Array<PointTuple>;
+
+    type BoundsExpression = Bounds | BoundsLiteral;
 
     export interface Evented {
 
@@ -215,7 +217,7 @@ declare namespace L {
 
         // Panning inertia options
         inertia?: boolean;
-        inertiaDeceleration?: boolean;
+        inertiaDeceleration?: number;
         inertiaMaxSpeed?: number;
         easeLinearity?: number;
         worldCopyJump?: boolean;
@@ -223,16 +225,16 @@ declare namespace L {
 
         // Keyboard navigation options
         keyboard?: boolean;
-        keyboardPanDelta?: boolean;
+        keyboardPanDelta?: number;
 
         // Mousewheel options
-        scrollWheelZoom?: boolean;
+        scrollWheelZoom?: Zoom;
         wheelDebounceTime?: number;
         wheelPxPerZoomLevel?: number;
 
         // Touch interaction options
         tap?: boolean;
-        tapTolerance?: boolean;
+        tapTolerance?: number;
         touchZoom?: Zoom;
         bounceAtZoomLimits?: boolean;
     }
@@ -362,6 +364,8 @@ declare namespace L {
         openPopup(content: HTMLElement, latlng: LatLngExpression, options?: PopupOptions): this;
         closePopup(popup?: Popup): this;
         openTooltip(tooltip: Tooltip): this;
+        openTooltip(content: string, latlng: LatLngExpression, options?: TooltipOptions): this;
+        openTooltip(content: HTMLElement, latlng: LatLngExpression, options?: TooltipOptions): this;
         closeTooltip(tooltip?: Tooltip): this;
 
         // Methods for modifying map state
@@ -379,6 +383,7 @@ declare namespace L {
         setMinZoom(zoom: number): this;
         setMaxZoom(zoom: number): this;
         panInsideBounds(bounds: LatLngBoundsExpression, options?: PanOptions): this;
+        invalidateSize(options: ZoomPanOptions): this;
         invalidateSize(animate: boolean): this;
         stop(): this;
         flyTo(latlng: LatLngExpression, zoom?: number, options?: ZoomPanOptions): this;

--- a/mapbox/mapbox.d.ts
+++ b/mapbox/mapbox.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Maxime Fabre <https://github.com/anahkiasen/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../leaflet/leaflet.d.ts"/>
+/// <reference path="../leaflet/leaflet-0.7.d.ts"/>
 
 //////////////////////////////////////////////////////////////////////
 ///////////////////////////// MAP OBJECT /////////////////////////////


### PR DESCRIPTION
Addresses #10961 #11012.

This is still a work in progress. I'm posting it here since the API is huge and there may be people interested in starting to review it. Other sets of eyes are very welcome, since there may be typos, omissions, or errors in definitions. A lot is still missing, including tests and jsdoc.

API http://leafletjs.com/reference-1.0.0.html

case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
