### PR TITLE
Update AjvOptions - multipleOfPrecision property

### DIFF
--- a/ajv/ajv.d.ts
+++ b/ajv/ajv.d.ts
@@ -82,7 +82,7 @@ declare module "ajv" {
             passContext?: boolean;
             loopRequired?: number;
             ownProperties?: boolean;
-            multipleOfPrecision?: boolean;
+            multipleOfPrecision?: boolean | number;
             errorDataPath?: string,
             messages?: boolean;
             beautify?: boolean;


### PR DESCRIPTION
Please fill in this template.

- [ ] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition: (N/A)
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/epoberezkin/ajv/commit/5f2cc30449d81a7d10148567f3f1ed038b00718e
- [x] Increase the version number in the header if appropriate.

---

Updating the AjvOptions - multipleOfPrecision property to allow boolean or number. Precision is specified as a number while the value defaults to false (i.e. disabled)

Link to PR which added the multipleOfPrecision option: https://github.com/epoberezkin/ajv/commit/5f2cc30449d81a7d10148567f3f1ed038b00718e