### PR TITLE
Add .observe() to Observable (which is added in 3.3.0)

### DIFF
--- a/kefir/kefir-tests.ts
+++ b/kefir/kefir-tests.ts
@@ -70,6 +70,19 @@ import { Observable, ObservablePool, Stream, Property, Event, Emitter } from 'ke
 	Kefir.sequentially(1000, [1, 2]).log('my stream');
 	Kefir.sequentially(1000, [1, 2]).offLog('my stream');
 	Kefir.sequentially(1000, [1, 2]).toPromise().then((x: number) => console.log('fulfilled with:', x));
+	Kefir.sequentially(1000, [1, 2]).observe({});
+	Kefir.sequentially(1000, [1, 2]).observe({
+		value: _ => {},
+		error: _ => {},
+		end: () => {},
+	});
+	Kefir.sequentially(1000, [1, 2]).observe();
+	const subscription = Kefir.sequentially(1000, [1, 2]).observe(
+		_ => {},
+		_ => {},
+		() => {}
+	);
+	if (!subscription.closed) subscription.unsubscribe();
 }
 
 // Modify an observable

--- a/kefir/kefir.d.ts
+++ b/kefir/kefir.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Kefir 3.2.0
+// Type definitions for Kefir 3.3.0
 // Project: http://rpominov.github.io/kefir/
 // Definitions by: Aya Morisawa <https://github.com/AyaMorisawa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -6,6 +6,17 @@
 /// <reference path="../node/node.d.ts" />
 
 declare module "kefir" {
+
+	export interface Subscription {
+		unsubscribe(): void;
+		closed: boolean; // Actually, `readonly` but it's avaiable in tsc starting with 2.0.0
+	}
+
+	export interface Observer<T, S> {
+		value?: (value: T) => void;
+		error?: (error: S) => void;
+		end?: () => void;
+	}
 
 	export interface Observable<T, S> {
 		// Subscribe / add side effects
@@ -22,6 +33,13 @@ declare module "kefir" {
 		flatten<U>(transformer?: (value: T) => U[]): Stream<U, S>;
 		toPromise(PromiseConstructor?: any): any;
 		toESObservable(): any;
+		// This method is designed to replace all other methods for subscribing
+		observe(params: Observer<T, S>): Subscription;
+		observe(
+			onValue?: (value: T) => void,
+			onError?: (error: S) => void,
+			onEnd?: () => void
+		): Subscription;
 	}
 
 	export interface Stream<T, S> extends Observable<T, S> {


### PR DESCRIPTION
Improvement to existing type definition.
- Added method [`Observe`](http://rpominov.github.io/kefir/#observe) (was added in 3.3.0)
