### PR TITLE
React-addons-test-utils: fixed some issues with testing Stateless Components

### DIFF
--- a/react-addons-test-utils/index.d.ts
+++ b/react-addons-test-utils/index.d.ts
@@ -6,7 +6,7 @@
 import { AbstractView, Component, ComponentClass,
     ReactElement, ReactInstance, ClassType,
     DOMElement, SFCElement, CElement,
-    ReactHTMLElement, DOMAttributes, SFC } from 'react';
+    ReactHTMLElement, DOMAttributes, SFC, StatelessComponent } from 'react';
 
 export = TestUtils;
 
@@ -160,9 +160,17 @@ declare namespace TestUtils {
         root: Component<any, any>,
         type: ClassType<any, T, C>): T[];
 
+    export function scryRenderedComponentsWithType<T extends StatelessComponent<{}>>(
+        root: Component<any, any>,
+        type: T): T[];
+
     export function findRenderedComponentWithType<T extends Component<{}, {}>, C extends ComponentClass<{}>>(
         root: Component<any, any>,
         type: ClassType<any, T, C>): T;
+
+    export function findRenderedComponentWithType<T extends StatelessComponent<{}>>(
+        root: Component<any, any>,
+        type: T): T;
 
     export function createRenderer(): ShallowRenderer;
 }

--- a/react-addons-test-utils/index.d.ts
+++ b/react-addons-test-utils/index.d.ts
@@ -119,7 +119,7 @@ declare namespace TestUtils {
     export function renderIntoDocument<T extends Component<any, any>>(
         element: CElement<any, T>): T;
     export function renderIntoDocument<P>(
-        element: ReactElement<P>): Component<P, {}> | Element | void;
+        element: ReactElement<P>): Component<P, {}> | StatelessComponent<P> | Element | void;
 
     export function mockComponent(
         mocked: MockedComponentClass, mockTagName?: string): typeof TestUtils;
@@ -157,19 +157,19 @@ declare namespace TestUtils {
         tagName: string): Element;
 
     export function scryRenderedComponentsWithType<T extends Component<{}, {}>, C extends ComponentClass<{}>>(
-        root: Component<any, any>,
+        root: Component<any, any> | StatelessComponent<any>,
         type: ClassType<any, T, C>): T[];
 
     export function scryRenderedComponentsWithType<T extends StatelessComponent<{}>>(
-        root: Component<any, any>,
+        root: Component<any, any> | StatelessComponent<any>,
         type: T): T[];
 
     export function findRenderedComponentWithType<T extends Component<{}, {}>, C extends ComponentClass<{}>>(
-        root: Component<any, any>,
+        root: Component<any, any> | StatelessComponent<any>,
         type: ClassType<any, T, C>): T;
 
     export function findRenderedComponentWithType<T extends StatelessComponent<{}>>(
-        root: Component<any, any>,
+        root: Component<any, any> | StatelessComponent<any>,
         type: T): T;
 
     export function createRenderer(): ShallowRenderer;

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -599,10 +599,12 @@ var foundComponent: ModernComponent = TestUtils.findRenderedComponentWithType(
 var foundComponents: ModernComponent[] = TestUtils.scryRenderedComponentsWithType(
     inst, ModernComponent);
 
+var statelessComp = TestUtils.renderIntoDocument<SCProps>(statelessElement) as React.StatelessComponent<SCProps>;
+
 var statelessFoundComponent = TestUtils.findRenderedComponentWithType(
-    inst, StatelessComponent);
+    statelessComp, StatelessComponent);
 var statelessFoundComponents = TestUtils.scryRenderedComponentsWithType(
-    inst, StatelessComponent);
+    statelessComp, StatelessComponent);
 
 // ReactTestUtils custom type guards
 

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -599,6 +599,11 @@ var foundComponent: ModernComponent = TestUtils.findRenderedComponentWithType(
 var foundComponents: ModernComponent[] = TestUtils.scryRenderedComponentsWithType(
     inst, ModernComponent);
 
+var statelessFoundComponent = TestUtils.findRenderedComponentWithType(
+    inst, StatelessComponent);
+var statelessFoundComponents = TestUtils.scryRenderedComponentsWithType(
+    inst, StatelessComponent);
+
 // ReactTestUtils custom type guards
 
 var emptyElement: React.ReactElement<{}>;


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [ ] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
