### PR TITLE
Added Response.statusText property to superagent.Response interface

### DIFF
--- a/superagent/superagent.d.ts
+++ b/superagent/superagent.d.ts
@@ -64,6 +64,7 @@ declare module "superagent" {
       charset: string;
       status: number;
       statusType: number;
+      statusText: string;
       info: boolean;
       ok: boolean;
       redirect: boolean;


### PR DESCRIPTION
It does not appear in the docs but it is available and supported: https://github.com/visionmedia/superagent/commit/77aa6c08e9de9b94c898584b60e2821606df07ca