### PR TITLE
[bootstrap-switch]: Update return types for non-JQuery methods

### DIFF
--- a/bootstrap-switch/bootstrap-switch-tests.ts
+++ b/bootstrap-switch/bootstrap-switch-tests.ts
@@ -18,6 +18,9 @@ function test_cases() {
 	
 	$('#switch').bootstrapSwitch('state', true, true);
 
+	$('#switch').bootstrapSwitch('state') === true;
+
+	$('#switch').bootstrapSwitch('onText') === 'test';
 
 	$('#switch').on('switchChange.bootstrapSwitch', (event) => {
 		console.log($(event.target).val());

--- a/bootstrap-switch/index.d.ts
+++ b/bootstrap-switch/index.d.ts
@@ -84,6 +84,8 @@ declare namespace BootstrapSwitch {
 interface JQuery {
     bootstrapSwitch(): JQuery;
     bootstrapSwitch(options: BootstrapSwitch.BootstrapSwitchOptions): JQuery;
+    bootstrapSwitch(method: 'state' | 'radioAllOff' | 'animate' | 'disabled' | 'readonly'): boolean;
+    bootstrapSwitch(method: 'size' | 'onColor' | 'offColor' | 'onText' | 'offText' | 'labelText' | 'baseClass' | 'wrapperClass'): string;
     bootstrapSwitch(method: string): JQuery;
     bootstrapSwitch(method: string, param: any): JQuery;
     bootstrapSwitch(method: string, param1: any, param2: any): JQuery;


### PR DESCRIPTION
Just adding that bootstrapSwitch('state') and various other "getters" return bools/strings, not JQuery objects.

Template:

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
The main documentation domain is currently down - http://www.bootstrap-switch.org/methods.html
http://stackoverflow.com/questions/20707921/how-to-get-twitter-bootstrap-toggle-switch-values-using-jquery demonstrates usage
- [ ] Increase the version number in the header if appropriate.
