### PR TITLE
[types-2.0] d3-format d3-timer d3-random JSDoc comments and Enhancement

### DIFF
--- a/d3-format/d3-format-tests.ts
+++ b/d3-format/d3-format-tests.ts
@@ -37,14 +37,14 @@ formatFn = d3Format.formatPrefix(',.0', 1e-6);
 specifier = d3Format.formatSpecifier('.0%');
 
 let fill: string = specifier.fill;
-let align: string = specifier.align;
-let sign: string = specifier.sign;
-let symbol: string = specifier.symbol;
+let align: '>' | '<' | '^' | '=' = specifier.align;
+let sign: '-' | '+' | '(' | ' ' = specifier.sign;
+let symbol: '$' | '#' | '' = specifier.symbol;
 let zero: boolean = specifier.zero;
-let width: number = specifier.width;
+let width: number | undefined = specifier.width;
 let comma: boolean = specifier.comma;
 let precision: number = specifier.precision;
-let type: string = specifier.type;
+let type: 'e' | 'f' | 'g' | 'r' | 's' | '%' | 'p' | 'b' | 'o' | 'd' | 'x' | 'X' | 'c' | '' | 'n' = specifier.type;
 
 let formatString: string = specifier.toString();
 

--- a/d3-format/index.d.ts
+++ b/d3-format/index.d.ts
@@ -26,7 +26,9 @@ export interface FormatLocaleDefinition {
     currency: [string, string];
 }
 
-
+/**
+ * A Format Locale Object
+ */
 export interface FormatLocaleObject {
 
     /**
@@ -49,23 +51,98 @@ export interface FormatLocaleObject {
     formatPrefix(specifier: string, value: number): (n: number) => string;
 }
 
-
+/**
+ * A Format Specifier
+ *
+ * For details see: {@link https://github.com/d3/d3-format#locale_format}
+ */
 export interface FormatSpecifier {
+    /**
+     * fill can be any character. The presence of a fill character is signaled by the align character following it.
+     */
     fill: string;
-    align: string;
-    sign: string;
-    symbol: string;
+    /**
+     * Alignment used for format, as set by choosing one of the following
+     *
+     * '>' - Forces the field to be right-aligned within the available space. (Default behavior).
+     * '<' - Forces the field to be left-aligned within the available space.
+     * '^' - Forces the field to be centered within the available space.
+     * '=' - Like '>', but with any sign and symbol to the left of any padding.
+     */
+    align: '>' | '<' | '^' | '=';
+    /**
+     * The sign can be:
+     *
+     * '-' - nothing for positive and a minus sign for negative. (Default behavior.)
+     * '+' -  a plus sign for positive and a minus sign for negative.
+     * '(' - nothing for positive and parentheses for negative.
+     * ' '(space) -  a space for positive and a minus sign for negative.
+     *
+     */
+    sign: '-' | '+' | '(' | ' ';
+    /**
+     * The symbol can be:
+     *
+     * '$' - apply currency symbols per the locale definition.
+     * '#' - for binary, octal, or hexadecimal notation, prefix by 0b, 0o, or 0x, respectively.
+     * ''(none) - no symbol.
+     */
+    symbol: '$' | '#' | '';
+    /**
+     * The zero (0) option enables zero-padding; this implicitly sets fill to 0 and align to =.
+     */
     zero: boolean;
-    width: number;
+    /**
+     * The width defines the minimum field width;
+     * if not specified, then the width will be determined by the content.
+     */
+    width: number | undefined;
+    /**
+     * The comma (,) option enables the use of a group separator, such as a comma for thousands.
+     */
     comma: boolean;
+    /**
+     * Depending on the type, the precision either indicates the number of digits that follow the decimal point (types 'f' and '%'),
+     * or the number of significant digits (types ''​ (none), 'e', 'g', 'r', 's' and 'p'). If the precision is not specified,
+     * it defaults to 6 for all types except ''​ (none), which defaults to 12.
+     * Precision is ignored for integer formats (types 'b', 'o', 'd', 'x', 'X' and 'c').
+     *
+     * See precisionFixed and precisionRound for help picking an appropriate precision
+     */
     precision: number;
-    type: string;
+    /**
+     * The available type values are:
+     *
+     * 'e' - exponent notation.
+     * 'f' - fixed point notation.
+     * 'g' - either decimal or exponent notation, rounded to significant digits.
+     * 'r' - decimal notation, rounded to significant digits.
+     * 's' - decimal notation with an SI prefix, rounded to significant digits.
+     * '%' - multiply by 100, and then decimal notation with a percent sign.
+     * 'p' - multiply by 100, round to significant digits, and then decimal notation with a percent sign.
+     * 'b' - binary notation, rounded to integer.
+     * 'o' - octal notation, rounded to integer.
+     * 'd' - decimal notation, rounded to integer.
+     * 'x' - hexadecimal notation, using lower-case letters, rounded to integer.
+     * 'X' - hexadecimal notation, using upper-case letters, rounded to integer.
+     * 'c' - converts the integer to the corresponding unicode character before printing.
+     * '' (none) - like g, but trim insignificant trailing zeros.
+     *
+     * The type 'n' is also supported as shorthand for ',g'. For the 'g', 'n' and ​''(none) types,
+     * decimal notation is used if the resulting string would have precision or fewer digits; otherwise, exponent notation is used.
+     */
+    type: 'e' | 'f' | 'g' | 'r' | 's' | '%' | 'p' | 'b' | 'o' | 'd' | 'x' | 'X' | 'c' | '' | 'n';
+    /**
+     * Return the object as a specifier string.
+     */
     toString(): string;
 }
 
 /**
  * Create a new locale-based object which exposes format(...) and formatPrefix(...)
  * methods for the specified locale.
+ *
+ * @param locale A Format locale definition.
  */
 export function formatLocale(locale: FormatLocaleDefinition): FormatLocaleObject;
 
@@ -73,6 +150,8 @@ export function formatLocale(locale: FormatLocaleDefinition): FormatLocaleObject
  * Create a new locale-based object which exposes format(...) and formatPrefix(...)
  * methods for the specified locale definition. The specified locale definition will be
  * set as the new default locale definition.
+ *
+ * @param defaultLocale A Format locale definition to be used as default.
  */
 export function formatDefaultLocale(defaultLocale: FormatLocaleDefinition): FormatLocaleObject;
 
@@ -81,6 +160,9 @@ export function formatDefaultLocale(defaultLocale: FormatLocaleDefinition): Form
  * takes a number as the only argument, and returns a string representing the formatted number.
  *
  * Uses the current default locale.
+ *
+ * The general form of a specifier is [​[fill]align][sign][symbol][0][width][,][.precision][type].
+ * For reference, an explanation of the segments of the specifier string, refer to the FormatSpecifier interface properties.
  *
  * @param specifier A Specifier string
  */
@@ -94,6 +176,9 @@ export function format(specifier: string): (n: number) => string;
  *
  *  Uses the current default locale.
  *
+ * The general form of a specifier is [​[fill]align][sign][symbol][0][width][,][.precision][type].
+ * For reference, an explanation of the segments of the specifier string, refer to the FormatSpecifier interface properties.
+ *
  * @param specifier A Specifier string
  * @param value The reference value to determine the appropriate SI prefix.
  */
@@ -102,6 +187,9 @@ export function formatPrefix(specifier: string, value: number): (n: number) => s
 /**
  * Parses the specified specifier, returning an object with exposed fields that correspond to the
  * format specification mini-language and a toString method that reconstructs the specifier.
+ *
+ * The general form of a specifier is [​[fill]align][sign][symbol][0][width][,][.precision][type].
+ * For reference, an explanation of the segments of the specifier string, refer to the FormatSpecifier interface properties.
  *
  * @param specifier A specifier string.
  */

--- a/d3-random/index.d.ts
+++ b/d3-random/index.d.ts
@@ -7,6 +7,9 @@
  * Returns a function for generating random numbers with a uniform distribution).
  * The minimum allowed value of a returned number is min, and the maximum is max.
  * If min is not specified, it defaults to 0; if max is not specified, it defaults to 1.
+ *
+ * @param min The minimum allowed value of a returned number, defaults to 0.
+ * @param max The maximum allowed value of a returned number, defaults to 1.
  */
 export function randomUniform(min?: number, max?: number): () => number;
 
@@ -14,27 +17,39 @@ export function randomUniform(min?: number, max?: number): () => number;
  * Returns a function for generating random numbers with a normal (Gaussian) distribution.
  * The expected value of the generated numbers is mu, with the given standard deviation sigma.
  * If mu is not specified, it defaults to 0; if sigma is not specified, it defaults to 1.
+ *
+ * @param mu Expected value, defaults to 0.
+ * @param sigma Standard deviation, defaults to 1.
  */
 export function randomNormal(mu?: number, sigma?: number): () => number;
 
 /**
  * Returns a function for generating random numbers with a log-normal distribution. The expected value of the random variable’s natural logrithm is mu,
  * with the given standard deviation sigma. If mu is not specified, it defaults to 0; if sigma is not specified, it defaults to 1.
+ *
+ * @param mu Expected value, defaults to 0.
+ * @param sigma Standard deviation, defaults to 1.
  */
 export function randomLogNormal(mu?: number, sigma?: number): () => number;
 
 /**
  * Returns a function for generating random numbers with a Bates distribution with n independent variables.
+ *
+ * @param n Number of independent random variables to use.
  */
 export function randomBates(n: number): () => number;
 
 /**
  * Returns a function for generating random numbers with an Irwin–Hall distribution with n independent variables.
+ *
+ * @param n Number of independent random variables to use.
  */
 export function randomIrwinHall(n: number): () => number;
 
 /**
  * Returns a function for generating random numbers with an exponential distribution with the rate lambda;
  * equivalent to time between events in a Poisson process with a mean of 1 / lambda.
+ *
+ * @param lambda Expected time between events.
  */
 export function randomExponential(lambda: number): () => number;

--- a/d3-timer/index.d.ts
+++ b/d3-timer/index.d.ts
@@ -17,10 +17,11 @@ export interface Timer {
      * Restart a timer with the specified callback and optional delay and time.
      * This is equivalent to stopping this timer and creating a new timer with the specified arguments,
      * although this timer retains the original invocation priority.
+     *
      * @param callback A callback function to be invoked and passed in the apparent
      * elapsed time since the timer became active in milliseconds.
-     * @param [delay] An optional numeric delay in milliseconds (default = 0) relative to time.
-     * @param [time] An optional time in milliseconds relative to which the delay is calculated (default = now).
+     * @param delay An optional numeric delay in milliseconds (default = 0) relative to time.
+     * @param time An optional time in milliseconds relative to which the delay is calculated (default = now).
      */
     restart(callbackFn: (elapsed: number) => void, delay?: number, time?: number): void;
 
@@ -36,8 +37,8 @@ export interface Timer {
  *
  * @param callback A callback function to be invoked and passed in the apparent
  * elapsed time since the timer became active in milliseconds.
- * @param [delay] An optional numeric delay in milliseconds (default = 0) relative to time.
- * @param [time] An optional time in milliseconds relative to which the delay is calculated (default = now).
+ * @param delay An optional numeric delay in milliseconds (default = 0) relative to time.
+ * @param time An optional time in milliseconds relative to which the delay is calculated (default = now).
  */
 export function timer(callback: (elapsed: number) => void, delay?: number, time?: number): Timer;
 
@@ -52,8 +53,8 @@ export function timerFlush(): void;
  *
  * @param callback A callback function to be invoked and passed in the apparent
  * elapsed time since the timer became active in milliseconds.
- * @param [delay] An optional numeric delay in milliseconds (default = 0) relative to time.
- * @param [time] An optional time in milliseconds relative to which the delay is calculated (default = now).
+ * @param delay An optional numeric delay in milliseconds (default = 0) relative to time.
+ * @param time An optional time in milliseconds relative to which the delay is calculated (default = now).
  */
 export function timeout(callback: (elapsed: number) => void, delay?: number, time?: number): Timer;
 
@@ -64,8 +65,8 @@ export function timeout(callback: (elapsed: number) => void, delay?: number, tim
  *
  * @param callback A callback function to be invoked and passed in the apparent
  * elapsed time since the timer became active in milliseconds.
- * @param [delay] An optional numeric delay in milliseconds between repeat invocations of the callback.
+ * @param delay An optional numeric delay in milliseconds between repeat invocations of the callback.
  * If not specified, the interval timer behaves like the regular timer.
- * @param [time] An optional time in milliseconds relative to which the initial delay is calculated (default = now).
+ * @param time An optional time in milliseconds relative to which the initial delay is calculated (default = now).
  */
 export function interval(callback: (elapsed: number) => void, delay?: number, time?: number): Timer;


### PR DESCRIPTION
This PR adds complete JSDoc comments to the following D3 module definitions:
- d3-format
- d3-timer
- d3-random

Refer to #11366.

It also includes some minor enhancements
- d3-format: Use string literals to refine interface for FormatSpecifier.

cc @gustavderdrache

@RyanCavanaugh @andy-ms could you kindly merge this PR.
