### PR TITLE
react-relay: Relay.createContainer accepts stateless components

### DIFF
--- a/react-relay/index.d.ts
+++ b/react-relay/index.d.ts
@@ -56,7 +56,7 @@ declare module "react-relay" {
         supports(...options: string[]): boolean
     }
 
-    function createContainer<T>(component: React.ComponentClass<T>, params?: CreateContainerOpts): RelayContainerClass<any>
+    function createContainer<T>(component: React.ComponentClass<T> | React.StatelessComponent<T>, params?: CreateContainerOpts): RelayContainerClass<any>
     function injectNetworkLayer(networkLayer: RelayNetworkLayer): any
     function isContainer(component: React.ComponentClass<any>): boolean
     function QL(...args: any[]): string


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/pull/525
- [ ] Increase the version number in the header if appropriate.

Notes:
- Relay containers can be created with stateless components
- This is a pretty modest change to enable that
- see discussion here (relay enabled this some time ago): https://github.com/facebook/relay/pull/525
