### PR TITLE
[validator] Add MobilePhoneLocale

### DIFF
--- a/validator/validator-tests.ts
+++ b/validator/validator-tests.ts
@@ -178,7 +178,39 @@ let any: any;
 
   result = validator.isMD5('sample');
 
+  result = validator.isMobilePhone('sample', 'ar-DZ');
+  result = validator.isMobilePhone('sample', 'ar-SA');
+  result = validator.isMobilePhone('sample', 'ar-SY');
+  result = validator.isMobilePhone('sample', 'cs-CZ');
+  result = validator.isMobilePhone('sample', 'de-DE');
+  result = validator.isMobilePhone('sample', 'da-DK');
+  result = validator.isMobilePhone('sample', 'el-GR');
+  result = validator.isMobilePhone('sample', 'en-AU');
+  result = validator.isMobilePhone('sample', 'en-GB');
+  result = validator.isMobilePhone('sample', 'en-HK');
+  result = validator.isMobilePhone('sample', 'en-IN');
+  result = validator.isMobilePhone('sample', 'en-NZ');
   result = validator.isMobilePhone('sample', 'en-US');
+  result = validator.isMobilePhone('sample', 'en-CA');
+  result = validator.isMobilePhone('sample', 'en-ZA');
+  result = validator.isMobilePhone('sample', 'en-ZM');
+  result = validator.isMobilePhone('sample', 'es-ES');
+  result = validator.isMobilePhone('sample', 'fi-FI');
+  result = validator.isMobilePhone('sample', 'fr-FR');
+  result = validator.isMobilePhone('sample', 'hu-HU');
+  result = validator.isMobilePhone('sample', 'it-IT');
+  result = validator.isMobilePhone('sample', 'ja-JP');
+  result = validator.isMobilePhone('sample', 'ms-MY');
+  result = validator.isMobilePhone('sample', 'nb-NO');
+  result = validator.isMobilePhone('sample', 'nn-NO');
+  result = validator.isMobilePhone('sample', 'pl-PL');
+  result = validator.isMobilePhone('sample', 'pt-PT');
+  result = validator.isMobilePhone('sample', 'ru-RU');
+  result = validator.isMobilePhone('sample', 'sr-RS');
+  result = validator.isMobilePhone('sample', 'tr-TR');
+  result = validator.isMobilePhone('sample', 'vi-VN');
+  result = validator.isMobilePhone('sample', 'zh-CN');
+  result = validator.isMobilePhone('sample', 'zh-TW');
 
   result = validator.isMongoId('sample');
 

--- a/validator/validator.d.ts
+++ b/validator/validator.d.ts
@@ -6,7 +6,8 @@
 declare namespace ValidatorJS {
   type AlphaLocale = "ar" | "ar-AE" | "ar-BH" | "ar-DZ" | "ar-EG" | "ar-IQ" | "ar-JO" | "ar-KW" | "ar-LB" | "ar-LY" | "ar-MA" | "ar-QA" | "ar-QM" | "ar-SA" | "ar-SD" | "ar-SY" | "ar-TN" | "ar-YE" | "cs-CZ" | "de-DE" | "en-AU" | "en-GB" | "en-HK" | "en-IN" | "en-NZ" | "en-US" | "en-ZA" | "en-ZM" | "es-ES" | "fr-FR" | "hu-HU" | "nl-NL" | "pl-PL" | "pt-BR" | "pt-PT" | "ru-RU" | "sr-RS" | "sr-RS@latin" | "tr-TR";
   type AlphanumericLocale = "ar" | "ar-AE" | "ar-BH" | "ar-DZ" | "ar-EG" | "ar-IQ" | "ar-JO" | "ar-KW" | "ar-LB" | "ar-LY" | "ar-MA" | "ar-QA" | "ar-QM" | "ar-SA" | "ar-SD" | "ar-SY" | "ar-TN" | "ar-YE" | "cs-CZ" | "de-DE" | "en-AU" | "en-GB" | "en-HK" | "en-IN" | "en-NZ" | "en-US" | "en-ZA" | "en-ZM" | "es-ES" | "fr-FR" | "fr-BE" | "hu-HU" | "nl-BE" | "nl-NL" | "pl-PL" | "pt-BR" | "pt-PT" | "ru-RU" | "sr-RS" | "sr-RS@latin" | "tr-TR";
-
+  type MobilePhoneLocale = "ar-DZ" | "ar-SA" | "ar-SY" | "cs-CZ" | "de-DE" | "da-DK" | "el-GR" | "en-AU" | "en-GB" | "en-HK" | "en-IN" | "en-NZ" | "en-US" | "en-CA" | "en-ZA" | "en-ZM" | "es-ES" | "fi-FI" | "fr-FR" | "hu-HU" | "it-IT" | "ja-JP" | "ms-MY" | "nb-NO" | "nn-NO" | "pl-PL" | "pt-PT" | "ru-RU" | "sr-RS" | "tr-TR" | "vi-VN" | "zh-CN" | "zh-TW"
+  
   interface ValidatorStatic {
 
     // **************
@@ -130,7 +131,7 @@ declare namespace ValidatorJS {
     // 'en-IN', 'en-NZ', 'en-US', 'en-CA', 'en-ZA', 'en-ZM', 'es-ES', 'fi-FI', 'fr-FR', 'hu-HU',
     // 'it-IT', 'ja-JP', 'ms-MY', 'nb-NO', 'nn-NO', 'pl-PL', 'pt-PT', 'ru-RU', 'sr-RS', 'tr-TR',
     // 'vi-VN', 'zh-CN', 'zh-TW']).
-    isMobilePhone(str: string, locale: string): boolean;
+    isMobilePhone(str: string, locale: MobilePhoneLocale): boolean;
 
     // check if the string is a valid hex-encoded representation of a MongoDB ObjectId
     // (http://docs.mongodb.org/manual/reference/object-id/).


### PR DESCRIPTION
# Improvement to existing type definition.
- Refer to [validator document](https://github.com/chriso/validator.js), it explains how to use `isMobilePhone(str, locale)`:

> check if the string is a mobile phone number, (locale is one of ['ar-DZ', 'ar-SA', 'ar-SY', 'cs-CZ', 'de-DE', 'da-DK', 'el-GR', 'en-AU', 'en-GB', 'en-HK', 'en-IN', 'en-NZ', 'en-US', 'en-CA', 'en-ZA', 'en-ZM', 'es-ES', 'fi-FI', 'fr-FR', 'hu-HU', 'it-IT', 'ja-JP', 'ms-MY', 'nb-NO', 'nn-NO', 'pl-PL', 'pt-PT', 'ru-RU', 'sr-RS', 'tr-TR', 'vi-VN', 'zh-CN', 'zh-TW']).

So,  I add a type including these locales and related tests for this definition.
