### PR TITLE
Adding RenderStatus to API

### DIFF
--- a/polymer/polymer.d.ts
+++ b/polymer/polymer.d.ts
@@ -7,7 +7,7 @@
 
 declare namespace polymer {
 
-  type PropConstructorType = StringConstructor|ObjectConstructor|BooleanConstructor|NumberConstructor|DateConstructor|ArrayConstructor;
+  type PropConstructorType = StringConstructor | ObjectConstructor | BooleanConstructor | NumberConstructor | DateConstructor | ArrayConstructor;
 
   interface PropObjectType {
     type: PropConstructorType;
@@ -305,15 +305,38 @@ declare namespace polymer {
       wantShadow: boolean
   }
 
-  interface PolymerStatic {
+  interface RenderStatus {
+    _afterNextRenderQueue: [Element, Function, any][];
+    _callbacks: Function[];
+    _ready: boolean;
+    _waitingNextRender: boolean;
+    _catchFirstRender(): void;
+    _flushNextRender(): void;
+    _flushRenderCallbacks(callbacks: [Element, Function, any][]): void;
+    _makeReady(): void;
+    _watchNextRender(): void;
 
+    afterNextRender(element: Element, fn: Function, args?: any): void;
+    hasRendered(): boolean;
+    whenReady(cb: Function): void;
+  }
+
+  interface ImportStatus extends RenderStatus {
+    whenLoaded(cb: Function): void;
+  }
+
+  interface PolymerStatic {
     Settings: Settings;
 
-    dom:DomApiStatic;
+    dom: DomApiStatic;
 
-    (prototype: Base|{new ():Base}):webcomponents.CustomElementConstructor;
+    (prototype: Base | { new (): Base }): webcomponents.CustomElementConstructor;
 
-    Class(prototype: Base|{new ():Base}):webcomponents.CustomElementConstructor;
+    Class(prototype: Base | { new (): Base }): webcomponents.CustomElementConstructor;
+
+    RenderStatus: RenderStatus
+
+    ImportStatus: ImportStatus
   }
 }
 

--- a/polymer/polymer.d.ts
+++ b/polymer/polymer.d.ts
@@ -306,16 +306,6 @@ declare namespace polymer {
   }
 
   interface RenderStatus {
-    _afterNextRenderQueue: [Element, Function, any][];
-    _callbacks: Function[];
-    _ready: boolean;
-    _waitingNextRender: boolean;
-    _catchFirstRender(): void;
-    _flushNextRender(): void;
-    _flushRenderCallbacks(callbacks: [Element, Function, any][]): void;
-    _makeReady(): void;
-    _watchNextRender(): void;
-
     afterNextRender(element: Element, fn: Function, args?: any): void;
     hasRendered(): boolean;
     whenReady(cb: Function): void;

--- a/polymer/polymer.d.ts
+++ b/polymer/polymer.d.ts
@@ -336,6 +336,7 @@ declare namespace polymer {
 
     RenderStatus: RenderStatus
 
+    /** @deprecated */
     ImportStatus: ImportStatus
   }
 }


### PR DESCRIPTION
The current definition of the Polymer API is missing the RenderStatus object.

[https://github.com/Polymer/polymer/blob/master/src/lib/render-status.html](https://github.com/Polymer/polymer/blob/master/src/lib/render-status.html)

I'm not sure if we should also be documenting the private methods of the object. I can remove them if we feel that only public methods should be included in the definition.
