### PR TITLE
Add missing chrome-app to the @types/chrome pkg

### DIFF
--- a/chrome/chrome-app.d.ts
+++ b/chrome/chrome-app.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Adam Lay <https://github.com/AdamLay>, MIZUNE Pine <https://github.com/pine613>, MIZUSHIMA Junki <https://github.com/mzsm>, Ingvar Stepanyan <https://github.com/RReverser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="chrome.d.ts"/>
+/// <reference path="index.d.ts"/>
 /// <reference types="filesystem"/>
 
 ////////////////////

--- a/chrome/tsconfig.json
+++ b/chrome/tsconfig.json
@@ -14,6 +14,9 @@
     },
     "files": [
         "index.d.ts",
+        "chrome-app.d.ts",
+        "chrome-app-tests.d.ts",
+        "chrome-cast.d.ts",
         "chrome-tests.ts"
     ]
 }


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Based on mhegazy comment at https://github.com/Microsoft/types-publisher/issues/68#issuecomment-252104274
