### PR TITLE
Fixed 'evaluateJavascript' to 'evaluateJavaScript' (phantomjs).

### DIFF
--- a/phantomjs/phantomjs.d.ts
+++ b/phantomjs/phantomjs.d.ts
@@ -89,7 +89,7 @@ interface WebPage {
 	deleteCookie(cookieName: string): boolean;
 	evaluate(fn: Function, ...args: any[]): any;
 	evaluateAsync(fn: Function): void;
-	evaluateJavascript(str: string): any; // :TODO: elaborate this when documentation improves
+	evaluateJavaScript(str: string): any; // :TODO: elaborate this when documentation improves
 	getPage(windowName: string): WebPage;
 	go(index: number): void;
 	goBack(): void;


### PR DESCRIPTION
Fixed wrong case.

references:
- http://phantomjs.org/api/webpage/method/evaluate-java-script.html
- https://github.com/ariya/phantomjs/blob/1.9/src/webpage.h#L240
