### PR TITLE
analytics-node export Analytics class as described in the docs

### DIFF
--- a/analytics-node/analytics-node-tests.ts
+++ b/analytics-node/analytics-node-tests.ts
@@ -1,8 +1,8 @@
-import AnalyticsNode = require("analytics-node");
-var analytics: AnalyticsNode.Analytics;
+import Analytics = require("analytics-node");
+var analytics: Analytics;
 
 function testConfig(): void {
-  analytics = new AnalyticsNode.Analytics('YOUR_WRITE_KEY', {
+  analytics = new Analytics('YOUR_WRITE_KEY', {
     flushAt: 20,
     flushAfter: 10000
   });

--- a/analytics-node/index.d.ts
+++ b/analytics-node/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Andrew Fong <https://github.com/fongandrew>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export = AnalyticsNode;
+export = AnalyticsNode.Analytics;
 
 declare namespace AnalyticsNode {
 


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://segment.com/docs/sources/server/node/
- [ ] Increase the version number in the header if appropriate.

This fixes #12706.

According to the [documentation](https://segment.com/docs/sources/server/node/), an instance is supposed to be created like this:

```js
var Analytics = require('analytics-node');
var analytics = new Analytics('YOUR_WRITE_KEY');
```