### PR TITLE
Added type definitions for new module canvas-gauges

### DIFF
--- a/canvas-gauges/canvas-gauges-tests.ts
+++ b/canvas-gauges/canvas-gauges-tests.ts
@@ -1,5 +1,12 @@
 /// <reference path="canvas-gauges.d.ts" />
 
+import {
+    LinearGaugeOptions,
+    RadialGaugeOptions,
+    LinearGauge,
+    RadialGauge
+} from 'canvas-gauges';
+
 let linearOptions: LinearGaugeOptions = {
     renderTo: document.createElement('canvas')
 };
@@ -9,3 +16,5 @@ let radialOptions: RadialGaugeOptions = {
 
 new LinearGauge(linearOptions);
 new RadialGauge(radialOptions);
+
+console.log(document.gauges.length);

--- a/canvas-gauges/canvas-gauges-tests.ts
+++ b/canvas-gauges/canvas-gauges-tests.ts
@@ -1,0 +1,11 @@
+/// <reference path="canvas-gauges.d.ts" />
+
+let linearOptions: LinearGaugeOptions = {
+    renderTo: document.createElement('canvas')
+};
+let radialOptions: RadialGaugeOptions = {
+    renderTo: 'gauge-id'
+};
+
+new LinearGauge(linearOptions);
+new RadialGauge(radialOptions);

--- a/canvas-gauges/canvas-gauges.d.ts
+++ b/canvas-gauges/canvas-gauges.d.ts
@@ -3,249 +3,261 @@
 // Definitions by: Mikhus <ttps://github.com/Mikhus>
 // Definitions: https://github.com/Mikhus/DefinitelyTyped
 
-declare type RenderTarget = string|HTMLElement;
+declare namespace CanvasGauges {
+    export type RenderTarget = string|HTMLElement;
 
-interface AnimationRule {
-    (percent: number): number;
+    export interface AnimationRule {
+        (percent: number): number;
+    }
+
+    export interface Highlight {
+        from: number,
+        to: number,
+        color: string
+    }
+
+    export type MajorTicks = string[]|number[];
+
+    export interface GenericOptions {
+        renderTo: RenderTarget,
+        width?: number,
+        height?: number,
+        minValue?: number,
+        maxValue?: number,
+        value?: number,
+        units?: string|boolean,
+        majorTicks?: MajorTicks,
+        minorTicks?: number,
+        strokeTicks?: boolean,
+        animatedValue?: boolean,
+        title?: string|boolean,
+        borders?: boolean,
+        valueInt?: number,
+        valueDec?: number,
+        majorTicksInt?: number,
+        majorTicksDec?: number,
+        animation?: boolean,
+        animationDuration?: number,
+        animationRule?: string|AnimationRule,
+        colorPlate?: string,
+        colorMajorTicks?: string,
+        colorMinorTicks?: string,
+        colorTitle?: string,
+        colorUnits?: string,
+        colorNumbers?: string,
+        colorNeedle?: string,
+        colorNeedleEnd?: string,
+        colorValueText?: string,
+        colorValueTextShadow?: string,
+        colorBorderShadow?: string,
+        colorBorderOuter?: string,
+        colorBorderOuterEnd?: string,
+        colorBorderMiddle?: string,
+        colorBorderMiddleEnd?: string,
+        colorBorderInner?: string,
+        colorBorderInnerEnd?: string,
+        colorValueBoxRect?: string,
+        colorValueBoxRectEnd?: string,
+        colorValueBoxBackground?: string,
+        colorValueBoxShadow?: string,
+        colorNeedleShadowUp?: string,
+        colorNeedleShadowDown?: string,
+        needle?: boolean,
+        needleShadow?: boolean,
+        needleType?: string,
+        needleStart?: number,
+        needleEnd?: number,
+        needleWidth?: number,
+        borderOuterWidth?: number,
+        borderMiddleWidth?: number,
+        borderInnerWidth?: number,
+        borderShadowWidth?: number,
+        valueBox?: boolean,
+        valueBoxStroke?: number,
+        valueText?: string,
+        valueTextShadow?: boolean,
+        valueBoxBorderRadius?: number,
+        highlights?: Highlight[],
+        fontNumbers?: string,
+        fontTitle?: string,
+        fontUnits?: string,
+        fontValue?: string,
+        fontTitleSize?: number,
+        fontValueSize?: number,
+        fontUnitsSize?: number,
+        fontNumbersSize?: number
+    }
+
+    export interface RadialGaugeOptions extends GenericOptions {
+        ticksAngle?: number,
+        startAngle?: number,
+        colorNeedleCircleOuter?: string,
+        colorNeedleCircleOuterEnd?: string,
+        colorNeedleCircleInner?: string,
+        colorNeedleCircleInnerEnd?: string,
+        needleCircleSize?: number,
+        needleCircleInner?: boolean,
+        needleCircleOuter?: boolean,
+        animationTarget?: string
+    }
+
+    export interface LinearGaugeOptions extends GenericOptions {
+        borderRadius?: number,
+        barBeginCircle?: number,
+        barWidth?: number,
+        barStrokeWidth?: number,
+        barProgress?: boolean,
+        colorBar?: string,
+        colorBarEnd?: string,
+        colorBarStroke?: string,
+        colorBarProgress?: string,
+        colorBarProgressEnd?: string,
+        tickSide?: string,
+        needleSide?: string,
+        numberSide?: string,
+        ticksWidth?: number,
+        ticksWidthMinor?: number,
+        ticksPadding?: number,
+        barLength?: number
+    }
+
+    export interface DrawEventCallback {
+        (percent: number): any;
+    }
+
+    export interface EndEventCallback {
+        (): any;
+    }
+
+    export interface rules {
+        linear: AnimationRule,
+        quad: AnimationRule,
+        dequad: AnimationRule,
+        quint: AnimationRule,
+        dequint: AnimationRule,
+        cycle: AnimationRule,
+        decycle: AnimationRule,
+        bounce: AnimationRule,
+        debounce: AnimationRule,
+        elastic: AnimationRule,
+        delastic: AnimationRule
+    }
+
+    export class Animation {
+        public duration: number;
+        public rule: string|AnimationRule;
+        public draw: DrawEventCallback;
+        public end: EndEventCallback;
+
+        public static rules: rules;
+
+        constructor(rule?: string|AnimationRule, duration?: number,
+                    draw?: DrawEventCallback, end?: EndEventCallback);
+
+        public animate(draw?: DrawEventCallback, end?: EndEventCallback): any;
+        public destroy(): any;
+    }
+
+    export class SmartCanvas {
+        public element: HTMLCanvasElement;
+        public elementClone: HTMLCanvasElement;
+        public context: CanvasRenderingContext2D;
+        public contextClone: CanvasRenderingContext2D;
+        public drawWidth: number;
+        public drawHeight: number;
+        public drawX: number;
+        public drawY: number;
+        public minSide: number;
+        public width: number;
+        public height: number;
+
+        constructor(element: HTMLCanvasElement,
+                    width?: number,
+                    height?: number);
+
+        public init(): any;
+        public onRedraw(): any;
+        public destroy(): any;
+        public commit(): SmartCanvas;
+        public redraw(): SmartCanvas;
+
+        public pixelRatio: number;
+        public static redraw(): any;
+        public static collection: Array<SmartCanvas>;
+    }
+
+    export class DomObserver {
+        public Type: BaseGauge;
+        public mutationsObserved: boolean;
+        public isObservable: boolean;
+        public options: GenericOptions;
+        public element: string;
+        public type: string;
+
+        constructor(options: GenericOptions,
+                    element: string,
+                    type: string);
+
+        public isValidNode(node: Node|HTMLElement): boolean;
+        public traverse(): any;
+        public observe(records: MutationRecord[]): any;
+        public process(node: Node|HTMLElement): BaseGauge;
+
+        public static parse(value: any): any;
+        public static toDashed(camelCase: string): string;
+        public static toAttributeName(str: string): string;
+        static domReady(handler: Function): any;
+    }
+
+    export abstract class BaseGauge {
+        public type: BaseGauge;
+        public options: GenericOptions;
+        public canvas: SmartCanvas;
+        public animation: Animation;
+        public value: number;
+
+        constructor(options: GenericOptions);
+
+        public update(options: GenericOptions): BaseGauge;
+        public destroy(): any;
+        public abstract draw(): BaseGauge;
+
+        public static initialize(type: string, options: GenericOptions): any;
+    }
+
+    export class RadialGauge extends BaseGauge {
+        public type: RadialGauge;
+        public options: RadialGaugeOptions;
+
+        constructor(options: RadialGaugeOptions);
+
+        public draw(): RadialGauge;
+    }
+
+    export class LinearGauge extends BaseGauge {
+        public type: LinearGauge;
+        public options: LinearGaugeOptions;
+
+        constructor(options: LinearGaugeOptions);
+
+        public draw(): LinearGauge;
+    }
+
+    export interface Collection extends Array<BaseGauge> {
+        get: (id: number | string) => BaseGauge;
+    }
 }
 
-interface Highlight {
-    from: number,
-    to: number,
-    color: string
+declare module 'canvas-gauges' {
+    export = CanvasGauges;
 }
 
-declare type MajorTicks = string[]|number[];
-
-interface GenericOptions {
-    renderTo: RenderTarget,
-    width?: number,
-    height?: number,
-    minValue?: number,
-    maxValue?: number,
-    value?: number,
-    units?: string|boolean,
-    majorTicks?: MajorTicks,
-    minorTicks?: number,
-    strokeTicks?: boolean,
-    animatedValue?: boolean,
-    title?: string|boolean,
-    borders?: boolean,
-    valueInt?: number,
-    valueDec?: number,
-    majorTicksInt?: number,
-    majorTicksDec?: number,
-    animation?: boolean,
-    animationDuration?: number,
-    animationRule?: string|AnimationRule,
-    colorPlate?: string,
-    colorMajorTicks?: string,
-    colorMinorTicks?: string,
-    colorTitle?: string,
-    colorUnits?: string,
-    colorNumbers?: string,
-    colorNeedle?: string,
-    colorNeedleEnd?: string,
-    colorValueText?: string,
-    colorValueTextShadow?: string,
-    colorBorderShadow?: string,
-    colorBorderOuter?: string,
-    colorBorderOuterEnd?: string,
-    colorBorderMiddle?: string,
-    colorBorderMiddleEnd?: string,
-    colorBorderInner?: string,
-    colorBorderInnerEnd?: string,
-    colorValueBoxRect?: string,
-    colorValueBoxRectEnd?: string,
-    colorValueBoxBackground?: string,
-    colorValueBoxShadow?: string,
-    colorNeedleShadowUp?: string,
-    colorNeedleShadowDown?: string,
-    needle?: boolean,
-    needleShadow?: boolean,
-    needleType?: string,
-    needleStart?: number,
-    needleEnd?: number,
-    needleWidth?: number,
-    borderOuterWidth?: number,
-    borderMiddleWidth?: number,
-    borderInnerWidth?: number,
-    borderShadowWidth?: number,
-    valueBox?: boolean,
-    valueBoxStroke?: number,
-    valueText?: string,
-    valueTextShadow?: boolean,
-    valueBoxBorderRadius?: number,
-    highlights?: Highlight[],
-    fontNumbers?: string,
-    fontTitle?: string,
-    fontUnits?: string,
-    fontValue?: string,
-    fontTitleSize?: number,
-    fontValueSize?: number,
-    fontUnitsSize?: number,
-    fontNumbersSize?: number
+interface Document {
+    gauges: CanvasGauges.Collection;
 }
 
-interface RadialGaugeOptions extends GenericOptions {
-    ticksAngle?: number,
-    startAngle?: number,
-    colorNeedleCircleOuter?: string,
-    colorNeedleCircleOuterEnd?: string,
-    colorNeedleCircleInner?: string,
-    colorNeedleCircleInnerEnd?: string,
-    needleCircleSize?: number,
-    needleCircleInner?: boolean,
-    needleCircleOuter?: boolean,
-    animationTarget?: string
-}
-
-interface LinearGaugeOptions extends GenericOptions {
-    borderRadius?: number,
-    barBeginCircle?: number,
-    barWidth?: number,
-    barStrokeWidth?: number,
-    barProgress?: boolean,
-    colorBar?: string,
-    colorBarEnd?: string,
-    colorBarStroke?: string,
-    colorBarProgress?: string,
-    colorBarProgressEnd?: string,
-    tickSide?: string,
-    needleSide?: string,
-    numberSide?: string,
-    ticksWidth?: number,
-    ticksWidthMinor?: number,
-    ticksPadding?: number,
-    barLength?: number
-}
-
-interface DrawEventCallback {
-    (percent: number): any;
-}
-
-interface EndEventCallback {
-    (): any;
-}
-
-interface rules {
-    linear: AnimationRule,
-    quad: AnimationRule,
-    dequad: AnimationRule,
-    quint: AnimationRule,
-    dequint: AnimationRule,
-    cycle: AnimationRule,
-    decycle: AnimationRule,
-    bounce: AnimationRule,
-    debounce: AnimationRule,
-    elastic: AnimationRule,
-    delastic: AnimationRule
-}
-
-declare class Animation {
-    public duration: number;
-    public rule: string|AnimationRule;
-    public draw: DrawEventCallback;
-    public end: EndEventCallback;
-
-    public static rules: rules;
-
-    constructor(rule?: string|AnimationRule, duration?: number,
-                draw?: DrawEventCallback, end?: EndEventCallback);
-
-    public animate(draw?: DrawEventCallback, end?: EndEventCallback): any;
-    public destroy(): any;
-}
-
-declare class SmartCanvas {
-    public element: HTMLCanvasElement;
-    public elementClone: HTMLCanvasElement;
-    public context: CanvasRenderingContext2D;
-    public contextClone: CanvasRenderingContext2D;
-    public drawWidth: number;
-    public drawHeight: number;
-    public drawX: number;
-    public drawY: number;
-    public minSide: number;
-    public width: number;
-    public height: number;
-
-    constructor(element: HTMLCanvasElement,
-                width?: number,
-                height?: number);
-
-    public init(): any;
-    public onRedraw(): any;
-    public destroy(): any;
-    public commit(): SmartCanvas;
-    public redraw(): SmartCanvas;
-
-    public pixelRatio: number;
-    public static redraw(): any;
-    public static collection: Array<SmartCanvas>;
-}
-
-declare class DomObserver {
-    public Type: BaseGauge;
-    public mutationsObserved: boolean;
-    public isObservable: boolean;
-    public options: GenericOptions;
-    public element: string;
-    public type: string;
-
-    constructor(options: GenericOptions,
-                element: string,
-                type: string);
-
-    public isValidNode(node: Node|HTMLElement): boolean;
-    public traverse(): any;
-    public observe(records: MutationRecord[]): any;
-    public process(node: Node|HTMLElement): BaseGauge;
-
-    public static parse(value: any): any;
-    public static toDashed(camelCase: string): string;
-    public static toAttributeName(str: string): string;
-    static domReady(handler: Function): any;
-}
-
-declare abstract class BaseGauge {
-    public type: BaseGauge;
-    public options: GenericOptions;
-    public canvas: SmartCanvas;
-    public animation: Animation;
-    public value: number;
-
-    constructor(options: GenericOptions);
-
-    public update(options: GenericOptions): BaseGauge;
-    public destroy(): any;
-    public abstract draw(): BaseGauge;
-
-    public static initialize(type: string, options: GenericOptions): any;
-}
-
-declare class RadialGauge extends BaseGauge {
-    public type: RadialGauge;
-    public options: RadialGaugeOptions;
-
-    constructor(options: RadialGaugeOptions);
-
-    public draw(): RadialGauge;
-}
-
-declare class LinearGauge extends BaseGauge {
-    public type: LinearGauge;
-    public options: LinearGaugeOptions;
-
-    constructor(options: LinearGaugeOptions);
-
-    public draw(): LinearGauge;
-}
-
-interface Collection extends Array<BaseGauge> {
-    get: (id: number | string) => BaseGauge;
-}
-
-interface DocumentWithGauges extends Document {
-    gauges: Collection
+interface Window {
+    BaseGauge: CanvasGauges.BaseGauge;
+    RadialGauge: CanvasGauges.RadialGauge;
+    LinearGauge: CanvasGauges.LinearGauge;
 }

--- a/canvas-gauges/canvas-gauges.d.ts
+++ b/canvas-gauges/canvas-gauges.d.ts
@@ -1,0 +1,251 @@
+// Type definitions for canvas-gauges
+// Project: https://github.com/Mikhus/canvas-gauges
+// Definitions by: Mikhus <ttps://github.com/Mikhus>
+// Definitions: https://github.com/Mikhus/DefinitelyTyped
+
+declare type RenderTarget = string|HTMLElement;
+
+interface AnimationRule {
+    (percent: number): number;
+}
+
+interface Highlight {
+    from: number,
+    to: number,
+    color: string
+}
+
+declare type MajorTicks = string[]|number[];
+
+interface GenericOptions {
+    renderTo: RenderTarget,
+    width?: number,
+    height?: number,
+    minValue?: number,
+    maxValue?: number,
+    value?: number,
+    units?: string|boolean,
+    majorTicks?: MajorTicks,
+    minorTicks?: number,
+    strokeTicks?: boolean,
+    animatedValue?: boolean,
+    title?: string|boolean,
+    borders?: boolean,
+    valueInt?: number,
+    valueDec?: number,
+    majorTicksInt?: number,
+    majorTicksDec?: number,
+    animation?: boolean,
+    animationDuration?: number,
+    animationRule?: string|AnimationRule,
+    colorPlate?: string,
+    colorMajorTicks?: string,
+    colorMinorTicks?: string,
+    colorTitle?: string,
+    colorUnits?: string,
+    colorNumbers?: string,
+    colorNeedle?: string,
+    colorNeedleEnd?: string,
+    colorValueText?: string,
+    colorValueTextShadow?: string,
+    colorBorderShadow?: string,
+    colorBorderOuter?: string,
+    colorBorderOuterEnd?: string,
+    colorBorderMiddle?: string,
+    colorBorderMiddleEnd?: string,
+    colorBorderInner?: string,
+    colorBorderInnerEnd?: string,
+    colorValueBoxRect?: string,
+    colorValueBoxRectEnd?: string,
+    colorValueBoxBackground?: string,
+    colorValueBoxShadow?: string,
+    colorNeedleShadowUp?: string,
+    colorNeedleShadowDown?: string,
+    needle?: boolean,
+    needleShadow?: boolean,
+    needleType?: string,
+    needleStart?: number,
+    needleEnd?: number,
+    needleWidth?: number,
+    borderOuterWidth?: number,
+    borderMiddleWidth?: number,
+    borderInnerWidth?: number,
+    borderShadowWidth?: number,
+    valueBox?: boolean,
+    valueBoxStroke?: number,
+    valueText?: string,
+    valueTextShadow?: boolean,
+    valueBoxBorderRadius?: number,
+    highlights?: Highlight[],
+    fontNumbers?: string,
+    fontTitle?: string,
+    fontUnits?: string,
+    fontValue?: string,
+    fontTitleSize?: number,
+    fontValueSize?: number,
+    fontUnitsSize?: number,
+    fontNumbersSize?: number
+}
+
+interface RadialGaugeOptions extends GenericOptions {
+    ticksAngle?: number,
+    startAngle?: number,
+    colorNeedleCircleOuter?: string,
+    colorNeedleCircleOuterEnd?: string,
+    colorNeedleCircleInner?: string,
+    colorNeedleCircleInnerEnd?: string,
+    needleCircleSize?: number,
+    needleCircleInner?: boolean,
+    needleCircleOuter?: boolean,
+    animationTarget?: string
+}
+
+interface LinearGaugeOptions extends GenericOptions {
+    borderRadius?: number,
+    barBeginCircle?: number,
+    barWidth?: number,
+    barStrokeWidth?: number,
+    barProgress?: boolean,
+    colorBar?: string,
+    colorBarEnd?: string,
+    colorBarStroke?: string,
+    colorBarProgress?: string,
+    colorBarProgressEnd?: string,
+    tickSide?: string,
+    needleSide?: string,
+    numberSide?: string,
+    ticksWidth?: number,
+    ticksWidthMinor?: number,
+    ticksPadding?: number,
+    barLength?: number
+}
+
+interface DrawEventCallback {
+    (percent: number): any;
+}
+
+interface EndEventCallback {
+    (): any;
+}
+
+interface rules {
+    linear: AnimationRule,
+    quad: AnimationRule,
+    dequad: AnimationRule,
+    quint: AnimationRule,
+    dequint: AnimationRule,
+    cycle: AnimationRule,
+    decycle: AnimationRule,
+    bounce: AnimationRule,
+    debounce: AnimationRule,
+    elastic: AnimationRule,
+    delastic: AnimationRule
+}
+
+declare class Animation {
+    public duration: number;
+    public rule: string|AnimationRule;
+    public draw: DrawEventCallback;
+    public end: EndEventCallback;
+
+    public static rules: rules;
+
+    constructor(rule?: string|AnimationRule, duration?: number,
+                draw?: DrawEventCallback, end?: EndEventCallback);
+
+    public animate(draw?: DrawEventCallback, end?: EndEventCallback): any;
+    public destroy(): any;
+}
+
+declare class SmartCanvas {
+    public element: HTMLCanvasElement;
+    public elementClone: HTMLCanvasElement;
+    public context: CanvasRenderingContext2D;
+    public contextClone: CanvasRenderingContext2D;
+    public drawWidth: number;
+    public drawHeight: number;
+    public drawX: number;
+    public drawY: number;
+    public minSide: number;
+    public width: number;
+    public height: number;
+
+    constructor(element: HTMLCanvasElement,
+                width?: number,
+                height?: number);
+
+    public init(): any;
+    public onRedraw(): any;
+    public destroy(): any;
+    public commit(): SmartCanvas;
+    public redraw(): SmartCanvas;
+
+    public pixelRatio: number;
+    public static redraw(): any;
+    public static collection: Array<SmartCanvas>;
+}
+
+declare class DomObserver {
+    public Type: BaseGauge;
+    public mutationsObserved: boolean;
+    public isObservable: boolean;
+    public options: GenericOptions;
+    public element: string;
+    public type: string;
+
+    constructor(options: GenericOptions,
+                element: string,
+                type: string);
+
+    public isValidNode(node: Node|HTMLElement): boolean;
+    public traverse(): any;
+    public observe(records: MutationRecord[]): any;
+    public process(node: Node|HTMLElement): BaseGauge;
+
+    public static parse(value: any): any;
+    public static toDashed(camelCase: string): string;
+    public static toAttributeName(str: string): string;
+    static domReady(handler: Function): any;
+}
+
+declare abstract class BaseGauge {
+    public type: BaseGauge;
+    public options: GenericOptions;
+    public canvas: SmartCanvas;
+    public animation: Animation;
+    public value: number;
+
+    constructor(options: GenericOptions);
+
+    public update(options: GenericOptions): BaseGauge;
+    public destroy(): any;
+    public abstract draw(): BaseGauge;
+
+    public static initialize(type: string, options: GenericOptions): any;
+}
+
+declare class RadialGauge extends BaseGauge {
+    public type: RadialGauge;
+    public options: RadialGaugeOptions;
+
+    constructor(options: RadialGaugeOptions);
+
+    public draw(): RadialGauge;
+}
+
+declare class LinearGauge extends BaseGauge {
+    public type: LinearGauge;
+    public options: LinearGaugeOptions;
+
+    constructor(options: LinearGaugeOptions);
+
+    public draw(): LinearGauge;
+}
+
+interface Collection extends Array<BaseGauge> {
+    get: (id: number | string) => BaseGauge;
+}
+
+interface DocumentWithGauges extends Document {
+    gauges: Collection
+}

--- a/canvas-gauges/canvas-gauges.d.ts
+++ b/canvas-gauges/canvas-gauges.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for canvas-gauges
 // Project: https://github.com/Mikhus/canvas-gauges
-// Definitions by: Mikhus <ttps://github.com/Mikhus>
+// Definitions by: Mikhus <https://github.com/Mikhus>
 // Definitions: https://github.com/Mikhus/DefinitelyTyped
 
 declare namespace CanvasGauges {


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
