### PR TITLE
Allow false as input value.

### DIFF
--- a/classnames/index.d.ts
+++ b/classnames/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Dave Keen <http://www.keendevelopment.ch>, Adi Dahiya <https://github.com/adidahiya>, Jason Killian <https://github.com/JKillian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare type ClassValue = string | number | ClassDictionary | ClassArray | undefined | null;
+declare type ClassValue = string | number | ClassDictionary | ClassArray | undefined | null | false;
 
 interface ClassDictionary {
 	[id: string]: boolean | undefined | null;


### PR DESCRIPTION
`classNames` supports `false` as input. All falsy arguments are ignored, i.e. `classNames(false, "class1", "class2")` returns `"class1 class2"` (see [source](https://github.com/JedWatson/classnames/blob/master/index.js#L18)).
This is very handy when using `&&`: `classNames(flag && "myClass")`;