### PR TITLE
Fix moment().localeData() return type

### DIFF
--- a/moment/moment-tests.ts
+++ b/moment/moment-tests.ts
@@ -216,6 +216,7 @@ moment().isBetween(moment(), moment());
 moment().isBetween(new Date(), new Date());
 moment().isBetween([1,1,2000], [1,1,2001], "year");
 
+moment().localeData().firstDayOfWeek();
 moment.localeData('fr');
 moment(1316116057189).fromNow();
 

--- a/moment/moment.d.ts
+++ b/moment/moment.d.ts
@@ -332,7 +332,7 @@ declare namespace moment {
         locales() : string[];
         localeData(language: string): Moment;
         localeData(reset: boolean): Moment;
-        localeData(): MomentLanguage;
+        localeData(): MomentLanguageData;
 
         /**
          * @deprecated since version 2.7.0


### PR DESCRIPTION
The return type is the same when calling `localeData()` on an instance as when calling it on the global `moment` object. See http://momentjs.com/docs/#/i18n/instance-locale/.
