### PR TITLE
[openlayers] Override ol.layer.Vector getSource()

### DIFF
--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -6361,6 +6361,13 @@ declare module ol {
             constructor(opt_options?: olx.layer.VectorOptions);
 
             /**
+             * Return the associated {@link ol.source.Vector vectorsource} of the layer.
+             * @return {ol.source.Vector} Source.
+             * @api stable
+             */
+            getSource(): ol.source.Vector;
+       
+            /**
              * Get the style for features.  This returns whatever was passed to the `style`
              * option at construction or to the `setStyle` method.
              * @return {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction}


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://openlayers.org/en/latest/apidoc/ol.layer.Vector.html .
  - it has been reviewed by a DefinitelyTyped member.

Override function `ol.layer.Vector#getSource()`
