### PR TITLE
fix: update version number for source-map

### DIFF
--- a/source-map/index.d.ts
+++ b/source-map/index.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for source-map v0.1.38
+﻿// Type definitions for source-map v0.5.6
 // Project: https://github.com/mozilla/source-map
 // Definitions by: Morten Houston Ludvigsen <https://github.com/MortenHoustonLudvigsen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/source-map/index.d.ts
+++ b/source-map/index.d.ts
@@ -58,7 +58,7 @@ declare namespace SourceMap {
         public static GENERATED_ORDER: number;
         public static ORIGINAL_ORDER: number;
 
-        constructor(rawSourceMap: RawSourceMap);
+        constructor(rawSourceMap: RawSourceMap | string);
 
         public computeColumnSpans(): void;
 
@@ -115,9 +115,9 @@ declare namespace SourceMap {
             relativePath?: string
         ): SourceNode;
 
-        public add(chunk: any): SourceNode;
+        public add(chunk: (string | SourceNode)[] | SourceNode | string): SourceNode;
 
-        public prepend(chunk: any): SourceNode;
+        public prepend(chunk: (string | SourceNode)[] | SourceNode | string): SourceNode;
 
         public setSourceContent(sourceFile: string, sourceContent: string): void;
 

--- a/source-map/source-map-tests.ts
+++ b/source-map/source-map-tests.ts
@@ -14,6 +14,15 @@ function testSourceMapConsumer() {
             file: 'sdf'
         });
 
+        scm = new SourceMap.SourceMapConsumer(JSON.stringify({
+            version: 3,
+            sources: ['foo', 'bar'],
+            names: ['foo', 'bar'],
+            sourcesContent: ['foo'],
+            mappings: 'foo',
+            file: 'sdf'
+        }));
+
         // create with partial RawSourceMap
         scm = new SourceMap.SourceMapConsumer({
             version: 3,
@@ -129,10 +138,14 @@ function testSourceNode() {
 
     function testAdd(node: SourceMap.SourceNode) {
         node.add('foo');
+        node.add(new SourceMap.SourceNode());
+        node.add([new SourceMap.SourceNode(), 'bar']);
     }
 
     function testPrepend(node: SourceMap.SourceNode) {
         node.prepend('foo');
+        node.prepend(new SourceMap.SourceNode());
+        node.prepend([new SourceMap.SourceNode(), 'bar']);
     }
 
     function testSetSourceContent(node: SourceMap.SourceNode) {


### PR DESCRIPTION
**In last PR, i forgot to update the target version of source-map**

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [ ] Provide a URL to  documentation or source code which provides context for the suggested changes: < https://github.com/mozilla/source-map >
- [x] Increase the version number in the header if appropriate.

