### PR TITLE
Fix node-fetch - remove Blob and FormData properties as they don't exist. Add Buffer and Body properties as they do.

### DIFF
--- a/node-fetch/index.d.ts
+++ b/node-fetch/index.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Torsten Werner <https://github.com/torstenwerner>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+///<reference types="node" />
+
 export class Request extends Body {
 	constructor(input: string | Request, init?: RequestInit);
 	method: string;
@@ -53,12 +55,12 @@ export class Headers {
 
 export class Body {
 	bodyUsed: boolean;
+	body: NodeJS.ReadableStream;
 	arrayBuffer(): Promise<ArrayBuffer>;
-	blob(): Promise<Blob>;
-	formData(): Promise<FormData>;
 	json(): Promise<any>;
 	json<T>(): Promise<T>;
 	text(): Promise<string>;
+	buffer(): Promise<Buffer>;
 }
 
 export class Response extends Body {
@@ -83,7 +85,7 @@ interface ResponseInit {
 }
 
 type HeaderInit = Headers | Array<string>;
-type BodyInit = ArrayBuffer | ArrayBufferView | Blob | FormData | string;
+type BodyInit = ArrayBuffer | ArrayBufferView | string | NodeJS.ReadableStream;
 type RequestInfo = Request | string;
 
 export default function fetch(url: string | Request, init?: RequestInit): Promise<Response>;

--- a/node-fetch/node-fetch-tests.ts
+++ b/node-fetch/node-fetch-tests.ts
@@ -1,4 +1,4 @@
-﻿import fetch, { Headers, Request, RequestInit, Response } from 'node-fetch';
+import fetch, { Headers, Request, RequestInit, Response } from 'node-fetch';
 
 function test_fetchUrlWithOptions() {
 	var headers = new Headers();

--- a/node-fetch/tsconfig.json
+++ b/node-fetch/tsconfig.json
@@ -10,7 +10,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "lib": ["es5", "es6"]
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
- [ ] Increase the version number in the header if appropriate.

The typings for node-fetch originate from cloning whatwg-fetch. This is not quite applicable as whatwg-fetch exposes the .blob and .formData properties on responses, which aren't available in node-fetch as Blob and FormData aren't in Node at all. Indeed, these mean a project including node-fetch without the lib.dom.d.ts will be unable to build at all due to references to Blob and FormData!
This PR removes the properties and references to non-existing types, as well as editing tsconfig.json to ensure no reliance on other things from lib.dom.d.ts.

It also adds the `body` and `buffer` properties, exposed in the readme: https://github.com/bitinn/node-fetch

Jarrad