### PR TITLE
Call strategy with only mode or options

### DIFF
--- a/hapi/hapi.d.ts
+++ b/hapi/hapi.d.ts
@@ -1872,8 +1872,9 @@ declare module "hapi" {
 			}
 			}
 			});*/
-			strategy(name: string, scheme: any, mode?: boolean | string, options?: any): void;
-			strategy(name: string, scheme: any, modeOrOptions: any): void;
+			strategy(name: string, scheme: string, mode?: boolean | string, options?: any): void;
+			strategy(name: string, scheme: string, mode?: boolean | string): void;
+			strategy(name: string, scheme: string, options?:any): void;
 
 			/** server.auth.test(strategy, request, next)
 			 Tests a request against an authentication strategy where:

--- a/hapi/hapi.d.ts
+++ b/hapi/hapi.d.ts
@@ -1873,6 +1873,7 @@ declare module "hapi" {
 			}
 			});*/
 			strategy(name: string, scheme: any, mode?: boolean | string, options?: any): void;
+			strategy(name: string, scheme: any, modeOrOptions: any): void;
 
 			/** server.auth.test(strategy, request, next)
 			 Tests a request against an authentication strategy where:


### PR DESCRIPTION
The [tests](https://github.com/hapijs/hapi/tree/master/test/auth.js) indicate that a method ~~override~~ overload to `server.auth.strategy` also allows to set either one of `mode` or `options` as the last argument.
