### PR TITLE
Change #Extend PolyMouseEvent interface from MouseEvent interface

### DIFF
--- a/googlemaps/google.maps.d.ts
+++ b/googlemaps/google.maps.d.ts
@@ -756,7 +756,7 @@ declare namespace google.maps {
         zIndex?: number;
     }
 
-    export interface PolyMouseEvent {
+    export interface PolyMouseEvent extends MouseEvent {
         edge?: number;
         path?: number;
         vertex?: number;


### PR DESCRIPTION
PolyMouseEvent should inherit from MouseEvent according to google documentation https://developers.google.com/maps/documentation/javascript/3.exp/reference#PolyMouseEvent
