### PR TITLE
[lodash] add type guards to isNull, isUndefined, isNil

### DIFF
--- a/lodash/index.d.ts
+++ b/lodash/index.d.ts
@@ -12310,7 +12310,7 @@ declare module _ {
          * _.isNil(NaN);
          * // => false
          */
-        isNil(value?: any): boolean;
+        isNil(value: any): value is null | undefined;
     }
 
     interface LoDashImplicitWrapperBase<T, TWrapper> {
@@ -12335,7 +12335,7 @@ declare module _ {
          * @param value The value to check.
          * @return Returns true if value is null, else false.
          */
-        isNull(value?: any): boolean;
+        isNull(value: any): value is null;
     }
 
     interface LoDashImplicitWrapperBase<T, TWrapper> {
@@ -12662,7 +12662,7 @@ declare module _ {
          * @param value The value to check.
          * @return Returns true if value is undefined, else false.
          */
-        isUndefined(value: any): boolean;
+        isUndefined(value: any): value is undefined;
     }
 
     interface LoDashImplicitWrapperBase<T, TWrapper> {


### PR DESCRIPTION
Please fill in this template.

- [ ] Prefer to make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.

-----

This very simple PR adds type guards to `isNull()` and `isUndefined` ([more information here](https://www.typescriptlang.org/docs/handbook/advanced-types.html), chapter "User-Defined Type Guards").

Example:

```typescript
    this.startBlock: number;

    /* ... */

    let startBlock: number | null;
    if (!_.isNull(startBlock) && !_.isUndefined(startBlock)) {
      // even with "strictNullChecks" option enabled Typescript will not generate an error,
      // knowing that "startBlock" can only be a number.
      this.startBlock = startBlock;
    } else {
      this.startBlock = 0;
    }
```

Please tell me if I forgot to do something, it's my first PR.