### PR TITLE
Add copy-webpack-plugin definition

### DIFF
--- a/copy-webpack-plugin/copy-webpack-plugin-tests.ts
+++ b/copy-webpack-plugin/copy-webpack-plugin-tests.ts
@@ -1,0 +1,72 @@
+import { Configuration } from 'webpack'
+import * as CopyWebpackPlugin from 'copy-webpack-plugin'
+
+const c: Configuration = {
+	plugins: [
+		new CopyWebpackPlugin([
+			// {output}/file.txt
+			{ from: 'from/file.txt' },
+			
+			// {output}/to/file.txt
+			{ from: 'from/file.txt', to: 'to/file.txt' },
+			
+			// {output}/to/directory/file.txt
+			{ from: 'from/file.txt', to: 'to/directory' },
+			
+			// Copy directory contents to {output}/
+			{ from: 'from/directory' },
+			
+			// Copy directory contents to {output}/to/directory/
+			{ from: 'from/directory', to: 'to/directory' },
+			
+			// Copy glob results to /absolute/path/
+			{ from: 'from/directory/**/*', to: '/absolute/path' },
+			
+			// Copy glob results (with dot files) to /absolute/path/
+			{
+				from: {
+					glob:'from/directory/**/*',
+					dot: true,
+				},
+				to: '/absolute/path'
+			},
+			
+			// Copy glob results, relative to context
+			{
+				context: 'from/directory',
+				from: '**/*',
+				to: '/absolute/path'
+			},
+			
+			// {output}/file/without/extension
+			{
+				from: 'path/to/file.txt',
+				to: 'file/without/extension',
+				toType: 'file'
+			},
+			
+			// {output}/directory/with/extension.ext/file.txt
+			{
+				from: 'path/to/file.txt',
+				to: 'directory/with/extension.ext',
+				toType: 'dir'
+			},
+		], {
+			ignore: [
+				// Doesn't copy any files with a txt extension	
+				'*.txt',
+				
+				// Doesn't copy any file, even if they start with a dot
+				'**/*',
+				
+				// Doesn't copy any file, except if they start with a dot
+				{ glob: '**/*', dot: false }
+			],
+			
+			// By default, we only copy modified files during
+			// a watch or webpack-dev-server build. Setting this
+			// to `true` copies all files.
+			copyUnmodified: true,
+		})
+	]
+}

--- a/copy-webpack-plugin/index.d.ts
+++ b/copy-webpack-plugin/index.d.ts
@@ -1,0 +1,59 @@
+// Type definitions for copy-webpack-plugin v4.0.0
+// Project: https://github.com/kevlened/copy-webpack-plugin
+// Definitions by: flying-sheep <http://github.com/flying-sheep>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Plugin } from 'webpack'
+import { IOptions } from 'minimatch'
+
+interface MiniMatchGlob extends IOptions {
+	glob: string
+}
+
+interface CopyPattern {
+	/** File source path or glob */
+	from: string | MiniMatchGlob
+	/**
+	 * Path or webpack file-loader patterns. defaults:
+	 * output root if `from` is file or dir.
+	 * resolved glob path if `from` is glob.
+	 */
+	to?: string
+	/**
+	 * How to interpret `to`. defaults:
+	 * 'file' if to has extension or from is file.
+	 * 'dir' if from is directory, to has no extension or ends in '/'.
+	 * 'template' if to contains a template pattern.
+	 */
+	toType?: 'file' | 'dir' | 'template'
+	/** A path that determines how to interpret the `from` path. (default: `compiler.options.context`) */
+	context?: string
+	/**
+	 * Removes all directory references and only copies file names.
+	 * 
+	 * If files have the same name, the result is non-deterministic. (default: `false`)
+	 */
+	flatten?: boolean
+	/** Additional globs to ignore for this pattern. (default: `[]`) */
+	ignore?: Array<string | MiniMatchGlob>
+	/** Function that modifies file contents before writing to webpack. (default: `(content, path) => content`) */
+	transform?: (content: string, path: string) => string
+	/** Overwrites files already in `compilation.assets` (usually added by other plugins; default: `false`) */
+	force?: boolean
+}
+
+interface CopyWebpackPluginConfiguration {
+	/** Array of globs to ignore. (applied to from; default: `[]`) */
+	ignore?: Array<string | MiniMatchGlob>
+	/** Copies files, regardless of modification when using `watch` or `webpack-dev-server`. All files are copied on first build, regardless of this option. (default: `false`) */
+	copyUnmodified?: boolean
+	/** Debug level. warning: only warnings, info/true: file location and read info, debug: very detailed debugging info. (default: `'warning'`) */
+	debug?: 'warning' | 'info'|true | 'debug'
+}
+
+interface CopyWebpackPlugin {
+    new (patterns?: CopyPattern[], options?: CopyWebpackPluginConfiguration): Plugin
+}
+
+declare const copyWebpackPlugin: CopyWebpackPlugin
+export = copyWebpackPlugin

--- a/copy-webpack-plugin/tsconfig.json
+++ b/copy-webpack-plugin/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "copy-webpack-plugin-tests.ts"
+    ]
+}


### PR DESCRIPTION
- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Run `tsc` without errors.
- [x] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.