### PR TITLE
add typings for onselected and onunselected methods, refs #11493

### DIFF
--- a/c3/c3.d.ts
+++ b/c3/c3.d.ts
@@ -385,10 +385,10 @@ declare namespace c3 {
          * - d is the data where mouse cursor moves out. In this callback, this will be the Chart object.
          */
         onmouseout?: (d: any, element?: any) => void;
-        // onselected?: any;
-        // onunselected?: any;
-        // ondragstart?: any;
-        // ondragend?: any;
+        
+        onselected?: (d: any, element?: any) => void;
+
+        onunselected?: (d: any, element?: any) => void; 
     }
 
     interface Axis {


### PR DESCRIPTION
- onselected and onunselected methods are valid methods in c3 
- ondragend and ondragstart are not so removed these commented out lines
