### PR TITLE
Changed type of injectedScript property to string

### DIFF
--- a/chrome/chrome.d.ts
+++ b/chrome/chrome.d.ts
@@ -1617,7 +1617,7 @@ declare namespace chrome.devtools.inspectedWindow {
 		/** Optional. When true, the loader will ignore the cache for all inspected page resources loaded before the load event is fired. The effect is similar to pressing Ctrl+Shift+R in the inspected window or within the Developer Tools window.  */
         ignoreCache?: boolean;
 		/** Optional. If specified, the script will be injected into every frame of the inspected page immediately upon load, before any of the frame's scripts. The script will not be injected after subsequent reloads—for example, if the user presses Ctrl+R.  */
-        injectedScript?: boolean;
+        injectedScript?: string;
 		/**
 		 * Optional.
  		 * If specified, this script evaluates into a function that accepts three string arguments: the source to preprocess, the URL of the source, and a function name if the source is an DOM event handler. The preprocessorerScript function should return a string to be compiled by Chrome in place of the input source. In the case that the source is a DOM event handler, the returned source must compile to a single JS function.


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/extensions/devtools_inspectedWindow#method-reload
- [ ] Increase the version number in the header if appropriate.

The injectedScript property of the ReloadOptions should take string value with script code, not the bool flag as in current version