### PR TITLE
react-router: added render prop and fixed applyRouterMiddleware types

### DIFF
--- a/react-router/index.d.ts
+++ b/react-router/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-router v2.0.0
 // Project: https://github.com/rackt/react-router
-// Definitions by: Sergey Buturlakin <https://github.com/sergey-buturlakin>, Yuichi Murata <https://github.com/mrk21>, Václav Ostrožlík <https://github.com/vasek17>, Nathan Brown <https://github.com/ngbrown>, Alex Wendland <https://github.com/awendland>
+// Definitions by: Sergey Buturlakin <https://github.com/sergey-buturlakin>, Yuichi Murata <https://github.com/mrk21>, Václav Ostrožlík <https://github.com/vasek17>, Nathan Brown <https://github.com/ngbrown>, Alex Wendland <https://github.com/awendland>, Kostya Esmukov <https://github.com/KostyaEsmukov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace ReactRouter;

--- a/react-router/lib/Router.d.ts
+++ b/react-router/lib/Router.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import RouterContext from './RouterContext';
 import {
     QueryString, Query,
     Location, LocationDescriptor, LocationState,
@@ -48,16 +49,17 @@ declare namespace Router {
         components: RouteComponent[];
     }
 
-	interface RouterProps extends React.Props<Router> {
-	    history?: History;
-	    routes?: RouteConfig; // alias for children
-	    createElement?: (component: RouteComponent, props: Object) => any;
-	    onError?: (error: any) => any;
-	    onUpdate?: () => any;
-	    parseQueryString?: ParseQueryString;
-	    stringifyQuery?: StringifyQuery;
+    interface RouterProps extends React.Props<Router> {
+        history?: History;
+        routes?: RouteConfig; // alias for children
+        createElement?: (component: RouteComponent, props: Object) => any;
+        onError?: (error: any) => any;
+        onUpdate?: () => any;
+        parseQueryString?: ParseQueryString;
+        stringifyQuery?: StringifyQuery;
         basename?: string;
-	}
+        render?: (renderProps: React.Props<{}>) => RouterContext;
+    }
 
     interface PlainRoute {
         path?: RoutePattern;

--- a/react-router/lib/applyRouterMiddleware.d.ts
+++ b/react-router/lib/applyRouterMiddleware.d.ts
@@ -1,7 +1,9 @@
 import * as React from 'react';
+import Router from './Router';
+import RouterContext from './RouterContext';
 
 export interface Middleware {
-    renderRouterContext: (previous: React.Props<{}>[], props: React.Props<{}>) => React.Props<{}>[];
-    renderRouteComponent: (previous: React.Props<{}>[], props: React.Props<{}>) => React.Props<{}>[];
+    renderRouterContext?: (previous: RouterContext, props: React.Props<{}>) => RouterContext;
+    renderRouteComponent?: (previous: Router.RouteComponent, props: React.Props<{}>) => Router.RouteComponent;
 }
-export default function applyRouterMiddleware(...middlewares: Middleware[]): (renderProps: React.Props<{}>) => React.Props<{}>[];
+export default function applyRouterMiddleware(...middlewares: Middleware[]): (renderProps: React.Props<{}>) => RouterContext;

--- a/react-router/react-router-tests.tsx
+++ b/react-router/react-router-tests.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import * as ReactDOM from "react-dom"
 import {renderToString} from "react-dom/server";
 
-import { browserHistory, hashHistory, match, createMemoryHistory, withRouter, routerShape, Router, Route, IndexRoute, InjectedRouter, Link, RouterOnContext, RouterContext} from "react-router";
+import { applyRouterMiddleware, browserHistory, hashHistory, match, createMemoryHistory, withRouter, routerShape, Router, Route, IndexRoute, InjectedRouter, Link, RouterOnContext, RouterContext} from "react-router";
 
 interface MasterContext {
 	router: RouterOnContext;
@@ -105,3 +105,15 @@ const routes = (
 match({history, routes, location: "baseurl"}, (error, redirectLocation, renderProps) => {
 	renderToString(<RouterContext {...renderProps} />);
 });
+
+
+ReactDOM.render((
+	<Router
+		history={history}
+		routes={routes}
+		render={applyRouterMiddleware({
+			renderRouteComponent: child => child
+		})}
+	>
+	</Router>
+), document.body);


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/ReactTraining/react-router/blob/32728be890822840fe67277bf57286ab5b75fff8/docs/API.md#renderprops
- [x] Increase the version number in the header if appropriate.

---

I have added a missing `render` prop to the `<Router />` component and fixed `applyRouterMiddleware` types.

References:
- https://github.com/ReactTraining/react-router/blob/32728be890822840fe67277bf57286ab5b75fff8/docs/API.md#renderprops
- https://github.com/ReactTraining/react-router/blob/32728be890822840fe67277bf57286ab5b75fff8/modules/applyRouterMiddleware.js
- https://github.com/ReactTraining/react-router/blob/32728be890822840fe67277bf57286ab5b75fff8/docs/Troubleshooting.md#inject-props-to-all-routes-via-middleware
