### PR TITLE
Adding typing for co-body [Types 2.0]

### DIFF
--- a/co-body/co-body-tests.ts
+++ b/co-body/co-body-tests.ts
@@ -1,0 +1,44 @@
+/// <reference types="node"/>
+/// <reference types="koa"/>
+
+import * as koa from 'koa';
+import * as parse from 'co-body';
+
+var app = new koa();
+
+app.use(async function (ctx: koa.Context, next: Function): Promise<void> {
+  var body: any;
+
+  // application/json
+  body = await parse.json(ctx.req);
+
+  // explicit limit
+  body = await parse.json(ctx.req, { limit: '10kb' });
+
+  // application/x-www-form-urlencoded
+  body = await parse.form(ctx.req);
+
+  // text/plain
+  body = await parse.text(ctx.req);
+
+  // either
+  body = await parse(ctx.req);
+
+  // custom type
+  body = await parse(ctx.req, { textTypes: ['text', 'html'] });
+
+  // This lib also supports ctx.req in Koa (or other libraries), so that you may simply use this instead of this.req.
+
+  // application/json
+  body = await parse.json(ctx);
+
+  // application/x-www-form-urlencoded
+  body = await parse.form(ctx);
+
+  // text/plain
+  body = await parse.text(ctx);
+
+  // either
+  body = await parse(ctx);
+});
+

--- a/co-body/index.d.ts
+++ b/co-body/index.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for co-body
+// Project: https://github.com/cojs/co-body
+// Definitions by: Joshua DeVinney <https://github.com/geoffreak>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node"/>
+/// <reference types="koa"/>
+/// <reference types="qs"/>
+
+import * as http from 'http';
+import * as Koa from 'koa';
+import * as qs from 'qs';
+
+declare namespace CoBody {
+    type Context = http.IncomingMessage | Koa.Context;
+
+    export interface Parse {
+        (context: Context, options?: Options): Promise<any>;
+        text: (context: Context, options?: Options) => Promise<any>;
+        form: (context: Context, options?: Options) => Promise<any>;
+        json: (context: Context, options?: Options) => Promise<any>;
+    }
+
+    export interface Options {
+        limit?: number | string;
+        strict?: boolean;
+        queryString?: qs.IParseOptions;
+        jsonTypes?: string[];
+        formTypes?: string[];
+        textTypes?: string[];
+        encoding?: string;
+        length?: number;
+    }
+}
+
+declare var CoBody: CoBody.Parse;
+export = CoBody;

--- a/co-body/tsconfig.json
+++ b/co-body/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "co-body-tests.ts"
+    ]
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

---

Typing for [`co-body`](https://github.com/cojs/co-body)
