### PR TITLE
Allow interface to be named

### DIFF
--- a/redux-devtools/redux-devtools.d.ts
+++ b/redux-devtools/redux-devtools.d.ts
@@ -8,7 +8,7 @@
 declare module "redux-devtools" {
   import * as React from 'react'
 
-  interface IDevTools {
+  export interface IDevTools {
     new (): JSX.ElementClass
     instrument(): (opts: any) => any;
   }


### PR DESCRIPTION
Allow interface to be named. Solves:

> error TS4023: Exported variable 'DevTools' has or is using name 'IDevTools' from external module "/Users/remojansen/CODE/forks/redux-bootstrap/node_modules/@types/redux-devtools/index" but cannot be named.
