### PR TITLE
Fix date-fns version

### DIFF
--- a/date-fns/index.d.ts
+++ b/date-fns/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for date-fns v2.5.1
+// Type definitions for date-fns v1.9.0
 // Project: https://date-fns.org/
 // Definitions by: Matt Lewis <https://github.com/mattlewis92>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
There was a typo in the version number in the last PR, ideally `@types/date-fns#2.5.1` would be unpublished from npm

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/date-fns/date-fns
- [x] Increase the version number in the header if appropriate.

