### PR TITLE
archiver: append supports any readable stream

### DIFF
--- a/archiver/index.d.ts
+++ b/archiver/index.d.ts
@@ -32,7 +32,7 @@ declare namespace archiver {
 
     export interface Archiver extends STREAM.Transform {
         pipe(writeStream: FS.WriteStream): void;
-        append(source: FS.ReadStream | Buffer | string, name: nameInterface): void;
+        append(source: STREAM.Readable | Buffer | string, name: nameInterface): void;
 
         directory(dirpath: string, destpath: nameInterface | string): void;
         directory(dirpath: string, destpath: nameInterface | string, data: any | Function): void;


### PR DESCRIPTION
source can actually be any type of stream not only `FS.ReadStream`
See: https://archiverjs.com/docs/Archiver.html#append

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://archiverjs.com/docs/Archiver.html#append
- [x] Increase the version number in the header if appropriate.
