### PR TITLE
Update convert-source-map typings to match it's API at 1.3.0

### DIFF
--- a/convert-source-map/index.d.ts
+++ b/convert-source-map/index.d.ts
@@ -1,26 +1,27 @@
-// Type definitions for convert-source-map
+// Type definitions for convert-source-map v1.3.0
 // Project: https://github.com/thlorenz/convert-source-map
 // Definitions by: Andrew Gaspar <https://github.com/AndrewGaspar/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 
 export interface SourceMapConverter {
     toObject(): any;
     toJSON(space?: any): string;
     toBase64(): string;
-    toComment(): string;
-
-    addProperty(key: string, value: any): SourceMapConverter;
-    setProperty(key: string, value: any): SourceMapConverter;
-
+    toComment(options?: { multiline?: boolean; }): string;
+    addProperty(key: string, value: any): this;
+    setProperty(key: string, value: any): this;
     getProperty(key: string): any;
 }
-
-export declare function removeComments(src: string): string;
-export declare var commentRegex: RegExp;
 
 export declare function fromObject(obj: any): SourceMapConverter;
 export declare function fromJSON(json: string): SourceMapConverter;
 export declare function fromBase64(base64: string): SourceMapConverter;
 export declare function fromComment(comment: string): SourceMapConverter;
-export declare function fromSource(source: string): SourceMapConverter;
+export declare function fromMapFileComment(comment: string, mapFileDir: string): SourceMapConverter;
+export declare function fromSource(source: string, largeSource?: boolean): SourceMapConverter | null;
+export declare function fromMapFileSource(source: string, mapFileDir: string): SourceMapConverter | null;
+export declare function removeComments(src: string): string;
+export declare function removeMapFileComments(src: string): string;
+export declare function generateMapFileComment(file: string, options?: { multiline?: boolean; }): string;
+export declare var commentRegex: RegExp;
+export declare var mapFileCommentRegex: RegExp;

--- a/convert-source-map/index.d.ts
+++ b/convert-source-map/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for convert-source-map v1.3.0
 // Project: https://github.com/thlorenz/convert-source-map
-// Definitions by: Andrew Gaspar <https://github.com/AndrewGaspar/>
+// Definitions by: Andrew Gaspar <https://github.com/AndrewGaspar/>, Melvin Groenhoff <https://github.com/mgroenhoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface SourceMapConverter {


### PR DESCRIPTION
https://github.com/thlorenz/convert-source-map/blob/v1.3.0/README.md
