### PR TITLE
Fix PreloadJs installplugin() type

### DIFF
--- a/preloadjs/index.d.ts
+++ b/preloadjs/index.d.ts
@@ -158,7 +158,7 @@ declare namespace createjs {
         // methods
         close(): void;
         getItems(loaded: boolean): Object[];
-        installPlugin(plugin: () => any): void;
+        installPlugin(plugin: any): void;
         loadFile(file: Object | string, loadNow?: boolean, basePath?: string): void;
         loadManifest(manifest: Object | string | any[], loadNow?: boolean, basePath?: string): void;
         registerLoader(loader: AbstractLoader): void;


### PR DESCRIPTION
Fixing https://github.com/DefinitelyTyped/DefinitelyTyped/issues/4692

The docs of preloadjs http://www.createjs.com/docs/preloadjs/modules/PreloadJS.html states that the 'installPlugin' method should be able to add 'createjs.Sound' which is not a function.