### PR TITLE
Add typings for shallowequal.

### DIFF
--- a/shallowequal/shallowequal-tests.ts
+++ b/shallowequal/shallowequal-tests.ts
@@ -1,0 +1,12 @@
+/// <reference path="shallowequal.d.ts" />
+
+import shallowEqual = require('shallowequal');
+
+const a = {}, b = {};
+function compare(a: any, b: any, indexOrKey?: number | string) {
+  return false;
+}
+
+shallowEqual(a, b);
+shallowEqual(a, b, compare);
+shallowEqual(a, b, compare, {});

--- a/shallowequal/shallowequal.d.ts
+++ b/shallowequal/shallowequal.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for shallowequal v0.2.2
+// Project: https://github.com/dashed/shallowequal
+// Definitions by: Sean Kelley <https://github.com/seansfkelley>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'shallowequal' {
+  function shallowEqual(objA: any, objB: any, compare?: (objA: any, objB: any, indexOrKey?: number | string) => boolean, compareContext?: any): boolean;
+  export = shallowEqual;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
