### PR TITLE
Add Atom Grammars

### DIFF
--- a/atom/atom.d.ts
+++ b/atom/atom.d.ts
@@ -946,9 +946,14 @@ declare namespace AtomCore {
 		registry: any;
 		repository: Object;
 		scopeName: string;
+		tokenizeLines: (text: string) => any;
 		// TBD
 
 	}
+	
+	  interface IGrammars {
+    		grammarForScopeName(scope: string): IGrammar;
+  	}
 
 	interface IPane /* extends Theorist.Model */ {
 		itemForURI: (uri:string)=>IEditor;
@@ -1302,6 +1307,7 @@ declare namespace AtomCore {
 		deserializers:IDeserializerManager;
 		config: IConfig;
 		commands: ICommandRegistry;
+		grammars: IGrammars;
 		keymaps: IKeymapManager;
 		keymap: IKeymapManager;
 		packages: IPackageManager;


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

See [Atom Grammar Registry Docs](https://atom.io/docs/api/v1.10.2/GrammarRegistry).

Atom grammars can be found by typings `atom.grammars` into the console.
