### PR TITLE
Fix incorrect method definition in pdfkit.d.ts

### DIFF
--- a/pdfkit/index.d.ts
+++ b/pdfkit/index.d.ts
@@ -160,7 +160,7 @@ declare namespace PDFKit.Mixins {
         bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): TDocument;
         quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): TDocument;
         rect(x: number, y: number, w: number, h: number): TDocument;
-        roundRect(x: number, y: number, w: number, h: number, r?: number): TDocument;
+        roundedRect(x: number, y: number, w: number, h: number, r?: number): TDocument;
         ellipse(x: number, y: number, r1: number, r2?: number): TDocument;
         circle(x: number, y: number, raduis: number): TDocument;
         polygon(...points: number[][]): TDocument;

--- a/pdfkit/pdfkit-tests.ts
+++ b/pdfkit/pdfkit-tests.ts
@@ -52,6 +52,8 @@ doc.path("M 0,20 L 100,160 Q 130,200 150,120 C 190,-40 200,200 300,150 L 400,90"
 
 //Rectangle shape helper sample
 doc.rect(100,200,100,100);
+// Rounded rectangle
+doc.roundedRect(150,250,150,150,10);
 
 //polygon
 doc.polygon([100,0],[50,100],[50,100]);


### PR DESCRIPTION
Please fill in this template.

- [X] Prefer to make your PR against the `types-2.0` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/devongovett/pdfkit/blob/v0.7.2/docs/guide.pdf page 9, https://github.com/devongovett/pdfkit/blob/v0.8.0/docs/guide.pdf page 9 (to show it was never correct and still isn't)
- [ ] Increase the version number in the header if appropriate.
