### PR TITLE
Add type definitions for koa-send.

### DIFF
--- a/koa-send/koa-send-tests.ts
+++ b/koa-send/koa-send-tests.ts
@@ -1,0 +1,23 @@
+/// <reference path="../koa/koa.d.ts" />
+/// <reference path="koa-send.d.ts" />
+
+import * as Koa from "koa";
+import * as send from "koa-send";
+
+const app = new Koa();
+
+app.use(async (ctx: Koa.Context) => {
+    const path: string = await send(ctx, 'stimpy.html');
+});
+
+app.use(async (ctx: Koa.Context) => {
+    await send(ctx, 'stimpy.html', {
+        root: '../static-files',
+        index: 'index.html',
+        maxAge: 10,
+        hidden: true,
+        format: true,
+        gzip: true,
+        setHeaders: () => {},
+    });
+});

--- a/koa-send/koa-send.d.ts
+++ b/koa-send/koa-send.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for koa-send v3.x
+// Project: https://github.com/koajs/send
+// Definitions by: Peter Safranek <https://github.com/pe8ter>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../koa/koa.d.ts" />
+
+declare module "koa-send" {
+
+    import * as Koa from "koa";
+
+    interface ISendOptions {
+        root?: string;
+        index?: string;
+        maxAge?: number;
+        hidden?: boolean;
+        format?: boolean;
+        gzip?: boolean;
+        setHeaders?: Function;
+    }
+
+    function send(ctx: Koa.Context, path: string, opts?: ISendOptions): Promise<string>;
+
+    namespace send {}
+
+    export = send;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
