### PR TITLE
yargs: fix fail API

### DIFF
--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -5,7 +5,7 @@
 
 /// <reference path="yargs.d.ts" />
 
-import yargs = require('yargs');
+import * as yargs from 'yargs';
 
 // Examples taken from yargs website
 // https://github.com/chevex/yargs

--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -4,6 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="yargs.d.ts" />
+/// <reference path="../node/node.d.ts"/>
 
 import * as yargs from 'yargs';
 
@@ -340,6 +341,18 @@ function Argv$commandDirWithOptions() {
 			visit: (commandObject: any, pathToFile: string, filename: string) => { },
 			include: /.*\.js$/,
 			exclude: /.*\.spec.js$/,
+		})
+		.argv
+}
+
+// http://yargs.js.org/docs/#methods-failfn
+function Argv$fail() {
+	var argv = yargs
+		.fail(function (msg, err) {
+			if (err) throw err // preserve stack
+			console.error('You broke it!')
+			console.error(msg)
+			process.exit(1)
 		})
 		.argv
 }

--- a/yargs/yargs.d.ts
+++ b/yargs/yargs.d.ts
@@ -135,7 +135,7 @@ declare module "yargs" {
 			count(key: string): Argv;
 			count(keys: string[]): Argv;
 
-			fail(func: (msg: string) => any): void;
+			fail(func: (msg: string, err: Error) => any): Argv;
 		}
 
 		interface RequireDirectoryOptions {


### PR DESCRIPTION
Fixed compilation with `--target es6` and fixed the changed API: http://yargs.js.org/docs/#methods-failfn.
