### PR TITLE
Missing type for combineActions + minor changes

### DIFF
--- a/redux-actions/redux-actions.d.ts
+++ b/redux-actions/redux-actions.d.ts
@@ -54,20 +54,34 @@ declare namespace ReduxActions {
         metaCreator: MetaCreator<Input, Meta>
     ): (...args: Input[]) => ActionMeta<Payload, Meta>;
 
+    export function handleAction<StateAndPayload>(
+        actionType: { toString: () => string },
+        reducer: Reducer<StateAndPayload, StateAndPayload> | ReducerMap<StateAndPayload, StateAndPayload>
+    ): Reducer<StateAndPayload, StateAndPayload>;
+
     export function handleAction<State, Payload>(
-        actionType: string,
+        actionType: { toString: () => string },
         reducer: Reducer<State, Payload> | ReducerMap<State, Payload>
     ): Reducer<State, Payload>;
 
     export function handleAction<State, Payload, Meta>(
-        actionType: string,
+        actionType: { toString: () => string },
         reducer: ReducerMeta<State, Payload, Meta> | ReducerMap<State, Payload>
     ): Reducer<State, Payload>;
+
+    export function handleActions<StateAndPayload>(
+        reducerMap: ReducerMap<StateAndPayload, StateAndPayload>,
+        initialState?: StateAndPayload
+    ): Reducer<StateAndPayload, StateAndPayload>;
 
     export function handleActions<State, Payload>(
         reducerMap: ReducerMap<State, Payload>,
         initialState?: State
     ): Reducer<State, Payload>;
+
+    export function combineActions(
+        ...actionTypes: { toString: () => string }[]
+    ): { toString: () => string };
 }
 
 declare module 'redux-actions' {


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Added the combineActions function as that was completely missing. The actionType parameter should be any object with a toString method (including the native string object). Also added convenience definitions for handleAction and handleActions in cases where state and payload is the same (like the same convenience definition for createAction).
