### PR TITLE
Add justifyContent to CssProperties

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -1181,6 +1181,12 @@ declare namespace __React {
 
         imeMode?: any;
 
+        /**
+         * Defines how the browser distributes space between and around flex items
+         * along the main-axis of their container.
+         */
+        justifyContent?: "flex-start" | "flex-end" | "center" | "space-between" | "space-around";
+
         layoutGrid?: any;
 
         layoutGridChar?: any;


### PR DESCRIPTION
`justifyContent` was missing from CssProperties and this PR adds it. More information about it [here](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
