### PR TITLE
HighchartsOptions > series changed to HighchartsSeriesOptions[] type. 

### DIFF
--- a/highcharts/highcharts.d.ts
+++ b/highcharts/highcharts.d.ts
@@ -5483,7 +5483,7 @@ interface HighchartsOptions {
      * for that specific type of plot can be added to a series individually. For example, even though a general
      * lineWidth is specified in plotOptions.series, an individual lineWidth can be specified for each series.
      */
-    series?: HighchartsIndividualSeriesOptions[];
+    series?: HighchartsSeriesOptions[];
     /**
      * The chart's subtitle
      */
@@ -6350,4 +6350,3 @@ declare var Highcharts: HighchartsStatic;
 declare module "highcharts" {
     export = Highcharts;
 }
-


### PR DESCRIPTION
The current series type of  HighchartsIndividualSeriesOptions[] does not allow one to set many properties, like 'dashStyle' for example, for each individual series. Using HighchartsSeriesOptions[] instead works for making these configurations on each individual series as it extends both HighchartsIndividualSeriesOptions and HighchartsSeriesChart.

Eg: One should be able to define dashstyle for each individual series in a line chart. http://api.highcharts.com/highcharts/series%3Cline%3E.dashStyle 

case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
