### PR TITLE
add type definitions for qrcode

### DIFF
--- a/qrcode/qrcode-tests.ts
+++ b/qrcode/qrcode-tests.ts
@@ -1,0 +1,16 @@
+/// <reference path="qrcode.d.ts" />
+
+import * as QRCode from 'qrcode';
+
+QRCode.toDataURL('i am a pony!', function (err, url) {
+    console.log(url);
+});
+
+var qrcodedraw = new QRCodeLib.QRCodeDraw();
+
+qrcodedraw.draw(document.getElementById('test') as HTMLCanvasElement, "this text will be in the code!", function (error, canvas) {
+    if (error) {
+        return console.log('Error =( ', error);
+    }
+    console.log('success!');
+});

--- a/qrcode/qrcode.d.ts
+++ b/qrcode/qrcode.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for qrcode
+// Project: https://github.com/soldair/node-qrcode
+// Definitions by: York Yao <https://github.com/plantain-00/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type QRCodeOptions = {
+    errorCorrectLevel?: "minimum" | "medium" | "high" | "max";
+}
+
+declare module "qrcode" {
+    var qrcode: {
+        toDataURL(text: string, callback: (error: Error, dataURL: string) => void): void;
+        toDataURL(text: string, options: QRCodeOptions, callback: (error: Error, dataURL: string) => void): void;
+        draw(text: string, callback: (error: Error, canvas: HTMLCanvasElement) => void): void;
+        draw(text: string, options: QRCodeOptions, callback: (error: Error, canvas: HTMLCanvasElement) => void): void;
+        drawSvg(text: string, callback: (error: Error, svgString: string) => void): void;
+        drawSvg(text: string, options: QRCodeOptions, callback: (error: Error, svgString: string) => void): void;
+        save(path: string, text: string, callback: (error: Error, written: any) => void): void;
+        save(path: string, text: string, options: QRCodeOptions, callback: (error: Error, written: any) => void): void;
+        drawText(text: string, callback: (error: Error) => void): void;
+        drawText(text: string, options: QRCodeOptions, callback: (error: Error) => void): void;
+        drawBitArray(text: string, callback: (error: Error, bits: any, width: number) => void): void;
+        drawBitArray(text: string, options: QRCodeOptions, callback: (error: Error, bits: any, width: number) => void): void;
+    };
+    export = qrcode;
+}
+
+declare var QRCodeLib: {
+    QRCodeDraw: {
+        new (): {
+            draw(element: HTMLCanvasElement, text: string, callback: (error: Error, canvas: HTMLCanvasElement) => void): void;
+            draw(element: HTMLCanvasElement, text: string, options: QRCodeOptions, callback: (error: Error, canvas: HTMLCanvasElement) => void): void;
+        }
+    };
+};


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
