### PR TITLE
Mongoose fixes ObjectId constructor

### DIFF
--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -525,6 +525,7 @@ mongoose.Types.Buffer.from([1, 2, 3]);
  */
 var objectId: mongoose.Types.ObjectId = mongoose.Types.ObjectId.createFromHexString('0x1234');
 objectId = new mongoose.Types.ObjectId(12345);
+objectId = mongoose.Types.ObjectId(12345);
 objectId.getTimestamp();
 /* practical examples */
 export interface IManagerSchema extends mongoose.MongooseDocument {

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -1091,10 +1091,22 @@ declare module "mongoose" {
     }
 
     /*
-      * section types/objectid.js
-      * http://mongoosejs.com/docs/api.html#types-objectid-js
-      */
-    class ObjectId extends mongodb.ObjectID {}
+     * section types/objectid.js
+     * http://mongoosejs.com/docs/api.html#types-objectid-js
+     */
+    var ObjectId: ObjectIdConstructor;
+
+    // mongodb.ObjectID does not allow mongoose.Types.ObjectId(id). This is
+    //   commonly used in mongoose and is found in an example in the docs:
+    //   http://mongoosejs.com/docs/api.html#aggregate_Aggregate
+    // constructor exposes static methods of mongodb.ObjectID and ObjectId(id)
+    type ObjectIdConstructor = typeof mongodb.ObjectID & {
+      (s?: string | number): mongodb.ObjectID;
+    }
+
+    // var objectId: mongoose.Types.ObjectId should reference mongodb.ObjectID not
+    //   the ObjectIdConstructor, so we add the interface below
+    interface ObjectId extends mongodb.ObjectID {}
 
     /*
       * section types/embedded.js


### PR DESCRIPTION
`mongoose.Types.ObjectId(id)` is commonly used in mongoose and appears in many examples on stackoverflow: http://stackoverflow.com/questions/6578178/node-js-mongoose-js-string-to-objectid-function#answers-header

Also found as an example in mongoose docs: http://mongoosejs.com/docs/api.html#aggregate_Aggregate

Currently only `new mongoose.Types.ObjectId(id)` is allowed. Added ability to convert to `ObjectId` without using `new`.
