### PR TITLE
youtube: Add alternative YT.Player constructor

### DIFF
--- a/youtube/youtube.d.ts
+++ b/youtube/youtube.d.ts
@@ -83,6 +83,7 @@ declare namespace YT {
     export class Player {
         // Constructor
         constructor(id: string, playerOptions: PlayerOptions);
+        constructor(element: HTMLElement, playerOptions: PlayerOptions);
 
         // Queueing functions
         loadVideoById(videoId: string, startSeconds?: number, suggestedQuality?: string): void;


### PR DESCRIPTION
Add `YT.Player` constructor from `HTMLElement` instead of id string.

The [YouTube IFrame Player API](https://developers.google.com/youtube/iframe_api_reference) has the following description of the constructor: "The first parameter specifies either the DOM element or the `id` of the HTML element where the API will insert the `<iframe>` tag containing the player."
