### PR TITLE
[types-2.0] jest - It optional callback fix

### DIFF
--- a/jest/index.d.ts
+++ b/jest/index.d.ts
@@ -87,7 +87,7 @@ declare namespace jest {
     }
 
     interface ProvidesCallback {
-        (cb?: DoneCallback): any;
+        (cb: DoneCallback): any;
     }
 
     interface Lifecycle {
@@ -95,7 +95,7 @@ declare namespace jest {
     }
 
     interface It {
-        (name: string, fn: ProvidesCallback): void;
+        (name: string, fn?: ProvidesCallback): void;
         only: It;
         skip: It;
     }

--- a/jest/jest-tests.ts
+++ b/jest/jest-tests.ts
@@ -351,3 +351,12 @@ describe('genMockFromModule', function () {
       });
     });
 });
+
+/**
+ * Pass strictNullChecks
+ */
+describe('strictNullChecks', function () {
+    it('does not complain when using done callback', (done) => {
+        done();
+    })
+});

--- a/jest/tsconfig.json
+++ b/jest/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "noImplicitAny": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
When using `strictNullChecks`, it detects a minor misstake that declares the actual function as optional, but truth is the parameter is optional, not the other way around.

This example fails:

``` js
describe('strictNullChecks', function () {
    it('does not complain when using done callback', (done) => {
        done(); // error is possibly undefined
    })
});
```

I can revert `strictNullChecks` if you want to but it's very useful to find bugs like these.
