### PR TITLE
Correct the Angular Material IToastService updateContent typings

### DIFF
--- a/angular-material/angular-material-tests.ts
+++ b/angular-material/angular-material-tests.ts
@@ -132,7 +132,10 @@ myApp.controller('SidenavController', ($scope: ng.IScope, $mdSidenav: ng.materia
 });
 
 myApp.controller('ToastController', ($scope: ng.IScope, $mdToast: ng.material.IToastService) => {
-    $scope['openToast'] = () => $mdToast.show($mdToast.simple().textContent('Hello!'));
+    $scope['openToast'] = () => {
+        $mdToast.show($mdToast.simple().textContent('Hello!'));
+        $mdToast.updateTextContent('New Content');
+    }
 
     $scope['customToast'] = () => {
         var options = {

--- a/angular-material/angular-material.d.ts
+++ b/angular-material/angular-material.d.ts
@@ -177,7 +177,8 @@ declare namespace angular.material {
         showSimple(content: string): angular.IPromise<any>;
         simple(): ISimpleToastPreset;
         build(): IToastPreset<any>;
-        updateContent(): void;
+        updateContent(newContent: string): void;
+        updateTextContent(newContent: string): void
         hide(response?: any): void;
         cancel(response?: any): void;
     }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
updateContent/updateTextContent actually takes an argument
https://github.com/angular/material/blob/8840fb417c7ac708284acd8a4113a52f62fa4bd8/src/components/toast/toast.js#L351
