### PR TITLE
Treat clipboard as a module

### DIFF
--- a/clipboard/clipboard-tests.ts
+++ b/clipboard/clipboard-tests.ts
@@ -1,4 +1,4 @@
-
+import * as Clipboard from 'clipboard';
 
 var cb1 = new Clipboard('.btn');
 var cb2 = new Clipboard(document.getElementById('id'), {

--- a/clipboard/index.d.ts
+++ b/clipboard/index.d.ts
@@ -3,54 +3,56 @@
 // Definitions by: Andrei Kurosh <https://github.com/impworks>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare class Clipboard {
-    constructor(selector: (string | Element | NodeListOf<Element>), options?: ClipboardOptions);
-
-    /**
-     * Subscribes to events that indicate the result of a copy/cut operation.
-     * @param type {String} Event type ('success' or 'error').
-     * @param handler Callback function.
-     */
-    on(type: "success", handler: (e: ClipboardEvent) => void): this;
-    on(type: "error", handler: (e: ClipboardEvent) => void): this;
-    on(type: string, handler: (e: ClipboardEvent) => void): this;
-
-    /**
-     * Clears all event bindings.
-     */
-    destroy(): void;
-}
-
-interface ClipboardOptions {
-    /**
-     * Overwrites default command ('cut' or 'copy').
-     * @param {Element} elem Current element
-     * @returns {String} Only 'cut' or 'copy'.
-     */
-    action?: (elem: Element) => string;
-
-    /**
-     * Overwrites default target input element.
-     * @param {Element} elem Current element
-     * @returns {Element} <input> element to use.
-     */
-    target?: (elem: Element) => Element;
-
-    /**
-     * Returns the explicit text to copy.
-     * @param {Element} elem Current element
-     * @returns {String} Text to be copied.
-     */
-    text?: (elem: Element) => string;
-}
-
-interface ClipboardEvent {
-    action: string;
-    text: string;
-    trigger: Element;
-    clearSelection(): void;
-}
-
 declare module 'clipboard' {
+    class Clipboard {
+        constructor(selector: (string | Element | NodeListOf<Element>), options?: Clipboard.Options);
+
+        /**
+         * Subscribes to events that indicate the result of a copy/cut operation.
+         * @param type {String} Event type ('success' or 'error').
+         * @param handler Callback function.
+         */
+        on(type: "success", handler: (e: Clipboard.Event) => void): this;
+        on(type: "error", handler: (e: Clipboard.Event) => void): this;
+        on(type: string, handler: (e: Clipboard.Event) => void): this;
+
+        /**
+         * Clears all event bindings.
+         */
+        destroy(): void;
+    }
+
+    namespace Clipboard {
+        interface Options {
+            /**
+             * Overwrites default command ('cut' or 'copy').
+             * @param {Element} elem Current element
+             * @returns {String} Only 'cut' or 'copy'.
+             */
+            action?: (elem: Element) => string;
+
+            /**
+             * Overwrites default target input element.
+             * @param {Element} elem Current element
+             * @returns {Element} <input> element to use.
+             */
+            target?: (elem: Element) => Element;
+
+            /**
+             * Returns the explicit text to copy.
+             * @param {Element} elem Current element
+             * @returns {String} Text to be copied.
+             */
+            text?: (elem: Element) => string;
+        }
+
+        interface Event {
+            action: string;
+            text: string;
+            trigger: Element;
+            clearSelection(): void;
+        }
+    }
+
     export = Clipboard;
 }


### PR DESCRIPTION
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: (see below)
- [x] Increase the version number in the header if appropriate.

Previously clipboard was unable to be imported when the targeting ES6 modules. This resolves the issue and seems to work well. Following the conventions from [ws.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/ws/ws.d.ts).