### PR TITLE
Ceymard leaflet

### DIFF
--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -44,11 +44,9 @@ declare namespace L {
 
     export interface CRS {
         latLngToPoint(latlng: LatLngExpression, zoom: number): Point;
-        pointToLatLng(point: Point): LatLng;
-        pointToLatLng(point: PointTuple): LatLng;
+        pointToLatLng(point: PointExpression): LatLng;
         project(latlng: LatLngExpression): Point;
-        unproject(point: Point): LatLng;
-        unproject(point: PointTuple): LatLng;
+        unproject(point: PointExpression): LatLng;
         scale(zoom: number): number;
         zoom(scale: number): number;
         getProjectedBounds(zoom: number): Bounds;
@@ -71,8 +69,7 @@ declare namespace L {
 
     export interface Projection {
         project(latlng: LatLngExpression): Point;
-        unproject(point: Point): LatLng;
-        unproject(point: PointTuple): LatLng;
+        unproject(point: PointExpression): LatLng;
 
         bounds: LatLngBounds;
     }
@@ -153,25 +150,18 @@ declare namespace L {
 
     export interface Point {
         clone(): Point;
-        add(otherPoint: Point): Point; // investigate if this mutates or returns a new instance
-        add(otherPoint: PointTuple): Point;
-        subtract(otherPoint: Point): Point;
-        subtract(otherPoint: PointTuple): Point;
+        add(otherPoint: PointExpression): Point; // investigate if this mutates or returns a new instance
+        subtract(otherPoint: PointExpression): Point;
         divideBy(num: number): Point;
         multiplyBy(num: number): Point;
-        scaleBy(scale: Point): Point;
-        scaleBy(scale: PointTuple): Point;
-        unscaleBy(scale: Point): Point;
-        unscaleBy(scale: PointTuple): Point;
+        scaleBy(scale: PointExpression): Point;
+        unscaleBy(scale: PointExpression): Point;
         round(): Point;
         floor(): Point;
         ceil(): Point;
-        distanceTo(otherPoint: Point): Point;
-        distanceTo(otherPoint: PointTuple): Point;
-        equals(otherPoint: Point): boolean;
-        equals(otherPoint: PointTuple): boolean;
-        contains(otherPoint: Point): boolean;
-        contains(otherPoint: PointTuple): boolean;
+        distanceTo(otherPoint: PointExpression): Point;
+        equals(otherPoint: PointExpression): boolean;
+        contains(otherPoint: PointExpression): boolean;
         toString(): string;
     }
 
@@ -186,16 +176,14 @@ declare namespace L {
     export type BoundsLiteral = Array<PointTuple>;
 
     export interface Bounds {
-        extend(point: Point): this;
-        extend(point: PointTuple): this;
+        extend(point: PointExpression): this;
         getCenter(round?: boolean): Point;
         getBottomLeft(): Point;
         getTopRight(): Point;
         getSize(): Point;
         contains(otherBounds: Bounds): boolean;
         contains(otherBounds: BoundsLiteral): boolean;
-        contains(point: Point): boolean;
-        contains(point: PointTuple): boolean;
+        contains(point: PointExpression): boolean;
         intersects(otherBounds: Bounds): boolean;
         intersects(otherBounds: BoundsLiteral): boolean;
         overlaps(otherBounds: Bounds): boolean;
@@ -207,9 +195,7 @@ declare namespace L {
 
     type BoundsExpression = Bounds | BoundsLiteral;
 
-    export function bounds(topLeft: Point, bottomRight: Point): Bounds;
-
-    export function bounds(topLeft: PointTuple, bottomRight: PointTuple): Bounds;
+    export function bounds(topLeft: PointExpression, bottomRight: PointExpression): Bounds;
 
     export function bounds(points: Array<Point>): Bounds;
 
@@ -1229,8 +1215,7 @@ declare namespace L {
         fitBounds(bounds: LatLngBoundsLiteral, options: FitBoundsOptions): this;
         fitWorld(options?: FitBoundsOptions): this;
         panTo(latlng: LatLngExpression, options?: PanOptions): this;
-        panBy(offset: Point): this;
-        panBy(offset: PointTuple): this;
+        panBy(offset: PointExpression): this;
         setMaxBounds(bounds: LatLngBounds): this;
         setMaxBounds(bounds: LatLngBoundsLiteral): this;
         setMinZoom(zoom: number): this;
@@ -1271,16 +1256,13 @@ declare namespace L {
         getZoomScale(toZoom: number, fromZoom: number): number;
         getScaleZoom(scale: number, fromZoom: number): number;
         project(latlng: LatLngExpression, zoom: number): Point;
-        unproject(point: Point, zoom: number): LatLng;
-        unproject(point: PointTuple, zoom: number): LatLng;
-        layerPointToLatLng(point: Point): LatLng;
-        layerPointToLatLng(point: PointTuple): LatLng;
+        unproject(point: PointExpression, zoom: number): LatLng;
+        layerPointToLatLng(point: PointExpression): LatLng;
         latLngToLayerPoint(latlng: LatLngExpression): Point;
         wrapLatLng(latlng: LatLngExpression): LatLng;
         distance(latlng1: LatLngExpression, latlng2: LatLngExpression): number;
-        containerPointToLayerPoint(point: Point): Point;
-        containerPointToLayerPoint(point: PointTuple): Point;
-        layerPointToContainerPoint(point: Point): Point;
+        containerPointToLayerPoint(point: PointExpression): Point;
+        layerPointToContainerPoint(point: PointExpression): Point;
         layerPointToContainerPoint(point: PointTuple): Point;
         latLngToContainerPoint(latlng: LatLngExpression): Point;
         mouseEventToContainerPoint(ev: MouseEvent): Point;

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -43,25 +43,17 @@ declare namespace L {
     }
 
     export interface CRS {
-        latLngToPoint(latlng: LatLng, zoom: number): Point;
-        latLngToPoint(latlng: LatLngLiteral, zoom: number): Point;
-        latLngToPoint(latlng: LatLngTuple, zoom: number): Point;
+        latLngToPoint(latlng: LatLngExpression, zoom: number): Point;
         pointToLatLng(point: Point): LatLng;
         pointToLatLng(point: PointTuple): LatLng;
-        project(latlng: LatLng): Point;
-        project(latlng: LatLngLiteral): Point;
-        project(latlng: LatLngTuple): Point;
+        project(latlng: LatLngExpression): Point;
         unproject(point: Point): LatLng;
         unproject(point: PointTuple): LatLng;
         scale(zoom: number): number;
         zoom(scale: number): number;
         getProjectedBounds(zoom: number): Bounds;
-        distance(latlng1: LatLng, latlng2: LatLng): number;
-        distance(latlng1: LatLngLiteral, latlng2: LatLngLiteral): number;
-        distance(latlng1: LatLngTuple, latlng2: LatLngTuple): number;
-        wrapLatLng(latlng: LatLng): LatLng;
-        wrapLatLng(latlng: LatLngLiteral): LatLng;
-        wrapLatLng(latlng: LatLngTuple): LatLng;
+        distance(latlng1: LatLngExpression, latlng2: LatLngExpression): number;
+        wrapLatLng(latlng: LatLngExpression): LatLng;
 
         code: string;
         wrapLng: [number, number];
@@ -78,9 +70,7 @@ declare namespace L {
     }
 
     export interface Projection {
-        project(latlng: LatLng): Point;
-        project(latlng: LatLngLiteral): Point;
-        project(latlng: LatLngTuple): Point;
+        project(latlng: LatLngExpression): Point;
         unproject(point: Point): LatLng;
         unproject(point: PointTuple): LatLng;
 
@@ -94,13 +84,9 @@ declare namespace L {
     }
 
     export interface LatLng {
-        equals(otherLatLng: LatLng, maxMargin?: number): boolean;
-        equals(otherLatLng: LatLngLiteral, maxMargin?: number): boolean;
-        equals(otherLatLng: LatLngTuple, maxMargin?: number): boolean;
+        equals(otherLatLng: LatLngExpression, maxMargin?: number): boolean;
         toString(): string;
-        distanceTo(otherLatLng: LatLng): number;
-        distanceTo(otherLatLng: LatLngLiteral): number;
-        distanceTo(otherLatLng: LatLngTuple): number;
+        distanceTo(otherLatLng: LatLngExpression): number;
         wrap(): LatLng;
         toBounds(sizeInMeters: number): LatLngBounds;
 
@@ -129,9 +115,7 @@ declare namespace L {
     export function latLng(coords: {lat: number, lng: number, alt: number}): LatLng;
 
     export interface LatLngBounds {
-        extend(latlng: LatLng): this;
-        extend(latlng: LatLngLiteral): this;
-        extend(latlng: LatLngTuple): this;
+        extend(latlng: LatLngExpression): this;
         extend(otherBounds: LatLngBounds): this;
         extend(otherBounds: LatLngBoundsLiteral): this;
         pad(bufferRatio: number): LatLngBounds; // does this modify the current instance or does it return a new one?
@@ -146,9 +130,7 @@ declare namespace L {
         getNorth(): number;
         contains(otherBounds: LatLngBounds): boolean;
         contains(otherBounds: LatLngBoundsLiteral): boolean;
-        contains(latlng: LatLng): boolean;
-        contains(latlng: LatLngLiteral): boolean;
-        contains(latlng: LatLngTuple): boolean;
+        contains(latlng: LatLngExpression): boolean;
         intersects(otherBounds: LatLngBounds): boolean;
         intersects(otherBounds: LatLngLiteral): boolean;
         overlaps(otherBounds: Bounds): boolean; // investigate if this is really bounds and not latlngbounds
@@ -163,11 +145,7 @@ declare namespace L {
 
     type LatLngBoundsExpression = LatLngBounds | LatLngBoundsLiteral;
 
-    export function latLngBounds(southWest: LatLng, northEast: LatLng): LatLngBounds;
-
-    export function latLngBounds(southWest: LatLngLiteral, northEast: LatLngLiteral): LatLngBounds;
-
-    export function latLngBounds(southWest: LatLngTuple, northEast: LatLngTuple): LatLngBounds;
+    export function latLngBounds(southWest: LatLngExpression, northEast: LatLngExpression): LatLngBounds;
 
     export function latLngBounds(latlngs: LatLngBoundsLiteral): LatLngBounds;
 
@@ -404,9 +382,7 @@ declare namespace L {
         bindPopup(content: Popup): this;
         unbindPopup(): this;
         openPopup(): this;
-        openPopup(latlng: LatLng): this;
-        openPopup(latlng: LatLngLiteral): this;
-        openPopup(latlng: LatLngTuple): this;
+        openPopup(latlng: LatLngExpression): this;
         closePopup(): this;
         togglePopup(): this;
         isPopupOpen(): boolean;
@@ -422,9 +398,7 @@ declare namespace L {
         bindTooltip(content: Tooltip, options?: TooltipOptions): this;
         unbindTooltip(): this;
         openTooltip(): this;
-        openTooltip(latlng: LatLng): this;
-        openTooltip(latlng: LatLngLiteral): this;
-        openTooltip(latlng: LatLngTuple): this;
+        openTooltip(latlng: LatLngExpression): this;
         closeTooltip(): this;
         toggleTooltip(): this;
         isTooltipOpen(): boolean;
@@ -564,51 +538,28 @@ declare namespace L {
 
     interface InternalPolyline extends Path {
         getLatLngs(): Array<LatLng>;
-        setLatLngs(latlngs: Array<LatLng>): this;
-        setLatLngs(latlngs: Array<LatLngLiteral>): this;
-        setLatLngs(latlngs: Array<LatLngTuple>): this;
+        setLatLngs(latlngs: Array<LatLngExpression>): this;
         isEmpty(): boolean;
         getCenter(): LatLng;
         getBounds(): LatLngBounds;
-        addLatLng(latlng: LatLng): this;
-        addLatLng(latlng: LatLngLiteral): this;
-        addLatLng(latlng: LatLngTuple): this;
-        addLatLng(latlng: Array<LatLng>): this; // these three overloads aren't explicitly noted in the docs
-        addLatLng(latlng: Array<LatLngLiteral>): this;
-        addLatLng(latlng: Array<LatLngTuple>): this;
+        addLatLng(latlng: LatLngExpression): this;
+        addLatLng(latlng: Array<LatLngExpression>): this; // these three overloads aren't explicitly noted in the docs
     }
 
     export interface Polyline extends InternalPolyline {
         toGeoJSON(): GeoJSON.LineString | GeoJSON.MultiLineString;
     }
 
-    export function polyline(latlngs: Array<LatLng>, options?: PolylineOptions): Polyline;
-
-    export function polyline(latlngs: Array<LatLngLiteral>, options?: PolylineOptions): Polyline;
-
-    export function polyline(latlngs: Array<LatLngTuple>, options?: PolylineOptions): Polyline;
-
-    export function polyline(latlngs: Array<Array<LatLng>>, options?: PolylineOptions): Polyline;
-
-    export function polyline(latlngs: Array<Array<LatLngLiteral>>, options?: PolylineOptions): Polyline;
-
-    export function polyline(latlngs: Array<Array<LatLngTuple>>, options?: PolylineOptions): Polyline;
+    export function polyline(latlngs: Array<LatLngExpression>, options?: PolylineOptions): Polyline;
+    export function polyline(latlngs: Array<Array<LatLngExpression>>, options?: PolylineOptions): Polyline;
 
     export interface Polygon extends InternalPolyline {
         toGeoJSON(): GeoJSON.Polygon | GeoJSON.MultiPolygon;
     }
 
-    export function polygon(latlngs: Array<LatLng>, options?: PolylineOptions): Polygon;
+    export function polygon(latlngs: Array<LatLngExpression>, options?: PolylineOptions): Polygon;
 
-    export function polygon(latlngs: Array<LatLngLiteral>, options?: PolylineOptions): Polygon;
-
-    export function polygon(latlngs: Array<LatLngTuple>, options?: PolylineOptions): Polygon;
-
-    export function polygon(latlngs: Array<Array<LatLng>>, options?: PolylineOptions): Polygon;
-
-    export function polygon(latlngs: Array<Array<LatLngLiteral>>, options?: PolylineOptions): Polygon;
-
-    export function polygon(latlngs: Array<Array<LatLngTuple>>, options?: PolylineOptions): Polygon;
+    export function polygon(latlngs: Array<Array<LatLngExpression>>, options?: PolylineOptions): Polygon;
 
     export interface Rectangle extends Polygon {
         setBounds(latLngBounds: LatLngBounds): this;
@@ -625,19 +576,13 @@ declare namespace L {
 
     export interface CircleMarker extends Path {
         toGeoJSON(): GeoJSON.Point;
-        setLatLng(latLng: LatLng): this;
-        setLatLng(latLng: LatLngLiteral): this;
-        setLatLng(latLng: LatLngTuple): this;
+        setLatLng(latLng: LatLngExpression): this;
         getLatLng(): LatLng;
         setRadius(radius: number): this;
         getRadius(): number;
     }
 
-    export function circleMarker(latlng: LatLng, options?: CircleMarkerOptions): CircleMarker;
-
-    export function circleMarker(latlng: LatLngLiteral, options?: CircleMarkerOptions): CircleMarker;
-
-    export function circleMarker(latlng: LatLngLiteral, options?: CircleMarkerOptions): CircleMarker;
+    export function circleMarker(latlng: LatLngExpression, options?: CircleMarkerOptions): CircleMarker;
 
     export interface CircleOptions extends PathOptions {
         radius?: number;
@@ -649,17 +594,8 @@ declare namespace L {
         getBounds(): LatLngBounds;
     }
 
-    export function circle(latlng: LatLng, options?: CircleOptions): Circle;
-
-    export function circle(latlng: LatLngLiteral, options?: CircleOptions): Circle;
-
-    export function circle(latlng: LatLngTuple, options?: CircleOptions): Circle;
-
-    export function circle(latlng: LatLng, radius: number, options?: CircleOptions): Circle;
-
-    export function circle(latlng: LatLngLiteral, radius: number, options?: CircleOptions): Circle;
-
-    export function circle(latlng: LatLngTuple, radius: number, options?: CircleOptions): Circle;
+    export function circle(latlng: LatLngExpression, options?: CircleOptions): Circle;
+    export function circle(latlng: LatLngExpression, radius: number, options?: CircleOptions): Circle;
 
     export interface RendererOptions extends LayerOptions {
         padding?: number;
@@ -1274,39 +1210,25 @@ declare namespace L {
         hasLayer(layer: Layer): boolean;
         eachLayer(fn: (layer: Layer) => void, context?: Object): this;
         openPopup(popup: Popup): this;
-        openPopup(content: string, latlng: LatLng, options?: PopupOptions): this;
-        openPopup(content: string, latlng: LatLngLiteral, options?: PopupOptions): this;
-        openPopup(content: string, latlng: LatLngTuple, options?: PopupOptions): this;
-        openPopup(content: HTMLElement, latlng: LatLng, options?: PopupOptions): this;
-        openPopup(content: HTMLElement, latlng: LatLngLiteral, options?: PopupOptions): this;
-        openPopup(content: HTMLElement, latlng: LatLngTuple, options?: PopupOptions): this;
+        openPopup(content: string, latlng: LatLngExpression, options?: PopupOptions): this;
+        openPopup(content: HTMLElement, latlng: LatLngExpression, options?: PopupOptions): this;
         closePopup(popup?: Popup): this;
         openTooltip(tooltip: Tooltip): this;
-        openTooltip(content: string, latlng: LatLng, options?: TooltipOptions): this;
-        openTooltip(content: string, latlng: LatLngLiteral, options?: TooltipOptions): this;
-        openTooltip(content: string, latlng: LatLngTuple, options?: TooltipOptions): this;
-        openTooltip(content: HTMLElement, latlng: LatLng, options?: TooltipOptions): this;
-        openTooltip(content: HTMLElement, latlng: LatLngLiteral, options?: TooltipOptions): this;
-        openTooltip(content: HTMLElement, latlng: LatLngTuple, options?: TooltipOptions): this;
+        openTooltip(content: string, latlng: LatLngExpression, options?: TooltipOptions): this;
+        openTooltip(content: HTMLElement, latlng: LatLngExpression, options?: TooltipOptions): this;
         closeTooltip(tooltip?: Tooltip): this;
 
         // Methods for modifying map state
-        setView(center: LatLng, zoom: number, options?: ZoomPanOptions): this;
-        setView(center: LatLngLiteral, zoom: number, options?: ZoomPanOptions): this;
-        setView(center: LatLngTuple, zoom: number, options?: ZoomPanOptions): this;
+        setView(center: LatLngExpression, zoom: number, options?: ZoomPanOptions): this;
         setZoom(zoom: number, options: ZoomPanOptions): this;
         zoomIn(delta?: number, options?: ZoomOptions): this;
         zoomOut(delta?: number, options?: ZoomOptions): this;
-        setZoomAround(latlng: LatLng, zoom: number, options: ZoomOptions): this;
-        setZoomAround(latlng: LatLngLiteral, zoom: number, options: ZoomOptions): this;
-        setZoomAround(latlng: LatLngTuple, zoom: number, options: ZoomOptions): this; // will the latlng version using tuple take precedence or will the point tuple version?
+        setZoomAround(latlng: LatLngExpression, zoom: number, options: ZoomOptions): this;
         setZoomAround(offset: Point, zoom: number, options: ZoomOptions): this;
         fitBounds(bounds: LatLngBounds, options: FitBoundsOptions): this;
         fitBounds(bounds: LatLngBoundsLiteral, options: FitBoundsOptions): this;
         fitWorld(options?: FitBoundsOptions): this;
-        panTo(latlng: LatLng, options?: PanOptions): this;
-        panTo(latlng: LatLngLiteral, options?: PanOptions): this;
-        panTo(latlng: LatLngTuple, options?: PanOptions): this;
+        panTo(latlng: LatLngExpression, options?: PanOptions): this;
         panBy(offset: Point): this;
         panBy(offset: PointTuple): this;
         setMaxBounds(bounds: LatLngBounds): this;
@@ -1318,9 +1240,7 @@ declare namespace L {
         invalidateSize(options: ZoomPanOptions): this;
         invalidateSize(animate: boolean): this;
         stop(): this;
-        flyTo(latlng: LatLng, zoom?: number, options?: ZoomPanOptions): this;
-        flyTo(latlng: LatLngLiteral, zoom?: number, options?: ZoomPanOptions): this;
-        flyTo(latlng: LatLngTuple, zoom?: number, options?: ZoomPanOptions): this;
+        flyTo(latlng: LatLngExpression, zoom?: number, options?: ZoomPanOptions): this;
         flyToBounds(bounds: LatLngBounds, options?: FitBoundsOptions): this;
         flyToBounds(bounds: LatLngBoundsLiteral, options?: FitBoundsOptions): this;
 
@@ -1350,29 +1270,19 @@ declare namespace L {
         // Conversion methods
         getZoomScale(toZoom: number, fromZoom: number): number;
         getScaleZoom(scale: number, fromZoom: number): number;
-        project(latlng: LatLng, zoom: number): Point;
-        project(latlng: LatLngLiteral, zoom: number): Point;
-        project(latlng: LatLngTuple, zoom: number): Point;
+        project(latlng: LatLngExpression, zoom: number): Point;
         unproject(point: Point, zoom: number): LatLng;
         unproject(point: PointTuple, zoom: number): LatLng;
         layerPointToLatLng(point: Point): LatLng;
         layerPointToLatLng(point: PointTuple): LatLng;
-        latLngToLayerPoint(latlng: LatLng): Point;
-        latLngToLayerPoint(latlng: LatLngLiteral): Point;
-        latLngToLayerPoint(latlng: LatLngTuple): Point;
-        wrapLatLng(latlng: LatLng): LatLng;
-        wrapLatLng(latlng: LatLngLiteral): LatLng;
-        wrapLatLng(latlng: LatLngTuple): LatLng;
-        distance(latlng1: LatLng, latlng2: LatLng): number;
-        distance(latlng1: LatLngLiteral, latlng2: LatLngLiteral): number;
-        distance(latlng1: LatLngTuple, latlng2: LatLngTuple): number;
+        latLngToLayerPoint(latlng: LatLngExpression): Point;
+        wrapLatLng(latlng: LatLngExpression): LatLng;
+        distance(latlng1: LatLngExpression, latlng2: LatLngExpression): number;
         containerPointToLayerPoint(point: Point): Point;
         containerPointToLayerPoint(point: PointTuple): Point;
         layerPointToContainerPoint(point: Point): Point;
         layerPointToContainerPoint(point: PointTuple): Point;
-        latLngToContainerPoint(latlng: LatLng): Point;
-        latLngToContainerPoint(latlng: LatLngLiteral): Point;
-        latLngToContainerPoint(latlng: LatLngTuple): Point;
+        latLngToContainerPoint(latlng: LatLngExpression): Point;
         mouseEventToContainerPoint(ev: MouseEvent): Point;
         mouseEventToLayerPoint(ev: MouseEvent): Point;
         mouseEventToLatLng(ev: MouseEvent): LatLng;
@@ -1450,9 +1360,7 @@ declare namespace L {
 
     export interface Marker extends Layer {
         getLatLng(): LatLng;
-        setLatLng(latlng: LatLng): this;
-        setLatLng(latlng: LatLngLiteral): this;
-        setLatLng(latlng: LatLngTuple): this;
+        setLatLng(latlng: LatLngExpression): this;
         setZIndexOffset(offset: number): this;
         setIcon(icon: Icon): this;
         setOpacity(opacity: number): this;
@@ -1461,11 +1369,7 @@ declare namespace L {
         dragging: Handler;
     }
 
-    export function marker(latlng: LatLng, options?: MarkerOptions): Marker;
-
-    export function marker(latlng: LatLngLiteral, options?: MarkerOptions): Marker;
-
-    export function marker(latlng: LatLngTuple, options?: MarkerOptions): Marker;
+    export function marker(latlng: LatLngExpression, options?: MarkerOptions): Marker;
 
     export namespace Browser {
         export const ie: boolean;

--- a/leaflet/leaflet.d.ts
+++ b/leaflet/leaflet.d.ts
@@ -113,8 +113,7 @@ declare namespace L {
 
     export interface LatLngBounds {
         extend(latlng: LatLngExpression): this;
-        extend(otherBounds: LatLngBounds): this;
-        extend(otherBounds: LatLngBoundsLiteral): this;
+        extend(otherBounds: LatLngBoundsExpression): this;
         pad(bufferRatio: number): LatLngBounds; // does this modify the current instance or does it return a new one?
         getCenter(): LatLng;
         getSouthWest(): LatLng;
@@ -125,16 +124,12 @@ declare namespace L {
         getSouth(): number;
         getEast(): number;
         getNorth(): number;
-        contains(otherBounds: LatLngBounds): boolean;
-        contains(otherBounds: LatLngBoundsLiteral): boolean;
+        contains(otherBounds: LatLngBoundsExpression): boolean;
         contains(latlng: LatLngExpression): boolean;
-        intersects(otherBounds: LatLngBounds): boolean;
-        intersects(otherBounds: LatLngLiteral): boolean;
-        overlaps(otherBounds: Bounds): boolean; // investigate if this is really bounds and not latlngbounds
-        overlaps(otherBounds: BoundsLiteral): boolean;
+        intersects(otherBounds: LatLngBoundsExpression): boolean;
+        overlaps(otherBounds: BoundsExpression): boolean; // investigate if this is really bounds and not latlngbounds
         toBBoxString(): string;
-        equals(otherBounds: LatLngBounds): boolean;
-        equals(otherBounds: LatLngBoundsLiteral): boolean;
+        equals(otherBounds: LatLngBoundsExpression): boolean;
         isValid(): boolean;
     }
 
@@ -181,13 +176,10 @@ declare namespace L {
         getBottomLeft(): Point;
         getTopRight(): Point;
         getSize(): Point;
-        contains(otherBounds: Bounds): boolean;
-        contains(otherBounds: BoundsLiteral): boolean;
+        contains(otherBounds: BoundsExpression): boolean;
         contains(point: PointExpression): boolean;
-        intersects(otherBounds: Bounds): boolean;
-        intersects(otherBounds: BoundsLiteral): boolean;
-        overlaps(otherBounds: Bounds): boolean;
-        overlaps(otherBounds: BoundsLiteral): boolean;
+        intersects(otherBounds: BoundsExpression): boolean;
+        overlaps(otherBounds: BoundsExpression): boolean;
 
         min: Point;
         max: Point;
@@ -548,13 +540,10 @@ declare namespace L {
     export function polygon(latlngs: Array<Array<LatLngExpression>>, options?: PolylineOptions): Polygon;
 
     export interface Rectangle extends Polygon {
-        setBounds(latLngBounds: LatLngBounds): this;
-        setBounds(latLngBounds: LatLngBoundsLiteral): this;
+        setBounds(latLngBounds: LatLngBoundsExpression): this;
     }
 
-    export function rectangle(latLngBounds: LatLngBounds, options?: PolylineOptions): Rectangle;
-
-    export function rectangle(latLngBounds: LatLngBoundsLiteral, options?: PolylineOptions): Rectangle;
+    export function rectangle(latLngBounds: LatLngBoundsExpression, options?: PolylineOptions): Rectangle;
 
     export interface CircleMarkerOptions extends PathOptions {
         radius?: number;
@@ -1211,23 +1200,19 @@ declare namespace L {
         zoomOut(delta?: number, options?: ZoomOptions): this;
         setZoomAround(latlng: LatLngExpression, zoom: number, options: ZoomOptions): this;
         setZoomAround(offset: Point, zoom: number, options: ZoomOptions): this;
-        fitBounds(bounds: LatLngBounds, options: FitBoundsOptions): this;
-        fitBounds(bounds: LatLngBoundsLiteral, options: FitBoundsOptions): this;
+        fitBounds(bounds: LatLngBoundsExpression, options: FitBoundsOptions): this;
         fitWorld(options?: FitBoundsOptions): this;
         panTo(latlng: LatLngExpression, options?: PanOptions): this;
         panBy(offset: PointExpression): this;
-        setMaxBounds(bounds: LatLngBounds): this;
-        setMaxBounds(bounds: LatLngBoundsLiteral): this;
+        setMaxBounds(bounds: LatLngBoundsExpression): this;
         setMinZoom(zoom: number): this;
         setMaxZoom(zoom: number): this;
-        panInsideBounds(bounds: LatLngBounds, options?: PanOptions): this;
-        panInsideBounds(bounds: LatLngBoundsLiteral, options?: PanOptions): this;
+        panInsideBounds(bounds: LatLngBoundsExpression, options?: PanOptions): this;
         invalidateSize(options: ZoomPanOptions): this;
         invalidateSize(animate: boolean): this;
         stop(): this;
         flyTo(latlng: LatLngExpression, zoom?: number, options?: ZoomPanOptions): this;
-        flyToBounds(bounds: LatLngBounds, options?: FitBoundsOptions): this;
-        flyToBounds(bounds: LatLngBoundsLiteral, options?: FitBoundsOptions): this;
+        flyToBounds(bounds: LatLngBoundsExpression, options?: FitBoundsOptions): this;
 
         // Other methods
         addHandler(name: string, HandlerClass: () => Handler): this; // HandlerClass is actually a constructor function, is this the right way?
@@ -1245,8 +1230,7 @@ declare namespace L {
         getBounds(): LatLngBounds;
         getMinZoom(): number;
         getMaxZoom(): number;
-        getBoundsZoom(bounds: LatLngBounds, inside?: boolean): number;
-        getBoundsZoom(bounds: LatLngBoundsLiteral, inside?: boolean): number;
+        getBoundsZoom(bounds: LatLngBoundsExpression, inside?: boolean): number;
         getSize(): Point;
         getPixelBounds(): Bounds;
         getPixelOrigin(): Point;


### PR DESCRIPTION
These changes remove a lot of overrides for several methods to prefer using a single, already defined type that describe all the possibilites.

This was done because it was cumbersome to write libraries for leaflet ; allowing the user to use any variant of LatLng, LatLngLiteral is important and not easily feasible as is.


- [x] Prefer to make your PR against the `types-2.0` branch. *used master, as I want it available to typings users*
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: *not sure if applicable*
- [x] Increase the version number in the header if appropriate. *did not increase the version header as it mentions version 1.0.0-rc3 of leaflet itself*
