### PR TITLE
[angular-resource]: enforce action hash type in $resource()

### DIFF
--- a/angularjs/angular-resource.d.ts
+++ b/angularjs/angular-resource.d.ts
@@ -42,15 +42,20 @@ declare namespace angular.resource {
         (url: string, paramDefaults?: any,
             /** example:  {update: { method: 'PUT' }, delete: deleteDescriptor }
              where deleteDescriptor : IActionDescriptor */
-            actions?: any, options?: IResourceOptions): IResourceClass<IResource<any>>;
+            actions?: IActionHash, options?: IResourceOptions): IResourceClass<IResource<any>>;
         <T, U>(url: string, paramDefaults?: any,
             /** example:  {update: { method: 'PUT' }, delete: deleteDescriptor }
              where deleteDescriptor : IActionDescriptor */
-            actions?: any, options?: IResourceOptions): U;
+            actions?: IActionHash, options?: IResourceOptions): U;
         <T>(url: string, paramDefaults?: any,
             /** example:  {update: { method: 'PUT' }, delete: deleteDescriptor }
              where deleteDescriptor : IActionDescriptor */
-            actions?: any, options?: IResourceOptions): IResourceClass<T>;
+            actions?: IActionHash, options?: IResourceOptions): IResourceClass<T>;
+    }
+    
+    // Hash of action descriptors allows custom action names
+    interface IActionHash {
+        [action: string]: IActionDescriptor
     }
 
     // Just a reference to facilitate describing new actions


### PR DESCRIPTION
$resource documentation: https://code.angularjs.org/1.5.8/docs/api/ngResource/service/$resource

This PR adds type information to the `actions` parameter of `$resource()`. The type is a hash of `IActionDescriptor`s with user-defined keys.
