### PR TITLE
Change StackPolicyBody and StackPolicyUrl to accept string instead of…

### DIFF
--- a/aws-sdk/index.d.ts
+++ b/aws-sdk/index.d.ts
@@ -616,8 +616,8 @@ export module CloudFormation {
         ResourceTypes?: string[];
         OnFailure?: string[];       //  cannot specify both DisableRollback and OnFailure
                                     //  DO_NOTHING | ROLLBACK | DELETE
-        StackPolicyBody?: string[];  //  cannot specify both StackPolicyBody and StackPolicyURL
-        StackPolicyURL?: string[];   //  cannot specify both StackPolicyBody and StackPolicyURL
+        StackPolicyBody?: string;  //  cannot specify both StackPolicyBody and StackPolicyURL
+        StackPolicyURL?: string;   //  cannot specify both StackPolicyBody and StackPolicyURL
         Tags?: CloudFormation.Tag[];
     }
 


### PR DESCRIPTION
If changing an existing definition:
- Provide a URL to  documentation or source code which provides context for the suggested changes: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CloudFormation.html#createStack-property
- Increase the version number in the header if appropriate.

The documentation clearly states, that both the StackPolicyBody and StackPolicyUrl are strings, not array of strings.
