### PR TITLE
Adding jquery-param typings

### DIFF
--- a/jquery-param/index.d.ts
+++ b/jquery-param/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for jquery-param v1.0.0
+// Project: https://github.com/knowledgecode/jquery-param
+// Definitions by: Pat Sissons <http://github.com/patsissons>
+
+export as namespace param;
+
+export = param;
+
+declare function param(obj: any): string;

--- a/jquery-param/jquery-param-tests.ts
+++ b/jquery-param/jquery-param-tests.ts
@@ -1,0 +1,3 @@
+import param = require('jquery-param');
+
+const test1 = param({ a: 'A', b: 'B', c: 'C' });

--- a/jquery-param/tsconfig.json
+++ b/jquery-param/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jquery-param-tests.ts"
+    ]
+}


### PR DESCRIPTION
- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Run `tsc` without errors.
- [x] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

typings based on https://github.com/knowledgecode/jquery-param