### PR TITLE
[@types/mongodb] Add "toString()" for ObjectID

### DIFF
--- a/mongodb/index.d.ts
+++ b/mongodb/index.d.ts
@@ -426,6 +426,8 @@ export class ObjectID {
     getTimestamp(): Date;
     // Returns the ObjectID id as a 24 byte hex string representation
     toHexString(): string;
+    // Returns the ObjectID id as a 24 byte hex string representation
+    toString(): string;
 }
 
 // Class documentation : http://mongodb.github.io/node-mongodb-native/2.1/api/Binary.html


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [ ] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

---

It's as same as #12430.

This isn't mentioned by document but `toString()` about the return result is as same as `toHexString()`.

```
instance._id.toString();  // '581948bb3cb9cc153bd82657'
instance._id.toHexString();  // '581948bb3cb9cc153bd82657'
```