### PR TITLE
Improve IDevTools.instrument typing

### DIFF
--- a/redux-devtools/index.d.ts
+++ b/redux-devtools/index.d.ts
@@ -4,12 +4,14 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="react" />
+/// <reference types="redux" />
 
 import * as React from 'react';
+import { GenericStoreEnhancer } from 'redux';
 
 interface IDevTools {
     new (): JSX.ElementClass;
-    instrument(): Function
+    instrument(): GenericStoreEnhancer
 }
 
 export declare function createDevTools(el: React.ReactElement<any>): IDevTools;

--- a/redux-devtools/index.d.ts
+++ b/redux-devtools/index.d.ts
@@ -15,7 +15,7 @@ interface IDevTools {
 }
 
 export declare function createDevTools(el: React.ReactElement<any>): IDevTools;
-export declare function persistState(debugSessionKey: string): Function;
+export declare function persistState(debugSessionKey: string): GenericStoreEnhancer;
 
 declare const factory: { instrument(): Function };
 


### PR DESCRIPTION
Changed `IDevTools.instrument` from `Function` to `GenericStoreEnhancer` for better TypeScript tooling in combination with redux 3.6.
