### PR TITLE
[validator] Correct parameter type

### DIFF
--- a/validator/validator.d.ts
+++ b/validator/validator.d.ts
@@ -17,7 +17,7 @@ declare namespace ValidatorJS {
     contains(str: string, elem: any): boolean;
 
     // check if the string matches the comparison.
-    equals(str: string, comparison: any): boolean;
+    equals(str: string, comparison: string): boolean;
 
     // check if the string is a date that's after the specified date (defaults to now).
     isAfter(str: string, date?: string): boolean;
@@ -152,7 +152,7 @@ declare namespace ValidatorJS {
     isURL(str: string, options?: IsURLOptions): boolean;
 
     // check if the string is a UUID. Must be one of ['3', '4', '5', 'all'], default is all.
-    isUUID(str: string, version?: string|number): boolean;
+    isUUID(str: string, version?: string | number): boolean;
 
     // check if the string is uppercase.
     isUppercase(str: string): boolean;
@@ -161,10 +161,10 @@ declare namespace ValidatorJS {
     isVariableWidth(str: string): boolean;
 
     // checks characters if they appear in the whitelist.
-    isWhitelisted(str: string, chars: string|string[]): boolean;
+    isWhitelisted(str: string, chars: string | string[]): boolean;
 
     // check if string matches the pattern.
-    matches(str: string, pattern: RegExp|string, modifiers?: string): boolean;
+    matches(str: string, pattern: RegExp | string, modifiers?: string): boolean;
 
     // **************
     // * Sanitizers *
@@ -181,13 +181,13 @@ declare namespace ValidatorJS {
     unescape(input: string): string;
 
     // trim characters from the left-side of the input.
-    ltrim(input: any, chars?: string): string;
+    ltrim(input: string, chars?: string): string;
 
     // canonicalize an email address.
     normalizeEmail(email: string, options?: NormalizeEmailOptions): string;
 
     // trim characters from the right-side of the input.
-    rtrim(input: any, chars?: string): string;
+    rtrim(input: string, chars?: string): string;
 
     // remove characters with a numerical value < 32 and 127, mostly control characters. If keep_new_lines is true,
     // newline characters are preserved (\n and \r, hex 0xA and 0xD). Unicode-safe in JavaScript.
@@ -195,19 +195,19 @@ declare namespace ValidatorJS {
 
     // convert the input to a boolean. Everything except for '0', 'false' and '' returns true. In strict mode only '1'
     // and 'true' return true.
-    toBoolean(input: any, strict?: boolean): boolean;
+    toBoolean(input: string, strict?: boolean): boolean;
 
     // convert the input to a date, or null if the input is not a date.
-    toDate(input: any): Date; // Date or null
+    toDate(input: string): Date; // Date or null
 
     // convert the input to a float, or NaN if the input is not a float.
-    toFloat(input: any): number; // number or NaN
+    toFloat(input: string): number; // number or NaN
 
     // convert the input to an integer, or NaN if the input is not an integer.
-    toInt(input: any, radix?: number): number; // number or NaN
+    toInt(input: string, radix?: number): number; // number or NaN
 
     // trim characters (whitespace by default) from both sides of the input.
-    trim(input: any, chars?: string): string;
+    trim(input: string, chars?: string): string;
 
     // remove characters that do not appear in the whitelist. The characters are used in a RegExp and so you will
     // need to escape some chars, e.g. whitelist(input, '\\[\\]').
@@ -284,8 +284,8 @@ declare namespace ValidatorJS {
     require_host: boolean;
     require_valid_protocol?: boolean;
     allow_underscores?: boolean;
-    host_whitelist?: (string|RegExp)[];
-    host_blacklist?: (string|RegExp)[];
+    host_whitelist?: (string | RegExp)[];
+    host_blacklist?: (string | RegExp)[];
     allow_trailing_dot?: boolean;
     allow_protocol_relative_urls?: boolean;
   }
@@ -304,7 +304,7 @@ declare module "validator" {
 }
 
 // deprecated interfaces for backward compatibility, please use ValidatorJS.* instead the ones
-interface IValidatorStatic extends ValidatorJS.ValidatorStatic {}
-interface IURLoptions extends ValidatorJS.IsURLOptions {}
-interface IFQDNoptions extends ValidatorJS.IsFQDNOptions {}
-interface IEmailoptions extends ValidatorJS.NormalizeEmailOptions {}
+interface IValidatorStatic extends ValidatorJS.ValidatorStatic { }
+interface IURLoptions extends ValidatorJS.IsURLOptions { }
+interface IFQDNoptions extends ValidatorJS.IsFQDNOptions { }
+interface IEmailoptions extends ValidatorJS.NormalizeEmailOptions { }


### PR DESCRIPTION
# Improvement to existing type definition
- Main changing
  - [equals](https://github.com/chriso/validator.js/blob/68a10cb4ba0ee54f2c51b0023fd0456f58ed3256/src/lib/equals.js#L4) doesn't allow `comparison` is non-string
  - [toBoolean](https://github.com/chriso/validator.js/blob/68a10cb4ba0ee54f2c51b0023fd0456f58ed3256/src/lib/toBoolean.js#L4) doesn't allow `input` is non-string
  - [toFloat](https://github.com/chriso/validator.js/blob/68a10cb4ba0ee54f2c51b0023fd0456f58ed3256/src/lib/toFloat.js) doesn't allow `input` is non-string
  - [toInt](https://github.com/chriso/validator.js/blob/68a10cb4ba0ee54f2c51b0023fd0456f58ed3256/src/lib/toInt.js) doesn't allow `input` is non-string
  - [ltrim](https://github.com/chriso/validator.js/blob/68a10cb4ba0ee54f2c51b0023fd0456f58ed3256/src/lib/ltrim.js) doesn't allow `input` is non-string
  - [toDate](https://github.com/chriso/validator.js/blob/68a10cb4ba0ee54f2c51b0023fd0456f58ed3256/src/lib/toDate.js) doesn't allow `input` is non-string
  - [trim](https://github.com/chriso/validator.js/blob/68a10cb4ba0ee54f2c51b0023fd0456f58ed3256/src/lib/trim.js#L4) doesn't allow `input` is non-string
  - [rtrim](https://github.com/chriso/validator.js/blob/68a10cb4ba0ee54f2c51b0023fd0456f58ed3256/src/lib/rtrim.js#L4) doesn't allow `input` is non-string
  - If I have mentioned some parameters can't allow non-string, it can refer to [assertString](https://github.com/chriso/validator.js/blob/68a10cb4ba0ee54f2c51b0023fd0456f58ed3256/src/lib/util/assertString.js), the function will do `typeof input !== 'string'`
- Other changing
  - Format by typescript_auto_format
