### PR TITLE
ssh2: Error TS2411 when compiled with "strictNullChecks"

### DIFF
--- a/ssh2/index.d.ts
+++ b/ssh2/index.d.ts
@@ -1087,7 +1087,7 @@ export interface PseudoTtyInfo {
 }
 
 export interface TerminalModes {
-    [mode: string]: number;
+    [mode: string]: number|undefined;
     /** Interrupt character; `255` if none. Not all of these characters are supported on all systems. */
     VINTR?: number;
     /** The quit character (sends `SIGQUIT` signal on POSIX systems). */


### PR DESCRIPTION
The index signature in the `TerminalModes` causes a variety of errors when compiled with the `strictNullChecks` option:

```
index.d.ts(1092,5): error TS2411: Property 'VINTR' of type 'number | undefined' is not assignable to string index type 'number'.
index.d.ts(1094,5): error TS2411: Property 'VQUIT' of type 'number | undefined' is not assignable to string index type 'number'.
index.d.ts(1096,5): error TS2411: Property 'VERASE' of type 'number | undefined' is not assignable to string index type 'number'.
...
```

The reason for this is that not all properties satisfy the index signature (most properties are actually `number|undefined`, and not `number`).
This can be solved by changing the index signature from `[mode: string]: number` to `[mode: string]: number|undefined`.