### PR TITLE
passport: Added generic versions of serializeUser and deserializeUser

### DIFF
--- a/passport/passport-tests.ts
+++ b/passport/passport-tests.ts
@@ -29,7 +29,9 @@ const newFramework:passport.Framework = {
 passport.use(new TestStrategy());
 passport.framework(newFramework);
 passport.serializeUser((user, done) => { });
+passport.serializeUser<string, number>((user, done) => { });
 passport.deserializeUser((id, done) => { });
+passport.deserializeUser<string, number>((id, done) => { });
 
 passport.use(new TestStrategy())
   .unuse('test')

--- a/passport/passport.d.ts
+++ b/passport/passport.d.ts
@@ -45,7 +45,9 @@ declare module 'passport' {
             authorize(strategies: string[], callback?: Function): express.Handler;
             authorize(strategies: string[], options: Object, callback?: Function): express.Handler;
             serializeUser(fn: (user: any, done: (err: any, id: any) => void) => void): void;
+            serializeUser<TUser, TID>(fn: (user: TUser, done: (err: any, id: TID) => void) => void): void;
             deserializeUser(fn: (id: any, done: (err: any, user: any) => void) => void): void;
+            deserializeUser<TUser, TID>(fn: (id: TID, done: (err: any, user: TUser) => void) => void): void;
             transformAuthInfo(fn: (info: any, done: (err: any, info: any) => void) => void): void;
         }
 


### PR DESCRIPTION
Added generic versions of serializeUser and deserializeUser for strong typing. Kept the existing versions with "any" typing for backward compatibility.
