### PR TITLE
Fixes #12097 [enzyme] enzyme.d.ts need to be updated to match latest released version

### DIFF
--- a/enzyme/enzyme-tests.tsx
+++ b/enzyme/enzyme-tests.tsx
@@ -96,6 +96,18 @@ namespace ShallowWrapperTest {
         boolVal = shallowWrapper.containsAnyMatchingElements([<div className="foo bar"/>]);
     }
 
+    function test_dive() {
+        interface TmpProps {
+            foo: any
+        }
+
+        interface TmpState {
+            bar: any
+        }
+
+        const diveWrapper: ShallowWrapper<TmpProps, TmpState> = shallowWrapper.dive<TmpProps, TmpState>({ context: { foobar: 'barfoo' }});
+    }
+
     function test_equals() {
         boolVal = shallowWrapper.equals(<div className="foo bar"/>);
     }
@@ -222,11 +234,11 @@ namespace ShallowWrapperTest {
     }
 
     function test_setState() {
-        shallowWrapper = shallowWrapper.setState({ stateProperty: 'state' });
+        shallowWrapper = shallowWrapper.setState({ stateProperty: 'state' }, () => console.log('state updated'));
     }
 
     function test_setProps() {
-        shallowWrapper = shallowWrapper.setProps({ propsProperty: 'foo' });
+        shallowWrapper = shallowWrapper.setProps({ propsProperty: 'foo' }, () => console.log('props updated'));
     }
 
     function test_setContext() {

--- a/enzyme/enzyme.d.ts
+++ b/enzyme/enzyme.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for Enzyme v2.4.1
+// Type definitions for Enzyme v2.5.1
 // Project: https://github.com/airbnb/enzyme
-// Definitions by: Marian Palkus <https://github.com/MarianPalkus>, Cap3 <http://www.cap3.de>
+// Definitions by: Marian Palkus <https://github.com/MarianPalkus>, Cap3 <http://www.cap3.de>, Ivo Stratev <https://github.com/NoHomey>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 ///<reference path="../react/react.d.ts" />
@@ -253,8 +253,9 @@ declare module "enzyme" {
          *
          * NOTE: can only be called on a wrapper instance that is also the root instance.
          * @param state
+         * @param [callback]
          */
-        setState(state: S): this;
+        setState(state: S, callback?: () => void): this;
 
         /**
          * A method that sets the props of the root component, and re-renders. Useful for when you are wanting to test
@@ -265,9 +266,10 @@ declare module "enzyme" {
          * Returns itself.
          *
          * NOTE: can only be called on a wrapper instance that is also the root instance.
-         * @param state
+         * @param props
+         * @param [callback]
          */
-        setProps(props: P): this;
+        setProps(props: P, callback?: () => void): this;
 
         /**
          * A method that sets the context of the root component, and re-renders. Useful for when you are wanting to
@@ -423,6 +425,13 @@ declare module "enzyme" {
          */
         childAt(index: number): ShallowWrapper<any, any>;
         childAt<P2, S2>(index: number): ShallowWrapper<P2, S2>;
+
+        /**
+         * Shallow render the one non-DOM child of the current wrapper, and return a wrapper around the result.
+         * NOTE: can only be called on wrapper of a single non-DOM component element node.
+         * @param [options]
+         */
+        dive<P2, S2>(options?: ShallowRendererProps): ShallowWrapper<P2, S2>;
 
         /**
          * Returns a wrapper around all of the parents/ancestors of the wrapper. Does not include the node in the


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes:

The following API changes have been made in [2.5.0](https://github.com/airbnb/enzyme/blob/master/CHANGELOG.md#250-october-17-2016):
- new optional `callback` argument to `setState` and `setProps`
- new `dive` method to `ShallowWrapper`

[2.5.1](https://github.com/airbnb/enzyme/blob/master/CHANGELOG.md#251-october-17-2016) brings no API changes.
