### PR TITLE
Expose Knex interface

### DIFF
--- a/knex/knex.d.ts
+++ b/knex/knex.d.ts
@@ -16,28 +16,28 @@ declare module "knex" {
   type ColumnName = string|Knex.Raw|Knex.QueryBuilder;
   type TableName = string|Knex.Raw|Knex.QueryBuilder;
 
-  interface Knex extends Knex.QueryInterface {
-    (tableName?: string): Knex.QueryBuilder;
-    VERSION: string;
-    __knex__: string;
-
-    raw: Knex.RawBuilder;
-    transaction: <R>(transactionScope: ((trx: Knex.Transaction) => void)) => Promise<any>;
-    destroy(callback: Function): void;
-    destroy(): Promise<void>;
-
-    schema: Knex.SchemaBuilder;
-
-    client: any;
-    migrate: Knex.Migrator;
-    seed: any;
-    fn: Knex.FunctionHelper;
-    on(eventName: string, callback: Function): Knex.QueryBuilder;
-  }
-
-  function Knex(config: Knex.Config) : Knex;
+  function Knex(config: Knex.Config) : Knex.Knex;
 
   namespace Knex {
+    interface Knex extends Knex.QueryInterface {
+      (tableName?: string): Knex.QueryBuilder;
+      VERSION: string;
+      __knex__: string;
+
+      raw: Knex.RawBuilder;
+      transaction: <R>(transactionScope: ((trx: Knex.Transaction) => void)) => Promise<any>;
+      destroy(callback: Function): void;
+      destroy(): Promise<void>;
+
+      schema: Knex.SchemaBuilder;
+
+      client: any;
+      migrate: Knex.Migrator;
+      seed: any;
+      fn: Knex.FunctionHelper;
+      on(eventName: string, callback: Function): Knex.QueryBuilder;
+    }
+    
     //
     // QueryInterface
     //


### PR DESCRIPTION
The Knex interface is useful when passing the connection object around in an application. Without it, modules that receive the dependency cannot declare the type of the dependency.
This pull request simply aims at exposing the interface without further changes.
