### PR TITLE
Types 2.0: Fix incorrectly merged auth0-js module name change

### DIFF
--- a/auth0-js/index.d.ts
+++ b/auth0-js/index.d.ts
@@ -128,6 +128,6 @@ interface Auth0DelegationToken {
 
 declare const Auth0: Auth0Static;
 
-declare module "auth0" {
+declare module "auth0-js" {
     export = Auth0
 }


### PR DESCRIPTION
In c2a54db3e9247d3881668c3ca80e5b5284961db6, the `'auth0'` to `'auth0-js'` module name change is not merged into `types-2.0`.
The name change has been approved and has valid reasoning (See #10721).
