### PR TITLE
Make Marker and Icon extendable classes and options optional

### DIFF
--- a/leaflet/index.d.ts
+++ b/leaflet/index.d.ts
@@ -391,6 +391,7 @@ declare namespace L {
     }
 
     export class Layer extends Evented {
+        constructor(options?: LayerOptions);
         addTo(map: Map): this;
         remove(): this;
         removeFrom(map: Map): this;
@@ -1346,10 +1347,17 @@ declare namespace L {
     }
 
     export class Icon {
-        static Default: IconDefault;
+        constructor(options: IconOptions);
     }
 
-    export function icon(options?: IconOptions): Icon;
+    export namespace Icon {
+        export class Default extends Icon {
+            constructor(options?: IconOptions);
+            imagePath: string;
+        }
+    }
+
+    export function icon(options: IconOptions): Icon;
 
     export interface DivIconOptions extends LayerOptions {
         html?: string;
@@ -1360,9 +1368,11 @@ declare namespace L {
         className?: string;
     }
 
-    export class DivIcon extends Icon {}
+    export class DivIcon extends Icon {
+        constructor(options?: DivIconOptions);
+    }
 
-    export function divIcon(options: DivIconOptions): DivIcon;
+    export function divIcon(options?: DivIconOptions): DivIcon;
 
     export interface MarkerOptions extends InteractiveLayerOptions {
         icon?: Icon;

--- a/leaflet/index.d.ts
+++ b/leaflet/index.d.ts
@@ -390,7 +390,7 @@ declare namespace L {
         interactive?: boolean;
     }
 
-    export interface Layer extends Evented {
+    export class Layer extends Evented {
         addTo(map: Map): this;
         remove(): this;
         removeFrom(map: Map): this;
@@ -502,7 +502,7 @@ declare namespace L {
     }
 
     export namespace tileLayer {
-        export function wms(baseUrl: string, options: WMSOptions): WMS;
+        export function wms(baseUrl: string, options?: WMSOptions): WMS;
     }
 
     export interface ImageOverlayOptions extends LayerOptions {
@@ -1247,12 +1247,12 @@ declare namespace L {
 
         // Methods for modifying map state
         setView(center: LatLngExpression, zoom: number, options?: ZoomPanOptions): this;
-        setZoom(zoom: number, options: ZoomPanOptions): this;
+        setZoom(zoom: number, options?: ZoomPanOptions): this;
         zoomIn(delta?: number, options?: ZoomOptions): this;
         zoomOut(delta?: number, options?: ZoomOptions): this;
-        setZoomAround(latlng: LatLngExpression, zoom: number, options: ZoomOptions): this;
-        setZoomAround(offset: Point, zoom: number, options: ZoomOptions): this;
-        fitBounds(bounds: LatLngBoundsExpression, options: FitBoundsOptions): this;
+        setZoomAround(latlng: LatLngExpression, zoom: number, options?: ZoomOptions): this;
+        setZoomAround(offset: Point, zoom: number, options?: ZoomOptions): this;
+        fitBounds(bounds: LatLngBoundsExpression, options?: FitBoundsOptions): this;
         fitWorld(options?: FitBoundsOptions): this;
         panTo(latlng: LatLngExpression, options?: PanOptions): this;
         panBy(offset: PointExpression): this;
@@ -1345,11 +1345,11 @@ declare namespace L {
         imagePath: string;
     }
 
-    export namespace Icon {
-        export const Default: IconDefault;
+    export class Icon {
+        static Default: IconDefault;
     }
 
-    export function icon(options: IconOptions): Icon;
+    export function icon(options?: IconOptions): Icon;
 
     export interface DivIconOptions extends LayerOptions {
         html?: string;
@@ -1360,7 +1360,7 @@ declare namespace L {
         className?: string;
     }
 
-    export interface DivIcon extends Icon {}
+    export class DivIcon extends Icon {}
 
     export function divIcon(options: DivIconOptions): DivIcon;
 
@@ -1376,12 +1376,14 @@ declare namespace L {
         riseOffset?: number;
     }
 
-    export interface Marker extends Layer {
+    export class Marker extends Layer {
+        constructor(latlng: LatLngExpression, options?: MarkerOptions);
         getLatLng(): LatLng;
         setLatLng(latlng: LatLngExpression): this;
         setZIndexOffset(offset: number): this;
         setIcon(icon: Icon): this;
         setOpacity(opacity: number): this;
+        getElement(): Element;
 
         // Properties
         dragging: Handler;

--- a/leaflet/leaflet-tests.ts
+++ b/leaflet/leaflet-tests.ts
@@ -297,6 +297,7 @@ map = map
 	.setView(latLngLiteral, 12, zoomPanOptions)
 	.setView(latLngTuple, 12)
 	.setView(latLngTuple, 12, zoomPanOptions)
+	.setZoom(11)
 	.setZoom(12, zoomPanOptions) // investigate if zoomPanOptions are really required
 	.zoomIn()
 	.zoomIn(1)
@@ -309,6 +310,7 @@ map = map
 	.setZoomAround(latLngTuple, 12, zoomOptions)
 	.setZoomAround(point, 12, zoomOptions)
 	.setZoomAround(pointTuple, 11, zoomOptions)
+	.fitBounds(latLngBounds)
 	.fitBounds(latLngBounds, fitBoundsOptions) // investigate if fit bounds options are really required
 	.fitBounds(latLngBoundsLiteral, fitBoundsOptions)
 	.fitWorld()
@@ -355,3 +357,24 @@ let draggable = new L.Draggable(elementToDrag);
 draggable.enable();
 draggable.disable();
 draggable.on('drag', () => {});
+
+class MyMarker extends L.Marker {
+	constructor() {
+		super([12, 13]);
+	}
+}
+class MyLayer extends L.Layer {
+	constructor() {
+		super();
+	}
+}
+class MyIcon extends L.Icon {
+	constructor() {
+		super({iconUrl: 'icon.png'});
+	}
+}
+class MyDivIcon extends L.DivIcon {
+	constructor() {
+		super();
+	}
+}


### PR DESCRIPTION
`Marker` and `Icon` are extendable classes. We use them like that. This change also make some `options`... optional! 