### PR TITLE
mongodb: Cursor.map returns Cursor, not void

### DIFF
--- a/mongodb/mongodb.d.ts
+++ b/mongodb/mongodb.d.ts
@@ -1172,7 +1172,7 @@ declare module "mongodb" {
     // http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#limit
     limit(value: number): Cursor;
     // http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#map
-    map(transform: Function): void;
+    map(transform: Function): Cursor;
     // http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#max
     max(max: number): Cursor;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#maxAwaitTimeMS


### PR DESCRIPTION
The `Cursor.map` function actually returns a `Cursor` instance, and not `void`.