### PR TITLE
react-router: add `router` to RouteComponentProps

### DIFF
--- a/react-router/lib/Router.d.ts
+++ b/react-router/lib/Router.d.ts
@@ -89,6 +89,7 @@ declare namespace Router {
         routeParams?: R;
         routes?: PlainRoute[];
         children?: React.ReactElement<any>;
+        router?: Router;
     }
 
     interface RouterOnContext extends History {


### PR DESCRIPTION
As stated at https://github.com/ReactTraining/react-router/blob/master/docs/API.md#router-1 there is no history and there is `router` property on injected props

Seems that current definitions are for `react-router@2`, but my change is about `react-router@3`. How should I make a new type definitions?