### PR TITLE
Updated to version 3.3.3 - fix in cascade from boolean to string

### DIFF
--- a/jstree/jstree-tests.ts
+++ b/jstree/jstree-tests.ts
@@ -114,3 +114,15 @@ tree.get_path('nodeId');
 tree.get_path('nodeId', '/');
 tree.get_path('nodeId', '/', true);
 
+
+
+var coreThemes: JSTreeStaticDefaultsCoreThemes = {
+    ellipsis:true
+};
+
+// tree with new theme elipsis
+var treeWithNewCoreProperties = $('#treeWithNewEllipsisProperties').jstree({
+    core: {
+        themes: coreThemes
+    }
+});

--- a/jstree/jstree.d.ts
+++ b/jstree/jstree.d.ts
@@ -1,8 +1,8 @@
-﻿// Type definitions for jsTree v3.3.2 
+﻿// Type definitions for jsTree v3.3.3 
 // Project: http://www.jstree.com/
 // Definitions by: Adam Pluciński <https://github.com/adaskothebeast>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// 1 commit bb0473ae8cfc205585b6404ef86f650df2f6996e 2016-08-15
+// 1 commit 26e99ad5ec27c1a594ed57974cb16e0987482fd5 2016-11-19
 
 ///<reference path="../jquery/jquery.d.ts" />
 
@@ -375,6 +375,12 @@ interface JSTreeStaticDefaultsCoreThemes {
     icons?: boolean;
 
     /**
+    * a boolean indicating if node ellipsis should be shown - this only works with a fixed with on the container
+    * @name $.jstree.defaults.core.themes.ellipsis
+    */
+    ellipsis?: boolean;
+
+    /**
     * a boolean indicating if the tree background is striped
     * @name $.jstree.defaults.core.themes.stripes
     */
@@ -423,13 +429,13 @@ interface JSTreeStaticDefaultsCheckbox {
     keep_selected_style: boolean;
 
     /**
-    * This setting controls how cascading and undetermined nodes are applied. 
-    * If 'up' is in the string - cascading up is enabled, if 'down' is in the string - cascading down is enabled, if 'undetermined' is in the string - undetermined nodes will be used. 
+    * This setting controls how cascading and undetermined nodes are applied.
+    * If 'up' is in the string - cascading up is enabled, if 'down' is in the string - cascading down is enabled, if 'undetermined' is in the string - undetermined nodes will be used.
     * If `three_state` is set to `true` this setting is automatically set to 'up+down+undetermined'. Defaults to ''.
     * @name $.jstree.defaults.checkbox.cascade
     * @plugin checkbox
     */
-    cascade: boolean;
+    cascade: string;
 
     /**
     * This setting controls if checkbox are bound to the general tree selection 
@@ -736,6 +742,11 @@ interface JSTree extends JQuery {
     * @name teardown()
     */
     teardown: () => void;
+
+    /**
+    * Create prototype node
+    */
+    _create_prototype_node: () => HTMLElement;
 
     /**
     * bind all events. Used internally.
@@ -1566,6 +1577,24 @@ interface JSTree extends JQuery {
     * @name toggle_icons()
     */
     toggle_icons: () => void;
+
+    /**
+    * show the node ellipsis
+    * @name show_icons()
+    */
+    show_ellipsis: () => void;
+
+    /**
+    * hide the node ellipsis
+    * @name hide_ellipsis()
+    */
+    hide_ellipsis: () => void;
+
+    /**
+    * toggle the node ellipsis
+    * @name toggle_icons()
+    */
+    toggle_ellipsis: () => void;
 
     /**
     * set the node icon for a node


### PR DESCRIPTION
Please fill in this template.

- [ ] Prefer to make your PR against the `types-2.0` branch.
- [ X] Test the change in your own code.
- [X ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [X ] Provide a URL to  documentation or source code which provides context for the suggested changes: https://www.jstree.com/api/#/?f=$.jstree.defaults.checkbox.cascade
- [ X] Increase the version number in the header if appropriate.

