### PR TITLE
Added type definitions for metric-suffix

### DIFF
--- a/metric-suffix/index.d.ts
+++ b/metric-suffix/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for metric-suffix.js 0.0.3
+// Project: https://github.com/mstdokumaci/metric-suffix.js
+// Definitions by: David Muller <https://github.com/davidm77>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace metric_suffix;
+
+export = metric_suffix;
+
+declare function metric_suffix(value: number, precision?: number): string;

--- a/metric-suffix/metric-suffix-external-tests.ts
+++ b/metric-suffix/metric-suffix-external-tests.ts
@@ -1,0 +1,22 @@
+import metric_suffix = require('metric-suffix');
+
+metric_suffix(42) // 42 
+metric_suffix(999) // 999 
+metric_suffix(1000) // 1.0k 
+ 
+metric_suffix(1234, 2) // 1.2k 
+metric_suffix(12345, 2) // 12k 
+metric_suffix(123456, 2) // 123k 
+ 
+metric_suffix(1234, 3) // 1.23k 
+metric_suffix(12345, 3) // 12.3k 
+metric_suffix(123456, 3) // 123k 
+ 
+metric_suffix(1234, 4) // 1.234k 
+metric_suffix(12345, 4) // 12.35k 
+metric_suffix(123456, 4) // 123.5k 
+ 
+metric_suffix(986725) // 987k 
+metric_suffix(986725, 4) // 986.7k 
+metric_suffix(986725123) // 987M 
+metric_suffix(986725123, 5) // 986.73M 

--- a/metric-suffix/metric-suffix-tests.ts
+++ b/metric-suffix/metric-suffix-tests.ts
@@ -1,0 +1,20 @@
+metric_suffix(42) // 42 
+metric_suffix(999) // 999 
+metric_suffix(1000) // 1.0k 
+ 
+metric_suffix(1234, 2) // 1.2k 
+metric_suffix(12345, 2) // 12k 
+metric_suffix(123456, 2) // 123k 
+ 
+metric_suffix(1234, 3) // 1.23k 
+metric_suffix(12345, 3) // 12.3k 
+metric_suffix(123456, 3) // 123k 
+ 
+metric_suffix(1234, 4) // 1.234k 
+metric_suffix(12345, 4) // 12.35k 
+metric_suffix(123456, 4) // 123.5k 
+ 
+metric_suffix(986725) // 987k 
+metric_suffix(986725, 4) // 986.7k 
+metric_suffix(986725123) // 987M 
+metric_suffix(986725123, 5) // 986.73M 

--- a/metric-suffix/tsconfig.json
+++ b/metric-suffix/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "metric-suffix-tests.ts",
+        "metric-suffix-external-tests.ts"
+    ]
+}


### PR DESCRIPTION
Please fill in this template.

- [X] Prefer to make your PR against the `types-2.0` branch.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If adding a new definition:
- [X] The package does not provide its own types, and you can not add them.
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Run `tsc` without errors.
- [X] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [ ] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

