### PR TITLE
Add missing type parameter to mongoose.types.array

### DIFF
--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -1,6 +1,10 @@
 /// <reference path="mongoose.d.ts" />
+/// <reference path="../lodash/lodash.d.ts"/>
 
 import * as mongoose from 'mongoose';
+
+// test compatibility with other libraries
+import * as _ from 'lodash';
 var fs = require('fs');
 
 // dummy variables
@@ -458,6 +462,20 @@ mongooseArray.unshift(2, 4, 'hi').toFixed();
 /* inherited properties */
 mongooseArray.concat();
 mongooseArray.length;
+/* practical examples */
+interface MySubEntity extends mongoose.Types.Subdocument {
+  property1: string;
+  property2: string;
+}
+interface MyEntity extends mongoose.Document {
+  sub: mongoose.Types.Array<MySubEntity>
+}
+var myEntity: MyEntity;
+var subDocArray = _.filter(myEntity.sub, function (sd) {
+  sd.property1;
+  sd.property2.toLowerCase();
+});
+
 
 /*
  * section types/documentarray.js
@@ -1397,4 +1415,4 @@ const extended: mongoose.Model<extended> = base.discriminator<extended>('extende
 const x = new extended({
   username: 'hi',     // required in baseSchema
   email: 'beddiw',    // required in extededSchema
-})
+});

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -927,7 +927,7 @@ declare module "mongoose" {
      * section types/array.js
      * http://mongoosejs.com/docs/api.html#types-array-js
      */
-    class Array<T> extends global.Array {
+    class Array<T> extends global.Array<T> {
       /**
        * Atomically shifts the array at most one time per document save().
        * Calling this mulitple times on an array before saving sends the same command as


### PR DESCRIPTION
```
from:
class Array<T> extends global.Array { ... }

to:
class Array<T> extends global.Array<T> { ... }
```

Was causing compatibility issues with lodash array methods.
