### PR TITLE
csurf.d.ts relying on CookieOptions from express

### DIFF
--- a/csurf/csurf.d.ts
+++ b/csurf/csurf.d.ts
@@ -12,7 +12,7 @@ declare namespace Express {
 }
 
 declare module "csurf" {
-  import express = require('express');
+  import express = require('express-serve-static-core');
 
   function csurf(options?: {
     value?: (req: express.Request) => string;


### PR DESCRIPTION
It seems express no longer exports `CookieOptions`, we need to import `express-serve-static-core` instead.

Thanks