### PR TITLE
add request.body

### DIFF
--- a/koa-bodyparser/koa-bodyparser.d.ts
+++ b/koa-bodyparser/koa-bodyparser.d.ts
@@ -20,7 +20,7 @@ declare module "koa-bodyparser" {
     import * as Koa from "koa";
     module "koa" {
         interface Request {
-            body?: any;
+            body: any;
         }
     }
 

--- a/koa-bodyparser/koa-bodyparser.d.ts
+++ b/koa-bodyparser/koa-bodyparser.d.ts
@@ -18,6 +18,11 @@
 declare module "koa-bodyparser" {
 
     import * as Koa from "koa";
+    module "koa" {
+        interface Request {
+            body?: any;
+        }
+    }
 
     function bodyParser(opts?: {
         /**


### PR DESCRIPTION
@jeffijoe has raised an issue to discuss this problem #9992
According to https://github.com/koajs/bodyparser , when the bodyParser middleware is used, a property `body` will be added to the `ctx.request`.  
Otherwise, the typescript will raise error "Property 'body ' does not exist in Request type",
@vvakame
