### PR TITLE
add self to contributors list for GraphQL typings

### DIFF
--- a/graphql/graphql.d.ts
+++ b/graphql/graphql.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for graphql v0.7.0
 // Project: https://www.npmjs.com/package/graphql
-// Definitions by: TonyYang <https://github.com/TonyPythoneer>
+// Definitions by: TonyYang <https://github.com/TonyPythoneer>, Caleb Meredith <https://github.com/calebmer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /*************************************


### PR DESCRIPTION
I’ve been maintaining custom definitions for [one of my projects](https://github.com/calebmer/postgraphql/blob/master/typings/graphql.d.ts) and I’d like to migrate to community definitions. I’ve also had discussions with the community around adding definitions to the [GraphQL package itself](https://github.com/graphql/graphql-js/pull/428).

See #12078, #12142, and #12143.

/cc @TonyPythoneer
