### PR TITLE
Knockout: Add support for TypeScript 2.0 strictNullChecks option

### DIFF
--- a/knockout/index.d.ts
+++ b/knockout/index.d.ts
@@ -87,7 +87,7 @@ interface KnockoutComputed<T> extends KnockoutObservable<T>, KnockoutComputedFun
 interface KnockoutObservableArrayStatic {
     fn: KnockoutObservableArrayFunctions<any>;
 
-    <T>(value?: T[]): KnockoutObservableArray<T>;
+    <T>(value?: T[] | null): KnockoutObservableArray<T>;
 }
 
 interface KnockoutObservableArray<T> extends KnockoutObservable<T[]>, KnockoutObservableArrayFunctions<T> {
@@ -97,12 +97,12 @@ interface KnockoutObservableArray<T> extends KnockoutObservable<T[]>, KnockoutOb
 interface KnockoutObservableStatic {
     fn: KnockoutObservableFunctions<any>;
 
-    <T>(value?: T): KnockoutObservable<T>;
+    <T>(value?: T | null): KnockoutObservable<T>;
 }
 
 interface KnockoutObservable<T> extends KnockoutSubscribable<T>, KnockoutObservableFunctions<T> {
 	(): T;
-	(value: T): void;
+	(value: T | null): void;
 
 	peek(): T;
 	valueHasMutated?:{(): void;};
@@ -506,7 +506,7 @@ interface KnockoutStatic {
     // templating.js
     //////////////////////////////////
 
-    setTemplateEngine(templateEngine: KnockoutNativeTemplateEngine): void;
+    setTemplateEngine(templateEngine: KnockoutNativeTemplateEngine | undefined): void;
 
     renderTemplate(template: Function, dataOrBindingContext: KnockoutBindingContext, options: Object, targetNodeOrNodeArray: Node, renderMode: string): any;
     renderTemplate(template: any, dataOrBindingContext: KnockoutBindingContext, options: Object, targetNodeOrNodeArray: Node, renderMode: string): any;
@@ -526,7 +526,7 @@ interface KnockoutStatic {
         bindingRewriteValidators: any[];
         twoWayBindings: any;
         parseObjectLiteral: (objectLiteralString: string) => any[];
-        
+
         /**
         Internal, private KO utility for updating model properties from within bindings
         property:            If the property being updated is (or might be) an observable, pass it here
@@ -538,7 +538,7 @@ interface KnockoutStatic {
         value:               The value to be written
         checkIfDifferent:    If true, and if the property being written is a writable observable, the value will only be written if
                              it is !== existing value on that writable observable
-                             
+
         Note that if you need to write to the viewModel without an observable property,
         you need to set ko.expressionRewriting.twoWayBindings[key] = true; *before* the binding evaluation.
         */
@@ -564,21 +564,21 @@ interface KnockoutStatic {
     };
 
     components: KnockoutComponents;
-    
+
     /////////////////////////////////
     // options.js
     /////////////////////////////////
-    
+
     options: {
         deferUpdates: boolean,
-        
+
         useOnlyNativeEvents: boolean
     };
-    
+
     /////////////////////////////////
     // tasks.js
     /////////////////////////////////
-    
+
     tasks: KnockoutTasks;
 }
 

--- a/knockout/index.d.ts
+++ b/knockout/index.d.ts
@@ -5,17 +5,17 @@
 
 
 interface KnockoutSubscribableFunctions<T> {
-    [key: string]: KnockoutBindingHandler;
+    [key: string]: KnockoutBindingHandler | undefined;
 
 	notifySubscribers(valueToWrite?: T, event?: string): void;
 }
 
 interface KnockoutComputedFunctions<T> {
-    [key: string]: KnockoutBindingHandler;
+    [key: string]: KnockoutBindingHandler | undefined;
 }
 
 interface KnockoutObservableFunctions<T> {
-    [key: string]: KnockoutBindingHandler;
+    [key: string]: KnockoutBindingHandler | undefined;
 
 	equalityComparer(a: any, b: any): boolean;
 }
@@ -35,7 +35,7 @@ interface KnockoutObservableArrayFunctions<T> {
     sort(compareFunction: (left: T, right: T) => number): KnockoutObservableArray<T>;
 
     // Ko specific
-    [key: string]: KnockoutBindingHandler;
+    [key: string]: KnockoutBindingHandler | undefined;
 
     replace(oldItem: T, newItem: T): void;
 

--- a/knockout/tests/knockout-templatingBehaviors-tests.ts
+++ b/knockout/tests/knockout-templatingBehaviors-tests.ts
@@ -216,11 +216,15 @@ describe('Templating', function() {
         var myData = ko.observable({ childProp: 123 });
         ko.applyBindings({ someProp: myData }, testNode);
         expect(testNode.childNodes[0].innerHTML).toEqual("result = 123");
-
+        expect(myData).toBeDefined();
         // Now mutate and notify
-        myData().childProp = 456;
-        myData.valueHasMutated();
-        expect(testNode.childNodes[0].innerHTML).toEqual("result = 456");
+        if (myData) {
+            myData().childProp = 456;
+            if (myData.valueHasMutated) {
+                myData.valueHasMutated();
+            }
+            expect(testNode.childNodes[0].innerHTML).toEqual("result = 456");
+        }
     });
 
     it('Should stop tracking inner observables immediately when the container node is removed from the document', function() {
@@ -300,7 +304,11 @@ describe('Templating', function() {
         ko.applyBindings({ someProp: { childProp: innerObservable} }, testNode);
 
         expect(innerObservable.getSubscriptionsCount()).toEqual(1);
-        ko.removeNode(document.getElementById('innerTemplateOutput'));
+        let innerTemplateOutputEl = document.getElementById('innerTemplateOutput');
+        expect(innerTemplateOutputEl).not.toBeNull();
+        if (innerTemplateOutputEl) {
+            ko.removeNode(innerTemplateOutputEl);
+        }
         expect(innerObservable.getSubscriptionsCount()).toEqual(0);
     });
 

--- a/knockout/tests/knockout-tests.ts
+++ b/knockout/tests/knockout-tests.ts
@@ -170,7 +170,7 @@ function test_bindings() {
     };
     ko.bindingHandlers.slideVisible = {
         update: function (element, valueAccessor, allBindingsAccessor) {
-            var value = valueAccessor(), allBindings = allBindingsAccessor();
+            var value = valueAccessor(), allBindings = allBindingsAccessor ? allBindingsAccessor() : null;
             var valueUnwrapped = ko.utils.unwrapObservable(value);
             var duration = allBindings.slideDuration || 400;
             if (valueUnwrapped == true)
@@ -211,7 +211,7 @@ function test_bindings() {
     ko.bindingHandlers.withProperties = {
         init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
             var newProperties = valueAccessor(),
-                innerBindingContext = bindingContext.extend(newProperties);
+                innerBindingContext = bindingContext ? bindingContext.extend(newProperties) : null;
             ko.applyBindingsToDescendants(innerBindingContext, element);
             return { controlsDescendantBindings: true };
         }
@@ -219,7 +219,7 @@ function test_bindings() {
     ko.bindingHandlers.withProperties = {
         init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
             var newProperties = valueAccessor(),
-                childBindingContext = bindingContext.createChildContext(viewModel);
+                childBindingContext = bindingContext ? bindingContext.createChildContext(viewModel) : null;
             ko.utils.extend(childBindingContext, newProperties);
             ko.applyBindingsToDescendants(childBindingContext, element);
             return { controlsDescendantBindings: true };
@@ -227,8 +227,8 @@ function test_bindings() {
     };
     ko.bindingHandlers.randomOrder = {
         init: function (elem, valueAccessor) {
-            var child = ko.virtualElements.firstChild(elem),
-                childElems = [];
+            var child = ko.virtualElements.firstChild(elem) as Node,
+                childElems: Node[] = [];
             while (child) {
                 childElems.push(child);
                 child = ko.virtualElements.nextSibling(child);
@@ -342,6 +342,7 @@ function test_more() {
     var first;
     this.firstName = ko.observable(first).extend({ required: "Please enter a first name", logChange: "first name" });
 
+    const name = "My Name";
     var upperCaseName = ko.computed(function () {
         return name.toUpperCase();
     }).extend({ throttle: 500 });
@@ -405,7 +406,7 @@ function test_more() {
     });
     ko.observableArray.fn.filterByProperty = function (propName, matchValue) {
         return ko.computed(function () {
-            var allItems = this(), matchingItems = [];
+            var allItems = this(), matchingItems: string[] = [];
             for (var i = 0; i < allItems.length; i++) {
                 var current = allItems[i];
                 if (ko.utils.unwrapObservable(current[propName]) === matchValue)
@@ -431,7 +432,7 @@ function test_more() {
 
     ko.applyBindings(new AppViewModel4());
     this.doneTasks = ko.computed(function () {
-    var all = this.tasks(), done = [];
+    var all = this.tasks(), done: string[] = [];
         for (var i = 0; i < all.length; i++)
             if (all[i].done())
                 done.push(all[i]);
@@ -545,7 +546,9 @@ function test_misc() {
             ko.computed({
                 read: function () {
                     ko.utils.unwrapObservable(valueAccessor());
-                    ko.bindingHandlers.options.update.apply(this, args);
+                    if (ko.bindingHandlers.options.update) {
+                        ko.bindingHandlers.options.update.apply(this, args);
+                    }
                 },
                 owner: this,
                 disposeWhenNodeIsRemoved: element
@@ -569,19 +572,19 @@ function test_misc() {
     ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
         $(element).datepicker("destroy");
     });
-	
+
 	this.observableFactory = function(flag = true): KnockoutObservable<number>{
 	    if (flag) {
 			return ko.computed({
-				read:function(){ 
-					return 3; 
+				read:function(){
+					return 3;
 				}
 			});
 		} else {
 			return ko.observable(3);
 		}
 	}
-	
+
 }
 
 interface KnockoutBindingHandlers {
@@ -626,21 +629,21 @@ function test_Components() {
         // viewModel from createViewModel factory method
         ko.components.register("name", { template: "string-template", viewModel: { createViewModel: function (params: any, componentInfo: KnockoutComponentTypes.ComponentInfo) { return null; } } });
 
-        // viewModel from an AMD module 
+        // viewModel from an AMD module
         ko.components.register("name", { template: "string-template", viewModel: { require: "module" } });
 
         // ------- template overloads
 
         // template from named element
         ko.components.register("name", { template: { element: "elementID" }, viewModel: viewModelFn });
-        
+
         // template using single Node
         ko.components.register("name", { template: { element: singleNode }, viewModel: viewModelFn });
-        
+
         // template using Node array
         ko.components.register("name", { template: nodeArray, viewModel: viewModelFn });
-        
-        // template using an AMD module 
+
+        // template using an AMD module
         ko.components.register("name", { template: { require: "text!module" }, viewModel: viewModelFn });
 
         // Empty config for registering custom elements that are handled by name convention
@@ -650,8 +653,8 @@ function test_Components() {
 
 
 function testUnwrapUnion() {
-    
-    var possibleObs: KnockoutObservable<number> | number;
+
+    var possibleObs: KnockoutObservable<number> | number = 0;
     var num = ko.unwrap(possibleObs);
 
 }
@@ -660,21 +663,21 @@ function test_tasks() {
     // Schedule an empty task
     ko.tasks.schedule(function() {
     });
-    
+
     // Schedule a task with arguments and return type
     let logSomethingTask = (message: string) => {
         console.log("Log message");
         return true;
     };
-    
+
     let taskHandle = ko.tasks.schedule(logSomethingTask);
-    
+
     // Cancel a task
     ko.tasks.cancel(taskHandle);
-    
+
     // Process the current microtask queue on demand
     ko.tasks.runEarly();
-    
+
     // Redefine or augment how Knockout schedules the event to process and flush the queue
     ko.tasks.scheduler = function (callback) {
         setTimeout(callback, 0);

--- a/knockout/tsconfig.json
+++ b/knockout/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "noImplicitAny": false,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
