### PR TITLE
Add bulkDocs types

### DIFF
--- a/pouchdb-core/pouchdb-core-tests.ts
+++ b/pouchdb-core/pouchdb-core-tests.ts
@@ -38,6 +38,23 @@ namespace PouchDBCoreTests {
         });
     }
 
+    function testBulkDocs() {
+        const db = new PouchDB<MyModel>();
+        type MyModel = { property: 'someProperty '};
+        let model: PouchDB.Core.Document<MyModel>;
+        let model2: PouchDB.Core.Document<MyModel>;
+
+        db.bulkDocs([model, model2]).then((result) => {
+            result.forEach(({ ok, id, rev }) => {
+                isString(id);
+                isString(rev);
+            });
+        });
+
+        db.bulkDocs([model, model2], null, (error, response) => {
+        });
+    }
+
     function testCompact() {
       const db = new PouchDB<{}>();
       // Promise version

--- a/pouchdb-core/pouchdb-core.d.ts
+++ b/pouchdb-core/pouchdb-core.d.ts
@@ -268,6 +268,12 @@ declare namespace PouchDB {
         allDocs(options?: Core.AllDocsOptions):
             Promise<Core.AllDocsResponse<Content>>;
 
+        bulkDocs(docs: Core.Document<Content>[],
+                 options: Core.PutOptions | void,
+                 callback: Core.Callback<Core.Error, Core.Response[]>): void;
+        bulkDocs(docs: Core.Document<Content>[],
+                 options: Core.PutOptions | void): Promise<Core.Response[]>;
+
         /** Compact the database */
         compact(options?: Core.CompactOptions): Promise<Core.Response>;
         compact(options: Core.CompactOptions,

--- a/pouchdb-core/pouchdb-core.d.ts
+++ b/pouchdb-core/pouchdb-core.d.ts
@@ -272,7 +272,7 @@ declare namespace PouchDB {
                  options: Core.PutOptions | void,
                  callback: Core.Callback<Core.Error, Core.Response[]>): void;
         bulkDocs(docs: Core.Document<Content>[],
-                 options: Core.PutOptions | void): Promise<Core.Response[]>;
+                 options?: Core.PutOptions): Promise<Core.Response[]>;
 
         /** Compact the database */
         compact(options?: Core.CompactOptions): Promise<Core.Response>;


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Hi, I've added bulkDocs to db. I need it and I hope it helps a little.
