### PR TITLE
Updated the RowMethods interface

### DIFF
--- a/jquery.dataTables/jquery.dataTables.d.ts
+++ b/jquery.dataTables/jquery.dataTables.d.ts
@@ -903,12 +903,12 @@ declare namespace DataTables {
         */
         data(d: any[] | Object): DataTable;
         
-		/**
-		* Get the id of the selected row.
-		*
-		* @param hash	Set to true to append a hash (#) to the start of the row id.
-		*/
-		id(hash?: boolean): string;
+        /**
+        * Get the id of the selected row.
+        *
+        * @param hash Set to true to append a hash (#) to the start of the row id.
+        */
+        id(hash?: boolean): string;
 
         /**
         * Get the row index of the row column.

--- a/jquery.dataTables/jquery.dataTables.d.ts
+++ b/jquery.dataTables/jquery.dataTables.d.ts
@@ -902,6 +902,13 @@ declare namespace DataTables {
         * @param d Data to use for the row.
         */
         data(d: any[] | Object): DataTable;
+        
+		/**
+		* Get the id of the selected row.
+		*
+		* @param hash	Set to true to append a hash (#) to the start of the row id.
+		*/
+		id(hash?: boolean): string;
 
         /**
         * Get the row index of the row column.


### PR DESCRIPTION
This Interface was missing the Definition of the id() method.

Link to official documentation: https://datatables.net/reference/api/row().id()
