### PR TITLE
setEncoding(encoding: string | null)

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -280,7 +280,7 @@ declare namespace NodeJS {
     export interface ReadableStream extends EventEmitter {
         readable: boolean;
         read(size?: number): string | Buffer;
-        setEncoding(encoding: string): void;
+        setEncoding(encoding: string | null): void;
         pause(): ReadableStream;
         resume(): ReadableStream;
         pipe<T extends WritableStream>(destination: T, options?: { end?: boolean; }): T;


### PR DESCRIPTION
> Encoding can be disabled by calling readable.setEncoding(null).

https://nodejs.org/api/stream.html#stream_readable_setencoding_encoding

Typescript v2.\* has strictNullChecks which prevents passing null to setEncoding

https://www.typescriptlang.org/docs/release-notes/typescript-2.0.html
