### PR TITLE
Export issue with PrismJS

### DIFF
--- a/prismjs/prism.d.ts
+++ b/prismjs/prism.d.ts
@@ -2,6 +2,8 @@
 // Project: http://prismjs.com/
 // Definitions by: Erik Lieben <https://github.com/eriklieben>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+export = Prism;
+export as namespace Prism;
 
 declare namespace PrismJS {
 
@@ -161,4 +163,4 @@ declare namespace PrismJS {
 	}
 }
 
-declare var Prism : PrismJS.Prism;
+declare var Prism : PrismJS.Prism; 

--- a/prismjs/prism.d.ts
+++ b/prismjs/prism.d.ts
@@ -162,5 +162,4 @@ declare namespace PrismJS {
 		stringify(o:string| Array<any>, language: LanguageDefinition, parent: HTMLPreElement): string; 
 	}
 }
-
 declare var Prism : PrismJS.Prism; 

--- a/prismjs/prism.d.ts
+++ b/prismjs/prism.d.ts
@@ -163,4 +163,3 @@ declare namespace PrismJS {
 		
 declare var Prism : PrismJS.Prism; 
 export = Prism;
-export as namespace Prism;

--- a/prismjs/prism.d.ts
+++ b/prismjs/prism.d.ts
@@ -162,4 +162,4 @@ declare namespace PrismJS {
 }
 		
 declare var Prism : PrismJS.Prism; 
-export = Prism;
+export as namespace Prism;

--- a/prismjs/prism.d.ts
+++ b/prismjs/prism.d.ts
@@ -2,8 +2,6 @@
 // Project: http://prismjs.com/
 // Definitions by: Erik Lieben <https://github.com/eriklieben>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-export = Prism;
-export as namespace Prism;
 
 declare namespace PrismJS {
 
@@ -162,4 +160,7 @@ declare namespace PrismJS {
 		stringify(o:string| Array<any>, language: LanguageDefinition, parent: HTMLPreElement): string; 
 	}
 }
+		
 declare var Prism : PrismJS.Prism; 
+export = Prism;
+export as namespace Prism;


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

There was a problem with the importing of this module, due to the lack of export keyword.
