### PR TITLE
Tweaked module exporting for Twilio API. (#10885)

### DIFF
--- a/twilio/twilio-tests.ts
+++ b/twilio/twilio-tests.ts
@@ -1,4 +1,4 @@
-import { twilio } from './twilio';
+import * as twilio from './twilio';
 
 // Examples taken from https://twilio.github.io/twilio-node/ (v2.1.0)
 

--- a/twilio/twilio.d.ts
+++ b/twilio/twilio.d.ts
@@ -12,11 +12,11 @@ import * as Http from 'http';
 
 import Q = require('q');
 
-export interface twilio {
+declare interface twilio {
   (sid?: string, tkn?: string, options?: twilio.ClientOptions): twilio.RestClient;
 }
 
-export module twilio {
+declare module twilio {
 
   // Composite Classes:
   //==============================
@@ -166,7 +166,7 @@ export module twilio {
     clientName: string;
     outgoingScopeParams: any;
     scopeParams: any;
-    
+
     constructor(sid?: string, tkn?: string);
 
     allowClientIncoming(clientName: string): Capability;
@@ -319,7 +319,7 @@ export module twilio {
     allowWorkerActivityUpdates(): void;
     allowWorkerFetchAttributes(): void;
     allowTaskReservationUpdates(): void;
-    
+
     addPolicy(url: string, method: string, allowed?: boolean, queryFilter?: any, postFilter?: any): void;
     allow(url: string, method: string, queryFilter?: any, postFilter?: any): void;
     deny(url: string, method: string, queryFilter?: any, postFilter?: any): void;
@@ -380,7 +380,7 @@ export module twilio {
   }
 
   export interface TwimlMethod { (arg1: any | string | TwimlCallback, arg2?: any | string | TwimlCallback): Node }
-  
+
   export interface TwimlCallback { (node?: Node): void; }
 
   export class Node implements NodeOptions {
@@ -435,7 +435,7 @@ export module twilio {
   export interface WebhookExpressOptions {
     // The full URL (with query string) you used to configure the webhook with Twilio - overrides host/protocol options
     url?: string;
-    
+
     // manually specify the host name used by Twilio in a number's webhook config
     host?: string;
 
@@ -871,5 +871,6 @@ export module twilio {
     originationUrls: OriginationURLResource;
   }
   export interface TrunkResource extends ListMappedResource<TrunkInstance> {}
-
 }
+
+export = twilio;


### PR DESCRIPTION
This commit simply cherry-picks a change that was already approved on master into the types-2.0 branch, as my understanding is that branch is used by the types-publisher to send the info to npm.
