### PR TITLE
Adding missing import statements

### DIFF
--- a/highcharts/highcharts-more.d.ts
+++ b/highcharts/highcharts-more.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Maciej Suchecki <http://github.com/mc-suchecki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+import * as Highcharts from "highcharts";
+
 declare var HighchartsMore: (H: Highcharts.Static) => Highcharts.Static;
 export = HighchartsMore;
 export as namespace HighchartsMore;

--- a/highcharts/highstock.d.ts
+++ b/highcharts/highstock.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: David Deutsch <http://github.com/DavidKDeutsch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+import * as Highcharts from "highcharts";
+
 declare namespace __Highstock {
     interface ChartObject extends Highcharts.ChartObject {
         options: Options;

--- a/highcharts/highstock.d.ts
+++ b/highcharts/highstock.d.ts
@@ -98,27 +98,29 @@ declare namespace __Highstock {
 }
 
 
-interface JQuery {
-    highcharts(type: "StockChart"): __Highstock.ChartObject;
-    /**
-     * Creates a new Highcharts.Chart for the current JQuery selector; usually
-     * a div selected by $('#container')
-     * @param {Highcharts.Options} options Options for this chart
-     * @return current {JQuery} selector the current JQuery selector
-     **/
-    highcharts(type: "StockChart", options: __Highstock.Options): JQuery;
-    /**
-     * Creates a new Highcharts.Chart for the current JQuery selector; usually
-     * a div selected by $('#container')
-     * @param {Highcharts.Options} options Options for this chart
-     * @param callback Callback function used to manipulate the constructed chart instance
-     * @return current {JQuery} selector the current JQuery selector
-     **/
-    highcharts(type: "StockChart", options: __Highstock.Options, callback: (chart: __Highstock.ChartObject) => void): JQuery;
+declare global {
+    interface JQuery {
+        highcharts(type: "StockChart"): __Highstock.ChartObject;
+        /**
+         * Creates a new Highcharts.Chart for the current JQuery selector; usually
+         * a div selected by $('#container')
+         * @param {Highcharts.Options} options Options for this chart
+         * @return current {JQuery} selector the current JQuery selector
+         **/
+        highcharts(type: "StockChart", options: __Highstock.Options): JQuery;
+        /**
+         * Creates a new Highcharts.Chart for the current JQuery selector; usually
+         * a div selected by $('#container')
+         * @param {Highcharts.Options} options Options for this chart
+         * @param callback Callback function used to manipulate the constructed chart instance
+         * @return current {JQuery} selector the current JQuery selector
+         **/
+        highcharts(type: "StockChart", options: __Highstock.Options, callback: (chart: __Highstock.ChartObject) => void): JQuery;
 
 
-    highcharts(type: string): Highcharts.ChartObject;
-    highcharts(type: string, options: Highcharts.Options): JQuery;
-    highcharts(type: string, options: Highcharts.Options, callback: (chart: Highcharts.ChartObject) => void): JQuery;
+        highcharts(type: string): Highcharts.ChartObject;
+        highcharts(type: string, options: Highcharts.Options): JQuery;
+        highcharts(type: string, options: Highcharts.Options, callback: (chart: Highcharts.ChartObject) => void): JQuery;
+    }
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.


Context: webpack build fails if highcharts-more are imported:
```typescript
import 'highcharts/highcharts-more';
```

With an error
```
Error in bail mode: [default] C:/WORKS/web-app/node_modules/@types/highcharts/highcharts-more.d.ts:6:32
Identifier 'Highcharts' must be imported from a module
```