### PR TITLE
Add definitions for pem

### DIFF
--- a/pem/pem-tests.ts
+++ b/pem/pem-tests.ts
@@ -1,0 +1,727 @@
+/// <reference path="pem.d.ts" />
+
+import * as pem from 'pem';
+
+const tests = {
+
+  'Create default sized dhparam key': (test: any) => {
+    pem.createDhparam((error: any, data: any) => {
+      var dhparam = (data && data.dhparam || '').toString();
+      test.ifError(error);
+      test.ok(dhparam);
+      test.ok(dhparam.match(/^\n*\-\-\-\-\-BEGIN DH PARAMETERS\-\-\-\-\-\n/));
+      test.ok(dhparam.match(/\n\-\-\-\-\-END DH PARAMETERS\-\-\-\-\-\n*$/));
+      test.ok(dhparam.trim().length > 150 && dhparam.trim().length < 160);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+      test.done();
+    });
+  },
+
+  'Create 2048bit dhparam key': (test: any) => {
+    pem.createDhparam(2048, (error: any, data: any) => {
+      var dhparam = (data && data.dhparam || '').toString();
+      test.ifError(error);
+      test.ok(dhparam);
+      test.ok(dhparam.match(/^\n*\-\-\-\-\-BEGIN DH PARAMETERS\-\-\-\-\-\n/));
+      test.ok(dhparam.match(/\n\-\-\-\-\-END DH PARAMETERS\-\-\-\-\-\n*$/));
+      test.ok(dhparam.trim().length > 420 && dhparam.trim().length < 430);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+      test.done();
+    });
+  },
+
+  'Create default sized Private key': (test: any) => {
+    pem.createPrivateKey((error: any, data: any) => {
+      var key = (data && data.key || '').toString();
+      test.ifError(error);
+      test.ok(key);
+      test.ok(key.match(/^\n*\-\-\-\-\-BEGIN RSA PRIVATE KEY\-\-\-\-\-\n/));
+      test.ok(key.match(/\n\-\-\-\-\-END RSA PRIVATE KEY\-\-\-\-\-\n*$/));
+      test.ok(key.trim().length > 850 && key.trim().length < 1900);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+      test.done();
+    });
+  },
+
+  'Create 2048bit Private key': (test: any) => {
+    pem.createPrivateKey(2048, (error: any, data: any) => {
+      var key = (data && data.key || '').toString();
+      test.ifError(error);
+      test.ok(key);
+      test.ok(key.match(/^\n*\-\-\-\-\-BEGIN RSA PRIVATE KEY\-\-\-\-\-\n/));
+      test.ok(key.match(/\n\-\-\-\-\-END RSA PRIVATE KEY\-\-\-\-\-\n*$/));
+      test.ok(key.trim().length > 1650 && key.trim().length < 1700);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+      test.done();
+    });
+  },
+
+  'Create 2048bit Private key with Password': (test: any) => {
+    pem.createPrivateKey(2048,{cipher:'des',password:'TestMe'}, (error: any, data: any) => {
+      var key = (data && data.key || '').toString();
+      test.ifError(error);
+      test.ok(key);
+      test.ok(key.match(/ENCRYPTED\n/));
+      test.ok(key.match(/^\n*\-\-\-\-\-BEGIN RSA PRIVATE KEY\-\-\-\-\-\n/));
+      test.ok(key.match(/\n\-\-\-\-\-END RSA PRIVATE KEY\-\-\-\-\-\n*$/));
+      test.ok(key.trim().length > 1700 && key.trim().length < 1780);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+      test.done();
+    });
+  },
+
+  'Create default CSR': (test: any) => {
+    pem.createCSR((error: any, data: any) => {
+      var csr = (data && data.csr || '').toString();
+      test.ifError(error);
+      test.ok(csr);
+      test.ok(csr.match(/^\n*\-\-\-\-\-BEGIN CERTIFICATE REQUEST\-\-\-\-\-\n/));
+      test.ok(csr.match(/\n\-\-\-\-\-END CERTIFICATE REQUEST\-\-\-\-\-\n*$/));
+
+      test.ok(data && data.clientKey);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+      test.done();
+    });
+  },
+
+  'Create CSR using config file': (test: any) => {
+    var certInfo = {
+      issuer : {},
+      country: 'EE',
+      state: 'Harjumaa',
+      locality: 'Tallinn',
+      organization: 'Node.ee',
+      organizationUnit: 'test',
+      commonName: 'www.node.ee',
+      emailAddress: 'andris@node.ee'
+    };
+
+    pem.createCSR({ csrConfigFile: './test/fixtures/test.cnf' }, (error: any, data: any) => {
+      var csr = (data && data.csr || '').toString();
+      test.ifError(error);
+      test.ok(csr);
+      test.ok(csr.match(/^\n*\-\-\-\-\-BEGIN CERTIFICATE REQUEST\-\-\-\-\-\n/));
+      test.ok(csr.match(/\n\-\-\-\-\-END CERTIFICATE REQUEST\-\-\-\-\-\n*$/));
+
+      test.ok(data && data.clientKey);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+
+      pem.readCertificateInfo(csr, (error: any, data: any) => {
+        test.ifError(error);
+        test.deepEqual(data, certInfo);
+        // test.ok(fs.readdirSync('./tmp').length === 0);
+        test.done();
+      });
+    });
+  },
+
+  'Create CSR with own key': (test: any) => {
+    pem.createPrivateKey((error: any, data: any) => {
+      var key = (data && data.key || '').toString();
+
+      pem.createCSR({
+                      clientKey: key
+                    }, (error: any, data: any) => {
+        var csr = (data && data.csr || '').toString();
+        test.ifError(error);
+        test.ok(csr);
+        test.ok(csr.match(/^\n*\-\-\-\-\-BEGIN CERTIFICATE REQUEST\-\-\-\-\-\n/));
+        test.ok(csr.match(/\n\-\-\-\-\-END CERTIFICATE REQUEST\-\-\-\-\-\n*$/));
+
+        test.equal(data && data.clientKey, key);
+
+        test.ok(data && data.clientKey);
+        // test.ok(fs.readdirSync('./tmp').length === 0);
+        test.done();
+      });
+    });
+  },
+
+  'Create CSR with own encrypted key': (test: any) => {
+    var password = 'my:secure! "password\'s\nawesome';
+    pem.createPrivateKey(2048, { cipher: 'des3', password: password }, (error: any, data: any) => {
+      var key = (data && data.key || '').toString();
+
+      pem.createCSR({
+                      clientKey: key,
+                      clientKeyPassword: password
+                    }, (error: any, data: any) => {
+        var csr = (data && data.csr || '').toString();
+        test.ifError(error);
+        test.ok(csr);
+        test.ok(csr.match(/^\n*\-\-\-\-\-BEGIN CERTIFICATE REQUEST\-\-\-\-\-\n/));
+        test.ok(csr.match(/\n\-\-\-\-\-END CERTIFICATE REQUEST\-\-\-\-\-\n*$/));
+
+        test.equal(data && data.clientKey, key);
+
+        test.ok(data && data.clientKey);
+        // test.ok(fs.readdirSync('./tmp').length === 0);
+        test.done();
+      });
+    });
+  },
+
+  'Create default certificate': (test: any) => {
+    pem.createCertificate((error: any, data: any) => {
+      var certificate = (data && data.certificate || '').toString();
+      test.ifError(error);
+      test.ok(certificate);
+      test.ok(certificate.match(/^\n*\-\-\-\-\-BEGIN CERTIFICATE\-\-\-\-\-\n/));
+      test.ok(certificate.match(/\n\-\-\-\-\-END CERTIFICATE\-\-\-\-\-\n*$/));
+
+      test.ok((data && data.clientKey) !== (data && data.serviceKey));
+
+      test.ok(data && data.clientKey);
+      test.ok(data && data.serviceKey);
+      test.ok(data && data.csr);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+      test.done();
+    });
+  },
+
+  'Create self signed certificate': (test: any) => {
+    pem.createCertificate({
+                            selfSigned: true
+                          }, (error: any, data: any) => {
+      var certificate = (data && data.certificate || '').toString();
+      test.ifError(error);
+      test.ok(certificate);
+      test.ok(certificate.match(/^\n*\-\-\-\-\-BEGIN CERTIFICATE\-\-\-\-\-\n/));
+      test.ok(certificate.match(/\n\-\-\-\-\-END CERTIFICATE\-\-\-\-\-\n*$/));
+
+      test.ok((data && data.clientKey) === (data && data.serviceKey));
+
+      test.ok(data && data.clientKey);
+      test.ok(data && data.serviceKey);
+      test.ok(data && data.csr);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+      test.done();
+    });
+  },
+
+  'Read default cert data from CSR': (test: any) => {
+    pem.createCSR((error: any, data: any) => {
+      var csr = (data && data.csr || '').toString();
+      test.ifError(error);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+
+      pem.readCertificateInfo(csr, (error: any, data: any) => {
+        test.ifError(error);
+        test.deepEqual(data, {
+          issuer : {},
+          country: '',
+          state: '',
+          locality: '',
+          organization: '',
+          organizationUnit: '',
+          commonName: 'localhost',
+          emailAddress: ''
+        });
+        // test.ok(fs.readdirSync('./tmp').length === 0);
+        test.done();
+      });
+    });
+  },
+
+  'Read edited cert data from CSR': (test: any) => {
+    var certInfo = {
+      issuer : {},
+      country: 'EE',
+      state: 'Harjumaa',
+      locality: 'Tallinn',
+      organization: 'Node.ee',
+      organizationUnit: 'test',
+      commonName: 'www.node.ee',
+      emailAddress: 'andris@node.ee'
+    };
+    pem.createCSR(Object.create(certInfo), (error: any, data: any) => {
+      var csr = (data && data.csr || '').toString();
+      test.ifError(error);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+
+      pem.readCertificateInfo(csr, (error: any, data: any) => {
+        test.ifError(error);
+        test.deepEqual(data, certInfo);
+        // test.ok(fs.readdirSync('./tmp').length === 0);
+        test.done();
+      });
+    });
+  },
+
+  'Read default cert data from certificate': (test: any) => {
+    pem.createCertificate((error: any, data: any) => {
+      var certificate = (data && data.certificate || '').toString();
+      test.ifError(error);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+
+      pem.readCertificateInfo(certificate, (error: any, data: any) => {
+        test.ifError(error);
+
+        if (data.validity) {
+          delete data.validity;
+        }
+        if (data.serial) {
+          delete data.serial;
+        }
+
+        test.deepEqual(data, {
+          issuer : {
+            country: '',
+            state: '',
+            locality: '',
+            organization: '',
+            organizationUnit: '',
+            commonName: 'localhost'
+          },
+          country: '',
+          state: '',
+          locality: '',
+          organization: '',
+          organizationUnit: '',
+          commonName: 'localhost',
+          emailAddress: ''
+        });
+        // test.ok(fs.readdirSync('./tmp').length === 0);
+        test.done();
+      });
+    });
+  },
+
+  'Read edited cert data from certificate': (test: any) => {
+    var certInfo = {
+      issuer : {
+        country: 'EE',
+        state: 'Harjumaa',
+        locality: 'Tallinn',
+        organization: 'Node.ee',
+        organizationUnit: 'test',
+        commonName: 'www.node.ee'
+      },
+      country: 'EE',
+      state: 'Harjumaa',
+      locality: 'Tallinn',
+      organization: 'Node.ee',
+      organizationUnit: 'test',
+      commonName: 'www.node.ee',
+      emailAddress: 'andris@node.ee'
+    };
+    pem.createCertificate(Object.create(certInfo), (error: any, data: any) => {
+      var certificate = (data && data.certificate || '').toString();
+      test.ifError(error);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+
+      pem.readCertificateInfo(certificate, (error: any, data: any) => {
+        test.ifError(error);
+
+        if (data.validity) {
+          delete data.validity;
+        }
+        if (data.serial) {
+          delete data.serial;
+        }
+
+        test.deepEqual(data, certInfo);
+        // test.ok(fs.readdirSync('./tmp').length === 0);
+        test.done();
+      });
+    });
+  },
+
+  'Get public key from private key': (test: any) => {
+    pem.createPrivateKey((error: any, data: any) => {
+      var key = (data && data.key || '').toString();
+      test.ifError(error);
+      test.ok(key);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+
+      pem.getPublicKey(key, (error: any, data: any) => {
+        var pubkey = (data && data.publicKey || '').toString();
+        test.ifError(error);
+        test.ok(pubkey);
+
+        test.ok(pubkey.match(/^\n*\-\-\-\-\-BEGIN PUBLIC KEY\-\-\-\-\-\n/));
+        test.ok(pubkey.match(/\n\-\-\-\-\-END PUBLIC KEY\-\-\-\-\-\n*$/));
+        // test.ok(fs.readdirSync('./tmp').length === 0);
+
+        test.done();
+      });
+    });
+  },
+
+  'Get public key from CSR': (test: any) => {
+    pem.createCSR((error: any, data: any) => {
+      var key = (data && data.clientKey || '').toString();
+      test.ifError(error);
+      test.ok(key);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+
+      pem.getPublicKey(key, (error: any, data: any) => {
+        var pubkey = (data && data.publicKey || '').toString();
+        test.ifError(error);
+        test.ok(pubkey);
+
+        test.ok(pubkey.match(/^\n*\-\-\-\-\-BEGIN PUBLIC KEY\-\-\-\-\-\n/));
+        test.ok(pubkey.match(/\n\-\-\-\-\-END PUBLIC KEY\-\-\-\-\-\n*$/));
+        // test.ok(fs.readdirSync('./tmp').length === 0);
+
+        test.done();
+      });
+    });
+  },
+
+  'Get public key from certificate': (test: any) => {
+    pem.createCertificate((error: any, data: any) => {
+      var key = (data && data.clientKey || '').toString();
+      test.ifError(error);
+      test.ok(key);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+
+      pem.getPublicKey(key, (error: any, data: any) => {
+        var pubkey = (data && data.publicKey || '').toString();
+        test.ifError(error);
+        test.ok(pubkey);
+
+        test.ok(pubkey.match(/^\n*\-\-\-\-\-BEGIN PUBLIC KEY\-\-\-\-\-\n/));
+        test.ok(pubkey.match(/\n\-\-\-\-\-END PUBLIC KEY\-\-\-\-\-\n*$/));
+        // test.ok(fs.readdirSync('./tmp').length === 0);
+
+        test.done();
+      });
+    });
+  },
+
+  'Get fingerprint from certificate': (test: any) => {
+    pem.createCertificate((error: any, data: any) => {
+      var certificate = (data && data.certificate || '').toString();
+      test.ifError(error);
+      test.ok(certificate);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+
+      pem.getFingerprint(certificate, (error: any, data: any) => {
+        var fingerprint = (data && data.fingerprint || '').toString();
+        test.ifError(error);
+        test.ok(fingerprint);
+        test.ok(fingerprint.match(/^[0-9A-F]{2}(:[0-9A-F]{2}){19}$/));
+        // test.ok(fs.readdirSync('./tmp').length === 0);
+
+        test.done();
+      });
+    });
+  },
+
+  'Get modulus from certificate': (test: any) => {
+    pem.createCertificate((error: any, data: any) => {
+      var certificate = (data && data.certificate || '').toString();
+      test.ifError(error);
+      test.ok(certificate);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+
+      pem.getModulus(certificate, (error: any, data: any) => {
+        var certmodulus = (data && data.modulus || '').toString();
+        test.ifError(error);
+        test.ok(certmodulus);
+        test.ok(certmodulus.match(/^[0-9A-F]*$/));
+        // test.ok(fs.readdirSync('./tmp').length === 0);
+        pem.getModulus(certificate, (error: any, data: any) => {
+          var keymodulus = (data && data.modulus || '').toString();
+          test.ifError(error);
+          test.ok(keymodulus);
+          test.ok(keymodulus.match(/^[0-9A-F]*$/));
+          test.ok(keymodulus === certmodulus);
+          // test.ok(fs.readdirSync('./tmp').length === 0);
+          test.done();
+        });
+      });
+    });
+  },
+
+  'Get modulus from a protected key': (test: any) => {
+    var certificate = ''; // fs.readFileSync('./test/fixtures/test.crt').toString();
+    var key = ''; // fs.readFileSync('./test/fixtures/test.key').toString();
+
+    pem.getModulus(certificate, (error: any, data: any) => {
+      var certmodulus = (data && data.modulus || '').toString();
+      test.ifError(error);
+      test.ok(certmodulus);
+      test.ok(certmodulus.match(/^[0-9A-F]*$/));
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+      pem.getModulus(key, 'password', (error: any, data: any) => {
+        var keymodulus = (data && data.modulus || '').toString();
+        test.ifError(error);
+        test.ok(keymodulus);
+        test.ok(keymodulus.match(/^[0-9A-F]*$/));
+        test.ok(keymodulus === certmodulus);
+        // test.ok(fs.readdirSync('./tmp').length === 0);
+        test.done();
+      });
+    });
+
+  },
+
+  'Get DH param info': (test: any) => {
+    var dh = ''; // fs.readFileSync('./test/fixtures/test.dh').toString();
+
+    pem.getDhparamInfo(dh, (error: any, data: any) => {
+      var size = data && data.size || 0;
+      var prime = (data && data.prime || '').toString();
+      test.ifError(error);
+      test.equal(size, 1024);
+      test.ok(prime);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+      test.equal(typeof size, 'number');
+      test.ok(/([0-9a-f][0-9a-f]:)+[0-9a-f][0-9a-f]$/g.test(prime));
+      test.done();
+    });
+  },
+
+  'Create and verify wildcard certificate': (test: any) => {
+    var certInfo = {
+      commonName: '*.node.ee'
+    };
+    pem.createCertificate(Object.create(certInfo), (error: any, data: any) => {
+      var certificate = (data && data.certificate || '').toString();
+      test.ifError(error);
+      // test.ok(fs.readdirSync('./tmp').length === 0);
+
+      pem.readCertificateInfo(certificate, (error: any, data: any) => {
+        test.ifError(error);
+        test.equal(data.commonName, certInfo.commonName);
+        // test.ok(fs.readdirSync('./tmp').length === 0);
+        test.done();
+      });
+    });
+  },
+  'Return an error if openssl was not found': (test: any) => {
+    pem.config({
+                 pathOpenSSL: 'zzzzzzzzzzz'
+               });
+
+    pem.createPrivateKey((error: any) => {
+      test.ok(error);
+      pem.config({
+                   pathOpenSSL: 'openssl'
+                 });
+      pem.createPrivateKey((error: any) => {
+        test.ifError(error);
+        test.done();
+      });
+    });
+  },
+  'Create PKCS12 without key password': (test: any) => {
+    pem.createPrivateKey((error: any, data: any) => {
+      var key = (data && data.key || '').toString();
+
+      pem.createCertificate({
+                              clientKey: key,
+                              selfSigned: true
+                            }, (error: any, csr: any) => {
+
+        pem.createPkcs12(csr.clientKey, csr.certificate, 'mypassword', function(err: any, pkcs12: any){
+          test.ifError(err);
+          test.ok(pkcs12);
+
+          // test.ok(fs.readdirSync('./tmp').length === 0);
+          test.done();
+        });
+      });
+    });
+  },
+  'Create PKCS12 with key password': (test: any) => {
+    pem.createPrivateKey({cipher:'aes128',password:'xxx'}, (error: any, data: any) => {
+      var key = (data && data.key || '').toString();
+
+      pem.createCertificate({
+                              clientKey: key,
+                              selfSigned: true
+                            }, (error: any, csr: any) => {
+
+        pem.createPkcs12(csr.clientKey, csr.certificate, 'mypassword', {cipher: 'aes256', clientKeyPassword: 'xxx'}, function(err: any, pkcs12: any){
+          test.ifError(err);
+          test.ok(pkcs12);
+
+          // test.ok(fs.readdirSync('./tmp').length === 0);
+          test.done();
+        });
+      });
+    });
+  },
+  'Create PKCS12 with ca certificates': (test: any) => {
+    pem.createCertificate({
+                            commonName: 'CA Certificate'
+                          }, (error: any, ca: any) => {
+      test.ifError(error);
+
+      pem.createCertificate({
+                              serviceKey: ca.serviceKey,
+                              serviceCertificate: ca.certificate,
+                              serial: Date.now(),
+                            }, (error: any, cert: any) => {
+        test.ifError(error);
+
+        pem.createPkcs12(cert.clientKey, cert.certificate, '', {certFiles: [ca.certificate]}, (error: any, pkcs12: any) => {
+          test.ifError(error);
+          test.ok(pkcs12.pkcs12);
+
+          // test.ok(fs.readdirSync('./tmp').length === 0);
+
+          pem.readPkcs12(pkcs12.pkcs12, (error: any, keystore: any) => {
+            test.ifError(error);
+            test.ok(keystore);
+
+            test.equal(ca.certificate, keystore.ca[0]);
+            test.equal(cert.certificate, keystore.cert);
+            test.equal(cert.clientKey, keystore.key);
+
+            test.done();
+          });
+        });
+      });
+    });
+  },
+  'Respond with ENOENT for missing PKCS12 file': (test: any) => {
+    pem.readPkcs12('/i/do/not/exist.p12', (error: any) => {
+      test.ok(error);
+      test.equal(error.code, 'ENOENT');
+
+      test.done();
+    });
+  },
+  'Verify sigining chain': (test: any) => {
+    pem.createCertificate({
+                            commonName: 'CA Certificate'
+                          }, (error: any, ca: any) => {
+      test.ifError(error);
+
+      pem.createCertificate({
+                              serviceKey: ca.serviceKey,
+                              serviceCertificate: ca.certificate,
+                              serial: Date.now(),
+                            }, (error: any, cert: any) => {
+        test.ifError(error);
+
+        pem.verifySigningChain(cert.certificate, ca.certificate, (error: any, valid: any) => {
+          test.ifError(error);
+          test.ok(valid === true);
+
+          test.done();
+        });
+      });
+    });
+  },
+  'Verify deep sigining chain': (test: any) => {
+    pem.createCertificate({
+                            commonName: 'CA Certificate'
+                          }, (error: any, ca: any) => {
+      test.ifError(error);
+
+      pem.createCertificate({
+                              commonName: 'Intermediate CA Certificate',
+                              serviceKey: ca.serviceKey,
+                              serviceCertificate: ca.certificate,
+                              serial: Date.now(),
+                            }, (error: any, intermediate: any) => {
+        test.ifError(error);
+
+        pem.createCertificate({
+                                serviceKey: intermediate.clientKey,
+                                serviceCertificate: intermediate.certificate,
+                                serial: Date.now(),
+                              }, (error: any, cert: any) => {
+          test.ifError(error);
+
+          pem.verifySigningChain(cert.certificate, [ca.certificate, intermediate.certificate], (error: any, valid: any) => {
+            test.ifError(error);
+            test.ok(valid === true);
+
+            test.done();
+          });
+        });
+      });
+    });
+  },
+  'Fail to verify invalid sigining chain': (test: any) => {
+    pem.createCertificate({
+                            commonName: 'CA Certificate'
+                          }, (error: any, ca: any) => {
+      test.ifError(error);
+
+      pem.createCertificate({
+                              serviceKey: ca.serviceKey,
+                              serviceCertificate: ca.certificate,
+                              serial: Date.now(),
+                            }, (error: any, cert: any) => {
+        test.ifError(error);
+
+        pem.verifySigningChain(cert.certificate, cert.certificate, (error: any, valid: any) => {
+          test.ifError(error);
+          test.ok(valid === false);
+
+          test.done();
+        });
+      });
+    });
+  },
+  'Fail to verify deep sigining chain with missing CA certificate': (test: any) => {
+    pem.createCertificate({
+                            commonName: 'CA Certificate'
+                          }, (error: any, ca: any) => {
+      test.ifError(error);
+
+      pem.createCertificate({
+                              commonName: 'Intermediate CA Certificate',
+                              serviceKey: ca.serviceKey,
+                              serviceCertificate: ca.certificate,
+                              serial: Date.now(),
+                            }, (error: any, intermediate: any) => {
+        test.ifError(error);
+
+        pem.createCertificate({
+                                serviceKey: intermediate.clientKey,
+                                serviceCertificate: intermediate.certificate,
+                                serial: Date.now(),
+                              }, (error: any, cert: any) => {
+          test.ifError(error);
+
+          pem.verifySigningChain(cert.certificate, [intermediate.certificate], (error: any, valid: any) => {
+            test.ifError(error);
+            test.ok(valid === false);
+
+            test.done();
+          });
+        });
+      });
+    });
+  },
+  'Fail to verify deep sigining chain with missing intermediate certificate': (test: any) => {
+    pem.createCertificate({
+                            commonName: 'CA Certificate'
+                          }, (error: any, ca: any) => {
+      test.ifError(error);
+
+      pem.createCertificate({
+                              commonName: 'Intermediate CA Certificate',
+                              serviceKey: ca.serviceKey,
+                              serviceCertificate: ca.certificate,
+                              serial: Date.now(),
+                            }, (error: any, intermediate: any) => {
+        test.ifError(error);
+
+        pem.createCertificate({
+                                serviceKey: intermediate.clientKey,
+                                serviceCertificate: intermediate.certificate,
+                                serial: Date.now(),
+                                days: 1024
+                              }, (error: any, cert: any) => {
+          test.ifError(error);
+
+          pem.verifySigningChain(cert.certificate, [ca.certificate], (error: any, valid: any) => {
+            test.ifError(error);
+            test.ok(valid === false);
+
+            test.done();
+          });
+        });
+      });
+    });
+  }
+};

--- a/pem/pem.d.ts
+++ b/pem/pem.d.ts
@@ -1,0 +1,155 @@
+// Type definitions for PEM v1.8.3
+// Project: https://github.com/andris9/pem
+// Definitions by: Anthony Trinh <https://github.com/tony19>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "pem" {
+    /**
+     * Creates a private key
+     *
+     * @param {Number} [keyBitsize=2048] Size of the key, defaults to 2048bit (can also be a function)
+     * @param {Object} [options] object of cipher and password {cipher:'aes128',password:'xxx'}, defaults empty object
+     * @param {Function} callback Callback function with an error object and {key}
+     */
+    function createPrivateKey(keyBitsize: Number, options: Object, callback: Function): void;
+    function createPrivateKey(keyBitsize: Number, callback: Function): void;
+    function createPrivateKey(options: Object, callback: Function): void;
+    function createPrivateKey(callback: Function): void;
+
+    /**
+     * Creates a dhparam key
+     *
+     * @param {Number} [keyBitsize=512] Size of the key, defaults to 512bit
+     * @param {Function} callback Callback function with an error object and {dhparam}
+     */
+    function createDhparam(keyBitsize: Number, callback: Function): void;
+    function createDhparam(callback: Function): void;
+
+    /**
+     * Creates a Certificate Signing Request
+     *
+     * If client key is undefined, a new key is created automatically. The used key is included
+     * in the callback return as clientKey
+     *
+     * @param {Object} [options] Optional options object
+     * @param {String} [options.clientKey] Optional client key to use
+     * @param {Number} [options.keyBitsize] If clientKey is undefined, bit size to use for generating a new key (defaults to 2048)
+     * @param {String} [options.hash] Hash function to use (either md5 sha1 or sha256, defaults to sha256)
+     * @param {String} [options.country] CSR country field
+     * @param {String} [options.state] CSR state field
+     * @param {String} [options.locality] CSR locality field
+     * @param {String} [options.organization] CSR organization field
+     * @param {String} [options.organizationUnit] CSR organizational unit field
+     * @param {String} [options.commonName='localhost'] CSR common name field
+     * @param {String} [options.emailAddress] CSR email address field
+     * @param {String} [options.csrConfigFile] CSR config file
+     * @param {Array}  [options.altNames] is a list of subjectAltNames in the subjectAltName field
+     * @param {Function} callback Callback function with an error object and {csr, clientKey}
+     */
+    function createCSR(options: Object, callback: Function): void;
+    function createCSR(callback: Function): void;
+
+    /**
+     * Creates a certificate based on a CSR. If CSR is not defined, a new one
+     * will be generated automatically. For CSR generation all the options values
+     * can be used as with createCSR.
+     *
+     * @param {Object} [options] Optional options object
+     * @param {String} [options.serviceKey] Private key for signing the certificate, if not defined a new one is generated
+     * @param {String} [options.serviceKeyPassword] Password of the service key
+     * @param {Boolean} [options.selfSigned] If set to true and serviceKey is not defined, use clientKey for signing
+     * @param {String} [options.hash] Hash function to use (either md5 sha1 or sha256, defaults to sha256)
+     * @param {String} [options.csr] CSR for the certificate, if not defined a new one is generated
+     * @param {Number} [options.days] Certificate expire time in days
+     * @param {String} [options.clientKeyPassword] Password of the client key
+     * @param {String} [options.extFile] extension config file - without '-extensions v3_req'
+     * @param {String} [options.config] extension config file - with '-extensions v3_req'
+     * @param {Function} callback Callback function with an error object and {certificate, csr, clientKey, serviceKey}
+     */
+    function createCertificate(options: Object, callback: Function): void;
+    function createCertificate(callback: Function): void;
+
+    /**
+     * Reads subject data from a certificate or a CSR
+     *
+     * @param {String} certificate PEM encoded CSR or certificate
+     * @param {Function} callback Callback function with an error object and {country, state, locality, organization, organizationUnit, commonName, emailAddress}
+     */
+    function readCertificateInfo(certificate: string, callback: Function): void;
+    function readCertificateInfo(callback: Function): void;
+
+    /**
+     * Exports a public key from a private key, CSR or certificate
+     *
+     * @param {String} certificate PEM encoded private key, CSR or certificate
+     * @param {Function} callback Callback function with an error object and {publicKey}
+     */
+    function getPublicKey(certificate: string, callback: Function): void;
+    function getPublicKey(callback: Function): void;
+
+    /**
+     * Gets the fingerprint for a certificate
+     *
+     * @param {String} certificate PEM encoded certificate
+     * @param {String} hash Hash function to use (either md5 sha1 or sha256, defaults to sha256)
+     * @param {Function} callback Callback function with an error object and {fingerprint}
+     */
+    function getFingerprint(certificate: string, hash: string, callback: Function): void;
+    function getFingerprint(certificate: string, callback: Function): void;
+    function getFingerprint(callback: Function): void;
+
+    /**
+     * Gets the modulus from a certificate, a CSR or a private key
+     *
+     * @param {String} certificate PEM encoded, CSR PEM encoded, or private key
+     * @param {String} password password for the certificate
+     * @param {Function} callback Callback function with an error object and {modulus}
+     */
+    function getModulus(certificate: string, password: string, callback: Function): void;
+    function getModulus(certificate: string, callback: Function): void;
+
+    /**
+     * Gets the size and prime of DH parameters
+     *
+     * @param {String} dh DH parameters PEM encoded
+     * @param {Function} callback Callback function with an error object and {size, prime}
+     */
+    function getDhparamInfo(dh: string, callback: Function): void;
+
+    /**
+     * Exports private key and certificate to a PKCS12 keystore
+     *
+     * @param {String} key PEM encoded private key
+     * @param {String} certificate PEM encoded certificate
+     * @param {String} password Password of the result PKCS12 file
+     * @param {Object} [options] object of cipher and optional client key password {cipher:'aes128', clientKeyPassword: 'xxx'}
+     * @param {Function} callback Callback function with an error object and {pkcs12}
+     */
+    function createPkcs12(key: string, certificate: string, password: string, options: Object, callback: Function): void;
+    function createPkcs12(key: string, certificate: string, password: string, callback: Function): void;
+
+    /**
+     * Reads private key and certificate from a PKCS12 keystore
+     * @param {String} bufferOrPath
+     * @param {Object} [options] object of cipher and optional client key password {cipher:'aes128', clientKeyPassword: 'xxx'}
+     * @param {Function} callback Callback function with an error object and {pkcs12}
+     * @returns the result of the callback
+     */
+    function readPkcs12(bufferOrPath: string, options: Object, callback: Function): any;
+    function readPkcs12(options: Object, callback: Function): any;
+
+    /**
+     * Verifies the signing chain of the passed certificate
+     *
+     * @param {String} certificate PEM encoded certificate
+     * @param {Array} ca List of CA certificates
+     * @param {Function} callback Callback function with an error object and a boolean valid
+     */
+    function verifySigningChain(certificate: string, ca: Array<string>, callback: Function): void;
+
+    /**
+     * config the pem module
+     * @param {Object} options
+     */
+    function config(options: Object): void;
+}


### PR DESCRIPTION
Type definitions for [pem](https://github.com/andris9/pem)

case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
