### PR TITLE
Added the definition for the npm package simple-url-cache

### DIFF
--- a/simple-url-cache/simple-url-cache-tests.ts
+++ b/simple-url-cache/simple-url-cache-tests.ts
@@ -1,0 +1,56 @@
+/// <reference path="./simple-url-cache.d.ts" />
+
+import simpleUrlCache = require("simple-url-cache");
+
+const fileStorageConfig = {
+    type: 'file',
+    dir: './cache'
+};
+
+const redisStorageConfig = {
+    type: 'redis',
+    host: '127.00.1',
+    port: 1234
+}
+
+const regexRules = {
+    cacheMaxAge: [
+        {
+            regex: /.*/,
+            maxAge: 3600
+        }
+    ],
+    cacheAlways: [
+        {
+            regex: /always/
+        }
+    ],
+    cacheNever: [
+        {
+            regex: /never/
+        }
+    ],
+    default: 'never'
+};
+
+const cacheEngine1 = new simpleUrlCache.CacheEngine(fileStorageConfig, regexRules);
+
+let url1 = cacheEngine1.url('/someUrl.html');
+
+url1.cache('<b>some HTML');
+url1.isCached();
+url1.getUrl();
+url1.removeUrl();
+url1.destroy();
+
+const cacheEngine2 = new simpleUrlCache.CacheEngine(redisStorageConfig, regexRules);
+
+let url2 = cacheEngine2.url('/someUrl.html');
+url2.cache('<b>some HTML');
+url2.isCached();
+url2.getUrl();
+url2.removeUrl();
+url2.destroy();
+
+
+

--- a/simple-url-cache/simple-url-cache.d.ts
+++ b/simple-url-cache/simple-url-cache.d.ts
@@ -1,0 +1,112 @@
+// Type definitions for simple-url-cache
+// Project: https://github.com/a-lucas/simple-url-cache
+// Definitions by: Antoine LUCAS <https://github.com/a-lucas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../redis/redis.d.ts" />
+
+
+declare module 'simple-url-cache' {
+    import redis = require("redis");
+
+    namespace SimpleUrlCache {
+        
+        interface RegexRule {
+            regex:RegExp
+        }
+
+        interface MaxAgeRegexRule extends RegexRule {
+            maxAge:number
+        }
+
+        interface CacheRules {
+            cacheMaxAge:MaxAgeRegexRule[],
+            cacheAlways:RegexRule[],
+            cacheNever:RegexRule[],
+            default:string
+        }
+
+        interface StorageConfig {
+            type:string
+        }
+
+        interface FileStorageConfig extends StorageConfig {
+            dir:string;
+        }
+
+        interface RedisStorageConfig extends StorageConfig {
+            host:string;
+            port:number;
+            path?:string;
+            url?:string;
+            socket_keepalive?:boolean;
+            password?:string;
+            db?:string;
+        }
+
+
+        interface CacheStorage {
+            isCached():Promise<boolean>;
+            removeUrl():Promise<boolean>;
+            getUrl():Promise<string>;
+            cache(html:string):Promise<boolean>;
+            cache(html:string, force:boolean):Promise<boolean>;
+            destroy(): void;
+        }
+
+        abstract class CacheCategory {
+            constructor(currentUrl:string, _config:CacheRules) ;
+
+            private getRegexTest(u:RegexRule):boolean;
+
+            private getCacheCategory():string;
+
+            public getCategory():string;
+
+            public getCurrentUrl():string;
+        }
+
+        module RedisPool {
+
+            export function connect(config:RedisStorageConfig): redis.RedisClient;
+
+            export function isOnline():boolean;
+
+            export function kill():void;
+        }
+
+    }
+
+
+    export class FileStorage extends SimpleUrlCache.CacheCategory implements SimpleUrlCache.CacheStorage {
+        constructor(_url:string, _storageConfig: SimpleUrlCache.FileStorageConfig, _regexRules: SimpleUrlCache.CacheRules);
+
+        isCached():Promise<boolean>;
+        removeUrl():Promise<boolean>;
+        getUrl():Promise<string>;
+        cache(html:string):Promise<boolean>
+        cache(html:string, force:boolean):Promise<boolean>;
+
+        destroy(): void;
+    }
+
+    export class RedisStorage extends SimpleUrlCache.CacheCategory implements SimpleUrlCache.CacheStorage {
+        constructor(_url:string, _storageConfig: SimpleUrlCache.RedisStorageConfig, _regexRules: SimpleUrlCache.CacheRules);
+
+        isCached():Promise<boolean>;
+        removeUrl():Promise<boolean>;
+        getUrl():Promise<string>;
+        cache(html:string):Promise<boolean>;
+        cache(html:string, force:boolean):Promise<boolean>;
+        destroy(): void;
+    }
+
+    export class CacheEngine {
+        constructor(storageConfig: SimpleUrlCache.FileStorageConfig, cacheRules: SimpleUrlCache.CacheRules);
+        constructor(storageConfig: SimpleUrlCache.RedisStorageConfig, cacheRules: SimpleUrlCache.CacheRules);
+        url(url: string): FileStorage;
+        url(url: string): RedisStorage;
+    }
+
+
+}

--- a/simple-url-cache/simple-url-cache.d.ts
+++ b/simple-url-cache/simple-url-cache.d.ts
@@ -5,45 +5,56 @@
 
 /// <reference path="../redis/redis.d.ts" />
 
+// Type definitions for simple-url-cache
+// Project: https://github.com/a-lucas/simple-url-cache
+// Definitions by: Antoine LUCAS <https://github.com/a-lucas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
 
 declare module 'simple-url-cache' {
     import redis = require("redis");
 
-    namespace SimpleUrlCache {
-        
-        interface RegexRule {
-            regex:RegExp
-        }
+    export class CacheEngine {
+        constructor(storageConfig: FileStorageConfig, cacheRules: CacheRules);
+        constructor(storageConfig: RedisStorageConfig, cacheRules: CacheRules);
+        url(url: string): FileStorage;
+        url(url: string): RedisStorage;
+    }
 
-        interface MaxAgeRegexRule extends RegexRule {
-            maxAge:number
-        }
+    export interface RegexRule {
+        regex:RegExp
+    }
 
-        interface CacheRules {
-            cacheMaxAge:MaxAgeRegexRule[],
-            cacheAlways:RegexRule[],
-            cacheNever:RegexRule[],
-            default:string
-        }
+    export interface MaxAgeRegexRule extends RegexRule {
+        maxAge:number
+    }
 
+    export interface CacheRules {
+        cacheMaxAge:MaxAgeRegexRule[],
+        cacheAlways:RegexRule[],
+        cacheNever:RegexRule[],
+        default:string
+    }
+
+
+    export interface FileStorageConfig extends privateN.StorageConfig {
+        dir:string;
+    }
+
+    export interface RedisStorageConfig extends privateN.StorageConfig {
+        host:string;
+        port:number;
+        path?:string;
+        url?:string;
+        socket_keepalive?:boolean;
+        password?:string;
+        db?:string;
+    }
+
+    namespace privateN {
         interface StorageConfig {
             type:string
         }
-
-        interface FileStorageConfig extends StorageConfig {
-            dir:string;
-        }
-
-        interface RedisStorageConfig extends StorageConfig {
-            host:string;
-            port:number;
-            path?:string;
-            url?:string;
-            socket_keepalive?:boolean;
-            password?:string;
-            db?:string;
-        }
-
 
         interface CacheStorage {
             isCached():Promise<boolean>;
@@ -77,9 +88,8 @@ declare module 'simple-url-cache' {
 
     }
 
-
-    export class FileStorage extends SimpleUrlCache.CacheCategory implements SimpleUrlCache.CacheStorage {
-        constructor(_url:string, _storageConfig: SimpleUrlCache.FileStorageConfig, _regexRules: SimpleUrlCache.CacheRules);
+    export class FileStorage extends privateN.CacheCategory implements privateN.CacheStorage {
+        constructor(_url:string, _storageConfig: FileStorageConfig, _regexRules: CacheRules);
 
         isCached():Promise<boolean>;
         removeUrl():Promise<boolean>;
@@ -90,8 +100,8 @@ declare module 'simple-url-cache' {
         destroy(): void;
     }
 
-    export class RedisStorage extends SimpleUrlCache.CacheCategory implements SimpleUrlCache.CacheStorage {
-        constructor(_url:string, _storageConfig: SimpleUrlCache.RedisStorageConfig, _regexRules: SimpleUrlCache.CacheRules);
+    export class RedisStorage extends privateN.CacheCategory implements privateN.CacheStorage {
+        constructor(_url:string, _storageConfig: RedisStorageConfig, _regexRules: CacheRules);
 
         isCached():Promise<boolean>;
         removeUrl():Promise<boolean>;
@@ -100,13 +110,4 @@ declare module 'simple-url-cache' {
         cache(html:string, force:boolean):Promise<boolean>;
         destroy(): void;
     }
-
-    export class CacheEngine {
-        constructor(storageConfig: SimpleUrlCache.FileStorageConfig, cacheRules: SimpleUrlCache.CacheRules);
-        constructor(storageConfig: SimpleUrlCache.RedisStorageConfig, cacheRules: SimpleUrlCache.CacheRules);
-        url(url: string): FileStorage;
-        url(url: string): RedisStorage;
-    }
-
-
 }


### PR DESCRIPTION
- [X] npm test passes
- [X] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [X] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [X] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

https://www.npmjs.com/package/simple-url-cache
