### PR TITLE
[TS 2] redux-mock-store tweaks

### DIFF
--- a/redux-mock-store/redux-mock-store-tests.ts
+++ b/redux-mock-store/redux-mock-store-tests.ts
@@ -41,3 +41,7 @@ store.dispatch({ type: 'INCREMENT' });
 var actions: Array<any> = store.getActions();
 
 store.clearActions();
+
+// actions access without the need to cast
+var actions2 = store.getActions();
+actions2[10].payload.id;

--- a/redux-mock-store/redux-mock-store.d.ts
+++ b/redux-mock-store/redux-mock-store.d.ts
@@ -8,16 +8,16 @@
 declare module 'redux-mock-store' {
     import * as Redux from 'redux'
 
-    function createMockStore<T>(middlewares?:Redux.Middleware[]):mockStore<T>
+    function createMockStore<T>(middlewares?: Redux.Middleware[]): mockStore<T>;
 
-    export type mockStore<T> = (state?:T) => IStore<T>;
+    export type mockStore<T> = (state?: T) => IStore<T>;
 
-    export type IStore<T> = {
-        dispatch(action: any):any
-        getState():T
-        getActions():Object[]
-        clearActions():void
-        subscribe(listener: Function):Function
+    export interface IStore<T> {
+        dispatch(action: any): any;
+        getState(): T;
+        getActions(): any[];
+        clearActions(): void;
+        subscribe(listener: Function): Function;
     }
 
     export default createMockStore


### PR DESCRIPTION
`getActions()` returns `any[]` instead of `Object`, this eliminates the need to manual cast and you can access for example the payload props directly.

type `IStore` was changed to a real interface allowing users to extend it.
