### PR TITLE
Mongoose: set document id property to be optional

### DIFF
--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -871,7 +871,7 @@ declare module "mongoose" {
     /** Hash containing current validation errors. */
     errors: Object;
     /** The string version of this documents _id. */
-    id: string;
+    id?: string;
     /** This documents _id. */
     _id: any;
     /** Boolean flag specifying if the document is new. */

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -715,7 +715,7 @@ declare module "mongoose" {
    * section document.js
    * http://mongoosejs.com/docs/api.html#document-js
    */
-  class MongooseDocument {
+  class MongooseDocument implements MongooseDocumentOptionals {
     /** Checks if a path is set to its default. */
     $isDefault(path?: string): boolean;
 
@@ -870,14 +870,17 @@ declare module "mongoose" {
 
     /** Hash containing current validation errors. */
     errors: Object;
-    /** The string version of this documents _id. */
-    id?: string;
     /** This documents _id. */
     _id: any;
     /** Boolean flag specifying if the document is new. */
     isNew: boolean;
     /** The documents schema. */
     schema: Schema;
+  }
+
+  interface MongooseDocumentOptionals {
+    /** The string version of this documents _id. */
+    id?: string;
   }
 
   interface DocumentToObjectOptions {


### PR DESCRIPTION
According to docs: http://mongoosejs.com/docs/api.html#document_Document-id
`Document.prototype.id` can be turned off, so `id` property should be optional.
Issue was brought up here: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11291#issuecomment-250215931
