### PR TITLE
Add universal module declaration form to vega

### DIFF
--- a/vega/index.d.ts
+++ b/vega/index.d.ts
@@ -541,3 +541,6 @@ declare namespace vg {
 
   // TODO: classes for View, Model, etc.
 }
+
+export = vg;
+export as namespace vg;


### PR DESCRIPTION
`vega` can be included as a commonjs module in a bundling setup - a universal module style declaration is needed to make this scenario work.
