### PR TITLE
[restangular]: add route-bound methods for scoped service

### DIFF
--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -90,10 +90,19 @@ declare namespace restangular {
     withConfig(configurer: (RestangularProvider: IProvider) => any): IService;
     restangularizeElement(parent: any, element: any, route: string, collection?: any, reqParams?: any): IElement;
     restangularizeCollection(parent: any, element: any, route: string): ICollection;
-    service(route: string, parent?: any): IService;
+    service(route: string, parent?: any): IScopedService;
     stripRestangular(element: any): any;
     extendModel(route: string, extender: (model: IElement) => any): void;
     extendCollection(route: string, extender: (collection: ICollection) => any): void;
+  }
+  
+  interface IScopedService extends IService {
+    one(id: number): IElement;
+    one(id: string): IElement;
+    post(elementToPost: any, queryParams?: any, headers?: any): IPromise<any>;
+    post<T>(elementToPost: T, queryParams?: any, headers?: any): IPromise<T>;
+    getList(queryParams?: any, headers?: any): ICollectionPromise<any>;
+    getList<T>(queryParams?: any, headers?: any): ICollectionPromise<T>;
   }
 
   interface IElement extends IService {


### PR DESCRIPTION
Documentation: https://github.com/mgonto/restangular#decoupled-restangular-service

When configured via `Restangular.service('route')`, the route is bound to some functions. This change overrides those functions with the correct signatures.
