### PR TITLE
add type definitions for msgpack-lite package.

### DIFF
--- a/msgpack-lite/msgpack-lite-tests.ts
+++ b/msgpack-lite/msgpack-lite-tests.ts
@@ -1,0 +1,5 @@
+/// <reference path="msgpack-lite.d.ts" />
+import * as msgpack from "msgpack-lite";
+
+var encoded = msgpack.encode("");
+msgpack.decode(encoded);

--- a/msgpack-lite/msgpack-lite.d.ts
+++ b/msgpack-lite/msgpack-lite.d.ts
@@ -1,0 +1,67 @@
+// Type definitions for msgpack-lite 0.1.20
+// Project: https://github.com/kawanet/msgpack-lite
+// Definitions by: Endel Dreyer <https://github.com/endel/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+declare module "msgpack-lite" {
+  import { Transform } from "stream";
+
+  namespace MsgpackLite {
+    interface BufferOptions { codec: any; }
+
+    interface Encoder {
+      bufferish: any;
+      maxBufferSize: number;
+      minBufferSize: number;
+      offset: number;
+      start: number;
+      write: (chunk: any) => void;
+      fetch: () => void;
+      flush: () => void;
+      push: (chunk: any) => void;
+      pull: () => number;
+      read: () => number;
+      reserve: (length: number) => number;
+      send: (buffer: Buffer) => void;
+      encode: (chunk: any) => void;
+      end: (chunk: any) => void;
+    }
+
+    interface Decoder {
+      bufferish: any;
+      offset: number;
+      fetch: () => void;
+      flush: () => void;
+      pull: () => number;
+      read: () => number;
+      write: (chunk: any) => void;
+      reserve: (length: number) => number;
+      decode: (chunk: any) => void;
+      push: (chunk: any) => void;
+      end: (chunk: any) => void;
+    }
+
+    interface EncodeStream extends Transform {
+      encoder: Encoder;
+    }
+    interface DecodeStream extends Transform {
+      decoder: Decoder;
+    }
+
+    interface Codec {
+      new (options?: any): Codec;
+      options: any;
+      init (): void;
+    }
+
+    export function encode(input: any, options?: BufferOptions): any;
+    export function decode(input: Buffer | Uint8Array | Array<number>, options?: BufferOptions): any;
+    export function createEncodeStream (): EncodeStream;
+    export function createDecodeStream (): DecodeStream;
+    export function createCodec (options?: any): Codec;
+    export function codec (): { preset: Codec };
+  }
+
+  export = MsgpackLite;
+}


### PR DESCRIPTION
Request for type definitions here: https://github.com/kawanet/msgpack-lite/issues/50
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
