### PR TITLE
update react-autosuggest typings to work with newest react-autosuggest version (7.0.1)

### DIFF
--- a/react-autosuggest/react-autosuggest-tests.tsx
+++ b/react-autosuggest/react-autosuggest-tests.tsx
@@ -62,7 +62,7 @@ export class ReactAutosuggestBasicTest extends React.Component<any, any> {
         };
 
         return <Autosuggest suggestions={suggestions}
-                            onSuggestionsUpdateRequested={this.onSuggestionsUpdateRequested.bind(this)}
+                            onSuggestionsFetchRequested={this.onSuggestionsFetchRequested.bind(this)}
                             getSuggestionValue={this.getSuggestionValue}
                             renderSuggestion={this.renderSuggestion}
                             onSuggestionSelected={this.onSuggestionsSelected}
@@ -85,7 +85,7 @@ export class ReactAutosuggestBasicTest extends React.Component<any, any> {
         });
     }
 
-    protected onSuggestionsUpdateRequested({ value }): void {
+    protected onSuggestionsFetchRequested({ value }): void {
         this.setState({
             suggestions: this.getSuggestions(value)
         });
@@ -185,7 +185,7 @@ export class ReactAutosuggestMultipleTest extends React.Component<any, any> {
 
         return <Autosuggest multiSection={true}
                             suggestions={suggestions}
-                            onSuggestionsUpdateRequested={this.onSuggestionsUpdateRequested.bind(this)}
+                            onSuggestionsFetchRequested={this.onSuggestionsFetchRequested.bind(this)}
                             onSuggestionSelected={this.onSuggestionSelected}
                             getSuggestionValue={this.getSuggestionValue}
                             renderSuggestion={this.renderSuggestion}
@@ -216,7 +216,7 @@ export class ReactAutosuggestMultipleTest extends React.Component<any, any> {
         });
     }
 
-    protected onSuggestionsUpdateRequested({ value }): void {
+    protected onSuggestionsFetchRequested({ value }): void {
         this.setState({
             suggestions: this.getSuggestions(value)
         });
@@ -292,7 +292,7 @@ export class ReactAutosuggestCustomTest extends React.Component<any, any> {
         };
 
         return <Autosuggest suggestions={suggestions}
-                            onSuggestionsUpdateRequested={this.onSuggestionsUpdateRequested}
+                            onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
                             getSuggestionValue={this.getSuggestionValue}
                             renderSuggestion={this.renderSuggestion}
                             inputProps={inputProps} />;
@@ -329,7 +329,7 @@ export class ReactAutosuggestCustomTest extends React.Component<any, any> {
         });
     }
 
-    protected onSuggestionsUpdateRequested({ value }): void {
+    protected onSuggestionsFetchRequested({ value }): void {
         this.setState({
             suggestions: this.getSuggestions(value)
         });

--- a/react-autosuggest/react-autosuggest.d.ts
+++ b/react-autosuggest/react-autosuggest.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-autosuggest v3.7.3
+// Type definitions for react-autosuggest v7.0.1
 // Project: http://react-autosuggest.js.org/
 // Definitions by: Nicolas Schmitt <https://github.com/nicolas-schmitt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/react-autosuggest/react-autosuggest.d.ts
+++ b/react-autosuggest/react-autosuggest.d.ts
@@ -6,65 +6,70 @@
 /// <reference path="../react/react.d.ts"/>
 
 declare namespace ReactAutosuggest {
-  import React = __React;
+    import React = __React;
 
-  interface SuggestionUpdateRequest {
-    value: string;
-    reason: string;
-  }
+    interface SuggestionsFetchRequest {
+        value: string;
+        reason: string;
+    }
 
-  interface InputValues {
-    value: string;
-    valueBeforeUpDown?: string;
-  }
+    interface InputValues {
+        value: string;
+        valueBeforeUpDown?: string;
+    }
 
-  interface InputProps extends React.HTMLAttributes {
-    value: string;
-    onChange: (event: React.FormEvent, params?: {newValue: string, method: string}) => void;
-  }
+    interface InputProps extends React.HTMLAttributes {
+        value: string;
+        onChange: (event: React.FormEvent, params?: { newValue: string, method: string }) => void;
+    }
 
-  interface ExplicitSuggestionSelectedEventData<TSuggestion> {
-    method: string;
-    sectionIndex: number;
-    suggestion: TSuggestion;
-    suggestionValue: string;
-  }
+    interface ExplicitSuggestionSelectedEventData<TSuggestion> {
+        method: string;
+        sectionIndex: number;
+        suggestion: TSuggestion;
+        suggestionValue: string;
+    }
 
-  interface SuggestionSelectedEventData extends ExplicitSuggestionSelectedEventData<any> {
-  }
+    interface SuggestionSelectedEventData extends ExplicitSuggestionSelectedEventData<any> {
+    }
 
-  interface Theme {
-    container: string;
-    containerOpen: string;
-    input: string;
-    sectionContainer: string;
-    sectionSuggestionsContainer: string;
-    sectionTitle: string;
-    suggestion: string;
-    suggestionFocused: string;
-    suggestionsContainer: string;
-  }
+    interface Theme {
+        container: string;
+        containerOpen: string;
+        input: string;
+        sectionContainer: string;
+        sectionSuggestionsContainer: string;
+        sectionTitle: string;
+        suggestion: string;
+        suggestionFocused: string;
+        suggestionsContainer: string;
+    }
 
-  interface AutosuggestProps extends React.Props<Autosuggest> {
-    suggestions: any[];
-    onSuggestionsUpdateRequested?: (request: SuggestionUpdateRequest) => void;
-    getSuggestionValue: (suggestion: any) => string;
-    renderSuggestion: (suggestion: any, inputValues: InputValues) => JSX.Element;
-    inputProps: InputProps;
-    shouldRenderSuggestions?: (value: string) => boolean;
-    multiSection?: boolean;
-    renderSectionTitle?: (section: any, inputValues: InputValues) => JSX.Element;
-    getSectionSuggestions?: (section: any) => any[];
-    onSuggestionSelected?: (event: React.FormEvent, data: SuggestionSelectedEventData | ExplicitSuggestionSelectedEventData<any>) => void;
-    focusInputOnSuggestionClick?: boolean;
-    theme?: Theme;
-    id?: string;
-  }
+    interface AutosuggestProps extends React.Props<Autosuggest> {
+        suggestions: any[];
+        onSuggestionsFetchRequested: (request: SuggestionsFetchRequest) => void;
+        onSuggestionsClearRequested?: () => void;
+        getSuggestionValue: (suggestion: any) => any;
+        renderSuggestion: (suggestion: any, inputValues: InputValues) => JSX.Element;
+        inputProps: InputProps;
+        onSuggestionSelected?: (event: React.FormEvent, data: SuggestionSelectedEventData | ExplicitSuggestionSelectedEventData<any>) => void;
+        shouldRenderSuggestions?: (value: string) => boolean;
+        alwaysRenderSuggestions?: boolean;
+        focusFirstSuggestion?: boolean;
+        focusInputOnSuggestionClick?: boolean;
+        multiSection?: boolean;
+        renderSectionTitle?: (section: any, inputValues: InputValues) => JSX.Element;
+        getSectionSuggestions?: (section: any) => any[];
+        renderInputComponent?: () => JSX.Element;
+        renderSuggestionsContainer?: (children: any) => JSX.Element;
+        theme?: Theme;
+        id?: string;
+    }
 
-  class Autosuggest extends React.Component<AutosuggestProps, any> {}
+    class Autosuggest extends React.Component<AutosuggestProps, any> { }
 }
 
 declare module 'react-autosuggest' {
-  import Autosuggest = ReactAutosuggest.Autosuggest;
-  export = Autosuggest;
+    import Autosuggest = ReactAutosuggest.Autosuggest;
+    export = Autosuggest;
 }


### PR DESCRIPTION
New version of react-autosuggest is released and the current typing is no more compatible with that. 

A **required** method name for fetching the suggestions changed to **onSuggestionsFetchRequested**. I also aligned the interface type name of its input argument to reflect the new method name: **SuggestionsFetchRequest**

Also some other **optional** methods and properties were introduced into the AutosuggestProps class:
- optional **onSuggestionsClearRequested**
- optional **alwaysRenderSuggestions** property
- etc.

I changed the return type of **getSuggestionValue** method form **string** to **any** because it can happen that you would like to return with an object with multiple properties instead of a single string.

More information of current interface:
https://github.com/moroshko/react-autosuggest#props