### PR TITLE
component defines twice in IModalSettings

### DIFF
--- a/angular-ui-bootstrap/angular-ui-bootstrap.d.ts
+++ b/angular-ui-bootstrap/angular-ui-bootstrap.d.ts
@@ -329,13 +329,7 @@ declare namespace angular.ui.bootstrap {
          * @default false
          */
         bindToController?: boolean;
-		
-        /**
-        * A string reference to the component to be rendered that is registered with Angular's compiler.
-        * If using a directive, the directive must have restrict: 'E' and a template or templateUrl set.
-        */
-        component?: string;
-
+	
         /**
          * members that will be resolved and passed to the controller as locals; it is equivalent of the `resolve` property for AngularJS routes
          * If property value is an array, it must be in Inline Array Annotation format for injection (strings followed by factory method)


### PR DESCRIPTION
The property "component" was defined twice in the "IModalSettings".
Removed the one with the lesser comments.
