### PR TITLE
koa ```listen``` allow empty arguments

### DIFF
--- a/koa/koa-tests.ts
+++ b/koa/koa-tests.ts
@@ -19,3 +19,5 @@ app.use(ctx => {
 });
 
 app.listen(3000);
+
+const server = app.listen();

--- a/koa/koa.d.ts
+++ b/koa/koa.d.ts
@@ -159,6 +159,7 @@ declare module "koa" {
         constructor();
 
         // From node.d.ts
+        listen(): http.Server;
         listen(port: number, hostname?: string, backlog?: number, listeningListener?: Function): http.Server;
         listen(port: number, hostname?: string, listeningListener?: Function): http.Server;
         listen(port: number, backlog?: number, listeningListener?: Function): http.Server;


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

https://github.com/koajs/koa/blob/a293cc2d5e714281260111b6729929fcf379a93f/test/context/state.js#L16
and the `server.listen([port][, hostname][, backlog][, callback])` all parameters is options
https://nodejs.org/api/net.html#net_server_listen_port_hostname_backlog_callback
