### PR TITLE
Add chai-oequal types

### DIFF
--- a/chai-oequal/chai-oequal-tests.ts
+++ b/chai-oequal/chai-oequal-tests.ts
@@ -1,0 +1,35 @@
+import Chai = require('chai');
+import ChaiOequal = require('chai-oequal');
+
+Chai.use(ChaiOequal);
+
+import {
+    expect,
+    assert
+} from 'chai';
+
+expect({
+    equals: () => true,
+}).to.be.oequal({});
+expect({
+    customequals: () => true,
+}).to.be.oequal({}, 'customequals');
+expect({
+    equals: () => true,
+}).to.be.oeql({});
+expect({
+    equals: () => true,
+}).to.be.oeq({});
+
+assert.oequal({
+    equals: () => true,
+}, {});
+assert.oequal({
+    customequals: () => true,
+}, {}, 'customequals');
+assert.oeql({
+    equals: () => true,
+}, {});
+assert.oeq({
+    equals: () => true,
+}, {});

--- a/chai-oequal/index.d.ts
+++ b/chai-oequal/index.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for chai-oequal
+// Project: https://github.com/wrwrwr/chai-oequal
+// Definitions by: Mizunashi Mana <https://github.com/mizunashi-mana>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="chai" />
+
+declare namespace Chai {
+    // For BDD APIs
+    interface Assertion extends LanguageChains, NumericComparison, TypeComparison {
+        oequal(result: any, method?: string): Equal;
+        oeql(result: any, method?: string): Equal;
+        oeq(result: any, method?: string): Equal;
+    }
+
+    // For Assert APIs
+    interface Assert {
+        oequal(act: any, exp: any, method?: string): Equal;
+        oeql(act: any, exp: any, method?: string): Equal;
+        oeq(act: any, exp: any, method?: string): Equal;
+    }
+}
+
+declare module 'chai-oequal' {
+    function chaiOequal(chai: any, utils: any): void;
+    export = chaiOequal;
+}

--- a/chai-oequal/tsconfig.json
+++ b/chai-oequal/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "chai-oequal-tests.ts"
+    ]
+}

--- a/chai-oequal/tslint.json
+++ b/chai-oequal/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tslint.json",
+  "rules": {
+    "no-single-declare-module": false
+  }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [ x Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Run `tsc` without errors.
- [x] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

