### PR TITLE
[underscore] added iteratee shorthand syntax for some usages of map and uniq

### DIFF
--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>, Josh Baldwin <https://github.com/jbaldwin/>, Christopher Currens <https://github.com/ccurrens/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+import IterateeMatcherShorthand = _.IterateeMatcherShorthand;
+import IterateePropertyShorthand = _.IterateePropertyShorthand;
 declare module _ {
 	/**
 	* underscore.js _.throttle options.
@@ -66,6 +68,10 @@ declare module _ {
 	interface ObjectIterator<T, TResult> {
 		(element: T, key: string, list: Dictionary<T>): TResult;
 	}
+
+	type IterateePropertyShorthand = string | number;
+
+	type IterateeMatcherShorthand<T> = Dictionary<T>;
 
 	interface MemoIterator<T, TResult> {
 		(prev: TResult, curr: T, index: number, list: List<T>): TResult;
@@ -146,7 +152,7 @@ interface UnderscoreStatic {
 	**/
 	map<T, TResult>(
 		list: _.List<T>,
-		iterator: _.ListIterator<T, TResult>,
+		iterator: _.ListIterator<T, TResult> | _.IterateePropertyShorthand | _.IterateeMatcherShorthand<any>,
 		context?: any): TResult[];
 
 	/**
@@ -158,15 +164,16 @@ interface UnderscoreStatic {
 	**/
 	map<T, TResult>(
 		object: _.Dictionary<T>,
-		iterator: _.ObjectIterator<T, TResult>,
+		iterator: _.ObjectIterator<T, TResult> ,
 		context?: any): TResult[];
+
 
 	/**
 	* @see _.map
 	**/
 	collect<T, TResult>(
 		list: _.List<T>,
-		iterator: _.ListIterator<T, TResult>,
+		iterator: _.ListIterator<T, TResult> | _.IterateePropertyShorthand | _.IterateeMatcherShorthand<any>,
 		context?: any): TResult[];
 
 	/**
@@ -900,7 +907,7 @@ interface UnderscoreStatic {
 	uniq<T, TSort>(
 		array: _.List<T>,
 		isSorted?: boolean,
-		iterator?: _.ListIterator<T, TSort>,
+		iterator?: _.ListIterator<T, TSort> | _.IterateePropertyShorthand,
 		context?: any): T[];
 
 	/**
@@ -916,7 +923,7 @@ interface UnderscoreStatic {
 	**/
 	unique<T, TSort>(
 		array: _.List<T>,
-		iterator?: _.ListIterator<T, TSort>,
+		iterator?: _.ListIterator<T, TSort> | _.IterateePropertyShorthand,
 		context?: any): T[];
 
 	/**

--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -162,7 +162,7 @@ interface UnderscoreStatic {
 	**/
 	map<T, TResult>(
 		object: _.Dictionary<T>,
-		iterator: _.ObjectIterator<T, TResult> ,
+		iterator: _.ObjectIterator<T, TResult>,
 		context?: any): TResult[];
 
 

--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>, Josh Baldwin <https://github.com/jbaldwin/>, Christopher Currens <https://github.com/ccurrens/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import IterateeMatcherShorthand = _.IterateeMatcherShorthand;
-import IterateePropertyShorthand = _.IterateePropertyShorthand;
 declare module _ {
 	/**
 	* underscore.js _.throttle options.


### PR DESCRIPTION
In underscore, many functions accept what the documentation calls an iteratee.
An iteratee is a function with a signature depending on the type of the collection of types applied to the method.
However, when the documentation mention "iteratee", it also means that whatever is provided to this param will be passed to the _.iteratee function.

The _.iteratee function returns 
- _.identity when nothing is provided.
- the same function when a function is provided
- a _.matcher function when an object is provided
- a _.property function when everything else is provided

Both last cases (object and everything else) act as shorthand syntax to generate the iterators.

So instead of writing 

``` js
const result1 = _.map([{a:1}, {a:2, b:1}, {a:3, b:2}], obj => ( obj["a" ]) ); //[1, 2, 3]
```

You can write instead 

``` js
const result1 = _.map([{a:1}, {a:2, b:1}, {a:3, b:2}], "a"); //[1, 2, 3]
```

Under the hood "a" is passed to _.iteratee which returns _.property("a")

Also instead of writing 

``` js
const result2 = _.map([{a:1}, {a:2, b:1}, {a:3, b:"foo"}], obj => (obj["a"] === 2 && obj["b"] === 1)); //[false, true, false]
```

``` js
const result2 = _.map([{a:1}, {a:2, b:1, c:3}, {a:3, b:"foo"}], {a:2, b:1}); //result [false, true, false]
```

The problem is that current state of the typings doesn't allow these shorthands syntax.

So i have written a tentative proposition to allow this.
I have written them for map and uniq, using the use case that did make most sense, ie property and matcher for map, and only property for uniq.
Also for the property shorthand, i have reduced the key format to string and number since i think this would be the most frequent case and it makes things less complicated.

I'm no typing ninja, so please review these typings before inclusion. Any suggestion, comments, alternative syntax are welcomed.
If this is useful for others and if this proposition is accepted, i could add them to all underscore methods that accept an iteratee.
