### PR TITLE
Improve webpack 2 definitions

### DIFF
--- a/webpack/index.d.ts
+++ b/webpack/index.d.ts
@@ -4,8 +4,10 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="uglify-js" />
+/// <reference types="tapable" />
 
 import * as UglifyJS from 'uglify-js';
+import * as tapable from 'tapable';
 
 declare namespace webpack {
     interface Configuration {
@@ -345,7 +347,7 @@ declare namespace webpack {
     }
     type Rule = LoaderRule | UseRule | RulesRule | OneOfRule;
 
-    interface Plugin { }
+    interface Plugin extends tapable.Plugin {}
 
     interface Webpack {
         (config: Configuration, callback?: compiler.CompilerCallback): compiler.Compiler;

--- a/webpack/index.d.ts
+++ b/webpack/index.d.ts
@@ -520,11 +520,11 @@ declare namespace webpack {
     }
 
     interface DefinePluginStatic {
-        new (definitions: any): Plugin;
+        new (definitions: {[key: string]: any}): Plugin;
     }
 
     interface ProvidePluginStatic {
-        new (definitions: any): Plugin;
+        new (definitions: {[key: string]: any}): Plugin;
     }
 
     interface SourceMapDevToolPluginStatic {

--- a/webpack/index.d.ts
+++ b/webpack/index.d.ts
@@ -247,7 +247,7 @@ declare namespace webpack {
     }
     type ConditionSpec = TestConditionSpec | OrConditionSpec | AndConditionSpec | NotConditionSpec;
 
-    interface ConditionArray extends Array<Condition> {} 
+    interface ConditionArray extends Array<Condition> {}
     type Condition = string | RegExp | ((absPath: string) => boolean) | ConditionSpec | ConditionArray;
 
     interface OldLoader {
@@ -260,26 +260,26 @@ declare namespace webpack {
     }
     type Loader = string | OldLoader | NewLoader;
 
-    /** 
+    /**
      * There are direct and delegate rules. Direct Rules need a test, Delegate rules delegate to subrules bringing their own.
      * Direct rules can optionally contain delegate keys (oneOf, rules).
-     * 
+     *
      * These types exist to enforce that a rule has the keys `((loader XOR loaders) AND test) OR oneOf OR rules`
      */
     interface BaseRule {
         /**
          * Specifies the category of the loader. No value means normal loader.
-         * 
+         *
          * There is also an additional category "inlined loader" which are loaders applied inline of the import/require.
-         * 
+         *
          * All loaders are sorted in the order post, inline, normal, pre and used in this order.
-         * 
+         *
          * All normal loaders can be omitted (overridden) by prefixing ! in the request.
-         * 
+         *
          * All normal and pre loaders can be omitted (overridden) by prefixing -! in the request.
-         * 
+         *
          * All normal, post and pre loaders can be omitted (overridden) by prefixing !! in the request.
-         * 
+         *
          * Inline loaders and ! prefixes should not be used as they are non-standard. They may be use by loader generated code.
          */
         enforce?: 'pre' | 'post';
@@ -295,7 +295,7 @@ declare namespace webpack {
         issuer?: Condition | Condition[];
         /**
          * An object with parser options. All applied parser options are merged.
-         * 
+         *
          * For each different parser options object a new parser is created and plugins can apply plugins depending on the parser options. Many of the default plugins apply their parser plugins only if a property in the parser options is not set or true.
          */
         parser?: { [optName: string]: any };
@@ -336,7 +336,7 @@ declare namespace webpack {
         use: Loader | Loader[];
     }
     type UseRule = OldUseRule | NewUseRule;
-    
+
     // Delegate Rules
     interface RulesRule extends BaseRule {
         /** An array of Rules that is also used when the Rule matches. */

--- a/webpack/index.d.ts
+++ b/webpack/index.d.ts
@@ -528,11 +528,11 @@ declare namespace webpack {
     }
 
     interface SourceMapDevToolPluginStatic {
-        new (options?: SourceMapDevToolPluginOptions): Plugin;
+        // if string | false | null, maps to the filename option
+        new (options?: string | false | null | SourceMapDevToolPluginOptions): Plugin;
     }
 
-    // if string | false | null, maps to the filename option
-    type SourceMapDevToolPluginOptions = string | false | null | {
+    interface SourceMapDevToolPluginOptions {
         // output filename pattern (false/null to append)
         filename?: string | false | null,
         // source map comment pattern (false to not append)
@@ -562,11 +562,11 @@ declare namespace webpack {
     }
 
     interface EvalSourceMapDevToolPluginStatic {
-        new (options?: EvalSourceMapDevToolPluginOptions): Plugin;
+        // if string | false, maps to the append option
+        new (options?: string | false | EvalSourceMapDevToolPluginOptions): Plugin;
     }
 
-    // if string | false, maps to the append option
-    type EvalSourceMapDevToolPluginOptions = string | false | {
+    interface EvalSourceMapDevToolPluginOptions {
         append?: false | string,
         moduleFilenameTemplate?: string,
         sourceRoot?: string,

--- a/webpack/index.d.ts
+++ b/webpack/index.d.ts
@@ -63,7 +63,7 @@ declare namespace webpack {
         /** Store compiler state to a json file. */
         recordsOutputPath?: string;
         /** Add additional plugins to the compiler. */
-        plugins?: (Plugin | Function)[];
+        plugins?: Plugin[];
         /** Stats options for logging  */
         stats?: compiler.StatsToStringOptions;
     }

--- a/webpack/index.d.ts
+++ b/webpack/index.d.ts
@@ -409,7 +409,7 @@ declare namespace webpack {
          * Adds SourceMaps for assets, but wrapped inside eval statements.
          * Much faster incremental build speed, but harder to debug.
          */
-        EvalSourceMapDevToolPlugin: SourceMapDevToolPluginStatic;
+        EvalSourceMapDevToolPlugin: EvalSourceMapDevToolPluginStatic;
         /**
          * Enables Hot Module Replacement. (This requires records data if not in dev-server mode, recordsPath)
          * Generates Hot Update Chunks of each chunk in the records.
@@ -528,7 +528,31 @@ declare namespace webpack {
     }
 
     interface SourceMapDevToolPluginStatic {
-        new (options: any): Plugin;
+        new (options?: string | false | null | {
+            filename?: string | false | null,
+            append?: false | string,
+            moduleFilenameTemplate?: string,
+            fallbackModuleFilenameTemplate?: string,
+            test?: RegExp,
+            noSources?: boolean,
+            module?: boolean,
+            lineToLine?: boolean | {
+                test?: Condition | Condition[],
+                include?: Condition | Condition[],
+                exclude?: Condition | Condition[]
+            }
+        }): Plugin;
+    }
+
+    interface EvalSourceMapDevToolPluginStatic {
+        new (options?: {
+            module?: boolean,
+            lineToLine?: boolean | {
+                test?: Condition | Condition[],
+                include?: Condition | Condition[],
+                exclude?: Condition | Condition[]
+            }
+        }): Plugin;
     }
 
     interface HotModuleReplacementPluginStatic {

--- a/webpack/index.d.ts
+++ b/webpack/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for webpack 2.0.0
+// Type definitions for webpack 2.1
 // Project: https://github.com/webpack/webpack
 // Definitions by: Qubo <https://github.com/tkqubo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -155,23 +155,115 @@ declare namespace webpack {
     }
     type Module = OldModule | NewModule;
 
-    interface Resolve {
+    interface NewResolve {
+        /**
+         * A list of directories to resolve modules from.
+         *
+         * Absolute paths will be searched once.
+         *
+         * If an entry is relative, will be resolved using node's resolution algorithm
+         * relative to the requested file.
+         *
+         * Defaults to `["node_modules"]`
+         */
+        modules?: string[];
+
+        /**
+         * A list of package description files to search for.
+         *
+         * Defaults to `["package.json"]`
+         */
+        descriptionFiles?: string[];
+
+        /**
+         * A list of fields in a package description object to use for finding
+         * the entry point.
+         *
+         * Defaults to `["browser", "module", "main"]` or `["module", "main"]`,
+         * depending on the value of the `target` `Configuration` value.
+         */
+        mainFields?: string[];
+
+        /**
+         * A list of fields in a package description object to try to parse
+         * in the same format as the `alias` resolve option.
+         *
+         * Defaults to `["browser"]` or `[]`, depending on the value of the
+         * `target` `Configuration` value.
+         *
+         * @see alias
+         */
+        aliasFields?: string[];
+
+        /**
+         * A list of file names to search for when requiring directories that
+         * don't contain a package description file.
+         *
+         * Defaults to `["index"]`.
+         */
+        mainFiles?: string[];
+
+        /**
+         * A list of file extensions to try when requesting files.
+         *
+         * An empty string is considered invalid.
+         */
+        extensions?: string[];
+
+        /**
+         * If true, requires that all requested paths must use an extension
+         * from `extensions`.
+         */
+        enforceExtension?: boolean;
+
+        /**
+         * Replace the given module requests with other modules or paths.
+         *
+         * @see aliasFields
+         */
+        alias?: { [key: string]: string; };
+
+        /**
+         * Whether to use a cache for resolving, or the specific object
+         * to use for caching. Sharing objects may be useful when running
+         * multiple webpack compilers.
+         *
+         * Defaults to `true`.
+         */
+        unsafeCache?: {} | boolean;
+
+        /**
+         * A function used to decide whether to cache the given resolve request.
+         *
+         * Defaults to `() => true`.
+         */
+        cachePredicate?: (data: { path: string, request: string }) => boolean;
+    }
+
+    interface OldResolve {
         /** Replace modules by other modules or paths. */
         alias?: { [key: string]: string; };
         /**
          * The directory (absolute path) that contains your modules.
          * May also be an array of directories.
-         * This setting should be used to add individual directories to the search path. */
+         * This setting should be used to add individual directories to the search path.
+         *
+         * @deprecated Replaced by `modules` in webpack 2.
+         */
         root?: string | string[];
         /**
          * An array of directory names to be resolved to the current directory as well as its ancestors, and searched for modules.
          * This functions similarly to how node finds “node_modules” directories.
          * For example, if the value is ["mydir"], webpack will look in “./mydir”, “../mydir”, “../../mydir”, etc.
+         *
+         * @deprecated Replaced by `modules` in webpack 2.
          */
         modulesDirectories?: string[];
         /**
          * A directory (or array of directories absolute paths),
          * in which webpack should look for modules that weren’t found in resolve.root or resolve.modulesDirectories.
+         *
+         * @deprecated Replaced by `modules` in webpack 2.
          */
         fallback?: string | string[];
         /**
@@ -179,22 +271,49 @@ declare namespace webpack {
          * For example, in order to discover CoffeeScript files, your array should contain the string ".coffee".
          */
         extensions?: string[];
-        /** Check these fields in the package.json for suitable files. */
+        /**
+         * Check these fields in the package.json for suitable files.
+         *
+         * @deprecated Replaced by `mainFields` in webpack 2.
+         */
         packageMains?: (string | string[])[];
-        /** Check this field in the package.json for an object. Key-value-pairs are threaded as aliasing according to this spec */
+
+        /**
+         * Check this field in the package.json for an object. Key-value-pairs are threaded as aliasing according to this spec
+         *
+         * @deprecated Replaced by `aliasFields` in webpack 2.
+         */
         packageAlias?: (string | string[])[];
+
         /**
          * Enable aggressive but unsafe caching for the resolving of a part of your files.
          * Changes to cached paths may cause failure (in rare cases). An array of RegExps, only a RegExp or true (all files) is expected.
          * If the resolved path matches, it’ll be cached.
+         *
+         * @deprecated Split into `unsafeCache` and `cachePredicate` in webpack 2.
          */
         unsafeCache?: RegExp | RegExp[] | boolean;
     }
 
-    interface ResolveLoader extends Resolve {
-        /** It describes alternatives for the module name that are tried. */
+    type Resolve = OldResolve | NewResolve;
+
+    interface OldResolveLoader extends OldResolve {
+        /** It describes alternatives for the module name that are tried.
+         * @deprecated Replaced by `moduleExtensions` in webpack 2.
+         */
         moduleTemplates?: string[];
     }
+
+    interface NewResolveLoader extends NewResolve {
+        /**
+         * List of strings to append to a loader's name when trying to resolve it.
+         */
+        moduleExtensions?: string[];
+
+        enforceModuleExtension?: boolean;
+    }
+
+    type ResolveLoader = OldResolveLoader | NewResolveLoader;
 
     type ExternalsElement = string | RegExp | ExternalsObjectElement | ExternalsFunctionElement;
 

--- a/webpack/index.d.ts
+++ b/webpack/index.d.ts
@@ -347,7 +347,9 @@ declare namespace webpack {
     }
     type Rule = LoaderRule | UseRule | RulesRule | OneOfRule;
 
-    interface Plugin extends tapable.Plugin {}
+    interface Plugin extends tapable.Plugin {
+        apply (thisArg: Webpack, ...args: any[]): void
+    }
 
     interface Webpack {
         (config: Configuration, callback?: compiler.CompilerCallback): compiler.Compiler;
@@ -404,6 +406,11 @@ declare namespace webpack {
          */
         SourceMapDevToolPlugin: SourceMapDevToolPluginStatic;
         /**
+         * Adds SourceMaps for assets, but wrapped inside eval statements.
+         * Much faster incremental build speed, but harder to debug.
+         */
+        EvalSourceMapDevToolPlugin: SourceMapDevToolPluginStatic;
+        /**
          * Enables Hot Module Replacement. (This requires records data if not in dev-server mode, recordsPath)
          * Generates Hot Update Chunks of each chunk in the records.
          * It also enables the API and makes __webpack_hash__ available in the bundle.
@@ -422,6 +429,11 @@ declare namespace webpack {
          * Does not watch specified files matching provided paths or RegExps.
          */
         WatchIgnorePlugin: WatchIgnorePluginStatic;
+        /**
+         * Uses the module name as the module id inside the bundle, instead of a number.
+         * Helps with debugging, but increases bundle size.
+         */
+        NamedModulesPlugin: NamedModulesPluginStatic;
     }
 
     interface Optimize {
@@ -533,6 +545,10 @@ declare namespace webpack {
 
     interface WatchIgnorePluginStatic {
         new (paths: RegExp[]): Plugin;
+    }
+
+    interface NamedModulesPluginStatic {
+        new (): Plugin;
     }
 
     namespace optimize {

--- a/webpack/index.d.ts
+++ b/webpack/index.d.ts
@@ -528,31 +528,55 @@ declare namespace webpack {
     }
 
     interface SourceMapDevToolPluginStatic {
-        new (options?: string | false | null | {
-            filename?: string | false | null,
-            append?: false | string,
-            moduleFilenameTemplate?: string,
-            fallbackModuleFilenameTemplate?: string,
-            test?: RegExp,
-            noSources?: boolean,
-            module?: boolean,
-            lineToLine?: boolean | {
-                test?: Condition | Condition[],
-                include?: Condition | Condition[],
-                exclude?: Condition | Condition[]
-            }
-        }): Plugin;
+        new (options?: SourceMapDevToolPluginOptions): Plugin;
+    }
+
+    // if string | false | null, maps to the filename option
+    type SourceMapDevToolPluginOptions = string | false | null | {
+        // output filename pattern (false/null to append)
+        filename?: string | false | null,
+        // source map comment pattern (false to not append)
+        append?: false | string,
+        // template for the module filename inside the source map
+        moduleFilenameTemplate?: string,
+        // fallback used when the moduleFilenameTemplate produces a collision
+        fallbackModuleFilenameTemplate?: string,
+        // test/include/exclude files
+        test?: Condition | Condition[],
+        include?: Condition | Condition[],
+        exclude?: Condition | Condition[]
+        // whether to include the footer comment with source information
+        noSources?: boolean,
+        // the source map sourceRoot ("The URL root from which all sources are relative.")
+        sourceRoot?: string | null,
+        // whether to generate per-module source map
+        module?: boolean,
+        // whether to include column information in the source map
+        columns?: boolean,
+        // whether to preserve line numbers between source and source map
+        lineToLine?: boolean | {
+            test?: Condition | Condition[],
+            include?: Condition | Condition[],
+            exclude?: Condition | Condition[]
+        }
     }
 
     interface EvalSourceMapDevToolPluginStatic {
-        new (options?: {
-            module?: boolean,
-            lineToLine?: boolean | {
-                test?: Condition | Condition[],
-                include?: Condition | Condition[],
-                exclude?: Condition | Condition[]
-            }
-        }): Plugin;
+        new (options?: EvalSourceMapDevToolPluginOptions): Plugin;
+    }
+
+    // if string | false, maps to the append option
+    type EvalSourceMapDevToolPluginOptions = string | false | {
+        append?: false | string,
+        moduleFilenameTemplate?: string,
+        sourceRoot?: string,
+        module?: boolean,
+        columns?: boolean,
+        lineToLine?: boolean | {
+            test?: Condition | Condition[],
+            include?: Condition | Condition[],
+            exclude?: Condition | Condition[]
+        }
     }
 
     interface HotModuleReplacementPluginStatic {

--- a/webpack/webpack-tests.ts
+++ b/webpack/webpack-tests.ts
@@ -482,3 +482,7 @@ configuration = {
 		]
 	}
 }
+
+const resolve: webpack.Resolve = {
+    cachePredicate: 'boo' // why does this test _not_ fail!?
+}

--- a/webpack/webpack-tests.ts
+++ b/webpack/webpack-tests.ts
@@ -341,23 +341,25 @@ plugin = new webpack.ProvidePlugin({
 });
 plugin = new webpack.SourceMapDevToolPlugin({
     //// asset matching
-    //test: string | RegExp | Array,
-    //include: string | RegExp | Array,
-    //exclude: string | RegExp | Array,
+    test: /\.js$/,
+    //include: Condition | Condition[],
+    exclude: [
+        /node_modules/
+    ],
     //
     //// file and reference
-    //filename: string,
-    //append: bool | string,
-    //
+    filename: null, // | string
+    //append: false | string,
     //// sources naming
     //moduleFilenameTemplate: string,
     //fallbackModuleFilenameTemplate: string,
     //
     //// quality/performance
-    //module: bool,
-    //columns: bool,
-    //lineToLine: bool | object
+    module: true,
+    columns: true,
+    lineToLine: false // | { test?: Condition | Condition[], ... }
 });
+plugin = new webpack.EvalSourceMapDevToolPlugin(false);
 plugin = new webpack.HotModuleReplacementPlugin();
 plugin = new webpack.ExtendedAPIPlugin();
 plugin = new webpack.NoErrorsPlugin();


### PR DESCRIPTION
- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

There were some preexisting lint failures, but I didn't try fixing them here.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes:
* https://github.com/webpack/webpack/blob/master/lib/webpack.js
* https://github.com/webpack/webpack/blob/master/lib/NamedModulesPlugin.js
* https://github.com/webpack/webpack/blob/master/lib/SourceMapDevToolPlugin.js
* https://github.com/webpack/webpack/blob/master/lib/EvalSourceMapDevToolPlugin.js
* https://github.com/webpack/webpack/blob/master/lib/ModuleFilenameHelpers.js
* https://github.com/webpack/webpack/blob/master/lib/SourceMapDevToolModuleOptionsPlugin.js
* https://github.com/webpack/webpack-sources/blob/master/lib/SourceAndMapMixin.js
* I believe `sourceRoot` is meant to be consumed by the `source-map` module.
- [x] Increase the version number in the header if appropriate.
