### PR TITLE
InferableComponentEnhancer must be exported

### DIFF
--- a/recompose/index.d.ts
+++ b/recompose/index.d.ts
@@ -21,7 +21,7 @@ declare module 'recompose' {
     interface ComponentEnhancer<TInner, TOutter> {
         (component: Component<TInner>): ComponentClass<TOutter>;
     }
-    interface InferableComponentEnhancer {
+    export interface InferableComponentEnhancer {
         <P, TComp extends (Component<P>)>(component: TComp): TComp;
     }
 


### PR DESCRIPTION
In case you use recompose definitions with `"declaration": true,` you will face 
`[ts] Exported variable 'withTranslate' has or is using name 'InferableComponentEnhancer' from external module 'recompose' but cannot be named` and so for other method which returns `InferableComponentEnhancer `.

Obviously `InferableComponentEnhancer ` are to be exported