### PR TITLE
Add missing each, and correct type of Date.now()

### DIFF
--- a/sugar/sugar.d.ts
+++ b/sugar/sugar.d.ts
@@ -3079,6 +3079,11 @@ interface ObjectConstructor {
 	/**
 	* @see map
 	**/
+	each(obj: any, map: (key: string, value: any) => void): void;
+
+	/**
+	* @see map
+	**/
 	any(obj: any, map: string): boolean;
 
 	/**
@@ -4174,7 +4179,7 @@ interface DateConstructor {
 	* @example
 	*   Date.now() -> ex. 1311938296231
 	**/
-	now(): string;
+	now(): number;
 
 	/**
 	* Alternate form of %Date.create% with any ambiguity assumed to be the past.


### PR DESCRIPTION
`Object.each` , was already in the comments, but not declared. [Sugar 1.3.9 mention here](https://github.com/andrewplummer/Sugar/blob/1.3.9/lib/object.js#L12).

`Date.now()` returns the same as the builtin
