### PR TITLE
Fix duplicate identifier in express-serve-static-core

### DIFF
--- a/express-serve-static-core/index.d.ts
+++ b/express-serve-static-core/index.d.ts
@@ -14,8 +14,9 @@ declare namespace Express {
     export interface Application { }
 }
 
-declare module "express-serve-static-core" {
-    import * as http from "http";
+import * as http from "http";
+
+declare namespace m {
 
     interface NextFunction {
         (err?: any): void;
@@ -1075,3 +1076,5 @@ declare module "express-serve-static-core" {
         response: Response;
     }
 }
+
+export = m;


### PR DESCRIPTION
Replace module declaration with namespace declaration, so it can be loaded
multiply times without having 'TS2300: Duplicate identifier' errors.
