### PR TITLE
Change Promise to PromiseLike so target=es5 will not be wrong

### DIFF
--- a/ioredis/ioredis.d.ts
+++ b/ioredis/ioredis.d.ts
@@ -42,10 +42,10 @@ declare module IORedis {
 
     interface Redis extends NodeJS.EventEmitter, Commander {
         status: string;
-        connect(callback?: Function): Promise<any>;
+        connect(callback?: Function): PromiseLike<any>;
         disconnect(): void;
         duplicate(): Redis;
-        monitor(calback: (error: Error, monitor: NodeJS.EventEmitter) => void): Promise<NodeJS.EventEmitter>;
+        monitor(calback: (error: Error, monitor: NodeJS.EventEmitter) => void): PromiseLike<NodeJS.EventEmitter>;
 
         send_command(command: string, ...args: any[]): any;
         auth(password: string, callback?: ResCallbackT<any>): any;
@@ -615,7 +615,7 @@ declare module IORedis {
 
     interface Cluster extends NodeJS.EventEmitter, Commander {
         new (nodes: { host: string; port: number; }[], options?: IORedis.ClusterOptions): Redis;
-        connect(callback: Function): Promise<any>;
+        connect(callback: Function): PromiseLike<any>;
         disconnect(): void;
         nodes(role: string): Redis[];
     }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url https://github.com/luin/ioredis/blob/master/API.md .
  - it has been reviewed by a DefinitelyTyped member.

The library use bluebird.js as its promise(https://github.com/luin/ioredis/blob/master/package.json#L25).

When target=es5, the error is: 

```
node_modules/@types/ioredis/index.d.ts(42,39): error TS2304: Cannot find name 'Promise'.
```

This PR should fix this problem.

Other ideas:
It is better to use bluebird's definition, so I tried to do that, add:

```
/// <reference path="../bluebird/bluebird.d.ts" />
import * as Promise from "bluebird";
```

but the second line can only be placed in `declare module "ioredis" {}`, so the Promise is not available in  `declare module IORedis {}`.
