### PR TITLE
Updated react-native navigation typings

### DIFF
--- a/react-native/index.d.ts
+++ b/react-native/index.d.ts
@@ -6111,6 +6111,17 @@ declare module "react" {
         removeEventListener(eventName: BackPressEventName, handler: () => void): void;
     }
 
+    export interface ButtonProperties {
+        title: string;
+        onPress: () => any;
+        color?: string;
+        accessibilityLabel?: string;
+        disabled?: boolean;
+    }
+
+    export interface ButtonStatic extends ComponentClass<ButtonProperties> {
+    }
+
     export type CameraRollGroupType = "Album" | "All" | "Event" | "Faces" | "Library" | "PhotoStream" | "SavedPhotos";
     export type CameraRollAssetType = "All" | "Videos" | "Photos";
 
@@ -7569,7 +7580,7 @@ declare module "react" {
     // Network Polyfill
     // TODO: Add proper support for fetch
     export type fetch = (url: string, options?: Object) => Promise<any>
-	export const fetch: fetch;
+    export const fetch: fetch;
 
     // Timers polyfill
     export type timedScheduler = (fn: string | Function, time: number) => number
@@ -7600,8 +7611,9 @@ declare module "react" {
         type: string;
     }
 
-     export interface NavigationRoute {
+    export interface NavigationRoute {
       key: string;
+      title?: string;
     }
 
     export interface NavigationState extends NavigationRoute {
@@ -7614,19 +7626,35 @@ declare module "react" {
         onNavigate: (action: NavigationAction) => boolean
     ) => JSX.Element;
 
-    export interface NavigationHeaderProps {
-        renderTitleComponent?(props: Object): JSX.Element
-        renderLeftComponent?(props: Object): JSX.Element
-        renderRightComponent?(props: Object): JSX.Element
-        onNavigateBack(): void
-        style?: ViewStyle
-        viewProps?: any
+    interface SubViewProps extends NavigationSceneRendererProps {
+        onNavigateBack?(): void;
+    }
+
+    type SubViewRenderer = (subViewProps: SubViewProps) => JSX.Element;
+
+    export interface NavigationHeaderProps extends NavigationSceneRendererProps {
+        onNavigateBack?(): void,
+        renderLeftComponent?: SubViewRenderer,
+        renderRightComponent?: SubViewRenderer,
+        renderTitleComponent?: SubViewRenderer,
+        style?: ViewStyle,
+        viewProps?: any,
         statusBarHeight?: number | NavigationAnimatedValue
     }
 
     export interface NavigationHeaderStatic extends React.ComponentClass<NavigationHeaderProps> {
-        Title: () => JSX.ElementClass
+        Title: NavigationHeaderTitleStatic
         HEIGHT: number
+    }
+
+    export interface NavigationHeaderTitleProps {
+        children?: JSX.Element,
+        style?: ViewStyle,
+        textStyle?: TextStyle,
+        viewProps?: any
+    }
+
+    export interface NavigationHeaderTitleStatic extends React.ComponentClass<NavigationHeaderTitleProps> {
     }
 
     export interface NavigationCardStackProps {
@@ -7672,13 +7700,11 @@ declare module "react" {
         /**
          * Function that renders the header.
          */
-        renderHeader?: Function,
-
+        renderHeader?: NavigationSceneRenderer,
         /**
          * Function that renders the a scene for a route.
          */
-        renderScene: Function,
-
+        renderScene: NavigationSceneRenderer,
         /**
          * Custom style applied to the cards stack.
          */
@@ -7709,35 +7735,19 @@ declare module "react" {
         route: NavigationRoute,
     };
 
+    // Similar to `NavigationTransitionProps`, except that the prop `scene`
+    // represents the scene for the renderer to render.
     export interface NavigationSceneRendererProps {
-        // The layout of the transitioner of the scenes.
         layout: NavigationLayout,
-
-        // The navigation state of the transitioner.
         navigationState: NavigationState,
-
-        // The progressive index of the transitioner's navigation state.
         position: NavigationAnimatedValue,
-
-        // The value that represents the progress of the transition when navigation
-        // state changes from one to another. Its numberic value will range from 0
-        // to 1.
-        //  progress.__getAnimatedValue() < 1 : transtion is happening.
-        //  progress.__getAnimatedValue() == 1 : transtion completes.
         progress: NavigationAnimatedValue,
-
-        // All the scenes of the transitioner.
         scenes: Array<NavigationScene>,
-
-        // The active scene, corresponding to the route at
-        // `navigationState.routes[navigationState.index]`.
         scene: NavigationScene,
-
-        // The gesture distance for `horizontal` and `vertical` transitions
         gestureResponseDistance?: number,
     }
 
-    export interface NavigationSceneRenderer extends React.ComponentClass<NavigationSceneRendererProps> {
+    export interface NavigationSceneRenderer extends React.StatelessComponent<NavigationSceneRendererProps> {
     }
 
     export interface NavigationPropTypes {
@@ -7764,11 +7774,11 @@ declare module "react" {
 
     export interface NavigationCardProps extends React.ComponentClass<NavigationSceneRendererProps> {
         onComponentRef: (ref: any) => void,
-        onNavigateBack: Function,
-        panHandlers: GestureResponderHandlers,
+        onNavigateBack?: Function,
+        panHandlers?: GestureResponderHandlers,
         pointerEvents: string,
         renderScene: NavigationSceneRenderer,
-        style: any,
+        style?: ViewStyle,
     }
 
     export interface NavigationCardStackStatic extends React.ComponentClass<NavigationCardStackProps> {
@@ -7847,13 +7857,13 @@ declare module "react" {
         timing?: (value: NavigationAnimatedValue, config: any) => any,
     }
     export interface NavigationTransitionerProps {
-        configureTransition: (
+        configureTransition?: (
             a: NavigationTransitionProps,
             b?: NavigationTransitionProps
         ) => NavigationTransitionSpec,
         navigationState: NavigationState,
-        onTransitionEnd: () => void,
-        onTransitionStart: () => void,
+        onTransitionEnd?: () => void,
+        onTransitionStart?: () => void,
         render: (a: NavigationTransitionProps, b?: NavigationTransitionProps) => any,
         style: any,
     }
@@ -8103,6 +8113,9 @@ declare module "react" {
 
     export var BackAndroid: BackAndroidStatic
     export type BackAndroid = BackAndroidStatic
+
+    export var Button: ButtonStatic
+    export type Button = ButtonStatic
 
     export var CameraRoll: CameraRollStatic
     export type CameraRoll = CameraRollStatic


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes:
* [Proper `NavigationSceneRenderer` type](https://github.com/facebook/react-native/blob/master/Libraries/NavigationExperimental/NavigationTypeDefinition.js#L115)
* [`NavigationCardStack` should use `NavigationSceneRenderer` for `renderHeader` and `renderScene`](https://github.com/facebook/react-native/blob/master/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js#L63)
* [Optional `NavigationCard` props](https://github.com/facebook/react-native/blob/master/Libraries/CustomComponents/NavigationExperimental/NavigationCard.js#L68) and [optional `NavigationTransitioner` props](https://github.com/facebook/react-native/blob/master/Libraries/NavigationExperimental/NavigationTransitioner.js#L67)
* [`NavigationRoute` __title__ prop](https://github.com/facebook/react-native/blob/9ee815f6b52e0c2417c04e5a05e1e31df26daed2/Libraries/NavigationExperimental/NavigationTypeDefinition.js#L26)
* ... I can keep going if it's necessary
- [x] Increase the version number in the header if appropriate.

Currently building an app with TypeScript and RN and was running into some immediate issues setting up NavigationExperimental, this fixes what I've encountered so far.

Also, there were a few places where there are discrepancies between what the Flow types and the propTypes say is optional. Going forward, should I prefer what one says over the other? Otherwise there are quite a few properties that aren't actually required that Flow seems to just omit the `?` on.