### PR TITLE
Overwriting method signature

### DIFF
--- a/method-override/method-override.d.ts
+++ b/method-override/method-override.d.ts
@@ -20,8 +20,10 @@ declare module "method-override" {
         }
     }
 
-    function e(getter?: string, options?: e.MethodOverrideOptions): express.RequestHandler;
-    function e(getter?: (req: express.Request, res: express.Response) => string, options?: e.MethodOverrideOptions): express.RequestHandler;
+
+    type stringType = string;
+    type functionType = (req: express.Request, res: express.Response) => string; 
+    function e(getter?: stringType | functionType, options?: e.MethodOverrideOptions): express.RequestHandler;
 
     export = e;
 }

--- a/method-override/method-override.d.ts
+++ b/method-override/method-override.d.ts
@@ -21,9 +21,8 @@ declare module "method-override" {
     }
 
 
-    type stringType = string;
-    type functionType = (req: express.Request, res: express.Response) => string; 
-    function e(getter?: stringType | functionType, options?: e.MethodOverrideOptions): express.RequestHandler;
+    function e(getter?: string | ((req: express.Request, res: express.Response) => string), options?: e.MethodOverrideOptions): express.RequestHandler;
+
 
     export = e;
 }


### PR DESCRIPTION
Two functions with the same name.
- Improvement to existing type definition.
- documentation: https://www.npmjs.com/package/method-override .
- it has not been reviewed by a DefinitelyTyped member.

Overwriting method signature. See error in the Webstorm IDE.
![override](https://cloud.githubusercontent.com/assets/9041034/18812175/97bda326-82cb-11e6-87cf-9efb4f3681a2.png)
