### PR TITLE
Add type definition for keymirror

### DIFF
--- a/keymirror/index.d.ts
+++ b/keymirror/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for keymirror 0.1.1
+// Project: https://github.com/STRML/keyMirror
+// Definitions by: Johannes Fahrenkrug <https://github.com/jfahrenkrug>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function KeyMirror(obj: Object): Object;
+export = KeyMirror;

--- a/keymirror/index.d.ts
+++ b/keymirror/index.d.ts
@@ -3,5 +3,5 @@
 // Definitions by: Johannes Fahrenkrug <https://github.com/jfahrenkrug>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function KeyMirror(obj: Object): Object;
+declare function KeyMirror(obj: {}): { [key: string]: string };
 export = KeyMirror;

--- a/keymirror/keymirror-tests.ts
+++ b/keymirror/keymirror-tests.ts
@@ -1,0 +1,3 @@
+import keyMirror = require('keymirror');
+
+keyMirror({key1: null, key2: null});

--- a/keymirror/tsconfig.json
+++ b/keymirror/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "keymirror-tests.ts"
+    ]
+}


### PR DESCRIPTION
This adds the type definitions for the tiny keymirror package.

- [X] Prefer to make your PR against the `types-2.0` branch.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [X] The package does not provide its own types, and you can not add them.
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Run `tsc` without errors.
- [X] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.


