### PR TITLE
Typings for slack-node

### DIFF
--- a/slack-node/index.d.ts
+++ b/slack-node/index.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for slack-node v0.1
+// Project: https://github.com/clonn/slack-node-sdk
+// Definitions by: Joshua DeVinney <https://github.com/geoffreak>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as request from "request";
+
+declare class Slack {
+    token: string;
+    domain: string;
+    apiMode: boolean;
+    url: string;
+    timeout: number;
+    maxAttempts: number;
+
+    constructor(token?: string, domain?: string);
+    composeUrl(): string;
+    setWebhook(url: string): this;
+    detectEmoji(emoji: string): { key: "icon_url" | "icon_emoji", val: string };
+    webhook(options: Slack.WebhookOptions, callback: (err: any, response: Slack.WebhookResponse) => void): void;
+    api(method: string, callback: (err: any, response: any) => void): this;
+    api(method: string, options: any, callback: (err: any, response: any) => void): this;
+}
+
+declare namespace Slack {
+
+    export interface WebhookOptions {
+        icon_emoji?: string;
+        response_type?: string;
+        channel?: string;
+        text?: string;
+        username?: string;
+        attachments?: any[];
+        link_names?: any;
+    }
+
+    export interface WebhookResponse {
+        status: "fail" | "ok";
+        statusCode: number;
+        headers: any;
+        response: any;
+    }
+}
+
+export = Slack;

--- a/slack-node/slack-node-tests.ts
+++ b/slack-node/slack-node-tests.ts
@@ -1,0 +1,49 @@
+import * as Slack from "slack-node";
+
+let webhookUri = "__uri___";
+
+let slack = new Slack();
+slack.setWebhook(webhookUri);
+
+slack.webhook({
+  channel: "#general",
+  username: "webhookbot",
+  text: "This is posted to #general and comes from a bot named webhookbot."
+}, function(err, response) {
+  console.log(response);
+});
+
+// slack emoji
+slack.webhook({
+  channel: "#general",
+  username: "webhookbot",
+  icon_emoji: ":ghost:",
+  text: "test message, test message"
+}, function(err, response) {
+  console.log(response);
+});
+
+// URL image
+slack.webhook({
+  channel: "#general",
+  username: "webhookbot",
+  icon_emoji: "http://icons.iconarchive.com/icons/rokey/popo-emotions/128/after-boom-icon.png",
+  text: "test message, test message"
+}, function(err, response) {
+  console.log(response);
+});
+
+
+let apiToken = "-- api token --";
+slack = new Slack(apiToken);
+
+slack.api("users.list", function(err, response) {
+  console.log(response);
+});
+
+slack.api("chat.postMessage", {
+  text: "hello from nodejs",
+  channel: "#general"
+}, function(err, response){
+  console.log(response);
+});

--- a/slack-node/tsconfig.json
+++ b/slack-node/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "noImplicitAny": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/slack-node/tsconfig.json
+++ b/slack-node/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "slack-node-tests.ts"
+    ]
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

---

Typings for [`slack-node`](https://github.com/clonn/slack-node-sdk)
