### PR TITLE
add transducers-js types w/ tests

### DIFF
--- a/transducers-js/transducers-js-tests.ts
+++ b/transducers-js/transducers-js-tests.ts
@@ -1,0 +1,168 @@
+/// <reference path="transducers-js.d.ts" />
+/// <reference path="../lodash/lodash.d.ts" />
+/// <reference path="../immutable/immutable.d.ts" />
+
+// tests taken from https://github.com/cognitect-labs/transducers-js
+
+import * as t from 'transducers-js';
+
+var map    = t.map,
+    filter = t.filter,
+    comp   = t.comp,
+    into   = t.into;
+
+// basic usage
+
+var inc = function(n: number) { return n + 1; };
+var isEven = function(n: number) { return n % 2 == 0; };
+var xf = comp(map(inc), filter(isEven));
+
+console.log(into([], xf, [0,1,2,3,4])); // [2,4]
+
+// integration
+
+var arr   = [0,1,2,3,4,5,6,7,8,9,10],
+    apush = function(arr: number[], x: number) { arr.push(x); return arr; },
+    xf    = comp(map(inc), filter(isEven)),
+    toFn  = t.toFn;
+
+arr.reduce(toFn(xf, apush), []); // native
+_(arr).reduce(toFn(xf, apush), []); // underscore or lodash
+
+// immutable-js
+
+import * as Immutable from 'immutable';
+
+var inc = function(n: number): number { return n + 1; };
+var isEven = function(n: number): boolean { return n % 2 == 0; };
+var sum = function(a: number, b: number): number { return a + b; };
+var transduce = t.transduce;
+
+var largeVector = Immutable.List();
+
+for(var i = 0; i < 1000000; i++) {
+  largeVector = largeVector.push(i);
+}
+
+// built in Immutable-js functionality
+largeVector.map(inc).filter(isEven).reduce(sum);
+
+// faster with transducers
+var xf = comp(map(inc),filter(isEven));
+transduce(xf, sum, 0, largeVector);
+
+// source examples
+
+function mapExample () {
+  var inc = function(n: number) { return n+1; };
+  var xf = t.map(inc);
+  t.into([], xf, [1,2,3]); // [2,3,4]
+}
+
+function filterExample () {
+  var isEven = function(n: number) { return n % 2 == 0; };
+  var xf = t.filter(isEven);
+  t.into([], xf, [0,1,2,3,4]); // [0,2,4];
+}
+
+function removeExample () {
+  var isEven = function(n: number) { return n % 2 == 0; };
+  var xf = t.remove(isEven);
+  t.into([], xf, [0,1,2,3,4]); // [1,3];
+}
+
+function complementExample () {
+  var isEven = function(n: number) { return n % 2 == 0; };
+  var isOdd = t.complement(isEven);
+}
+
+function keepIndexedExample () {
+  var xf = t.keepIndexed(function(i: number, x: string|number) { if (typeof x == "string") return "cool"; });
+  t.into([], xf, [0,1,"foo",3,4,"bar"]); // ["foo","bar"]
+}
+
+function takeExample () {
+  var xf = t.take(3);
+  t.into([], xf, [0,1,2,3,4,5]); // [0,1,2];
+}
+
+function takeWhileExample () {
+  var xf = t.takeWhile(function(n) { return n < 3; });
+  t.into([], xf, [0,1,2,3,4,5]); // [0,1,2];
+}
+
+function intoExample () {
+  var inc = function(n: number) { return n+1; };
+  var isEven = function(n: number) { return n % 2 == 0; };
+  var apush = function(arr: number[], x: number) { arr.push(x); return arr; };
+  var xf = t.comp(t.map(inc),t.filter(isEven));
+  t.into([], xf, [1,2,3,4]); // [2,4]
+}
+
+function toFnExample () {
+  var arr = [0,1,2,3,4,5];
+  var apush = function(arr: number[], x: number) { arr.push(x); return arr; };
+  var xf = t.comp(t.map(inc),t.filter(isEven));
+  arr.reduce(t.toFn(xf, apush), []); // [2,4,6]
+}
+
+function takeNthExample () {
+  var xf = t.takeNth(3);
+  t.into([], xf, [0,1,2,3,4,5]); // [2,5];
+}
+
+function dropExample () {
+  var xf = t.drop(3);
+  t.into([], xf, [0,1,2,3,4,5]); // [3,4,5];
+}
+
+function dropWhileExample () {
+  var xf = t.dropWhile(function(n: number) { return n < 3; });
+  t.into([], xf, [0,1,2,3,4,5]); // [3,4,5];
+}
+
+function partitionByExample () {
+  var xf = t.partitionBy(function(x: string|number) { return typeof x == "string"; });
+  t.into([], xf, [0,1,"foo","bar",2,3,"bar","baz"]); // [[0,1],["foo","bar"],[2,3],["bar","baz"]];
+}
+
+function partitionAllExample () {
+  var xf = t.partitionAll(3);
+  t.into([], xf, [0,1,2,3,4,5]); // [[0,1,2],[3,4,5]]
+}
+
+function wrapExample () {
+  var arrayPush = t.wrap(function(arr: number[], x: number) { arr.push(x); return arr; });
+}
+
+function ensureReducedExample () {
+  var x = t.ensureReduced(1);
+  var y = t.ensureReduced(x);
+  x === y; // true
+}
+
+function unreducedExample () {
+  var x = t.reduced(1);
+  t.unreduced(x); // 1
+  t.unreduced(t.unreduced(x)); // 1
+}
+
+function catExample () {
+  var reverse = function(arr: number[]) { 
+    var arr: number[] = Array.prototype.slice.call(arr, 0);
+    arr.reverse();
+    return arr; 
+  };
+  var xf = t.comp(t.map(reverse), t.cat);
+  t.into([], xf, [[3,2,1],[6,5,4]]); // [1,2,3,4,5,6]
+}
+
+function mapcatExample () {
+  var reverse = function(arr: number[]) { 
+    var arr: number[] = Array.prototype.slice.call(arr, 0);
+    arr.reverse();
+    return arr; 
+  };
+  var xf = t.mapcat(reverse);
+  t.into([], xf, [[3,2,1],[6,5,4]]); // [1,2,3,4,5,6]
+}

--- a/transducers-js/transducers-js.d.ts
+++ b/transducers-js/transducers-js.d.ts
@@ -1,0 +1,304 @@
+// Type definitions for transducers-js
+// Project: https://github.com/cognitect-labs/transducers-js
+// Definitions by: Colin Kahn <https://github.com/colinkahn>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'transducers-js' {
+  export interface IteratorResult<T> {
+    done: boolean;
+    value?: T
+  }
+
+  export interface Iterator<T> {
+    next (value?: any): IteratorResult<T>;
+    return? (value?: any): IteratorResult<T>;
+    throw? (e?: any): IteratorResult<T>;
+  }
+
+  export interface Reduced<TResult> {
+    ['@@transducer/reduced']: boolean;
+    ['@@transducer/value']: TResult;
+  }
+
+  export interface Reducer<TResult, TInput> {
+    (result: TResult, input: TInput): TResult;
+  }
+
+  export interface Transducer<TResult, TInput, TOutput> {
+    (xf: Transformer<TResult, TOutput>): Transformer<TResult, TInput>;
+  }
+
+  export interface CompletingTransformer <TResult, TCompleteResult, TInput> {
+    ['@@transducer/init'] (): TResult | void;
+    ['@@transducer/step'] (result: TResult, input: TInput): TResult | Reduced<TResult>;
+    ['@@transducer/result'] (result: TResult): TCompleteResult;
+  }
+
+  export interface Transformer<TResult, TInput> extends CompletingTransformer<TResult, TResult, TInput> {
+  }
+
+  /**
+   * Return a reduced value. Reduced values short circuit transduce.
+   */
+  export function reduced<TResult> (x: TResult): Reduced<TResult>;
+
+  /**
+   * Check if a value is reduced.
+   */
+  export function isReduced (x : any) : Boolean;
+
+  /**
+   * Function composition. Take N function and return their composition.
+   */
+  export function comp<T> (...args: T[]): T;
+
+  /**
+   * Take a predicate function and return its complement.
+   */
+  export function complement (f: Function): Function;
+
+  /**
+   * Identity function.
+   */
+  export function identity<T> (arg: T): T;
+
+  export class Map<TResult, TInput, TOutput> implements Transformer<TResult, TInput> {
+    constructor (f: (x: TInput) => TOutput, xf: Transformer<TResult, TOutput>);
+    ['@@transducer/init'] (): TResult;
+    ['@@transducer/step'] (result: TResult, input: TInput): TResult;
+    ['@@transducer/result'] (result: TResult): TResult;
+  }
+
+  /**
+   * Mapping transducer constructor
+   */
+  export function map<TResult, TInput, TOutput> (f: (x: TInput) => TOutput): Transducer<TResult, TInput, TOutput>;
+
+  export class Filter<TResult, TInput> implements Transformer<TResult, TInput> {
+    constructor (pred: (x: TInput) => boolean, xf: Transformer<TResult, TInput>);
+    ['@@transducer/init'] (): TResult;
+    ['@@transducer/step'] (result: TResult, input: TInput): TResult;
+    ['@@transducer/result'] (result: TResult): TResult;
+  }
+
+  /**
+   * Filtering transducer constructor
+   */
+  export function filter<TResult, TInput> (pred: (x: TInput) => boolean): Transducer<TResult, TInput, TInput>;
+
+  /**
+   * Similar to filter except the predicate is used to
+   * eliminate values.
+   */
+  export function remove<TResult, TInput> (pred: (x: TInput) => boolean): Transducer<TResult, TInput, TInput>;
+
+  export class Keep<TResult, TInput> implements Transformer<TResult, TInput> {
+    constructor (f: (x: TInput) => any, xf: Transformer<TResult, TInput>);
+    ['@@transducer/init'] (): TResult;
+    ['@@transducer/step'] (result: TResult, input: TInput): TResult;
+    ['@@transducer/result'] (result: TResult): TResult;
+  }
+
+  /**
+   * A keeping transducer. Keep inputs as long as the provided
+   * function does not return null or undefined.
+   */
+  export function keep<TResult, TInput> (f: (x: TInput) => any): Transducer<TResult, TInput, TInput>;
+
+  export class KeepIndexed<TResult, TInput> implements Transformer<TResult, TInput> {
+    constructor (f: (i: number, x:TInput) => any, xf: Transformer<TResult, TInput>);
+    ['@@transducer/init'] (): TResult;
+    ['@@transducer/step'] (result: TResult, input: TInput): TResult;
+    ['@@transducer/result'] (result: TResult): TResult;
+  }
+
+  /**
+   * Like keep but the provided function will be passed the
+   * index as the fist argument.
+   */
+  export function keepIndexed<TResult, TInput> (f: (i: number, x: TInput) => any): Transducer<TResult, TInput, TInput>;
+
+  export class Take<TResult, TInput> implements Transformer<TResult, TInput> {
+    constructor (n: number, xf: Transformer<TResult, TInput>);
+    ['@@transducer/init'] (): TResult;
+    ['@@transducer/step'] (result: TResult, input: TInput): TResult | Reduced<TResult>;
+    ['@@transducer/result'] (result: TResult): TResult;
+  }
+
+  /**
+   * A take transducer constructor. Will take n values before
+   * returning a reduced result.
+   */
+  export function take<TResult, TInput> (n: number): Transducer<TResult, TInput, TInput>;
+
+  export class TakeWhile<TResult, TInput> implements Transformer<TResult, TInput> {
+    constructor (pred: (n: TInput) => boolean, xf: Transformer<TResult, TInput>);
+    ['@@transducer/init'] (): TResult;
+    ['@@transducer/step'] (result: TResult, input: TInput): TResult | Reduced<TResult>;
+    ['@@transducer/result'] (result: TResult): TResult;
+  }
+
+  /**
+   * Like the take transducer except takes as long as the pred
+   * return true for inputs.
+   */
+  export function takeWhile<TResult, TInput> (pred: (n: TInput) => boolean): Transducer<TResult, TInput, TInput>;
+
+  export class TakeNth<TResult, TInput> implements Transformer<TResult, TInput> {
+    constructor (n: number, xf: Transformer<TResult, TInput>);
+    ['@@transducer/init'] (): TResult;
+    ['@@transducer/step'] (result: TResult, input: TInput): TResult;
+    ['@@transducer/result'] (result: TResult): TResult;
+  }
+
+  /**
+   * A transducer that takes every Nth input
+   */
+  export function takeNth<TResult, TInput> (n: number): Transducer<TResult, TInput, TInput>;
+
+  export class Drop<TResult, TInput> implements Transformer<TResult, TInput> {
+    constructor (n: number, xf: Transformer<TResult, TInput>);
+    ['@@transducer/init'] (): TResult;
+    ['@@transducer/step'] (result: TResult, input: TInput): TResult;
+    ['@@transducer/result'] (result: TResult): TResult;
+  }
+
+  /**
+   * A dropping transducer constructor
+   */
+  export function drop<TResult, TInput> (n: number): Transducer<TResult, TInput, TInput>;
+
+  export class DropWhile<TResult, TInput> implements Transformer<TResult, TInput> {
+    constructor (pred: (input: TInput) => boolean, xf: Transformer<TResult, TInput>);
+    ['@@transducer/init'] (): TResult;
+    ['@@transducer/step'] (result: TResult, input: TInput): TResult;
+    ['@@transducer/result'] (result: TResult): TResult;
+  }
+
+  /**
+   * A dropping transducer that drop inputs as long as
+   * pred is true.
+   */
+  export function dropWhile<TResult, TInput> (pred: (input: TInput) => boolean): Transducer<TResult, TInput, TInput>;
+
+  export class PartitionBy<TResult, TInput> implements Transformer<TResult, TInput> {
+    constructor (f: (input: TInput) => any, xf: Transformer<TResult, TInput[]>);
+    ['@@transducer/init'] (): TResult;
+    ['@@transducer/step'] (result: TResult, input: TInput): TResult
+    ['@@transducer/result'] (result: TResult): TResult
+  }
+
+  /**
+   * A partitioning transducer. Collects inputs into
+   * arrays as long as predicate remains true for contiguous
+   * inputs.
+   */
+  export function partitionBy<TResult, TInput> (f: (input: TInput) => any): Transducer<TResult, TInput, TInput[]>;
+
+  export class PartitionAll<TResult, TInput> implements Transformer<TResult, TInput> {
+    constructor (n: number, xf: Transformer<TResult, TInput[]>);
+    ['@@transducer/init'] (): TResult;
+    ['@@transducer/step'] (result: TResult, input: TInput): TResult
+    ['@@transducer/result'] (result: TResult): TResult
+  }
+
+  /**
+   * A partitioning transducer. Collects inputs into
+   * arrays of size N.
+   */
+  export function partitionAll<TResult, TInput> (n: number): Transducer<TResult, TInput, TInput[]>;
+
+  export class Completing<TResult, TCompleteResult, TInput> implements CompletingTransformer<TResult, TCompleteResult, TInput> {
+    constructor (cf: (result: TResult) => TCompleteResult, xf: Transformer<TResult, TInput>);
+    ['@@transducer/init'] (): TResult;
+    ['@@transducer/step'] (result: TResult, input: TInput): TResult
+    ['@@transducer/result'] (result: TResult): TCompleteResult
+  }
+
+  /**
+   * A completing transducer constructor. Useful to provide cleanup
+   * logic at the end of a reduction/transduction.
+   */
+  export function completing<TResult, TCompleteResult, TInput> (cf: (result: TResult) => TCompleteResult): CompletingTransformer<TResult, TCompleteResult, TInput>;
+
+  export class Wrap<TResult, TInput> implements Transformer<TResult, TInput> {
+    constructor (stepFn: Reducer<TResult, TInput>, xf: Transformer<TResult, TInput>);
+    ['@@transducer/init'] (): TResult;
+    ['@@transducer/step'] (result: TResult, input: TInput): TResult
+    ['@@transducer/result'] (result: TResult): TResult
+  }
+
+  /**
+   * Take a two-arity reducing function where the first argument is the
+   * accumluation and the second argument is the next input and convert
+   * it into a transducer transformer object.
+   */
+  export function wrap<TResult, TInput> (stepFn: Reducer<TResult, TInput>): Transducer<TResult, TInput, TInput>;
+
+  /**
+   * Given a transformer return a concatenating transformer
+   */
+  export function cat<TResult, TInput> (xf: Transformer<TResult, TInput>): Transformer<TResult, TInput> ;
+
+  /**
+   * A mapping concatenating transformer
+   */
+  export function mapcat<TResult, TInput, TOutput> (f: (arr: TInput[]) => TOutput[]): Transducer<TResult, TInput[], TOutput>;
+
+  /**
+   * Given a transducer, a builder function, an initial value
+   * and a iterable collection - returns the reduction.
+   */
+  export function transduce<TResult, TInput, TOutput> (
+    xf: Transducer<TResult, TInput, TOutput>,
+    f: Transformer<TResult, TInput> | Reducer<TResult, TInput>,
+    init: TResult,
+    coll: TInput[] | Iterator<TInput> | string | Object): TResult;
+
+  /**
+   * Given a transducer, an intial value and a
+   * collection - returns the reduction.
+   */
+  export function reduce<TResult, TInput, TOutput> (
+    xf: Transducer<TResult, TInput, TOutput>,
+    init: TResult,
+    coll: TInput[] | Iterator<TInput> | string | Object): TResult
+
+  /**
+   * Reduce a value into the given empty value using a transducer.
+   */
+  export function into<TResult, TInput, TOutput>(
+    empty: TResult,
+    xf: Transducer<TResult, TInput, TOutput>,
+    coll: TInput[] | Iterator<TInput> | string | Object): TResult;
+
+  /**
+   * Convert a transducer transformer object into a function so
+   * that it can be used with existing reduce implementation i.e. native,
+   * Underscore, lodash
+   */
+  export function toFn<TResult, TInput, TOutput> (
+    xf: Transducer<TResult, TInput, TOutput>,
+    builder: Reducer<TResult, TInput> | Transformer<TResult, TInput>
+  ): Reducer<TResult, TInput>;
+
+  /**
+   * A transformer which simply returns the first input.
+   */
+  export function first<TResult, TInput> (): Wrap<TResult, TInput>;
+
+  /**
+   * Ensure that a value is reduced. If already reduced will not re-wrap.
+   */
+  export function ensureReduced<TResult> (x: TResult | Reduced<TResult>): Reduced<TResult>;
+
+  /**
+   * Ensure a value is not reduced. Unwraps if reduced.
+   */
+  export function unreduced<TResult> (x: TResult | Reduced<TResult>): TResult;
+
+  /**
+   * Returns the value of a reduced result.
+   */
+  export function deref<TResult> (x: Reduced<TResult>): TResult;
+}


### PR DESCRIPTION
Types for [transducers-js](https://github.com/cognitect-labs/transducers-js)

case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
