### PR TITLE
chore(selenium-webdriver): update webdriver wait method

### DIFF
--- a/selenium-webdriver/index.d.ts
+++ b/selenium-webdriver/index.d.ts
@@ -5468,7 +5468,7 @@ declare namespace webdriver {
          *     rejected if the condition times out.
          * @template T
          */
-        wait<T>(condition: webdriver.promise.Promise<T>|webdriver.until.Condition<T>|((driver: WebDriver)=>T), timeout?: number, opt_message?: string): webdriver.promise.Promise<T>;
+        wait<T>(condition: webdriver.promise.Promise<T>|webdriver.until.Condition<T>|((driver: WebDriver)=>T)|Function, timeout?: number, opt_message?: string): webdriver.promise.Promise<T>;
 
         /**
          * Schedules a command to make the driver sleep for the given amount of time.

--- a/selenium-webdriver/selenium-webdriver-tests.ts
+++ b/selenium-webdriver/selenium-webdriver-tests.ts
@@ -756,6 +756,8 @@ function TestWebDriver() {
     booleanPromise = driver.wait(booleanPromise);
     booleanPromise = driver.wait(booleanCondition);
     booleanPromise = driver.wait(function(driver: webdriver.WebDriver) { return true; });
+    let conditionFunction: Function;
+    booleanPromise = driver.wait(conditionFunction);
     booleanPromise = driver.wait(booleanPromise, 123);
     booleanPromise = driver.wait(booleanPromise, 123, 'Message');
 


### PR DESCRIPTION
- This fix is for the `types-2.0` branch
- Add tested for `wait` method change.
- Ran `tsc` wtihout errors.
- Allowing for a more generic signature will help projects downstream like Protractor.