### PR TITLE
Fixes #11604 [wiring-pi] There is no INST_EDGE_FALLING exported const but INT_EDGE_FALLING

### DIFF
--- a/wiring-pi/wiring-pi.d.ts
+++ b/wiring-pi/wiring-pi.d.ts
@@ -29,7 +29,7 @@ declare module 'wiring-pi' {
     // Interrupts
     export function wiringPiISR(pin: number, edgeType: number, callback: (delta: number) => void): void;
     export function wiringPiISRCancel(pin: number): void;
-    export const INST_EDGE_FALLING: number;
+    export const INT_EDGE_FALLING: number;
     export const INT_EDGE_RISING: number;
     export const INT_EDGE_BOTH: number;
     export const INT_EDGE_SETUP: number;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Exporting correct `const` `INST_EDGE_FALLING` -> `INT_EDGE_FALLING`.
