### PR TITLE
Allows Element in quills ctor

### DIFF
--- a/quill/quill.d.ts
+++ b/quill/quill.d.ts
@@ -38,7 +38,7 @@ declare namespace QuillJS {
     type formatsType = { [key: string]: any };
 
     export interface QuillStatic {
-        new (selector: string, options?: QuillOptionsStatic): QuillStatic;
+        new (container: string | Element, options?: QuillOptionsStatic): QuillStatic;
         deleteText(start: number, end: number, source?: sourceType): void;
         disable(): void;
         enable(enabled?: boolean): void;


### PR DESCRIPTION
Improvement to existing type definition.

> Quill requires a container where the editor will be appended. You can pass in either a CSS selector or a DOM object.

http://quilljs.com/docs/configuration/#container
