### PR TITLE
add angularjs $q.when() overloads

### DIFF
--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -279,8 +279,14 @@ namespace TestQ {
         b: string;
         c: boolean;
     }
+    interface TValue {
+        e: number;
+        f: boolean;
+    }
     var tResult: TResult;
     var promiseTResult: angular.IPromise<TResult>;
+    var tValue: TValue;
+    var promiseTValue: angular.IPromise<TValue>;
 
     var $q: angular.IQService;
     var promiseAny: angular.IPromise<any>;
@@ -349,6 +355,22 @@ namespace TestQ {
         let result: angular.IPromise<TResult>;
         result = $q.when<TResult>(tResult);
         result = $q.when<TResult>(promiseTResult);
+
+        result = $q.when<TResult, TValue>(tValue, (result: TValue) => tResult);
+        result = $q.when<TResult, TValue>(tValue, (result: TValue) => tResult, (any) => any);
+        result = $q.when<TResult, TValue>(tValue, (result: TValue) => tResult, (any) => any, (any) => any);
+
+        result = $q.when<TResult, TValue>(promiseTValue, (result: TValue) => tResult);
+        result = $q.when<TResult, TValue>(promiseTValue, (result: TValue) => tResult, (any) => any);
+        result = $q.when<TResult, TValue>(promiseTValue, (result: TValue) => tResult, (any) => any, (any) => any);
+
+        result = $q.when<TResult, TValue>(tValue, (result: TValue) => promiseTResult);
+        result = $q.when<TResult, TValue>(tValue, (result: TValue) => promiseTResult, (any) => any);
+        result = $q.when<TResult, TValue>(tValue, (result: TValue) => promiseTResult, (any) => any, (any) => any);
+
+        result = $q.when<TResult, TValue>(promiseTValue, (result: TValue) => promiseTResult);
+        result = $q.when<TResult, TValue>(promiseTValue, (result: TValue) => promiseTResult, (any) => any);
+        result = $q.when<TResult, TValue>(promiseTValue, (result: TValue) => promiseTResult, (any) => any, (any) => any);
     }
 }
 

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1041,6 +1041,7 @@ declare namespace angular {
          * @param value Value or a promise
          */
         when<T>(value: IPromise<T>|T): IPromise<T>;
+        when<TResult, T>(value: IPromise<T>|T, successCallback: (promiseValue: T) => IPromise<TResult>|TResult, errorCallback?: (reason: any) => any, notifyCallback?: (state: any) => any): IPromise<TResult>;
         /**
          * Wraps an object that might be a value or a (3rd party) then-able promise into a $q promise. This is useful when you are dealing with an object that might or might not be a promise, or if the promise comes from a source that can't be trusted.
          */


### PR DESCRIPTION
Added missing overloads for the [$q.when()](https://code.angularjs.org/1.5.8/docs/api/ng/service/$q#when) method.

`when(value, [successCallback], [errorCallback], [progressCallback]);`
