### PR TITLE
CKEditor HTML parser typings

### DIFF
--- a/ckeditor/ckeditor-tests.ts
+++ b/ckeditor/ckeditor-tests.ts
@@ -329,3 +329,20 @@ function test_basicWriter() {
     writer.closeTag('p');
     alert(writer.getHtml(true)); // '<p class="MyClass">Hello</p>'
 }
+
+function test_htmlWriter() {
+    var writer = new CKEDITOR.htmlWriter();
+    writer.openTag('p', {});
+    writer.attribute('class', 'MyClass');
+    writer.openTagClose('p', false);
+    writer.text('Hello');
+    writer.closeTag('p');
+    alert(writer.getHtml(true)); // '<p class="MyClass">Hello</p>'
+
+    writer.indentationChars = '\t';
+    writer.lineBreakChars = '\r\n';
+    writer.selfClosingEnd = '>';
+    writer.indentation();
+    writer.lineBreak();
+    writer.setRules('img', {breakBeforeOpen: true, breakAfterOpen: true});
+}

--- a/ckeditor/ckeditor-tests.ts
+++ b/ckeditor/ckeditor-tests.ts
@@ -319,3 +319,13 @@ function test_focusManager() {
     var object: CKEDITOR.dom.domObject = focusManager.currentActive;
     var bool: boolean = focusManager.hasFocus;
 }
+
+function test_basicWriter() {
+    var writer = new CKEDITOR.htmlParser.basicWriter();
+    writer.openTag('p', {});
+    writer.attribute('class', 'MyClass');
+    writer.openTagClose('p', false);
+    writer.text('Hello');
+    writer.closeTag('p');
+    alert(writer.getHtml(true)); // '<p class="MyClass">Hello</p>'
+}

--- a/ckeditor/ckeditor.d.ts
+++ b/ckeditor/ckeditor.d.ts
@@ -1270,6 +1270,16 @@ declare namespace CKEDITOR {
         toHtml(data: string, fixForBody?: string): void;
     }
 
+    class htmlDataProcessor {
+        dataFilter: htmlParser.filter;
+        htmlFilter: htmlParser.filter;
+        writer: htmlParser.basicWriter;
+
+        constructor(editor: editor);
+        toDataFormat(html: string, options?: Object): string;
+        toHtml(data: string, options?: Object): string;
+    }
+
 
     class event {
         constructor();

--- a/ckeditor/ckeditor.d.ts
+++ b/ckeditor/ckeditor.d.ts
@@ -1803,6 +1803,16 @@ declare namespace CKEDITOR {
 
     }
 
+    class htmlWriter extends htmlParser.basicWriter {
+        indentationChars: string;
+        lineBreakChars: string;
+        selfClosingEnd: string;
+
+        indentation(): void;
+        lineBreak(): void;
+        setRules(tagName: string, rules: Object): void;
+    }
+
 
     namespace tools {
         var callFunction: Function;


### PR DESCRIPTION
#### test(CKEditor): Add missing tests for htmlParser.basicWriter

---
#### feat(CKEditor): Add typings for htmlWriter

See related documentation at:
http://docs.ckeditor.com/#!/api/CKEDITOR.htmlWriter

---
#### feat(CKEditor): Add typings for htmlDataProcessor

See related documentation at:
http://docs.ckeditor.com/#!/api/CKEDITOR.htmlDataProcessor
