### PR TITLE
[types-2.0]: fix readline types

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -1349,10 +1349,7 @@ declare module "readline" {
         (line: string, callback: (err: any, result: CompleterResult) => void): any;
     }
 
-    export interface CompleterResult {
-        completions: string[];
-        line: string;
-    }
+    export type CompleterResult = [string[], string];
 
     export interface ReadLineOptions {
         input: NodeJS.ReadableStream;

--- a/node/node-4-tests.ts
+++ b/node/node-4-tests.ts
@@ -685,6 +685,12 @@ namespace readline_tests {
         result = readline.createInterface(input, output);
         result = readline.createInterface(input, output, completer);
         result = readline.createInterface(input, output, completer, terminal);
+        result = readline.createInterface({
+             input: input,
+             completer: function(str: string): readline.CompleteResult {
+                 return [['test'], 'test'];
+             }
+         });
     }
 
     {

--- a/node/node-4.d.ts
+++ b/node/node-4.d.ts
@@ -970,10 +970,7 @@ declare module "readline" {
         (line: string, callback: (err: any, result: CompleterResult) => void): any;
     }
 
-    export interface CompleterResult {
-        completions: string[];
-        line: string;
-    }
+    export type CompleterResult = [string[], string];
 
     export interface ReadLineOptions {
         input: NodeJS.ReadableStream;

--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -872,6 +872,12 @@ namespace readline_tests {
         result = readline.createInterface(input, output);
         result = readline.createInterface(input, output, completer);
         result = readline.createInterface(input, output, completer, terminal);
+        result = readline.createInterface({
+            input: input,
+            completer: function(str: string): readline.CompleterResult {
+                return [['test'], 'test'];
+            }
+        });
     }
 
     {


### PR DESCRIPTION
According to the doc, `CompleterResult` is a tuple type with `string[]` as the first element and `string` as the second.

https://nodejs.org/dist/latest-v4.x/docs/api/readline.html#readline_readline_createinterface_options

return type annotation is required here because TypeScript's type inference algorithm does not resolve overloading signature.

This is a breaking change. But the original definition should have already break user's code, (and thusly user must have cast result to any) I don't think this change will break anything in fact
