### PR TITLE
Adding typescript definitions for koa-basic-auth and swagger-parser p…

### DIFF
--- a/koa-basic-auth/index.d.ts
+++ b/koa-basic-auth/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for koa-basic-auth v2.x
+// Type definitions for koa-basic-auth 2.x
 // Project: https://github.com/koajs/basic-auth
 // Definitions by: Tobias Wolff <https://github.com/Tobias4872/>
 // Definitions: https://github.com/Tobias4872/DefinitelyTyped

--- a/koa-basic-auth/index.d.ts
+++ b/koa-basic-auth/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for koa-basic-auth v2.x
+// Project: https://github.com/koajs/basic-auth
+// Definitions by: Tobias Wolff <https://github.com/Tobias4872/>
+// Definitions: https://github.com/Tobias4872/DefinitelyTyped
+
+import * as Koa from "koa";
+
+declare function auth(opts?: {
+
+    name: string;
+
+    pass: string;
+
+}): { (ctx: Koa.Context, next?: () => any): any };
+
+export = auth;

--- a/koa-basic-auth/koa-basic-auth-tests.ts
+++ b/koa-basic-auth/koa-basic-auth-tests.ts
@@ -1,0 +1,8 @@
+import * as Koa from "koa";
+import auth = require("koa-basic-auth");
+
+const app = new Koa();
+
+app.use(auth({name: "test", pass: "test"}));
+
+app.listen(80);

--- a/koa-basic-auth/tsconfig.json
+++ b/koa-basic-auth/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "koa-basic-auth-tests.ts"
+    ]
+}

--- a/koa-basic-auth/tslint.json
+++ b/koa-basic-auth/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tslint.json"
+}

--- a/swagger-parser/index.d.ts
+++ b/swagger-parser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for koa-basic-auth v2.x
+// Type definitions for swagger-parser 4.x
 // Project: https://github.com/BigstickCarpet/swagger-parser
 // Definitions by: Tobias Wolff <https://github.com/Tobias4872/>
 // Definitions: https://github.com/Tobias4872/DefinitelyTyped

--- a/swagger-parser/index.d.ts
+++ b/swagger-parser/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for koa-basic-auth v2.x
+// Project: https://github.com/BigstickCarpet/swagger-parser
+// Definitions by: Tobias Wolff <https://github.com/Tobias4872/>
+// Definitions: https://github.com/Tobias4872/DefinitelyTyped
+
+declare namespace SwaggerParser {
+  function parse(path: string): any;
+}
+
+export = SwaggerParser;

--- a/swagger-parser/swagger-parser-tests.ts
+++ b/swagger-parser/swagger-parser-tests.ts
@@ -1,0 +1,5 @@
+import parser = require("swagger-parser");
+
+parser.parse("test.yaml").then((file: string) => {
+  console.log(file);
+});

--- a/swagger-parser/tsconfig.json
+++ b/swagger-parser/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "swagger-parser-tests.ts"
+    ]
+}

--- a/swagger-parser/tslint.json
+++ b/swagger-parser/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tslint.json"
+}


### PR DESCRIPTION
Adding two new definition files for the koa-basic-auth and swagger-parser packages.

Both definitions have been tested with "tsc" as well as run through "npm run lint".