### PR TITLE
node-sass: accurate importer typings

### DIFF
--- a/node-sass/index.d.ts
+++ b/node-sass/index.d.ts
@@ -8,8 +8,7 @@
 type ImporterReturnType = { file: string } | { contents: string } | Error | null;
 
 interface Importer {
-    (url: string, prev: string): ImporterReturnType;
-    (url: string, prev: string, done: (data: ImporterReturnType) => void): void;
+    (url: string, prev: string, done: (data: ImporterReturnType) => void): ImporterReturnType | void;
 }
 
 interface Options {

--- a/node-sass/index.d.ts
+++ b/node-sass/index.d.ts
@@ -5,9 +5,11 @@
 
 /// <reference types="node" />
 
+type ImporterReturnType = { file: string } | { contents: string } | Error | null;
 
 interface Importer {
-    (url: string, prev: string, done: (data: { file: string; contents: string; }) => void): void;
+    (url: string, prev: string): ImporterReturnType;
+    (url: string, prev: string, done: (data: ImporterReturnType) => void): void;
 }
 
 interface Options {

--- a/node-sass/node-sass-tests.ts
+++ b/node-sass/node-sass-tests.ts
@@ -1,63 +1,47 @@
 import * as sass from 'node-sass';
+
 sass.render({
   file: '/path/to/myFile.scss',
   data: 'body{background:blue; a{color:black;}}',
   importer: function(url, prev, done) {
-    // url is the path in import as is, which libsass encountered.
-    // prev is the previously resolved path.
-    // done is an optional callback, either consume it or return value synchronously.
-    // this.options contains this options hash, this.callback contains the node-style callback
     someAsyncFunction(url, prev, function(result) {
-      done({
-        file: result.path, // only one of them is required, see section Sepcial Behaviours.
-        contents: result.data
-      });
+      if (result == null) {
+        // return null to opt out of handling this path
+        // compiler will fall to next importer in array (or its own default)
+        return null;
+      }
+      // only one of them is required, see section Sepcial Behaviours.
+      done({ file: result.path });
+      done({ contents: result.data });
     });
-    // OR
-    var result = someSyncFunction(url, prev);
-    return { file: result.path, contents: result.data };
   },
   includePaths: ['lib/', 'mod/'],
   outputStyle: 'compressed'
 }, function(error, result) { // node-style callback from v3.0.0 onwards
   if (error) {
-    console.log(error.status); // used to be "code" in v2x and below
-    console.log(error.column);
-    console.log(error.message);
-    console.log(error.line);
+    console.log(error.status, error.column, error.message, error.line);
   }
   else {
-    console.log(result.css.toString());
-
     console.log(result.stats);
-
+    console.log(result.css.toString());
     console.log(result.map.toString());
     // or better
     console.log(JSON.stringify(result.map)); // note, JSON.stringify accepts Buffer too
   }
 });
 // OR
-var result = sass.renderSync({
+const result = sass.renderSync({
   file: '/path/to/file.scss',
   data: 'body{background:blue; a{color:black;}}',
   outputStyle: 'compressed',
   outFile: '/to/my/output.css',
   sourceMap: true, // or an absolute or relative (to outFile) path
   sourceMapRoot: '.',
-  importer: function(url, prev, done) {
-    // url is the path in import as is, which libsass encountered.
-    // prev is the previously resolved path.
-    // done is an optional callback, either consume it or return value synchronously.
-    // this.options contains this options hash
-    someAsyncFunction(url, prev, function(result) {
-      done({
-        file: result.path, // only one of them is required, see section Sepcial Behaviours.
-        contents: result.data
-      });
-    });
-    // OR
-    var result = someSyncFunction(url, prev);
-    return { file: result.path, contents: result.data };
+  importer: function(url, prev) {
+    if (url.startsWith('!')) {
+      return new Error('Cannot accept this file');
+    }
+    return { file: [prev, url].join('/') };
   },
 });
 
@@ -65,7 +49,7 @@ console.log(result.css);
 console.log(result.map);
 console.log(result.stats);
 
-function someAsyncFunction(url: string, prev: string, callback: (result: { path: string; data: string }) => void): void {}
-function someSyncFunction(url: string, prev: string): { path: string; data: string} {
+function someAsyncFunction(url: string, prev: string, callback: (result: { path: string; data: string }) => void): void { }
+function someSyncFunction(url: string, prev: string): { path: string; data: string } {
   return null;
 }


### PR DESCRIPTION
more accurate definition of `importer` function:
- supports sync and async usage (even at the same time, which is just fine, I checked)
- return object should declare _either_ `file` or `contents`, not both
- can also return Error to throw or `null` to opt out of handling path

PR checklist

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/sass/node-sass#importer--v200---experimental
- [ ] Increase the version number in the header if appropriate.
