### PR TITLE
[minimist] Update with JSDoc and generic overloads

### DIFF
--- a/minimist/index.d.ts
+++ b/minimist/index.d.ts
@@ -39,12 +39,13 @@ declare namespace minimist {
         string?: string | string[];
 
         /**
-         * A string or array of strings to always treat as booleans
+         * A boolean, string or array of strings to always treat as booleans. If true will treat
+         * all double hyphenated arguments without equals signs as boolean (e.g. affects `--foo`, not `-f` or `--foo=bar`)
          */
         boolean?: boolean | string | string[];
 
         /**
-         * An object mapping string names to strings or arrays of string argument names to use
+         * An object mapping string names to strings or arrays of string argument names to use as aliases
          */
         alias?: { [key: string]: string | string[] };
 
@@ -65,7 +66,8 @@ declare namespace minimist {
         unknown?: (arg: string) => boolean;
 
         /**
-         * When true, populate argv._ with everything before the -- and argv['--'] with everything after the --         
+         * When true, populate argv._ with everything before the -- and argv['--'] with everything after the --.
+         * Note that with -- set, parsing for arguments still stops after the `--`.
          */
         '--'?: boolean;
     }
@@ -79,7 +81,7 @@ declare namespace minimist {
         '--'?: string[];
 
         /**
-         * An array of non-option arguments
+         * Contains all the arguments that didn't have an option associated with them
          */
         _: string[];       
     }

--- a/minimist/index.d.ts
+++ b/minimist/index.d.ts
@@ -1,33 +1,87 @@
-// Type definitions for minimist 1.1.3
+// Type definitions for minimist 1.2.0
 // Project: https://github.com/substack/minimist
-// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Necroskillz <https://github.com/Necroskillz>
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Necroskillz <https://github.com/Necroskillz>, kamranayub <https://github.com/kamranayub>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
+/**
+ * Return an argument object populated with the array arguments from args
+ * 
+ * @param args An optional argument array (typically `process.argv.slice(2)`)
+ * @param opts An optional options object to customize the parsing
+ */
 declare function minimist(args?: string[], opts?: minimist.Opts): minimist.ParsedArgs;
+
+/**
+ * Return an argument object populated with the array arguments from args. Strongly-typed
+ * to be the intersect of type T with minimist.ParsedArgs.
+ *
+ * @type T The type that will be intersected with minimist.ParsedArgs to represent the argument object
+ * @param args An optional argument array (typically `process.argv.slice(2)`)
+ * @param opts An optional options object to customize the parsing
+ */
+declare function minimist<T>(args?: string[], opts?: minimist.Opts): T & minimist.ParsedArgs;
+
+/**
+ * Return an argument object populated with the array arguments from args. Strongly-typed
+ * to be the the type T which should extend minimist.ParsedArgs
+ *
+ * @type T The type that extends minimist.ParsedArgs and represents the argument object
+ * @param args An optional argument array (typically `process.argv.slice(2)`)
+ * @param opts An optional options object to customize the parsing
+ */
+declare function minimist<T extends minimist.ParsedArgs>(args?: string[], opts?: minimist.Opts): T;
 
 declare namespace minimist {
     export interface Opts {
-        // a string or array of strings argument names to always treat as strings
+        /**
+         * A string or array of strings argument names to always treat as strings         
+         */ 
         string?: string | string[];
-        // a string or array of strings to always treat as booleans
+
+        /**
+         * A string or array of strings to always treat as booleans
+         */
         boolean?: boolean | string | string[];
-        // an object mapping string names to strings or arrays of string argument names to use
+
+        /**
+         * An object mapping string names to strings or arrays of string argument names to use
+         */
         alias?: { [key: string]: string | string[] };
-        // an object mapping string argument names to default values
+
+        /**
+         * An object mapping string argument names to default values
+         */
         default?: { [key: string]: any };
-        // when true, populate argv._ with everything after the first non-option
+
+        /**
+         * When true, populate argv._ with everything after the first non-option
+         */
         stopEarly?: boolean;
-        // a function which is invoked with a command line parameter not defined in the opts configuration object.
-        // If the function returns false, the unknown option is not added to argv
+
+        /**
+         * A function which is invoked with a command line parameter not defined in the opts 
+         * configuration object. If the function returns false, the unknown option is not added to argv         
+         */
         unknown?: (arg: string) => boolean;
-        // when true, populate argv._ with everything before the -- and argv['--'] with everything after the --
+
+        /**
+         * When true, populate argv._ with everything before the -- and argv['--'] with everything after the --         
+         */
         '--'?: boolean;
     }
 
     export interface ParsedArgs {
         [arg: string]: any;
-        _: string[];
+
+        /**
+         * If opts['--'] is true, populated with everything after the --
+         */
+        '--'?: string[];
+
+        /**
+         * An array of non-option arguments
+         */
+        _: string[];       
     }
 }
 

--- a/minimist/minimist-tests.ts
+++ b/minimist/minimist-tests.ts
@@ -2,11 +2,21 @@
 import minimist = require('minimist');
 import Opts = minimist.Opts;
 
+interface CustomArgs {
+	foo: boolean;
+}
+
+interface CustomArgs2 extends minimist.ParsedArgs {
+	foo: boolean;
+}
+
 var num: string;
 var str: string;
 var strArr: string[];
 var args: string[];
 var obj: minimist.ParsedArgs;
+var iobj: minimist.ParsedArgs & CustomArgs;
+var eobj: CustomArgs2;
 var opts: Opts;
 var arg: any;
 
@@ -40,6 +50,18 @@ opts['--'] = true;
 obj = minimist();
 obj = minimist(strArr);
 obj = minimist(strArr, opts);
+iobj = minimist<CustomArgs>();
+iobj = minimist<CustomArgs>(strArr);
+iobj = minimist<CustomArgs>(strArr, opts);
+eobj = minimist<CustomArgs2>();
+eobj = minimist<CustomArgs2>(strArr);
+eobj = minimist<CustomArgs2>(strArr, opts);
 var remainingArgCount = obj._.length;
 
 arg = obj['foo'];
+
+arg = iobj.foo;
+remainingArgCount = iobj._.length;
+
+arg = eobj.foo;
+remainingArgCount = eobj._.length;


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Increase the version number in the header if appropriate.

## Context

When using minimist in a TypeScript project, it would be ideal if it supported using the types I make to represent my arguments:

```ts
interface ProcessArgs {
  readonly x: string;
  readonly y: boolean;
}

var parsed = minimist<ProcessArgs>(process.argv.slice(2));

parsed.x; // OK
parsed._; // OK
parsed['--']; // OK
```

To achieve this, I made a local function which had the generic type args and passed through to minimist, but I figured updating the root cause would be best and make the declarations more TypeScript dev friendly.

I included two options:

- Intersection: this is to allow total decoupling between my custom interface and minimist, allowing zero dependency inside the file I define my interface to minimist itself (because I can parse in a different file, that references both minimist and my custom interface to create a single coupling point)
- Extension: if someone prefers to extend the `minimist.ParsedArgs` interface, they can do so and it will still work as expected (preferring for TS to explictly return an inherited Type vs. Intersected Type)
