### PR TITLE
[chai] Add eq + equals to Deep assertion

### DIFF
--- a/chai/index.d.ts
+++ b/chai/index.d.ts
@@ -163,6 +163,8 @@ declare namespace Chai {
 
     interface Deep {
         equal: Equal;
+        equals: Equal;
+        eq: Equal;
         include: Include;
         property: Property;
         members: Members;


### PR DESCRIPTION
I'm adding this based on https://github.com/chaijs/chai/blob/master/lib/chai/core/assertions.js#L560-L563
