### PR TITLE
Pixi.js: Fix Pixi.Text._generateFillStyle

### DIFF
--- a/pixi.js/index.d.ts
+++ b/pixi.js/index.d.ts
@@ -1375,7 +1375,7 @@ declare module PIXI {
         protected wordWrap(text: string): string;
         protected _calculateBounds(): void;
         protected _onStyleChange: () => void;
-        protected _generateFillStyle(style: string | number | CanvasGradient, lines: string[]): string | number | CanvasGradient;
+        protected _generateFillStyle(style: TextStyle, lines: string[]): string | number | CanvasGradient;
         destroy(options?: IDestroyOptions | boolean): void;
         dirty: boolean;
 


### PR DESCRIPTION
This is to mirror the change made in pixijs/pixi-typescript#133, which did not get merged as part of the last update (#13617).

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [X] Run `tsc` without errors.
- [X] Run `npm run lint package-name` if a `tslint.json` is present.  **(It isn't.)**

I'm updating an existing project:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: **The source is [here](http://pixijs.download/release/docs/core_text_Text.js.html#line505), but it's kind of subtle.  No docs on this since it's essentially a `protected` method within `PIXI.Text`.**
- [X] Increase the version number in the header if appropriate.  **(It isn't.)**
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.  **(I'm not.)**
