### PR TITLE
Added methods from Joi.any() to the root exports

### DIFF
--- a/joi/joi-tests.ts
+++ b/joi/joi-tests.ts
@@ -801,3 +801,56 @@ Joi.isRef(ref);
 schema = Joi.reach(schema, '');
 
 const Joi2 = Joi.extend({ name: '', base: schema });
+
+// --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+
+schema = Joi.allow(x, x);
+schema = Joi.allow([x, x, x]);
+schema = Joi.valid(x);
+schema = Joi.valid(x, x);
+schema = Joi.valid([x, x, x]);
+schema = Joi.only(x);
+schema = Joi.only(x, x);
+schema = Joi.only([x, x, x]);
+schema = Joi.equal(x);
+schema = Joi.equal(x, x);
+schema = Joi.equal([x, x, x]);
+schema = Joi.invalid(x);
+schema = Joi.invalid(x, x);
+schema = Joi.invalid([x, x, x]);
+schema = Joi.disallow(x);
+schema = Joi.disallow(x, x);
+schema = Joi.disallow([x, x, x]);
+schema = Joi.not(x);
+schema = Joi.not(x, x);
+schema = Joi.not([x, x, x]);
+
+schema = Joi.required();
+schema = Joi.optional();
+schema = Joi.forbidden();
+schema = Joi.strip();
+
+schema = Joi.description(str);
+schema = Joi.notes(str);
+schema = Joi.notes(strArr);
+schema = Joi.tags(str);
+schema = Joi.tags(strArr);
+
+schema = Joi.meta(obj);
+schema = Joi.example(obj);
+schema = Joi.unit(str);
+
+schema = Joi.options(validOpts);
+schema = Joi.strict();
+schema = Joi.strict(bool);
+schema = Joi.concat(x);
+
+schema = Joi.when(str, whenOpts);
+schema = Joi.when(ref, whenOpts);
+
+schema = Joi.label(str);
+schema = Joi.raw();
+schema = Joi.raw(bool);
+schema = Joi.empty();
+schema = Joi.empty(str);
+schema = Joi.empty(anySchema);

--- a/joi/joi.d.ts
+++ b/joi/joi.d.ts
@@ -879,4 +879,118 @@ declare module 'joi' {
 	 */
 	export function extend(extention: Extension): any;
 
+	/**
+	 * Whitelists a value
+	 */
+	export function allow(value: any, ...values: any[]): Schema;
+	export function allow(values: any[]): Schema;
+
+	/**
+	 * Adds the provided values into the allowed whitelist and marks them as the only valid values allowed.
+	 */
+	export function valid(value: any, ...values: any[]): Schema;
+	export function valid(values: any[]): Schema;
+	export function only(value: any, ...values : any[]): Schema;
+	export function only(values: any[]): Schema;
+	export function equal(value: any, ...values : any[]): Schema;
+	export function equal(values: any[]): Schema;
+
+	/**
+	 * Blacklists a value
+	 */
+	export function invalid(value: any, ...values: any[]): Schema;
+	export function invalid(values: any[]): Schema;
+	export function disallow(value: any, ...values : any[]): Schema;
+	export function disallow(values: any[]): Schema;
+	export function not(value: any, ...values : any[]): Schema;
+	export function not(values: any[]): Schema;
+
+	/**
+	 * Marks a key as required which will not allow undefined as value. All keys are optional by default.
+	 */
+	export function required(): Schema;
+
+	/**
+	 * Marks a key as optional which will allow undefined as values. Used to annotate the schema for readability as all keys are optional by default.
+	 */
+	export function optional(): Schema;
+
+	/**
+	 * Marks a key as forbidden which will not allow any value except undefined. Used to explicitly forbid keys.
+	 */
+	export function forbidden(): Schema;
+
+	/**
+	 * Marks a key to be removed from a resulting object or array after validation. Used to sanitize output.
+	 */
+	export function strip(): Schema;
+
+	/**
+	 * Annotates the key
+	 */
+	export function description(desc: string): Schema;
+
+	/**
+	 * Annotates the key
+	 */
+	export function notes(notes: string): Schema;
+	export function notes(notes: string[]): Schema;
+
+	/**
+	 * Annotates the key
+	 */
+	export function tags(notes: string): Schema;
+	export function tags(notes: string[]): Schema;
+
+	/**
+	 * Attaches metadata to the key.
+	 */
+	export function meta(meta: Object): Schema;
+
+	/**
+	 * Annotates the key with an example value, must be valid.
+	 */
+	export function example(value: any): Schema;
+
+	/**
+	 * Annotates the key with an unit name.
+	 */
+	export function unit(name: string): Schema;
+
+	/**
+	 * Overrides the global validate() options for the current key and any sub-key.
+	 */
+	export function options(options: ValidationOptions): Schema;
+
+	/**
+	 * Sets the options.convert options to false which prevent type casting for the current key and any child keys.
+	 */
+	export function strict(isStrict?: boolean): Schema;
+
+	/**
+	 * Returns a new type that is the result of adding the rules of one type to another.
+	 */
+	export function concat<T>(schema: T): T;
+
+	/**
+	 * Converts the type into an alternatives type where the conditions are merged into the type definition where:
+	 */
+	export function when<U>(ref: string, options: WhenOptions<U>): AlternativesSchema;
+	export function when<U>(ref: Reference, options: WhenOptions<U>): AlternativesSchema;
+
+	/**
+	 * Overrides the key name in error messages.
+	 */
+	export function label(name: string): Schema;
+
+	/**
+	 * Outputs the original untouched value instead of the casted value.
+	 */
+	export function raw(isRaw?: boolean): Schema;
+
+	/**
+	 * Considers anything that matches the schema to be empty (undefined).
+	 * @param schema - any object or joi schema to match. An undefined schema unsets that rule.
+	 */
+	export function empty(schema?: any) : Schema;
 }


### PR DESCRIPTION
Added methods from Joi.any() to the root exports, as the root clones Joi.any() (see line 31 of https://github.com/hapijs/joi/blob/1ea86e6ad16c218714b39209bac3be99a0c598dd/lib/index.js) and a number of the any methods (such as Joi.required()) are necessary for use with the .when method.

case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
