### PR TITLE
Missing stroke parameters in SVG properties

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -2179,7 +2179,8 @@ declare namespace React {
         stopColor?: string;
         stopOpacity?: number | string;
         stroke?: string;
-        strokeDasharray?: string;
+        strokeDasharray?: string | number;
+        strokeDashoffset?: string | number;
         strokeLinecap?: "butt" | "round" | "square" | "inherit";
         strokeLinejoin?: "miter" | "round" | "bevel" | "inherit";
         strokeMiterlimit?: string;

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -341,13 +341,17 @@ React.DOM.svg({
         x: 22,
         y: 10,
         width: 4,
-        height: 28
+        height: 28,
+        strokeDasharray: '30%',
+        strokeDashoffset: '20%'
     }),
     React.DOM.rect({
         x: 10,
         y: 22,
         width: 28,
-        height: 4
+        height: 4,
+        strokeDasharray: 30,
+        strokeDashoffset: 20
     }),
     React.DOM.path({
         d: "M0,0V3H3V0ZM1,1V2H2V1Z",


### PR DESCRIPTION
I added missing `strokeDashoffset` to svg properties and make `strokeDashoffset` accept numbers

