### PR TITLE
Adding formats property in quill options

### DIFF
--- a/quill/quill.d.ts
+++ b/quill/quill.d.ts
@@ -10,7 +10,8 @@ declare namespace QuillJS {
         modules?: { [key: string]: any },
         placeholder?: string,
         readOnly?: boolean,
-        theme?: string
+        theme?: string,
+        formats?: string[] 
     }
 
     export interface BoundsStatic {


### PR DESCRIPTION
Quill options [object](https://github.com/quilljs/quill/blob/189563a27fe18ef97688d948d458eabe316db1d3/core/quill.js#L303)
