### PR TITLE
Fix return type of `config()`, add documentation

### DIFF
--- a/dotenv/dotenv-tests.ts
+++ b/dotenv/dotenv-tests.ts
@@ -1,15 +1,19 @@
-
-
 import dotenv = require('dotenv');
 
-dotenv.config({
+// typically, result will be an Object
+let env = dotenv.config({
     silent: true
+});
+
+// ... but it might also be `false`
+let result = dotenv.config({
+    path: '.non-existing-env'
 });
 
 dotenv.config({
     path: '.env'
-})
+});
 
 dotenv.config({
     encoding: 'utf8'
-})
+});

--- a/dotenv/index.d.ts
+++ b/dotenv/index.d.ts
@@ -1,12 +1,35 @@
 // Type definitions for dotenv 2.0.0
 // Project: https://github.com/motdotla/dotenv
-// Definitions by: Jussi Kinnula <https://github.com/jussikinnula/>
-// Definitions: https://github.com/jussikinnula/DefinitelyTyped
+// Definitions by: Borek Bernard <https://github.com/borekb>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function config(options?: dotenvOptions): boolean;
+/**
+ * Loads `.env` into `process.env`.
+ *
+ * @param options
+ * @return Object Object with the parsed keys and values, e.g., 'KEY=value' becomes { KEY: 'value' }
+ */
+export function config(options?: DotenvOptions): Object | false;
 
-interface dotenvOptions {
+export interface DotenvOptions {
+    /**
+     * Dotenv outputs a warning to your console if missing a .env file. Suppress this warning using silent.
+     *
+     * @default false
+     */
     silent?: boolean;
+
+    /**
+     * You can specify a custom path if your file containing environment variables is named or located differently.
+     *
+     * @default '.env'
+     */
     path?: string;
+
+    /**
+     * You may specify the encoding of your file containing environment variables using this option.
+     *
+     * @default 'utf8'
+     */
     encoding?: string;
 }

--- a/dotenv/index.d.ts
+++ b/dotenv/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for dotenv 2.0.0
 // Project: https://github.com/motdotla/dotenv
-// Definitions by: Borek Bernard <https://github.com/borekb>
+// Definitions by: Jussi Kinnula <https://github.com/jussikinnula/>, Borek Bernard <https://github.com/borekb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**

--- a/dotenv/tsconfig.json
+++ b/dotenv/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "noImplicitAny": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
The return type is `Object | false`, not `boolean`, see https://github.com/motdotla/dotenv/blob/v2.0.0/lib/main.js#L36 and https://github.com/motdotla/dotenv/blob/v2.0.0/lib/main.js#L41
