### PR TITLE
Update react typings to allow state to be null

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -176,7 +176,7 @@ declare namespace React {
         // In the future, if we can define its call signature conditionally
         // on the existence of `children` in `P`, then we should remove this.
         props: P & { children?: ReactNode };
-        state: S;
+        state: S | null;
         context: any;
         refs: {
             [key: string]: ReactInstance


### PR DESCRIPTION
In react, `null` is the default value of state:
See: https://github.com/facebook/react/blob/c78464f8ea9a5b00ec80252d20a71a1482210e57/src/isomorphic/classic/class/ReactClass.js#L787


- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/facebook/react/blob/c78464f8ea9a5b00ec80252d20a71a1482210e57/src/isomorphic/classic/class/ReactClass.js#L787
- [ ] Increase the version number in the header if appropriate.
