### PR TITLE
Marionnette.Region.empty may take a preventDestroy optional flag

### DIFF
--- a/backbone.marionette/index.d.ts
+++ b/backbone.marionette/index.d.ts
@@ -288,6 +288,15 @@ declare namespace Marionette {
         triggerAttach?: boolean;
     }
 
+    interface RegionEmptyOptions {
+        /**
+         * If you would like to prevent the view currently shown in the region
+         * from being destroyed you can set this option to true to prevent the
+         * default destroy behavior.
+         */
+        preventDestroy?: boolean;
+    }
+
     /**
      * Regions provide consistent methods to manage, show and destroy views in
      * your applications and layouts. They use a jQuery selector to show your
@@ -348,7 +357,7 @@ declare namespace Marionette {
         /**
          * Empties the current view from the region.
          */
-        empty(): any;
+        empty(options?: RegionEmptyOptions): any;
 
         /**
          * @returns view that this region has.


### PR DESCRIPTION
Quoting current documentation on `Region` [here](http://marionettejs.com/docs/v2.4.3/marionette.region.html#emptying-a-region) :

```
Emptying a region

You can empty a region of its view and contents by invoking .empty() on the region instance.
If you would like to prevent the view currently shown in the region from being destroyed you can pass {preventDestroy: true} to the empty method to prevent the default destroy behavior.
The empty method returns the region instance from the invocation of the method.
```
