### PR TITLE
[react-native] EasingFunction for easing key in NavigationTransitionSpec type

### DIFF
--- a/react-native/index.d.ts
+++ b/react-native/index.d.ts
@@ -7867,7 +7867,7 @@ declare module "react" {
     export type NavigationTransitionSpec = {
         duration?: number,
         // An easing function from `Easing`.
-        easing?: () => any,
+        easing?: EasingFunction,
         // A timing function such as `Animated.timing`.
         timing?: (value: NavigationAnimatedValue, config: any) => any,
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react-native/docs/easing.html#easing
- [ ] Increase the version number in the header if appropriate.

-------------------------------------------

The key `easing` for the `NavigationTransitionSpec` type expects a `() => any` but should really expect an Easing functions ( `(input: number) => number` ).

This fixes that issue
