### PR TITLE
Add missing fields to StripeCheckoutOptions

### DIFF
--- a/stripe-checkout/index.d.ts
+++ b/stripe-checkout/index.d.ts
@@ -25,10 +25,14 @@ interface StripeCheckoutOptions {
     currency?: string;
     panelLabel?: string;
     zipCode?: boolean;
+    billingAddress?: boolean;
     email?: string;
+    shippingAddress?: boolean;
     label?: string;
     allowRememberMe?: boolean;
     bitcoin?: boolean;
+    alipay?: boolean | 'auto';
+    alipayReusable?: boolean;
     opened?: () => void;
     closed?: () => void;
 }

--- a/stripe-checkout/stripe-checkout-tests.ts
+++ b/stripe-checkout/stripe-checkout-tests.ts
@@ -11,7 +11,7 @@ handler.open();
 handler.close();
 
 // Test all configuration options.
-var options = {
+var options: StripeCheckoutOptions = {
 	key: "my-secret-key",
 	token: function(token: StripeTokenResponse) {
 		console.log(token.id);
@@ -24,9 +24,13 @@ var options = {
     panelLabel: "Pay Definitely Typed {{amount}}",
     label: "Pay Definitely Typed",
     zipCode: false,
+    billingAddress: false,
     email: "test@example.com",
     allowRememberMe: false,
     bitcoin: false,
+    alipay: "auto",
+    alipayReusable: false,
+    shippingAddress: false,
     opened: function() {},
     closed: function() {}
 }


### PR DESCRIPTION
Added missing fields. They're listed at https://stripe.com/docs/checkout#integration-simple-options
