### PR TITLE
Update index.d.ts

### DIFF
--- a/webdriverio/index.d.ts
+++ b/webdriverio/index.d.ts
@@ -31,52 +31,86 @@ declare namespace WebdriverIO {
     // Action
     export interface Client<T> {
         addValue(selector: string, value: string | number): Client<void>;
+        addValue(value: string | number): Client<void>;
         addValue<P>(
             selector: string,
             value: string | number,
             callback: (err: any) => P
         ): Client<P>;
+        addValue<P>(
+            value: string | number,
+            callback: (err: any) => P
+        ): Client<P>;
 
         clearElement(selector: string): Client<void>;
+        clearElement(): Client<void>;
         clearElement<P>(
             selector: string,
             callback: (err: any) => P
         ): Client<P>;
+        clearElement<P>(
+            callback: (err: any) => P
+        ): Client<P>;
 
         click(selector: string): Client<void>;
+        click(): Client<void>;
         click<P>(
             selector: string,
             callback: (err: any) => P
         ): Client<P>;
+        click<P>(
+            callback: (err: any) => P
+        ): Client<P>;
 
         doubleClick(selector: string): Client<void>;
+        doubleClick(): Client<void>;
         doubleClick<P>(
             selector: string,
             callback: (err: any) => P
         ): Client<P>;
+        doubleClick<P>(
+            callback: (err: any) => P
+        ): Client<P>;
 
         dragAndDrop(sourceElem: string, destinationElem: string): Client<void>;
+        dragAndDrop(destinationElem: string): Client<void>;
         dragAndDrop<P>(
             sourceElem: string,
             destinationElem: string, callback: (err: any) => P
         ): Client<P>;
+        dragAndDrop<P>(
+            destinationElem: string, callback: (err: any) => P
+        ): Client<P>;
 
         leftClick(selector: string): Client<void>;
+        leftClick(): Client<void>;
         leftClick<P>(
             selector: string,
             callback: (err: any) => P
         ): Client<P>;
+        leftClick<P>(
+            callback: (err: any) => P
+        ): Client<P>;
 
         middleClick(selector: string): Client<void>;
+        middleClick(): Client<void>;
         middleClick<P>(
             selector: string,
             callback: (err: any) => P
         ): Client<P>;
+        middleClick<P>(
+            callback: (err: any) => P
+        ): Client<P>;
 
         moveToObject(selector: string): Client<void>;
+        moveToObject(): Client<void>;
         moveToObject(selector: string, xoffset: number, yoffset: number): Client<void>;
+        moveToObject(xoffset: number, yoffset: number): Client<void>;
         moveToObject<P>(
             selector: string,
+            callback: (err: any) => P
+        ): Client<P>;
+        moveToObject<P>(
             callback: (err: any) => P
         ): Client<P>;
         moveToObject<P>(
@@ -85,38 +119,68 @@ declare namespace WebdriverIO {
             yoffset: number,
             callback: (err: any) => P
         ): Client<P>;
+        moveToObject<P>(
+            xoffset: number,
+            yoffset: number,
+            callback: (err: any) => P
+        ): Client<P>;
 
         rightClick(selector: string): Client<void>;
+        rightClick(): Client<void>;
         rightClick<P>(
             selector: string,
             callback: (err: any) => P
         ): Client<P>;
+        rightClick<P>(
+            callback: (err: any) => P
+        ): Client<P>;
 
         selectByAttribute(selector: string, attribute: string, value: string): Client<void>;
+        selectByAttribute(attribute: string, value: string): Client<void>;
         selectByAttribute<P>(
             selector: string,
             attribute: string,
             value: string,
             callback: (err: any) => P
         ): Client<P>;
+        selectByAttribute<P>(
+            attribute: string,
+            value: string,
+            callback: (err: any) => P
+        ): Client<P>;
 
         selectByIndex(selectElem: string, index: number): Client<void>;
+        selectByIndex(index: number): Client<void>;
         selectByIndex<P>(
             selectElem: string,
             index: number,
             callback: (err: any) => P
         ): Client<P>;
+        selectByIndex<P>(
+            index: number,
+            callback: (err: any) => P
+        ): Client<P>;
 
         selectByValue(selectElem: string, value: string): Client<void>;
+        selectByValue(value: string): Client<void>;
         selectByValue<P>(
             selectElem: string,
             value: string,
             callback: (err: any) => P
         ): Client<P>;
+        selectByValue<P>(
+            value: string,
+            callback: (err: any) => P
+        ): Client<P>;
 
         selectByVisibleText(selectElem: string, text: string): Client<void>;
+        selectByVisibleText(text: string): Client<void>;
         selectByVisibleText<P>(
             selectElem: string,
+            text: string,
+            callback: (err: any) => P
+        ): Client<P>;
+        selectByVisibleText<P>(
             text: string,
             callback: (err: any) => P
         ): Client<P>;
@@ -134,15 +198,24 @@ declare namespace WebdriverIO {
         ): Client<P>;
 
         setValue(selector: string, values: number | string | Array<string>): Client<void>;
+        setValue(values: number | string | Array<string>): Client<void>;
         setValue<P>(
             selector: string,
             values: number | string | Array<string>,
             callback: (err: any) => P
         ): Client<void>;
+        setValue<P>(
+            values: number | string | Array<string>,
+            callback: (err: any) => P
+        ): Client<void>;
 
         submitForm(selector: string): Client<void>;
+        submitForm(): Client<void>;
         submitForm<P>(
             selector: string,
+            callback: (err: any) => P
+        ): Client<void>;
+        submitForm<P>(
             callback: (err: any) => P
         ): Client<void>;
     }
@@ -277,23 +350,38 @@ declare namespace WebdriverIO {
     // Property
     export interface Client<T> {
         getAttribute(selector: string, attributeName: string): Client<string | string[]>;
+        getAttribute(attributeName: string): Client<string | string[]>;
         getAttribute<P>(
             selector: string,
             attributeName: string,
             callback: (err: any, attribute: string | string[]) => P
         ): Client<P>;
+        getAttribute<P>(
+            attributeName: string,
+            callback: (err: any, attribute: string | string[]) => P
+        ): Client<P>;
 
         getCssProperty(selector: string, cssProperty: string): Client<CssProperty | CssProperty[]>;
+        getCssProperty(cssProperty: string): Client<CssProperty | CssProperty[]>;
         getCssProperty<P>(
             selector: string,
             cssProperty: string,
             callback: (err: any, cssProperty: CssProperty | CssProperty[]) => P
         ): Client<P>;
+        getCssProperty<P>(
+            cssProperty: string,
+            callback: (err: any, cssProperty: CssProperty | CssProperty[]) => P
+        ): Client<P>;
 
         getElementSize(selector: string): Client<Size | Size[]>;
+        getElementSize(): Client<Size | Size[]>;
         getElementSize(selector: string, dimension: string): Client<number | number[]>;
+        getElementSize(dimension: string): Client<number | number[]>;
         getElementSize<P>(
             selector: string,
+            callback: (err: any, size: Size | Size[]) => P
+        ): Client<P>;
+        getElementSize<P>(
             callback: (err: any, size: Size | Size[]) => P
         ): Client<P>;
         getElementSize<P>(
@@ -301,10 +389,18 @@ declare namespace WebdriverIO {
             dimension: string,
             callback: (err: any, elementSize: number | number[]) => P
         ): Client<P>;
+        getElementSize<P>(
+            dimension: string,
+            callback: (err: any, elementSize: number | number[]) => P
+        ): Client<P>;
 
         getHTML(selector: string, includeSelectorTag?: boolean): Client<string | string[]>;
+        getHTML(includeSelectorTag?: boolean): Client<string | string[]>;
         getHTML<P>(
             selector: string,
+            callback: (err: any, html: string | string[]) => P
+        ): Client<P>;
+        getHTML<P>(
             callback: (err: any, html: string | string[]) => P
         ): Client<P>;
         getHTML<P>(
@@ -312,11 +408,20 @@ declare namespace WebdriverIO {
             includeSelectorTag: boolean,
             callback: (err: any, html: string | string[]) => P
         ): Client<P>;
+        getHTML<P>(
+            includeSelectorTag: boolean,
+            callback: (err: any, html: string | string[]) => P
+        ): Client<P>;
 
         getLocation(selector: string): Client<Size>;
+        getLocation(): Client<Size>;
         getLocation(selector: string, axis: string): Client<number>;
+        getLocation(axis: string): Client<number>;
         getLocation<P>(
             selector: string,
+            callback: (err: any, size: Size) => P
+        ): Client<P>;
+        getLocation<P>(
             callback: (err: any, size: Size) => P
         ): Client<P>;
         getLocation<P>(
@@ -324,15 +429,28 @@ declare namespace WebdriverIO {
             axis: string,
             callback: (err: any, location: number) => P
         ): Client<P>;
+        getLocation<P>(
+            axis: string,
+            callback: (err: any, location: number) => P
+        ): Client<P>;
 
         getLocationInView(selector: string): Client<Size | Size[]>;
+        getLocationInView(): Client<Size | Size[]>;
         getLocationInView(selector: string, axis: string): Client<number | number[]>;
+        getLocationInView(axis: string): Client<number | number[]>;
         getLocationInView<P>(
             selector: string,
             callback: (err: any, size: Size | Size[]) => P
         ): Client<P>;
         getLocationInView<P>(
+            callback: (err: any, size: Size | Size[]) => P
+        ): Client<P>;
+        getLocationInView<P>(
             selector: string,
+            axis: string,
+            callback: (err: any, location: number | number[]) => P
+        ): Client<P>;
+        getLocationInView<P>(
             axis: string,
             callback: (err: any, location: number | number[]) => P
         ): Client<P>;
@@ -341,14 +459,22 @@ declare namespace WebdriverIO {
         getSource<P>(callback: (err: any, source: string) => P): Client<P>;
 
         getTagName(selector: string): Client<string | string[]>;
+        getTagName(): Client<string | string[]>;
         getTagName<P>(
             selector: string,
             callback: (err: any, tagName: string | string[]) => P
         ): Client<P>;
+        getTagName<P>(
+            callback: (err: any, tagName: string | string[]) => P
+        ): Client<P>;
 
         getText(selector: string): Client<string | string[]>;
+        getText(): Client<string | string[]>;
         getText<P>(
             selector: string,
+            callback: (err: any, text: string | string[]) => P
+        ): Client<P>;
+        getText<P>(
             callback: (err: any, text: string | string[]) => P
         ): Client<P>;
 
@@ -363,8 +489,12 @@ declare namespace WebdriverIO {
         ): Client<P>;
 
         getValue(selector: string): Client<string | string[]>;
+        getValue(): Client<string | string[]>;
         getValue<P>(
             selector: string,
+            callback: (err: any, value: string | string[]) => P
+        ): Client<P>;
+        getValue<P>(
             callback: (err: any, value: string | string[]) => P
         ): Client<P>;
     }
@@ -757,32 +887,52 @@ declare namespace WebdriverIO {
     // State
     export interface Client<T> {
         isEnabled(selector: string): Client<boolean>;
+        isEnabled(): Client<boolean>;
         isEnabled<P>(
             selector: string,
             callback: (err: any, isEnabled: boolean) => P
         ): Client<P>;
+        isEnabled<P>(
+            callback: (err: any, isEnabled: boolean) => P
+        ): Client<P>;
 
         isExisting(selector: string): Client<boolean>;
+        isExisting(): Client<boolean>;
         isExisting<P>(
             selector: string,
             callback: (err: any, isExisting: boolean) => P
         ): Client<P>;
+        isExisting<P>(
+            callback: (err: any, isExisting: boolean) => P
+        ): Client<P>;
 
         isSelected(selector: string): Client<boolean>;
+        isSelected(): Client<boolean>;
         isSelected<P>(
             selector: string,
             callback: (err: any, isSelected: boolean) => P
         ): Client<P>;
+        isSelected<P>(
+            callback: (err: any, isSelected: boolean) => P
+        ): Client<P>;
 
         isVisible(selector: string): Client<boolean>;
+        isVisible(): Client<boolean>;
         isVisible<P>(
             selector: string,
             callback: (err: any, isVisible: boolean) => P
         ): Client<P>;
+        isVisible<P>(
+            callback: (err: any, isVisible: boolean) => P
+        ): Client<P>;
 
         isVisibleWithinViewport(selector: string): Client<boolean>;
+        isVisibleWithinViewport(): Client<boolean>;
         isVisibleWithinViewport<P>(
             selector: string,
+            callback: (err: any, isVisible: boolean) => P
+        ): Client<P>;
+        isVisibleWithinViewport<P>(
             callback: (err: any, isVisible: boolean) => P
         ): Client<P>;
     }
@@ -808,8 +958,13 @@ declare namespace WebdriverIO {
         ): Client<P>;
 
         chooseFile(selector: string, localPath: string): Client<void>;
+        chooseFile(localPath: string): Client<void>;
         chooseFile<P>(
             selector: string,
+            localPath: string,
+            callback: (err: any) => P
+        ): Client<P>;
+        chooseFile<P>(
             localPath: string,
             callback: (err: any) => P
         ): Client<P>;
@@ -847,10 +1002,14 @@ declare namespace WebdriverIO {
         ): Client<P>;
 
         scroll(selector: string): Client<void>;
+        scroll(): Client<void>;
         scroll(selector: string, xoffset: number, yoffset: number): Client<void>;
         scroll(xoffset: number, yoffset: number): Client<void>;
         scroll<P>(
             selector: string,
+            callback: (err: any) => P
+        ): Client<P>;
+        scroll<P>(
             callback: (err: any) => P
         ): Client<P>;
         scroll<P>(
@@ -872,8 +1031,12 @@ declare namespace WebdriverIO {
         ): Client<P>;
 
         waitForEnabled(selector: string, milliseconds?: number, reverse?: boolean): Client<boolean>;
+        waitForEnabled(milliseconds?: number, reverse?: boolean): Client<boolean>;
         waitForEnabled<P>(
             selector: string,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForEnabled<P>(
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
         waitForEnabled<P>(
@@ -882,15 +1045,28 @@ declare namespace WebdriverIO {
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
         waitForEnabled<P>(
+            milliseconds: number,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForEnabled<P>(
             selector: string,
+            milliseconds: number,
+            reverse: boolean,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForEnabled<P>(
             milliseconds: number,
             reverse: boolean,
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
 
         waitForExist(selector: string, milliseconds?: number, reverse?: boolean): Client<boolean>;
+        waitForExist(milliseconds?: number, reverse?: boolean): Client<boolean>;
         waitForExist<P>(
             selector: string,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForExist<P>(
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
         waitForExist<P>(
@@ -899,15 +1075,28 @@ declare namespace WebdriverIO {
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
         waitForExist<P>(
+            milliseconds: number,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForExist<P>(
             selector: string,
+            milliseconds: number,
+            reverse: boolean,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForExist<P>(
             milliseconds: number,
             reverse: boolean,
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
 
         waitForSelected(selector: string, milliseconds?: number, reverse?: boolean): Client<boolean>;
+        waitForSelected(milliseconds?: number, reverse?: boolean): Client<boolean>;
         waitForSelected<P>(
             selector: string,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForSelected<P>(
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
         waitForSelected<P>(
@@ -916,15 +1105,28 @@ declare namespace WebdriverIO {
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
         waitForSelected<P>(
+            milliseconds: number,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForSelected<P>(
             selector: string,
+            milliseconds: number,
+            reverse: boolean,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForSelected<P>(
             milliseconds: number,
             reverse: boolean,
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
 
         waitForText(selector: string, milliseconds?: number, reverse?: boolean): Client<boolean>;
+        waitForText(milliseconds?: number, reverse?: boolean): Client<boolean>;
         waitForText<P>(
             selector: string,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForText<P>(
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
         waitForText<P>(
@@ -933,19 +1135,36 @@ declare namespace WebdriverIO {
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
         waitForText<P>(
+            milliseconds: number,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForText<P>(
             selector: string,
+            milliseconds: number,
+            reverse: boolean,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForText<P>(
             milliseconds: number,
             reverse: boolean,
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
 
         waitForValue(selector: string, milliseconds?: number, reverse?: boolean): Client<boolean>;
+        waitForValue(milliseconds?: number, reverse?: boolean): Client<boolean>;
         waitForValue<P>(
             selector: string,
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
         waitForValue<P>(
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForValue<P>(
             selector: string,
+            milliseconds: number,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForValue<P>(
             milliseconds: number,
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
@@ -955,10 +1174,19 @@ declare namespace WebdriverIO {
             reverse: boolean,
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
+        waitForValue<P>(
+            milliseconds: number,
+            reverse: boolean,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
 
         waitForVisible(selector: string, milliseconds?: number, reverse?: boolean): Client<boolean>;
+        waitForVisible(milliseconds?: number, reverse?: boolean): Client<boolean>;
         waitForVisible<P>(
             selector: string,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForVisible<P>(
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
         waitForVisible<P>(
@@ -967,7 +1195,16 @@ declare namespace WebdriverIO {
             callback: (err: any, enabled: boolean) => P
         ): Client<P>;
         waitForVisible<P>(
+            milliseconds: number,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForVisible<P>(
             selector: string,
+            milliseconds: number,
+            reverse: boolean,
+            callback: (err: any, enabled: boolean) => P
+        ): Client<P>;
+        waitForVisible<P>(
             milliseconds: number,
             reverse: boolean,
             callback: (err: any, enabled: boolean) => P
@@ -1085,3 +1322,4 @@ declare var browser: WebdriverIO.Client<void>;
 declare module "webdriverio" {
     export = WebdriverIO;
 }
+

--- a/webdriverio/index.d.ts
+++ b/webdriverio/index.d.ts
@@ -32,158 +32,44 @@ declare namespace WebdriverIO {
     export interface Client<T> {
         addValue(selector: string, value: string | number): Client<void>;
         addValue(value: string | number): Client<void>;
-        addValue<P>(
-            selector: string,
-            value: string | number,
-            callback: (err: any) => P
-        ): Client<P>;
-        addValue<P>(
-            value: string | number,
-            callback: (err: any) => P
-        ): Client<P>;
 
         clearElement(selector: string): Client<void>;
         clearElement(): Client<void>;
-        clearElement<P>(
-            selector: string,
-            callback: (err: any) => P
-        ): Client<P>;
-        clearElement<P>(
-            callback: (err: any) => P
-        ): Client<P>;
 
         click(selector: string): Client<void>;
         click(): Client<void>;
-        click<P>(
-            selector: string,
-            callback: (err: any) => P
-        ): Client<P>;
-        click<P>(
-            callback: (err: any) => P
-        ): Client<P>;
 
         doubleClick(selector: string): Client<void>;
         doubleClick(): Client<void>;
-        doubleClick<P>(
-            selector: string,
-            callback: (err: any) => P
-        ): Client<P>;
-        doubleClick<P>(
-            callback: (err: any) => P
-        ): Client<P>;
 
         dragAndDrop(sourceElem: string, destinationElem: string): Client<void>;
         dragAndDrop(destinationElem: string): Client<void>;
-        dragAndDrop<P>(
-            sourceElem: string,
-            destinationElem: string, callback: (err: any) => P
-        ): Client<P>;
-        dragAndDrop<P>(
-            destinationElem: string, callback: (err: any) => P
-        ): Client<P>;
 
         leftClick(selector: string): Client<void>;
         leftClick(): Client<void>;
-        leftClick<P>(
-            selector: string,
-            callback: (err: any) => P
-        ): Client<P>;
-        leftClick<P>(
-            callback: (err: any) => P
-        ): Client<P>;
 
         middleClick(selector: string): Client<void>;
         middleClick(): Client<void>;
-        middleClick<P>(
-            selector: string,
-            callback: (err: any) => P
-        ): Client<P>;
-        middleClick<P>(
-            callback: (err: any) => P
-        ): Client<P>;
 
         moveToObject(selector: string): Client<void>;
         moveToObject(): Client<void>;
         moveToObject(selector: string, xoffset: number, yoffset: number): Client<void>;
         moveToObject(xoffset: number, yoffset: number): Client<void>;
-        moveToObject<P>(
-            selector: string,
-            callback: (err: any) => P
-        ): Client<P>;
-        moveToObject<P>(
-            callback: (err: any) => P
-        ): Client<P>;
-        moveToObject<P>(
-            selector: string,
-            xoffset: number,
-            yoffset: number,
-            callback: (err: any) => P
-        ): Client<P>;
-        moveToObject<P>(
-            xoffset: number,
-            yoffset: number,
-            callback: (err: any) => P
-        ): Client<P>;
 
         rightClick(selector: string): Client<void>;
         rightClick(): Client<void>;
-        rightClick<P>(
-            selector: string,
-            callback: (err: any) => P
-        ): Client<P>;
-        rightClick<P>(
-            callback: (err: any) => P
-        ): Client<P>;
 
         selectByAttribute(selector: string, attribute: string, value: string): Client<void>;
         selectByAttribute(attribute: string, value: string): Client<void>;
-        selectByAttribute<P>(
-            selector: string,
-            attribute: string,
-            value: string,
-            callback: (err: any) => P
-        ): Client<P>;
-        selectByAttribute<P>(
-            attribute: string,
-            value: string,
-            callback: (err: any) => P
-        ): Client<P>;
 
         selectByIndex(selectElem: string, index: number): Client<void>;
         selectByIndex(index: number): Client<void>;
-        selectByIndex<P>(
-            selectElem: string,
-            index: number,
-            callback: (err: any) => P
-        ): Client<P>;
-        selectByIndex<P>(
-            index: number,
-            callback: (err: any) => P
-        ): Client<P>;
 
         selectByValue(selectElem: string, value: string): Client<void>;
         selectByValue(value: string): Client<void>;
-        selectByValue<P>(
-            selectElem: string,
-            value: string,
-            callback: (err: any) => P
-        ): Client<P>;
-        selectByValue<P>(
-            value: string,
-            callback: (err: any) => P
-        ): Client<P>;
 
         selectByVisibleText(selectElem: string, text: string): Client<void>;
         selectByVisibleText(text: string): Client<void>;
-        selectByVisibleText<P>(
-            selectElem: string,
-            text: string,
-            callback: (err: any) => P
-        ): Client<P>;
-        selectByVisibleText<P>(
-            text: string,
-            callback: (err: any) => P
-        ): Client<P>;
 
         selectorExecute<P>(
             selectors: string | string[],
@@ -199,25 +85,9 @@ declare namespace WebdriverIO {
 
         setValue(selector: string, values: number | string | Array<string>): Client<void>;
         setValue(values: number | string | Array<string>): Client<void>;
-        setValue<P>(
-            selector: string,
-            values: number | string | Array<string>,
-            callback: (err: any) => P
-        ): Client<void>;
-        setValue<P>(
-            values: number | string | Array<string>,
-            callback: (err: any) => P
-        ): Client<void>;
 
         submitForm(selector: string): Client<void>;
         submitForm(): Client<void>;
-        submitForm<P>(
-            selector: string,
-            callback: (err: any) => P
-        ): Client<void>;
-        submitForm<P>(
-            callback: (err: any) => P
-        ): Client<void>;
     }
 
     // Appium
@@ -260,51 +130,21 @@ declare namespace WebdriverIO {
     // Cookie
     export interface Client<T> {
         deleteCookie(name?: string): Client<void>;
-        deleteCookie<P>(
-            callback: (err: any) => P
-        ): Client<P>;
-        deleteCookie<P>(
-            name: string,
-            callback: (err: any) => P
-        ): Client<P>;
 
         getCookie(): Client<Cookie[]>;
         getCookie(name: string): Client<Cookie>;
-        getCookie<P>(
-            callback: (err: any, cookies: Cookie[]) => P
-        ): Client<P>;
-        getCookie<P>(
-            name: string,
-            callback: (err: any, cookie: Cookie) => P
-        ): Client<P>;
 
         setCookie(cookie: Cookie): Client<void>;
-        setCookie<P>(
-            cookie: Cookie,
-            callback: (err: any) => P
-        ): Client<P>;
     }
 
     export interface Client<T> {
         session(action?: string, sessionId?: string): Client<RawResult<any>>;
-        session<P>(
-            callback: (err: any, result: RawResult<any>) => P
-        ): Client<P>;
 
         getGridNodeDetails(): Client<Object>;
-        getGridNodeDetails<P>(
-            callback: (err: any, details: Object) => P
-        ): Client<P>;
 
         gridProxyDetails(): Client<Object>;
-        gridProxyDetails<P>(
-            callback: (err: any, result: Object) => P
-        ): Client <P>;
 
         gridTestSession(): Client<Object>;
-        gridProxyDetails<P>(
-            callback: (err: any, result: Object) => P
-        ): Client <P>;
     }
 
     // Mobile
@@ -351,152 +191,43 @@ declare namespace WebdriverIO {
     export interface Client<T> {
         getAttribute(selector: string, attributeName: string): Client<string | string[]>;
         getAttribute(attributeName: string): Client<string | string[]>;
-        getAttribute<P>(
-            selector: string,
-            attributeName: string,
-            callback: (err: any, attribute: string | string[]) => P
-        ): Client<P>;
-        getAttribute<P>(
-            attributeName: string,
-            callback: (err: any, attribute: string | string[]) => P
-        ): Client<P>;
 
         getCssProperty(selector: string, cssProperty: string): Client<CssProperty | CssProperty[]>;
         getCssProperty(cssProperty: string): Client<CssProperty | CssProperty[]>;
-        getCssProperty<P>(
-            selector: string,
-            cssProperty: string,
-            callback: (err: any, cssProperty: CssProperty | CssProperty[]) => P
-        ): Client<P>;
-        getCssProperty<P>(
-            cssProperty: string,
-            callback: (err: any, cssProperty: CssProperty | CssProperty[]) => P
-        ): Client<P>;
 
         getElementSize(selector: string): Client<Size | Size[]>;
         getElementSize(): Client<Size | Size[]>;
         getElementSize(selector: string, dimension: string): Client<number | number[]>;
         getElementSize(dimension: string): Client<number | number[]>;
-        getElementSize<P>(
-            selector: string,
-            callback: (err: any, size: Size | Size[]) => P
-        ): Client<P>;
-        getElementSize<P>(
-            callback: (err: any, size: Size | Size[]) => P
-        ): Client<P>;
-        getElementSize<P>(
-            selector: string,
-            dimension: string,
-            callback: (err: any, elementSize: number | number[]) => P
-        ): Client<P>;
-        getElementSize<P>(
-            dimension: string,
-            callback: (err: any, elementSize: number | number[]) => P
-        ): Client<P>;
 
         getHTML(selector: string, includeSelectorTag?: boolean): Client<string | string[]>;
         getHTML(includeSelectorTag?: boolean): Client<string | string[]>;
-        getHTML<P>(
-            selector: string,
-            callback: (err: any, html: string | string[]) => P
-        ): Client<P>;
-        getHTML<P>(
-            callback: (err: any, html: string | string[]) => P
-        ): Client<P>;
-        getHTML<P>(
-            selector: string,
-            includeSelectorTag: boolean,
-            callback: (err: any, html: string | string[]) => P
-        ): Client<P>;
-        getHTML<P>(
-            includeSelectorTag: boolean,
-            callback: (err: any, html: string | string[]) => P
-        ): Client<P>;
 
         getLocation(selector: string): Client<Size>;
         getLocation(): Client<Size>;
         getLocation(selector: string, axis: string): Client<number>;
         getLocation(axis: string): Client<number>;
-        getLocation<P>(
-            selector: string,
-            callback: (err: any, size: Size) => P
-        ): Client<P>;
-        getLocation<P>(
-            callback: (err: any, size: Size) => P
-        ): Client<P>;
-        getLocation<P>(
-            selector: string,
-            axis: string,
-            callback: (err: any, location: number) => P
-        ): Client<P>;
-        getLocation<P>(
-            axis: string,
-            callback: (err: any, location: number) => P
-        ): Client<P>;
 
         getLocationInView(selector: string): Client<Size | Size[]>;
         getLocationInView(): Client<Size | Size[]>;
         getLocationInView(selector: string, axis: string): Client<number | number[]>;
         getLocationInView(axis: string): Client<number | number[]>;
-        getLocationInView<P>(
-            selector: string,
-            callback: (err: any, size: Size | Size[]) => P
-        ): Client<P>;
-        getLocationInView<P>(
-            callback: (err: any, size: Size | Size[]) => P
-        ): Client<P>;
-        getLocationInView<P>(
-            selector: string,
-            axis: string,
-            callback: (err: any, location: number | number[]) => P
-        ): Client<P>;
-        getLocationInView<P>(
-            axis: string,
-            callback: (err: any, location: number | number[]) => P
-        ): Client<P>;
 
         getSource(): Client<string>;
         getSource<P>(callback: (err: any, source: string) => P): Client<P>;
 
         getTagName(selector: string): Client<string | string[]>;
         getTagName(): Client<string | string[]>;
-        getTagName<P>(
-            selector: string,
-            callback: (err: any, tagName: string | string[]) => P
-        ): Client<P>;
-        getTagName<P>(
-            callback: (err: any, tagName: string | string[]) => P
-        ): Client<P>;
 
         getText(selector: string): Client<string | string[]>;
         getText(): Client<string | string[]>;
-        getText<P>(
-            selector: string,
-            callback: (err: any, text: string | string[]) => P
-        ): Client<P>;
-        getText<P>(
-            callback: (err: any, text: string | string[]) => P
-        ): Client<P>;
 
         getTitle(): Client<string>;
-        getTitle<P>(
-            callback: (err: any, title: string) => P
-        ): Client<P>;
 
         getUrl(): Client<string>;
-        getUrl<P>(
-            callback: (err: any, title: string) => P
-        ): Client<P>;
 
         getValue(selector: string): Client<string | string[]>;
         getValue(): Client<string | string[]>;
-        getValue<P>(
-            selector: string,
-            callback: (err: any, value: string | string[]) => P
-        ): Client<P>;
-        getValue<P>(
-            callback: (err: any, value: string | string[]) => P
-        ): Client<P>;
     }
 
     export interface LogEntry {
@@ -543,95 +274,35 @@ declare namespace WebdriverIO {
     // Navigation
     export interface Client<T> {
         back(): Client<void>;
-        back<P>(
-            callback: (err: any) => P
-        ): Client<P>;
 
         forward(): Client<void>;
-        forward<P>(
-            callback: (err: any) => P
-        ): Client<P>;
 
         refresh(): Client<void>;
-        refresh<P>(
-            callback: (err: any) => P
-        ): Client<P>;
 
         url(): Client<RawResult<string>>;
         url(url: string): Client<void>;
-        url<P>(
-            callback: (err: any, result: RawResult<string>) => P
-        ): Client<P>;
-        url<P>(
-            url: string,
-            callback: (err: any) => P
-        ): Client<P>;
     }
 
     // Advanced input
     export interface Client<T> {
         // you probably want to use the click and drag and drop commands instead
         buttonDown(button?: string | Button): Client<void>;
-        buttonDown<P>(
-            callback: (err: any) => P
-        ): Client<P>;
-        buttonDown<P>(
-            button: string | Button,
-            callback: (err: any) => P
-        ): Client<P>;
 
         // you probably want to use the click and drag and drop commands instead
         buttonPress(button?: string | Button): Client<void>;
-        buttonPress<P>(
-            callback: (err: any) => P
-        ): Client<P>;
-        buttonPress<P>(
-            button: string | Button,
-            callback: (err: any) => P
-        ): Client<P>;
 
         // you probably want to use the click and drag and drop commands instead
         buttonUp(button?: string | Button): Client<void>;
-        buttonUp<P>(
-            callback: (err: any) => P
-        ): Client<P>;
-        buttonUp(button?: string | Button): Client<void>;
-        buttonUp<P>(
-            button: string | Button,
-            callback: (err: any) => P
-        ): Client<P>;
 
         // you probably want to use the click and drag and drop commands instead
         doDoubleClick(): Client<void>;
-        doDoubleClick<P>(
-            callback: (err: any) => P
-        ): Client<P>;
 
         // you probably want to use addValue and setValue instead
         keys(value: string | string[]): Client<void>;
-        keys<P>(
-            value: string | string[],
-            callback: (err: any) => P
-        ): Client<P>;
 
         // you probably want to use the moveToObject command instead
         moveTo(id: ElementId, xoffset?: number, yoffset?: number): Client<void>;
         moveTo(xoffset?: number, yoffset?: number): Client<void>;
-        moveTo<P>(
-            id: ElementId,
-            callback: (err: any) => P
-        ): Client<P>;
-        moveTo<P>(
-            id: ElementId,
-            xoffset: number,
-            callback: (err: any) => P
-        ): Client<P>;
-        moveTo<P>(
-            id: ElementId,
-            xoffset: number,
-            yoffset: number,
-            callback: (err: any) => P
-        ): Client<P>;
 
         // touchClick
         // touchDoubleClick
@@ -646,73 +317,24 @@ declare namespace WebdriverIO {
     // Useful Protocol
     export interface Client<T> {
         alertAccept(): Client<void>;
-        alertAccept<P>(
-            callback: (err: any) => P
-        ): Client<P>;
 
         alertDismiss(): Client<void>;
-        alertDismiss<P>(
-            callback: (err: any) => P
-        ): Client<P>;
 
         alertText(text?: string): Client<string>;
-        alertText<P>(
-            callback: (err: any, text: string) => P
-        ): Client<P>;
-        alertText<P>(
-            text: string,
-            callback: (err: any, text: string) => P
-        ): Client<P>;
 
         frame(id: any): Client<void>;
-        frame<P>(
-            id: any,
-            callback: (err: any) => P
-        ): Client<P>;
 
         frameParent(): Client<void>;
-        frameParent<P>(
-            callback: (err: any) => P
-        ): Client<P>;
 
         init(capabilities?: DesiredCapabilities): Client<void>;
-        init<P>(
-            callback: (err: any) => P
-        ): Client<P>;
-        init<P>(
-            capabilities: DesiredCapabilities,
-            callback: (err: any) => P
-        ): Client<P>;
 
         log(type: string): Client<RawResult<LogEntry[]>>;
-        log<P>(
-            type: string,
-            callback: (err: any, result: RawResult<LogEntry[]>) => P
-        ): Client<P>;
 
         logTypes(): Client<RawResult<string[]>>;
-        logTypes<P>(
-            callback: (err: any, result: RawResult<string[]>) => P
-        ): Client<P>;
 
         session(action?: string, sessionId?: string): Client<RawResult<any>>;
-        session<P>(
-            callback: (err: any, result: RawResult<any>) => P
-        ): Client<P>;
-        session<P>(
-            action: string,
-            callback: (err: any, result: RawResult<any>) => P
-        ): Client<P>;
-        session<P>(
-            action: string,
-            sessionId: string,
-            callback: (err: any, result: RawResult<any>) => P
-        ): Client<P>;
 
         sessions(): Client<RawResult<Session[]>>;
-        sessions<P>(
-            callback: (err: any, sessions: RawResult<Session[]>) => P
-        ): Client<P>;
 
         // timeouts
         // timeoutsAsyncScript
@@ -735,116 +357,40 @@ declare namespace WebdriverIO {
     // Element
     export interface Client<T> {
         element(selector: string): Client<RawResult<Element>>;
-        element<P>(
-            selector: string,
-            callback: (err: any, result: RawResult<Element>) => P
-        ): Client<P>;
 
         elementActive(): Client<RawResult<Element>>;
-        elementActive<P>(
-            callback: (err: any, element: Element) => P
-        ): Client<P>;
 
         elementIdAttribute(id: ElementId, attributeName: string): Client<RawResult<string>>;
-        elementIdAttribute<P>(
-            id: ElementId,
-            attributeName: string,
-            callback: (err: any, result: RawResult<string>) => P
-        ): Client<P>;
 
         elementIdClear(id: ElementId): Client<void>;
-        elementIdClear<P>(
-            id: ElementId,
-            callback: (err: any) => P
-        ): Client<P>;
 
         elementIdClick(id: ElementId): Client<void>;
-        elementIdClick<P>(
-            id: ElementId,
-            callback: (err: any) => P
-        ): Client<P>;
 
         elementIdCssProperty(id: ElementId, propertyName: string): Client<RawResult<string>>;
-        elementIdCssProperty<P>(
-            id: ElementId,
-            propertyName: string,
-            callback: (err: any, result: RawResult<string>) => P
-        ): Client<P>;
 
         elementIdDisplayed(id: ElementId): Client<RawResult<boolean>>;
-        elementIdDisplayed<P>(
-            id: ElementId,
-            callback: (err: any, result: RawResult<boolean>) => P
-        ): Client<P>;
 
         elementIdElement(id: ElementId, selector: string): Client<RawResult<Element>>;
-        elementIdElement<P>(
-            id: ElementId,
-            selector: string,
-            callback: (err: any, result: RawResult<Element>) => P
-        ): Client<P>;
 
         elementIdElements(id: ElementId, selector: string): Client<RawResult<Element[]>>;
-        elementIdElements<P>(
-            id: ElementId,
-            selector: string,
-            callback: (err: any, result: RawResult<Element[]>) => P
-        ): Client<P>;
 
         elementIdEnabled(id: ElementId): Client<RawResult<boolean>>;
-        elementIdEnabled<P>(
-            id: ElementId,
-            callback: (err: any, result: RawResult<boolean>) => P
-        ): Client<P>;
 
         elementIdLocation(id: ElementId): Client<RawResult<Location>>;
-        elementIdLocation<P>(
-            id: ElementId,
-            callback: (err: any, result: RawResult<Location>) => P
-        ): Client<P>;
 
         elementIdLocationInView(id: ElementId): Client<RawResult<Location>>;
-        elementIdLocationInView<P>(
-            id: ElementId,
-            callback: (err: any, result: RawResult<Location>) => P
-        ): Client<P>;
 
         elementIdName(id: ElementId): Client<RawResult<string>>;
-        elementIdName<P>(
-            id: ElementId,
-            callback: (err: any, result: RawResult<string>) => P
-        ): Client<P>;
 
         elementIdSelected(id: ElementId): Client<RawResult<boolean>>;
-        elementIdSelected<P>(
-            id: ElementId,
-            callback: (err: any, result: RawResult<boolean>) => P
-        ): Client<P>;
 
         elementIdSize(id: ElementId): Client<RawResult<Size>>;
-        elementIdSize<P>(
-            id: ElementId,
-            callback: (err: any, result: RawResult<Size>) => P
-        ): Client<P>;
 
         elementIdText(id: ElementId): Client<RawResult<string>>;
-        elementIdText<P>(
-            id: ElementId,
-            callback: (err: any, result: RawResult<string>) => P
-        ): Client<P>;
 
         elementIdValue(id: ElementId, values: string | string[]): Client<RawResult<void>>;
-        elementIdValue<P>(
-            id: ElementId,
-            values: string | string[],
-            callback: (err: any, result: RawResult<void>) => P
-        ): Client<P>;
 
         elements(selector: string): Client<RawResult<Element[]>>;
-        elements<P>(
-            selector: string,
-            callback: (err: any, result: RawResult<Element[]>) => P
-        ): Client<P>;
     }
 
     // Unuseful Protocol
@@ -876,10 +422,6 @@ declare namespace WebdriverIO {
 
         // use submitForm instead
         submit(id: ElementId): Client<void>;
-        submit<P>(
-            id: ElementId,
-            callback: (err: any) => P
-        ): Client<P>;
 
         // title
     }
@@ -888,53 +430,18 @@ declare namespace WebdriverIO {
     export interface Client<T> {
         isEnabled(selector: string): Client<boolean>;
         isEnabled(): Client<boolean>;
-        isEnabled<P>(
-            selector: string,
-            callback: (err: any, isEnabled: boolean) => P
-        ): Client<P>;
-        isEnabled<P>(
-            callback: (err: any, isEnabled: boolean) => P
-        ): Client<P>;
 
         isExisting(selector: string): Client<boolean>;
         isExisting(): Client<boolean>;
-        isExisting<P>(
-            selector: string,
-            callback: (err: any, isExisting: boolean) => P
-        ): Client<P>;
-        isExisting<P>(
-            callback: (err: any, isExisting: boolean) => P
-        ): Client<P>;
 
         isSelected(selector: string): Client<boolean>;
         isSelected(): Client<boolean>;
-        isSelected<P>(
-            selector: string,
-            callback: (err: any, isSelected: boolean) => P
-        ): Client<P>;
-        isSelected<P>(
-            callback: (err: any, isSelected: boolean) => P
-        ): Client<P>;
 
         isVisible(selector: string): Client<boolean>;
         isVisible(): Client<boolean>;
-        isVisible<P>(
-            selector: string,
-            callback: (err: any, isVisible: boolean) => P
-        ): Client<P>;
-        isVisible<P>(
-            callback: (err: any, isVisible: boolean) => P
-        ): Client<P>;
 
         isVisibleWithinViewport(selector: string): Client<boolean>;
         isVisibleWithinViewport(): Client<boolean>;
-        isVisibleWithinViewport<P>(
-            selector: string,
-            callback: (err: any, isVisible: boolean) => P
-        ): Client<P>;
-        isVisibleWithinViewport<P>(
-            callback: (err: any, isVisible: boolean) => P
-        ): Client<P>;
     }
 
     export interface CommandHistoryEntry {
@@ -945,270 +452,46 @@ declare namespace WebdriverIO {
     // Utility
     export interface Client<T> {
         addCommand(commandName: string, customMethod: Function, overwrite?: boolean): Client<void>;
-        addCommand<P>(
-            commandName: string,
-            customMethod: Function,
-            callback: (err: any) => P
-        ): Client<P>;
-        addCommand<P>(
-            commandName: string,
-            customMethod: Function,
-            overwrite: boolean,
-            callback: (err: any) => P
-        ): Client<P>;
 
         chooseFile(selector: string, localPath: string): Client<void>;
         chooseFile(localPath: string): Client<void>;
-        chooseFile<P>(
-            selector: string,
-            localPath: string,
-            callback: (err: any) => P
-        ): Client<P>;
-        chooseFile<P>(
-            localPath: string,
-            callback: (err: any) => P
-        ): Client<P>;
 
         debug(): Client<void>;
-        debug<P>(
-            callback: (err: any) => P
-        ): Client<P>;
 
         end(): Client<void>;
-        end<P>(
-            callback: (err: any) => P
-        ): Client<P>;
 
         endAll(): Client<void>;
-        endAll<P>(
-            callback: (err: any) => P
-        ): Client<P>;
 
         getCommandHistory(): Client<CommandHistoryEntry[]>;
-        getCommandHistory<P>(
-            callback: (err: any, history: CommandHistoryEntry[]) => P
-        ): Client<P>;
 
         pause(milliseconds: number): Client<void>;
-        pause<P>(milliseconds: number, callback: (err: any) => P): Client<P>;
 
         saveScreenshot(filename?: string): Client<Buffer>;
-        saveScreenshot<P>(
-            callback: (err: any, screenshot: Buffer) => P
-        ): Client<P>;
-        saveScreenshot<P>(
-            filename: string,
-            callback: (err: any, screenshot: Buffer) => P
-        ): Client<P>;
 
         scroll(selector: string): Client<void>;
         scroll(): Client<void>;
         scroll(selector: string, xoffset: number, yoffset: number): Client<void>;
         scroll(xoffset: number, yoffset: number): Client<void>;
-        scroll<P>(
-            selector: string,
-            callback: (err: any) => P
-        ): Client<P>;
-        scroll<P>(
-            callback: (err: any) => P
-        ): Client<P>;
-        scroll<P>(
-            selector: string,
-            xoffset: number,
-            yoffset: number,
-            callback: (err: any) => P
-        ): Client<P>;
-        scroll<P>(
-            xoffset: number,
-            yoffset: number,
-            callback: (err: any) => P
-        ): Client<P>;
 
         uploadFile(localPath: string): Client<void>;
-        uploadFile<P>(
-            localPath: string,
-            callback: (err: any) => P
-        ): Client<P>;
 
         waitForEnabled(selector: string, milliseconds?: number, reverse?: boolean): Client<boolean>;
         waitForEnabled(milliseconds?: number, reverse?: boolean): Client<boolean>;
-        waitForEnabled<P>(
-            selector: string,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForEnabled<P>(
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForEnabled<P>(
-            selector: string,
-            milliseconds: number,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForEnabled<P>(
-            milliseconds: number,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForEnabled<P>(
-            selector: string,
-            milliseconds: number,
-            reverse: boolean,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForEnabled<P>(
-            milliseconds: number,
-            reverse: boolean,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
 
         waitForExist(selector: string, milliseconds?: number, reverse?: boolean): Client<boolean>;
         waitForExist(milliseconds?: number, reverse?: boolean): Client<boolean>;
-        waitForExist<P>(
-            selector: string,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForExist<P>(
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForExist<P>(
-            selector: string,
-            milliseconds: number,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForExist<P>(
-            milliseconds: number,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForExist<P>(
-            selector: string,
-            milliseconds: number,
-            reverse: boolean,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForExist<P>(
-            milliseconds: number,
-            reverse: boolean,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
 
         waitForSelected(selector: string, milliseconds?: number, reverse?: boolean): Client<boolean>;
         waitForSelected(milliseconds?: number, reverse?: boolean): Client<boolean>;
-        waitForSelected<P>(
-            selector: string,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForSelected<P>(
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForSelected<P>(
-            selector: string,
-            milliseconds: number,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForSelected<P>(
-            milliseconds: number,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForSelected<P>(
-            selector: string,
-            milliseconds: number,
-            reverse: boolean,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForSelected<P>(
-            milliseconds: number,
-            reverse: boolean,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
 
         waitForText(selector: string, milliseconds?: number, reverse?: boolean): Client<boolean>;
         waitForText(milliseconds?: number, reverse?: boolean): Client<boolean>;
-        waitForText<P>(
-            selector: string,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForText<P>(
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForText<P>(
-            selector: string,
-            milliseconds: number,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForText<P>(
-            milliseconds: number,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForText<P>(
-            selector: string,
-            milliseconds: number,
-            reverse: boolean,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForText<P>(
-            milliseconds: number,
-            reverse: boolean,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
 
         waitForValue(selector: string, milliseconds?: number, reverse?: boolean): Client<boolean>;
         waitForValue(milliseconds?: number, reverse?: boolean): Client<boolean>;
-        waitForValue<P>(
-            selector: string,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForValue<P>(
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForValue<P>(
-            selector: string,
-            milliseconds: number,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForValue<P>(
-            milliseconds: number,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForValue<P>(
-            selector: string,
-            milliseconds: number,
-            reverse: boolean,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForValue<P>(
-            milliseconds: number,
-            reverse: boolean,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
 
         waitForVisible(selector: string, milliseconds?: number, reverse?: boolean): Client<boolean>;
         waitForVisible(milliseconds?: number, reverse?: boolean): Client<boolean>;
-        waitForVisible<P>(
-            selector: string,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForVisible<P>(
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForVisible<P>(
-            selector: string,
-            milliseconds: number,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForVisible<P>(
-            milliseconds: number,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForVisible<P>(
-            selector: string,
-            milliseconds: number,
-            reverse: boolean,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
-        waitForVisible<P>(
-            milliseconds: number,
-            reverse: boolean,
-            callback: (err: any, enabled: boolean) => P
-        ): Client<P>;
 
         waitUntil(
             condition: () => boolean | Q.IPromise<boolean>,
@@ -1216,69 +499,24 @@ declare namespace WebdriverIO {
             timeoutMsg?: string,
             interval?: number
         ): Client<boolean>;
-        waitUntil<P>(
-            condition: () => boolean | Q.IPromise<boolean>,
-            timeout?: number,
-            timeoutMsg?: string,
-            interval?: number,
-            callback?: (err: any, enabled: boolean) => P
-        ): Client<P>;
     }
 
     // Window
     export interface Client<T> {
         close(windowHandle?: string): Client<void>;
-        close<P>(
-            callback: (err: any) => P
-        ): Client<P>;
-        close<P>(
-            windowHandle: string,
-            callback: (err: any) => P
-        ): Client<P>;
 
         getCurrentTabId(): Client<string>;
-        getCurrentTabId<P>(
-            callback: (err: any, tabId: string) => P
-        ): Client<P>;
 
         getTabIds(): Client<string[]>;
-        getTabIds<P>(
-            callback: (err: any, tabIds: string[]) => P
-        ): Client<P>;
 
         getViewportSize(): Client<Size>;
         getViewportSize(dimension: string): Client<number>;
-        getViewportSize<P>(
-            callback: (err: any, size: Size) => P
-        ): Client<P>;
-        getViewportSize<P>(
-            dimension: string,
-            callback: (err: any, viewportSize: number) => P
-        ): Client<P>;
 
         newWindow(url: string, windowName: string, windowFeatures: string): Client<string>;
-        newWindow<P>(
-            url: string,
-            windowName: string,
-            windowFeatures: string,
-            callback: (err: any, windowId: string) => P
-        ): Client<P>;
 
         setViewportSize(size: Size, type: boolean): Client<void>;
-        setViewportSize<P>(
-            size: Size,
-            type: boolean,
-            callback: (err: any) => P
-        ): Client<P>;
 
         switchTab(windowHandle?: string): Client<void>;
-        switchTab<P>(
-            callback: (err: any) => P
-        ): Client<P>;
-        switchTab<P>(
-            windowHandle: string,
-            callback: (err: any) => P
-        ): Client<P>;
     }
 
     export interface Options {


### PR DESCRIPTION
Please fill in this template.
- [X] Prefer to make your PR against the `types-2.0` branch.
- [X] The package does not provide its own types, and you can not add them.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Run `tsc` without errors.
- [X] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [X] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

Version 4.0 introduced support for the page object pattern, but the current typings do not reflect the ability to return a page element. 

Under the current typings `private get usernameInput() { return browser.element('input#Username') }` results in the `usernameInput` to be returned as an instance of the `Client`, which a `selector: string` as the first argument in many cases.

For example, `getValue()` needs to be called with the syntax `this.usernameInput.getValue('#input#Username')`, which is obviously redundant. 

This request duplicates the typings for calls of the `Client` functions that make sense to call from an `Element`s point of view. In the duplicated version, the `selector: string` is removed so the developer can call it without the need to add a `selector: string`.
