### PR TITLE
[material-ui] Snackbar optional onRequestClose

### DIFF
--- a/material-ui/index.d.ts
+++ b/material-ui/index.d.ts
@@ -1496,7 +1496,7 @@ declare namespace __MaterialUI {
         contentStyle?: React.CSSProperties;
         message: React.ReactNode;
         onActionTouchTap?: React.TouchEventHandler<{}>;
-        onRequestClose: (reason: string) => void;
+        onRequestClose?: (reason: string) => void;
         open: boolean;
         style?: React.CSSProperties;
     }


### PR DESCRIPTION
Make `Snackbar`'s `onRequestClose` property optional. See [here](https://github.com/callemall/material-ui/blob/master/src/Snackbar/Snackbar.js#L90) for more details.