### PR TITLE
Add node.js crypto.timingSafeEqual typings

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -542,6 +542,15 @@ namespace crypto_tests {
 
         assert.deepEqual(clearText2, clearText);
     }
+
+    {
+      let buffer1: Buffer = new Buffer([1, 2, 3, 4, 5]);
+      let buffer2: Buffer = new Buffer([1, 2, 3, 4, 5]);
+      let buffer3: Buffer = new Buffer([5, 4, 3, 2, 1]);
+
+      assert(crypto.timingSafeEqual(buffer1, buffer2))
+      assert(!crypto.timingSafeEqual(buffer1, buffer3))
+    }
 }
 
 //////////////////////////////////////////////////

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -2814,6 +2814,7 @@ declare module "crypto" {
         setPrivateKey(private_key: string, encoding: HexBase64Latin1Encoding): void;
     }
     export function createECDH(curve_name: string): ECDH;
+    export function timingSafeEqual(a: Buffer, b: Buffer): boolean;
     export var DEFAULT_ENCODING: string;
 }
 


### PR DESCRIPTION
This function is new in node 6.6.0.

https://nodejs.org/dist/latest-v6.x/docs/api/crypto.html#crypto_crypto_timingsafeequal_a_b
