### PR TITLE
Add responseType to client options

### DIFF
--- a/auth0-js/auth0-js.d.ts
+++ b/auth0-js/auth0-js.d.ts
@@ -33,6 +33,7 @@ interface Auth0Static {
 /** Represents constructor options for the Auth0 client. */
 interface Auth0ClientOptions {
     clientID: string;
+    responseType: string;
     callbackURL: string;
     callbackOnLocationHash?: boolean;
     domain: string;


### PR DESCRIPTION
Add responseType as per the Angular2 quickstart [here](https://auth0.com/docs/quickstart/spa/angular2/02-custom-login).

    auth0 = new Auth0({
      domain: 'YOUR_AUTH0_DOMAIN',
      clientID: 'YOUR_CLIENT_ID',
      responseType: 'token',
      callbackURL: 'https://YOUR_APP/callback',
    });