### PR TITLE
Added `simplesignal` and `prando` to notNeededPackages.json

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -52,6 +52,18 @@
             "typingsPackageName": "typescript-services",
             "sourceRepoURL": "https://github.com/Microsoft/TypeScript",
             "asOfVersion": "2.0.0"
+        },
+        {
+            "libraryName": "Prando",
+            "typingsPackageName": "prando",
+            "sourceRepoURL": "https://github.com/zeh/prando",
+            "asOfVersion": "1.0.0"
+        },
+        {
+            "libraryName": "SimpleSignal",
+            "typingsPackageName": "simplesignal",
+            "sourceRepoURL": "https://github.com/zeh/simplesignal",
+            "asOfVersion": "1.0.0"
         }
     ]
 }


### PR DESCRIPTION
As per the publishing instructions [in the handbook](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) under "Publicize your declaration file", this adds references to two of my projects to the list of NPM packages that do not need declaration types. The packages themselves already ship with their own `.d.ts` file, and their `types` declared within `packages.json`.

The existing list is small, and doesn't seem to have a particular order, so I added the new definitions at the end. Let me know if any change is warranted.