### PR TITLE
use object type for body in supertest expect fn arguments

### DIFF
--- a/supertest/supertest-tests.ts
+++ b/supertest/supertest-tests.ts
@@ -4,7 +4,7 @@
 import * as supertest from 'supertest';
 import * as express from 'express';
 
-var app = express();
+const app = express();
 
 supertest(app)
   .get('/user')
@@ -16,15 +16,15 @@ supertest(app)
   });
 
 // cookie scenario
-var request = supertest(app);
-var agent = supertest.agent();
+const request = supertest(app);
+const agent = supertest.agent();
 request
   .post('/login')
   .end((err: any, res: supertest.Response) => {
     if (err) throw err;
     agent.saveCookies(res);
 
-    var req = request.get('/admin');
+    const req = request.get('/admin');
     agent.attachCookies(req);
     req.expect(200, (err: any, res: supertest.Response) => {
       if (err) throw err;
@@ -32,7 +32,7 @@ request
   });
 
 // cookie scenario, new version
-var client = supertest.agent(app);
+const client = supertest.agent(app);
 client
   .post('/login')
   .end((err: any, res: supertest.Response) => {
@@ -56,3 +56,11 @@ function hasPreviousAndNextKeys(res: supertest.Response) {
   if (!('next' in res.body)) return "missing next key";
   if (!('prev' in res.body)) throw new Error("missing prev key");
 }
+
+// object expect
+supertest(app)
+  .get('/')
+  .expect(200, { foo: 'bar' })
+  .end((err: any, res: supertest.Response) => {
+    if (err) throw err;
+  });

--- a/supertest/supertest.d.ts
+++ b/supertest/supertest.d.ts
@@ -23,7 +23,7 @@ declare module "supertest" {
       url: string;
       serverAddress(app: any, path: string): string;
       expect(status: number, callback?: CallbackHandler): this;
-      expect(status: number, body: string, callback?: CallbackHandler): this;
+      expect(status: number, body: any, callback?: CallbackHandler): this;
       expect(body: string, callback?: CallbackHandler): this;
       expect(body: RegExp, callback?: CallbackHandler): this;
       expect(body: Object, callback?: CallbackHandler): this;


### PR DESCRIPTION
This pr fixes the type on the `expect` function arguments.

Currently: the type is:

```
expect(status: number, body: string, callback?: CallbackHandler): this;
```

The body parameter is actually an object in the supertest library. 
Noted:
README: https://github.com/visionmedia/supertest#expectstatus-body-fn 
Source Code: https://github.com/visionmedia/supertest/blob/master/lib/test.js#L95

This pr corrects the type to `Object`:

```
expect(status: number, body: Object, callback?: CallbackHandler): this;
```

Case 2: Improvement to existing type definition.
- [x] documentation or source code reference which provides context for the suggested changes. 
- [ ] it has been reviewed by a DefinitelyTyped member.
