### PR TITLE
Update angular-material typings for IPanelRef

### DIFF
--- a/angular-material/index.d.ts
+++ b/angular-material/index.d.ts
@@ -344,6 +344,8 @@ declare module 'angular' {
             id: string;
             config: IPanelConfig;
             isAttached: boolean;
+            panelContainer: JQuery;
+            panelEl: JQuery;
             open(): angular.IPromise<any>;
             close(): angular.IPromise<any>;
             attach(): angular.IPromise<any>;


### PR DESCRIPTION
https://github.com/angular/material/commit/87c4b01a4e93cf5dfaeb7f6b965a4cf1c5d2d413 adds panelContainer and panelEl as part of the IPanelRef. This updates the typings to expose those fields as well.
