### PR TITLE
[Lodash] Add fromIndex param to findIndex, findLastIndex and findLast

### DIFF
--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -681,6 +681,7 @@ namespace TestFindIndex {
     let array: TResult[];
     let list: _.List<TResult>;
     let predicateFn: (value: TResult, index?: number, collection?: _.List<TResult>) => boolean;
+    let fromIndex: number;
 
     {
         let result: number;
@@ -689,21 +690,25 @@ namespace TestFindIndex {
         result = _.findIndex<TResult>(array, predicateFn);
         result = _.findIndex<TResult>(array, '');
         result = _.findIndex<{a: number}, TResult>(array, {a: 42});
+        result = _.findIndex<TResult>(array, predicateFn, fromIndex);
 
         result = _.findIndex<TResult>(list);
         result = _.findIndex<TResult>(list, predicateFn);
         result = _.findIndex<TResult>(list, '');
         result = _.findIndex<{a: number}, TResult>(list, {a: 42});
+        result = _.findIndex<TResult>(list, predicateFn, fromIndex);
 
         result = _<TResult>(array).findIndex();
         result = _<TResult>(array).findIndex(predicateFn);
         result = _<TResult>(array).findIndex('');
         result = _<TResult>(array).findIndex<{a: number}>({a: 42});
+        result = _<TResult>(array).findIndex(predicateFn, fromIndex);
 
         result = _(list).findIndex();
         result = _(list).findIndex<TResult>(predicateFn);
         result = _(list).findIndex('');
         result = _(list).findIndex<{a: number}>({a: 42});
+        result = _(list).findIndex<TResult>(predicateFn, fromIndex);
     }
 
     {
@@ -713,11 +718,13 @@ namespace TestFindIndex {
         result = _<TResult>(array).chain().findIndex(predicateFn);
         result = _<TResult>(array).chain().findIndex('');
         result = _<TResult>(array).chain().findIndex<{a: number}>({a: 42});
+        result = _<TResult>(array).chain().findIndex(predicateFn, fromIndex);
 
         result = _(list).chain().findIndex();
         result = _(list).chain().findIndex<TResult>(predicateFn);
         result = _(list).chain().findIndex('');
         result = _(list).chain().findIndex<{a: number}>({a: 42});
+        result = _(list).chain().findIndex<TResult>(predicateFn, fromIndex);
     }
 }
 
@@ -727,6 +734,7 @@ namespace TestFindLastIndex {
     let list: _.List<TResult>;
 
     let predicateFn: (value: TResult, index?: number, collection?: _.List<TResult>) => boolean;
+    let fromIndex: number;
 
     {
         let result: number;
@@ -735,21 +743,25 @@ namespace TestFindLastIndex {
         result = _.findLastIndex<TResult>(array, predicateFn);
         result = _.findLastIndex<TResult>(array, '');
         result = _.findLastIndex<{a: number}, TResult>(array, {a: 42});
+        result = _.findLastIndex<TResult>(array, predicateFn, fromIndex);
 
         result = _.findLastIndex<TResult>(list);
         result = _.findLastIndex<TResult>(list, predicateFn);
         result = _.findLastIndex<TResult>(list, '');
         result = _.findLastIndex<{a: number}, TResult>(list, {a: 42});
+        result = _.findLastIndex<TResult>(list, predicateFn, fromIndex);
 
         result = _<TResult>(array).findLastIndex();
         result = _<TResult>(array).findLastIndex(predicateFn);
         result = _<TResult>(array).findLastIndex('');
         result = _<TResult>(array).findLastIndex<{a: number}>({a: 42});
+        result = _<TResult>(array).findLastIndex(predicateFn, fromIndex);
 
         result = _(list).findLastIndex();
         result = _(list).findLastIndex<TResult>(predicateFn);
         result = _(list).findLastIndex('');
         result = _(list).findLastIndex<{a: number}>({a: 42});
+        result = _(list).findLastIndex<TResult>(predicateFn, fromIndex);
     }
 
     {
@@ -759,11 +771,13 @@ namespace TestFindLastIndex {
         result = _<TResult>(array).chain().findLastIndex(predicateFn);
         result = _<TResult>(array).chain().findLastIndex('');
         result = _<TResult>(array).chain().findLastIndex<{a: number}>({a: 42});
+        result = _<TResult>(array).chain().findLastIndex(predicateFn, fromIndex);
 
         result = _(list).chain().findLastIndex();
         result = _(list).chain().findLastIndex<TResult>(predicateFn);
         result = _(list).chain().findLastIndex('');
         result = _(list).chain().findLastIndex<{a: number}>({a: 42});
+        result = _(list).chain().findLastIndex<TResult>(predicateFn, fromIndex);
     }
 }
 
@@ -3735,11 +3749,15 @@ result = <number>_.findLast([1, 2, 3, 4], function (num) {
 result = <IFoodCombined>_.findLast(foodsCombined, { 'type': 'vegetable' });
 result = <IFoodCombined>_.findLast(foodsCombined, 'organic');
 
+result = <IFoodCombined>_.findLast(foodsCombined, 'organic', 1);
+
 result = <number>_([1, 2, 3, 4]).findLast(function (num) {
     return num % 2 == 0;
 });
 result = <IFoodCombined>_(foodsCombined).findLast({ 'type': 'vegetable' });
 result = <IFoodCombined>_(foodsCombined).findLast('organic');
+
+result = <IFoodCombined>_(foodsCombined).findLast('organic', 1);
 
 // _.flatMap
 namespace TestFlatMap {

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -1590,11 +1590,13 @@ declare module _ {
          *
          * @param array The array to search.
          * @param predicate The function invoked per iteration.
+         * @param fromIndex The index to search from.
          * @return Returns the index of the found element, else -1.
          */
         findIndex<T>(
             array: List<T>,
-            predicate?: ListIterator<T, boolean>
+            predicate?: ListIterator<T, boolean>,
+            fromIndex?: number
         ): number;
 
         /**
@@ -1602,7 +1604,8 @@ declare module _ {
          */
         findIndex<T>(
             array: List<T>,
-            predicate?: string
+            predicate?: string,
+            fromIndex?: number
         ): number;
 
         /**
@@ -1610,7 +1613,8 @@ declare module _ {
          */
         findIndex<W, T>(
             array: List<T>,
-            predicate?: W
+            predicate?: W,
+            fromIndex?: number
         ): number;
     }
 
@@ -1619,21 +1623,24 @@ declare module _ {
          * @see _.findIndex
          */
         findIndex(
-            predicate?: ListIterator<T, boolean>
+            predicate?: ListIterator<T, boolean>,
+            fromIndex?: number
         ): number;
 
         /**
          * @see _.findIndex
          */
         findIndex(
-            predicate?: string
+            predicate?: string,
+            fromIndex?: number
         ): number;
 
         /**
          * @see _.findIndex
          */
         findIndex<W>(
-            predicate?: W
+            predicate?: W,
+            fromIndex?: number
         ): number;
     }
 
@@ -1642,21 +1649,24 @@ declare module _ {
          * @see _.findIndex
          */
         findIndex<TResult>(
-            predicate?: ListIterator<TResult, boolean>
+            predicate?: ListIterator<TResult, boolean>,
+            fromIndex?: number
         ): number;
 
         /**
          * @see _.findIndex
          */
         findIndex(
-            predicate?: string
+            predicate?: string,
+            fromIndex?: number
         ): number;
 
         /**
          * @see _.findIndex
          */
         findIndex<W>(
-            predicate?: W
+            predicate?: W,
+            fromIndex?: number
         ): number;
     }
 
@@ -1665,21 +1675,24 @@ declare module _ {
          * @see _.findIndex
          */
         findIndex(
-            predicate?: ListIterator<T, boolean>
+            predicate?: ListIterator<T, boolean>,
+            fromIndex?: number
         ): LoDashExplicitWrapper<number>;
 
         /**
          * @see _.findIndex
          */
         findIndex(
-            predicate?: string
+            predicate?: string,
+            fromIndex?: number
         ): LoDashExplicitWrapper<number>;
 
         /**
          * @see _.findIndex
          */
         findIndex<W>(
-            predicate?: W
+            predicate?: W,
+            fromIndex?: number
         ): LoDashExplicitWrapper<number>;
     }
 
@@ -1688,21 +1701,24 @@ declare module _ {
          * @see _.findIndex
          */
         findIndex<TResult>(
-            predicate?: ListIterator<TResult, boolean>
+            predicate?: ListIterator<TResult, boolean>,
+            fromIndex?: number
         ): LoDashExplicitWrapper<number>;
 
         /**
          * @see _.findIndex
          */
         findIndex(
-            predicate?: string
+            predicate?: string,
+            fromIndex?: number
         ): LoDashExplicitWrapper<number>;
 
         /**
          * @see _.findIndex
          */
         findIndex<W>(
-            predicate?: W
+            predicate?: W,
+            fromIndex?: number
         ): LoDashExplicitWrapper<number>;
     }
 
@@ -1722,11 +1738,13 @@ declare module _ {
          *
          * @param array The array to search.
          * @param predicate The function invoked per iteration.
+         * @param fromIndex The index to search from.
          * @return Returns the index of the found element, else -1.
          */
         findLastIndex<T>(
             array: List<T>,
-            predicate?: ListIterator<T, boolean>
+            predicate?: ListIterator<T, boolean>,
+            fromIndex?: number
         ): number;
 
         /**
@@ -1734,7 +1752,8 @@ declare module _ {
          */
         findLastIndex<T>(
             array: List<T>,
-            predicate?: string
+            predicate?: string,
+            fromIndex?: number
         ): number;
 
         /**
@@ -1742,7 +1761,8 @@ declare module _ {
          */
         findLastIndex<W, T>(
             array: List<T>,
-            predicate?: W
+            predicate?: W,
+            fromIndex?: number
         ): number;
     }
 
@@ -1751,21 +1771,24 @@ declare module _ {
          * @see _.findLastIndex
          */
         findLastIndex(
-            predicate?: ListIterator<T, boolean>
+            predicate?: ListIterator<T, boolean>,
+            fromIndex?: number
         ): number;
 
         /**
          * @see _.findLastIndex
          */
         findLastIndex(
-            predicate?: string
+            predicate?: string,
+            fromIndex?: number
         ): number;
 
         /**
          * @see _.findLastIndex
          */
         findLastIndex<W>(
-            predicate?: W
+            predicate?: W,
+            fromIndex?: number
         ): number;
     }
 
@@ -1774,21 +1797,24 @@ declare module _ {
          * @see _.findLastIndex
          */
         findLastIndex<TResult>(
-            predicate?: ListIterator<TResult, boolean>
+            predicate?: ListIterator<TResult, boolean>,
+            fromIndex?: number
         ): number;
 
         /**
          * @see _.findLastIndex
          */
         findLastIndex(
-            predicate?: string
+            predicate?: string,
+            fromIndex?: number
         ): number;
 
         /**
          * @see _.findLastIndex
          */
         findLastIndex<W>(
-            predicate?: W
+            predicate?: W,
+            fromIndex?: number
         ): number;
     }
 
@@ -1797,21 +1823,24 @@ declare module _ {
          * @see _.findLastIndex
          */
         findLastIndex(
-            predicate?: ListIterator<T, boolean>
+            predicate?: ListIterator<T, boolean>,
+            fromIndex?: number
         ): LoDashExplicitWrapper<number>;
 
         /**
          * @see _.findLastIndex
          */
         findLastIndex(
-            predicate?: string
+            predicate?: string,
+            fromIndex?: number
         ): LoDashExplicitWrapper<number>;
 
         /**
          * @see _.findLastIndex
          */
         findLastIndex<W>(
-            predicate?: W
+            predicate?: W,
+            fromIndex?: number
         ): LoDashExplicitWrapper<number>;
     }
 
@@ -1820,21 +1849,24 @@ declare module _ {
          * @see _.findLastIndex
          */
         findLastIndex<TResult>(
-            predicate?: ListIterator<TResult, boolean>
+            predicate?: ListIterator<TResult, boolean>,
+            fromIndex?: number
         ): LoDashExplicitWrapper<number>;
 
         /**
          * @see _.findLastIndex
          */
         findLastIndex(
-            predicate?: string
+            predicate?: string,
+            fromIndex?: number
         ): LoDashExplicitWrapper<number>;
 
         /**
          * @see _.findLastIndex
          */
         findLastIndex<W>(
-            predicate?: W
+            predicate?: W,
+            fromIndex?: number
         ): LoDashExplicitWrapper<number>;
     }
 
@@ -6892,25 +6924,32 @@ declare module _ {
         * right to left.
         * @param collection Searches for a value in this list.
         * @param callback The function called per iteration.
+        * @param fromIndex The index to search from.
         * @return The found element, else undefined.
         **/
         findLast<T>(
             collection: Array<T>,
-            callback: ListIterator<T, boolean>): T;
+            callback: ListIterator<T, boolean>,
+            fromIndex?: number
+        ): T;
 
         /**
         * @see _.find
         **/
         findLast<T>(
             collection: List<T>,
-            callback: ListIterator<T, boolean>): T;
+            callback: ListIterator<T, boolean>,
+            fromIndex?: number
+        ): T;
 
         /**
         * @see _.find
         **/
         findLast<T>(
             collection: Dictionary<T>,
-            callback: DictionaryIterator<T, boolean>): T;
+            callback: DictionaryIterator<T, boolean>,
+            fromIndex?: number
+        ): T;
 
         /**
         * @see _.find
@@ -6918,7 +6957,9 @@ declare module _ {
         **/
         findLast<W, T>(
             collection: Array<T>,
-            whereValue: W): T;
+            whereValue: W,
+            fromIndex?: number
+        ): T;
 
         /**
         * @see _.find
@@ -6926,7 +6967,9 @@ declare module _ {
         **/
         findLast<W, T>(
             collection: List<T>,
-            whereValue: W): T;
+            whereValue: W,
+            fromIndex?: number
+        ): T;
 
         /**
         * @see _.find
@@ -6934,7 +6977,9 @@ declare module _ {
         **/
         findLast<W, T>(
             collection: Dictionary<T>,
-            whereValue: W): T;
+            whereValue: W,
+            fromIndex?: number
+        ): T;
 
         /**
         * @see _.find
@@ -6942,7 +6987,9 @@ declare module _ {
         **/
         findLast<T>(
             collection: Array<T>,
-            pluckValue: string): T;
+            pluckValue: string,
+            fromIndex?: number
+        ): T;
 
         /**
         * @see _.find
@@ -6950,7 +6997,9 @@ declare module _ {
         **/
         findLast<T>(
             collection: List<T>,
-            pluckValue: string): T;
+            pluckValue: string,
+            fromIndex?: number
+        ): T;
 
         /**
         * @see _.find
@@ -6958,7 +7007,9 @@ declare module _ {
         **/
         findLast<T>(
             collection: Dictionary<T>,
-            pluckValue: string): T;
+            pluckValue: string,
+            fromIndex?: number
+        ): T;
     }
 
     interface LoDashImplicitArrayWrapper<T> {
@@ -6966,20 +7017,26 @@ declare module _ {
         * @see _.findLast
         */
         findLast(
-            callback: ListIterator<T, boolean>): T;
+            callback: ListIterator<T, boolean>,
+            fromIndex?: number
+        ): T;
         /**
         * @see _.findLast
         * @param _.where style callback
         */
         findLast<W>(
-            whereValue: W): T;
+            whereValue: W,
+            fromIndex?: number
+        ): T;
 
         /**
         * @see _.findLast
         * @param _.where style callback
         */
         findLast(
-            pluckValue: string): T;
+            pluckValue: string,
+            fromIndex?: number
+        ): T;
     }
 
     //_.flatMap

--- a/lodash/lodash.d.ts
+++ b/lodash/lodash.d.ts
@@ -1590,7 +1590,6 @@ declare module _ {
          *
          * @param array The array to search.
          * @param predicate The function invoked per iteration.
-         * @param thisArg The this binding of predicate.
          * @return Returns the index of the found element, else -1.
          */
         findIndex<T>(
@@ -1723,7 +1722,6 @@ declare module _ {
          *
          * @param array The array to search.
          * @param predicate The function invoked per iteration.
-         * @param thisArg The function invoked per iteration.
          * @return Returns the index of the found element, else -1.
          */
         findLastIndex<T>(
@@ -6894,7 +6892,6 @@ declare module _ {
         * right to left.
         * @param collection Searches for a value in this list.
         * @param callback The function called per iteration.
-        * @param thisArg The this binding of callback.
         * @return The found element, else undefined.
         **/
         findLast<T>(


### PR DESCRIPTION
Param `fromIndex` available since lodash 4.13.0, see https://github.com/lodash/lodash/wiki/Changelog#v4130

Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes: 
  - https://lodash.com/docs/4.16.4#findIndex
  - https://lodash.com/docs/4.16.4#findLastIndex
  - https://lodash.com/docs/4.16.4#findLast
