### PR TITLE
Update Google Maps API type definition to 3.25

### DIFF
--- a/googlemaps/google.maps.d.ts
+++ b/googlemaps/google.maps.d.ts
@@ -922,6 +922,7 @@ declare namespace google.maps {
         formatted_address: string;
         geometry: GeocoderGeometry;
         partial_match: boolean;
+        place_id: string;
         postcode_localities: string[];
         types: string[];
     }
@@ -984,10 +985,11 @@ declare namespace google.maps {
         avoidFerries?: boolean;
         avoidHighways?: boolean;
         avoidTolls?: boolean;
-        destination?: LatLng|LatLngLiteral|string;
-        durationInTraffic?: boolean;
+        destination?: string|LatLng|Place;
+        durationInTraffic?: boolean; /* Deprecated. Use drivingOptions field instead */
+        drivingOptions?: DrivingOptions;
         optimizeWaypoints?: boolean;
-        origin?: LatLng|LatLngLiteral|string;
+        origin?: string|LatLng|Place;
         provideRouteAlternatives?: boolean;
         region?: string;
         transitOptions?: TransitOptions;
@@ -1030,6 +1032,18 @@ declare namespace google.maps {
     }
 
     export interface TransitFare { }
+
+    export interface DrivingOptions {
+        departureTime: Date;
+        trafficModel: TrafficModel
+    }
+
+    export enum TrafficModel
+    {
+        BEST_GUESS,
+        OPTIMISTIC,
+        PESSIMISTIC
+    }
 
     export interface DirectionsWaypoint {
         location: LatLng|LatLngLiteral|string;
@@ -1215,9 +1229,10 @@ declare namespace google.maps {
         avoidFerries?: boolean;
         avoidHighways?: boolean;
         avoidTolls?: boolean;
-        destinations?: LatLng[]|string[];
+        destinations?: string[]|LatLng[]|Place[];
+        drivingOptions?: DrivingOptions;
         durationInTraffic?: boolean;
-        origins?: LatLng[]|string[];
+        origins?: string[]|LatLng|Place;
         region?: string;
         transitOptions?: TransitOptions;
         travelMode?: TravelMode;
@@ -1237,6 +1252,7 @@ declare namespace google.maps {
     export interface DistanceMatrixResponseElement {
         distance: Distance;
         duration: Duration;
+        duration_in_traffic: Duration;
         fare: TransitFare;
         status: DistanceMatrixElementStatus;
     }

--- a/googlemaps/google.maps.d.ts
+++ b/googlemaps/google.maps.d.ts
@@ -1232,7 +1232,7 @@ declare namespace google.maps {
         destinations?: string[]|LatLng[]|Place[];
         drivingOptions?: DrivingOptions;
         durationInTraffic?: boolean;
-        origins?: string[]|LatLng|Place;
+        origins?: string[]|LatLng[]|Place[];
         region?: string;
         transitOptions?: TransitOptions;
         travelMode?: TravelMode;

--- a/googlemaps/google.maps.d.ts
+++ b/googlemaps/google.maps.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Google Maps JavaScript API 3.20
+// Type definitions for Google Maps JavaScript API 3.25
 // Project: https://developers.google.com/maps/
 // Definitions by: Folia A/S <http://www.folia.dk>, Chris Wrench <https://github.com/cgwrench>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/googlemaps/google.maps.d.ts
+++ b/googlemaps/google.maps.d.ts
@@ -2060,7 +2060,7 @@ declare namespace google.maps {
 
         export interface PlaceResult {
             address_components: GeocoderAddressComponent[];
-            aspects: PlaceAspectRating[];
+            aspects: PlaceAspectRating[];  /* Deprecated. Will be removed May 2, 2017 */
             formatted_address: string;
             formatted_phone_number: string;
             geometry: PlaceGeometry;
@@ -2103,7 +2103,8 @@ declare namespace google.maps {
             openNow?: boolean;
             radius?: number;
             rankBy?: RankBy;
-            types?: string[];
+            types?: string[]; /* Deprecated. Will be removed February 16, 2017 */
+            type?: string;
         }
 
         export class PlacesService {
@@ -2144,7 +2145,8 @@ declare namespace google.maps {
             location?: LatLng|LatLngLiteral;
             name?: string;
             radius?: number;
-            types?: string[];
+            types?: string[];  /* Deprecated. Will be removed February 16, 2017 */
+            type?: string;
         }
 
         export enum RankBy {
@@ -2168,7 +2170,8 @@ declare namespace google.maps {
             location?: LatLng|LatLngLiteral;
             query: string;
             radius?: number;
-            types?: string[];
+            types?: string[]; /* Deprecated. Will be removed February 16, 2017 */
+            type?: string;
         }
     }
 


### PR DESCRIPTION
I noticed that the API definition was out of date. The current stable version of the Google Maps API is 3.25. I went through and applied all the changes for 3.20 -> 3.25.

API Reference:
https://developers.google.com/maps/documentation/javascript/reference

Change log:
https://developers.google.com/maps/documentation/javascript/releases
