### PR TITLE
constructor of Chart also accepts HTMLCanvasElement

### DIFF
--- a/chart.js/index.d.ts
+++ b/chart.js/index.d.ts
@@ -392,7 +392,7 @@ interface RadialLinearScale {
 }
 
 declare class Chart {
-    constructor (context: CanvasRenderingContext2D, options: ChartConfiguration);
+    constructor (context: CanvasRenderingContext2D | HTMLCanvasElement, options: ChartConfiguration);
     config: ChartConfiguration;
     destroy: () => {};
     update: (duration?: any, lazy?: any) => {};


### PR DESCRIPTION
- [x] Prefer to make your PR against the `types-2.0` branch.
- [ ] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

According to http://www.chartjs.org/docs/#getting-started-creating-a-chart the constructor also accepts a HTMLCanvasElement as first argument.