### PR TITLE
add definition of tesseract.js

### DIFF
--- a/tesseract.js/tesseract.js-tests.ts
+++ b/tesseract.js/tesseract.js-tests.ts
@@ -1,0 +1,63 @@
+/// <reference path="tesseract.js.d.ts" />
+
+import * as TesseractLib from 'tesseract.js';
+
+TesseractLib.recognize("./demo.png", {
+    lang: 'chi_sim',
+}).progress(function (p) {
+    console.log('progress', p);
+}).then(function (result) {
+    console.log(result.text)
+});
+
+TesseractLib.detect("./demo.png").then(function (result) {
+    console.log(result)
+});
+
+TesseractLib.recognize("./demo.png")
+    .progress(message => console.log(message))
+    .catch(err => console.error(err))
+    .then(result => console.log(result))
+    .finally(resultOrError => console.log(resultOrError));
+
+var job1 = TesseractLib.recognize("./demo.png");
+job1.progress(message => console.log(message));
+job1.catch(err => console.error(err));
+job1.then(result => console.log(result));
+job1.finally(resultOrError => console.log(resultOrError));
+
+TesseractLib.create({
+    workerPath: '/path/to/worker.js',
+    langPath: 'https://cdn.rawgit.com/naptha/tessdata/gh-pages/3.02/',
+    corePath: 'https://cdn.rawgit.com/naptha/tesseract.js-core/0.1.0/index.js',
+});
+
+Tesseract.recognize("./demo.png", {
+    lang: 'chi_sim',
+}).progress(function (p) {
+    console.log('progress', p);
+}).then(function (result) {
+    console.log(result.text)
+});
+
+Tesseract.detect("./demo.png").then(function (result) {
+    console.log(result)
+});
+
+Tesseract.recognize("./demo.png")
+    .progress(message => console.log(message))
+    .catch(err => console.error(err))
+    .then(result => console.log(result))
+    .finally(resultOrError => console.log(resultOrError));
+
+var job2 = Tesseract.recognize("./demo.png");
+job2.progress(message => console.log(message));
+job2.catch(err => console.error(err));
+job2.then(result => console.log(result));
+job2.finally(resultOrError => console.log(resultOrError));
+
+Tesseract.create({
+    workerPath: '/path/to/worker.js',
+    langPath: 'https://cdn.rawgit.com/naptha/tessdata/gh-pages/3.02/',
+    corePath: 'https://cdn.rawgit.com/naptha/tesseract.js-core/0.1.0/index.js',
+});

--- a/tesseract.js/tesseract.js.d.ts
+++ b/tesseract.js/tesseract.js.d.ts
@@ -8,12 +8,12 @@
 declare module Tesseract {
     type ImageLike = string | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement
         | CanvasRenderingContext2D | File | Blob | ImageData | Buffer;
-    type Progress = {
+    interface Progress {
         status: string;
         progress: number;
         loaded?: number;
     }
-    type Block = {
+    interface Block {
         paragraphs: Paragraph;
         text: string;
         confidence: number;
@@ -26,20 +26,20 @@ declare module Tesseract {
         words: Word[];
         symbols: Symbol[];
     }
-    type Baseline = {
+    interface Baseline {
         x0: number;
         y0: number;
         x1: number;
         y1: number;
         has_baseline: boolean;
     }
-    type Bbox = {
+    interface Bbox {
         x0: number;
         y0: number;
         x1: number;
         y1: number;
-    };
-    type Line = {
+    }
+    interface Line {
         words: Word[];
         text: string;
         confidence: number;
@@ -50,7 +50,7 @@ declare module Tesseract {
         page: Page;
         symbols: Symbol[];
     }
-    type Paragraph = {
+    interface Paragraph {
         lines: Line[];
         text: string;
         confidence: number;
@@ -62,7 +62,7 @@ declare module Tesseract {
         words: Word[];
         symbols: Symbol[];
     }
-    type Symbol = {
+    interface Symbol {
         choices: Choice[];
         image: any;
         text: string;
@@ -78,11 +78,11 @@ declare module Tesseract {
         block: Block;
         page: Page;
     }
-    type Choice = {
+    interface Choice {
         text: string;
         confidence: number;
     }
-    type Word = {
+    interface Word {
         symbols: Symbol[];
         choices: Choice[];
         text: string;
@@ -107,7 +107,7 @@ declare module Tesseract {
         block: Block;
         page: Page;
     }
-    type Page = {
+    interface Page {
         blocks: Block[];
         confidence: number;
         html: string;
@@ -119,16 +119,16 @@ declare module Tesseract {
         text: string;
         version: string;
         words: Word[];
-    };
-    type TesseractJob = {
+    }
+    interface TesseractJob {
         then: (callback: (result: Page) => void) => TesseractJob;
         progress: (callback: (progress: Progress) => void) => TesseractJob;
         catch: (callback: (error: Error) => void) => TesseractJob;
         finally: (callback: (resultOrError: Error | Page) => void) => TesseractJob;
         error?: (error: Error) => TesseractJob;
-    };
+    }
 
-    type TesseractStatic = {
+    interface TesseractStatic {
         recognize(image: ImageLike): TesseractJob;
         recognize(image: ImageLike, options: any): TesseractJob;
         detect(image: ImageLike): TesseractJob;

--- a/tesseract.js/tesseract.js.d.ts
+++ b/tesseract.js/tesseract.js.d.ts
@@ -1,0 +1,149 @@
+// Type definitions for tesseract.js
+// Project: https://github.com/naptha/tesseract.js
+// Definitions by: York Yao <https://github.com/plantain-00/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module Tesseract {
+    type ImageLike = string | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement
+        | CanvasRenderingContext2D | File | Blob | ImageData | Buffer;
+    type Progress = {
+        status: string;
+        progress: number;
+        loaded?: number;
+    }
+    type Block = {
+        paragraphs: Paragraph;
+        text: string;
+        confidence: number;
+        baseline: Baseline;
+        bbox: Bbox;
+        blocktype: string;
+        polygon: any;
+        page: Page;
+        lines: Line[];
+        words: Word[];
+        symbols: Symbol[];
+    }
+    type Baseline = {
+        x0: number;
+        y0: number;
+        x1: number;
+        y1: number;
+        has_baseline: boolean;
+    }
+    type Bbox = {
+        x0: number;
+        y0: number;
+        x1: number;
+        y1: number;
+    };
+    type Line = {
+        words: Word[];
+        text: string;
+        confidence: number;
+        baseline: Baseline;
+        bbox: Bbox;
+        paragraph: Paragraph;
+        block: Block;
+        page: Page;
+        symbols: Symbol[];
+    }
+    type Paragraph = {
+        lines: Line[];
+        text: string;
+        confidence: number;
+        baseline: Baseline;
+        bbox: Bbox;
+        is_ltr: boolean;
+        block: Block;
+        page: Page;
+        words: Word[];
+        symbols: Symbol[];
+    }
+    type Symbol = {
+        choices: Choice[];
+        image: any;
+        text: string;
+        confidence: number;
+        baseline: Baseline;
+        bbox: Bbox;
+        is_superscript: boolean;
+        is_subscript: boolean;
+        is_dropcap: boolean;
+        word: Word;
+        line: Line;
+        paragraph: Paragraph;
+        block: Block;
+        page: Page;
+    }
+    type Choice = {
+        text: string;
+        confidence: number;
+    }
+    type Word = {
+        symbols: Symbol[];
+        choices: Choice[];
+        text: string;
+        confidence: number;
+        baseline: Baseline;
+        bbox: Bbox;
+        is_numeric: boolean;
+        in_dictionary: boolean;
+        direction: string;
+        language: string;
+        is_bold: boolean;
+        is_italic: boolean;
+        is_underlined: boolean;
+        is_monospace: boolean;
+        is_serif: boolean;
+        is_smallcaps: boolean;
+        font_size: number;
+        font_id: number;
+        font_name: string;
+        line: Line;
+        paragraph: Paragraph;
+        block: Block;
+        page: Page;
+    }
+    type Page = {
+        blocks: Block[];
+        confidence: number;
+        html: string;
+        lines: Line[];
+        oem: string;
+        paragraphs: Paragraph[];
+        psm: string;
+        symbols: Symbol[];
+        text: string;
+        version: string;
+        words: Word[];
+    };
+    type TesseractJob = {
+        then: (callback: (result: Page) => void) => TesseractJob;
+        progress: (callback: (progress: Progress) => void) => TesseractJob;
+        catch: (callback: (error: Error) => void) => TesseractJob;
+        finally: (callback: (resultOrError: Error | Page) => void) => TesseractJob;
+        error?: (error: Error) => TesseractJob;
+    };
+
+    type TesseractStatic = {
+        recognize(image: ImageLike): TesseractJob;
+        recognize(image: ImageLike, options: any): TesseractJob;
+        detect(image: ImageLike): TesseractJob;
+
+        create(paths: {
+            workerPath: string;
+            langPath: string;
+            corePath: string;
+        }): TesseractStatic;
+    }
+}
+
+declare module "tesseract.js" {
+    var Tesseract: Tesseract.TesseractStatic
+    export = Tesseract;
+}
+
+declare var Tesseract: Tesseract.TesseractStatic;


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
