### PR TITLE
[validator] Add new stuff which document not mentioned

### DIFF
--- a/validator/validator-tests.ts
+++ b/validator/validator-tests.ts
@@ -299,6 +299,16 @@ let any: any;
   result = validator.whitelist('sample', 'abc');
 }
 
+{
+  let str: string;
+  str = validator.toString([123, 456, '123', '456', true, false]);
+}
+
+{
+  let ver: string;
+  ver = validator.version;
+}
+
 // **************
 // * Extensions *
 // **************

--- a/validator/validator.d.ts
+++ b/validator/validator.d.ts
@@ -213,6 +213,10 @@ declare namespace ValidatorJS {
     // remove characters that do not appear in the whitelist. The characters are used in a RegExp and so you will
     // need to escape some chars, e.g. whitelist(input, '\\[\\]').
     whitelist(input: string, chars: string): string;
+    
+    toString(input: any | any[]): string;
+    
+    version: string;
 
     // **************
     // * Extensions *


### PR DESCRIPTION
# Improvement to existing type definition.
1. It needs  to refer to source code. It's not mentioned on document.
2. The exports has [toString](https://github.com/chriso/validator.js/blob/master/src/index.js#L116) - It's from [lib/util/toString.js](https://github.com/chriso/validator.js/blob/master/src/lib/util/toString.js)
3. The exports has [version](https://github.com/chriso/validator.js/blob/master/src/index.js#L86) - It's from [here](https://github.com/chriso/validator.js/blob/master/src/index.js#L1)
