### PR TITLE
change Topic property latch to boolean type

### DIFF
--- a/roslib/roslib.d.ts
+++ b/roslib/roslib.d.ts
@@ -310,7 +310,7 @@ declare namespace ROSLIB {
 			compression?: string,
 			throttle_rate?: number,
 			queue_size?: number,
-			latch?: number,
+			latch?: boolean,
 			queue_length?: number
 		});
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

I understand that this would cause existing users of this interface to change their code (which sucks) but I believe that `number` is the wrong type for the `latch` property of `Topic`. If you look at the [JavaScript source for roslibjs/Topic](https://github.com/RobotWebTools/roslibjs/blob/develop/src/core/Topic.js#L35) you will see that the `number` that gets passed in for `latch` is treated like this:

```
this.latch = latch || false;
```

if `latch` is zero (or falsy), then `this.latch` becomes false. if `latch` is non-zero (or truthy) then `this.latch` becomes that non-zero number. A boolean would ensure more type safety in this case because `this.latch` could then only be `true` or `false`.

If this change is a bad idea because it breaks existing users, then I understand. I just wanted to bring the topic to the table.
