### PR TITLE
StereoCamera has eyeSep property https://github.com/mrdoob/three.js/p…

### DIFF
--- a/three/index.d.ts
+++ b/three/index.d.ts
@@ -669,6 +669,7 @@ declare namespace THREE {
         constructor();
 
         aspect: number;
+        eyeSep: number;
         cameraL: PerspectiveCamera;
         cameraR: PerspectiveCamera;
 


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/9432/files PR includes `eyeSep` property on `StereoCamera` object.

Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/mrdoob/three.js/pull/9432/files
- [x] Increase the version number in the header if appropriate.