### PR TITLE
add angular-ui-router-default definition and test

### DIFF
--- a/angular-ui-router-default/angular-ui-router-default-tests.ts
+++ b/angular-ui-router-default/angular-ui-router-default-tests.ts
@@ -1,0 +1,39 @@
+/// <reference path="./angular-ui-router-default.d.ts" />
+
+angular.module("test", [
+	"ui.router",
+	"ui.router.default"
+])
+	.config(function($stateProvider: angular.ui.IStateProvider) {
+		$stateProvider
+			.state('concrete', {
+				// no abstract or default
+			})
+			.state('string', {
+				abstract: true,
+				default: 'concrete'
+			})
+			.state('func_str', {
+				abstract: true,
+				default: function($rootScope): string { return $rootScope.test; }
+			})
+			.state('func_promise', {
+				abstract: true,
+				default: function($q: ng.IQService): ng.IPromise<string> {
+					return $q.when("concrete");
+				}
+			})
+			.state('injection_str', {
+				abstract: true,
+				default: ["$rootScope", function($rootScope) {
+					return $rootScope.test;
+				}]
+			})
+			.state('injection_promise', {
+				abstract: true,
+				default: ["$q", function($q: ng.IQService) {
+					return $q.when("concrete");
+				}]
+			})
+		;
+	});

--- a/angular-ui-router-default/angular-ui-router-default.d.ts
+++ b/angular-ui-router-default/angular-ui-router-default.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for angular-ui-router-default 0.5+
+// Project: https://github.com/nonplus/angular-ui-router-default
+// Definitions by: Stepan Riha <https://github.com/nonplus>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../angular-ui-router/angular-ui-router.d.ts" />
+
+declare namespace angular.ui {
+	export type StateDefaultSpecifier = string
+		| ((...args: any[]) => string)
+		| ((...args: any[]) => ng.IPromise<string>)
+		| (string | ((...args: any[]) => string))[]
+		| (string | ((...args: any[]) => ng.IPromise<string>))[];
+	interface IState {
+		default?: StateDefaultSpecifier
+	}
+}


### PR DESCRIPTION
Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
