### PR TITLE
Add missing `zscanStream` redis command to `ioredis`

### DIFF
--- a/ioredis/index.d.ts
+++ b/ioredis/index.d.ts
@@ -338,6 +338,7 @@ declare module IORedis {
 
         scanStream(options?: IORedis.ScanStreamOption): NodeJS.EventEmitter;
         hscanStream(key: string, options?: IORedis.ScanStreamOption): NodeJS.EventEmitter;
+        zscanStream(key: string, options?: IORedis.ScanStreamOption): NodeJS.EventEmitter;
     }
 
     interface Pipeline {


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/luin/ioredis#streamify-scanning
- [ ] Increase the version number in the header if appropriate.

This exists as a command in `ioredis` but was missing from the type definition.