### PR TITLE
Update getDelegationToken for auth0-js

### DIFF
--- a/auth0-js/auth0-js.d.ts
+++ b/auth0-js/auth0-js.d.ts
@@ -22,7 +22,7 @@ interface Auth0Static {
     logout(query: string): void;
     getConnections(callback?: Function): void;
     refreshToken(refreshToken: string, callback: (error?: Auth0Error, delegationResult?: Auth0DelegationToken) => any): void;
-    getDelegationToken(targetClientId: string, id_token: string, options: any, callback: (error?: Auth0Error, delegationResult?: Auth0DelegationToken) => any): void;
+    getDelegationToken(options: any, callback: (error?: Auth0Error, delegationResult?: Auth0DelegationToken) => any): void;
     getProfile(id_token: string, callback?: Function): Auth0UserProfile;
     getSSOData(withActiveDirectories: any, callback?: Function): void;
     parseHash(hash: string): Auth0DecodedHash;


### PR DESCRIPTION
Tried passing in the `targetClientID` and `id_token` but got an error. 

Based on [Auth0.js delegation token documentation](https://github.com/auth0/auth0.js#delegation-token-request) you should just be passing in the options and callback. This worked for me.

```js
auth0.getDelegationToken(options, function (err, delegationResult) {
    // Call your API using delegationResult.id_token
});
```