### PR TITLE
types-2.0: convert "merge-stream" into an isolated module

### DIFF
--- a/merge-stream/index.d.ts
+++ b/merge-stream/index.d.ts
@@ -6,11 +6,13 @@
 /// <reference types="node"/>
 
 
-interface IMergedStream extends NodeJS.ReadWriteStream {
-    add(source: NodeJS.ReadableStream): IMergedStream;
-    add(source: NodeJS.ReadableStream[]): IMergedStream;
-    isEmpty(): boolean;
+module merge {
+	interface IMergedStream extends NodeJS.ReadWriteStream {
+	    add(source: NodeJS.ReadableStream): IMergedStream;
+	    add(source: NodeJS.ReadableStream[]): IMergedStream;
+	    isEmpty(): boolean;
+	}
 }
 
-declare function merge<T extends NodeJS.ReadableStream>(...streams: T[]): IMergedStream;
+declare function merge<T extends NodeJS.ReadableStream>(...streams: T[]): merge.IMergedStream;
 export = merge;


### PR DESCRIPTION
_case 2. Improvement to existing type definition._

When I use with typescript 2.0.3 and `@types/merge-stream` I get the following error:

`index.ts(XX,XX): error TS2497: Module '"merge-stream"' resolves to a non-module entity and cannot be imported using this construct.`

This fixes that error by converting the merge-stream declaration into an isolated module.

/cc @k-kagurazaka @tomxtobin
