### PR TITLE
[express] The properties don't exist

### DIFF
--- a/express-serve-static-core/express-serve-static-core.d.ts
+++ b/express-serve-static-core/express-serve-static-core.d.ts
@@ -1064,26 +1064,7 @@ declare module "express-serve-static-core" {
     }
 
     interface Express extends Application {
-        /**
-            * Framework version.
-            */
-        version: string;
-
-        /**
-            * Expose mime.
-            */
-        mime: string;
-
         (): Application;
-
-        /**
-        * Create an express application.
-        */
-        createApplication(): Application;
-
-        createServer(): Application;
-
-        application: any;
 
         request: Request;
 

--- a/express-serve-static-core/express-serve-static-core.d.ts
+++ b/express-serve-static-core/express-serve-static-core.d.ts
@@ -1064,8 +1064,6 @@ declare module "express-serve-static-core" {
     }
 
     interface Express extends Application {
-        (): Application;
-
         request: Request;
 
         response: Response;


### PR DESCRIPTION
# Improvement to existing type definition.

 I try to call the properties but undefined.

```
> a.version
undefined
> a.mime
undefined
> a()
TypeError: Cannot read property '_header' of undefined
    at /home/tony/Tony/opensource-git/routing-controllers/node_modules/finalhandler/index.js:62:20
    at EventEmitter.handle (/home/tony/Tony/opensource-git/routing-controllers/node_modules/express/lib/application.js:169:5)
    at app (/home/tony/Tony/opensource-git/routing-controllers/node_modules/express/lib/express.js:38:9)
    at repl:1:1
    at sigintHandlersWrap (vm.js:22:35)
    at sigintHandlersWrap (vm.js:96:12)
    at ContextifyScript.Script.runInThisContext (vm.js:21:12)
    at REPLServer.defaultEval (repl.js:313:29)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
> a.createApplication()
TypeError: a.createApplication is not a function
    at repl:1:3
    at sigintHandlersWrap (vm.js:22:35)
    at sigintHandlersWrap (vm.js:96:12)
    at ContextifyScript.Script.runInThisContext (vm.js:21:12)
    at REPLServer.defaultEval (repl.js:313:29)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.<anonymous> (repl.js:504:10)
    at emitOne (events.js:101:20)
    at REPLServer.emit (events.js:188:7)
> a.createServer()
TypeError: a.createServer is not a function
    at repl:1:3
    at sigintHandlersWrap (vm.js:22:35)
    at sigintHandlersWrap (vm.js:96:12)
    at ContextifyScript.Script.runInThisContext (vm.js:21:12)
    at REPLServer.defaultEval (repl.js:313:29)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.<anonymous> (repl.js:504:10)
    at emitOne (events.js:101:20)
    at REPLServer.emit (events.js:188:7)
> a.application
undefined
```
