### PR TITLE
[node/net] Fix ordering of Server.listen definitions

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1933,9 +1933,9 @@ declare module "net" {
         listen(port: number, listeningListener?: Function): Server;
         listen(path: string, backlog?: number, listeningListener?: Function): Server;
         listen(path: string, listeningListener?: Function): Server;
+        listen(options: ListenOptions, listeningListener?: Function): Server;
         listen(handle: any, backlog?: number, listeningListener?: Function): Server;
         listen(handle: any, listeningListener?: Function): Server;
-        listen(options: ListenOptions, listeningListener?: Function): Server;
         close(callback?: Function): Server;
         address(): { port: number; family: string; address: string; };
         getConnections(cb: (error: Error, count: number) => void): void;


### PR DESCRIPTION
The version of `Server.listen` that takes a `ListenOptions` as the first argument should come before the versions that take `any` as the first argument. For example, even if a `ListenOptions` object is given, VSCode will assume it is `any` in its helper text. I find that not as preferable for type-safety reasons ( avoid all `any`s 😉  ).

I would have done this to the `types-2.0` branch, but development on `node.d.ts` still seems active on `master`.