### PR TITLE
Fix for hs-base64 typings

### DIFF
--- a/js-base64/js-base64-test.ts
+++ b/js-base64/js-base64-test.ts
@@ -1,6 +1,6 @@
 /// <reference path="js-base64.d.ts" />
 
-import { Base64 } from 'js-base64'
+import { Base64 } from './js-base64'
 
 Base64.encode('dankogai');  // ZGFua29nYWk=
 Base64.encode('小飼弾');    // 5bCP6aO85by+

--- a/js-base64/js-base64.d.ts
+++ b/js-base64/js-base64.d.ts
@@ -19,36 +19,53 @@ add methods:
 - [ ] noConflict
  */
 
-declare module 'js-base64' {
-    namespace JSBase64 {
-        const Base64: Base64Static
-        interface Base64Static {
-            /**
-             * .encode
-             * @param {String} string
-             * @return {String}
-             */
-            encode(base64: string): string;
+// Type definitions for js-base64 v2.1.9
+// Project: https://github.com/dankogai/js-base64
+// Definitions by: Denis Carriere <https://github.com/DenisCarriere>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-            /**
-             * .encodeURI
-             * @param {String} string
-             * @return {String}
-             */
-            encodeURI(base64: string): string
+/**
+## TODO
 
-            /**
-             * .decode
-             * @param {String} string
-             * @return {String}
-             */
-            decode(base64: string): string
+add methods:
+- [x] encode
+- [x] encodeURI
+- [x] decode
+- [ ] atob
+- [ ] btoa
+- [ ] fromBase64
+- [ ] toBase64
+- [ ] utob
+- [ ] btou
+- [ ] noConflict
+ */
 
-            /**
-             * Library version
-             */
-            VERSION:string
-        }
-    }
-    export = JSBase64
+interface Base64Static {
+    /**
+     * .encode
+     * @param {String} string
+     * @return {String}
+     */
+    encode(base64: string): string;
+
+    /**
+     * .encodeURI
+     * @param {String} string
+     * @return {String}
+     */
+    encodeURI(base64: string): string
+
+    /**
+     * .decode
+     * @param {String} string
+     * @return {String}
+     */
+    decode(base64: string): string
+
+    /**
+     * Library version
+     */
+    VERSION:string
 }
+
+export declare var Base64: Base64Static;


### PR DESCRIPTION
Improvement to existing type definition.
- Fix applied in the context of the following issue: https://github.com/dankogai/js-base64/issues/38

The old version was causing an issue with webpack (because of duplicate
identifier). This update fix this issue.
