### PR TITLE
Revert "[@types/mongoose] Declare a right type for _id"

### DIFF
--- a/mongoose/index.d.ts
+++ b/mongoose/index.d.ts
@@ -871,7 +871,7 @@ declare module "mongoose" {
     /** Hash containing current validation errors. */
     errors: Object;
     /** This documents _id. */
-    _id: mongodb.ObjectID;
+    _id: any;
     /** Boolean flag specifying if the document is new. */
     isNew: boolean;
     /** The documents schema. */

--- a/passport-local-mongoose/passport-local-mongoose-tests.ts
+++ b/passport-local-mongoose/passport-local-mongoose-tests.ts
@@ -23,6 +23,7 @@ import { Strategy as LocalStrategy } from 'passport-local';
 
 //#region Test Models
 interface User extends PassportLocalDocument {
+    _id: string;
     username: string;
     hash: string;
     salt: string;


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#12462

There is no right type for `_id`, it can be any type not just `ObjectID`, the typings should reflect that.
This was an issue before. #7593