### PR TITLE
leaflet: Fix typo and make className optional in PathOptions

### DIFF
--- a/leaflet/index.d.ts
+++ b/leaflet/index.d.ts
@@ -355,7 +355,7 @@ declare namespace L {
     export interface PathOptions extends InteractiveLayerOptions {
         stroke?: boolean;
         color?: string;
-        wight?: number;
+        weight?: number;
         opacity?: number;
         lineCap?: LineCapShape;
         lineJoin?: LineJoinShape;
@@ -366,7 +366,7 @@ declare namespace L {
         fillOpacity?: number;
         fillRule?: FillRule;
         renderer?: Renderer;
-        className: string;
+        className?: string;
     }
 
     export interface Path extends Layer {


### PR DESCRIPTION
Fix typo `wight` -> `weight`, and `className` not being optional when it should be
