### PR TITLE
Fix angular-ui-notification

### DIFF
--- a/angular-ui-notification/angular-ui-notification-tests.ts
+++ b/angular-ui-notification/angular-ui-notification-tests.ts
@@ -1,5 +1,5 @@
 
-function TestNotifications(NotificationProvider: angular.uiNotification.INotificationProvider, Notification: angular.uiNotification.INotificationService) {
+function TestNotifications(NotificationProvider: angular.uiNotification.NotificationProvider, Notification: angular.uiNotification.NotificationService) {
     NotificationProvider.setOptions({
         delay: 10000,
         startTop: 20,

--- a/angular-ui-notification/angular-ui-notification-tests.ts
+++ b/angular-ui-notification/angular-ui-notification-tests.ts
@@ -1,5 +1,5 @@
 
-function TestNotifications(NotificationProvider: angular.uiNotification.NotificationProvider, Notification: angular.uiNotification.NotificationService) {
+function TestNotifications(NotificationProvider: angular.uiNotification.INotificationProvider, Notification: angular.uiNotification.INotificationService) {
     NotificationProvider.setOptions({
         delay: 10000,
         startTop: 20,

--- a/angular-ui-notification/index.d.ts
+++ b/angular-ui-notification/index.d.ts
@@ -3,80 +3,64 @@
 // Definitions by: Kamil Rojewski <https://github.com/krojew/DefinitelyTyped>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace angular.uiNotification {
-    // Taken from angular to avoid dependency
-    interface IPromise<T> {
-        /**
-         * Regardless of when the promise was or will be resolved or rejected, then calls one of the success or error callbacks asynchronously as soon as the result is available. The callbacks are called with a single argument: the result or rejection reason. Additionally, the notify callback may be called zero or more times to provide a progress indication, before the promise is resolved or rejected.
-         * The successCallBack may return IPromise<void> for when a $q.reject() needs to be returned
-         * This method returns a new promise which is resolved or rejected via the return value of the successCallback, errorCallback. It also notifies via the return value of the notifyCallback method. The promise can not be resolved or rejected from the notifyCallback method.
-         */
-        then<TResult>(successCallback: (promiseValue: T) => IPromise<TResult>|TResult, errorCallback?: (reason: any) => any, notifyCallback?: (state: any) => any): IPromise<TResult>;
+/// <reference types="angular" />
 
-        /**
-         * Shorthand for promise.then(null, errorCallback)
-         */
-        catch<TResult>(onRejected: (reason: any) => IPromise<TResult>|TResult): IPromise<TResult>;
+import * as angular from 'angular';
 
-        /**
-         * Allows you to observe either the fulfillment or rejection of a promise, but to do so without modifying the final value. This is useful to release resources or do some clean-up that needs to be done whether the promise was rejected or resolved. See the full specification for more information.
-         *
-         * Because finally is a reserved word in JavaScript and reserved keywords are not supported as property names by ES3, you'll need to invoke the method like promise['finally'](callback) to make your code IE8 and Android 2.x compatible.
-         */
-        finally(finallyCallback: () => any): IPromise<T>;
-    }
+declare module 'angular' {
+    export namespace uiNotification {
+        type XPosition = 'right' | 'left' | 'center';
+        type YPosition = 'top' | 'bottom';
 
-    type XPosition = 'right'|'left'|'center';
-    type YPosition = 'top'|'bottom';
+        type MessageType = 'primary' | 'info' | 'success' | 'warning' | 'error';
 
-    type MessageType = 'primary'|'info'|'success'|'warning'|'error';
+        interface IGlobalMessageOptions {
+            delay?: number;
+            startTop?: number;
+            startRight?: number;
+            verticalSpacing?: number;
+            horizontalSpacing?: number;
+            positionX?: XPosition;
+            positionY?: YPosition;
+            replaceMessage?: boolean;
+            templateUrl?: string;
+            onClose?: (element: any) => any;
+            closeOnClick?: boolean;
+            maxCount?: number;
+        }
 
-    interface IGlobalMessageOptions {
-        delay?: number;
-        startTop?: number;
-        startRight?: number;
-        verticalSpacing?: number;
-        horizontalSpacing?: number;
-        positionX?: XPosition;
-        positionY?: YPosition;
-        replaceMessage?: boolean;
-        templateUrl?: string;
-        onClose?: (element: any) => any;
-        closeOnClick?: boolean;
-        maxCount?: number;
-    }
+        interface IMessageOptions {
+            title?: string;
+            message?: string;
+            templateUrl?: string;
+            delay?: number;
+            type?: MessageType;
+            positionX?: XPosition;
+            positionY?: YPosition;
+            replaceMessage?: boolean;
+            closeOnClick?: boolean;
+        }
 
-    interface IMessageOptions {
-        title?: string;
-        message?: string;
-        templateUrl?: string;
-        delay?: number;
-        type?: MessageType;
-        positionX?: XPosition;
-        positionY?: YPosition;
-        replaceMessage?: boolean;
-        closeOnClick?: boolean;
-    }
+        interface INotificationScope {
+            kill(isHard: boolean): void;
+        }
 
-    interface INotificationScope {
-        kill(isHard: boolean): void;
-    }
+        interface INotificationProvider {
+            setOptions(options: IGlobalMessageOptions): void;
+        }
 
-    interface INotificationProvider {
-        setOptions(options: IGlobalMessageOptions): void;
-    }
+        type Message = string | IMessageOptions;
 
-    type Message = string|IMessageOptions;
+        interface INotificationService {
+            primary(message: Message): IPromise<INotificationScope>;
+            info(message: Message): IPromise<INotificationScope>;
+            success(message: Message): IPromise<INotificationScope>;
+            warning(message: Message): IPromise<INotificationScope>;
+            error(message: Message): IPromise<INotificationScope>;
 
-    interface INotificationService {
-        primary(message: Message): IPromise<INotificationScope>;
-        info(message: Message): IPromise<INotificationScope>;
-        success(message: Message): IPromise<INotificationScope>;
-        warning(message: Message): IPromise<INotificationScope>;
-        error(message: Message): IPromise<INotificationScope>;
+            clearAll(): void;
 
-        clearAll(): void;
-
-        (message: Message, type?: MessageType): IPromise<INotificationScope>;
+            (message: Message, type?: MessageType): IPromise<INotificationScope>;
+        }
     }
 }

--- a/angular-ui-notification/index.d.ts
+++ b/angular-ui-notification/index.d.ts
@@ -1,7 +1,9 @@
-// Type definitions for angular-ui-notification 0.2
+// Type definitions for angular-ui-notification
 // Project: https://github.com/alexcrack/angular-ui-notification
 // Definitions by: Kamil Rojewski <https://github.com/krojew/DefinitelyTyped>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="angular" />
 
 import * as angular from 'angular';
 
@@ -12,7 +14,7 @@ declare module 'angular' {
 
         type MessageType = 'primary' | 'info' | 'success' | 'warning' | 'error';
 
-        interface GlobalMessageOptions {
+        interface IGlobalMessageOptions {
             delay?: number;
             startTop?: number;
             startRight?: number;
@@ -27,7 +29,7 @@ declare module 'angular' {
             maxCount?: number;
         }
 
-        interface MessageOptions {
+        interface IMessageOptions {
             title?: string;
             message?: string;
             templateUrl?: string;
@@ -39,26 +41,26 @@ declare module 'angular' {
             closeOnClick?: boolean;
         }
 
-        interface NotificationScope {
+        interface INotificationScope {
             kill(isHard: boolean): void;
         }
 
-        interface NotificationProvider {
-            setOptions(options: GlobalMessageOptions): void;
+        interface INotificationProvider {
+            setOptions(options: IGlobalMessageOptions): void;
         }
 
-        type Message = string | MessageOptions;
+        type Message = string | IMessageOptions;
 
-        interface NotificationService {
-            primary(message: Message): IPromise<NotificationScope>;
-            info(message: Message): IPromise<NotificationScope>;
-            success(message: Message): IPromise<NotificationScope>;
-            warning(message: Message): IPromise<NotificationScope>;
-            error(message: Message): IPromise<NotificationScope>;
+        interface INotificationService {
+            primary(message: Message): IPromise<INotificationScope>;
+            info(message: Message): IPromise<INotificationScope>;
+            success(message: Message): IPromise<INotificationScope>;
+            warning(message: Message): IPromise<INotificationScope>;
+            error(message: Message): IPromise<INotificationScope>;
 
             clearAll(): void;
 
-            (message: Message, type?: MessageType): IPromise<NotificationScope>;
+            (message: Message, type?: MessageType): IPromise<INotificationScope>;
         }
     }
 }

--- a/angular-ui-notification/index.d.ts
+++ b/angular-ui-notification/index.d.ts
@@ -1,9 +1,7 @@
-// Type definitions for angular-ui-notification
+// Type definitions for angular-ui-notification 0.2
 // Project: https://github.com/alexcrack/angular-ui-notification
 // Definitions by: Kamil Rojewski <https://github.com/krojew/DefinitelyTyped>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-/// <reference types="angular" />
 
 import * as angular from 'angular';
 
@@ -14,7 +12,7 @@ declare module 'angular' {
 
         type MessageType = 'primary' | 'info' | 'success' | 'warning' | 'error';
 
-        interface IGlobalMessageOptions {
+        interface GlobalMessageOptions {
             delay?: number;
             startTop?: number;
             startRight?: number;
@@ -29,7 +27,7 @@ declare module 'angular' {
             maxCount?: number;
         }
 
-        interface IMessageOptions {
+        interface MessageOptions {
             title?: string;
             message?: string;
             templateUrl?: string;
@@ -41,26 +39,26 @@ declare module 'angular' {
             closeOnClick?: boolean;
         }
 
-        interface INotificationScope {
+        interface NotificationScope {
             kill(isHard: boolean): void;
         }
 
-        interface INotificationProvider {
-            setOptions(options: IGlobalMessageOptions): void;
+        interface NotificationProvider {
+            setOptions(options: GlobalMessageOptions): void;
         }
 
-        type Message = string | IMessageOptions;
+        type Message = string | MessageOptions;
 
-        interface INotificationService {
-            primary(message: Message): IPromise<INotificationScope>;
-            info(message: Message): IPromise<INotificationScope>;
-            success(message: Message): IPromise<INotificationScope>;
-            warning(message: Message): IPromise<INotificationScope>;
-            error(message: Message): IPromise<INotificationScope>;
+        interface NotificationService {
+            primary(message: Message): IPromise<NotificationScope>;
+            info(message: Message): IPromise<NotificationScope>;
+            success(message: Message): IPromise<NotificationScope>;
+            warning(message: Message): IPromise<NotificationScope>;
+            error(message: Message): IPromise<NotificationScope>;
 
             clearAll(): void;
 
-            (message: Message, type?: MessageType): IPromise<INotificationScope>;
+            (message: Message, type?: MessageType): IPromise<NotificationScope>;
         }
     }
 }


### PR DESCRIPTION
This PR fixes the typings for the `angular-ui-notification` package.  It removes a redundant definition and augments the existing `angular` module instead of defining a new one.

Another change was to remove the `I` prefix from the interfaces as suggested in the `readme.md`.

The linter accepts the changes, `npm test` succeeds and it works in a private project.