### PR TITLE
Pixi.js bugfix

### DIFF
--- a/pixi.js/pixi.js-tests.ts
+++ b/pixi.js/pixi.js-tests.ts
@@ -274,7 +274,7 @@ namespace basics {
 
             // draw a circle, set the lineStyle to zero so the circle doesn't have an outline
             this.graphics.lineStyle(0);
-            this.graphics.beginFill(PIXI.utils.hex2string(0xFFFF0B), 0.5);
+            this.graphics.beginFill(0xFFFF0B, 0.5);
             this.graphics.drawCircle(470, 90, 60);
             this.graphics.endFill();
 
@@ -461,7 +461,7 @@ namespace basics {
 
             var style: PIXI.TextStyle = {
                 font: '36px Arial bold italic',
-                fill: '#F7EDCA',
+                fill: PIXI.utils.hex2string(0xF7EDCA),
                 stroke: '#4a1850',
                 strokeThickness: 5,
                 dropShadow: true,

--- a/pixi.js/pixi.js-tests.ts
+++ b/pixi.js/pixi.js-tests.ts
@@ -274,7 +274,7 @@ namespace basics {
 
             // draw a circle, set the lineStyle to zero so the circle doesn't have an outline
             this.graphics.lineStyle(0);
-            this.graphics.beginFill(0xFFFF0B, 0.5);
+            this.graphics.beginFill(PIXI.utils.hex2string(0xFFFF0B), 0.5);
             this.graphics.drawCircle(470, 90, 60);
             this.graphics.endFill();
 

--- a/pixi.js/pixi.js.d.ts
+++ b/pixi.js/pixi.js.d.ts
@@ -1103,7 +1103,7 @@ declare namespace PIXI {
 
         static uuid(): number;
         static hex2rgb(hex: number, out?: number[]): number[];
-        static hex2String(hex: number): string;
+        static hex2string(hex: number): string;
         static rgb2hex(rgb: Number[]): number;
         static canUseNewCanvasBlendModel(): boolean;
         static getNextPowerOfTwo(number: number): number;


### PR DESCRIPTION
In the current version, `PIXI.utils.hex2string` ([Pixi docs](https://pixijs.github.io/docs/PIXI.utils.html#.hex2string)) is incorrectly capitalized as `PIXI.utils.hex2String`.

This PR fixes the typo and modifies an existing test to cover this method.

- [x] Prefer to make your PR against the `types-2.0` branch.
    - Merging into `master` because this bugfix should be available to to `typings` users as well.
- [x] Test the change in your own code.
    - Done locally.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: [Pixi's documentation on `hex2string`](https://pixijs.github.io/docs/PIXI.utils.html#.hex2string)
- [ ] Increase the version number in the header if appropriate.
    - I don't believe it is, but please let me know.
