### PR TITLE
[express] Complete routing methods

### DIFF
--- a/express-serve-static-core/express-serve-static-core.d.ts
+++ b/express-serve-static-core/express-serve-static-core.d.ts
@@ -93,6 +93,23 @@ declare module "express-serve-static-core" {
         patch: IRouterMatcher<this>;
         options: IRouterMatcher<this>;
         head: IRouterMatcher<this>;
+        
+        checkout: IRouterMatcher<this>;
+        copy: IRouterMatcher<this>;
+        lock: IRouterMatcher<this>;
+        merge: IRouterMatcher<this>;
+        mkactivity: IRouterMatcher<this>;
+        mkcol: IRouterMatcher<this>;
+        move: IRouterMatcher<this>;
+        m-search: IRouterMatcher<this>;
+        notify: IRouterMatcher<this>;
+        purge: IRouterMatcher<this>;
+        report: IRouterMatcher<this>;
+        search: IRouterMatcher<this>;
+        subscribe: IRouterMatcher<this>;
+        trace: IRouterMatcher<this>;
+        unlock: IRouterMatcher<this>;
+        unsubscribe: IRouterMatcher<this>;
 
         use: IRouterHandler<this> & IRouterMatcher<this>;
 
@@ -114,6 +131,23 @@ declare module "express-serve-static-core" {
         patch: IRouterHandler<this>;
         options: IRouterHandler<this>;
         head: IRouterHandler<this>;
+        
+        checkout: IRouterHandler<this>;
+        copy: IRouterHandler<this>;
+        lock: IRouterHandler<this>;
+        merge: IRouterHandler<this>;
+        mkactivity: IRouterHandler<this>;
+        mkcol: IRouterHandler<this>;
+        move: IRouterHandler<this>;
+        m-search: IRouterHandler<this>;
+        notify: IRouterHandler<this>;
+        purge: IRouterHandler<this>;
+        report: IRouterHandler<this>;
+        search: IRouterHandler<this>;
+        subscribe: IRouterHandler<this>;
+        trace: IRouterHandler<this>;
+        unlock: IRouterHandler<this>;
+        unsubscribe: IRouterHandler<this>
     }
 
     export interface Router extends IRouter { }

--- a/express-serve-static-core/express-serve-static-core.d.ts
+++ b/express-serve-static-core/express-serve-static-core.d.ts
@@ -101,7 +101,7 @@ declare module "express-serve-static-core" {
         mkactivity: IRouterMatcher<this>;
         mkcol: IRouterMatcher<this>;
         move: IRouterMatcher<this>;
-        m-search: IRouterMatcher<this>;
+        "m-search": IRouterMatcher<this>;
         notify: IRouterMatcher<this>;
         purge: IRouterMatcher<this>;
         report: IRouterMatcher<this>;
@@ -139,7 +139,7 @@ declare module "express-serve-static-core" {
         mkactivity: IRouterHandler<this>;
         mkcol: IRouterHandler<this>;
         move: IRouterHandler<this>;
-        m-search: IRouterHandler<this>;
+        "m-search": IRouterHandler<this>;
         notify: IRouterHandler<this>;
         purge: IRouterHandler<this>;
         report: IRouterHandler<this>;


### PR DESCRIPTION
# Improvement to existing type definition.

Based on **Routing methods** of section of [express document](http://expressjs.com/en/api.html), it has not only `'all', 'get', 'post', 'put', 'delete', 'patch', 'options', 'head'` but also `'checkout', 'copy', 'lock', 'merge', 'mkactivity', 'mkcol', 'move', 'm-search', 'notify', 'purge', 'report', 'search', 'subscribe', 'trace', 'unlock', 'unsubscribe'`.
