### PR TITLE
Add CommonHTML to MathJax type definitions

### DIFF
--- a/mathjax/mathjax-tests.ts
+++ b/mathjax/mathjax-tests.ts
@@ -56,5 +56,6 @@ MathJax.Hub.Config({
 
 MathJax.Hub.Config({
   "HTML-CSS": { linebreaks: { automatic: true } },
+  CommonHTML: { linebreaks: { automatic: true } },
          SVG: { linebreaks: { automatic: true } }
 });

--- a/mathjax/mathjax.d.ts
+++ b/mathjax/mathjax.d.ts
@@ -578,7 +578,7 @@ declare namespace jax {
         MMLorHTML?:IMMLorHTMLConfiguration;
         NativeMML?:INativeMMLOutputProcessor;
         "HTML-CSS"?:IHTMLCSSOutputProcessor;
-        CommonHTML: ICommonHTMLOutputProcessor;
+        CommonHTML?: ICommonHTMLOutputProcessor;
         AsciiMath?:IAsciiMathInputProcessor;
         MathML?:IMathMLInputProcessor;
         TeX?:ITeXInputProcessor;

--- a/mathjax/mathjax.d.ts
+++ b/mathjax/mathjax.d.ts
@@ -578,6 +578,7 @@ declare namespace jax {
         MMLorHTML?:IMMLorHTMLConfiguration;
         NativeMML?:INativeMMLOutputProcessor;
         "HTML-CSS"?:IHTMLCSSOutputProcessor;
+        CommonHTML: ICommonHTMLOutputProcessor;
         AsciiMath?:IAsciiMathInputProcessor;
         MathML?:IMathMLInputProcessor;
         TeX?:ITeXInputProcessor;
@@ -1226,6 +1227,29 @@ declare namespace jax {
          * above.)
          */
         tooltip?:IToolTip;
+    }
+
+    export interface ICommonHTMLOutputProcessor {
+        /*The scaling factor (as a percentage) of math with respect to the surrounding text. The CommonHTML output
+         * processor tries to match the ex-size of the mathematics with that of the text where it is placed, but you may
+         * want to adjust the results using this scaling factor. The user can also adjust this value using the contextual
+         * menu item associated with the typeset mathematics.
+         */
+        scale?:number;
+        /*This gives a minimum scale (as a percent) for the scaling used by MathJax to match the equation to the
+         * surrounding text. This will prevent MathJax from making the mathematics too small.
+         */
+        minScaleAdjust?:number;
+        /*This setting controls whether <mtext> elements will be typeset using the math fonts or the font of the
+         * surrounding text. When false, the font for mathvariant="normal" will be used; when true, the font will be
+         * inherited from the surrounding paragraph.
+         */
+        mtextFontInherit?:boolean;
+        /*This is an object that configures automatic linebreaking in the CommonHTML output. In order to be backward
+         * compatible with earlier versions of MathJax, only explicit line breaks are performed by default, so you must
+         * enable line breaks if you want automatic ones.
+         */
+        linebreaks?:ILineBreaks;
     }
 
     export interface IAsciiMathInputProcessor {


### PR DESCRIPTION
Reference for extra options added to a configuration object: http://docs.mathjax.org/en/latest/options/CommonHTML.html
