### PR TITLE
[node] Correct fs.createWriteStream

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -2321,6 +2321,8 @@ declare module "fs" {
         encoding?: string;
         fd?: number;
         mode?: number;
+        autoClose?: boolean;
+        start?: number;
     }): WriteStream;
     export function fdatasync(fd: number, callback: Function): void;
     export function fdatasyncSync(fd: number): void;


### PR DESCRIPTION
# Improvement to existing type definition.

According to this #11537 issue, it points [createWriteStream](https://nodejs.org/api/fs.html#fs_fs_createwritestream_path_options) misses autoClose and start.
