### PR TITLE
Create typings for jquery-alertable

### DIFF
--- a/jquery-alertable/jquery-alertable-tests.ts
+++ b/jquery-alertable/jquery-alertable-tests.ts
@@ -1,0 +1,79 @@
+/// <reference path="jquery-alertable.d.ts" />
+/// <reference path="../jquery/jquery.d.ts" />
+
+//
+// Examples from https://github.com/claviska/jquery-alertable
+//
+
+function example_alerts_tests() {
+
+	// Basic example
+	$.alertable.alert('Howdy!');
+
+	// Example with action when the modal is dismissed
+	$.alertable.alert('Howdy!').always(function() {
+	    // Modal was dismissed
+	});
+}
+
+function example_confirmations_tests() {
+
+	// Basic example
+	$.alertable.confirm('You sure?').then(function() {
+	    // OK was selected
+	});
+
+	// Example with then/always
+	$.alertable.confirm('You sure?').then(function() {
+	    // OK was selected
+	}, function() {
+	    // Cancel was selected
+	}).always(function() {
+	    // Modal was dismissed
+	});
+}
+
+function example_prompts_tests() {
+
+	// Basic example
+	$.alertable.prompt('How many?').then(function(data) {
+	    // Prompt was submitted
+	});
+
+	// Example with then/always
+	$.alertable.prompt('How many?').then(function(data) {
+	    // Prompt was submitted
+	}, function() {
+	    // Prompt was canceled
+	}).always(function() {
+	    // Modal was dismissed
+	});
+}
+
+function options_tests() {
+	$.alertable.alert('Howdy!', {
+	    container: 'body',
+	    html: false,
+	    cancelButton: '<button class="alertable-cancel" type="button">Cancel</button>',
+	    okButton: '<button class="alertable-ok" type="button">OK</button>',
+	    overlay: '<div class="alertable-overlay"></div>',
+	    prompt: '<input class="alertable-input" type="text" name="value">',
+	    modal: `<form class="alertable">
+    <div class="alertable-message"></div>
+    <div class="alertable-prompt"></div>
+    <div class="alertable-buttons"></div>
+</form>`,
+		hide: () => $(this.modal).add(this.overlay).fadeOut(100),
+		show: () => $(this.modal).add(this.overlay).fadeIn(100)
+	});
+
+	$.alertable.confirm('You sure?', {
+	    container: 'body'
+	});
+
+	$.alertable.prompt('How many?', {
+	    container: 'body'
+	});
+
+	$.alertable.defaults.container = 'body';
+}

--- a/jquery-alertable/jquery-alertable.d.ts
+++ b/jquery-alertable/jquery-alertable.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for jquery-alertable 1.0.2
+// Project: https://github.com/claviska/jquery-alertable
+// Definitions by: Steven Robertson <https://github.com/stever>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../jquery/jquery.d.ts"/>
+
+interface JQueryStatic {
+    alertable: Alertable;
+}
+
+interface Alertable {
+    alert(message: string, options?: AlertableOptions): JQueryPromise<void>;
+    confirm(message: string, options?: AlertableOptions): JQueryPromise<void>;
+    prompt(message: string, options?: AlertableOptions): JQueryPromise<void>;
+    defaults: AlertableOptions;
+}
+
+interface AlertableOptions {
+    container?: string;
+    html?: boolean;
+    cancelButton?: string;
+    okButton?: string;
+    overlay?: string;
+    prompt?: string;
+    modal?: string;
+    hide?: Function;
+    show?: Function;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Library: https://github.com/claviska/jquery-alertable
