### PR TITLE
fix the framework type

### DIFF
--- a/passport/passport-tests.ts
+++ b/passport/passport-tests.ts
@@ -7,19 +7,34 @@ import passport = require('passport');
 
 class TestStrategy implements passport.Strategy {
   public name: string = 'test';
-  constructor() {}
-  authenticate(req: express.Request) {}
+  constructor() { }
+  authenticate(req: express.Request) { }
 }
 
+const newFramework:passport.Framework = {
+  initialize: function () {
+    return function () { };
+  },
+  authenticate: function (passport, name, options) {
+    return function () {
+      return 'authenticate(): ' + name + ' ' + options;
+    };
+  },
+  authorize: function (passport, name, options) {
+    return function () {
+      return 'authorize(): ' + name + ' ' + options;
+    }
+  }
+};
 passport.use(new TestStrategy());
-passport.framework('test');
-passport.serializeUser((user, done) => {});
-passport.deserializeUser((id, done) => {});
+passport.framework(newFramework);
+passport.serializeUser((user, done) => { });
+passport.deserializeUser((id, done) => { });
 
 passport.use(new TestStrategy())
   .unuse('test')
   .use(new TestStrategy())
-  .framework('test-fw');
+  .framework(newFramework);
 
 
 var app = express();
@@ -28,27 +43,27 @@ app.configure(() => {
   app.use(passport.session());
 });
 
-app.post('/login', 
+app.post('/login',
   passport.authenticate('local', { failureRedirect: '/login', failureFlash: true }),
-  function(req, res) {
+  function (req, res) {
     res.redirect('/');
   });
 
-app.post('/login', function(req, res, next) {
-  passport.authenticate('local', function(err: any, user: { username: string; }, info: { message: string; }) {
+app.post('/login', function (req, res, next) {
+  passport.authenticate('local', function (err: any, user: { username: string; }, info: { message: string; }) {
     if (err) { return next(err) }
     if (!user) {
       req.session['error'] = info.message;
       return res.redirect('/login')
     }
-    req.logIn(user, function(err) {
+    req.logIn(user, function (err) {
       if (err) { return next(err); }
       return res.redirect('/users/' + user.username);
     });
   })(req, res, next);
 });
 
-app.get('/logout', function(req, res) {
+app.get('/logout', function (req, res) {
   req.logout();
   res.redirect('/');
 });
@@ -66,20 +81,22 @@ function authSetting(): void {
   };
 
   app.get('/auth/facebook',
-      passport.authenticate('facebook'));
+    passport.authenticate('facebook'));
   app.get('/auth/facebook/callback',
-      passport.authenticate('facebook', authOption), successCallback);
+    passport.authenticate('facebook', authOption), successCallback);
 
   app.get('/auth/twitter',
-      passport.authenticate('twitter'));
+    passport.authenticate('twitter'));
   app.get('/auth/twitter/callback',
-      passport.authenticate('twitter', authOption));
+    passport.authenticate('twitter', authOption));
 
   app.get('/auth/google',
-      passport.authenticate('google', { scope:
-        [ 'https://www.googleapis.com/auth/userinfo.profile' ] }));
+    passport.authenticate('google', {
+      scope:
+      ['https://www.googleapis.com/auth/userinfo.profile']
+    }));
   app.get('/auth/google/callback',
-      passport.authenticate('google', authOption), successCallback);
+    passport.authenticate('google', authOption), successCallback);
 
 }
 

--- a/passport/passport.d.ts
+++ b/passport/passport.d.ts
@@ -93,6 +93,6 @@ declare module 'passport' {
     interface Framework {
         initialize(passport: Passport, options?: Object): Function;
         authenticate(passport: Passport, name: string, options?: Object, callback?: Function): Function;
-        authorize(passport: Passport, name: string, options?: Object, callback?: Function): Function;
+        authorize?(passport: Passport, name: string, options?: Object, callback?: Function): Function;
     }
 }

--- a/passport/passport.d.ts
+++ b/passport/passport.d.ts
@@ -91,8 +91,8 @@ declare module 'passport' {
     }
 
     interface Framework {
-        initialize(): Function;
-        authenticate(passport: Passport, name: string, options?: Object):Function;
-        authorize(passport: Passport, name: string, options?: Object):Function;
+        initialize(passport: Passport, options?: Object): Function;
+        authenticate(passport: Passport, name: string, options?: Object): Function;
+        authorize(passport: Passport, name: string, options?: Object): Function;
     }
 }

--- a/passport/passport.d.ts
+++ b/passport/passport.d.ts
@@ -30,7 +30,7 @@ declare module 'passport' {
     function use(strategy: Strategy): Passport;
     function use(name: string, strategy: Strategy): Passport;
     function unuse(name: string): Passport;
-    function framework(fw: string): Passport;
+    function framework(fw: Framework): Passport;
     function initialize(options?: { userProperty: string; }): express.Handler;
     function session(options?: { pauseStream: boolean; }): express.Handler;
 
@@ -50,7 +50,7 @@ declare module 'passport' {
         use(strategy: Strategy): Passport;
         use(name: string, strategy: Strategy): Passport;
         unuse(name: string): Passport;
-        framework(fw: string): Passport;
+        framework(fw: Framework): Passport;
         initialize(options?: { userProperty: string; }): express.Handler;
         session(options?: { pauseStream: boolean; }): express.Handler;
 
@@ -76,7 +76,7 @@ declare module 'passport' {
         provider: string;
         id: string;
         displayName: string;
-        name? : {
+        name?: {
             familyName: string;
             givenName: string;
             middleName?: string;
@@ -88,5 +88,11 @@ declare module 'passport' {
         photos?: {
             value: string;
         }[];
+    }
+
+    interface Framework {
+        initialize(): Function;
+        authenticate(passport: Passport, name: string, options?: Object):Function;
+        authorize(passport: Passport, name: string, options?: Object):Function;
     }
 }

--- a/passport/passport.d.ts
+++ b/passport/passport.d.ts
@@ -92,7 +92,7 @@ declare module 'passport' {
 
     interface Framework {
         initialize(passport: Passport, options?: Object): Function;
-        authenticate(passport: Passport, name: string, options?: Object): Function;
-        authorize(passport: Passport, name: string, options?: Object): Function;
+        authenticate(passport: Passport, name: string, options?: Object, callback?: Function): Function;
+        authorize(passport: Passport, name: string, options?: Object, callback?: Function): Function;
     }
 }


### PR DESCRIPTION
According to the [inline document and code of passport.framework](https://github.com/jaredhanson/passport/blob/master/lib/authenticator.js#L84-L106) and the [test code of passport.framework](https://github.com/jaredhanson/passport/blob/master/test/authenticator.framework.test.js#L12-L45), the type of parameter in `framework(fw : string)` is not string. It should be a object which has two required properties, `initialize()` and `authenticate()`, and a optional property `authorize()`.

Actually if you have written any typescript code using the `passport.framework` api, you will find out that the string type of parameter is definitely wrong . 
