### PR TITLE
Fix syntax error in interact.d.ts

### DIFF
--- a/interactjs/interact.d.ts
+++ b/interactjs/interact.d.ts
@@ -200,7 +200,7 @@ declare namespace Interact {
         (element: HTMLElement): Interactable;
         (element: SVGElement): Interactable;
         (element: string): Interactable;
-        (element: string, {context: Element}): Interactable;
+        (element: string, options: {context: Element}): Interactable;
         // returns boolean or {[key: string]: any}
         autoScroll(): any;
         autoScroll(options: boolean): InteractStatic;


### PR DESCRIPTION
A parameter name was missing making TypeScript compiler fail.