### PR TITLE
[types-2.0] D3 strictNullChecks Batch 1

### DIFF
--- a/d3-brush/d3-brush-tests.ts
+++ b/d3-brush/d3-brush-tests.ts
@@ -32,7 +32,7 @@ let brushY: d3Brush.BrushBehavior<BrushDatum> = d3Brush.brushY<BrushDatum>();
 
 // extent() ----------------------------------------------------------------------
 
-let extent: (this: SVGGElement, d: BrushDatum, i: number, group: Array<SVGGElement> | ArrayLike<SVGGElement>) => [[number, number], [number, number]];
+let extent: (this: SVGGElement, d: BrushDatum, i: number, group: SVGGElement[] | ArrayLike<SVGGElement>) => [[number, number], [number, number]];
 extent = brush.extent();
 
 // chainable with array
@@ -50,13 +50,13 @@ brush = brush.extent(function (d, i, group) {
 brush = brush.filter(function (d, i, group) {
 
     // Cast d3 event to D3ZoomEvent to be used in filter logic
-    let e = <d3Brush.D3BrushEvent<BrushDatum>>event;
+    let e = <d3Brush.D3BrushEvent<BrushDatum>> event;
 
     console.log('Owner SVG Element of svg group: ', this.ownerSVGElement); // this is of type SVGGElement
     return e.sourceEvent.type !== 'zoom' || !d.filterZoomEvent; // datum type is BrushDatum (as propagated to SVGGElement with brush event attached)
 });
 
-let filterFn: (this: SVGGElement, d?: BrushDatum, index?: number, group?: Array<SVGGElement>) => boolean;
+let filterFn: (this: SVGGElement, d: BrushDatum, index: number, group: SVGGElement[]) => boolean;
 filterFn = brush.filter();
 
 // handleSize() ----------------------------------------------------------------
@@ -67,9 +67,13 @@ let handleSize: number = brush.handleSize();
 
 // on() ------------------------------------------------------------------------
 
-let brushed: (this: SVGGElement, datum: BrushDatum, index: number, group: Array<SVGGElement> | ArrayLike<SVGGElement>) => void;
-let wrongHandler1: (this: SVGSVGElement, datum: BrushDatum, index: number, group: Array<SVGSVGElement> | ArrayLike<SVGSVGElement>) => void;
-let wrongHandler2: (this: SVGGElement, datum: { test: string }, index: number, group: Array<SVGGElement> | ArrayLike<SVGGElement>) => void;
+let brushed: ((this: SVGGElement, datum: BrushDatum, index: number, group: SVGGElement[] | ArrayLike<SVGGElement>) => void) | undefined;
+brushed = function (d, i, group) {
+    // do anything
+};
+
+let wrongHandler1: (this: SVGSVGElement, datum: BrushDatum, index: number, group: SVGSVGElement[] | ArrayLike<SVGSVGElement>) => void;
+let wrongHandler2: (this: SVGGElement, datum: { test: string }, index: number, group: SVGGElement[] | ArrayLike<SVGGElement>) => void;
 
 // chainable
 brush = brush.on('end', brushed);
@@ -83,7 +87,11 @@ brushed = brush.on('end');
 brush = brush.on('end', null);
 
 // re-apply
-brush.on('end', function (d, i, group) {
+brush.on('end', function (d, i, g) {
+    let that: SVGGElement = this;
+    let datum: BrushDatum = d;
+    let index: number = i;
+    let group: SVGGElement[] | ArrayLike<SVGGElement> = g;
     console.log('Owner SVG Element of svg group: ', this.ownerSVGElement); // this is of type SVGGElement
     console.log('Extent as per data: ', d.extent); // datum of type BrushDatum
     // do anything
@@ -127,7 +135,7 @@ let gTransition = g.transition();
 brush.move(g, [[10, 10], [50, 50]]); // two-dimensional brush
 brush.move(g, function (d, i, group) {
     console.log('Owner SVG Element of svg group: ', this.ownerSVGElement); // this is of type SVGGElement
-    let selection: [[number, number], [number, number]];
+    let selection: [[number, number], [number, number]] = [[0, 0], [0, 0]];
     selection[0][0] = d.extent[0][0] + 10; // datum type is brushDatum
     selection[0][1] = d.extent[0][1] + 10;
     selection[1][0] = d.extent[0][0] + 40;
@@ -139,7 +147,7 @@ brush.move(g, function (d, i, group) {
 brush.move(gTransition, [[10, 10], [50, 50]]); // two-dimensional brush
 brush.move(gTransition, function (d, i, group) {
     console.log('Owner SVG Element of svg group: ', this.ownerSVGElement); // this is of type SVGGElement
-    let selection: [[number, number], [number, number]];
+    let selection: [[number, number], [number, number]] = [[0, 0], [0, 0]];
     selection[0][0] = d.extent[0][0] + 10; // datum type is brushDatum
     selection[0][1] = d.extent[0][1] + 10;
     selection[1][0] = d.extent[0][0] + 40;
@@ -154,7 +162,7 @@ let gXTransition = gX.transition();
 brush.move(gX, [10, 40]); // two-dimensional brush
 brush.move(gX, function (d, i, group) {
     console.log('Owner SVG Element of svg group: ', this.ownerSVGElement); // this is of type SVGGElement
-    let selection: [number, number];
+    let selection: [number, number] = [0, 0];
     selection[0] = d.extent[0][0] + 10; // datum type is brushDatum
     selection[1] = d.extent[0][0] + 40;
     return selection;
@@ -164,7 +172,7 @@ brush.move(gX, function (d, i, group) {
 brush.move(gXTransition, [10, 40]); // two-dimensional brush
 brush.move(gXTransition, function (d, i, group) {
     console.log('Owner SVG Element of svg group: ', this.ownerSVGElement); // this is of type SVGGElement
-    let selection: [number, number];
+    let selection: [number, number] = [0, 0];
     selection[0] = d.extent[0][0] + 10; // datum type is brushDatum
     selection[1] = d.extent[0][0] + 40;
     return selection;
@@ -176,7 +184,7 @@ brush.move(gXTransition, function (d, i, group) {
 // -----------------------------------------------------------------------------
 
 
-let e: d3Brush.D3BrushEvent<BrushDatum>;
+let e: d3Brush.D3BrushEvent<BrushDatum> = event;
 
 
 let target: d3Brush.BrushBehavior<BrushDatum> = e.target;

--- a/d3-brush/index.d.ts
+++ b/d3-brush/index.d.ts
@@ -159,7 +159,7 @@ export interface BrushBehavior<Datum> {
      * start (at the start of a brush gesture, such as on mousedown), brush (when the brush moves, such as on mousemove), or
      * end (at the end of a brush gesture, such as on mouseup.)
      */
-    on(typenames: string): ValueFn<SVGGElement, Datum, void>;
+    on(typenames: string): ValueFn<SVGGElement, Datum, void> | undefined;
     /**
      * Removes the current event listeners for the specified typenames, if any.
      *

--- a/d3-brush/index.d.ts
+++ b/d3-brush/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-brush module v1.0.2
+// Type definitions for D3JS d3-brush module v1.0.3
 // Project: https://github.com/d3/d3-brush/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-brush/index.d.ts
+++ b/d3-brush/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-brush module v1.0
+// Type definitions for D3JS d3-brush module 1.0
 // Project: https://github.com/d3/d3-brush/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-brush/index.d.ts
+++ b/d3-brush/index.d.ts
@@ -1,7 +1,9 @@
-// Type definitions for D3JS d3-brush module v1.0.3
+// Type definitions for D3JS d3-brush module v1.0
 // Project: https://github.com/d3/d3-brush/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Last module patch version validated against: 1.0.3
 
 import { ArrayLike, Selection, TransitionLike, ValueFn } from 'd3-selection';
 

--- a/d3-brush/tsconfig.json
+++ b/d3-brush/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es6",
     "noImplicitAny": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "baseUrl": "../",
     "typeRoots": [
       "../"

--- a/d3-brush/tslint.json
+++ b/d3-brush/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../tslint.json",
+    "rules": {
+        "unified-signatures": false
+    }
+}

--- a/d3-drag/d3-drag-tests.ts
+++ b/d3-drag/d3-drag-tests.ts
@@ -38,7 +38,7 @@ interface CustomSubject {
     r: number;
 }
 
-let svg: SVGSVGElement = select<SVGSVGElement, any>('svg').node(); // mock
+let svg: SVGSVGElement = select<SVGSVGElement, any>('svg').node()!; // mock
 
 let circles: Selection<SVGCircleElement, CircleDatum, SVGSVGElement, any> = select<SVGSVGElement, any>('svg').selectAll<SVGCircleElement, CircleDatum>('circle'); // mock
 

--- a/d3-drag/d3-drag-tests.ts
+++ b/d3-drag/d3-drag-tests.ts
@@ -38,9 +38,9 @@ interface CustomSubject {
     r: number;
 }
 
-let svg: SVGSVGElement;
+let svg: SVGSVGElement = select<SVGSVGElement, any>('svg').node(); // mock
 
-let circles: Selection<SVGCircleElement, CircleDatum, SVGSVGElement, any>;
+let circles: Selection<SVGCircleElement, CircleDatum, SVGSVGElement, any> = select<SVGSVGElement, any>('svg').selectAll<SVGCircleElement, CircleDatum>('circle'); // mock
 
 // -----------------------------------------------------------------------------
 // Test Define DragBehavior
@@ -91,7 +91,7 @@ containerAccessor = circleDrag.container();
 
 // set and get filter ---------------------------------------------------------
 
-let filterFn: (this: SVGCircleElement, datum: CircleDatum, index?: number, group?: Array<SVGCircleElement> | NodeListOf<SVGCircleElement>) => boolean;
+let filterFn: (this: SVGCircleElement, datum: CircleDatum, index: number, group: SVGCircleElement[] | NodeListOf<SVGCircleElement>) => boolean;
 
 filterFn = function (d) {
     return (d.color !== 'green' && this.r.baseVal.value < 10) ? !event.button : true; // 'this' is SVGCircleElement and d is CircleDatum
@@ -108,9 +108,13 @@ filterFn = circleDrag.filter();
 
 // set and get subject ---------------------------------------------------------
 
-circleCustomDrag.subject(function (d) {
+circleCustomDrag.subject(function (d, i, g) {
     // Cast event type for completeness, otherwise event is of type any.
     let e = <d3Drag.D3DragEvent<SVGCircleElement, CircleDatum, CustomSubject | d3Drag.SubjectPosition>>event;
+    let that: SVGCircleElement = this;
+    let datum: CircleDatum = d;
+    let index: number = i;
+    let group: SVGCircleElement[] | ArrayLike<SVGCircleElement> = g;
 
     if (d == null) {
         return { x: e.x, y: e.y };
@@ -127,7 +131,7 @@ circleCustomDrag.subject(function (d) {
 });
 
 // test getter
-let subjectAccessor: (this: SVGCircleElement, datum?: CircleDatum, index?: number, group?: Array<SVGCircleElement> | NodeListOf<SVGCircleElement>) => CustomSubject | d3Drag.SubjectPosition;
+let subjectAccessor: (this: SVGCircleElement, datum: CircleDatum, index: number, group: SVGCircleElement[] | NodeListOf<SVGCircleElement>) => CustomSubject | d3Drag.SubjectPosition;
 
 subjectAccessor = circleCustomDrag.subject();
 
@@ -169,9 +173,9 @@ circleDrag = circleDrag
 // remove event listeners for a drag event type
 circleDrag.on('start.tmp', null);
 
-let handler: (this: SVGCircleElement, d?: CircleDatum, i?: number, group?: Array<SVGCircleElement> | NodeListOf<SVGCircleElement>) => void = circleDrag.on('start');
-// let wrongHandler1: (this:SVGRectElement, d?:CircleDatum, i?: number, group?: Array<SVGRectElement> | NodeListOf<SVGRectElement>)=> void = circleDrag.on('start'); // fails, wrong dragged DOM event
-// let wrongHandler2: (this:SVGCircleElement, d?:{test: number}, i?: number, group?: Array<SVGCircleElement> | NodeListOf<SVGCircleElement>)=> void = circleDrag.on('start'); // fails, handler with wrong datum type
+let handler: ((this: SVGCircleElement, d: CircleDatum, i: number, group: SVGCircleElement[] | NodeListOf<SVGCircleElement>) => void) | undefined = circleDrag.on('start');
+// let wrongHandler1: ((this:SVGRectElement, d:CircleDatum, i: number, group: SVGRectElement[] | NodeListOf<SVGRectElement>)=> void) | undefined = circleDrag.on('start'); // fails, wrong dragged DOM event
+// let wrongHandler2: ((this:SVGCircleElement, d:{test: number}, i: number, group: SVGCircleElement[] | NodeListOf<SVGCircleElement>)=> void) | undefined = circleDrag.on('start'); // fails, handler with wrong datum type
 
 // -----------------------------------------------------------------------------
 // Test Attach Drag Behavior
@@ -179,7 +183,7 @@ let handler: (this: SVGCircleElement, d?: CircleDatum, i?: number, group?: Array
 
 circles.call(circleDrag);
 
-let wrongSelection: Selection<HTMLDivElement, any, any, any>;
+let wrongSelection: Selection<HTMLDivElement, any, any, any> = select<HTMLDivElement, any>('div');
 
 // wrongSelection.call(circleDrag); // fails, as dragged elements are not of type specified for drag behavior
 
@@ -188,7 +192,7 @@ let wrongSelection: Selection<HTMLDivElement, any, any, any>;
 // -----------------------------------------------------------------------------
 
 
-let e: d3Drag.D3DragEvent<SVGCircleElement, CircleDatum, CircleDatum | d3Drag.SubjectPosition>;
+let e: d3Drag.D3DragEvent<SVGCircleElement, CircleDatum, CircleDatum | d3Drag.SubjectPosition> = event;
 
 
 circleDrag = e.target; // target return drag behavior
@@ -214,15 +218,16 @@ e = e.on('drag', dragged);
 // e = e.on('drag', wrongDragHandler2); // fails, wrong this-type for DOM Element context
 
 handler = e.on('dragged');
-// let wrongHandler3: (this:SVGRectElement, d?:CircleDatum, i?: number, group?: Array<SVGRectElement> | NodeListOf<SVGRectElement>)=> void = e.on('dragged'); // fails, wrong dragged DOM event
-// let wrongHandler4: (this:SVGCircleElement, d?:{test: number}, i?: number, group?: Array<SVGCircleElement> | NodeListOf<SVGCircleElement>)=> void = e.on('dragged'); // fails, handler with wrong datum type
+// let wrongHandler3: ((this:SVGRectElement, d:CircleDatum, i: number, group: SVGRectElement[] | NodeListOf<SVGRectElement>)=> void) | undefined = e.on('dragged'); // fails, wrong dragged DOM event
+// let wrongHandler4: ((this:SVGCircleElement, d:{test: number}, i: number, group: SVGCircleElement[] | NodeListOf<SVGCircleElement>)=> void) | undefined = e.on('dragged'); // fails, handler with wrong datum type
 
 
 // -----------------------------------------------------------------------------
 // Test dragDisable() and dragEnable()
 // -----------------------------------------------------------------------------
 
-let w: Window;
+let w: Window = window;
+
 d3Drag.dragDisable(w);
 
 d3Drag.dragEnable(w);

--- a/d3-drag/d3-drag-tests.ts
+++ b/d3-drag/d3-drag-tests.ts
@@ -63,7 +63,7 @@ circleCustomDrag = d3Drag.drag<SVGCircleElement, CircleDatum, CustomSubject | d3
 
 // set and get container element/accessor ----------------------------
 
-let containerAccessor: (this: SVGCircleElement, d: CircleDatum, i: number, group: Array<SVGCircleElement> | NodeListOf<SVGCircleElement>) => d3Drag.DragContainerElement;
+let containerAccessor: (this: SVGCircleElement, d: CircleDatum, i: number, group: SVGCircleElement[] | NodeListOf<SVGCircleElement>) => d3Drag.DragContainerElement;
 
 containerAccessor = function (d, i, group) {
     console.log('Node Id of circle: ', d.nodeId);
@@ -110,7 +110,7 @@ filterFn = circleDrag.filter();
 
 circleCustomDrag.subject(function (d, i, g) {
     // Cast event type for completeness, otherwise event is of type any.
-    let e = <d3Drag.D3DragEvent<SVGCircleElement, CircleDatum, CustomSubject | d3Drag.SubjectPosition>>event;
+    let e = <d3Drag.D3DragEvent<SVGCircleElement, CircleDatum, CustomSubject | d3Drag.SubjectPosition>> event;
     let that: SVGCircleElement = this;
     let datum: CircleDatum = d;
     let index: number = i;
@@ -139,14 +139,14 @@ subjectAccessor = circleCustomDrag.subject();
 
 function dragstarted(this: SVGCircleElement, d: CircleDatum) {
     // cast d3 event to drag event. Otherwise, d3 event is currently defined as type 'any'
-    let e = <d3Drag.D3DragEvent<SVGCircleElement, CircleDatum, CircleDatum | d3Drag.SubjectPosition>>event;
+    let e = <d3Drag.D3DragEvent<SVGCircleElement, CircleDatum, CircleDatum | d3Drag.SubjectPosition>> event;
     e.sourceEvent.stopPropagation();
     select(this).classed('dragging', true);
 }
 
 function dragged(this: SVGCircleElement, d: CircleDatum) {
     // cast d3 event to drag event. Otherwise, d3 event is currently defined as type 'any'
-    let e = <d3Drag.D3DragEvent<SVGCircleElement, CircleDatum, CircleDatum | d3Drag.SubjectPosition>>event;
+    let e = <d3Drag.D3DragEvent<SVGCircleElement, CircleDatum, CircleDatum | d3Drag.SubjectPosition>> event;
     select(this).attr('cx', d.x = e.x).attr('cy', d.y = e.y);
 }
 

--- a/d3-drag/index.d.ts
+++ b/d3-drag/index.d.ts
@@ -1,7 +1,9 @@
-// Type definitions for D3JS d3-drag module v1.0.2
+// Type definitions for D3JS d3-drag module v1.0
 // Project: https://github.com/d3/d3-drag/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Last module patch version validated against: 1.0.2
 
 import { ArrayLike, Selection, ValueFn } from 'd3-selection';
 

--- a/d3-drag/index.d.ts
+++ b/d3-drag/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-drag module v1.0
+// Type definitions for D3JS d3-drag module 1.0
 // Project: https://github.com/d3/d3-drag/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-drag/index.d.ts
+++ b/d3-drag/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-drag module v1.0.1
+// Type definitions for D3JS d3-drag module v1.0.2
 // Project: https://github.com/d3/d3-drag/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-drag/index.d.ts
+++ b/d3-drag/index.d.ts
@@ -174,7 +174,7 @@ export interface DragBehavior<GElement extends DraggedElementBaseType, Datum, Su
      * start (after a new pointer becomes active [on mousedown or touchstart]), drag (after an active pointer moves [on mousemove or touchmove], or
      * end (after an active pointer becomes inactive [on mouseup, touchend or touchcancel].)
      */
-    on(typenames: string): ValueFn<GElement, Datum, void>;
+    on(typenames: string): ValueFn<GElement, Datum, void> | undefined;
     /**
      * Remove the current event listeners for the specified typenames, if any, return the drag behavior.
      *
@@ -297,7 +297,7 @@ export interface D3DragEvent<GElement extends DraggedElementBaseType, Datum, Sub
      * start (after a new pointer becomes active [on mousedown or touchstart]), drag (after an active pointer moves [on mousemove or touchmove], or
      * end (after an active pointer becomes inactive [on mouseup, touchend or touchcancel].)
      */
-    on(typenames: string): ValueFn<GElement, Datum, void>;
+    on(typenames: string): ValueFn<GElement, Datum, void> | undefined;
     /**
      * Remove the current event listeners for the specified typenames, if any, return the drag behavior.
      *

--- a/d3-drag/tsconfig.json
+++ b/d3-drag/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es6",
     "noImplicitAny": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "baseUrl": "../",
     "typeRoots": [
       "../"

--- a/d3-drag/tslint.json
+++ b/d3-drag/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../tslint.json",
+    "rules": {
+        "unified-signatures": false
+    }
+}

--- a/d3-force/d3-force-tests.ts
+++ b/d3-force/d3-force-tests.ts
@@ -55,7 +55,7 @@ let simLinks: SimLink[];
 
 let num: number;
 
-let canvas = document.querySelector('canvas');
+let canvas = document.querySelector('canvas')!;
 let context = canvas.getContext('2d');
 let width = canvas.width;
 let height = canvas.height;
@@ -459,27 +459,26 @@ let f: d3Force.Force<SimNode, SimLink>;
 maybeF = nodeLinkSimulation.force('charge');
 maybeF = nodeLinkSimulation.force('link');
 
-
 // assuming certainty that force has been previously assigned
-f = nodeLinkSimulation.force<d3Force.Force<SimNode, SimLink>>('charge');
+f = nodeLinkSimulation.force<d3Force.Force<SimNode, SimLink>>('charge')!;
 
 // if force may not have been assigned for the name
-maybeF = nodeLinkSimulation.force<d3Force.Force<SimNode, SimLink> | undefined>('charge');
-// f = nodeLinkSimulation.force<d3Force.Force<SimNode, SimLink> | undefined>('charge'); // fails, with strictNullChecks
+maybeF = nodeLinkSimulation.force<d3Force.Force<SimNode, SimLink>>('charge');
+// f = nodeLinkSimulation.force<d3Force.Force<SimNode, SimLink>>('charge'); // fails, with strictNullChecks
 
 // getter with force type cast to improve return type specificity
 
 let fLink: d3Force.ForceLink<SimNode, SimLink>;
 
 // Need explicit, careful type casting to a specific force type
-fLink = nodeLinkSimulation.force<d3Force.ForceLink<SimNode, SimLink>>('link');
+fLink = nodeLinkSimulation.force<d3Force.ForceLink<SimNode, SimLink>>('link')!;
 
 // This is mainly an issue for ForceLinks, if once wants to get the links from an initialized force
 // or re-set new links for an initialized force, e.g.:
 
-simLinks = nodeLinkSimulation.force<d3Force.ForceLink<SimNode, SimLink>>('link').links();
+simLinks = nodeLinkSimulation.force<d3Force.ForceLink<SimNode, SimLink>>('link')!.links();
 
-// fLink = nodeLinkSimulation.force('link'); // fails, as ForceLink specific properties are missing from 'generic' force
+// fLink = nodeLinkSimulation.force('link')!; // fails, as ForceLink specific properties are missing from 'generic' force
 
 
 // on() --------------------------------------------------------------------------------

--- a/d3-force/d3-force-tests.ts
+++ b/d3-force/d3-force-tests.ts
@@ -26,8 +26,8 @@ interface SimLink extends d3Force.SimulationLinkDatum<SimNode> {
 }
 
 interface Graph {
-    nodes: Array<SimNode>;
-    links: Array<SimLink>;
+    nodes: SimNode[];
+    links: SimLink[];
 }
 
 
@@ -47,18 +47,18 @@ let graph: Graph = {
     ]
 };
 
-let simNode: SimNode;
+let simNode: SimNode | undefined;
 let simLink: SimLink;
 
-let simNodes: Array<SimNode>;
-let simLinks: Array<SimLink>;
+let simNodes: SimNode[];
+let simLinks: SimLink[];
 
-let num: Number;
+let num: number;
 
-let canvas = document.querySelector('canvas'),
-    context = canvas.getContext('2d'),
-    width = canvas.width,
-    height = canvas.height;
+let canvas = document.querySelector('canvas');
+let context = canvas.getContext('2d');
+let width = canvas.width;
+let height = canvas.height;
 
 // -------------------------------------------------------------------------------------
 // Test Pre-Defined Forces
@@ -108,14 +108,14 @@ forceCollide = d3Force.forceCollide<SimNode>(15);
 forceCollide = d3Force.forceCollide<SimNode>(function (node, index, nodes) {
     let n: SimNode = node;
     let i: number = index;
-    let ns: Array<SimNode> = nodes;
+    let ns: SimNode[] = nodes;
     return n.r;
 });
 
 
 // Configure Collision force -----------------------------------------------------------
 
-let radiusAccessor: (node: SimNode, i: number, nodes: Array<SimNode>) => number;
+let radiusAccessor: (node: SimNode, i: number, nodes: SimNode[]) => number;
 
 // radius
 
@@ -123,7 +123,7 @@ forceCollide = forceCollide.radius(20);
 forceCollide = forceCollide.radius(function (node, index, nodes) {
     let n: SimNode = node;
     let i: number = index;
-    let ns: Array<SimNode> = nodes;
+    let ns: SimNode[] = nodes;
     return 2 * n.r;
 });
 
@@ -160,8 +160,8 @@ forceLink = d3Force.forceLink<SimNode, SimLink>(graph.links);
 
 // Configure Link force -----------------------------------------------------------
 
-let linkNumberAccessor: (link: SimLink, i: number, links: Array<SimLink>) => number;
-let nodeIdAccessor: (node: SimNode, i: number, nodes: Array<SimNode>) => number | string;
+let linkNumberAccessor: (link: SimLink, i: number, links: SimLink[]) => number;
+let nodeIdAccessor: (node: SimNode, i: number, nodes: SimNode[]) => number | string;
 
 // links
 
@@ -174,7 +174,8 @@ simLink = simLinks[0];
 simNode = (typeof simLink.source !== 'number' && typeof simLink.source !== 'string') ? simLink.source : undefined;
 simNode = (typeof simLink.target !== 'number' && typeof simLink.target !== 'string') ? simLink.target : undefined;
 
-num = simLink.index;
+let maybeNum: number | undefined = simLink.index; // Ex-ante type before initialization of links
+num = simLink.index!; // Ex-post after link initialization, use ! non-null assertion operator to narrow to number
 
 num = simLink.value;
 num = simLink.d;
@@ -186,7 +187,7 @@ num = simLink.s;
 forceLink = forceLink.id(function (node, index, nodes) {
     let n: SimNode = node;
     let i: number = index;
-    let ns: Array<SimNode> = nodes;
+    let ns: SimNode[] = nodes;
     return n.id;
 });
 
@@ -196,7 +197,7 @@ forceLink = forceLink.distance(50);
 forceLink = forceLink.distance(function (link, index, links) {
     let l: SimLink = link;
     let i: number = index;
-    let ls: Array<SimLink> = links;
+    let ls: SimLink[] = links;
     return l.d;
 });
 
@@ -208,7 +209,7 @@ forceLink = forceLink.strength(0.95);
 forceLink = forceLink.strength(function (link, index, links) {
     let l: SimLink = link;
     let i: number = index;
-    let ls: Array<SimLink> = links;
+    let ls: SimLink[] = links;
     return l.s;
 });
 
@@ -236,7 +237,7 @@ forceCharge = d3Force.forceManyBody<SimNode>();
 
 // Configure ManyBody force -----------------------------------------------------------
 
-let simNodeNumberAccessor: (node: SimNode, i: number, nodes: Array<SimNode>) => number;
+let simNodeNumberAccessor: (node: SimNode, i: number, nodes: SimNode[]) => number;
 
 // strength
 
@@ -244,7 +245,7 @@ forceCharge = forceCharge.strength(-3000);
 forceCharge = forceCharge.strength(function (node, index, nodes) {
     let n: SimNode = node;
     let i: number = index;
-    let ns: Array<SimNode> = nodes;
+    let ns: SimNode[] = nodes;
     return -1000 * n.group;
 });
 simNodeNumberAccessor = forceCharge.strength();
@@ -288,7 +289,7 @@ forcePosX = forcePosX.strength(0.2);
 forcePosX = forcePosX.strength(function (node, index, nodes) {
     let n: SimNode = node;
     let i: number = index;
-    let ns: Array<SimNode> = nodes;
+    let ns: SimNode[] = nodes;
     return 0.1 * n.group;
 });
 simNodeNumberAccessor = forcePosX.strength();
@@ -299,7 +300,7 @@ forcePosX = forcePosX.x(100);
 forcePosX = forcePosX.x(function (node, index, nodes) {
     let n: SimNode = node;
     let i: number = index;
-    let ns: Array<SimNode> = nodes;
+    let ns: SimNode[] = nodes;
     let target: number;
     switch (n.group) {
         case 1:
@@ -343,7 +344,7 @@ forcePosY = forcePosY.strength(0.2);
 forcePosY = forcePosY.strength(function (node, index, nodes) {
     let n: SimNode = node;
     let i: number = index;
-    let ns: Array<SimNode> = nodes;
+    let ns: SimNode[] = nodes;
     return 0.1 * n.group;
 });
 simNodeNumberAccessor = forcePosY.strength();
@@ -354,7 +355,7 @@ forcePosY = forcePosY.y(100);
 forcePosY = forcePosY.y(function (node, index, nodes) {
     let n: SimNode = node;
     let i: number = index;
-    let ns: Array<SimNode> = nodes;
+    let ns: SimNode[] = nodes;
     let target: number;
     switch (n.group) {
         case 1:
@@ -450,13 +451,21 @@ nodeLinkSimulation
     .force('charge', forceCharge)
     .force('center', forceCenter);
 
+let maybeF: d3Force.Force<SimNode, SimLink> | undefined;
 let f: d3Force.Force<SimNode, SimLink>;
 
 // getter with generic force returned
 
-f = nodeLinkSimulation.force('charge');
-f = nodeLinkSimulation.force('link');
+maybeF = nodeLinkSimulation.force('charge');
+maybeF = nodeLinkSimulation.force('link');
 
+
+// assuming certainty that force has been previously assigned
+f = nodeLinkSimulation.force<d3Force.Force<SimNode, SimLink>>('charge');
+
+// if force may not have been assigned for the name
+maybeF = nodeLinkSimulation.force<d3Force.Force<SimNode, SimLink> | undefined>('charge');
+// f = nodeLinkSimulation.force<d3Force.Force<SimNode, SimLink> | undefined>('charge'); // fails, with strictNullChecks
 
 // getter with force type cast to improve return type specificity
 
@@ -476,40 +485,48 @@ simLinks = nodeLinkSimulation.force<d3Force.ForceLink<SimNode, SimLink>>('link')
 // on() --------------------------------------------------------------------------------
 
 function drawLink(d: SimLink) {
-    let source: SimNode, target: SimNode;
+    let source: SimNode | undefined;
+    let target: SimNode | undefined;
     source = (typeof d.source !== 'string' && typeof d.source !== 'number') ? d.source : undefined;
     target = (typeof d.target !== 'string' && typeof d.target !== 'number') ? d.target : undefined;
-    if (source && target) {
+    if (context && source && source.x && source.y && target && target.x && target.y) {
         context.moveTo(source.x, source.y);
         context.lineTo(target.x, target.y);
     }
 }
 
 function drawNode(d: SimNode) {
-    context.moveTo(d.x + 3, d.y);
-    context.arc(d.x, d.y, 3, 0, 2 * Math.PI);
+    if (context && d.x && d.y) {
+        context.moveTo(d.x + 3, d.y);
+        context.arc(d.x, d.y, 3, 0, 2 * Math.PI);
+    }
 }
 
 nodeLinkSimulation = nodeLinkSimulation.on('tick', function ticked() {
 
     let that: d3Force.Simulation<SimNode, SimLink> = this;
 
-    context.clearRect(0, 0, width, height);
+    if (context) {
+        context.clearRect(0, 0, width, height);
 
-    context.beginPath();
-    graph.links.forEach(drawLink);
-    context.strokeStyle = '#aaa';
-    context.stroke();
+        context.beginPath();
+        graph.links.forEach(drawLink);
+        context.strokeStyle = '#aaa';
+        context.stroke();
 
-    context.beginPath();
-    graph.nodes.forEach(drawNode);
-    context.fill();
-    context.strokeStyle = '#fff';
-    context.stroke();
+        context.beginPath();
+        graph.nodes.forEach(drawNode);
+        context.fill();
+        context.strokeStyle = '#fff';
+        context.stroke();
+    }
 });
 
 // remove listener
 nodeSimulation = nodeSimulation.on('tick', null);
+
+// get listener
+let listener: ((this: d3Force.Simulation<SimNode, undefined>) => void) | undefined = nodeSimulation.on('tick');
 
 // Configure and Use Force Simulation ===================================================
 

--- a/d3-force/index.d.ts
+++ b/d3-force/index.d.ts
@@ -1,8 +1,10 @@
-// Type definitions for D3JS d3-force module v1.0.4
+// Type definitions for D3JS d3-force module v1.0
 // Project: https://github.com/d3/d3-force/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+
+// Last module patch version validated against: 1.0.4
 
 // -----------------------------------------------------------------------
 // Force Simulation

--- a/d3-force/index.d.ts
+++ b/d3-force/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-force module v1.0
+// Type definitions for D3JS d3-force module 1.0
 // Project: https://github.com/d3/d3-force/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-force/index.d.ts
+++ b/d3-force/index.d.ts
@@ -114,7 +114,7 @@ export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum ext
     /**
      * Returns the simulation’s array of nodes as specified to the constructor.
      */
-    nodes(): Array<NodeDatum>;
+    nodes(): NodeDatum[];
     /**
      * Set the simulation’s nodes to the specified array of objects, initialize their positions and velocities if necessary,
      * and then re-initialize any bound forces; Returns the simulation.
@@ -142,7 +142,7 @@ export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum ext
      * this method must be called again with the new (or changed) array to notify the simulation and bound forces of the change;
      * the simulation does not make a defensive copy of the specified array.
      */
-    nodes(nodesData: Array<NodeDatum>): this;
+    nodes(nodesData: NodeDatum[]): this;
 
     /**
      * Return the current alpha of the simulation, which defaults to 1.
@@ -307,7 +307,7 @@ export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum ext
  *
  * @param nodesData Optional array of nodes data, defaults to empty array.
  */
-export function forceSimulation<NodeDatum extends SimulationNodeDatum>(nodesData?: Array<NodeDatum>): Simulation<NodeDatum, undefined>;
+export function forceSimulation<NodeDatum extends SimulationNodeDatum>(nodesData?: NodeDatum[]): Simulation<NodeDatum, undefined>;
 /**
  * Create a new simulation with the specified array of nodes and no forces.
  * If nodes is not specified, it defaults to the empty array.
@@ -321,7 +321,7 @@ export function forceSimulation<NodeDatum extends SimulationNodeDatum>(nodesData
  *
  * @param nodesData Optional array of nodes data, defaults to empty array.
  */
-export function forceSimulation<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum>>(nodesData?: Array<NodeDatum>): Simulation<NodeDatum, LinkDatum>;
+export function forceSimulation<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum>>(nodesData?: NodeDatum[]): Simulation<NodeDatum, LinkDatum>;
 
 // ----------------------------------------------------------------------
 // Forces
@@ -351,7 +351,7 @@ export interface Force<NodeDatum extends SimulationNodeDatum, LinkDatum extends 
      *
      * A force may perform necessary work during initialization, such as evaluating per-node parameters, to avoid repeatedly performing work during each application of the force.
      */
-    initialize?(nodes: Array<NodeDatum>): void;
+    initialize?(nodes: NodeDatum[]): void;
 }
 
 
@@ -374,7 +374,7 @@ export interface ForceCenter<NodeDatum extends SimulationNodeDatum> extends Forc
      *
      * A force may perform necessary work during initialization, such as evaluating per-node parameters, to avoid repeatedly performing work during each application of the force.
      */
-    initialize(nodes: Array<NodeDatum>): void;
+    initialize(nodes: NodeDatum[]): void;
 
     /**
      * Return the current x-coordinate of the centering position, which defaults to zero.
@@ -433,12 +433,12 @@ export interface ForceCollide<NodeDatum extends SimulationNodeDatum> extends For
      *
      * A force may perform necessary work during initialization, such as evaluating per-node parameters, to avoid repeatedly performing work during each application of the force.
      */
-    initialize(nodes: Array<NodeDatum>): void;
+    initialize(nodes: NodeDatum[]): void;
 
     /**
      * Returns the current radius accessor function.
      */
-    radius(): (node: NodeDatum, i: number, nodes: Array<NodeDatum>) => number;
+    radius(): (node: NodeDatum, i: number, nodes: NodeDatum[]) => number;
     /**
      * Set the radius used in collision detection to a constant number for each node.
      *
@@ -461,7 +461,7 @@ export interface ForceCollide<NodeDatum extends SimulationNodeDatum> extends For
      * @param radius A radius accessor function which is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The function returns a radius.
      */
-    radius(radius: (node: NodeDatum, i: number, nodes: Array<NodeDatum>) => number): this;
+    radius(radius: (node: NodeDatum, i: number, nodes: NodeDatum[]) => number): this;
 
     /**
      * Return the current strength, which defaults to 0.7.
@@ -531,7 +531,7 @@ export function forceCollide<NodeDatum extends SimulationNodeDatum>(radius: numb
  * @param radius A radius accessor function which is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
  * The function returns a radius.
  */
-export function forceCollide<NodeDatum extends SimulationNodeDatum>(radius: (node: NodeDatum, i: number, nodes: Array<NodeDatum>) => number): ForceCollide<NodeDatum>;
+export function forceCollide<NodeDatum extends SimulationNodeDatum>(radius: (node: NodeDatum, i: number, nodes: NodeDatum[]) => number): ForceCollide<NodeDatum>;
 
 // Link ----------------------------------------------------------------
 
@@ -549,13 +549,13 @@ export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum exte
      *
      * A force may perform necessary work during initialization, such as evaluating per-node parameters, to avoid repeatedly performing work during each application of the force.
      */
-    initialize(nodes: Array<NodeDatum>): void;
+    initialize(nodes: NodeDatum[]): void;
 
     /**
      * Return the current array of links, which defaults to the empty array.
      *
      */
-    links(): Array<LinkDatum>;
+    links(): LinkDatum[];
     /**
      * Set the array of links associated with this force, recompute the distance and strength parameters for each link, and return this force.
      *
@@ -571,12 +571,12 @@ export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum exte
      *
      * @param links An array of link data.
      */
-    links(links: Array<LinkDatum>): this;
+    links(links: LinkDatum[]): this;
 
     /**
      * Return the current node id accessor, which defaults to the numeric node.index.
      */
-    id(): (node: NodeDatum, i: number, nodesData: Array<NodeDatum>) => (string | number);
+    id(): (node: NodeDatum, i: number, nodesData: NodeDatum[]) => (string | number);
     /**
      * Set the node id accessor to the specified function and return this force.
      *
@@ -590,12 +590,12 @@ export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum exte
      * being passed the node, the zero-based index of the node in the node array, and the node array. It returns a string to represent the node id which can be used
      * for matching link source and link target strings during the ForceLink initialization.
      */
-    id(id: (node: NodeDatum, i: number, nodesData: Array<NodeDatum>) => string): this;
+    id(id: (node: NodeDatum, i: number, nodesData: NodeDatum[]) => string): this;
 
     /**
      * Return the current distance accessor, which defaults to implying a default distance of 30.
      */
-    distance(): (link: LinkDatum, i: number, links: Array<LinkDatum>) => number;
+    distance(): (link: LinkDatum, i: number, links: LinkDatum[]) => number;
     /**
      * Set the distance accessor to use the specified constant number for all links,
      * re-evaluates the distance accessor for each link, and returns this force.
@@ -620,13 +620,13 @@ export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum exte
      * @param distance A distance accessor function which is invoked for each link being passed the link,
      * its zero-based index and the complete array of links. It returns the distance.
      */
-    distance(distance: (link: LinkDatum, i: number, links: Array<LinkDatum>) => number): this;
+    distance(distance: (link: LinkDatum, i: number, links: LinkDatum[]) => number): this;
 
     /**
      * Return the current strength accessor.
      * For details regarding the default behavior see: {@link https://github.com/d3/d3-force#link_strength}
      */
-    strength(): (link: LinkDatum, i: number, links: Array<LinkDatum>) => number;
+    strength(): (link: LinkDatum, i: number, links: LinkDatum[]) => number;
     /**
      * Set the strenght accessor to use the specified constant number for all links,
      * re-evaluates the strength accessor for each link, and returns this force.
@@ -651,7 +651,7 @@ export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum exte
      * @param strength A distance accessor function which is invoked for each link being passed the link,
      * its zero-based index and the complete array of links. It returns the strength.
      */
-    strength(strength: (link: LinkDatum, i: number, links: Array<LinkDatum>) => number): this;
+    strength(strength: (link: LinkDatum, i: number, links: LinkDatum[]) => number): this;
 
     /**
      * Return the current iteration count which defaults to 1.
@@ -690,7 +690,7 @@ export function forceLink<NodeDatum extends SimulationNodeDatum, LinksDatum exte
  *
  * @param links An array of link data.
  */
-export function forceLink<NodeDatum extends SimulationNodeDatum, LinksDatum extends SimulationLinkDatum<NodeDatum>>(links: Array<LinksDatum>): ForceLink<NodeDatum, LinksDatum>;
+export function forceLink<NodeDatum extends SimulationNodeDatum, LinksDatum extends SimulationLinkDatum<NodeDatum>>(links: LinksDatum[]): ForceLink<NodeDatum, LinksDatum>;
 
 // Many Body ----------------------------------------------------------------
 
@@ -710,14 +710,14 @@ export interface ForceManyBody<NodeDatum extends SimulationNodeDatum> extends Fo
      *
      * A force may perform necessary work during initialization, such as evaluating per-node parameters, to avoid repeatedly performing work during each application of the force.
      */
-    initialize(nodes: Array<NodeDatum>): void;
+    initialize(nodes: NodeDatum[]): void;
 
     /**
      * Return the current strength accessor.
      *
      * For details regarding the default behavior see: {@link https://github.com/d3/d3-force#manyBody_strength}
      */
-    strength(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
+    strength(): (d: NodeDatum, i: number, data: NodeDatum[]) => number;
     /**
      * Set the strength accessor to the specified constant strength for all nodes, re-evaluates the strength accessor for each node, and
      * returns this force.
@@ -752,7 +752,7 @@ export interface ForceManyBody<NodeDatum extends SimulationNodeDatum> extends Fo
      * @param strength A strength accessor function which is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The function returns the strength.
      */
-    strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
+    strength(strength: (d: NodeDatum, i: number, data: NodeDatum[]) => number): this;
 
     /**
      * Return the current value of the Barnes–Hut approximation criterion , which defaults to 0.9
@@ -836,12 +836,12 @@ export interface ForceX<NodeDatum extends SimulationNodeDatum> extends Force<Nod
      *
      * A force may perform necessary work during initialization, such as evaluating per-node parameters, to avoid repeatedly performing work during each application of the force.
      */
-    initialize(nodes: Array<NodeDatum>): void;
+    initialize(nodes: NodeDatum[]): void;
 
     /**
      *  Returns the current strength accessor, which defaults to a constant strength for all nodes of 0.1.
      */
-    strength(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
+    strength(): (d: NodeDatum, i: number, data: NodeDatum[]) => number;
     /**
      * Set the strength accessor to the specified constant strength for all nodes, re-evaluates the strength accessor for each node, and returns this force.
      *
@@ -878,12 +878,12 @@ export interface ForceX<NodeDatum extends SimulationNodeDatum> extends Force<Nod
      * @param strength A strength accessor function which is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The function returns the strength.
      */
-    strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
+    strength(strength: (d: NodeDatum, i: number, data: NodeDatum[]) => number): this;
 
     /**
      * Return the current x-accessor, which defaults to a function returning 0 for all nodes.
      */
-    x(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
+    x(): (d: NodeDatum, i: number, data: NodeDatum[]) => number;
     /**
      * Set the x-coordinate accessor to the specified number, re-evaluates the x-accessor for each node,
      * and returns this force.
@@ -908,7 +908,7 @@ export interface ForceX<NodeDatum extends SimulationNodeDatum> extends Force<Nod
      * @param x A x-coordinate accessor function which is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The function returns the x-coordinate.
      */
-    x(x: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
+    x(x: (d: NodeDatum, i: number, data: NodeDatum[]) => number): this;
 }
 
 /**
@@ -946,7 +946,7 @@ export function forceX<NodeDatum extends SimulationNodeDatum>(x: number): ForceX
  * @param x A x-coordinate accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
  * The function returns the x-coordinate.
  */
-export function forceX<NodeDatum extends SimulationNodeDatum>(x: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForceX<NodeDatum>;
+export function forceX<NodeDatum extends SimulationNodeDatum>(x: (d: NodeDatum, i: number, data: NodeDatum[]) => number): ForceX<NodeDatum>;
 
 /**
  * The y-positioning force pushes nodes towards a desired position along the given dimension with a configurable strength.
@@ -962,12 +962,12 @@ export interface ForceY<NodeDatum extends SimulationNodeDatum> extends Force<Nod
      *
      * A force may perform necessary work during initialization, such as evaluating per-node parameters, to avoid repeatedly performing work during each application of the force.
      */
-    initialize(nodes: Array<NodeDatum>): void;
+    initialize(nodes: NodeDatum[]): void;
 
     /**
      *  Returns the current strength accessor, which defaults to a constant strength for all nodes of 0.1.
      */
-    strength(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
+    strength(): (d: NodeDatum, i: number, data: NodeDatum[]) => number;
     /**
      * Set the strength accessor to the specified constant strength for all nodes, re-evaluates the strength accessor for each node, and returns this force.
      *
@@ -1004,12 +1004,12 @@ export interface ForceY<NodeDatum extends SimulationNodeDatum> extends Force<Nod
      * @param strength A strength accessor function which is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The function returns the strength.
      */
-    strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
+    strength(strength: (d: NodeDatum, i: number, data: NodeDatum[]) => number): this;
 
     /**
      * Return the current y-accessor, which defaults to a function returning 0 for all nodes.
      */
-    y(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
+    y(): (d: NodeDatum, i: number, data: NodeDatum[]) => number;
     /**
      * Set the y-coordinate accessor to the specified number, re-evaluates the y-accessor for each node,
      * and returns this force.
@@ -1034,7 +1034,7 @@ export interface ForceY<NodeDatum extends SimulationNodeDatum> extends Force<Nod
      * @param y A y-coordinate accessor function which is invoked for each node in the simulation, being passed the node, its zero-based index and the complete array of nodes.
      * The function returns the y-coordinate.
      */
-    y(y: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
+    y(y: (d: NodeDatum, i: number, data: NodeDatum[]) => number): this;
 }
 
 /**
@@ -1072,4 +1072,4 @@ export function forceY<NodeDatum extends SimulationNodeDatum>(y: number): ForceY
  * @param y A y-coordinate accessor function which is invoked for each node in the simulation, being passed the node and its zero-based index.
  * The function returns the y-coordinate.
  */
-export function forceY<NodeDatum extends SimulationNodeDatum>(y: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForceY<NodeDatum>;
+export function forceY<NodeDatum extends SimulationNodeDatum>(y: (d: NodeDatum, i: number, data: NodeDatum[]) => number): ForceY<NodeDatum>;

--- a/d3-force/index.d.ts
+++ b/d3-force/index.d.ts
@@ -574,7 +574,7 @@ export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum exte
     links(links: Array<LinkDatum>): this;
 
     /**
-     * Return the current node id accessor, which defaults to the numeric index of the node.
+     * Return the current node id accessor, which defaults to the numeric node.index.
      */
     id(): (node: NodeDatum, i: number, nodesData: Array<NodeDatum>) => (string | number);
     /**
@@ -584,10 +584,10 @@ export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum exte
      * into the nodes array.
      *
      * The id accessor is invoked for each node whenever the force is initialized,
-     * as when the nodes or links change, being passed the node and its zero-based index.
+     * as when the nodes or links change, being passed the node, the zero-based index of the node in the node array, and the node array.
      *
      * @param id A node id accessor function which is invoked for each node in the simulation,
-     * being passed the node, its zero-based index and the complete array of nodes. It returns a string to represent the node id which can be used
+     * being passed the node, the zero-based index of the node in the node array, and the node array. It returns a string to represent the node id which can be used
      * for matching link source and link target strings during the ForceLink initialization.
      */
     id(id: (node: NodeDatum, i: number, nodesData: Array<NodeDatum>) => string): this;

--- a/d3-force/index.d.ts
+++ b/d3-force/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-force module v1.0.2
+// Type definitions for D3JS d3-force module v1.0.4
 // Project: https://github.com/d3/d3-force/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-force/index.d.ts
+++ b/d3-force/index.d.ts
@@ -225,7 +225,7 @@ export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum ext
      *
      * @param name Name of the registered force.
      */
-    force<F extends Force<NodeDatum, LinkDatum> | undefined>(name: string): F;
+    force<F extends Force<NodeDatum, LinkDatum>>(name: string): F| undefined;
     /**
      * Remove a previously registered force.
      *

--- a/d3-force/index.d.ts
+++ b/d3-force/index.d.ts
@@ -44,11 +44,11 @@ export interface SimulationNodeDatum {
     /**
      * Node’s fixed x-position (if position was fixed)
      */
-    fx?: number | null | undefined;
+    fx?: number | null;
     /**
      * Node’s fixed y-position (if position was fixed)
      */
-    fy?: number | null | undefined;
+    fy?: number | null;
 }
 
 /**
@@ -225,7 +225,7 @@ export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum ext
      *
      * @param name Name of the registered force.
      */
-    force<F extends Force<NodeDatum, LinkDatum>>(name: string): F | undefined;
+    force<F extends Force<NodeDatum, LinkDatum> | undefined>(name: string): F;
     /**
      * Remove a previously registered force.
      *
@@ -261,7 +261,7 @@ export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum ext
      * The type must be one of the following: "tick" (after each tick of the simulation’s internal timer) or
      * "end" (after the simulation’s timer stops when alpha < alphaMin).
      */
-    on(typenames: 'tick' | 'end' | string): (this: Simulation<NodeDatum, LinkDatum>) => void;
+    on(typenames: 'tick' | 'end' | string): ((this: Simulation<NodeDatum, LinkDatum>) => void) | undefined;
     /**
      * Remove the current event listeners for the specified typenames, if any, return the simulation.
      *
@@ -337,7 +337,7 @@ export function forceSimulation<NodeDatum extends SimulationNodeDatum, LinkDatum
  *
  * Forces may optionally implement force.initialize to receive the simulation’s array of nodes.
  */
-export interface Force<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum>> {
+export interface Force<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum> | undefined> {
     /**
      * Apply this force, optionally observing the specified alpha.
      * Typically, the force is applied to the array of nodes previously passed to force.initialize,
@@ -369,6 +369,14 @@ export interface Force<NodeDatum extends SimulationNodeDatum, LinkDatum extends 
  */
 export interface ForceCenter<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
     /**
+     * Assign the array of nodes to this force. This method is called when a force is bound to a simulation via simulation.force
+     * and when the simulation’s nodes change via simulation.nodes.
+     *
+     * A force may perform necessary work during initialization, such as evaluating per-node parameters, to avoid repeatedly performing work during each application of the force.
+     */
+    initialize(nodes: Array<NodeDatum>): void;
+
+    /**
      * Return the current x-coordinate of the centering position, which defaults to zero.
      */
     x(): number;
@@ -378,6 +386,7 @@ export interface ForceCenter<NodeDatum extends SimulationNodeDatum> extends Forc
      * @param x x-coordinate.
      */
     x(x: number): this;
+
     /**
      * Return the current y-coordinate of the centering position, which defaults to zero.
      */
@@ -418,6 +427,14 @@ export function forceCenter<NodeDatum extends SimulationNodeDatum>(x?: number, y
  * The generic refers to the type of data for a node.
  */
 export interface ForceCollide<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
+    /**
+     * Assign the array of nodes to this force. This method is called when a force is bound to a simulation via simulation.force
+     * and when the simulation’s nodes change via simulation.nodes.
+     *
+     * A force may perform necessary work during initialization, such as evaluating per-node parameters, to avoid repeatedly performing work during each application of the force.
+     */
+    initialize(nodes: Array<NodeDatum>): void;
+
     /**
      * Returns the current radius accessor function.
      */
@@ -526,6 +543,14 @@ export function forceCollide<NodeDatum extends SimulationNodeDatum>(radius: (nod
  * The second generic refers to the type of data for a link.
  */
 export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum>> extends Force<NodeDatum, LinkDatum> {
+    /**
+     * Assign the array of nodes to this force. This method is called when a force is bound to a simulation via simulation.force
+     * and when the simulation’s nodes change via simulation.nodes.
+     *
+     * A force may perform necessary work during initialization, such as evaluating per-node parameters, to avoid repeatedly performing work during each application of the force.
+     */
+    initialize(nodes: Array<NodeDatum>): void;
+
     /**
      * Return the current array of links, which defaults to the empty array.
      *
@@ -680,6 +705,14 @@ export function forceLink<NodeDatum extends SimulationNodeDatum, LinksDatum exte
  */
 export interface ForceManyBody<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
     /**
+     * Assign the array of nodes to this force. This method is called when a force is bound to a simulation via simulation.force
+     * and when the simulation’s nodes change via simulation.nodes.
+     *
+     * A force may perform necessary work during initialization, such as evaluating per-node parameters, to avoid repeatedly performing work during each application of the force.
+     */
+    initialize(nodes: Array<NodeDatum>): void;
+
+    /**
      * Return the current strength accessor.
      *
      * For details regarding the default behavior see: {@link https://github.com/d3/d3-force#manyBody_strength}
@@ -797,6 +830,13 @@ export function forceManyBody<NodeDatum extends SimulationNodeDatum>(): ForceMan
  * The generic refers to the type of data for a node.
  */
 export interface ForceX<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
+    /**
+     * Assign the array of nodes to this force. This method is called when a force is bound to a simulation via simulation.force
+     * and when the simulation’s nodes change via simulation.nodes.
+     *
+     * A force may perform necessary work during initialization, such as evaluating per-node parameters, to avoid repeatedly performing work during each application of the force.
+     */
+    initialize(nodes: Array<NodeDatum>): void;
 
     /**
      *  Returns the current strength accessor, which defaults to a constant strength for all nodes of 0.1.
@@ -916,6 +956,14 @@ export function forceX<NodeDatum extends SimulationNodeDatum>(x: (d: NodeDatum, 
  * The generic refers to the type of data for a node.
  */
 export interface ForceY<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
+    /**
+     * Assign the array of nodes to this force. This method is called when a force is bound to a simulation via simulation.force
+     * and when the simulation’s nodes change via simulation.nodes.
+     *
+     * A force may perform necessary work during initialization, such as evaluating per-node parameters, to avoid repeatedly performing work during each application of the force.
+     */
+    initialize(nodes: Array<NodeDatum>): void;
+
     /**
      *  Returns the current strength accessor, which defaults to a constant strength for all nodes of 0.1.
      */

--- a/d3-force/tsconfig.json
+++ b/d3-force/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es6",
     "noImplicitAny": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "baseUrl": "../",
     "typeRoots": [
       "../"

--- a/d3-force/tslint.json
+++ b/d3-force/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../tslint.json",
+    "rules": {
+        "unified-signatures": false
+    }
+}

--- a/d3-selection-multi/d3-selection-multi-tests.ts
+++ b/d3-selection-multi/d3-selection-multi-tests.ts
@@ -1,4 +1,4 @@
-
+// tslint:disable:object-literal-shorthand
 /**
  * Typescript definition tests for d3/d3-selection-multi module
  *
@@ -28,7 +28,7 @@ selection = selection.attrs({
     foo: () => 1,
     bar: (d) => d,
     baz: (d, i) => i !== 0,
-    bat: function () {
+    bat: function() {
         return this.href;
     },
 });
@@ -189,7 +189,7 @@ valueMap = {
         let that: SVGCircleElement = this;
         let datum: SampleDatum = d;
         let index: number = i;
-        let group: Array<SVGCircleElement> | ArrayLike<SVGCircleElement> = g;
+        let group: SVGCircleElement[] | ArrayLike<SVGCircleElement> = g;
         return d.filled;
     }
 };

--- a/d3-selection-multi/d3-selection-multi-tests.ts
+++ b/d3-selection-multi/d3-selection-multi-tests.ts
@@ -7,12 +7,12 @@
  * are not intended as functional tests.
  */
 
-import { Selection, ArrayLike } from 'd3-selection';
+import { selectAll, Selection, ArrayLike } from 'd3-selection';
 import { Transition } from 'd3-transition';
 
 import * as d3SelectionMulti from 'd3-selection-multi';
 
-let selection: Selection<HTMLAnchorElement, string, null, undefined>;
+let selection: Selection<HTMLAnchorElement, string, HTMLElement, undefined> = selectAll<HTMLAnchorElement, string>('a');
 
 // Selection.attrs
 
@@ -34,8 +34,11 @@ selection = selection.attrs({
 });
 
 // Function that returns a map
-selection = selection.attrs(function (d) {
-    return this.id ? null : { id: d };
+selection = selection.attrs(function (d, i, g) {
+    let that: HTMLAnchorElement = this;
+    let index: number = i;
+    let group: HTMLAnchorElement[] | ArrayLike<HTMLAnchorElement> = g;
+    return this.id ? {} : { id: d };
 });
 
 // Selection.styles
@@ -86,11 +89,14 @@ selection = selection.properties({
 });
 
 // Function that returns an object
-selection = selection.properties(function (d) {
-    return this.href ? null : { href: d };
+selection = selection.properties(function (d, i, g) {
+    let that: HTMLAnchorElement = this;
+    let index: number = i;
+    let group: HTMLAnchorElement[] | ArrayLike<HTMLAnchorElement> = g;
+    return that.href ? {} : { href: d };
 });
 
-let transition: Transition<HTMLAnchorElement, string, null, undefined>;
+let transition: Transition<HTMLAnchorElement, string, HTMLElement, undefined> = selectAll<HTMLAnchorElement, string>('a').transition();
 
 // Transition.attrs
 
@@ -112,8 +118,11 @@ transition = transition.attrs({
 });
 
 // Function that returns a map
-transition = transition.attrs(function (d) {
-    return this.id ? null : { id: d };
+transition = transition.attrs(function (d, i, g) {
+    let that: HTMLAnchorElement = this;
+    let index: number = i;
+    let group: HTMLAnchorElement[] | ArrayLike<HTMLAnchorElement> = g;
+    return this.id ? {} : { id: d };
 });
 
 // Transition.styles
@@ -173,7 +182,7 @@ valueMap = {
     bar2: function (d, i) {
         let that: SVGCircleElement = this;
         let datum: SampleDatum = d;
-        let index: number =  i;
+        let index: number = i;
         return d.r;
     },
     bar3: function (d, i, g) {

--- a/d3-selection-multi/index.d.ts
+++ b/d3-selection-multi/index.d.ts
@@ -7,10 +7,26 @@ import {Selection, BaseType, ArrayLike, ValueFn} from 'd3-selection';
 import {Transition} from 'd3-transition';
 
 
-// An object mapping attribute (or style or property) names to value accessors
+/**
+ * An object mapping attribute (or style or property) names to value accessors
+ *
+ * The first generic corresponds to type of the selected element(s).
+ *
+ * The second generic corresponds to the type of the data on the selected element.
+ */
+// Retained ValueMap as type as it works better with IDE support for its intended purpose. It is not meant to be extended. So type is o.k.
+// tslint:disable-next-line:interface-over-type-literal
 export type ValueMap<T extends BaseType, Datum> = { [key: string]: number | string | boolean | null | ValueFn<T, Datum, number | string | boolean | null> };
 
 declare module 'd3-selection' {
+    /**
+     * A D3 Selection of elements.
+     *
+     * The first generic "GElement" refers to the type of the selected element(s).
+     * The second generic "Datum" refers to the type of the datum of a selected element(s).
+     * The third generic "PElement" refers to the type of the parent element(s) in the D3 selection.
+     * The fourth generic "PDatum" refers to the type of the datum of the parent element(s).
+     */
     export interface Selection<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {
         /**
          * Set multiple attributes on the given selection. Attribute values may be constant or derived from each node and its bound data.
@@ -59,6 +75,14 @@ declare module 'd3-selection' {
 }
 
 declare module 'd3-transition' {
+    /**
+     * A D3 Transition.
+     *
+     * The first generic "GElement" refers to the type of the selected element(s) in the Transition.
+     * The second generic "Datum" refers to the type of the datum of a selected element(s) in the Transition.
+     * The third generic "PElement" refers to the type of the parent element(s) in the D3 selection in the Transition.
+     * The fourth generic "PDatum" refers to the type of the datum of the parent element(s) in the Transition.
+     */
     export interface Transition<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {
         /**
          * Set multiple attribute values. The transition will animate from the present value to the new value. Attribute values may be constant or derived from each node and its bound data.

--- a/d3-selection-multi/index.d.ts
+++ b/d3-selection-multi/index.d.ts
@@ -8,7 +8,7 @@ import {Transition} from 'd3-transition';
 
 
 // An object mapping attribute (or style or property) names to value accessors
-export type ValueMap<Element, Datum> = { [key: string]: number | string | boolean | null | ValueFn<Element, Datum, number | string | boolean | null> };
+export type ValueMap<T extends BaseType, Datum> = { [key: string]: number | string | boolean | null | ValueFn<T, Datum, number | string | boolean | null> };
 
 declare module 'd3-selection' {
     export interface Selection<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {

--- a/d3-selection-multi/index.d.ts
+++ b/d3-selection-multi/index.d.ts
@@ -1,7 +1,9 @@
-// Type definitions for D3JS d3-selection-multi module v1.0.0
+// Type definitions for D3JS d3-selection-multi module v1.0
 // Project: https://github.com/d3/d3-selection-multi/
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Last module patch version validated against: 1.0.0
 
 import {Selection, BaseType, ArrayLike, ValueFn} from 'd3-selection';
 import {Transition} from 'd3-transition';

--- a/d3-selection-multi/index.d.ts
+++ b/d3-selection-multi/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-selection-multi module v1.0
+// Type definitions for D3JS d3-selection-multi module 1.0
 // Project: https://github.com/d3/d3-selection-multi/
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-selection-multi/tsconfig.json
+++ b/d3-selection-multi/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es6",
     "noImplicitAny": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "baseUrl": "../",
     "typeRoots": [
       "../"

--- a/d3-selection-multi/tslint.json
+++ b/d3-selection-multi/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../tslint.json",
+    "rules": {
+        "unified-signatures": false
+    }
+}

--- a/d3-selection/d3-selection-tests.ts
+++ b/d3-selection/d3-selection-tests.ts
@@ -79,17 +79,17 @@ let body: d3Selection.Selection<HTMLBodyElement, BodyDatum, HTMLElement, any> = 
 let baseTypeEl2: d3Selection.Selection<d3Selection.BaseType, any, null, undefined> = d3Selection.select(baseTypeEl.node());
 // let body2: d3Selection.Selection<HTMLElement, any, null, undefined> = d3Selection.select(baseTypeEl.node()); // fails as baseTypeEl.node() is of type cannot be assigned to HTMLElement
 
-let body3: d3Selection.Selection<HTMLBodyElement, any, null, undefined> = d3Selection.select(body.node()); // element types match, but datum is of type 'any' as it cannot be inferred from .node()
+let body3: d3Selection.Selection<HTMLBodyElement, any, null, undefined> = d3Selection.select(body.node()!); // element types match, but datum is of type 'any' as it cannot be inferred from .node()
 
 // Using select() with node argument and type parameters creates selection
 // with Group element of type HTMLBodyElement and datum of BodyDatum type. The parent element is of type 'null' with datum of type 'undefined'
 
-let body4: d3Selection.Selection<HTMLBodyElement, BodyDatum, null, undefined> = d3Selection.select<HTMLBodyElement, BodyDatum>(body.node());
+let body4: d3Selection.Selection<HTMLBodyElement, BodyDatum, null, undefined> = d3Selection.select<HTMLBodyElement, BodyDatum>(body.node()!);
 
 //  Explicitly cast body.node() to HTMLBodyElement to narrow selection definition.
-let body5: d3Selection.Selection<HTMLBodyElement, BodyDatum, null, undefined> = d3Selection.select<HTMLBodyElement, BodyDatum>(body.node());
+let body5: d3Selection.Selection<HTMLBodyElement, BodyDatum, null, undefined> = d3Selection.select<HTMLBodyElement, BodyDatum>(body.node()!);
 
-// d3Selection.select<HTMLBodyElement, BodyDatum>(baseTypeEl.node()); // fails as baseTypeEl.node() is not of type HTMLBodyElement
+// d3Selection.select<HTMLBodyElement, BodyDatum>(baseTypeEl.node()!); // fails as baseTypeEl.node() is not of type HTMLBodyElement
 
 // test, when it is not certain, whether an element of the type to be selected exists
 let maybeSVG1: d3Selection.Selection<SVGSVGElement | null, any, HTMLElement, undefined> = d3Selection.select<SVGSVGElement, any>('svg');
@@ -182,7 +182,7 @@ maybeG = svgEl.select<SVGGElement | null>('g');
 // Using select(...) sub-selection with a selector function argument.
 
 function svgGroupSelector(this: SVGSVGElement, d: SVGDatum, i: number, groups: SVGSVGElement[]): SVGGElement {
-    return this.querySelector('g'); // this-type compatible with group element-type to which the selector function will be appplied
+    return this.querySelector('g')!; // this-type compatible with group element-type to which the selector function will be appplied
 }
 
 firstG = svgEl.select(svgGroupSelector);
@@ -191,7 +191,7 @@ firstG = svgEl.select(function () {
     let that: SVGSVGElement = this;
     // let that2: HTMLElement  = this; // fails, type mismatch
     console.log('Get <svg> Element width using "this": ', this.width.baseVal.value); // 'this' type is SVGSVGElement
-    return this.querySelector('g'); // this of type SVGSVGElement by type inference
+    return this.querySelector('g')!; // this of type SVGSVGElement by type inference
 });
 
 firstG = svgEl.select(function (d, i, g) {
@@ -205,7 +205,7 @@ firstG = svgEl.select(function (d, i, g) {
     if (g.length > 1) {
         console.log('Get width of 2nd <svg> Element in group: ', g[1].width.baseVal.value); // type is SVGSVGElement
     }
-    return this.querySelector('g'); // this of type SVGSVGElement by type inference
+    return this.querySelector('g')!; // this of type SVGSVGElement by type inference
 });
 
 
@@ -932,7 +932,7 @@ let emptyFlag = gElementsOldData.empty();
 
 // node() and nodes() --------------------------------------------------------------------
 
-let bodyNode: HTMLBodyElement = body.node();
+let bodyNode: HTMLBodyElement | null= body.node();
 
 let gElementsNodes: SVGGElement[] = gElementsOldData.nodes();
 
@@ -1068,9 +1068,9 @@ let resultText: string = d3Selection.customEvent(successEvent, customListener, b
 // mouse() ---------------------------------------------------------------------------------
 
 let position: [number, number] | null;
-let svg: SVGSVGElement = d3Selection.select<SVGSVGElement, any>('svg').node();
-let g: SVGGElement = d3Selection.select<SVGGElement, any>('g').node();
-let h: HTMLElement = d3Selection.select<HTMLElement, any>('div').node();
+let svg: SVGSVGElement = d3Selection.select<SVGSVGElement, any>('svg').node()!;
+let g: SVGGElement = d3Selection.select<SVGGElement, any>('g').node()!;
+let h: HTMLElement = d3Selection.select<HTMLElement, any>('div').node()!;
 let changedTouches: TouchList = new TouchList(); // dummy
 
 position = d3Selection.mouse(svg);
@@ -1101,7 +1101,7 @@ positions = d3Selection.touches(h, changedTouches);
 // Tests of Local
 // ---------------------------------------------------------------------------------------
 
-let xElement: Element = d3Selection.select<Element, any>('foo').node();
+let xElement: Element = d3Selection.select<Element, any>('foo').node()!;
 let foo: d3Selection.Local<number[]> = d3Selection.local<number[]>();
 let propName: string = foo.toString();
 

--- a/d3-selection/d3-selection-tests.ts
+++ b/d3-selection/d3-selection-tests.ts
@@ -15,8 +15,8 @@ import * as d3Selection from 'd3-selection';
 // ---------------------------------------------------------------------------------------
 
 // Generic DOM related variables
-let xDoc: Document = document,
-    xWindow: Window = window;
+let xDoc: Document = document;
+let xWindow: Window = window;
 
 interface BodyDatum {
     foo: string;
@@ -181,7 +181,7 @@ maybeG = svgEl.select<SVGGElement | null>('g');
 
 // Using select(...) sub-selection with a selector function argument.
 
-function svgGroupSelector(this: SVGSVGElement, d: SVGDatum, i: number, groups: Array<SVGSVGElement>): SVGGElement {
+function svgGroupSelector(this: SVGSVGElement, d: SVGDatum, i: number, groups: SVGSVGElement[]): SVGGElement {
     return this.querySelector('g'); // this-type compatible with group element-type to which the selector function will be appplied
 }
 
@@ -234,14 +234,14 @@ let gElementsOldData: d3Selection.Selection<SVGGElement, CircleDatum, SVGSVGElem
 
 // Using selectAll(...) sub-selection with a selector function argument.
 
-function svgGroupSelectorAll(this: SVGSVGElement, d: SVGDatum, i: number, groups: Array<SVGSVGElement>): NodeListOf<SVGGElement> {
+function svgGroupSelectorAll(this: SVGSVGElement, d: SVGDatum, i: number, groups: SVGSVGElement[]): NodeListOf<SVGGElement> {
     return this.querySelectorAll('g'); // this-type compatible with group element-type to which the selector function will be appplied
 }
 
 
 gElementsOldData = svgEl.selectAll<SVGGElement, CircleDatum>(svgGroupSelectorAll);
 
-function wrongSvgGroupSelectorAll(this: HTMLElement, d: SVGDatum, i: number, groups: Array<HTMLElement>): NodeListOf<SVGGElement> {
+function wrongSvgGroupSelectorAll(this: HTMLElement, d: SVGDatum, i: number, groups: HTMLElement[]): NodeListOf<SVGGElement> {
     return this.querySelectorAll('g');
 }
 // gElementsOldData = svgEl.selectAll<SVGGElement, CircleDatum>(wrongSvgGroupSelectorAll); // fails, wrong this context
@@ -342,7 +342,7 @@ filterdGElements2 = d3Selection.selectAll<SVGElement, any>('.any-svg-type').filt
 
 filterdGElements2 = d3Selection.selectAll<SVGElement, any>('.any-svg-type').filter<SVGGElement>(function(){
     let that: SVGElement = this;
-    return that.tagName === 'g'|| that.tagName === 'G';
+    return that.tagName === 'g' || that.tagName === 'G';
 });
 // filterdGElements2 = d3Selection.selectAll<SVGElement, any>('.any-svg-type').filter(function(){
 //     let that: SVGElement = this;
@@ -361,9 +361,9 @@ filterdGElements = gElementsOldData.filter(d3Selection.matcher('.top-level'));
 
 // Getter return values tests -------------------------------------------------------------
 
-let flag: boolean,
-    str: string,
-    dummy: any;
+let flag: boolean;
+let str: string;
+let dummy: any;
 
 flag = body.classed('any-class');
 str = body.attr('class');
@@ -522,13 +522,13 @@ body = body
 // ---------------------------------------------------------------------------------------
 
 
-let data: Array<CircleDatum> = [
+let data: CircleDatum[] = [
     { nodeId: 'c1', cx: 10, cy: 10, r: 5, name: 'foo', label: 'Foo' },
     { nodeId: 'c2', cx: 20, cy: 20, r: 5, name: 'bar', label: 'Bar' },
     { nodeId: 'c3', cx: 30, cy: 30, r: 5, name: 'fooBar', label: 'Foo Bar' }
 ];
 
-let data2: Array<CircleDatumAlternative> = [
+let data2: CircleDatumAlternative[] = [
     { nodeId: 'c1', cx: 10, cy: 10, r: 5, name: 'foo', label: 'Foo', color: 'seagreen' },
     { nodeId: 'c2', cx: 20, cy: 20, r: 5, name: 'bar', label: 'Bar', color: 'midnightblue' },
     { nodeId: 'c4', cx: 10, cy: 15, r: 10, name: 'newbie', label: 'Newbie', color: 'red' }
@@ -632,7 +632,7 @@ let dimensions: SVGDatum = {
     height: 300
 };
 
-let startCircleData: Array<CircleDatumAlternative> = [
+let startCircleData: CircleDatumAlternative[] = [
     {
         nodeId: 'n1',
         name: 'node_1',
@@ -652,7 +652,7 @@ let startCircleData: Array<CircleDatumAlternative> = [
         color: 'slateblue'
     }
 ];
-let endCircleData: Array<CircleDatumAlternative> = [
+let endCircleData: CircleDatumAlternative[] = [
     {
         nodeId: 'n1',
         name: 'node_1',
@@ -759,8 +759,8 @@ const matrix = [
 // SCENARIO 1 - Fully type parameterized, when there is a need for `this` typings in callbacks
 // and enforcement of type of data used in data join as input to data(...)
 
-let nMatrix: Array<number[]>,
-    nRow: Array<number>;
+let nMatrix: number[][];
+let nRow: number[];
 
 let tr: d3Selection.Selection<HTMLTableRowElement, number[], HTMLTableElement, any>;
 tr = d3Selection.select('body')
@@ -934,7 +934,7 @@ let emptyFlag = gElementsOldData.empty();
 
 let bodyNode: HTMLBodyElement = body.node();
 
-let gElementsNodes: Array<SVGGElement> = gElementsOldData.nodes();
+let gElementsNodes: SVGGElement[] = gElementsOldData.nodes();
 
 // size() --------------------------------------------------------------------------------
 
@@ -983,7 +983,7 @@ circles = circles.call(enforceMinRadius, 40); // check chaining return type by r
 
 // on(...) -------------------------------------------------------------------------------
 
-let listener: undefined | ((this: HTMLBodyElement, datum: BodyDatum, index: number, group: Array<HTMLBodyElement> | ArrayLike<HTMLBodyElement>) => void);
+let listener: undefined | ((this: HTMLBodyElement, datum: BodyDatum, index: number, group: HTMLBodyElement[] | ArrayLike<HTMLBodyElement>) => void);
 
 
 body = body.on('click', function (d, i, g) {
@@ -1052,7 +1052,7 @@ let successEvent = { type: 'wonEuro2016', team: 'Island' };
 let customListener: (this: HTMLBodyElement, finalOpponent: string) => string;
 
 customListener = function (finalOpponent) {
-    let e = <SuccessEvent>d3Selection.event;
+    let e = <SuccessEvent> d3Selection.event;
 
     return e.team + ' defeated ' + finalOpponent + ' in the EURO 2016 Cup. Who would have thought!!!';
 };
@@ -1067,11 +1067,11 @@ let resultText: string = d3Selection.customEvent(successEvent, customListener, b
 
 // mouse() ---------------------------------------------------------------------------------
 
-let position: [number, number] | null,
-    svg: SVGSVGElement = d3Selection.select<SVGSVGElement, any>('svg').node(),
-    g: SVGGElement = d3Selection.select<SVGGElement, any>('g').node(),
-    h: HTMLElement = d3Selection.select<HTMLElement, any>('div').node(),
-    changedTouches: TouchList = new TouchList(); // dummy
+let position: [number, number] | null;
+let svg: SVGSVGElement = d3Selection.select<SVGSVGElement, any>('svg').node();
+let g: SVGGElement = d3Selection.select<SVGGElement, any>('g').node();
+let h: HTMLElement = d3Selection.select<HTMLElement, any>('div').node();
+let changedTouches: TouchList = new TouchList(); // dummy
 
 position = d3Selection.mouse(svg);
 position = d3Selection.mouse(g);

--- a/d3-selection/index.d.ts
+++ b/d3-selection/index.d.ts
@@ -44,10 +44,10 @@ export type ContainerElement = HTMLElement | SVGSVGElement | SVGGElement;
 
 
 /**
- * Type for optional parameters map, when dispatching custom events
+ * Interface for optional parameters map, when dispatching custom events
  * on a selection
  */
-export type CustomEventParameters = {
+export interface CustomEventParameters {
     /**
      * If true, the event is dispatched to ancestors in reverse tree order
      */
@@ -65,7 +65,7 @@ export type CustomEventParameters = {
 /**
  * Callback type for selections and transitions
  */
-export type ValueFn<T extends BaseType, Datum, Result> = (this: T, datum: Datum, index: number, groups: Array<T> | ArrayLike<T>) => Result;
+export type ValueFn<T extends BaseType, Datum, Result> = (this: T, datum: Datum, index: number, groups: T[] | ArrayLike<T>) => Result;
 
 
 /**
@@ -248,7 +248,7 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
      * the current index (i), and the current group (nodes), with this as the current DOM element. It must return an array of elements
      * (or a pseudo-array, such as a NodeList), or the empty array if there are no matching elements.
      */
-    selectAll<DescElement extends BaseType, OldDatum>(selector: ValueFn<GElement, Datum, Array<DescElement> | ArrayLike<DescElement>>): Selection<DescElement, OldDatum, GElement, Datum>;
+    selectAll<DescElement extends BaseType, OldDatum>(selector: ValueFn<GElement, Datum, DescElement[] | ArrayLike<DescElement>>): Selection<DescElement, OldDatum, GElement, Datum>;
 
     // Modifying -------------------------------
 
@@ -732,7 +732,7 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
      * The datum for a given key is assigned to the element with the matching key. If multiple elements have the same key,
      * the duplicate elements are put into the exit selection; if multiple data have the same key, the duplicate data are put into the enter selection.
      */
-    data<NewDatum>(data: Array<NewDatum>, key?: ValueFn<GElement | PElement, Datum | NewDatum, string>): Selection<GElement, NewDatum, PElement, PDatum>;
+    data<NewDatum>(data: NewDatum[], key?: ValueFn<GElement | PElement, Datum | NewDatum, string>): Selection<GElement, NewDatum, PElement, PDatum>;
     /**
      * Joins the data returned by the specified value function with the selected elements, returning a new selection that it represents
      * the update selection: the elements successfully bound to data. Also defines the enter and exit selections on
@@ -764,7 +764,7 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
      * The datum for a given key is assigned to the element with the matching key. If multiple elements have the same key,
      * the duplicate elements are put into the exit selection; if multiple data have the same key, the duplicate data are put into the enter selection.
      */
-    data<NewDatum>(data: ValueFn<PElement, PDatum, Array<NewDatum>>, key?: ValueFn<GElement | PElement, Datum | NewDatum, string>): Selection<GElement, NewDatum, PElement, PDatum>;
+    data<NewDatum>(data: ValueFn<PElement, PDatum, NewDatum[]>, key?: ValueFn<GElement | PElement, Datum | NewDatum, string>): Selection<GElement, NewDatum, PElement, PDatum>;
 
     /**
      * Return the enter selection: placeholder nodes for each datum that had no corresponding DOM element
@@ -883,7 +883,7 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
     /**
      * Return an array of all (non-null) elements in this selection.
      */
-    nodes(): Array<GElement>;
+    nodes(): GElement[];
 
     /**
      * Returns the total number of elements in this selection.
@@ -1064,17 +1064,17 @@ export function local<T>(): Local<T>;
 // ---------------------------------------------------------------------------
 
 /**
- * Type for object literal containing local name with related fully qualified namespace
+ * Interface for object literal containing local name with related fully qualified namespace
  */
-export type NamespaceLocalObject = {
+export interface NamespaceLocalObject {
     /**
      * Fully qualified namespace
      */
-    space: string,
+    space: string;
     /**
      * Name of the local to be namespaced.
      */
-    local: string
+    local: string;
 }
 
 /**
@@ -1094,9 +1094,9 @@ export function namespace(prefixedLocal: string): NamespaceLocalObject | string;
 // ---------------------------------------------------------------------------
 
 /**
- * Type for maps of namespace prefixes to corresponding fully qualified namespace strings
+ * Interface for maps of namespace prefixes to corresponding fully qualified namespace strings
  */
-export type NamespaceMap = { [prefix: string]: string };
+export interface NamespaceMap { [prefix: string]: string; }
 
 /**
  * Map of namespace prefixes to corresponding fully qualified namespace strings
@@ -1153,7 +1153,7 @@ export function matcher(selector: string): (this: BaseType) => boolean;
  *
  * @param selector A CSS selector string.
  */
-export function selector<DescElement extends Element>(selector: string): (this: BaseType) => DescElement
+export function selector<DescElement extends Element>(selector: string): (this: BaseType) => DescElement;
 
 /**
  * Given the specified selector, returns a function which returns all descendants of "this" element that match the specified selector.

--- a/d3-selection/index.d.ts
+++ b/d3-selection/index.d.ts
@@ -878,7 +878,7 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
     /**
      * Return the first (non-null) element in this selection. If the selection is empty, returns null.
      */
-    node(): GElement;
+    node(): GElement | null;
 
     /**
      * Return an array of all (non-null) elements in this selection.

--- a/d3-selection/index.d.ts
+++ b/d3-selection/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-selection module v1.0
+// Type definitions for D3JS d3-selection module 1.0
 // Project: https://github.com/d3/d3-selection/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-selection/index.d.ts
+++ b/d3-selection/index.d.ts
@@ -1,7 +1,9 @@
-// Type definitions for D3JS d3-selection module v1.0.2
+// Type definitions for D3JS d3-selection module v1.0
 // Project: https://github.com/d3/d3-selection/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Last module patch version validated against: 1.0.2
 
 // --------------------------------------------------------------------------
 // Shared Type Definitions and Interfaces

--- a/d3-selection/tsconfig.json
+++ b/d3-selection/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es6",
     "noImplicitAny": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "baseUrl": "../",
     "typeRoots": [
       "../"

--- a/d3-selection/tslint.json
+++ b/d3-selection/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../tslint.json",
+    "rules": {
+        "unified-signatures": false
+    }
+}

--- a/d3-transition/d3-transition-tests.ts
+++ b/d3-transition/d3-transition-tests.ts
@@ -44,7 +44,7 @@ let dimensions: SVGDatum = {
     height: 300
 };
 
-let startCircleData: Array<CircleDatum> = [
+let startCircleData: CircleDatum[] = [
     {
         nodeId: 'n1',
         name: 'node_1',
@@ -65,7 +65,7 @@ let startCircleData: Array<CircleDatum> = [
     }
 ];
 
-let endCircleData: Array<CircleDatum> = [
+let endCircleData: CircleDatum[] = [
     {
         nodeId: 'n1',
         name: 'node_1',
@@ -129,9 +129,9 @@ let exitCircles = circles.exit<CircleDatum>(); // Note: need to re-type datum ty
 // Create Transition from Selection
 // --------------------------------------------------------------------------
 
-let updateTransition: d3Transition.Transition<SVGCircleElement, CircleDatum, SVGSVGElement, SVGDatum>,
-    enterTransition: d3Transition.Transition<SVGCircleElement, CircleDatum, SVGSVGElement, SVGDatum>,
-    exitTransition: d3Transition.Transition<SVGCircleElement, CircleDatum, SVGSVGElement, SVGDatum>;
+let updateTransition: d3Transition.Transition<SVGCircleElement, CircleDatum, SVGSVGElement, SVGDatum>;
+let enterTransition: d3Transition.Transition<SVGCircleElement, CircleDatum, SVGSVGElement, SVGDatum>;
+let exitTransition: d3Transition.Transition<SVGCircleElement, CircleDatum, SVGSVGElement, SVGDatum>;
 
 updateTransition = circles.transition('update');
 enterTransition = enterCircles.transition('enter');
@@ -411,7 +411,7 @@ exitTransition.remove();
 // Test Event Handling
 // --------------------------------------------------------------------------
 
-let listener: undefined | ((this: SVGCircleElement, datum: CircleDatum, index: number, group: Array<SVGCircleElement> | ArrayLike<SVGCircleElement>) => void);
+let listener: undefined | ((this: SVGCircleElement, datum: CircleDatum, index: number, group: SVGCircleElement[] | ArrayLike<SVGCircleElement>) => void);
 
 
 enterTransition = enterTransition.on('end', function (d, i, g) {
@@ -483,7 +483,7 @@ let empty: boolean = enterTransition.empty();
 // node() and nodes() --------------------------------------------------------------------
 
 let firstCircleNode: SVGCircleElement = enterTransition.node();
-let circleNodes: Array<SVGCircleElement> = enterTransition.nodes();
+let circleNodes: SVGCircleElement[] = enterTransition.nodes();
 
 // size() --------------------------------------------------------------------------------
 

--- a/d3-transition/d3-transition-tests.ts
+++ b/d3-transition/d3-transition-tests.ts
@@ -206,7 +206,7 @@ firstDivTransition = bodyTransition.select(function (d, i, g) {
     let group: HTMLBodyElement[] | ArrayLike<HTMLBodyElement> = g;
 
     console.log('Body Datum foo', d.foo); // d is of type BodyDatum
-    return this.querySelector('div'); // 'this' type is HTMLElement, return type is HTMLDivElement
+    return this.querySelector('div')!; // 'this' type is HTMLElement, return type is HTMLDivElement
 });
 
 
@@ -482,7 +482,7 @@ let empty: boolean = enterTransition.empty();
 
 // node() and nodes() --------------------------------------------------------------------
 
-let firstCircleNode: SVGCircleElement = enterTransition.node();
+let firstCircleNode: SVGCircleElement = enterTransition.node()!;
 let circleNodes: SVGCircleElement[] = enterTransition.nodes();
 
 // size() --------------------------------------------------------------------------------

--- a/d3-transition/index.d.ts
+++ b/d3-transition/index.d.ts
@@ -480,7 +480,7 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
     /**
      * Return the first (non-null) element in this transition. If the transition is empty, returns null.
      */
-    node(): GElement;
+    node(): GElement | null;
 
     /**
      * Return an array of all (non-null) elements in this transition.

--- a/d3-transition/index.d.ts
+++ b/d3-transition/index.d.ts
@@ -365,7 +365,19 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
      *
      * @param filter A CSS selector string.
      */
-    filter(filter: string): this;
+    filter(filter: string): Transition<GElement, Datum, PElement, PDatum>;
+    /**
+     * For each selected element, selects only the elements that match the specified filter, and returns a transition on the resulting selection.
+     *
+     * The new transition has the same id, name and timing as this transition; however, if a transition with the same id already exists on a selected element,
+     * the existing transition is returned for that element.
+     *
+     * The generic refers to the type of element which will be selected after applying the filter, i.e. if the element types
+     * contained in a pre-filter selection are narrowed to a subset as part of the filtering.
+     *
+     * @param filter A CSS selector string.
+     */
+    filter<FilteredElement extends BaseType>(filter: string): Transition<FilteredElement, Datum, PElement, PDatum>;
     /**
      * For each selected element, selects only the elements that match the specified filter, and returns a transition on the resulting selection.
      *
@@ -376,7 +388,21 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
      * the current index (i), and the current group (nodes), with this as the current DOM element. The filter function returns a boolean indicating,
      * whether the selected element matches.
      */
-    filter(filter: ValueFn<GElement, Datum, boolean>): this;
+    filter(filter: ValueFn<GElement, Datum, boolean>): Transition<GElement, Datum, PElement, PDatum>;
+    /**
+     * For each selected element, selects only the elements that match the specified filter, and returns a transition on the resulting selection.
+     *
+     * The new transition has the same id, name and timing as this transition; however, if a transition with the same id already exists on a selected element,
+     * the existing transition is returned for that element.
+     *
+     * The generic refers to the type of element which will be selected after applying the filter, i.e. if the element types
+     * contained in a pre-filter selection are narrowed to a subset as part of the filtering.
+     *
+     * @param filter A filter function which is evaluated for each selected element, in order, being passed the current datum (d),
+     * the current index (i), and the current group (nodes), with this as the current DOM element. The filter function returns a boolean indicating,
+     * whether the selected element matches.
+     */
+    filter<FilteredElement extends BaseType>(filter: ValueFn<GElement, Datum, boolean>): Transition<FilteredElement, Datum, PElement, PDatum>;
 
     // Event Handling -------------------
 
@@ -389,7 +415,7 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
      * the optional name allows multiple callbacks to be registered to receive events of the same type, such as "start.foo"" and "start.bar".
      * To specify multiple typenames, separate typenames with spaces, such as "interrupt end"" or "start.foo start.bar".
      */
-    on(type: string): ValueFn<GElement, Datum, void>;
+    on(type: string): ValueFn<GElement, Datum, void> | undefined;
     /**
      * Remove all listeners for a given name.
      *
@@ -443,7 +469,7 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
     /**
      * Return the first (non-null) element in this transition. If the transition is empty, returns null.
      */
-    node(): GElement | null;
+    node(): GElement;
 
     /**
      * Return an array of all (non-null) elements in this transition.

--- a/d3-transition/index.d.ts
+++ b/d3-transition/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-transition module v1.0.2
+// Type definitions for D3JS d3-transition module v1.0.3
 // Project: https://github.com/d3/d3-transition/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -36,6 +36,9 @@ declare module 'd3-selection' {
          * Otherwise, the timing of the returned transition is inherited from the existing transition of the same id on the nearest ancestor of each selected element.
          * Thus, this method can be used to synchronize a transition across multiple selections,
          * or to re-select a transition for specific elements and modify its configuration.
+         *
+         * If the specified transition is not found on a selected node or its ancestors (such as if the transition already ended),
+         * the default timing parameters are used; however, in a future release, this will likely be changed to throw an error.
          *
          * @param transition A transition instance.
          */

--- a/d3-transition/index.d.ts
+++ b/d3-transition/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-transition module v1.0
+// Type definitions for D3JS d3-transition module 1.0
 // Project: https://github.com/d3/d3-transition/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-transition/index.d.ts
+++ b/d3-transition/index.d.ts
@@ -9,6 +9,14 @@ import { ArrayLike, BaseType, Selection, ValueFn } from 'd3-selection';
  * Extend interface 'Selection' by declaration merging with 'd3-selection'
  */
 declare module 'd3-selection' {
+    /**
+     * A D3 Selection of elements.
+     *
+     * The first generic "GElement" refers to the type of the selected element(s).
+     * The second generic "Datum" refers to the type of the datum of a selected element(s).
+     * The third generic "PElement" refers to the type of the parent element(s) in the D3 selection.
+     * The fourth generic "PDatum" refers to the type of the datum of the parent element(s).
+     */
     export interface Selection<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {
         /**
          * Interrupts the active transition of the specified name on the selected elements, and cancels any pending transitions with the specified name, if any.
@@ -129,7 +137,7 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
      * the current index (i), and the current group (nodes), with this as the current DOM element. It must return an array of elements
      * (or a pseudo-array, such as a NodeList), or the empty array if there are no matching elements.
      */
-    selectAll<DescElement extends BaseType, OldDatum>(selector: ValueFn<GElement, Datum, Array<DescElement> | ArrayLike<DescElement>>): Transition<DescElement, OldDatum, GElement, Datum>;
+    selectAll<DescElement extends BaseType, OldDatum>(selector: ValueFn<GElement, Datum, DescElement[] | ArrayLike<DescElement>>): Transition<DescElement, OldDatum, GElement, Datum>;
 
     /**
      * Return the selection corresponding to this transition.
@@ -477,7 +485,7 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
     /**
      * Return an array of all (non-null) elements in this transition.
      */
-    nodes(): Array<GElement>;
+    nodes(): GElement[];
 
     /**
      * Returns the total number of elements in this transition.

--- a/d3-transition/index.d.ts
+++ b/d3-transition/index.d.ts
@@ -1,7 +1,9 @@
-// Type definitions for D3JS d3-transition module v1.0.3
+// Type definitions for D3JS d3-transition module v1.0
 // Project: https://github.com/d3/d3-transition/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Last module patch version validated against: 1.0.3
 
 import { ArrayLike, BaseType, Selection, ValueFn } from 'd3-selection';
 

--- a/d3-transition/tsconfig.json
+++ b/d3-transition/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es6",
     "noImplicitAny": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "baseUrl": "../",
     "typeRoots": [
       "../"

--- a/d3-transition/tslint.json
+++ b/d3-transition/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../tslint.json",
+    "rules": {
+        "unified-signatures": false
+    }
+}

--- a/d3-zoom/d3-zoom-tests.ts
+++ b/d3-zoom/d3-zoom-tests.ts
@@ -10,6 +10,7 @@ import * as d3Zoom from 'd3-zoom';
 import { ArrayLike, select, Selection, event } from 'd3-selection';
 import { Transition } from 'd3-transition';
 import { scaleLinear, ScaleLinear } from 'd3-scale';
+import { interpolateZoom, interpolate, interpolateArray, ZoomInterpolator, ZoomView } from 'd3-interpolate';
 
 // --------------------------------------------------------------------------
 // Preparatory Steps
@@ -183,6 +184,26 @@ translateExtent = svgZoom.translateExtent();
 svgZoom = svgZoom.duration(500);
 
 let duration: number = svgZoom.duration();
+
+// interpolate() --------------------------------------------------------------
+
+// chainable setter accepts interpoateZoom, interpolate and interpolateArray
+svgZoom = svgZoom.interpolate(interpolateZoom);
+svgZoom = svgZoom.interpolate(interpolate);
+svgZoom = svgZoom.interpolate(interpolateArray);
+
+
+// getter
+
+let basicInterpolatorFactory: (a: ZoomView, b: ZoomView) => ((t: number) => ZoomView);
+let zoomInterpolatorFactory: (a: ZoomView, b: ZoomView) => ZoomInterpolator;
+
+// Basic case without casting
+basicInterpolatorFactory = svgZoom.interpolate();
+
+// Assuming it is know that a specialized interpolation factory was used. E.g. ZoomInterpolator also has a duration
+// argument
+zoomInterpolatorFactory = svgZoom.interpolate<(a: ZoomView, b: ZoomView) => ZoomInterpolator>();
 
 // on() --------------------------------------------------------------------
 

--- a/d3-zoom/d3-zoom-tests.ts
+++ b/d3-zoom/d3-zoom-tests.ts
@@ -33,7 +33,7 @@ let canvas = select<HTMLCanvasElement, any>('canvas')
     .attr('width', function (d) { return d.width; })
     .attr('height', function (d) { return d.height; });
 
-let context = canvas.node().getContext('2d');
+let context = canvas.node()!.getContext('2d');
 
 function drawPointsOnCanvas(radius: number) {
     if (context) {
@@ -454,7 +454,7 @@ let sourceEvent: any = e.sourceEvent;
 
 let zTransform: d3Zoom.ZoomTransform;
 
-zTransform = d3Zoom.zoomTransform(canvas.node());
+zTransform = d3Zoom.zoomTransform(canvas.node()!);
 
 // Test ZoomTransform -------------------------------------------------------
 

--- a/d3-zoom/d3-zoom-tests.ts
+++ b/d3-zoom/d3-zoom-tests.ts
@@ -9,7 +9,7 @@
 import * as d3Zoom from 'd3-zoom';
 import { ArrayLike, select, Selection, event } from 'd3-selection';
 import { Transition } from 'd3-transition';
-import { ScaleLinear } from 'd3-scale';
+import { scaleLinear, ScaleLinear } from 'd3-scale';
 
 // --------------------------------------------------------------------------
 // Preparatory Steps
@@ -35,16 +35,20 @@ let canvas = select<HTMLCanvasElement, any>('canvas')
 let context = canvas.node().getContext('2d');
 
 function drawPointsOnCanvas(radius: number) {
-    context.beginPath();
-    points.forEach(drawPointOnCanvas(radius));
-    context.fill();
+    if (context) {
+        context.beginPath();
+        points.forEach(drawPointOnCanvas(radius));
+        context.fill();
+    }
 }
 
 function drawPointOnCanvas(radius: number) {
 
     return function (point: [number, number]) {
-        context.moveTo(point[0] + radius, point[1]);
-        context.arc(point[0], point[1], radius, 0, 2 * Math.PI);
+        if (context) {
+            context.moveTo(point[0] + radius, point[1]);
+            context.arc(point[0], point[1], radius, 0, 2 * Math.PI);
+        }
     };
 }
 
@@ -81,8 +85,8 @@ interface GroupDatum {
     toK: number;
 }
 
-let groupsSelection: Selection<SVGGElement, GroupDatum, any, any>,
-    groupsTransition: Transition<SVGGElement, GroupDatum, any, any>;
+let groupsSelection: Selection<SVGGElement, GroupDatum, any, any>;
+let groupsTransition: Transition<SVGGElement, GroupDatum, any, any>;
 
 
 // --------------------------------------------------------------------------
@@ -94,14 +98,15 @@ let groupsSelection: Selection<SVGGElement, GroupDatum, any, any>,
 function zoomedCanvas(this: HTMLCanvasElement, d: CanvasDatum) {
 
     // Cast d3 event to D3ZoomEvent to be used in zoom event handler
-    let e = <d3Zoom.D3ZoomEvent<HTMLCanvasElement, any>>event;
-
-    context.save();
-    context.clearRect(0, 0, this.width, this.height); // this element
-    context.translate(e.transform.x, e.transform.y);
-    context.scale(e.transform.k, e.transform.k);
-    drawPointsOnCanvas(d.radius);
-    context.restore();
+    let e = <d3Zoom.D3ZoomEvent<HTMLCanvasElement, any>> event;
+    if (context) {
+        context.save();
+        context.clearRect(0, 0, this.width, this.height); // this element
+        context.translate(e.transform.x, e.transform.y);
+        context.scale(e.transform.k, e.transform.k);
+        drawPointsOnCanvas(d.radius);
+        context.restore();
+    }
 }
 
 let canvasZoom: d3Zoom.ZoomBehavior<HTMLCanvasElement, CanvasDatum>;
@@ -115,7 +120,7 @@ canvasZoom = d3Zoom.zoom()
 function zoomedSVGOverlay(this: SVGRectElement) {
 
     // Cast d3 event to D3ZoomEvent to be used in zoom event handler
-    let e = <d3Zoom.D3ZoomEvent<HTMLCanvasElement, any>>event;
+    let e = <d3Zoom.D3ZoomEvent<HTMLCanvasElement, any>> event;
 
     g.attr('transform', e.transform.toString());
 }
@@ -131,19 +136,19 @@ svgZoom = d3Zoom.zoom<SVGRectElement, SVGDatum>();
 svgZoom = svgZoom.filter(function (d, i, group) {
 
     // Cast d3 event to D3ZoomEvent to be used in filter logic
-    let e = <d3Zoom.D3ZoomEvent<SVGRectElement, SVGDatum>>event;
+    let e = <d3Zoom.D3ZoomEvent<SVGRectElement, SVGDatum>> event;
 
     console.log('Overlay Rectangle width: ', this.width.baseVal.value); // this typing is SVGRectElement
     return e.sourceEvent.type !== 'brush' || !d.filterBrushEvent; // datum type is SVGDatum (as propagated to SVGRectElement with zoom event attached)
 });
 
-let filterFn: (this: SVGRectElement, d?: SVGDatum, index?: number, group?: Array<SVGRectElement>) => boolean;
+let filterFn: (this: SVGRectElement, d: SVGDatum, index: number, group: SVGRectElement[]) => boolean;
 filterFn = svgZoom.filter();
 
 
 // extent()  ---------------------------------------------------------------
 
-let extentAccessor: (this: SVGRectElement, d: SVGDatum, index: number, group: Array<SVGRectElement>) => [[number, number], [number, number]];
+let extentAccessor: (this: SVGRectElement, d: SVGDatum, index: number, group: SVGRectElement[]) => [[number, number], [number, number]];
 extentAccessor = svgZoom.extent();
 
 // chainable with array
@@ -185,15 +190,16 @@ let duration: number = svgZoom.duration();
 svgZoom = svgZoom.on('zoom', zoomedSVGOverlay);
 // svgZoom = svgZoom.on('zoom', zoomedCanvas); // fails, zoom event handler has wrong this and datum type
 
-let zoomHandler: (this: SVGRectElement, datum: SVGDatum, index: number, group: Array<SVGRectElement> | ArrayLike<SVGRectElement>) => void;
+let zoomHandler: ((this: SVGRectElement, datum: SVGDatum, index: number, group: SVGRectElement[] | ArrayLike<SVGRectElement>) => void) | undefined;
 zoomHandler = svgZoom.on('zoom');
 
 // chainable remove handler
 svgZoom = svgZoom.on('zoom', null);
 
 // re-apply
-svgZoom.on('zoom', zoomHandler);
-
+if (zoomHandler) {
+    svgZoom.on('zoom', zoomHandler);
+}
 // --------------------------------------------------------------------------
 // Test Attach ZoomBehaviour
 // --------------------------------------------------------------------------
@@ -230,7 +236,7 @@ svgZoom.transform(svgOverlay, function (datum, index, groups) {
     let that: SVGRectElement = this;
     let d: SVGDatum = datum;
     let i: number = index;
-    let g: Array<SVGRectElement> | ArrayLike<SVGRectElement> = groups;
+    let g: SVGRectElement[] | ArrayLike<SVGRectElement> = groups;
     console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
     console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
     return d3Zoom.zoomIdentity;
@@ -244,7 +250,7 @@ svgZoom.transform(svgOverlayTransition, function (datum, index, groups) {
     let that: SVGRectElement = this;
     let d: SVGDatum = datum;
     let i: number = index;
-    let g: Array<SVGRectElement> | ArrayLike<SVGRectElement> = groups;
+    let g: SVGRectElement[] | ArrayLike<SVGRectElement> = groups;
     console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
     console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
     return d3Zoom.zoomIdentity;
@@ -263,7 +269,7 @@ svgZoom.translateBy(
         let that: SVGRectElement = this;
         let d: SVGDatum = datum;
         let i: number = index;
-        let g: Array<SVGRectElement> | ArrayLike<SVGRectElement> = groups;
+        let g: SVGRectElement[] | ArrayLike<SVGRectElement> = groups;
         console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
         console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
         return 30;
@@ -274,7 +280,7 @@ svgZoom.translateBy(
         let that: SVGRectElement = this;
         let d: SVGDatum = datum;
         let i: number = index;
-        let g: Array<SVGRectElement> | ArrayLike<SVGRectElement> = groups;
+        let g: SVGRectElement[] | ArrayLike<SVGRectElement> = groups;
         console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
         console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
         return 30;
@@ -286,7 +292,7 @@ svgZoom.translateBy(
         let that: SVGRectElement = this;
         let d: SVGDatum = datum;
         let i: number = index;
-        let g: Array<SVGRectElement> | ArrayLike<SVGRectElement> = groups;
+        let g: SVGRectElement[] | ArrayLike<SVGRectElement> = groups;
         console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
         console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
         return 30;
@@ -295,7 +301,7 @@ svgZoom.translateBy(
         let that: SVGRectElement = this;
         let d: SVGDatum = datum;
         let i: number = index;
-        let g: Array<SVGRectElement> | ArrayLike<SVGRectElement> = groups;
+        let g: SVGRectElement[] | ArrayLike<SVGRectElement> = groups;
         console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
         console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
         return 30;
@@ -312,7 +318,7 @@ svgZoom.translateBy(
         let that: SVGRectElement = this;
         let d: SVGDatum = datum;
         let i: number = index;
-        let g: Array<SVGRectElement> | ArrayLike<SVGRectElement> = groups;
+        let g: SVGRectElement[] | ArrayLike<SVGRectElement> = groups;
         console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
         console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
         return 30;
@@ -323,7 +329,7 @@ svgZoom.translateBy(
         let that: SVGRectElement = this;
         let d: SVGDatum = datum;
         let i: number = index;
-        let g: Array<SVGRectElement> | ArrayLike<SVGRectElement> = groups;
+        let g: SVGRectElement[] | ArrayLike<SVGRectElement> = groups;
         console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
         console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
         return 30;
@@ -335,7 +341,7 @@ svgZoom.translateBy(
         let that: SVGRectElement = this;
         let d: SVGDatum = datum;
         let i: number = index;
-        let g: Array<SVGRectElement> | ArrayLike<SVGRectElement> = groups;
+        let g: SVGRectElement[] | ArrayLike<SVGRectElement> = groups;
         console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
         console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
         return 30;
@@ -344,7 +350,7 @@ svgZoom.translateBy(
         let that: SVGRectElement = this;
         let d: SVGDatum = datum;
         let i: number = index;
-        let g: Array<SVGRectElement> | ArrayLike<SVGRectElement> = groups;
+        let g: SVGRectElement[] | ArrayLike<SVGRectElement> = groups;
         console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
         console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
         return 30;
@@ -357,26 +363,26 @@ svgZoom.scaleBy(svgOverlay, 3);
 // svgZoom.scaleBy(groupsSelection, 3); // fails, as groupSelection mismachtes DOM Element type and datum type
 
 svgZoom.scaleBy(svgOverlay, function (datum, index, groups) {
-        let that: SVGRectElement = this;
-        let d: SVGDatum = datum;
-        let i: number = index;
-        let g: Array<SVGRectElement> | ArrayLike<SVGRectElement> = groups;
-        console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
-        console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
-        return 3;
+    let that: SVGRectElement = this;
+    let d: SVGDatum = datum;
+    let i: number = index;
+    let g: SVGRectElement[] | ArrayLike<SVGRectElement> = groups;
+    console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
+    console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
+    return 3;
 });
 // use on transition
 svgZoom.scaleBy(svgOverlayTransition, 3);
 // svgZoom.scaleBy(groupsTransition, 3); // fails, as groupTransition mismachtes DOM Element type and datum type
 
 svgZoom.scaleBy(svgOverlayTransition, function (datum, index, groups) {
-        let that: SVGRectElement = this;
-        let d: SVGDatum = datum;
-        let i: number = index;
-        let g: Array<SVGRectElement> | ArrayLike<SVGRectElement> = groups;
-        console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
-        console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
-        return 3;
+    let that: SVGRectElement = this;
+    let d: SVGDatum = datum;
+    let i: number = index;
+    let g: SVGRectElement[] | ArrayLike<SVGRectElement> = groups;
+    console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
+    console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
+    return 3;
 });
 
 // scaleTo() -------------------------------------------------------------------------------------
@@ -386,33 +392,33 @@ svgZoom.scaleTo(svgOverlay, 3);
 // svgZoom.scaleBy(groupsSelection, 3); // fails, as groupSelection mismachtes DOM Element type and datum type
 
 svgZoom.scaleTo(svgOverlay, function (datum, index, groups) {
-        let that: SVGRectElement = this;
-        let d: SVGDatum = datum;
-        let i: number = index;
-        let g: Array<SVGRectElement> | ArrayLike<SVGRectElement> = groups;
-        console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
-        console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
-        return 3;
+    let that: SVGRectElement = this;
+    let d: SVGDatum = datum;
+    let i: number = index;
+    let g: SVGRectElement[] | ArrayLike<SVGRectElement> = groups;
+    console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
+    console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
+    return 3;
 });
 // use on transition
 svgZoom.scaleTo(svgOverlayTransition, 3);
 // svgZoom.scaleBy(groupsTransition, 3); // fails, as groupTransition mismachtes DOM Element type and datum type
 
 svgZoom.scaleTo(svgOverlayTransition, function (datum, index, groups) {
-        let that: SVGRectElement = this;
-        let d: SVGDatum = datum;
-        let i: number = index;
-        let g: Array<SVGRectElement> | ArrayLike<SVGRectElement> = groups;
-        console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
-        console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
-        return 30;
+    let that: SVGRectElement = this;
+    let d: SVGDatum = datum;
+    let i: number = index;
+    let g: SVGRectElement[] | ArrayLike<SVGRectElement> = groups;
+    console.log('Owner SVG Element of svg rect: ', this.ownerSVGElement); // this is of type SVGRectElement
+    console.log('Filter Brush Event status as per datum: ', d.filterBrushEvent); // datum type is SVGDatum
+    return 30;
 });
 
 // --------------------------------------------------------------------------
 // Test Zoom Event Interface
 // --------------------------------------------------------------------------
 
-let e: d3Zoom.D3ZoomEvent<SVGRectElement, SVGDatum>;
+let e: d3Zoom.D3ZoomEvent<SVGRectElement, SVGDatum> = event; // mock assignment
 
 let target: d3Zoom.ZoomBehavior<SVGRectElement, SVGDatum> = e.target;
 let type: 'start' | 'zoom' | 'end' | string = e.type;
@@ -445,7 +451,7 @@ let invertedY: number = zTransform.invertY(240);
 
 // TODO: reScaleX, reScaleY
 
-let linearScale: ScaleLinear<number, number>;
+let linearScale: ScaleLinear<number, number> = scaleLinear();
 
 linearScale = zTransform.rescaleX(linearScale);
 linearScale = zTransform.rescaleY(linearScale);

--- a/d3-zoom/index.d.ts
+++ b/d3-zoom/index.d.ts
@@ -481,7 +481,7 @@ export interface ZoomBehavior<ZoomRefElement extends ZoomedElementBaseType, Datu
      * start (after zooming begins [such as mousedown]), zoom (after a change to the zoom  transform [such as mousemove], or
      * end (after an active pointer becomes inactive [such as on mouseup].)
      */
-    on(typenames: string): ValueFn<ZoomRefElement, Datum, void>;
+    on(typenames: string): ValueFn<ZoomRefElement, Datum, void> | undefined;
     /**
      * Remove the current event listeners for the specified typenames, if any, return the drag behavior.
      *

--- a/d3-zoom/index.d.ts
+++ b/d3-zoom/index.d.ts
@@ -1,7 +1,9 @@
-// Type definitions for d3JS d3-zoom module v1.1.0
+// Type definitions for d3JS d3-zoom module v1.1
 // Project: https://github.com/d3/d3-zoom/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Last module patch version validated against: 1.1.1
 
 import { ArrayLike, Selection, TransitionLike, ValueFn } from 'd3-selection';
 import { ZoomView, ZoomInterpolator } from 'd3-interpolate';

--- a/d3-zoom/index.d.ts
+++ b/d3-zoom/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for d3JS d3-zoom module v1.0.3
+// Type definitions for d3JS d3-zoom module v1.1.0
 // Project: https://github.com/d3/d3-zoom/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { ArrayLike, Selection, TransitionLike, ValueFn } from 'd3-selection';
+import { ZoomView, ZoomInterpolator } from 'd3-interpolate';
 
 
 // --------------------------------------------------------------------------
@@ -473,6 +474,23 @@ export interface ZoomBehavior<ZoomRefElement extends ZoomedElementBaseType, Datu
     duration(duration: number): this;
 
     /**
+     * Returns the current interpolation factory, which defaults to d3.interpolateZoom to implement smooth zooming.
+     */
+    interpolate<InterpolationFactory extends (a: ZoomView, b: ZoomView) => ((t: number) => ZoomView)>(): InterpolationFactory;
+
+    /**
+     * Sets the interpolation factory for zoom transitions to the specified function.
+     * Use the default d3.interpolateZoom to implement smooth zooming.
+     * To apply direct interpolation between two views, try d3.interpolate instead.
+     *
+     * Each view is defined as an array of three numbers: cx, cy and width. The first two coordinates cx, cy represent the center of the viewport;
+     * the last coordinate width represents the size of the viewport.
+     *
+     * @param interpolatorFactory An interpolator factory to be used to generate interpolators beetween zooms for transitions.
+     */
+    interpolate(interpolatorFactory: (a: ZoomView, b: ZoomView) => ((t: number) => ZoomView)): this;
+
+    /**
      * Return the first currently-assigned listener matching the specified typenames, if any.
      *
      * @param typenames The typenames is a string containing one or more typename separated by whitespace.
@@ -685,8 +703,11 @@ export interface ZoomTransform {
 }
 
 /**
- * Return the current transform for the specified node. Internally, an element’s transform is stored as element.__zoom;
- * however, you should use this method rather than accessing it directly. If the given node has no defined transform, returns the identity transformation.
+ * Returns the current transform for the specified node. Note that node should typically be a DOM element, and not a selection.
+ * (A selection may consist of multiple nodes, in different states, and this function only returns a single transform.) If you have a selection, call selection.node first.
+ * In the context of an event listener, the node is typically the element that received the input event (which should be equal to event.transform), "this".
+ * Internally, an element’s transform is stored as element.__zoom; however, you should use this method rather than accessing it directly. If the given node has no defined transform, returns the identity transformation.
+ * The returned transform represents a two-dimensional transformation matrix
  *
  * For details see {@link https://github.com/d3/d3-zoom#zoom-transforms}
  *

--- a/d3-zoom/index.d.ts
+++ b/d3-zoom/index.d.ts
@@ -24,10 +24,10 @@ type ZoomedElementBaseType = Element;
  * that  can be passed into zoomTransform methods rescaleX and rescaleY
  */
 export interface ZoomScale {
-    domain(): Array<number>;
-    domain(domain: Array<number>): this;
-    range(): Array<number>;
-    range(range: Array<number>): this;
+    domain(): number[];
+    domain(domain: number[]): this;
+    range(): number[];
+    range(range: number[]): this;
     copy(): ZoomScale;
     invert(value: number): number;
 }

--- a/d3-zoom/index.d.ts
+++ b/d3-zoom/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for d3JS d3-zoom module v1.1
+// Type definitions for d3JS d3-zoom module 1.1
 // Project: https://github.com/d3/d3-zoom/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3-zoom/tsconfig.json
+++ b/d3-zoom/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es6",
     "noImplicitAny": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "baseUrl": "../",
     "typeRoots": [
       "../"

--- a/d3-zoom/tslint.json
+++ b/d3-zoom/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../tslint.json",
+    "rules": {
+        "unified-signatures": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: <<not applicable>>
- [x] Increase the version number in the header if appropriate.

Related to Issue #11365, replaces PR #12566.

@gustavderdrache @alejo90 @alitaheri 

Thanks to @alejo90 @alitaheri for the initial PRs, after some thought and reviewing some alternative approaches, I decided to create a new PR, mostly, because I noticed there was some 'technical debt' in the tests to remove along the way, which I had parked for follow-up. Did not wan to impose that on someone else.

I will follow-up with **d3-force** as soon as I have a chance as the next in line, because you had it in  PR #12566. There are also the others,with dependencies on d3-selection, which should be next in line  for validation and enhancement.

@gustavderdrache for d3-selection-multi I made the assumption that, when a `ValueFn` is used, it always evaluates to a `ValueMap`, never to `null` for purposes  of `strictNullChecking`. As a corollary, the "no-op" for a given evaluated Value Function is the empty object `{}`.

cc @yuit

* **(d3-selection) [Enhancement]**: Validated, updated and activated to enforece `strictNullChecks`. `BaseType` updated to include `null`. As a result of this approach, the **developer must explicitly** include `| null`, if a Selection or a (sub-)selecting method may contain `null` element(s). By the same token, the `node()` method, will return `null` only, if the Selection to which it was applied may contain `null` element(s).
* **(d3-selection) [Enhancement]**: Added additional signature to `filter(...)` method such that a generic can be used to control the type of the filtered elements, should they be a subset of the unfiltered types.
* (d3-selection) [Enhancement]: Added `Document` to `BaseType` union type.
* **(d3-transition) [Enhancement]**: Validated, updated and activated to enforece `strictNullChecks`. `BaseType` updated to include `null`. As a result of this approach, the developer must explicitly include `| null`, if a Transition or a (sub-)selecting method may contain `null` element(s). By the same token, the `node()` method, will return `null` only, if the Transition to which it was applied may contain `null` element(s).
* **(d3-transition) [Enhancement]**: Added additional signature to `filter(...)` method such that a generic can be used to control the type of the filtered elements, should they be a subset of the unfiltered types.
* **(d3-selection-multi) [Enhancement]**: updated `ValueMap` type use extension of selection/transition `BaseType` as defined above consistent  with `strictNullChecks`.
* **(d3-selection-multi) [Test Fix]**: Updated tests where a Value Function is used to return a ValueMap for each selected item, as the ValueMap must be defined as a mapping object idiomatically, the test was changed to never return `null` as a result of the value function. Instead it returns `{}`, when no updates are required for the currently iterated selected element.
* In general, for all three above modules: Tests have been updated to be more explicit about type-checking inside callback functions. Also, where shortcuts where taken in the shape tests to simply test interface/signature contracts, without necessary variable initialization, mock initializations have been included. This is necessitated by enabling `strictNullChecks`.