### PR TITLE
[node] Add events for dgram

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -673,6 +673,9 @@ namespace dgram_tests {
     {
         let _socket: dgram.Socket;
         let _boolean: boolean;
+        let _err: Error;
+        let _str: string;
+        let _rinfo: dgram.AddressInfo;
         /**
          * events.EventEmitter
          * 1. close
@@ -691,10 +694,10 @@ namespace dgram_tests {
             let _rinfo: dgram.AddressInfo = rinfo;
         })
 
-        _boolean = _socket.emit("close", () => {});
-        _boolean = _socket.emit("error", () => {});
-        _boolean = _socket.emit("listening", () => {});
-        _boolean = _socket.emit("message", () => {});
+        _boolean = _socket.emit("close")
+        _boolean = _socket.emit("error", _err);
+        _boolean = _socket.emit("listening");
+        _boolean = _socket.emit("message", _str, _rinfo);
 
         _socket = _socket.on("close", () => {});
         _socket = _socket.on("error", (err) => {

--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -659,14 +659,83 @@ namespace tty_tests {
 ////////////////////////////////////////////////////
 
 namespace dgram_tests {
-    var ds: dgram.Socket = dgram.createSocket("udp4", (msg: Buffer, rinfo: dgram.RemoteInfo): void => {
-    });
-    ds.bind();
-    ds.bind(41234);
-    var ai: dgram.AddressInfo = ds.address();
-    ds.send(new Buffer("hello"), 0, 5, 5000, "127.0.0.1", (error: Error, bytes: number): void => {
-    });
-    ds.send(new Buffer("hello"), 5000, "127.0.0.1");
+    {
+        var ds: dgram.Socket = dgram.createSocket("udp4", (msg: Buffer, rinfo: dgram.RemoteInfo): void => {
+        });
+        ds.bind();
+        ds.bind(41234);
+        var ai: dgram.AddressInfo = ds.address();
+        ds.send(new Buffer("hello"), 0, 5, 5000, "127.0.0.1", (error: Error, bytes: number): void => {
+        });
+        ds.send(new Buffer("hello"), 5000, "127.0.0.1");
+    }
+
+    {
+        let _socket: dgram.Socket;
+        let _boolean: boolean;
+        /**
+         * events.EventEmitter
+         * 1. close
+         * 2. error
+         * 3. listening
+         * 4. message
+         **/
+
+        _socket = _socket.addListener("close", () => {});
+        _socket = _socket.addListener("error", (err) => {
+            let _err: Error = err;
+        })
+        _socket = _socket.addListener("listening", () => {});
+        _socket = _socket.addListener("message", (msg, rinfo) => {
+            let _msg: string = msg;
+            let _rinfo: dgram.AddressInfo = rinfo;
+        })
+
+        _boolean = _socket.emit("close", () => {});
+        _boolean = _socket.emit("error", () => {});
+        _boolean = _socket.emit("listening", () => {});
+        _boolean = _socket.emit("message", () => {});
+
+        _socket = _socket.on("close", () => {});
+        _socket = _socket.on("error", (err) => {
+            let _err: Error = err;
+        })
+        _socket = _socket.on("listening", () => {});
+        _socket = _socket.on("message", (msg, rinfo) => {
+            let _msg: string = msg;
+            let _rinfo: dgram.AddressInfo = rinfo;
+        })
+
+        _socket = _socket.once("close", () => {});
+        _socket = _socket.once("error", (err) => {
+            let _err: Error = err;
+        })
+        _socket = _socket.once("listening", () => {});
+        _socket = _socket.once("message", (msg, rinfo) => {
+            let _msg: string = msg;
+            let _rinfo: dgram.AddressInfo = rinfo;
+        })
+
+        _socket = _socket.prependListener("close", () => {});
+        _socket = _socket.prependListener("error", (err) => {
+            let _err: Error = err;
+        })
+        _socket = _socket.prependListener("listening", () => {});
+        _socket = _socket.prependListener("message", (msg, rinfo) => {
+            let _msg: string = msg;
+            let _rinfo: dgram.AddressInfo = rinfo;
+        })
+
+        _socket = _socket.prependOnceListener("close", () => {});
+        _socket = _socket.prependOnceListener("error", (err) => {
+            let _err: Error = err;
+        })
+        _socket = _socket.prependOnceListener("listening", () => {});
+        _socket = _socket.prependOnceListener("message", (msg, rinfo) => {
+            let _msg: string = msg;
+            let _rinfo: dgram.AddressInfo = rinfo;
+        })
+    }
 }
 
 ////////////////////////////////////////////////////

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1855,8 +1855,8 @@ declare module "dgram" {
 
     interface RemoteInfo {
         address: string;
+        family: string;
         port: number;
-        size: number;
     }
 
     interface AddressInfo {

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1908,11 +1908,11 @@ declare module "dgram" {
         addListener(event: "listening", listener: () => void): this;
         addListener(event: "message", listener: (msg: string, rinfo: AddressInfo) => void): this;
 
-        emit(event: string, listener: Function): boolean;
-        emit(event: "close", listener: () => void): boolean;
-        emit(event: "error", listener: (err: Error) => void): boolean;
-        emit(event: "listening", listener: () => void): boolean;
-        emit(event: "message", listener: (msg: string, rinfo: AddressInfo) => void): boolean;
+        emit(event: string, ...args: any[]): boolean;
+        emit(event: "close"): boolean;
+        emit(event: "error", err: Error): boolean;
+        emit(event: "listening"): boolean;
+        emit(event: "message", msg: string, rinfo: AddressInfo): boolean;
 
         on(event: string, listener: Function): this;
         on(event: "close", listener: () => void): this;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1894,6 +1894,49 @@ declare module "dgram" {
         dropMembership(multicastAddress: string, multicastInterface?: string): void;
         ref(): void;
         unref(): void;
+
+        /**
+         * events.EventEmitter
+         * 1. close
+         * 2. error
+         * 3. listening
+         * 4. message
+         **/
+        addListener(event: string, listener: Function): this;
+        addListener(event: "close", listener: () => void): this;
+        addListener(event: "error", listener: (err: Error) => void): this;
+        addListener(event: "listening", listener: () => void): this;
+        addListener(event: "message", listener: (msg: string, rinfo: AddressInfo) => void): this;
+
+        emit(event: string, listener: Function): boolean;
+        emit(event: "close", listener: () => void): boolean;
+        emit(event: "error", listener: (err: Error) => void): boolean;
+        emit(event: "listening", listener: () => void): boolean;
+        emit(event: "message", listener: (msg: string, rinfo: AddressInfo) => void): boolean;
+
+        on(event: string, listener: Function): this;
+        on(event: "close", listener: () => void): this;
+        on(event: "error", listener: (err: Error) => void): this;
+        on(event: "listening", listener: () => void): this;
+        on(event: "message", listener: (msg: string, rinfo: AddressInfo) => void): this;
+
+        once(event: string, listener: Function): this;
+        once(event: "close", listener: () => void): this;
+        once(event: "error", listener: (err: Error) => void): this;
+        once(event: "listening", listener: () => void): this;
+        once(event: "message", listener: (msg: string, rinfo: AddressInfo) => void): this;
+
+        prependListener(event: string, listener: Function): this;
+        prependListener(event: "close", listener: () => void): this;
+        prependListener(event: "error", listener: (err: Error) => void): this;
+        prependListener(event: "listening", listener: () => void): this;
+        prependListener(event: "message", listener: (msg: string, rinfo: AddressInfo) => void): this;
+
+        prependOnceListener(event: string, listener: Function): this;
+        prependOnceListener(event: "close", listener: () => void): this;
+        prependOnceListener(event: "error", listener: (err: Error) => void): this;
+        prependOnceListener(event: "listening", listener: () => void): this;
+        prependOnceListener(event: "message", listener: (msg: string, rinfo: AddressInfo) => void): this;
     }
 }
 


### PR DESCRIPTION
# Improvement to existing type definition.
- Refer to [dgram](https://nodejs.org/api/dgram.html), I add definition and tests.
- Correct RemoteInfo, the reason is as followings:

> rinfo is an object with the sender's address information provided by the address, family and port properties
