### PR TITLE
Implement xml-js types-2.0

### DIFF
--- a/xml-js/index.d.ts
+++ b/xml-js/index.d.ts
@@ -1,0 +1,82 @@
+// Type definitions for xml-js 0.9.6
+// Project: https://github.com/nashwaan/xml-js
+// Definitions by: Denis Carriere <https://github.com/DenisCarriere>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface ElementCompact {
+    [key: string]: any
+    _attributes?: {
+        [key: string]: number | number
+    }
+    _cdata?: string | number
+    _comment?: string | number
+    _declaration?: {
+        _attributes?: {
+            version?: string | number
+            encoding?: string | number
+        }
+    }
+    _text?: string | number
+}
+
+export interface Element {
+    attributes?: {
+        [key: string]: string | number
+    }
+    cdata?: string | number
+    comment?: string | number
+    declaration?: {
+        attributes?: {
+            version: string | number
+            encoding: string | number
+        }
+    }
+    elements?: Array<Element>
+    text?: string | number
+    type?: string | number
+    name?: string | number
+}
+
+declare namespace Options {
+    interface XML2JS extends ChangingKeyNames, IgnoreOptions {
+        compact?: boolean
+        spaces?: number | string
+        trim?: boolean
+        sanitize?: boolean
+        nativeType?: boolean
+        addParent?: boolean
+        alwaysChildren?: boolean
+    }
+
+    interface JS2XML extends ChangingKeyNames, IgnoreOptions {
+        spaces?: number | string
+        compact?: boolean
+        fullTagEmptyElement?: boolean
+    }
+
+    interface IgnoreOptions {
+        ignoreDeclaration?: boolean
+        ignoreAttributes?: boolean
+        ignoreComment?: boolean
+        ignoreCdata?: boolean
+        ignoreText?: boolean
+    }
+
+    interface ChangingKeyNames {
+        declarationKey?: string
+        attributesKey?: string
+        textKey?: string
+        cdataKey?: string
+        commentKey?: string
+        parentKey?: string
+        typeKey?: string
+        nameKey?: string
+        elementsKey?: string
+    }
+}
+
+export function js2xml(json: Element | ElementCompact, options?: Options.JS2XML): string;
+export function json2xml(json: Element | ElementCompact, options?: Options.JS2XML): string;
+export function xml2json(xml: string, options?: Options.XML2JS): any;
+export function xml2js(xml: string, options?: Options.XML2JS): any;
+

--- a/xml-js/tsconfig.json
+++ b/xml-js/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "xml-js-tests.ts"
+    ]
+}

--- a/xml-js/xml-js-tests.ts
+++ b/xml-js/xml-js-tests.ts
@@ -1,0 +1,48 @@
+import { Element, ElementCompact } from 'xml-js'
+import * as convert from 'xml-js'
+
+// Declaration
+const declarationCompact1: ElementCompact = { _declaration: { _attributes: { version: 2 } }};
+const declarationCompact2: ElementCompact = { _declaration: { _attributes: { version: '1.0', encoding: 'utf-8' }}};
+const declaration1: Element = { declaration: { }};
+const declaration2: Element = { declaration: { attributes: { version: '1.0', encoding: 'utf-8' }}};
+
+// Comment
+const commentCompact: ElementCompact = { _comment : 'Hello, World!' };
+const comment: Element = { elements: [{ type: 'comment', comment: 'Hello, World!' }]};
+
+// CDATA
+const cdataCompact: ElementCompact = { _cdata: '<foo></bar>' };
+const cdata: Element = { elements : [{ type: 'cdata', cdata: '<foo></bar>' }]};
+
+// Element
+const elementCompact1: ElementCompact = { a: {} };
+const element1: Element = { elements:[{ type: 'element', name: 'a' }]};
+
+const elementCompact2: ElementCompact = { a: { _attributes: { x: '1.234', y:'It\'s' }}};
+const element2: Element = { elements: [{ type: 'element', name: 'a', attributes: { x: '1.234', y: 'It\'s' }}]};
+
+const elementCompact3: ElementCompact = { a: { _text: ' Hi ' }};
+const element3: Element = { elements:[{ type: 'element', name: 'a', elements: [{ type: 'text', text: ' Hi ' }]}]};
+
+const elementCompact4: ElementCompact = { a: {}, b: {} };
+const element4: Element = { elements:[{ type: 'element', name: 'a' }, { type: 'element', name: 'b' }]};
+
+const elementCompact5: ElementCompact = { a: { b: {} }};
+const element5: Element = { elements: [{ type: 'element', name: 'a', elements: [{ type: 'element', name: 'b' }]}]};
+
+// xml2json
+const xml = `
+<?xml version="1.0" encoding="utf-8"?>
+<note importance="high" logged="true">
+    <title>Happy</title>
+    <todo>Work</todo>
+    <todo>Play</todo>
+</note>`;
+convert.xml2json(xml, { compact: true, spaces: 4 });
+convert.xml2json(xml, { compact: false });
+
+// json2xml
+convert.json2xml({ a: {} }, { compact: true, spaces: 4 });
+convert.json2xml({ elements:[{ type: 'element', name: 'a' }]}, { compact: false });
+


### PR DESCRIPTION
Implement `xml-js`

Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Run `tsc` without errors.
- [x] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.
