### PR TITLE
Add definition for swagger-jsdoc

### DIFF
--- a/swagger-jsdoc/swagger-jsdoc-tests.ts
+++ b/swagger-jsdoc/swagger-jsdoc-tests.ts
@@ -1,0 +1,23 @@
+/// <reference path="swagger-jsdoc.d.ts" />
+/// <reference path="../express/express.d.ts" />
+
+import * as express from 'express';
+const swaggerJsdoc = require('./swagger-jsdoc');
+const app = express();
+
+let options = {
+    swaggerDefinition: {
+        info: {
+            title: 'A test api',
+            version: '1.0.0'
+        }
+    }
+};
+
+let swaggerSpec = swaggerJsdoc(options);
+
+app.get('/api-docs.json', function(req, res) {
+    res.send(swaggerSpec);
+})
+
+app.listen(8888);

--- a/swagger-jsdoc/swagger-jsdoc-tests.ts
+++ b/swagger-jsdoc/swagger-jsdoc-tests.ts
@@ -1,8 +1,8 @@
-/// <reference path="swagger-jsdoc.d.ts" />
 /// <reference path="../express/express.d.ts" />
+/// <reference path="./swagger-jsdoc.d.ts" />
 
 import * as express from 'express';
-const swaggerJsdoc = require('./swagger-jsdoc');
+import swaggerJSDoc = require('./swagger-jsdoc');
 const app = express();
 
 let options = {
@@ -14,7 +14,7 @@ let options = {
     }
 };
 
-let swaggerSpec = swaggerJsdoc(options);
+let swaggerSpec = swaggerJSDoc(options);
 
 app.get('/api-docs.json', function(req, res) {
     res.send(swaggerSpec);

--- a/swagger-jsdoc/swagger-jsdoc-tests.ts
+++ b/swagger-jsdoc/swagger-jsdoc-tests.ts
@@ -2,7 +2,7 @@
 /// <reference path="./swagger-jsdoc.d.ts" />
 
 import * as express from 'express';
-import swaggerJSDoc = require('./swagger-jsdoc');
+import swaggerJSDoc = require('swagger-jsdoc');
 const app = express();
 
 let options = {
@@ -13,6 +13,7 @@ let options = {
         }
     }
 };
+
 
 let swaggerSpec = swaggerJSDoc(options);
 

--- a/swagger-jsdoc/swagger-jsdoc-tests.ts.tscparams
+++ b/swagger-jsdoc/swagger-jsdoc-tests.ts.tscparams
@@ -1,0 +1,1 @@
+-m commonjs

--- a/swagger-jsdoc/swagger-jsdoc.d.ts
+++ b/swagger-jsdoc/swagger-jsdoc.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for Swagger-JSDoc
+// Project: https://github.com/surnet/swagger-jsdoc
+// Definitions by: Daniel Grove <https://github.com/drGrove>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/* =================== USAGE ===================
+
+    import * as Express from "express"
+    const swaggerJsdoc = require('./swagger-jsdoc');
+    const app = new Express()
+
+    let spec = SwaggerJsdoc({
+        swaggerDefinition: {
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+            description: 'A sample API'
+          },
+          host: 'localhost:3000',
+          basePath: '/'
+        },
+        apis: [
+          './example/routes*.js',
+          './example/parameters.yaml'
+        ]
+      }
+    };
+
+    app.get('/api-docs.json', function(req, res) {
+      res.setHeader('Content-Type', 'application/json');
+      res.send(spec);
+    });
+
+ =============================================== */
+interface swaggerOptions {
+    swaggerDefinition: {
+        info: {
+            title: string,
+            version: string
+        },
+        host: string,
+        basePath: string
+    },
+    apis: string[]
+}
+
+declare interface swaggerjsdoc {
+    (options?: swaggerOptions): any
+}
+

--- a/swagger-jsdoc/swagger-jsdoc.d.ts
+++ b/swagger-jsdoc/swagger-jsdoc.d.ts
@@ -5,11 +5,11 @@
 
 /* =================== USAGE ===================
 
-    import * as Express from "express"
-    import swaggerJsdoc = require('./swagger-jsdoc');
-    const app = new Express()
+    import * as express from "express"
+    import swaggerJSDoc = require('swagger-jsdoc');
+    const app = express()
 
-    let spec = SwaggerJSDoc({
+    let options = {
         swaggerDefinition: {
           info: {
             title: 'Hello World',
@@ -25,6 +25,8 @@
         ]
       }
     };
+
+    var spec = swaggerJSDoc(options);
 
     app.get('/api-docs.json', function(req, res) {
       res.setHeader('Content-Type', 'application/json');

--- a/swagger-jsdoc/swagger-jsdoc.d.ts
+++ b/swagger-jsdoc/swagger-jsdoc.d.ts
@@ -34,22 +34,6 @@
  =============================================== */
 
 declare module "swagger-jsdoc" {
-    interface SwaggerDefinition {
-        info: InfoObject,
-        host: string,
-        basePath: string
-    }
-
-    interface InfoObject {
-        title: string,
-        version: string
-    }
-
-    interface swaggerOptions {
-        swaggerDefinition: SwaggerDefinition
-        apis: string[]
-    }
-
-    function swaggerJSDoc(options?: swaggerOptions): any;
+    function swaggerJSDoc(options?: any): any;
     export = swaggerJSDoc;
 }

--- a/swagger-jsdoc/swagger-jsdoc.d.ts
+++ b/swagger-jsdoc/swagger-jsdoc.d.ts
@@ -6,10 +6,10 @@
 /* =================== USAGE ===================
 
     import * as Express from "express"
-    const swaggerJsdoc = require('./swagger-jsdoc');
+    import swaggerJsdoc = require('./swagger-jsdoc');
     const app = new Express()
 
-    let spec = SwaggerJsdoc({
+    let spec = SwaggerJSDoc({
         swaggerDefinition: {
           info: {
             title: 'Hello World',
@@ -32,19 +32,24 @@
     });
 
  =============================================== */
-interface swaggerOptions {
-    swaggerDefinition: {
-        info: {
-            title: string,
-            version: string
-        },
+
+declare module "swagger-jsdoc" {
+    interface SwaggerDefinition {
+        info: InfoObject,
         host: string,
         basePath: string
-    },
-    apis: string[]
-}
+    }
 
-declare interface swaggerjsdoc {
-    (options?: swaggerOptions): any
-}
+    interface InfoObject {
+        title: string,
+        version: string
+    }
 
+    interface swaggerOptions {
+        swaggerDefinition: SwaggerDefinition
+        apis: string[]
+    }
+
+    function swaggerJSDoc(options?: swaggerOptions): any;
+    export = swaggerJSDoc;
+}


### PR DESCRIPTION
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
