### PR TITLE
added type definitions for FiveJS (for learning about typescript definitions)

### DIFF
--- a/five/five-tests.ts
+++ b/five/five-tests.ts
@@ -1,0 +1,60 @@
+/// <reference path="./typings/five.d.ts" />
+
+five.upHigh() // ⁵
+five.downLow() // ₅
+five.tooSlow() // 5, with a ~500 millisecond delay
+five.roman() // V
+five.morseCode() // di-di-di-di-dit
+five.negative() // -5
+five.loud() // FIVE
+five.smooth() // S
+
+five.arabic() // خمسة
+five.azerbaijani() // beş
+five.basque() // bost
+five.bosnian() // pet
+five.bulgarian() // пет
+five.catalan() // cinc
+five.chinese() // 五
+five.choctaw() // tahlapi
+five.croatian() // pet
+five.czech() // pět
+five.dovah() // hen
+five.dutch() // vijf
+five.elvish() // lempe
+five.english() // Five
+five.finnish() // viisi
+five.french() // cinq
+five.german() // fünf
+five.hebrew() // חמש
+five.hindi() // पांच
+five.indonesian() // lima
+five.irish() // cúig
+five.italian() // cinque
+five.japanese() // 五
+five.kannada() // ಐದು
+five.klingon() // vagh
+five.korean() // 오
+five.latin() // quinque
+five.mongolian() // таван
+five.persian() // پنج
+five.piglatin() // ivefay
+five.polish() // pięć
+five.portuguese() // cinco
+five.romanian() // cinci
+five.russian() // пять
+five.slovenian() // pet
+five.spanish() // cinco
+five.swedish() // fem
+five.tamil() // ஐந்து
+five.telugu() // ఐదు
+five.thai() // ห้า
+
+five.binary(); // 101
+five.octal(); // 5
+five.hex(); // 5
+
+five.map([1, 2, 3]); // [5, 5, 5]
+five.reduce([1, 2, 3]); // 5
+
+five.fab(); // ['Juwan Howard','Ray Jackson','Jimmy King','Jalen Rose','Chris Webber']

--- a/five/five.d.ts
+++ b/five/five.d.ts
@@ -1,0 +1,99 @@
+// Type definitions for Five.js 0.8.0
+// Project: https://github.com/jackdcrawford/five
+// Definitions by: Raphi Stein <https://github.com/RaphiStein/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface FiveStatic {
+    (): number;
+
+    // law: ()=>string; // FUTURE VERSION
+
+    upHigh: ()=> string; // ⁵
+    downLow: ()=> string ; // ₅
+    tooSlow: ()=> string; // 5, with a ~500 millisecond delay
+    roman: ()=> string; // V
+    morseCode: ()=> string; // .....
+    negative: ()=> number;
+    loud: (language?:string)=> string;
+    smooth: ()=> string; // S
+    // mdFive: ()=> string; // 30056e1cab7a61d256fc8edd970d14f5 // FUTURE VERSION
+
+    /* Languages */
+
+    arabic: ()=>string; // خمسة
+    azerbaijani: ()=>string; // beş
+    basque: ()=>string; // bost
+    bosnian: ()=>string; // pet
+    bulgarian: ()=>string; // пет
+    catalan: ()=>string; // cinc
+    chinese: ()=>string; // 五
+    choctaw: ()=>string; // tahlapi
+    croatian: ()=>string; // pet
+    czech: ()=>string; // pět
+    dovah: ()=>string; // hen
+    dutch: ()=>string; // vijf
+    elvish: ()=>string; // lempe
+    english: ()=>string; // Five
+    finnish: ()=>string; // viisi
+    french: ()=>string; // cinq
+    german: ()=>string; // fünf
+    hebrew: ()=>string; // חמש
+    hindi: ()=>string; // पांच
+    indonesian: ()=>string; // lima
+    irish: ()=>string; // cúig
+    italian: ()=>string; // cinque
+    japanese: ()=>string; // 五
+    kannada: ()=>string; // ಐದು
+    klingon: ()=>string; // vagh
+    korean: ()=>string; // 오
+    latin: ()=>string; // quinque
+    mongolian: ()=>string; // таван
+    persian: ()=>string; // پنج
+    piglatin: ()=>string; // ivefay
+    polish: ()=>string; // pięć
+    portuguese: ()=>string; // cinco
+    romanian: ()=>string; // cinci
+    russian: ()=>string; // пять
+    slovenian: ()=>string; // pet
+    spanish: ()=>string; // cinco
+    swedish: ()=>string; // fem
+    tamil: ()=>string; // ஐந்து
+    telugu: ()=>string; // ఐదు
+    thai: ()=>string; // ห้า
+
+
+    binary: () => number; // 101
+    octal: () => number; // 5
+    hex: () => number; // 5
+    /*base: (base: number) => number; // 11/*/ // FUTURE VERSION
+
+    // isFive: (num: number) => boolean;  // FUTURE VERSION
+
+    /* Filter, Map and Reduce */
+
+    // filter: (arr:any[])=>number[]; // [5, 5] // FUTURE VERSION
+    map: (arr:any[])=>number[]; // [5, 5, 5]
+    reduce: (arr:any[])=>number[]; // 5
+
+    /* Novelty */
+
+    fab: ()=>string; // ['Juwan Howard','Ray Jackson','Jimmy King','Jalen Rose','Chris Webber']
+
+    // FUTURE VERSION
+    // jackson: ()=>string; // ['Jackie','Tito','Jermaine','Marlon','Michael']
+    // luniz: ()=>string; // ‘I Got 5 on It’
+    // r: ()=>string; // '£5'
+    // funk: ()=>string; // '5 bad boys with the power to rock you'
+    // rot: (str:string) => string; //"knaj.ox"
+
+    // oclock: ()=>string; // '🕔'
+    // guys: ()=>string; // '🍔'
+    //
+}
+
+
+declare var five:FiveStatic;
+
+declare module "Five" {
+    export = five;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
