### PR TITLE
Superagent callback fix

### DIFF
--- a/superagent/index.d.ts
+++ b/superagent/index.d.ts
@@ -49,7 +49,7 @@ declare namespace request {
         search(url: string, callback?: CallbackHandler): Req;
         connect(url: string, callback?: CallbackHandler): Req;
 
-      parse(fn: (res: Response, callback: (err: Error, body: any) => void) => void): this;
+      parse(fn: (res: Response, callback: (err: Error | null, body: any) => void) => void): this;
       saveCookies(res: Response): void;
       attachCookies(req: Req): void;
     }
@@ -109,7 +109,7 @@ declare namespace request {
       withCredentials(): this;
       write(data: string, encoding?: string): this;
       write(data: Buffer, encoding?: string): this;
-      parse(fn: (res: Response, callback: (err: Error, body: any) => void) => void): this;
+      parse(fn: (res: Response, callback: (err: Error | null, body: any) => void) => void): this;
     }
 
 }

--- a/superagent/superagent-tests.ts
+++ b/superagent/superagent-tests.ts
@@ -303,7 +303,7 @@ request
 request
   .get('/search')
   .then((response) => {})
-  .catch((error) => {}); 
+  .catch((error) => {});
 // Requesting binary data.
 // adapted from: https://github.com/visionmedia/superagent/blob/v2.0.0/test/client/request.js#L110
 request

--- a/superagent/tsconfig.json
+++ b/superagent/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "noImplicitAny": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
This PR enables strictNullChecks, and then allows callback's error parameter to be null. There was already a test for a null error before, but it was only passing because strictNullChecks was off; with it on, the definitions need to explicitly allow null.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: [N/A, the test backing the change was already in the repo.]
- [x] Increase the version number in the header if appropriate.
