### PR TITLE
Updating Quill definitions to 1.1.0. 

### DIFF
--- a/quill/quill-tests.ts
+++ b/quill/quill-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path="quill.d.ts" />
+/// <reference path="./quill.d.ts" />
 
 function test_quill() {
     var quillEditor = new Quill('#editor', {
@@ -25,9 +25,14 @@ function test_enable() {
     quillEditor.enable();
 }
 
+function test_enable_false() {
+    let quillEditor = new Quill('#Editor');
+    quillEditor.enable(false);
+}
+
 function test_getContents() {
     var quillEditor = new Quill('#editor');
-    var delta: QuillJS.DeltaStatic = quillEditor.getContents();
+    var delta: Quill.DeltaStatic = quillEditor.getContents();
 }
 
 function test_getLength() {
@@ -95,24 +100,24 @@ function test_insertEmbed() {
 
 function test_updateContents() {
     var quillEditor = new Quill('#editor');
-    quillEditor.updateContents({
+    quillEditor.updateContents(new Delta({
         ops: [
             { retain: 6 },        // Keep 'Hello '
             { delete: 5 },        // 'World' is deleted
             { insert: 'Quill' },  // Insert 'Quill'
             { retain: 1, attributes: { bold: true } }    // Apply bold to exclamation mark
         ]
-    });
+    }));
 }
 
 function test_setContents() {
     var quillEditor = new Quill('#editor');
 
-    quillEditor.setContents([
+    quillEditor.setContents(new Delta({ ops: [
         { insert: 'Hello ' },
         { insert: 'World!', attributes: { bold: true } },
         { insert: '\n' }
-    ]);
+    ]}));
 }
 
 function test_setText() {

--- a/quill/quill.d.ts
+++ b/quill/quill.d.ts
@@ -1,17 +1,33 @@
-// Type definitions for Quill v1.0.3
+// Type definitions for Quill v1.1.0
 // Project: http://quilljs.com
 // Definitions by: Sumit <https://github.com/sumitkm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace QuillJS {
+declare namespace Quill {
+
+    type Key = { key: string, shortKey?: boolean };
+    type Sources = "api" | "user" | "silent";
+    type Formats = { [key: string]: any };
+
+    export interface KeyboardStatic {
+        addBinding(key: Key, callback: (range: RangeStatic, context: any) => void): void;
+        addBinding(key: Key, context: any, callback: (range: RangeStatic, context: any) => void) : void;
+    }
+
+    export interface ClipboardStatic {
+        addMatcher(selector: string, callback: (node: any, delta: DeltaStatic) => DeltaStatic) : void;
+        addMatcher(nodeType: number, callback: (node: any, delta: DeltaStatic) => DeltaStatic) : void;
+        dangerouslyPasteHTML(html: string, source?: Sources): void;
+        dangerouslyPasteHTML(index: number, html: string, source?: Sources): void;
+    }
 
     export interface QuillOptionsStatic {
         debug?: string,
-        modules?: { [key: string]: any },
+        modules?: Formats,
         placeholder?: string,
         readOnly?: boolean,
         theme?: string,
-        formats?: string[] 
+        formats?: string[]
     }
 
     export interface BoundsStatic {
@@ -22,11 +38,26 @@ declare namespace QuillJS {
     }
 
     export interface DeltaStatic {
+        new (ops: Array<any>) : DeltaStatic;
+        new (ops: any) : DeltaStatic;
         ops?: Array<any>;
-        retain?: any,
-        delete?: any,
-        insert?: any,
-        attributes?: any
+        retain(length: number, attributes: any) : DeltaStatic;
+        delete(length: number) : DeltaStatic;
+        filter(predicate: any) : DeltaStatic;
+        forEach(predicate: any) : DeltaStatic;
+        insert(text: any, attributes: any): DeltaStatic;
+        map(predicate: any) : DeltaStatic;
+        partition(predicate: any) : DeltaStatic;
+        reduce(predicate: any, initial: number): DeltaStatic;
+        chop() : DeltaStatic;
+        length(): number;
+        slice(start: number, end: number): DeltaStatic;
+        compose(other: any): DeltaStatic;
+        concat(other: DeltaStatic): DeltaStatic;
+        diff(other: DeltaStatic, index: number) : DeltaStatic;
+        eachLine(predicate: any, newline: any) : DeltaStatic;
+        transform(other: any, priority: any) : DeltaStatic;
+        transformPosition(index: number, priority: any) : DeltaStatic;
     }
 
     export interface RangeStatic {
@@ -35,62 +66,70 @@ declare namespace QuillJS {
         length: number;
     }
 
-    type sourceType = "api" | "user" | "silent";
-    type formatsType = { [key: string]: any };
-
-    export interface QuillStatic {
-        new (container: string | Element, options?: QuillOptionsStatic): QuillStatic;
-        deleteText(start: number, end: number, source?: sourceType): void;
+    export interface Quill {
+        new (container: string | Element, options?: QuillOptionsStatic): Quill;
+        deleteText(index: number, length: number, source?: Sources): void;
         disable(): void;
         enable(enabled?: boolean): void;
-        getContents(start?: number, end?: number): DeltaStatic;
+        getContents(index?: number, length?: number): DeltaStatic;
         getLength(): number;
-        getText(start?: number, end?: number): string;
-        insertEmbed(index: number, type: string, url: string, source?: sourceType): void;
-        insertText(index: number, text: string, source?: sourceType): void;
-        insertText(index: number, text: string, format: string, value: string, source?: sourceType): void;
-        insertText(index: number, text: string, formats: formatsType, source?: sourceType): void;
-        pasteHTML(index: number, html: string, source?:sourceType): string;
-        pasteHTML(html:string, source?: sourceType): string;
-        setContents(delta: DeltaStatic, source?: sourceType): void;
-        setText(text: string, source?: sourceType): void;
+        getText(index?: number, length?: number): string;
+        insertEmbed(index: number, type: string, value: any, source?: Sources): void;
+        insertText(index: number, text: string, source?: Sources): DeltaStatic;
+        insertText(index: number, text: string, format: string, value: any, source?: Sources): DeltaStatic;
+        insertText(index: number, text: string, formats: Formats, source?: Sources): DeltaStatic;
+        /**
+        * @deprecated Use clipboard.dangerouslyPasteHTML(index: number, html: string, source: Sources)
+        */
+        pasteHTML(index: number, html: string, source?: Sources): string;
+        /**
+        * @deprecated Use dangerouslyPasteHTML(html: string, source: Sources): void;
+        */
+        pasteHTML(html: string, source?: Sources): string;
+        setContents(delta: DeltaStatic, source?: Sources): DeltaStatic;
+        setText(text: string, source?: Sources): DeltaStatic;
         update(source?: string): void;
-        updateContents(delta: DeltaStatic, source?: sourceType): void;
+        updateContents(delta: DeltaStatic, source?: Sources): DeltaStatic;
 
-        format(name: string, value: any, source?: sourceType): void;
-        formatLine(index: number, length: number, source?: sourceType): void;
-        formatLine(index: number, length: number, format: string, value: any, source?: sourceType): void;
-        formatLine(index: number, length: number, formats: formatsType, source?: sourceType): void;
-        formatText(index: number, length: number, source?: sourceType): void;
-        formatText(index: number, length: number, format: string, value: any, source?: sourceType): void;
-        formatText(index: number, length: number, formats: formatsType, source?: sourceType): void;
-        getFormat(range?: RangeStatic): formatsType;
-        getFormat(index: number, length?: number): formatsType;
-        removeFormat(index: Number, length: Number, source?: sourceType): void;
+        format(name: string, value: any, source?: Sources): DeltaStatic;
+        formatLine(index: number, length: number, source?: Sources): DeltaStatic;
+        formatLine(index: number, length: number, format: string, value: any, source?: Sources): DeltaStatic;
+        formatLine(index: number, length: number, formats: Formats, source?: Sources): DeltaStatic;
+        formatText(index: number, length: number, source?: Sources): DeltaStatic;
+        formatText(index: number, length: number, format: string, value: any, source?: Sources): DeltaStatic;
+        formatText(index: number, length: number, formats: Formats, source?: Sources): DeltaStatic;
+        getFormat(range?: RangeStatic): Formats;
+        getFormat(index: number, length?: number): Formats;
+        removeFormat(index: number, length: number, source?: Sources): void;
 
         blur(): void;
         focus(): void;
         getBounds(index: number, length?: number): BoundsStatic;
         getSelection(focus?: boolean): RangeStatic;
         hasFocus(): boolean;
-        setSelection(index: number, length: number, source?: sourceType): void;
-        setSelection(range: RangeStatic, source?: sourceType): void;
+        setSelection(index: number, length: number, source?: Sources): void;
+        setSelection(range: RangeStatic, source?: Sources): void;
 
         on(eventName: string, callback: (<T>(delta: T, oldContents: T, source: string) => void) |
-            ((name: string, ...args: any[]) => void)): QuillStatic;
-        once(eventName: string, callback: (delta: DeltaStatic, source: string) => void): QuillStatic;
-        off(eventName: string, callback: (delta: DeltaStatic, source: string) => void): QuillStatic;
+            ((name: string, ...args: any[]) => void)): Quill;
+        once(eventName: string, callback: (delta: DeltaStatic, source: string) => void): Quill;
+        off(eventName: string, callback: (delta: DeltaStatic, source: string) => void): Quill;
 
         debug(level: string): void;
         import(path: string): any;
         register(path: string, def: any, suppressWarning?: boolean): void;
-        register(defs: formatsType, suppressWarning?: boolean): void;
+        register(defs: Formats, suppressWarning?: boolean): void;
         addContainer(className: string, refNode?: any): any;
+        addContainer(domNode: any, refNode?: any): any;
         getModule(name: string): any
+
+        clipboard: ClipboardStatic;
     }
 }
 
-declare var Quill: QuillJS.QuillStatic;
+declare var Quill: Quill.Quill;
+
+declare var Delta: Quill.DeltaStatic;
 
 declare module "quill" {
     export = Quill;


### PR DESCRIPTION
case 2. Update Quill JS definitions to v1.1.0 Added more interfaces from the Quill framework. Also changed top level namespace to Quill as requested by some users.
- documentation or source code reference which provides context for the suggested changes.  [QuillJS API](http://quilljs.com/docs/api/)
