### PR TITLE
AppBar type fix

### DIFF
--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -513,8 +513,8 @@ declare namespace __MaterialUI {
         iconClassNameRight?: string;
         iconElementLeft?: React.ReactElement<any>;
         iconElementRight?: React.ReactElement<any>;
-        iconStyleRight?: string;
-        iconStyleLeft?: string;
+        iconStyleRight?: React.CSSProperties;
+        iconStyleLeft?: React.CSSProperties;
         onLeftIconButtonTouchTap?: TouchTapEventHandler;
         onRightIconButtonTouchTap?: TouchTapEventHandler;
         onTitleTouchTap?: TouchTapEventHandler;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
Isn't it obvious, it doesn't need a link to a doc or whatever, but what the heck: [App Bar - Material-UI](http://www.material-ui.com/#/components/app-bar).

///
Styles should be CSS properties not string. :wink: 
