### PR TITLE
[angular-ui-scroll] Include startIndex parameter on adapter reload() method

### DIFF
--- a/angular-ui-scroll/angular-ui-scroll.d.ts
+++ b/angular-ui-scroll/angular-ui-scroll.d.ts
@@ -42,9 +42,10 @@ declare namespace angular.ui {
          */
         topVisibleScope: ng.IRepeatScope;
         /**
-         * calling this method reinitializes and reloads the scroller content.
+         * calling this method reinitializes and reloads the scroller content. 
+         * @param startIndex is an integer indicating what item index the scroller will use to start the load process.
          */
-        reload(): void;
+        reload(startIndex?: number): void;
         /**
          * Replaces the item in the buffer at the given index with the new items.
          *


### PR DESCRIPTION
As per docs here: https://github.com/angular-ui/ui-scroll
`reload()` includes a `startIndex` parameterl;
