### PR TITLE
(helmet): change to namespace and export interfaces

### DIFF
--- a/helmet/helmet.d.ts
+++ b/helmet/helmet.d.ts
@@ -4,172 +4,175 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../express/express.d.ts" />
+declare module "helmet" {
 
-declare module 'helmet' {
-    import express = require('express');
+  import express = require('express');
 
-    interface IHelmetConfiguration {
-        contentSecurityPolicy? : boolean | IHelmetContentSecurityPolicyConfiguration,
-        dnsPrefetchControl?: boolean | IHelmetDnsPrefetchControlConfiguration,
-        frameguard?: boolean | IHelmetFrameguardConfiguration,
-        hidePoweredBy?: boolean | IHelmetHidePoweredByConfiguration,
-        hpkp?: boolean | IHelmetHpkpConfiguration,
-        hsts?: boolean | IHelmetHstsConfiguration,
-        ieNoOpen?: boolean,
-        noCache?: boolean,
-        noSniff?: boolean,
-        xssFilter?: boolean | IHelmetXssFilterConfiguration
-    }
+  namespace helmet {
 
-    interface IHelmetContentSecurityPolicyDirectiveFunction {
-      (req: express.Request, res: express.Response): string;
-    }
-    type HelmetCspDirectiveValue = string | IHelmetContentSecurityPolicyDirectiveFunction;
+      export interface IHelmetConfiguration {
+          contentSecurityPolicy? : boolean | IHelmetContentSecurityPolicyConfiguration,
+          dnsPrefetchControl?: boolean | IHelmetDnsPrefetchControlConfiguration,
+          frameguard?: boolean | IHelmetFrameguardConfiguration,
+          hidePoweredBy?: boolean | IHelmetHidePoweredByConfiguration,
+          hpkp?: boolean | IHelmetHpkpConfiguration,
+          hsts?: boolean | IHelmetHstsConfiguration,
+          ieNoOpen?: boolean,
+          noCache?: boolean,
+          noSniff?: boolean,
+          xssFilter?: boolean | IHelmetXssFilterConfiguration
+      }
 
-    interface IHelmetContentSecurityPolicyDirectives {
-        baseUri? : HelmetCspDirectiveValue[],
-        childSrc? : HelmetCspDirectiveValue[],
-        connectSrc? : HelmetCspDirectiveValue[],
-        defaultSrc? : HelmetCspDirectiveValue[],
-        fontSrc? : HelmetCspDirectiveValue[],
-        formAction? : HelmetCspDirectiveValue[],
-        frameAncestors? : HelmetCspDirectiveValue[],
-        frameSrc? : HelmetCspDirectiveValue[],
-        imgSrc? : HelmetCspDirectiveValue[],
-        mediaSrc? : HelmetCspDirectiveValue[],
-        objectSrc? : HelmetCspDirectiveValue[],
-        pluginTypes? : HelmetCspDirectiveValue[],
-        reportUri?: string,
-        sandbox? : HelmetCspDirectiveValue[],
-        scriptSrc? : HelmetCspDirectiveValue[],
-        styleSrc? : HelmetCspDirectiveValue[]
-    }
+      export interface IHelmetContentSecurityPolicyDirectiveFunction {
+          (req: express.Request, res: express.Response): string;
+      }
+      export type HelmetCspDirectiveValue = string | IHelmetContentSecurityPolicyDirectiveFunction;
 
-    interface IHelmetContentSecurityPolicyConfiguration {
-        reportOnly? : boolean;
-        setAllHeaders? : boolean;
-        disableAndroid? : boolean;
-        browserSniff?: boolean;
-        directives? : IHelmetContentSecurityPolicyDirectives
-    }
+      export interface IHelmetContentSecurityPolicyDirectives {
+          baseUri? : HelmetCspDirectiveValue[],
+          childSrc? : HelmetCspDirectiveValue[],
+          connectSrc? : HelmetCspDirectiveValue[],
+          defaultSrc? : HelmetCspDirectiveValue[],
+          fontSrc? : HelmetCspDirectiveValue[],
+          formAction? : HelmetCspDirectiveValue[],
+          frameAncestors? : HelmetCspDirectiveValue[],
+          frameSrc? : HelmetCspDirectiveValue[],
+          imgSrc? : HelmetCspDirectiveValue[],
+          mediaSrc? : HelmetCspDirectiveValue[],
+          objectSrc? : HelmetCspDirectiveValue[],
+          pluginTypes? : HelmetCspDirectiveValue[],
+          reportUri?: string,
+          sandbox? : HelmetCspDirectiveValue[],
+          scriptSrc? : HelmetCspDirectiveValue[],
+          styleSrc? : HelmetCspDirectiveValue[]
+      }
 
-    interface IHelmetDnsPrefetchControlConfiguration {
-        allow? : boolean;
-    }
+      export interface IHelmetContentSecurityPolicyConfiguration {
+          reportOnly? : boolean;
+          setAllHeaders? : boolean;
+          disableAndroid? : boolean;
+          browserSniff?: boolean;
+          directives? : IHelmetContentSecurityPolicyDirectives
+      }
 
-    interface IHelmetFrameguardConfiguration {
-        action? : string,
-        domain? : string
-    }
+      export interface IHelmetDnsPrefetchControlConfiguration {
+          allow? : boolean;
+      }
 
-    interface IHelmetHidePoweredByConfiguration {
-        setTo? : string
-    }
+      export interface IHelmetFrameguardConfiguration {
+          action? : string,
+          domain? : string
+      }
 
-    interface IHelmetSetIfFunction {
-      (req: express.Request, res: express.Response): boolean;
-    }
+      export interface IHelmetHidePoweredByConfiguration {
+          setTo? : string
+      }
 
-    interface IHelmetHpkpConfiguration {
-        maxAge : number;
-        sha256s : string[];
-        includeSubdomains? : boolean;
-        reportUri? : string;
-        reportOnly? : boolean;
-        setIf?: IHelmetSetIfFunction
-    }
+      export interface IHelmetSetIfFunction {
+          (req: express.Request, res: express.Response): boolean;
+      }
 
-    interface IHelmetHstsConfiguration {
-        maxAge: number;
-        includeSubdomains? : boolean;
-        preload? : boolean;
-        setIf? : IHelmetSetIfFunction,
-        force? : boolean;
-    }
+      export interface IHelmetHpkpConfiguration {
+          maxAge : number;
+          sha256s : string[];
+          includeSubdomains? : boolean;
+          reportUri? : string;
+          reportOnly? : boolean;
+          setIf?: IHelmetSetIfFunction
+      }
 
-    interface IHelmetXssFilterConfiguration {
-        setOnOldIE? : boolean;
-    }
+      export interface IHelmetHstsConfiguration {
+          maxAge: number;
+          includeSubdomains? : boolean;
+          preload? : boolean;
+          setIf? : IHelmetSetIfFunction,
+          force? : boolean;
+      }
 
-    /**
-     * @summary Interface for helmet class.
-     * @interface
-     */
-    interface Helmet {
-        /**
-         * @summary Constructor.
-         * @return {RequestHandler} The Request handler.
-         */
-        (options ?: IHelmetConfiguration): express.RequestHandler;
+      export interface IHelmetXssFilterConfiguration {
+          setOnOldIE? : boolean;
+      }
 
-        /**
-         * @summary Set policy around third-party content via headers
-         * @param {IHelmetContentSecurityPolicyConfiguration} options The options
-         * @return {RequestHandler} The Request handler
-         */
-        contentSecurityPolicy(options ?: IHelmetContentSecurityPolicyConfiguration): express.RequestHandler;
+      /**
+       * @summary Interface for helmet class.
+       * @interface
+       */
+      export interface Helmet {
+          /**
+           * @summary Constructor.
+           * @return {RequestHandler} The Request handler.
+           */
+          (options ?: IHelmetConfiguration): express.RequestHandler;
 
-        /**
-         * @summary Stop browsers from doing DNS prefetching.
-         * @param {IHelmetDnsPrefetchControlConfiguration} options The options
-         * @return {RequestHandler} The Request handler
-         */
-        dnsPrefetchControl(options ?: IHelmetDnsPrefetchControlConfiguration): express.RequestHandler;
+          /**
+           * @summary Set policy around third-party content via headers
+           * @param {IHelmetContentSecurityPolicyConfiguration} options The options
+           * @return {RequestHandler} The Request handler
+           */
+          contentSecurityPolicy(options ?: IHelmetContentSecurityPolicyConfiguration): express.RequestHandler;
 
-        /**
-         * @summary Prevent clickjacking.
-         * @param {IHelmetFrameguardConfiguration} options The options
-         * @return {RequestHandler} The Request handler
-         */
-        frameguard(options ?: IHelmetFrameguardConfiguration): express.RequestHandler;
+          /**
+           * @summary Stop browsers from doing DNS prefetching.
+           * @param {IHelmetDnsPrefetchControlConfiguration} options The options
+           * @return {RequestHandler} The Request handler
+           */
+          dnsPrefetchControl(options ?: IHelmetDnsPrefetchControlConfiguration): express.RequestHandler;
 
-        /**
-         * @summary Hide "X-Powered-By" header.
-         * @param {IHelmetHidePoweredByConfiguration} options The options
-         * @return {RequestHandler} The Request handler.
-         */
-        hidePoweredBy(options ?: IHelmetHidePoweredByConfiguration): express.RequestHandler;
+          /**
+           * @summary Prevent clickjacking.
+           * @param {IHelmetFrameguardConfiguration} options The options
+           * @return {RequestHandler} The Request handler
+           */
+          frameguard(options ?: IHelmetFrameguardConfiguration): express.RequestHandler;
 
-        /**
-         * @summary Adds the "Public-Key-Pins" header.
-         * @param {IHelmetHpkpConfiguration} options The options
-         * @return {RequestHandler} The Request handler.
-         */
-        hpkp(options ?: IHelmetHpkpConfiguration): express.RequestHandler;
+          /**
+           * @summary Hide "X-Powered-By" header.
+           * @param {IHelmetHidePoweredByConfiguration} options The options
+           * @return {RequestHandler} The Request handler.
+           */
+          hidePoweredBy(options ?: IHelmetHidePoweredByConfiguration): express.RequestHandler;
 
-        /**
-         * @summary Adds the "Strict-Transport-Security" header.
-         * @param {IHelmetHstsConfiguration} options The options
-         * @return {RequestHandler} The Request handler.
-         */
-        hsts(options ?: IHelmetHstsConfiguration): express.RequestHandler;
+          /**
+           * @summary Adds the "Public-Key-Pins" header.
+           * @param {IHelmetHpkpConfiguration} options The options
+           * @return {RequestHandler} The Request handler.
+           */
+          hpkp(options ?: IHelmetHpkpConfiguration): express.RequestHandler;
 
-        /**
-         * @summary Add the "X-Download-Options" header.
-         * @return {RequestHandler} The Request handler.
-         */
-        ieNoOpen(): express.RequestHandler;
+          /**
+           * @summary Adds the "Strict-Transport-Security" header.
+           * @param {IHelmetHstsConfiguration} options The options
+           * @return {RequestHandler} The Request handler.
+           */
+          hsts(options ?: IHelmetHstsConfiguration): express.RequestHandler;
 
-        /**
-         * @summary Add the "Cache-Control" and "Pragma" headers to stop caching.
-         * @return {RequestHandler} The Request handler.
-         */
-        noCache(options ?: Object): express.RequestHandler;
+          /**
+           * @summary Add the "X-Download-Options" header.
+           * @return {RequestHandler} The Request handler.
+           */
+          ieNoOpen(): express.RequestHandler;
 
-        /**
-         * @summary Adds the "X-Content-Type-Options" header.
-         * @return {RequestHandler} The Request handler.
-         */
-        noSniff(): express.RequestHandler;
+          /**
+           * @summary Add the "Cache-Control" and "Pragma" headers to stop caching.
+           * @return {RequestHandler} The Request handler.
+           */
+          noCache(options ?: Object): express.RequestHandler;
 
-        /**
-         * @summary Mitigate cross-site scripting attacks with the "X-XSS-Protection" header.
-         * @param {IHelmetXssFilterConfiguration} options The options
-         * @return {RequestHandler} The Request handler.
-         */
-        xssFilter(options ?: IHelmetXssFilterConfiguration): express.RequestHandler;
-    }
+          /**
+           * @summary Adds the "X-Content-Type-Options" header.
+           * @return {RequestHandler} The Request handler.
+           */
+          noSniff(): express.RequestHandler;
 
-    var helmet: Helmet;
-    export = helmet;
+          /**
+           * @summary Mitigate cross-site scripting attacks with the "X-XSS-Protection" header.
+           * @param {IHelmetXssFilterConfiguration} options The options
+           * @return {RequestHandler} The Request handler.
+           */
+          xssFilter(options ?: IHelmetXssFilterConfiguration): express.RequestHandler;
+      }
+  }
+
+  var helmet: helmet.Helmet;
+  export = helmet;
 }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Confession:  I am a TS noob.  I was having problems with the helmet/helmet.d.ts.  I could not use the interfaces in my own types due to the interfaces not being exported.  Also got the error:

Exported variable helmet has or is using private name helmet.

I modeled this rewrite off of the morgan/morgan.d.ts definition which allowed me to do what I wanted.

Do I need to submit this to the 2.0 branch as well?
