### PR TITLE
Bunyan - A serializer returns any , not string.

### DIFF
--- a/bunyan/bunyan-tests.ts
+++ b/bunyan/bunyan-tests.ts
@@ -56,7 +56,20 @@ var options:bunyan.LoggerOptions = {
 
 var log = bunyan.createLogger(options);
 
+var customSerializer = function(anything: any) {
+    return { obj: anything};
+};
+
+log.addSerializers({anything: customSerializer});
 log.addSerializers(bunyan.stdSerializers);
+log.addSerializers(
+    {
+        err: bunyan.stdSerializers.err,
+        req: bunyan.stdSerializers.req,
+        res: bunyan.stdSerializers.res
+    }
+);
+
 var child = log.child({name: 'child'});
 child.reopenFileStreams();
 log.addStream({path: '/dev/null'});

--- a/bunyan/bunyan.d.ts
+++ b/bunyan/bunyan.d.ts
@@ -11,7 +11,7 @@ declare module "bunyan" {
     class Logger extends EventEmitter {
         constructor(options:LoggerOptions);
         addStream(stream:Stream):void;
-        addSerializers(serializers:Serializers):void;
+        addSerializers(serializers:Serializers | StdSerializers):void;
         child(options:LoggerOptions, simple?:boolean):Logger;
         child(obj:Object, simple?:boolean):Logger;
         reopenFileStreams():void;
@@ -21,7 +21,7 @@ declare module "bunyan" {
         levels(name: number | string, value: number | string):void;
 
         fields:any;
-        src:boolean;       
+        src:boolean;
 
         trace(error:Error, format?:any, ...params:any[]):void;
         trace(buffer:Buffer, format?:any, ...params:any[]):void;
@@ -58,8 +58,18 @@ declare module "bunyan" {
         src?: boolean;
     }
 
+	interface Serializer {
+		(input:any): any;
+	}
+
     interface Serializers {
-        [key:string]: (input:any) => string;
+        [key:string]: Serializer;
+    }
+
+    interface StdSerializers {
+        err: Serializer;
+        res: Serializer;
+        req: Serializer;
     }
 
     interface Stream {
@@ -72,7 +82,7 @@ declare module "bunyan" {
         count?: number;
     }
 
-    export var stdSerializers:Serializers;
+    export var stdSerializers: StdSerializers;
 
     export var TRACE:number;
     export var DEBUG:number;


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

The original serializer definition is : 

``` typescript
interface Serializers {
        [key:string]: (input:any) => string;
}
```

However, in the source code, Req Serializers, Err serializers and REs serializer all return a JSON Object.  See `res`: 

``` javascript
// Serialize an HTTP response.
Logger.stdSerializers.res = function res(res) {
    if (!res || !res.statusCode)
        return res;
    return {
        statusCode: res.statusCode,
        header: res._header
    }
};
```

So I just changed this, and also added a definition for these 3 default serializers.
- I also added a definition for the 3 defaults serializers (err, res and req)
