### PR TITLE
Update Auth0DecodedHash

### DIFF
--- a/auth0-js/auth0-js.d.ts
+++ b/auth0-js/auth0-js.d.ts
@@ -84,7 +84,7 @@ interface Auth0Identity {
 
 interface Auth0DecodedHash {
     access_token: string;
-    id_token: string;
+    idToken: string;
     profile: Auth0UserProfile;
     state: any;
 }


### PR DESCRIPTION
Update Auth0DecodedHash id_token property to match the actual specification. It should be in camel case, not snake case. 

From [Auth0 Angular2 Quickstart](https://auth0.com/docs/quickstart/spa/angular2/02-custom-login):

`var result = this.auth0.parseHash(window.location.hash);`
`...`
`localStorage.setItem('id_token', result.idToken);`