### PR TITLE
service_worker_api: Fixed cache.addAll argument.

### DIFF
--- a/service_worker_api/index.d.ts
+++ b/service_worker_api/index.d.ts
@@ -305,7 +305,7 @@ interface Cache {
      *
      * @param request An array of Request objects you want to add to the cache.
      */
-    addAll(...request: Array<Request | string>): Promise<void>;
+    addAll(requests: Array<Request | string>): Promise<void>;
 
     /**
      * Adds additional key/value pairs to the current Cache object.

--- a/service_worker_api/service_worker_api-test.ts
+++ b/service_worker_api/service_worker_api-test.ts
@@ -35,7 +35,7 @@ self.addEventListener('install', function(event: InstallEvent) {
 self.addEventListener('install', function(event: InstallEvent) {
     event.waitUntil(
         self.caches.open('v1').then(function(cache) {
-            return cache.addAll(
+            return cache.addAll([
                 '/sw-test/',
                 '/sw-test/index.html',
                 '/sw-test/style.css',
@@ -46,7 +46,7 @@ self.addEventListener('install', function(event: InstallEvent) {
                 '/sw-test/gallery/bountyHunters.jpg',
                 '/sw-test/gallery/myLittleVader.jpg',
                 '/sw-test/gallery/snowTroopers.jpg'
-            );
+            ]);
         })
     );
 });


### PR DESCRIPTION
cache.addAll expects an array of requests, not multiple arguments.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/API/Cache/addAll

