### PR TITLE
electron: Disallow passing arbitrary objects to clipboard.write.

### DIFF
--- a/electron/github-electron-renderer-tests.ts
+++ b/electron/github-electron-renderer-tests.ts
@@ -95,6 +95,7 @@ clipboard.clear();
 clipboard.write({
 	html: '<html></html>',
 	text: 'Hello World!',
+	bookmark: "Bookmark name",
 	image: clipboard.readImage()
 });
 

--- a/electron/index.d.ts
+++ b/electron/index.d.ts
@@ -1864,12 +1864,7 @@ declare namespace Electron {
 		/**
 		 * Writes data to the clipboard.
 		 */
-		write(data: {
-			text?: string;
-			rtf?: string;
-			html?: string;
-			image?: NativeImage;
-		}, type?: ClipboardType): void;
+		write(data: { text: string; bookmark?: string; } | { rtf: string; } | { html: string; } | { image: NativeImage; }, type?: ClipboardType): void;
 		/**
 		 * @returns An Object containing title and url keys representing the bookmark in the clipboard.
 		 *


### PR DESCRIPTION
Previous version of typing allowed to write `clipboard.write("test_string")` which would compile fine, but fail in runtime with "Error processing argument at index 0, conversion failure from test_string". Also, the argument `bookmark` was missing.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `npm run lint -- package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Documentation](http://electron.atom.io/docs/api/clipboard/#clipboardwritedata-type)
[Actual implementation](https://github.com/electron/electron/blob/e97d3c21a38d2feeb29cbcd17b5f092a39cea0c4/atom/common/api/atom_api_clipboard.cc#L50)
- [ ] Increase the version number in the header if appropriate.
