### PR TITLE
Fix angular-spinner for TS 2

### DIFF
--- a/angular-spinner/angular-spinner-tests.ts
+++ b/angular-spinner/angular-spinner-tests.ts
@@ -1,4 +1,4 @@
-/// <reference path="angular-spinner.d.ts" />
+import {ISpinnerService} from 'angular-spinner';
 
 var myApp = angular.module('testModule');
 

--- a/angular-spinner/angular-spinner-tests.ts
+++ b/angular-spinner/angular-spinner-tests.ts
@@ -1,4 +1,4 @@
-import {ISpinnerService} from 'angular-spinner';
+import {ISpinnerService} from './angular-spinner';
 
 var myApp = angular.module('testModule');
 

--- a/angular-spinner/angular-spinner.d.ts
+++ b/angular-spinner/angular-spinner.d.ts
@@ -6,20 +6,20 @@
 /// <reference path="../angularjs/angular.d.ts" />
 
 /**
-* SpinnerService 
+* SpinnerService
 * see https://github.com/urish/angular-spinner
 */
-interface ISpinnerService {
+export interface ISpinnerService {
     /**
      * Start selected spinner
-     * 
+     *
      * @param spinner key
      */
     spin(key: string): void;
 
     /**
      * Stop selected spinner
-     * 
+     *
      * @param spinner key
      */
     stop(key: string): void;


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url https://github.com/urish/angular-spinner .
  - [ ] it has been reviewed by a DefinitelyTyped member.

The angular-spinner type definition was missing the "export" keyword and thus the module wasn't recognized by TypeScript 2.

*This is a re-submit of #12128 since it was not possible to rebase that branch to the current state.