### PR TITLE
[convert-source-map] Update convert-source-map to latest v1.3.0

### DIFF
--- a/convert-source-map/convert-source-map.d.ts
+++ b/convert-source-map/convert-source-map.d.ts
@@ -1,27 +1,87 @@
-// Type definitions for convert-source-map
+// Type definitions for convert-source-map v1.3.0
 // Project: https://github.com/thlorenz/convert-source-map
-// Definitions by: Andrew Gaspar <https://github.com/AndrewGaspar/>
+// Definitions by: Andrew Gaspar <https://github.com/AndrewGaspar/>, TeamworkGuy2 <https://github.com/TeamworkGuy2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/** Converts a source-map from/to different formats and allows adding/changing properties.
+ * (documentation based on project's README file)
+ */
 declare module "convert-source-map" {
-	export interface SourceMapConverter {
-		toObject(): any;
-		toJSON(space?: any): string;
-		toBase64(): string;
-		toComment(): string;
 
-		addProperty(key: string, value: any): SourceMapConverter;
+    export interface SourceMapConverter {
+        /** The parsed sourcemap object */
+        sourcemap: any;
+
+        /** Returns a copy of the underlying source map */
+        toObject(): any;
+
+        /** Converts source map to json string. If space is given (optional), this will be passed to JSON.stringify when the JSON string is generated */
+        toJSON(space?: string | number): string;
+
+        /** Converts source map to base64 encoded json string */
+        toBase64(): string;
+
+        /** Converts source map to an inline comment that can be appended to the source-file.
+         * By default, the comment is formatted like: //# sourceMappingURL=..., which you would normally see in a JS source file.
+         * When options.multiline == true, the comment is formatted like: /*# sourceMappingURL=... *\/, which you would find in a CSS source file
+         */
+        toComment(options?: { multiline?: boolean }): string;
+
+        /** Adds given property to the source map. Throws an error if property already exists */
+        addProperty(key: string, value: any): SourceMapConverter;
+
+        /** Sets given property to the source map. If property doesn't exist it is added, otherwise its value is updated */
 		setProperty(key: string, value: any): SourceMapConverter;
 
+        /** Gets given property of the source map */
 		getProperty(key: string): any;
 	}
 
-	export function removeComments(src: string): string;
-	export var commentRegex: RegExp;
 
-	export function fromObject(obj: any): SourceMapConverter;
-	export function fromJSON(json: string): SourceMapConverter;
-	export function fromBase64(base64: string): SourceMapConverter;
-	export function fromComment(comment: string): SourceMapConverter;
-	export function fromSource(source: string): SourceMapConverter;
+    /** Returns source map converter from given object */
+    export function fromObject(obj: any): SourceMapConverter;
+
+    /** Returns source map converter from given json string */
+    export function fromJSON(json: string): SourceMapConverter;
+
+    /** Returns source map converter from given base64 encoded json string */
+    export function fromBase64(base64: string): SourceMapConverter;
+
+    /** Returns source map converter from given base64 encoded json string prefixed with //# sourceMappingURL=... */
+    export function fromComment(comment: string): SourceMapConverter;
+
+    /**Returns source map converter from given filename by parsing //# sourceMappingURL=filename.
+     * filename must point to a file that is found inside the mapFileDir. Most tools store this file right next to the generated file, i.e. the one containing the source map.
+     */
+    export function fromMapFileComment(comment: string, commentFileDir: string): SourceMapConverter;
+
+    /** Finds last sourcemap comment in file and returns source map converter or returns null if no source map comment was found.
+     * If largeSource is set to true, an algorithm that does not use regex is applied to find the source map.
+     * This is faster and especially useful if you're running into "call stack size exceeded" errors with the default algorithm.
+     * However, it is less accurate and may match content that isn't a source map comment.
+     */
+    export function fromSource(content: string, largeSource?: boolean): SourceMapConverter;
+
+    /** Finds last sourcemap comment in file and returns source map converter or returns null if no source map comment was found.
+     * The sourcemap will be read from the map file found by parsing # sourceMappingURL=file comment. For more info see fromMapFileComment.
+     */
+    export function fromMapFileSource(content: string, commentFileDir: string): SourceMapConverter;
+
+    /** Returns src with all source map comments removed */
+    export function removeComments(src: string): string;
+
+    /** Returns src with all source map comments pointing to map files removed */
+    export function removeMapFileComments(src: string): string;
+
+    /** Returns the regex used to find source map comments */
+    export var commentRegex: RegExp;
+
+    /** Returns the regex used to find source map comments pointing to map files */
+    export var mapFileCommentRegex: RegExp;
+
+    /** Returns a comment that links to an external source map via file.
+     * By default, the comment is formatted like: //# sourceMappingURL=..., which you would normally see in a JS source file.
+     * When options.multiline == true, the comment is formatted like: /*# sourceMappingURL=... *\/, which you would find in a CSS source file.
+     */
+    export function generateMapFileComment(file: string, options?: { multiline?: boolean }): string;
 }


### PR DESCRIPTION
- [ ] Prefer to make your PR against the `types-2.0` branch. 
 -  TeamworkGuy2: _I haven't had time to install typescript@2.0 in Visual Studio and figure out how definition files work in it.  When I do, I'll update the various DT definitions I've written_
- [ ] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/thlorenz/convert-source-map/blob/master/index.js
- [x] Increase the version number in the header if appropriate.

Changes:
Added documentation copy-pasted from project's README file. 
Added some missing functions, parameters, and 'sourcemap' property based on the source code.
