### PR TITLE
Fix typo in #11667

### DIFF
--- a/q/Q.d.ts
+++ b/q/Q.d.ts
@@ -15,7 +15,7 @@ declare function Q<T>(value: T): Q.Promise<T>;
 /**
  * Calling with nothing at all creates a void promise
  */
-declare function Q(): Q.Promise<void>;
+declare function Q<T>(): Q.Promise<void>;
 
 declare namespace Q {
     interface IPromise<T> {


### PR DESCRIPTION
Seems my environment was pulling in definitions from somewhere else when I tested #11667

The merged version fails with 

>  node_modules/@types/q/index.d.ts(170,15): Error TS2428: All declarations of 'Promise' must have identical type parameters.
