### PR TITLE
Fixing react-addons-shallow-compare

### DIFF
--- a/react-addons-shallow-compare/index.d.ts
+++ b/react-addons-shallow-compare/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for React v0.14 (react-addons-css-transition-group)
+// Type definitions for React v0.14 (react-addons-shallow-compare)
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -6,6 +6,10 @@
 import { Component } from 'react';
 
 export = shallowCompare;
+
+// workaround to allow ES6 import syntax
+// https://github.com/Microsoft/TypeScript/issues/5073
+declare namespace shallowCompare {}
 
 declare function shallowCompare<P, S>(
     component: Component<P, S>,

--- a/react-addons-shallow-compare/react-addons-shallow-compare-tests.ts
+++ b/react-addons-shallow-compare/react-addons-shallow-compare-tests.ts
@@ -1,0 +1,2 @@
+/// <reference path="tests/import-commonjs.tsx" />
+/// <reference path="tests/import-es6.tsx" />

--- a/react-addons-shallow-compare/tests/import-commonjs.tsx
+++ b/react-addons-shallow-compare/tests/import-commonjs.tsx
@@ -1,0 +1,12 @@
+import React = require('react');
+import shallowCompare = require('react-addons-shallow-compare');
+
+export class MyComponent extends React.Component<{}, {}> {
+    shouldComponentUpdate(nextProps: any, nextState: any, nextContext: any): boolean {
+        return shallowCompare(this, nextProps, nextState);
+    }
+
+    render() {
+        return <div>empty</div>;
+    }
+}

--- a/react-addons-shallow-compare/tests/import-es6.tsx
+++ b/react-addons-shallow-compare/tests/import-es6.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import * as shallowCompare from 'react-addons-shallow-compare';
+
+export class MyComponent extends React.Component<{}, {}> {
+    shouldComponentUpdate(nextProps: any, nextState: any, nextContext: any): boolean {
+        return shallowCompare(this, nextProps, nextState);
+    }
+
+    render() {
+        return <div>empty</div>;
+    }
+}

--- a/react-addons-shallow-compare/tsconfig.json
+++ b/react-addons-shallow-compare/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "react-addons-shallow-compare-tests.ts"
     ],
     "compilerOptions": {
         "module": "commonjs",
@@ -13,6 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "preserve"
     }
 }


### PR DESCRIPTION
Seems like in TypeScript 2.0 this is still present https://github.com/Microsoft/TypeScript/issues/5073.
