### PR TITLE
Add interface for $componentController

### DIFF
--- a/angular/index.d.ts
+++ b/angular/index.d.ts
@@ -1707,6 +1707,16 @@ declare namespace angular {
          */
         require?: {[controller: string]: string};
     }
+    
+    ///////////////////////////////////////////////////////////////////////////
+    // ComponentControllerService
+    // see https://docs.angularjs.org/api/ngMock/service/$componentController
+    ///////////////////////////////////////////////////////////////////////////
+    interface IComponentControllerService {
+      // TBinding is an interface exposed by a component as per John Papa's style guide
+      // https://github.com/johnpapa/angular-styleguide/blob/master/a1/README.md#accessible-members-up-top
+      <T, TBinding>(componentName: string, locals?: { $scope: IScope, [key: string]: any }, bindings?: TBinding, ident?: string): T;
+    }
 
     type IControllerConstructor =
         (new (...args: any[]) => IController) |


### PR DESCRIPTION
Please fill in this template.

- [X] Prefer to make your PR against the `types-2.0` branch.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://docs.angularjs.org/guide/component#unit-testing-component-controllers and https://docs.angularjs.org/api/ngMock/service/$componentController
- [na?] Increase the version number in the header if appropriate.

Add interface for IComponentControllerService ($componentController)