### PR TITLE
Add Fluid app type definitions

### DIFF
--- a/fluidapp/fluidapp-tests.ts
+++ b/fluidapp/fluidapp-tests.ts
@@ -1,0 +1,43 @@
+/// <reference path="index-userscript.d.ts" />
+
+// Setting Dock badge
+window.fluid.dockBadge = "10";
+
+// Setting Dock menu items
+window.fluid.addDockMenuItem("mytitle", () => {});
+window.fluid.removeDockMenuItem("mytitle");
+
+// Showing Growl notifications
+window.fluid.showGrowlNotification({
+    title: "title",
+    description: "description",
+    priority: 1,
+    sticky: false,
+    identifier: "foo",
+    onclick: () => {},
+    icon: new HTMLImageElement()
+});
+window.fluid.showGrowlNotification({
+    icon: ""
+});
+
+// (Un)hide SSB application
+window.fluid.hide();
+window.fluid.unhide();
+
+// Activate/terminate SSB application
+window.fluid.activate();
+window.fluid.terminate();
+
+// Eval local JavaScript files
+window.fluid.include("");
+
+// Get SSB application path values
+const applicationPath = window.fluid.applicationPath;
+const resourcePath = window.fluid.resourcePath;
+const userscriptPath = window.fluid.userscriptPath;
+
+// Get user attention
+window.fluid.requestUserAttention();
+window.fluid.beep();
+window.fluid.playSound("Basso");

--- a/fluidapp/index-userscript.d.ts
+++ b/fluidapp/index-userscript.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for Fluid 1.8.5
+// Project: http://fluidapp.com
+// Definitions by: Chris Long <https://github.com/cglong>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="index.d.ts" />
+
+declare namespace FluidApp {
+    interface Fluid {
+        applicationPath: string;
+        resourcePath: string;
+        userscriptPath: string;
+
+        activate(): any;
+        hide(): any;
+        include(path: string): any;
+        terminate(): any;
+        unhide(): any;
+    }
+}

--- a/fluidapp/index.d.ts
+++ b/fluidapp/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for Fluid 1.8.5
+// Project: http://fluidapp.com
+// Definitions by: Chris Long <https://github.com/cglong>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface Window {
+    fluid: FluidApp.Fluid;
+}
+
+declare namespace FluidApp {
+    interface Fluid {
+        dockBadge: string;
+
+        addDockMenuItem(title: string, onClickHandler: () => any): any;
+        beep(): any;
+        playSound(sound: string): any;
+        removeDockMenuItem(title: string): any;
+        requestUserAttention(): any;
+        showGrowlNotification(notification: Notification): any;
+    }
+
+    interface Notification {
+        description?: string;
+        icon?: HTMLImageElement | string;
+        identifier?: string;
+        onclick?: () => any;
+        priority?: number;
+        sticky?: boolean;
+        title?: string;
+    }
+}

--- a/fluidapp/tsconfig.json
+++ b/fluidapp/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "index-userscript.d.ts",
+        "fluidapp-tests.ts"
+    ]
+}


### PR DESCRIPTION
Adds type definitions for the [Fluid](http://fluidapp.com/) SSB macOS application. Note that `index.d.ts` is used by webapp developers and end-users, while the methods/properties defined in `index-userscript.d.ts` are restricted for usage by end-users writing personal userscripts to inject at runtime using the Fluid UI.

---

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Run `tsc` without errors.
- [x] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.
