### PR TITLE
[node] Delete deprecated functions

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1019,8 +1019,6 @@ declare module "os" {
     export function arch(): string;
     export function platform(): string;
     export function tmpdir(): string;
-    export function tmpDir(): string;
-    export function getNetworkInterfaces(): { [index: string]: NetworkInterfaceInfo[] };
     export var EOL: string;
     export function endianness(): "BE" | "LE";
 }


### PR DESCRIPTION
# The purposes of PR
- `tmpDir` is deprecated. Please refer to [tmpDir in Nodejs source code](https://github.com/nodejs/node/blob/master/lib/os.js#L54).
- `getNetworkInterfaces` is deprecated. Please refer to [getNetworkInterfaces in Nodejs source code](https://github.com/nodejs/node/blob/master/lib/os.js#L57).
