### PR TITLE
URIjs fix .joinPaths()

### DIFF
--- a/urijs/URIjs.d.ts
+++ b/urijs/URIjs.d.ts
@@ -52,8 +52,6 @@ declare namespace uri {
         is(qry: string): boolean;
         iso8859(): URI;
 
-        joinPaths(...paths: (string | URI)[]): URI;
-
         normalize(): URI;
         normalizeFragment(): URI;
         normalizeHash(): URI;
@@ -190,6 +188,8 @@ declare namespace uri {
         expand(template: string, vals: Object): URI;
 
         iso8859(): void;
+    
+        joinPaths(...paths: (string | URI)[]): URI;
 
         parse(url: string): {
             protocol: string;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

the .joinPaths function is on URIStatic, not an instance of URI
https://medialize.github.io/URI.js/docs.html#static-joinPaths
