### PR TITLE
Add fast-levenshtein type definition

### DIFF
--- a/fast-levenshtein/fast-levenshtein-tests.ts
+++ b/fast-levenshtein/fast-levenshtein-tests.ts
@@ -1,0 +1,13 @@
+import * as fastLevenshtein from 'fast-levenshtein';
+
+declare const boolVal: boolean;
+declare const strVal: string;
+
+// option datas tests
+let opts: fastLevenshtein.LevenshteinOptions = {};
+
+opts.useCollator = boolVal;
+
+// API tests
+fastLevenshtein.get(strVal, strVal);
+fastLevenshtein.get(strVal, strVal, opts);

--- a/fast-levenshtein/index.d.ts
+++ b/fast-levenshtein/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for fast-levenshtein
+// Project: https://github.com/hiddentao/fast-levenshtein
+// Definitions by: Mizunashi Mana <https://github.com/mizunashi-mana>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface LevenshteinOptions {
+    useCollator?: boolean;
+}
+
+export function get(str1: string, str2: string, opts?: LevenshteinOptions): number;

--- a/fast-levenshtein/tsconfig.json
+++ b/fast-levenshtein/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "files": [
+        "index.d.ts",
+        "fast-levenshtein-tests.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

---

Typings for [fast-levenshtein](https://www.npmjs.com/package/fast-levenshtein)
