### PR TITLE
Implemented cheap-ruler definition

### DIFF
--- a/cheap-ruler/cheap-ruler-tests.ts
+++ b/cheap-ruler/cheap-ruler-tests.ts
@@ -4,7 +4,7 @@ import * as cheapRuler from 'cheap-ruler'
 
 // -- Fixtures --
 const unit = 'miles'
-const lineString: GeoJSON.Feature<GeoJSON.LineString> = {
+const lineString = {
   "type": "Feature",
   "properties": {},
   "geometry": {
@@ -44,9 +44,9 @@ cheapRuler.units.kilometers
 50 * cheapRuler.units.yards / cheapRuler.units.meters
 
 // -- Test cheapRuler --
-const ruler = cheapRuler(35.05, 'kilometers')
+const ruler = cheapRuler(35.05)
 
-console.log(ruler.distance([30.5, 50.5], [30.51, 50.49]))
+ruler.distance([30.5, 50.5], [30.51, 50.49])
 ruler.bearing([30.5, 50.5], [30.51, 50.49])
 ruler.destination([30.5, 50.5], 0.1, 90)
 ruler.lineDistance(points)

--- a/cheap-ruler/cheap-ruler-tests.ts
+++ b/cheap-ruler/cheap-ruler-tests.ts
@@ -3,6 +3,9 @@
 import * as cheapRuler from 'cheap-ruler'
 
 // -- Fixtures --
+const bbox = [30.5, 50.5, 31, 51]
+const point1 = [30.5, 50.5]
+const point2 = [30.51, 50.49]
 const unit = 'miles'
 const lineString = {
   "type": "Feature",
@@ -46,15 +49,15 @@ cheapRuler.units.kilometers
 // -- Test cheapRuler --
 const ruler = cheapRuler(35.05)
 
-ruler.distance([30.5, 50.5], [30.51, 50.49])
-ruler.bearing([30.5, 50.5], [30.51, 50.49])
-ruler.destination([30.5, 50.5], 0.1, 90)
+ruler.distance(point1, point2)
+ruler.bearing(point1, point2)
+ruler.destination(point1, 0.1, 90)
 ruler.lineDistance(points)
 ruler.area(polygon)
 ruler.along(line, 2.5)
-ruler.pointOnLine(line, [-67.04, 50.5]).point
-ruler.lineSlice([-67.04, 50.5], [-67.05, 50.56], line)
+ruler.pointOnLine(line, point1).point
+ruler.lineSlice(point1, point2, line)
 ruler.lineSliceAlong(10, 20, line)
-ruler.bufferPoint([30.5, 50.5], 0.01)
-ruler.bufferBBox([30.5, 50.5, 31, 51], 0.2)
-ruler.insideBBox([30.5, 50.5], [30, 50, 31, 51])
+ruler.bufferPoint(point1, 0.01)
+ruler.bufferBBox(bbox, 0.2)
+ruler.insideBBox(point1, bbox)

--- a/cheap-ruler/cheap-ruler-tests.ts
+++ b/cheap-ruler/cheap-ruler-tests.ts
@@ -1,0 +1,60 @@
+/// <reference path="cheap-ruler.d.ts"/>
+
+import * as cheapRuler from 'cheap-ruler'
+
+// -- Fixtures --
+const unit = 'miles'
+const lineString: GeoJSON.Feature<GeoJSON.LineString> = {
+  "type": "Feature",
+  "properties": {},
+  "geometry": {
+    "type": "LineString",
+    "coordinates": [
+      [-77.031669, 38.878605],
+      [-77.029609, 38.881946],
+      [-77.020339, 38.884084],
+      [-77.025661, 38.885821],
+      [-77.021884, 38.889563],
+      [-77.019824, 38.892368]
+    ]
+  }
+}
+const line = lineString.geometry.coordinates
+const polygon = [[
+    [-67.031, 50.458], [-67.031, 50.534], [-66.929, 50.534],
+    [-66.929, 50.458], [-67.031, 50.458]
+]]
+const points = [
+    [-67.031, 50.458], [-67.031, 50.534],
+    [-66.929, 50.534], [-66.929, 50.458]
+]
+
+// -- Test initiators --
+cheapRuler(35.05)
+cheapRuler(35.05, 'miles')
+cheapRuler(35.05, unit)
+cheapRuler.fromTile(1567, 12)
+cheapRuler.fromTile(1567, 12, 'miles')
+cheapRuler.fromTile(1567, 12, unit)
+
+// -- Test units --
+cheapRuler.units
+cheapRuler.units.miles
+cheapRuler.units.kilometers
+50 * cheapRuler.units.yards / cheapRuler.units.meters
+
+// -- Test cheapRuler --
+const ruler = cheapRuler(35.05, 'kilometers')
+
+console.log(ruler.distance([30.5, 50.5], [30.51, 50.49]))
+ruler.bearing([30.5, 50.5], [30.51, 50.49])
+ruler.destination([30.5, 50.5], 0.1, 90)
+ruler.lineDistance(points)
+ruler.area(polygon)
+ruler.along(line, 2.5)
+ruler.pointOnLine(line, [-67.04, 50.5]).point
+ruler.lineSlice([-67.04, 50.5], [-67.05, 50.56], line)
+ruler.lineSliceAlong(10, 20, line)
+ruler.bufferPoint([30.5, 50.5], 0.01)
+ruler.bufferBBox([30.5, 50.5, 31, 51], 0.2)
+ruler.insideBBox([30.5, 50.5], [30, 50, 31, 51])

--- a/cheap-ruler/cheap-ruler.d.ts
+++ b/cheap-ruler/cheap-ruler.d.ts
@@ -1,0 +1,226 @@
+// Type definitions for cheap-ruler 2.4.1
+// Project: https://github.com/mapbox/cheap-ruler
+// Definitions by: Denis Carriere <https://github.com/DenisCarriere>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../geojson/geojson.d.ts" />
+
+declare module "cheap-ruler" {
+    interface TemplateUnits {
+        kilometers: number
+        miles: number
+        nauticalmiles: number
+        meters: number
+        metres: number
+        yards: number
+        feet: number
+        inches: number
+    }
+    interface InterfacePointOnLine {
+        point: Array<number>
+        index: number
+        t: number
+    }
+    class CheapRuler {
+        /**
+         * Given two points of the form [longitude, latitude], returns the distance.
+         *
+         * @name distance
+         * @param {Array<number>} a point [longitude, latitude]
+         * @param {Array<number>} b point [longitude, latitude]
+         * @returns {number} distance
+         * @example
+         * var distance = ruler.distance([30.5, 50.5], [30.51, 50.49]);
+         * //=distance
+         */
+        distance(a: Array<number>, b: Array<number>): number;
+
+        /**
+         * Returns the bearing between two points in angles.
+         *
+         * @name bearing
+         * @param {Array<number>} a point [longitude, latitude]
+         * @param {Array<number>} b point [longitude, latitude]
+         * @returns {number} bearing
+         * @example
+         * var bearing = ruler.bearing([30.5, 50.5], [30.51, 50.49]);
+         * //=bearing
+         */
+        bearing(a: Array<number>, b: Array<number>): number;
+
+        /**
+         * Returns a new point given distance and bearing from the starting point.
+         *
+         * @name destination
+         * @param {Array<number>} p point [longitude, latitude]
+         * @param {number} dist distance
+         * @param {number} bearing
+         * @returns {Array<number>} point [longitude, latitude]
+         * @example
+         * var point = ruler.destination([30.5, 50.5], 0.1, 90);
+         * //=point
+         */
+        destination(p: Array<number>, dist: number, bearing: number): Array<number>;
+
+        /**
+         * Given a line (an array of points), returns the total line distance.
+         *
+         * @name lineDistance
+         * @param {Array<Array<number>>} points [longitude, latitude]
+         * @returns {number} total line distance
+         * @example
+         * var length = ruler.lineDistance([
+         *     [-67.031, 50.458], [-67.031, 50.534],
+         *     [-66.929, 50.534], [-66.929, 50.458]
+         * ]);
+         * //=length
+         */
+        lineDistance(points: Array<Array<number>>): number;
+
+        /**
+         * Given a polygon (an array of rings, where each ring is an array of points), returns the area.
+         *
+         * @name area
+         * @param {Array<Array<Array<number>>>} polygon
+         * @returns {number} area value in the specified units (square kilometers by default)
+         * @example
+         * var area = ruler.area([[
+         *     [-67.031, 50.458], [-67.031, 50.534], [-66.929, 50.534],
+         *     [-66.929, 50.458], [-67.031, 50.458]
+         * ]]);
+         * //=area
+         */
+        area(polygon: Array<Array<Array<number>>>): number;
+
+        /**
+         * Returns the point at a specified distance along the line.
+         *
+         * @name along
+         * @param {Array<Array<number>>} line
+         * @param {number} dist distance
+         * @returns {Array<number>} point [longitude, latitude]
+         * @example
+         * var point = ruler.along(line, 2.5);
+         * //=point
+         */
+        along(line: Array<Array<number>>, dist: number): Array<number>
+
+        /**
+         * Returns an object of the form {point, index} where point is closest point on the line from the given point, and index is the start index of the segment with the closest point.
+         *
+         * @pointOnLine
+         * @param {Array<Array<number>>} line
+         * @param {Array<number>} p point [longitude, latitude]
+         * @returns {Object} {point, index}
+         * @example
+         * var point = ruler.pointOnLine(line, [-67.04, 50.5]).point;
+         * //=point
+         */
+        pointOnLine(line: Array<Array<number>>, p: Array<number>): InterfacePointOnLine
+
+        /**
+         * Returns a part of the given line between the start and the stop points (or their closest points on the line).
+         *
+         * @name lineSlice
+         * @param {Array<number>} start point [longitude, latitude]
+         * @param {Array<number>} stop point [longitude, latitude]
+         * @param {Array<Array<number>>} line
+         * @returns {Array<Array<number>>} line part of a line
+         * @example
+         * var line2 = ruler.lineSlice([-67.04, 50.5], [-67.05, 50.56], line1);
+         * //=line2
+         */
+        lineSlice(start: Array<number>, stop: Array<number>, line: Array<Array<number>>): Array<Array<number>>
+
+        /**
+         * Returns a part of the given line between the start and the stop points indicated by distance along the line.
+         *
+         * @name lineSliceAlong
+         * @param {number} start distance
+         * @param {number} stop distance
+         * @param {Array<Array<number>>} line
+         * @returns {Array<Array<number>>} line part of a line
+         * @example
+         * var line2 = ruler.lineSliceAlong(10, 20, line1);
+         * //=line2
+         */
+        lineSliceAlong(start: number, stop: number, line: Array<Array<number>>): Array<Array<number>>
+
+        /**
+         * Given a point, returns a bounding box object ([w, s, e, n]) created from the given point buffered by a given distance.
+         *
+         * @name bufferPoint
+         * @param {Array<number>} p point [longitude, latitude]
+         * @param {number} buffer
+         * @returns {Array<number>} box object ([w, s, e, n])
+         * @example
+         * var bbox = ruler.bufferPoint([30.5, 50.5], 0.01);
+         * //=bbox
+         */
+        bufferPoint(p: Array<number>, buffer: number): Array<number>
+
+        /**
+         * Given a bounding box, returns the box buffered by a given distance.
+         *
+         * @name bufferBBox
+         * @param {Array<number>} box object ([w, s, e, n])
+         * @param {number} buffer
+         * @returns {Array<number>} box object ([w, s, e, n])
+         * @example
+         * var bbox = ruler.bufferBBox([30.5, 50.5, 31, 51], 0.2);
+         * //=bbox
+         */
+        bufferBBox(bbox: Array<number>, buffer: number): Array<number>
+
+        /**
+         * Returns true if the given point is inside in the given bounding box, otherwise false.
+         *
+         * @name insideBBox
+         * @param {Array<number>} p point [longitude, latitude]
+         * @param {Array<number>} box object ([w, s, e, n])
+         * @returns {boolean}
+         * @example
+         * var inside = ruler.insideBBox([30.5, 50.5], [30, 50, 31, 51]);
+         * //=inside
+         */
+        insideBBox(p: Array<number>, bbox: Array<number>): boolean
+    }
+    /**
+     * A collection of very fast approximations to common geodesic measurements. Useful for performance-sensitive code that measures things on a city scale.
+     *
+     * @name cheapRuler
+     * @param {number} lat latitude
+     * @param {string} [units='kilometers']
+     * @returns {Object} CheapRuler
+     * @example
+     * var ruler = cheapRuler(35.05, 'miles');
+     * //=ruler
+     */
+    function cheapRuler(lat: number, units?: string): CheapRuler;
+    namespace cheapRuler {
+        /**
+         * Multipliers for converting between units.
+         *
+         * @name units
+         * @example
+         * // convert 50 meters to yards
+         * 50 * cheapRuler.units.yards / cheapRuler.units.meters;
+         */
+        const units: TemplateUnits
+
+        /**
+         * Creates a ruler object from tile coordinates (y and z). Convenient in tile-reduce scripts.
+         *
+         * @name fromTile
+         * @param {number} y
+         * @param {number} z
+         * @param {string} [units='kilometers']
+         * @returns {Object} CheapRuler
+         * @example
+         * var ruler = cheapRuler.fromTile(1567, 12);
+         * //=ruler
+         */
+        function fromTile(y: number, z: number, units?: string)
+    }
+    export = cheapRuler
+}

--- a/cheap-ruler/cheap-ruler.d.ts
+++ b/cheap-ruler/cheap-ruler.d.ts
@@ -23,7 +23,6 @@ declare module "cheap-ruler" {
         /**
          * Given two points of the form [longitude, latitude], returns the distance.
          *
-         * @name distance
          * @param {Array<number>} a point [longitude, latitude]
          * @param {Array<number>} b point [longitude, latitude]
          * @returns {number} distance
@@ -36,7 +35,6 @@ declare module "cheap-ruler" {
         /**
          * Returns the bearing between two points in angles.
          *
-         * @name bearing
          * @param {Array<number>} a point [longitude, latitude]
          * @param {Array<number>} b point [longitude, latitude]
          * @returns {number} bearing
@@ -49,7 +47,6 @@ declare module "cheap-ruler" {
         /**
          * Returns a new point given distance and bearing from the starting point.
          *
-         * @name destination
          * @param {Array<number>} p point [longitude, latitude]
          * @param {number} dist distance
          * @param {number} bearing
@@ -63,7 +60,6 @@ declare module "cheap-ruler" {
         /**
          * Given a line (an array of points), returns the total line distance.
          *
-         * @name lineDistance
          * @param {Array<Array<number>>} points [longitude, latitude]
          * @returns {number} total line distance
          * @example
@@ -78,7 +74,6 @@ declare module "cheap-ruler" {
         /**
          * Given a polygon (an array of rings, where each ring is an array of points), returns the area.
          *
-         * @name area
          * @param {Array<Array<Array<number>>>} polygon
          * @returns {number} area value in the specified units (square kilometers by default)
          * @example
@@ -93,7 +88,6 @@ declare module "cheap-ruler" {
         /**
          * Returns the point at a specified distance along the line.
          *
-         * @name along
          * @param {Array<Array<number>>} line
          * @param {number} dist distance
          * @returns {Array<number>} point [longitude, latitude]
@@ -119,7 +113,6 @@ declare module "cheap-ruler" {
         /**
          * Returns a part of the given line between the start and the stop points (or their closest points on the line).
          *
-         * @name lineSlice
          * @param {Array<number>} start point [longitude, latitude]
          * @param {Array<number>} stop point [longitude, latitude]
          * @param {Array<Array<number>>} line
@@ -133,7 +126,6 @@ declare module "cheap-ruler" {
         /**
          * Returns a part of the given line between the start and the stop points indicated by distance along the line.
          *
-         * @name lineSliceAlong
          * @param {number} start distance
          * @param {number} stop distance
          * @param {Array<Array<number>>} line
@@ -147,7 +139,6 @@ declare module "cheap-ruler" {
         /**
          * Given a point, returns a bounding box object ([w, s, e, n]) created from the given point buffered by a given distance.
          *
-         * @name bufferPoint
          * @param {Array<number>} p point [longitude, latitude]
          * @param {number} buffer
          * @returns {Array<number>} box object ([w, s, e, n])
@@ -160,7 +151,6 @@ declare module "cheap-ruler" {
         /**
          * Given a bounding box, returns the box buffered by a given distance.
          *
-         * @name bufferBBox
          * @param {Array<number>} box object ([w, s, e, n])
          * @param {number} buffer
          * @returns {Array<number>} box object ([w, s, e, n])
@@ -173,7 +163,6 @@ declare module "cheap-ruler" {
         /**
          * Returns true if the given point is inside in the given bounding box, otherwise false.
          *
-         * @name insideBBox
          * @param {Array<number>} p point [longitude, latitude]
          * @param {Array<number>} box object ([w, s, e, n])
          * @returns {boolean}
@@ -186,10 +175,9 @@ declare module "cheap-ruler" {
     /**
      * A collection of very fast approximations to common geodesic measurements. Useful for performance-sensitive code that measures things on a city scale.
      *
-     * @name cheapRuler
      * @param {number} lat latitude
      * @param {string} [units='kilometers']
-     * @returns {Object} CheapRuler
+     * @returns {CheapRuler}
      * @example
      * var ruler = cheapRuler(35.05, 'miles');
      * //=ruler
@@ -199,7 +187,6 @@ declare module "cheap-ruler" {
         /**
          * Multipliers for converting between units.
          *
-         * @name units
          * @example
          * // convert 50 meters to yards
          * 50 * cheapRuler.units.yards / cheapRuler.units.meters;
@@ -209,11 +196,10 @@ declare module "cheap-ruler" {
         /**
          * Creates a ruler object from tile coordinates (y and z). Convenient in tile-reduce scripts.
          *
-         * @name fromTile
          * @param {number} y
          * @param {number} z
          * @param {string} [units='kilometers']
-         * @returns {Object} CheapRuler
+         * @returns {CheapRuler}
          * @example
          * var ruler = cheapRuler.fromTile(1567, 12);
          * //=ruler

--- a/cheap-ruler/cheap-ruler.d.ts
+++ b/cheap-ruler/cheap-ruler.d.ts
@@ -4,6 +4,12 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module "cheap-ruler" {
+    type BBox = [number, number, number, number] | number[]
+    type Point = [number, number] | number[]
+    type Line = Array<Point>
+    type Points = Array<Point>
+    type Polygon = Array<Array<Point>>
+
     interface TemplateUnits {
         kilometers: number
         miles: number
@@ -15,7 +21,7 @@ declare module "cheap-ruler" {
         inches: number
     }
     interface InterfacePointOnLine {
-        point: Array<number>
+        point: Point
         index: number
         t: number
     }
@@ -23,44 +29,44 @@ declare module "cheap-ruler" {
         /**
          * Given two points of the form [longitude, latitude], returns the distance.
          *
-         * @param {Array<number>} a point [longitude, latitude]
-         * @param {Array<number>} b point [longitude, latitude]
+         * @param {Point} a point [longitude, latitude]
+         * @param {Point} b point [longitude, latitude]
          * @returns {number} distance
          * @example
          * var distance = ruler.distance([30.5, 50.5], [30.51, 50.49]);
          * //=distance
          */
-        distance(a: Array<number>, b: Array<number>): number;
+        distance(a: Point, b: Point): number;
 
         /**
          * Returns the bearing between two points in angles.
          *
-         * @param {Array<number>} a point [longitude, latitude]
-         * @param {Array<number>} b point [longitude, latitude]
+         * @param {Point} a point [longitude, latitude]
+         * @param {Point} b point [longitude, latitude]
          * @returns {number} bearing
          * @example
          * var bearing = ruler.bearing([30.5, 50.5], [30.51, 50.49]);
          * //=bearing
          */
-        bearing(a: Array<number>, b: Array<number>): number;
+        bearing(a: Point, b: Point): number;
 
         /**
          * Returns a new point given distance and bearing from the starting point.
          *
-         * @param {Array<number>} p point [longitude, latitude]
+         * @param {Point} p point [longitude, latitude]
          * @param {number} dist distance
          * @param {number} bearing
-         * @returns {Array<number>} point [longitude, latitude]
+         * @returns {Point} point [longitude, latitude]
          * @example
          * var point = ruler.destination([30.5, 50.5], 0.1, 90);
          * //=point
          */
-        destination(p: Array<number>, dist: number, bearing: number): Array<number>;
+        destination(p: Point, dist: number, bearing: number): Point;
 
         /**
          * Given a line (an array of points), returns the total line distance.
          *
-         * @param {Array<Array<number>>} points [longitude, latitude]
+         * @param {Points} points [longitude, latitude]
          * @returns {number} total line distance
          * @example
          * var length = ruler.lineDistance([
@@ -69,12 +75,12 @@ declare module "cheap-ruler" {
          * ]);
          * //=length
          */
-        lineDistance(points: Array<Array<number>>): number;
+        lineDistance(points: Points): number;
 
         /**
          * Given a polygon (an array of rings, where each ring is an array of points), returns the area.
          *
-         * @param {Array<Array<Array<number>>>} polygon
+         * @param {Polygon} polygon
          * @returns {number} area value in the specified units (square kilometers by default)
          * @example
          * var area = ruler.area([[
@@ -83,94 +89,94 @@ declare module "cheap-ruler" {
          * ]]);
          * //=area
          */
-        area(polygon: Array<Array<Array<number>>>): number;
+        area(polygon: Polygon): number;
 
         /**
          * Returns the point at a specified distance along the line.
          *
-         * @param {Array<Array<number>>} line
+         * @param {Line} line
          * @param {number} dist distance
-         * @returns {Array<number>} point [longitude, latitude]
+         * @returns {Point} point [longitude, latitude]
          * @example
          * var point = ruler.along(line, 2.5);
          * //=point
          */
-        along(line: Array<Array<number>>, dist: number): Array<number>
+        along(line: Line, dist: number): Point
 
         /**
          * Returns an object of the form {point, index} where point is closest point on the line from the given point, and index is the start index of the segment with the closest point.
          *
          * @pointOnLine
-         * @param {Array<Array<number>>} line
-         * @param {Array<number>} p point [longitude, latitude]
+         * @param {Line} line
+         * @param {Point} p point [longitude, latitude]
          * @returns {Object} {point, index}
          * @example
          * var point = ruler.pointOnLine(line, [-67.04, 50.5]).point;
          * //=point
          */
-        pointOnLine(line: Array<Array<number>>, p: Array<number>): InterfacePointOnLine
+        pointOnLine(line: Line, p: Point): InterfacePointOnLine
 
         /**
          * Returns a part of the given line between the start and the stop points (or their closest points on the line).
          *
-         * @param {Array<number>} start point [longitude, latitude]
-         * @param {Array<number>} stop point [longitude, latitude]
-         * @param {Array<Array<number>>} line
-         * @returns {Array<Array<number>>} line part of a line
+         * @param {Point} start point [longitude, latitude]
+         * @param {Point} stop point [longitude, latitude]
+         * @param {Line} line
+         * @returns {Line} line part of a line
          * @example
          * var line2 = ruler.lineSlice([-67.04, 50.5], [-67.05, 50.56], line1);
          * //=line2
          */
-        lineSlice(start: Array<number>, stop: Array<number>, line: Array<Array<number>>): Array<Array<number>>
+        lineSlice(start: Point, stop: Point, line: Line): Line
 
         /**
          * Returns a part of the given line between the start and the stop points indicated by distance along the line.
          *
          * @param {number} start distance
          * @param {number} stop distance
-         * @param {Array<Array<number>>} line
-         * @returns {Array<Array<number>>} line part of a line
+         * @param {Line} line
+         * @returns {Line} line part of a line
          * @example
          * var line2 = ruler.lineSliceAlong(10, 20, line1);
          * //=line2
          */
-        lineSliceAlong(start: number, stop: number, line: Array<Array<number>>): Array<Array<number>>
+        lineSliceAlong(start: number, stop: number, line: Line): Line
 
         /**
          * Given a point, returns a bounding box object ([w, s, e, n]) created from the given point buffered by a given distance.
          *
-         * @param {Array<number>} p point [longitude, latitude]
+         * @param {Point} p point [longitude, latitude]
          * @param {number} buffer
-         * @returns {Array<number>} box object ([w, s, e, n])
+         * @returns {BBox} box object ([w, s, e, n])
          * @example
          * var bbox = ruler.bufferPoint([30.5, 50.5], 0.01);
          * //=bbox
          */
-        bufferPoint(p: Array<number>, buffer: number): Array<number>
+        bufferPoint(p: Point, buffer: number): BBox
 
         /**
          * Given a bounding box, returns the box buffered by a given distance.
          *
-         * @param {Array<number>} box object ([w, s, e, n])
+         * @param {BBox} box object ([w, s, e, n])
          * @param {number} buffer
-         * @returns {Array<number>} box object ([w, s, e, n])
+         * @returns {BBox} box object ([w, s, e, n])
          * @example
          * var bbox = ruler.bufferBBox([30.5, 50.5, 31, 51], 0.2);
          * //=bbox
          */
-        bufferBBox(bbox: Array<number>, buffer: number): Array<number>
+        bufferBBox(bbox: BBox, buffer: number): BBox
 
         /**
          * Returns true if the given point is inside in the given bounding box, otherwise false.
          *
-         * @param {Array<number>} p point [longitude, latitude]
-         * @param {Array<number>} box object ([w, s, e, n])
+         * @param {Point} p point [longitude, latitude]
+         * @param {Point} box object ([w, s, e, n])
          * @returns {boolean}
          * @example
          * var inside = ruler.insideBBox([30.5, 50.5], [30, 50, 31, 51]);
          * //=inside
          */
-        insideBBox(p: Array<number>, bbox: Array<number>): boolean
+        insideBBox(p: Point, bbox: BBox): boolean
     }
     /**
      * A collection of very fast approximations to common geodesic measurements. Useful for performance-sensitive code that measures things on a city scale.

--- a/cheap-ruler/cheap-ruler.d.ts
+++ b/cheap-ruler/cheap-ruler.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Denis Carriere <https://github.com/DenisCarriere>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../geojson/geojson.d.ts" />
-
 declare module "cheap-ruler" {
     interface TemplateUnits {
         kilometers: number

--- a/cheap-ruler/cheap-ruler.d.ts
+++ b/cheap-ruler/cheap-ruler.d.ts
@@ -218,7 +218,7 @@ declare module "cheap-ruler" {
          * var ruler = cheapRuler.fromTile(1567, 12);
          * //=ruler
          */
-        function fromTile(y: number, z: number, units?: string)
+        function fromTile(y: number, z: number, units?: string): CheapRuler;
     }
     export = cheapRuler
 }


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Added `cheap-ruler` definition
https://github.com/mapbox/cheap-ruler
