### PR TITLE
Add definitions for 'aws-serverless-express'

### DIFF
--- a/aws-serverless-express/aws-serverless-express-tests.ts
+++ b/aws-serverless-express/aws-serverless-express-tests.ts
@@ -1,0 +1,29 @@
+/// <reference path="./aws-serverless-express.d.ts" />
+/// <reference path="../express/express.d.ts"/>
+
+import * as awsServerlessExpress from 'aws-serverless-express';
+import * as express from 'express';
+
+const app = express();
+const server = awsServerlessExpress.createServer(app, () => {});
+
+const mockEvent = {
+    key: 'value'
+};
+
+const mockContext = {
+    callbackWaitsForEmptyEventLoop: true,
+    functionName: 'testFunction',
+    functionVersion: '1',
+    invokedFunctionArn: 'arn',
+    memoryLimitInMB: 128,
+    awsRequestId: 'id',
+    logGroupName: 'group',
+    logStreamName: 'stream',
+    getRemainingTimeInMillis: () => 2000,
+    done: () => false,
+    fail: (error: any) => false,
+    succeed: (message: string) => false
+};
+
+awsServerlessExpress.proxy(server, mockEvent, mockContext);

--- a/aws-serverless-express/aws-serverless-express.d.ts
+++ b/aws-serverless-express/aws-serverless-express.d.ts
@@ -1,0 +1,24 @@
+// Type definitions for aws-serverless-express
+// Project: https://github.com/awslabs/aws-serverless-express
+// Definitions by: Ben Speakman <https://github.com/threesquared>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts"/>
+/// <reference path="../aws-lambda/aws-lambda.d.ts"/>
+
+declare module 'aws-serverless-express' {
+
+    import * as http from 'http';
+    import * as lambda from 'aws-lambda';
+
+    export function createServer(
+        requestListener: (request: http.IncomingMessage, response: http.ServerResponse) => http.Server,
+        serverListenCallback?: () => any
+    ): http.Server;
+
+    export function proxy(
+        server: http.Server,
+        event: any,
+        context: lambda.Context
+    ): void;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
