### PR TITLE
node.d.ts, Streams data event callback should provide any object

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -3368,7 +3368,7 @@ declare module "stream" {
 
             on(event: string, listener: Function): this;
             on(event: "close", listener: () => void): this;
-            on(event: "data", listener: (chunk: Buffer | string) => void): this;
+            on(event: "data", listener: (chunk: any) => void): this;
             on(event: "end", listener: () => void): this;
             on(event: "readable", listener: () => void): this;
             on(event: "error", listener: (err: Error) => void): this;


### PR DESCRIPTION
When `objectMode` is `true`, the data event will provide JSON is the callback and not just `string | Buffer`. For this reason, the callback argument type should be any.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/stream.html#stream_implementing_a_writable_stream
- [x] Increase the version number in the header if appropriate.

If ObjectMode is true, the data event can provide arbitrary objects in the callback