### PR TITLE
Better type checking for combineReducers in redux, using Mapped Types in TypeScript 2.1

### DIFF
--- a/redux/index.d.ts
+++ b/redux/index.d.ts
@@ -57,8 +57,8 @@ declare namespace Redux {
     /**
      * Object whose values correspond to different reducer functions.
      */
-    interface ReducersMapObject {
-      [key: string]: Reducer<any>;
+    type ReducersMapObject<S> = {
+      [K in keyof S]: Reducer<S[K]>;
     }
 
     /**
@@ -79,7 +79,7 @@ declare namespace Redux {
      * @returns A reducer function that invokes every reducer inside the passed
      *   object, and builds a state object with the same shape.
      */
-    function combineReducers<S>(reducers: ReducersMapObject): Reducer<S>;
+    function combineReducers<S>(reducers: ReducersMapObject<S>): Reducer<S>;
 
 
     /* store */


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://redux.js.org/docs/api/combineReducers.html#combinereducersreducers
- [ ] Increase the version number in the header if appropriate.

