### PR TITLE
Implemented shapefile definition

### DIFF
--- a/shapefile/shapefile-tests.ts
+++ b/shapefile/shapefile-tests.ts
@@ -1,0 +1,19 @@
+/// <reference path="shapefile.d.ts"/>
+import * as shapefile from 'shapefile'
+
+shapefile.open('./example.shp')
+    .then(source => {
+        source.bbox
+        source.read()
+            .then(result => {
+                result.value
+                result.done
+        })
+    })
+
+shapefile.read("example.shp")
+    .then(result => {
+        result.bbox
+        result.features
+        result.type
+    })

--- a/shapefile/shapefile.d.ts
+++ b/shapefile/shapefile.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for shapefile 0.5.6
+// Project: https://github.com/mbostock/shapefile
+// Definitions by: Denis Carriere <https://github.com/DenisCarriere>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+
+declare const shapefile: shapefile.ShapefileStatic;
+
+declare namespace shapefile {
+    interface Shapefile {
+        _shp: any
+        _dbf: any
+        bbox: Array<number>
+    }
+    interface ShapefileStatic {
+        open(shp: any, dbf?:any, options?:any): Promise<Shapefile>;
+        read(shp: any, dbf?:any, options?:any): Promise<GeoJSON.FeatureCollection<any>>;
+    }
+}
+
+declare module "shapefile" {
+    export = shapefile
+}

--- a/shapefile/shapefile.d.ts
+++ b/shapefile/shapefile.d.ts
@@ -4,7 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../geojson/geojson.d.ts"/>
-/// <reference path="../es6-promise/es6-promise.d.ts"/>
 
 declare const shapefile: shapefile.ShapefileStatic;
 

--- a/shapefile/shapefile.d.ts
+++ b/shapefile/shapefile.d.ts
@@ -3,18 +3,27 @@
 // Definitions by: Denis Carriere <https://github.com/DenisCarriere>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference path="../geojson/geojson.d.ts"/>
+/// <reference path="../es6-promise/es6-promise.d.ts"/>
 
 declare const shapefile: shapefile.ShapefileStatic;
 
 declare namespace shapefile {
+    interface Options {
+        encoding: string
+        highWaterMark: number
+    }
+    interface Feature {
+        done: boolean
+        value: GeoJSON.Feature<any>
+    }
     interface Shapefile {
-        _shp: any
-        _dbf: any
         bbox: Array<number>
+        read(): Promise<Feature>;
     }
     interface ShapefileStatic {
-        open(shp: any, dbf?:any, options?:any): Promise<Shapefile>;
-        read(shp: any, dbf?:any, options?:any): Promise<GeoJSON.FeatureCollection<any>>;
+        open(shp: any, dbf?: any, options?: Options): Promise<Shapefile>;
+        read(shp: any, dbf?: any, options?: Options): Promise<GeoJSON.FeatureCollection<any>>;
     }
 }
 


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Implemented shapefile definition
