### PR TITLE
Add typings for d3-box

### DIFF
--- a/d3-box/d3-box-tests.ts
+++ b/d3-box/d3-box-tests.ts
@@ -3,8 +3,8 @@
 
 // Inspired by http://bl.ocks.org/mbostock/4061502
 
-function iqr(k) {
-  return function(d) {
+function iqr(k: number) {
+  return function(d: any) {
     var q1 = d.quartiles[0],
         q3 = d.quartiles[2],
         iqr = (q3 - q1) * k;

--- a/d3-box/d3-box-tests.ts
+++ b/d3-box/d3-box-tests.ts
@@ -1,2 +1,26 @@
 /// <reference path="../d3/d3.d.ts" />
 /// <reference path="d3-box.d.ts" />
+
+// Inspired by http://bl.ocks.org/mbostock/4061502
+
+function iqr(k) {
+  return function(d) {
+    var q1 = d.quartiles[0],
+        q3 = d.quartiles[2],
+        iqr = (q3 - q1) * k;
+    let i = -1,
+        j = d.length;
+    while (d[++i] < q1 - iqr);
+    while (d[--j] > q3 + iqr);
+    return [i, j];
+  };
+}
+
+var chart = d3.box()
+    .whiskers(iqr(1.5))
+    .width(100)
+    .height(100);
+
+chart.domain([1, 30]);
+
+d3.selectAll("sth.").call(chart.duration(1000));

--- a/d3-box/d3-box-tests.ts
+++ b/d3-box/d3-box-tests.ts
@@ -1,0 +1,2 @@
+/// <reference path="../d3/d3.d.ts" />
+/// <reference path="d3-box.d.ts" />

--- a/d3-box/d3-box.d.ts
+++ b/d3-box/d3-box.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for d3-slider
+// Type definitions for d3-box
 // Project: https://github.com/JacksonGariety/d3-box
 // Definitions by: Linkun Chen <https://github.com/lk-chen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -22,8 +22,8 @@ declare namespace d3 {
         domain(x: number[]): Box;
         value(): (d: any) => number;
         value(x: (d: any) => number): Box;
-        whiskers(): (d: any[]) => number[];
-        whiskers(x: (d: any[]) => number[]): Box;
+        whiskers(): (d: any[], i?: number) => number[];
+        whiskers(x: (d: any[], i?: number) => number[]): Box;
         quartiles(): (d: any[]) => number[];
         quantiles(x: (d: any[]) => number[]): Box;
     }

--- a/d3-box/d3-box.d.ts
+++ b/d3-box/d3-box.d.ts
@@ -1,0 +1,6 @@
+// Type definitions for d3-slider
+// Project: https://github.com/JacksonGariety/d3-box
+// Definitions by: Linkun Chen <https://github.com/lk-chen>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../d3/d3.d.ts"/>

--- a/d3-box/d3-box.d.ts
+++ b/d3-box/d3-box.d.ts
@@ -4,3 +4,28 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../d3/d3.d.ts"/>
+
+declare namespace d3 {
+    export function box(): Box;
+
+    interface Box {
+        (sel: d3.Selection<any>): void;
+        width(): number;
+        width(x: number): Box;
+        height(): number;
+        height(x: number): Box;
+        tickFormat(): (n: number) => string;
+        tickFormat(fun: (n: number) => string): Box;
+        duration(): number;
+        duration(x: number): Box;
+        domain(): () => number[];
+        domain(x: number[]): Box;
+        value(): (d: any) => number;
+        value(x: (d: any) => number): Box;
+        whiskers(): (d: any[]) => number[];
+        whiskers(x: (d: any[]) => number[]): Box;
+        quartiles(): (d: any[]) => number[];
+        quantiles(x: (d: any[]) => number[]): Box;
+    }
+}
+


### PR DESCRIPTION
Typings for d3-box.
- [x] checked compilation succeeds with `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts`.
