### PR TITLE
angularjs: directives can be defined with just the linking function

### DIFF
--- a/angularjs/angular-tests.ts
+++ b/angularjs/angular-tests.ts
@@ -192,8 +192,25 @@ mod.controller({
     MyCtrl2: function() {},
     MyCtrl3: ['$fooService', function($fooService: any) { }]
 });
-mod.directive('name', <any>function ($scope: ng.IScope) { })
-mod.directive('name', ['$scope', <any>function ($scope: ng.IScope) { }])
+mod.directive('myDirectiveA', ($rootScope: ng.IRootScopeService) => {
+    return (scope, el, attrs) => {
+        let foo = 'none';
+        el.click(e => {
+            foo = e.type;
+            $rootScope.$apply();
+        });
+        scope.$watch(() => foo, () => el.text(foo));
+    };
+});
+mod.directive('myDirectiveB', ['$rootScope', function ($rootScope: ng.IRootScopeService) {
+    return {
+        link(scope, el, attrs) {
+            el.click(e => {
+                el.hide();
+            });
+        }
+    };
+}]);
 mod.directive({
     myFooDir: () => ({
         template: 'my-foo-dir.tpl.html'

--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1770,7 +1770,7 @@ declare namespace angular {
     ///////////////////////////////////////////////////////////////////////////
 
     interface IDirectiveFactory {
-        (...args: any[]): IDirective;
+        (...args: any[]): IDirective | IDirectiveLinkFn;
     }
 
     interface IDirectiveLinkFn {
@@ -1778,8 +1778,8 @@ declare namespace angular {
             scope: IScope,
             instanceElement: JQuery,
             instanceAttributes: IAttributes,
-            controller: {},
-            transclude: ITranscludeFunction
+            controller?: IController | IController[] | {[key: string]: IController},
+            transclude?: ITranscludeFunction
         ): void;
     }
 
@@ -1807,7 +1807,6 @@ declare namespace angular {
         controller?: string | Injectable<IControllerConstructor>;
         controllerAs?: string;
         /**
-         * @deprecated
          * Deprecation warning: although bindings for non-ES6 class controllers are currently bound to this before
          * the controller constructor is called, this use is now deprecated. Please place initialization code that
          * relies upon bindings inside a $onInit method on the controller, instead.


### PR DESCRIPTION
As a shortcut, directives can be defined with just the linking function.

See https://docs.angularjs.org/api/ng/service/$compile

"You can either return a Directive Definition Object (see below) that defines the directive properties, or just the postLink function (all other properties will have the default values)."
