### PR TITLE
Rewrite WebRTC RTCPeerConnection definitions

### DIFF
--- a/webrtc/MediaStream.d.ts
+++ b/webrtc/MediaStream.d.ts
@@ -6,6 +6,11 @@
 // Taken from http://dev.w3.org/2011/webrtc/editor/getusermedia.html
 // version: W3C Editor's Draft 29 June 2015
 
+interface ConstrainBooleanParameters {
+    exact?: boolean;
+    ideal?: boolean;
+}
+
 interface NumberRange {
     max?: number;
     min?: number;
@@ -21,6 +26,11 @@ interface ConstrainStringParameters {
     ideal?: string | string[];
 }
 
+interface MediaStreamConstraints {
+    video?: boolean | MediaTrackConstraints;
+    audio?: boolean | MediaTrackConstraints;
+}
+
 declare namespace W3C {
     type LongRange = NumberRange;
     type DoubleRange = NumberRange;
@@ -31,16 +41,49 @@ declare namespace W3C {
     type ConstrainString = string | string[] | ConstrainStringParameters;
 }
 
+interface MediaTrackConstraints extends MediaTrackConstraintSet {
+    advanced?: MediaTrackConstraintSet[];
+}
+
 interface MediaTrackConstraintSet {
+    width?: W3C.ConstrainLong;
+    height?: W3C.ConstrainLong;
+    aspectRatio?: W3C.ConstrainDouble;
+    frameRate?: W3C.ConstrainDouble;
+    facingMode?: W3C.ConstrainString;
+    volume?: W3C.ConstrainDouble;
+    sampleRate?: W3C.ConstrainLong;
+    sampleSize?: W3C.ConstrainLong;
     echoCancellation?: W3C.ConstrainBoolean;
     latency?: W3C.ConstrainDouble;
+    deviceId?: W3C.ConstrainString;
+    groupId?: W3C.ConstrainString;
 }
 
 interface MediaTrackSupportedConstraints {
+    width?: boolean;
+    height?: boolean;
+    aspectRatio?: boolean;
+    frameRate?: boolean;
+    facingMode?: boolean;
+    volume?: boolean;
+    sampleRate?: boolean;
+    sampleSize?: boolean;
+    echoCancellation?: boolean;
     latency?: boolean;
+    deviceId?: boolean;
+    groupId?: boolean;
 }
 
 interface MediaStream extends EventTarget {
+    //id: string;
+    //active: boolean;
+
+    //onactive: EventListener;
+    //oninactive: EventListener;
+    //onaddtrack: (event: MediaStreamTrackEvent) => any;
+    //onremovetrack: (event: MediaStreamTrackEvent) => any;
+
     clone(): MediaStream;
     stop(): void;
 
@@ -54,12 +97,29 @@ interface MediaStream extends EventTarget {
     removeTrack(track: MediaStreamTrack): void;
 }
 
+interface MediaStreamTrackEvent extends Event {
+    //track: MediaStreamTrack;
+}
+
 declare enum MediaStreamTrackState {
 	"live",
     "ended"
 }
 
 interface MediaStreamTrack extends EventTarget {
+    //id: string;
+    //kind: string;
+    //label: string;
+    enabled: boolean;
+    //muted: boolean;
+    //remote: boolean;
+    //readyState: MediaStreamTrackState;
+
+    //onmute: EventListener;
+    //onunmute: EventListener;
+    //onended: EventListener;
+    //onoverconstrained: EventListener;
+
     clone(): MediaStreamTrack;
 
     stop(): void;
@@ -71,11 +131,39 @@ interface MediaStreamTrack extends EventTarget {
 }
 
 interface MediaTrackCapabilities {
+    //width: number | W3C.LongRange;
+    //height: number | W3C.LongRange;
+    //aspectRatio: number | W3C.DoubleRange;
+    //frameRate: number | W3C.DoubleRange;
+    //facingMode: string;
+    //volume: number | W3C.DoubleRange;
+    //sampleRate: number | W3C.LongRange;
+    //sampleSize: number | W3C.LongRange;
+    //echoCancellation: boolean[];
     latency: number | W3C.DoubleRange;
+    //deviceId: string;
+    //groupId: string;
 }
 
 interface MediaTrackSettings {
+    //width: number;
+    //height: number;
+    //aspectRatio: number;
+    //frameRate: number;
+    //facingMode: string;
+    //volume: number;
+    //sampleRate: number;
+    //sampleSize: number;
+    //echoCancellation: boolean;
     latency: number;
+    //deviceId: string;
+    //groupId: string;
+}
+
+interface MediaStreamError {
+    //name: string;
+    //message: string;
+    //constraintName: string;
 }
 
 interface NavigatorGetUserMedia {
@@ -104,4 +192,11 @@ interface MediaDevices {
 
     getUserMedia(constraints: MediaStreamConstraints): Promise<MediaStream>;
     enumerateDevices(): Promise<MediaDeviceInfo[]>;
+}
+
+interface MediaDeviceInfo {
+    //label: string;
+    //deviceId: string;
+    //kind: string;
+    //groupId: string;
 }

--- a/webrtc/RTCPeerConnection-tests.ts
+++ b/webrtc/RTCPeerConnection-tests.ts
@@ -1,114 +1,60 @@
+/// <reference path="MediaStream.d.ts" />
+/// <reference path="RTCPeerConnection.d.ts" />
 
+let defaultIceServers: RTCIceServer[] = RTCPeerConnection.defaultIceServers;
+if (defaultIceServers.length > 0) {
+    let urls = defaultIceServers[0].urls;
+}
 
-
-let voidpromise: Promise<void>;
-
-var minimalConfig: RTCConfiguration = {};
-var config: RTCConfiguration = {
-    iceServers: [
-        {
-            // Single url
-            urls: "stun.l.google.com:19302"
-        },
-        {
-            // List of urls and credentials
-            urls: ["another-stun.example.com"],
-            username: "dude",
-            credential: "pass",
-            credentialType: "token"
-        },
-    ],
-    iceTransportPolicy: "relay",
-    bundlePolicy: "max-compat",
-    rtcpMuxPolicy: "negotiate",
-    peerIdentity: "dude",
-    certificates: [{ expires: 1337 }],
-    iceCandidatePoolSize: 5
+// Create a peer connection
+let ice1: RTCIceServer = {
+    'urls': 'stun:stun.l.google.com:19302',
+    'username': 'john',
+    'credential': '1234',
+    'credentialType': 'password',
 };
-var constraints: RTCMediaConstraints =
-    { mandatory: { OfferToReceiveAudio: true, OfferToReceiveVideo: true } };
-
-var peerConnection: RTCPeerConnection =
-    new RTCPeerConnection(config, constraints);
-
-navigator.getUserMedia({ audio: true, video: true },
-    stream => {
-        peerConnection.addStream(stream);
-    },
-    error => {
-        console.log('Error message: ' + error.message);
-        console.log('Error name: ' + error.name);
+let ice2: RTCIceServer = {'urls': ['stun:stunserver.org', 'stun:stun.example.com']};
+let pc: RTCPeerConnection = new RTCPeerConnection();
+let pc2: RTCPeerConnection = new RTCPeerConnection({
+    iceServers: [ice1, ice2],
+});
+RTCPeerConnection.generateCertificate("sha-256").then((cert: RTCCertificate) => {
+    new RTCPeerConnection({
+        iceServers: [ice1],
+        iceTransportPolicy: 'relay',
+        bundlePolicy: 'max-compat',
+        rtcpMuxPolicy: 'negotiate',
+        peerIdentity: 'dude',
+        certificates: [cert],
+        iceCandidatePoolSize: 5,
     });
-
-peerConnection.onaddstream = ev => console.log(ev.type);
-peerConnection.ondatachannel = ev => console.log(ev.channel);
-peerConnection.oniceconnectionstatechange = ev => console.log(ev.type);
-peerConnection.onnegotiationneeded = ev => console.log(ev.type);
-peerConnection.onopen = ev => console.log(ev.type);
-peerConnection.onicecandidate = ev => console.log(ev.type);
-peerConnection.onremovestream = ev => console.log(ev.type);
-peerConnection.onstatechange = ev => console.log(ev.type);
-
-peerConnection.createOffer();
-let offer2: Promise<RTCSessionDescription> = peerConnection.createOffer({
-    voiceActivityDetection: true,
-    iceRestart: false
 });
 
-var type: string = RTCSdpType[RTCSdpType.offer];
-var offer: RTCSessionDescriptionInit = { type: type, sdp: "some sdp" };
-var sessionDescription = new RTCSessionDescription(offer);
+// Get/set the configuration
+let conf: RTCConfiguration = pc2.getConfiguration();
+pc.setConfiguration(conf);
 
-peerConnection.setRemoteDescription(sessionDescription).then(
-    () => peerConnection.createAnswer(),
-    error => console.log('Error setting remote description: ' + error + "; offer.sdp=" + offer.sdp)
-);
+// Close peer connection
+pc2.close();
 
-var webkitSessionDescription = new webkitRTCSessionDescription(offer);
+// Offer/answer flow
+let offer: RTCSessionDescriptionInit;
+let answer: RTCSessionDescriptionInit;
+pc.createOffer({iceRestart: true})
+    .then((_offer: RTCSessionDescriptionInit) => offer = _offer);
+pc.setLocalDescription(offer);
+pc2.setRemoteDescription(offer);
+pc2.createAnswer().then((_answer: RTCSessionDescriptionInit) => answer = _answer);
+pc2.setLocalDescription(answer);
+pc.setRemoteDescription(answer);
 
-// New syntax
-voidpromise = peerConnection.setLocalDescription(webkitSessionDescription);
-
-// Legacy syntax
-peerConnection.setRemoteDescription(webkitSessionDescription, () => {
-    peerConnection.createAnswer(
-        answer => {
-            peerConnection.setLocalDescription(answer,
-                () => console.log('Set local description'),
-                error => console.log(
-                    "Error setting local description from created answer: " + error +
-                    "; answer.sdp=" + answer.sdp));
-        },
-        error => console.log("Error creating answer: " + error));
-},
-    error => console.log('Error setting remote description: ' + error +
-        "; offer.sdp=" + offer.sdp));
-
-var mozSessionDescription = new mozRTCSessionDescription(offer);
-
-peerConnection.setRemoteDescription(mozSessionDescription);
-
-var wkPeerConnection: webkitRTCPeerConnection =
-    new webkitRTCPeerConnection(config, constraints);
-
-let candidate: RTCIceCandidate = { 'candidate': 'foobar' };
-voidpromise = peerConnection.addIceCandidate(candidate);
-
-var mediaTrackConstraintSet: MediaTrackConstraintSet = {};
-var mediaTrackConstraints: MediaTrackConstraints = mediaTrackConstraintSet;
-
-wkPeerConnection.getStats(null);
-
-let mediaStreamTrack: MediaStreamTrack = {
-    enabled: true, id:
-        'id', kind: 'kind', label: 'label', muted: true, onended: () => { }, onmute: () => { },
-    onoverconstrained: () => { }, onunmute: () => { }, readonly: true, readyState: 'string',
-    remote: true, applyConstraints: (): Promise<void> => { return new Promise<void>(() => { }) },
-    clone: ():MediaStreamTrack => { return this;}, 
-    getCapabilities: ():MediaTrackCapabilities => { return {latency:0};},
-    getConstraints: ():MediaTrackConstraints => { return {}},
-    getSettings: ():MediaTrackSettings => { return { latency: 0}},
-    stop: () => {}, addEventListener: () => {}, dispatchEvent: (evt:Event):boolean => { return false;},
-    removeEventListener: () => {}
-};
-wkPeerConnection.getStats(mediaStreamTrack);
+// Event handlers
+pc.onnegotiationneeded = ev => console.log(ev.type);
+pc.onicecandidate = ev => console.log(ev.candidate);
+pc.onicecandidateerror = ev => console.log(ev.errorText);
+pc.onsignalingstatechange = ev => console.log(ev.type);
+pc.oniceconnectionstatechange = ev => console.log(ev.type);
+pc.onicegatheringstatechange = ev => console.log(ev.type);
+pc.onconnectionstatechange = ev => console.log(ev.type);
+pc.ontrack = ev => console.log(ev.receiver);
+pc.ondatachannel = ev => console.log(ev.channel);

--- a/webrtc/RTCPeerConnection-tests.ts
+++ b/webrtc/RTCPeerConnection-tests.ts
@@ -58,3 +58,34 @@ pc.onicegatheringstatechange = ev => console.log(ev.type);
 pc.onconnectionstatechange = ev => console.log(ev.type);
 pc.ontrack = ev => console.log(ev.receiver);
 pc.ondatachannel = ev => console.log(ev.channel);
+
+// Legacy interface extensions
+pc.createOffer(
+    (sdp: RTCSessionDescription) => console.log(sdp.sdp),
+    (error: DOMException) => console.log(error.message),
+    {iceRestart: true}
+).then(() => console.log('createOffer complete'));
+pc.setLocalDescription(
+    {type: 'offer', sdp: 'foobar'},
+    () => console.log('local description set'),
+    (error: DOMException) => console.log(error.message)
+).then(() => console.log('setLocalDescription complete'));
+pc.createAnswer(
+    (sdp: RTCSessionDescription) => console.log(sdp.sdp),
+    (error: DOMException) => console.log(error.message)
+).then(() => console.log('createAnswer complete'));
+pc.setRemoteDescription(
+    {type: 'answer', sdp: 'foobar'},
+    () => console.log('remote description set'),
+    (error: DOMException) => console.log(error.message)
+).then(() => console.log('setRemoteDescription complete'));
+pc.addIceCandidate(
+    {candidate: 'candidate', sdpMid: 'foo', sdpMLineIndex: 1},
+    () => console.log('candidate added'),
+    (error: DOMException) => console.log(error.message)
+).then(() => console.log('addIceCandidate complete'));
+pc.getStats(
+    null,
+    (report: RTCStatsReport) => console.log('got report'),
+    (error: DOMException) => console.log(error.message)
+).then(() => console.log('getStats complete'));

--- a/webrtc/RTCPeerConnection.d.ts
+++ b/webrtc/RTCPeerConnection.d.ts
@@ -396,6 +396,18 @@ interface RTCDataChannelEvent {
     readonly channel: RTCDataChannel;
 }
 
+// https://www.w3.org/TR/webrtc/#idl-def-rtcsessiondescriptioncallback
+// Deprecated!
+type RTCSessionDescriptionCallback = (sdp: RTCSessionDescription) => void;
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcpeerconnectionerrorcallback
+// Deprecated!
+type RTCPeerConnectionErrorCallback = (error: DOMException) => void;
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcstatscallback
+// Deprecated!
+type RTCStatsCallback = (report: RTCStatsReport) => void;
+
 // https://www.w3.org/TR/webrtc/#idl-def-rtcpeerconnection
 interface RTCPeerConnection extends EventTarget {
     createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescriptionInit>;
@@ -445,8 +457,28 @@ interface RTCPeerConnection extends EventTarget {
     createDataChannel(label: string | null, dataChannelDict?: RTCDataChannelInit): RTCDataChannel;
     ondatachannel: (event: 	RTCDataChannelEvent) => void;
 
-    // Extension: h-rtcpeerconnection-interface-extensions-2
+    // Extension: https://www.w3.org/TR/webrtc/#h-rtcpeerconnection-interface-extensions-2
     getStats(selector?: MediaStreamTrack | null): Promise<RTCStatsReport>;
+
+    // Extension: https://www.w3.org/TR/webrtc/#legacy-interface-extensions
+    // Deprecated!
+    createOffer(successCallback: RTCSessionDescriptionCallback,
+        failureCallback: RTCPeerConnectionErrorCallback,
+        options?: RTCOfferOptions): Promise<void>;
+    setLocalDescription(description: RTCSessionDescriptionInit,
+        successCallback: () => void,
+        failureCallback: RTCPeerConnectionErrorCallback): Promise<void>;
+    createAnswer(successCallback: RTCSessionDescriptionCallback,
+        failureCallback: RTCPeerConnectionErrorCallback): Promise<void>;
+    setRemoteDescription(description: RTCSessionDescriptionInit,
+        successCallback: () => void,
+        failureCallback: RTCPeerConnectionErrorCallback): Promise<void>;
+    addIceCandidate(candidate: RTCIceCandidateInit | RTCIceCandidate,
+        successCallback: () => void,
+        failureCallback: RTCPeerConnectionErrorCallback): Promise<void>;
+    getStats(selector: MediaStreamTrack | null,
+        successCallback: RTCStatsCallback,
+        failureCallback: RTCPeerConnectionErrorCallback): Promise<void>;
 }
 interface RTCPeerConnectionStatic {
     new(configuration?: RTCConfiguration): RTCPeerConnection;

--- a/webrtc/RTCPeerConnection.d.ts
+++ b/webrtc/RTCPeerConnection.d.ts
@@ -1,405 +1,470 @@
-// Type definitions for WebRTC
-// Project: http://dev.w3.org/2011/webrtc/
-// Definitions by: Ken Smith <https://github.com/smithkl42/>
+// Type definitions for WebRTC 2016-09-13
+// Project: https://www.w3.org/TR/webrtc/
+// Definitions by: Danilo Bargen <https://github.com/dbrgn/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 //
-// W3 Spec: https://www.w3.org/TR/webrtc/#idl-def-RTCIceServer
+// W3 Spec: https://www.w3.org/TR/webrtc/
+//
+// Note: Commented out definitions clash with definitions in lib.es6.d.ts. I
+// still kept them in here though, as sometimes they're more specific than the
+// ES6 library ones.
 
-/// <reference path="MediaStream.d.ts" />
+/// <reference path='MediaStream.d.ts' />
 
-// TODO(1): Get Typescript to have string-enum types as WebRtc is full of string
-// enums.
-// https://typescript.codeplex.com/discussions/549207
+type EventHandler = (event: Event) => void;
 
-// TODO(2): get Typescript to have union types as WebRtc uses them.
-// https://typescript.codeplex.com/workitem/1364
-
-// https://www.w3.org/TR/webrtc/#idl-def-RTCIceTransportPolicy
-type RTCIceTransportPolicy = 'public' | 'relay' | 'all';
-
-// https://www.w3.org/TR/webrtc/#idl-def-RTCBundlePolicy
-type RTCBundlePolicy = 'balanced' | 'max-compat' | 'max-bundle';
-
-// https://www.w3.org/TR/webrtc/#idl-def-RTCRtcpMuxPolicy
-type RTCRtcpMuxPolicy = 'negotiate' | 'require';
-
-// https://www.w3.org/TR/webrtc/#idl-def-RTCCertificate
-interface RTCCertificate {
-    expires: number;
+// https://www.w3.org/TR/webrtc/#idl-def-rtcofferansweroptions
+interface RTCOfferAnswerOptions {
+    voiceActivityDetection?: boolean; // default = true
 }
 
-// https://www.w3.org/TR/webrtc/#idl-def-RTCConfiguration
-// https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection#RTCConfiguration_dictionary
-interface RTCConfiguration {
-  iceServers           ?: RTCIceServer[];        // optional according to mozilla docs
-  iceTransportPolicy   ?: RTCIceTransportPolicy; // default = 'all'
-  bundlePolicy         ?: RTCBundlePolicy;       // default = 'balanced'
-  rtcpMuxPolicy        ?: RTCRtcpMuxPolicy;      // default = 'require'
-  peerIdentity         ?: string;                // default = null
-  certificates         ?: RTCCertificate[];      // default is auto-generated
-  iceCandidatePoolSize ?: number;                // default = 0
+// https://www.w3.org/TR/webrtc/#idl-def-rtcofferoptions
+interface RTCOfferOptions extends RTCOfferAnswerOptions {
+    iceRestart?: boolean; // default = false
 }
 
-declare var RTCConfiguration: {
-  prototype: RTCConfiguration;
-  new (): RTCConfiguration;
-};
+// https://www.w3.org/TR/webrtc/#idl-def-rtcansweroptions
+interface RTCAnswerOptions extends RTCOfferAnswerOptions {
+}
 
-// https://www.w3.org/TR/webrtc/#idl-def-RTCIceCredentialType
+// https://www.w3.org/TR/webrtc/#idl-def-rtcsdptype
+type RTCSdpType = 'offer' | 'pranswer' | 'answer' | 'rollback';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcsessiondescriptioninit
+interface RTCSessionDescriptionInit {
+    type: RTCSdpType;
+    sdp?: string; // If type is 'rollback', this member can be left undefined.
+}
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcsessiondescription
+interface RTCSessionDescription {
+    readonly type: RTCSdpType;
+    readonly sdp: string;
+}
+interface RTCSessionDescriptionStatic {
+    new(descriptionInitDict: RTCSessionDescriptionInit): RTCSessionDescription; // Deprecated
+}
+
+// https://www.w3.org/TR/webrtc/#dom-rtciceprotocol
+type RTCIceProtocol = 'udp' | 'tcp';
+
+// https://www.w3.org/TR/webrtc/#dom-rtcicecandidatetype
+type RTCIceCandidateType = 'host' | 'srflx' | 'prflx' | 'relay';
+
+// https://www.w3.org/TR/webrtc/#dom-rtcicetcpcandidatetype
+type RTCIceTcpCandidateType = 'active' | 'passive' | 'so';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcicecandidateinit
+interface RTCIceCandidateInit {
+    candidate: string;
+    sdpMid?: string; // default = null
+    sdpMLineIndex?: number; // default = null
+}
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcicecandidate
+interface RTCIceCandidate {
+    readonly candidate: string;
+    readonly sdpMid?: string;
+    readonly sdpMLineIndex?: number;
+    //readonly foundation: string;
+    //readonly priority: number;
+    //readonly ip: string;
+    //readonly protocol: RTCIceProtocol;
+    //readonly port: number;
+    //readonly type: RTCIceCandidateType;
+    //readonly tcpType?: RTCIceTcpCandidateType;
+    //readonly relatedAddress?: string;
+    //readonly relatedPort?: number;
+}
+interface RTCIceCandidateStatic {
+    new(candidateInitDict: RTCIceCandidateInit): RTCIceCandidate;
+}
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcicecandidatepair
+interface RTCIceCandidatePair {
+    //local: RTCIceCandidate;
+    //remote: RTCIceCandidate;
+}
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcsignalingstate
+type RTCSignalingState = 'stable' | 'have-local-offer' | 'have-remote-offer' | 'have-local-pranswer' | 'have-remote-pranswer';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcicegatheringstate
+type RTCIceGatheringState = 'new' | 'gathering' | 'complete';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtciceconnectionstate
+type RTCIceConnectionState = 'new' | 'checking' | 'connected' | 'completed' | 'failed' | 'disconnected' | 'closed';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcpeerconnectionstate
+type RTCPeerConnectionState = 'new' | 'connecting' | 'connected' | 'disconnected' | 'failed' | 'closed';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcicecredentialtype
 type RTCIceCredentialType = 'password' | 'token';
 
-// https://www.w3.org/TR/webrtc/#idl-def-RTCIceServer
+// https://www.w3.org/TR/webrtc/#idl-def-rtciceserver
 interface RTCIceServer {
-  urls?: any;
-  username?: string;
-  credential?: string;
-  credentialType?: RTCIceCredentialType; // default = 'password'
-}
-declare var RTCIceServer: {
-  prototype: RTCIceServer;
-  new (): RTCIceServer;
-};
-
-// moz (Firefox) specific prefixes.
-interface mozRTCPeerConnection extends RTCPeerConnection {
-}
-declare var mozRTCPeerConnection: {
-  prototype: mozRTCPeerConnection;
-  new (settings?: RTCConfiguration,
-       constraints?:RTCMediaConstraints): mozRTCPeerConnection;
-};
-// webkit (Chrome) specific prefixes.
-interface webkitRTCPeerConnection extends RTCPeerConnection {
-}
-declare var webkitRTCPeerConnection: {
-  prototype: webkitRTCPeerConnection;
-  new (settings?: RTCConfiguration,
-       constraints?:RTCMediaConstraints): webkitRTCPeerConnection;
-};
-
-// For Chrome, look at the code here:
-// https://code.google.com/p/chromium/codesearch#chromium/src/third_party/libjingle/source/talk/app/webrtc/webrtcsession.cc&sq=package:chromium&dr=C&l=63
-interface RTCOptionalMediaConstraint {
-  // When true, will use DTLS/SCTP data channels
-  DtlsSrtpKeyAgreement?: boolean;
-  // When true will use Rtp-based data channels (depreicated)
-  RtpDataChannels?: boolean;
+    //urls: string | string[];
+    username?: string;
+    credential?: string;
+    credentialType?: RTCIceCredentialType; // default = 'password'
 }
 
-// ks 12/20/12 - There's more here that doesn't seem to be documented very well yet.
-// http://www.w3.org/TR/2013/WD-webrtc-20130910/
-interface RTCMediaConstraints {
-  mandatory?: RTCMediaOfferConstraints;
-  optional?: RTCOptionalMediaConstraint[]
+// https://www.w3.org/TR/webrtc/#idl-def-rtcicetransportpolicy
+type RTCIceTransportPolicy = 'relay' | 'all';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcbundlepolicy
+type RTCBundlePolicy = 'balanced' | 'max-compat' | 'max-bundle';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcrtcpmuxpolicy
+type RTCRtcpMuxPolicy = 'negotiate' | 'require';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcicerole
+type RTCIceRole = 'controlling' | 'controlled';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcicecomponent
+type RTCIceComponent = 'RTP' | 'RTCP';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcicetransportstate
+type RTCIceTransportState = 'new' | 'checking' | 'connected' | 'completed' | 'failed' | 'disconnected' | 'closed';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtciceparameters
+interface RTCIceParameters {
+    //usernameFragment: string;
+    //password: string;
 }
 
-interface RTCMediaOfferConstraints {
-  OfferToReceiveAudio: boolean;
-  OfferToReceiveVideo: boolean;
+// https://www.w3.org/TR/webrtc/#idl-def-rtcicetransport
+interface RTCIceTransport {
+    //readonly role: RTCIceRole;
+    //readonly component: RTCIceComponent;
+    //readonly state: RTCIceTransportState;
+    readonly gatheringState: RTCIceGatheringState;
+    getLocalCandidates(): RTCIceCandidate[];
+    getRemoteCandidates(): RTCIceCandidate[];
+    getSelectedCandidatePair(): RTCIceCandidatePair | null;
+    getLocalParameters(): RTCIceParameters | null;
+    getRemoteParameters(): RTCIceParameters | null;
+    onstatechange: EventHandler;
+    ongatheringstatechange: EventHandler;
+    onselectedcandidatepairchange: EventHandler;
 }
 
-interface RTCSessionDescriptionInit {
-  type: string;  // RTCSdpType; See TODO(1)
-  sdp: string;
+// https://www.w3.org/TR/webrtc/#idl-def-rtcdtlstransportstate
+type RTCDtlsTransportState = 'new' | 'connecting' | 'connected' | 'closed' | 'failed';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcdtlstransport
+interface RTCDtlsTransport {
+    readonly transport: RTCIceTransport;
+    //readonly state: RTCDtlsTransportState;
+    getRemoteCertificates(): ArrayBuffer[];
+    onstatechange: EventHandler;
 }
 
-interface RTCSessionDescription {
-  type?: string;  // RTCSdpType; See TODO(1)
-  sdp?: string;
+// https://www.w3.org/TR/webrtc/#idl-def-rtcrtpcodeccapability
+interface RTCRtpCodecCapability {
+    mimeType: string;
 }
-declare var RTCSessionDescription: {
-  prototype: RTCSessionDescription;
-  new (descriptionInitDict?: RTCSessionDescriptionInit): RTCSessionDescription;
-  // TODO: Add serializer.
-  // See: http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCSdpType)
-};
 
-interface webkitRTCSessionDescription extends RTCSessionDescription{
-  type?: string;
-  sdp?: string;
+// https://www.w3.org/TR/webrtc/#idl-def-rtcrtpheaderextensioncapability
+interface RTCRtpHeaderExtensionCapability {
+    uri: string;
 }
-declare var webkitRTCSessionDescription: {
-  prototype: webkitRTCSessionDescription;
-  new (descriptionInitDict?: RTCSessionDescriptionInit): webkitRTCSessionDescription;
-};
 
-interface mozRTCSessionDescription extends RTCSessionDescription{
-  type?: string;
-  sdp?: string;
+// https://www.w3.org/TR/webrtc/#idl-def-rtcrtpcapabilities
+interface RTCRtpCapabilities {
+    //codecs: RTCRtpCodecCapability[];
+    //headerExtensions: RTCRtpHeaderExtensionCapability[];
 }
-declare var mozRTCSessionDescription: {
-  prototype: mozRTCSessionDescription;
-  new (descriptionInitDict?: RTCSessionDescriptionInit): mozRTCSessionDescription;
-};
 
+// https://www.w3.org/TR/webrtc/#idl-def-rtcrtprtxparameters
+interface RTCRtpRtxParameters {
+    //ssrc: number;
+}
 
+// https://www.w3.org/TR/webrtc/#idl-def-rtcrtpfecparameters
+interface RTCRtpFecParameters {
+    //ssrc: number;
+}
 
+// https://www.w3.org/TR/webrtc/#idl-def-rtcdtxstatus
+type RTCDtxStatus = 'disabled' | 'enabled';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcprioritytype
+type RTCPriorityType = 'very-low' | 'low' | 'medium' | 'high';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcrtpencodingparameters
+interface RTCRtpEncodingParameters {
+    //ssrc: number;
+    //rtx: RTCRtpRtxParameters;
+    //fec: RTCRtpFecParameters;
+    dtx: RTCDtxStatus;
+    //active: boolean;
+    //priority: RTCPriorityType;
+    //maxBitrate: number;
+    maxFramerate: number;
+    rid: string;
+    scaleResolutionDownBy?: number; // default = 1
+}
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcrtpheaderextensionparameters
+interface RTCRtpHeaderExtensionParameters {
+    //uri: string;
+    //id: number;
+    encrypted: boolean;
+}
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcrtcpparameters
+interface RTCRtcpParameters {
+    //cname: string;
+    //reducedSize: boolean;
+}
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcrtpcodecparameters
+interface RTCRtpCodecParameters {
+    //payloadType: number;
+    mimeType: string;
+    //clockRate: number;
+    channels?: number; // default = 1
+    sdpFmtpLine: string;
+}
+
+type RTCDegradationPreference = 'maintain-framerate' | 'maintain-resolution' | 'balanced';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcrtpparameters
+interface RTCRtpParameters {
+    transactionId: string;
+    //encodings: RTCRtpEncodingParameters[];
+    //headerExtensions: RTCRtpHeaderExtensionParameters[];
+    //rtcp: RTCRtcpParameters;
+    //codecs: RTCRtpCodecParameters[];
+    degradationPreference?: RTCDegradationPreference; // default = 'balanced'
+}
+
+// https://www.w3.org/TR/webrtc/#dom-rtcrtpcontributingsource
+interface RTCRtpContributingSource {
+    //readonly timestamp: number;
+    readonly source: number;
+    //readonly audioLevel: number | null;
+    readonly voiceActivityFlag: boolean | null;
+}
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcrtpcapabilities
+interface RTCRtcCapabilities {
+    codecs: RTCRtpCodecCapability[];
+    headerExtensions: RTCRtpHeaderExtensionCapability[];
+}
+
+// https://www.w3.org/TR/webrtc/#dom-rtcrtpsender
+interface RTCRtpSender {
+    //readonly track?: MediaStreamTrack;
+    //readonly transport?: RTCDtlsTransport;
+    //readonly rtcpTransport?: RTCDtlsTransport;
+    setParameters(parameters?: RTCRtpParameters): Promise<void>;
+    getParameters(): RTCRtpParameters;
+    replaceTrack(withTrack: MediaStreamTrack): Promise<void>;
+}
+interface RTCRtpSenderStatic {
+    new(): RTCRtpSender;
+    getCapabilities(kind: string): RTCRtpCapabilities;
+}
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcrtpreceiver
+interface RTCRtpReceiver {
+    //readonly track?: MediaStreamTrack;
+    //readonly transport?: RTCDtlsTransport;
+    //readonly rtcpTransport?: RTCDtlsTransport;
+    getParameters(): RTCRtpParameters;
+    getContributingSources(): RTCRtpContributingSource[];
+}
+interface RTCRtpReceiverStatic {
+    new(): RTCRtpReceiver;
+    getCapabilities(kind: string): RTCRtcCapabilities;
+}
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcrtptransceiverdirection
+type RTCRtpTransceiverDirection = 'sendrecv' | 'sendonly' | 'recvonly' | 'inactive';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcrtptransceiver
+interface RTCRtpTransceiver {
+    readonly mid: string | null;
+    readonly sender: RTCRtpSender;
+    readonly receiver: RTCRtpReceiver;
+    readonly stopped: boolean;
+    readonly direction: RTCRtpTransceiverDirection;
+    setDirection(direction: RTCRtpTransceiverDirection): void;
+    stop(): void;
+    setCodecPreferences(codecs: RTCRtpCodecCapability[]): void;
+}
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcrtptransceiverinit
+interface RTCRtpTransceiverInit {
+    direction?: RTCRtpTransceiverDirection; // default = 'sendrecv'
+    streams: MediaStream[];
+    sendEncodings: RTCRtpEncodingParameters[];
+}
+
+// https://www.w3.org/TR/webrtc/#dom-rtccertificate
+interface RTCCertificate {
+    readonly expires: number;
+    getAlgorithm(): string;
+}
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcconfiguration
+interface RTCConfiguration {
+    iceServers?: RTCIceServer[];
+    iceTransportPolicy?: RTCIceTransportPolicy; // default = 'all'
+    bundlePolicy?: RTCBundlePolicy; // default = 'balanced'
+    rtcpMuxPolicy?: RTCRtcpMuxPolicy; // default = 'require'
+    peerIdentity?: string; // default = null
+    certificates?: RTCCertificate[];
+    iceCandidatePoolSize?: number; // default = 0
+}
+
+// Compatibility for older definitions on DefinitelyTyped.
+type RTCPeerConnectionConfig = RTCConfiguration;
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcsctptransport
+interface RTCSctpTransport {
+    readonly transport: RTCDtlsTransport;
+    readonly maxMessageSize: number;
+}
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcdatachannelinit
 interface RTCDataChannelInit {
-  ordered             ?: boolean; // messages must be sent in-order.
-  maxPacketLifeTime   ?: number;  // unsigned short
-  maxRetransmits      ?: number;  // unsigned short
-  protocol            ?: string;  // default = ''
-  negotiated          ?: boolean; // default = false;
-  id                  ?: number;  // unsigned short
+    ordered?: boolean; // default = true
+    maxPacketLifeTime?: number;
+    maxRetransmits?: number;
+    protocol?: string; // default = ''
+    negotiated?: boolean; // default = false
+    id?: number;
 }
 
-// TODO(1)
-declare enum RTCSdpType {
-  // http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcsdptype
-  'offer',
-  'pranswer',
-  'answer'
-}
+// https://www.w3.org/TR/webrtc/#idl-def-rtcdatachannelstate
+type RTCDataChannelState = 'connecting' | 'open' | 'closing' | 'closed';
 
-interface RTCMessageEvent {
-  // http://dev.w3.org/2011/webrtc/editor/webrtc.html#event-datachannel-message
-  // At present, this can be an: ArrayBuffer, a string, or a Blob.
-  // See TODO(2)
-  data: any;
-}
+// https://www.w3.org/TR/websockets/#dom-websocket-binarytype
+type RTCBinaryType = 'blob' | 'arraybuffer';
 
-// TODO(1)
-declare enum RTCDataChannelState {
-  // http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCDataChannelState
-  'connecting',
-  'open',
-  'closing',
-  'closed'
-}
-
+// https://www.w3.org/TR/webrtc/#idl-def-rtcdatachannel
 interface RTCDataChannel extends EventTarget {
-  label: string;
-  reliable: boolean;
-  readyState: string; // RTCDataChannelState; see TODO(1)
-  bufferedAmount: number;
-  binaryType: string;
+    readonly label: string;
+    readonly ordered: boolean;
+    readonly maxPacketLifeTime: number | null;
+    readonly maxRetransmits: number | null;
+    readonly protocol: string;
+    readonly negotiated: boolean;
+    readonly id: number;
+    readonly readyState: RTCDataChannelState;
+    readonly bufferedAmount: number;
+    bufferedAmountLowThreshold: number;
+    binaryType: RTCBinaryType;
 
-  onopen: (event: Event) => void;
-  onerror: (event: Event) => void;
-  onclose: (event: Event) => void;
-  onmessage: (event: RTCMessageEvent) => void;
+    close(): void;
+    send(data: string | Blob | ArrayBuffer | ArrayBufferView): void;
 
-  close(): void;
-
-  send(data: string): void ;
-  send(data: ArrayBuffer): void;
-  send(data: ArrayBufferView): void;
-  send(data: Blob): void;
-}
-declare var RTCDataChannel: {
-  prototype: RTCDataChannel;
-  new (): RTCDataChannel;
-};
-
-// https://www.w3.org/TR/webrtc/#rtcdatachannelevent
-interface RTCDataChannelEvent extends Event {
-  channel: RTCDataChannel;
-}
-declare var RTCDataChannelEvent: {
-  prototype: RTCDataChannelEvent;
-  new (eventInitDict: RTCDataChannelEventInit): RTCDataChannelEvent;
-};
-
-interface RTCIceCandidateEvent extends Event {
-  candidate: RTCIceCandidate;
+    onopen: EventHandler;
+    onmessage: (event: MessageEvent) => void;
+    onbufferedamountlow: EventHandler;
+    onerror: (event: ErrorEvent) => void;
+    onclose: EventHandler;
 }
 
-interface RTCMediaStreamEvent extends Event {
-  stream: MediaStream;
+// https://www.w3.org/TR/webrtc/#h-rtctrackevent
+interface RTCTrackEvent extends Event {
+    readonly receiver: RTCRtpReceiver;
+    readonly track: MediaStreamTrack;
+    readonly streams: MediaStream[];
+    readonly transceiver: RTCRtpTransceiver;
 }
 
-interface EventInit {
+// https://www.w3.org/TR/webrtc/#h-rtcpeerconnectioniceevent
+interface RTCPeerConnectionIceEvent extends Event {
+    readonly candidate: RTCIceCandidate | null;
+    readonly url: string;
 }
 
-interface RTCDataChannelEventInit extends EventInit {
-  channel: RTCDataChannel;
+// https://www.w3.org/TR/webrtc/#h-rtcpeerconnectioniceerrorevent
+interface RTCPeerConnectionIceErrorEvent extends Event {
+    readonly hostCandidate: string;
+    readonly url: string;
+    readonly errorCode: number;
+    readonly errorText: string;
 }
 
-interface RTCVoidCallback {
-  (): void;
-}
-interface RTCSessionDescriptionCallback {
-  (sdp: RTCSessionDescription): void;
-}
-interface RTCPeerConnectionErrorCallback {
-  (errorInformation: DOMError): void;
+// https://www.w3.org/TR/webrtc/#h-rtcdatachannelevent
+interface RTCDataChannelEvent {
+    readonly channel: RTCDataChannel;
 }
 
-// TODO(1)
-declare enum RTCIceGatheringState {
-  // http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicegatheringstate-enum
-  'new',
-  'gathering',
-  'complete'
+// https://www.w3.org/TR/webrtc/#idl-def-rtcpeerconnection
+interface RTCPeerConnection extends EventTarget {
+    createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescriptionInit>;
+    createAnswer(options?: RTCAnswerOptions): Promise<RTCSessionDescriptionInit>;
+
+    setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>;
+    readonly localDescription: RTCSessionDescription | null;
+    readonly currentLocalDescription: RTCSessionDescription | null;
+    readonly pendingLocalDescription: RTCSessionDescription | null;
+
+    setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void>;
+    readonly remoteDescription: RTCSessionDescription | null;
+    readonly currentRemoteDescription: RTCSessionDescription | null;
+    readonly pendingRemoteDescription: RTCSessionDescription | null;
+
+    addIceCandidate(candidate?: RTCIceCandidateInit | RTCIceCandidate): Promise<void>;
+
+    readonly signalingState: RTCSignalingState;
+    readonly iceGatheringState: RTCIceGatheringState;
+    readonly iceConnectionState: RTCIceConnectionState;
+    readonly connectionState: RTCPeerConnectionState;
+    readonly canTrickleIceCandidates?: boolean | null;
+
+    getConfiguration(): RTCConfiguration;
+    setConfiguration(configuration: RTCConfiguration): void;
+    close(): void;
+
+    onnegotiationneeded: EventHandler;
+    onicecandidate: (event: RTCPeerConnectionIceEvent) => void;
+    onicecandidateerror: (event: RTCPeerConnectionIceErrorEvent) => void;
+    onsignalingstatechange: EventHandler;
+    oniceconnectionstatechange: EventHandler;
+    onicegatheringstatechange: EventHandler;
+    onconnectionstatechange: EventHandler;
+
+    // Extension: https://www.w3.org/TR/webrtc/#h-rtcpeerconnection-interface-extensions
+    getSenders(): RTCRtpSender[];
+    getReceivers(): RTCRtpReceiver[];
+    getTransceivers(): RTCRtpTransceiver[];
+    addTrack(track: MediaStreamTrack, ...streams: MediaStream[]): RTCRtpSender;
+    removeTrack(sender: RTCRtpSender): void;
+    addTransceiver(trackOrKind: MediaStreamTrack | string, init?: RTCRtpTransceiverInit): RTCRtpTransceiver;
+    ontrack: (event: RTCTrackEvent) => void;
+
+    // Extension: https://www.w3.org/TR/webrtc/#h-rtcpeerconnection-interface-extensions-1
+    readonly sctp: RTCSctpTransport | null;
+    createDataChannel(label: string | null, dataChannelDict?: RTCDataChannelInit): RTCDataChannel;
+    ondatachannel: (event: 	RTCDataChannelEvent) => void;
+
+    // Extension: h-rtcpeerconnection-interface-extensions-2
+    getStats(selector?: MediaStreamTrack | null): Promise<RTCStatsReport>;
+}
+interface RTCPeerConnectionStatic {
+    new(configuration?: RTCConfiguration): RTCPeerConnection;
+    readonly defaultIceServers: RTCIceServer[];
+
+    // Extension: https://www.w3.org/TR/webrtc/#sec.cert-mgmt
+    generateCertificate(keygenAlgorithm: string): Promise<RTCCertificate>;
 }
 
-// TODO(1)
-declare enum RTCIceConnectionState {
-  // http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCIceConnectionState
-  'new',
-  'checking',
-  'connected',
-  'completed',
-  'failed',
-  'disconnected',
-  'closed'
-}
-
-// TODO(1)
-declare enum RTCSignalingState {
-  // http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCSignalingState
-  'stable',
-  'have-local-offer',
-  'have-remote-offer',
-  'have-local-pranswer',
-  'have-remote-pranswer',
-  'closed'
-}
-
-// This is based on the current implementation of WebRtc in Chrome; the spec is
-// a little unclear on this.
-// http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCStatsReport
-interface RTCStatsReport {
-  stat(id: string): string;
-}
-
-interface RTCStatsCallback {
-  (report: RTCStatsReport): void;
-}
-
-interface RTCOfferAnswerOptions {
-    voiceActivityDetection ?: boolean; // default = true
-}
-
-interface RTCOfferOptions extends RTCOfferAnswerOptions {
-    iceRestart ?: boolean; // default = false
-}
-
-interface RTCAnswerOptions extends RTCOfferAnswerOptions { }
-
-interface RTCPeerConnection {
-
-  createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescription>;
-  createOffer(successCallback: RTCSessionDescriptionCallback,
-              failureCallback?: RTCPeerConnectionErrorCallback,
-              constraints?: RTCMediaConstraints): void; // Deprecated
-  createAnswer(options?: RTCAnswerOptions): Promise<RTCSessionDescription>;
-  createAnswer(successCallback: RTCSessionDescriptionCallback,
-               failureCallback?: RTCPeerConnectionErrorCallback,
-               constraints?: RTCMediaConstraints): void; // Deprecated
-  setLocalDescription(description: RTCSessionDescription | RTCSessionDescriptionInit): Promise<void>;
-  setLocalDescription(description: RTCSessionDescription,
-                      successCallback?: RTCVoidCallback,
-                      failureCallback?: RTCPeerConnectionErrorCallback): void; // Deprecated
-  setRemoteDescription(description: RTCSessionDescription | RTCSessionDescriptionInit): Promise<void>;
-  setRemoteDescription(description: RTCSessionDescription,
-                        successCallback?: RTCVoidCallback,
-                        failureCallback?: RTCPeerConnectionErrorCallback): void;
-  localDescription: RTCSessionDescription;
-  remoteDescription: RTCSessionDescription;
-  signalingState: string; // RTCSignalingState; see TODO(1)
-  updateIce(configuration?: RTCConfiguration,
-            constraints?: RTCMediaConstraints): void;
-  addIceCandidate(candidate: RTCIceCandidate): Promise<void>;
-  addIceCandidate(candidate:RTCIceCandidate,
-                  successCallback:() => void,
-                  failureCallback:RTCPeerConnectionErrorCallback): void;
-  iceGatheringState: string;  // RTCIceGatheringState; see TODO(1)
-  iceConnectionState: string;  // RTCIceConnectionState; see TODO(1)
-  getLocalStreams(): MediaStream[];
-  getRemoteStreams(): MediaStream[];
-  createDataChannel(label?: string,
-                    dataChannelDict?: RTCDataChannelInit): RTCDataChannel;
-  ondatachannel: (event: RTCDataChannelEvent) => void;
-  addStream(stream: MediaStream, constraints?: RTCMediaConstraints): void;
-  removeStream(stream: MediaStream): void;
-  close(): void;
-  onnegotiationneeded: (event: Event) => void;
-  onconnecting: (event: Event) => void;
-  onopen: (event: Event) => void;
-  onaddstream: (event: RTCMediaStreamEvent) => void;
-  onremovestream: (event: RTCMediaStreamEvent) => void;
-  onstatechange: (event: Event) => void;
-  oniceconnectionstatechange: (event: Event) => void;
-  onicecandidate: (event: RTCIceCandidateEvent) => void;
-  onidentityresult: (event: Event) => void;
-  onsignalingstatechange: (event: Event) => void;
-  getStats(selector: MediaStreamTrack | null): Promise<RTCStatsReport>;
-  getStats(selector: MediaStreamTrack | null,
-           successCallback: RTCStatsCallback,
-           failureCallback: RTCPeerConnectionErrorCallback): void;
-}
-declare var RTCPeerConnection: {
-  prototype: RTCPeerConnection;
-  new (configuration: RTCConfiguration,
-       constraints?: RTCMediaConstraints): RTCPeerConnection;
-};
-
-interface RTCIceCandidate {
-  candidate: string;
-  sdpMid?: string;
-  sdpMLineIndex?: number;
-}
-declare var RTCIceCandidate: {
-  prototype: RTCIceCandidate;
-  new (candidateInitDict?: RTCIceCandidate): RTCIceCandidate;
-};
-
-interface webkitRTCIceCandidate extends RTCIceCandidate {
-  candidate: string;
-  sdpMid?: string;
-  sdpMLineIndex?: number;
-}
-declare var webkitRTCIceCandidate: {
-  prototype: webkitRTCIceCandidate;
-  new (candidateInitDict?: webkitRTCIceCandidate): webkitRTCIceCandidate;
-};
-
-interface mozRTCIceCandidate extends RTCIceCandidate {
-  candidate: string;
-  sdpMid?: string;
-  sdpMLineIndex?: number;
-}
-declare var mozRTCIceCandidate: {
-  prototype: mozRTCIceCandidate;
-  new (candidateInitDict?: mozRTCIceCandidate): mozRTCIceCandidate;
-};
-
-interface RTCIceCandidateInit {
-  candidate: string;
-  sdpMid?: string;
-  sdpMLineIndex?: number;
-}
-declare var RTCIceCandidateInit:{
-  prototype: RTCIceCandidateInit;
-  new (): RTCIceCandidateInit;
-};
-
-interface PeerConnectionIceEvent {
-  peer: RTCPeerConnection;
-  candidate: RTCIceCandidate;
-}
-declare var PeerConnectionIceEvent: {
-  prototype: PeerConnectionIceEvent;
-  new (): PeerConnectionIceEvent;
-};
-
-interface RTCPeerConnectionConfig {
-  iceServers: RTCIceServer[];
-}
-declare var RTCPeerConnectionConfig: {
-  prototype: RTCPeerConnectionConfig;
-  new (): RTCPeerConnectionConfig;
-};
-
-interface Window{
-  RTCPeerConnection: RTCPeerConnection;
-  webkitRTCPeerConnection: webkitRTCPeerConnection;
-  mozRTCPeerConnection: mozRTCPeerConnection;
-  RTCSessionDescription: RTCSessionDescription;
-  webkitRTCSessionDescription: webkitRTCSessionDescription;
-  mozRTCSessionDescription: mozRTCSessionDescription;
-  RTCIceCandidate: RTCIceCandidate;
-  webkitRTCIceCandidate: webkitRTCIceCandidate;
-  mozRTCIceCandidate: mozRTCIceCandidate;
+declare var RTCPeerConnection: RTCPeerConnectionStatic;
+declare var RTCSessionDescription: RTCSessionDescriptionStatic;
+declare var RTCIceCandidate: RTCIceCandidateStatic;
+//declare var RTCRtpSender: RTCRtpSenderStatic;
+//declare var RTCRtpReceiver: RTCRtpReceiverStatic;
+interface Window {
+    RTCPeerConnection: RTCPeerConnectionStatic;
+    RTCSessionDescription: RTCSessionDescriptionStatic;
+    RTCIceCandidate: RTCIceCandidateStatic;
+    RTCRtpSender: RTCRtpSenderStatic;
+    RTCRtpReceiver: RTCRtpReceiverStatic;
 }

--- a/webrtc/readme.md
+++ b/webrtc/readme.md
@@ -1,14 +1,14 @@
 #  WebRTC Definition Notes
 
-## The WebRTC specification 
+## The WebRTC specification
 
-The WebRTC specification is currently a work in progress, but it has been implemented at a basic level in recent versions of Chrome, Opera and (to a lesser extent) Firefox. 
-The latest version of the specification can be found at http://dev.w3.org/2011/webrtc/editor/webrtc.html. 
+The WebRTC specification is currently a work in progress, but it has been
+implemented at a basic level in recent versions of Chrome, Opera and (to a
+lesser extent) Firefox.  The latest version of the specification can be found
+at https://www.w3.org/TR/webrtc/.
 
-This particular set of definitions has been annotated with the vendor-specific prefixes for Chrome (e.g., `webitkit`), 
-but anyone who wants, feel free to add the Mozilla-specific prefixes.
+This particular set of definitions does not use any vendor-specific prefixes.
+Instead, you should probably use [adapter.js](https://github.com/webrtc/adapter).
 
-### Adding the reference to your project
-
-    
-    
+The definitions track the currently published working draft. Deprecated
+features are dropped.


### PR DESCRIPTION
The WebRTC specification moves fast, and these definitions were very outdated. They also relied on enums sometimes because at the time of writing string union types (`type foo = 'a' | 'b'`) didn't exist yet. There was also a lot of deprecated API still present.

I used the [specification](https://www.w3.org/TR/webrtc/) IDL to rewrite all definitions in `RTCPeerConnection.d.ts`.

In the end I had to comment out some of the attributes because they clashed with types defined in `lib.es6.d.ts`. Not sure what the best approach would be here.

I also removed vendor specific prefixes. I think the correct approach when doing WebRTC is to use [adapter.js](https://github.com/webrtc/adapter). Otherwise people can add their own vendor-prefixed definitions if they wish.

Legacy API (with callbacks instead of promises) is not (yet) implemented. Does someone think this is important?

@groege @vvkame @martinduparc @bemasc @nakakura @iislucas @nestalk @smithkl42

---

case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes: https://www.w3.org/TR/webrtc/
  - it has been reviewed by a DefinitelyTyped member.
