### PR TITLE
Make victor less ambient

### DIFF
--- a/victor/index.d.ts
+++ b/victor/index.d.ts
@@ -124,24 +124,24 @@ declare class Victor
      * @param vector
      */
     multiply(vector:Victor):Victor;
-    
+
     /**
      * Multiplies both vector axis by the given scalar value
-     * 
+     *
      * @param victor
      */
     multiplyScalar(scalar: number): Victor;
 
     /**
      * Multiplies the X axis by the given scalar
-     * 
+     *
      * @param victor
      */
     multiplyScalarX(scalar: number): Victor;
 
     /**
      * Multiplies the Y axis by the given scalar
-     * 
+     *
      * @param vector
      */
     multiplyScalarY(scalar: number): Victor;
@@ -374,6 +374,4 @@ declare class Victor
 
 }
 
-declare module "victor" {
-	export = Victor;
-}
+export = Victor;

--- a/victor/victor-tests.ts
+++ b/victor/victor-tests.ts
@@ -1,3 +1,5 @@
+import Victor = require('victor');
+
 var vector1 = new Victor(10,10)
 var vector2 = new Victor(20,20)
 
@@ -40,11 +42,3 @@ vector1.angle()
 vector1.angleDeg()
 vector1.verticalAngle()
 vector1.verticalAngleDeg()
-
-
-
-
-
-
-
-


### PR DESCRIPTION
It's not currently possible to import Victor from "@types/victor" using es6-style imports:

``` ts
import Victor from "victor";
```

Gives `Module '"victor"' has no default export.`

``` ts
import * as Victor from "victor";
```

Gives `Module '"victor"' resolves to a non-module entity and cannot be imported using this construct.`

``` ts
import Victor = require("victor");
```

Works, but, I don't think it's the way things are supposed to work now?

``` ts
import "victor";
```

Also works, but will fail at runtime unless victor has already been loaded.
See: http://victorjs.org/

This changes the victor declarations to use `export = Victor` instead of declaring an ambient namespace/module. There are no other changes. This will be a breaking change for anyone using victor as an ambient import, probably.

Note that it's entirely possible that I've misunderstood how the types-2.0 branch works, in which case this should be disregarded. (There doesn't seem to be much documentation about how to update the "@types/whatever" declarations).

case 2. Improvement to existing type definition.
- [x] documentation or source code reference which provides context for the suggested changes.
- [x] it has been reviewed by a DefinitelyTyped member.
