### PR TITLE
Add @types/murmurhash-js

### DIFF
--- a/murmurhash-js/index.d.ts
+++ b/murmurhash-js/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for murmurhash-js v1.0.0
+// Project: https://github.com/mikolalysenko/murmurhash-js
+// Definitions by: Chi Vinh Le <https://github.com/cvle>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type MurmurFunc = (str: string, seed?: number) => number;
+
+declare const murmur: MurmurFunc & {
+    murmur3: MurmurFunc;
+    murmur2: MurmurFunc;
+};
+
+export = murmur;

--- a/murmurhash-js/murmurhash-js-tests.ts
+++ b/murmurhash-js/murmurhash-js-tests.ts
@@ -1,0 +1,21 @@
+import * as murmur from 'murmurhash-js';
+import * as murmur2 from 'murmurhash-js/murmurhash2_gc';
+import * as murmur3 from 'murmurhash-js/murmurhash3_gc';
+
+let hash: number;
+
+hash = murmur('string');
+hash = murmur('string with seed', 1337);
+
+hash = murmur.murmur2('string');
+hash = murmur.murmur2('string with seed', 1337);
+
+hash = murmur.murmur3('string');
+hash = murmur.murmur3('string with seed', 1337);
+
+hash = murmur2('string');
+hash = murmur2('string with seed', 1337);
+
+hash = murmur3('string');
+hash = murmur3('string with seed', 1337);
+

--- a/murmurhash-js/murmurhash2_gc.d.ts
+++ b/murmurhash-js/murmurhash2_gc.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for murmurhash-js v1.0.0
+// Project: https://github.com/mikolalysenko/murmurhash-js
+// Definitions by: Chi Vinh Le <https://github.com/cvle>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare const murmur: (str: string, seed?: number) => number;
+export = murmur;

--- a/murmurhash-js/murmurhash3_gc.d.ts
+++ b/murmurhash-js/murmurhash3_gc.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for murmurhash-js v1.0.0
+// Project: https://github.com/mikolalysenko/murmurhash-js
+// Definitions by: Chi Vinh Le <https://github.com/cvle>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare const murmur: (str: string, seed?: number) => number;
+export = murmur;

--- a/murmurhash-js/tsconfig.json
+++ b/murmurhash-js/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "murmurhash-js-tests.ts"
+    ]
+}


### PR DESCRIPTION
Add type definitions for [murmurhash-js](https://github.com/mikolalysenko/murmurhash-js).
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
