### PR TITLE
react-css-modules: augment react's HTMLAttributes interface

### DIFF
--- a/react-css-modules/index.d.ts
+++ b/react-css-modules/index.d.ts
@@ -3,35 +3,30 @@
 // Definitions by: Kostya Esmukov <https://github.com/KostyaEsmukov>, Tadas Dailyda <https://github.com/skirsdeda>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as React from 'react';
-
-declare module 'react-css-modules' {
-
-    interface TypeOptions {
-        allowMultiple?: boolean;
-        errorWhenNotFound?: boolean;
-    }
-
-    type StylesObject = any;
-
-    interface CSSModules {
-        (defaultStyles: StylesObject, options?: TypeOptions): <C extends Function>(Component: C) => C;
-        <C extends Function>(Component: C, defaultStyles: StylesObject, options?: TypeOptions): C;
-    }
-
-    module CSSModules {
-        // Extend your component's Prop interface with this one to get access to `this.props.styles`
-        //
-        // interface MyComponentProps extends CSSModules.InjectedCSSModuleProps {}
-        interface InjectedCSSModuleProps {
-            styles?: StylesObject;
-        }
-    }
-
-    let CSSModules: CSSModules;
-
-    export = CSSModules;
+interface TypeOptions {
+    allowMultiple?: boolean;
+    errorWhenNotFound?: boolean;
 }
+
+type StylesObject = any;
+
+interface CSSModules {
+    (defaultStyles: StylesObject, options?: TypeOptions): <C extends Function>(Component: C) => C;
+    <C extends Function>(Component: C, defaultStyles: StylesObject, options?: TypeOptions): C;
+}
+
+declare module CSSModules {
+    // Extend your component's Prop interface with this one to get access to `this.props.styles`
+    //
+    // interface MyComponentProps extends CSSModules.InjectedCSSModuleProps {}
+    interface InjectedCSSModuleProps {
+        styles?: StylesObject;
+    }
+}
+
+declare let CSSModules: CSSModules;
+
+export = CSSModules;
 
 declare module 'react' {
     interface HTMLAttributes<T> {

--- a/react-css-modules/index.d.ts
+++ b/react-css-modules/index.d.ts
@@ -1,8 +1,9 @@
 // Type definitions for react-css-modules 3.7.9
 // Project: https://github.com/gajus/react-css-modules
-// Definitions by: Kostya Esmukov <https://github.com/KostyaEsmukov>
+// Definitions by: Kostya Esmukov <https://github.com/KostyaEsmukov>, Tadas Dailyda <https://github.com/skirsdeda>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+import * as React from 'react';
 
 declare module 'react-css-modules' {
 
@@ -30,4 +31,10 @@ declare module 'react-css-modules' {
     let CSSModules: CSSModules;
 
     export = CSSModules;
+}
+
+declare module 'react' {
+    interface HTMLAttributes<T> {
+        styleName?: string;
+    }
 }

--- a/react-css-modules/tsconfig.json
+++ b/react-css-modules/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "noImplicitAny": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- makes `styleName` property recognized on all React elements.
- not yet reviewed.

Type checking works as expected but TS complains about line 33: Exports and export assignments are not permitted in module augmentations. This happens after adding "import from 'react'". Couldn't find the right way to fix this unfortunately. Maybe someone can help with this.
