### PR TITLE
common-tags: use TemplateStringsArray type for typescript 2.0

### DIFF
--- a/common-tags/common-tags.d.ts
+++ b/common-tags/common-tags.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module 'common-tags' {
-    type TemplateTag = (literals: string[], ...placeholders: any[]) => string;
+    type TemplateTag = (literals: TemplateStringsArray, ...placeholders: any[]) => string;
 
     type TemplateTransformer = {
         onSubstitution?: (substitution: string, resultSoFar: string) => string;


### PR DESCRIPTION
After upgrading to typescript@rc, I've been met with a bunch of errors like this:

```
error TS2345: Argument of type 'TemplateStringsArray' is not assignable to parameter of type 'string[]'.
  Property 'push' is missing in type 'TemplateStringsArray'.
```

This PR makes common-tags use the TemplateStringsArray type to ensure compat with typescript 2.0.

@zuzusik
