### PR TITLE
updated SchemaOptions.versionKey type

### DIFF
--- a/mongoose/mongoose-3.x.d.ts
+++ b/mongoose/mongoose-3.x.d.ts
@@ -323,7 +323,7 @@ declare module "mongoose" {
     strict?: boolean;
     toJSON?: Object;
     toObject?: Object;
-    versionKey?: boolean;
+    versionKey?: string|boolean;
   }
 
   export interface Model<T extends Document> extends NodeJS.EventEmitter {


### PR DESCRIPTION
I changed it accordingly to the mongoose documentation that allows disabling versionKey for a schema by writing:

    new Schema({..}, { versionKey: false });

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/13163
@simonxca