### PR TITLE
[fix](d3-format):

### DIFF
--- a/d3-format/d3-format-tests.ts
+++ b/d3-format/d3-format-tests.ts
@@ -64,7 +64,7 @@ num = d3Format.precisionRound(0.0005, 3000);
 // ----------------------------------------------------------------------
 
 let decimal: '.' | ',' = localeDef.decimal;
-let thousands: '.' | ',' = localeDef.thousands;
+let thousands: '.' | ',' | '\u00a0' = localeDef.thousands;
 let grouping: Array<number> = localeDef.grouping;
 let currency: [string, string] = localeDef.currency;
 

--- a/d3-format/index.d.ts
+++ b/d3-format/index.d.ts
@@ -15,7 +15,7 @@ export interface FormatLocaleDefinition {
      * The group separator (e.g., ","). Note that the thousands property is a misnomer, as\
      * the grouping definition allows groups other than thousands.
      */
-    thousands: '.' | ',';
+    thousands: '.' | ',' | '\u00a0';
     /**
      * The array of group sizes (e.g., [3]), cycled as needed.
      */


### PR DESCRIPTION
Improvement to existing type definition. 
cc @gustavderdrache
- Add non-breaking space `\u00a0` to string literal definition for "thousands" separator in locale definition. (Thanks for catching this to @vetvicka)

This ensures the string literal intersection type covers equivalent options to those generally used in all locale definitions already published in the **d3-format** repo and therefore contains all reasonable options.
