### PR TITLE
Update Aphrodite definitions

### DIFF
--- a/aphrodite/aphrodite-tests.tsx
+++ b/aphrodite/aphrodite-tests.tsx
@@ -68,6 +68,10 @@ class App extends React.Component<{}, {}> {
     }
 }
 
+css();
+css(false, null, styles.red);
+css([false, null, [styles.red]], styles.blue);
+
 const output = StyleSheetServer.renderStatic(() => {
     return "test";
 });
@@ -80,3 +84,34 @@ StyleSheet.rehydrate(output.css.renderedClassNames);
 
 StyleSheetTestUtils.suppressStyleInjection();
 StyleSheetTestUtils.clearBufferAndResumeStyleInjection();
+
+// Testing extensions
+const oldStyleSheet = StyleSheet;
+{
+    function myExtension(selector: string, base: string, callback: (selector: string) => string) {
+        if (selector[0] !== "&") {
+            return null;
+        }
+
+        return callback(base + selector.slice(1));
+    }
+
+    const {css, StyleSheet, StyleSheetServer, StyleSheetTestUtils} = oldStyleSheet.extend([
+        myExtension
+    ]);
+
+    css(styles.red);
+
+    const output = StyleSheetServer.renderStatic(() => {
+        return "test";
+    });
+
+    output.css.content;
+    output.css.renderedClassNames;
+    output.html;
+
+    StyleSheet.rehydrate(output.css.renderedClassNames);
+
+    StyleSheetTestUtils.suppressStyleInjection();
+    StyleSheetTestUtils.clearBufferAndResumeStyleInjection();
+}

--- a/aphrodite/aphrodite-v0.5.0.d.ts
+++ b/aphrodite/aphrodite-v0.5.0.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Aphrodite 1.1.0
+// Type definitions for Aphrodite 0.5.0
 // Project: https://github.com/Khan/aphrodite
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -27,7 +27,6 @@ declare module "aphrodite" {
     }
 
     export var StyleSheet: StyleSheetStatic;
-
     /**
      * Get class names from passed styles
      */
@@ -70,30 +69,6 @@ declare module "aphrodite" {
     }
 
     export var StyleSheetTestUtils: StyleSheetTestUtilsStatic;
-
-    export interface SelectorHandler {
-        (selector: string, baseSelector: string, callback: (selector: string) => string): string;
-    }
-
-    export interface Extension {
-        selectorHandler?: SelectorHandler,
-    }
-
-    /**
-     * Calling StyleSheet.extend() returns an object with each of the exported
-     * properties on it.
-     */
-    interface Exports {
-        css(...styles: any[]): string;
-
-        StyleSheet: StyleSheetStatic;
-        StyleSheetServer: StyleSheetServerStatic;
-        StyleSheetTestUtils: StyleSheetTestUtilsStatic;
-    }
-
-    interface StyleSheetStatic {
-        extend(extensions: Extension[]): Exports;
-    }
 }
 
 declare module "aphrodite/no-important" {


### PR DESCRIPTION
Summary: Aphrodite's API changed in the past couple releases, this
updates the typings file to account for that. I've never written type
definitions before, let me know if anything could be cleaner.

I also copied the old definitions into a separate file as mentioned in
the README, let me know if that's useful.

Test Plan:
 - `npm test`

PR template:
- [ ] Prefer to make your PR against the `types-2.0` branch. (I can do this if it would be helpful)
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/khan/aphrodite#changelog
- [x] Increase the version number in the header if appropriate.