### PR TITLE
Seems like the error callback is malformatted

### DIFF
--- a/ws/index.d.ts
+++ b/ws/index.d.ts
@@ -135,7 +135,7 @@ declare namespace WebSocket {
 
         constructor(options?: IServerOptions, callback?: Function);
 
-        close(cb?: () => {}): void;
+        close(cb?: (err) => void): void;
         handleUpgrade(request: http.IncomingMessage, socket: net.Socket,
             upgradeHead: Buffer, callback: (client: WebSocket) => void): void;
 

--- a/ws/index.d.ts
+++ b/ws/index.d.ts
@@ -135,7 +135,7 @@ declare namespace WebSocket {
 
         constructor(options?: IServerOptions, callback?: Function);
 
-        close(cb?: (err) => void): void;
+        close(cb?: (err?: any) => void): void;
         handleUpgrade(request: http.IncomingMessage, socket: net.Socket,
             upgradeHead: Buffer, callback: (client: WebSocket) => void): void;
 


### PR DESCRIPTION
New to typescript, but it complains on my cb function since it expects an error argument and doesn't return an object.

I proposed these changes, but haven't done any typescripting really (trying to migrate to TS), so feel free to deny this PR if it's wrong.
I did check with the source code in ws before suggesting this though.

PS: I'm so sorry that I didn't follow the contribution guideline, but I'm doing this from github and have no setup right now that enables me to follow them :-(