### PR TITLE
Corrected Typing for Creatable OptionCreator Arg on Types-2.0

### DIFF
--- a/react-select/index.d.ts
+++ b/react-select/index.d.ts
@@ -356,7 +356,7 @@ declare namespace ReactSelectClass {
         /**
          * factory to create new options
          */
-        newOptionCreator?: (input: string) => Option;
+        newOptionCreator?: (arg: { label: string, labelKey: string, valueKey: string }) => Option;
 
         /**
          * Creates prompt/placeholder for option text.


### PR DESCRIPTION
Simple type fix, reference code: https://github.com/JedWatson/react-select/blob/master/src/Creatable.js#L237

Re submission of #12276 against the correct branch
