### PR TITLE
Better React setState

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -18,9 +18,6 @@ If you are using modules you should use `react.d.ts`, `react-dom.d.ts` or any of
 
 ## Known Problems & Workarounds
 
-### **The type of `setState` is incorrect.**
-The `setState(state)` method on `React.Component<P, S>` takes an object with a subset of the properties on `S`, but there's no way to express this in TypeScript currently. The workaround is simple: make all properties on `S` optional. There are a number of [proposals](https://github.com/Microsoft/TypeScript/issues/2710) on [ways](https://github.com/Microsoft/TypeScript/issues/4889) to [solve](https://github.com/Microsoft/TypeScript/issues/7355) this problem, but nothing seems to have been approved yet.
-  
 ### **The type of `cloneElement` is incorrect.**
 This is similar to the `setState` problem, in that `cloneElement(element, props)` should should accept a `props` object with a subset of the properties on `element.props`. There is an additional complication, however—React attributes, such as `key` and `ref`, should also be accepted in `props`, but should not exist on `element.props`. The "correct" way to model this, then, is with
 ```ts

--- a/react/react.d.ts
+++ b/react/react.d.ts
@@ -161,8 +161,8 @@ declare namespace __React {
     // Base component for plain JS classes
     class Component<P, S> implements ComponentLifecycle<P, S> {
         constructor(props?: P, context?: any);
-        setState(f: (prevState: S, props: P) => S, callback?: () => any): void;
-        setState(state: S, callback?: () => any): void;
+        setState(f: (prevState: S, props: P) => Partial<S>, callback?: () => any): void;
+        setState(state: Partial<S>, callback?: () => any): void;
         forceUpdate(callback?: () => any): void;
         render(): JSX.Element;
 


### PR DESCRIPTION
Uses the [mapped types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-1.html) functionality from TypeScript 2.1 to implement `setState` correctly.

The `Partial<T>` type is included with TypeScript 2.1, but will probably generate an error on earlier versions of TypeScript. Ideally, this should be aliased as `type Partial<T> = T` for earlier versions.
