### PR TITLE
[@types/validator] Added isEmpty function definition which was missing

### DIFF
--- a/validator/validator-tests.ts
+++ b/validator/validator-tests.ts
@@ -27,6 +27,7 @@ import isDateFunc = require('validator/lib/isDate');
 import isDecimalFunc = require('validator/lib/isDecimal');
 import isDivisibleByFunc = require('validator/lib/isDivisibleBy');
 import isEmailFunc = require('validator/lib/isEmail');
+import isEmptyFunc = require('validator/lib/isEmpty');
 import isFQDNFunc = require('validator/lib/isFQDN');
 import isFloatFunc = require('validator/lib/isFloat');
 import isFullWidthFunc = require('validator/lib/isFullWidth');
@@ -125,6 +126,9 @@ namespace import_tests {
 
   let _isEmail = validator.isEmail;
   _isEmail = isEmailFunc;
+
+  let _isEmpty = validator.isEmpty;
+  _isEmpty = isEmptyFunc;
 
   let _isFQDN = validator.isFQDN;
   _isFQDN = isFQDNFunc;

--- a/validator/validator.d.ts
+++ b/validator/validator.d.ts
@@ -7,7 +7,7 @@ declare namespace ValidatorJS {
   type AlphaLocale = "ar" | "ar-AE" | "ar-BH" | "ar-DZ" | "ar-EG" | "ar-IQ" | "ar-JO" | "ar-KW" | "ar-LB" | "ar-LY" | "ar-MA" | "ar-QA" | "ar-QM" | "ar-SA" | "ar-SD" | "ar-SY" | "ar-TN" | "ar-YE" | "cs-CZ" | "de-DE" | "en-AU" | "en-GB" | "en-HK" | "en-IN" | "en-NZ" | "en-US" | "en-ZA" | "en-ZM" | "es-ES" | "fr-FR" | "hu-HU" | "nl-NL" | "pl-PL" | "pt-BR" | "pt-PT" | "ru-RU" | "sr-RS" | "sr-RS@latin" | "tr-TR";
   type AlphanumericLocale = "ar" | "ar-AE" | "ar-BH" | "ar-DZ" | "ar-EG" | "ar-IQ" | "ar-JO" | "ar-KW" | "ar-LB" | "ar-LY" | "ar-MA" | "ar-QA" | "ar-QM" | "ar-SA" | "ar-SD" | "ar-SY" | "ar-TN" | "ar-YE" | "cs-CZ" | "de-DE" | "en-AU" | "en-GB" | "en-HK" | "en-IN" | "en-NZ" | "en-US" | "en-ZA" | "en-ZM" | "es-ES" | "fr-FR" | "fr-BE" | "hu-HU" | "nl-BE" | "nl-NL" | "pl-PL" | "pt-BR" | "pt-PT" | "ru-RU" | "sr-RS" | "sr-RS@latin" | "tr-TR";
   type MobilePhoneLocale = "ar-DZ" | "ar-SA" | "ar-SY" | "cs-CZ" | "de-DE" | "da-DK" | "el-GR" | "en-AU" | "en-GB" | "en-HK" | "en-IN" | "en-NZ" | "en-US" | "en-CA" | "en-ZA" | "en-ZM" | "es-ES" | "fi-FI" | "fr-FR" | "hu-HU" | "it-IT" | "ja-JP" | "ms-MY" | "nb-NO" | "nn-NO" | "pl-PL" | "pt-PT" | "ru-RU" | "sr-RS" | "tr-TR" | "vi-VN" | "zh-CN" | "zh-TW"
-  
+
   interface ValidatorStatic {
 
     // **************
@@ -71,6 +71,9 @@ declare namespace ValidatorJS {
 
     // check if the string is an email.
     isEmail(str: string, options?: IsEmailOptions): boolean;
+
+    // check if the string has a length of zero.
+    isEmpty(str: string): boolean;
 
     // check if the string is a fully qualified domain name (e.g. domain.com).
     isFQDN(str: string, options?: IsFQDNOptions): boolean;
@@ -213,9 +216,9 @@ declare namespace ValidatorJS {
     // remove characters that do not appear in the whitelist. The characters are used in a RegExp and so you will
     // need to escape some chars, e.g. whitelist(input, '\\[\\]').
     whitelist(input: string, chars: string): string;
-    
+
     toString(input: any | any[]): string;
-    
+
     version: string;
 
     // **************
@@ -405,6 +408,11 @@ declare module "validator/lib/isDivisibleBy" {
 declare module "validator/lib/isEmail" {
   const isEmail: typeof validator.isEmail;
   export = isEmail;
+}
+
+declare module "validator/lib/isEmpty" {
+  const isEmpty: typeof validator.isEmpty;
+  export = isEmpty;
 }
 
 declare module "validator/lib/isFQDN" {


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.

- [x] Run `tsc` without errors.

typescript: version  2.0.7
The following commands output no errors.

* tsc --noImplicitAny validator.d.ts   
* tsc --noImplicitAny validator-tests.ts

https://www.npmjs.com/package/validator