### PR TITLE
Updated Chalk to use `export default`

### DIFF
--- a/chalk/chalk-tests.ts
+++ b/chalk/chalk-tests.ts
@@ -1,4 +1,4 @@
-import chalk = require('chalk');
+import chalk from 'chalk';
 
 var str = '';
 var bool = false;

--- a/chalk/index.d.ts
+++ b/chalk/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Diullei Gomes <https://github.com/Diullei>, Bart van der Schoor <https://github.com/Bartvds>, Nico Jansen <https://github.com/nicojs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export = Chalk;
+export default Chalk;
 
 declare namespace Chalk {
     export var enabled: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: Context inlined
- [ ] Increase the version number in the header if appropriate.

*Context*

both webpack 2.x and rollup will fail to import chalk as `import * as chalk from 'chalk'`, as they will rewrite commonjs `module.exports = new Chalk()` to `export default`. This change allows Typescript to stick with `import chalk from 'chalk'` and make rollup/webpack commonjs loaders happy.