### PR TITLE
Added missing properties to React-Bootstrap TabProps interface

### DIFF
--- a/react-bootstrap/index.d.ts
+++ b/react-bootstrap/index.d.ts
@@ -601,7 +601,17 @@ declare namespace ReactBootstrap {
     // <Tab />
     interface TabProps extends React.HTMLProps<Tab> {
         animation?: boolean;
+        'aria-labelledby'?:string;
+        bsClass?:string; 
         eventKey?: any; // TODO: Add more specific type
+        onEnter?: Function;
+        onEntered?: Function;
+        onEntering?: Function;
+        onExit?: Function;
+        onExited?: Function;
+        onExiting?: Function;
+        unmountOnExit?: boolean;
+        tabClassName?:string;
     }
     interface TabClass extends React.ClassicComponentClass<TabProps> {
         Container: TabContainer;

--- a/react-bootstrap/react-bootstrap-tests.tsx
+++ b/react-bootstrap/react-bootstrap-tests.tsx
@@ -599,6 +599,21 @@ export class ReactBootstrapTest extends Component<any, any> {
                 </div>
 
                 <div style={style}>
+                  <Tabs defaultActiveKey={1} animation={true}>
+                    <Tab animation={true}
+                     onEntered={() => {}}
+                     onEntering={() => {}}
+                     onExit={() => {}}
+                     onExited={() => {}}
+                     onExiting={()=>{}}
+                     unmountOnExit={true}
+                     bsClass="some style" tabClassName="classname"  eventKey={1} title='Tab 1'>Tab 1 content</Tab>
+                    <Tab eventKey={2} title='Tab 2'>Tab 2 content</Tab>
+                    <Tab eventKey={3} title='Tab 3' disabled>Tab 3 content</Tab>
+                  </Tabs>
+                </div>
+
+                <div style={style}>
                   <Tab.Container id="left-tabs-example" defaultActiveKey="first">
                     <Row className="clearfix">
                       <Col sm={4}>


### PR DESCRIPTION
Adds missing properties on the React-Bootstrap TabProps interface for use with the Tab component

properties taken from https://react-bootstrap.github.io/components.html#tabs

