### PR TITLE
Fixed custom user attribute types

### DIFF
--- a/ldclient-js/ldclient-js-tests.ts
+++ b/ldclient-js/ldclient-js-tests.ts
@@ -6,6 +6,9 @@ const ldClient = LDClient.initialize(
     {
         key: 'USER KEY',
         name: 'USER NAME',
+        custom: {
+            'CUSTOM ATTRIBUTE': ['CUSTOM VALUE'],
+        },
     },
     {
         hash: 'SECURE USER HASH',

--- a/ldclient-js/ldclient-js.d.ts
+++ b/ldclient-js/ldclient-js.d.ts
@@ -131,7 +131,9 @@ declare namespace LaunchDarkly {
         /**
          * Any additional attributes associated with the user.
          */
-        custom?: string | boolean | number | Array<string | boolean | number>;
+        custom?: {
+            [key: string]: string | boolean | number | Array<string | boolean | number>,
+        };
     }
 
     /**


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://docs.launchdarkly.com/docs/js-sdk-reference#users .
  - it has been reviewed by a DefinitelyTyped member.

I recently submitted #11916 which was merged yesterday. I realized today that there is an error in the type of the `LaunchDarkly.LDUser.custom` property. The [docs](http://docs.launchdarkly.com/docs/js-sdk-reference#users) say:

> Custom attribute values can be strings, booleans (like true or false), numbers, or lists of strings, booleans or numbers.

As a result, I incorrectly specified the type of `custom` as `string | boolean | number | Array<string | boolean | number>`. However, that should be the type of custom _attributes_; per the example given just above that comment in the docs, the `custom` property should be an object. This PR corrects that mistake and adds to the test file to make sure it does not regress.
