### PR TITLE
Added type definition for gulp cache

### DIFF
--- a/gulp-cache/gulp-cache-tests.ts
+++ b/gulp-cache/gulp-cache-tests.ts
@@ -1,0 +1,37 @@
+/// <reference path="gulp-cache.d.ts" />
+/// <reference path="../gulp/gulp.d.ts" />
+
+import * as fs from "fs";
+import * as gulp from "gulp";
+import * as cache from "gulp-cache";
+import File = require("vinyl");
+
+// Some gulp plugin
+let jshint: any;
+
+gulp.task('lint', function () {
+    gulp.src('./non/existent/path/*.js')
+        .pipe(cache(jshint('.jshintrc'), {
+            key: makeHashKey,
+            success: function (jshintedFile) {
+                return jshintedFile.jshint.success;
+            },
+            value: function (jshintedFile) {
+                return {
+                    jshint: jshintedFile.jshint
+                };
+            }
+        }))
+        .pipe(jshint.reporter('default'));
+});
+
+var jsHintVersion = '2.4.1',
+    jshintOptions = fs.readFileSync('.jshintrc');
+
+function makeHashKey(file: File) {
+    return [file.contents.toString('utf8'), jsHintVersion, jshintOptions].join('');
+}
+
+gulp.task('clear', function (done: any) {
+    return cache.clearAll(done);
+});

--- a/gulp-cache/gulp-cache.d.ts
+++ b/gulp-cache/gulp-cache.d.ts
@@ -1,0 +1,94 @@
+// Type definitions for gulp-cache v0.4.5
+// Project: https://github.com/jgable/gulp-cache
+// Definitions by: Arun Aravind <https://github.com/aravindarun>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+/// <reference path="../vinyl/vinyl.d.ts" />
+/// <reference path="../gulp-util/gulp-util.d.ts" />
+
+declare module "gulp-cache" {
+    import File = require("vinyl");
+    import { Transform } from "stream";
+    import { PluginError } from "gulp-util";
+
+    namespace gc {
+        type Predicate<T> = (arg: T) => boolean;
+
+        interface IGulpCacheOptions {
+            /**
+             * The cache instance to use for caching.
+             */
+            fileCache?: IGulpCache;
+
+            /**
+             * The name of the bucket which stores the cached objects.
+             * Default value = 'default'
+             */
+            name?: string,
+
+            /**
+             * The hash generator to use.
+             */
+            key?: (file: File, callback?: (err: any, result: string) => void) => string | Promise<string>;
+
+            /**
+             * Value representing the success of a task.
+             */
+            success?: boolean | Predicate<any>;
+
+            /**
+             * Content that is to be cached.
+             */
+            value?: (result: any) => Object | Promise<Object> | string;
+        }
+
+        interface ICacheOptions {
+            /**
+             * Specifies the name of the directory where the cache
+             * is to be stored.
+             */
+            cacheDirName: string;
+        }
+
+        interface IGulpCacheStatic {
+            /**
+             * Caches the result of a task.
+             * @param task The task whose result is to be cached.
+             */
+            (task: NodeJS.ReadWriteStream): Transform;
+
+            /**
+             * Caches the result of a task.
+             * @param task Task whose result is to be cached.
+             * @param options Override values for available settings.
+             */
+            (task: NodeJS.ReadWriteStream, options: IGulpCacheOptions): Transform;
+
+            clear(options: IGulpCacheOptions): Transform;
+
+            /**
+             * Represents a cache store.
+             */
+            Cache: IGulpCache;
+
+            /**
+             * Purges the cache.
+             * @param err PluginError instance in case of a plugin error.
+             *            If callback is not specified an exception of type
+             *            'PluginError' is thrown.
+             */
+            clearAll(callback?: (err: PluginError) => void): void;
+        }
+
+        /**
+         * Represents a cach store.
+         */
+        interface IGulpCache {
+            new (options: ICacheOptions): any;
+        }
+    }
+
+    const _: gc.IGulpCacheStatic;
+    export = _;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
