### PR TITLE
Add responseType to signup options

### DIFF
--- a/auth0-js/auth0-js.d.ts
+++ b/auth0-js/auth0-js.d.ts
@@ -106,6 +106,7 @@ interface Auth0LoginOptions {
 
 interface Auth0SignupOptions extends Auth0LoginOptions {
     auto_login: boolean;
+    responseType: string;
 }
 
 interface Auth0Error {

--- a/auth0-js/auth0-js.d.ts
+++ b/auth0-js/auth0-js.d.ts
@@ -96,6 +96,7 @@ interface Auth0PopupOptions {
 
 interface Auth0LoginOptions {
     auto_login?: boolean;
+    responseType?: string;
     connection?: string;
     email?: string;
     username?: string;
@@ -106,7 +107,6 @@ interface Auth0LoginOptions {
 
 interface Auth0SignupOptions extends Auth0LoginOptions {
     auto_login: boolean;
-    responseType: string;
 }
 
 interface Auth0Error {


### PR DESCRIPTION
Add responseType to the signup options as per the [Auth0 Angular2 quickstart](https://auth0.com/docs/quickstart/spa/angular2/02-custom-login)

    this.auth0.signup({
        connection: 'Username-Password-Authentication',
        responseType: 'token',
        ....