### PR TITLE
SchemaOptions versionKey type can now accept booleans

### DIFF
--- a/csurf/csurf.d.ts
+++ b/csurf/csurf.d.ts
@@ -12,7 +12,7 @@ declare namespace Express {
 }
 
 declare module "csurf" {
-  import express = require('express');
+  import express = require('express-serve-static-core');
 
   function csurf(options?: {
     value?: (req: express.Request) => string;

--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -269,8 +269,18 @@ schema.plugin(function (schema, opts) {
   schema.get('path');
   opts.hasOwnProperty('');
 }).plugin(cb, {opts: true});
-schema.post('post', function (doc) {}).post('post', function (doc, next) {
+schema
+.post('save', function (error, doc, next) {
+  error.stack;
+  doc.model;
+  next.apply;
+})
+.post('save', function (doc: mongoose.Document, next: Function) {
+  doc.model;
   next(new Error());
+})
+.post('save', function (doc: mongoose.Document) {
+  doc.model;
 });
 schema.queue('m1', [1, 2, 3]).queue('m2', [[]]);
 schema.remove('path');

--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -196,6 +196,18 @@ QCModel.find({}).cursor({}).on('data', function (doc: any) {
 }).on('error', function (error: any) {
   throw error;
 }).close().then(cb).catch(cb);
+querycursor.map(function (doc) {
+  doc.foo = "bar";
+  return doc;
+}).on('data', function (doc: any) {
+  console.log(doc.foo);
+});
+querycursor.map(function (doc) {
+  doc.foo = "bar";
+  return doc;
+}).next(function (error, doc) {
+  console.log(doc.foo);
+});
 
 /*
  * section virtualtype.js

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -717,7 +717,7 @@ declare module "mongoose" {
     /** defaults to true */
     validateBeforeSave?: boolean;
     /** defaults to "__v" */
-    versionKey?: string;
+    versionKey?: string|boolean;
     /**
      * skipVersioning allows excluding paths from
      * versioning (the internal revision will not be

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -609,9 +609,13 @@ declare module "mongoose" {
      * @param method name of the method to hook
      * @param fn callback
      */
-    post<T extends Document>(method: string, fn: (doc: T) => void, ...args: any[]): this;
-    post<T extends Document>(method: string, fn: (doc: T, next: (err?: NativeError) => void,
-      ...otherArgs: any[]) => void): this;
+    post<T extends Document>(method: string, fn: (
+      error: mongodb.MongoError, doc: T, next: (err?: NativeError) => void
+    ) => void): this;
+
+    post<T extends Document>(method: string, fn: (
+      doc: T, next: (err?: NativeError) => void
+    ) => void): this;
 
     /**
      * Defines a pre hook for the document.

--- a/mongoose/mongoose.d.ts
+++ b/mongoose/mongoose.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Mongoose 4.6.8
+// Type definitions for Mongoose 4.7.0
 // Project: http://mongoosejs.com/
 // Definitions by: simonxca <https://github.com/simonxca/>, horiuchi <https://github.com/horiuchi/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -497,10 +497,16 @@ declare module "mongoose" {
     eachAsync(fn: (doc: T) => any, callback?: (err: any) => void): Promise<T>;
 
     /**
+     * Registers a transform function which subsequently maps documents retrieved
+     * via the streams interface or .next()
+     */
+    map(fn: (doc: T) => T): this;
+
+    /**
      * Get the next document from this cursor. Will return null when there are
      * no documents left.
      */
-    next(callback?: (err: any) => void): Promise<any>;
+    next(callback?: (err: any, doc?: T) => void): Promise<any>;
   }
 
   /*
@@ -562,6 +568,12 @@ declare module "mongoose" {
 
     /** Compiles indexes from fields and schema-level indexes */
     indexes(): any[];
+
+    /**
+     * Loads an ES6 class into a schema. Maps setters + getters, static methods, and
+     * instance methods to schema virtuals, statics, and methods.
+     */
+    loadClass(model: Function): this;
 
     /**
      * Adds an instance method to documents constructed from Models compiled from this schema.

--- a/nconf/nconf-tests.ts
+++ b/nconf/nconf-tests.ts
@@ -57,6 +57,7 @@ nconf.init(opts);
 p = nconf.overrides();
 p = nconf.overrides(opts);
 nconf.remove(str);
+bool = nconf.required(strArr);
 store = nconf.create(str, opts);
 
 str = nconf.key(value, value);
@@ -118,6 +119,7 @@ p = p.defaults(opts);
 p.init(opts);
 p = p.overrides(opts);
 p.remove(str);
+bool = p.required(strArr);
 store = p.create(str, opts);
 
 // - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/nconf/nconf.d.ts
+++ b/nconf/nconf.d.ts
@@ -32,6 +32,7 @@ declare module "nconf" {
 	export function init(options?: IOptions): void;
 	export function overrides(options?: IOptions): Provider;
 	export function remove(name: string): void;
+	export function required(keys: string[]): boolean;
 	export function create(name: string, options: IOptions): IStore;
 
 	export function key(...values: any[]): string;
@@ -95,6 +96,7 @@ declare module "nconf" {
 		init(options?: IOptions): void;
 		overrides(options?: IOptions): Provider;
 		remove(name: string): void;
+		required(keys: string[]): boolean;
 		create(name: string, options: IOptions): IStore;
 	}
 

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -2005,6 +2005,7 @@ declare namespace __React {
         optimum?: number;
         pattern?: string;
         placeholder?: string;
+        playsInline?: boolean;
         poster?: string;
         preload?: string;
         radioGroup?: string;

--- a/redux-localstorage-debounce/redux-localstorage-debounce-tests.ts
+++ b/redux-localstorage-debounce/redux-localstorage-debounce-tests.ts
@@ -1,0 +1,29 @@
+// Redux Localstorage Filter Test
+// ================================================================================
+/// <reference path="./redux-localstorage-debounce.d.ts" />
+/// <reference path="../redux-localstorage/redux-localstorage.d.ts" />
+/// <reference path="../redux/redux.d.ts" />
+
+// Imports
+// --------------------------------------------------------------------------------
+import { compose } from "redux"
+import {
+    default as persistState
+} from "redux-localstorage"
+import * as adapter from "redux-localstorage/lib/adapters/localStorage"
+import { default as debounce } from "redux-localstorage-debounce"
+
+const storageWait = compose(
+    debounce(100)
+)(adapter(window.localStorage))
+const enhancerWait = persistState(storageWait, "test")
+
+const storageMax = compose(
+    debounce(100, 200)
+)(adapter(window.localStorage))
+const enhancerMax = persistState(storageMax, "test")
+
+const storageOpts = compose(
+    debounce(100, { maxWait : 200, foo : "bar" })
+)(adapter(window.localStorage))
+const enhancerOpts = persistState(storageOpts, "test")

--- a/redux-localstorage-debounce/redux-localstorage-debounce.d.ts
+++ b/redux-localstorage-debounce/redux-localstorage-debounce.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for redux-localstorage-debounce v0.1.0
+// Project: https://github.com/elgerlambert/redux-localstorage-debounce
+// Definitions by: Karol Janyst <https://github.com/LKay>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../redux/redux.d.ts" />
+/// <reference path="../redux-localstorage/redux-localstorage.d.ts" />
+
+declare namespace ReduxLocalStorage {
+
+    namespace Debounce {
+        interface DebounceOptions {
+            maxWait?: number
+            [key: string]: any
+        }
+        function debounce (wait: number, options?: number | DebounceOptions): <A>(adapter: StorageAdapter<A>) => StorageAdapter<A>
+    }
+
+}
+
+declare module "redux-localstorage-debounce" {
+    export default ReduxLocalStorage.Debounce.debounce
+}

--- a/redux-localstorage-filter/redux-localstorage-filter-tests.ts
+++ b/redux-localstorage-filter/redux-localstorage-filter-tests.ts
@@ -1,0 +1,24 @@
+// Redux Localstorage Filter Test
+// ================================================================================
+/// <reference path="./redux-localstorage-filter.d.ts" />
+/// <reference path="../redux-localstorage/redux-localstorage.d.ts" />
+/// <reference path="../redux/redux.d.ts" />
+
+// Imports
+// --------------------------------------------------------------------------------
+import { compose } from "redux"
+import {
+    default as persistState
+} from "redux-localstorage"
+import * as adapter from "redux-localstorage/lib/adapters/localStorage"
+import { default as filter } from "redux-localstorage-filter"
+
+const storageSingle = compose(
+    filter("foo")
+)(adapter(window.localStorage))
+const enhancerSingle = persistState(storageSingle, "test")
+
+const storageMulti = compose(
+    filter(["foo", "bar"])
+)(adapter(window.localStorage))
+const enhancerMulti = persistState(storageMulti, "test")

--- a/redux-localstorage-filter/redux-localstorage-filter.d.ts
+++ b/redux-localstorage-filter/redux-localstorage-filter.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for redux-localstorage-filter v0.1.1
+// Project: https://github.com/elgerlambert/redux-localstorage-filter
+// Definitions by: Karol Janyst <https://github.com/LKay>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../redux/redux.d.ts" />
+/// <reference path="../redux-localstorage/redux-localstorage.d.ts" />
+
+declare namespace ReduxLocalStorage {
+
+    namespace Filter {
+        function getSubset (obj: any, paths: Array<string>): any
+        function filter (paths?: string | Array<string>): <A>(adapter: StorageAdapter<A>) => StorageAdapter<A>
+    }
+
+}
+
+declare module "redux-localstorage-filter" {
+    import getSubset = ReduxLocalStorage.Filter.getSubset
+
+    export {
+        getSubset
+    }
+
+    export default ReduxLocalStorage.Filter.filter
+
+}

--- a/redux-localstorage/redux-localstorage-tests.ts
+++ b/redux-localstorage/redux-localstorage-tests.ts
@@ -1,0 +1,40 @@
+// Redux Localstorage Test
+// ================================================================================
+/// <reference path="./redux-localstorage.d.ts" />
+/// <reference path="../redux/redux.d.ts" />
+
+// Imports
+// --------------------------------------------------------------------------------
+import { compose, combineReducers, createStore } from "redux"
+import {
+    default as persistState,
+    mergePersistedState,
+    actionTypes
+} from "redux-localstorage"
+import * as adapterAsyncStorage from "redux-localstorage/lib/adapters/AsyncStorage"
+import * as adapterLocalStorage from "redux-localstorage/lib/adapters/localStorage"
+import * as adapterSessionStorage from "redux-localstorage/lib/adapters/sessionStorage"
+
+const AsyncStorage: any = {}
+
+const rootReducer: Redux.Reducer<any> = (state: any, action: any) => state
+
+const reducer = compose(
+    mergePersistedState()
+)(rootReducer)
+
+const storageAsyncStorage = adapterAsyncStorage(AsyncStorage)
+const storageLocalStorage = adapterLocalStorage(window.localStorage)
+const storageSessionStorage = adapterSessionStorage(window.sessionStorage)
+
+const createStoreAsyncStorage = compose(
+    persistState(storageAsyncStorage, "foo")
+)(createStore)(reducer)
+
+const createStoreLocalStorage = compose(
+    persistState(storageLocalStorage, "foo")
+)(createStore)(reducer)
+
+const createStoreSessionStorage = compose(
+    persistState(storageSessionStorage, "foo")
+)(createStore)(reducer)

--- a/redux-localstorage/redux-localstorage.d.ts
+++ b/redux-localstorage/redux-localstorage.d.ts
@@ -1,0 +1,67 @@
+// Type definitions for redux-localstorage v1.0.0-rc4
+// Project: https://github.com/elgerlambert/redux-localstorage
+// Definitions by: Karol Janyst <https://github.com/LKay>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../redux/redux.d.ts" />
+
+declare namespace ReduxLocalStorage {
+
+    interface ActionTypes {
+        INIT: string
+    }
+
+    interface AdapterCallback {
+        <A>(err?: any, result?: A): void
+    }
+
+    interface StorageAdapter<A> {
+        0: A
+        put(key: string, value: any, callback: AdapterCallback): void
+        get(key: string, callback: AdapterCallback): void
+        del(key: string, callback: AdapterCallback): void
+    }
+
+    interface StorageAdapterCreator<A> {
+        (storage: A): StorageAdapter<A>
+    }
+
+    interface StorageAdapterEnhancer {}
+
+    function mergePersistedState (merge?: <A1, A2>(initialState: A1, persistentState: A2) => A1 & A2): <A>(next: Redux.Reducer<A>) => Redux.Reducer<A>
+
+    function persistState<A> (storage?: StorageAdapter<A>, key?: string, callback?: Function): Redux.GenericStoreEnhancer
+
+}
+
+declare module "redux-localstorage/lib/adapters/AsyncStorage" {
+    const adapterCreator: ReduxLocalStorage.StorageAdapterCreator<any>
+    export = adapterCreator
+}
+
+declare module "redux-localstorage/lib/adapters/localStorage" {
+    const adapterCreator: ReduxLocalStorage.StorageAdapterCreator<Storage>
+    export = adapterCreator
+}
+
+declare module "redux-localstorage/lib/adapters/sessionStorage" {
+    const adapterCreator: ReduxLocalStorage.StorageAdapterCreator<Storage>
+    export = adapterCreator
+}
+
+declare module "redux-localstorage" {
+    import mergePersistedState = ReduxLocalStorage.mergePersistedState
+
+    const actionTypes: ReduxLocalStorage.ActionTypes
+
+    export type StorageAdapterEnhancer = ReduxLocalStorage.StorageAdapterEnhancer
+
+    export {
+        mergePersistedState,
+        actionTypes
+    }
+
+    export default ReduxLocalStorage.persistState
+}
+
+


### PR DESCRIPTION
I changed it accordingly to the mongoose documentation that allows disabling versionKey for a schema by writing:

    new Schema({..}, { versionKey: false });

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/13163