### PR TITLE
Added the brand property to the StripeCardData and fix style issues, lint

### DIFF
--- a/stripe/index.d.ts
+++ b/stripe/index.d.ts
@@ -68,15 +68,13 @@ interface StripeCardData {
     createToken(data: StripeTokenData, responseHandler: (status: number, response: StripeTokenResponse) => void): void;
 }
 
-interface StripeBankAccount
-{
-    createToken(params: StripeBankTokenParams, stripeResponseHandler: (status:number, response: StripeBankTokenResponse) => void): void;
+interface StripeBankAccount {
+    createToken(params: StripeBankTokenParams, stripeResponseHandler: (status: number, response: StripeBankTokenResponse) => void): void;
     validateRoutingNumber(routingNumber: number | string, countryCode: string): boolean;
     validateAccountNumber(accountNumber: number | string, countryCode: string): boolean;
 }
 
-interface StripeBankTokenParams
-{
+interface StripeBankTokenParams {
     country: string;
     currency: string;
     account_number: number | string;
@@ -85,8 +83,7 @@ interface StripeBankTokenParams
     account_holder_type: string;
 }
 
-interface StripeBankTokenResponse
-{
+interface StripeBankTokenResponse {
     id: string;
     bank_account: {
         country: string;
@@ -103,13 +100,7 @@ interface StripeBankTokenResponse
     error?: StripeError;
 }
 
-declare var Stripe: StripeStatic;
-declare module "Stripe" {
-    export = StripeStatic;
-}
-
-interface StripeApplePay
-{
+interface StripeApplePay {
     checkAvailability(resopnseHandler: (result: boolean) => void): void;
     buildSession(data: StripeApplePayPaymentRequest,
                  onSuccessHandler: (result: StripeApplePaySessionResult, completion: ((value: any) => void)) => void,
@@ -120,8 +111,7 @@ type StripeApplePayBillingContactField = 'postalAddress' | 'name';
 type StripeApplePayShippingContactField = StripeApplePayBillingContactField | 'phone' | 'email';
 type StripeApplePayShipping = 'shipping' | 'delivery' | 'storePickup' | 'servicePickup';
 
-interface StripeApplePayPaymentRequest
-{
+interface StripeApplePayPaymentRequest {
     billingContact: StripeApplePayPaymentContact;
     countryCode: string;
     currencyCode: string;
@@ -135,30 +125,26 @@ interface StripeApplePayPaymentRequest
 }
 
 // https://developer.apple.com/reference/applepayjs/1916082-applepay_js_data_types
-interface StripeApplePayLineItem
-{
+interface StripeApplePayLineItem {
     type: 'pending' | 'final';
     label: string;
     amount: number;
 }
 
-interface StripeApplePaySessionResult
-{
+interface StripeApplePaySessionResult {
     token: StripeTokenResponse;
     shippingContact?: StripeApplePayPaymentContact;
     shippingMethod?: StripeApplePayShippingMethod;
 }
 
-interface StripeApplePayShippingMethod
-{
+interface StripeApplePayShippingMethod {
     label: string;
     detail: string;
     amount: number;
     identifier: string;
 }
 
-interface StripeApplePayPaymentContact
-{
+interface StripeApplePayPaymentContact {
     emailAddress: string;
     phoneNumber: string;
     givenName: string;

--- a/stripe/index.d.ts
+++ b/stripe/index.d.ts
@@ -49,6 +49,8 @@ interface StripeError {
     param?: string;
 }
 
+type StripeCardDataBrand = 'Visa' | 'American Express' | 'MasterCard' | 'Discover JCB' | 'Diners Club' | 'Unknown';
+
 interface StripeCardData {
     object: string;
     last4: string;
@@ -62,6 +64,7 @@ interface StripeCardData {
     address_state?: string;
     address_zip?: string;
     address_country?: string;
+    brand?: StripeCardDataBrand;
     createToken(data: StripeTokenData, responseHandler: (status: number, response: StripeTokenResponse) => void): void;
 }
 

--- a/stripe/index.d.ts
+++ b/stripe/index.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Andy Hawkins <https://github.com/a904guy/,http://a904guy.com>, Eric J. Smith <https://github.com/ejsmith/>, Amrit Kahlon <https://github.com/amritk/>, Adam Cmiel <https://github.com/adamcmiel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+declare const Stripe: StripeStatic;
+
 interface StripeStatic {
     applePay: StripeApplePay;
     setPublishableKey(key: string): void;

--- a/stripe/index.d.ts
+++ b/stripe/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for stripe
+// Type definitions for stripe 0.0
 // Project: https://stripe.com/
 // Definitions by: Andy Hawkins <https://github.com/a904guy/,http://a904guy.com>, Eric J. Smith <https://github.com/ejsmith/>, Amrit Kahlon <https://github.com/amritk/>, Adam Cmiel <https://github.com/adamcmiel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -155,3 +155,7 @@ interface StripeApplePayPaymentContact {
     postalCode: string;
     countryCode: string;
 }
+
+// The Stripe client side APIs are not made available to package managers for direct installation.
+// As explained compliance reasons. Source: https://github.com/stripe/stripe-node/blob/master/README.md#these-are-serverside-bindings-only
+// A release date versioning schema is used to version these APIs.

--- a/stripe/stripe-tests.ts
+++ b/stripe/stripe-tests.ts
@@ -1,0 +1,25 @@
+function success(card: StripeCardData) {
+    console.log(card.brand && card.brand.toString());
+}
+
+const cardNumber = '4242424242424242';
+
+const isValid = Stripe.validateCardNumber(cardNumber);
+if (isValid) {
+    const tokenData: StripeTokenData = {
+        number: cardNumber,
+        exp_month: 1,
+        exp_year: 2100,
+        cvc: '111'
+    };
+    Stripe.card.createToken(tokenData, (status, response) => {
+        if (response.error) {
+            console.error(response.error.message);
+            if (response.error.param) {
+                console.error(response.error.param);
+            }
+        } else {
+            success(response.card);
+        }
+    });
+}

--- a/stripe/tsconfig.json
+++ b/stripe/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "noImplicitAny": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/stripe/tsconfig.json
+++ b/stripe/tsconfig.json
@@ -13,6 +13,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "stripe-tests.ts"
     ]
 }

--- a/stripe/tslint.json
+++ b/stripe/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../tslint.json",
+    "rules": {
+        // The stripe client side APIs are only not published as dedicated packages compliance reasons. A release date versioning schema is used.
+        "dt-header": false
+    }
+}

--- a/stripe/tslint.json
+++ b/stripe/tslint.json
@@ -1,7 +1,3 @@
 {
-    "extends": "../tslint.json",
-    "rules": {
-        // The stripe client side APIs are only not published as dedicated packages compliance reasons. A release date versioning schema is used.
-        "dt-header": false
-    }
+    "extends": "../tslint.json"
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.<sup>1</sup>

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/api#card_object
- [x] Increase the version number in the header if appropriate.<sup>2</sup>

Unsure about ambient declaration:
Removed as it seemed to be in error:
  - Letter casing was not correct. (examining source suggests the global may be re-exported as an AMD module but under the name `"stipe"`, not `"Stripe"`
  - The export was the `interface` StipeStatic which is only useful to refer to the type of the global defined by the module (the global `Stripe` created by `stripe.js` from `https://js.stripe.com/v2/`)
  - This module does not seem a suitable candidate for a UMD declaration.

Interface change
Added the `brand` property to the `StripeCardData` declaration with the type
`'Visa' | 'American Express' | 'MasterCard' | 'Discover JCB' | 'Diners Club' | 'Unknown'`

**Notes**:
  1. See the suppression in tslint.json (added) and then 
  2. The stripe client side APIs are only not published as dedicated packages for compliance reasons. A release date versioning schema is used.