### PR TITLE
Allow children in stateless components’ props by default

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -201,7 +201,7 @@ declare namespace React {
 
     type SFC<P> = StatelessComponent<P>;
     interface StatelessComponent<P> {
-        (props: P, context?: any): ReactElement<any>;
+        (props: P & { children?: ReactNode }, context?: any): ReactElement<any>;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: P;

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -152,6 +152,10 @@ StatelessComponent2.defaultProps = {
     foo: 42
 };
 
+var StatelessComponent3: React.SFC<SCProps> =
+    // allows usage of props.children
+    props => React.DOM.div(null, props.foo, props.children);
+
 // React.createFactory
 var factory: React.CFactory<Props, ModernComponent> =
     React.createFactory(ModernComponent);

--- a/react/react-tsx-tests.tsx
+++ b/react/react-tsx-tests.tsx
@@ -13,3 +13,13 @@ StatelessComponent.defaultProps = {
 };
 
 <StatelessComponent />;
+
+var StatelessComponent2: React.SFC<SCProps> = ({ foo, children }) => {
+    return <div>{ foo }{ children }</div>;
+};
+StatelessComponent2.displayName = "StatelessComponent4";
+StatelessComponent2.defaultProps = {
+    foo: 42
+};
+
+<StatelessComponent2>24</StatelessComponent2>;


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://facebook.github.io/react/docs/jsx-in-depth.html#children-in-jsx
- [ ] Increase the version number in the header if appropriate.

This allows passing children to `StatelessComponent<P>` exactly like base components without the need to use `React.Props<T>` or extending the `P` type with an explicit 'children' property.

# Before
````typescript
    type FooProps = {
      bar: number;
    }
    const Foo: React.SFC<FooProps> = props => (
      <div>
        {props.children} = {props.bar} // error TS2459: Type 'FooProps' has no property 'children' and no string index signature.
      </div>
    );
````

# After
````typescript
    type FooProps = {
      bar: number;
    }
    const Foo: React.SFC<FooProps> = props => (
      <div>
        {props.children} = {props.bar}
      </div>
    );

    <Foo bar="42">6×9</Foo> // <div>6×9 = 42</div>
````
