### PR TITLE
allow returning null for SFCs

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -201,7 +201,7 @@ declare namespace React {
 
     type SFC<P> = StatelessComponent<P>;
     interface StatelessComponent<P> {
-        (props: P, context?: any): ReactElement<any>;
+        (props: P, context?: any): ReactElement<any> | null;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: P;


### PR DESCRIPTION
case 2. Improvement to existing type definition.

Similar to https://github.com/DefinitelyTyped/DefinitelyTyped/blob/types-2.0/react/index.d.ts#L171.
Added earlier this year in this commit https://github.com/facebook/react/pull/5884.
