### PR TITLE
Add success flag property

### DIFF
--- a/jsonschema/index.d.ts
+++ b/jsonschema/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for jsonschema
 // Project: https://github.com/tdegrunt/jsonschema
-// Definitions by: Vlado Tešanovic <https://github.com/vladotesanovic>
+// Definitions by: Vlado Tešanovic <https://github.com/vladotesanovic>, kinesivan <https://github.com/kinesivan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 declare module "jsonschema" {
 
@@ -11,6 +11,7 @@ declare module "jsonschema" {
         propertyPath: string;
         name: string;
         schema: {};
+        valid: boolean;
         throwError: any;
         disableFormat: boolean;
     }


### PR DESCRIPTION
JSONSchema validator results contain a `valid` bool that certifies whether the JSON validation came back positive or not. This property was missing from the definitions file in my project, so I had to add it locally. See [source code for context.](https://github.com/tdegrunt/jsonschema/blob/master/lib/index.d.ts#L25)

Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.