### PR TITLE
Add is-windows type definition

### DIFF
--- a/is-windows/index.d.ts
+++ b/is-windows/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for is-windows 0.2
+// Project: https://github.com/jonschlinkert/is-windows
+// Definitions by: Mizunashi Mana <https://github.com/mizunashi-mana>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function isWindows(): boolean;
+declare namespace isWindows {}
+export = isWindows;

--- a/is-windows/is-windows-tests.ts
+++ b/is-windows/is-windows-tests.ts
@@ -1,0 +1,3 @@
+import * as isWindows from 'is-windows';
+
+var bool: boolean = isWindows();

--- a/is-windows/tsconfig.json
+++ b/is-windows/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "is-windows-tests.ts"
+    ]
+}

--- a/is-windows/tslint.json
+++ b/is-windows/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "../tslint.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Run `tsc` without errors.
- [x] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.
