### PR TITLE
Fix getLocation return type

### DIFF
--- a/webdriverio/index.d.ts
+++ b/webdriverio/index.d.ts
@@ -313,11 +313,11 @@ declare namespace WebdriverIO {
             callback: (err: any, html: string | string[]) => P
         ): Client<P>;
 
-        getLocation(selector: string): Client<Size>;
+        getLocation(selector: string): Client<Location>;
         getLocation(selector: string, axis: string): Client<number>;
         getLocation<P>(
             selector: string,
-            callback: (err: any, size: Size) => P
+            callback: (err: any, location: Location) => P
         ): Client<P>;
         getLocation<P>(
             selector: string,
@@ -325,11 +325,11 @@ declare namespace WebdriverIO {
             callback: (err: any, location: number) => P
         ): Client<P>;
 
-        getLocationInView(selector: string): Client<Size | Size[]>;
+        getLocationInView(selector: string): Client<Location | Location[]>;
         getLocationInView(selector: string, axis: string): Client<number | number[]>;
         getLocationInView<P>(
             selector: string,
-            callback: (err: any, size: Size | Size[]) => P
+            callback: (err: any, location: Location | Location[]) => P
         ): Client<P>;
         getLocationInView<P>(
             selector: string,
@@ -395,7 +395,7 @@ declare namespace WebdriverIO {
         value: any;
     }
 
-    export interface Location {
+    export interface GeoLocation {
         latitude: number;
         longitude: number;
         altitude: number;


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.
   _no lint_

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://webdriver.io/api/property/getLocation.html
- [x] Increase the version number in the header if appropriate.
   _no need_

This is a correction of the `getLocation` and `getLocationInView` return types.
In the types is `Size` but it's supposed to be `Location` according to documentation and use.
Also renamed `GeoLocation` type because it was being incorrectly merged with `Location` type.