### PR TITLE
[lodash]: memoize.Cache expects construcor

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -5872,12 +5872,18 @@ namespace TestMemoize {
         result = _(memoizeFn).chain().memoize(memoizeResolverFn);
     }
 
-    _.memoize.Cache = {
-        delete: key => false,
-        get: key => undefined,
-        has: key => false,
-        set(key, value) { return this; }
-    };
+    interface MemoizeCache<K, V> {
+        delete(key: K): boolean;
+        get(key: K): V;
+        has(key: K): boolean;
+        set(key: K, value: V): this;
+    }
+    interface MemoizeCacheConstructor {
+        new (): MemoizeCache<any, any>;
+    }
+    let MemoizeCache: MemoizeCacheConstructor
+
+    _.memoize.Cache = MemoizeCache;
 }
 
 // _.overArgs

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -355,6 +355,9 @@ declare module _ {
          */
         set(key: string, value: any): _.Dictionary<any>;
     }
+    interface MapCacheConstructor {
+        new (): MapCache;
+    }
 
     interface LoDashWrapperBase<T, TWrapper> { }
 
@@ -10411,7 +10414,7 @@ declare module _ {
          */
         memoize: {
             <T extends Function>(func: T, resolver?: Function): T & MemoizedFunction;
-            Cache: MapCache;
+            Cache: MapCacheConstructor;
         }
     }
 


### PR DESCRIPTION
https://lodash.com/docs/4.15.0#memoize (see last line in _Examples_ section of docs for claryfication)
