### PR TITLE
New reference path for 'electron' directory

### DIFF
--- a/electron-devtools-installer/electron-devtools-installer-tests.ts
+++ b/electron-devtools-installer/electron-devtools-installer-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path="../github-electron/github-electron.d.ts" />
+/// <reference path="../electron/github-electron.d.ts" />
 /// <reference path="electron-devtools-installer.d.ts" />
 
 import installExtension, {

--- a/electron-json-storage/electron-json-storage-tests.ts
+++ b/electron-json-storage/electron-json-storage-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path="../github-electron/github-electron.d.ts" />
+/// <reference path="../electron/github-electron.d.ts" />
 /// <reference path="electron-json-storage.d.ts" />
 
 import electron = require('electron');

--- a/electron-notifications/electron-notifications.d.ts
+++ b/electron-notifications/electron-notifications.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Daniel Pereira <https://github.com/djpereira>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../github-electron/github-electron.d.ts" />
+/// <reference path="../electron/github-electron.d.ts" />
 
 declare namespace ElectronNotifications {
 

--- a/electron-notify/electron-notify.d.ts
+++ b/electron-notify/electron-notify.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Daniel Pereira <https://github.com/djpereira>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../github-electron/github-electron.d.ts" />
+/// <reference path="../electron/github-electron.d.ts" />
 
 /** Nice and simple notifications for electron apps */
 declare module 'electron-notify' {

--- a/electron-window-state/electron-window-state.d.ts
+++ b/electron-window-state/electron-window-state.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: rhysd <https://github.com/rhysd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../github-electron/github-electron.d.ts" />
+/// <reference path="../electron/github-electron.d.ts" />
 
 declare namespace ElectronWindowState {
 	interface WindowState {

--- a/menubar/menubar.d.ts
+++ b/menubar/menubar.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: rhysd <https://rhysd.github.io>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../github-electron/github-electron.d.ts" />
+/// <reference path="../electron/github-electron.d.ts" />
 /// <reference path="../node/node.d.ts" />
 
 declare namespace Menubar {


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: N/A
- [x] Increase the version number in the header if appropriate.

I fixed refererence path because 'github-electron' directory was deprecated. I'll create a PR for new  types-2.0 branch as well.

This should fix below. `@types/github-electron` may not exist.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/11867#issuecomment-257402569