### PR TITLE
[material-ui] Add target property to buttons

### DIFF
--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -633,6 +633,7 @@ declare namespace __MaterialUI {
         disableTouchRipple?: boolean;
         focusRippleColor?: string;
         focusRippleOpacity?: number;
+        href?: string;
         keyboardFocused?: boolean;
         linkButton?: boolean;
         onBlur?: React.FocusEventHandler;
@@ -644,6 +645,7 @@ declare namespace __MaterialUI {
         onClick?: React.MouseEventHandler;
         style?: React.CSSProperties;
         tabIndex?: number;
+        target?: string;
         touchRippleColor?: string;
         touchRippleOpacity?: number;
         type?: string;
@@ -663,7 +665,6 @@ declare namespace __MaterialUI {
         backgroundColor?: string;
         disabled?: boolean;
         hoverColor?: string;
-        href?: string;
         icon?: React.ReactNode;
         label?: React.ReactNode;
         labelPosition?: "before" | "after";
@@ -689,7 +690,6 @@ declare namespace __MaterialUI {
         disabledBackgroundColor?: string;
         disabledLabelColor?: string;
         fullWidth?: boolean;
-        href?: string;
         icon?: React.ReactNode;
         label?: React.ReactNode;
         labelColor?: string;
@@ -716,7 +716,6 @@ declare namespace __MaterialUI {
         className?: string;
         disabled?: boolean;
         disabledColor?: string;
-        href?: string;
         iconClassName?: string;
         iconStyle?: React.CSSProperties;
         linkButton?: boolean;


### PR DESCRIPTION
Buttons' `target` is passed to the underlying EnhancedButton properties: https://github.com/callemall/material-ui/blob/master/src/internal/EnhancedButton.js#L330

Bonus: Refactor the `href` property to be available in the base class.
