### PR TITLE
Fix object-assign

### DIFF
--- a/object-assign/index.d.ts
+++ b/object-assign/index.d.ts
@@ -10,4 +10,7 @@ declare function objectAssign<T, U, V, W>(target: T, source1: U, source2: V, sou
 declare function objectAssign<T, U, V, W, Q>(target: T, source1: U, source2: V, source3: W, source4: Q): T & U & V & W & Q;
 declare function objectAssign<T, U, V, W, Q, R>(target: T, source1: U, source2: V, source3: W, source4: Q, source5: R): T & U & V & W & Q & R;
 declare function objectAssign(target: any, ...sources: any[]): any;
+
+declare namespace objectAssign {}
+
 export = objectAssign;

--- a/object-assign/object-assign-tests.ts
+++ b/object-assign/object-assign-tests.ts
@@ -1,5 +1,5 @@
 
-import objectAssign = require("object-assign");
+import * as objectAssign from "object-assign";
 
 interface Target {
   hellow: string;
@@ -10,7 +10,7 @@ interface Source1 {
 }
 
 interface Result extends Target, Source1 {
-  
+
 }
 
 interface Source2 {
@@ -18,7 +18,7 @@ interface Source2 {
 }
 
 interface Result2 extends Result, Source2 {
-  
+
 }
 
 interface Source3 {
@@ -26,7 +26,7 @@ interface Source3 {
 }
 
 interface Result3 extends Result2, Source3 {
-  
+
 }
 
 interface Source4 {
@@ -34,7 +34,7 @@ interface Source4 {
 }
 
 interface Result4 extends Result3, Source4 {
-  
+
 }
 
 interface Source5 {
@@ -42,7 +42,7 @@ interface Source5 {
 }
 
 interface Result5 extends Result4, Source5 {
-  
+
 }
 
 function assign1(): Result {


### PR DESCRIPTION
Improved the object-assign type definition in order for it to work with `import * as objectAssign from 'object-assign';`.

Follows #11709 of `master` branch.
