### PR TITLE
Added version for canvas-gauges type definitions

### DIFF
--- a/canvas-gauges/canvas-gauges.d.ts
+++ b/canvas-gauges/canvas-gauges.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for canvas-gauges
+// Type definitions for canvas-gauges v2.0.8
 // Project: https://github.com/Mikhus/canvas-gauges
 // Definitions by: Mikhus <https://github.com/Mikhus>
 // Definitions: https://github.com/Mikhus/DefinitelyTyped


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Adds version to the header, so [@types/canvas-gauges](https://www.npmjs.com/package/@types/canvas-gauges) package has correct version. 
