### PR TITLE
Update request.d.ts

### DIFF
--- a/request/index.d.ts
+++ b/request/index.d.ts
@@ -97,7 +97,7 @@ declare namespace request {
         followRedirect?: boolean | ((response: http.IncomingMessage) => boolean);
         followAllRedirects?: boolean;
         maxRedirects?: number;
-        encoding?: string;
+        encoding?: string | null;
         pool?: any;
         timeout?: number;
         proxy?: any;


### PR DESCRIPTION
Use `string | null` for CoreOptions.encoding type as the encoding has to be null in order to get a buffer as the body (needed to download files). [see documentation](https://github.com/request/request#requestoptions-callback)
