### PR TITLE
Fix definitions for 'mapValues',  'mapValuesLimit', 'mapValuesSeries'

### DIFF
--- a/async/async-tests.ts
+++ b/async/async-tests.ts
@@ -648,7 +648,7 @@ async.mapValues<number, string, Error>({
 
     }, 500);
 
-}, function(err: Error, results: string[]): void {
+}, function(err: Error, results: Dictionary<string>): void {
 
     console.log("async.mapValues: done with results", results);
 
@@ -668,7 +668,7 @@ async.mapValuesSeries<number, string, Error>({
 
     }, 500);
 
-}, function(err: Error, results: string[]): void {
+}, function(err: Error, results: Dictionary<string>): void {
 
     console.log("async.mapValuesSeries: done with results", results);
 

--- a/async/index.d.ts
+++ b/async/index.d.ts
@@ -111,8 +111,8 @@ interface Async {
     mapSeries: typeof async.map;
     mapLimit<T, R, E>(arr: T[], limit: number, iterator: AsyncResultIterator<T, R, E>, callback?: AsyncResultArrayCallback<R, E>): void;
     mapLimit<T, R, E>(arr: Dictionary<T>, limit: number, iterator: AsyncResultIterator<T, R, E>, callback?: AsyncResultArrayCallback<R, E>): void;
-    mapValuesLimit<T, R, E>(obj: Dictionary<T>, limit: number, iteratee: (value: T, key: string, callback: AsyncResultCallback<R, E>) => void, callback: AsyncResultCallback<R[], E>): void;
-    mapValues<T, R, E>(obj: Dictionary<T>, iteratee: (value: T, key: string, callback: AsyncResultCallback<R, E>) => void, callback: AsyncResultCallback<R[], E>): void;
+    mapValuesLimit<T, R, E>(obj: Dictionary<T>, limit: number, iteratee: (value: T, key: string, callback: AsyncResultCallback<R, E>) => void, callback: AsyncResultObjectCallback<R, E>): void;
+    mapValues<T, R, E>(obj: Dictionary<T>, iteratee: (value: T, key: string, callback: AsyncResultCallback<R, E>) => void, callback: AsyncResultObjectCallback<R, E>): void;
     mapValuesSeries: typeof async.mapValues;
     filter<T, E>(arr: T[], iterator: AsyncBooleanIterator<T, E>, callback?: AsyncResultArrayCallback<T, E>): void;
     filter<T, E>(arr: Dictionary<T>, iterator: AsyncBooleanIterator<T, E>, callback?: AsyncResultArrayCallback<T, E>): void;


### PR DESCRIPTION
`mapValues`, `mapValuesLimit`, and `mapValuesSeries` all yield dictionaries rather than arrays.

Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://caolan.github.io/async/docs.html#mapValues

