### PR TITLE
fixed babel-code-frame typings

### DIFF
--- a/babel-code-frame/babel-code-frame-tests.ts
+++ b/babel-code-frame/babel-code-frame-tests.ts
@@ -1,4 +1,4 @@
-import codeFrame from "babel-code-frame";
+import codeFrame = require("babel-code-frame");
 
 const code = `
     const number = 1;

--- a/babel-code-frame/index.d.ts
+++ b/babel-code-frame/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for babel-code-frame 6.16
+// Type definitions for babel-code-frame 6.20
 // Project: https://github.com/babel/babel/tree/master/packages
 // Definitions by: Mohsen Azimi <https://github.com/mohsen1>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/babel-code-frame/index.d.ts
+++ b/babel-code-frame/index.d.ts
@@ -28,9 +28,11 @@ interface BabelCodeFrameOptions {
  *
  * @returns Framed code
  */
-export default function babelCodeFrame(
+declare function codeFrame(
     rawLines: string,
     lineNumber: number,
     colNumber: number,
     options?: BabelCodeFrameOptions
 ): string;
+
+export = codeFrame;


### PR DESCRIPTION
Please fill in this template.

- [X] Prefer to make your PR against the `types-2.0` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [X] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/babel/babel/blob/master/packages/babel-code-frame/src/index.js#L96 although the code suggests `default` exists, it does infact not, the NPM package sets `module.exports = exports.default` at the end.
- [X] Increase the version number in the header if appropriate.

The initially added typings were incorrect.