### PR TITLE
[types-2.0] D3 Upgrade to version 4.4

### DIFF
--- a/d3/d3-v3.5-tests.ts
+++ b/d3/d3-v3.5-tests.ts
@@ -1,4 +1,4 @@
-
+/* tslint:disable */
 
 //Example from http://bl.ocks.org/3887235
 interface TestPieChartData {
@@ -2708,14 +2708,14 @@ function testMultiUtcFormat() {
 }
 
 function testEnterSizeEmpty() {
-    
+
     var selectionSize: number,
         emptyStatus: boolean;
-        
+
     var newNodes = d3.selectAll('.test')
                 .data(['1', '2', '3'])
                 .enter();
-                
+
     emptyStatus = newNodes.empty();
     selectionSize = newNodes.size();
 

--- a/d3/d3-v3.5-tests.ts
+++ b/d3/d3-v3.5-tests.ts
@@ -1,4 +1,4 @@
-/* tslint:disable */
+
 
 //Example from http://bl.ocks.org/3887235
 interface TestPieChartData {

--- a/d3/d3-v3.5.d.ts
+++ b/d3/d3-v3.5.d.ts
@@ -1,7 +1,11 @@
-// Type definitions for d3JS v3.5.17
+// Type definitions for d3JS 3.5
 // Project: http://d3js.org/
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/* tslint:disable */
+
+// Latest patch version of module validated against: 3.5.17
 
 export = d3;
 export as namespace d3;

--- a/d3/index.d.ts
+++ b/d3/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3 standard bundle v4.3
+// Type definitions for D3JS d3 standard bundle 4.4
 // Project: https://github.com/d3/d3
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/d3/legacy/plugins/index.d.ts
+++ b/d3/legacy/plugins/index.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/* tslint:disable */
+
 import * as d3 from 'd3';
 
 declare module 'd3' {

--- a/d3/package.json
+++ b/d3/package.json
@@ -12,7 +12,7 @@
     "@types/d3-ease": "1.0",
     "@types/d3-force": "1.0",
     "@types/d3-format": "1.0",
-    "@types/d3-geo": "1.3",
+    "@types/d3-geo": "1.4",
     "@types/d3-hierarchy": "1.0",
     "@types/d3-interpolate": "1.1",
     "@types/d3-path": "1.0",
@@ -29,6 +29,6 @@
     "@types/d3-timer": "1.0",
     "@types/d3-transition": "1.0",
     "@types/d3-voronoi": "1.1",
-    "@types/d3-zoom": "1.0"
+    "@types/d3-zoom": "1.1"
   }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/d3/d3/blob/master/package.json>>
- [x] Increase the version number in the header if appropriate.


d3 [Chore]:
* Update dependencies for d3-geo to 1.4 and d3-zoom to 1.1 to reflect d3 Standard Bundle version 4.4
* Exempted _legacy_ definitions and tests from TSLint at file level.