### PR TITLE
Added type declarations for parseurl.

### DIFF
--- a/parseurl/index.d.ts
+++ b/parseurl/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for parseurl
+// Project: https://github.com/pillarjs/parseurl
+// Definitions by: Stefan Reichel <https://github.com/bomret>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { IncomingMessage } from "http";
+import { Url } from "url";
+
+declare function parseurl(req: IncomingMessage): Url | undefined;
+
+declare namespace parseurl {
+    export function original(req: IncomingMessage): Url | undefined;
+}
+
+export = parseurl;

--- a/parseurl/parseurl-tests.ts
+++ b/parseurl/parseurl-tests.ts
@@ -1,0 +1,6 @@
+import parseurl = require("parseurl");
+
+const req: any = {};
+
+const parsedUrl = parseurl(req);
+const originalParsedUrl = parseurl.original(req);

--- a/parseurl/tsconfig.json
+++ b/parseurl/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parseurl-tests.ts"
+    ]
+}

--- a/parseurl/tslint.json
+++ b/parseurl/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "../tslint.json" }


### PR DESCRIPTION
- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Run `tsc` without errors.
- [x] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.