### PR TITLE
update getFragment declaration

### DIFF
--- a/react-relay/react-relay.d.ts
+++ b/react-relay/react-relay.d.ts
@@ -23,7 +23,7 @@ declare module "react-relay" {
 
     /** add static getFragment method to the component constructor */
     interface RelayContainerClass<T> extends React.ComponentClass<T> {
-        getFragment: ((q: string) => string)
+        getFragment: ((q: string, v?: RelayVariables) => string)
     }
 
     interface RelayQueryRequestResolve {


### PR DESCRIPTION
**case 2**. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

**Explanation**: The documentation for Relay is pretty bad, but Relay's getFragment method allows for an optional second argument for passing initial variables to the fragment. This simply adds that.
