### PR TITLE
Update node-sass bindings

### DIFF
--- a/node-sass/node-sass-tests.ts
+++ b/node-sass/node-sass-tests.ts
@@ -44,6 +44,7 @@ var result = sass.renderSync({
   outputStyle: 'compressed',
   outFile: '/to/my/output.css',
   sourceMap: true, // or an absolute or relative (to outFile) path
+  sourceMapRoot: '.',
   importer: function(url, prev, done) {
     // url is the path in import as is, which libsass encountered.
     // prev is the previously resolved path.

--- a/node-sass/node-sass-tests.ts
+++ b/node-sass/node-sass-tests.ts
@@ -1,5 +1,5 @@
 /// <reference path="node-sass.d.ts" />
-import sass = require('node-sass');
+import * as sass from 'node-sass';
 sass.render({
   file: '/path/to/myFile.scss',
   data: 'body{background:blue; a{color:black;}}',

--- a/node-sass/node-sass.d.ts
+++ b/node-sass/node-sass.d.ts
@@ -22,7 +22,7 @@ declare module "node-sass" {
         linefeed?: string;
         omitSourceMapUrl?: boolean;
         outFile?: string;
-        outputStyle?: string;
+        outputStyle?: "compact" | "compressed" | "expanded" | "nested";
         precision?: number;
         sourceComments?: boolean;
         sourceMap?: boolean | string;

--- a/node-sass/node-sass.d.ts
+++ b/node-sass/node-sass.d.ts
@@ -28,7 +28,7 @@ declare module "node-sass" {
         sourceMap?: boolean | string;
         sourceMapContents?: boolean;
         sourceMapEmbed?: boolean;
-        sourceMapRoot?: boolean;
+        sourceMapRoot?: string;
     }
 
     interface SassError extends Error {

--- a/node-sass/node-sass.d.ts
+++ b/node-sass/node-sass.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Node Sass
+// Type definitions for Node Sass v3.10.1
 // Project: https://github.com/sass/node-sass
 // Definitions by: Asana <https://asana.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- [x] See node-sass docs: https://github.com/sass/node-sass/blob/master/README.md
- [ ] it has been reviewed by a DefinitelyTyped member.

Fixes:
- fix bindings not compiling with `--target es6`
- `sourceMapRoot` option must be a `string` not a `boolean`
- `outputStyle` must only be one of `"nested" | "expanded" | "compact" | "compressed"`
- add node-sass version as per contribution guidelines
