### PR TITLE
Updated jquery.dataTables for 1.10.9

### DIFF
--- a/jquery.datatables/index.d.ts
+++ b/jquery.datatables/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for JQuery DataTables 1.10.8
+// Type definitions for JQuery DataTables 1.10.9
 // Project: http://www.datatables.net
 // Definitions by: Kiarash Ghiaseddin <https://github.com/Silver-Connection/DefinitelyTyped>, Omid Rad <https://github.com/omidkrad>, Armin Sander <https://github.com/pragmatrix/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -8,7 +8,7 @@
 // - Plugin and extension definitions are not typed.
 // - Some return types are not fully wokring
 
-/// <reference types="jquery"/>
+/// <reference types="jquery" />
 
 interface JQuery {
     DataTable(param?: DataTables.Settings): DataTables.DataTable;
@@ -1752,9 +1752,10 @@ declare namespace DataTables {
         oFeatures: FeaturesLegacy;
         oScroll: ScrollingLegacy;
         oLanguage: LanguageLegacy; // | { fnInfoCallback: FunctionInfoCallback; };
-        oBrowser: { bScrollOversize: boolean; };
+        oBrowser: BrowserLegacy;
         aanFeatures: ArrayStringNode[][];
         aoData: RowLegacy[];
+        aIds: any;
         aiDisplay: number[];
         aiDisplayMaster: number[];
         aoColumns: ColumnLegacy[];
@@ -1827,6 +1828,14 @@ declare namespace DataTables {
         iTabIndex: number;
         nScrollHead: Node;
         nScrollFoot: Node;
+        rowIdFn: (mSource: string | number | Function) => Function;
+    }
+
+    export interface BrowserLegacy {
+        barWidth: number,
+        bBounding: boolean,
+        bScrollbarLeft: boolean,
+        bScrollOversize: boolean
     }
 
     export interface FeaturesLegacy {

--- a/jquery.datatables/jquery.dataTables-tests.ts
+++ b/jquery.datatables/jquery.dataTables-tests.ts
@@ -1,4 +1,4 @@
-/// <reference types="jquery" />
+/// <reference types="jquery"/>
 
 
 $(document).ready(function () {
@@ -267,6 +267,17 @@ $(document).ready(function () {
         };
 
     //#endregion "Settings"
+
+    //#region "Settings-Legacy"
+
+    var browserLegacy: DataTables.BrowserLegacy = {
+        barWidth: 10,
+        bBounding: true,
+        bScrollbarLeft: true,
+        bScrollOversize: true
+    }
+    
+    //#endregion
 
     //#region "Init"
 

--- a/jquery.datatables/tsconfig.json
+++ b/jquery.datatables/tsconfig.json
@@ -1,8 +1,4 @@
 {
-    "files": [
-        "index.d.ts",
-        "jquery.dataTables-tests.ts"
-    ],
     "compilerOptions": {
         "module": "commonjs",
         "target": "es6",
@@ -15,5 +11,9 @@
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
-    }
+    },
+    "files": [
+        "index.d.ts",
+        "jquery.dataTables-tests.ts"
+    ]
 }


### PR DESCRIPTION
Release Notes: https://cdn.datatables.net/1.10.9/

* Moved legacy browser settings to its own data type.
* Added 'aIds' property on legacy settings object for mapping row ids to data indexes.
* Added 'rowIdFn' function to legacy settings object to get a row's id from the row's data.