### PR TITLE
[types-2.0] traverse: added this context, static calling and docs

### DIFF
--- a/traverse/index.d.ts
+++ b/traverse/index.d.ts
@@ -1,21 +1,199 @@
 // Type definitions for traverse 0.6.6
 // Project: https://github.com/substack/js-traverse
-// Definitions by: newclear <https://github.com/newclear>
-// Definitions: https://github.com/newclear/DefinitelyTyped
+// Definitions by: Bazyli Brzóska <https://invent.life>, newclear <https://github.com/newclear>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+interface Traverse<T> {
+  /**
+   * Get the element at the array `path`.
+   */
+  get(path: string[]): any;
 
-interface Traverse {
-    get(paths: string[]): any;
-    has(paths: string[]): boolean;
-    set(paths: string[], value: any): any;
-    map(cb: (v: any) => void): any;
-    forEach(cb: (v: any) => void): any;
-    reduce(cb: (acc: any, v: any) => void, init?: any): any;
-    paths(): string[];
-    nodes(): any[];
-    clone(): any;
+  /**
+   * Return whether the element at the array `path` exists.
+   */
+  has(path: string[]): boolean;
+
+  /**
+   * Set the element at the array `path` to `value`.
+   */
+  set(path: string[], value: any): any;
+
+  /**
+   * Execute `fn` for each node in the object and return a new object with the results of the walk. To update nodes in the result use `this.update(value)`.
+   */
+  map(cb: (this: TraverseContext, v: any) => void): any;
+
+  /**
+   * Execute `fn` for each node in the object but unlike `.map()`, when `this.update()` is called it updates the object in-place.
+   */
+  forEach(cb: (this: TraverseContext, v: any) => void): any;
+
+  /**
+   * For each node in the object, perform a [left-fold](http://en.wikipedia.org/wiki/Fold_(higher-order_function)) with the return value of `fn(acc, node)`.
+   * 
+   * If `init` isn't specified, `init` is set to the root object for the first step and the root element is skipped.
+   */
+  reduce(cb: (this: TraverseContext, acc: any, v: any) => void, init?: any): any;
+
+  /**
+   * Return an `Array` of every possible non-cyclic path in the object. 
+   * Paths are `Array`s of string keys.
+   */
+  paths(): string[];
+
+  /**
+   * Return an `Array` of every node in the object.
+   */
+  nodes(): any[];
+
+  /**
+   * Create a deep clone of the object.
+   */
+  clone(): T;
 }
 
-declare function traverse(obj: any): Traverse;
+interface StaticTraverse {
+  /**
+   * Get the element at the array `path`.
+   */
+  get(obj: any, path: string[]): any;
+  
+  /**
+   * Return whether the element at the array `path` exists.
+   */
+  has(obj: any, path: string[]): boolean;
+
+  /**
+   * Set the element at the array `path` to `value`.
+   */
+  set(obj: any, path: string[], value: any): any;
+
+  /**
+   * Execute `fn` for each node in the object and return a new object with the results of the walk. To update nodes in the result use `this.update(value)`.
+   */
+  map(obj: any, cb: (this: TraverseContext, v: any) => void): any;
+
+  /**
+   * Execute `fn` for each node in the object but unlike `.map()`, when `this.update()` is called it updates the object in-place.
+   */
+  forEach(obj: any, cb: (this: TraverseContext, v: any) => void): any;
+
+  /**
+   * For each node in the object, perform a [left-fold](http://en.wikipedia.org/wiki/Fold_(higher-order_function)) with the return value of `fn(acc, node)`.
+   * 
+   * If `init` isn't specified, `init` is set to the root object for the first step and the root element is skipped.
+   */
+  reduce(obj: any, cb: (this: TraverseContext, acc: any, v: any) => void, init?: any): any;
+
+  /**
+   * Return an `Array` of every possible non-cyclic path in the object. 
+   * Paths are `Array`s of string keys.
+   */
+  paths(obj: any): string[];
+
+  /**
+   * Return an `Array` of every node in the object.
+   */
+  nodes(obj: any): any[];
+
+  /**
+   * Create a deep clone of the object.
+   */
+  clone<T>(obj: T): T;
+}
+
+interface TraverseContext {
+  /**
+   * The present node on the recursive walk
+   */
+  node: any;
+
+  /**
+   * An array of string keys from the root to the present node
+   */
+  path: string[]
+
+  /**
+   * The context of the node's parent.
+   * This is `undefined` for the root node.
+   */
+  parent: TraverseContext | undefined;
+
+  /**
+   * The name of the key of the present node in its parent.
+   * This is `undefined` for the root node.
+   */
+  key: string | undefined;
+
+  /**
+   * Whether the present node is the root node
+   */
+  isRoot: boolean;
+  /**
+   * Whether the present node is not the root node
+   */
+  notRoot: boolean;
+
+  /**
+   * Whether or not the present node is a leaf node (has no children)
+   */
+  isLeaf: boolean;
+  /**
+   * Whether or not the present node is not a leaf node (has children)
+   */
+  notLeaf: boolean;
+
+  /**
+   * Depth of the node within the traversal
+   */
+  level: number;
+
+  /**
+   * If the node equals one of its parents, the `circular` attribute is set to the context of that parent and the traversal progresses no deeper.
+   */
+  circular: TraverseContext | undefined;
+
+  /**
+   * Set a new value for the present node.
+   * 
+   * All the elements in `value` will be recursively traversed unless `stopHere` is true (false by default).
+   */
+  update(value: any, stopHere?: boolean): void;
+
+  /**
+   * Remove the current element from the output. If the node is in an Array it will be spliced off. Otherwise it will be deleted from its parent.
+   */
+  remove(stopHere?: boolean): void;
+
+  /**
+   * Delete the current element from its parent in the output. Calls `delete` even on Arrays.
+   */
+  delete(stopHere?: boolean): void;
+
+  /**
+   * Call this function before any of the children are traversed.
+   * You can assign into `this.keys` here to traverse in a custom order.
+   */
+  before(callback: (this: TraverseContext, value: any) => void): void;
+
+  /**
+   * Call this function after any of the children are traversed.
+   */
+  after(callback: (this: TraverseContext, value: any) => void): void;
+
+  /**
+   * Call this function before each of the children are traversed.
+   */
+  pre(callback: (this: TraverseContext, child: any) => void): void;
+
+  /**
+   * Call this function after each of the children are traversed.
+   */
+  pre(callback: (this: TraverseContext, child: any) => void): void;
+}
+
+declare function traverseFunction<T>(obj: T): Traverse<T>;
+declare const traverse: typeof traverseFunction & StaticTraverse;
 
 export = traverse;

--- a/traverse/index.d.ts
+++ b/traverse/index.d.ts
@@ -172,13 +172,13 @@ interface TraverseContext {
   delete(stopHere?: boolean): void;
 
   /**
-   * Call this function before any of the children are traversed.
+   * Call this function before all of the children are traversed.
    * You can assign into `this.keys` here to traverse in a custom order.
    */
   before(callback: (this: TraverseContext, value: any) => void): void;
 
   /**
-   * Call this function after any of the children are traversed.
+   * Call this function after all of the children are traversed.
    */
   after(callback: (this: TraverseContext, value: any) => void): void;
 
@@ -190,7 +190,7 @@ interface TraverseContext {
   /**
    * Call this function after each of the children are traversed.
    */
-  pre(callback: (this: TraverseContext, child: any) => void): void;
+  post(callback: (this: TraverseContext, child: any) => void): void;
 }
 
 declare function traverseFunction<T>(obj: T): Traverse<T>;


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
Not a version change: added `this` context, documentation for each property and made `.clone()` generic.
- [x] Increase the version number in the header if appropriate.