### PR TITLE
Mongoose: add missing options property in schematype

### DIFF
--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -961,6 +961,7 @@ schematype.unique(true).unique(true);
 schematype.validate(/re/)
   .validate({}, 'error')
   .validate(cb, 'try', 'tri');
+schematype.options.required;
 
 /*
  * section promise.js

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -2011,6 +2011,12 @@ declare module "mongoose" {
      */
     validate(obj: RegExp | Function | Object, errorMsg?: string,
       type?: string): this;
+
+    /**
+     * http://mongoosejs.com/docs/api.html#schematype_SchemaType
+     * Options for this schema type (required, index, etc.)
+     */
+    options: any;
   }
 
   /*


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes. http://mongoosejs.com/docs/api.html#schematype_SchemaType 
  - it has been reviewed by a DefinitelyTyped member.
