### PR TITLE
Add max argument overload to yargs.demand

### DIFF
--- a/yargs/index.d.ts
+++ b/yargs/index.d.ts
@@ -40,8 +40,7 @@ declare namespace yargs {
         demand(keys: string[], required?: boolean): Argv;
         demand(positionals: number, required?: boolean): Argv;
         demand(positionals: number, msg: string): Argv;
-        demand(positionals: number, max: number): Argv;
-        demand(positionals: number, max: number, msg: string): Argv;
+        demand(positionals: number, max: number, msg?: string): Argv;
 
         require(key: string, msg: string): Argv;
         require(key: string, required: boolean): Argv;

--- a/yargs/index.d.ts
+++ b/yargs/index.d.ts
@@ -40,6 +40,7 @@ declare namespace yargs {
         demand(keys: string[], required?: boolean): Argv;
         demand(positionals: number, required?: boolean): Argv;
         demand(positionals: number, msg: string): Argv;
+        demand(positionals: number, max: number): Argv;
         demand(positionals: number, max: number, msg: string): Argv;
 
         require(key: string, msg: string): Argv;

--- a/yargs/index.d.ts
+++ b/yargs/index.d.ts
@@ -40,6 +40,7 @@ declare namespace yargs {
         demand(keys: string[], required?: boolean): Argv;
         demand(positionals: number, required?: boolean): Argv;
         demand(positionals: number, msg: string): Argv;
+        demand(positionals: number, max: number, msg: string): Argv;
 
         require(key: string, msg: string): Argv;
         require(key: string, required: boolean): Argv;

--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -57,6 +57,9 @@ function divide() {
 function demand_count() {
 	var argv = yargs
 		.demand(2)
+		.demand(2, false)
+		.demand(2, 2)
+		.demand(2, 2, "message")
 		.argv;
 	console.dir(argv);
 }

--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -227,7 +227,7 @@ function completion_sync() {
 
 function completion_async() {
 	var argv = yargs
-		.completion('completion', (current, argv, done) => {
+		.completion('completion', (current: string, argv: any, done: (completion: string[]) => void) => {
 			setTimeout(function () {
 				done([
 					'apple',


### PR DESCRIPTION
Please fill in this template.
- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/yargs/yargs#demandcount-max-msg
- [x] Increase the version number in the header if appropriate. (Not needed.)
