### PR TITLE
Updated jquery.dataTables for 1.10.8

### DIFF
--- a/jquery.datatables/index.d.ts
+++ b/jquery.datatables/index.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for JQuery DataTables 1.10.7
+﻿// Type definitions for JQuery DataTables 1.10.8
 // Project: http://www.datatables.net
 // Definitions by: Kiarash Ghiaseddin <https://github.com/Silver-Connection/DefinitelyTyped>, Omid Rad <https://github.com/omidkrad>, Armin Sander <https://github.com/pragmatrix/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -8,7 +8,7 @@
 // - Plugin and extension definitions are not typed.
 // - Some return types are not fully wokring
 
-/// <reference types="jquery"/>
+/// <reference path="../jquery/index.d.ts" />
 
 interface JQuery {
     DataTable(param?: DataTables.Settings): DataTables.DataTable;
@@ -182,11 +182,11 @@ declare namespace DataTables {
         destroy(remove?: boolean): DataTable;
 
         /**
-        * Redraw the table.
+        * Redraw the DataTables in the current context, optionally updating ordering, searching and paging as required.
         *
-        * @param reset Reset (default) or hold the current paging position. A full re-sort and re-filter is performed when this method is called, which is why the pagination reset is the default action.
+        * @param paging This parameter is used to determine what kind of draw DataTables will perform.
         */
-        draw(reset?: boolean): DataTable;
+        draw(paging?: boolean | string): DataTable;
 
         /*
         * Look up a language token that was defined in the DataTables' language initialisation object.
@@ -374,6 +374,7 @@ declare namespace DataTables {
         length: number;
         recordsTotal: number;
         recordsDisplay: number;
+        serverSide: boolean
     }
 
     //#endregion "page-methods"
@@ -435,6 +436,11 @@ declare namespace DataTables {
         * @param b Additional API instance(s) to concatenate to the initial instance.
         */
         concat(a: Object, ...b: Object[]): DataTable;
+
+        /**
+        * Get the number of entries in an API instance's result set, regardless of multi-table grouping (e.g. any data, selected rows, etc). Since: 1.10.8
+        */
+        count(): number;
 
         /**
         * Iterate over the contents of the API result set.
@@ -902,11 +908,20 @@ declare namespace DataTables {
         * @param d Data to use for the row.
         */
         data(d: any[] | Object): DataTable;
-
+        
         /**
         * Get the id of the selected row.
         *
         * @param hash Set to true to append a hash (#) to the start of the row id.
+        */
+        id(hash?: boolean): string;
+
+        /**
+        * Get the id of the selected row. Since: 1.10.8
+        *
+        * @param hash true - Append a hash (#) to the start of the row id. This can be useful for then using the id as a selector
+        * false - Do not modify the id value.
+        * @returns Row id. If the row does not have an id available 'undefined' will be returned.
         */
         id(hash?: boolean): string;
 
@@ -969,6 +984,15 @@ declare namespace DataTables {
         * @param fn Function to execute for every row selected.
         */
         every(fn: (rowIdx: number, tableLoop: number, rowLoop: number) => void): DataTable;
+
+        /**
+        * Get the ids of the selected rows. Since: 1.10.8
+        *
+        * @param hash true - Append a hash (#) to the start of each row id. This can be useful for then using the ids as selectors
+        * false - Do not modify the id value.
+        * @returns Api instance with the selected rows in its result set. If a row does not have an id available 'undefined' will be returned as the value.
+        */
+        ids(hash?: boolean): DataTable;
 
         /**
         * Get the row indexes of the selected rows.
@@ -1057,11 +1081,12 @@ declare namespace DataTables {
         isDataTable(table: string): boolean;
 
         /**
-        * Get all DataTables on the page
+        * Get all DataTable tables that have been initialised - optionally you can select to get only currently visible tables and / or retrieve the tables as API instances.
         *
-        * @param visible Get only visible tables
+        * @param visible As a boolean value this options is used to indicate if you want all tables on the page should be returned (false), or visible tables only (true).
+        * Since 1.10.8 this option can also be given as an object.
         */
-        tables(visible?: boolean): DataTables.DataTable[];
+        tables(visible?: boolean | ObjectTablesStatic): DataTables.DataTable[] | DataTables.DataTable;
 
         /**
         * Version number compatibility check function
@@ -1098,6 +1123,18 @@ declare namespace DataTables {
         * @param period ms
         */
         throttle(fn: Function, period?: number): Function;
+    }
+
+    interface ObjectTablesStatic {
+        /**
+        * Get only visible tables (true) or all tables regardless of visibility (false).
+        */
+        visible: boolean
+
+        /**
+        * Return a DataTables API instance for the selected tables (true) or an array (false).
+        */
+        api: boolean
     }
 
     //#endregion "Static-Methods"
@@ -1257,7 +1294,7 @@ declare namespace DataTables {
         pageLength?: number;
 
         /**
-        * Pagination button display options. Basic Types: simple, simple_numbers, full, full_numbers
+        * Pagination button display options. Basic Types: numbers (1.10.8) simple, simple_numbers, full, full_numbers
         */
         pagingType?: string;
 
@@ -1270,6 +1307,11 @@ declare namespace DataTables {
         * Display component renderer types. Since: 1.10
         */
         renderer?: string | RendererSettings;
+
+        /**
+        * Data property name that DataTables will use to set <tr> element DOM IDs. Since: 1.10.8
+        */
+        rowId?: string;
 
         /**
         * Allow the table to reduce in height when a limited number of rows are shown. Since: 1.10
@@ -1670,7 +1712,7 @@ declare namespace DataTables {
 
     //#region "language-settings"
 
-	// these are all optional
+    // these are all optional
     interface LanguageSettings {
         emptyTable?: string;
         info?: string;

--- a/jquery.datatables/jquery.dataTables-tests.ts
+++ b/jquery.datatables/jquery.dataTables-tests.ts
@@ -1,4 +1,5 @@
-/// <reference types="jquery" />
+/// <reference path="../jquery/index.d.ts" />
+/// <reference path="index.d.ts" />
 
 
 $(document).ready(function () {
@@ -82,21 +83,21 @@ $(document).ready(function () {
             width: "200px"
         }
     col =
-    {
-        data: "",
-        orderData: [10, 11, 20],
-        render: "",
-    }
+        {
+            data: "",
+            orderData: [10, 11, 20],
+            render: "",
+        }
     col =
-    {
-        data: colDataObject,
-        render: colRenderObject,
-    }
+        {
+            data: colDataObject,
+            render: colRenderObject,
+        }
     col =
-    {
-        data: colDataFunc,
-        render: colRenderFunc,
-    }
+        {
+            data: colDataFunc,
+            render: colRenderFunc,
+        }
 
     //#endregion "Column"
 
@@ -124,16 +125,16 @@ $(document).ready(function () {
         };
 
     colDef =
-    {
-        targets: "2",
-        cellType: "th",
-    };
+        {
+            targets: "2",
+            cellType: "th",
+        };
 
     colDef =
-    {
-        targets: ["2", 5],
-        cellType: "th",
-    };
+        {
+            targets: ["2", 5],
+            cellType: "th",
+        };
 
     //#endregion "ColumnDef"
 
@@ -219,6 +220,7 @@ $(document).ready(function () {
             pagingType: "simple",
             retrieve: true,
             renderer: "bootstrap",
+            rowId: "custId",
             scrollCollapse: true,
             search: true,
             searchCols: [{ "search": "", "smart": true, "regex": false, "caseInsensitive": true }],
@@ -229,41 +231,41 @@ $(document).ready(function () {
 
 
     config =
-    {
-        ajax: ajaxFunc,
-        deferLoading: [10, 100],
-        lengthMenu: [[10, 25, 50, -1], [10, 25, 50, "All"]],
-        order: [0, 'asc'],
-        orderFixed: [[0, 'asc'], [1, 'asc']],
-        renderer: {
-            header: "bootstrap",
-            pageButton: "jqueryui"
-        },
-        search: { "search": "", "smart": true, "regex": false, "caseInsensitive": true },
-        searchCols: [
-            null,
-            { "search": "", "smart": true, "regex": false, "caseInsensitive": true },
-            { "search": "" },
-            { "search": "", "smart": true },
-            null
-        ],
-    };
+        {
+            ajax: ajaxFunc,
+            deferLoading: [10, 100],
+            lengthMenu: [[10, 25, 50, -1], [10, 25, 50, "All"]],
+            order: [0, 'asc'],
+            orderFixed: [[0, 'asc'], [1, 'asc']],
+            renderer: {
+                header: "bootstrap",
+                pageButton: "jqueryui"
+            },
+            search: { "search": "", "smart": true, "regex": false, "caseInsensitive": true },
+            searchCols: [
+                null,
+                { "search": "", "smart": true, "regex": false, "caseInsensitive": true },
+                { "search": "" },
+                { "search": "", "smart": true },
+                null
+            ],
+        };
 
     config =
-    {
-        ajax: {
-            data: {},
-            dataSrc: "",
-        },
-    };
+        {
+            ajax: {
+                data: {},
+                dataSrc: "",
+            },
+        };
 
     config =
-    {
-        ajax: {
-            data: ajaxDataFunc,
-            dataSrc: function (data) { },
-        },
-    };
+        {
+            ajax: {
+                data: ajaxDataFunc,
+                dataSrc: function (data: any) { },
+            },
+        };
 
     //#endregion "Settings"
 
@@ -305,8 +307,9 @@ $(document).ready(function () {
     destroy = dt.destroy(true);
     destroy.$("");
 
-    var draw = dt.draw();
+    var draw: DataTables.DataTable = dt.draw();
     draw = dt.draw(true);
+    draw = dt.draw("page");
     draw.$("");
 
     var initSettings = dt.init();
@@ -343,7 +346,8 @@ $(document).ready(function () {
         "end": 20,
         "length": 10,
         "recordsTotal": 57,
-        "recordsDisplay": 57
+        "recordsDisplay": 57,
+        "serverSide": false
     };
 
     var page_len_get = dt.page.len();
@@ -390,20 +394,20 @@ $(document).ready(function () {
     var select = $('<select />')
         .appendTo('body')
         .on('change', function () {
-        dt
-            .column(0)
-            .search($(this).val())
-            .draw();
-    });
+            dt
+                .column(0)
+                .search($(this).val())
+                .draw();
+        });
     // Get the search data for the first column and add to the select list
     var data = dt
         .cells('', 0)
         .cache('search')
         .sort()
         .unique()
-        .each(function (d) {
-        select.append($('<option value="' + d + '">' + d + '</option>'));
-    });
+        .each(function (d: any) {
+            select.append($('<option value="' + d + '">' + d + '</option>'));
+        });
 
     var cells_data = cells.data();
     var data = dt
@@ -520,28 +524,28 @@ $(document).ready(function () {
     columns = dt.columns("selector", modifier);
 
     var columns_cache = columns.cache("order");
-    dt.columns('.select-filter').eq(0).each(function (colIdx) {
+    dt.columns('.select-filter').eq(0).each(function (colIdx: any) {
         // Create the select list and search operation
         var select = $('<select />')
             .appendTo(
             dt.column(colIdx).footer()
             )
             .on('change', function () {
-            dt
-                .column(colIdx)
-                .search($(this).val())
-                .draw();
-        });
- 
+                dt
+                    .column(colIdx)
+                    .search($(this).val())
+                    .draw();
+            });
+
         // Get the search data for the first column and add to the select list
         dt
             .column(colIdx)
             .cache('search')
             .sort()
             .unique()
-            .each(function (d) {
-            select.append($('<option value="' + d + '">' + d + '</option>'));
-        });
+            .each(function (d: any) {
+                select.append($('<option value="' + d + '">' + d + '</option>'));
+            });
     });
 
     var columns_data = columns.data();
@@ -553,7 +557,7 @@ $(document).ready(function () {
             .sort()       // Sort data alphabetically
             .unique()     // Reduce to unique values
             .join('<br>')
-        );
+    );
 
     //var idx = dt
     //    .columns('.check')
@@ -611,31 +615,31 @@ $(document).ready(function () {
         dt.column(0).footer()
         )
         .on('change', function () {
-        dt
-            .column(0)
-            .search($(this).val())
-            .draw();
-    });
- 
+            dt
+                .column(0)
+                .search($(this).val())
+                .draw();
+        });
+
     // Get the search data for the first column and add to the select list
     dt
         .column(0)
         .cache('search')
         .sort()
         .unique()
-        .each(function (d) {
-        select.append($('<option value="' + d + '">' + d + '</option>'));
-    });
+        .each(function (d: any) {
+            select.append($('<option value="' + d + '">' + d + '</option>'));
+        });
 
     var column_data = column.data();
     alert('Column 4 sum: ' +
         dt
             .column(4)
             .data()
-    .reduce(function (a, b) {
-    return a + b;
-    })
-        );
+            .reduce(function (a: any, b: any) {
+                return a + b;
+            })
+    );
 
     var column_dataSrc = column.dataSrc();
     $('#example').on('click', 'tbody td', function () {
@@ -688,7 +692,7 @@ $(document).ready(function () {
             .draw();
     });
 
-    dt.columns('.select-filter').eq(0).each(function (colIdx) {
+    dt.columns('.select-filter').eq(0).each(function (colIdx: any) {
         // Create the select list and search operation
         var select = $('<select />')
             .appendTo(
@@ -696,20 +700,20 @@ $(document).ready(function () {
             )
             .on('change', function () {
                 dt
-                .column(colIdx)
-                .search($(this).val())
-                .draw();
-        });
- 
+                    .column(colIdx)
+                    .search($(this).val())
+                    .draw();
+            });
+
         // Get the search data for the first column and add to the select list
         dt
             .column(colIdx)
             .cache('search')
             .sort()
             .unique()
-            .each(function (d) {
-            select.append($('<option value="' + d + '">' + d + '</option>'));
-        });
+            .each(function (d: any) {
+                select.append($('<option value="' + d + '">' + d + '</option>'));
+            });
     });
 
     var column_visible_get = column.visible();
@@ -717,7 +721,7 @@ $(document).ready(function () {
     column_visible_set = column.visible(false, true);
     alert('Column index 0 is ' +
         (dt.column(0).visible() === true ? 'visible' : 'not visible')
-        );
+    );
     for (var i = 0; i < 4; i++) {
         dt.column(i).visible(false, false);
     }
@@ -751,6 +755,8 @@ $(document).ready(function () {
     var row_19 = dt.row("selector").index();
     var row_20 = dt.row("selector").node();
     var row_21 = dt.row("selector").remove();
+    var row_22: string = dt.row("selector").id();
+    var row_23: string = dt.row("selector").id(false);
 
     var rows_1 = dt.rows();
     var rows_2 = dt.rows().remove();
@@ -767,6 +773,8 @@ $(document).ready(function () {
     var rows_13 = dt.rows.add([{}, {}]);
     dt.rows().every(function () { });
     dt.rows().every(function (rowIdx, tableLoop, rowLoop) { });
+    var rows_14: DataTables.DataTable = dt.rows("selector").ids();
+    var rows_15: DataTables.DataTable = dt.rows("selector").ids(false);
 
     var table3 = $('#example').DataTable();
     table3.row.add({
@@ -804,9 +812,9 @@ $(document).ready(function () {
         pupil,
     ])
         .draw();
-        //.nodes()
-        //.to$()
-        //.addClass('new');
+    //.nodes()
+    //.to$()
+    //.addClass('new');
 
     $('#example tbody').on('click', 'td.details-control', function () {
         var tr = $(this).parents('tr');
@@ -831,7 +839,7 @@ $(document).ready(function () {
     ])
         .show();
 
-    dt.rows().eq(0).each(function (rowIdx) {
+    dt.rows().eq(0).each(function (rowIdx: any) {
         dt
             .row(rowIdx)
             .child(
@@ -842,7 +850,7 @@ $(document).ready(function () {
                 '<td>' + rowIdx + '.3</td>' +
                 '<td>' + rowIdx + '.4</td>' +
                 '</tr>'
-                )
+            )
             )
             .show();
     });
@@ -881,6 +889,20 @@ $(document).ready(function () {
 
     //#endregion "Methods-Row"
 
+    //#region "Methods-Static"
+
+    // Variable is a stand-in for $.fn.dataTable. See extension of JQueryStatic at the top of jquery.dataTables.d.ts.
+    var staticFn: DataTables.StaticFunctions;
+
+    // With boolean parameter type, always returns DataTables.DataTable[].
+    var static_1: DataTables.DataTable[] = <DataTables.DataTable[]>staticFn.tables(true);
+    // With object parameter type, returns DataTables.DataTable[] when "api" property is false.
+    static_1 = <DataTables.DataTable[]>staticFn.tables({ "visible": true, "api": false });
+    // With object parameter type, returns DataTables.DataTable when "api" property is true.
+    var static_2: DataTables.DataTable = <DataTables.DataTable>staticFn.tables({ "visible": true, "api": true });
+
+    //#endregion "Methods-Static"
+
     //#region "Methods-Table"
 
     var tables = dt.tables();
@@ -905,6 +927,7 @@ $(document).ready(function () {
     //#region "Methods-Util"
 
     var util_1: boolean = dt.any();
+    var util_2: number = dt.count();
 
     //#endregion "Methods-Util"
 });

--- a/jquery.datatables/tsconfig.json
+++ b/jquery.datatables/tsconfig.json
@@ -6,7 +6,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "target": "es6",
-        "noImplicitAny": false,
+        "noImplicitAny": true,
         "strictNullChecks": false,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
Updated jquery.dataTables for 1.10.8

Release Notes: https://cdn.datatables.net/1.10.8/
- Expanded .draw() parameter data type to allow string.
- Added "serverSide" parameter to page.Info() return type.
- $.fn.dataTable.tables() can now return instance of DataTables API.
- Added rowId option.
- Added row().id() method.
- Added rows().ids() method.
- Added count() method.
- Added 'numbers' paging option.
- Resolved implicit 'any' instances in test file.
- Attempt to clarify use of $.fn.dataTable.tables() method in test file.

Note: rows().every(), columns().every(), cells().every() parameter list was incorrectly updated in the 1.10.6 version of this file. The parameters listed apply to 1.10.8.
Note: the added 'postfix' option to 'number' renderer appears to be used internally.
