### PR TITLE
Make ImmutableJS callback arguments non optional

### DIFF
--- a/immutable/immutable.d.ts
+++ b/immutable/immutable.d.ts
@@ -258,11 +258,11 @@ declare namespace Immutable {
      * @see `Map#mergeWith`
      */
     mergeWith(
-      merger: (previous?: T, next?: T, key?: number) => T,
+      merger: (previous: T, next: T, key: number) => T,
       ...iterables: Iterable.Indexed<T>[]
     ): List<T>;
     mergeWith(
-      merger: (previous?: T, next?: T, key?: number) => T,
+      merger: (previous: T, next: T, key: number) => T,
       ...iterables: Array<T>[]
     ): List<T>;
 
@@ -276,11 +276,11 @@ declare namespace Immutable {
      * @see `Map#mergeDeepWith`
      */
     mergeDeepWith(
-      merger: (previous?: T, next?: T, key?: number) => T,
+      merger: (previous: T, next: T, key: number) => T,
       ...iterables: Iterable.Indexed<T>[]
     ): List<T>;
     mergeDeepWith(
-      merger: (previous?: T, next?: T, key?: number) => T,
+      merger: (previous: T, next: T, key: number) => T,
       ...iterables: Array<T>[]
     ): List<T>;
 
@@ -539,11 +539,11 @@ declare namespace Immutable {
      *
      */
     mergeWith(
-      merger: (previous?: V, next?: V, key?: K) => V,
+      merger: (previous: V, next: V, key: K) => V,
       ...iterables: Iterable<K, V>[]
     ): Map<K, V>;
     mergeWith(
-      merger: (previous?: V, next?: V, key?: K) => V,
+      merger: (previous: V, next: V, key: K) => V,
       ...iterables: {[key: string]: V}[]
     ): Map<string, V>;
 
@@ -570,11 +570,11 @@ declare namespace Immutable {
      *
      */
     mergeDeepWith(
-      merger: (previous?: V, next?: V, key?: K) => V,
+      merger: (previous: V, next: V, key: K) => V,
       ...iterables: Iterable<K, V>[]
     ): Map<K, V>;
     mergeDeepWith(
-      merger: (previous?: V, next?: V, key?: K) => V,
+      merger: (previous: V, next: V, key: K) => V,
       ...iterables: {[key: string]: V}[]
     ): Map<string, V>;
 
@@ -1457,7 +1457,7 @@ declare namespace Immutable {
        *
        */
       mapKeys<M>(
-        mapper: (key?: K, value?: V, iter?: this) => M,
+        mapper: (key: K, value: V, iter: this) => M,
         context?: any
       ): /*this*/Iterable.Keyed<M, V>;
 
@@ -1472,9 +1472,9 @@ declare namespace Immutable {
        */
       mapEntries<KM, VM>(
         mapper: (
-          entry?: [K, V],
-          index?: number,
-          iter?: this
+          entry: [K, V],
+          index: number,
+          iter: this
         ) => [KM, VM],
         context?: any
       ): /*this*/Iterable.Keyed<KM, VM>;
@@ -1639,7 +1639,7 @@ declare namespace Immutable {
        * provided predicate function. Otherwise -1 is returned.
        */
       findIndex(
-        predicate: (value?: T, index?: number, iter?: this) => boolean,
+        predicate: (value: T, index: number, iter: this) => boolean,
         context?: any
       ): number;
 
@@ -1648,7 +1648,7 @@ declare namespace Immutable {
        * provided predicate function. Otherwise -1 is returned.
        */
       findLastIndex(
-        predicate: (value?: T, index?: number, iter?: this) => boolean,
+        predicate: (value: T, index: number, iter: this) => boolean,
         context?: any
       ): number;
     }
@@ -1969,7 +1969,7 @@ declare namespace Immutable {
      *
      */
     map<M>(
-      mapper: (value?: V, key?: K, iter?: this) => M,
+      mapper: (value: V, key: K, iter: this) => M,
       context?: any
     ): /*this*/Iterable<K, M>;
 
@@ -1982,7 +1982,7 @@ declare namespace Immutable {
      *
      */
     filter(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): this;
 
@@ -1995,7 +1995,7 @@ declare namespace Immutable {
      *
      */
     filterNot(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): this;
 
@@ -2031,7 +2031,7 @@ declare namespace Immutable {
      *
      */
     sortBy<C>(
-      comparatorValueMapper: (value?: V, key?: K, iter?: this) => C,
+      comparatorValueMapper: (value: V, key: K, iter: this) => C,
       comparator?: (valueA: C, valueB: C) => number
     ): this;
 
@@ -2042,7 +2042,7 @@ declare namespace Immutable {
      * Note: This is always an eager operation.
      */
     groupBy<G>(
-      grouper: (value?: V, key?: K, iter?: this) => G,
+      grouper: (value: V, key: K, iter: this) => G,
       context?: any
     ): Seq.Keyed<G, this>;
 
@@ -2057,7 +2057,7 @@ declare namespace Immutable {
      * (including the last iteration which returned false).
      */
     forEach(
-      sideEffect: (value?: V, key?: K, iter?: this) => any,
+      sideEffect: (value: V, key: K, iter: this) => any,
       context?: any
     ): number;
 
@@ -2116,7 +2116,7 @@ declare namespace Immutable {
      *
      */
     skipWhile(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): this;
 
@@ -2130,7 +2130,7 @@ declare namespace Immutable {
      *
      */
     skipUntil(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): this;
 
@@ -2156,7 +2156,7 @@ declare namespace Immutable {
      *
      */
     takeWhile(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): this;
 
@@ -2169,7 +2169,7 @@ declare namespace Immutable {
      *
      */
     takeUntil(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): this;
 
@@ -2207,11 +2207,11 @@ declare namespace Immutable {
      * Similar to `iter.map(...).flatten(true)`.
      */
     flatMap<MK, MV>(
-      mapper: (value?: V, key?: K, iter?: this) => Iterable<MK, MV>,
+      mapper: (value: V, key: K, iter: this) => Iterable<MK, MV>,
       context?: any
     ): /*this*/Iterable<MK, MV>;
     flatMap<MK, MV>(
-      mapper: (value?: V, key?: K, iter?: this) => /*iterable-like*/any,
+      mapper: (value: V, key: K, iter: this) => /*iterable-like*/any,
       context?: any
     ): /*this*/Iterable<MK, MV>;
 
@@ -2228,7 +2228,7 @@ declare namespace Immutable {
      * @see `Array#reduce`.
      */
     reduce<R>(
-      reducer: (reduction?: R, value?: V, key?: K, iter?: this) => R,
+      reducer: (reduction: R, value: V, key: K, iter: this) => R,
       initialReduction?: R,
       context?: any
     ): R;
@@ -2240,7 +2240,7 @@ declare namespace Immutable {
      * with `Array#reduceRight`.
      */
     reduceRight<R>(
-      reducer: (reduction?: R, value?: V, key?: K, iter?: this) => R,
+      reducer: (reduction: R, value: V, key: K, iter: this) => R,
       initialReduction?: R,
       context?: any
     ): R;
@@ -2249,7 +2249,7 @@ declare namespace Immutable {
      * True if `predicate` returns true for all entries in the Iterable.
      */
     every(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): boolean;
 
@@ -2257,7 +2257,7 @@ declare namespace Immutable {
      * True if `predicate` returns true for any entry in the Iterable.
      */
     some(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): boolean;
 
@@ -2287,7 +2287,7 @@ declare namespace Immutable {
      */
     count(): number;
     count(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): number;
 
@@ -2298,7 +2298,7 @@ declare namespace Immutable {
      * Note: This is not a lazy operation.
      */
     countBy<G>(
-      grouper: (value?: V, key?: K, iter?: this) => G,
+      grouper: (value: V, key: K, iter: this) => G,
       context?: any
     ): Seq.Keyed<G, number>;
 
@@ -2309,7 +2309,7 @@ declare namespace Immutable {
      * Returns the first value for which the `predicate` returns true.
      */
     find(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any,
       notSetValue?: V
     ): V;
@@ -2320,7 +2320,7 @@ declare namespace Immutable {
      * Note: `predicate` will be called for each entry in reverse.
      */
     findLast(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any,
       notSetValue?: V
     ): V;
@@ -2329,7 +2329,7 @@ declare namespace Immutable {
      * Returns the first [key, value] entry for which the `predicate` returns true.
      */
     findEntry(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any,
       notSetValue?: V
     ): [K, V];
@@ -2341,7 +2341,7 @@ declare namespace Immutable {
      * Note: `predicate` will be called for each entry in reverse.
      */
     findLastEntry(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any,
       notSetValue?: V
     ): [K, V];
@@ -2350,7 +2350,7 @@ declare namespace Immutable {
      * Returns the key for which the `predicate` returns true.
      */
     findKey(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): K;
 
@@ -2360,7 +2360,7 @@ declare namespace Immutable {
      * Note: `predicate` will be called for each entry in reverse.
      */
     findLastKey(
-      predicate: (value?: V, key?: K, iter?: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): K;
 
@@ -2399,7 +2399,7 @@ declare namespace Immutable {
      *
      */
     maxBy<C>(
-      comparatorValueMapper: (value?: V, key?: K, iter?: this) => C,
+      comparatorValueMapper: (value: V, key: K, iter: this) => C,
       comparator?: (valueA: C, valueB: C) => number
     ): V;
 
@@ -2428,7 +2428,7 @@ declare namespace Immutable {
      *
      */
     minBy<C>(
-      comparatorValueMapper: (value?: V, key?: K, iter?: this) => C,
+      comparatorValueMapper: (value: V, key: K, iter: this) => C,
       comparator?: (valueA: C, valueB: C) => number
     ): V;
 


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- Make callback arguments non optional per best practices on callback signatures http://definitelytyped.org/guides/best-practices.html
- In addition, the optional arguments cause issues on typescript 2 with strict null checks. 
