### PR TITLE
[Node.d.ts]: Update definitions for module "crypto"

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -2436,6 +2436,7 @@ declare module "crypto" {
         setPrivateKey(private_key: string, encoding: HexBase64Latin1Encoding): void;
     }
     export function createECDH(curve_name: string): ECDH;
+    export var DEFAULT_ENCODING: string;
 }
 
 declare module "stream" {


### PR DESCRIPTION
case 2. Improvement to existing type definition.

This pull request adds the constant [DEFAULT_ENCODING](https://nodejs.org/dist/latest-v6.x/docs/api/crypto.html#crypto_crypto_default_encoding) to node.d.ts' module "crypto"
