### PR TITLE
Refactor View.events definition

### DIFF
--- a/backbone/backbone-global.d.ts
+++ b/backbone/backbone-global.d.ts
@@ -392,7 +392,7 @@ declare namespace Backbone {
         * For assigning events as object hash, do it like this: this.events = <any>{ "event:selector": callback, ... };
         * That works only if you set it in the constructor or the initialize method.
         **/
-        events(): EventsHash;
+        events: (() => EventsHash) | EventsHash;
 
         $(selector: string): JQuery;
         model: TModel;


### PR DESCRIPTION
#11273

Update type definition for `View.events`. Removes the need to cast `<any>{...}` when assigning.
