### PR TITLE
More accurate hinted and inferred types for react-redux connect()

### DIFF
--- a/react-redux/react-redux-tests.tsx
+++ b/react-redux/react-redux-tests.tsx
@@ -8,7 +8,7 @@ import { Component, ReactElement } from 'react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Router, RouterState } from 'react-router';
-import { Store, Dispatch, bindActionCreators } from 'redux';
+import { ActionCreator, Store, Dispatch, bindActionCreators } from 'redux';
 import { connect, Provider } from 'react-redux';
 import objectAssign = require('object-assign');
 import * as History from 'history';
@@ -17,302 +17,324 @@ import * as History from 'history';
 // Quick Start
 // https://github.com/rackt/react-redux/blob/master/docs/quick-start.md#quick-start
 //
-
-interface CounterState {
-    counter: number;
-}
-declare var increment: Function;
-
-class Counter extends Component<any, any> {
-    render() {
-        return (
-            <button onClick={this.props.onIncrement}>
-                {this.props.value}
-            </button>
-        );
+namespace TestQuickStartExample {
+    interface CounterStateProps {
+        value: number;
     }
-}
+    interface CounterDispatchProps {
+        onIncrement: ActionCreator<CounterState>;
+    }
+    interface CounterState {
+        counter: number;
+    }
+    declare var increment: Function;
 
-function mapStateToProps(state: CounterState) {
-    return {
+    class Counter extends Component<CounterStateProps & CounterDispatchProps, CounterState> {
+        render() {
+            return (
+                <button onClick={this.props.onIncrement}>
+                    {this.props.value}
+                </button>
+            );
+        }
+    }
+
+    const mapStateToProps = (state: CounterState) => ({
         value: state.counter
-    };
-}
-
-// Which action creators does it want to receive by props?
-function mapDispatchToProps(dispatch: Dispatch<CounterState>) {
-    return {
-        onIncrement: () => dispatch(increment())
-    };
-}
-
-connect(
-    mapStateToProps,
-    mapDispatchToProps
-)(Counter);
-
-
-@connect(mapStateToProps)
-class CounterContainer extends Component<any, any> {
-
-}
-
-// Ensure connect's first two arguments can be replaced by wrapper functions
-interface ICounterStateProps {
-    value: number
-}
-interface ICounterDispatchProps {
-    onIncrement: () => void
-}
-connect<ICounterStateProps, ICounterDispatchProps, {}>(
-    () => mapStateToProps,
-    () => mapDispatchToProps
-)(Counter);
-// only first argument
-connect<ICounterStateProps, {}, {}>(
-    () => mapStateToProps
-)(Counter);
-// wrap only one argument
-connect<ICounterStateProps, ICounterDispatchProps, {}>(
-    mapStateToProps,
-    () => mapDispatchToProps
-)(Counter);
-// with extra arguments
-connect<ICounterStateProps, ICounterDispatchProps, {}>(
-    () => mapStateToProps,
-    () => mapDispatchToProps,
-    (s: ICounterStateProps, d: ICounterDispatchProps) =>
-        objectAssign({}, s, d),
-    { pure: true }
-)(Counter);
-
-
-class App extends Component<any, any> {
-    render(): JSX.Element {
-        // ...
-        return null;
-    }
-}
-
-const targetEl = document.getElementById('root');
-
-ReactDOM.render((
-    <Provider store={store}>
-        {() => <App />}
-    </Provider>
-), targetEl);
-
-//
-// API
-// https://github.com/rackt/react-redux/blob/master/docs/api.md
-//
-declare var store: Store<TodoState>;
-declare var routerState: RouterState;
-declare var history: History.History;
-class MyRootComponent extends Component<any, any> {
-
-}
-class TodoApp extends Component<any, any> {
-
-}
-interface TodoState {
-    todos: string[]|string;
-}
-interface TodoProps {
-    userId: number;
-}
-interface DispatchProps {
-    addTodo(userId: number, text: string): void;
-    action: Function;
-}
-declare var actionCreators: () => {
-    action: Function;
-}
-declare var addTodo: () => { type: string; };
-declare var todoActionCreators: { [type: string]: (...args: any[]) => any; };
-declare var counterActionCreators: { [type: string]: (...args: any[]) => any; };
-
-ReactDOM.render(
-  <Provider store={store}>
-    {() => <MyRootComponent />}
-  </Provider>,
-  document.body
-);
-
-//TODO: for React Router 0.13
-////TODO: error TS2339: Property 'run' does not exist on type 'typeof "react-router"'.
-////TODO: error TS2339: Property 'HistoryLocation' does not exist on type 'typeof "react-router"'.
-//declare var routes: any;
-//Router.run(routes, Router.HistoryLocation, (Handler, routerState) => { // note "routerState" here
-//    ReactDOM.render(
-//        <Provider store={store}>
-//            {/*
-//             //TODO: error TS2339: Property 'routerState' does not exist on type 'RouteProp'.
-//             {() => <Handler routerState={routerState} />} // note "routerState" here: important to pass it down
-//            */}
-//        </Provider>,
-//        document.getElementById('root')
-//    );
-//});
-
-
-//TODO: for React Router 1.0
-ReactDOM.render(
-    <Provider store={store}>
-        {() => <Router history={history}>...</Router>}
-    </Provider>,
-    targetEl
-);
-
-// Inject just dispatch and don't listen to store
-
-connect()(TodoApp);
-
-// Inject dispatch and every field in the global state
-
-connect((state: TodoState) => state)(TodoApp);
-
-// Inject dispatch and todos
-
-function mapStateToProps2(state: TodoState) {
-    return { todos: state.todos };
-}
-
-export default connect(mapStateToProps2)(TodoApp);
-
-// Inject todos and all action creators (addTodo, completeTodo, ...)
-
-//function mapStateToProps(state) {
-//    return { todos: state.todos };
-//}
-
-connect(mapStateToProps2, actionCreators)(TodoApp);
-
-// Inject todos and all action creators (addTodo, completeTodo, ...) as actions
-
-//function mapStateToProps(state) {
-//    return { todos: state.todos };
-//}
-
-function mapDispatchToProps2(dispatch: Dispatch<TodoState>) {
-    return { actions: bindActionCreators(actionCreators, dispatch) };
-}
-
-connect(mapStateToProps2, mapDispatchToProps2)(TodoApp);
-
-// Inject todos and a specific action creator (addTodo)
-
-//function mapStateToProps(state) {
-//    return { todos: state.todos };
-//}
-
-function mapDispatchToProps3(dispatch: Dispatch<TodoState>) {
-    return bindActionCreators({ addTodo }, dispatch);
-}
-
-connect(mapStateToProps2, mapDispatchToProps3)(TodoApp);
-
-// Inject todos, todoActionCreators as todoActions, and counterActionCreators as counterActions
-
-//function mapStateToProps(state) {
-//    return { todos: state.todos };
-//}
-
-function mapDispatchToProps4(dispatch: Dispatch<TodoState>) {
-    return {
-        todoActions: bindActionCreators(todoActionCreators, dispatch),
-        counterActions: bindActionCreators(counterActionCreators, dispatch)
-    };
-}
-
-connect(mapStateToProps2, mapDispatchToProps4)(TodoApp);
-
-// Inject todos, and todoActionCreators and counterActionCreators together as actions
-
-//function mapStateToProps(state) {
-//    return { todos: state.todos };
-//}
-
-function mapDispatchToProps5(dispatch: Dispatch<TodoState>) {
-    return {
-        actions: bindActionCreators(objectAssign({}, todoActionCreators, counterActionCreators), dispatch)
-    };
-}
-
-connect(mapStateToProps2, mapDispatchToProps5)(TodoApp);
-
-// Inject todos, and all todoActionCreators and counterActionCreators directly as props
-
-//function mapStateToProps(state) {
-//    return { todos: state.todos };
-//}
-
-function mapDispatchToProps6(dispatch: Dispatch<TodoState>) {
-    return bindActionCreators(objectAssign({}, todoActionCreators, counterActionCreators), dispatch);
-}
-
-connect(mapStateToProps2, mapDispatchToProps6)(TodoApp);
-
-// Inject todos of a specific user depending on props
-
-function mapStateToProps3(state: TodoState, ownProps: TodoProps): TodoState {
-    return { todos: state.todos[ownProps.userId] };
-}
-
-connect(mapStateToProps3)(TodoApp);
-
-// Inject todos of a specific user depending on props, and inject props.userId into the action
-
-//function mapStateToProps(state) {
-//    return { todos: state.todos };
-//}
-
-function mergeProps(stateProps: TodoState, dispatchProps: DispatchProps, ownProps: TodoProps): DispatchProps & TodoState & TodoProps {
-    return objectAssign({}, ownProps, dispatchProps, {
-        todos: stateProps.todos[ownProps.userId],
-        addTodo: (text: string) => dispatchProps.addTodo(ownProps.userId, text)
     });
+
+    // Which action creators does it want to receive by props?
+    const mapDispatchToProps = (dispatch: Dispatch<CounterState>) => ({
+        onIncrement: () => dispatch(increment())
+    });
+
+    connect(
+        mapStateToProps,
+        mapDispatchToProps
+    )(Counter);
+
+    // https://github.com/Microsoft/TypeScript/issues/4881
+    //@connect(mapStateToProps)
+    //class WrappedCounter extends Component<CounterStateProps & CounterDispatchProps, CounterState> {
+    //}
+    //React.createElement(WrappedCounter, {});
+    // As a workaround, declare state and dispatch props as optional
+    interface OptionalCounterStateProps {
+        value?: number;
+    }
+    interface OptionalCounterDispatchProps {
+        onIncrement?: ActionCreator<CounterState>;
+    }
+    interface Props {
+        requiredOwnProp: string
+    }
+    @connect(mapStateToProps)
+    class WrappedCounter extends Component<Props & OptionalCounterStateProps & OptionalCounterDispatchProps, CounterState> {
+    }
+    React.createElement(WrappedCounter, { requiredOwnProp: 'here I am' });
+
+    // Ensure connect's first two arguments can be replaced by wrapper functions
+    connect<CounterStateProps, CounterDispatchProps, {}>(
+        () => mapStateToProps,
+        () => mapDispatchToProps
+    )(Counter);
+    // only first argument
+    connect<CounterStateProps, {}, {}>(
+        () => mapStateToProps
+    )(Counter);
+    // wrap only one argument
+    connect<CounterStateProps, CounterDispatchProps, {}>(
+        mapStateToProps,
+        () => mapDispatchToProps
+    )(Counter);
+    // with extra arguments
+    connect<CounterStateProps, CounterDispatchProps, {}, CounterStateProps & CounterDispatchProps>(
+        () => mapStateToProps,
+        () => mapDispatchToProps,
+        (stateProps: CounterStateProps, dispatchProps: CounterDispatchProps) =>
+            objectAssign({}, stateProps, dispatchProps),
+        { pure: true }
+    )(Counter);
 }
 
-connect(mapStateToProps2, actionCreators, mergeProps)(TodoApp);
+namespace TestTodosApp {
+
+    class App extends Component<any, any> {
+        render(): JSX.Element {
+            // ...
+            return null;
+        }
+    }
+
+    const targetEl = document.getElementById('root');
+
+    ReactDOM.render((
+        <Provider store={store}>
+            {() => <App />}
+        </Provider>
+    ), targetEl);
+
+    //
+    // API
+    // https://github.com/rackt/react-redux/blob/master/docs/api.md
+    //
+    declare var store: Store<TodoState>;
+    declare var routerState: RouterState;
+    declare var history: History.History;
+    class MyRootComponent extends Component<{}, RouterState> {
+    }
+    class TodoApp extends Component<any, TodoState> {
+    }
+    interface TodoState {
+        todos: string[] | string;
+    }
+    interface TodoProps {
+        userId: number;
+    }
+    interface DispatchProps {
+        addTodo(userId: number, text: string): void;
+        action: Function;
+    }
+    declare var actionCreators: () => {
+        action: Function;
+    }
+    declare var addTodo: () => { type: string; };
+    declare var todoActionCreators: { [type: string]: (...args: any[]) => any; };
+    declare var counterActionCreators: { [type: string]: (...args: any[]) => any; };
+
+    ReactDOM.render(
+        <Provider store={store}>
+            {() => <MyRootComponent />}
+        </Provider>,
+        document.body
+    );
+
+    //TODO: for React Router 0.13
+    ////TODO: error TS2339: Property 'run' does not exist on type 'typeof "react-router"'.
+    ////TODO: error TS2339: Property 'HistoryLocation' does not exist on type 'typeof "react-router"'.
+    //declare var routes: any;
+    //Router.run(routes, Router.HistoryLocation, (Handler, routerState) => { // note "routerState" here
+    //    ReactDOM.render(
+    //        <Provider store={store}>
+    //            {/*
+    //             //TODO: error TS2339: Property 'routerState' does not exist on type 'RouteProp'.
+    //             {() => <Handler routerState={routerState} />} // note "routerState" here: important to pass it down
+    //            */}
+    //        </Provider>,
+    //        document.getElementById('root')
+    //    );
+    //});
 
 
+    //TODO: for React Router 1.0
+    ReactDOM.render(
+        <Provider store={store}>
+            {() => <Router history={history}>...</Router>}
+        </Provider>,
+        targetEl
+    );
 
+    // Inject just dispatch and don't listen to store
 
+    connect()(TodoApp);
 
-interface TestProp {
-    property1: number;
-    someOtherProperty?: string;
+    // Inject dispatch and every field in the global state
+
+    connect((state: TodoState) => state)(TodoApp);
+
+    // Inject dispatch and todos
+
+    function mapStateToProps(state: TodoState) {
+        return { todos: state.todos };
+    }
+
+    connect(mapStateToProps)(TodoApp);
+
+    // Inject todos and all action creators (addTodo, completeTodo, ...)
+
+    //function mapStateToProps(state) {
+    //    return { todos: state.todos };
+    //}
+
+    connect(mapStateToProps, actionCreators)(TodoApp);
+
+    // Inject todos and all action creators (addTodo, completeTodo, ...) as actions
+
+    //function mapStateToProps(state) {
+    //    return { todos: state.todos };
+    //}
+
+    function mapDispatchToProps(dispatch: Dispatch<TodoState>) {
+        return { actions: bindActionCreators(actionCreators, dispatch) };
+    }
+
+    connect(mapStateToProps, mapDispatchToProps)(TodoApp);
+
+    // Inject todos and a specific action creator (addTodo)
+
+    //function mapStateToProps(state) {
+    //    return { todos: state.todos };
+    //}
+
+    function mapDispatchToProps2(dispatch: Dispatch<TodoState>) {
+        return bindActionCreators({ addTodo }, dispatch);
+    }
+
+    connect(mapStateToProps, mapDispatchToProps2)(TodoApp);
+
+    // Inject todos, todoActionCreators as todoActions, and counterActionCreators as counterActions
+
+    //function mapStateToProps(state) {
+    //    return { todos: state.todos };
+    //}
+
+    function mapDispatchToProps3(dispatch: Dispatch<TodoState>) {
+        return {
+            todoActions: bindActionCreators(todoActionCreators, dispatch),
+            counterActions: bindActionCreators(counterActionCreators, dispatch)
+        };
+    }
+
+    connect(mapStateToProps, mapDispatchToProps3)(TodoApp);
+
+    // Inject todos, and todoActionCreators and counterActionCreators together as actions
+
+    //function mapStateToProps(state) {
+    //    return { todos: state.todos };
+    //}
+
+    function mapDispatchToProps4(dispatch: Dispatch<TodoState>) {
+        return {
+            actions: bindActionCreators(objectAssign({}, todoActionCreators, counterActionCreators), dispatch)
+        };
+    }
+
+    connect(mapStateToProps, mapDispatchToProps4)(TodoApp);
+
+    // Inject todos, and all todoActionCreators and counterActionCreators directly as props
+
+    //function mapStateToProps(state) {
+    //    return { todos: state.todos };
+    //}
+
+    function mapDispatchToProps5(dispatch: Dispatch<TodoState>) {
+        return bindActionCreators(objectAssign({}, todoActionCreators, counterActionCreators), dispatch);
+    }
+
+    connect(mapStateToProps, mapDispatchToProps5)(TodoApp);
+
+    // Inject todos of a specific user depending on props
+
+    function mapStateToProps2(state: TodoState, ownProps: TodoProps): TodoState {
+        return { todos: state.todos[ownProps.userId] };
+    }
+
+    connect(mapStateToProps2)(TodoApp);
+
+    // Inject todos of a specific user depending on props, and inject props.userId into the action
+
+    //function mapStateToProps(state) {
+    //    return { todos: state.todos };
+    //}
+
+    function mergeProps(stateProps: TodoState, dispatchProps: DispatchProps, ownProps: TodoProps): DispatchProps & TodoState & TodoProps {
+        return objectAssign({}, ownProps, dispatchProps, {
+            todos: stateProps.todos[ownProps.userId],
+            addTodo: (text: string) => dispatchProps.addTodo(ownProps.userId, text)
+        });
+    }
+
+    connect(mapStateToProps, actionCreators, mergeProps)(TodoApp);
 }
-interface TestState {
-    isLoaded: boolean;
-    state1: number;
+
+namespace TestComponent {
+    declare var store: Store<TestState>;
+    interface TestProps {
+        property1: number;
+        someOtherProperty?: string;
+    }
+    interface TestState {
+        isLoaded: boolean;
+        state1: number;
+    }
+    class TestComponent extends Component<TestProps, TestState> {
+        static staticMethod(): number {
+            return 0;
+        }
+    }
+    // Own properties can't be always be inferred, so a single type parameter will do
+    const WrappedTestComponent = connect<TestProps>()(TestComponent);
+
+    // return value of the connect()(TestComponent) is of the type TestComponent
+    let ATestComponent: typeof TestComponent = null;
+    ATestComponent = TestComponent;
+    ATestComponent = WrappedTestComponent;
+    // Wrapped component is accessible
+    WrappedTestComponent.WrappedComponent === TestComponent
+    // Static properties are accessible
+    WrappedTestComponent.staticMethod();
+
+    <TestComponent property1={42}/>;
+    <WrappedTestComponent property1={42}/>;
+    <ATestComponent property1={42}/>;
+
+    class NonComponent {
+    }
+    // this doesn't compile
+    //connect()(NonComponent);
+
+    // stateless functions
+    interface HelloMessageProps {
+        name: string;
+    }
+    function HelloMessage(props: HelloMessageProps) {
+        return <div>Hello {props.name}</div>;
+    }
+
+    const ConnectedHelloMessage = connect<HelloMessageProps>()(HelloMessage);
+    ReactDOM.render(<HelloMessage name="Sebastian"/>, document.getElementById('content'));
+    ReactDOM.render(<ConnectedHelloMessage name="Sebastian"/>, document.getElementById('content'));
 }
-class TestComponent extends Component<TestProp, TestState> { }
-const WrappedTestComponent = connect()(TestComponent);
-
-// return value of the connect()(TestComponent) is of the type TestComponent
-let ATestComponent: typeof TestComponent = null;
-ATestComponent = TestComponent;
-ATestComponent = WrappedTestComponent;
-
-let anElement: ReactElement<TestProp>;
-<TestComponent property1={42} />;
-<WrappedTestComponent property1={42} />;
-<ATestComponent property1={42} />;
-
-class NonComponent {}
-// this doesn't compile
-//connect()(NonComponent);
-
-// stateless functions
-interface HelloMessageProps { name: string; }
-function HelloMessage(props: HelloMessageProps) {
-    return <div>Hello {props.name}</div>;
-}
-let ConnectedHelloMessage = connect()(HelloMessage);
-ReactDOM.render(<HelloMessage name="Sebastian" />, document.getElementById('content'));
-ReactDOM.render(<ConnectedHelloMessage name="Sebastian" />, document.getElementById('content'));
 
 // stateless functions that uses mapStateToProps and mapDispatchToProps
 namespace TestStatelessFunctionWithMapArguments {
@@ -343,6 +365,8 @@ namespace TestStatelessFunctionWithMapArguments {
         mapStateToProps,
         mapDispatchToProps
     )(Greeting);
+
+    React.createElement(ConnectedGreeting, { name: 'hello', onClick: () => undefined });
 }
 
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/8787
@@ -374,7 +398,7 @@ namespace TestTOwnPropsInference {
     const ConnectedWithTypeHint = connect<StateProps, {}, OwnProps>(mapStateToPropsWithoutOwnProps)(OwnPropsComponent);
 
     // This compiles, which is bad.
-    React.createElement(ConnectedWithoutOwnProps, { anything: 'goes!' });
+    // React.createElement(ConnectedWithoutOwnProps, { anything: 'goes!' });
 
     // This compiles, as expected.
     React.createElement(ConnectedWithOwnProps, { own: 'string' });


### PR DESCRIPTION
First of all, sorry I ended up reformatting most of the code in the process of this PR. The tests were getting to be very disorganized, and I wanted the way the way the typings are exported to be consistent with how the typings are defined in React and Redux. I can try to reimplement my changes without messing with the formatting too much if this is a problem.

Anyway, I found quite a few problems with how `connect` was being inferred. Namely, calling `connect()` with no arguments would result in a type that was exactly the same as the class being wrapped. Merged properties were also slightly incorrect, and there was no way for the user to define the type that the final merged properties would have. Also, when `connect` is called _with_ arguments, static members wouldn't be accessible since the type was just `ComponentClass<P>`. These should all be resolved with this PR.

Lastly, I made the tests stricter, and I also provided an example of using the `@connect` decorator with explicit types (not just cheating by using `any`!)

They only breaking change with this is that for whatever reason, `TOwnProps` sometimes can't be inferred in JSX, but it's fine in `React.createElement`. I've added a single type param version of `connect` to compensate for this.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [ ] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

- Cleaned up and made the typings and tests consistent stylewise
- Support typings for the mergeProps parameter
- Allow mapStateToProps and mapDispatchToProps to be optional when type parameters are provided
- Make static members accessible on the wrapped component
- Use stricter typings in the quick start counter tests
- Added a single type variable form for connect to specify TOwnProps