### PR TITLE
Fix for "Cannot find namespace 'Redux'" in redux-promise-middleware

### DIFF
--- a/redux-promise-middleware/index.d.ts
+++ b/redux-promise-middleware/index.d.ts
@@ -3,10 +3,6 @@
 // Definitions by: ianks <https://github.com/ianks>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-/// <reference types='redux' />
+import { Middleware } from 'redux';
 
-declare module "redux-promise-middleware" {
-    function promiseMiddleware(config?: { promiseTypeSuffixes: string[] }): Redux.Middleware;
-
-    export default promiseMiddleware;
-}
+export default function promiseMiddleware(config?: { promiseTypeSuffixes: string[] }): Middleware;

--- a/redux-promise-middleware/package.json
+++ b/redux-promise-middleware/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "redux": "^3.6.0"
+  }
+}


### PR DESCRIPTION
I had trouble running this against current `redux` definitions.

Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.
