### PR TITLE
Update Babylon's typings to support the all plugins option

### DIFF
--- a/babylon/index.d.ts
+++ b/babylon/index.d.ts
@@ -43,5 +43,5 @@ export interface BabylonOptions {
 
 export type PluginName = 'jsx' | 'flow' | 'asyncFunctions' | 'classConstructorCall' | 'doExpressions'
     | 'trailingFunctionCommas' | 'objectRestSpread' | 'decorators' | 'classProperties' | 'exportExtensions'
-    | 'exponentiationOperator' | 'asyncGenerators' | 'functionBind' | 'functionSent';
+    | 'exponentiationOperator' | 'asyncGenerators' | 'functionBind' | 'functionSent' | '*';
 


### PR DESCRIPTION
Just a minor update to the Babylon definition to add the "all" plugin reference `*`

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present. 👍 

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://github.com/babel/babylon#plugins

![screen shot 2016-11-23 at 13 14 01](https://cloud.githubusercontent.com/assets/49038/20563068/ba9dea18-b17e-11e6-887f-5f0394bafdb0.png)

- [x] Increase the version number in the header if appropriate.
