### PR TITLE
Added global version of material-ui

### DIFF
--- a/material-ui/material-ui-global.d.ts
+++ b/material-ui/material-ui-global.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for material-ui v0.15.1
+// Project: https://github.com/callemall/material-ui
+// Definitions by: Nathan Brown <https://github.com/ngbrown>, Oliver Herrmann <https://github.com/herrmanno>, Vladimir Pouzanov <https://github.com/farcaller>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="material-ui.d.ts" />
+
+import MaterialUI = __MaterialUI;


### PR DESCRIPTION
This adds a global re-rexport for MaterialUI for those of us who use a dedicated webpacked version in `window.MaterialUI`. I believe this doesn't need any tests as it doesn't add any functionality.
