### PR TITLE
Added typings for change-emitter@0.1.2

### DIFF
--- a/change-emitter/change-emitter-tests.ts
+++ b/change-emitter/change-emitter-tests.ts
@@ -1,0 +1,124 @@
+/// <reference path="change-emitter.d.ts"/>
+
+import { createChangeEmitter, ChangeEmitterOf0 } from "change-emitter";
+
+function usage() {
+    // https://github.com/acdlite/change-emitter#usage
+
+    const emitter = createChangeEmitter()
+
+    // Called `listen` instead of `subscribe` to avoid confusion with observable spec
+    const unlisten = emitter.listen((...args) => {
+        console.log(args)
+    })
+
+    emitter.emit(1, 2, 3) // logs `[1, 2, 3]`
+    unlisten()
+    emitter.emit(4, 5, 6) // doesn't log
+}
+
+function largerExample() {
+    // https://github.com/acdlite/change-emitter#larger-example
+
+    const createStore = (reducer: Function, initialState: any) => {
+        let state = initialState
+        const emitter = createChangeEmitter()
+
+        function dispatch(action: any) {
+            state = reducer(state, action)
+            emitter.emit()
+            return action
+        }
+
+        function getState() {
+            return state
+        }
+
+        return {
+            dispatch,
+            getState,
+            subscribe: emitter.listen
+        }
+    }
+}
+
+function untypedEmitter() {
+    const { emit, listen } = createChangeEmitter();
+
+    const unlisten0 = listen(() => {/* do something */});
+    const unlisten1 = listen(value => {/* do something with value */});
+    const unlisten2 = listen((value1, value2) => {/* do something with values */});
+    const unlistenArgs = listen((...args: any[]) => {/* do something with values */});
+
+    emit();
+    emit("hello");
+    emit("hello", "world");
+    emit(1, 2, 3, 4, 5);
+
+    unlisten0();
+    unlisten1();
+    unlisten2();
+    unlistenArgs();
+}
+
+function emitterOf0Args() {
+    const { emit, listen }: ChangeEmitterOf0 = createChangeEmitter();
+
+    const unlisten = listen(() => { });
+    // const unlisten = listen(value => {}); // SYNTAX ERROR
+
+    emit();
+    // emit("hello"); // SYNTAX ERROR
+
+    unlisten();
+}
+
+function emitterOf1Args() {
+    const { emit, listen } = createChangeEmitter<string>();
+
+    const unlisten = listen(value => { value.length });
+
+    emit("hello");
+
+    unlisten();
+}
+
+function emitterOf2Args() {
+    const { emit, listen } = createChangeEmitter<string, boolean>();
+
+    const unlisten = listen((value, success) => { value.length > 0 === success });
+
+    emit("hello", true);
+
+    unlisten();
+}
+
+function emitterOf3Args() {
+    const { emit, listen } = createChangeEmitter<string, boolean, number>();
+
+    const unlisten = listen((value, success, count) => { value.length > count === success });
+
+    emit("hello", true, 3);
+
+    unlisten();
+}
+
+function emitterOf4Args() {
+    const { emit, listen } = createChangeEmitter<string, boolean, number, Date>();
+
+    const unlisten = listen((v1, v2, v3, v4) => { });
+
+    emit("hello", true, 3, new Date());
+
+    unlisten();
+}
+
+function emitterOf5Args() {
+    const { emit, listen } = createChangeEmitter<string, boolean, number, Date, string>();
+
+    const unlisten = listen((v1, v2, v3, v4, v5) => { });
+
+    emit("hello", true, 3, new Date(), "world");
+
+    unlisten();
+}

--- a/change-emitter/change-emitter.d.ts
+++ b/change-emitter/change-emitter.d.ts
@@ -1,0 +1,58 @@
+// Type definitions for change-emitter v0.1.2
+// Project: https://github.com/acdlite/change-emitter
+// Definitions by: Iskander Sierra <https://github.com/iskandersierra>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'change-emitter' {
+
+    type Unlisten = () => void;
+    type Listener = (...args: any[]) => void;
+    type ListenerOf0 = () => void;
+    type ListenerOf1<T> = (value: T) => void;
+    type ListenerOf2<T1, T2> = (value1: T1, value2: T2) => void;
+    type ListenerOf3<T1, T2, T3> = (value1: T1, value2: T2, value3: T3) => void;
+    type ListenerOf4<T1, T2, T3, T4> = (value1: T1, value2: T2, value3: T3, value4: T4) => void;
+    type ListenerOf5<T1, T2, T3, T4, T5> = (value1: T1, value2: T2, value3: T3, value4: T4, value5: T5) => void;
+
+    interface ChangeEmitter {
+        listen(listener: Listener): Unlisten;
+        emit(...args: any[]): void;
+    }
+
+    interface ChangeEmitterOf1<T> {
+        listen(listener: ListenerOf1<T>): Unlisten;
+        emit(value: T): void;
+    }
+
+    interface ChangeEmitterOf0 {
+        listen(listener: ListenerOf0): Unlisten;
+        emit(): void;
+    }
+
+    interface ChangeEmitterOf2<T1, T2> {
+        listen(listener: ListenerOf2<T1, T2>): Unlisten;
+        emit(value1: T1, value2: T2): void;
+    }
+
+    interface ChangeEmitterOf3<T1, T2, T3> {
+        listen(listener: ListenerOf3<T1, T2, T3>): Unlisten;
+        emit(value1: T1, value2: T2, value3: T3): void;
+    }
+
+    interface ChangeEmitterOf4<T1, T2, T3, T4> {
+        listen(listener: ListenerOf4<T1, T2, T3, T4>): Unlisten;
+        emit(value1: T1, value2: T2, value3: T3, value4: T4): void;
+    }
+
+    interface ChangeEmitterOf5<T1, T2, T3, T4, T5> {
+        listen(listener: ListenerOf5<T1, T2, T3, T4, T5>): Unlisten;
+        emit(value1: T1, value2: T2, value3: T3, value4: T4, value5: T5): void;
+    }
+
+    export function createChangeEmitter(): ChangeEmitter;
+    export function createChangeEmitter<T>(): ChangeEmitterOf1<T>;
+    export function createChangeEmitter<T1, T2>(): ChangeEmitterOf2<T1, T2>;
+    export function createChangeEmitter<T1, T2, T3>(): ChangeEmitterOf3<T1, T2, T3>;
+    export function createChangeEmitter<T1, T2, T3, T4>(): ChangeEmitterOf4<T1, T2, T3, T4>;
+    export function createChangeEmitter<T1, T2, T3, T4, T5>(): ChangeEmitterOf5<T1, T2, T3, T4, T5>;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

[change-emitter](https://www.npmjs.com/package/change-emitter) on [github](https://github.com/acdlite/change-emitter) and on [travis-ci](https://travis-ci.org/iskandersierra/DefinitelyTyped)
