### PR TITLE
interface Props extends React.HTMLAttributes

### DIFF
--- a/react-swipeable/react-swipeable.d.ts
+++ b/react-swipeable/react-swipeable.d.ts
@@ -22,7 +22,7 @@ declare namespace ReactSwipeableModule {
         (event: React.TouchEvent<any>, delta: number): void;
     }
 
-    interface Props extends React.HTMLAttributes {
+    interface Props extends React.HTMLAttributes<any> {
         onSwiped?: OnSwipedCallback;
         onSwiping?: onSwipingCallback;
         onSwipingUp?: OnSwipingDirectionCallback;

--- a/react-swipeable/react-swipeable.d.ts
+++ b/react-swipeable/react-swipeable.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-///<reference types='react' />
-
 declare namespace ReactSwipeableModule {
     interface onSwipingCallback {
         (event: React.TouchEvent<any>, deltaX: number, deltaY: number, absX: number, absY: number, velocity: number): void;

--- a/react-swipeable/react-swipeable.d.ts
+++ b/react-swipeable/react-swipeable.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-swipeable 3.3.1
+// Type definitions for react-swipeable 3.7.0
 // Project: https://www.npmjs.com/package/react-swipeable
 // Definitions by: Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -37,6 +37,7 @@ declare namespace ReactSwipeableModule {
         delta?: number;
         preventDefaultTouchmoveEvent?: boolean;
         nodeName?: string;
+        trackMouse?: boolean;
     }
 
     interface ReactSwipeable extends React.ComponentClass<Props> { }

--- a/react-swipeable/react-swipeable.d.ts
+++ b/react-swipeable/react-swipeable.d.ts
@@ -22,7 +22,7 @@ declare namespace ReactSwipeableModule {
         (event: React.TouchEvent<any>, delta: number): void;
     }
 
-    interface Props {
+    interface Props extends React.HTMLAttributes {
         onSwiped?: OnSwipedCallback;
         onSwiping?: onSwipingCallback;
         onSwipingUp?: OnSwipingDirectionCallback;


### PR DESCRIPTION
Please fill in this template.
- [ ] Prefer to make your PR against the `types-2.0` branch.
- [ ] The package does not provide its own types, and you can not add them.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [X] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/dogfessional/react-swipeable/blob/master/src/Swipeable.js#L177
- [ ] Increase the version number in the header if appropriate.

Since the ReactSwipeable props are passed down to the html element, interface Props should extend React.HTMLAttributes to allow other props to be added to the html element like onClick for example.

Proof:

https://github.com/dogfessional/react-swipeable/blob/master/src/Swipeable.js#L177
