### PR TITLE
Vinyl@1.2.0

### DIFF
--- a/vinyl/vinyl-tests.ts
+++ b/vinyl/vinyl-tests.ts
@@ -134,6 +134,18 @@ describe('File', () => {
 		});
 	});
 
+	describe('File.isCustomProp()', () => {
+		it('should return true when a File property is not managed internally', done => {
+			File.isCustomProp('foobar').should.equal(true);
+			done();
+		});
+
+		it('should return false when a File property is managed internally', done => {
+			File.isCustomProp('cwd').should.equal(false);
+			done();
+		});
+	});
+
 	describe('isBuffer()', () => {
 		it('should return true when the contents are a Buffer', done => {
 			var val = new Buffer("test");

--- a/vinyl/vinyl-tests.ts
+++ b/vinyl/vinyl-tests.ts
@@ -121,6 +121,19 @@ describe('File', () => {
 
 	});
 
+	describe('File.isVinyl()', () => {
+		it('should return true when an object is a Vinyl file', done => {
+			var file = new File();
+			File.isVinyl(file).should.equal(true);
+			done();
+		});
+
+		it('should return false when an object is not a Vinyl file', done => {
+			File.isVinyl({}).should.equal(false);
+			done();
+		});
+	});
+
 	describe('isBuffer()', () => {
 		it('should return true when the contents are a Buffer', done => {
 			var val = new Buffer("test");

--- a/vinyl/vinyl.d.ts
+++ b/vinyl/vinyl.d.ts
@@ -1,5 +1,5 @@
-// Type definitions for vinyl 1.1.0
-// Project: https://github.com/wearefractal/vinyl
+// Type definitions for vinyl 1.2.0
+// Project: https://github.com/gulpjs/vinyl
 // Definitions by: vvakame <https://github.com/vvakame/>, jedmao <https://github.com/jedmao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
@@ -140,6 +140,11 @@ declare module "vinyl" {
 		 * Checks if a given object is a vinyl file.
 		 */
 		public static isVinyl(obj: any): boolean;
+
+		/**
+		 * Checks if a property is not managed internally.
+		 */
+		public static isCustomProp(name: string): boolean;
 	}
 
 	export = File;


### PR DESCRIPTION
**Overview**
- Adds a test for the `Vinyl.isVinyl` static method
- Adds support for `Vinyl.isCustomProp` static method (introduced in [Vinyl 1.2.0](https://github.com/gulpjs/vinyl/commit/7b01e7523fcc97317580107b02f874b09641e5e9))
- Updates the Vinyl repo from [`wearefractal/vinyl`](https://github.com/wearefractal/vinyl) to [`gulpjs/vinyl`](https://github.com/gulpjs/vinyl)

**Reason**

I was creating a new class that extends Vinyl. Following the [Extending Vinyl guidelines](https://github.com/gulpjs/vinyl#extending-vinyl), I tried overriding the `isCustomProp` method, but tsc complained that `isCustomProp` does not exist on type Vinyl.

So I checked the DT Vinyl definitions and noticed they haven't been updated to 1.2.0, where the `isCustomProp` method was introduced.

Let me know if I need to change anything!
