### PR TITLE
[node] Add definite events for Readable and Writable

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -777,7 +777,15 @@ declare module "cluster" {
         [index: string]: Worker
     };
 
-    // Event emitter
+    /**
+     * Event emitter
+     * The defined events on documents including:
+     *   1. close
+     *   2. data
+     *   3. end
+     *   4. readable
+     *   5. error
+     **/
     export function addListener(event: string, listener: Function): void;
     export function on(event: "disconnect", listener: (worker: Worker) => void): void;
     export function on(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): void;
@@ -2468,6 +2476,64 @@ declare module "stream" {
             unshift(chunk: any): void;
             wrap(oldStream: NodeJS.ReadableStream): NodeJS.ReadableStream;
             push(chunk: any, encoding?: string): boolean;
+            
+            /**
+             * Event emitter
+             * The defined events on documents including:
+             *   1. close
+             *   2. data
+             *   3. end
+             *   4. readable
+             *   5. error
+             **/
+            addListener(event: string, listener: Function): this;
+            addListener(event: "close", listener: () => void): this;
+            addListener(event: "data", listener: (chunk: Buffer | string) => void): this;
+            addListener(event: "end", listener: () => void): this;
+            addListener(event: "readable", listener: () => void): this;
+            addListener(event: "error", listener: (err: Error) => void): this;
+
+            emit(event: string, ...args: any[]): boolean;            
+            emit(event: "close"): boolean;
+            emit(event: "data", chunk: Buffer | string): boolean;
+            emit(event: "end"): boolean;
+            emit(event: "readable"): boolean;
+            emit(event: "error", err: Error): boolean;
+            
+            on(event: string, listener: Function): this;
+            on(event: "close", listener: () => void): this;
+            on(event: "data", listener: (chunk: Buffer | string) => void): this;
+            on(event: "end", listener: () => void): this;
+            on(event: "readable", listener: () => void): this;
+            on(event: "error", listener: (err: Error) => void): this;
+
+            once(event: string, listener: Function): this;            
+            once(event: "close", listener: () => void): this;
+            once(event: "data", listener: (chunk: Buffer | string) => void): this;
+            once(event: "end", listener: () => void): this;
+            once(event: "readable", listener: () => void): this;
+            once(event: "error", listener: (err: Error) => void): this;
+            
+            prependListener(event: string, listener: Function): this;
+            prependListener(event: "close", listener: () => void): this;
+            prependListener(event: "data", listener: (chunk: Buffer | string) => void): this;
+            prependListener(event: "end", listener: () => void): this;
+            prependListener(event: "readable", listener: () => void): this;
+            prependListener(event: "error", listener: (err: Error) => void): this;
+
+            prependOnceListener(event: string, listener: Function): this;
+            prependOnceListener(event: "close", listener: () => void): this;
+            prependOnceListener(event: "data", listener: (chunk: Buffer | string) => void): this;
+            prependOnceListener(event: "end", listener: () => void): this;
+            prependOnceListener(event: "readable", listener: () => void): this;
+            prependOnceListener(event: "error", listener: (err: Error) => void): this;
+            
+            removeListener(event: string, listener: Function): this;
+            removeListener(event: "close", listener: () => void): this;
+            removeListener(event: "data", listener: (chunk: Buffer | string) => void): this;
+            removeListener(event: "end", listener: () => void): this;
+            removeListener(event: "readable", listener: () => void): this;
+            removeListener(event: "error", listener: (err: Error) => void): this;
         }
 
         export interface WritableOptions {
@@ -2487,6 +2553,72 @@ declare module "stream" {
             end(): void;
             end(chunk: any, cb?: Function): void;
             end(chunk: any, encoding?: string, cb?: Function): void;
+            
+            /**
+             * Event emitter
+             * The defined events on documents including:
+             *   1. close
+             *   2. drain
+             *   3. error
+             *   4. finish
+             *   5. pipe
+             *   6. unpipe
+             **/
+            addListener(event: string, listener: Function): this;
+            addListener(event: "close", listener: () => void): this;
+            addListener(event: "drain", listener: () => void): this;
+            addListener(event: "error", listener: (err: Error) => void): this;
+            addListener(event: "finish", listener: () => void): this;
+            addListener(event: "pipe", listener: (src: Readable) => void): this;
+            addListener(event: "unpipe", listener: (src: Readable) => void): this;
+            
+            emit(event: string, ...args: any[]): boolean;
+            emit(event: "close"): boolean;
+            emit(event: "drain", chunk: Buffer | string): boolean;
+            emit(event: "error", err: Error): boolean;
+            emit(event: "finish"): boolean;
+            emit(event: "pipe", src: Readable): boolean;
+            emit(event: "unpipe", src: Readable): boolean;
+            
+            on(event: string, listener: Function): this;
+            on(event: "close", listener: () => void): this;
+            on(event: "drain", listener: () => void): this;
+            on(event: "error", listener: (err: Error) => void): this;
+            on(event: "finish", listener: () => void): this;
+            on(event: "pipe", listener: (src: Readable) => void): this;
+            on(event: "unpipe", listener: (src: Readable) => void): this;
+            
+            once(event: string, listener: Function): this;
+            once(event: "close", listener: () => void): this;
+            once(event: "drain", listener: () => void): this;
+            once(event: "error", listener: (err: Error) => void): this;
+            once(event: "finish", listener: () => void): this;
+            once(event: "pipe", listener: (src: Readable) => void): this;
+            once(event: "unpipe", listener: (src: Readable) => void): this;
+            
+            prependListener(event: string, listener: Function): this;
+            prependListener(event: "close", listener: () => void): this;
+            prependListener(event: "drain", listener: () => void): this;
+            prependListener(event: "error", listener: (err: Error) => void): this;
+            prependListener(event: "finish", listener: () => void): this;
+            prependListener(event: "pipe", listener: (src: Readable) => void): this;
+            prependListener(event: "unpipe", listener: (src: Readable) => void): this;
+
+            prependOnceListener(event: string, listener: Function): this;
+            prependOnceListener(event: "close", listener: () => void): this;
+            prependOnceListener(event: "drain", listener: () => void): this;
+            prependOnceListener(event: "error", listener: (err: Error) => void): this;
+            prependOnceListener(event: "finish", listener: () => void): this;
+            prependOnceListener(event: "pipe", listener: (src: Readable) => void): this;
+            prependOnceListener(event: "unpipe", listener: (src: Readable) => void): this;
+
+            removeListener(event: string, listener: Function): this;
+            removeListener(event: "close", listener: () => void): this;
+            removeListener(event: "drain", listener: () => void): this;
+            removeListener(event: "error", listener: (err: Error) => void): this;
+            removeListener(event: "finish", listener: () => void): this;
+            removeListener(event: "pipe", listener: (src: Readable) => void): this;
+            removeListener(event: "unpipe", listener: (src: Readable) => void): this;
         }
 
         export interface DuplexOptions extends ReadableOptions, WritableOptions {

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -281,8 +281,8 @@ declare namespace NodeJS {
     }
 
     export interface ReadWriteStream extends ReadableStream, WritableStream {
-      pause(): ReadWriteStream;
-      resume(): ReadWriteStream;
+        pause(): ReadWriteStream;
+        resume(): ReadWriteStream;
     }
 
     export interface Events extends EventEmitter { }
@@ -456,7 +456,7 @@ declare namespace NodeJS {
     }
 }
 
-interface IterableIterator<T> {}
+interface IterableIterator<T> { }
 
 /**
  * @deprecated
@@ -588,7 +588,7 @@ declare module "http" {
         agent?: Agent | boolean;
     }
 
-    export interface Server extends events.EventEmitter, net.Server {
+    export interface Server extends net.Server {
         setTimeout(msecs: number, callback: Function): void;
         maxHeadersCount: number;
         timeout: number;
@@ -599,7 +599,7 @@ declare module "http" {
     export interface ServerRequest extends IncomingMessage {
         connection: net.Socket;
     }
-    export interface ServerResponse extends events.EventEmitter, stream.Writable {
+    export interface ServerResponse extends stream.Writable {
         // Extended base methods
         write(buffer: Buffer): boolean;
         write(buffer: Buffer, cb?: Function): boolean;
@@ -629,7 +629,7 @@ declare module "http" {
         end(str: string, encoding?: string, cb?: Function): void;
         end(data?: any, encoding?: string): void;
     }
-    export interface ClientRequest extends events.EventEmitter, stream.Writable {
+    export interface ClientRequest extends stream.Writable {
         // Extended base methods
         write(buffer: Buffer): boolean;
         write(buffer: Buffer, cb?: Function): boolean;
@@ -655,7 +655,7 @@ declare module "http" {
         end(str: string, encoding?: string, cb?: Function): void;
         end(data?: any, encoding?: string): void;
     }
-    export interface IncomingMessage extends events.EventEmitter, stream.Readable {
+    export interface IncomingMessage extends stream.Readable {
         httpVersion: string;
         httpVersionMajor: string;
         httpVersionMinor: string;
@@ -1042,7 +1042,7 @@ declare module "https" {
         requestCert?: boolean;
         rejectUnauthorized?: boolean;
         NPNProtocols?: any;
-        SNICallback?: (servername: string, cb:(err:Error,ctx:tls.SecureContext)=>any) => any;
+        SNICallback?: (servername: string, cb: (err: Error, ctx: tls.SecureContext) => any) => any;
     }
 
     export interface RequestOptions extends http.RequestOptions {
@@ -1855,7 +1855,7 @@ declare module "fs" {
     }
 
     export const constants: Constants;
-    
+
     /** Tests a user's permissions for the file specified by path. */
     export function access(path: string | Buffer, callback: (err: NodeJS.ErrnoException) => void): void;
     export function access(path: string | Buffer, mode: number, callback: (err: NodeJS.ErrnoException) => void): void;
@@ -2198,7 +2198,7 @@ declare module "tls" {
         requestCert?: boolean;
         rejectUnauthorized?: boolean;
         NPNProtocols?: string[] | Buffer;
-        SNICallback?: (servername: string, cb:(err:Error,ctx:SecureContext)=>any) => any;
+        SNICallback?: (servername: string, cb: (err: Error, ctx: SecureContext) => any) => any;
         ecdhCurve?: string;
         dhparam?: string | Buffer;
         handshakeTimeout?: number;
@@ -2214,7 +2214,7 @@ declare module "tls" {
         port?: number;
         socket?: net.Socket;
         pfx?: string | Buffer
-        key?: string |string[] | Buffer | Buffer[];
+        key?: string | string[] | Buffer | Buffer[];
         passphrase?: string;
         cert?: string | string[] | Buffer | Buffer[];
         ca?: string | Buffer | (string | Buffer)[];
@@ -2446,7 +2446,7 @@ declare module "stream" {
     }
     namespace internal {
 
-        export class Stream extends internal {}
+        export class Stream extends internal { }
 
         export interface ReadableOptions {
             highWaterMark?: number;
@@ -2468,7 +2468,7 @@ declare module "stream" {
             unshift(chunk: any): void;
             wrap(oldStream: NodeJS.ReadableStream): NodeJS.ReadableStream;
             push(chunk: any, encoding?: string): boolean;
-            
+
             /**
              * Event emitter
              * The defined events on documents including:
@@ -2479,19 +2479,20 @@ declare module "stream" {
              *   5. error
              **/
             addListener(event: string, listener: Function): this;
+            addListener(event: string, listener: Function): this;
             addListener(event: "close", listener: () => void): this;
             addListener(event: "data", listener: (chunk: Buffer | string) => void): this;
             addListener(event: "end", listener: () => void): this;
             addListener(event: "readable", listener: () => void): this;
             addListener(event: "error", listener: (err: Error) => void): this;
 
-            emit(event: string, ...args: any[]): boolean;            
+            emit(event: string, ...args: any[]): boolean;
             emit(event: "close"): boolean;
             emit(event: "data", chunk: Buffer | string): boolean;
             emit(event: "end"): boolean;
             emit(event: "readable"): boolean;
             emit(event: "error", err: Error): boolean;
-            
+
             on(event: string, listener: Function): this;
             on(event: "close", listener: () => void): this;
             on(event: "data", listener: (chunk: Buffer | string) => void): this;
@@ -2499,13 +2500,13 @@ declare module "stream" {
             on(event: "readable", listener: () => void): this;
             on(event: "error", listener: (err: Error) => void): this;
 
-            once(event: string, listener: Function): this;            
+            once(event: string, listener: Function): this;
             once(event: "close", listener: () => void): this;
             once(event: "data", listener: (chunk: Buffer | string) => void): this;
             once(event: "end", listener: () => void): this;
             once(event: "readable", listener: () => void): this;
             once(event: "error", listener: (err: Error) => void): this;
-            
+
             prependListener(event: string, listener: Function): this;
             prependListener(event: "close", listener: () => void): this;
             prependListener(event: "data", listener: (chunk: Buffer | string) => void): this;
@@ -2519,7 +2520,7 @@ declare module "stream" {
             prependOnceListener(event: "end", listener: () => void): this;
             prependOnceListener(event: "readable", listener: () => void): this;
             prependOnceListener(event: "error", listener: (err: Error) => void): this;
-            
+
             removeListener(event: string, listener: Function): this;
             removeListener(event: "close", listener: () => void): this;
             removeListener(event: "data", listener: (chunk: Buffer | string) => void): this;
@@ -2532,8 +2533,8 @@ declare module "stream" {
             highWaterMark?: number;
             decodeStrings?: boolean;
             objectMode?: boolean;
-            write?: (chunk: string|Buffer, encoding: string, callback: Function) => any;
-            writev?: (chunks: {chunk: string|Buffer, encoding: string}[], callback: Function) => any;
+            write?: (chunk: string | Buffer, encoding: string, callback: Function) => any;
+            writev?: (chunks: { chunk: string | Buffer, encoding: string }[], callback: Function) => any;
         }
 
         export class Writable extends events.EventEmitter implements NodeJS.WritableStream {
@@ -2545,7 +2546,7 @@ declare module "stream" {
             end(): void;
             end(chunk: any, cb?: Function): void;
             end(chunk: any, encoding?: string, cb?: Function): void;
-            
+
             /**
              * Event emitter
              * The defined events on documents including:
@@ -2563,7 +2564,7 @@ declare module "stream" {
             addListener(event: "finish", listener: () => void): this;
             addListener(event: "pipe", listener: (src: Readable) => void): this;
             addListener(event: "unpipe", listener: (src: Readable) => void): this;
-            
+
             emit(event: string, ...args: any[]): boolean;
             emit(event: "close"): boolean;
             emit(event: "drain", chunk: Buffer | string): boolean;
@@ -2571,7 +2572,7 @@ declare module "stream" {
             emit(event: "finish"): boolean;
             emit(event: "pipe", src: Readable): boolean;
             emit(event: "unpipe", src: Readable): boolean;
-            
+
             on(event: string, listener: Function): this;
             on(event: "close", listener: () => void): this;
             on(event: "drain", listener: () => void): this;
@@ -2579,7 +2580,7 @@ declare module "stream" {
             on(event: "finish", listener: () => void): this;
             on(event: "pipe", listener: (src: Readable) => void): this;
             on(event: "unpipe", listener: (src: Readable) => void): this;
-            
+
             once(event: string, listener: Function): this;
             once(event: "close", listener: () => void): this;
             once(event: "drain", listener: () => void): this;
@@ -2587,7 +2588,7 @@ declare module "stream" {
             once(event: "finish", listener: () => void): this;
             once(event: "pipe", listener: (src: Readable) => void): this;
             once(event: "unpipe", listener: (src: Readable) => void): this;
-            
+
             prependListener(event: string, listener: Function): this;
             prependListener(event: "close", listener: () => void): this;
             prependListener(event: "drain", listener: () => void): this;
@@ -2636,7 +2637,7 @@ declare module "stream" {
         }
 
         export interface TransformOptions extends ReadableOptions, WritableOptions {
-            transform?: (chunk: string|Buffer, encoding: string, callback: Function) => any;
+            transform?: (chunk: string | Buffer, encoding: string, callback: Function) => any;
             flush?: (callback: Function) => any;
         }
 
@@ -3074,7 +3075,7 @@ declare module "v8" {
         space_available_size: number;
         physical_space_size: number;
     }
-    export function getHeapStatistics() : {total_heap_size: number, total_heap_size_executable: number, total_physical_size: number, total_avaialble_size: number, used_heap_size: number, heap_size_limit: number};
+    export function getHeapStatistics(): { total_heap_size: number, total_heap_size_executable: number, total_physical_size: number, total_avaialble_size: number, used_heap_size: number, heap_size_limit: number };
     export function getHeapSpaceStatistics(): HeapSpaceInfo[];
     export function setFlagsFromString(flags: string): void;
 }

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -777,6 +777,7 @@ declare module "cluster" {
         [index: string]: Worker
     };
 
+    // Event emitter
     export function addListener(event: string, listener: Function): void;
     export function on(event: "disconnect", listener: (worker: Worker) => void): void;
     export function on(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): void;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -777,15 +777,6 @@ declare module "cluster" {
         [index: string]: Worker
     };
 
-    /**
-     * Event emitter
-     * The defined events on documents including:
-     *   1. close
-     *   2. data
-     *   3. end
-     *   4. readable
-     *   5. error
-     **/
     export function addListener(event: string, listener: Function): void;
     export function on(event: "disconnect", listener: (worker: Worker) => void): void;
     export function on(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): void;


### PR DESCRIPTION
# Improvement to existing type definition

Add these events and provide referable document
- stream.Readable
  - [Event: 'close'](https://nodejs.org/api/stream.html#stream_event_close_1)
  - [Event: 'data'](https://nodejs.org/api/stream.html#stream_event_data)
  - [Event: 'end'](https://nodejs.org/api/stream.html#stream_event_end)
  - [Event: 'error'](https://nodejs.org/api/stream.html#stream_event_error_1)
  - [Event: 'readable'](https://nodejs.org/api/stream.html#stream_event_readable)
- stream.Writable
  - [Event: 'close'](https://nodejs.org/api/stream.html#stream_event_close)
  - [Event: 'drain'](https://nodejs.org/api/stream.html#stream_event_drain)
    - The document isn't clearly. Please refer source code in Nodejs: 
      - [Event: 'drain'](https://github.com/nodejs/node/blob/be68b68d4863f0d389cc46fdf6f1cbcd1b241d0a/lib/stream.js#L45) registers [a function](https://github.com/nodejs/node/blob/be68b68d4863f0d389cc46fdf6f1cbcd1b241d0a/lib/stream.js#L39)
  - [Event: 'error'](https://nodejs.org/api/stream.html#stream_event_error)
  - [Event: 'finish'](https://nodejs.org/api/stream.html#stream_event_finish)
  - [Event: 'pipe'](https://nodejs.org/api/stream.html#stream_event_pipe)
  - [Event: 'unpipe'](https://nodejs.org/api/stream.html#stream_event_unpipe)

---
# Action
- Add
  - Add definite events as the above list
- Delete
  - Remove some interfaces extends `EventEmitter` again
    - An interface doesn't need to extends  `EventEmitter`-like twice, otherwise it will show `someoneType simultaneously extend types EventEmitter and anotherType`.
    - Refer [export interface Server extends events.EventEmitter, net.Server](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/11217/commits/4d6e4d7853b2a13bf31f0f2cd985aaab4afd1387#diff-bf89eb87012559957ad998badfd53de5L591). The `net.Server` has included `EventEmitter`. It doesn't need to extend `events.EventEmitter` again.
    - [ServerResponse](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/11217/commits/4d6e4d7853b2a13bf31f0f2cd985aaab4afd1387#diff-bf89eb87012559957ad998badfd53de5L602),[ClientRequest](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/11217/commits/4d6e4d7853b2a13bf31f0f2cd985aaab4afd1387#diff-bf89eb87012559957ad998badfd53de5L602), [IncomingMessage](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/11217/commits/4d6e4d7853b2a13bf31f0f2cd985aaab4afd1387#diff-bf89eb87012559957ad998badfd53de5L632) are same reason.
- Modify
  - Change the code format by `typescript_auto_format` of sublime 
