### PR TITLE
Make $scope optional in IComponentControllerService locals

### DIFF
--- a/angular-mocks/angular-mocks-tests.ts
+++ b/angular-mocks/angular-mocks-tests.ts
@@ -106,7 +106,7 @@ $componentController<{}, { test: boolean }>('Test controller', { $scope: <ng.ISc
 $componentController<{}, { test?: boolean }>('Test controller', { $scope: <ng.IScope>{} }, {});
 $componentController<{}, {}>('Test controller', { $scope: <ng.IScope>{} }, {}, 'identity');
 $componentController<{ cb: () => void }, {}>('Test controller', { $scope: <ng.IScope>{} });
-$componentController<{}, {test:{name:string}}>('Test controller', { test: {name:'Test Local'} });
+$componentController<{}, { test: {name: string} }>('Test controller', { test: {name: 'Test Local'} });
 
 ///////////////////////////////////////
 // IHttpBackendService
@@ -452,11 +452,11 @@ requestHandler.passThrough().passThrough();
 requestHandler.respond((method, url, data, headers) => [404, 'data', { header: 'value' }, 'responseText']);
 requestHandler.respond((method, url, data, headers) => [404, 'data', { header: 'value' }, 'responseText']).respond({});
 requestHandler.respond((method, url, data, headers) => { return [404, { key: 'value' }, { header: 'value' }, 'responseText']; });
-requestHandler.respond((method, url, data, headers, params) => { 
+requestHandler.respond((method, url, data, headers, params) => {
     if(params.id === 1) {
         return [200, { key: 'value'}, { header: 'value'}, 'responseText'];
     } else {
-        return [404, { key: 'value' }, { header: 'value' }, 'responseText']; 
+        return [404, { key: 'value' }, { header: 'value' }, 'responseText'];
     }
 });
 requestHandler.respond('data');

--- a/angular-mocks/angular-mocks-tests.ts
+++ b/angular-mocks/angular-mocks-tests.ts
@@ -106,6 +106,7 @@ $componentController<{}, { test: boolean }>('Test controller', { $scope: <ng.ISc
 $componentController<{}, { test?: boolean }>('Test controller', { $scope: <ng.IScope>{} }, {});
 $componentController<{}, {}>('Test controller', { $scope: <ng.IScope>{} }, {}, 'identity');
 $componentController<{ cb: () => void }, {}>('Test controller', { $scope: <ng.IScope>{} });
+$componentController<{}, {test:{name:string}}>('Test controller', { test: {name:'Test Local'} });
 
 ///////////////////////////////////////
 // IHttpBackendService

--- a/angular-mocks/index.d.ts
+++ b/angular-mocks/index.d.ts
@@ -107,7 +107,7 @@ declare module 'angular' {
   interface IComponentControllerService {
     // TBinding is an interface exposed by a component as per John Papa's style guide
     // https://github.com/johnpapa/angular-styleguide/blob/master/a1/README.md#accessible-members-up-top
-    <T, TBinding>(componentName: string, locals: { $scope: IScope, [key: string]: any }, bindings?: TBinding, ident?: string): T;
+    <T, TBinding>(componentName: string, locals: { $scope?: IScope, [key: string]: any }, bindings?: TBinding, ident?: string): T;
   }
 
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.

The `locals` definition for `IComponentControllerService` does not need `$scope` as mandatory dependency (v1.5.4+). It will be used if passed in, otherwise it creates a new isolate scope from `$rootScope`. Hence making that dependency optional.

[Official Doc Reference](https://code.angularjs.org/1.5.8/docs/api/ngMock/service/$componentController)
