### PR TITLE
Add dataSourceConfig typings to material-ui/AutoComplete

### DIFF
--- a/material-ui/index.d.ts
+++ b/material-ui/index.d.ts
@@ -533,6 +533,7 @@ declare namespace __MaterialUI {
         animated?: boolean;
         animation?: React.ComponentClass<Popover.PopoverAnimationProps>;
         dataSource: AutoCompleteDataSource;
+        dataSourceConfig?: { text: string; value: string; };
         disableFocusRipple?: boolean;
         errorStyle?: React.CSSProperties;
         errorText?: string;

--- a/material-ui/material-ui-tests.tsx
+++ b/material-ui/material-ui-tests.tsx
@@ -396,6 +396,11 @@ export class AutoCompleteExampleSimple extends React.Component<{}, {dataSource: 
     });
   };
 
+  dataSourceConfig = {
+    text: 'textKey',
+    value: 'valueKey',
+  };
+
   render() {
     return (
       <div>
@@ -413,6 +418,12 @@ export class AutoCompleteExampleSimple extends React.Component<{}, {dataSource: 
                     popoverProps={{
             animated: true
           }}
+        />
+        <AutoComplete
+          hintText="Type anything"
+          dataSource={this.state.dataSource}
+          dataSourceConfig={this.dataSourceConfig}
+          onUpdateInput={this.handleUpdateInput}
         />
       </div>
     );


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.material-ui.com/#/components/auto-complete
- [ ] Increase the version number in the header if appropriate. I haven't change the version because it is a small change, but does not broke the backward compatibility.

