### PR TITLE
[node] Correct assert.fail parameters

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -2598,7 +2598,7 @@ declare module "assert" {
             });
         }
 
-        export function fail(actual?: any, expected?: any, message?: string, operator?: string): void;
+        export function fail(actual: any, expected: any, message: string, operator: string): void;
         export function ok(value: any, message?: string): void;
         export function equal(actual: any, expected: any, message?: string): void;
         export function notEqual(actual: any, expected: any, message?: string): void;


### PR DESCRIPTION
# Improvement to existing type definition.
- It should be [assert.fail(actual, expected, message, operator)](https://nodejs.org/api/assert.html#assert_assert_fail_actual_expected_message_operator), not all parameters are optional.
