### PR TITLE
[node] connection are socket are same in IncomingMessage

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -659,7 +659,7 @@ declare module "http" {
         httpVersion: string;
         httpVersionMajor: string;
         httpVersionMinor: string;
-        connection: any;
+        connection: net.Socket;
         headers: any;
         rawHeaders: string[];
         trailers: any;


### PR DESCRIPTION
# Improvement to existing type definition.

It doesn't be mentioned in the document. It needs to refer to source code.

When initializing a `IncomingMessage` instance, it will set `socket` to [this.socket](https://github.com/nodejs/node/blob/357f904169c39bbc9c2d8558bbffce2337c83c1b/lib/_http_incoming.js#L30) and [this.connection](https://github.com/nodejs/node/blob/357f904169c39bbc9c2d8558bbffce2337c83c1b/lib/_http_incoming.js#L31).

The `this.socket` is [message.socket](https://nodejs.org/dist/latest-v6.x/docs/api/http.html#http_message_socket) on document and It's a [net.Socket](https://nodejs.org/dist/latest-v6.x/docs/api/net.html#net_class_net_socket) object.

 Therefore, `this.socket` and `this.connection` get same object and the object is `net.Socket`.
