### PR TITLE
Fixed CasperJS module exports

### DIFF
--- a/casperjs/index.d.ts
+++ b/casperjs/index.d.ts
@@ -1,26 +1,22 @@
-// Type definitions for CasperJS v1.0.0
+// Type definitions for CasperJS v1.0.29
 // Project: http://casperjs.org/
 // Definitions by: Jed Mao <https://github.com/jedmao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="phantomjs" />
 
-interface CasperModule {
-    create(options: CasperOptions): Casper;
-    selectXPath(expression: string): Object
-}
 
-interface EventEmitter {
-    removeAllFilters(filter: string): Casper;
-    setFilter(filter: string, cb: Function): boolean;
-}
+export function create(options?: CasperOptions): Casper;
 
-interface Casper extends EventEmitter {
-    test: Tester;
+export function selectXPath(expression: string): Object;
 
-	constructor (options: CasperOptions): Casper;
+export class Casper {
 
+	constructor(options: CasperOptions);
+
+	test: Tester;
 	options: CasperOptions;
+
 	// Properties
 	__utils__: ClientUtils;
 
@@ -41,10 +37,10 @@ interface Casper extends EventEmitter {
 	debugPage(): Casper;
 	die(message: string, status?: number): Casper;
 	download(url: string, target?: string, method?: string, data?: any): Casper;
-    each<T>(array: T[], fn: (self: Casper, item: T, index: number) => void): Casper;
+	each<T>(array: T[], fn: (this: Casper, item: T, index: number) => void): Casper;
 	echo(message: string, style?: string): Casper;
-    evaluate<T>(fn: () => T, ...args: any[]): T
-    evaluateOrDie(fn: () => any, message?: string, status?: number): Casper;
+	evaluate<T>(fn: () => T, ...args: any[]): T
+	evaluateOrDie(fn: () => any, message?: string, status?: number): Casper;
 	exit(status?: number): Casper;
 	exists(selector: string): boolean;
 	fetchText(selector: string): string;
@@ -78,12 +74,12 @@ interface Casper extends EventEmitter {
 	setHttpAuth(username: string, password: string): Casper;
 	start(url?: string, then?: (response: HttpResponse) => void): Casper;
 	status(asString: boolean): any;
-	then(fn: (self?: Casper) => void): Casper;
+	then(fn: (this: Casper) => void): Casper;
 	thenBypass(nb: number): Casper;
 	thenBypassIf(condition: any, nb: number): Casper;
 	thenBypassUnless(condition: any, nb: number): Casper;
 	thenClick(selector: string): Casper;
-    thenEvaluate(fn: () => any, ...args: any[]): Casper;
+	thenEvaluate(fn: () => any, ...args: any[]): Casper;
 	thenOpen(location: string, then?: (response: HttpResponse) => void): Casper;
 	thenOpen(location: string, options?: OpenSettings, then?: (response: HttpResponse) => void): Casper;
 	thenOpenAndEvaluate(location: string, then?: Function, ...args: any[]): Casper;
@@ -112,6 +108,8 @@ interface Casper extends EventEmitter {
 	withPopup(popupInfo: string, step: Function): Casper;
 	withPopup(popupInfo: RegExp, step: Function): Casper;
 	zoom(factor: number): Casper;
+	removeAllFilters(filter: string): Casper;
+	setFilter(filter: string, cb: Function): boolean;
 }
 
 interface HttpResponse {
@@ -212,8 +210,8 @@ interface Tester {
 	assertDoesntExist(selector: string, message?: string): any;
 	assertElementCount(selctor: string, expected: number, message?: string): any;
 	assertEquals(testValue: any, expected: any, message?: string): any;
-	assertEval(fn: Function, message: string, arguments: any): any;
-	assertEvalEquals(fn: Function, expected: any, message?: string, arguments?: any): any;
+	assertEval(fn: Function, message: string, args: any): any;
+	assertEvalEquals(fn: Function, expected: any, message?: string, args?: any): any;
 	assertExists(selector: string, message?: string): any;
 	assertFalsy(subject: any, message?: string): any;
 	assertField(inputName: string, expected: string, message?: string): any;
@@ -241,11 +239,11 @@ interface Tester {
 	assertUrlMatch(pattern: RegExp, message?: string): any;
 	assertVisible(selector: string, message?: string): any;
 
-    /* since 1.1 */
-    begin(description: string, planned: number, suite: Function): any;
-    begin(description: string, suite: Function): any;
-    begin(description: string, planned: number, config: Object): any;
-    begin(description: string, config: Object): any;
+	/* since 1.1 */
+	begin(description: string, planned: number, suite: Function): any;
+	begin(description: string, suite: Function): any;
+	begin(description: string, planned: number, config: Object): any;
+	begin(description: string, config: Object): any;
 
 	colorize(message: string, style: string): any;
 	comment(message: string): any;

--- a/phantomcss/index.d.ts
+++ b/phantomcss/index.d.ts
@@ -3,142 +3,145 @@
 // Definitions by: Amaury Bauzac <https://github.com/abauzac>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="casperjs" />
+import { Casper } from 'casperjs';
 /// <reference types="resemblejs" />
-declare namespace PhantomCSS {
+
+declare global {
+  namespace PhantomCSS {
     interface PhantomCSS {
-        init(options: PhantomCSSOptions): void;
-        update(options: PhantomCSSOptions): void;
+      init(options: PhantomCSSOptions): void;
+      update(options: PhantomCSSOptions): void;
 
-        /**
-         * Take a screenshot of the targeted HTML element
-         * FileName is required if addIteratorToImage option is set to false
-         */
-        screenshot(target: string, fileName?: string): void;
+      /**
+       * Take a screenshot of the targeted HTML element
+       * FileName is required if addIteratorToImage option is set to false
+       */
+      screenshot(target: string, fileName?: string): void;
 
-        /**
-         * Take a screenshot of the targeted HTML element
-         * FileName is required if addIteratorToImage option is set to false
-         */
-        screenshot(target: ClipRect, fileName?: string): void;
-        /**
-         * Take a screenshot of the targeted HTML element
-         * FileName is required if addIteratorToImage option is set to false
-         */
-        screenshot(target: string, timeToWait: number, hideSelector: string, fileName?: string): void;
+      /**
+       * Take a screenshot of the targeted HTML element
+       * FileName is required if addIteratorToImage option is set to false
+       */
+      screenshot(target: ClipRect, fileName?: string): void;
+      /**
+       * Take a screenshot of the targeted HTML element
+       * FileName is required if addIteratorToImage option is set to false
+       */
+      screenshot(target: string, timeToWait: number, hideSelector: string, fileName?: string): void;
 
-        compareAll(exclude: string): void;
-        compareAll(exclude: string, diffList: string[], include: string): void;
-        compareMatched(match: string, exclude: string): void;
-        compareMatched(match: RegExp, exclude: RegExp): void;
-        /**
-         * Explicitly define what files you want to compare
-         */
-        compareExplicit(list: string[]): void;
-        /**
-         * Compare image diffs generated in this test run only
-         */
-        compareSession(list?: any[]): void;
-        compareFiles(baseFile: string, diffFiles: string): PhantomCSSTest;
-        waitForTests(tests: PhantomCSSTest[]): void;
-        done(): void;
-        /**
-         * Turn off CSS transitions and jQuery animations
-         */
-        turnOffAnimations(): void;
-        getExitStatus(): number;
-        /**
-         * Get a list of image diffs generated in this test run
-         */
-        getCreatedDiffFiles(): Array<string>;
+      compareAll(exclude: string): void;
+      compareAll(exclude: string, diffList: string[], include: string): void;
+      compareMatched(match: string, exclude: string): void;
+      compareMatched(match: RegExp, exclude: RegExp): void;
+      /**
+       * Explicitly define what files you want to compare
+       */
+      compareExplicit(list: string[]): void;
+      /**
+       * Compare image diffs generated in this test run only
+       */
+      compareSession(list?: any[]): void;
+      compareFiles(baseFile: string, diffFiles: string): PhantomCSSTest;
+      waitForTests(tests: PhantomCSSTest[]): void;
+      done(): void;
+      /**
+       * Turn off CSS transitions and jQuery animations
+       */
+      turnOffAnimations(): void;
+      getExitStatus(): number;
+      /**
+       * Get a list of image diffs generated in this test run
+       */
+      getCreatedDiffFiles(): Array<string>;
     }
 
     interface PhantomCSSTest {
-        filename?: string;
-        error?: boolean;
-        fail?: boolean;
-        success?: boolean;
-        failFile?: string;
-        mismatch?: any;
+      filename?: string;
+      error?: boolean;
+      fail?: boolean;
+      success?: boolean;
+      failFile?: string;
+      mismatch?: any;
     }
 
     interface PhantomCSSOptions {
-		/**
-			Rebase is useful when you want to create new baseline
-			images without manually deleting the files
-			casperjs demo/test.js --rebase
-		*/
-        rebase?: any;
-		/**
-		  A reference to a particular Casper instance. Required for SlimerJS.
-		 */
-        casper?: Casper;
-		/**
-        libraryRoot is relative to this file and must point to your phantomcss folder (not lib or node_modules). If you are using NPM, this will be './node_modules/phantomcss'.
-    	*/
-        libraryRoot?: string;
-
-        screenshotRoot?: string;
-		/**
-        By default, failure images are put in the './failures' folder.
-        If failedComparisonsRoot is set to false a separate folder will
-        not be created but failure images can still be found alongside
-        the original and new images.
-    	*/
-        failedComparisonsRoot?: string;
-
-		/**
-        You might want to keep master/baseline images in a completely
-        different folder to the diffs/failures.  Useful when working
-        with version control systems. By default this resolves to the
-        screenshotRoot folder.
-		*/
-        comparisonResultRoot?: string;
-
-        /**
-        Don't add count number to images. If set to false (default), a filename is
-        required when capturing screenshots.
-        */
-        addIteratorToImage: boolean;
-
-		/**
-        Remove results directory tree after run.  Use in conjunction
-        with failedComparisonsRoot to see failed comparisons.
-		*/
-        cleanupComparisonImages?: boolean;
-
-		/**
-		 * Don't add label to generated failure image
-		 */
-        addLabelToFailedImage?: boolean;
-		/**
-        * Change the output screenshot filenames for your specific
-        * integration
-    	*/
-        fileNameGetter?: (rootPath: string, fileName?: string) => string;
-
-		/**
-        Mismatch tolerance defaults to  0.05%. Increasing this value
-        will decrease test coverage
-    	*/
-        mismatchTolerance?: number;
-
-        onPass?: (test: PhantomCSSTest) => void;
-        onFail?: (test: PhantomCSSTest) => void;
-        onTimeout?: (test: PhantomCSSTest) => void;
-        onComplete?: (tests: PhantomCSSTest[], noOfFails: number, noOfErrors: number) => void;
-		/**
-        Called when creating new baseline images
-		*/
-        onNewImage?: (test: PhantomCSSTest) => void;
-
-        /**
-       Prefix the screenshot number to the filename, instead of suffixing it
+      /**
+          Rebase is useful when you want to create new baseline
+          images without manually deleting the files
+          casperjs demo/test.js --rebase
+      */
+      rebase?: any;
+      /**
+        A reference to a particular Casper instance. Required for SlimerJS.
        */
-        prefixCount?: boolean;
+      casper?: Casper;
+      /**
+      libraryRoot is relative to this file and must point to your phantomcss folder (not lib or node_modules). If you are using NPM, this will be './node_modules/phantomcss'.
+      */
+      libraryRoot?: string;
 
-        hideElements?: string;
-        outputSettings?: resemble.OutputSettings;
+      screenshotRoot?: string;
+      /**
+      By default, failure images are put in the './failures' folder.
+      If failedComparisonsRoot is set to false a separate folder will
+      not be created but failure images can still be found alongside
+      the original and new images.
+      */
+      failedComparisonsRoot?: string;
+
+      /**
+      You might want to keep master/baseline images in a completely
+      different folder to the diffs/failures.  Useful when working
+      with version control systems. By default this resolves to the
+      screenshotRoot folder.
+      */
+      comparisonResultRoot?: string;
+
+      /**
+      Don't add count number to images. If set to false (default), a filename is
+      required when capturing screenshots.
+      */
+      addIteratorToImage: boolean;
+
+      /**
+      Remove results directory tree after run.  Use in conjunction
+      with failedComparisonsRoot to see failed comparisons.
+      */
+      cleanupComparisonImages?: boolean;
+
+      /**
+       * Don't add label to generated failure image
+       */
+      addLabelToFailedImage?: boolean;
+      /**
+      * Change the output screenshot filenames for your specific
+      * integration
+      */
+      fileNameGetter?: (rootPath: string, fileName?: string) => string;
+
+      /**
+      Mismatch tolerance defaults to  0.05%. Increasing this value
+      will decrease test coverage
+      */
+      mismatchTolerance?: number;
+
+      onPass?: (test: PhantomCSSTest) => void;
+      onFail?: (test: PhantomCSSTest) => void;
+      onTimeout?: (test: PhantomCSSTest) => void;
+      onComplete?: (tests: PhantomCSSTest[], noOfFails: number, noOfErrors: number) => void;
+      /**
+      Called when creating new baseline images
+      */
+      onNewImage?: (test: PhantomCSSTest) => void;
+
+      /**
+     Prefix the screenshot number to the filename, instead of suffixing it
+     */
+      prefixCount?: boolean;
+
+      hideElements?: string;
+      outputSettings?: resemble.OutputSettings;
     }
 
+  }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://docs.casperjs.org/en/latest/modules/casper.html
- [x] Increase the version number in the header if appropriate.

This morning I tried installing this package using `@types/casperjs` but there was an error with importing it. Upon further inspection I saw it didn't actually export any methods.

I fixed this and fixed some of the `this` bindings.