### PR TITLE
Dedup createElement overloads in react/index.d.ts.

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -108,7 +108,7 @@ declare namespace React {
         type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>): CFactory<P, ClassicComponent<P, ComponentState>>;
     function createFactory<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
         type: ClassType<P, T, C>): CFactory<P, T>;
-    function createFactory<P>(type: ComponentClass<P> | SFC<P>): Factory<P>;
+    function createFactory<P>(type: ComponentClass<P>): Factory<P>;
 
     function createElement<P extends DOMAttributes<T>, T extends Element>(
         type: string,
@@ -127,7 +127,7 @@ declare namespace React {
         props?: P & ClassAttributes<T>,
         ...children: ReactNode[]): CElement<P, T>;
     function createElement<P>(
-        type: ComponentClass<P> | SFC<P>,
+        type: ComponentClass<P>,
         props?: P & Attributes,
         ...children: ReactNode[]): ReactElement<P>;
 

--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -59,22 +59,22 @@ declare namespace React {
     // ----------------------------------------------------------------------
 
     interface Factory<P> {
-        (props?: P & Attributes, ...children: ReactNode[]): ReactElement<P>;
+        (props?: Attributes & P, ...children: ReactNode[]): ReactElement<P>;
     }
 
     interface SFCFactory<P> {
-        (props?: P & Attributes, ...children: ReactNode[]): SFCElement<P>;
+        (props?: Attributes & P, ...children: ReactNode[]): SFCElement<P>;
     }
 
     interface ComponentFactory<P, T extends Component<P, ComponentState>> {
-        (props?: P & ClassAttributes<T>, ...children: ReactNode[]): CElement<P, T>;
+        (props?: ClassAttributes<T> & P, ...children: ReactNode[]): CElement<P, T>;
     }
 
     type CFactory<P, T extends Component<P, ComponentState>> = ComponentFactory<P, T>;
     type ClassicFactory<P> = CFactory<P, ClassicComponent<P, ComponentState>>;
 
     interface DOMFactory<P extends DOMAttributes<T>, T extends Element> {
-        (props?: P & ClassAttributes<T> | null, ...children: ReactNode[]): DOMElement<P, T>;
+        (props?: ClassAttributes<T> & P | null, ...children: ReactNode[]): DOMElement<P, T>;
     }
 
     interface HTMLFactory<T extends HTMLElement> extends DOMFactory<HTMLAttributes<T>, T> {
@@ -112,28 +112,28 @@ declare namespace React {
 
     function createElement<P extends DOMAttributes<T>, T extends Element>(
         type: string,
-        props?: P & ClassAttributes<T>,
+        props?: ClassAttributes<T> & P,
         ...children: ReactNode[]): DOMElement<P, T>;
     function createElement<P>(
         type: SFC<P>,
-        props?: P & Attributes,
+        props?: Attributes & P,
         ...children: ReactNode[]): SFCElement<P>;
     function createElement<P>(
         type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>,
-        props?: P & ClassAttributes<ClassicComponent<P, ComponentState>>,
+        props?: ClassAttributes<ClassicComponent<P, ComponentState>> & P,
         ...children: ReactNode[]): CElement<P, ClassicComponent<P, ComponentState>>;
     function createElement<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
         type: ClassType<P, T, C>,
-        props?: P & ClassAttributes<T>,
+        props?: ClassAttributes<T> & P,
         ...children: ReactNode[]): CElement<P, T>;
     function createElement<P>(
         type: ComponentClass<P>,
-        props?: P & Attributes,
+        props?: Attributes & P,
         ...children: ReactNode[]): ReactElement<P>;
 
     function cloneElement<P extends DOMAttributes<T>, T extends Element>(
         element: DOMElement<P, T>,
-        props?: P & ClassAttributes<T>,
+        props?: ClassAttributes<T> & P,
         ...children: ReactNode[]): DOMElement<P, T>;
     function cloneElement<P extends Q, Q>(
         element: SFCElement<P>,
@@ -175,7 +175,7 @@ declare namespace React {
         // always pass children as variadic arguments to `createElement`.
         // In the future, if we can define its call signature conditionally
         // on the existence of `children` in `P`, then we should remove this.
-        props: P & { children?: ReactNode };
+        props: { children?: ReactNode } & P;
         state: S;
         context: {};
         refs: {
@@ -2557,41 +2557,41 @@ declare global {
             circle: React.SVGProps;
             clipPath: React.SVGProps;
             defs: React.SVGProps;
-        desc: React.SVGProps;
+            desc: React.SVGProps;
             ellipse: React.SVGProps;
-        feBlend: React.SVGProps;
-        feColorMatrix: React.SVGProps;
-        feComponentTransfer: React.SVGProps;
-        feComposite: React.SVGProps;
-        feConvolveMatrix: React.SVGProps;
-        feDiffuseLighting: React.SVGProps;
-        feDisplacementMap: React.SVGProps;
-        feDistantLight: React.SVGProps;
-        feFlood: React.SVGProps;
-        feFuncA: React.SVGProps;
-        feFuncB: React.SVGProps;
-        feFuncG: React.SVGProps;
-        feFuncR: React.SVGProps;
-        feGaussianBlur: React.SVGProps;
-        feImage: React.SVGProps;
-        feMerge: React.SVGProps;
-        feMergeNode: React.SVGProps;
-        feMorphology: React.SVGProps;
-        feOffset: React.SVGProps;
-        fePointLight: React.SVGProps;
-        feSpecularLighting: React.SVGProps;
-        feSpotLight: React.SVGProps;
-        feTile: React.SVGProps;
-        feTurbulence: React.SVGProps;
-        filter: React.SVGProps;
-        foreignObject: React.SVGProps;
+            feBlend: React.SVGProps;
+            feColorMatrix: React.SVGProps;
+            feComponentTransfer: React.SVGProps;
+            feComposite: React.SVGProps;
+            feConvolveMatrix: React.SVGProps;
+            feDiffuseLighting: React.SVGProps;
+            feDisplacementMap: React.SVGProps;
+            feDistantLight: React.SVGProps;
+            feFlood: React.SVGProps;
+            feFuncA: React.SVGProps;
+            feFuncB: React.SVGProps;
+            feFuncG: React.SVGProps;
+            feFuncR: React.SVGProps;
+            feGaussianBlur: React.SVGProps;
+            feImage: React.SVGProps;
+            feMerge: React.SVGProps;
+            feMergeNode: React.SVGProps;
+            feMorphology: React.SVGProps;
+            feOffset: React.SVGProps;
+            fePointLight: React.SVGProps;
+            feSpecularLighting: React.SVGProps;
+            feSpotLight: React.SVGProps;
+            feTile: React.SVGProps;
+            feTurbulence: React.SVGProps;
+            filter: React.SVGProps;
+            foreignObject: React.SVGProps;
             g: React.SVGProps;
             image: React.SVGProps;
             line: React.SVGProps;
             linearGradient: React.SVGProps;
-        marker: React.SVGProps;
+            marker: React.SVGProps;
             mask: React.SVGProps;
-        metadata: React.SVGProps;
+            metadata: React.SVGProps;
             path: React.SVGProps;
             pattern: React.SVGProps;
             polygon: React.SVGProps;
@@ -2599,13 +2599,13 @@ declare global {
             radialGradient: React.SVGProps;
             rect: React.SVGProps;
             stop: React.SVGProps;
-        switch: React.SVGProps;
+            switch: React.SVGProps;
             symbol: React.SVGProps;
             text: React.SVGProps;
-        textPath: React.SVGProps;
+            textPath: React.SVGProps;
             tspan: React.SVGProps;
             use: React.SVGProps;
-        view: React.SVGProps;
+            view: React.SVGProps;
         }
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [ yes ] Prefer to make your PR against the `types-2.0` branch.
- [ no ] The package does not provide its own types, and you can not add them.
- [ yes ] Test the change in your own code.
- [ done ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [ done ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ n/a ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ n/a ] Run `tsc` without errors.
- [ n/a ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [ n/a ] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ n/a ] Increase the version number in the header if appropriate.

This is causing issues for ts2kt where it results in duplicate Kotlin methods.