### PR TITLE
Knockout: Add specialized signatures for subscribe

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -61,8 +61,10 @@ interface KnockoutSubscription {
 }
 
 interface KnockoutSubscribable<T> extends KnockoutSubscribableFunctions<T> {
-	subscribe(callback: (newValue: T) => void, target?: any, event?: string): KnockoutSubscription;
+    subscribe(callback: (newValue: T) => void, target: any, event: "beforeChange"): KnockoutSubscription;
+	subscribe(callback: (newValue: T) => void, target?: any, event?: "change"): KnockoutSubscription;
 	subscribe<TEvent>(callback: (newValue: TEvent) => void, target: any, event: string): KnockoutSubscription;
+
 	extend(requestedExtenders: { [key: string]: any; }): KnockoutSubscribable<T>;
 	getSubscriptionsCount(): number;
 }
@@ -91,6 +93,11 @@ interface KnockoutObservableArrayStatic {
 }
 
 interface KnockoutObservableArray<T> extends KnockoutObservable<T[]>, KnockoutObservableArrayFunctions<T> {
+    subscribe(callback: (newValue: KnockoutArrayChange<T>[]) => void, target: any, event: "arrayChange"): KnockoutSubscription;
+    subscribe(callback: (newValue: T[]) => void, target: any, event: "beforeChange"): KnockoutSubscription;
+    subscribe(callback: (newValue: T[]) => void, target?: any, event?: "change"): KnockoutSubscription;
+    subscribe<TEvent>(callback: (newValue: TEvent) => void, target: any, event: string): KnockoutSubscription;
+
     extend(requestedExtenders: { [key: string]: any; }): KnockoutObservableArray<T>;
 }
 
@@ -325,7 +332,7 @@ interface KnockoutUtils {
 }
 
 interface KnockoutArrayChange<T> {
-    status: string;
+    status: "added" | "deleted";
     value: T;
     index: number;
     moved?: number;

--- a/knockout/knockoutamd-tests.ts
+++ b/knockout/knockoutamd-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./knockout.d.ts" />
 
-﻿import ko = require("knockout");
+import ko = require("knockout");
 
 var myArray = ko.observableArray([1, 2, 3]);
 

--- a/knockout/tests/knockout-tests.ts
+++ b/knockout/tests/knockout-tests.ts
@@ -680,3 +680,38 @@ function test_tasks() {
         setTimeout(callback, 0);
     };
 }
+
+function observableEventsTests() {
+    var observable = ko.observable(1);
+    observable.subscribe(value => {
+        var num: number = value;
+    });
+    observable.subscribe(value => {
+        var num: number = value;
+    }, null, "change");
+    observable.subscribe(value => {
+        var num: number = value;
+    }, null, "beforeChange");
+}
+
+function observableArrayEventsTests() {
+    var observableArray = ko.observableArray([1, 2, 3, 4]);
+    observableArray.subscribe(array => {
+        var arr: number[] = array;
+    });
+    observableArray.subscribe(array => {
+        var arr: number[] = array;
+    }, null, "change");
+    observableArray.subscribe(array => {
+        var arr: number[] = array;
+    }, null, "beforeChange");
+    var count = 0;
+    observableArray.subscribe(changes => {
+        changes.forEach(change => {
+            if (change.status == "added")
+                count++;
+            else if (change.status == "deleted")
+                count--;
+        });
+    }, null, "arrayChange");
+}


### PR DESCRIPTION
Documentation:
- http://blog.stevensanderson.com/2013/10/08/knockout-3-0-release-candidate-available/

Changes:
- `subscribe` now has specialized events where "change" is default
- "beforeChange" known event name is also supported
- "arrayChange" event for observable arrays (fixes #11203)
- improve change object definition with tagged union type
- added tests of existing events and newly introduced ones
