### PR TITLE
Fix export for "bunyan-config" and improve definitions

### DIFF
--- a/bunyan-config/bunyan-config-tests.ts
+++ b/bunyan-config/bunyan-config-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="bunyan-config.d.ts"/>
 
 import * as bunyan from "bunyan";
-import bunyanConfig from "bunyan-config";
+import bunyanConfig = require("bunyan-config");
 
 var jsonConfig = {
     name: "myLogger",

--- a/bunyan-config/bunyan-config.d.ts
+++ b/bunyan-config/bunyan-config.d.ts
@@ -27,5 +27,5 @@ declare module "bunyan-config" {
      * @return {LoggerOptions} A logger options.
      */
     function bunyanConfig(jsonConfig?: Configuration): bunyan.LoggerOptions;
-    export default bunyanConfig;
+    export = bunyanConfig;
 }

--- a/express-mung/express-mung.d.ts
+++ b/express-mung/express-mung.d.ts
@@ -10,8 +10,8 @@ declare module "express-mung" {
     import { Request, Response } from "express";
     import * as http from "http";
 
-    type Transform = (body: {}, request: Request, response: Response) => {};
-    type TransformHeader = (body: http.IncomingMessage, request: Request, response: Response) => {};
+    type Transform = (body: {}, request: Request, response: Response) => any;
+    type TransformHeader = (body: http.IncomingMessage, request: Request, response: Response) => any;
 
     /**
      * Transform the JSON body of the response.

--- a/vitalsigns/vitalsigns-tests.ts
+++ b/vitalsigns/vitalsigns-tests.ts
@@ -1,11 +1,12 @@
 /// <reference path="vitalsigns.d.ts"/>
 
+import * as express from "express";
 import VitalSigns = require("vitalsigns");
 
 var vitals = new VitalSigns();
 
 vitals.monitor('cpu');
-vitals.monitor('mem', {units: 'MB'});
+vitals.monitor('mem', { units: 'MB' });
 vitals.monitor('tick');
 
 vitals.unhealthyWhen('cpu', 'usage').equals(100);
@@ -13,7 +14,7 @@ vitals.unhealthyWhen('tick', 'maxMs').greaterThan(500);
 
 vitals.monitor({
     connections: () => new Object()
-}, {name: 'game'});
+}, { name: 'game' });
 
 var vitals = new VitalSigns({
     autoCheck: 5000,
@@ -21,5 +22,8 @@ var vitals = new VitalSigns({
     httpUnhealthy: 503
 });
 
-vitals.monitor('cpu', {name: 'foo'});
+vitals.monitor('cpu', { name: 'foo' });
 vitals.unhealthyWhen('foo', 'bar').not.greaterThan(5);
+
+var app = express();
+app.get('/health', vitals.express);

--- a/vitalsigns/vitalsigns.d.ts
+++ b/vitalsigns/vitalsigns.d.ts
@@ -3,7 +3,11 @@
 // Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+///<reference path="../express/express.d.ts"/>
+
 declare module "vitalsigns" {
+    import { RequestHandler } from "express";
+
     namespace vitalsigns {
         /**
          * Contraint.
@@ -149,6 +153,12 @@ declare module "vitalsigns" {
         destroy(): void;
 
         /**
+         * Gets a request handler.
+         * @type {RequestHandler}
+         */
+        express: RequestHandler;
+
+        /**
          * Retrieves an array of human-readable messages that define the specific health constraints that failed when running the last health check.
          * @returns {Array<string>} An array of failure messages.
          */
@@ -160,7 +170,7 @@ declare module "vitalsigns" {
          * @param {ReportOptions} [options] A mapping of options to customize this report.
          * @return {Object} The full health report.
          */
-        getReport(options?: vitalsigns.ReportOptions): Object;
+        getReport(options?: vitalsigns.ReportOptions): {};
 
         /**
          * Generates a health report and checks each health constraint against it. Any constraints that fail will be added to the 'failed' array in the form of
@@ -168,14 +178,14 @@ declare module "vitalsigns" {
          * @param {Object} [report] A report object on which to run the health constraints. If omitted, this function will generate a health report automatically.
          * @return {boolean} true if all health constraints passed; false otherwise.
          */
-        isHealthy(report?: Object): boolean;
+        isHealthy(report?: {}): boolean;
 
         /**
          * Registers monitor.
          * @param {string} monitorName A monitor name.
          * @param {MonitorField} [field] Options.
          */
-        monitor(monitor: string | vitalsigns.Monitor | Object, field?: vitalsigns.MonitorField): void;
+        monitor(monitor: string | vitalsigns.Monitor | {}, field?: vitalsigns.MonitorField): void;
 
         /**
          * Defines a new health constraint in a chainable, more easily readable format.


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Using this module `bunyan-config`, I obtain the error:

> error TS2349: Cannot invoke an expression whose type lacks a call signature.

This pull request fixes this error.

Improve définitions `VitalSigns` and `express-mung`:
- Replace `Object` to `{}` type.
- Add `express` property in `VitalSigns` class.
