### PR TITLE
ssh2 to allow undefined to TerminalModes interface

### DIFF
--- a/ssh2/index.d.ts
+++ b/ssh2/index.d.ts
@@ -1087,7 +1087,7 @@ export interface PseudoTtyInfo {
 }
 
 export interface TerminalModes {
-    [mode: string]: number;
+    [mode: string]: number | undefined;
     /** Interrupt character; `255` if none. Not all of these characters are supported on all systems. */
     VINTR?: number;
     /** The quit character (sends `SIGQUIT` signal on POSIX systems). */


### PR DESCRIPTION
Suppress `error TS2411: Property 'ECHOKE' of type '0 | 1 | undefined' is not assignable to string index type 'number'.` error when `strictNullChecks` is enabled on the compiler.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Run `tsc` without errors.
- [ ] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/13502

