### PR TITLE
[TS 2] React Component/PureComponent constructor super accept rest params

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -163,6 +163,7 @@ declare namespace React {
 
     // Base component for plain JS classes
     class Component<P, S> implements ComponentLifecycle<P, S> {
+        constructor(...args: any[])
         constructor(props?: P, context?: any);
         setState(f: (prevState: S, props: P) => S, callback?: () => any): void;
         setState(state: S, callback?: () => any): void;

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -214,8 +214,8 @@ var component: ModernComponent =
 var componentNullContainer: ModernComponent =
     ReactDOM.render(element, null);
 
-var componentElementOrNull: ModernComponent = 
-    ReactDOM.render(element, document.getElementById("anelement"));    
+var componentElementOrNull: ModernComponent =
+    ReactDOM.render(element, document.getElementById("anelement"));
 var componentNoState: ModernComponentNoState =
     ReactDOM.render(elementNoState, container);
 var componentNoStateElementOrNull: ModernComponentNoState =
@@ -620,4 +620,18 @@ let newObj2 = update(obj, {b: {$set: obj.b * 2}});
 
 let objShallow = {a: 5, b: 3};
 let newObjShallow = update(obj, {$merge: {b: 6, c: 7}}); // => {a: 5, b: 6, c: 7}
+}
+
+//
+// react component class constructor super spread operator
+// --------------------------------------------------------------------------
+class ConstructorSuperSpreadComponent extends React.Component<{}, {}> {
+    constructor(...args: any[]) {
+        super(...args);
+    }
+}
+class ConstructorSuperSpreadPureComponent extends React.PureComponent<{}, {}> {
+    constructor(...args: any[]) {
+        super(...args);
+    }
 }

--- a/redux-mock-store/redux-mock-store-tests.ts
+++ b/redux-mock-store/redux-mock-store-tests.ts
@@ -1,5 +1,5 @@
 import * as Redux from 'redux';
-import configureStore, {IStore} from 'redux-mock-store';
+import configureStore, { IStore } from 'redux-mock-store';
 
 // Redux store API tests
 // The following test are taken from ../redux/redux-tests.ts
@@ -41,3 +41,6 @@ store.dispatch({ type: 'INCREMENT' });
 var actions: Array<any> = store.getActions();
 
 store.clearActions();
+
+// Get actions with any payload without casting
+store.getActions()[2].payload.myProp;

--- a/redux-mock-store/redux-mock-store.d.ts
+++ b/redux-mock-store/redux-mock-store.d.ts
@@ -6,19 +6,19 @@
 ///<reference types="redux" />
 
 declare module 'redux-mock-store' {
-    import * as Redux from 'redux'
+    import * as Redux from 'redux';
 
-    function createMockStore<T>(middlewares?:Redux.Middleware[]):mockStore<T>
+    function createMockStore<T>(middlewares?: Redux.Middleware[]): mockStore<T>;
 
-    export type mockStore<T> = (state?:T) => IStore<T>;
+    export type mockStore<T> = (state?: T) => IStore<T>;
 
-    export type IStore<T> = {
-        dispatch(action: any):any
-        getState():T
-        getActions():Object[]
-        clearActions():void
-        subscribe(listener: Function):Function
+    export interface IStore<T> {
+        dispatch(action: any): any;
+        getState(): T;
+        getActions(): any[];
+        clearActions(): void;
+        subscribe(listener: Function): Function;
     }
 
-    export default createMockStore
+    export default createMockStore;
 }


### PR DESCRIPTION
This PR successfully passes spread operator to `super` calls on `React.Component` and `React.PureComponent` and fixes [11472](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11472).

I was unable to infer types on the spread array, but it seems that it's not possible yet.
Even so, when you call super with spread operator, you don't intend to use the props or context anyways.

It was not my intention to cleanup the white spaces in `react/react-tests.ts` since my editor auto cleans white spaces. But it is harmless.
