### PR TITLE
Mongoose types-2.0 remove promise dependencies

### DIFF
--- a/mongoose/index.d.ts
+++ b/mongoose/index.d.ts
@@ -4,9 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="mongodb" />
-/// <reference types="mpromise" />
 /// <reference types="node" />
-/// <reference types="mongoose-promise" />
 
 /*
  * Guidelines for maintaining these definitions:


### PR DESCRIPTION
`mongoose-promise` and `mpromise` dependencies were removed a month ago from the `master` branch. However, `types-2.0` has not been updated.
