### PR TITLE
Optional parameters for Option interface

### DIFF
--- a/react-select/index.d.ts
+++ b/react-select/index.d.ts
@@ -20,9 +20,9 @@ declare namespace ReactSelectClass {
 
     export interface Option {
         /** Text for rendering */
-        label: string;
+        label?: string;
         /** Value for searching */
-        value: string | number;
+        value?: string | number;
         /**
          * Allow this option to be cleared
          * @default true


### PR DESCRIPTION
If I try use options `valueKey` and `labelKey` (https://github.com/JedWatson/react-select#further-options) I get the error:
```
[ts] Type '{ Id: string; FullName: string; }' is not assignable to type 'string | number | Option | Option[] | string[] | number[]'.
       Type '{ Id: string; FullName: string; }' is not assignable to type 'number[]'.
[ts] Type '{ Id: string; FullName: string; }' is not assignable to type 'string | number | Option | Option[] | string[] | number[]'.
       Type '{ Id: string; FullName: string; }' is not assignable to type 'number[]'.
         Property 'length' is missing in type '{ Id: string; FullName: string; }'.
---------------------------------------------------------------
const defaultValue: {
    Id: string;
    FullName: string;
    PhotoUrl: string;
}
```
I add optional parameters to `Option` interface that we could use as values this object (for example):
```
{
    Id: 'Some string',
    FullName: 'Piter Jack',
    ...
}
```
instead this object:
```
{
    value: 'Some string',
    label: 'Piter Jack',
    ...
}
```