### PR TITLE
[openlayers] Add FullScreen Options

### DIFF
--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -121,15 +121,15 @@ declare namespace olx {
         className?: string;
         /*** experimental Text label to use for the button. Default is ⤢ (NORTH EAST AND SOUTH WEST ARROW). Instead of text, also a Node (e.g. a span element) can be used.*/
         label?: string | Element;
-        /*** Text label to use for the button when full-screen is active. Default is × (a cross). Instead of text, also a Node (e.g. a span element) can be used.*/
+        /*** experimental Text label to use for the button when full-screen is active. Default is × (a cross). Instead of text, also a Node (e.g. a span element) can be used.*/
         labelActive?: string | Element;
-        /*** Text label to use for the button tip. Default is Toggle full-screen*/
+        /*** experimental Text label to use for the button tip. Default is Toggle full-screen*/
         tipLabel?: string;
-        /*** Full keyboard access.*/
+        /*** experimental Full keyboard access.*/
         keys?: boolean;
-        /*** Target.*/
+        /*** experimental Target.*/
         target?: Element;
-        /*** The element to be displayed fullscreen. When not provided, the element containing the map viewport will be displayed fullscreen.*/
+        /*** experimental The element to be displayed fullscreen. When not provided, the element containing the map viewport will be displayed fullscreen.*/
         source?: Element | string;
     }
     

--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -116,6 +116,23 @@ declare namespace olx {
         render?: Function;
     }
 
+    interface FullScreenOptions {
+        /*** experimental CSS class name. Default is ol-full-screen.*/
+        className?: string;
+        /*** experimental Text label to use for the button. Default is ⤢ (NORTH EAST AND SOUTH WEST ARROW). Instead of text, also a Node (e.g. a span element) can be used.*/
+        label?: string | Element;
+        /*** Text label to use for the button when full-screen is active. Default is × (a cross). Instead of text, also a Node (e.g. a span element) can be used.*/
+        labelActive?: string | Element;
+        /*** Text label to use for the button tip. Default is Toggle full-screen*/
+        tipLabel?: string;
+        /*** Full keyboard access.*/
+        keys?: boolean;
+        /*** Target.*/
+        target?: Element;
+        /*** The element to be displayed fullscreen. When not provided, the element containing the map viewport will be displayed fullscreen.*/
+        source?: Element | string;
+    }
+    
     interface AttributionOptions {
 
         /** HTML markup for this attribution. */
@@ -2908,6 +2925,7 @@ declare namespace ol {
         }
 
         class FullScreen extends Control {
+            constructor(options?: olx.FullScreenOptions);
         }
 
         class MousePosition extends Control {


### PR DESCRIPTION
case 2. Improvement to existing type definition `openlayers.d.ts`.
- documentation or source code reference which provides context for the suggested changes.  url http://openlayers.org/en/latest/apidoc/ol.control.FullScreen.html .

Implement FullScreenOptions.
