### PR TITLE
Add typings for node-fetch extensions, remove unsupported options

### DIFF
--- a/node-fetch/index.d.ts
+++ b/node-fetch/index.d.ts
@@ -5,6 +5,8 @@
 
 ///<reference types="node" />
 
+import { Agent } from "http";
+
 export class Request extends Body {
 	constructor(input: string | Request, init?: RequestInit);
 	method: string;
@@ -12,20 +14,35 @@ export class Request extends Body {
 	headers: Headers;
 	context: RequestContext;
 	referrer: string;
-	mode: RequestMode;
 	redirect: RequestRedirect;
-	credentials: RequestCredentials;
-	cache: RequestCache;
+
+	//node-fetch extensions to the whatwg/fetch spec
+	compress: boolean;
+	agent?: Agent;
+	counter: number;
+	follow: number;
+	hostname: string;
+	protocol: string;
+	port?: number;
+	timeout: number;
+	size: number;
 }
 
 interface RequestInit {
+	//whatwg/fetch standard options
 	method?: string;
 	headers?: HeaderInit | { [index: string]: string };
 	body?: BodyInit;
-	mode?: RequestMode;
 	redirect?: RequestRedirect;
-	credentials?: RequestCredentials;
-	cache?: RequestCache;
+
+	//node-fetch extensions
+	timeout?: number; //=0 req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies)
+	compress?: boolean; //=true support gzip/deflate content encoding. false to disable
+	size?: number; //=0 maximum response body size in bytes. 0 to disable
+	agent?: Agent; //=null http.Agent instance, allows custom proxy, certificate etc.
+	follow?: number; //=20 maximum redirect count. 0 to not follow redirect
+
+	//node-fetch does not support mode, cache or credentials options
 }
 
 type RequestContext =
@@ -56,7 +73,6 @@ export class Headers {
 export class Body {
 	bodyUsed: boolean;
 	body: NodeJS.ReadableStream;
-	arrayBuffer(): Promise<ArrayBuffer>;
 	json(): Promise<any>;
 	json<T>(): Promise<T>;
 	text(): Promise<string>;
@@ -71,7 +87,9 @@ export class Response extends Body {
 	url: string;
 	status: number;
 	ok: boolean;
+	size: number;
 	statusText: string;
+	timeout: number;
 	headers: Headers;
 	clone(): Response;
 }

--- a/node-fetch/node-fetch-tests.ts
+++ b/node-fetch/node-fetch-tests.ts
@@ -1,4 +1,5 @@
 import fetch, { Headers, Request, RequestInit, Response } from 'node-fetch';
+import { Agent } from "http";
 
 function test_fetchUrlWithOptions() {
 	var headers = new Headers();
@@ -6,10 +7,11 @@ function test_fetchUrlWithOptions() {
 	var requestOptions: RequestInit = {
 		method: "POST",
 		headers: headers,
-		mode: 'same-origin',
-		credentials: 'omit',
-		cache: 'default',
-		redirect: 'manual'
+		compress: true,
+		follow: 10,
+		redirect: 'manual',
+		size: 100,
+		timeout: 5000
 	};
 	handlePromise(fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions));
 }
@@ -36,6 +38,11 @@ function test_fetchUrlWithRequestObject() {
 		}
 	};
 	var request: Request = new Request("http://www.andlabs.net/html5/uCOR.php", requestOptions);
+	var timeout: number = request.timeout;
+	var size: number = request.size;
+	var agent: Agent = request.agent;
+	var protocol: string = request.protocol
+
 	handlePromise(fetch(request));
 }
 


### PR DESCRIPTION
The current `node-fetch` definitions are [based off](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/9510) `whatwg-fetch`, but `node-fetch` has various extensions and limitations compared to that spec/module (links below). This PR removes unsupported options and adds documented extensions.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present. - **N/A**

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [node-fetch readme](https://github.com/bitinn/node-fetch/blob/master/README.md#options), [node-fetch known differences from whatwg/fetch](https://github.com/bitinn/node-fetch/blob/master/LIMITS.md)
- [ ] Increase the version number in the header if appropriate. **N/A - this is a correction, not an update**

