### PR TITLE
Add mongoose-seeder types

### DIFF
--- a/mongoose-seeder/index.d.ts
+++ b/mongoose-seeder/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for mongoose-seeder 1.2.1
+// Project: https://github.com/SamVerschueren/mongoose-seeder
+// Definitions by: Crevil <https://github.com/Crevil/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'mongoose-seeder' {
+  import * as Q from 'q';
+
+  export interface IOptions {
+    dropDatabase?: boolean;
+    dropCollections?: boolean;
+  }
+
+  type seedCallback = (err: any, dbData: any) => void;
+
+  export function seed(data: any, options: IOptions, callback: seedCallback): void;
+  export function seed(data: any, callback: seedCallback): void;
+
+  export function seed(data: any, options: IOptions): Q.Promise<any>;
+}

--- a/mongoose-seeder/mongoose-seeder-tests.ts
+++ b/mongoose-seeder/mongoose-seeder-tests.ts
@@ -1,0 +1,29 @@
+import * as seeder from 'mongoose-seeder';
+
+const data = `{
+    "users": {
+        "_model": "User",
+        "foo": {
+            "firstName": "Foo",
+            "name": "Bar",
+            "email": "foo@bar.com"
+        }
+    }
+}`;
+
+seeder.seed(data, (err, dbData) => {
+});
+seeder.seed(data, { dropCollections: true }, (err, dbData) => {
+});
+
+seeder.seed(data, { dropDatabase: true }).then((dbData) => {
+  // ...
+}).catch((err) => {
+  // handle error
+});
+
+seeder.seed(data, { dropCollections: true }).then((dbData) => {
+  // ...
+}).catch((err) => {
+  // handle error
+});

--- a/mongoose-seeder/tsconfig.json
+++ b/mongoose-seeder/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mongoose-seeder-tests.ts"
+    ]
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
