### PR TITLE
videojs corrections

### DIFF
--- a/videojs/videojs.d.ts
+++ b/videojs/videojs.d.ts
@@ -44,9 +44,11 @@ interface VideoJSPlayer {
 	size(width: number, height: number): VideoJSPlayer;
 	requestFullScreen(): VideoJSPlayer;
 	cancelFullScreen(): VideoJSPlayer;
-	ready(callback: () => void ): void;
-	on(eventName: string, callback: () => void ): void;
+	ready(callback: () => void ): VideoJSPlayer;
+	on(eventName: string, callback: (eventObject: Event) => void ): void;
 	off(eventName: string, callback: () => void ): void;
+	off(eventName: string): void;
+	off(): void;
 	dispose(): void;
 	addRemoteTextTrack(options : {}) : HTMLTrackElement;
 	removeRemoteTextTrack(track : HTMLTrackElement) : void;


### PR DESCRIPTION
Improvement to existing type definition - videojs.
- ready() is chainable
  http://docs.videojs.com/docs/api/video.html#Methodsready
  https://github.com/videojs/video.js/blob/master/src/js/component.js#L787
- on() will provide event object to callback
  http://docs.videojs.com/docs/api/video.html#Methodson
- off() can be called without callback and without event name
  http://docs.videojs.com/docs/api/video.html#Methodsoff
