### PR TITLE
Correct missing ‘auto’ option of GridList’s cellHeight

### DIFF
--- a/material-ui/material-ui.d.ts
+++ b/material-ui/material-ui.d.ts
@@ -966,7 +966,7 @@ declare namespace __MaterialUI {
 
     namespace GridList {
         interface GridListProps {
-            cellHeight?: number;
+            cellHeight?: number|'auto';
             cols?: number;
             padding?: number;
             style?: React.CSSProperties;


### PR DESCRIPTION
Please fill in this template.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/callemall/material-ui/blob/master/src/GridList/GridList.js
- [x] Increase the version number in the header if appropriate.

