### PR TITLE
[material-ui] ListItem and MenuItem props fixes

### DIFF
--- a/material-ui/index.d.ts
+++ b/material-ui/index.d.ts
@@ -1063,7 +1063,7 @@ declare namespace __MaterialUI {
         export class List extends React.Component<ListProps, {}> {
         }
 
-        interface ListItemProps extends React.HTMLAttributes<{}>, React.Props<ListItem> {
+        interface ListItemProps extends EnhancedButtonProps {
             // <EnhancedButton/> is the element that get the 'other' properties
             autoGenerateNestedIndicator?: boolean;
             disableKeyboardFocus?: boolean;
@@ -1137,7 +1137,7 @@ declare namespace __MaterialUI {
         export class Menu extends React.Component<MenuProps, {}>{
         }
 
-        interface MenuItemProps extends React.HTMLAttributes<{}>, React.Props<MenuItem> {
+        interface MenuItemProps extends List.ListItemProps {
             // <ListItem/> is the element that get the 'other' properties
             checked?: boolean;
             desktop?: boolean;
@@ -1152,10 +1152,6 @@ declare namespace __MaterialUI {
             secondaryText?: React.ReactNode;
             style?: React.CSSProperties;
             value?: any;
-
-            // useful attributes passed to <ListItem/>
-            primaryText?: React.ReactNode;
-            secondaryTextLines?: number; // 1 or 2
         }
         export class MenuItem extends React.Component<MenuItemProps, {}>{
         }


### PR DESCRIPTION
`MenuItem` properties are passed to the underlying `ListItem` element. Remove  the extending of `React.Props<>` because it is causing problems with multiple implementation of the `ref` property with different generic arguments. `React.Props<>` is deprecated nevertheless.

The same applies to `ListItem` properties and its underlying `EnhancedButton`.
