### PR TITLE
Add missing walk() method to fs-extra

### DIFF
--- a/fs-extra/fs-extra-tests.ts
+++ b/fs-extra/fs-extra-tests.ts
@@ -101,3 +101,12 @@ fs.ensureSymlink(path, errorCallback);
 fs.ensureSymlinkSync(path);
 fs.emptyDir(path, errorCallback);
 fs.emptyDirSync(path);
+
+var items: string[];
+fs.walk("my-path")
+  .on('data', function (item) {
+    items.push(item.path);
+  })
+  .on('end', function () {
+    console.dir(items);
+  });

--- a/fs-extra/index.d.ts
+++ b/fs-extra/index.d.ts
@@ -8,6 +8,7 @@
 /// <reference types="node" />
 
 import * as stream from 'stream';
+import { Stats } from "fs";
 export * from "fs";
 
 export declare function copy(src: string, dest: string, callback?: (err: Error) => void): void;
@@ -72,8 +73,21 @@ export declare function ensureSymlinkSync(path: string): void;
 
 export declare function emptyDir(path: string, callback?: (err: Error) => void): void;
 export declare function emptyDirSync(path: string): boolean;
-	
-    export interface CopyFilterFunction {
+
+export interface WalkEventEmitter {
+    on(event: 'data', callback: (file: WalkEventFile) => void): WalkEventEmitter;
+    on(event: 'end', callback: () => void): WalkEventEmitter;
+    on(event: string, callback: Function): WalkEventEmitter;
+}
+
+export interface WalkEventFile {
+    path: string;
+    stats: Stats;
+}
+
+export function walk(path: string, options?: {}): WalkEventEmitter;
+
+export interface CopyFilterFunction {
     (src: string): boolean
 }
 

--- a/fs-extra/index.d.ts
+++ b/fs-extra/index.d.ts
@@ -100,11 +100,11 @@ export interface CopyOptions {
     filter?: CopyFilter
     recursive?: boolean
 }
-	
-	export interface MoveOptions {
-		clobber? : boolean;
-		limit?: number;
-	}
+
+export interface MoveOptions {
+    clobber? : boolean;
+    limit?: number;
+}
 
 export interface MoveOptions {
     clobber? : boolean;


### PR DESCRIPTION
A couple of other small indentation fixes to the same file are included as well. Test is taken directly from the example in the docs.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] ~~Run `npm run lint -- package-name` if a `tslint.json` is present.~~

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/fs-extra#walk
- [ ] Increase the version number in the header if appropriate. **[No version number in the header?]**
