### PR TITLE
Fix error caused by using nonexistent member of Node.js http module

### DIFF
--- a/express-serve-static-core/index.d.ts
+++ b/express-serve-static-core/index.d.ts
@@ -126,7 +126,7 @@ declare module "express-serve-static-core" {
 
     interface Errback { (err: Error): void; }
 
-    interface Request extends http.ServerRequest, Express.Request {
+    interface Request extends http.ClientRequest, Express.Request {
 
         /**
             * Return request header.


### PR DESCRIPTION
FIxed error in express-serve-static-core/index.d.ts which was caused by extending http.ServerRequest, which is not a member of the Node.js http module. Changed this to http.ClientRequest.
