### PR TITLE
fixes #11929

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -201,7 +201,7 @@ declare namespace React {
 
     type SFC<P> = StatelessComponent<P>;
     interface StatelessComponent<P> {
-        (props: P, context?: any): ReactElement<any> | null;
+        (props: P, context?: any): ReactElement<any>;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: P;


### PR DESCRIPTION
Revert breaking change made in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/11912.

I'll file an issue about that in the TypeScript repository later as I think this a bug in the way how the TypeScript compiler uses TSX. It works fine if you don't use TSX and it is "correct" to return `null` in the way the JS API behaves.
