### PR TITLE
Add type definitions for chunked-dc

### DIFF
--- a/chunked-dc/chunked-dc-tests.ts
+++ b/chunked-dc/chunked-dc-tests.ts
@@ -1,0 +1,21 @@
+/// <reference path="chunked-dc.d.ts" />
+
+// Chunker
+
+let chunker = new Chunker(1337, Uint8Array.of(1,2,3), 2);
+for (let chunk of chunker) {
+    // Do smoething with chunk
+}
+while (chunker.hasNext) {
+    let chunk = chunker.next().value;
+}
+
+// Unchunker
+
+let unchunker = new Unchunker();
+unchunker.onMessage = (message: Uint8Array, context: any[]) => {
+    // Do something with the received message
+};
+let chunk = Uint8Array.of(1,2).buffer;
+unchunker.add(chunk);
+unchunker.gc(1024);

--- a/chunked-dc/chunked-dc.d.ts
+++ b/chunked-dc/chunked-dc.d.ts
@@ -1,0 +1,55 @@
+// Type definitions for chunked-dc v0.1.2
+// Project: https://github.com/saltyrtc/chunked-dc-js
+// Definitions by: Danilo Bargen <https://github.com/dbrgn/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Interfaces
+declare namespace chunkedDc {
+
+    /** common.ts **/
+
+    interface CommonStatic {
+        HEADER_LENGTH: number;
+    }
+
+    /** chunker.ts **/
+
+    interface Chunker extends IterableIterator<Uint8Array> {
+        hasNext: boolean;
+        next(): IteratorResult<Uint8Array>;
+        [Symbol.iterator](): IterableIterator<Uint8Array>;
+    }
+
+    interface ChunkerStatic {
+        new(id: number, message: Uint8Array, chunkSize: number): Chunker
+    }
+
+    /** unchunker.ts **/
+
+    type MessageListener = (message: Uint8Array, context?: any) => void;
+
+    interface Unchunker {
+        onMessage: MessageListener;
+        add(chunk: ArrayBuffer, context?: any): void;
+        gc(maxAge: number): number;
+    }
+
+    interface UnchunkerStatic {
+        new(): Unchunker
+    }
+
+    /** main.ts **/
+
+    interface Standalone {
+        Chunker: ChunkerStatic,
+        Unchunker: UnchunkerStatic,
+    }
+
+}
+
+// Entry point for the packed ES5 version:
+declare var chunkedDc: chunkedDc.Standalone;
+
+// Entry point for the ES2015 version:
+declare var Chunker: chunkedDc.ChunkerStatic;
+declare var Unchunker: chunkedDc.UnchunkerStatic;

--- a/chunked-dc/chunked-dc.tscparams
+++ b/chunked-dc/chunked-dc.tscparams
@@ -1,0 +1,1 @@
+--target es2015 --noImplicitAny


### PR DESCRIPTION
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
