### PR TITLE
Added missing nconf.required(keys) and Provider.required(keys) methods.

### DIFF
--- a/nconf/nconf-tests.ts
+++ b/nconf/nconf-tests.ts
@@ -57,6 +57,7 @@ nconf.init(opts);
 p = nconf.overrides();
 p = nconf.overrides(opts);
 nconf.remove(str);
+bool = nconf.required(strArr);
 store = nconf.create(str, opts);
 
 str = nconf.key(value, value);
@@ -118,6 +119,7 @@ p = p.defaults(opts);
 p.init(opts);
 p = p.overrides(opts);
 p.remove(str);
+bool = p.required(strArr);
 store = p.create(str, opts);
 
 // - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/nconf/nconf.d.ts
+++ b/nconf/nconf.d.ts
@@ -32,6 +32,7 @@ declare module "nconf" {
 	export function init(options?: IOptions): void;
 	export function overrides(options?: IOptions): Provider;
 	export function remove(name: string): void;
+	export function required(keys: string[]): boolean;
 	export function create(name: string, options: IOptions): IStore;
 
 	export function key(...values: any[]): string;
@@ -95,6 +96,7 @@ declare module "nconf" {
 		init(options?: IOptions): void;
 		overrides(options?: IOptions): Provider;
 		remove(name: string): void;
+		required(keys: string[]): boolean;
 		create(name: string, options: IOptions): IStore;
 	}
 


### PR DESCRIPTION
Please fill in this template.

- [ ] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: [nconf#nconfrequiredkeys](https://github.com/indexzero/nconf#nconfrequiredkeys)
- [x] Increase the version number in the header if appropriate.

