### PR TITLE
Fix `bluebird-global` typings being incompatible with es2015 libs.

### DIFF
--- a/bluebird-global/bluebird-global-tests.ts
+++ b/bluebird-global/bluebird-global-tests.ts
@@ -29,3 +29,16 @@ function testFunctionReturningPromise() {
             console.log("finally callback");
         });
 }
+
+function testPromiseRejection() {
+    new Promise<string>((resolve, reject) => {
+        reject(new Error("problem occurred"));
+    })
+        .catch((error) => {
+            return "recovered from error";
+        })
+        .then((value) => {
+            return value.toUpperCase();
+        });
+
+}

--- a/bluebird-global/index.d.ts
+++ b/bluebird-global/index.d.ts
@@ -26,6 +26,12 @@
  * If a promise-polyfilling library wants to play nicely with TypeScript, it needs to augment
  * the Promise<T> and PromiseConstructor interfaces defined in the standard ts library.
  * For various reasons this couldn't be done in The `bluebird` typings.
+ *
+ * 4. Contributors: After changing this file please manually test these cases (via altering ./tsconfig.json ):
+ *   a. target es5, no `lib` key
+ *   b. target es6, no `lib` key
+ *   c. target es5, latest "es20xx", e.g. "es2017"
+ *   d. target es6, latest "es20xx", e.g. "es2017"
  */
 
 import * as Bluebird from "bluebird";

--- a/bluebird-global/index.d.ts
+++ b/bluebird-global/index.d.ts
@@ -26,7 +26,6 @@
  * If a promise-polyfilling library wants to play nicely with TypeScript, it needs to augment
  * the Promise<T> and PromiseConstructor interfaces defined in the standard ts library.
  * For various reasons this couldn't be done in The `bluebird` typings.
- *
  */
 
 import * as Bluebird from "bluebird";
@@ -35,7 +34,78 @@ declare global {
     /*
      * Patch all instance method
      */
-    interface Promise<T> extends Bluebird<T> {}
+    interface Promise<T> {
+        all: typeof Bluebird.prototype.all;
+        any: typeof Bluebird.prototype.any;
+        asCallback: typeof Bluebird.prototype.asCallback;
+        bind: typeof Bluebird.prototype.bind;
+        call: typeof Bluebird.prototype.call;
+        cancel: typeof Bluebird.prototype.cancel;
+        // catch: typeof Bluebird.prototype.catch;
+        caught: typeof Bluebird.prototype.caught;
+        delay: typeof Bluebird.prototype.delay;
+        disposer: typeof Bluebird.prototype.disposer;
+        done: typeof Bluebird.prototype.done;
+        each: typeof Bluebird.prototype.each;
+        error: typeof Bluebird.prototype.error;
+        filter: typeof Bluebird.prototype.filter;
+        finally: typeof Bluebird.prototype.finally;
+        get: typeof Bluebird.prototype.get;
+        isCancelled: typeof Bluebird.prototype.isCancelled;
+        isFulfilled: typeof Bluebird.prototype.isFulfilled;
+        isPending: typeof Bluebird.prototype.isPending;
+        isRejected: typeof Bluebird.prototype.isRejected;
+        isResolved: typeof Bluebird.prototype.isResolved;
+        lastly: typeof Bluebird.prototype.lastly;
+        map: typeof Bluebird.prototype.map;
+        mapSeries: typeof Bluebird.prototype.mapSeries;
+        nodeify: typeof Bluebird.prototype.nodeify;
+        props: typeof Bluebird.prototype.props;
+        race: typeof Bluebird.prototype.race;
+        reason: typeof Bluebird.prototype.reason;
+        reduce: typeof Bluebird.prototype.reduce;
+        reflect: typeof Bluebird.prototype.reflect;
+        return: typeof Bluebird.prototype.return;
+        some: typeof Bluebird.prototype.some;
+        spread: typeof Bluebird.prototype.spread;
+        suppressUnhandledRejections: typeof Bluebird.prototype.suppressUnhandledRejections;
+        tap: typeof Bluebird.prototype.tap;
+        // then: typeof Bluebird.prototype.then;
+        thenReturn: typeof Bluebird.prototype.thenReturn;
+        thenThrow: typeof Bluebird.prototype.thenThrow;
+        throw: typeof Bluebird.prototype.throw;
+        timeout: typeof Bluebird.prototype.timeout;
+        toJSON: typeof Bluebird.prototype.toJSON;
+        toString: typeof Bluebird.prototype.toString;
+        value: typeof Bluebird.prototype.value;
+
+        /*
+         * Copy&paste ::then and ::catch from lib.es2015.promise.d.ts, because Bluebird's typings are not
+         * in line with the standard lib.
+         *
+         * This is only needed for es5 target, which doesn't include the lib.es2015.promise.d.ts typings.
+         *
+         * @todo Make Bluebird's typings be in line with the standard lib.
+         */
+        then(onfulfilled?: ((value: T) => T | PromiseLike<T>) | undefined | null, onrejected?: ((reason: any) => T | PromiseLike<T>) | undefined | null): Promise<T>;
+        then<TResult>(onfulfilled: ((value: T) => T | PromiseLike<T>) | undefined | null, onrejected: (reason: any) => TResult | PromiseLike<TResult>): Promise<T | TResult>;
+        then<TResult>(onfulfilled: (value: T) => TResult | PromiseLike<TResult>, onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<TResult>;
+        then<TResult1, TResult2>(onfulfilled: (value: T) => TResult1 | PromiseLike<TResult1>, onrejected: (reason: any) => TResult2 | PromiseLike<TResult2>): Promise<TResult1 | TResult2>;
+        catch(onrejected?: ((reason: any) => T | PromiseLike<T>) | undefined | null): Promise<T>;
+        catch<TResult>(onrejected: (reason: any) => TResult | PromiseLike<TResult>): Promise<T | TResult>;
+
+        /*
+         * TypeScript disallows adding overrides via `catch: typeof Bluebird.prototype.catch`. Copy&paste them then.
+         *
+         * @todo Duplication of code is never ideal. See whether there's a better way of achieving this.
+         */
+        catch(predicate: (error: any) => boolean, onReject: (error: any) => T | Bluebird.Thenable<T> | void | Bluebird.Thenable<void>): Bluebird<T>;
+        catch<U>(predicate: (error: any) => boolean, onReject: (error: any) => U | Bluebird.Thenable<U>): Bluebird<U | T>;
+        catch<E extends Error>(ErrorClass: new (...args: any[]) => E, onReject: (error: E) => T | Bluebird.Thenable<T> | void | Bluebird.Thenable<void>): Bluebird<T>;
+        catch<E extends Error, U>(ErrorClass: new (...args: any[]) => E, onReject: (error: E) => U | Bluebird.Thenable<U>): Bluebird<U | T>;
+        catch(predicate: Object, onReject: (error: any) => T | Bluebird.Thenable<T> | void | Bluebird.Thenable<void>): Bluebird<T>;
+        catch<U>(predicate: Object, onReject: (error: any) => U | Bluebird.Thenable<U>): Bluebird<U | T>;
+    }
 
     /*
      * Patch all static methods and the constructor
@@ -43,7 +113,7 @@ declare global {
     interface PromiseConstructor {
         new <T>(callback: (resolve: (thenableOrResult?: T | Bluebird.Thenable<T>) => void, reject: (error?: any) => void, onCancel?: (callback: () => void) => void) => void): Promise<T>;
 
-        all: typeof Bluebird.all;
+        // all: typeof Bluebird.all;
         any: typeof Bluebird.any;
         attempt: typeof Bluebird.attempt;
         bind: typeof Bluebird.bind;
@@ -66,13 +136,45 @@ declare global {
         promisify: typeof Bluebird.promisify;
         promisifyAll: typeof Bluebird.promisifyAll;
         props: typeof Bluebird.props;
-        race: typeof Bluebird.race;
+        // race: typeof Bluebird.race;
         reduce: typeof Bluebird.reduce;
-        reject: typeof Bluebird.reject;
-        resolve: typeof Bluebird.resolve;
+        // reject: typeof Bluebird.reject;
+        // resolve: typeof Bluebird.resolve;
         some: typeof Bluebird.some;
         try: typeof Bluebird.try;
         using: typeof Bluebird.using;
+
+        /*
+         * Copy&paste from lib.es2015.promise.d.ts, because Bluebird's typings are not in line with the standard lib.
+         *
+         * This is only needed for es5 target, which doesn't include the lib.es2015.promise.d.ts typings.
+         *
+         * @todo Make Bluebird's typings be in line with the standard lib.
+         */
+        all<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike <T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>, T10 | PromiseLike<T10>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>;
+        all<T1, T2, T3, T4, T5, T6, T7, T8, T9>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike <T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>;
+        all<T1, T2, T3, T4, T5, T6, T7, T8>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike <T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8]>;
+        all<T1, T2, T3, T4, T5, T6, T7>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike <T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>]): Promise<[T1, T2, T3, T4, T5, T6, T7]>;
+        all<T1, T2, T3, T4, T5, T6>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike <T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>]): Promise<[T1, T2, T3, T4, T5, T6]>;
+        all<T1, T2, T3, T4, T5>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike <T4>, T5 | PromiseLike<T5>]): Promise<[T1, T2, T3, T4, T5]>;
+        all<T1, T2, T3, T4>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike <T4>]): Promise<[T1, T2, T3, T4]>;
+        all<T1, T2, T3>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>]): Promise<[T1, T2, T3]>;
+        all<T1, T2>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>]): Promise<[T1, T2]>;
+        all<T>(values: (T | PromiseLike<T>)[]): Promise<T[]>;
+        race<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>, T10 | PromiseLike<T10>]): Promise<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10>;
+        race<T1, T2, T3, T4, T5, T6, T7, T8, T9>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>]): Promise<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>;
+        race<T1, T2, T3, T4, T5, T6, T7, T8>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>]): Promise<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8>;
+        race<T1, T2, T3, T4, T5, T6, T7>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>]): Promise<T1 | T2 | T3 | T4 | T5 | T6 | T7>;
+        race<T1, T2, T3, T4, T5, T6>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>]): Promise<T1 | T2 | T3 | T4 | T5 | T6>;
+        race<T1, T2, T3, T4, T5>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>]): Promise<T1 | T2 | T3 | T4 | T5>;
+        race<T1, T2, T3, T4>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>]): Promise<T1 | T2 | T3 | T4>;
+        race<T1, T2, T3>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>]): Promise<T1 | T2 | T3>;
+        race<T1, T2>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>]): Promise<T1 | T2>;
+        race<T>(values: (T | PromiseLike<T>)[]): Promise<T>;
+        reject(reason: any): Promise<never>;
+        reject<T>(reason: any): Promise<T>;
+        resolve<T>(value: T | PromiseLike<T>): Promise<T>;
+        resolve(): Promise<void>;
     }
 
     /*

--- a/bluebird-global/tsconfig.json
+++ b/bluebird-global/tsconfig.json
@@ -1,13 +1,25 @@
 {
+    /*
+     * When manually testing, please test these cases:
+     *   1. target es5, no `lib` key
+     *   2. target es6, no `lib` key
+     *   3. target es5, latest "es20xx", e.g. "es2017"
+     *   4. target es6, latest "es20xx", e.g. "es2017"
+     */
     "compilerOptions": {
         "module": "commonjs",
         "target": "es5",
+//        "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"
+        ],
+        "lib": [
+          "es2017",
+          "dom"
         ],
         "types": [],
         "noEmit": true,

--- a/bluebird-global/tsconfig.json
+++ b/bluebird-global/tsconfig.json
@@ -1,15 +1,7 @@
 {
-    /*
-     * When manually testing, please test these cases:
-     *   1. target es5, no `lib` key
-     *   2. target es6, no `lib` key
-     *   3. target es5, latest "es20xx", e.g. "es2017"
-     *   4. target es6, latest "es20xx", e.g. "es2017"
-     */
     "compilerOptions": {
         "module": "commonjs",
         "target": "es5",
-//        "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,

--- a/bluebird-global/tslint.json
+++ b/bluebird-global/tslint.json
@@ -1,6 +1,9 @@
 {
   "extends": "../tslint.json",
   "rules": {
-    "no-empty-interface": false
+    "no-empty-interface": false,
+    "array-type": false,
+    "unified-signatures": false,
+    "forbidden-types": false
   }
 }


### PR DESCRIPTION
- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/13643#issuecomment-269840044
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

Fixes #13643.

1. Make `bluebird-global` work nicely with es20xx ts stdlibs.
2. Make unit tests for `bluebird-global` run with es2017 ts stdlib. This is not ideal,
because I'd like the tests to run also against vanilla es5, but that's the lesser
of two evils.
3. Remove some tslint rules, that flag errors in the code taken from the `lib.es2015.promise.d.ts`