### PR TITLE
Improved react-actions type inferencing of createAction and handleAction

### DIFF
--- a/redux-actions/index.d.ts
+++ b/redux-actions/index.d.ts
@@ -9,72 +9,50 @@ declare namespace ReduxActions {
     // FSA-compliant action.
     // See: https://github.com/acdlite/flux-standard-action
     interface BaseAction {
-        type: string
+        type: string;
     }
 
     export interface Action<Payload> extends BaseAction {
-        payload?: Payload
-        error?: boolean
-        meta?: any
+        payload?: Payload;
+        error?: boolean;
     }
 
     export interface ActionMeta<Payload, Meta> extends Action<Payload> {
-        meta: Meta
+        meta: Meta;
     }
 
-    type PayloadCreator<Input, Payload> = (...args: Input[]) => Payload;
+    interface ReducerMap<State, Payload> {
+        [actionType: string]: Reducer<State, Payload>;
+    }
 
-    type MetaCreator<Input, Payload> = (...args: Input[]) => Payload;
+    interface Reducer<State, Payload> {
+        (state: State, action: Action<Payload>): State;
+    }
 
-    type Reducer<State, Payload> = (state: State, action: Action<Payload>) => State;
+    interface ReducerMeta<State, Payload, Meta> extends Reducer<State, Payload> {
+        (state: State, action: ActionMeta<Payload, Meta>): State;
+    }
 
-    type ReducerMeta<State, Payload, Meta> = (state: State, action: ActionMeta<Payload, Meta>) => State;
-
-    type ReducerMap<State, Payload> = {
-        [actionType: string]: Reducer<State, Payload>
-    };
-
-    export function createAction(
+    export function createAction<Payload>(
         actionType: string,
-        payloadCreator?: PayloadCreator<any, any>,
-        metaCreator?: MetaCreator<any, any>
-    ): (...args: any[]) => Action<any>;
+        payloadCreator?: (...args: any[]) => Payload,
+    ): (...args: any[]) => Action<Payload>;
 
-    export function createAction<InputAndPayload>(
+    export function createAction<Payload, Meta>(
         actionType: string,
-        payloadCreator?: PayloadCreator<InputAndPayload, InputAndPayload>
-    ): (...args: InputAndPayload[]) => Action<InputAndPayload>;
-
-    export function createAction<Input, Payload>(
-        actionType: string,
-        payloadCreator?: PayloadCreator<Input, Payload>
-    ): (...args: Input[]) => Action<Payload>;
-
-    export function createAction<Input, Payload, Meta>(
-        actionType: string,
-        payloadCreator: PayloadCreator<Input, Payload>,
-        metaCreator: MetaCreator<Input, Meta>
-    ): (...args: Input[]) => ActionMeta<Payload, Meta>;
-
-    export function handleAction<StateAndPayload>(
-        actionType: { toString: () => string },
-        reducer: Reducer<StateAndPayload, StateAndPayload> | ReducerMap<StateAndPayload, StateAndPayload>
-    ): Reducer<StateAndPayload, StateAndPayload>;
+        payloadCreator: (...args: any[]) => Payload,
+        metaCreator: (...args: any[]) => Meta
+    ): (...args: any[]) => ActionMeta<Payload, Meta>;
 
     export function handleAction<State, Payload>(
-        actionType: { toString: () => string },
+        actionType: { toString(): string },
         reducer: Reducer<State, Payload> | ReducerMap<State, Payload>
     ): Reducer<State, Payload>;
 
     export function handleAction<State, Payload, Meta>(
-        actionType: { toString: () => string },
+        actionType: { toString(): string },
         reducer: ReducerMeta<State, Payload, Meta> | ReducerMap<State, Payload>
     ): Reducer<State, Payload>;
-
-    export function handleActions<StateAndPayload>(
-        reducerMap: ReducerMap<StateAndPayload, StateAndPayload>,
-        initialState?: StateAndPayload
-    ): Reducer<StateAndPayload, StateAndPayload>;
 
     export function handleActions<State, Payload>(
         reducerMap: ReducerMap<State, Payload>,
@@ -82,7 +60,6 @@ declare namespace ReduxActions {
     ): Reducer<State, Payload>;
 
     export function combineActions(
-        ...actionTypes: { toString: () => string }[]
-    ): { toString: () => string };
+        ...actionTypes: { toString(): string }[]
+    ): { toString(): string };
 }
-

--- a/redux-actions/redux-actions-tests.ts
+++ b/redux-actions/redux-actions-tests.ts
@@ -85,10 +85,10 @@ const typedActionHandler = ReduxActions.handleAction<TypedState, TypedPayload>(
 typedState = typedActionHandler({ value: 0 }, typedIncrementAction());
 
 const typedIncrementByActionWithMeta: (value: number) => ReduxActions.ActionMeta<TypedPayload, MetaType> =
-    ReduxActions.createAction<number, TypedPayload, MetaType>(
+    ReduxActions.createAction<TypedPayload, MetaType>(
     'INCREMENT_BY',
         amount => ({ increase: amount }),
-    amount => ({ remote: true })
+        amount => ({ remote: true })
     );
 
 const typedActionHandlerWithReduceMap = ReduxActions.handleAction<TypedState, TypedPayload>(


### PR DESCRIPTION
The parameter-less definition of `createAction` causes the payload type to be `any`, when it can be easily inferred by omitting the definition entirely. The combined `InputAndPayload` and `StateAndPayload` types also aren't appropriate, they only seem to be there for the sake of having single-variable type definitions.

Also, [until TypeScript supports variadic kinds (#5453)](https://github.com/Microsoft/TypeScript/issues/5453), it doesn't make sense to try to infer the input argument list type. Thus I've also removed the `Input` type variable from some definitions since most of the time it will need to be manually set to `any` unless all arguments have the same type.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [ ] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

