### PR TITLE
[codemirror] line argument is an object, not a primitive

### DIFF
--- a/codemirror/index.d.ts
+++ b/codemirror/index.d.ts
@@ -393,8 +393,8 @@ declare namespace CodeMirror {
 
         /** Fired whenever a line is (re-)rendered to the DOM. Fired right after the DOM element is built, before it is added to the document.
         The handler may mess with the style of the resulting element, or add event handlers, but should not try to change the state of the editor. */
-        on(eventName: 'renderLine', handler: (instance: CodeMirror.Editor, line: number, element: HTMLElement) => void ): void;
-        off(eventName: 'renderLine', handler: (instance: CodeMirror.Editor, line: number, element: HTMLElement) => void ): void;
+        on(eventName: 'renderLine', handler: (instance: CodeMirror.Editor, line: CodeMirror.LineHandle, element: HTMLElement) => void ): void;
+        off(eventName: 'renderLine', handler: (instance: CodeMirror.Editor, line: CodeMirror.LineHandle, element: HTMLElement) => void ): void;
 
         /** Expose the state object, so that the Editor.state.completionActive property is reachable*/
         state: any;
@@ -1240,4 +1240,3 @@ declare namespace CodeMirror {
       }
     }
 }
-


### PR DESCRIPTION
- [x] Prefer to make your PR against the `types-2.0` branch.
- ~~[ ] The package does not provide its own types, and you can not add them.~~
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://codemirror.net/doc/manual.html#events

This is the signature for `renderLine`:

<img width="635" src="https://cloud.githubusercontent.com/assets/359239/19874695/548986e4-9f84-11e6-9ee3-4b3a54527072.png">

- ~~[ ] Increase the version number in the header if appropriate.~~

