### PR TITLE
[rethinkdb] More missing methods and overloads

### DIFF
--- a/rethinkdb/rethinkdb-tests.ts
+++ b/rethinkdb/rethinkdb-tests.ts
@@ -1,6 +1,4 @@
-/// <reference path="rethinkdb.d.ts" />
-
-import r = require("rethinkdb");
+import * as r from "rethinkdb";
 
 r.connect({ host: "localhost", port: 28015 }, function(err, conn) {
     console.log("HI", err, conn);
@@ -19,10 +17,18 @@ r.connect({ host: "localhost", port: 28015 }, function(err, conn) {
         .between("james", "beth")
         .limit(4)
         .run(conn, function(err, cursor) {
-          cursor.toArray().then(rows => {
-            console.log(rows);
+          cursor.toArray<string>((err, strings) => {
+            console.log(strings);
           });
         });
+    });
+
+    r.js("'str1' + 'str2'").run(conn, function (err, value) {});
+    r.uuid().run(conn, function (err, uuid) {});
+    r.uuid("input value").run(conn, function (err, uuid) {});
+
+    r.table("games").changes().run(conn, function(err, cursor) {
+      cursor.each(console.log);
     });
 });
 
@@ -43,6 +49,11 @@ r.connect({ host: "localhost", port: 28015 }).then(function(conn) {
         })
         .between("james", "beth")
         .limit(4)
-        .run(conn);
+        .run(conn)
+        .then(cursor => {
+          cursor.toArray().then(rows => {
+            console.log(rows);
+          });
+        });
     });
 });

--- a/rethinkdb/rethinkdb-tests.ts
+++ b/rethinkdb/rethinkdb-tests.ts
@@ -15,6 +15,13 @@ r.connect({ host: "localhost", port: 28015 }, function(err: Error, conn: r.Conne
     r.table("players").filter(r.row.hasFields("games_won").not()).run(conn, errorAndCursorCallback);
     r.table("players").filter(r.row.hasFields({ "games_won": { "championships": true } }).not()).run(conn, errorAndCursorCallback);
 
+    r.table("players").filter(
+      r.row.hasFields("games_won").not()
+      .or(r.row("games_won").not().eq(true))
+      .and(true)
+    )
+    .run(conn, errorAndCursorCallback);
+
     testDb.tableCreate("users").run(conn, function(err, stuff) {
         const users = testDb.table("users");
 

--- a/rethinkdb/rethinkdb-tests.ts
+++ b/rethinkdb/rethinkdb-tests.ts
@@ -14,6 +14,7 @@ r.connect({ host: "localhost", port: 28015 }, function(err, conn) {
         users.filter(function(doc?) {
             return doc("henry").eq("bob");
         })
+        .filter(r.row("updatedAt").default(0).lt(r.now().sub(1000)))
         .between("james", "beth")
         .limit(4)
         .run(conn, function(err, cursor) {

--- a/rethinkdb/rethinkdb-tests.ts
+++ b/rethinkdb/rethinkdb-tests.ts
@@ -1,3 +1,5 @@
+/// <reference path="./rethinkdb.d.ts"/>
+
 import * as r from "rethinkdb";
 
 r.connect({ host: "localhost", port: 28015 }, function(err, conn) {

--- a/rethinkdb/rethinkdb-tests.ts
+++ b/rethinkdb/rethinkdb-tests.ts
@@ -1,17 +1,20 @@
 /// <reference path="rethinkdb.d.ts" />
 
-import r = require("rethinkdb")
+import r = require("rethinkdb");
 
-r.connect({host:"localhost", port: 28015}, function(err, conn) {
-    console.log("HI", err, conn)
-    var testDb = r.db('test')
-    testDb.tableCreate('users').run(conn, function(err, stuff) {
-        var users = testDb.table('users')
+r.connect({ host: "localhost", port: 28015 }, function(err, conn) {
+    console.log("HI", err, conn);
 
-        users.insert({name: "bob"}).run(conn, function() {})
+    const testDb = r.db("test");
+
+    testDb.tableCreate("users").run(conn, function(err, stuff) {
+        const users = testDb.table("users");
+
+        users.insert({ name: "bob" }).run(conn, function() {
+        });
 
         users.filter(function(doc?) {
-            return doc("henry").eq("bob")
+            return doc("henry").eq("bob");
         })
         .between("james", "beth")
         .limit(4)
@@ -19,26 +22,27 @@ r.connect({host:"localhost", port: 28015}, function(err, conn) {
           cursor.toArray().then(rows => {
             console.log(rows);
           });
-        })
-
-    })
-})
+        });
+    });
+});
 
 // use promises instead of callbacks
-r.connect({host:"localhost", port: 28015}).then(function(conn) {
-    console.log("HI", conn)
-    var testDb = r.db('test')
-    testDb.tableCreate('users').run(conn).then(function(stuff) {
-        var users = testDb.table('users')
+r.connect({ host: "localhost", port: 28015 }).then(function(conn) {
+    console.log("HI", conn);
 
-        users.insert({name: "bob"}).run(conn, function() {})
+    const testDb = r.db("test");
+
+    testDb.tableCreate("users").run(conn).then(function(stuff) {
+        const users = testDb.table("users");
+
+        users.insert({ name: "bob" }).run(conn, function() {
+        });
 
         users.filter(function(doc?) {
-            return doc("henry").eq("bob")
+            return doc("henry").eq("bob");
         })
         .between("james", "beth")
         .limit(4)
         .run(conn);
-
-    })
-})
+    });
+});

--- a/rethinkdb/rethinkdb-tests.ts
+++ b/rethinkdb/rethinkdb-tests.ts
@@ -2,16 +2,26 @@
 
 import * as r from "rethinkdb";
 
-r.connect({ host: "localhost", port: 28015 }, function(err, conn) {
+function errorAndCursorCallback(err: Error, cursor: r.Cursor): void {}
+function cursorCallback(cursor: r.Cursor): void {}
+
+r.connect({ host: "localhost", port: 28015 }, function(err: Error, conn: r.Connection) {
     console.log("HI", err, conn);
 
     const testDb = r.db("test");
+
+    r.table("players").hasFields("games_won").run(conn, errorAndCursorCallback);
+    r.table("players").hasFields({ "games_won": { "championships": true } }).run(conn, errorAndCursorCallback);
+    r.table("players").filter(r.row.hasFields("games_won").not()).run(conn, errorAndCursorCallback);
+    r.table("players").filter(r.row.hasFields({ "games_won": { "championships": true } }).not()).run(conn, errorAndCursorCallback);
 
     testDb.tableCreate("users").run(conn, function(err, stuff) {
         const users = testDb.table("users");
 
         users.insert({ name: "bob" }).run(conn, function() {
         });
+
+        users.hasFields("foo_bar").run(conn, () => {});
 
         users.filter(function(doc?) {
             return doc("henry").eq("bob");
@@ -36,12 +46,17 @@ r.connect({ host: "localhost", port: 28015 }, function(err, conn) {
 });
 
 // use promises instead of callbacks
-r.connect({ host: "localhost", port: 28015 }).then(function(conn) {
+r.connect({ host: "localhost", port: 28015 }).then(function(conn: r.Connection) {
     console.log("HI", conn);
 
     const testDb = r.db("test");
 
-    testDb.tableCreate("users").run(conn).then(function(stuff) {
+    r.table("players").hasFields("games_won").run(conn).then(cursorCallback);
+    r.table("players").hasFields({ "games_won": { "championships": true } }).run(conn).then(cursorCallback);
+    r.table("players").filter(r.row.hasFields("games_won").not()).run(conn).then(cursorCallback);
+    r.table("players").filter(r.row.hasFields({ "games_won": { "championships": true } }).not()).run(conn).then(cursorCallback);
+
+    testDb.tableCreate("users").run(conn).then(function() {
         const users = testDb.table("users");
 
         users.insert({ name: "bob" }).run(conn, function() {
@@ -53,8 +68,8 @@ r.connect({ host: "localhost", port: 28015 }).then(function(conn) {
         .between("james", "beth")
         .limit(4)
         .run(conn)
-        .then(cursor => {
-          cursor.toArray().then(rows => {
+        .then((cursor: r.Cursor) => {
+          cursor.toArray().then((rows: any[]) => {
             console.log(rows);
           });
         });

--- a/rethinkdb/rethinkdb.d.ts
+++ b/rethinkdb/rethinkdb.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for RethinkDB 2.3
 // Project: http://rethinkdb.com/
-// Definitions by: Sean Hess <https://seanhess.github.io/>, Alex Gorbatchev <https://github.com/alexgorbatchev>
+// Definitions by: Alex Gorbatchev <https://github.com/alexgorbatchev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 //
 // Reference: https://rethinkdb.com/api/javascript/

--- a/rethinkdb/rethinkdb.d.ts
+++ b/rethinkdb/rethinkdb.d.ts
@@ -355,10 +355,10 @@ declare module "rethinkdb" {
         append(prop: string): Expression<Object>;
         contains(prop: string): Expression<boolean>;
 
-        and(b: boolean): Expression<boolean>;
-        or(b: boolean): Expression<boolean>;
-        eq(v: any): Expression<boolean>;
-        ne(v: any): Expression<boolean>;
+        and(b: boolean | Expression<boolean>): Expression<boolean>;
+        or(b: boolean | Expression<boolean>): Expression<boolean>;
+        eq(v: any | Expression<any>): Expression<boolean>;
+        ne(v: any | Expression<any>): Expression<boolean>;
         not(): Expression<boolean>;
 
         gt(value: T): Expression<boolean>;

--- a/rethinkdb/rethinkdb.d.ts
+++ b/rethinkdb/rethinkdb.d.ts
@@ -339,7 +339,29 @@ declare module "rethinkdb" {
         le(value: T): Expression<boolean>;
 
         add(n: number): Expression<number>;
-        sub(n: number): Expression<number>;
+
+        /**
+         * Subtract two numbers.
+         *
+         * See: https://rethinkdb.com/api/javascript/sub/
+         *
+         * Example:
+         *
+         *     r.expr(2).sub(2).run(conn, callback)
+         */
+        sub(n: number, ...numbers: number[]): Expression<number>;
+
+        /**
+         * Retrieve how many seconds elapsed between today and `date`.
+         *
+         * See: https://rethinkdb.com/api/javascript/sub/
+         *
+         * Example:
+         *
+         *     r.now().sub(365 * 24 * 60 * 60)
+         */
+        sub(date: Time): Expression<number>;
+
         mul(n: number): Expression<number>;
         div(n: number): Expression<number>;
         mod(n: number): Expression<number>;

--- a/rethinkdb/rethinkdb.d.ts
+++ b/rethinkdb/rethinkdb.d.ts
@@ -1,7 +1,5 @@
-//
 // Type definitions for RethinkDB 2.3
 // Project: http://rethinkdb.com/
-//
 // Definitions by: Sean Hess <https://seanhess.github.io/>, Alex Gorbatchev <https://github.com/alexgorbatchev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 //
@@ -12,7 +10,6 @@
 //
 // Testing:
 //   $ tsc --noImplicitAny --module commonjs -p rethinkdb/
-//
 
 /// <reference path="../node/node.d.ts"/>
 

--- a/rethinkdb/rethinkdb.d.ts
+++ b/rethinkdb/rethinkdb.d.ts
@@ -47,7 +47,7 @@ declare module "rethinkdb" {
     export function row(name: string): Expression<any>;
     export function expr(stuff: any): Expression<any>;
 
-    export function now(): Time;
+    export function now(): Expression<Time>;
 
     // Control Structures
     export function branch(test: Expression<boolean>, trueBranch: Expression<any>, falseBranch: Expression<any>): Expression<any>;

--- a/rethinkdb/rethinkdb.d.ts
+++ b/rethinkdb/rethinkdb.d.ts
@@ -1,14 +1,34 @@
-// Type definitions for Rethinkdb 1.10.0
+//
+// Type definitions for RethinkDB 2.3
 // Project: http://rethinkdb.com/
-// Definitions by: Sean Hess <https://seanhess.github.io/>
+//
+// Definitions by: Sean Hess <https://seanhess.github.io/>, Alex Gorbatchev <https://github.com/alexgorbatchev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Reference: http://www.rethinkdb.com/api/#js
-// TODO: Document manipulation and below
-///<reference path="../bluebird/bluebird-2.0.d.ts"/>
+//
+// Reference: https://rethinkdb.com/api/javascript/
+//
+// Notes:
+//   - Currently missing control structures and geospatial commands. Please help out!
+//
+// Testing:
+//   $ tsc --noImplicitAny --module commonjs -p rethinkdb/
+//
 
+/// <reference path="../node/node.d.ts"/>
+
+/**
+ * https://rethinkdb.com/api/javascript/
+ */
 declare module "rethinkdb" {
-
-    export function connect(host: ConnectionOptions, cb?: (err: Error, conn: Connection) => void): Promise<Connection>;
+    /**
+     * Create a new connection to the database server.
+     *
+     * See: https://rethinkdb.com/api/javascript/connect/
+     */
+    export function connect(opts: ConnectionOptions, cb: (err: ReqlDriverError, conn: Connection) => void): void;
+    export function connect(host: string, cb: (err: ReqlDriverError, conn: Connection) => void): void;
+    export function connect(opts: ConnectionOptions): Promise<Connection>;
+    export function connect(host: string): Promise<Connection>;
 
     export function dbCreate(name: string): Operation<CreateResult>;
     export function dbDrop(name: string): Operation<DropResult>;
@@ -32,6 +52,19 @@ declare module "rethinkdb" {
     // Control Structures
     export function branch(test: Expression<boolean>, trueBranch: Expression<any>, falseBranch: Expression<any>): Expression<any>;
 
+    /**
+     * Create a javascript expression.
+     *
+     * @param {Number} timeout - The number of seconds before `r.js` times out. The default value is `5` seconds.
+     */
+    export function js(jsString: string, opts?: { timeout: number }): Operation<any>;
+
+    /**
+     * Return a UUID (universally unique identifier), a string that can be used as a unique ID. If a string is passed to uuid as an argument, the UUID will be deterministic, derived from the string’s SHA-1 hash.
+     *
+     * RethinkDB’s UUIDs are standards-compliant. Without the optional argument, a version 4 random UUID will be generated; with that argument, a version 5 UUID will be generated, using a fixed namespace UUID of 91461c99-f89d-49d2-af96-d8e2e14e9b58.
+     */
+    export function uuid(input?: string): Operation<string>;
 
     export class Cursor {
         hasNext(): boolean;
@@ -49,19 +82,57 @@ declare module "rethinkdb" {
         close(): Promise<void>;
     }
 
+    /**
+     * Connection options.
+     *
+     * See: https://rethinkdb.com/api/javascript/connect/
+     */
     interface ConnectionOptions {
-        host: string;
-        port: number;
+        /** The host to connect to (default `localhost`) */
+        host?: string;
+
+        /** The port to connect on (default `28015`) */
+        port?: number;
+
+        /** The default database (default `test`) */
         db?: string;
-        authKey?: string;
+
+        /** The user account to connect as (default `admin`) */
+        user?: string;
+
+        /** The password for the user account to connect as (default `''`, empty) */
+        password?: string;
+
+        /** Timeout period in seconds for the connection to be opened (default `20`) */
+        timeout?: number;
+
+        /**
+         * A hash of options to support SSL connections (default `null`). Currently,
+         * there is only one option available, and if the `ssl` option is specified,
+         * this key is required.
+         */
+        ssl?: {
+          /** A list of Node.js `Buffer` objects containing SSL CA certificates */
+          ca: Buffer[];
+        };
+    }
+
+    interface NoReplyWait {
+      noreplyWait: boolean;
     }
 
     interface Connection {
+        open: boolean;
+
         close(cb: (err: Error) => void): void;
-        close(opts: { noreplyWait: boolean }, cb: (err: Error) => void): void;
+        close(opts: NoReplyWait, cb: (err: Error) => void): void;
         close(): Promise<void>;
-        close(opts: { noreplyWait: boolean }): Promise<void>;
-        reconnect(cb?: (err: Error, conn: Connection) => void): Promise<Connection>;
+        close(opts: NoReplyWait): Promise<void>;
+
+        reconnect(cb: (err: Error, conn: Connection) => void): void;
+        reconnect(opts: NoReplyWait, cb: (err: Error, conn: Connection) => void): void;
+        reconnect(opts?: NoReplyWait): Promise<Connection>;
+
         use(dbName: string): void;
         addListener(event: string, cb: Function): void;
         on(event: string, cb: Function): void;
@@ -92,6 +163,45 @@ declare module "rethinkdb" {
         delete(options?: UpdateOptions): Operation<WriteResult>;
     }
 
+    /**
+     * See: https://rethinkdb.com/api/javascript/changes/
+     */
+    interface ChangesOptions {
+        /**
+         * Controls how change notifications are batched. Acceptable values are `true`, `false` and a numeric value:
+         *
+         *   * `true`: When multiple changes to the same document occur before a batch of notifications is sent, the changes are “squashed” into one change. The client receives a notification that will bring it fully up to date with the server.
+         *   * `false`: All changes will be sent to the client verbatim. This is the default.
+         *   * `n`: A numeric value (floating point). Similar to `true`, but the server will wait `n` seconds to respond in order to squash as many changes together as possible, reducing network traffic. The first batch will always be returned immediately.
+         */
+        squash: boolean | number;
+
+        /**
+         * The number of changes the server will buffer between client reads before it starts dropping changes and generates an error (default: 100,000).
+         */
+        changefeedQueueSize: number;
+
+        /**
+         * If `true`, the changefeed stream will begin with the current contents of the table or selection being monitored. These initial results will have `new_val` fields, but no `old_val` fields. The initial results may be intermixed with actual changes, as long as an initial result for the changed document has already been given. If an initial result for a document has been sent and a change is made to that document that would move it to the unsent part of the result set (e.g., a changefeed monitors the top 100 posters, the first 50 have been sent, and poster 48 has become poster 52), an “uninitial” notification will be sent, with an `old_val` field but no `new_val` field.
+         */
+        includeInitial: boolean;
+
+        /**
+         * If `true`, the changefeed stream will include special status documents consisting of the field `state` and a string indicating a change in the feed’s state. These documents can occur at any point in the feed between the notification documents described below. If `includeStates` is `false` (the default), the status documents will not be sent.
+         */
+        includeStates: boolean;
+
+        /**
+         * If `true`, a changefeed stream on an `orderBy.limit` changefeed will include `old_offset` and `new_offset` fields in status documents that include `old_val` and `new_val`. This allows applications to maintain ordered lists of the stream’s result set. If `old_offset` is set and not `null`, the element at `old_offset` is being deleted; if `new_offset` is set and not `null`, then `new_val` is being inserted at `new_offset`. Setting `includeOffsets` to `true` on a changefeed that does not support it will raise an error.
+         */
+        includeOffsets: boolean;
+
+        /**
+         * If `true`, every result on a changefeed will include a `type` field with a string that indicates the kind of change the result represents: `add`, `remove`, `change`, `initial`, `uninitial`, `state`. Defaults to `false`.
+         */
+        includeTypes: boolean;
+    }
+
     interface Table extends Sequence {
         indexCreate(name: string, index?: ExpressionFunction<any>): Operation<CreateResult>;
         indexDrop(name: string): Operation<DropResult>;
@@ -103,15 +213,26 @@ declare module "rethinkdb" {
         get(key: string): Sequence; // primary key
         getAll(key: string, index?: Index): Sequence; // without index defaults to primary key
         getAll(...keys: string[]): Sequence;
+
+        /**
+         * Turn a query into a changefeed, an infinite stream of objects representing
+         * changes to the query’s results as they occur. A changefeed may return changes
+         * to a table or an individual document (a “point” changefeed). Commands such as
+         * filter or `map` may be used before the changes command to transform or filter
+         * the output, and many commands that operate on sequences can be chained after
+         * `changes`.
+         *
+         * See: https://rethinkdb.com/api/javascript/changes/
+         */
+        changes(opts?: ChangesOptions): Sequence;
     }
 
     interface Sequence extends Operation<Cursor>, Writeable {
-
         between(lower: any, upper: any, index?: Index): Sequence;
+
         filter(rql: ExpressionFunction<boolean>): Sequence;
         filter(rql: Expression<boolean>): Sequence;
         filter(obj: { [key: string]: any }): Sequence;
-
 
         // Join
         // these return left, right
@@ -231,16 +352,120 @@ declare module "rethinkdb" {
         default(value: T): Expression<T>;
     }
 
+    interface OperationOptions {
+        /**
+         * One of three possible values affecting the consistency guarantee for the query (default: 'single').
+         *
+         *   * 'single' (the default) returns values that are in memory (but not necessarily written to disk) on the primary replica.
+         *   * 'majority' will only return values that are safely committed on disk on a majority of replicas. This requires sending a message to every replica on each read, so it is the slowest but most consistent.
+         *   * 'outdated' will return values that are in memory on an arbitrarily-selected replica. This is the fastest but least consistent.
+         */
+        readMode: "single" | "majority" | "outdated";
+
+        /**
+         * What format to return times in (default: 'native'). Set this to 'raw' if you want times returned as JSON objects for exporting.
+         */
+        timeFormat: "native" | "raw";
+
+        /**
+         * Whether or not to return a profile of the query’s execution (default: false).
+         */
+        profile: boolean;
+
+        /**
+         * Possible values are 'hard' and 'soft'. In soft durability mode RethinkDB will acknowledge the write immediately after receiving it, but before the write has been committed to disk.
+         */
+        durability: "hard" | "soft";
+
+        /**
+         * What format to return `grouped_data` and `grouped_streams` in (default: 'native'). Set this to 'raw' if you want the raw pseudotype.
+         */
+        groupFormat: "native" | "raw";
+
+        /**
+         * Set to `true` to not receive the result object or cursor and return immediately.
+         */
+        noreply: boolean;
+
+        /**
+         * The database to run this query against as a string. The default is the database specified in the db parameter to connect (which defaults to test). The database may also be specified with the db command.
+         */
+        db: string;
+
+        /**
+         * The maximum numbers of array elements that can be returned by a query (default: 100,000). This affects all ReQL commands that return arrays. Note that it has no effect on the size of arrays being written to the database; those always have an upper limit of 100,000 elements.
+         */
+        arrayLimit: number;
+
+        /**
+         * What format to return binary data in (default: 'native'). Set this to 'raw' if you want the raw pseudotype.
+         */
+        binaryFormat: "native" | "raw";
+
+        /**
+         * Minimum number of rows to wait for before batching a result set (default: 8). This is an integer.
+         */
+        minBatchRows: number;
+
+        /**
+         * Maximum number of rows to wait for before batching a result set (default: unlimited). This is an integer.
+         */
+        maxBatchRows: number;
+
+        /**
+         * Maximum number of bytes to wait for before batching a result set (default: 1MB). This is an integer.
+         */
+        maxBatchBytes: number;
+
+        /**
+         * Maximum number of seconds to wait before batching a result set (default: 0.5). This is a float (not an integer) and may be specified to the microsecond.
+         */
+        maxBatchSeconds: number;
+
+        /**
+         * Factor to scale the other parameters down by on the first batch (default: 4). For example, with this set to 8 and maxBatchRows set to 80, on the first batch maxBatchRows will be adjusted to 10 (80 / 8). This allows the first batch to return faster.
+         */
+        firstBatchScaledownFactor: number;
+    }
+
     interface Operation<T> {
-        run(conn: Connection, cb?: (err: Error, result: T) => void): Promise<T>;
+        /**
+         * Run a query on a connection. The callback will get either an error, a single JSON result, or a cursor, depending on the query.
+         *
+         * See: https://rethinkdb.com/api/javascript/run/
+         */
+        run(conn: Connection, opts: OperationOptions, cb: (err: Error, result: T) => void): void;
+        run(conn: Connection, cb: (err: Error, result: T) => void): void;
+        run(conn: Connection, opts: OperationOptions): Promise<T>;
+        run(conn: Connection): Promise<T>;
     }
 
     interface Aggregator { }
+
     interface Sort { }
 
-    interface Time { }
+    interface ReqlType {
+      $reql_type$: string;
+    }
 
+    interface Time extends ReqlType {
+      $reql_type$: "TIME";
+      epoch_time: number;
+      timezone: string;
+    }
 
-    // http://www.rethinkdb.com/api/#js
-    // TODO control structures
+    interface Binary extends ReqlType {
+      $reql_type$: "BINARY";
+      data: string;
+    }
+
+    interface ReqlError extends Error {}
+
+    /**
+     * An error has occurred within the driver. This may be a driver bug, or it may
+     * be an unfulfillable command, such as an unserializable query.
+     *
+     * See https://www.rethinkdb.com/docs/error-types/
+     */
+    interface ReqlDriverError extends ReqlError {}
 }

--- a/rethinkdb/tsconfig.json
+++ b/rethinkdb/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "module": "es6",
+        "target": "es6"
+    },
+    "include": [
+      "*.ts"
+    ]
+}


### PR DESCRIPTION
Aside from adding more methods and overloads, I removed dependency on `Bluebird` in favor of `node` and set compile target default to `es6` so that TypeScript would use native `Promise` definitions.

cc @seanhess
