### PR TITLE
Update express-brute types

### DIFF
--- a/express-brute/index.d.ts
+++ b/express-brute/index.d.ts
@@ -8,81 +8,6 @@
 import express = require("express");
 
 /**
- * @summary Options for {@link MemoryStore} class.
- * @interface
- */
-interface MemoryStoreOptions {
-    /**
-     * @summary Key prefix.
-     * @type {string}
-     */
-    prefix: string;
-}
-
-/**
- * @summary Options for {@link ExpressBrute#getMiddleware} class.
- * @interface
- */
-interface ExpressBruteMiddleware {
-    /**
-     * @summary Allows you to override the value of failCallback for this middleware.
-     * @type {Function}
-     */
-    failCallback: Function;
-
-    /**
-     * @summary Disregard IP address when matching requests if set to true. Defaults to false.
-     * @type {boolean}
-     */
-    ignoreIP: boolean;
-
-    /**
-     * @summary Key.
-     * @type {any}
-     */
-    key: any;
-}
-
-/**
- * @summary Options for {@link ExpressBrute} class.
- * @interface
- */
-interface ExpressBruteOptions {
-    /**
-     * @summary The number of retires the user has before they need to start waiting (default: 2)
-     */
-    freeRetries?: number;
-    /**
-     * @summary Specify whether or not a simplified reset method should be attached at req.brute.reset. The simplified method takes only a callback, and resets all ExpressBrute middleware that was called on the current request. If multiple instances of ExpressBrute have middleware on the same request, only those with attachResetToRequest set to true will be reset (default: true)
-     */
-    attachResetToRequest?: boolean;
-    /**
-     * @summary Defines whether the lifetime counts from the time of the last request that ExpressBrute didn't prevent for a given IP (true) or from of that IP's first request (false). Useful for allowing limits over fixed periods of time, for example: a limited number of requests per day. (Default: true).
-     */
-    refreshTimeoutOnRequest?: boolean;
-    /**
-     * @summary The initial wait time (in milliseconds) after the user runs out of retries (default: 500 milliseconds)
-     */
-    minWait?: number;
-    /**
-     * @summary The maximum amount of time (in milliseconds) between requests the user needs to wait (default: 15 minutes). The wait for a given request is determined by adding the time the user needed to wait for the previous two requests.
-     */
-    maxWait?: number;
-    /**
-     * @summary The length of time (in seconds since the last request) to remember the number of requests that have been made by an IP. By default it will be set to maxWait * the number of attempts before you hit maxWait to discourage simply waiting for the lifetime to expire before resuming an attack. With default values this is about 6 hours.
-     */
-    lifetime?: number;
-    /**
-     * @summary Gets called with (req, res, next, nextValidRequestDate) when a request is rejected (default: ExpressBrute.FailForbidden)
-     */
-    failCallback?: (req: express.Request, res: express.Response, next: Function, nextValidRequestDate: any) => void;
-    /**
-     * @summary Gets called whenever an error occurs with the persistent store from which ExpressBrute cannot recover. It is passed an object containing the properties message (a description of the message), parent (the error raised by the session store), and [key, ip] or [req, res, next] depending on whether or the error occurs during reset or in the middleware itself.
-     */
-    handleStoreError?: any;
-}
-
-/**
  * @summary Middleware.
  * @class
  */
@@ -92,13 +17,13 @@ declare class ExpressBrute {
      * @constructor
      * @param {any} store The store.
      */
-    constructor(store: any, options?: ExpressBruteOptions);
+    constructor(store: any, options?: ExpressBrute.Options);
 
     /**
      * @summary Generates middleware that will bounce requests with the same key and IP address that happen faster than the current wait time by calling failCallback.
      * @param {Object} options The options.
      */
-    getMiddleware(options: ExpressBruteMiddleware): express.RequestHandler;
+    getMiddleware(options: ExpressBrute.Middleware): express.RequestHandler;
 
     /**
      * @summary Middleware that will bounce requests that happen faster than the current wait time by calling failCallback.
@@ -120,6 +45,81 @@ declare class ExpressBrute {
 }
 
 declare namespace ExpressBrute {
+    /**
+     * @summary Options for {@link MemoryStore} class.
+     * @interface
+     */
+    export interface MemoryStoreOptions {
+        /**
+         * @summary Key prefix.
+         * @type {string}
+         */
+        prefix: string;
+    }
+
+    /**
+     * @summary Options for {@link ExpressBrute#getMiddleware} class.
+     * @interface
+     */
+    export interface Middleware {
+        /**
+         * @summary Allows you to override the value of failCallback for this middleware.
+         * @type {Function}
+         */
+        failCallback: Function;
+
+        /**
+         * @summary Disregard IP address when matching requests if set to true. Defaults to false.
+         * @type {boolean}
+         */
+        ignoreIP: boolean;
+
+        /**
+         * @summary Key.
+         * @type {any}
+         */
+        key: any;
+    }
+
+    /**
+     * @summary Options for {@link ExpressBrute} class.
+     * @interface
+     */
+    export interface Options {
+        /**
+         * @summary The number of retires the user has before they need to start waiting (default: 2)
+         */
+        freeRetries?: number;
+        /**
+         * @summary Specify whether or not a simplified reset method should be attached at req.brute.reset. The simplified method takes only a callback, and resets all ExpressBrute middleware that was called on the current request. If multiple instances of ExpressBrute have middleware on the same request, only those with attachResetToRequest set to true will be reset (default: true)
+         */
+        attachResetToRequest?: boolean;
+        /**
+         * @summary Defines whether the lifetime counts from the time of the last request that ExpressBrute didn't prevent for a given IP (true) or from of that IP's first request (false). Useful for allowing limits over fixed periods of time, for example: a limited number of requests per day. (Default: true).
+         */
+        refreshTimeoutOnRequest?: boolean;
+        /**
+         * @summary The initial wait time (in milliseconds) after the user runs out of retries (default: 500 milliseconds)
+         */
+        minWait?: number;
+        /**
+         * @summary The maximum amount of time (in milliseconds) between requests the user needs to wait (default: 15 minutes). The wait for a given request is determined by adding the time the user needed to wait for the previous two requests.
+         */
+        maxWait?: number;
+        /**
+         * @summary The length of time (in seconds since the last request) to remember the number of requests that have been made by an IP. By default it will be set to maxWait * the number of attempts before you hit maxWait to discourage simply waiting for the lifetime to expire before resuming an attack. With default values this is about 6 hours.
+         */
+        lifetime?: number;
+        /**
+         * @summary Gets called with (req, res, next, nextValidRequestDate) when a request is rejected (default: ExpressBrute.FailForbidden)
+         */
+        failCallback?: (req: express.Request, res: express.Response, next: Function, nextValidRequestDate: any) => void;
+        /**
+         * @summary Gets called whenever an error occurs with the persistent store from which ExpressBrute cannot recover. It is passed an object containing the properties message (a description of the message), parent (the error raised by the session store), and [key, ip] or [req, res, next] depending on whether or the error occurs during reset or in the middleware itself.
+         */
+        handleStoreError?: any;
+    }
+
     /**
      * @summary In-memory store.
      * @class

--- a/express-brute/index.d.ts
+++ b/express-brute/index.d.ts
@@ -48,13 +48,37 @@ interface ExpressBruteMiddleware {
  * @interface
  */
 interface ExpressBruteOptions {
+    /**
+     * @summary The number of retires the user has before they need to start waiting (default: 2)
+     */
     freeRetries?: number;
+    /**
+     * @summary Specify whether or not a simplified reset method should be attached at req.brute.reset. The simplified method takes only a callback, and resets all ExpressBrute middleware that was called on the current request. If multiple instances of ExpressBrute have middleware on the same request, only those with attachResetToRequest set to true will be reset (default: true)
+     */
     attachResetToRequest?: boolean;
+    /**
+     * @summary Defines whether the lifetime counts from the time of the last request that ExpressBrute didn't prevent for a given IP (true) or from of that IP's first request (false). Useful for allowing limits over fixed periods of time, for example: a limited number of requests per day. (Default: true).
+     */
     refreshTimeoutOnRequest?: boolean;
+    /**
+     * @summary The initial wait time (in milliseconds) after the user runs out of retries (default: 500 milliseconds)
+     */
     minWait?: number;
+    /**
+     * @summary The maximum amount of time (in milliseconds) between requests the user needs to wait (default: 15 minutes). The wait for a given request is determined by adding the time the user needed to wait for the previous two requests.
+     */
     maxWait?: number;
+    /**
+     * @summary The length of time (in seconds since the last request) to remember the number of requests that have been made by an IP. By default it will be set to maxWait * the number of attempts before you hit maxWait to discourage simply waiting for the lifetime to expire before resuming an attack. With default values this is about 6 hours.
+     */
     lifetime?: number;
+    /**
+     * @summary Gets called with (req, res, next, nextValidRequestDate) when a request is rejected (default: ExpressBrute.FailForbidden)
+     */
     failCallback?: (req: express.Request, res: express.Response, next: Function, nextValidRequestDate: any) => void;
+    /**
+     * @summary Gets called whenever an error occurs with the persistent store from which ExpressBrute cannot recover. It is passed an object containing the properties message (a description of the message), parent (the error raised by the session store), and [key, ip] or [req, res, next] depending on whether or the error occurs during reset or in the middleware itself.
+     */
     handleStoreError?: any;
 }
 

--- a/express-brute/index.d.ts
+++ b/express-brute/index.d.ts
@@ -77,13 +77,6 @@ declare class ExpressBrute {
     getMiddleware(options: ExpressBruteMiddleware): express.RequestHandler;
 
     /**
-     * @summary Uses the current proxy trust settings to get the current IP from a request object.
-     * @param {Request} request The HTTP request.
-     * @return {RequestHandler} The Request handler.
-     */
-    getIPFromRequest(request: express.Request): express.RequestHandler;
-
-    /**
      * @summary Middleware that will bounce requests that happen faster than the current wait time by calling failCallback.
      * @param {Request}     request     The HTTP request.
      * @param {Response}    response    The HTTP response.

--- a/express-brute/index.d.ts
+++ b/express-brute/index.d.ts
@@ -49,7 +49,6 @@ interface ExpressBruteMiddleware {
  */
 interface ExpressBruteOptions {
     freeRetries?: number;
-    proxyDepth?: number;
     attachResetToRequest?: boolean;
     refreshTimeoutOnRequest?: boolean;
     minWait?: number;


### PR DESCRIPTION
- 	proxyDepth option on ExpressBrute has been removed

- 	getIPFromRequest(req) has been removed from instances

- 	Document ExpressBruteOptions

- 	Export MemoryStoreOptions, Middleware and Options interfaces