### PR TITLE
libxmljs: Union types for possibly undefined return values

### DIFF
--- a/libxmljs/index.d.ts
+++ b/libxmljs/index.d.ts
@@ -17,13 +17,13 @@ export declare function parseHtmlString(source: string): HTMLDocument;
 
 export declare class XMLDocument {
     constructor(version: number, encoding: string);
-    child(idx: number): Element;
+    child(idx: number): Element | undefined;
     childNodes(): Element[];
     errors(): SyntaxError[];
     encoding(): string;
     encoding(enc: string): void;
     find(xpath: string): Element[];
-    get(xpath: string): Element;
+    get(xpath: string): Element | undefined;
     node(name: string, content: string): Element;
     root(): Element;
     toString(): string;
@@ -48,7 +48,7 @@ export declare class Element {
     attrs(): Attribute[];
     parent(): Element;
     doc(): XMLDocument;
-    child(idx: number): Element;
+    child(idx: number): Element | undefined;
     childNodes(): Element[];
     addChild(child: Element): Element;
     nextSibling(): Element;
@@ -60,9 +60,9 @@ export declare class Element {
     find(xpath: string): Element[];
     find(xpath: string, ns_uri: string): Element[];
     find(xpath: string, namespaces: { [key: string]: string; }): Element[];
-    get(xpath: string): Element;
-    get(xpath: string, ns_uri: string): Element;
-    get(xpath: string, ns_uri: { [key: string]: string; }): Element;
+    get(xpath: string): Element | undefined;
+    get(xpath: string, ns_uri: string): Element | undefined;
+    get(xpath: string, ns_uri: { [key: string]: string; }): Element | undefined;
     defineNamespace(href: string): Namespace;
     defineNamespace(prefix: string, href: string): Namespace;
     namespace(): Namespace;


### PR DESCRIPTION
Please fill in this template.
- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/libxmljs/libxmljs/wiki
- [ ] Increase the version number in the header if appropriate.
