### PR TITLE
Added type definition for passport-http

### DIFF
--- a/passport-http/index.d.ts
+++ b/passport-http/index.d.ts
@@ -1,0 +1,62 @@
+// Type definitions for passport-http 0.3.0
+// Project: https://github.com/jaredhanson/passport-http
+// Definitions by: Christophe Vidal <https://github.com/krizalys>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../passport/index.d.ts"/>
+/// <reference path="../express/index.d.ts"/>
+
+import passport = require("passport");
+import express = require("express");
+
+interface BasicStrategyOptions {
+    realm?: string;
+    passReqToCallback?: boolean;
+}
+
+interface DigestStrategyOptions {
+    realm?: string;
+    domain?: string | Array<string>;
+    opaque?: string;
+    algorithm?: string;
+    qop?: string | Array<string>;
+}
+
+interface DigestValidateOptions {
+    nonce: string;
+    cnonce: string;
+    nc: number;
+    opaque: string;
+}
+
+interface BasicVerifyFunction {
+    (username: string, password: string, done: (error: any, user?: any) => void): void;
+}
+
+interface BasicVerifyFunctionWithRequest {
+    (req: express.Request, username: string, password: string, done: (error: any, user?: any) => void): void;
+}
+
+interface DigestSecretFunction {
+    (username: string, done: (error: any, user?: any, password?: any) => void): void;
+}
+
+interface DigestValidateFunction {
+    (params: DigestValidateOptions, done: (error: any, valid: boolean) => void): void;
+}
+
+declare class BasicStrategy implements passport.Strategy {
+    constructor(verify: BasicVerifyFunction);
+    constructor(options: BasicStrategyOptions, verify: BasicVerifyFunction);
+
+    name: string;
+    authenticate: (req: express.Request, options?: Object) => void;
+}
+
+declare class DigestStrategy implements passport.Strategy {
+    constructor(secret: DigestSecretFunction, validate?: DigestValidateFunction);
+    constructor(options: DigestStrategyOptions, secret: DigestSecretFunction, validate?: DigestValidateFunction);
+
+    name: string;
+    authenticate: (req: express.Request, options?: Object) => void;
+}

--- a/passport-http/passport-http-tests.ts
+++ b/passport-http/passport-http-tests.ts
@@ -1,0 +1,138 @@
+/// <reference path="./index.d.ts"/>
+
+/**
+ * Created by Christophe Vidal <https://github.com/krizalys>
+ */
+
+import passport = require("passport");
+import http = require("passport-http");
+
+interface IUser {
+    username: string;
+    password?: string;
+}
+
+class User {
+    public password: string;
+
+    static findOne(user: IUser, callback: (error: Error, user: User) => void): void {
+        callback(null, new User());
+    }
+}
+
+function validateNonce(nonce: string) {
+}
+
+function validateParams(nonce: string, cnonce: string, nc: number, opaque: string) {
+}
+
+passport.use(new http.BasicStrategy((username: string, password: string, done: any) => {
+    User.findOne({
+        username: username,
+        password: password,
+    }, (error, user) => {
+        if (error) {
+            return done(error);
+        }
+
+        if (!user) {
+            return done(null, false);
+        }
+
+        done(null, user);
+    });
+}));
+
+passport.use(new http.BasicStrategy({
+    realm: "User",
+    passReqToCallback: true,
+}, (username: string, password: string, done: any) => {
+    User.findOne({
+        username: username,
+        password: password,
+    }, (error, user) => {
+        if (error) {
+            return done(error);
+        }
+
+        if (!user) {
+            return done(null, false);
+        }
+
+        done(null, user);
+    });
+}));
+
+passport.use(new http.DigestStrategy((username: string, done: any) => {
+    User.findOne({username: username}, (error, user) => {
+        if (error) {
+            return done(error);
+        }
+
+        if (!user) {
+            return done(null, false);
+        }
+
+        done(null, user, user.password);
+    });
+}));
+
+passport.use(new http.DigestStrategy((username: string, done: any) => {
+    User.findOne({username: username}, (error, user) => {
+        if (error) {
+            return done(error);
+        }
+
+        if (!user) {
+            return done(null, false);
+        }
+
+        done(null, user, user.password);
+    });
+}, (params: http.DigestValidateOptions, done: any) => {
+    validateParams(params.nonce, params.cnonce, params.nc, params.opaque);
+    done(null, true);
+}));
+
+passport.use(new http.DigestStrategy({
+    realm: "User",
+    domain: "example.com",
+    opaque: "OpAqUeStRiNg",
+    algorithm: "MD5",
+    qop: "auth",
+}, (username: string, done: any) => {
+    User.findOne({username: username}, (error, user) => {
+        if (error) {
+            return done(error);
+        }
+
+        if (!user) {
+            return done(null, false);
+        }
+
+        done(null, user, user.password);
+    });
+}));
+
+passport.use(new http.DigestStrategy({
+    realm: "User",
+    domain: "example.com",
+    opaque: "OpAqUeStRiNg",
+    algorithm: "MD5",
+    qop: "auth",
+}, (username: string, done: any) => {
+    User.findOne({username: username}, (error, user) => {
+        if (error) {
+            return done(error);
+        }
+
+        if (!user) {
+            return done(null, false);
+        }
+
+        done(null, user, user.password);
+    });
+}, (params: http.DigestValidateOptions, done: any) => {
+    validateParams(params.nonce, params.cnonce, params.nc, params.opaque);
+    done(null, true);
+}));

--- a/passport-http/tsconfig.json
+++ b/passport-http/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "passport-http-tests.ts"
+    ]
+}


### PR DESCRIPTION
Added a new type definition + test for [passport-http](https://github.com/jaredhanson/passport-http):
- [x] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
