### PR TITLE
Remove `export as namespace` for Q promise library

### DIFF
--- a/q/index.d.ts
+++ b/q/index.d.ts
@@ -4,7 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = Q;
-export as namespace Q;
 
 /**
  * If value is a Q promise, returns the promise.


### PR DESCRIPTION
This particular file was causing me issues with the new typings-2.0 since it doesn't support exporting namespaces from within modules.

Please fill in this template.

- [✔] Make your PR against the `master` branch.
- [✔] Use a meaningful title for the pull request. Include the name of the package modified.
- [✔] Test the change in your own code.
- [✔] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [✔] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [✗] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.


Couldn't run linting since there seems to be an error with a node dependency, error as follows:

```
> definitely-typed@0.0.1 lint /home/mboudreau/Work/DefinitelyTyped
> node scripts/lint.js "q"

node ../node_modules/tslint/lib/tslint-cli --format stylish "**/*.d.ts"
/home/mboudreau/Work/DefinitelyTyped/node_modules/types-publisher/bin/lib/header.js:21
function renderParseError({ line, column, expected }) {
                          ^

SyntaxError: Unexpected token {
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/mboudreau/Work/DefinitelyTyped/node_modules/types-publisher/bin/tslint/dtHeaderRule.js:3:18)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
```

Figured that this is an issue that was introduced or that the npm dependency versions are too loose.  Either way, removing a single line shouldn't be affecting linting. 

Also tried to run the tests, which compile, but don't run because it seems that this:

```
declare var arrayPromise: Q.IPromise<number[]>;
declare var stringPromise: Q.IPromise<string>;
declare function returnsNumPromise(text: string): Q.Promise<number>;
declare function returnsNumPromise(text: string): JQueryPromise<number>;

Q<number[]>(arrayPromise) // type specification required
    .then(arr => arr.join(','))
    .then<number>(returnsNumPromise) // requires specification
    .then(num => num.toFixed());
```

Gets compiled to this:

```
Q(arrayPromise) // type specification required
    .then(arr => arr.join(','))
    .then(returnsNumPromise) // requires specification
    .then(num => num.toFixed());
```

Which gives me this error when trying to run it:

```
Q(arrayPromise) // type specification required
  ^

ReferenceError: arrayPromise is not defined
    at Object.<anonymous> (/home/mboudreau/Work/DefinitelyTyped/q/q-tests.js:74:3)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:139:18)
    at node.js:990:3
```

Since the compiler seems to completely ignore vars that haven't been initialised.  Not sure if this is normal behaviour or if I've stumbled upon some bad tests, or if the tests are just meant to compile, but never actually 'run'.