### PR TITLE
axios: Define string key for AxiosXHRConfigBase.headers

### DIFF
--- a/axios/axios-tests.ts
+++ b/axios/axios-tests.ts
@@ -69,6 +69,10 @@ axios.post("http://example.com/", {
     ]
 });
 
+var config: Axios.AxiosXHRConfigBase<any> = {headers: {}};
+config.headers['X-Custom-Header'] = 'baz';
+axios.post("http://example.com/", config);
+
 var getRepoIssue = axios.get<Issue>("https://api.github.com/repos/mzabriskie/axios/issues/1");
 
 var axiosInstance = axios.create({

--- a/axios/axios.d.ts
+++ b/axios/axios.d.ts
@@ -39,7 +39,7 @@ declare namespace Axios {
         /**
          * custom headers to be sent
          */
-        headers?: Object;
+        headers?: {[key: string]: any};
 
         /**
          * URL parameters to be sent with the request


### PR DESCRIPTION
When setting headers for a request, tsc complains that "Index signature of object type implicitly has an 'any' type." The below example would cause this error:

``` javascript
const ajaxSettings: AxiosXHRConfigBase = {headers: {}};
ajaxSettings.headers["Authorization"] = "secret";
```

Looking at Axios [dispatchRequest.js](https://github.com/mzabriskie/axios/blob/4882ce5359c0ea5238de1cda21fb40a0584f9858/lib/core/dispatchRequest.js#L37) the only expected values for a header keys are either 
- http headers
- 'common'
- an http method name with nested http headers (I think defaults for that method). eg 
  `{'header-one': 'aaa', post: {'header-two': bbb}}`

All of these keys are strings.
