### PR TITLE
Update react-native.0.29.d.ts

### DIFF
--- a/react-native/react-native.0.29.d.ts
+++ b/react-native/react-native.0.29.d.ts
@@ -1871,7 +1871,7 @@ declare namespace  __React {
          * Specifies the side of the screen from which the drawer will slide in.
          * enum(DrawerConsts.DrawerPosition.Left, DrawerConsts.DrawerPosition.Right)
          */
-        drawerPosition?: any;
+        drawerPosition?: number;
 
         /**
          * Specifies the width of the drawer, more precisely the width of the


### PR DESCRIPTION
drawerPosition is of type `number`
Android DrawerConsts.DrawerPosition.Left is equivalent to DrawerLayoutAndroid.positions.Left
Android DrawerConsts.DrawerPosition.Right is equivalent to DrawerLayoutAndroid.positions.Right