### PR TITLE
Update parsimmon typings

### DIFF
--- a/parsimmon/parsimmon-tests.ts
+++ b/parsimmon/parsimmon-tests.ts
@@ -4,6 +4,7 @@ import P = require('parsimmon');
 import Parser = P.Parser;
 import Mark = P.Mark;
 import Result = P.Result;
+import Index = P.Index;
 
 // --  --  --  --  --  --  --  --  --  --  --  --  --
 
@@ -20,6 +21,7 @@ class Bar {
 var str: string;
 var bool: boolean;
 var num: number;
+var index: Index;
 var regex: RegExp;
 
 var foo: Foo;
@@ -35,6 +37,7 @@ var strPar: Parser<string>;
 var numPar: Parser<number>;
 var voidPar: Parser<void>;
 var anyPar: Parser<any>;
+var indexPar: Parser<Index>;
 
 var fooPar: Parser<Foo>;
 var barPar: Parser<Bar>;
@@ -50,6 +53,10 @@ var barArrPar: Parser<Bar[]>;
 
 var fooMarkPar: Parser<Mark<Foo>>;
 
+index = fooMarkPar.parse(str).value.start;
+index = fooMarkPar.parse(str).value.end;
+foo = fooMarkPar.parse(str).value.value;
+
 // --  --  --  --  --  --  --  --  --  --  --  --  --
 
 var fooResult: Result<Foo>;
@@ -57,7 +64,7 @@ var fooResult: Result<Foo>;
 bool = fooResult.status;
 foo = fooResult.value;
 str = fooResult.expected;
-num = fooResult.index;
+index = fooResult.index;
 
 // --  --  --  --  --  --  --  --  --  --  --  --  --
 
@@ -139,7 +146,7 @@ strPar = P.optWhitespace;
 strPar = P.any;
 strPar = P.all;
 voidPar = P.eof;
-numPar = P.index;
+indexPar = P.index;
 
 // --  --  --  --  --  --  --  --  --  --  --  --  --
 

--- a/parsimmon/parsimmon.d.ts
+++ b/parsimmon/parsimmon.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Parsimmon 0.9.2
 // Project: https://github.com/jneen/parsimmon
-// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Mizunashi Mana <https://github.com/mizunashi-mana>, Boris Cherny <https://github.com/bcherny>
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Mizunashi Mana <https://github.com/mizunashi-mana>, Boris Cherny <https://github.com/bcherny>, Benny van Reeven <https://github.com/bvanreeven>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // TODO convert to generics
@@ -10,9 +10,18 @@ declare module 'parsimmon' {
 
 		export type StreamType = string;
 
+		export interface Index {
+			/** zero-based character offset */
+			offset: number;
+			/** one-based line offset */
+			line: number;
+			/** one-based column offset */
+			column: number;
+		}
+
 		export interface Mark<T> {
-			start: number;
-			end: number;
+			start: Index;
+			end: Index;
 			value: T;
 		}
 
@@ -20,7 +29,7 @@ declare module 'parsimmon' {
 			status: boolean;
 			value?: T;
 			expected?: string;
-			index?: number;
+			index?: Index;
 		}
 
 		export interface Parser<T> {
@@ -243,7 +252,7 @@ declare module 'parsimmon' {
 		/**
 		 * is a parser that yields the current index of the parse.
 		 */
-		export var index: Parser<number>;
+		export var index: Parser<Index>;
 		/**
 		 * Returns a parser that yield a single character if it passes the predicate
 		 */


### PR DESCRIPTION
According to the [README](https://github.com/jneen/parsimmon/blob/master/README.md) and [API docs](https://github.com/jneen/parsimmon/blob/master/API.md), an index is now an
object instead of a number.

The typings have been updated in the relevant places:
- `Result<T>.index`
- `Mark<T>.start` and `Mark<T>.end`
- `Parsimmon.index`
