### PR TITLE
Added https type to Websocket.Server

### DIFF
--- a/ws/ws-tests.ts
+++ b/ws/ws-tests.ts
@@ -56,10 +56,8 @@ var WebSocketServer = WebSocket.Server;
 }
 
 {
-    var httpsserver = https.createServer({});
-    var wss = new WebSocket.Server({ server: httpsserver});
-    var httpserver = http.createServer();
-    var wss = new WebSocket.Server({ server: httpserver});
+    new WebSocket.Server({ server: https.createServer({}) });
+    new WebSocket.Server({ server: http.createServer() });
 }
 
 

--- a/ws/ws-tests.ts
+++ b/ws/ws-tests.ts
@@ -2,6 +2,7 @@
 
 import * as WebSocket from 'ws';
 import * as http from'http';
+import * as https from'https';
 
 var WebSocketServer = WebSocket.Server;
 
@@ -53,6 +54,14 @@ var WebSocketServer = WebSocket.Server;
         }, 500);
     });
 }
+
+{
+    var httpsserver = https.createServer({});
+    var wss = new WebSocket.Server({ server: httpsserver});
+    var httpserver = http.createServer();
+    var wss = new WebSocket.Server({ server: httpserver});
+}
+
 
 {
     const verifyClient = function(

--- a/ws/ws.d.ts
+++ b/ws/ws.d.ts
@@ -8,7 +8,7 @@
 declare module "ws" {
     import * as events from 'events';
     import * as http from 'http';
-    import * as http from 'https';
+    import * as https from 'https';
     import * as net from 'net';
 
     class WebSocket extends events.EventEmitter {

--- a/ws/ws.d.ts
+++ b/ws/ws.d.ts
@@ -8,6 +8,7 @@
 declare module "ws" {
     import * as events from 'events';
     import * as http from 'http';
+    import * as http from 'https';
     import * as net from 'net';
 
     class WebSocket extends events.EventEmitter {
@@ -99,7 +100,7 @@ declare module "ws" {
         export interface IServerOptions {
             host?: string;
             port?: number;
-            server?: http.Server;
+            server?: http.Server | https.Server;
             verifyClient?: VerifyClientCallbackAsync | VerifyClientCallbackSync;
             handleProtocols?: any;
             path?: string;


### PR DESCRIPTION
Hi,

the current typing misses to pass to the Websocket.Server server option a https Server.

Cheers

meno
