### PR TITLE
d3.format() arg types

### DIFF
--- a/d3-format/index.d.ts
+++ b/d3-format/index.d.ts
@@ -166,7 +166,7 @@ export function formatDefaultLocale(defaultLocale: FormatLocaleDefinition): Form
  *
  * @param specifier A Specifier string
  */
-export function format(specifier: string): (n: number) => string;
+export function format(specifier: string | string[]): (n: number) => string;
 
 /**
  * Returns a new format function for the given string specifier. The returned function


### PR DESCRIPTION
Fixed d3.format() to take string | string[] arguments per wiki (and my experience), https://github.com/d3/d3-format#locale_format

Please fill in this template.

- [* ] Make your PR against the `master` branch.
- [ *] Use a meaningful title for the pull request. Include the name of the package modified.
- [ *] Test the change in your own code.
- [ *] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [ *] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ na] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [*] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [ *] Provide a URL to documentation or source code which provides context for the suggested changes: [d3-format wiki](https://github.com/d3/d3-format#locale_format)
see bottom: `currency` - the currency prefix and suffix (e.g., `["$", ""]`).
- [ ] Increase the version number in the header if appropriate.
