### PR TITLE
Added typings for `react-native-sortable-list` component

### DIFF
--- a/react-native-sortable-list/react-native-sortable-list-tests.tsx
+++ b/react-native-sortable-list/react-native-sortable-list-tests.tsx
@@ -1,0 +1,208 @@
+/// <reference path="../react/react.d.ts"/>
+/// <reference path="../react-native/react-native.d.ts"/>
+/// <reference path="react-native-sortable-list.d.ts" />
+
+import * as React from 'react';
+import {
+    Animated,
+    Easing,
+    AppRegistry,
+    StyleSheet,
+    Text,
+    Image,
+    View,
+    Dimensions,
+    FlexJustifyType,
+    FlexAlignType
+} from 'react-native';
+import SortableList, {RowProps} from 'react-native-sortable-list';
+
+
+const window = Dimensions.get('window');
+
+const data = {
+    0: {
+        image: 'https://placekitten.com/200/200',
+        text: 'Chloe',
+    },
+    1: {
+        image: 'https://placekitten.com/200/201',
+        text: 'Jasper',
+    },
+    2: {
+        image: 'https://placekitten.com/200/202',
+        text: 'Pepper',
+    },
+    3: {
+        image: 'https://placekitten.com/200/203',
+        text: 'Oscar',
+    },
+    4: {
+        image: 'https://placekitten.com/200/204',
+        text: 'Dusty',
+    },
+    5: {
+        image: 'https://placekitten.com/200/205',
+        text: 'Spooky',
+    },
+    6: {
+        image: 'https://placekitten.com/200/210',
+        text: 'Kiki',
+    },
+    7: {
+        image: 'https://placekitten.com/200/215',
+        text: 'Smokey',
+    },
+    8: {
+        image: 'https://placekitten.com/200/220',
+        text: 'Gizmo',
+    },
+    9: {
+        image: 'https://placekitten.com/220/239',
+        text: 'Kitty',
+    },
+};
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        justifyContent: "center" as FlexJustifyType,
+        alignItems: "center" as FlexAlignType,
+        backgroundColor: '#eee',
+        paddingTop: 60,
+    },
+
+    list: {
+        flex: 1,
+    },
+
+    contentContainer: {
+        width: window.width,
+        paddingHorizontal: 30,
+    },
+
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        backgroundColor: 'white',
+        padding: 16,
+        marginVertical: 5,
+        height: 90,
+        width: window.width - 30 * 2,
+        borderRadius: 4,
+        shadowColor: 'rgba(0,0,0,0.2)',
+        shadowOpacity: 1,
+        shadowOffset: {height: 2, width: 2},
+        shadowRadius: 2,
+    },
+
+    image: {
+        width: 60,
+        height: 60,
+        marginRight: 30,
+        borderRadius: 30,
+    },
+
+    text: {
+        fontSize: 24,
+    },
+
+});
+
+class Basic extends React.Component<void, void> {
+    render() {
+        return (
+            <View style={styles.container}>
+                <SortableList
+                    style={styles.list}
+                    contentContainerStyle={styles.contentContainer}
+                    data={data}
+                    renderRow={this._renderRow}/>
+            </View>
+        );
+    }
+
+    _renderRow = ({data, active}: RowProps) => {
+        return <Row data={data} active={active}/>
+    }
+}
+
+interface RowState {
+    style: {
+        shadowRadius: Animated.Value
+        transform: {scale: Animated.Value}[]
+    }
+}
+
+class Row extends React.Component<RowProps, RowState> {
+
+    state = {
+        style: {
+            shadowRadius: new Animated.Value(2),
+            transform: [{scale: new Animated.Value(1)}],
+        }
+    };
+
+    componentWillReceiveProps(nextProps: RowProps) {
+        if (this.props.active !== nextProps.active) {
+            if (this.props.active !== nextProps.active) {
+                if (nextProps.active) {
+                    this.startActivationAnimation();
+                } else {
+                    this.startDeactivationAnimation();
+                }
+            }
+        }
+    }
+
+    startActivationAnimation = () => {
+        const {style} = this.state;
+
+        Animated.parallel([
+            Animated.timing(style.transform[0].scale, {
+                duration: 100,
+                easing: Easing.out(Easing.quad),
+                toValue: 1.1
+            }),
+            Animated.timing(style.shadowRadius, {
+                duration: 100,
+                easing: Easing.out(Easing.quad),
+                toValue: 10
+            }),
+        ]).start();
+    };
+
+    startDeactivationAnimation = () => {
+        const {style} = this.state;
+
+        Animated.parallel([
+            Animated.timing(style.transform[0].scale, {
+                duration: 100,
+                easing: Easing.out(Easing.quad),
+                toValue: 1
+            }),
+            Animated.timing(style.shadowRadius, {
+                duration: 100,
+                easing: Easing.out(Easing.quad),
+                toValue: 2
+            }),
+        ]).start();
+    };
+
+    render() {
+        const {data} = this.props;
+
+        return (
+            <Animated.View style={[
+                styles.row,
+                this.state.style,
+    ]}>
+                <Image source={{uri: data.image}} style={styles.image}/>
+                <Text style={styles.text}>{data.text}</Text>
+            </Animated.View>
+        );
+    }
+}
+
+
+AppRegistry.registerComponent('Basic', () => Basic);

--- a/react-native-sortable-list/react-native-sortable-list.d.ts
+++ b/react-native-sortable-list/react-native-sortable-list.d.ts
@@ -1,0 +1,99 @@
+// Type definitions for react-native-sortable-list
+// Project: https://github.com/gitim/react-native-sortable-list
+// Definitions by: Michael Sivolobov <https://github.com/sivolobov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../react/react.d.ts"/>
+/// <reference path="../react-native/react-native.d.ts"/>
+
+declare namespace __SortableList {
+
+    type DataKey = string | number;
+
+    export type DataValue = any
+
+    type DataByNumber = {
+        [key: number]: DataValue
+    }
+
+    type DataByString = {
+        [key: string]: DataValue
+    }
+
+    export type Data = DataByNumber | DataByString;
+
+    export interface RowProps {
+        active: boolean
+        data: DataValue
+        key?: DataKey
+        index?: number
+        disabled?: boolean
+    }
+
+    interface SortableListProps {
+
+        /**
+         * data source
+         */
+        data: Data
+
+        /**
+         * an array of keys from data, the order of keys from the array will be used to initial rows order
+         */
+        order?: DataKey[]
+
+        /**
+         * style of HOC
+         */
+        style?: React.ViewStyle
+
+        /**
+         * these styles will be applied to the inner scroll view content container
+         */
+        contentContainerStyle?: React.ViewStyle
+
+        /**
+         * when false, rows are not sortable. The default value is true.
+         */
+        sortingEnabled?: boolean
+
+        /**
+         * when false, the content does not scrollable. The default value is true.
+         */
+        scrollEnabled?: boolean
+
+        /**
+         * Takes a row key, row index, data entry from the data source and its statuses disabled,
+         *  active and should return a renderable component to be rendered as the row.
+         */
+        renderRow: (props: RowProps) => JSX.Element
+
+        /**
+         * Called when rows were reordered, takes an array of rows keys of the next rows order.
+         */
+        onChangeOrder?: (nextOrder: DataKey[]) => void
+
+        /**
+         * Called when a row was activated (user long tapped).
+         */
+        onActivateRow?: (key: DataKey) => void
+
+        /**
+         * Called when the active row was released.
+         */
+        onReleaseRow?: (key: DataKey) => void
+    }
+
+    export interface SortableListStatic extends React.ClassicComponentClass<SortableListProps> {}
+
+    export var SortableList: SortableListStatic;
+    export type SortableList = SortableListStatic;
+}
+
+declare module 'react-native-sortable-list' {
+    import SortableList = __SortableList;
+
+    export interface RowProps extends SortableList.RowProps {}
+
+    export default SortableList.SortableList;
+}

--- a/react-native-sortable-list/tsconfig.json
+++ b/react-native-sortable-list/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "target": "es6",
+        "noImplicitAny": true
+    }
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
