### PR TITLE
Add typings for cssbeautify library

### DIFF
--- a/cssbeautify/cssbeautify-tests.ts
+++ b/cssbeautify/cssbeautify-tests.ts
@@ -1,4 +1,4 @@
-import * as cssbeautify from './index';
+import cssbeautify = require('./index');
 
 var str = '';
 

--- a/cssbeautify/cssbeautify-tests.ts
+++ b/cssbeautify/cssbeautify-tests.ts
@@ -1,0 +1,13 @@
+import * as cssbeautify from './index';
+
+var str = '';
+
+str = cssbeautify(str);
+
+str = cssbeautify(str, {});
+
+str = cssbeautify(str, {
+  indent: '  ',
+  openbrace: 'separate-line',
+  autosemicolon: true
+});

--- a/cssbeautify/index.d.ts
+++ b/cssbeautify/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for CSS Beautify v0.3.1
+// Project: https://github.com/senchalabs/cssbeautify
+// Definitions by: rictic <https://github.com/rictic>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface Options {
+  /**
+   * A string used for the indentation of the declaration (default is 4
+   * spaces).
+   */
+  indent?: string;
+  /**
+   * Defines the placement of open curly brace, either end-of-line (default)
+   * or separate-line
+   */
+  openbrace?: 'end-of-line'|'separate-line';
+
+  /**
+   * Always inserts a semicolon after the last ruleset(default is false)
+   */
+  autosemicolon?: boolean;
+}
+declare namespace beautify {}
+declare function beautify(cssText: string, options?: Options): string;
+
+export = beautify;

--- a/cssbeautify/index.d.ts
+++ b/cssbeautify/index.d.ts
@@ -20,7 +20,6 @@ interface Options {
    */
   autosemicolon?: boolean;
 }
-declare namespace beautify {}
 declare function beautify(cssText: string, options?: Options): string;
 
 export = beautify;

--- a/cssbeautify/tsconfig.json
+++ b/cssbeautify/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "cssbeautify-tests.ts"
+    ]
+}


### PR DESCRIPTION
Adds a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
