### PR TITLE
Add confit typings

### DIFF
--- a/confit/confit-tests.ts
+++ b/confit/confit-tests.ts
@@ -1,0 +1,29 @@
+/// <reference path="./confit.d.ts" />
+import confit = require("confit");
+
+var basedir = "./config";
+
+confit(basedir).create(function (err, config) {
+    config.get("key");
+    config.set("key", 120);
+    config.use({});
+});
+
+confit(options)
+  .addDefault('./mydefaults.json')  //or .addDefault({foo: 'bar'})
+  .addOverride('./mysettings.json') //or .addOverride({foo: 'baz'})
+  .create(function (err, config) {
+      // ...
+  });
+
+var options = {
+    basedir: basedir,
+    protocols: <confit.ProtocolsSet>{
+        file: (value, cb) => { cb(); },
+        glob: (value) => {}
+    }
+};
+
+confit(options).create(function (err, config) {
+    // ...
+});

--- a/confit/confit.d.ts
+++ b/confit/confit.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for Confit 2.x
+// Project: https://github.com/krakenjs/confit
+// Definitions by: Ethan Resnick <https://github.com/ethanresnick/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "confit" {
+  interface ProtocolsSetPrivate {
+    [protocol:string] : (value:any, callback?:any) => void
+  }
+
+  interface ConfigStore {
+    get(name: string): any;
+    set<T>(name: string, newValue: T): T;
+    use(newSettings: Object): void;
+  }
+
+  type options = {
+    basedir: string;
+    protocols: ProtocolsSetPrivate
+  }
+
+  interface ConfigFactory {
+    create(callback: (err: any, config: ConfigStore) => any) : void;
+    addOverride(filepathOrSettingsObj: string|Object): this;
+    addDefault(filepathOrSettingsObj: string|Object): this;
+  }
+
+  function confit(optionsOrBaseDir: options|string): ConfigFactory;
+
+  namespace confit {
+    export interface ProtocolsSet extends ProtocolsSetPrivate {}
+  }
+
+  export = confit;
+}


### PR DESCRIPTION
Typings for [confit](https://www.npmjs.com/package/confit).

case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
