### PR TITLE
enzyme: Enable enzyme-tests.ts again and fix <svg> attributes errors

### DIFF
--- a/enzyme/enzyme-tests.tsx
+++ b/enzyme/enzyme-tests.tsx
@@ -1,4 +1,3 @@
-/*
 import { shallow, mount, render, describeWithDOM, spyLifecycle } from "enzyme";
 import * as React from "react";
 import {Component, ReactElement, HTMLAttributes} from "react";
@@ -39,7 +38,7 @@ namespace ShallowWrapperTest {
         objectVal: Object,
         boolVal: Boolean,
         stringVal: String,
-        elementWrapper: ShallowWrapper<HTMLAttributes, {}>
+        elementWrapper: ShallowWrapper<HTMLAttributes<{}>, {}>
 
     function test_shallow_options() {
         shallow(<MyComponent propsProperty={1}/>, {
@@ -319,7 +318,7 @@ namespace ReactWrapperTest {
         objectVal: Object,
         boolVal: Boolean,
         stringVal: String,
-        elementWrapper: ReactWrapper<HTMLAttributes, {}>
+        elementWrapper: ReactWrapper<HTMLAttributes<{}>, {}>
 
     function test_unmount() {
         reactWrapper = reactWrapper.unmount();
@@ -593,7 +592,7 @@ namespace CheerioWrapperTest {
         objectVal: Object,
         boolVal: Boolean,
         stringVal: String,
-        elementWrapper: CheerioWrapper<HTMLAttributes, {}>
+        elementWrapper: CheerioWrapper<HTMLAttributes<{}>, {}>
 
     function test_find() {
         elementWrapper = cheerioWrapper.find('.selector');
@@ -821,4 +820,4 @@ namespace CheerioWrapperTest {
     function test_everyWhere() {
         boolVal = cheerioWrapper.everyWhere((aCheerioWrapper: CheerioWrapper<MyComponentProps, MyComponentState>) => true);
     }
-}*/
+}

--- a/enzyme/enzyme-tests.tsx
+++ b/enzyme/enzyme-tests.tsx
@@ -38,6 +38,7 @@ namespace ShallowWrapperTest {
         objectVal: Object,
         boolVal: Boolean,
         stringVal: String,
+        numOrStringVal: number | string,
         elementWrapper: ShallowWrapper<HTMLAttributes<{}>, {}>
 
     function test_shallow_options() {
@@ -305,6 +306,10 @@ namespace ShallowWrapperTest {
 
     function test_isEmptyRender() {
         boolVal = shallowWrapper.isEmptyRender();
+    }
+
+    function test_svg() {
+        numOrStringVal = shallowWrapper.find('svg').props().strokeWidth;
     }
 }
 

--- a/enzyme/index.d.ts
+++ b/enzyme/index.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: Marian Palkus <https://github.com/MarianPalkus>, Cap3 <http://www.cap3.de>, Ivo Stratev <https://github.com/NoHomey>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { ReactElement, Component, StatelessComponent, ComponentClass, HTMLAttributes as ReactHTMLAttributes } from "react";
+import { ReactElement, Component, StatelessComponent, ComponentClass, HTMLAttributes as ReactHTMLAttributes, SVGAttributes as ReactSVGAttributes } from "react";
 
-type HTMLAttributes = ReactHTMLAttributes<{}>;
+type HTMLAttributes = ReactHTMLAttributes<{}> & ReactSVGAttributes<{}>;
 
 export class ElementClass extends Component<any, any> {
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: http://airbnb.io/enzyme/docs/api/shallow.html
- [x] Increase the version number in the header if appropriate.

enzyme is a shallow test wrapper for React. So it should support `<svg>` also but it currently causes an error such as `'strokeWidth' prop is not defined`.

I fixed that.