### PR TITLE
[node.d.ts] Add definite events for stream.Readable and stream.Writable

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -2483,30 +2483,35 @@ declare module "stream" {
             addListener(event: "end", listener: () => void): this;
             addListener(event: "readable", listener: () => void): this;
             addListener(event: "error", listener: (err: Error) => void): this;
+            addListener(event: string, listener: Function): this;
             
             emit(event: "close"): boolean;
             emit(event: "data", chunk: Buffer | string): boolean;
             emit(event: "end"): boolean;
             emit(event: "readable"): boolean;
             emit(event: "error", err: Error): boolean;
+            emit(event: string, ...args: any[]): boolean;
             
             on(event: "close", listener: () => void): this;
             on(event: "data", listener: (chunk: Buffer | string) => void): this;
             on(event: "end", listener: () => void): this;
             on(event: "readable", listener: () => void): this;
             on(event: "error", listener: (err: Error) => void): this;
+            on(event: string, listener: Function): this;
             
             once(event: "close", listener: () => void): this;
             once(event: "data", listener: (chunk: Buffer | string) => void): this;
             once(event: "end", listener: () => void): this;
             once(event: "readable", listener: () => void): this;
             once(event: "error", listener: (err: Error) => void): this;
+            once(event: string, listener: Function): this;
             
             prependListener(event: "close", listener: () => void): this;
             prependListener(event: "data", listener: (chunk: Buffer | string) => void): this;
             prependListener(event: "end", listener: () => void): this;
             prependListener(event: "readable", listener: () => void): this;
             prependListener(event: "error", listener: (err: Error) => void): this;
+            prependListener(event: string, listener: Function): this;
             
             prependOnceListener(event: "close", listener: () => void): this;
             prependOnceListener(event: "data", listener: (chunk: Buffer | string) => void): this;
@@ -2519,6 +2524,7 @@ declare module "stream" {
             removeListener(event: "end", listener: () => void): this;
             removeListener(event: "readable", listener: () => void): this;
             removeListener(event: "error", listener: (err: Error) => void): this;
+            removeListener(event: string, listener: Function): this;
         }
 
         export interface WritableOptions {
@@ -2555,6 +2561,7 @@ declare module "stream" {
             addListener(event: "finish", listener: () => void): this;
             addListener(event: "pipe", listener: (src: Readable) => void): this;
             addListener(event: "unpipe", listener: (src: Readable) => void): this;
+            addListener(event: string, listener: Function): this;
 
             emit(event: "close"): boolean;
             emit(event: "drain", chunk: Buffer | string): boolean;
@@ -2562,6 +2569,7 @@ declare module "stream" {
             emit(event: "finish"): boolean;
             emit(event: "pipe", src: Readable): boolean;
             emit(event: "unpipe", src: Readable): boolean;
+            emit(event: string, ...args: any[]): boolean;
             
             on(event: "close", listener: () => void): this;
             on(event: "drain", listener: () => void): this;
@@ -2569,6 +2577,7 @@ declare module "stream" {
             on(event: "finish", listener: () => void): this;
             on(event: "pipe", listener: (src: Readable) => void): this;
             on(event: "unpipe", listener: (src: Readable) => void): this;
+            on(event: string, listener: Function): this;
 
             once(event: "close", listener: () => void): this;
             once(event: "drain", listener: () => void): this;
@@ -2576,6 +2585,7 @@ declare module "stream" {
             once(event: "finish", listener: () => void): this;
             once(event: "pipe", listener: (src: Readable) => void): this;
             once(event: "unpipe", listener: (src: Readable) => void): this;
+            once(event: string, listener: Function): this;
 
             prependListener(event: "close", listener: () => void): this;
             prependListener(event: "drain", listener: () => void): this;
@@ -2583,6 +2593,7 @@ declare module "stream" {
             prependListener(event: "finish", listener: () => void): this;
             prependListener(event: "pipe", listener: (src: Readable) => void): this;
             prependListener(event: "unpipe", listener: (src: Readable) => void): this;
+            prependListener(event: string, listener: Function): this;
 
             prependOnceListener(event: "close", listener: () => void): this;
             prependOnceListener(event: "drain", listener: () => void): this;
@@ -2590,6 +2601,7 @@ declare module "stream" {
             prependOnceListener(event: "finish", listener: () => void): this;
             prependOnceListener(event: "pipe", listener: (src: Readable) => void): this;
             prependOnceListener(event: "unpipe", listener: (src: Readable) => void): this;
+            prependOnceListener(event: string, listener: Function): this;
 
             removeListener(event: "close", listener: () => void): this;
             removeListener(event: "drain", listener: () => void): this;
@@ -2597,6 +2609,7 @@ declare module "stream" {
             removeListener(event: "finish", listener: () => void): this;
             removeListener(event: "pipe", listener: (src: Readable) => void): this;
             removeListener(event: "unpipe", listener: (src: Readable) => void): this;
+            removeListener(event: string, listener: Function): this;
         }
 
         export interface DuplexOptions extends ReadableOptions, WritableOptions {

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -2468,6 +2468,57 @@ declare module "stream" {
             unshift(chunk: any): void;
             wrap(oldStream: NodeJS.ReadableStream): NodeJS.ReadableStream;
             push(chunk: any, encoding?: string): boolean;
+            
+            /**
+             * Event emitter
+             * The defined events on documents including:
+             *   1. close
+             *   2. data
+             *   3. end
+             *   4. readable
+             *   5. error
+             **/
+            addListener(event: "close", listener: () => void): this;
+            addListener(event: "data", listener: (chunk: Buffer | string) => void): this;
+            addListener(event: "end", listener: () => void): this;
+            addListener(event: "readable", listener: () => void): this;
+            addListener(event: "error", listener: (err: Error) => void): this;
+            
+            emit(event: "close"): boolean;
+            emit(event: "data", chunk: Buffer | string): boolean;
+            emit(event: "end"): boolean;
+            emit(event: "readable"): boolean;
+            emit(event: "error", (err: Error): boolean;
+            
+            on(event: "close", listener: () => void): this;
+            on(event: "data", listener: (chunk: Buffer | string) => void): this;
+            on(event: "end", listener: () => void): this;
+            on(event: "readable", listener: () => void): this;
+            on(event: "error", listener: (err: Error) => void): this;
+            
+            once(event: "close", listener: () => void): this;
+            once(event: "data", listener: (chunk: Buffer | string) => void): this;
+            once(event: "end", listener: () => void): this;
+            once(event: "readable", listener: () => void): this;
+            once(event: "error", listener: (err: Error) => void): this;
+            
+            prependListener(event: "close", listener: () => void): this;
+            prependListener(event: "data", listener: (chunk: Buffer | string) => void): this;
+            prependListener(event: "end", listener: () => void): this;
+            prependListener(event: "readable", listener: () => void): this;
+            prependListener(event: "error", listener: (err: Error) => void): this;
+            
+            prependOnceListener(event: "close", listener: () => void): this;
+            prependOnceListener(event: "data", listener: (chunk: Buffer | string) => void): this;
+            prependOnceListener(event: "end", listener: () => void): this;
+            prependOnceListener(event: "readable", listener: () => void): this;
+            prependOnceListener(event: "error", listener: (err: Error) => void): this;
+            
+            removeListener(event: "close", listener: () => void): this;
+            removeListener(event: "data", listener: (chunk: Buffer | string) => void): this;
+            removeListener(event: "end", listener: () => void): this;
+            removeListener(event: "readable", listener: () => void): this;
+            removeListener(event: "error", listener: (err: Error) => void): this;
         }
 
         export interface WritableOptions {

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -2488,7 +2488,7 @@ declare module "stream" {
             emit(event: "data", chunk: Buffer | string): boolean;
             emit(event: "end"): boolean;
             emit(event: "readable"): boolean;
-            emit(event: "error", (err: Error): boolean;
+            emit(event: "error", err: Error): boolean;
             
             on(event: "close", listener: () => void): this;
             on(event: "data", listener: (chunk: Buffer | string) => void): this;
@@ -2538,6 +2538,65 @@ declare module "stream" {
             end(): void;
             end(chunk: any, cb?: Function): void;
             end(chunk: any, encoding?: string, cb?: Function): void;
+            
+            /**
+             * Event emitter
+             * The defined events on documents including:
+             *   1. close
+             *   2. drain
+             *   3. error
+             *   4. finish
+             *   5. pipe
+             *   6. unpipe
+             **/
+            addListener(event: "close", listener: () => void): this;
+            addListener(event: "drain", listener: () => void): this;
+            addListener(event: "error", listener: (err: Error) => void): this;
+            addListener(event: "finish", listener: () => void): this;
+            addListener(event: "pipe", listener: (src: Readable) => void): this;
+            addListener(event: "unpipe", listener: (src: Readable) => void): this;
+
+            emit(event: "close"): boolean;
+            emit(event: "drain", chunk: Buffer | string): boolean;
+            emit(event: "error", err: Error): boolean;
+            emit(event: "finish"): boolean;
+            emit(event: "pipe", src: Readable): boolean;
+            emit(event: "unpipe", src: Readable): boolean;
+            
+            on(event: "close", listener: () => void): this;
+            on(event: "drain", listener: () => void): this;
+            on(event: "error", listener: (err: Error) => void): this;
+            on(event: "finish", listener: () => void): this;
+            on(event: "pipe", listener: (src: Readable) => void): this;
+            on(event: "unpipe", listener: (src: Readable) => void): this;
+
+            once(event: "close", listener: () => void): this;
+            once(event: "drain", listener: () => void): this;
+            once(event: "error", listener: (err: Error) => void): this;
+            once(event: "finish", listener: () => void): this;
+            once(event: "pipe", listener: (src: Readable) => void): this;
+            once(event: "unpipe", listener: (src: Readable) => void): this;
+
+            prependListener(event: "close", listener: () => void): this;
+            prependListener(event: "drain", listener: () => void): this;
+            prependListener(event: "error", listener: (err: Error) => void): this;
+            prependListener(event: "finish", listener: () => void): this;
+            prependListener(event: "pipe", listener: (src: Readable) => void): this;
+            prependListener(event: "unpipe", listener: (src: Readable) => void): this;
+
+            prependOnceListener(event: "close", listener: () => void): this;
+            prependOnceListener(event: "drain", listener: () => void): this;
+            prependOnceListener(event: "error", listener: (err: Error) => void): this;
+            prependOnceListener(event: "finish", listener: () => void): this;
+            prependOnceListener(event: "pipe", listener: (src: Readable) => void): this;
+            prependOnceListener(event: "unpipe", listener: (src: Readable) => void): this;
+
+            removeListener(event: "close", listener: () => void): this;
+            removeListener(event: "drain", listener: () => void): this;
+            removeListener(event: "error", listener: (err: Error) => void): this;
+            removeListener(event: "finish", listener: () => void): this;
+            removeListener(event: "pipe", listener: (src: Readable) => void): this;
+            removeListener(event: "unpipe", listener: (src: Readable) => void): this;
         }
 
         export interface DuplexOptions extends ReadableOptions, WritableOptions {

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -2555,61 +2555,61 @@ declare module "stream" {
              *   5. pipe
              *   6. unpipe
              **/
+            addListener(event: string, listener: Function): this;
             addListener(event: "close", listener: () => void): this;
             addListener(event: "drain", listener: () => void): this;
             addListener(event: "error", listener: (err: Error) => void): this;
             addListener(event: "finish", listener: () => void): this;
             addListener(event: "pipe", listener: (src: Readable) => void): this;
             addListener(event: "unpipe", listener: (src: Readable) => void): this;
-            addListener(event: string, listener: Function): this;
-
+            
+            emit(event: string, ...args: any[]): boolean;
             emit(event: "close"): boolean;
             emit(event: "drain", chunk: Buffer | string): boolean;
             emit(event: "error", err: Error): boolean;
             emit(event: "finish"): boolean;
             emit(event: "pipe", src: Readable): boolean;
             emit(event: "unpipe", src: Readable): boolean;
-            emit(event: string, ...args: any[]): boolean;
             
+            on(event: string, listener: Function): this;
             on(event: "close", listener: () => void): this;
             on(event: "drain", listener: () => void): this;
             on(event: "error", listener: (err: Error) => void): this;
             on(event: "finish", listener: () => void): this;
             on(event: "pipe", listener: (src: Readable) => void): this;
             on(event: "unpipe", listener: (src: Readable) => void): this;
-            on(event: string, listener: Function): this;
-
+            
+            once(event: string, listener: Function): this;
             once(event: "close", listener: () => void): this;
             once(event: "drain", listener: () => void): this;
             once(event: "error", listener: (err: Error) => void): this;
             once(event: "finish", listener: () => void): this;
             once(event: "pipe", listener: (src: Readable) => void): this;
             once(event: "unpipe", listener: (src: Readable) => void): this;
-            once(event: string, listener: Function): this;
-
+            
+            prependListener(event: string, listener: Function): this;
             prependListener(event: "close", listener: () => void): this;
             prependListener(event: "drain", listener: () => void): this;
             prependListener(event: "error", listener: (err: Error) => void): this;
             prependListener(event: "finish", listener: () => void): this;
             prependListener(event: "pipe", listener: (src: Readable) => void): this;
             prependListener(event: "unpipe", listener: (src: Readable) => void): this;
-            prependListener(event: string, listener: Function): this;
 
+            prependOnceListener(event: string, listener: Function): this;
             prependOnceListener(event: "close", listener: () => void): this;
             prependOnceListener(event: "drain", listener: () => void): this;
             prependOnceListener(event: "error", listener: (err: Error) => void): this;
             prependOnceListener(event: "finish", listener: () => void): this;
             prependOnceListener(event: "pipe", listener: (src: Readable) => void): this;
             prependOnceListener(event: "unpipe", listener: (src: Readable) => void): this;
-            prependOnceListener(event: string, listener: Function): this;
 
+            removeListener(event: string, listener: Function): this;
             removeListener(event: "close", listener: () => void): this;
             removeListener(event: "drain", listener: () => void): this;
             removeListener(event: "error", listener: (err: Error) => void): this;
             removeListener(event: "finish", listener: () => void): this;
             removeListener(event: "pipe", listener: (src: Readable) => void): this;
             removeListener(event: "unpipe", listener: (src: Readable) => void): this;
-            removeListener(event: string, listener: Function): this;
         }
 
         export interface DuplexOptions extends ReadableOptions, WritableOptions {


### PR DESCRIPTION
# Improvement to existing type definition

Add these events and provide referable document
- stream.Readable
  - [Event: 'close'](https://nodejs.org/api/stream.html#stream_event_close_1)
  - [Event: 'data'](https://nodejs.org/api/stream.html#stream_event_data)
  - [Event: 'end'](https://nodejs.org/api/stream.html#stream_event_end)
  - [Event: 'error'](https://nodejs.org/api/stream.html#stream_event_error_1)
  - [Event: 'readable'](https://nodejs.org/api/stream.html#stream_event_readable)
- stream.Writable
  - [Event: 'close'](https://nodejs.org/api/stream.html#stream_event_close)
  - [Event: 'drain'](https://nodejs.org/api/stream.html#stream_event_drain)
    - The document isn't clearly. Please refer source code in Nodejs: 
      - [Event: 'drain'](https://github.com/nodejs/node/blob/be68b68d4863f0d389cc46fdf6f1cbcd1b241d0a/lib/stream.js#L45) registers [a function](https://github.com/nodejs/node/blob/be68b68d4863f0d389cc46fdf6f1cbcd1b241d0a/lib/stream.js#L39)
  - [Event: 'error'](https://nodejs.org/api/stream.html#stream_event_error)
  - [Event: 'finish'](https://nodejs.org/api/stream.html#stream_event_finish)
  - [Event: 'pipe'](https://nodejs.org/api/stream.html#stream_event_pipe)
  - [Event: 'unpipe'](https://nodejs.org/api/stream.html#stream_event_unpipe)
