### PR TITLE
Must be "tooltips" (plurar) instead of "tooltip"

### DIFF
--- a/chart.js/chart.js.d.ts
+++ b/chart.js/chart.js.d.ts
@@ -73,7 +73,7 @@ interface ChartOptions {
     onClick?: (any?: any) => any;
     title?: ChartTitleOptions;
     legend?: ChartLegendOptions;
-    tooltip?: ChartTooltipOptions;
+    tooltips?: ChartTooltipOptions;
     hover?: ChartHoverOptions;
     animation?: ChartAnimationOptions;
     elements?: ChartElementsOptions;


### PR DESCRIPTION
...must be "tooltips" (plurar) instead of "tooltip" in ChartOptions

My custom callback given in "ChartTooltipOptions.custom" was never called... :/ "tooltips" (plurar) is OK

Take a look @ http://www.chartjs.org/docs/#advanced-usage-external-tooltips
