### PR TITLE
jQuery.html() accepts everything that jQuery.append() does http://sta…

### DIFF
--- a/jquery/jquery-tests.ts
+++ b/jquery/jquery-tests.ts
@@ -2203,6 +2203,16 @@ function test_html() {
     $("div").html("<b>Wow!</b> Such excitement...");
     $("div b").append(document.createTextNode("!!!"))
               .css("color", "red");
+
+    // Anything valid in jQuery.append is valid in jQuery.html
+    // http://stackoverflow.com/a/27404233/3012550
+    var jQueryObject = $("<p>jQuery object</p>");
+    var element = document.createElement("element");
+    var textNode = document.createTextNode("text");
+    $("div").html(jQueryObject);
+    $("div").html(element);
+    $("div").html(textNode);
+    $("div").html([jQueryObject, element, textNode]);
 }
 
 function test_inArray() {

--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -1293,7 +1293,7 @@ interface JQuery {
      *
      * @param htmlString A string of HTML to set as the content of each matched element.
      */
-    html(htmlString: string): JQuery;
+    html(htmlString: JQuery|any[]|Element|DocumentFragment|Text|string): JQuery;
     /**
      * Set the HTML contents of each element in the set of matched elements.
      *


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

See http://stackoverflow.com/a/27404233/3012550

the jQuery documentation says that `html()` only takes a string or a function, but examining the source code shows that `html()` delegates unknown arguments to `append()`, so really `html()` accepts everything that `append()` does. 
