### PR TITLE
Updated fbsdk definitions for authentication responses and api calls.

### DIFF
--- a/fbsdk/fbsdk-tests.ts
+++ b/fbsdk/fbsdk-tests.ts
@@ -3,16 +3,16 @@
 window.fbAsyncInit = function() {
     FB.init(
         {
-            appId      : '{your-app-id}',
+            appId      : "{your-app-id}",
             xfbml      : true,
-            version    : 'v2.0'
+            version    : "v2.0"
         }
     );
 
     FB.ui(
         {
-            method: 'share',
-            href: 'https://developers.facebook.com/docs/dialogs/'
+            method: "share",
+            href: "https://developers.facebook.com/docs/dialogs/"
         },
         function(response) {
             console.log(response);
@@ -21,9 +21,24 @@ window.fbAsyncInit = function() {
 
     FB.api(
         "/me",
-        "POST",
-        function (fbResponse){
+        "post",
+        function (fbResponse) {
             console.log(fbResponse);
         }
     );
+
+    function checkAuth(response: FB.LoginStatusResponse): void {
+        if (response.status === "connected") {
+            console.log(response.authResponse.accessToken);
+            console.log(response.authResponse.expiresIn);
+            console.log(response.authResponse.signedRequest);
+            console.log(response.authResponse.userID);
+        } else if (response.status === "unknown") {
+            console.log("not logged in");
+        }
+    }
+
+    FB.login(checkAuth);
+
+    FB.getLoginStatus(checkAuth);
 };

--- a/fbsdk/fbsdk.d.ts
+++ b/fbsdk/fbsdk.d.ts
@@ -171,23 +171,44 @@ interface FBResponseObject {
     error: any;
 }
 
+declare type LoginStatus = "connected" | "not_authorized" | "unknown";
+declare type ApiMethod = "get" | "post" | "delete";
+
+interface AuthResponse {
+    accessToken: string;
+    expiresIn: number;
+    signedRequest: string;
+    userID: string;
+}
+
+interface FBError {
+    type: string;
+    message: string;
+    code: number;
+    error_subcode?: number;
+    error_user_msg?: string;
+    error_user_title?: string;
+    fbtrace_id: string;
+}
+
 interface FBSDK{
     /* This method is used to initialize and setup the SDK. */
     init(fbInitObject : FBInitParams) : void;
 
     /* This method lets you make calls to the Graph API. */
-    api(path : string, method : string, callback : (fbResponseObject : Object) => any) :  Object;
-    api(path : string, params : Object, callback : (fbResponseObject : FBResponseObject) => any) :  Object;
-    api(path : string, method : string, params : Object, callback : (fbResponseObject : Object) => any) : Object;
+    api(path: string, callback: (response: any) => void): void;
+    api(path: string, method: ApiMethod, callback: (response: any) => void): void;
+    api(path: string, params: any, callback: (response: any) => void): void;
+    api(path: string, method: ApiMethod, params: any, callback: (response: any) => void): void;
 
     /* This method is used to trigger different forms of Facebook created UI dialogs. */
     ui(params : FBUIParams, handler : (fbResponseObject : Object) => any) : void;
 
     /* Allows you to determine if a user is logged in to Facebook and has authenticated your app */
-    getLoginStatus(handler : Function, force?: Boolean) : void;
+    getLoginStatus(handler : (fbResponseObject : FB.LoginStatusResponse) => any, force?: Boolean) : void;
 
     /* Calling FB.login prompts the user to authenticate your application using the Login Dialog. */
-    login(handler : (fbResponseObject : Object) => any, params?: FBLoginOptions): void;
+    login(handler : (fbResponseObject : FB.LoginStatusResponse) => any, params?: FBLoginOptions): void;
 
     /* Log the user out of your site and Facebook */
     logout(handler : (fbResponseObject : Object) => any) : void;
@@ -198,6 +219,7 @@ interface FBSDK{
     Event : FBSDKEvents;
     XFBML : FBSDKXFBML;
     Canvas : FBSDKCanvas;
+    Error: FBError;
 }
 
 interface Window{
@@ -206,6 +228,13 @@ interface Window{
 
 declare module "FB" {
     export = FB;
+}
+
+declare namespace FB {
+    export interface LoginStatusResponse {
+        authResponse?: AuthResponse;
+        status: LoginStatus;
+    }
 }
 
 declare var FB : FBSDK;


### PR DESCRIPTION
Improvement to existing type definition. This is far from perfect, but helps make api calls and authentication usable. I may be able to improve this type definition more as I continue the project I'm using it in. If I do continue, I'll probably reformat the entire file in a single commit/PR since it's throwing all sorts of lint warnings with atom-typescript. I've tried to restrain myself to meaningful changes only here, though.

Fixes #11327
May help with #11007
Closes #11662

Documentation links:
- `login`/`getLoginStatus`/`authResponse` - https://developers.facebook.com/docs/javascript/reference/v2.7#auth-methods
- `api` - https://developers.facebook.com/docs/javascript/reference/FB.api
- api errors - https://developers.facebook.com/docs/graph-api/using-graph-api#errors
