### PR TITLE
Material UI: Correct sub type of MuiThemeProviderProps

### DIFF
--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -454,7 +454,7 @@ declare namespace __MaterialUI {
         //** @deprecated use MuiThemeProvider instead **/
         export function themeDecorator(muiTheme: Styles.MuiTheme): <TFunction extends Function>(Component: TFunction) => TFunction;
 
-        interface MuiThemeProviderProps extends React.Props<MuiThemeProvider> {
+        interface MuiThemeProviderProps extends React.HTMLAttributes<MuiThemeProvider> {
             muiTheme?: Styles.MuiTheme;
         }
         export class MuiThemeProvider extends React.Component<MuiThemeProviderProps, {}>{


### PR DESCRIPTION
This will fix errors whereby

```
React.createElement(MuiThemeProvider, {
    muiTheme: lightMuiTheme,
    className: 'root',
});
```

would report

```
error TS2345: Argument of type '{ muiTheme: MuiTheme; className: string; }' is not assignable to parameter of type '(MuiThemeProviderProps & Attributes) | undefined'.
   Object literal may only specify known properties, and 'className' does not exist in type '(MuiThemeProviderProps & Attributes) | undefined'.
```
