### PR TITLE
add type definitions for angular-promise-tracker

### DIFF
--- a/angular-promise-tracker/angular-promise-tracker-tests.ts
+++ b/angular-promise-tracker/angular-promise-tracker-tests.ts
@@ -1,0 +1,22 @@
+/// <reference path="./angular-promise-tracker.d.ts" />
+
+angular.module('promise-tracker-tests', []).run(['$q', 'promiseTracker',
+    ($q: angular.IQService, promiseTracker: angular.promisetracker.PromiseTrackerService) => {
+        const trackerWithoutOptions = promiseTracker();
+
+        const options = {
+            activationDelay: 10,
+            minDuration: 500
+        } as angular.promisetracker.PromiseTrackerOptions;
+        const trackerWithOptions = promiseTracker(options);
+
+        const isActive: boolean = trackerWithOptions.active();
+        const tracking: boolean = trackerWithOptions.tracking();
+        const trackingCount: number = trackerWithOptions.trackingCount();
+        trackerWithOptions.cancel();
+
+        const createdPromise: angular.IDeferred<void> = trackerWithOptions.createPromise();
+
+        const promiseToAdd = $q.defer().promise;
+        const addedPromise: angular.IDeferred<void> = trackerWithOptions.addPromise(promiseToAdd);
+}]);

--- a/angular-promise-tracker/angular-promise-tracker.d.ts
+++ b/angular-promise-tracker/angular-promise-tracker.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for angular-promise-tracker v2.2.2
+// Project: https://github.com/ajoslin/angular-promise-tracker
+// Definitions by: Rufus Linke <https://github.com/rufusl/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../angularjs/angular.d.ts" />
+
+declare namespace angular.promisetracker {
+    interface PromiseTrackerOptions {
+        activationDelay: number;
+        minDuration: number;
+    }
+
+    interface PromiseTracker {
+        active(): boolean;
+        tracking(): boolean;
+        trackingCount(): number;
+        addPromise<T>(promise: angular.IPromise<T>): angular.IDeferred<void>;
+        createPromise(): angular.IDeferred<void>;
+        cancel(): void;
+    }
+
+    interface PromiseTrackerService {
+        (options?: PromiseTrackerOptions): PromiseTracker;
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [ ] Prefer to make your PR against the `types-2.0` branch.
Definitions have to be available for the typings tool.
- [X] The package does not provide its own types, and you can not add them.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Run `tsc` without errors.
- [X] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [ ] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

