### PR TITLE
Added typings for uritemplate

### DIFF
--- a/uritemplate/uritemplate-tests.ts
+++ b/uritemplate/uritemplate-tests.ts
@@ -1,0 +1,31 @@
+/// <reference path="uritemplate.d.ts" />
+
+import { UriTemplate } from 'uritemplate';
+
+function test_uritemplate() {
+
+    // syntax check: UriTemplate.parse
+    var template = UriTemplate.parse('http://localhost/categories{/categoryId}{?sort,pageNumber}');
+
+    // syntax check: template.expand
+    var url = template.expand({
+        categoryId : 'shoes',
+        sort: 'price',
+        pageNumber: 8
+    });
+
+    // import module check 
+    var expectedUrl = 'http://localhost/categories/shoes?sort=price&pageNumber=8';
+    if (expectedUrl != url) {
+        throw `Expected ${expectedUrl}, got ${url}`;
+    } else {
+        console.log('Test passed');
+    }
+
+    // syntax check: new UriTemplate.UriTemplateError
+    let error = new UriTemplate.UriTemplateError({
+        expressionText: 'error expression',
+        message: 'error message',
+        position: 5
+    });
+}

--- a/uritemplate/uritemplate.d.ts
+++ b/uritemplate/uritemplate.d.ts
@@ -1,0 +1,56 @@
+// Type definitions for URI Template JS 0.3.4
+// Project: https://github.com/fxa/uritemplate-js
+// Definitions by: Chui Tey <https://github.com/teyc/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/*
+ UriTemplate Copyright (c) 2012-2013 Franz Antesberger. All Rights Reserved.
+ Available via the MIT license.
+*/
+
+declare namespace uritemplate {
+
+    interface UriTemplate {
+        
+        /**
+         * Expands template into a string using parameter
+         * supplied
+         */
+        expand(data: {}): string;
+    }
+
+    interface UriTemplateErrorOptions {
+        expressionText: string
+        message: string
+        position: number
+    }
+
+    interface UriTemplateError {
+        new (options: UriTemplateErrorOptions): UriTemplateError
+    }
+
+
+    interface UriTemplateStatic {
+
+        /**
+         * parse template text returning instance of UriTemplate
+         * @param template text
+         * @return instance of UriTemplate
+         * @example
+         *   import UriTemplate = require('uritemplate');
+         *   let template = UriTemplate.parse('http://localhost/query{?name,city}');
+         *   let result   = template.expand({name: 'Jayden', city: 'Wodonga'});
+         *   // returns http://localhost/query?name=Jayden&city=Wodonga
+         */
+        parse(templateText: string): uritemplate.UriTemplate;
+
+        UriTemplateError: new (options: uritemplate.UriTemplateErrorOptions) => uritemplate.UriTemplateError;
+    }
+
+}
+
+declare module 'uritemplate' {
+
+    export var UriTemplate: uritemplate.UriTemplateStatic;
+
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
