### PR TITLE
Allow ES6 import syntax for react-fontawesome

### DIFF
--- a/react-fontawesome/react-fontawesome-tests.tsx
+++ b/react-fontawesome/react-fontawesome-tests.tsx
@@ -4,7 +4,7 @@
 
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import FontAwesome = require('react-fontawesome');
+import * as FontAwesome from 'react-fontawesome';
 
 class TestComponent extends React.Component<{}, {}> {
 

--- a/react-fontawesome/react-fontawesome.d.ts
+++ b/react-fontawesome/react-fontawesome.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-fontawesome v.1.1.0
+// Type definitions for react-fontawesome v.1.2.0
 // Project: https://github.com/danawoodman/react-fontawesome
 // Definitions by: Timur Rustamov <https://github.com/timurrustamov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -29,6 +29,8 @@ declare module "react-fontawesome" {
   }
 
   class FontAwesome extends React.Component<FontAwesomeProps, {}> {}
+
+  namespace FontAwesome {}
 
   export = FontAwesome;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: <<https://github.com/Microsoft/TypeScript/issues/5073>>
- [x] Increase the version number in the header if appropriate.

Allow ES6 import syntax. Example:
```javascript 
import * as f from 'react-fontawesome';
```