### PR TITLE
Update @types/screenfull to 3.0.0

### DIFF
--- a/screenfull/index.d.ts
+++ b/screenfull/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for screenfull.js 2.0.0
+// Type definitions for screenfull.js 3.0.0
 // Project: https://github.com/sindresorhus/screenfull.js
 // Definitions by: Ilia Choly <http://github.com/icholy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -24,3 +24,5 @@ interface IScreenfull {
   toggle(elem?: Element): void;
   exit(): void;
 }
+
+export = screenfull;

--- a/screenfull/screenfull-tests.ts
+++ b/screenfull/screenfull-tests.ts
@@ -1,4 +1,4 @@
-
+import screenfull = require('screenfull');
 
 function test_fullscreen_page() {
   if (screenfull.enabled) {
@@ -48,7 +48,7 @@ function test_detect_error() {
     document.addEventListener(screenfull.raw.fullscreenerror, function (event) {
       console.error('Failed to enable fullscreen', event);
     });
-  } 
+  }
 }
 
 function test_access_element() {


### PR DESCRIPTION
Screenfull in 3.0.0 can now be used as a CJS module. [Changelog](https://github.com/sindresorhus/screenfull.js/releases/tag/v3.0.0)
