### PR TITLE
react-select: Add arrowRenderer to ReactSelectProps

### DIFF
--- a/react-select/index.d.ts
+++ b/react-select/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-select v1.0.0
 // Project: https://github.com/JedWatson/react-select
-// Definitions by: ESQUIBET Hugo <https://github.com/Hesquibet/>, Gilad Gray <https://github.com/giladgray/>, Izaak Baker <https://github.com/iebaker/>
+// Definitions by: ESQUIBET Hugo <https://github.com/Hesquibet/>, Gilad Gray <https://github.com/giladgray/>, Izaak Baker <https://github.com/iebaker/>, Tadas Dailyda <https://github.com/skirsdeda/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as React from 'react';

--- a/react-select/index.d.ts
+++ b/react-select/index.d.ts
@@ -63,12 +63,24 @@ declare namespace ReactSelectClass {
         valueArray: Option[];
     }
 
+    export interface ArrowRendererProps {
+        /**
+         * Arrow mouse down event handler.
+         */
+        onMouseDown: React.MouseEventHandler<{}>;
+    }
+
     export interface ReactSelectProps extends React.Props<ReactSelectClass> {
         /**
          * text to display when `allowCreate` is true.
          * @default 'Add "{label}"?'
          */
         addLabelText?: string;
+        /**
+         * renders a custom drop-down arrow to be shown in the right-hand side of the select.
+         * @default undefined
+         */
+        arrowRenderer?: (props: ArrowRendererProps) => React.ReactElement<any>;
         /**
          * blurs the input element after a selection has been made. Handy for lowering the keyboard on mobile devices.
          * @default false


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation added.
- not yet reviewed.
