### PR TITLE
Add type property to jquery.fileupload

### DIFF
--- a/jquery.fileupload/jquery.fileupload.d.ts
+++ b/jquery.fileupload/jquery.fileupload.d.ts
@@ -105,6 +105,9 @@ interface JQueryFileInputOptions {
      */
     redirectParamName?: string;
 
+	// The HTTP request method must be "POST" or "PUT"
+	type?: string,
+
     /**
      * Set the following option to the location of a postMessage window,
      * to enable postMessage transport uploads:


### PR DESCRIPTION
Update for jquery.fileupload. It was missing the `type` options property ("PUT"/ "POST"). This option is not mentioned in the fileupload [README.md](https://github.com/blueimp/jQuery-File-Upload/blob/master/README.md), nor is it called out in the source documentation for [options](https://github.com/blueimp/jQuery-File-Upload/blob/master/js/jquery.fileupload.js#L89), but it does get referenced in the [source](https://github.com/blueimp/jQuery-File-Upload/blob/master/js/jquery.fileupload.js#L587)
