### PR TITLE
[types-2.0] d3-zoom and d3-force JSDoc comments

### DIFF
--- a/d3-force/index.d.ts
+++ b/d3-force/index.d.ts
@@ -8,154 +8,1004 @@
 // Force Simulation
 // -----------------------------------------------------------------------
 
-// TODO: Review below: fx and fy should be optional as a matter of principle. The other properties, are optional prior to initialization, but once the
-// the nodes array is passed into the simulation, will be initialized.
+/**
+ * The base data structure for the datum of a Simulation Node.
+ * The optional properties contained in this data structure are internally assigned
+ * by the Simulation upon (re-)initialization.
+ *
+ * When defining a data type to use for node data, it should be an extension of this interface
+ * and respect the already "earmarked" properties used by the simulation.
+ *
+ * IMPORTANT: Prior to initialization, the following properties are optional: index, x, y, vx, and vy.
+ * After initialization they will be defined. The optional properties fx and fy are ONLY defined,
+ * if the node's position has been fixed.
+ */
 export interface SimulationNodeDatum {
-    // NB: index is assigned internally by simulation, once initialized it is defined
+    /**
+     * Node’s zero-based index into nodes array. This property is set during the initialization process of a simulation.
+     */
     index?: number;
+    /**
+     * Node’s current x-position
+     */
     x?: number;
+    /**
+     * Node’s current y-position
+     */
     y?: number;
+    /**
+     * Node’s current x-velocity
+     */
     vx?: number;
+    /**
+     * Node’s current y-velocity
+     */
     vy?: number;
-    fx?: number;
-    fy?: number;
+    /**
+     * Node’s fixed x-position (if position was fixed)
+     */
+    fx?: number | null | undefined;
+    /**
+     * Node’s fixed y-position (if position was fixed)
+     */
+    fy?: number | null | undefined;
 }
 
+/**
+ * The base data structure for the datum of a Simulation Link, as used by ForceLink.
+ * The optional properties contained in this data structure are internally assigned
+ * by when initializating with ForceLink.links(...)
+ *
+ *
+ * IMPORTANT: The source and target properties may be internally mutated in type during the
+ * ForceLink initialization process (possibly being changed from a node index in the nodes array,
+ * or a node id string to the simulation node object which was mapped in using the current
+ * ForceLink.id(...) accessor function.)
+ */
 export interface SimulationLinkDatum<NodeDatum extends SimulationNodeDatum> {
-    // TODO: Strictly speaking, the string or number typing of source and target is only used when (re)initializing links
-    // Once initialized, links' source and target fields will be of type NodeDatum
+    /**
+     * Link’s source node.
+     * For convenience, a link’s source property may be initialized using numeric or string identifiers rather than object references; see link.id.
+     * After initialization, the source property represents the source node object.
+     */
     source: NodeDatum | string | number;
+    /**
+     * Link’s source link
+     * For convenience, a link’s target property may be initialized using numeric or string identifiers rather than object references; see link.id.
+     * After initialization, the target property represents the source node object.
+     */
     target: NodeDatum | string | number;
-    // NB: index is assigned internally by force, once initialized it is defined
+    /**
+     * The zero-based index into the links array. Internally generated when calling ForceLink.links(...)
+     */
     index?: number;
 }
 
-export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum>> {
+/**
+ * A Force Simulation
+ *
+ * The first generic refers to the type of the datum associated with a node in the simulation.
+ * The second generic refers to the type of the datum associated with a link in the simulation, if applicable.
+ *
+ */
+export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum> | undefined> {
+    /**
+     * Restart the simulation’s internal timer and return the simulation.
+     * In conjunction with simulation.alphaTarget or simulation.alpha, this method can be used to “reheat” the simulation during interaction,
+     * such as when dragging a node, or to resume the simulation after temporarily pausing it with simulation.stop.
+     */
     restart(): this;
+
+    /**
+     * Stop the simulation’s internal timer, if it is running, and return the simulation. If the timer is already stopped, this method does nothing.
+     * This method is useful for running the simulation manually; see simulation.tick.
+     */
     stop(): this;
+
+    /**
+     * Increments the current alpha by (alphaTarget - alpha) × alphaDecay; then invokes each registered force, passing the new alpha;
+     * then decrements each node’s velocity by velocity × velocityDecay; lastly increments each node’s position by velocity.
+     * This method does not dispatch events; events are only dispatched by the internal timer when the simulation is started automatically upon
+     * creation or by calling simulation.restart. The natural number of ticks when the simulation is started is
+     * ⌈log(alphaMin) / log(1 - alphaDecay)⌉; by default, this is 300.
+     */
     tick(): void;
+
+    /**
+     * Returns the simulation’s array of nodes as specified to the constructor.
+     */
     nodes(): Array<NodeDatum>;
+    /**
+     * Set the simulation’s nodes to the specified array of objects, initialize their positions and velocities if necessary,
+     * and then re-initialize any bound forces; Returns the simulation.
+     *
+     * Each node must be an object. The following properties are assigned by the simulation:
+     * - index (the node’s zero-based index into nodes)
+     * - x (the node’s current x-position)
+     * - y (the node’s current y-position)
+     * - vx (the node’s current x-velocity)
+     * - vy (the node’s current y-velocity)
+     *
+     * The position ⟨x,y⟩ and velocity ⟨vx,vy⟩ may be subsequently modified by forces and by the simulation.
+     * If either vx or vy is NaN, the velocity is initialized to ⟨0,0⟩. If either x or y is NaN, the position is initialized in a phyllotaxis arrangement,
+     * so chosen to ensure a deterministic, uniform distribution around the origin.
+     *
+     * To fix a node in a given position, you may specify two additional properties:
+     * - fx (the node’s fixed x-position)
+     * - fy (the node’s fixed y-position)
+     *
+     * At the end of each tick, after the application of any forces, a node with a defined node.fx has node.x reset to this value and node.vx set to zero;
+     * likewise, a node with a defined node.fy has node.y reset to this value and node.vy set to zero.
+     * To unfix a node that was previously fixed, set node.fx and node.fy to null, or delete these properties.
+     *
+     * If the specified array of nodes is modified, such as when nodes are added to or removed from the simulation,
+     * this method must be called again with the new (or changed) array to notify the simulation and bound forces of the change;
+     * the simulation does not make a defensive copy of the specified array.
+     */
     nodes(nodesData: Array<NodeDatum>): this;
+
+    /**
+     * Return the current alpha of the simulation, which defaults to 1.
+     */
     alpha(): number;
+    /**
+     * Set the current alpha to the specified number in the range [0,1] and return this simulation.
+     * The default is 1.
+     *
+     * @param alpha Current alpha of simulation.
+     */
     alpha(alpha: number): this;
+
+    /**
+     * Return the current minimum alpha value, which defaults to 0.001.
+     */
     alphaMin(): number;
+    /**
+     * Set the minimum alpha to the specified number in the range [0,1] and return this simulation.
+     * The default is 0.001. The simulation’s internal timer stops when the current alpha is less than the minimum alpha.
+     * The default alpha decay rate of ~0.0228 corresponds to 300 iterations.
+     *
+     * @param min Minimum alpha of simulation.
+     */
     alphaMin(min: number): this;
+
+    /**
+     * Return the current alpha decay rate, which defaults to 0.0228… = 1 - pow(0.001, 1 / 300) where 0.001 is the default minimum alpha.
+     */
     alphaDecay(): number;
+    /**
+     * Set the alpha decay rate to the specified number in the range [0,1] and return this simulation.
+     * The default is 0.0228… = 1 - pow(0.001, 1 / 300) where 0.001 is the default minimum alpha.
+     *
+     * The alpha decay rate determines how quickly the current alpha interpolates towards the desired target alpha;
+     * since the default target alpha is zero, by default this controls how quickly the simulation cools.
+     * Higher decay rates cause the simulation to stabilize more quickly, but risk getting stuck in a local minimum;
+     * lower values cause the simulation to take longer to run, but typically converge on a better layout.
+     * To have the simulation run forever at the current alpha, set the decay rate to zero;
+     * alternatively, set a target alpha greater than the minimum alpha.
+     *
+     * @param decay Alpha decay rate.
+     */
     alphaDecay(decay: number): this;
+
+    /**
+     * Returns the current target alpha value, which defaults to 0.
+     */
     alphaTarget(): number;
+    /**
+     * Set the current target alpha to the specified number in the range [0,1] and return this simulation.
+     * The default is 0.
+     *
+     * @param target Alpha target value.
+     */
     alphaTarget(target: number): this;
+
+    /**
+     * Return the current target alpha value, which defaults to 0.4.
+     */
     velocityDecay(): number;
+    /**
+     * Set the velocity decay factor to the specified number in the range [0,1] and return this simulation.
+     * The default is 0.4.
+     *
+     * The decay factor is akin to atmospheric friction; after the application of any forces during a tick,
+     * each node’s velocity is multiplied by 1 - decay. As with lowering the alpha decay rate,
+     * less velocity decay may converge on a better solution, but risks numerical instabilities and oscillation.
+     *
+     * @param decay Velocity Decay.
+     */
     velocityDecay(decay: number): this;
-    force<F extends Force<NodeDatum, LinkDatum>>(name: string): F; // force names are arbitrary, so return type inference is not possible
+
+    /**
+     * Return the force with the specified name, or undefined if there is no such force.
+     * (By default, new simulations have no forces.)
+     *
+     * Given that it is in general not known, what type of force has been registered under
+     * a specified name, use the generic to cast the result to the appropriate type, if known.
+     *
+     * @param name Name of the registered force.
+     */
+    force<F extends Force<NodeDatum, LinkDatum>>(name: string): F | undefined;
+    /**
+     * Remove a previously registered force.
+     *
+     * @param name Name of the registered force.
+     * @param force Use null to remove force.
+     */
     force(name: string, force: null): this;
+    /**
+     * Assign the force for the specified name and return this simulation.
+     * (By default, new simulations have no forces.)
+     *
+     * @param name Name to register the force under.
+     * @param force A force to use with the simulation.
+     */
     force(name: string, force: Force<NodeDatum, LinkDatum>): this;
+
+    /**
+     * Return the node closest to the position ⟨x,y⟩ with the given search radius.
+     * If radius is not specified, it defaults to infinity.
+     * If there is no node within the search area, returns undefined.
+     *
+     * @param x x-coordinate
+     * @param y y-coordinate
+     * @param radius Optional search radius. Defaults to infinity.
+     */
     find(x: number, y: number, radius?: number): NodeDatum | undefined;
+
+    /**
+     * Return the first currently-assigned listener matching the specified typenames, if any.
+     *
+     * @param typenames The typenames is a string containing one or more typename separated by whitespace. Each typename is a type,
+     * optionally followed by a period (.) and a name, such as "tick.foo" and "tick.bar"; the name allows multiple listeners to be registered for the same type.
+     * The type must be one of the following: "tick" (after each tick of the simulation’s internal timer) or
+     * "end" (after the simulation’s timer stops when alpha < alphaMin).
+     */
     on(typenames: 'tick' | 'end' | string): (this: Simulation<NodeDatum, LinkDatum>) => void;
+    /**
+     * Remove the current event listeners for the specified typenames, if any, return the simulation.
+     *
+     * @param typenames The typenames is a string containing one or more typename separated by whitespace. Each typename is a type,
+     * optionally followed by a period (.) and a name, such as "tick.foo" and "tick.bar"; the name allows multiple listeners to be registered for the same type.
+     * The type must be one of the following: "tick" (after each tick of the simulation’s internal timer) or
+     * "end" (after the simulation’s timer stops when alpha < alphaMin).
+     * @param listener Use null to remove the listener.
+     */
     on(typenames: 'tick' | 'end' | string, listener: null): this;
+    /**
+     * Set the event listener for the specified typenames and return this simulation.
+     * If an event listener was already registered for the same type and name,
+     * the existing listener is removed before the new listener is added.
+     * When a specified event is dispatched, each listener will be invoked with the this context as the simulation.
+     *
+     * The type must be one of the following:
+     * - tick [after each tick of the simulation’s internal timer]
+     * - end [after the simulation’s timer stops when alpha < alphaMin]
+     *
+     * Note that tick events are not dispatched when simulation.tick is called manually;
+     * events are only dispatched by the internal timer and are intended for interactive rendering of the simulation.
+     * To affect the simulation, register forces instead of modifying nodes’ positions or velocities inside a tick event listener.
+     *
+     * @param typenames The typenames is a string containing one or more typename separated by whitespace. Each typename is a type,
+     * optionally followed by a period (.) and a name, such as "tick.foo" and "tick.bar"; the name allows multiple listeners to be registered for the same type.
+     * The type must be one of the following: "tick" (after each tick of the simulation’s internal timer) or
+     * "end" (after the simulation’s timer stops when alpha < alphaMin).
+     * @param listener An event listener function which is invoked with the this context of the simulation.
+     */
     on(typenames: 'tick' | 'end' | string, listener: (this: this) => void): this;
 }
 
+/**
+ * Create a new simulation with the specified array of nodes and no forces.
+ * If nodes is not specified, it defaults to the empty array.
+ * The simulator starts automatically; use simulation.on to listen for tick events as the simulation runs.
+ * If you wish to run the simulation manually instead, call simulation.stop, and then call simulation.tick as desired.
+ *
+ * Use this signature, when creating a simulation WITHOUT link force(s).
+ *
+ * The generic refers to the type of the data for a node.
+ *
+ * @param nodesData Optional array of nodes data, defaults to empty array.
+ */
 export function forceSimulation<NodeDatum extends SimulationNodeDatum>(nodesData?: Array<NodeDatum>): Simulation<NodeDatum, undefined>;
+/**
+ * Create a new simulation with the specified array of nodes and no forces.
+ * If nodes is not specified, it defaults to the empty array.
+ * The simulator starts automatically; use simulation.on to listen for tick events as the simulation runs.
+ * If you wish to run the simulation manually instead, call simulation.stop, and then call simulation.tick as desired.
+ *
+ * Use this signature, when creating a simulation WITH link force(s).
+ *
+ * The first generic refers to the type of data for a node.
+ * The second generic refers to the type of data for a link.
+ *
+ * @param nodesData Optional array of nodes data, defaults to empty array.
+ */
 export function forceSimulation<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum>>(nodesData?: Array<NodeDatum>): Simulation<NodeDatum, LinkDatum>;
 
 // ----------------------------------------------------------------------
 // Forces
 // ----------------------------------------------------------------------
 
-
+/**
+ * A force is simply a function that modifies nodes’ positions or velocities; in this context, a force can apply a classical physical force such as electrical charge or gravity,
+ * or it can resolve a geometric constraint, such as keeping nodes within a bounding box or keeping linked nodes a fixed distance apart.
+ *
+ * Forces typically read the node’s current position ⟨x,y⟩ and then add to (or subtract from) the node’s velocity ⟨vx,vy⟩.
+ * However, forces may also “peek ahead” to the anticipated next position of the node, ⟨x + vx,y + vy⟩; this is necessary for resolving geometric constraints through iterative relaxation.
+ * Forces may also modify the position directly, which is sometimes useful to avoid adding energy to the simulation, such as when recentering the simulation in the viewport.
+ *
+ * Forces may optionally implement force.initialize to receive the simulation’s array of nodes.
+ */
 export interface Force<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum>> {
+    /**
+     * Apply this force, optionally observing the specified alpha.
+     * Typically, the force is applied to the array of nodes previously passed to force.initialize,
+     * however, some forces may apply to a subset of nodes, or behave differently.
+     * For example, d3.forceLink applies to the source and target of each link.
+     */
     (alpha: number): void;
+    /**
+     * Assign the array of nodes to this force. This method is called when a force is bound to a simulation via simulation.force
+     * and when the simulation’s nodes change via simulation.nodes.
+     *
+     * A force may perform necessary work during initialization, such as evaluating per-node parameters, to avoid repeatedly performing work during each application of the force.
+     */
     initialize?(nodes: Array<NodeDatum>): void;
 }
 
 
 // Centering ------------------------------------------------------------
 
+/**
+ * The centering force translates nodes uniformly so that the mean position of all nodes
+ * (the center of mass if all nodes have equal weight) is at the given position ⟨x,y⟩.
+ * This force modifies the positions of nodes on each application; it does not modify velocities,
+ * as doing so would typically cause the nodes to overshoot and oscillate around the desired center.
+ * This force helps keeps nodes in the center of the viewport, and unlike the positioning force,
+ * it does not distort their relative positions.
+ *
+ * The generic refers to the type of data for a node.
+ */
 export interface ForceCenter<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
+    /**
+     * Return the current x-coordinate of the centering position, which defaults to zero.
+     */
     x(): number;
+    /**
+     * Set the x-coordinate of the centering position.
+     *
+     * @param x x-coordinate.
+     */
     x(x: number): this;
+    /**
+     * Return the current y-coordinate of the centering position, which defaults to zero.
+     */
     y(): number;
+    /**
+     * Set the y-coordinate of the centering position.
+     *
+     * @param y y-coordinate.
+     */
     y(y: number): this;
 }
 
+/**
+ * Create a new centering force with the specified x- and y- coordinates.
+ * If x and y are not specified, they default to ⟨0,0⟩.
+ *
+ * The centering force translates nodes uniformly so that the mean position of all nodes
+ * (the center of mass if all nodes have equal weight) is at the given position ⟨x,y⟩.
+ * This force modifies the positions of nodes on each application; it does not modify velocities,
+ * as doing so would typically cause the nodes to overshoot and oscillate around the desired center.
+ * This force helps keeps nodes in the center of the viewport, and unlike the positioning force,
+ * it does not distort their relative positions.
+ *
+ * The generic refers to the type of data for a node.
+ *
+ * @param x An optional x-coordinate for the centering position, defaults to 0.
+ * @param y An optional y-coordinate for the centering position, defaults to 0.
+ */
 export function forceCenter<NodeDatum extends SimulationNodeDatum>(x?: number, y?: number): ForceCenter<NodeDatum>;
 
 // Collision ------------------------------------------------------------
 
+/**
+ * The collision force treats nodes as circles with a given radius, rather than points, and prevents nodes from overlapping.
+ * More formally, two nodes a and b are separated so that the distance between a and b is at least radius(a) + radius(b).
+ * To reduce jitter, this is by default a “soft” constraint with a configurable strength and iteration count.
+ *
+ * The generic refers to the type of data for a node.
+ */
 export interface ForceCollide<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
+    /**
+     * Returns the current radius accessor function.
+     */
     radius(): (node: NodeDatum, i: number, nodes: Array<NodeDatum>) => number;
+    /**
+     * Set the radius used in collision detection to a constant number for each node.
+     *
+     * The constant is internally wrapped into radius accessor function.
+     *
+     * The radius accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The resulting number is then stored internally, such that the radius of each node is only recomputed
+     * when the force is initialized or when this method is called with a new radius, and not on every application of the force.
+     *
+     * @param radius A constant radius for each node.
+     */
     radius(radius: number): this;
+    /**
+     * Set the radius accessor function determining the radius for each node in collision detection.
+     *
+     * The radius accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The resulting number is then stored internally, such that the radius of each node is only recomputed
+     * when the force is initialized or when this method is called with a new radius, and not on every application of the force.
+     *
+     * @param radius A radius accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The function returns a radius.
+     */
     radius(radius: (node: NodeDatum, i: number, nodes: Array<NodeDatum>) => number): this;
+
+    /**
+     * Return the current strength, which defaults to 0.7.
+     */
     strength(): number;
+    /**
+     * Set the force strength to the specified number in the range [0,1] and return this force.
+     * The default strength is 0.7.
+     *
+     * Overlapping nodes are resolved through iterative relaxation.
+     * For each node, the other nodes that are anticipated to overlap at the next tick (using the anticipated positions ⟨x + vx,y + vy⟩) are determined;
+     * the node’s velocity is then modified to push the node out of each overlapping node.
+     * The change in velocity is dampened by the force’s strength such that the resolution of simultaneous overlaps can be blended together to find a stable solution.
+     *
+     * @param strength Strength.
+     */
     strength(strength: number): this;
+
+    /**
+     * Return the current iteration count which defaults to 1.
+     */
     iterations(): number;
+    /**
+     * Sets the number of iterations per application to the specified number and return this force.
+     *
+     * Increasing the number of iterations greatly increases the rigidity of the constraint and avoids partial overlap of nodes,
+     * but also increases the runtime cost to evaluate the force.
+     *
+     * @param iterations Number of iterations.
+     */
     iterations(iterations: number): this;
 }
 
+/**
+ * Creates a new circle collision force with the default radius one for all nodes.
+ *
+ * The collision force treats nodes as circles with a given radius, rather than points, and prevents nodes from overlapping.
+ * More formally, two nodes a and b are separated so that the distance between a and b is at least radius(a) + radius(b).
+ * To reduce jitter, this is by default a “soft” constraint with a configurable strength and iteration count.
+ *
+ * The generic refers to the type of data for a node.
+ */
 export function forceCollide<NodeDatum extends SimulationNodeDatum>(): ForceCollide<NodeDatum>;
+/**
+ * Create a new circle collision force with the specified constant radius for all nodes.
+ *
+ * The collision force treats nodes as circles with a given radius, rather than points, and prevents nodes from overlapping.
+ * More formally, two nodes a and b are separated so that the distance between a and b is at least radius(a) + radius(b).
+ * To reduce jitter, this is by default a “soft” constraint with a configurable strength and iteration count.
+ *
+ * The generic refers to the type of data for a node.
+ *
+ * @param radius A constant radius for each node.
+ */
 export function forceCollide<NodeDatum extends SimulationNodeDatum>(radius: number): ForceCollide<NodeDatum>;
+/**
+ * Creates a new circle collision force with the specified radius accessor function.
+ *
+ * The collision force treats nodes as circles with a given radius, rather than points, and prevents nodes from overlapping.
+ * More formally, two nodes a and b are separated so that the distance between a and b is at least radius(a) + radius(b).
+ * To reduce jitter, this is by default a “soft” constraint with a configurable strength and iteration count.
+ *
+ * The radius accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+ * The resulting number is then stored internally, such that the radius of each node is only recomputed
+ * when the force is initialized or when this method is called with a new radius, and not on every application of the force.
+ *
+ * @param radius A radius accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
+ * The function returns a radius.
+ */
 export function forceCollide<NodeDatum extends SimulationNodeDatum>(radius: (node: NodeDatum, i: number, nodes: Array<NodeDatum>) => number): ForceCollide<NodeDatum>;
 
 // Link ----------------------------------------------------------------
 
+/**
+ * The link force pushes linked nodes together or apart according to the desired link distance.
+ * The strength of the force is proportional to the difference between the linked nodes’ distance and the target distance, similar to a spring force.
+ *
+ * The first generic refers to the type of data for a node.
+ * The second generic refers to the type of data for a link.
+ */
 export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum>> extends Force<NodeDatum, LinkDatum> {
+    /**
+     * Return the current array of links, which defaults to the empty array.
+     *
+     */
     links(): Array<LinkDatum>;
+    /**
+     * Set the array of links associated with this force, recompute the distance and strength parameters for each link, and return this force.
+     *
+     * Each link is an object with the following properties:
+     * * source - the link’s source node; see simulation.nodes
+     * * target - the link’s target node; see simulation.nodes
+     * * index - the zero-based index into links, assigned by this method
+     *
+     * For convenience, a link’s source and target properties may be initialized using numeric or string identifiers rather than object references; see link.id.
+     * If the specified array of links is modified, such as when links are added to or removed from the simulation,
+     * this method must be called again with the new (or changed) array to notify the force of the change;
+     * the force does not make a defensive copy of the specified array.
+     *
+     * @param links An array of link data.
+     */
     links(links: Array<LinkDatum>): this;
+
+    /**
+     * Return the current node id accessor, which defaults to the numeric index of the node.
+     */
     id(): (node: NodeDatum, i: number, nodesData: Array<NodeDatum>) => (string | number);
+    /**
+     * Set the node id accessor to the specified function and return this force.
+     *
+     * The default id accessor allows each link’s source and target to be specified as a zero-based index
+     * into the nodes array.
+     *
+     * The id accessor is invoked for each node whenever the force is initialized,
+     * as when the nodes or links change, being passed the node and its zero-based index.
+     *
+     * @param id A node id accessor function which is invoked for each node in the simulation,
+     * being passed the node and its zero-based index. It returns a string to represent the node id which can be used
+     * for matching link source and link target strings during the ForceLink initialization.
+     */
     id(id: (node: NodeDatum, i: number, nodesData: Array<NodeDatum>) => string): this;
+
+    /**
+     * Return the current distance accessor, which defaults to implying a default distance of 30.
+     */
     distance(): (link: LinkDatum, i: number, links: Array<LinkDatum>) => number;
+    /**
+     * Set the distance accessor to use the specified constant number for all links,
+     * re-evaluates the distance accessor for each link, and returns this force.
+     *
+     * The distance accessor is invoked for each link, being passed the link and its zero-based index.
+     * The resulting number is then stored internally, such that the distance of each link is only recomputed when the force is initialized or
+     * when this method is called with a new distance, and not on every application of the force.
+     *
+     * @param distance The constant distance to be used for all links.
+     */
     distance(distance: number): this;
+    /**
+     * Set the distance accessor to use the specified function,
+     * re-evaluates the distance accessor for each link, and returns this force.
+     *
+     * The distance accessor is invoked for each link, being passed the link and its zero-based index.
+     * The resulting number is then stored internally, such that the distance of each link is only recomputed when the force is initialized or
+     * when this method is called with a new distance, and not on every application of the force.
+     *
+     * @param distance A distance accessor function which is invoked for each link being passed the link,
+     * its zero-based index and the entire array of links. It returns the distance.
+     */
     distance(distance: (link: LinkDatum, i: number, links: Array<LinkDatum>) => number): this;
+
+    /**
+     * Return the current strength accessor.
+     * For details regarding the default behavior see: {@link https://github.com/d3/d3-force#link_strength}
+     */
     strength(): (link: LinkDatum, i: number, links: Array<LinkDatum>) => number;
+    /**
+     * Set the strenght accessor to use the specified constant number for all links,
+     * re-evaluates the strength accessor for each link, and returns this force.
+     *
+     * The strength accessor is invoked for each link, being passed the link and its zero-based index.
+     * The resulting number is then stored internally, such that the strength of each link is only recomputed
+     * when the force is initialized or when this method is called with a new strength, and not on every application of the force.
+     *
+     * @param strength The constant strength to be used for all links.
+     */
     strength(strength: number): this;
+    /**
+     * Set the strenght accessor to use the specified function,
+     * re-evaluates the strength accessor for each link, and returns this force.
+     *
+     * The strength accessor is invoked for each link, being passed the link and its zero-based index.
+     * The resulting number is then stored internally, such that the strength of each link is only recomputed
+     * when the force is initialized or when this method is called with a new strength, and not on every application of the force.
+     *
+     * @param strength A distance accessor function which is invoked for each link being passed the link,
+     * its zero-based index and the entire array of links. It returns the strength.
+     */
     strength(strength: (link: LinkDatum, i: number, links: Array<LinkDatum>) => number): this;
+
+    /**
+     * Return the current iteration count which defaults to 1.
+     */
     iterations(): number;
+    /**
+     * Sets the number of iterations per application to the specified number and return this force.
+     *
+     * Increasing the number of iterations greatly increases the rigidity of the constraint and is useful for complex structures such as lattices,
+     * but also increases the runtime cost to evaluate the force.
+     *
+     * @param iterations Number of iterations.
+     */
     iterations(iterations: number): this;
+
 }
 
+/**
+ * Creates a new link force with the defaulting links to an empty array.
+ *
+ * The link force pushes linked nodes together or apart according to the desired link distance.
+ * The strength of the force is proportional to the difference between the linked nodes’ distance and the target distance, similar to a spring force.
+ *
+ * The first generic refers to the type of data for a node.
+ * The second generic refers to the type of data for a link.
+ */
 export function forceLink<NodeDatum extends SimulationNodeDatum, LinksDatum extends SimulationLinkDatum<NodeDatum>>(): ForceLink<NodeDatum, LinksDatum>;
+/**
+ * Creates a new link force with the specified links array.
+ *
+ * The link force pushes linked nodes together or apart according to the desired link distance.
+ * The strength of the force is proportional to the difference between the linked nodes’ distance and the target distance, similar to a spring force.
+ *
+ * The first generic refers to the type of data for a node.
+ * The second generic refers to the type of data for a link.
+ */
 export function forceLink<NodeDatum extends SimulationNodeDatum, LinksDatum extends SimulationLinkDatum<NodeDatum>>(links: Array<LinksDatum>): ForceLink<NodeDatum, LinksDatum>;
 
 // Many Body ----------------------------------------------------------------
 
+/**
+ * The many-body (or n-body) force applies mutually amongst all nodes. It can be used to simulate gravity (attraction) if the strength is positive,
+ * or electrostatic charge (repulsion) if the strength is negative. This implementation uses quadtrees and the Barnes–Hut approximation to greatly
+ * improve performance; the accuracy can be customized using the theta parameter.
+ *
+ * Unlike links, which only affect two linked nodes, the charge force is global: every node affects every other node, even if they are on disconnected subgraphs.
+ *
+ * The generic refers to the type of data for a node.
+ */
 export interface ForceManyBody<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
+    /**
+     * Return the current strength accessor.
+     *
+     * For details regarding the default behavior see: {@link https://github.com/d3/d3-force#manyBody_strength}
+     */
     strength(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
+    /**
+     * Set the strength accessor to the specified constant strength for all nodes, re-evaluates the strength accessor for each node, and
+     * returns this force.
+     *
+     * A positive value causes nodes to attract each other, similar to gravity, while a negative value causes nodes to repel each other,
+     * similar to electrostatic charge.
+     *
+     * The default represents a constant value of -30.
+     *
+     * The strength accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The resulting number is then stored internally, such that the strength of each node is only recomputed when the force is initialized or
+     * when this method is called with a new strength, and not on every application of the force.
+     *
+     * @param strength The constant strength to be used for all nodes.
+     */
     strength(strength: number): this;
+    /**
+     * Set the strength accessor to the specified function, re-evaluates the strength accessor for each node, and
+     * returns this force.
+     *
+     * A positive value causes nodes to attract each other, similar to gravity, while a negative value causes nodes to repel each other,
+     * similar to electrostatic charge.
+     *
+     * The default represents a constant value of -30.
+     *
+     * The strength accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The resulting number is then stored internally, such that the strength of each node is only recomputed when the force is initialized or
+     * when this method is called with a new strength, and not on every application of the force.
+     *
+     * @param strength A strength accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The function returns the strength.
+     */
     strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
+
+    /**
+     * Return the current value of the Barnes–Hut approximation criterion , which defaults to 0.9
+     */
     theta(): number;
+    /**
+     * Set the Barnes–Hut approximation criterion to the specified number and returns this force.
+     *
+     * To accelerate computation, this force implements the Barnes–Hut approximation which takes O(n log n) per application
+     * where n is the number of nodes. For each application, a quadtree stores the current node positions;
+     * then for each node, the combined force of all other nodes on the given node is computed.
+     * For a cluster of nodes that is far away, the charge force can be approximated by treating the cluster as a single, larger node.
+     * The theta parameter determines the accuracy of the approximation:
+     * if the ratio w / l of the width w of the quadtree cell to the distance l from the node to the cell’s center of mass is less than theta,
+     * all nodes in the given cell are treated as a single node rather than individually.
+     *
+     * The default value is 0.9.
+     *
+     * @param theta Value for the theta parameter.
+     */
     theta(theta: number): this;
+
+    /**
+     * Returns the current minimum distance over which this force is considered, which defaults to 1.
+     */
     distanceMin(): number;
+    /**
+     * Sets the minimum distance between nodes over which this force is considered.
+     *
+     * A minimum distance establishes an upper bound on the strength of the force between two nearby nodes, avoiding instability.
+     * In particular, it avoids an infinitely-strong force if two nodes are exactly coincident; in this case, the direction of the force is random.
+     *
+     * The default value is 1.
+     *
+     * @param distance The minimum distance between nodes over which this force is considered.
+     */
     distanceMin(distance: number): this;
+
+    /**
+     * Returns the current maximum distance over which this force is considered, which defaults to infinity.
+     */
     distanceMax(): number;
+    /**
+     * Sets the maximum distance between nodes over which this force is considered.
+     *
+     * Specifying a finite maximum distance improves performance and produces a more localized layout.
+     *
+     * The default value is infinity.
+     *
+     * @param distance The maximum distance between nodes over which this force is considered.
+     */
     distanceMax(distance: number): this;
 }
 
+/**
+ * Creates a new many-body force with the default parameters.
+ *
+ * The many-body (or n-body) force applies mutually amongst all nodes. It can be used to simulate gravity (attraction) if the strength is positive,
+ * or electrostatic charge (repulsion) if the strength is negative. This implementation uses quadtrees and the Barnes–Hut approximation to greatly
+ * improve performance; the accuracy can be customized using the theta parameter.
+ *
+ * Unlike links, which only affect two linked nodes, the charge force is global: every node affects every other node, even if they are on disconnected subgraphs.
+ *
+ * The generic refers to the type of data for a node.
+ */
 export function forceManyBody<NodeDatum extends SimulationNodeDatum>(): ForceManyBody<NodeDatum>;
 
 // Positioning ----------------------------------------------------------------
 
+/**
+ * The x-positioning force pushes nodes towards a desired position along the given dimension with a configurable strength.
+ * The strength of the force is proportional to the one-dimensional distance between the node’s position and the target position.
+ * While this force can be used to position individual nodes, it is intended primarily for global forces that apply to all (or most) nodes.
+ *
+ * The generic refers to the type of data for a node.
+ */
 export interface ForceX<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
+
+    /**
+     *  Returns the current strength accessor, which defaults to a constant strength for all nodes of 0.1.
+     */
     strength(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
+    /**
+     * Set the strength accessor to the specified constant strength for all nodes, re-evaluates the strength accessor for each node, and returns this force.
+     *
+     * The strength determines how much to increment the node’s x-velocity: (x - node.x) × strength.
+     *
+     * For example, a value of 0.1 indicates that the node should move a tenth of the way from its current x-position to the target x-position with each application.
+     * Higher values moves nodes more quickly to the target position, often at the expense of other forces or constraints.
+     *
+     * A value outside the range [0,1] is not recommended.
+     *
+     * The strength accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The resulting number is then stored internally, such that the strength of each node is only recomputed when the force is initialized or
+     * when this method is called with a new strength, and not on every application of the force.
+     *
+     * @param strength Constant value of strength to be used for all nodes.
+     */
     strength(strength: number): this;
+    /**
+     * Set the strength accessor to the specified function, re-evaluates the strength accessor for each node, and returns this force.
+     *
+     * The strength determines how much to increment the node’s x-velocity: (x - node.x) × strength.
+     *
+     * For example, a value of 0.1 indicates that the node should move a tenth of the way from its current x-position to the target x-position with each application.
+     * Higher values moves nodes more quickly to the target position, often at the expense of other forces or constraints.
+     *
+     * A value outside the range [0,1] is not recommended.
+     *
+     * The strength accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The resulting number is then stored internally, such that the strength of each node is only recomputed when the force is initialized or
+     * when this method is called with a new strength, and not on every application of the force.
+     *
+     * @param strength A strength accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The function returns the strength.
+     */
     strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
+
+    /**
+     * Return the current x-accessor, which defaults to a function returning 0 for all nodes.
+     */
     x(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
+    /**
+     * Set the x-coordinate accessor to the specified number, re-evaluates the x-accessor for each node,
+     * and returns this force.
+     *
+     * The x-accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The resulting number is then stored internally, such that the target x-coordinate of each node is only recomputed when the force is initialized or
+     * when this method is called with a new x, and not on every application of the force.
+     *
+     * @param x Constant x-coordinate to be used for all nodes.
+     */
     x(x: number): this;
+    /**
+     * Set the x-coordinate accessor to the specified function, re-evaluates the x-accessor for each node,
+     * and returns this force.
+     *
+     * The x-accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The resulting number is then stored internally, such that the target x-coordinate of each node is only recomputed when the force is initialized or
+     * when this method is called with a new x, and not on every application of the force.
+     *
+     * @param x A x-coordinate accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The function returns the x-coordinate.
+     */
     x(x: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
 }
 
+/**
+ * Create a new positioning force along the x-axis towards the given position x which is defaulted to a constant 0 for all nodes.
+ *
+ * The x-positioning force pushes nodes towards a desired position along the given dimension with a configurable strength.
+ * The strength of the force is proportional to the one-dimensional distance between the node’s position and the target position.
+ * While this force can be used to position individual nodes, it is intended primarily for global forces that apply to all (or most) nodes.
+ *
+ * The generic refers to the type of data for a node.
+ */
 export function forceX<NodeDatum extends SimulationNodeDatum>(): ForceX<NodeDatum>;
+/**
+ * Create a new positioning force along the x-axis towards the given position x which is constant for all nodes.
+ *
+ * The x-positioning force pushes nodes towards a desired position along the given dimension with a configurable strength.
+ * The strength of the force is proportional to the one-dimensional distance between the node’s position and the target position.
+ * While this force can be used to position individual nodes, it is intended primarily for global forces that apply to all (or most) nodes.
+ *
+ * The generic refers to the type of data for a node.
+ *
+ * @param x Constant x-coordinate to be used for all nodes.
+ */
 export function forceX<NodeDatum extends SimulationNodeDatum>(x: number): ForceX<NodeDatum>;
+/**
+ * Create a new positioning force along the x-axis towards the position x given by evaluating the specified x-coordinate accessor
+ * for each node.
+ *
+ * The x-positioning force pushes nodes towards a desired position along the given dimension with a configurable strength.
+ * The strength of the force is proportional to the one-dimensional distance between the node’s position and the target position.
+ * While this force can be used to position individual nodes, it is intended primarily for global forces that apply to all (or most) nodes.
+ *
+ * The generic refers to the type of data for a node.
+ *
+ * @param x A x-coordinate accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
+ * The function returns the x-coordinate.
+ */
 export function forceX<NodeDatum extends SimulationNodeDatum>(x: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForceX<NodeDatum>;
 
+/**
+ * The y-positioning force pushes nodes towards a desired position along the given dimension with a configurable strength.
+ * The strength of the force is proportional to the one-dimensional distance between the node’s position and the target position.
+ * While this force can be used to position individual nodes, it is intended primarily for global forces that apply to all (or most) nodes.
+ *
+ * The generic refers to the type of data for a node.
+ */
 export interface ForceY<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
+    /**
+     *  Returns the current strength accessor, which defaults to a constant strength for all nodes of 0.1.
+     */
     strength(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
+    /**
+     * Set the strength accessor to the specified constant strength for all nodes, re-evaluates the strength accessor for each node, and returns this force.
+     *
+     * The strength determines how much to increment the node’s y-velocity: (y - node.y) × strength.
+     *
+     * For example, a value of 0.1 indicates that the node should move a tenth of the way from its current y-position to the target y-position with each application.
+     * Higher values moves nodes more quickly to the target position, often at the expense of other forces or constraints.
+     *
+     * A value outside the range [0,1] is not recommended.
+     *
+     * The strength accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The resulting number is then stored internally, such that the strength of each node is only recomputed when the force is initialized or
+     * when this method is called with a new strength, and not on every application of the force.
+     *
+     * @param strength Constant value of strength to be used for all nodes.
+     */
     strength(strength: number): this;
+    /**
+     * Set the strength accessor to the specified function, re-evaluates the strength accessor for each node, and returns this force.
+     *
+     * The strength determines how much to increment the node’s y-velocity: (y - node.y) × strength.
+     *
+     * For example, a value of 0.1 indicates that the node should move a tenth of the way from its current y-position to the target y-position with each application.
+     * Higher values moves nodes more quickly to the target position, often at the expense of other forces or constraints.
+     *
+     * A value outside the range [0,1] is not recommended.
+     *
+     * The strength accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The resulting number is then stored internally, such that the strength of each node is only recomputed when the force is initialized or
+     * when this method is called with a new strength, and not on every application of the force.
+     *
+     * @param strength A strength accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The function returns the strength.
+     */
     strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
+
+    /**
+     * Return the current y-accessor, which defaults to a function returning 0 for all nodes.
+     */
     y(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
+    /**
+     * Set the y-coordinate accessor to the specified number, re-evaluates the y-accessor for each node,
+     * and returns this force.
+     *
+     * The y-accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The resulting number is then stored internally, such that the target y-coordinate of each node is only recomputed when the force is initialized or
+     * when this method is called with a new y, and not on every application of the force.
+     *
+     * @param y Constant y-coordinate to be used for all nodes.
+     */
     y(y: number): this;
+    /**
+     * Set the y-coordinate accessor to the specified function, re-evaluates the y-accessor for each node,
+     * and returns this force.
+     *
+     * The y-accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The resulting number is then stored internally, such that the target y-coordinate of each node is only recomputed when the force is initialized or
+     * when this method is called with a new y, and not on every application of the force.
+     *
+     * @param y A y-coordinate accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The function returns the y-coordinate.
+     */
     y(y: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
 }
 
+/**
+ * Create a new positioning force along the y-axis towards the given position y which is defaulted to a constant 0 for all nodes.
+ *
+ * The y-positioning force pushes nodes towards a desired position along the given dimension with a configurable strength.
+ * The strength of the force is proportional to the one-dimensional distance between the node’s position and the target position.
+ * While this force can be used to position individual nodes, it is intended primarily for global forces that apply to all (or most) nodes.
+ *
+ * The generic refers to the type of data for a node.
+ */
 export function forceY<NodeDatum extends SimulationNodeDatum>(): ForceY<NodeDatum>;
+/**
+ * Create a new positioning force along the y-axis towards the given position y which is constant for all nodes.
+ *
+ * The y-positioning force pushes nodes towards a desired position along the given dimension with a configurable strength.
+ * The strength of the force is proportional to the one-dimensional distance between the node’s position and the target position.
+ * While this force can be used to position individual nodes, it is intended primarily for global forces that apply to all (or most) nodes.
+ *
+ * The generic refers to the type of data for a node.
+ *
+ * @param y Constant y-coordinate to be used for all nodes.
+ */
 export function forceY<NodeDatum extends SimulationNodeDatum>(y: number): ForceY<NodeDatum>;
+/**
+ * Create a new positioning force along the y-axis towards the position y given by evaluating the specified y-coordinate accessor
+ * for each node.
+ *
+ * The y-positioning force pushes nodes towards a desired position along the given dimension with a configurable strength.
+ * The strength of the force is proportional to the one-dimensional distance between the node’s position and the target position.
+ * While this force can be used to position individual nodes, it is intended primarily for global forces that apply to all (or most) nodes.
+ *
+ * The generic refers to the type of data for a node.
+ *
+ * @param y A y-coordinate accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
+ * The function returns the y-coordinate.
+ */
 export function forceY<NodeDatum extends SimulationNodeDatum>(y: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForceY<NodeDatum>;

--- a/d3-force/index.d.ts
+++ b/d3-force/index.d.ts
@@ -126,8 +126,8 @@ export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum ext
      * - vx (the node’s current x-velocity)
      * - vy (the node’s current y-velocity)
      *
-     * The position ⟨x,y⟩ and velocity ⟨vx,vy⟩ may be subsequently modified by forces and by the simulation.
-     * If either vx or vy is NaN, the velocity is initialized to ⟨0,0⟩. If either x or y is NaN, the position is initialized in a phyllotaxis arrangement,
+     * The position [x,y] and velocity [vx,vy] may be subsequently modified by forces and by the simulation.
+     * If either vx or vy is NaN, the velocity is initialized to [0,0]. If either x or y is NaN, the position is initialized in a phyllotaxis arrangement,
      * so chosen to ensure a deterministic, uniform distribution around the origin.
      *
      * To fix a node in a given position, you may specify two additional properties:
@@ -243,7 +243,7 @@ export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum ext
     force(name: string, force: Force<NodeDatum, LinkDatum>): this;
 
     /**
-     * Return the node closest to the position ⟨x,y⟩ with the given search radius.
+     * Return the node closest to the position [x,y] with the given search radius.
      * If radius is not specified, it defaults to infinity.
      * If there is no node within the search area, returns undefined.
      *
@@ -331,8 +331,8 @@ export function forceSimulation<NodeDatum extends SimulationNodeDatum, LinkDatum
  * A force is simply a function that modifies nodes’ positions or velocities; in this context, a force can apply a classical physical force such as electrical charge or gravity,
  * or it can resolve a geometric constraint, such as keeping nodes within a bounding box or keeping linked nodes a fixed distance apart.
  *
- * Forces typically read the node’s current position ⟨x,y⟩ and then add to (or subtract from) the node’s velocity ⟨vx,vy⟩.
- * However, forces may also “peek ahead” to the anticipated next position of the node, ⟨x + vx,y + vy⟩; this is necessary for resolving geometric constraints through iterative relaxation.
+ * Forces typically read the node’s current position [x,y] and then add to (or subtract from) the node’s velocity [vx,vy].
+ * However, forces may also “peek ahead” to the anticipated next position of the node, [x + vx,y + vy]; this is necessary for resolving geometric constraints through iterative relaxation.
  * Forces may also modify the position directly, which is sometimes useful to avoid adding energy to the simulation, such as when recentering the simulation in the viewport.
  *
  * Forces may optionally implement force.initialize to receive the simulation’s array of nodes.
@@ -359,7 +359,7 @@ export interface Force<NodeDatum extends SimulationNodeDatum, LinkDatum extends 
 
 /**
  * The centering force translates nodes uniformly so that the mean position of all nodes
- * (the center of mass if all nodes have equal weight) is at the given position ⟨x,y⟩.
+ * (the center of mass if all nodes have equal weight) is at the given position [x,y].
  * This force modifies the positions of nodes on each application; it does not modify velocities,
  * as doing so would typically cause the nodes to overshoot and oscillate around the desired center.
  * This force helps keeps nodes in the center of the viewport, and unlike the positioning force,
@@ -392,10 +392,10 @@ export interface ForceCenter<NodeDatum extends SimulationNodeDatum> extends Forc
 
 /**
  * Create a new centering force with the specified x- and y- coordinates.
- * If x and y are not specified, they default to ⟨0,0⟩.
+ * If x and y are not specified, they default to [0,0].
  *
  * The centering force translates nodes uniformly so that the mean position of all nodes
- * (the center of mass if all nodes have equal weight) is at the given position ⟨x,y⟩.
+ * (the center of mass if all nodes have equal weight) is at the given position [x,y].
  * This force modifies the positions of nodes on each application; it does not modify velocities,
  * as doing so would typically cause the nodes to overshoot and oscillate around the desired center.
  * This force helps keeps nodes in the center of the viewport, and unlike the positioning force,
@@ -425,9 +425,9 @@ export interface ForceCollide<NodeDatum extends SimulationNodeDatum> extends For
     /**
      * Set the radius used in collision detection to a constant number for each node.
      *
-     * The constant is internally wrapped into radius accessor function.
+     * The constant is internally wrapped into a radius accessor function.
      *
-     * The radius accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The radius accessor is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The resulting number is then stored internally, such that the radius of each node is only recomputed
      * when the force is initialized or when this method is called with a new radius, and not on every application of the force.
      *
@@ -437,11 +437,11 @@ export interface ForceCollide<NodeDatum extends SimulationNodeDatum> extends For
     /**
      * Set the radius accessor function determining the radius for each node in collision detection.
      *
-     * The radius accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The radius accessor is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The resulting number is then stored internally, such that the radius of each node is only recomputed
      * when the force is initialized or when this method is called with a new radius, and not on every application of the force.
      *
-     * @param radius A radius accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * @param radius A radius accessor function which is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The function returns a radius.
      */
     radius(radius: (node: NodeDatum, i: number, nodes: Array<NodeDatum>) => number): this;
@@ -455,7 +455,7 @@ export interface ForceCollide<NodeDatum extends SimulationNodeDatum> extends For
      * The default strength is 0.7.
      *
      * Overlapping nodes are resolved through iterative relaxation.
-     * For each node, the other nodes that are anticipated to overlap at the next tick (using the anticipated positions ⟨x + vx,y + vy⟩) are determined;
+     * For each node, the other nodes that are anticipated to overlap at the next tick (using the anticipated positions [x + vx,y + vy]) are determined;
      * the node’s velocity is then modified to push the node out of each overlapping node.
      * The change in velocity is dampened by the force’s strength such that the resolution of simultaneous overlaps can be blended together to find a stable solution.
      *
@@ -507,11 +507,11 @@ export function forceCollide<NodeDatum extends SimulationNodeDatum>(radius: numb
  * More formally, two nodes a and b are separated so that the distance between a and b is at least radius(a) + radius(b).
  * To reduce jitter, this is by default a “soft” constraint with a configurable strength and iteration count.
  *
- * The radius accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+ * The radius accessor is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
  * The resulting number is then stored internally, such that the radius of each node is only recomputed
  * when the force is initialized or when this method is called with a new radius, and not on every application of the force.
  *
- * @param radius A radius accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
+ * @param radius A radius accessor function which is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
  * The function returns a radius.
  */
 export function forceCollide<NodeDatum extends SimulationNodeDatum>(radius: (node: NodeDatum, i: number, nodes: Array<NodeDatum>) => number): ForceCollide<NodeDatum>;
@@ -562,7 +562,7 @@ export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum exte
      * as when the nodes or links change, being passed the node and its zero-based index.
      *
      * @param id A node id accessor function which is invoked for each node in the simulation,
-     * being passed the node and its zero-based index. It returns a string to represent the node id which can be used
+     * being passed the node, its zero-based index and the complete array of nodes. It returns a string to represent the node id which can be used
      * for matching link source and link target strings during the ForceLink initialization.
      */
     id(id: (node: NodeDatum, i: number, nodesData: Array<NodeDatum>) => string): this;
@@ -575,7 +575,9 @@ export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum exte
      * Set the distance accessor to use the specified constant number for all links,
      * re-evaluates the distance accessor for each link, and returns this force.
      *
-     * The distance accessor is invoked for each link, being passed the link and its zero-based index.
+     * The constant is internally wrapped into a distance accessor function.
+     *
+     * The distance accessor is invoked for each link, being passed the link, its zero-based index and the complete array of links.
      * The resulting number is then stored internally, such that the distance of each link is only recomputed when the force is initialized or
      * when this method is called with a new distance, and not on every application of the force.
      *
@@ -586,12 +588,12 @@ export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum exte
      * Set the distance accessor to use the specified function,
      * re-evaluates the distance accessor for each link, and returns this force.
      *
-     * The distance accessor is invoked for each link, being passed the link and its zero-based index.
+     * The distance accessor is invoked for each link, being passed the link, its zero-based index and the complete array of links.
      * The resulting number is then stored internally, such that the distance of each link is only recomputed when the force is initialized or
      * when this method is called with a new distance, and not on every application of the force.
      *
      * @param distance A distance accessor function which is invoked for each link being passed the link,
-     * its zero-based index and the entire array of links. It returns the distance.
+     * its zero-based index and the complete array of links. It returns the distance.
      */
     distance(distance: (link: LinkDatum, i: number, links: Array<LinkDatum>) => number): this;
 
@@ -604,7 +606,9 @@ export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum exte
      * Set the strenght accessor to use the specified constant number for all links,
      * re-evaluates the strength accessor for each link, and returns this force.
      *
-     * The strength accessor is invoked for each link, being passed the link and its zero-based index.
+     * The constant is internally wrapped into a strength accessor function.
+     *
+     * The strength accessor is invoked for each link, being passed the link, its zero-based index and the complete array of links.
      * The resulting number is then stored internally, such that the strength of each link is only recomputed
      * when the force is initialized or when this method is called with a new strength, and not on every application of the force.
      *
@@ -615,12 +619,12 @@ export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum exte
      * Set the strenght accessor to use the specified function,
      * re-evaluates the strength accessor for each link, and returns this force.
      *
-     * The strength accessor is invoked for each link, being passed the link and its zero-based index.
+     * The strength accessor is invoked for each link, being passed the link, its zero-based index and the complete array of links.
      * The resulting number is then stored internally, such that the strength of each link is only recomputed
      * when the force is initialized or when this method is called with a new strength, and not on every application of the force.
      *
      * @param strength A distance accessor function which is invoked for each link being passed the link,
-     * its zero-based index and the entire array of links. It returns the strength.
+     * its zero-based index and the complete array of links. It returns the strength.
      */
     strength(strength: (link: LinkDatum, i: number, links: Array<LinkDatum>) => number): this;
 
@@ -658,6 +662,8 @@ export function forceLink<NodeDatum extends SimulationNodeDatum, LinksDatum exte
  *
  * The first generic refers to the type of data for a node.
  * The second generic refers to the type of data for a link.
+ *
+ * @param links An array of link data.
  */
 export function forceLink<NodeDatum extends SimulationNodeDatum, LinksDatum extends SimulationLinkDatum<NodeDatum>>(links: Array<LinksDatum>): ForceLink<NodeDatum, LinksDatum>;
 
@@ -688,7 +694,9 @@ export interface ForceManyBody<NodeDatum extends SimulationNodeDatum> extends Fo
      *
      * The default represents a constant value of -30.
      *
-     * The strength accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The constant is internally wrapped into a strength accessor function.
+     *
+     * The strength accessor is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The resulting number is then stored internally, such that the strength of each node is only recomputed when the force is initialized or
      * when this method is called with a new strength, and not on every application of the force.
      *
@@ -704,11 +712,11 @@ export interface ForceManyBody<NodeDatum extends SimulationNodeDatum> extends Fo
      *
      * The default represents a constant value of -30.
      *
-     * The strength accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The strength accessor is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The resulting number is then stored internally, such that the strength of each node is only recomputed when the force is initialized or
      * when this method is called with a new strength, and not on every application of the force.
      *
-     * @param strength A strength accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * @param strength A strength accessor function which is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The function returns the strength.
      */
     strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
@@ -804,7 +812,9 @@ export interface ForceX<NodeDatum extends SimulationNodeDatum> extends Force<Nod
      *
      * A value outside the range [0,1] is not recommended.
      *
-     * The strength accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The constant is internally wrapped into a strength accessor function.
+     *
+     * The strength accessor is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The resulting number is then stored internally, such that the strength of each node is only recomputed when the force is initialized or
      * when this method is called with a new strength, and not on every application of the force.
      *
@@ -821,11 +831,11 @@ export interface ForceX<NodeDatum extends SimulationNodeDatum> extends Force<Nod
      *
      * A value outside the range [0,1] is not recommended.
      *
-     * The strength accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The strength accessor is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The resulting number is then stored internally, such that the strength of each node is only recomputed when the force is initialized or
      * when this method is called with a new strength, and not on every application of the force.
      *
-     * @param strength A strength accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * @param strength A strength accessor function which is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The function returns the strength.
      */
     strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
@@ -838,7 +848,9 @@ export interface ForceX<NodeDatum extends SimulationNodeDatum> extends Force<Nod
      * Set the x-coordinate accessor to the specified number, re-evaluates the x-accessor for each node,
      * and returns this force.
      *
-     * The x-accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The constant is internally wrapped into an x-coordinate accessor function.
+     *
+     * The x-accessor is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The resulting number is then stored internally, such that the target x-coordinate of each node is only recomputed when the force is initialized or
      * when this method is called with a new x, and not on every application of the force.
      *
@@ -849,11 +861,11 @@ export interface ForceX<NodeDatum extends SimulationNodeDatum> extends Force<Nod
      * Set the x-coordinate accessor to the specified function, re-evaluates the x-accessor for each node,
      * and returns this force.
      *
-     * The x-accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The x-accessor is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The resulting number is then stored internally, such that the target x-coordinate of each node is only recomputed when the force is initialized or
      * when this method is called with a new x, and not on every application of the force.
      *
-     * @param x A x-coordinate accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * @param x A x-coordinate accessor function which is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The function returns the x-coordinate.
      */
     x(x: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
@@ -918,7 +930,9 @@ export interface ForceY<NodeDatum extends SimulationNodeDatum> extends Force<Nod
      *
      * A value outside the range [0,1] is not recommended.
      *
-     * The strength accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The constant is internally wrapped into a strength accessor function.
+     *
+     * The strength accessor is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The resulting number is then stored internally, such that the strength of each node is only recomputed when the force is initialized or
      * when this method is called with a new strength, and not on every application of the force.
      *
@@ -935,11 +949,11 @@ export interface ForceY<NodeDatum extends SimulationNodeDatum> extends Force<Nod
      *
      * A value outside the range [0,1] is not recommended.
      *
-     * The strength accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The strength accessor is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The resulting number is then stored internally, such that the strength of each node is only recomputed when the force is initialized or
      * when this method is called with a new strength, and not on every application of the force.
      *
-     * @param strength A strength accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * @param strength A strength accessor function which is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The function returns the strength.
      */
     strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
@@ -952,7 +966,9 @@ export interface ForceY<NodeDatum extends SimulationNodeDatum> extends Force<Nod
      * Set the y-coordinate accessor to the specified number, re-evaluates the y-accessor for each node,
      * and returns this force.
      *
-     * The y-accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The constant is internally wrapped into a y-coordinate accessor function.
+     *
+     * The y-accessor is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The resulting number is then stored internally, such that the target y-coordinate of each node is only recomputed when the force is initialized or
      * when this method is called with a new y, and not on every application of the force.
      *
@@ -963,11 +979,11 @@ export interface ForceY<NodeDatum extends SimulationNodeDatum> extends Force<Nod
      * Set the y-coordinate accessor to the specified function, re-evaluates the y-accessor for each node,
      * and returns this force.
      *
-     * The y-accessor is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * The y-accessor is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The resulting number is then stored internally, such that the target y-coordinate of each node is only recomputed when the force is initialized or
      * when this method is called with a new y, and not on every application of the force.
      *
-     * @param y A y-coordinate accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
+     * @param y A y-coordinate accessor function which is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The function returns the y-coordinate.
      */
     y(y: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;

--- a/d3-zoom/index.d.ts
+++ b/d3-zoom/index.d.ts
@@ -35,66 +35,518 @@ export interface ZoomScale {
 // Zoom Behavior
 // --------------------------------------------------------------------------
 
-
+/**
+ * A D3 Zoom Behavior
+ *
+ * The first generic refers to the type of reference element to which the zoom behavior is attached.
+ * The second generic refers to the type of the datum of the reference element.
+ */
 export interface ZoomBehavior<ZoomRefElement extends ZoomedElementBaseType, Datum> extends Function {
+    /**
+     * Applies this zoom behavior to the specified selection, binding the necessary event listeners to
+     * allow panning and zooming, and initializing the zoom transform on each selected element to the identity transform if not already defined. This function is typically not invoked directly,
+     * and is instead invoked via selection.call.
+     *
+     * For details see: {@link https://github.com/d3/d3-zoom#_zoom}
+     *
+     * @param selection A D3 selection of elements.
+     * @param args Optional arguments to be passed in.
+     */
     (selection: Selection<ZoomRefElement, Datum, any, any>, ...args: any[]): void;
+    /**
+     * Sets the current zoom transform of the selected elements to the specified transform,
+     * instantaneously emitting start, zoom and end events.
+     *
+     * This method requires that you specify the new zoom transform completely,
+     * and does not enforce the defined scale extent and translate extent, if any.
+     * To derive a new transform from the existing transform, and to enforce the scale and translate extents,
+     * see the convenience methods zoom.translateBy, zoom.scaleBy and zoom.scaleTo.
+     *
+     * This function is typically not invoked directly, and is instead invoked via selection.call.
+     *
+     * @param selection A D3 selection of elements.
+     * @param transform A zoom transform object.
+     */
     transform(selection: Selection<ZoomRefElement, Datum, any, any>, transform: ZoomTransform): void;
+    /**
+     * Sets the current zoom transform of the selected elements to the transform returned by the specified
+     * zoom transform factory function evaluated for each element, instantaneously emitting start, zoom and end events.
+     *
+     * This method requires that you specify the new zoom transform completely,
+     * and does not enforce the defined scale extent and translate extent, if any.
+     * To derive a new transform from the existing transform, and to enforce the scale and translate extents,
+     * see the convenience methods zoom.translateBy, zoom.scaleBy and zoom.scaleTo.
+     *
+     * This function is typically not invoked directly, and is instead invoked via selection.call.
+     *
+     * @param selection A D3 selection of elements.
+     * @param transform A zoom transform factory function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element. The function returns a zoom transform object.
+     */
     transform(selection: Selection<ZoomRefElement, Datum, any, any>, transform: ValueFn<ZoomRefElement, Datum, ZoomTransform>): void;
+    /**
+     * Sets the current zoom transform of the transitioning elements to the specified transform.
+     * It defines a “zoom” tween to the specified transform using d3.interpolateZoom,
+     * emitting a start event when the transition starts, zoom events for each tick of the transition,
+     * and then an end event when the transition ends (or is interrupted).
+     *
+     * This method requires that you specify the new zoom transform completely,
+     * and does not enforce the defined scale extent and translate extent, if any.
+     * To derive a new transform from the existing transform, and to enforce the scale and translate extents,
+     * see the convenience methods zoom.translateBy, zoom.scaleBy and zoom.scaleTo.
+     *
+     * This function is typically not invoked directly, and is instead invoked via selection.call.
+     *
+     * @param transition A D3 transition on elements.
+     * @param transform A zoom transform object.
+     */
     transform(transition: TransitionLike<ZoomRefElement, Datum>, transform: ZoomTransform): void;
+    /**
+     * Sets the current zoom transform of the transitioning elements to the transform returned by the specified
+     * zoom transform factory function evaluated for each element.
+     * It defines a “zoom” tween to the specified transform using d3.interpolateZoom,
+     * emitting a start event when the transition starts, zoom events for each tick of the transition,
+     * and then an end event when the transition ends (or is interrupted).
+     *
+     * This method requires that you specify the new zoom transform completely,
+     * and does not enforce the defined scale extent and translate extent, if any.
+     * To derive a new transform from the existing transform, and to enforce the scale and translate extents,
+     * see the convenience methods zoom.translateBy, zoom.scaleBy and zoom.scaleTo.
+     *
+     * This function is typically not invoked directly, and is instead invoked via selection.call.
+     *
+     * @param transition A D3 transition on elements.
+     * @param transform A zoom transform factory function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element. The function returns a zoom transform object.
+     */
     transform(transition: TransitionLike<ZoomRefElement, Datum>, transform: ValueFn<ZoomRefElement, Datum, ZoomTransform>): void;
 
+    /**
+     * Translates the current zoom transform of the selected elements by x and y,
+     * such that the new t(x1) = t(x0) + k × x and t(y1) = t(y0) + k × y.
+     *
+     * x is provided as a constant for all elements.
+     * y is provided as a constant for all elements.
+     *
+     * @param selection A D3 selection of elements.
+     * @param x Amount of translation in x-direction.
+     * @param y Amount of translation in y-direction.
+     */
     translateBy(selection: Selection<ZoomRefElement, Datum, any, any>, x: number, y: number): void;
+    /**
+     * Translates the current zoom transform of the selected elements by x and y,
+     * such that the new t(x1) = t(x0) + k × x and t(y1) = t(y0) + k × y.
+     *
+     * x is provided by a value function evaluated for each element in the selection.
+     * y is provided as a constant for all elements.
+     *
+     * This method is a convenience method for zoom.transform.
+     * In contrast to zoom.transform, however, it is subject to the constraints imposed by zoom.extent, zoom.scaleExten, and zoom.translateExtent.
+     *
+     * @param selection A D3 selection of elements.
+     * @param x A value function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element.The function returns the amount of translation in x-direction.
+     * @param y Amount of translation in y-direction.
+     */
     translateBy(selection: Selection<ZoomRefElement, Datum, any, any>, x: ValueFn<ZoomRefElement, Datum, number>, y: number): void;
+    /**
+     * Translates the current zoom transform of the selected elements by x and y,
+     * such that the new t(x1) = t(x0) + k × x and t(y1) = t(y0) + k × y.
+     *
+     * x is provided as a constant for all elements.
+     * y is provided by a value function evaluated for each element in the selection.
+     *
+     * This method is a convenience method for zoom.transform.
+     * In contrast to zoom.transform, however, it is subject to the constraints imposed by zoom.extent, zoom.scaleExten, and zoom.translateExtent.
+     *
+     * @param selection A D3 selection of elements.
+     * @param x Amount of translation in x-direction.
+     * @param y A value function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element.The function returns the amount of translation in y-direction.
+     */
     translateBy(selection: Selection<ZoomRefElement, Datum, any, any>, x: number, y: ValueFn<ZoomRefElement, Datum, number>): void;
+    /**
+     * Translates the current zoom transform of the selected elements by x and y,
+     * such that the new t(x1) = t(x0) + k × x and t(y1) = t(y0) + k × y.
+     *
+     * x is provided by a value function evaluated for each element in the selection.
+     * y is provided by a value function evaluated for each element in the selection.
+     *
+     * This method is a convenience method for zoom.transform.
+     * In contrast to zoom.transform, however, it is subject to the constraints imposed by zoom.extent, zoom.scaleExten, and zoom.translateExtent.
+     *
+     * @param selection A D3 selection of elements.
+     * @param x A value function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element.The function returns the amount of translation in x-direction.
+     * @param y A value function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element.The function returns the amount of translation in y-direction.
+     */
     translateBy(selection: Selection<ZoomRefElement, Datum, any, any>, x: ValueFn<ZoomRefElement, Datum, number>, y: ValueFn<ZoomRefElement, Datum, number>): void;
+    /**
+     * Defines a “zoom” tween translating the current transform for the transitioning elements by x and y,
+     * such that the new t(x1) = t(x0) + k × x and t(y1) = t(y0) + k × y.
+     *
+     * x is provided as a constant for all elements.
+     * y is provided as a constant for all elements.
+     *
+     * This method is a convenience method for zoom.transform.
+     * In contrast to zoom.transform, however, it is subject to the constraints imposed by zoom.extent, zoom.scaleExten, and zoom.translateExtent.
+     *
+     * @param transition A D3 transition on elements.
+     * @param x Amount of translation in x-direction.
+     * @param y Amount of translation in y-direction.
+     */
     translateBy(transition: TransitionLike<ZoomRefElement, Datum>, x: number, y: number): void;
+    /**
+     * Defines a “zoom” tween translating the current transform for the transitioning elements by x and y,
+     * such that the new t(x1) = t(x0) + k × x and t(y1) = t(y0) + k × y.
+     *
+     * x is provided by a value function evaluated for each element in the selection.
+     * y is provided as a constant for all elements.
+     *
+     * This method is a convenience method for zoom.transform.
+     * In contrast to zoom.transform, however, it is subject to the constraints imposed by zoom.extent, zoom.scaleExten, and zoom.translateExtent.
+     *
+     * @param transition A D3 transition on elements.
+     * @param x A value function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element.The function returns the amount of translation in x-direction.
+     * @param y Amount of translation in y-direction.
+     */
     translateBy(transition: TransitionLike<ZoomRefElement, Datum>, x: ValueFn<ZoomRefElement, Datum, number>, y: number): void;
+    /**
+     * Defines a “zoom” tween translating the current transform for the transitioning elements by x and y,
+     * such that the new t(x1) = t(x0) + k × x and t(y1) = t(y0) + k × y.
+     *
+     * x is provided as a constant for all elements.
+     * y is provided by a value function evaluated for each element in the selection.
+     *
+     * This method is a convenience method for zoom.transform.
+     * In contrast to zoom.transform, however, it is subject to the constraints imposed by zoom.extent, zoom.scaleExten, and zoom.translateExtent.
+     *
+     * @param transition A D3 transition on elements.
+     * @param x Amount of translation in x-direction.
+     * @param y A value function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element.The function returns the amount of translation in y-direction.
+     */
     translateBy(transition: TransitionLike<ZoomRefElement, Datum>, x: number, y: ValueFn<ZoomRefElement, Datum, number>): void;
+    /**
+     * Defines a “zoom” tween translating the current transform for the transitioning elements by x and y,
+     * such that the new t(x1) = t(x0) + k × x and t(y1) = t(y0) + k × y.
+     *
+     * x is provided by a value function evaluated for each element in the selection.
+     * y is provided by a value function evaluated for each element in the selection.
+     *
+     * This method is a convenience method for zoom.transform.
+     * In contrast to zoom.transform, however, it is subject to the constraints imposed by zoom.extent, zoom.scaleExten, and zoom.translateExtent.
+     *
+     * @param transition A D3 transition on elements.
+     * @param x A value function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element.The function returns the amount of translation in x-direction.
+     * @param y A value function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element.The function returns the amount of translation in y-direction.
+     */
     translateBy(transition: TransitionLike<ZoomRefElement, Datum>, x: ValueFn<ZoomRefElement, Datum, number>, y: ValueFn<ZoomRefElement, Datum, number>): void;
 
+    /**
+     * Scales the current zoom transform of the selected elements by k, such that the new k(1) = k(0) × k.
+     *
+     * k is provided as a constant for all elements.
+     *
+     * This method is a convenience method for zoom.transform.
+     * In contrast to zoom.transform, however, it is subject to the constraints imposed by zoom.extent, zoom.scaleExten, and zoom.translateExtent.
+     *
+     * @param selection A D3 selection of elements.
+     * @param k Scale factor.
+     */
     scaleBy(selection: Selection<ZoomRefElement, Datum, any, any>, k: number): void;
+    /**
+     * Scales the current zoom transform of the selected elements by k, such that the new k(1) = k(0) × k.
+     *
+     * k is provided by a value function evaluated for each element in the selection.
+     *
+     * This method is a convenience method for zoom.transform.
+     * In contrast to zoom.transform, however, it is subject to the constraints imposed by zoom.extent, zoom.scaleExten, and zoom.translateExtent.
+     *
+     * @param selection A D3 selection of elements.
+     * @param k A value function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element.The function returns the scale factor.
+     */
     scaleBy(selection: Selection<ZoomRefElement, Datum, any, any>, k: ValueFn<ZoomRefElement, Datum, number>): void;
+    /**
+     * Defines a “zoom” tween translating scaling the current transform of the selected elements by k, such that the new k(1) = k(0) × k.
+     *
+     * k is provided as a constant for all elements.
+     *
+     * This method is a convenience method for zoom.transform.
+     * In contrast to zoom.transform, however, it is subject to the constraints imposed by zoom.extent, zoom.scaleExten, and zoom.translateExtent.
+     *
+     * @param transition A D3 transition on elements.
+     * @param k Scale factor.
+     */
     scaleBy(transition: TransitionLike<ZoomRefElement, Datum>, k: number): void;
+    /**
+     * Defines a “zoom” tween translating scaling the current transform of the selected elements by k, such that the new k(1) = k(0) × k.
+     *
+     * k is provided by a value function evaluated for each element in the selection.
+     *
+     * This method is a convenience method for zoom.transform.
+     * In contrast to zoom.transform, however, it is subject to the constraints imposed by zoom.extent, zoom.scaleExten, and zoom.translateExtent.
+     *
+     * @param transition A D3 transition on elements.
+     * @param k A value function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element.The function returns the scale factor.
+     */
     scaleBy(transition: TransitionLike<ZoomRefElement, Datum>, k: ValueFn<ZoomRefElement, Datum, number>): void;
 
+    /**
+     * Scales the current zoom transform of the selected elements to k, such that the new k(1) = k.
+     *
+     * k is provided as a constant for all elements.
+     *
+     * This method is a convenience method for zoom.transform.
+     * In contrast to zoom.transform, however, it is subject to the constraints imposed by zoom.extent, zoom.scaleExten, and zoom.translateExtent.
+     *
+     * @param selection A D3 selection of elements.
+     * @param k New scale.
+     */
     scaleTo(selection: Selection<ZoomRefElement, Datum, any, any>, k: number): void;
+    /**
+     * Scales the current zoom transform of the selected elements to k, such that the new k(1) = k.
+     *
+     * k is provided by a value function evaluated for each element in the selection.
+     *
+     * This method is a convenience method for zoom.transform.
+     * In contrast to zoom.transform, however, it is subject to the constraints imposed by zoom.extent, zoom.scaleExten, and zoom.translateExtent.
+     *
+     * @param selection A D3 selection of elements.
+     * @param k A value function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element.The function returns the new scale.
+     */
     scaleTo(selection: Selection<ZoomRefElement, Datum, any, any>, k: ValueFn<ZoomRefElement, Datum, number>): void;
+    /**
+     * Defines a “zoom” tween translating scaling the current transform of the selected elements to k, such that the new k(1) = k.
+     *
+     * k is provided as a constant for all elements.
+     *
+     * This method is a convenience method for zoom.transform.
+     * In contrast to zoom.transform, however, it is subject to the constraints imposed by zoom.extent, zoom.scaleExten, and zoom.translateExtent.
+     *
+     * @param transition A D3 transition on elements.
+     * @param k New scale.
+     */
     scaleTo(transition: TransitionLike<ZoomRefElement, Datum>, k: number): void;
+    /**
+     * Defines a “zoom” tween translating scaling the current transform of the selected elements to k, such that the new k(1) = k.
+     *
+     * k is provided by a value function evaluated for each element in the selection.
+     *
+     * This method is a convenience method for zoom.transform.
+     * In contrast to zoom.transform, however, it is subject to the constraints imposed by zoom.extent, zoom.scaleExten, and zoom.translateExtent.
+     *
+     * @param transition A D3 transition on elements.
+     * @param k A value function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element.The function returns the new scale.
+     */
     scaleTo(transition: TransitionLike<ZoomRefElement, Datum>, k: ValueFn<ZoomRefElement, Datum, number>): void;
 
+    /**
+     * Returns the current filter function.
+     */
     filter(): ValueFn<ZoomRefElement, Datum, boolean>;
+    /**
+     * Sets the filter to the specified filter function and returns the zoom behavior.
+     *
+     * If the filter returns falsey, the initiating event is ignored and no zoom gesture is started.
+     * Thus, the filter determines which input events are ignored. The default filter ignores mousedown events on secondary buttons,
+     * since those buttons are typically intended for other purposes, such as the context menu.
+     *
+     * @param filterFn A filter function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element. The function returns a boolean value.
+     */
     filter(filterFn: ValueFn<ZoomRefElement, Datum, boolean>): this;
 
+    /**
+     * Return the current extent accessor, which defaults to [[0, 0], [width, height]] where width is the client width of the element and height is its client height;
+     * for SVG elements, the nearest ancestor SVG element’s width and height is used. In this case,
+     * the owner SVG element must have defined width and height attributes rather than (for example) relying on CSS properties or the viewBox attribute;
+     * SVG provides no programmatic method for retrieving the initial viewport size. Alternatively, consider using element.getBoundingClientRect.
+     * (In Firefox, element.clientWidth and element.clientHeight is zero for SVG elements!)
+     */
     extent(): ValueFn<ZoomRefElement, Datum, [[number, number], [number, number]]>;
+    /**
+     * Set the viewport extent to the specified array of points [[x0, y0], [x1, y1]],
+     * where [x0, y0] is the top-left corner of the viewport and [x1, y1] is the bottom-right corner of the viewport,
+     * and return this zoom behavior.
+     *
+     * The viewport extent affects several functions: the center of the viewport remains fixed during changes by zoom.scaleBy and zoom.scaleTo;
+     * the viewport center and dimensions affect the path chosen by d3.interpolateZoom; and the viewport extent is needed to enforce the optional translate extent.
+     *
+     * @param extent An extent specified as an array of two coordinates.
+     */
     extent(extent: [[number, number], [number, number]]): this;
+    /**
+     * Set the viewport extent to the array of points [[x0, y0], [x1, y1]] returned by the
+     * extent accessor function, and return this zoom behavior.
+     * The extent accessor function is evaluated for each element.
+     *
+     * [x0, y0] is the top-left corner of the viewport and [x1, y1] is the bottom-right corner of the viewport.
+     *
+     * The viewport extent affects several functions: the center of the viewport remains fixed during changes by zoom.scaleBy and zoom.scaleTo;
+     * the viewport center and dimensions affect the path chosen by d3.interpolateZoom; and the viewport extent is needed to enforce the optional translate extent.
+     *
+     * The default is [[0, 0], [width, height]] where width is the client width of the element and height is its client height;
+     * for SVG elements, the nearest ancestor SVG element’s width and height is used.
+     * In this case, the owner SVG element must have defined width and height attributes rather than (for example) relying on CSS properties or the viewBox attribute;
+     * SVG provides no programmatic method for retrieving the initial viewport size. Alternatively, consider using element.getBoundingClientRect.
+     * (In Firefox, element.clientWidth and element.clientHeight is zero for SVG elements!)
+     *
+     * @extent An extent accessor function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element.The function returns the extent array.
+     */
     extent(extent: ValueFn<ZoomRefElement, Datum, [[number, number], [number, number]]>): this;
 
+    /**
+     * Return the current scale extent.
+     */
     scaleExtent(): [number, number];
+    /**
+     * Set the scale extent to the specified array of numbers [k0, k1] where k0 is the minimum allowed scale factor and k1 is the maximum allowed scale factor,
+     * and return this zoom behavior.
+     *
+     * The scale extent restricts zooming in and out. It is enforced on interaction and when using zoom.scaleBy, zoom.scaleTo and zoom.translateBy;
+     * however, it is not enforced when using zoom.transform to set the transform explicitly.
+     *
+     * The default scale extent is [0, infinity].
+     *
+     * If the user tries to zoom by wheeling when already at the corresponding limit of the scale extent, the wheel events will be ignored and not initiate a zoom gesture.
+     * This allows the user to scroll down past a zoomable area after zooming in, or to scroll up after zooming out.
+     * If you would prefer to always prevent scrolling on wheel input regardless of the scale extent, register a wheel event listener to prevent the browser default behavior
+     *
+     * @param extent A scale extent array of two numbers representing the scale boundaries.
+     */
     scaleExtent(extent: [number, number]): this;
 
+    /**
+     * Return the current translate extent.
+     */
     translateExtent(): [[number, number], [number, number]];
+    /**
+     * Set the translate extent to the specified array of points [[x0, y0], [x1, y1]], where [x0, y0] is the top-left corner of the world and [x1, y1]
+     * is the bottom-right corner of the world, and return this zoom behavior.
+     *
+     * The translate extent restricts panning, and may cause translation on zoom out. It is enforced on interaction and when using zoom.scaleBy, zoom.scaleTo and zoom.translateBy;
+     * however, it is not enforced when using zoom.transform to set the transform explicitly.
+     *
+     * The default scale extent is [[-infinity, infinity], [-infinity, infinity]].
+     *
+     * @param extent A translate extent array, i.e. an array of two arrays, each representing a point.
+     */
     translateExtent(extent: [[number, number], [number, number]]): this;
 
+    /**
+     * Get the duration for zoom transitions on double-click and double-tap in milliseconds.
+     */
     duration(): number;
+    /**
+     * Set the duration for zoom transitions on double-click and double-tap to the specified number of milliseconds and returns the zoom behavior.
+     *
+     * To disable double-click and double-tap transitions, you can remove the zoom behavior’s dblclick event listener after applying the zoom behavior to the selection.
+     *
+     * @param Duration in milliseconds.
+     */
     duration(duration: number): this;
 
+    /**
+     * Return the first currently-assigned listener matching the specified typenames, if any.
+     *
+     * @param typenames The typenames is a string containing one or more typename separated by whitespace.
+     * Each typename is a type, optionally followed by a period (.) and a name, such as "drag.foo"" and "drag.bar";
+     * the name allows multiple listeners to be registered for the same type. The type must be one of the following:
+     * start (after zooming begins [such as mousedown]), zoom (after a change to the zoom  transform [such as mousemove], or
+     * end (after an active pointer becomes inactive [such as on mouseup].)
+     */
     on(typenames: string): ValueFn<ZoomRefElement, Datum, void>;
+    /**
+     * Remove the current event listeners for the specified typenames, if any, return the drag behavior.
+     *
+     * @param typenames The typenames is a string containing one or more typename separated by whitespace.
+     * Each typename is a type, optionally followed by a period (.) and a name, such as "drag.foo"" and "drag.bar";
+     * the name allows multiple listeners to be registered for the same type. The type must be one of the following:
+     * start (after zooming begins [such as mousedown]), zoom (after a change to the zoom  transform [such as mousemove], or
+     * end (after an active pointer becomes inactive [such as on mouseup].)
+     * @param listener Use null to remove the listener.
+     */
     on(typenames: string, callback: null): this;
+    /**
+     * Set the event listener for the specified typenames and return the zoom behavior.
+     * If an event listener was already registered for the same type and name,
+     * the existing listener is removed before the new listener is added.
+     * When a specified event is dispatched, each listener will be invoked with the same context and arguments as selection.on listeners.
+     *
+     *
+     * @param typenames The typenames is a string containing one or more typename separated by whitespace.
+     * Each typename is a type, optionally followed by a period (.) and a name, such as "drag.foo"" and "drag.bar";
+     * the name allows multiple listeners to be registered for the same type. The type must be one of the following:
+     * start (after zooming begins [such as mousedown]), zoom (after a change to the zoom  transform [such as mousemove], or
+     * end (after an active pointer becomes inactive [such as on mouseup].)
+     * @param listener An event listener function which is evaluated for each selected element,
+     * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
+     * with this as the current DOM element.
+     */
     on(typenames: string, callback: ValueFn<ZoomRefElement, Datum, void>): this;
 }
 
-
+/**
+ * Creates a new zoom behavior. The returned behavior, zoom, is both an object and a function,
+ * and is typically applied to selected elements via selection.call.
+ *
+ * The first generic refers to the type of reference element to which the zoom behavior is attached.
+ * The second generic refers to the type of the datum of the reference element.
+ */
 export function zoom<ZoomRefElement extends ZoomedElementBaseType, Datum>(): ZoomBehavior<ZoomRefElement, Datum>;
 
 // --------------------------------------------------------------------------
 // Zoom Event
 // --------------------------------------------------------------------------
 
-
+/**
+ * A D3 Zoom Event
+ *
+ * The first generic refers to the type of reference element to which the zoom behavior is attached.
+ * The second generic refers to the type of the datum of the reference element.
+ */
 export interface D3ZoomEvent<ZoomRefElement extends ZoomedElementBaseType, Datum> {
+    /**
+     * The ZoomBehavior associated with the event
+     */
     target: ZoomBehavior<ZoomRefElement, Datum>;
+    /**
+     * The event type for the zoom event
+     */
     type: 'start' | 'zoom' | 'end' | string; // Leave failsafe string type for cases like 'zoom.foo'
+    /**
+     * The current zoom transform
+     */
     transform: ZoomTransform;
+    /**
+     * The underlying input event, such as mousemove or touchmove.
+     */
     sourceEvent: any;
 }
 
@@ -102,25 +554,147 @@ export interface D3ZoomEvent<ZoomRefElement extends ZoomedElementBaseType, Datum
 // Zoom Transforms
 // --------------------------------------------------------------------------
 
-
+/**
+ * A zoom transform
+ *
+ * The zoom behavior stores the zoom state on the element to which the zoom behavior was applied, not on the zoom behavior itself. This is because the zoom behavior can be applied to many elements simultaneously, and each element can be zoomed independently.
+ * The zoom state can change either on user interaction or programmatically via zoom.transform.
+ *
+ * To retrieve the zoom state, use event.transform on the current zoom event within a zoom event listener (see zoom.on), or use d3.zoomTransform for a given node. The latter is particularly useful for modifying the zoom state programmatically,
+ * say to implement buttons for zooming in and out.
+ *
+ * For details see {@link https://github.com/d3/d3-zoom#zoom-transforms}
+ */
 export interface ZoomTransform {
+    /**
+     * The translation amount tx along the x-axis.
+     * This property should be considered read-only; instead of mutating a transform,
+     * use transform.scale and transform.translate to derive a new transform.
+     * Also see zoom.scaleBy, zoom.scaleTo and zoom.translateBy for convenience methods on the zoom behavior.
+     */
     readonly x: number;
+
+    /**
+     * The translation amount ty along the y-axis
+     * This property should be considered read-only; instead of mutating a transform,
+     * use transform.scale and transform.translate to derive a new transform.
+     * Also see zoom.scaleBy, zoom.scaleTo and zoom.translateBy for convenience methods on the zoom behavior.
+     */
     readonly y: number;
+
+    /**
+     * The scale factor k.
+     * This property should be considered read-only; instead of mutating a transform,
+     * use transform.scale and transform.translate to derive a new transform.
+     * Also see zoom.scaleBy, zoom.scaleTo and zoom.translateBy for convenience methods on the zoom behavior.
+     */
     readonly k: number;
+
+    /**
+     * Return the transformation of the specified point which is a two-element array of numbers [x, y].
+     * The returned point is equal to [x × k + tx, y × k + ty].
+     *
+     * @param point Point coordinates [x, y]
+     */
     apply(point: [number, number]): [number, number];
+
+    /**
+     * Return the transformation of the specified x-coordinate, x × k + tx.
+     *
+     * @param x Value of x-coordinate.
+     */
     applyX(x: number): number;
+
+    /**
+     * Return the transformation of the specified y-coordinate, y × k + ty.
+     *
+     * @param y Value of y-coordinate.
+     */
     applyY(y: number): number;
+
+    /**
+     * Return the inverse transformation of the specified point which is a two-element array of numbers [x, y].
+     * The returned point is equal to [(x - tx) / k, (y - ty) / k].
+     *
+     * @param point Point coordinates [x, y]
+     */
     invert(point: [number, number]): [number, number];
+
+    /**
+     * Return the inverse transformation of the specified x-coordinate, (x - tx) / k.
+     *
+     * @param x Value of x-coordinate.
+     */
     invertX(x: number): number;
+
+    /**
+     * Return the inverse transformation of the specified y-coordinate, (y - ty) / k.
+     *
+     * @param y Value of y-coordinate.
+     */
     invertY(y: number): number;
+
+    /**
+     * Returns a copy of the continuous scale x whose domain is transformed.
+     * This is implemented by first applying the inverse x-transform on the scale’s range,
+     * and then applying the inverse scale to compute the corresponding domain
+     *
+     * The scale x must use d3.interpolateNumber; do not use continuous.rangeRound as this
+     * reduces the accuracy of continuous.invert and can lead to an inaccurate rescaled domain.
+     * This method does not modify the input scale x; x thus represents the untransformed scale,
+     * while the returned scale represents its transformed view.
+     *
+     * @param xScale A continuous scale for x-dimension.
+     */
     rescaleX<S extends ZoomScale>(xScale: S): S;
+
+    /**
+     * Returns a copy of the continuous scale y whose domain is transformed.
+     * This is implemented by first applying the inverse y-transform on the scale’s range,
+     * and then applying the inverse scale to compute the corresponding domain
+     *
+     * The scale y must use d3.interpolateNumber; do not use continuous.rangeRound as this
+     * reduces the accuracy of continuous.invert and can lead to an inaccurate rescaled domain.
+     * This method does not modify the input scale x; x thus represents the untransformed scale,
+     * while the returned scale represents its transformed view.
+     *
+     * @param yScale A continuous scale for y-dimension.
+     */
     rescaleY<S extends ZoomScale>(yScale: S): S;
+
+    /**
+     * Return a transform whose scale k1 is equal to k0 × k, where k0 is this transform’s scale.
+     *
+     * @param k A scale factor.
+     */
     scale(k: number): ZoomTransform;
+
+    /**
+     * Return a string representing the SVG transform corresponding to this transform.
+     */
     toString(): string;
+
+    /**
+     * Return a transform whose translation tx1 and ty1 is equal to tx0 + x and ty0 + y,
+     * where tx0 and ty0 is this transform’s translation.
+     *
+     * @param x Amount of translation in x-direction.
+     * @param y Amount of translation in y-direction.
+     */
     translate(x: number, y: number): ZoomTransform;
 }
 
+/**
+ * Return the current transform for the specified node. Internally, an element’s transform is stored as element.__zoom;
+ * however, you should use this method rather than accessing it directly. If the given node has no defined transform, returns the identity transformation.
+ *
+ * For details see {@link https://github.com/d3/d3-zoom#zoom-transforms}
+ *
+ * @param node An element for which to retrieve its current zoomt transform.
+ */
 export function zoomTransform(node: ZoomedElementBaseType): ZoomTransform;
 
-
+/**
+ * The identity transform, where k = 1, tx = ty = 0.
+ */
 export const zoomIdentity: ZoomTransform;

--- a/d3-zoom/index.d.ts
+++ b/d3-zoom/index.d.ts
@@ -492,7 +492,7 @@ export interface ZoomBehavior<ZoomRefElement extends ZoomedElementBaseType, Datu
      * end (after an active pointer becomes inactive [such as on mouseup].)
      * @param listener Use null to remove the listener.
      */
-    on(typenames: string, callback: null): this;
+    on(typenames: string, listener: null): this;
     /**
      * Set the event listener for the specified typenames and return the zoom behavior.
      * If an event listener was already registered for the same type and name,
@@ -509,7 +509,7 @@ export interface ZoomBehavior<ZoomRefElement extends ZoomedElementBaseType, Datu
      * in order, being passed the current datum (d), the current index (i), and the current group (nodes),
      * with this as the current DOM element.
      */
-    on(typenames: string, callback: ValueFn<ZoomRefElement, Datum, void>): this;
+    on(typenames: string, listener: ValueFn<ZoomRefElement, Datum, void>): this;
 }
 
 /**


### PR DESCRIPTION
This PR adds complete JSDoc comments to the following D3 module definitions:
- d3-force
- d3-zoom

Refer to #11366.

It also includes some minor enhancements
- some initial changes to move towards complete validation for `strictNullChecks` (review not complete)

cc @gustavderdrache

@andy-ms could you kindly merge this PR.
