### PR TITLE
Add typings for the inert extension to hapi.js

### DIFF
--- a/inert/index.d.ts
+++ b/inert/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for inert 4.0
+// Project: https://github.com/hapijs/inert/
+// Definitions by: Steve Ognibene <http://github.com/nycdotnet>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Note: this definition contains only enough to make TypeScript happy (hapi?) when
+//  importing inert.  The functionality that importing inert adds to the reply
+//  object and its other features are implemented in the hapi definition on
+//  DefinitelyTyped.  The inert object is never actually used in practice except to
+//  be passed as an extension to the server.register() method which already takes
+//  an `any` argument, so just using `any` here is fine.
+
+/// <reference types="node" />
+
+export var inert: any;

--- a/inert/inert-tests-es6.ts
+++ b/inert/inert-tests-es6.ts
@@ -1,0 +1,7 @@
+
+import * as HapiES6 from 'hapi';
+import * as InertES6 from 'inert';
+
+
+const server = new HapiES6.Server({});
+server.register(InertES6, () => {});

--- a/inert/inert-tests.ts
+++ b/inert/inert-tests.ts
@@ -1,0 +1,9 @@
+
+const Inert = require('inert');
+const Hapi = require('hapi');
+
+
+const server = new Hapi.Server({});
+server.register(Inert, () => {});
+
+export var makeThisAModule: any;

--- a/inert/tsconfig.json
+++ b/inert/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+		"inert-tests.ts",
+		"inert-tests-es6.ts"
+    ]
+}

--- a/inert/tslint.json
+++ b/inert/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "../tslint.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `types-2.0` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Run `tsc` without errors.
- [x] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

The hapi team explicitly rejected including this change in inert.  See here: https://github.com/hapijs/inert/pull/78

Therefore, I am submitting to DT.