### PR TITLE
Added typings for css-modules-require-hook

### DIFF
--- a/css-modules-require-hook/css-modules-require-hook-tests.ts
+++ b/css-modules-require-hook/css-modules-require-hook-tests.ts
@@ -1,0 +1,174 @@
+/// <reference path="./css-modules-require-hook.d.ts" />
+/// <reference path="../node/node.d.ts" />
+
+import * as hook from 'css-modules-require-hook';
+import * as path from 'path';
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#usage
+//
+
+hook({ generateScopedName: '[name]__[local]___[hash:base64:5]' });
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#adding-custom-postcss-plugins
+//
+
+hook({
+	prepend: [
+		() => {
+			// my prepender
+		},
+	],
+});
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#specify-custom-pattern-to-build-generic-names
+//
+
+hook({ generateScopedName: '[name]__[local]___[hash:base64:5]' });
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#using-stylus-as-a-preprocessor
+//
+
+hook({
+	extensions: ['.styl'],
+	preprocessCss: (css: string, filepath: string) => {
+		// my preprocesser
+	},
+});
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#tuning-options
+//
+
+hook({ /* my option */ });
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#devmode-boolean
+//
+
+hook({ devMode: false });
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#extensions-array
+//
+
+hook({ extensions: ['.scss', '.sass'] });
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#ignore-functionregexstring
+//
+
+hook({ ignore: (file: string) => false });
+hook({ ignore: 'unused' });
+hook({ ignore: /\.test\.(css|scss|sass)/$ });
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#preprocesscss-function
+//
+
+hook({ preprocessCss: (css: string, filepath: string) => css });
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#processcss-function
+//
+
+hook({ processCss: (css: string, filepath: string) => css });
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#processoropts-object
+//
+
+hook({
+	extensions: '.scss',
+	processorOpts: {
+		parser: () => {
+			// my parser
+		},
+	},
+});
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#camelcase-boolean
+//
+
+hook({ camelCase: true });
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#append-array
+//
+
+hook({
+	append: [
+		() => {
+			// another plugin
+		},
+	],
+});
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#prepend-array
+//
+
+hook({
+	prepend: [
+		() => {
+			// again, another plugin
+		},
+	],
+});
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#use-array
+//
+
+hook({
+	use: [
+		() => {
+			// they like plugins very much
+		},
+	],
+});
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#createimportedname-function
+//
+
+hook({
+	createImportedName: (css: string, filepath: string) => {
+		// my import name creator
+	},
+});
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#generatescopedname-stringfunction
+//
+
+hook({ generateScopedName: '[name]__[local]___[hash:base64:5]' });
+hook({
+	generateScopedName: () => {
+		// should generate something
+	},
+});
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#hashprefix-string
+//
+
+hook({ hashPrefix: 'awesome_' });
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#mode-string
+//
+
+hook({ mode: 'global' });
+hook({ mode: 'local' });
+hook({ mode: 'pure' });
+
+//
+// https://github.com/css-modules/css-modules-require-hook/blob/master/README.md#rootdir-string
+//
+
+hook({ rootDir: path.resolve('./my-folder') });

--- a/css-modules-require-hook/css-modules-require-hook.d.ts
+++ b/css-modules-require-hook/css-modules-require-hook.d.ts
@@ -1,0 +1,47 @@
+// Type definitions for css-modules-require-hook
+// Project: https://github.com/css-modules/css-modules-require-hook
+// Definitions by: Cedric van Putten <https://bycedric.com>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'css-modules-require-hook' {
+	interface Options {
+		/** Helps you to invalidate cache of all require calls. */
+		devMode?: boolean;
+		/** Attach the require hook to additional file extensions. */
+		extensions?: string | string[];
+		/** Provides possibility to exclude particular files from processing. */
+		ignore?: string | RegExp | Function;
+		/** In rare cases you may want to precompile styles, before they will be passed to the PostCSS pipeline. */
+		preprocessCss?: Function;
+		/** In rare cases you may want to get compiled styles in runtime, so providing this option helps. */
+		processCss?: Function;
+		/** Provides possibility to pass custom options to the LazyResult instance. */
+		processorOpts?: Object;
+		/** Camelizes exported class names. */
+		camelCase?: boolean;
+		/** Appends custom plugins to the end of the PostCSS pipeline. */
+		append?: Array<any>;
+		/** Prepends custom plugins to the beginning of the PostCSS pipeline. */
+		prepend?: Array<any>;
+		/** Provides the full list of PostCSS plugins to the pipeline. */
+		use?: Array<any>;
+		/** Short alias for the postcss-modules-extract-imports plugin's createImportedName option. */
+		createImportedName?: Function;
+		/** Short alias for the postcss-modules-scope plugin's option. */
+		generateScopedName?: string | Function;
+		/** Short alias for the generic-names helper option. */
+		hashPrefix?: string;
+		/** Short alias for the postcss-modules-local-by-default plugin's option. */
+		mode?: string;
+		/** Provides absolute path to the project directory. */
+		rootDir?: string;
+	}
+
+	interface RequireHook {
+		(options?: Options): void;
+	}
+
+	var requireHook: RequireHook;
+
+	export = requireHook;
+}

--- a/css-modules-require-hook/css-modules-require-hook.d.ts
+++ b/css-modules-require-hook/css-modules-require-hook.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for css-modules-require-hook
+// Type definitions for css-modules-require-hook 4.0.3
 // Project: https://github.com/css-modules/css-modules-require-hook
 // Definitions by: Cedric van Putten <https://bycedric.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -10,7 +10,7 @@ declare module 'css-modules-require-hook' {
 		/** Attach the require hook to additional file extensions. */
 		extensions?: string | string[];
 		/** Provides possibility to exclude particular files from processing. */
-		ignore?: string | RegExp | Function;
+		ignore?: string | RegExp | ((filepath: string) => boolean);
 		/** In rare cases you may want to precompile styles, before they will be passed to the PostCSS pipeline. */
 		preprocessCss?: Function;
 		/** In rare cases you may want to get compiled styles in runtime, so providing this option helps. */
@@ -20,11 +20,11 @@ declare module 'css-modules-require-hook' {
 		/** Camelizes exported class names. */
 		camelCase?: boolean;
 		/** Appends custom plugins to the end of the PostCSS pipeline. */
-		append?: Array<any>;
+		append?: any[];
 		/** Prepends custom plugins to the beginning of the PostCSS pipeline. */
-		prepend?: Array<any>;
+		prepend?: any[];
 		/** Provides the full list of PostCSS plugins to the pipeline. */
-		use?: Array<any>;
+		use?: any[];
 		/** Short alias for the postcss-modules-extract-imports plugin's createImportedName option. */
 		createImportedName?: Function;
 		/** Short alias for the postcss-modules-scope plugin's option. */
@@ -37,11 +37,7 @@ declare module 'css-modules-require-hook' {
 		rootDir?: string;
 	}
 
-	interface RequireHook {
-		(options?: Options): void;
-	}
-
-	var requireHook: RequireHook;
+	var requireHook: (options?: Options) => void;
 
 	export = requireHook;
 }


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
