### PR TITLE
Improve through2 declarations

### DIFF
--- a/through2/through2-tests.ts
+++ b/through2/through2-tests.ts
@@ -1,9 +1,11 @@
 /// <reference path="./through2.d.ts" />
 /// <reference path="../node/node.d.ts" />
 
+import stream = require('stream');
 import through2 = require('through2');
 
-var rws: NodeJS.ReadWriteStream;
+var rws: stream.Transform;
+var Rws: through2.Through2Constructor;
 
 rws = through2({
 	objectMode: true,
@@ -53,3 +55,48 @@ rws = through2.obj(function (entry: any, enc: string, callback: (err: any) => vo
 }, (flashCallback) => {
 	flashCallback();
 });
+
+// ctor
+Rws = through2.ctor({
+	objectMode: true,
+	allowHalfOpen: true
+}, function (entry: any, enc: string, callback: () => void) {
+	this.push('foo');
+	callback();
+}, () => {
+
+});
+
+rws = Rws();
+rws = new Rws();
+rws = new Rws({ objectMode: true, allowHalfOpen: true });
+
+Rws = through2.ctor(function (entry: any, enc: string, callback: () => void) {
+	this.push('foo');
+	callback();
+}, () => {
+
+});
+
+rws = Rws();
+rws = new Rws();
+rws = new Rws({ objectMode: true, allowHalfOpen: true });
+
+Rws = through2.ctor(function (entry: any, enc: string, callback: (error: any, data?: any) => void) {
+	callback(null, 'foo');
+}, (flushCallback: () => void) => {
+	flushCallback();
+});
+
+rws = Rws();
+rws = new Rws();
+rws = new Rws({ objectMode: true, allowHalfOpen: true });
+
+Rws = through2.ctor(function (entry: any, enc: string, callback: () => void) {
+	this.push('foo');
+	callback();
+});
+
+rws = Rws();
+rws = new Rws();
+rws = new Rws({ objectMode: true, allowHalfOpen: true });

--- a/through2/through2.d.ts
+++ b/through2/through2.d.ts
@@ -13,15 +13,13 @@ declare module 'through2' {
 	type TransformFunction = (chunk: any, enc: string, callback: TransformCallback) => void;
 	type FlushCallback = (flushCallback: () => void) => void;
 
-	function through2(transform?: TransformFunction, flush?: FlushCallback): NodeJS.ReadWriteStream;
+	function through2(transform?: TransformFunction, flush?: FlushCallback): stream.Transform;
 
-	function through2(opts?: stream.DuplexOptions, transform?: TransformFunction, flush?: FlushCallback): NodeJS.ReadWriteStream;
+	function through2(opts?: stream.DuplexOptions, transform?: TransformFunction, flush?: FlushCallback): stream.Transform;
 
 	namespace through2 {
 
-		export function obj(transform?: TransformFunction, flush?: FlushCallback): NodeJS.ReadWriteStream;
-
-		export function push(data: any): void;
+		export function obj(transform?: TransformFunction, flush?: FlushCallback): stream.Transform;
 
 	}
 

--- a/through2/through2.d.ts
+++ b/through2/through2.d.ts
@@ -9,17 +9,17 @@ declare module 'through2' {
 
 	import stream = require('stream');
 
-	type TransfofmCallback = (err?: any, data?: any) => void;
-	type TransformFunction = (chunk: any, enc: string, callback: TransfofmCallback) => void;
-	type FlashCallback = (flushCallback: () => void) => void;
+	type TransformCallback = (err?: any, data?: any) => void;
+	type TransformFunction = (chunk: any, enc: string, callback: TransformCallback) => void;
+	type FlushCallback = (flushCallback: () => void) => void;
 
-	function through2(transform?: TransformFunction, flush?: FlashCallback): NodeJS.ReadWriteStream;
+	function through2(transform?: TransformFunction, flush?: FlushCallback): NodeJS.ReadWriteStream;
 
-	function through2(opts?: stream.DuplexOptions, transform?: TransformFunction, flush?: FlashCallback): NodeJS.ReadWriteStream;
+	function through2(opts?: stream.DuplexOptions, transform?: TransformFunction, flush?: FlushCallback): NodeJS.ReadWriteStream;
 
 	namespace through2 {
 
-		export function obj(transform?: TransformFunction, flush?: FlashCallback): NodeJS.ReadWriteStream;
+		export function obj(transform?: TransformFunction, flush?: FlushCallback): NodeJS.ReadWriteStream;
 
 		export function push(data: any): void;
 

--- a/through2/through2.d.ts
+++ b/through2/through2.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for through2 v 2.0.0
 // Project: https://github.com/rvagg/through2
-// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, jedmao <https://github.com/jedmao>, Georgios Valotasios <https://github.com/valotas>
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, jedmao <https://github.com/jedmao>, Georgios Valotasios <https://github.com/valotas>, Ben Chauvette <https://github.com/bdchauvette>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../node/node.d.ts" />
@@ -23,8 +23,15 @@ declare module 'through2' {
 			(opts?: stream.DuplexOptions): stream.Transform;
 		}
 
+		/**
+		 * Convenvience method for creating object streams
+		 */
 		export function obj(transform?: TransformFunction, flush?: FlushCallback): stream.Transform;
 
+		/**
+		 * Creates a constructor for a custom Transform. This is useful when you
+		 * want to use the same transform logic in multiple instances.
+		 */
 		export function ctor(opts?: stream.DuplexOptions, transfrom?: TransformFunction, flush?: FlushCallback): Through2Constructor;
 	}
 

--- a/through2/through2.d.ts
+++ b/through2/through2.d.ts
@@ -18,9 +18,14 @@ declare module 'through2' {
 	function through2(opts?: stream.DuplexOptions, transform?: TransformFunction, flush?: FlushCallback): stream.Transform;
 
 	namespace through2 {
+		export interface Through2Constructor extends stream.Transform {
+			new(opts?: stream.DuplexOptions): stream.Transform;
+			(opts?: stream.DuplexOptions): stream.Transform;
+		}
 
 		export function obj(transform?: TransformFunction, flush?: FlushCallback): stream.Transform;
 
+		export function ctor(opts?: stream.DuplexOptions, transfrom?: TransformFunction, flush?: FlushCallback): Through2Constructor;
 	}
 
 	export = through2;


### PR DESCRIPTION
This PR improves the [`through2`](https://github.com/rvagg/through2) declarations by:

**1. Fixing typos**:
- `TransfofmCallback` &rarr;  `TransformCallback`
- `FlashCallback` &rarr;  `FlushCallback`

**2. Changing return types from `NodeJS.ReadWriteStream` to `stream.Transform`**

`stream.Transform` contains richer typing information, and is more accurate as a return type because it's what `through2` actually uses it to create streams. This is not a hidden, internal implementation detail, as the [`through2` docs themselves point users to the `stream.Transform` docs](https://github.com/rvagg/through2#api) for information about configuration options.

Because [`stream.Transform` implements `NodeJS.ReadWriteStream`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/node/node.d.ts#L3050), these changes should not break anything for existing users of the declaration.

**3. Adding typing info (and tests) for the `through2.ctor` method**

See the [API docs](https://github.com/rvagg/through2#api) for more info about the `through2.ctor` method.

**4. Adding basic JSDoc descriptions to `through2.obj` and `through2.ctor`**

It's always nice to get a description of what a method does, especially when they have somewhat cryptic names like `obj` and `ctor`.

**5. Adding myself as one of the authors**

Not sure if this is the correct way to do it, but I figure this includes some decent changes, so I might as well try 😅

(If there's a strict authorship crediting process, I'm totally fine with removing my name here. No worries!)
