### PR TITLE
add `NullValueNode`

### DIFF
--- a/graphql/index.d.ts
+++ b/graphql/index.d.ts
@@ -319,6 +319,7 @@ declare module "graphql/language/ast" {
         | FloatValueNode
         | StringValueNode
         | BooleanValueNode
+        | NullValueNode
         | EnumValueNode
         | ListValueNode
         | ObjectValueNode
@@ -450,6 +451,7 @@ declare module "graphql/language/ast" {
         | FloatValueNode
         | StringValueNode
         | BooleanValueNode
+        | NullValueNode
         | EnumValueNode
         | ListValueNode
         | ObjectValueNode
@@ -476,6 +478,11 @@ declare module "graphql/language/ast" {
         kind: 'BooleanValue';
         loc?: Location;
         value: boolean;
+    }
+
+    export type NullValueNode = {
+        kind: 'NullValue';
+        loc?: Location;
     }
 
     export type EnumValueNode = {


### PR DESCRIPTION
In the most recent update to GraphQL, the null literal was added to the AST. This PR adds the types for the new AST node. For reference, see:

- https://github.com/graphql/graphql-js/blob/e49df4980396ed40d9b43bad738c53e001d8f0e5/src/language/ast.js#L129
- https://github.com/graphql/graphql-js/blob/e49df4980396ed40d9b43bad738c53e001d8f0e5/src/language/ast.js#L264
- https://github.com/graphql/graphql-js/blob/e49df4980396ed40d9b43bad738c53e001d8f0e5/src/language/ast.js#L293-L296