### PR TITLE
Typings for com.darktalker.cordova.screenshot

### DIFF
--- a/com.darktalker.cordova.screenshot/com.darktalker.cordova.screenshot-tests.ts
+++ b/com.darktalker.cordova.screenshot/com.darktalker.cordova.screenshot-tests.ts
@@ -1,0 +1,6 @@
+navigator.screenshot.save(() => {/**/});
+navigator.screenshot.save(() => {/**/}, 'jpg', 50);
+navigator.screenshot.save(() => {/**/}, 'jpg', 50, 'myScreenShot');
+
+navigator.screenshot.URI(() => {/**/});
+navigator.screenshot.URI(() => {/**/}, 50);

--- a/com.darktalker.cordova.screenshot/index.d.ts
+++ b/com.darktalker.cordova.screenshot/index.d.ts
@@ -1,0 +1,55 @@
+// Type definitions com.darktalker.cordova.screenshot v0.1.5
+// Project: https://github.com/gitawego/cordova-screenshot
+// Definitions by: Ivana Dolezalova <https://github.com/akarienta>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace com.darktalker.cordova.screenshot {
+    export interface SaveSuccessObject {
+        success: boolean;
+        filePath: string;
+    }
+
+    interface SaveCallback {
+        /**
+         * @param errorMessage message of error, null if there isn't any
+         * @param successObject object which contains path to the file
+         */
+        (errorMessage: string, successObject: SaveSuccessObject): void;
+    }
+
+    export interface URISuccessObject {
+        URI: string;
+    }
+
+    interface URICallback {
+        /**
+         * @param errorMessage message of error, null if there isn't any
+         * @param successObject object which contains data URI of taken screenshot
+         */
+        (errorMessage: string, successObject: URICallback): void;
+    }
+
+    interface Plugin {
+        /**
+         * Takes a screenshot, saves it to device as JPG and provides a path to the file.
+         *
+         * @param SaveCallback callback function, holds results
+         * @param format format of to be taken image, possible values are 'jpg' and 'png' ('jpg' is default)
+         * @param quality custom quality of to be taken image in percentage (100 is default)
+         * @param filename custom filename of to be taken image, ('screenshot_<milliSecondsSince1970>.<format>' is default)
+         */
+        save(SaveCallback, format?: string, quality?: number, filename?: string): void;
+
+        /**
+         * Takes a screenshot and provides it trough data URI as JPG. No data are saved in the device.
+         *
+         * @param URICallback callback function, holds results
+         * @param quality custom quality of to be taken image in percentage (100 is default)
+         */
+        URI(URICallback, quality?: number): void;
+    }
+}
+
+interface Navigator {
+    screenshot: com.darktalker.cordova.screenshot.Plugin;
+}

--- a/com.darktalker.cordova.screenshot/index.d.ts
+++ b/com.darktalker.cordova.screenshot/index.d.ts
@@ -14,7 +14,7 @@ declare namespace com.darktalker.cordova.screenshot {
          * @param errorMessage message of error, null if there isn't any
          * @param successObject object which contains path to the file
          */
-        (errorMessage: string, successObject: SaveSuccessObject): void;
+        (errorMessage?: string, successObject?: SaveSuccessObject): void;
     }
 
     export interface URISuccessObject {
@@ -26,27 +26,27 @@ declare namespace com.darktalker.cordova.screenshot {
          * @param errorMessage message of error, null if there isn't any
          * @param successObject object which contains data URI of taken screenshot
          */
-        (errorMessage: string, successObject: URICallback): void;
+        (errorMessage?: string, successObject?: URICallback): void;
     }
 
     interface Plugin {
         /**
          * Takes a screenshot, saves it to device as JPG and provides a path to the file.
          *
-         * @param SaveCallback callback function, holds results
+         * @param saveCallback callback function, holds results
          * @param format format of to be taken image, possible values are 'jpg' and 'png' ('jpg' is default)
          * @param quality custom quality of to be taken image in percentage (100 is default)
          * @param filename custom filename of to be taken image, ('screenshot_<milliSecondsSince1970>.<format>' is default)
          */
-        save(SaveCallback, format?: string, quality?: number, filename?: string): void;
+        save(saveCallback: SaveCallback, format?: string, quality?: number, filename?: string): void;
 
         /**
          * Takes a screenshot and provides it trough data URI as JPG. No data are saved in the device.
          *
-         * @param URICallback callback function, holds results
+         * @param uriCallback callback function, holds results
          * @param quality custom quality of to be taken image in percentage (100 is default)
          */
-        URI(URICallback, quality?: number): void;
+        URI(uriCallback: URICallback, quality?: number): void;
     }
 }
 

--- a/com.darktalker.cordova.screenshot/index.d.ts
+++ b/com.darktalker.cordova.screenshot/index.d.ts
@@ -13,7 +13,6 @@ declare namespace com.darktalker.cordova.screenshot {
          * @param quality custom quality of to be taken image in percentage (100 is default)
          * @param filename custom filename of to be taken image, ('screenshot_<milliSecondsSince1970>.<format>' is default)
          */
-
         save(saveCallback: (errorMessage: string, successObject: {success: boolean, filePath: string}) => void,
              format?: string,
              quality?: number,
@@ -26,7 +25,7 @@ declare namespace com.darktalker.cordova.screenshot {
          * @param quality custom quality of to be taken image in percentage (100 is default)
          */
         URI(uriCallback: (errorMessage: string, successObject: {URI: string}) => void,
-            quality?: number);
+            quality?: number): void;
     }
 }
 

--- a/com.darktalker.cordova.screenshot/index.d.ts
+++ b/com.darktalker.cordova.screenshot/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions com.darktalker.cordova.screenshot v0.1.5
+// Type definitions for com.darktalker.cordova.screenshot 0.1.5
 // Project: https://github.com/gitawego/cordova-screenshot
 // Definitions by: Ivana Dolezalova <https://github.com/akarienta>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/com.darktalker.cordova.screenshot/index.d.ts
+++ b/com.darktalker.cordova.screenshot/index.d.ts
@@ -1,34 +1,9 @@
-// Type definitions for com.darktalker.cordova.screenshot 0.1.5
+// Type definitions for com.darktalker.cordova.screenshot v0.1.5
 // Project: https://github.com/gitawego/cordova-screenshot
 // Definitions by: Ivana Dolezalova <https://github.com/akarienta>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace com.darktalker.cordova.screenshot {
-    export interface SaveSuccessObject {
-        success: boolean;
-        filePath: string;
-    }
-
-    interface SaveCallback {
-        /**
-         * @param errorMessage message of error, null if there isn't any
-         * @param successObject object which contains path to the file
-         */
-        (errorMessage?: string, successObject?: SaveSuccessObject): void;
-    }
-
-    export interface URISuccessObject {
-        URI: string;
-    }
-
-    interface URICallback {
-        /**
-         * @param errorMessage message of error, null if there isn't any
-         * @param successObject object which contains data URI of taken screenshot
-         */
-        (errorMessage?: string, successObject?: URICallback): void;
-    }
-
     interface Plugin {
         /**
          * Takes a screenshot, saves it to device as JPG and provides a path to the file.
@@ -38,7 +13,11 @@ declare namespace com.darktalker.cordova.screenshot {
          * @param quality custom quality of to be taken image in percentage (100 is default)
          * @param filename custom filename of to be taken image, ('screenshot_<milliSecondsSince1970>.<format>' is default)
          */
-        save(saveCallback: SaveCallback, format?: string, quality?: number, filename?: string): void;
+
+        save(saveCallback: (errorMessage: string, successObject: {success: boolean, filePath: string}) => void,
+             format?: string,
+             quality?: number,
+             filename?: string): void;
 
         /**
          * Takes a screenshot and provides it trough data URI as JPG. No data are saved in the device.
@@ -46,7 +25,8 @@ declare namespace com.darktalker.cordova.screenshot {
          * @param uriCallback callback function, holds results
          * @param quality custom quality of to be taken image in percentage (100 is default)
          */
-        URI(uriCallback: URICallback, quality?: number): void;
+        URI(uriCallback: (errorMessage: string, successObject: {URI: string}) => void,
+            quality?: number);
     }
 }
 

--- a/com.darktalker.cordova.screenshot/tsconfig.json
+++ b/com.darktalker.cordova.screenshot/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "noImplicitAny": true,
+    "strictNullChecks": false,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "com.darktalker.cordova.screenshot-tests.ts"
+  ]
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.
