### PR TITLE
[node] Add listening for http.Server

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -592,6 +592,7 @@ declare module "http" {
         setTimeout(msecs: number, callback: Function): void;
         maxHeadersCount: number;
         timeout: number;
+        listening: boolean;
     }
     /**
      * @deprecated Use IncomingMessage


### PR DESCRIPTION
# Improvement to existing type definition

Refer to [server.listening](https://nodejs.org/api/http.html#http_server_listening), it's a boolean property.

Demo code:

```
var http = require('http')
var server = http.createServer();
server.listening // false
```
