### PR TITLE
Improve react-helmet type definition

### DIFF
--- a/react-helmet/index.d.ts
+++ b/react-helmet/index.d.ts
@@ -7,14 +7,11 @@
 
 import * as React from "react";
 
-declare var Helmet: {
-    (): ReactHelmet.HelmetComponent
-    rewind(): ReactHelmet.HelmetData
-    }
-
-export = Helmet;
+declare function ReactHelmet(): ReactHelmet.HelmetComponent;
 
 declare namespace ReactHelmet {
+    function rewind(): ReactHelmet.HelmetData;
+
     interface HelmetProps {
         base?: any;
         defaultTitle?: string;
@@ -43,3 +40,5 @@ declare namespace ReactHelmet {
 
     class HelmetComponent extends React.Component<HelmetProps, any> {}
 }
+
+export = ReactHelmet;

--- a/react-helmet/react-helmet-tests.tsx
+++ b/react-helmet/react-helmet-tests.tsx
@@ -39,3 +39,9 @@ function HTML() {
         </html>
     );
 }
+
+function log(datum: Helmet.HelmetDatum) {
+    return console.log('logging a helmet datum:', datum.toString());
+}
+
+log(head.title);


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation and source code: https://github.com/nfl/react-helmet

With this change the interfaces of `react-helmet`, e.g. `HelmetDatum`, can be consumed explicitly (see `react-helmet/react-helmet-tests.tsx`).
