### PR TITLE
Added typings for d3-tip

### DIFF
--- a/d3-tip/d3-tip-tests.ts
+++ b/d3-tip/d3-tip-tests.ts
@@ -1,0 +1,53 @@
+/// <reference path="../d3/d3.d.ts" />
+/// <reference path="d3-tip.d.ts" />
+
+// test variables
+
+interface dataType {
+    Title: string,
+    Number: number
+}
+
+let data: dataType[] = [ { Title: "one", Number: 1 }, { Title: "two", Number: 2} ]; 
+let svgElement: SVGElement;
+let root: HTMLElement;
+
+// start tests
+
+let d3tip: d3.Tooltip = d3.tip();
+
+d3tip = d3tip.hide();
+
+d3tip = d3tip.show();
+d3tip = d3tip.show(data);
+d3tip = d3tip.show(svgElement);
+d3tip = d3tip.show(data, svgElement);
+
+let attributeValue: string = d3tip.attr("library");
+d3tip = d3tip.attr("library","d3");
+d3tip = d3tip.attr("library", (d, i, o) => (d as dataType).Title);
+d3tip = d3tip.attr<dataType>("library", (d, i, o) => d.Title);
+
+let styleValue: string = d3tip.style("library");
+d3tip = d3tip.style("library","d3");
+d3tip = d3tip.style("library", (d, i, o) => (d as dataType).Title);
+d3tip = d3tip.style<dataType>("library", (d, i, o) => d.Title);
+
+let offsetValue: [number, number] = d3tip.offset();
+d3tip = d3tip.offset([-1, -1]);
+d3tip = d3tip.offset((d, i, o) => [-1, -1]);
+
+let directionValue: ("n" | "s" | "e" | "w" | "nw" | "ne" | "sw" | "se") = d3tip.direction();
+d3tip = d3tip.direction("n");
+d3tip = d3tip.direction((d, i ,o) => "n");
+
+let htmlValue: string = d3tip.html();
+d3tip = d3tip.html("<html><html/>");
+d3tip = d3tip.html((d, i ,o) => "<html><html/>");
+
+let rootElementValue: HTMLElement = d3tip.rootElement();
+d3tip = d3tip.rootElement(root);
+d3tip = d3tip.rootElement<dataType>((d, i ,o) => root);
+
+d3tip = d3tip.destroy();
+

--- a/d3-tip/d3-tip.d.ts
+++ b/d3-tip/d3-tip.d.ts
@@ -1,0 +1,40 @@
+// Type definitions for d3-tip
+// Project: https://github.com/Caged/d3-tip
+// Definitions by: Gert Braspenning <https://github.com/brspnnggrt>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../d3/d3.d.ts" />
+
+declare namespace d3 {
+    type TooltipDirection = ("n" | "s" | "e" | "w" | "nw" | "ne" | "sw" | "se");
+    interface Tooltip {
+        hide(): Tooltip;
+        show(): Tooltip;
+        show<Datum>(data: Datum[]): Tooltip;
+        show(target: SVGElement): Tooltip;
+        show<Datum>(data: Datum[], target: SVGElement): Tooltip;
+        attr(name: string): string;
+        attr(name: string, value: Primitive): Tooltip;
+        attr<Datum>(name: string, value: (datum: Datum, index: number, outerIndex: number) => Primitive): Tooltip;
+        attr<Datum>(obj: { [key: string]: Primitive | ((datum: Datum, index: number, outerIndex: number) => Primitive) }): Tooltip;
+        style(name: string): string;
+        style(name: string, value: Primitive, priority?: string): Tooltip;
+        style<Datum>(name: string, value: (datum: Datum, index: number, outerIndex: number) => Primitive, priority?: string): Tooltip;
+        style<Datum>(obj: { [key: string]: Primitive | ((datum: Datum, index: number, outerIndex: number) => Primitive) }, priority?: string): Tooltip;
+        offset(): [number, number];
+        offset(tuple: [number, number]): Tooltip;
+        offset<Datum>(func: (datum: Datum, index: number, outerIndex: number) => [number, number]): Tooltip;
+        direction(): TooltipDirection;
+        direction(direction: TooltipDirection): Tooltip;
+        direction<Datum>(func: (datum: Datum, index: number, outerIndex: number) => TooltipDirection): Tooltip;
+        html(): string;
+        html(content: string): Tooltip;
+        html<Datum>(func: (datum: Datum, index: number, outerIndex: number) => string): Tooltip;
+        rootElement(): HTMLElement;
+        rootElement(element: HTMLElement): Tooltip;
+        rootElement<Datum>(func: (datum: Datum, index: number, outerIndex: number) => HTMLElement): Tooltip;
+        destroy(): Tooltip;
+    }
+    export function tip(): Tooltip;
+}
+


### PR DESCRIPTION
Typings for d3-tip, https://github.com/Caged/d3-tip
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
