### PR TITLE
Add transform2xxOnly option and update Version No.

### DIFF
--- a/request-promise/request-promise.d.ts
+++ b/request-promise/request-promise.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for request-promise v3.0.0
+// Type definitions for request-promise v4.1.0
 // Project: https://github.com/request/request-promise
 // Definitions by: Christopher Glantschnig <https://github.com/cglantschnig/>, Joe Skeen <http://github.com/joeskeen>, Aya Morisawa <https://github.com/AyaMorisawa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -29,6 +29,7 @@ declare module 'request-promise' {
         interface RequestPromiseOptions extends request.CoreOptions {
             simple?: boolean;
             transform?: (body: any, response: http.IncomingMessage, resolveWithFullResponse?: boolean) => any;
+            transform2xxOnly?: boolean;
             resolveWithFullResponse?: boolean;
         }
 


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Base on the release notes from v4 to v4.1, I believe the new option transform2xxOnly and the cancel() action is the only new changes, with cancel() already implemented.
