### PR TITLE
Add module declaration to crossfilter so that it can be explicitly im…

### DIFF
--- a/crossfilter/crossfilter.d.ts
+++ b/crossfilter/crossfilter.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for CrossFilter
 // Project: https://github.com/square/crossfilter
-// Definitions by: Schmulik Raskin <https://github.com/schmuli>
+// Definitions by: Schmulik Raskin <https://github.com/schmuli>, Izaak Baker <https://github.com/iebaker>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace CrossFilter {
@@ -111,3 +111,8 @@ declare namespace CrossFilter {
 }
 
 declare var crossfilter: CrossFilter.CrossFilterStatic;
+declare module "crossfilter" {
+    var crossfilter: CrossFilter.CrossFilterStatic;
+    export = crossfilter;    	
+}
+


### PR DESCRIPTION
Improvement to typings for [Crossfilter](http://square.github.io/crossfilter/). Existing type declaration file simply declared global `crossfilter` variable, instead of module. Added `"crossfilter"` module declaration so that crossfilter can be explicitly imported with e.g. `import * as Crossfilter from "crossfilter"` 

This improves legibility of modules dependent upon Crossfilter, and can fix some runtime bugs where the `crossfilter` object ends up not attached to the window when using bundlers (e.g. webpack).
