### PR TITLE
Fixing react-addons-test-utils to find stateless components using scr…

### DIFF
--- a/react/react-addons-test-utils.d.ts
+++ b/react/react-addons-test-utils.d.ts
@@ -157,9 +157,17 @@ declare namespace __React {
                 root: Component<any, any>,
                 type: ClassType<any, T, C>): T[];
 
+            export function scryRenderedComponentsWithType<T extends StatelessComponent<{}>>(
+                root: Component<any, any>,
+                type: T): T[];
+
             export function findRenderedComponentWithType<T extends Component<{}, {}>, C extends ComponentClass<{}>>(
                 root: Component<any, any>,
                 type: ClassType<any, T, C>): T;
+
+            export function findRenderedComponentWithType<T extends StatelessComponent<{}>>(
+                root: Component<any, any>,
+                type: T): T;
 
             export function createRenderer(): ShallowRenderer;
         }

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -585,6 +585,11 @@ var foundComponent: ModernComponent = TestUtils.findRenderedComponentWithType(
 var foundComponents: ModernComponent[] = TestUtils.scryRenderedComponentsWithType(
     inst, ModernComponent);
 
+var statelessFoundComponent = TestUtils.findRenderedComponentWithType(
+    inst, StatelessComponent);
+var statelessFoundComponents = TestUtils.scryRenderedComponentsWithType(
+    inst, StatelessComponent);
+
 // ReactTestUtils custom type guards
 
 var emptyElement: React.ReactElement<{}>;


### PR DESCRIPTION
Please fill in this template.

- [ ] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [ ] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

…yRenderedComponentsWithType and findRenderedComponentWithType