### PR TITLE
knex: type knex.fn helper

### DIFF
--- a/knex/knex-tests.ts
+++ b/knex/knex-tests.ts
@@ -419,6 +419,7 @@ knex.schema.createTable('users', function (table) {
   table.string('name');
   table.enu('favorite_color', ['red', 'blue', 'green']);
   table.timestamps();
+  table.timestamp('created_at').defaultTo(knex.fn.now());
 });
 
 knex.schema.renameTable('users', 'old_users');

--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -12,7 +12,7 @@ declare module "knex" {
 
   type Callback = Function;
   type Client = Function;
-  type Value = string|number|boolean|Date|Array<string>|Array<number>|Array<Date>|Array<boolean>|Buffer;
+  type Value = string|number|boolean|Date|Array<string>|Array<number>|Array<Date>|Array<boolean>|Buffer|Knex.Raw;
   type ColumnName = string|Knex.Raw|Knex.QueryBuilder;
   type TableName = string|Knex.Raw|Knex.QueryBuilder;
 
@@ -31,7 +31,7 @@ declare module "knex" {
     client: any;
     migrate: Knex.Migrator;
     seed: any;
-    fn: any;
+    fn: Knex.FunctionHelper;
     on(eventName: string, callback: Function): Knex.QueryBuilder;
   }
 
@@ -544,6 +544,10 @@ declare module "knex" {
       rollback(config?: MigratorConfig):Promise<any>;
       status(config?: MigratorConfig):Promise<number>;
       currentVersion(config?: MigratorConfig):Promise<string>;
+    }
+
+    interface FunctionHelper {
+      now(): Raw;
     }
   }
 


### PR DESCRIPTION
As stated in sources, `knex.fn` contains only one function, `now()`, which returns `Raw`. As stated in documentation, `Raw` could be used as any value in query builder, so, this commit includes 2 changes:
1. Add `Raw` as one of case for type `Value`;
2. Introduce `FunctionHelper` interface (as in original source), which is returned by `knex.fn`.

https://github.com/tgriesser/knex/blob/master/src/functionhelper.js
http://knexjs.org/#Schema-timestamp (see Example section)
