### PR TITLE
add definitions for fossil-delta package

### DIFF
--- a/fossil-delta/fossil-delta-tests.ts
+++ b/fossil-delta/fossil-delta-tests.ts
@@ -1,0 +1,10 @@
+/// <reference path="fossil-delta.d.ts" />
+import * as fossilDelta from "fossil-delta";
+
+var origin =  new Array<number>(1,2,3);
+var target =  new Array<number>(1,2,3,4,5);
+
+var delta = fossilDelta.create(origin, target);
+var targetApplied = fossilDelta.apply(origin, delta);
+
+var outputSize: number = fossilDelta.outputSize(delta);

--- a/fossil-delta/fossil-delta.d.ts
+++ b/fossil-delta/fossil-delta.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for fossil-delta 0.2.5
+// Project: https://github.com/dchest/fossil-delta-js
+// Definitions by: Endel Dreyer <https://github.com/endel/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+declare module "fossil-delta" {
+  type ByteArray = Array<number> | Uint8Array | Buffer;
+
+  export function create(origin: ByteArray, target: ByteArray): Array<number>;
+  export function apply(origin: ByteArray, delta: Array<number>): Array<number>;
+  export function outputSize(delta: Array<number>): number;
+}


### PR DESCRIPTION
Type definitions for [fossil-delta](https://github.com/dchest/fossil-delta-js/) package.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
