### PR TITLE
restify: client.get() and similar, path can be hash of options

### DIFF
--- a/restify/restify.d.ts
+++ b/restify/restify.d.ts
@@ -470,24 +470,24 @@ declare module "restify" {
   }
 
   interface Client {
-    get: (opts: any, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
-    head: (opts: any, callback?: (err: any, req: Request, res: Response) => any) => any;
-    post: (opts: any, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
-    put: (opts: any, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
-    patch: (opts: any, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
-    del: (opts: any, callback?: (err: any, req: Request, res: Response) => any) => any;
+    get: (opts: string | { path?: string; [name: string]: any }, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
+    head: (opts: string | { path?: string; [name: string]: any }, callback?: (err: any, req: Request, res: Response) => any) => any;
+    post: (opts: string | { path?: string; [name: string]: any }, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
+    put: (opts: string | { path?: string; [name: string]: any }, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
+    patch: (opts: string | { path?: string; [name: string]: any }, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
+    del: (opts: string | { path?: string; [name: string]: any }, callback?: (err: any, req: Request, res: Response) => any) => any;
     basicAuth: (username: string, password: string) => any;
   }
 
   interface HttpClient extends Client {
-    get: (path?: any, callback?: Function) => any;
-    head: (path?:any, callback?: Function) => any;
-    post: (opts?: any, callback?: Function) => any;
-    put: (opts?: any, callback?: Function) => any;
-    patch: (opts?: any, callback?: Function) => any;
-    del: (opts?: any, callback?: Function) => any;
+    get: (opts?: string | { path?: string; [name: string]: any }, callback?: Function) => any;
+    head: (opts?: string | { path?: string; [name: string]: any }, callback?: Function) => any;
+    post: (opts?: string | { path?: string; [name: string]: any }, callback?: Function) => any;
+    put: (opts?: string | { path?: string; [name: string]: any }, callback?: Function) => any;
+    patch: (opts?: string | { path?: string; [name: string]: any }, callback?: Function) => any;
+    del: (opts?: string | { path?: string; [name: string]: any }, callback?: Function) => any;
   }
-
+ 
   interface ThrottleOptions {
     burst?: number;
     rate?: number;

--- a/restify/restify.d.ts
+++ b/restify/restify.d.ts
@@ -470,12 +470,12 @@ declare module "restify" {
   }
 
   interface Client {
-    get: (path: string, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
-    head: (path: string, callback?: (err: any, req: Request, res: Response) => any) => any;
-    post: (path: string, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
-    put: (path: string, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
-    patch: (path: string, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
-    del: (path: string, callback?: (err: any, req: Request, res: Response) => any) => any;
+    get: (opts: any, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
+    head: (opts: any, callback?: (err: any, req: Request, res: Response) => any) => any;
+    post: (opts: any, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
+    put: (opts: any, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
+    patch: (opts: any, object: any, callback?: (err: any, req: Request, res: Response, obj: any) => any) => any;
+    del: (opts: any, callback?: (err: any, req: Request, res: Response) => any) => any;
     basicAuth: (username: string, password: string) => any;
   }
 


### PR DESCRIPTION
Improvement to existing type definition.

As per http://restify.com/#client-api it states:

> Note that all further documentation refers to the "short-hand"
> form of methods like get/put/del which take a string path. You
> can also pass in an object to any of those methods with extra
> params (notably headers):

So the path can be either a string or a hash of options.
