### PR TITLE
types(selenium): fix typings error Level class in logging namespace

### DIFF
--- a/selenium-webdriver/index.d.ts
+++ b/selenium-webdriver/index.d.ts
@@ -1777,10 +1777,10 @@ declare namespace webdriver {
           toString(): string;
 
           /** This logger's name. */
-          name(): string;
+          name: string;
 
           /** The numeric log level. */
-          value(): number;
+          value: number;
 
           /**
            * Indicates no log messages should be recorded.

--- a/selenium-webdriver/selenium-webdriver-tests.ts
+++ b/selenium-webdriver/selenium-webdriver-tests.ts
@@ -849,8 +849,8 @@ function TestLogging() {
     level = webdriver.logging.Level.SEVERE;
     level = webdriver.logging.Level.WARNING;
 
-    var name: string = level.name();
-    var value: number = level.value();
+    var name: string = level.name;
+    var value: number = level.value;
 
     var type: string;
     type = webdriver.logging.Type.BROWSER;


### PR DESCRIPTION
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/SeleniumHQ/selenium/blob/ba56ad1ae0b98a1fe1efdd2163c62fc847950178/javascript/node/selenium-webdriver/lib/logging.js#L95
- [ ] Increase the version number in the header if appropriate.

The 'name' and 'value' properties should not be defined as function, they
are implemented using es6 get functions

```js
get value() {
  return this.value_;
}
```