### PR TITLE
Updated jquery.dataTables for 1.10.8

### DIFF
--- a/jquery.dataTables/jquery.dataTables-tests.ts
+++ b/jquery.dataTables/jquery.dataTables-tests.ts
@@ -219,6 +219,7 @@ $(document).ready(function () {
             pagingType: "simple",
             retrieve: true,
             renderer: "bootstrap",
+            rowId: "custId",
             scrollCollapse: true,
             search: true,
             searchCols: [{ "search": "", "smart": true, "regex": false, "caseInsensitive": true }],
@@ -261,7 +262,7 @@ $(document).ready(function () {
         {
             ajax: {
                 data: ajaxDataFunc,
-                dataSrc: function (data) { },
+                dataSrc: function (data: any) { },
             },
         };
 
@@ -305,8 +306,9 @@ $(document).ready(function () {
     destroy = dt.destroy(true);
     destroy.$("");
 
-    var draw = dt.draw();
+    var draw: DataTables.DataTable = dt.draw();
     draw = dt.draw(true);
+    draw = dt.draw("page");
     draw.$("");
 
     var initSettings = dt.init();
@@ -343,7 +345,8 @@ $(document).ready(function () {
         "end": 20,
         "length": 10,
         "recordsTotal": 57,
-        "recordsDisplay": 57
+        "recordsDisplay": 57,
+        "serverSide": false
     };
 
     var page_len_get = dt.page.len();
@@ -401,7 +404,7 @@ $(document).ready(function () {
         .cache('search')
         .sort()
         .unique()
-        .each(function (d) {
+        .each(function (d: any) {
             select.append($('<option value="' + d + '">' + d + '</option>'));
         });
 
@@ -520,7 +523,7 @@ $(document).ready(function () {
     columns = dt.columns("selector", modifier);
 
     var columns_cache = columns.cache("order");
-    dt.columns('.select-filter').eq(0).each(function (colIdx) {
+    dt.columns('.select-filter').eq(0).each(function (colIdx: any) {
         // Create the select list and search operation
         var select = $('<select />')
             .appendTo(
@@ -539,7 +542,7 @@ $(document).ready(function () {
             .cache('search')
             .sort()
             .unique()
-            .each(function (d) {
+            .each(function (d: any) {
                 select.append($('<option value="' + d + '">' + d + '</option>'));
             });
     });
@@ -623,7 +626,7 @@ $(document).ready(function () {
         .cache('search')
         .sort()
         .unique()
-        .each(function (d) {
+        .each(function (d: any) {
             select.append($('<option value="' + d + '">' + d + '</option>'));
         });
 
@@ -632,7 +635,7 @@ $(document).ready(function () {
         dt
             .column(4)
             .data()
-            .reduce(function (a, b) {
+            .reduce(function (a: any, b: any) {
                 return a + b;
             })
     );
@@ -688,7 +691,7 @@ $(document).ready(function () {
             .draw();
     });
 
-    dt.columns('.select-filter').eq(0).each(function (colIdx) {
+    dt.columns('.select-filter').eq(0).each(function (colIdx: any) {
         // Create the select list and search operation
         var select = $('<select />')
             .appendTo(
@@ -707,7 +710,7 @@ $(document).ready(function () {
             .cache('search')
             .sort()
             .unique()
-            .each(function (d) {
+            .each(function (d: any) {
                 select.append($('<option value="' + d + '">' + d + '</option>'));
             });
     });
@@ -751,6 +754,8 @@ $(document).ready(function () {
     var row_19 = dt.row("selector").index();
     var row_20 = dt.row("selector").node();
     var row_21 = dt.row("selector").remove();
+    var row_22: string = dt.row("selector").id();
+    var row_23: string = dt.row("selector").id(false);
 
     var rows_1 = dt.rows();
     var rows_2 = dt.rows().remove();
@@ -767,6 +772,8 @@ $(document).ready(function () {
     var rows_13 = dt.rows.add([{}, {}]);
     dt.rows().every(function () { });
     dt.rows().every(function (rowIdx, tableLoop, rowLoop) { });
+    var rows_14: DataTables.DataTable = dt.rows("selector").ids();
+    var rows_15: DataTables.DataTable = dt.rows("selector").ids(false);
 
     var table3 = $('#example').DataTable();
     table3.row.add({
@@ -831,7 +838,7 @@ $(document).ready(function () {
     ])
         .show();
 
-    dt.rows().eq(0).each(function (rowIdx) {
+    dt.rows().eq(0).each(function (rowIdx: any) {
         dt
             .row(rowIdx)
             .child(
@@ -881,6 +888,16 @@ $(document).ready(function () {
 
     //#endregion "Methods-Row"
 
+    //#region "Methods-Static"
+
+    // Variable is a stand-in for $.fn.dataTable. See extension of JQueryStatic at the top of jquery.dataTables.d.ts.
+    var staticFn: DataTables.StaticFunctions;
+
+    var static_1: DataTables.DataTable[] | DataTables.DataTable = staticFn.tables(true);
+    static_1 = staticFn.tables({ "visible": true, "api": true });
+
+    //#endregion "Methods-Static"
+
     //#region "Methods-Table"
 
     var tables = dt.tables();
@@ -905,6 +922,7 @@ $(document).ready(function () {
     //#region "Methods-Util"
 
     var util_1: boolean = dt.any();
+    var util_2: number = dt.count();
 
     //#endregion "Methods-Util"
 });

--- a/jquery.dataTables/jquery.dataTables.d.ts
+++ b/jquery.dataTables/jquery.dataTables.d.ts
@@ -182,11 +182,11 @@ declare namespace DataTables {
         destroy(remove?: boolean): DataTable;
 
         /**
-        * Redraw the table.
+        * Redraw the DataTables in the current context, optionally updating ordering, searching and paging as required.
         *
-        * @param reset Reset (default) or hold the current paging position. A full re-sort and re-filter is performed when this method is called, which is why the pagination reset is the default action.
+        * @param paging This parameter is used to determine what kind of draw DataTables will perform.
         */
-        draw(reset?: boolean): DataTable;
+        draw(paging?: boolean | string): DataTable;
 
         /*
         * Look up a language token that was defined in the DataTables' language initialisation object.
@@ -374,6 +374,7 @@ declare namespace DataTables {
         length: number;
         recordsTotal: number;
         recordsDisplay: number;
+        serverSide: boolean
     }
 
     //#endregion "page-methods"
@@ -435,6 +436,11 @@ declare namespace DataTables {
         * @param b Additional API instance(s) to concatenate to the initial instance.
         */
         concat(a: Object, ...b: Object[]): DataTable;
+
+        /**
+        * Get the number of entries in an API instance's result set, regardless of multi-table grouping (e.g. any data, selected rows, etc). Since: 1.10.8
+        */
+        count(): number;
 
         /**
         * Iterate over the contents of the API result set.
@@ -904,6 +910,15 @@ declare namespace DataTables {
         data(d: any[] | Object): DataTable;
 
         /**
+        * Get the id of the selected row. Since: 1.10.8
+        *
+        * @param hash true - Append a hash (#) to the start of the row id. This can be useful for then using the id as a selector
+        * false - Do not modify the id value.
+        * @returns Row id. If the row does not have an id available 'undefined' will be returned.
+        */
+        id(hash?: boolean): string;
+
+        /**
         * Get the row index of the row column.
         */
         index(): number;
@@ -962,6 +977,15 @@ declare namespace DataTables {
         * @param fn Function to execute for every row selected.
         */
         every(fn: (rowIdx: number, tableLoop: number, rowLoop: number) => void): DataTable;
+
+        /**
+        * Get the ids of the selected rows. Since: 1.10.8
+        *
+        * @param hash true - Append a hash (#) to the start of each row id. This can be useful for then using the ids as selectors
+        * false - Do not modify the id value.
+        * @returns Api instance with the selected rows in its result set. If a row does not have an id available 'undefined' will be returned as the value.
+        */
+        ids(hash?: boolean): DataTable;
 
         /**
         * Get the row indexes of the selected rows.
@@ -1050,11 +1074,12 @@ declare namespace DataTables {
         isDataTable(table: string): boolean;
 
         /**
-        * Get all DataTables on the page
+        * Get all DataTable tables that have been initialised - optionally you can select to get only currently visible tables and / or retrieve the tables as API instances.
         *
-        * @param visible Get only visible tables
+        * @param visible As a boolean value this options is used to indicate if you want all tables on the page should be returned (false), or visible tables only (true).
+        * Since 1.10.8 this option can also be given as an object.
         */
-        tables(visible?: boolean): DataTables.DataTable[];
+        tables(visible?: boolean | ObjectTablesStatic): DataTables.DataTable[] | DataTables.DataTable;
 
         /**
         * Version number compatibility check function
@@ -1091,6 +1116,18 @@ declare namespace DataTables {
         * @param period ms
         */
         throttle(fn: Function, period?: number): Function;
+    }
+
+    interface ObjectTablesStatic {
+        /**
+        * Get only visible tables (true) or all tables regardless of visibility (false).
+        */
+        visible: boolean
+
+        /**
+        * Return a DataTables API instance for the selected tables (true) or an array (false).
+        */
+        api: boolean
     }
 
     //#endregion "Static-Methods"
@@ -1250,7 +1287,7 @@ declare namespace DataTables {
         pageLength?: number;
 
         /**
-        * Pagination button display options. Basic Types: simple, simple_numbers, full, full_numbers
+        * Pagination button display options. Basic Types: numbers (1.10.8) simple, simple_numbers, full, full_numbers
         */
         pagingType?: string;
 
@@ -1263,6 +1300,11 @@ declare namespace DataTables {
         * Display component renderer types. Since: 1.10
         */
         renderer?: string | RendererSettings;
+
+        /**
+        * Data property name that DataTables will use to set <tr> element DOM IDs. Since: 1.10.8
+        */
+        rowId?: string;
 
         /**
         * Allow the table to reduce in height when a limited number of rows are shown. Since: 1.10

--- a/rethinkdb/rethinkdb-tests.ts
+++ b/rethinkdb/rethinkdb-tests.ts
@@ -15,8 +15,10 @@ r.connect({host:"localhost", port: 28015}, function(err, conn) {
         })
         .between("james", "beth")
         .limit(4)
-        .run(conn, function() {
-
+        .run(conn, function(err, cursor) {
+          cursor.toArray().then(rows => {
+            console.log(rows);
+          });
         })
 
     })

--- a/rethinkdb/rethinkdb.d.ts
+++ b/rethinkdb/rethinkdb.d.ts
@@ -8,234 +8,234 @@
 
 declare module "rethinkdb" {
 
-  export function connect(host:ConnectionOptions, cb?:(err:Error, conn:Connection)=>void):Promise<Connection>;
+    export function connect(host: ConnectionOptions, cb?: (err: Error, conn: Connection) => void): Promise<Connection>;
 
-  export function dbCreate(name:string):Operation<CreateResult>;
-  export function dbDrop(name:string):Operation<DropResult>;
-  export function dbList():Operation<string[]>;
+    export function dbCreate(name: string): Operation<CreateResult>;
+    export function dbDrop(name: string): Operation<DropResult>;
+    export function dbList(): Operation<string[]>;
 
-  export function db(name:string):Db;
-  export function table(name:string, options?:{useOutdated:boolean}):Table;
+    export function db(name: string): Db;
+    export function table(name: string, options?: { useOutdated: boolean }): Table;
 
-  export function asc(property:string):Sort;
-  export function desc(property:string):Sort;
+    export function asc(property: string): Sort;
+    export function desc(property: string): Sort;
 
-  export var count:Aggregator;
-  export function sum(prop:string):Aggregator;
-  export function avg(prop:string):Aggregator;
+    export var count: Aggregator;
+    export function sum(prop: string): Aggregator;
+    export function avg(prop: string): Aggregator;
 
-  export function row(name:string):Expression<any>;
-  export function expr(stuff:any):Expression<any>;
+    export function row(name: string): Expression<any>;
+    export function expr(stuff: any): Expression<any>;
 
-  export function now():Time;
+    export function now(): Time;
 
-  // Control Structures
-  export function branch(test:Expression<boolean>, trueBranch:Expression<any>, falseBranch:Expression<any>):Expression<any>;
-
-
-  export class Cursor {
-    hasNext():boolean;
-    each(cb:(err:Error, row:any)=>void, done?:()=>void): void;
-    each(cb:(err:Error, row:any)=>boolean, done?:()=>void): void; // returning false stops iteration
-    next(cb:(err:Error, row:any) => void): void;
-    toArray(cb:(err:Error, rows:any[]) => void): void;
-    toArray(): Promise<any[]>;
-    close(cb: (err: Error) => void): void;
-    close(): Promise<void>;
-  }
-
-  interface ConnectionOptions {
-    host:string;
-    port:number;
-    db?:string;
-    authKey?:string;
-  }
-
-  interface Connection {
-    close(cb: (err: Error) => void): void;
-    close(opts: { noreplyWait: boolean }, cb: (err: Error) => void): void;
-    close(): Promise<void>;
-    close(opts: { noreplyWait: boolean }): Promise<void>;
-    reconnect(cb?:(err:Error, conn:Connection)=>void):Promise<Connection>;
-    use(dbName:string): void;
-    addListener(event:string, cb:Function): void;
-    on(event:string, cb:Function): void;
-  }
-
-  interface Db {
-    tableCreate(name:string, options?:TableOptions):Operation<CreateResult>;
-    tableDrop(name:string):Operation<DropResult>;
-    tableList():Operation<string[]>;
-    table(name:string, options?:GetTableOptions):Table;
-  }
-
-  interface TableOptions {
-    primary_key?:string; // 'id'
-    durability?:string; // 'soft'
-    cache_size?:number;
-    datacenter?:string;
-  }
-
-  interface GetTableOptions {
-    useOutdated: boolean;
-  }
-
-  interface Writeable {
-    update(obj:Object, options?:UpdateOptions):Operation<WriteResult>;
-    replace(obj:Object, options?:UpdateOptions):Operation<WriteResult>;
-    replace(expr:ExpressionFunction<any>):Operation<WriteResult>;
-    delete(options?:UpdateOptions):Operation<WriteResult>;
-  }
-
-  interface Table extends Sequence {
-    indexCreate(name:string, index?:ExpressionFunction<any>):Operation<CreateResult>;
-    indexDrop(name:string):Operation<DropResult>;
-    indexList():Operation<string[]>;
-
-    insert(obj:any[], options?:InsertOptions):Operation<WriteResult>;
-    insert(obj:any, options?:InsertOptions):Operation<WriteResult>;
-
-    get(key:string):Sequence; // primary key
-    getAll(key:string, index?:Index):Sequence; // without index defaults to primary key
-    getAll(...keys:string[]):Sequence;
-  }
-
-  interface Sequence extends Operation<Cursor>, Writeable {
-
-    between(lower:any, upper:any, index?:Index):Sequence;
-    filter(rql:ExpressionFunction<boolean>):Sequence;
-    filter(rql:Expression<boolean>):Sequence;
-    filter(obj:{[key:string]:any}):Sequence;
+    // Control Structures
+    export function branch(test: Expression<boolean>, trueBranch: Expression<any>, falseBranch: Expression<any>): Expression<any>;
 
 
-    // Join
-    // these return left, right
-    innerJoin(sequence:Sequence, join:JoinFunction<boolean>):Sequence;
-    outerJoin(sequence:Sequence, join:JoinFunction<boolean>):Sequence;
-    eqJoin(leftAttribute:string, rightSequence:Sequence, index?:Index):Sequence;
-    eqJoin(leftAttribute:ExpressionFunction<any>, rightSequence:Sequence, index?:Index):Sequence;
-    zip():Sequence;
+    export class Cursor {
+        hasNext(): boolean;
+        each(cb: (err: Error, row: any) => void, done?: () => void): void;
+        each(cb: (err: Error, row: any) => boolean, done?: () => void): void; // returning false stops iteration
+        next(cb: (err: Error, row: any) => void): void;
+        toArray(cb: (err: Error, rows: any[]) => void): void;
+        toArray(): Promise<any[]>;
+        close(cb: (err: Error) => void): void;
+        close(): Promise<void>;
+    }
 
-    // Transform
-    map(transform:ExpressionFunction<any>):Sequence;
-    withFields(...selectors:any[]):Sequence;
-    concatMap(transform:ExpressionFunction<any>):Sequence;
-    orderBy(...keys:string[]):Sequence;
-    orderBy(...sorts:Sort[]):Sequence;
-    skip(n:number):Sequence;
-    limit(n:number):Sequence;
-    slice(start:number, end?:number):Sequence;
-    nth(n:number):Expression<any>;
-    indexesOf(obj:any):Sequence;
-    isEmpty():Expression<boolean>;
-    union(sequence:Sequence):Sequence;
-    sample(n:number):Sequence;
+    interface ConnectionOptions {
+        host: string;
+        port: number;
+        db?: string;
+        authKey?: string;
+    }
 
-    // Aggregate
-    reduce(r:ReduceFunction<any>, base?:any):Expression<any>;
-    count():Expression<number>;
-    distinct():Sequence;
-    groupedMapReduce(group:ExpressionFunction<any>, map:ExpressionFunction<any>, reduce:ReduceFunction<any>, base?:any):Sequence;
-    groupBy(...aggregators:Aggregator[]):Expression<Object>; // TODO: reduction object
-    contains(prop:string):Expression<boolean>;
+    interface Connection {
+        close(cb: (err: Error) => void): void;
+        close(opts: { noreplyWait: boolean }, cb: (err: Error) => void): void;
+        close(): Promise<void>;
+        close(opts: { noreplyWait: boolean }): Promise<void>;
+        reconnect(cb?: (err: Error, conn: Connection) => void): Promise<Connection>;
+        use(dbName: string): void;
+        addListener(event: string, cb: Function): void;
+        on(event: string, cb: Function): void;
+    }
 
-    // Manipulation
-    pluck(...props:string[]):Sequence;
-    without(...props:string[]):Sequence;
-  }
+    interface Db {
+        tableCreate(name: string, options?: TableOptions): Operation<CreateResult>;
+        tableDrop(name: string): Operation<DropResult>;
+        tableList(): Operation<string[]>;
+        table(name: string, options?: GetTableOptions): Table;
+    }
 
-  interface ExpressionFunction<U> {
-    (doc:Expression<any>):Expression<U>;
-  }
+    interface TableOptions {
+        primary_key?: string; // 'id'
+        durability?: string; // 'soft'
+        cache_size?: number;
+        datacenter?: string;
+    }
 
-  interface JoinFunction<U> {
-    (left:Expression<any>, right:Expression<any>):Expression<U>;
-  }
+    interface GetTableOptions {
+        useOutdated: boolean;
+    }
 
-  interface ReduceFunction<U> {
-    (acc:Expression<any>, val:Expression<any>):Expression<U>;
-  }
+    interface Writeable {
+        update(obj: Object, options?: UpdateOptions): Operation<WriteResult>;
+        replace(obj: Object, options?: UpdateOptions): Operation<WriteResult>;
+        replace(expr: ExpressionFunction<any>): Operation<WriteResult>;
+        delete(options?: UpdateOptions): Operation<WriteResult>;
+    }
 
-  interface InsertOptions {
-    upsert: boolean; // true
-    durability: string; // 'soft'
-    return_vals: boolean; // false
-  }
+    interface Table extends Sequence {
+        indexCreate(name: string, index?: ExpressionFunction<any>): Operation<CreateResult>;
+        indexDrop(name: string): Operation<DropResult>;
+        indexList(): Operation<string[]>;
 
-  interface UpdateOptions {
-    non_atomic: boolean;
-    durability: string; // 'soft'
-    return_vals: boolean; // false
-  }
+        insert(obj: any[], options?: InsertOptions): Operation<WriteResult>;
+        insert(obj: any, options?: InsertOptions): Operation<WriteResult>;
 
-  interface WriteResult {
-    inserted: number;
-    replaced: number;
-    unchanged: number;
-    errors: number;
-    deleted: number;
-    skipped: number;
-    first_error: Error;
-    generated_keys: string[]; // only for insert
-  }
+        get(key: string): Sequence; // primary key
+        getAll(key: string, index?: Index): Sequence; // without index defaults to primary key
+        getAll(...keys: string[]): Sequence;
+    }
 
-  interface JoinResult {
-    left:any;
-    right:any;
-  }
+    interface Sequence extends Operation<Cursor>, Writeable {
 
-  interface CreateResult {
-    created: number;
-  }
-
-  interface DropResult {
-    dropped: number;
-  }
-
-  interface Index {
-    index: string;
-    left_bound?: string; // 'closed'
-    right_bound?: string; // 'open'
-  }
-
-  interface Expression<T> extends Writeable, Operation<T> {
-      (prop:string):Expression<any>;
-      merge(query:Expression<Object>):Expression<Object>;
-      append(prop:string):Expression<Object>;
-      contains(prop:string):Expression<boolean>;
-
-      and(b:boolean):Expression<boolean>;
-      or(b:boolean):Expression<boolean>;
-      eq(v:any):Expression<boolean>;
-      ne(v:any):Expression<boolean>;
-      not():Expression<boolean>;
-
-      gt(value:T):Expression<boolean>;
-      ge(value:T):Expression<boolean>;
-      lt(value:T):Expression<boolean>;
-      le(value:T):Expression<boolean>;
-
-      add(n:number):Expression<number>;
-      sub(n:number):Expression<number>;
-      mul(n:number):Expression<number>;
-      div(n:number):Expression<number>;
-      mod(n:number):Expression<number>;
-
-      hasFields(...fields:string[]):Expression<boolean>;
-
-      default(value:T):Expression<T>;
-  }
-
-  interface Operation<T> {
-   run(conn:Connection, cb?:(err:Error, result:T)=>void):Promise<T>;
-  }
-
-  interface Aggregator {}
-  interface Sort {}
-
-  interface Time {}
+        between(lower: any, upper: any, index?: Index): Sequence;
+        filter(rql: ExpressionFunction<boolean>): Sequence;
+        filter(rql: Expression<boolean>): Sequence;
+        filter(obj: { [key: string]: any }): Sequence;
 
 
-  // http://www.rethinkdb.com/api/#js
-  // TODO control structures
+        // Join
+        // these return left, right
+        innerJoin(sequence: Sequence, join: JoinFunction<boolean>): Sequence;
+        outerJoin(sequence: Sequence, join: JoinFunction<boolean>): Sequence;
+        eqJoin(leftAttribute: string, rightSequence: Sequence, index?: Index): Sequence;
+        eqJoin(leftAttribute: ExpressionFunction<any>, rightSequence: Sequence, index?: Index): Sequence;
+        zip(): Sequence;
+
+        // Transform
+        map(transform: ExpressionFunction<any>): Sequence;
+        withFields(...selectors: any[]): Sequence;
+        concatMap(transform: ExpressionFunction<any>): Sequence;
+        orderBy(...keys: string[]): Sequence;
+        orderBy(...sorts: Sort[]): Sequence;
+        skip(n: number): Sequence;
+        limit(n: number): Sequence;
+        slice(start: number, end?: number): Sequence;
+        nth(n: number): Expression<any>;
+        indexesOf(obj: any): Sequence;
+        isEmpty(): Expression<boolean>;
+        union(sequence: Sequence): Sequence;
+        sample(n: number): Sequence;
+
+        // Aggregate
+        reduce(r: ReduceFunction<any>, base?: any): Expression<any>;
+        count(): Expression<number>;
+        distinct(): Sequence;
+        groupedMapReduce(group: ExpressionFunction<any>, map: ExpressionFunction<any>, reduce: ReduceFunction<any>, base?: any): Sequence;
+        groupBy(...aggregators: Aggregator[]): Expression<Object>; // TODO: reduction object
+        contains(prop: string): Expression<boolean>;
+
+        // Manipulation
+        pluck(...props: string[]): Sequence;
+        without(...props: string[]): Sequence;
+    }
+
+    interface ExpressionFunction<U> {
+        (doc: Expression<any>): Expression<U>;
+    }
+
+    interface JoinFunction<U> {
+        (left: Expression<any>, right: Expression<any>): Expression<U>;
+    }
+
+    interface ReduceFunction<U> {
+        (acc: Expression<any>, val: Expression<any>): Expression<U>;
+    }
+
+    interface InsertOptions {
+        upsert: boolean; // true
+        durability: string; // 'soft'
+        return_vals: boolean; // false
+    }
+
+    interface UpdateOptions {
+        non_atomic: boolean;
+        durability: string; // 'soft'
+        return_vals: boolean; // false
+    }
+
+    interface WriteResult {
+        inserted: number;
+        replaced: number;
+        unchanged: number;
+        errors: number;
+        deleted: number;
+        skipped: number;
+        first_error: Error;
+        generated_keys: string[]; // only for insert
+    }
+
+    interface JoinResult {
+        left: any;
+        right: any;
+    }
+
+    interface CreateResult {
+        created: number;
+    }
+
+    interface DropResult {
+        dropped: number;
+    }
+
+    interface Index {
+        index: string;
+        left_bound?: string; // 'closed'
+        right_bound?: string; // 'open'
+    }
+
+    interface Expression<T> extends Writeable, Operation<T> {
+        (prop: string): Expression<any>;
+        merge(query: Expression<Object>): Expression<Object>;
+        append(prop: string): Expression<Object>;
+        contains(prop: string): Expression<boolean>;
+
+        and(b: boolean): Expression<boolean>;
+        or(b: boolean): Expression<boolean>;
+        eq(v: any): Expression<boolean>;
+        ne(v: any): Expression<boolean>;
+        not(): Expression<boolean>;
+
+        gt(value: T): Expression<boolean>;
+        ge(value: T): Expression<boolean>;
+        lt(value: T): Expression<boolean>;
+        le(value: T): Expression<boolean>;
+
+        add(n: number): Expression<number>;
+        sub(n: number): Expression<number>;
+        mul(n: number): Expression<number>;
+        div(n: number): Expression<number>;
+        mod(n: number): Expression<number>;
+
+        hasFields(...fields: string[]): Expression<boolean>;
+
+        default(value: T): Expression<T>;
+    }
+
+    interface Operation<T> {
+        run(conn: Connection, cb?: (err: Error, result: T) => void): Promise<T>;
+    }
+
+    interface Aggregator { }
+    interface Sort { }
+
+    interface Time { }
+
+
+    // http://www.rethinkdb.com/api/#js
+    // TODO control structures
 }

--- a/rethinkdb/rethinkdb.d.ts
+++ b/rethinkdb/rethinkdb.d.ts
@@ -36,10 +36,15 @@ declare module "rethinkdb" {
     export class Cursor {
         hasNext(): boolean;
         each(cb: (err: Error, row: any) => void, done?: () => void): void;
+        each<T>(cb: (err: Error, row: T) => void, done?: () => void): void;
         each(cb: (err: Error, row: any) => boolean, done?: () => void): void; // returning false stops iteration
+        each<T>(cb: (err: Error, row: T) => boolean, done?: () => void): void; // returning false stops iteration
         next(cb: (err: Error, row: any) => void): void;
+        next<T>(cb: (err: Error, row: T) => void): void;
         toArray(cb: (err: Error, rows: any[]) => void): void;
+        toArray<T>(cb: (err: Error, rows: T[]) => void): void;
         toArray(): Promise<any[]>;
+        toArray<T>(): Promise<T[]>;
         close(cb: (err: Error) => void): void;
         close(): Promise<void>;
     }

--- a/rethinkdb/rethinkdb.d.ts
+++ b/rethinkdb/rethinkdb.d.ts
@@ -35,11 +35,13 @@ declare module "rethinkdb" {
 
   export class Cursor {
     hasNext():boolean;
-    each(cb:(err:Error, row:any)=>void, done?:()=>void);
-    each(cb:(err:Error, row:any)=>boolean, done?:()=>void); // returning false stops iteration
-    next(cb:(err:Error, row:any) => void);
-    toArray(cb:(err:Error, rows:any[]) => void);
-    close();
+    each(cb:(err:Error, row:any)=>void, done?:()=>void): void;
+    each(cb:(err:Error, row:any)=>boolean, done?:()=>void): void; // returning false stops iteration
+    next(cb:(err:Error, row:any) => void): void;
+    toArray(cb:(err:Error, rows:any[]) => void): void;
+    toArray(): Promise<any[]>;
+    close(cb: (err: Error) => void): void;
+    close(): Promise<void>;
   }
 
   interface ConnectionOptions {
@@ -50,11 +52,14 @@ declare module "rethinkdb" {
   }
 
   interface Connection {
-    close();
+    close(cb: (err: Error) => void): void;
+    close(opts: { noreplyWait: boolean }, cb: (err: Error) => void): void;
+    close(): Promise<void>;
+    close(opts: { noreplyWait: boolean }): Promise<void>;
     reconnect(cb?:(err:Error, conn:Connection)=>void):Promise<Connection>;
-    use(dbName:string);
-    addListener(event:string, cb:Function);
-    on(event:string, cb:Function);
+    use(dbName:string): void;
+    addListener(event:string, cb:Function): void;
+    on(event:string, cb:Function): void;
   }
 
   interface Db {


### PR DESCRIPTION
Updated jquery.dataTables for 1.10.8

Release Notes: [https://cdn.datatables.net/1.10.8/](https://cdn.datatables.net/1.10.8/)
- Expanded .draw() parameter data type to allow string.
- Added "serverSide" parameter to page.Info() return type.
- $.fn.dataTable.tables() can now return instance of DataTables API.
- Added rowId option.
- Added row().id() method.
- Added rows().ids() method.
- Added count() method.
- Added 'numbers' paging option.
- Resolved implicit 'any' instances in test file.

Note: rows().every(), columns().every(), cells().every() parameter list was incorrectly updated in the 1.10.6 version of this file. The parameters listed apply to 1.10.8.
Note: the added 'postfix' option to 'number' renderer appears to be used internally.
