### PR TITLE
Adding VRDevice.getFrameData and VRFrameData defs

### DIFF
--- a/webvr-api/index.d.ts
+++ b/webvr-api/index.d.ts
@@ -36,7 +36,7 @@ declare class VRDisplay extends EventTarget {
    * Populates the passed VRFrameData with the information required to render
    * the current frame.
    */
-  getFrameData(frameData: VRFrameData) : boolean;
+  getFrameData(frameData: VRFrameData): boolean;
 
   /**
    * Return a VRPose containing the future predicted pose of the VRDisplay
@@ -46,7 +46,7 @@ declare class VRDisplay extends EventTarget {
    * The VRPose will contain the position, orientation, velocity,
    * and acceleration of each of these properties.
    */
-  getPose() : VRPose;
+  getPose(): VRPose;
 
   /**
    * Return the current instantaneous pose of the VRDisplay, with no
@@ -159,15 +159,15 @@ interface VRPose {
 }
 
 interface VRFrameData {
-  timestamp : any; // Should be DOMHighResTimeStamp
+  timestamp: any; // Should be DOMHighResTimeStamp
 
-  leftProjectionMatrix : Float32Array;
-  leftViewMatrix : Float32Array;
+  leftProjectionMatrix: Float32Array;
+  leftViewMatrix: Float32Array;
 
-  rightProjectionMatrix : Float32Array;
-  rightViewMatrix : Float32Array;
+  rightProjectionMatrix: Float32Array;
+  rightViewMatrix: Float32Array;
 
-  pose : VRPose;
+  pose: VRPose;
 }
 
 interface VREyeParameters {

--- a/webvr-api/index.d.ts
+++ b/webvr-api/index.d.ts
@@ -33,6 +33,12 @@ declare class VRDisplay extends EventTarget {
   displayName: string;
 
   /**
+   * Populates the passed VRFrameData with the information required to render
+   * the current frame.
+   */
+  getFrameData(frameData: VRFrameData) : boolean;
+
+  /**
    * Return a VRPose containing the future predicted pose of the VRDisplay
    * when the current frame will be presented. The value returned will not
    * change until JavaScript has returned control to the browser.
@@ -150,6 +156,18 @@ interface VRPose {
   orientation: Float32Array;
   angularVelocity: Float32Array;
   angularAcceleration: Float32Array;
+}
+
+interface VRFrameData {
+  timestamp : any; // Should be DOMHighResTimeStamp
+
+  leftProjectionMatrix : Float32Array;
+  leftViewMatrix : Float32Array;
+
+  rightProjectionMatrix : Float32Array;
+  rightViewMatrix : Float32Array;
+
+  pose : VRPose;
 }
 
 interface VREyeParameters {

--- a/webvr-api/index.d.ts
+++ b/webvr-api/index.d.ts
@@ -159,7 +159,7 @@ interface VRPose {
 }
 
 declare class VRFrameData {
-  timestamp: any; // Should be DOMHighResTimeStamp
+  timestamp: number; // Should be DOMHighResTimeStamp
 
   leftProjectionMatrix: Float32Array;
   leftViewMatrix: Float32Array;

--- a/webvr-api/index.d.ts
+++ b/webvr-api/index.d.ts
@@ -158,7 +158,7 @@ interface VRPose {
   angularAcceleration: Float32Array;
 }
 
-interface VRFrameData {
+declare class VRFrameData {
   timestamp: any; // Should be DOMHighResTimeStamp
 
   leftProjectionMatrix: Float32Array;


### PR DESCRIPTION
Adding WebVR frame data types as defined in the WebVR spec.

https://w3c.github.io/webvr/#dom-vrdisplay-getframedata
https://w3c.github.io/webvr/#interface-vrframedata
