### PR TITLE
Fixed ClientOptions tracker on webtorrent

### DIFF
--- a/webtorrent/index.d.ts
+++ b/webtorrent/index.d.ts
@@ -19,7 +19,7 @@ declare namespace WebTorrent {
     nodeId?: string|Buffer, // DHT protocol node ID (default=randomly generated)
     peerId?: string|Buffer, // Wire protocol peer ID (default=randomly generated)
     rtcConfig?: Object,     // RTCPeerConnection configuration object (default=STUN only)
-    tracker?: boolean,      // Whether or not to enable trackers (default=true)
+    tracker?: boolean|Object,      // Whether or not to enable trackers (default=true)
     wrtc?: Object           // Custom webrtc implementation (in node, specify the [wrtc](https://www.npmjs.com/package/wrtc) package)
   }
 


### PR DESCRIPTION
As stated in the docs, https://github.com/feross/webtorrent/blob/master/docs/api.md , the tracker property of ClientOptions can be boolean or an object:

```
{
  maxConns: Number,        // Max number of connections per torrent (default=55)
  nodeId: String|Buffer,   // DHT protocol node ID (default=randomly generated)
  peerId: String|Buffer,   // Wire protocol peer ID (default=randomly generated)
  tracker: Boolean|Object, // Enable trackers (default=true), or options object for Tracker
  dht: Boolean|Object,     // Enable DHT (default=true), or options object for DHT
  webSeeds: Boolean        // Enable BEP19 web seeds (default=true)
}
```
