### PR TITLE
Add types for electron-debug 1.1.0

### DIFF
--- a/electron-debug/electron-debug-tests.ts
+++ b/electron-debug/electron-debug-tests.ts
@@ -1,0 +1,8 @@
+import debug = require('electron-debug')
+
+debug({enabled: false});
+
+debug({showDevTools: true});
+debug({showDevTools: 'right'});
+debug({showDevTools: 'bottom'});
+debug({showDevTools: 'undocked'});

--- a/electron-debug/index.d.ts
+++ b/electron-debug/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for electron-debug v1.1.0
+// Project: https://github.com/sindresorhus/electron-debug
+// Definitions by: Daniel Perez Alvarez <https://github.com/unindented>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Install keyboard shortcuts and optionally activate DevTools on each
+ * created BrowserWindow.
+ */
+declare function electronDebug(options: {
+    /** Enable debug options. */
+    enabled?: boolean;
+    /** Show DevTools on each created BrowserWindow. */
+    showDevTools?: boolean | 'right' | 'bottom' | 'undocked';
+}): void;
+
+export = electronDebug;

--- a/electron-debug/tsconfig.json
+++ b/electron-debug/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "electron-debug-tests.ts"
+    ]
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Run `tsc` without errors.
- [x] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.
