### PR TITLE
Fix wrong stream TransformOptions interface.

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -487,7 +487,10 @@ function simplified_stream_ctor_test() {
             chunks[0].chunk.slice(0);
             chunks[0].encoding.charAt(0);
             cb();
-        }
+        },
+        allowHalfOpen: true,
+        readableObjectMode: true,
+        writableObjectMode: true
     })
 }
 
@@ -747,7 +750,7 @@ namespace tls_tests {
             let _response: Buffer = response;
         })
         _TLSSocket = _TLSSocket.prependOnceListener("secureConnect", () => { });
-    } 
+    }
 }
 
 ////////////////////////////////////////////////////

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -3165,7 +3165,7 @@ declare module "stream" {
             end(chunk: any, encoding?: string, cb?: Function): void;
         }
 
-        export interface TransformOptions extends ReadableOptions, WritableOptions {
+        export interface TransformOptions extends DuplexOptions {
             transform?: (chunk: string | Buffer, encoding: string, callback: Function) => any;
             flush?: (callback: Function) => any;
         }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- [x] documentation:
  https://nodejs.org/api/stream.html#stream_object_mode_duplex_streams
- [ ] it has been reviewed by a DefinitelyTyped member.

Transform streams are duplex streams and extend the latter's constructor options.

Run into this issue this morning and the node guys confirmed it: 
https://github.com/nodejs/node/issues/8983
https://nodejs.org/api/stream.html#stream_object_mode_duplex_streams
