### PR TITLE
schemaOption versionKey type fixed

### DIFF
--- a/mongoose/index.d.ts
+++ b/mongoose/index.d.ts
@@ -717,7 +717,7 @@ declare module "mongoose" {
     /** defaults to true */
     validateBeforeSave?: boolean;
     /** defaults to "__v" */
-    versionKey?: string;
+    versionKey?: string|boolean;
     /**
      * skipVersioning allows excluding paths from
      * versioning (the internal revision will not be

--- a/mongoose/mongoose-3.x.d.ts
+++ b/mongoose/mongoose-3.x.d.ts
@@ -323,7 +323,7 @@ declare module "mongoose" {
     strict?: boolean;
     toJSON?: Object;
     toObject?: Object;
-    versionKey?: boolean;
+    versionKey?: string|boolean;
   }
 
   export interface Model<T extends Document> extends NodeJS.EventEmitter {

--- a/mongoose/mongoose-3.x.d.ts
+++ b/mongoose/mongoose-3.x.d.ts
@@ -323,7 +323,7 @@ declare module "mongoose" {
     strict?: boolean;
     toJSON?: Object;
     toObject?: Object;
-    versionKey?: string|boolean;
+    versionKey?: boolean;
   }
 
   export interface Model<T extends Document> extends NodeJS.EventEmitter {


### PR DESCRIPTION
Made a mistake in previous pull request.

[thread here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/13181)