### PR TITLE
Openlayers remove self:, optional projections

### DIFF
--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -13251,7 +13251,7 @@ declare module olx {
             crossOrigin?: (string);
             logo?: (string | olx.LogoOptions);
             opaque?: boolean;
-            projection: ol.ProjectionLike;
+            projection?: ol.ProjectionLike;
             reprojectionErrorThreshold?: number;
             maxZoom?: number;
             minZoom?: number;

--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -10957,7 +10957,7 @@ declare module ol {
      * @typedef {function(this:ol.source.ImageCanvas, ol.Extent, number,
      *     number, ol.Size, ol.proj.Projection): HTMLCanvasElement}
      */
-    type CanvasFunctionType = (self: ol.source.ImageCanvas, extent: ol.Extent, resolution: number, pixelRatio: number, size: ol.Size, proj: ol.proj.Projection) => HTMLCanvasElement;
+    type CanvasFunctionType = (extent: ol.Extent, resolution: number, pixelRatio: number, size: ol.Size, proj: ol.proj.Projection) => HTMLCanvasElement;
 
     /**
      * A color represented as a short array [red, green, blue, alpha].
@@ -11050,7 +11050,7 @@ declare module ol {
      * @typedef {function(this:ol.source.Vector, ol.Extent, number,
      *                    ol.proj.Projection)}
      */
-    type FeatureLoader = (self: ol.source.Vector, extent: ol.Extent, resolution: number, proj: ol.proj.Projection) => void;
+    type FeatureLoader = (extent: ol.Extent, resolution: number, proj: ol.proj.Projection) => void;
 
     /**
      * A function that returns an array of {@link ol.style.Style styles} given a
@@ -11060,7 +11060,7 @@ declare module ol {
      * @typedef {function(this: ol.Feature, number):
      *     (ol.style.Style|Array.<ol.style.Style>)}
      */
-    type FeatureStyleFunction = (self: ol.Feature, resolution: number) => (ol.style.Style | ol.style.Style[]);
+    type FeatureStyleFunction = (resolution: number) => (ol.style.Style | ol.style.Style[]);
 
     /**
      * {@link ol.source.Vector} sources use a function of this type to get the url

--- a/openlayers/openlayers.d.ts
+++ b/openlayers/openlayers.d.ts
@@ -12732,7 +12732,7 @@ declare module olx {
             geometryFunction?: ((feature: ol.Feature) => ol.geom.Point);
             format?: ol.format.Feature;
             logo?: string;
-            projection: ol.ProjectionLike;
+            projection?: ol.ProjectionLike;
             source: ol.source.Vector;
             wrapX?: boolean;
         }


### PR DESCRIPTION
Remaining references to self: as the first argument of functions were removed.  These appeared in three "type" definitions.  The openlayers documentation was consulted to confirm that the signatures of the functions start with what was previously the second arg.

Two layer options interfaces were modified to make the projection optional.  I confirmed in the source code that the Cluster source is a subclass of Vector source and the projection is set as undefined regardless of what was entered as the projection.  My experience with ol.source.XYZ confirms that the projection option is not required as I had never used it before.  

Other layer sources may not require the projection either.  The projection definition for all sources happens in the ol.source.Source base class where it does a number of checks for a valid input and falls through to null.  However, some of the sources may depend on the projection value being set to something other than null after instantiation.  More investigation is required to assure that making the projection optional for all source options would not have undesired effects.  
