### PR TITLE
Missing correct c3 namespace export

### DIFF
--- a/c3/c3.d.ts
+++ b/c3/c3.d.ts
@@ -5,6 +5,9 @@
 
 /// <reference path="../d3/d3.d.ts"/>
 
+export = c3;
+export as namespace c3;
+
 declare namespace c3 {
 
     type PrimitiveArray = Array<string | boolean | number>;


### PR DESCRIPTION
I was unable to properly use c3 type definitions with @types/c3 without this. I checked with documentation, and also d3 example from the docs and I've found those two lines missing. I update the file on local and now it's fine.
