### PR TITLE
react-datepicker: Fix type signature of event handlers

### DIFF
--- a/react-datepicker/index.d.ts
+++ b/react-datepicker/index.d.ts
@@ -16,7 +16,7 @@ declare module "react-datepicker" {
         disabled?: boolean;
         endDate?: {};
         excludeDates?: any[];
-        filterDate?():any;
+        filterDate?(): any;
         fixedHeight?: boolean;
         id?: string;
         includeDates?: any[];
@@ -25,10 +25,9 @@ declare module "react-datepicker" {
         maxDate?: {};
         minDate?: {};
         name?: string;
-        onBlur?():any;
-        onChange():any;
-        onChange(date?:any):any;
-        onFocus?():any;
+        onBlur?(handler: (e: any) => void): any;
+        onChange(handler: (date?: any, e?: any) => void): any;
+        onFocus?(handler: (e: any) => void): any;
         peekNextMonth?: boolean;
         placeholderText?: string;
         popoverAttachment?: string;
@@ -40,7 +39,7 @@ declare module "react-datepicker" {
         scrollableYearDropdown?: boolean;
         selected?: {};
         selectsEnd?: boolean;
-        selectsStart?: boolean; 
+        selectsStart?: boolean;
         showMonthDropdown?: boolean;
         showYearDropdown?: boolean;
         showWeekNumbers?: boolean;


### PR DESCRIPTION
According to the source code the event handlers should take handler functions as arguments not plain values:

>     onBlur: React.PropTypes.func,
>     onChange: React.PropTypes.func.isRequired,
>     onFocus: React.PropTypes.func,

I also ran the file through the typescript formatter. Hope that is ok.