### PR TITLE
Fix babel-traverse buildCodeFrameError signature

### DIFF
--- a/babel-traverse/babel-traverse.d.ts
+++ b/babel-traverse/babel-traverse.d.ts
@@ -346,7 +346,7 @@ declare module "babel-traverse" {
 
         getData(key: string, def?: any): any;
 
-        buildCodeFrameError(msg: string, Error: Error): Error;
+        buildCodeFrameError<TError extends Error>(msg: string, Error?: new (msg: string) => TError): TError;
 
         traverse(visitor: Visitor, state?: any): void;
 


### PR DESCRIPTION
- [buildCodeFrameError  Source](https://github.com/babel/babel/blob/master/packages/babel-traverse/src/path/index.js#L118)

The Error argument is not an error instance, instead it is a constructor function that returns an error instance. Additionally, the constructor function is optional, by default SyntaxError is used
