### PR TITLE
add type definitions for 'random-seed' package

### DIFF
--- a/random-seed/random-seed-tests.ts
+++ b/random-seed/random-seed-tests.ts
@@ -1,0 +1,20 @@
+/// <reference path="./random-seed.d.ts" />
+import * as gen from "random-seed";
+
+// these generators produce different numbers
+let rand1 = gen.create(); // method 1
+let rand2 = gen();        // method 3
+
+// these generators will produce
+// the same sequence of numbers
+let seed = 'My Secret String Value';
+let rand3 = gen.create(seed);
+let rand4 = gen(seed);
+
+// API
+rand1.addEntropy();
+rand1.random();
+rand1.range(100);
+rand1.intBetween(0, 10);
+rand1.floatBetween(0, 1);
+rand1.seed("new seed");

--- a/random-seed/random-seed-tests.ts
+++ b/random-seed/random-seed-tests.ts
@@ -1,15 +1,13 @@
 /// <reference path="./random-seed.d.ts" />
-import * as gen from "random-seed";
+import { RandomSeed, create } from "random-seed";
 
 // these generators produce different numbers
-let rand1 = gen.create(); // method 1
-let rand2 = gen();        // method 3
+let rand1: RandomSeed = create(); // method 1
 
 // these generators will produce
 // the same sequence of numbers
 let seed = 'My Secret String Value';
-let rand3 = gen.create(seed);
-let rand4 = gen(seed);
+let rand2 = create(seed);
 
 // API
 rand1.addEntropy();

--- a/random-seed/random-seed.d.ts
+++ b/random-seed/random-seed.d.ts
@@ -1,0 +1,33 @@
+// Type definitions for random-seed 0.3.0
+// Project: https://github.com/skratchdot/random-seed/
+// Definitions by: Endel Dreyer <https://github.com/endel>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "random-seed" {
+
+  interface RandomSeed {
+    range (range: number): number;
+    random (): number;
+    floatBetween (min: number, max: number): number;
+    intBetween (min: number, max: number): number;
+
+    string (count: number): string;
+    seed (seed: string): void;
+
+    cleanString (inStr: string): string;
+    hashString (inStr: string): string;
+
+    addEntropy (...args: any[]): void;
+    initState (): void;
+
+    done (): void;
+  }
+
+  function create (seed?: string): RandomSeed;
+
+  namespace create {
+    function create(seed?: string): RandomSeed;
+  }
+
+  export = create;
+}

--- a/random-seed/random-seed.d.ts
+++ b/random-seed/random-seed.d.ts
@@ -5,7 +5,7 @@
 
 declare module "random-seed" {
 
-  interface RandomSeed {
+  export interface RandomSeed {
     range (range: number): number;
     random (): number;
     floatBetween (min: number, max: number): number;
@@ -23,11 +23,6 @@ declare module "random-seed" {
     done (): void;
   }
 
-  function create (seed?: string): RandomSeed;
+  export function create (seed?: string): RandomSeed;
 
-  namespace create {
-    function create(seed?: string): RandomSeed;
-  }
-
-  export = create;
 }


### PR DESCRIPTION
Type definitions for [random-seed](https://github.com/skratchdot/random-seed)
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
