### PR TITLE
aws4 sign returns object with various properties, not RequestSigner

### DIFF
--- a/aws4/index.d.ts
+++ b/aws4/index.d.ts
@@ -30,4 +30,4 @@ export class RequestSigner {
     formatPath(): string;
 }
 
-export function sign(options?: any, credentials?: any): RequestSigner;
+export function sign(options?: any, credentials?: any): any;


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Run `tsc` without errors.
- [x] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.