### PR TITLE
add ElasticSeach 5.x API function for deleteByQuery

### DIFF
--- a/elasticsearch/elasticsearch-tests.ts
+++ b/elasticsearch/elasticsearch-tests.ts
@@ -86,3 +86,10 @@ client.cluster.stats({
   ignore: 1
 }, (err, response) => {
 });
+
+client.deleteByQuery({
+  index : 'index',
+  type : 'type'
+}, (err, response) => {
+
+});

--- a/elasticsearch/elasticsearch.d.ts
+++ b/elasticsearch/elasticsearch.d.ts
@@ -15,8 +15,8 @@ declare module Elasticsearch {
         create(params: CreateDocumentParams, callback: (err: any, response: any, status: any) => void): void;
         delete(params: DeleteDocumentParams): PromiseLike<any>;
         delete(params: DeleteDocumentParams, callback: (error: any, response: any) => void): void;
-        deleteByQuery(params : SearchParams, callback : (error: any, response: any) => void): void;
-        deleteByQuery(params : SearchParams): PromiseLike<any>;
+        deleteByQuery(params : DeleteByQueryParams, callback : (error: any, response: any) => void): void;
+        deleteByQuery(params : DeleteByQueryParams): PromiseLike<any>;
         exists(params: ExistsParams): PromiseLike<any>;
         exists(params: ExistsParams, callback: (error: any, response: any, status?: any) => void): void;
         get<T>(params: GetParams, callback: (error: any, response: GetResponse<T>) => void): void;
@@ -226,7 +226,7 @@ declare module Elasticsearch {
         type: string;
         id: string;
         body: T;
-        consistensy?: string;
+        consistency?: string;
         parent?: string;
         replication?: string;
         routing?: string;
@@ -260,6 +260,44 @@ declare module Elasticsearch {
         suggestSize?: number;
         suggestText?: string;
         timeout?: Date | number;
+    }
+
+    export interface DeleteByQueryParams extends GenericParams {
+        index?: string;
+        type?: string | string[] | number;
+        body?: any;
+        q?: string;
+        analyzer?: string;
+        analyzeWildcard?: boolean;
+        defaultOperator?: 'AND' | 'OR';
+        df?: string;
+        from?: number;
+        ignoreUnavailable?: boolean;
+        allowNoIndices?: boolean;
+        conflicts?: 'abort' | 'proceed';
+        expandWildcards?: 'open' | 'closed' | 'none' | 'all';
+        lenient?: boolean;
+        lowercaseExpandedTerms?: boolean;
+        preference?: string;
+        routing?: string | string[] | boolean;
+        scroll?: string;
+        searchType?: 'query_then_fetch' | 'dfs_query_then_fetch';
+        searchTimeout?: string;
+        size?: number;
+        sort: string | string[] | boolean;
+        _source?: string | string[] | boolean;
+        _sourceExclude?: string | string[] | boolean;
+        _sourceInclude?: string | string[] | boolean;
+        terminateAfter?: number;
+        stats?: string | string[] | boolean;
+        version?: boolean;
+        requestCache?: boolean;
+        refresh?: boolean;
+        timeout?: string;
+        waitForActiveShards?: string;
+        scrollSize?: number;
+        waitForCompletion?: boolean;
+        requestsPerSecond?: number;
     }
 
     export interface SearchResponse<T> {

--- a/elasticsearch/elasticsearch.d.ts
+++ b/elasticsearch/elasticsearch.d.ts
@@ -15,6 +15,8 @@ declare module Elasticsearch {
         create(params: CreateDocumentParams, callback: (err: any, response: any, status: any) => void): void;
         delete(params: DeleteDocumentParams): PromiseLike<any>;
         delete(params: DeleteDocumentParams, callback: (error: any, response: any) => void): void;
+        deleteByQuery(params : DeleteByQueryParams, callback : (error: any, response: any) => void): void;
+        deleteByQuery(params : DeleteByQueryParams): PromiseLike<any>;
         exists(params: ExistsParams): PromiseLike<any>;
         exists(params: ExistsParams, callback: (error: any, response: any, status?: any) => void): void;
         get<T>(params: GetParams, callback: (error: any, response: GetResponse<T>) => void): void;
@@ -329,6 +331,11 @@ declare module Elasticsearch {
         id: string;
         parent?: string;
         refresh?: boolean;
+    }
+
+    export interface DeleteByQueryParams extends GenericParams {
+        index: string;
+        body: any;
     }
 
     export interface UpdateDocumentParams extends GenericParams {

--- a/elasticsearch/elasticsearch.d.ts
+++ b/elasticsearch/elasticsearch.d.ts
@@ -284,7 +284,7 @@ declare module Elasticsearch {
         searchType?: 'query_then_fetch' | 'dfs_query_then_fetch';
         searchTimeout?: string;
         size?: number;
-        sort: string | string[] | boolean;
+        sort?: string | string[] | boolean;
         _source?: string | string[] | boolean;
         _sourceExclude?: string | string[] | boolean;
         _sourceInclude?: string | string[] | boolean;

--- a/elasticsearch/elasticsearch.d.ts
+++ b/elasticsearch/elasticsearch.d.ts
@@ -15,8 +15,8 @@ declare module Elasticsearch {
         create(params: CreateDocumentParams, callback: (err: any, response: any, status: any) => void): void;
         delete(params: DeleteDocumentParams): PromiseLike<any>;
         delete(params: DeleteDocumentParams, callback: (error: any, response: any) => void): void;
-        deleteByQuery(params : DeleteByQueryParams, callback : (error: any, response: any) => void): void;
-        deleteByQuery(params : DeleteByQueryParams): PromiseLike<any>;
+        deleteByQuery(params : SearchParams, callback : (error: any, response: any) => void): void;
+        deleteByQuery(params : SearchParams): PromiseLike<any>;
         exists(params: ExistsParams): PromiseLike<any>;
         exists(params: ExistsParams, callback: (error: any, response: any, status?: any) => void): void;
         get<T>(params: GetParams, callback: (error: any, response: GetResponse<T>) => void): void;
@@ -288,7 +288,7 @@ declare module Elasticsearch {
             }[]
         },
         aggregations?: any
-    } 
+    }
 
     export interface MSearchParams extends GenericParams {
         index?: string | string[] | Boolean;
@@ -331,11 +331,6 @@ declare module Elasticsearch {
         id: string;
         parent?: string;
         refresh?: boolean;
-    }
-
-    export interface DeleteByQueryParams extends GenericParams {
-        index: string;
-        body: any;
     }
 
     export interface UpdateDocumentParams extends GenericParams {


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/elastic/elasticsearch-js/blob/master/src/lib/apis/5_x.js#L1979
- [x] Increase the version number in the header if appropriate.

