### PR TITLE
Fix `redux-promise` export

### DIFF
--- a/redux-promise/redux-promise-tests.ts
+++ b/redux-promise/redux-promise-tests.ts
@@ -4,7 +4,7 @@
 
 import {createAction} from 'redux-actions';
 import { createStore, applyMiddleware, PromiseAction } from 'redux';
-import promise from 'redux-promise';
+import promise = require('redux-promise');
 
 declare var userReducer: any;
 

--- a/redux-promise/redux-promise.d.ts
+++ b/redux-promise/redux-promise.d.ts
@@ -19,5 +19,5 @@ declare namespace ReduxPromise {
 
 declare module "redux-promise" {
 	var promise: ReduxPromise.Promise;
-	export default promise;
+	export = promise;
 }


### PR DESCRIPTION
`redux-promise` is using an old version of Babel which transpiles
`default` export to:

``` js
exports['default'] = promiseMiddleware;
module.exports = promiseMiddleware;
```

Fix the declaration file to respect this.
