### PR TITLE
added typings for parse-mockdb

### DIFF
--- a/parse-mockdb/parse-mockdb-tests.ts
+++ b/parse-mockdb/parse-mockdb-tests.ts
@@ -1,5 +1,7 @@
 /// <reference path="parse-mockdb.d.ts" />
 
+import * as ParseMockDB from "parse-mockdb";
+
 ParseMockDB.mockDB(); // Mock the Parse RESTController
 
 // from parse-mockdb test suite

--- a/parse-mockdb/parse-mockdb-tests.ts
+++ b/parse-mockdb/parse-mockdb-tests.ts
@@ -1,0 +1,25 @@
+/// <reference path="parse-mockdb.d.ts" />
+
+ParseMockDB.mockDB(); // Mock the Parse RESTController
+
+// from parse-mockdb test suite
+ParseMockDB.registerHook("Foo", "beforeSave", (request) => {
+    const object = request.object;
+    if (object.get('error')) {
+        return Parse.Promise.error('whoah');
+    }
+    object.set('cool', true);
+    return Parse.Promise.as(object);
+});
+
+// from parse-mockdb test suite
+ParseMockDB.registerHook("Foo", "beforeDelete", (request) => {
+    const object = request.object;
+    if (object.get('error')) {
+        return Parse.Promise.error('whoah');
+    }
+    return Parse.Promise.as({});
+});
+
+ParseMockDB.cleanUp(); // Clear the Database
+ParseMockDB.unMockDB(); // Un-mock the Parse RESTController

--- a/parse-mockdb/parse-mockdb.d.ts
+++ b/parse-mockdb/parse-mockdb.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for parse-mockdb v0.1.13
+// Project: https://github.com/HustleInc/parse-mockdb
+// Definitions by: David Poetzsch-Heffter <https://github.com/dpoetzsch>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../parse/parse.d.ts" />
+
+declare namespace ParseMockDB {
+    function mockDB(): void;
+    function unMockDB(): void;
+    function cleanUp(): void;
+
+    function promiseResultSync<T>(promise: Parse.IPromise<T>): T;
+
+    type HookType = "beforeSave" | "beforeDelete";
+    function registerHook(className: string, hookType: HookType, hookFn: (request: Parse.Cloud.BeforeSaveRequest) => Parse.IPromise<any>): void;
+}
+
+declare module "parse-mockdb" {
+    export = ParseMockDB;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

This is a type definition for [parse-mockdb](https://github.com/HustleInc/parse-mockdb). It models all exported members (see [file `parse-mockdb.js` line 735ff](https://github.com/HustleInc/parse-mockdb/blob/master/src/parse-mockdb.js)). Typing tests are taken from documentation and the package's test suite.
