### PR TITLE
Fix for Select2 matcher

### DIFF
--- a/select2/select2.d.ts
+++ b/select2/select2.d.ts
@@ -50,7 +50,7 @@ interface Select2Options {
     closeOnSelect?: boolean;
     openOnEnter?: boolean;
     id?: (object: any) => string;
-    matcher?: (term: string, text: string, option: any) => boolean;
+    matcher?: (params: any, data: any) => boolean;
     formatSelection?: (object: any, container: JQuery, escapeMarkup:(markup: string) => string) => string;
     formatResult?: (object: any, container: JQuery, query: any, escapeMarkup: (markup: string) => string) => string;
     formatResultCssClass?: (object: any) => string;


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [ x] Test the change in your own code.
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [ ] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

There was an older format of matcher in d.ts file