### PR TITLE
Changes Quill casing to avoid issues w/ jspm & others

### DIFF
--- a/quill/quill.d.ts
+++ b/quill/quill.d.ts
@@ -91,6 +91,6 @@ declare namespace QuillJS {
 
 declare var Quill: QuillJS.QuillStatic;
 
-declare module "Quill" {
+declare module "quill" {
     export = Quill;
 }


### PR DESCRIPTION
Having `Quill` be capitalized causes issues with collisions with the definition file and actual module importing (since the file is `quill`).
