### PR TITLE
Add typings for sass-graph

### DIFF
--- a/sass-graph/sass-graph-tests.ts
+++ b/sass-graph/sass-graph-tests.ts
@@ -1,0 +1,8 @@
+/// <reference path="sass-graph.d.ts" />
+
+import { parseFile, parseDir, Graph } from "sass-graph";
+
+// Example copied from readme:
+// https://github.com/xzyfer/sass-graph/blob/master/readme.md
+const graph1: Graph = parseFile("test/fixtures/main.scss");
+const graph2: Graph = parseDir("test/fixtures");

--- a/sass-graph/sass-graph.d.ts
+++ b/sass-graph/sass-graph.d.ts
@@ -1,0 +1,81 @@
+// Type definitions for sass-graph v2.1.2
+// Project: https://github.com/xzyfer/sass-graph
+// Definitions by: Marvin Hagemeister <https://github.com/marvinhagemeister>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace SassGraph {
+
+  export interface Options {
+    loadPath?: string[];
+    extensions?: string[];
+  }
+
+  type Node = {
+    [filepath: string]: {
+      imports: string[];
+      importedBy: string[];
+      modified: string;
+    }
+  }
+
+  /**
+   * @class Graph
+   */
+  export interface Graph {
+    dir: string;
+    loadPaths: string[];
+    extensions: string[];
+    index: Node;
+
+    /**
+     * Add a sass file to the graph
+     * @param {string} filepath Path to the file to visit
+     * @param {string} [parent] Parent filepath
+     */
+    addFile(filepath: string, parent?: string): void;
+
+    /**
+     * visits all files that are ancestors of the provided file
+     * @param {string}   filepath Path to the file to visit
+     * @param {Function} callback Called when a node is visited
+     */
+    visitAncestors(filepath: string, callback: (edge: string, node: Node) => any): void;
+
+    /**
+     * Visits all files that are descendents of the provided file
+     * @param {string}   filepath Path to the file to visit
+     * @param {Function} callback Called when a node is visited
+     */
+    visitDescendents(filepath: string, callback: (edge: string, node: Node) => any): void;
+
+    /**
+     * A generic visitor that uses an edgeCallback to find the edges to traverse
+     * for a node
+     * @param {string}   filepath     Path to the file to visit
+     * @param {Function} callback     Called when a node is visited
+     * @param {Function} edgeCallback Called when we reach an edge
+     * @param {string[]} [visited]    Visited edges
+     */
+    visit(filepath: string, callback: (edge: string, node: Node) => any, edgeCallback: (errorMsg: string, node: Node) => any, visited?: string[]): void;
+  }
+
+  /**
+   * @function {parseFile} Get the dependency tree of a single file
+   * @param {string} filepath  Path to file which should be parsed
+   * @param {Object} [options] Parsing options
+   * @return {Graph}
+   */
+  export function parseFile(filepath: string, options?: Options): Graph;
+
+  /**
+   * @function {parseDir} Get the dependency tree of all sass files in a folder
+   * @param {string} dirpath   Folder which should be parsed
+   * @param {Object} [options] Parsing options
+   * @return {Graph}
+   */
+  export function parseDir(dirpath: string, options?: Options): Graph;
+}
+
+declare module "sass-graph" {
+    export = SassGraph;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
