### PR TITLE
[interact.js] Update module names

### DIFF
--- a/interact.js/index.d.ts
+++ b/interact.js/index.d.ts
@@ -243,6 +243,17 @@ declare namespace Interact {
 
 declare var interact: Interact.InteractStatic;
 
-declare module "interact.js" {
+// CommonJS module name until version 1.2.6 is "interact.js"
+ declare module "interact.js" {
+     export = interact;
+ }
+
+// CommonJS module name from version 1.2.7 onward is "interactjs"
+declare module "interactjs" {
+    export = interact;
+}
+
+// AMD module name is "interact"
+declare module "interact" {
     export = interact;
 }


### PR DESCRIPTION
Update CommonJS module name as it was changed in version 1.2.7.
AMD module name is also different from both new and old CommonJS module names, so a separate declaration was created for that as well.

_interact_ was the original module name, but it was already taken in npm repository, so _interact.js_ was used.
That name also causes problems with some bundlers, hence the new CommonJS name: _interactjs_.
But since the code uses UMD it still defines the AMD module name _interact_ while the CommonJS name is _interactjs_. 
The reason for this pull request is that I want to use interact library in browser, but can't, since the AMD package name is not _interact.js_.