### PR TITLE
Unional systemjs

### DIFF
--- a/systemjs/index.d.ts
+++ b/systemjs/index.d.ts
@@ -257,7 +257,7 @@ declare namespace SystemJSLoader {
         /**
          * This represents the System base class, which can be extended or reinstantiated to create a custom System instance.
          */
-        constructor(): System;
+        constructor: new () => System;
 
         /**
          * Deletes a module from the registry by normalized name.

--- a/systemjs/systemjs-tests.ts
+++ b/systemjs/systemjs-tests.ts
@@ -35,3 +35,5 @@ System.import('./app.js').then(function (m) {
 System.import('lodash').then(function (_) {
     console.log(_);
 });
+
+const clonedSystemJS = new System.constructor();


### PR DESCRIPTION
- [x] Prefer to make your PR against the `master` branch.

`SystemJS.constructor()` is newable:

https://github.com/systemjs/systemjs/blob/master/docs/system-api.md#systemjsconstructor

Current for does not allow `var x = new SystemJS.constructor()` --> "Only a void function can be called with the 'new' keyword"

This PR fix that.