### PR TITLE
Node.JS EventEmitter accepts symbols as event names

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -70,7 +70,7 @@ namespace assert_tests {
 
 namespace events_tests {
     let emitter: events.EventEmitter;
-    let event: string;
+    let event: string|symbol;
     let listener: Function;
     let any: any;
 
@@ -114,7 +114,7 @@ namespace events_tests {
     }
 
     {
-        let result: string[];
+        let result: (string|symbol)[];
 
         result = emitter.eventNames();
     }

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -241,20 +241,20 @@ declare namespace NodeJS {
     }
 
     export class EventEmitter {
-        addListener(event: string, listener: Function): this;
-        on(event: string, listener: Function): this;
-        once(event: string, listener: Function): this;
-        removeListener(event: string, listener: Function): this;
-        removeAllListeners(event?: string): this;
+        addListener(event: string|symbol, listener: Function): this;
+        on(event: string|symbol, listener: Function): this;
+        once(event: string|symbol, listener: Function): this;
+        removeListener(event: string|symbol, listener: Function): this;
+        removeAllListeners(event?: string|symbol): this;
         setMaxListeners(n: number): this;
         getMaxListeners(): number;
-        listeners(event: string): Function[];
-        emit(event: string, ...args: any[]): boolean;
-        listenerCount(type: string): number;
+        listeners(event: string|symbol): Function[];
+        emit(event: string|symbol, ...args: any[]): boolean;
+        listenerCount(type: string|symbol): number;
         // Added in Node 6...
-        prependListener(event: string, listener: Function): this;
-        prependOnceListener(event: string, listener: Function): this;
-        eventNames(): string[];
+        prependListener(event: string|symbol, listener: Function): this;
+        prependOnceListener(event: string|symbol, listener: Function): this;
+        eventNames(): (string|symbol)[];
     }
 
     export interface ReadableStream extends EventEmitter {
@@ -549,22 +549,22 @@ declare module "querystring" {
 declare module "events" {
     export class EventEmitter extends NodeJS.EventEmitter {
         static EventEmitter: EventEmitter;
-        static listenerCount(emitter: EventEmitter, event: string): number; // deprecated
+        static listenerCount(emitter: EventEmitter, event: string|symbol): number; // deprecated
         static defaultMaxListeners: number;
 
-        addListener(event: string, listener: Function): this;
-        on(event: string, listener: Function): this;
-        once(event: string, listener: Function): this;
-        prependListener(event: string, listener: Function): this;
-        prependOnceListener(event: string, listener: Function): this;
-        removeListener(event: string, listener: Function): this;
-        removeAllListeners(event?: string): this;
+        addListener(event: string|symbol, listener: Function): this;
+        on(event: string|symbol, listener: Function): this;
+        once(event: string|symbol, listener: Function): this;
+        prependListener(event: string|symbol, listener: Function): this;
+        prependOnceListener(event: string|symbol, listener: Function): this;
+        removeListener(event: string|symbol, listener: Function): this;
+        removeAllListeners(event?: string|symbol): this;
         setMaxListeners(n: number): this;
         getMaxListeners(): number;
-        listeners(event: string): Function[];
-        emit(event: string, ...args: any[]): boolean;
-        eventNames(): string[];
-        listenerCount(type: string): number;
+        listeners(event: string|symbol): Function[];
+        emit(event: string|symbol, ...args: any[]): boolean;
+        eventNames(): (string|symbol)[];
+        listenerCount(type: string|symbol): number;
     }
 }
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.

[Event names are allowed to be symbols as well as strings](https://nodejs.org/api/events.html#events_emitter_on_eventname_listener), since [Node 5.6.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V5.md#2016-02-09-version-560-stable-jasnell).

I haven't applied it to `node-4.d.ts` as it was only introduced in [Node 4.4.0](https://nodejs.org/en/blog/release/v4.4.0/).

The change to `EventEmitter#eventNames()` type is a breaking change to the definition as it now returns a looser set of types, but the API has been like that since 5.6.0, so I don't know what your policy is on this.
