### PR TITLE
ng-dialog: Added bindToController option to IDialogOpenOptions.

### DIFF
--- a/ng-dialog/ng-dialog.d.ts
+++ b/ng-dialog/ng-dialog.d.ts
@@ -236,6 +236,7 @@ declare namespace angular.dialog {
 		template: string;
 		controller?: string| any[] | any;
 		controllerAs?: string;
+		bindToController?: boolean;
 
 		/**
 		 * Scope object that will be passed to dialog. If you use controller with separate $scope service this object will be passed to $scope.$parent param.


### PR DESCRIPTION
Add option to existing type definition.

The option 'bindToController' is discussed in the project documentation 
https://github.com/likeastore/ngDialog#api.
