### PR TITLE
Create typings for ngeohash

### DIFF
--- a/ngeohash/ngeohash-tests.ts
+++ b/ngeohash/ngeohash-tests.ts
@@ -1,0 +1,10 @@
+///<reference path="ngeohash.d.ts"/>
+
+import geohash = require('ngeohash');
+
+console.log(geohash.encode(37.8324, 112.5584));
+// prints ww8p1r4t8
+
+var latlon = geohash.decode('ww8p1r4t8');
+console.log(latlon.latitude);
+console.log(latlon.longitude);

--- a/ngeohash/ngeohash.d.ts
+++ b/ngeohash/ngeohash.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for ngeohash v0.6.0
+// Project: https://github.com/sunng87/node-geohash
+// Definitions by: Erik Rothoff Andersson <https://github.com/erkie>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/
+
+declare namespace ngeohash {
+  interface GeographicPoint {
+    latitude: number;
+    longitude: number;
+  }
+
+  type GeographicBoundingBox = [number, number, number, number];
+  type NSEW = [number, number];
+
+  function encode(latitude: number, longitude: number, precision?: number): string;
+  function decode(hashstring: string): GeographicPoint;
+  function decode_bbox(hashstring: string): GeographicBoundingBox;
+  function bboxes(minlat: number, minlon: number, maxlat: number, maxlon: number, precision?: number): Array<string>;
+  function neighbor(hashstring: string, direction: NSEW): string;
+  function neighbors(hashstring: string): Array<string>;
+
+  function encode_int(latitude: number, longitude: number, bitDepth?: number): number;
+  function decode_int(hashinteger: number, bitDepth?: number): GeographicPoint;
+  function decode_bbox_int(hashinteger: number, bitDepth?: number): GeographicBoundingBox;
+  function bboxes_int(minlat: number, minlon: number, maxlat: number, maxlon: number, bitDepth?: number): number;
+  function neighbor_int(hashinteger: number, direction: NSEW, bitDepth?: number): number;
+  function neighbors_int(hashinteger: number, bitDepth?: number): number;
+}
+
+declare module "ngeohash" {
+  export = ngeohash;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Great library. https://github.com/sunng87/node-geohash
