### PR TITLE
fix scalar type config

### DIFF
--- a/graphql/index.d.ts
+++ b/graphql/index.d.ts
@@ -1185,9 +1185,9 @@ declare module "graphql/type/definition" {
     export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
         name: string;
         description?: string;
-        serialize: (value: any) => TInternal;
-        parseValue?: (value: any) => TExternal;
-        parseLiteral?: (valueNode: ValueNode) => TInternal;
+        serialize: (value: any) => TExternal | null | undefined;
+        parseValue?: (value: any) => TInternal | null | undefined;
+        parseLiteral?: (valueNode: ValueNode) => TInternal | null | undefined;
     }
 
     /**


### PR DESCRIPTION
The `GraphQLScalarTypeConfig` interface had incorrect types. Correct types may be seen here: https://github.com/graphql/graphql-js/blob/379a3084392179d2cae92c211a4559f9836299c6/src/type/definition.js#L348-L350