### PR TITLE
Fix builder function return type

### DIFF
--- a/yargs/index.d.ts
+++ b/yargs/index.d.ts
@@ -66,10 +66,10 @@ declare namespace yargs {
 
         command(command: string, description: string): Argv;
         command(command: string, description: string, handler: (args: Argv) => void): Argv;
-        command(command: string, description: string, builder: (args: Argv) => Options): Argv;
+        command(command: string, description: string, builder: (args: Argv) => Argv): Argv;
         command(command: string, description: string, builder: { [optionName: string]: Options }): Argv;
         command(command: string, description: string, builder: { [optionName: string]: Options }, handler: (args: Argv) => void): Argv;
-        command(command: string, description: string, builder: (args: Argv) => Options, handler: (args: Argv) => void): Argv;
+        command(command: string, description: string, builder: (args: Argv) => Argv, handler: (args: Argv) => void): Argv;
         command(command: string, description: string, module: CommandModule): Argv;
         command(module: CommandModule): Argv;
 

--- a/yargs/index.d.ts
+++ b/yargs/index.d.ts
@@ -65,11 +65,10 @@ declare namespace yargs {
         usage(options?: { [key: string]: Options }): Argv;
 
         command(command: string, description: string): Argv;
-        command(command: string, description: string, handler: (args: Argv) => void): Argv;
         command(command: string, description: string, builder: (args: Argv) => Argv): Argv;
         command(command: string, description: string, builder: { [optionName: string]: Options }): Argv;
-        command(command: string, description: string, builder: { [optionName: string]: Options }, handler: (args: Argv) => void): Argv;
-        command(command: string, description: string, builder: (args: Argv) => Argv, handler: (args: Argv) => void): Argv;
+        command(command: string, description: string, builder: { [optionName: string]: Options }, handler: (args: any) => void): Argv;
+        command(command: string, description: string, builder: (args: Argv) => Argv, handler: (args: any) => void): Argv;
         command(command: string, description: string, module: CommandModule): Argv;
         command(module: CommandModule): Argv;
 

--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -188,14 +188,13 @@ function command() {
 	var argv = yargs
 		.usage('npm <command>')
 		.command('install', 'tis a mighty fine package to install')
-		.command('publish', 'shiver me timbers, should you be sharing all that', yargs => {
-			argv = yargs.option('f', {
+		.command('publish', 'shiver me timbers, should you be sharing all that', yargs =>
+			yargs.option('f', {
 				alias: 'force',
 				description: 'yar, it usually be a bad idea'
 			})
 			.help('help')
-			.argv;
-		})
+		)
 		.command("build", "arghh, build it mate", {
 			tag: {
 				default: true,
@@ -247,8 +246,8 @@ function command() {
 					describe: 'the URL to make an HTTP request to'
 				})
 			},
-			function (argv) {
-				console.dir(argv)
+			function (argv: { url: string }) {
+				console.dir(argv.url)
 			}
 		)
 		.help()

--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -226,6 +226,33 @@ function command() {
 		})
 		.help('help')
 		.argv;
+
+	yargs
+		.command('get', 'make a get HTTP request', function (yargs) {
+			return yargs.option('url', {
+				alias: 'u',
+				default: 'http://yargs.js.org/'
+			})
+		})
+		.help()
+		.argv
+
+	yargs
+		.command(
+			'get',
+			'make a get HTTP request',
+			function (yargs) {
+				return yargs.option('u', {
+					alias: 'url',
+					describe: 'the URL to make an HTTP request to'
+				})
+			},
+			function (argv) {
+				console.dir(argv)
+			}
+		)
+		.help()
+		.argv
 }
 
 function completion_sync() {


### PR DESCRIPTION
The return value of the builder function seems to be wrong.
The docs state:
> `builder` can also be a function. This function is executed with a yargs instance, and can be used to provide advanced command specific help:

This code sample does not compile because the return type of the builder function does not match:
```TypeScript
yargs
  .command(
    'get',
    'make a get HTTP request',
    function (yargs) {
      return yargs.option('u', {
        alias: 'url',
        describe: 'the URL to make an HTTP request to'
      })
    },
    function (argv) {
      console.dir(argv)
    }
  )
  .help()
  .argv
```
It should be an instance of `Argv`, not `Options`. This PR fixes this.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/yargs#commandmodule
- [x] Increase the version number in the header if appropriate.

