### PR TITLE
Add parseFiles method to babyparse

### DIFF
--- a/babyparse/babyparse-tests.ts
+++ b/babyparse/babyparse-tests.ts
@@ -329,32 +329,32 @@ var CORE_PARSER_TESTS: ParserTest[] = [
         }
     },
     // {
-    // 	description: "Comment with non-default character",
-    // 	input: 'a,b,c\n!Comment goes here\nd,e,f',
-    // 	config: { comments: '!' },
-    // 	expected: {
-    // 		data: [['a', 'b', 'c'], ['d', 'e', 'f']],
-    // 		errors: []
-    // 	}
+    //   description: "Comment with non-default character",
+    //   input: 'a,b,c\n!Comment goes here\nd,e,f',
+    //   config: { comments: '!' },
+    //   expected: {
+    //     data: [['a', 'b', 'c'], ['d', 'e', 'f']],
+    //     errors: []
+    //   }
     // },
     // {
-    // 	description: "Bad comments value specified",
-    // 	notes: "Should silently disable comment parsing",
-    // 	input: 'a,b,c\n5comment\nd,e,f',
-    // 	config: { comments: 5 },
-    // 	expected: {
-    // 		data: [['a', 'b', 'c'], ['5comment'], ['d', 'e', 'f']],
-    // 		errors: []
-    // 	}
+    //   description: "Bad comments value specified",
+    //   notes: "Should silently disable comment parsing",
+    //   input: 'a,b,c\n5comment\nd,e,f',
+    //   config: { comments: 5 },
+    //   expected: {
+    //     data: [['a', 'b', 'c'], ['5comment'], ['d', 'e', 'f']],
+    //     errors: []
+    //   }
     // },
     // {
-    // 	description: "Multi-character comment string",
-    // 	input: 'a,b,c\n=N(Comment)\nd,e,f',
-    // 	config: { comments: "=N(" },
-    // 	expected: {
-    // 		data: [['a', 'b', 'c'], ['d', 'e', 'f']],
-    // 		errors: []
-    // 	}
+    //   description: "Multi-character comment string",
+    //   input: 'a,b,c\n=N(Comment)\nd,e,f',
+    //   config: { comments: "=N(" },
+    //   expected: {
+    //     data: [['a', 'b', 'c'], ['d', 'e', 'f']],
+    //     errors: []
+    //   }
     // },
     {
         description: "Input with only a commented line",
@@ -419,13 +419,13 @@ var CORE_PARSER_TESTS: ParserTest[] = [
         }
     },
     // {
-    // 	description: "Fast mode with comments",
-    // 	input: '// Commented line\na,b,c',
-    // 	config: { fastMode: true, comments: "//" },
-    // 	expected: {
-    // 		data: [['a', 'b', 'c']],
-    // 		errors: []
-    // 	}
+    //   description: "Fast mode with comments",
+    //   input: '// Commented line\na,b,c',
+    //   config: { fastMode: true, comments: "//" },
+    //   expected: {
+    //     data: [['a', 'b', 'c']],
+    //     errors: []
+    //   }
     // },
     {
         description: "Fast mode with preview",
@@ -1091,7 +1091,7 @@ function compare(actualData: any[], actualErrors: any[], expected: ParserTestExp
             }
         }
 
-        if (passed)	// final check will catch any other differences
+        if (passed)  // final check will catch any other differences
             passed = JSON.stringify(actual) == JSON.stringify(expected);
 
         // We pass back an object right now, even though it only contains
@@ -1228,3 +1228,11 @@ var parser = new Baby.Parser({})
 parser.getCharIndex();
 parser.abort();
 parser.parse("");
+
+/**
+ * Parse Files
+ */
+Baby.parseFiles('example.csv')
+Baby.parseFiles('example.csv', {encoding: 'utf-8'})
+Baby.parseFiles(['example1.csv', 'example2.txt'])
+Baby.parseFiles(['example1.csv', 'example2.txt'], {encoding: 'utf-8'})

--- a/babyparse/babyparse.d.ts
+++ b/babyparse/babyparse.d.ts
@@ -9,6 +9,11 @@ declare namespace BabyParse {
          * Parse a csv string or a csv file
          */
         parse(csvString: string, config?: ParseConfig): ParseResult;
+        
+        /**
+         * Parse single file or multiple files
+         */
+        parseFiles(input: string | string[] | FileObject | FileObject[], config?: ParseConfig): ParseResult;
 
         /**
          * Unparses javascript data objects and returns a csv string
@@ -84,6 +89,11 @@ declare namespace BabyParse {
     interface UnparseObject {
         fields: Array<any>;
         data: string | Array<any>;
+    }
+
+    interface FileObject {
+        file: string
+        config?: ParseConfig
     }
 
     interface ParseError {


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Function `parseFiles` is described in the main Readme.

https://github.com/Rich-Harris/BabyParse#parse-files
