### PR TITLE
add definitions for tz-format

### DIFF
--- a/tz-format/tz-format-tests.ts
+++ b/tz-format/tz-format-tests.ts
@@ -1,0 +1,6 @@
+/// <reference path="tz-format.d.ts" />
+
+import * as format from 'tz-format';
+
+format();
+format(new Date());

--- a/tz-format/tz-format.d.ts
+++ b/tz-format/tz-format.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module "tz-format" {
-	function format(date?: Date);
+	function format(date?: Date): string;
 	namespace format { }
 	export = format;
 }

--- a/tz-format/tz-format.d.ts
+++ b/tz-format/tz-format.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for tz-format
+// Project: https://github.com/SamVerschueren/tz-format
+// Definitions by: Sam Verschueren <https://github.com/samverschueren>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "tz-format" {
+	function format(date?: Date);
+	namespace format { }
+	export = format;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Added defs for [tz-format](https://github.com/SamVerschueren/tz-format).
