### PR TITLE
knex: add `withSchema` method definition

### DIFF
--- a/knex/knex-tests.ts
+++ b/knex/knex-tests.ts
@@ -414,6 +414,8 @@ knex.transaction(function(trx) {
   console.error(error);
 });
 
+knex.schema.withSchema("public").hasTable("table") as Promise<boolean>;
+
 knex.schema.createTable('users', function (table) {
   table.increments();
   table.string('name');

--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -347,6 +347,7 @@ declare module "knex" {
       table(tableName: string, callback: (tableBuilder: AlterTableBuilder) => any): Promise<void>;
       dropTableIfExists(tableName: string): Promise<void>;
       raw(statement: string): SchemaBuilder;
+      withSchema(schemaName: string): SchemaBuilder;
     }
 
     interface TableBuilder {


### PR DESCRIPTION
As documented here: http://knexjs.org/#Schema-withSchema, this commit adds `withSchema` method to `SchemaBuilder` interface
