### PR TITLE
jQuery: Export jQuery instead of $

### DIFF
--- a/jquery/index.d.ts
+++ b/jquery/index.d.ts
@@ -3243,7 +3243,7 @@ interface JQuery {
     queue(queueName: string, callback: Function): JQuery;
 }
 declare module "jquery" {
-    export = $;
+    export = jQuery;
 }
 declare var jQuery: JQueryStatic;
 declare var $: JQueryStatic;


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: http://stackoverflow.com/a/39361876/1130 and https://github.com/DefinitelyTyped/DefinitelyTyped/issues/2734
- [n/a] Increase the version number in the header if appropriate.

`$` can conflict with other libraries in the global namespace (like angular-protractor). When that's the case, import statement like this don't work: `import * as $ from 'jquery'`.   
Export `jQuery` instead of `$` to avoid issues when importing jQuery.
