### PR TITLE
removing ? from parameters supplied in immutable callback functions

### DIFF
--- a/immutable/index.d.ts
+++ b/immutable/index.d.ts
@@ -260,11 +260,11 @@ declare namespace Immutable {
      * @see `Map#mergeWith`
      */
     mergeWith(
-      merger: (previous?: T, next?: T, key?: number) => T,
+      merger: (previous: T, next: T, key: number) => T,
       ...iterables: Iterable.Indexed<T>[]
     ): List<T>;
     mergeWith(
-      merger: (previous?: T, next?: T, key?: number) => T,
+      merger: (previous: T, next: T, key: number) => T,
       ...iterables: Array<T>[]
     ): List<T>;
 
@@ -278,11 +278,11 @@ declare namespace Immutable {
      * @see `Map#mergeDeepWith`
      */
     mergeDeepWith(
-      merger: (previous?: T, next?: T, key?: number) => T,
+      merger: (previous: T, next: T, key: number) => T,
       ...iterables: Iterable.Indexed<T>[]
     ): List<T>;
     mergeDeepWith(
-      merger: (previous?: T, next?: T, key?: number) => T,
+      merger: (previous: T, next: T, key: number) => T,
       ...iterables: Array<T>[]
     ): List<T>;
 
@@ -541,11 +541,11 @@ declare namespace Immutable {
      *
      */
     mergeWith(
-      merger: (previous?: V, next?: V, key?: K) => V,
+      merger: (previous: V, next: V, key: K) => V,
       ...iterables: Iterable<K, V>[]
     ): Map<K, V>;
     mergeWith(
-      merger: (previous?: V, next?: V, key?: K) => V,
+      merger: (previous: V, next: V, key: K) => V,
       ...iterables: {[key: string]: V}[]
     ): Map<string, V>;
 
@@ -572,11 +572,11 @@ declare namespace Immutable {
      *
      */
     mergeDeepWith(
-      merger: (previous?: V, next?: V, key?: K) => V,
+      merger: (previous: V, next: V, key: K) => V,
       ...iterables: Iterable<K, V>[]
     ): Map<K, V>;
     mergeDeepWith(
-      merger: (previous?: V, next?: V, key?: K) => V,
+      merger: (previous: V, next: V, key: K) => V,
       ...iterables: {[key: string]: V}[]
     ): Map<string, V>;
 
@@ -1459,7 +1459,7 @@ declare namespace Immutable {
        *
        */
       mapKeys<M>(
-        mapper: (key?: K, value?: V, iter?: this) => M,
+        mapper: (key: K, value: V, iter: this) => M,
         context?: any
       ): /*this*/Iterable.Keyed<M, V>;
 
@@ -1474,9 +1474,9 @@ declare namespace Immutable {
        */
       mapEntries<KM, VM>(
         mapper: (
-          entry?: [K, V],
-          index?: number,
-          iter?: this
+          entry: [K, V],
+          index: number,
+          iter: this
         ) => [KM, VM],
         context?: any
       ): /*this*/Iterable.Keyed<KM, VM>;
@@ -1641,7 +1641,7 @@ declare namespace Immutable {
        * provided predicate function. Otherwise -1 is returned.
        */
       findIndex(
-        predicate: (value?: T, index?: number, iter?: this) => boolean,
+        predicate: (value: T, index: number, iter: this) => boolean,
         context?: any
       ): number;
 
@@ -1650,7 +1650,7 @@ declare namespace Immutable {
        * provided predicate function. Otherwise -1 is returned.
        */
       findLastIndex(
-        predicate: (value?: T, index?: number, iter?: this) => boolean,
+        predicate: (value: T, index: number, iter: this) => boolean,
         context?: any
       ): number;
     }
@@ -1971,7 +1971,7 @@ declare namespace Immutable {
      *
      */
     map<M>(
-      mapper: (value?: V, key?: K, iter?: this) => M,
+      mapper: (value: V, key: K, iter: this) => M,
       context?: any
     ): /*this*/Iterable<K, M>;
 
@@ -1984,7 +1984,7 @@ declare namespace Immutable {
      *
      */
     filter(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): this;
 
@@ -1997,7 +1997,7 @@ declare namespace Immutable {
      *
      */
     filterNot(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): this;
 
@@ -2033,7 +2033,7 @@ declare namespace Immutable {
      *
      */
     sortBy<C>(
-      comparatorValueMapper: (value?: V, key?: K, iter?: this) => C,
+      comparatorValueMapper: (value: V, key: K, iter: this) => C,
       comparator?: (valueA: C, valueB: C) => number
     ): this;
 
@@ -2044,7 +2044,7 @@ declare namespace Immutable {
      * Note: This is always an eager operation.
      */
     groupBy<G>(
-      grouper: (value?: V, key?: K, iter?: this) => G,
+      grouper: (value: V, key: K, iter: this) => G,
       context?: any
     ): Seq.Keyed<G, this>;
 
@@ -2059,7 +2059,7 @@ declare namespace Immutable {
      * (including the last iteration which returned false).
      */
     forEach(
-      sideEffect: (value?: V, key?: K, iter?: this) => any,
+      sideEffect: (value: V, key: K, iter: this) => any,
       context?: any
     ): number;
 
@@ -2118,7 +2118,7 @@ declare namespace Immutable {
      *
      */
     skipWhile(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): this;
 
@@ -2132,7 +2132,7 @@ declare namespace Immutable {
      *
      */
     skipUntil(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): this;
 
@@ -2158,7 +2158,7 @@ declare namespace Immutable {
      *
      */
     takeWhile(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): this;
 
@@ -2171,7 +2171,7 @@ declare namespace Immutable {
      *
      */
     takeUntil(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): this;
 
@@ -2209,11 +2209,11 @@ declare namespace Immutable {
      * Similar to `iter.map(...).flatten(true)`.
      */
     flatMap<MK, MV>(
-      mapper: (value?: V, key?: K, iter?: this) => Iterable<MK, MV>,
+      mapper: (value: V, key: K, iter: this) => Iterable<MK, MV>,
       context?: any
     ): /*this*/Iterable<MK, MV>;
     flatMap<MK, MV>(
-      mapper: (value?: V, key?: K, iter?: this) => /*iterable-like*/any,
+      mapper: (value: V, key: K, iter: this) => /*iterable-like*/any,
       context?: any
     ): /*this*/Iterable<MK, MV>;
 
@@ -2230,7 +2230,7 @@ declare namespace Immutable {
      * @see `Array#reduce`.
      */
     reduce<R>(
-      reducer: (reduction?: R, value?: V, key?: K, iter?: this) => R,
+      reducer: (reduction: R, value: V, key: K, iter: this) => R,
       initialReduction?: R,
       context?: any
     ): R;
@@ -2242,7 +2242,7 @@ declare namespace Immutable {
      * with `Array#reduceRight`.
      */
     reduceRight<R>(
-      reducer: (reduction?: R, value?: V, key?: K, iter?: this) => R,
+      reducer: (reduction: R, value: V, key: K, iter: this) => R,
       initialReduction?: R,
       context?: any
     ): R;
@@ -2251,7 +2251,7 @@ declare namespace Immutable {
      * True if `predicate` returns true for all entries in the Iterable.
      */
     every(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): boolean;
 
@@ -2259,7 +2259,7 @@ declare namespace Immutable {
      * True if `predicate` returns true for any entry in the Iterable.
      */
     some(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): boolean;
 
@@ -2289,7 +2289,7 @@ declare namespace Immutable {
      */
     count(): number;
     count(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): number;
 
@@ -2300,7 +2300,7 @@ declare namespace Immutable {
      * Note: This is not a lazy operation.
      */
     countBy<G>(
-      grouper: (value?: V, key?: K, iter?: this) => G,
+      grouper: (value: V, key: K, iter: this) => G,
       context?: any
     ): Seq.Keyed<G, number>;
 
@@ -2311,7 +2311,7 @@ declare namespace Immutable {
      * Returns the first value for which the `predicate` returns true.
      */
     find(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any,
       notSetValue?: V
     ): V;
@@ -2322,7 +2322,7 @@ declare namespace Immutable {
      * Note: `predicate` will be called for each entry in reverse.
      */
     findLast(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any,
       notSetValue?: V
     ): V;
@@ -2331,7 +2331,7 @@ declare namespace Immutable {
      * Returns the first [key, value] entry for which the `predicate` returns true.
      */
     findEntry(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any,
       notSetValue?: V
     ): [K, V];
@@ -2343,7 +2343,7 @@ declare namespace Immutable {
      * Note: `predicate` will be called for each entry in reverse.
      */
     findLastEntry(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any,
       notSetValue?: V
     ): [K, V];
@@ -2352,7 +2352,7 @@ declare namespace Immutable {
      * Returns the key for which the `predicate` returns true.
      */
     findKey(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): K;
 
@@ -2362,7 +2362,7 @@ declare namespace Immutable {
      * Note: `predicate` will be called for each entry in reverse.
      */
     findLastKey(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): K;
 
@@ -2401,7 +2401,7 @@ declare namespace Immutable {
      *
      */
     maxBy<C>(
-      comparatorValueMapper: (value?: V, key?: K, iter?: this) => C,
+      comparatorValueMapper: (value: V, key: K, iter: this) => C,
       comparator?: (valueA: C, valueB: C) => number
     ): V;
 
@@ -2430,7 +2430,7 @@ declare namespace Immutable {
      *
      */
     minBy<C>(
-      comparatorValueMapper: (value?: V, key?: K, iter?: this) => C,
+      comparatorValueMapper: (value: V, key: K, iter: this) => C,
       comparator?: (valueA: C, valueB: C) => number
     ): V;
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

There is a similar pull request here: 

https://github.com/facebook/immutable-js/pull/919

Currently the function parameters for immutablejs iterators are passed in as optional, but this is incorrect.

Despite immutablejs supplying its own typing file, the types it provides are even more incorrect: the third param in many of the iterator callbacks should be using typescript's this type. That's one reason I wanted to work off of definitelytyped's types for this PR instead of the existing ones in immutable.
