### PR TITLE
Add typings for react-datetime for typescript 1.8

### DIFF
--- a/react-datetime/react-datetime-tests.tsx
+++ b/react-datetime/react-datetime-tests.tsx
@@ -1,0 +1,174 @@
+/// <reference path="../moment/moment.d.ts" />
+/// <reference path="./react-datetime.d.ts" />
+
+import * as React from 'react';
+import * as moment from 'moment';
+import ReactDatetime = require('react-datetime');
+
+/*
+ Test the datetime picker.
+ */
+
+const TEST_BASIC_USAGE: JSX.Element = <ReactDatetime />;
+
+/*
+ Test date properties
+ */
+
+const TEST_DATE_PROPS_FOR_VALUE: JSX.Element = <ReactDatetime
+		value={ new Date() }
+	/>;
+
+const TEST_DATE_PROPS_FOR_DEFAULT_VALUE: JSX.Element = <ReactDatetime
+		defaultValue={ new Date() }
+	/>;
+
+/*
+ Test formats
+ */
+
+const TEST_FORMAT_PROPS_AS_STRINGS: JSX.Element = <ReactDatetime
+		dateFormat='mm/dd/yyyy'
+		timeFormat='hh:mm:ss'
+	/>;
+
+const TEST_FORMAT_PROPS_AS_BOOLEANS: JSX.Element = <ReactDatetime
+		dateFormat={ false }
+		timeFormat={ false }
+	/>;
+
+/*
+ Test boolean options
+ */
+
+const TEST_BOOLEAN_PROPS: JSX.Element = <ReactDatetime
+		input={ false }
+		open={ false }
+		strictParsing={ false }
+		closeOnSelect={ false }
+		disableOnClickOutside={ false }
+		utc={ false }
+	/>;
+
+/*
+ Test locale options
+ */
+
+const TEST_LOCALE_PROPS: JSX.Element = <ReactDatetime
+		locale='en-us'
+	/>;
+
+/*
+ Test input props
+ */
+
+const TEST_INPUT_PROPS: JSX.Element = <ReactDatetime
+		inputProps={
+			{
+				'placeholder': 'mm/dd/yyyy'
+			}
+		}
+	/>;
+
+/*
+ Test Event handlers
+ */
+
+ const TEST_EVENT_HANDLERS_WITH_STRINGS: JSX.Element = <ReactDatetime
+ 		onChange={
+ 			(momentOrInputString:string) => {}
+ 		}
+		onFocus={
+			() => {}
+		}
+		onBlur={
+			(momentOrInputString:string) => {}
+		}
+ 	/>;
+
+const TEST_EVENT_HANDLERS_WITH_MOMENT: JSX.Element = <ReactDatetime
+		onChange={
+			(momentOrInputString:moment.Moment) => {}
+		}
+		onBlur={
+			(momentOrInputString:moment.Moment) => {}
+		}
+	/>;
+
+/*
+ Test view mode and className
+ */
+
+const TEST_VIEW_MODE_AND_CLASS_PROPS: JSX.Element = <ReactDatetime
+		viewMode='days'
+		className='rdt'
+	/>;
+
+/*
+ Test date validator
+ */
+
+const TEST_DATE_VALIDATOR_PROP: JSX.Element = <ReactDatetime
+		isValidDate={ (currentDate:any, selectedDate:any) => {
+			return true;
+		} }
+	/>;
+
+/*
+ Test customizable components
+ */
+
+const TEST_CUSTOMIZABLE_COMPONENT_PROPS: JSX.Element = <ReactDatetime
+		renderDay={ (props, currentDate, selectedDate) => {
+			return <td {...props}>{ '0' + currentDate.date() }</td>;
+		} }
+		renderMonth={ (props, month, year, selectedDate) => {
+			return <td {...props}>{ month }</td>;
+		} }
+		renderYear={ (props, year, selectedDate) => {
+			return <td {...props}>{ year % 100 }</td>;
+		} }
+	/>;
+
+/*
+ Test time constraints.
+ */
+
+const TEST_BASIC_TIME_CONSTRAINTS: JSX.Element = <ReactDatetime
+		timeConstraints={ {} }
+	/>;
+
+const TEST_TIME_CONSTRAINTS_WITH_ONE: JSX.Element = <ReactDatetime
+		timeConstraints={ {
+			'hours': {
+				'min': 0,
+				'max': 23,
+				'step': 1
+			}
+		} }
+	/>;
+
+const TEST_TIME_CONSTRAINTS_WITH_ALL: JSX.Element = <ReactDatetime
+		timeConstraints={ {
+			'hours': {
+				'min': 0,
+				'max': 23,
+				'step': 1
+			},
+			'minutes': {
+				'min': 0,
+				'max': 59,
+				'step': 1
+			},
+			'seconds': {
+				'min': 0,
+				'max': 59,
+				'step': 1,
+			},
+			'milliseconds': {
+				'min': 0,
+				'max': 999,
+				'step': 1
+			}
+		} }
+	/>;

--- a/react-datetime/react-datetime.d.ts
+++ b/react-datetime/react-datetime.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-datetime
 // Project: https://github.com/YouCanBookMe/react-datetime
-// Definitions by: Ivan Verevkin <vereva@x-root.org>
+// Definitions by: Ivan Verevkin <https://github.com/idoo>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="../moment/moment.d.ts" />
 /// <reference path="../react/react.d.ts" />

--- a/react-datetime/react-datetime.d.ts
+++ b/react-datetime/react-datetime.d.ts
@@ -1,0 +1,136 @@
+// Type definitions for react-datetime
+// Project: https://github.com/YouCanBookMe/react-datetime
+// Definitions by: Ivan Verevkin <vereva@x-root.org>
+
+/// <reference path="../moment/moment.d.ts" />
+/// <reference path="../react/react.d.ts" />
+
+declare module ReactDatetime {
+  import React = __React;
+  // import * as moment from 'moment';
+
+  export interface DatetimepickerProps {
+    /*
+     Represents the selected date by the component, in order to use it as a controlled component.
+     This prop is parsed by moment.js, so it is possible to use a date string or a moment.js date.
+     */
+    value?: Date;
+    /*
+     Represents the selected date for the component to use it as a uncontrolled component.
+     This prop is parsed by moment.js, so it is possible to use a date string or a moment.js date.
+     */
+    defaultValue?: Date;
+    /*
+     Defines the format for the date. It accepts any moment.js date format.
+     If true the date will be displayed using the defaults for the current locale.
+     If false the datepicker is disabled and the component can be used as timepicker.
+     */
+    dateFormat?: boolean|string;
+    /*
+     Defines the format for the time. It accepts any moment.js time format.
+     If true the time will be displayed using the defaults for the current locale.
+     If false the timepicker is disabled and the component can be used as datepicker.
+     */
+    timeFormat?: boolean|string;
+    /*
+     Whether to show an input field to edit the date manually.
+     */
+    input?: boolean;
+    /*
+     Whether to open or close the picker. If not set react-datetime will open the
+     datepicker on input focus and close it on click outside.
+     */
+    open?: boolean;
+    /*
+     Manually set the locale for the react-datetime instance.
+     Moment.js locale needs to be loaded to be used, see i18n docs.
+     */
+    locale?: string;
+    /*
+     Whether to interpret input times as UTC or the user's local timezone.
+     */
+    utc?: boolean;
+    /*
+     Callback trigger when the date changes. The callback receives the selected `moment` object as
+     only parameter, if the date in the input is valid. If the date in the input is not valid, the
+     callback receives the value of the input (a string).
+     */
+    onChange?: (momentOrInputString: string|any) => void;
+    /*
+     Callback trigger for when the user opens the datepicker.
+     */
+    onFocus?: () => void;
+    /*
+     Callback trigger for when the user clicks outside of the input, simulating a regular onBlur.
+     The callback receives the selected `moment` object as only parameter, if the date in the input
+     is valid. If the date in the input is not valid, the callback receives the value of the
+     input (a string).
+     */
+    onBlur?: (momentOrInputString : string|any) => void;
+    /*
+     The default view to display when the picker is shown. ('years', 'months', 'days', 'time')
+     */
+    viewMode?: string|number;
+    /*
+     Extra class names for the component markup.
+     */
+    className?: string;
+    /*
+     Defines additional attributes for the input element of the component.
+     */
+    inputProps?: Object;
+    /*
+     Define the dates that can be selected. The function receives (currentDate, selectedDate)
+     and should return a true or false whether the currentDate is valid or not. See selectable dates.
+     */
+    isValidDate?: (currentDate: any, selectedDate: any) => boolean;
+    /*
+     Customize the way that the days are shown in the day picker. The accepted function has
+     the selectedDate, the current date and the default calculated props for the cell,
+     and must return a React component. See appearance customization
+     */
+    renderDay?: (props: any, currentDate: any, selectedDate: any) => JSX.Element;
+    /*
+     Customize the way that the months are shown in the month picker.
+     The accepted function has the selectedDate, the current date and the default calculated
+     props for the cell, the month and the year to be shown, and must return a
+     React component. See appearance customization
+     */
+    renderMonth?: (props: any, month: number, year: number, selectedDate: any) => JSX.Element;
+    /*
+     Customize the way that the years are shown in the year picker.
+     The accepted function has the selectedDate, the current date and the default calculated
+     props for the cell, the year to be shown, and must return a React component.
+     See appearance customization
+     */
+    renderYear?: (props: any, year: number, selectedDate: any) => JSX.Element;
+    /*
+     Whether to use moment's strict parsing when parsing input.
+     */
+    strictParsing?: boolean;
+    /*
+     When true, once the day has been selected, the react-datetime will be automatically closed.
+     */
+    closeOnSelect?: boolean;
+    /*
+     Allow to add some constraints to the time selector. It accepts an object with the format
+     {hours:{ min: 9, max: 15, step:2}} so the hours can't be lower than 9 or higher than 15, and
+     it will change adding or subtracting 2 hours everytime the buttons are clicked. The constraints
+     can be added to the hours, minutes, seconds and milliseconds.
+    */
+    timeConstraints?: Object;
+    /*
+     When true, keep the picker open when click event is triggered outside of component. When false,
+     close it.
+    */
+    disableOnClickOutside?: boolean;
+  }
+
+  interface DatetimeComponent extends React.ComponentClass<DatetimepickerProps> {
+  }
+}
+
+declare module "react-datetime" {
+  var ReactDatetime: ReactDatetime.DatetimeComponent;
+  export = ReactDatetime;
+}

--- a/react-datetime/tsconfig.json
+++ b/react-datetime/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "noImplicitAny": false,
+        "sourceMap": false,
+        "jsx": "react",
+        "noEmit": true
+    },
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/react-datetime/tsconfig.json
+++ b/react-datetime/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "target": "es5",
-        "noImplicitAny": false,
+        "noImplicitAny": true,
         "sourceMap": false,
         "jsx": "react",
         "noEmit": true

--- a/react-datetime/tslint.json
+++ b/react-datetime/tslint.json
@@ -1,7 +1,6 @@
 {
     "extends": "../tslint.json",
     "rules": {
-        // This package uses the Function type, and it will take effort to fix.
         "forbidden-types": false
     }
 }

--- a/react-datetime/tslint.json
+++ b/react-datetime/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../tslint.json",
+    "rules": {
+        // This package uses the Function type, and it will take effort to fix.
+        "forbidden-types": false
+    }
+}


### PR DESCRIPTION
The `react-datetime` package is updating its typings to Typescript 2. I'm requesting that the 1.8 typings be moved here to maintain backwards compatibility. This was discussed in YouCanBookMe/react-datetime#190

- [ ] Prefer to make your PR against the `types-2.0` branch.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them. **See above description**
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Run `tsc` without errors.
- [X] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

