### PR TITLE
Add global definition for XLSX library

### DIFF
--- a/xlsx/xlsx-global-tests.ts
+++ b/xlsx/xlsx-global-tests.ts
@@ -1,0 +1,25 @@
+/// <reference path="xlsx.d.ts" />
+
+var options:XLSX.IParsingOptions = {
+    cellDates:true
+};
+
+var workbook = XLSX.readFile('test.xlsx', options);
+var otherworkbook = XLSX.readFile('test.xlsx', {type: 'file'});
+
+console.log(workbook.Props.Author);
+
+var firstsheet:string = workbook.SheetNames[0];
+
+var firstworksheet = workbook.Sheets[firstsheet];
+
+console.log(firstworksheet["A1"]);
+
+interface tester {
+    name:string;
+    age: number;
+}
+
+var jsonvalues:tester[] = XLSX.utils.sheet_to_json<tester>(firstworksheet);
+var csv = XLSX.utils.sheet_to_csv(firstworksheet);
+var formulae = XLSX.utils.sheet_to_formulae(firstworksheet);

--- a/xlsx/xlsx.d.ts
+++ b/xlsx/xlsx.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: themauveavenger <https://github.com/themauveavenger/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'xlsx' {
+declare namespace XLSX {
 
     export function readFile(filename:string, opts?:IParsingOptions):IWorkBook;
     export function read(data:any, opts?:IParsingOptions):IWorkBook;
@@ -152,5 +152,8 @@ declare module 'xlsx' {
         decode_cell(address: string): ICell;
         decode_range(range: string): IRange;
     }
+}
 
+declare module 'xlsx' {
+    export = XLSX;
 }


### PR DESCRIPTION
Minor change to allow use as a global type.  This was made against master to make this global def available to typings.

New tests pass.  Existing tests pass.

- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

