### PR TITLE
Definitions for quoted-printable.

### DIFF
--- a/quoted-printable/quoted-printable-tests.ts
+++ b/quoted-printable/quoted-printable-tests.ts
@@ -1,0 +1,11 @@
+/// <reference path="./quoted-printable.d.ts" />
+/// <reference path="../utf8/utf8.d.ts" />
+
+import * as quotedPrintable from "quoted-printable";
+import * as utf8 from "utf8";
+
+quotedPrintable.version === "0.2.1";
+quotedPrintable.encode(utf8.encode("foo=bar"));
+quotedPrintable.encode(utf8.encode("Iñtërnâtiônàlizætiøn☃💩"));
+utf8.decode(quotedPrintable.decode("foo=3Dbar"));
+utf8.decode(quotedPrintable.decode("I=C3=B1t=C3=ABrn=C3=A2ti=C3=B4n=C3=A0liz=C3=A6ti=C3=B8n=E2=98=83=F0=9F=92=\r\n=A9"));

--- a/quoted-printable/quoted-printable.d.ts
+++ b/quoted-printable/quoted-printable.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for quoted-printable v0.2.1
+// Project: https://github.com/mathiasbynens/quoted-printable
+// Definitions by: Jeffery Grajkowsi <https://github.com/pushplay>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "quoted-printable" {
+    /**
+     * A string representing the semantic version number.
+     */
+    export const version: string;
+
+    /**
+     * This function takes an encoded byte string (the input
+     * parameter) and Quoted-Printable-encodes it. Each item
+     * in the input string represents an octet as per the
+     * desired character encoding.
+     */
+    export function encode(input: string): string;
+
+    /**
+     * This function takes a string of text (the text parameter)
+     * and Quoted-Printable-decodes it. The return value is a
+     * ‘byte string’, i.e. a string of which each item represents
+     * an octet as per the character encoding that’s being used.
+     */
+    export function decode(input: string): string;
+}

--- a/quoted-printable/quoted-printable.d.ts
+++ b/quoted-printable/quoted-printable.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for quoted-printable v0.2.1
 // Project: https://github.com/mathiasbynens/quoted-printable
-// Definitions by: Jeffery Grajkowsi <https://github.com/pushplay>
+// Definitions by: Jeffery Grajkowski <https://github.com/pushplay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module "quoted-printable" {


### PR DESCRIPTION
Using a hilariously old encoding in 2016.

case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
