### PR TITLE
Mongoose fixes

### DIFF
--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -971,7 +971,6 @@ schematype.unique(true).unique(true);
 schematype.validate(/re/)
   .validate({}, 'error')
   .validate(cb, 'try', 'tri');
-schematype.options.required;
 
 /*
  * section promise.js

--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -492,6 +492,16 @@ documentArray.toObject({}).length;
 documentArray.$shift();
 /* inherited from Native Array */
 documentArray.concat();
+/* practical example */
+interface MySubEntity1 extends mongoose.Types.Subdocument {
+  property1: string;
+  property2: string;
+}
+interface MyEntity1 extends mongoose.Document {
+  sub: mongoose.Types.DocumentArray<MySubEntity>
+}
+var newEnt: MyEntity1;
+var newSub: MySubEntity1 = newEnt.sub.create({ property1: "example", property2: "example" });
 
 /*
  * section types/buffer.js

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -2014,12 +2014,6 @@ declare module "mongoose" {
      */
     validate(obj: RegExp | Function | Object, errorMsg?: string,
       type?: string): this;
-
-    /**
-     * http://mongoosejs.com/docs/api.html#schematype_SchemaType
-     * Options for this schema type (required, index, etc.)
-     */
-    options: any;
   }
 
   /*

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -1045,13 +1045,13 @@ declare module "mongoose" {
        * This is the same subdocument constructor used for casting.
        * @param obj the value to cast to this arrays SubDocument schema
        */
-      create(obj: Object): Subdocument;
+      create(obj: Object): T;
 
       /**
        * Searches array items for the first document with a matching _id.
        * @returns the subdocument or null if not found.
        */
-      id(id: ObjectId | string | number | NativeBuffer): Embedded;
+      id(id: ObjectId | string | number | NativeBuffer): T;
 
       /** Helper for console.log */
       inspect(): T[];


### PR DESCRIPTION
1. Fixes return types of `documentArray.create()` and `documentArray.id()` as reported here: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11291#issuecomment-252487066
2. Removes private api `options` from `schematype`
