### PR TITLE
Add "string enum" types for base config log levels

### DIFF
--- a/winston/winston.d.ts
+++ b/winston/winston.d.ts
@@ -25,6 +25,10 @@ declare module "winston" {
   export var level: string;
 
   export var log: LogMethod;
+                
+  export type CLILoggingLevel = 'error' | 'warn' | 'help' | 'data' | 'info' | 'debug' | 'prompt' | 'verbose' | 'input' | 'silly';
+  export type NPMLoggingLevel = 'error' | 'warn' | 'info' | 'verbose' | 'debug' | 'silly';
+  export type SyslogLoggingLevel = 'emerg' | 'alert' | 'crit' | 'error' | 'warning' | 'notice' | 'info' | 'debug';
 
   export var silly: LeveledLogMethod;
   export var debug: LeveledLogMethod;


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/winstonjs/winston/tree/master/lib/winston/config

See the base/default config options here: https://github.com/winstonjs/winston/tree/master/lib/winston/config

Fixes #12366 

This allows for users to safely do things like

```ts
npmLogger.log('info', 'hello world')
```

but avoid unsafe `log` calls like

```ts
npmLogger.log('foobar', 'baz')
```

Note: this does not change __custom__ log levels.