### PR TITLE
fixed fit options

### DIFF
--- a/d3kit/d3kit-tests.ts
+++ b/d3kit/d3kit-tests.ts
@@ -5,7 +5,7 @@ function test_abstract_chart() {
         chart: d3kit.AbstractChart,
         options: d3kit.ChartOptions,
         margins: d3kit.ChartMargin,
-        offsets: d3kit.ChartOffset,
+        offsets: [number, number],
         defopts: d3kit.ChartOptions,
         fitopts: d3kit.FitOptions,
         watchop: d3kit.WatchOptions,
@@ -17,7 +17,7 @@ function test_abstract_chart() {
 
     // create examples of margins, offsets, options, fit options, watch options
     margins = { top: 20, right: 20, bottom: 20, left: 20};
-    offsets = { x: 0.5, y: 0.5 };
+    offsets = [0.5, 0.5];
     options = { initialWidth: 400, initialHeight: 300, margin: margins, offset: offsets };
     fitopts = { mode: 'basic', width: '90%', ratio: 4/3 };
     watchop = { mode: 'window', target: null, interval: 500 };
@@ -85,7 +85,7 @@ function test_svgchart() {
         chart: d3kit.SvgChart,
         options: d3kit.ChartOptions,
         margins: d3kit.ChartMargin,
-        offsets: d3kit.ChartOffset,
+        offsets: [number, number],
         svg: d3.Selection<d3.BaseType, any, d3.BaseType, any>, 
         rootg: d3.Selection<d3.BaseType, any, d3.BaseType, any>, 
         layers: d3kit.LayerOrganizer;
@@ -95,7 +95,7 @@ function test_svgchart() {
 
     // create examples of margins, offsets, options, fit options, watch options
     margins = { top: 20, right: 20, bottom: 20, left: 20};
-    offsets = { x: 0.5, y: 0.5 };
+    offsets = [0.5, 0.5];
     options = { initialWidth: 400, initialHeight: 300, margin: margins, offset: offsets };
 
     /**
@@ -119,7 +119,7 @@ function test_canvaschart() {
         chart: d3kit.CanvasChart,
         options: d3kit.ChartOptions,
         margins: d3kit.ChartMargin,
-        offsets: d3kit.ChartOffset,
+        offsets: [number, number],
         context: CanvasRenderingContext2D;
 
     // create a div, append to body, return Node as type Element
@@ -127,7 +127,7 @@ function test_canvaschart() {
 
     // create examples of margins, offsets, options, fit options, watch options
     margins = { top: 20, right: 20, bottom: 20, left: 20};
-    offsets = { x: 0.5, y: 0.5 };
+    offsets = [0.5, 0.5];
     options = { initialWidth: 400, initialHeight: 300, margin: margins, offset: offsets, pixelRatio: 1 };
 
     /**

--- a/d3kit/index.d.ts
+++ b/d3kit/index.d.ts
@@ -88,23 +88,23 @@ export class CanvasChart extends AbstractChart {
 
 export class LayerOrganizer {
     constructor(container: d3.Selection<d3.BaseType, any, d3.BaseType, any>, defaultTag?: string);
-    create(layerNames: string|Array<string>|LayerConfig|Array<LayerConfig>): d3.Selection<d3.BaseType, any, d3.BaseType, any>|Array<d3.Selection<d3.BaseType, any, d3.BaseType, any>>;
+    create(layerNames: string|string[]|LayerConfig|LayerConfig[]): d3.Selection<d3.BaseType, any, d3.BaseType, any>|Array<d3.Selection<d3.BaseType, any, d3.BaseType, any>>;
     get(name: string): d3.Selection<d3.BaseType, any, d3.BaseType, any>;
     has(name: string): boolean;
 }
 
 export interface LayerConfig {
-    [layerName: string]: string|string[]|LayerConfig|Array<LayerConfig>;
+    [layerName: string]: string|string[]|LayerConfig|LayerConfig[];
 }
 
 export namespace helper {
-    function debounce(fn: (...args: Array<any>) => void, delay: number): (...args: Array<any>) => void;
-    function deepExtend(dest: Object, ...args: Object[]): Object;
-    function extend(dest: Object, ...args: Object[]): Object;
-    function functor(value: any): (...args: Array<any>) => any;
-    function rebind(target: Object, source: Object): Object;
+    function debounce(fn: (...args: any[]) => void, delay: number): (...args: any[]) => void;
+    function deepExtend(dest: any, ...args: any[]): any;
+    function extend(dest: any, ...args: any[]): any;
+    function functor(value: any): (...args: any[]) => any;
+    function rebind(target: any, source: any): any;
     function isFunction(value: any): boolean;
     function isObject(value: any): boolean;
     function kebabCase(str: string): string;
-    function throttle(fn: (...args: Array<any>) => void, delay: number): (...args: Array<any>) => void;
+    function throttle(fn: (...args: any[]) => void, delay: number): (...args: any[]) => void;
 }

--- a/d3kit/index.d.ts
+++ b/d3kit/index.d.ts
@@ -26,8 +26,8 @@ export class AbstractChart {
     data(): any;
     margin(margins: ChartMargin): this;
     margin(): ChartMargin;
-    offset(offset: ChartOffset): this;
-    offset(): ChartOffset;
+    offset(offset: [number, number]): this;
+    offset(): [number, number];
     options(options: ChartOptions): this;
     options(): ChartOptions;
     updateDimensionNow(): this;
@@ -47,16 +47,11 @@ export interface ChartMargin {
     left?: number;
 }
 
-export interface ChartOffset {
-    x: number;
-    y: number;
-}
-
 export interface ChartOptions {
     initialWidth?: number;
     initialHeight?: number;
     margin?: ChartMargin;
-    offset?: ChartOffset;
+    offset?: [number, number];
     pixelRatio?: number;
 }
 


### PR DESCRIPTION
This is a minor fix. The shape of the fit options was `{x: number, y: number}` when it should have been simply `[number, number]`. As per [docs for the slimfit package](https://github.com/kristw/slimfit).

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see [documentation for the slimfit package](https://github.com/kristw/slimfit) which had the correct shape for the fit options object.
- [x] Increase the version number in the header if appropriate.

