### PR TITLE
Fix meteor-roles: getRolesForUser returns string[], not Role[]

### DIFF
--- a/meteor-roles/index.d.ts
+++ b/meteor-roles/index.d.ts
@@ -136,7 +136,7 @@ declare namespace Roles {
     function getRolesForUser(
         user : string|Object,
         group? : string
-    ) : Role[];
+    ) : string[];
 
     /**
      * Retrieve all users who are in target role.


### PR DESCRIPTION

- [x ] Prefer to make your PR against the `types-2.0` branch.

If changing an existing definition:
- [x ] Provide a URL to  documentation or source code which provides context for the suggested changes: 
[https://github.com/alanning/meteor-roles/blob/e486f5a34f93eff514205af58ace2c64fc9b2909/roles/roles_common.js#L397-L405](https://github.com/alanning/meteor-roles/blob/e486f5a34f93eff514205af58ace2c64fc9b2909/roles/roles_common.js#L397-L405)

This function only returns the array of string inside the role objects. Thus the return value should be string[] and not Role[]

