### PR TITLE
Add angular-feature-flags(https://github.com/mjt01/angular-feature-flags) definitions

### DIFF
--- a/angular-feature-flags/angular-feature-flags-tests.ts
+++ b/angular-feature-flags/angular-feature-flags-tests.ts
@@ -1,0 +1,31 @@
+/// <reference path="angular-feature-flags.d.ts" />
+
+let myApp = angular.module('myApp', ['feature-flags']);
+
+const flagsData: Array<angular.featureflags.FlagData> = [
+    {
+        key: '1',
+        active: true,
+        name: 'flag1',
+        description: 'This is the first flag'
+    },
+    {
+        key: '2',
+        active: false,
+        name: 'flag2',
+        description: 'This is the second flag'
+    }
+];
+
+myApp.config(function (featureFlagsProvider: angular.featureflags.FeatureFlagsProvider) {
+    featureFlagsProvider.setInitialFlags(flagsData);
+});
+
+myApp.run(function ($q: angular.IQService, $http: angular.IHttpService, featureFlags: angular.featureflags.FeatureFlagsService) {
+    let deferred = $q.defer();
+    deferred.resolve(flagsData);
+
+    featureFlags.set(deferred.promise);
+
+    featureFlags.set($http.get('/data/flags.json'));
+});

--- a/angular-feature-flags/angular-feature-flags.d.ts
+++ b/angular-feature-flags/angular-feature-flags.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for angular-feature-flags 1.4.0
+// Project: https://github.com/mjt01/angular-feature-flags
+// Definitions by: Borislav Zhivkov <https://github.com/borislavjivkov/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../angularjs/angular.d.ts" />
+
+declare namespace angular.featureflags {
+    export interface FlagData {
+        /**
+         * Unique key that is used from the markup to resolve whether a flag is active or not.
+         */
+        key: string;
+
+        /**
+         * Boolean value for enabling/disabling the feature
+         */
+        active: boolean;
+
+        /**
+         * A short name of the flag (only visible in the list of flags)
+         */
+        name: string;
+
+        /**
+         * A long description of the flag to further explain the feature being toggled (only visible in the list of flags)
+         */
+        description: string;
+    }
+
+    export interface FeatureFlagsProvider {
+        setInitialFlags(flags: Array<FlagData>): void;
+    }
+
+    export interface FeatureFlagsService {
+        set(flagsPromise: angular.IPromise<FlagData> | angular.IHttpPromise<FlagData>): void;
+    }
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

This pull request adds definition file for angular-feature-flags as requested in #9515
