### PR TITLE
[node] Correct NodeBuffer.toJSON type

### DIFF
--- a/node/node-4.d.ts
+++ b/node/node-4.d.ts
@@ -430,7 +430,7 @@ declare namespace NodeJS {
 interface NodeBuffer extends Uint8Array {
     write(string: string, offset?: number, length?: number, encoding?: string): number;
     toString(encoding?: string, start?: number, end?: number): string;
-    toJSON(): any;
+    toJSON(): {type: 'Buffer', data: any[]};
     equals(otherBuffer: Buffer): boolean;
     compare(otherBuffer: Buffer): number;
     copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -464,7 +464,7 @@ interface IterableIterator<T> {}
 interface NodeBuffer extends Uint8Array {
     write(string: string, offset?: number, length?: number, encoding?: string): number;
     toString(encoding?: string, start?: number, end?: number): string;
-    toJSON(): any;
+    toJSON(): {type: 'Buffer', data: any[]};
     equals(otherBuffer: Buffer): boolean;
     compare(otherBuffer: Buffer, targetStart?: number, targetEnd?: number, sourceStart?: number, sourceEnd?: number): number;
     copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;


### PR DESCRIPTION
# Improvement to existing type definition

Refer to [Buffer. toJSON() in Nodejs v6.x source code](https://github.com/nodejs/node/blob/master/lib/buffer.js#L789) and [Buffer. toJSON() in Nodejs v6.x source code](https://github.com/nodejs/node/blob/v4.x/lib/buffer.js#L663). It should return `{type: 'Buffer', data: any[]};`
