### PR TITLE
Updated jquery.dataTables for 1.10.7.

### DIFF
--- a/jquery.dataTables/jquery.dataTables-tests.ts
+++ b/jquery.dataTables/jquery.dataTables-tests.ts
@@ -311,6 +311,9 @@ $(document).ready(function () {
 
     var initSettings = dt.init();
 
+    var i18n = dt.i18n('buttons.copy', 'Copy to clipboard');
+    i18n = dt.i18n('select.rows', { _: '%d rows selected', 1: '1 row selected' }, 0);
+
     var off = dt.off("event");
     off = dt.off("event", function () { });
     off.$("");
@@ -900,6 +903,8 @@ $(document).ready(function () {
     //#endregion "Methods-Table"
 
     //#region "Methods-Util"
+
+    var util_1 = dt.any();
 
     //#endregion "Methods-Util"
 });

--- a/jquery.dataTables/jquery.dataTables-tests.ts
+++ b/jquery.dataTables/jquery.dataTables-tests.ts
@@ -311,7 +311,7 @@ $(document).ready(function () {
 
     var initSettings = dt.init();
 
-    var i18n = dt.i18n('buttons.copy', 'Copy to clipboard');
+    var i18n: string = dt.i18n('buttons.copy', 'Copy to clipboard');
     i18n = dt.i18n('select.rows', { _: '%d rows selected', 1: '1 row selected' }, 0);
 
     var off = dt.off("event");
@@ -904,7 +904,7 @@ $(document).ready(function () {
 
     //#region "Methods-Util"
 
-    var util_1 = dt.any();
+    var util_1: boolean = dt.any();
 
     //#endregion "Methods-Util"
 });

--- a/jquery.dataTables/jquery.dataTables.d.ts
+++ b/jquery.dataTables/jquery.dataTables.d.ts
@@ -197,7 +197,7 @@ declare namespace DataTables {
         *
         * @returns Resulting internationalised string.
         */
-        i18n(token: string, def: Object | string, numeric?: number): string;
+        i18n(token: string, def: any | string, numeric?: number): string;
 
         /*
         * Get the initialisation options used for the table. Since: DataTables 1.10.6

--- a/jquery.dataTables/jquery.dataTables.d.ts
+++ b/jquery.dataTables/jquery.dataTables.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for JQuery DataTables 1.10.6
+﻿// Type definitions for JQuery DataTables 1.10.7
 // Project: http://www.datatables.net
 // Definitions by: Kiarash Ghiaseddin <https://github.com/Silver-Connection/DefinitelyTyped>, Omid Rad <https://github.com/omidkrad>, Armin Sander <https://github.com/pragmatrix/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -187,6 +187,17 @@ declare namespace DataTables {
         * @param reset Reset (default) or hold the current paging position. A full re-sort and re-filter is performed when this method is called, which is why the pagination reset is the default action.
         */
         draw(reset?: boolean): DataTable;
+
+        /*
+        * Look up a language token that was defined in the DataTables' language initialisation object.
+        *
+        * @param token The language token to lookup from the language object.
+        * @param def The default value to use if the DataTables initialisation has not specified a value.
+        * @param numeric If handling numeric output, the number to be presented should be given in this parameter. If not numeric operator is required (for example button label text) this parameter is not required.
+        *
+        * @returns Resulting internationalised string.
+        */
+        i18n(token: string, def: Object | string, numeric?: number): string;
 
         /*
         * Get the initialisation options used for the table. Since: DataTables 1.10.6
@@ -412,6 +423,11 @@ declare namespace DataTables {
     //#region "util-methods"
 
     interface UtilityMethods {
+        /*
+        * Get a boolean value to indicate if there are any entries in the API instance's result set (i.e. any data, selected rows, etc).
+        */
+        any(): boolean;
+
         /**
         * Concatenate two or more API instances together
         *


### PR DESCRIPTION
Version release notes: https://cdn.datatables.net/1.10.7/
- Added any()
- Added i18n()

Note: selector-modifier support currently exists with interface ObjectSelectorModifier.
