### PR TITLE
Add navigationContext to react-native Navigator

### DIFF
--- a/react-native/react-native.d.ts
+++ b/react-native/react-native.d.ts
@@ -3247,6 +3247,19 @@ declare namespace  __React {
         debugOverlay?: boolean
 
     }
+    
+   /**
+   * Class that contains the info and methods for app navigation.
+   */
+    export interface NavigationContext { 
+        parent: NavigationContext,
+        top: NavigationContext,
+        currentRoute: any,
+        appendChild(childContext: NavigationContext): void;
+        addListener(eventType: string, listener: () => void, useCapture?: boolean): NativeEventSubscription;
+        emit(eventType: string, data: any, didEmitCallback?: () => void): void;
+        dispose(): void;
+    }
 
     /**
      * Use Navigator to transition between different scenes in your app.
@@ -3261,6 +3274,8 @@ declare namespace  __React {
         SceneConfigs: SceneConfigs;
         NavigationBar: NavigatorStatic.NavigationBarStatic;
         BreadcrumbNavigationBar: NavigatorStatic.BreadcrumbNavigationBarStatic
+
+	navigationContext: NavigationContext;
 
         getContext( self: any ): NavigatorStatic;
 

--- a/react-native/react-native.d.ts
+++ b/react-native/react-native.d.ts
@@ -3252,9 +3252,9 @@ declare namespace  __React {
    * Class that contains the info and methods for app navigation.
    */
     export interface NavigationContext { 
-        parent: NavigationContext,
-        top: NavigationContext,
-        currentRoute: any,
+        parent: NavigationContext;
+        top: NavigationContext;
+        currentRoute: any;
         appendChild(childContext: NavigationContext): void;
         addListener(eventType: string, listener: () => void, useCapture?: boolean): NativeEventSubscription;
         emit(eventType: string, data: any, didEmitCallback?: () => void): void;
@@ -3273,7 +3273,7 @@ declare namespace  __React {
     export interface NavigatorStatic extends React.ComponentClass<NavigatorProperties> {
         SceneConfigs: SceneConfigs;
         NavigationBar: NavigatorStatic.NavigationBarStatic;
-        BreadcrumbNavigationBar: NavigatorStatic.BreadcrumbNavigationBarStatic
+        BreadcrumbNavigationBar: NavigatorStatic.BreadcrumbNavigationBarStatic;
 
 	navigationContext: NavigationContext;
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.

**react-native\Libraries\CustomComponents\Navigator\Navigator.js**

```
var Navigator = React.createClass({
  ...
  componentWillMount: function() {
    // TODO(t7489503): Don't need this once ES6 Class landed.
    this.__defineGetter__('navigationContext', this._getNavigationContext);

    this._subRouteFocus = [];
    ...
    ... 
}
```

**react-native\Libraries\CustomComponents\Navigator\Navigation\NavigationContext.js**

```
class NavigationContext {
   ...
}
```
