### PR TITLE
Validator normalizeEmail type fix [Types 2.0]

### DIFF
--- a/validator/index.d.ts
+++ b/validator/index.d.ts
@@ -175,7 +175,7 @@ declare namespace ValidatorJS {
     ltrim(input: any, chars?: string): string;
 
     // canonicalize an email address.
-    normalizeEmail(email: string, options?: NormalizeEmailOptions): string;
+    normalizeEmail(email: string, options?: NormalizeEmailOptions): string | boolean;
 
     // trim characters from the right-side of the input.
     rtrim(input: any, chars?: string): string;

--- a/validator/index.d.ts
+++ b/validator/index.d.ts
@@ -175,7 +175,7 @@ declare namespace ValidatorJS {
     ltrim(input: any, chars?: string): string;
 
     // canonicalize an email address.
-    normalizeEmail(email: string, options?: NormalizeEmailOptions): string | boolean;
+    normalizeEmail(email: string, options?: NormalizeEmailOptions): string | false;
 
     // trim characters from the right-side of the input.
     rtrim(input: any, chars?: string): string;

--- a/validator/validator-tests.ts
+++ b/validator/validator-tests.ts
@@ -147,8 +147,9 @@ let any: any;
   result = validator.ltrim('sample', ' ');
 
   let normalizeEmailOptions: ValidatorJS.NormalizeEmailOptions;
-  result = validator.normalizeEmail('sample');
-  result = validator.normalizeEmail('sample', normalizeEmailOptions);
+  let normalizeResult: string | boolean;
+  normalizeResult = validator.normalizeEmail('sample');
+  normalizeResult = validator.normalizeEmail('sample', normalizeEmailOptions);
 
   result = validator.rtrim('sample');
   result = validator.rtrim('sample', ' ');

--- a/validator/validator-tests.ts
+++ b/validator/validator-tests.ts
@@ -147,7 +147,7 @@ let any: any;
   result = validator.ltrim('sample', ' ');
 
   let normalizeEmailOptions: ValidatorJS.NormalizeEmailOptions;
-  let normalizeResult: string | boolean;
+  let normalizeResult: string | false;
   normalizeResult = validator.normalizeEmail('sample');
   normalizeResult = validator.normalizeEmail('sample', normalizeEmailOptions);
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

---

`validator`'s `normalizeEmail` function can return a boolean when an invalid address is supplied
https://github.com/chriso/validator.js/blob/master/src/lib/normalizeEmail.js#L13

``` ts
import * as validator from 'validator';
console.log(validator.normalizeEmail(''))
console.log(validator.normalizeEmail('@butts.com'))
console.log(validator.normalizeEmail('gOI@NF.cc'))
console.log(typeof validator.normalizeEmail(''))
console.log(typeof validator.normalizeEmail('@butts.com'))
console.log(typeof validator.normalizeEmail('gOI@NF.cc'))
```

outputs:

```
false
false
goi@nf.cc
boolean
boolean
string
```
