### PR TITLE
Improve local forage

### DIFF
--- a/localForage/localForage-tests.ts
+++ b/localForage/localForage-tests.ts
@@ -18,6 +18,10 @@ namespace LocalForageTest {
         let newNumber: number = num;
     });
 
+    localForage.length().then((num: number) => {
+        var newNumber: number = num;
+    });
+
     localForage.key(0, (err: any, value: string) => {
         let newError: any = err;
         let newValue: string = value;
@@ -26,6 +30,10 @@ namespace LocalForageTest {
     localForage.keys((err: any, keys: Array<string>) => {
         let newError: any = err;
         let newArray: Array<string> = keys;
+    });
+
+    localForage.keys().then((keys: Array<string>) => {
+        var newArray: Array<string> = keys;
     });
 
     localForage.getItem("key",(err: any, str: string) => {

--- a/localForage/localForage-tests.ts
+++ b/localForage/localForage-tests.ts
@@ -61,6 +61,20 @@ namespace LocalForageTest {
     localForage.removeItem("key").then(() => {
     });
 
+    localForage.getDriver("CustomDriver").then((result: LocalForageDriver) => {
+        var driver: LocalForageDriver = result;
+        // we need to use a variable for proper type guards before TS 2.0
+        var _support = driver._support;
+        if (typeof _support === "function") {
+            // _support = _support.bind(driver);
+            _support().then((result: boolean) => {
+                let doesSupport: boolean = result;
+            });
+        } else if (typeof _support === "boolean") {
+            let doesSupport: boolean = _support;
+        }
+    });
+
     {
         let config: boolean;
 

--- a/localForage/localForage.d.ts
+++ b/localForage/localForage.d.ts
@@ -17,26 +17,39 @@ interface LocalForageOptions {
     description?: string;
 }
 
-interface LocalForageDriver {
+interface LocalForageDbMethods {
+    getItem<T>(key: string): Promise<T>;
+    getItem<T>(key: string, callback: (err: any, value: T) => void): void;
+
+    setItem<T>(key: string, value: T): Promise<T>;
+    setItem<T>(key: string, value: T, callback: (err: any, value: T) => void): void;
+
+    removeItem(key: string): Promise<void>;
+    removeItem(key: string, callback: (err: any) => void): void;
+
+    clear(): Promise<void>;
+    clear(callback: (err: any) => void): void;
+
+    length(): Promise<number>;
+    length(callback: (err: any, numberOfKeys: number) => void): void;
+
+    key(keyIndex: number): Promise<string>;
+    key(keyIndex: number, callback: (err: any, key: string) => void): void;
+
+    keys(): Promise<string[]>;
+    keys(callback: (err: any, keys: string[]) => void): void;
+
+    iterate(iteratee: (value: any, key: string, iterationNumber: number) => any): Promise<any>;
+    iterate(iteratee: (value: any, key: string, iterationNumber: number) => any,
+            callback: (err: any, result: any) => void): void;
+}
+
+interface LocalForageDriver extends LocalForageDbMethods {
     _driver: string;
 
     _initStorage(options: LocalForageOptions): void;
 
     _support: boolean | Promise<boolean>;
-
-    clear(callback: (err: any) => void): void;
-
-    getItem(key: string, callback: (err: any, value: any) => void): void;
-
-    key(keyIndex: number, callback: (err: any, key: string) => void): void;
-
-    keys(callback: (err: any, keys: string[]) => void): void;
-
-    length(callback: (err: any, numberOfKeys: number) => void): void;
-
-    removeItem(key: string, callback: (err: any) => void): void;
-
-    setItem(key: string, value: any, callback: (err: any, value: any) => void): void;
 }
 
 interface LocalForageSerializer {
@@ -49,7 +62,7 @@ interface LocalForageSerializer {
     bufferToString(buffer: ArrayBuffer): string;
 }
 
-interface LocalForage {
+interface LocalForage extends LocalForageDbMethods {
     LOCALSTORAGE: string;
     WEBSQL: string;
     INDEXEDDB: string;
@@ -82,31 +95,6 @@ interface LocalForage {
     getSerializer(callback: (serializer: LocalForageSerializer) => void): void;
 
     supports(driverName: string): boolean;
-
-    getItem<T>(key: string): Promise<T>;
-    getItem<T>(key: string, callback: (err: any, value: T) => void): void;
-
-    setItem<T>(key: string, value: T): Promise<T>;
-    setItem<T>(key: string, value: T, callback: (err: any, value: T) => void): void;
-
-    removeItem(key: string): Promise<void>;
-    removeItem(key: string, callback: (err: any) => void): void;
-
-    clear(): Promise<void>;
-    clear(callback: (err: any) => void): void;
-
-    length(): Promise<number>;
-    length(callback: (err: any, numberOfKeys: number) => void): void;
-
-    key(keyIndex: number): Promise<string>;
-    key(keyIndex: number, callback: (err: any, key: string) => void): void;
-
-    keys(): Promise<string[]>;
-    keys(callback: (err: any, keys: string[]) => void): void;
-
-    iterate(iteratee: (value: any, key: string, iterationNumber: number) => any): Promise<any>;
-    iterate(iteratee: (value: any, key: string, iterationNumber: number) => any,
-            callback: (err: any, result: any) => void): void;
 }
 
 declare module "localforage" {

--- a/localForage/localForage.d.ts
+++ b/localForage/localForage.d.ts
@@ -44,12 +44,16 @@ interface LocalForageDbMethods {
             callback: (err: any, result: any) => void): void;
 }
 
+interface LocalForageDriverSupportFunc {
+    (): Promise<boolean>;
+}
+
 interface LocalForageDriver extends LocalForageDbMethods {
     _driver: string;
 
     _initStorage(options: LocalForageOptions): void;
 
-    _support: boolean | Promise<boolean>;
+    _support: boolean | LocalForageDriverSupportFunc;
 }
 
 interface LocalForageSerializer {
@@ -90,6 +94,11 @@ interface LocalForage extends LocalForageDbMethods {
     setDriver(driver: string | string[], callback: () => void, errorCallback: (error: any) => void): void;
     defineDriver(driver: LocalForageDriver): Promise<void>;
     defineDriver(driver: LocalForageDriver, callback: () => void, errorCallback: (error: any) => void): void;
+    /**
+    * Return a particular driver
+    * @param {string} driver
+    */
+    getDriver(driver: string): Promise<LocalForageDriver>;
 
     getSerializer(): Promise<LocalForageSerializer>;
     getSerializer(callback: (serializer: LocalForageSerializer) => void): void;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- created a DbMethods interface since [the driver methods are copied to the localforage object](https://github.com/localForage/localForage/blob/master/src/localforage.js#L292) and as a result, should have the same definitions and not be repeated
- [fixes definition of _support](https://github.com/localForage/localForage/blob/master/src/localforage.js#L196-L202)
