### PR TITLE
Make `el` optional in vega ViewArgs

### DIFF
--- a/vega/index.d.ts
+++ b/vega/index.d.ts
@@ -14,7 +14,7 @@ declare namespace Vega {
 
   export interface ViewArgs {
     // TODO docs
-    el: any;
+    el?: any;
     data?: any;
     hover?: boolean;
     renderer?: string;


### PR DESCRIPTION
It is used without an element in this manner inside the [vega project itself](https://github.com/vega/vega/blob/master/bin/vg2svg#L68) - normally when running headlessly.
