### PR TITLE
Add type definition for express-formidable

### DIFF
--- a/express-formidable/express-formidable-tests.ts
+++ b/express-formidable/express-formidable-tests.ts
@@ -1,0 +1,16 @@
+import express = require("express");
+import expform = require("express-formidable");
+
+const app = express();
+
+app.use("/form1", expform());
+app.use("/form2", expform({
+    encoding: "utf-8",
+    uploadDir: "./uploads",
+    keepExtensions: true,
+    type: "multipart",
+    maxFieldsSize: 3 * 1024 * 1024,
+    maxFields: 50,
+    hash: "sha1",
+    multiples: true
+}));

--- a/express-formidable/index.d.ts
+++ b/express-formidable/index.d.ts
@@ -3,21 +3,19 @@
 // Definitions by: Torkild Dyvik Olsen <https://github.com/tdolsen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module "express-formidable" {
-    import { RequestHandler } from "express";
+import { RequestHandler } from "express";
 
-    interface ExpressFormidableOptions {
-        encoding?: string;
-        uploadDir?: string;
-        keepExtensions?: boolean;
-        type?: "multipart" | "urlencoded";
-        maxFieldsSize?: number;
-        maxFields?: number;
-        hash?: boolean | "sha1" | "md5";
-        multiples?: boolean;
-    }
-
-    function ExpressFormidable(options?: ExpressFormidableOptions): RequestHandler;
-
-    export = ExpressFormidable;
+interface ExpressFormidableOptions {
+    encoding?: string;
+    uploadDir?: string;
+    keepExtensions?: boolean;
+    type?: "multipart" | "urlencoded";
+    maxFieldsSize?: number;
+    maxFields?: number;
+    hash?: boolean | "sha1" | "md5";
+    multiples?: boolean;
 }
+
+declare function ExpressFormidable(options?: ExpressFormidableOptions): RequestHandler;
+
+export = ExpressFormidable;

--- a/express-formidable/index.d.ts
+++ b/express-formidable/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for express-formidable
+// Type definitions for express-formidable 1.0.0
 // Project: https://github.com/noraesae/express-formidable
 // Definitions by: Torkild Dyvik Olsen <https://github.com/tdolsen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/express-formidable/index.d.ts
+++ b/express-formidable/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for express-formidable
+// Project: https://github.com/noraesae/express-formidable
+// Definitions by: Torkild Dyvik Olsen <https://github.com/tdolsen>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "express-formidable" {
+    import { RequestHandler } from "express";
+
+    interface ExpressFormidableOptions {
+        encoding?: string;
+        uploadDir?: string;
+        keepExtensions?: boolean;
+        type?: "multipart" | "urlencoded";
+        maxFieldsSize?: number;
+        maxFields?: number;
+        hash?: boolean | "sha1" | "md5";
+        multiples?: boolean;
+    }
+
+    function ExpressFormidable(options?: ExpressFormidableOptions): RequestHandler;
+
+    export = ExpressFormidable;
+}

--- a/express-formidable/tsconfig.json
+++ b/express-formidable/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "express-formidable-tests.ts"
+    ]
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Run `tsc` without errors.
- [x] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.