### PR TITLE
Adding typing for disposable-email-domains [Types 2.0]

### DIFF
--- a/disposable-email-domains/disposable-email-domains-tests.ts
+++ b/disposable-email-domains/disposable-email-domains-tests.ts
@@ -1,0 +1,7 @@
+import * as disposable from 'disposable-email-domains';
+
+let length: number = disposable.length;
+
+for (let domain of disposable) {
+  console.log(domain);
+}

--- a/disposable-email-domains/index.d.ts
+++ b/disposable-email-domains/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for disposable-email-domains v1.0
+// Project: https://github.com/ivolo/disposable-email-domains
+// Definitions by: Joshua DeVinney <https://github.com/geoffreak>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare const domains: string[];
+export = domains;

--- a/disposable-email-domains/tsconfig.json
+++ b/disposable-email-domains/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "disposable-email-domains-tests.ts"
+    ]
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

---

Typing for [`disposable-email-domains`](https://github.com/ivolo/disposable-email-domains)
