### PR TITLE
[angular-ui-router] Added description of `redirectTo`

### DIFF
--- a/angular-ui-router/index.d.ts
+++ b/angular-ui-router/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for Angular JS (ui.router module) 1.1.5
 // Project: https://github.com/angular-ui/ui-router
-// Definitions by: Michel Salib <https://github.com/michelsalib>
-// Definitions by: Ivan Matiishyn <https://github.com/matiishyn>
+// Definitions by: Michel Salib <https://github.com/michelsalib>, Ivan Matiishyn <https://github.com/matiishyn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as angular from 'angular';
@@ -100,7 +99,7 @@ declare module 'angular' {
              * string | function | object
              * Synchronously or asynchronously redirects Transitions to a different state/params
              */
-            redirectTo?: String | Function | IState;
+            redirectTo?: string | Function | IState;
 
         }
 

--- a/angular-ui-router/index.d.ts
+++ b/angular-ui-router/index.d.ts
@@ -94,6 +94,13 @@ declare module 'angular' {
              * Boolean (default true). If false will reload state on everytransitions. Useful for when you'd like to restore all data  to its initial state.
              */
             cache?: boolean;
+
+            /**
+             * string | function | object
+             * Synchronously or asynchronously redirects Transitions to a different state/params
+             */
+            redirectTo?: String | Function | IState;
+
         }
 
         interface IUnfoundState {

--- a/angular-ui-router/index.d.ts
+++ b/angular-ui-router/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for Angular JS (ui.router module) 1.1.5
 // Project: https://github.com/angular-ui/ui-router
 // Definitions by: Michel Salib <https://github.com/michelsalib>
+// Definitions by: Ivan Matiishyn <https://github.com/matiishyn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as angular from 'angular';


### PR DESCRIPTION
Hey guys, plz review my PR
I'm using UI-Router 1.0.0-beta.3. And the `redirectTo` property is missing in the `IState` interface.
![image](https://cloud.githubusercontent.com/assets/3661065/21399652/bbcd7ba8-c7ac-11e6-8f0e-483b4dc35761.png)

This state hook is described in [migration guide](https://ui-router.github.io/guide/ng1/migrate-to-1_0#state-hook-redirectto) and here's a [documentation ](https://ui-router.github.io/docs/latest/interfaces/state.statedeclaration.html#redirectto)

Please fill in this template.
- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
