### PR TITLE
[@types/xml2js] Expose provided processors living in xml2js/lib/processors

### DIFF
--- a/xml2js/index.d.ts
+++ b/xml2js/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Michel Salib <https://github.com/michelsalib>, Jason McNeil <https://github.com/jasonrm>, Christopher Currens <https://github.com/ccurrens>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
+/// <reference path="./processors.d.ts" />
 
 export = xml2js;
 
@@ -29,8 +29,8 @@ declare namespace xml2js {
     interface Options {
         async?: boolean;
         attrkey?: string;
-        attrNameProcessors?: [(name: string) => string];
-        attrValueProcessors?: [(name: string) => string];
+        attrNameProcessors?: [(name: string) => any];
+        attrValueProcessors?: [(name: string) => any];
         charkey?: string;
         charsAsChildren?: boolean;
         childkey?: string;
@@ -45,10 +45,10 @@ declare namespace xml2js {
         normalize?: boolean;
         normalizeTags?: boolean;
         strict?: boolean;
-        tagNameProcessors?: [(name: string) => string];
+        tagNameProcessors?: [(name: string) => any];
         trim?: boolean;
         validator?: Function;
-        valueProcessors?: [(name: string) => string];
+        valueProcessors?: [(name: string) => any];
         xmlns?: boolean;
     }
 
@@ -75,4 +75,3 @@ declare namespace xml2js {
         toString(): string;
     }
 }
-

--- a/xml2js/processors.d.ts
+++ b/xml2js/processors.d.ts
@@ -1,0 +1,11 @@
+declare module 'xml2js/lib/processors' {
+    export function firstCharLowerCase(name: string): string;
+
+    export function normalize(name: string): string;
+
+    export function parseBooleans(name: string): boolean;
+
+    export function parseNumbers(name: string): number;
+
+    export function stripPrefix(name: string): string;
+}

--- a/xml2js/xml2js-tests.ts
+++ b/xml2js/xml2js-tests.ts
@@ -1,6 +1,7 @@
 /// <reference types="node"/>
 
 import xml2js = require('xml2js');
+import * as processors from 'xml2js/lib/processors';
 
 xml2js.parseString('<root>Hello xml2js!</root>', (err: any, result: any) => { });
 
@@ -30,6 +31,13 @@ xml2js.parseString('<root>Hello xml2js!</root>', {
     attrValueProcessors: undefined,
     tagNameProcessors: undefined,
     valueProcessors: undefined
+}, (err: any, result: any) => { });
+
+xml2js.parseString('<root>Hello xml2js!</root>', {
+    attrNameProcessors: [processors.firstCharLowerCase],
+    attrValueProcessors: [processors.normalize],
+    tagNameProcessors: [processors.stripPrefix],
+    valueProcessors: [processors.parseBooleans, processors.parseNumbers]
 }, (err: any, result: any) => { });
 
 var builder = new xml2js.Builder({


### PR DESCRIPTION
Documentation mentions there are several out-of-the-box processors that can be used to transform the resulting js object representing the input xml, but they are not accessible in typescript because they are not present in the typing definitions.

Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Leonidas-from-XIV/node-xml2js#processing-attribute-tag-names-and-values
- [ ] Increase the version number in the header if appropriate.

