### PR TITLE
fix(watch): watch accepts an array

### DIFF
--- a/browser-sync/browser-sync.d.ts
+++ b/browser-sync/browser-sync.d.ts
@@ -402,7 +402,7 @@ declare module "browser-sync" {
             /**
              * Stand alone file-watcher. Use this along with Browsersync to create your own, minimal build system
              */
-            watch(patterns: string, opts?: chokidar.WatchOptions, fn?: (event: string, file: fs.Stats) => any)
+            watch(patterns: string | string[], opts?: chokidar.WatchOptions, fn?: (event: string, file: fs.Stats) => any)
                 : NodeJS.EventEmitter;
             /**
              * Method to pause file change events


### PR DESCRIPTION
watch accepts an array of strings as per documentation
https://www.browsersync.io/docs/options/
