### PR TITLE
[types-2.0] d3-array (Test Adjustment)

### DIFF
--- a/d3-array/d3-array-tests.ts
+++ b/d3-array/d3-array-tests.ts
@@ -154,7 +154,7 @@ extentNum = d3Array.extent(numbersArray);
 extentStr = d3Array.extent(stringyNumbersArray);
 extentNumeric = d3Array.extent(numericArray);
 extentDate = d3Array.extent(dateArray);
-extentMixed = d3Array.extent([new NumCoercible(10), 13, '12', true]);
+extentMixed = d3Array.extent<NumCoercible>([new NumCoercible(10), 13, '12', true]);
 
 // with accessors
 


### PR DESCRIPTION
Change to existing definitions test for **d3-array**. This is related to the issue flagged by @aleung in PR #11184 .

@RyanCavanaugh 

**This is considered a temporary fix so that the DT/types-2.0 branch stays intact for other merges.**

However, the reason for the error flagged in the latest DefinitelyTyped Test Runner may be due to a regression in TypeScript@next (2.1.0-dev.20160912 or 2.1.0-dev.20160913).

The definition for the `extent(...)` function includes the following overload:

```
/**
 * Return the min and max simultaneously.
 */
export function extent<T extends Numeric>(array: Array<T | Primitive>): [T | Primitive, T | Primitive] | [undefined, undefined];
```

The now failing test seems due to the fact that `T` is no longer inferred as `NumCoercible`, but only as `Numeric`.

_Applied temporary fix:_
- Add explicit typing to an `extent` test with mixed array including NumCoercible. 
