### PR TITLE
[core-js] Update to padStart, padEnd (stage 4)

### DIFF
--- a/core-js/core-js-tests.ts
+++ b/core-js/core-js-tests.ts
@@ -334,15 +334,15 @@ b = Reflect.setPrototypeOf(a, a);
 
 // #############################################################################################
 // ECMAScript 7
-// Modules: es7.array.includes, es7.string.at, es7.string.lpad, es7.string.rpad, 
+// Modules: es7.array.includes, es7.string.at, ees7.string.pad-start, es7.string.pad-end,
 //          es7.object.to-array, es7.object.get-own-property-descriptors, es7.regexp.escape,
 //          es7.map.to-json, and es7.set.to-json
 // #############################################################################################
 
 b = arrayOfPoint.includes(point, i);
 s = s.at(i);
-s = s.lpad(i, s);
-s = s.rpad(i, s);
+s = s.padStart(i, s);
+s = s.padEnd(i, s);
 arrayOfAny = Object.values(a);
 arrayOfStringAny = Object.entries(a);
 pdm = Object.getOwnPropertyDescriptors(a);

--- a/core-js/index.d.ts
+++ b/core-js/index.d.ts
@@ -890,7 +890,7 @@ declare namespace Reflect {
 
 // #############################################################################################
 // ECMAScript 7
-// Modules: es7.array.includes, es7.string.at, es7.string.lpad, es7.string.rpad,
+// Modules: es7.array.includes, es7.string.at, es7.string.pad-start, es7.string.pad-end,
 //          es7.object.to-array, es7.object.get-own-property-descriptors, es7.regexp.escape,
 //          es7.map.to-json, and es7.set.to-json
 // #############################################################################################
@@ -901,8 +901,8 @@ interface Array<T> {
 
 interface String {
     at(index: number): string;
-    lpad(length: number, fillStr?: string): string;
-    rpad(length: number, fillStr?: string): string;
+    padStart(length: number, fillStr?: string): string;
+    padEnd(length: number, fillStr?: string): string;
 }
 
 interface ObjectConstructor {


### PR DESCRIPTION
The type definitions for core-js are unfortunately heavily outdated. The type definitions target version 0.9.7 when the current version is actually 2.4.1.

I hope I can make a larger update to the whole type definitions at a later date, but for now, I am just updating `String.padStart` and `String.padEnd` which supersede the previous `String.lpad` and `String.rpad`. The new names follow the [new specification](https://github.com/tc39/proposal-string-pad-start-end) which is currently at the final stage 4. There is also an open issue Microsoft/TypeScript#11942 which will eventually place the type definitions for these two methods in the core type definitions.

I would want to update the version number in the type definition header, but since the current state is neither fully compatible to 0.9.7 nor 2.4.1, I am refraining from doing so. As said, I hope I can work on a full upgrade of the type definitions soon.