### PR TITLE
+ Navbar.Link and Navbar.Text to react-bootstrap

### DIFF
--- a/react-bootstrap/index.d.ts
+++ b/react-bootstrap/index.d.ts
@@ -518,6 +518,21 @@ declare namespace ReactBootstrap {
     type NavbarToggle = React.ClassicComponent<NavbarToggleProps, {}>;
     var NavbarToggle: React.ClassicComponentClass<NavbarToggleProps>;
 
+    // <Navbar.Link />
+    interface NavbarLinkProps {
+        href: string;
+        onClick?: React.MouseEventHandler<{}>;
+    }
+    type NavbarLink = React.ClassicComponent<NavbarLinkProps, {}>;
+    const NavbarLink: React.ClassicComponentClass<NavbarLinkProps>;
+
+    // <Navbar.Text />
+    interface NavbarTextProps {
+        pullRight?: boolean;
+    }
+    type NavbarText = React.ClassicComponent<NavbarTextProps, {}>;
+    const NavbarText: React.ClassicComponentClass<NavbarTextProps>;
+
     // <Navbar />
     interface NavbarProps extends React.HTMLProps<Navbar> {
         brand?: any; // TODO: Add more specific type
@@ -540,6 +555,8 @@ declare namespace ReactBootstrap {
         Collapse: typeof NavbarCollapse;
         Header: typeof NavbarHeader;
         Toggle: typeof NavbarToggle;
+        Link: typeof NavbarLink;
+        Text: typeof NavbarText;
     }
     type Navbar = React.ClassicComponent<NavbarProps, {}>;
     var Navbar: NavbarClass;

--- a/react-bootstrap/react-bootstrap-tests.tsx
+++ b/react-bootstrap/react-bootstrap-tests.tsx
@@ -519,6 +519,12 @@ export class ReactBootstrapTest extends Component<any, any> {
                           <MenuItem eventKey='4'>Separated link</MenuItem>
                         </NavDropdown>
                       </Nav>
+                      <Navbar.Text>
+                          Signed in as: <Navbar.Link href="#">Mark Otto</Navbar.Link>
+                      </Navbar.Text>
+                      <Navbar.Text pullRight>
+                          Have a great day!
+                      </Navbar.Text>
                     </Navbar.Collapse>
                   </Navbar>
                 </div>


### PR DESCRIPTION
Please see - http://react-bootstrap.github.io/components.html#navbars-text-link

react-bootstrap is supporting and Navbar.Link and Navbar.Text, but d.ts doesn't contains it.

Please fill in this template.
- [OK] Prefer to make your PR against the `types-2.0` branch.
- [OK] The package does not provide its own types, and you can not add them.
- [OK] Test the change in your own code.
- [OK] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [OK] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [OK] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [ ] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
