### PR TITLE
[Material UI] Fix AutoComplete props

### DIFF
--- a/material-ui/index.d.ts
+++ b/material-ui/index.d.ts
@@ -528,18 +528,16 @@ declare namespace __MaterialUI {
         type cornersAndCenter = 'bottom-center' | 'bottom-left' | 'bottom-right' | 'top-center' | 'top-left' | 'top-right';
     }
 
-    type AutoCompleteDataItem = { text: string, value: React.ReactNode } | string;
-    type AutoCompleteDataSource = { text: string, value: React.ReactNode }[] | string[];
-    interface AutoCompleteProps {
+    interface AutoCompleteProps<DataItem> {
         anchorOrigin?: propTypes.origin;
         animated?: boolean;
         animation?: React.ComponentClass<Popover.PopoverAnimationProps>;
-        dataSource: AutoCompleteDataSource;
+        dataSource: DataItem[];
         dataSourceConfig?: { text: string; value: string; };
         disableFocusRipple?: boolean;
         errorStyle?: React.CSSProperties;
         errorText?: React.ReactNode;
-        filter?: (searchText: string, key: string, item: AutoCompleteDataItem) => boolean;
+        filter?: (searchText: string, key: string, item: DataItem) => boolean;
         floatingLabelText?: React.ReactNode;
         fullWidth?: boolean;
         hintText?: React.ReactNode;
@@ -551,8 +549,8 @@ declare namespace __MaterialUI {
         onBlur?: React.FocusEventHandler<{}>;
         onFocus?: React.FocusEventHandler<{}>;
         onKeyDown?: React.KeyboardEventHandler<{}>;
-        onNewRequest?: (chosenRequest: string, index: number) => void;
-        onUpdateInput?: (searchText: string, dataSource: AutoCompleteDataSource) => void;
+        onNewRequest?: (chosenRequest: DataItem, index: number) => void;
+        onUpdateInput?: (searchText: string, dataSource: DataItem[]) => void;
         open?: boolean;
         openOnFocus?: boolean;
         popoverProps?: Popover.PopoverProps;
@@ -561,7 +559,7 @@ declare namespace __MaterialUI {
         targetOrigin?: propTypes.origin;
         textFieldStyle?: React.CSSProperties;
     }
-    export class AutoComplete extends React.Component<AutoCompleteProps, {}> {
+    export class AutoComplete extends React.Component<AutoCompleteProps<any>, {}> {
         static noFilter: () => boolean;
         static defaultFilter: (searchText: string, key: string) => boolean;
         static caseSensitiveFilter: (searchText: string, key: string) => boolean;

--- a/material-ui/index.d.ts
+++ b/material-ui/index.d.ts
@@ -538,11 +538,11 @@ declare namespace __MaterialUI {
         dataSourceConfig?: { text: string; value: string; };
         disableFocusRipple?: boolean;
         errorStyle?: React.CSSProperties;
-        errorText?: string;
+        errorText?: React.ReactNode;
         filter?: (searchText: string, key: string, item: AutoCompleteDataItem) => boolean;
         floatingLabelText?: React.ReactNode;
         fullWidth?: boolean;
-        hintText?: string;
+        hintText?: React.ReactNode;
         listStyle?: React.CSSProperties;
         maxSearchResults?: number;
         menuCloseDelay?: number;
@@ -739,17 +739,17 @@ declare namespace __MaterialUI {
 
     namespace BottomNavigation {
         interface BottomNavigationProps {
-            selectedIndex?: number;
             className?: string;
+            selectedIndex?: number;
             style?: React.CSSProperties;
         }
 
         export class BottomNavigation extends React.Component<BottomNavigationProps, {}> { }
 
         interface BottomNavigationItemProps extends SharedEnhancedButtonProps<BottomNavigationItem> {
-            label?: string;
-            icon?: any;
             className?: string;
+            icon?: React.ReactNode;
+            label?: React.ReactNode;
         }
 
         export class BottomNavigationItem extends React.Component<BottomNavigationItemProps, {}> { }

--- a/material-ui/material-ui-tests.tsx
+++ b/material-ui/material-ui-tests.tsx
@@ -422,7 +422,12 @@ export class AutoCompleteExampleSimple extends React.Component<{}, {dataSource: 
         />
         <AutoComplete
           hintText="Type anything"
-          dataSource={this.state.dataSource}
+          dataSource={[
+            {
+              textKey: 'hello',
+              valueKey: 'world',
+            },
+          ]}
           dataSourceConfig={this.dataSourceConfig}
           onUpdateInput={this.handleUpdateInput}
         />


### PR DESCRIPTION
http://www.material-ui.com/#/components/auto-complete

Shows `errorText` and `hintText` as nodes. Data source and data item definitions were only correct if the `dataSourceConfig` is not used to customize the functionality.

- [ ] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] ~Run `npm run lint -- package-name` if a `tslint.json` is present.~

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] ~Increase the version number in the header if appropriate.~
