### PR TITLE
js-yaml: add missing DumpOptions

### DIFF
--- a/js-yaml/index.d.ts
+++ b/js-yaml/index.d.ts
@@ -42,6 +42,14 @@ declare namespace jsyaml {
 		styles?: Object;
 		// specifies a schema to use.
 		schema?: any;
+		// if true, sort keys when dumping YAML. If a function, use the function to sort the keys. (default: false)
+		sortKeys?: boolean;
+		// set max line width. (default: 80)
+		lineWidth?: number;
+		// if true, don't convert duplicate objects into references (default: false)
+		noRefs?: boolean;
+		// if true don't try to be compatible with older yaml versions. Currently: don't quote "yes", "no" and so on, as required for YAML 1.1 (default: false)
+		noCompatMode?: boolean;
 	}
 
 	export interface TypeConstructorOptions {


### PR DESCRIPTION
Please fill in this template.

- [X] Prefer to make your PR against the `types-2.0` branch.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodeca/js-yaml#safedump-object---options-
- [X] Increase the version number in the header if appropriate. **N/A**

