### PR TITLE
fixed setMaxBounds to match maxBounds in MapOptions

### DIFF
--- a/leaflet/leaflet-tests.ts
+++ b/leaflet/leaflet-tests.ts
@@ -237,8 +237,8 @@ map = map
 	.panTo(latLngTuple, panOptions)
 	.panBy(point)
 	.panBy(pointTuple)
-	.setMaxBounds(bounds) // investigate if this really receives Bounds instead of LatLngBounds
-	.setMaxBounds(boundsLiteral)
+	.setMaxBounds(latLngBounds)
+	.setMaxBounds(latLngBoundsLiteral)
 	.setMinZoom(5)
 	.setMaxZoom(10)
 	.panInsideBounds(latLngBounds)

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -1231,8 +1231,7 @@ declare namespace L {
         panTo(latlng: LatLngTuple, options?: PanOptions): this;
         panBy(offset: Point): this;
         panBy(offset: PointTuple): this;
-        setMaxBounds(bounds: Bounds): this; // is this really bounds and not lanlngbounds?
-        setMaxBounds(bounds: BoundsLiteral): this;
+        setMaxBounds(bounds: LatLngBoundsExpression): this; // is this really bounds and not lanlngbounds?
         setMinZoom(zoom: number): this;
         setMaxZoom(zoom: number): this;
         panInsideBounds(bounds: LatLngBounds, options?: PanOptions): this;

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -1231,7 +1231,8 @@ declare namespace L {
         panTo(latlng: LatLngTuple, options?: PanOptions): this;
         panBy(offset: Point): this;
         panBy(offset: PointTuple): this;
-        setMaxBounds(bounds: LatLngBoundsExpression): this; // is this really bounds and not lanlngbounds?
+        setMaxBounds(bounds: LatLngBounds): this;
+        setMaxBounds(bounds: LatLngBoundsLiteral): this;
         setMinZoom(zoom: number): this;
         setMaxZoom(zoom: number): this;
         panInsideBounds(bounds: LatLngBounds, options?: PanOptions): this;


### PR DESCRIPTION
Changes setMaxBounds from `Bounds` to `LatLngBoundsExpression` to match the property in `MapOptions`. Digged through Leaflet-Sourcecode to check this. Seems correct and is working in a project. Changed leaflet-test to match changes.
- Travis-Build passed: https://travis-ci.org/Schwobaland/DefinitelyTyped
- tsc --noImplicitAny leaflet/leaflet-tests.ts: working
- tsc --noImplicitAny --module commonjs leaflet/leaflet-tests.ts: working
