### PR TITLE
Include interface Archiver in namespace

### DIFF
--- a/archiver/index.d.ts
+++ b/archiver/index.d.ts
@@ -18,29 +18,32 @@
 import * as FS from 'fs';
 import * as STREAM from 'stream';
 
-interface nameInterface {
-    name?: string;
-}
 
-interface Archiver extends STREAM.Transform {
-    pipe(writeStream: FS.WriteStream): void;
+declare function archiver(format: string, options?: archiver.Options): archiver.Archiver;
+
+declare namespace archiver {
+
+    export function create(format: string, options?: Options): Archiver;
+
+
+    export interface nameInterface {
+        name?: string;
+    }
+
+    export interface Archiver extends STREAM.Transform {
+        pipe(writeStream: FS.WriteStream): void;
         append(source: FS.ReadStream | Buffer | string, name: nameInterface): void;
 
         directory(dirpath: string, destpath: nameInterface | string): void;
         directory(dirpath: string, destpath: nameInterface | string, data: any | Function): void;
 
         bulk(mappings: any): void;
-    finalize(): void;
-}
+        finalize(): void;
+    }
 
-interface Options {
+    export interface Options {
 
-}
-
-declare function archiver(format: string, options?: Options): Archiver;
-
-declare namespace archiver {
-    function create(format: string, options?: Options): Archiver;
+    }
 }
 
 export = archiver;


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: http://pastebin.com/raw/JPUm9dDA
- [x] Increase the version number in the header if appropriate.

I've included the interface Archiver in the namespace. Basically this makes it easier to pass around an archive as a function parameter when using the typedefinition files