### PR TITLE
Updated “assert” types to match that of npm’s “assert” module.

### DIFF
--- a/assert/assert.d.ts
+++ b/assert/assert.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for commonjs-assert, known as "assert" on npm
+// Type definitions for assert
 // Project: https://github.com/defunctzombie/commonjs-assert
 // Definitions by: vvakame <https://github.com/vvakame>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/assert/assert.d.ts
+++ b/assert/assert.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for commonjs-assert (known as "assert" on npm)
+// Type definitions for commonjs-assert, known as "assert" on npm
 // Project: https://github.com/defunctzombie/commonjs-assert
 // Definitions by: vvakame <https://github.com/vvakame>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/assert/assert.d.ts
+++ b/assert/assert.d.ts
@@ -1,10 +1,15 @@
-// Type definitions for assert and power-assert
-// Project: https://github.com/Jxck/assert
-// Project: https://github.com/twada/power-assert
+// Type definitions for commonjs-assert (known as "assert" on npm)
+// Project: https://github.com/defunctzombie/commonjs-assert
 // Definitions by: vvakame <https://github.com/vvakame>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// copy from assert external module in node.d.ts
+// Definitions for commonjs-assert match that of node.js' assert module,
+// but commonjs-assert is intended to be used as an independent module,
+// for instance when making a stand-alone site or app that doesn't have
+// access to node modules. For that reason, these definitions define a
+// "assert" module. This will conflict with node.d.ts and other assert
+// modules such as "power-assert", but a project should realistically
+// only be using one of these at a time.
 
 declare function assert(value:any, message?:string):void;
 declare namespace assert {
@@ -52,12 +57,6 @@ declare namespace assert {
     export function ifError(value:any):void;
 }
 
-// duplicate to node.d.ts
-// declare module "assert" {
-//     export = assert;
-// }
-
-// move to power-assert.d.ts. do not use this definition file.
-declare module "power-assert" {
+declare module "assert" {
     export = assert;
 }

--- a/fbemitter/fbemitter-tests.ts
+++ b/fbemitter/fbemitter-tests.ts
@@ -1,7 +1,6 @@
 ///<reference path="fbemitter.d.ts" />
 ///<reference path="../node/node.d.ts" />
 ///<reference path="../mocha/mocha.d.ts" />
-///<reference path="../assert/assert.d.ts" />
 'use strict';
 
 /**


### PR DESCRIPTION
A little background: It appears there are many modules that go by the name "assert". There's one built into node, npm's assert module (which is github's defunctzombie/commonjs-assert), github's Jxck/assert (not sure if this one is on npm), and power-assert which also seems to get wrapped up in the conversation.

DefinitelyTyped already has a definition for "assert", but it doesn't define an "assert" module in the .d.ts file, which for me completely defeats the purpose. (It actually does define it, but it's commented out). It does however define a "power-assert" module which makes no sense seeing as how DefinitelyTyped definitions are supposed to match their npm named equivalents and power-assert is a separate npm module.

It's possible that people ran into conflicts on the "assert" module name when including both node.d.ts and assert.d.ts, but realistically a project shouldn't be using both of these modules at the same time.

This pull request simply restores (un-comments) the "assert" module code and removes any references to "power-assert".
