### PR TITLE
Request: Add RequestOptions to Response object

### DIFF
--- a/request/index.d.ts
+++ b/request/index.d.ts
@@ -75,7 +75,7 @@ declare namespace request {
 
     interface CoreOptions {
         baseUrl?: string;
-        callback?: (error: any, response: http.IncomingMessage, body: any) => void;
+        callback?: (error: any, response: RequestResponse, body: any) => void;
         jar?: any; // CookieJar
         formData?: any; // Object
         form?: any; // Object or string
@@ -134,8 +134,12 @@ declare namespace request {
     export type Options = OptionsWithUri | OptionsWithUrl;
 
     export interface RequestCallback {
-        (error: any, response: http.IncomingMessage, body: any): void;
+        (error: any, response: RequestResponse, body: any): void;
     }
+
+	export interface RequestResponse extends http.IncomingMessage {
+		request: Options;
+	}
 
     export interface HttpArchiveRequest {
         url?: string;


### PR DESCRIPTION
The response object returned by "Request" contains the original request object:
https://github.com/request/request/blob/master/request.js#L867
