### PR TITLE
[Node] errno is a number, not a string.

### DIFF
--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -165,7 +165,7 @@ namespace fs_tests {
     }
 
     {
-        var errno: string;
+        var errno: number;
         fs.readFile('testfile', (err, data) => {
             if (err && err.errno) {
                 errno = err.errno;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -233,7 +233,7 @@ declare var Buffer: {
 ************************************************/
 declare namespace NodeJS {
     export interface ErrnoException extends Error {
-        errno?: string;
+        errno?: number;
         code?: string;
         path?: string;
         syscall?: string;


### PR DESCRIPTION
## Improvement to existing type definition.

The Node documentation [erroneously describes errno as a string](https://github.com/nodejs/node/pull/9007). It is actually a number.
