### PR TITLE
[mongoose] Declare a right type for _id

### DIFF
--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -871,7 +871,7 @@ declare module "mongoose" {
     /** Hash containing current validation errors. */
     errors: Object;
     /** This documents _id. */
-    _id: any;
+    _id: mongodb.ObjectID;
     /** Boolean flag specifying if the document is new. */
     isNew: boolean;
     /** The documents schema. */

--- a/passport-local-mongoose/passport-local-mongoose-tests.ts
+++ b/passport-local-mongoose/passport-local-mongoose-tests.ts
@@ -27,7 +27,6 @@ import { Strategy as LocalStrategy } from 'passport-local';
 
 //#region Test Models
 interface User extends PassportLocalDocument {
-    _id: string;
     username: string;
     hash: string;
     salt: string;


### PR DESCRIPTION
Please fill in this template.

- [ ] Prefer to make your PR against the `types-2.0` branch.
- [ ] The package does not provide its own types, and you can not add them.
- [ ] Test the change in your own code.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [ ] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

---

In fact, `_id` is a `ObjectID` instance, it should have a exactly type, not `any` type.