### PR TITLE
SchemaOptions versionKey type can now accept booleans

### DIFF
--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -717,7 +717,7 @@ declare module "mongoose" {
     /** defaults to true */
     validateBeforeSave?: boolean;
     /** defaults to "__v" */
-    versionKey?: string;
+    versionKey?: string|boolean;
     /**
      * skipVersioning allows excluding paths from
      * versioning (the internal revision will not be


### PR DESCRIPTION
I changed it accordingly to the mongoose documentation that allows disabling versionKey for a schema by writing:

    new Schema({..}, { versionKey: false });

