### PR TITLE
Sinon mongoose

### DIFF
--- a/sinon-mongoose/sinon-mongoose-tests.ts
+++ b/sinon-mongoose/sinon-mongoose-tests.ts
@@ -1,0 +1,7 @@
+/// <reference types="sinon"/>
+
+function testChain() {
+    sinon.stub().chain('exec');
+}
+
+testChain();

--- a/sinon-mongoose/sinon-mongoose-tests.ts
+++ b/sinon-mongoose/sinon-mongoose-tests.ts
@@ -1,7 +1,7 @@
 /// <reference types="sinon"/>
 
 function testChain() {
-    sinon.stub().chain('exec');
+    Sinon.stub().chain('exec');
 }
 
 testChain();

--- a/sinon-mongoose/sinon-mongoose.d.ts
+++ b/sinon-mongoose/sinon-mongoose.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for sinon-mongoose v1.3.0
+// Project: https://github.com/underscopeio/sinon-mongoose
+// Definitions by: Steve Hipwell <https://github.com/stevehipwell>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as s from "sinon";
+
+declare namespace Sinon {
+
+  export interface SinonStub {
+
+    /**
+     * When called, the stub will create a new stub to represent a mongoose chained function.
+     */
+    chain(name: string): SinonStub
+  }
+
+}

--- a/sinon-mongoose/sinon-mongoose.d.ts
+++ b/sinon-mongoose/sinon-mongoose.d.ts
@@ -5,9 +5,9 @@
 
 import * as s from "sinon";
 
-declare namespace Sinon {
+declare module "sinon" {
 
-  export interface SinonStub {
+  interface SinonStub {
 
     /**
      * When called, the stub will create a new stub to represent a mongoose chained function.

--- a/sinon-mongoose/tsconfig.json
+++ b/sinon-mongoose/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "noImplicitAny": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/sinon-mongoose/tsconfig.json
+++ b/sinon-mongoose/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "sinon-mongoose.d.ts",
+        "sinon-mongoose-tests.ts"
+    ]
+}


### PR DESCRIPTION
case 1. Add a new type definition.
- [x ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [x ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [x ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.
