### PR TITLE
[node] Update cluster definition

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -741,17 +741,30 @@ declare module "http" {
 declare module "cluster" {
     import * as child from "child_process";
     import * as events from "events";
+    import * as net from "net";
 
+    // interfaces
     export interface ClusterSettings {
+        execArgv?: string[]; // default: process.execArgv
         exec?: string;
         args?: string[];
         silent?: boolean;
+        stdio?: any[];
+        uid?: number;
+        gid?: number;
+    }
+
+    export interface ClusterSetupMasterSettings {
+        exec?: string;  // default: process.argv[1]
+        args?: string[];  // default: process.argv.slice(2)
+        silent?: boolean;  // default: false
+        stdio?: any[];
     }
 
     export interface Address {
         address: string;
         port: number;
-        addressType: string;
+        addressType: number | "udp4" | "udp6";  // 4, 6, -1, "udp4", "udp6"
     }
 
     export class Worker extends events.EventEmitter {
@@ -766,33 +779,153 @@ declare module "cluster" {
         isDead(): boolean;
     }
 
-    export var settings: ClusterSettings;
+    export interface Cluster extends events.EventEmitter {
+        Worker: Worker;
+        disconnect(callback?: Function): void;
+        fork(env?: any): Worker;
+        isMaster: boolean;
+        isWorker: boolean;
+        // TODO: cluster.schedulingPolicy
+        settings: ClusterSettings;
+        setupMaster(settings?: ClusterSetupMasterSettings): void;
+        worker: Worker;
+        workers: {
+            [index: string]: Worker
+        }
+
+        /**
+         * events.EventEmitter
+         *   1. disconnect
+         *   2. exit
+         *   3. fork
+         *   4. listening
+         *   5. message
+         *   6. online
+         *   7. setup
+         */
+        addListener(event: string, listener: Function): this;
+        addListener(event: "disconnect", listener: (worker: Worker) => void): this;
+        addListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): this;
+        addListener(event: "fork", listener: (worker: Worker) => void): this;
+        addListener(event: "listening", listener: (worker: Worker, address: Address) => void): this;
+        addListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): this;  // the handle is a net.Socket or net.Server object, or undefined.
+        addListener(event: "online", listener: (worker: Worker) => void): this;
+        addListener(event: "setup", listener: (settings: any) => void): this;
+
+        on(event: string, listener: Function): this;
+        on(event: "disconnect", listener: (worker: Worker) => void): this;
+        on(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): this;
+        on(event: "fork", listener: (worker: Worker) => void): this;
+        on(event: "listening", listener: (worker: Worker, address: Address) => void): this;
+        on(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): this;  // the handle is a net.Socket or net.Server object, or undefined.
+        on(event: "online", listener: (worker: Worker) => void): this;
+        on(event: "setup", listener: (settings: any) => void): this;
+
+        once(event: string, listener: Function): this;
+        once(event: "disconnect", listener: (worker: Worker) => void): this;
+        once(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): this;
+        once(event: "fork", listener: (worker: Worker) => void): this;
+        once(event: "listening", listener: (worker: Worker, address: Address) => void): this;
+        once(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): this;  // the handle is a net.Socket or net.Server object, or undefined.
+        once(event: "online", listener: (worker: Worker) => void): this;
+        once(event: "setup", listener: (settings: any) => void): this;
+
+        prependListener(event: string, listener: Function): this;
+        prependListener(event: "disconnect", listener: (worker: Worker) => void): this;
+        prependListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): this;
+        prependListener(event: "fork", listener: (worker: Worker) => void): this;
+        prependListener(event: "listening", listener: (worker: Worker, address: Address) => void): this;
+        prependListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): this;  // the handle is a net.Socket or net.Server object, or undefined.
+        prependListener(event: "online", listener: (worker: Worker) => void): this;
+        prependListener(event: "setup", listener: (settings: any) => void): this;
+
+        prependOnceListener(event: string, listener: Function): this;
+        prependOnceListener(event: "disconnect", listener: (worker: Worker) => void): this;
+        prependOnceListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): this;
+        prependOnceListener(event: "fork", listener: (worker: Worker) => void): this;
+        prependOnceListener(event: "listening", listener: (worker: Worker, address: Address) => void): this;
+        prependOnceListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): this;  // the handle is a net.Socket or net.Server object, or undefined.
+        prependOnceListener(event: "online", listener: (worker: Worker) => void): this;
+        prependOnceListener(event: "setup", listener: (settings: any) => void): this;
+
+    }
+
+    export function disconnect(callback ?: Function): void;
+    export function fork(env?: any): Worker;
     export var isMaster: boolean;
     export var isWorker: boolean;
-    export function setupMaster(settings?: ClusterSettings): void;
-    export function fork(env?: any): Worker;
-    export function disconnect(callback?: Function): void;
+    // TODO: cluster.schedulingPolicy
+    export var settings: ClusterSettings;
+    export function setupMaster(settings?: ClusterSetupMasterSettings): void;
     export var worker: Worker;
     export var workers: {
         [index: string]: Worker
-    };
+    }
 
-    // Event emitter
-    export function addListener(event: string, listener: Function): void;
-    export function on(event: "disconnect", listener: (worker: Worker) => void): void;
-    export function on(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): void;
-    export function on(event: "fork", listener: (worker: Worker) => void): void;
-    export function on(event: "listening", listener: (worker: Worker, address: any) => void): void;
-    export function on(event: "message", listener: (worker: Worker, message: any) => void): void;
-    export function on(event: "online", listener: (worker: Worker) => void): void;
-    export function on(event: "setup", listener: (settings: any) => void): void;
-    export function on(event: string, listener: Function): any;
-    export function once(event: string, listener: Function): void;
-    export function removeListener(event: string, listener: Function): void;
-    export function removeAllListeners(event?: string): void;
-    export function setMaxListeners(n: number): void;
+    /**
+     * events.EventEmitter
+     *   1. disconnect
+     *   2. exit
+     *   3. fork
+     *   4. listening
+     *   5. message
+     *   6. online
+     *   7. setup
+     */
+    export function addListener(event: string, listener: Function): Cluster;
+    export function addListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+    export function addListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+    export function addListener(event: "fork", listener: (worker: Worker) => void): Cluster;
+    export function addListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+    export function addListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
+    export function addListener(event: "online", listener: (worker: Worker) => void): Cluster;
+    export function addListener(event: "setup", listener: (settings: any) => void): Cluster;
+
+    export function on(event: string, listener: Function): Cluster;
+    export function on(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+    export function on(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+    export function on(event: "fork", listener: (worker: Worker) => void): Cluster;
+    export function on(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+    export function on(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
+    export function on(event: "online", listener: (worker: Worker) => void): Cluster;
+    export function on(event: "setup", listener: (settings: any) => void): Cluster;
+
+    export function once(event: string, listener: Function): Cluster;
+    export function once(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+    export function once(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+    export function once(event: "fork", listener: (worker: Worker) => void): Cluster;
+    export function once(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+    export function once(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
+    export function once(event: "online", listener: (worker: Worker) => void): Cluster;
+    export function once(event: "setup", listener: (settings: any) => void): Cluster;
+
+    export function removeListener(event: string, listener: Function): Cluster;
+    export function removeAllListeners(event?: string): Cluster;
+    export function setMaxListeners(n: number): Cluster;
+    export function getMaxListeners(): number;
     export function listeners(event: string): Function[];
     export function emit(event: string, ...args: any[]): boolean;
+    export function listenerCount(type: string): number;
+
+    export function prependListener(event: string, listener: Function): Cluster;
+    export function prependListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+    export function prependListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+    export function prependListener(event: "fork", listener: (worker: Worker) => void): Cluster;
+    export function prependListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+    export function prependListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
+    export function prependListener(event: "online", listener: (worker: Worker) => void): Cluster;
+    export function prependListener(event: "setup", listener: (settings: any) => void): Cluster;
+
+    export function prependOnceListener(event: string, listener: Function): Cluster;
+    export function prependOnceListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+    export function prependOnceListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+    export function prependOnceListener(event: "fork", listener: (worker: Worker) => void): Cluster;
+    export function prependOnceListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+    export function prependOnceListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
+    export function prependOnceListener(event: "online", listener: (worker: Worker) => void): Cluster;
+    export function prependOnceListener(event: "setup", listener: (settings: any) => void): Cluster;
+
+    export function eventNames(): string[];
 }
 
 declare module "zlib" {

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -791,7 +791,7 @@ declare module "cluster" {
         worker: Worker;
         workers: {
             [index: string]: Worker
-        }
+        };
 
         /**
          * events.EventEmitter
@@ -860,7 +860,7 @@ declare module "cluster" {
     export var worker: Worker;
     export var workers: {
         [index: string]: Worker
-    }
+    };
 
     /**
      * events.EventEmitter


### PR DESCRIPTION
# Improvement to existing type definition
1. Based on [cluster.settings](https://nodejs.org/api/cluster.html#cluster_cluster_settings), it should add `execArgv`, `stdio`, `uid` and `gid` for `ClusterSettings`. 
2. Based on [cluster.setupMaster([settings])](https://nodejs.org/api/cluster.html#cluster_cluster_setupmaster_settings), the `settings` parament is different with `ClusterSettings` interface, so I created `ClusterSetupMasterSettings` interface.
3. Based on events function, it should return itself. I create a `Cluster` interface to replace `export function addListener(event: string, listener: Function): void;` to `addListener(event: string, listener: Function): this;`.  However, `on`, `once`, `prependListener`, `prependOnceListener` are same reason.
4. Based on [Address](https://nodejs.org/api/cluster.html#cluster_event_listening_1), I improved `Adress` interface. And, the `adress` parament of `Event: listening` sould be defined `Address` interface.

---

By the way, the `cluster` is [a `EventEmitter` instance with extra properties](https://github.com/nodejs/node/blob/master/lib/cluster.js#L15). I am difficult to define `cluster` module, so I wrote duplicate codes for `Cluster` interface and `cluster` module in the definition, tried to describe this module.

Originally, my solution is as following:

```
declare module "cluster" {
    interface Cluster extends events.EventEmitter {
        // do something ...
    }
    var cluster: Cluster;
    export = cluster;
}
```

But it will cause `cluster` module exports only one property, not more. I think it's not a good idea.

Does everyone have the better method to solve to write duplicate codes?
