### PR TITLE
add i18next-xhr-backend definitions

### DIFF
--- a/i18next-xhr-backend/i18next-xhr-backend-tests.ts
+++ b/i18next-xhr-backend/i18next-xhr-backend-tests.ts
@@ -1,0 +1,21 @@
+/// <reference path="../i18next/i18next"/>
+/// <reference path="i18next-xhr-backend.d.ts"/>
+
+import * as i18next from 'i18next';
+import XHR from 'i18next-xhr-backend';
+
+let options = {
+    loadPath: '',
+    addPath: '',
+    allowMultiLoading: false,
+    parse: function(data:string) { return data.replace(/a/g, ''); },
+    crossDomain: false,
+    withCredentials: false,
+    ajax: function (url:string, options:Object, callback: Function, data: Object) {}
+};
+
+i18next.use(XHR).init({
+    backend: options
+});
+
+let xhr = new XHR(null, options);

--- a/i18next-xhr-backend/i18next-xhr-backend.d.ts
+++ b/i18next-xhr-backend/i18next-xhr-backend.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for i18next-xhr-backend 1.2.0
-// Project: http://i18next.com/
+// Project: https://github.com/i18next/i18next-xhr-backend
 // Definitions by: Jan Mühlemann <https://github.com/jamuhl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
@@ -12,23 +12,25 @@ declare module 'i18next-xhr-backend' {
         interpolator: Interpolator
     }
 
+    interface BackendOptions {
+        loadPath: string | Function,
+        addPath:  string,
+        allowMultiLoading: boolean,
+        parse: Function,
+        crossDomain: boolean,
+        withCredentials: boolean,
+        ajax: Function
+    }
+
     export default class Backend {
         type: 'backend';
         services: Services;
-        options: {
-            loadPath: string | Function,
-            addPath:  string,
-            allowMultiLoading: boolean,
-            parse: () => {},
-            crossDomain: boolean,
-            withCredentials: boolean,
-            ajax: () => void
-        };
-        constructor(services: Services, options?: {});
-        init(services: Services, options?: {}): void;
-        readMulti(languages: any[], namespaces: any[], callback: () => void): void;
-        read(language: {}, namespace: {}, callback: () => void): void;
-        loadUrl(url: string, callback: () => void): void;
+        options: BackendOptions;
+        constructor(services: Services, options?: BackendOptions);
+        init(services: Services, options?: BackendOptions): void;
+        readMulti(languages: any[], namespaces: any[], callback: Function): void;
+        read(language: {}, namespace: {}, callback: Function): void;
+        loadUrl(url: string, callback: Function): void;
         create(languages: any[], namespace: string, key: string, fallbackValue: string): void;
     }
 }

--- a/i18next-xhr-backend/i18next-xhr-backend.d.ts
+++ b/i18next-xhr-backend/i18next-xhr-backend.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for i18next-xhr-backend 1.2.0
+// Project: http://i18next.com/
+// Definitions by: Jan Mühlemann <https://github.com/jamuhl>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'i18next-xhr-backend' {
+
+    interface Interpolator {
+        interpolate: () => string
+    }
+    interface Services {
+        interpolator: Interpolator
+    }
+
+    export default class Backend {
+        type: 'backend';
+        services: Services;
+        options: {
+            loadPath: string | Function,
+            addPath:  string,
+            allowMultiLoading: boolean,
+            parse: () => {},
+            crossDomain: boolean,
+            withCredentials: boolean,
+            ajax: () => void
+        };
+        constructor(services: Services, options?: {});
+        init(services: Services, options?: {}): void;
+        readMulti(languages: any[], namespaces: any[], callback: () => void): void;
+        read(language: {}, namespace: {}, callback: () => void): void;
+        loadUrl(url: string, callback: () => void): void;
+        create(languages: any[], namespace: string, key: string, fallbackValue: string): void;
+    }
+}

--- a/i18next-xhr-backend/i18next-xhr-backend.d.ts
+++ b/i18next-xhr-backend/i18next-xhr-backend.d.ts
@@ -13,21 +13,21 @@ declare module 'i18next-xhr-backend' {
     }
 
     interface BackendOptions {
-        loadPath: string | Function,
-        addPath:  string,
-        allowMultiLoading: boolean,
-        parse: Function,
-        crossDomain: boolean,
-        withCredentials: boolean,
-        ajax: Function
+        loadPath?: string | Function,
+        addPath?:  string,
+        allowMultiLoading?: boolean,
+        parse?: Function,
+        crossDomain?: boolean,
+        withCredentials?: boolean,
+        ajax?: Function
     }
 
     export default class Backend {
         type: 'backend';
         services: Services;
         options: BackendOptions;
-        constructor(services: Services, options?: BackendOptions);
-        init(services: Services, options?: BackendOptions): void;
+        constructor(services?: Services, options?: BackendOptions);
+        init(services?: Services, options?: BackendOptions): void;
         readMulti(languages: any[], namespaces: any[], callback: Function): void;
         read(language: {}, namespace: {}, callback: Function): void;
         loadUrl(url: string, callback: Function): void;


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url https://github.com/i18next/i18next-xhr-backend .
  - it has been reviewed by a DefinitelyTyped member.
