### PR TITLE
[Yargs] Allow Command modules to be passed into command fn

### DIFF
--- a/yargs/index.d.ts
+++ b/yargs/index.d.ts
@@ -201,10 +201,10 @@ declare namespace yargs {
     }
 
     interface CommandModule {
-        aliases?: Array<string>|string;
+        aliases?: string[] | string;
         builder: {[key: string]: Options} | ((args: Argv) => Argv);
-        command: Array<string>|string;
-        describe: string|false;
+        command: string[] | string;
+        describe: string | false;
         handler: (args: any) => void;
     }
 

--- a/yargs/index.d.ts
+++ b/yargs/index.d.ts
@@ -70,6 +70,7 @@ declare namespace yargs {
         command(command: string, description: string, builder: { [optionName: string]: Options }): Argv;
         command(command: string, description: string, builder: { [optionName: string]: Options }, handler: (args: Argv) => void): Argv;
         command(command: string, description: string, builder: (args: Argv) => Options, handler: (args: Argv) => void): Argv;
+        command(command: string, description: string, module: CommandModule): Argv;
         command(module: CommandModule): Argv;
 
         commandDir(dir: string, opts?: RequireDirectoryOptions): Argv;
@@ -202,12 +203,13 @@ declare namespace yargs {
 
     interface CommandModule {
         aliases?: string[] | string;
-        builder: {[key: string]: Options} | ((args: Argv) => Argv);
-        command: string[] | string;
-        describe: string | false;
+        builder?: CommandBuilder;
+        command?: string[] | string;
+        describe?: string | false;
         handler: (args: any) => void;
     }
 
+    type CommandBuilder = {[key: string]: Options} | ((args: Argv) => Argv);
     type SyncCompletionFunction = (current: string, argv: any) => string[];
     type AsyncCompletionFunction = (current: string, argv: any, done: (completion: string[]) => void) => void;
 }

--- a/yargs/index.d.ts
+++ b/yargs/index.d.ts
@@ -70,7 +70,7 @@ declare namespace yargs {
         command(command: string, description: string, builder: { [optionName: string]: Options }): Argv;
         command(command: string, description: string, builder: { [optionName: string]: Options }, handler: (args: Argv) => void): Argv;
         command(command: string, description: string, builder: (args: Argv) => Options, handler: (args: Argv) => void): Argv;
-        command(module: ICommandModule): Argv;
+        command(module: CommandModule): Argv;
 
         commandDir(dir: string, opts?: RequireDirectoryOptions): Argv;
 
@@ -200,12 +200,12 @@ declare namespace yargs {
         nargs?: number;
     }
 
-    interface ICommandModule {
+    interface CommandModule {
         aliases?: Array<string>|string;
         builder: {[key: string]: Options} | ((args: Argv) => Argv);
         command: Array<string>|string;
         describe: string|false;
-        handler: (args: Argv) => void;
+        handler: (args: any) => void;
     }
 
     type SyncCompletionFunction = (current: string, argv: any) => string[];

--- a/yargs/index.d.ts
+++ b/yargs/index.d.ts
@@ -70,6 +70,7 @@ declare namespace yargs {
         command(command: string, description: string, builder: { [optionName: string]: Options }): Argv;
         command(command: string, description: string, builder: { [optionName: string]: Options }, handler: (args: Argv) => void): Argv;
         command(command: string, description: string, builder: (args: Argv) => Options, handler: (args: Argv) => void): Argv;
+        command(module: ICommandModule): Argv;
 
         commandDir(dir: string, opts?: RequireDirectoryOptions): Argv;
 
@@ -197,6 +198,14 @@ declare namespace yargs {
         number?: boolean;
         normalize?: boolean;
         nargs?: number;
+    }
+
+    interface ICommandModule {
+        aliases?: Array<string>|string;
+        builder: {[key: string]: Options} | ((args: Argv) => Argv);
+        command: Array<string>|string;
+        describe: string|false;
+        handler: (args: Argv) => void;
     }
 
     type SyncCompletionFunction = (current: string, argv: any) => string[];

--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -207,6 +207,18 @@ function command() {
 				description:"Should i publish?"
 			}
 		})
+		.command({
+			command: "test",
+			describe: "test package",
+			builder: {
+				mateys: {
+					demand: false
+				}
+			},
+			handler: (args: any) => {
+				/* handle me mateys! */
+			}
+		})
 		.help('help')
 		.argv;
 }

--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -219,6 +219,11 @@ function command() {
 				/* handle me mateys! */
 			}
 		})
+		.command("test", "test mateys", {
+			handler: (args: any) => {
+				/* handle me mateys! */
+			}
+		})
 		.help('help')
 		.argv;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [ ] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: <http://yargs.js.org/docs/#methods-commandmodule>
- [ ] Increase the version number in the header if appropriate.

