### PR TITLE
Axios: give an index type to response headers

### DIFF
--- a/axios/axios-tests.ts
+++ b/axios/axios-tests.ts
@@ -80,7 +80,11 @@ var axiosInstance = axios.create({
     timeout: 1000
 });
 
-axiosInstance.request({url: "issues/1"});
+axiosInstance.request({url: "issues/1"}).then(res => {
+    if (res.headers['content-type'].startsWith('application/json')) {
+        throw new Error('Unexpected content-type');
+    }
+});
 
 axios.all<Repository, Repository>([getRepoDetails, getRepoDetails]).then(([repo1, repo2]) => {
     var sumIds = repo1.data.id + repo2.data.id;

--- a/axios/index.d.ts
+++ b/axios/index.d.ts
@@ -159,7 +159,7 @@ declare namespace Axios {
         /**
          * headers that the server responded with
          */
-        headers: Object;
+        headers: {[index: string]: any};
 
         /**
          * config that was provided to `axios` for the request


### PR DESCRIPTION
- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mzabriskie/axios/blob/49768168/lib/helpers/parseHeaders.js (only used with the XMLHttpRequest adapter; node http adapter uses node's parser)
- [x] Increase the version number in the header if appropriate.

Lack of indexing in `AxiosXHR#headers` made it unusable without casting.

I am not sure what type to use for the value, though. It is _almost always_ `string`, but when using the nodejs `http` adapter, [the `set-cookies` header is a `string[]`](https://nodejs.org/api/http.html#http_message_headers). Setting it to `string | string[]` would force "innocent" users to always check if it's a `string` or `string[]`, and adding an explicit `'set-cookie'?: string[]` entry doesn't type-check.