### PR TITLE
[@types/immutable] Enhanced immutable typings for use with strict null checks on

### DIFF
--- a/immutable/immutable-tests.ts
+++ b/immutable/immutable-tests.ts
@@ -46,7 +46,10 @@ list = list.asImmutable();
 let indexedSeq: immutable.Seq.Indexed<number> = list.toSeq();
 
 // Iterable tests
-let value: number = list.get(0);
+let optionalValue: number | undefined;
+let value: number;
+
+optionalValue = list.get(0);
 value = list.get(0, 1);
 list = list.interpose(0);
 list = list.interleave(list, list1);
@@ -77,8 +80,8 @@ value = list.hashCode();
 bool = list.has(1);
 bool = list.includes(1);
 bool = list.contains(1);
-value = list.first();
-value = list.last();
+optionalValue = list.first();
+optionalValue = list.last();
 let toArr: number[] = list.toArray();
 let toMap: immutable.Map<number, number> = list.toMap();
 let toOrderedMap: immutable.OrderedMap<number, number> = list.toOrderedMap();
@@ -177,23 +180,23 @@ tuple = list.findLastEntry(
     null,
     0
 );
-value = list.findKey(
+optionalValue = list.findKey(
     (value: number, key: number, iter: immutable.List<number>) => true,
     null
 );
-value = list.findLastKey(
+optionalValue = list.findLastKey(
     (value: number, key: number, iter: immutable.List<number>) => true,
     null
 );
-value = list.keyOf(0);
-value = list.lastKeyOf(0);
-value = list.max((valA: number, valB: number) => 0);
-value = list.maxBy<string>(
+optionalValue = list.keyOf(0);
+optionalValue = list.lastKeyOf(0);
+optionalValue = list.max((valA: number, valB: number) => 0);
+optionalValue = list.maxBy<string>(
     (value: number, key: number, iter: immutable.List<number>) => "foo",
     (valueA: string, valueB: string) => 0
 );
-value = list.min((valA: number, valB: number) => 0);
-value = list.minBy<string>(
+optionalValue = list.min((valA: number, valB: number) => 0);
+optionalValue = list.minBy<string>(
     (value: number, key: number, iter: immutable.List<number>) => "foo",
     (valueA: string, valueB: string) => 0
 );
@@ -279,7 +282,7 @@ let stack: immutable.Stack<number> = immutable.Stack<number>();
 bool = immutable.Stack.isStack(stack);
 stack = immutable.Stack.of<number>(0, 1, 2, 3, 4, 5);
 stack = immutable.Stack<number>(list);
-value = stack.peek();
+optionalValue = stack.peek();
 stack = stack.clear();
 stack = stack.unshift(0, 1, 2);
 stack = stack.unshiftAll(list);

--- a/immutable/index.d.ts
+++ b/immutable/index.d.ts
@@ -988,7 +988,7 @@ declare namespace Immutable {
     /**
      * Alias for `Stack.first()`.
      */
-    peek(): T;
+    peek(): T | undefined;
 
 
     // Persistent changes
@@ -1521,8 +1521,8 @@ declare namespace Immutable {
        * `index` may be a negative number, which indexes back from the end of the
        * Iterable. `s.get(-1)` gets the last item in the Iterable.
        */
-      get(index: number, notSetValue?: T): T;
-
+      get(index: number, notSetValue: T): T;
+      get(index: number): T | undefined;
 
       // Conversion to Seq
 
@@ -1758,7 +1758,8 @@ declare namespace Immutable {
      * so if `notSetValue` is not provided and this method returns `undefined`,
      * that does not guarantee the key was not found.
      */
-    get(key: K, notSetValue?: V): V;
+    get(key: K, notSetValue: V): V;
+    get(key: K): V | undefined;
 
     /**
      * True if a key exists within this `Iterable`, using `Immutable.is` to determine equality
@@ -1775,12 +1776,12 @@ declare namespace Immutable {
     /**
      * The first value in the Iterable.
      */
-    first(): V;
+    first(): V | undefined;
 
     /**
      * The last value in the Iterable.
      */
-    last(): V;
+    last(): V | undefined;
 
 
     // Reading deep values
@@ -2231,9 +2232,12 @@ declare namespace Immutable {
      */
     reduce<R>(
       reducer: (reduction: R, value: V, key: K, iter: this) => R,
-      initialReduction?: R,
+      initialReduction: R,
       context?: any
     ): R;
+    reduce<R>(
+      reducer: (reduction: R, value: V, key: K, iter: this) => R
+    ): R | undefined;
 
     /**
      * Reduces the Iterable in reverse (from the right side).
@@ -2243,9 +2247,12 @@ declare namespace Immutable {
      */
     reduceRight<R>(
       reducer: (reduction: R, value: V, key: K, iter: this) => R,
-      initialReduction?: R,
+      initialReduction: R,
       context?: any
     ): R;
+    reduceRight<R>(
+      reducer: (reduction: R, value: V, key: K, iter: this) => R
+    ): R | undefined;
 
     /**
      * True if `predicate` returns true for all entries in the Iterable.
@@ -2312,9 +2319,13 @@ declare namespace Immutable {
      */
     find(
       predicate: (value: V, key: K, iter: this) => boolean,
-      context?: any,
-      notSetValue?: V
+      context: any,
+      notSetValue: V
     ): V;
+    find(
+      predicate: (value: V, key: K, iter: this) => boolean,
+      context?: any
+    ): V | undefined;
 
     /**
      * Returns the last value for which the `predicate` returns true.
@@ -2323,18 +2334,26 @@ declare namespace Immutable {
      */
     findLast(
       predicate: (value: V, key: K, iter: this) => boolean,
-      context?: any,
-      notSetValue?: V
+      context: any,
+      notSetValue: V
     ): V;
+    findLast(
+      predicate: (value: V, key: K, iter: this) => boolean,
+      context?: any
+    ): V | undefined;
 
     /**
      * Returns the first [key, value] entry for which the `predicate` returns true.
      */
     findEntry(
       predicate: (value: V, key: K, iter: this) => boolean,
-      context?: any,
-      notSetValue?: V
+      context: any,
+      notSetValue: V
     ): [K, V];
+    findEntry(
+      predicate: (value: V, key: K, iter: this) => boolean,
+      context?: any
+    ): [K, V] | undefined;
 
     /**
      * Returns the last [key, value] entry for which the `predicate`
@@ -2344,9 +2363,13 @@ declare namespace Immutable {
      */
     findLastEntry(
       predicate: (value: V, key: K, iter: this) => boolean,
-      context?: any,
-      notSetValue?: V
+      context: any,
+      notSetValue: V
     ): [K, V];
+    findLastEntry(
+      predicate: (value: V, key: K, iter: this) => boolean,
+      context?: any
+    ): [K, V] | undefined;
 
     /**
      * Returns the key for which the `predicate` returns true.
@@ -2354,7 +2377,7 @@ declare namespace Immutable {
     findKey(
       predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
-    ): K;
+    ): K | undefined;
 
     /**
      * Returns the last key for which the `predicate` returns true.
@@ -2364,17 +2387,17 @@ declare namespace Immutable {
     findLastKey(
       predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
-    ): K;
+    ): K | undefined;
 
     /**
      * Returns the key associated with the search value, or undefined.
      */
-    keyOf(searchValue: V): K;
+    keyOf(searchValue: V): K | undefined;
 
     /**
      * Returns the last key associated with the search value, or undefined.
      */
-    lastKeyOf(searchValue: V): K;
+    lastKeyOf(searchValue: V): K | undefined;
 
     /**
      * Returns the maximum value in this collection. If any values are
@@ -2391,7 +2414,7 @@ declare namespace Immutable {
      * If `comparator` returns 0 and either value is NaN, undefined, or null,
      * that value will be returned.
      */
-    max(comparator?: (valueA: V, valueB: V) => number): V;
+    max(comparator?: (valueA: V, valueB: V) => number): V | undefined;
 
     /**
      * Like `max`, but also accepts a `comparatorValueMapper` which allows for
@@ -2403,7 +2426,7 @@ declare namespace Immutable {
     maxBy<C>(
       comparatorValueMapper: (value: V, key: K, iter: this) => C,
       comparator?: (valueA: C, valueB: C) => number
-    ): V;
+    ): V | undefined;
 
     /**
      * Returns the minimum value in this collection. If any values are
@@ -2420,7 +2443,7 @@ declare namespace Immutable {
      * If `comparator` returns 0 and either value is NaN, undefined, or null,
      * that value will be returned.
      */
-    min(comparator?: (valueA: V, valueB: V) => number): V;
+    min(comparator?: (valueA: V, valueB: V) => number): V | undefined;
 
     /**
      * Like `min`, but also accepts a `comparatorValueMapper` which allows for
@@ -2432,7 +2455,7 @@ declare namespace Immutable {
     minBy<C>(
       comparatorValueMapper: (value: V, key: K, iter: this) => C,
       comparator?: (valueA: C, valueB: C) => number
-    ): V;
+    ): V | undefined;
 
 
     // Comparison
@@ -2540,5 +2563,4 @@ declare namespace Immutable {
   export interface Iterator<T> {
     next(): { value: T; done: boolean; }
   }
-
 }

--- a/immutable/tsconfig.json
+++ b/immutable/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "noImplicitAny": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
I made return types union types with `undefined` in all the cases I could find that may return `undefined`. I also made callback arguments non optional when I knew they were always passed by the calling function. 

Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://facebook.github.io/immutable-js/docs/#/
- [ ] Increase the version number in the header if appropriate.

