### PR TITLE
Fix module exports

### DIFF
--- a/csv-parse/index.d.ts
+++ b/csv-parse/index.d.ts
@@ -124,7 +124,7 @@ declare module "csv-parse" {
 
     let parse: parseIntf;
 
-    export = parse;
+    export { parse };
 }
 
 declare module "csv-parse/lib/sync" {
@@ -132,5 +132,5 @@ declare module "csv-parse/lib/sync" {
 
    function parse (input: string, options?: options): any;
 
-   export = parse;
+   export { parse };
 }


### PR DESCRIPTION
Please fill in this template.

- [ ] Prefer to make your PR against the `types-2.0` branch.
- [ ] Test the change in your own code.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

`export = parse;` was invalid syntax for exporting in Typescript, fixed to conform to proper ES6 export syntax.