### PR TITLE
Add LanguageSettings.url option

### DIFF
--- a/jquery.dataTables/jquery.dataTables.d.ts
+++ b/jquery.dataTables/jquery.dataTables.d.ts
@@ -1685,6 +1685,7 @@ declare namespace DataTables {
         zeroRecords?: string;
         paginate?: LanguagePaginateSettings;
         aria?: LanguageAriaSettings;
+        url?: string;
     }
 
     interface LanguagePaginateSettings {


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

The datatables language options contains a url parameter to get language settings over ajax. This should be included in the typings file.
