### PR TITLE
react-bootstrap-table: add ignoreSinglePage option

### DIFF
--- a/react-bootstrap-table/react-bootstrap-table-tests.tsx
+++ b/react-bootstrap-table/react-bootstrap-table-tests.tsx
@@ -21,7 +21,7 @@ function priceFormatter(cell: any, row: any) {
 }
 
 render(
-  <BootstrapTable data={products} striped={true} hover={true}>
+  <BootstrapTable data={products} striped={true} hover={true} ignoreSinglePage>
       <TableHeaderColumn dataField="id" isKey={true} dataAlign="center" dataSort={true}>Product ID</TableHeaderColumn>
       <TableHeaderColumn dataField="name" dataSort={true} editable={{ type: 'textarea', rows: 10 }}>Product Name</TableHeaderColumn>
       <TableHeaderColumn dataField="price" dataFormat={priceFormatter}>Product Price</TableHeaderColumn>

--- a/react-bootstrap-table/react-bootstrap-table.d.ts
+++ b/react-bootstrap-table/react-bootstrap-table.d.ts
@@ -125,6 +125,7 @@ declare module "react-bootstrap-table" {
 		containerStyle?: any;
 		headerStyle?: any;
 		bodyStyle?: any;
+		ignoreSinglePage?: boolean;
 
 	}
 	


### PR DESCRIPTION
As shown in the [docs](http://allenfang.github.io/react-bootstrap-table/docs.html)

```
ignoreSinglePage : Bool
Enable to ignore the pagination if only one page, default is false.
```

@flaub @scharf
