### PR TITLE
Update missing ASTNode.tagName in parse5

### DIFF
--- a/parse5/index.d.ts
+++ b/parse5/index.d.ts
@@ -58,6 +58,7 @@ export interface ASTNode {
     namespaceURI?: string;
     parentNode?: ASTNode;
     nodeName: string;
+    tagName?: string;
     quirksMode?: boolean;
     value?: string;
     __location: LocationInfo | ElementLocationInfo;

--- a/parse5/parse5-tests.ts
+++ b/parse5/parse5-tests.ts
@@ -58,6 +58,7 @@ fragment = parse5.parseFragment('<div></div>', {locationInfo: true});
 fragment.quirksMode = true;
 fragment.namespaceURI = '';
 fragment.nodeName = '';
+fragment.tagName = '';
 fragment.value = '';
 fragment = fragment.childNodes[0];
 fragment = fragment.parentNode;


### PR DESCRIPTION
Please fill in this template.

- [X] Prefer to make your PR against the `types-2.0` branch.
- [X] The package does not provide its own types, and you can not add them.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [X] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/inikulin/parse5/blob/9727f8c2e1218e1d0ded56b4a5f888e49452a7ba/lib/tree_adapters/default.js#L409,L416
- [X] Increase the version number in the header if appropriate. (not appropriate)

