### PR TITLE
[restangular]: fix function signatures

### DIFF
--- a/restangular/restangular.d.ts
+++ b/restangular/restangular.d.ts
@@ -84,8 +84,8 @@ declare namespace restangular {
     one(route: string, id?: number): IElement;
     one(route: string, id?: string): IElement;
     oneUrl(route: string, url: string): IElement;
-    all(route: string): IElement;
-    allUrl(route: string, url: string): IElement;
+    all(route: string): ICollection;
+    allUrl(route: string, url: string): ICollection;
     copy(fromElement: any): IElement;
     withConfig(configurer: (RestangularProvider: IProvider) => any): IService;
     restangularizeElement(parent: any, element: any, route: string, collection?: any, reqParams?: any): IElement;
@@ -104,8 +104,6 @@ declare namespace restangular {
     put(queryParams?: any, headers?: any): IPromise<any>;
     post(subElement: any, elementToPost: any, queryParams?: any, headers?: any): IPromise<any>;
     post<T>(subElement: any, elementToPost: T, queryParams?: any, headers?: any): IPromise<T>;
-    post(elementToPost: any, queryParams?: any, headers?: any): IPromise<any>;
-    post<T>(elementToPost: T, queryParams?: any, headers?: any): IPromise<T>;
     remove(queryParams?: any, headers?: any): IPromise<any>;
     head(queryParams?: any, headers?: any): IPromise<any>;
     trace(queryParams?: any, headers?: any): IPromise<any>;


### PR DESCRIPTION
Documentation: https://github.com/mgonto/restangular#restangular-methods

According to the documentation and source code, `all` and `allUrl` return collections, not elements.
Additionally, the `post` signature without `subElement` is only available on collections, not elements.
