### PR TITLE
Expose structural GraphQL types

### DIFF
--- a/graphql/index.d.ts
+++ b/graphql/index.d.ts
@@ -19,69 +19,7 @@ declare module "graphql" {
 
 
     // Create and operate on GraphQL type definitions and schema.
-    export {
-        GraphQLSchema,
-
-        // Definitions
-        GraphQLScalarType,
-        GraphQLObjectType,
-        GraphQLInterfaceType,
-        GraphQLUnionType,
-        GraphQLEnumType,
-        GraphQLInputObjectType,
-        GraphQLList,
-        GraphQLNonNull,
-        GraphQLDirective,
-
-        // "Enum" of Type Kinds
-        TypeKind,
-
-        // "Enum" of Directive Locations
-        DirectiveLocation,
-
-        // Scalars
-        GraphQLInt,
-        GraphQLFloat,
-        GraphQLString,
-        GraphQLBoolean,
-        GraphQLID,
-
-        // Built-in Directives defined by the Spec
-        specifiedDirectives,
-        GraphQLIncludeDirective,
-        GraphQLSkipDirective,
-        GraphQLDeprecatedDirective,
-
-        // Constant Deprecation Reason
-        DEFAULT_DEPRECATION_REASON,
-
-        // Meta-field definitions.
-        SchemaMetaFieldDef,
-        TypeMetaFieldDef,
-        TypeNameMetaFieldDef,
-
-        // GraphQL Types for introspection.
-        __Schema,
-        __Directive,
-        __DirectiveLocation,
-        __Type,
-        __Field,
-        __InputValue,
-        __EnumValue,
-        __TypeKind,
-
-        // Predicates
-        isType,
-        isInputType,
-        isOutputType,
-        isLeafType,
-        isCompositeType,
-        isAbstractType,
-
-        // Un-modifiers
-        getNullableType,
-        getNamedType,
-    } from 'graphql/type';
+    export * from 'graphql/type';
 
 
     // Parse and operate on GraphQL language source files.
@@ -1014,29 +952,7 @@ declare module "graphql/type/index" {
     // GraphQL Schema definition
     export { GraphQLSchema } from 'graphql/type/schema';
 
-    export {
-        // Predicates
-        isType,
-        isInputType,
-        isOutputType,
-        isLeafType,
-        isCompositeType,
-        isAbstractType,
-
-        // Un-modifiers
-        getNullableType,
-        getNamedType,
-
-        // Definitions
-        GraphQLScalarType,
-        GraphQLObjectType,
-        GraphQLInterfaceType,
-        GraphQLUnionType,
-        GraphQLEnumType,
-        GraphQLInputObjectType,
-        GraphQLList,
-        GraphQLNonNull,
-    } from 'graphql/type/definition';
+    export * from 'graphql/type/definition';
 
     export {
         // "Enum" of Directive Locations
@@ -1098,7 +1014,7 @@ declare module "graphql/type/definition" {
     /**
      * These are all of the possible kinds of types.
      */
-    type GraphQLType =
+    export type GraphQLType =
         GraphQLScalarType |
         GraphQLObjectType |
         GraphQLInterfaceType |
@@ -1108,12 +1024,12 @@ declare module "graphql/type/definition" {
         GraphQLList<any> |
         GraphQLNonNull<any>;
 
-    function isType(type: any): boolean;
+    function isType(type: any): type is GraphQLType;
 
     /**
      * These types may be used as input types for arguments and directives.
      */
-    type GraphQLInputType =
+    export type GraphQLInputType =
         GraphQLScalarType |
         GraphQLEnumType |
         GraphQLInputObjectType |
@@ -1125,12 +1041,12 @@ declare module "graphql/type/definition" {
         GraphQLList<any>
         >;
 
-    function isInputType(type: GraphQLType): boolean;
+    function isInputType(type: GraphQLType): type is GraphQLInputType;
 
     /**
      * These types may be used as output types as the result of fields.
      */
-    type GraphQLOutputType =
+    export type GraphQLOutputType =
         GraphQLScalarType |
         GraphQLObjectType |
         GraphQLInterfaceType |
@@ -1146,40 +1062,40 @@ declare module "graphql/type/definition" {
         GraphQLList<any>
         >;
 
-    function isOutputType(type: GraphQLType): boolean;
+    function isOutputType(type: GraphQLType): type is GraphQLOutputType;
 
     /**
      * These types may describe types which may be leaf values.
      */
-    type GraphQLLeafType =
+    export type GraphQLLeafType =
         GraphQLScalarType |
         GraphQLEnumType;
 
-    function isLeafType(type: GraphQLType): boolean;
+    function isLeafType(type: GraphQLType): type is GraphQLLeafType;
 
     /**
      * These types may describe the parent context of a selection set.
      */
-    type GraphQLCompositeType =
+    export type GraphQLCompositeType =
         GraphQLObjectType |
         GraphQLInterfaceType |
         GraphQLUnionType;
 
-    function isCompositeType(type: GraphQLType): boolean;
+    function isCompositeType(type: GraphQLType): type is GraphQLCompositeType;
 
     /**
      * These types may describe the parent context of a selection set.
      */
-    type GraphQLAbstractType =
+    export type GraphQLAbstractType =
         GraphQLInterfaceType |
         GraphQLUnionType;
 
-    function isAbstractType(type: GraphQLType): boolean;
+    function isAbstractType(type: GraphQLType): type is GraphQLAbstractType;
 
     /**
      * These types can all accept null as a value.
      */
-    type GraphQLNullableType =
+    export type GraphQLNullableType =
         GraphQLScalarType |
         GraphQLObjectType |
         GraphQLInterfaceType |
@@ -1195,7 +1111,7 @@ declare module "graphql/type/definition" {
     /**
      * These named types do not include modifiers like List or NonNull.
      */
-    type GraphQLNamedType =
+    export type GraphQLNamedType =
         GraphQLScalarType |
         GraphQLObjectType |
         GraphQLInterfaceType |
@@ -1245,7 +1161,7 @@ declare module "graphql/type/definition" {
         toString(): string;
     }
 
-    interface GraphQLScalarTypeConfig<TInternal, TExternal> {
+    export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
         name: string;
         description?: string;
         serialize: (value: any) => TInternal;
@@ -1303,7 +1219,7 @@ declare module "graphql/type/definition" {
 
     //
 
-    interface GraphQLObjectTypeConfig<TSource> {
+    export interface GraphQLObjectTypeConfig<TSource> {
         name: string;
         interfaces?: Thunk<Array<GraphQLInterfaceType>>;
         fields: Thunk<GraphQLFieldConfigMap<TSource>>;
@@ -1311,26 +1227,26 @@ declare module "graphql/type/definition" {
         description?: string
     }
 
-    type GraphQLTypeResolveFn = (
+    export type GraphQLTypeResolveFn = (
         value: any,
         context: any,
         info: GraphQLResolveInfo
     ) => GraphQLObjectType;
 
-    type GraphQLIsTypeOfFn = (
+    export type GraphQLIsTypeOfFn = (
         source: any,
         context: any,
         info: GraphQLResolveInfo
     ) => boolean;
 
-    type GraphQLFieldResolveFn<TSource> = (
+    export type GraphQLFieldResolveFn<TSource> = (
         source: TSource,
         args: { [argName: string]: any },
         context: any,
         info: GraphQLResolveInfo
     ) => any;
 
-    interface GraphQLResolveInfo {
+    export interface GraphQLResolveInfo {
         fieldName: string;
         fieldASTs: Array<Field>;
         returnType: GraphQLOutputType;
@@ -1343,7 +1259,7 @@ declare module "graphql/type/definition" {
         variableValues: { [variableName: string]: any };
     }
 
-    interface GraphQLFieldConfig<TSource> {
+    export interface GraphQLFieldConfig<TSource> {
         type: GraphQLOutputType;
         args?: GraphQLFieldConfigArgumentMap;
         resolve?: GraphQLFieldResolveFn<TSource>;
@@ -1351,21 +1267,21 @@ declare module "graphql/type/definition" {
         description?: string;
     }
 
-    interface GraphQLFieldConfigArgumentMap {
+    export interface GraphQLFieldConfigArgumentMap {
         [argName: string]: GraphQLArgumentConfig;
     }
 
-    interface GraphQLArgumentConfig {
+    export interface GraphQLArgumentConfig {
         type: GraphQLInputType;
         defaultValue?: any;
         description?: string;
     }
 
-    interface GraphQLFieldConfigMap<TSource> {
+    export interface GraphQLFieldConfigMap<TSource> {
         [fieldName: string]: GraphQLFieldConfig<TSource>;
     }
 
-    interface GraphQLFieldDefinition {
+    export interface GraphQLFieldDefinition {
         name: string;
         description: string;
         type: GraphQLOutputType;
@@ -1375,14 +1291,14 @@ declare module "graphql/type/definition" {
         deprecationReason: string;
     }
 
-    interface GraphQLArgument {
+    export interface GraphQLArgument {
         name: string;
         type: GraphQLInputType;
         defaultValue?: any;
         description?: string;
     }
 
-    interface GraphQLFieldDefinitionMap {
+    export interface GraphQLFieldDefinitionMap {
         [fieldName: string]: GraphQLFieldDefinition;
     }
 
@@ -1416,7 +1332,7 @@ declare module "graphql/type/definition" {
         toString(): string;
     }
 
-    interface GraphQLInterfaceTypeConfig {
+    export interface GraphQLInterfaceTypeConfig {
         name: string,
         fields: Thunk<GraphQLFieldConfigMap<any>>,
         /**
@@ -1463,7 +1379,7 @@ declare module "graphql/type/definition" {
         toString(): string;
     }
 
-    interface GraphQLUnionTypeConfig {
+    export interface GraphQLUnionTypeConfig {
         name: string,
         types: Thunk<Array<GraphQLObjectType>>,
         /**
@@ -1508,23 +1424,23 @@ declare module "graphql/type/definition" {
         toString(): string;
     }
 
-    interface GraphQLEnumTypeConfig {
+    export interface GraphQLEnumTypeConfig {
         name: string;
         values: GraphQLEnumValueConfigMap;
         description?: string;
     }
 
-    interface GraphQLEnumValueConfigMap {
+    export interface GraphQLEnumValueConfigMap {
         [valueName: string]: GraphQLEnumValueConfig;
     }
 
-    interface GraphQLEnumValueConfig {
+    export interface GraphQLEnumValueConfig {
         value?: any;
         deprecationReason?: string;
         description?: string;
     }
 
-    interface GraphQLEnumValueDefinition {
+    export interface GraphQLEnumValueDefinition {
         name: string;
         description: string;
         deprecationReason: string;
@@ -1554,36 +1470,36 @@ declare module "graphql/type/definition" {
     class GraphQLInputObjectType {
         name: string;
         description: string;
-        constructor(config: InputObjectConfig);
+        constructor(config: GraphQLInputObjectConfig);
         getFields(): InputObjectFieldMap;
         toString(): string;
     }
 
-    interface InputObjectConfig {
+    export interface GraphQLInputObjectConfig {
         name: string;
         fields: Thunk<InputObjectConfigFieldMap>;
         description?: string;
     }
 
-    interface InputObjectFieldConfig {
+    export interface GraphQLInputObjectFieldConfig {
         type: GraphQLInputType;
         defaultValue?: any;
         description?: string;
     }
 
-    interface InputObjectConfigFieldMap {
-        [fieldName: string]: InputObjectFieldConfig;
+    export interface InputObjectConfigFieldMap {
+        [fieldName: string]: GraphQLInputObjectFieldConfig;
     }
 
-    interface InputObjectField {
+    export interface GraphQLInputObjectField {
         name: string;
         type: GraphQLInputType;
         defaultValue?: any;
         description?: string;
     }
 
-    interface InputObjectFieldMap {
-        [fieldName: string]: InputObjectField;
+    export interface InputObjectFieldMap {
+        [fieldName: string]: GraphQLInputObjectField;
     }
 
     /**


### PR DESCRIPTION
The types that were moved to the top level export in this change are fundamental to the way GraphQL objects are defined, especially when it comes to generating them. When `GraphQLInputType` of `GraphQLObjectFieldConfig` are the return type of functions they should definitely be exported.

In PostGraphQL we have been [rolling our own types](https://github.com/calebmer/postgraphql/blob/5a5ad3aa540d05da659df26e6fd744dd1800895d/typings/graphql.d.ts) for the `graphql` module. We’d like to use the definitions published under the `@types` namespace if possible. These changes are required to make that migration.
