### PR TITLE
Add types for point-in-polygon

### DIFF
--- a/point-in-polygon/point-in-polygon-tests.ts
+++ b/point-in-polygon/point-in-polygon-tests.ts
@@ -1,0 +1,6 @@
+/// <reference path="point-in-polygon.d.ts" />
+
+import inside from 'point-in-polygon';
+
+const polygon = [ [ 1, 1 ], [ 1, 2 ], [ 2, 2 ], [ 2, 1 ] ];
+const inPolygon: boolean = inside([ 1.5, 1.5 ], polygon);

--- a/point-in-polygon/point-in-polygon.d.ts
+++ b/point-in-polygon/point-in-polygon.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for point-in-polygon
+// Project: https://github.com/substack/point-in-polygon
+// Definitions by: kogai <https://github.com/kogai>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'point-in-polygon' {
+    export default function inside(point: number[], polygon: number[][]): boolean;
+}


### PR DESCRIPTION
add types for [point-in-polygon](https://github.com/substack/point-in-polygon)

case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
