### PR TITLE
Add definition for "nodemailer-stub-transport".

### DIFF
--- a/nodemailer-stub-transport/nodemailer-stub-transport-tests.ts
+++ b/nodemailer-stub-transport/nodemailer-stub-transport-tests.ts
@@ -1,0 +1,8 @@
+/// <reference path="nodemailer-stub-transport.d.ts"/>
+
+import nodemailer = require("nodemailer");
+import stubTransport = require("nodemailer-stub-transport");
+
+var transport = nodemailer.createTransport(stubTransport());
+nodemailer.createTransport(stubTransport({ error: new Error('Invalid recipient') }));
+transport = nodemailer.createTransport(stubTransport({ keepBcc: true }));

--- a/nodemailer-stub-transport/nodemailer-stub-transport-tests.ts
+++ b/nodemailer-stub-transport/nodemailer-stub-transport-tests.ts
@@ -6,3 +6,5 @@ import stubTransport = require("nodemailer-stub-transport");
 var transport = nodemailer.createTransport(stubTransport());
 nodemailer.createTransport(stubTransport({ error: new Error('Invalid recipient') }));
 transport = nodemailer.createTransport(stubTransport({ keepBcc: true }));
+
+nodemailer.createTransport(stubTransport());

--- a/nodemailer-stub-transport/nodemailer-stub-transport.d.ts
+++ b/nodemailer-stub-transport/nodemailer-stub-transport.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for nodemailer-stub-transport v1.1.0
+// Project: https://github.com/andris9/nodemailer-stub-transport
+// Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../nodemailer/nodemailer.d.ts"/>
+
+declare module "nodemailer-stub-transport" {
+    import * as nodemailer from "nodemailer";
+
+    namespace StubTransportStatic {
+        /**
+         * Options.
+         * @interface
+         */
+        export interface Options {
+            /**
+             * Specifies a custom error.
+             * @type {any}
+             */
+            error?: any;
+
+            /**
+             * Value that indicates if the BCC addresses must be included in generated message.
+             * @type {boolean}
+             */
+            keepBcc?: boolean;
+        }
+    }
+
+    /**
+     * Creates a stub transport.
+     * @param {Options} [options] Options.
+     * @return {Transport} The stub transport.
+     */
+    function stubTransport(options?: StubTransportStatic.Options): nodemailer.Transport;
+    export = stubTransport;
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
