### PR TITLE
Rewriting the react-fa typings

### DIFF
--- a/react-fa/index.d.ts
+++ b/react-fa/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for react-fa v4.0.0
+// Type definitions for react-fa v5.0.0
 // Project: https://github.com/andreypopp/react-fa
-// Definitions by: Frank Laub <https://github.com/flaub>
+// Definitions by: Frank Laub <https://github.com/flaub>, Pat Sissons <http://github.com/patsissons>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { Component, ComponentClass, HTMLProps } from 'react';

--- a/react-fa/index.d.ts
+++ b/react-fa/index.d.ts
@@ -3,33 +3,41 @@
 // Definitions by: Frank Laub <https://github.com/flaub>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="react" />
+import { Component, ComponentClass, HTMLProps } from 'react';
 
-
-import { Component, ClassAttributes  } from 'react';
-
-type IconSize = "lg" | "2x" | "3x" | "4x" | "5x"
-
-interface IconProps extends ClassAttributes<Icon> {
-    name: string
-    className?: string
-    size?: IconSize
-    rotate?: "45" | "90" | "135" | "180" | "225" | "270" | "315"
-    flip?: "horizontal" | "vertical"
-    fixedWidth?: boolean
-    spin?: boolean
-    pulse?: boolean
-    stack?: "1x" | "2x"
-    inverse?: boolean
-    Component?: string | Function
+// fake intermediate interface to remove typing on size, as the typing
+// is overrided by react-fa
+interface SizeOverrideHTMLProps<T> extends HTMLProps<T> {
+    size?: any;
 }
 
-export class Icon extends Component<IconProps, {}> {}
+export type IconSize = 'lg' | '2x' | '3x' | '4x' | '5x';
+export type IconRotation = '45' | '90' | '135' | '180' | '225' | '270' | '315';
+export type IconFlip = 'horizontal' | 'vertical';
+export type IconStackSize = '1x' | '2x';
 
-interface IconStackProps extends ClassAttributes<IconStack> {
-    className?: string
-    size?: IconSize
+export interface IconProps extends SizeOverrideHTMLProps<Icon> {
+    name: string;
+    size?: IconSize;
+    spin?: boolean;
+    rotate?: IconRotation;
+    flip?: IconFlip;
+    fixedWidth?: boolean;
+    pulse?: boolean;
+    stack?: IconStackSize;
+    inverse?: boolean;
+    Component?: string | Function;
 }
-export class IconStack extends Component<IconStackProps, {}> {}
+
+export type Icon = Component<IconProps, any>;
+export const Icon: ComponentClass<IconProps>;
+
+export interface IconStackProps extends SizeOverrideHTMLProps<IconStack> {
+    size?: IconSize;
+    children?: IconProps[];
+}
+
+export type IconStack = Component<IconStackProps, any>;
+export const IconStack: ComponentClass<IconStackProps>;
 
 export default Icon;

--- a/react-fa/react-fa-tests.tsx
+++ b/react-fa/react-fa-tests.tsx
@@ -1,20 +1,31 @@
-/// <reference types="react-dom"/>
+import * as React from 'react';
+import { Icon, IconStack } from 'react-fa';
+import DefaultIcon from 'react-fa';
 
-// Imports
-// --------------------------------------------------------------------------------
-import * as React from "react"
-import { render } from "react-dom"
-import { Icon, IconStack } from "react-fa"
+export class ReactFATest extends React.Component<any, any> {
+    render() {
+        const defaultProps = {
+            name: 'flask',
+            Component: 'div',
+        };
 
-render(
-	<Icon spin name="spinner" rotate="90" size="2x" Component="span" />,
-	document.getElementById("main")
-)
+        return (
+            <div>
+                <Icon { ...defaultProps } />
+                <Icon { ...defaultProps } size='lg' />
+                <Icon { ...defaultProps } spin />
+                <Icon { ...defaultProps } rotate='90' />
+                <Icon { ...defaultProps } flip='vertical' />
+                <Icon { ...defaultProps } fixedWidth />
+                <Icon { ...defaultProps } pulse />
 
-render(
-	<IconStack size="2x">
-		<Icon name="test" stack="2x" />
-		<Icon name="test" stack="1x" />
-	</IconStack>,
-	document.getElementById("main")
-)
+                <DefaultIcon { ...defaultProps } />
+
+                <IconStack size='lg'>
+                    <Icon name='circle' stack='2x' />
+                    <Icon name='flask' stack='1x' inverse />
+                </IconStack>
+            </div>
+        );
+    }
+}


### PR DESCRIPTION
This PR rewrites the typings using the module template from the typescript handbook and adds a lot of missing type information.

This PR changes the export style (which was previously incorrect) and as such is a major version bump (as per SemVer 2). Most consumers will not notice as there is now a default export which should bridge that gap (for most). Individual components are now exported and therefore should be imported explicitly.

Example:
```ts
// recommended import style
import { Icon, IconStack } from 'react-fa';

// still possible via default export, but not recommended
import Icon from 'react-fa';

// No longer possible
import * as Icon from 'react-fa';
```

namespace import syntax is [not officially supported by react-fa](https://github.com/andreypopp/react-fa/blob/master/src/index.js#L10)

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/andreypopp/react-fa
- [x] Increase the version number in the header if appropriate.
