### PR TITLE
Adding union type for offset

### DIFF
--- a/bootstrap-notify/bootstrap-notify.d.ts
+++ b/bootstrap-notify/bootstrap-notify.d.ts
@@ -36,7 +36,10 @@ interface NotifySettings {
 		from?: string;
 		align?: string;
 	};
-	offset?: number;
+	offset?: number | {
+		x?: number;
+		y?: number;
+	};
 	spacing?: number;
 	z_index?: number;
 	delay?: number;


### PR DESCRIPTION
Offset allows for either just a number or optionally an x/y coordinate. 
See the offical documenation for offset, offset.x and offset.y at
http://bootstrap-notify.remabledesigns.com/#documentation-settings
