### PR TITLE
Fix redeclare block-scoped Base64

### DIFF
--- a/js-base64/js-base64.d.ts
+++ b/js-base64/js-base64.d.ts
@@ -19,34 +19,37 @@ add methods:
 - [ ] noConflict
  */
 
-interface Base64 {
-    /**
-     * .encode
-     * @param {String} string
-     * @return {String}
-     */
-    encode(base64: string): string;
+declare namespace Base64 {
+    const Base64: Base64Static
+    interface Base64Static {
+        /**
+         * .encode
+         * @param {String} string
+         * @return {String}
+         */
+        encode(base64: string): string;
 
-    /**
-     * .encodeURI
-     * @param {String} string
-     * @return {String}
-     */
-    encodeURI(base64: string): string
+        /**
+         * .encodeURI
+         * @param {String} string
+         * @return {String}
+         */
+        encodeURI(base64: string): string
 
-    /**
-     * .decode
-     * @param {String} string
-     * @return {String}
-     */
-    decode(base64: string): string
+        /**
+         * .decode
+         * @param {String} string
+         * @return {String}
+         */
+        decode(base64: string): string
 
-    /**
-     * Library version
-     */
-    VERSION:string
+        /**
+         * Library version
+         */
+        VERSION:string
+    }
 }
 
 declare module 'js-base64' {
-    const Base64: Base64
+    export = Base64
 }


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Issue found by https://github.com/dankogai/js-base64/issues/38#issuecomment-250999729
