### PR TITLE
Add number type to propToCol

### DIFF
--- a/handsontable/handsontable-tests.ts
+++ b/handsontable/handsontable-tests.ts
@@ -267,6 +267,7 @@ function test_HandsontableMethods() {
   hot.loadData([]);
   hot.populateFromArray(123, 123, [], 123, 123, 'foo', 'foo', 'foo', []);
   hot.propToCol('foo');
+  hot.propToCol(123);
   hot.removeCellMeta(123, 123, 'foo');
   hot.removeHook('foo', function() {});
   hot.render();

--- a/handsontable/index.d.ts
+++ b/handsontable/index.d.ts
@@ -266,7 +266,7 @@ declare namespace ht {
     listen(): void;
     loadData(data: any[]): void;
     populateFromArray(row: number, col: number, input: any[], endRow?: number, endCol?: number, source?: string, method?: string, direction?: string, deltas?: any[]): any;
-    propToCol(prop: string): number;
+    propToCol(prop: string | number): number;
     removeCellMeta(row: number, col: number, key: string): void;
     removeHook(key: string, callback: Function): void;
     render(): void;


### PR DESCRIPTION
Please fill in this template.

- [*] Prefer to make your PR against the `types-2.0` branch.
- [*] Test the change in your own code.
- [*] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [*] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [n/a] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [n/a] The package does not provide its own types, and you can not add them.
- [n/a] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [n/a] Run `tsc` without errors.
- [n/a] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [*] Provide a URL to  documentation or source code which provides context for the suggested changes: 
I believe that the documentation on handsontable's site is incorrect for this method: http://docs.handsontable.com/0.29.0/Core.html#propToCol
In my application I am getting props from handsontable that are numbers, not strings. Further evidence is that the inverse method (colToProp) is correctly documented to return string | number: http://docs.handsontable.com/0.29.0/Core.html#colToProp
- [n/a] Increase the version number in the header if appropriate.

