### PR TITLE
Update fs-extra-promise to use bluebird@3.x.x

### DIFF
--- a/fs-extra-promise/fs-extra-promise.d.ts
+++ b/fs-extra-promise/fs-extra-promise.d.ts
@@ -6,7 +6,7 @@
 // Imported from: https://github.com/soywiz/typescript-node-definitions/fs-extra.d.ts via TSD fs-extra definition
 
 ///<reference path="../node/node.d.ts"/>
-///<reference path="../bluebird/bluebird-2.0.d.ts"/>
+///<reference path="../bluebird/bluebird.d.ts"/>
 
 declare module "fs-extra-promise" {
 	import stream = require("stream");


### PR DESCRIPTION
case 2. Improvement to existing type definition.
`fs-extra-promise` currently uses `bluebird@^3.4.6` but the definitions require `bluebird@2.x.x` (due to #10561 ).

Source:

``` bash
$ npm info fs-extra-promise@latest dependencies
{ 'fs-extra': '^0.30.0', bluebird: '^3.4.6' }
```
