### PR TITLE
[jasmine] Remove unnecessary overloads

### DIFF
--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -10,24 +10,17 @@ declare function describe(description: string, specDefinitions: () => void): voi
 declare function fdescribe(description: string, specDefinitions: () => void): void;
 declare function xdescribe(description: string, specDefinitions: () => void): void;
 
-declare function it(expectation: string, assertion?: () => void, timeout?: number): void;
 declare function it(expectation: string, assertion?: (done: DoneFn) => void, timeout?: number): void;
-declare function fit(expectation: string, assertion?: () => void, timeout?: number): void;
 declare function fit(expectation: string, assertion?: (done: DoneFn) => void, timeout?: number): void;
-declare function xit(expectation: string, assertion?: () => void, timeout?: number): void;
 declare function xit(expectation: string, assertion?: (done: DoneFn) => void, timeout?: number): void;
 
 /** If you call the function pending anywhere in the spec body, no matter the expectations, the spec will be marked pending. */
 declare function pending(reason?: string): void;
 
-declare function beforeEach(action: () => void, timeout?: number): void;
 declare function beforeEach(action: (done: DoneFn) => void, timeout?: number): void;
-declare function afterEach(action: () => void, timeout?: number): void;
 declare function afterEach(action: (done: DoneFn) => void, timeout?: number): void;
 
-declare function beforeAll(action: () => void, timeout?: number): void;
 declare function beforeAll(action: (done: DoneFn) => void, timeout?: number): void;
-declare function afterAll(action: () => void, timeout?: number): void;
 declare function afterAll(action: (done: DoneFn) => void, timeout?: number): void;
 
 declare function expect(spy: Function): jasmine.Matchers;


### PR DESCRIPTION
Please fill in this template.

- [ ] Prefer to make your PR against the `types-2.0` branch.
  - This is a port to the master branch. See comment below.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

Note this is the same change in the jasmine typings as in #12389 (commit e515b24a20) for the master branch. Ported this to the master branch (for "typings" users) because the unnecesary overloads trigger a compile error since TypeScript 2.1 (see https://github.com/Microsoft/TypeScript/issues/12733).