### PR TITLE
Fix ChartAxisXOptions (minimum & maximum) for CanvasJS

### DIFF
--- a/canvasjs/canvasjs.d.ts
+++ b/canvasjs/canvasjs.d.ts
@@ -376,7 +376,7 @@ declare namespace CanvasJS {
         dataSeriesIndex: number;
     }
 
-    interface ChartAxisXOptions {
+    interface ChartAxisOptions {
         /**
         * Sets the Axis Title.
         * Default: null
@@ -471,18 +471,6 @@ declare namespace CanvasJS {
         * Defines how values must be formatted before they appear on Axis X. You can format numbers and date time values using this property. Below you will find descriptive table explaining various specifiers with example.
         */
         valueFormatString?: string;
-        /**
-        * Sets the minimum value of Axis. Values smaller than minimum are clipped.
-        * Default: Automatically Calculated based on the data
-        * Example: 100, 350..
-        */
-        minimum?: number;
-        /**
-        * Sets the maximum value permitted on Axis. Values greater than maximum are clipped.
-        * Default: Automatically Calculated based on the data
-        * Example: 100, 350..
-        */
-        maximum?: number;
         /**
         * Sets the distance between Tick Marks, Grid Lines and Interlaced Colors.
         * Default: Automatically Calculated
@@ -638,13 +626,41 @@ declare namespace CanvasJS {
         labelFontStyle?: string;
     }
 
-    interface ChartAxisYOptions extends ChartAxisXOptions {
+	interface ChartAxisXOptions extends ChartAxisOptions {
+		/**
+        * Sets the minimum value of Axis. Values smaller than minimum are clipped.
+        * Default: Automatically Calculated based on the data
+        * Example: 100, 350..
+        */
+        minimum?: number | Date;
+        /**
+        * Sets the maximum value permitted on Axis. Values greater than maximum are clipped.
+        * Default: Automatically Calculated based on the data
+        * Example: 100, 350..
+        */
+        maximum?: number | Date;
+	}
+	
+    interface ChartAxisYOptions extends ChartAxisOptions {
         /**
         * When includeZero is set to true, axisY sets the range in such a way that Zero is a part of it. It is set to true by default. But, whenever y values are very big and difference among dataPoints are hard to judge, setting includeZero to false makes axisY to set a range that makes the differences prominently visible.
         * Default: true
         * Example: true, false
         */
         includeZero?: boolean;
+		
+		/**
+        * Sets the minimum value of Axis. Values smaller than minimum are clipped.
+        * Default: Automatically Calculated based on the data
+        * Example: 100, 350..
+        */
+        minimum?: number;
+        /**
+        * Sets the maximum value permitted on Axis. Values greater than maximum are clipped.
+        * Default: Automatically Calculated based on the data
+        * Example: 100, 350..
+        */
+        maximum?: number;
     }
 
     interface ChartToolTipOptions {


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Change the type for minimum and maximum options in ChartAxisXOptions to
support both number and Date.
