### PR TITLE
Use modules for sat

### DIFF
--- a/sat/sat-tests.ts
+++ b/sat/sat-tests.ts
@@ -1,4 +1,7 @@
 /// <reference path="sat.d.ts" />
+
+import SAT = require("sat");
+
 class SatTest{
 	public vectorTest(){
 		let v1: SAT.Vector = new SAT.Vector(10, 10);
@@ -15,7 +18,7 @@ class SatTest{
 		console.log("perp: v3 - " + v3.x.toString() + v3.y.toString());
 
 	}
-	
+
 }
 
 let test = new SatTest;

--- a/sat/sat.d.ts
+++ b/sat/sat.d.ts
@@ -140,3 +140,7 @@ declare namespace SAT {
 	export function testPolygonPolygon(a: Polygon, b: Polygon, response?: Response): boolean;
 
 }
+
+declare module "sat" {
+	export = SAT;
+}


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

[sat](https://github.com/jriecken/sat-js/blob/master/SAT.js#L26) uses universal module definition, so basically it can use both `var SAT = require("sat");` or be added to the global namespace if the environment does not support modules.

Is this the correct way of going about it?
