### PR TITLE
Updated @types/redux-logger to v2.7.4 which uses a default export.

### DIFF
--- a/react-css-modules/index.d.ts
+++ b/react-css-modules/index.d.ts
@@ -26,7 +26,7 @@ declare module CSSModules {
 
 declare let CSSModules: CSSModules;
 
-export = CSSModules;
+export default CSSModules;
 
 declare module 'react' {
     interface HTMLAttributes<T> {

--- a/react-css-modules/react-css-modules-tests.tsx
+++ b/react-css-modules/react-css-modules-tests.tsx
@@ -3,7 +3,7 @@
 
 
 import * as React from 'react';
-import * as CSSModules from 'react-css-modules';
+import CSSModules from 'react-css-modules';
 
 const styles = {};
 

--- a/redux-logger/index.d.ts
+++ b/redux-logger/index.d.ts
@@ -1,5 +1,5 @@
-// Type definitions for redux-logger v2.6.0
-// Project: https://github.com/fcomb/redux-logger
+// Type definitions for redux-logger v2.7.4
+// Project: https://github.com/evgenyrodionov/redux-logger
 // Definitions by: Alexander Rusakov <https://github.com/arusakov/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
@@ -42,9 +42,4 @@ interface ReduxLoggerOptions {
   diffPredicate?: LoggerPredicate;
 }
 
-
-// Trickery to get TypeScript to accept that our anonymous, non-default export is a function.
-// see https://github.com/Microsoft/TypeScript/issues/3612 for more
-declare namespace createLogger { }
-declare function createLogger(options?: ReduxLoggerOptions): Redux.Middleware;
-export = createLogger;
+export default function createLogger(options?: ReduxLoggerOptions): Redux.Middleware;

--- a/redux-logger/redux-logger-tests.ts
+++ b/redux-logger/redux-logger-tests.ts
@@ -1,5 +1,5 @@
 
-import * as createLogger from 'redux-logger';
+import createLogger from 'redux-logger';
 import { applyMiddleware, createStore } from 'redux'
 
 let logger = createLogger();


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/evgenyrodionov/redux-logger/blob/master/src/index.js#L86
- [x] Increase the version number in the header if appropriate.

As shown [here](https://github.com/evgenyrodionov/redux-logger/blob/master/src/index.js#L86), `redux-logger` now uses a default export. Current definition doesn't type that correctly.