### PR TITLE
Added missing return type to on() methods. (johnny-five)

### DIFF
--- a/johnny-five/johnny-five.d.ts
+++ b/johnny-five/johnny-five.d.ts
@@ -118,9 +118,9 @@ declare module "johnny-five" {
 
     export class Compass{
         constructor(option: CompassOptions);
-        on(event: string, cb: ()=>void): void;
-        on(event: "change", cb: ()=>void): void;
-        on(event: "data", cb: (data: any)=>void): void;
+        on(event: string, cb: ()=>void): this;
+        on(event: "change", cb: ()=>void): this;
+        on(event: "data", cb: (data: any)=>void): this;
     }
 
     export interface ESCOption{
@@ -153,9 +153,9 @@ declare module "johnny-five" {
 
     export class Gyro{
         constructor(option: GyroGeneralOption | GyroAnalogOption | GyroMPU6050Option);
-        on(event: string, cb: ()=>void): void;
-        on(event: "change", cb: ()=>void): void;
-        on(event: "data", cb: (data: any)=>void): void;
+        on(event: string, cb: ()=>void): this;
+        on(event: "change", cb: ()=>void): this;
+        on(event: "data", cb: (data: any)=>void): this;
         recalibrate(): void;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/events.html#events_emitter_on_eventname_listener

* Returns a reference to the EventEmitter, so that calls can be chained.

