### PR TITLE
Add `fillRule` to SVGAttributes

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -2083,6 +2083,7 @@ declare namespace React {
         dy?: number | string;
         fill?: string;
         fillOpacity?: number | string;
+        fillRule?: "nonzero" | "evenodd" | "inherit";
         filter?: string;
         fontFamily?: string;
         fontSize?: number | string;

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -325,17 +325,23 @@ React.DOM.input(htmlAttr);
 
 React.DOM.svg({ viewBox: "0 0 48 48" },
     React.DOM.rect({
-      x: 22,
-      y: 10,
-      width: 4,
-      height: 28
+        x: 22,
+        y: 10,
+        width: 4,
+        height: 28
     }),
     React.DOM.rect({
-      x: 10,
-      y: 22,
-      width: 28,
-      height: 4
-    }));
+        x: 10,
+        y: 22,
+        width: 28,
+        height: 4
+    }),
+    React.DOM.path({
+        d: "M0,0V3H3V0ZM1,1V2H2V1Z",
+        fill: "#999999",
+        fillRule: "evenodd"
+    })
+);
 
 
 //


### PR DESCRIPTION
Please fill in this template.
- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule
- [x] Increase the version number in the header if appropriate. – N/A
