### PR TITLE
Add typings for murmurhash3js

### DIFF
--- a/murmurhash3js/murmurhash3js-tests.ts
+++ b/murmurhash3js/murmurhash3js-tests.ts
@@ -1,6 +1,6 @@
 /// <reference path="./murmurhash3js.d.ts"/>
 
-import murmurhash3js = require('murmurhash3js');
+import * as murmurhash3js from 'murmurhash3js';
 
 murmurhash3js.x86.hash32('string');
 murmurhash3js.x86.hash32('string with seed', 1337);

--- a/murmurhash3js/murmurhash3js-tests.ts
+++ b/murmurhash3js/murmurhash3js-tests.ts
@@ -1,0 +1,12 @@
+/// <reference path="./murmurhash3js.d.ts"/>
+
+import murmurhash3js = require('murmurhash3js');
+
+murmurhash3js.x86.hash32('string');
+murmurhash3js.x86.hash32('string with seed', 1337);
+
+murmurhash3js.x86.hash128('string');
+murmurhash3js.x86.hash128('string with seed', 1337);
+
+murmurhash3js.x64.hash128('string');
+murmurhash3js.x64.hash128('string with seed', 1337);

--- a/murmurhash3js/murmurhash3js.d.ts
+++ b/murmurhash3js/murmurhash3js.d.ts
@@ -12,4 +12,4 @@ declare module 'murmurhash3js' {
     export module x64 {
         function hash128(val: string, seed?: number): string;
     }
-} 
+}

--- a/murmurhash3js/murmurhash3js.d.ts
+++ b/murmurhash3js/murmurhash3js.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for murmurhash3js v3.0.1
+// Project: https://github.com/pid/murmurHash3js
+// Definitions by: Dave Lee <https://github.com/dlee-nvisia>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'murmurhash3js' {
+    export module x86 {
+        function hash32(val: string, seed?: number): string;
+        function hash128(val: string, seed?: number): string;
+    }
+    
+    export module x64 {
+        function hash128(val: string, seed?: number): string;
+    }
+} 


### PR DESCRIPTION
case 1. Add a new type definition.
- [X] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [X] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [X] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

It's a relatively simple library, located at [this github fork](https://github.com/pid/murmurHash3js) according to the [canonical npm page](https://www.npmjs.com/package/murmurhash3js)
