### PR TITLE
Added declare module

### DIFF
--- a/signalr/signalr.d.ts
+++ b/signalr/signalr.d.ts
@@ -363,3 +363,7 @@ interface JQueryStatic {
     connection: SignalR;
     hubConnection: SignalR.Hub.HubCreator;
 }
+
+declare module "signalr" {
+    export = SignalR;
+}


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

This allows you to import the typing in Typescript 2.0 using import \* as SignalR from 'signalr'; the same way it is declared in the jquery typings.

https://blogs.msdn.microsoft.com/typescript/2016/06/15/the-future-of-declaration-files/
