### PR TITLE
Update typings for JW Player 6.

### DIFF
--- a/jwplayer/index.d.ts
+++ b/jwplayer/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for JW Player 6
 // Project: http://developer.longtailvideo.com/trac/
-// Definitions by: Martin Duparc <https://github.com/martinduparc/> and Isaac Schemm <https://github.com/IsaacSchemm/>
+// Definitions by: Martin Duparc <https://github.com/martinduparc/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // JW Player is the leading HTML5 & Flash video player, optimized for mobile and the desktop. Easy enough for beginners, advanced enough for pros.

--- a/jwplayer/index.d.ts
+++ b/jwplayer/index.d.ts
@@ -1,15 +1,17 @@
-// Type definitions for JW Player
+// Type definitions for JW Player 6
 // Project: http://developer.longtailvideo.com/trac/
-// Definitions by: Martin Duparc <https://github.com/martinduparc/>
+// Definitions by: Martin Duparc <https://github.com/martinduparc/> and Isaac Schemm <https://github.com/IsaacSchemm/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // JW Player is the leading HTML5 & Flash video player, optimized for mobile and the desktop. Easy enough for beginners, advanced enough for pros.
 
 interface JWPlayer {
 	addButton(icon: string, label: string, handler: () => void, id: string): void;
+	getAudioTracks(): any[];
 	getBuffer(): number;
 	getCaptionsList(): any[];
 	getControls(): boolean;
+	getCurrentAudioTrack(): number;
 	getCurrentCaptions(): number;
 	getCurrentQuality(): number;
 	getDuration(): number;
@@ -18,7 +20,7 @@ interface JWPlayer {
 	getMute(): boolean;
 	getPlaylist(): any[];
 	getPlaylistIndex(): number;
-	getPlaylistItem(index: number): any;
+	getPlaylistItem(index?: number): any;
 	getPosition(): number;
 	getQualityLevels(): any[];
 	getRenderingMode(): string;
@@ -26,34 +28,70 @@ interface JWPlayer {
 	getState(): string;
 	getVolume(): number;
 	getWidth(): number;
-	load(playlist: any): void;
+	load(playlist: any[]): void;
 	load(playlist: string): void;
+	onAdClick(callback: (o: { tag: string; }) => void): void;
+	onAdCompanions(callback: (o: {
+		tag: string;
+		companions: any[];
+	}) => void): void;
+	onAdComplete(callback: (o: { tag: string; }) => void): void;
+	onAdError(callback: (o: {
+		tag: string;
+		message: string;
+	}) => void): void;
+	onAdImpression(callback: (o: { tag: string; }) => void): void;
+	onAdPause(callback: (o: { tag: string; }) => void): void;
+	onAdPlay(callback: (o: { tag: string; }) => void): void;
+	onAdSkipped(callback: (o: { tag: string; }) => void): void;
+	onAdTime(callback: (o: {
+		tag: string;
+		position: number;
+		duration: number;
+		sequence: number;
+	}) => void): void;
+	onAudioTracks(callback: (o: { levels: any[]; }) => void): void;
+	onAudioTrackChange(callback: (o: { currentTrack: number; }) => void): void;
+	onBeforeComplete(callback: () => void): void;
 	onBeforePlay(callback: () => void): void;
-	onBuffer(callback: () => void): void;
+	onBuffer(callback: (o: { oldstate: string }) => void): void;
 	onBufferChange(callback: () => void): void;
-	onCaptionsChange(callback: () => void): void;
-	onCaptionsList(callback: () => void): void;
+	onCaptionsChange(callback: (o: { track: number; }) => void): void;
+	onCaptionsList(callback: (o: { tracks: any[]; }) => void): void;
 	onComplete(callback: () => void): void;
-	onControls(callback: () => void): void;
+	onControls(callback: (o: { controls: boolean; }) => void): void;
 	onDisplayClick(callback: () => void): void;
-	onError(callback: () => void): void;
-	onFullscreen(callback: () => void): void;
-	onIdle(callback: () => void): void;
-	onMeta(callback: () => void): void;
-	onMute(callback: () => void): void;
-	onPlay(callback: () => void): void;
+	onError(callback: (o: { message: string }) => void): void;
+	onFullscreen(callback: (o: { fullscreen: boolean; }) => void): void;
+	onIdle(callback: (o: { oldstate: string }) => void): void;
+	onLevelsChanged(callback: (o: { currentQuality: number }) => void): void;
+	onMeta(callback: (o: { metadata: any; }) => void): void;
+	onMute(callback: (o: { mute: boolean; }) => void): void;
+	onPause(callback: (o: { oldstate: string }) => void): void;
+	onPlay(callback: (o: { oldstate: string }) => void): void;
 	onPlaylist(callback: () => void): void;
 	onPlaylistItem(callback: () => void): void;
 	onPlaylistComplete(callback: () => void): void;
 	onReady(callback: () => void): void;
 	onResize(callback: () => void): void;
 	onQualityChange(callback: () => void): void;
-	onQualityLevels(callback: () => void): void;
-	onSeek(callback: () => void): void;
-	onTime(callback: () => void): void;
-	onVolume(callback: () => void): void;
-	pause(): void;
-	play(): void;
+	onQualityLevels(callback: (o: { levels: any[] }) => void): void;
+	onSeek(callback: (o: {
+		position: number;
+		offset: number;
+	}) => void): void;
+	onSetupError(callback: (o: {
+		fallback: boolean;
+		message: string;
+	}) => void): void;
+	onTime(callback: (o: {
+		duration: number;
+		position: number;
+	}) => void): void;
+	onVolume(callback: (o: { volume: number; }) => void): void;
+	pause(state?: boolean): void;
+	play(state?: boolean): void;
+	playAd(tag: string): void;
 	playlistItem(index: number): void;
 	registerPlugin(id: string, target: string, jsPlugin: () => void, swfURL?: string): void;
 	remove(): void;
@@ -61,9 +99,11 @@ interface JWPlayer {
 	resize(width: number, height: number): void;
 	seek(position: number): void;
 	setControls(controls: boolean): void;
+	setCurrentAudioTrack(index: number): void;
 	setCurrentCaptions(index: number): void;
 	setCurrentQuality(index: number): void;
-	setMute(state: boolean): void;
+	setFullscreen(state: boolean): void;
+	setMute(state?: boolean): void;
 	setup(options: any): JWPlayer;
 	setVolume(volume: number): void;
 	stop(): void;
@@ -71,6 +111,8 @@ interface JWPlayer {
 
 interface JWPlayerStatic {
 	(id: string): JWPlayer;
+	key: string;
+	version: string;
 }
 
 declare var jwplayer:JWPlayerStatic;

--- a/jwplayer/tsconfig.json
+++ b/jwplayer/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "noImplicitAny": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
Please fill in this template.

- [ ] Prefer to make your PR against the `types-2.0` branch.
- [ ] Test the change in your own code.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to  documentation or source code which provides context for the suggested changes: https://support.jwplayer.com/customer/portal/articles/2051720-jw6-javascript-api-reference
- [ ] Increase the version number in the header if appropriate.

Notes:
* Library documentation at https://support.jwplayer.com/customer/portal/articles/2051720-jw6-javascript-api-reference
* The documentation says there is no .setFullscreen, but both JW Player 6 and JW Player 7 will honor .setFullscreen(false).
* The current version, JW Player 7, is largely backwards-compatible, although new methods have been added (not included here) and .onSomething event handlers are deprecated in favor of .on('something').