### PR TITLE
[react-intl] Update React namespaces

### DIFF
--- a/react-intl/index.d.ts
+++ b/react-intl/index.d.ts
@@ -6,8 +6,6 @@
 ///<reference types="react" />
 
 declare namespace ReactIntl {
-    // Import React
-    import React = __React;
 
     interface Locale {
         locale: string;

--- a/react-intl/index.d.ts
+++ b/react-intl/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-intl 2.1.5
+// Type definitions for react-intl 2.2.0
 // Project: http://formatjs.io/react/
 // Definitions by: Bruno Grieder <https://github.com/bgrieder>, Christian Droulers <https://github.com/cdroulers>, Fedor Nezhivoi <https://github.com/gyzerok>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/react-redux/index.d.ts
+++ b/react-redux/index.d.ts
@@ -2,6 +2,9 @@
 // Project: https://github.com/rackt/react-redux
 // Definitions by: Qubo <https://github.com/tkqubo>, Sean Kelley <https://github.com/seansfkelley>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+    
+/// <reference types="react" />
+/// <reference types="redux" />
 
 import * as React from 'react';
 import * as Redux from 'redux';

--- a/react-redux/index.d.ts
+++ b/react-redux/index.d.ts
@@ -3,7 +3,6 @@
 // Definitions by: Qubo <https://github.com/tkqubo>, Sean Kelley <https://github.com/seansfkelley>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
 import * as React from 'react';
 import * as Redux from 'redux';
 

--- a/react-redux/index.d.ts
+++ b/react-redux/index.d.ts
@@ -2,9 +2,7 @@
 // Project: https://github.com/rackt/react-redux
 // Definitions by: Qubo <https://github.com/tkqubo>, Sean Kelley <https://github.com/seansfkelley>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-    
-/// <reference types="react" />
-/// <reference types="redux" />
+
 
 import * as React from 'react';
 import * as Redux from 'redux';


### PR DESCRIPTION
fix
`
Cannot find namespace '__React'.
`