### PR TITLE
Add moveAsync definition to fs-extra-promise

### DIFF
--- a/fs-extra-promise/fs-extra-promise-tests.ts
+++ b/fs-extra-promise/fs-extra-promise-tests.ts
@@ -62,6 +62,8 @@ fs.mkdirsSync(dir);
 fs.mkdirp(dir, errorCallback);
 fs.mkdirpSync(dir);
 
+fs.move(src, dest, errorCallback);
+
 fs.outputFile(file, data, errorCallback);
 fs.outputFileSync(file, data);
 fs.outputJson(file, data, errorCallback);

--- a/fs-extra-promise/index.d.ts
+++ b/fs-extra-promise/index.d.ts
@@ -10,7 +10,7 @@
 import * as stream from 'stream';
 import { Stats } from 'fs';
 import * as Promise from 'bluebird';
-import { CopyFilter, CopyOptions, OpenOptions, MkdirOptions } from 'fs-extra';
+import { CopyFilter, CopyOptions, OpenOptions, MkdirOptions, MoveOptions } from 'fs-extra';
 
 export * from 'fs-extra';
 
@@ -23,6 +23,8 @@ export declare function createFileAsync(file: string): Promise<void>;
 
 export declare function mkdirsAsync(dir: string, options?: MkdirOptions): Promise<void>;
 export declare function mkdirpAsync(dir: string, options?: MkdirOptions): Promise<void>;
+
+export declare function moveAsync(src: string, dest: string, options?: MoveOptions): Promise<void>;
 
 export declare function outputFileAsync(file: string, data: any): Promise<void>;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jprichardson/node-fs-extra#movesrc-dest-options-callback
- [x] Increase the version number in the header if appropriate.

