### PR TITLE
Fix generic types for ReactElement

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -25,8 +25,8 @@ declare namespace React {
         ref?: Ref<T>;
     }
 
-    interface ReactElement<P> {
-        type: string | ComponentClass<P> | SFC<P>;
+    interface ReactElement<T extends Component<P, any>, P> {
+        type: string | ComponentClass<T> | SFC<T>;
         props: P;
         key?: Key;
     }


### PR DESCRIPTION
Hello,

this change in the React typings fixes wrong generic types for the `props` property in `ReactElement`.

This is tested in the projects I work on an works as expected.
