### PR TITLE
add __moduleName to SystemJS typedefs

### DIFF
--- a/systemjs/index.d.ts
+++ b/systemjs/index.d.ts
@@ -12,7 +12,7 @@ declare namespace SystemJSLoader {
 
     /**
      * The following module formats are supported:
-     * 
+     *
      * - esm: ECMAScript Module (previously referred to as es6)
      * - cjs: CommonJS
      * - amd: Asynchronous Module Definition
@@ -101,7 +101,7 @@ declare namespace SystemJSLoader {
          * Use this option to disable this iteration and copying of the exports.
          */
         esmExports?: boolean;
-        
+
         /**
          * To ignore resources that shouldn't be traced as part of the build.
          * Use with the SystemJS Builder. (https://github.com/systemjs/builder#ignore-resources)
@@ -218,7 +218,7 @@ declare namespace SystemJSLoader {
          * Sets the module name of the transpiler to be used for loading ES6 modules.
          */
         transpiler?: Transpiler;
-        
+
         trace?: boolean;
 
         /**
@@ -324,6 +324,8 @@ declare namespace SystemJSLoader {
 }
 
 declare var SystemJS: SystemJSLoader.System;
+
+declare var __moduleName: string;
 
 /**
  * @deprecated use SystemJS https://github.com/systemjs/systemjs/releases/tag/0.19.10


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

I'm not 100% sure if this is the correct place though, but according to this https://github.com/systemjs/systemjs/issues/1502 issue thread, I had to use `__moduleName` instead of `module.id` to get things working. `__moduleName` was nog recognised by TypeScript so I thought that it made sense to add it.

Feedback is more then welcome.

// @guybedford @asapach