### PR TITLE
[three.js] Simplify typings by employing "polymorphic this types" for clone()/copy() methods

### DIFF
--- a/threejs/three-canvasrenderer.d.ts
+++ b/threejs/three-canvasrenderer.d.ts
@@ -17,7 +17,6 @@ declare namespace THREE {
         color: Color;
 
         program(context: any, color: Color): void;
-        clone(): SpriteCanvasMaterial;
     }
 
     export interface CanvasRendererParameters {

--- a/threejs/three.d.ts
+++ b/threejs/three.d.ts
@@ -461,9 +461,6 @@ declare namespace THREE {
          * @param vector point to look at
          */
         lookAt(vector: Vector3): void;
-
-        clone(): Camera;
-        copy(camera?: Camera): Camera;
     }
 
     export class CubeCamera extends Object3D {
@@ -540,8 +537,6 @@ declare namespace THREE {
         updateProjectionMatrix(): void;
         setViewOffset(fullWidth: number, fullHeight: number, offsetX: number, offsetY: number, width: number, height: number): void;
         clearViewOffset(): void;
-        clone(): OrthographicCamera;
-        copy(source: OrthographicCamera): OrthographicCamera;
         toJSON(meta?: any): any;
     }
 
@@ -646,7 +641,6 @@ declare namespace THREE {
          * Updates the camera projection matrix. Must be called after change of parameters.
          */
         updateProjectionMatrix(): void;
-        clone(): PerspectiveCamera;
         toJSON(meta?: any): any;
 
         // deprecated
@@ -682,8 +676,8 @@ declare namespace THREE {
         count: number;
 
         setDynamic(dynamic: boolean): BufferAttribute;
-        clone(): BufferAttribute;
-        copy(source: BufferAttribute): BufferAttribute;
+        clone(): this;
+        copy(source: this): this;
         copyAt(index1: number, attribute: BufferAttribute, index2: number): BufferAttribute;
         copyArray(array: ArrayLike<number>): BufferAttribute;
         copyColorsArray(colors: {r: number, g: number, b: number}[]): BufferAttribute;
@@ -703,7 +697,6 @@ declare namespace THREE {
         setXY(index: number, x: number, y: number): BufferAttribute;
         setXYZ(index: number, x: number, y: number, z: number): BufferAttribute;
         setXYZW(index: number, x: number, y: number, z: number, w: number): BufferAttribute;
-        clone(): BufferAttribute;
 
         length: number; // deprecated, use count
     }
@@ -834,8 +827,8 @@ declare namespace THREE {
         toNonIndexed(): BufferGeometry;
 
         toJSON(): any;
-        clone(): BufferGeometry;
-        copy(source: BufferGeometry): BufferGeometry;
+        clone(): this;
+        copy(source: this): this;
 
         /**
          * Disposes the object from memory.
@@ -1086,8 +1079,8 @@ declare namespace THREE {
          */
         materialIndex: number;
 
-        clone(): Face3;
-        copy(source: Face3): Face3;
+        clone(): this;
+        copy(source: this): this;
     }
 
     export class Face4 extends Face3 {} // deprecated, use Face3
@@ -1308,9 +1301,9 @@ declare namespace THREE {
         /**
          * Creates a new clone of the Geometry.
          */
-        clone(): Geometry;
+        clone(): this;
 
-        copy(source: Geometry): Geometry;
+        copy(source: this): this;
 
         /**
          * Removes The object from memory.
@@ -1343,9 +1336,6 @@ declare namespace THREE {
         constructor(data: ArrayLike<number>, itemSize: number, meshPerAttribute?: number);
 
         meshPerAttribute: number;
-
-        clone(): InstancedBufferAttribute;
-        copy(source: InstancedBufferAttribute): InstancedBufferAttribute;
     }
 
     /**
@@ -1358,8 +1348,6 @@ declare namespace THREE {
         maxInstancedCount: number;
 
         addGroup(start: number, count: number, instances: number): void;
-        clone(): InstancedBufferGeometry;
-        copy(source: InstancedBufferGeometry): InstancedBufferGeometry;
     }
 
     /**
@@ -1378,11 +1366,11 @@ declare namespace THREE {
         needsUpdate: boolean;
 
         setDynamic(dynamic: boolean): InterleavedBuffer;
-        clone(): InterleavedBuffer;
-        copy(source: InterleavedBuffer): InterleavedBuffer;
+        clone(): this;
+        copy(source: this): this;
         copyAt(index1: number, attribute: InterleavedBufferAttribute, index2: number): InterleavedBuffer;
         set(value: ArrayLike<number>, index: number): InterleavedBuffer;
-        clone(): InterleavedBuffer;
+        clone(): this;
     }
 
     /**
@@ -1392,9 +1380,6 @@ declare namespace THREE {
         constructor(array: ArrayLike<number>, stride: number, meshPerAttribute?: number);
 
         meshPerAttribute: number;
-
-        clone(): InstancedInterleavedBuffer;
-        copy(source: InstancedInterleavedBuffer): InstancedInterleavedBuffer;
     }
 
     /**
@@ -1686,14 +1671,14 @@ declare namespace THREE {
 
         toJSON(meta?: { geometries: any, materials: any, textures: any, images: any }): any;
 
-        clone(recursive?: boolean): Object3D;
+        clone(recursive?: boolean): this;
 
         /**
          *
          * @param object
          * @param recursive
          */
-        copy(source: Object3D, recursive?: boolean): Object3D;
+        copy(source: this, recursive?: boolean): this;
 
         // deprecated
         eulerOrder: string;
@@ -1777,9 +1762,6 @@ declare namespace THREE {
         shadowBias: any; // deprecated, use shadow.bias
         shadowMapWidth: any; // deprecated, use shadow.mapSize.width
         shadowMapHeight: any; // deprecated, use shadow.mapSize.height
-
-        copy(source: Light): Light;
-        clone(recursive?: boolean): Light;
     }
 
     export class LightShadow {
@@ -1792,8 +1774,8 @@ declare namespace THREE {
         map: RenderTarget;
         matrix: Matrix4;
 
-        copy(source: LightShadow): LightShadow;
-        clone(recursive?: boolean): LightShadow;
+        copy(source: this): this;
+        clone(recursive?: boolean): this;
         toJSON(): any;
     }
 
@@ -1814,9 +1796,6 @@ declare namespace THREE {
         constructor(hex?: number|string, intensity?: number);
 
         castShadow: boolean;
-
-        copy(source: AmbientLight): AmbientLight;
-        clone(recursive?: boolean): AmbientLight;
     }
 
     /**
@@ -1845,9 +1824,6 @@ declare namespace THREE {
         intensity: number;
 
         shadow: LightShadow;
-
-        copy(source: DirectionalLight): DirectionalLight;
-        clone(recursive?: boolean): HemisphereLight;
     }
 
     export class DirectionalLightShadow extends LightShadow {}
@@ -1857,9 +1833,6 @@ declare namespace THREE {
 
         groundColor: Color;
         intensity: number;
-
-        copy(source: HemisphereLight): HemisphereLight;
-        clone(recursive?: boolean): HemisphereLight;
     }
 
     /**
@@ -1888,9 +1861,6 @@ declare namespace THREE {
         decay: number;
         shadow: LightShadow;
         power: number;
-
-        copy(source: PointLight): PointLight;
-        clone(recursive?: boolean): PointLight;
     }
 
     /**
@@ -1933,9 +1903,6 @@ declare namespace THREE {
         shadow: SpotLightShadow;
         power: number;
         penumbra: number;
-
-        clone(recursive?: boolean): SpotLight;
-        copy(source: PointLight): SpotLight;
     }
 
     export class SpotLightShadow extends LightShadow {
@@ -2359,8 +2326,8 @@ declare namespace THREE {
 
         setValues(parameters: MaterialParameters): void;
         toJSON(meta?: any): any;
-        clone(): Material;
-        copy(source: Material): Material;
+        clone(): this;
+        copy(source: this): this;
         update(): void;
         dispose(): void;
 
@@ -2384,8 +2351,6 @@ declare namespace THREE {
         linejoin: string;
 
         setValues(parameters: LineBasicMaterialParameters): void;
-        clone(): LineBasicMaterial;
-        copy(source: LineBasicMaterial): LineBasicMaterial;
     }
 
     export interface LineDashedMaterialParameters extends MaterialParameters {
@@ -2406,8 +2371,6 @@ declare namespace THREE {
         gapSize: number;
 
         setValues(parameters: LineDashedMaterialParameters): void;
-        clone(): LineDashedMaterial;
-        copy(source: LineDashedMaterial): LineDashedMaterial;
     }
 
     /**
@@ -2456,8 +2419,6 @@ declare namespace THREE {
         morphTargets: boolean;
 
         setValues(parameters: MeshBasicMaterialParameters): void;
-        clone(): MeshBasicMaterial;
-        copy(source: MeshBasicMaterial): MeshBasicMaterial;
     }
 
     export interface MeshDepthMaterialParameters extends MaterialParameters {
@@ -2472,8 +2433,6 @@ declare namespace THREE {
         wireframeLinewidth: number;
 
         setValues(parameters: MeshDepthMaterialParameters): void;
-        clone(): MeshDepthMaterial;
-        copy(source: MeshDepthMaterial): MeshDepthMaterial;
     }
 
     export interface MeshLambertMaterialParameters extends MaterialParameters {
@@ -2528,8 +2487,6 @@ declare namespace THREE {
         morphNormals: boolean;
 
         setValues(parameters: MeshLambertMaterialParameters): void;
-        clone(): MeshLambertMaterial;
-        copy(source: MeshLambertMaterial): MeshLambertMaterial;
     }
 
     export interface MeshStandardMaterialParameters extends MaterialParameters {
@@ -2599,8 +2556,6 @@ declare namespace THREE {
         morphNormals: boolean;
 
         setValues(parameters: MeshStandardMaterialParameters): void;
-        clone(): MeshStandardMaterial;
-        copy(source: MeshStandardMaterial): MeshStandardMaterial;
     }
 
     export interface MeshNormalMaterialParameters extends MaterialParameters {
@@ -2619,8 +2574,6 @@ declare namespace THREE {
         morphTargets: boolean;
 
         setValues(parameters: MeshNormalMaterialParameters): void;
-        clone(): MeshNormalMaterial;
-        copy(source: MeshNormalMaterial): MeshNormalMaterial;
     }
 
     export interface MeshPhongMaterialParameters extends MaterialParameters {
@@ -2696,8 +2649,6 @@ declare namespace THREE {
         metal: boolean; // deprecated
 
         setValues(parameters: MeshPhongMaterialParameters): void;
-        clone(): MeshPhongMaterial;
-        copy(source: MeshPhongMaterial): MeshPhongMaterial;
     }
 
     export interface MeshPhysicalMaterialParameters extends MeshStandardMaterialParameters {
@@ -2723,7 +2674,6 @@ declare namespace THREE {
         materials: Material[];
 
         toJSON(meta: any): any;
-        clone(): MultiMaterial;
     }
 
     export class MeshFaceMaterial extends MultiMaterial {} // deprecated, use MultiMaterial
@@ -2744,8 +2694,6 @@ declare namespace THREE {
         sizeAttenuation: boolean;
 
         setValues(parameters: PointsMaterialParameters): void;
-        clone(): PointsMaterial;
-        copy(source: PointsMaterial): PointsMaterial;
     }
 
     export class PointCloudMaterial extends PointsMaterial {} // deprecated
@@ -2788,8 +2736,6 @@ declare namespace THREE {
         index0AttributeName: string;
 
         setValues(parameters: ShaderMaterialParameters): void;
-        clone(): ShaderMaterial;
-        copy(source: ShaderMaterial): ShaderMaterial;
         toJSON(meta: any): any;
     }
 
@@ -2811,8 +2757,6 @@ declare namespace THREE {
         rotation: number;
 
         setValues(parameters: SpriteMaterialParameters): void;
-        clone(): SpriteMaterial;
-        copy(source: SpriteMaterial): SpriteMaterial;
     }
 
     export class ShadowMaterial extends ShaderMaterial {
@@ -2830,8 +2774,8 @@ declare namespace THREE {
         set(min: Vector2, max: Vector2): Box2;
         setFromPoints(points: Vector2[]): Box2;
         setFromCenterAndSize(center: Vector2, size: Vector2): Box2;
-        clone(): Box2;
-        copy(box: Box2): Box2;
+        clone(): this;
+        copy(box: this): this;
         makeEmpty(): Box2;
         isEmpty(): boolean;
         center(optionalTarget?: Vector2): Vector2;
@@ -2865,8 +2809,8 @@ declare namespace THREE {
         setFromPoints(points: Vector3[]): Box3;
         setFromCenterAndSize(center: Vector3, size: Vector3): Box3;
         setFromObject(object: Object3D): Box3;
-        clone(): Box3;
-        copy(box: Box3): Box3;
+        clone(): this;
+        copy(box: this): this;
         makeEmpty(): Box3;
         isEmpty(): boolean;
         center(optionalTarget?: Vector3): Vector3;
@@ -2962,13 +2906,13 @@ declare namespace THREE {
         /**
          * Clones this color.
          */
-        clone(): Color;
+        clone(): this;
 
         /**
          * Copies given color.
          * @param color Color to copy.
          */
-        copy(color: Color): Color;
+        copy(color: this): this;
 
         /**
          * Copies given color making conversion from gamma to linear space.
@@ -3184,8 +3128,8 @@ declare namespace THREE {
         onChangeCallback: Function;
 
         set(x: number, y: number, z: number, order?: string): Euler;
-        clone(): Euler;
-        copy(euler: Euler): Euler;
+        clone(): this;
+        copy(euler: this): this;
         setFromRotationMatrix(m: Matrix4, order?: string, update?: boolean): Euler;
         setFromQuaternion(q: Quaternion, order?: string, update?: boolean): Euler;
         setFromVector3( v: Vector3, order?: string ): Euler;
@@ -3212,8 +3156,8 @@ declare namespace THREE {
         planes: Plane[];
 
         set(p0?: number, p1?: number, p2?: number, p3?: number, p4?: number, p5?: number): Frustum;
-        clone(): Frustum;
-        copy(frustum: Frustum): Frustum;
+        clone(): this;
+        copy(frustum: this): this;
         setFromMatrix(m: Matrix4): Frustum;
         intersectsObject(object: Object3D): boolean;
         intersectsObject(sprite: Sprite): boolean;
@@ -3229,8 +3173,8 @@ declare namespace THREE {
         end: Vector3;
 
         set(start?: Vector3, end?: Vector3): Line3;
-        clone(): Line3;
-        copy(line: Line3): Line3;
+        clone(): this;
+        copy(line: this): this;
         center(optionalTarget?: Vector3): Vector3;
         delta(optionalTarget?: Vector3): Vector3;
         distanceSq(): number;
@@ -3326,7 +3270,7 @@ declare namespace THREE {
         /**
          * copy(m:T):T;
          */
-        copy(m: Matrix): Matrix;
+        copy(m: this): this;
 
         /**
          * multiplyScalar(s:number):T;
@@ -3348,7 +3292,7 @@ declare namespace THREE {
         /**
          * clone():T;
          */
-        clone(): Matrix;
+        clone(): this;
     }
 
     /**
@@ -3367,8 +3311,8 @@ declare namespace THREE {
 
         set(n11: number, n12: number, n13: number, n21: number, n22: number, n23: number, n31: number, n32: number, n33: number): Matrix3;
         identity(): Matrix3;
-        clone(): Matrix3;
-        copy(m: Matrix3): Matrix3;
+        clone(): this;
+        copy(m: this): this;
         setFromMatrix4(m: Matrix4): Matrix3;
         applyToVector3Array(array: ArrayLike<number>, offset?: number, length?: number): ArrayLike<number>;
         applyToBuffer(buffer: BufferAttribute, offset?: number, length?: number): BufferAttribute;
@@ -3431,8 +3375,8 @@ declare namespace THREE {
          * Resets this matrix to identity.
          */
         identity(): Matrix4;
-        clone(): Matrix4;
-        copy(m: Matrix4): Matrix4;
+        clone(): this;
+        copy(m: this): this;
         copyPosition(m: Matrix4): Matrix4;
         extractBasis( xAxis: Vector3, yAxis: Vector3, zAxis: Vector3): Matrix4;
         makeBasis( xAxis: Vector3, yAxis: Vector3, zAxis: Vector3): Matrix4;
@@ -3593,8 +3537,8 @@ declare namespace THREE {
         setComponents(x: number, y: number, z: number, w: number): Plane;
         setFromNormalAndCoplanarPoint(normal: Vector3, point: Vector3): Plane;
         setFromCoplanarPoints(a: Vector3, b: Vector3, c: Vector3): Plane;
-        clone(): Plane;
-        copy(plane: Plane): Plane;
+        clone(): this;
+        copy(plane: this): this;
         normalize(): Plane;
         negate(): Plane;
         distanceToPoint(point: Vector3): number;
@@ -3617,8 +3561,8 @@ declare namespace THREE {
         constructor(radius?: number, phi?: number, theta?: number);
 
         set(radius: number, phi: number, theta: number): Spherical;
-        clone(): Spherical;
-        copy(other: Spherical): Spherical;
+        clone(): this;
+        copy(other: this): this;
         makeSafe(): void;
         setFromVector3(vec3: Vector3): Spherical;
     }
@@ -3654,12 +3598,12 @@ declare namespace THREE {
         /**
          * Clones this quaternion.
          */
-        clone(): Quaternion;
+        clone(): this;
 
         /**
          * Copies values of q to this quaternion.
          */
-        copy(q: Quaternion): Quaternion;
+        copy(q: this): this;
 
         /**
          * Sets this quaternion from rotation specified by Euler angles.
@@ -3739,8 +3683,8 @@ declare namespace THREE {
         direction: Vector3;
 
         set(origin: Vector3, direction: Vector3): Ray;
-        clone(): Ray;
-        copy(ray: Ray): Ray;
+        clone(): this;
+        copy(ray: this): this;
         at(t: number, optionalTarget?: Vector3): Vector3;
         lookAt(v: Vector3): Vector3;
         recast(t: number): Ray;
@@ -3773,8 +3717,8 @@ declare namespace THREE {
 
         set(center: Vector3, radius: number): Sphere;
         setFromPoints(points: Vector3[], optionalCenter?: Vector3): Sphere;
-        clone(): Sphere;
-        copy(sphere: Sphere): Sphere;
+        clone(): this;
+        copy(sphere: this): this;
         empty(): boolean;
         containsPoint(point: Vector3): boolean;
         distanceToPoint(point: Vector3): number;
@@ -3850,8 +3794,8 @@ declare namespace THREE {
 
         set(a: Vector3, b: Vector3, c: Vector3): Triangle;
         setFromPointsAndIndices(points: Vector3[], i0: number, i1: number, i2: number): Triangle;
-        clone(): Triangle;
-        copy(triangle: Triangle): Triangle;
+        clone(): this;
+        copy(triangle: this): this;
         area(): number;
         midpoint(optionalTarget?: Vector3): Vector3;
         normal(optionalTarget?: Vector3): Vector3;
@@ -3885,7 +3829,7 @@ declare namespace THREE {
         /**
          * copy(v:T):T;
          */
-        copy(v: Vector): Vector;
+        copy(v: this): this;
 
         /**
          * add(v:T):T;
@@ -3974,7 +3918,7 @@ declare namespace THREE {
         /**
          * clone():T;
          */
-        clone(): Vector;
+        clone(): this;
     }
 
     /**
@@ -4019,11 +3963,11 @@ declare namespace THREE {
         /**
          * Clones this vector.
          */
-        clone(): Vector2;
+        clone(): this;
         /**
          * Copies value of v to this vector.
          */
-        copy(v: Vector2): Vector2;
+        copy(v: this): this;
 
         /**
          * Adds v to this vector.
@@ -4185,11 +4129,11 @@ declare namespace THREE {
         /**
          * Clones this vector.
          */
-        clone(): Vector3;
+        clone(): this;
         /**
          * Copies value of v to this vector.
          */
-        copy(v: Vector3): Vector3;
+        copy(v: this): this;
 
         /**
          * Adds v to this vector.
@@ -4381,11 +4325,11 @@ declare namespace THREE {
         /**
          * Clones this vector.
          */
-        clone(): Vector4;
+        clone(): this;
         /**
          * Copies value of v to this vector.
          */
-        copy(v: Vector4): Vector4;
+        copy(v: this): this;
 
         /**
          * Adds v to this vector.
@@ -4533,9 +4477,6 @@ declare namespace THREE {
         constructor(skin: SkinnedMesh);
 
         skin: SkinnedMesh;
-
-        clone(): Bone;
-        copy(source: Bone): Bone;
     }
 
     export class Group extends Object3D {
@@ -4551,8 +4492,6 @@ declare namespace THREE {
         getObjectForDistance(distance: number): Object3D;
         raycast(raycaster: Raycaster, intersects: any): void;
         update(camera: Camera): void;
-        clone(): LOD;
-        copy(source: LOD): LOD;
         toJSON(meta: any): any;
 
         // deprecated
@@ -4583,8 +4522,6 @@ declare namespace THREE {
         add(object: Object3D): void;
         add(texture: Texture, size?: number, distance?: number, blending?: Blending, color?: Color): void;
         updateLensFlares(): void;
-        clone(): LensFlare;
-        copy(source: LensFlare): LensFlare;
     }
 
     export class Line extends Object3D {
@@ -4598,8 +4535,6 @@ declare namespace THREE {
         material: Material; // LineDashedMaterial or LineBasicMaterial or ShaderMaterial
 
         raycast(raycaster: Raycaster, intersects: any): void;
-        clone(): Line;
-        copy(source: Line): Line;
     }
 
     export const LineStrip: number; // deprecated
@@ -4611,9 +4546,6 @@ declare namespace THREE {
             material?: LineDashedMaterial | LineBasicMaterial | ShaderMaterial,
             mode?: number
         );
-
-        clone(): LineSegments;
-        copy(source: LineSegments): LineSegments;
     }
 
     enum LineMode {}
@@ -4630,8 +4562,6 @@ declare namespace THREE {
         updateMorphTargets(): void;
         getMorphTargetIndexByName(name: string): number;
         raycast(raycaster: Raycaster, intersects: any): void;
-        clone(): Mesh;
-        copy(source: Mesh): Mesh;
     }
 
     /**
@@ -4661,8 +4591,6 @@ declare namespace THREE {
         material: Material;
 
         raycast(raycaster: Raycaster, intersects: any): void;
-        clone(): Points;
-        copy(source: Points): Points;
     }
 
     export class PointCloud extends Points {} // deprecated
@@ -4683,7 +4611,7 @@ declare namespace THREE {
         calculateInverses(bone: Bone): void;
         pose(): void;
         update(): void;
-        clone(): Skeleton;
+        clone(): this;
     }
 
     export class SkinnedMesh extends Mesh {
@@ -4704,8 +4632,6 @@ declare namespace THREE {
         pose(): void;
         normalizeSkinWeights(): void;
         updateMatrixWorld(force?: boolean): void;
-        clone(): SkinnedMesh;
-        copy(source: SkinnedMesh): SkinnedMesh;
     }
 
     export class Sprite extends Object3D {
@@ -4715,8 +4641,6 @@ declare namespace THREE {
         material: SpriteMaterial;
 
         raycast(raycaster: Raycaster, intersects: any): void;
-        clone(): Sprite;
-        copy(source: Sprite): Sprite;
     }
 
     export class Particle extends Sprite {} // deprecated
@@ -5048,8 +4972,8 @@ declare namespace THREE {
         generateMipmaps: any; // deprecated, use texture.generateMipmaps
 
         setSize(width: number, height: number): void;
-        clone(): WebGLRenderTarget;
-        copy(source: WebGLRenderTarget): WebGLRenderTarget;
+        clone(): this;
+        copy(source: this): this;
         dispose(): void;
     }
 
@@ -5596,14 +5520,13 @@ declare namespace THREE {
         autoUpdate: boolean;
         background: any;
 
-        copy(source: Scene, recursive?: boolean): Scene;
         toJSON(meta?: any): any;
     }
 
     export interface IFog {
         name: string;
         color: Color;
-        clone(): IFog;
+        clone(): this;
         toJSON(): any;
     }
 
@@ -5631,7 +5554,7 @@ declare namespace THREE {
          */
         far: number;
 
-        clone(): Fog;
+        clone(): this;
         toJSON(): any;
     }
 
@@ -5650,7 +5573,7 @@ declare namespace THREE {
          */
         density: number;
 
-        clone(): FogExp2;
+        clone(): this;
         toJSON(): any;
     }
 
@@ -5698,8 +5621,8 @@ declare namespace THREE {
         static DEFAULT_IMAGE: any;
         static DEFAULT_MAPPING: any;
 
-        clone(): Texture;
-        copy(source: Texture): Texture;
+        clone(): this;
+        copy(source: this): this;
         toJSON(meta: any): any;
         dispose(): void;
         transformUv(uv: Vector): void;
@@ -5733,9 +5656,6 @@ declare namespace THREE {
             type?: TextureDataType,
             anisotropy?: number
         );
-
-        clone(): CanvasTexture;
-        copy(source: CanvasTexture): CanvasTexture;
     }
 
     export class CubeTexture extends Texture {
@@ -5753,8 +5673,6 @@ declare namespace THREE {
         );
 
         images: any; // returns and sets the value of Texture.image in the codde ?
-
-        copy(source: CubeTexture): CubeTexture;
     }
 
     export class CompressedTexture extends Texture {
@@ -5774,9 +5692,6 @@ declare namespace THREE {
         );
 
         image: { width: number; height: number; };
-
-        clone(): CompressedTexture;
-        copy(source: CompressedTexture): CompressedTexture;
     }
 
     export class DataTexture extends Texture {
@@ -5796,9 +5711,6 @@ declare namespace THREE {
         );
 
         image: { data: ImageData; width: number; height: number; };
-
-        clone(): DataTexture;
-        copy(source: DataTexture): DataTexture;
     }
 
     export class VideoTexture extends Texture {
@@ -5813,9 +5725,6 @@ declare namespace THREE {
             type?: TextureDataType,
             anisotropy?: number
             );
-
-        clone(): VideoTexture;
-        copy(source: VideoTexture): VideoTexture;
     }
 
     // Extras /////////////////////////////////////////////////////////////////////
@@ -6221,8 +6130,6 @@ declare namespace THREE {
             heightSegments: number;
             depthSegments: number;
         };
-
-        clone(): BoxGeometry;
     }
 
     export class CubeGeometry extends BoxGeometry {} // deprecated, use BoxGeometry
@@ -6306,8 +6213,6 @@ declare namespace THREE {
 
     export class EdgesGeometry extends BufferGeometry {
         constructor(geometry: BufferGeometry, thresholdAngle: number);
-
-        clone(): EdgesGeometry;
     }
 
     export class ExtrudeGeometry extends Geometry {


### PR DESCRIPTION
Note: This also solves TS 2.0 --strictNullChecks errors.
