### PR TITLE
Missing kendo.ui WorkbookSheetRow.type property

### DIFF
--- a/kendo-ui/kendo-ui.d.ts
+++ b/kendo-ui/kendo-ui.d.ts
@@ -18290,6 +18290,7 @@ declare namespace kendo.ooxml {
         cells?: WorkbookSheetRowCell[];
         index?: number;
         height?: number;
+        type?: string;
     }
 
     interface WorkbookSheet {

--- a/kendo-ui/kendo-ui.d.ts
+++ b/kendo-ui/kendo-ui.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Kendo UI Professional v2016.3.1028
+// Type definitions for Kendo UI Professional v2016.3.1029
 // Project: http://www.telerik.com/kendo-ui
 // Definitions by: Telerik <https://github.com/telerik/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/kendo-ui/kendo-ui.d.ts
+++ b/kendo-ui/kendo-ui.d.ts
@@ -18290,7 +18290,7 @@ declare namespace kendo.ooxml {
         cells?: WorkbookSheetRowCell[];
         index?: number;
         height?: number;
-        type?: string;
+        type?: "header" | "footer" | "groupHeader" | "groupFooter" | "data";
     }
 
     interface WorkbookSheet {


### PR DESCRIPTION
Please fill in this template.

- [ ] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [X] Provide a URL to  documentation or source code which provides context for the suggested changes: http://docs.telerik.com/kendo-ui/controls/data-management/grid/excel-export#row-type
- [X] Increase the version number in the header if appropriate.

