### PR TITLE
q: add the `fulfill` method of deferreds (undocumented)

### DIFF
--- a/q/index.d.ts
+++ b/q/index.d.ts
@@ -32,6 +32,8 @@ declare namespace Q {
         reject(reason: any): void;
         notify(value: any): void;
         makeNodeResolver(): (reason: any, value: T) => void;
+        /** An undocumented method. Use the `resolve` method instead.  */
+        fulfill(value: T): void;
     }
 
     interface Promise<T> {

--- a/q/q-tests.ts
+++ b/q/q-tests.ts
@@ -20,6 +20,8 @@ Q.when(delay(1000), function (val: void) {
 // Note from Q documentation: a deferred can be resolved with a value or a promise.
 var otherPromise = Q.defer<string>().promise;
 Q.defer<string>().resolve(otherPromise);
+// An undocumented method. Use `resolve` instead.
+Q.defer<string>().fulfill('foo');
 
 Q.timeout(Q(new Date()), 1000, "My dates never arrived. :(").then(d => d.toJSON());
 


### PR DESCRIPTION
q: The `fulfill` method of deferreds is undocumented, but it's used by some projects. So the type definitions are needed.

Please fill in this template.
- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: There is no link to API docs. A link to the implementation: https://github.com/kriskowal/q/blob/01252cbe917178f5935cbe2a1ab43e12934c7057/q.js#L626
- [x] Increase the version number in the header if appropriate.
