### PR TITLE
Dedup createElement overloads in react/index.d.ts.

### DIFF
--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -124,7 +124,7 @@ declare namespace __React {
         props?: P & ClassAttributes<T>,
         ...children: ReactNode[]): CElement<P, T>;
     function createElement<P>(
-        type: ComponentClass<P> | SFC<P>,
+        type: ComponentClass<P>,
         props?: P & Attributes,
         ...children: ReactNode[]): ReactElement<P>;
 


### PR DESCRIPTION
Please fill in this template.
- [ no ] Prefer to make your PR against the `types-2.0` branch.
- [ no ] The package does not provide its own types, and you can not add them.
- [ yes ] Test the change in your own code.
- [ done ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [ done ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ n/a ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ n/a ] Run `tsc` without errors.
- [ n/a ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [ n/a ] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ n/a ] Increase the version number in the header if appropriate.

There is another createElement method a few lines away that has the same parameter types.
This is causing issues for ts2kt where it results in duplicate Kotlin methods.
