### PR TITLE
Sequelize failing test, when using nested property

### DIFF
--- a/sequelize/sequelize-tests.ts
+++ b/sequelize/sequelize-tests.ts
@@ -875,6 +875,7 @@ User.findAll( { order : [[User, { model : User, as : 'residents' }, 'lastName', 
 User.findAll( { include : [User], order : [[User, 'name', 'c']] } );
 User.findAll( { include : [{ all : 'HasMany', attributes : ['name'] }] } );
 User.findAll( { include : [{ all : true }, { model : User, attributes : ['id'] }] } );
+User.findAll( { include : [{ all : true, nested: true }, { model : User, attributes : ['id'] }] } );
 User.findAll( { include : [{ all : 'BelongsTo' }] } );
 User.findAll( { include : [{ all : true }] } );
 User.findAll( { where : { username : 'barfooz' }, raw : true } );


### PR DESCRIPTION
I'm not 100% how to fix this problem, but I have at least created a failing test.  Sequelize documentation here http://docs.sequelizejs.com/en/latest/docs/models-usage/ allows you to find with something called "Nested Eager Loading".  This typescript definition does not currently support that.

Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [ ] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

