### PR TITLE
Added type definitions for object-refs [types 2.0]

### DIFF
--- a/object-refs/index.d.ts
+++ b/object-refs/index.d.ts
@@ -1,0 +1,52 @@
+// Type definitions for object-refs 0.1.1
+// Project: https://github.com/bpmn-io/object-refs
+// Definitions by: Jan Steinbruecker <https://github.com/3fd>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = Refs;
+
+declare class Refs {
+
+    /**
+     * Creates a new references object defining two inversly related
+     * attribute descriptors a and b.
+     * @param {Refs.AttributeDescriptor} a property descriptor
+     * @param {Refs.AttributeDescriptor} b property descriptor
+     **/
+    constructor(a: Refs.AttributeDescriptor, b: Refs.AttributeDescriptor);
+
+    /**
+     * Binds one side of a bi-directional reference to a target object.
+     * @param {*} target
+     * @param {string|Refs.AttributeDescriptor} property
+     */
+    bind(target: any, property: string|Refs.AttributeDescriptor): void;
+
+    ensureBound(target: any, property: string|Refs.AttributeDescriptor): void;
+
+    ensureRefsCollection(target: any, property: Refs.AttributeDescriptor): any;
+
+    set(target: any, property: string|Refs.AttributeDescriptor, value: any): void;
+
+    unset(target: any, property: string|Refs.AttributeDescriptor, value: any): void;
+
+}
+
+declare namespace Refs {
+
+    interface AttributeDescriptor {
+        name: string;
+        collection?: boolean;
+        enumerable?: boolean;
+    }
+
+    namespace Collection {
+
+        /** Extends a collection with Refs aware methods */
+        function extend(collection: any[], refs: Refs, property: string|AttributeDescriptor, target: any): any;
+
+        function isExtended(collection: any[]): boolean;
+
+    }
+
+}

--- a/object-refs/object-refs-tests.ts
+++ b/object-refs/object-refs-tests.ts
@@ -1,0 +1,17 @@
+import * as Refs from 'object-refs';
+
+let refs = new Refs({ name: 'wheels', collection: true, enumerable: true }, { name: 'car' });
+
+let car: any = { name: 'toyota' };
+let wheels: any = [{ pos: 'front-left' }, { pos: 'front-right' }];
+
+refs.bind(car, 'wheels');
+
+car.wheels; //[]
+car.wheels.add(wheels[0]);
+car.wheels.add(wheels[1]);
+car.wheels; // [{ pos: 'front-left' }, { pos: 'front-right' }]
+
+wheels[0].car // { name: 'toyota' };
+car.wheels.remove(wheels[0]);
+wheels[0].car // undefined

--- a/object-refs/tsconfig.json
+++ b/object-refs/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "object-refs-tests.ts"
+    ]
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

---

type definition for [object-refs](https://github.com/bpmn-io/object-refs)
