### PR TITLE
Add typings for iconv-lite (types-2.0).

### DIFF
--- a/iconv-lite/iconv-lite-tests.ts
+++ b/iconv-lite/iconv-lite-tests.ts
@@ -1,0 +1,52 @@
+// Code examples from iconv-lite README
+
+import * as iconv from "./";
+
+import * as assert from "assert";
+import * as fs from "fs";
+import * as http from "http";
+
+// Basic API
+(() => {
+	// Convert from an encoded buffer to js string.
+	const str: string = iconv.decode(new Buffer([0x68, 0x65, 0x6c, 0x6c, 0x6f]), 'win1251');
+
+	// Convert from js string to an encoded buffer.
+	const buf: Buffer = iconv.encode("Sample input string", 'win1251');
+
+	// Check if encoding is supported
+	const exists: boolean = iconv.encodingExists("us-ascii");
+})();
+
+// Streaming API
+(() => {
+	// Decode stream (from binary stream to js strings)
+	http.createServer(function(req, res) {
+		var converterStream = iconv.decodeStream('win1251');
+		req.pipe(converterStream);
+
+		converterStream.on('data', function(str: string) {
+			console.log(str); // Do something with decoded strings, chunk-by-chunk.
+		});
+	});
+
+	// Convert encoding streaming example
+	fs.createReadStream('file-in-win1251.txt')
+		.pipe(iconv.decodeStream('win1251'))
+		.pipe(iconv.encodeStream('ucs2'))
+		.pipe(fs.createWriteStream('file-in-ucs2.txt'));
+
+	// Sugar: all encode/decode streams have .collect(cb) method to accumulate data.
+	http.createServer(function(req, res) {
+		req.pipe(iconv.decodeStream('win1251')).collect(function(err, body) {
+			assert(typeof body == 'string');
+			console.log(body); // full request body string
+		});
+	});
+})();
+
+// Extend Node.js own encodings
+(() => {
+	iconv.extendNodeEncodings();
+	iconv.undoExtendNodeEncodings();
+})();

--- a/iconv-lite/index.d.ts
+++ b/iconv-lite/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for iconv-lite
+// Project: https://github.com/ashtuchkin/iconv-lite
+// Definitions by: Martin Poelstra <https://github.com/poelstra>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference types="node" />
+
+import stream = require("stream");
+
+export interface Options {
+    stripBOM: boolean;
+    addBOM: boolean;
+    defaultEncoding: string;
+}
+
+export function decode(buffer: Buffer, encoding: string, options?: Options): string;
+export function encode(source: string, encoding: string, options?: Options): Buffer;
+export function encodingExists(encoding: string): boolean;
+
+export class DecodeStream extends stream.Transform {
+    collect(cb: (err: Error, decoded: string) => any): DecodeStream;
+}
+
+export class EncodeStream extends stream.Transform {
+    collect(cb: (err: Error, decoded: Buffer) => any): EncodeStream;
+}
+
+export function decodeStream(encoding: string, options?: Options): DecodeStream;
+export function encodeStream(encoding: string, options?: Options): EncodeStream;
+
+export function extendNodeEncodings(): void;
+export function undoExtendNodeEncodings(): void;

--- a/iconv-lite/tsconfig.json
+++ b/iconv-lite/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [
+            "node"
+        ],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "iconv-lite-tests.ts"
+    ]
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
  - Note: I followed the suggested new naming of https://github.com/DefinitelyTyped/DefinitelyTyped/issues/10711 instead
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
