### PR TITLE
Make comp ctrl locals param scope optional

### DIFF
--- a/angular-mocks/index.d.ts
+++ b/angular-mocks/index.d.ts
@@ -107,7 +107,7 @@ declare module 'angular' {
   interface IComponentControllerService {
     // TBinding is an interface exposed by a component as per John Papa's style guide
     // https://github.com/johnpapa/angular-styleguide/blob/master/a1/README.md#accessible-members-up-top
-    <T, TBinding>(componentName: string, locals: { $scope: IScope, [key: string]: any }, bindings?: TBinding, ident?: string): T;
+    <T, TBinding>(componentName: string, locals: { $scope?: IScope, [key: string]: any }, bindings?: TBinding, ident?: string): T;
   }
 
 


### PR DESCRIPTION
IComponentControllerService ($componentController) has a second param, locals, which allows for an optional scope key to be provided. This fixes the typing to make that property actually optional.

You can see that here https://docs.angularjs.org/guide/component#unit-testing-component-controllers and here https://docs.angularjs.org/api/ngMock/service/$componentController