### PR TITLE
Correct @types/three TubeGeometry path argument

### DIFF
--- a/three/index.d.ts
+++ b/three/index.d.ts
@@ -6483,10 +6483,10 @@ declare namespace THREE {
     }
 
     export class TubeGeometry extends Geometry {
-        constructor(path: Path, segments?: number, radius?: number, radiusSegments?: number, closed?: boolean, taper?: (u: number) => number);
+        constructor(path: Curve<Vector3>, segments?: number, radius?: number, radiusSegments?: number, closed?: boolean, taper?: (u: number) => number);
 
         parameters: {
-            path: Path;
+            path: Curve<Vector3>;
             segments: number;
             radius: number;
             radialSegments: number;


### PR DESCRIPTION
Despite being called "path," `TubeGeometry` requires a Vector3 curve. I think this came from someone misreading the docs (https://threejs.org/docs/#Reference/Geometries/TubeGeometry), where it identifies the first argument like this:

```
path — Curve - A path that inherits from the Curve base class
```

The "Curve" in the description links to https://threejs.org/docs/#Reference/Extras.Core/Curve. A `Path`, meanwhile, comes from a list of Vector2s, which does not have the correct interface to work with this code.

Making this change locally allowed me to go totally tube crazy.