### PR TITLE
Fix missing type declaration for pickadate types-2.0

### DIFF
--- a/pickadate/index.d.ts
+++ b/pickadate/index.d.ts
@@ -138,7 +138,7 @@ declare namespace Pickadate {
          * Specify where to insert the picker's root element by passing any
          * valid CSS selector to this option. Defaults to undefined.
          */
-        container?: string;
+        container?: string|JQuery;
 
         /**
          * The hidden input container.


### PR DESCRIPTION
case 2. Improvement to existing type definition.

As you can see in the original source code of picker js the container element is wrapped in jQuery and allows to pass a jQuery element.

https://github.com/amsul/pickadate.js/blob/master/lib/picker.js#L130

This pull request adds the missing type for the container declaration.
