### PR TITLE
[types-2.0] Upgrade d3 to version 4.3

### DIFF
--- a/d3/index.d.ts
+++ b/d3/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3 standard bundle v4.2
+// Type definitions for D3JS d3 standard bundle v4.3
 // Project: https://github.com/d3/d3
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3/package.json
+++ b/d3/package.json
@@ -12,7 +12,7 @@
     "@types/d3-ease": "1.0",
     "@types/d3-force": "1.0",
     "@types/d3-format": "1.0",
-    "@types/d3-geo": "1.2",
+    "@types/d3-geo": "1.3",
     "@types/d3-hierarchy": "1.0",
     "@types/d3-interpolate": "1.1",
     "@types/d3-path": "1.0",
@@ -28,7 +28,7 @@
     "@types/d3-time-format": "2.0",
     "@types/d3-timer": "1.0",
     "@types/d3-transition": "1.0",
-    "@types/d3-voronoi": "1.0",
+    "@types/d3-voronoi": "1.1",
     "@types/d3-zoom": "1.0"
   }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: <<https://github.com/d3/d3/releases>>
- [x] Increase the version number in the header if appropriate.

This PR upgrades the pinned dependencies on d3-geo and d3-voronoi to correspond to the latest version of the D3 Standard Bundle. The header comment is bumped to v 4.3

* [Chore]: Bump minor version number in definitons header
* [Chore]: Bump minor version  of `@types/d3-geo` dependency in package.json to 1.3
* [Chore]: Bump minor version  of `@types/d3-voronoi` dependency in package.json to 1.1

Follow-up to #12296 and #12297.

cc @Ledragon @gustavderdrache