### PR TITLE
[react-native] Updated NavigationCardStack to not extend from NavigationRoute

### DIFF
--- a/react-native/react-native.d.ts
+++ b/react-native/react-native.d.ts
@@ -7490,7 +7490,7 @@ declare namespace  __React {
       key: string;
     }
 
-    export interface NavigationState extends NavigationRoute {
+    export interface NavigationState {
         index: number;
         routes: NavigationRoute[];
     }


### PR DESCRIPTION
According to this: https://github.com/facebook/react-native/blob/9ee815f6b52e0c2417c04e5a05e1e31df26daed2/Libraries/NavigationExperimental/NavigationPropTypes.js
