### PR TITLE
Added barThickness to ChartXAxe interface in chart.js

### DIFF
--- a/chart.js/chart.js.d.ts
+++ b/chart.js/chart.js.d.ts
@@ -345,6 +345,7 @@ interface ChartXAxe {
     stacked?: boolean;
     categoryPercentage?: number;
     barPercentage?: number;
+    barThickness?: number;
     gridLines?: GridLineOptions;
     position?: string;
     ticks?: TickOptions;


### PR DESCRIPTION
The `barThickness` option was missing in the definition file.

See [this reference in the chart.js source code](https://github.com/chartjs/Chart.js/blob/master/src/controllers/controller.bar.js#L165) or [the official docs](https://github.com/chartjs/Chart.js/blob/master/docs/04-Bar-Chart.md#chart-options).
