### PR TITLE
Adding typing for koa-logger [Types 2.0]

### DIFF
--- a/koa-logger/index.d.ts
+++ b/koa-logger/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for koa-logger v2.0
+// Project: https://github.com/koajs/logger
+// Definitions by: Joshua DeVinney <https://github.com/geoffreak>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="koa"/>
+
+import * as Koa from 'koa';
+
+declare var KoaLogger: () => (ctx: Koa.Context, next: () => Promise<any>) => any;
+export = KoaLogger;

--- a/koa-logger/koa-logger-tests.ts
+++ b/koa-logger/koa-logger-tests.ts
@@ -1,0 +1,7 @@
+/// <reference types="koa"/>
+
+import * as koa from 'koa';
+import * as logger from 'koa-logger';
+
+const app = new koa();
+app.use(logger());

--- a/koa-logger/tsconfig.json
+++ b/koa-logger/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "koa-logger-tests.ts"
+    ]
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

---

Typing for [`koa-logger` version 2.0](https://github.com/koajs/logger/tree/next), this time with no silly mistakes in typing.
