### PR TITLE
[dateformat.d.ts] Add definitions for dateformat

### DIFF
--- a/dateformat/dateformat-tests.ts
+++ b/dateformat/dateformat-tests.ts
@@ -1,0 +1,58 @@
+/// <reference path='dateformat.d.ts' />
+
+/**
+ * https://github.com/felixge/node-dateformat#usage
+ */
+
+import * as dateFormat from 'dateformat'
+const now = new Date()
+
+// Basic usage
+dateFormat(now, 'dddd, mmmm dS, yyyy, h:MM:ss TT')
+// Saturday, June 9th, 2007, 5:46:21 PM
+
+// You can use one of several named masks
+dateFormat(now, 'isoDateTime')
+// 2007-06-09T17:46:21
+
+// ...Or add your own
+dateFormat.masks['hammerTime'] = `HH:MM! "Can't touch this!"`
+dateFormat(now, 'hammerTime')
+// 17:46! Can't touch this!
+
+// When using the standalone dateFormat function,
+// you can also provide the date as a string
+dateFormat('Jun 9 2007', 'fullDate')
+// Saturday, June 9, 2007
+
+// Note that if you don't include the mask argument,
+// dateFormat.masks.default is used
+dateFormat(now)
+// Sat Jun 09 2007 17:46:21
+
+// And if you don't include the date argument,
+// the current date and time is used
+dateFormat()
+// Sat Jun 09 2007 17:46:22
+
+// You can also skip the date argument (as long as your mask doesn't
+// contain any numbers), in which case the current date/time is used
+dateFormat('longTime')
+// 5:46:22 PM EST
+
+// And finally, you can convert local time to UTC time. Simply pass in
+// true as an additional argument (no argument skipping allowed in this case):
+dateFormat(now, 'longTime', true)
+// 10:46:21 PM UTC
+
+// ...Or add the prefix 'UTC:' or 'GMT:' to your mask.
+dateFormat(now, 'UTC:h:MM:ss TT Z')
+// 10:46:21 PM UTC
+
+// You can also get the ISO 8601 week of the year:
+dateFormat(now, 'W')
+// 42
+
+// and also get the ISO 8601 numeric representation of the day of the week:
+dateFormat(now, 'N')
+// 6

--- a/dateformat/dateformat.d.ts
+++ b/dateformat/dateformat.d.ts
@@ -1,0 +1,77 @@
+// Type definitions for dateformat v1.0.12
+// Project: https://github.com/felixge/node-dateformat
+// Definitions by: Kombu <https://github.com/aicest>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * dateFormat.masks
+ *
+ * Predefined Formats
+ *
+ * https://github.com/felixge/node-dateformat/blob/master/lib/dateformat.js#L107
+ */
+interface DateFormatMasks {
+    default: string;
+    shortDate: string;
+    mediumDate: string;
+    longDate: string;
+    fullDate: string;
+    shortTime: string;
+    mediumTime: string;
+    longTime: string;
+    isoDate: string;
+    isoTime: string;
+    isoDateTime: string;
+    isoUtcDateTime: string;
+    expiresHeaderFormat: string;
+    [key: string]: string;
+}
+
+/**
+ * dateFormat.i18n
+ *
+ * Internationalization strings
+ *
+ * Example:
+ *
+ * ```
+ * dateFormat.i18n = {
+ *   dayNames: [
+ *     'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat',
+ *     'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'
+ *   ],
+ *   monthNames: [
+ *     'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+ *     'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'
+ *   ]
+ * }
+ * ```
+ *
+ * https://github.com/felixge/node-dateformat/blob/master/lib/dateformat.js#L124
+ */
+interface DateFormatI18n {
+    dayNames: string[];
+    monthNames: string[];
+}
+
+/**
+ * dateFormat()
+ *
+ * Accepts a date, a mask, or a date and a mask.
+ * Returns a formatted version of the given date.
+ * The date defaults to the current date/time.
+ * The mask defaults to dateFormat.masks.default.
+ *
+ * https://github.com/felixge/node-dateformat/blob/master/lib/dateformat.js#L18
+ */
+interface DateFormatStatic {
+    (date?: Date | string | number, mask?: string, utc?: boolean, gmt?: boolean): string;
+    (mask?: string, utc?: boolean, gmt?: boolean): string;
+    masks: DateFormatMasks;
+    i18n: DateFormatI18n;
+}
+
+declare module 'dateformat' {
+    const dateFormat: DateFormatStatic;
+    export = dateFormat;
+}


### PR DESCRIPTION
Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
