### PR TITLE
fix: Correct import issues using old import format

### DIFF
--- a/clipboard/index.d.ts
+++ b/clipboard/index.d.ts
@@ -52,5 +52,6 @@ interface ClipboardEvent {
 }
 
 declare module 'clipboard' {
-    export = Clipboard;
+    const clipboard: typeof Clipboard;
+    export = clipboard;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] The package does not provide its own types, and you can not add them.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header.

If changing an existing definition:
- [ ] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

For whatever reason, TypeScript isn't happy importing unless you expose the type as a variable of your declared module... This fixes the problem through the use of the `typeof` operator.