### PR TITLE
EaselJS: add missing ScaleBitmap class

### DIFF
--- a/easeljs/easeljs.d.ts
+++ b/easeljs/easeljs.d.ts
@@ -52,7 +52,22 @@ declare namespace createjs {
         // methods
         clone(): Bitmap;
     }
+    
+    export class ScaleBitmap extends DisplayObject {
+        constructor(imageOrUrl: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | Object | string, scale9Grid: Rectangle);
 
+        // properties
+        image: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement;
+        sourceRect: Rectangle;
+        drawWidth: number;
+        drawHeight: number;
+        scale9Grid: Rectangle;
+        snapToPixel: boolean;
+
+        // methods
+        setDrawSize (newWidth: number, newHeight: number): void;
+        clone(): ScaleBitmap;
+    }
 
     export class BitmapText extends DisplayObject {
         constructor(text?:string, spriteSheet?:SpriteSheet);


### PR DESCRIPTION
Here's the source code that have the changes I'm proposing: https://github.com/CreateJS/EaselJS/blob/9b4a11f793d396290650619b1bc40b824b8d8571/extras/ScaleBitmap/ScaleBitmap.js#L49-L117

The `ScaleBitmap` class is not documented on the [official docs](http://createjs.com/docs/easeljs/) unfortunately. 
