### PR TITLE
Replace reference to deprecated http.ClientResponse with newer http.I…

### DIFF
--- a/websocket/websocket.d.ts
+++ b/websocket/websocket.d.ts
@@ -542,7 +542,7 @@ declare module "websocket" {
         url: url.Url;
         secure: boolean;
         socket: net.Socket;
-        response: http.ClientResponse;
+        response: http.IncomingMessage;
 
         constructor(clientConfig?: IClientConfig);
 


### PR DESCRIPTION
`http.ClientResponse` is deprecated, and does not exist in node 6.7.0. Replaced it with the newer `http.IncomingMessage`
