### PR TITLE
Missing c3 namespace export

### DIFF
--- a/c3/index.d.ts
+++ b/c3/index.d.ts
@@ -5,6 +5,9 @@
 
 /// <reference types="d3"/>
 
+export = c3;
+export as namespace c3;
+
 declare namespace c3 {
 
     type PrimitiveArray = Array<string | boolean | number>;


### PR DESCRIPTION
I had trouble importing c3 module using npm @types approach and it looks like c3 namespace was not exported properly. I checked how d3 module which works ok is done and used the same approach.
