### PR TITLE
Function signatures do not match documentation/implementation

### DIFF
--- a/dojo/dojo.d.ts
+++ b/dojo/dojo.d.ts
@@ -2465,7 +2465,7 @@ declare namespace dojo {
          * @param callback
          * @param thisObj
          */
-        forEach(callback: any, thisObj: any): Function;
+        forEach(callback: any, thisObj?: any): Function;
         /**
          * allows setting the innerHTML of each node in the NodeList,
          * if there is a value passed in, otherwise, reads the innerHTML value of the first node.
@@ -3591,7 +3591,7 @@ declare namespace dojo {
          *
          *
          */
-        interface url{(): void}
+        interface url { (url?: string): void }
         interface url {
             /**
              *
@@ -5566,7 +5566,7 @@ declare namespace dojo {
              *
              * @param src The object to clone
              */
-            clone(src: any): any;
+            clone<T>(src: T): T;
             /**
              * Returns a new object which "looks" to obj for properties which it
              * does not have a value for. Optionally takes a bag of properties to
@@ -5578,19 +5578,19 @@ declare namespace dojo {
              * This can be thought of similarly to ES4's "wrap", save that it does
              * not act on types but rather on pure objects.
              *
-             * @param obj The object to delegate to for properties not found directly on thereturn object or in props.
+             * @param obj The object to delegate to for properties not found directly on the returned object or in props.
              * @param props an object containing properties to assign to the returned object
              */
-            delegate(obj: Object, props: Object[]): any;
+            delegate<T, U>(obj: T, props: U): T & U;
             /**
              * determine if an object supports a given method
              * useful for longer api chains where you have to test each object in
              * the chain. Useful for object and method detection.
              *
              * @param name Path to an object, in the form "A.B.C".
-             * @param obj               OptionalObject to use as root of path. Defaults to'dojo.global'. Null may be passed.
+             * @param obj Optional Object to use as root of path. Defaults to'dojo.global'. Null may be passed.
              */
-            exists(name: String, obj?: Object): boolean;
+            exists<T>(name: String, obj?: T): boolean;
             /**
              * Adds all properties and methods of props to constructor's
              * prototype, making them available to all instances created with
@@ -5599,15 +5599,15 @@ declare namespace dojo {
              * @param ctor Target constructor to extend.
              * @param props One or more objects to mix into ctor.prototype
              */
-            extend(ctor: Object, props: Object): Object;
+            extend<T extends Object, U extends Object>(ctor: T, props: U): T & U;
             /**
              * Get a property from a dot-separated string, such as "A.B.C"
              * Useful for longer api chains where you have to test each object in
              * the chain, or when you have an object reference in string format.
              *
              * @param name Path to an property, in the form "A.B.C".
-             * @param create               OptionalOptional. Defaults to false. If true, Objects will becreated at any point along the 'path' that is undefined.
-             * @param context               OptionalOptional. Object to use as root of path. Defaults to'dojo.global'. Null may be passed.
+             * @param create Optional. Defaults to false. If true, Objects will be created at any point along the 'path' that is undefined.
+             * @param context Optional. Object to use as root of path. Defaults to 'dojo.global'. Null may be passed.
              */
             getObject(name: String, create?: boolean, context?: Object): any;
             /**
@@ -5620,10 +5620,10 @@ declare namespace dojo {
              * Each of these values will be used to "placehold" (similar to curry)
              * for the hitched function.
              *
-             * @param scope The scope to use when method executes. If method is a string,scope is also the object containing method.
+             * @param scope The scope to use when method executes. If method is a string, scope is also the object containing method.
              * @param method A function to be hitched to scope, or the name of the method inscope to be hitched.
              */
-            hitch(scope: Object, method: (...args: any[]) => any, ...args: any[]): any;
+            hitch<T>(scope: Object, method: (...args: any[]) => T, ...args: any[]): (...args: any[]) => T;
             /**
              * Returns a function that will only ever execute in the a given scope.
              * This allows for easy use of object member functions
@@ -5637,7 +5637,7 @@ declare namespace dojo {
              * @param scope The scope to use when method executes. If method is a string,scope is also the object containing method.
              * @param method A function to be hitched to scope, or the name of the method inscope to be hitched.
              */
-            hitch(scope: Object, method: string, ...args: any[]): any;
+            hitch<T>(scope: Object, method: string, ...args: any[]): (...args: any[]) => T;
             /**
              * Returns true if it is a built-in function or some other kind of
              * oddball that should report as a function but doesn't
@@ -5718,7 +5718,8 @@ declare namespace dojo {
              *
              * @param method The function to "wrap"
              */
-            partial(method: string | Function, ...args: any[]): Function;
+            partial<T>(method: string, ...args: any[]): (...args: any[]) => T;
+            partial<T>(method: (...args: any[]) => T, ...args: any[]): (...args: any[]) => T;
             /**
              * Performs parameterized substitutions on a string. Throws an
              * exception if any parameter is unmatched.
@@ -16897,23 +16898,23 @@ declare namespace dojo {
          * @param options This provides any configuration information that will be mixed into the store.This should generally include the data property to provide the starting set of data.
          */
         class Memory extends dojo.store.api.Store {
-            constructor(options: dojo.store.Memory);
+            constructor(options?: dojo.store.Memory);
             /**
              * The array of all the objects in the memory store
              *
              */
-            "data": any[];
+            data: any[];
             /**
              * Indicates the property to use as the identity property. The values of this
              * property should be unique.
              *
              */
-            "idProperty": string;
+            idProperty: string;
             /**
              * An index of data indices into the data array by id
              *
              */
-            "index": Object;
+            index: Object;
             /**
              * Creates an object, throws an error if the object already exists
              *
@@ -19049,7 +19050,7 @@ declare namespace dojo {
          * @param refNode               OptionalOptional reference node. Used by dojo.place to place the newly creatednode somewhere in the dom relative to refNode. Can be a DomNode referenceor String ID of a node.
          * @param pos               OptionalOptional positional reference. Defaults to "last" by way of dojo.place,though can be set to "first","after","before","last", "replace" or "only"to further control the placement of the new node relative to the refNode.'refNode' is required if a 'pos' is specified.
          */
-        create(tag: HTMLElement, attrs: Object, refNode?: HTMLElement, pos?: String): any;
+        create(tag: HTMLElement, attrs?: Object, refNode?: HTMLElement, pos?: String): HTMLElement;
         /**
          * Create an element, allowing for optional attribute decoration
          * and placement.
@@ -19068,7 +19069,7 @@ declare namespace dojo {
          * @param refNode               OptionalOptional reference node. Used by dojo.place to place the newly creatednode somewhere in the dom relative to refNode. Can be a DomNode referenceor String ID of a node.
          * @param pos               OptionalOptional positional reference. Defaults to "last" by way of dojo.place,though can be set to "first","after","before","last", "replace" or "only"to further control the placement of the new node relative to the refNode.'refNode' is required if a 'pos' is specified.
          */
-        create(tag: String, attrs: Object, refNode?: HTMLElement, pos?: String): any;
+        create(tag: String, attrs?: Object, refNode?: HTMLElement, pos?: String): HTMLElement;
         /**
          * Create an element, allowing for optional attribute decoration
          * and placement.
@@ -19087,7 +19088,7 @@ declare namespace dojo {
          * @param refNode               OptionalOptional reference node. Used by dojo.place to place the newly creatednode somewhere in the dom relative to refNode. Can be a DomNode referenceor String ID of a node.
          * @param pos               OptionalOptional positional reference. Defaults to "last" by way of dojo.place,though can be set to "first","after","before","last", "replace" or "only"to further control the placement of the new node relative to the refNode.'refNode' is required if a 'pos' is specified.
          */
-        create(tag: HTMLElement, attrs: Object, refNode?: String, pos?: String): any;
+        create(tag: HTMLElement, attrs?: Object, refNode?: String, pos?: String): HTMLElement;
         /**
          * Create an element, allowing for optional attribute decoration
          * and placement.
@@ -19106,7 +19107,7 @@ declare namespace dojo {
          * @param refNode               OptionalOptional reference node. Used by dojo.place to place the newly creatednode somewhere in the dom relative to refNode. Can be a DomNode referenceor String ID of a node.
          * @param pos               OptionalOptional positional reference. Defaults to "last" by way of dojo.place,though can be set to "first","after","before","last", "replace" or "only"to further control the placement of the new node relative to the refNode.'refNode' is required if a 'pos' is specified.
          */
-        create(tag: String, attrs: Object, refNode?: String, pos?: String): any;
+        create(tag: String, attrs?: Object, refNode?: String, pos?: String): HTMLElement;
         /**
          * Removes a node from its parent, clobbering it and all of its
          * children.
@@ -27096,7 +27097,7 @@ declare namespace dojo {
          * @param topic The name of the topic to publish to
          * @param event An event to distribute to the topic listeners
          */
-        publish(topic: String, event: Object): any;
+        publish(topic: String, ...data: any[]): any;
         /**
          * Subscribes to a topic on the pub/sub hub
          *
@@ -27134,20 +27135,25 @@ declare namespace dojo {
          *
          * @param doc The document to get the associated window for.
          */
-        get(doc: HTMLDocument): any;
+        get(doc: HTMLDocument): Window;
         /**
          * Returns the dimensions and scroll position of the viewable area of a browser window
          *
-         * @param doc               Optional
+         * @param doc Optional
          */
-        getBox(doc?: HTMLDocument): Object;
+        getBox(doc?: HTMLDocument): {
+            h: number
+            l: number
+            t: number
+            w: number
+        };
         /**
          * Scroll the passed node into view using minimal movement, if it is not already.
          *
          * @param node
-         * @param pos               Optional
+         * @param pos Optional
          */
-        scrollIntoView(node: HTMLElement, pos: Object): void;
+        scrollIntoView(node: HTMLElement, pos?: Object): void;
     }
     /**
      * Permalink: http://dojotoolkit.org/api/1.9/dojo/touch.html

--- a/dojo/dojo.d.ts
+++ b/dojo/dojo.d.ts
@@ -1783,7 +1783,13 @@ declare namespace dojo {
      * @param errback       OptionalCallback to be invoked when the promise is rejected.
      * @param progback       OptionalCallback to be invoked when the promise emits a progress update.
      */
-    interface when { <T, U>(value: T|dojo.promise.Promise<T>, callback: dojo.promise.Callback<T, U>, errback?: any, progback?: any): U|dojo.promise.Promise<U> }
+    interface when {
+		<T>(value: T): dojo.promise.Promise<T>
+		<T, U>(value: T, callback: (arg: T, ...args: any[]) => U): U
+		<T, U>(value: T, callback: (...args: any[]) => U): U
+		<T, U>(value: dojo.promise.Promise<T>, callback?: dojo.promise.Callback<T, U>, errback?: Function, progback?: Function): dojo.promise.Promise<U>
+		<T, U>(value: T, callback?: dojo.promise.Callback<T, U>, errback?: Function, progback?: Function): U
+	}
     /**
      * Permalink: http://dojotoolkit.org/api/1.9/dojo/DeferredList.html
      *
@@ -1833,7 +1839,7 @@ declare namespace dojo {
          * @param reason A message that may be sent to the deferred's canceler,explaining why it's being canceled.
          * @param strict               OptionalIf strict, will throw an error if the deferred has alreadybeen fulfilled and consequently cannot be canceled.
          */
-        cancel(reason: any, strict?: boolean): any;
+        cancel(reason?: any, strict?: boolean): any;
         /**
          * Checks whether the deferred has been canceled.
          *
@@ -1863,7 +1869,7 @@ declare namespace dojo {
          * @param update The progress update. Passed to progbacks.
          * @param strict               OptionalIf strict, will throw an error if the deferred has alreadybeen fulfilled and consequently no progress can be emitted.
          */
-        progress(update: any, strict?: boolean): dojo.promise.Promise<any>;
+        progress<T>(update?: any, strict?: boolean): dojo.promise.Promise<T>;
         /**
          * Reject the deferred.
          * Reject the deferred, putting it in an error state.
@@ -1871,7 +1877,7 @@ declare namespace dojo {
          * @param error The error result of the deferred. Passed to errbacks.
          * @param strict               OptionalIf strict, will throw an error if the deferred has alreadybeen fulfilled and consequently cannot be rejected.
          */
-        reject(error: any, strict?: boolean): any;
+        reject(error?: any, strict?: boolean): any;
         /**
          * Resolve the deferred.
          * Resolve the deferred, putting it in a success state.
@@ -1879,7 +1885,7 @@ declare namespace dojo {
          * @param value The result of the deferred. Passed to callbacks.
          * @param strict               OptionalIf strict, will throw an error if the deferred has alreadybeen fulfilled and consequently cannot be resolved.
          */
-        resolve(value: any, strict?: boolean): dojo.promise.Promise<any>;
+        resolve<T>(value?: T, strict?: boolean): dojo.promise.Promise<T>;
         /**
          * Add new callbacks to the deferred.
          * Add new callbacks to the deferred. Callbacks can be added
@@ -1889,7 +1895,7 @@ declare namespace dojo {
          * @param errback               OptionalCallback to be invoked when the promise is rejected.Receives the rejection error.
          * @param progback               OptionalCallback to be invoked when the promise emits a progressupdate. Receives the progress update.
          */
-        then(callback?: Function, errback?: Function, progback?: Function): dojo.promise.Promise<any>;
+        then<T>(callback?: Function, errback?: Function, progback?: Function): dojo.promise.Promise<T>;
         /**
          *
          */
@@ -5712,17 +5718,7 @@ declare namespace dojo {
              *
              * @param method The function to "wrap"
              */
-            partial(method: Function): any;
-            /**
-             * similar to hitch() except that the scope object is left to be
-             * whatever the execution context eventually becomes.
-             * Calling lang.partial is the functional equivalent of calling:
-             *
-             * lang.hitch(null, funcName, ...);
-             *
-             * @param method The function to "wrap"
-             */
-            partial(method: String): any;
+            partial(method: string | Function, ...args: any[]): Function;
             /**
              * Performs parameterized substitutions on a string. Throws an
              * exception if any parameter is unmatched.
@@ -5731,16 +5727,7 @@ declare namespace dojo {
              * @param map If an object, it is used as a dictionary to look up substitutions.If a function, it is called for every substitution with following parameters:a whole match, a name, an offset, and the whole templatestring (see https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/replacefor more details).
              * @param pattern               OptionalOptional regular expression objects that overrides the default pattern.Must be global and match one item. The default is: /{([^}]+)}/g,which matches patterns like that: "{xxx}", where "xxx" is any sequenceof characters, which doesn't include "}".
              */
-            replace(tmpl: String, map: Object, pattern?: RegExp): String;
-            /**
-             * Performs parameterized substitutions on a string. Throws an
-             * exception if any parameter is unmatched.
-             *
-             * @param tmpl String to be used as a template.
-             * @param map If an object, it is used as a dictionary to look up substitutions.If a function, it is called for every substitution with following parameters:a whole match, a name, an offset, and the whole templatestring (see https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/replacefor more details).
-             * @param pattern               OptionalOptional regular expression objects that overrides the default pattern.Must be global and match one item. The default is: /{([^}]+)}/g,which matches patterns like that: "{xxx}", where "xxx" is any sequenceof characters, which doesn't include "}".
-             */
-            replace(tmpl: String, map: Function, pattern?: RegExp): String;
+            replace(tmpl: string, map: Object | Function, pattern?: RegExp): string;
             /**
              * Set a property from a dot-separated string, such as "A.B.C"
              * Useful for longer api chains where you have to test each object in
@@ -5752,7 +5739,7 @@ declare namespace dojo {
              * @param value value or object to place at location given by name
              * @param context               OptionalOptional. Object to use as root of path. Defaults todojo.global.
              */
-            setObject(name: String, value: any, context?: Object): any;
+            setObject(name: string, value: any, context?: Object): any;
             /**
              * Trims whitespace from both sides of the string
              * This version of trim() was selected for inclusion into the base due
@@ -5764,7 +5751,7 @@ declare namespace dojo {
              *
              * @param str String to be trimmed
              */
-            trim(str: String): String;
+            trim(str: string): string;
         }
         /**
          * Permalink: http://dojotoolkit.org/api/1.9/dojo/_base/unload.html
@@ -20089,9 +20076,8 @@ declare namespace dojo {
          * @param str a string literal of a JSON item, for instance:'{ "foo": [ "bar", 1, { "baz": "thud" } ] }'
          * @param strict When set to true, this will ensure that only valid, secure JSON is ever parsed.Make sure this is set to true for untrusted content. Note that on browsers/engineswithout native JSON support, setting this to true will run slower.
          */
-        parse(str: any, strict: any): void;
+        parse(str: string, strict?: boolean): any;
         /**
-         * Returns a JSON serialization of an object.
          * Returns a JSON serialization of an object.
          * This function follows native JSON API
          * Note that this doesn't check for infinite recursion, so don't do that!
@@ -20100,7 +20086,8 @@ declare namespace dojo {
          * @param replacer A replacer function that is called for each value and can return a replacement
          * @param spacer A spacer string to be used for pretty printing of JSON
          */
-        stringify(value: any, replacer: any, spacer: any): void;
+        stringify(value: any, spacer?: string): string;
+        stringify(value: any, replacer?: Function, spacer?: string): string;
     }
     /**
      * Permalink: http://dojotoolkit.org/api/1.9/dojo/loadInit.html


### PR DESCRIPTION
I found more instances where the definitions do not match the actual API. Most of these changes are obvious, but changes to the `when` function took a bit more parsing of the documentation.

[http://dojotoolkit.org/reference-guide/1.10/dojo/when.html#dojo-when](http://dojotoolkit.org/reference-guide/1.10/dojo/when.html#dojo-when)
