### PR TITLE
Improve typings for form-data

### DIFF
--- a/form-data/form-data-tests.ts
+++ b/form-data/form-data-tests.ts
@@ -132,3 +132,10 @@ import * as ImportUsingES6Syntax from 'form-data';
             console.log(json);
         });
 }
+
+() => {
+    var form = new FormData();
+	form.getLength((err: Error, length: number): void => {
+		// nothing
+	});
+}

--- a/form-data/index.d.ts
+++ b/form-data/index.d.ts
@@ -5,15 +5,18 @@
 
 // Imported from: https://github.com/soywiz/typescript-node-definitions/form-data.d.ts
 
+/// <reference types="node" />
+
 export = FormData;
 
-declare class FormData {
+import * as stream from "stream";
+
+declare class FormData extends stream.Readable {
     append(key: string, value: any, options?: any): void;
     getHeaders(): FormData.Dictionary<string>;
-    // TODO expand pipe
-    pipe(to: any): any;
     submit(params: string | Object, callback: (error: any, response: any) => void): any;
     getBoundary(): string;
+    getLength(callback: (err: Error, length: number) => void): void;
 }
 
 declare namespace FormData {


### PR DESCRIPTION
I'm unable to run the tests because they currently don't run at all on the types-2.0 branch.

FormData class derives from a combined-stream which derives from a node Stream, see 

https://github.com/form-data/form-data/blob/master/lib/form_data.js

and

https://github.com/felixge/node-combined-stream/blob/master/lib/combined_stream.js

Also, the getLength() method is in the mentioned file form-data.js above
