### PR TITLE
Update auth0-lock to match default export

### DIFF
--- a/auth0-lock/index.d.ts
+++ b/auth0-lock/index.d.ts
@@ -122,5 +122,5 @@ interface Auth0LockStatic {
 declare var Auth0Lock: Auth0LockStatic;
 
 declare module "auth0-lock" {
-    export = Auth0Lock;
+    export default Auth0Lock;
 }


### PR DESCRIPTION
Updated typings to match [default export in Auth0Lock](https://github.com/auth0/lock/blob/master/src/index.js#L23).

The original definition works but gives the following compile error:

Module '"auth0-lock"' has no default export.

Opening this pull request to `types-2.0` at the request of @vvakame over in #12252.
