### PR TITLE
Missing property `socket.destroyed`

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -1703,6 +1703,7 @@ declare module "net" {
         localPort: number;
         bytesRead: number;
         bytesWritten: number;
+        destroyed: boolean;
 
         // Extended base methods
         end(): void;

--- a/node/node-4.d.ts
+++ b/node/node-4.d.ts
@@ -1265,7 +1265,6 @@ declare module "net" {
         localPort: number;
         bytesRead: number;
         bytesWritten: number;
-        destroyed: boolean;
 
         // Extended base methods
         end(): void;

--- a/node/node-4.d.ts
+++ b/node/node-4.d.ts
@@ -1265,6 +1265,7 @@ declare module "net" {
         localPort: number;
         bytesRead: number;
         bytesWritten: number;
+        destroyed: boolean;
 
         // Extended base methods
         end(): void;

--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -33,33 +33,33 @@ import {Buffer as ImportedBuffer, SlowBuffer as ImportedSlowBuffer} from "buffer
 namespace assert_tests {
     {
         assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
-        
+
         assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");
-        
+
         assert.deepStrictEqual({ a: 1 }, { a: 1 }, "uses === comparator");
-        
+
         assert.doesNotThrow(() => {
             const b = false;
             if (b) { throw "a hammer at your face"; }
         }, undefined, "What the...*crunch*");
-        
+
         assert.equal(3, "3", "uses == comparator");
 
         assert.fail(1, 2, undefined, '>');
-        
+
         assert.ifError(0);
-        
+
         assert.notDeepStrictEqual({ x: { y: "3" } }, { x: { y: 3 } }, "uses !== comparator");
-        
+
         assert.notEqual(1, 2, "uses != comparator");
-        
+
         assert.notStrictEqual(2, "2", "uses === comparator");
-        
+
         assert.ok(true);
         assert.ok(1);
-        
+
         assert.strictEqual(1, 1,  "uses === comparator");
-        
+
         assert.throws(() => { throw "a hammer at your face"; }, undefined, "DODGED IT");
     }
 }
@@ -139,21 +139,21 @@ namespace fs_tests {
         fs.writeFile("thebible.txt",
             "Do unto others as you would have them do unto you.",
             assert.ifError);
-        
+
         fs.write(1234, "test");
-        
+
         fs.writeFile("Harry Potter",
             "\"You be wizzing, Harry,\" jived Dumbledore.",
             {
                 encoding: "ascii"
             },
-            assert.ifError);	
+            assert.ifError);
     }
 
     {
         var content: string;
         var buffer: Buffer;
-        
+
         content = fs.readFileSync('testfile', 'utf8');
         content = fs.readFileSync('testfile', { encoding: 'utf8' });
         buffer = fs.readFileSync('testfile');
@@ -163,7 +163,7 @@ namespace fs_tests {
         fs.readFile('testfile', (err, data) => buffer = data);
         fs.readFile('testfile', { flag: 'r' }, (err, data) => buffer = data);
     }
-    
+
     {
         var errno: string;
         fs.readFile('testfile', (err, data) => {
@@ -172,28 +172,28 @@ namespace fs_tests {
             }
         });
     }
-    
+
     {
         fs.mkdtemp('/tmp/foo-', (err, folder) => {
             console.log(folder);
             // Prints: /tmp/foo-itXde2
         });
     }
-    
+
     {
         var tempDir: string;
         tempDir = fs.mkdtempSync('/tmp/foo-');
     }
-    
+
     {
         fs.watch('/tmp/foo-', (event, filename) => {
           console.log(event, filename);
         });
-        
+
         fs.watch('/tmp/foo-', 'utf8', (event, filename) => {
           console.log(event, filename);
         });
-        
+
         fs.watch('/tmp/foo-', {
           recursive: true,
           persistent: true,
@@ -202,22 +202,22 @@ namespace fs_tests {
           console.log(event, filename);
         });
     }
-    
+
     {
         fs.access('/path/to/folder', (err) => { });
-        
+
         fs.access(Buffer.from(''), (err) => { });
-        
+
         fs.access('/path/to/folder', fs.constants.F_OK | fs.constants.R_OK, (err) => { });
-        
+
         fs.access(Buffer.from(''), fs.constants.F_OK | fs.constants.R_OK, (err) => { });
-        
+
         fs.accessSync('/path/to/folder');
-        
+
         fs.accessSync(Buffer.from(''));
-        
+
         fs.accessSync('path/to/folder', fs.constants.W_OK | fs.constants.X_OK);
-        
+
         fs.accessSync(Buffer.from(''), fs.constants.W_OK | fs.constants.X_OK);
     }
 }
@@ -386,14 +386,14 @@ function bufferTests() {
 namespace url_tests {
     {
         url.format(url.parse('http://www.example.com/xyz'));
-        
+
         // https://google.com/search?q=you're%20a%20lizard%2C%20gary
         url.format({
             protocol: 'https',
             host: "google.com",
             pathname: 'search',
             query: { q: "you're a lizard, gary" }
-        });   
+        });
     }
 
     {
@@ -410,7 +410,7 @@ namespace util_tests {
     {
         // Old and new util.inspect APIs
         util.inspect(["This is nice"], false, 5);
-        util.inspect(["This is nice"], { colors: true, depth: 5, customInspect: false });    
+        util.inspect(["This is nice"], { colors: true, depth: 5, customInspect: false });
     }
 }
 
@@ -750,7 +750,7 @@ namespace tls_tests {
             let _response: Buffer = response;
         })
         _TLSSocket = _TLSSocket.prependOnceListener("secureConnect", () => { });
-    } 
+    }
 }
 
 ////////////////////////////////////////////////////
@@ -1230,7 +1230,7 @@ namespace string_decoder_tests {
 namespace child_process_tests {
     {
         childProcess.exec("echo test");
-        childProcess.spawnSync("echo test");    
+        childProcess.spawnSync("echo test");
     }
 }
 
@@ -1393,7 +1393,7 @@ namespace process_tests {
     {
         var eventEmitter: events.EventEmitter;
         eventEmitter = process;                // Test that process implements EventEmitter...
-        
+
         var _p: NodeJS.Process = process;
         _p = p;
     }
@@ -1585,6 +1585,9 @@ namespace net_tests {
             str = host;
         })
         _socket = _socket.prependOnceListener("timeout", () => { })
+
+        bool = _socket.destroyed;
+        _socket.destroy();
     }
 
     {


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v4.x/docs/api/net.html#net_socket_destroyed
- [x] Increase the version number in the header if appropriate.

https://nodejs.org/dist/latest-v4.x/docs/api/net.html#net_socket_destroyed