### PR TITLE
node-schedule: Add support for object literal syntax

### DIFF
--- a/node-schedule/index.d.ts
+++ b/node-schedule/index.d.ts
@@ -215,6 +215,67 @@ export class RecurrenceRule {
 }
 
 /**
+ * Recurrence rule specification.
+ */
+export interface RecurrenceSpec {
+    /**
+     * Day of the month.
+     *
+     * @public
+     * @type {RecurrenceSegment}
+     */
+    date?: RecurrenceSegment;
+
+    /**
+     * Day of the week.
+     *
+     * @public
+     * @type {RecurrenceSegment}
+     */
+    dayOfWeek?: RecurrenceSegment;
+
+    /**
+     * Hour.
+     *
+     * @public
+     * @type {RecurrenceSegment}
+     */
+    hour?: RecurrenceSegment;
+
+    /**
+     * Minute.
+     *
+     * @public
+     * @type {RecurrenceSegment}
+     */
+    minute?: RecurrenceSegment;
+
+    /**
+     * Month.
+     *
+     * @public
+     * @type {RecurrenceSegment}
+     */
+    month?: RecurrenceSegment;
+
+    /**
+     * Second.
+     *
+     * @public
+     * @type {RecurrenceSegment}
+     */
+    second?: RecurrenceSegment;
+
+    /**
+     * Year.
+     *
+     * @public
+     * @type {RecurrenceSegment}
+     */
+    year?: RecurrenceSegment;
+}
+
+/**
  * Invocation.
  *
  * @class
@@ -266,11 +327,19 @@ export class Invocation {
 /**
  * Create a schedule job.
  *
- * @param {string|RecurrenceRule|Date} name     either an optional name for the new Job or scheduling information
- * @param {RecurrenceRule|Date|string} rule     either the scheduling info or the JobCallback
- * @param {JobCallback}                callback The callback to be executed on each invocation.
+ * @param {string}                                    name     name for the new Job
+ * @param {RecurrenceRule|RecurrenceSpec|Date|string} rule     scheduling info
+ * @param {JobCallback}                               callback callback to be executed on each invocation
  */
-    export function scheduleJob(name:string|RecurrenceRule|Date, rule: RecurrenceRule|Date|string|JobCallback, callback?: JobCallback): Job;
+    export function scheduleJob(name: string, rule: RecurrenceRule | RecurrenceSpec | Date | string, callback: JobCallback): Job;
+
+/**
+ * Create a schedule job.
+ *
+ * @param {RecurrenceRule|RecurrenceSpec|Date|string} rule     scheduling info
+ * @param {JobCallback}                               callback callback to be executed on each invocation
+ */
+    export function scheduleJob(rule: RecurrenceRule | RecurrenceSpec | Date | string, callback: JobCallback): Job;
 
 /**
  * Changes the timing of a Job, canceling all pending invocations.
@@ -279,7 +348,7 @@ export class Invocation {
  * @param spec {JobCallback} the new timing for this Job
  * @return {Job} if the job could be rescheduled, {null} otherwise.
  */
-    export function rescheduleJob(job:Job|string, spec:RecurrenceRule|Date|string):Job;
+    export function rescheduleJob(job: Job | string, spec: RecurrenceRule | RecurrenceSpec | Date | string): Job;
 
 /**
  * Dictionary of all Jobs, accessible by name.


### PR DESCRIPTION
Add support for object literal syntax on the scheduleJob and rescheduleJob functions. Also improve the clarity of scheduleJob by expressing it as an overload.

See: https://github.com/node-schedule/node-schedule#object-literal-syntax

Note: This is the same as PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12298, which was against the **master** branch.