### PR TITLE
Add definitions for node-spdy

### DIFF
--- a/spdy/spdy-tests.ts
+++ b/spdy/spdy-tests.ts
@@ -1,0 +1,682 @@
+/// <reference path="spdy.d.ts" />
+
+// copied unit tests from https://github.com/indutny/node-spdy/tree/a583cf6/test
+
+import * as spdy from 'spdy';
+
+let describe: any;
+let it: any;
+let fixtures: any;
+let http: any;
+let https: any;
+let util: any;
+let assert: any;
+let afterEach: any;
+let beforeEach: any;
+let net: any;
+let tls: any;
+let transport: any;
+
+describe('SPDY Client', () => {
+  describe('regular', () => {
+    fixtures.everyConfig((protocol: any, npn: string, version: string, plain: boolean) => {
+      let server: any;
+      let agent: any;
+      let hmodule: any;
+
+      beforeEach((done: any) => {
+        hmodule = plain ? http : https;
+
+        const options = util._extend({
+                                     spdy: {
+                                       plain: plain
+                                     }
+                                   }, fixtures.keys);
+        server = spdy.createServer(options, (req: any, res: any) => {
+          let body = '';
+          req.on('data', (chunk: any) => {
+            body += chunk;
+          });
+          req.on('end', () => {
+            res.writeHead(200, req.headers);
+            res.addTrailers({ trai: 'ler' });
+
+            const push = res.push('/push', {
+              request: {
+                push: 'yes'
+              }
+            }, (err: any) => {
+              assert(!err);
+
+              push.end('push');
+              push.on('error', () => {
+              });
+
+              res.end(body || 'okay');
+            });
+          });
+        });
+
+        server.listen(fixtures.port, () => {
+          agent = spdy.createAgent({
+                                     rejectUnauthorized: false,
+                                     port: <number>fixtures.port,
+                                     spdy: {
+                                       plain: plain,
+                                       protocol: plain ? npn : null,
+                                       protocols: [ npn ]
+                                     }
+                                   });
+
+          done();
+        });
+      });
+
+      afterEach((done: any) => {
+        let waiting = 2;
+        agent.close(next);
+        server.close(next);
+
+        function next() {
+          if (--waiting === 0)
+            done();
+        }
+      });
+
+      it('should send GET request', (done: any) => {
+        const req = hmodule.request({
+                                    agent: agent,
+
+                                    method: 'GET',
+                                    path: '/get',
+                                    headers: {
+                                      a: 'b'
+                                    }
+                                  }, (res: any) => {
+          assert.equal(res.statusCode, 200);
+          assert.equal(res.headers.a, 'b');
+
+          fixtures.expectData(res, 'okay', done);
+        });
+        req.end();
+      });
+
+      it('should send POST request', (done: any) => {
+        const req = hmodule.request({
+                                    agent: agent,
+
+                                    method: 'POST',
+                                    path: '/post',
+
+                                    headers: {
+                                      post: 'headers'
+                                    }
+                                  }, (res: any) => {
+          assert.equal(res.statusCode, 200);
+          assert.equal(res.headers.post, 'headers');
+
+          fixtures.expectData(res, 'post body', done);
+        });
+
+        agent._spdyState.socket.once(plain ? 'connect' : 'secureConnect',
+                                     () => {
+                                       req.end('post body');
+                                     });
+      });
+
+      it('should receive PUSH_PROMISE', (done: any) => {
+        const req = hmodule.request({
+                                    agent: agent,
+
+                                    method: 'GET',
+                                    path: '/get'
+                                  }, (res: any) => {
+          assert.equal(res.statusCode, 200);
+
+          res.resume();
+        });
+        req.on('push', (push: any) => {
+          assert.equal(push.path, '/push');
+          assert.equal(push.headers.push, 'yes');
+
+          push.resume();
+          push.once('end', done);
+        });
+        req.end();
+      });
+
+      it('should receive trailing headers', (done: any) => {
+        var req = hmodule.request({
+                                    agent: agent,
+
+                                    method: 'GET',
+                                    path: '/get'
+                                  }, (res: any) => {
+          assert.equal(res.statusCode, 200);
+
+          res.on('trailers', (headers: any) => {
+            assert.equal(headers.trai, 'ler');
+            fixtures.expectData(res, 'okay', done);
+          });
+        });
+        req.end();
+      });
+    });
+  });
+
+  describe('x-forwarded-for', () => {
+    fixtures.everyConfig((protocol: any, npn: any, version: string, plain: boolean) => {
+      let server: any;
+      let agent: any;
+      let hmodule: any;
+
+      beforeEach((done: any) => {
+        hmodule = plain ? http : https;
+
+        const options = util._extend({
+                                     spdy: {
+                                       plain: plain,
+                                       'x-forwarded-for': true
+                                     }
+                                   }, fixtures.keys);
+        server = spdy.createServer(options, (req: any, res: any) => {
+          res.writeHead(200, req.headers);
+          res.end();
+        });
+
+        server.listen(fixtures.port, () => {
+          agent = spdy.createAgent({
+                                     rejectUnauthorized: false,
+                                     port: fixtures.port,
+                                     spdy: {
+                                       'x-forwarded-for': '1.2.3.4',
+                                       plain: plain,
+                                       protocol: plain ? npn : null,
+                                       protocols: [ npn ]
+                                     }
+                                   });
+
+          done();
+        });
+      });
+
+      afterEach((done: any) => {
+        let waiting = 2;
+        agent.close(next);
+        server.close(next);
+
+        function next() {
+          if (--waiting === 0)
+            done();
+        }
+      });
+
+      it('should send x-forwarded-for', (done: any) => {
+        var req = hmodule.request({
+                                    agent: agent,
+
+                                    method: 'GET',
+                                    path: '/get'
+                                  }, (res: any) => {
+          assert.equal(res.statusCode, 200);
+          assert.equal(res.headers['x-forwarded-for'], '1.2.3.4');
+
+          res.resume();
+          res.once('end', done);
+        });
+        req.end();
+      });
+    });
+  });
+});
+
+describe('SPDY Server', () => {
+  fixtures.everyConfig((protocol: any, npn: any, version: number, plain: boolean) => {
+    let server: any; // spdy.Server;
+    let client: any;
+
+    beforeEach((done: any) => {
+      server = spdy.createServer(util._extend({
+                                                spdy: {
+                                                  'x-forwarded-for': true,
+                                                  plain: plain
+                                                }
+                                              }, fixtures.keys));
+
+      server.listen(fixtures.port, () => {
+        const socket = (plain ? net : tls).connect({
+                                                   rejectUnauthorized: false,
+                                                   port: fixtures.port,
+                                                   NPNProtocols: [ npn ]
+                                                 }, () => {
+          client = transport.connection.create(socket, {
+            protocol: protocol,
+            isServer: false
+          });
+          client.start(version);
+          done();
+        });
+      });
+    });
+
+    afterEach((done: any) => {
+      client.socket.destroy();
+      server.close(done);
+    });
+
+    it('should process GET request', (done: any) => {
+      const stream = client.request({
+                                    method: 'GET',
+                                    path: '/get',
+                                    headers: {
+                                      a: 'b'
+                                    }
+                                  }, (err: any) => {
+        assert(!err);
+
+        stream.on('response', (status: any, headers: any) => {
+          assert.equal(status, 200);
+          assert.equal(headers.ok, 'yes');
+
+          fixtures.expectData(stream, 'response', done);
+        });
+
+        stream.end();
+      });
+
+      server.on('request', (req: any, res: any) => {
+        assert.equal(req.isSpdy, res.isSpdy);
+        assert.equal(req.spdyVersion, res.spdyVersion);
+        assert(req.isSpdy);
+        if (!plain) {
+          const socket = <any>req.socket;
+          assert(socket.encrypted);
+          assert(socket.getPeerCertificate());
+        }
+
+        // Auto-detection
+        if (version === 3.1)
+          assert(req.spdyVersion >= 3 && req.spdyVersion <= 3.1);
+        else
+          assert.equal(req.spdyVersion, version);
+        assert(req.spdyStream);
+        assert(res.spdyStream);
+
+        assert.equal(req.method, 'GET');
+        assert.equal(req.url, '/get');
+        assert.deepEqual(req.headers, { a: 'b', host: 'localhost' });
+
+        req.on('end', () => {
+          res.writeHead(200, {
+            ok: 'yes'
+          });
+          res.end('response');
+          assert(res.finished, 'res.finished should be set');
+        });
+        req.resume();
+      });
+    });
+
+    it('should process POST request', (done: any) => {
+      const stream = client.request({
+                                    method: 'POST',
+                                    path: '/post'
+                                  }, (err: any) => {
+        assert(!err);
+
+        stream.on('response', (status: any, headers: any) => {
+          assert.equal(status, 200);
+          assert.equal(headers.ok, 'yes');
+
+          fixtures.expectData(stream, 'response', next);
+        });
+
+        stream.end('request');
+      });
+
+      server.on('request', (req: any, res: any) => {
+        assert.equal(req.method, 'POST');
+        assert.equal(req.url, '/post');
+
+        res.writeHead(200, {
+          ok: 'yes'
+        });
+        res.end('response');
+
+        fixtures.expectData(req, 'request', next);
+      });
+
+      let waiting = 2;
+      function next() {
+        if (--waiting === 0)
+          return done();
+      }
+    });
+
+    it('should process expect-continue request', (done: any) => {
+      const stream = client.request({
+                                    method: 'GET',
+                                    path: '/get',
+                                    headers: {
+                                      Expect: '100-continue'
+                                    }
+                                  }, (err: any) => {
+        assert(!err);
+
+        stream.on('response', (status: any, headers: any) => {
+          assert.equal(status, 100);
+
+          fixtures.expectData(stream, 'response', done);
+        });
+
+        stream.end();
+      });
+
+      server.on('request', (req: any, res: any) => {
+        req.on('end', () => {
+          res.end('response');
+        });
+        req.resume();
+      });
+    });
+
+    it('should emit `checkContinue` request', (done: any) => {
+      const stream = client.request({
+                                    method: 'GET',
+                                    path: '/get',
+                                    headers: {
+                                      Expect: '100-continue'
+                                    }
+                                  }, (err: any) => {
+        assert(!err);
+
+        stream.on('response', (status: any, headers: any) => {
+          assert.equal(status, 100);
+
+          fixtures.expectData(stream, 'response', done);
+        });
+
+        stream.end();
+      });
+
+      server.on('checkContinue', (req: any, res: any) => {
+        req.on('end', () => {
+          res.writeContinue();
+          res.end('response');
+        });
+        req.resume();
+      });
+    });
+
+    it('should send PUSH_PROMISE', (done: any) => {
+      const stream = client.request({
+                                    method: 'POST',
+                                    path: '/page'
+                                  }, (err: any) => {
+        assert(!err);
+
+        stream.on('pushPromise', (push: any) => {
+          assert.equal(push.path, '/push');
+          assert.equal(push.headers.yes, 'push');
+
+          fixtures.expectData(push, 'push', next);
+          fixtures.expectData(stream, 'response', next);
+        });
+
+        stream.end('request');
+      });
+
+      server.on('request', (req: any, res: any) => {
+        assert.equal(req.method, 'POST');
+        assert.equal(req.url, '/page');
+
+        res.writeHead(200, {
+          ok: 'yes'
+        });
+
+        const push = res.push('/push', {
+          request: {
+            yes: 'push'
+          }
+        });
+        push.end('push');
+
+        res.end('response');
+
+        fixtures.expectData(req, 'request', next);
+      });
+
+      let waiting = 3;
+      function next() {
+        if (--waiting === 0)
+          return done();
+      }
+    });
+
+    it('should receive trailing headers', (done: any) => {
+      const stream = client.request({
+                                    method: 'POST',
+                                    path: '/post'
+                                  }, (err: any) => {
+        assert(!err);
+
+        stream.sendHeaders({ trai: 'ler' });
+        stream.end();
+
+        stream.on('response', (status: any, headers: any) => {
+          assert.equal(status, 200);
+          assert.equal(headers.ok, 'yes');
+
+          fixtures.expectData(stream, 'response', done);
+        });
+      });
+
+      server.on('request', (req: any, res: any) => {
+        let gotHeaders = false;
+        req.on('trailers', (headers: any) => {
+          gotHeaders = true;
+          assert.equal(headers.trai, 'ler');
+        });
+
+        req.on('end', () => {
+          assert(gotHeaders);
+
+          res.writeHead(200, {
+            ok: 'yes'
+          });
+          res.end('response');
+        });
+        req.resume();
+      });
+    });
+
+    it('should call .writeHead() automatically', (done: any) => {
+      const stream = client.request({
+                                    method: 'POST',
+                                    path: '/post'
+                                  }, (err: any) => {
+        assert(!err);
+
+        stream.on('response', (status: any, headers: any) => {
+          assert.equal(status, 300);
+
+          fixtures.expectData(stream, 'response', done);
+        });
+        stream.end();
+      });
+
+      server.on('request', (req: any, res: any) => {
+        req.on('end', () => {
+          res.statusCode = 300;
+          res.end('response');
+        });
+        req.resume();
+      });
+    });
+
+    it('should not crash on .writeHead() after socket close', (done: any) => {
+      const stream = client.request({
+                                    method: 'POST',
+                                    path: '/post'
+                                  }, (err: any) => {
+        assert(!err);
+
+        setTimeout(() => {
+          client.socket.destroy();
+        }, 50);
+        stream.on('error', () => {});
+        stream.end();
+      });
+
+      server.on('request', (req: any, res: any) => {
+        req.connection.on('close', () => {
+          assert.doesNotThrow(() => {
+            res.writeHead(200);
+            res.end('response');
+          });
+          done();
+        });
+      });
+    });
+
+    it('should not crash on .push() after socket close', (done: any) => {
+      const stream = client.request({
+                                    method: 'POST',
+                                    path: '/post'
+                                  }, (err: any) => {
+        assert(!err);
+
+        setTimeout(() => {
+          client.socket.destroy();
+        }, 50);
+        stream.on('error', () => {});
+        stream.end();
+      });
+
+      server.on('request', (req: any, res: any) => {
+        req.connection.on('close', () => {
+          assert.doesNotThrow(() => {
+            assert.equal(res.push('/push', {}), undefined);
+            res.end('response');
+          });
+          done();
+        });
+      });
+    });
+
+    it('should end response after writing everything down', (done: any) => {
+      const stream = client.request({
+                                    method: 'GET',
+                                    path: '/post'
+                                  }, (err: any) => {
+        assert(!err);
+
+        stream.on('response', (status: any, headers: any) => {
+          assert.equal(status, 200);
+
+          fixtures.expectData(stream, 'hello world, what\'s up?', done);
+        });
+
+        stream.end();
+      });
+
+      server.on('request', (req: any, res: any) => {
+        req.resume();
+        res.writeHead(200);
+        res.write('hello ');
+        res.write('world');
+        res.write(', what\'s');
+        res.write(' up?');
+        res.end();
+      });
+    });
+
+    it('should handle x-forwarded-for', (done: any) => {
+      client.sendXForwardedFor('1.2.3.4');
+
+      const stream = client.request({
+                                    method: 'GET',
+                                    path: '/post'
+                                  }, (err: any) => {
+        assert(!err);
+
+        stream.resume();
+        stream.on('end', done);
+        stream.end();
+      });
+
+      server.on('request', (req: any, res: any) => {
+        assert.equal(req.headers['x-forwarded-for'], '1.2.3.4');
+        req.resume();
+        res.end();
+      });
+    });
+  });
+
+  it('should respond to http/1.1', (done: any) => {
+    const server = spdy.createServer(fixtures.keys, (req: any, res: any) => {
+      assert.equal(req.isSpdy, res.isSpdy);
+      assert.equal(req.spdyVersion, res.spdyVersion);
+      assert(!req.isSpdy);
+      assert.equal(req.spdyVersion, 1);
+
+      res.writeHead(200);
+      res.end();
+    });
+
+    server.listen(fixtures.port, () => {
+      const req = https.request({
+                                agent: false,
+                                rejectUnauthorized: false,
+                                NPNProtocols: [ 'http/1.1' ],
+                                port: fixtures.port,
+                                method: 'GET',
+                                path: '/'
+                              }, (res: any) => {
+        assert.equal(res.statusCode, 200);
+        res.resume();
+        res.on('end', () => {
+          server.close(done);
+        });
+      });
+
+      req.end();
+    });
+  });
+
+  it('should support custom base', (done: any) => {
+    function Pseuver(options: spdy.ServerOptions, listener: Function) {
+      https.Server.call(this, options, listener);
+    }
+    util.inherits(Pseuver, https.Server);
+
+    const server = spdy.createServer(Pseuver, fixtures.keys, (req: any, res: any) => {
+      assert.equal(req.isSpdy, res.isSpdy);
+      assert.equal(req.spdyVersion, res.spdyVersion);
+      assert(!req.isSpdy);
+      assert.equal(req.spdyVersion, 1);
+
+      res.writeHead(200);
+      res.end();
+    });
+
+    server.listen(fixtures.port, () => {
+      const req = https.request({
+                                agent: false,
+                                rejectUnauthorized: false,
+                                NPNProtocols: [ 'http/1.1' ],
+                                port: fixtures.port,
+                                method: 'GET',
+                                path: '/'
+                              }, (res: any) => {
+        assert.equal(res.statusCode, 200);
+        res.resume();
+        res.on('end', () => {
+          server.close(done);
+        });
+      });
+
+      req.end();
+    });
+  });
+});

--- a/spdy/spdy.d.ts
+++ b/spdy/spdy.d.ts
@@ -1,0 +1,412 @@
+// Type definitions for node-spdy v3.4.3
+// Project: https://github.com/indutny/node-spdy
+// Definitions by: Anthony Trinh <https://github.com/tony19>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "spdy" {
+    // lib/spdy/agent.js
+    namespace agent {
+        export class Agent extends node.https.Agent {}
+        export class PlainAgent extends node.http.Agent {}
+        export function create(base: any, options: AgentOptions): Agent | PlainAgent;
+
+        export interface AgentOptions extends node.https.AgentOptions {
+            port?: number,
+            spdy?: {
+                plain?: boolean,
+                ssl?: boolean,
+                'x-forwarded-for'?: string,
+                protocol?: string,
+                protocols?: string[]
+            };
+        }
+    }
+
+    // lib/spdy/handle.js
+    export interface Handle {
+        create(options: Object, stream: any, socket: Socket): Handle;
+        getStream(callback?: Function): any;
+        assignSocket(socket: Socket, options: Object): void;
+        assignClientRequest(req: any): void;
+        assignRequest(req: any): void;
+        assignResponse(res: any): void;
+        emitRequest(): void;
+        emitResponse(status: any, headers: any): void;
+    }
+
+    // lib/spdy/request.js
+    namespace request {
+        export function onNewListener(type: string): void;
+    }
+
+    // lib/spdy/response.js
+    namespace response {
+        export function writeHead(statusCode: number, reason: string, obj: Object): void;
+        export function writeHead(statusCode: number, obj: Object): void;
+        export function end(data: any, encoding: string, callback: Function): void;
+    }
+
+    // lib/spdy/server.js
+    namespace server {
+        export interface Server extends node.https.Server {}
+        export interface PlainServer extends node.http.Server {}
+        export interface IncomingMessage extends node.http.IncomingMessage {}
+        export interface ServerResponse extends node.http.ServerResponse {
+            push(filename: string, options: PushOptions): any;
+        }
+        export function create(base: any,
+                               options: node.https.ServerOptions,
+                               handler: (request: IncomingMessage, response: ServerResponse) => void): Server;
+        export function create(options: node.https.ServerOptions,
+                               handler: (request: IncomingMessage, response: ServerResponse) => void): Server;
+        export function create(handler: (request: IncomingMessage, response: ServerResponse) => void): Server;
+
+        export type Protocol =
+            'h2'
+                | 'spdy/3.1'
+                | 'spdy/3'
+                | 'spdy/2'
+                | 'http/1.1'
+                | 'http/1.0';
+
+        export interface PushOptions {
+            status?: number,
+            method?: string,
+            request?: any,
+            response?: any
+        }
+
+        export interface ServerOptions extends node.https.ServerOptions {
+            spdy?: {
+                protocols?: Protocol[],
+                plain?: boolean,
+                'x-forwarded-for'?: boolean,
+                connection?: {
+                    windowSize?: number,
+                    autoSpdy31?: boolean,
+                },
+            };
+        }
+    }
+
+    // copied from definitions of Node 6.7.0
+    namespace node {
+        namespace http {
+            interface Server extends net.Server {
+                setTimeout(msecs: number, callback: Function): any;
+
+                maxHeadersCount: number;
+                timeout: number;
+                listening: boolean;
+            }
+
+            interface AgentOptions {
+                /**
+                 * Keep sockets around in a pool to be used by other requests in the future. Default = false
+                 */
+                keepAlive?: boolean;
+                /**
+                 * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
+                 * Only relevant if keepAlive is set to true.
+                 */
+                keepAliveMsecs?: number;
+                /**
+                 * Maximum number of sockets to allow per host. Default for Node 0.10 is 5, default for Node 0.12 is Infinity
+                 */
+                maxSockets?: number;
+                /**
+                 * Maximum number of sockets to leave open in a free state. Only relevant if keepAlive is set to true. Default = 256.
+                 */
+                maxFreeSockets?: number;
+            }
+
+            class Agent {
+                maxSockets: number;
+                sockets: any;
+                requests: any;
+
+                constructor(opts?: AgentOptions);
+
+                /**
+                 * Destroy any sockets that are currently in use by the agent.
+                 * It is usually not necessary to do this. However, if you are using an agent with KeepAlive enabled,
+                 * then it is best to explicitly shut down the agent when you know that it will no longer be used. Otherwise,
+                 * sockets may hang open for quite a long time before the server terminates them.
+                 */
+                destroy(): void;
+            }
+
+            export interface IncomingMessage {
+                path: string;
+                httpVersion: string;
+                httpVersionMajor: number;
+                httpVersionMinor: number;
+                connection: any;
+                headers: any;
+                rawHeaders: string[];
+                trailers: any;
+                rawTrailers: any;
+                setTimeout(msecs: number, callback: Function): any;
+                /**
+                 * Only valid for request obtained from http.Server.
+                 */
+                method?: string;
+                /**
+                 * Only valid for request obtained from http.Server.
+                 */
+                url?: string;
+                /**
+                 * Only valid for response obtained from http.ClientRequest.
+                 */
+                statusCode?: number;
+                /**
+                 * Only valid for response obtained from http.ClientRequest.
+                 */
+                statusMessage?: string;
+                socket: any;
+                destroy(error?: Error): void;
+                get(name: string): string;
+            }
+
+            export interface ServerResponse {
+                // Extended base methods
+                write(buffer: any): boolean;
+                write(buffer: any, cb?: Function): boolean;
+                write(str: string, cb?: Function): boolean;
+                write(str: string, encoding?: string, cb?: Function): boolean;
+                write(str: string, encoding?: string, fd?: string): boolean;
+
+                writeContinue(): void;
+                writeHead(statusCode: number, reasonPhrase?: string, headers?: any): void;
+                writeHead(statusCode: number, headers?: any): void;
+                statusCode: number;
+                statusMessage: string;
+                headersSent: boolean;
+                setHeader(name: string, value: string | string[]): void;
+                setTimeout(msecs: number, callback: Function): ServerResponse;
+                sendDate: boolean;
+                getHeader(name: string): string;
+                removeHeader(name: string): void;
+                write(chunk: any, encoding?: string): any;
+                addTrailers(headers: any): void;
+                finished: boolean;
+
+                // Extended base methods
+                end(): void;
+                end(buffer: any, cb?: Function): void;
+                end(str: string, cb?: Function): void;
+                end(str: string, encoding?: string, cb?: Function): void;
+                end(data?: any, encoding?: string): void;
+            }
+        }
+
+        namespace https {
+            interface Server extends tls.Server {
+                close(callback?: Function): Server;
+            }
+
+            interface ServerOptions {
+                pfx?: any;
+                key?: any;
+                passphrase?: string;
+                cert?: any;
+                ca?: any;
+                crl?: any;
+                ciphers?: string;
+                honorCipherOrder?: boolean;
+                requestCert?: boolean;
+                rejectUnauthorized?: boolean;
+                NPNProtocols?: any;
+                SNICallback?: (servername: string, cb: (err: Error, ctx: tls.SecureContext) => any) => any;
+            }
+
+            class Agent extends http.Agent {}
+
+            interface AgentOptions extends http.AgentOptions {
+                pfx?: any;
+                key?: any;
+                passphrase?: string;
+                cert?: any;
+                ca?: any;
+                ciphers?: string;
+                rejectUnauthorized?: boolean;
+                secureProtocol?: string;
+                maxCachedSessions?: number;
+            }
+        }
+
+        namespace tls {
+            interface Server extends net.Server {
+                close(): Server;
+                address(): { port: number; family: string; address: string; };
+                addContext(hostName: string, credentials: {
+                    key: string;
+                    cert: string;
+                    ca: string;
+                }): void;
+                maxConnections: number;
+                connections: number;
+
+                /**
+                 * events.EventEmitter
+                 * 1. tlsClientError
+                 * 2. newSession
+                 * 3. OCSPRequest
+                 * 4. resumeSession
+                 * 5. secureConnection
+                 **/
+                addListener(event: string, listener: Function): this;
+                addListener(event: "tlsClientError", listener: (err: Error, tlsSocket: any) => void): this;
+                addListener(event: "newSession", listener: (sessionId: any, sessionData: any, callback: (err: Error, resp: any) => void) => void): this;
+                addListener(event: "OCSPRequest", listener: (certificate: any, issuer: any, callback: Function) => void): this;
+                addListener(event: "resumeSession", listener: (sessionId: any, callback: (err: Error, sessionData: any) => void) => void): this;
+                addListener(event: "secureConnection", listener: (tlsSocket: any) => void): this;
+
+                emit(event: string, ...args: any[]): boolean;
+                emit(event: "tlsClientError", err: Error, tlsSocket: any): boolean;
+                emit(event: "newSession", sessionId: any, sessionData: any, callback: (err: Error, resp: any) => void): boolean;
+                emit(event: "OCSPRequest", certificate: any, issuer: any, callback: Function): boolean;
+                emit(event: "resumeSession", sessionId: any, callback: (err: Error, sessionData: any) => void): boolean;
+                emit(event: "secureConnection", tlsSocket: any): boolean;
+
+                on(event: string, listener: Function): this;
+                on(event: "tlsClientError", listener: (err: Error, tlsSocket: any) => void): this;
+                on(event: "newSession", listener: (sessionId: any, sessionData: any, callback: (err: Error, resp: any) => void) => void): this;
+                on(event: "OCSPRequest", listener: (certificate: any, issuer: any, callback: Function) => void): this;
+                on(event: "resumeSession", listener: (sessionId: any, callback: (err: Error, sessionData: any) => void) => void): this;
+                on(event: "secureConnection", listener: (tlsSocket: any) => void): this;
+
+                once(event: string, listener: Function): this;
+                once(event: "tlsClientError", listener: (err: Error, tlsSocket: any) => void): this;
+                once(event: "newSession", listener: (sessionId: any, sessionData: any, callback: (err: Error, resp: any) => void) => void): this;
+                once(event: "OCSPRequest", listener: (certificate: any, issuer: any, callback: Function) => void): this;
+                once(event: "resumeSession", listener: (sessionId: any, callback: (err: Error, sessionData: any) => void) => void): this;
+                once(event: "secureConnection", listener: (tlsSocket: any) => void): this;
+
+                prependListener(event: string, listener: Function): this;
+                prependListener(event: "tlsClientError", listener: (err: Error, tlsSocket: any) => void): this;
+                prependListener(event: "newSession", listener: (sessionId: any, sessionData: any, callback: (err: Error, resp: any) => void) => void): this;
+                prependListener(event: "OCSPRequest", listener: (certificate: any, issuer: any, callback: Function) => void): this;
+                prependListener(event: "resumeSession", listener: (sessionId: any, callback: (err: Error, sessionData: any) => void) => void): this;
+                prependListener(event: "secureConnection", listener: (tlsSocket: any) => void): this;
+
+                prependOnceListener(event: string, listener: Function): this;
+                prependOnceListener(event: "tlsClientError", listener: (err: Error, tlsSocket: any) => void): this;
+                prependOnceListener(event: "newSession", listener: (sessionId: any, sessionData: any, callback: (err: Error, resp: any) => void) => void): this;
+                prependOnceListener(event: "OCSPRequest", listener: (certificate: any, issuer: any, callback: Function) => void): this;
+                prependOnceListener(event: "resumeSession", listener: (sessionId: any, callback: (err: Error, sessionData: any) => void) => void): this;
+                prependOnceListener(event: "secureConnection", listener: (tlsSocket: any) => void): this;
+            }
+
+            interface SecureContext {
+                context: any;
+            }
+        }
+
+        namespace net {
+            interface Server {
+                // net.Server
+                listen(port: number, hostname?: string, backlog?: number, listeningListener?: Function): Server;
+                listen(port: number, hostname?: string, listeningListener?: Function): Server;
+                listen(port: number, backlog?: number, listeningListener?: Function): Server;
+                listen(port: number, listeningListener?: Function): Server;
+                listen(path: string, backlog?: number, listeningListener?: Function): Server;
+                listen(path: string, listeningListener?: Function): Server;
+                listen(handle: any, backlog?: number, listeningListener?: Function): Server;
+                listen(handle: any, listeningListener?: Function): Server;
+                listen(options: ListenOptions, listeningListener?: Function): Server;
+
+                close(callback?: Function): Server;
+
+                address(): { port: number; family: string; address: string; };
+
+                getConnections(cb: (error: Error, count: number) => void): void;
+
+                ref(): Server;
+
+                unref(): Server;
+
+                maxConnections: number;
+                connections: number;
+
+                /**
+                 * events.EventEmitter
+                 *   1. close
+                 *   2. connection
+                 *   3. error
+                 *   4. listening
+                 */
+                addListener(event: string, listener: Function): this;
+                addListener(event: "close", listener: () => void): this;
+                addListener(event: "connection", listener: (socket: Socket) => void): this;
+                addListener(event: "error", listener: (err: Error) => void): this;
+                addListener(event: "listening", listener: () => void): this;
+
+                emit(event: string, ...args: any[]): boolean;
+                emit(event: "close"): boolean;
+                emit(event: "connection", socket: Socket): boolean;
+                emit(event: "error", err: Error): boolean;
+                emit(event: "listening"): boolean;
+
+                on(event: string, listener: Function): this;
+                on(event: "close", listener: () => void): this;
+                on(event: "connection", listener: (socket: Socket) => void): this;
+                on(event: "error", listener: (err: Error) => void): this;
+                on(event: "listening", listener: () => void): this;
+
+                once(event: string, listener: Function): this;
+                once(event: "close", listener: () => void): this;
+                once(event: "connection", listener: (socket: Socket) => void): this;
+                once(event: "error", listener: (err: Error) => void): this;
+                once(event: "listening", listener: () => void): this;
+
+                prependListener(event: string, listener: Function): this;
+                prependListener(event: "close", listener: () => void): this;
+                prependListener(event: "connection", listener: (socket: Socket) => void): this;
+                prependListener(event: "error", listener: (err: Error) => void): this;
+                prependListener(event: "listening", listener: () => void): this;
+
+                prependOnceListener(event: string, listener: Function): this;
+                prependOnceListener(event: "close", listener: () => void): this;
+                prependOnceListener(event: "connection", listener: (socket: Socket) => void): this;
+                prependOnceListener(event: "error", listener: (err: Error) => void): this;
+                prependOnceListener(event: "listening", listener: () => void): this;
+            }
+
+            interface ListenOptions {
+                port?: number;
+                host?: string;
+                backlog?: number;
+                path?: string;
+                exclusive?: boolean;
+            }
+        }
+    }
+
+    // lib/spdy/socket.js
+    namespace socket {
+        export interface Socket {
+            // net.Socket
+        }
+    }
+
+    // lib/spdy.js
+    export type Agent = agent.Agent;
+    export type PlainAgent = agent.PlainAgent;
+    export type AgentOptions = agent.AgentOptions;
+    export type Socket = socket.Socket;
+    export type Server = server.Server;
+    export type IncomingMessage = server.IncomingMessage;
+    export type ServerRequest = server.IncomingMessage;
+    export type ServerResponse = server.ServerResponse;
+    export type PlainServer = server.PlainServer;
+    export type ServerOptions = server.ServerOptions;
+    export function createAgent(base: any, options: AgentOptions): Agent | PlainAgent;
+    export function createAgent(options: AgentOptions): Agent | PlainAgent;
+    export function createServer(base: any,
+                                 options: ServerOptions,
+                                 handler: (request: IncomingMessage, response: ServerResponse) => void): Server;
+    export function createServer(options: ServerOptions,
+                                 handler: (request: IncomingMessage, response: ServerResponse) => void): Server;
+    export function createServer(handler: (request: IncomingMessage, response: ServerResponse) => void): Server;
+}


### PR DESCRIPTION
Type definitions for [node-spdy](https://github.com/indutny/node-spdy)

case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
