### PR TITLE
Fix incorrect react-day-picker modifiers type

### DIFF
--- a/react-day-picker/index.d.ts
+++ b/react-day-picker/index.d.ts
@@ -74,10 +74,10 @@ declare namespace ReactDayPicker {
         localeUtils?: LocaleUtils;
         locale?: string;
         captionElement?: React.ReactElement<CaptionElementProps>;
-        onDayClick?: (e: React.SyntheticEvent<{}>, day: Date, modifiers: string[]) => any;
-        onDayTouchTap?: (e: React.SyntheticEvent<{}>, day: Date, modifiers: string[]) => any;
-        onDayMouseEnter?: (e: React.SyntheticEvent<{}>, day: Date, modifiers: string[]) => any;
-        onDayMouseLeave?: (e: React.SyntheticEvent<{}>, day: Date, modifiers: string[]) => any;
+        onDayClick?: (e: React.SyntheticEvent<{}>, day: Date, modifiers: DayModifiers) => any;
+        onDayTouchTap?: (e: React.SyntheticEvent<{}>, day: Date, modifiers: DayModifiers) => any;
+        onDayMouseEnter?: (e: React.SyntheticEvent<{}>, day: Date, modifiers: DayModifiers) => any;
+        onDayMouseLeave?: (e: React.SyntheticEvent<{}>, day: Date, modifiers: DayModifiers) => any;
         onDayTouchEnd?: (e: React.SyntheticEvent<{}>, day: Date, modifiers: DayModifiers) => any;
         onDayTouchStart?: (e: React.SyntheticEvent<{}>, day: Date, modifiers: DayModifiers) => any;
         navbarElement?: React.ReactElement<NavbarElementProps>;

--- a/sharepoint/SharePoint-tests.ts
+++ b/sharepoint/SharePoint-tests.ts
@@ -1198,7 +1198,7 @@ namespace CSR {
             return this.onPostRenderField(targetField, (schema, ctx: SPClientTemplates.RenderContext_FieldInForm) => {
                 if (ctx.ControlMode == SPClientTemplates.ClientControlMode.EditForm
                     || ctx.ControlMode == SPClientTemplates.ClientControlMode.NewForm) {
-                    var targetControl = CSR.getControl(schema);
+                    var targetControl = CSR.getControl(<SPClientTemplates.FieldSchema_InForm>schema);
                     sourceField.forEach((field) => {
                         CSR.addUpdatedValueCallback(ctx, field, v => {
                             dependentValues[field] = v;


### PR DESCRIPTION
Appears to have regressed from master:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/react-day-picker/react-day-picker.d.ts

Should match changes found here:
https://github.com/DefinitelyTyped/DefinitelyTyped/commit/21b05005073a35496f9fda2d133a27b4627abf1c
