### PR TITLE
feat: upgrade acorn definition to sync with latest acorn

### DIFF
--- a/acorn/README.md
+++ b/acorn/README.md
@@ -1,0 +1,9 @@
+This file exists for reminding contributors that this definition is **WIP**.
+
+### Note
+
+There are a **large** number of methods of class `Parser` and `LooseParser` haven't been declared.
+
+However, these methods may not be useful for common users. So, I hang the job util it worth continuing.
+
+Of course, volunteers are welcomed to spend time extracting these things.

--- a/acorn/acorn-tests.ts
+++ b/acorn/acorn-tests.ts
@@ -14,7 +14,7 @@ var string: string;
 // acorn
 string = acorn.version;
 program = acorn.parse('code');
-program = acorn.parse('code', {ranges: true, onToken: tokens, onComment: comments});
+program = acorn.parse('code', { ranges: true, onToken: tokens, onComment: comments });
 program = acorn.parse('code', {
     ranges: true,
     onToken: (token) => tokens.push(token),
@@ -28,3 +28,32 @@ any = token.value;
 
 // Comment
 string = comment.value;
+
+const parser = new acorn.Parser({}, 'export default ""', 0);
+
+const node = new acorn.Node(parser, 1, 1);
+
+acorn.addLooseExports(function () {
+    return {
+        type: 'Program',
+        sourceType: 'script',
+        body: [
+            {
+                type: 'EmptyStatement'
+            }
+        ]
+    }
+}, parser, {});
+
+acorn.parseExpressionAt('string', 2);
+
+acorn.isNewLine(56);
+
+acorn.isIdentifierStart(56);
+
+acorn.isIdentifierChar(56);
+
+acorn.getLineInfo('string', 56);
+
+acorn.plugins['test'] = function (p: acorn.Parser, config: any) {
+}

--- a/acorn/acorn-tests.ts
+++ b/acorn/acorn-tests.ts
@@ -33,6 +33,16 @@ const parser = new acorn.Parser({}, 'export default ""', 0);
 
 const node = new acorn.Node(parser, 1, 1);
 
+class LooseParser {
+    constructor(input: string, options = {}) {
+
+    }
+
+    // this means you can extend LooseParser
+    test() {
+
+    }
+}
 acorn.addLooseExports(function () {
     return {
         type: 'Program',
@@ -43,7 +53,7 @@ acorn.addLooseExports(function () {
             }
         ]
     }
-}, parser, {});
+}, LooseParser, {});
 
 acorn.parseExpressionAt('string', 2);
 

--- a/acorn/index.d.ts
+++ b/acorn/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for Acorn v1.0.1
+// Type definitions for Acorn v4.0.3
 // Project: https://github.com/marijnh/acorn
-// Definitions by: RReverser <https://github.com/RReverser>
+// Definitions by: RReverser <https://github.com/RReverser>, e-cloud <https://github.com/e-cloud>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="estree" />
@@ -10,13 +10,89 @@ export = acorn;
 import * as ESTree from 'estree';
 
 declare namespace acorn {
-    var version: string;
-    function parse(input: string, options?: Options): ESTree.Program;
-    function parseExpressionAt(input: string, pos: number, options?: Options): ESTree.Expression;
-    function getLineInfo(input: string, offset: number): ESTree.Position;
-    var defaultOptions: Options;
+    interface PlainObject {
+        [name: string]: any;
+    }
 
-    interface TokenType {
+    interface PluginsObject {
+        [name: string]: (p: Parser, config: any) => void;
+    }
+
+    interface Options {
+        ecmaVersion?: 3 | 5 | 6 | 7 | 8 | 2015 | 2016 | 2017;
+        sourceType?: 'script' | 'module';
+        onInsertedSemicolon?: (lastTokEnd: number, lastTokEndLoc?: ESTree.Position) => void;
+        onTrailingComma?: (lastTokEnd: number, lastTokEndLoc?: ESTree.Position) => void;
+        allowReserved?: boolean;
+        allowReturnOutsideFunction?: boolean;
+        allowImportExportEverywhere?: boolean;
+        allowHashBang?: boolean;
+        locations?: boolean;
+        onToken?: ((token: Token) => any) | Token[];
+        onComment?: ((
+            isBlock: boolean, text: string, start: number, end: number, startLoc?: ESTree.Position,
+            endLoc?: ESTree.Position
+        ) => void) | Comment[];
+        ranges?: boolean;
+        program?: ESTree.Program;
+        sourceFile?: string;
+        directSourceFile?: string;
+        preserveParens?: boolean;
+        plugins?: PlainObject;
+    }
+
+    class Parser {
+        constructor(options: Options, input: string, startPos?: number);
+
+        parse(): ESTree.Program;
+    }
+
+    const plugins: PluginsObject;
+
+    const defaultOptions: Options;
+
+    class Position implements ESTree.Position {
+        line: number;
+        column: number;
+
+        constructor(line: number, col: number);
+
+        offset(n: number): Position;
+    }
+
+    class SourceLocation implements ESTree.SourceLocation {
+        start: Position;
+        end: Position;
+        source?: string;
+
+        constructor(p: Parser, start: Position, end: Position);
+    }
+
+    function getLineInfo(input: string, offset: number): ESTree.Position;
+
+    class Node {
+        type: string;
+        start: number;
+        end: number;
+        loc?: ESTree.SourceLocation;
+        sourceFile?: string;
+        range?: [number, number];
+
+        constructor(parser: Parser, pos: number, loc: number);
+    }
+
+    interface TokeTypeConfig {
+        keyword: string;
+        beforeExpr?: boolean;
+        startsExpr?: boolean;
+        isLoop?: boolean;
+        isAssign?: boolean;
+        prefix?: boolean;
+        postfix?: boolean;
+        binop?: number;
+    }
+
+    class TokenType {
         label: string;
         keyword: string;
         beforeExpr: boolean;
@@ -26,19 +102,110 @@ declare namespace acorn {
         prefix: boolean;
         postfix: boolean;
         binop: number;
-        updateContext: (prevType: TokenType) => any;
+        updateContext: (prevType: TokenType) => void;
+
+        constructor(label: string, conf?: TokeTypeConfig);
     }
+
+    const tokTypes: {
+        num: TokenType;
+        regexp: TokenType;
+        string: TokenType;
+        name: TokenType;
+        eof: TokenType;
+        bracketL: TokenType;
+        bracketR: TokenType;
+        braceL: TokenType;
+        braceR: TokenType;
+        parenL: TokenType;
+        parenR: TokenType;
+        comma: TokenType;
+        semi: TokenType;
+        colon: TokenType;
+        dot: TokenType;
+        question: TokenType;
+        arrow: TokenType;
+        template: TokenType;
+        ellipsis: TokenType;
+        backQuote: TokenType;
+        dollarBraceL: TokenType;
+        eq: TokenType;
+        assign: TokenType;
+        incDec: TokenType;
+        prefix: TokenType;
+        logicalOR: TokenType;
+        logicalAND: TokenType;
+        bitwiseOR: TokenType;
+        bitwiseXOR: TokenType;
+        bitwiseAND: TokenType;
+        equality: TokenType;
+        relational: TokenType;
+        bitShift: TokenType;
+        plusMin: TokenType;
+        modulo: TokenType;
+        star: TokenType;
+        slash: TokenType;
+        starstar: TokenType;
+        _break: TokenType;
+        _case: TokenType;
+        _catch: TokenType;
+        _continue: TokenType;
+        _debugger: TokenType;
+        _default: TokenType;
+        _do: TokenType;
+        _else: TokenType;
+        _finally: TokenType;
+        _for: TokenType;
+        _function: TokenType;
+        _if: TokenType;
+        _return: TokenType;
+        _switch: TokenType;
+        _throw: TokenType;
+        _try: TokenType;
+        _var: TokenType;
+        _const: TokenType;
+        _while: TokenType;
+        _with: TokenType;
+        _new: TokenType;
+        _this: TokenType;
+        _super: TokenType;
+        _class: TokenType;
+        _extends: TokenType;
+        _export: TokenType;
+        _import: TokenType;
+        _null: TokenType;
+        _true: TokenType;
+        _false: TokenType;
+        _in: TokenType;
+        _instanceof: TokenType;
+        _typeof: TokenType;
+        _void: TokenType;
+        _delete: TokenType;
+    }
+
+    class TokContext {
+        constructor(token: string, isExpr: boolean, preserveSpace: boolean, override: (p: Parser) => void);
+    }
+
+    const tokContexts: {
+        b_stat: TokContext;
+        b_expr: TokContext;
+        b_tmpl: TokContext;
+        p_stat: TokContext;
+        p_expr: TokContext;
+        q_tmpl: TokContext;
+        f_expr: TokContext;
+    };
+
+    function isIdentifierStart(code: number, astral?: boolean): boolean;
+
+    function isIdentifierChar(code: number, astral?: boolean): boolean;
 
     interface AbstractToken {
         start: number;
         end: number;
-        loc: ESTree.SourceLocation;
-        range: [number, number];
-    }
-
-    interface Token extends AbstractToken {
-        type: TokenType;
-        value: any;
+        loc?: SourceLocation;
+        range?: [number, number];
     }
 
     interface Comment extends AbstractToken {
@@ -46,23 +213,42 @@ declare namespace acorn {
         value: string;
     }
 
-    interface Options {
-        ecmaVersion?: number;
-        sourceType?: string;
-        onInsertedSemicolon?: (lastTokEnd: number, lastTokEndLoc?: ESTree.Position) => any;
-        onTrailingComma?: (lastTokEnd: number, lastTokEndLoc?: ESTree.Position) => any;
-        allowReserved?: boolean;
-        allowReturnOutsideFunction?: boolean;
-        allowImportExportEverywhere?: boolean;
-        allowHashBang?: boolean;
-        locations?: boolean;
-        onToken?: ((token: Token) => any) | Token[];
-        onComment?: ((isBlock: boolean, text: string, start: number, end: number, startLoc?: ESTree.Position, endLoc?: ESTree.Position) => any) | Comment[];
-        ranges?: boolean;
-        program?: ESTree.Program;
-        sourceFile?: string;
-        directSourceFile?: string;
-        preserveParens?: boolean;
-        plugins?: { [name: string]: Function; };
+    class Token {
+        constructor(p: Parser);
     }
+
+    interface Token extends AbstractToken {
+        type: TokenType;
+        value: any;
+    }
+
+    function isNewLine(code: number): boolean;
+
+    const lineBreak: RegExp;
+
+    const lineBreakG: RegExp;
+
+    const version: string;
+
+    interface IParse {
+        (input: string, options?: Options): ESTree.Program;
+    }
+
+    const parse: IParse;
+
+    function parseExpressionAt(input: string, pos?: number, options?: Options): ESTree.Expression;
+
+    // todo: here the tokenizer function returns a Parser instance, that is targeting the detail of
+    // Parser prototype. Someone need this please reade README.md first.
+    // function tokenizer(options: Options, input: string): Parser;
+
+    let parse_dammit: IParse | undefined;
+    let LooseParser: LooseParser | undefined;
+    let pluginsLoose: PluginsObject | undefined;
+
+    class LooseParser {
+
+    }
+
+    function addLooseExports(parse: IParse, parser: LooseParser, plugins: PluginsObject): void;
 }

--- a/acorn/index.d.ts
+++ b/acorn/index.d.ts
@@ -243,12 +243,16 @@ declare namespace acorn {
     // function tokenizer(options: Options, input: string): Parser;
 
     let parse_dammit: IParse | undefined;
-    let LooseParser: LooseParser | undefined;
+    let LooseParser: ILooseParserClass | undefined;
     let pluginsLoose: PluginsObject | undefined;
 
-    class LooseParser {
+    interface ILooseParserClass {
+        new (input: string, options?: Options): ILooseParser
+    }
+
+    interface ILooseParser {
 
     }
 
-    function addLooseExports(parse: IParse, parser: LooseParser, plugins: PluginsObject): void;
+    function addLooseExports(parse: IParse, parser: ILooseParserClass, plugins: PluginsObject): void;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: <<https://github.com/ternjs/acorn>>
- [x] Increase the version number in the header if appropriate.

NOTE: something is not done yet. But it will not block the usage in common cases. see README.md