### PR TITLE
Added clipboard-js definitions and tests

### DIFF
--- a/clipboard-js/clipboard-js-tests.ts
+++ b/clipboard-js/clipboard-js-tests.ts
@@ -1,0 +1,6 @@
+/// <reference path="clipboard-js.d.ts" />
+
+clipboard.copy("Hello World");
+clipboard.copy(document.body).then(() => console.log("success"));
+
+clipboard.paste().then(val => console.log(val));

--- a/clipboard-js/clipboard-js.d.ts
+++ b/clipboard-js/clipboard-js.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for clipboard-js 0.3.1
+// Project: https://github.com/lgarron/clipboard.js
+// Definitions by: Mark Wong Siang Kai <https://github.com/markwongsk>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace clipboard {
+
+    interface IClipboardJsStatic {
+        copy(val: string | Element): Promise<void>;
+        paste(): Promise<string>;
+    }
+}
+
+declare var clipboard: clipboard.IClipboardJsStatic;
+
+declare module 'clipboard-js' {
+    export = clipboard;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

This creates a simple definition for `clipboard-js` (https://github.com/lgarron/clipboard.js).
