### PR TITLE
Update react-native.d.ts - Modal Props should be optional

### DIFF
--- a/react-native/react-native.d.ts
+++ b/react-native/react-native.d.ts
@@ -3663,13 +3663,13 @@ declare namespace  __React {
          * On iOS, the modal is still restricted by what's specified in your app's Info.plist's UISupportedInterfaceOrientations field.
          * @platform ios
          */
-        supportedOrientations: ('portrait' | 'portrait-upside-down' | 'landscape' | 'landscape-left' | 'landscape-right')[]
+        supportedOrientations?: ('portrait' | 'portrait-upside-down' | 'landscape' | 'landscape-left' | 'landscape-right')[]
         /**
          * The `onOrientationChange` callback is called when the orientation changes while the modal is being displayed.
          * The orientation provided is only 'portrait' or 'landscape'. This callback is also called on initial render, regardless of the current orientation.
          * @platform ios
          */
-        onOrientationChange: () => void,
+        onOrientationChange?: () => void
     }
 
     export interface ModalStatic extends React.ComponentClass<ModalProperties> {


### PR DESCRIPTION
Please fill in this template.

- [ x] Prefer to make your PR against the `types-2.0` branch.
- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code.

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: [Modal](https://github.com/facebook/react-native/blob/master/Libraries/Modal/Modal.js#L113-L124)
- [ ] Increase the version number in the header if appropriate.

These properties should be optional.

https://github.com/facebook/react-native/blob/master/Libraries/Modal/Modal.js#L113-L124

i.e. they are PropTypes.func / PropTypes.arrayOf not PropTypes.func.required / PropTypes.arrayOf().required