### PR TITLE
Fix aggregation unit type from "Number" to "string".

### DIFF
--- a/elastic.js/elastic.js.d.ts
+++ b/elastic.js/elastic.js.d.ts
@@ -2350,7 +2350,7 @@ declare module elasticjs {
      Sets the distance unit.  Valid values are:
      in, yd, ft, km, NM, mm, cm, mi, and m.
      */
-    unit(unit: Number): GeoDistanceAggregation;
+    unit(unit: string): GeoDistanceAggregation;
 
   }
 
@@ -2485,7 +2485,7 @@ declare module elasticjs {
      Sets the distance unit.  Valid values are "mi" for miles or "km"
      for kilometers. Defaults to "km".
      */
-    unit(unit: Number): GeoDistanceFacet;
+    unit(unit: string): GeoDistanceFacet;
 
     /*
      Allows you to specify a different value field to aggrerate over.
@@ -2582,7 +2582,7 @@ declare module elasticjs {
      Sets the distance unit.  Valid values are "mi" for miles or "km"
      for kilometers. Defaults to "km".
      */
-    unit(unit: Number): GeoDistanceFilter;
+    unit(unit: string): GeoDistanceFilter;
 
   }
 
@@ -2706,7 +2706,7 @@ declare module elasticjs {
      Sets the distance unit.  Valid values are "mi" for miles or "km"
      for kilometers. Defaults to "km".
      */
-    unit(unit: Number): GeoDistanceRangeFilter;
+    unit(unit: string): GeoDistanceRangeFilter;
 
   }
 
@@ -7413,7 +7413,7 @@ declare module elasticjs {
 
      Valid during sort types:  geo distance
      */
-    unit(unit: Number): Sort;
+    unit(unit: string): Sort;
 
   }
 


### PR DESCRIPTION
Please fill in this template.

- [ ] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geodistance-aggregation.html
- [ ] Increase the version number in the header if appropriate.

Aggregation unit values are supposed to be a string (like "km", "mi", "m" and so on) and not a Numbers.