### PR TITLE
Adds ssh2-streams and cleans up ssh2

### DIFF
--- a/ssh2-streams/index.d.ts
+++ b/ssh2-streams/index.d.ts
@@ -24,100 +24,589 @@ declare module "ssh2-streams" {
          */
         constructor(config?: SSH2StreamConfig);
 
-        /** (Client/Server) */ ping(): boolean;
-        /** (Client/Server) */ disconnect(reasonCode?: number): boolean;
-        /** (Client/Server) */ rekey(): boolean;
-        /** (Client/Server) */ requestSuccess(data?: Buffer): boolean;
-        /** (Client/Server) */ requestFailure(): boolean;
-        /** (Client/Server) */ channelSuccess(channel: number): boolean;
-        /** (Client/Server) */ channelFailure(channel: number): boolean;
-        /** (Client/Server) */ channelEOF(channel: number): boolean;
-        /** (Client/Server) */ channelClose(channel: number): boolean;
-        /** (Client/Server) */ channelWindowAdjust(channel: number, amount: number): boolean;
-        /** (Client/Server) */ channelData(channel: number, data: string | Buffer): boolean;
-        /** (Client/Server) */ channelExtData(channel: number, data: string | Buffer, type: number): boolean;
-        /** (Client/Server) */ channelOpenConfirm(remoteChannel: number, localChannel: number, initWindow: number, maxPacket: number): boolean;
-        /** (Client/Server) */ channelOpenFail(remoteChannel: number, reasonCode: number, description?: string, lang?: string): boolean;
+        /**
+         * (Client/Server)
+         * Writes a dummy GLOBAL_REQUEST packet (specifically "keepalive@openssh.com") that requests a reply.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        ping(): boolean;
 
-        /** (Client-only) */ service(serviceName: string): boolean;
-        /** (Client-only) */ tcpipForward(bindAddr: string, bindPort: number, wantReply?: boolean): boolean;
-        /** (Client-only) */ cancelTcpipForward(bindAddr: string, bindPort: number, wantReply?: boolean): boolean;
-        /** (Client-only) */ authPassword(username: string, password: string): boolean;
-        /** (Client-only) */ authPK(username: string, pubKey: ParsedKey, cbSign?: (blob: Buffer, callback: (signedBlob: Buffer) => void) => void): boolean;
-        /** (Client-only) */ authHostBased(username: string, pubKey: ParsedKey, localHostname: string, localUsername: string, cbSign?: (blob: Buffer, callback: (signedBlob: Buffer) => void) => void): boolean;
-        /** (Client-only) */ authKeyboard(username: string): boolean;
-        /** (Client-only) */ authNone(username: string): boolean;
-        /** (Client-only) */ authInfoRes(responses?: string[]): boolean;
-        /** (Client-only) */ directTcpip(channel: number, initWindow: number, maxPacket: number, config: TcpipForwardingConfig): boolean;
-        /** (Client-only) */ session(channel: number, initWindow: number, maxPacket: number): boolean;
-        /** (Client-only) */ openssh_agentForward(channel: number, wantReply?: boolean): boolean;
-        /** (Client-only) */ windowChange(channel: number, rows: number, cols: number, height: number, width: number): boolean;
-        /** (Client-only) */ pty(channel: number, rows: number, cols: number, height: number, width: number, terminalType?: string, terminalModes?: any, wantReply?: boolean): boolean;
-        /** (Client-only) */ env(channel: number, key: string, value: string | Buffer, wantReply?: boolean): boolean;
-        /** (Client-only) */ shell(channel: number, wantReply?: boolean): boolean;
-        /** (Client-only) */ exec(channel: number, command: string, wantReply?: boolean): boolean;
-        /** (Client-only) */ signal(channel: number, signalName: string): boolean;
-        /** (Client-only) */ x11Forward(channel: number, config: X11ForwardingConfig, wantReply?: boolean): boolean;
-        /** (Client-only) */ subsystem(channel: number, name: string, wantReply?: boolean): boolean;
-        /** (Client-only) */ openssh_noMoreSessions(wantReply?: boolean): boolean;
-        /** (Client-only) */ openssh_streamLocalForward(socketPath: string, wantReply?: boolean): boolean;
-        /** (Client-only) */ openssh_cancelStreamLocalForward(socketPath: string, wantReply?: boolean): boolean;
-        /** (Client-only) */ openssh_directStreamLocal(channel: number, initWindow: number, maxPacket: number, config: SocketForwardingConfig): boolean;
+        /**
+         * (Client/Server)
+         * Writes a disconnect packet and closes the stream.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        disconnect(reasonCode?: number): boolean;
 
-        /** (Server-only) */ serviceAccept(serviceName: string): boolean;
-        /** (Server-only) */ authFailure(authMethods?: string[], partialSuccess?: boolean): boolean;
-        /** (Server-only) */ authSuccess(): boolean;
-        /** (Server-only) */ authPKOK(keyAlgorithm: string, keyData: Buffer): boolean;
-        /** (Server-only) */ authInfoReq(name: string, instructions: string, prompts: Prompt[]): boolean;
-        /** (Server-only) */ forwardedTcpip(channel: number, initWindow: number, maxPacket: number, info: ForwardedTcpip): boolean;
-        /** (Server-only) */ x11(channel: number, initWindow: number, maxPacket: number, info: ForwardedX11): boolean;
-        /** (Server-only) */ openssh_forwardedStreamLocal(channel: number, initWindow: number, maxPacket: number, info: ForwardedSocket): boolean;
-        /** (Server-only) */ exitStatus(channel: number, exitCode: number): boolean;
-        /** (Server-only) */ exitSignal(channel: number, signalName: string, coreDumped: boolean, errorMessage: string): boolean;
+        /**
+         * (Client/Server)
+         * Starts the re-keying process. Incoming/Outgoing packets are buffered until the re-keying
+         * process has finished. Returns `false` to indicate that no more packets should be written
+         * until the `NEWKEYS` event is seen.
+         */
+        rekey(): boolean;
 
-        /** (Client/Server) */ on(event: "header", listener: (header: Header) => void): this;
-        /** (Client/Server) */ on(event: "GLOBAL_REQUEST", listener: (reqName: string, wantReply: boolean, request: GlobalRequest | Buffer | undefined) => void): this;
-        /** (Client/Server) */ on(event: "DISCONNECT", listener: (reason: string, reasonCode: number, description: string) => void): this;
-        /** (Client/Server) */ on(event: "DEBUG", listener: (message: string) => void): this;
-        /** (Client/Server) */ on(event: "NEWKEYS", listener: () => void): this;
-        /** (Client/Server) */ on(event: "REQUEST_SUCCESS", listener: (resData: Buffer) => void): this;
-        /** (Client/Server) */ on(event: "REQUEST_FAILURE", listener: () => void): this;
-        /** (Client/Server) */ on(event: "CHANNEL_OPEN", listener: (channelInfo: ChannelOpenInfo) => void): this;
-        /** (Client/Server) */ on(event: "CHANNEL_OPEN_CONFIRMATION:0", listener: (channelInfo: ChannelOpenConfirmationInfo) => void): this;
-        /** (Client/Server) */ on(event: "CHANNEL_OPEN_FAILURE:0", listener: (failInfo: ChannelOpenFailureInfo) => void): this;
-        /** (Client/Server) */ on(event: "CHANNEL_REQUEST:0", listener: (request: ChannelRequest) => void): this;
-        /** (Client/Server) */ on(event: "CHANNEL_DATA:0", listener: (data: Buffer) => void): this;
-        /** (Client/Server) */ on(event: "CHANNEL_EXTENDED_DATA:0", listener: (type: number, data: Buffer) => void): this;
-        /** (Client/Server) */ on(event: "CHANNEL_WINDOW_ADJUST:0", listener: (bytesToAdd: number) => void): this;
-        /** (Client/Server) */ on(event: "CHANNEL_SUCCESS:0", listener: () => void): this;
-        /** (Client/Server) */ on(event: "CHANNEL_FAILURE:0", listener: () => void): this;
-        /** (Client/Server) */ on(event: "CHANNEL_EOF:0", listener: () => void): this;
-        /** (Client/Server) */ on(event: "CHANNEL_CLOSE:0", listener: () => void): this;
+        /**
+         * (Client/Server)
+         * Writes a request success packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        requestSuccess(data?: Buffer): boolean;
 
-        /** (Client-only) */ on(event: "fingerprint", listener: (hostKey: Buffer, callback: (success: boolean) => void) => void): this;
-        /** (Client-only) */ on(event: "SERVICE_ACCEPT", listener: (serviceName: string) => void): this;
-        /** (Client-only) */ on(event: "USERAUTH_PASSWD_CHANGEREQ", listener: (message: string) => void): this;
-        /** (Client-only) */ on(event: "USERAUTH_INFO_REQUEST", listener: (name: string, instructions: string, lang: string, prompts: Prompt[]) => void): this;
-        /** (Client-only) */ on(event: "USERAUTH_PK_OK", listener: () => void): this;
-        /** (Client-only) */ on(event: "USERAUTH_SUCCESS", listener: () => void): this;
-        /** (Client-only) */ on(event: "USERAUTH_FAILURE", listener: (methodsContinue: string[], partialSuccess: boolean) => void): this;
-        /** (Client-only) */ on(event: "USERAUTH_BANNER", listener: (message: string) => void): this;
+        /**
+         * (Client/Server)
+         * Writes a request failure packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        requestFailure(): boolean;
 
-        /** (Server-only) */ on(event: "SERVICE_REQUEST", listener: (serviceName: string) => void): this;
-        /** (Server-only) */ on(event: "USERAUTH_REQUEST", listener: (username: string, serviceName: string, authMethod: string, authMethodData: AuthMethodData) => void): this;
-        /** (Server-only) */ on(event: "USERAUTH_INFO_RESPONSE", listener: (responses: string[]) => void): this;
+        /**
+         * (Client/Server)
+         * Writes a channel success packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        channelSuccess(channel: number): boolean;
 
-        on(event: "end", listener: () => void): this;
-        on(event: "close", listener: () => void): this;
-        on(event: "drain", listener: () => void): this;
-        on(event: "error", listener: (err: any) => void): this;
-        on(event: "finish", listener: () => void): this;
-        on(event: "pipe", listener: (src: stream.Readable) => void): this;
-        on(event: "unpipe", listener: (src: stream.Readable) => void): this;
-        on(event: "data", listener: (chunk: string | Buffer) => void): this;
-        on(event: "readable", listener: () => void): this;
-        on(event: "continue", listener: () => void): this;
+        /**
+         * (Client/Server)
+         * Writes a channel failure packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        channelFailure(channel: number): boolean;
+
+        /**
+         * (Client/Server)
+         * Writes a channel EOF packet for the given `channel`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        channelEOF(channel: number): boolean;
+
+        /**
+         * (Client/Server)
+         * Writes a channel close packet for the given `channel`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        channelClose(channel: number): boolean;
+
+        /**
+         * (Client/Server)
+         * Writes a channel window adjust packet for the given `channel` where `amount` is the
+         * number of bytes to add to the channel window.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        channelWindowAdjust(channel: number, amount: number): boolean;
+
+        /**
+         * (Client/Server)
+         * Writes a channel data packet for the given `channel` where `data` is a _Buffer_ or _string_.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        channelData(channel: number, data: string | Buffer): boolean;
+
+        /**
+         * (Client/Server)
+         * Writes a channel extended data packet for the given `channel` where `data is a _Buffer_
+         * or _string_.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        channelExtData(channel: number, data: string | Buffer, type: number): boolean;
+
+        /**
+         * (Client/Server)
+         * Writes a channel open confirmation packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        channelOpenConfirm(remoteChannel: number, localChannel: number, initWindow: number, maxPacket: number): boolean;
+
+        /**
+         * (Client/Server)
+         * Writes a channel open failure packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        channelOpenFail(remoteChannel: number, reasonCode: number, description?: string, lang?: string): boolean;
+
+
+        /**
+         * (Client-only)
+         * Writes a service request packet for `serviceName`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        service(serviceName: string): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a tcpip forward global request packet. `wantReply` defaults to `true`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        tcpipForward(bindAddr: string, bindPort: number, wantReply?: boolean): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a cancel tcpip forward global request packet. `wantReply` defaults to `true`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        cancelTcpipForward(bindAddr: string, bindPort: number, wantReply?: boolean): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a password userauth request packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        authPassword(username: string, password: string): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a publickey userauth request packet. `pubKey` is the object returned from using
+         * `utils.parseKey()` on a private or public key. If `cbSign` is not present, a pubkey
+         * check userauth packet is written. Otherwise `cbSign` is called with `(blob, callback)`,
+         * where `blob` is the data to sign with the private key and the resulting signature
+         * _Buffer_ is passed to `callback` as the first argument.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        authPK(username: string, pubKey: ParsedKey, cbSign?: (blob: Buffer, callback: (signedBlob: Buffer) => void) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a hostbased userauth request packet. `pubKey` is the object returned from using
+         * `utils.parseKey()` on a private or public key. `cbSign` is called with `(blob, callback)`,
+         * where `blob` is the data to sign with the private key and the resulting signature
+         * _Buffer_ is passed to `callback` as the first argument.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        authHostBased(username: string, pubKey: ParsedKey, localHostname: string, localUsername: string, cbSign?: (blob: Buffer, callback: (signedBlob: Buffer) => void) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a keyboard-interactive userauth request packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        authKeyboard(username: string): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a "none" userauth request packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        authNone(username: string): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a userauth info response packet. `responses` is an _array_ of zero or more strings
+         * corresponding to responses to prompts previously sent by the server.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        authInfoRes(responses?: string[]): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a direct tcpip channel open packet. `config` must contain `srcIP`, `srcPort`,
+         * `dstIP`, and `dstPort`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        directTcpip(channel: number, initWindow: number, maxPacket: number, config: TcpipForwardingConfig): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a session channel open packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        session(channel: number, initWindow: number, maxPacket: number): boolean;
+
+        /**
+         * (Client-only)
+         * Writes an `auth-agent-req@openssh.com` channel request packet. `wantReply` defaults to
+         * `true`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        openssh_agentForward(channel: number, wantReply?: boolean): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a window change channel request packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        windowChange(channel: number, rows: number, cols: number, height: number, width: number): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a pty channel request packet. If `terminalType` is falsey, `vt100` is used.
+         * `terminalModes` can be the raw bytes, an _object_ of the terminal modes to set, or a falsey value for no modes. `wantReply` defaults to `true`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        pty(channel: number, rows: number, cols: number, height: number, width: number, terminalType?: string, terminalModes?: any, wantReply?: boolean): boolean;
+
+        /**
+         * (Client-only)
+         * Writes an env channel request packet. `value` can be a _string_ or _Buffer_. `wantReply`
+         * defaults to `true`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        env(channel: number, key: string, value: string | Buffer, wantReply?: boolean): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a shell channel request packet. `wantReply` defaults to `true`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        shell(channel: number, wantReply?: boolean): boolean;
+
+        /**
+         * (Client-only)
+         * Writes an exec channel request packet. `wantReply` defaults to `true`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        exec(channel: number, command: string, wantReply?: boolean): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a signal channel request packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        signal(channel: number, signalName: string): boolean;
+
+        /**
+         * (Client-only)
+         * Writes an X11 forward channel request packet. `wantReply` defaults to `true`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        x11Forward(channel: number, config: X11ForwardingConfig, wantReply?: boolean): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a subsystem channel request packet. `name` is the name of the subsystem (e.g.
+         * `sftp` or `netconf`). `wantReply` defaults to `true`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        subsystem(channel: number, name: string, wantReply?: boolean): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a no-more-sessions@openssh.com request packet. `wantReply` defaults to `true`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        openssh_noMoreSessions(wantReply?: boolean): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a streamlocal-forward@openssh.com request packet. `wantReply` defaults to `true`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        openssh_streamLocalForward(socketPath: string, wantReply?: boolean): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a cancel-streamlocal-forward@openssh.com request packet. `wantReply` defaults to
+         * `true`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        openssh_cancelStreamLocalForward(socketPath: string, wantReply?: boolean): boolean;
+
+        /**
+         * (Client-only)
+         * Writes a direct-streamlocal@openssh.com channel open packet. `config` must contain
+         * `socketPath`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        openssh_directStreamLocal(channel: number, initWindow: number, maxPacket: number, config: SocketForwardingConfig): boolean;
+
+
+        /**
+         * (Server-only)
+         * Writes a service accept packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        serviceAccept(serviceName: string): boolean;
+
+        /**
+         * (Server-only)
+         * Writes a userauth failure packet. `authMethods` is an _array_ of authentication methods
+         * that can continue.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        authFailure(authMethods?: string[], partialSuccess?: boolean): boolean;
+
+        /**
+         * (Server-only)
+         * Writes a userauth success packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        authSuccess(): boolean;
+
+        /**
+         * (Server-only)
+         * Writes a userauth PK OK packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        authPKOK(keyAlgorithm: string, keyData: Buffer): boolean;
+
+        /**
+         * (Server-only)
+         * Writes a userauth info request packet. `prompts` is an array of `Prompt` objects.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        authInfoReq(name: string, instructions: string, prompts: Prompt[]): boolean;
+
+        /**
+         * (Server-only)
+         * Writes a forwarded tcpip channel open packet. `info` must contain `boundAddr`,
+         * `boundPort`, `remoteAddr`, and `remotePort`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        forwardedTcpip(channel: number, initWindow: number, maxPacket: number, info: ForwardedTcpip): boolean;
+
+        /**
+         * (Server-only)
+         * Writes an X11 channel open packet. `info` must contain `originAddr` and `originPort`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        x11(channel: number, initWindow: number, maxPacket: number, info: ForwardedX11): boolean;
+
+        /**
+         * (Server-only)
+         * Writes an forwarded-streamlocal@openssh.com channel open packet. `info` must contain
+         * `socketPath`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        openssh_forwardedStreamLocal(channel: number, initWindow: number, maxPacket: number, info: ForwardedSocket): boolean;
+
+        /**
+         * (Server-only)
+         * Writes an exit status channel request packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        exitStatus(channel: number, exitCode: number): boolean;
+
+        /**
+         * (Server-only)
+         * Writes an exit signal channel request packet.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        exitSignal(channel: number, signalName: string, coreDumped: boolean, errorMessage: string): boolean;
+
+
+        /**
+         * (Client/Server)
+         * Emitted when the protocol header is seen.
+         */
+        on(event: "header", listener: (header: Header) => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "GLOBAL_REQUEST", listener: (reqName: string, wantReply: boolean, request: GlobalRequest | Buffer | undefined) => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "DISCONNECT", listener: (reason: string, reasonCode: number, description: string) => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "DEBUG", listener: (message: string) => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "NEWKEYS", listener: () => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "REQUEST_SUCCESS", listener: (resData: Buffer) => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "REQUEST_FAILURE", listener: () => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "CHANNEL_OPEN", listener: (channelInfo: ChannelOpenInfo) => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "CHANNEL_OPEN_CONFIRMATION:0", listener: (channelInfo: ChannelOpenConfirmationInfo) => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "CHANNEL_OPEN_FAILURE:0", listener: (failInfo: ChannelOpenFailureInfo) => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "CHANNEL_REQUEST:0", listener: (request: ChannelRequest) => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "CHANNEL_DATA:0", listener: (data: Buffer) => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "CHANNEL_EXTENDED_DATA:0", listener: (type: number, data: Buffer) => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "CHANNEL_WINDOW_ADJUST:0", listener: (bytesToAdd: number) => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "CHANNEL_SUCCESS:0", listener: () => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "CHANNEL_FAILURE:0", listener: () => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "CHANNEL_EOF:0", listener: () => void): this;
+
+        /**
+         * (Client/Server)
+         */
+        on(event: "CHANNEL_CLOSE:0", listener: () => void): this;
+
+
+        /**
+         * (Client-only)
+         * This event allows you to verify a host's key. If `callback` is called with `true`, the
+         * handshake continues. Otherwise a disconnection will occur if `callback` is called with
+         * `false`. The default behavior is to auto-allow any host key if there are no handlers
+         * for this event.
+         */
+        on(event: "fingerprint", listener: (hostKey: Buffer, callback: (success: boolean) => void) => void): this;
+
+        /**
+         * (Client-only)
+         */
+        on(event: "SERVICE_ACCEPT", listener: (serviceName: string) => void): this;
+
+        /**
+         * (Client-only)
+         */
+        on(event: "USERAUTH_PASSWD_CHANGEREQ", listener: (message: string) => void): this;
+
+        /**
+         * (Client-only)
+         */
+        on(event: "USERAUTH_INFO_REQUEST", listener: (name: string, instructions: string, lang: string, prompts: Prompt[]) => void): this;
+
+        /**
+         * (Client-only)
+         */
+        on(event: "USERAUTH_PK_OK", listener: () => void): this;
+
+        /**
+         * (Client-only)
+         */
+        on(event: "USERAUTH_SUCCESS", listener: () => void): this;
+
+        /**
+         * (Client-only)
+         */
+        on(event: "USERAUTH_FAILURE", listener: (methodsContinue: string[], partialSuccess: boolean) => void): this;
+
+        /**
+         * (Client-only)
+         */
+        on(event: "USERAUTH_BANNER", listener: (message: string) => void): this;
+
+        /**
+         * (Server-only)
+         */
+        on(event: "SERVICE_REQUEST", listener: (serviceName: string) => void): this;
+
+        /**
+         * (Server-only)
+         */
+        on(event: "USERAUTH_REQUEST", listener: (username: string, serviceName: string, authMethod: string, authMethodData: AuthMethodData) => void): this;
+
+        /**
+         * (Server-only)
+         */
+        on(event: "USERAUTH_INFO_RESPONSE", listener: (responses: string[]) => void): this;
+
+        /**
+         * Emitted when the connection has authenticated.
+         */
         on(event: "ready", listener: () => void): this;
+
+        /**
+         * Emitted when the socket has disconnected.
+         */
+        on(event: "end", listener: () => void): this;
+
+        /**
+         * Emitted when the client socket was closed.
+         */
+        on(event: "close", listener: () => void): this;
+
+        /**
+         * Emitted when more requests/data can be sent to the stream.
+         */
+        on(event: "continue", listener: () => void): this;
+
+        /**
+         * Emitted when an error occurred.
+         */
+        on(event: "error", listener: (err: any) => void): this;
+
         on(event: string | symbol, listener: Function): this;
     }
 

--- a/ssh2-streams/index.d.ts
+++ b/ssh2-streams/index.d.ts
@@ -1,0 +1,1196 @@
+// Type definitions for ssh2-streams v0.1.9
+// Project: https://github.com/mscdex/ssh2-streams
+// Definitions by: Ron Buckton <https://github.com/rbuckton>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+declare module "ssh2-streams" {
+    import * as stream from "stream";
+
+    export class SSH2Stream extends stream.Transform {
+        /**
+         * The number of bytes sent since the last keying. This metric can be useful in determining when to call rekey().
+         */
+        bytesSent: number;
+
+        /**
+         * The number of bytes received since the last keying. This metric can be useful in determining when to call rekey().
+         */
+        bytesReceived: number;
+
+        /**
+         * Creates and returns a new SSH2Stream instance.
+         */
+        constructor(config?: SSH2StreamConfig);
+
+        /** (Client/Server) */ ping(): boolean;
+        /** (Client/Server) */ disconnect(reasonCode?: number): boolean;
+        /** (Client/Server) */ rekey(): boolean;
+        /** (Client/Server) */ requestSuccess(data?: Buffer): boolean;
+        /** (Client/Server) */ requestFailure(): boolean;
+        /** (Client/Server) */ channelSuccess(channel: number): boolean;
+        /** (Client/Server) */ channelFailure(channel: number): boolean;
+        /** (Client/Server) */ channelEOF(channel: number): boolean;
+        /** (Client/Server) */ channelClose(channel: number): boolean;
+        /** (Client/Server) */ channelWindowAdjust(channel: number, amount: number): boolean;
+        /** (Client/Server) */ channelData(channel: number, data: string | Buffer): boolean;
+        /** (Client/Server) */ channelExtData(channel: number, data: string | Buffer, type: number): boolean;
+        /** (Client/Server) */ channelOpenConfirm(remoteChannel: number, localChannel: number, initWindow: number, maxPacket: number): boolean;
+        /** (Client/Server) */ channelOpenFail(remoteChannel: number, reasonCode: number, description?: string, lang?: string): boolean;
+
+        /** (Client-only) */ service(serviceName: string): boolean;
+        /** (Client-only) */ tcpipForward(bindAddr: string, bindPort: number, wantReply?: boolean): boolean;
+        /** (Client-only) */ cancelTcpipForward(bindAddr: string, bindPort: number, wantReply?: boolean): boolean;
+        /** (Client-only) */ authPassword(username: string, password: string): boolean;
+        /** (Client-only) */ authPK(username: string, pubKey: ParsedKey, cbSign?: (blob: Buffer, callback: (signedBlob: Buffer) => void) => void): boolean;
+        /** (Client-only) */ authHostBased(username: string, pubKey: ParsedKey, localHostname: string, localUsername: string, cbSign?: (blob: Buffer, callback: (signedBlob: Buffer) => void) => void): boolean;
+        /** (Client-only) */ authKeyboard(username: string): boolean;
+        /** (Client-only) */ authNone(username: string): boolean;
+        /** (Client-only) */ authInfoRes(responses?: string[]): boolean;
+        /** (Client-only) */ directTcpip(channel: number, initWindow: number, maxPacket: number, config: TcpipForwardingConfig): boolean;
+        /** (Client-only) */ session(channel: number, initWindow: number, maxPacket: number): boolean;
+        /** (Client-only) */ openssh_agentForward(channel: number, wantReply?: boolean): boolean;
+        /** (Client-only) */ windowChange(channel: number, rows: number, cols: number, height: number, width: number): boolean;
+        /** (Client-only) */ pty(channel: number, rows: number, cols: number, height: number, width: number, terminalType?: string, terminalModes?: any, wantReply?: boolean): boolean;
+        /** (Client-only) */ env(channel: number, key: string, value: string | Buffer, wantReply?: boolean): boolean;
+        /** (Client-only) */ shell(channel: number, wantReply?: boolean): boolean;
+        /** (Client-only) */ exec(channel: number, command: string, wantReply?: boolean): boolean;
+        /** (Client-only) */ signal(channel: number, signalName: string): boolean;
+        /** (Client-only) */ x11Forward(channel: number, config: X11ForwardingConfig, wantReply?: boolean): boolean;
+        /** (Client-only) */ subsystem(channel: number, name: string, wantReply?: boolean): boolean;
+        /** (Client-only) */ openssh_noMoreSessions(wantReply?: boolean): boolean;
+        /** (Client-only) */ openssh_streamLocalForward(socketPath: string, wantReply?: boolean): boolean;
+        /** (Client-only) */ openssh_cancelStreamLocalForward(socketPath: string, wantReply?: boolean): boolean;
+        /** (Client-only) */ openssh_directStreamLocal(channel: number, initWindow: number, maxPacket: number, config: SocketForwardingConfig): boolean;
+
+        /** (Server-only) */ serviceAccept(serviceName: string): boolean;
+        /** (Server-only) */ authFailure(authMethods?: string[], partialSuccess?: boolean): boolean;
+        /** (Server-only) */ authSuccess(): boolean;
+        /** (Server-only) */ authPKOK(keyAlgorithm: string, keyData: Buffer): boolean;
+        /** (Server-only) */ authInfoReq(name: string, instructions: string, prompts: Prompt[]): boolean;
+        /** (Server-only) */ forwardedTcpip(channel: number, initWindow: number, maxPacket: number, info: ForwardedTcpip): boolean;
+        /** (Server-only) */ x11(channel: number, initWindow: number, maxPacket: number, info: ForwardedX11): boolean;
+        /** (Server-only) */ openssh_forwardedStreamLocal(channel: number, initWindow: number, maxPacket: number, info: ForwardedSocket): boolean;
+        /** (Server-only) */ exitStatus(channel: number, exitCode: number): boolean;
+        /** (Server-only) */ exitSignal(channel: number, signalName: string, coreDumped: boolean, errorMessage: string): boolean;
+
+        /** (Client/Server) */ on(event: "header", listener: (header: Header) => void): this;
+        /** (Client/Server) */ on(event: "GLOBAL_REQUEST", listener: (reqName: string, wantReply: boolean, request: GlobalRequest | Buffer | undefined) => void): this;
+        /** (Client/Server) */ on(event: "DISCONNECT", listener: (reason: string, reasonCode: number, description: string) => void): this;
+        /** (Client/Server) */ on(event: "DEBUG", listener: (message: string) => void): this;
+        /** (Client/Server) */ on(event: "NEWKEYS", listener: () => void): this;
+        /** (Client/Server) */ on(event: "REQUEST_SUCCESS", listener: (resData: Buffer) => void): this;
+        /** (Client/Server) */ on(event: "REQUEST_FAILURE", listener: () => void): this;
+        /** (Client/Server) */ on(event: "CHANNEL_OPEN", listener: (channelInfo: ChannelOpenInfo) => void): this;
+        /** (Client/Server) */ on(event: "CHANNEL_OPEN_CONFIRMATION:0", listener: (channelInfo: ChannelOpenConfirmationInfo) => void): this;
+        /** (Client/Server) */ on(event: "CHANNEL_OPEN_FAILURE:0", listener: (failInfo: ChannelOpenFailureInfo) => void): this;
+        /** (Client/Server) */ on(event: "CHANNEL_REQUEST:0", listener: (request: ChannelRequest) => void): this;
+        /** (Client/Server) */ on(event: "CHANNEL_DATA:0", listener: (data: Buffer) => void): this;
+        /** (Client/Server) */ on(event: "CHANNEL_EXTENDED_DATA:0", listener: (type: number, data: Buffer) => void): this;
+        /** (Client/Server) */ on(event: "CHANNEL_WINDOW_ADJUST:0", listener: (bytesToAdd: number) => void): this;
+        /** (Client/Server) */ on(event: "CHANNEL_SUCCESS:0", listener: () => void): this;
+        /** (Client/Server) */ on(event: "CHANNEL_FAILURE:0", listener: () => void): this;
+        /** (Client/Server) */ on(event: "CHANNEL_EOF:0", listener: () => void): this;
+        /** (Client/Server) */ on(event: "CHANNEL_CLOSE:0", listener: () => void): this;
+
+        /** (Client-only) */ on(event: "fingerprint", listener: (hostKey: Buffer, callback: (success: boolean) => void) => void): this;
+        /** (Client-only) */ on(event: "SERVICE_ACCEPT", listener: (serviceName: string) => void): this;
+        /** (Client-only) */ on(event: "USERAUTH_PASSWD_CHANGEREQ", listener: (message: string) => void): this;
+        /** (Client-only) */ on(event: "USERAUTH_INFO_REQUEST", listener: (name: string, instructions: string, lang: string, prompts: Prompt[]) => void): this;
+        /** (Client-only) */ on(event: "USERAUTH_PK_OK", listener: () => void): this;
+        /** (Client-only) */ on(event: "USERAUTH_SUCCESS", listener: () => void): this;
+        /** (Client-only) */ on(event: "USERAUTH_FAILURE", listener: (methodsContinue: string[], partialSuccess: boolean) => void): this;
+        /** (Client-only) */ on(event: "USERAUTH_BANNER", listener: (message: string) => void): this;
+
+        /** (Server-only) */ on(event: "SERVICE_REQUEST", listener: (serviceName: string) => void): this;
+        /** (Server-only) */ on(event: "USERAUTH_REQUEST", listener: (username: string, serviceName: string, authMethod: string, authMethodData: AuthMethodData) => void): this;
+        /** (Server-only) */ on(event: "USERAUTH_INFO_RESPONSE", listener: (responses: string[]) => void): this;
+
+        on(event: "end", listener: () => void): this;
+        on(event: "close", listener: () => void): this;
+        on(event: "drain", listener: () => void): this;
+        on(event: "error", listener: (err: any) => void): this;
+        on(event: "finish", listener: () => void): this;
+        on(event: "pipe", listener: (src: stream.Readable) => void): this;
+        on(event: "unpipe", listener: (src: stream.Readable) => void): this;
+        on(event: "data", listener: (chunk: string | Buffer) => void): this;
+        on(event: "readable", listener: () => void): this;
+        on(event: "continue", listener: () => void): this;
+        on(event: "ready", listener: () => void): this;
+        on(event: string | symbol, listener: Function): this;
+    }
+
+    export interface SSH2StreamConfig {
+        /**
+         * Set to true to create an instance in server mode.
+         */
+        server?: boolean;
+
+        /**
+         * If in server mode, an object keyed on host key format.
+         */
+        hostKeys?: HostKeys;
+
+        /**
+         * A message that is sent to clients immediately upon connection, before handshaking begins.
+         */
+        banner?: string;
+
+        /**
+         * A custom server software name/version identifier.
+         * @default 'ssh2js' + moduleVersion + 'srv'
+         */
+        ident?: string;
+
+        /**
+         * This is the maximum packet size that will be accepted. It should be 35000 bytes or larger to be compatible with other SSH2 implementations.
+         * @default 35000
+         */
+        maxPacketSize?: number;
+
+        /**
+         * This is the highWaterMark to use for the parser stream.
+         * @default 32 * 1024
+         */
+        highWaterMark?: number;
+
+        /**
+         * This option allows you to explicitly override the default transport layer algorithms used for the connection. Each value must be an array of valid algorithms for that category. The order of the algorithms in the arrays are important, with the most favorable being first.
+         */
+        algorithms?: Algorithms;
+
+        /**
+         * Set this to a function that receives a single string argument to get detailed (local) debug information.
+         */
+        debug?: (information: string) => any;
+    }
+
+    export interface HostKeys {
+        [format: string]: HostKey;
+    }
+
+    export interface HostKey {
+        privatekey: ParsedKey;
+        publickey: ParsedKey;
+    }
+
+    /**
+     * Overrides for the default transport layer algorithms used for the connection.
+     *
+     * The order of the algorithms in the arrays are important, with the most favorable being first.
+     */
+    export interface Algorithms {
+        kex?: string[];
+        cipher?: string[];
+        serverHostKey?: string[];
+        hmac?: string[];
+        compress?: string[];
+    }
+
+    export interface Header {
+        /**
+         * (Client-only) An optional greeting message presented by the server.
+         */
+        greeting?: string;
+
+        /**
+         * The raw identification string sent by the remote party.
+         */
+        identRaw: string;
+
+        /**
+         * Contains various version information parsed from identRaw.
+         */
+        versions: Versions;
+
+        /**
+         * Any text that comes after the software name/version.
+         */
+        comments: string;
+    }
+
+    export interface Versions {
+        /**
+         * The SSH protocol version supported by the remote party.
+         */
+        protocol: string;
+
+        /**
+         * The software name and version used by the remote party.
+         */
+        software: string;
+    }
+
+    export interface TcpipForwardGlobalRequest {
+        /**
+         * The IP address to start/stop binding to.
+         */
+        bindAddr: string;
+
+        /**
+         * The port to start/stop binding to.
+         */
+        bindPort: number;
+    }
+
+    export interface openssh_StreamLocalForwardGlobalRequest {
+        socketPath: string;
+    }
+
+    export type GlobalRequest = TcpipForwardGlobalRequest | openssh_StreamLocalForwardGlobalRequest | Buffer;
+
+    export interface ChannelOpenConfirmationInfo {
+        recipient: number;
+        sender: number;
+        window: number;
+        packetSize: number;
+    }
+
+    export interface ChannelOpenFailureInfo {
+        recipient: number;
+        reasonCode: number;
+        reason: string;
+        description: string;
+    }
+
+    export interface X11ChannelInfo {
+        type: "x11";
+        sender: number;
+        window: number;
+        packetSize: number;
+        data: X11ChannelData;
+    }
+
+    export interface X11ChannelData {
+        srcIP: string;
+        srcPort: number;
+    }
+
+    export interface ForwardedTcpipChannelInfo {
+        type: "forwarded-tcpip";
+        sender: number;
+        window: number;
+        packetSize: number;
+        data: TcpipChannelData;
+    }
+
+    export interface DirectTcpipChannelInfo {
+        type: "direct-tcpip";
+        sender: number;
+        window: number;
+        packetSize: number;
+        data: TcpipChannelData;
+    }
+
+    export interface TcpipChannelData {
+        srcIP: string;
+        srcPort: number;
+        destIP: string;
+        destPort: number;
+    }
+
+    export interface openssh_ForwardedStreamLocalChannelInfo {
+        type: "forwarded-streamlocal@openssh.com";
+        sender: number;
+        window: number;
+        packetSize: number;
+        data: SocketChannelData;
+    }
+
+    export interface openssh_DirectStreamLocalChannelInfo {
+        type: "direct-streamlocal@openssh.com";
+        sender: number;
+        window: number;
+        packetSize: number;
+        data: SocketChannelData;
+    }
+
+    export interface SocketChannelData {
+        socketPath: string;
+    }
+
+    export interface openssh_AuthAgentChannelInfo {
+        type: "auth-agent@openssh.com";
+        sender: number;
+        window: number;
+        packetSize: number;
+    }
+
+    export interface SessionChannelInfo {
+        type: "session";
+        sender: number;
+        window: number;
+        packetSize: number;
+    }
+
+    export type ChannelOpenInfo = X11ChannelInfo | ForwardedTcpipChannelInfo | openssh_ForwardedStreamLocalChannelInfo | openssh_AuthAgentChannelInfo | DirectTcpipChannelInfo | openssh_DirectStreamLocalChannelInfo | SessionChannelInfo;
+
+    export interface ExitStatusChannelRequest {
+        request: "exit-status";
+        recipient: number;
+        code: number;
+    }
+
+    export interface ExitSignalChannelRequest {
+        request: "exit-signal";
+        recipient: number;
+        signal: string;
+        coredump: boolean;
+        description: string;
+    }
+
+    export interface PseudoTtyChannelRequest {
+        request: "pty-req";
+        recipient: number;
+        wantReply: boolean;
+        term: string;
+        cols: number;
+        rows: number;
+        width: number;
+        height: number;
+        modes: any;
+    }
+
+    export interface WindowChangeChannelRequest {
+        request: "window-change";
+        recipient: number;
+        cols: number;
+        rows: number;
+        width: number;
+        height: number;
+    }
+
+    export interface X11ChannelRequest {
+        request: "x11-req";
+        recipient: number;
+        wantReply: boolean;
+        single: boolean;
+        protocol: string;
+        cookie: string;
+        screen: number;
+    }
+
+    export interface EnvChannelRequest {
+        request: "env";
+        recipient: number;
+        wantReply: boolean;
+        key: string;
+        val: string;
+    }
+
+    export interface ShellChannelRequest {
+        request: "shell";
+        recipient: number;
+        wantReply: boolean;
+    }
+
+    export interface ExecChannelRequest {
+        request: "exec";
+        recipient: number;
+        wantReply: boolean;
+        command: string;
+    }
+
+    export interface SubsystemChannelRequest {
+        request: "subsystem";
+        recipient: number;
+        wantReply: boolean;
+        subsystem: string;
+    }
+
+    export interface SignalChannelRequest {
+        request: "signal";
+        recipient: number;
+        signal: string;
+    }
+
+    export interface FlowControlChannelRequest {
+        request: "xon-xoff";
+        recipient: number;
+        clientControl: boolean;
+    }
+
+    export interface openssh_AuthAgentChannelRequest {
+        request: "auth-agent-req@openssh.com";
+        recipient: number;
+    }
+
+    export type ChannelRequest = ExitStatusChannelRequest | ExitSignalChannelRequest | PseudoTtyChannelRequest | WindowChangeChannelRequest | X11ChannelRequest | EnvChannelRequest | ShellChannelRequest | ExecChannelRequest | SubsystemChannelRequest | SignalChannelRequest | FlowControlChannelRequest;
+
+    export interface PublicKeyAuthMethodData {
+        keyAlgo: string;
+        key: Buffer;
+        signature?: Buffer;
+        blob?: Buffer;
+    }
+
+    export interface HostbasedAuthMethodData {
+        keyAlgo: string;
+        key: Buffer;
+        signature?: Buffer;
+        blob?: Buffer;
+        localHostname: string;
+        localUsername: string;
+    }
+
+    export type AuthMethodData = string | PublicKeyAuthMethodData | HostbasedAuthMethodData;
+
+    export interface TcpipForwardingConfig {
+        /**
+         * Source IP address of outgoing connection.
+         */
+        srcIP: string;
+
+        /**
+         * Source port of outgoing connection.
+         */
+        srcPort: number;
+
+        /**
+         * Destination IP address of outgoing connection.
+         */
+        destIP: string;
+
+        /**
+         * Destination port of outgoing connection.
+         */
+        destPort: number;
+    }
+
+    export interface X11ForwardingConfig {
+        /**
+         * true if only a single connection should be forwarded.
+         */
+        single: boolean;
+
+        /**
+         * The name of the X11 authentication method used (e.g. MIT-MAGIC-COOKIE-1).
+         */
+        protocol: string;
+
+        /**
+         * The X11 authentication cookie encoded in hexadecimal.
+         */
+        cookie: string;
+
+        /**
+         * The screen number to forward X11 connections for.
+         */
+        screen: number;
+    }
+
+    export interface SocketForwardingConfig {
+        socketPath: string;
+    }
+
+    export interface Prompt {
+        prompt: string;
+        echo?: boolean;
+    }
+
+    export interface ForwardedTcpip {
+        bindAddr: string;
+        bindPort: number;
+        remoteAddr: string;
+        remotePort: number;
+    }
+
+    export interface ForwardedX11 {
+        originAddr: string;
+        originPort: number;
+    }
+
+    export interface ForwardedSocket {
+        socketPath: string;
+    }
+
+    export class SFTPStream extends stream.Transform {
+        /**
+         * Creates and returns a new SFTPStream instance.
+         */
+        constructor(remoteIdentRaw: string);
+
+        /**
+         * Creates and returns a new SFTPStream instance.
+         */
+        constructor(cfg?: SFTPStreamConfig, remoteIdentRaw?: string);
+
+        /**
+         * Converts string flags (e.g. `'r'`, `'a+'`, etc.) to the appropriate
+         * `SFTPStream.OPEN_MODE` flag mask.
+         *
+         * Returns `null` if conversion failed.
+         */
+        static stringToFlags(flagsStr: string): number;
+
+        /**
+         * Converts flag mask (e.g. number containing `SFTPStream.OPEN_MODE` values) to the
+         * appropriate string value.
+         *
+         * Returns `null` if conversion failed.
+         */
+        static flagsToString(flagsMask: number): string;
+
+        /**
+         * (Client-only)
+         * Downloads a file at `remotePath` to `localPath` using parallel reads for faster throughput.
+         */
+        fastGet(remotePath: string, localPath: string, options: TransferOptions, callback: (err: any) => void): void;
+
+        /**
+         * (Client-only)
+         * Downloads a file at `remotePath` to `localPath` using parallel reads for faster throughput.
+         */
+        fastGet(remotePath: string, localPath: string, callback: (err: any) => void): void;
+
+        /**
+         * (Client-only)
+         * Uploads a file from `localPath` to `remotePath` using parallel reads for faster throughput.
+         */
+        fastPut(localPath: string, remotePath: string, options: TransferOptions, callback: (err: any) => void): void;
+
+        /**
+         * (Client-only)
+         * Uploads a file from `localPath` to `remotePath` using parallel reads for faster throughput.
+         */
+        fastPut(localPath: string, remotePath: string, callback: (err: any) => void): void;
+
+        /**
+         * (Client-only)
+         * Returns a new readable stream for `path`.
+         */
+        createReadStream(path: string, options?: ReadStreamOptions): stream.Readable;
+
+        /**
+         * (Client-only)
+         * Returns a new writable stream for `path`.
+         */
+        createWriteStream(path: string, options?: WriteStreamOptions): stream.Writable;
+
+        /**
+         * (Client-only)
+         * Opens a file `filename` for `mode` with optional `attributes`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        open(filename: string, mode: string, attributes: InputAttributes, callback: (err: any, handle: Buffer) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Opens a file `filename` for `mode`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        open(filename: string, mode: string, callback: (err: any, handle: Buffer) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Closes the resource associated with `handle` given by `open()` or `opendir()`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        close(handle: Buffer, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Reads `length` bytes from the resource associated with `handle` starting at `position`
+         * and stores the bytes in `buffer` starting at `offset`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        readData(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number, callback: (err: any, bytesRead: number, buffer: Buffer, position: number) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        writeData(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Retrieves attributes for the resource associated with `handle`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        fstat(handle: Buffer, callback: (err: any, stats: Stats) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Sets the attributes defined in `attributes` for the resource associated with `handle`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        fsetstat(handle: Buffer, attributes: InputAttributes, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Sets the access time and modified time for the resource associated with `handle`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        futimes(handle: Buffer, atime: number | Date, mtime: number | Date, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Sets the owner for the resource associated with `handle`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        fchown(handle: Buffer, uid: number, gid: number, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Sets the mode for the resource associated with `handle`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        fchmod(handle: Buffer, mode: number | string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Opens a directory `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        opendir(path: string, callback: (err: any, handle: Buffer) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Retrieves a directory listing.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        readdir(location: string | Buffer, callback: (err: any, list: FileEntry[]) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Removes the file/symlink at `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        unlink(path: string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Renames/moves `srcPath` to `destPath`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        rename(srcPath: string, destPath: string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Creates a new directory `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        mkdir(path: string, attributes: InputAttributes, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Creates a new directory `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        mkdir(path: string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Removes the directory at `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        rmdir(path: string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Retrieves attributes for `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        stat(path: string, callback: (err: any, stats: Stats) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Retrieves attributes for `path`. If `path` is a symlink, the link itself is stat'ed
+         * instead of the resource it refers to.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        lstat(path: string, callback: (err: any, stats: Stats) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Sets the attributes defined in `attributes` for `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        setstat(path: string, attributes: InputAttributes, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Sets the access time and modified time for `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        utimes(path: string, atime: number | Date, mtime: number | Date, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Sets the owner for `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        chown(path: string, uid: number, gid: number, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Sets the mode for `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        chmod(path: string, mode: number | string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Retrieves the target for a symlink at `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        readlink(path: string, callback: (err: any, target: string) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Creates a symlink at `linkPath` to `targetPath`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        symlink(targetPath: string, linkPath: string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Resolves `path` to an absolute path.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        realpath(path: string, callback: (err: any, absPath: string) => void): boolean;
+
+        /**
+         * (Client-only, OpenSSH extension)
+         * Performs POSIX rename(3) from `srcPath` to `destPath`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        ext_openssh_rename(srcPath: string, destPath: string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only, OpenSSH extension)
+         * Performs POSIX statvfs(2) on `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        ext_openssh_statvfs(path: string, callback: (err: any, fsInfo: any) => void): boolean;
+
+        /**
+         * (Client-only, OpenSSH extension)
+         * Performs POSIX fstatvfs(2) on open handle `handle`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        ext_openssh_fstatvfs(handle: Buffer, callback: (err: any, fsInfo: any) => void): boolean;
+
+        /**
+         * (Client-only, OpenSSH extension)
+         * Performs POSIX link(2) to create a hard link to `targetPath` at `linkPath`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        ext_openssh_hardlink(targetPath: string, linkPath: string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only, OpenSSH extension)
+         * Performs POSIX fsync(3) on the open handle `handle`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        ext_openssh_fsync(handle: Buffer, callback: (err: any, fsInfo: any) => void): boolean;
+
+        /**
+         * (Server-only)
+         * Sends a status response for the request identified by `id`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        status(reqID: number, statusCode: number, message?: string): boolean;
+
+        /**
+         * (Server-only)
+         * Sends a handle response for the request identified by `id`.
+         *
+         * @param handle A handle must be less than 256 bytes and is an opaque value that could
+         *          merely contain the value of a backing file descriptor or some other unique,
+         *          custom value.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        handle(reqID: number, handle: Buffer): boolean;
+
+        /**
+         * (Server-only)
+         * Sends a data response for the request identified by `id`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        data(reqID: number, data: string | Buffer, encoding?: string): boolean;
+
+        /**
+         * (Server-only)
+         * Sends a name response for the request identified by `id`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        name(reqID: number, names: FileEntry[]): boolean;
+
+        /**
+         * (Server-only)
+         * Sends an attrs response for the request identified by `id`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        attrs(reqID: number, attrs: Attributes): boolean;
+
+        /**
+         * (Client/Server)
+         * Emitted after initial protocol version check has passed.
+         */
+        on(event: "ready", listener: () => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests to open a file.
+         *
+         * Respond with:
+         * * `handle()` - This indicates a successful opening of the file and passes the given handle back to the client to use to refer to this open file for future operations (e.g. reading, writing, closing).
+         * * `status()` - Use this to indicate a failure to open the requested file.
+         */
+        on(event: "OPEN", listener: (reqID: number, filename: string, flags: number, attrs: InputAttributes) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests to read data from a file handle.
+         *
+         * Respond with:
+         * * `data()` - Use this to send the requested chunk of data back to the client. The amount of data sent is allowed to be less than the `length` requested.
+         * * `status()` - Use this to indicate either end of file (`STATUS_CODE.EOF`) has been reached (`offset` is past the end of the file) or if an error occurred while reading the requested part of the file.
+         */
+        on(event: "READ", listener: (reqID: number, handle: Buffer, offset: number, length: number) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests to write data to a file handle.
+         *
+         * Respond with:
+         * * `status()` - Use this to indicate success/failure of the write to the file.
+         */
+        on(event: "WRITE", listener: (reqID: number, handle: Buffer, offset: number, data: Buffer) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests attributes for the resource associated with `handle`.
+         *
+         * Respond with:
+         * * `attrs()` - Use this to send the attributes for the requested file/directory back to the client.
+         * * `status()` - Use this to indicate an error occurred while accessing the file/directory.
+         */
+        on(event: "FSTAT", listener: (reqID: number, handle: Buffer) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests to write attributes for the resource associated with `handle`.
+         *
+         * Respond with:
+         * * `status()` - Use this to indicates success/failure of the setting of the given file/directory attributes.
+         */
+        on(event: "FSETSTAT", listener: (reqID: number, handle: Buffer, attrs: InputAttributes) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests to close a handle.
+         *
+         * Respond with:
+         * * `status()` - Use this to indicate success (`STATUS_CODE.OK`) or failure of the closing of the file identified by `handle`.
+         */
+        on(event: "CLOSE", listener: (reqID: number, handle: Buffer) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests to open a directory.
+         *
+         * Respond with:
+         * * `handle()` - This indicates a successful opening of the directory and passes the given handle back to the client to use to refer to this open directory for future operations (e.g. reading directory contents, closing).
+         * * `status()` - Use this to indicate a failure to open the requested directory.
+         */
+        on(event: "OPENDIR", listener: (reqID: number, path: string) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests to read the contents of a directory.
+         *
+         * Respond with:
+         * * `name()` - Use this to send one or more directory listings for the open directory back to the client.
+         * * `status()` - Use this to indicate either end of directory contents (`STATUS_CODE.EOF`) or if an error occurred while reading the directory contents.
+         */
+        on(event: "READDIR", listener: (reqID: number, handle: Buffer) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests attributes for a path. If `path` is a symlink, the
+         * link itself should stat'ed instead of the resource it refers to.
+         *
+         * Respond with:
+         * * `attrs()` - Use this to send the attributes for the requested file/directory back to the client.
+         * * `status()` - Use this to indicate an error occurred while accessing the file/directory.
+         */
+        on(event: "LSTAT", listener: (reqID: number, path: string) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests attributes for a path.
+         *
+         * Respond with:
+         * * `attrs()` - Use this to send the attributes for the requested file/directory back to the client.
+         * * `status()` - Use this to indicate an error occurred while accessing the file/directory.
+         */
+        on(event: "STAT", listener: (reqID: number, path: string) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests to delete a file or symlink.
+         *
+         * Respond with:
+         * * `status()` - Use this to indicate success/failure of the removal of the file at `path`.
+         */
+        on(event: "REMOVE", listener: (reqID: number, path: string) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests to remove a directory.
+         *
+         * Respond with:
+         * * `status()` - Use this to indicate success/failure of the removal of the directory at `path`.
+         */
+        on(event: "RMDIR", listener: (reqID: number, path: string) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests the absolute path for a path.
+         *
+         * Respond with:
+         * * `name()` - Use this to respond with a normalized version of `path`. No file/directory attributes are required to be sent in this response.
+         * * `status()` - Use this to indicate a failure in normalizing `path`.
+         */
+        on(event: "REALPATH", listener: (reqID: number, path: string) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests the target for a symlink at `path`.
+         *
+         * Respond with:
+         * * `name()` - Use this to respond with the target of the symlink at `path`. No file/directory attributes are required to be sent in this response.
+         * * `status()` - Use this to indicate a failure in reading the symlink at `path`.
+         */
+        on(event: "READLINK", listener: (reqID: number, path: string) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests to set the attributes defined in `attrs` for `path`.
+         *
+         * Respond with:
+         * * `status()` - Use this to indicates success/failure of the setting of the given file/directory attributes.
+         */
+        on(event: "SETSTAT", listener: (reqID: number, path: string, attrs: InputAttributes) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests a new directory be created.
+         *
+         * Respond with:
+         * * `status()` - Use this to indicate success/failure of the creation of the directory at `path`.
+         */
+        on(event: "MKDIR", listener: (reqID: number, path: string, attrs: InputAttributes) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests a path be renamed.
+         *
+         * Respond with:
+         * * `status()` - Use this to indicate success/failure of the renaming of the file/directory at `oldPath` to `newPath`.
+         */
+        on(event: "RENAME", listener: (reqID: number, oldPath: string, newPath: string) => void): this;
+
+        /**
+         * (Server-only)
+         * Emitted when the client requests a new symlink be created for a path.
+         *
+         * Respond with:
+         * * `status()` - Use this to indicate success/failure of the symlink creation.
+         */
+        on(event: "SYMLINK", listener: (reqID: number, linkPath: string, targetPath: string) => void): this;
+
+        /**
+         * Emitted when the socket has disconnected.
+         */
+        on(event: "end", listener: () => void): this;
+
+        /**
+         * Emitted when the client socket was closed.
+         */
+        on(event: "close", listener: () => void): this;
+
+        /**
+         * Emitted when more requests/data can be sent to the stream.
+         */
+        on(event: "continue", listener: () => void): this;
+
+        /**
+         * Emitted when an error occurred.
+         */
+        on(event: "error", listener: (err: any) => void): this;
+
+        on(event: string | symbol, listener: Function): this;
+    }
+
+    export namespace SFTPStream {
+        /**
+         * Contains the various status codes (for use especially with SFTPStream#status())
+         */
+        export enum STATUS_CODE {
+            OK = 0,
+            EOF = 1,
+            NO_SUCH_FILE = 2,
+            PERMISSION_DENIED = 3,
+            FAILURE = 4,
+            BAD_MESSAGE = 5,
+            NO_CONNECTION = 6,
+            CONNECTION_LOST = 7,
+            OP_UNSUPPORTED = 8
+        }
+
+        /**
+         * Contains the various open file flags
+         */
+        export enum OPEN_MODE {
+            READ = 0x00000001,
+            WRITE = 0x00000002,
+            APPEND = 0x00000004,
+            CREAT = 0x00000008,
+            TRUNC = 0x00000010,
+            EXCL = 0x00000020
+        }
+    }
+
+    export interface SFTPStreamConfig {
+        /**
+         * Set to true to create an instance in server mode.
+         */
+        server?: boolean;
+
+        /**
+         * This is the highWaterMark to use for the stream.
+         */
+        highWaterMark?: number;
+
+        /**
+         * Set this to a function that receives a single string argument to get detailed (local) debug information.
+         */
+        debug?: (information: string) => any;
+    }
+
+    export interface TransferOptions {
+        /**
+         * Number of concurrent reads
+         */
+        concurrency?: number;
+
+        /**
+         * Size of each read in bytes
+         */
+        chunkSize?: number;
+
+        /**
+         * Called every time a part of a file was transferred
+         */
+        step?: (total_transferred: number, chunk: number, total: number) => void;
+    }
+
+    export interface ReadStreamOptions {
+        flags?: string;
+        encoding?: string;
+        handle?: Buffer;
+        mode?: number;
+        autoClose?: boolean;
+        start?: number;
+        end?: number;
+    }
+
+    export interface WriteStreamOptions {
+        flags?: string;
+        encoding?: string;
+        mode?: number;
+    }
+
+    export interface FileEntry {
+        filename: string;
+        longname: string;
+        attrs: Attributes;
+    }
+
+    export interface InputAttributes {
+        mode?: number | string;
+        uid?: number;
+        gid?: number;
+        size?: number;
+        atime?: number | Date;
+        mtime?: number | Date;
+    }
+
+    export interface Attributes {
+        mode: number;
+        uid: number;
+        gid: number;
+        size: number;
+        atime: number;
+        mtime: number;
+    }
+
+    export interface Stats extends Attributes {
+        isDirectory(): boolean;
+        isFile(): boolean;
+        isBlockDevice(): boolean;
+        isCharacterDevice(): boolean;
+        isSymbolicLink(): boolean;
+        isFIFO(): boolean;
+        isSocket(): boolean;
+    }
+
+    export namespace utils {
+        export function parseKey(keyData: string | Buffer): ParsedKey | Error;
+        export function genPublicKey(privKeyInfo: ParsedKey): ParsedKey;
+        export function decryptKey(privKeyInfo: ParsedKey, passphrase: string): void;
+    }
+
+    export interface ParsedKey {
+        fulltype: string;
+        type: string;
+        extra: string;
+        comment: string;
+        encryption: string;
+        private: Buffer;
+        privateOrig: Buffer;
+        public: Buffer;
+        publicOrig: Buffer;
+        ppk?: boolean;
+        privateMAC?: string;
+    }
+}

--- a/ssh2-streams/ssh2-streams-tests.ts
+++ b/ssh2-streams/ssh2-streams-tests.ts
@@ -1,0 +1,104 @@
+import * as stream from "stream";
+import * as ssh2 from "ssh2-streams";
+
+declare const SERVER_KEY: string;
+declare const HOST_KEYS: { 'ssh-rsa': ssh2.HostKey };
+declare const clientBufStream: stream.Transform & { buffer: string; };
+declare const serverBufStream: stream.Transform & { buffer: string; };
+declare const parsedKey: ssh2.ParsedKey;
+declare const prompts: ssh2.Prompt[];
+declare const buffer: Buffer;
+
+const algos = ['ssh-dss', 'ssh-rsa', 'ecdsa-sha2-nistp521'];
+const client = new ssh2.SSH2Stream({ algorithms: { serverHostKey: algos } });
+const server = new ssh2.SSH2Stream({ server: true, hostKeys: HOST_KEYS });
+
+client
+    .pipe(server)
+    .pipe(client);
+
+client
+    .on("error", (err: Error) => {})
+    .on("ready", () => {})
+    .on("header", (header: ssh2.Header) => {})
+    .on("fingerprint", (hostKey: Buffer, callback: (success: boolean) => void) => {})
+    .on("USERAUTH_BANNER", (message: string) => {})
+    .on("USERAUTH_SUCCESS", () => {})
+    .on("USERAUTH_FAILURE", (authsLeft: string[], partial: boolean) => {})
+    .on("USERAUTH_PK_OK", () => {})
+    .on("USERAUTH_INFO_REQUEST", (name: string, instructions: string, lang: string, prompts: ssh2.Prompt[]) => {})
+    .on("CHANNEL_OPEN", (info: ssh2.ChannelOpenInfo) => {})
+    .on("SERVICE_ACCEPT", (serviceName: string) => {})
+    .on("REQUEST_SUCCESS", (resData?: Buffer) => {})
+    .on("REQUEST_FAILURE", () => {})
+    .on("GLOBAL_REQUEST", (reqName: string, wantReply: boolean, reqData: ssh2.TcpipForwardGlobalRequest | ssh2.openssh_StreamLocalForwardGlobalRequest) => {});
+
+client.ping();
+client.authPassword("username", "password");
+client.authPK("username", parsedKey);
+client.authHostBased("username", parsedKey, "localHostname", "localUsername");
+client.authKeyboard("username");
+client.authNone("username");
+client.authInfoRes();
+client.authInfoRes(["answer"]);
+client.service("ssh-userauth");
+client.requestFailure();
+client.disconnect();
+client.tcpipForward("bindAddr", 8080);
+client.cancelTcpipForward("bindAddr", 8080);
+client.openssh_noMoreSessions();
+client.openssh_streamLocalForward("socketPath");
+client.openssh_cancelStreamLocalForward("socketPath");
+client.session(0, 0, 0);
+client.directTcpip(0, 0, 0, { srcIP: "srcIP", srcPort: 0, destIP: "destIP", destPort: 0 });
+client.openssh_directStreamLocal(0, 0, 0, { socketPath: "socketPath" });
+client.x11Forward(0, { single: true, cookie: "cookie", protocol: "protocol", screen: 0 });
+client.pty(0, 0, 0, 0, 0, "term", null);
+client.openssh_agentForward(0);
+client.shell(0);
+client.exec(0, "command");
+client.env(0, "key", "value");
+client.subsystem(0, "name");
+client.channelOpenConfirm(0, 0, 0, 0);
+client.channelOpenFail(0, 0, "desc", "lang");
+
+server
+    .on("SERVICE_REQUEST", (serviceName: string) => {})
+    .on("USERAUTH_REQUEST", (username: string, serviceName: string, authmethod: string, authMethodData: string | ssh2.PublicKeyAuthMethodData | ssh2.HostbasedAuthMethodData) => {})
+    .on("USERAUTH_INFO_RESPONSE", (responses: string[]) => {})
+
+server.disconnect(0);
+server.authSuccess();
+server.authFailure(["authMethods"], false);
+server.requestSuccess();
+server.requestFailure();
+server.rekey();
+server.channelSuccess(0);
+server.channelFailure(0);
+server.channelEOF(0);
+server.channelClose(0);
+server.channelWindowAdjust(0, 0);
+server.channelData(0, "data");
+server.channelExtData(0, "data", 0);
+server.authInfoReq("name", "instructions", prompts);
+server.authPKOK("keyAlgorithm", buffer);
+server.forwardedTcpip(0, 0, 0, { bindAddr: "bindAddr", bindPort: 8080, remoteAddr: "remoteAddr", remotePort: 8080 });
+server.x11(0, 0, 0, { originAddr: "originAddr", originPort: 0 });
+server.openssh_forwardedStreamLocal(0, 0, 0, { socketPath: "socketPath" });
+
+const maybeParsedKey = ssh2.utils.parseKey("keyData");
+ssh2.utils.decryptKey(parsedKey, "passphrase");
+const publicKey = ssh2.utils.genPublicKey(parsedKey);
+
+
+declare const attrs: ssh2.Attributes;
+const sftp = new ssh2.SFTPStream();
+sftp.attrs(0, attrs);
+sftp.chmod("path", 0, () => {});
+sftp.chown("path", 0, 0, () => {});
+sftp.close(buffer, () => {});
+sftp.createReadStream("path");
+sftp.createWriteStream("path");
+sftp.data(0, buffer);
+sftp.fastGet("remotePath", "localPath", () => {});
+sftp.fastPut("localPath", "remotePath", () => {});

--- a/ssh2-streams/tsconfig.json
+++ b/ssh2-streams/tsconfig.json
@@ -13,6 +13,6 @@
     },
     "files": [
         "index.d.ts",
-        "ssh2-tests.ts"
+        "ssh2-streams-tests.ts"
     ]
 }

--- a/ssh2/index.d.ts
+++ b/ssh2/index.d.ts
@@ -1,428 +1,1560 @@
-// Type definitions for ssh2
+// Type definitions for ssh2 v0.5.x
 // Project: https://github.com/mscdex/ssh2
-// Definitions by: Qubo <https://github.com/tkQubo>
+// Definitions by: Qubo <https://github.com/tkQubo>, Ron Buckton <https://github.com/rbuckton>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
+declare module "ssh2" {
+    import * as stream from "stream";
+    import * as events from "events";
+    import * as net from "net";
 
-import stream = require('stream');
+    import {
+        utils,
+        Algorithms,
+        Header,
+        Prompt,
+        SFTPStream,
+        InputAttributes,
+        Attributes,
+        Stats,
+        TransferOptions,
+        ReadStreamOptions,
+        WriteStreamOptions,
+        FileEntry
+    } from "ssh2-streams";
 
-declare namespace ssh2 {
-    interface Client extends NodeJS.EventEmitter {
-        Server: ServerStatic;
-        new (): Client;
-        /**
-         * SFTPStream.STATUS_CODE from ssh2-streams.
-         */
-        SFTP_STATUS_CODE: Sftp.StatusCode;
-        /**
-         * SFTPStream.OPEN_MODE from ssh2-streams.
-         */
-        SFTP_OPEN_MODE: Sftp.OpenMode;
-        //TODO: Type ssh2-streams
-        /**
-         * utility methods from ssh2-streams.
-         */
-        utils: Utils;
+    export import SFTP_STATUS_CODE = SFTPStream.STATUS_CODE;
+    export import SFTP_OPEN_MODE = SFTPStream.OPEN_MODE;
 
-        connect(config: ConnectConfig): void;
-        end(): void;
+    export { utils };
+
+    export interface Channel extends stream.Duplex {
+        /** If `true` only sends `EOF` when `end()` is called. */
+        allowHalfOpen: boolean;
+        /** Standard input for the Channel. */
+        stdin: this;
+        /** Standard output for the Channel. */
+        stdout: this;
+        /** Standard error for the Channel. */
+        stderr: stream.Readable | stream.Writable;
+        /** Indicates whether this is a server or client channel. */
+        server: boolean;
+        /** The channel type, usually "session". */
+        type: string | undefined;
+        /** The channel subtype, usually "exec", "shell", or undefined. */
+        subtype: string | undefined;
+
+        /**
+         * Sends EOF to the remote side.
+         *
+         * Returns false if you should wait for the continue event before sending any more traffic.
+         */
+        eof(): boolean;
+
+        /**
+         * Closes the channel on both sides.
+         *
+         * Returns false if you should wait for the continue event before sending any more traffic.
+         */
+        close(): boolean;
+
+        /**
+         * Shuts down the channel on this side.
+         */
         destroy(): void;
-        exec(command: string, options: ExecOption, callback: ChannelCallback): boolean;
-        exec(command: string, callback: ChannelCallback): boolean;
-        shell(window: boolean | PseudoTtySettings, options: boolean | number | X11Settings, callback: ChannelCallback): boolean;
-        shell(window: boolean | PseudoTtySettings, callback: ChannelCallback): boolean;
-        shell(callback: ChannelCallback): boolean;
-        subsys(subsystem: string, callback: ChannelCallback): boolean;
-        sftp(callback: SftpCallback): boolean;
-        forwardIn(bindAddr: string, bindPort: number, callback?: ForwardInCallback): boolean;
-        unforwardIn(bindAddr: string, bindPort: number, callback?: ErrorCallback): boolean;
-        forwardOut(srcIP: string, srcPort: number, dstIP: string, dstPort: number, callback: ChannelCallback): boolean;
-        openssh_noMoreSessions(callback?: ErrorCallback): boolean;
-        openssh_forwardInStreamLocal(socketPath: string, callback?: ErrorCallback): boolean;
-        openssh_unforwardInStreamLocal(socketPath: string, callback?: ErrorCallback): boolean;
-        openssh_forwardOutStreamLocal(socketPath: string, callback?: ChannelCallback): boolean;
     }
 
-    interface ConnectConfig {
+    export interface ClientChannel extends Channel {
+        /** Standard error for the Channel. */
+        stderr: stream.Readable;
+        /** Indicates whether this is a server or client channel. */
+        server: false;
+
         /**
-         * @description Hostname or IP address of the server.
-         * @default 'localhost'
+         * Lets the server know that the local terminal window has been resized.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
          */
+        setWindow(rows: number, cols: number, height: number, width: number): boolean;
+
+        /**
+         * Sends a POSIX signal to the current process on the server. Valid signal names are:
+         * 'ABRT', 'ALRM', 'FPE', 'HUP', 'ILL', 'INT', 'KILL', 'PIPE', 'QUIT', 'SEGV', 'TERM',
+         * 'USR1', and 'USR2'.
+         *
+         * Some server implementations may ignore this request if they do not support signals.
+         *
+         * Note: If you are trying to send SIGINT and you find `signal()` doesn't work, try writing
+         * `'\x03'` to the Channel stream instead.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        signal(signalName: string): boolean;
+
+        /**
+         * Emitted once the channel is completely closed on both the client and the server.
+         */
+        on(event: "close", listener: () => void): this;
+
+        /**
+         * An `exit` event *may* (the SSH2 spec says it is optional) be emitted when the process
+         * finishes. If the process finished normally, the process's return value is passed to
+         * the `exit` callback.
+         */
+        on(event: "exit", listener: (exitCode: number | null, signalName?: string, didCoreDump?: boolean, description?: string) => void): this;
+
+        on(event: string | symbol, listener: Function): this;
+    }
+
+    export interface ServerChannel extends Channel {
+        /** Standard error for the Channel. */
+        stderr: stream.Writable;
+        /** Indicates whether this is a server or client channel. */
+        server: true;
+
+        /**
+         * Sends an exit status code to the client.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        exit(exitCode: number): boolean;
+
+        /**
+         * Sends an exit signal to the client.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        exit(name: string, coreDumped: boolean, msg: string): boolean;
+
+        /**
+         * Emitted once the channel is completely closed on both the client and the server.
+         */
+        on(event: "close", listener: () => void): this;
+
+        on(event: string | symbol, listener: Function): this;
+    }
+
+    export class Client extends events.EventEmitter {
+        // Client-events
+
+        /**
+         * Emitted when a notice was sent by the server upon connection.
+         */
+        on(event: "banner", listener: (message: string) => void): this;
+
+        /**
+         * Emitted when authentication was successful.
+         */
+        on(event: "ready", listener: () => void): this;
+
+        /**
+         * Emitted when an incoming forwarded TCP connection is being requested.
+         *
+         * Calling `accept()` accepts the connection and returns a `Channel` object.
+         * Calling `reject()` rejects the connection and no further action is needed.
+         */
+        on(event: "tcp connection", listener: (details: TcpConnectionDetails, accept: () => ClientChannel, reject: () => void) => void): this;
+
+        /**
+         * Emitted when an incoming X11 connection is being requested.
+         *
+         * Calling `accept()` accepts the connection and returns a `Channel` object.
+         * Calling `reject()` rejects the connection and no further action is needed.
+         */
+        on(event: "x11", listener: (details: X11Details, accept: () => ClientChannel, reject: () => void) => void): this;
+
+        /**
+         * Emitted when the server is asking for replies to the given `prompts` for keyboard-
+         * interactive user authentication.
+         *
+         * * `name` is generally what you'd use as a window title (for GUI apps).
+         * * `prompts` is an array of `Prompt` objects.
+         *
+         * The answers for all prompts must be provided as an array of strings and passed to
+         * `finish` when you are ready to continue.
+         *
+         * NOTE: It's possible for the server to come back and ask more questions.
+         */
+        on(event: "keyboard-interactive", listener: (name: string, instructions: string, lang: string, prompts: Prompt[], finish: (responses: string[]) => void) => void): this;
+
+        /**
+         * Emitted when the server has requested that the user's password be changed, if using
+         * password-based user authentication.
+         *
+         * Call `done` with the new password.
+         */
+        on(event: "change password", listener: (message: string, lang: string, done: (password: string) => void) => void): this;
+
+        /**
+         * Emitted when more requests/data can be sent to the server (after a `Client` method
+         * returned `false`).
+         */
+        on(event: "continue", listener: () => void): this;
+
+        /**
+         * Emitted when an error occurred.
+         */
+        on(event: "error", listener: (err: Error & ClientErrorExtensions) => void): this;
+
+        /**
+         * Emitted when the socket was disconnected.
+         */
+        on(event: "end", listener: () => void): this;
+
+        /**
+         * Emitted when the socket was closed.
+         */
+        on(event: "close", listener: (hadError: boolean) => void): this;
+
+        /**
+         * Emitted when the socket has timed out.
+         */
+        on(event: "timeout", listener: () => void): this;
+
+        /**
+         * Emitted when the socket has connected.
+         */
+        on(event: "connect", listener: () => void): this;
+
+        /**
+         * Emitted when the server responds with a greeting message.
+         */
+        on(event: "greeting", listener: (greeting: string) => void): this;
+
+        on(event: string | symbol, listener: Function): this;
+
+        // Client-methods
+
+        /**
+         * Creates and returns a new Client instance.
+         */
+        constructor();
+
+        /**
+         * Attempts a connection to a server.
+         */
+        connect(config: ConnectConfig): void;
+
+        /**
+         * Executes a command on the server.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         *
+         * @param command The command to execute.
+         * @param options Options for the command.
+         * @param callback The callback to execute when the command has completed.
+         */
+        exec(command: string, options: ExecOptions, callback: (err: Error, channel: ClientChannel) => void): boolean;
+
+        /**
+         * Executes a command on the server.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         *
+         * @param command The command to execute.
+         * @param callback The callback to execute when the command has completed.
+         */
+        exec(command: string, callback: (err: Error, channel: ClientChannel) => void): boolean;
+
+        /**
+         * Starts an interactive shell session on the server.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         *
+         * @param window Either an object containing containing pseudo-tty settings, `false` to suppress creation of a pseudo-tty.
+         * @param options Options for the command.
+         * @param callback The callback to execute when the channel has been created.
+         */
+        shell(window: PseudoTtyOptions | false, options: ShellOptions, callback: (err: Error, channel: ClientChannel) => void): boolean;
+
+        /**
+         * Starts an interactive shell session on the server.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         *
+         * @param window Either an object containing containing pseudo-tty settings, `false` to suppress creation of a pseudo-tty.
+         * @param callback The callback to execute when the channel has been created.
+         */
+        shell(window: PseudoTtyOptions | false, callback: (err: Error, channel: ClientChannel) => void): boolean;
+
+        /**
+         * Starts an interactive shell session on the server.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         *
+         * @param options Options for the command.
+         * @param callback The callback to execute when the channel has been created.
+         */
+        shell(options: ShellOptions, callback: (err: Error, channel: ClientChannel) => void): boolean;
+
+        /**
+         * Starts an interactive shell session on the server.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         *
+         * @param callback The callback to execute when the channel has been created.
+         */
+        shell(callback: (err: Error, channel: ClientChannel) => void): boolean;
+
+        /**
+         * Bind to `remoteAddr` on `remotePort` on the server and forward incoming TCP connections.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         *
+         * @param remoteAddr The remote address to bind on the server. The following lists several special values for `remoteAddr` and their respective bindings:
+         *
+         *   | address       | description
+         *   |:--------------|:-----------
+         *   | `''`          | Listen on all protocol families supported by the server
+         *   | `'0.0.0.0'`   | Listen on all IPv4 addresses
+         *   | `'::'`        | Listen on all IPv6 addresses
+         *   | `'localhost'` | Listen on the loopback interface for all protocol families
+         *   | `'127.0.0.1'` | Listen on the loopback interfaces for IPv4
+         *   | `'::1'`       | Listen on the loopback interfaces for IPv6
+         *
+         * @param remotePort The remote port to bind on the server. If this value is `0`, the actual bound port is provided to `callback`.
+         * @param callback An optional callback that is invoked when the remote address is bound.
+         */
+        forwardIn(remoteAddr: string, remotePort: number, callback?: (err: Error, bindPort: number) => void): boolean;
+
+        /**
+         * Unbind from `remoteAddr` on `remotePort` on the server and stop forwarding incoming TCP
+         * connections. Until `callback` is called, more connections may still come in.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         *
+         * @param remoteAddr The remote address to unbind on the server.
+         * @param remotePort The remote port to unbind on the server.
+         * @param callback An optional callback that is invoked when the remote address is unbound.
+         */
+        unforwardIn(remoteAddr: string, remotePort: number, callback?: (err: Error) => void): boolean;
+
+        /**
+         * Open a connection with `srcIP` and `srcPort` as the originating address and port and
+         * `dstIP` and `dstPort` as the remote destination address and port.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         *
+         * @param srcIP The originating address.
+         * @param srcPort The originating port.
+         * @param dstIP The destination address.
+         * @param dstPort The destination port.
+         * @param callback The callback that is invoked when the address is bound.
+         */
+        forwardOut(srcIP: string, srcPort: number, dstIP: string, dstPort: number, callback: (err: Error, channel: ClientChannel) => void): boolean;
+
+        /**
+         * Starts an SFTP session.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         *
+         * @param callback The callback that is invoked when the SFTP session has started.
+         */
+        sftp(callback: (err: Error, sftp: SFTPWrapper) => void): boolean;
+
+        /**
+         * Invokes `subsystem` on the server.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         *
+         * @param subsystem The subsystem to start on the server.
+         * @param callback The callback that is invoked when the subsystem has started.
+         */
+        subsys(subsystem: string, callback: (err: Error, channel: ClientChannel) => void): boolean;
+
+        /**
+         * Disconnects the socket.
+         */
+        end(): void;
+
+        /**
+         * Destroys the socket.
+         */
+        destroy(): void;
+
+        /**
+         * OpenSSH extension that sends a request to reject any new sessions (e.g. exec, shell,
+         * sftp, subsys) for this connection.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        openssh_noMoreSessions(callback?: (err: Error) => void): boolean;
+
+        /**
+         * OpenSSH extension that binds to a UNIX domain socket at `socketPath` on the server and
+         * forwards incoming connections.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        openssh_forwardInStreamLocal(socketPath: string, callback?: (err: Error) => void): boolean;
+
+        /**
+         * OpenSSH extension that unbinds from a UNIX domain socket at `socketPath` on the server
+         * and stops forwarding incoming connections.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        openssh_unforwardInStreamLocal(socketPath: string, callback?: (err: Error) => void): boolean;
+
+        /**
+         * OpenSSH extension that opens a connection to a UNIX domain socket at `socketPath` on
+         * the server.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        openssh_forwardOutStreamLocal(socketPath: string, callback?: (err: Error, channel: ClientChannel) => void): boolean;
+    }
+
+    export interface ConnectConfig {
+        /** Hostname or IP address of the server. */
         host?: string;
-        /**
-         * @description Port number of the server.
-         * @default 22
-         */
+        /** Port number of the server. */
         port?: number;
-        /**
-         * @description Only connect via resolved IPv4 address for `host`.
-         * @default false
-         */
+        /** Only connect via resolved IPv4 address for `host`. */
         forceIPv4?: boolean;
-        /**
-         * @description Only connect via resolved IPv6 address for `host`.
-         * @default false
-         */
+        /** Only connect via resolved IPv6 address for `host`. */
         forceIPv6?: boolean;
-        /**
-         * @description 'md5' or 'sha1'. The host's key is hashed using this method and passed to the **hostVerifier** function.
-         * @default (none)
-         */
-        hostHash?: string;
-        /**
-         * @description Function that is passed a string hex hash of the host's key for verification purposes.
-         * Return `true` to continue with the handshake or `false` to reject and disconnect.
-         */
+        /** The host's key is hashed using this method and passed to `hostVerifier`. */
+        hostHash?: "md5" | "sha1";
+        /** Verifies a hexadecimal hash of the host's key. */
         hostVerifier?: (keyHash: string) => boolean;
-        /**
-         * @description Username for authentication.
-         */
+        /** Username for authentication. */
         username?: string;
-        /**
-         * @description Password for password-based user authentication.
-         */
+        /** Password for password-based user authentication. */
         password?: string;
-        /**
-         * @description Path to ssh-agent's UNIX socket for ssh-agent-based user authentication.
-         * Windows users: set to 'pageant' for authenticating with Pageant or (actual) path to a cygwin "UNIX socket."
-         */
+        /** Path to ssh-agent's UNIX socket for ssh-agent-based user authentication (or 'pageant' when using Pagent on Windows). */
         agent?: string;
-        /**
-         * @description Buffer or string that contains a private key for either key-based or hostbased user authentication (OpenSSH format).
-         */
+        /** Buffer or string that contains a private key for either key-based or hostbased user authentication (OpenSSH format). */
         privateKey?: Buffer | string;
-        /**
-         * @description For an encrypted private key, this is the passphrase used to decrypt it.
-         */
+        /** For an encrypted private key, this is the passphrase used to decrypt it. */
         passphrase?: string;
-        /**
-         * @description Along with **localUsername** and **privateKey**, set this to a non-empty string for hostbased user authentication.
-         */
+        /** Along with `localUsername` and `privateKey`, set this to a non-empty string for hostbased user authentication. */
         localHostname?: string;
-        /**
-         * @description Along with **localHostname** and **privateKey**, set this to a non-empty string for hostbased user authentication.
-         */
+        /** Along with `localHostname` and `privateKey`, set this to a non-empty string for hostbased user authentication. */
         localUsername?: string;
-        /**
-         * @description Try keyboard-interactive user authentication if primary user authentication method fails.
-         * If you set this to `true`, you need to handle the `keyboard-interactive` event.
-         */
+        /** Try keyboard-interactive user authentication if primary user authentication method fails. */
         tryKeyboard?: boolean;
-        /**
-         * @description How often (in milliseconds) to send SSH-level keepalive packets to the server
-         * (in a similar way as OpenSSH's ServerAliveInterval config option). Set to 0 to disable.
-         * @default 0
-         */
+        /** How often (in milliseconds) to send SSH-level keepalive packets to the server. Set to 0 to disable. */
         keepaliveInterval?: number;
-        /**
-         * @description How many consecutive, unanswered SSH-level keepalive packets that can be sent to the server
-         * before disconnection (similar to OpenSSH's ServerAliveCountMax config option).
-         * @default 3
-         */
+        /** How many consecutive, unanswered SSH-level keepalive packets that can be sent to the server before disconnection. */
         keepaliveCountMax?: number;
-        /**
-         * @description How long (in milliseconds) to wait for the SSH handshake to complete.
-         * @default 20000
-         */
+        /** * How long (in milliseconds) to wait for the SSH handshake to complete. */
         readyTimeout?: number;
-        /**
-         * @description Performs a strict server vendor check before sending vendor-specific requests,
-         * etc. (e.g. check for OpenSSH server when using `openssh_noMoreSessions()`)
-         * @default true
-         */
+        /** Performs a strict server vendor check before sending vendor-specific requests. */
         strictVendor?: boolean;
-        /**
-         * A ReadableStream to use for communicating with the server instead of creating and using a new TCP connection (useful for connection hopping).
-         */
+        /** A `ReadableStream` to use for communicating with the server instead of creating and using a new TCP connection (useful for connection hopping). */
         sock?: NodeJS.ReadableStream;
-        /**
-         * @description Set to `true` to use OpenSSH agent forwarding (`auth-agent@openssh.com`) for the life of the connection. `agent` must also be set to use this feature.
-         * @default false
-         */
+        /** Set to `true` to use OpenSSH agent forwarding (`auth-agent@openssh.com`) for the life of the connection. */
         agentForward?: boolean;
-        /**
-         * @description Set this to a function that receives a single string argument to get detailed (local) debug information.
-         */
+        /** Explicit overrides for the default transport layer algorithms used for the connection. */
+        algorithms?: Algorithms;
+        /** A function that receives a single string argument to get detailed (local) debug information. */
         debug?: (information: string) => any;
     }
 
-    interface ExecOption {
-        /**
-         * @description An environment to use for the execution of the command.
-         */
-        env?: any;
-        /**
-         * @description Set to true to allocate a pseudo-tty with defaults, or an object containing specific pseudo-tty settings
-         * (see 'Pseudo-TTY settings'). Setting up a pseudo-tty can be useful when working with remote processes
-         * that expect input from an actual terminal (e.g. sudo's password prompt).
-         */
-        pty?: boolean | PseudoTtySettings;
-        /**
-         * @description Set to true to use defaults below, set to a number to specify a specific screen number,
-         * or an object.
-         */
-        x11?: boolean | number | X11Settings;
+    export interface TcpConnectionDetails {
+        /** The originating IP of the connection. */
+        srcIP: string;
+        /** The originating port of the connection. */
+        srcPort: number;
+        /** The remote IP the connection was received on (given in earlier call to `forwardIn()`). */
+        destIP: string;
+        /** The remote port the connection was received on (given in earlier call to `forwardIn()`). */
+        destPort: number;
     }
 
-    interface X11Settings {
-        /**
-         * Allow just a single connection?
-         * @default false
-         */
+    export interface X11Details {
+        /** The originating IP of the connection. */
+        srcIP: string;
+        /** The originating port of the connection. */
+        srcPort: number;
+    }
+
+    export interface ClientErrorExtensions {
+        /** Indicates 'client-socket' for socket-level errors and 'client-ssh' for SSH disconnection messages. */
+        level?: string;
+        /** Additional detail for 'client-ssh' messages. */
+        description?: string;
+    }
+
+    export interface ExecOptions {
+        /** An environment to use for the execution of the command. */
+        env?: any;
+        /** Set to `true` to allocate a pseudo-tty with defaults, or an object containing specific pseudo-tty settings. */
+        pty?: true | PseudoTtyOptions;
+        /** Set either to `true` to use defaults, a number to specify a specific screen number, or an object containing x11 settings. */
+        x11?: boolean | number | X11Options;
+    }
+
+    export interface ShellOptions {
+        /** Set either to `true` to use defaults, a number to specify a specific screen number, or an object containing x11 settings. */
+        x11?: boolean | number | X11Options;
+    }
+
+    export interface X11Options {
+        /** Whether to allow just a single connection (default: `false`).*/
         single?: boolean;
-        /**
-         * Screen number to use
-         * @default 0
-         */
+        /** The Screen number to use (default: `0`). */
         screen?: number;
     }
 
-    interface PseudoTtySettings {
-        /**
-         * @description * Number of rows
-         * @default 24
-         */
+    export interface PseudoTtyOptions {
+        /** The number of rows (default: `24`). */
         rows?: number;
-        /**
-         * @description * Number of columns
-         * @default 80
-         */
+        /** The number of columns (default: `80`). */
         cols?: number;
-        /**
-         * @description * Height in pixels
-         * @default 480
-         */
+        /** The height in pixels (default: `480`). */
         height?: number;
-        /**
-         * @description * Width in pixels
-         * @default 640
-         */
+        /** The width in pixels (default: `640`). */
         width?: number;
-        /**
-         * @description The value to use for $TERM
-         * @default 'vt100'
-         */
+        /** The value to use for $TERM (default: `'vt100'`) */
         term?: string;
     }
 
-    interface ForwardInCallback {
-        (err?: Error, bindPort?: number): void;
-    }
+    export class Server extends events.EventEmitter {
+        static KEEPALIVE_INTERVAL: number;
+        static KEEPALIVE_CLIENT_INTERVAL: number;
+        static KEEPALIVE_CLIENT_COUNT_MAX: number;
 
-    interface ChannelCallback {
-        (err?: Error, channel?: Channel): void;
-    }
+        // Server events
 
-    interface SftpCallback {
-        (err?: Error, sftp?: Sftp.Wrapper): void;
-    }
+        /**
+         * Emitted when a new client has connected.
+         */
+        on(event: "connection", listener: (client: Connection, info: ClientInfo) => void): this;
 
-    interface ErrorCallback {
-        (err?: Error): void;
-    }
+        /**
+         * Emitted when an error occurs.
+         */
+        on(event: "error", listener: (err: Error) => void): this;
 
-    interface Channel extends stream.Duplex {
-        new (info?: any, client?: any, options?: any): Channel;
-        eof(): boolean;
-        close(): boolean;
-        destroy(): void;
-        setWindow(rows: number, cols: number, height: number, width: number): boolean;
-        signal(signalName: string): boolean;
-        exit(name: string, coreDumped: boolean, msg: string): boolean;
-        exit(status: number): boolean;
-        stderr?: ServerStderr;
-    }
+        /**
+         * Emitted when the server has been bound after calling `server.listen()`.
+         */
+        on(event: "listening", listener: () => void): this;
 
-    interface ServerStderr extends NodeJS.WritableStream {
-        new (channel: Channel): ServerStderr;
-    }
+        /**
+         * Emitted when the server closes. Note that if connections exist, this event is not emitted until all connections are ended.
+         */
+        on(event: "close", listener: () => void): this;
 
-    interface ServerStatic {
-        new (config: ServerConfig, listener?: any): Server;
-        createServer(config: ServerConfig, listener?: any): Server;
-        KEEPALIVE_INTERVAL: number;
-        KEEPALIVE_CLIENT_INTERVAL: number;
-        KEEPALIVE_CLIENT_COUNT_MAX: number;
-    }
+        on(event: string | symbol, listener: Function): this;
 
-    interface Server extends NodeJS.EventEmitter {
-        listen(port: number, hostname?: string, backlog?: number, callback?: Function): Server;
-        listen(port: number, hostname?: string, callback?: Function): Server;
-        listen(path: string, callback?: Function): Server;
-        listen(handle: any, listeningListener?: Function): Server;
+        // Server methods
+
+        /**
+         * Creates and returns a new Server instance.
+         *
+         * @param config Server configuration properties.
+         * @param connectionListener if supplied, is added as a connection listener.
+         */
+        constructor(config: ServerConfig, connectionListener?: (client: Connection, info: ClientInfo) => void);
+
+        /**
+         * Creates and returns a new Server instance.
+         *
+         * @param config Server configuration properties.
+         * @param connectionListener if supplied, is added as a connection listener.
+         */
+        static createServer(config: ServerConfig, connectionListener?: (client: Connection, info: ClientInfo) => void): Server;
+
+        /**
+         * Start a local socket server listening for connections on the given `path`.
+         *
+         * This function is asynchronous. When the server has been bound, `listening` event will be emitted.
+         *
+         * @param path A UNIX domain socket path.
+         * @param backlog The maximum length of the queue of pending connections.
+         * @param callback An optional callback to add to the `listening` event of the server.
+         */
+        listen(path: string, backlog?: number, callback?: () => void): this;
+
+        /**
+         * Start a local socket server listening for connections on the given `path`.
+         *
+         * This function is asynchronous. When the server has been bound, `listening` event will be emitted.
+         *
+         * @param path A UNIX domain socket path.
+         * @param callback An optional callback to add to the `listening` event of the server.
+         */
+        listen(path: string, callback?: () => void): this;
+
+        /**
+         * This will cause the server to accept connections on the specified handle, but it is
+         * presumed that the file descriptor or handle has already been bound to a port or domain
+         * socket.
+         *
+         * This function is asynchronous. When the server has been bound, `listening` event will be emitted.
+         *
+         * @param handle Either a server or socket (anything with an underlying `_handle` member), or an `{fd: number}` object.
+         * @param backlog The maximum length of the queue of pending connections.
+         * @param callback An optional callback to add to the `listening` event of the server.
+         */
+        listen(handle: net.Server | net.Socket | { fd: number }, backlog?: number, callback?: () => void): this;
+
+        /**
+         * This will cause the server to accept connections on the specified handle, but it is
+         * presumed that the file descriptor or handle has already been bound to a port or domain
+         * socket.
+         *
+         * This function is asynchronous. When the server has been bound, `listening` event will be emitted.
+         *
+         * @param handle Either a server or socket (anything with an underlying `_handle` member), or an `{fd: number}` object.
+         * @param callback An optional callback to add to the `listening` event of the server.
+         */
+        listen(handle: net.Server | net.Socket | { fd: number }, callback?: () => void): this;
+
+        /**
+         * This will cause the server to accept connections using the specified options.
+         *
+         * This function is asynchronous. When the server has been bound, `listening` event will be emitted.
+         *
+         * @param options Connection options.
+         * @param callback An optional callback to add to the `listening` event of the server.
+         */
+        listen(options: net.ListenOptions, callback?: () => void): this;
+
+        /**
+         * Begin accepting connections on the specified port and hostname.
+         *
+         * This function is asynchronous. When the server has been bound, `listening` event will be emitted.
+         *
+         * @param port The port on which to start listening. If this value is `undefined` or `0`,
+         *          the operating system will define a random port which can be retrieved later
+         *          using `server.address().port`.
+         * @param hostname The hostname to bind. If `hostname` is omitted, the server will accept
+         *          conections on any IPv6 address (`::`) when IPv6 is availble, or any IPv4
+         *          address (`0.0.0.0`) otherwise.
+         * @param backlog The maximum length of the queue of pending connections.
+         * @param callback An optional callback to add to the `listening` event of the server.
+         */
+        listen(port: number, hostname?: string, backlog?: number, callback?: () => void): this;
+
+        /**
+         * Begin accepting connections on the specified port and hostname.
+         *
+         * This function is asynchronous. When the server has been bound, `listening` event will be emitted.
+         *
+         * @param port The port on which to start listening. If this value is `undefined` or `0`,
+         *          the operating system will define a random port which can be retrieved later
+         *          using `server.address().port`.
+         * @param hostname The hostname to bind. If `hostname` is omitted, the server will accept
+         *          conections on any IPv6 address (`::`) when IPv6 is availble, or any IPv4
+         *          address (`0.0.0.0`) otherwise.
+         * @param callback An optional callback to add to the `listening` event of the server.
+         */
+        listen(port: number, hostname?: string, callback?: () => void): this;
+
+        /**
+         * Begin accepting connections on the specified port.
+         *
+         * This function is asynchronous. When the server has been bound, `listening` event will be emitted.
+         *
+         * @param port The port on which to start listening. If this value is `undefined` or `0`,
+         *          the operating system will define a random port which can be retrieved later
+         *          using `server.address().port`.
+         * @param backlog The maximum length of the queue of pending connections.
+         * @param callback An optional callback to add to the `listening` event of the server.
+         */
+        listen(port: number, backlog?: number, callback?: () => void): this;
+
+        /**
+         * Begin accepting connections on the specified port.
+         *
+         * This function is asynchronous. When the server has been bound, `listening` event will be emitted.
+         *
+         * @param port The port on which to start listening. If this value is `undefined` or `0`,
+         *          the operating system will define a random port which can be retrieved later
+         *          using `server.address().port`.
+         * @param callback An optional callback to add to the `listening` event of the server.
+         */
+        listen(port: number, callback?: () => void): this;
+
+        /**
+         * Begin accepting connections on a random port.
+         *
+         * This function is asynchronous. When the server has been bound, `listening` event will be emitted.
+         *
+         * @param callback An optional callback to add to the `listening` event of the server.
+         */
+        listen(callback?: () => void): this;
+
+        /**
+         * Returns the bound address, the address family name, and port of the server as reported
+         * by the operating system.
+         */
         address(): { port: number; family: string; address: string; };
-        getConnections(callback: any): any; //TODO: No type
-        close(callback?: Function): Server;
+
+        /**
+         * Asynchronously get the number of concurrent connections on the server.
+         */
+        getConnections(callback: (err: Error, count: number) => void): void;
+
+        /**
+         * Stops the server from accepting new connections and keeps existing connections. This
+         * function is asynchronous, the server is finally closed when all connections are ended
+         * and the server emits a 'close' event.
+         *
+         * @param callback Optional callback that will be called once the `close` event occurs.
+         *      Unlike that event, it will be called with an `Error` as its only argument if the
+         *      server was not open when it was closed.
+         */
+        close(callback?: (err: Error) => void): this;
+
+        /**
+         * Opposite of `unref`, calling `ref` on a previously unrefd server will not let the
+         * program exit if it's the only server left (the default behavior). If the server is
+         * refd calling `ref` again will have no effect.
+         */
         ref(): void;
+
+        /**
+         * Calling `unref` on a server will allow the program to exit if this is the only active
+         * server in the event system. If the server is already unrefd calling `unref` again
+         * will have no effect.
+         */
         unref(): void;
     }
 
-    interface ServerConfig {
-        /**
-         * @description Buffer or string that contains the host private key (OpenSSH format).
-         */
-        privateKey: Buffer | string;
-        /**
-         * @description For an encrypted host private key, this is the passphrase used to decrypt it.
-         */
-        passphrase?: string;
-        /**
-         * @description A message that is sent to clients immediately upon connection, before handshaking begins.
-         */
+    export interface ServerConfig {
+        /** An array of host private keys. */
+        hostKeys: (Buffer | string | EncryptedPrivateKey)[];
+        /** Explicit overrides for the default transport layer algorithms used for the connection. */
+        algorithms?: Algorithms;
+        /** A message that is sent to clients immediately upon connection, before handshaking begins. */
         banner?: string;
-        /**
-         * @description A custom server software name/version identifier.
-         * @default 'ssh2js' + moduleVersion + 'srv'
-         */
-        indent?: string;
-        /**
-         * @description This is the highWaterMark to use for the parser stream.
-         * @default 32 * 1024
-         */
+        /** A custom server software name/version identifier. */
+        ident?: string;
+        /** This is the highWaterMark to use for the parser stream (default: `32 * 1024`). */
         highWaterMark?: number;
-        /**
-         * @description Set this to a function that receives a single string argument to get detailed (local) debug information.
-         */
+        /** This is the maximum packet size that will be accepted. It should be 35000 bytes or larger to be compatible with other SSH2 implementations. */
+        maxPacketSize?: number;
+        /** A function that receives a single string argument to get detailed (local) debug information. */
         debug?: (information: string) => any;
     }
 
-    // utility methods from ssh2-streams.
-    interface Utils {
-        iv_inc: Function;
-        isStreamCipher: Function;
-        isGCM: Function;
-        readInt: Function;
-        readString: Function;
-        parseKey: Function;
-        genPublicKey: Function;
-        convertPPKPrivate: Function;
-        verifyPPKMAC: Function;
-        decryptKey: Function;
+    export interface EncryptedPrivateKey {
+        /** A Buffer or string that contains a private key. */
+        key: Buffer | string;
+        /** The passphrase to decrypt a private key. */
+        passphrase?: string;
     }
 
-    namespace Sftp {
-        // SFTPStream.STATUS_CODE from ssh2-streams.
-        interface StatusCode {
-            OK: number;
-            EOF: number;
-            NO_SUCH_FILE: number;
-            PERMISSION_DENIED: number;
-            FAILURE: number;
-            BAD_MESSAGE: number;
-            NO_CONNECTION: number;
-            CONNECTION_LOST: number;
-            OP_UNSUPPORTED: number;
-        }
+    export interface ClientInfo {
+        /** The remote address of the connection. */
+        ip: string;
+        /** Information about the client. */
+        header: Header;
+    }
 
-        // SFTPStream.OPEN_MODE from ssh2-streams.
-        interface OpenMode {
-            READ: number;
-            WRITE: number;
-            APPEND: number;
-            CREAT: number;
-            TRUNC: number;
-            EXCL: number;
-        }
+    export interface Connection extends events.EventEmitter {
+        // Connection events
 
-        interface Attributes {
-            mode: number;
-            uid: number;
-            gid: number;
-            size: number;
-            atime: number;
-            mtime: number;
-        }
-        interface InputAttributes {
-            mode?: number;
-            uid?: number;
-            gid?: number;
-            size?: number;
-            atime?: number;
-            mtime?: number;
-        }
-        interface Stats extends Attributes {
-            isDirectory(): boolean;
-            isFile(): boolean;
-            isBlockDevice(): boolean;
-            isCharacterDevice(): boolean;
-            isSymbloicLink(): boolean;
-            isFIFO(): boolean;
-            isSocket(): boolean;
-        }
+        /**
+         * Emitted when the client has requested authentication.
+         */
+        on(event: "authentication", listener: (authCtx: AuthContext) => void): this;
 
-        interface Wrapper extends NodeJS.EventEmitter {
-            fastGet(remotePath: string, localPath: string, callback: (err: any) => void): void;
-            fastGet(remotePath: string, localPath: string, options: TransferOptions, callback: (err: any) => void): void;
-            fastPut(localPath: string, remotePath: string, callback: (err: any) => void): void;
-            fastPut(localPath: string, remotePath: string, options: TransferOptions, callback: (err: any) => void): void;
+        /**
+         * Emitted when the client has been successfully authenticated.
+         */
+        on(event: "ready", listener: () => void): this;
 
-            createReadStream(path: string, options?: ReadStreamOptions): stream.Readable;
-            createWriteStream(path: string, options?: WriteStreamOptions): stream.Writable;
-            open(filename: string, mode: string, callback: (err: any, handle: Buffer) => void): boolean;
-            open(filename: string, mode: string, attributes: InputAttributes, callback: (err: any, handle: Buffer) => void): boolean;
-            close(handle: Buffer, callback: (err: any) => void): boolean;
-            readData(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number,
-                callback: (err: any, bytesRead: number, buffer: Buffer, position: number) => void): boolean;
-            writeData(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number,
-                callback: (err: any) => void): boolean;
-            fstat(handle: Buffer, callback: (err: any, stats: Stats) => void): boolean;
-            fsetstat(handle: Buffer, attributes: InputAttributes, callback: (err: any) => void): boolean;
-            futimes(handle: Buffer, atime: number | Date, mtime: number | Date, callback: (err: any) => void): boolean;
-            fchown(handle: Buffer, uid: number, gid: number, callback: (err: any) => void): boolean;
-            fchmod(handle: Buffer, mode: number | string, callback: (err: any) => void): boolean;
-            opendir(path: string, callback: (err: any, handle: Buffer) => void): boolean;
-            readdir(location: string | Buffer, callback: (err: any, list: ReadDirItem[]) => void): boolean;
-            unlink(path: string, callback: (err: any) => void): boolean;
-            rename(srcPath: string, destPath: string, callback: (err: any) => void): boolean;
-            mkdir(path: string, callback: (err: any) => void): boolean;
-            mkdir(path: string, attributes: InputAttributes, callback: (err: any) => void): boolean;
-            rmdir(path: string, callback: (err: any) => void): boolean;
-            stat(path: string, callback: (err: any, stats: Stats) => void): boolean;
-            lstat(path: string, callback: (err: any, stats: Stats) => void): boolean;
-            setstat(path: string, attributes: InputAttributes, callback: (err: any) => void): boolean;
-            utimes(path: string, atime: number | Date, mtime: number | Date, callback: (err: any) => void): boolean;
-            chown(path: string, uid: number, gid: number, callback: (err: any) => void): boolean;
-            chmod(path: string, mode: number | string, callback: (err: any) => void): boolean;
-            readlink(path: string, callback: (err: any, target: string) => void): boolean;
-            symlink(targetPath: string, linkPath: string, callback: (err: any) => void): boolean;
-            realpath(path: string, callback: (err: any, absPath: string) => void): boolean;
+        /**
+         * Emitted when the client has requested a new session.
+         * Sessions are used to start interactive shells, execute commands, request X11 forwarding, etc.
+         */
+        on(event: "session", listener: (accept: () => Session, reject: () => boolean) => void): this;
 
-            ext_openssh_rename(srcPath: string, destPath: string, callback: (err: any) => void): boolean;
-            ext_openssh_statvfs(path: string, callback: (err: any, fsInfo: any) => void): boolean;
-            ext_openssh_fstatvfs(handle: Buffer, callback: (err: any, fsInfo: any) => void): boolean;
-            ext_openssh_hardlink(targetPath: string, linkPath: string, callback: (err: any) => void): boolean;
-            ext_openssh_fsync(handle: Buffer, callback: (err: any, fsInfo: any) => void): boolean;
-        }
+        /**
+         * Emitted when the client has requested an outbound (TCP) connection.
+         */
+        on(event: "tcpip", listener: (accept: () => ServerChannel, reject: () => boolean, info: TcpipRequestInfo) => void): this;
 
-        interface TransferOptions {
-            concurrency?: number;
-            chunkSize?: number;
-            step?: (total_transferred: number, chunk: number, total: number) => void;
-        }
-        interface ReadStreamOptions {
-            flags?: string;
-            encoding?: string;
-            handle?: Buffer;
-            mode?: number;
-            autoClose?: boolean;
-            start?: number;
-            end?: number;
-        }
-        interface WriteStreamOptions {
-            flags?: string;
-            encoding?: string;
-            mode?: number;
-        }
-        interface ReadDirItem {
-            filename: string;
-            longname: string;
-            attrs: Attributes;
-        }
+        /**
+         * Emitted when the client has requested a connection to a UNIX domain socket.
+         */
+        on(event: "openssh.streamlocal", listener: (accept: () => ServerChannel, reject: () => boolean, info: SocketRequestInfo) => void): this;
+
+        /**
+         * Emitted when the client has sent a global request for name.
+         * If info.bindPort === 0, you should pass the chosen port to accept so that the client will know what port was bound.
+         */
+        on(event: "request", listener: (accept: (chosenPort?: number) => void, reject: () => void, name: "tcpip-forward" | "cancel-tcpip-forward", info: TcpipBindInfo) => void): this;
+
+        /**
+         * Emitted when the client has sent a global request for name.
+         */
+        on(event: "request", listener: (accept: () => void, reject: () => void, name: "streamlocal-forward@openssh.com" | "cancel-streamlocal-forward@openssh.com", info: SocketBindInfo) => void): this;
+
+        /**
+         * Emitted when the client has sent a global request for name.
+         * If info.bindPort === 0, you should pass the chosen port to accept so that the client will know what port was bound.
+         */
+        on(event: "request", listener: (accept: (chosenPort?: number) => void, reject: () => void, name: string, info: TcpipBindInfo | SocketBindInfo) => void): this;
+
+        /**
+         * Emitted when the client has finished rekeying (either client or server initiated).
+         */
+        on(event: "rekey", listener: () => void): this;
+
+        /**
+         * Emitted when more requests/data can be sent to the client (after a Connection method returned false).
+         */
+        on(event: "continue", listener: () => void): this;
+
+        /**
+         * Emitted when an error occurrs.
+         */
+        on(event: "error", listener: (err: Error) => void): this;
+
+        /**
+         * Emitted when the socket has disconnected.
+         */
+        on(event: "end", listener: () => void): this;
+
+        /**
+         * Emitted when the client socket was closed.
+         */
+        on(event: "close", listener: (hadError: boolean) => void): this;
+
+        on(event: string | symbol, listener: Function): this;
+
+        noMoreSessions: boolean;
+        authenticated: boolean;
+
+        // Connection methods
+
+        /**
+         * Closes the client connection.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        end(): boolean;
+
+        /**
+         * Alert the client of an incoming X11 client connection from `originAddr` on port `originPort`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        x11(originAddr: string, originPort: number, callback: (err: Error, channel: ServerChannel) => void): boolean;
+
+        /**
+         * Alert the client of an incoming TCP connection on `boundAddr` on port `boundPort` from
+         * `remoteAddr` on port `remotePort`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        forwardOut(boundAddr: string, boundPort: number, remoteAddr: string, remotePort: number, callback: (err: Error, channel: ServerChannel) => void): boolean;
+
+        /**
+         * Initiates a rekeying with the client.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         *
+         * @param callback An optional callback added as a one-time handler for the `rekey` event.
+         */
+        rekey(callback?: (err: Error) => void): boolean;
+
+        /**
+         * Alert the client of an incoming UNIX domain socket connection on socketPath.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        openssh_forwardOutStreamLocal(socketPath: string, callback: (err: Error, channel: ServerChannel) => void): boolean;
+    }
+
+    export interface AuthContextBase extends events.EventEmitter {
+        /** The client's username. */
+        username: string;
+        /** The service requesting authentication. */
+        service: string;
+        /** The method of authentication. */
+        method: string;
+
+        /**
+         * Accepts the authentication request.
+         */
+        accept(): void;
+
+        /**
+         * Rejects the authentication request.
+         */
+        reject(): void;
+
+        /**
+         * Rejects the authentication request.
+         */
+        reject(isPartialSuccess: boolean): void;
+
+        /**
+         * Rejects the authentication request.
+         */
+        reject(authMethodsLeft?: string[], isPartialSuccess?: boolean): void;
+
+        /**
+         * Emitted when the client aborts the authentication request.
+         */
+        on(event: "abort", listener: (err: Error) => void): this;
+
+        on(event: string | symbol, listener: Function): this;
+    }
+
+    export interface KeyboardAuthContext extends AuthContextBase {
+        /** The method of authentication. */
+        method: "keyboard-interactive";
+
+        /** A list of preferred authentication "sub-methods" sent by the client. */
+        submethods: string[];
+
+        /**
+         * Send prompts to the client.
+         * @param prompts The prompts to send to the client.
+         * @param callback A callback to call with the responses from the client.
+         */
+        prompt(prompts: string | Prompt | (string | Prompt)[], callback: () => void): void;
+
+        /**
+         * Send prompts to the client.
+         * @param prompts The prompts to send to the client.
+         * @param title The title for the prompt.
+         * @param callback A callback to call with the responses from the client.
+         */
+        prompt(prompts: string | Prompt | (string | Prompt)[], title: string, callback: () => void): void;
+
+        /**
+         * Send prompts to the client.
+         * @param prompts The prompts to send to the client.
+         * @param title The title for the prompt.
+         * @param instructions Instructions for the client.
+         * @param callback A callback to call with the responses from the client.
+         */
+        prompt(prompts: string | Prompt | (string | Prompt)[], title: string, instructions: string, callback: () => void): void;
+    }
+
+    export interface PublicKeyAuthContext extends AuthContextBase {
+        /** The method of authentication. */
+        method: "publickey";
+        /** The public key sent by the client. */
+        key: PublicKey;
+        /** The signature to verify, or `undefined` if the client is only checking the validity of the key. */
+        signature: Buffer | undefined;
+        /** The signature algorithm, or `undefined` if the client is only checking the validity of the key. */
+        sigAlgo: string;
+        /** The data used to verify the key, or `undefined` if the client is only checking the validity of the key. */
+        blob: Buffer;
+    }
+
+    export interface PublicKey {
+        /** The name of the key algorithm. */
+        algo: string;
+        /** The actual key data. */
+        data: Buffer;
+    }
+
+    export interface HostbasedAuthContext extends AuthContextBase {
+        /** The method of authentication. */
+        method: "hostbased";
+        /** The public key sent by the client. */
+        key: PublicKey;
+        /** The signature to verify, or `undefined` if the client is only checking the validity of the key. */
+        signature: Buffer | undefined;
+        /** The signature algorithm, or `undefined` if the client is only checking the validity of the key. */
+        sigAlgo: string;
+        /** The data used to verify the key, or `undefined` if the client is only checking the validity of the key. */
+        blob: Buffer;
+        /** The local hostname of the client. */
+        localHostname: string;
+        /** The local username of the client. */
+        localUsername: string;
+    }
+
+    export interface PasswordAuthContext extends AuthContextBase {
+        /** The method of authentication. */
+        method: "password";
+        /** The password sent by the client. */
+        password: string;
+    }
+
+    export interface NoneAuthContext extends AuthContextBase {
+        /** The method of authentication. */
+        method: "none";
+    }
+
+    export type AuthContext = KeyboardAuthContext | PublicKeyAuthContext | HostbasedAuthContext | PasswordAuthContext | NoneAuthContext;
+
+    export interface TcpipRequestInfo {
+        /** Source IP address of outgoing connection. */
+        srcIP: string;
+        /** Source port of outgoing connection. */
+        srcPort: number;
+        /** Destination IP address of outgoing connection. */
+        destIP: string;
+        /** Destination port of outgoing connection. */
+        destPort: number;
+    }
+
+    export interface SocketRequestInfo {
+        /** Destination socket path of outgoing connection. */
+        socketPath: string;
+    }
+
+    export interface TcpipBindInfo {
+        /** The IP address to start/stop binding to. */
+        bindAddr: string;
+        /** The port to start/stop binding to. */
+        bindPort: number;
+    }
+
+    export interface SocketBindInfo {
+        /** The socket path to start/stop binding to. */
+        socketPath: string;
+    }
+
+    export interface Session extends events.EventEmitter {
+        // Session events
+
+        /**
+         * Emitted when the client requested allocation of a pseudo-TTY for this session.
+         */
+        on(event: "pty", listener: (accept: () => boolean, reject: () => boolean, info: PseudoTtyInfo) => void): this;
+
+        /**
+         * Emitted when the client reported a change in window dimensions during this session.
+         */
+        on(event: "window-change", listener: (accept: () => boolean, reject: () => boolean, info: WindowChangeInfo) => void): this;
+
+        /**
+         * Emitted when the client requested X11 forwarding.
+         */
+        on(event: "x11", listener: (accept: () => boolean, reject: () => boolean, info: X11Info) => void): this;
+
+        /**
+         * Emitted when the client requested an environment variable to be set for this session.
+         */
+        on(event: "env", listener: (accept: () => boolean, reject: () => boolean, info: SetEnvInfo) => void): this;
+
+        /**
+         * Emitted when the client has sent a POSIX signal.
+         */
+        on(event: "signal", listener: (accept: () => boolean, reject: () => boolean, info: SignalInfo) => void): this;
+
+        /**
+         * Emitted when the client has requested incoming ssh-agent requests be forwarded to them.
+         */
+        on(event: "auth-agent", listener: (accept: () => boolean, reject: () => boolean) => void): this;
+
+        /**
+         * Emitted when the client has requested an interactive shell.
+         */
+        on(event: "shell", listener: (accept: () => ServerChannel, reject: () => boolean) => void): this;
+
+        /**
+         * Emitted when the client has requested execution of a command string.
+         */
+        on(event: "exec", listener: (accept: () => ServerChannel, reject: () => boolean, info: ExecInfo) => void): this;
+
+        /**
+         * Emitted when the client has requested the SFTP subsystem.
+         */
+        on(event: "sftp", listener: (accept: () => SFTPStream, reject: () => boolean) => void): this;
+
+        /**
+         * Emitted when the client has requested an arbitrary subsystem.
+         */
+        on(event: "subsystem", listener: (accept: () => ServerChannel, reject: () => boolean, info: SubsystemInfo) => void): this;
+
+        /**
+         * Emitted when the session has closed.
+         */
+        on(event: "close", listener: () => void): this;
+
+        on(event: string | symbol, listener: Function): this;
+    }
+
+    export interface PseudoTtyInfo {
+        /** The number of columns for the pseudo-TTY. */
+        cols: number;
+        /** The number of rows for the pseudo-TTY. */
+        rows: number;
+        /** The width of the pseudo-TTY in pixels. */
+        width: number;
+        /** The height of the pseudo-TTY in pixels. */
+        height: number;
+        /** Contains the requested terminal modes of the pseudo-TTY. */
+        modes: TerminalModes;
+    }
+
+    export interface TerminalModes {
+        [mode: string]: number;
+        /** Interrupt character; `255` if none. Not all of these characters are supported on all systems. */
+        VINTR?: number;
+        /** The quit character (sends `SIGQUIT` signal on POSIX systems). */
+        VQUIT?: number;
+        /** Erase the character to left of the cursor. */
+        VERASE?: number;
+        /** Kill the current input line. */
+        VKILL?: number;
+        /** End-of-file character (sends `EOF` from the terminal). */
+        VEOF?: number;
+        /** End-of-line character in addition to carriage return and/or linefeed. */
+        VEOL?: number;
+        /** Additional end-of-line character. */
+        VEOL2?: number;
+        /** Continues paused output (normally control-Q). */
+        VSTART?: number;
+        /** Pauses output (normally control-S). */
+        VSTOP?: number;
+        /** Suspends the current program. */
+        VSUSP?: number;
+        /** Another suspend character. */
+        VDSUSP?: number;
+        /** Reprints the current input line. */
+        VREPRINT?: number;
+        /** Erases a word left of cursor. */
+        VWERASE?: number;
+        /** Enter the next character typed literally, even if it is a special character */
+        VLNEXT?: number;
+        /** Character to flush output. */
+        VFLUSH?: number;
+        /** Switch to a different shell layer. */
+        VSWTCH?: number;
+        /** Prints system status line (load, command, pid, etc). */
+        VSTATUS?: number;
+        /** Toggles the flushing of terminal output. */
+        VDISCARD?: number;
+        /** The ignore parity flag.  The parameter SHOULD be `0` if this flag is FALSE, and `1` if it is TRUE. */
+        IGNPAR?: 0 | 1;
+        /** Mark parity and framing errors. */
+        PARMRK?: 0 | 1;
+        /** Enable checking of parity errors. */
+        INPCK?: 0 | 1;
+        /** Strip 8th bit off characters. */
+        ISTRIP?: 0 | 1;
+        /** Map NL into CR on input. */
+        INLCR?: 0 | 1;
+        /** Ignore CR on input. */
+        IGNCR?: 0 | 1;
+        /** Map CR to NL on input. */
+        ICRNL?: 0 | 1;
+        /** Translate uppercase characters to lowercase. */
+        IUCLC?: 0 | 1;
+        /** Enable output flow control. */
+        IXON?: 0 | 1;
+        /** Any char will restart after stop. */
+        IXANY?: 0 | 1;
+        /** Enable input flow control. */
+        IXOFF?: 0 | 1;
+        /** Ring bell on input queue full. */
+        IMAXBEL?: 0 | 1;
+        /** Enable signals INTR, QUIT, [D]SUSP. */
+        ISIG?: 0 | 1;
+        /** Canonicalize input lines. */
+        ICANON?: 0 | 1;
+        /** Enable input and output of uppercase characters by preceding their lowercase equivalents with `\`. */
+        XCASE?: 0 | 1;
+        /** Enable echoing. */
+        ECHO?: 0 | 1;
+        /** Visually erase chars. */
+        ECHOE?: 0 | 1;
+        /** Kill character discards current line. */
+        ECHOK?: 0 | 1;
+        /** Echo NL even if ECHO is off. */
+        ECHONL?: 0 | 1;
+        /** Don't flush after interrupt. */
+        NOFLSH?: 0 | 1;
+        /** Stop background jobs from output. */
+        TOSTOP?: 0 | 1;
+        /** Enable extensions. */
+        IEXTEN?: 0 | 1;
+        /** Echo control characters as ^(Char). */
+        ECHOCTL?: 0 | 1;
+        /** Visual erase for line kill. */
+        ECHOKE?: 0 | 1;
+        /** Retype pending input. */
+        PENDIN?: 0 | 1;
+        /** Enable output processing. */
+        OPOST?: 0 | 1;
+        /** Convert lowercase to uppercase. */
+        OLCUC?: 0 | 1;
+        /** Map NL to CR-NL. */
+        ONLCR?: 0 | 1;
+        /** Translate carriage return to newline (output). */
+        OCRNL?: 0 | 1;
+        /** Translate newline to carriage return-newline (output). */
+        ONOCR?: 0 | 1;
+        /** Newline performs a carriage return (output). */
+        ONLRET?: 0 | 1;
+        /** 7 bit mode. */
+        CS7?: 0 | 1;
+        /** 8 bit mode. */
+        CS8?: 0 | 1;
+        /** Parity enable. */
+        PARENB?: 0 | 1;
+        /** Odd parity, else even. */
+        PARODD?: 0 | 1;
+        /** Specifies the input baud rate in bits per second. */
+        TTY_OP_ISPEED?: number;
+        /** Specifies the output baud rate in bits per second. */
+        TTY_OP_OSPEED?: number;
+    }
+
+    export interface WindowChangeInfo {
+        /** The number of columns for the pseudo-TTY. */
+        cols: number;
+        /** The number of rows for the pseudo-TTY. */
+        rows: number;
+        /** The width of the pseudo-TTY in pixels. */
+        width: number;
+        /** The height of the pseudo-TTY in pixels. */
+        height: number;
+    }
+
+    export interface X11Info {
+        /** true if only a single connection should be forwarded. */
+        single: boolean;
+        /** The name of the X11 authentication method used. */
+        protocol: string;
+        /** The X11 authentication cookie encoded in hexadecimal. */
+        cookie: string;
+        /** The screen number for which to forward X11 connections. */
+        screen: number;
+    }
+
+    export interface SetEnvInfo {
+        /** The environment variable's name. */
+        key: string;
+        /** The environment variable's value. */
+        value: string;
+    }
+
+    export interface SignalInfo {
+        /** The signal name (e.g. SIGUSR1). */
+        name: string;
+    }
+
+    export interface ExecInfo {
+        /** The command line to be executed. */
+        command: string;
+    }
+
+    export interface SubsystemInfo {
+        /** The name of the subsystem. */
+        name: string;
+    }
+
+    export interface SFTPWrapper extends events.EventEmitter {
+        /**
+         * (Client-only)
+         * Downloads a file at `remotePath` to `localPath` using parallel reads for faster throughput.
+         */
+        fastGet(remotePath: string, localPath: string, options: TransferOptions, callback: (err: any) => void): void;
+
+        /**
+         * (Client-only)
+         * Downloads a file at `remotePath` to `localPath` using parallel reads for faster throughput.
+         */
+        fastGet(remotePath: string, localPath: string, callback: (err: any) => void): void;
+
+        /**
+         * (Client-only)
+         * Uploads a file from `localPath` to `remotePath` using parallel reads for faster throughput.
+         */
+        fastPut(localPath: string, remotePath: string, options: TransferOptions, callback: (err: any) => void): void;
+
+        /**
+         * (Client-only)
+         * Uploads a file from `localPath` to `remotePath` using parallel reads for faster throughput.
+         */
+        fastPut(localPath: string, remotePath: string, callback: (err: any) => void): void;
+
+        /**
+         * (Client-only)
+         * Returns a new readable stream for `path`.
+         */
+        createReadStream(path: string, options?: ReadStreamOptions): stream.Readable;
+
+        /**
+         * (Client-only)
+         * Returns a new writable stream for `path`.
+         */
+        createWriteStream(path: string, options?: WriteStreamOptions): stream.Writable;
+
+        /**
+         * (Client-only)
+         * Opens a file `filename` for `mode` with optional `attributes`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        open(filename: string, mode: string, attributes: InputAttributes, callback: (err: any, handle: Buffer) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Opens a file `filename` for `mode`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        open(filename: string, mode: string, callback: (err: any, handle: Buffer) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Closes the resource associated with `handle` given by `open()` or `opendir()`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        close(handle: Buffer, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Reads `length` bytes from the resource associated with `handle` starting at `position`
+         * and stores the bytes in `buffer` starting at `offset`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        read(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number, callback: (err: any, bytesRead: number, buffer: Buffer, position: number) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        write(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Retrieves attributes for the resource associated with `handle`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        fstat(handle: Buffer, callback: (err: any, stats: Stats) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Sets the attributes defined in `attributes` for the resource associated with `handle`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        fsetstat(handle: Buffer, attributes: InputAttributes, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Sets the access time and modified time for the resource associated with `handle`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        futimes(handle: Buffer, atime: number | Date, mtime: number | Date, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Sets the owner for the resource associated with `handle`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        fchown(handle: Buffer, uid: number, gid: number, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Sets the mode for the resource associated with `handle`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        fchmod(handle: Buffer, mode: number | string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Opens a directory `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        opendir(path: string, callback: (err: any, handle: Buffer) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Retrieves a directory listing.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        readdir(location: string | Buffer, callback: (err: any, list: FileEntry[]) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Removes the file/symlink at `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        unlink(path: string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Renames/moves `srcPath` to `destPath`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        rename(srcPath: string, destPath: string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Creates a new directory `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        mkdir(path: string, attributes: InputAttributes, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Creates a new directory `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        mkdir(path: string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Removes the directory at `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        rmdir(path: string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Retrieves attributes for `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        stat(path: string, callback: (err: any, stats: Stats) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Retrieves attributes for `path`. If `path` is a symlink, the link itself is stat'ed
+         * instead of the resource it refers to.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        lstat(path: string, callback: (err: any, stats: Stats) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Sets the attributes defined in `attributes` for `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        setstat(path: string, attributes: InputAttributes, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Sets the access time and modified time for `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        utimes(path: string, atime: number | Date, mtime: number | Date, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Sets the owner for `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        chown(path: string, uid: number, gid: number, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Sets the mode for `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        chmod(path: string, mode: number | string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Retrieves the target for a symlink at `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        readlink(path: string, callback: (err: any, target: string) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Creates a symlink at `linkPath` to `targetPath`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        symlink(targetPath: string, linkPath: string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only)
+         * Resolves `path` to an absolute path.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        realpath(path: string, callback: (err: any, absPath: string) => void): boolean;
+
+        /**
+         * (Client-only, OpenSSH extension)
+         * Performs POSIX rename(3) from `srcPath` to `destPath`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        ext_openssh_rename(srcPath: string, destPath: string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only, OpenSSH extension)
+         * Performs POSIX statvfs(2) on `path`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        ext_openssh_statvfs(path: string, callback: (err: any, fsInfo: any) => void): boolean;
+
+        /**
+         * (Client-only, OpenSSH extension)
+         * Performs POSIX fstatvfs(2) on open handle `handle`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        ext_openssh_fstatvfs(handle: Buffer, callback: (err: any, fsInfo: any) => void): boolean;
+
+        /**
+         * (Client-only, OpenSSH extension)
+         * Performs POSIX link(2) to create a hard link to `targetPath` at `linkPath`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        ext_openssh_hardlink(targetPath: string, linkPath: string, callback: (err: any) => void): boolean;
+
+        /**
+         * (Client-only, OpenSSH extension)
+         * Performs POSIX fsync(3) on the open handle `handle`.
+         *
+         * Returns `false` if you should wait for the `continue` event before sending any more traffic.
+         */
+        ext_openssh_fsync(handle: Buffer, callback: (err: any, fsInfo: any) => void): boolean;
+
+        /**
+         * Ends the stream.
+         */
+        end(): void;
+
+        /**
+         * Emitted when an error occurred.
+         */
+        on(event: "error", listener: (err: any) => void): this;
+
+        /**
+         * Emitted when the session has ended.
+         */
+        on(event: "end", listener: () => void): this;
+
+        /**
+         * Emitted when the session has closed.
+         */
+        on(event: "close", listener: () => void): this;
+
+        /**
+         * Emitted when more requests/data can be sent to the stream.
+         */
+        on(event: "continue", listener: () => void): this;
+
+        on(event: string | symbol, listener: Function): this;
     }
 }
-
-declare var ssh2: ssh2.Client;
-
-export = ssh2;

--- a/ssh2/ssh2-tests.ts
+++ b/ssh2/ssh2-tests.ts
@@ -1,5 +1,7 @@
-
+import * as fs from "fs";
+import * as crypto from "crypto";
 import * as ssh2 from 'ssh2';
+import * as ssh2_streams from 'ssh2-streams';
 
 declare var inspect: any;
 
@@ -14,7 +16,7 @@ var Client = require('ssh2').Client;
 var conn = new Client();
 conn.on('ready', () => {
     console.log('Client :: ready');
-    conn.exec('uptime', (err: Error, stream: ssh2.Channel) => {
+    conn.exec('uptime', (err: Error, stream: ssh2.ClientChannel) => {
         if (err) throw err;
         stream
             .on('close', (code: any, signal: any) => {
@@ -40,7 +42,7 @@ var Client = require('ssh2').Client;
 var conn = new Client();
 conn.on('ready', () => {
     console.log('Client :: ready');
-    conn.shell( (err: Error, stream: ssh2.Channel) => {
+    conn.shell( (err: Error, stream: ssh2.ClientChannel) => {
         if (err) throw err;
         stream.on('close', () => {
             console.log('Stream :: close');
@@ -66,7 +68,7 @@ var Client = require('ssh2').Client;
 var conn = new Client();
 conn.on('ready', () => {
     console.log('Client :: ready');
-    conn.forwardOut('192.168.100.102', 8000, '127.0.0.1', 80, (err: Error, stream: ssh2.Channel) => {
+    conn.forwardOut('192.168.100.102', 8000, '127.0.0.1', 80, (err: Error, stream: ssh2.ClientChannel) => {
         if (err) throw err;
         stream.on('close', () => {
             console.log('TCP :: CLOSED');
@@ -131,9 +133,9 @@ var Client = require('ssh2').Client;
 var conn = new Client();
 conn.on('ready', () => {
     console.log('Client :: ready');
-    conn.sftp( (err: Error, sftp: ssh2.Sftp.Wrapper) => {
+    conn.sftp( (err: Error, sftp: ssh2.SFTPWrapper) => {
         if (err) throw err;
-        sftp.readdir('foo', (err: Error, list: ssh2.Sftp.ReadDirItem[]) => {
+        sftp.readdir('foo', (err: Error, list: ssh2_streams.FileEntry[]) => {
             if (err) throw err;
             console.dir(list);
             conn.end();
@@ -155,7 +157,7 @@ var conn1 = new Client(),
 
 conn1.on('ready', () => {
     console.log('FIRST :: connection ready');
-    conn1.exec('nc 192.168.1.2 22', (err: Error, stream: ssh2.Channel) => {
+    conn1.exec('nc 192.168.1.2 22', (err: Error, stream: ssh2.ClientChannel) => {
         if (err) {
             console.log('FIRST :: exec error: ' + err);
             return conn1.end();
@@ -174,7 +176,7 @@ conn1.on('ready', () => {
 
 conn2.on('ready', () => {
     console.log('SECOND :: connection ready');
-    conn2.exec('uptime', (err: Error, stream: ssh2.Channel) => {
+    conn2.exec('uptime', (err: Error, stream: ssh2.ClientChannel) => {
         if (err) {
             console.log('SECOND :: exec error: ' + err);
             return conn1.end();
@@ -205,7 +207,7 @@ conn.on('x11', (info: any, accept: any, reject: any) => {
 });
 
 conn.on('ready', () => {
-    conn.exec('xeyes', { x11: true }, (err: Error, stream: ssh2.Channel) => {
+    conn.exec('xeyes', { x11: true }, (err: Error, stream: ssh2.ClientChannel) => {
         if (err) throw err;
         var code = 0;
         stream.on('end', () => {
@@ -244,7 +246,7 @@ socks.createServer( (info: any, accept: any, deny: any) => {
             info.srcPort,
             info.dstAddr,
             info.dstPort,
-             (err: Error, stream: ssh2.Channel) => {
+             (err: Error, stream: ssh2.ClientChannel) => {
                 if (err) {
                     conn.end();
                     return deny();
@@ -279,7 +281,7 @@ var conn = new Client();
 
 conn.on('ready', () => {
     console.log('Client :: ready');
-    conn.subsys('netconf', (err: Error, stream: ssh2.Channel) => {
+    conn.subsys('netconf', (err: Error, stream: ssh2.ClientChannel) => {
         if (err) throw err;
         stream.on('data', (data: any) => {
             console.log(data);
@@ -307,20 +309,18 @@ const sshconfig: ssh2.ConnectConfig = {
 
 // Only allow password and public key authentication and command execution:
 
-var fs = require('fs'),
-    crypto = require('crypto');
 var buffersEqual = require('buffer-equal-constant-time'),
     //ssh2 = require('ssh2'),
     utils = ssh2.utils;
 
-var pubKey = utils.genPublicKey(utils.parseKey(fs.readFileSync('user.pub')));
+var pubKey = utils.genPublicKey(<ssh2_streams.ParsedKey>utils.parseKey(fs.readFileSync('user.pub')));
 
 new ssh2.Server({
-    privateKey: fs.readFileSync('host.key')
-}, (client: any) => {
+    hostKeys: [fs.readFileSync('host.key')]
+}, (client: ssh2.Connection) => {
     console.log('Client connected!');
 
-    client.on('authentication', (ctx: any) => {
+    client.on('authentication', ctx => {
         if (ctx.method === 'password'
             && ctx.username === 'foo'
             && ctx.password === 'bar')
@@ -331,7 +331,7 @@ new ssh2.Server({
             if (ctx.signature) {
                 var verifier = crypto.createVerify(ctx.sigAlgo);
                 verifier.update(ctx.blob);
-                if (verifier.verify(pubKey.publicOrig, ctx.signature, 'binary'))
+                if (verifier.verify(pubKey.publicOrig.toString("utf8"), ctx.signature))
                     ctx.accept();
                 else
                     ctx.reject();
@@ -365,13 +365,12 @@ new ssh2.Server({
 
 // SFTP only server:
 
-var fs = require('fs');
 //var ssh2 = require('ssh2');
 var OPEN_MODE = ssh2.SFTP_OPEN_MODE,
     STATUS_CODE = ssh2.SFTP_STATUS_CODE;
 
 new ssh2.Server({
-    privateKey: fs.readFileSync('host.key')
+    hostKeys: [fs.readFileSync('host.key')]
 }, (client: any) => {
     console.log('Client connected!');
 


### PR DESCRIPTION
This adds type definitions for [ssh2-streams](https://www.npmjs.com/package/ssh2-streams) and improves the type definitions for [ssh2](https://www.npmjs.com/package/ssh2). These changes specifically target TypeScript 2.0.

Changes and additions are pulled from the following sources:
- https://github.com/mscdex/ssh2-streams/blob/master/README.md
- https://github.com/mscdex/ssh2-streams/blob/master/SFTPStream.md
- https://github.com/mscdex/ssh2/blob/master/README.md
