### PR TITLE
Added types for klaw

### DIFF
--- a/klaw/klaw-tests.ts
+++ b/klaw/klaw-tests.ts
@@ -6,41 +6,41 @@ const path = require('path');
 
 // README.md: Streams 1 (push) example:
 
-let items: Array<klaw.Item> = [] // files, directories, symlinks, etc
+let items: klaw.Item[] = [] // files, directories, symlinks, etc
 
 klaw('/some/dir')
-  .on('data', function (item: klaw.Item) {
-    items.push(item)
-  })
-  .on('end', function () {
-    console.dir(items) // => [ ... array of files]
-  })
+    .on('data', function(item: klaw.Item) {
+        items.push(item)
+    })
+    .on('end', function() {
+        console.dir(items) // => [ ... array of files]
+    })
 
 // README.md: Streams 2 & 3 (pull) with error handling
 
 klaw('/some/dir')
-  .on('readable', function () {
-    let item: klaw.Item;
-    while (item = this.read()) {
-      items.push(item)
-    }
-  })
-  .on('error', function (err: Error, item: klaw.Item) {
-    console.log(err.message)
-    console.log(item.path) // the file the error occurred on
-  })
-  .on('end', function () {
-    console.log(items) // => [ ... array of files]
-  })
+    .on('readable', function() {
+        let item: klaw.Item;
+        while (item = this.read()) {
+            items.push(item)
+        }
+    })
+    .on('error', function(err: Error, item: klaw.Item) {
+        console.log(err.message)
+        console.log(item.path) // the file the error occurred on
+    })
+    .on('end', function() {
+        console.log(items) // => [ ... array of files]
+    })
 
 // README.md: Example (ignore hidden directories):
 
 var filterFunc = function(item: klaw.Item): boolean {
-  var basename = path.basename(item.path)
-  return basename === '.' || basename[0] !== '.'
+    var basename = path.basename(item.path)
+    return basename === '.' || basename[0] !== '.'
 }
 
-klaw('/some/dir', { filter : filterFunc  })
-  .on('data', function(item: klaw.Item){
-    // only items of none hidden folders will reach here
-  })
+klaw('/some/dir', { filter: filterFunc })
+    .on('data', function(item: klaw.Item) {
+        // only items of none hidden folders will reach here
+    })

--- a/klaw/klaw-tests.ts
+++ b/klaw/klaw-tests.ts
@@ -1,0 +1,46 @@
+/// <reference path="klaw.d.ts" />
+/// <reference path="../node/node.d.ts" />
+
+import * as klaw from "klaw";
+const path = require('path');
+
+// README.md: Streams 1 (push) example:
+
+let items: Array<klaw.Item> = [] // files, directories, symlinks, etc
+
+klaw('/some/dir')
+  .on('data', function (item: klaw.Item) {
+    items.push(item)
+  })
+  .on('end', function () {
+    console.dir(items) // => [ ... array of files]
+  })
+
+// README.md: Streams 2 & 3 (pull) with error handling
+
+klaw('/some/dir')
+  .on('readable', function () {
+    let item: klaw.Item;
+    while (item = this.read()) {
+      items.push(item)
+    }
+  })
+  .on('error', function (err: Error, item: klaw.Item) {
+    console.log(err.message)
+    console.log(item.path) // the file the error occurred on
+  })
+  .on('end', function () {
+    console.log(items) // => [ ... array of files]
+  })
+
+// README.md: Example (ignore hidden directories):
+
+var filterFunc = function(item: klaw.Item): boolean {
+  var basename = path.basename(item.path)
+  return basename === '.' || basename[0] !== '.'
+}
+
+klaw('/some/dir', { filter : filterFunc  })
+  .on('data', function(item: klaw.Item){
+    // only items of none hidden folders will reach here
+  })

--- a/klaw/klaw.d.ts
+++ b/klaw/klaw.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for klaw
+// Project: https://github.com/jprichardson/node-klaw
+// Definitions by: Matthew McEachen <https://github.com/mceachen>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module "klaw" {
+
+  import * as fs from "fs"
+  import {Readable, ReadableOptions} from 'stream'
+
+  function K(root: string, options?: K.Options): K.Walker
+
+  namespace K {
+    interface Item {
+      path: string
+      stats: fs.Stats
+    }
+
+    type QueueMethod = "shift" | "pop"
+
+    interface Options extends ReadableOptions {
+      queueMethod?: QueueMethod
+      pathSorter?: (a: Array<Item>) => Array<Item>
+      fs?: any // fs or mock-fs
+      filter?: (a: Item) => boolean
+    }
+
+    type Event = "close" | "data" | "end" | "readable" | "error"
+
+    interface Walker {
+      on(event: Event, listener: Function): this
+      on(event: "close", listener: () => void): this
+      on(event: "data", listener: (item: Item) => void): this
+      on(event: "end", listener: () => void): this
+      on(event: "readable", listener: () => void): this
+      on(event: "error", listener: (err: Error) => void): this
+      read(): Item
+    }
+  }
+
+  export = K
+}

--- a/klaw/klaw.d.ts
+++ b/klaw/klaw.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for klaw
+// Type definitions for klaw v1.3.0
 // Project: https://github.com/jprichardson/node-klaw
 // Definitions by: Matthew McEachen <https://github.com/mceachen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -7,38 +7,38 @@
 
 declare module "klaw" {
 
-  import * as fs from "fs"
-  import {Readable, ReadableOptions} from 'stream'
+    import * as fs from "fs"
+    import { Readable, ReadableOptions } from 'stream'
 
-  function K(root: string, options?: K.Options): K.Walker
+    function K(root: string, options?: K.Options): K.Walker
 
-  namespace K {
-    interface Item {
-      path: string
-      stats: fs.Stats
+    namespace K {
+        interface Item {
+            path: string
+            stats: fs.Stats
+        }
+
+        type QueueMethod = "shift" | "pop"
+
+        interface Options extends ReadableOptions {
+            queueMethod?: QueueMethod
+            pathSorter?: (a: Array<Item>) => Array<Item>
+            fs?: any // fs or mock-fs
+            filter?: (a: Item) => boolean
+        }
+
+        type Event = "close" | "data" | "end" | "readable" | "error"
+
+        interface Walker {
+            on(event: Event, listener: Function): this
+            on(event: "close", listener: () => void): this
+            on(event: "data", listener: (item: Item) => void): this
+            on(event: "end", listener: () => void): this
+            on(event: "readable", listener: () => void): this
+            on(event: "error", listener: (err: Error) => void): this
+            read(): Item
+        }
     }
 
-    type QueueMethod = "shift" | "pop"
-
-    interface Options extends ReadableOptions {
-      queueMethod?: QueueMethod
-      pathSorter?: (a: Array<Item>) => Array<Item>
-      fs?: any // fs or mock-fs
-      filter?: (a: Item) => boolean
-    }
-
-    type Event = "close" | "data" | "end" | "readable" | "error"
-
-    interface Walker {
-      on(event: Event, listener: Function): this
-      on(event: "close", listener: () => void): this
-      on(event: "data", listener: (item: Item) => void): this
-      on(event: "end", listener: () => void): this
-      on(event: "readable", listener: () => void): this
-      on(event: "error", listener: (err: Error) => void): this
-      read(): Item
-    }
-  }
-
-  export = K
+    export = K
 }


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Thanks for DefinitelyTyped!
