### PR TITLE
Add 'bytesRead' and 'path' to fs.ReadStream

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1522,7 +1522,7 @@ declare module "child_process" {
         disconnect(): void;
         unref(): void;
         ref(): void;
-    
+
         /**
          * events.EventEmitter
          * 1. close
@@ -2150,6 +2150,8 @@ declare module "fs" {
     export interface ReadStream extends stream.Readable {
         close(): void;
         destroy(): void;
+        bytesRead: number;
+        path: string | Buffer;
 
         /**
          * events.EventEmitter


### PR DESCRIPTION
- [ ] Prefer to make your PR against the `types-2.0` branch.
> We need them here, will create another PR for `types-2.0`
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: 

https://nodejs.org/api/fs.html#fs_readstream_bytesread
https://nodejs.org/api/fs.html#fs_readstream_path

> Add *bytesRead* and *path* to ReadStream according to API