### PR TITLE
fix for missing process.cpuUsage([previousValue]) function in v6.x API of node package

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -329,6 +329,11 @@ declare namespace NodeJS {
         heapTotal: number;
         heapUsed: number;
     }
+    
+    export interface CpuUsage {
+        user: number;
+        system: number;
+    }
 
     export interface ProcessVersions {
         http_parser: string;
@@ -396,6 +401,7 @@ declare namespace NodeJS {
         platform: string;
         mainModule?: NodeModule;
         memoryUsage(): MemoryUsage;
+        cpuUsage(previousValue?: CpuUsage): CpuUsage;
         nextTick(callback: Function, ...args: any[]): void;
         umask(mask?: number): number;
         uptime(): number;


### PR DESCRIPTION

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] Increase the version number in the header if appropriate.
