### PR TITLE
xml2js: Allow parsing a NodeJS buffer

### DIFF
--- a/xml2js/index.d.ts
+++ b/xml2js/index.d.ts
@@ -8,8 +8,8 @@
 export = xml2js;
 
 declare namespace xml2js {
-    function parseString(xml: string, callback: (err: any, result: any) => void): void;
-    function parseString(xml: string, options: OptionsV2, callback: (err: any, result: any) => void): void;
+    function parseString(xml: convertableToString, callback: (err: any, result: any) => void): void;
+    function parseString(xml: convertableToString, options: OptionsV2, callback: (err: any, result: any) => void): void;
 
     var defaults: {
         '0.1': Options;
@@ -23,7 +23,7 @@ declare namespace xml2js {
 
     class Parser {
         constructor(options?: OptionsV2);
-        parseString(str: string, cb?: Function): void;
+        parseString(str: convertableToString, cb?: Function): void;
     }
 
     interface Options {
@@ -69,6 +69,10 @@ declare namespace xml2js {
         headless?: boolean;
         chunkSize?: number;
         cdata?: boolean;
+    }
+
+    interface convertableToString {
+        toString(): string;
     }
 }
 

--- a/xml2js/xml2js-tests.ts
+++ b/xml2js/xml2js-tests.ts
@@ -1,3 +1,4 @@
+/// <reference types="node"/>
 
 import xml2js = require('xml2js');
 
@@ -67,3 +68,11 @@ var v2Defaults = xml2js.defaults['0.2'];
 v2Defaults.async = false;
 v2Defaults.chunkSize = 20000;
 
+import fs = require('fs');
+ 
+fs.readFile(__dirname + '/foo.xml', function(err, data) {
+    parser.parseString(data, function (err: any, result: any) {
+        console.dir(result);
+        console.log('Done');
+    });
+});


### PR DESCRIPTION
Please fill in this template.

- [X] Prefer to make your PR against the `types-2.0` branch.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [X] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [X] Provide a URL to  documentation or source code which provides context for the suggested changes: <https://www.npmjs.com/package/xml2js#simple-as-pie-usage>
- [ ] Increase the version number in the header if appropriate.

