### PR TITLE
fix object-assign

### DIFF
--- a/object-assign/object-assign-tests.ts
+++ b/object-assign/object-assign-tests.ts
@@ -1,5 +1,5 @@
 /// <reference path="object-assign.d.ts" />
-import objectAssign = require("object-assign");
+import * as objectAssign from 'object-assign';
 
 interface Target {
   hellow: string;
@@ -10,7 +10,7 @@ interface Source1 {
 }
 
 interface Result extends Target, Source1 {
-  
+
 }
 
 interface Source2 {
@@ -18,7 +18,7 @@ interface Source2 {
 }
 
 interface Result2 extends Result, Source2 {
-  
+
 }
 
 interface Source3 {
@@ -26,7 +26,7 @@ interface Source3 {
 }
 
 interface Result3 extends Result2, Source3 {
-  
+
 }
 
 interface Source4 {
@@ -34,7 +34,7 @@ interface Source4 {
 }
 
 interface Result4 extends Result3, Source4 {
-  
+
 }
 
 interface Source5 {
@@ -42,7 +42,7 @@ interface Source5 {
 }
 
 interface Result5 extends Result4, Source5 {
-  
+
 }
 
 function assign1(): Result {

--- a/object-assign/object-assign.d.ts
+++ b/object-assign/object-assign.d.ts
@@ -10,5 +10,6 @@ declare module "object-assign" {
   function objectAssign<T, U, V, W, Q>(target: T, source1: U, source2: V, source3: W, source4: Q): T & U & V & W & Q;
   function objectAssign<T, U, V, W, Q, R>(target: T, source1: U, source2: V, source3: W, source4: Q, source5: R): T & U & V & W & Q & R;
   function objectAssign(target: any, ...sources: any[]): any;
+  namespace objectAssign { }
   export = objectAssign;
 }


### PR DESCRIPTION
Improved the `object-assign` type definition in order for it to work with `import * as objectAssign from 'object-assign';`.
