### PR TITLE
Fixes #11798 [wiring-pi] wiring-pi needs to be updated

### DIFF
--- a/wiring-pi/wiring-pi-tests.ts
+++ b/wiring-pi/wiring-pi-tests.ts
@@ -55,6 +55,7 @@ read = wpi.wiringPiI2CReadReg8(fd, 2);
 read = wpi.wiringPiI2CReadReg16(fd, 2);
 ret = wpi.wiringPiI2CWriteReg8(fd, 2, read);
 ret = wpi.wiringPiI2CWriteReg16(fd, 2, read);
+wpi.wiringPiI2CClose(fd);
 // SPI
 fd = wpi.wiringPiSPIGetFd(2);
 fd = wpi.wiringPiSPISetup(2, 32000000);
@@ -62,6 +63,7 @@ fd = wpi.wiringPiSPISetupMode(2, 32000000, 3);
 let buff: Buffer = new Buffer("spi data");
 ret = wpi.wiringPiSPIDataRW(2, buff);
 console.log(buff.toString());
+wpi.wiringPiSPIClose(fd);
 // Serial
 fd = wpi.serialOpen('/dev/AMA0', 9600);
 wpi.serialFlush(fd);

--- a/wiring-pi/wiring-pi.d.ts
+++ b/wiring-pi/wiring-pi.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for wiring-pi 2.1.1
+// Type definitions for wiring-pi 2.2.0
 // Project: https://github.com/eugeneware/wiring-pi
 // Definitions by: Ivo Stratev <https://github.com/NoHomey>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -116,6 +116,7 @@ declare module 'wiring-pi' {
     // I2C
     export function wiringPiI2CSetup(devId: number): number;
     export function wiringPiI2CSetupInterface(device: string, devId: number): number;
+    export function wiringPiI2CClose(fd: number): void;
     export function wiringPiI2CRead(fd: number): number;
     export function wiringPiI2CReadReg8(fd: number, reg: number): number;
     export function wiringPiI2CReadReg16(fd: number, reg: number): number;
@@ -127,6 +128,7 @@ declare module 'wiring-pi' {
     export function wiringPiSPIDataRW(channel: number, data: Buffer): number;
     export function wiringPiSPISetup(channel: number, speed: number): number;
     export function wiringPiSPISetupMode(channel: number, speed: number, mode: number): number;
+    export function wiringPiSPIClose(fd: number): void;
     // Serial
     export function serialOpen(device: string, baudrate: number): number;
     export function serialClose(fd: number): void;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes. https://github.com/eugeneware/wiring-pi/blob/master/DOCUMENTATION.md#wiringpii2cclosefd, https://github.com/eugeneware/wiring-pi/blob/master/DOCUMENTATION.md#wiringpispiclosefd

Updating wiring-pi to match [v2.2.0](https://github.com/eugeneware/wiring-pi/releases/tag/v2.2.0).
