### PR TITLE
three: Fix parameter type in Quaternion.dot

### DIFF
--- a/three/index.d.ts
+++ b/three/index.d.ts
@@ -3646,7 +3646,7 @@ declare namespace THREE {
         inverse(): Quaternion;
 
         conjugate(): Quaternion;
-        dot(v: Vector3): number;
+        dot(v: Quaternion): number;
         lengthSq(): number;
 
         /**


### PR DESCRIPTION
Please fill in this template.

- [✓] Prefer to make your PR against the `types-2.0` branch.
- [✓] Test the change in your own code.
- [✓] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [✓] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [✓] Run `npm run lint -- package-name` if a `tslint.json` is present.


If changing an existing definition:
- [✓] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/mrdoob/three.js/blob/dev/src/math/Quaternion.js#L321
- [✓] Increase the version number in the header if appropriate.

Quaternion.dot takes in another quaternion, not a Vector3.

Signed-off-by: David Li <jiawei.davidli@gmail.com>