### PR TITLE
Three changes to index.d.ts

### DIFF
--- a/three/index.d.ts
+++ b/three/index.d.ts
@@ -261,7 +261,7 @@ declare namespace THREE {
         reset(): AnimationAction;
         isRunning(): boolean;
         startAt(time: number): AnimationAction;
-        setLoop(mode: boolean, repetitions: number): AnimationAction;
+        setLoop(mode: AnimationActionLoopStyles, repetitions?: number): AnimationAction;
         setEffectiveWeight(weight: number): AnimationAction;
         getEffectiveWeight(): number;
         fadeIn(duration: number): AnimationAction;
@@ -1284,6 +1284,11 @@ declare namespace THREE {
          * Face normals must be existing / computed beforehand.
          */
         computeVertexNormals(areaWeighted?: boolean): void;
+
+        /**
+         * Compute vertex normals, but duplicating face normals.
+         */
+        computeFlatVertexNormals(): void;
 
         /**
          * Computes morph normals.
@@ -5729,7 +5734,7 @@ declare namespace THREE {
             encoding?: TextureEncoding
         );
 
-        image: { data: ImageData; width: number; height: number; };
+        image: ImageData;
     }
 
     export class VideoTexture extends Texture {

--- a/three/index.d.ts
+++ b/three/index.d.ts
@@ -261,7 +261,7 @@ declare namespace THREE {
         reset(): AnimationAction;
         isRunning(): boolean;
         startAt(time: number): AnimationAction;
-        setLoop(mode: AnimationActionLoopStyles, repetitions?: number): AnimationAction;
+        setLoop(mode: AnimationActionLoopStyles, repetitions: number): AnimationAction;
         setEffectiveWeight(weight: number): AnimationAction;
         getEffectiveWeight(): number;
         fadeIn(duration: number): AnimationAction;


### PR DESCRIPTION
1. Geometry has method computeFlatVertexNormals (added in mrdoob/three.js#9222)
2. The type of image in DataTexture is actually ImageData.
3. The type of the first parameter in AnimationAction.setLoop() is the enum AnimationActionLoopStyles (see https://github.com/mrdoob/three.js/blob/master/src/animation/AnimationAction.js#L50)

Please fill in this template.

- [X] Prefer to make your PR against the `types-2.0` branch.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [N/A] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [N/A] Increase the version number in the header if appropriate.

