### PR TITLE
vue: fixed definition for activate() in ComponentOption

### DIFF
--- a/vue/vue-tests.ts
+++ b/vue/vue-tests.ts
@@ -88,6 +88,11 @@ namespace TestGlobalAPI {
     },
     init: function() {}
   });
+  Vue.component("component", {
+    activate: function(callback: Function) {
+      callback();
+    }
+  });
   var transition = Vue.transition("transition");
   Vue.transition("transition", transition);
   Vue.transition("transition", {

--- a/vue/vue.d.ts
+++ b/vue/vue.d.ts
@@ -96,7 +96,7 @@ declare namespace vuejs {
         detached?(): void;
         beforeDestroy?(): void;
         destroyed?(): void;
-        activate?(): void;
+        activate?(callback: Function): void;
         directives?: { [key: string]: (DirectiveOption | Function) };
         elementDirectives?: { [key: string]: (DirectiveOption | Function) };
         filters?: { [key: string]: (Function | FilterOption) };


### PR DESCRIPTION
the callback was missing in the activate function

The activate function was added in vue 1.0.17 the callback was always part of the api

Documentation of activate:
https://vuejs.org/guide/components.html#activate-Hook
