### PR TITLE
Use correct redux-devtools-tests

### DIFF
--- a/redux-devtools/redux-devtools-tests.tsx
+++ b/redux-devtools/redux-devtools-tests.tsx
@@ -2,9 +2,11 @@
 /// <reference types="redux" />
 
 import * as React from 'react'
-import { createStore, applyMiddleware, compose } from 'redux'
+import { createStore, compose, Reducer, Store } from 'redux'
 import { Provider } from 'react-redux'
 import { createDevTools, persistState } from 'redux-devtools'
+
+declare var reducer: Reducer<any>
 
 class DevToolsMonitor extends React.Component<any, any> {  
 }
@@ -18,10 +20,12 @@ const finalCreateStore = compose(
   persistState('test-session')
 )(createStore)
 
+const store: Store<any> = finalCreateStore(reducer)
+
 class App extends React.Component<any, any> {
   render() {
     return (
-      <Provider>
+      <Provider store={store}>
         <DevTools />
       </Provider>
     )

--- a/redux-devtools/redux-devtools-tests.tsx
+++ b/redux-devtools/redux-devtools-tests.tsx
@@ -2,7 +2,7 @@
 /// <reference types="redux" />
 
 import * as React from 'react'
-import { createStore, compose, Reducer, Store } from 'redux'
+import { compose, createStore, Reducer, Store } from 'redux'
 import { Provider } from 'react-redux'
 import { createDevTools, persistState } from 'redux-devtools'
 

--- a/redux-devtools/tsconfig.json
+++ b/redux-devtools/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "files": [
         "index.d.ts",
-        "redux-devtools-2.1.4-tests.tsx"
+        "redux-devtools-tests.tsx"
     ],
     "compilerOptions": {
         "module": "commonjs",


### PR DESCRIPTION
Fixes #11458 
Updated `redux-devtools-tests.tsx` to include parts of `redux-devtools-2.1.4-tests.tsx` and `tsconfig.json` to include the tests for recent versions of redux-devtools.
Compile error is independent from this PR, needs #11601 to be fixed.
