### PR TITLE
Correct types of httpVersionMinor and httpVersionMinor

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -658,8 +658,8 @@ declare module "http" {
     }
     export interface IncomingMessage extends stream.Readable {
         httpVersion: string;
-        httpVersionMajor: string;
-        httpVersionMinor: string;
+        httpVersionMajor: number;
+        httpVersionMinor: number;
         connection: net.Socket;
         headers: any;
         rawHeaders: string[];


### PR DESCRIPTION
Correct type of httpVersionMajor and httpVersionMinor in IncomingMessage from string to number.

see e.a. https://github.com/nodejs/node/blob/v6.x/lib/_http_server.js#L92
