### PR TITLE
Improve polylabel ES6 import syntax

### DIFF
--- a/polylabel/polylabel-tests.ts
+++ b/polylabel/polylabel-tests.ts
@@ -1,10 +1,8 @@
 /// <reference path="./polylabel.d.ts" />
-/// <reference path="../node/node.d.ts" />
-import polylabel = require('polylabel');
+import * as polylabel from 'polylabel';
 
 const polygon = [[[3116,3071],[3118,3068],[3108,3102],[3751,927]]]
-let p: number[]
-p = polylabel(polygon)
-p = polylabel(polygon, 1.0)
-p = polylabel(polygon, 1.0, true)
-p = polylabel(polygon, 1.0, false)
+polylabel(polygon)
+polylabel(polygon, 1.0)
+polylabel(polygon, 1.0, true)
+polylabel(polygon, 1.0, false)

--- a/polylabel/polylabel.d.ts
+++ b/polylabel/polylabel.d.ts
@@ -15,7 +15,7 @@
  * - guarantees finding global optimum within the given precision
  * - is many times faster (10-40x)
  */
-declare module 'polylabel' {
+declare module "polylabel" {
     /**
      * Polylabel returns the pole of inaccessibility coordinate in [x, y] format.
      * 
@@ -28,6 +28,7 @@ declare module 'polylabel' {
      * @example
      * var p = polylabel(polygon, 1.0);
      */
-    function polylabel (polygon: number[][][], precision?: number, debug?: boolean): number[];
+    function polylabel(polygon: number[][][], precision?: number, debug?: boolean): number[];
+    namespace polylabel {}
     export = polylabel;
 }


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Using `import * as polylabel from 'polylabel'` is now valid in Typescript vs. require('polylabel').
