### PR TITLE
[@types/billplz] added TypeScript 2.0 type definitions for node-billplz

### DIFF
--- a/billplz/billplz-tests.ts
+++ b/billplz/billplz-tests.ts
@@ -1,0 +1,44 @@
+import * as Billplz from 'billplz';
+
+const billplz = new Billplz({
+  key: 'your-api-key',
+  endpoint: 'http://localhost/',
+  sandbox: true
+});
+
+// test create collection
+billplz.create_collection({
+  title: 'your-title'
+});
+
+// test create open collection
+billplz.create_collectionOpen({
+  title: 'your-title',
+  description: 'your-description',
+  amount: 100
+});
+
+// test create bill
+billplz.create_bill({
+  collection_id: 'your-collection-id',
+  description: 'your-description',
+  email: 'your-email',
+  mobile: 12345,
+  name: 'your-name',
+  amount: 100,
+  callback_url: 'https://example.com/webhook/',
+  redirect_url: 'https://example.com/done',
+  due_at: '0000-00-00'
+});
+
+// test get bill
+billplz.get_bill('your-bill-id');
+
+// test delete bill
+billplz.delete_bill('your-bill-id');
+
+// test change collection status
+billplz.change_collection_status('your-collection-id', 'status-here');
+
+// test registration check
+billplz.registration_check('your-bank-account-number');

--- a/billplz/index.d.ts
+++ b/billplz/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Akim <https://github.com/Akim95>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module Billplz {
+declare namespace Billplz {
     // api options type
     interface BillplzOptions {
         key: string;

--- a/billplz/index.d.ts
+++ b/billplz/index.d.ts
@@ -1,0 +1,78 @@
+// Type definitions for billplz 1.0.2
+// Project: https://github.com/suhz/node-billplz
+// Definitions by: Akim <https://github.com/Akim95>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module Billplz {
+    // api options type
+    interface BillplzOptions {
+        key: string;
+        endpoint?: string;
+        sandbox?: boolean;
+    }
+
+    // collection type
+    interface CollectionArguments {
+        title: string;
+    }
+
+    // open collection type
+    interface OpenCollectionArguments {
+        title: string;
+        description: string;
+        amount: number;
+        fixed_amount?: boolean;
+        fixed_quantity?: boolean;
+        payment_button?: string;
+        reference_1_label?: string
+        reference_2_label?: string;
+        email_link?: string;
+        tax?: number;
+    }
+
+    // bill type
+    interface BillArguments {
+        collection_id: string;
+        email: string;
+        mobile: number;
+        name: string;
+        amount: number;
+        callback_url: string;
+        description: string;
+        due_at?: string;
+        redirect_url?: string;
+        deliver?: boolean;
+        reference_1_label?: string;
+        reference_1?: string;
+        reference_2_label?: string;
+        reference_2?: string;
+    }
+}
+
+declare class Billplz {
+    // constructor
+    constructor(options: string | Billplz.BillplzOptions);
+
+    // create_collection
+    create_collection(title: Billplz.CollectionArguments, callback?: (res: any, err: any) => void): void;
+
+    // create collectionOpen
+    create_collectionOpen(args: Billplz.OpenCollectionArguments, callback?: (res: any, err: any) => void): void;
+
+    // create bill
+    create_bill(args: Billplz.BillArguments, callback?: (res: any, err: any) => void): void;
+
+    // get bill
+    get_bill(billId: string, callback?: (res: any, err: any) => void): void;
+
+    // delete bill
+    delete_bill(billId: string, callback?: (res: any, err: any) => void): void;
+
+    // change_collection status
+    change_collection_status(collectionId: string, status: string, callback?: (res: any, err: any) => void): void;
+
+    // registration check
+    registration_check(bankAccountNumber: string, callback?: (res: any, err: any) => void): void;
+}
+
+export = Billplz;

--- a/billplz/tsconfig.json
+++ b/billplz/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "billplz-tests.ts"
+    ]
+}


### PR DESCRIPTION
Please fill in this template.
- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Run `tsc` without errors.
- [x] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.
