### PR TITLE
Hammerjs: optional inputClass is a HammerInput, not a void function

### DIFF
--- a/hammerjs/hammerjs-tests.ts
+++ b/hammerjs/hammerjs-tests.ts
@@ -113,3 +113,30 @@
     myElement.textContent += ev.type + " ";
   } );
 })();
+
+
+(() =>
+{
+  var myElement = document.getElementById( 'myElement' );
+
+  // We create a manager object using custom options
+  var options: HammerOptions = {
+    recognizers: [
+      [Hammer.Tap, { event: 'doubletap', taps: 2 }],
+      [Hammer.Tap, { event: 'singletap' }],
+    ],
+    inputClass: Hammer.TouchInput,
+  };
+  var mc = new Hammer.Manager( myElement, options );
+
+  // we want to recognize this simulatenous, so a quadrupletap will be detected even while a tap has been recognized.
+  mc.get( 'doubletap' ).recognizeWith( 'singletap' );
+  // we only want to trigger a tap, when we don't have detected a doubletap
+  mc.get( 'singletap' ).requireFailure( 'doubletap' );
+
+
+  mc.on( "singletap doubletap", function ( ev )
+  {
+    myElement.textContent += ev.type + " ";
+  } );
+})();

--- a/hammerjs/index.d.ts
+++ b/hammerjs/index.d.ts
@@ -82,7 +82,7 @@ interface HammerDefaults extends HammerOptions
   touchAction:string;
   cssProps:CssProps;
 
-  inputClass:() => void;
+  inputClass:HammerInput;
   inputTarget:EventTarget;
 }
 
@@ -105,7 +105,7 @@ interface HammerOptions
   touchAction?:string;
   recognizers?:RecognizerTuple[];
 
-  inputClass?:() => void;
+  inputClass?:HammerInput;
   inputTarget?:EventTarget;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] ~Run `npm run lint -- package-name` if a `tslint.json` is present.~

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hammerjs/hammer.js/blob/a28c530297f6e66785476013a6c9162305a2ce42/src/inputjs/create-input-instance.js
  `Type` and `inputClass` should share a type, and all possibilities for `Type` extend `Input`, which in this definition is called `HammerInput`, so `inputClass` should also be a `HammerInput`.
- [ ] ~Increase the version number in the header if appropriate.~

