### PR TITLE
[redux-actions] Export action interfaces

### DIFF
--- a/redux-actions/index.d.ts
+++ b/redux-actions/index.d.ts
@@ -12,13 +12,13 @@ declare namespace ReduxActions {
         type: string
     }
 
-    interface Action<Payload> extends BaseAction {
+    export interface Action<Payload> extends BaseAction {
         payload?: Payload
         error?: boolean
         meta?: any
     }
 
-    interface ActionMeta<Payload, Meta> extends Action<Payload> {
+    export interface ActionMeta<Payload, Meta> extends Action<Payload> {
         meta: Meta
     }
 


### PR DESCRIPTION
Exporting the action interfaces helps with casting/signatures when crafting reducers.
