### PR TITLE
Adds missing `retained` status to `KnockoutArrayChange`

### DIFF
--- a/knockout/knockout.d.ts
+++ b/knockout/knockout.d.ts
@@ -332,7 +332,7 @@ interface KnockoutUtils {
 }
 
 interface KnockoutArrayChange<T> {
-    status: "added" | "deleted";
+    status: "added" | "deleted" | "retained";
     value: T;
     index: number;
     moved?: number;


### PR DESCRIPTION
Adds missing `retained` status to `KnockoutArrayChange`: [Reference](https://github.com/knockout/knockout/blob/241c26ca82e6e4b3eaee39e3dc0a92f85bc1df0c/src/binding/editDetection/arrayToDomNodeChildren.js#L112)