### PR TITLE
Add bluebird-global typings for bluebird.js.

### DIFF
--- a/bluebird-global/bluebird-global-tests.ts
+++ b/bluebird-global/bluebird-global-tests.ts
@@ -1,0 +1,37 @@
+
+function testSomeStaticMethods() {
+    Promise.config({});
+    Promise.delay(100).then(() => {});
+    Promise.all([]).finally(() => {});
+}
+
+function testFunctionReturningPromise() {
+
+    function functionReturningPromise(): Promise<string> {
+        return new Promise<string>((resolve, reject, onCancel) => {
+
+            if (onCancel) {
+                onCancel(() => {
+                    console.log("onCancel cleanup");
+                });
+            }
+
+            resolve("lorem ipsum");
+        })
+            .then((value) => {
+                return value + " dolor";
+            })
+        ;
+    }
+
+    functionReturningPromise()
+        .then((value) => {
+            console.log("then callback: " + value);
+        })
+        .finally(() => {
+            console.log("finally callback");
+        });
+
+}
+
+

--- a/bluebird-global/bluebird-global-tests.ts
+++ b/bluebird-global/bluebird-global-tests.ts
@@ -33,5 +33,3 @@ function testFunctionReturningPromise() {
         });
 
 }
-
-

--- a/bluebird-global/bluebird-global-tests.ts
+++ b/bluebird-global/bluebird-global-tests.ts
@@ -1,4 +1,3 @@
-
 function testSomeStaticMethods() {
     Promise.config({});
     Promise.delay(100).then(() => {});
@@ -6,7 +5,6 @@ function testSomeStaticMethods() {
 }
 
 function testFunctionReturningPromise() {
-
     function functionReturningPromise(): Promise<string> {
         return new Promise<string>((resolve, reject, onCancel) => {
 
@@ -20,8 +18,7 @@ function testFunctionReturningPromise() {
         })
             .then((value) => {
                 return value + " dolor";
-            })
-        ;
+            });
     }
 
     functionReturningPromise()
@@ -31,5 +28,4 @@ function testFunctionReturningPromise() {
         .finally(() => {
             console.log("finally callback");
         });
-
 }

--- a/bluebird-global/index.d.ts
+++ b/bluebird-global/index.d.ts
@@ -1,0 +1,85 @@
+// Type definitions for bluebird 3.0
+// Project: https://github.com/petkaantonov/bluebird
+// Definitions by: d-ph <https://github.com/d-ph>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/*
+ * 1. Why use `bluebird-global` instead of `bluebird`?
+ *
+ * If you want to leverage the fact, that bluebird polyfills the global Promise in the browser, then
+ * you need to tell TypeScript about this. The following declaration file does exactly that.
+ *
+ * 2. How to use it?
+ *
+ * Add `bluebird-global` to the `types` array in your `tsconfig.json` like this:
+ *
+ * {
+ *   "compilerOptions": {
+ *     "types": [
+ *       "bluebird-global"
+ *     ],
+ *   }
+ * }
+ *
+ * 3. Why so much effort?
+ *
+ * If a promise-polyfilling library wants to play nicely with TypeScript, it needs to augment
+ * the Promise<T> and PromiseConstructor interfaces defined in the standard ts library.
+ * For various reasons this couldn't be done in The `bluebird` typings.
+ *
+ */
+
+import * as Bluebird from "bluebird";
+
+declare global {
+
+    /*
+     * Patch all instance method
+     */
+    interface Promise<T> extends Bluebird<T> {}
+
+    /*
+     * Patch all static methods and the constructor
+     */
+    interface PromiseConstructor {
+        new <T>(callback: (resolve: (thenableOrResult?: T | Bluebird.Thenable<T>) => void, reject: (error?: any) => void, onCancel?: (callback: () => void) => void) => void): Promise<T>;
+
+        try: typeof Bluebird.try;
+        attempt: typeof Bluebird.attempt;
+        method: typeof Bluebird.method;
+        resolve: typeof Bluebird.resolve;
+        reject: typeof Bluebird.reject;
+        defer: typeof Bluebird.defer;
+        cast: typeof Bluebird.cast;
+        bind: typeof Bluebird.bind;
+        is: typeof Bluebird.is;
+        longStackTraces: typeof Bluebird.longStackTraces;
+        delay: typeof Bluebird.delay;
+        promisify: typeof Bluebird.promisify;
+        promisifyAll: typeof Bluebird.promisifyAll;
+        fromNode: typeof Bluebird.fromNode;
+        fromCallback: typeof Bluebird.fromCallback;
+        coroutine: typeof Bluebird.coroutine;
+        onPossiblyUnhandledRejection: typeof Bluebird.onPossiblyUnhandledRejection;
+        all: typeof Bluebird.all;
+        props: typeof Bluebird.props;
+        any: typeof Bluebird.any;
+        race: typeof Bluebird.race;
+        some: typeof Bluebird.some;
+        join: typeof Bluebird.join;
+        map: typeof Bluebird.map;
+        reduce: typeof Bluebird.reduce;
+        filter: typeof Bluebird.filter;
+        each: typeof Bluebird.each;
+        mapSeries: typeof Bluebird.mapSeries;
+        using: typeof Bluebird.using;
+        config: typeof Bluebird.config;
+    }
+
+    /*
+     * Declare the `Promise` variable. This is needed for es5 only and is a no-op for all other targets.
+     */
+    var Promise: PromiseConstructor;
+
+}
+

--- a/bluebird-global/index.d.ts
+++ b/bluebird-global/index.d.ts
@@ -42,38 +42,40 @@ declare global {
      * Patch all static methods and the constructor
      */
     interface PromiseConstructor {
+
         new <T>(callback: (resolve: (thenableOrResult?: T | Bluebird.Thenable<T>) => void, reject: (error?: any) => void, onCancel?: (callback: () => void) => void) => void): Promise<T>;
 
-        try: typeof Bluebird.try;
+        all: typeof Bluebird.all;
+        any: typeof Bluebird.any;
         attempt: typeof Bluebird.attempt;
-        method: typeof Bluebird.method;
-        resolve: typeof Bluebird.resolve;
-        reject: typeof Bluebird.reject;
-        defer: typeof Bluebird.defer;
-        cast: typeof Bluebird.cast;
         bind: typeof Bluebird.bind;
-        is: typeof Bluebird.is;
-        longStackTraces: typeof Bluebird.longStackTraces;
+        cast: typeof Bluebird.cast;
+        config: typeof Bluebird.config;
+        coroutine: typeof Bluebird.coroutine;
+        defer: typeof Bluebird.defer;
         delay: typeof Bluebird.delay;
+        each: typeof Bluebird.each;
+        filter: typeof Bluebird.filter;
+        fromCallback: typeof Bluebird.fromCallback;
+        fromNode: typeof Bluebird.fromNode;
+        is: typeof Bluebird.is;
+        join: typeof Bluebird.join;
+        longStackTraces: typeof Bluebird.longStackTraces;
+        map: typeof Bluebird.map;
+        mapSeries: typeof Bluebird.mapSeries;
+        method: typeof Bluebird.method;
+        onPossiblyUnhandledRejection: typeof Bluebird.onPossiblyUnhandledRejection;
         promisify: typeof Bluebird.promisify;
         promisifyAll: typeof Bluebird.promisifyAll;
-        fromNode: typeof Bluebird.fromNode;
-        fromCallback: typeof Bluebird.fromCallback;
-        coroutine: typeof Bluebird.coroutine;
-        onPossiblyUnhandledRejection: typeof Bluebird.onPossiblyUnhandledRejection;
-        all: typeof Bluebird.all;
         props: typeof Bluebird.props;
-        any: typeof Bluebird.any;
         race: typeof Bluebird.race;
-        some: typeof Bluebird.some;
-        join: typeof Bluebird.join;
-        map: typeof Bluebird.map;
         reduce: typeof Bluebird.reduce;
-        filter: typeof Bluebird.filter;
-        each: typeof Bluebird.each;
-        mapSeries: typeof Bluebird.mapSeries;
+        reject: typeof Bluebird.reject;
+        resolve: typeof Bluebird.resolve;
+        some: typeof Bluebird.some;
+        try: typeof Bluebird.try;
         using: typeof Bluebird.using;
-        config: typeof Bluebird.config;
+
     }
 
     /*
@@ -82,4 +84,3 @@ declare global {
     var Promise: PromiseConstructor;
 
 }
-

--- a/bluebird-global/index.d.ts
+++ b/bluebird-global/index.d.ts
@@ -32,7 +32,6 @@
 import * as Bluebird from "bluebird";
 
 declare global {
-
     /*
      * Patch all instance method
      */
@@ -42,7 +41,6 @@ declare global {
      * Patch all static methods and the constructor
      */
     interface PromiseConstructor {
-
         new <T>(callback: (resolve: (thenableOrResult?: T | Bluebird.Thenable<T>) => void, reject: (error?: any) => void, onCancel?: (callback: () => void) => void) => void): Promise<T>;
 
         all: typeof Bluebird.all;
@@ -75,12 +73,10 @@ declare global {
         some: typeof Bluebird.some;
         try: typeof Bluebird.try;
         using: typeof Bluebird.using;
-
     }
 
     /*
      * Declare the `Promise` variable. This is needed for es5 only and is a no-op for all other targets.
      */
     var Promise: PromiseConstructor;
-
 }

--- a/bluebird-global/tsconfig.json
+++ b/bluebird-global/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "bluebird-global-tests.ts"
+    ]
+}

--- a/bluebird-global/tsconfig.json
+++ b/bluebird-global/tsconfig.json
@@ -3,6 +3,7 @@
         "module": "commonjs",
         "target": "es5",
         "noImplicitAny": true,
+        "noImplicitThis": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/bluebird-global/tslint.json
+++ b/bluebird-global/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tslint.json",
+  "rules": {
+    "no-empty-interface": false
+  }
+}

--- a/bluebird/index.d.ts
+++ b/bluebird/index.d.ts
@@ -7,6 +7,9 @@
  * The code following this comment originates from:
  *   https://github.com/types/npm-bluebird
  *
+ * Note for browser users: use bluebird-global typings instead of this one
+ * if you want to use Bluebird via the global Promise symbol.
+ *
  * Licensed under:
  *   The MIT License (MIT)
  *


### PR DESCRIPTION
Re-PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/13100 against `master` as requested.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Run `tsc` without errors.
- [x] Include the required [files](https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package) and header. Base these on the README, *not* on an existing project.

What it does.

bluebird-global uses bluebird typings in order to expose its functions on the global Promise symbol. This is generally how devs use bluebird.js in the browser. For various reasons this couldn't be done in the bluebird typings.