### PR TITLE
[openlayers] Fix RegularShape type

### DIFF
--- a/openlayers/index.d.ts
+++ b/openlayers/index.d.ts
@@ -1275,6 +1275,17 @@ declare namespace olx {
             snapToPixel?: boolean;
             stroke?: ol.style.Stroke;
         }
+        interface RegularShapeOptions {
+            fill?: ol.style.Fill;
+            points: number;
+            radius?: number;
+            radius1?: number;
+            radius2?: number;
+            angle?: number;
+            snapToPixel?: boolean;
+            stroke?: ol.style.Stroke;
+            rotation?: number;
+        }
     }
 
     namespace tilegrid {
@@ -4710,7 +4721,7 @@ declare namespace ol {
          * Meters per unit lookup table.
          */
         //TODO: validate!
-        var METERS_PER_UNIT: Object;
+        var METERS_PER_UNIT: {[unit: string]: number};
 
         /**
          * Registers coordinate transform functions to convert coordinates between the source projection and the destination projection. The forward and inverse functions convert coordinate pairs; this function converts these into the functions used internally which also handle extents and coordinate arrays.
@@ -4791,6 +4802,24 @@ declare namespace ol {
              * @param extent The new extent of the projection.
              */
             setExtent(extent: Extent): void;
+
+            getCode(): string;
+
+            getMetersPerUnit(): number;
+
+            getPointResolution(resolution: number, point: ol.Coordinate): number;
+
+            getUnits(): ol.proj.Units;
+
+            getWorldExtent(): ol.Extent;
+
+            isGlobal(): boolean;
+
+            setGetPointResolution(func: (n: number, c: ol.Coordinate) => number): void;
+
+            setGlobal(global: boolean): void;
+
+            setWorldExtent(worldExtent: ol.Extent): void;
         }
     }
 
@@ -5045,7 +5074,8 @@ declare namespace ol {
             (feature: Feature): ol.geom.Geometry
         }
 
-        class RegularShape {
+        class RegularShape extends Image {
+            constructor(opts: olx.style.RegularShapeOptions);
         }
 
         class Stroke {

--- a/openlayers/openlayers-3.14.2-tests.ts
+++ b/openlayers/openlayers-3.14.2-tests.ts
@@ -68,6 +68,7 @@ var tilegrid: ol.tilegrid.TileGrid;
 var transformFn: ol.TransformFunction;
 var vectorSource: ol.source.Vector;
 var units: ol.proj.Units;
+var styleRegularShape: ol.style.RegularShape;
 
 //
 // ol.Attribution
@@ -722,3 +723,18 @@ voidValue = interaction.setActive(true);
 const select: ol.interaction.Select = new ol.interaction.Select({
     layers: (layer: ol.layer.Layer) => true,
 });
+
+//
+// ol.style.RegularShape
+//
+
+styleRegularShape = new ol.style.RegularShape({
+    fill: new ol.style.Fill({color: 'red'}),
+    points: 4,
+});
+
+//
+// ol.proj
+//
+
+let value = ol.proj.METERS_PER_UNIT['degrees'];

--- a/openlayers/openlayers-3.14.2.d.ts
+++ b/openlayers/openlayers-3.14.2.d.ts
@@ -865,6 +865,17 @@ declare namespace olx {
             snapToPixel?: boolean;
             stroke?: ol.style.Stroke;
         }
+        interface RegularShapeOptions {
+            fill?: ol.style.Fill;
+            points: number;
+            radius?: number;
+            radius1?: number;
+            radius2?: number;
+            angle?: number;
+            snapToPixel?: boolean;
+            stroke?: ol.style.Stroke;
+            rotation?: number;
+        }
     }
 
     namespace tilegrid {
@@ -4170,7 +4181,7 @@ declare namespace ol {
          * Meters per unit lookup table.
          */
         //TODO: validate!
-        var METERS_PER_UNIT: GlobalObject;
+        var METERS_PER_UNIT: {[unit: string]: number};
 
         /**
          * Registers coordinate transform functions to convert coordinates between the source projection and the destination projection. The forward and inverse functions convert coordinate pairs; this function converts these into the functions used internally which also handle extents and coordinate arrays.
@@ -4535,7 +4546,8 @@ declare namespace ol {
             (feature: Feature): ol.geom.Geometry
         }
 
-        class RegularShape {
+        class RegularShape extends Image {
+            constructor(opts: olx.style.RegularShapeOptions);
         }
 
         class Stroke {


### PR DESCRIPTION
According to the [documentation](http://openlayers.org/en/v3.6.0/apidoc/ol.style.RegularShape.html), `ol.style.RegularShape` extends the `ol.style.Image` type and its constructor takes a `RegularShapeOptions` parameter.

This PR also fixes the `ol.proj.Projection` ([doc](openlayers.org/en/v3.6.0/apidoc/ol.proj.Projection.html)) type by adding the missing methods.
