### PR TITLE
http-errors: add 421 constructor and make sure all constructors can take optional messages

### DIFF
--- a/http-errors/http-errors-tests.ts
+++ b/http-errors/http-errors-tests.ts
@@ -75,4 +75,11 @@ var err = new createError['404']();
 //createError['404'](); // TypeScript should fail with "Did you mean to include 'new'?"
 //new createError(); // TypeScript should fail with "Only a void function can be called with the 'new' keyword"
 
+// Error messages can have custom messages
+var err = new createError.NotFound('This might be a problem');
+
+// 1.5.0 supports 421 - Misdirected Request
+var err = new createError.MisdirectedRequest();
+var err = new createError.MisdirectedRequest('Where should this go?');
+
 let error: createError.HttpError;

--- a/http-errors/http-errors.d.ts
+++ b/http-errors/http-errors.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for http-errors v1.3.1
+// Type definitions for http-errors v1.5.0
 // Project: https://github.com/jshttp/http-errors
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -12,6 +12,8 @@ declare module 'http-errors' {
           statusCode: number;
           expose: boolean;
       }
+                
+      type HttpErrorConstructor = new(msg?: string) => HttpError;
 
       interface CreateHttpError {
           // See https://github.com/Microsoft/TypeScript/issues/227#issuecomment-50092674
@@ -19,68 +21,69 @@ declare module 'http-errors' {
 
           (...args: Array<Error | string | number | Object>): HttpError;
 
-          Continue: new() => HttpError;
-          SwitchingProtocols: new() => HttpError;
-          Processing: new() => HttpError;
-          OK: new() => HttpError;
-          Created: new() => HttpError;
-          Accepted: new() => HttpError;
-          NonAuthoritativeInformation: new() => HttpError;
-          NoContent: new() => HttpError;
-          ResetContent: new() => HttpError;
-          PartialContent: new() => HttpError;
-          MultiStatus: new() => HttpError;
-          AlreadyReported: new() => HttpError;
-          IMUsed: new() => HttpError;
-          MultipleChoices: new() => HttpError;
-          MovedPermanently: new() => HttpError;
-          Found: new() => HttpError;
-          SeeOther: new() => HttpError;
-          NotModified: new() => HttpError;
-          UseProxy: new() => HttpError;
-          Unused: new() => HttpError;
-          TemporaryRedirect: new() => HttpError;
-          PermanentRedirect: new() => HttpError;
-          BadRequest: new() => HttpError;
-          Unauthorized: new() => HttpError;
-          PaymentRequired: new() => HttpError;
-          Forbidden: new() => HttpError;
-          NotFound: new() => HttpError;
-          MethodNotAllowed: new() => HttpError;
-          NotAcceptable: new() => HttpError;
-          ProxyAuthenticationRequired: new() => HttpError;
-          RequestTimeout: new() => HttpError;
-          Conflict: new() => HttpError;
-          Gone: new() => HttpError;
-          LengthRequired: new() => HttpError;
-          PreconditionFailed: new() => HttpError;
-          PayloadTooLarge: new() => HttpError;
-          URITooLong: new() => HttpError;
-          UnsupportedMediaType: new() => HttpError;
-          RangeNotSatisfiable: new() => HttpError;
-          ExpectationFailed: new() => HttpError;
-          ImATeapot: new() => HttpError;
-          UnprocessableEntity: new() => HttpError;
-          Locked: new() => HttpError;
-          FailedDependency: new() => HttpError;
-          UnorderedCollection: new() => HttpError;
-          UpgradeRequired: new() => HttpError;
-          PreconditionRequired: new() => HttpError;
-          TooManyRequests: new() => HttpError;
-          RequestHeaderFieldsTooLarge: new() => HttpError;
-          UnavailableForLegalReasons: new() => HttpError;
-          InternalServerError: new() => HttpError;
-          NotImplemented: new() => HttpError;
-          BadGateway: new() => HttpError;
-          ServiceUnavailable: new() => HttpError;
-          GatewayTimeout: new() => HttpError;
-          HTTPVersionNotSupported: new() => HttpError;
-          VariantAlsoNegotiates: new() => HttpError;
-          InsufficientStorage: new() => HttpError;
-          LoopDetected: new() => HttpError;
-          BandwidthLimitExceeded: new() => HttpError;
-          NotExtended: new() => HttpError;
-          NetworkAuthenticationRequired: new() => HttpError;
+          Continue: HttpErrorConstructor;
+          SwitchingProtocols: HttpErrorConstructor;
+          Processing: HttpErrorConstructor;
+          OK: HttpErrorConstructor;
+          Created: HttpErrorConstructor;
+          Accepted: HttpErrorConstructor;
+          NonAuthoritativeInformation: HttpErrorConstructor;
+          NoContent: HttpErrorConstructor;
+          ResetContent: HttpErrorConstructor;
+          PartialContent: HttpErrorConstructor;
+          MultiStatus: HttpErrorConstructor;
+          AlreadyReported: HttpErrorConstructor;
+          IMUsed: HttpErrorConstructor;
+          MultipleChoices: HttpErrorConstructor;
+          MovedPermanently: HttpErrorConstructor;
+          Found: HttpErrorConstructor;
+          SeeOther: HttpErrorConstructor;
+          NotModified: HttpErrorConstructor;
+          UseProxy: HttpErrorConstructor;
+          Unused: HttpErrorConstructor;
+          TemporaryRedirect: HttpErrorConstructor;
+          PermanentRedirect: HttpErrorConstructor;
+          BadRequest: HttpErrorConstructor;
+          Unauthorized: HttpErrorConstructor;
+          PaymentRequired: HttpErrorConstructor;
+          Forbidden: HttpErrorConstructor;
+          NotFound: HttpErrorConstructor;
+          MethodNotAllowed: HttpErrorConstructor;
+          NotAcceptable: HttpErrorConstructor;
+          ProxyAuthenticationRequired: HttpErrorConstructor;
+          RequestTimeout: HttpErrorConstructor;
+          Conflict: HttpErrorConstructor;
+          Gone: HttpErrorConstructor;
+          LengthRequired: HttpErrorConstructor;
+          PreconditionFailed: HttpErrorConstructor;
+          PayloadTooLarge: HttpErrorConstructor;
+          URITooLong: HttpErrorConstructor;
+          UnsupportedMediaType: HttpErrorConstructor;
+          RangeNotSatisfiable: HttpErrorConstructor;
+          ExpectationFailed: HttpErrorConstructor;
+          ImATeapot: HttpErrorConstructor;
+          MisdirectedRequest: HttpErrorConstructor;
+          UnprocessableEntity: HttpErrorConstructor;
+          Locked: HttpErrorConstructor;
+          FailedDependency: HttpErrorConstructor;
+          UnorderedCollection: HttpErrorConstructor;
+          UpgradeRequired: HttpErrorConstructor;
+          PreconditionRequired: HttpErrorConstructor;
+          TooManyRequests: HttpErrorConstructor;
+          RequestHeaderFieldsTooLarge: HttpErrorConstructor;
+          UnavailableForLegalReasons: HttpErrorConstructor;
+          InternalServerError: HttpErrorConstructor;
+          NotImplemented: HttpErrorConstructor;
+          BadGateway: HttpErrorConstructor;
+          ServiceUnavailable: HttpErrorConstructor;
+          GatewayTimeout: HttpErrorConstructor;
+          HTTPVersionNotSupported: HttpErrorConstructor;
+          VariantAlsoNegotiates: HttpErrorConstructor;
+          InsufficientStorage: HttpErrorConstructor;
+          LoopDetected: HttpErrorConstructor;
+          BandwidthLimitExceeded: HttpErrorConstructor;
+          NotExtended: HttpErrorConstructor;
+          NetworkAuthenticationRequired: HttpErrorConstructor;
       }
     }
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

This fixes a bunch of type issues I was having `http-errors` when migrating to TypeScript 2.0
