### PR TITLE
Allow arbitrary properties on TileLayerOptions

### DIFF
--- a/leaflet/leaflet-tests.ts
+++ b/leaflet/leaflet-tests.ts
@@ -166,11 +166,52 @@ mapPixelBounds = map.getPixelBounds();
 mapPixelBounds = map.getPixelWorldBounds();
 mapPixelBounds = map.getPixelWorldBounds(12);
 
+let tileLayerOptions: L.TileLayerOptions = {};
+tileLayerOptions = {
+    minZoom: 0,
+    maxZoom: 18,
+    maxNativeZoom: 2,
+    errorTileUrl: '',
+    zoomOffset: 0,
+    tms: true,
+    zoomReverse: true,
+    detectRetina: true,
+    crossOrigin: false,
+    opacity: 1,
+    updateWhenIdle: true,
+    updateWhenZooming: true,
+    updateInterval: 500,
+    attribution: '',
+    zIndex: 1,
+    noWrap: true,
+    pane: '',
+    className: '',
+    keepBuffer: 1,
+    foo: 'bar',
+    bar: () => 'foo',
+    abc: (data: any) => 'foobar'
+};
+
+tileLayerOptions.subdomains = 'a';
+tileLayerOptions.subdomains = ['a', 'b'];
+
+tileLayerOptions.tileSize = 256;
+tileLayerOptions.tileSize = point;
+//tileLayerOptions.tileSize = pointTuple; investigate if this is valid
+
+tileLayerOptions.bounds = latLngBounds;
+tileLayerOptions.bounds = latLngBoundsLiteral;
+
+let tileLayer: L.TileLayer;
+tileLayer = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png');
+tileLayer = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', tileLayerOptions);
+tileLayer = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png?{foo}&{bar}&{abc}', {foo: 'bar', bar: (data: any) => 'foo', abc: () => ''});
+
 map = map
 	// addControl
 	// removeControl
-	.addLayer(L.tileLayer(''))
-	.removeLayer(L.tileLayer('')) // use a different type of layer
+	.addLayer(tileLayer)
+	.removeLayer(tileLayer) // use a different type of layer
 	.eachLayer((currentLayer) => {
 		layer = currentLayer;
 	})

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -447,6 +447,7 @@ declare namespace L {
         zoomReverse?: boolean;
         detectRetina?: boolean;
         crossOrigin?: boolean;
+        [name: string]: any;
     }
 
     export interface TileLayer extends GridLayer {


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- Allow custom keys in `TileLayer` options 
- API http://leafletjs.com/reference-1.0.0.html#tilelayer
