### PR TITLE
Add d3-scale-chromatic definitions and tests.

### DIFF
--- a/d3-scale-chromatic/d3-scale-chromatic-tests.ts
+++ b/d3-scale-chromatic/d3-scale-chromatic-tests.ts
@@ -1,0 +1,60 @@
+/**
+ * Typescript definition tests for d3/d3-scale-chromatic module
+ *
+ * Note: These tests are intended to test the definitions only
+ * in the sense of typing and call signature consistency. They
+ * are not intended as functional tests.
+ */
+
+import * as d3ScaleChromatic from 'd3-scale-chromatic';
+
+// -----------------------------------------------------------------------
+// Categorical
+// -----------------------------------------------------------------------
+let accent: string = d3ScaleChromatic.schemeAccent[0]; // #7fc97f
+let dark: string = d3ScaleChromatic.schemeDark2[0]; // #1b9e77
+let paired: string = d3ScaleChromatic.schemePaired[0]; // #a6cee3
+let pastel1: string = d3ScaleChromatic.schemePastel1[0]; // #fbb4ae
+let pastel2: string = d3ScaleChromatic.schemePastel2[0]; // #b3e2cd
+let set1: string = d3ScaleChromatic.schemeSet1[0]; // #e41a1c
+let set2: string = d3ScaleChromatic.schemeSet2[0]; // #66c2a5
+let set3: string = d3ScaleChromatic.schemeSet3[0]; // #8dd3c7
+
+// -----------------------------------------------------------------------
+// Diverging
+// -----------------------------------------------------------------------
+let BrBG: string = d3ScaleChromatic.interpolateBrBG(0); // rgb(84, 48, 5)
+let PRGn: string = d3ScaleChromatic.interpolatePRGn(0); // rgb(64, 0, 75)
+let PiYG: string = d3ScaleChromatic.interpolatePiYG(0); // rgb(142, 1, 82)
+let PuOr: string = d3ScaleChromatic.interpolatePuOr(0); // rgb(127, 59, 8)
+let RdBu: string = d3ScaleChromatic.interpolateRdBu(0); // rgb(103, 0, 31)
+let RdGy: string = d3ScaleChromatic.interpolateRdGy(0); // rgb(103, 0, 31)
+let RdYlBu: string = d3ScaleChromatic.interpolateRdYlBu(0); // rgb(103, 0, 31)
+let RdYlGn: string = d3ScaleChromatic.interpolateRdYlGn(0); // rgb(103, 0, 31)
+let Spectral: string = d3ScaleChromatic.interpolateSpectral(0); // rgb(158, 1, 66)
+
+// -----------------------------------------------------------------------
+// Sequential
+// -----------------------------------------------------------------------
+let Blue: string = d3ScaleChromatic.interpolateBlues(1); // rgb(8, 48, 107)
+let Green: string = d3ScaleChromatic.interpolateGreens(1); // rgb(0, 68, 27)
+let Grey: string = d3ScaleChromatic.interpolateGreys(1); // rgb(0, 0, 0)
+let Orange: string = d3ScaleChromatic.interpolateOranges(1); // rgb(127, 39, 4)
+let Purple: string = d3ScaleChromatic.interpolatePurples(1); // rgb(63, 0, 125)
+let Red: string = d3ScaleChromatic.interpolateReds(1); // rgb(103, 0, 13)
+
+// -----------------------------------------------------------------------
+// Sequential(Multi-Hue)
+// -----------------------------------------------------------------------
+let BuGn: string = d3ScaleChromatic.interpolateBuGn(1); // rgb(0, 68, 27)
+let BuPu: string = d3ScaleChromatic.interpolateBuPu(1); // rgb(77, 0, 75)
+let GnBu: string = d3ScaleChromatic.interpolateGnBu(1); // rgb(8, 64, 129)
+let OrRd: string = d3ScaleChromatic.interpolateOrRd(1); // rgb(127, 0, 0)
+let PuBuGn: string = d3ScaleChromatic.interpolatePuBuGn(1); // rgb(1, 70, 54)
+let PuBu: string = d3ScaleChromatic.interpolatePuBu(1); // rgb(2, 56, 88)
+let PuRd: string = d3ScaleChromatic.interpolatePuRd(1); // rgb(103, 0, 31)
+let RdPu: string = d3ScaleChromatic.interpolateRdPu(1); // rgb(73, 0, 106)
+let YlGnBu: string = d3ScaleChromatic.interpolateYlGnBu(1); // rgb(8, 29, 88)
+let YlGn: string = d3ScaleChromatic.interpolateYlGn(1); // rgb(0, 69, 41)
+let YlOrBr: string = d3ScaleChromatic.interpolateYlOrBr(1); // rgb(102, 37, 6)
+let YlOrRd: string = d3ScaleChromatic.interpolateYlOrRd(1); // rgb(128, 0, 38)

--- a/d3-scale-chromatic/index.d.ts
+++ b/d3-scale-chromatic/index.d.ts
@@ -1,0 +1,91 @@
+// Type definitions for D3JS d3-scale-chromatic module v1.0.2
+// Project: https://github.com/d3/d3-scale-chromatic/
+// Definitions by: Hugues Stefanski <https://github.com/Ledragon>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// -----------------------------------------------------------------------
+// Categorical
+// -----------------------------------------------------------------------
+/**An array of eight categorical colors represented as RGB hexadecimal strings. */
+export const schemeAccent: Array<string>;
+/**An array of eight categorical colors represented as RGB hexadecimal strings. */
+export const schemeDark2: Array<string>;
+/**An array of twelve categorical colors represented as RGB hexadecimal strings. */
+export const schemePaired: Array<string>;
+/**An array of nine categorical colors represented as RGB hexadecimal strings. */
+export const schemePastel1: Array<string>;
+/**An array of eight categorical colors represented as RGB hexadecimal strings. */
+export const schemePastel2: Array<string>;
+/**An array of nine categorical colors represented as RGB hexadecimal strings. */
+export const schemeSet1: Array<string>;
+/**An array of eight categorical colors represented as RGB hexadecimal strings. */
+export const schemeSet2: Array<string>;
+/**An array of twelve categorical colors represented as RGB hexadecimal strings. */
+export const schemeSet3: Array<string>;
+
+// -----------------------------------------------------------------------
+// Diverging
+// -----------------------------------------------------------------------
+/**Given a number value in the range [0,1], returns the corresponding color from the “BrBG” diverging color scheme represented as an RGB string. */
+export function interpolateBrBG(value: number): string;
+/** Given a number t in the range [0,1], returns the corresponding color from the “PRGn” diverging color scheme represented as an RGB string.*/
+export function interpolatePRGn(value: number): string;
+/** Given a number t in the range [0,1], returns the corresponding color from the “PiYG” diverging color scheme represented as an RGB string.*/
+export function interpolatePiYG(value: number): string;
+/** Given a number t in the range [0,1], returns the corresponding color from the “PuOr” diverging color scheme represented as an RGB string.*/
+export function interpolatePuOr(value: number): string;
+/** Given a number t in the range [0,1], returns the corresponding color from the “RdBu” diverging color scheme represented as an RGB string.*/
+export function interpolateRdBu(value: number): string;
+/** Given a number t in the range [0,1], returns the corresponding color from the “RdGy” diverging color scheme represented as an RGB string.*/
+export function interpolateRdGy(value: number): string;
+/** Given a number t in the range [0,1], returns the corresponding color from the “RdYlBu” diverging color scheme represented as an RGB string.*/
+export function interpolateRdYlBu(value: number): string;
+/** Given a number t in the range [0,1], returns the corresponding color from the “RdYlGn” diverging color scheme represented as an RGB string.*/
+export function interpolateRdYlGn(value: number): string;
+/** Given a number t in the range [0,1], returns the corresponding color from the “Spectral” diverging color scheme represented as an RGB string.*/
+export function interpolateSpectral(value: number): string;
+
+// -----------------------------------------------------------------------
+// Sequential
+// -----------------------------------------------------------------------
+/**Given a number t in the range [0,1], returns the corresponding color from the “Blues” sequential color scheme represented as an RGB string. */
+export function interpolateBlues(value: number): string;
+/**Given a number t in the range [0,1], returns the corresponding color from the “Greens” sequential color scheme represented as an RGB string. */
+export function interpolateGreens(value: number): string;
+/**Given a number t in the range [0,1], returns the corresponding color from the “Greys” sequential color scheme represented as an RGB string. */
+export function interpolateGreys(value: number): string;
+/**Given a number t in the range [0,1], returns the corresponding color from the “Oranges” sequential color scheme represented as an RGB string. */
+export function interpolateOranges(value: number): string;
+/**Given a number t in the range [0,1], returns the corresponding color from the “Purples” sequential color scheme represented as an RGB string. */
+export function interpolatePurples(value: number): string;
+/**Given a number t in the range [0,1], returns the corresponding color from the “Reds” sequential color scheme represented as an RGB string. */
+export function interpolateReds(value: number): string;
+
+// -----------------------------------------------------------------------
+// Sequential(Multi-Hue)
+// -----------------------------------------------------------------------
+
+/**Given a number t in the range [0,1], returns the corresponding color from the “BuGn” sequential color scheme represented as an RGB string. */
+export function interpolateBuGn(value: number): string;
+/**Given a number t in the range [0,1], returns the corresponding color from the “BuPu” sequential color scheme represented as an RGB string. */
+export function interpolateBuPu(value: number): string;
+/**Given a number t in the range [0,1], returns the corresponding color from the “GnBu” sequential color scheme represented as an RGB string. */
+export function interpolateGnBu(value: number): string;
+/**Given a number t in the range [0,1], returns the corresponding color from the “OrRd” sequential color scheme represented as an RGB string. */
+export function interpolateOrRd(value: number): string;
+/**Given a number t in the range [0,1], returns the corresponding color from the “PuBuGn” sequential color scheme represented as an RGB string. */
+export function interpolatePuBuGn(value: number): string;
+/**Given a number t in the range [0,1], returns the corresponding color from the “PuBu” sequential color scheme represented as an RGB string. */
+export function interpolatePuBu(value: number): string;
+/**Given a number t in the range [0,1], returns the corresponding color from the “PuRd” sequential color scheme represented as an RGB string. */
+export function interpolatePuRd(value: number): string;
+/**Given a number t in the range [0,1], returns the corresponding color from the “RdPu” sequential color scheme represented as an RGB string. */
+export function interpolateRdPu(value: number): string;
+/**Given a number t in the range [0,1], returns the corresponding color from the “YlGnBu” sequential color scheme represented as an RGB string. */
+export function interpolateYlGnBu(value: number): string;
+/**Given a number t in the range [0,1], returns the corresponding color from the “YlGn” sequential color scheme represented as an RGB string. */
+export function interpolateYlGn(value: number): string;
+/**Given a number t in the range [0,1], returns the corresponding color from the “YlOrBr” sequential color scheme represented as an RGB string. */
+export function interpolateYlOrBr(value: number): string;
+/**Given a number t in the range [0,1], returns the corresponding color from the “YlOrRd” sequential color scheme represented as an RGB string. */
+export function interpolateYlOrRd(value: number): string;

--- a/d3-scale-chromatic/tsconfig.json
+++ b/d3-scale-chromatic/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "noImplicitAny": true,
+    "strictNullChecks": false,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "d3-scale-chromatic-tests.ts"
+  ]
+}


### PR DESCRIPTION
This PR is related to issue #9936 it adds definitions and tests for **d3-scale-chromatic** provided thanks to @Ledragon .

Thanks in advance for merging it. I reviewed the definitions :+1: 

Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
