### PR TITLE
improve definitions of clipboard.js

### DIFF
--- a/clipboard/clipboard-tests.ts
+++ b/clipboard/clipboard-tests.ts
@@ -26,3 +26,7 @@ cb2.on('success', function(e) {
 });
 cb2.on('error', function(e) { });
 
+
+import * as Clipboard2 from "clipboard";
+
+var cb6 = new Clipboard2('.btn');

--- a/clipboard/clipboard.d.ts
+++ b/clipboard/clipboard.d.ts
@@ -3,8 +3,8 @@
 // Definitions by: Andrei Kurosh <https://github.com/impworks>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare class Clipboard {
-    constructor(selector: (string | Element | NodeListOf<Element>), options?: ClipboardOptions);
+interface ClipboardStatic {
+    new(selector: (string | Element | NodeListOf<Element>), options?: ClipboardOptions): ClipboardStatic;
 
     /**
      * Subscribes to events that indicate the result of a copy/cut operation.
@@ -52,5 +52,8 @@ interface ClipboardEvent {
 }
 
 declare module 'clipboard' {
+    var Clipboard: ClipboardStatic;
     export = Clipboard;
 }
+
+declare var Clipboard: ClipboardStatic;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.
  - it has been reviewed by a DefinitelyTyped member.

Case:
When clipboard.js is used with webpack, clipboard.js should be imported like:

```
import * as Clipboard from "clipboard";
```
