### PR TITLE
Update module names in interact.d.ts

### DIFF
--- a/interactjs/interact.d.ts
+++ b/interactjs/interact.d.ts
@@ -243,6 +243,18 @@ declare namespace Interact {
 
 declare var interact: Interact.InteractStatic;
 
+// CommonJS module name until version 1.2.6 is "interact.js"
 declare module "interact.js" {
     export = interact;
 }
+
+// CommonJS module name from version 1.2.7 onward is "interactjs"
+declare module "interactjs" {
+    export = interact;
+}
+
+// AMD module name is "interact"
+declare module "interact" {
+    export = interact;
+}
+


### PR DESCRIPTION
Update CommonJS module name as it was changed in version 1.2.7.
AMD module name is also different from both new and old CommonJS module names, so a separate declaration was created for that as well.