### PR TITLE
added seed, randomTests and randomizeTests property

### DIFF
--- a/jasmine/jasmine-tests.ts
+++ b/jasmine/jasmine-tests.ts
@@ -904,6 +904,23 @@ describe("Custom matcher: 'toBeGoofy'", function () {
     });
 });
 
+describe("Randomize Tests", function() {
+	it("should allow randomization of the order of tests", function() {
+		expect(function() {
+			var env = jasmine.getEnv();
+			return env.randomizeTests(true);
+		}).not.toThrow();
+	});
+
+	it("should allow a seed to be passed in for randomization", function() {
+		expect(function() {
+			var env = jasmine.getEnv();
+			env.randomizeTests(true);
+			return env.seed(1234);
+		}).not.toThrow();
+	});
+});
+
 (() => {
     // from boot.js
     var env = jasmine.getEnv();

--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jasmine 2.2
+// Type definitions for Jasmine 2.4.1
 // Project: http://jasmine.github.io/
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>, Theodore Brown <https://github.com/theodorejb>, David Pärsson <https://github.com/davidparsson/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -180,6 +180,9 @@ declare namespace jasmine {
         addMatchers(matchers: CustomMatcherFactories): void;
         specFilter(spec: Spec): boolean;
         throwOnExpectationFailure(value: boolean): void;
+        seed: (s: number) => number;
+        randomTests: () => boolean;
+        randomizeTests: (b: boolean) => void;
     }
 
     interface FakeTimer {


### PR DESCRIPTION
Improvement to existing type definition

This PR includes changes to support randomisation of tests which are available in the jasmine api since version 2.4.0, also noticed that [this](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/9167) PR already introduced a change that was part of the version `2.4.1` hence updating the version in the type definition header as well. 

source code for the above mentioned changes can be found in the links below
[seed](https://github.com/jasmine/jasmine/blob/master/src/core/Env.js#L187)
[randomTests](https://github.com/jasmine/jasmine/blob/master/src/core/Env.js#L183)
[randomizeTests](https://github.com/jasmine/jasmine/blob/master/src/core/Env.js#L179)

I also have a question about how we can determine what version of the definitions are currently available for jasmine in the `DefinitelyTyped` repo, because as you can see failing to update the version number in the definition can lead to problems where we are already using the features from a newer version whereas the definition file version may say something completely different. Can we do something to ensure we have all the correct API definitions available for a specific version of `jasmine` without having to manually verify the whole thing?
