### PR TITLE
[types-2.0] csv-parse: Strict return type of stream read to string[] rather than any.

### DIFF
--- a/csv-parse/csv-parse-tests.ts
+++ b/csv-parse/csv-parse-tests.ts
@@ -10,26 +10,22 @@ function callbackAPITest() {
 }
 
 function streamAPITest() {
-    var output:any = [];
+    let output:string[][] = [];
     // Create the parser
     var parser = parse({delimiter: ':'});
-    var record: any;
+    let record: string[];
     // Use the writable stream api
     parser.on('readable', function(){
-    while(record = parser.read()){
-        output.push(record);
-    }
+        while(record = parser.read()){
+            output.push(record);
+        }
     });
     // Catch any error
     parser.on('error', function(err: any){
-    console.log(err.message);
+        console.log(err.message);
     });
-    // When we are done, test that the parsed output matched what expected
     parser.on('finish', function(){
-    output.should.eql([
-        [ 'root','x','0','0','root','/root','/bin/bash' ],
-        [ 'someone','x','1022','1022','a funny cat','/home/someone','/bin/bash' ]
-    ]);
+        console.log(output);
     });
     // Now that setup is done, write data to the stream
     parser.write("root:x:0:0:root:/root:/bin/bash\n");

--- a/csv-parse/csv-parse.d.ts
+++ b/csv-parse/csv-parse.d.ts
@@ -106,11 +106,15 @@ declare module "csv-parse/types" {
        new (options: options): Parser;
     }
 
+    interface ParserStream extends NodeJS.ReadWriteStream {
+        read(size?: number): any & string[];
+    }
+
     interface parse {
         (input: string, options?: options, callback?: callbackFn): any;
         (options: options, callback: callbackFn): any;
         (callback: callbackFn): any;
-        (options?: options): NodeJS.ReadWriteStream;
+        (options?: options): ParserStream;
         Parser: ParserConstructor;
     }
 }


### PR DESCRIPTION
``` typescript
const parser = parse();
parser.on('readable', () => {
  let record: any;    // <-- it should be string[]
  while (record = parser.read()) {
    // ...
  }
});
```

The Q&A on StackOverflow: http://stackoverflow.com/questions/39664513/how-to-declare-a-stream-like-interface-in-typescript
