### PR TITLE
Add allowRelative and relativeOnly to UriOptions

### DIFF
--- a/joi/joi-6.5.0.d.ts
+++ b/joi/joi-6.5.0.d.ts
@@ -93,6 +93,14 @@ declare module 'joi' {
 		 * Can be an Array or String (strings are automatically escaped for use in a Regular Expression).
 		 */
 		scheme ?: string | RegExp | Array<string | RegExp>;
+		/**
+		 * Allow relative URIs. Defaults to false.
+		 */
+		allowRelative ?: boolean;
+		/**
+		 * Restrict only relative URIs. Defaults to false.
+		 */
+		relativeOnly ?: boolean;
 	}
 
 	export interface WhenOptions<T> {

--- a/joi/joi-tests.ts
+++ b/joi/joi-tests.ts
@@ -95,6 +95,18 @@ uriOpts = {scheme: str};
 uriOpts = {scheme: exp};
 uriOpts = {scheme: strArr};
 uriOpts = {scheme: expArr};
+uriOpts = {scheme: str, allowRelative: bool};
+uriOpts = {scheme: str, relativeOnly: bool};
+uriOpts = {scheme: str, allowRelative: bool, relativeOnly: bool};
+uriOpts = {scheme: exp, allowRelative: bool};
+uriOpts = {scheme: exp, relativeOnly: bool};
+uriOpts = {scheme: exp, allowRelative: bool, relativeOnly: bool};
+uriOpts = {scheme: strArr, allowRelative: bool};
+uriOpts = {scheme: strArr, relativeOnly: bool};
+uriOpts = {scheme: strArr, allowRelative: bool, relativeOnly: bool};
+uriOpts = {scheme: expArr, allowRelative: bool};
+uriOpts = {scheme: expArr, relativeOnly: bool};
+uriOpts = {scheme: expArr, allowRelative: bool, relativeOnly: bool};
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
@@ -222,7 +234,7 @@ namespace common {
 	anySchema = anySchema.empty();
 	anySchema = anySchema.empty(str);
 	anySchema = anySchema.empty(anySchema);
-	
+
 	anySchema = anySchema.error(err);
 }
 

--- a/joi/joi.d.ts
+++ b/joi/joi.d.ts
@@ -97,6 +97,14 @@ declare module 'joi' {
 		 * Can be an Array or String (strings are automatically escaped for use in a Regular Expression).
 		 */
 		scheme ?: string | RegExp | Array<string | RegExp>;
+		/**
+		 * Allow relative URIs. Defaults to false.
+		 */
+		allowRelative ?: boolean;
+		/**
+		 * Restrict only relative URIs. Defaults to false.
+		 */
+		relativeOnly ?: boolean;
 	}
 
 	export interface WhenOptions<T> {
@@ -291,7 +299,7 @@ declare module 'joi' {
 		 * @param schema - any object or joi schema to match. An undefined schema unsets that rule.
 		 */
 		empty(schema?: any) : T;
-		
+
 		/**
 		 * Overrides the default joi error with a custom error if the rule fails where:
 		 * @param err - the override error.
@@ -831,7 +839,7 @@ declare module 'joi' {
 	export function alternatives(): AlternativesSchema;
 	export function alternatives(types: Schema[]): AlternativesSchema;
 	export function alternatives(type1: Schema, type2: Schema, ...types: Schema[]): AlternativesSchema;
-	
+
 	/**
 	 * Generates a placeholder schema for a schema that you would provide with the fn.
 	 * Supports the same methods of the any() type.


### PR DESCRIPTION
I make this change on the master branch as it's a backward compatible change.

- [ ] Prefer to make your PR against the `types-2.0` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/joi/blob/master/API.md#stringurioptions
- [ ] Increase the version number in the header if appropriate.

