### PR TITLE
[node] Add events in fs

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1738,16 +1738,92 @@ declare module "fs" {
 
     interface FSWatcher extends events.EventEmitter {
         close(): void;
+        
+        /**
+         * events.EventEmitter
+         *   1. change
+         *   2. error
+         */
+        addListener(event: string, listener: Function): this;
+        addListener(event: "change", listener: (eventType: string, filename: string | Buffer) => void): this;
+        addListener(event: "error", listener: (code: number, signal: string) => void): this;
+        
+        on(event: string, listener: Function): this;
+        on(event: "change", listener: (eventType: string, filename: string | Buffer) => void): this;
+        on(event: "error", listener: (code: number, signal: string) => void): this;
+        
+        once(event: string, listener: Function): this;
+        once(event: "change", listener: (eventType: string, filename: string | Buffer) => void): this;
+        once(event: "error", listener: (code: number, signal: string) => void): this;
+        
+        prependListener(event: string, listener: Function): this;
+        prependListener(event: "change", listener: (eventType: string, filename: string | Buffer) => void): this;
+        prependListener(event: "error", listener: (code: number, signal: string) => void): this;
+        
+        prependOnceListener(event: string, listener: Function): this;
+        prependOnceListener(event: "change", listener: (eventType: string, filename: string | Buffer) => void): this;
+        prependOnceListener(event: "error", listener: (code: number, signal: string) => void): this;
     }
 
     export interface ReadStream extends stream.Readable {
         close(): void;
         destroy(): void;
+        
+        /**
+         * events.EventEmitter
+         *   1. open
+         *   2. close
+         */
+        addListener(event: string, listener: Function): this;
+        addListener(event: "open", listener: (fd: number) => void): this;
+        addListener(event: "close", listener: () => void): this;
+        
+        on(event: string, listener: Function): this;
+        on(event: "open", listener: (fd: number) => void): this;
+        on(event: "close", listener: () => void): this;
+        
+        once(event: string, listener: Function): this;
+        once(event: "open", listener: (fd: number) => void): this;
+        once(event: "close", listener: () => void): this;
+        
+        prependListener(event: string, listener: Function): this;
+        prependListener(event: "open", listener: (fd: number) => void): this;
+        prependListener(event: "close", listener: () => void): this;
+        
+        prependOnceListener(event: string, listener: Function): this;
+        prependOnceListener(event: "open", listener: (fd: number) => void): this;
+        prependOnceListener(event: "close", listener: () => void): this;
     }
+
     export interface WriteStream extends stream.Writable {
         close(): void;
         bytesWritten: number;
         path: string | Buffer;
+        
+        /**
+         * events.EventEmitter
+         *   1. open
+         *   2. close
+         */
+        addListener(event: string, listener: Function): this;
+        addListener(event: "open", listener: (fd: number) => void): this;
+        addListener(event: "close", listener: () => void): this;
+        
+        on(event: string, listener: Function): this;
+        on(event: "open", listener: (fd: number) => void): this;
+        on(event: "close", listener: () => void): this;
+        
+        once(event: string, listener: Function): this;
+        once(event: "open", listener: (fd: number) => void): this;
+        once(event: "close", listener: () => void): this;
+        
+        prependListener(event: string, listener: Function): this;
+        prependListener(event: "open", listener: (fd: number) => void): this;
+        prependListener(event: "close", listener: () => void): this;
+        
+        prependOnceListener(event: string, listener: Function): this;
+        prependOnceListener(event: "open", listener: (fd: number) => void): this;
+        prependOnceListener(event: "close", listener: () => void): this;
     }
 
     /**


### PR DESCRIPTION
# Improvement to existing type definition
- Add events in [fs.FSWatcher](https://nodejs.org/api/fs.html#fs_class_fs_fswatcher)
- Add events in [fs.ReadStream](https://nodejs.org/api/fs.html#fs_class_fs_readstream)
- Add events in [fs.WriteStream](https://nodejs.org/api/fs.html#fs_class_fs_writestream)
