### PR TITLE
Update bluebird/index.d.ts from 'export =' to 'export default'

### DIFF
--- a/bluebird/bluebird-tests.ts
+++ b/bluebird/bluebird-tests.ts
@@ -5,7 +5,7 @@
 
 // Note: try to maintain the ordering and separators, and keep to the pattern
 
-import Promise = require("bluebird");
+import Promise from "bluebird";
 
 var obj: Object;
 var bool: boolean;

--- a/bluebird/index.d.ts
+++ b/bluebird/index.d.ts
@@ -777,4 +777,4 @@ declare namespace Bluebird {
   export function setScheduler(scheduler: (callback: (...args: any[]) => void) => void): void;
 }
 
-export = Bluebird;
+export default Bluebird;


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present. *Not present.*

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require
- [ ] Increase the version number in the header if appropriate. *Not appropriate.*

---

This change seems necessary because importing from a `export =`-declared module is incompatible with tsc option `"module": "es2015"`.

I encountered this issue while developing an angular 2 AoT project whose build uses rollup, which requires ES2015 modules.