### PR TITLE
Missing cc in sendgrid package

### DIFF
--- a/sendgrid/sendgrid.d.ts
+++ b/sendgrid/sendgrid.d.ts
@@ -49,7 +49,8 @@ declare namespace Sendgrid {
         subject?: string;
         text?: string;
         html?: string;
-        bcc?: any;
+        cc?: string[];
+        bcc?: string[];
         replyto?: string;
         date?: Date;
         headers?: { [key: string]: string };
@@ -65,7 +66,8 @@ declare namespace Sendgrid {
         subject: string;
         text: string;
         html: string;
-        bcc: any;
+        cc: string[];
+        bcc: string[];
         replyto: string;
         date: Date;
         headers: { [key: string]: string };


### PR DESCRIPTION
The sendgrid package was missing the `cc` field, and the `bcc` field had a too generic type (`any` instead of `string[]`, as used on the `setCcs` and `setBccs` below.

[SourceCode](https://github.com/sendgrid/sendgrid-nodejs/blob/master/lib/helpers/mail/mail.js#L559)