### PR TITLE
Update deep-diff.d.ts

### DIFF
--- a/deep-diff/deep-diff-tests.ts
+++ b/deep-diff/deep-diff-tests.ts
@@ -23,7 +23,7 @@ var rhs = {
     }
 };
 
-var differences: deepDiff.IDiff[] = diff(lhs, rhs);
+var differences: deepDiff.Diff<string | Object>[] = diff(lhs, rhs);
 
 console.log(differences);
 
@@ -53,7 +53,7 @@ var rhs = {
     }
 };
 
-observableDiff(lhs, rhs, function (d: deepDiff.IDiff) {
+observableDiff<string | Object>(lhs, rhs, function (d) {
     // Apply all changes except those to the 'name' property...
     if (d.path.length !== 1 || d.path.join('.') !== 'name') {
         applyChange(lhs, rhs, d);

--- a/deep-diff/deep-diff-tests.ts
+++ b/deep-diff/deep-diff-tests.ts
@@ -23,7 +23,7 @@ var rhs = {
     }
 };
 
-var differences: deepDiff.Diff<string | Object>[] = diff(lhs, rhs);
+var differences = diff(lhs, rhs);
 
 console.log(differences);
 
@@ -53,7 +53,7 @@ var rhs = {
     }
 };
 
-observableDiff<string | Object>(lhs, rhs, function (d) {
+observableDiff(lhs, rhs, function (d) {
     // Apply all changes except those to the 'name' property...
     if (d.path.length !== 1 || d.path.join('.') !== 'name') {
         applyChange(lhs, rhs, d);

--- a/deep-diff/deep-diff.d.ts
+++ b/deep-diff/deep-diff.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: ZauberNerd <https://github.com/ZauberNerd/>, forabi <https://github.com/forabi/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'deep-diff' {
+declare namespace deepDiff {
   export interface BaseDiff<T> {
     /**
      * indicates the kind of change; will be one of the following:
@@ -14,7 +14,7 @@ declare module 'deep-diff' {
      */
     kind: 'N' |'D' | 'E' |'A';
     /** The property path (from the left-hand-side root) */
-    path: string[];
+    path: ReadonlyArray<string>;
   }
 
   export interface NewDiff<T> extends BaseDiff<T> {
@@ -45,7 +45,7 @@ declare module 'deep-diff' {
     /** Indicates the array index where the change occurred */
     index?: number;
     /** Contains a nested change record indicating the change that occurred at the array index */
-    item?: Diff;
+    item?: Diff<T>;
     /** The property path (from the left-hand-side root) */
     path: ReadonlyArray<string> & { 0: number };
   }
@@ -61,7 +61,7 @@ declare module 'deep-diff' {
   /**
    * A function that calculates the differences between two objects
    */
-  declare type DiffFunction = <T>(
+  export type DiffFunction = <T>(
     /**
      * The left-hand operand; the origin object
      */
@@ -103,7 +103,7 @@ declare module 'deep-diff' {
       lhs: DiffableObject<T>,
       rhs: typeof lhs,
       changes: (diff: Diff<T>) => void,
-      prefilter?: Prefilter,
+      prefilter?: (path: string[], key: string) => boolean,
       path?: string[],
       key?: string,
       stack?: Diff<T>[],
@@ -115,7 +115,7 @@ declare module 'deep-diff' {
     applyDiff<T>(
       target: DiffableObject<T>,
       source: typeof target,
-      filter: (target: typeof target, source: typeof source, change: Diff<T>) => boolean,
+      filter: (target: typeof source, src: typeof source, change: Diff<T>) => boolean,
     ): void;
 
     /**
@@ -132,11 +132,15 @@ declare module 'deep-diff' {
      */
     revertChange<T>(
       target: DiffableObject<T>,
-      source: typeof source,
+      source: typeof target,
       change: Diff<T>,
     ): void;
   }
-  const deepDiff: DeepDiff;
-  export const diff: DiffFunction;
-  export default Object.assign(diff, deepDiff, { diff });
+}
+
+declare const DeepDiff: deepDiff.DeepDiff;
+
+declare module 'deep-diff' {
+  const deepDiff: deepDiff.DeepDiff;
+  export = deepDiff;
 }

--- a/deep-diff/deep-diff.d.ts
+++ b/deep-diff/deep-diff.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for deep-diff
 // Project: https://github.com/flitbit/diff/
-// Definitions by: forabi <https://github.com/forabi/>
+// Definitions by: ZauberNerd <https://github.com/ZauberNerd/>, forabi <https://github.com/forabi/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module 'deep-diff' {

--- a/deep-diff/deep-diff.d.ts
+++ b/deep-diff/deep-diff.d.ts
@@ -1,42 +1,142 @@
 // Type definitions for deep-diff
 // Project: https://github.com/flitbit/diff/
-// Definitions by: ZauberNerd <https://github.com/ZauberNerd/>
+// Definitions by: forabi <https://github.com/forabi/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace deepDiff {
-    interface IDiff {
-        kind: string;
-        path: string[];
-        lhs: any;
-        rhs: any;
-        index?: number;
-        item?: IDiff;
-    }
+declare module 'deep-diff' {
+  export interface BaseDiff<T> {
+    /**
+     * indicates the kind of change; will be one of the following:
+     * 'N' = indicates a newly added property/element
+     * 'D' = indicates a property/element was deleted
+     * 'E' = indicates a property/element was edited
+     * 'A' = indicates a change occurred within an array
+     */
+    kind: 'N' |'D' | 'E' |'A';
+    /** The property path (from the left-hand-side root) */
+    path: string[];
+  }
 
-    interface IAccumulator {
-        push(diff: IDiff): void;
-        length: number;
-    }
+  export interface NewDiff<T> extends BaseDiff<T> {
+    kind: 'N';
+    /** The value on the right-hand-side of the comparison (undefined if kind === 'D') */
+    rhs: T;
+  }
 
-    interface IPrefilter {
-        (path: string[], key: string): boolean;
-    }
+  export interface EditDiff<T> extends BaseDiff<T> {
+    kind: 'E';
+    /** The value on the left-hand-side of the comparison (undefined if kind === 'N') */
+    lhs: T;
+    rhs: T;
+  }
 
-    interface IDeepDiff {
-        diff(): IDiff;
-        diff(lhs: Object, rhs: Object, prefilter?: IPrefilter, acc?: IAccumulator): IDiff[];
-        observableDiff(lhs: Object, rhs: Object, changes: Function, prefilter?: IPrefilter, path?: string[], key?: string, stack?: Object[]): void;
-        applyDiff(target: Object, source: Object, filter: Function): void;
-        applyChange(target: Object, source: Object, change: IDiff): void;
-        revertChange(target: Object, source: Object, change: IDiff): void;
-        isConflict(): boolean;
-        noConflict(): IDeepDiff;
-    }
-}
+  export interface DeleteDiff<T> extends BaseDiff<T> {
+    kind: 'D';
+    /** The value on the left-hand-side of the comparison (undefined if kind === 'N') */
+    lhs: T;
+  }
 
-declare var DeepDiff: deepDiff.IDeepDiff;
+  export interface ArrayDiff<T> extends BaseDiff<T> {
+    kind: 'A';
+    /** The value on the right-hand-side of the comparison (undefined if kind === 'D') */
+    rhs: T;
+    /** The value on the left-hand-side of the comparison (undefined if kind === 'N') */
+    lhs: T;
+    /** Indicates the array index where the change occurred */
+    index?: number;
+    /** Contains a nested change record indicating the change that occurred at the array index */
+    item?: Diff;
+    /** The property path (from the left-hand-side root) */
+    path: ReadonlyArray<string> & { 0: number };
+  }
 
-declare module "deep-diff" {
-    var diff: deepDiff.IDeepDiff;
-    export = diff;
+  type Diff<T> = NewDiff<T> | EditDiff<T> | DeleteDiff<T> | ArrayDiff<T>;
+  
+  interface Accumulator<T> {
+    push(o: T): void;
+    length: number;
+  }
+
+  type DiffableObject<T> = { [id: string]: T } | Array<T>;
+  /**
+   * A function that calculates the differences between two objects
+   */
+  declare type DiffFunction = <T>(
+    /**
+     * The left-hand operand; the origin object
+     */
+    origin?: DiffableObject<T>,
+    /**
+     * The right-hand operand; the object being compared structurally with the origin object.
+     */
+    target?: typeof origin,
+    /**
+     * An optional function that determines whether difference analysis should continue down the object graph
+     */
+    prefilter?: (path: string[], key: string) => boolean,
+    /**
+     * An optional accumulator/array (requirement is that it have a push function).
+     * Each difference is pushed to the specified accumulator.
+     */
+    acc?: Accumulator<Diff<T>>,
+  ) => Diff<T>[] | undefined;
+
+  interface DeepDiff {
+    /**
+     * A function that calculates the differences between two objects.
+     */
+    diff: DiffFunction;
+
+    isConflict(): boolean;
+
+    /**
+     * In a browser, deep-diff defines a global variable DeepDiff.
+     * If there is a conflict in the global namespace you can restore the conflicting definition and assign deep-diff to another variable like this:
+     * var deep = DeepDiff.noConflict();.
+     */
+    noConflict(): DeepDiff;
+
+    /**
+     * A function that calculates the differences between two objects and reports each to an observer function
+     */
+    observableDiff<T>(
+      lhs: DiffableObject<T>,
+      rhs: typeof lhs,
+      changes: (diff: Diff<T>) => void,
+      prefilter?: Prefilter,
+      path?: string[],
+      key?: string,
+      stack?: Diff<T>[],
+    ): void;
+
+    /**
+     * A function that applies any structural differences from one object to another
+     */
+    applyDiff<T>(
+      target: DiffableObject<T>,
+      source: typeof target,
+      filter: (target: typeof target, source: typeof source, change: Diff<T>) => boolean,
+    ): void;
+
+    /**
+     * A function that applies a single change record to an origin object
+     */
+    applyChange<T>(
+      target: DiffableObject<T>,
+      source: typeof target,
+      change: Diff<T>,
+    ): void;
+  
+    /**
+     * A function that reverts a single change record from a target object
+     */
+    revertChange<T>(
+      target: DiffableObject<T>,
+      source: typeof source,
+      change: Diff<T>,
+    ): void;
+  }
+  const deepDiff: DeepDiff;
+  export const diff: DiffFunction;
+  export default Object.assign(diff, deepDiff, { diff });
 }


### PR DESCRIPTION
Documentation: https://github.com/flitbit/diff
## Improvements compared to the current typings:
- Introduces and uses a `DiffableObject<T>` type instead of a generic object, this allows VS Code to understand what the result of a function call to `diff` will be.
- Introduces a `BaseDiff<T>` interface which is extended for each kind of diffs. This allows VS Code to perform control flow analysis in TypeScript >= 2.0.
- For `ArrayDiff`, the first item in the path array is a number
- Add descriptions for all functions and types
- `diff()` may return `undefined` for indentical objects
## Example

``` typescript
import deepDiff from 'deep-diff';
// or import { diff as deepDiff } from 'deep-diff';

type landmark = { [id: string]: GeometricalObject } | { };

const diffs = deepDiff(
  this.props.landmarks,
  nextProps.landmarks
); // diffs is of type Diff<GeometricalObject>[] or undefined;

diffs.forEach(diff => /* do something */) // Error: diffs is possibly undefined

if (diffs) {
  // diffs is now of type Diff<GeometricalObject>[]
  shouldRerender = true;
  diffs.forEach(diff => {
    // diff is of type Diff<GeometricalObject>
    if (diff.kind === 'N') {
      // diff is now of type NewDiff<GeometricalObject>
      // rhs is of type GeometricalObject;
      const object = geometricalObjectToFabricObject(diff.rhs, diff.path[0]);


      // Property lhs is undefined for diffs of kind N
      diff.lhs // Error: Property 'lhs' does not exist on type 'NewDiff<GeometricalObject>'
      if (object) {
        // diff.path is of type string[];
        objectMap.set(diff.path[0], object);
        landmarksGroup.add(object);
      }
    } else if (diff.kind === 'E') {
      // diff is of type EditDiff<GeometricalObject>
      // diff has properties: lhs, rhs
      objectMap.get(diff.path[0]).set(diff.path[1], diff.rhs);
    } else if (diff.kind === 'D') {
      // diff is of type DeleteDiff<GeometricalObject>
      // Property rhs is undefined for diffs of kind N
      diff.rhs // Error: Property 'rhs' does not exist on type 'NewDiff<GeometricalObject>'
      objectMap.get(diff.path[1]).remove();
      objectMap.delete(diff.path[0]);
    } else if (diff.kind === 'A') {
      // diff is of type ArrayDiff<GeometricalObject>
      // diff has properties: index, item
      // diff.path[0] is of type number
      // diff.path[1] is of type string
    }
  });
}
```
