### PR TITLE
Updating pegs to 0.10.0.

### DIFF
--- a/pegjs/pegjs-tests.ts
+++ b/pegjs/pegjs-tests.ts
@@ -8,7 +8,7 @@
 import * as pegjs from 'pegjs';
 
 {
-    let pegparser: pegjs.Parser = pegjs.buildParser("start = ('a' / 'b')+");
+    let pegparser: pegjs.Parser = pegjs.generate("start = ('a' / 'b')+");
 
     try {
         let result: string = pegparser.parse("abba");
@@ -20,7 +20,7 @@ import * as pegjs from 'pegjs';
 }
 
 {
-    let parser = pegjs.buildParser("A = 'test'", {
+    let parser = pegjs.generate("A = 'test'", {
         cache: true,
         allowedStartRules: ["A"],
         optimize: "speed",
@@ -29,7 +29,7 @@ import * as pegjs from 'pegjs';
 }
 
 try {
-    let parserOrSource: pegjs.Parser | string = pegjs.buildParser("A = 'test'", {output: "source"});
+    let source: string = pegjs.generate("A = 'test'", {output: "source"});
 } catch (error) {
     if (error instanceof pegjs.GrammarError) {
         let e: pegjs.GrammarError = error;

--- a/pegjs/pegjs.d.ts
+++ b/pegjs/pegjs.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for PEG.js
+// Type definitions for PEG.js v0.10.0
 // Project: http://pegjs.org/
-// Definitions by: vvakame <https://github.com/vvakame>, Tobias Kahlert <https://github.com/SrTobi>
+// Definitions by: vvakame <https://github.com/vvakame>, Tobias Kahlert <https://github.com/SrTobi>, C.J. Bell <https://github.com/siegebell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace PEG {
@@ -63,19 +63,72 @@ declare module "pegjs" {
         SyntaxError: any;
     }
 
-    interface BuildOptions {
-        cache?: boolean;
+    interface BuildOptionsBase {
+        /** rules the parser will be allowed to start parsing from (default: the first rule in the grammar) */
         allowedStartRules?: string[];
-        optimize?: string;
+        /** if `true`, makes the parser cache results, avoiding exponential parsing time in pathological cases but making the parser slower (default: `false`) */
+        cache?: boolean;
+        /** selects between optimizing the generated parser for parsing speed (`"speed"`) or code size (`"size"`) (default: `"speed"`) */
+        optimize?: "speed" | "size";
+        /** plugins to use */
         plugins?: any[];
+        /** makes the parser trace its progress (default: `false`) */
+        trace?: boolean
     }
 
-    interface OutputBuildOptions extends BuildOptions {
-        output?: string;
+
+    interface ParserBuildOptions extends BuildOptionsBase {
+        /** if set to `"parser"`, the method will return generated parser object; if set to `"source"`, it will return parser source code as a string (default: `"parser"`) */
+        output?: "parser"
     }
 
-    function buildParser(grammar: string, options?: BuildOptions): Parser;
-    function buildParser(grammar: string, options?: OutputBuildOptions): Parser | string;
+    interface OutputFormatAmdCommonjs extends BuildOptionsBase {
+        /** if set to `"parser"`, the method will return generated parser object; if set to `"source"`, it will return parser source code as a string (default: `"parser"`) */
+        output: "source";
+        /** format of the genreated parser (`"amd"`, `"bare"`, `"commonjs"`, `"globals"`, or `"umd"`); valid only when `output` is set to `"source"` (default: `"bare"`) */
+        format: "amd" | "commonjs";
+        /** parser dependencies, the value is an object which maps variables used to access the dependencies in the parser to module IDs used to load them; valid only when `format` is set to `"amd"`, `"commonjs"`, or `"umd"` (default: `{}`) */
+        dependencies?: any
+    }
+
+    interface OutputFormatUmd extends BuildOptionsBase {
+        /** if set to `"parser"`, the method will return generated parser object; if set to `"source"`, it will return parser source code as a string (default: `"parser"`) */
+        output: "source";
+        /** format of the genreated parser (`"amd"`, `"bare"`, `"commonjs"`, `"globals"`, or `"umd"`); valid only when `output` is set to `"source"` (default: `"bare"`) */
+        format: "umd";
+        /** parser dependencies, the value is an object which maps variables used to access the dependencies in the parser to module IDs used to load them; valid only when `format` is set to `"amd"`, `"commonjs"`, or `"umd"` (default: `{}`) */
+        dependencies?: any
+        /** name of a global variable into which the parser object is assigned to when no module loader is detected; valid only when `format` is set to `"globals"` or `"umd"` (default: `null`) */
+        exportVar?: any
+    }
+
+    interface OutputFormatGlobals extends BuildOptionsBase {
+        /** if set to `"parser"`, the method will return generated parser object; if set to `"source"`, it will return parser source code as a string (default: `"parser"`) */
+        output: "source";
+        /** format of the genreated parser (`"amd"`, `"bare"`, `"commonjs"`, `"globals"`, or `"umd"`); valid only when `output` is set to `"source"` (default: `"bare"`) */
+        format: "globals";
+        /** name of a global variable into which the parser object is assigned to when no module loader is detected; valid only when `format` is set to `"globals"` or `"umd"` (default: `null`) */
+        exportVar?: any
+    }
+
+    interface OutputFormatBare extends BuildOptionsBase {
+        /** if set to `"parser"`, the method will return generated parser object; if set to `"source"`, it will return parser source code as a string (default: `"parser"`) */
+        output: "source";
+        /** format of the genreated parser (`"amd"`, `"bare"`, `"commonjs"`, `"globals"`, or `"umd"`); valid only when `output` is set to `"source"` (default: `"bare"`) */
+        format?: "bare"
+    }
+
+    /** Returns a generated parser object. It will throw an exception if the grammar is invalid. The exception will contain `message` property with more details about the error. */
+    function generate(grammar: string, options?: ParserBuildOptions): Parser;
+    /** Returns the generated source code as a `string`. It will throw an exception if the grammar is invalid. The exception will contain `message` property with more details about the error. */
+    function generate(grammar: string, options: OutputFormatAmdCommonjs): string;
+    /** Returns the generated source code as a `string`. It will throw an exception if the grammar is invalid. The exception will contain `message` property with more details about the error. */
+    function generate(grammar: string, options: OutputFormatUmd): string;
+    /** Returns the generated source code as a `string`. It will throw an exception if the grammar is invalid. The exception will contain `message` property with more details about the error. */
+    function generate(grammar: string, options: OutputFormatGlobals): string;
+    /** Returns the generated source code as a `string`. It will throw an exception if the grammar is invalid. The exception will contain `message` property with more details about the error. */
+    function generate(grammar: string, options: OutputFormatBare): string;
+
 
     namespace parser {
         type SyntaxError = PegjsError;


### PR DESCRIPTION
Updating types for pegjs 0.10.0
- pegjs: https://github.com/pegjs/pegjs
- added comments
- added more build options
- renamed `buildParser` to `generate`
- added more typing restrictions on the `generate` function
