### PR TITLE
add walk and walkSync to fs-extra

### DIFF
--- a/fs-extra/fs-extra-tests.ts
+++ b/fs-extra/fs-extra-tests.ts
@@ -2,6 +2,7 @@
 /// <reference types="node" />
 
 import fs = require('fs-extra');
+import * as Path from 'path'
 
 var src: string;
 var dest: string;
@@ -110,3 +111,26 @@ fs.walk("my-path")
   .on('end', function () {
     console.dir(items);
   });
+
+const ignoreHiddenFiles = (item: string): boolean => {
+  const basename = Path.basename(item)
+  return basename === '.' || basename[0] !== '.'
+}
+
+const sortPaths = (left: string, right: string) => left.localeCompare(right);
+
+const options = {
+  filter: ignoreHiddenFiles,
+  pathSorter: sortPaths
+}
+
+fs.walk(path, options)
+  .on('readable', () => {
+    let item: { path: string, stats: fs.Stats } | undefined
+    while ((item = this.read())) {
+      items.push(item.path)
+    }
+  })
+  .on('end', function () {
+
+  })

--- a/fs-extra/fs-extra-tests.ts
+++ b/fs-extra/fs-extra-tests.ts
@@ -125,8 +125,8 @@ const options = {
 }
 
 fs.walk(path, options)
-  .on('readable', () => {
-    let item: { path: string, stats: fs.Stats } | undefined
+  .on('readable', function (this: fs.PathEntryStream) {
+    let item: fs.PathEntry | undefined
     while ((item = this.read())) {
       items.push(item.path)
     }

--- a/fs-extra/index.d.ts
+++ b/fs-extra/index.d.ts
@@ -7,8 +7,8 @@
 
 /// <reference types="node" />
 
-import * as stream from 'stream';
 import { Stats } from "fs";
+
 export * from "fs";
 
 export declare function copy(src: string, dest: string, callback?: (err: Error) => void): void;
@@ -76,6 +76,8 @@ export declare function emptyDirSync(path: string): boolean;
 
 export interface WalkEventEmitter extends NodeJS.ReadableStream {
     on(event: 'data', callback: (file: WalkEventFile) => void): this;
+    on(event: 'readable', callback: (this: PathEntryStream) => void): this;
+    on(event: 'error', callback: (error: Error, item: PathEntry) => void): this;
     on(event: 'end', callback: () => void): this;
     on(event: string | symbol, callback: Function): this;
 }
@@ -85,7 +87,40 @@ export interface WalkEventFile {
     stats: Stats;
 }
 
-export function walk(path: string, options?: {}): WalkEventEmitter;
+export interface WalkOptions {
+  /**
+   * Control how results are enumerated from `readdir`:
+   * - 'shift' will return the first element from the array.
+   * - 'pop' will return the last element from the array.
+   *
+   * If not specified, the default behaviour is 'shift'
+   */
+  queueMethod?: 'pop' | 'shift';
+  /**
+   * Provide a function to sort the paths before they are enumerated
+   */
+  pathSorter?: (left: string, right: string) => number;
+  /**
+   * An optional object to override the default `fs` APIs for testing purposes
+   */
+  fs?: Object;
+  /**
+   * Provide a function to exclude certain file paths. The function should
+   * return true when the element should be kept, and false otherwise.
+   */
+  filter?: (path: string, index: number, array: Array<PathEntry>) => boolean;
+}
+
+export type PathEntry = {
+  path: string;
+  stats: Stats;
+}
+
+export type PathEntryStream = {
+  read(): PathEntry | null
+}
+
+export function walk(path: string, options?: WalkOptions): WalkEventEmitter;
 export function walkSync(path: string): ReadonlyArray<string>;
 
 export interface CopyFilterFunction {

--- a/fs-extra/index.d.ts
+++ b/fs-extra/index.d.ts
@@ -86,6 +86,7 @@ export interface WalkEventFile {
 }
 
 export function walk(path: string, options?: {}): WalkEventEmitter;
+export function walkSync(path: string): ReadonlyArray<string>;
 
 export interface CopyFilterFunction {
     (src: string): boolean


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- ~~[ ] Run `npm run lint -- package-name` if a `tslint.json` is present.~~

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - `walk` - [source](https://github.com/jprichardson/node-klaw/blob/master/src/index.js#L53-L55) and [documentation](https://github.com/jprichardson/node-fs-extra/tree/1.0.0#walk)
  - `walkSync` - [source](https://github.com/jprichardson/node-fs-extra/blob/1.0.0/lib/walk-sync/index.js#L4) and [documentation](https://github.com/jprichardson/node-fs-extra/tree/1.0.0#walksyncdir)
- ~~[ ] Increase the version number in the header if appropriate.~~

