### PR TITLE
Support .constructor in chalk typings

### DIFF
--- a/chalk/chalk-tests.ts
+++ b/chalk/chalk-tests.ts
@@ -1,7 +1,7 @@
 import chalk = require('chalk');
 
-var str: string;
-var bool: boolean;
+var str = '';
+var bool = false;
 var chain: chalk.ChalkChain;
 
 chalk.enabled = bool;

--- a/chalk/chalk-tests.ts
+++ b/chalk/chalk-tests.ts
@@ -1,5 +1,3 @@
-
-
 import chalk = require('chalk');
 
 var str: string;
@@ -35,3 +33,10 @@ chain = chain.underline;
 str = chain('someString');
 
 chalk.enabled = chalk.supportsColor = bool;
+
+var chalkObj = new chalk.constructor({enabled: false});
+
+chain = chalkObj.green;
+chain = chalkObj.underline;
+chalkObj.enabled = true;
+str = chain('foo');

--- a/chalk/index.d.ts
+++ b/chalk/index.d.ts
@@ -3,118 +3,150 @@
 // Definitions by: Diullei Gomes <https://github.com/Diullei>, Bart van der Schoor <https://github.com/Bartvds>, Nico Jansen <https://github.com/nicojs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export = Chalk;
+export var enabled: boolean;
+export var supportsColor: boolean;
+export var styles: ChalkStyleMap;
 
-declare namespace Chalk {
+export function stripColor(value: string): any;
+export function hasColor(str: string): boolean;
 
-    export var enabled: boolean;
-    export var supportsColor: boolean;
-    export var styles: ChalkStyleMap;
-
-    export function stripColor(value: string): any;
-    export function hasColor(str: string): boolean;
-
-    export interface ChalkChain extends ChalkStyle {
-        (...text: string[]): string;
-    }
-
-    export interface ChalkStyleElement {
-        open: string;
-        close: string;
-    }
-
-    // General
-    export var reset: ChalkChain;
-    export var bold: ChalkChain;
-    export var italic: ChalkChain;
-    export var underline: ChalkChain;
-    export var inverse: ChalkChain;
-    export var strikethrough: ChalkChain;
-
-    // Text colors
-    export var black: ChalkChain;
-    export var red: ChalkChain;
-    export var green: ChalkChain;
-    export var yellow: ChalkChain;
-    export var blue: ChalkChain;
-    export var magenta: ChalkChain;
-    export var cyan: ChalkChain;
-    export var white: ChalkChain;
-    export var gray: ChalkChain;
-    export var grey: ChalkChain;
-
-    // Background colors
-    export var bgBlack: ChalkChain;
-    export var bgRed: ChalkChain;
-    export var bgGreen: ChalkChain;
-    export var bgYellow: ChalkChain;
-    export var bgBlue: ChalkChain;
-    export var bgMagenta: ChalkChain;
-    export var bgCyan: ChalkChain;
-    export var bgWhite: ChalkChain;
-
-
-    export interface ChalkStyle {
-        // General
-        reset: ChalkChain;
-        bold: ChalkChain;
-        italic: ChalkChain;
-        underline: ChalkChain;
-        inverse: ChalkChain;
-        strikethrough: ChalkChain;
-
-        // Text colors
-        black: ChalkChain;
-        red: ChalkChain;
-        green: ChalkChain;
-        yellow: ChalkChain;
-        blue: ChalkChain;
-        magenta: ChalkChain;
-        cyan: ChalkChain;
-        white: ChalkChain;
-        gray: ChalkChain;
-        grey: ChalkChain;
-
-        // Background colors
-        bgBlack: ChalkChain;
-        bgRed: ChalkChain;
-        bgGreen: ChalkChain;
-        bgYellow: ChalkChain;
-        bgBlue: ChalkChain;
-        bgMagenta: ChalkChain;
-        bgCyan: ChalkChain;
-        bgWhite: ChalkChain;
-    }
-
-    export interface ChalkStyleMap {
-        // General
-        reset: ChalkStyleElement;
-        bold: ChalkStyleElement;
-        italic: ChalkStyleElement;
-        underline: ChalkStyleElement;
-        inverse: ChalkStyleElement;
-        strikethrough: ChalkStyleElement;
-
-        // Text colors
-        black: ChalkStyleElement;
-        red: ChalkStyleElement;
-        green: ChalkStyleElement;
-        yellow: ChalkStyleElement;
-        blue: ChalkStyleElement;
-        magenta: ChalkStyleElement;
-        cyan: ChalkStyleElement;
-        white: ChalkStyleElement;
-        gray: ChalkStyleElement;
-
-        // Background colors
-        bgBlack: ChalkStyleElement;
-        bgRed: ChalkStyleElement;
-        bgGreen: ChalkStyleElement;
-        bgYellow: ChalkStyleElement;
-        bgBlue: ChalkStyleElement;
-        bgMagenta: ChalkStyleElement;
-        bgCyan: ChalkStyleElement;
-        bgWhite: ChalkStyleElement;
-    }
+export interface ChalkChain extends ChalkStyle {
+    (...text: string[]): string;
 }
 
+export interface ChalkStyleElement {
+    open: string;
+    close: string;
+}
+
+// General
+export var reset: ChalkChain;
+export var bold: ChalkChain;
+export var italic: ChalkChain;
+export var underline: ChalkChain;
+export var inverse: ChalkChain;
+export var strikethrough: ChalkChain;
+
+// Text colors
+export var black: ChalkChain;
+export var red: ChalkChain;
+export var green: ChalkChain;
+export var yellow: ChalkChain;
+export var blue: ChalkChain;
+export var magenta: ChalkChain;
+export var cyan: ChalkChain;
+export var white: ChalkChain;
+export var gray: ChalkChain;
+export var grey: ChalkChain;
+
+// Background colors
+export var bgBlack: ChalkChain;
+export var bgRed: ChalkChain;
+export var bgGreen: ChalkChain;
+export var bgYellow: ChalkChain;
+export var bgBlue: ChalkChain;
+export var bgMagenta: ChalkChain;
+export var bgCyan: ChalkChain;
+export var bgWhite: ChalkChain;
+
+
+export interface ChalkStyle {
+    // General
+    reset: ChalkChain;
+    bold: ChalkChain;
+    italic: ChalkChain;
+    underline: ChalkChain;
+    inverse: ChalkChain;
+    strikethrough: ChalkChain;
+
+    // Text colors
+    black: ChalkChain;
+    red: ChalkChain;
+    green: ChalkChain;
+    yellow: ChalkChain;
+    blue: ChalkChain;
+    magenta: ChalkChain;
+    cyan: ChalkChain;
+    white: ChalkChain;
+    gray: ChalkChain;
+    grey: ChalkChain;
+
+    // Background colors
+    bgBlack: ChalkChain;
+    bgRed: ChalkChain;
+    bgGreen: ChalkChain;
+    bgYellow: ChalkChain;
+    bgBlue: ChalkChain;
+    bgMagenta: ChalkChain;
+    bgCyan: ChalkChain;
+    bgWhite: ChalkChain;
+}
+
+export interface ChalkStyleMap {
+    // General
+    reset: ChalkStyleElement;
+    bold: ChalkStyleElement;
+    italic: ChalkStyleElement;
+    underline: ChalkStyleElement;
+    inverse: ChalkStyleElement;
+    strikethrough: ChalkStyleElement;
+
+    // Text colors
+    black: ChalkStyleElement;
+    red: ChalkStyleElement;
+    green: ChalkStyleElement;
+    yellow: ChalkStyleElement;
+    blue: ChalkStyleElement;
+    magenta: ChalkStyleElement;
+    cyan: ChalkStyleElement;
+    white: ChalkStyleElement;
+    gray: ChalkStyleElement;
+
+    // Background colors
+    bgBlack: ChalkStyleElement;
+    bgRed: ChalkStyleElement;
+    bgGreen: ChalkStyleElement;
+    bgYellow: ChalkStyleElement;
+    bgBlue: ChalkStyleElement;
+    bgMagenta: ChalkStyleElement;
+    bgCyan: ChalkStyleElement;
+    bgWhite: ChalkStyleElement;
+}
+
+export const constructor: {
+    new (options: {enabled: boolean}): Chalk;
+}
+
+export interface Chalk {
+    enabled: boolean;
+
+    // General
+    reset: ChalkChain;
+    bold: ChalkChain;
+    italic: ChalkChain;
+    underline: ChalkChain;
+    inverse: ChalkChain;
+    strikethrough: ChalkChain;
+
+    // Text colors
+    black: ChalkChain;
+    red: ChalkChain;
+    green: ChalkChain;
+    yellow: ChalkChain;
+    blue: ChalkChain;
+    magenta: ChalkChain;
+    cyan: ChalkChain;
+    white: ChalkChain;
+    gray: ChalkChain;
+    grey: ChalkChain;
+
+    // Background colors
+    bgBlack: ChalkChain;
+    bgRed: ChalkChain;
+    bgGreen: ChalkChain;
+    bgYellow: ChalkChain;
+    bgBlue: ChalkChain;
+    bgMagenta: ChalkChain;
+    bgCyan: ChalkChain;
+    bgWhite: ChalkChain;
+}

--- a/chalk/index.d.ts
+++ b/chalk/index.d.ts
@@ -3,150 +3,131 @@
 // Definitions by: Diullei Gomes <https://github.com/Diullei>, Bart van der Schoor <https://github.com/Bartvds>, Nico Jansen <https://github.com/nicojs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export var enabled: boolean;
-export var supportsColor: boolean;
-export var styles: ChalkStyleMap;
+export = Chalk;
 
-export function stripColor(value: string): any;
-export function hasColor(str: string): boolean;
+declare namespace Chalk {
+    export var enabled: boolean;
+    export var supportsColor: boolean;
+    export var styles: ChalkStyleMap;
 
-export interface ChalkChain extends ChalkStyle {
-    (...text: string[]): string;
-}
+    export function stripColor(value: string): any;
+    export function hasColor(str: string): boolean;
 
-export interface ChalkStyleElement {
-    open: string;
-    close: string;
-}
+    export interface ChalkChain extends ChalkStyle {
+        (): false;
+        (...text: string[]): string;
+    }
 
-// General
-export var reset: ChalkChain;
-export var bold: ChalkChain;
-export var italic: ChalkChain;
-export var underline: ChalkChain;
-export var inverse: ChalkChain;
-export var strikethrough: ChalkChain;
-
-// Text colors
-export var black: ChalkChain;
-export var red: ChalkChain;
-export var green: ChalkChain;
-export var yellow: ChalkChain;
-export var blue: ChalkChain;
-export var magenta: ChalkChain;
-export var cyan: ChalkChain;
-export var white: ChalkChain;
-export var gray: ChalkChain;
-export var grey: ChalkChain;
-
-// Background colors
-export var bgBlack: ChalkChain;
-export var bgRed: ChalkChain;
-export var bgGreen: ChalkChain;
-export var bgYellow: ChalkChain;
-export var bgBlue: ChalkChain;
-export var bgMagenta: ChalkChain;
-export var bgCyan: ChalkChain;
-export var bgWhite: ChalkChain;
-
-
-export interface ChalkStyle {
-    // General
-    reset: ChalkChain;
-    bold: ChalkChain;
-    italic: ChalkChain;
-    underline: ChalkChain;
-    inverse: ChalkChain;
-    strikethrough: ChalkChain;
-
-    // Text colors
-    black: ChalkChain;
-    red: ChalkChain;
-    green: ChalkChain;
-    yellow: ChalkChain;
-    blue: ChalkChain;
-    magenta: ChalkChain;
-    cyan: ChalkChain;
-    white: ChalkChain;
-    gray: ChalkChain;
-    grey: ChalkChain;
-
-    // Background colors
-    bgBlack: ChalkChain;
-    bgRed: ChalkChain;
-    bgGreen: ChalkChain;
-    bgYellow: ChalkChain;
-    bgBlue: ChalkChain;
-    bgMagenta: ChalkChain;
-    bgCyan: ChalkChain;
-    bgWhite: ChalkChain;
-}
-
-export interface ChalkStyleMap {
-    // General
-    reset: ChalkStyleElement;
-    bold: ChalkStyleElement;
-    italic: ChalkStyleElement;
-    underline: ChalkStyleElement;
-    inverse: ChalkStyleElement;
-    strikethrough: ChalkStyleElement;
-
-    // Text colors
-    black: ChalkStyleElement;
-    red: ChalkStyleElement;
-    green: ChalkStyleElement;
-    yellow: ChalkStyleElement;
-    blue: ChalkStyleElement;
-    magenta: ChalkStyleElement;
-    cyan: ChalkStyleElement;
-    white: ChalkStyleElement;
-    gray: ChalkStyleElement;
-
-    // Background colors
-    bgBlack: ChalkStyleElement;
-    bgRed: ChalkStyleElement;
-    bgGreen: ChalkStyleElement;
-    bgYellow: ChalkStyleElement;
-    bgBlue: ChalkStyleElement;
-    bgMagenta: ChalkStyleElement;
-    bgCyan: ChalkStyleElement;
-    bgWhite: ChalkStyleElement;
-}
-
-export const constructor: {
-    new (options: {enabled: boolean}): Chalk;
-}
-
-export interface Chalk {
-    enabled: boolean;
+    export interface ChalkStyleElement {
+        open: string;
+        close: string;
+    }
 
     // General
-    reset: ChalkChain;
-    bold: ChalkChain;
-    italic: ChalkChain;
-    underline: ChalkChain;
-    inverse: ChalkChain;
-    strikethrough: ChalkChain;
+    export var reset: ChalkChain;
+    export var bold: ChalkChain;
+    export var dim: ChalkChain;
+    export var italic: ChalkChain;
+    export var underline: ChalkChain;
+    export var inverse: ChalkChain;
+    export var hidden: ChalkChain;
+    export var strikethrough: ChalkChain;
 
     // Text colors
-    black: ChalkChain;
-    red: ChalkChain;
-    green: ChalkChain;
-    yellow: ChalkChain;
-    blue: ChalkChain;
-    magenta: ChalkChain;
-    cyan: ChalkChain;
-    white: ChalkChain;
-    gray: ChalkChain;
-    grey: ChalkChain;
+    export var black: ChalkChain;
+    export var red: ChalkChain;
+    export var green: ChalkChain;
+    export var yellow: ChalkChain;
+    export var blue: ChalkChain;
+    export var magenta: ChalkChain;
+    export var cyan: ChalkChain;
+    export var white: ChalkChain;
+    export var gray: ChalkChain;
+    export var grey: ChalkChain;
 
     // Background colors
-    bgBlack: ChalkChain;
-    bgRed: ChalkChain;
-    bgGreen: ChalkChain;
-    bgYellow: ChalkChain;
-    bgBlue: ChalkChain;
-    bgMagenta: ChalkChain;
-    bgCyan: ChalkChain;
-    bgWhite: ChalkChain;
+    export var bgBlack: ChalkChain;
+    export var bgRed: ChalkChain;
+    export var bgGreen: ChalkChain;
+    export var bgYellow: ChalkChain;
+    export var bgBlue: ChalkChain;
+    export var bgMagenta: ChalkChain;
+    export var bgCyan: ChalkChain;
+    export var bgWhite: ChalkChain;
+
+
+    export interface ChalkStyle {
+        // General
+        reset: ChalkChain;
+        bold: ChalkChain;
+        dim: ChalkChain;
+        italic: ChalkChain;
+        underline: ChalkChain;
+        inverse: ChalkChain;
+        hidden: ChalkChain;
+        strikethrough: ChalkChain;
+
+        // Text colors
+        black: ChalkChain;
+        red: ChalkChain;
+        green: ChalkChain;
+        yellow: ChalkChain;
+        blue: ChalkChain;
+        magenta: ChalkChain;
+        cyan: ChalkChain;
+        white: ChalkChain;
+        gray: ChalkChain;
+        grey: ChalkChain;
+
+        // Background colors
+        bgBlack: ChalkChain;
+        bgRed: ChalkChain;
+        bgGreen: ChalkChain;
+        bgYellow: ChalkChain;
+        bgBlue: ChalkChain;
+        bgMagenta: ChalkChain;
+        bgCyan: ChalkChain;
+        bgWhite: ChalkChain;
+    }
+
+    export interface ChalkStyleMap {
+        // General
+        reset: ChalkStyleElement;
+        bold: ChalkStyleElement;
+        dim: ChalkStyleElement;
+        italic: ChalkStyleElement;
+        underline: ChalkStyleElement;
+        inverse: ChalkStyleElement;
+        hidden: ChalkStyleElement;
+        strikethrough: ChalkStyleElement;
+
+        // Text colors
+        black: ChalkStyleElement;
+        red: ChalkStyleElement;
+        green: ChalkStyleElement;
+        yellow: ChalkStyleElement;
+        blue: ChalkStyleElement;
+        magenta: ChalkStyleElement;
+        cyan: ChalkStyleElement;
+        white: ChalkStyleElement;
+        gray: ChalkStyleElement;
+
+        // Background colors
+        bgBlack: ChalkStyleElement;
+        bgRed: ChalkStyleElement;
+        bgGreen: ChalkStyleElement;
+        bgYellow: ChalkStyleElement;
+        bgBlue: ChalkStyleElement;
+        bgMagenta: ChalkStyleElement;
+        bgCyan: ChalkStyleElement;
+        bgWhite: ChalkStyleElement;
+    }
+
+    export const constructor: {
+        new (options: {enabled: boolean}): Chalk;
+    }
+
+    export interface Chalk extends ChalkStyle {
+        enabled: boolean;
+    }
 }

--- a/chalk/tsconfig.json
+++ b/chalk/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "noImplicitAny": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
Documented here: https://www.npmjs.com/package/chalk#chalkenabled 

Also converts the module into an isolated, types-2.0 module.
