### PR TITLE
Add callback parameter to tls.Server.close

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -1539,7 +1539,7 @@ declare module "child_process" {
         disconnect(): void;
         unref(): void;
         ref(): void;
-    
+
         /**
          * events.EventEmitter
          * 1. close
@@ -3051,7 +3051,7 @@ declare module "tls" {
     }
 
     export interface Server extends net.Server {
-        close(): Server;
+        close(callback?: Function): Server;
         address(): { port: number; family: string; address: string; };
         addContext(hostName: string, credentials: {
             key: string;

--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -1,3 +1,4 @@
+/// <reference path="index.d.ts" />
 import * as assert from "assert";
 import * as fs from "fs";
 import * as events from "events";
@@ -47,33 +48,33 @@ namespace global_tests {
 namespace assert_tests {
     {
         assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
-        
+
         assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");
-        
+
         assert.deepStrictEqual({ a: 1 }, { a: 1 }, "uses === comparator");
-        
+
         assert.doesNotThrow(() => {
             const b = false;
             if (b) { throw "a hammer at your face"; }
         }, undefined, "What the...*crunch*");
-        
+
         assert.equal(3, "3", "uses == comparator");
 
         assert.fail(1, 2, undefined, '>');
-        
+
         assert.ifError(0);
-        
+
         assert.notDeepStrictEqual({ x: { y: "3" } }, { x: { y: 3 } }, "uses !== comparator");
-        
+
         assert.notEqual(1, 2, "uses != comparator");
-        
+
         assert.notStrictEqual(2, "2", "uses === comparator");
-        
+
         assert.ok(true);
         assert.ok(1);
-        
+
         assert.strictEqual(1, 1,  "uses === comparator");
-        
+
         assert.throws(() => { throw "a hammer at your face"; }, undefined, "DODGED IT");
     }
 }
@@ -153,21 +154,21 @@ namespace fs_tests {
         fs.writeFile("thebible.txt",
             "Do unto others as you would have them do unto you.",
             assert.ifError);
-        
+
         fs.write(1234, "test");
-        
+
         fs.writeFile("Harry Potter",
             "\"You be wizzing, Harry,\" jived Dumbledore.",
             {
                 encoding: "ascii"
             },
-            assert.ifError);	
+            assert.ifError);
     }
 
     {
         var content: string;
         var buffer: Buffer;
-        
+
         content = fs.readFileSync('testfile', 'utf8');
         content = fs.readFileSync('testfile', { encoding: 'utf8' });
         buffer = fs.readFileSync('testfile');
@@ -177,7 +178,7 @@ namespace fs_tests {
         fs.readFile('testfile', (err, data) => buffer = data);
         fs.readFile('testfile', { flag: 'r' }, (err, data) => buffer = data);
     }
-    
+
     {
         var errno: number;
         fs.readFile('testfile', (err, data) => {
@@ -186,28 +187,28 @@ namespace fs_tests {
             }
         });
     }
-    
+
     {
         fs.mkdtemp('/tmp/foo-', (err, folder) => {
             console.log(folder);
             // Prints: /tmp/foo-itXde2
         });
     }
-    
+
     {
         var tempDir: string;
         tempDir = fs.mkdtempSync('/tmp/foo-');
     }
-    
+
     {
         fs.watch('/tmp/foo-', (event, filename) => {
           console.log(event, filename);
         });
-        
+
         fs.watch('/tmp/foo-', 'utf8', (event, filename) => {
           console.log(event, filename);
         });
-        
+
         fs.watch('/tmp/foo-', {
           recursive: true,
           persistent: true,
@@ -216,22 +217,22 @@ namespace fs_tests {
           console.log(event, filename);
         });
     }
-    
+
     {
         fs.access('/path/to/folder', (err) => { });
-        
+
         fs.access(Buffer.from(''), (err) => { });
-        
+
         fs.access('/path/to/folder', fs.constants.F_OK | fs.constants.R_OK, (err) => { });
-        
+
         fs.access(Buffer.from(''), fs.constants.F_OK | fs.constants.R_OK, (err) => { });
-        
+
         fs.accessSync('/path/to/folder');
-        
+
         fs.accessSync(Buffer.from(''));
-        
+
         fs.accessSync('path/to/folder', fs.constants.W_OK | fs.constants.X_OK);
-        
+
         fs.accessSync(Buffer.from(''), fs.constants.W_OK | fs.constants.X_OK);
     }
 }
@@ -400,14 +401,14 @@ function bufferTests() {
 namespace url_tests {
     {
         url.format(url.parse('http://www.example.com/xyz'));
-        
+
         // https://google.com/search?q=you're%20a%20lizard%2C%20gary
         url.format({
             protocol: 'https',
             host: "google.com",
             pathname: 'search',
             query: { q: "you're a lizard, gary" }
-        });   
+        });
     }
 
     {
@@ -424,7 +425,7 @@ namespace util_tests {
     {
         // Old and new util.inspect APIs
         util.inspect(["This is nice"], false, 5);
-        util.inspect(["This is nice"], { colors: true, depth: 5, customInspect: false });    
+        util.inspect(["This is nice"], { colors: true, depth: 5, customInspect: false });
     }
 }
 
@@ -731,6 +732,14 @@ namespace tls_tests {
         _server = _server.prependOnceListener("secureConnection", (tlsSocket) => {
             let _tlsSocket: tls.TLSSocket = tlsSocket;
         })
+
+        // close callback parameter is optional
+        _server = _server.close();
+
+        // close callback parameter doesn't specify any arguments, so any
+        // function is acceptable
+        _server = _server.close(() => {});
+        _server = _server.close((...args:any[]) => {});
     }
 
     {
@@ -772,7 +781,7 @@ namespace tls_tests {
             let _response: Buffer = response;
         })
         _TLSSocket = _TLSSocket.prependOnceListener("secureConnect", () => { });
-    } 
+    }
 }
 
 ////////////////////////////////////////////////////
@@ -1315,9 +1324,9 @@ namespace string_decoder_tests {
 namespace child_process_tests {
     {
         childProcess.exec("echo test");
-        childProcess.spawnSync("echo test");    
+        childProcess.spawnSync("echo test");
     }
-    
+
     {
         let _cp: childProcess.ChildProcess;
         let _boolean: boolean;
@@ -1574,7 +1583,7 @@ namespace process_tests {
     {
         var eventEmitter: events.EventEmitter;
         eventEmitter = process;                // Test that process implements EventEmitter...
-        
+
         var _p: NodeJS.Process = process;
         _p = p;
     }
@@ -1605,8 +1614,22 @@ namespace console_tests {
 
 namespace net_tests {
     {
-        // Make sure .listen() and .close() retuern a Server instance
-        net.createServer().listen(0).close().address();
+        let server = net.createServer();
+        // Check methods which return server instances by chaining calls
+        server = server.listen(0)
+                .close()
+                .ref()
+                .unref();
+
+        // close has an optional callback function. No callback parameters are
+        // specified, so any callback function is permissible.
+        server = server.close((...args: any[]) => {});
+
+        // test the types of the address object fields
+        let address = server.address();
+        address.port = 1234;
+        address.family = "ipv4";
+        address.address = "127.0.0.1";
     }
 
     {


### PR DESCRIPTION
Please fill in this template.

- [ ✓ ] Prefer to make your PR against the `types-2.0` branch.
- [ ✓ ] Test the change in your own code.
- [ ✓ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [ ✓ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ✗ ] Run `npm run lint -- package-name` if a `tslint.json` is present.
    - Not present.
If changing an existing definition:
- [ ✓ ] Provide a URL to  documentation or source code which provides context for the suggested changes: https://nodejs.org/api/tls.html#tls_server_close_callback
- [ ✗ ] Increase the version number in the header if appropriate.
    - Node interface hasn't changed, just updating types to reflect current interface.