### PR TITLE
winston LoggerOptions has wrong property types

### DIFF
--- a/winston/index.d.ts
+++ b/winston/index.d.ts
@@ -242,7 +242,8 @@ declare namespace winston {
 
     export interface LoggerOptions {
         transports?: TransportInstance[];
-        rewriters?: TransportInstance[];
+        rewriters?: MetadataRewriter[];
+        filters?: MetadataFilter[];
         exceptionHandlers?: TransportInstance[];
         handleExceptions?: boolean;
         level?: string;


### PR DESCRIPTION
LoggerOptions.rewriters is of the type `TransportInstance[]` when it should be of type `MetadataRewriter[]`. Also `LoggerOptions.filters` is missing from `LoggerOptions`.

https://github.com/winstonjs/winston/blob/0198c175082dc142263cf6dabbe3db74cefa47f8/README.md#filters-and-rewriters

https://github.com/winstonjs/winston/blob/master/lib/winston/logger.js#L90

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
