### PR TITLE
fix incorrect type in chalk

### DIFF
--- a/chalk/index.d.ts
+++ b/chalk/index.d.ts
@@ -14,7 +14,7 @@ declare namespace Chalk {
     export function hasColor(str: string): boolean;
 
     export interface ChalkChain extends ChalkStyle {
-        (): false;
+        (): boolean;
         (...text: string[]): string;
     }
 


### PR DESCRIPTION
ChalkChain conctructor return type is `false` while it should be `boolean`
