### PR TITLE
[node] Add events and exitedAfterDisconnect in cluster.work 

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -778,6 +778,55 @@ declare module "cluster" {
         disconnect(): void;
         isConnected(): boolean;
         isDead(): boolean;
+        
+        /**
+         * events.EventEmitter
+         *   1. disconnect
+         *   2. error
+         *   3. exit
+         *   4. listening
+         *   5. message
+         *   6. online
+         */
+        addListener(event: string, listener: Function): this;
+        addListener(event: "disconnect", listener: () => void): this;
+        addListener(event: "error", listener: (code: number, signal: string) => void): this;
+        addListener(event: "exit", listener: (code: number, signal: string) => void): this;
+        addListener(event: "listening", listener: (address: Address) => void): this;
+        addListener(event: "message", listener: (message: any, handle: net.Socket | net.Server) => void): this;  // the handle is a net.Socket or net.Server object, or undefined.
+        addListener(event: "online", listener: () => void): this;
+        
+        on(event: string, listener: Function): this;
+        on(event: "disconnect", listener: () => void): this;
+        on(event: "error", listener: (code: number, signal: string) => void): this;
+        on(event: "exit", listener: (code: number, signal: string) => void): this;
+        on(event: "listening", listener: (address: Address) => void): this;
+        on(event: "message", listener: (message: any, handle: net.Socket | net.Server) => void): this;  // the handle is a net.Socket or net.Server object, or undefined.
+        on(event: "online", listener: () => void): this;
+        
+        once(event: string, listener: Function): this;
+        once(event: "disconnect", listener: () => void): this;
+        once(event: "error", listener: (code: number, signal: string) => void): this;
+        once(event: "exit", listener: (code: number, signal: string) => void): this;
+        once(event: "listening", listener: (address: Address) => void): this;
+        once(event: "message", listener: (message: any, handle: net.Socket | net.Server) => void): this;  // the handle is a net.Socket or net.Server object, or undefined.
+        once(event: "online", listener: () => void): this;
+        
+        prependListener(event: string, listener: Function): this;
+        prependListener(event: "disconnect", listener: () => void): this;
+        prependListener(event: "error", listener: (code: number, signal: string) => void): this;
+        prependListener(event: "exit", listener: (code: number, signal: string) => void): this;
+        prependListener(event: "listening", listener: (address: Address) => void): this;
+        prependListener(event: "message", listener: (message: any, handle: net.Socket | net.Server) => void): this;  // the handle is a net.Socket or net.Server object, or undefined.
+        prependListener(event: "online", listener: () => void): this;
+        
+        prependOnceListener(event: string, listener: Function): this;
+        prependOnceListener(event: "disconnect", listener: () => void): this;
+        prependOnceListener(event: "error", listener: (code: number, signal: string) => void): this;
+        prependOnceListener(event: "exit", listener: (code: number, signal: string) => void): this;
+        prependOnceListener(event: "listening", listener: (address: Address) => void): this;
+        prependOnceListener(event: "message", listener: (message: any, handle: net.Socket | net.Server) => void): this;  // the handle is a net.Socket or net.Server object, or undefined.
+        prependOnceListener(event: "online", listener: () => void): this;
     }
 
     export interface Cluster extends events.EventEmitter {

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -778,6 +778,7 @@ declare module "cluster" {
         disconnect(): void;
         isConnected(): boolean;
         isDead(): boolean;
+        exitedAfterDisconnect: boolean;
         
         /**
          * events.EventEmitter


### PR DESCRIPTION
# Improvement to existing type definition
- Refer to [work events](https://nodejs.org/api/cluster.html#cluster_class_worker), it adds `events`
  - [Event: 'error'](https://nodejs.org/api/cluster.html#cluster_event_error) paraments not mentioned on document. It needs to refer [source code](https://github.com/nodejs/node/blob/master/lib/cluster.js#L51)
- Refer to [worker.exitedAfterDisconnect](https://nodejs.org/api/cluster.html#cluster_worker_exitedafterdisconnect), it adds `exitedAfterDisconnect`.
