### PR TITLE
Add aws4 type definitions

### DIFF
--- a/aws4/aws4-tests.ts
+++ b/aws4/aws4-tests.ts
@@ -1,0 +1,24 @@
+/// <reference path="./index.d.ts" />
+
+import * as aws4 from ".";
+
+let requestSigner = new aws4.RequestSigner({}, {});
+requestSigner.matchHost("");
+requestSigner.isSingleRegion();
+requestSigner.createHost();
+requestSigner.prepareRequest();
+requestSigner.sign();
+requestSigner.getDateTime();
+requestSigner.getDate();
+requestSigner.authHeader();
+requestSigner.signature();
+requestSigner.stringToSign();
+requestSigner.canonicalString();
+requestSigner.canonicalHeaders();
+requestSigner.signedHeaders();
+requestSigner.credentialString();
+requestSigner.defaultCredentials();
+requestSigner.parsePath();
+requestSigner.formatPath();
+
+aws4.sign({}, {});

--- a/aws4/index.d.ts
+++ b/aws4/index.d.ts
@@ -1,0 +1,33 @@
+// Type definitions for aws4 1.5.0
+// Project: https://github.com/mhart/aws4
+// Definitions by: Andrew Crites <https://github.com/ajcrites>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export class RequestSigner {
+    constructor(request?: any, credentials?: any);
+    request: any;
+    credentials: any;
+    service: any;
+    region: any;
+    isCodeCommitGit: any;
+
+    matchHost(host?: string): string;
+    isSingleRegion(): boolean;
+    createHost(): string;
+    prepareRequest(): void;
+    sign(): any;
+    getDateTime(): string;
+    getDate(): string;
+    authHeader(): string;
+    signature(): string;
+    stringToSign(): string;
+    canonicalString(): string;
+    canonicalHeaders(): string;
+    signedHeaders(): string;
+    credentialString(): string;
+    defaultCredentials(): any;
+    parsePath(): any;
+    formatPath(): string;
+}
+
+export function sign(options?: any, credentials?: any): RequestSigner;

--- a/aws4/tsconfig.json
+++ b/aws4/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "aws4-tests.ts"
+    ]
+}


### PR DESCRIPTION
Please fill in this template.

- [X] Prefer to make your PR against the `types-2.0` branch.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [X] The package does not provide its own types, and you can not add them.
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Run `tsc` without errors.
- [X] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.