### PR TITLE
lodash-es: fix dep to point properly to `@types/lodash`

### DIFF
--- a/lodash-es/package.json
+++ b/lodash-es/package.json
@@ -1,5 +1,5 @@
 {
     "dependencies": {
-        "lodash": ">=4.14.0"
+        "@types/lodash": ">=4.14.0"
     }
 }

--- a/lodash-es/package.json
+++ b/lodash-es/package.json
@@ -1,5 +1,0 @@
-{
-    "dependencies": {
-        "@types/lodash": ">=4.14.0"
-    }
-}


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

Currently when added the `package.json` the `dependencies` was set to `lodash` instead of `@types/lodash` by mistake.