### PR TITLE
Changed cascade to a string.

### DIFF
--- a/jstree/jstree.d.ts
+++ b/jstree/jstree.d.ts
@@ -429,7 +429,7 @@ interface JSTreeStaticDefaultsCheckbox {
     * @name $.jstree.defaults.checkbox.cascade
     * @plugin checkbox
     */
-    cascade: boolean;
+    cascade: string;
 
     /**
     * This setting controls if checkbox are bound to the general tree selection 


### PR DESCRIPTION
$.jstree.defaults.checkbox.cascade is a string, not a boolean. See https://www.jstree.com/api/#/?f=$.jstree.defaults.checkbox.cascade
