### PR TITLE
isTTY property on ReadableStream and WriteableStream

### DIFF
--- a/node/node-0.10.d.ts
+++ b/node/node-0.10.d.ts
@@ -99,7 +99,7 @@ declare namespace NodeJS {
 
     export interface ReadableStream extends EventEmitter {
         readable: boolean;
-        isTTY: boolean;
+        isTTY?: boolean;
         read(size?: number): any;
         setEncoding(encoding: string): void;
         pause(): void;
@@ -113,7 +113,7 @@ declare namespace NodeJS {
 
     export interface WritableStream extends EventEmitter {
         writable: boolean;
-        isTTY: boolean;
+        isTTY?: boolean;
         write(buffer: Buffer, cb?: Function): boolean;
         write(str: string, cb?: Function): boolean;
         write(str: string, encoding?: string, cb?: Function): boolean;

--- a/node/node-0.10.d.ts
+++ b/node/node-0.10.d.ts
@@ -99,6 +99,7 @@ declare namespace NodeJS {
 
     export interface ReadableStream extends EventEmitter {
         readable: boolean;
+        isTTY: boolean;
         read(size?: number): any;
         setEncoding(encoding: string): void;
         pause(): void;
@@ -112,6 +113,7 @@ declare namespace NodeJS {
 
     export interface WritableStream extends EventEmitter {
         writable: boolean;
+        isTTY: boolean;
         write(buffer: Buffer, cb?: Function): boolean;
         write(str: string, cb?: Function): boolean;
         write(str: string, encoding?: string, cb?: Function): boolean;

--- a/node/node-0.11.d.ts
+++ b/node/node-0.11.d.ts
@@ -99,7 +99,7 @@ declare namespace NodeJS {
 
     export interface ReadableStream extends EventEmitter {
         readable: boolean;
-        isTTY: boolean;
+        isTTY?: boolean;
         read(size?: number): any;
         setEncoding(encoding: string): void;
         pause(): void;
@@ -113,7 +113,7 @@ declare namespace NodeJS {
 
     export interface WritableStream extends EventEmitter {
         writable: boolean;
-        isTTY: boolean;
+        isTTY?: boolean;
         write(buffer: Buffer, cb?: Function): boolean;
         write(str: string, cb?: Function): boolean;
         write(str: string, encoding?: string, cb?: Function): boolean;

--- a/node/node-0.11.d.ts
+++ b/node/node-0.11.d.ts
@@ -99,6 +99,7 @@ declare namespace NodeJS {
 
     export interface ReadableStream extends EventEmitter {
         readable: boolean;
+        isTTY: boolean;
         read(size?: number): any;
         setEncoding(encoding: string): void;
         pause(): void;
@@ -112,6 +113,7 @@ declare namespace NodeJS {
 
     export interface WritableStream extends EventEmitter {
         writable: boolean;
+        isTTY: boolean;
         write(buffer: Buffer, cb?: Function): boolean;
         write(str: string, cb?: Function): boolean;
         write(str: string, encoding?: string, cb?: Function): boolean;

--- a/node/node-0.12.d.ts
+++ b/node/node-0.12.d.ts
@@ -180,7 +180,7 @@ declare namespace NodeJS {
 
     export interface ReadableStream extends EventEmitter {
         readable: boolean;
-        isTTY: boolean;
+        isTTY?: boolean;
         read(size?: number): string|Buffer;
         setEncoding(encoding: string): void;
         pause(): void;
@@ -194,7 +194,7 @@ declare namespace NodeJS {
 
     export interface WritableStream extends EventEmitter {
         writable: boolean;
-        isTTY: boolean;
+        isTTY?: boolean;
         write(buffer: Buffer|string, cb?: Function): boolean;
         write(str: string, encoding?: string, cb?: Function): boolean;
         end(): void;

--- a/node/node-0.12.d.ts
+++ b/node/node-0.12.d.ts
@@ -180,6 +180,7 @@ declare namespace NodeJS {
 
     export interface ReadableStream extends EventEmitter {
         readable: boolean;
+        isTTY: boolean;
         read(size?: number): string|Buffer;
         setEncoding(encoding: string): void;
         pause(): void;
@@ -193,6 +194,7 @@ declare namespace NodeJS {
 
     export interface WritableStream extends EventEmitter {
         writable: boolean;
+        isTTY: boolean;
         write(buffer: Buffer|string, cb?: Function): boolean;
         write(str: string, encoding?: string, cb?: Function): boolean;
         end(): void;

--- a/node/node-0.8.8.d.ts
+++ b/node/node-0.8.8.d.ts
@@ -89,7 +89,7 @@ interface EventEmitter {
 
 interface WritableStream extends EventEmitter {
     writable: boolean;
-    isTTY: boolean;
+    isTTY?: boolean;
     write(str: string, encoding?: string, fd?: string): boolean;
     write(buffer: Buffer): boolean;
     end(): void;
@@ -101,7 +101,7 @@ interface WritableStream extends EventEmitter {
 
 interface ReadableStream extends EventEmitter {
     readable: boolean;
-    isTTY: boolean;
+    isTTY?: boolean;
     setEncoding(encoding: string): void;
     pause(): void;
     resume(): void;

--- a/node/node-0.8.8.d.ts
+++ b/node/node-0.8.8.d.ts
@@ -89,6 +89,7 @@ interface EventEmitter {
 
 interface WritableStream extends EventEmitter {
     writable: boolean;
+    isTTY: boolean;
     write(str: string, encoding?: string, fd?: string): boolean;
     write(buffer: Buffer): boolean;
     end(): void;
@@ -100,6 +101,7 @@ interface WritableStream extends EventEmitter {
 
 interface ReadableStream extends EventEmitter {
     readable: boolean;
+    isTTY: boolean;
     setEncoding(encoding: string): void;
     pause(): void;
     resume(): void;

--- a/node/node-4.d.ts
+++ b/node/node-4.d.ts
@@ -232,6 +232,7 @@ declare namespace NodeJS {
 
     export interface ReadableStream extends EventEmitter {
         readable: boolean;
+        isTTY: boolean;
         read(size?: number): string|Buffer;
         setEncoding(encoding: string): void;
         pause(): void;
@@ -245,6 +246,7 @@ declare namespace NodeJS {
 
     export interface WritableStream extends EventEmitter {
         writable: boolean;
+        isTTY: boolean;
         write(buffer: Buffer|string, cb?: Function): boolean;
         write(str: string, encoding?: string, cb?: Function): boolean;
         end(): void;

--- a/node/node-4.d.ts
+++ b/node/node-4.d.ts
@@ -232,7 +232,7 @@ declare namespace NodeJS {
 
     export interface ReadableStream extends EventEmitter {
         readable: boolean;
-        isTTY: boolean;
+        isTTY?: boolean;
         read(size?: number): string|Buffer;
         setEncoding(encoding: string): void;
         pause(): void;
@@ -246,7 +246,7 @@ declare namespace NodeJS {
 
     export interface WritableStream extends EventEmitter {
         writable: boolean;
-        isTTY: boolean;
+        isTTY?: boolean;
         write(buffer: Buffer|string, cb?: Function): boolean;
         write(str: string, encoding?: string, cb?: Function): boolean;
         end(): void;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -259,6 +259,7 @@ declare namespace NodeJS {
 
     export interface ReadableStream extends EventEmitter {
         readable: boolean;
+        isTTY: boolean;
         read(size?: number): string | Buffer;
         setEncoding(encoding: string): void;
         pause(): ReadableStream;
@@ -272,6 +273,7 @@ declare namespace NodeJS {
 
     export interface WritableStream extends EventEmitter {
         writable: boolean;
+        isTTY: boolean;
         write(buffer: Buffer | string, cb?: Function): boolean;
         write(str: string, encoding?: string, cb?: Function): boolean;
         end(): void;

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -259,7 +259,7 @@ declare namespace NodeJS {
 
     export interface ReadableStream extends EventEmitter {
         readable: boolean;
-        isTTY: boolean;
+        isTTY?: boolean;
         read(size?: number): string | Buffer;
         setEncoding(encoding: string): void;
         pause(): ReadableStream;
@@ -273,7 +273,7 @@ declare namespace NodeJS {
 
     export interface WritableStream extends EventEmitter {
         writable: boolean;
-        isTTY: boolean;
+        isTTY?: boolean;
         write(buffer: Buffer | string, cb?: Function): boolean;
         write(str: string, encoding?: string, cb?: Function): boolean;
         end(): void;


### PR DESCRIPTION
Since 0.58, there is a `isTTY` on ReadableStream and WriteableStream to identify if stream is on a TTY (like stdin).

Not making PR on `types-2.0` as it's covering all existing typed node versions.

- [ ] Prefer to make your PR against the `types-2.0` branch.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [X] Provide a URL to  documentation or source code which provides context for the suggested changes: https://nodejs.org/api/tty.html
- [ ] Increase the version number in the header if appropriate.

