### PR TITLE
Improve EJS renderFile typings

### DIFF
--- a/ejs/index.d.ts
+++ b/ejs/index.d.ts
@@ -11,7 +11,12 @@ declare namespace Ejs {
     function resolveInclude(name: string, filename: string): string;
     function compile(template: string, opts?: Options): (TemplateFunction);
     function render(template: string, data?: Data, opts?: Options): string;
-    function renderFile(path: string, data?: Data, opts?: Options, cb?: Function): any;// TODO RenderFileCallback return type
+
+    type RenderFileCallback<T> = (err: Error, str?: string) => T;
+    function renderFile<T>(path: string, cb: RenderFileCallback<T>): T;
+    function renderFile<T>(path: string, data: Data, cb: RenderFileCallback<T>): T;
+    function renderFile<T>(path: string, data: Data, opts: Options, cb: RenderFileCallback<T>): T;
+
     function clearCache(): any;
 
     interface TemplateFunction {


### PR DESCRIPTION
- Make data and opts arguments optional.
- Type the render file callback.

[Relevant function documentation](https://github.com/mde/ejs/blob/2f5e8a5daf9133b3ef68f201ed1d3ff9b0d74317/lib/ejs.js#L335).
