### PR TITLE
CKEditor: add properties in buttonDefinition

### DIFF
--- a/ckeditor/ckeditor-tests.ts
+++ b/ckeditor/ckeditor-tests.ts
@@ -274,23 +274,23 @@ function test_adding_command_and_buttons() {
     var textarea = document.createElement('textarea');
     var instance = CKEDITOR.replace(textarea);
 
-    instance.addCommand("aCommand", {
-        exec: function(edt) {
+    instance.addCommand( 'aCommand', {
+        exec: function( editor: CKEDITOR.editor ) {
             // empty logic
             return true;
         }
     });
 
-    instance.ui.addButton('firstButton', {
+    instance.ui.addButton( 'firstButton', {
         icon: 'http://www.example.com/assets/images/icons.png',
         iconOffset: -32,
-        label: "Label 1",
+        label: 'Label 1',
         command: 'aCommand',
         toolbar: 'tools'
     });
 
-    instance.ui.addButton('secondButton', {
-        label: "Label 2",
+    instance.ui.addButton( 'secondButton', {
+        label: 'Label 2',
         command: 'aCommand',
         toolbar: 'tools'
     });

--- a/ckeditor/ckeditor-tests.ts
+++ b/ckeditor/ckeditor-tests.ts
@@ -270,6 +270,32 @@ function test_dom_window() {
     alert(size.height);
 }
 
+function test_adding_command_and_buttons() {
+    var textarea = document.createElement('textarea');
+    var instance = CKEDITOR.replace(textarea);
+
+    instance.addCommand("aCommand", {
+        exec: function(edt) {
+            // empty logic
+            return true;
+        }
+    });
+
+    instance.ui.addButton('firstButton', {
+        icon: 'http://www.example.com/assets/images/icons.png',
+        iconOffset: -32,
+        label: "Label 1",
+        command: 'aCommand',
+        toolbar: 'tools'
+    });
+
+    instance.ui.addButton('secondButton', {
+        label: "Label 2",
+        command: 'aCommand',
+        toolbar: 'tools'
+    });
+}
+
 function test_adding_dialog_by_path() {
     CKEDITOR.dialog.add( 'abbrDialog', this.path + 'dialogs/abbr.js' );
 }

--- a/ckeditor/index.d.ts
+++ b/ckeditor/index.d.ts
@@ -1255,6 +1255,8 @@ declare namespace CKEDITOR {
     }
 
     interface buttonDefinition {
+        icon?: string;
+        iconOffset?: number;
         label : string;
         command : string;
         toolbar : string;


### PR DESCRIPTION
Add `icon` and `iconOffset` optional properties in `buttonDefinition` interface

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: No doc... but see these links:
  - [ckeditor-dev/plugins/placeholder](https://github.com/ckeditor/ckeditor-dev/blob/a35fa6cc318116ce13497a266a5bd80d768453ee/plugins/placeholder/plugin.js#L63)
  - [#3122 Icon definition for toolbar buttons...](https://dev.ckeditor.com/ticket/3122)
  - [jsfiddle demo](http://jsfiddle.net/kt4f9mk4/3/)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
