### PR TITLE
Add swagger-schema-official type definition

### DIFF
--- a/swagger-schema-official/index.d.ts
+++ b/swagger-schema-official/index.d.ts
@@ -1,0 +1,236 @@
+// Type definitions for swagger-schema-official 2.0.0-d79c205
+// Project: http://swagger.io/specification/
+// Definitions by: Mohsen Azimi <https://github.com/mohsen1>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "swagger-schema-official" {
+
+  export interface Info {
+    title: string;
+    version: string;
+    description?: string;
+    termsOfService?: string;
+    contact?: Contact;
+    license?: License;
+  }
+
+  export interface Contact {
+    name?: string;
+    email?: string;
+    url?: string;
+  }
+
+  export interface License {
+    name: string;
+    url?: string;
+  }
+
+  export interface ExternalDocs {
+    url: string;
+    description?: string;
+  }
+
+  export interface Tag {
+    name: string;
+    description?: string;
+    externalDocs?: ExternalDocs;
+  }
+
+  export interface Example {
+    // Example type interface is intentionally loose
+  }
+
+  export interface Header extends BaseSchema {
+    type: string;
+  }
+
+  // ----------------------------- Parameter -----------------------------------
+  interface BaseParameter {
+    name: string;
+    in: string;
+    required?: boolean;
+    description?: string;
+  }
+
+  export interface BodyParameter extends BaseParameter {
+    schema?: Schema;
+  }
+
+  export interface QueryParameter extends BaseParameter, BaseSchema {
+    type: string;
+    allowEmptyValue?: boolean;
+  }
+
+  export interface PathParameter extends BaseParameter {
+    type: string;
+    required: boolean;
+  }
+
+  export interface HeaderParameter extends BaseParameter {
+    type: string;
+  }
+
+  export interface FormDataParameter extends BaseParameter, BaseSchema {
+    type: string;
+    collectionFormat?: string;
+  }
+
+  type Parameter =
+    BodyParameter |
+    FormDataParameter |
+    QueryParameter |
+    PathParameter |
+    HeaderParameter;
+
+  // ------------------------------- Path --------------------------------------
+  export interface Path {
+    $ref?: string;
+    get?: Operation;
+    put?: Operation;
+    post?: Operation;
+    delete?: Operation;
+    options?: Operation;
+    head?: Operation;
+    patch?: Operation;
+    parameters?: [Parameter];
+  }
+
+  // ----------------------------- Operation -----------------------------------
+  export interface Operation {
+    responses: { [responseName: string]: Response };
+    summary?: string;
+    description?: string;
+    externalDocs?: ExternalDocs;
+    operationId?: string;
+    produces?: [string];
+    consumes?: [string];
+    parameters?: [Parameter];
+    schemes?: [string];
+    deprecated?: boolean;
+    security?: [Secuirty];
+    tags?:[string];
+  }
+
+  // ----------------------------- Response ------------------------------------
+  export interface Response {
+    description: string;
+    schema?: Schema;
+    headers?: { [headerName: string]: Header };
+    examples?: { [exampleName: string]: Example };
+  }
+
+  // ------------------------------ Schema -------------------------------------
+  interface BaseSchema {
+    format?: string;
+    title?: string;
+    description?: string;
+    default?: string|boolean|number|Object;
+    multipleOf?: number;
+    maximum?: number;
+    exclusiveMaximum?: number;
+    minimum?: number;
+    exclusiveMinimum?: number;
+    maxLength?: number;
+    minLength?: number;
+    pattern?: string;
+    maxItems?: number;
+    minItems?: number;
+    uniqueItems?: boolean;
+    maxProperties?: number;
+    minProperties?: number;
+    enum?: [string|boolean|number|Object];
+    type?: string;
+    items?: Schema|[Schema];
+  }
+
+  export interface Schema extends BaseSchema {
+    $ref?: string;
+    allOf?: [Schema];
+    additionalProperties?: boolean;
+    properties?: {[propertyName: string]: Schema};
+    discriminator?: string;
+    readOnly?: boolean;
+    xml?: XML;
+    externalDocs?: ExternalDocs;
+    example?: {[exampleName: string]: Example};
+    required?: [string];
+  }
+
+  export interface XML {
+    type?: string;
+    namespace?: string;
+    prefix?: string;
+    attribute?: string;
+    wrapped?: boolean;
+  }
+
+  // ----------------------------- Security ------------------------------------
+  interface BaseSecurity {
+    type: string;
+    description?: string;
+  }
+
+  export interface BasicAuthenticationSecurity extends BaseSecurity {
+    // It's the exact same interface as BaseSecurity
+  }
+
+  export interface ApiKeySecurity extends BaseSecurity {
+    name: string;
+    in: string;
+  }
+
+  interface BaseOAuthSecuirty extends BaseSecurity {
+    flow: string;
+  }
+
+  export interface OAuth2ImplicitSecurity extends BaseOAuthSecuirty {
+    authorizationUrl: string;
+  }
+
+  export interface OAuth2PasswordSecurity extends BaseOAuthSecuirty {
+    tokenUrl: string;
+    scopes?: [OAuthScope];
+  }
+
+  export interface OAuth2ApplicationSecurity extends BaseOAuthSecuirty {
+    tokenUrl: string;
+    scopes?: [OAuthScope];
+  }
+
+  export interface OAuth2AccessCodeSecurity extends BaseOAuthSecuirty {
+    tokenUrl: string;
+    authorizationUrl: string;
+    scopes?: [OAuthScope];
+  }
+
+  export interface OAuthScope {
+    [scopeName: string]: string;
+  }
+
+  type Secuirty =
+    BasicAuthenticationSecurity |
+    OAuth2AccessCodeSecurity |
+    OAuth2ApplicationSecurity |
+    OAuth2ImplicitSecurity |
+    OAuth2PasswordSecurity |
+    ApiKeySecurity;
+
+  // --------------------------------- Spec ------------------------------------
+  export interface Spec {
+    swagger: string;
+    info: Info;
+    externalDocs?: ExternalDocs;
+    host?: string;
+    basePath?: string;
+    schemes?: [string];
+    consumes?: [string];
+    produces?: [string];
+    paths: {[pathName: string]: Path}
+    definitions?: {[definitionsName: string]: Schema }
+    parameters?: {[parameterName: string]: BodyParameter|QueryParameter}
+    responses?: {[responseName: string]: Response }
+    security?: [Secuirty]
+    securityDefinitions?: { [securityDefinitionName: string]: Secuirty}
+    tags?: [Tag]
+  }
+}

--- a/swagger-schema-official/index.d.ts
+++ b/swagger-schema-official/index.d.ts
@@ -1,236 +1,230 @@
-// Type definitions for swagger-schema-official 2.0.0-d79c205
+// Type definitions for swagger-schema-official 2.0
 // Project: http://swagger.io/specification/
 // Definitions by: Mohsen Azimi <https://github.com/mohsen1>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module "swagger-schema-official" {
+export interface Info {
+  title: string;
+  version: string;
+  description?: string;
+  termsOfService?: string;
+  contact?: Contact;
+  license?: License;
+}
 
-  export interface Info {
-    title: string;
-    version: string;
-    description?: string;
-    termsOfService?: string;
-    contact?: Contact;
-    license?: License;
-  }
+export interface Contact {
+  name?: string;
+  email?: string;
+  url?: string;
+}
 
-  export interface Contact {
-    name?: string;
-    email?: string;
-    url?: string;
-  }
+export interface License {
+  name: string;
+  url?: string;
+}
 
-  export interface License {
-    name: string;
-    url?: string;
-  }
+export interface ExternalDocs {
+  url: string;
+  description?: string;
+}
 
-  export interface ExternalDocs {
-    url: string;
-    description?: string;
-  }
+export interface Tag {
+  name: string;
+  description?: string;
+  externalDocs?: ExternalDocs;
+}
 
-  export interface Tag {
-    name: string;
-    description?: string;
-    externalDocs?: ExternalDocs;
-  }
+export interface Header extends BaseSchema {
+  type: string;
+}
 
-  export interface Example {
-    // Example type interface is intentionally loose
-  }
+// ----------------------------- Parameter -----------------------------------
+interface BaseParameter {
+  name: string;
+  in: string;
+  required?: boolean;
+  description?: string;
+}
 
-  export interface Header extends BaseSchema {
-    type: string;
-  }
+export interface BodyParameter extends BaseParameter {
+  schema?: Schema;
+}
 
-  // ----------------------------- Parameter -----------------------------------
-  interface BaseParameter {
-    name: string;
-    in: string;
-    required?: boolean;
-    description?: string;
-  }
+export interface QueryParameter extends BaseParameter, BaseSchema {
+  type: string;
+  allowEmptyValue?: boolean;
+}
 
-  export interface BodyParameter extends BaseParameter {
-    schema?: Schema;
-  }
+export interface PathParameter extends BaseParameter {
+  type: string;
+  required: boolean;
+}
 
-  export interface QueryParameter extends BaseParameter, BaseSchema {
-    type: string;
-    allowEmptyValue?: boolean;
-  }
+export interface HeaderParameter extends BaseParameter {
+  type: string;
+}
 
-  export interface PathParameter extends BaseParameter {
-    type: string;
-    required: boolean;
-  }
+export interface FormDataParameter extends BaseParameter, BaseSchema {
+  type: string;
+  collectionFormat?: string;
+}
 
-  export interface HeaderParameter extends BaseParameter {
-    type: string;
-  }
+type Parameter =
+  BodyParameter |
+  FormDataParameter |
+  QueryParameter |
+  PathParameter |
+  HeaderParameter;
 
-  export interface FormDataParameter extends BaseParameter, BaseSchema {
-    type: string;
-    collectionFormat?: string;
-  }
+// ------------------------------- Path --------------------------------------
+export interface Path {
+  $ref?: string;
+  get?: Operation;
+  put?: Operation;
+  post?: Operation;
+  delete?: Operation;
+  options?: Operation;
+  head?: Operation;
+  patch?: Operation;
+  parameters?: [Parameter];
+}
 
-  type Parameter =
-    BodyParameter |
-    FormDataParameter |
-    QueryParameter |
-    PathParameter |
-    HeaderParameter;
+// ----------------------------- Operation -----------------------------------
+export interface Operation {
+  responses: { [responseName: string]: Response };
+  summary?: string;
+  description?: string;
+  externalDocs?: ExternalDocs;
+  operationId?: string;
+  produces?: [string];
+  consumes?: [string];
+  parameters?: [Parameter];
+  schemes?: [string];
+  deprecated?: boolean;
+  security?: [Secuirty];
+  tags?: [string];
+}
 
-  // ------------------------------- Path --------------------------------------
-  export interface Path {
-    $ref?: string;
-    get?: Operation;
-    put?: Operation;
-    post?: Operation;
-    delete?: Operation;
-    options?: Operation;
-    head?: Operation;
-    patch?: Operation;
-    parameters?: [Parameter];
-  }
+// ----------------------------- Response ------------------------------------
+export interface Response {
+  description: string;
+  schema?: Schema;
+  headers?: { [headerName: string]: Header };
+  examples?: { [exampleName: string]: {} };
+}
 
-  // ----------------------------- Operation -----------------------------------
-  export interface Operation {
-    responses: { [responseName: string]: Response };
-    summary?: string;
-    description?: string;
-    externalDocs?: ExternalDocs;
-    operationId?: string;
-    produces?: [string];
-    consumes?: [string];
-    parameters?: [Parameter];
-    schemes?: [string];
-    deprecated?: boolean;
-    security?: [Secuirty];
-    tags?:[string];
-  }
+// ------------------------------ Schema -------------------------------------
+interface BaseSchema {
+  format?: string;
+  title?: string;
+  description?: string;
+  default?: string|boolean|number|{};
+  multipleOf?: number;
+  maximum?: number;
+  exclusiveMaximum?: number;
+  minimum?: number;
+  exclusiveMinimum?: number;
+  maxLength?: number;
+  minLength?: number;
+  pattern?: string;
+  maxItems?: number;
+  minItems?: number;
+  uniqueItems?: boolean;
+  maxProperties?: number;
+  minProperties?: number;
+  enum?: [string|boolean|number|{}];
+  type?: string;
+  items?: Schema|[Schema];
+}
 
-  // ----------------------------- Response ------------------------------------
-  export interface Response {
-    description: string;
-    schema?: Schema;
-    headers?: { [headerName: string]: Header };
-    examples?: { [exampleName: string]: Example };
-  }
+export interface Schema extends BaseSchema {
+  $ref?: string;
+  allOf?: [Schema];
+  additionalProperties?: boolean;
+  properties?: {[propertyName: string]: Schema};
+  discriminator?: string;
+  readOnly?: boolean;
+  xml?: XML;
+  externalDocs?: ExternalDocs;
+  example?: {[exampleName: string]: {}};
+  required?: [string];
+}
 
-  // ------------------------------ Schema -------------------------------------
-  interface BaseSchema {
-    format?: string;
-    title?: string;
-    description?: string;
-    default?: string|boolean|number|Object;
-    multipleOf?: number;
-    maximum?: number;
-    exclusiveMaximum?: number;
-    minimum?: number;
-    exclusiveMinimum?: number;
-    maxLength?: number;
-    minLength?: number;
-    pattern?: string;
-    maxItems?: number;
-    minItems?: number;
-    uniqueItems?: boolean;
-    maxProperties?: number;
-    minProperties?: number;
-    enum?: [string|boolean|number|Object];
-    type?: string;
-    items?: Schema|[Schema];
-  }
+export interface XML {
+  type?: string;
+  namespace?: string;
+  prefix?: string;
+  attribute?: string;
+  wrapped?: boolean;
+}
 
-  export interface Schema extends BaseSchema {
-    $ref?: string;
-    allOf?: [Schema];
-    additionalProperties?: boolean;
-    properties?: {[propertyName: string]: Schema};
-    discriminator?: string;
-    readOnly?: boolean;
-    xml?: XML;
-    externalDocs?: ExternalDocs;
-    example?: {[exampleName: string]: Example};
-    required?: [string];
-  }
+// ----------------------------- Security ------------------------------------
+interface BaseSecurity {
+  type: string;
+  description?: string;
+}
 
-  export interface XML {
-    type?: string;
-    namespace?: string;
-    prefix?: string;
-    attribute?: string;
-    wrapped?: boolean;
-  }
+// tslint:disable:no-empty-interface
+export interface BasicAuthenticationSecurity extends BaseSecurity {
+  // It's the exact same interface as BaseSecurity
+}
 
-  // ----------------------------- Security ------------------------------------
-  interface BaseSecurity {
-    type: string;
-    description?: string;
-  }
+export interface ApiKeySecurity extends BaseSecurity {
+  name: string;
+  in: string;
+}
 
-  export interface BasicAuthenticationSecurity extends BaseSecurity {
-    // It's the exact same interface as BaseSecurity
-  }
+interface BaseOAuthSecuirty extends BaseSecurity {
+  flow: string;
+}
 
-  export interface ApiKeySecurity extends BaseSecurity {
-    name: string;
-    in: string;
-  }
+export interface OAuth2ImplicitSecurity extends BaseOAuthSecuirty {
+  authorizationUrl: string;
+}
 
-  interface BaseOAuthSecuirty extends BaseSecurity {
-    flow: string;
-  }
+export interface OAuth2PasswordSecurity extends BaseOAuthSecuirty {
+  tokenUrl: string;
+  scopes?: [OAuthScope];
+}
 
-  export interface OAuth2ImplicitSecurity extends BaseOAuthSecuirty {
-    authorizationUrl: string;
-  }
+export interface OAuth2ApplicationSecurity extends BaseOAuthSecuirty {
+  tokenUrl: string;
+  scopes?: [OAuthScope];
+}
 
-  export interface OAuth2PasswordSecurity extends BaseOAuthSecuirty {
-    tokenUrl: string;
-    scopes?: [OAuthScope];
-  }
+export interface OAuth2AccessCodeSecurity extends BaseOAuthSecuirty {
+  tokenUrl: string;
+  authorizationUrl: string;
+  scopes?: [OAuthScope];
+}
 
-  export interface OAuth2ApplicationSecurity extends BaseOAuthSecuirty {
-    tokenUrl: string;
-    scopes?: [OAuthScope];
-  }
+export interface OAuthScope {
+  [scopeName: string]: string;
+}
 
-  export interface OAuth2AccessCodeSecurity extends BaseOAuthSecuirty {
-    tokenUrl: string;
-    authorizationUrl: string;
-    scopes?: [OAuthScope];
-  }
+type Secuirty =
+  BasicAuthenticationSecurity |
+  OAuth2AccessCodeSecurity |
+  OAuth2ApplicationSecurity |
+  OAuth2ImplicitSecurity |
+  OAuth2PasswordSecurity |
+  ApiKeySecurity;
 
-  export interface OAuthScope {
-    [scopeName: string]: string;
-  }
-
-  type Secuirty =
-    BasicAuthenticationSecurity |
-    OAuth2AccessCodeSecurity |
-    OAuth2ApplicationSecurity |
-    OAuth2ImplicitSecurity |
-    OAuth2PasswordSecurity |
-    ApiKeySecurity;
-
-  // --------------------------------- Spec ------------------------------------
-  export interface Spec {
-    swagger: string;
-    info: Info;
-    externalDocs?: ExternalDocs;
-    host?: string;
-    basePath?: string;
-    schemes?: [string];
-    consumes?: [string];
-    produces?: [string];
-    paths: {[pathName: string]: Path}
-    definitions?: {[definitionsName: string]: Schema }
-    parameters?: {[parameterName: string]: BodyParameter|QueryParameter}
-    responses?: {[responseName: string]: Response }
-    security?: [Secuirty]
-    securityDefinitions?: { [securityDefinitionName: string]: Secuirty}
-    tags?: [Tag]
-  }
+// --------------------------------- Spec ------------------------------------
+export interface Spec {
+  swagger: string;
+  info: Info;
+  externalDocs?: ExternalDocs;
+  host?: string;
+  basePath?: string;
+  schemes?: [string];
+  consumes?: [string];
+  produces?: [string];
+  paths: {[pathName: string]: Path};
+  definitions?: {[definitionsName: string]: Schema };
+  parameters?: {[parameterName: string]: BodyParameter|QueryParameter};
+  responses?: {[responseName: string]: Response };
+  security?: [Secuirty];
+  securityDefinitions?: { [securityDefinitionName: string]: Secuirty};
+  tags?: [Tag];
 }

--- a/swagger-schema-official/swagger-schema-official-tests.ts
+++ b/swagger-schema-official/swagger-schema-official-tests.ts
@@ -1,0 +1,1324 @@
+import * as swagger from "swagger-schema-official";
+
+const apiExample: swagger.Spec = {
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "v2"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "200 300 response",
+            "examples": {
+              "application/json": "{\n    \"versions\": [\n        {\n            \"status\": \"CURRENT\",\n            \"updated\": \"2011-01-21T11:33:21Z\",\n            \"id\": \"v2.0\",\n            \"links\": [\n                {\n                    \"href\": \"http://127.0.0.1:8774/v2/\",\n                    \"rel\": \"self\"\n                }\n            ]\n        },\n        {\n            \"status\": \"EXPERIMENTAL\",\n            \"updated\": \"2013-07-23T11:33:21Z\",\n            \"id\": \"v3.0\",\n            \"links\": [\n                {\n                    \"href\": \"http://127.0.0.1:8774/v3/\",\n                    \"rel\": \"self\"\n                }\n            ]\n        }\n    ]\n}"
+            }
+          },
+          "300": {
+            "description": "200 300 response",
+            "examples": {
+              "application/json": "{\n    \"versions\": [\n        {\n            \"status\": \"CURRENT\",\n            \"updated\": \"2011-01-21T11:33:21Z\",\n            \"id\": \"v2.0\",\n            \"links\": [\n                {\n                    \"href\": \"http://127.0.0.1:8774/v2/\",\n                    \"rel\": \"self\"\n                }\n            ]\n        },\n        {\n            \"status\": \"EXPERIMENTAL\",\n            \"updated\": \"2013-07-23T11:33:21Z\",\n            \"id\": \"v3.0\",\n            \"links\": [\n                {\n                    \"href\": \"http://127.0.0.1:8774/v3/\",\n                    \"rel\": \"self\"\n                }\n            ]\n        }\n    ]\n}"
+            }
+          }
+        }
+      }
+    },
+    "/v2": {
+      "get": {
+        "operationId": "getVersionDetailsv2",
+        "summary": "Show API version details",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "200 203 response",
+            "examples": {
+              "application/json": "{\n    \"version\": {\n        \"status\": \"CURRENT\",\n        \"updated\": \"2011-01-21T11:33:21Z\",\n        \"media-types\": [\n            {\n                \"base\": \"application/xml\",\n                \"type\": \"application/vnd.openstack.compute+xml;version=2\"\n            },\n            {\n                \"base\": \"application/json\",\n                \"type\": \"application/vnd.openstack.compute+json;version=2\"\n            }\n        ],\n        \"id\": \"v2.0\",\n        \"links\": [\n            {\n                \"href\": \"http://127.0.0.1:8774/v2/\",\n                \"rel\": \"self\"\n            },\n            {\n                \"href\": \"http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf\",\n                \"type\": \"application/pdf\",\n                \"rel\": \"describedby\"\n            },\n            {\n                \"href\": \"http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl\",\n                \"type\": \"application/vnd.sun.wadl+xml\",\n                \"rel\": \"describedby\"\n            },\n            {\n              \"href\": \"http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl\",\n              \"type\": \"application/vnd.sun.wadl+xml\",\n              \"rel\": \"describedby\"\n            }\n        ]\n    }\n}"
+            }
+          },
+          "203": {
+            "description": "200 203 response",
+            "examples": {
+              "application/json": "{\n    \"version\": {\n        \"status\": \"CURRENT\",\n        \"updated\": \"2011-01-21T11:33:21Z\",\n        \"media-types\": [\n            {\n                \"base\": \"application/xml\",\n                \"type\": \"application/vnd.openstack.compute+xml;version=2\"\n            },\n            {\n                \"base\": \"application/json\",\n                \"type\": \"application/vnd.openstack.compute+json;version=2\"\n            }\n        ],\n        \"id\": \"v2.0\",\n        \"links\": [\n            {\n                \"href\": \"http://23.253.228.211:8774/v2/\",\n                \"rel\": \"self\"\n            },\n            {\n                \"href\": \"http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf\",\n                \"type\": \"application/pdf\",\n                \"rel\": \"describedby\"\n            },\n            {\n                \"href\": \"http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl\",\n                \"type\": \"application/vnd.sun.wadl+xml\",\n                \"rel\": \"describedby\"\n            }\n        ]\n    }\n}"
+            }
+          }
+        }
+      }
+    }
+  },
+  "consumes": [
+    "application/json"
+  ]
+};
+
+const petStore: swagger.Spec = {
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "foo@example.com",
+      "url": "http://madskristensen.net"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to\nNam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\nSed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n",
+        "operationId": "findPets",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "type": "array",
+            "collectionFormat": "csv",
+            "items": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "Pet to add to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NewPet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "find pet by id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/NewPet"
+        },
+        {
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        }
+      ]
+    },
+    "NewPet": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Error": {
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+};
+
+const minimal: swagger.Spec = {
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of pets.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    }
+  }
+};
+
+const simple: swagger.Spec = {
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to",
+        "operationId": "findPets",
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "Pet to add to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NewPet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "findPetById",
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/NewPet"
+        },
+        {
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        }
+      ]
+    },
+    "NewPet": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "ErrorModel": {
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+};
+
+const externalDocs: swagger.Spec = {
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+    }
+  },
+  "externalDocs": {
+    "description": "find more info here",
+    "url": "https://swagger.io/about"
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to",
+        "operationId": "findPets",
+        "externalDocs": {
+          "description": "find more info here",
+          "url": "https://swagger.io/about"
+        },
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "Pet to add to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NewPet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "findPetById",
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/NewPet"
+        },
+        {
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        }
+      ]
+    },
+    "NewPet": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "ErrorModel": {
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+};
+
+const petstore: swagger.Spec = {
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    },
+    "Error": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+};
+
+const uber: swagger.Spec = {
+  "swagger": "2.0",
+  "info": {
+    "title": "Uber API",
+    "description": "Move your app forward with the Uber API",
+    "version": "1.0.0"
+  },
+  "host": "api.uber.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/v1",
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/products": {
+      "get": {
+        "summary": "Product Types",
+        "description": "The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.",
+        "parameters": [
+          {
+            "name": "latitude",
+            "in": "query",
+            "description": "Latitude component of location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "longitude",
+            "in": "query",
+            "description": "Longitude component of location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          }
+        ],
+        "tags": [
+          "Products"
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of products",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Product"
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/estimates/price": {
+      "get": {
+        "summary": "Price Estimates",
+        "description": "The Price Estimates endpoint returns an estimated price range for each product offered at a given location. The price estimate is provided as a formatted string with the full price range and the localized currency symbol.<br><br>The response also includes low and high estimates, and the [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code for situations requiring currency conversion. When surge is active for a particular product, its surge_multiplier will be greater than 1, but the price estimate already factors in this multiplier.",
+        "parameters": [
+          {
+            "name": "start_latitude",
+            "in": "query",
+            "description": "Latitude component of start location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "start_longitude",
+            "in": "query",
+            "description": "Longitude component of start location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "end_latitude",
+            "in": "query",
+            "description": "Latitude component of end location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "end_longitude",
+            "in": "query",
+            "description": "Longitude component of end location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          }
+        ],
+        "tags": [
+          "Estimates"
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of price estimates by product",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PriceEstimate"
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/estimates/time": {
+      "get": {
+        "summary": "Time Estimates",
+        "description": "The Time Estimates endpoint returns ETAs for all products offered at a given location, with the responses expressed as integers in seconds. We recommend that this endpoint be called every minute to provide the most accurate, up-to-date ETAs.",
+        "parameters": [
+          {
+            "name": "start_latitude",
+            "in": "query",
+            "description": "Latitude component of start location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "start_longitude",
+            "in": "query",
+            "description": "Longitude component of start location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "customer_uuid",
+            "in": "query",
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique customer identifier to be used for experience customization."
+          },
+          {
+            "name": "product_id",
+            "in": "query",
+            "type": "string",
+            "description": "Unique identifier representing a specific product for a given latitude & longitude."
+          }
+        ],
+        "tags": [
+          "Estimates"
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of products",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Product"
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/me": {
+      "get": {
+        "summary": "User Profile",
+        "description": "The User Profile endpoint returns information about the Uber user that has authorized with the application.",
+        "tags": [
+          "User"
+        ],
+        "responses": {
+          "200": {
+            "description": "Profile information for a user",
+            "schema": {
+              "$ref": "#/definitions/Profile"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/history": {
+      "get": {
+        "summary": "User Activity",
+        "description": "The User Activity endpoint returns data about a user's lifetime activity with Uber. The response will include pickup locations and times, dropoff locations and times, the distance of past requests, and information about which products were requested.<br><br>The history array in the response will have a maximum length based on the limit parameter. The response value count may exceed limit, therefore subsequent API requests may be necessary.",
+        "parameters": [
+          {
+            "name": "offset",
+            "in": "query",
+            "type": "integer",
+            "format": "int32",
+            "description": "Offset the list of returned results by this amount. Default is zero."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of items to retrieve. Default is 5, maximum is 100."
+          }
+        ],
+        "tags": [
+          "User"
+        ],
+        "responses": {
+          "200": {
+            "description": "History information for the given user",
+            "schema": {
+              "$ref": "#/definitions/Activities"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Product": {
+      "properties": {
+        "product_id": {
+          "type": "string",
+          "description": "Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of product."
+        },
+        "display_name": {
+          "type": "string",
+          "description": "Display name of product."
+        },
+        "capacity": {
+          "type": "string",
+          "description": "Capacity of product. For example, 4 people."
+        },
+        "image": {
+          "type": "string",
+          "description": "Image URL representing the product."
+        }
+      }
+    },
+    "PriceEstimate": {
+      "properties": {
+        "product_id": {
+          "type": "string",
+          "description": "Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles"
+        },
+        "currency_code": {
+          "type": "string",
+          "description": "[ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code."
+        },
+        "display_name": {
+          "type": "string",
+          "description": "Display name of product."
+        },
+        "estimate": {
+          "type": "string",
+          "description": "Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or \"Metered\" for TAXI."
+        },
+        "low_estimate": {
+          "type": "number",
+          "description": "Lower bound of the estimated price."
+        },
+        "high_estimate": {
+          "type": "number",
+          "description": "Upper bound of the estimated price."
+        },
+        "surge_multiplier": {
+          "type": "number",
+          "description": "Expected surge multiplier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier."
+        }
+      }
+    },
+    "Profile": {
+      "properties": {
+        "first_name": {
+          "type": "string",
+          "description": "First name of the Uber user."
+        },
+        "last_name": {
+          "type": "string",
+          "description": "Last name of the Uber user."
+        },
+        "email": {
+          "type": "string",
+          "description": "Email address of the Uber user"
+        },
+        "picture": {
+          "type": "string",
+          "description": "Image URL of the Uber user."
+        },
+        "promo_code": {
+          "type": "string",
+          "description": "Promo code of the Uber user."
+        }
+      }
+    },
+    "Activity": {
+      "properties": {
+        "uuid": {
+          "type": "string",
+          "description": "Unique identifier for the activity"
+        }
+      }
+    },
+    "Activities": {
+      "properties": {
+        "offset": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Position in pagination."
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of items to retrieve (100 max)."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total number of items available."
+        },
+        "history": {
+          "type": "array",
+          "items": [
+            {
+              "$ref": "#/definitions/Activity"
+            }
+          ]
+        }
+      }
+    },
+    "Error": {
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "string"
+        }
+      }
+    }
+  }
+};

--- a/swagger-schema-official/tsconfig.json
+++ b/swagger-schema-official/tsconfig.json
@@ -8,6 +8,7 @@
         "typeRoots": [
             "../"
         ],
+        "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/swagger-schema-official/tsconfig.json
+++ b/swagger-schema-official/tsconfig.json
@@ -8,9 +8,6 @@
         "typeRoots": [
             "../"
         ],
-        "types": [
-          "mocha"
-        ],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/swagger-schema-official/tsconfig.json
+++ b/swagger-schema-official/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [
+          "mocha"
+        ],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "swagger-schema-official-tests.ts"
+    ]
+}

--- a/swagger-schema-official/tslint.json
+++ b/swagger-schema-official/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tslint.json"
+}


### PR DESCRIPTION
This is basically moving [`swagger.d.ts`](https://github.com/mohsen1/swagger.d.ts) to here. I wish we could have `"swagger"` module name but per naming policies it has to match the npm package. 

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Run `tsc` without errors.
- [x] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
