### PR TITLE
Added the definition for the npm package simple-url-cache

### DIFF
--- a/shelljs/shelljs-tests.ts
+++ b/shelljs/shelljs-tests.ts
@@ -119,6 +119,21 @@ shell.chmod("u+x", "/Users/brandon");
 
 shell.exit(0);
 
+shell.touch('/Users/brandom/test1');
+shell.touch('/Users/brandom/test1', '/Users/brandom/test2');
+
+shell.touch(['/Users/brandom/test1']);
+shell.touch(['/Users/brandom/test1', '/Users/brandom/test2']);
+
+shell.touch('-c', '/Users/brandom/test1');
+shell.touch('-c', '/Users/brandom/test1', '/Users/brandom/test2');
+shell.touch('-c', ['/Users/brandom/test1', '/Users/brandom/test2']);
+
+shell.touch({ '-r': '/some/file.txt' }, '/Users/brandom/test1');
+shell.touch({ '-r': '/some/file.txt' }, '/Users/brandom/test1', '/Users/brandom/test2');
+shell.touch({ '-r': '/oome/file.txt' }, ['/Users/brandom/test1', '/Users/brandom/test2']);
+
+
 var tmp = shell.tempdir(); // "/tmp" for most *nix platforms
 
 var errorlol = shell.error();

--- a/shelljs/shelljs.d.ts
+++ b/shelljs/shelljs.d.ts
@@ -128,7 +128,7 @@ declare module "shelljs"
      * @param {string} dest   The destination.
      */
     export function mv(source: string, dest: string): void;
-    
+
     /**
      * Moves files. The wildcard * is accepted.
      * @param {string[]} source The source.
@@ -436,7 +436,7 @@ declare module "shelljs"
      * Object containing environment variables (both getter and setter). Shortcut to process.env.
      */
     export var env: { [key: string]: string };
-    
+
     /**
      * Executes the given command synchronously.
      * @param  {string}                 command The command to execute.
@@ -510,6 +510,18 @@ declare module "shelljs"
      * @return {string} Returns null if no error occurred, otherwise returns string explaining the error
      */
     export function error(): string;
+
+
+    export function touch(...files: string[]): void;
+    export function touch(files: string[]): void;
+
+    export function touch(options: string, ...files: string[]): void;
+    export function touch(options: string, files: string[]): void;
+    
+    export function touch(options: Object, ...files: string[]): void;
+    export function touch(options: Object, files: string[]): void;
+
+
 
     // Configuration
 

--- a/shelljs/shelljs.d.ts
+++ b/shelljs/shelljs.d.ts
@@ -512,16 +512,25 @@ declare module "shelljs"
     export function error(): string;
 
 
+
     export function touch(...files: string[]): void;
     export function touch(files: string[]): void;
 
-    export function touch(options: string, ...files: string[]): void;
-    export function touch(options: string, files: string[]): void;
-    
-    export function touch(options: Object, ...files: string[]): void;
-    export function touch(options: Object, files: string[]): void;
+    type TouchOptionsLiteral = "-a" |  "-c" | "-m" | "-d" | "-r";
 
+    export function touch(options: TouchOptionsLiteral, ...files: string[]): void;
+    export function touch(options: TouchOptionsLiteral, files: string[]): void;
 
+    /**
+     * Update the access and modification times of each FILE to the current time. A FILE argument that does not exist is created empty, unless -c is supplied
+     */
+    type touchOptionsArray = {
+        '-d'?: string;
+        '-r'?: string;
+    };
+
+    export function touch(options: touchOptionsArray, ...files: string[]): void;
+    export function touch(options: touchOptionsArray, files: string[]): void;
 
     // Configuration
 

--- a/simple-url-cache/simple-url-cache-tests.ts
+++ b/simple-url-cache/simple-url-cache-tests.ts
@@ -1,0 +1,56 @@
+/// <reference path="./simple-url-cache.d.ts" />
+
+import simpleUrlCache = require("simple-url-cache");
+
+const fileStorageConfig = {
+    type: 'file',
+    dir: './cache'
+};
+
+const redisStorageConfig = {
+    type: 'redis',
+    host: '127.00.1',
+    port: 1234
+}
+
+const regexRules = {
+    cacheMaxAge: [
+        {
+            regex: /.*/,
+            maxAge: 3600
+        }
+    ],
+    cacheAlways: [
+        {
+            regex: /always/
+        }
+    ],
+    cacheNever: [
+        {
+            regex: /never/
+        }
+    ],
+    default: 'never'
+};
+
+const cacheEngine1 = new simpleUrlCache.CacheEngine(fileStorageConfig, regexRules);
+
+let url1 = cacheEngine1.url('/someUrl.html');
+
+url1.cache('<b>some HTML');
+url1.isCached();
+url1.getUrl();
+url1.removeUrl();
+url1.destroy();
+
+const cacheEngine2 = new simpleUrlCache.CacheEngine(redisStorageConfig, regexRules);
+
+let url2 = cacheEngine2.url('/someUrl.html');
+url2.cache('<b>some HTML');
+url2.isCached();
+url2.getUrl();
+url2.removeUrl();
+url2.destroy();
+
+
+

--- a/simple-url-cache/simple-url-cache.d.ts
+++ b/simple-url-cache/simple-url-cache.d.ts
@@ -1,0 +1,95 @@
+// Type definitions for simple-url-cache
+// Project: https://github.com/a-lucas/simple-url-cache
+// Definitions by: Antoine LUCAS <https://github.com/a-lucas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../redis/redis.d.ts" />
+
+declare module 'simple-url-cache' {
+    import redis = require("redis");
+
+    export class CacheEngine {
+        constructor(storageConfig: FileStorageConfig, cacheRules: CacheRules);
+        constructor(storageConfig: RedisStorageConfig, cacheRules: CacheRules);
+        url(url: string): FileStorage;
+        url(url: string): RedisStorage;
+    }
+
+    export interface RegexRule {
+        regex:RegExp
+    }
+
+    export interface MaxAgeRegexRule extends RegexRule {
+        maxAge:number
+    }
+
+    export interface CacheRules {
+        cacheMaxAge:MaxAgeRegexRule[],
+        cacheAlways:RegexRule[],
+        cacheNever:RegexRule[],
+        default:string
+    }
+
+    export interface FileStorageConfig extends privateN.StorageConfig {
+        dir:string;
+    }
+
+    export interface RedisStorageConfig extends privateN.StorageConfig {
+        host:string;
+        port:number;
+        path?:string;
+        url?:string;
+        socket_keepalive?:boolean;
+        password?:string;
+        db?:string;
+    }
+
+    namespace privateN {
+        interface StorageConfig {
+            type:string
+        }
+
+        interface CacheStorage {
+            isCached():Promise<boolean>;
+            removeUrl():Promise<boolean>;
+            getUrl():Promise<string>;
+            cache(html:string):Promise<boolean>;
+            cache(html:string, force:boolean):Promise<boolean>;
+            destroy(): void;
+        }
+
+        abstract class CacheCategory {
+            constructor(currentUrl:string, _config:CacheRules) ;
+            private getRegexTest(u:RegexRule):boolean;
+            private getCacheCategory():string;
+            public getCategory():string;
+            public getCurrentUrl():string;
+        }
+
+        module RedisPool {
+            export function connect(config:RedisStorageConfig): redis.RedisClient;
+            export function isOnline():boolean;
+            export function kill():void;
+        }
+    }
+
+    export class FileStorage extends privateN.CacheCategory implements privateN.CacheStorage {
+        constructor(_url:string, _storageConfig: FileStorageConfig, _regexRules: CacheRules);
+        isCached():Promise<boolean>;
+        removeUrl():Promise<boolean>;
+        getUrl():Promise<string>;
+        cache(html:string):Promise<boolean>
+        cache(html:string, force:boolean):Promise<boolean>;
+        destroy(): void;
+    }
+
+    export class RedisStorage extends privateN.CacheCategory implements privateN.CacheStorage {
+        constructor(_url:string, _storageConfig: RedisStorageConfig, _regexRules: CacheRules);
+        isCached():Promise<boolean>;
+        removeUrl():Promise<boolean>;
+        getUrl():Promise<string>;
+        cache(html:string):Promise<boolean>;
+        cache(html:string, force:boolean):Promise<boolean>;
+        destroy(): void;
+    }
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

https://www.npmjs.com/package/simple-url-cache
