### PR TITLE
Add touch type definition

### DIFF
--- a/touch/index.d.ts
+++ b/touch/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for touch
+// Project: https://github.com/isaacs/node-touch
+// Definitions by: Mizunashi Mana <https://github.com/mizunashi-mana>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function touch(filename: string, cb: (err: any) => any): void;
+declare function touch(filename: string, opts: touch.Options, cb: (err: any) => any): void;
+
+declare namespace touch {
+    export interface Options {
+        force?: boolean;
+        time?: Date | string | number;
+        atime?: boolean | Date;
+        mtime?: boolean | Date;
+        ref?: string;
+        nocreate?: boolean;
+    }
+
+    export function sync(filename: string, opts?: touch.Options): void;
+
+    export function ftouch(fd: number, cb: (err: any) => any): void;
+    export function ftouch(fd: number, opts: touch.Options, cb: (err: any) => any): void;
+
+    export namespace ftouch {
+        export function sync(fd: number, opts?: touch.Options): void;
+    }
+
+    export const ftouchSync: typeof ftouch.sync;
+}
+
+export = touch;

--- a/touch/touch-tests.ts
+++ b/touch/touch-tests.ts
@@ -1,0 +1,44 @@
+import * as touch from 'touch';
+
+// type value definitions
+const boolVal = true;
+const numVal = 0;
+const strVal = "string";
+const dateVal = new Date();
+
+// Options tests
+let opts: touch.Options = {};
+
+opts.force = boolVal;
+
+opts.time = numVal;
+opts.time = strVal;
+opts.time = dateVal;
+
+opts.atime = boolVal;
+opts.atime = dateVal;
+
+opts.mtime = boolVal;
+opts.mtime = dateVal;
+
+opts.ref = strVal;
+
+opts.nocreate = boolVal;
+
+// touch API tests
+touch(strVal, (e) => console.log(e));
+touch(strVal, opts, (e) => console.log(e));
+
+touch.sync(strVal);
+touch.sync(strVal, opts);
+
+// ftouch API tests
+touch.ftouch(numVal, (e) => console.log(e));
+touch.ftouch(numVal, opts, (e) => console.log(e));
+
+touch.ftouch.sync(numVal);
+touch.ftouch.sync(numVal, opts);
+
+touch.ftouchSync(numVal);
+touch.ftouchSync(numVal, opts);
+

--- a/touch/tsconfig.json
+++ b/touch/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "touch-tests.ts"
+    ]
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

---

Typings for [touch](https://www.npmjs.com/package/touch)
