### PR TITLE
Updated LS cache typings

### DIFF
--- a/lscache/index.d.ts
+++ b/lscache/index.d.ts
@@ -36,13 +36,23 @@ interface LSCache {
     * Appends CACHE_PREFIX so lscache will partition data in to different buckets.
     * @param {string} bucket
     */
-    setBucket(bucket: string):void;
+    setBucket(bucket: string): void;
     /**
     * Resets the string being appended to CACHE_PREFIX so lscache will use the default storage behavior.
     */
     resetBucket(): void;
+    /**
+     * Test if the current browser supports localStorage
+     * @return {boolean} true if supported else false
+     */
+    supported(): boolean;
+    /**
+     * Enable/Disable warning if set fails
+     * @param {boolean} enabled
+     */
+    enableWarnings(enabled: boolean): void;
 }
-declare var lscache:LSCache;
+declare var lscache: LSCache;
 declare module 'lscache' {
     var lscache: LSCache;
     export = lscache;

--- a/lscache/index.d.ts
+++ b/lscache/index.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for lscache v1.0.5
+﻿// Type definitions for lscache v1.0.7
 // Project: https://github.com/pamelafox/lscache
 // Definitions by: Chris Martinez <https://github.com/Chris-Martinezz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/lscache/lscache-tests.ts
+++ b/lscache/lscache-tests.ts
@@ -1,6 +1,9 @@
 ﻿
 
 // Copied examples directly from lscache github site with slight modifications
+alert(lscache.supported());
+
+lscache.enableWarnings(true);
 
 lscache.set('greeting', 'Hello World!', 2);
 


### PR DESCRIPTION
Please fill in this template.
- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.

Documentation: https://github.com/pamelafox/lscache/blob/master/README.md

There is an outstanding PR to add docs for 2 undocumented methods https://github.com/pamelafox/lscache/pull/64 which can be found in the code at https://github.com/pamelafox/lscache/blob/master/lscache.js#L319 and https://github.com/pamelafox/lscache/blob/master/lscache.js#L363
