### PR TITLE
Module declaration for Jest

### DIFF
--- a/jest/jest.d.ts
+++ b/jest/jest.d.ts
@@ -156,6 +156,10 @@ declare namespace jest {
     }
 }
 
+declare module "jest" {
+    export = jest;
+}
+
 //Jest ships with a copy of Jasmine. They monkey-patch its APIs and divergence/deprecation are expected.
 //Relevant parts of Jasmine's API are below so they can be changed and removed over time.
 //This file can't reference jasmine.d.ts since the globals aren't compatible.


### PR DESCRIPTION
Module declaration to allow import syntax like:

import { autoMockOff } from "jest";
import \* as Jest from "jest";
