### PR TITLE
Adding lowlight

### DIFF
--- a/lowlight/lowlight-tests.ts
+++ b/lowlight/lowlight-tests.ts
@@ -1,0 +1,82 @@
+/// <reference path="lowlight.d.ts" />
+
+import { highlight, highlightAuto, registerLanguage } from 'lowlight';
+import * as core from 'lowlight/lib/core';
+
+function highlighter(hljs: any): any {
+    return {
+        aliases: ['cmake.in'],
+        case_insensitive: true,
+        keywords: {
+            keyword:
+                'forall all exists exist only m M i e 1 2 3 4 5 6 7 8 9 0 - + * / \ % ! . , ; : | lim limsup liminf infinity not'
+        },
+        contains: [
+        {
+            className: 'variable',
+            begin: '(', end: ')'
+        },
+        ]
+    };
+}
+
+registerLanguage('math', highlighter);
+
+console.log(highlight('typescript',
+`class CPP {
+    private year: number;
+    public constructor(private version: string) {
+        this.year = Number(version.match(/.+\d+$/));
+    }
+
+    public version(): string {
+        return this.version;
+    }
+}
+`
+));
+
+console.info(highlightAuto(
+`class CPP {
+    private year: number;
+    public constructor(private version: string) {
+        this.year = Number(version.match(/.+\d+$/));
+    }
+
+    public version(): string {
+        return this.version;
+    }
+}
+`
+));
+
+core.registerLanguage('math', highlighter);
+
+console.log(core.highlight('javascript',
+`class CPP {
+    constructor(version) {
+        this.version = version;
+        this.year = Number(version.match(/.+\d+$/));
+    }
+
+    version(){
+        return this.version;
+    }
+}
+`
+, { prefix: 'core-' }));
+
+
+console.info(core.highlightAuto(
+`class CPP {
+    constructor(version) {
+        this.version = version;
+        this.year = Number(version.match(/.+\d+$/));
+    }
+
+    version(){
+        return this.version;
+    }
+}
+`
+, { prefix: 'core-', subset: ['purescript', 'javascript', 'typescript', 'coffeescript'] }));

--- a/lowlight/lowlight.d.ts
+++ b/lowlight/lowlight.d.ts
@@ -1,0 +1,99 @@
+// Type definitions for lowlight
+// Project: https://github.com/wooorm/lowlight
+// Definitions by: Ivo Stratev <https://github.com/NoHomey>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'lowlight' {
+    export { highlight, highlightAuto, registerLanguage } from 'lowlight/lib/core';
+}
+
+declare module 'lowlight/lib/core' {
+    export function highlight(language: string, value: string, options?: lowlight.HighlightOptions): lowlight.HighlightResult;
+    export function highlightAuto(value: string, options?: lowlight.HighlightAutoOptions): lowlight.HighlightAutoResult;
+    export function registerLanguage(name: string, syntax: Function): void;
+}
+
+declare namespace lowlight {
+    namespace AST {
+        namespace Unist {
+            interface Data {
+                [index: string]: any;
+            }
+
+            interface Position {
+                line: number;
+                column: number;
+                offset?: number;
+            }
+
+            interface Location {
+                start: Position;
+                end: Position;
+                indent?: Array<number>;
+            }
+
+            export interface Node {
+                type: string;
+                data?: Data;
+                position?: Location;
+            }
+
+            export interface Parent extends Node {
+                children: Array<Node>;
+            }
+
+            export interface Text extends Node {
+                value: string;
+            }
+        }
+
+        interface Properties {
+            [index: string]: any;
+        }
+
+        export interface Root extends Unist.Parent {
+            type: 'root';
+        }
+
+        export interface Element extends Unist.Parent {
+            type: 'element';
+            tagName: string;
+            properties: Properties;
+        }
+
+        export interface Doctype extends Unist.Node {
+            type: 'doctype';
+            name: string;
+            public?: string;
+            system?: string;
+        }
+
+        export interface Comment extends Unist.Text {
+                type: 'comment';
+        }
+
+        export interface Text extends Unist.Text {
+            type: 'text';
+        }
+    }
+
+    type HastNode = AST.Root | AST.Element | AST.Doctype | AST.Comment | AST.Text;
+
+    interface HighlightOptions {
+            prefix?: string;
+    }
+
+    interface HighlightAutoOptions extends HighlightOptions {
+        subset?: Array<string>;
+    }
+
+    interface HighlightResult {
+        relevance: number;
+        language: string;
+        value: Array<HastNode>;
+    }
+
+    interface HighlightAutoResult extends HighlightResult {
+        secondBest?: HighlightAutoResult;
+    }
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

Adding type definition for [lowlight](https://github.com/wooorm/lowlight).

API reference: https://github.com/wooorm/lowlight#api, lowlight uses [HAST](https://github.com/wooorm/hast#ast) and [UNIST](https://github.com/wooorm/unist#unist-nodes) interfaces implementation.
