### PR TITLE
Fix murmurhash-js direct import

### DIFF
--- a/murmurhash-js/index.d.ts
+++ b/murmurhash-js/index.d.ts
@@ -3,11 +3,12 @@
 // Definitions by: Chi Vinh Le <https://github.com/cvle>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-type MurmurFunc = (str: string, seed?: number) => number;
+import * as murmur2 from "./murmurhash2_gc";
+import * as murmur3 from "./murmurhash3_gc";
 
-declare const murmur: MurmurFunc & {
-    murmur3: MurmurFunc;
-    murmur2: MurmurFunc;
+declare const murmur: typeof murmur3 & {
+    murmur3: typeof murmur3;
+    murmur2: typeof murmur2;
 };
 
 export = murmur;


### PR DESCRIPTION
The newly added types for murmuhash-js in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12189 was intended to support directly importing the desired murmurhash version which is a common usage pattern. This fails because `murmurhash2_gc.d.ts` and `murmurhash3_gc.d.ts` are not included in the final package. This PR fixes this issue.
