### PR TITLE
[rethinkdb] Moving `changes()` method to Sequence interface and fixing `InsertOptions`

### DIFF
--- a/rethinkdb/index.d.ts
+++ b/rethinkdb/index.d.ts
@@ -234,7 +234,15 @@ declare module "rethinkdb" {
         get(key: string): Sequence; // primary key
         getAll(key: string, index?: Index): Sequence; // without index defaults to primary key
         getAll(...keys: string[]): Sequence;
+    }
 
+    interface Sequence extends Operation<Cursor>, Writeable {
+        between(lower: any, upper: any, index?: Index): Sequence;
+
+        filter(rql: ExpressionFunction<boolean>): Sequence;
+        filter(rql: Expression<boolean>): Sequence;
+        filter(obj: { [key: string]: any }): Sequence; 
+        
         /**
          * Turn a query into a changefeed, an infinite stream of objects representing
          * changes to the query’s results as they occur. A changefeed may return changes
@@ -246,14 +254,6 @@ declare module "rethinkdb" {
          * See: https://rethinkdb.com/api/javascript/changes/
          */
         changes(opts?: ChangesOptions): Sequence;
-    }
-
-    interface Sequence extends Operation<Cursor>, Writeable {
-        between(lower: any, upper: any, index?: Index): Sequence;
-
-        filter(rql: ExpressionFunction<boolean>): Sequence;
-        filter(rql: Expression<boolean>): Sequence;
-        filter(obj: { [key: string]: any }): Sequence;
 
         // Join
         // these return left, right
@@ -304,9 +304,9 @@ declare module "rethinkdb" {
     }
 
     interface InsertOptions {
-        upsert: boolean; // true
-        durability: string; // 'soft'
-        return_vals: boolean; // false
+        conflict?: 'error' | 'replace' | 'update' | ((id: string, oldDoc: any, newDoc: any) => any);
+        durability?: 'hard' | 'soft';
+        returnChanges?: boolean | 'always';
     }
 
     interface UpdateOptions {


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.rethinkdb.com/api/javascript/changes/
https://www.rethinkdb.com/api/javascript/insert/
- [ ] Increase the version number in the header if appropriate.

Also adjusting `InsertOptions` to be compatible with current rethinkdb driver.