### PR TITLE
Update definition for leaflet 1.0

### DIFF
--- a/leaflet/leaflet-tests.ts
+++ b/leaflet/leaflet-tests.ts
@@ -207,6 +207,12 @@ tileLayer = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png');
 tileLayer = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', tileLayerOptions);
 tileLayer = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png?{foo}&{bar}&{abc}', {foo: 'bar', bar: (data: any) => 'foo', abc: () => ''});
 
+let eventHandler = () => {};
+L.DomEvent.on(htmlElement, 'click', eventHandler);
+L.DomEvent.on(htmlElement, 'click', eventHandler);
+L.DomEvent.disableScrollPropagation(htmlElement);
+L.DomEvent.disableScrollPropagation(disableClickPropagation);
+
 map = map
 	// addControl
 	// removeControl

--- a/leaflet/leaflet-tests.ts
+++ b/leaflet/leaflet-tests.ts
@@ -209,9 +209,9 @@ tileLayer = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png?{foo}&{bar}&{ab
 
 let eventHandler = () => {};
 L.DomEvent.on(htmlElement, 'click', eventHandler);
-L.DomEvent.on(htmlElement, 'click', eventHandler);
+L.DomEvent.off(htmlElement, 'click', eventHandler);
 L.DomEvent.disableScrollPropagation(htmlElement);
-L.DomEvent.disableScrollPropagation(disableClickPropagation);
+L.DomEvent.disableClickPropagation(htmlElement);
 
 map = map
 	// addControl

--- a/leaflet/leaflet-tests.ts
+++ b/leaflet/leaflet-tests.ts
@@ -210,6 +210,8 @@ tileLayer = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png?{foo}&{bar}&{ab
 let eventHandler = () => {};
 L.DomEvent.on(htmlElement, 'click', eventHandler);
 L.DomEvent.off(htmlElement, 'click', eventHandler);
+L.DomEvent.on(htmlElement, { 'click': eventHandler });
+L.DomEvent.off(htmlElement, { 'click': eventHandler }, eventHandler);
 L.DomEvent.disableScrollPropagation(htmlElement);
 L.DomEvent.disableClickPropagation(htmlElement);
 

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -1188,13 +1188,8 @@ declare namespace L {
     export namespace DomEvent {
         export function on(el: HTMLElement, types: string | Object, fn: Function, context?: any): typeof DomEvent;
         export function off(el: HTMLElement, types: string | Object, fn: Function, context?: any): typeof DomEvent;
-        export function stopPropagation(e: DOMEvent): typeof DomEvent;
         export function disableScrollPropagation(el: HTMLElement): typeof DomEvent;
         export function disableClickPropagation(el: HTMLElement): typeof DomEvent;
-        export function preventDefault(e: DOMEvent): typeof DomEvent;
-        export function stop(e: DOMEvent): typeof DomEvent;
-        export function getMousePosition(e: DOMEvent, container?: HTMLElement): Point;
-        export function getWheelDelta(e: DOMEvent): Number;
     }
 
     interface DefaultMapPanes {

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -1186,8 +1186,8 @@ declare namespace L {
     }
 
     export namespace DomEvent {
-        export function disableScrollPropagation(el: HTMLScriptElement): any;
-        export function disableClickPropagation(el: HTMLScriptElement): any;
+        export function disableScrollPropagation(el: HTMLElement): typeof DomEvent;
+        export function disableClickPropagation(el: HTMLElement): typeof DomEvent;
     }
 
     interface DefaultMapPanes {

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -1186,8 +1186,10 @@ declare namespace L {
     }
 
     export namespace DomEvent {
-        export function on(el: HTMLElement, types: string | Object, fn: Function, context?: any): typeof DomEvent;
-        export function off(el: HTMLElement, types: string | Object, fn: Function, context?: any): typeof DomEvent;
+        export function on(el: HTMLElement, types: string, fn: Function, context?: Object): typeof DomEvent;
+        export function on(el: HTMLElement, eventMap: {[eventName: string]: Function}, context?: Object): typeof DomEvent;
+        export function off(el: HTMLElement, types: string, fn: Function, context?: Object): typeof DomEvent;
+        export function off(el: HTMLElement, eventMap: {[eventName: string]: Function}, context?: Object): typeof DomEvent;
         export function disableScrollPropagation(el: HTMLElement): typeof DomEvent;
         export function disableClickPropagation(el: HTMLElement): typeof DomEvent;
     }

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -1185,6 +1185,11 @@ declare namespace L {
         distance: number;
     }
 
+    export namespace DomEvent {
+        export function disableScrollPropagation(el: HTMLScriptElement): any;
+        export function disableClickPropagation(el: HTMLScriptElement): any;
+    }
+
     interface DefaultMapPanes {
         mapPane: HTMLElement;
         tilePane: HTMLElement;

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -1186,8 +1186,15 @@ declare namespace L {
     }
 
     export namespace DomEvent {
+        export function on(el: HTMLElement, types: string | Object, fn: Function, context?: any): typeof DomEvent;
+        export function off(el: HTMLElement, types: string | Object, fn: Function, context?: any): typeof DomEvent;
+        export function stopPropagation(e: DOMEvent): typeof DomEvent;
         export function disableScrollPropagation(el: HTMLElement): typeof DomEvent;
         export function disableClickPropagation(el: HTMLElement): typeof DomEvent;
+        export function preventDefault(e: DOMEvent): typeof DomEvent;
+        export function stop(e: DOMEvent): typeof DomEvent;
+        export function getMousePosition(e: DOMEvent, container?: HTMLElement): Point;
+        export function getWheelDelta(e: DOMEvent): Number;
     }
 
     interface DefaultMapPanes {


### PR DESCRIPTION
Improvement to existing type definition.
- Add definition for `L.DomEvent.on()` ([source](https://github.com/Leaflet/Leaflet/blob/master/src/dom/DomEvent.js#L23))
- Add definition for `L.DomEvent.off()` ([source](https://github.com/Leaflet/Leaflet/blob/master/src/dom/DomEvent.js#L49))
- Add definition for `L.DomEvent.disableScrollPropagation()` ([source](https://github.com/Leaflet/Leaflet/blob/master/src/dom/DomEvent.js#L172))
- Add definition for `L.DomEvent.disableClickPropagation()` ([source](https://github.com/Leaflet/Leaflet/blob/master/src/dom/DomEvent.js#L179))

All tests passed!
