### PR TITLE
yargs: allow .version with no arguments

### DIFF
--- a/yargs/index.d.ts
+++ b/yargs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for yargs 6.3.0
+// Type definitions for yargs 6.5.0
 // Project: https://github.com/chevex/yargs
 // Definitions by: Martin Poelstra <https://github.com/poelstra>, Mizunashi Mana <https://github.com/mizunashi-mana>, Jeffery Grajkowski <https://github.com/pushplay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -118,7 +118,7 @@ declare namespace yargs {
         epilog(msg: string): Argv;
         epilogue(msg: string): Argv;
 
-        version(version: string, option?: string, description?: string): Argv;
+        version(version?: string, option?: string, description?: string): Argv;
         version(version: () => string, option?: string, description?: string): Argv;
 
         showHelpOnFail(enable: boolean, message?: string): Argv;

--- a/yargs/yargs-tests.ts
+++ b/yargs/yargs-tests.ts
@@ -306,15 +306,18 @@ function Argv$showHelp() {
 
 function Argv$version() {
 	var argv1 = yargs
-		.version('1.0.0');
+		.version();
 
 	var argv2 = yargs
-		.version('1.0.0', '--version');
+		.version('1.0.0');
 
 	var argv3 = yargs
-		.version('1.0.0', '--version', 'description');
+		.version('1.0.0', '--version');
 
 	var argv4 = yargs
+		.version('1.0.0', '--version', 'description');
+
+	var argv5 = yargs
 		.version(function () { return '1.0.0'; }, '--version', 'description');
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [documentation](http://yargs.js.org/docs/#methods-versionoption-description-version)
- [x] Increase the version number in the header if appropriate.

Updated yargs typings to allow `.version()` with no arguments. Documentation for this reads:

If no arguments are passed to `version` (`.version()`), yargs will parse the `package.json` of your module and use its `version` value. The default value of `option` is `--version`. 