### PR TITLE
Allow passing state and ownProps to factory function mapStateToProps

### DIFF
--- a/react-redux/react-redux-tests.tsx
+++ b/react-redux/react-redux-tests.tsx
@@ -262,6 +262,17 @@ function mapStateToProps3(state: TodoState, ownProps: TodoProps): TodoState {
 
 connect(mapStateToProps3)(TodoApp);
 
+// Allow passing state and ownProps arguments to factory function makeMapStateToProps
+function makeMapStateToProps(mState: any, mOwnProps: TodoProps) {
+    // do preparation work that should be done once for every connected container instance here (e.g. memoized selectors),
+    // then...
+
+    // return some mapStateToProps function like usual
+    return mapStateToProps3;
+}
+
+connect<TodoState, {}, TodoProps>(makeMapStateToProps)(TodoApp);
+
 // Inject todos of a specific user depending on props, and inject props.userId into the action
 
 //function mapStateToProps(state) {

--- a/react-redux/react-redux.d.ts
+++ b/react-redux/react-redux.d.ts
@@ -49,16 +49,18 @@ declare namespace ReactRedux {
   export function connect(): InferableComponentDecorator;
 
   export function connect<TStateProps, TDispatchProps, TOwnProps>(
-    mapStateToProps: FuncOrSelf<MapStateToProps<TStateProps, TOwnProps>>,
+    mapStateToProps: FactoryFuncOrSelf<MapStateToProps<TStateProps, TOwnProps>, TOwnProps>,
     mapDispatchToProps?: FuncOrSelf<MapDispatchToPropsFunction<TDispatchProps, TOwnProps>|MapDispatchToPropsObject>
   ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
 
   export function connect<TStateProps, TDispatchProps, TOwnProps>(
-    mapStateToProps: FuncOrSelf<MapStateToProps<TStateProps, TOwnProps>>,
+    mapStateToProps: FactoryFuncOrSelf<MapStateToProps<TStateProps, TOwnProps>, TOwnProps>,
     mapDispatchToProps: FuncOrSelf<MapDispatchToPropsFunction<TDispatchProps, TOwnProps>|MapDispatchToPropsObject>,
     mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps>,
     options?: Options
   ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
+
+  type FactoryFuncOrSelf<TMapStateToProps, TOwnProps> = TMapStateToProps | ((state?: any, ownProps?: TOwnProps) => TMapStateToProps);
 
   type FuncOrSelf<T> = T | (() => T);
 


### PR DESCRIPTION
To do per container instance preparation, using a factory function that can make use of state and ownProps arguments is very helpful.

For example when using the reselect library to use [non shared memoized selectors](https://github.com/reactjs/reselect#accessing-react-props-in-selectors) (one per instance).