### PR TITLE
Allow stringifying any type of object

### DIFF
--- a/query-string/query-string.d.ts
+++ b/query-string/query-string.d.ts
@@ -4,8 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module "query-string" {
-    type value = string | boolean | number;
-                
+
     interface StringifyOptions { strict?: boolean; encode?: boolean; }
 
     /**
@@ -20,7 +19,7 @@ declare module "query-string" {
      *
      * @param obj
      */
-    export function stringify(obj: { [key: string]: value | value[] }, options?: StringifyOptions): string;
+    export function stringify(obj: any, options?: StringifyOptions): string;
 
     /**
      * Extract a query string from a URL that can be passed into .parse().


### PR DESCRIPTION
Please fill in this template.

- [ ] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sindresorhus/query-string
- [ ] Increase the version number in the header if appropriate.

This patch allows stringifying any type of object. Previously, due to the type signature, it was not allowed to use any types other than plain objects, even if they were simple DTOs.