### PR TITLE
[material-ui] Add boolean for muiTheme.userAgent

### DIFF
--- a/material-ui/index.d.ts
+++ b/material-ui/index.d.ts
@@ -141,7 +141,7 @@ declare namespace __MaterialUI {
             fontFamily?: string;
             palette?: ThemePalette;
             isRtl?: boolean;
-            userAgent?: string;
+            userAgent?: string | boolean;
             zIndex?: zIndex;
             baseTheme?: RawTheme;
             rawTheme?: RawTheme;


### PR DESCRIPTION
It turns out that `muiTheme.userAgent` supports booleans as well. This is used when you want to disable the autoprefixer functionality: https://github.com/callemall/material-ui/blob/ccf712c5733508784cd709c18c29059542d6aad1/src/utils/autoprefixer.js#L20