### PR TITLE
Improvement to definitions of module async.

### DIFF
--- a/async/async-tests.ts
+++ b/async/async-tests.ts
@@ -435,3 +435,357 @@ async.dir(function (name, callback) {
         callback(null, { hello: name });
     }, 1000);
 }, "world");
+
+// each
+
+async.each<number>({
+    "a": 1,
+    "b": 2
+}, function(val: number, next: ErrorCallback): void {
+
+    setTimeout(function(): void {
+
+        console.log(`async.each: ${val}`);
+
+        next();
+
+    }, 500);
+
+}, function(err?: Error): void {
+
+    console.log("async.each: done.");
+
+});
+
+async.eachSeries<number>({
+    "a": 1,
+    "b": 2
+}, function(val: number, next: ErrorCallback): void {
+
+    setTimeout(function(): void {
+
+        console.log(`async.eachSeries: ${val}`);
+
+        next();
+
+    }, 500);
+
+}, function(err?: Error): void {
+
+    console.log("async.eachSeries: done.");
+
+});
+
+async.eachLimit<number>({
+    "a": 1,
+    "b": 2,
+    "c": 3,
+    "d": 4,
+    "e": 5,
+    "f": 6
+}, 2, function(val: number, next: ErrorCallback): void {
+
+    setTimeout(function(): void {
+
+        console.log(`async.eachLimit: ${val}`);
+
+        next();
+
+    }, 500);
+
+}, function(err?: Error): void {
+
+    console.log("async.eachLimit: done.");
+
+});
+
+// forEachOf/eachOf
+
+async.eachOf<number>({
+    "a": 1,
+    "b": 2
+}, function(val: number, key: string, next: ErrorCallback): void {
+
+    setTimeout(function(): void {
+
+        console.log(`async.forEachOf/eachOf: ${key} = ${val}`);
+
+        next();
+
+    }, 500);
+
+}, function(err?: Error): void {
+
+    console.log("async.forEachOf/eachOf: done.");
+
+});
+
+async.forEachOfSeries<number>({
+    "a": 1,
+    "b": 2
+}, function(val: number, key: string, next: ErrorCallback): void {
+
+    setTimeout(function(): void {
+
+        console.log(`async.forEachOfSeries: ${key} = ${val}`);
+
+        next();
+
+    }, 500);
+
+}, function(err?: Error): void {
+
+    console.log("async.forEachOfSeries: done.");
+
+});
+
+async.forEachOfLimit<number>({
+    "a": 1,
+    "b": 2,
+    "c": 3,
+    "d": 4,
+    "e": 5,
+    "f": 6
+}, 2, function(val: number, key: string, next: ErrorCallback): void {
+
+    setTimeout(function(): void {
+
+        console.log(`async.forEachOfLimit: ${key} = ${val}`);
+
+        next();
+
+    }, 500);
+
+}, function(err?: Error): void {
+
+    console.log("async.forEachOfLimit: done.");
+
+});
+
+// map
+
+async.map<number, string>({
+    "a": 1,
+    "b": 2,
+    "c": 3
+}, function(val: number, next: AsyncResultCallback<string>): void {
+
+    setTimeout(function(): void {
+
+        console.log(`async.map: ${val}`);
+
+        next(null, val.toString());
+
+    }, 500);
+
+}, function(err: Error, results: string[]): void {
+
+    console.log("async.map: done with results", results);
+
+});
+
+async.mapSeries<number, string>({
+    "a": 1,
+    "b": 2,
+    "c": 3
+}, function(val: number, next: AsyncResultCallback<string>): void {
+
+    setTimeout(function(): void {
+
+        console.log(`async.mapSeries: ${val}`);
+
+        next(null, val.toString());
+
+    }, 500);
+
+}, function(err: Error, results: string[]): void {
+
+    console.log("async.mapSeries: done with results", results);
+
+});
+
+async.mapLimit<number, string>({
+    "a": 1,
+    "b": 2,
+    "c": 3,
+    "d": 4,
+    "e": 5,
+    "f": 6
+}, 2, function(val: number, next: AsyncResultCallback<string>): void {
+
+    setTimeout(function(): void {
+
+        console.log(`async.mapLimit: ${val}`);
+
+        next(null, val.toString());
+
+    }, 500);
+
+}, function(err: Error, results: string[]): void {
+
+    console.log("async.mapLimit: done with results", results);
+
+});
+
+// mapValues
+
+async.mapValues<number, string>({
+    "a": 1,
+    "b": 2,
+    "c": 3
+}, function(val: number, key: string, next: AsyncResultCallback<string>): void {
+
+    setTimeout(function(): void {
+
+        console.log(`async.mapValues: ${key} = ${val}`);
+
+        next(null, val.toString());
+
+    }, 500);
+
+}, function(err: Error, results: string[]): void {
+
+    console.log("async.mapValues: done with results", results);
+
+});
+
+async.mapValuesSeries<number, string>({
+    "a": 1,
+    "b": 2,
+    "c": 3
+}, function(val: number, key: string, next: AsyncResultCallback<string>): void {
+
+    setTimeout(function(): void {
+
+        console.log(`async.mapValuesSeries: ${key} = ${val}`);
+
+        next(null, val.toString());
+
+    }, 500);
+
+}, function(err: Error, results: string[]): void {
+
+    console.log("async.mapValuesSeries: done with results", results);
+
+});
+
+// filter/select/reject
+
+async.filter<number>({
+    "a": 1,
+    "b": 2,
+    "c": 3
+}, function(val: number, next: AsyncBooleanResultCallback): void {
+
+    setTimeout(function(): void {
+
+        console.log(`async.filter/select: ${val}`);
+
+        next(null, val % 2 === 0);
+
+    }, 500);
+
+}, function(err: Error, results: number[]): void {
+
+    console.log("async.filter/select: done with results", results);
+
+});
+
+async.reject<number>({
+    "a": 1,
+    "b": 2,
+    "c": 3
+}, function(val: number, next: AsyncBooleanResultCallback): void {
+
+    setTimeout(function(): void {
+
+        console.log(`async.reject: ${val}`);
+
+        next(null, val % 2 === 0);
+
+    }, 500);
+
+}, function(err: Error, results: number[]): void {
+
+    console.log("async.reject: done with results", results);
+
+});
+
+// concat
+
+async.concat<string, string>({
+    "a": "1",
+    "b": "2",
+    "c": "3"
+}, function(item: string, next: AsyncResultCallback<string[]>): void {
+
+    console.log(`async.concat: ${item}`);
+
+    next(null, [item, item, item]);
+
+}, function(err: Error, results: string[]) {
+
+    console.log("async.concat: done with results", results);
+
+});
+
+// detect/find
+
+async.detect<number>({
+    "a": 1,
+    "b": 2,
+    "c": 3
+}, function(item: number, next: AsyncBooleanResultCallback): void {
+
+    console.log(`async.detect/find: ${item}`);
+
+    next(null, item > 1);
+
+}, function(err: Error, result: number) {
+
+    if (err) {
+
+        console.log(err);
+
+    } else {
+
+        console.log("async.detect/find: done with result", result);
+    }
+
+});
+
+// every/all
+
+async.every<number>({
+    "a": 1,
+    "b": 2,
+    "c": 3
+}, function(item: number, next: AsyncBooleanResultCallback): void {
+
+    console.log(`async.every/all: ${item}`);
+
+    next(null, item > 0);
+
+}, function(err: Error, result: boolean) {
+
+    console.log("async.every/all: done with result", result);
+
+});
+
+// some/any
+
+async.some<number>({
+    "a": 1,
+    "b": 2,
+    "c": 3
+}, function(item: number, next: AsyncBooleanResultCallback): void {
+
+    console.log(`async.some/any: ${item}`);
+
+    next(null, item > 2);
+
+}, function(err: Error, result: boolean) {
+
+    console.log("async.some/any: done with result", result);
+
+});

--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -6,6 +6,7 @@
 interface Dictionary<T> { [key: string]: T; }
 
 interface ErrorCallback { (err?: Error): void; }
+interface AsyncWaterfallCallback { (err: Error, ...args: any[]): void; }
 interface AsyncBooleanResultCallback { (err: Error, truthValue: boolean): void; }
 interface AsyncResultCallback<T> { (err: Error, result: T): void; }
 interface AsyncResultArrayCallback<T> { (err: Error, results: T[]): void; }
@@ -97,68 +98,66 @@ interface Async {
     forEach: typeof async.each;
     forEachSeries: typeof async.each;
     forEachLimit: typeof async.eachLimit;
-    forEachOf(obj: any, iterator: (item: any, key: string|number, callback?: ErrorCallback) => void, callback: ErrorCallback): void;
     forEachOf<T>(obj: T[], iterator: AsyncForEachOfIterator<T>, callback?: ErrorCallback): void;
     forEachOf<T>(obj: Dictionary<T>, iterator: AsyncForEachOfIterator<T>, callback?: ErrorCallback): void;
     forEachOfSeries: typeof async.forEachOf;
-    forEachOfLimit(obj: any, limit: number, iterator: (item: any, key: string|number, callback?: ErrorCallback) => void, callback: ErrorCallback): void;
     forEachOfLimit<T>(obj: T[], limit: number, iterator: AsyncForEachOfIterator<T>, callback?: ErrorCallback): void;
     forEachOfLimit<T>(obj: Dictionary<T>, limit: number, iterator: AsyncForEachOfIterator<T>, callback?: ErrorCallback): void;
     eachOf: typeof async.forEachOf;
     eachOfSeries: typeof async.forEachOf;
     eachOfLimit: typeof async.forEachOfLimit;
-    map<T, R>(arr: T[], iterator: AsyncResultIterator<T, R>, callback?: AsyncResultArrayCallback<R>): any;
-    map<T, R>(arr: Dictionary<T>, iterator: AsyncResultIterator<T, R>, callback?: AsyncResultArrayCallback<R>): any;
+    map<T, R>(arr: T[], iterator: AsyncResultIterator<T, R>, callback?: AsyncResultArrayCallback<R>): void;
+    map<T, R>(arr: Dictionary<T>, iterator: AsyncResultIterator<T, R>, callback?: AsyncResultArrayCallback<R>): void;
     mapSeries: typeof async.map;
-    mapLimit<T, R>(arr: T[], limit: number, iterator: AsyncResultIterator<T, R>, callback?: AsyncResultArrayCallback<R>): any;
-    mapLimit<T, R>(arr: Dictionary<T>, limit: number, iterator: AsyncResultIterator<T, R>, callback?: AsyncResultArrayCallback<R>): any;
+    mapLimit<T, R>(arr: T[], limit: number, iterator: AsyncResultIterator<T, R>, callback?: AsyncResultArrayCallback<R>): void;
+    mapLimit<T, R>(arr: Dictionary<T>, limit: number, iterator: AsyncResultIterator<T, R>, callback?: AsyncResultArrayCallback<R>): void;
     mapValuesLimit<T, R>(obj: Dictionary<T>, limit: number, iteratee: (value: T, key: string, callback: AsyncResultCallback<R>) => void, callback: AsyncResultCallback<R[]>): void;
     mapValues<T, R>(obj: Dictionary<T>, iteratee: (value: T, key: string, callback: AsyncResultCallback<R>) => void, callback: AsyncResultCallback<R[]>): void;
     mapValuesSeries: typeof async.mapValues;
-    filter<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): any;
-    filter<T>(arr: Dictionary<T>, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): any;
+    filter<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): void;
+    filter<T>(arr: Dictionary<T>, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): void;
     filterSeries: typeof async.filter;
-    filterLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): any;
-    filterLimit<T>(arr: Dictionary<T>, limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): any;
+    filterLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): void;
+    filterLimit<T>(arr: Dictionary<T>, limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): void;
     select: typeof async.filter;
     selectSeries: typeof async.filter;
     selectLimit: typeof async.filterLimit;
     reject: typeof async.filter;
     rejectSeries: typeof async.filter;
     rejectLimit: typeof async.filterLimit;
-    reduce<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback?: AsyncResultCallback<R>): any;
+    reduce<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback?: AsyncResultCallback<R>): void;
     inject: typeof async.reduce;
     foldl: typeof async.reduce;
     reduceRight: typeof async.reduce;
     foldr: typeof async.reduce;
-    detect<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncResultCallback<T>): any;
-    detect<T>(arr: Dictionary<T>, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultCallback<T>): any;
+    detect<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncResultCallback<T>): void;
+    detect<T>(arr: Dictionary<T>, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultCallback<T>): void;
     detectSeries: typeof async.detect;
-    detectLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultCallback<T>): any;
-    detectLimit<T>(arr: Dictionary<T>, limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultCallback<T>): any;
+    detectLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultCallback<T>): void;
+    detectLimit<T>(arr: Dictionary<T>, limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultCallback<T>): void;
     find: typeof async.detect;
     findSeries: typeof async.detect;
     findLimit: typeof async.detectLimit;
-    sortBy<T, V>(arr: T[], iterator: AsyncResultIterator<T, V>, callback?: AsyncResultArrayCallback<T>): any;
-    some<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): any;
-    some<T>(arr: Dictionary<T>, iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): any;
+    sortBy<T, V>(arr: T[], iterator: AsyncResultIterator<T, V>, callback?: AsyncResultArrayCallback<T>): void;
+    some<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): void;
+    some<T>(arr: Dictionary<T>, iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): void;
     someSeries: typeof async.some;
-    someLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, AsyncBooleanResultCallback): any;
-    someLimit<T>(arr: Dictionary<T>, limit: number, iterator: AsyncBooleanIterator<T>, AsyncBooleanResultCallback): any;
+    someLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, AsyncBooleanResultCallback): void;
+    someLimit<T>(arr: Dictionary<T>, limit: number, iterator: AsyncBooleanIterator<T>, AsyncBooleanResultCallback): void;
     any: typeof async.some;
     anySeries: typeof async.someSeries;
     anyLimit: typeof async.someLimit;
-    every<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): any;
-    every<T>(arr: Dictionary<T>, iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): any;
+    every<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): void;
+    every<T>(arr: Dictionary<T>, iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): void;
     everySeries: typeof async.every;
-    everyLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): any;
-    everyLimit<T>(arr: Dictionary<T>, limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): any;
+    everyLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): void;
+    everyLimit<T>(arr: Dictionary<T>, limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): void;
     all: typeof async.every;
     allSeries: typeof async.every;
     allLimit: typeof async.everyLimit;
 
-    concat<T, R>(arr: T[], iterator: AsyncResultIterator<T, R[]>, callback?: AsyncResultArrayCallback<R>): any;
-    concat<T, R>(arr: Dictionary<T>, iterator: AsyncResultIterator<T, R[]>, callback?: AsyncResultArrayCallback<R>): any;
+    concat<T, R>(arr: T[], iterator: AsyncResultIterator<T, R[]>, callback?: AsyncResultArrayCallback<R>): void;
+    concat<T, R>(arr: Dictionary<T>, iterator: AsyncResultIterator<T, R[]>, callback?: AsyncResultArrayCallback<R>): void;
     concatSeries: typeof async.concat;
 
     // Control Flow
@@ -168,14 +167,14 @@ interface Async {
     parallel<T>(tasks: Dictionary<AsyncFunction<T>>, callback?: AsyncResultObjectCallback<T>): void;
     parallelLimit<T>(tasks: Array<AsyncFunction<T>>, limit: number, callback?: AsyncResultArrayCallback<T>): void;
     parallelLimit<T>(tasks: Dictionary<AsyncFunction<T>>, limit: number, callback?: AsyncResultObjectCallback<T>): void;
-    whilst(test: () => boolean, fn: AsyncVoidFunction, callback: (err: any) => void): void;
-    doWhilst(fn: AsyncVoidFunction, test: () => boolean, callback: (err: any) => void): void;
-    until(test: () => boolean, fn: AsyncVoidFunction, callback: (err: any) => void): void;
-    doUntil(fn: AsyncVoidFunction, test: () => boolean, callback: (err: any) => void): void;
-    during(test: (testCallback : (error: Error, truth: boolean) => void) => void, fn: AsyncVoidFunction, callback: (err: any) => void): void;
-    doDuring(fn: AsyncVoidFunction, test: (testCallback: (error: Error, truth: boolean) => void) => void, callback: (err: any) => void): void;
-    forever(next: (errCallback : (err: Error) => void) => void, errBack: (err: Error) => void) : void;
-    waterfall(tasks: Function[], callback?: (err: Error, results?: any) => void): void;
+    whilst(test: () => boolean, fn: AsyncVoidFunction, callback: ErrorCallback): void;
+    doWhilst(fn: AsyncVoidFunction, test: () => boolean, callback: ErrorCallback): void;
+    until(test: () => boolean, fn: AsyncVoidFunction, callback: ErrorCallback): void;
+    doUntil(fn: AsyncVoidFunction, test: () => boolean, callback: ErrorCallback): void;
+    during(test: (testCallback : AsyncBooleanResultCallback) => void, fn: AsyncVoidFunction, callback: ErrorCallback): void;
+    doDuring(fn: AsyncVoidFunction, test: (testCallback: AsyncBooleanResultCallback) => void, callback: ErrorCallback): void;
+    forever(next: (next : ErrorCallback) => void, errBack: ErrorCallback) : void;
+    waterfall<T>(tasks: Function[], callback?: AsyncResultCallback<T>): void;
     compose(...fns: Function[]): Function;
     seq(...fns: Function[]): Function;
     applyEach(fns: Function[], argsAndCallback: any[]): void;           // applyEach(fns, args..., callback). TS does not support ... for a middle argument. Callback is optional.
@@ -183,10 +182,10 @@ interface Async {
     queue<T>(worker: AsyncWorker<T>, concurrency?: number): AsyncQueue<T>;
     priorityQueue<T>(worker: AsyncWorker<T>, concurrency: number): AsyncPriorityQueue<T>;
     cargo(worker : (tasks: any[], callback : ErrorCallback) => void, payload? : number) : AsyncCargo;
-    auto(tasks: any, concurrency?: number, callback?: (error: Error, results: any) => void): void;
-    autoInject(tasks: any, callback?: (error: Error, results: any) => void): void;
-    retry<T>(opts: number, task: (callback : AsyncResultCallback<T>, results: any) => void, callback: (error: Error, results: any) => void): void;
-    retry<T>(opts: { times: number, interval: number|((retryCount: number) => number) }, task: (callback: AsyncResultCallback<T>, results : any) => void, callback: (error: Error, results: any) => void): void;
+    auto(tasks: any, concurrency?: number, callback?: AsyncResultCallback<any>): void;
+    autoInject(tasks: any, callback?: AsyncResultCallback<any>): void;
+    retry<T>(opts: number, task: (callback : AsyncResultCallback<T>, results: any) => void, callback:  AsyncResultCallback<any>): void;
+    retry<T>(opts: { times: number, interval: number|((retryCount: number) => number) }, task: (callback: AsyncResultCallback<T>, results : any) => void, callback:  AsyncResultCallback<any>): void;
     retryable<T>(opts: number | {times: number, interval: number}, task: AsyncFunction<T>): AsyncFunction<T>;
     apply(fn: Function, ...arguments: any[]): AsyncFunction<any>;
     nextTick(callback: Function, ...args: any[]): void;

--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -1,11 +1,12 @@
 // Type definitions for Async 2.0.1
 // Project: https://github.com/caolan/async
-// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Arseniy Maximov <https://github.com/kern0>, Joe Herman <https://github.com/Penryn>
+// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Arseniy Maximov <https://github.com/kern0>, Joe Herman <https://github.com/Penryn>, Angus Fenying <https://github.com/fenying>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface Dictionary<T> { [key: string]: T; }
 
 interface ErrorCallback { (err?: Error): void; }
+interface AsyncBooleanResultCallback { (err: Error, truthValue: boolean): void; }
 interface AsyncResultCallback<T> { (err: Error, result: T): void; }
 interface AsyncResultArrayCallback<T> { (err: Error, results: T[]): void; }
 interface AsyncResultObjectCallback<T> { (err: Error, results: Dictionary<T>): void; }
@@ -15,7 +16,7 @@ interface AsyncIterator<T> { (item: T, callback: ErrorCallback): void; }
 interface AsyncForEachOfIterator<T> { (item: T, key: number|string, callback: ErrorCallback): void; }
 interface AsyncResultIterator<T, R> { (item: T, callback: AsyncResultCallback<R>): void; }
 interface AsyncMemoIterator<T, R> { (memo: R, item: T, callback: AsyncResultCallback<R>): void; }
-interface AsyncBooleanIterator<T> { (item: T, callback: (err: string, truthValue: boolean) => void): void; }
+interface AsyncBooleanIterator<T> { (item: T, callback: AsyncBooleanResultCallback): void; }
 
 interface AsyncWorker<T> { (task: T, callback: ErrorCallback): void; }
 interface AsyncVoidFunction { (callback: ErrorCallback): void; }
@@ -89,52 +90,76 @@ interface Async {
 
     // Collections
     each<T>(arr: T[], iterator: AsyncIterator<T>, callback?: ErrorCallback): void;
-    eachSeries<T>(arr: T[], iterator: AsyncIterator<T>, callback?: ErrorCallback): void;
+    each<T>(arr: Dictionary<T>, iterator: AsyncIterator<T>, callback?: ErrorCallback): void;
+    eachSeries: typeof async.each;
     eachLimit<T>(arr: T[], limit: number, iterator: AsyncIterator<T>, callback?: ErrorCallback): void;
+    eachLimit<T>(arr: Dictionary<T>, limit: number, iterator: AsyncIterator<T>, callback?: ErrorCallback): void;
+    forEach: typeof async.each;
+    forEachSeries: typeof async.each;
+    forEachLimit: typeof async.eachLimit;
     forEachOf(obj: any, iterator: (item: any, key: string|number, callback?: ErrorCallback) => void, callback: ErrorCallback): void;
     forEachOf<T>(obj: T[], iterator: AsyncForEachOfIterator<T>, callback?: ErrorCallback): void;
-    forEachOfSeries(obj: any, iterator: (item: any, key: string|number, callback?: ErrorCallback) => void, callback: ErrorCallback): void;
-    forEachOfSeries<T>(obj: T[], iterator: AsyncForEachOfIterator<T>, callback?: ErrorCallback): void;
+    forEachOf<T>(obj: Dictionary<T>, iterator: AsyncForEachOfIterator<T>, callback?: ErrorCallback): void;
+    forEachOfSeries: typeof async.forEachOf;
     forEachOfLimit(obj: any, limit: number, iterator: (item: any, key: string|number, callback?: ErrorCallback) => void, callback: ErrorCallback): void;
     forEachOfLimit<T>(obj: T[], limit: number, iterator: AsyncForEachOfIterator<T>, callback?: ErrorCallback): void;
+    forEachOfLimit<T>(obj: Dictionary<T>, limit: number, iterator: AsyncForEachOfIterator<T>, callback?: ErrorCallback): void;
+    eachOf: typeof async.forEachOf;
+    eachOfSeries: typeof async.forEachOf;
+    eachOfLimit: typeof async.forEachOfLimit;
     map<T, R>(arr: T[], iterator: AsyncResultIterator<T, R>, callback?: AsyncResultArrayCallback<R>): any;
-    mapSeries<T, R>(arr: T[], iterator: AsyncResultIterator<T, R>, callback?: AsyncResultArrayCallback<R>): any;
+    map<T, R>(arr: Dictionary<T>, iterator: AsyncResultIterator<T, R>, callback?: AsyncResultArrayCallback<R>): any;
+    mapSeries: typeof async.map;
     mapLimit<T, R>(arr: T[], limit: number, iterator: AsyncResultIterator<T, R>, callback?: AsyncResultArrayCallback<R>): any;
-    mapValuesLimit<T, R>(obj: {[name: string]: T}, limit: number, iteratee: (value: string, key: T, callback: AsyncResultCallback<R>) => void, callback: AsyncResultCallback<R[]>): void;
-    mapValues<T, R>(obj: {[name: string]: T}, iteratee: (value: string, key: T, callback: AsyncResultCallback<R>) => void, callback: AsyncResultCallback<R[]>): void;
+    mapLimit<T, R>(arr: Dictionary<T>, limit: number, iterator: AsyncResultIterator<T, R>, callback?: AsyncResultArrayCallback<R>): any;
+    mapValuesLimit<T, R>(obj: Dictionary<T>, limit: number, iteratee: (value: T, key: string, callback: AsyncResultCallback<R>) => void, callback: AsyncResultCallback<R[]>): void;
+    mapValues<T, R>(obj: Dictionary<T>, iteratee: (value: T, key: string, callback: AsyncResultCallback<R>) => void, callback: AsyncResultCallback<R[]>): void;
     mapValuesSeries: typeof async.mapValues;
     filter<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): any;
-    select<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): any;
-    filterSeries<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): any;
-    selectSeries<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): any;
+    filter<T>(arr: Dictionary<T>, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): any;
+    filterSeries: typeof async.filter;
     filterLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): any;
-    selectLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): any;
-    reject<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): any;
-    rejectSeries<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): any;
-    rejectLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): any;
+    filterLimit<T>(arr: Dictionary<T>, limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultArrayCallback<T>): any;
+    select: typeof async.filter;
+    selectSeries: typeof async.filter;
+    selectLimit: typeof async.filterLimit;
+    reject: typeof async.filter;
+    rejectSeries: typeof async.filter;
+    rejectLimit: typeof async.filterLimit;
     reduce<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback?: AsyncResultCallback<R>): any;
-    inject<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback?: AsyncResultCallback<R>): any;
-    foldl<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback?: AsyncResultCallback<R>): any;
-    reduceRight<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncResultCallback<R>): any;
-    foldr<T, R>(arr: T[], memo: R, iterator: AsyncMemoIterator<T, R>, callback: AsyncResultCallback<R>): any;
+    inject: typeof async.reduce;
+    foldl: typeof async.reduce;
+    reduceRight: typeof async.reduce;
+    foldr: typeof async.reduce;
     detect<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncResultCallback<T>): any;
-    find: typeof async.detect;
-    detectSeries<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncResultCallback<T>): any;
-    findSeries: typeof async.detectSeries;
+    detect<T>(arr: Dictionary<T>, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultCallback<T>): any;
+    detectSeries: typeof async.detect;
     detectLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultCallback<T>): any;
+    detectLimit<T>(arr: Dictionary<T>, limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncResultCallback<T>): any;
+    find: typeof async.detect;
+    findSeries: typeof async.detect;
     findLimit: typeof async.detectLimit;
     sortBy<T, V>(arr: T[], iterator: AsyncResultIterator<T, V>, callback?: AsyncResultArrayCallback<T>): any;
-    some<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: (result: boolean) => void): any;
-    someLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: (result: boolean) => void): any;
-    anyLimit: typeof async.someLimit;
-    someSeries<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: (result: boolean) => void): any;
+    some<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): any;
+    some<T>(arr: Dictionary<T>, iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): any;
+    someSeries: typeof async.some;
+    someLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, AsyncBooleanResultCallback): any;
+    someLimit<T>(arr: Dictionary<T>, limit: number, iterator: AsyncBooleanIterator<T>, AsyncBooleanResultCallback): any;
+    any: typeof async.some;
     anySeries: typeof async.someSeries;
-    any<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: (result: boolean) => void): any;
-    every<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: (result: boolean) => any): any;
-    everyLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: (result: boolean) => any): any;
-    all<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: (result: boolean) => any): any;
+    anyLimit: typeof async.someLimit;
+    every<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): any;
+    every<T>(arr: Dictionary<T>, iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): any;
+    everySeries: typeof async.every;
+    everyLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): any;
+    everyLimit<T>(arr: Dictionary<T>, limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): any;
+    all: typeof async.every;
+    allSeries: typeof async.every;
+    allLimit: typeof async.everyLimit;
+
     concat<T, R>(arr: T[], iterator: AsyncResultIterator<T, R[]>, callback?: AsyncResultArrayCallback<R>): any;
-    concatSeries<T, R>(arr: T[], iterator: AsyncResultIterator<T, R[]>, callback?: AsyncResultArrayCallback<R>): any;
+    concat<T, R>(arr: Dictionary<T>, iterator: AsyncResultIterator<T, R[]>, callback?: AsyncResultArrayCallback<R>): any;
+    concatSeries: typeof async.concat;
 
     // Control Flow
     series<T>(tasks: AsyncFunction<T>[], callback?: AsyncResultArrayCallback<T>): void;
@@ -166,10 +191,6 @@ interface Async {
     apply(fn: Function, ...arguments: any[]): AsyncFunction<any>;
     nextTick(callback: Function, ...args: any[]): void;
     setImmediate: typeof async.nextTick;
-
-    allLimit<T>(arr: T[], limit: number, iteratee: AsyncBooleanIterator<T>, cb?: (result: boolean) => any) : any;
-    everySeries<T>(arr: T[], iteratee: AsyncBooleanIterator<T>, cb?: (result: boolean) => any) : any
-    allSeries: typeof async.everySeries;
 
     reflect<T>(fn: AsyncFunction<T>) : (callback: (err: void, result: {error?: Error, value?: T}) => void) => void;
     reflectAll<T>(tasks: AsyncFunction<T>[]): ((callback: (err: void, result: {error?: Error, value?: T}) => void) => void)[];

--- a/async/async.d.ts
+++ b/async/async.d.ts
@@ -142,8 +142,8 @@ interface Async {
     some<T>(arr: T[], iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): void;
     some<T>(arr: Dictionary<T>, iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): void;
     someSeries: typeof async.some;
-    someLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, AsyncBooleanResultCallback): void;
-    someLimit<T>(arr: Dictionary<T>, limit: number, iterator: AsyncBooleanIterator<T>, AsyncBooleanResultCallback): void;
+    someLimit<T>(arr: T[], limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): void;
+    someLimit<T>(arr: Dictionary<T>, limit: number, iterator: AsyncBooleanIterator<T>, callback?: AsyncBooleanResultCallback): void;
     any: typeof async.some;
     anySeries: typeof async.someSeries;
     anyLimit: typeof async.someLimit;


### PR DESCRIPTION
1. Added dictionary-typed signatures for some collection APIs.
   
   Most of these async collection APIs support Dictionary, but most of them were not defined with dictionary-typed signatures.
2. Fixed incorrected callback definition for some collection APIs.
   
   Some async collection APIs like `async.every`, was defined with a wrong callback as `(result: boolean): void`, while actually it should be `(err: Error, result: boolean): void`.
