### PR TITLE
feat(CKEditor): Add missing typings for `focusManager`

### DIFF
--- a/ckeditor/ckeditor-tests.ts
+++ b/ckeditor/ckeditor-tests.ts
@@ -300,3 +300,22 @@ function test_adding_widget() {
         });
     }
 }
+
+function test_focusManager() {
+    var textarea = document.createElement('textarea');
+    var instance = CKEDITOR.replace(textarea);
+    var element = CKEDITOR.document.getById('myElement');
+
+    instance.focusManager.focus();
+    instance.focusManager.focus(element);
+    instance.focusManager.lock();
+    instance.focusManager.unlock();
+    instance.focusManager.blur();
+    instance.focusManager.blur(true);
+    instance.focusManager.add(element, true);
+    instance.focusManager.remove(element);
+
+    var focusManager = new CKEDITOR.focusManager(instance);
+    var object: CKEDITOR.dom.domObject = focusManager.currentActive;
+    var bool: boolean = focusManager.hasFocus;
+}

--- a/ckeditor/ckeditor.d.ts
+++ b/ckeditor/ckeditor.d.ts
@@ -544,8 +544,19 @@ declare namespace CKEDITOR {
     }
 
 
-    interface focusManager {
+    class focusManager {
+        // Properties
+        currentActive: dom.domObject;
+        hasFocus: boolean;
 
+        // Methods
+        constructor(editor: editor);
+        focus(currentActive?: dom.element): void;
+        lock(): void;
+        unlock(): void;
+        blur(noDelay?: boolean): void;
+        add(element: dom.element, isCapture: boolean): void;
+        remove(element: dom.element): void;
     }
 
     interface keystrokeHandler {


### PR DESCRIPTION
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] adds corresponding tests to the test file.
