### PR TITLE
fix(CKEditor): Fix config.toolbar type

### DIFF
--- a/ckeditor/ckeditor-tests.ts
+++ b/ckeditor/ckeditor-tests.ts
@@ -37,6 +37,23 @@ function test_CKEDITOR() {
     CKEDITOR.replaceAll((textarea, config) => false);
 }
 
+function test_config() {
+    var config1: CKEDITOR.config = {
+        toolbar: 'basic',
+    };
+    var config2: CKEDITOR.config = {
+        toolbar: [
+            [ 'mode', 'document', 'doctools' ],
+            [ 'clipboard', 'undo' ],
+            '/',
+            [ 'find', 'selection', 'spellchecker' ],
+            [ 'basicstyles', 'cleanup' ],
+            '/',
+            [ 'list', 'indent', 'blocks', 'align', 'bidi' ],
+        ],
+    };
+}
+
 function test_dom_comment() {
     var type = CKEDITOR.NODE_COMMENT;
     var nativeNode = document.createComment('Example');

--- a/ckeditor/ckeditor.d.ts
+++ b/ckeditor/ckeditor.d.ts
@@ -796,7 +796,7 @@ declare namespace CKEDITOR {
         templates_files?: Object;
         templates_replaceContent?: boolean;
         title?: string | boolean;
-        toolbar?: string | (string[])[];
+        toolbar?: string | (string | string[])[];
         toolbarCanCollapse?: boolean;
         toolbarGroupCycling?: boolean;
         toolbarGroups?: toolbarGroups[];


### PR DESCRIPTION
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] adds corresponding tests to the test file.

---

The type for toolbar is currently defined as  `string | (string[])[]`,
but it should be `string | (string | string[])[]`.

The `toolbar` property is either:
- a toolbar name (`string`)
- or an array of elements, that can be `string`s (for instance a newline
  marker `'/'`) or `string[]`s (for instance a list of buttons).

For example, this is a valid configuration:

``` js
CKEDITOR.config.toolbar = [
    [ 'mode', 'document', 'doctools' ],
    [ 'clipboard', 'undo' ],
    '/',
    [ 'find', 'selection', 'spellchecker' ],
    [ 'basicstyles', 'cleanup' ],
    '/',
    [ 'list', 'indent', 'blocks', 'align', 'bidi' ],
];
```
