### PR TITLE
fix(express-serve-static-core): fix#10910 fixed application use argument does not match parameters

### DIFF
--- a/express-serve-static-core/index.d.ts
+++ b/express-serve-static-core/index.d.ts
@@ -856,6 +856,10 @@ interface RequestParamHandler {
     (req: Request, res: Response, next: NextFunction, value: any, name: string): any;
 }
 
+type ApplicaitonRequestHandler<T> =  IRouterHandler<T> & IRouterMatcher<T> & {
+  (...handlers: RequestHandlerParams[]): T;
+};
+
 interface Application extends IRouter, Express.Application {
     /**
      * Express instance itself is a request handler, which could be invoked without
@@ -1096,6 +1100,8 @@ interface Application extends IRouter, Express.Application {
      * Used to get all registered routes in Express Application
      */
     _router: any;
+
+    use: ApplicaitonRequestHandler<this>;
 }
 
 interface Express extends Application {


### PR DESCRIPTION
This PR fixes #12266

In few words, application.use causing IDE error

```
Argument types do not match parameters
```

![screen shot 2016-12-21 at 11 47 04 am](https://cloud.githubusercontent.com/assets/8107129/21386493/58f4c3a8-c773-11e6-9c56-b5f7ad9c0eb9.png)

With fix
![screen shot 2016-12-21 at 11 50 01 am](https://cloud.githubusercontent.com/assets/8107129/21386588/c6baf222-c773-11e6-8284-0f3b585b3d53.png)

Complete ```tsc``` process executed successfully without errors