### PR TITLE
Fix menubar module for types-2.0

### DIFF
--- a/menubar/index.d.ts
+++ b/menubar/index.d.ts
@@ -3,8 +3,8 @@
 // Definitions by: rhysd <https://rhysd.github.io>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../github-electron/github-electron.d.ts" />
-/// <reference path="../node/node.d.ts" />
+/// <reference types="electron" />
+/// <reference types="node" />
 
 declare namespace Menubar {
 	type Position

--- a/menubar/menubar-tests.ts
+++ b/menubar/menubar-tests.ts
@@ -1,5 +1,3 @@
-/// <reference path="./menubar.d.ts" />
-
 import * as menubar from "menubar";
 
 var mb1 = menubar();

--- a/menubar/tsconfig.json
+++ b/menubar/tsconfig.json
@@ -1,0 +1,20 @@
+
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "menubar-tests.ts"
+    ]
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: N/A
- [x] Increase the version number in the header if appropriate.

I fixed refererence path because 'github-electron' directory was removed.

Fixed this issue comment: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/11867#issuecomment-257402569