### PR TITLE
[joi] Correct the validate function

### DIFF
--- a/joi/joi-tests.ts
+++ b/joi/joi-tests.ts
@@ -800,7 +800,7 @@ namespace validate_tests {
         value = Joi.validate(value, obj, (err, value) => value);
         value = Joi.validate(value, schema, (err, value) => value);
 
-        returnValue = Joi.validate(value, schema, obj, validOpts);
+        returnValue = Joi.validate(value, schema, validOpts);
         returnValue = Joi.validate(value, obj, validOpts);
         value = Joi.validate(value, obj, validOpts, (err, value) => value);
         value = Joi.validate(value, schema, validOpts, (err, value) => value);

--- a/joi/joi-tests.ts
+++ b/joi/joi-tests.ts
@@ -796,10 +796,12 @@ namespace validate_tests {
         value = Joi.validate(value, (err, value) => value);
 
         returnValue = Joi.validate(value, schema);
+        returnValue = Joi.validate(value, obj);
         value = Joi.validate(value, obj, (err, value) => value);
         value = Joi.validate(value, schema, (err, value) => value);
 
-        returnValue = Joi.validate(value, schema);
+        returnValue = Joi.validate(value, schema, obj, validOpts);
+        returnValue = Joi.validate(value, obj, validOpts);
         value = Joi.validate(value, obj, validOpts, (err, value) => value);
         value = Joi.validate(value, schema, validOpts, (err, value) => value);
     }

--- a/joi/joi-tests.ts
+++ b/joi/joi-tests.ts
@@ -756,30 +756,55 @@ schema = Joi.lazy(() => schema)
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-Joi.validate(value, obj);
-Joi.validate(value, schema);
-Joi.validate(value, schema, validOpts);
-Joi.validate(value, schema, validOpts, (err, value) => {
-	x = value;
-	str = err.message;
-	str = err.details[0].path;
-	str = err.details[0].message;
-	str = err.details[0].type;
-});
-Joi.validate(value, schema, (err, value) => {
-	x = value;
-	str = err.message;
-	str = err.details[0].path;
-	str = err.details[0].message;
-	str = err.details[0].type;
-});
-// variant
-Joi.validate(num, schema, validOpts, (err, value) => {
-	num = value;
-});
+namespace validate_tests {
+    {
+        Joi.validate(value, obj);
+        Joi.validate(value, schema);
+        Joi.validate(value, schema, validOpts);
+        Joi.validate(value, schema, validOpts, (err, value) => {
+            x = value;
+            str = err.message;
+            str = err.details[0].path;
+            str = err.details[0].message;
+            str = err.details[0].type;
+        });
+        Joi.validate(value, schema, (err, value) => {
+            x = value;
+            str = err.message;
+            str = err.details[0].path;
+            str = err.details[0].message;
+            str = err.details[0].type;
+        });
+        // variant
+        Joi.validate(num, schema, validOpts, (err, value) => {
+            num = value;
+        });
 
-// plain opts
-Joi.validate(value, {});
+        // plain opts
+        Joi.validate(value, {});
+    }
+
+    {
+        let value = { username: 'example', password: 'example' };
+        let schema = Joi.object().keys({
+            username: Joi.string().max(255).required(),
+            password: Joi.string().regex(/^[a-zA-Z0-9]{3,255}$/).required(),
+        });
+        let returnValue: Joi.ValidationResult<typeof value>;
+
+        returnValue = Joi.validate(value);
+        value = Joi.validate(value, (err, value) => value);
+
+        returnValue = Joi.validate(value, schema);
+        value = Joi.validate(value, obj, (err, value) => value);
+        value = Joi.validate(value, schema, (err, value) => value);
+
+        returnValue = Joi.validate(value, schema);
+        value = Joi.validate(value, obj, validOpts, (err, value) => value);
+        value = Joi.validate(value, schema, validOpts, (err, value) => value);
+    }
+}
+
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 

--- a/joi/joi.d.ts
+++ b/joi/joi.d.ts
@@ -827,11 +827,19 @@ declare module 'joi' {
 	/**
 	 * Validates a value using the given schema and options.
 	 */
+	export function validate<T>(value: T): ValidationResult<T>;
+	export function validate<T, R>(value: T, callback: (err: ValidationError, value: T) => R): R;
+	export function validate<T, R>(value: T, callback: (err: ValidationError, value: T) => R): R;
+
 	export function validate<T>(value: T, schema: Schema): ValidationResult<T>;
 	export function validate<T>(value: T, schema: Object): ValidationResult<T>;
-	export function validate<T>(value: T, schema: Schema, callback: (err: ValidationError, value: T) => void): void;
-	export function validate<T>(value: T, schema: Object, callback: (err: ValidationError, value: T) => void): void;
-	export function validate<T>(value: T, schema: Object, options?: ValidationOptions, callback?: (err: ValidationError, value: T) => void): void;
+	export function validate<T, R>(value: T, schema: Schema, callback: (err: ValidationError, value: T) => R): R;
+	export function validate<T, R>(value: T, schema: Object, callback: (err: ValidationError, value: T) => R): R;
+
+	export function validate<T>(value: T, schema: Schema, options: ValidationOptions): ValidationResult<T>;
+	export function validate<T>(value: T, schema: Object, options: ValidationOptions): ValidationResult<T>;
+	export function validate<T, R>(value: T, schema: Schema, options: ValidationOptions, callback: (err: ValidationError, value: T) => R): R;
+	export function validate<T, R>(value: T, schema: Object, options: ValidationOptions, callback: (err: ValidationError, value: T) => R): R;
 
 	/**
 	 * Converts literal schema definition to joi schema object (or returns the same back if already a joi schema object).

--- a/joi/joi.d.ts
+++ b/joi/joi.d.ts
@@ -827,8 +827,8 @@ declare module 'joi' {
 	/**
 	 * Validates a value using the given schema and options.
 	 */
-	export function validate<T>(value: T, schema: Schema, callback: (err: ValidationError, value: T) => void): void;
-	export function validate<T>(value: T, schema: Object, callback: (err: ValidationError, value: T) => void): void;
+	export function validate<T>(value: T, schema: Schema, callback: (err: ValidationError, value: T) => void): ValidationResult<T>;
+	export function validate<T>(value: T, schema: Object, callback: (err: ValidationError, value: T) => void): ValidationResult<T>;
 	export function validate<T>(value: T, schema: Object, options?: ValidationOptions, callback?: (err: ValidationError, value: T) => void): ValidationResult<T>;
 
 	/**

--- a/joi/joi.d.ts
+++ b/joi/joi.d.ts
@@ -827,9 +827,11 @@ declare module 'joi' {
 	/**
 	 * Validates a value using the given schema and options.
 	 */
-	export function validate<T>(value: T, schema: Schema, callback: (err: ValidationError, value: T) => void): ValidationResult<T>;
-	export function validate<T>(value: T, schema: Object, callback: (err: ValidationError, value: T) => void): ValidationResult<T>;
-	export function validate<T>(value: T, schema: Object, options?: ValidationOptions, callback?: (err: ValidationError, value: T) => void): ValidationResult<T>;
+	export function validate<T>(value: T, schema: Schema): ValidationResult<T>;
+	export function validate<T>(value: T, schema: Object): ValidationResult<T>;
+	export function validate<T>(value: T, schema: Schema, callback: (err: ValidationError, value: T) => void): void;
+	export function validate<T>(value: T, schema: Object, callback: (err: ValidationError, value: T) => void): void;
+	export function validate<T>(value: T, schema: Object, options?: ValidationOptions, callback?: (err: ValidationError, value: T) => void): void;
 
 	/**
 	 * Converts literal schema definition to joi schema object (or returns the same back if already a joi schema object).

--- a/joi/joi.d.ts
+++ b/joi/joi.d.ts
@@ -829,7 +829,6 @@ declare module 'joi' {
 	 */
 	export function validate<T>(value: T): ValidationResult<T>;
 	export function validate<T, R>(value: T, callback: (err: ValidationError, value: T) => R): R;
-	export function validate<T, R>(value: T, callback: (err: ValidationError, value: T) => R): R;
 
 	export function validate<T>(value: T, schema: Schema): ValidationResult<T>;
 	export function validate<T>(value: T, schema: Object): ValidationResult<T>;


### PR DESCRIPTION
Based on the document:

```
const schema = {
    a: Joi.number()
};

const value = {
    a: '123'
};

Joi.validate(value, schema, (err, value) => { });
// err -> null
// value.a -> 123 (number, not string)

// or
const result = Joi.validate(value, schema);
// result.error -> null
// result.value -> { "a" : 123 }
```

The validate should return a result when it takes options argument or not.
