### PR TITLE
Remove `children` from `ParentNode` in dom4

### DIFF
--- a/dom4/dom4.d.ts
+++ b/dom4/dom4.d.ts
@@ -5,11 +5,6 @@
 
 interface ParentNode {
     /**
-     * Returns the child elements.
-     */
-    children: HTMLCollection;
-
-    /**
      * Returns the first element that is a descendant of node that matches relativeSelectors.
      */
     query(relativeSelectors: string): Element;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- see https://github.com/Microsoft/TypeScript/blob/v2.0.3/lib/lib.d.ts#L18372
- it has been reviewed by a DefinitelyTyped member.

seems like `children` is defined in TS lib.d.ts, and has a `readonly` modifier which causes downstream compilation issues.
