### PR TITLE
[TS 2] React Component/PureComponent constructor super accept rest pa…

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -163,6 +163,7 @@ declare namespace React {
 
     // Base component for plain JS classes
     class Component<P, S> implements ComponentLifecycle<P, S> {
+        constructor(...args: any[]);
         constructor(props?: P, context?: any);
         setState(f: (prevState: S, props: P) => S, callback?: () => any): void;
         setState(state: S, callback?: () => any): void;

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -214,8 +214,8 @@ var component: ModernComponent =
 var componentNullContainer: ModernComponent =
     ReactDOM.render(element, null);
 
-var componentElementOrNull: ModernComponent = 
-    ReactDOM.render(element, document.getElementById("anelement"));    
+var componentElementOrNull: ModernComponent =
+    ReactDOM.render(element, document.getElementById("anelement"));
 var componentNoState: ModernComponentNoState =
     ReactDOM.render(elementNoState, container);
 var componentNoStateElementOrNull: ModernComponentNoState =
@@ -620,4 +620,18 @@ let newObj2 = update(obj, {b: {$set: obj.b * 2}});
 
 let objShallow = {a: 5, b: 3};
 let newObjShallow = update(obj, {$merge: {b: 6, c: 7}}); // => {a: 5, b: 6, c: 7}
+}
+
+//
+// React Component classes super spread arguments
+// --------------------------------------------------------------------------
+class ConstructorSpreadArgsComponent extends React.Component<{}, {}> {
+    constructor(...args: any[]) {
+        super(...args);
+    }
+}
+class ConstructorSpreadArgsPureComponent extends React.PureComponent<{}, {}> {
+    constructor(...args: any[]) {
+        super(...args);
+    }
 }


### PR DESCRIPTION
This PR successfully passes spread operator to super calls on React.Component and React.PureComponent and fixes [11472](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11472).

I was unable to infer types on the spread array, but it seems that it's not possible yet.
Even so, when you call super with spread operator, you don't intend to use the props or context anyways.

It was not my intention to cleanup the white spaces in `react/react-tests.ts` since my editor auto cleans white spaces. But it is harmless.
