### PR TITLE
[nprogress] Update configuration properties

### DIFF
--- a/nprogress/NProgress-tests.ts
+++ b/nprogress/NProgress-tests.ts
@@ -21,13 +21,13 @@ function test_configuration() {
     });
 
     NProgress.configure({
-        ease: 'ease',
+        easing: 'ease',
         minimum: 0.09,
         showSpinner: false,
         speed: 420,
         template: "<div>blah</div>",
         trickle: false,
-        trickleRate: 0.42,
-        trickleSpeed: 42
+        trickleSpeed: 42,
+        parent: 'body',
     });
 }

--- a/nprogress/NProgress.d.ts
+++ b/nprogress/NProgress.d.ts
@@ -69,14 +69,14 @@ interface NProgressStatic {
 interface NProgressConfigureOptions {
 
     /**
+     * CSS selector to change the parent DOM element of the progress. Default is body.
+     */
+    parent?: string
+
+    /**
      * The minimum progress percentage. Default is 0.08.
      */
     minimum?: number;
-
-    /**
-     * How much to increase per trickle. Example: .02. Default is true.
-     */
-    trickleRate?: number;
 
     /**
      * How often to trickle, in milliseconds. Default is 800.
@@ -94,9 +94,9 @@ interface NProgressConfigureOptions {
     trickle?: boolean;
 
     /**
-     * The CSS easing animation to use. Default is 'ease'.
+     * The CSS easing animation to use. Default is 'linear'.
      */
-    ease?: string;
+    easing?: string;
 
     /**
      * The animation speed in milliseconds. Default is 200.


### PR DESCRIPTION
Update a couple of nprogress configuration properties:
- `ease` is renamed to `easing`.
- `trickleRate` is removed.
- `parent` is added.

More info [here](https://github.com/rstacruz/nprogress/blob/master/nprogress.js#L19-L31).
