### PR TITLE
[@types/mongoose] Declare a right type for _id

### DIFF
--- a/mongoose/index.d.ts
+++ b/mongoose/index.d.ts
@@ -871,7 +871,7 @@ declare module "mongoose" {
     /** Hash containing current validation errors. */
     errors: Object;
     /** This documents _id. */
-    _id: any;
+    _id: mongodb.ObjectID;
     /** Boolean flag specifying if the document is new. */
     isNew: boolean;
     /** The documents schema. */

--- a/passport-local-mongoose/passport-local-mongoose-tests.ts
+++ b/passport-local-mongoose/passport-local-mongoose-tests.ts
@@ -23,7 +23,6 @@ import { Strategy as LocalStrategy } from 'passport-local';
 
 //#region Test Models
 interface User extends PassportLocalDocument {
-    _id: string;
     username: string;
     hash: string;
     salt: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [ ] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

---

It's as same as #12431.

In fact, `_id` is a `ObjectID` instance, it should have a exactly type, not `any` type.