### PR TITLE
update react typings to 0.37

### DIFF
--- a/react-native/index.d.ts
+++ b/react-native/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-native 0.34
+// Type definitions for react-native 0.37
 // Project: https://github.com/facebook/react-native
 // Definitions by: Bruno Grieder <https://github.com/bgrieder>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -1922,6 +1922,16 @@ declare module "react" {
         [key: string]: any
     }
 
+    /**
+     * Passed data from WebView via window.postMessage.
+     */
+    export interface WebViewMessageEventData {
+	/**
+	 * The data sent from a WebView; can only be a string.
+	 */
+	data: string
+    }
+    
     export interface WebViewPropertiesAndroid {
 
         /**
@@ -2080,6 +2090,11 @@ declare module "react" {
          */
         onLoadStart?: (event: NavState) => void
 
+        /**
+         * Invoked when window.postMessage is called from WebView.
+         */
+	onMessage?: ( event: NativeSyntheticEvent<WebViewMessageEventData> ) => void
+	
         /**
          * Function that is invoked when the `WebView` loading starts or ends.
          */


### PR DESCRIPTION
Please fill in this template.

- [ x ] Prefer to make your PR against the `types-2.0` branch.
- [ x ] Test the change in your own code.
- [ x  ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ x ] The package does not provide its own types, and you can not add them.
- [ x ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ x ] Run `tsc` without errors.
- [ x ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [ x ] Provide a URL to  documentation or source code which provides context for the suggested changes: <<url here>>
- [ x ] Increase the version number in the header if appropriate.

adds the onMessage propType for webView added in 0.37

@bgrieder - not sure how to best check for other potential new types between 0.34 and 0.37, but this is one I'm sure is missing:
https://facebook.github.io/react-native/docs/webview.html#onmessage