### PR TITLE
[material-ui] Fixed muiThemeable to accept component classes and func…

### DIFF
--- a/material-ui/index.d.ts
+++ b/material-ui/index.d.ts
@@ -449,7 +449,11 @@ declare namespace __MaterialUI {
         var lightBaseTheme: RawTheme;
         var darkBaseTheme: RawTheme;
 
-        export function muiThemeable<TComponent extends React.Component<P, S>, P, S>(): (component: TComponent) => TComponent;
+        interface InferableComponentDecorator {
+            <P, TComponentConstruct extends (React.ComponentClass<P> | React.StatelessComponent<P>)>(component: TComponentConstruct): TComponentConstruct;
+        }
+
+        export function muiThemeable(): InferableComponentDecorator;
 
         //** @deprecated use MuiThemeProvider instead **/
         export function themeDecorator(muiTheme: Styles.MuiTheme): <TFunction extends Function>(Component: TFunction) => TFunction;


### PR DESCRIPTION
Fixes #9843

Edited muiThemeable declaration so that it correctly infers the props type and allows to use it with component classes and stateless components.

Checklist
- [x] run a test on travis.ci
