### PR TITLE
[@types/supertest] Correct type

### DIFF
--- a/supertest/index.d.ts
+++ b/supertest/index.d.ts
@@ -7,7 +7,7 @@ import * as superagent from "superagent"
 
 export = supertest;
 
-declare function supertest(app: any): supertest.SuperTest<any>;
+declare function supertest(app: any): supertest.SuperTest<supertest.Test>;
 declare namespace supertest {
     interface Response extends superagent.Response {
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.

`master` branch has correct type for supertest. -- https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/supertest/supertest.d.ts#L11

But `types-2.0` branch doesn't correctly extend that. I had fixed it.
