### PR TITLE
Fix analytics node definition to work with `es6` module definition.

### DIFF
--- a/analytics-node/analytics-node-tests.ts
+++ b/analytics-node/analytics-node-tests.ts
@@ -1,7 +1,7 @@
 /// <reference path="./analytics-node.d.ts" />
 
-var analytics: AnalyticsNode.Analytics;
-import Analytics = require("analytics-node");
+import Analytics from "analytics-node";
+var analytics: Analytics;
 
 function testConfig(): void {
   analytics = new Analytics('YOUR_WRITE_KEY', {

--- a/analytics-node/analytics-node.d.ts
+++ b/analytics-node/analytics-node.d.ts
@@ -3,13 +3,13 @@
 // Definitions by: Andrew Fong <https://github.com/fongandrew>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace AnalyticsNode {
+declare module "analytics-node" {
 
   interface Integrations {
     [index: string]: boolean;
   }
 
-  export class Analytics {
+  export default class Analytics {
     constructor(writeKey: string, opts?: {
       flushAt?: number,
       flushAfter?: number


### PR DESCRIPTION
Fix analytics node definition to work with `es6` module definition.
