### PR TITLE
Added definition for the missing dns.setServers(servers) method

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1398,13 +1398,18 @@ declare module "url" {
 }
 
 declare module "dns" {
+    export interface MxRecord {
+        exchange: string,
+        priority: number
+    }
+
     export function lookup(domain: string, family: number, callback: (err: Error, address: string, family: number) => void): string;
     export function lookup(domain: string, callback: (err: Error, address: string, family: number) => void): string;
     export function resolve(domain: string, rrtype: string, callback: (err: Error, addresses: string[]) => void): string[];
     export function resolve(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
     export function resolve4(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
     export function resolve6(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
-    export function resolveMx(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
+    export function resolveMx(domain: string, callback: (err: Error, addresses: MxRecord[]) =>void ): string[];
     export function resolveTxt(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
     export function resolveSrv(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
     export function resolveNs(domain: string, callback: (err: Error, addresses: string[]) => void): string[];

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1410,6 +1410,7 @@ declare module "dns" {
     export function resolveNs(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
     export function resolveCname(domain: string, callback: (err: Error, addresses: string[]) => void): string[];
     export function reverse(ip: string, callback: (err: Error, domains: string[]) => void): string[];
+    export function setServers(servers: string[]): void;
 
     //Error codes
     export var NODATA: string;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Method is documented here:
https://nodejs.org/docs/latest/api/dns.html#dns_dns_setservers_servers
