### PR TITLE
[openlayers] update color type to tuple

### DIFF
--- a/openlayers/openlayers-tests.ts
+++ b/openlayers/openlayers-tests.ts
@@ -1,86 +1,87 @@
 /// <reference path="openlayers.d.ts" />
 
 // Basic type variables for test functions
-var anyValue: any;
-var voidValue: void;
-var numberValue: number;
-var booleanValue: boolean;
-var stringValue: string;
-var stringArray: Array<string>;
-var jsonValue: JSON;
-var voidOrBooleanValue: void | boolean;
-var domEventTarget: EventTarget;
-var fn: Function;
-var object: Object;
+let anyValue: any;
+let voidValue: void;
+let numberValue: number;
+let booleanValue: boolean;
+let stringValue: string;
+let stringArray: Array<string>;
+let jsonValue: JSON;
+let voidOrBooleanValue: void | boolean;
+let domEventTarget: EventTarget;
+let fn: Function;
+let object: Object;
 
 // Callback predefinitions for OpenLayers
-var preRenderFunction: ol.PreRenderFunction;
-var transformFunction: ol.TransformFunction;
-var coordinateFormatType: ol.CoordinateFormatType;
-var featureStyleFunction: ol.FeatureStyleFunction;
-var featureLoader: ol.FeatureLoader;
-var easingFunction: (t: number) => number;
-var drawGeometryFunction: ol.DrawGeometryFunctionType;
+let preRenderFunction: ol.PreRenderFunction;
+let transformFunction: ol.TransformFunction;
+let coordinateFormatType: ol.CoordinateFormatType;
+let featureStyleFunction: ol.FeatureStyleFunction;
+let featureLoader: ol.FeatureLoader;
+let easingFunction: (t: number) => number;
+let drawGeometryFunction: ol.DrawGeometryFunctionType;
 
 // Type variables for OpenLayers
-var attribution: ol.Attribution;
-var boundingCoordinates: Array<ol.Coordinate>;
-var circle: ol.geom.Circle;
-var color: ol.Color;
-var coordinate: ol.Coordinate;
-var coordinatesArray: Array<ol.Coordinate>;
-var coordinatesArrayDim2: Array<Array<ol.Coordinate>>;
-var extent: ol.Extent;
-var olEvent: ol.events.Event;
-var eventKey: ol.EventsKey;
-var eventKeyArray: Array<ol.EventsKey>;
-var eventKeyMixed: ol.EventsKey | Array<ol.EventsKey>;
-var eventTarget: ol.events.EventTarget;
-var feature: ol.Feature;
-var featureArray: Array<ol.Feature>;
-var featureCollection: ol.Collection<ol.Feature>;
-var featureFormat: ol.format.Feature;
-var featureUrlFunction: ol.FeatureUrlFunction;
-var graticule: ol.Graticule;
-var geometriesArray: Array<ol.geom.Geometry>;
-var geometry: ol.geom.Geometry;
-var geometryCollection: ol.geom.GeometryCollection;
-var geometryLayout: ol.geom.GeometryLayout;
-var geometryType: ol.geom.GeometryType;
-var linearRing: ol.geom.LinearRing;
-var lineString: ol.geom.LineString;
-var loadingStrategy: ol.LoadingStrategy;
-var logoOptions: olx.LogoOptions;
-var mapBrowserEvent: ol.MapBrowserEvent;
-var multiLineString: ol.geom.MultiLineString;
-var multiPoint: ol.geom.MultiPoint;
-var multiPolygon: ol.geom.MultiPolygon;
-var point: ol.geom.Point;
-var polygon: ol.geom.Polygon;
-var projection: ol.proj.Projection;
-var projectionLike: ol.ProjectionLike;
-var simpleGeometry: ol.geom.SimpleGeometry;
-var size: ol.Size;
-var style: ol.style.Style;
-var styleArray: Array<ol.style.Style>;
-var styleFunction: ol.StyleFunction;
-var tilegrid: ol.tilegrid.TileGrid;
-var transformFn: ol.TransformFunction;
-var vectorSource: ol.source.Vector;
-var units: ol.proj.Units;
-var styleRegularShape: ol.style.RegularShape;
+let attribution: ol.Attribution;
+let boundingCoordinates: Array<ol.Coordinate>;
+let circle: ol.geom.Circle;
+let color: ol.Color;
+let coordinate: ol.Coordinate;
+let coordinatesArray: Array<ol.Coordinate>;
+let coordinatesArrayDim2: Array<Array<ol.Coordinate>>;
+let extent: ol.Extent;
+let olEvent: ol.events.Event;
+let eventKey: ol.EventsKey;
+let eventKeyArray: Array<ol.EventsKey>;
+let eventKeyMixed: ol.EventsKey | Array<ol.EventsKey>;
+let eventTarget: ol.events.EventTarget;
+let feature: ol.Feature;
+let featureArray: Array<ol.Feature>;
+let featureCollection: ol.Collection<ol.Feature>;
+let featureFormat: ol.format.Feature;
+let featureUrlFunction: ol.FeatureUrlFunction;
+let graticule: ol.Graticule;
+let geometriesArray: Array<ol.geom.Geometry>;
+let geometry: ol.geom.Geometry;
+let geometryCollection: ol.geom.GeometryCollection;
+let geometryLayout: ol.geom.GeometryLayout;
+let geometryType: ol.geom.GeometryType;
+let linearRing: ol.geom.LinearRing;
+let lineString: ol.geom.LineString;
+let loadingStrategy: ol.LoadingStrategy;
+let logoOptions: olx.LogoOptions;
+let mapBrowserEvent: ol.MapBrowserEvent;
+let multiLineString: ol.geom.MultiLineString;
+let multiPoint: ol.geom.MultiPoint;
+let multiPolygon: ol.geom.MultiPolygon;
+let point: ol.geom.Point;
+let polygon: ol.geom.Polygon;
+let projection: ol.proj.Projection;
+let projectionLike: ol.ProjectionLike;
+let simpleGeometry: ol.geom.SimpleGeometry;
+let size: ol.Size;
+let style: ol.style.Style;
+let styleArray: Array<ol.style.Style>;
+let styleFunction: ol.StyleFunction;
+let tilegrid: ol.tilegrid.TileGrid;
+let transformFn: ol.TransformFunction;
+let vectorSource: ol.source.Vector;
+let units: ol.proj.Units;
+let styleRegularShape: ol.style.RegularShape;
 
 //
 // ol.Attribution
 //
 
-var attribution: ol.Attribution = new ol.Attribution({
+attribution = new ol.Attribution({
     html: stringValue,
 });
 
 //
 // ol.color
 //
+color = [255, 255, 255, 1.0];
 color = ol.color.asArray(color);
 color = ol.color.asArray(stringValue);
 stringValue = ol.color.asString(color);
@@ -90,15 +91,15 @@ stringValue = ol.color.asString(stringValue);
 // ol.extent
 //
 transformFunction = function (input: number[]) {
-    var returnData: number[];
+    let returnData: number[];
     return returnData;
 };
 transformFunction = function (input: number[], output: number[]) {
-    var returnData: number[];
+    let returnData: number[];
     return returnData;
 };
 transformFunction = function (input: number[], output: number[], dimension: number) {
-    var returnData: number[];
+    let returnData: number[];
     return returnData;
 }
 extent = ol.extent.applyTransform(extent, transformFunction);
@@ -148,7 +149,7 @@ circle = <ol.geom.Circle>circle.transform(projectionLike, projectionLike);
 //
 // ol.geom.Geometry
 //
-var geometryResult: ol.geom.Geometry;
+let geometryResult: ol.geom.Geometry;
 coordinate = geometryResult.getClosestPoint(coordinate);
 geometryResult.getClosestPoint(coordinate, coordinate);
 extent = geometryResult.getExtent();
@@ -202,7 +203,7 @@ voidValue = lineString.setCoordinates(coordinatesArray, geometryLayout);
 //
 // ol.geom.MultiLineString
 //
-var lineStringsArray: Array<ol.geom.LineString>;
+let lineStringsArray: Array<ol.geom.LineString>;
 
 multiLineString = new ol.geom.MultiLineString(coordinatesArrayDim2);
 multiLineString = new ol.geom.MultiLineString(coordinatesArrayDim2, geometryLayout);
@@ -223,7 +224,7 @@ voidValue = multiLineString.setCoordinates(coordinatesArrayDim2, geometryLayout)
 //
 // ol.geom.MultiPoint
 //
-var pointsArray: Array<ol.geom.Point>;
+let pointsArray: Array<ol.geom.Point>;
 
 multiPoint = new ol.geom.MultiPoint(coordinatesArray);
 multiPoint = new ol.geom.MultiPoint(coordinatesArray, geometryLayout);
@@ -241,8 +242,8 @@ voidValue = multiPoint.setCoordinates(coordinatesArray, geometryLayout);
 //
 // ol.geom.MultiPolygon
 //
-var coordinatesArrayDim3: Array<Array<Array<ol.Coordinate>>>;
-var polygonsArray: Array<ol.geom.Polygon>;
+let coordinatesArrayDim3: Array<Array<Array<ol.Coordinate>>>;
+let polygonsArray: Array<ol.geom.Polygon>;
 
 multiPolygon = new ol.geom.MultiPolygon(coordinatesArrayDim3);
 multiPolygon = new ol.geom.MultiPolygon(coordinatesArrayDim3, geometryLayout);
@@ -276,8 +277,8 @@ voidValue = point.setCoordinates(coordinate, geometryLayout);
 //
 // ol.geom.Polygon
 //
-var localSphere: ol.Sphere;
-var linearRingsArray: Array<ol.geom.LinearRing>;
+let localSphere: ol.Sphere;
+let linearRingsArray: Array<ol.geom.LinearRing>;
 
 polygon = new ol.geom.Polygon(coordinatesArrayDim2);
 polygon = new ol.geom.Polygon(coordinatesArrayDim2, geometryLayout);
@@ -314,7 +315,7 @@ voidValue = simpleGeometry.translate(numberValue, numberValue);
 //
 // ol.source
 //
-var featureCallback: (f: ol.Feature) => any;
+let featureCallback: (f: ol.Feature) => any;
 vectorSource = new ol.source.Vector({
     attributions: [attribution],
     features: featureCollection,
@@ -366,8 +367,8 @@ feature = new ol.Feature({
 feature = feature.clone();
 geometry = feature.getGeometry();
 stringValue = feature.getGeometryName();
-var featureGetId: string | number = feature.getId();
-var featureGetStyle: ol.style.Style | Array<ol.style.Style> | ol.FeatureStyleFunction = feature.getStyle();
+let featureGetId: string | number = feature.getId();
+let featureGetStyle: ol.style.Style | Array<ol.style.Style> | ol.FeatureStyleFunction = feature.getStyle();
 featureStyleFunction = feature.getStyleFunction();
 voidValue = feature.setGeometry(geometry);
 voidValue = feature.setGeometryName(stringValue);
@@ -382,7 +383,7 @@ voidValue = feature.setProperties(object);
 // ol.View
 //
 
-var view: ol.View = new ol.View({
+let view: ol.View = new ol.View({
     center: [0, 0],
     zoom: numberValue,
 });
@@ -390,14 +391,14 @@ var view: ol.View = new ol.View({
 //
 // ol.layer.Tile
 //
-var tileLayer: ol.layer.Tile = new ol.layer.Tile({
+let tileLayer: ol.layer.Tile = new ol.layer.Tile({
     source: new ol.source.OSM()
 });
 
 //
 // ol.Object
 //
-var olObject: ol.Object = new ol.Object({
+let olObject: ol.Object = new ol.Object({
     a: numberValue,
     b: stringValue,
     c: booleanValue,
@@ -417,7 +418,7 @@ voidValue = olObject.unset(stringValue, booleanValue);
 // ol.Observable
 //
 ol.Observable.unByKey(eventKey);
-var observable: ol.Observable = new ol.Observable();
+let observable: ol.Observable = new ol.Observable();
 voidValue = observable.changed();
 voidOrBooleanValue = observable.dispatchEvent({type: stringValue});
 voidOrBooleanValue = observable.dispatchEvent({type: stringValue, target: domEventTarget});
@@ -438,7 +439,7 @@ voidValue = observable.unByKey(eventKeyArray);
 //
 // ol.proj
 //
-var getPointResolutionFn: (n: number, c: ol.Coordinate) => number;
+let getPointResolutionFn: (n: number, c: ol.Coordinate) => number;
 projection = new ol.proj.Projection({
     code:stringValue,
 });
@@ -458,7 +459,7 @@ voidValue = projection.setWorldExtent(extent);
 // ol.Map
 //
 
-var map: ol.Map = new ol.Map({
+let map: ol.Map = new ol.Map({
     view: view,
     layers: [tileLayer],
     target: stringValue
@@ -468,7 +469,7 @@ voidValue = map.beforeRender(preRenderFunction);
 //
 // ol.source.ImageWMS
 //
-var imageWMS: ol.source.ImageWMS = new ol.source.ImageWMS({
+let imageWMS: ol.source.ImageWMS = new ol.source.ImageWMS({
     params: {},
     projection: projection,
     serverType: stringValue,
@@ -484,7 +485,7 @@ projection = source.getProjection();
 //
 // ol.source.TileWMS
 //
-var tileWMS: ol.source.TileWMS = new ol.source.TileWMS({
+let tileWMS: ol.source.TileWMS = new ol.source.TileWMS({
     params: {},
     projection: projection,
     serverType: stringValue,
@@ -497,7 +498,7 @@ stringValue = tileWMS.getGetFeatureInfoUrl([0, 0], 1, "EPSG:4326", {});
 //
 // ol.source.WMTS
 //
-var wmts: ol.source.WMTS = new ol.source.WMTS({
+let wmts: ol.source.WMTS = new ol.source.WMTS({
     layer: "",
     projection: projection,
     matrixSet: "",
@@ -512,21 +513,21 @@ var wmts: ol.source.WMTS = new ol.source.WMTS({
 //
 // ol.animation
 //
-var bounceOptions: olx.animation.BounceOptions;
+let bounceOptions: olx.animation.BounceOptions;
 bounceOptions.duration = numberValue;
 bounceOptions.start = numberValue;
 bounceOptions.resolution = numberValue;
 bounceOptions.easing = easingFunction;
 preRenderFunction = ol.animation.bounce(bounceOptions);
 
-var panOptions: olx.animation.PanOptions;
+let panOptions: olx.animation.PanOptions;
 panOptions.duration = numberValue;
 panOptions.start = numberValue;
 panOptions.source = coordinate;
 panOptions.easing = easingFunction;
 preRenderFunction = ol.animation.pan(panOptions);
 
-var rotateOptions: olx.animation.RotateOptions;
+let rotateOptions: olx.animation.RotateOptions;
 rotateOptions.duration = numberValue;
 rotateOptions.start = numberValue;
 rotateOptions.anchor = coordinate;
@@ -534,7 +535,7 @@ rotateOptions.rotation = numberValue;
 rotateOptions.easing = easingFunction;
 preRenderFunction = ol.animation.rotate(rotateOptions);
 
-var zoomOptions: olx.animation.ZoomOptions;
+let zoomOptions: olx.animation.ZoomOptions;
 zoomOptions.duration = numberValue;
 zoomOptions.start = numberValue;
 zoomOptions.resolution = numberValue;
@@ -570,7 +571,7 @@ easingFunction = ol.easing.upAndDown;
 //
 // ol.Geolocation
 //
-var geolocation: ol.Geolocation = new ol.Geolocation({
+let geolocation: ol.Geolocation = new ol.Geolocation({
     projection: projection
 });
 coordinate = geolocation.getPosition();
@@ -583,16 +584,16 @@ graticule = new ol.Graticule();
 graticule = new ol.Graticule({
     map: map,
 });
-var graticuleMap: ol.Map = graticule.getMap();
-var graticuleMeridians: Array<ol.geom.LineString> = graticule.getMeridians();
-var graticuleParallels: Array<ol.geom.LineString> = graticule.getParallels();
+let graticuleMap: ol.Map = graticule.getMap();
+let graticuleMeridians: Array<ol.geom.LineString> = graticule.getMeridians();
+let graticuleParallels: Array<ol.geom.LineString> = graticule.getParallels();
 voidValue = graticule.setMap(graticuleMap);
 
 //
 // ol.DeviceOrientation
 //
 
-var deviceOrientation: ol.DeviceOrientation = new ol.DeviceOrientation({
+let deviceOrientation: ol.DeviceOrientation = new ol.DeviceOrientation({
     tracking: true,
 });
 numberValue = deviceOrientation.getHeading();
@@ -601,15 +602,15 @@ numberValue = deviceOrientation.getHeading();
 // ol.Overlay
 //
 
-var popup: ol.Overlay = new ol.Overlay({
+let popup: ol.Overlay = new ol.Overlay({
     element: document.getElementById('popup')
 });
 voidValue = map.addOverlay(popup);
-var popupElement: Element = popup.getElement();
-var popupMap: ol.Map = popup.getMap();
-var popupOffset: Array<number> = popup.getOffset();
+let popupElement: Element = popup.getElement();
+let popupMap: ol.Map = popup.getMap();
+let popupOffset: Array<number> = popup.getOffset();
 coordinate = popup.getPosition();
-var popupPositioning: ol.OverlayPositioning = popup.getPositioning();
+let popupPositioning: ol.OverlayPositioning = popup.getPositioning();
 voidValue = popup.setElement(popupElement);
 voidValue = popup.setMap(popupMap);
 voidValue = popup.setOffset(popupOffset);
@@ -621,23 +622,23 @@ voidValue = popup.setPositioning(popupPositioning);
 // ol.format.GeoJSON
 //
 
-var geojsonOptions: olx.format.GeoJSONOptions;
+let geojsonOptions: olx.format.GeoJSONOptions;
 geojsonOptions.defaultDataProjection = "EPSG";
 geojsonOptions.defaultDataProjection = projection;
 geojsonOptions.geometryName = "geom";
 
-var geojsonFormat: ol.format.GeoJSON;
+let geojsonFormat: ol.format.GeoJSON;
 geojsonFormat = new ol.format.GeoJSON();
 geojsonFormat = new ol.format.GeoJSON(geojsonOptions);
 
 // Test options
-var readOptions: olx.format.ReadOptions;
+let readOptions: olx.format.ReadOptions;
 readOptions.dataProjection = "EPSG";
 readOptions.dataProjection = projection;
 readOptions.featureProjection = "EPSG";
 readOptions.featureProjection = projection;
 
-var writeOptions: olx.format.WriteOptions;
+let writeOptions: olx.format.WriteOptions;
 writeOptions.dataProjection = "EPSG";
 writeOptions.dataProjection = projection;
 writeOptions.featureProjection = "EPSG";
@@ -667,11 +668,11 @@ jsonValue = geojsonFormat.writeGeometryObject(geometry, writeOptions);
 //
 // ol.interactions
 //
-var modify: ol.interaction.Modify = new ol.interaction.Modify({
+let modify: ol.interaction.Modify = new ol.interaction.Modify({
     features: new ol.Collection<ol.Feature>(featureArray)
 });
 
-var draw: ol.interaction.Draw = new ol.interaction.Draw({
+let draw: ol.interaction.Draw = new ol.interaction.Draw({
     type: "Point",
     clickTolerance: numberValue,
     features: new ol.Collection([]),
@@ -694,29 +695,29 @@ draw = new ol.interaction.Draw({
     type: "Point",
     style: styleFunction
 });
-var styleFunctionAsStyle = function(feature: ol.Feature, resolution: number): ol.style.Style { return style; }
+let styleFunctionAsStyle = function(feature: ol.Feature, resolution: number): ol.style.Style { return style; }
 draw = new ol.interaction.Draw({
     type: "Point",
     style: styleFunctionAsStyle
 });
-var styleFunctionAsArray = function(feature: ol.Feature, resolution: number): ol.style.Style[] { return styleArray; }
+let styleFunctionAsArray = function(feature: ol.Feature, resolution: number): ol.style.Style[] { return styleArray; }
 draw = new ol.interaction.Draw({
     type: "Point",
     style: styleFunctionAsArray
 });
 
-var dragbox: ol.interaction.DragBox = new ol.interaction.DragBox({
+let dragbox: ol.interaction.DragBox = new ol.interaction.DragBox({
     className: stringValue,
     condition: ol.events.condition.always,
     boxEndCondition: function (mapBrowserEvent: ol.MapBrowserEvent, startPixel: ol.Pixel, endPixel: ol.Pixel) {
-        var width: number = endPixel[0] - startPixel[0];
-        var height: number = endPixel[1] - startPixel[1];
+        let width: number = endPixel[0] - startPixel[0];
+        let height: number = endPixel[1] - startPixel[1];
         return booleanValue;
     }
 });
 polygon = dragbox.getGeometry();
 
-var interaction: ol.interaction.Interaction = new ol.interaction.Interaction({
+let interaction: ol.interaction.Interaction = new ol.interaction.Interaction({
     handleEvent: function (e: ol.MapBrowserEvent) {
         return booleanValue;
     }

--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -10966,7 +10966,7 @@ declare module ol {
      * given then `1` will be used.
      * @typedef {Array.<number>|Uint8Array|Uint8ClampedArray}
      */
-    type Color = (number[] | Uint8Array | Uint8ClampedArray);
+    type Color = ([number, number, number, number] | Uint8Array | Uint8ClampedArray);
 
     /**
      * A type accepted by CanvasRenderingContext2D.fillStyle.


### PR DESCRIPTION
According to the [documentation](http://openlayers.org/en/latest/apidoc/ol.html#.Color), the color type can be represented as a short array [red, green, blue, alpha]. The type has been changed to a tuple to fit the description.
