### PR TITLE
[openlayers] Update definition version

### DIFF
--- a/openlayers/index.d.ts
+++ b/openlayers/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for OpenLayers v3.6.0
+// Type definitions for OpenLayers v3.18.2
 // Project: http://openlayers.org/
 // Definitions by: Olivier Sechet <https://github.com/osechet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
The definition file is for v3.18.2. During the merge from master, the version has not been updated and remained 3.6.0.
