### PR TITLE
Add definition for bwip-js

### DIFF
--- a/bwip-js/bwip-js-tests.ts
+++ b/bwip-js/bwip-js-tests.ts
@@ -1,0 +1,43 @@
+/// <reference path="./bwip-js.d.ts" />
+/// <reference path="../node/node.d.ts" />
+'use strict';
+
+import * as bwipjs from 'bwip-js';
+import * as http from 'http';
+import * as fs from 'fs';
+
+bwipjs.loadFont('Inconsolata', 108,
+    fs.readFileSync('fonts/Inconsolata.otf', 'binary'));
+
+
+http.createServer(function(req, res) {
+    // If the url does not begin /?bcid= then 404.  Otherwise, we end up
+    // returning 400 on requests like favicon.ico.
+    if (req.url.indexOf('/?bcid=') != 0) {
+        res.writeHead(404, { 'Content-Type':'text/plain' });
+        res.end('BWIPJS: Unknown request format.', 'utf8');
+    } else {
+        bwipjs(req, res);
+    }
+
+}).listen(3030);
+
+bwipjs.toBuffer({
+    bcid:        'code128',       // Barcode type
+    text:        '0123456789',    // Text to encode
+    scale:       3,               // 3x scaling factor
+    height:      10,              // Bar height, in millimeters
+    includetext: true,            // Show human-readable text
+    textxalign:  'center',        // Always good to set this
+    textfont:    'Inconsolata',   // Use your custom font
+    textsize:    13               // Font size, in points
+}, function (err:string|Error, png: Buffer) {
+    if (err) {
+        console.log(err);
+    } else {
+        // `png` is a Buffer
+        // png.length           : PNG file length
+        // png.readUInt32BE(16) : PNG image width
+        // png.readUInt32BE(20) : PNG image height
+    }
+});

--- a/bwip-js/bwip-js.d.ts
+++ b/bwip-js/bwip-js.d.ts
@@ -1,0 +1,86 @@
+// Type definitions for bwip-js 1.1.1
+// Project: https://github.com/metafloor/bwip-js
+// Definitions by: TANAKA Koichi <https://github.com/MugeSo/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module 'bwip-js' {
+    import {IncomingMessage as Request, ServerResponse as Response} from 'http';
+
+    module BwipJs {
+        export function loadFont(fontName:string, sizeMulti: number, fontFile: string): void;
+        export function toBuffer(opts: ToBufferOptions, callback:(err: string|Error, png: Buffer) => void): void;
+        interface ToBufferOptions {
+            bcid: string;
+            text: string;
+
+            parse?: boolean;
+            parsefunc?: boolean;
+
+            height?: number;
+            width?: number;
+
+            scaleX?: number;
+            scaleY?: number;
+            scale?: number;
+
+            rotate?: 'N'|'R'|'L'|'I';
+
+            paddingwidth?: number;
+            paddingheight?: number;
+
+            monochrome?: boolean;
+            alttext?: boolean;
+
+            includetext?: boolean;
+            textfont?: string;
+            textsize?: number;
+            textgaps?: number;
+
+            textxalign?:'offleft'|'left'|'center'|'right'|'offright'|'justify';
+            textyalign?:'below'|'center'|'above';
+            textxoffset?: number;
+            textyoffset?: number;
+
+            showborder?: boolean;
+            borderwidth?: number;
+            borderleft?: number;
+            borderright?: number;
+            bordertop?: number;
+            boraderbottom?: number;
+
+            barcolor?: string;
+            backgroundcolor?: string;
+            bordercolor?: string;
+            textcolor?: string;
+
+            addontextxoffset?: number;
+            addontextyoffset?: number;
+            addontextfont?: string;
+            addontextsize?: number;
+
+            guardwhitespace?: boolean;
+            guardwidth?: number;
+            guardheight?: number;
+            guardleftpos?: number;
+            guardrightpos?: number;
+            guardleftypos?: number;
+            guardrightypos?: number;
+
+            sizelimit?: number;
+
+            includecheck?: boolean;
+            includecheckintext?: boolean;
+
+            inkspread?: number;
+            inkspreadh?: number;
+            inkspreadv?: number;
+        }
+    }
+
+
+    function BwipJs(req: Request, res: Response, opts?:BwipJs.ToBufferOptions): void;
+
+    export = BwipJs;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Project: https://github.com/metafloor/bwip-js
npm: https://www.npmjs.com/package/bwip-js
